### PR TITLE
[codex] Copy Reborn Docker migrations for Postgres build

### DIFF
--- a/Dockerfile.reborn
+++ b/Dockerfile.reborn
@@ -48,6 +48,7 @@ FROM deps AS builder
 
 COPY Cargo.toml Cargo.lock ./
 COPY crates/ crates/
+COPY migrations/ migrations/
 COPY skills/ skills/
 COPY tests/ tests/
 COPY wit/ wit/

--- a/crates/ironclaw_reborn_cli/tests/smoke.rs
+++ b/crates/ironclaw_reborn_cli/tests/smoke.rs
@@ -124,6 +124,15 @@ fn dockerfile_reborn_builds_with_postgres_feature() {
         dockerfile.contains("config.production.toml"),
         "Dockerfile.reborn must ship the opt-in production config: {dockerfile}"
     );
+    let builder_stage = dockerfile
+        .split_once("FROM deps AS builder")
+        .map(|(_, stage)| stage)
+        .expect("Dockerfile.reborn should define a builder stage");
+    assert!(
+        builder_stage.contains("COPY migrations/ migrations/")
+            && dockerfile.matches("COPY migrations/ migrations/").count() == 1,
+        "Dockerfile.reborn must copy repo-level SQL migrations exactly once in the builder stage for postgres include_str! builds: {dockerfile}"
+    );
     assert!(
         !dockerfile.contains("IRONCLAW_REBORN_HOME=/data/ironclaw-reborn"),
         "Dockerfile.reborn must let the entrypoint resolve Railway volume mounts before falling back to /data: {dockerfile}"


### PR DESCRIPTION
## Summary
- Copy repo-level `migrations/` into the `Dockerfile.reborn` builder stage only.
- Add a smoke-test assertion that verifies the migration copy is exactly once and specifically in the builder stage.

## Why
`ironclaw_filesystem` embeds the root filesystem SQL migrations with `include_str!` behind the `postgres` feature. Railway's production Reborn Docker build enables `postgres`, so the final Docker image compile needs `migrations/V26` through `V30` present in the build context.

The copy is intentionally not in the cargo-chef planner stage. `cargo chef prepare` does not need to evaluate `include_str!`, and keeping migrations out of that stage avoids invalidating dependency-cache recipe generation on SQL-only changes.

This does not mean you need to manually run those files in Supabase for this build failure. The immediate issue is that Rust needs to read them while compiling the binary.

## Validation
- `git diff --check`
- `cargo fmt --check --package ironclaw_reborn_cli`
- `rg -n "COPY migrations/ migrations/|FROM deps AS builder|FROM chef AS planner" Dockerfile.reborn crates/ironclaw_reborn_cli/tests/smoke.rs`
- `cargo test -p ironclaw_reborn_cli dockerfile_reborn_builds_with_postgres_feature --features webui-v2-beta,slack-v2-host-beta,postgres`

The targeted test passes. It still prints existing unrelated warnings in `ironclaw_reborn_composition` about `openai_user_id` and `StoredSlackPersonalDmTarget::from_target`.