### PR TITLE
fix(reborn): return terminal OpenAI response statuses

### DIFF
--- a/crates/ironclaw_reborn_composition/src/openai_compat_serve.rs
+++ b/crates/ironclaw_reborn_composition/src/openai_compat_serve.rs
@@ -15,7 +15,8 @@ use ironclaw_host_api::{
 };
 use ironclaw_product_adapters::{
     AdapterInstallationId, ProductAdapterId, ProductInboundAck, ProductOutboundEnvelope,
-    ProductWorkflow, ProjectionReadRequest, ProjectionStream,
+    ProductOutboundPayload, ProductProjectionItem, ProductProjectionState, ProductWorkflow,
+    ProjectionReadRequest, ProjectionStream, ProjectionSubscriptionRequest,
 };
 use ironclaw_product_workflow::{
     DefaultInboundTurnService, DefaultProductWorkflow, ProductActorUserResolutionRequest,
@@ -29,8 +30,8 @@ use ironclaw_reborn_openai_compat::{
     OpenAiChatCompletionProjectionRequest, OpenAiChatCompletionsWorkflow,
     OpenAiChatProjectionStreamRequest, OpenAiCompatErrorKind, OpenAiCompatHttpError,
     OpenAiCompatProjectionStreamer, OpenAiCompatRefStore, OpenAiCompatResourceBinding,
-    OpenAiCompatRouterState, OpenAiResponseObject, OpenAiResponseOutputItem,
-    OpenAiResponseOutputItemStatus, OpenAiResponseProjection,
+    OpenAiCompatRouterState, OpenAiResponseErrorObject, OpenAiResponseObject,
+    OpenAiResponseOutputItem, OpenAiResponseOutputItemStatus, OpenAiResponseProjection,
     OpenAiResponseProjectionStreamRequest, OpenAiResponseReadRequest, OpenAiResponseStatus,
     OpenAiResponseWaitRequest, OpenAiResponsesMessageRole, OpenAiResponsesProjectionReader,
     OpenAiResponsesWorkflow, openai_compat_router_with_state, openai_compat_routes,
@@ -43,6 +44,9 @@ use ironclaw_threads::{
 use crate::RebornBuildError;
 use crate::RebornRuntime;
 use crate::webui_serve::ProtectedRouteMount;
+
+#[cfg(test)]
+mod tests;
 
 const OPENAI_COMPAT_LEDGER_USER_ID: &str = "openai-compat";
 const OPENAI_COMPAT_LEDGER_ENGINE_ROOT: &str = "/engine";
@@ -121,11 +125,13 @@ pub async fn build_openai_compat_route_mount(
     let chat_projection_reader = Arc::new(OpenAiChatCompletionThreadProjectionReader::new(
         runtime.webui_thread_service(),
     ));
+    let projection_stream = runtime.webui_event_stream();
     let responses_projection_reader = Arc::new(OpenAiResponsesThreadProjectionReader::new(
         runtime.webui_thread_service(),
+        projection_stream.clone(),
     ));
     let projection_streamer = Arc::new(OpenAiCompatRuntimeProjectionStreamer::new(
-        runtime.webui_event_stream(),
+        projection_stream,
     ));
     let chat_workflow = Arc::new(
         OpenAiChatCompletionsWorkflow::new(
@@ -279,13 +285,18 @@ impl OpenAiChatCompletionProjectionReader for OpenAiChatCompletionThreadProjecti
 
 struct OpenAiResponsesThreadProjectionReader {
     thread_service: Arc<dyn SessionThreadService>,
+    projection_stream: Arc<dyn ProjectionStream>,
     poll_interval: Duration,
 }
 
 impl OpenAiResponsesThreadProjectionReader {
-    fn new(thread_service: Arc<dyn SessionThreadService>) -> Self {
+    fn new(
+        thread_service: Arc<dyn SessionThreadService>,
+        projection_stream: Arc<dyn ProjectionStream>,
+    ) -> Self {
         Self {
             thread_service,
+            projection_stream,
             poll_interval: OPENAI_COMPAT_PROJECTION_POLL_INTERVAL,
         }
     }
@@ -327,6 +338,25 @@ impl OpenAiResponsesThreadProjectionReader {
             }
         }
     }
+
+    async fn read_projected_response_status(
+        &self,
+        request: &ProjectionReadRequest,
+        submitted_run_id: &str,
+    ) -> Result<Option<OpenAiResponseStatus>, OpenAiCompatHttpError> {
+        let events = self
+            .projection_stream
+            .drain(ProjectionSubscriptionRequest {
+                actor: request.actor.clone(),
+                scope: request.scope.clone(),
+                after_cursor: request.after_cursor.clone(),
+            })
+            .await?;
+        Ok(response_status_from_projection_events(
+            &events,
+            submitted_run_id,
+        ))
+    }
 }
 
 #[async_trait]
@@ -354,6 +384,22 @@ impl OpenAiResponsesProjectionReader for OpenAiResponsesThreadProjectionReader {
                     Some(content),
                 )));
             }
+            if let Some(status) = self
+                .read_projected_response_status(&request.projection_read, &submitted_run_id)
+                .await?
+                && matches!(
+                    status,
+                    OpenAiResponseStatus::Failed | OpenAiResponseStatus::Cancelled
+                )
+            {
+                return Ok(OpenAiResponseProjection::new(response_object(
+                    request.public_id,
+                    request.mapping.created_at,
+                    request.requested_model,
+                    status,
+                    None,
+                )));
+            }
             tokio::time::sleep(self.poll_interval).await;
         }
     }
@@ -364,12 +410,18 @@ impl OpenAiResponsesProjectionReader for OpenAiResponsesThreadProjectionReader {
     ) -> Result<OpenAiResponseObject, OpenAiCompatHttpError> {
         let submitted_run_id = response_turn_run_ref_from_mapping(&request)?;
         let content = self
-            .read_finalized_response_message(&request.projection_read, submitted_run_id)
+            .read_finalized_response_message(&request.projection_read, submitted_run_id.clone())
             .await?;
-        let status = if content.is_some() {
-            OpenAiResponseStatus::Completed
+        let projected_status = if content.is_some() {
+            None
         } else {
-            OpenAiResponseStatus::InProgress
+            self.read_projected_response_status(&request.projection_read, &submitted_run_id)
+                .await?
+        };
+        let status = match (content.is_some(), projected_status) {
+            (true, _) => OpenAiResponseStatus::Completed,
+            (false, Some(status)) => status,
+            (false, None) => OpenAiResponseStatus::InProgress,
         };
         Ok(response_object(
             request.public_id,
@@ -399,6 +451,55 @@ fn response_turn_run_ref_from_mapping(
     Ok(turn_run_ref.as_str().to_string())
 }
 
+fn response_status_from_projection_events(
+    events: &[ProductOutboundEnvelope],
+    submitted_run_id: &str,
+) -> Option<OpenAiResponseStatus> {
+    events.iter().rev().find_map(|event| match event.payload() {
+        ProductOutboundPayload::ProjectionSnapshot { state }
+        | ProductOutboundPayload::ProjectionUpdate { state } => {
+            response_status_from_projection_state(state, submitted_run_id)
+        }
+        ProductOutboundPayload::FinalReply(_)
+        | ProductOutboundPayload::Progress(_)
+        | ProductOutboundPayload::CapabilityActivity(_)
+        | ProductOutboundPayload::CapabilityDisplayPreview(_)
+        | ProductOutboundPayload::GatePrompt(_)
+        | ProductOutboundPayload::AuthPrompt(_)
+        | ProductOutboundPayload::KeepAlive => None,
+    })
+}
+
+fn response_status_from_projection_state(
+    state: &ProductProjectionState,
+    submitted_run_id: &str,
+) -> Option<OpenAiResponseStatus> {
+    state.items.iter().rev().find_map(|item| match item {
+        ProductProjectionItem::RunStatus { run_id, status, .. }
+            if run_id.to_string() == submitted_run_id =>
+        {
+            response_status_from_projection_run_status(status)
+        }
+        ProductProjectionItem::Text { .. }
+        | ProductProjectionItem::Thinking { .. }
+        | ProductProjectionItem::CapabilityActivity(_)
+        | ProductProjectionItem::WorkSummary { .. }
+        | ProductProjectionItem::RunStatus { .. }
+        | ProductProjectionItem::Gate { .. }
+        | ProductProjectionItem::SkillActivation { .. } => None,
+    })
+}
+
+fn response_status_from_projection_run_status(status: &str) -> Option<OpenAiResponseStatus> {
+    match status {
+        "running" => Some(OpenAiResponseStatus::InProgress),
+        "completed" => Some(OpenAiResponseStatus::Completed),
+        "failed" | "killed" => Some(OpenAiResponseStatus::Failed),
+        "cancelled" => Some(OpenAiResponseStatus::Cancelled),
+        _ => None,
+    }
+}
+
 fn response_object(
     id: ironclaw_reborn_openai_compat::OpenAiResponseId,
     created_at: u64,
@@ -416,6 +517,13 @@ fn response_object(
             }]
         })
         .unwrap_or_default();
+    let error = if matches!(status, OpenAiResponseStatus::Failed) {
+        Some(OpenAiResponseErrorObject::from_kind(
+            OpenAiCompatErrorKind::Internal,
+        ))
+    } else {
+        None
+    };
     OpenAiResponseObject {
         id,
         object: "response".to_string(),
@@ -423,7 +531,7 @@ fn response_object(
         status,
         model,
         output,
-        error: None,
+        error,
         incomplete_details: None,
         usage: None,
     }

--- a/crates/ironclaw_reborn_composition/src/openai_compat_serve.rs
+++ b/crates/ironclaw_reborn_composition/src/openai_compat_serve.rs
@@ -16,7 +16,7 @@ use ironclaw_host_api::{
 use ironclaw_product_adapters::{
     AdapterInstallationId, ProductAdapterId, ProductInboundAck, ProductOutboundEnvelope,
     ProductOutboundPayload, ProductProjectionItem, ProductProjectionState, ProductWorkflow,
-    ProjectionReadRequest, ProjectionStream, ProjectionSubscriptionRequest,
+    ProjectionCursor, ProjectionReadRequest, ProjectionStream, ProjectionSubscriptionRequest,
 };
 use ironclaw_product_workflow::{
     DefaultInboundTurnService, DefaultProductWorkflow, ProductActorUserResolutionRequest,
@@ -343,19 +343,21 @@ impl OpenAiResponsesThreadProjectionReader {
         &self,
         request: &ProjectionReadRequest,
         submitted_run_id: &str,
-    ) -> Result<Option<OpenAiResponseStatus>, OpenAiCompatHttpError> {
+        after_cursor: Option<ProjectionCursor>,
+    ) -> Result<ProjectedResponseStatusRead, OpenAiCompatHttpError> {
         let events = self
             .projection_stream
             .drain(ProjectionSubscriptionRequest {
                 actor: request.actor.clone(),
                 scope: request.scope.clone(),
-                after_cursor: request.after_cursor.clone(),
+                after_cursor,
             })
             .await?;
-        Ok(response_status_from_projection_events(
-            &events,
-            submitted_run_id,
-        ))
+        let next_cursor = events.last().map(|event| event.projection_cursor().clone());
+        Ok(ProjectedResponseStatusRead {
+            status: response_status_from_projection_events(&events, submitted_run_id),
+            next_cursor,
+        })
     }
 }
 
@@ -371,6 +373,7 @@ impl OpenAiResponsesProjectionReader for OpenAiResponsesThreadProjectionReader {
             } => submitted_run_id.to_string(),
             _ => return Err(OpenAiCompatHttpError::internal()),
         };
+        let mut projection_after_cursor = request.projection_read.after_cursor.clone();
         loop {
             if let Some(content) = self
                 .read_finalized_response_message(&request.projection_read, submitted_run_id.clone())
@@ -384,9 +387,17 @@ impl OpenAiResponsesProjectionReader for OpenAiResponsesThreadProjectionReader {
                     Some(content),
                 )));
             }
-            if let Some(status) = self
-                .read_projected_response_status(&request.projection_read, &submitted_run_id)
-                .await?
+            let projected = self
+                .read_projected_response_status(
+                    &request.projection_read,
+                    &submitted_run_id,
+                    projection_after_cursor.clone(),
+                )
+                .await?;
+            if let Some(next_cursor) = projected.next_cursor {
+                projection_after_cursor = Some(next_cursor);
+            }
+            if let Some(status) = projected.status
                 && matches!(
                     status,
                     OpenAiResponseStatus::Failed | OpenAiResponseStatus::Cancelled
@@ -415,11 +426,19 @@ impl OpenAiResponsesProjectionReader for OpenAiResponsesThreadProjectionReader {
         let projected_status = if content.is_some() {
             None
         } else {
-            self.read_projected_response_status(&request.projection_read, &submitted_run_id)
-                .await?
+            self.read_projected_response_status(
+                &request.projection_read,
+                &submitted_run_id,
+                request.projection_read.after_cursor.clone(),
+            )
+            .await?
+            .status
         };
         let status = match (content.is_some(), projected_status) {
             (true, _) => OpenAiResponseStatus::Completed,
+            (false, Some(OpenAiResponseStatus::Completed | OpenAiResponseStatus::InProgress)) => {
+                OpenAiResponseStatus::InProgress
+            }
             (false, Some(status)) => status,
             (false, None) => OpenAiResponseStatus::InProgress,
         };
@@ -433,6 +452,11 @@ impl OpenAiResponsesProjectionReader for OpenAiResponsesThreadProjectionReader {
             content,
         ))
     }
+}
+
+struct ProjectedResponseStatusRead {
+    status: Option<OpenAiResponseStatus>,
+    next_cursor: Option<ProjectionCursor>,
 }
 
 fn response_turn_run_ref_from_mapping(

--- a/crates/ironclaw_reborn_composition/src/openai_compat_serve/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/openai_compat_serve/tests.rs
@@ -1,5 +1,8 @@
 use super::*;
 
+use std::collections::VecDeque;
+use std::sync::Mutex;
+
 use ironclaw_host_api::ThreadId;
 use ironclaw_product_adapters::{
     AdapterInstallationId, ExternalConversationRef, ProductAdapterError, ProductAdapterId,
@@ -112,6 +115,29 @@ async fn openai_responses_retrieve_keeps_finalized_message_completion() {
 }
 
 #[tokio::test]
+async fn openai_responses_retrieve_keeps_completed_projection_in_progress_until_message() {
+    let fixture = ResponseReaderFixture::new("completed-lag").await;
+    let run_id = TurnRunId::new();
+    let reader = OpenAiResponsesThreadProjectionReader::new(
+        fixture.threads.clone(),
+        Arc::new(StaticProjectionStream::new(vec![run_status_envelope(
+            fixture.thread_id.as_str(),
+            run_id,
+            "completed",
+        )])),
+    );
+
+    let response = reader
+        .read_response(fixture.read_request(run_id))
+        .await
+        .expect("read response");
+
+    assert_eq!(response.status, OpenAiResponseStatus::InProgress);
+    assert!(response.output.is_empty());
+    assert!(response.error.is_none());
+}
+
+#[tokio::test]
 async fn openai_responses_wait_returns_terminal_projection_status_without_message() {
     let fixture = ResponseReaderFixture::new("wait-failed").await;
     let run_id = TurnRunId::new();
@@ -132,6 +158,33 @@ async fn openai_responses_wait_returns_terminal_projection_status_without_messag
     assert_eq!(projection.response.status, OpenAiResponseStatus::Failed);
     assert!(projection.response.output.is_empty());
     assert!(projection.response.error.is_some());
+}
+
+#[tokio::test]
+async fn openai_responses_wait_advances_projection_cursor_between_polls() {
+    let fixture = ResponseReaderFixture::new("wait-cursor").await;
+    let run_id = TurnRunId::new();
+    let first = run_status_envelope(fixture.thread_id.as_str(), TurnRunId::new(), "running");
+    let first_cursor = first.projection_cursor().clone();
+    let stream = Arc::new(SequencedProjectionStream::new(vec![
+        vec![first],
+        vec![run_status_envelope(
+            fixture.thread_id.as_str(),
+            run_id,
+            "failed",
+        )],
+    ]));
+    let mut reader =
+        OpenAiResponsesThreadProjectionReader::new(fixture.threads.clone(), stream.clone());
+    reader.poll_interval = Duration::from_millis(1);
+
+    let projection = reader
+        .wait_for_response_completion(fixture.wait_request(run_id))
+        .await
+        .expect("wait response");
+
+    assert_eq!(projection.response.status, OpenAiResponseStatus::Failed);
+    assert_eq!(stream.after_cursors(), vec![None, Some(first_cursor)]);
 }
 
 struct ResponseReaderFixture {
@@ -290,6 +343,43 @@ impl ProjectionStream for StaticProjectionStream {
         _request: ProjectionSubscriptionRequest,
     ) -> Result<Vec<ProductOutboundEnvelope>, ProductAdapterError> {
         Ok(self.envelopes.clone())
+    }
+}
+
+struct SequencedProjectionStream {
+    batches: Mutex<VecDeque<Vec<ProductOutboundEnvelope>>>,
+    after_cursors: Mutex<Vec<Option<ProjectionCursor>>>,
+}
+
+impl SequencedProjectionStream {
+    fn new(batches: Vec<Vec<ProductOutboundEnvelope>>) -> Self {
+        Self {
+            batches: Mutex::new(batches.into()),
+            after_cursors: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn after_cursors(&self) -> Vec<Option<ProjectionCursor>> {
+        self.after_cursors.lock().expect("after cursor log").clone()
+    }
+}
+
+#[async_trait]
+impl ProjectionStream for SequencedProjectionStream {
+    async fn drain(
+        &self,
+        request: ProjectionSubscriptionRequest,
+    ) -> Result<Vec<ProductOutboundEnvelope>, ProductAdapterError> {
+        self.after_cursors
+            .lock()
+            .expect("after cursor log")
+            .push(request.after_cursor);
+        Ok(self
+            .batches
+            .lock()
+            .expect("projection batches")
+            .pop_front()
+            .unwrap_or_default())
     }
 }
 

--- a/crates/ironclaw_reborn_composition/src/openai_compat_serve/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/openai_compat_serve/tests.rs
@@ -1,0 +1,324 @@
+use super::*;
+
+use ironclaw_host_api::ThreadId;
+use ironclaw_product_adapters::{
+    AdapterInstallationId, ExternalConversationRef, ProductAdapterError, ProductAdapterId,
+    ProductOutboundTarget, ProjectionCursor,
+};
+use ironclaw_reborn_openai_compat::{
+    OpenAiCompatActorScope, OpenAiCompatInternalRefs, OpenAiCompatProductActionRef,
+    OpenAiCompatProjectionRef, OpenAiCompatPublicId, OpenAiCompatRequestFingerprint,
+    OpenAiCompatRouteSurface, OpenAiCompatTurnRunRef, OpenAiResponseId,
+};
+use ironclaw_threads::{
+    AppendAssistantDraftRequest, EnsureThreadRequest, InMemorySessionThreadService, MessageContent,
+};
+use ironclaw_turns::{ReplyTargetBindingRef, TurnActor, TurnRunId, TurnScope};
+
+#[tokio::test]
+async fn openai_responses_retrieve_returns_failed_projection_status() {
+    let fixture = ResponseReaderFixture::new("failed").await;
+    let run_id = TurnRunId::new();
+    let reader = OpenAiResponsesThreadProjectionReader::new(
+        fixture.threads.clone(),
+        Arc::new(StaticProjectionStream::new(vec![run_status_envelope(
+            fixture.thread_id.as_str(),
+            run_id,
+            "failed",
+        )])),
+    );
+
+    let response = reader
+        .read_response(fixture.read_request(run_id))
+        .await
+        .expect("read response");
+
+    assert_eq!(response.status, OpenAiResponseStatus::Failed);
+    assert!(response.output.is_empty());
+    assert!(response.error.is_some());
+}
+
+#[tokio::test]
+async fn openai_responses_retrieve_returns_cancelled_projection_status() {
+    let fixture = ResponseReaderFixture::new("cancelled").await;
+    let run_id = TurnRunId::new();
+    let reader = OpenAiResponsesThreadProjectionReader::new(
+        fixture.threads.clone(),
+        Arc::new(StaticProjectionStream::new(vec![run_status_envelope(
+            fixture.thread_id.as_str(),
+            run_id,
+            "cancelled",
+        )])),
+    );
+
+    let response = reader
+        .read_response(fixture.read_request(run_id))
+        .await
+        .expect("read response");
+
+    assert_eq!(response.status, OpenAiResponseStatus::Cancelled);
+    assert!(response.output.is_empty());
+    assert!(response.error.is_none());
+}
+
+#[tokio::test]
+async fn openai_responses_retrieve_ignores_other_run_statuses() {
+    let fixture = ResponseReaderFixture::new("other-run").await;
+    let requested_run_id = TurnRunId::new();
+    let reader = OpenAiResponsesThreadProjectionReader::new(
+        fixture.threads.clone(),
+        Arc::new(StaticProjectionStream::new(vec![run_status_envelope(
+            fixture.thread_id.as_str(),
+            TurnRunId::new(),
+            "failed",
+        )])),
+    );
+
+    let response = reader
+        .read_response(fixture.read_request(requested_run_id))
+        .await
+        .expect("read response");
+
+    assert_eq!(response.status, OpenAiResponseStatus::InProgress);
+    assert!(response.output.is_empty());
+    assert!(response.error.is_none());
+}
+
+#[tokio::test]
+async fn openai_responses_retrieve_keeps_finalized_message_completion() {
+    let fixture = ResponseReaderFixture::new("completed").await;
+    let run_id = TurnRunId::new();
+    fixture
+        .append_final_assistant_message(run_id, "done")
+        .await
+        .expect("append final message");
+    let reader = OpenAiResponsesThreadProjectionReader::new(
+        fixture.threads.clone(),
+        Arc::new(StaticProjectionStream::new(vec![run_status_envelope(
+            fixture.thread_id.as_str(),
+            run_id,
+            "running",
+        )])),
+    );
+
+    let response = reader
+        .read_response(fixture.read_request(run_id))
+        .await
+        .expect("read response");
+
+    assert_eq!(response.status, OpenAiResponseStatus::Completed);
+    assert_eq!(response.output.len(), 1);
+    assert!(response.error.is_none());
+}
+
+#[tokio::test]
+async fn openai_responses_wait_returns_terminal_projection_status_without_message() {
+    let fixture = ResponseReaderFixture::new("wait-failed").await;
+    let run_id = TurnRunId::new();
+    let reader = OpenAiResponsesThreadProjectionReader::new(
+        fixture.threads.clone(),
+        Arc::new(StaticProjectionStream::new(vec![run_status_envelope(
+            fixture.thread_id.as_str(),
+            run_id,
+            "failed",
+        )])),
+    );
+
+    let projection = reader
+        .wait_for_response_completion(fixture.wait_request(run_id))
+        .await
+        .expect("wait response");
+
+    assert_eq!(projection.response.status, OpenAiResponseStatus::Failed);
+    assert!(projection.response.output.is_empty());
+    assert!(projection.response.error.is_some());
+}
+
+struct ResponseReaderFixture {
+    threads: Arc<InMemorySessionThreadService>,
+    actor_scope: OpenAiCompatActorScope,
+    projection_read: ProjectionReadRequest,
+    thread_scope: ThreadScope,
+    thread_id: ThreadId,
+}
+
+impl ResponseReaderFixture {
+    async fn new(suffix: &str) -> Self {
+        let tenant_id = TenantId::new(format!("tenant-{suffix}")).expect("tenant");
+        let user_id = UserId::new(format!("user-{suffix}")).expect("user");
+        let agent_id = AgentId::new(format!("agent-{suffix}")).expect("agent");
+        let thread_id = ThreadId::new(format!("thread-{suffix}")).expect("thread");
+        let actor_scope = OpenAiCompatActorScope::new(
+            tenant_id.clone(),
+            user_id.clone(),
+            Some(agent_id.clone()),
+            None,
+        );
+        let projection_read = ProjectionReadRequest {
+            actor: TurnActor::new(user_id.clone()),
+            scope: TurnScope::new_with_owner(
+                tenant_id.clone(),
+                Some(agent_id.clone()),
+                None,
+                thread_id.clone(),
+                Some(user_id.clone()),
+            ),
+            after_cursor: None,
+            limit: None,
+        };
+        let thread_scope = ThreadScope {
+            tenant_id,
+            agent_id,
+            project_id: None,
+            owner_user_id: Some(user_id),
+            mission_id: None,
+        };
+        let threads = Arc::new(InMemorySessionThreadService::default());
+        threads
+            .ensure_thread(EnsureThreadRequest {
+                scope: thread_scope.clone(),
+                thread_id: Some(thread_id.clone()),
+                created_by_actor_id: "actor:test".to_string(),
+                title: None,
+                metadata_json: None,
+            })
+            .await
+            .expect("ensure thread");
+
+        Self {
+            threads,
+            actor_scope,
+            projection_read,
+            thread_scope,
+            thread_id,
+        }
+    }
+
+    fn read_request(&self, run_id: TurnRunId) -> OpenAiResponseReadRequest {
+        OpenAiResponseReadRequest {
+            public_id: OpenAiResponseId::new("resp_test").expect("response id"),
+            actor_scope: self.actor_scope.clone(),
+            requested_model: Some("reborn-test".to_string()),
+            projection_read: self.projection_read.clone(),
+            mapping: self.mapping(run_id),
+        }
+    }
+
+    fn wait_request(&self, run_id: TurnRunId) -> OpenAiResponseWaitRequest {
+        OpenAiResponseWaitRequest {
+            public_id: OpenAiResponseId::new("resp_test").expect("response id"),
+            actor_scope: self.actor_scope.clone(),
+            accepted_ack: ProductInboundAck::Accepted {
+                accepted_message_ref: ironclaw_turns::AcceptedMessageRef::new("accepted:test")
+                    .expect("accepted ref"),
+                submitted_run_id: run_id,
+            },
+            requested_model: "reborn-test".to_string(),
+            projection_read: self.projection_read.clone(),
+            mapping: self.mapping(run_id),
+        }
+    }
+
+    fn mapping(
+        &self,
+        run_id: TurnRunId,
+    ) -> ironclaw_reborn_openai_compat::OpenAiCompatResourceMapping {
+        ironclaw_reborn_openai_compat::OpenAiCompatResourceMapping {
+            public_id: OpenAiCompatPublicId::Response(
+                OpenAiResponseId::new("resp_test").expect("response id"),
+            ),
+            owner: self.actor_scope.clone(),
+            surface: OpenAiCompatRouteSurface::ResponsesApi,
+            request_fingerprint: OpenAiCompatRequestFingerprint::from_body_bytes(b"{}"),
+            created_at: 123,
+            idempotency_key: None,
+            accepted_ack: None,
+            binding: OpenAiCompatResourceBinding::Bound {
+                internal_refs: OpenAiCompatInternalRefs::new(
+                    OpenAiCompatProductActionRef::new("product-action:test").expect("action ref"),
+                )
+                .with_turn_run_ref(
+                    OpenAiCompatTurnRunRef::new(run_id.to_string()).expect("run ref"),
+                )
+                .with_projection_ref(
+                    OpenAiCompatProjectionRef::new("projection:test").expect("projection ref"),
+                ),
+            },
+        }
+    }
+
+    async fn append_final_assistant_message(
+        &self,
+        run_id: TurnRunId,
+        text: &str,
+    ) -> Result<(), SessionThreadError> {
+        let message = self
+            .threads
+            .append_assistant_draft(AppendAssistantDraftRequest {
+                scope: self.thread_scope.clone(),
+                thread_id: self.thread_id.clone(),
+                turn_run_id: run_id.to_string(),
+                content: MessageContent::text(text),
+            })
+            .await?;
+        self.threads
+            .finalize_assistant_message(
+                &self.thread_scope,
+                &self.thread_id,
+                message.message_id,
+                MessageContent::text(text),
+            )
+            .await?;
+        Ok(())
+    }
+}
+
+struct StaticProjectionStream {
+    envelopes: Vec<ProductOutboundEnvelope>,
+}
+
+impl StaticProjectionStream {
+    fn new(envelopes: Vec<ProductOutboundEnvelope>) -> Self {
+        Self { envelopes }
+    }
+}
+
+#[async_trait]
+impl ProjectionStream for StaticProjectionStream {
+    async fn drain(
+        &self,
+        _request: ProjectionSubscriptionRequest,
+    ) -> Result<Vec<ProductOutboundEnvelope>, ProductAdapterError> {
+        Ok(self.envelopes.clone())
+    }
+}
+
+fn run_status_envelope(
+    thread_id: &str,
+    run_id: TurnRunId,
+    status: &str,
+) -> ProductOutboundEnvelope {
+    ProductOutboundEnvelope::new(
+        ProductAdapterId::new(OPENAI_COMPAT_ADAPTER_ID).expect("adapter id"),
+        AdapterInstallationId::new(OPENAI_COMPAT_INSTALLATION_ID).expect("installation id"),
+        ProductOutboundTarget::new(
+            ReplyTargetBindingRef::new("reply:test").expect("reply target"),
+            ExternalConversationRef::new(None, "conversation:test", None, None)
+                .expect("conversation ref"),
+            None,
+        ),
+        ProjectionCursor::new(format!("cursor:{}", run_id.as_uuid())).expect("cursor"),
+        ProductOutboundPayload::ProjectionUpdate {
+            state: ProductProjectionState::new(
+                thread_id,
+                vec![ProductProjectionItem::RunStatus {
+                    run_id,
+                    status: status.to_string(),
+                    failure_category: None,
+                    failure_summary: None,
+                }],
+            )
+            .expect("projection state"),
+        },
+    )
+}


### PR DESCRIPTION
## Summary

- Return projection-backed `failed` and `cancelled` statuses from OpenAI-compatible Responses retrieve instead of falling back to `in_progress`.
- Reuse the existing authorized WebUI projection stream in the Reborn composition reader, keeping route/host boundaries unchanged.
- Keep finalized assistant messages authoritative for completed output, and terminate wait early only for failed/cancelled runs.
- Add composition-level regression tests for retrieve/wait status mapping and finalized-message completion.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Closes #4714

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [ ] `cargo build`
- [x] Relevant tests pass: `cargo test -p ironclaw_reborn_composition --features openai-compat-beta openai_responses --locked`
- [ ] `cargo test --features integration` if database-backed or integration behavior changed
- [ ] Manual testing: Not applicable; Reborn composition reader behavior is covered by contract-style unit tests.
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

Additional validation:
- `cargo clippy -p ironclaw_reborn_composition --features openai-compat-beta --all-targets -- -D warnings`
- `git diff --check`

## Security Impact

None. This reuses the existing authorized projection read request and WebUI projection stream inside Reborn composition. It does not add new routes, listeners, permissions, secrets access, network calls, file access, tool execution, or sandbox policy changes.

## Database Impact

None.

## Blast Radius

Limited to Reborn OpenAI-compatible Responses retrieve/wait projection shaping in `ironclaw_reborn_composition`. Streaming behavior is unchanged.

## Rollback Plan

Revert this PR to restore the previous finalized-message-only retrieve behavior.

## Review Follow-Through

Reviewer judgment requested on whether `wait_for_response_completion` should also terminate on cancelled runs as implemented here, rather than waiting forever for a finalized assistant message.

---

**Review track**: B