### PR TITLE
[codex] Fix NEAR context overflow classification

### DIFF
--- a/crates/ironclaw_llm/src/error.rs
+++ b/crates/ironclaw_llm/src/error.rs
@@ -99,12 +99,12 @@ pub(crate) fn is_context_length_error_message(lower: &str) -> bool {
         "too many tokens",
         "payload too large",
         "longer than the model's context length",
-        "prompt is too long",
     ];
 
-    CONTEXT_PATTERNS
-        .iter()
-        .any(|pattern| lower.contains(pattern))
+    parse_prompt_too_long_counts(lower).is_some()
+        || CONTEXT_PATTERNS
+            .iter()
+            .any(|pattern| lower.contains(pattern))
 }
 
 /// Try to extract token counts from a context-length error message.
@@ -142,14 +142,12 @@ pub(crate) fn parse_context_token_counts(lower: &str) -> (usize, usize) {
 }
 
 fn parse_prompt_too_long_counts(lower: &str) -> Option<(usize, usize)> {
-    let tail = lower.split_once("prompt is too long")?.1;
-    let mut numbers = tail
-        .split(|ch: char| !ch.is_ascii_digit())
-        .filter(|part| !part.is_empty())
-        .filter_map(|part| part.parse().ok())
-        .filter(|&n| n > 0);
-    let used = numbers.next()?;
-    let limit = numbers.next().unwrap_or(0);
+    let tail = lower.split_once("prompt is too long:")?.1.trim_start();
+    let (used, tail) = tail.split_once("tokens")?;
+    let used = used.trim().parse().ok().filter(|&n| n > 0)?;
+    let tail = tail.trim_start().strip_prefix('>')?.trim_start();
+    let (limit, _) = tail.split_once("maximum")?;
+    let limit = limit.trim().parse().ok().filter(|&n| n > 0)?;
     Some((used, limit))
 }
 
@@ -297,6 +295,18 @@ mod tests {
         let (used, limit) = parse_context_token_counts(msg);
         assert_eq!(used, 150000);
         assert_eq!(limit, 128000);
+    }
+
+    #[test]
+    fn prompt_too_long_requires_near_proxy_token_limit_shape() {
+        let malformed = r#"{"error":{"message":"prompt is too long: 234872 tokens"}}"#;
+        assert!(!is_context_length_error_message(malformed));
+        assert_eq!(parse_context_token_counts(malformed), (0, 0));
+
+        let unrelated = r#"{"error":{"message":"prompt is too long for this schema"}}"#;
+        assert!(!is_context_length_error_message(unrelated));
+        assert_eq!(parse_context_token_counts(unrelated), (0, 0));
+        assert!(context_length_error(400, unrelated).is_none());
     }
 
     // ------------------------------------------------------------------

--- a/crates/ironclaw_llm/src/error.rs
+++ b/crates/ironclaw_llm/src/error.rs
@@ -99,6 +99,7 @@ pub(crate) fn is_context_length_error_message(lower: &str) -> bool {
         "too many tokens",
         "payload too large",
         "longer than the model's context length",
+        "prompt is too long",
     ];
 
     CONTEXT_PATTERNS
@@ -111,9 +112,16 @@ pub(crate) fn is_context_length_error_message(lower: &str) -> bool {
 /// Handles patterns like:
 /// - "maximum context length is 128000 tokens. However, your messages resulted in 150000 tokens."
 /// - "The input (150000 tokens) is longer than the model's context length (128000 tokens)."
+/// - "prompt is too long: 150000 tokens > 128000 maximum"
 ///
 /// Returns `(0, 0)` if parsing fails.
 pub(crate) fn parse_context_token_counts(lower: &str) -> (usize, usize) {
+    // NEAR Anthropic-compatible proxy pattern:
+    // "prompt is too long: {used} tokens > {limit} maximum"
+    if let Some((used, limit)) = parse_prompt_too_long_counts(lower) {
+        return (used, limit);
+    }
+
     let numbers = token_count_numbers(lower);
     if numbers.len() < 2 {
         return (0, 0);
@@ -131,6 +139,18 @@ pub(crate) fn parse_context_token_counts(lower: &str) -> (usize, usize) {
     }
 
     (0, 0)
+}
+
+fn parse_prompt_too_long_counts(lower: &str) -> Option<(usize, usize)> {
+    let tail = lower.split_once("prompt is too long")?.1;
+    let mut numbers = tail
+        .split(|ch: char| !ch.is_ascii_digit())
+        .filter(|part| !part.is_empty())
+        .filter_map(|part| part.parse().ok())
+        .filter(|&n| n > 0);
+    let used = numbers.next()?;
+    let limit = numbers.next().unwrap_or(0);
+    Some((used, limit))
 }
 
 fn token_count_numbers(lower: &str) -> Vec<usize> {

--- a/crates/ironclaw_llm/src/nearai_chat.rs
+++ b/crates/ironclaw_llm/src/nearai_chat.rs
@@ -1217,6 +1217,18 @@ mod tests {
     }
 
     #[test]
+    fn context_length_error_detects_provider_prompt_too_long_wording() {
+        let body = r#"{"error":{"message":"Provider failed for model 'anthropic/claude-sonnet-4-5': prompt is too long: 234872 tokens > 200000 maximum","type":"invalid_request_error","param":null,"code":null}}"#;
+        match crate::error::context_length_error(400, body) {
+            Some(LlmError::ContextLengthExceeded { used, limit }) => {
+                assert_eq!(used, 234872);
+                assert_eq!(limit, 200000);
+            }
+            other => panic!("expected context-length error, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn context_length_error_does_not_treat_all_bad_requests_as_overflow() {
         let body = r#"{"error":{"message":"invalid tool schema"}}"#;
         assert!(crate::error::context_length_error(400, body).is_none());
@@ -1244,7 +1256,7 @@ mod tests {
                         "400 Bad Request",
                         serde_json::json!({
                             "error": {
-                                "message": "Provider failed: The input (314325 tokens) is longer than the model's context length (262144 tokens)."
+                                "message": "Provider failed for model 'anthropic/claude-sonnet-4-5': prompt is too long: 234872 tokens > 200000 maximum"
                             }
                         })
                         .to_string(),
@@ -1272,8 +1284,8 @@ mod tests {
 
         match err {
             LlmError::ContextLengthExceeded { used, limit } => {
-                assert_eq!(used, 314325);
-                assert_eq!(limit, 262144);
+                assert_eq!(used, 234872);
+                assert_eq!(limit, 200000);
             }
             other => panic!("expected context-length error, got {other:?}"),
         }

--- a/crates/ironclaw_llm/src/nearai_chat.rs
+++ b/crates/ironclaw_llm/src/nearai_chat.rs
@@ -1234,13 +1234,17 @@ mod tests {
         assert!(crate::error::context_length_error(400, body).is_none());
     }
 
-    #[tokio::test]
-    async fn complete_maps_context_overflow_http_400_to_context_length_exceeded() {
+    async fn assert_complete_maps_context_overflow_message(
+        message: &str,
+        expected_used: usize,
+        expected_limit: usize,
+    ) {
         use tokio::io::{AsyncReadExt, AsyncWriteExt};
         use tokio::net::TcpListener;
 
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let base_url = format!("http://{}", listener.local_addr().unwrap());
+        let message = message.to_string();
         tokio::spawn(async move {
             loop {
                 let Ok((mut socket, _)) = listener.accept().await else {
@@ -1256,7 +1260,7 @@ mod tests {
                         "400 Bad Request",
                         serde_json::json!({
                             "error": {
-                                "message": "Provider failed for model 'anthropic/claude-sonnet-4-5': prompt is too long: 234872 tokens > 200000 maximum"
+                                "message": message
                             }
                         })
                         .to_string(),
@@ -1284,11 +1288,31 @@ mod tests {
 
         match err {
             LlmError::ContextLengthExceeded { used, limit } => {
-                assert_eq!(used, 234872);
-                assert_eq!(limit, 200000);
+                assert_eq!(used, expected_used);
+                assert_eq!(limit, expected_limit);
             }
             other => panic!("expected context-length error, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn complete_maps_prompt_too_long_http_400_to_context_length_exceeded() {
+        assert_complete_maps_context_overflow_message(
+            "Provider failed for model 'anthropic/claude-sonnet-4-5': prompt is too long: 234872 tokens > 200000 maximum",
+            234872,
+            200000,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn complete_maps_longer_than_context_http_400_to_context_length_exceeded() {
+        assert_complete_maps_context_overflow_message(
+            "Provider failed: The input (314325 tokens) is longer than the model's context length (262144 tokens).",
+            314325,
+            262144,
+        )
+        .await;
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Classify NEAR/Anthropic-compatible `prompt is too long` 400 responses as `ContextLengthExceeded`.
- Parse the used and limit token counts from the new error shape.
- Add parser and provider-boundary regression coverage for the exact failure mode.

## Root Cause

NEAR returned an oversized prompt error as a generic HTTP 400 body:

`prompt is too long: 234872 tokens > 200000 maximum`

The existing context-length classifier did not recognize that wording, so the provider surfaced `RequestFailed`. The retry wrapper treats `RequestFailed` as transient, which retried the same oversized payload instead of allowing the dispatcher to compact and retry.

## Validation

- `cargo fmt --all`
- `cargo test -p ironclaw_llm context_length_error`
- `cargo test -p ironclaw_llm complete_maps_context_overflow_http_400_to_context_length_exceeded`
- `cargo test -p ironclaw_llm --lib`