### PR TITLE
Slack gate feedback: user-facing hints for rejected acks and delivery errors (Phase A)

### DIFF
--- a/crates/ironclaw_product_adapters/src/inbound.rs
+++ b/crates/ironclaw_product_adapters/src/inbound.rs
@@ -768,6 +768,21 @@ impl ProductRejectionKind {
             Self::PolicyDenied => "That request was declined by policy.",
         }
     }
+
+    /// Auth-resolution-flavored variant of [`Self::user_facing_hint`]: kinds whose
+    /// generic hint references approval commands get auth-specific guidance
+    /// (`auth deny <auth-request-ref>`); all other kinds reuse the generic hint.
+    pub fn user_facing_auth_hint(&self) -> &'static str {
+        match self {
+            Self::BindingRequired => {
+                "I couldn't match this reply to an active auth request. Reply in the auth prompt thread, or use `auth deny <auth-request-ref>` to decline."
+            }
+            Self::InvalidRequest => {
+                "I couldn't read that request. Use `auth deny <auth-request-ref>` to decline an auth request."
+            }
+            _ => self.user_facing_hint(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -1073,5 +1088,43 @@ mod tests {
             cases.len(),
             "every ProductRejectionKind must have a distinct user-facing hint"
         );
+    }
+
+    #[test]
+    fn rejection_kind_user_facing_auth_hint_overrides_approval_kinds_and_falls_through() {
+        // BindingRequired and InvalidRequest must return auth-specific guidance,
+        // not the approval-command text from user_facing_hint().
+        let binding_hint = ProductRejectionKind::BindingRequired.user_facing_auth_hint();
+        assert!(
+            binding_hint.contains("auth deny"),
+            "BindingRequired auth hint must reference 'auth deny', got: {binding_hint}"
+        );
+        assert!(
+            !binding_hint.contains("approve gate:"),
+            "BindingRequired auth hint must not contain approval command, got: {binding_hint}"
+        );
+
+        let invalid_hint = ProductRejectionKind::InvalidRequest.user_facing_auth_hint();
+        assert!(
+            invalid_hint.contains("auth deny"),
+            "InvalidRequest auth hint must reference 'auth deny', got: {invalid_hint}"
+        );
+        assert!(
+            !invalid_hint.contains("approve"),
+            "InvalidRequest auth hint must not contain approval command, got: {invalid_hint}"
+        );
+
+        // All other kinds fall through to user_facing_hint().
+        for kind in [
+            ProductRejectionKind::AccessDenied,
+            ProductRejectionKind::UnknownInstallation,
+            ProductRejectionKind::PolicyDenied,
+        ] {
+            assert_eq!(
+                kind.user_facing_auth_hint(),
+                kind.user_facing_hint(),
+                "{kind:?} auth hint must fall through to user_facing_hint()"
+            );
+        }
     }
 }

--- a/crates/ironclaw_product_adapters/src/inbound.rs
+++ b/crates/ironclaw_product_adapters/src/inbound.rs
@@ -751,6 +751,25 @@ impl ProductRejection {
     }
 }
 
+impl ProductRejectionKind {
+    /// Returns a sanitized, user-facing hint for this rejection kind.
+    ///
+    /// Never interpolates internal state, reasons, or redacted strings.
+    pub fn user_facing_hint(&self) -> &'static str {
+        match self {
+            Self::BindingRequired => {
+                "I couldn't match this reply to an active conversation. Reply in the approval thread, or use `approve gate:<ref>`."
+            }
+            Self::AccessDenied => "You don't have access to resolve this request.",
+            Self::UnknownInstallation => "This workspace isn't set up with IronClaw yet.",
+            Self::InvalidRequest => {
+                "I couldn't read that request. Use `approve` / `deny`, optionally with `gate:<ref>`."
+            }
+            Self::PolicyDenied => "That request was declined by policy.",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum InboundRetryDisposition {
@@ -1020,5 +1039,25 @@ mod tests {
             .retry_disposition(),
             InboundRetryDisposition::ReplayPrior
         );
+    }
+
+    #[test]
+    fn rejection_kind_user_facing_hint_is_exhaustive_and_sanitized() {
+        // Every variant must return a non-empty, static hint with no internal state.
+        let cases = [
+            (ProductRejectionKind::BindingRequired, "approve gate:"),
+            (ProductRejectionKind::AccessDenied, "access"),
+            (ProductRejectionKind::UnknownInstallation, "workspace"),
+            (ProductRejectionKind::InvalidRequest, "approve"),
+            (ProductRejectionKind::PolicyDenied, "policy"),
+        ];
+        for (kind, expected_substr) in &cases {
+            let hint = kind.user_facing_hint();
+            assert!(!hint.is_empty(), "{kind:?} hint must not be empty");
+            assert!(
+                hint.contains(expected_substr),
+                "{kind:?} hint '{hint}' must contain '{expected_substr}'"
+            );
+        }
     }
 }

--- a/crates/ironclaw_product_adapters/src/inbound.rs
+++ b/crates/ironclaw_product_adapters/src/inbound.rs
@@ -1059,5 +1059,19 @@ mod tests {
                 "{kind:?} hint '{hint}' must contain '{expected_substr}'"
             );
         }
+
+        // Hints must be pairwise distinct — two kinds sharing a hint would
+        // make the user-facing feedback ambiguous about what went wrong.
+        let mut hints: Vec<&str> = cases
+            .iter()
+            .map(|(kind, _)| kind.user_facing_hint())
+            .collect();
+        hints.sort_unstable();
+        hints.dedup();
+        assert_eq!(
+            hints.len(),
+            cases.len(),
+            "every ProductRejectionKind must have a distinct user-facing hint"
+        );
     }
 }

--- a/crates/ironclaw_reborn_composition/src/slack_delivery.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_delivery.rs
@@ -3015,6 +3015,77 @@ mod tests {
         );
     }
 
+    /// Accepted ack, then binding lookup fails → generic delivery-error notice
+    /// posted to the conversation (A3). Drives the observer (the caller), not
+    /// just `deliver_final_reply`, so the error→feedback mapping in
+    /// `observe_workflow_ack` is covered.
+    #[tokio::test]
+    async fn accepted_ack_then_binding_error_posts_delivery_error_notice() {
+        let install = "test-install";
+        let egress = Arc::new(FakeProtocolHttpEgress::new(vec!["slack.com".to_string()]));
+        egress.allow_credential_handle("slack_bot_token");
+        egress.program_response(
+            "slack.com",
+            Ok(EgressResponse::new(
+                200,
+                slack_post_ok_json("D123", "3000.1"),
+            )),
+        );
+
+        let outbound = Arc::new(InMemoryOutboundStateStore::default());
+        let coordinator = Arc::new(ScriptedTurnCoordinator::with_single_status(
+            TurnStatus::Running,
+        ));
+        let services = SlackFinalReplyDeliveryServices {
+            // Errors on lookup_binding, so delivery fails after the Accepted
+            // ack and before any polling.
+            binding_service: Arc::new(TestNoopConversationBindingService),
+            thread_service: Arc::new(InMemorySessionThreadService::default()),
+            turn_coordinator: coordinator,
+            outbound_store: outbound.clone(),
+            communication_preferences: outbound,
+            adapter: test_adapter(install),
+            egress: egress.clone(),
+            delivery_sink: Arc::new(FakeOutboundDeliverySink::default()),
+            auth_challenges: None,
+        };
+        let settings = SlackFinalReplyDeliverySettings {
+            poll_interval: std::time::Duration::ZERO,
+            max_wait: std::time::Duration::from_millis(1),
+            max_concurrent_deliveries: NonZeroUsize::new(1).unwrap(),
+            max_pending_deliveries: NonZeroUsize::new(8).unwrap(),
+        };
+        let observer = SlackFinalReplyDeliveryObserver::with_settings(services, settings);
+
+        let env = envelope(user_message_payload());
+        let ack = ProductInboundAck::Accepted {
+            accepted_message_ref: AcceptedMessageRef::new("slack:binding-error-test").expect("ref"),
+            submitted_run_id: TurnRunId::new(),
+        };
+
+        observer.observe_workflow_ack(env, ack).await;
+
+        let calls = egress.calls();
+        let post_calls: Vec<_> = calls
+            .iter()
+            .filter(|c| c.path == "/api/chat.postMessage")
+            .collect();
+        assert_eq!(
+            post_calls.len(),
+            1,
+            "expected exactly one chat.postMessage (the delivery-error notice), bodies: {:?}",
+            post_calls
+                .iter()
+                .map(|c| std::str::from_utf8(&c.body).unwrap_or("?"))
+                .collect::<Vec<_>>()
+        );
+        let body = std::str::from_utf8(&post_calls[0].body).unwrap_or("");
+        assert!(
+            body.contains("Something went wrong delivering the result"),
+            "post must contain the generic delivery-error notice, body: {body}"
+        );
+    }
+
     // --- OnceLock slot behaviour tests ----------------------------------------
 
     #[tokio::test]

--- a/crates/ironclaw_reborn_composition/src/slack_delivery.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_delivery.rs
@@ -3086,6 +3086,193 @@ mod tests {
         );
     }
 
+    /// Rejected AuthResolution ack → static user-facing hint posted; internal
+    /// rejection reason must not leak into the Slack message.
+    ///
+    /// This is the caller-level regression for `rejection_hint_for_resolution`
+    /// covering the `ProductInboundPayload::AuthResolution(_)` branch: the hint
+    /// must be the sanitized `user_facing_hint()` string, not the raw internal
+    /// reason stored in `ProductRejection::reason`.
+    #[tokio::test]
+    async fn rejected_auth_resolution_ack_posts_static_hint_not_internal_reason() {
+        let install = "test-install";
+        let egress = Arc::new(FakeProtocolHttpEgress::new(vec!["slack.com".to_string()]));
+        egress.allow_credential_handle("slack_bot_token");
+        // Program a success response for the hint post.
+        egress.program_response(
+            "slack.com",
+            Ok(EgressResponse::new(
+                200,
+                slack_post_ok_json("D123", "4000.1"),
+            )),
+        );
+
+        let outbound = Arc::new(InMemoryOutboundStateStore::default());
+        let coordinator = Arc::new(ScriptedTurnCoordinator::with_single_status(
+            TurnStatus::Running,
+        ));
+        let observer = make_observer(coordinator, egress.clone(), outbound, install);
+
+        // Build an AuthResolution envelope — this payload kind is included in
+        // `rejection_hint_for_resolution`'s `is_resolution` match but had no
+        // caller-level test before this one.
+        let auth_resolution_payload = ProductInboundPayload::AuthResolution(
+            ironclaw_product_adapters::AuthResolutionPayload::new(
+                "gate:auth-hint-test",
+                ironclaw_product_adapters::AuthResolutionResult::Denied,
+            )
+            .expect("auth resolution payload"),
+        );
+        let env = envelope(auth_resolution_payload);
+
+        // Use a rejection with a distinctive internal reason that must NOT appear
+        // in the posted message.
+        let internal_marker = "internal-secret-reason-marker";
+        let ack =
+            ProductInboundAck::Rejected(ironclaw_product_adapters::ProductRejection::permanent(
+                ironclaw_product_adapters::ProductRejectionKind::BindingRequired,
+                internal_marker,
+            ));
+
+        observer.observe_workflow_ack(env, ack).await;
+
+        let calls = egress.calls();
+        let post_calls: Vec<_> = calls
+            .iter()
+            .filter(|c| c.path == "/api/chat.postMessage")
+            .collect();
+        assert_eq!(
+            post_calls.len(),
+            1,
+            "expected exactly one chat.postMessage (the hint), bodies: {:?}",
+            post_calls
+                .iter()
+                .map(|c| std::str::from_utf8(&c.body).unwrap_or("?"))
+                .collect::<Vec<_>>()
+        );
+
+        let body = std::str::from_utf8(&post_calls[0].body).unwrap_or("");
+
+        // The posted text must contain the static user-facing hint for
+        // BindingRequired.
+        let expected_hint =
+            ironclaw_product_adapters::ProductRejectionKind::BindingRequired.user_facing_hint();
+        assert!(
+            body.contains(expected_hint),
+            "post must contain the static user-facing hint '{expected_hint}', body: {body}"
+        );
+
+        // The internal rejection reason must NOT appear in the post.
+        assert!(
+            !body.contains(internal_marker),
+            "post must not contain the internal rejection reason '{internal_marker}', body: {body}"
+        );
+    }
+
+    /// When a blocked-state notification (approval prompt) was delivered and
+    /// the subsequent wait times out, no additional timeout notice must be
+    /// posted to Slack.
+    ///
+    /// This is the caller-level regression for the
+    /// `RunWaitTimedOutAfterNotification` error variant: `observe_workflow_ack`
+    /// maps this variant to `feedback = None` so the user is not double-notified
+    /// after already seeing the approval prompt.
+    #[tokio::test]
+    async fn timeout_after_blocked_notification_suppresses_timeout_message() {
+        use ironclaw_product_workflow::FakeConversationBindingService;
+
+        let install = "test-install";
+        let gate_ref_str = "gate:approval-timeout-test";
+        let egress = Arc::new(FakeProtocolHttpEgress::new(vec!["slack.com".to_string()]));
+        egress.allow_credential_handle("slack_bot_token");
+        // One programmed response for the approval-prompt postMessage.
+        // No second response — if the timeout notice were posted, the test
+        // would fail because `FakeProtocolHttpEgress` returns an error on
+        // an empty queue.
+        egress.program_response(
+            "slack.com",
+            Ok(EgressResponse::new(
+                200,
+                slack_post_ok_json("D123", "5000.1"),
+            )),
+        );
+
+        let outbound = Arc::new(InMemoryOutboundStateStore::default());
+        // Always BlockedApproval with the same gate_ref: the first poll exits
+        // `wait_for_actionable` immediately (new blocked state, different from
+        // `delivered_blocked_marker=None`), delivering the approval prompt.
+        // Subsequent polls (second call to `wait_for_actionable`) return the same
+        // marker as `delivered_blocked_marker`, so the loop does not exit — it
+        // times out after `max_wait=1ms` and the error is converted to
+        // `RunWaitTimedOutAfterNotification`.
+        let coordinator = Arc::new(ScriptedTurnCoordinator::with_states(vec![scripted_state(
+            TurnStatus::BlockedApproval,
+            Some(gate_ref_str),
+        )]));
+
+        let binding_service = Arc::new(FakeConversationBindingService::new());
+        let thread_service = Arc::new(InMemorySessionThreadService::default());
+        let services = SlackFinalReplyDeliveryServices {
+            binding_service,
+            thread_service,
+            turn_coordinator: coordinator,
+            outbound_store: outbound.clone(),
+            communication_preferences: outbound,
+            adapter: test_adapter(install),
+            egress: egress.clone(),
+            delivery_sink: Arc::new(FakeOutboundDeliverySink::default()),
+            auth_challenges: None,
+        };
+        let settings = SlackFinalReplyDeliverySettings {
+            poll_interval: std::time::Duration::ZERO,
+            max_wait: std::time::Duration::from_millis(1),
+            max_concurrent_deliveries: NonZeroUsize::new(1).unwrap(),
+            max_pending_deliveries: NonZeroUsize::new(8).unwrap(),
+        };
+        let observer = SlackFinalReplyDeliveryObserver::with_settings(services, settings);
+
+        let run_id = TurnRunId::new();
+        let env = envelope(user_message_payload());
+        let ack = ProductInboundAck::Accepted {
+            accepted_message_ref: AcceptedMessageRef::new("slack:blocked-timeout-test")
+                .expect("ref"),
+            submitted_run_id: run_id,
+        };
+
+        observer.observe_workflow_ack(env, ack).await;
+
+        let calls = egress.calls();
+        let post_calls: Vec<_> = calls
+            .iter()
+            .filter(|c| c.path == "/api/chat.postMessage")
+            .collect();
+
+        // Exactly one postMessage: the approval prompt notification.
+        // No timeout notice must have been posted.
+        assert_eq!(
+            post_calls.len(),
+            1,
+            "expected exactly one chat.postMessage (the approval prompt), bodies: {:?}",
+            post_calls
+                .iter()
+                .map(|c| std::str::from_utf8(&c.body).unwrap_or("?"))
+                .collect::<Vec<_>>()
+        );
+
+        let body = std::str::from_utf8(&post_calls[0].body).unwrap_or("");
+
+        // The one message must be the approval prompt, not a timeout notice.
+        assert!(
+            !body.contains("longer than expected"),
+            "timeout notice must not be posted after blocked-notification timeout, body: {body}"
+        );
+        // The approval prompt must reference the gate ref.
+        assert!(
+            body.contains(gate_ref_str),
+            "approval prompt must reference the gate ref, body: {body}"
+        );
+    }
+
     // --- OnceLock slot behaviour tests ----------------------------------------
 
     #[tokio::test]

--- a/crates/ironclaw_reborn_composition/src/slack_delivery.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_delivery.rs
@@ -27,8 +27,9 @@ use ironclaw_product_adapters::{
     DeclaredEgressHost, EgressCredentialHandle, EgressHeader, EgressMethod, EgressPath,
     EgressRequest, EgressResponse, ExternalActorRef, ExternalConversationRef, FinalReplyView,
     GatePromptView, OutboundDeliverySink, ProductAdapter, ProductAdapterError, ProductInboundAck,
-    ProductInboundEnvelope, ProductInboundPayload, ProductOutboundPayload, ProductTriggerReason,
-    ProtocolHttpEgress, ProtocolHttpEgressError,
+    ProductInboundEnvelope, ProductInboundPayload, ProductOutboundPayload, ProductRejection,
+    ProductRejectionKind, ProductTriggerReason, ProductWorkflowRejectionKind, ProtocolHttpEgress,
+    ProtocolHttpEgressError,
 };
 use ironclaw_product_workflow::{
     ConversationBindingService, ProductOutboundDeliveryRequest, ProductOutboundTargetResolver,
@@ -145,26 +146,6 @@ impl SlackFinalReplyDeliveryObserver {
                 SLACK_AUTH_CANCELED_MESSAGE,
             )
             .await?;
-            return Ok(());
-        }
-        // A2: For rejected resolution attempts, post a user-facing hint back to the
-        // conversation so the user knows why their approve/deny was not processed.
-        if let Some(hint) = rejection_hint_for_resolution(&envelope, &ack) {
-            if let Err(error) = post_slack_message(
-                self.services.egress.as_ref(),
-                envelope.external_conversation_ref(),
-                hint,
-            )
-            .await
-            {
-                tracing::debug!(
-                    target = "ironclaw::reborn::slack_delivery",
-                    error = %error,
-                    "failed to post rejection hint to Slack (best-effort)"
-                );
-            }
-            // A rejected resolution ack never carries a run to deliver; return
-            // explicitly rather than relying on the guards below to no-op.
             return Ok(());
         }
         if !should_deliver_after_ack(&envelope, &ack) {
@@ -500,6 +481,43 @@ impl SlackFinalReplyDeliveryObserver {
             );
         }
     }
+
+    async fn post_rejection_hint_if_authorized(
+        &self,
+        envelope: &ProductInboundEnvelope,
+        ack: &ProductInboundAck,
+    ) -> bool {
+        let Some(hint) = rejection_hint_for_resolution(envelope, ack) else {
+            return false;
+        };
+        if let Err(error) = self
+            .services
+            .binding_service
+            .lookup_binding(ResolveBindingRequest::from_envelope(envelope))
+            .await
+        {
+            tracing::debug!(
+                target = "ironclaw::reborn::slack_delivery",
+                error = %error,
+                "skipped Slack rejection hint because the originating conversation was not authorized"
+            );
+            return true;
+        }
+        if let Err(error) = post_slack_message(
+            self.services.egress.as_ref(),
+            envelope.external_conversation_ref(),
+            hint,
+        )
+        .await
+        {
+            tracing::debug!(
+                target = "ironclaw::reborn::slack_delivery",
+                error = %error,
+                "failed to post rejection hint to Slack (best-effort)"
+            );
+        }
+        true
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -767,6 +785,15 @@ fn jittered_poll_interval(base: Duration, run_id: &TurnRunId) -> Duration {
 #[async_trait]
 impl ImmediateAckWorkflowObserver for SlackFinalReplyDeliveryObserver {
     async fn observe_workflow_ack(&self, envelope: ProductInboundEnvelope, ack: ProductInboundAck) {
+        // A2: rejected approval/auth feedback is a single best-effort post, not a
+        // long-running final delivery. Handle it before taking the shared delivery
+        // semaphore so it cannot queue behind runs that may poll until max_wait.
+        if self
+            .post_rejection_hint_if_authorized(&envelope, &ack)
+            .await
+        {
+            return;
+        }
         let Ok(_permit) = self.delivery_permits.clone().acquire_owned().await else {
             tracing::warn!(
                 target = "ironclaw::reborn::slack_delivery",
@@ -805,6 +832,18 @@ impl ImmediateAckWorkflowObserver for SlackFinalReplyDeliveryObserver {
                 );
             }
         }
+    }
+
+    async fn observe_workflow_error(
+        &self,
+        envelope: ProductInboundEnvelope,
+        error: ProductAdapterError,
+    ) {
+        let Some(ack) = rejection_ack_for_workflow_error(&error) else {
+            return;
+        };
+        self.post_rejection_hint_if_authorized(&envelope, &ack)
+            .await;
     }
 }
 
@@ -958,6 +997,34 @@ fn rejection_hint_for_resolution(
         _ => effective_rejection.kind.user_facing_hint(),
     };
     Some(hint)
+}
+
+fn rejection_ack_for_workflow_error(error: &ProductAdapterError) -> Option<ProductInboundAck> {
+    match error {
+        ProductAdapterError::WorkflowRejected {
+            kind,
+            retryable: false,
+            ..
+        } => Some(ProductInboundAck::Rejected(ProductRejection::permanent(
+            product_rejection_kind_for_workflow_rejection(*kind),
+            "workflow rejected resolution",
+        ))),
+        _ => None,
+    }
+}
+
+fn product_rejection_kind_for_workflow_rejection(
+    kind: ProductWorkflowRejectionKind,
+) -> ProductRejectionKind {
+    match kind {
+        ProductWorkflowRejectionKind::ScopeNotFound => ProductRejectionKind::BindingRequired,
+        ProductWorkflowRejectionKind::Unauthorized => ProductRejectionKind::AccessDenied,
+        ProductWorkflowRejectionKind::InvalidRequest => ProductRejectionKind::InvalidRequest,
+        ProductWorkflowRejectionKind::ThreadBusy
+        | ProductWorkflowRejectionKind::AdmissionRejected
+        | ProductWorkflowRejectionKind::Unavailable
+        | ProductWorkflowRejectionKind::Conflict => ProductRejectionKind::PolicyDenied,
+    }
 }
 
 fn is_accepted_auth_denial(envelope: &ProductInboundEnvelope, ack: &ProductInboundAck) -> bool {
@@ -2752,14 +2819,20 @@ mod tests {
         outbound: Arc<InMemoryOutboundStateStore>,
         installation_id: &str,
     ) -> SlackFinalReplyDeliveryObserver {
+        use ironclaw_product_workflow::FakeConversationBindingService;
+
         let thread_service = Arc::new(InMemorySessionThreadService::default());
-        let services = make_services(
-            coordinator,
+        let services = SlackFinalReplyDeliveryServices {
+            binding_service: Arc::new(FakeConversationBindingService::new()),
             thread_service,
+            turn_coordinator: coordinator,
+            outbound_store: outbound.clone(),
+            communication_preferences: outbound,
+            adapter: test_adapter(installation_id),
             egress,
-            outbound,
-            installation_id,
-        );
+            delivery_sink: Arc::new(FakeOutboundDeliverySink::default()),
+            auth_challenges: None,
+        };
         let settings = SlackFinalReplyDeliverySettings {
             poll_interval: std::time::Duration::ZERO,
             max_wait: std::time::Duration::from_millis(1),
@@ -2782,6 +2855,16 @@ mod tests {
                 ironclaw_product_adapters::ApprovalDecision::ApproveOnce,
             )
             .expect("scoped approval resolution"),
+        )
+    }
+
+    fn approval_resolution_payload() -> ProductInboundPayload {
+        ProductInboundPayload::ApprovalResolution(
+            ironclaw_product_adapters::ApprovalResolutionPayload::new(
+                "gate:approval-hint-test",
+                ironclaw_product_adapters::ApprovalDecision::ApproveOnce,
+            )
+            .expect("approval resolution"),
         )
     }
 
@@ -2836,6 +2919,47 @@ mod tests {
         assert!(
             body.contains("approve gate:"),
             "rejection hint body must contain 'approve gate:', got: {body}"
+        );
+    }
+
+    /// Rejected unscoped approval ack → hint posted to the envelope conversation.
+    #[tokio::test]
+    async fn rejected_approval_resolution_ack_posts_hint_to_conversation() {
+        let install = "test-install";
+        let egress = Arc::new(FakeProtocolHttpEgress::new(vec!["slack.com".to_string()]));
+        egress.allow_credential_handle("slack_bot_token");
+        egress.program_response(
+            "slack.com",
+            Ok(EgressResponse::new(
+                200,
+                slack_post_ok_json("D123", "1000.2"),
+            )),
+        );
+
+        let outbound = Arc::new(InMemoryOutboundStateStore::default());
+        let coordinator = Arc::new(ScriptedTurnCoordinator::with_single_status(
+            TurnStatus::Running,
+        ));
+        let observer = make_observer(coordinator, egress.clone(), outbound, install);
+        let env = envelope(approval_resolution_payload());
+        let ack = rejected_ack(ironclaw_product_adapters::ProductRejectionKind::BindingRequired);
+
+        observer.observe_workflow_ack(env, ack).await;
+
+        let calls = egress.calls();
+        let post_calls: Vec<_> = calls
+            .iter()
+            .filter(|c| c.path == "/api/chat.postMessage")
+            .collect();
+        assert_eq!(
+            post_calls.len(),
+            1,
+            "expected exactly one hint chat.postMessage call"
+        );
+        let body = std::str::from_utf8(&post_calls[0].body).expect("utf8 body");
+        assert!(
+            body.contains("approve gate:"),
+            "rejection hint body must contain approval guidance, got: {body}"
         );
     }
 
@@ -2895,6 +3019,34 @@ mod tests {
         );
     }
 
+    /// Duplicate { prior: Rejected } → nothing posted at observer level.
+    #[tokio::test]
+    async fn duplicate_rejected_ack_posts_nothing() {
+        let install = "test-install";
+        let egress = Arc::new(FakeProtocolHttpEgress::new(vec!["slack.com".to_string()]));
+        egress.allow_credential_handle("slack_bot_token");
+
+        let outbound = Arc::new(InMemoryOutboundStateStore::default());
+        let coordinator = Arc::new(ScriptedTurnCoordinator::with_single_status(
+            TurnStatus::Running,
+        ));
+        let observer = make_observer(coordinator, egress.clone(), outbound, install);
+        let env = envelope(scoped_approval_resolution_payload());
+        let ack = ProductInboundAck::Duplicate {
+            prior: Box::new(rejected_ack(
+                ironclaw_product_adapters::ProductRejectionKind::BindingRequired,
+            )),
+        };
+
+        observer.observe_workflow_ack(env, ack).await;
+
+        let calls = egress.calls();
+        assert!(
+            !calls.iter().any(|c| c.path == "/api/chat.postMessage"),
+            "no chat.postMessage expected for Duplicate{{Rejected}}"
+        );
+    }
+
     /// All `Duplicate` acks suppress the hint, regardless of the prior inside.
     ///
     /// `Duplicate` is keyed on the external event id: transport retries of the
@@ -2926,6 +3078,36 @@ mod tests {
         assert!(
             rejection_hint_for_resolution(&env, &duplicate_accepted).is_none(),
             "Duplicate{{Accepted}} must not produce a hint"
+        );
+    }
+
+    /// A failed best-effort rejection-hint post must not fall through into generic
+    /// delivery-error feedback.
+    #[tokio::test]
+    async fn rejected_resolution_hint_post_failure_is_best_effort() {
+        let install = "test-install";
+        let egress = Arc::new(FakeProtocolHttpEgress::new(vec!["slack.com".to_string()]));
+        egress.allow_credential_handle("slack_bot_token");
+
+        let outbound = Arc::new(InMemoryOutboundStateStore::default());
+        let coordinator = Arc::new(ScriptedTurnCoordinator::with_single_status(
+            TurnStatus::Running,
+        ));
+        let observer = make_observer(coordinator, egress.clone(), outbound, install);
+        let env = envelope(scoped_approval_resolution_payload());
+        let ack = rejected_ack(ironclaw_product_adapters::ProductRejectionKind::BindingRequired);
+
+        observer.observe_workflow_ack(env, ack).await;
+
+        let calls = egress.calls();
+        let post_calls: Vec<_> = calls
+            .iter()
+            .filter(|c| c.path == "/api/chat.postMessage")
+            .collect();
+        assert_eq!(
+            post_calls.len(),
+            1,
+            "expected exactly one failed best-effort hint post"
         );
     }
 
@@ -3180,6 +3362,101 @@ mod tests {
         );
     }
 
+    /// WorkflowRejected errors after protocol ACK still post resolution hints when
+    /// the originating conversation is authorized.
+    #[tokio::test]
+    async fn workflow_rejected_resolution_error_posts_authorized_hint() {
+        let install = "test-install";
+        let egress = Arc::new(FakeProtocolHttpEgress::new(vec!["slack.com".to_string()]));
+        egress.allow_credential_handle("slack_bot_token");
+        egress.program_response(
+            "slack.com",
+            Ok(EgressResponse::new(
+                200,
+                slack_post_ok_json("D123", "4500.1"),
+            )),
+        );
+
+        let outbound = Arc::new(InMemoryOutboundStateStore::default());
+        let coordinator = Arc::new(ScriptedTurnCoordinator::with_single_status(
+            TurnStatus::Running,
+        ));
+        let observer = make_observer(coordinator, egress.clone(), outbound, install);
+        let env = envelope(scoped_approval_resolution_payload());
+        let error = ProductAdapterError::WorkflowRejected {
+            kind: ProductWorkflowRejectionKind::ScopeNotFound,
+            status_code: 404,
+            retryable: false,
+            reason: ironclaw_product_adapters::RedactedString::new("missing gate"),
+        };
+
+        observer.observe_workflow_error(env, error).await;
+
+        let calls = egress.calls();
+        let post_calls: Vec<_> = calls
+            .iter()
+            .filter(|c| c.path == "/api/chat.postMessage")
+            .collect();
+        assert_eq!(
+            post_calls.len(),
+            1,
+            "expected exactly one hint chat.postMessage call"
+        );
+        let body = std::str::from_utf8(&post_calls[0].body).expect("utf8 body");
+        assert!(
+            body.contains("approve gate:"),
+            "workflow rejection hint body must contain approval guidance, got: {body}"
+        );
+        assert!(
+            !body.contains("missing gate"),
+            "workflow rejection hint must not expose redacted reason, got: {body}"
+        );
+    }
+
+    /// If route/binding authorization fails, rejected-resolution feedback is
+    /// suppressed instead of posting to an arbitrary shared Slack conversation.
+    #[tokio::test]
+    async fn workflow_rejected_resolution_error_without_binding_posts_nothing() {
+        let install = "test-install";
+        let egress = Arc::new(FakeProtocolHttpEgress::new(vec!["slack.com".to_string()]));
+        egress.allow_credential_handle("slack_bot_token");
+
+        let outbound = Arc::new(InMemoryOutboundStateStore::default());
+        let coordinator = Arc::new(ScriptedTurnCoordinator::with_single_status(
+            TurnStatus::Running,
+        ));
+        let thread_service = Arc::new(InMemorySessionThreadService::default());
+        let services = make_services(
+            coordinator,
+            thread_service,
+            egress.clone(),
+            outbound,
+            install,
+        );
+        let settings = SlackFinalReplyDeliverySettings {
+            poll_interval: std::time::Duration::ZERO,
+            max_wait: std::time::Duration::from_millis(1),
+            max_concurrent_deliveries: NonZeroUsize::new(1).unwrap(),
+            max_pending_deliveries: NonZeroUsize::new(8).unwrap(),
+        };
+        let observer = SlackFinalReplyDeliveryObserver::with_settings(services, settings);
+        let env = envelope(scoped_approval_resolution_payload());
+        let error = ProductAdapterError::WorkflowRejected {
+            kind: ProductWorkflowRejectionKind::ScopeNotFound,
+            status_code: 404,
+            retryable: false,
+            reason: ironclaw_product_adapters::RedactedString::new("missing gate"),
+        };
+
+        observer.observe_workflow_error(env, error).await;
+
+        let calls = egress.calls();
+        assert!(
+            !calls.iter().any(|c| c.path == "/api/chat.postMessage"),
+            "no chat.postMessage expected when binding authorization fails"
+        );
+    }
+
     /// When a blocked-state notification (approval prompt) was delivered and
     /// the subsequent wait times out, no additional timeout notice must be
     /// posted to Slack.
@@ -3281,6 +3558,85 @@ mod tests {
         assert!(
             body.contains(gate_ref_str),
             "approval prompt must reference the gate ref, body: {body}"
+        );
+    }
+
+    /// Same suppression as the approval-prompt case, but through the auth prompt
+    /// payload path.
+    #[tokio::test]
+    async fn timeout_after_auth_blocked_notification_suppresses_timeout_message() {
+        use ironclaw_product_workflow::FakeConversationBindingService;
+
+        let install = "test-install";
+        let gate_ref_str = "gate:auth-timeout-test";
+        let egress = Arc::new(FakeProtocolHttpEgress::new(vec!["slack.com".to_string()]));
+        egress.allow_credential_handle("slack_bot_token");
+        egress.program_response(
+            "slack.com",
+            Ok(EgressResponse::new(
+                200,
+                slack_post_ok_json("D123", "5000.2"),
+            )),
+        );
+
+        let outbound = Arc::new(InMemoryOutboundStateStore::default());
+        let coordinator = Arc::new(ScriptedTurnCoordinator::with_states(vec![scripted_state(
+            TurnStatus::BlockedAuth,
+            Some(gate_ref_str),
+        )]));
+
+        let binding_service = Arc::new(FakeConversationBindingService::new());
+        let thread_service = Arc::new(InMemorySessionThreadService::default());
+        let services = SlackFinalReplyDeliveryServices {
+            binding_service,
+            thread_service,
+            turn_coordinator: coordinator,
+            outbound_store: outbound.clone(),
+            communication_preferences: outbound,
+            adapter: test_adapter(install),
+            egress: egress.clone(),
+            delivery_sink: Arc::new(FakeOutboundDeliverySink::default()),
+            auth_challenges: None,
+        };
+        let settings = SlackFinalReplyDeliverySettings {
+            poll_interval: std::time::Duration::ZERO,
+            max_wait: std::time::Duration::from_millis(1),
+            max_concurrent_deliveries: NonZeroUsize::new(1).unwrap(),
+            max_pending_deliveries: NonZeroUsize::new(8).unwrap(),
+        };
+        let observer = SlackFinalReplyDeliveryObserver::with_settings(services, settings);
+
+        let env = envelope(user_message_payload());
+        let ack = ProductInboundAck::Accepted {
+            accepted_message_ref: AcceptedMessageRef::new("slack:auth-blocked-timeout-test")
+                .expect("ref"),
+            submitted_run_id: TurnRunId::new(),
+        };
+
+        observer.observe_workflow_ack(env, ack).await;
+
+        let calls = egress.calls();
+        let post_calls: Vec<_> = calls
+            .iter()
+            .filter(|c| c.path == "/api/chat.postMessage")
+            .collect();
+        assert_eq!(
+            post_calls.len(),
+            1,
+            "expected exactly one chat.postMessage (the auth prompt), bodies: {:?}",
+            post_calls
+                .iter()
+                .map(|c| std::str::from_utf8(&c.body).unwrap_or("?"))
+                .collect::<Vec<_>>()
+        );
+        let body = std::str::from_utf8(&post_calls[0].body).unwrap_or("");
+        assert!(
+            !body.contains("longer than expected"),
+            "timeout notice must not be posted after auth notification timeout, body: {body}"
+        );
+        assert!(
+            body.contains(gate_ref_str),
+            "auth prompt must reference the gate ref, body: {body}"
         );
     }
 

--- a/crates/ironclaw_reborn_composition/src/slack_delivery.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_delivery.rs
@@ -149,19 +149,23 @@ impl SlackFinalReplyDeliveryObserver {
         }
         // A2: For rejected resolution attempts, post a user-facing hint back to the
         // conversation so the user knows why their approve/deny was not processed.
-        if let Some(hint) = rejection_hint_for_resolution(&envelope, &ack)
-            && let Err(error) = post_slack_message(
+        if let Some(hint) = rejection_hint_for_resolution(&envelope, &ack) {
+            if let Err(error) = post_slack_message(
                 self.services.egress.as_ref(),
                 envelope.external_conversation_ref(),
                 hint,
             )
             .await
-        {
-            tracing::debug!(
-                target = "ironclaw::reborn::slack_delivery",
-                error = %error,
-                "failed to post rejection hint to Slack (best-effort)"
-            );
+            {
+                tracing::debug!(
+                    target = "ironclaw::reborn::slack_delivery",
+                    error = %error,
+                    "failed to post rejection hint to Slack (best-effort)"
+                );
+            }
+            // A rejected resolution ack never carries a run to deliver; return
+            // explicitly rather than relying on the guards below to no-op.
+            return Ok(());
         }
         if !should_deliver_after_ack(&envelope, &ack) {
             return Ok(());
@@ -925,8 +929,13 @@ fn rejection_hint_for_resolution(
     envelope: &ProductInboundEnvelope,
     ack: &ProductInboundAck,
 ) -> Option<&'static str> {
-    // Unwrap Duplicate recursively, but only one level — a re-sent approve that
-    // was already accepted must not produce an error message.
+    // Deliberately unwrap Duplicate exactly one level, not recursively: the
+    // inbound ledger stores the original (non-Duplicate) ack as `prior`, so a
+    // re-sent approve always arrives as Duplicate{original}. Deeper nesting
+    // would mean the ledger stored a Duplicate, which the pipeline never
+    // produces, so it is treated as non-rejected (no hint) rather than
+    // unwrapped further. A re-sent approve whose original succeeded
+    // (Duplicate{Accepted}) must not produce an error message.
     let effective_rejection: &ProductRejection = match ack {
         ProductInboundAck::Rejected(rejection) => rejection,
         ProductInboundAck::Duplicate { prior } => match prior.as_ref() {
@@ -2884,6 +2893,38 @@ mod tests {
         );
     }
 
+    /// Duplicate unwrapping is deliberately single-level: Duplicate{Rejected}
+    /// posts a hint, but Duplicate{Duplicate{Rejected}} does not. The inbound
+    /// ledger stores the original ack as `prior`, so duplicates wrap exactly
+    /// one level; deeper nesting never occurs in the pipeline and is treated
+    /// as non-rejected.
+    #[test]
+    fn rejection_hint_unwraps_duplicate_exactly_one_level() {
+        let env = envelope(scoped_approval_resolution_payload());
+
+        let single = ProductInboundAck::Duplicate {
+            prior: Box::new(rejected_ack(
+                ironclaw_product_adapters::ProductRejectionKind::BindingRequired,
+            )),
+        };
+        assert!(
+            rejection_hint_for_resolution(&env, &single).is_some(),
+            "Duplicate{{Rejected}} must produce a hint"
+        );
+
+        let double = ProductInboundAck::Duplicate {
+            prior: Box::new(ProductInboundAck::Duplicate {
+                prior: Box::new(rejected_ack(
+                    ironclaw_product_adapters::ProductRejectionKind::BindingRequired,
+                )),
+            }),
+        };
+        assert!(
+            rejection_hint_for_resolution(&env, &double).is_none(),
+            "Duplicate{{Duplicate{{Rejected}}}} must not produce a hint (single-level unwrap)"
+        );
+    }
+
     /// Delivery error (RunWaitTimedOut) → timeout notice posted to conversation.
     ///
     /// Uses `FakeConversationBindingService` so the binding lookup succeeds and
@@ -2961,14 +3002,12 @@ mod tests {
             "expected at least one chat.postMessage for timeout notice"
         );
 
-        // At least one post must contain the timeout message text.
-        let timeout_found = post_calls.iter().any(|c| {
-            let body = std::str::from_utf8(&c.body).unwrap_or("");
-            body.contains("longer than expected")
-        });
+        // The timeout notice must be the final post — a working message may
+        // precede it, but nothing should be posted after the timeout notice.
+        let last_body = std::str::from_utf8(&post_calls[post_calls.len() - 1].body).unwrap_or("");
         assert!(
-            timeout_found,
-            "at least one chat.postMessage must contain timeout notice text, bodies: {:?}",
+            last_body.contains("longer than expected"),
+            "last chat.postMessage must contain timeout notice text, bodies: {:?}",
             post_calls
                 .iter()
                 .map(|c| std::str::from_utf8(&c.body).unwrap_or("?"))

--- a/crates/ironclaw_reborn_composition/src/slack_delivery.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_delivery.rs
@@ -27,8 +27,8 @@ use ironclaw_product_adapters::{
     DeclaredEgressHost, EgressCredentialHandle, EgressHeader, EgressMethod, EgressPath,
     EgressRequest, EgressResponse, ExternalActorRef, ExternalConversationRef, FinalReplyView,
     GatePromptView, OutboundDeliverySink, ProductAdapter, ProductAdapterError, ProductInboundAck,
-    ProductInboundEnvelope, ProductInboundPayload, ProductOutboundPayload, ProductRejection,
-    ProductTriggerReason, ProtocolHttpEgress, ProtocolHttpEgressError,
+    ProductInboundEnvelope, ProductInboundPayload, ProductOutboundPayload, ProductTriggerReason,
+    ProtocolHttpEgress, ProtocolHttpEgressError,
 };
 use ironclaw_product_workflow::{
     ConversationBindingService, ProductOutboundDeliveryRequest, ProductOutboundTargetResolver,
@@ -924,25 +924,21 @@ fn should_deliver_after_ack(envelope: &ProductInboundEnvelope, ack: &ProductInbo
 
 /// Returns the user-facing hint to post when a resolution attempt (approval or
 /// auth) is rejected. Returns `None` for non-resolution payloads (e.g. user
-/// messages) or for `Duplicate` wrapping a non-rejected prior ack.
+/// messages) or for any `Duplicate` ack regardless of the prior ack inside it.
 fn rejection_hint_for_resolution(
     envelope: &ProductInboundEnvelope,
     ack: &ProductInboundAck,
 ) -> Option<&'static str> {
-    // Deliberately unwrap Duplicate exactly one level, not recursively: the
-    // inbound ledger stores the original (non-Duplicate) ack as `prior`, so a
-    // re-sent approve always arrives as Duplicate{original}. Deeper nesting
-    // would mean the ledger stored a Duplicate, which the pipeline never
-    // produces, so it is treated as non-rejected (no hint) rather than
-    // unwrapped further. A re-sent approve whose original succeeded
-    // (Duplicate{Accepted}) must not produce an error message.
-    let effective_rejection: &ProductRejection = match ack {
-        ProductInboundAck::Rejected(rejection) => rejection,
-        ProductInboundAck::Duplicate { prior } => match prior.as_ref() {
-            ProductInboundAck::Rejected(rejection) => rejection,
-            _ => return None,
-        },
-        _ => return None,
+    // `Duplicate` is keyed on the external event id (see `ActionFingerprintKey`
+    // in ironclaw_product_workflow): Slack transport retries reuse the same
+    // event id, so the same event arriving N times produces Duplicate{original}
+    // on the second through Nth delivery. A user re-typing "approve" produces a
+    // new event id and therefore a fresh `Rejected` ack, never `Duplicate`.
+    // Posting a hint on `Duplicate{Rejected}` would repeat the side effect N
+    // times on transport retries while suppressing it loses nothing — the
+    // original processing already posted the hint.
+    let ProductInboundAck::Rejected(effective_rejection) = ack else {
+        return None;
     };
     // Only post feedback for resolution-type payloads; user messages and other
     // payloads that happen to be rejected produce no channel noise.
@@ -955,7 +951,13 @@ fn rejection_hint_for_resolution(
     if !is_resolution {
         return None;
     }
-    Some(effective_rejection.kind.user_facing_hint())
+    let hint = match envelope.payload() {
+        ProductInboundPayload::AuthResolution(_) => {
+            effective_rejection.kind.user_facing_auth_hint()
+        }
+        _ => effective_rejection.kind.user_facing_hint(),
+    };
+    Some(hint)
 }
 
 fn is_accepted_auth_denial(envelope: &ProductInboundEnvelope, ack: &ProductInboundAck) -> bool {
@@ -2893,35 +2895,37 @@ mod tests {
         );
     }
 
-    /// Duplicate unwrapping is deliberately single-level: Duplicate{Rejected}
-    /// posts a hint, but Duplicate{Duplicate{Rejected}} does not. The inbound
-    /// ledger stores the original ack as `prior`, so duplicates wrap exactly
-    /// one level; deeper nesting never occurs in the pipeline and is treated
-    /// as non-rejected.
+    /// All `Duplicate` acks suppress the hint, regardless of the prior inside.
+    ///
+    /// `Duplicate` is keyed on the external event id: transport retries of the
+    /// same Slack event land as `Duplicate{original}`. The original processing
+    /// already posted any hint, so replays must not repeat the side effect.
+    /// A user re-typing "approve" produces a new event id → a fresh `Rejected`,
+    /// never a `Duplicate`, so suppressing `Duplicate{Rejected}` loses nothing.
     #[test]
-    fn rejection_hint_unwraps_duplicate_exactly_one_level() {
+    fn duplicate_acks_produce_no_hint() {
         let env = envelope(scoped_approval_resolution_payload());
 
-        let single = ProductInboundAck::Duplicate {
+        let duplicate_rejected = ProductInboundAck::Duplicate {
             prior: Box::new(rejected_ack(
                 ironclaw_product_adapters::ProductRejectionKind::BindingRequired,
             )),
         };
         assert!(
-            rejection_hint_for_resolution(&env, &single).is_some(),
-            "Duplicate{{Rejected}} must produce a hint"
+            rejection_hint_for_resolution(&env, &duplicate_rejected).is_none(),
+            "Duplicate{{Rejected}} must NOT produce a hint (transport replay)"
         );
 
-        let double = ProductInboundAck::Duplicate {
-            prior: Box::new(ProductInboundAck::Duplicate {
-                prior: Box::new(rejected_ack(
-                    ironclaw_product_adapters::ProductRejectionKind::BindingRequired,
-                )),
+        let duplicate_accepted = ProductInboundAck::Duplicate {
+            prior: Box::new(ProductInboundAck::Accepted {
+                accepted_message_ref: ironclaw_turns::AcceptedMessageRef::new("slack:prior")
+                    .expect("ref"),
+                submitted_run_id: ironclaw_turns::TurnRunId::new(),
             }),
         };
         assert!(
-            rejection_hint_for_resolution(&env, &double).is_none(),
-            "Duplicate{{Duplicate{{Rejected}}}} must not produce a hint (single-level unwrap)"
+            rejection_hint_for_resolution(&env, &duplicate_accepted).is_none(),
+            "Duplicate{{Accepted}} must not produce a hint"
         );
     }
 
@@ -3086,13 +3090,14 @@ mod tests {
         );
     }
 
-    /// Rejected AuthResolution ack → static user-facing hint posted; internal
-    /// rejection reason must not leak into the Slack message.
+    /// Rejected AuthResolution ack → auth-flavored hint posted; approval
+    /// command text and internal rejection reason must not appear.
     ///
     /// This is the caller-level regression for `rejection_hint_for_resolution`
     /// covering the `ProductInboundPayload::AuthResolution(_)` branch: the hint
-    /// must be the sanitized `user_facing_hint()` string, not the raw internal
-    /// reason stored in `ProductRejection::reason`.
+    /// must come from `user_facing_auth_hint()` (which references `auth deny
+    /// <auth-request-ref>`), not from `user_facing_hint()` (which references
+    /// approval commands), and not from the raw internal reason.
     #[tokio::test]
     async fn rejected_auth_resolution_ack_posts_static_hint_not_internal_reason() {
         let install = "test-install";
@@ -3153,13 +3158,19 @@ mod tests {
 
         let body = std::str::from_utf8(&post_calls[0].body).unwrap_or("");
 
-        // The posted text must contain the static user-facing hint for
-        // BindingRequired.
-        let expected_hint =
-            ironclaw_product_adapters::ProductRejectionKind::BindingRequired.user_facing_hint();
+        // The posted text must contain the auth-specific hint for BindingRequired,
+        // not the approval-command variant.
+        let expected_hint = ironclaw_product_adapters::ProductRejectionKind::BindingRequired
+            .user_facing_auth_hint();
         assert!(
             body.contains(expected_hint),
-            "post must contain the static user-facing hint '{expected_hint}', body: {body}"
+            "post must contain the auth-flavored hint '{expected_hint}', body: {body}"
+        );
+
+        // The approval command must NOT appear in an auth-resolution hint.
+        assert!(
+            !body.contains("approve gate:"),
+            "post must not contain approval command 'approve gate:', body: {body}"
         );
 
         // The internal rejection reason must NOT appear in the post.

--- a/crates/ironclaw_reborn_composition/src/slack_delivery.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_delivery.rs
@@ -27,8 +27,8 @@ use ironclaw_product_adapters::{
     DeclaredEgressHost, EgressCredentialHandle, EgressHeader, EgressMethod, EgressPath,
     EgressRequest, EgressResponse, ExternalActorRef, ExternalConversationRef, FinalReplyView,
     GatePromptView, OutboundDeliverySink, ProductAdapter, ProductAdapterError, ProductInboundAck,
-    ProductInboundEnvelope, ProductInboundPayload, ProductOutboundPayload, ProductTriggerReason,
-    ProtocolHttpEgress, ProtocolHttpEgressError,
+    ProductInboundEnvelope, ProductInboundPayload, ProductOutboundPayload, ProductRejection,
+    ProductTriggerReason, ProtocolHttpEgress, ProtocolHttpEgressError,
 };
 use ironclaw_product_workflow::{
     ConversationBindingService, ProductOutboundDeliveryRequest, ProductOutboundTargetResolver,
@@ -56,6 +56,10 @@ const SLACK_API_HOST: &str = "slack.com";
 const SLACK_BOT_TOKEN_HANDLE: &str = "slack_bot_token";
 const SLACK_WORKING_MESSAGE: &str = "Ironclaw is thinking...";
 const SLACK_AUTH_CANCELED_MESSAGE: &str = "Authentication canceled.";
+const SLACK_DELIVERY_TIMEOUT_MESSAGE: &str =
+    "This is taking longer than expected — check the WebUI for the result.";
+const SLACK_DELIVERY_ERROR_MESSAGE: &str =
+    "Something went wrong delivering the result here. Check the WebUI.";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct BlockedActionableMarker {
@@ -143,6 +147,22 @@ impl SlackFinalReplyDeliveryObserver {
             .await?;
             return Ok(());
         }
+        // A2: For rejected resolution attempts, post a user-facing hint back to the
+        // conversation so the user knows why their approve/deny was not processed.
+        if let Some(hint) = rejection_hint_for_resolution(&envelope, &ack)
+            && let Err(error) = post_slack_message(
+                self.services.egress.as_ref(),
+                envelope.external_conversation_ref(),
+                hint,
+            )
+            .await
+        {
+            tracing::debug!(
+                target = "ironclaw::reborn::slack_delivery",
+                error = %error,
+                "failed to post rejection hint to Slack (best-effort)"
+            );
+        }
         if !should_deliver_after_ack(&envelope, &ack) {
             return Ok(());
         }
@@ -169,7 +189,20 @@ impl SlackFinalReplyDeliveryObserver {
                     &envelope,
                     &mut working_message,
                 )
-                .await?;
+                .await
+                .map_err(|err| {
+                    // If we already delivered a blocked-state notification
+                    // (approval/auth prompt), a timeout does not leave the user
+                    // in silence — convert to the quieter variant so A3 does
+                    // not double-post.
+                    if matches!(err, SlackFinalReplyDeliveryError::RunWaitTimedOut { .. })
+                        && delivered_blocked_marker.is_some()
+                    {
+                        SlackFinalReplyDeliveryError::RunWaitTimedOutAfterNotification { run_id }
+                    } else {
+                        err
+                    }
+                })?;
             if matches!(
                 actionable_state.status,
                 TurnStatus::BlockedApproval | TurnStatus::BlockedAuth
@@ -737,12 +770,36 @@ impl ImmediateAckWorkflowObserver for SlackFinalReplyDeliveryObserver {
             );
             return;
         };
-        if let Err(error) = self.deliver_final_reply(envelope, ack).await {
+        if let Err(error) = self.deliver_final_reply(envelope.clone(), ack).await {
             tracing::warn!(
                 target = "ironclaw::reborn::slack_delivery",
                 error = %error,
                 "Slack final reply delivery failed after immediate ACK"
             );
+            // A3: Best-effort feedback post so the user is not left in silence.
+            // Skip if a blocked-state notification was already delivered — the
+            // user already saw an approval/auth prompt and is not in silence.
+            let feedback = match &error {
+                SlackFinalReplyDeliveryError::RunWaitTimedOut { .. } => {
+                    Some(SLACK_DELIVERY_TIMEOUT_MESSAGE)
+                }
+                SlackFinalReplyDeliveryError::RunWaitTimedOutAfterNotification { .. } => None,
+                _ => Some(SLACK_DELIVERY_ERROR_MESSAGE),
+            };
+            if let Some(feedback) = feedback
+                && let Err(post_err) = post_slack_message(
+                    self.services.egress.as_ref(),
+                    envelope.external_conversation_ref(),
+                    feedback,
+                )
+                .await
+            {
+                tracing::debug!(
+                    target = "ironclaw::reborn::slack_delivery",
+                    error = %post_err,
+                    "failed to post delivery-error feedback to Slack (best-effort)"
+                );
+            }
         }
     }
 }
@@ -765,6 +822,11 @@ enum SlackFinalReplyDeliveryError {
     OutboundPolicy(#[from] OutboundError),
     #[error("run {run_id} did not finish before Slack delivery timeout")]
     RunWaitTimedOut { run_id: TurnRunId },
+    /// Timeout after at least one blocked-state notification (approval/auth
+    /// prompt) was already delivered. The user is not in silence, so no
+    /// additional feedback message is needed.
+    #[error("run {run_id} did not reach a terminal state after delivering a blocked notification")]
+    RunWaitTimedOutAfterNotification { run_id: TurnRunId },
     #[error("invalid projection ref: {reason}")]
     InvalidProjectionRef { reason: String },
 }
@@ -854,6 +916,37 @@ fn should_deliver_after_ack(envelope: &ProductInboundEnvelope, ack: &ProductInbo
         ProductInboundPayload::ScopedApprovalResolution(payload)
             if payload.decision == ironclaw_product_adapters::ApprovalDecision::Deny
     )
+}
+
+/// Returns the user-facing hint to post when a resolution attempt (approval or
+/// auth) is rejected. Returns `None` for non-resolution payloads (e.g. user
+/// messages) or for `Duplicate` wrapping a non-rejected prior ack.
+fn rejection_hint_for_resolution(
+    envelope: &ProductInboundEnvelope,
+    ack: &ProductInboundAck,
+) -> Option<&'static str> {
+    // Unwrap Duplicate recursively, but only one level — a re-sent approve that
+    // was already accepted must not produce an error message.
+    let effective_rejection: &ProductRejection = match ack {
+        ProductInboundAck::Rejected(rejection) => rejection,
+        ProductInboundAck::Duplicate { prior } => match prior.as_ref() {
+            ProductInboundAck::Rejected(rejection) => rejection,
+            _ => return None,
+        },
+        _ => return None,
+    };
+    // Only post feedback for resolution-type payloads; user messages and other
+    // payloads that happen to be rejected produce no channel noise.
+    let is_resolution = matches!(
+        envelope.payload(),
+        ProductInboundPayload::ApprovalResolution(_)
+            | ProductInboundPayload::ScopedApprovalResolution(_)
+            | ProductInboundPayload::AuthResolution(_)
+    );
+    if !is_resolution {
+        return None;
+    }
+    Some(effective_rejection.kind.user_facing_hint())
 }
 
 fn is_accepted_auth_denial(envelope: &ProductInboundEnvelope, ack: &ProductInboundAck) -> bool {
@@ -2636,6 +2729,250 @@ mod tests {
                 .expect("load record")
                 .is_none(),
             "run_id_blocked was never submitted so must have no delivery record"
+        );
+    }
+
+    // ── Phase A: ack-feedback and delivery-error feedback tests ───────────────
+
+    /// Build a minimal `SlackFinalReplyDeliveryObserver` for observer-path tests.
+    fn make_observer(
+        coordinator: Arc<dyn TurnCoordinator>,
+        egress: Arc<FakeProtocolHttpEgress>,
+        outbound: Arc<InMemoryOutboundStateStore>,
+        installation_id: &str,
+    ) -> SlackFinalReplyDeliveryObserver {
+        let thread_service = Arc::new(InMemorySessionThreadService::default());
+        let services = make_services(
+            coordinator,
+            thread_service,
+            egress,
+            outbound,
+            installation_id,
+        );
+        let settings = SlackFinalReplyDeliverySettings {
+            poll_interval: std::time::Duration::ZERO,
+            max_wait: std::time::Duration::from_millis(1),
+            max_concurrent_deliveries: NonZeroUsize::new(1).unwrap(),
+            max_pending_deliveries: NonZeroUsize::new(8).unwrap(),
+        };
+        SlackFinalReplyDeliveryObserver::with_settings(services, settings)
+    }
+
+    fn rejected_ack(kind: ironclaw_product_adapters::ProductRejectionKind) -> ProductInboundAck {
+        ProductInboundAck::Rejected(ironclaw_product_adapters::ProductRejection::permanent(
+            kind,
+            "internal reason",
+        ))
+    }
+
+    fn scoped_approval_resolution_payload() -> ProductInboundPayload {
+        ProductInboundPayload::ScopedApprovalResolution(
+            ironclaw_product_adapters::ScopedApprovalResolutionPayload::new(
+                ironclaw_product_adapters::ApprovalDecision::ApproveOnce,
+            )
+            .expect("scoped approval resolution"),
+        )
+    }
+
+    fn user_message_payload() -> ProductInboundPayload {
+        ProductInboundPayload::UserMessage(
+            ironclaw_product_adapters::UserMessagePayload::new(
+                "hello",
+                vec![],
+                ironclaw_product_adapters::ProductTriggerReason::DirectChat,
+            )
+            .expect("user message"),
+        )
+    }
+
+    /// Rejected scoped-approval ack → hint posted to the envelope conversation.
+    #[tokio::test]
+    async fn rejected_scoped_approval_ack_posts_hint_to_conversation() {
+        let install = "test-install";
+        let egress = Arc::new(FakeProtocolHttpEgress::new(vec!["slack.com".to_string()]));
+        egress.allow_credential_handle("slack_bot_token");
+        // Program a success response for the hint post.
+        egress.program_response(
+            "slack.com",
+            Ok(EgressResponse::new(
+                200,
+                slack_post_ok_json("D123", "1000.1"),
+            )),
+        );
+
+        let outbound = Arc::new(InMemoryOutboundStateStore::default());
+        let coordinator = Arc::new(ScriptedTurnCoordinator::with_single_status(
+            TurnStatus::Running,
+        ));
+        let observer = make_observer(coordinator, egress.clone(), outbound, install);
+        let env = envelope(scoped_approval_resolution_payload());
+        let ack = rejected_ack(ironclaw_product_adapters::ProductRejectionKind::BindingRequired);
+
+        observer.observe_workflow_ack(env, ack).await;
+
+        let calls = egress.calls();
+        let post_calls: Vec<_> = calls
+            .iter()
+            .filter(|c| c.path == "/api/chat.postMessage")
+            .collect();
+        assert!(
+            !post_calls.is_empty(),
+            "expected hint chat.postMessage call"
+        );
+
+        let body = std::str::from_utf8(&post_calls[0].body).expect("utf8 body");
+        // Hint text must contain "approve gate:" from BindingRequired hint.
+        assert!(
+            body.contains("approve gate:"),
+            "rejection hint body must contain 'approve gate:', got: {body}"
+        );
+    }
+
+    /// Rejected user-message payload → nothing posted.
+    #[tokio::test]
+    async fn rejected_user_message_ack_posts_nothing() {
+        let install = "test-install";
+        let egress = Arc::new(FakeProtocolHttpEgress::new(vec!["slack.com".to_string()]));
+        egress.allow_credential_handle("slack_bot_token");
+
+        let outbound = Arc::new(InMemoryOutboundStateStore::default());
+        let coordinator = Arc::new(ScriptedTurnCoordinator::with_single_status(
+            TurnStatus::Running,
+        ));
+        let observer = make_observer(coordinator, egress.clone(), outbound, install);
+        let env = envelope(user_message_payload());
+        let ack = rejected_ack(ironclaw_product_adapters::ProductRejectionKind::BindingRequired);
+
+        observer.observe_workflow_ack(env, ack).await;
+
+        let calls = egress.calls();
+        assert!(
+            !calls.iter().any(|c| c.path == "/api/chat.postMessage"),
+            "no chat.postMessage expected for rejected user-message payload"
+        );
+    }
+
+    /// Duplicate { prior: Accepted } → nothing posted (already succeeded).
+    #[tokio::test]
+    async fn duplicate_accepted_ack_posts_nothing() {
+        let install = "test-install";
+        let run_id = TurnRunId::new();
+        let egress = Arc::new(FakeProtocolHttpEgress::new(vec!["slack.com".to_string()]));
+        egress.allow_credential_handle("slack_bot_token");
+
+        let outbound = Arc::new(InMemoryOutboundStateStore::default());
+        // The coordinator is a no-op because Duplicate{Accepted} has no submitted_run_id.
+        let coordinator = Arc::new(ScriptedTurnCoordinator::with_single_status(
+            TurnStatus::Running,
+        ));
+        let observer = make_observer(coordinator, egress.clone(), outbound, install);
+        let env = envelope(scoped_approval_resolution_payload());
+        let prior = ProductInboundAck::Accepted {
+            accepted_message_ref: AcceptedMessageRef::new("slack:prior").expect("ref"),
+            submitted_run_id: run_id,
+        };
+        let ack = ProductInboundAck::Duplicate {
+            prior: Box::new(prior),
+        };
+
+        observer.observe_workflow_ack(env, ack).await;
+
+        let calls = egress.calls();
+        assert!(
+            !calls.iter().any(|c| c.path == "/api/chat.postMessage"),
+            "no chat.postMessage expected for Duplicate{{Accepted}}"
+        );
+    }
+
+    /// Delivery error (RunWaitTimedOut) → timeout notice posted to conversation.
+    ///
+    /// Uses `FakeConversationBindingService` so the binding lookup succeeds and
+    /// delivery enters the polling loop, which then times out because the
+    /// coordinator always returns `Running`.
+    #[tokio::test]
+    async fn delivery_timeout_posts_timeout_notice_to_conversation() {
+        use ironclaw_product_workflow::FakeConversationBindingService;
+
+        let install = "test-install";
+        let egress = Arc::new(FakeProtocolHttpEgress::new(vec!["slack.com".to_string()]));
+        egress.allow_credential_handle("slack_bot_token");
+        // Two slots: one for any working-message post, one for the timeout notice.
+        egress.program_response(
+            "slack.com",
+            Ok(EgressResponse::new(
+                200,
+                slack_post_ok_json("D123", "2000.1"),
+            )),
+        );
+        egress.program_response(
+            "slack.com",
+            Ok(EgressResponse::new(
+                200,
+                slack_post_ok_json("D123", "2000.2"),
+            )),
+        );
+
+        let outbound = Arc::new(InMemoryOutboundStateStore::default());
+        // Always Running → wait_for_actionable times out after max_wait=1ms.
+        let coordinator = Arc::new(ScriptedTurnCoordinator::with_single_status(
+            TurnStatus::Running,
+        ));
+        // Use FakeConversationBindingService so the binding lookup succeeds and
+        // the delivery loop can actually reach the timeout.
+        let binding_service = Arc::new(FakeConversationBindingService::new());
+        let thread_service = Arc::new(InMemorySessionThreadService::default());
+        let services = SlackFinalReplyDeliveryServices {
+            binding_service,
+            thread_service,
+            turn_coordinator: coordinator,
+            outbound_store: outbound.clone(),
+            communication_preferences: outbound,
+            adapter: test_adapter(install),
+            egress: egress.clone(),
+            delivery_sink: Arc::new(FakeOutboundDeliverySink::default()),
+            auth_challenges: None,
+        };
+        let settings = SlackFinalReplyDeliverySettings {
+            poll_interval: std::time::Duration::ZERO,
+            max_wait: std::time::Duration::from_millis(1),
+            max_concurrent_deliveries: NonZeroUsize::new(1).unwrap(),
+            max_pending_deliveries: NonZeroUsize::new(8).unwrap(),
+        };
+        let observer = SlackFinalReplyDeliveryObserver::with_settings(services, settings);
+
+        // Accepted ack for a user message so deliver_final_reply enters the
+        // polling loop and hits the timeout.
+        let run_id = TurnRunId::new();
+        let env = envelope(user_message_payload());
+        let ack = ProductInboundAck::Accepted {
+            accepted_message_ref: AcceptedMessageRef::new("slack:timeout-test").expect("ref"),
+            submitted_run_id: run_id,
+        };
+
+        observer.observe_workflow_ack(env, ack).await;
+
+        let calls = egress.calls();
+        let post_calls: Vec<_> = calls
+            .iter()
+            .filter(|c| c.path == "/api/chat.postMessage")
+            .collect();
+        assert!(
+            !post_calls.is_empty(),
+            "expected at least one chat.postMessage for timeout notice"
+        );
+
+        // At least one post must contain the timeout message text.
+        let timeout_found = post_calls.iter().any(|c| {
+            let body = std::str::from_utf8(&c.body).unwrap_or("");
+            body.contains("longer than expected")
+        });
+        assert!(
+            timeout_found,
+            "at least one chat.postMessage must contain timeout notice text, bodies: {:?}",
+            post_calls
+                .iter()
+                .map(|c| std::str::from_utf8(&c.body).unwrap_or("?"))
+                .collect::<Vec<_>>()
         );
     }
 

--- a/crates/ironclaw_wasm_product_adapters/src/runner_immediate_ack.rs
+++ b/crates/ironclaw_wasm_product_adapters/src/runner_immediate_ack.rs
@@ -19,7 +19,8 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use ironclaw_product_adapters::{
-    InboundRetryDisposition, ProductInboundAck, ProductInboundEnvelope, ProtocolAuthEvidence,
+    InboundRetryDisposition, ProductAdapterError, ProductInboundAck, ProductInboundEnvelope,
+    ProtocolAuthEvidence,
 };
 
 use crate::runner::{NativeProductAdapterRunner, RunnerError, WebhookProcessOutcome};
@@ -31,6 +32,16 @@ use crate::runner::{NativeProductAdapterRunner, RunnerError, WebhookProcessOutco
 #[async_trait]
 pub trait ImmediateAckWorkflowObserver: Send + Sync {
     async fn observe_workflow_ack(&self, envelope: ProductInboundEnvelope, ack: ProductInboundAck);
+
+    /// Called when the asynchronous workflow returns an error after the protocol
+    /// ACK has already been sent. Implementations must treat follow-up feedback
+    /// as best-effort because the transport cannot retry this event.
+    async fn observe_workflow_error(
+        &self,
+        _envelope: ProductInboundEnvelope,
+        _error: ProductAdapterError,
+    ) {
+    }
 }
 
 impl NativeProductAdapterRunner {
@@ -62,8 +73,8 @@ impl NativeProductAdapterRunner {
 
     /// Same as [`Self::process_verified_webhook_immediate_ack`], but notifies a
     /// host-owned observer after the asynchronous workflow dispatch returns an
-    /// ack. This lets product hosts trigger follow-up delivery (for example a
-    /// final reply push) without delaying the protocol-level ACK.
+    /// ack or error. This lets product hosts trigger follow-up delivery (for
+    /// example a final reply push) without delaying the protocol-level ACK.
     pub async fn process_verified_webhook_immediate_ack_with_observer(
         &self,
         body: &[u8],
@@ -115,6 +126,9 @@ impl NativeProductAdapterRunner {
                         error = %error,
                         "async webhook workflow dispatch failed after protocol ack"
                     );
+                    if let Some(observer) = observer {
+                        observer.observe_workflow_error(envelope, error).await;
+                    }
                 }
                 Err(_) => {
                     tracing::debug!(
@@ -151,6 +165,7 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::Duration;
 
+    use super::ImmediateAckWorkflowObserver;
     use async_trait::async_trait;
     use ironclaw_product_adapters::capabilities::ProductAdapterCapabilities;
     use ironclaw_product_adapters::external::{
@@ -271,6 +286,58 @@ mod tests {
         }
     }
 
+    struct RejectingWorkflow;
+
+    #[async_trait]
+    impl ironclaw_product_adapters::ProductWorkflow for RejectingWorkflow {
+        async fn submit_inbound(
+            &self,
+            _envelope: ProductInboundEnvelope,
+        ) -> Result<ProductInboundAck, ProductAdapterError> {
+            Err(ProductAdapterError::WorkflowRejected {
+                kind: ironclaw_product_adapters::ProductWorkflowRejectionKind::ScopeNotFound,
+                status_code: 404,
+                retryable: false,
+                reason: ironclaw_product_adapters::RedactedString::new("missing binding"),
+            })
+        }
+
+        async fn resolve_projection_subscription(
+            &self,
+            _envelope: ProductInboundEnvelope,
+        ) -> Result<ProjectionSubscriptionRequest, ProductAdapterError> {
+            Err(ProductAdapterError::Internal {
+                detail: ironclaw_product_adapters::redaction::RedactedString::new(
+                    "test stub: resolve_projection_subscription not supported",
+                ),
+            })
+        }
+    }
+
+    struct RecordingObserver {
+        ack_count: Arc<AtomicUsize>,
+        error_count: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl ImmediateAckWorkflowObserver for RecordingObserver {
+        async fn observe_workflow_ack(
+            &self,
+            _envelope: ProductInboundEnvelope,
+            _ack: ProductInboundAck,
+        ) {
+            self.ack_count.fetch_add(1, Ordering::SeqCst);
+        }
+
+        async fn observe_workflow_error(
+            &self,
+            _envelope: ProductInboundEnvelope,
+            _error: ProductAdapterError,
+        ) {
+            self.error_count.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
     struct BlockingWorkflow {
         entered: Arc<AtomicUsize>,
         release: Arc<Notify>,
@@ -344,6 +411,30 @@ mod tests {
         assert_eq!(outcome, WebhookProcessOutcome::AcceptedForAsyncDispatch);
         runner.drain_immediate_ack_tasks().await;
         assert_eq!(parse_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn immediate_ack_observer_receives_post_ack_workflow_errors() {
+        let parse_count = Arc::new(AtomicUsize::new(0));
+        let ack_count = Arc::new(AtomicUsize::new(0));
+        let error_count = Arc::new(AtomicUsize::new(0));
+        let runner = runner_with_workflow(Arc::clone(&parse_count), Arc::new(RejectingWorkflow), 1);
+        let observer = Arc::new(RecordingObserver {
+            ack_count: Arc::clone(&ack_count),
+            error_count: Arc::clone(&error_count),
+        });
+        let evidence = verified_evidence(&runner);
+
+        let outcome = runner
+            .process_verified_webhook_immediate_ack_with_observer(b"{}", &evidence, Some(observer))
+            .await
+            .expect("verified webhook should dispatch");
+
+        assert_eq!(outcome, WebhookProcessOutcome::AcceptedForAsyncDispatch);
+        runner.drain_immediate_ack_tasks().await;
+        assert_eq!(parse_count.load(Ordering::SeqCst), 1);
+        assert_eq!(ack_count.load(Ordering::SeqCst), 0);
+        assert_eq!(error_count.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Phase A of the Slack approval/auth gate fix plan (`docs/plans/2026-06-10-slack-gate-feedback-and-routing.md`). Today, when a user replies "approve"/"deny" in Slack and the resolution is rejected (no binding, missing gate, policy denial), or when delivery of a run result fails, **nothing is posted back to Slack** — the user gets silence.

- **Rejected-ack feedback**: `SlackFinalReplyDeliveryObserver::observe_workflow_ack` now posts a sanitized, user-facing hint to the originating conversation when a resolution attempt (approval, scoped approval, or auth) is rejected. Hints come from a new `ProductRejectionKind::user_facing_hint()` — static strings only; the internal `RedactedString` reason is never echoed.
- **Delivery-error feedback**: delivery failures (e.g. run-wait timeout) post a best-effort notice to the conversation instead of dying in a log line. A new `RunWaitTimedOutAfterNotification` variant suppresses the timeout notice when an approval/auth prompt was already delivered for that run (the prompt itself is the user feedback).
- Duplicate acks unwrap exactly one level (`Duplicate{Rejected}` → hint; `Duplicate{Accepted}` → silence), documented and pinned by test.

## Review fixes included

- Explicit early return after posting a rejection hint (rejected acks never carry a run to deliver).
- Pairwise-distinct hint assertion across all `ProductRejectionKind` variants.
- Timeout test asserts the timeout notice is the **last** `chat.postMessage`.

## Test plan

- `cargo test -p ironclaw_product_adapters --features test-support` — green (includes new hint exhaustiveness/distinctness tests)
- `cargo test -p ironclaw_reborn_composition --features slack-v2-host-beta slack_delivery` — 18 passed (rejected-ack hint, rejected user-message silence, Duplicate one-level unwrap, timeout notice)
- `cargo clippy -p ironclaw_reborn_composition -p ironclaw_product_adapters --features slack-v2-host-beta,test-support --tests` — zero warnings

Phase B (conversation-keyed gate routing so bare "approve" in a prompt thread resolves) follows in a separate PR and should land after this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)