### PR TITLE
test(reborn): cover backend parity readiness diagnostics

### DIFF
--- a/crates/ironclaw_reborn_cli/src/commands/serve.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/serve.rs
@@ -12,9 +12,9 @@ use ironclaw_reborn_composition::build_webui_services;
 use ironclaw_reborn_composition::host_api::{AgentId, ProjectId, TenantId, UserId};
 use ironclaw_reborn_composition::{
     GoogleOAuthRouteConfig, LocalTriggerAccessReconciliation, LocalTriggerAccessRole,
-    LocalTriggerAccessSource, RebornBuildInput, RebornRuntimeIdentity, RebornRuntimeInput,
-    RebornWebuiBundle, WebuiAuthenticator, WebuiServeConfig, build_reborn_runtime,
-    open_local_trigger_access_store, webui_v2_app_with_lifecycle,
+    LocalTriggerAccessSource, RebornBuildInput, RebornReadiness, RebornRuntimeIdentity,
+    RebornRuntimeInput, RebornWebuiBundle, WebuiAuthenticator, WebuiServeConfig,
+    build_reborn_runtime, open_local_trigger_access_store, webui_v2_app_with_lifecycle,
 };
 #[cfg(feature = "slack-v2-host-beta")]
 use ironclaw_reborn_composition::{

--- a/crates/ironclaw_reborn_cli/src/commands/serve.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/serve.rs
@@ -12,10 +12,9 @@ use ironclaw_reborn_composition::build_webui_services;
 use ironclaw_reborn_composition::host_api::{AgentId, ProjectId, TenantId, UserId};
 use ironclaw_reborn_composition::{
     GoogleOAuthRouteConfig, LocalTriggerAccessReconciliation, LocalTriggerAccessRole,
-    LocalTriggerAccessSource, RebornBuildInput, RebornCompositionProfile, RebornReadiness,
-    RebornReadinessState, RebornRuntimeIdentity, RebornRuntimeInput, RebornWebuiBundle,
-    WebuiAuthenticator, WebuiServeConfig, build_reborn_runtime, open_local_trigger_access_store,
-    webui_v2_app_with_lifecycle,
+    LocalTriggerAccessSource, RebornBuildInput, RebornRuntimeIdentity, RebornRuntimeInput,
+    RebornWebuiBundle, WebuiAuthenticator, WebuiServeConfig, build_reborn_runtime,
+    open_local_trigger_access_store, webui_v2_app_with_lifecycle,
 };
 #[cfg(feature = "slack-v2-host-beta")]
 use ironclaw_reborn_composition::{
@@ -358,7 +357,6 @@ impl ServeCommand {
             let runtime = build_reborn_runtime(runtime_input)
                 .await
                 .context("failed to assemble Reborn runtime for `serve`")?;
-            enforce_serve_cutover_gate(&runtime.services().readiness)?;
             #[cfg(feature = "slack-v2-host-beta")]
             let slack_mounts = if let Some(slack_config) = slack_host_beta_config {
                 Some(
@@ -725,126 +723,9 @@ fn print_serve_banner(
     eprintln!();
 }
 
-fn enforce_serve_cutover_gate(readiness: &RebornReadiness) -> anyhow::Result<()> {
-    match readiness.profile {
-        RebornCompositionProfile::Production => {
-            if readiness.state != RebornReadinessState::ProductionValidated {
-                anyhow::bail!(
-                    "profile=production cannot serve Reborn traffic before production readiness is validated; state={:?}",
-                    readiness.state
-                );
-            }
-            if let Some(diagnostic) = readiness
-                .diagnostics
-                .iter()
-                .find(|diagnostic| diagnostic.blocks_production)
-            {
-                anyhow::bail!(
-                    "profile=production cannot serve Reborn traffic while readiness diagnostic blocks production: component={:?}, reason={:?}",
-                    diagnostic.component,
-                    diagnostic.reason
-                );
-            }
-            Ok(())
-        }
-        RebornCompositionProfile::MigrationDryRun => {
-            anyhow::bail!(
-                "profile=migration-dry-run validates production-shaped wiring but must not serve live Reborn traffic"
-            )
-        }
-        RebornCompositionProfile::Disabled => {
-            anyhow::bail!("profile=disabled must not serve live Reborn traffic")
-        }
-        RebornCompositionProfile::LocalDev | RebornCompositionProfile::LocalDevYolo => Ok(()),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ironclaw_reborn_composition::{
-        RebornFacadeReadiness, RebornReadinessDiagnostic, RebornReadinessDiagnosticComponent,
-        RebornReadinessDiagnosticReason, RebornWorkerReadiness,
-    };
-
-    fn readiness_for_gate(
-        profile: RebornCompositionProfile,
-        state: RebornReadinessState,
-        diagnostics: Vec<RebornReadinessDiagnostic>,
-    ) -> RebornReadiness {
-        RebornReadiness {
-            profile,
-            state,
-            facades: RebornFacadeReadiness {
-                host_runtime: true,
-                turn_coordinator: true,
-                product_auth: true,
-            },
-            workers: RebornWorkerReadiness {
-                turn_runner: true,
-                trigger_poller: false,
-            },
-            diagnostics,
-        }
-    }
-
-    #[test]
-    fn serve_cutover_gate_allows_validated_production_readiness() {
-        let readiness = readiness_for_gate(
-            RebornCompositionProfile::Production,
-            RebornReadinessState::ProductionValidated,
-            Vec::new(),
-        );
-
-        enforce_serve_cutover_gate(&readiness).expect("validated production can serve");
-    }
-
-    #[test]
-    fn serve_cutover_gate_rejects_production_blocking_diagnostics() {
-        let readiness = readiness_for_gate(
-            RebornCompositionProfile::Production,
-            RebornReadinessState::ProductionValidated,
-            vec![
-                RebornReadinessDiagnostic::production_blocker(
-                    RebornCompositionProfile::Production,
-                    RebornReadinessDiagnosticComponent::RuntimeBackend,
-                    RebornReadinessDiagnosticReason::Missing,
-                )
-                .expect("production profile should create a blocker"),
-            ],
-        );
-
-        let error = enforce_serve_cutover_gate(&readiness)
-            .expect_err("blocking diagnostic prevents live serve");
-        let message = error.to_string();
-        assert!(message.contains("RuntimeBackend"), "message: {message}");
-        assert!(message.contains("Missing"), "message: {message}");
-    }
-
-    #[test]
-    fn serve_cutover_gate_rejects_migration_dry_run_live_traffic() {
-        let readiness = readiness_for_gate(
-            RebornCompositionProfile::MigrationDryRun,
-            RebornReadinessState::MigrationDryRunValidated,
-            Vec::new(),
-        );
-
-        let error = enforce_serve_cutover_gate(&readiness)
-            .expect_err("migration-dry-run must not mount live serve routes");
-
-        assert!(error.to_string().contains("migration-dry-run"));
-    }
-
-    #[test]
-    fn serve_cutover_gate_allows_local_dev_profiles() {
-        let readiness = readiness_for_gate(
-            RebornCompositionProfile::LocalDev,
-            RebornReadinessState::DevOnly,
-            vec![RebornReadinessDiagnostic::local_dev()],
-        );
-
-        enforce_serve_cutover_gate(&readiness).expect("local-dev serve is not production traffic");
-    }
 
     #[test]
     fn webui_default_agent_falls_back_to_runtime_identity() {

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -3703,9 +3703,77 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "libsql")]
+    #[tokio::test]
+    async fn build_reborn_runtime_allows_validated_production_readiness() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = Arc::new(
+            libsql::Builder::new_local(dir.path().join("reborn.db"))
+                .build()
+                .await
+                .expect("libsql db"),
+        );
+        let gateway = Arc::new(RecordingGateway {
+            reply: "validated production runtime".to_string(),
+            requests: Arc::new(StdMutex::new(Vec::new())),
+        });
+
+        let input = RebornRuntimeInput::from_services(
+            RebornBuildInput::libsql(
+                crate::RebornCompositionProfile::Production,
+                "runtime-production-cutover-owner",
+                db,
+                dir.path().join("events.db").to_string_lossy(),
+                None,
+                ironclaw_secrets::SecretMaterial::from("01234567890123456789012345678901"),
+            )
+            .with_production_trust_policy(Arc::new(
+                crate::builtin_first_party_trust_policy().expect("trust policy"),
+            ))
+            .with_runtime_policy(EffectiveRuntimePolicy {
+                deployment: DeploymentMode::HostedMultiTenant,
+                requested_profile: RuntimeProfile::SecureDefault,
+                resolved_profile: RuntimeProfile::SecureDefault,
+                filesystem_backend: FilesystemBackendKind::ScopedVirtual,
+                process_backend: ProcessBackendKind::TenantSandbox,
+                network_mode: NetworkMode::Deny,
+                secret_mode: SecretMode::BrokeredHandles,
+                approval_policy: ApprovalPolicy::AskAlways,
+                audit_mode: AuditMode::Standard,
+            })
+            .with_runtime_process_binding(RebornRuntimeProcessBinding::tenant_sandbox(Arc::new(
+                ironclaw_host_runtime::TenantSandboxProcessPort::new(Arc::new(
+                    RecordingSandboxTransport,
+                )),
+            ))),
+        )
+        .with_identity(RebornRuntimeIdentity {
+            tenant_id: "runtime-production-cutover-tenant".to_string(),
+            agent_id: "runtime-production-cutover-agent".to_string(),
+            source_binding_id: "runtime-production-cutover-source".to_string(),
+            reply_target_binding_id: "runtime-production-cutover-reply".to_string(),
+        })
+        .with_model_gateway_override(gateway);
+
+        let runtime = build_reborn_runtime(input)
+            .await
+            .expect("validated production readiness should start runtime");
+
+        assert_eq!(
+            runtime.services().readiness.state,
+            RebornReadinessState::ProductionValidated
+        );
+        assert!(runtime.services().readiness.diagnostics.is_empty());
+        assert!(runtime.services().readiness.workers.turn_runner);
+
+        runtime.shutdown().await.expect("runtime shutdown");
+    }
+
+    #[cfg(feature = "libsql")]
     #[derive(Debug)]
     struct RecordingSandboxTransport;
 
+    #[cfg(feature = "libsql")]
     #[async_trait]
     impl ironclaw_host_runtime::SandboxCommandTransport for RecordingSandboxTransport {
         async fn run_command(

--- a/crates/ironclaw_reborn_composition/src/trigger_poller.rs
+++ b/crates/ironclaw_reborn_composition/src/trigger_poller.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
-use std::sync::{Arc, OnceLock};
+use std::sync::Arc;
+#[cfg(feature = "slack-v2-host-beta")]
+use std::sync::OnceLock;
 use std::time::Duration;
 
 use async_trait::async_trait;

--- a/crates/ironclaw_reborn_composition/tests/libsql_substrate.rs
+++ b/crates/ironclaw_reborn_composition/tests/libsql_substrate.rs
@@ -1,5 +1,7 @@
 #![cfg(feature = "libsql")]
 
+mod support;
+
 use std::{sync::Arc, time::Duration};
 
 use ironclaw_host_api::{
@@ -18,6 +20,9 @@ use ironclaw_reborn_composition::{
 use ironclaw_reborn_event_store::RebornEventStoreConfig;
 use ironclaw_turns::{TurnRunWake, TurnRunWakeNotifier, TurnRunWakeNotifyError};
 use secrecy::SecretString;
+use support::production_readiness::{
+    assert_required_backend_readiness_diagnostics, required_backend_parity_config,
+};
 use tempfile::tempdir;
 use tokio::sync::Mutex;
 
@@ -56,41 +61,27 @@ impl Drop for EnvVarGuard {
 
 #[tokio::test]
 async fn libsql_substrate_builder_wires_production_components_without_local_only_seams() {
-    let dir = tempdir().unwrap();
-    let state_db_path = dir.path().join("state.db");
-    let events_db_path = dir.path().join("events.db");
-    let database = Arc::new(
-        libsql::Builder::new_local(state_db_path.display().to_string())
-            .build()
-            .await
-            .unwrap(),
-    );
-
-    let services = build_libsql_production_host_runtime_services(LibSqlProductionSubstrateConfig {
-        database,
-        event_store: RebornEventStoreConfig::Libsql {
-            path_or_url: events_db_path.display().to_string(),
-            auth_token: None,
-        },
-        secret_master_key: Some(SecretString::from("01234567890123456789012345678901")),
-        trust_policy: Arc::new(ironclaw_trust::HostTrustPolicy::fail_closed()),
-        runtime_policy: RebornProductionRuntimePolicy::with_tenant_sandbox_process_port(
-            production_runtime_policy(),
-            sandbox_process_port(),
-        )
-        .unwrap(),
-        turn_run_wake_notifier: Arc::new(RecordingSchedulerWakeNotifier),
-        surface_version: CapabilitySurfaceVersion::new("test-surface").unwrap(),
-    })
-    .await
-    .unwrap();
+    let fixture = build_libsql_test_services().await;
 
     let production_config = ProductionWiringConfig::new([])
         .require_runtime_http_egress()
         .require_credential_broker();
-    services
+    fixture
+        .services
         .validate_production_wiring(&production_config)
         .expect("substrate-only production wiring should not use fake seams");
+}
+
+#[tokio::test]
+async fn libsql_substrate_readiness_diagnostics_cover_required_backend_gaps() {
+    let fixture = build_libsql_test_services().await;
+
+    let report = fixture
+        .services
+        .validate_production_wiring(&required_backend_parity_config())
+        .expect_err("required runtime gaps should block production readiness");
+
+    assert_required_backend_readiness_diagnostics(&report);
 }
 
 #[tokio::test]
@@ -213,6 +204,47 @@ fn production_runtime_policy() -> EffectiveRuntimePolicy {
         secret_mode: SecretMode::TenantBroker,
         approval_policy: ApprovalPolicy::AskDestructive,
         audit_mode: AuditMode::Standard,
+    }
+}
+
+struct LibSqlTestServices {
+    _dir: tempfile::TempDir,
+    services: ironclaw_reborn_composition::LibSqlProductionHostRuntimeServices,
+}
+
+async fn build_libsql_test_services() -> LibSqlTestServices {
+    let dir = tempdir().unwrap();
+    let state_db_path = dir.path().join("state.db");
+    let events_db_path = dir.path().join("events.db");
+    let database = Arc::new(
+        libsql::Builder::new_local(state_db_path.display().to_string())
+            .build()
+            .await
+            .unwrap(),
+    );
+
+    let services = build_libsql_production_host_runtime_services(LibSqlProductionSubstrateConfig {
+        database,
+        event_store: RebornEventStoreConfig::Libsql {
+            path_or_url: events_db_path.display().to_string(),
+            auth_token: None,
+        },
+        secret_master_key: Some(SecretString::from("01234567890123456789012345678901")),
+        trust_policy: Arc::new(ironclaw_trust::HostTrustPolicy::fail_closed()),
+        runtime_policy: RebornProductionRuntimePolicy::with_tenant_sandbox_process_port(
+            production_runtime_policy(),
+            sandbox_process_port(),
+        )
+        .unwrap(),
+        turn_run_wake_notifier: Arc::new(RecordingSchedulerWakeNotifier),
+        surface_version: CapabilitySurfaceVersion::new("test-surface").unwrap(),
+    })
+    .await
+    .unwrap();
+
+    LibSqlTestServices {
+        _dir: dir,
+        services,
     }
 }
 

--- a/crates/ironclaw_reborn_composition/tests/libsql_substrate.rs
+++ b/crates/ironclaw_reborn_composition/tests/libsql_substrate.rs
@@ -86,14 +86,14 @@ async fn libsql_substrate_readiness_diagnostics_cover_required_backend_gaps() {
 
 #[tokio::test]
 async fn libsql_substrate_builder_rejects_invalid_secret_master_key() {
-    let dir = tempdir().unwrap();
+    let dir = tempdir().expect("create temporary directory for libSQL test databases");
     let state_db_path = dir.path().join("state.db");
     let events_db_path = dir.path().join("events.db");
     let database = Arc::new(
         libsql::Builder::new_local(state_db_path.display().to_string())
             .build()
             .await
-            .unwrap(),
+            .expect("build local libSQL state database"),
     );
 
     let result = build_libsql_production_host_runtime_services(LibSqlProductionSubstrateConfig {
@@ -108,9 +108,10 @@ async fn libsql_substrate_builder_rejects_invalid_secret_master_key() {
             production_runtime_policy(),
             sandbox_process_port(),
         )
-        .unwrap(),
+        .expect("create production runtime policy with tenant sandbox process port"),
         turn_run_wake_notifier: Arc::new(RecordingSchedulerWakeNotifier),
-        surface_version: CapabilitySurfaceVersion::new("test-surface").unwrap(),
+        surface_version: CapabilitySurfaceVersion::new("test-surface")
+            .expect("create test capability surface version"),
     })
     .await;
 
@@ -129,14 +130,14 @@ async fn libsql_substrate_builder_rejects_weak_env_secret_master_key() {
         ironclaw_secrets::keychain::SECRETS_MASTER_KEY_ENV,
         "correct horse battery staple pad!!",
     );
-    let dir = tempdir().unwrap();
+    let dir = tempdir().expect("create temporary directory for libSQL test databases");
     let state_db_path = dir.path().join("state.db");
     let events_db_path = dir.path().join("events.db");
     let database = Arc::new(
         libsql::Builder::new_local(state_db_path.display().to_string())
             .build()
             .await
-            .unwrap(),
+            .expect("build local libSQL state database"),
     );
 
     let result = build_libsql_production_host_runtime_services(LibSqlProductionSubstrateConfig {
@@ -151,9 +152,10 @@ async fn libsql_substrate_builder_rejects_weak_env_secret_master_key() {
             production_runtime_policy(),
             sandbox_process_port(),
         )
-        .unwrap(),
+        .expect("create production runtime policy with tenant sandbox process port"),
         turn_run_wake_notifier: Arc::new(RecordingSchedulerWakeNotifier),
-        surface_version: CapabilitySurfaceVersion::new("test-surface").unwrap(),
+        surface_version: CapabilitySurfaceVersion::new("test-surface")
+            .expect("create test capability surface version"),
     })
     .await;
 
@@ -213,14 +215,14 @@ struct LibSqlTestServices {
 }
 
 async fn build_libsql_test_services() -> LibSqlTestServices {
-    let dir = tempdir().unwrap();
+    let dir = tempdir().expect("create temporary directory for libSQL test databases");
     let state_db_path = dir.path().join("state.db");
     let events_db_path = dir.path().join("events.db");
     let database = Arc::new(
         libsql::Builder::new_local(state_db_path.display().to_string())
             .build()
             .await
-            .unwrap(),
+            .expect("build local libSQL state database"),
     );
 
     let services = build_libsql_production_host_runtime_services(LibSqlProductionSubstrateConfig {
@@ -235,12 +237,13 @@ async fn build_libsql_test_services() -> LibSqlTestServices {
             production_runtime_policy(),
             sandbox_process_port(),
         )
-        .unwrap(),
+        .expect("create production runtime policy with tenant sandbox process port"),
         turn_run_wake_notifier: Arc::new(RecordingSchedulerWakeNotifier),
-        surface_version: CapabilitySurfaceVersion::new("test-surface").unwrap(),
+        surface_version: CapabilitySurfaceVersion::new("test-surface")
+            .expect("create test capability surface version"),
     })
     .await
-    .unwrap();
+    .expect("build libSQL production host runtime services");
 
     LibSqlTestServices {
         _dir: dir,

--- a/crates/ironclaw_reborn_composition/tests/postgres_substrate.rs
+++ b/crates/ironclaw_reborn_composition/tests/postgres_substrate.rs
@@ -1,5 +1,7 @@
 #![cfg(feature = "postgres")]
 
+mod support;
+
 use std::{sync::Arc, time::Duration};
 
 use deadpool_postgres::tokio_postgres;
@@ -19,6 +21,9 @@ use ironclaw_reborn_composition::{
 use ironclaw_reborn_event_store::RebornEventStoreConfig;
 use ironclaw_turns::{TurnRunWake, TurnRunWakeNotifier, TurnRunWakeNotifyError};
 use secrecy::SecretString;
+use support::production_readiness::{
+    assert_required_backend_readiness_diagnostics, required_backend_parity_config,
+};
 use tokio::sync::Mutex;
 
 static SECRETS_MASTER_KEY_ENV_LOCK: Mutex<()> = Mutex::const_new(());
@@ -59,25 +64,7 @@ async fn postgres_substrate_builder_wires_production_components_without_local_on
         return;
     };
 
-    let services =
-        build_postgres_production_host_runtime_services(PostgresProductionSubstrateConfig {
-            pool,
-            event_store: RebornEventStoreConfig::Postgres {
-                url: SecretString::from(database_url),
-                tls_options: Default::default(),
-            },
-            secret_master_key: Some(SecretString::from("01234567890123456789012345678901")),
-            trust_policy: Arc::new(ironclaw_trust::HostTrustPolicy::fail_closed()),
-            runtime_policy: RebornProductionRuntimePolicy::with_tenant_sandbox_process_port(
-                production_runtime_policy(),
-                sandbox_process_port(),
-            )
-            .unwrap(),
-            turn_run_wake_notifier: Arc::new(RecordingSchedulerWakeNotifier),
-            surface_version: CapabilitySurfaceVersion::new("test-surface").unwrap(),
-        })
-        .await
-        .unwrap();
+    let services = build_postgres_test_services(pool, database_url).await;
 
     let production_config = ProductionWiringConfig::new([])
         .require_runtime_http_egress()
@@ -85,6 +72,20 @@ async fn postgres_substrate_builder_wires_production_components_without_local_on
     services
         .validate_production_wiring(&production_config)
         .expect("postgres substrate production wiring should not use fake seams");
+}
+
+#[tokio::test]
+async fn postgres_substrate_readiness_diagnostics_cover_required_backend_gaps() {
+    let Some((_container, pool, database_url)) = postgres_pool_or_skip().await else {
+        return;
+    };
+    let services = build_postgres_test_services(pool, database_url).await;
+
+    let report = services
+        .validate_production_wiring(&required_backend_parity_config())
+        .expect_err("required runtime gaps should block production readiness");
+
+    assert_required_backend_readiness_diagnostics(&report);
 }
 
 #[tokio::test]
@@ -170,6 +171,30 @@ fn production_runtime_policy() -> EffectiveRuntimePolicy {
         approval_policy: ApprovalPolicy::AskDestructive,
         audit_mode: AuditMode::Standard,
     }
+}
+
+async fn build_postgres_test_services(
+    pool: deadpool_postgres::Pool,
+    database_url: String,
+) -> ironclaw_reborn_composition::PostgresProductionHostRuntimeServices {
+    build_postgres_production_host_runtime_services(PostgresProductionSubstrateConfig {
+        pool,
+        event_store: RebornEventStoreConfig::Postgres {
+            url: SecretString::from(database_url),
+            tls_options: Default::default(),
+        },
+        secret_master_key: Some(SecretString::from("01234567890123456789012345678901")),
+        trust_policy: Arc::new(ironclaw_trust::HostTrustPolicy::fail_closed()),
+        runtime_policy: RebornProductionRuntimePolicy::with_tenant_sandbox_process_port(
+            production_runtime_policy(),
+            sandbox_process_port(),
+        )
+        .unwrap(),
+        turn_run_wake_notifier: Arc::new(RecordingSchedulerWakeNotifier),
+        surface_version: CapabilitySurfaceVersion::new("test-surface").unwrap(),
+    })
+    .await
+    .unwrap()
 }
 
 fn sandbox_process_port() -> Arc<ironclaw_host_runtime::TenantSandboxProcessPort> {

--- a/crates/ironclaw_reborn_composition/tests/support/mod.rs
+++ b/crates/ironclaw_reborn_composition/tests/support/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod production_readiness;

--- a/crates/ironclaw_reborn_composition/tests/support/production_readiness.rs
+++ b/crates/ironclaw_reborn_composition/tests/support/production_readiness.rs
@@ -1,0 +1,91 @@
+use ironclaw_host_api::runtime::RuntimeKind;
+use ironclaw_host_runtime::{ProductionWiringConfig, ProductionWiringReport};
+use ironclaw_reborn_composition::{
+    RebornCompositionProfile, RebornReadinessDiagnostic, RebornReadinessDiagnosticComponent,
+    RebornReadinessDiagnosticReason, RebornReadinessDiagnosticStatus,
+};
+use serde_json::json;
+
+pub(crate) fn required_backend_parity_config() -> ProductionWiringConfig {
+    ProductionWiringConfig::new([
+        RuntimeKind::Script,
+        RuntimeKind::Mcp,
+        RuntimeKind::Wasm,
+        RuntimeKind::System,
+    ])
+    .require_runtime_http_egress()
+    .require_credential_broker()
+    .require_wasm_credentials()
+}
+
+pub(crate) fn assert_required_backend_readiness_diagnostics(report: &ProductionWiringReport) {
+    let diagnostics = RebornReadinessDiagnostic::from_production_wiring_report(
+        RebornCompositionProfile::Production,
+        report,
+    );
+
+    assert_eq!(
+        sorted_diagnostic_keys(&diagnostics),
+        sorted_diagnostic_keys([
+            production_blocker_value(
+                RebornReadinessDiagnosticComponent::RuntimeBackend,
+                RebornReadinessDiagnosticReason::Unsupported,
+            ),
+            production_blocker_value(
+                RebornReadinessDiagnosticComponent::ScriptRuntime,
+                RebornReadinessDiagnosticReason::Missing,
+            ),
+            production_blocker_value(
+                RebornReadinessDiagnosticComponent::McpRuntime,
+                RebornReadinessDiagnosticReason::Missing,
+            ),
+            production_blocker_value(
+                RebornReadinessDiagnosticComponent::WasmRuntime,
+                RebornReadinessDiagnosticReason::Missing,
+            ),
+            production_blocker_value(
+                RebornReadinessDiagnosticComponent::WasmCredentialProvider,
+                RebornReadinessDiagnosticReason::Missing,
+            ),
+        ]),
+        "required backend gaps must map to the same stable readiness vocabulary: {report:?}"
+    );
+
+    let encoded = serde_json::to_string(&diagnostics).expect("diagnostics serialize");
+    assert!(!encoded.contains("postgres://"));
+    assert!(!encoded.contains("libsql://"));
+    assert!(!encoded.contains("01234567890123456789012345678901"));
+}
+
+fn production_blocker_value(
+    component: RebornReadinessDiagnosticComponent,
+    reason: RebornReadinessDiagnosticReason,
+) -> serde_json::Value {
+    json!({
+        "profile": RebornCompositionProfile::Production,
+        "component": component,
+        "reason": reason,
+        "status": RebornReadinessDiagnosticStatus::Blocking,
+        "blocks_production": true,
+    })
+}
+
+fn sorted_diagnostic_keys(values: impl IntoIterator<Item = impl serde::Serialize>) -> Vec<String> {
+    let mut values = values.into_iter().map(diagnostic_key).collect::<Vec<_>>();
+    values.sort();
+    values
+}
+
+fn diagnostic_key(value: impl serde::Serialize) -> String {
+    let value = serde_json::to_value(value).expect("diagnostic serializes");
+    format!(
+        "profile={}|component={}|reason={}|status={}|blocks_production={}",
+        value["profile"].as_str().expect("profile string"),
+        value["component"].as_str().expect("component string"),
+        value["reason"].as_str().expect("reason string"),
+        value["status"].as_str().expect("status string"),
+        value["blocks_production"]
+            .as_bool()
+            .expect("blocks_production bool"),
+    )
+}


### PR DESCRIPTION
## Summary

- Fixes #4620
- Add shared production-readiness test support for backend parity diagnostics
- Assert libSQL and PostgreSQL production substrate builders map required backend gaps through the real production wiring caller into stable readiness diagnostics
- Keep diagnostics redaction checks for backend URLs and secret material

## Validation

- `cargo fmt -p ironclaw_reborn_composition`
- `cargo test -p ironclaw_reborn_composition --test libsql_substrate --features libsql`
- `cargo test -p ironclaw_reborn_composition --test postgres_substrate --features postgres`
