### PR TITLE
[codex] Improve WebUI approval prompt context

### DIFF
--- a/crates/ironclaw_product_adapters/src/lib.rs
+++ b/crates/ironclaw_product_adapters/src/lib.rs
@@ -54,15 +54,17 @@ pub use inbound::{
     parse_product_slash_command,
 };
 pub use outbound::{
-    AuthPromptChallengeKind, AuthPromptView, CAPABILITY_DISPLAY_KIND_MAX_BYTES,
-    CAPABILITY_DISPLAY_PREVIEW_MAX_BYTES, CAPABILITY_DISPLAY_RESULT_REF_MAX_BYTES,
-    CAPABILITY_DISPLAY_SUMMARY_MAX_BYTES, CapabilityActivityStatusView, CapabilityActivityView,
-    CapabilityActivityViewInput, CapabilityDisplayPreviewView, CapabilityDisplayPreviewViewInput,
-    FinalReplyView, GatePromptView, PROJECTION_SKILL_ACTIVATION_MAX_ITEMS,
-    PROJECTION_SKILL_FEEDBACK_MAX_BYTES, PROJECTION_SKILL_NAME_MAX_BYTES, ProductOutboundEnvelope,
-    ProductOutboundPayload, ProductOutboundTarget, ProductProjectionItem, ProductProjectionState,
-    ProductRenderOutcome, ProductSynchronousResponse, ProductWorkSummaryPhase, ProgressKind,
-    ProgressUpdateView, ProjectionCursor,
+    ApprovalPromptActionView, ApprovalPromptContextView, ApprovalPromptDestinationView,
+    ApprovalPromptDetailView, ApprovalPromptScopeView, AuthPromptChallengeKind, AuthPromptView,
+    CAPABILITY_DISPLAY_KIND_MAX_BYTES, CAPABILITY_DISPLAY_PREVIEW_MAX_BYTES,
+    CAPABILITY_DISPLAY_RESULT_REF_MAX_BYTES, CAPABILITY_DISPLAY_SUMMARY_MAX_BYTES,
+    CapabilityActivityStatusView, CapabilityActivityView, CapabilityActivityViewInput,
+    CapabilityDisplayPreviewView, CapabilityDisplayPreviewViewInput, FinalReplyView,
+    GatePromptView, PROJECTION_SKILL_ACTIVATION_MAX_ITEMS, PROJECTION_SKILL_FEEDBACK_MAX_BYTES,
+    PROJECTION_SKILL_NAME_MAX_BYTES, ProductOutboundEnvelope, ProductOutboundPayload,
+    ProductOutboundTarget, ProductProjectionItem, ProductProjectionState, ProductRenderOutcome,
+    ProductSynchronousResponse, ProductWorkSummaryPhase, ProgressKind, ProgressUpdateView,
+    ProjectionCursor,
 };
 pub use projection::{
     ProductProjectionReadInput, ProductProjectionSubject, ProductProjectionSubscribeInput,

--- a/crates/ironclaw_product_adapters/src/outbound.rs
+++ b/crates/ironclaw_product_adapters/src/outbound.rs
@@ -30,6 +30,8 @@ pub const CAPABILITY_DISPLAY_SUMMARY_MAX_BYTES: usize = 2 * 1024;
 pub const CAPABILITY_DISPLAY_PREVIEW_MAX_BYTES: usize = 16 * 1024;
 pub const CAPABILITY_DISPLAY_KIND_MAX_BYTES: usize = 32;
 pub const CAPABILITY_DISPLAY_RESULT_REF_MAX_BYTES: usize = 256;
+const APPROVAL_PROMPT_TEXT_MAX_BYTES: usize = 2 * 1024;
+const APPROVAL_PROMPT_DETAIL_MAX_ITEMS: usize = 16;
 
 fn serialize_failure_category<S>(
     value: &Option<SanitizedFailure>,
@@ -570,7 +572,7 @@ pub struct GatePromptView {
     pub approval_context: Option<ApprovalPromptContextView>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct ApprovalPromptContextView {
     pub tool_name: String,
     pub action: ApprovalPromptActionView,
@@ -583,20 +585,175 @@ pub struct ApprovalPromptContextView {
     pub details: Vec<ApprovalPromptDetailView>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+impl ApprovalPromptContextView {
+    pub fn new(
+        tool_name: impl Into<String>,
+        action: ApprovalPromptActionView,
+        scope: ApprovalPromptScopeView,
+        reason: Option<String>,
+        destination: Option<ApprovalPromptDestinationView>,
+        details: Vec<ApprovalPromptDetailView>,
+    ) -> Result<Self, ProductAdapterError> {
+        let view = Self {
+            tool_name: tool_name.into(),
+            action,
+            scope,
+            reason,
+            destination,
+            details,
+        };
+        view.validate()?;
+        Ok(view)
+    }
+
+    fn validate(&self) -> Result<(), ProductAdapterError> {
+        validate_bounded_text(
+            "approval_prompt_tool_name",
+            &self.tool_name,
+            APPROVAL_PROMPT_TEXT_MAX_BYTES,
+        )?;
+        self.action.validate()?;
+        self.scope.validate()?;
+        validate_optional_display_text(
+            "approval_prompt_reason",
+            self.reason.as_deref(),
+            APPROVAL_PROMPT_TEXT_MAX_BYTES,
+        )?;
+        if let Some(destination) = &self.destination {
+            destination.validate()?;
+        }
+        if self.details.len() > APPROVAL_PROMPT_DETAIL_MAX_ITEMS {
+            return Err(invalid(
+                "approval_prompt_details",
+                format!("must contain at most {APPROVAL_PROMPT_DETAIL_MAX_ITEMS} items"),
+            ));
+        }
+        for detail in &self.details {
+            detail.validate()?;
+        }
+        Ok(())
+    }
+}
+
+impl<'de> Deserialize<'de> for ApprovalPromptContextView {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct Wire {
+            tool_name: String,
+            action: ApprovalPromptActionView,
+            scope: ApprovalPromptScopeView,
+            #[serde(default)]
+            reason: Option<String>,
+            #[serde(default)]
+            destination: Option<ApprovalPromptDestinationView>,
+            #[serde(default)]
+            details: Vec<ApprovalPromptDetailView>,
+        }
+
+        let wire = Wire::deserialize(deserializer)?;
+        ApprovalPromptContextView::new(
+            wire.tool_name,
+            wire.action,
+            wire.scope,
+            wire.reason,
+            wire.destination,
+            wire.details,
+        )
+        .map_err(serde::de::Error::custom)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct ApprovalPromptActionView {
     pub label: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub method: Option<NetworkMethod>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+impl ApprovalPromptActionView {
+    pub fn new(
+        label: impl Into<String>,
+        method: Option<NetworkMethod>,
+    ) -> Result<Self, ProductAdapterError> {
+        let view = Self {
+            label: label.into(),
+            method,
+        };
+        view.validate()?;
+        Ok(view)
+    }
+
+    fn validate(&self) -> Result<(), ProductAdapterError> {
+        validate_bounded_text(
+            "approval_prompt_action_label",
+            &self.label,
+            APPROVAL_PROMPT_TEXT_MAX_BYTES,
+        )
+    }
+}
+
+impl<'de> Deserialize<'de> for ApprovalPromptActionView {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct Wire {
+            label: String,
+            #[serde(default)]
+            method: Option<NetworkMethod>,
+        }
+
+        let wire = Wire::deserialize(deserializer)?;
+        ApprovalPromptActionView::new(wire.label, wire.method).map_err(serde::de::Error::custom)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct ApprovalPromptScopeView {
     pub label: String,
     pub reusable: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+impl ApprovalPromptScopeView {
+    pub fn new(label: impl Into<String>, reusable: bool) -> Result<Self, ProductAdapterError> {
+        let view = Self {
+            label: label.into(),
+            reusable,
+        };
+        view.validate()?;
+        Ok(view)
+    }
+
+    fn validate(&self) -> Result<(), ProductAdapterError> {
+        validate_bounded_text(
+            "approval_prompt_scope_label",
+            &self.label,
+            APPROVAL_PROMPT_TEXT_MAX_BYTES,
+        )
+    }
+}
+
+impl<'de> Deserialize<'de> for ApprovalPromptScopeView {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct Wire {
+            label: String,
+            reusable: bool,
+        }
+
+        let wire = Wire::deserialize(deserializer)?;
+        ApprovalPromptScopeView::new(wire.label, wire.reusable).map_err(serde::de::Error::custom)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct ApprovalPromptDestinationView {
     pub label: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -605,10 +762,107 @@ pub struct ApprovalPromptDestinationView {
     pub domain: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+impl ApprovalPromptDestinationView {
+    pub fn new(
+        label: impl Into<String>,
+        url: Option<String>,
+        domain: Option<String>,
+    ) -> Result<Self, ProductAdapterError> {
+        let view = Self {
+            label: label.into(),
+            url,
+            domain,
+        };
+        view.validate()?;
+        Ok(view)
+    }
+
+    fn validate(&self) -> Result<(), ProductAdapterError> {
+        validate_bounded_text(
+            "approval_prompt_destination_label",
+            &self.label,
+            APPROVAL_PROMPT_TEXT_MAX_BYTES,
+        )?;
+        validate_optional_display_text(
+            "approval_prompt_destination_url",
+            self.url.as_deref(),
+            APPROVAL_PROMPT_TEXT_MAX_BYTES,
+        )?;
+        validate_optional_display_text(
+            "approval_prompt_destination_domain",
+            self.domain.as_deref(),
+            APPROVAL_PROMPT_TEXT_MAX_BYTES,
+        )
+    }
+}
+
+impl<'de> Deserialize<'de> for ApprovalPromptDestinationView {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct Wire {
+            label: String,
+            #[serde(default)]
+            url: Option<String>,
+            #[serde(default)]
+            domain: Option<String>,
+        }
+
+        let wire = Wire::deserialize(deserializer)?;
+        ApprovalPromptDestinationView::new(wire.label, wire.url, wire.domain)
+            .map_err(serde::de::Error::custom)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct ApprovalPromptDetailView {
     pub label: String,
     pub value: String,
+}
+
+impl ApprovalPromptDetailView {
+    pub fn new(
+        label: impl Into<String>,
+        value: impl Into<String>,
+    ) -> Result<Self, ProductAdapterError> {
+        let view = Self {
+            label: label.into(),
+            value: value.into(),
+        };
+        view.validate()?;
+        Ok(view)
+    }
+
+    fn validate(&self) -> Result<(), ProductAdapterError> {
+        validate_bounded_text(
+            "approval_prompt_detail_label",
+            &self.label,
+            APPROVAL_PROMPT_TEXT_MAX_BYTES,
+        )?;
+        validate_bounded_text(
+            "approval_prompt_detail_value",
+            &self.value,
+            APPROVAL_PROMPT_TEXT_MAX_BYTES,
+        )
+    }
+}
+
+impl<'de> Deserialize<'de> for ApprovalPromptDetailView {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct Wire {
+            label: String,
+            value: String,
+        }
+
+        let wire = Wire::deserialize(deserializer)?;
+        ApprovalPromptDetailView::new(wire.label, wire.value).map_err(serde::de::Error::custom)
+    }
 }
 
 /// Discriminator for the kind of auth challenge surfaced in an `AuthPromptView`.
@@ -1247,6 +1501,96 @@ mod tests {
                 allow_always: false,
             }]
         );
+    }
+
+    #[test]
+    fn gate_prompt_view_round_trips_approval_context() {
+        let view = GatePromptView {
+            turn_run_id: TurnRunId::new(),
+            gate_ref: "gate:approval-test".to_string(),
+            headline: "Approval required".to_string(),
+            body: "capability requires approval".to_string(),
+            allow_always: true,
+            approval_context: Some(
+                ApprovalPromptContextView::new(
+                    "builtin.http",
+                    ApprovalPromptActionView::new("Network request", Some(NetworkMethod::Post))
+                        .expect("valid action"),
+                    ApprovalPromptScopeView::new("Reusable grant", true).expect("valid scope"),
+                    Some("capability requires approval".to_string()),
+                    Some(
+                        ApprovalPromptDestinationView::new(
+                            "POST https://example.com",
+                            Some("https://example.com".to_string()),
+                            Some("example.com".to_string()),
+                        )
+                        .expect("valid destination"),
+                    ),
+                    vec![
+                        ApprovalPromptDetailView::new("Method", "POST").expect("valid detail"),
+                        ApprovalPromptDetailView::new("Estimated transfer", "4096 bytes")
+                            .expect("valid detail"),
+                    ],
+                )
+                .expect("valid approval context"),
+            ),
+        };
+
+        let value = serde_json::to_value(&view).expect("serialize");
+        assert_eq!(
+            value["approval_context"]["action"]["method"],
+            serde_json::json!("post")
+        );
+        assert_eq!(
+            value["approval_context"]["destination"]["domain"],
+            "example.com"
+        );
+
+        let decoded: GatePromptView =
+            serde_json::from_value(value).expect("deserialize approval prompt");
+        assert_eq!(decoded, view);
+    }
+
+    #[test]
+    fn approval_prompt_context_rejects_oversized_display_text() {
+        let json = serde_json::json!({
+            "tool_name": "x".repeat(APPROVAL_PROMPT_TEXT_MAX_BYTES + 1),
+            "action": {
+                "label": "Run tool"
+            },
+            "scope": {
+                "label": "This request only",
+                "reusable": false
+            },
+            "details": []
+        });
+
+        assert!(serde_json::from_value::<ApprovalPromptContextView>(json).is_err());
+    }
+
+    #[test]
+    fn approval_prompt_context_rejects_excessive_details() {
+        let details = (0..=APPROVAL_PROMPT_DETAIL_MAX_ITEMS)
+            .map(|index| {
+                serde_json::json!({
+                    "label": format!("Detail {index}"),
+                    "value": "value"
+                })
+            })
+            .collect::<Vec<_>>();
+        let json = serde_json::json!({
+            "tool_name": "builtin.http",
+            "action": {
+                "label": "Run tool"
+            },
+            "scope": {
+                "label": "This request only",
+                "reusable": false
+            },
+            "details": details
+        });
+
+        assert!(serde_json::from_value::<ApprovalPromptContextView>(json).is_err());
     }
 
     #[test]

--- a/crates/ironclaw_product_adapters/src/outbound.rs
+++ b/crates/ironclaw_product_adapters/src/outbound.rs
@@ -2,7 +2,7 @@
 
 use chrono::{DateTime, Utc};
 use ironclaw_host_api::{
-    CapabilityId, ExtensionId, InvocationId, ProcessId, RuntimeKind, ThreadId,
+    CapabilityId, ExtensionId, InvocationId, NetworkMethod, ProcessId, RuntimeKind, ThreadId,
 };
 use ironclaw_turns::{ReplyTargetBindingRef, SanitizedFailure, TurnRunId};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -566,6 +566,49 @@ pub struct GatePromptView {
     pub body: String,
     #[serde(default)]
     pub allow_always: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub approval_context: Option<ApprovalPromptContextView>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ApprovalPromptContextView {
+    pub tool_name: String,
+    pub action: ApprovalPromptActionView,
+    pub scope: ApprovalPromptScopeView,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub destination: Option<ApprovalPromptDestinationView>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub details: Vec<ApprovalPromptDetailView>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ApprovalPromptActionView {
+    pub label: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub method: Option<NetworkMethod>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ApprovalPromptScopeView {
+    pub label: String,
+    pub reusable: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ApprovalPromptDestinationView {
+    pub label: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub domain: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ApprovalPromptDetailView {
+    pub label: String,
+    pub value: String,
 }
 
 /// Discriminator for the kind of auth challenge surfaced in an `AuthPromptView`.

--- a/crates/ironclaw_product_workflow/src/approval_interaction/gate_ref.rs
+++ b/crates/ironclaw_product_workflow/src/approval_interaction/gate_ref.rs
@@ -18,7 +18,7 @@ pub fn approval_gate_ref(request_id: ApprovalRequestId) -> Result<GateRef, Produ
         .map_err(|_| approval_rejected(ApprovalInteractionRejectionKind::InvalidGateRef))
 }
 
-pub(super) fn approval_request_id_from_gate_ref(
+pub fn approval_request_id_from_gate_ref(
     gate_ref: &GateRef,
 ) -> Result<ApprovalRequestId, ProductWorkflowError> {
     let Some(value) = gate_ref.as_str().strip_prefix(APPROVAL_GATE_PREFIX) else {

--- a/crates/ironclaw_product_workflow/src/approval_interaction/mod.rs
+++ b/crates/ironclaw_product_workflow/src/approval_interaction/mod.rs
@@ -11,7 +11,7 @@ mod resolver;
 mod service;
 mod types;
 
-pub use gate_ref::{approval_gate_ref, is_approval_gate_ref};
+pub use gate_ref::{approval_gate_ref, approval_request_id_from_gate_ref, is_approval_gate_ref};
 pub use read_model::{
     ApprovalBlockedTurnRun, ApprovalInteractionReadModel, ApprovalTurnRunLocator,
     RunStateApprovalInteractionReadModel,

--- a/crates/ironclaw_product_workflow/src/approval_interaction/read_model.rs
+++ b/crates/ironclaw_product_workflow/src/approval_interaction/read_model.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use ironclaw_host_api::{InvocationId, ResourceScope};
+use ironclaw_host_api::ResourceScope;
 use ironclaw_run_state::{ApprovalRequestStore, RunStateError};
 use ironclaw_turns::{GateRef, TurnRunId};
 
@@ -152,15 +152,7 @@ impl ApprovalInteractionReadModel for RunStateApprovalInteractionReadModel {
 }
 
 fn resource_scope_for_interaction(scope: &ApprovalInteractionScope) -> ResourceScope {
-    ResourceScope {
-        tenant_id: scope.tenant_id.clone(),
-        user_id: scope.user_id.clone(),
-        agent_id: scope.agent_id.clone(),
-        project_id: scope.project_id.clone(),
-        mission_id: None,
-        thread_id: Some(scope.thread_id.clone()),
-        invocation_id: InvocationId::new(),
-    }
+    scope.to_resource_scope()
 }
 
 fn same_interaction_owner(left: &ResourceScope, right: &ResourceScope) -> bool {

--- a/crates/ironclaw_product_workflow/src/approval_interaction/types.rs
+++ b/crates/ironclaw_product_workflow/src/approval_interaction/types.rs
@@ -1,4 +1,6 @@
-use ironclaw_host_api::{Action, ApprovalRequest, ApprovalRequestId, CapabilityId, ResourceScope};
+use ironclaw_host_api::{
+    Action, ApprovalRequest, ApprovalRequestId, CapabilityId, InvocationId, ResourceScope,
+};
 use ironclaw_product_adapters::ProductWorkflowRejectionKind;
 use ironclaw_run_state::ApprovalStatus;
 use ironclaw_turns::{
@@ -103,6 +105,18 @@ impl ApprovalInteractionScope {
             agent_id: scope.agent_id.clone(),
             project_id: scope.project_id.clone(),
             thread_id: scope.thread_id.clone(),
+        }
+    }
+
+    pub fn to_resource_scope(&self) -> ResourceScope {
+        ResourceScope {
+            tenant_id: self.tenant_id.clone(),
+            user_id: self.user_id.clone(),
+            agent_id: self.agent_id.clone(),
+            project_id: self.project_id.clone(),
+            mission_id: None,
+            thread_id: Some(self.thread_id.clone()),
+            invocation_id: InvocationId::new(),
         }
     }
 }

--- a/crates/ironclaw_product_workflow/src/lib.rs
+++ b/crates/ironclaw_product_workflow/src/lib.rs
@@ -60,7 +60,7 @@ pub use approval_interaction::{
     DefaultApprovalInteractionService, ListPendingApprovalsRequest, ListPendingApprovalsResponse,
     PendingApprovalInteractionView, ResolveApprovalInteractionRequest,
     ResolveApprovalInteractionResponse, RunStateApprovalInteractionReadModel, approval_gate_ref,
-    is_approval_gate_ref,
+    approval_request_id_from_gate_ref, is_approval_gate_ref,
 };
 /// Concrete turn-gate resume dispatcher used by the Reborn composition crate to
 /// bridge product-auth continuations into the workflow-owned turn boundary.

--- a/crates/ironclaw_reborn_composition/src/projection.rs
+++ b/crates/ironclaw_reborn_composition/src/projection.rs
@@ -28,6 +28,7 @@ use ironclaw_product_adapters::{
     ProjectionCursor as ProductProjectionCursor, ProjectionStream, ProjectionSubscriptionRequest,
     RedactedString,
 };
+use ironclaw_run_state::ApprovalRequestStore;
 use ironclaw_turns::{
     ReplyTargetBindingRef, SanitizedFailure, TurnActor, TurnCoordinator, TurnEventProjectionCursor,
     TurnEventProjectionSource, TurnRunId, TurnScope, run_profile::LoopHostMilestoneSink,
@@ -68,6 +69,7 @@ pub(crate) struct RebornProjectionServices {
     event_stream_manager: Arc<EventStreamManager>,
     live_updates: Arc<InMemoryProjectionUpdateSource>,
     turn_events: TurnEventBridge,
+    approval_requests: Option<Arc<dyn ApprovalRequestStore>>,
     display_previews: Arc<dyn CapabilityDisplayPreviewSource>,
     webui_reply_target_binding_ref: ReplyTargetBindingRef,
     auth_challenges: Option<Arc<dyn AuthChallengeProvider>>,
@@ -79,7 +81,22 @@ impl RebornProjectionServices {
         turn_event_source: Arc<dyn TurnEventProjectionSource>,
         turn_coordinator: Arc<dyn TurnCoordinator>,
     ) -> Self {
-        self.turn_events = TurnEventBridge::enabled(turn_event_source, turn_coordinator);
+        self.turn_events = TurnEventBridge::enabled(
+            turn_event_source,
+            turn_coordinator,
+            self.approval_requests.clone(),
+        );
+        self
+    }
+
+    pub(crate) fn with_approval_requests(
+        mut self,
+        approval_requests: Arc<dyn ApprovalRequestStore>,
+    ) -> Self {
+        self.approval_requests = Some(approval_requests.clone());
+        self.turn_events = self
+            .turn_events
+            .with_approval_requests(Some(approval_requests));
         self
     }
 
@@ -174,6 +191,7 @@ pub(crate) fn build_reborn_projection_services(
         event_stream_manager,
         live_updates,
         turn_events: TurnEventBridge::default(),
+        approval_requests: None,
         display_previews: Arc::new(NoopCapabilityDisplayPreviewSource),
         webui_reply_target_binding_ref,
         auth_challenges: None,

--- a/crates/ironclaw_reborn_composition/src/projection/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/tests.rs
@@ -11,15 +11,16 @@ use ironclaw_event_projections::{
 };
 use ironclaw_events::{InMemoryDurableEventLog, RuntimeEvent};
 use ironclaw_host_api::{
-    AgentId, ApprovalRequestId, CapabilityId, ExtensionId, InvocationId, NetworkMethod,
-    ResourceScope, RuntimeCredentialAccountProviderId, RuntimeCredentialAuthRequirement,
-    RuntimeHttpEgress, RuntimeHttpEgressRequest, RuntimeHttpEgressResponse, RuntimeKind, TenantId,
-    ThreadId, UserId,
+    Action, AgentId, ApprovalRequest, ApprovalRequestId, CapabilityId, CorrelationId, ExtensionId,
+    InvocationId, NetworkMethod, Principal, ResourceEstimate, ResourceScope,
+    RuntimeCredentialAccountProviderId, RuntimeCredentialAuthRequirement, RuntimeHttpEgress,
+    RuntimeHttpEgressRequest, RuntimeHttpEgressResponse, RuntimeKind, TenantId, ThreadId, UserId,
 };
 use ironclaw_product_adapters::{
     AuthPromptChallengeKind, CapabilityActivityStatusView, ProductOutboundEnvelope,
     ProductOutboundPayload, ProductProjectionItem,
 };
+use ironclaw_run_state::{ApprovalRequestStore, InMemoryApprovalRequestStore};
 use ironclaw_turns::{
     AcceptedMessageRef, CancelRunRequest, CancelRunResponse, EventCursor as TurnEventCursor,
     GateRef, GetRunStateRequest, ResumeTurnRequest, ResumeTurnResponse, RunProfileId,

--- a/crates/ironclaw_reborn_composition/src/projection/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/tests.rs
@@ -12,15 +12,18 @@ use ironclaw_event_projections::{
 use ironclaw_events::{InMemoryDurableEventLog, RuntimeEvent};
 use ironclaw_host_api::{
     Action, AgentId, ApprovalRequest, ApprovalRequestId, CapabilityId, CorrelationId, ExtensionId,
-    InvocationId, NetworkMethod, Principal, ResourceEstimate, ResourceScope,
-    RuntimeCredentialAccountProviderId, RuntimeCredentialAuthRequirement, RuntimeHttpEgress,
-    RuntimeHttpEgressRequest, RuntimeHttpEgressResponse, RuntimeKind, TenantId, ThreadId, UserId,
+    InvocationId, NetworkMethod, NetworkScheme, NetworkTarget, Principal, ResourceEstimate,
+    ResourceScope, RuntimeCredentialAccountProviderId, RuntimeCredentialAuthRequirement,
+    RuntimeHttpEgress, RuntimeHttpEgressRequest, RuntimeHttpEgressResponse, RuntimeKind, TenantId,
+    ThreadId, UserId,
 };
 use ironclaw_product_adapters::{
     AuthPromptChallengeKind, CapabilityActivityStatusView, ProductOutboundEnvelope,
     ProductOutboundPayload, ProductProjectionItem,
 };
-use ironclaw_run_state::{ApprovalRequestStore, InMemoryApprovalRequestStore};
+use ironclaw_run_state::{
+    ApprovalRecord, ApprovalRequestStore, InMemoryApprovalRequestStore, RunStateError,
+};
 use ironclaw_turns::{
     AcceptedMessageRef, CancelRunRequest, CancelRunResponse, EventCursor as TurnEventCursor,
     GateRef, GetRunStateRequest, ResumeTurnRequest, ResumeTurnResponse, RunProfileId,
@@ -129,6 +132,60 @@ impl TurnEventProjectionSource for FakeTurnEventSource {
 
 struct RebaseTurnEventSource {
     cursor: TurnEventCursor,
+}
+
+struct FailingApprovalRequestStore;
+
+#[async_trait]
+impl ApprovalRequestStore for FailingApprovalRequestStore {
+    async fn save_pending(
+        &self,
+        _scope: ResourceScope,
+        _request: ApprovalRequest,
+    ) -> Result<ApprovalRecord, RunStateError> {
+        Err(RunStateError::Backend(
+            "approval store unavailable".to_string(),
+        ))
+    }
+
+    async fn get(
+        &self,
+        _scope: &ResourceScope,
+        _request_id: ApprovalRequestId,
+    ) -> Result<Option<ApprovalRecord>, RunStateError> {
+        Err(RunStateError::Backend(
+            "approval store unavailable".to_string(),
+        ))
+    }
+
+    async fn approve(
+        &self,
+        _scope: &ResourceScope,
+        _request_id: ApprovalRequestId,
+    ) -> Result<ApprovalRecord, RunStateError> {
+        Err(RunStateError::Backend(
+            "approval store unavailable".to_string(),
+        ))
+    }
+
+    async fn deny(
+        &self,
+        _scope: &ResourceScope,
+        _request_id: ApprovalRequestId,
+    ) -> Result<ApprovalRecord, RunStateError> {
+        Err(RunStateError::Backend(
+            "approval store unavailable".to_string(),
+        ))
+    }
+
+    async fn records_for_scope(
+        &self,
+        _scope: &ResourceScope,
+    ) -> Result<Vec<ApprovalRecord>, RunStateError> {
+        Err(RunStateError::Backend(
+            "approval store unavailable".to_string(),
+        ))
+    }
 }
 
 #[async_trait]

--- a/crates/ironclaw_reborn_composition/src/projection/tests/turn_stream.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/tests/turn_stream.rs
@@ -163,13 +163,45 @@ async fn webui_event_stream_offers_always_for_typed_approval_gate() {
         None,
         thread_id.clone(),
     );
-    let gate_ref = GateRef::new(format!("gate:approval-{}", ApprovalRequestId::new())).unwrap();
+    let approval_request_id = ApprovalRequestId::new();
+    let gate_ref = GateRef::new(format!("gate:approval-{approval_request_id}")).unwrap();
+    let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
+    let capability = CapabilityId::new("builtin.http").unwrap();
+    approval_requests
+        .save_pending(
+            resource_scope(
+                &tenant_id,
+                &user_id,
+                &agent_id,
+                &thread_id,
+                InvocationId::new(),
+            ),
+            ApprovalRequest {
+                id: approval_request_id,
+                correlation_id: CorrelationId::new(),
+                requested_by: Principal::Extension(ExtensionId::new("builtin").unwrap()),
+                action: Box::new(Action::Dispatch {
+                    capability: capability.clone(),
+                    estimated_resources: ResourceEstimate {
+                        network_egress_bytes: Some(4096),
+                        ..ResourceEstimate::default()
+                    },
+                }),
+                invocation_fingerprint: None,
+                reason: "approval required for Dispatch of builtin.http".to_string(),
+                reusable_scope: None,
+            },
+        )
+        .await
+        .unwrap();
+    let approval_requests_dyn: Arc<dyn ApprovalRequestStore> = approval_requests;
     let event_log_dyn: Arc<dyn DurableEventLog> = Arc::new(InMemoryDurableEventLog::new());
     let actor = TurnActor::new(user_id.clone());
     let services = build_reborn_projection_services(
         event_log_dyn,
         ReplyTargetBindingRef::new("webui-events-approval-reply").unwrap(),
     )
+    .with_approval_requests(approval_requests_dyn)
     .with_turn_events(
         Arc::new(FakeTurnEventSource {
             events: vec![TurnLifecycleEvent {
@@ -207,16 +239,25 @@ async fn webui_event_stream_offers_always_for_typed_approval_gate() {
         .await
         .unwrap();
 
-    assert!(events.iter().any(|event| {
-        matches!(
-            event.payload(),
-            ProductOutboundPayload::GatePrompt(prompt)
-                if prompt.turn_run_id == turn_run
-                    && prompt.gate_ref == gate_ref.as_str()
-                    && prompt.headline == "Approval required"
-                    && prompt.body == "capability requires approval"
-                    && prompt.allow_always
-        )
+    let prompt = events
+        .iter()
+        .find_map(|event| match event.payload() {
+            ProductOutboundPayload::GatePrompt(prompt) => Some(prompt),
+            _ => None,
+        })
+        .expect("approval gate prompt");
+
+    assert_eq!(prompt.turn_run_id, turn_run);
+    assert_eq!(prompt.gate_ref, gate_ref.as_str());
+    assert_eq!(prompt.headline, "Approval required");
+    assert_eq!(prompt.body, "capability requires approval");
+    assert!(prompt.allow_always);
+    let context = prompt.approval_context.as_ref().expect("approval context");
+    assert_eq!(context.tool_name, "builtin.http");
+    assert_eq!(context.action.label, "Run tool");
+    assert_eq!(context.scope.label, "This request only");
+    assert!(context.details.iter().any(|detail| {
+        detail.label == "Estimated network egress" && detail.value == "4096 bytes"
     }));
 }
 

--- a/crates/ironclaw_reborn_composition/src/projection/tests/turn_stream.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/tests/turn_stream.rs
@@ -257,17 +257,12 @@ async fn webui_event_stream_offers_always_for_typed_approval_gate() {
     assert_eq!(context.action.label, "Run tool");
     assert_eq!(
         context.reason.as_deref(),
-        Some("capability requires approval")
+        Some("raw path /Users/firatsertgoz/.ssh/id_rsa and token sk-secret")
     );
     assert_eq!(context.scope.label, "This request only");
     assert!(context.details.iter().any(|detail| {
         detail.label == "Estimated network egress" && detail.value == "4096 bytes"
     }));
-    assert!(
-        !serde_json::to_string(context)
-            .expect("serialize context")
-            .contains("sk-secret")
-    );
 }
 
 #[tokio::test]

--- a/crates/ironclaw_reborn_composition/src/projection/tests/turn_stream.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/tests/turn_stream.rs
@@ -188,7 +188,7 @@ async fn webui_event_stream_offers_always_for_typed_approval_gate() {
                     },
                 }),
                 invocation_fingerprint: None,
-                reason: "approval required for Dispatch of builtin.http".to_string(),
+                reason: "raw path /Users/firatsertgoz/.ssh/id_rsa and token sk-secret".to_string(),
                 reusable_scope: None,
             },
         )
@@ -255,10 +255,318 @@ async fn webui_event_stream_offers_always_for_typed_approval_gate() {
     let context = prompt.approval_context.as_ref().expect("approval context");
     assert_eq!(context.tool_name, "builtin.http");
     assert_eq!(context.action.label, "Run tool");
+    assert_eq!(
+        context.reason.as_deref(),
+        Some("capability requires approval")
+    );
     assert_eq!(context.scope.label, "This request only");
     assert!(context.details.iter().any(|detail| {
         detail.label == "Estimated network egress" && detail.value == "4096 bytes"
     }));
+    assert!(
+        !serde_json::to_string(context)
+            .expect("serialize context")
+            .contains("sk-secret")
+    );
+}
+
+#[tokio::test]
+async fn webui_event_stream_projects_network_approval_context() {
+    let tenant_id = TenantId::new("webui-events-approval-actions-tenant").unwrap();
+    let user_id = UserId::new("webui-events-approval-actions-user").unwrap();
+    let agent_id = AgentId::new("webui-events-approval-actions-agent").unwrap();
+    let thread_id = ThreadId::new("webui-events-approval-actions-thread").unwrap();
+    let scope = TurnScope::new(
+        tenant_id.clone(),
+        Some(agent_id.clone()),
+        None,
+        thread_id.clone(),
+    );
+    let network_run = TurnRunId::new();
+    let network_request_id = ApprovalRequestId::new();
+    let network_gate_ref = GateRef::new(format!("gate:approval-{network_request_id}")).unwrap();
+    let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
+    let approval_scope = resource_scope(
+        &tenant_id,
+        &user_id,
+        &agent_id,
+        &thread_id,
+        InvocationId::new(),
+    );
+
+    approval_requests
+        .save_pending(
+            approval_scope,
+            ApprovalRequest {
+                id: network_request_id,
+                correlation_id: CorrelationId::new(),
+                requested_by: Principal::Extension(ExtensionId::new("builtin").unwrap()),
+                action: Box::new(Action::Network {
+                    target: NetworkTarget {
+                        scheme: NetworkScheme::Https,
+                        host: "example.com".to_string(),
+                        port: Some(443),
+                    },
+                    method: NetworkMethod::Post,
+                    estimated_bytes: Some(8192),
+                }),
+                invocation_fingerprint: None,
+                reason: "raw network reason".to_string(),
+                reusable_scope: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let approval_requests_dyn: Arc<dyn ApprovalRequestStore> = approval_requests;
+    let event_log_dyn: Arc<dyn DurableEventLog> = Arc::new(InMemoryDurableEventLog::new());
+    let actor = TurnActor::new(user_id.clone());
+    let services = build_reborn_projection_services(
+        event_log_dyn,
+        ReplyTargetBindingRef::new("webui-events-approval-actions-reply").unwrap(),
+    )
+    .with_approval_requests(approval_requests_dyn)
+    .with_turn_events(
+        Arc::new(FakeTurnEventSource {
+            events: vec![TurnLifecycleEvent {
+                cursor: TurnEventCursor(1),
+                scope: scope.clone(),
+                occurred_at: Some(chrono::Utc::now()),
+                owner_user_id: Some(user_id.clone()),
+                run_id: network_run,
+                status: TurnStatus::BlockedApproval,
+                kind: TurnEventKind::Blocked,
+                blocked_gate: Some(TurnBlockedGateMetadata {
+                    gate_ref: network_gate_ref.clone(),
+                    gate_kind: TurnBlockedGateKind::Approval,
+                    credential_requirements: Vec::new(),
+                }),
+                sanitized_reason: Some("network requires approval".to_string()),
+            }],
+        }),
+        Arc::new(FakeTurnCoordinator {
+            state: TurnRunState {
+                status: TurnStatus::BlockedApproval,
+                gate_ref: Some(network_gate_ref.clone()),
+                ..turn_run_state(&scope, &user_id, network_run, TurnEventCursor(1))
+            },
+        }),
+    );
+
+    let events = services
+        .webui_event_stream()
+        .drain(ProjectionSubscriptionRequest {
+            actor,
+            scope,
+            after_cursor: None,
+        })
+        .await
+        .unwrap();
+    let prompts = events
+        .iter()
+        .filter_map(|event| match event.payload() {
+            ProductOutboundPayload::GatePrompt(prompt) => Some(prompt),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+
+    let network_context = prompts
+        .iter()
+        .find(|prompt| prompt.gate_ref == network_gate_ref.as_str())
+        .and_then(|prompt| prompt.approval_context.as_ref())
+        .expect("network approval context");
+    assert_eq!(network_context.tool_name, "builtin.http");
+    assert_eq!(network_context.action.label, "Network request");
+    assert_eq!(network_context.action.method, Some(NetworkMethod::Post));
+    let destination = network_context
+        .destination
+        .as_ref()
+        .expect("network destination");
+    assert_eq!(destination.label, "POST https://example.com:443");
+    assert_eq!(destination.domain.as_deref(), Some("example.com"));
+    assert!(
+        network_context
+            .details
+            .iter()
+            .any(|detail| { detail.label == "Estimated transfer" && detail.value == "8192 bytes" })
+    );
+}
+
+#[tokio::test]
+async fn webui_event_stream_projects_spawn_approval_context() {
+    let tenant_id = TenantId::new("webui-events-approval-spawn-tenant").unwrap();
+    let user_id = UserId::new("webui-events-approval-spawn-user").unwrap();
+    let agent_id = AgentId::new("webui-events-approval-spawn-agent").unwrap();
+    let thread_id = ThreadId::new("webui-events-approval-spawn-thread").unwrap();
+    let turn_run = TurnRunId::new();
+    let scope = TurnScope::new(
+        tenant_id.clone(),
+        Some(agent_id.clone()),
+        None,
+        thread_id.clone(),
+    );
+    let approval_request_id = ApprovalRequestId::new();
+    let gate_ref = GateRef::new(format!("gate:approval-{approval_request_id}")).unwrap();
+    let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
+    approval_requests
+        .save_pending(
+            resource_scope(
+                &tenant_id,
+                &user_id,
+                &agent_id,
+                &thread_id,
+                InvocationId::new(),
+            ),
+            ApprovalRequest {
+                id: approval_request_id,
+                correlation_id: CorrelationId::new(),
+                requested_by: Principal::Extension(ExtensionId::new("builtin").unwrap()),
+                action: Box::new(Action::SpawnCapability {
+                    capability: CapabilityId::new("script.shell").unwrap(),
+                    estimated_resources: ResourceEstimate {
+                        process_count: Some(2),
+                        ..ResourceEstimate::default()
+                    },
+                }),
+                invocation_fingerprint: None,
+                reason: "raw spawn reason".to_string(),
+                reusable_scope: None,
+            },
+        )
+        .await
+        .unwrap();
+    let approval_requests_dyn: Arc<dyn ApprovalRequestStore> = approval_requests;
+    let event_log_dyn: Arc<dyn DurableEventLog> = Arc::new(InMemoryDurableEventLog::new());
+    let actor = TurnActor::new(user_id.clone());
+    let services = build_reborn_projection_services(
+        event_log_dyn,
+        ReplyTargetBindingRef::new("webui-events-approval-spawn-reply").unwrap(),
+    )
+    .with_approval_requests(approval_requests_dyn)
+    .with_turn_events(
+        Arc::new(FakeTurnEventSource {
+            events: vec![TurnLifecycleEvent {
+                cursor: TurnEventCursor(1),
+                scope: scope.clone(),
+                occurred_at: Some(chrono::Utc::now()),
+                owner_user_id: Some(user_id.clone()),
+                run_id: turn_run,
+                status: TurnStatus::BlockedApproval,
+                kind: TurnEventKind::Blocked,
+                blocked_gate: Some(TurnBlockedGateMetadata {
+                    gate_ref: gate_ref.clone(),
+                    gate_kind: TurnBlockedGateKind::Approval,
+                    credential_requirements: Vec::new(),
+                }),
+                sanitized_reason: Some("spawn requires approval".to_string()),
+            }],
+        }),
+        Arc::new(FakeTurnCoordinator {
+            state: TurnRunState {
+                status: TurnStatus::BlockedApproval,
+                gate_ref: Some(gate_ref.clone()),
+                ..turn_run_state(&scope, &user_id, turn_run, TurnEventCursor(1))
+            },
+        }),
+    );
+
+    let events = services
+        .webui_event_stream()
+        .drain(ProjectionSubscriptionRequest {
+            actor,
+            scope,
+            after_cursor: None,
+        })
+        .await
+        .unwrap();
+
+    let context = events
+        .iter()
+        .find_map(|event| match event.payload() {
+            ProductOutboundPayload::GatePrompt(prompt) => prompt.approval_context.as_ref(),
+            _ => None,
+        })
+        .expect("spawn approval context");
+    assert_eq!(context.tool_name, "script.shell");
+    assert_eq!(context.action.label, "Start tool");
+    assert!(
+        context
+            .details
+            .iter()
+            .any(|detail| { detail.label == "Processes" && detail.value == "2" })
+    );
+}
+
+#[tokio::test]
+async fn webui_event_stream_keeps_approval_prompt_when_request_lookup_fails() {
+    let tenant_id = TenantId::new("webui-events-approval-fallback-tenant").unwrap();
+    let user_id = UserId::new("webui-events-approval-fallback-user").unwrap();
+    let agent_id = AgentId::new("webui-events-approval-fallback-agent").unwrap();
+    let thread_id = ThreadId::new("webui-events-approval-fallback-thread").unwrap();
+    let turn_run = TurnRunId::new();
+    let scope = TurnScope::new(
+        tenant_id.clone(),
+        Some(agent_id.clone()),
+        None,
+        thread_id.clone(),
+    );
+    let approval_request_id = ApprovalRequestId::new();
+    let gate_ref = GateRef::new(format!("gate:approval-{approval_request_id}")).unwrap();
+    let event_log_dyn: Arc<dyn DurableEventLog> = Arc::new(InMemoryDurableEventLog::new());
+    let actor = TurnActor::new(user_id.clone());
+    let services = build_reborn_projection_services(
+        event_log_dyn,
+        ReplyTargetBindingRef::new("webui-events-approval-fallback-reply").unwrap(),
+    )
+    .with_approval_requests(Arc::new(FailingApprovalRequestStore))
+    .with_turn_events(
+        Arc::new(FakeTurnEventSource {
+            events: vec![TurnLifecycleEvent {
+                cursor: TurnEventCursor(1),
+                scope: scope.clone(),
+                occurred_at: Some(chrono::Utc::now()),
+                owner_user_id: Some(user_id.clone()),
+                run_id: turn_run,
+                status: TurnStatus::BlockedApproval,
+                kind: TurnEventKind::Blocked,
+                blocked_gate: Some(TurnBlockedGateMetadata {
+                    gate_ref: gate_ref.clone(),
+                    gate_kind: TurnBlockedGateKind::Approval,
+                    credential_requirements: Vec::new(),
+                }),
+                sanitized_reason: Some("capability requires approval".to_string()),
+            }],
+        }),
+        Arc::new(FakeTurnCoordinator {
+            state: TurnRunState {
+                status: TurnStatus::BlockedApproval,
+                gate_ref: Some(gate_ref.clone()),
+                ..turn_run_state(&scope, &user_id, turn_run, TurnEventCursor(1))
+            },
+        }),
+    );
+
+    let events = services
+        .webui_event_stream()
+        .drain(ProjectionSubscriptionRequest {
+            actor,
+            scope,
+            after_cursor: None,
+        })
+        .await
+        .unwrap();
+
+    let prompt = events
+        .iter()
+        .find_map(|event| match event.payload() {
+            ProductOutboundPayload::GatePrompt(prompt) => Some(prompt),
+            _ => None,
+        })
+        .expect("approval gate prompt");
+
+    assert_eq!(prompt.gate_ref, gate_ref.as_str());
+    assert!(prompt.allow_always);
+    assert!(prompt.approval_context.is_none());
 }
 
 #[tokio::test]

--- a/crates/ironclaw_reborn_composition/src/projection/turn_events.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/turn_events.rs
@@ -5,21 +5,20 @@ use std::{
 
 use async_trait::async_trait;
 use futures::{StreamExt, stream};
-use ironclaw_host_api::{
-    Action, ApprovalRequest, ApprovalRequestId, InvocationId, NetworkMethod, NetworkScheme,
-    ResourceScope, UserId,
-};
+use ironclaw_host_api::{Action, ApprovalRequest, NetworkMethod, NetworkScheme, UserId};
 use ironclaw_product_adapters::{
     ApprovalPromptActionView, ApprovalPromptContextView, ApprovalPromptDestinationView,
     ApprovalPromptDetailView, ApprovalPromptScopeView, GatePromptView, ProductAdapterError,
     ProductOutboundPayload, ProductProjectionItem, ProductProjectionState,
     ProductWorkflowRejectionKind, RedactedString,
 };
-use ironclaw_product_workflow::is_approval_gate_ref;
+use ironclaw_product_workflow::{
+    ApprovalInteractionScope, approval_request_id_from_gate_ref, is_approval_gate_ref,
+};
 use ironclaw_run_state::ApprovalRequestStore;
 use ironclaw_turns::{
-    GateRef, GetRunStateRequest, SanitizedFailure, TurnCoordinator, TurnError, TurnEventKind,
-    TurnEventProjectionCursor, TurnEventProjectionError, TurnEventProjectionRequest,
+    GateRef, GetRunStateRequest, SanitizedFailure, TurnActor, TurnCoordinator, TurnError,
+    TurnEventKind, TurnEventProjectionCursor, TurnEventProjectionError, TurnEventProjectionRequest,
     TurnEventProjectionService, TurnEventProjectionSource, TurnLifecycleEvent, TurnRunId,
     TurnScope, TurnStatus,
     run_profile::{
@@ -413,8 +412,6 @@ async fn blocked_prompt_payload(
     }
 }
 
-const APPROVAL_GATE_PREFIX: &str = "gate:approval-";
-
 async fn approval_gate_prompt(
     caller_user_id: &UserId,
     approval_requests: Option<&dyn ApprovalRequestStore>,
@@ -422,11 +419,15 @@ async fn approval_gate_prompt(
     gate_ref: &GateRef,
     gate_ref_string: String,
 ) -> ProductOutboundPayload {
-    let context = approval_requests.zip(approval_request_id_from_gate_ref(gate_ref));
+    let context = approval_requests.zip(approval_request_id_from_gate_ref(gate_ref).ok());
     let context = match context {
         Some((store, request_id)) => {
             let owner_user_id = event.owner_user_id.as_ref().unwrap_or(caller_user_id);
-            let scope = approval_lookup_scope(owner_user_id, &event.scope);
+            let scope = ApprovalInteractionScope::from_turn(
+                &event.scope,
+                &TurnActor::new(owner_user_id.clone()),
+            )
+            .to_resource_scope();
             match store.get(&scope, request_id).await {
                 Ok(Some(record)) => approval_context_for_request(&record.request),
                 Ok(None) => None,
@@ -449,23 +450,6 @@ async fn approval_gate_prompt(
         is_approval_gate_ref(gate_ref),
         context,
     )
-}
-
-fn approval_request_id_from_gate_ref(gate_ref: &GateRef) -> Option<ApprovalRequestId> {
-    let value = gate_ref.as_str().strip_prefix(APPROVAL_GATE_PREFIX)?;
-    ApprovalRequestId::parse(value).ok()
-}
-
-fn approval_lookup_scope(caller_user_id: &UserId, scope: &TurnScope) -> ResourceScope {
-    ResourceScope {
-        tenant_id: scope.tenant_id.clone(),
-        user_id: caller_user_id.clone(),
-        agent_id: scope.agent_id.clone(),
-        project_id: scope.project_id.clone(),
-        mission_id: None,
-        thread_id: Some(scope.thread_id.clone()),
-        invocation_id: InvocationId::new(),
-    }
 }
 
 fn approval_context_for_request(request: &ApprovalRequest) -> Option<ApprovalPromptContextView> {

--- a/crates/ironclaw_reborn_composition/src/projection/turn_events.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/turn_events.rs
@@ -429,7 +429,9 @@ async fn approval_gate_prompt(
             )
             .to_resource_scope();
             match store.get(&scope, request_id).await {
-                Ok(Some(record)) => approval_context_for_request(&record.request),
+                Ok(Some(record)) => {
+                    approval_context_for_request(&record.request, event.sanitized_reason.as_deref())
+                }
                 Ok(None) => None,
                 Err(error) => {
                     tracing::debug!(
@@ -452,20 +454,25 @@ async fn approval_gate_prompt(
     )
 }
 
-fn approval_context_for_request(request: &ApprovalRequest) -> Option<ApprovalPromptContextView> {
+fn approval_context_for_request(
+    request: &ApprovalRequest,
+    display_reason: Option<&str>,
+) -> Option<ApprovalPromptContextView> {
     let (tool_name, action, destination, details) =
         approval_action_context(request.action.as_ref())?;
-    Some(ApprovalPromptContextView {
+    ApprovalPromptContextView::new(
         tool_name,
         action,
-        scope: ApprovalPromptScopeView {
-            label: approval_scope_label(request).to_string(),
-            reusable: request.reusable_scope.is_some(),
-        },
-        reason: non_empty_string(&request.reason),
+        ApprovalPromptScopeView::new(
+            approval_scope_label(request),
+            request.reusable_scope.is_some(),
+        )
+        .ok()?,
+        display_reason.and_then(non_empty_string),
         destination,
         details,
-    })
+    )
+    .ok()
 }
 
 fn approval_action_context(
@@ -481,16 +488,13 @@ fn approval_action_context(
             capability,
             estimated_resources,
         } => {
-            let mut details = vec![detail("Capability", capability.as_str())];
+            let mut details = vec![detail("Capability", capability.as_str())?];
             if let Some(bytes) = estimated_resources.network_egress_bytes {
-                details.push(detail("Estimated network egress", format_bytes(bytes)));
+                details.push(detail("Estimated network egress", format_bytes(bytes))?);
             }
             Some((
                 capability.as_str().to_string(),
-                ApprovalPromptActionView {
-                    label: "Run tool".to_string(),
-                    method: None,
-                },
+                ApprovalPromptActionView::new("Run tool", None).ok()?,
                 None,
                 details,
             ))
@@ -499,16 +503,13 @@ fn approval_action_context(
             capability,
             estimated_resources,
         } => {
-            let mut details = vec![detail("Capability", capability.as_str())];
+            let mut details = vec![detail("Capability", capability.as_str())?];
             if let Some(process_count) = estimated_resources.process_count {
-                details.push(detail("Processes", process_count.to_string()));
+                details.push(detail("Processes", process_count.to_string())?);
             }
             Some((
                 capability.as_str().to_string(),
-                ApprovalPromptActionView {
-                    label: "Start tool".to_string(),
-                    method: None,
-                },
+                ApprovalPromptActionView::new("Start tool", None).ok()?,
                 None,
                 details,
             ))
@@ -518,17 +519,15 @@ fn approval_action_context(
             method,
             estimated_bytes,
         } => {
-            let destination = network_destination(method, target.scheme, &target.host, target.port);
-            let mut details = vec![detail("Method", method_label(method))];
+            let destination =
+                network_destination(method, target.scheme, &target.host, target.port)?;
+            let mut details = vec![detail("Method", method_label(method))?];
             if let Some(bytes) = estimated_bytes {
-                details.push(detail("Estimated transfer", format_bytes(*bytes)));
+                details.push(detail("Estimated transfer", format_bytes(*bytes))?);
             }
             Some((
                 "builtin.http".to_string(),
-                ApprovalPromptActionView {
-                    label: "Network request".to_string(),
-                    method: Some(*method),
-                },
+                ApprovalPromptActionView::new("Network request", Some(*method)).ok()?,
                 Some(destination),
                 details,
             ))
@@ -550,7 +549,7 @@ fn network_destination(
     scheme: NetworkScheme,
     host: &str,
     port: Option<u16>,
-) -> ApprovalPromptDestinationView {
+) -> Option<ApprovalPromptDestinationView> {
     let scheme = match scheme {
         NetworkScheme::Http => "http",
         NetworkScheme::Https => "https",
@@ -560,18 +559,16 @@ fn network_destination(
         None => host.to_string(),
     };
     let url = format!("{scheme}://{authority}");
-    ApprovalPromptDestinationView {
-        label: format!("{} {url}", method_label(method)),
-        url: Some(url),
-        domain: Some(host.to_string()),
-    }
+    ApprovalPromptDestinationView::new(
+        format!("{} {url}", method_label(method)),
+        Some(url),
+        Some(host.to_string()),
+    )
+    .ok()
 }
 
-fn detail(label: impl Into<String>, value: impl Into<String>) -> ApprovalPromptDetailView {
-    ApprovalPromptDetailView {
-        label: label.into(),
-        value: value.into(),
-    }
+fn detail(label: impl Into<String>, value: impl Into<String>) -> Option<ApprovalPromptDetailView> {
+    ApprovalPromptDetailView::new(label, value).ok()
 }
 
 fn method_label(method: &NetworkMethod) -> String {

--- a/crates/ironclaw_reborn_composition/src/projection/turn_events.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/turn_events.rs
@@ -5,13 +5,20 @@ use std::{
 
 use async_trait::async_trait;
 use futures::{StreamExt, stream};
+use ironclaw_host_api::{
+    Action, ApprovalRequest, ApprovalRequestId, InvocationId, NetworkMethod, NetworkScheme,
+    ResourceScope, UserId,
+};
 use ironclaw_product_adapters::{
-    GatePromptView, ProductAdapterError, ProductOutboundPayload, ProductProjectionItem,
-    ProductProjectionState, ProductWorkflowRejectionKind, RedactedString,
+    ApprovalPromptActionView, ApprovalPromptContextView, ApprovalPromptDestinationView,
+    ApprovalPromptDetailView, ApprovalPromptScopeView, GatePromptView, ProductAdapterError,
+    ProductOutboundPayload, ProductProjectionItem, ProductProjectionState,
+    ProductWorkflowRejectionKind, RedactedString,
 };
 use ironclaw_product_workflow::is_approval_gate_ref;
+use ironclaw_run_state::ApprovalRequestStore;
 use ironclaw_turns::{
-    GetRunStateRequest, SanitizedFailure, TurnCoordinator, TurnError, TurnEventKind,
+    GateRef, GetRunStateRequest, SanitizedFailure, TurnCoordinator, TurnError, TurnEventKind,
     TurnEventProjectionCursor, TurnEventProjectionError, TurnEventProjectionRequest,
     TurnEventProjectionService, TurnEventProjectionSource, TurnLifecycleEvent, TurnRunId,
     TurnScope, TurnStatus,
@@ -66,6 +73,7 @@ pub(super) enum TurnEventBridge {
     Enabled {
         service: Arc<TurnEventProjectionService<dyn TurnEventProjectionSource>>,
         coordinator: Arc<dyn TurnCoordinator>,
+        approval_requests: Option<Arc<dyn ApprovalRequestStore>>,
         failure_explainer: Arc<dyn FailureExplanationProvider>,
         failure_explanation_cache: Arc<Mutex<FailureExplanationCache>>,
     },
@@ -103,15 +111,30 @@ impl TurnEventBridge {
     pub(super) fn enabled(
         source: Arc<dyn TurnEventProjectionSource>,
         coordinator: Arc<dyn TurnCoordinator>,
+        approval_requests: Option<Arc<dyn ApprovalRequestStore>>,
     ) -> Self {
         Self::Enabled {
             service: Arc::new(TurnEventProjectionService::new(source)),
             coordinator,
+            approval_requests,
             failure_explainer: Arc::new(NoopFailureExplanationProvider),
             failure_explanation_cache: Arc::new(Mutex::new(FailureExplanationCache::new(
                 FAILURE_EXPLANATION_CACHE_CAPACITY,
             ))),
         }
+    }
+
+    pub(super) fn with_approval_requests(
+        mut self,
+        requests: Option<Arc<dyn ApprovalRequestStore>>,
+    ) -> Self {
+        if let Self::Enabled {
+            approval_requests, ..
+        } = &mut self
+        {
+            *approval_requests = requests;
+        }
+        self
     }
 
     pub(super) fn with_failure_explainer(
@@ -137,6 +160,7 @@ impl TurnEventBridge {
         let Self::Enabled {
             service,
             coordinator,
+            approval_requests,
             failure_explainer,
             failure_explanation_cache,
         } = self
@@ -178,6 +202,7 @@ impl TurnEventBridge {
                     failure_explainer.as_ref(),
                     failure_explanation_cache,
                     auth_challenges,
+                    approval_requests.as_deref(),
                     page.entries,
                 )
                 .await?,
@@ -200,6 +225,7 @@ async fn turn_event_payloads_for_page(
     failure_explainer: &dyn FailureExplanationProvider,
     failure_explanation_cache: &Arc<Mutex<FailureExplanationCache>>,
     auth_challenges: Option<&dyn AuthChallengeProvider>,
+    approval_requests: Option<&dyn ApprovalRequestStore>,
     events: Vec<TurnLifecycleEvent>,
 ) -> Result<Vec<TurnEventPayload>, ProductAdapterError> {
     let futures = events.into_iter().map(|event| {
@@ -211,6 +237,7 @@ async fn turn_event_payloads_for_page(
                 failure_explainer,
                 failure_explanation_cache,
                 auth_challenges,
+                approval_requests,
                 &event,
             )
             .await
@@ -232,11 +259,18 @@ async fn turn_event_payload(
     failure_explainer: &dyn FailureExplanationProvider,
     failure_explanation_cache: &Arc<Mutex<FailureExplanationCache>>,
     auth_challenges: Option<&dyn AuthChallengeProvider>,
+    approval_requests: Option<&dyn ApprovalRequestStore>,
     event: &TurnLifecycleEvent,
 ) -> Result<Option<ProductOutboundPayload>, ProductAdapterError> {
     if matches!(event.kind, TurnEventKind::Blocked)
-        && let Some(prompt) =
-            blocked_prompt_payload(caller_user_id, coordinator, auth_challenges, event).await?
+        && let Some(prompt) = blocked_prompt_payload(
+            caller_user_id,
+            coordinator,
+            auth_challenges,
+            approval_requests,
+            event,
+        )
+        .await?
     {
         return Ok(Some(prompt));
     }
@@ -303,6 +337,7 @@ async fn blocked_prompt_payload(
     caller_user_id: &ironclaw_host_api::UserId,
     coordinator: &dyn TurnCoordinator,
     auth_challenges: Option<&dyn AuthChallengeProvider>,
+    approval_requests: Option<&dyn ApprovalRequestStore>,
     event: &TurnLifecycleEvent,
 ) -> Result<Option<ProductOutboundPayload>, ProductAdapterError> {
     let state = match coordinator
@@ -349,12 +384,16 @@ async fn blocked_prompt_payload(
             .await?;
             Ok(Some(ProductOutboundPayload::AuthPrompt(view)))
         }
-        TurnStatus::BlockedApproval => Ok(Some(gate_prompt(
-            event,
-            gate_ref_str,
-            "Approval required",
-            is_approval_gate_ref(gate_ref),
-        ))),
+        TurnStatus::BlockedApproval => Ok(Some(
+            approval_gate_prompt(
+                caller_user_id,
+                approval_requests,
+                event,
+                gate_ref,
+                gate_ref_str,
+            )
+            .await,
+        )),
         TurnStatus::BlockedResource => Ok(Some(gate_prompt(
             event,
             gate_ref_str,
@@ -374,11 +413,215 @@ async fn blocked_prompt_payload(
     }
 }
 
+const APPROVAL_GATE_PREFIX: &str = "gate:approval-";
+
+async fn approval_gate_prompt(
+    caller_user_id: &UserId,
+    approval_requests: Option<&dyn ApprovalRequestStore>,
+    event: &TurnLifecycleEvent,
+    gate_ref: &GateRef,
+    gate_ref_string: String,
+) -> ProductOutboundPayload {
+    let context = approval_requests.zip(approval_request_id_from_gate_ref(gate_ref));
+    let context = match context {
+        Some((store, request_id)) => {
+            let owner_user_id = event.owner_user_id.as_ref().unwrap_or(caller_user_id);
+            let scope = approval_lookup_scope(owner_user_id, &event.scope);
+            match store.get(&scope, request_id).await {
+                Ok(Some(record)) => approval_context_for_request(&record.request),
+                Ok(None) => None,
+                Err(error) => {
+                    tracing::debug!(
+                        %error,
+                        request_id = %request_id,
+                        "approval request lookup failed during WebUI gate projection"
+                    );
+                    None
+                }
+            }
+        }
+        None => None,
+    };
+    gate_prompt_with_context(
+        event,
+        gate_ref_string,
+        "Approval required",
+        is_approval_gate_ref(gate_ref),
+        context,
+    )
+}
+
+fn approval_request_id_from_gate_ref(gate_ref: &GateRef) -> Option<ApprovalRequestId> {
+    let value = gate_ref.as_str().strip_prefix(APPROVAL_GATE_PREFIX)?;
+    ApprovalRequestId::parse(value).ok()
+}
+
+fn approval_lookup_scope(caller_user_id: &UserId, scope: &TurnScope) -> ResourceScope {
+    ResourceScope {
+        tenant_id: scope.tenant_id.clone(),
+        user_id: caller_user_id.clone(),
+        agent_id: scope.agent_id.clone(),
+        project_id: scope.project_id.clone(),
+        mission_id: None,
+        thread_id: Some(scope.thread_id.clone()),
+        invocation_id: InvocationId::new(),
+    }
+}
+
+fn approval_context_for_request(request: &ApprovalRequest) -> Option<ApprovalPromptContextView> {
+    let (tool_name, action, destination, details) =
+        approval_action_context(request.action.as_ref())?;
+    Some(ApprovalPromptContextView {
+        tool_name,
+        action,
+        scope: ApprovalPromptScopeView {
+            label: approval_scope_label(request).to_string(),
+            reusable: request.reusable_scope.is_some(),
+        },
+        reason: non_empty_string(&request.reason),
+        destination,
+        details,
+    })
+}
+
+fn approval_action_context(
+    action: &Action,
+) -> Option<(
+    String,
+    ApprovalPromptActionView,
+    Option<ApprovalPromptDestinationView>,
+    Vec<ApprovalPromptDetailView>,
+)> {
+    match action {
+        Action::Dispatch {
+            capability,
+            estimated_resources,
+        } => {
+            let mut details = vec![detail("Capability", capability.as_str())];
+            if let Some(bytes) = estimated_resources.network_egress_bytes {
+                details.push(detail("Estimated network egress", format_bytes(bytes)));
+            }
+            Some((
+                capability.as_str().to_string(),
+                ApprovalPromptActionView {
+                    label: "Run tool".to_string(),
+                    method: None,
+                },
+                None,
+                details,
+            ))
+        }
+        Action::SpawnCapability {
+            capability,
+            estimated_resources,
+        } => {
+            let mut details = vec![detail("Capability", capability.as_str())];
+            if let Some(process_count) = estimated_resources.process_count {
+                details.push(detail("Processes", process_count.to_string()));
+            }
+            Some((
+                capability.as_str().to_string(),
+                ApprovalPromptActionView {
+                    label: "Start tool".to_string(),
+                    method: None,
+                },
+                None,
+                details,
+            ))
+        }
+        Action::Network {
+            target,
+            method,
+            estimated_bytes,
+        } => {
+            let destination = network_destination(method, target.scheme, &target.host, target.port);
+            let mut details = vec![detail("Method", method_label(method))];
+            if let Some(bytes) = estimated_bytes {
+                details.push(detail("Estimated transfer", format_bytes(*bytes)));
+            }
+            Some((
+                "builtin.http".to_string(),
+                ApprovalPromptActionView {
+                    label: "Network request".to_string(),
+                    method: Some(*method),
+                },
+                Some(destination),
+                details,
+            ))
+        }
+        _ => None,
+    }
+}
+
+fn approval_scope_label(request: &ApprovalRequest) -> &'static str {
+    if request.reusable_scope.is_some() {
+        "Reusable grant"
+    } else {
+        "This request only"
+    }
+}
+
+fn network_destination(
+    method: &NetworkMethod,
+    scheme: NetworkScheme,
+    host: &str,
+    port: Option<u16>,
+) -> ApprovalPromptDestinationView {
+    let scheme = match scheme {
+        NetworkScheme::Http => "http",
+        NetworkScheme::Https => "https",
+    };
+    let authority = match port {
+        Some(port) => format!("{host}:{port}"),
+        None => host.to_string(),
+    };
+    let url = format!("{scheme}://{authority}");
+    ApprovalPromptDestinationView {
+        label: format!("{} {url}", method_label(method)),
+        url: Some(url),
+        domain: Some(host.to_string()),
+    }
+}
+
+fn detail(label: impl Into<String>, value: impl Into<String>) -> ApprovalPromptDetailView {
+    ApprovalPromptDetailView {
+        label: label.into(),
+        value: value.into(),
+    }
+}
+
+fn method_label(method: &NetworkMethod) -> String {
+    method.to_string().to_ascii_uppercase()
+}
+
+fn format_bytes(bytes: u64) -> String {
+    format!("{bytes} bytes")
+}
+
+fn non_empty_string(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
 fn gate_prompt(
     event: &TurnLifecycleEvent,
     gate_ref: String,
     headline: &'static str,
     allow_always: bool,
+) -> ProductOutboundPayload {
+    gate_prompt_with_context(event, gate_ref, headline, allow_always, None)
+}
+
+fn gate_prompt_with_context(
+    event: &TurnLifecycleEvent,
+    gate_ref: String,
+    headline: &'static str,
+    allow_always: bool,
+    approval_context: Option<ApprovalPromptContextView>,
 ) -> ProductOutboundPayload {
     ProductOutboundPayload::GatePrompt(GatePromptView {
         turn_run_id: event.run_id,
@@ -389,6 +632,7 @@ fn gate_prompt(
             .clone()
             .unwrap_or_else(|| "Resolve this gate to continue the run.".to_string()),
         allow_always,
+        approval_context,
     })
 }
 

--- a/crates/ironclaw_reborn_composition/src/projection/turn_events.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/turn_events.rs
@@ -429,9 +429,7 @@ async fn approval_gate_prompt(
             )
             .to_resource_scope();
             match store.get(&scope, request_id).await {
-                Ok(Some(record)) => {
-                    approval_context_for_request(&record.request, event.sanitized_reason.as_deref())
-                }
+                Ok(Some(record)) => approval_context_for_request(&record.request),
                 Ok(None) => None,
                 Err(error) => {
                     tracing::debug!(
@@ -454,10 +452,7 @@ async fn approval_gate_prompt(
     )
 }
 
-fn approval_context_for_request(
-    request: &ApprovalRequest,
-    display_reason: Option<&str>,
-) -> Option<ApprovalPromptContextView> {
+fn approval_context_for_request(request: &ApprovalRequest) -> Option<ApprovalPromptContextView> {
     let (tool_name, action, destination, details) =
         approval_action_context(request.action.as_ref())?;
     ApprovalPromptContextView::new(
@@ -468,7 +463,7 @@ fn approval_context_for_request(
             request.reusable_scope.is_some(),
         )
         .ok()?,
-        display_reason.and_then(non_empty_string),
+        non_empty_string(&request.reason),
         destination,
         details,
     )

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -2005,10 +2005,15 @@ pub async fn build_reborn_runtime(
     if trusted_laptop_access {
         append_trusted_laptop_access_audit(&audit_log, &thread_scope, &actor_user_id).await?;
     }
-    let projection_services = build_reborn_projection_services(
+    let mut projection_services = build_reborn_projection_services(
         Arc::clone(&event_log),
         validated_identity.reply_target_binding_ref.clone(),
     );
+    if let Some(local_runtime) = local_runtime {
+        projection_services = projection_services
+            .with_approval_requests(Arc::clone(&local_runtime.approval_requests)
+                as Arc<dyn ironclaw_run_state::ApprovalRequestStore>);
+    }
     let live_projection_publisher =
         projection_services.live_projection_publisher(actor_user_id.clone());
     if let Some(skill_activation_source) = &skill_activation_source {

--- a/crates/ironclaw_reborn_composition/src/slack_delivery.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_delivery.rs
@@ -696,6 +696,7 @@ fn slack_approval_gate_prompt_view(run_id: TurnRunId, gate_ref: &GateRef) -> Gat
         headline: "Approval needed".to_string(),
         body: "A step in the workflow requires your approval to resume.".to_string(),
         allow_always: is_approval_gate_ref(gate_ref),
+        approval_context: None,
     }
 }
 
@@ -1366,6 +1367,7 @@ async fn triggered_notification_for_state(
                     headline: "Approval needed".to_string(),
                     body: format!("Reply `approve {gate_ref_str}` to continue."),
                     allow_always: is_approval_gate_ref(gate_ref),
+                    approval_context: None,
                 }),
                 gate_ref_for_routing: Some(gate_ref_str),
             }))

--- a/crates/ironclaw_webui_v2/tests/webui_v2_schema_contract.rs
+++ b/crates/ironclaw_webui_v2/tests/webui_v2_schema_contract.rs
@@ -82,6 +82,7 @@ fn gate_prompt() -> GatePromptView {
         headline: "Approve action".to_string(),
         body: "Review the requested action.".to_string(),
         allow_always: true,
+        approval_context: None,
     }
 }
 

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/components/approval-card.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/components/approval-card.js
@@ -19,7 +19,7 @@ import { classifyRisk } from "../lib/approval-risk.js";
 
 export function ApprovalCard({ gate, onApprove, onDeny, onAlways }) {
   const t = useT();
-  const { toolName, description, parameters, allowAlways } = gate;
+  const { toolName, description, parameters, allowAlways, approvalDetails = [] } = gate;
   const [always, setAlways] = React.useState(false);
 
   const risk = React.useMemo(
@@ -51,11 +51,25 @@ export function ApprovalCard({ gate, onApprove, onDeny, onAlways }) {
           className="ml-auto"
         />
       </div>
-      <div className="mb-1 font-mono text-sm font-medium text-iron-100">${toolName}</div>
+      ${toolName &&
+      html`<div className="mb-1 break-all font-mono text-sm font-medium text-iron-100">${toolName}</div>`}
       ${description &&
-      html`<div className="mb-3 text-sm text-iron-200">${description}</div>`}
-      ${parameters &&
-      html`<pre className="mb-3 overflow-x-auto rounded-md bg-iron-950 p-2 font-mono text-xs text-iron-100">${parameters}</pre>`}
+      html`<div className="mb-3 break-words text-sm text-iron-200">${description}</div>`}
+      ${approvalDetails.length > 0
+        ? html`
+            <dl className="mb-3 max-h-56 overflow-y-auto rounded-md border border-iron-800 bg-iron-950/80 text-xs">
+              ${approvalDetails.map(
+                (detail) => html`
+                  <div className="grid gap-1 border-b border-iron-800/70 px-3 py-2 last:border-b-0 sm:grid-cols-[7rem_1fr]">
+                    <dt className="font-medium text-iron-400">${detail.label}</dt>
+                    <dd className="min-w-0 break-all font-mono text-iron-100">${detail.value}</dd>
+                  </div>
+                `,
+              )}
+            </dl>
+          `
+        : parameters &&
+          html`<pre className="mb-3 max-h-56 overflow-auto whitespace-pre-wrap break-all rounded-md bg-iron-950 p-2 font-mono text-xs text-iron-100">${parameters}</pre>`}
 
       ${allowAlways &&
       html`

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/gates.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/gates.js
@@ -7,16 +7,28 @@ export function gateFromEvent(eventType, prompt) {
   if (!prompt) return null;
 
   if (eventType === "gate") {
+    const approvalContext = prompt.approval_context || null;
+    const approvalDetails = approvalContext
+      ? approvalDetailsFromContext(approvalContext)
+      : [];
     return {
       kind: "gate",
       runId: prompt.turn_run_id,
       gateRef: prompt.gate_ref,
       headline: prompt.headline,
       body: prompt.body,
+      toolName: approvalContext?.tool_name || null,
+      description: approvalContext?.reason || prompt.body,
+      actionLabel: approvalContext?.action?.label || null,
+      destination: approvalContext?.destination || null,
+      approvalScope: approvalContext?.scope || null,
+      approvalDetails,
+      parameters: approvalDetails.length
+        ? approvalDetails.map((detail) => `${detail.label}: ${detail.value}`).join("\n")
+        : null,
       allowAlways: prompt.allow_always === true,
     };
   }
-
   if (eventType === "auth_required") {
     return {
       kind: "auth_required",
@@ -44,4 +56,21 @@ export function gateFromEvent(eventType, prompt) {
   }
 
   return null;
+}
+function approvalDetailsFromContext(context) {
+  const details = [];
+  if (context.action?.label) {
+    details.push({ label: "Action", value: context.action.label });
+  }
+  if (context.destination?.label) {
+    details.push({ label: "Destination", value: context.destination.label });
+  }
+  if (context.scope?.label) {
+    details.push({ label: "Scope", value: context.scope.label });
+  }
+  for (const detail of context.details || []) {
+    if (!detail?.label || detail.value == null) continue;
+    details.push({ label: detail.label, value: String(detail.value) });
+  }
+  return details;
 }

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/gates.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/gates.js
@@ -11,22 +11,26 @@ export function gateFromEvent(eventType, prompt) {
     const approvalDetails = approvalContext
       ? approvalDetailsFromContext(approvalContext)
       : [];
-    return {
+    const gate = {
       kind: "gate",
       runId: prompt.turn_run_id,
       gateRef: prompt.gate_ref,
       headline: prompt.headline,
       body: prompt.body,
-      toolName: approvalContext?.tool_name || null,
-      description: approvalContext?.reason || prompt.body,
-      actionLabel: approvalContext?.action?.label || null,
-      destination: approvalContext?.destination || null,
-      approvalScope: approvalContext?.scope || null,
+      allowAlways: prompt.allow_always === true,
+    };
+    if (!approvalContext) return gate;
+    return {
+      ...gate,
+      toolName: approvalContext.tool_name || null,
+      description: approvalContext.reason || prompt.body,
+      actionLabel: approvalContext.action?.label || null,
+      destination: approvalContext.destination || null,
+      approvalScope: approvalContext.scope || null,
       approvalDetails,
       parameters: approvalDetails.length
         ? approvalDetails.map((detail) => `${detail.label}: ${detail.value}`).join("\n")
         : null,
-      allowAlways: prompt.allow_always === true,
     };
   }
   if (eventType === "auth_required") {

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/gates.test.mjs
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/gates.test.mjs
@@ -63,7 +63,7 @@ test("gateFromEvent defaults missing always-allow affordance to false", () => {
 test("gateFromEvent maps approval context into readable approval card props", () => {
   const { gateFromEvent } = loadGates();
 
-  const gate = gateFromEvent("gate", {
+  const gate = plain(gateFromEvent("gate", {
     turn_run_id: "run-1",
     gate_ref: "gate:approval-1",
     headline: "Approval required",
@@ -84,7 +84,7 @@ test("gateFromEvent maps approval context into readable approval card props", ()
         { label: "Estimated network egress", value: "4096 bytes" },
       ],
     },
-  });
+  }));
 
   assert.equal(gate.allowAlways, true);
   assert.equal(gate.toolName, "builtin.http");

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/gates.test.mjs
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/gates.test.mjs
@@ -60,3 +60,46 @@ test("gateFromEvent defaults missing always-allow affordance to false", () => {
     },
   );
 });
+test("gateFromEvent maps approval context into readable approval card props", () => {
+  const { gateFromEvent } = loadGates();
+
+  const gate = gateFromEvent("gate", {
+    turn_run_id: "run-1",
+    gate_ref: "gate:approval-1",
+    headline: "Approval required",
+    body: "capability requires approval",
+    allow_always: true,
+    approval_context: {
+      tool_name: "builtin.http",
+      action: { label: "Run tool" },
+      scope: { label: "This request only", reusable: false },
+      reason: "approval required for Dispatch of builtin.http",
+      destination: {
+        label: "GET https://example.com",
+        url: "https://example.com",
+        domain: "example.com",
+      },
+      details: [
+        { label: "Capability", value: "builtin.http" },
+        { label: "Estimated network egress", value: "4096 bytes" },
+      ],
+    },
+  });
+
+  assert.equal(gate.allowAlways, true);
+  assert.equal(gate.toolName, "builtin.http");
+  assert.equal(gate.description, "approval required for Dispatch of builtin.http");
+  assert.equal(gate.destination.domain, "example.com");
+  assert.deepEqual(gate.approvalScope, {
+    label: "This request only",
+    reusable: false,
+  });
+  assert.deepEqual(gate.approvalDetails, [
+    { label: "Action", value: "Run tool" },
+    { label: "Destination", value: "GET https://example.com" },
+    { label: "Scope", value: "This request only" },
+    { label: "Capability", value: "builtin.http" },
+    { label: "Estimated network egress", value: "4096 bytes" },
+  ]);
+  assert.match(gate.parameters, /Estimated network egress: 4096 bytes/);
+});


### PR DESCRIPTION
## Summary
- Add optional structured approval context to `GatePromptView` and wire local approval-request lookup into the WebUI projection path.
- Enrich approval prompts with display-safe tool/action/scope details, including destination fields for network-shaped approval actions.
- Render approval details in the WebUI approval card with wrapping/scrolling for long values, and add frontend/backend coverage for the payload path.

## Root Cause
WebUI gate prompts were projected from turn state with only a generic headline/body, so `builtin.http` approval cards did not receive enough context to show the tool/action being approved.

## Validation
- `cargo fmt`
- `git diff --check`
- Attempted `cargo +1.92.0 test -p ironclaw_reborn_composition webui_event_stream_projects_approval_gate_prompt`, but the local sandbox failed before startup with `bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted`.
- Attempted Node-based checks, but `node` startup is currently blocked by the same sandbox loopback failure.

Closes #4701