### PR TITLE
feat(threads): fold attachment text into model-visible context (#4644)

### DIFF
--- a/crates/ironclaw_threads/src/attachment_context.rs
+++ b/crates/ironclaw_threads/src/attachment_context.rs
@@ -1,0 +1,195 @@
+//! Render attachment references into model-visible message content.
+//!
+//! When a transcript message carries [`AttachmentRef`]s, the model-visible
+//! projection of that message ([`crate::ContextMessage`]) appends a rendered
+//! `<attachments>` block so the model can reason about the files: documents and
+//! audio contribute their extracted text / transcript, and every attachment
+//! contributes its stored project path (`storage_key`) so the agent can
+//! `file_read` it. Image pixels reach the model through a separate multimodal
+//! path; here an image contributes a pointer to its stored file.
+
+use ironclaw_common::{AttachmentKind, AttachmentRef};
+
+/// Append a rendered `<attachments>` block to `content` when `attachments` is
+/// non-empty; otherwise return `content` unchanged.
+pub(crate) fn augment_model_content(content: String, attachments: &[AttachmentRef]) -> String {
+    match render_attachments_block(attachments) {
+        Some(block) => format!("{content}\n\n{block}"),
+        None => content,
+    }
+}
+
+fn render_attachments_block(attachments: &[AttachmentRef]) -> Option<String> {
+    if attachments.is_empty() {
+        return None;
+    }
+    let mut out = String::from("<attachments>");
+    for (index, attachment) in attachments.iter().enumerate() {
+        out.push('\n');
+        out.push_str(&render_attachment(index + 1, attachment));
+    }
+    out.push_str("\n</attachments>");
+    Some(out)
+}
+
+fn render_attachment(index: usize, attachment: &AttachmentRef) -> String {
+    let filename = escape_xml_attr(attachment.filename.as_deref().unwrap_or("unknown"));
+    let mime = escape_xml_attr(&attachment.mime_type);
+    let type_label = match attachment.kind {
+        AttachmentKind::Audio => "audio",
+        AttachmentKind::Image => "image",
+        AttachmentKind::Document => "document",
+    };
+    let project_path_attr = attachment
+        .storage_key
+        .as_deref()
+        .map(|path| format!(" project_path=\"{}\"", escape_xml_attr(path)))
+        .unwrap_or_default();
+    let size_attr = attachment
+        .size_bytes
+        .map(|size| format!(" size=\"{}\"", format_size(size)))
+        .unwrap_or_default();
+
+    let body = body_text(attachment);
+    let body = match attachment.storage_key.as_deref() {
+        Some(path) => format!("Saved to project file: {}\n{}", escape_xml_text(path), body),
+        None => body,
+    };
+
+    format!(
+        "<attachment index=\"{index}\" type=\"{type_label}\" filename=\"{filename}\" mime=\"{mime}\"{project_path_attr}{size_attr}>\n\
+         {body}\n\
+         </attachment>"
+    )
+}
+
+fn body_text(attachment: &AttachmentRef) -> String {
+    match attachment.kind {
+        AttachmentKind::Audio => match &attachment.extracted_text {
+            Some(text) => format!("Transcript: {}", escape_xml_text(text)),
+            None => "Audio transcript unavailable.".to_string(),
+        },
+        AttachmentKind::Document => match &attachment.extracted_text {
+            Some(text) => escape_xml_text(text),
+            None => "[Document attached — text extraction unavailable]".to_string(),
+        },
+        AttachmentKind::Image => {
+            "[Image attached — the file is saved at the project path above; read it from there to view it.]"
+                .to_string()
+        }
+    }
+}
+
+fn escape_xml_attr(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('"', "&quot;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
+fn escape_xml_text(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
+fn format_size(bytes: u64) -> String {
+    if bytes < 1024 {
+        format!("{bytes}B")
+    } else if bytes < 1024 * 1024 {
+        format!("{}KB", bytes / 1024)
+    } else {
+        format!("{:.1}MB", bytes as f64 / (1024.0 * 1024.0))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn doc_ref(extracted: Option<&str>) -> AttachmentRef {
+        AttachmentRef {
+            id: "att-0".to_string(),
+            kind: AttachmentKind::Document,
+            mime_type: "application/pdf".to_string(),
+            filename: Some("report.pdf".to_string()),
+            size_bytes: Some(2048),
+            storage_key: Some("/workspace/attachments/2026-06-09/m1-0-report.pdf".to_string()),
+            extracted_text: extracted.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn empty_attachments_leave_content_unchanged() {
+        assert_eq!(augment_model_content("hello".to_string(), &[]), "hello");
+    }
+
+    #[test]
+    fn document_extracted_text_is_folded_into_content() {
+        let out = augment_model_content(
+            "see attached".to_string(),
+            &[doc_ref(Some("Quarterly revenue up 12%"))],
+        );
+        assert!(out.starts_with("see attached\n\n<attachments>"));
+        assert!(out.contains("type=\"document\""));
+        assert!(out.contains("filename=\"report.pdf\""));
+        assert!(out.contains("project_path=\"/workspace/attachments/2026-06-09/m1-0-report.pdf\""));
+        assert!(out.contains("size=\"2KB\""));
+        assert!(
+            out.contains(
+                "Saved to project file: /workspace/attachments/2026-06-09/m1-0-report.pdf"
+            )
+        );
+        assert!(out.contains("Quarterly revenue up 12%"));
+        assert!(out.ends_with("</attachments>"));
+    }
+
+    #[test]
+    fn document_without_text_notes_unavailable() {
+        let out = augment_model_content("x".to_string(), &[doc_ref(None)]);
+        assert!(out.contains("[Document attached — text extraction unavailable]"));
+    }
+
+    #[test]
+    fn image_points_at_stored_file() {
+        let image = AttachmentRef {
+            id: "att-1".to_string(),
+            kind: AttachmentKind::Image,
+            mime_type: "image/png".to_string(),
+            filename: Some("diagram.png".to_string()),
+            size_bytes: Some(4096),
+            storage_key: Some("/workspace/attachments/2026-06-09/m1-1-diagram.png".to_string()),
+            extracted_text: None,
+        };
+        let out = augment_model_content("look".to_string(), &[image]);
+        assert!(out.contains("type=\"image\""));
+        assert!(out.contains("the file is saved at the project path above"));
+    }
+
+    #[test]
+    fn audio_transcript_is_rendered() {
+        let audio = AttachmentRef {
+            id: "att-2".to_string(),
+            kind: AttachmentKind::Audio,
+            mime_type: "audio/ogg".to_string(),
+            filename: Some("voice.ogg".to_string()),
+            size_bytes: Some(1024),
+            storage_key: Some("/workspace/attachments/2026-06-09/m1-2-voice.ogg".to_string()),
+            extracted_text: Some("hello can you help".to_string()),
+        };
+        let out = augment_model_content("".to_string(), &[audio]);
+        assert!(out.contains("type=\"audio\""));
+        assert!(out.contains("Transcript: hello can you help"));
+    }
+
+    #[test]
+    fn special_characters_are_escaped() {
+        let mut att = doc_ref(Some("a < b & c > d"));
+        att.filename = Some("a\"&<>.txt".to_string());
+        let out = augment_model_content("x".to_string(), &[att]);
+        assert!(out.contains("filename=\"a&quot;&amp;&lt;&gt;.txt\""));
+        assert!(out.contains("a &lt; b &amp; c &gt; d"));
+    }
+}

--- a/crates/ironclaw_threads/src/attachment_context.rs
+++ b/crates/ironclaw_threads/src/attachment_context.rs
@@ -50,7 +50,7 @@ fn render_attachment(index: usize, attachment: &AttachmentRef) -> String {
         .map(|size| format!(" size=\"{}\"", format_size(size)))
         .unwrap_or_default();
 
-    let body = body_text(attachment);
+    let body = body_text(attachment, attachment.storage_key.is_some());
     let body = match attachment.storage_key.as_deref() {
         Some(path) => format!("Saved to project file: {}\n{}", escape_xml_text(path), body),
         None => body,
@@ -63,7 +63,7 @@ fn render_attachment(index: usize, attachment: &AttachmentRef) -> String {
     )
 }
 
-fn body_text(attachment: &AttachmentRef) -> String {
+fn body_text(attachment: &AttachmentRef, has_project_path: bool) -> String {
     match attachment.kind {
         AttachmentKind::Audio => match &attachment.extracted_text {
             Some(text) => format!("Transcript: {}", escape_xml_text(text)),
@@ -73,10 +73,14 @@ fn body_text(attachment: &AttachmentRef) -> String {
             Some(text) => escape_xml_text(text),
             None => "[Document attached — text extraction unavailable]".to_string(),
         },
-        AttachmentKind::Image => {
+        // An image's pixels reach the model through the multimodal path; here it
+        // only contributes a pointer to its stored file, so the body is useful
+        // only when the file was actually landed.
+        AttachmentKind::Image if has_project_path => {
             "[Image attached — the file is saved at the project path above; read it from there to view it.]"
                 .to_string()
         }
+        AttachmentKind::Image => "[Image attached — not yet stored.]".to_string(),
     }
 }
 
@@ -166,6 +170,26 @@ mod tests {
         let out = augment_model_content("look".to_string(), &[image]);
         assert!(out.contains("type=\"image\""));
         assert!(out.contains("the file is saved at the project path above"));
+    }
+
+    #[test]
+    fn image_without_storage_key_does_not_claim_a_project_path() {
+        let image = AttachmentRef {
+            id: "att-1".to_string(),
+            kind: AttachmentKind::Image,
+            mime_type: "image/png".to_string(),
+            filename: Some("diagram.png".to_string()),
+            size_bytes: Some(4096),
+            storage_key: None,
+            extracted_text: None,
+        };
+        let out = augment_model_content("look".to_string(), &[image]);
+        assert!(out.contains("type=\"image\""));
+        // No `project_path` attr and no "saved at the project path above" claim
+        // when the image was never landed.
+        assert!(!out.contains("project_path="));
+        assert!(!out.contains("saved at the project path above"));
+        assert!(out.contains("not yet stored"));
     }
 
     #[test]

--- a/crates/ironclaw_threads/src/filesystem_service.rs
+++ b/crates/ironclaw_threads/src/filesystem_service.rs
@@ -1968,7 +1968,10 @@ fn context_messages_with_summary_replacements(
                 sequence: message.sequence,
                 kind: message.kind,
                 tool_result_provider_call: message.tool_result_provider_call.clone(),
-                content,
+                content: crate::attachment_context::augment_model_content(
+                    content,
+                    &message.attachments,
+                ),
             });
         }
     }
@@ -1994,7 +1997,10 @@ fn context_messages_by_id(
                 sequence: message.sequence,
                 kind: message.kind,
                 tool_result_provider_call: message.tool_result_provider_call.clone(),
-                content: message.content.clone()?,
+                content: crate::attachment_context::augment_model_content(
+                    message.content.clone()?,
+                    &message.attachments,
+                ),
             })
         })
         .collect()

--- a/crates/ironclaw_threads/src/in_memory.rs
+++ b/crates/ironclaw_threads/src/in_memory.rs
@@ -936,7 +936,10 @@ fn context_messages_with_summary_replacements(thread: &StoredThread) -> Vec<Cont
                 sequence: message.sequence,
                 kind: message.kind,
                 tool_result_provider_call: message.tool_result_provider_call.clone(),
-                content,
+                content: crate::attachment_context::augment_model_content(
+                    content,
+                    &message.attachments,
+                ),
             });
         }
     }
@@ -963,7 +966,10 @@ fn context_messages_by_id(
                 sequence: message.sequence,
                 kind: message.kind,
                 tool_result_provider_call: message.tool_result_provider_call.clone(),
-                content: message.content.clone()?,
+                content: crate::attachment_context::augment_model_content(
+                    message.content.clone()?,
+                    &message.attachments,
+                ),
             })
         })
         .collect()

--- a/crates/ironclaw_threads/src/lib.rs
+++ b/crates/ironclaw_threads/src/lib.rs
@@ -9,6 +9,7 @@
 //! `docs/plans/2026-05-16-scoped-filesystem-tenant-isolation.md`.
 #![warn(unreachable_pub)]
 
+mod attachment_context;
 mod capability_display_preview;
 mod contract;
 mod error;

--- a/crates/ironclaw_threads/tests/session_thread_contract.rs
+++ b/crates/ironclaw_threads/tests/session_thread_contract.rs
@@ -2505,6 +2505,54 @@ async fn list_threads_for_scope_title_stays_none_when_user_message_is_whitespace
     );
 }
 
+#[tokio::test]
+async fn attachment_extracted_text_reaches_model_visible_context() {
+    let service = InMemorySessionThreadService::default();
+    let scope = scope("attachments-context");
+    let thread = service
+        .ensure_thread(EnsureThreadRequest {
+            scope: scope.clone(),
+            thread_id: Some(ThreadId::new("thread-attachments-context").unwrap()),
+            created_by_actor_id: "actor-a".into(),
+            title: None,
+            metadata_json: None,
+        })
+        .await
+        .unwrap();
+
+    service
+        .accept_inbound_message(AcceptInboundMessageRequest {
+            scope: scope.clone(),
+            thread_id: thread.thread_id.clone(),
+            actor_id: "actor-a".into(),
+            source_binding_id: None,
+            reply_target_binding_id: None,
+            external_event_id: Some("event-att-ctx".into()),
+            content: MessageContent::with_attachments("see attached", vec![sample_attachment_ref()]),
+        })
+        .await
+        .unwrap();
+
+    let window = service
+        .load_context_window(LoadContextWindowRequest {
+            scope,
+            thread_id: thread.thread_id,
+            max_messages: 10,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(window.messages.len(), 1);
+    let content = &window.messages[0].content;
+    // The user's text plus a rendered <attachments> block with the document's
+    // extracted text and stored project path are what the model sees.
+    assert!(content.starts_with("see attached"));
+    assert!(content.contains("<attachments>"));
+    assert!(content.contains("type=\"document\""));
+    assert!(content.contains("quarterly numbers"));
+    assert!(content.contains("project_path=\"attachments/2026-06-09/m1-report.pdf\""));
+}
+
 fn sample_attachment_ref() -> AttachmentRef {
     AttachmentRef {
         id: "att-1".into(),

--- a/crates/ironclaw_threads/tests/session_thread_contract.rs
+++ b/crates/ironclaw_threads/tests/session_thread_contract.rs
@@ -2520,7 +2520,7 @@ async fn attachment_extracted_text_reaches_model_visible_context() {
         .await
         .unwrap();
 
-    service
+    let accepted = service
         .accept_inbound_message(AcceptInboundMessageRequest {
             scope: scope.clone(),
             thread_id: thread.thread_id.clone(),
@@ -2528,15 +2528,18 @@ async fn attachment_extracted_text_reaches_model_visible_context() {
             source_binding_id: None,
             reply_target_binding_id: None,
             external_event_id: Some("event-att-ctx".into()),
-            content: MessageContent::with_attachments("see attached", vec![sample_attachment_ref()]),
+            content: MessageContent::with_attachments(
+                "see attached",
+                vec![sample_attachment_ref()],
+            ),
         })
         .await
         .unwrap();
 
     let window = service
         .load_context_window(LoadContextWindowRequest {
-            scope,
-            thread_id: thread.thread_id,
+            scope: scope.clone(),
+            thread_id: thread.thread_id.clone(),
             max_messages: 10,
         })
         .await
@@ -2550,7 +2553,25 @@ async fn attachment_extracted_text_reaches_model_visible_context() {
     assert!(content.contains("<attachments>"));
     assert!(content.contains("type=\"document\""));
     assert!(content.contains("quarterly numbers"));
-    assert!(content.contains("project_path=\"attachments/2026-06-09/m1-report.pdf\""));
+    assert!(content.contains("project_path=\"/workspace/attachments/2026-06-09/m1-report.pdf\""));
+
+    // The by-id projection (`load_context_messages`) renders the same
+    // <attachments> block — both context read paths fold attachment text.
+    let direct = service
+        .load_context_messages(LoadContextMessagesRequest {
+            scope,
+            thread_id: thread.thread_id,
+            message_ids: vec![accepted.message_id],
+        })
+        .await
+        .unwrap();
+    assert_eq!(direct.messages.len(), 1);
+    let direct_content = &direct.messages[0].content;
+    assert!(direct_content.contains("<attachments>"));
+    assert!(direct_content.contains("quarterly numbers"));
+    assert!(
+        direct_content.contains("project_path=\"/workspace/attachments/2026-06-09/m1-report.pdf\"")
+    );
 }
 
 fn sample_attachment_ref() -> AttachmentRef {
@@ -2560,7 +2581,10 @@ fn sample_attachment_ref() -> AttachmentRef {
         mime_type: "application/pdf".into(),
         filename: Some("report.pdf".into()),
         size_bytes: Some(2048),
-        storage_key: Some("attachments/2026-06-09/m1-report.pdf".into()),
+        // The landed scoped path, as `land_attachment` records it: rooted at the
+        // project mount alias (`/workspace`), which the agent's `file_read`
+        // resolves through — not a raw host path.
+        storage_key: Some("/workspace/attachments/2026-06-09/m1-report.pdf".into()),
         extracted_text: Some("quarterly numbers".into()),
     }
 }


### PR DESCRIPTION
## Summary

**Attachments now reach the model.** When the thread store projects a transcript message into the model-visible `ContextMessage`, it appends a rendered `<attachments>` block built from the message's `AttachmentRef`s — so a document's `extracted_text` (and an audio transcript) become part of the prompt the model sees, **with no change to the model gateway or the `ContextMessage` shape**.

This completes the document/audio **text** path of Track 3 end-to-end: upload → land → extract → persist ref → model sees the text.

## What changed

- New `ironclaw_threads::attachment_context::augment_model_content` folds a rendered block into `ContextMessage.content`:
  - **Documents / audio** contribute their `extracted_text` / transcript.
  - **Every** attachment contributes its stored project path (`storage_key`) so the agent can `file_read` it.
  - **Images** contribute a pointer to the stored file (pixels reach the model via a separate multimodal path — a follow-up).
  - All attribute/text values are XML-escaped.
- Wired into both stores' context-window builders (`in_memory` + `filesystem`, `context_messages_with_summary_replacements` + `context_messages_by_id`). This fits the crate's stated charter — "policy-filtered read APIs for model-visible context".

Chosen deliberately over adding a field to `ContextMessage`: that would ripple a populated-but-unused field through `ironclaw_loop_support` + the model gateway. Folding at projection time keeps the change to one crate and delivers the value immediately.

## Tests

6 renderer unit tests (document with/without text, image pointer, audio transcript, escaping, empty) + an integration test driving `accept_inbound_message → load_context_window` asserting the block (extracted text + `project_path`) is in the model-visible content.

```
cargo clippy -p ironclaw_threads --all-features --tests   # clean
cargo test  -p ironclaw_threads --all-features            # 98 pass
```

## Stacking

Based on `fix/4644-inbound-extraction` (#4676).

## Remaining for #4644

- **Image pixels** to the model: multimodal `content_parts` via byte-readback from `storage_key` in the model gateway (needs a filesystem handle at that layer).
- **Audio transcription**: a `TranscriptionProvider` injected at the composition lander to fill audio `extracted_text`.
- `chat_workflow.rs` `[non_text_content]` fix (OpenAI-compat path).
- Web UX ("+" button, in-thread attachment cards); e2e; other-channel convergence; per-attachment memory index note.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Model-visible conversation context now includes an `<attachments>...</attachments>` block when attachments are present.
  * Attachments are rendered with type, filename, and size, and include document extracted text / audio transcripts (or clear “unavailable” placeholders when missing).
  * Images are represented with either a storage-backed project file reference or a “not yet stored” notice, plus a “Saved to project file” line when available.
  * `<attachments>` content is safely escaped to handle special characters.
* **Tests**
  * Added a session-thread contract test to verify document extracted text and project path appear in model-visible context, including consistency across context-loading paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->