### PR TITLE
Enable Slack for QA Railway Reborn

### DIFF
--- a/docker/reborn/config.production.toml
+++ b/docker/reborn/config.production.toml
@@ -37,6 +37,10 @@ model = "anthropic/claude-sonnet-4-5"
 api_key_env = "NEARAI_API_KEY"
 
 [slack]
-enabled = false
+enabled = true
+installation_id = "railway-qa-slack"
+team_id = "T0AQMKHM7LK"
+api_app_id = "A0BAJ5WQ0JU"
+user_id = "reborn-cli"
 signing_secret_env = "IRONCLAW_REBORN_SLACK_SIGNING_SECRET"
 bot_token_env = "IRONCLAW_REBORN_SLACK_BOT_TOKEN"

--- a/docker/reborn/config.toml
+++ b/docker/reborn/config.toml
@@ -25,6 +25,10 @@ model = "anthropic/claude-sonnet-4-5"
 api_key_env = "NEARAI_API_KEY"
 
 [slack]
-enabled = false
+enabled = true
+installation_id = "railway-qa-slack"
+team_id = "T0AQMKHM7LK"
+api_app_id = "A0BAJ5WQ0JU"
+user_id = "reborn-cli"
 signing_secret_env = "IRONCLAW_REBORN_SLACK_SIGNING_SECRET"
 bot_token_env = "IRONCLAW_REBORN_SLACK_BOT_TOKEN"


### PR DESCRIPTION
## Summary
- Enable Slack in the baked Reborn Docker configs used by Railway QA deployments.
- Add the QA Slack workspace/app identifiers while keeping bot token and signing secret env-only.

## Validation
- `cargo test -p ironclaw_reborn_cli --features webui-v2-beta,slack-v2-host-beta,postgres slack_host_beta_config -- --nocapture`

## Notes
- `team_id` and `api_app_id` are Slack identifiers, not secrets.
- Railway still needs `IRONCLAW_REBORN_SLACK_SIGNING_SECRET` and `IRONCLAW_REBORN_SLACK_BOT_TOKEN` set with rotated values.