### PR TITLE
Scrub provider reasoning metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4835,6 +4835,7 @@ dependencies = [
  "ironclaw_processes",
  "ironclaw_reborn_event_store",
  "ironclaw_resources",
+ "ironclaw_safety",
  "ironclaw_scripts",
  "ironclaw_secrets",
  "ironclaw_skills",

--- a/crates/ironclaw_loop_support/src/capability_port.rs
+++ b/crates/ironclaw_loop_support/src/capability_port.rs
@@ -38,7 +38,8 @@ use self::provider_input::{
     normalize_provider_arguments, prepare_provider_arguments, schema_contains_external_ref,
 };
 use self::provider_validation::{
-    PROVIDER_TOOL_NAME_MAX_BYTES, validate_provider_arguments, validate_provider_tool_call,
+    PROVIDER_TOOL_NAME_MAX_BYTES, sanitize_provider_tool_call_metadata,
+    validate_provider_arguments, validate_provider_tool_call,
 };
 use self::surface_snapshot::{
     RuntimeSurfaceCapabilitySnapshot, SurfaceCapabilitySnapshot, SurfaceSnapshot,
@@ -1021,6 +1022,7 @@ impl LoopCapabilityPort for HostRuntimeLoopCapabilityPort {
         let prepared = self.prepare_provider_tool_call(&tool_call)?;
         let mut normalized_tool_call = tool_call.clone();
         normalized_tool_call.arguments = prepared.normalized_arguments;
+        sanitize_provider_tool_call_metadata(&mut normalized_tool_call)?;
         let input_ref = self
             .input_resolver
             .register_provider_tool_call_input(&self.run_context, &normalized_tool_call)
@@ -1043,9 +1045,9 @@ impl LoopCapabilityPort for HostRuntimeLoopCapabilityPort {
                 provider_call_id: tool_call.id,
                 provider_tool_name: tool_call.name,
                 arguments: tool_call.arguments,
-                response_reasoning: tool_call.response_reasoning,
-                reasoning: tool_call.reasoning,
-                signature: tool_call.signature,
+                response_reasoning: normalized_tool_call.response_reasoning,
+                reasoning: normalized_tool_call.reasoning,
+                signature: normalized_tool_call.signature,
             }),
         })
     }
@@ -3191,6 +3193,47 @@ mod tests {
 
         assert!(input_ref.as_str().starts_with("input:provider-tool-"));
         assert_eq!(resolved, serde_json::json!({"message":"hello"}));
+    }
+
+    #[tokio::test]
+    async fn provider_tool_call_registration_redacts_secret_reasoning_in_replay() {
+        let capability_id = CapabilityId::new("demo.echo").expect("valid capability id");
+        let provider_id = ExtensionId::new("demo").expect("valid provider id");
+        let port = runtime_capability_port(
+            &capability_id,
+            &provider_id,
+            Arc::new(RecordingHostRuntime::new(vec![visible_capability(
+                capability_id.clone(),
+                provider_id.clone(),
+            )])),
+            Arc::new(RecordingResultWriter::default()),
+            dummy_milestone_sink(),
+            "thread-provider-reasoning-redaction",
+        )
+        .await;
+        let api_key = format!("sk-proj-{}", "a".repeat(24));
+        let mut call = provider_tool_call();
+        call.response_reasoning = Some(format!("response {api_key}"));
+        call.reasoning = Some(format!("call {api_key}"));
+
+        port.visible_capabilities(VisibleCapabilityRequest {})
+            .await
+            .expect("visible capabilities should load before provider registration");
+        let candidate = port
+            .register_provider_tool_call(call)
+            .await
+            .expect("provider tool call should register with redacted metadata");
+
+        let replay = candidate
+            .provider_replay
+            .expect("provider replay metadata should be recorded");
+        assert_eq!(
+            replay.response_reasoning.as_deref(),
+            Some("response [REDACTED]")
+        );
+        assert_eq!(replay.reasoning.as_deref(), Some("call [REDACTED]"));
+        assert!(!replay.response_reasoning.unwrap().contains(&api_key));
+        assert!(!replay.reasoning.unwrap().contains(&api_key));
     }
 
     #[tokio::test]

--- a/crates/ironclaw_loop_support/src/capability_port/provider_validation.rs
+++ b/crates/ironclaw_loop_support/src/capability_port/provider_validation.rs
@@ -1,5 +1,5 @@
 use ironclaw_safety::{
-    ProviderValidationError, validate_optional_provider_metadata_text,
+    scrub_optional_provider_metadata_string,
     validate_provider_arguments as validate_safety_provider_arguments, validate_provider_identity,
     validate_provider_token, validate_provider_tool_name as validate_safety_provider_tool_name,
 };
@@ -11,55 +11,125 @@ pub(super) fn validate_provider_tool_call(
     tool_call: &ProviderToolCall,
 ) -> Result<(), AgentLoopHostError> {
     validate_provider_identity(&tool_call.provider_id, "provider id", 512)
-        .map_err(invalid_invocation)?;
-    validate_provider_identity(&tool_call.provider_model_id, "provider model id", 512)
-        .map_err(invalid_invocation)?;
+        .map_err(|error| invalid_invocation("validate_provider_tool_call_provider_id", error))?;
+    validate_provider_identity(&tool_call.provider_model_id, "provider model id", 512).map_err(
+        |error| invalid_invocation("validate_provider_tool_call_provider_model_id", error),
+    )?;
     let turn_id = tool_call.turn_id.as_deref().ok_or_else(|| {
         AgentLoopHostError::new(
             AgentLoopHostErrorKind::InvalidInvocation,
             "provider tool call is missing a provider turn id",
         )
     })?;
-    validate_provider_token(turn_id, "provider turn id", 512).map_err(invalid_invocation)?;
-    validate_provider_token(&tool_call.id, "provider call id", 512).map_err(invalid_invocation)?;
+    validate_provider_token(turn_id, "provider turn id", 512)
+        .map_err(|error| invalid_invocation("validate_provider_tool_call_turn_id", error))?;
+    validate_provider_token(&tool_call.id, "provider call id", 512)
+        .map_err(|error| invalid_invocation("validate_provider_tool_call_call_id", error))?;
     validate_provider_tool_name(&tool_call.name)?;
     validate_provider_arguments(&tool_call.arguments)?;
-    validate_optional_provider_metadata_text(
+    validate_optional_provider_reasoning_text(
         tool_call.response_reasoning.as_deref(),
         "provider response reasoning",
         4096,
     )
-    .map_err(invalid_invocation)?;
-    validate_optional_provider_metadata_text(
+    .map_err(|error| invalid_invocation("validate_provider_response_reasoning", error))?;
+    validate_optional_provider_reasoning_text(
         tool_call.reasoning.as_deref(),
         "provider reasoning",
         4096,
     )
-    .map_err(invalid_invocation)?;
-    validate_optional_provider_metadata_text(
+    .map_err(|error| invalid_invocation("validate_provider_reasoning", error))?;
+    validate_optional_provider_signature_text(
         tool_call.signature.as_deref(),
         "provider signature",
         4096,
     )
-    .map_err(invalid_invocation)?;
+    .map_err(|error| invalid_invocation("validate_provider_signature", error))?;
     Ok(())
 }
 
 pub(super) fn validate_provider_tool_name(value: &str) -> Result<(), AgentLoopHostError> {
-    validate_safety_provider_tool_name(value).map_err(invalid_invocation)
+    validate_safety_provider_tool_name(value)
+        .map_err(|error| invalid_invocation("validate_provider_tool_name", error))
 }
 
 pub(super) fn validate_provider_arguments(
     arguments: &serde_json::Value,
 ) -> Result<(), AgentLoopHostError> {
-    validate_safety_provider_arguments(arguments).map_err(invalid_invocation)
+    validate_safety_provider_arguments(arguments)
+        .map_err(|error| invalid_invocation("validate_provider_arguments", error))
 }
 
-fn invalid_invocation(error: ProviderValidationError) -> AgentLoopHostError {
+pub(super) fn sanitize_provider_tool_call_metadata(
+    tool_call: &mut ProviderToolCall,
+) -> Result<(), AgentLoopHostError> {
+    tool_call.response_reasoning = scrub_optional_provider_metadata_string(
+        tool_call.response_reasoning.take(),
+        "provider response reasoning",
+        4096,
+    )
+    .map_err(|error| invalid_invocation("sanitize_provider_response_reasoning", error))?;
+    tool_call.reasoning = scrub_optional_provider_metadata_string(
+        tool_call.reasoning.take(),
+        "provider reasoning",
+        4096,
+    )
+    .map_err(|error| invalid_invocation("sanitize_provider_reasoning", error))?;
+    validate_optional_provider_signature_text(
+        tool_call.signature.as_deref(),
+        "provider signature",
+        4096,
+    )
+    .map_err(|error| invalid_invocation("validate_provider_signature", error))?;
+    Ok(())
+}
+
+fn validate_optional_provider_reasoning_text(
+    value: Option<&str>,
+    label: &'static str,
+    max_len: usize,
+) -> Result<(), String> {
+    let Some(value) = value else {
+        return Ok(());
+    };
+    validate_provider_metadata_text_bounds(value, label, max_len)
+}
+
+fn validate_optional_provider_signature_text(
+    value: Option<&str>,
+    label: &'static str,
+    max_len: usize,
+) -> Result<(), String> {
+    let Some(value) = value else {
+        return Ok(());
+    };
+    validate_provider_metadata_text_bounds(value, label, max_len)
+}
+
+fn validate_provider_metadata_text_bounds(
+    value: &str,
+    label: &'static str,
+    max_len: usize,
+) -> Result<(), String> {
+    if value.len() > max_len {
+        return Err(format!("{label} exceeds {max_len} bytes"));
+    }
+    if value.chars().any(|character| {
+        character == '\0' || (character.is_control() && !matches!(character, '\n' | '\r' | '\t'))
+    }) {
+        return Err(format!("{label} must not contain NUL/control characters"));
+    }
+    Ok(())
+}
+
+fn invalid_invocation(
+    operation: &'static str,
+    error: impl std::fmt::Display,
+) -> AgentLoopHostError {
     let safe_summary = error.to_string();
     crate::raw_agent_loop_host_error(
         "capability_provider_validation",
-        "validate_provider_arguments",
+        operation,
         AgentLoopHostErrorKind::InvalidInvocation,
         safe_summary,
         error,
@@ -89,15 +159,15 @@ mod tests {
     }
 
     #[test]
-    fn provider_tool_call_validation_rejects_sensitive_metadata() {
+    fn provider_tool_call_validation_allows_benign_metadata_phrases() {
         let mut call = provider_tool_call();
-        let api_key = format!("sk-proj-{}", "a".repeat(24));
-        call.arguments = serde_json::json!({"password": api_key});
-        assert!(validate_provider_tool_call(&call).is_err());
+        let benign_metadata = "provider error included traceback".to_string();
+        call.response_reasoning = Some(benign_metadata.clone());
+        call.reasoning = Some(benign_metadata.clone());
+        call.signature = Some(benign_metadata);
 
-        let mut call = provider_tool_call();
-        call.reasoning = Some("provider error included traceback".to_string());
-        assert!(validate_provider_tool_call(&call).is_err());
+        validate_provider_tool_call(&call)
+            .expect("benign provider metadata phrases should be accepted");
     }
 
     #[test]
@@ -120,6 +190,34 @@ mod tests {
         let error = validate_provider_tool_call(&call)
             .expect_err("non-whitespace response reasoning control should fail");
         assert_eq!(error.kind, AgentLoopHostErrorKind::InvalidInvocation);
+    }
+
+    #[test]
+    fn provider_tool_call_validation_rejects_overlong_signature() {
+        let mut call = provider_tool_call();
+        call.signature = Some("x".repeat(4097));
+
+        let error = validate_provider_tool_call(&call).expect_err("overlong signature rejected");
+        assert_eq!(error.kind, AgentLoopHostErrorKind::InvalidInvocation);
+    }
+
+    #[test]
+    fn provider_tool_call_metadata_sanitizer_redacts_secret_reasoning() {
+        let mut call = provider_tool_call();
+        let api_key = format!("sk-proj-{}", "a".repeat(24));
+        call.response_reasoning = Some(format!("use {api_key} to finish"));
+        call.reasoning = Some(format!("selected because {api_key} was present"));
+
+        sanitize_provider_tool_call_metadata(&mut call).expect("metadata should be scrubbed");
+
+        assert_eq!(
+            call.response_reasoning.as_deref(),
+            Some("use [REDACTED] to finish")
+        );
+        assert_eq!(
+            call.reasoning.as_deref(),
+            Some("selected because [REDACTED] was present")
+        );
     }
 
     #[test]

--- a/crates/ironclaw_reborn/Cargo.toml
+++ b/crates/ironclaw_reborn/Cargo.toml
@@ -48,6 +48,7 @@ ironclaw_host_api = { path = "../ironclaw_host_api", version = "0.1.0" }
 ironclaw_host_runtime = { path = "../ironclaw_host_runtime", version = "0.1.0" }
 ironclaw_llm = { path = "../ironclaw_llm", version = "0.1.0", optional = true, default-features = false }
 ironclaw_loop_support = { path = "../ironclaw_loop_support", version = "0.1.0" }
+ironclaw_safety = { path = "../ironclaw_safety", version = "0.2.2" }
 ironclaw_secrets = { path = "../ironclaw_secrets", version = "0.1.0", optional = true }
 ironclaw_filesystem = { path = "../ironclaw_filesystem", version = "0.1.0", optional = true }
 ironclaw_threads = { path = "../ironclaw_threads", version = "0.1.0" }

--- a/crates/ironclaw_reborn/src/model_gateway.rs
+++ b/crates/ironclaw_reborn/src/model_gateway.rs
@@ -27,6 +27,7 @@ use ironclaw_loop_support::{
     HostManagedModelResponse, HostManagedModelRouteSnapshot, HostManagedToolResultContent,
     ModelCost, StaticModelCostTable, ThreadBackedLoopContextPort, ThreadBackedLoopModelPort,
 };
+use ironclaw_safety::scrub_optional_provider_metadata_string;
 use ironclaw_threads::{ProviderToolCallReferenceEnvelope, SessionThreadService, ThreadScope};
 use ironclaw_turns::run_profile::LoopModelUsage;
 use ironclaw_turns::{
@@ -943,6 +944,7 @@ async fn tool_response_to_host(
             FinishReason::ToolUse | FinishReason::Stop
         )
     {
+        let scrubbed_reasoning = scrub_provider_reasoning(response.reasoning)?;
         let advertised_tool_names = capabilities
             .tool_definitions()
             .map_err(map_capability_host_error)?
@@ -967,7 +969,7 @@ async fn tool_response_to_host(
             .map(|tool_call| {
                 provider_tool_call_from_llm(
                     tool_call,
-                    response.reasoning.clone(),
+                    scrubbed_reasoning.clone(),
                     provider_turn_id.clone(),
                     replay_identity,
                 )
@@ -992,7 +994,7 @@ async fn tool_response_to_host(
         return Ok(HostManagedModelResponse::capability_calls_with_reasoning(
             candidates,
             response.content.unwrap_or_default(),
-            response.reasoning,
+            scrubbed_reasoning,
         )
         .with_usage(LoopModelUsage {
             input_tokens: response.input_tokens,
@@ -1002,6 +1004,7 @@ async fn tool_response_to_host(
 
     match response.finish_reason {
         FinishReason::Stop => {
+            let scrubbed_reasoning = scrub_provider_reasoning(response.reasoning)?;
             let content = clean_response(&response.content.unwrap_or_default());
             if content.trim().is_empty() {
                 return Err(HostManagedModelError::safe(
@@ -1015,7 +1018,7 @@ async fn tool_response_to_host(
             );
             Ok(HostManagedModelResponse::assistant_reply_with_reasoning(
                 content,
-                response.reasoning,
+                scrubbed_reasoning,
             )
             .with_usage(LoopModelUsage {
                 input_tokens: response.input_tokens,
@@ -1060,6 +1063,22 @@ fn provider_tool_call_from_llm(
     }
 }
 
+fn scrub_provider_reasoning(
+    reasoning: Option<String>,
+) -> Result<Option<String>, HostManagedModelError> {
+    scrub_optional_provider_metadata_string(reasoning, "provider response reasoning", 4096).map_err(
+        |error| {
+            ironclaw_loop_support::raw_host_managed_model_error(
+                "provider_reasoning_metadata",
+                "scrub_provider_reasoning",
+                HostManagedModelErrorKind::InvalidOutput,
+                "provider reasoning metadata is invalid",
+                error,
+            )
+        },
+    )
+}
+
 fn provider_turn_id(provider_turn_scope: &str, tool_calls: &[ToolCall]) -> String {
     let mut stable = String::new();
     stable.push_str(provider_turn_scope);
@@ -1092,10 +1111,11 @@ fn response_to_host_reply(
     };
     match response.finish_reason {
         FinishReason::Stop => {
+            let scrubbed_reasoning = scrub_provider_reasoning(response.reasoning)?;
             let content = clean_response(&response.content);
             Ok(HostManagedModelResponse::assistant_reply_with_reasoning(
                 content,
-                response.reasoning,
+                scrubbed_reasoning,
             )
             .with_usage(usage))
         }

--- a/crates/ironclaw_reborn/tests/llm_gateway.rs
+++ b/crates/ironclaw_reborn/tests/llm_gateway.rs
@@ -146,6 +146,31 @@ async fn gateway_preserves_text_only_provider_reasoning() {
 }
 
 #[tokio::test]
+async fn gateway_redacts_text_only_provider_reasoning() {
+    let api_key = format!("sk-proj-{}", "a".repeat(24));
+    let provider = Arc::new(RecordingLlmProvider::reply_with_reasoning(
+        "assistant response",
+        &format!("use {api_key} to finish"),
+    ));
+    let gateway = LlmProviderModelGateway::with_provider_identity(
+        STATIC_PROVIDER_ID,
+        provider,
+        LlmModelProfilePolicy::new()
+            .allow_model_profile(interactive_model(), Some("host-selected-model".to_string())),
+    );
+
+    let response = gateway
+        .stream_model(model_request(interactive_model()))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.safe_reasoning_deltas,
+        vec!["use [REDACTED] to finish".to_string()]
+    );
+}
+
+#[tokio::test]
 async fn gateway_cleans_legacy_tool_marker_from_text_only_assistant_reply() {
     let provider = Arc::new(RecordingLlmProvider::reply(
         "Done.\n[Called tool `demo__echo` with arguments: {\"message\":\"hi\"}]",
@@ -249,6 +274,42 @@ async fn gateway_cleans_legacy_tool_marker_from_tool_capable_stop_reply() {
 }
 
 #[tokio::test]
+async fn gateway_redacts_tool_capable_stop_reply_provider_reasoning() {
+    let api_key = format!("sk-proj-{}", "a".repeat(24));
+    let provider = Arc::new(ToolAwareProvider::tool_response(ToolCompletionResponse {
+        content: Some("assistant response".to_string()),
+        tool_calls: Vec::new(),
+        input_tokens: 1,
+        output_tokens: 1,
+        finish_reason: FinishReason::Stop,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+        reasoning: Some(format!("use {api_key} to finish")),
+    }));
+    let gateway = LlmProviderModelGateway::with_provider_identity(
+        STATIC_PROVIDER_ID,
+        provider,
+        LlmModelProfilePolicy::new()
+            .allow_model_profile(interactive_model(), Some("host-selected-model".to_string())),
+    );
+    let capabilities = Arc::new(GatewayCapabilityPort::with_tool_surface());
+
+    let response = gateway
+        .stream_model_with_capabilities(model_request(interactive_model()), capabilities)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.safe_reasoning_deltas,
+        vec!["use [REDACTED] to finish".to_string()]
+    );
+    let ParentLoopOutput::AssistantReply(reply) = response.output else {
+        panic!("expected assistant reply");
+    };
+    assert_eq!(reply.content, "assistant response");
+}
+
+#[tokio::test]
 async fn gateway_cleans_flattened_tool_history_from_tool_capable_stop_reply() {
     let provider = Arc::new(ToolAwareProvider::tool_stop_reply(
         "Finished.\nTool result from the benchmark: passed.\nPrevious tool result from demo__echo: hi\nTool result from demo__echo: hi",
@@ -346,6 +407,121 @@ async fn gateway_with_tool_surface_calls_complete_with_tools_and_returns_capabil
     assert_eq!(
         registered[0].arguments,
         serde_json::json!({"message":"hello"})
+    );
+}
+
+#[tokio::test]
+async fn gateway_with_tool_surface_preserves_benign_reasoning_text_containing_api_key() {
+    let provider = Arc::new(ToolAwareProvider::tool_response(ToolCompletionResponse {
+        content: None,
+        tool_calls: vec![ToolCall {
+            id: "call_1".to_string(),
+            name: "demo__echo".to_string(),
+            arguments: serde_json::json!({"message":"hello"}),
+            reasoning: None,
+            signature: None,
+        }],
+        input_tokens: 1,
+        output_tokens: 1,
+        finish_reason: FinishReason::ToolUse,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+        reasoning: Some("use the api key to finish".to_string()),
+    }));
+    let gateway = LlmProviderModelGateway::with_provider_identity(
+        STATIC_PROVIDER_ID,
+        provider,
+        LlmModelProfilePolicy::new()
+            .allow_model_profile(interactive_model(), Some("host-selected-model".to_string())),
+    );
+    let capabilities = Arc::new(GatewayCapabilityPort::with_tool_surface());
+
+    let response = gateway
+        .stream_model_with_capabilities(model_request(interactive_model()), capabilities.clone())
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.safe_reasoning_deltas,
+        vec!["use the api key to finish".to_string()]
+    );
+    let ParentLoopOutput::CapabilityCalls(calls) = response.output else {
+        panic!("expected capability calls");
+    };
+    assert_eq!(calls.len(), 1);
+    assert_eq!(
+        calls[0]
+            .provider_replay
+            .as_ref()
+            .and_then(|replay| replay.response_reasoning.as_deref()),
+        Some("use the api key to finish")
+    );
+    assert_eq!(
+        capabilities
+            .registered
+            .lock()
+            .unwrap()
+            .first()
+            .and_then(|call| call.response_reasoning.as_deref()),
+        Some("use the api key to finish")
+    );
+}
+
+#[tokio::test]
+async fn gateway_with_tool_surface_redacts_secret_reasoning_before_persisting() {
+    let api_key = format!("sk-proj-{}", "a".repeat(24));
+    let provider = Arc::new(ToolAwareProvider::tool_response(ToolCompletionResponse {
+        content: None,
+        tool_calls: vec![ToolCall {
+            id: "call_1".to_string(),
+            name: "demo__echo".to_string(),
+            arguments: serde_json::json!({"message":"hello"}),
+            reasoning: None,
+            signature: None,
+        }],
+        input_tokens: 1,
+        output_tokens: 1,
+        finish_reason: FinishReason::ToolUse,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+        reasoning: Some(format!("use {api_key} to finish")),
+    }));
+    let gateway = LlmProviderModelGateway::with_provider_identity(
+        STATIC_PROVIDER_ID,
+        provider,
+        LlmModelProfilePolicy::new()
+            .allow_model_profile(interactive_model(), Some("host-selected-model".to_string())),
+    );
+    let capabilities = Arc::new(GatewayCapabilityPort::with_tool_surface());
+
+    let response = gateway
+        .stream_model_with_capabilities(model_request(interactive_model()), capabilities.clone())
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.safe_reasoning_deltas,
+        vec!["use [REDACTED] to finish".to_string()]
+    );
+    let ParentLoopOutput::CapabilityCalls(calls) = response.output else {
+        panic!("expected capability calls");
+    };
+    assert_eq!(calls.len(), 1);
+    assert_eq!(
+        calls[0]
+            .provider_replay
+            .as_ref()
+            .and_then(|replay| replay.response_reasoning.as_deref()),
+        Some("use [REDACTED] to finish")
+    );
+    assert_eq!(
+        capabilities
+            .registered
+            .lock()
+            .unwrap()
+            .first()
+            .and_then(|call| call.response_reasoning.as_deref()),
+        Some("use [REDACTED] to finish")
     );
 }
 

--- a/crates/ironclaw_safety/src/lib.rs
+++ b/crates/ironclaw_safety/src/lib.rs
@@ -27,9 +27,11 @@ pub use leak_detector::{
 pub use policy::{Policy, PolicyAction, PolicyRule, Severity};
 pub use prompt_validation::{PromptSafetyRejection, validate_trusted_trigger_prompt};
 pub use provider_validation::{
-    PROVIDER_TOOL_NAME_MAX_BYTES, ProviderValidationError,
-    validate_optional_provider_metadata_text, validate_provider_arguments,
-    validate_provider_identity, validate_provider_token, validate_provider_tool_name,
+    PROVIDER_TOOL_NAME_MAX_BYTES, ProviderValidationError, scrub_optional_provider_metadata_string,
+    scrub_optional_provider_metadata_text, scrub_provider_metadata_string,
+    scrub_provider_metadata_text, validate_optional_provider_metadata_text,
+    validate_provider_arguments, validate_provider_identity, validate_provider_token,
+    validate_provider_tool_name,
 };
 pub use redaction::{redact_exact_values, redaction_values_for_secret};
 pub use sanitizer::{InjectionWarning, SanitizedOutput, Sanitizer};

--- a/crates/ironclaw_safety/src/provider_validation.rs
+++ b/crates/ironclaw_safety/src/provider_validation.rs
@@ -7,27 +7,6 @@ pub const PROVIDER_TOOL_NAME_MAX_BYTES: usize = 64;
 const PROVIDER_ARGUMENTS_MAX_BYTES: usize = 16 * 1024;
 const PROVIDER_ARGUMENTS_MAX_DEPTH: usize = 16;
 
-const SENSITIVE_PROVIDER_TEXT_MARKERS: [&str; 18] = [
-    "access token",
-    "api key",
-    "api_key",
-    "apikey",
-    "authorization:",
-    "bearer ",
-    "host path",
-    "invalid api key",
-    "invalid_api_key",
-    "password",
-    "passwd",
-    "provider error",
-    "raw runtime",
-    "secret",
-    "stack trace",
-    "tool input",
-    "tool_input",
-    "traceback",
-];
-
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 #[error("{message}")]
 pub struct ProviderValidationError {
@@ -137,12 +116,48 @@ pub fn validate_optional_provider_metadata_text(
     let Some(value) = value else {
         return Ok(());
     };
-    if value.len() > max_len {
-        return Err(ProviderValidationError::new(format!(
-            "{label} exceeds {max_len} bytes"
-        )));
-    }
+    validate_provider_metadata_text_bounds(value, label, max_len)?;
     validate_provider_metadata_text(value, label)
+}
+
+pub fn scrub_optional_provider_metadata_text(
+    value: Option<&str>,
+    label: &str,
+    max_len: usize,
+) -> Result<Option<String>, ProviderValidationError> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    validate_provider_metadata_text_bounds(value, label, max_len)?;
+    scrub_provider_metadata_text(value, label).map(Some)
+}
+
+pub fn scrub_optional_provider_metadata_string(
+    value: Option<String>,
+    label: &str,
+    max_len: usize,
+) -> Result<Option<String>, ProviderValidationError> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    validate_provider_metadata_text_bounds(&value, label, max_len)?;
+    scrub_provider_metadata_string(value, label).map(Some)
+}
+
+pub fn scrub_provider_metadata_text(
+    value: &str,
+    label: &str,
+) -> Result<String, ProviderValidationError> {
+    validate_provider_metadata_text_controls(value, label)?;
+    Ok(redact_provider_secret_matches(value))
+}
+
+pub fn scrub_provider_metadata_string(
+    value: String,
+    label: &str,
+) -> Result<String, ProviderValidationError> {
+    validate_provider_metadata_text_controls(&value, label)?;
+    Ok(redact_provider_secret_matches_owned(value))
 }
 
 fn validate_provider_json_value(
@@ -192,6 +207,27 @@ fn validate_provider_metadata_text(
     value: &str,
     label: &str,
 ) -> Result<(), ProviderValidationError> {
+    validate_provider_metadata_text_controls(value, label)?;
+    reject_provider_secret_leaks(value, label)
+}
+
+fn validate_provider_metadata_text_bounds(
+    value: &str,
+    label: &str,
+    max_len: usize,
+) -> Result<(), ProviderValidationError> {
+    if value.len() > max_len {
+        return Err(ProviderValidationError::new(format!(
+            "{label} exceeds {max_len} bytes"
+        )));
+    }
+    validate_provider_metadata_text_controls(value, label)
+}
+
+fn validate_provider_metadata_text_controls(
+    value: &str,
+    label: &str,
+) -> Result<(), ProviderValidationError> {
     if value.chars().any(|character| {
         character == '\0' || (character.is_control() && !matches!(character, '\n' | '\r' | '\t'))
     }) {
@@ -199,11 +235,7 @@ fn validate_provider_metadata_text(
             "{label} must not contain NUL/control characters"
         )));
     }
-    let lower = value.to_ascii_lowercase();
-    for forbidden in SENSITIVE_PROVIDER_TEXT_MARKERS {
-        reject_sensitive_provider_text_marker(&lower, label, forbidden)?;
-    }
-    reject_provider_secret_leaks(value, label)
+    Ok(())
 }
 
 fn validate_provider_argument_text(
@@ -220,19 +252,6 @@ fn validate_provider_argument_text(
     reject_provider_secret_leaks(value, label)
 }
 
-fn reject_sensitive_provider_text_marker(
-    lower_value: &str,
-    label: &str,
-    forbidden: &'static str,
-) -> Result<(), ProviderValidationError> {
-    if lower_value.contains(forbidden) {
-        return Err(ProviderValidationError::new(format!(
-            "{label} must not contain sensitive marker `{forbidden}`"
-        )));
-    }
-    Ok(())
-}
-
 fn reject_provider_secret_leaks(value: &str, label: &str) -> Result<(), ProviderValidationError> {
     static DETECTOR: OnceLock<LeakDetector> = OnceLock::new();
     let result = DETECTOR.get_or_init(LeakDetector::new).scan(value);
@@ -242,6 +261,49 @@ fn reject_provider_secret_leaks(value: &str, label: &str) -> Result<(), Provider
         )));
     }
     Ok(())
+}
+
+fn redact_provider_secret_matches(value: &str) -> String {
+    static DETECTOR: OnceLock<LeakDetector> = OnceLock::new();
+    let result = DETECTOR.get_or_init(LeakDetector::new).scan(value);
+    if result.matches.is_empty() {
+        return value.to_string();
+    }
+
+    redact_provider_secret_match_ranges(value, result.matches)
+}
+
+fn redact_provider_secret_matches_owned(value: String) -> String {
+    static DETECTOR: OnceLock<LeakDetector> = OnceLock::new();
+    let result = DETECTOR.get_or_init(LeakDetector::new).scan(&value);
+    if result.matches.is_empty() {
+        return value;
+    }
+
+    redact_provider_secret_match_ranges(&value, result.matches)
+}
+
+fn redact_provider_secret_match_ranges(value: &str, matches: Vec<crate::LeakMatch>) -> String {
+    let mut ranges = matches
+        .into_iter()
+        .map(|leak_match| leak_match.location)
+        .collect::<Vec<_>>();
+    ranges.sort_by_key(|range| range.start);
+
+    let mut redacted = String::with_capacity(value.len());
+    let mut cursor = 0;
+    for range in ranges {
+        if range.end <= cursor {
+            continue;
+        }
+        if range.start > cursor {
+            redacted.push_str(&value[cursor..range.start]);
+        }
+        redacted.push_str("[REDACTED]");
+        cursor = range.end;
+    }
+    redacted.push_str(&value[cursor..]);
+    redacted
 }
 
 #[cfg(test)]
@@ -267,19 +329,28 @@ mod tests {
     }
 
     #[test]
-    fn provider_metadata_rejects_sensitive_markers() {
-        let error = validate_optional_provider_metadata_text(
+    fn provider_metadata_allows_benign_sensitive_marker_phrases() {
+        validate_optional_provider_metadata_text(
             Some("provider error included traceback"),
             "provider reasoning",
             4096,
         )
-        .expect_err("sensitive marker should fail");
+        .expect("ordinary provider reasoning phrases should pass");
+    }
 
-        assert!(
-            error
-                .to_string()
-                .contains("sensitive marker `provider error`")
-        );
+    #[test]
+    fn provider_metadata_scrubber_redacts_secret_like_tokens() {
+        let api_key = format!("sk-proj-{}", "a".repeat(24));
+        let redacted = scrub_optional_provider_metadata_text(
+            Some(&format!("use {api_key} to finish")),
+            "provider reasoning",
+            4096,
+        )
+        .expect("metadata should be scrubbed")
+        .expect("metadata present");
+
+        assert_eq!(redacted, "use [REDACTED] to finish");
+        assert!(!redacted.contains(&api_key));
     }
 
     #[test]

--- a/crates/ironclaw_threads/src/tool_result_reference.rs
+++ b/crates/ironclaw_threads/src/tool_result_reference.rs
@@ -250,7 +250,7 @@ mod tests {
     }
 
     #[test]
-    fn provider_reference_validation_rejects_sensitive_arguments_and_text() {
+    fn provider_reference_validation_rejects_sensitive_arguments_but_allows_reasoning_phrases() {
         let mut envelope = provider_reference();
         let api_key = format!("sk-proj-{}", "a".repeat(24));
         envelope.arguments = serde_json::json!({"api_key": api_key});
@@ -258,7 +258,9 @@ mod tests {
 
         let mut envelope = provider_reference();
         envelope.response_reasoning = Some("raw provider error included a stack trace".to_string());
-        assert!(envelope.validate().is_err());
+        envelope
+            .validate()
+            .expect("ordinary provider reasoning phrases should pass");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- allow benign provider reasoning phrases such as `api key` while redacting detected secret-like tokens
- scrub provider reasoning on tool-call, tool-capable Stop, and text-only Stop gateway paths
- keep provider arguments strict and keep provider signatures bounded/control-character validated without mutation
- add caller-level regression coverage for provider replay metadata redaction

## Tests
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p ironclaw_safety provider_validation -- --nocapture`
- `cargo test -p ironclaw_loop_support provider_tool_call -- --nocapture`
- `cargo test -p ironclaw_threads provider_reference_validation -- --nocapture`
- `cargo test -p ironclaw_reborn --features root-llm-provider --test llm_gateway -- --nocapture`

## Notes
- Provider signatures intentionally remain Option A from discussion: bounded/control-character validation only, replayed unchanged for compatibility with opaque provider protocol metadata.