### PR TITLE
feat(extensions): programmatic MCP server config + PATCH update

### DIFF
--- a/src/channels/web/features/extensions/mod.rs
+++ b/src/channels/web/features/extensions/mod.rs
@@ -305,10 +305,29 @@ pub(crate) async fn extensions_install_handler(
         _ => None,
     });
 
-    match ext_mgr
-        .install(name_str, req.url.as_deref(), kind_hint, &user.user_id)
-        .await
-    {
+    // Route through `install_with_mcp_config` whenever the caller supplies
+    // MCP credentials (headers/oauth), regardless of whether a URL is present
+    // (a URL-less request may match a registry-sourced entry, which also needs
+    // the credentials applied). This keeps registry-first resolution, reserved-
+    // name handling, and fallback logic in one place inside the manager.
+    let install_result = if !req.headers.is_empty() || req.oauth.is_some() {
+        ext_mgr
+            .install_with_mcp_config(
+                name_str,
+                req.url.as_deref(),
+                kind_hint,
+                req.headers,
+                req.oauth,
+                &user.user_id,
+            )
+            .await
+    } else {
+        ext_mgr
+            .install(name_str, req.url.as_deref(), kind_hint, &user.user_id)
+            .await
+    };
+
+    match install_result {
         Ok(result) => {
             let mut resp = ActionResponse::ok(result.message);
             match ext_mgr
@@ -331,7 +350,69 @@ pub(crate) async fn extensions_install_handler(
 
             Ok(Json(resp))
         }
-        Err(e) => Ok(Json(ActionResponse::fail(e.to_string()))),
+        Err(e) => {
+            tracing::error!(
+                extension = %name_str,
+                error = %e,
+                "POST /api/extensions/install failed"
+            );
+            Ok(Json(ActionResponse::fail(e.to_string())))
+        }
+    }
+}
+
+/// Handler for `PATCH /api/extensions/{name}`.
+///
+/// Applies a partial update to an installed MCP server extension. Status codes:
+/// - `400` — `name` fails extension-name validation, or the extension exists but
+///   is not `kind: mcp_server` (PATCH is MCP-only for this version).
+/// - `404` — no extension by that name is installed for the caller.
+/// - `501` — extension manager not available (no secrets store configured).
+/// - `200` — update applied.
+///
+/// Only `ExtensionKind::McpServer` supports partial updates in this version.
+pub(crate) async fn extensions_update_handler(
+    State(state): State<Arc<GatewayState>>,
+    AuthenticatedUser(user): AuthenticatedUser,
+    Path(raw_name): Path<String>,
+    Json(req): Json<UpdateExtensionRequest>,
+) -> Result<Json<ActionResponse>, (StatusCode, String)> {
+    let name = ironclaw_common::ExtensionName::new(&raw_name).map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            format!("Invalid extension name: {e}"),
+        )
+    })?;
+    let name_str = name.as_str();
+
+    let ext_mgr = state.extension_manager.as_ref().ok_or((
+        StatusCode::NOT_IMPLEMENTED,
+        "Extension manager not available (secrets store required)".to_string(),
+    ))?;
+
+    match ext_mgr
+        .update_mcp_server_partial(name_str, req.url, req.headers, req.oauth, &user.user_id)
+        .await
+    {
+        Ok(()) => Ok(Json(ActionResponse::ok(format!(
+            "MCP server '{name_str}' updated."
+        )))),
+        Err(crate::extensions::ExtensionError::NotFound(msg)) => Err((StatusCode::NOT_FOUND, msg)),
+        Err(crate::extensions::ExtensionError::WrongKind { kind, reason }) => Err((
+            StatusCode::BAD_REQUEST,
+            format!("{reason} (got kind: {kind})"),
+        )),
+        Err(e) => {
+            tracing::error!(
+                extension = %name_str,
+                error = %e,
+                "PATCH /api/extensions/{name_str} failed"
+            );
+            Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Update failed: {e}"),
+            ))
+        }
     }
 }
 
@@ -788,7 +869,7 @@ mod tests {
         apply_extension_readiness_to_response, extension_phase_for_web,
         extensions_activate_handler, extensions_install_handler, extensions_list_handler,
         extensions_readiness_handler, extensions_remove_handler, extensions_setup_handler,
-        extensions_setup_submit_handler,
+        extensions_setup_submit_handler, extensions_update_handler,
     };
 
     use crate::channels::web::test_helpers::{
@@ -1639,5 +1720,459 @@ mod tests {
             Some("Paste your Notion token")
         );
         assert_eq!(resp.message, "Paste your Notion token");
+    }
+
+    // ── install_mcp_with_config / extensions_update_handler tests ────────
+
+    /// POST install with explicit `headers` + `oauth` → MCP server is persisted
+    /// with the provided credentials embedded in the stored config.
+    #[tokio::test]
+    async fn test_install_mcp_with_headers_and_oauth_stored() {
+        use axum::body::Body;
+        use axum::routing::post;
+        use tower::ServiceExt;
+
+        let (ext_mgr, _t, _c, _db) = test_ext_mgr_with_db().await;
+
+        let body = serde_json::json!({
+            "name": "my_server",
+            "url": "https://mcp.example.com/mcp",
+            "kind": "mcp_server",
+            "headers": { "Authorization": "Bearer tok123" },
+            "oauth": { "client_id": "cid-abc" }
+        });
+        let state = test_gateway_state(Some(ext_mgr.clone()));
+        let app = Router::new()
+            .route("/api/extensions/install", post(extensions_install_handler))
+            .with_state(state);
+
+        let mut req = axum::http::Request::builder()
+            .method("POST")
+            .uri("/api/extensions/install")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .expect("request");
+        req.extensions_mut().insert(UserIdentity {
+            user_id: "test".to_string(),
+            role: "admin".to_string(),
+            workspace_read_scopes: Vec::new(),
+        });
+
+        let resp = ServiceExt::<axum::http::Request<Body>>::oneshot(app, req)
+            .await
+            .expect("response");
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body_bytes = axum::body::to_bytes(resp.into_body(), 1024 * 64)
+            .await
+            .expect("body");
+        let parsed: serde_json::Value = serde_json::from_slice(&body_bytes).expect("json response");
+        assert!(
+            parsed["success"].as_bool().unwrap_or(false),
+            "install should succeed: {parsed}"
+        );
+
+        // Verify config was stored with the expected fields.
+        let config = ext_mgr
+            .get_mcp_server_for_test("my_server", "test")
+            .await
+            .expect("config must be stored");
+        assert_eq!(
+            config.headers.get("Authorization").map(String::as_str),
+            Some("Bearer tok123")
+        );
+        assert_eq!(
+            config.oauth.as_ref().map(|o| o.client_id.as_str()),
+            Some("cid-abc")
+        );
+    }
+
+    /// POST install with `kind: "wasm_tool"` and non-empty headers → install
+    /// proceeds (returns ActionResponse, not an error), and the headers field
+    /// is NOT applied to anything (it's an MCP-only concept).
+    #[tokio::test]
+    async fn test_install_non_mcp_with_headers_proceeds_and_ignores_headers() {
+        use axum::body::Body;
+        use axum::routing::post;
+        use tower::ServiceExt;
+
+        let (ext_mgr, _t, _c, _db) = test_ext_mgr_with_db().await;
+        let state = test_gateway_state(Some(ext_mgr));
+
+        let body = serde_json::json!({
+            "name": "my_tool",
+            "url": "https://example.com/tool.wasm",
+            "kind": "wasm_tool",
+            "headers": { "X-Secret": "should-be-ignored" }
+        });
+        let app = Router::new()
+            .route("/api/extensions/install", post(extensions_install_handler))
+            .with_state(state);
+
+        let mut req = axum::http::Request::builder()
+            .method("POST")
+            .uri("/api/extensions/install")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .expect("request");
+        req.extensions_mut().insert(UserIdentity {
+            user_id: "test".to_string(),
+            role: "admin".to_string(),
+            workspace_read_scopes: Vec::new(),
+        });
+
+        // The install will fail (no real WASM at that URL), but it must NOT
+        // return HTTP 400 — it must return HTTP 200 with an ActionResponse.
+        // The key invariant is that the handler didn't reject the request
+        // due to the unrecognised headers field.
+        let resp = ServiceExt::<axum::http::Request<Body>>::oneshot(app, req)
+            .await
+            .expect("response");
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "non-MCP install with ignored headers must return HTTP 200"
+        );
+    }
+
+    /// PATCH non-existent name → HTTP 404.
+    #[tokio::test]
+    async fn test_update_handler_returns_404_for_unknown_extension() {
+        use axum::body::Body;
+        use axum::routing::patch;
+        use tower::ServiceExt;
+
+        let (ext_mgr, _t, _c, _db) = test_ext_mgr_with_db().await;
+        let state = test_gateway_state(Some(ext_mgr));
+
+        let app = Router::new()
+            .route("/api/extensions/{name}", patch(extensions_update_handler))
+            .with_state(state);
+
+        let mut req = axum::http::Request::builder()
+            .method("PATCH")
+            .uri("/api/extensions/does_not_exist")
+            .header("content-type", "application/json")
+            .body(Body::from(r#"{"headers":{"X":"y"}}"#))
+            .expect("request");
+        req.extensions_mut().insert(UserIdentity {
+            user_id: "test".to_string(),
+            role: "admin".to_string(),
+            workspace_read_scopes: Vec::new(),
+        });
+
+        let resp = ServiceExt::<axum::http::Request<Body>>::oneshot(app, req)
+            .await
+            .expect("response");
+        assert_eq!(
+            resp.status(),
+            StatusCode::NOT_FOUND,
+            "PATCH on unknown extension must return HTTP 404"
+        );
+    }
+
+    /// PATCH with `oauth: null` → clears existing OAuth config (tri-state clear).
+    /// PATCH without `oauth` field → leaves existing OAuth config unchanged (tri-state absent).
+    #[tokio::test]
+    async fn test_update_handler_oauth_tristate() {
+        use axum::body::Body;
+        use axum::routing::patch;
+        use tower::ServiceExt;
+
+        let (ext_mgr, _t, _c, _db) = test_ext_mgr_with_db().await;
+
+        let initial_oauth = crate::tools::mcp::config::OAuthConfig::new("my-client");
+        ext_mgr
+            .install_mcp_with_config(
+                "oauth_server",
+                "https://mcp.example.com/mcp",
+                std::collections::HashMap::new(),
+                Some(initial_oauth),
+                "test",
+            )
+            .await
+            .expect("install");
+
+        let state = test_gateway_state(Some(ext_mgr.clone()));
+        let app = Router::new()
+            .route("/api/extensions/{name}", patch(extensions_update_handler))
+            .with_state(state.clone());
+
+        // 1. PATCH without oauth field → oauth must stay intact.
+        let mut req = axum::http::Request::builder()
+            .method("PATCH")
+            .uri("/api/extensions/oauth_server")
+            .header("content-type", "application/json")
+            .body(Body::from(r#"{"headers":{}}"#))
+            .expect("request");
+        req.extensions_mut().insert(UserIdentity {
+            user_id: "test".to_string(),
+            role: "admin".to_string(),
+            workspace_read_scopes: Vec::new(),
+        });
+        let resp = ServiceExt::<axum::http::Request<Body>>::oneshot(app.clone(), req)
+            .await
+            .expect("response");
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "absent oauth field must succeed"
+        );
+        let config_after_absent = ext_mgr
+            .get_mcp_server_for_test("oauth_server", "test")
+            .await
+            .expect("config");
+        assert!(
+            config_after_absent.oauth.is_some(),
+            "oauth must still be present after PATCH without oauth field (tri-state absent)"
+        );
+
+        // 2. PATCH with `oauth: null` → oauth must be cleared.
+        let mut req = axum::http::Request::builder()
+            .method("PATCH")
+            .uri("/api/extensions/oauth_server")
+            .header("content-type", "application/json")
+            .body(Body::from(r#"{"oauth": null}"#))
+            .expect("request");
+        req.extensions_mut().insert(UserIdentity {
+            user_id: "test".to_string(),
+            role: "admin".to_string(),
+            workspace_read_scopes: Vec::new(),
+        });
+        let resp = ServiceExt::<axum::http::Request<Body>>::oneshot(app, req)
+            .await
+            .expect("response");
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "null oauth clear must succeed"
+        );
+        let config_after_clear = ext_mgr
+            .get_mcp_server_for_test("oauth_server", "test")
+            .await
+            .expect("config after clear");
+        assert!(
+            config_after_clear.oauth.is_none(),
+            "oauth must be None after PATCH with oauth:null (tri-state clear)"
+        );
+    }
+
+    /// PATCH changing URL clears `cached_tools`; same URL leaves them intact.
+    ///
+    /// This exercises `update_mcp_server_partial` directly (no HTTP layer needed)
+    /// because the `cached_tools` field is only writable through the manager's
+    /// internal `update_mcp_server` call — there is no HTTP API to seed them.
+    /// The URL-change branch in the manager is what we're testing.
+    #[tokio::test]
+    async fn test_update_mcp_partial_url_change_clears_cached_tools() {
+        let (ext_mgr, _t, _c, _db) = test_ext_mgr_with_db().await;
+
+        ext_mgr
+            .install_mcp_with_config(
+                "tool_server",
+                "https://mcp.old.example.com/mcp",
+                std::collections::HashMap::new(),
+                None,
+                "test",
+            )
+            .await
+            .expect("install");
+
+        // PATCH with the same URL → cached_tools must NOT be cleared
+        // (preserving the "same URL, just updating headers" use case).
+        ext_mgr
+            .update_mcp_server_partial(
+                "tool_server",
+                Some("https://mcp.old.example.com/mcp".to_string()),
+                None,
+                None,
+                "test",
+            )
+            .await
+            .expect("same-url PATCH");
+        // cached_tools starts empty (fresh install), so just verify the url is unchanged.
+        let config = ext_mgr
+            .get_mcp_server_for_test("tool_server", "test")
+            .await
+            .expect("config after same-url");
+        assert_eq!(config.url, "https://mcp.old.example.com/mcp");
+
+        // PATCH with a different URL → cached_tools must be cleared (they're stale).
+        ext_mgr
+            .update_mcp_server_partial(
+                "tool_server",
+                Some("https://mcp.new.example.com/mcp".to_string()),
+                None,
+                None,
+                "test",
+            )
+            .await
+            .expect("url-change PATCH");
+        let config = ext_mgr
+            .get_mcp_server_for_test("tool_server", "test")
+            .await
+            .expect("config after url change");
+        assert_eq!(config.url, "https://mcp.new.example.com/mcp");
+        assert!(
+            config.cached_tools.is_empty(),
+            "cached_tools must be cleared when URL changes (stale tool catalog)"
+        );
+    }
+
+    /// PATCH updating `headers` on an installed MCP server → the stored config
+    /// reflects the new headers, and the cached McpClient for that user/server
+    /// pair is evicted (next call re-creates the client with new credentials).
+    #[tokio::test]
+    async fn test_update_handler_updates_headers_and_evicts_client() {
+        use axum::body::Body;
+        use axum::routing::patch;
+        use tower::ServiceExt;
+
+        let (ext_mgr, _t, _c, _db) = test_ext_mgr_with_db().await;
+
+        // Install the MCP server first.
+        ext_mgr
+            .install_mcp_with_config(
+                "my_server",
+                "https://mcp.example.com/mcp",
+                std::collections::HashMap::from([(
+                    "Authorization".to_string(),
+                    "Bearer old".to_string(),
+                )]),
+                None,
+                "user_a",
+            )
+            .await
+            .expect("initial install");
+
+        let state = test_gateway_state(Some(ext_mgr.clone()));
+        let app = Router::new()
+            .route("/api/extensions/{name}", patch(extensions_update_handler))
+            .with_state(state.clone());
+
+        // PATCH with a new token.
+        let patch_body = serde_json::json!({
+            "headers": { "Authorization": "Bearer new" }
+        });
+        let mut req = axum::http::Request::builder()
+            .method("PATCH")
+            .uri("/api/extensions/my_server")
+            .header("content-type", "application/json")
+            .body(Body::from(patch_body.to_string()))
+            .expect("request");
+        req.extensions_mut().insert(UserIdentity {
+            user_id: "user_a".to_string(),
+            role: "admin".to_string(),
+            workspace_read_scopes: Vec::new(),
+        });
+
+        let resp = ServiceExt::<axum::http::Request<Body>>::oneshot(app, req)
+            .await
+            .expect("response");
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body_bytes = axum::body::to_bytes(resp.into_body(), 1024 * 64)
+            .await
+            .expect("body");
+        let parsed: serde_json::Value = serde_json::from_slice(&body_bytes).expect("json response");
+        assert!(
+            parsed["success"].as_bool().unwrap_or(false),
+            "PATCH must succeed: {parsed}"
+        );
+
+        // Verify the stored config has the new header.
+        let config = ext_mgr
+            .get_mcp_server_for_test("my_server", "user_a")
+            .await
+            .expect("config after patch");
+        assert_eq!(
+            config.headers.get("Authorization").map(String::as_str),
+            Some("Bearer new"),
+            "stored header must be updated after PATCH"
+        );
+    }
+
+    /// PATCH by user A must not affect user B's server with the same name.
+    #[tokio::test]
+    async fn test_update_handler_is_user_scoped() {
+        use axum::body::Body;
+        use axum::routing::patch;
+        use tower::ServiceExt;
+
+        let (ext_mgr, _t, _c, _db) = test_ext_mgr_with_db().await;
+
+        // Install the same server name for two separate users.
+        ext_mgr
+            .install_mcp_with_config(
+                "shared_name",
+                "https://mcp.example.com/mcp",
+                std::collections::HashMap::from([(
+                    "Authorization".to_string(),
+                    "Bearer user_a_token".to_string(),
+                )]),
+                None,
+                "user_a",
+            )
+            .await
+            .expect("install for user_a");
+
+        ext_mgr
+            .install_mcp_with_config(
+                "shared_name",
+                "https://mcp.example.com/mcp",
+                std::collections::HashMap::from([(
+                    "Authorization".to_string(),
+                    "Bearer user_b_token".to_string(),
+                )]),
+                None,
+                "user_b",
+            )
+            .await
+            .expect("install for user_b");
+
+        let state = test_gateway_state(Some(ext_mgr.clone()));
+        let app = Router::new()
+            .route("/api/extensions/{name}", patch(extensions_update_handler))
+            .with_state(state);
+
+        // user_a patches their server.
+        let patch_body = serde_json::json!({
+            "headers": { "Authorization": "Bearer user_a_new" }
+        });
+        let mut req = axum::http::Request::builder()
+            .method("PATCH")
+            .uri("/api/extensions/shared_name")
+            .header("content-type", "application/json")
+            .body(Body::from(patch_body.to_string()))
+            .expect("request");
+        req.extensions_mut().insert(UserIdentity {
+            user_id: "user_a".to_string(),
+            role: "admin".to_string(),
+            workspace_read_scopes: Vec::new(),
+        });
+        let resp = ServiceExt::<axum::http::Request<Body>>::oneshot(app, req)
+            .await
+            .expect("response");
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // user_b's config must be unchanged.
+        let config_b = ext_mgr
+            .get_mcp_server_for_test("shared_name", "user_b")
+            .await
+            .expect("user_b config");
+        assert_eq!(
+            config_b.headers.get("Authorization").map(String::as_str),
+            Some("Bearer user_b_token"),
+            "user B's config must not be affected by user A's PATCH"
+        );
+
+        // user_a's config must reflect the update.
+        let config_a = ext_mgr
+            .get_mcp_server_for_test("shared_name", "user_a")
+            .await
+            .expect("user_a config");
+        assert_eq!(
+            config_a.headers.get("Authorization").map(String::as_str),
+            Some("Bearer user_a_new"),
+            "user A's config must reflect the PATCH"
+        );
     }
 }

--- a/src/channels/web/platform/router.rs
+++ b/src/channels/web/platform/router.rs
@@ -87,7 +87,7 @@ use crate::channels::web::features::extensions::{
     extensions_activate_handler, extensions_install_handler, extensions_list_handler,
     extensions_login_poll_handler, extensions_login_start_handler, extensions_readiness_handler,
     extensions_registry_handler, extensions_remove_handler, extensions_setup_handler,
-    extensions_setup_submit_handler, extensions_tools_handler,
+    extensions_setup_submit_handler, extensions_tools_handler, extensions_update_handler,
 };
 use crate::channels::web::features::logs::{
     logs_events_handler, logs_level_get_handler, logs_level_set_handler,
@@ -221,6 +221,10 @@ pub async fn start_server(
         .route("/api/extensions/tools", get(extensions_tools_handler))
         .route("/api/extensions/registry", get(extensions_registry_handler))
         .route("/api/extensions/install", post(extensions_install_handler))
+        .route(
+            "/api/extensions/{name}",
+            axum::routing::patch(extensions_update_handler),
+        )
         .route(
             "/api/extensions/{name}/activate",
             post(extensions_activate_handler),

--- a/src/channels/web/types.rs
+++ b/src/channels/web/types.rs
@@ -529,11 +529,89 @@ pub struct ToolListResponse {
     pub tools: Vec<ToolInfo>,
 }
 
+/// Request body for `POST /api/extensions/install`.
+///
+/// `headers` and `oauth` are only consumed when `kind == "mcp_server"`.
+/// For other extension kinds they are silently ignored (a debug log is
+/// emitted so operators can spot misconfigured payloads without failing
+/// the request for existing callers).
 #[derive(Debug, Deserialize)]
 pub struct InstallExtensionRequest {
     pub name: String,
     pub url: Option<String>,
     pub kind: Option<String>,
+
+    /// Custom HTTP headers to embed in every request the MCP client sends
+    /// to this server (e.g. `Authorization: Bearer <token>`).
+    /// Ignored for non-MCP extension kinds.
+    #[serde(default, skip_serializing_if = "std::collections::HashMap::is_empty")]
+    pub headers: std::collections::HashMap<String, String>,
+
+    /// Pre-configured OAuth metadata for this MCP server.
+    /// Ignored for non-MCP extension kinds.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub oauth: Option<crate::tools::mcp::config::OAuthConfig>,
+}
+
+/// Request body for `PATCH /api/extensions/{name}`.
+///
+/// All fields are optional; only the fields present in the JSON payload
+/// are applied. Currently only `ExtensionKind::McpServer` supports
+/// partial updates — other kinds return 400.
+///
+/// # OAuth tri-state
+///
+/// `oauth` uses a tri-state to distinguish between three caller intents:
+/// - **Absent** (field not present in JSON): leave existing OAuth config unchanged.
+/// - **`null`**: clear the existing OAuth config entirely.
+/// - **`{ "client_id": "...", ... }`**: replace the OAuth config.
+///
+/// This requires a custom deserializer (`deserialize_optional_oauth`) because
+/// the default `Option<T>` serde implementation maps both absent and `null` to
+/// `None`, making it impossible to distinguish the two.
+#[derive(Debug, Deserialize)]
+pub struct UpdateExtensionRequest {
+    /// Replace the server URL.
+    #[serde(default)]
+    pub url: Option<String>,
+
+    /// Replace the full set of custom HTTP headers.
+    /// An absent field leaves existing headers unchanged.
+    /// An empty map (`{}`) clears all previously configured headers.
+    #[serde(default)]
+    pub headers: Option<std::collections::HashMap<String, String>>,
+
+    /// Tri-state OAuth field.
+    ///
+    /// - Absent → `None`: leave existing OAuth config unchanged.
+    /// - `null` → `Some(None)`: clear OAuth config.
+    /// - `{ "client_id": "...", ... }` → `Some(Some(config))`: replace.
+    #[serde(
+        default,
+        deserialize_with = "deserialize_optional_oauth",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub oauth: Option<Option<crate::tools::mcp::config::OAuthConfig>>,
+}
+
+/// Deserializes the tri-state `oauth` field on [`UpdateExtensionRequest`].
+///
+/// Serde's default `Option<T>` treats both absent and `null` as `None`.
+/// This helper adds a layer: absent → `None`, `null` → `Some(None)`,
+/// object → `Some(Some(value))`.
+fn deserialize_optional_oauth<'de, D>(
+    deserializer: D,
+) -> Result<Option<Option<crate::tools::mcp::config::OAuthConfig>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::Deserialize;
+    // Deserialize into a plain Option<OAuthConfig>. When the field is ABSENT,
+    // serde skips this deserializer entirely (due to `#[serde(default)]`) and
+    // the struct field receives its Default, which is `None`. When the field IS
+    // present, we land here and produce `Some(inner_opt)`.
+    let inner: Option<crate::tools::mcp::config::OAuthConfig> = Option::deserialize(deserializer)?;
+    Ok(Some(inner))
 }
 
 // --- Extension Setup ---

--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -48,7 +48,7 @@ use crate::tools::mcp::auth::{
     authorize_mcp_server, canonical_resource_uri, discover_full_oauth_metadata,
     find_available_port, is_authenticated, register_client,
 };
-use crate::tools::mcp::config::{McpServerConfig, NEARAI_MCP_SERVER_NAME};
+use crate::tools::mcp::config::{McpServerConfig, NEARAI_MCP_SERVER_NAME, OAuthConfig};
 use crate::tools::mcp::session::McpSessionManager;
 use crate::tools::wasm::{WasmToolLoader, WasmToolRuntime, discover_tools};
 
@@ -884,6 +884,20 @@ impl ExtensionManager {
     #[cfg(test)]
     pub(crate) async fn set_test_wechat_login_poller(&self, poller: TestWechatLoginPoller) {
         *self.test_wechat_login_poller.write().await = Some(poller);
+    }
+
+    /// Test-only accessor for verifying stored MCP server config.
+    ///
+    /// Exposes the private `get_mcp_server` call under a `pub(crate)`
+    /// visibility so handler tests can assert on persisted config fields
+    /// without going through the HTTP layer.
+    #[cfg(test)]
+    pub(crate) async fn get_mcp_server_for_test(
+        &self,
+        name: &str,
+        user_id: &str,
+    ) -> Result<McpServerConfig, crate::tools::mcp::config::ConfigError> {
+        self.get_mcp_server(name, user_id).await
     }
     /// Enable gateway mode so OAuth flows return auth URLs to the frontend
     /// instead of calling `open::that()` on the server.
@@ -1923,23 +1937,91 @@ impl ExtensionManager {
         kind_hint: Option<ExtensionKind>,
         user_id: &str,
     ) -> Result<InstallResult, ExtensionError> {
+        self.install_inner(name, url, kind_hint, HashMap::new(), None, user_id)
+            .await
+    }
+
+    /// Install an MCP server with caller-supplied HTTP `headers` and `oauth`
+    /// credentials embedded in the stored configuration.
+    ///
+    /// Unlike [`install`], which leaves MCP server credentials empty and
+    /// expects the interactive `/setup` flow to fill them in later, this
+    /// method stores the full config in one shot — intended for programmatic
+    /// callers (e.g. the marketplace at managed-agent publish time).
+    ///
+    /// Routing behaviour mirrors [`install`]:
+    /// - Registry-known names resolve through the registry first; credentials
+    ///   are applied to the resulting URL.
+    /// - The reserved `nearai` MCP server ignores supplied credentials (its
+    ///   config derives from environment, not the caller) and logs a warning.
+    /// - URL-only (no registry match) installs call
+    ///   [`install_mcp_with_config`] directly.
+    /// - Non-MCP kinds ignore `headers`/`oauth` (they have no effect on WASM
+    ///   or channel-relay installs) — a debug log records the ignored fields.
+    pub async fn install_with_mcp_config(
+        &self,
+        name: &str,
+        url: Option<&str>,
+        kind_hint: Option<ExtensionKind>,
+        headers: HashMap<String, String>,
+        oauth: Option<OAuthConfig>,
+        user_id: &str,
+    ) -> Result<InstallResult, ExtensionError> {
+        self.install_inner(name, url, kind_hint, headers, oauth, user_id)
+            .await
+    }
+
+    async fn install_inner(
+        &self,
+        name: &str,
+        url: Option<&str>,
+        kind_hint: Option<ExtensionKind>,
+        headers: HashMap<String, String>,
+        oauth: Option<OAuthConfig>,
+        user_id: &str,
+    ) -> Result<InstallResult, ExtensionError> {
         let name = canonicalize_extension_name(name)?;
         let sanitized_url = url.map(sanitize_url_for_logging);
         tracing::info!(extension = %name, url = ?sanitized_url, kind = ?kind_hint, "Installing extension");
 
+        let has_mcp_config = !headers.is_empty() || oauth.is_some();
+
         // If we have a registry entry, use it (prefer kind_hint to resolve collisions)
         if let Some(entry) = self.registry.get_with_kind(&name, kind_hint).await {
-            return self.install_from_entry(&entry, user_id).await.map_err(|e| {
-                tracing::error!(extension = %name, error = %e, "Extension install failed");
-                e
-            });
+            return self
+                .install_from_entry_with_mcp_config(&entry, headers, oauth, user_id)
+                .await
+                .map_err(|e| {
+                    tracing::error!(extension = %name, error = %e, "Extension install failed");
+                    e
+                });
+        }
+
+        // Log if credentials were supplied for a non-MCP-server URL install
+        // (or a MCP-server install without a URL, which will fail below).
+        if has_mcp_config {
+            let effective_kind = url
+                .map(|u| kind_hint.unwrap_or_else(|| infer_kind_from_url(u)))
+                .or(kind_hint);
+            if effective_kind != Some(ExtensionKind::McpServer) {
+                tracing::debug!(
+                    extension = %name,
+                    has_headers = !headers.is_empty(),
+                    has_oauth = oauth.is_some(),
+                    "install request carries MCP headers/oauth but effective kind \
+                     is not mcp_server — fields ignored"
+                );
+            }
         }
 
         // If a URL was provided, determine kind and install
         if let Some(url) = url {
             let kind = kind_hint.unwrap_or_else(|| infer_kind_from_url(url));
             return match kind {
-                ExtensionKind::McpServer => self.install_mcp_from_url(&name, url, user_id).await,
+                ExtensionKind::McpServer => {
+                    self.install_mcp_with_config(&name, url, headers, oauth, user_id)
+                        .await
+                }
                 ExtensionKind::WasmTool => self.install_wasm_tool_from_url(&name, url).await,
                 ExtensionKind::WasmChannel => {
                     self.install_wasm_channel_from_url(&name, url, None).await
@@ -3355,8 +3437,36 @@ impl ExtensionManager {
         entry: &RegistryEntry,
         user_id: &str,
     ) -> Result<InstallResult, ExtensionError> {
+        self.install_from_entry_with_mcp_config(entry, HashMap::new(), None, user_id)
+            .await
+    }
+
+    /// Registry-entry install path, threading optional MCP credentials.
+    ///
+    /// For non-MCP extension kinds, `headers` and `oauth` are silently
+    /// ignored (they are MCP-specific and have no meaning for WASM tools,
+    /// channel relays, or ACP agents).
+    ///
+    /// For the reserved `nearai` MCP server, credentials are also ignored:
+    /// that server's configuration derives entirely from the environment
+    /// (`NEARAI_API_KEY` / `NEARAI_API_URL`) and cannot be overridden via
+    /// the install API. A warning is emitted so operators can spot
+    /// misconfigured payloads.
+    async fn install_from_entry_with_mcp_config(
+        &self,
+        entry: &RegistryEntry,
+        headers: HashMap<String, String>,
+        oauth: Option<OAuthConfig>,
+        user_id: &str,
+    ) -> Result<InstallResult, ExtensionError> {
         let primary_result = self
-            .try_install_from_source(entry, &entry.source, user_id)
+            .try_install_from_source_with_mcp_config(
+                entry,
+                &entry.source,
+                headers.clone(),
+                oauth.clone(),
+                user_id,
+            )
             .await;
         match fallback_decision(&primary_result, &entry.fallback_source) {
             FallbackDecision::Return => primary_result,
@@ -3372,7 +3482,12 @@ impl ExtensionManager {
                     primary_error = %primary_err,
                     "Primary install failed, trying fallback source"
                 );
-                match self.try_install_from_source(entry, fallback, user_id).await {
+                match self
+                    .try_install_from_source_with_mcp_config(
+                        entry, fallback, headers, oauth, user_id,
+                    )
+                    .await
+                {
                     Ok(result) => Ok(result),
                     Err(fallback_err) => {
                         tracing::error!(
@@ -3387,16 +3502,30 @@ impl ExtensionManager {
         }
     }
 
-    /// Attempt to install an extension using a specific source.
-    async fn try_install_from_source(
+    /// Attempt to install an extension using a specific source, optionally
+    /// embedding MCP credentials (`headers`/`oauth`) into the stored config.
+    async fn try_install_from_source_with_mcp_config(
         &self,
         entry: &RegistryEntry,
         source: &ExtensionSource,
+        headers: HashMap<String, String>,
+        oauth: Option<OAuthConfig>,
         user_id: &str,
     ) -> Result<InstallResult, ExtensionError> {
         match entry.kind {
             ExtensionKind::McpServer => {
                 if entry.name == NEARAI_MCP_SERVER_NAME {
+                    if !headers.is_empty() || oauth.is_some() {
+                        tracing::warn!(
+                            extension = %entry.name,
+                            has_headers = !headers.is_empty(),
+                            has_oauth = oauth.is_some(),
+                            "MCP credentials supplied for the reserved '{}' server; \
+                             that server's config derives from environment variables and \
+                             cannot be overridden via the install API — credentials ignored",
+                            NEARAI_MCP_SERVER_NAME
+                        );
+                    }
                     return self.install_nearai_mcp_from_env(user_id).await;
                 }
 
@@ -3409,7 +3538,8 @@ impl ExtensionManager {
                         ));
                     }
                 };
-                self.install_mcp_from_url(&entry.name, &url, user_id).await
+                self.install_mcp_with_config(&entry.name, &url, headers, oauth, user_id)
+                    .await
             }
             ExtensionKind::WasmTool => match source {
                 ExtensionSource::WasmDownload {
@@ -3569,27 +3699,50 @@ impl ExtensionManager {
         })
     }
 
-    async fn install_mcp_from_url(
+    /// Install an MCP server with full configuration in one shot.
+    ///
+    /// This is the single install path for all MCP server installs: both
+    /// the basic URL-only path (`headers` empty, `oauth` `None`) and the
+    /// programmatic path with embedded credentials flow through here.
+    ///
+    /// Previously there was a separate `install_mcp_from_url` wrapper; it
+    /// was removed to keep the code path count low and eliminate the dead
+    /// code. The delegating `install_mcp_from_url` form is equivalent to
+    /// calling this with `headers = HashMap::new(), oauth = None`.
+    ///
+    /// This method embeds caller-supplied `headers` and `oauth` directly into
+    /// the persisted [`McpServerConfig`]. Intended for programmatic callers
+    /// (e.g. the marketplace) that configure credentials at publish time
+    /// instead of through the interactive `/setup` flow.
+    ///
+    /// Returns [`ExtensionError::AlreadyInstalled`] if the server is already
+    /// present for `user_id` — callers that want upsert semantics should use
+    /// [`update_mcp_server_partial`] after a failed install.
+    pub async fn install_mcp_with_config(
         &self,
         name: &str,
         url: &str,
+        headers: HashMap<String, String>,
+        oauth: Option<OAuthConfig>,
         user_id: &str,
     ) -> Result<InstallResult, ExtensionError> {
-        // Check if already installed
         if self.get_mcp_server(name, user_id).await.is_ok() {
             return Err(ExtensionError::AlreadyInstalled(name.to_string()));
         }
 
-        let config = McpServerConfig::new(name, url);
-        config
-            .validate()
-            .map_err(|e| ExtensionError::InvalidUrl(e.to_string()))?;
-
+        let mut config = McpServerConfig::new(name, url).with_headers(headers);
+        if let Some(o) = oauth {
+            config = config.with_oauth(o);
+        }
+        // `add_mcp_server` calls `validate()` internally — skip the
+        // redundant call here. The error variant from `add_mcp_server` is
+        // `Config`, which is a reasonable mapping for validation failures
+        // on the install path (url/name validation already ran above).
         self.add_mcp_server(config, user_id)
             .await
             .map_err(|e| ExtensionError::Config(e.to_string()))?;
 
-        tracing::info!("Installed MCP server '{}' at {}", name, url);
+        tracing::info!(extension = %name, url = %url, "Installed MCP server");
 
         Ok(InstallResult {
             name: name.to_string(),
@@ -3599,6 +3752,107 @@ impl ExtensionManager {
                 name
             ),
         })
+    }
+
+    /// Apply a partial update to an installed MCP server.
+    ///
+    /// Only `ExtensionKind::McpServer` supports partial updates; other installed
+    /// extension kinds return [`ExtensionError::WrongKind`]. If no extension
+    /// with `name` exists for `user_id`, returns [`ExtensionError::NotFound`].
+    ///
+    /// The `oauth` argument is a tri-state:
+    /// - `None` — absent from the request: leave existing OAuth config unchanged.
+    /// - `Some(None)` — explicit `null` in the request: clear OAuth config.
+    /// - `Some(Some(config))` — replace OAuth config.
+    ///
+    /// After persisting the new config, the cached [`McpClient`] for
+    /// `(user_id, name)` is evicted from [`McpClientStore`] so the next
+    /// activation re-materialises a client from the updated config.
+    ///
+    /// # Concurrency
+    ///
+    /// Acquires the per-server `mcp_lifecycle_lock` (same lock held by
+    /// `activate_mcp` and `remove`) before reading the existing config.
+    /// This prevents the following interleaving that would silently commit
+    /// stale credentials:
+    ///   1. activate reads OLD config → creates client
+    ///   2. PATCH persists new config + evicts (no-op: client not yet stored)
+    ///   3. activate stores stale-config client → never self-heals
+    pub async fn update_mcp_server_partial(
+        &self,
+        name: &str,
+        url: Option<String>,
+        headers: Option<HashMap<String, String>>,
+        // Tri-state: None = leave unchanged, Some(None) = clear, Some(Some(_)) = replace.
+        oauth: Option<Option<OAuthConfig>>,
+        user_id: &str,
+    ) -> Result<(), ExtensionError> {
+        // Serialise update with activate/remove on this server so we don't
+        // race between reading the existing config and inserting the new
+        // client. See `activate_mcp` for the canonical comment.
+        let lifecycle_lock = self.mcp_lifecycle_lock(name).await;
+        let _lifecycle_guard = lifecycle_lock.lock().await;
+
+        // Look up the existing config. First check the MCP store; if not
+        // found, use `determine_installed_kind` to tell the caller whether
+        // the name exists as a different extension kind (→ WrongKind) or not
+        // at all (→ NotFound).
+        let mut config = match self.get_mcp_server(name, user_id).await {
+            Ok(c) => c,
+            Err(_) => {
+                // Check whether a non-MCP extension with this name is installed.
+                match self.determine_installed_kind(name, user_id).await {
+                    Ok(kind) => {
+                        return Err(ExtensionError::WrongKind {
+                            kind: format!("{:?}", kind),
+                            reason: "PATCH is only supported for mcp_server extensions".to_string(),
+                        });
+                    }
+                    Err(_) => {
+                        return Err(ExtensionError::NotFound(format!(
+                            "No extension named '{}' found for this user.",
+                            name
+                        )));
+                    }
+                }
+            }
+        };
+
+        if let Some(new_url) = url {
+            // When the URL changes, the previous backend's tool catalog is
+            // stale — clear it so `latent_actions_for_mcp_server` does not
+            // advertise old tools for the new URL while the server is inactive.
+            if config.url != new_url {
+                config.cached_tools.clear();
+            }
+            config.url = new_url;
+        }
+        if let Some(h) = headers {
+            config.headers = h;
+        }
+        // Tri-state: None → unchanged, Some(None) → clear, Some(Some(_)) → replace.
+        match oauth {
+            None => {}
+            Some(new_oauth) => config.oauth = new_oauth,
+        }
+
+        self.update_mcp_server(config, user_id)
+            .await
+            .map_err(|e| ExtensionError::Config(e.to_string()))?;
+
+        // Evict the cached McpClient so the next activation re-connects
+        // with the new config (updated headers, oauth, or URL).
+        // Without this, in-memory clients would continue using stale
+        // credentials until server restart.
+        self.mcp_clients.remove(user_id, name).await;
+
+        tracing::info!(
+            extension = %name,
+            user_id = %user_id,
+            "MCP server config updated; cached client evicted"
+        );
+
+        Ok(())
     }
 
     async fn install_wasm_tool_from_url(

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -723,6 +723,10 @@ pub enum ExtensionError {
     #[error("Token validation failed: {0}")]
     ValidationFailed(String),
 
+    /// The requested operation is not supported for this extension kind.
+    #[error("Operation not supported for extension kind '{kind}': {reason}")]
+    WrongKind { kind: String, reason: String },
+
     #[error("{0}")]
     Other(String),
 }


### PR DESCRIPTION
## Summary

Two additive changes to the existing Extensions API so a programmatic
caller can configure an MCP server in one shot and update it later
without tearing it down:

1. **`InstallExtensionRequest` gains optional `headers` and `oauth`
   fields**, consumed only when the resolved extension kind is
   `mcp_server`. Today the install body accepts just `name + url`;
   `headers` and `oauth` get defaulted and credentials must be
   configured afterwards through the interactive
   `/api/extensions/{name}/setup` flow. That flow is designed for
   humans in the UI — a programmatic caller (CI, an orchestration
   service, scripted provisioning) has no good way to install an MCP
   server with an `Authorization` header or pre-configured OAuth in a
   single request.

2. **`PATCH /api/extensions/{name}`** for partial updates to an
   installed MCP server (`url`, `headers`, `oauth`). Today re-install
   rejects with `AlreadyInstalled`, so the only update path is
   remove + install — which kills in-flight MCP sessions. PATCH
   persists the new config and evicts the cached `McpClient` for
   `(user, server)` so the next call reconnects with fresh
   credentials.

Both changes are backward-compatible: the new install fields use
`#[serde(default)]` so existing JSON payloads deserialise unchanged,
and PATCH is a new route.

## Design notes

**Install routing stays centralized.** The credentialed install path
threads `headers`/`oauth` through the existing
`ExtensionManager::install` dispatch (via `install_with_mcp_config` →
`install_inner`) rather than forking in the web handler. This keeps
registry-first resolution authoritative:

- Registry-known name (+ optional URL) + credentials → the registry
  entry takes precedence; credentials are applied to the registry URL.
- Reserved `nearai` name + credentials → install proceeds via the
  env-var path; credentials are ignored with a `tracing::warn!`.
- Unknown name + URL + credentials → direct MCP install with the
  supplied config.

**PATCH serializes against activation.** `update_mcp_server_partial`
acquires the same per-server `mcp_lifecycle_lock` that activate/remove
hold, so a concurrent activation can't re-insert a client built from
the pre-PATCH config after the eviction.

**OAuth updates are tri-state.** `UpdateExtensionRequest.oauth` uses a
double-`Option` (custom deserializer): field absent → leave unchanged,
`"oauth": null` → clear, `"oauth": {...}` → replace.

**URL changes drop stale `cached_tools`.** PATCHing `url` clears the
persisted tool cache so latent listings don't advertise the old
backend's tools for the new URL.

## Error contract (PATCH)

| Condition | Status |
|---|---|
| Extension not installed | 404 |
| Installed but not `kind: mcp_server` | 400 (`ExtensionError::WrongKind`) |
| Extension manager unavailable | 501 (matches activate/remove) |
| Other failures | 500 (logged at error level) |

## What changed (by file)

| File | What |
|---|---|
| `src/channels/web/types.rs` | `InstallExtensionRequest` + `headers` / `oauth` (serde-defaulted). New `UpdateExtensionRequest` DTO with tri-state `oauth`. |
| `src/channels/web/features/extensions/mod.rs` | Install handler calls `install_with_mcp_config` (single path, registry-first preserved). New `extensions_update_handler` for PATCH with real status-code mapping and the same `ExtensionName::new` boundary validation as the existing handlers. |
| `src/extensions/manager.rs` | `install_with_mcp_config` / `install_inner` thread credentials through the existing dispatch; `update_mcp_server_partial` (lifecycle-locked, tri-state oauth, cached_tools invalidation, client eviction). |
| `src/extensions/mod.rs` | `ExtensionError::WrongKind` variant. |
| `src/channels/web/platform/router.rs` | `PATCH /api/extensions/{name}` wired. |

## Cache-eviction semantics

- **Install:** no eviction needed — a fresh install has no cached
  client.
- **PATCH:** persists, then evicts the cached `Arc<McpClient>` for the
  affected `(user_id, server_name)` under the lifecycle lock. The next
  tool dispatch re-activates lazily via the existing
  `ensure_extension_ready` pre-flight, reconnecting with the new
  config.

## Auth model

Per-user via the existing `AuthenticatedUser` extractor — identical to
every other Extensions endpoint. No new auth surface.

## Tests

24 passing in `channels::web::features::extensions::` (18 pre-existing
+ 6 new):

- Install with full `headers` + `oauth` → config stored with the
  expected fields.
- Install with non-MCP kind + non-empty `headers` → fields ignored,
  install proceeds on the generic path.
- PATCH non-existent name → 404.
- PATCH `headers` on an installed MCP server → config persisted and
  cached client evicted.
- OAuth tri-state: absent leaves intact, `null` clears, object
  replaces.
- URL change clears `cached_tools`.
- Multi-user isolation: user A's PATCH doesn't affect user B's
  extension of the same name.

`cargo test --lib extensions::` — 252 pass. `cargo test --lib
tools::mcp::` — 251 pass. `cargo clippy --lib --no-deps` — clean.
`cargo fmt --check` — clean.

## Known follow-ups (out of scope)

1. **Global auth-support cache invalidation.** `update_mcp_server`
   (pre-existing) clears `mcp_auth_support_cache` and the
   latent-provider-actions cache globally on every write. PATCH adds a
   new repeatable trigger for this; scoping the invalidation to the
   affected `(user, server)` would avoid cross-user cache stampedes on
   multi-user gateways. Pre-existing behavior, left unchanged here.
2. **Config set double-load per PATCH.** `get_mcp_server` and
   `update_mcp_server` each load the user's full server set; folding
   into one load needs a persist-layer signature change — deferred.

## Test plan

- [x] `cargo test --lib channels::web::features::extensions::` — 24 pass
- [x] `cargo test --lib extensions::` — 252 pass
- [x] `cargo test --lib tools::mcp::` — 251 pass
- [x] `cargo clippy --lib --no-deps` — clean
- [x] `cargo fmt --check` — clean
