### PR TITLE
[codex] Fix Reborn Docker Railway build inputs

### DIFF
--- a/Dockerfile.reborn
+++ b/Dockerfile.reborn
@@ -82,8 +82,6 @@ RUN useradd -m -d /home/ironclaw -u 1000 ironclaw \
     && chown -R ironclaw:ironclaw /home/ironclaw /data/ironclaw-reborn /workspace \
     && chmod +x /usr/local/bin/ironclaw-reborn-entrypoint
 
-VOLUME ["/data/ironclaw-reborn"]
-
 WORKDIR /workspace
 
 EXPOSE 3000

--- a/crates/ironclaw_reborn_cli/tests/smoke.rs
+++ b/crates/ironclaw_reborn_cli/tests/smoke.rs
@@ -128,6 +128,10 @@ fn dockerfile_reborn_builds_with_postgres_feature() {
         !dockerfile.contains("IRONCLAW_REBORN_HOME=/data/ironclaw-reborn"),
         "Dockerfile.reborn must let the entrypoint resolve Railway volume mounts before falling back to /data: {dockerfile}"
     );
+    assert!(
+        !dockerfile.contains("\nVOLUME "),
+        "Railway's Dockerfile builder rejects Docker VOLUME instructions; configure Railway volumes outside the image: {dockerfile}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Remove the Docker `VOLUME` instruction from `Dockerfile.reborn` because Railway rejects Dockerfile-level volumes and expects Railway Volumes to be configured outside the image.
- Copy the repo-level `migrations/` directory into both Reborn Docker build stages so `ironclaw_filesystem` can compile with the `postgres` feature; it embeds `migrations/V26`-`V30` via `include_str!`.
- Add smoke-test assertions that keep `Dockerfile.reborn` compatible with Railway and keep the Postgres migration inputs in the build context.

## Why
Railway first rejected the production Dockerfile because of `VOLUME ["/data/ironclaw-reborn"]`. After removing that, the Postgres-enabled build failed because the Dockerfile did not copy `migrations/`, but `ironclaw_filesystem/src/postgres.rs` needs those SQL files at compile time.

## Validation
- `git diff --check`
- `rg -n "COPY migrations|^VOLUME\\b|VOLUME \\[" Dockerfile.reborn crates/ironclaw_reborn_cli/tests/smoke.rs`
- `cargo test -p ironclaw_reborn_cli dockerfile_reborn_builds_with_postgres_feature --features webui-v2-beta,slack-v2-host-beta,postgres`

The targeted test passes. It still prints existing unrelated warnings in `ironclaw_reborn_composition` about `openai_user_id` and `StoredSlackPersonalDmTarget::from_target`.