### PR TITLE
[codex] Fix manual token runtime credential selection

### DIFF
--- a/crates/ironclaw_authorization/src/lib.rs
+++ b/crates/ironclaw_authorization/src/lib.rs
@@ -1170,7 +1170,7 @@ fn obligations_for_grant(
                         return None;
                     }
                 }
-                RuntimeCredentialRequirementSource::ProductAuthAccount { provider, .. } => {
+                RuntimeCredentialRequirementSource::ProductAuthAccount { provider, setup } => {
                     // Mirror SecretHandle: only mandate the obligation when the credential is
                     // required. An optional product-auth credential is skipped rather than
                     // injected so that a missing account does not hard-fail dispatch.
@@ -1178,6 +1178,7 @@ fn obligations_for_grant(
                         obligations.push(Obligation::InjectCredentialAccountOnce {
                             handle: credential.handle.clone(),
                             provider: provider.clone(),
+                            setup: setup.clone(),
                             provider_scopes: credential.provider_scopes.clone(),
                             requester_extension: descriptor.provider.clone(),
                         });

--- a/crates/ironclaw_authorization/tests/runtime_credentials_contract.rs
+++ b/crates/ironclaw_authorization/tests/runtime_credentials_contract.rs
@@ -219,6 +219,55 @@ async fn capability_access_resolves_product_auth_account_runtime_credentials() {
 }
 
 #[tokio::test]
+async fn capability_access_preserves_oauth_product_auth_account_setup() {
+    let slot = SecretHandle::new("github_runtime_token").unwrap();
+    let oauth_setup = RuntimeCredentialAccountSetup::OAuth {
+        scopes: vec!["repo".to_string()],
+    };
+    let descriptor = CapabilityDescriptor {
+        effects: vec![EffectKind::DispatchCapability, EffectKind::UseSecret],
+        runtime_credentials: vec![RuntimeCredentialRequirement {
+            source: RuntimeCredentialRequirementSource::ProductAuthAccount {
+                provider: RuntimeCredentialAccountProviderId::new("github").unwrap(),
+                setup: oauth_setup.clone(),
+            },
+            provider_scopes: vec!["repo".to_string()],
+            ..runtime_credential(slot.clone(), github_audience(), true)
+        }],
+        ..wasm_descriptor()
+    };
+    let grant = grant_for(
+        descriptor.id.clone(),
+        Principal::Extension(ExtensionId::new("caller").unwrap()),
+        vec![EffectKind::DispatchCapability, EffectKind::UseSecret],
+    );
+
+    let decision = GrantAuthorizer::new()
+        .authorize_dispatch(
+            &execution_context(CapabilitySet {
+                grants: vec![grant],
+            }),
+            &descriptor,
+            &ResourceEstimate::default(),
+        )
+        .await;
+
+    let Decision::Allow { obligations } = decision else {
+        panic!("expected allow decision, got {decision:?}");
+    };
+    assert_eq!(
+        obligations.as_slice(),
+        &[Obligation::InjectCredentialAccountOnce {
+            handle: slot,
+            provider: RuntimeCredentialAccountProviderId::new("github").unwrap(),
+            setup: oauth_setup,
+            provider_scopes: vec!["repo".to_string()],
+            requester_extension: ExtensionId::new("echo").unwrap(),
+        }]
+    );
+}
+
+#[tokio::test]
 async fn capability_access_denies_runtime_credentials_without_use_secret_effect() {
     let descriptor = CapabilityDescriptor {
         effects: vec![EffectKind::DispatchCapability],

--- a/crates/ironclaw_authorization/tests/runtime_credentials_contract.rs
+++ b/crates/ironclaw_authorization/tests/runtime_credentials_contract.rs
@@ -211,6 +211,7 @@ async fn capability_access_resolves_product_auth_account_runtime_credentials() {
         &[Obligation::InjectCredentialAccountOnce {
             handle: slot,
             provider: RuntimeCredentialAccountProviderId::new("github").unwrap(),
+            setup: Default::default(),
             provider_scopes: vec!["repo".to_string()],
             requester_extension: ExtensionId::new("echo").unwrap(),
         }]

--- a/crates/ironclaw_host_api/src/decision.rs
+++ b/crates/ironclaw_host_api/src/decision.rs
@@ -13,7 +13,8 @@ use std::collections::HashSet;
 use crate::ApprovalRequest;
 use crate::{
     CapabilityId, ExtensionId, HostApiError, MountView, NetworkPolicy, ResourceCeiling,
-    ResourceReservationId, RuntimeCredentialAccountProviderId, SecretHandle,
+    ResourceReservationId, RuntimeCredentialAccountProviderId, RuntimeCredentialAccountSetup,
+    SecretHandle,
 };
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -58,6 +59,8 @@ pub enum Obligation {
     InjectCredentialAccountOnce {
         handle: SecretHandle,
         provider: RuntimeCredentialAccountProviderId,
+        #[serde(default)]
+        setup: RuntimeCredentialAccountSetup,
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         provider_scopes: Vec<String>,
         requester_extension: ExtensionId,

--- a/crates/ironclaw_host_runtime/src/obligations.rs
+++ b/crates/ironclaw_host_runtime/src/obligations.rs
@@ -21,8 +21,8 @@ use ironclaw_host_api::{
     CapabilityDispatchResult, CapabilityId, CredentialStageError, DecisionSummary, EffectKind,
     ExtensionId, MountView, NetworkPolicy, Obligation, ProcessId, ResourceCeiling,
     ResourceEstimate, ResourceReservation, ResourceScope, ResourceUsage,
-    RuntimeCredentialAccountProviderId, RuntimeCredentialAuthRequirement, RuntimeHttpEgress,
-    SandboxQuota, SecretHandle,
+    RuntimeCredentialAccountProviderId, RuntimeCredentialAccountSetup,
+    RuntimeCredentialAuthRequirement, RuntimeHttpEgress, SandboxQuota, SecretHandle,
 };
 use ironclaw_network::NetworkHttpEgress;
 use ironclaw_processes::{ProcessError, ProcessRecord, ProcessStart, ProcessStore};
@@ -45,6 +45,7 @@ pub(crate) const DEFAULT_RUNTIME_SECRET_INJECTION_TTL: Duration = Duration::from
 pub struct RuntimeCredentialAccountRequest<'a> {
     pub scope: &'a ResourceScope,
     pub provider: &'a RuntimeCredentialAccountProviderId,
+    pub setup: &'a RuntimeCredentialAccountSetup,
     pub provider_scopes: &'a [String],
     pub requester_extension: &'a ExtensionId,
 }
@@ -1288,6 +1289,7 @@ impl BuiltinObligationHandler {
                 .resolve_access_secret(RuntimeCredentialAccountRequest {
                     scope: &request.context.resource_scope,
                     provider: obligation.provider,
+                    setup: obligation.setup,
                     provider_scopes: obligation.provider_scopes,
                     requester_extension: obligation.requester_extension,
                 })
@@ -1721,6 +1723,7 @@ fn secret_injection_handles(obligations: &[Obligation]) -> Vec<SecretHandle> {
 struct CredentialAccountInjectionObligation<'a> {
     handle: &'a SecretHandle,
     provider: &'a RuntimeCredentialAccountProviderId,
+    setup: &'a RuntimeCredentialAccountSetup,
     provider_scopes: &'a [String],
     requester_extension: &'a ExtensionId,
 }
@@ -1734,11 +1737,13 @@ fn credential_account_injection_obligations(
             Obligation::InjectCredentialAccountOnce {
                 handle,
                 provider,
+                setup,
                 provider_scopes,
                 requester_extension,
             } => Some(CredentialAccountInjectionObligation {
                 handle,
                 provider,
+                setup,
                 provider_scopes,
                 requester_extension,
             }),

--- a/crates/ironclaw_host_runtime/src/wasm_credentials.rs
+++ b/crates/ironclaw_host_runtime/src/wasm_credentials.rs
@@ -151,7 +151,7 @@ impl RuntimeCredentialRestager {
         request: &WasmRuntimeCredentialRequest,
         credential: &HostWasmRuntimeCredential,
     ) -> Result<(), CredentialStageError> {
-        let RuntimeCredentialRequirementSource::ProductAuthAccount { provider, .. } =
+        let RuntimeCredentialRequirementSource::ProductAuthAccount { provider, setup } =
             &credential.source
         else {
             return Ok(());
@@ -161,6 +161,7 @@ impl RuntimeCredentialRestager {
             .resolve_access_secret(RuntimeCredentialAccountRequest {
                 scope: &request.scope,
                 provider,
+                setup,
                 provider_scopes: &credential.provider_scopes,
                 requester_extension: &credential.requester_extension,
             })

--- a/crates/ironclaw_host_runtime/tests/builtin_obligation_handler_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/builtin_obligation_handler_contract.rs
@@ -1317,6 +1317,7 @@ async fn inject_credential_account_once_fails_when_no_resolver_wired() {
     let obligations = vec![Obligation::InjectCredentialAccountOnce {
         handle: ironclaw_host_api::SecretHandle::new("github_runtime_token").unwrap(),
         provider: ironclaw_host_api::RuntimeCredentialAccountProviderId::new("github").unwrap(),
+        setup: ironclaw_host_api::RuntimeCredentialAccountSetup::ManualToken,
         provider_scopes: Vec::new(),
         requester_extension: ironclaw_host_api::ExtensionId::new("github").unwrap(),
     }];
@@ -1357,6 +1358,7 @@ async fn inject_credential_account_once_fails_when_resolver_returns_auth_require
     let obligations = vec![Obligation::InjectCredentialAccountOnce {
         handle: ironclaw_host_api::SecretHandle::new("github_runtime_token").unwrap(),
         provider: ironclaw_host_api::RuntimeCredentialAccountProviderId::new("github").unwrap(),
+        setup: ironclaw_host_api::RuntimeCredentialAccountSetup::ManualToken,
         provider_scopes: provider_scopes.clone(),
         requester_extension: ironclaw_host_api::ExtensionId::new("github").unwrap(),
     }];
@@ -1419,6 +1421,7 @@ async fn inject_credential_account_once_resolves_and_stages_secret() {
     let obligations = vec![Obligation::InjectCredentialAccountOnce {
         handle: injection_slot.clone(),
         provider: ironclaw_host_api::RuntimeCredentialAccountProviderId::new("github").unwrap(),
+        setup: ironclaw_host_api::RuntimeCredentialAccountSetup::ManualToken,
         provider_scopes: Vec::new(),
         requester_extension: ironclaw_host_api::ExtensionId::new("github").unwrap(),
     }];
@@ -1471,6 +1474,7 @@ async fn inject_credential_account_once_reads_from_resolved_source_scope() {
     let obligations = vec![Obligation::InjectCredentialAccountOnce {
         handle: injection_slot,
         provider: ironclaw_host_api::RuntimeCredentialAccountProviderId::new("github").unwrap(),
+        setup: ironclaw_host_api::RuntimeCredentialAccountSetup::ManualToken,
         provider_scopes: Vec::new(),
         requester_extension: ironclaw_host_api::ExtensionId::new("github").unwrap(),
     }];
@@ -1512,6 +1516,7 @@ async fn inject_credential_account_once_maps_unknown_resolved_secret_to_auth_req
     let obligations = vec![Obligation::InjectCredentialAccountOnce {
         handle: ironclaw_host_api::SecretHandle::new("github_runtime_token").unwrap(),
         provider: ironclaw_host_api::RuntimeCredentialAccountProviderId::new("github").unwrap(),
+        setup: ironclaw_host_api::RuntimeCredentialAccountSetup::ManualToken,
         provider_scopes: Vec::new(),
         requester_extension: ironclaw_host_api::ExtensionId::new("github").unwrap(),
     }];

--- a/crates/ironclaw_host_runtime/tests/github_wasm_runtime_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/github_wasm_runtime_contract.rs
@@ -60,6 +60,9 @@ macro_rules! google_wasm_services_for_test {
                 Obligation::InjectCredentialAccountOnce {
                     handle: SecretHandle::new("google_runtime_token").unwrap(),
                     provider: RuntimeCredentialAccountProviderId::new("google").unwrap(),
+                    setup: ironclaw_host_api::RuntimeCredentialAccountSetup::OAuth {
+                        scopes: required_scopes.clone(),
+                    },
                     provider_scopes: required_scopes.clone(),
                     requester_extension: ExtensionId::new(package_id).unwrap(),
                 },
@@ -107,6 +110,7 @@ async fn host_runtime_services_routes_structured_github_wasm_search_through_runt
             Obligation::InjectCredentialAccountOnce {
                 handle: slot_handle,
                 provider: RuntimeCredentialAccountProviderId::new("github").unwrap(),
+                setup: ironclaw_host_api::RuntimeCredentialAccountSetup::ManualToken,
                 provider_scopes: Vec::new(),
                 requester_extension: ExtensionId::new("github").unwrap(),
             },
@@ -193,6 +197,7 @@ async fn host_runtime_services_restages_github_product_auth_for_multi_request_wa
             Obligation::InjectCredentialAccountOnce {
                 handle: slot_handle,
                 provider: RuntimeCredentialAccountProviderId::new("github").unwrap(),
+                setup: ironclaw_host_api::RuntimeCredentialAccountSetup::ManualToken,
                 provider_scopes: Vec::new(),
                 requester_extension: ExtensionId::new("github").unwrap(),
             },
@@ -284,6 +289,9 @@ async fn host_runtime_services_routes_google_drive_wasm_list_files_with_scoped_g
             Obligation::InjectCredentialAccountOnce {
                 handle: slot_handle,
                 provider: RuntimeCredentialAccountProviderId::new("google").unwrap(),
+                setup: ironclaw_host_api::RuntimeCredentialAccountSetup::OAuth {
+                    scopes: required_scopes.clone(),
+                },
                 provider_scopes: required_scopes.clone(),
                 requester_extension: ExtensionId::new("google-drive").unwrap(),
             },
@@ -550,6 +558,7 @@ async fn host_runtime_services_maps_github_wasm_input_errors_to_invalid_input() 
             Obligation::InjectCredentialAccountOnce {
                 handle: slot_handle,
                 provider: RuntimeCredentialAccountProviderId::new("github").unwrap(),
+                setup: ironclaw_host_api::RuntimeCredentialAccountSetup::ManualToken,
                 provider_scopes: Vec::new(),
                 requester_extension: ExtensionId::new("github").unwrap(),
             },
@@ -612,6 +621,7 @@ async fn host_runtime_services_missing_github_runtime_secret_blocks_on_auth() {
             Obligation::InjectCredentialAccountOnce {
                 handle: slot_handle,
                 provider: RuntimeCredentialAccountProviderId::new("github").unwrap(),
+                setup: ironclaw_host_api::RuntimeCredentialAccountSetup::ManualToken,
                 provider_scopes: Vec::new(),
                 requester_extension: ExtensionId::new("github").unwrap(),
             },

--- a/crates/ironclaw_host_runtime/tests/runtime_http_egress_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/runtime_http_egress_contract.rs
@@ -2409,6 +2409,7 @@ async fn mcp_http_client_reuses_product_auth_staged_credential_for_json_rpc_sess
                 Obligation::InjectCredentialAccountOnce {
                     handle: runtime_slot_handle.clone(),
                     provider: RuntimeCredentialAccountProviderId::new("mcp").unwrap(),
+                    setup: ironclaw_host_api::RuntimeCredentialAccountSetup::ManualToken,
                     provider_scopes: Vec::new(),
                     requester_extension: ExtensionId::new("mcp").unwrap(),
                 },

--- a/crates/ironclaw_product_workflow/src/reborn_services.rs
+++ b/crates/ironclaw_product_workflow/src/reborn_services.rs
@@ -388,6 +388,7 @@ impl OutboundPreferencesProductFacade for UnsupportedOutboundPreferencesProductF
 pub struct ExtensionCredentialStatusRequest {
     pub scope: AuthProductScope,
     pub provider: AuthProviderId,
+    pub setup: crate::LifecycleExtensionCredentialSetup,
     pub provider_scopes: Vec<ProviderScope>,
     pub requester_extension: ExtensionId,
 }

--- a/crates/ironclaw_product_workflow/src/reborn_services/extension_credentials.rs
+++ b/crates/ironclaw_product_workflow/src/reborn_services/extension_credentials.rs
@@ -174,6 +174,7 @@ fn credential_status_request(
     Ok(ExtensionCredentialStatusRequest {
         scope,
         provider: provider_for_requirement(requirement)?,
+        setup: requirement.setup.clone(),
         provider_scopes: provider_scopes_for_requirement(requirement)?,
         requester_extension: extension_id.clone(),
     })

--- a/crates/ironclaw_reborn_composition/src/product_auth_durable/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_durable/tests.rs
@@ -208,6 +208,7 @@ async fn filesystem_runtime_account_selection_matches_setup_invocation_account()
         .select_unique_configured_runtime_account(RuntimeCredentialAccountSelectionRequest::new(
             CredentialAccountSelectionRequest::new(runtime_scope.clone(), google_provider()),
             runtime_scope,
+            ironclaw_host_api::RuntimeCredentialAccountSetup::OAuth { scopes: Vec::new() },
             Vec::new(),
         ))
         .await
@@ -253,6 +254,7 @@ async fn filesystem_runtime_account_selection_matches_new_thread_reusable_accoun
         .resolve_access_secret(RuntimeCredentialAccountRequest {
             scope: &runtime_scope.resource,
             provider: &RuntimeCredentialAccountProviderId::new("google").unwrap(),
+            setup: &ironclaw_host_api::RuntimeCredentialAccountSetup::ManualToken,
             provider_scopes: &[],
             requester_extension: &ExtensionId::new("google-calendar").unwrap(),
         })
@@ -869,6 +871,9 @@ async fn filesystem_runtime_account_selection_tolerates_many_session_account_roo
         .select_unique_configured_runtime_account(RuntimeCredentialAccountSelectionRequest::new(
             CredentialAccountSelectionRequest::new(runtime_scope.clone(), google_provider()),
             runtime_scope,
+            ironclaw_host_api::RuntimeCredentialAccountSetup::OAuth {
+                scopes: vec!["drive.readonly".to_string()],
+            },
             vec![ProviderScope::new("drive.readonly").unwrap()],
         ))
         .await
@@ -913,6 +918,9 @@ async fn filesystem_runtime_account_selection_tolerates_many_account_records_per
         .select_unique_configured_runtime_account(RuntimeCredentialAccountSelectionRequest::new(
             CredentialAccountSelectionRequest::new(runtime_scope.clone(), google_provider()),
             runtime_scope,
+            ironclaw_host_api::RuntimeCredentialAccountSetup::OAuth {
+                scopes: vec!["drive.readonly".to_string()],
+            },
             vec![ProviderScope::new("drive.readonly").unwrap()],
         ))
         .await

--- a/crates/ironclaw_reborn_composition/src/product_auth_runtime_credentials.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_runtime_credentials.rs
@@ -7,6 +7,7 @@ use ironclaw_auth::{
     CredentialOwnership, ProviderScope,
 };
 use ironclaw_host_api::CredentialStageError;
+use ironclaw_host_api::RuntimeCredentialAccountSetup;
 use ironclaw_host_runtime::{
     RuntimeCredentialAccessSecret, RuntimeCredentialAccountRequest,
     RuntimeCredentialAccountResolver,
@@ -34,6 +35,7 @@ pub(crate) trait RuntimeCredentialAccountSelectionService: Send + Sync {
 pub(crate) struct RuntimeCredentialAccountSelectionRequest {
     lookup: CredentialAccountSelectionRequest,
     runtime_scope: AuthProductScope,
+    setup: RuntimeCredentialAccountSetup,
     provider_scopes: Vec<ProviderScope>,
 }
 
@@ -41,11 +43,13 @@ impl RuntimeCredentialAccountSelectionRequest {
     pub(crate) fn new(
         lookup: CredentialAccountSelectionRequest,
         runtime_scope: AuthProductScope,
+        setup: RuntimeCredentialAccountSetup,
         provider_scopes: Vec<ProviderScope>,
     ) -> Self {
         Self {
             lookup,
             runtime_scope,
+            setup,
             provider_scopes,
         }
     }
@@ -84,7 +88,11 @@ impl RuntimeCredentialAccountSelectionService for ProductAuthRuntimeCredentialAc
             .filter(|account| {
                 account.provider == request.lookup.provider
                     && account.status == CredentialAccountStatus::Configured
-                    && account_has_provider_scopes(account, &request.provider_scopes)
+                    && account_has_provider_scopes(
+                        account,
+                        &request.setup,
+                        &request.provider_scopes,
+                    )
                     && account_visible_from_runtime_scope(account, &request.runtime_scope)
             })
             .collect::<Vec<_>>();
@@ -152,6 +160,7 @@ impl RuntimeCredentialAccountResolver for ProductAuthRuntimeCredentialResolver {
                     CredentialAccountSelectionRequest::new(auth_scope, provider)
                         .for_extension(request.requester_extension.clone()),
                     AuthProductScope::new(request.scope.clone(), AuthSurface::Api),
+                    request.setup.clone(),
                     provider_scopes,
                 ),
             )
@@ -176,11 +185,19 @@ impl RuntimeCredentialAccountResolver for ProductAuthRuntimeCredentialResolver {
 
 fn account_has_provider_scopes(
     account: &CredentialAccount,
+    setup: &RuntimeCredentialAccountSetup,
     required_scopes: &[ProviderScope],
 ) -> bool {
+    if !credential_setup_requires_stored_scopes(setup) {
+        return true;
+    }
     required_scopes
         .iter()
         .all(|required| account.scopes.iter().any(|scope| scope == required))
+}
+
+fn credential_setup_requires_stored_scopes(setup: &RuntimeCredentialAccountSetup) -> bool {
+    matches!(setup, RuntimeCredentialAccountSetup::OAuth { .. })
 }
 
 fn account_visible_from_runtime_scope(
@@ -304,11 +321,55 @@ mod tests {
             .resolve_access_secret(RuntimeCredentialAccountRequest {
                 scope: &scope,
                 provider: &RuntimeCredentialAccountProviderId::new("github").unwrap(),
+                setup: &RuntimeCredentialAccountSetup::ManualToken,
                 provider_scopes: &[],
                 requester_extension: &ExtensionId::new("github").unwrap(),
             })
             .await
             .unwrap();
+
+        assert_eq!(resolved.handle, access_secret);
+        assert_eq!(resolved.scope, scope);
+    }
+
+    #[tokio::test]
+    async fn resolver_accepts_unscoped_github_manual_token_for_scoped_runtime_request() {
+        let accounts = Arc::new(InMemoryAuthProductServices::new());
+        let scope =
+            ResourceScope::local_default(UserId::new("alice").unwrap(), InvocationId::new())
+                .unwrap();
+        let auth_scope = AuthProductScope::new(scope.clone(), AuthSurface::Api);
+        let access_secret = SecretHandle::new("github_manual_access").unwrap();
+        accounts
+            .create_account(NewCredentialAccount {
+                scope: auth_scope,
+                provider: AuthProviderId::new("github").unwrap(),
+                label: CredentialAccountLabel::new("work github").unwrap(),
+                status: CredentialAccountStatus::Configured,
+                ownership: CredentialOwnership::UserReusable,
+                owner_extension: None,
+                granted_extensions: Vec::new(),
+                access_secret: Some(access_secret.clone()),
+                refresh_secret: None,
+                scopes: Vec::new(),
+            })
+            .await
+            .unwrap();
+        let resolver = ProductAuthRuntimeCredentialResolver::new(Arc::new(
+            ProductAuthRuntimeCredentialAccountSelector::new(accounts),
+        ));
+        let required_scopes = vec!["repo".to_string()];
+
+        let resolved = resolver
+            .resolve_access_secret(RuntimeCredentialAccountRequest {
+                scope: &scope,
+                provider: &RuntimeCredentialAccountProviderId::new("github").unwrap(),
+                setup: &RuntimeCredentialAccountSetup::ManualToken,
+                provider_scopes: &required_scopes,
+                requester_extension: &ExtensionId::new("github").unwrap(),
+            })
+            .await
+            .expect("GitHub PAT scopes are encoded in the token and cannot be introspected");
 
         assert_eq!(resolved.handle, access_secret);
         assert_eq!(resolved.scope, scope);
@@ -346,6 +407,7 @@ mod tests {
             .resolve_access_secret(RuntimeCredentialAccountRequest {
                 scope: &admin_scope,
                 provider: &RuntimeCredentialAccountProviderId::new("google").unwrap(),
+                setup: &RuntimeCredentialAccountSetup::ManualToken,
                 provider_scopes: &[],
                 requester_extension: &ExtensionId::new("gmail").unwrap(),
             })
@@ -388,6 +450,7 @@ mod tests {
             .resolve_access_secret(RuntimeCredentialAccountRequest {
                 scope: &runtime_scope,
                 provider: &RuntimeCredentialAccountProviderId::new("github").unwrap(),
+                setup: &RuntimeCredentialAccountSetup::ManualToken,
                 provider_scopes: &[],
                 requester_extension: &ExtensionId::new("github").unwrap(),
             })
@@ -432,6 +495,7 @@ mod tests {
             .resolve_access_secret(RuntimeCredentialAccountRequest {
                 scope: &runtime_scope,
                 provider: &RuntimeCredentialAccountProviderId::new("github").unwrap(),
+                setup: &RuntimeCredentialAccountSetup::ManualToken,
                 provider_scopes: &[],
                 requester_extension: &ExtensionId::new("github").unwrap(),
             })
@@ -476,6 +540,7 @@ mod tests {
             .resolve_access_secret(RuntimeCredentialAccountRequest {
                 scope: &runtime_scope,
                 provider: &RuntimeCredentialAccountProviderId::new("github").unwrap(),
+                setup: &RuntimeCredentialAccountSetup::ManualToken,
                 provider_scopes: &[],
                 requester_extension: &ExtensionId::new("github").unwrap(),
             })
@@ -519,6 +584,7 @@ mod tests {
             .resolve_access_secret(RuntimeCredentialAccountRequest {
                 scope: &runtime_scope,
                 provider: &RuntimeCredentialAccountProviderId::new("github").unwrap(),
+                setup: &RuntimeCredentialAccountSetup::ManualToken,
                 provider_scopes: &[],
                 requester_extension: &ExtensionId::new("github").unwrap(),
             })
@@ -542,6 +608,7 @@ mod tests {
             .resolve_access_secret(RuntimeCredentialAccountRequest {
                 scope: &scope,
                 provider: &RuntimeCredentialAccountProviderId::new("github").unwrap(),
+                setup: &RuntimeCredentialAccountSetup::ManualToken,
                 provider_scopes: &[],
                 requester_extension: &ExtensionId::new("github").unwrap(),
             })
@@ -584,11 +651,57 @@ mod tests {
             .resolve_access_secret(RuntimeCredentialAccountRequest {
                 scope: &scope,
                 provider: &RuntimeCredentialAccountProviderId::new("google").unwrap(),
+                setup: &RuntimeCredentialAccountSetup::OAuth {
+                    scopes: required_scopes.clone(),
+                },
                 provider_scopes: &required_scopes,
                 requester_extension: &ExtensionId::new("google-drive").unwrap(),
             })
             .await
             .unwrap_err();
+
+        assert_eq!(error, CredentialStageError::AuthRequired);
+    }
+
+    #[tokio::test]
+    async fn resolver_does_not_treat_unscoped_google_account_as_scoped() {
+        let accounts = Arc::new(InMemoryAuthProductServices::new());
+        let scope =
+            ResourceScope::local_default(UserId::new("alice").unwrap(), InvocationId::new())
+                .unwrap();
+        let auth_scope = AuthProductScope::new(scope.clone(), AuthSurface::Api);
+        accounts
+            .create_account(NewCredentialAccount {
+                scope: auth_scope,
+                provider: AuthProviderId::new("google").unwrap(),
+                label: CredentialAccountLabel::new("work google").unwrap(),
+                status: CredentialAccountStatus::Configured,
+                ownership: CredentialOwnership::UserReusable,
+                owner_extension: None,
+                granted_extensions: Vec::new(),
+                access_secret: Some(SecretHandle::new("google_manual_access").unwrap()),
+                refresh_secret: None,
+                scopes: Vec::new(),
+            })
+            .await
+            .unwrap();
+        let resolver = ProductAuthRuntimeCredentialResolver::new(Arc::new(
+            ProductAuthRuntimeCredentialAccountSelector::new(accounts),
+        ));
+        let required_scopes = vec!["https://www.googleapis.com/auth/drive".to_string()];
+
+        let error = resolver
+            .resolve_access_secret(RuntimeCredentialAccountRequest {
+                scope: &scope,
+                provider: &RuntimeCredentialAccountProviderId::new("google").unwrap(),
+                setup: &RuntimeCredentialAccountSetup::OAuth {
+                    scopes: required_scopes.clone(),
+                },
+                provider_scopes: &required_scopes,
+                requester_extension: &ExtensionId::new("google-drive").unwrap(),
+            })
+            .await
+            .expect_err("unscoped OAuth accounts must not satisfy scoped Google requirements");
 
         assert_eq!(error, CredentialStageError::AuthRequired);
     }
@@ -618,12 +731,14 @@ mod tests {
         let resolver = ProductAuthRuntimeCredentialResolver::new(Arc::new(
             ProductAuthRuntimeCredentialAccountSelector::new(accounts),
         ));
+        let required_scopes = vec!["repo".to_string()];
 
         let error = resolver
             .resolve_access_secret(RuntimeCredentialAccountRequest {
                 scope: &scope,
                 provider: &RuntimeCredentialAccountProviderId::new("github").unwrap(),
-                provider_scopes: &[],
+                setup: &RuntimeCredentialAccountSetup::ManualToken,
+                provider_scopes: &required_scopes,
                 requester_extension: &ExtensionId::new("github").unwrap(),
             })
             .await
@@ -662,6 +777,7 @@ mod tests {
             .resolve_access_secret(RuntimeCredentialAccountRequest {
                 scope: &scope,
                 provider: &RuntimeCredentialAccountProviderId::new("github").unwrap(),
+                setup: &RuntimeCredentialAccountSetup::ManualToken,
                 provider_scopes: &[],
                 requester_extension: &ExtensionId::new("github").unwrap(),
             })
@@ -729,6 +845,7 @@ mod tests {
             .resolve_access_secret(RuntimeCredentialAccountRequest {
                 scope: &scope,
                 provider: &RuntimeCredentialAccountProviderId::new("github").unwrap(),
+                setup: &RuntimeCredentialAccountSetup::ManualToken,
                 provider_scopes: &[],
                 requester_extension: &ExtensionId::new("github").unwrap(),
             })
@@ -786,6 +903,7 @@ mod tests {
             .resolve_access_secret(RuntimeCredentialAccountRequest {
                 scope: &scope,
                 provider: &RuntimeCredentialAccountProviderId::new("github").unwrap(),
+                setup: &RuntimeCredentialAccountSetup::ManualToken,
                 provider_scopes: &[],
                 requester_extension: &ExtensionId::new("github").unwrap(),
             })
@@ -850,6 +968,9 @@ mod tests {
             .resolve_access_secret(RuntimeCredentialAccountRequest {
                 scope: &scope,
                 provider: &RuntimeCredentialAccountProviderId::new("google").unwrap(),
+                setup: &RuntimeCredentialAccountSetup::OAuth {
+                    scopes: vec![gmail_scope.as_str().to_string()],
+                },
                 provider_scopes: &[gmail_scope.as_str().to_string()],
                 requester_extension: &ExtensionId::new("gmail").unwrap(),
             })
@@ -907,6 +1028,9 @@ mod tests {
             .resolve_access_secret(RuntimeCredentialAccountRequest {
                 scope: &scope,
                 provider: &RuntimeCredentialAccountProviderId::new("google").unwrap(),
+                setup: &RuntimeCredentialAccountSetup::OAuth {
+                    scopes: vec![google_scope.as_str().to_string()],
+                },
                 provider_scopes: &[google_scope.as_str().to_string()],
                 requester_extension: &requester,
             })
@@ -964,6 +1088,9 @@ mod tests {
             .resolve_access_secret(RuntimeCredentialAccountRequest {
                 scope: &scope,
                 provider: &RuntimeCredentialAccountProviderId::new("google").unwrap(),
+                setup: &RuntimeCredentialAccountSetup::OAuth {
+                    scopes: vec![google_scope.as_str().to_string()],
+                },
                 provider_scopes: &[google_scope.as_str().to_string()],
                 requester_extension: &requester,
             })

--- a/crates/ironclaw_reborn_composition/src/product_auth_runtime_credentials.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_runtime_credentials.rs
@@ -197,7 +197,10 @@ fn account_has_provider_scopes(
 }
 
 fn credential_setup_requires_stored_scopes(setup: &RuntimeCredentialAccountSetup) -> bool {
-    matches!(setup, RuntimeCredentialAccountSetup::OAuth { .. })
+    match setup {
+        RuntimeCredentialAccountSetup::OAuth { .. } => true,
+        RuntimeCredentialAccountSetup::ManualToken => false,
+    }
 }
 
 fn account_visible_from_runtime_scope(

--- a/crates/ironclaw_reborn_composition/src/product_auth_serve/mod.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_serve/mod.rs
@@ -1640,6 +1640,93 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn extension_google_oauth_start_binds_existing_configured_account_with_matching_scope() {
+        let shared = Arc::new(ironclaw_auth::InMemoryAuthProductServices::new());
+        let product_auth = Arc::new(RebornProductAuthServices::from_shared(
+            shared.clone(),
+            Arc::new(NoopDispatcher),
+        ));
+        let state = ProductAuthRouteState::new(
+            product_auth,
+            TenantId::new("tenant-alpha").expect("tenant"),
+            None,
+            None,
+        )
+        .with_google_oauth(
+            GoogleOAuthRouteConfig::new(
+                "google-client.apps.googleusercontent.com",
+                "http://127.0.0.1:3000/api/reborn/product-auth/oauth/google/callback",
+            )
+            .expect("google oauth route config"),
+        );
+        let app = product_auth_route_mount(state)
+            .protected
+            .layer(axum::Extension(test_caller()));
+        let flow_invocation_id = InvocationId::new();
+        let mut existing_resource = test_resource_scope();
+        existing_resource.invocation_id = flow_invocation_id;
+        let existing_scope = AuthProductScope::new(existing_resource, AuthSurface::Callback);
+        let account = shared
+            .create_account(NewCredentialAccount {
+                scope: existing_scope.clone(),
+                provider: AuthProviderId::new(GOOGLE_PROVIDER_ID).expect("provider"),
+                label: CredentialAccountLabel::new("google-drive google").expect("label"),
+                status: CredentialAccountStatus::Configured,
+                ownership: CredentialOwnership::UserReusable,
+                owner_extension: None,
+                granted_extensions: Vec::new(),
+                access_secret: Some(SecretHandle::new("google-drive-access").expect("secret")),
+                refresh_secret: Some(SecretHandle::new("google-drive-refresh").expect("secret")),
+                scopes: vec![
+                    ProviderScope::new("https://www.googleapis.com/auth/drive")
+                        .expect("provider scope"),
+                ],
+            })
+            .await
+            .expect("seed configured google account");
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/api/webchat/v2/extensions/google-drive/setup/oauth/start")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        serde_json::json!({
+                            "provider": GOOGLE_PROVIDER_ID,
+                            "account_label": "google-drive google",
+                            "scopes": ["https://www.googleapis.com/auth/drive"],
+                            "expires_at": (Utc::now() + ChronoDuration::minutes(5)).to_rfc3339(),
+                            "invocation_id": flow_invocation_id.to_string(),
+                        })
+                        .to_string(),
+                    ))
+                    .expect("request"),
+            )
+            .await
+            .expect("route response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("response body");
+        let json: serde_json::Value = serde_json::from_slice(&body).expect("start json");
+        let flow_id = AuthFlowId::from_uuid(
+            Uuid::parse_str(json["flow_id"].as_str().expect("flow id")).expect("flow uuid"),
+        );
+        let flow = shared
+            .get_flow(&existing_scope, flow_id)
+            .await
+            .expect("flow lookup")
+            .expect("flow");
+        let update_binding = flow
+            .update_binding
+            .expect("matching account should be bound for OAuth reconnect");
+        assert_eq!(update_binding.account_id, account.id);
+        assert_eq!(update_binding.ownership, CredentialOwnership::UserReusable);
+    }
+
+    #[tokio::test]
     async fn extension_google_oauth_start_continues_when_update_binding_lookup_is_unavailable() {
         let shared = Arc::new(ironclaw_auth::InMemoryAuthProductServices::new());
         let flow_manager: Arc<dyn AuthFlowManager> = shared.clone();

--- a/crates/ironclaw_reborn_composition/src/product_auth_serve/mod.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_serve/mod.rs
@@ -882,6 +882,12 @@ pub(super) async fn scoped_update_binding_for_requester(
             CredentialAccountSelectionRequest::new(scope.clone(), provider.clone())
                 .for_extension(requester_extension.clone()),
             scope.clone(),
+            ironclaw_host_api::RuntimeCredentialAccountSetup::OAuth {
+                scopes: provider_scopes
+                    .iter()
+                    .map(|scope| scope.as_str().to_string())
+                    .collect(),
+            },
             provider_scopes,
         ))
         .await;

--- a/crates/ironclaw_reborn_composition/src/webui_extension_credentials.rs
+++ b/crates/ironclaw_reborn_composition/src/webui_extension_credentials.rs
@@ -8,8 +8,8 @@ use ironclaw_auth::{
 };
 use ironclaw_product_workflow::{
     ExtensionCredentialSetupService, ExtensionCredentialStatusRequest,
-    ExtensionCredentialSubmitRequest, RebornServicesError, RebornServicesErrorCode,
-    RebornServicesErrorKind,
+    ExtensionCredentialSubmitRequest, LifecycleExtensionCredentialSetup, RebornServicesError,
+    RebornServicesErrorCode, RebornServicesErrorKind,
 };
 
 use crate::{
@@ -45,6 +45,7 @@ impl ExtensionCredentialSetupService for ProductAuthExtensionCredentialSetup {
                     CredentialAccountSelectionRequest::new(request.scope.clone(), request.provider)
                         .for_extension(request.requester_extension),
                     request.scope,
+                    runtime_credential_setup(request.setup),
                     request.provider_scopes,
                 ),
             )
@@ -136,6 +137,19 @@ fn map_auth_error(error: crate::RebornAuthProductError) -> RebornServicesError {
     }
 }
 
+fn runtime_credential_setup(
+    setup: LifecycleExtensionCredentialSetup,
+) -> ironclaw_host_api::RuntimeCredentialAccountSetup {
+    match setup {
+        LifecycleExtensionCredentialSetup::ManualToken => {
+            ironclaw_host_api::RuntimeCredentialAccountSetup::ManualToken
+        }
+        LifecycleExtensionCredentialSetup::OAuth { scopes } => {
+            ironclaw_host_api::RuntimeCredentialAccountSetup::OAuth { scopes }
+        }
+    }
+}
+
 fn invalid_auth_setup_request() -> RebornServicesError {
     services_error(
         RebornServicesErrorCode::InvalidRequest,
@@ -177,6 +191,7 @@ mod tests {
     };
     use ironclaw_product_workflow::{
         ExtensionCredentialSetupService, ExtensionCredentialStatusRequest,
+        LifecycleExtensionCredentialSetup,
     };
 
     use crate::{RebornAuthContinuationDispatcher, RebornProductAuthServices};
@@ -216,6 +231,7 @@ mod tests {
             .credential_status(ExtensionCredentialStatusRequest {
                 scope,
                 provider: AuthProviderId::new("notion").expect("provider"),
+                setup: LifecycleExtensionCredentialSetup::ManualToken,
                 provider_scopes: Vec::new(),
                 requester_extension: ExtensionId::new("notion").expect("extension"),
             })
@@ -254,6 +270,7 @@ mod tests {
             .credential_status(ExtensionCredentialStatusRequest {
                 scope,
                 provider: AuthProviderId::new("notion").expect("provider"),
+                setup: LifecycleExtensionCredentialSetup::ManualToken,
                 provider_scopes: Vec::new(),
                 requester_extension: ExtensionId::new("notion").expect("extension"),
             })
@@ -304,6 +321,9 @@ mod tests {
                 .credential_status(ExtensionCredentialStatusRequest {
                     scope: ui_scope.clone(),
                     provider: AuthProviderId::new("google").expect("provider"),
+                    setup: LifecycleExtensionCredentialSetup::OAuth {
+                        scopes: vec![scope.to_string()],
+                    },
                     provider_scopes: vec![ProviderScope::new(scope).expect("scope")],
                     requester_extension: ExtensionId::new(extension).expect("extension"),
                 })

--- a/tests/support/reborn/harness.rs
+++ b/tests/support/reborn/harness.rs
@@ -2624,6 +2624,7 @@ impl GithubHarnessAuthorizer {
                 Obligation::InjectCredentialAccountOnce {
                     handle: SecretHandle::new("github_runtime_token")?,
                     provider: RuntimeCredentialAccountProviderId::new("github")?,
+                    setup: ironclaw_host_api::RuntimeCredentialAccountSetup::ManualToken,
                     provider_scopes: Vec::new(),
                     requester_extension: ExtensionId::new("github")?,
                 },


### PR DESCRIPTION
## Summary

- Thread runtime credential setup mode (`ManualToken` vs `OAuth`) through authorization obligations, host runtime requests, WASM restaging, WebUI credential status, and product-auth selection.
- Allow manual-token credentials to satisfy runtime requests without stored provider-scope metadata, since PAT scopes cannot be introspected from stored account records.
- Keep OAuth credential selection strict by continuing to require stored account scopes to cover requested provider scopes.

## Root Cause

Manual-token accounts such as GitHub PATs are stored with empty provider-scope metadata. Runtime credential selection filtered every configured account by requested provider scopes, so a valid GitHub PAT could be treated as missing and the agent would ask the user for another token.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p ironclaw_reborn_composition product_auth_runtime_credentials`
- `cargo test -p ironclaw_reborn_composition webui_extension_credentials`
- `cargo test -p ironclaw_authorization --test runtime_credentials_contract`
- `cargo test -p ironclaw_host_runtime --test builtin_obligation_handler_contract`
- `cargo test -p ironclaw_host_runtime --test github_wasm_runtime_contract`
- `cargo test -p ironclaw_host_runtime --test runtime_http_egress_contract mcp_http_client_reuses_product_auth_staged_credential_for_json_rpc_session`