### PR TITLE
[codex] Document Reborn operator observability backend contracts

### DIFF
--- a/docs/reborn/contracts/operator-observability-backends.md
+++ b/docs/reborn/contracts/operator-observability-backends.md
@@ -1,0 +1,66 @@
+# Reborn Operator Observability Backend Contracts
+
+Issues: #4595, #4597, #4598
+
+PR #4608 added the WebUI v2 route shells and product-workflow DTOs for operator status, logs, and service lifecycle. The remaining work is to wire concrete backend behavior behind those stable surfaces.
+
+## Operator status (#4595)
+
+`GET /api/webchat/v2/operator/status` should report a bounded, redacted snapshot of the current Reborn host.
+
+Required payload shape:
+
+- `state`: one of the stable `RebornOperatorStatusState` values.
+- `checks`: individual readiness checks with stable ids, severity, status, message, and remediation.
+- No raw host paths, secrets, tokens, command lines, provider payloads, or unbounded logs.
+
+Minimum backend inputs:
+
+- Reborn composition readiness state.
+- Runtime process binding/readiness state.
+- Storage/secrets configuration readiness, reported as booleans or stable diagnostic ids only.
+- LLM config availability, reported without API keys or provider error strings.
+
+## Operator logs (#4597)
+
+`GET /api/webchat/v2/operator/logs` should return bounded, cursor-paginated, redacted log entries.
+
+Required behavior:
+
+- Respect the facade limit clamp before hitting the backend.
+- Support optional level and target filters using stable enum/string values.
+- Return opaque cursors only; clients must not parse cursor internals.
+- Redact secrets, tokens, credentials, raw request bodies, host-sensitive paths, and provider payload details.
+- Return `service_unavailable` or an unavailable command-plane payload when no concrete backend is wired.
+
+Initial backend options:
+
+- In-process bounded ring buffer for current-process structured events.
+- Optional journald/systemd integration behind a separate service implementation.
+- File-tail support only if path allowlisting and redaction are enforced before response construction.
+
+## Service lifecycle (#4598)
+
+`POST /api/webchat/v2/operator/service` should expose lifecycle status and control only where the host deployment owns a manageable service unit.
+
+Required behavior:
+
+- `status` is safe in every deployment and may report `unsupported`.
+- `install`, `start`, and `stop` fail closed unless a concrete host service manager is explicitly wired.
+- Commands must not shell out through untrusted input.
+- Responses include stable state, message, and diagnostics without raw command output.
+
+Initial backend options:
+
+- Systemd service manager implementation behind an allowlisted unit name.
+- Local development no-op/status implementation that reports unsupported instead of pretending success.
+
+## Test requirements
+
+Implementation PRs must drive the caller path:
+
+- Service-facade tests for status/logs/service lifecycle mapping.
+- Router tests for query/body validation and rate-limit descriptor stability.
+- Redaction tests for log messages and lifecycle diagnostics.
+- Failure-path tests for unwired, unsupported, malformed, and backend-error cases.
+- Backend-specific tests for limit clamping, cursor stability, and command allowlisting.

--- a/docs/reborn/contracts/operator-observability-backends.md
+++ b/docs/reborn/contracts/operator-observability-backends.md
@@ -8,7 +8,8 @@ PR #4608 added the WebUI v2 route shells and product-workflow DTOs for operator 
 
 `GET /api/webchat/v2/operator/status` should report a bounded, redacted snapshot of the current Reborn host.
 
-Required payload shape:
+Required payload shape, nested under the `operator_status` field of the root
+`RebornOperatorCommandPlaneResponse`:
 
 - `state`: one of the stable `RebornOperatorStatusState` values.
 - `checks`: individual readiness checks with stable ids, severity, status, message, and remediation.
@@ -23,7 +24,9 @@ Minimum backend inputs:
 
 ## Operator logs (#4597)
 
-`GET /api/webchat/v2/operator/logs` should return bounded, cursor-paginated, redacted log entries.
+`GET /api/webchat/v2/operator/logs` should return bounded, cursor-paginated,
+redacted log entries nested under the `logs` field of the root
+`RebornOperatorCommandPlaneResponse`.
 
 Required behavior:
 
@@ -41,7 +44,10 @@ Initial backend options:
 
 ## Service lifecycle (#4598)
 
-`POST /api/webchat/v2/operator/service` should expose lifecycle status and control only where the host deployment owns a manageable service unit.
+`POST /api/webchat/v2/operator/service` should expose lifecycle status and
+control only where the host deployment owns a manageable service unit, with the
+payload nested under the `service_lifecycle` field of the root
+`RebornOperatorCommandPlaneResponse`.
 
 Required behavior:
 


### PR DESCRIPTION
## Summary

- Adds backend contract notes for the remaining #4608 follow-up work.
- Splits status (#4595), logs (#4597), and service lifecycle (#4598) into concrete backend expectations.
- Documents redaction, failure behavior, and caller-path test requirements.

## Impact

This does not close #4595/#4597/#4598 by itself. It is a draft contract PR to pin the next implementation slices while local patch-based Rust edits are blocked in this session.

## Validation

- Documentation-only change; no local tests run.
- Local file writes and pipe-based remote update commands are currently blocked by `bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted`.

Refs #4595.
Refs #4597.
Refs #4598.