### PR TITLE
Auth-gate resume: re-dispatch original capability call after OAuth completes

### DIFF
--- a/crates/ironclaw_agent_loop/src/executor.rs
+++ b/crates/ironclaw_agent_loop/src/executor.rs
@@ -27,9 +27,9 @@ use capability_helpers::{
     CapabilitySurfaceIndex, append_capability_error_ref, append_capability_result_ref,
     append_capability_safe_summary_ref, apply_capability_filter, capability_call_signature,
     capability_invocation_from_candidate, capability_is_visible, capability_summary,
-    gate_tool_result_summary, model_visible_capability_failure_observation,
-    pending_approval_resume_candidate, pending_auth_resume_candidate, push_call_signature_once,
-    push_completed_result,
+    clear_matching_pending_auth_resume, gate_tool_result_summary,
+    model_visible_capability_failure_observation, pending_approval_resume_candidate,
+    pending_auth_resume_candidate, push_call_signature_once, push_completed_result,
 };
 #[cfg(test)]
 use capability_helpers::{sanitize_result_ref_suffix, synthetic_provider_error_result_ref};

--- a/crates/ironclaw_agent_loop/src/executor.rs
+++ b/crates/ironclaw_agent_loop/src/executor.rs
@@ -28,7 +28,8 @@ use capability_helpers::{
     append_capability_safe_summary_ref, apply_capability_filter, capability_call_signature,
     capability_invocation_from_candidate, capability_is_visible, capability_summary,
     gate_tool_result_summary, model_visible_capability_failure_observation,
-    pending_approval_resume_candidate, push_call_signature_once, push_completed_result,
+    pending_approval_resume_candidate, pending_auth_resume_candidate, push_call_signature_once,
+    push_completed_result,
 };
 #[cfg(test)]
 use capability_helpers::{sanitize_result_ref_suffix, synthetic_provider_error_result_ref};

--- a/crates/ironclaw_agent_loop/src/executor/canonical.rs
+++ b/crates/ironclaw_agent_loop/src/executor/canonical.rs
@@ -298,7 +298,7 @@ impl DefaultExecutorPipeline {
                     state.iteration = state.iteration.saturating_add(1);
                 }
 
-                PromptStep::ResumeApproval(resume) => {
+                PromptStep::ResumeApproval(resume) | PromptStep::ResumeAuth(resume) => {
                     let resume = *resume;
                     pending_input_ack = resume.pending_input_ack;
                     pending_input_ack.ack(host).await?;

--- a/crates/ironclaw_agent_loop/src/executor/capabilities.rs
+++ b/crates/ironclaw_agent_loop/src/executor/capabilities.rs
@@ -202,6 +202,7 @@ impl ExecutorStage<CapabilityInput> for CapabilityStage {
                     CapabilityOutcome::Completed(result) => {
                         push_call_signature_once(&mut state, &mut signatures, &call)?;
                         clear_matching_pending_approval_resume(&mut state, &call);
+                        clear_matching_pending_auth_resume(&mut state, &call);
                         append_completed_capability_result(
                             ctx.host,
                             &mut state,
@@ -219,6 +220,7 @@ impl ExecutorStage<CapabilityInput> for CapabilityStage {
                     } => {
                         push_call_signature_once(&mut state, &mut signatures, &call)?;
                         clear_matching_pending_approval_resume(&mut state, &call);
+                        clear_matching_pending_auth_resume(&mut state, &call);
                         append_spawned_child_result(
                             ctx.host,
                             &mut state,
@@ -241,6 +243,7 @@ impl ExecutorStage<CapabilityInput> for CapabilityStage {
                     {
                         push_call_signature_once(&mut state, &mut signatures, &call)?;
                         clear_matching_pending_approval_resume(&mut state, &call);
+                        clear_matching_pending_auth_resume(&mut state, &call);
                         let result = CapabilityResultMessage {
                             result_ref,
                             safe_summary,
@@ -399,6 +402,7 @@ impl CapabilityStage {
         match outcome {
             CapabilityOutcome::Completed(result) => {
                 clear_matching_pending_approval_resume(&mut state, &call);
+                clear_matching_pending_auth_resume(&mut state, &call);
                 append_completed_capability_result(
                     ctx.host,
                     &mut state,
@@ -416,6 +420,7 @@ impl CapabilityStage {
                 ..
             } => {
                 clear_matching_pending_approval_resume(&mut state, &call);
+                clear_matching_pending_auth_resume(&mut state, &call);
                 append_spawned_child_result(
                     ctx.host,
                     &mut state,
@@ -565,6 +570,7 @@ impl CapabilityStage {
         capability_batch: &mut CapabilityBatchTurnSummary,
     ) -> Result<BatchStep, AgentLoopExecutorError> {
         clear_matching_pending_approval_resume(&mut state, &call);
+        clear_matching_pending_auth_resume(&mut state, &call);
         for _ in 0..MAX_CAPABILITY_RETRIES {
             match ctx
                 .planner
@@ -754,6 +760,19 @@ fn clear_matching_pending_approval_resume(
         .is_some_and(|resume| resume.capability_id == call.capability_id)
     {
         state.pending_approval_resume = None;
+    }
+}
+
+fn clear_matching_pending_auth_resume(
+    state: &mut LoopExecutionState,
+    call: &CapabilityCallCandidate,
+) {
+    if state
+        .pending_auth_resume
+        .as_ref()
+        .is_some_and(|resume| resume.capability_id == call.capability_id)
+    {
+        state.pending_auth_resume = None;
     }
 }
 

--- a/crates/ironclaw_agent_loop/src/executor/capabilities.rs
+++ b/crates/ironclaw_agent_loop/src/executor/capabilities.rs
@@ -25,9 +25,9 @@ use super::{
     append_capability_result_ref, append_capability_safe_summary_ref, batch_policy_kind,
     cancelled_exit, capability_batch_counts, capability_call_signature, capability_error_class,
     capability_failure_kind, capability_host_error, capability_invocation_from_candidate,
-    capability_is_visible, capability_summary, failed_exit, honor_retry_alteration,
-    model_visible_capability_failure_observation, push_call_signature_once, push_completed_result,
-    sanitized_strategy_summary,
+    capability_is_visible, capability_summary, clear_matching_pending_auth_resume, failed_exit,
+    honor_retry_alteration, model_visible_capability_failure_observation, push_call_signature_once,
+    push_completed_result, sanitized_strategy_summary,
 };
 
 #[derive(Debug, Default, Clone, Copy)]
@@ -764,19 +764,6 @@ fn clear_matching_pending_approval_resume(
         .is_some_and(|resume| resume.capability_id == call.capability_id)
     {
         state.pending_approval_resume = None;
-    }
-}
-
-fn clear_matching_pending_auth_resume(
-    state: &mut LoopExecutionState,
-    call: &CapabilityCallCandidate,
-) {
-    if state
-        .pending_auth_resume
-        .as_ref()
-        .is_some_and(|resume| resume.capability_id == call.capability_id)
-    {
-        state.pending_auth_resume = None;
     }
 }
 

--- a/crates/ironclaw_agent_loop/src/executor/capabilities.rs
+++ b/crates/ironclaw_agent_loop/src/executor/capabilities.rs
@@ -457,6 +457,10 @@ impl CapabilityStage {
                 credential_requirements,
                 ..
             } => {
+                // Clearing here keeps the clear-on-every-outcome invariant; for auth
+                // outcomes GateStage re-populates the record when it blocks.
+                clear_matching_pending_approval_resume(&mut state, &call);
+                clear_matching_pending_auth_resume(&mut state, &call);
                 GateStage
                     .process(
                         ctx,

--- a/crates/ironclaw_agent_loop/src/executor/capability_helpers.rs
+++ b/crates/ironclaw_agent_loop/src/executor/capability_helpers.rs
@@ -398,6 +398,19 @@ pub(super) fn gate_tool_result_summary(kind: GateKind, outcome: &'static str) ->
     format!("{gate} gate {outcome}")
 }
 
+pub(super) fn clear_matching_pending_auth_resume(
+    state: &mut LoopExecutionState,
+    call: &CapabilityCallCandidate,
+) {
+    if state
+        .pending_auth_resume
+        .as_ref()
+        .is_some_and(|resume| resume.capability_id == call.capability_id)
+    {
+        state.pending_auth_resume = None;
+    }
+}
+
 pub(super) fn push_completed_result(
     state: &mut LoopExecutionState,
     capability_id: &CapabilityId,
@@ -470,5 +483,31 @@ mod tests {
             Some(&2000)
         );
         assert_eq!(state.result_refs.len(), 3);
+    }
+
+    #[test]
+    fn pending_auth_resume_candidate_carries_non_empty_effective_capability_ids() {
+        use crate::state::PendingAuthResume;
+        use ironclaw_turns::run_profile::{CapabilityInputRef, CapabilitySurfaceVersion};
+
+        let cap_a = CapabilityId::new("test.cap_a").unwrap();
+        let cap_b = CapabilityId::new("test.cap_b").unwrap();
+        let resume = PendingAuthResume {
+            gate_ref: ironclaw_turns::LoopGateRef::new("gate:auth-test").unwrap(),
+            capability_id: cap_a.clone(),
+            surface_version: CapabilitySurfaceVersion::new("surface:v1").unwrap(),
+            input_ref: CapabilityInputRef::new("input:test").unwrap(),
+            effective_capability_ids: vec![cap_a.clone(), cap_b.clone()],
+            provider_replay: None,
+        };
+        let surface_version = CapabilitySurfaceVersion::new("surface:v1").unwrap();
+
+        let candidate = pending_auth_resume_candidate(&resume, surface_version);
+
+        assert_eq!(
+            candidate.effective_capability_ids,
+            vec![cap_a, cap_b],
+            "pending_auth_resume_candidate must propagate all effective_capability_ids"
+        );
     }
 }

--- a/crates/ironclaw_agent_loop/src/executor/capability_helpers.rs
+++ b/crates/ironclaw_agent_loop/src/executor/capability_helpers.rs
@@ -16,7 +16,9 @@ use ironclaw_turns::{
 };
 
 use crate::{
-    state::{CapabilityCallSignature, LoopExecutionState, PendingApprovalResume},
+    state::{
+        CapabilityCallSignature, LoopExecutionState, PendingApprovalResume, PendingAuthResume,
+    },
     strategies::{CapabilityCallSummary, CapabilityErrorSummary, CapabilityFilter, GateKind},
 };
 
@@ -39,6 +41,19 @@ pub(super) fn capability_invocation_from_candidate(
 
 pub(super) fn pending_approval_resume_candidate(
     resume: &PendingApprovalResume,
+    surface_version: CapabilitySurfaceVersion,
+) -> CapabilityCallCandidate {
+    CapabilityCallCandidate {
+        surface_version,
+        capability_id: resume.capability_id.clone(),
+        input_ref: resume.input_ref.clone(),
+        effective_capability_ids: resume.effective_capability_ids.clone(),
+        provider_replay: resume.provider_replay.clone(),
+    }
+}
+
+pub(super) fn pending_auth_resume_candidate(
+    resume: &PendingAuthResume,
     surface_version: CapabilitySurfaceVersion,
 ) -> CapabilityCallCandidate {
     CapabilityCallCandidate {

--- a/crates/ironclaw_agent_loop/src/executor/gates.rs
+++ b/crates/ironclaw_agent_loop/src/executor/gates.rs
@@ -75,17 +75,20 @@ impl ExecutorStage<GateInput> for GateStage {
                         input: resume.input,
                         estimate: resume.estimate,
                     });
-                state.pending_auth_resume = match kind {
-                    GateKind::Auth => Some(PendingAuthResume {
+                if matches!(kind, GateKind::Auth) {
+                    state.pending_auth_resume = Some(PendingAuthResume {
                         gate_ref: gate_ref.clone(),
                         capability_id: call.capability_id.clone(),
                         surface_version: call.surface_version.clone(),
                         input_ref: call.input_ref.clone(),
                         effective_capability_ids: call.effective_capability_ids.clone(),
                         provider_replay: call.provider_replay.clone(),
-                    }),
-                    _ => state.pending_auth_resume.take(),
-                };
+                    });
+                }
+                // Non-auth blocks do not invalidate a pending auth resume: a resource or
+                // approval gate can fire mid-re-dispatch, and clearing here would erase the
+                // record before it is consumed. Clearing on completion happens in the
+                // capability stage.
                 match CheckpointStage.cancel_if_requested(ctx, state).await? {
                     CancelCheck::Continue(next) => state = *next,
                     CancelCheck::Exit(exit) => return Ok(BatchStep::Exit(exit)),

--- a/crates/ironclaw_agent_loop/src/executor/gates.rs
+++ b/crates/ironclaw_agent_loop/src/executor/gates.rs
@@ -14,8 +14,9 @@ use crate::{
 
 use super::{
     AgentLoopExecutorError, BatchStep, CancelCheck, CheckpointStage, ExecutorStage, StageContext,
-    append_capability_result_ref, append_capability_safe_summary_ref, blocked_kind, exit_id,
-    failed_exit, gate_tool_result_summary, loop_gate_kind, push_completed_result,
+    append_capability_result_ref, append_capability_safe_summary_ref, blocked_kind,
+    clear_matching_pending_auth_resume, exit_id, failed_exit, gate_tool_result_summary,
+    loop_gate_kind, push_completed_result,
 };
 
 #[derive(Debug, Default, Clone, Copy)]
@@ -116,6 +117,10 @@ impl ExecutorStage<GateInput> for GateStage {
             }
             GateOutcome::SkipAndContinue { gate } => {
                 state.gate_state = gate;
+                // A skipped gate bypasses all capability-outcome clear sites, so a
+                // pending_auth_resume for this call would survive and trigger an
+                // infinite re-dispatch loop on the next prompt iteration.
+                clear_matching_pending_auth_resume(&mut state, &call);
                 append_capability_safe_summary_ref(
                     ctx.host,
                     &mut state,
@@ -131,6 +136,9 @@ impl ExecutorStage<GateInput> for GateStage {
             }
             GateOutcome::Abort { gate, failure_kind } => {
                 state.gate_state = gate;
+                // Clear any pending auth resume so a stale record does not persist
+                // into the Final checkpoint for an aborted capability.
+                clear_matching_pending_auth_resume(&mut state, &call);
                 append_capability_safe_summary_ref(
                     ctx.host,
                     &mut state,

--- a/crates/ironclaw_agent_loop/src/executor/gates.rs
+++ b/crates/ironclaw_agent_loop/src/executor/gates.rs
@@ -8,7 +8,7 @@ use ironclaw_turns::{
 };
 
 use crate::{
-    state::{CheckpointKind, LoopExecutionState, PendingApprovalResume},
+    state::{CheckpointKind, LoopExecutionState, PendingApprovalResume, PendingAuthResume},
     strategies::{GateKind, GateOutcome},
 };
 
@@ -75,6 +75,17 @@ impl ExecutorStage<GateInput> for GateStage {
                         input: resume.input,
                         estimate: resume.estimate,
                     });
+                state.pending_auth_resume = match kind {
+                    GateKind::Auth => Some(PendingAuthResume {
+                        gate_ref: gate_ref.clone(),
+                        capability_id: call.capability_id.clone(),
+                        surface_version: call.surface_version.clone(),
+                        input_ref: call.input_ref.clone(),
+                        effective_capability_ids: call.effective_capability_ids.clone(),
+                        provider_replay: call.provider_replay.clone(),
+                    }),
+                    _ => state.pending_auth_resume.take(),
+                };
                 match CheckpointStage.cancel_if_requested(ctx, state).await? {
                     CancelCheck::Continue(next) => state = *next,
                     CancelCheck::Exit(exit) => return Ok(BatchStep::Exit(exit)),

--- a/crates/ironclaw_agent_loop/src/executor/prompt.rs
+++ b/crates/ironclaw_agent_loop/src/executor/prompt.rs
@@ -60,13 +60,11 @@ pub(super) enum PromptStep {
     ResumeApproval(Box<ApprovalResumePromptOutput>),
     /// Re-dispatch an auth-gated capability call without a model turn.
     ///
-    /// Mirrors [`PromptStep::ResumeApproval`] but carries no approval resume token.
-    /// The capability stage's `take_if` on `pending_approval_resume` finds nothing,
-    /// so the invocation goes out as a plain re-invocation — exactly what we want.
-    ///
-    /// Uses [`ApprovalResumePromptOutput`] purely as a shared resume payload shape
-    /// (state + ack + surface + call). It carries no approval semantics or token —
-    /// the struct is reused for its fields, not for any approval meaning.
+    /// Emitted when `pending_auth_resume` is set on the incoming state. The original
+    /// capability call is re-dispatched as a plain invocation (no approval token).
+    /// The `pending_auth_resume` slot is cleared at every capability-outcome site
+    /// (Completed, SpawnedChild, AuthRequired, error/retry paths) and at gate
+    /// SkipAndContinue/Abort outcomes — never consumed via `take_if` here.
     ResumeAuth(Box<ApprovalResumePromptOutput>),
     Exit(LoopExit),
     /// Compaction-only turn: PromptCompactionStep ran (forced by the

--- a/crates/ironclaw_agent_loop/src/executor/prompt.rs
+++ b/crates/ironclaw_agent_loop/src/executor/prompt.rs
@@ -22,7 +22,7 @@ use crate::strategies::CompactionDecision;
 use super::{
     AgentLoopExecutorError, CancelCheck, CheckpointStage, ExecutorStage, HostStage,
     PendingInputAck, StageContext, apply_capability_filter, cancelled_exit, debug_host_unavailable,
-    failed_exit, pending_approval_resume_candidate,
+    failed_exit, pending_approval_resume_candidate, pending_auth_resume_candidate,
 };
 
 #[derive(Debug, Default, Clone, Copy)]
@@ -58,6 +58,12 @@ pub(super) struct ApprovalResumePromptOutput {
 pub(super) enum PromptStep {
     Prepared(Box<PromptOutput>),
     ResumeApproval(Box<ApprovalResumePromptOutput>),
+    /// Re-dispatch an auth-gated capability call without a model turn.
+    ///
+    /// Mirrors [`PromptStep::ResumeApproval`] but carries no approval resume token.
+    /// The capability stage's `take_if` on `pending_approval_resume` finds nothing,
+    /// so the invocation goes out as a plain re-invocation — exactly what we want.
+    ResumeAuth(Box<ApprovalResumePromptOutput>),
     Exit(LoopExit),
     /// Compaction-only turn: PromptCompactionStep ran (forced by the
     /// `skip_model_this_iteration` flag), no prompt was assembled, no
@@ -239,6 +245,19 @@ impl<'a> PromptPlanningPipeline<'a> {
         if let Some(resume) = self.state.pending_approval_resume.as_ref() {
             let call = pending_approval_resume_candidate(resume, surface.version.clone());
             return Ok(PromptStep::ResumeApproval(Box::new(
+                ApprovalResumePromptOutput {
+                    state: self.state,
+                    pending_input_ack: self.pending_input_ack,
+                    surface,
+                    call,
+                },
+            )));
+        }
+        // Auth-resume check runs after approval (approval takes priority; both set
+        // simultaneously is impossible today, but this ordering is defensive).
+        if let Some(resume) = self.state.pending_auth_resume.as_ref() {
+            let call = pending_auth_resume_candidate(resume, surface.version.clone());
+            return Ok(PromptStep::ResumeAuth(Box::new(
                 ApprovalResumePromptOutput {
                     state: self.state,
                     pending_input_ack: self.pending_input_ack,

--- a/crates/ironclaw_agent_loop/src/executor/prompt.rs
+++ b/crates/ironclaw_agent_loop/src/executor/prompt.rs
@@ -63,6 +63,10 @@ pub(super) enum PromptStep {
     /// Mirrors [`PromptStep::ResumeApproval`] but carries no approval resume token.
     /// The capability stage's `take_if` on `pending_approval_resume` finds nothing,
     /// so the invocation goes out as a plain re-invocation — exactly what we want.
+    ///
+    /// Uses [`ApprovalResumePromptOutput`] purely as a shared resume payload shape
+    /// (state + ack + surface + call). It carries no approval semantics or token —
+    /// the struct is reused for its fields, not for any approval meaning.
     ResumeAuth(Box<ApprovalResumePromptOutput>),
     Exit(LoopExit),
     /// Compaction-only turn: PromptCompactionStep ran (forced by the

--- a/crates/ironclaw_agent_loop/src/executor/tests.rs
+++ b/crates/ironclaw_agent_loop/src/executor/tests.rs
@@ -4137,3 +4137,195 @@ async fn resume_with_still_missing_credentials_blocks_again_without_model_turn()
         "phase 2 pending_auth_resume.gate_ref must equal the refreshed phase-2 gate ref"
     );
 }
+
+#[tokio::test]
+async fn gate_stage_skip_and_continue_clears_stale_pending_auth_resume() {
+    // Bug scenario: auth record stored for capability A → resume re-dispatches A
+    // → re-dispatch returns ApprovalRequired → GateStage runs with kind Approval
+    // → planner returns SkipAndContinue. Without the fix, pending_auth_resume
+    // for A survives, and the next prompt iteration re-dispatches A again —
+    // potential infinite re-dispatch loop with no model turn.
+    //
+    // This test exercises GateStage directly (not the full executor) so we can
+    // seed pending_auth_resume before the gate runs, mirroring the existing
+    // gate_stage_skips_and_continues_records_skipped_summary pattern.
+    let family = family_with_gate_outcome(GateOutcome::SkipAndContinue {
+        gate: empty_gate_state(),
+    });
+    let host = MockHost::new(Vec::new());
+    let ctx = StageContext {
+        planner: family.planner(),
+        host: &host,
+    };
+    // Seed a pending_auth_resume for the same capability that will be dispatched
+    // through GateStage — this simulates the state reloaded from a BeforeBlock
+    // checkpoint that was written when the auth gate first blocked.
+    let seeded_gate_ref = LoopGateRef::new("gate:auth-original").expect("valid");
+    let mut state = LoopExecutionState::initial_for_run(host.run_context());
+    state.pending_auth_resume = Some(PendingAuthResume {
+        gate_ref: seeded_gate_ref.clone(),
+        capability_id: capability_id(),
+        surface_version: surface_version(),
+        input_ref: CapabilityInputRef::new("input:original").expect("valid"),
+        effective_capability_ids: Vec::new(),
+        provider_replay: None,
+    });
+    let call = match provider_calls_response().output {
+        ParentLoopOutput::CapabilityCalls(mut calls) => calls.remove(0),
+        ParentLoopOutput::AssistantReply(_) => panic!("expected provider call fixture"),
+    };
+    let gate_ref = LoopGateRef::new("gate:approval-skip").expect("valid");
+
+    let step = GateStage
+        .process(
+            ctx,
+            GateInput {
+                state,
+                call,
+                kind: GateKind::Approval,
+                gate_ref,
+                credential_requirements: Vec::new(),
+                approval_resume: None,
+            },
+        )
+        .await
+        .expect("gate stage");
+
+    let BatchStep::Continue(final_state) = step else {
+        panic!("expected SkipAndContinue to return Continue");
+    };
+    assert!(
+        final_state.pending_auth_resume.is_none(),
+        "SkipAndContinue must clear pending_auth_resume for the skipped capability \
+         to prevent an infinite re-dispatch loop on the next prompt iteration"
+    );
+}
+
+#[tokio::test]
+async fn gate_stage_abort_clears_stale_pending_auth_resume() {
+    // Bug scenario: auth record stored for capability A → resume re-dispatches A
+    // → re-dispatch returns ResourceBlocked → GateStage runs with kind Resource
+    // → planner returns Abort. Without the fix, pending_auth_resume persists
+    // into the Final checkpoint, leaving a stale record.
+    let failure_kind = LoopFailureKind::CapabilityProtocolError;
+    let family = family_with_gate_outcome(GateOutcome::Abort {
+        gate: empty_gate_state(),
+        failure_kind,
+    });
+    let host = MockHost::new(Vec::new());
+    let ctx = StageContext {
+        planner: family.planner(),
+        host: &host,
+    };
+    // Seed a pending_auth_resume for the same capability.
+    let seeded_gate_ref = LoopGateRef::new("gate:auth-original-abort").expect("valid");
+    let mut state = LoopExecutionState::initial_for_run(host.run_context());
+    state.pending_auth_resume = Some(PendingAuthResume {
+        gate_ref: seeded_gate_ref.clone(),
+        capability_id: capability_id(),
+        surface_version: surface_version(),
+        input_ref: CapabilityInputRef::new("input:original-abort").expect("valid"),
+        effective_capability_ids: Vec::new(),
+        provider_replay: None,
+    });
+    let call = match provider_calls_response().output {
+        ParentLoopOutput::CapabilityCalls(mut calls) => calls.remove(0),
+        ParentLoopOutput::AssistantReply(_) => panic!("expected provider call fixture"),
+    };
+    let gate_ref = LoopGateRef::new("gate:resource-abort").expect("valid");
+
+    let step = GateStage
+        .process(
+            ctx,
+            GateInput {
+                state,
+                call,
+                kind: GateKind::Resource,
+                gate_ref,
+                credential_requirements: Vec::new(),
+                approval_resume: None,
+            },
+        )
+        .await
+        .expect("gate stage");
+
+    // The Abort arm must return a Failed exit and write a Final checkpoint.
+    let BatchStep::Exit(LoopExit::Failed(failed)) = step else {
+        panic!("expected failed exit from Abort arm");
+    };
+    assert_eq!(failed.reason_kind, failure_kind);
+    assert!(failed.checkpoint_id.is_some());
+
+    // The Final checkpoint must NOT carry a stale pending_auth_resume.
+    let final_state = final_staged_state(&host);
+    assert!(
+        final_state.pending_auth_resume.is_none(),
+        "Abort must clear pending_auth_resume for the aborted capability \
+         to prevent a stale record from persisting into the Final checkpoint"
+    );
+}
+
+#[tokio::test]
+async fn gate_stage_skip_does_not_clear_auth_resume_for_different_capability() {
+    // The clear is capability-scoped: a SkipAndContinue for capability B must NOT
+    // erase a pending_auth_resume record belonging to capability A.
+    let family = family_with_gate_outcome(GateOutcome::SkipAndContinue {
+        gate: empty_gate_state(),
+    });
+    let host = MockHost::new(Vec::new());
+    let ctx = StageContext {
+        planner: family.planner(),
+        host: &host,
+    };
+    // Seed a pending_auth_resume for a DIFFERENT capability (not the one being gated).
+    let different_cap_id = ironclaw_host_api::CapabilityId::new("other.cap").expect("valid");
+    let seeded_gate_ref = LoopGateRef::new("gate:auth-other-cap").expect("valid");
+    let mut state = LoopExecutionState::initial_for_run(host.run_context());
+    state.pending_auth_resume = Some(PendingAuthResume {
+        gate_ref: seeded_gate_ref.clone(),
+        capability_id: different_cap_id.clone(),
+        surface_version: surface_version(),
+        input_ref: CapabilityInputRef::new("input:other-cap").expect("valid"),
+        effective_capability_ids: Vec::new(),
+        provider_replay: None,
+    });
+    // The call being dispatched through GateStage is capability_id() ("demo.echo"),
+    // not the seeded "other.cap".
+    let call = match provider_calls_response().output {
+        ParentLoopOutput::CapabilityCalls(mut calls) => calls.remove(0),
+        ParentLoopOutput::AssistantReply(_) => panic!("expected provider call fixture"),
+    };
+    let gate_ref = LoopGateRef::new("gate:approval-skip-other").expect("valid");
+
+    let step = GateStage
+        .process(
+            ctx,
+            GateInput {
+                state,
+                call,
+                kind: GateKind::Approval,
+                gate_ref,
+                credential_requirements: Vec::new(),
+                approval_resume: None,
+            },
+        )
+        .await
+        .expect("gate stage");
+
+    let BatchStep::Continue(final_state) = step else {
+        panic!("expected SkipAndContinue to return Continue");
+    };
+    // The record for "other.cap" must survive — only the matching capability is cleared.
+    let surviving = final_state
+        .pending_auth_resume
+        .as_ref()
+        .expect("pending_auth_resume for a different capability must not be cleared");
+    assert_eq!(
+        surviving.capability_id, different_cap_id,
+        "surviving pending_auth_resume must belong to the other capability"
+    );
+    assert_eq!(
+        surviving.gate_ref, seeded_gate_ref,
+        "surviving pending_auth_resume.gate_ref must be unchanged"
+    );
+}

--- a/crates/ironclaw_agent_loop/src/executor/tests.rs
+++ b/crates/ironclaw_agent_loop/src/executor/tests.rs
@@ -4010,3 +4010,113 @@ async fn resume_after_auth_gate_redispatches_original_call_without_model_turn() 
         "completed result ref must be recorded in final state"
     );
 }
+
+#[tokio::test]
+async fn resume_with_still_missing_credentials_blocks_again_without_model_turn() {
+    // Phase 1: scripted AuthRequired -> executor exits Blocked and writes a
+    // BeforeBlock checkpoint carrying a pending_auth_resume record.
+    let gate_ref = LoopGateRef::new("gate:auth-still-missing").expect("valid");
+    let host = MockHost::new(vec![calls_response()]).with_batch_outcomes(vec![
+        ironclaw_turns::run_profile::CapabilityBatchOutcome {
+            outcomes: vec![CapabilityOutcome::AuthRequired {
+                gate_ref: gate_ref.clone(),
+                credential_requirements: Vec::new(),
+                safe_summary: "auth required (phase 1)".to_string(),
+            }],
+            stopped_on_suspension: true,
+        },
+        // Phase 2 scripted outcome: credentials are STILL missing — block again.
+        ironclaw_turns::run_profile::CapabilityBatchOutcome {
+            outcomes: vec![CapabilityOutcome::AuthRequired {
+                gate_ref: LoopGateRef::new("gate:auth-still-missing-2").expect("valid"),
+                credential_requirements: Vec::new(),
+                safe_summary: "auth required (phase 2 — still missing)".to_string(),
+            }],
+            stopped_on_suspension: true,
+        },
+    ]);
+    let executor = CanonicalAgentLoopExecutor;
+    let initial_state = LoopExecutionState::initial_for_run(host.run_context());
+
+    // Phase 1 run — expect Blocked exit.
+    let first_exit = executor
+        .execute_family(&crate::families::default(), &host, initial_state)
+        .await
+        .expect("first execute blocks on auth gate");
+    assert!(
+        matches!(first_exit, LoopExit::Blocked(_)),
+        "expected Blocked exit in phase 1, got {first_exit:?}"
+    );
+    // Exactly one model call in phase 1.
+    assert_eq!(
+        host.model_requests().len(),
+        1,
+        "phase 1 must make exactly one model call"
+    );
+
+    // Recover the BeforeBlock checkpoint — this is what resume loads.
+    let before_block_state = final_staged_state_for_kind(&host, LoopCheckpointKind::BeforeBlock);
+    assert!(
+        before_block_state.pending_auth_resume.is_some(),
+        "BeforeBlock checkpoint must carry pending_auth_resume after phase 1"
+    );
+    let phase1_capability_id = before_block_state
+        .pending_auth_resume
+        .as_ref()
+        .expect("pending_auth_resume set")
+        .capability_id
+        .clone();
+
+    // Phase 2 run — seeded from the BeforeBlock state.
+    // Credentials are still missing: the capability re-dispatches and blocks again.
+    let second_exit = executor
+        .execute_family(&crate::families::default(), &host, before_block_state)
+        .await
+        .expect("second execute — still-missing credentials path should not error");
+    assert!(
+        matches!(second_exit, LoopExit::Blocked(_)),
+        "expected Blocked exit in phase 2 (credentials still missing), got {second_exit:?}"
+    );
+
+    // (a) No additional model call during phase 2 — re-dispatch happened without model turn.
+    assert_eq!(
+        host.model_requests().len(),
+        1,
+        "auth resume with still-missing credentials must not trigger a new model call"
+    );
+
+    // (b) Exactly two batch invocations total: phase 1 block + phase 2 re-dispatch block.
+    let batch_invocations = host.batch_invocations();
+    assert_eq!(
+        batch_invocations.len(),
+        2,
+        "expected two batch invocations (phase 1 block + phase 2 re-dispatch block)"
+    );
+
+    // (c) The new BeforeBlock checkpoint must carry a pending_auth_resume record
+    //     whose capability_id matches the original one from phase 1.
+    let phase2_before_block_states: Vec<_> = host
+        .staged_payloads()
+        .into_iter()
+        .filter(|p| p.kind == LoopCheckpointKind::BeforeBlock)
+        .map(|p| {
+            LoopExecutionState::from_checkpoint_payload(&p.payload, CheckpointKind::BeforeBlock)
+                .expect("phase 2 BeforeBlock checkpoint payload")
+        })
+        .collect();
+    // There should be at least two BeforeBlock checkpoints (one per phase).
+    assert!(
+        phase2_before_block_states.len() >= 2,
+        "expected at least two BeforeBlock checkpoints (phase 1 + phase 2)"
+    );
+    let phase2_resume = phase2_before_block_states
+        .last()
+        .expect("at least one")
+        .pending_auth_resume
+        .as_ref()
+        .expect("phase 2 BeforeBlock checkpoint must carry pending_auth_resume");
+    assert_eq!(
+        phase2_resume.capability_id, phase1_capability_id,
+        "phase 2 pending_auth_resume.capability_id must match the original capability"
+    );
+}

--- a/crates/ironclaw_agent_loop/src/executor/tests.rs
+++ b/crates/ironclaw_agent_loop/src/executor/tests.rs
@@ -3748,3 +3748,65 @@ async fn await_dependent_run_gate_skip_and_continue_accumulates_byte_len() {
          causing iter 2 to be a SkipModel iteration"
     );
 }
+
+#[tokio::test]
+async fn auth_gate_block_stores_pending_auth_resume() {
+    // Drive the full executor loop so the GateStage block arm runs through the
+    // canonical path (cancel-check → progress emit → write_before_block).
+    let gate_ref = LoopGateRef::new("gate:auth-block").expect("valid");
+    let host = MockHost::new(vec![calls_response()]).with_batch_outcomes(vec![
+        ironclaw_turns::run_profile::CapabilityBatchOutcome {
+            outcomes: vec![CapabilityOutcome::AuthRequired {
+                gate_ref: gate_ref.clone(),
+                credential_requirements: Vec::new(),
+                safe_summary: "auth required".to_string(),
+            }],
+            stopped_on_suspension: true,
+        },
+    ]);
+    let executor = CanonicalAgentLoopExecutor;
+    let initial_state = LoopExecutionState::initial_for_run(host.run_context());
+
+    let exit = executor
+        .execute_family(&crate::families::default(), &host, initial_state)
+        .await
+        .expect("execute blocks on auth gate");
+
+    // Exit must be a blocked (auth) exit.
+    assert!(
+        matches!(exit, LoopExit::Blocked(_)),
+        "expected Blocked exit for auth gate, got {exit:?}"
+    );
+
+    // BeforeBlock checkpoint must have been written.
+    assert!(
+        host.checkpoint_kinds()
+            .contains(&LoopCheckpointKind::BeforeBlock),
+        "BeforeBlock checkpoint must be written when auth gate blocks"
+    );
+
+    // Recover state from the BeforeBlock checkpoint — this is what the resume
+    // path will load, so it must carry the pending_auth_resume record.
+    let before_block_state = final_staged_state_for_kind(&host, LoopCheckpointKind::BeforeBlock);
+
+    // Auth slot must be populated.
+    let pending = before_block_state
+        .pending_auth_resume
+        .as_ref()
+        .expect("BeforeBlock checkpoint must carry pending_auth_resume when auth gate blocks");
+    assert_eq!(
+        pending.gate_ref, gate_ref,
+        "pending_auth_resume.gate_ref must match the blocked gate ref"
+    );
+    assert_eq!(
+        pending.capability_id,
+        capability_id(),
+        "pending_auth_resume.capability_id must match the scripted capability"
+    );
+
+    // Approval slot must NOT be touched by an auth block.
+    assert!(
+        before_block_state.pending_approval_resume.is_none(),
+        "auth block must not populate pending_approval_resume"
+    );
+}

--- a/crates/ironclaw_agent_loop/src/executor/tests.rs
+++ b/crates/ironclaw_agent_loop/src/executor/tests.rs
@@ -18,7 +18,8 @@ use ironclaw_turns::{
 
 use crate::state::{
     CapabilityCallSignature, CheckpointKind, DeferredCompactionWatermark, IndexedMessageKind,
-    LoopExecutionState, MessageIndexEntry, RepeatedCallWarningPhase, RepeatedCallWarningState,
+    LoopExecutionState, MessageIndexEntry, PendingAuthResume, RepeatedCallWarningPhase,
+    RepeatedCallWarningState,
 };
 use crate::strategies::{
     CapabilityBatchTurnSummary, CapabilityFilter, DefaultCompactionStrategy, GateKind, GateOutcome,
@@ -3778,11 +3779,14 @@ async fn auth_gate_block_stores_pending_auth_resume() {
         "expected Blocked exit for auth gate, got {exit:?}"
     );
 
-    // BeforeBlock checkpoint must have been written.
-    assert!(
-        host.checkpoint_kinds()
-            .contains(&LoopCheckpointKind::BeforeBlock),
-        "BeforeBlock checkpoint must be written when auth gate blocks"
+    // BeforeBlock checkpoint must have been written in the expected sequence.
+    assert_eq!(
+        host.checkpoint_kinds(),
+        vec![
+            LoopCheckpointKind::BeforeModel,
+            LoopCheckpointKind::BeforeSideEffect,
+            LoopCheckpointKind::BeforeBlock,
+        ]
     );
 
     // Recover state from the BeforeBlock checkpoint — this is what the resume
@@ -3808,5 +3812,70 @@ async fn auth_gate_block_stores_pending_auth_resume() {
     assert!(
         before_block_state.pending_approval_resume.is_none(),
         "auth block must not populate pending_approval_resume"
+    );
+}
+
+#[tokio::test]
+async fn non_auth_gate_block_preserves_pending_auth_resume() {
+    // Regression test for the fix where `_ => state.pending_auth_resume.take()`
+    // would erase a live auth resume record when a non-auth gate (e.g. approval)
+    // blocked mid-re-dispatch.
+    //
+    // Scenario: auth gate previously blocked → record stored → OAuth completes →
+    // resume re-dispatches the call → re-dispatch hits an APPROVAL gate → Block
+    // arm must NOT clear the auth record. The auth record must survive so that
+    // the outer resume handler can still consume it.
+    let approval_gate_ref = LoopGateRef::new("gate:approval-during-redispatch").expect("valid");
+    let host = MockHost::new(vec![calls_response()]).with_batch_outcomes(vec![
+        ironclaw_turns::run_profile::CapabilityBatchOutcome {
+            outcomes: vec![CapabilityOutcome::ApprovalRequired {
+                gate_ref: approval_gate_ref.clone(),
+                safe_summary: "approval required during redispatch".to_string(),
+                approval_resume: None,
+            }],
+            stopped_on_suspension: true,
+        },
+    ]);
+    let executor = CanonicalAgentLoopExecutor;
+
+    // Seed a live auth resume record, simulating a state that was rehydrated
+    // from a BeforeBlock checkpoint written when the auth gate first blocked.
+    let seeded_gate_ref = LoopGateRef::new("gate:auth-original").expect("valid");
+    let seeded_auth_resume = PendingAuthResume {
+        gate_ref: seeded_gate_ref.clone(),
+        capability_id: capability_id(),
+        surface_version: surface_version(),
+        input_ref: CapabilityInputRef::new("input:original").expect("valid"),
+        effective_capability_ids: Vec::new(),
+        provider_replay: None,
+    };
+    let mut initial_state = LoopExecutionState::initial_for_run(host.run_context());
+    initial_state.pending_auth_resume = Some(seeded_auth_resume.clone());
+
+    let exit = executor
+        .execute_family(&crate::families::default(), &host, initial_state)
+        .await
+        .expect("execute blocks on approval gate");
+
+    // Exit must be a Blocked exit (approval gate fired).
+    assert!(
+        matches!(exit, LoopExit::Blocked(_)),
+        "expected Blocked exit when approval gate blocks, got {exit:?}"
+    );
+
+    // The BeforeBlock checkpoint must carry the auth resume record unchanged —
+    // the approval-gate Block arm must not have erased it.
+    let before_block_state = final_staged_state_for_kind(&host, LoopCheckpointKind::BeforeBlock);
+    let surviving_resume = before_block_state
+        .pending_auth_resume
+        .as_ref()
+        .expect("pending_auth_resume must survive a non-auth gate block");
+    assert_eq!(
+        surviving_resume.gate_ref, seeded_gate_ref,
+        "surviving pending_auth_resume.gate_ref must be the original auth gate ref, not the approval gate ref"
+    );
+    assert_eq!(
+        surviving_resume.capability_id, seeded_auth_resume.capability_id,
+        "surviving pending_auth_resume.capability_id must be unchanged"
     );
 }

--- a/crates/ironclaw_agent_loop/src/executor/tests.rs
+++ b/crates/ironclaw_agent_loop/src/executor/tests.rs
@@ -3985,7 +3985,12 @@ async fn resume_after_auth_gate_redispatches_original_call_without_model_turn() 
         "re-dispatched invocation must carry the original input_ref"
     );
 
-    // (c) Auth re-dispatch is token-less — no approval_resume on the invocation.
+    // (c) Neither invocation carries an approval_resume token.
+    //     Phase 1 is a plain first invocation; phase 2 is a token-less auth re-dispatch.
+    assert_eq!(
+        batch_invocations[0].invocations[0].approval_resume, None,
+        "phase-1 invocation must not carry an approval_resume token"
+    );
     assert_eq!(
         batch_invocations[1].invocations[0].approval_resume, None,
         "auth re-dispatch must not carry an approval_resume token"

--- a/crates/ironclaw_agent_loop/src/executor/tests.rs
+++ b/crates/ironclaw_agent_loop/src/executor/tests.rs
@@ -3951,6 +3951,15 @@ async fn resume_after_auth_gate_redispatches_original_call_without_model_turn() 
         "BeforeBlock checkpoint must carry pending_auth_resume"
     );
 
+    // Derive the expected input_ref from the BeforeBlock checkpoint before the
+    // state is consumed by the phase 2 execute call.
+    let original_input_ref = before_block_state
+        .pending_auth_resume
+        .as_ref()
+        .expect("pending_auth_resume set in BeforeBlock checkpoint")
+        .input_ref
+        .clone();
+
     // Phase 2 run — seeded from the BeforeBlock checkpoint state.
     // The prompt stage must detect pending_auth_resume and skip the model call,
     // re-dispatching the original capability invocation directly.
@@ -3978,8 +3987,8 @@ async fn resume_after_auth_gate_redispatches_original_call_without_model_turn() 
         "expected two batch invocations (phase 1 block + phase 2 re-dispatch)"
     );
 
-    // The Phase 2 invocation must carry the original input_ref.
-    let original_input_ref = CapabilityInputRef::new("input:demo").expect("valid");
+    // The Phase 2 invocation must carry the original input_ref (derived from the
+    // BeforeBlock checkpoint, not a magic string literal).
     assert_eq!(
         batch_invocations[1].invocations[0].input_ref, original_input_ref,
         "re-dispatched invocation must carry the original input_ref"
@@ -4118,5 +4127,13 @@ async fn resume_with_still_missing_credentials_blocks_again_without_model_turn()
     assert_eq!(
         phase2_resume.capability_id, phase1_capability_id,
         "phase 2 pending_auth_resume.capability_id must match the original capability"
+    );
+    // The gate_ref in the phase-2 BeforeBlock checkpoint must reflect the refreshed
+    // AuthRequired outcome from phase 2, not the stale phase-1 gate ref.  This
+    // proves GateStage wrote a fresh record rather than preserving the old one.
+    let phase2_gate_ref = LoopGateRef::new("gate:auth-still-missing-2").expect("valid");
+    assert_eq!(
+        phase2_resume.gate_ref, phase2_gate_ref,
+        "phase 2 pending_auth_resume.gate_ref must equal the refreshed phase-2 gate ref"
     );
 }

--- a/crates/ironclaw_agent_loop/src/executor/tests.rs
+++ b/crates/ironclaw_agent_loop/src/executor/tests.rs
@@ -264,7 +264,9 @@ async fn prompt_stage_compacts_candidate_prompt_then_rebuilds_final_bundle() {
     let output = match step {
         PromptStep::Prepared(output) => output,
         PromptStep::Exit(exit) => panic!("expected prepared prompt, got {exit:?}"),
-        PromptStep::ResumeApproval(_) => panic!("unexpected ResumeApproval"),
+        PromptStep::ResumeApproval(_) | PromptStep::ResumeAuth(_) => {
+            panic!("unexpected resume step")
+        }
         PromptStep::SkipModel(_, _) => panic!("unexpected SkipModel"),
     };
     assert_eq!(host.prompt_requests().len(), 2);
@@ -340,7 +342,9 @@ async fn prompt_stage_deferred_compaction_returns_to_normal_prompt_path() {
     let output = match step {
         PromptStep::Prepared(output) => output,
         PromptStep::Exit(exit) => panic!("expected prepared prompt, got {exit:?}"),
-        PromptStep::ResumeApproval(_) => panic!("unexpected ResumeApproval"),
+        PromptStep::ResumeApproval(_) | PromptStep::ResumeAuth(_) => {
+            panic!("unexpected resume step")
+        }
         PromptStep::SkipModel(_, _) => panic!("unexpected SkipModel"),
     };
     assert_eq!(host.prompt_requests().len(), 1);
@@ -423,7 +427,9 @@ async fn prompt_stage_successful_compaction_clears_deferred_watermark() {
     let output = match step {
         PromptStep::Prepared(output) => output,
         PromptStep::Exit(exit) => panic!("expected prepared prompt, got {exit:?}"),
-        PromptStep::ResumeApproval(_) => panic!("unexpected ResumeApproval"),
+        PromptStep::ResumeApproval(_) | PromptStep::ResumeAuth(_) => {
+            panic!("unexpected resume step")
+        }
         PromptStep::SkipModel(_, _) => panic!("unexpected SkipModel"),
     };
     assert_eq!(
@@ -509,7 +515,9 @@ async fn prompt_stage_compaction_index_maps_system_summary_and_other_kinds() {
     let output = match step {
         PromptStep::Prepared(output) => output,
         PromptStep::Exit(exit) => panic!("expected prepared prompt, got {exit:?}"),
-        PromptStep::ResumeApproval(_) => panic!("unexpected ResumeApproval"),
+        PromptStep::ResumeApproval(_) | PromptStep::ResumeAuth(_) => {
+            panic!("unexpected resume step")
+        }
         PromptStep::SkipModel(_, _) => panic!("unexpected SkipModel"),
     };
     assert_eq!(
@@ -561,7 +569,9 @@ async fn prompt_stage_cancellation_after_prompt_bundle_returns_cancelled_exit() 
             assert!(cancelled.checkpoint_id.is_some());
         }
         PromptStep::Prepared(_) => panic!("expected cancelled exit"),
-        PromptStep::ResumeApproval(_) => panic!("unexpected ResumeApproval"),
+        PromptStep::ResumeApproval(_) | PromptStep::ResumeAuth(_) => {
+            panic!("unexpected resume step")
+        }
         PromptStep::Exit(exit) => panic!("expected cancelled exit, got {exit:?}"),
         PromptStep::SkipModel(_, _) => panic!("unexpected SkipModel"),
     }
@@ -664,7 +674,9 @@ async fn prompt_stage_compaction_security_rejection_returns_failed_exit() {
             assert!(failed.checkpoint_id.is_some());
         }
         PromptStep::Prepared(_) => panic!("security rejection should end the run"),
-        PromptStep::ResumeApproval(_) => panic!("unexpected ResumeApproval"),
+        PromptStep::ResumeApproval(_) | PromptStep::ResumeAuth(_) => {
+            panic!("unexpected resume step")
+        }
         PromptStep::Exit(exit) => panic!("expected failed exit, got {exit:?}"),
         PromptStep::SkipModel(_, _) => panic!("unexpected SkipModel"),
     }
@@ -2945,7 +2957,9 @@ async fn prompt_stage_returns_skip_model_when_flag_set() {
     let returned_state = match step {
         PromptStep::SkipModel(state, _ack) => *state,
         PromptStep::Prepared(_) => panic!("expected SkipModel, got Prepared"),
-        PromptStep::ResumeApproval(_) => panic!("expected SkipModel, got ResumeApproval"),
+        PromptStep::ResumeApproval(_) | PromptStep::ResumeAuth(_) => {
+            panic!("expected SkipModel, got resume step")
+        }
         PromptStep::Exit(exit) => panic!("expected SkipModel, got Exit({exit:?})"),
     };
 
@@ -3005,7 +3019,9 @@ async fn prompt_stage_skip_model_carries_pending_input_ack() {
     let mut carried_ack = match step {
         PromptStep::SkipModel(_state, ack) => ack,
         PromptStep::Prepared(_) => panic!("expected SkipModel, got Prepared"),
-        PromptStep::ResumeApproval(_) => panic!("expected SkipModel, got ResumeApproval"),
+        PromptStep::ResumeApproval(_) | PromptStep::ResumeAuth(_) => {
+            panic!("expected SkipModel, got resume step")
+        }
         PromptStep::Exit(exit) => panic!("expected SkipModel, got Exit({exit:?})"),
     };
 
@@ -3877,5 +3893,115 @@ async fn non_auth_gate_block_preserves_pending_auth_resume() {
     assert_eq!(
         surviving_resume.capability_id, seeded_auth_resume.capability_id,
         "surviving pending_auth_resume.capability_id must be unchanged"
+    );
+}
+
+#[tokio::test]
+async fn resume_after_auth_gate_redispatches_original_call_without_model_turn() {
+    // Phase 1: executor blocks on an auth gate and writes a BeforeBlock checkpoint
+    // that carries a pending_auth_resume record with the original input_ref.
+    let gate_ref = LoopGateRef::new("gate:auth-resume-test").expect("valid");
+    let completed_ref = LoopResultRef::new("result:auth-resumed").expect("valid");
+    let host = MockHost::new(vec![calls_response()]).with_batch_outcomes(vec![
+        ironclaw_turns::run_profile::CapabilityBatchOutcome {
+            outcomes: vec![CapabilityOutcome::AuthRequired {
+                gate_ref: gate_ref.clone(),
+                credential_requirements: Vec::new(),
+                safe_summary: "auth required".to_string(),
+            }],
+            stopped_on_suspension: true,
+        },
+        // Phase 2 scripted outcome: the auth is now satisfied, call completes.
+        ironclaw_turns::run_profile::CapabilityBatchOutcome {
+            outcomes: vec![CapabilityOutcome::Completed(
+                ironclaw_turns::run_profile::CapabilityResultMessage {
+                    result_ref: completed_ref.clone(),
+                    safe_summary: "auth resumed and completed".to_string(),
+                    progress: ironclaw_turns::run_profile::CapabilityProgress::MadeProgress,
+                    terminate_hint: true,
+                    byte_len: 0,
+                },
+            )],
+            stopped_on_suspension: false,
+        },
+    ]);
+    let executor = CanonicalAgentLoopExecutor;
+    let initial_state = LoopExecutionState::initial_for_run(host.run_context());
+
+    // Phase 1 run — expect a Blocked exit.
+    let first_exit = executor
+        .execute_family(&crate::families::default(), &host, initial_state)
+        .await
+        .expect("first execute blocks on auth gate");
+    assert!(
+        matches!(first_exit, LoopExit::Blocked(_)),
+        "expected Blocked exit, got {first_exit:?}"
+    );
+    // Exactly one model call happened during Phase 1.
+    assert_eq!(
+        host.model_requests().len(),
+        1,
+        "phase 1 must make exactly one model call"
+    );
+
+    // Recover the BeforeBlock checkpoint state — this is what resume loads.
+    let before_block_state = final_staged_state_for_kind(&host, LoopCheckpointKind::BeforeBlock);
+    assert!(
+        before_block_state.pending_auth_resume.is_some(),
+        "BeforeBlock checkpoint must carry pending_auth_resume"
+    );
+
+    // Phase 2 run — seeded from the BeforeBlock checkpoint state.
+    // The prompt stage must detect pending_auth_resume and skip the model call,
+    // re-dispatching the original capability invocation directly.
+    let second_exit = executor
+        .execute_family(&crate::families::default(), &host, before_block_state)
+        .await
+        .expect("second execute resumes from auth gate");
+    assert!(
+        matches!(second_exit, LoopExit::Completed(_)),
+        "expected Completed exit after auth resume, got {second_exit:?}"
+    );
+
+    // (a) No additional model call during Phase 2 — capability re-dispatched before model.
+    assert_eq!(
+        host.model_requests().len(),
+        1,
+        "auth resume must re-dispatch the saved invocation without a model call"
+    );
+
+    // (b) Exactly two batch invocations total: Phase 1 (blocked) + Phase 2 (completed).
+    let batch_invocations = host.batch_invocations();
+    assert_eq!(
+        batch_invocations.len(),
+        2,
+        "expected two batch invocations (phase 1 block + phase 2 re-dispatch)"
+    );
+
+    // The Phase 2 invocation must carry the original input_ref.
+    let original_input_ref = CapabilityInputRef::new("input:demo").expect("valid");
+    assert_eq!(
+        batch_invocations[1].invocations[0].input_ref, original_input_ref,
+        "re-dispatched invocation must carry the original input_ref"
+    );
+
+    // (c) Auth re-dispatch is token-less — no approval_resume on the invocation.
+    assert_eq!(
+        batch_invocations[1].invocations[0].approval_resume, None,
+        "auth re-dispatch must not carry an approval_resume token"
+    );
+
+    // (d) pending_auth_resume is cleared in the final state.
+    let final_state = final_staged_state(&host);
+    assert!(
+        final_state.pending_auth_resume.is_none(),
+        "pending_auth_resume must be cleared after successful re-dispatch"
+    );
+
+    // (e) The completed result was recorded.
+    assert_eq!(
+        final_state.result_refs,
+        vec![completed_ref],
+        "completed result ref must be recorded in final state"
     );
 }

--- a/crates/ironclaw_agent_loop/src/state.rs
+++ b/crates/ironclaw_agent_loop/src/state.rs
@@ -85,6 +85,8 @@ pub struct LoopExecutionState {
     pub gate_state: GateStrategyState,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pending_approval_resume: Option<PendingApprovalResume>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pending_auth_resume: Option<PendingAuthResume>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -102,6 +104,24 @@ pub struct PendingApprovalResume {
     pub provider_replay: Option<ProviderToolCallReplay>,
     pub input: serde_json::Value,
     pub estimate: ResourceEstimate,
+}
+
+/// Auth-gated capability call parked at a blocked-auth checkpoint.
+///
+/// Unlike [`PendingApprovalResume`] there is no resume token: on resume the
+/// call is re-dispatched as a fresh invocation and the host re-evaluates the
+/// auth requirement (credentials now present → executes; still missing →
+/// blocks again).
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct PendingAuthResume {
+    pub gate_ref: LoopGateRef,
+    pub capability_id: CapabilityId,
+    pub surface_version: CapabilitySurfaceVersion,
+    pub input_ref: CapabilityInputRef,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub effective_capability_ids: Vec<CapabilityId>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_replay: Option<ProviderToolCallReplay>,
 }
 
 impl LoopExecutionState {
@@ -136,6 +156,7 @@ impl LoopExecutionState {
             stop_state: StopStrategyState::default(),
             gate_state: GateStrategyState::default(),
             pending_approval_resume: None,
+            pending_auth_resume: None,
         }
     }
 
@@ -631,6 +652,71 @@ mod tests {
         assert_eq!(
             restored.post_capability_state, state.post_capability_state,
             "entire PostCapabilityStageState must round-trip without loss"
+        );
+    }
+
+    #[test]
+    fn pending_auth_resume_round_trips_through_checkpoint_payload() {
+        let context = test_run_context();
+        let mut state = LoopExecutionState::initial_for_run(&context);
+        state.pending_auth_resume = Some(PendingAuthResume {
+            gate_ref: LoopGateRef::new("gate:auth-test").expect("valid gate ref"),
+            capability_id: CapabilityId::new("gsuite.calendar.list_events").expect("valid cap id"),
+            surface_version: CapabilitySurfaceVersion::new("surface-v1")
+                .expect("valid surface version"),
+            input_ref: CapabilityInputRef::new("input:test").expect("valid input ref"),
+            effective_capability_ids: vec![],
+            provider_replay: None,
+        });
+        let payload = encode_payload(&state);
+        let restored =
+            LoopExecutionState::from_checkpoint_payload(&payload, CheckpointKind::BeforeBlock)
+                .expect("decode checkpoint payload");
+        assert_eq!(
+            restored.pending_auth_resume, state.pending_auth_resume,
+            "PendingAuthResume must survive checkpoint encode/decode"
+        );
+    }
+
+    #[test]
+    fn checkpoint_payload_without_auth_resume_slot_decodes_to_none() {
+        // Encode a state with no pending_auth_resume; decode must yield None.
+        // Also exercise backward compat: a payload JSON object lacking the
+        // field entirely (as pre-existing checkpoints would) must decode
+        // with None rather than failing.
+        let context = test_run_context();
+        let state = LoopExecutionState::initial_for_run(&context);
+        assert!(
+            state.pending_auth_resume.is_none(),
+            "initial state must have no pending_auth_resume"
+        );
+
+        // Round-trip through the normal encode/decode path.
+        let payload = encode_payload(&state);
+        let restored =
+            LoopExecutionState::from_checkpoint_payload(&payload, CheckpointKind::BeforeBlock)
+                .expect("decode checkpoint payload");
+        assert!(
+            restored.pending_auth_resume.is_none(),
+            "decoded state must have no pending_auth_resume when field was absent from payload"
+        );
+
+        // Explicitly remove the field from the JSON to simulate a checkpoint
+        // produced before PendingAuthResume was added. Decoding must still succeed.
+        let mut value: serde_json::Value = serde_json::from_slice(&payload).expect("parse");
+        value
+            .as_object_mut()
+            .expect("state serializes as object")
+            .remove("pending_auth_resume");
+        let stripped_payload = serde_json::to_vec(&value).expect("re-encode");
+        let from_legacy = LoopExecutionState::from_checkpoint_payload(
+            &stripped_payload,
+            CheckpointKind::BeforeBlock,
+        )
+        .expect("decode legacy checkpoint payload without pending_auth_resume");
+        assert!(
+            from_legacy.pending_auth_resume.is_none(),
+            "legacy checkpoint missing pending_auth_resume field must decode to None"
         );
     }
 }

--- a/docs/plans/2026-06-10-auth-gate-resume-redispatch.md
+++ b/docs/plans/2026-06-10-auth-gate-resume-redispatch.md
@@ -1,0 +1,360 @@
+# Auth-Gate Resume Re-Dispatch Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When an auth-gated capability call resumes after OAuth completes, the loop re-dispatches the original capability invocation automatically (mirroring approval-gate resume), so the model receives the real payload instead of waking with no signal.
+
+**Architecture:** Add a `pending_auth_resume: Option<PendingAuthResume>` slot to `LoopExecutionState`, populated in `GateStage`'s Block arm for `GateKind::Auth` from the already-available `CapabilityCallCandidate`. On resume, the prompt stage detects the slot (exactly like `pending_approval_resume` at `prompt.rs:239`) and returns a resume step that skips the model call and re-invokes the capability. Unlike approval resume, no resume token is attached — the host re-evaluates the auth requirement fresh; credentials now present → executes and returns the full payload; still missing → blocks again (idempotent).
+
+**Tech Stack:** Rust, `crates/ironclaw_agent_loop` (canonical executor), `crates/ironclaw_turns` (neutral contracts — likely untouched).
+
+**Bug context (diagnosed 2026-06-10):** Auth gates block with `approval_resume: None` (`executor/capabilities.rs:464`), store no resume record, append no tool result (`executor/gates.rs:61-101`). `LoopInput::GateResolved` is never consumed or rendered (`executor/input.rs:186`). After OAuth → `dispatch_turn_gate_resume` (`ironclaw_product_workflow/src/auth_continuation.rs:64`) → `PlannedDriver::resume` (`ironclaw_reborn/src/planned_driver.rs:123`) reloads the checkpoint and re-prompts the model cold. Model answers from stale context (memory) instead of retrying the calendar call.
+
+**Key existing machinery to mirror (read these first):**
+
+| What | Where |
+|---|---|
+| `PendingApprovalResume` struct | `crates/ironclaw_agent_loop/src/state.rs:87-91` |
+| Block-arm population (approval only) | `crates/ironclaw_agent_loop/src/executor/gates.rs:64-77` |
+| Resume detection in prompt stage | `crates/ironclaw_agent_loop/src/executor/prompt.rs:239-249` |
+| Candidate rebuild helper | `crates/ironclaw_agent_loop/src/executor/capability_helpers.rs:40-51` (`pending_approval_resume_candidate`) |
+| Resume consumption in capability batch | `crates/ironclaw_agent_loop/src/executor/capabilities.rs:131-157` (`take_if` + `CapabilityApprovalResume`) |
+| Clear-on-completion | `crates/ironclaw_agent_loop/src/executor/capabilities.rs:747-757` (`clear_matching_pending_approval_resume`) |
+| Auth outcome → GateStage | `crates/ironclaw_agent_loop/src/executor/capabilities.rs:450-468` |
+| `CapabilityCallCandidate` fields | `crates/ironclaw_turns/src/run_profile/host.rs:1211-1219` (`surface_version`, `capability_id`, `input_ref`, `effective_capability_ids`, `provider_replay`) |
+| `PromptStep::ResumeApproval` routing | `crates/ironclaw_agent_loop/src/executor/canonical.rs` (grep `ResumeApproval`) |
+| Test scaffolding | `crates/ironclaw_agent_loop/src/test_support/mod.rs:449,1063` (`ScriptedCapabilityOutcome::AuthRequired`) |
+
+**Scope guard:** No changes to `ironclaw_reborn`, `ironclaw_product_workflow`, `ironclaw_loop_support`, or host-runtime crates. The candidate already carries everything needed for re-dispatch — this is purely executor/state work in `ironclaw_agent_loop` (plus, only if Task 1 proves it necessary, a serialization shim in `state/slots.rs`).
+
+---
+
+### Task 0: Investigate checkpoint serialization compatibility
+
+The state must survive checkpoint round-trips (`LoopExecutionState::from_checkpoint_payload`, used by `PlannedDriver::resume`). Determine the serialization mechanism before touching state.
+
+**Files:**
+- Read: `crates/ironclaw_agent_loop/src/state.rs` (struct + `from_checkpoint_payload` / `to_checkpoint_payload`)
+- Read: `crates/ironclaw_agent_loop/src/state/slots.rs` (note: contains manual code mappings like `indexed_message_kind_code` — the codec may be hand-rolled, not pure serde)
+
+- [ ] **Step 1: Determine how `pending_approval_resume` is encoded into the checkpoint payload**
+
+Run: `grep -n "pending_approval_resume\|checkpoint_payload\|serde" crates/ironclaw_agent_loop/src/state.rs crates/ironclaw_agent_loop/src/state/slots.rs | head -40`
+
+Two possible outcomes:
+- **Serde-based:** adding a new `#[serde(default)] Option<…>` field is backward compatible (old checkpoints deserialize with `None`). No schema version bump needed — confirm by finding an existing `#[serde(default)]` field that was added after v1.
+- **Manual codec:** mirror exactly how `PendingApprovalResume` is encoded/decoded in `slots.rs`, with a length/presence guard so old payloads (missing the slot) decode to `None`. If the codec is strictly positional with no presence guard, bump `CHECKPOINT_SCHEMA_VERSION` in `crates/ironclaw_reborn/src/planned_driver.rs` (grep `CHECKPOINT_SCHEMA_VERSION`) — note this invalidates in-flight blocked runs across deploy, which is acceptable for local-dev but call it out in the PR description.
+
+- [ ] **Step 2: Record the finding as a comment in your working notes and pick the corresponding branch in Task 1 Step 3**
+
+No commit — investigation only.
+
+---
+
+### Task 1: Add `PendingAuthResume` state slot
+
+**Files:**
+- Modify: `crates/ironclaw_agent_loop/src/state.rs` (struct at ~line 87, `initial_for_run` defaults at ~line 138)
+- Modify (only if manual codec): `crates/ironclaw_agent_loop/src/state/slots.rs`
+
+- [ ] **Step 1: Write the failing round-trip test** (in the existing `#[cfg(test)]` module of `state.rs`, mirroring the existing checkpoint round-trip tests there — grep `from_checkpoint_payload` in the test module for the analog)
+
+```rust
+#[test]
+fn pending_auth_resume_round_trips_through_checkpoint_payload() {
+    let mut state = LoopExecutionState::initial_for_run(&test_run_context());
+    state.pending_auth_resume = Some(PendingAuthResume {
+        gate_ref: LoopGateRef::new("gate:auth:test").expect("gate ref"),
+        capability_id: CapabilityId::new("gsuite.calendar.list_events").expect("cap id"),
+        surface_version: CapabilitySurfaceVersion::new("surface-v1").expect("surface"),
+        input_ref: CapabilityInputRef::new("input:test").expect("input ref"),
+        effective_capability_ids: vec![],
+        provider_replay: None,
+    });
+    let payload = state.to_checkpoint_payload(CheckpointKind::BeforeBlock).expect("encode");
+    let restored = LoopExecutionState::from_checkpoint_payload(payload.as_bytes(), CheckpointKind::BeforeBlock)
+        .expect("decode");
+    assert_eq!(restored.pending_auth_resume, state.pending_auth_resume);
+}
+
+#[test]
+fn checkpoint_payload_without_auth_resume_slot_decodes_to_none() {
+    // Encode a state that has no pending_auth_resume; decode must yield None
+    // (guards backward compat with pre-existing checkpoints).
+    let state = LoopExecutionState::initial_for_run(&test_run_context());
+    let payload = state.to_checkpoint_payload(CheckpointKind::BeforeBlock).expect("encode");
+    let restored = LoopExecutionState::from_checkpoint_payload(payload.as_bytes(), CheckpointKind::BeforeBlock)
+        .expect("decode");
+    assert!(restored.pending_auth_resume.is_none());
+}
+```
+
+Adjust constructor names (`test_run_context`, `to_checkpoint_payload` signature, `CheckpointKind` variant) to match the existing round-trip tests in that module — copy their setup verbatim.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p ironclaw_agent_loop pending_auth_resume_round_trips -- --nocapture`
+Expected: FAIL — `pending_auth_resume` field / `PendingAuthResume` type not found.
+
+- [ ] **Step 3: Add the type and field**
+
+In `state.rs`, next to `PendingApprovalResume` (~line 91):
+
+```rust
+/// Auth-gated capability call parked at a `BlockedAuth` checkpoint.
+///
+/// Unlike [`PendingApprovalResume`] there is no resume token: on resume the
+/// call is re-dispatched as a fresh invocation and the host re-evaluates the
+/// auth requirement (credentials now present → executes; still missing →
+/// blocks again).
+#[derive(Debug, Clone, PartialEq)]
+pub struct PendingAuthResume {
+    pub gate_ref: LoopGateRef,
+    pub capability_id: CapabilityId,
+    pub surface_version: CapabilitySurfaceVersion,
+    pub input_ref: CapabilityInputRef,
+    pub effective_capability_ids: Vec<CapabilityId>,
+    pub provider_replay: Option<ProviderToolCallReplay>,
+}
+```
+
+(Match derive list, field visibility, and import style of `PendingApprovalResume` exactly — including `Serialize`/`Deserialize` derives if that struct has them.)
+
+On `LoopExecutionState`:
+
+```rust
+    pub pending_approval_resume: Option<PendingApprovalResume>,
+    pub pending_auth_resume: Option<PendingAuthResume>,
+```
+
+If serde-based codec: add `#[serde(default, skip_serializing_if = "Option::is_none")]` on the new field. If manual codec: replicate the `PendingApprovalResume` encode/decode in `slots.rs` with a presence guard per Task 0's finding.
+
+Initialize `pending_auth_resume: None` in `initial_for_run` (~line 138).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p ironclaw_agent_loop pending_auth_resume -- --nocapture` and `cargo test -p ironclaw_agent_loop checkpoint`
+Expected: PASS (both new tests, no regressions in existing checkpoint tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/ironclaw_agent_loop/src/state.rs crates/ironclaw_agent_loop/src/state/slots.rs
+git commit -m "feat(agent_loop): add PendingAuthResume checkpoint state slot"
+```
+
+---
+
+### Task 2: Populate the slot in GateStage's Block arm for auth gates
+
+**Files:**
+- Modify: `crates/ironclaw_agent_loop/src/executor/gates.rs:61-101` (Block arm)
+- Test: `crates/ironclaw_agent_loop/src/executor/tests.rs`
+
+- [ ] **Step 1: Write the failing test.** Locate the existing approval-gate-block test as the template:
+
+Run: `grep -n "pending_approval_resume\|ApprovalRequired" crates/ironclaw_agent_loop/src/executor/tests.rs | head -20`
+
+Copy that test's harness setup, switch the scripted outcome to `ScriptedCapabilityOutcome::AuthRequired { gate_ref }` (`test_support/mod.rs:449`), run the loop to the blocked exit, and assert on the checkpointed state:
+
+```rust
+#[tokio::test]
+async fn auth_gate_block_stores_pending_auth_resume_in_checkpoint() {
+    // Harness setup copied from the approval-block analog test, with the
+    // capability scripted to return AuthRequired.
+    // ... (analog setup) ...
+    let exit = /* run loop */;
+    let LoopExit::Blocked(blocked) = exit else { panic!("expected blocked exit") };
+    assert_eq!(blocked.kind, LoopBlockedKind::Auth);
+    let state = /* decode checkpoint payload written by the harness, same as analog test */;
+    let resume = state.pending_auth_resume.expect("auth resume record stored");
+    assert_eq!(resume.gate_ref, blocked.gate_ref);
+    assert_eq!(resume.capability_id.as_str(), "cap.test"); // whatever id the harness scripts
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p ironclaw_agent_loop auth_gate_block_stores -- --nocapture`
+Expected: FAIL — `pending_auth_resume` is `None`.
+
+- [ ] **Step 3: Populate in the Block arm.** In `gates.rs` Block arm, after the existing `state.pending_approval_resume = …` assignment (line 64-77), add:
+
+```rust
+                state.pending_auth_resume = match kind {
+                    GateKind::Auth => Some(crate::state::PendingAuthResume {
+                        gate_ref: gate_ref.clone(),
+                        capability_id: call.capability_id.clone(),
+                        surface_version: call.surface_version.clone(),
+                        input_ref: call.input_ref.clone(),
+                        effective_capability_ids: call.effective_capability_ids.clone(),
+                        provider_replay: call.provider_replay.clone(),
+                    }),
+                    _ => state.pending_auth_resume.take(),
+                };
+```
+
+(`call` is the `CapabilityCallCandidate` already in scope; all six fields exist on it plus `gate_ref` — no `GateInput` changes needed.)
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `cargo test -p ironclaw_agent_loop --lib executor`
+Expected: PASS, including pre-existing gate tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/ironclaw_agent_loop/src/executor/gates.rs crates/ironclaw_agent_loop/src/executor/tests.rs
+git commit -m "feat(agent_loop): store pending auth resume record when auth gate blocks"
+```
+
+---
+
+### Task 3: Re-dispatch on resume in the prompt stage
+
+**Files:**
+- Modify: `crates/ironclaw_agent_loop/src/executor/prompt.rs` (~line 239, after the approval-resume check)
+- Modify: `crates/ironclaw_agent_loop/src/executor/capability_helpers.rs` (new candidate helper next to `pending_approval_resume_candidate` at line 40)
+- Modify: `crates/ironclaw_agent_loop/src/executor/canonical.rs` + wherever `PromptStep` is defined (grep `enum PromptStep`) — route the new variant identically to `ResumeApproval`
+- Modify: `crates/ironclaw_agent_loop/src/executor/capabilities.rs` — clear slot on completion
+- Test: `crates/ironclaw_agent_loop/src/executor/tests.rs`
+
+- [ ] **Step 1: Write the failing end-to-end resume test.** Locate the approval-resume analog:
+
+Run: `grep -n "ResumeApproval\|resume" crates/ironclaw_agent_loop/src/executor/tests.rs | head -20`
+
+Test shape: block on `AuthRequired`, capture the checkpoint, build a fresh executor run from that checkpoint state (the analog test shows how), script the capability to now return `Completed`, and assert (a) the capability host received a re-invocation with the original `input_ref` and **no** approval resume attached, (b) the completed result is appended, (c) `pending_auth_resume` is cleared afterward.
+
+```rust
+#[tokio::test]
+async fn resume_after_auth_gate_redispatches_original_call_without_model_turn() {
+    // Phase 1: run until AuthRequired blocks; decode checkpoint state (as in Task 2 test).
+    // Phase 2: re-enter executor with the decoded state; capability now scripted Completed.
+    // ... (analog setup) ...
+    // (a) host saw the re-dispatch with the original input_ref, resume token absent
+    // (b) result appended to result_refs / capability batch summary
+    // (c) state.pending_auth_resume is None after completion
+    // (d) the model stage ran AFTER the capability completed (payload visible), not before
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p ironclaw_agent_loop resume_after_auth_gate -- --nocapture`
+Expected: FAIL — no re-dispatch happens; loop goes straight to a model turn.
+
+- [ ] **Step 3: Add the candidate helper** in `capability_helpers.rs` next to line 40:
+
+```rust
+pub(super) fn pending_auth_resume_candidate(
+    resume: &PendingAuthResume,
+    surface_version: CapabilitySurfaceVersion,
+) -> CapabilityCallCandidate {
+    CapabilityCallCandidate {
+        surface_version,
+        capability_id: resume.capability_id.clone(),
+        input_ref: resume.input_ref.clone(),
+        effective_capability_ids: resume.effective_capability_ids.clone(),
+        provider_replay: resume.provider_replay.clone(),
+    }
+}
+```
+
+- [ ] **Step 4: Detect in prompt stage.** In `prompt.rs`, immediately after the `pending_approval_resume` check (line 239-249), add the parallel check (approval keeps priority — both set simultaneously is impossible today, but order it defensively):
+
+```rust
+        if let Some(resume) = self.state.pending_auth_resume.as_ref() {
+            let call = pending_auth_resume_candidate(resume, surface.version.clone());
+            return Ok(PromptStep::ResumeAuth(Box::new(ApprovalResumePromptOutput {
+                state: self.state,
+                pending_input_ack: self.pending_input_ack,
+                surface,
+                call,
+            })));
+        }
+```
+
+Add `PromptStep::ResumeAuth(Box<ApprovalResumePromptOutput>)` to the `PromptStep` enum and route it in `canonical.rs` through the **same** match-arm body as `ResumeApproval` (the downstream capability stage distinguishes them by which state slot is populated — `take_if` on `pending_approval_resume` at `capabilities.rs:139` simply finds nothing for an auth resume, so the invocation goes out without a resume token, which is exactly what we want).
+
+- [ ] **Step 5: Clear on completion.** In `capabilities.rs`, mirror `clear_matching_pending_approval_resume` (line 747-757):
+
+```rust
+fn clear_matching_pending_auth_resume(state: &mut LoopExecutionState, call: &CapabilityCallCandidate) {
+    if state
+        .pending_auth_resume
+        .as_ref()
+        .is_some_and(|resume| resume.capability_id == call.capability_id)
+    {
+        state.pending_auth_resume = None;
+    }
+}
+```
+
+Call it at every site where `clear_matching_pending_approval_resume` is called (lines 204, 221, 243, 401, 418, 567 — grep to confirm, the file will have shifted). Also clear it in `handle_capability_error` paths so a failing re-dispatch doesn't loop forever — find where the approval slot is cleared on error and mirror.
+
+- [ ] **Step 6: Run the full test**
+
+Run: `cargo test -p ironclaw_agent_loop resume_after_auth_gate -- --nocapture`
+Expected: PASS.
+
+- [ ] **Step 7: Run full crate tests**
+
+Run: `cargo test -p ironclaw_agent_loop`
+Expected: PASS — especially existing `ResumeApproval` tests unchanged.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/ironclaw_agent_loop/src/executor/ crates/ironclaw_agent_loop/src/state.rs
+git commit -m "feat(agent_loop): re-dispatch auth-gated capability call on resume"
+```
+
+---
+
+### Task 4: Re-block idempotency + cross-crate verification
+
+**Files:**
+- Test: `crates/ironclaw_agent_loop/src/executor/tests.rs`
+- Verify only (no edits): `crates/ironclaw_reborn/tests/loop_driver_host.rs`, `crates/ironclaw_turns/tests/agent_loop_host_contract.rs`
+
+- [ ] **Step 1: Write the still-blocked test** — resume where the capability STILL returns `AuthRequired` (credentials not actually stored). Assert: loop exits `Blocked` again with a (possibly new) auth gate_ref, `pending_auth_resume` re-populated, no model turn consumed, no infinite loop.
+
+```rust
+#[tokio::test]
+async fn resume_with_still_missing_credentials_blocks_again_without_model_turn() {
+    // Same two-phase shape as Task 3 test, but phase-2 capability scripted
+    // AuthRequired again. Expect LoopExit::Blocked(kind=Auth) and a stored
+    // pending_auth_resume; model invocation count must be 0 in phase 2.
+}
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `cargo test -p ironclaw_agent_loop resume_with_still_missing -- --nocapture`
+Expected: PASS already if Tasks 2-3 are correct (Block arm re-stores). If it fails, fix the Block arm interaction before proceeding.
+
+- [ ] **Step 3: Full quality gate**
+
+Run: `cargo fmt && cargo clippy --all --benches --tests --examples --all-features && cargo test -p ironclaw_agent_loop -p ironclaw_reborn -p ironclaw_turns`
+Expected: zero clippy warnings, all green. (`ironclaw_reborn`/`ironclaw_turns` consume `LoopExecutionState` and the driver contract — they must compile and pass untouched.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A crates/ironclaw_agent_loop
+git commit -m "test(agent_loop): cover repeated auth block on resume"
+```
+
+---
+
+## Out of scope (explicitly)
+
+- Rendering a model-visible "auth completed" notice from `LoopInput::GateResolved` — superseded by re-dispatch.
+- Any change to `ironclaw_product_workflow` auth continuation, OAuth gate providers, or WebUI handlers — the resume entry path already works.
+- Approval-gate behavior — must be byte-for-byte unchanged (existing tests are the guard).
+
+## Risks
+
+1. **Checkpoint codec is manual/positional** → Task 0 decides; worst case bump `CHECKPOINT_SCHEMA_VERSION` (invalidates in-flight blocked runs; old checkpoints fall to `checkpoint_unavailable_exit`, which is the pre-existing degraded path).
+2. **`ApprovalResumePromptOutput` naming** now serves two variants — acceptable; rename only if clippy/review demands (keep diff minimal).
+3. **Double-slot conflict** (both approval+auth set): impossible today (one gate per block), but prompt stage checks approval first — deterministic either way.


### PR DESCRIPTION
## Problem

In Reborn WebUI, completing a Google Calendar OAuth flow then asking "next meeting" returned stale memory instead of real calendar data. Asking again next turn worked.

**Root cause:** auth gates block with no resume record. Approval gates store `PendingApprovalResume` and re-dispatch the gated call on resume; auth gates store nothing (`approval_resume: None` in the AuthRequired arm), append no tool result, and `LoopInput::GateResolved` is never rendered to the model. On resume the model is prompted cold with zero signal that auth succeeded, so it answers from context. The next user turn makes it retry, credentials are now injected, and the call succeeds.

## Fix

Mirror the approval-gate resume path for auth gates (all changes in `crates/ironclaw_agent_loop`):

- **`PendingAuthResume`** state slot on `LoopExecutionState` (serde-backward-compatible: old checkpoints decode to `None`, verified by a field-stripped legacy-payload test). Carries only refs/IDs — no resume token, unlike approval.
- **GateStage Block arm** stores the record when an auth gate blocks (before the `BeforeBlock` checkpoint write). Non-auth blocks leave the slot untouched so a resource/approval gate firing mid-re-dispatch can't erase a live record.
- **Resume re-dispatch:** prompt stage detects the slot and returns `PromptStep::ResumeAuth` (reusing `ApprovalResumePromptOutput` as a payload shape), routed through the same canonical arm as `ResumeApproval`. The re-invocation goes out token-less — the host re-evaluates auth fresh: credentials present → executes, result appended, model prompted next iteration with the real payload; still missing → blocks again with a refreshed record (idempotent, no model turn consumed).
- **Clear-on-every-outcome:** `clear_matching_pending_auth_resume` paired with the approval twin at all 7 capability-outcome sites; the AuthRequired arm clears then lets GateStage re-populate.

Plan: `docs/plans/2026-06-10-auth-gate-resume-redispatch.md`

## Status

- [x] Task 0: checkpoint codec investigation (serde JSON, additive `#[serde(default)]` field is compatible)
- [x] Task 1: `PendingAuthResume` state slot + round-trip/legacy-payload tests
- [x] Task 2: GateStage stores record on auth block + preservation across non-auth blocks
- [x] Task 3: resume re-dispatch in prompt stage + clear-on-completion
- [x] Task 4: re-block idempotency test + full quality gate

## Test plan

- [x] `cargo test -p ironclaw_agent_loop` green (291 lib tests + integration suites)
- [x] `cargo test -p ironclaw_reborn` (23) and `cargo test -p ironclaw_turns` (132) green, untouched
- [x] `cargo clippy --tests` zero warnings; `cargo fmt` clean
- [x] Checkpoint backward compat: field-stripped legacy payload decodes to `None`
- [x] End-to-end: block → checkpoint decode → seeded resume → token-less re-dispatch with original `input_ref` → result recorded → slot cleared → zero phase-2 model calls
- [x] Still-missing-credentials: re-blocks with refreshed `gate_ref`, no model turn, no spin
- [x] Non-auth gate block preserves a live auth resume record

🤖 Generated with [Claude Code](https://claude.com/claude-code)