### PR TITLE
Restore WebUI v2 always approval affordance

### DIFF
--- a/crates/ironclaw_approvals/src/lib.rs
+++ b/crates/ironclaw_approvals/src/lib.rs
@@ -21,6 +21,7 @@ pub use policy::{
     PersistentApprovalAction, PersistentApprovalPolicy, PersistentApprovalPolicyError,
     PersistentApprovalPolicyInput, PersistentApprovalPolicyKey, PersistentApprovalPolicyStore,
     PersistentApprovalScope, permission_mode_allows_persistent_approval,
+    persistent_approval_grant_issuer,
 };
 
 pub struct ApprovalResolver<'a, A, L>

--- a/crates/ironclaw_approvals/src/policy.rs
+++ b/crates/ironclaw_approvals/src/policy.rs
@@ -22,7 +22,7 @@ const POLICY_PATH_CACHE_MAX_ENTRIES: usize = 1024;
 const POLICY_CAS_RETRY_ATTEMPTS: usize = 3;
 
 pub fn permission_mode_allows_persistent_approval(permission: PermissionMode) -> bool {
-    matches!(permission, PermissionMode::Allow)
+    matches!(permission, PermissionMode::Allow | PermissionMode::Ask)
 }
 
 #[derive(Debug, Error)]

--- a/crates/ironclaw_approvals/src/policy.rs
+++ b/crates/ironclaw_approvals/src/policy.rs
@@ -33,11 +33,9 @@ pub fn permission_mode_allows_persistent_approval(permission: PermissionMode) ->
 }
 
 pub fn persistent_approval_grant_issuer() -> Principal {
-    Principal::System(
-        SystemServiceId::new(PERSISTENT_APPROVAL_GRANT_ISSUER)
-            // Safety: static lowercase ASCII literal satisfies SystemServiceId validation.
-            .expect("persistent approval grant issuer literal is valid"),
-    )
+    Principal::System(SystemServiceId::from_trusted(
+        PERSISTENT_APPROVAL_GRANT_ISSUER.to_string(),
+    ))
 }
 
 #[derive(Debug, Error)]

--- a/crates/ironclaw_approvals/src/policy.rs
+++ b/crates/ironclaw_approvals/src/policy.rs
@@ -11,8 +11,8 @@ use ironclaw_filesystem::{
 };
 use ironclaw_host_api::{
     Action, ApprovalRequestId, CapabilityGrant, CapabilityGrantId, CapabilityId, GrantConstraints,
-    HostApiError, PermissionMode, Principal, ProjectId, ResourceScope, ScopedPath, TenantId,
-    ThreadId, UserId, sha256_digest_token,
+    HostApiError, PermissionMode, Principal, ProjectId, ResourceScope, ScopedPath, SystemServiceId,
+    TenantId, ThreadId, UserId, sha256_digest_token,
 };
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -20,9 +20,24 @@ use thiserror::Error;
 const POLICY_PREFIX: &str = "/approvals/persistent";
 const POLICY_PATH_CACHE_MAX_ENTRIES: usize = 1024;
 const POLICY_CAS_RETRY_ATTEMPTS: usize = 3;
+const PERSISTENT_APPROVAL_GRANT_ISSUER: &str = "persistent-approval";
 
+/// Returns whether an extension manifest permission mode may be upgraded by an
+/// explicit "always allow" user decision.
+///
+/// `Ask` is eligible because it is the prompting posture for user-mediated
+/// approval. Extension authors that require mandatory per-invocation consent
+/// must use a separate gate that does not offer persistent approval.
 pub fn permission_mode_allows_persistent_approval(permission: PermissionMode) -> bool {
     matches!(permission, PermissionMode::Allow | PermissionMode::Ask)
+}
+
+pub fn persistent_approval_grant_issuer() -> Principal {
+    Principal::System(
+        SystemServiceId::new(PERSISTENT_APPROVAL_GRANT_ISSUER)
+            // Safety: static lowercase ASCII literal satisfies SystemServiceId validation.
+            .expect("persistent approval grant issuer literal is valid"),
+    )
 }
 
 #[derive(Debug, Error)]
@@ -158,7 +173,7 @@ impl PersistentApprovalPolicy {
             id: self.grant_id,
             capability: self.key.capability_id.clone(),
             grantee: self.key.grantee.clone(),
-            issued_by: self.approved_by.clone(),
+            issued_by: persistent_approval_grant_issuer(),
             constraints: self.constraints.clone(),
         })
     }
@@ -652,6 +667,19 @@ mod tests {
 
     use super::*;
 
+    #[test]
+    fn permission_modes_allowed_for_persistent_approval_are_explicit() {
+        assert!(permission_mode_allows_persistent_approval(
+            PermissionMode::Allow
+        ));
+        assert!(permission_mode_allows_persistent_approval(
+            PermissionMode::Ask
+        ));
+        assert!(!permission_mode_allows_persistent_approval(
+            PermissionMode::Deny
+        ));
+    }
+
     #[tokio::test]
     async fn in_memory_policy_revoke_removes_active_grant() {
         let store = InMemoryPersistentApprovalPolicyStore::new();
@@ -944,6 +972,21 @@ mod tests {
         assert_eq!(policy.grant_id, first_grant.id);
         assert_eq!(first_grant.id, second_grant.id);
         assert_eq!(first_grant.id, reloaded_grant.id);
+    }
+
+    #[tokio::test]
+    async fn active_grant_uses_persistent_approval_issuer_marker() {
+        let store = InMemoryPersistentApprovalPolicyStore::new();
+        let scope = scope(None, Some("thread-a"));
+
+        let policy = store.allow(input(scope)).await.expect("allow policy");
+        let grant = policy.active_grant().expect("active grant");
+
+        assert_eq!(
+            policy.approved_by,
+            Principal::User(UserId::new("alice").unwrap())
+        );
+        assert_eq!(grant.issued_by, persistent_approval_grant_issuer());
     }
 
     #[tokio::test]

--- a/crates/ironclaw_host_runtime/tests/host_runtime_persistent_approvals_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_persistent_approvals_contract.rs
@@ -349,7 +349,7 @@ async fn default_runtime_falls_back_when_persistent_policy_lookup_fails() {
 }
 
 #[tokio::test]
-async fn default_runtime_does_not_reuse_persistent_policy_for_manifest_ask() {
+async fn default_runtime_reuses_persistent_policy_for_manifest_ask() {
     let registry = Arc::new(registry_with_echo_capability_permission("ask"));
     let dispatcher = Arc::new(RecordingDispatcher::default());
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
@@ -403,13 +403,13 @@ async fn default_runtime_does_not_reuse_persistent_policy_for_manifest_ask() {
         .unwrap();
 
     match outcome {
-        ironclaw_host_runtime::RuntimeCapabilityOutcome::Failed(failure) => {
-            assert_eq!(failure.capability_id, capability_id());
-            assert_eq!(failure.kind, RuntimeFailureKind::Authorization);
+        ironclaw_host_runtime::RuntimeCapabilityOutcome::Completed(completed) => {
+            assert_eq!(completed.capability_id, capability_id());
+            assert_eq!(completed.output, json!({"ok": true}));
         }
-        other => panic!("expected authorization failure, got {:?}", other),
+        other => panic!("expected Completed outcome, got {:?}", other),
     }
-    assert!(!dispatcher.has_request());
+    assert!(dispatcher.has_request());
 }
 
 #[tokio::test]

--- a/crates/ironclaw_product_adapters/src/outbound.rs
+++ b/crates/ironclaw_product_adapters/src/outbound.rs
@@ -564,6 +564,8 @@ pub struct GatePromptView {
     pub gate_ref: String,
     pub headline: String,
     pub body: String,
+    #[serde(default)]
+    pub allow_always: bool,
 }
 
 /// Discriminator for the kind of auth challenge surfaced in an `AuthPromptView`.
@@ -653,6 +655,8 @@ pub enum ProductProjectionItem {
     Gate {
         gate_ref: String,
         headline: String,
+        #[serde(default)]
+        allow_always: bool,
     },
     SkillActivation {
         id: String,
@@ -698,7 +702,9 @@ impl ProductProjectionItem {
                 }
                 Ok(())
             }
-            Self::Gate { gate_ref, headline } => {
+            Self::Gate {
+                gate_ref, headline, ..
+            } => {
                 validate_bounded_text(
                     "projection_gate_ref",
                     gate_ref,
@@ -785,6 +791,8 @@ impl<'de> Deserialize<'de> for ProductProjectionItem {
             Gate {
                 gate_ref: String,
                 headline: String,
+                #[serde(default)]
+                allow_always: bool,
             },
             SkillActivation {
                 id: String,
@@ -826,7 +834,15 @@ impl<'de> Deserialize<'de> for ProductProjectionItem {
                     .map_err(serde::de::Error::custom)?,
                 failure_summary,
             },
-            Wire::Gate { gate_ref, headline } => ProductProjectionItem::Gate { gate_ref, headline },
+            Wire::Gate {
+                gate_ref,
+                headline,
+                allow_always,
+            } => ProductProjectionItem::Gate {
+                gate_ref,
+                headline,
+                allow_always,
+            },
             Wire::SkillActivation {
                 id,
                 run_id,

--- a/crates/ironclaw_product_adapters/src/outbound.rs
+++ b/crates/ironclaw_product_adapters/src/outbound.rs
@@ -1162,6 +1162,51 @@ mod tests {
     }
 
     #[test]
+    fn projection_state_round_trips_gate_item_with_allow_always() {
+        let state = ProductProjectionState::new(
+            "thread-1",
+            vec![ProductProjectionItem::Gate {
+                gate_ref: "gate:approval-test".to_string(),
+                headline: "Approval required".to_string(),
+                allow_always: true,
+            }],
+        )
+        .expect("valid gate projection");
+        let value = serde_json::to_value(&state).expect("serialize");
+
+        assert_eq!(value["items"][0]["gate"]["gate_ref"], "gate:approval-test");
+        assert_eq!(value["items"][0]["gate"]["headline"], "Approval required");
+        assert_eq!(value["items"][0]["gate"]["allow_always"], true);
+        let decoded: ProductProjectionState =
+            serde_json::from_value(value).expect("deserialize gate projection");
+        assert_eq!(decoded, state);
+    }
+
+    #[test]
+    fn projection_state_accepts_legacy_gate_item_without_allow_always() {
+        let json = serde_json::json!({
+            "thread_id": "thread-1",
+            "items": [{
+                "gate": {
+                    "gate_ref": "gate:approval-test",
+                    "headline": "Approval required"
+                }
+            }]
+        });
+
+        let decoded: ProductProjectionState =
+            serde_json::from_value(json).expect("deserialize legacy gate projection");
+        assert_eq!(
+            decoded.items,
+            vec![ProductProjectionItem::Gate {
+                gate_ref: "gate:approval-test".to_string(),
+                headline: "Approval required".to_string(),
+                allow_always: false,
+            }]
+        );
+    }
+
+    #[test]
     fn projection_state_round_trips_skill_activation_item() {
         let run_id = TurnRunId::new();
         let state = ProductProjectionState::new(

--- a/crates/ironclaw_product_workflow/src/approval_interaction/gate_ref.rs
+++ b/crates/ironclaw_product_workflow/src/approval_interaction/gate_ref.rs
@@ -51,3 +51,19 @@ pub(super) fn approval_reply_binding_ref(
     )
     .map_err(|_| approval_rejected(ApprovalInteractionRejectionKind::InvalidBindingRef))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_approval_gate_ref_accepts_only_typed_approval_prefix() {
+        let typed = approval_gate_ref(ApprovalRequestId::new()).expect("approval gate");
+        let generic = GateRef::new("gate:approve-slack").expect("generic gate");
+        let adjacent = GateRef::new("gate:approvalish-test").expect("adjacent gate");
+
+        assert!(is_approval_gate_ref(&typed));
+        assert!(!is_approval_gate_ref(&generic));
+        assert!(!is_approval_gate_ref(&adjacent));
+    }
+}

--- a/crates/ironclaw_reborn_composition/src/profile_approval_authorization.rs
+++ b/crates/ironclaw_reborn_composition/src/profile_approval_authorization.rs
@@ -1,9 +1,11 @@
 use std::{borrow::Cow, sync::Arc};
 
+use ironclaw_approvals::persistent_approval_grant_issuer;
 use ironclaw_authorization::{GrantAuthorizer, TrustAwareCapabilityDispatchAuthorizer};
 use ironclaw_host_api::{
-    Action, ApprovalRequest, ApprovalRequestId, CapabilityDescriptor, Decision, EffectKind,
-    ExecutionContext, Principal, ResourceEstimate, runtime_policy::ApprovalPolicy,
+    Action, ApprovalRequest, ApprovalRequestId, CapabilityDescriptor, CapabilityGrant, Decision,
+    EffectKind, ExecutionContext, Principal, ResourceEstimate, Timestamp,
+    runtime_policy::ApprovalPolicy,
 };
 use ironclaw_trust::TrustDecision;
 
@@ -163,12 +165,17 @@ fn has_matching_approval_grant(
 ) -> bool {
     let expected_grantee = Principal::Extension(context.extension_id.clone());
     let expected_user_approver = Principal::User(context.user_id.clone());
+    let persistent_approval_issuer = persistent_approval_grant_issuer();
+    let now = chrono::Utc::now();
     context.grants.grants.iter().any(|grant| {
+        let grant_unexpired = grant_is_unexpired(grant, &now);
         let one_shot_approval_grant = grant.constraints.max_invocations == Some(1)
             && (grant.issued_by == Principal::HostRuntime
-                || grant.issued_by == expected_user_approver);
+                || grant.issued_by == expected_user_approver)
+            && grant_unexpired;
         let persistent_approval_grant = grant.constraints.max_invocations.is_none()
-            && grant.issued_by == expected_user_approver;
+            && grant.issued_by == persistent_approval_issuer
+            && grant_unexpired;
         grant.capability == descriptor.id
             && (one_shot_approval_grant || persistent_approval_grant)
             && grant.grantee == expected_grantee
@@ -180,6 +187,14 @@ fn has_matching_approval_grant(
             && gate_policy
                 .effects_require_approval(approval_policy, &grant.constraints.allowed_effects)
     })
+}
+
+fn grant_is_unexpired(grant: &CapabilityGrant, now: &Timestamp) -> bool {
+    grant
+        .constraints
+        .expires_at
+        .as_ref()
+        .is_none_or(|expires_at| expires_at > now)
 }
 
 fn approval_request(
@@ -451,7 +466,46 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn user_issued_persistent_approval_grant_allows_reuse() {
+    async fn persistent_approval_grant_allows_reuse() {
+        let authorizer = test_authorizer(ApprovalPolicy::AskDestructive);
+
+        let shell_id = CapabilityId::new("builtin.shell").unwrap();
+        let descriptor = test_descriptor_with_id(shell_id.clone(), vec![EffectKind::SpawnProcess]);
+        let base_ctx = test_context(CapabilitySet { grants: vec![] });
+        let ctx = test_context(CapabilitySet {
+            grants: vec![CapabilityGrant {
+                id: CapabilityGrantId::new(),
+                capability: shell_id,
+                grantee: Principal::Extension(base_ctx.extension_id.clone()),
+                issued_by: persistent_approval_grant_issuer(),
+                constraints: GrantConstraints {
+                    allowed_effects: vec![EffectKind::SpawnProcess],
+                    mounts: MountView::default(),
+                    network: NetworkPolicy::default(),
+                    secrets: Vec::new(),
+                    resource_ceiling: None,
+                    expires_at: None,
+                    max_invocations: None,
+                },
+            }],
+        });
+        let decision = authorizer
+            .authorize_dispatch_with_trust(
+                &ctx,
+                &descriptor,
+                &ResourceEstimate::default(),
+                &test_trust_decision(),
+            )
+            .await;
+
+        assert!(
+            matches!(decision, Decision::Allow { .. }),
+            "persistent approval grant should satisfy the local-dev gate, got {decision:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn user_issued_persistent_like_grant_does_not_allow_reuse() {
         let authorizer = test_authorizer(ApprovalPolicy::AskDestructive);
 
         let shell_id = CapabilityId::new("builtin.shell").unwrap();
@@ -484,8 +538,102 @@ mod tests {
             .await;
 
         assert!(
-            matches!(decision, Decision::Allow { .. }),
-            "same-user persistent approval grant should satisfy the local-dev gate, got {decision:?}"
+            matches!(decision, Decision::RequireApproval { .. }),
+            "standing user grant must not impersonate persistent approval replay, got {decision:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn other_user_issued_persistent_like_grant_does_not_allow_reuse() {
+        let authorizer = test_authorizer(ApprovalPolicy::AskDestructive);
+
+        let shell_id = CapabilityId::new("builtin.shell").unwrap();
+        let descriptor = test_descriptor_with_id(shell_id.clone(), vec![EffectKind::SpawnProcess]);
+        let ctx = test_context(CapabilitySet {
+            grants: vec![CapabilityGrant {
+                id: CapabilityGrantId::new(),
+                capability: shell_id,
+                grantee: Principal::Extension(ExtensionId::new("builtin").unwrap()),
+                issued_by: Principal::User(ironclaw_host_api::UserId::new("other-user").unwrap()),
+                constraints: GrantConstraints {
+                    allowed_effects: vec![EffectKind::SpawnProcess],
+                    mounts: MountView::default(),
+                    network: NetworkPolicy::default(),
+                    secrets: Vec::new(),
+                    resource_ceiling: None,
+                    expires_at: None,
+                    max_invocations: None,
+                },
+            }],
+        });
+        let decision = authorizer
+            .authorize_dispatch_with_trust(
+                &ctx,
+                &descriptor,
+                &ResourceEstimate::default(),
+                &test_trust_decision(),
+            )
+            .await;
+
+        assert!(
+            matches!(decision, Decision::RequireApproval { .. }),
+            "different-user standing grant must not impersonate persistent approval replay, got {decision:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn expired_persistent_approval_grant_does_not_allow_reuse() {
+        let authorizer = test_authorizer(ApprovalPolicy::AskDestructive);
+
+        let shell_id = CapabilityId::new("builtin.shell").unwrap();
+        let descriptor = test_descriptor_with_id(shell_id.clone(), vec![EffectKind::SpawnProcess]);
+        let base_ctx = test_context(CapabilitySet { grants: vec![] });
+        let ctx = test_context(CapabilitySet {
+            grants: vec![
+                CapabilityGrant {
+                    id: CapabilityGrantId::new(),
+                    capability: shell_id.clone(),
+                    grantee: Principal::Extension(base_ctx.extension_id.clone()),
+                    issued_by: Principal::HostRuntime,
+                    constraints: GrantConstraints {
+                        allowed_effects: vec![EffectKind::SpawnProcess],
+                        mounts: MountView::default(),
+                        network: NetworkPolicy::default(),
+                        secrets: Vec::new(),
+                        resource_ceiling: None,
+                        expires_at: None,
+                        max_invocations: None,
+                    },
+                },
+                CapabilityGrant {
+                    id: CapabilityGrantId::new(),
+                    capability: shell_id,
+                    grantee: Principal::Extension(base_ctx.extension_id.clone()),
+                    issued_by: persistent_approval_grant_issuer(),
+                    constraints: GrantConstraints {
+                        allowed_effects: vec![EffectKind::SpawnProcess],
+                        mounts: MountView::default(),
+                        network: NetworkPolicy::default(),
+                        secrets: Vec::new(),
+                        resource_ceiling: None,
+                        expires_at: Some(chrono::Utc::now() - chrono::Duration::seconds(1)),
+                        max_invocations: None,
+                    },
+                },
+            ],
+        });
+        let decision = authorizer
+            .authorize_dispatch_with_trust(
+                &ctx,
+                &descriptor,
+                &ResourceEstimate::default(),
+                &test_trust_decision(),
+            )
+            .await;
+
+        assert!(
+            matches!(decision, Decision::RequireApproval { .. }),
+            "expired persistent approval grant must not satisfy the local-dev gate, got {decision:?}"
         );
     }
 

--- a/crates/ironclaw_reborn_composition/src/profile_approval_authorization.rs
+++ b/crates/ironclaw_reborn_composition/src/profile_approval_authorization.rs
@@ -114,7 +114,7 @@ fn require_approval_for_profile_policy(
     let gate_effects = approval_gate_effects(action_kind, descriptor);
     if let Decision::Allow { .. } = &decision
         && gate_policy.effects_require_approval(approval_policy, &gate_effects)
-        && !has_matching_one_shot_approval_grant(
+        && !has_matching_approval_grant(
             context,
             descriptor,
             &gate_effects,
@@ -154,7 +154,7 @@ fn approval_gate_effects(
     }
 }
 
-fn has_matching_one_shot_approval_grant(
+fn has_matching_approval_grant(
     context: &ExecutionContext,
     descriptor: &CapabilityDescriptor,
     gate_effects: &[EffectKind],
@@ -164,10 +164,13 @@ fn has_matching_one_shot_approval_grant(
     let expected_grantee = Principal::Extension(context.extension_id.clone());
     let expected_user_approver = Principal::User(context.user_id.clone());
     context.grants.grants.iter().any(|grant| {
-        grant.capability == descriptor.id
-            && grant.constraints.max_invocations == Some(1)
+        let one_shot_approval_grant = grant.constraints.max_invocations == Some(1)
             && (grant.issued_by == Principal::HostRuntime
-                || grant.issued_by == expected_user_approver)
+                || grant.issued_by == expected_user_approver);
+        let persistent_approval_grant = grant.constraints.max_invocations.is_none()
+            && grant.issued_by == expected_user_approver;
+        grant.capability == descriptor.id
+            && (one_shot_approval_grant || persistent_approval_grant)
             && grant.grantee == expected_grantee
             // Match against the spawn-elevated effect set so a one-shot lease
             // that does not cover SpawnProcess cannot satisfy a spawn gate.
@@ -444,6 +447,45 @@ mod tests {
         assert!(
             matches!(decision, Decision::Allow { .. }),
             "same-user one-shot approval lease should satisfy the local-dev gate, got {decision:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn user_issued_persistent_approval_grant_allows_reuse() {
+        let authorizer = test_authorizer(ApprovalPolicy::AskDestructive);
+
+        let shell_id = CapabilityId::new("builtin.shell").unwrap();
+        let descriptor = test_descriptor_with_id(shell_id.clone(), vec![EffectKind::SpawnProcess]);
+        let base_ctx = test_context(CapabilitySet { grants: vec![] });
+        let ctx = test_context(CapabilitySet {
+            grants: vec![CapabilityGrant {
+                id: CapabilityGrantId::new(),
+                capability: shell_id,
+                grantee: Principal::Extension(base_ctx.extension_id.clone()),
+                issued_by: Principal::User(base_ctx.user_id.clone()),
+                constraints: GrantConstraints {
+                    allowed_effects: vec![EffectKind::SpawnProcess],
+                    mounts: MountView::default(),
+                    network: NetworkPolicy::default(),
+                    secrets: Vec::new(),
+                    resource_ceiling: None,
+                    expires_at: None,
+                    max_invocations: None,
+                },
+            }],
+        });
+        let decision = authorizer
+            .authorize_dispatch_with_trust(
+                &ctx,
+                &descriptor,
+                &ResourceEstimate::default(),
+                &test_trust_decision(),
+            )
+            .await;
+
+        assert!(
+            matches!(decision, Decision::Allow { .. }),
+            "same-user persistent approval grant should satisfy the local-dev gate, got {decision:?}"
         );
     }
 

--- a/crates/ironclaw_reborn_composition/src/projection/tests/turn_stream.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/tests/turn_stream.rs
@@ -221,6 +221,76 @@ async fn webui_event_stream_projects_approval_gate_prompt() {
 }
 
 #[tokio::test]
+async fn webui_event_stream_does_not_offer_always_for_generic_approval_gate() {
+    let tenant_id = TenantId::new("webui-events-generic-approval-tenant").unwrap();
+    let user_id = UserId::new("webui-events-generic-approval-user").unwrap();
+    let agent_id = AgentId::new("webui-events-generic-approval-agent").unwrap();
+    let thread_id = ThreadId::new("webui-events-generic-approval-thread").unwrap();
+    let turn_run = TurnRunId::new();
+    let scope = TurnScope::new(
+        tenant_id.clone(),
+        Some(agent_id.clone()),
+        None,
+        thread_id.clone(),
+    );
+    let gate_ref = GateRef::new("gate:generic-approval").unwrap();
+    let event_log_dyn: Arc<dyn DurableEventLog> = Arc::new(InMemoryDurableEventLog::new());
+    let actor = TurnActor::new(user_id.clone());
+    let services = build_reborn_projection_services(
+        event_log_dyn,
+        ReplyTargetBindingRef::new("webui-events-generic-approval-reply").unwrap(),
+    )
+    .with_turn_events(
+        Arc::new(FakeTurnEventSource {
+            events: vec![TurnLifecycleEvent {
+                cursor: TurnEventCursor(1),
+                scope: scope.clone(),
+                occurred_at: Some(chrono::Utc::now()),
+                owner_user_id: Some(user_id.clone()),
+                run_id: turn_run,
+                status: TurnStatus::BlockedApproval,
+                kind: TurnEventKind::Blocked,
+                blocked_gate: Some(TurnBlockedGateMetadata {
+                    gate_ref: gate_ref.clone(),
+                    gate_kind: TurnBlockedGateKind::Approval,
+                    credential_requirements: Vec::new(),
+                }),
+                sanitized_reason: Some("generic approval required".to_string()),
+            }],
+        }),
+        Arc::new(FakeTurnCoordinator {
+            state: TurnRunState {
+                status: TurnStatus::BlockedApproval,
+                gate_ref: Some(gate_ref.clone()),
+                ..turn_run_state(&scope, &user_id, turn_run, TurnEventCursor(1))
+            },
+        }),
+    );
+
+    let events = services
+        .webui_event_stream()
+        .drain(ProjectionSubscriptionRequest {
+            actor,
+            scope,
+            after_cursor: None,
+        })
+        .await
+        .unwrap();
+
+    assert!(events.iter().any(|event| {
+        matches!(
+            event.payload(),
+            ProductOutboundPayload::GatePrompt(prompt)
+                if prompt.turn_run_id == turn_run
+                    && prompt.gate_ref == gate_ref.as_str()
+                    && prompt.headline == "Approval required"
+                    && prompt.body == "generic approval required"
+                    && !prompt.allow_always
+        )
+    }));
+}
+
+#[tokio::test]
 async fn webui_event_stream_projects_blocked_dependent_run_status() {
     let tenant_id = TenantId::new("webui-events-tenant").unwrap();
     let user_id = UserId::new("webui-events-user").unwrap();

--- a/crates/ironclaw_reborn_composition/src/projection/tests/turn_stream.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/tests/turn_stream.rs
@@ -151,7 +151,7 @@ async fn webui_event_stream_resumes_mixed_batch_without_skipping_turn_event() {
 }
 
 #[tokio::test]
-async fn webui_event_stream_projects_approval_gate_prompt() {
+async fn webui_event_stream_offers_always_for_typed_approval_gate() {
     let tenant_id = TenantId::new("webui-events-approval-tenant").unwrap();
     let user_id = UserId::new("webui-events-approval-user").unwrap();
     let agent_id = AgentId::new("webui-events-approval-agent").unwrap();

--- a/crates/ironclaw_reborn_composition/src/projection/tests/turn_stream.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/tests/turn_stream.rs
@@ -215,6 +215,7 @@ async fn webui_event_stream_projects_approval_gate_prompt() {
                     && prompt.gate_ref == gate_ref.as_str()
                     && prompt.headline == "Approval required"
                     && prompt.body == "capability requires approval"
+                    && prompt.allow_always
         )
     }));
 }

--- a/crates/ironclaw_reborn_composition/src/projection/turn_events.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/turn_events.rs
@@ -331,7 +331,6 @@ async fn blocked_prompt_payload(
     let Some(gate_ref) = state.gate_ref.as_ref() else {
         return Ok(None);
     };
-    let allow_persistent_approval = is_approval_gate_ref(gate_ref);
     let gate_ref_str = gate_ref.as_str().to_string();
     match event.status {
         TurnStatus::BlockedAuth => {
@@ -354,7 +353,7 @@ async fn blocked_prompt_payload(
             event,
             gate_ref_str,
             "Approval required",
-            allow_persistent_approval,
+            is_approval_gate_ref(gate_ref),
         ))),
         TurnStatus::BlockedResource => Ok(Some(gate_prompt(
             event,

--- a/crates/ironclaw_reborn_composition/src/projection/turn_events.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/turn_events.rs
@@ -9,6 +9,7 @@ use ironclaw_product_adapters::{
     GatePromptView, ProductAdapterError, ProductOutboundPayload, ProductProjectionItem,
     ProductProjectionState, ProductWorkflowRejectionKind, RedactedString,
 };
+use ironclaw_product_workflow::is_approval_gate_ref;
 use ironclaw_turns::{
     GetRunStateRequest, SanitizedFailure, TurnCoordinator, TurnError, TurnEventKind,
     TurnEventProjectionCursor, TurnEventProjectionError, TurnEventProjectionRequest,
@@ -330,6 +331,7 @@ async fn blocked_prompt_payload(
     let Some(gate_ref) = state.gate_ref.as_ref() else {
         return Ok(None);
     };
+    let allow_persistent_approval = is_approval_gate_ref(gate_ref);
     let gate_ref_str = gate_ref.as_str().to_string();
     match event.status {
         TurnStatus::BlockedAuth => {
@@ -352,7 +354,7 @@ async fn blocked_prompt_payload(
             event,
             gate_ref_str,
             "Approval required",
-            true,
+            allow_persistent_approval,
         ))),
         TurnStatus::BlockedResource => Ok(Some(gate_prompt(
             event,

--- a/crates/ironclaw_reborn_composition/src/projection/turn_events.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/turn_events.rs
@@ -348,13 +348,17 @@ async fn blocked_prompt_payload(
             .await?;
             Ok(Some(ProductOutboundPayload::AuthPrompt(view)))
         }
-        TurnStatus::BlockedApproval => {
-            Ok(Some(gate_prompt(event, gate_ref_str, "Approval required")))
-        }
+        TurnStatus::BlockedApproval => Ok(Some(gate_prompt(
+            event,
+            gate_ref_str,
+            "Approval required",
+            true,
+        ))),
         TurnStatus::BlockedResource => Ok(Some(gate_prompt(
             event,
             gate_ref_str,
             "Resource unavailable",
+            false,
         ))),
         // Non-blocked statuses: no prompt payload. Exhaustive match so a new
         // TurnStatus variant forces a compile error and an explicit decision.
@@ -373,6 +377,7 @@ fn gate_prompt(
     event: &TurnLifecycleEvent,
     gate_ref: String,
     headline: &'static str,
+    allow_always: bool,
 ) -> ProductOutboundPayload {
     ProductOutboundPayload::GatePrompt(GatePromptView {
         turn_run_id: event.run_id,
@@ -382,6 +387,7 @@ fn gate_prompt(
             .sanitized_reason
             .clone()
             .unwrap_or_else(|| "Resolve this gate to continue the run.".to_string()),
+        allow_always,
     })
 }
 

--- a/crates/ironclaw_reborn_composition/src/runtime/approval.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/approval.rs
@@ -369,7 +369,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn active_extension_capability_rejects_persistent_approval_when_manifest_asks() {
+    async fn active_extension_capability_allows_persistent_approval_when_manifest_asks() {
         let capability = CapabilityId::new("gmail.send_message").expect("capability id");
         let provider = ExtensionId::new("gmail").expect("provider id");
         let caller = ExtensionId::new("caller").expect("caller id");
@@ -399,10 +399,47 @@ mod tests {
             },
         );
 
+        terms_provider
+            .persistent_approval_allowed(&gate)
+            .await
+            .expect("active extension default ask should allow explicit persistent approval");
+    }
+
+    #[tokio::test]
+    async fn active_extension_capability_rejects_persistent_approval_when_manifest_denies() {
+        let capability = CapabilityId::new("gmail.send_message").expect("capability id");
+        let provider = ExtensionId::new("gmail").expect("provider id");
+        let caller = ExtensionId::new("caller").expect("caller id");
+        let source = LocalDevExtensionSurfaceSource::from_surface(
+            LocalDevExtensionSurface::from_active_capabilities(vec![ActiveExtensionCapability {
+                id: capability.clone(),
+                provider,
+                effects: vec![EffectKind::Network],
+                default_permission: PermissionMode::Deny,
+                runtime_credentials: Vec::new(),
+            }]),
+        );
+        let terms_provider = LocalDevApprovalLeaseTermsProvider::new(
+            Arc::new(local_dev_capability_policy().expect("policy parses")),
+            Arc::new(ExtensionRegistry::new()),
+            MountView::default(),
+            MountView::default(),
+            MountView::default(),
+            source,
+        );
+        let gate = approval_gate_record(
+            ApprovalRequestId::new(),
+            Principal::Extension(caller),
+            Action::Dispatch {
+                capability,
+                estimated_resources: ResourceEstimate::default(),
+            },
+        );
+
         let error = terms_provider
             .persistent_approval_allowed(&gate)
             .await
-            .expect_err("active extension default ask should reject persistent approval");
+            .expect_err("active extension default deny should reject persistent approval");
 
         assert!(matches!(
             error,

--- a/crates/ironclaw_reborn_composition/src/slack_delivery.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_delivery.rs
@@ -248,6 +248,7 @@ impl SlackFinalReplyDeliveryObserver {
                         headline: "Approval needed".to_string(),
                         body: "A step in the workflow requires your approval to resume."
                             .to_string(),
+                        allow_always: true,
                     }),
                 }
             }

--- a/crates/ironclaw_reborn_composition/src/slack_delivery.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_delivery.rs
@@ -30,12 +30,13 @@ use ironclaw_product_adapters::{
 use ironclaw_product_workflow::{
     ConversationBindingService, ProductOutboundDeliveryRequest, ProductOutboundTargetResolver,
     ProductWorkflowError, ResolveBindingRequest, ResolvedBinding,
-    VerifiedProductOutboundTargetMetadata, prepare_and_render_product_outbound,
+    VerifiedProductOutboundTargetMetadata, is_approval_gate_ref,
+    prepare_and_render_product_outbound,
 };
 use ironclaw_threads::{FinalizedAssistantMessageByRunRequest, SessionThreadService, ThreadScope};
 use ironclaw_turns::{
-    GetRunStateRequest, ReplyTargetBindingRef, TurnActor, TurnCoordinator, TurnRunId, TurnRunState,
-    TurnScope, TurnStatus,
+    GateRef, GetRunStateRequest, ReplyTargetBindingRef, TurnActor, TurnCoordinator, TurnRunId,
+    TurnRunState, TurnScope, TurnStatus,
 };
 use ironclaw_wasm_product_adapters::ImmediateAckWorkflowObserver;
 use serde::{Deserialize, Serialize};
@@ -242,14 +243,9 @@ impl SlackFinalReplyDeliveryObserver {
                 };
                 SlackActionableNotification {
                     event_kind: RunNotificationEventKind::ApprovalNeeded,
-                    payload: ProductOutboundPayload::GatePrompt(GatePromptView {
-                        turn_run_id: run_id,
-                        gate_ref: gate_ref.as_str().to_string(),
-                        headline: "Approval needed".to_string(),
-                        body: "A step in the workflow requires your approval to resume."
-                            .to_string(),
-                        allow_always: true,
-                    }),
+                    payload: ProductOutboundPayload::GatePrompt(slack_approval_gate_prompt_view(
+                        run_id, gate_ref,
+                    )),
                 }
             }
             TurnStatus::BlockedAuth => {
@@ -674,6 +670,16 @@ fn slack_run_notification_projection_id(
     format!("slack-run-notification:{suffix}:{run_id}")
 }
 
+fn slack_approval_gate_prompt_view(run_id: TurnRunId, gate_ref: &GateRef) -> GatePromptView {
+    GatePromptView {
+        turn_run_id: run_id,
+        gate_ref: gate_ref.as_str().to_string(),
+        headline: "Approval needed".to_string(),
+        body: "A step in the workflow requires your approval to resume.".to_string(),
+        allow_always: is_approval_gate_ref(gate_ref),
+    }
+}
+
 fn slack_auth_prompt_view(
     envelope: &ProductInboundEnvelope,
     mut view: ironclaw_product_adapters::AuthPromptView,
@@ -954,5 +960,29 @@ mod tests {
             &envelope(payload),
             &accepted_ack()
         ));
+    }
+
+    #[test]
+    fn slack_approval_prompt_offers_always_for_typed_approval_gate() {
+        let gate_ref = GateRef::new(format!(
+            "gate:approval-{}",
+            ironclaw_host_api::ApprovalRequestId::new()
+        ))
+        .expect("gate ref");
+
+        let prompt = slack_approval_gate_prompt_view(TurnRunId::new(), &gate_ref);
+
+        assert_eq!(prompt.gate_ref, gate_ref.as_str());
+        assert!(prompt.allow_always);
+    }
+
+    #[test]
+    fn slack_approval_prompt_does_not_offer_always_for_generic_gate() {
+        let gate_ref = GateRef::new("gate:approve-slack").expect("gate ref");
+
+        let prompt = slack_approval_gate_prompt_view(TurnRunId::new(), &gate_ref);
+
+        assert_eq!(prompt.gate_ref, gate_ref.as_str());
+        assert!(!prompt.allow_always);
     }
 }

--- a/crates/ironclaw_webui_v2/tests/webui_v2_schema_contract.rs
+++ b/crates/ironclaw_webui_v2/tests/webui_v2_schema_contract.rs
@@ -81,6 +81,7 @@ fn gate_prompt() -> GatePromptView {
         gate_ref: "gate:approval".to_string(),
         headline: "Approve action".to_string(),
         body: "Review the requested action.".to_string(),
+        allow_always: true,
     }
 }
 

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/gates.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/gates.js
@@ -13,6 +13,7 @@ export function gateFromEvent(eventType, prompt) {
       gateRef: prompt.gate_ref,
       headline: prompt.headline,
       body: prompt.body,
+      allowAlways: prompt.allow_always === true,
     };
   }
 

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/gates.test.mjs
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/gates.test.mjs
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import vm from "node:vm";
+
+function loadGates() {
+  const source = readFileSync(new URL("./gates.js", import.meta.url), "utf8")
+    .replace("export function gateFromEvent", "function gateFromEvent");
+  const context = { globalThis: {} };
+  vm.runInNewContext(
+    `${source}\nglobalThis.__testExports = { gateFromEvent };`,
+    context,
+  );
+  return context.globalThis.__testExports;
+}
+
+function plain(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+test("gateFromEvent maps approval always-allow affordance", () => {
+  const { gateFromEvent } = loadGates();
+
+  assert.deepEqual(
+    plain(gateFromEvent("gate", {
+      turn_run_id: "run-1",
+      gate_ref: "gate:approval",
+      headline: "Approval required",
+      body: "Review the action.",
+      allow_always: true,
+    })),
+    {
+      kind: "gate",
+      runId: "run-1",
+      gateRef: "gate:approval",
+      headline: "Approval required",
+      body: "Review the action.",
+      allowAlways: true,
+    },
+  );
+});
+
+test("gateFromEvent defaults missing always-allow affordance to false", () => {
+  const { gateFromEvent } = loadGates();
+
+  assert.deepEqual(
+    plain(gateFromEvent("gate", {
+      turn_run_id: "run-1",
+      gate_ref: "gate:resource",
+      headline: "Resource unavailable",
+      body: "Try later.",
+    })),
+    {
+      kind: "gate",
+      runId: "run-1",
+      gateRef: "gate:resource",
+      headline: "Resource unavailable",
+      body: "Try later.",
+      allowAlways: false,
+    },
+  );
+});

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/useChatEvents.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/useChatEvents.js
@@ -407,8 +407,7 @@ function applyProjectionItems({
     }
 
     if (item.gate) {
-      // ProductProjectionItem::Gate { gate_ref, headline } — projection
-      // carries gate_ref but not run_id, so we correlate to the
+      // ProductProjectionItem::Gate carries gate_ref but not run_id, so we correlate to the
       // active run (snapshotted above). Without a run_id the
       // pendingGate is unusable (`resolveGate` would 400 at the path
       // construction in `api.js`), so skip emitting the gate entirely
@@ -421,6 +420,7 @@ function applyProjectionItems({
           gateRef: item.gate.gate_ref,
           headline: item.gate.headline,
           body: "",
+          allowAlways: item.gate.allow_always === true,
         });
         setIsProcessing(false);
       }

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/useChatEvents.test.mjs
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/useChatEvents.test.mjs
@@ -246,6 +246,7 @@ test("useChatEvents: cleared non-auth gates are not restored by later projection
     gateRef: "gate:resource",
     headline: "Resource unavailable",
     body: "",
+    allowAlways: false,
   });
 
   harness.handleEvent({
@@ -276,6 +277,38 @@ test("useChatEvents: cleared non-auth gates are not restored by later projection
   });
 
   assert.equal(harness.pendingGate, null);
+});
+
+test("useChatEvents: projection approval gate preserves always-allow affordance", () => {
+  const runId = "run-approval";
+  const harness = createUseChatEventsHarness();
+
+  harness.handleEvent({
+    type: "projection_update",
+    frame: {
+      state: {
+        items: [
+          { run_status: { run_id: runId, status: "blocked_approval" } },
+          {
+            gate: {
+              gate_ref: "gate:approval",
+              headline: "Approval required",
+              allow_always: true,
+            },
+          },
+        ],
+      },
+    },
+  });
+
+  assert.deepEqual(plain(harness.pendingGate), {
+    kind: "gate",
+    runId,
+    gateRef: "gate:approval",
+    headline: "Approval required",
+    body: "",
+    allowAlways: true,
+  });
 });
 
 test("useChatEvents: stale terminal run status does not clear newer run", () => {


### PR DESCRIPTION
## Summary
- add `allow_always` to WebUI v2 gate prompt/projection payloads and preserve it through live gate events and projection replay
- only advertise Always Allow for typed product-workflow approval gates; generic approval gates remain one-shot only
- allow persistent approval policies for manifest `Ask` capabilities while still rejecting `Deny`
- let profile approval replay accept same-user persistent approval grants, not only one-shot approval leases
- add targeted coverage for Ask-capability persistent approval eligibility, persistent grant reuse, and generic approval gate projection

## Validation
- `cargo fmt`
- `cargo fmt --check` earlier in this hotfix pass before the final review-comment commit
- `cargo clippy -p ironclaw_reborn_cli --features webui-v2-beta --bin ironclaw-reborn -- -D warnings`
- manual WebUI verification on local server: `Approve and always` wrote the persistent policy, later `builtin.http` and `builtin.write_file` calls replayed the persistent grant without a second approval gate

Note: no unit/integration test suite was run in this final pass; kept to fmt + lint per hotfix urgency.