### PR TITLE
[codex] Allow Reborn Postgres cleartext opt-in

### DIFF
--- a/crates/ironclaw_reborn_cli/src/runtime/mod.rs
+++ b/crates/ironclaw_reborn_cli/src/runtime/mod.rs
@@ -743,6 +743,14 @@ mod tests {
         )
     }
 
+    #[cfg(feature = "postgres")]
+    fn clear_reborn_postgres_tls_env() -> (EnvGuard, EnvGuard) {
+        (
+            EnvGuard::clear("DATABASE_SSLMODE"),
+            EnvGuard::clear("IRONCLAW_REBORN_ALLOW_REMOTE_POSTGRES_CLEAR_TEXT"),
+        )
+    }
+
     #[tokio::test]
     async fn block_on_cli_can_run_inside_existing_tokio_runtime() {
         let value = block_on_cli(async { Ok::<_, anyhow::Error>(42) }).expect("block future");
@@ -1323,6 +1331,7 @@ default_profile = "secure_default"
     fn build_runtime_input_production_rejects_remote_postgres_sslmode_disable_redacted() {
         let _lock = lock_trigger_env();
         let (_enabled, _interval) = clear_trigger_poller_env();
+        let (_database_sslmode, _allow_cleartext) = clear_reborn_postgres_tls_env();
         let _postgres_url = EnvGuard::set(
             "IRONCLAW_REBORN_POSTGRES_URL",
             "postgres://event_user:RAW_PASSWORD_SENTINEL_3162@db.example.com/events?sslmode=disable",
@@ -1371,9 +1380,161 @@ default_profile = "secure_default"
 
     #[cfg(feature = "postgres")]
     #[test]
+    fn build_runtime_input_production_rejects_database_sslmode_disable_without_opt_in() {
+        let _lock = lock_trigger_env();
+        let (_enabled, _interval) = clear_trigger_poller_env();
+        let _database_sslmode = EnvGuard::set("DATABASE_SSLMODE", "Disable");
+        let _allow_cleartext = EnvGuard::clear("IRONCLAW_REBORN_ALLOW_REMOTE_POSTGRES_CLEAR_TEXT");
+        let _postgres_url = EnvGuard::set(
+            "IRONCLAW_REBORN_POSTGRES_URL",
+            "postgres://event_user:RAW_PASSWORD_SENTINEL_3162@db.example.com/events?sslmode=require",
+        );
+        let _secret_master_key =
+            EnvGuard::set("IRONCLAW_REBORN_SECRET_MASTER_KEY", "test-master-key");
+        let (_temp, config) = boot_config_with_config_toml(
+            "production",
+            r#"
+[storage]
+backend = "postgres"
+url_env = "IRONCLAW_REBORN_POSTGRES_URL"
+secret_master_key_env = "IRONCLAW_REBORN_SECRET_MASTER_KEY"
+
+[policy]
+deployment_mode = "hosted_multi_tenant"
+default_profile = "secure_default"
+"#,
+        );
+
+        let err = build_runtime_input(&config, RuntimeInputCaller::Run)
+            .err()
+            .expect("DATABASE_SSLMODE=disable must fail without the Reborn opt-in");
+        let rendered = format!("{err:#}");
+
+        assert!(
+            rendered.contains("sslmode=disable"),
+            "error should mention rejected sslmode, got: {rendered}"
+        );
+        assert!(!rendered.contains("RAW_PASSWORD_SENTINEL_3162"));
+        assert!(!rendered.contains("postgres://"));
+        assert!(!rendered.contains("db.example.com"));
+    }
+
+    #[cfg(feature = "postgres")]
+    #[test]
+    fn build_runtime_input_production_allows_database_sslmode_disable_with_opt_in() {
+        let _lock = lock_trigger_env();
+        let (_enabled, _interval) = clear_trigger_poller_env();
+        let _database_sslmode = EnvGuard::set("DATABASE_SSLMODE", "DISABLE");
+        let _allow_cleartext =
+            EnvGuard::set("IRONCLAW_REBORN_ALLOW_REMOTE_POSTGRES_CLEAR_TEXT", "On");
+        let _postgres_url = EnvGuard::set(
+            "IRONCLAW_REBORN_POSTGRES_URL",
+            "postgres://event_user:RAW_PASSWORD_SENTINEL_3162@db.example.com/events?sslmode=require",
+        );
+        let _secret_master_key =
+            EnvGuard::set("IRONCLAW_REBORN_SECRET_MASTER_KEY", "test-master-key");
+        let (_temp, config) = boot_config_with_config_toml(
+            "production",
+            r#"
+[storage]
+backend = "postgres"
+url_env = "IRONCLAW_REBORN_POSTGRES_URL"
+secret_master_key_env = "IRONCLAW_REBORN_SECRET_MASTER_KEY"
+
+[policy]
+deployment_mode = "hosted_multi_tenant"
+default_profile = "secure_default"
+"#,
+        );
+
+        let runtime_input =
+            build_runtime_input(&config, RuntimeInputCaller::Run).expect("runtime input");
+        let services = runtime_input.services.expect("services input");
+        assert_eq!(services.profile(), RebornCompositionProfile::Production);
+    }
+
+    #[cfg(feature = "postgres")]
+    #[test]
+    fn build_runtime_input_production_rejects_invalid_cleartext_opt_in() {
+        let _lock = lock_trigger_env();
+        let (_enabled, _interval) = clear_trigger_poller_env();
+        let _database_sslmode = EnvGuard::set("DATABASE_SSLMODE", "disable");
+        let _allow_cleartext = EnvGuard::set(
+            "IRONCLAW_REBORN_ALLOW_REMOTE_POSTGRES_CLEAR_TEXT",
+            "enabled",
+        );
+        let _postgres_url = EnvGuard::set(
+            "IRONCLAW_REBORN_POSTGRES_URL",
+            "postgres://event_user:RAW_PASSWORD_SENTINEL_3162@db.example.com/events?sslmode=require",
+        );
+        let _secret_master_key =
+            EnvGuard::set("IRONCLAW_REBORN_SECRET_MASTER_KEY", "test-master-key");
+        let (_temp, config) = boot_config_with_config_toml(
+            "production",
+            r#"
+[storage]
+backend = "postgres"
+url_env = "IRONCLAW_REBORN_POSTGRES_URL"
+secret_master_key_env = "IRONCLAW_REBORN_SECRET_MASTER_KEY"
+
+[policy]
+deployment_mode = "hosted_multi_tenant"
+default_profile = "secure_default"
+"#,
+        );
+
+        let err = build_runtime_input(&config, RuntimeInputCaller::Run)
+            .err()
+            .expect("invalid cleartext opt-in must fail loudly");
+        let rendered = format!("{err:#}");
+
+        assert!(rendered.contains("IRONCLAW_REBORN_ALLOW_REMOTE_POSTGRES_CLEAR_TEXT"));
+        assert!(rendered.contains("true"));
+        assert!(rendered.contains("false"));
+        assert!(!rendered.contains("RAW_PASSWORD_SENTINEL_3162"));
+        assert!(!rendered.contains("postgres://"));
+        assert!(!rendered.contains("db.example.com"));
+    }
+
+    #[cfg(feature = "postgres")]
+    #[test]
+    fn build_runtime_input_production_accepts_verify_full_database_sslmode() {
+        let _lock = lock_trigger_env();
+        let (_enabled, _interval) = clear_trigger_poller_env();
+        let _database_sslmode = EnvGuard::set("DATABASE_SSLMODE", "verify-full");
+        let _allow_cleartext = EnvGuard::clear("IRONCLAW_REBORN_ALLOW_REMOTE_POSTGRES_CLEAR_TEXT");
+        let _postgres_url = EnvGuard::set(
+            "IRONCLAW_REBORN_POSTGRES_URL",
+            "postgres://event_user:RAW_PASSWORD_SENTINEL_3162@db.example.com/events?sslmode=require",
+        );
+        let _secret_master_key =
+            EnvGuard::set("IRONCLAW_REBORN_SECRET_MASTER_KEY", "test-master-key");
+        let (_temp, config) = boot_config_with_config_toml(
+            "production",
+            r#"
+[storage]
+backend = "postgres"
+url_env = "IRONCLAW_REBORN_POSTGRES_URL"
+secret_master_key_env = "IRONCLAW_REBORN_SECRET_MASTER_KEY"
+
+[policy]
+deployment_mode = "hosted_multi_tenant"
+default_profile = "secure_default"
+"#,
+        );
+
+        let runtime_input =
+            build_runtime_input(&config, RuntimeInputCaller::Run).expect("runtime input");
+        let services = runtime_input.services.expect("services input");
+        assert_eq!(services.profile(), RebornCompositionProfile::Production);
+    }
+
+    #[cfg(feature = "postgres")]
+    #[test]
     fn build_runtime_input_production_constructs_postgres_services_input() {
         let lock = lock_trigger_env();
         let (enabled, interval) = clear_trigger_poller_env();
+        let (database_sslmode, allow_cleartext) = clear_reborn_postgres_tls_env();
         let postgres_url = EnvGuard::set(
             "IRONCLAW_REBORN_POSTGRES_URL",
             "postgres://event_user:RAW_PASSWORD_SENTINEL_3162@db.example.com/events?sslmode=require",
@@ -1425,6 +1586,8 @@ default_profile = "secure_default"
         drop(secret_master_key);
         drop(interval);
         drop(enabled);
+        drop(allow_cleartext);
+        drop(database_sslmode);
         drop(lock);
     }
 

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -2344,6 +2344,7 @@ async fn build_production_shaped(
         RebornStorageInput::Postgres {
             pool,
             url,
+            tls_options,
             secret_master_key,
         } => {
             let production_wiring = production_wiring(
@@ -2362,7 +2363,7 @@ async fn build_production_shaped(
                 oauth_dcr_provider_configs,
                 owner_id,
             };
-            build_postgres_production(context, pool, url, secret_master_key).await
+            build_postgres_production(context, pool, url, tls_options, secret_master_key).await
         }
     }
 }
@@ -2929,6 +2930,7 @@ async fn build_postgres_production(
     context: RebornProductionBuildContext,
     pool: deadpool_postgres::Pool,
     url: ironclaw_secrets::SecretMaterial,
+    tls_options: ironclaw_reborn_event_store::PostgresPoolTlsOptions,
     secret_master_key: ironclaw_secrets::SecretMaterial,
 ) -> Result<RebornServices, RebornBuildError> {
     use ironclaw_filesystem::PostgresRootFilesystem;
@@ -2945,7 +2947,7 @@ async fn build_postgres_production(
     let stores = ProductionStoreBundle::new(
         filesystem,
         secret_master_key,
-        ironclaw_reborn_event_store::RebornEventStoreConfig::Postgres { url },
+        ironclaw_reborn_event_store::RebornEventStoreConfig::Postgres { url, tls_options },
     )?;
 
     build_backend_production(

--- a/crates/ironclaw_reborn_composition/src/input.rs
+++ b/crates/ironclaw_reborn_composition/src/input.rs
@@ -20,6 +20,8 @@ use secrecy::SecretString;
 
 #[cfg(feature = "postgres")]
 use ironclaw_reborn_config::StorageBackend;
+#[cfg(feature = "postgres")]
+use ironclaw_reborn_event_store::{PostgresPoolTlsOptions, RebornPostgresSslMode};
 
 #[cfg(feature = "postgres")]
 use crate::RebornBuildError;
@@ -33,6 +35,11 @@ use crate::{RebornCompositionProfile, RebornProductAuthServicePorts};
 const DEFAULT_REBORN_POSTGRES_URL_ENV: &str = "IRONCLAW_REBORN_POSTGRES_URL";
 #[cfg(feature = "postgres")]
 const DEFAULT_REBORN_SECRET_MASTER_KEY_ENV: &str = "IRONCLAW_REBORN_SECRET_MASTER_KEY";
+#[cfg(feature = "postgres")]
+const DATABASE_SSLMODE_ENV: &str = "DATABASE_SSLMODE";
+#[cfg(feature = "postgres")]
+const ALLOW_REMOTE_POSTGRES_CLEAR_TEXT_ENV: &str =
+    "IRONCLAW_REBORN_ALLOW_REMOTE_POSTGRES_CLEAR_TEXT";
 
 /// Composition-time OAuth client metadata.
 ///
@@ -194,6 +201,7 @@ pub(crate) enum RebornStorageInput {
     Postgres {
         pool: deadpool_postgres::Pool,
         url: ironclaw_secrets::SecretMaterial,
+        tls_options: PostgresPoolTlsOptions,
         secret_master_key: Option<ironclaw_secrets::SecretMaterial>,
     },
 }
@@ -345,6 +353,7 @@ impl RebornBuildInput {
             RebornStorageInput::Postgres {
                 pool,
                 url,
+                tls_options: PostgresPoolTlsOptions::default(),
                 secret_master_key: Some(secret_master_key),
             },
         )
@@ -363,6 +372,7 @@ impl RebornBuildInput {
             RebornStorageInput::Postgres {
                 pool,
                 url,
+                tls_options: PostgresPoolTlsOptions::default(),
                 secret_master_key: None,
             },
         )
@@ -418,17 +428,28 @@ impl RebornBuildInput {
         let pool_max_size = storage
             .pool_max_size
             .unwrap_or(ironclaw_reborn_event_store::DEFAULT_POSTGRES_POOL_MAX_SIZE);
-        let pool =
-            crate::open_reborn_postgres_pool_with_max_size(database_url.clone(), pool_max_size)?;
+        let tls_options = postgres_pool_tls_options_from_env()?;
+        let pool = ironclaw_reborn_event_store::open_postgres_pool_with_tls_options(
+            database_url.clone(),
+            pool_max_size,
+            tls_options,
+        )?;
         let runtime_policy = resolve_production_runtime_policy(profile, config_file)?;
         let trust_policy = crate::builtin_first_party_trust_policy()?;
 
-        Ok(
-            Self::postgres(profile, owner_id, pool, database_url, secret_master_key)
-                .with_production_trust_policy(Arc::new(trust_policy))
-                .with_runtime_policy(runtime_policy)
-                .with_runtime_process_binding(RebornRuntimeProcessBinding::none()),
+        Ok(Self::new(
+            profile,
+            owner_id,
+            RebornStorageInput::Postgres {
+                pool,
+                url: database_url,
+                tls_options,
+                secret_master_key: Some(secret_master_key),
+            },
         )
+        .with_production_trust_policy(Arc::new(trust_policy))
+        .with_runtime_policy(runtime_policy)
+        .with_runtime_process_binding(RebornRuntimeProcessBinding::none()))
     }
 
     pub fn with_required_runtime_backends(
@@ -684,6 +705,56 @@ fn required_production_key_env(
         });
     }
     Ok(SecretString::from(value))
+}
+
+#[cfg(feature = "postgres")]
+fn postgres_pool_tls_options_from_env() -> Result<PostgresPoolTlsOptions, RebornBuildError> {
+    let ssl_mode_override = match std::env::var(DATABASE_SSLMODE_ENV) {
+        Ok(value) if value.trim().is_empty() => None,
+        Ok(value) => Some(
+            value
+                .trim()
+                .parse::<RebornPostgresSslMode>()
+                .map_err(|error| RebornBuildError::InvalidConfig {
+                    reason: format!("{DATABASE_SSLMODE_ENV}: {error}"),
+                })?,
+        ),
+        Err(std::env::VarError::NotPresent) => None,
+        Err(std::env::VarError::NotUnicode(_)) => {
+            return Err(RebornBuildError::InvalidConfig {
+                reason: format!("{DATABASE_SSLMODE_ENV} must be valid UTF-8"),
+            });
+        }
+    };
+    let allow_remote_cleartext = match std::env::var(ALLOW_REMOTE_POSTGRES_CLEAR_TEXT_ENV) {
+        Ok(value) => parse_cleartext_opt_in(&value).ok_or_else(|| {
+            RebornBuildError::InvalidConfig {
+                reason: format!(
+                    "{ALLOW_REMOTE_POSTGRES_CLEAR_TEXT_ENV} must be one of true, false, 1, 0, yes, no, on, or off"
+                ),
+            }
+        })?,
+        Err(std::env::VarError::NotPresent) => false,
+        Err(std::env::VarError::NotUnicode(_)) => {
+            return Err(RebornBuildError::InvalidConfig {
+                reason: format!("{ALLOW_REMOTE_POSTGRES_CLEAR_TEXT_ENV} must be valid UTF-8"),
+            });
+        }
+    };
+
+    Ok(PostgresPoolTlsOptions {
+        ssl_mode_override,
+        allow_remote_cleartext,
+    })
+}
+
+#[cfg(feature = "postgres")]
+fn parse_cleartext_opt_in(value: &str) -> Option<bool> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "" | "0" | "false" | "no" | "off" => Some(false),
+        "1" | "true" | "yes" | "on" => Some(true),
+        _ => None,
+    }
 }
 
 #[cfg(test)]

--- a/crates/ironclaw_reborn_composition/tests/postgres_substrate.rs
+++ b/crates/ironclaw_reborn_composition/tests/postgres_substrate.rs
@@ -64,6 +64,7 @@ async fn postgres_substrate_builder_wires_production_components_without_local_on
             pool,
             event_store: RebornEventStoreConfig::Postgres {
                 url: SecretString::from(database_url),
+                tls_options: Default::default(),
             },
             secret_master_key: Some(SecretString::from("01234567890123456789012345678901")),
             trust_policy: Arc::new(ironclaw_trust::HostTrustPolicy::fail_closed()),
@@ -97,6 +98,7 @@ async fn postgres_substrate_builder_rejects_invalid_secret_master_key() {
             pool,
             event_store: RebornEventStoreConfig::Postgres {
                 url: SecretString::from(database_url),
+                tls_options: Default::default(),
             },
             secret_master_key: Some(SecretString::from("too-short")),
             trust_policy: Arc::new(ironclaw_trust::HostTrustPolicy::fail_closed()),
@@ -134,6 +136,7 @@ async fn postgres_substrate_builder_rejects_weak_env_secret_master_key() {
             pool,
             event_store: RebornEventStoreConfig::Postgres {
                 url: SecretString::from(database_url),
+                tls_options: Default::default(),
             },
             secret_master_key: None,
             trust_policy: Arc::new(ironclaw_trust::HostTrustPolicy::fail_closed()),

--- a/crates/ironclaw_reborn_event_store/src/lib.rs
+++ b/crates/ironclaw_reborn_event_store/src/lib.rs
@@ -54,13 +54,41 @@ pub use filesystem_store::{FilesystemDurableAuditLog, FilesystemDurableEventLog}
 #[cfg(feature = "postgres")]
 pub const DEFAULT_POSTGRES_POOL_MAX_SIZE: usize = 16;
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct PostgresPoolTlsOptions {
+    pub ssl_mode_override: Option<RebornPostgresSslMode>,
+    pub allow_remote_cleartext: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RebornPostgresSslMode {
+    Disable,
+    Prefer,
+    Require,
+}
+
+impl std::str::FromStr for RebornPostgresSslMode {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.to_ascii_lowercase().as_str() {
+            "disable" => Ok(Self::Disable),
+            "allow" | "prefer" => Ok(Self::Prefer),
+            "require" | "verify-ca" | "verify-full" => Ok(Self::Require),
+            _ => Err(format!(
+                "invalid Postgres ssl mode '{value}', expected 'disable', 'allow', 'prefer', 'require', 'verify-ca', or 'verify-full'"
+            )),
+        }
+    }
+}
+
 /// Open a PostgreSQL pool using the same TLS policy as the production event
 /// store backend.
 #[cfg(feature = "postgres")]
 pub fn open_postgres_pool(
     url: SecretString,
 ) -> Result<deadpool_postgres::Pool, RebornEventStoreError> {
-    postgres_backed::build_pool(url, DEFAULT_POSTGRES_POOL_MAX_SIZE)
+    postgres_backed::build_pool(url, DEFAULT_POSTGRES_POOL_MAX_SIZE, Default::default())
 }
 
 /// Open a PostgreSQL pool with an explicit maximum connection count.
@@ -69,7 +97,17 @@ pub fn open_postgres_pool_with_max_size(
     url: SecretString,
     max_size: usize,
 ) -> Result<deadpool_postgres::Pool, RebornEventStoreError> {
-    postgres_backed::build_pool(url, max_size)
+    postgres_backed::build_pool(url, max_size, Default::default())
+}
+
+/// Open a PostgreSQL pool with explicit TLS options.
+#[cfg(feature = "postgres")]
+pub fn open_postgres_pool_with_tls_options(
+    url: SecretString,
+    max_size: usize,
+    tls_options: PostgresPoolTlsOptions,
+) -> Result<deadpool_postgres::Pool, RebornEventStoreError> {
+    postgres_backed::build_pool(url, max_size, tls_options)
 }
 
 /// Backend configuration for Reborn durable event/audit stores.
@@ -96,7 +134,10 @@ pub enum RebornEventStoreConfig {
     /// [`PostgresRootFilesystem`](ironclaw_filesystem::PostgresRootFilesystem)
     /// over the provided URL and runs durable-log ops through the unified
     /// filesystem dispatch fabric.
-    Postgres { url: SecretString },
+    Postgres {
+        url: SecretString,
+        tls_options: PostgresPoolTlsOptions,
+    },
     /// libSQL backend configuration. The store opens a
     /// [`LibSqlRootFilesystem`](ironclaw_filesystem::LibSqlRootFilesystem)
     /// over the provided local path or remote URL and runs durable-log ops
@@ -136,7 +177,7 @@ pub enum RebornEventStoreError {
     )]
     ProductionLibsqlAmbiguousTarget,
     #[error(
-        "remote Reborn Postgres event store requires sslmode=require (sslmode=disable rejected)"
+        "remote Reborn Postgres event store requires sslmode=require unless remote cleartext is explicitly allowed (sslmode=disable rejected)"
     )]
     RemotePostgresClearTextDisabled,
     #[error("Reborn Postgres pool max_size must be greater than 0")]
@@ -198,13 +239,14 @@ pub async fn build_reborn_event_stores(
                 audit: Arc::new(JsonlDurableAuditLog::from_store(store)),
             })
         }
-        RebornEventStoreConfig::Postgres { url } => {
+        RebornEventStoreConfig::Postgres { url, tls_options } => {
             #[cfg(feature = "postgres")]
             {
-                postgres_backed::build(url).await
+                postgres_backed::build(url, tls_options).await
             }
             #[cfg(not(feature = "postgres"))]
             {
+                let _ = tls_options;
                 let _ = url;
                 Err(RebornEventStoreError::BackendUnavailable {
                     backend: "postgres",
@@ -496,12 +538,16 @@ mod postgres_backed {
     use tokio_postgres::{Config, NoTls};
     use tokio_postgres_rustls::MakeRustlsConnect;
 
-    use super::{RebornEventStoreError, RebornEventStores, wrap_root_filesystem_as_event_stores};
+    use super::{
+        PostgresPoolTlsOptions, RebornEventStoreError, RebornEventStores, RebornPostgresSslMode,
+        wrap_root_filesystem_as_event_stores,
+    };
 
     pub(super) async fn build(
         url: SecretString,
+        tls_options: PostgresPoolTlsOptions,
     ) -> Result<RebornEventStores, RebornEventStoreError> {
-        let pool = build_pool(url, super::DEFAULT_POSTGRES_POOL_MAX_SIZE)?;
+        let pool = build_pool(url, super::DEFAULT_POSTGRES_POOL_MAX_SIZE, tls_options)?;
         let filesystem = Arc::new(PostgresRootFilesystem::new(pool));
         filesystem.run_migrations().await.map_err(|source| {
             RebornEventStoreError::backend("postgres", "run migrations", source)
@@ -512,6 +558,7 @@ mod postgres_backed {
     pub(super) fn build_pool(
         url: SecretString,
         max_size: usize,
+        tls_options: PostgresPoolTlsOptions,
     ) -> Result<Pool, RebornEventStoreError> {
         if max_size == 0 {
             return Err(RebornEventStoreError::InvalidPostgresPoolMaxSize);
@@ -520,12 +567,25 @@ mod postgres_backed {
         let mut pg_config: Config = raw_url.parse().map_err(|source| {
             RebornEventStoreError::backend("postgres", "parse connection string", source)
         })?;
+        if let Some(ssl_mode) = tls_options.ssl_mode_override {
+            pg_config.ssl_mode(ssl_mode.into());
+        }
         let manager_config = ManagerConfig {
             recycling_method: RecyclingMethod::Fast,
         };
         let local = is_local_postgres_config(&pg_config);
         let local_wants_tls = local && matches!(pg_config.get_ssl_mode(), SslMode::Require);
-        let manager = if local && !local_wants_tls {
+        let remote_cleartext = !local && matches!(pg_config.get_ssl_mode(), SslMode::Disable);
+        let manager = if remote_cleartext {
+            if !tls_options.allow_remote_cleartext {
+                return Err(RebornEventStoreError::RemotePostgresClearTextDisabled);
+            }
+            tracing::warn!(
+                target = "ironclaw::reborn::event_store::postgres",
+                "remote Reborn Postgres cleartext connection explicitly allowed; use only on a trusted private network"
+            );
+            Manager::from_config(pg_config, NoTls, manager_config)
+        } else if local && !local_wants_tls {
             // Local without an explicit `sslmode=require`: NoTls is acceptable
             // because the connection never leaves the host.
             Manager::from_config(pg_config, NoTls, manager_config)
@@ -621,6 +681,16 @@ mod postgres_backed {
         }
     }
 
+    impl From<RebornPostgresSslMode> for SslMode {
+        fn from(value: RebornPostgresSslMode) -> Self {
+            match value {
+                RebornPostgresSslMode::Disable => SslMode::Disable,
+                RebornPostgresSslMode::Prefer => SslMode::Prefer,
+                RebornPostgresSslMode::Require => SslMode::Require,
+            }
+        }
+    }
+
     /// Build a rustls TLS connector for remote Postgres connections.
     ///
     /// Mirrors `src/db/tls.rs`: prefer the platform's native certificate
@@ -655,8 +725,9 @@ mod postgres_backed {
 
     #[cfg(test)]
     mod tests {
-        use super::{Config, enforce_remote_ssl_mode, is_local_postgres_config};
-        use crate::RebornEventStoreError;
+        use super::{Config, build_pool, enforce_remote_ssl_mode, is_local_postgres_config};
+        use crate::{PostgresPoolTlsOptions, RebornEventStoreError, RebornPostgresSslMode};
+        use secrecy::SecretString;
         use tokio_postgres::config::SslMode;
 
         fn parse(url: &str) -> Config {
@@ -773,6 +844,51 @@ mod postgres_backed {
                 err,
                 RebornEventStoreError::RemotePostgresClearTextDisabled
             ));
+        }
+
+        #[test]
+        fn sslmode_aliases_parse_to_internal_modes() {
+            for value in ["allow", "prefer"] {
+                assert_eq!(
+                    value.parse::<RebornPostgresSslMode>().expect("parse"),
+                    RebornPostgresSslMode::Prefer,
+                    "{value} should map to the internal prefer mode"
+                );
+            }
+            for value in ["require", "verify-ca", "verify-full"] {
+                assert_eq!(
+                    value.parse::<RebornPostgresSslMode>().expect("parse"),
+                    RebornPostgresSslMode::Require,
+                    "{value} should map to the internal require mode"
+                );
+            }
+        }
+
+        #[test]
+        fn build_pool_rejects_remote_cleartext_without_explicit_opt_in() {
+            let err = build_pool(
+                SecretString::from("postgres://user@db.example.com/db?sslmode=disable".to_string()),
+                1,
+                PostgresPoolTlsOptions::default(),
+            )
+            .expect_err("remote cleartext must fail closed");
+            assert!(matches!(
+                err,
+                RebornEventStoreError::RemotePostgresClearTextDisabled
+            ));
+        }
+
+        #[test]
+        fn build_pool_allows_remote_cleartext_with_explicit_opt_in() {
+            build_pool(
+                SecretString::from("postgres://user@db.example.com/db?sslmode=disable".to_string()),
+                1,
+                PostgresPoolTlsOptions {
+                    ssl_mode_override: None,
+                    allow_remote_cleartext: true,
+                },
+            )
+            .expect("explicit remote cleartext opt-in should allow pool construction");
         }
 
         #[test]

--- a/crates/ironclaw_reborn_event_store/tests/durable_event_store_contract.rs
+++ b/crates/ironclaw_reborn_event_store/tests/durable_event_store_contract.rs
@@ -479,6 +479,7 @@ async fn postgres_replay_advances_next_cursor_past_trailing_filtered_records() {
         RebornProfile::Production,
         RebornEventStoreConfig::Postgres {
             url: SecretString::new(url.into_boxed_str()),
+            tls_options: Default::default(),
         },
     )
     .await
@@ -541,6 +542,7 @@ async fn postgres_runtime_and_audit_logs_survive_rebuild_with_filtered_cursor_se
         RebornProfile::Production,
         RebornEventStoreConfig::Postgres {
             url: SecretString::new(url.clone().into_boxed_str()),
+            tls_options: Default::default(),
         },
     )
     .await
@@ -589,6 +591,7 @@ async fn postgres_runtime_and_audit_logs_survive_rebuild_with_filtered_cursor_se
         RebornProfile::Production,
         RebornEventStoreConfig::Postgres {
             url: SecretString::new(url.into_boxed_str()),
+            tls_options: Default::default(),
         },
     )
     .await

--- a/crates/ironclaw_reborn_event_store/tests/profile_contract.rs
+++ b/crates/ironclaw_reborn_event_store/tests/profile_contract.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "postgres")]
+use ironclaw_reborn_event_store::PostgresPoolTlsOptions;
 use ironclaw_reborn_event_store::{
     RebornEventStoreConfig, RebornEventStoreError, RebornProfile, build_reborn_event_stores,
 };
@@ -84,6 +86,7 @@ async fn unavailable_postgres_backend_error_does_not_leak_secret_config() {
                     .to_string()
                     .into_boxed_str(),
             ),
+            tls_options: Default::default(),
         },
     )
     .await;
@@ -118,6 +121,7 @@ async fn production_postgres_rejects_remote_sslmode_disable_before_connecting() 
                     .to_string()
                     .into_boxed_str(),
             ),
+            tls_options: Default::default(),
         },
     )
     .await;
@@ -137,6 +141,41 @@ async fn production_postgres_rejects_remote_sslmode_disable_before_connecting() 
 
 #[cfg(feature = "postgres")]
 #[tokio::test]
+async fn production_postgres_event_store_honors_explicit_remote_cleartext_opt_in() {
+    let result = build_reborn_event_stores(
+        RebornProfile::Production,
+        RebornEventStoreConfig::Postgres {
+            url: SecretString::new(
+                "postgres://event_user:RAW_PASSWORD_SENTINEL_3162@example.invalid/events?sslmode=disable"
+                    .to_string()
+                    .into_boxed_str(),
+            ),
+            tls_options: PostgresPoolTlsOptions {
+                ssl_mode_override: None,
+                allow_remote_cleartext: true,
+            },
+        },
+    )
+    .await;
+
+    let error = result
+        .err()
+        .expect("invalid host should fail only after accepting the cleartext opt-in");
+    assert!(
+        !matches!(
+            error,
+            RebornEventStoreError::RemotePostgresClearTextDisabled
+        ),
+        "event-store factory must pass explicit TLS options into the Postgres backend"
+    );
+    let displayed = error.to_string();
+    assert!(!displayed.contains("RAW_PASSWORD_SENTINEL_3162"));
+    assert!(!displayed.contains("example.invalid"));
+    assert!(!displayed.contains("postgres://"));
+}
+
+#[cfg(feature = "postgres")]
+#[tokio::test]
 async fn postgres_connection_failure_does_not_fall_back_or_leak_secret_config() {
     let result = build_reborn_event_stores(
         RebornProfile::Production,
@@ -146,6 +185,7 @@ async fn postgres_connection_failure_does_not_fall_back_or_leak_secret_config() 
                     .to_string()
                     .into_boxed_str(),
             ),
+            tls_options: Default::default(),
         },
     )
     .await;

--- a/docker/reborn/config.production.toml
+++ b/docker/reborn/config.production.toml
@@ -23,6 +23,9 @@ regex_activation_enabled = true
 backend = "postgres"
 url_env = "IRONCLAW_REBORN_POSTGRES_URL"
 secret_master_key_env = "IRONCLAW_REBORN_SECRET_MASTER_KEY"
+# Remote Postgres defaults to TLS. For trusted private-network deployments
+# where the provider cannot complete TLS, set both DATABASE_SSLMODE=disable
+# and IRONCLAW_REBORN_ALLOW_REMOTE_POSTGRES_CLEAR_TEXT=true.
 
 [webui]
 env_token_var = "IRONCLAW_REBORN_WEBUI_TOKEN"


### PR DESCRIPTION
## Summary

- adds explicit Reborn Postgres TLS options so `DATABASE_SSLMODE=disable` can override the connection URL
- keeps remote cleartext disabled by default unless `IRONCLAW_REBORN_ALLOW_REMOTE_POSTGRES_CLEAR_TEXT=true` is also set
- rejects invalid cleartext opt-in values loudly instead of silently treating typos as disabled
- accepts libpq-compatible `DATABASE_SSLMODE` aliases: `allow`, `verify-ca`, and `verify-full`
- threads parsed TLS options into the Reborn event/audit store config so the second Postgres pool does not silently revert to default TLS behavior
- allows hosted production `secure_default` to boot without a process backend by not advertising/wiring `builtin.shell` unless a process backend is configured
- adds caller-level CLI coverage, event-store pool/factory policy tests, and production composition coverage for `secure_default` without a process port
- documents the Railway/private-network escape hatch in `docker/reborn/config.production.toml`

## Why

Railway deployments can fail during Postgres TLS handshakes. This keeps production fail-closed by default while allowing trusted private-network deployments to opt into cleartext intentionally.

After TLS is bypassed, Railway-style production also uses the `hosted_multi_tenant` + `secure_default` policy from `docker/reborn/config.production.toml`. That profile has no process backend, so production should not require a tenant sandbox or expose shell. The branch now keeps `builtin.shell` out of the advertised first-party capabilities for process-less production while preserving the existing fail-closed requirement for hosted profiles that do need a tenant sandbox.

## Validation

- `cargo fmt --check`
- `cargo test -p ironclaw_reborn_event_store --features postgres sslmode_aliases_parse_to_internal_modes -- --nocapture`
- `cargo test -p ironclaw_reborn_event_store --features postgres production_postgres_event_store_honors_explicit_remote_cleartext_opt_in -- --nocapture`
- `cargo test -p ironclaw_reborn_cli --features postgres build_runtime_input_production_accepts_verify_full_database_sslmode -- --nocapture`
- `cargo test -p ironclaw_reborn_event_store --features postgres build_pool_ -- --nocapture`
- `cargo test -p ironclaw_reborn_event_store --features postgres production_postgres_ -- --nocapture`
- `cargo test -p ironclaw_reborn_cli --features postgres build_runtime_input_production_ -- --nocapture`
- `cargo test -p ironclaw_reborn_event_store --no-default-features unavailable_postgres_backend_error_does_not_leak_secret_config -- --nocapture`
- `cargo test -p ironclaw_reborn_composition --features postgres postgres_substrate_builder_rejects_invalid_secret_master_key -- --nocapture` (Docker/testcontainers unavailable locally, test skipped live container path after compiling)
- `cargo test -p ironclaw_reborn_composition --features libsql production_libsql_secure_default_builds_without_process_port -- --nocapture`
- `cargo test -p ironclaw_reborn_composition --features libsql production_libsql_services_require_process_port_for_first_party_runtime -- --nocapture`
- `cargo test -p ironclaw_reborn_cli --features postgres build_runtime_input_production_constructs_postgres_services_input -- --nocapture`
- `cargo clippy -p ironclaw_reborn_event_store --features postgres --all-targets -- -D warnings`
- `cargo clippy -p ironclaw_reborn_event_store --no-default-features --all-targets -- -D warnings`
- `cargo clippy -p ironclaw_reborn_composition --features postgres --lib -- -D warnings`
- `cargo clippy -p ironclaw_reborn_cli --features postgres --all-targets -- -D warnings`

Note: `cargo clippy -p ironclaw_reborn_composition --features postgres --all-targets -- -D warnings` currently fails on pre-existing test-only warnings in `crates/ironclaw_reborn_composition/src/runtime.rs` unrelated to this PR (`unused import: RebornRuntimeProcessBinding`, `RecordingSandboxTransport is never constructed`).