### PR TITLE
fix(reborn): model credential error summary

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,7 +55,7 @@ DATABASE_POOL_SIZE=30  # multi-tenant default; reduce to 5-10 for single-user or
 # the built-in defaults.
 # NEARAI_MODEL=deepseek-ai/DeepSeek-V4-Flash
 # NEARAI_BASE_URL=https://private.near.ai
-NEARAI_AUTH_URL=https://private.near.ai
+# NEARAI_AUTH_URL=https://private.near.ai
 # NEARAI_SESSION_TOKEN=sess_...                  # hosting providers: set this
 # NEARAI_SESSION_PATH=~/.ironclaw/session.json   # optional, default shown
 # NEARAI_API_KEY=...                             # API key from cloud.near.ai

--- a/crates/ironclaw_reborn/src/failure_categories.rs
+++ b/crates/ironclaw_reborn/src/failure_categories.rs
@@ -2,6 +2,10 @@
 /// Exposed for cross-crate consumers that project this category to a user-facing message.
 pub const MODEL_CREDITS_EXHAUSTED_CATEGORY: &str = "model_credits_exhausted";
 
+/// Failure category identifier for model provider credential or endpoint configuration failures.
+/// Exposed for cross-crate consumers that project this category to a user-facing message.
+pub const MODEL_CREDENTIALS_UNAVAILABLE_CATEGORY: &str = "model_credentials_unavailable";
+
 pub(crate) const MODEL_CREDITS_EXHAUSTED_REASON_KIND:
     ironclaw_turns::run_profile::AgentLoopHostErrorReasonKind =
     ironclaw_turns::run_profile::AgentLoopHostErrorReasonKind::ModelCreditsExhausted;

--- a/crates/ironclaw_reborn/src/lib.rs
+++ b/crates/ironclaw_reborn/src/lib.rs
@@ -25,6 +25,7 @@ pub mod local_trigger_access;
 pub mod loop_driver_host;
 pub mod loop_exit_applier;
 pub mod milestone_events;
+mod model_failure_mapping;
 pub mod model_routes;
 pub mod planned_driver;
 pub mod planned_driver_factory;

--- a/crates/ironclaw_reborn/src/model_failure_mapping.rs
+++ b/crates/ironclaw_reborn/src/model_failure_mapping.rs
@@ -1,0 +1,23 @@
+use ironclaw_turns::run_profile::{AgentLoopHostErrorKind, AgentLoopHostErrorReasonKind};
+
+use crate::failure_categories::{
+    MODEL_CREDENTIALS_UNAVAILABLE_CATEGORY, MODEL_CREDITS_EXHAUSTED_CATEGORY,
+    MODEL_CREDITS_EXHAUSTED_REASON_KIND,
+};
+
+pub(crate) fn model_stage_failure_category(
+    is_model_stage: bool,
+    kind: AgentLoopHostErrorKind,
+    reason_kind: Option<AgentLoopHostErrorReasonKind>,
+) -> Option<&'static str> {
+    if !is_model_stage {
+        return None;
+    }
+
+    if reason_kind == Some(MODEL_CREDITS_EXHAUSTED_REASON_KIND) {
+        return Some(MODEL_CREDITS_EXHAUSTED_CATEGORY);
+    }
+
+    (kind == AgentLoopHostErrorKind::CredentialUnavailable)
+        .then_some(MODEL_CREDENTIALS_UNAVAILABLE_CATEGORY)
+}

--- a/crates/ironclaw_reborn/src/planned_driver.rs
+++ b/crates/ironclaw_reborn/src/planned_driver.rs
@@ -21,12 +21,14 @@ use ironclaw_turns::{
     run_profile::{
         AgentLoopDriver, AgentLoopDriverDescriptor, AgentLoopDriverError, AgentLoopDriverHost,
         AgentLoopDriverResumeRequest, AgentLoopDriverRunRequest, AgentLoopHostError,
-        LoadCheckpointPayloadRequest, LoopCheckpointKind, LoopDriverId, LoopRunContext,
+        AgentLoopHostErrorKind, LoadCheckpointPayloadRequest, LoopCheckpointKind, LoopDriverId,
+        LoopRunContext,
     },
 };
 
 use crate::failure_categories::{
-    MODEL_CREDITS_EXHAUSTED_CATEGORY, MODEL_CREDITS_EXHAUSTED_REASON_KIND,
+    MODEL_CREDENTIALS_UNAVAILABLE_CATEGORY, MODEL_CREDITS_EXHAUSTED_CATEGORY,
+    MODEL_CREDITS_EXHAUSTED_REASON_KIND,
 };
 
 pub const PLANNED_DRIVER_DEFAULT_ID: &str = "reborn:planned-default";
@@ -252,6 +254,11 @@ pub(crate) fn map_executor_error(error: AgentLoopExecutorError) -> AgentLoopDriv
                     reason_kind: MODEL_CREDITS_EXHAUSTED_CATEGORY.to_string(),
                 };
             }
+            if stage == HostStage::Model && kind == AgentLoopHostErrorKind::CredentialUnavailable {
+                return AgentLoopDriverError::Failed {
+                    reason_kind: MODEL_CREDENTIALS_UNAVAILABLE_CATEGORY.to_string(),
+                };
+            }
             AgentLoopDriverError::Unavailable {
                 reason: format!("{}: {safe_summary}", host_stage_name(stage)),
             }
@@ -435,7 +442,7 @@ mod tests {
     }
 
     #[test]
-    fn executor_host_diagnostics_map_to_actionable_unavailable_reason() {
+    fn executor_model_credential_diagnostics_map_to_credentials_category() {
         let mapped = map_executor_error(AgentLoopExecutorError::HostUnavailableWithDiagnostics {
             stage: HostStage::Model,
             kind: AgentLoopHostErrorKind::CredentialUnavailable,
@@ -446,8 +453,8 @@ mod tests {
 
         assert_eq!(
             mapped,
-            AgentLoopDriverError::Unavailable {
-                reason: "Model: model credentials are unavailable".to_string()
+            AgentLoopDriverError::Failed {
+                reason_kind: MODEL_CREDENTIALS_UNAVAILABLE_CATEGORY.to_string()
             }
         );
     }

--- a/crates/ironclaw_reborn/src/planned_driver.rs
+++ b/crates/ironclaw_reborn/src/planned_driver.rs
@@ -21,15 +21,11 @@ use ironclaw_turns::{
     run_profile::{
         AgentLoopDriver, AgentLoopDriverDescriptor, AgentLoopDriverError, AgentLoopDriverHost,
         AgentLoopDriverResumeRequest, AgentLoopDriverRunRequest, AgentLoopHostError,
-        AgentLoopHostErrorKind, LoadCheckpointPayloadRequest, LoopCheckpointKind, LoopDriverId,
-        LoopRunContext,
+        LoadCheckpointPayloadRequest, LoopCheckpointKind, LoopDriverId, LoopRunContext,
     },
 };
 
-use crate::failure_categories::{
-    MODEL_CREDENTIALS_UNAVAILABLE_CATEGORY, MODEL_CREDITS_EXHAUSTED_CATEGORY,
-    MODEL_CREDITS_EXHAUSTED_REASON_KIND,
-};
+use crate::model_failure_mapping::model_stage_failure_category;
 
 pub const PLANNED_DRIVER_DEFAULT_ID: &str = "reborn:planned-default";
 const PLANNED_DRIVER_VERSION: u64 = 1;
@@ -248,15 +244,11 @@ pub(crate) fn map_executor_error(error: AgentLoopExecutorError) -> AgentLoopDriv
                 safe_summary = %safe_summary,
                 "planned driver host stage unavailable"
             );
-            if stage == HostStage::Model && reason_kind == Some(MODEL_CREDITS_EXHAUSTED_REASON_KIND)
+            if let Some(category) =
+                model_stage_failure_category(stage == HostStage::Model, kind, reason_kind)
             {
                 return AgentLoopDriverError::Failed {
-                    reason_kind: MODEL_CREDITS_EXHAUSTED_CATEGORY.to_string(),
-                };
-            }
-            if stage == HostStage::Model && kind == AgentLoopHostErrorKind::CredentialUnavailable {
-                return AgentLoopDriverError::Failed {
-                    reason_kind: MODEL_CREDENTIALS_UNAVAILABLE_CATEGORY.to_string(),
+                    reason_kind: category.to_string(),
                 };
             }
             AgentLoopDriverError::Unavailable {
@@ -336,6 +328,10 @@ fn resumable_checkpoint_kind_from_host(kind: LoopCheckpointKind) -> Result<Check
 mod tests {
     use super::*;
     use crate::app_loop_family::build_loop_family_registry;
+    use crate::failure_categories::{
+        MODEL_CREDENTIALS_UNAVAILABLE_CATEGORY, MODEL_CREDITS_EXHAUSTED_CATEGORY,
+        MODEL_CREDITS_EXHAUSTED_REASON_KIND,
+    };
     use ironclaw_agent_loop::test_support::{
         MockAgentLoopDriverHost, MockHostCall, test_run_context,
     };
@@ -493,6 +489,25 @@ mod tests {
             mapped,
             AgentLoopDriverError::Unavailable {
                 reason: format!("Prompt: {CREDIT_SUMMARY}")
+            }
+        );
+    }
+
+    #[test]
+    fn non_model_stage_with_credential_unavailable_maps_to_unavailable() {
+        const CREDENTIAL_SUMMARY: &str = "model credentials are unavailable";
+        let mapped = map_executor_error(AgentLoopExecutorError::HostUnavailableWithDiagnostics {
+            stage: HostStage::Prompt,
+            kind: AgentLoopHostErrorKind::CredentialUnavailable,
+            safe_summary: LoopSafeSummary::new(CREDENTIAL_SUMMARY).expect("safe"),
+            reason_kind: None,
+            diagnostic_ref: None,
+        });
+
+        assert_eq!(
+            mapped,
+            AgentLoopDriverError::Unavailable {
+                reason: format!("Prompt: {CREDENTIAL_SUMMARY}")
             }
         );
     }

--- a/crates/ironclaw_reborn/src/text_loop_driver.rs
+++ b/crates/ironclaw_reborn/src/text_loop_driver.rs
@@ -18,7 +18,8 @@ use ironclaw_turns::{
 };
 
 use crate::failure_categories::{
-    MODEL_CREDITS_EXHAUSTED_CATEGORY, MODEL_CREDITS_EXHAUSTED_REASON_KIND,
+    MODEL_CREDENTIALS_UNAVAILABLE_CATEGORY, MODEL_CREDITS_EXHAUSTED_CATEGORY,
+    MODEL_CREDITS_EXHAUSTED_REASON_KIND,
 };
 
 pub(crate) const TEXT_ONLY_DRIVER_ID: &str = "reborn:text-only-model-reply";
@@ -207,8 +208,15 @@ fn map_host_error(stage: &'static str, error: AgentLoopHostError) -> AgentLoopDr
         AgentLoopHostErrorKind::BudgetExceeded
         | AgentLoopHostErrorKind::BudgetApprovalRequired
         | AgentLoopHostErrorKind::BudgetAccountingFailed
-        | AgentLoopHostErrorKind::CredentialUnavailable
         | AgentLoopHostErrorKind::PolicyDenied => AgentLoopDriverError::Failed {
+            reason_kind: loop_failure_kind_name(LoopFailureKind::ModelError).to_string(),
+        },
+        AgentLoopHostErrorKind::CredentialUnavailable if stage == STAGE_MODEL => {
+            AgentLoopDriverError::Failed {
+                reason_kind: MODEL_CREDENTIALS_UNAVAILABLE_CATEGORY.to_string(),
+            }
+        }
+        AgentLoopHostErrorKind::CredentialUnavailable => AgentLoopDriverError::Failed {
             reason_kind: loop_failure_kind_name(LoopFailureKind::ModelError).to_string(),
         },
         AgentLoopHostErrorKind::CheckpointRejected => AgentLoopDriverError::Failed {
@@ -280,6 +288,24 @@ mod tests {
             mapped,
             AgentLoopDriverError::Failed {
                 reason_kind: MODEL_CREDITS_EXHAUSTED_CATEGORY.to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn model_credential_unavailable_maps_to_sanitized_failure_category() {
+        let mapped = map_host_error(
+            "model",
+            AgentLoopHostError::new(
+                AgentLoopHostErrorKind::CredentialUnavailable,
+                "model credentials are unavailable",
+            ),
+        );
+
+        assert_eq!(
+            mapped,
+            AgentLoopDriverError::Failed {
+                reason_kind: MODEL_CREDENTIALS_UNAVAILABLE_CATEGORY.to_string()
             }
         );
     }

--- a/crates/ironclaw_reborn/src/text_loop_driver.rs
+++ b/crates/ironclaw_reborn/src/text_loop_driver.rs
@@ -17,10 +17,7 @@ use ironclaw_turns::{
     },
 };
 
-use crate::failure_categories::{
-    MODEL_CREDENTIALS_UNAVAILABLE_CATEGORY, MODEL_CREDITS_EXHAUSTED_CATEGORY,
-    MODEL_CREDITS_EXHAUSTED_REASON_KIND,
-};
+use crate::model_failure_mapping::model_stage_failure_category;
 
 pub(crate) const TEXT_ONLY_DRIVER_ID: &str = "reborn:text-only-model-reply";
 /// Stage name for the model call site; matches the string used in `map_host_error` call sites.
@@ -182,9 +179,11 @@ fn map_host_error(stage: &'static str, error: AgentLoopHostError) -> AgentLoopDr
         "loop host port returned sanitized error"
     );
 
-    if stage == STAGE_MODEL && error.reason_kind == Some(MODEL_CREDITS_EXHAUSTED_REASON_KIND) {
+    if let Some(category) =
+        model_stage_failure_category(stage == STAGE_MODEL, error.kind, error.reason_kind)
+    {
         return AgentLoopDriverError::Failed {
-            reason_kind: MODEL_CREDITS_EXHAUSTED_CATEGORY.to_string(),
+            reason_kind: category.to_string(),
         };
     }
 
@@ -211,11 +210,6 @@ fn map_host_error(stage: &'static str, error: AgentLoopHostError) -> AgentLoopDr
         | AgentLoopHostErrorKind::PolicyDenied => AgentLoopDriverError::Failed {
             reason_kind: loop_failure_kind_name(LoopFailureKind::ModelError).to_string(),
         },
-        AgentLoopHostErrorKind::CredentialUnavailable if stage == STAGE_MODEL => {
-            AgentLoopDriverError::Failed {
-                reason_kind: MODEL_CREDENTIALS_UNAVAILABLE_CATEGORY.to_string(),
-            }
-        }
         AgentLoopHostErrorKind::CredentialUnavailable => AgentLoopDriverError::Failed {
             reason_kind: loop_failure_kind_name(LoopFailureKind::ModelError).to_string(),
         },
@@ -253,6 +247,10 @@ fn loop_failure_kind_name(kind: LoopFailureKind) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::failure_categories::{
+        MODEL_CREDENTIALS_UNAVAILABLE_CATEGORY, MODEL_CREDITS_EXHAUSTED_CATEGORY,
+        MODEL_CREDITS_EXHAUSTED_REASON_KIND,
+    };
 
     #[test]
     fn host_internal_errors_map_to_sanitized_unavailable() {
@@ -320,6 +318,24 @@ mod tests {
                 CREDIT_SUMMARY,
             )
             .with_reason_kind(MODEL_CREDITS_EXHAUSTED_REASON_KIND),
+        );
+
+        assert_eq!(
+            mapped,
+            AgentLoopDriverError::Failed {
+                reason_kind: loop_failure_kind_name(LoopFailureKind::ModelError).to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn non_model_stage_with_credential_unavailable_maps_to_model_error() {
+        let mapped = map_host_error(
+            "prompt",
+            AgentLoopHostError::new(
+                AgentLoopHostErrorKind::CredentialUnavailable,
+                "model credentials are unavailable",
+            ),
         );
 
         assert_eq!(

--- a/crates/ironclaw_reborn/src/turn_runner.rs
+++ b/crates/ironclaw_reborn/src/turn_runner.rs
@@ -36,7 +36,9 @@ use ironclaw_turns::{
 
 use crate::{
     driver_registry::{DriverRegistry, LoopDriverRegistryKey},
-    failure_categories::MODEL_CREDITS_EXHAUSTED_CATEGORY,
+    failure_categories::{
+        MODEL_CREDENTIALS_UNAVAILABLE_CATEGORY, MODEL_CREDITS_EXHAUSTED_CATEGORY,
+    },
     loop_exit_applier::LoopExitApplier,
 };
 
@@ -62,14 +64,17 @@ fn sanitized_failure(category: &'static str) -> Option<SanitizedFailure> {
 }
 
 fn sanitized_driver_failure(reason_kind: &str) -> Option<SanitizedFailure> {
-    if reason_kind == MODEL_CREDITS_EXHAUSTED_CATEGORY {
+    if matches!(
+        reason_kind,
+        MODEL_CREDITS_EXHAUSTED_CATEGORY | MODEL_CREDENTIALS_UNAVAILABLE_CATEGORY
+    ) {
         return match SanitizedFailure::new(reason_kind.to_string()) {
             Ok(failure) => Some(failure),
             Err(error) => {
                 debug!(
                     reason_kind,
                     %error,
-                    "model credit exhaustion failure category failed validation; using generic driver failure"
+                    "model failure category failed validation; using generic driver failure"
                 );
                 sanitized_failure("driver_failed")
             }

--- a/crates/ironclaw_reborn/src/turn_runner/tests/mod.rs
+++ b/crates/ironclaw_reborn/src/turn_runner/tests/mod.rs
@@ -1607,6 +1607,13 @@ fn sanitized_driver_failure_returns_credits_exhausted_for_known_category() {
 }
 
 #[test]
+fn sanitized_driver_failure_returns_model_credentials_for_known_category() {
+    let result = sanitized_driver_failure(MODEL_CREDENTIALS_UNAVAILABLE_CATEGORY);
+    let failure = result.expect("should return Some for model credentials category");
+    assert_eq!(failure.category(), MODEL_CREDENTIALS_UNAVAILABLE_CATEGORY);
+}
+
+#[test]
 fn sanitized_driver_failure_returns_driver_failed_for_unknown_category() {
     let result = sanitized_driver_failure("some_unknown_driver_category");
     let failure = result.expect("should return Some fallback for unknown category");

--- a/crates/ironclaw_reborn_composition/src/projection/tests/failure_explanation.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/tests/failure_explanation.rs
@@ -1,4 +1,5 @@
 use super::*;
+use ironclaw_reborn::failure_categories::MODEL_CREDENTIALS_UNAVAILABLE_CATEGORY;
 
 #[tokio::test]
 async fn webui_event_stream_projects_failed_run_failure_summary() {
@@ -166,6 +167,16 @@ async fn webui_event_stream_projects_model_credit_exhaustion_failure_summary() {
         }),
         _ => false,
     }));
+}
+
+#[tokio::test]
+async fn webui_event_stream_projects_model_credentials_failure_summary() {
+    assert_failed_run_status_summary(
+        "webui-events-model-credentials-thread",
+        MODEL_CREDENTIALS_UNAVAILABLE_CATEGORY,
+        "The run failed because model credentials or provider configuration are invalid. Check the selected provider's API key and base URL.",
+    )
+    .await;
 }
 
 #[tokio::test]

--- a/crates/ironclaw_reborn_composition/src/projection/tests/failure_explanation.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/tests/failure_explanation.rs
@@ -1,5 +1,7 @@
 use super::*;
-use ironclaw_reborn::failure_categories::MODEL_CREDENTIALS_UNAVAILABLE_CATEGORY;
+use ironclaw_reborn::failure_categories::{
+    MODEL_CREDENTIALS_UNAVAILABLE_CATEGORY, MODEL_CREDITS_EXHAUSTED_CATEGORY,
+};
 
 #[tokio::test]
 async fn webui_event_stream_projects_failed_run_failure_summary() {
@@ -36,6 +38,21 @@ async fn assert_failed_run_status_summary(
     failure_category: &str,
     expected_summary: &str,
 ) {
+    assert_failed_run_status_summary_with_explainer(
+        thread_id,
+        failure_category,
+        expected_summary,
+        None,
+    )
+    .await;
+}
+
+async fn assert_failed_run_status_summary_with_explainer(
+    thread_id: &str,
+    failure_category: &str,
+    expected_summary: &str,
+    failure_explainer: Option<Arc<dyn FailureExplanationProvider>>,
+) {
     let tenant_id = TenantId::new("webui-events-tenant").unwrap();
     let user_id = UserId::new("webui-events-user").unwrap();
     let agent_id = AgentId::new("webui-events-agent").unwrap();
@@ -71,6 +88,11 @@ async fn assert_failed_run_status_summary(
             state: turn_run_state(&scope, &user_id, turn_run, TurnEventCursor(1)),
         }),
     );
+    let services = if let Some(failure_explainer) = failure_explainer {
+        services.with_failure_explainer(failure_explainer)
+    } else {
+        services
+    };
 
     let events = services
         .webui_event_stream()
@@ -103,70 +125,12 @@ async fn assert_failed_run_status_summary(
 
 #[tokio::test]
 async fn webui_event_stream_projects_model_credit_exhaustion_failure_summary() {
-    let tenant_id = TenantId::new("webui-events-tenant").unwrap();
-    let user_id = UserId::new("webui-events-user").unwrap();
-    let agent_id = AgentId::new("webui-events-agent").unwrap();
-    let thread_id = ThreadId::new("webui-events-credit-failed-thread").unwrap();
-    let turn_run = TurnRunId::new();
-    let scope = TurnScope::new(
-        tenant_id.clone(),
-        Some(agent_id.clone()),
-        None,
-        thread_id.clone(),
-    );
-    let event_log_dyn: Arc<dyn DurableEventLog> = Arc::new(InMemoryDurableEventLog::new());
-    let actor = TurnActor::new(user_id.clone());
-    let services = build_reborn_projection_services(
-        event_log_dyn,
-        ReplyTargetBindingRef::new("webui-events-reply").unwrap(),
+    assert_failed_run_status_summary(
+        "webui-events-credit-failed-thread",
+        MODEL_CREDITS_EXHAUSTED_CATEGORY,
+        "The AI provider account is out of credits. Add credits or switch providers and try again.",
     )
-    .with_turn_events(
-        Arc::new(FakeTurnEventSource {
-            events: vec![TurnLifecycleEvent {
-                cursor: TurnEventCursor(1),
-                scope: scope.clone(),
-                occurred_at: Some(chrono::Utc::now()),
-                owner_user_id: Some(user_id.clone()),
-                run_id: turn_run,
-                status: TurnStatus::Failed,
-                kind: TurnEventKind::Failed,
-                blocked_gate: None,
-                sanitized_reason: Some("model_credits_exhausted".to_string()),
-            }],
-        }),
-        Arc::new(FakeTurnCoordinator {
-            state: turn_run_state(&scope, &user_id, turn_run, TurnEventCursor(1)),
-        }),
-    );
-
-    let events = services
-        .webui_event_stream()
-        .drain(ProjectionSubscriptionRequest {
-            actor,
-            scope,
-            after_cursor: None,
-        })
-        .await
-        .unwrap();
-
-    assert!(events.iter().any(|event| match event.payload() {
-        ProductOutboundPayload::ProjectionUpdate { state } => state.items.iter().any(|item| {
-            matches!(
-                item,
-                ProductProjectionItem::RunStatus {
-                    run_id,
-                    status,
-                    failure_category: Some(category),
-                    failure_summary: Some(summary),
-                } if *run_id == turn_run
-                    && status == "failed"
-                    && category.category() == "model_credits_exhausted"
-                    && summary
-                        == "The AI provider account is out of credits. Add credits or switch providers and try again."
-            )
-        }),
-        _ => false,
-    }));
+    .await;
 }
 
 #[tokio::test]
@@ -175,6 +139,19 @@ async fn webui_event_stream_projects_model_credentials_failure_summary() {
         "webui-events-model-credentials-thread",
         MODEL_CREDENTIALS_UNAVAILABLE_CATEGORY,
         "The run failed because model credentials or provider configuration are invalid. Check the selected provider's API key and base URL.",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn webui_event_stream_pins_model_credentials_summary_before_explainer() {
+    assert_failed_run_status_summary_with_explainer(
+        "webui-events-pinned-model-credentials-thread",
+        MODEL_CREDENTIALS_UNAVAILABLE_CATEGORY,
+        "The run failed because model credentials or provider configuration are invalid. Check the selected provider's API key and base URL.",
+        Some(Arc::new(FakeFailureExplainer {
+            explanation: "SENTINEL explainer output should not be used".to_string(),
+        })),
     )
     .await;
 }

--- a/crates/ironclaw_reborn_composition/src/projection/turn_events.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/turn_events.rs
@@ -509,11 +509,8 @@ async fn failure_summary_for_turn_event(
     category: &str,
     fallback_summary: String,
 ) -> String {
-    if matches!(
-        category,
-        MODEL_CREDITS_EXHAUSTED_CATEGORY | MODEL_CREDENTIALS_UNAVAILABLE_CATEGORY
-    ) {
-        return fallback_summary;
+    if let Some(summary) = pinned_failure_summary(category) {
+        return summary.to_string();
     }
     failure_explainer
         .explain_failure(FailureExplanationInput {
@@ -522,6 +519,18 @@ async fn failure_summary_for_turn_event(
         })
         .await
         .unwrap_or(fallback_summary)
+}
+
+fn pinned_failure_summary(category: &str) -> Option<&'static str> {
+    match category {
+        MODEL_CREDITS_EXHAUSTED_CATEGORY => Some(
+            "The AI provider account is out of credits. Add credits or switch providers and try again.",
+        ),
+        MODEL_CREDENTIALS_UNAVAILABLE_CATEGORY => Some(
+            "The run failed because model credentials or provider configuration are invalid. Check the selected provider's API key and base URL.",
+        ),
+        _ => None,
+    }
 }
 
 fn failure_category_for_turn_event(event: &TurnLifecycleEvent) -> Option<String> {
@@ -534,6 +543,10 @@ fn failure_category_for_turn_event(event: &TurnLifecycleEvent) -> Option<String>
 }
 
 fn failure_summary_for_category(category: &str) -> &'static str {
+    if let Some(summary) = pinned_failure_summary(category) {
+        return summary;
+    }
+
     match category {
         "driver_not_found" => {
             "The run failed because the configured execution driver was not available."
@@ -549,12 +562,6 @@ fn failure_summary_for_category(category: &str) -> &'static str {
         "host_creation_failed" => "The run failed while preparing the runtime host.",
         "route_snapshot_persistence_failed" => {
             "The run failed while saving the selected model route."
-        }
-        MODEL_CREDITS_EXHAUSTED_CATEGORY => {
-            "The AI provider account is out of credits. Add credits or switch providers and try again."
-        }
-        MODEL_CREDENTIALS_UNAVAILABLE_CATEGORY => {
-            "The run failed because model credentials or provider configuration are invalid. Check the selected provider's API key and base URL."
         }
         "heartbeat_failed" => "The run failed after the runner heartbeat could not be recorded.",
         "exit_application_failed" => "The run failed while recording its final result.",

--- a/crates/ironclaw_reborn_composition/src/projection/turn_events.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/turn_events.rs
@@ -23,7 +23,9 @@ use ironclaw_turns::{
 };
 use tokio::sync::{Mutex, OnceCell, Semaphore};
 
-use ironclaw_reborn::failure_categories::MODEL_CREDITS_EXHAUSTED_CATEGORY;
+use ironclaw_reborn::failure_categories::{
+    MODEL_CREDENTIALS_UNAVAILABLE_CATEGORY, MODEL_CREDITS_EXHAUSTED_CATEGORY,
+};
 
 use crate::AuthChallengeProvider;
 use crate::auth_prompt::auth_prompt_view_for_blocked_auth;
@@ -507,7 +509,10 @@ async fn failure_summary_for_turn_event(
     category: &str,
     fallback_summary: String,
 ) -> String {
-    if category == MODEL_CREDITS_EXHAUSTED_CATEGORY {
+    if matches!(
+        category,
+        MODEL_CREDITS_EXHAUSTED_CATEGORY | MODEL_CREDENTIALS_UNAVAILABLE_CATEGORY
+    ) {
         return fallback_summary;
     }
     failure_explainer
@@ -547,6 +552,9 @@ fn failure_summary_for_category(category: &str) -> &'static str {
         }
         MODEL_CREDITS_EXHAUSTED_CATEGORY => {
             "The AI provider account is out of credits. Add credits or switch providers and try again."
+        }
+        MODEL_CREDENTIALS_UNAVAILABLE_CATEGORY => {
+            "The run failed because model credentials or provider configuration are invalid. Check the selected provider's API key and base URL."
         }
         "heartbeat_failed" => "The run failed after the runner heartbeat could not be recorded.",
         "exit_application_failed" => "The run failed while recording its final result.",

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -3703,9 +3703,11 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "libsql")]
     #[derive(Debug)]
     struct RecordingSandboxTransport;
 
+    #[cfg(feature = "libsql")]
     #[async_trait]
     impl ironclaw_host_runtime::SandboxCommandTransport for RecordingSandboxTransport {
         async fn run_command(


### PR DESCRIPTION
Fixes #4683.

## Summary
- Preserve model credential/config failures as a dedicated Reborn failure category.
- Surface an actionable WebUI error instead of the generic driver-unavailable message.
- Make `.env.example` less likely to pair `NEARAI_API_KEY` with the private NEAR AI endpoint.

## Root Cause
NEAR AI credential/configuration failures were classified as `CredentialUnavailable` at the model/host boundary, but the planned-driver path collapsed that into `driver_unavailable` before WebUI projection. Users saw an execution-driver availability message even though the remediation was provider configuration.

## Validation
- `cargo fmt`
- `cargo test -p ironclaw_reborn model_credential`
- `cargo test -p ironclaw_reborn_composition webui_event_stream_projects_model_credentials_failure_summary`