### PR TITLE
fix: deliver triggered-run results to the outbound default (Slack DM) by persisting trigger creator as thread owner

### DIFF
--- a/crates/ironclaw_conversations/Cargo.toml
+++ b/crates/ironclaw_conversations/Cargo.toml
@@ -29,5 +29,6 @@ uuid = { version = "1", features = ["v4", "serde"] }
 default = []
 
 [dev-dependencies]
+ironclaw_triggers = { path = "../ironclaw_triggers", version = "0.1.0", features = ["test-support"] }
 tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt", "sync"] }

--- a/crates/ironclaw_conversations/src/inbound.rs
+++ b/crates/ironclaw_conversations/src/inbound.rs
@@ -541,7 +541,7 @@ mod tests {
         assert_eq!(binding.trusted_calls(), 1);
         assert_eq!(
             binding.trusted_scopes(),
-            vec![(Some(agent()), Some(project()))]
+            vec![(Some(agent()), Some(project()), None)]
         );
         let resolve_requests = binding.resolve_requests();
         assert_eq!(resolve_requests.len(), 1);
@@ -579,7 +579,7 @@ mod tests {
         assert!(matches!(err, InboundTurnError::BindingRequired { .. }));
         assert_eq!(
             binding.trusted_scopes(),
-            vec![(Some(agent()), Some(project()))]
+            vec![(Some(agent()), Some(project()), None)]
         );
         let resolve_requests = binding.resolve_requests();
         assert_eq!(resolve_requests.len(), 1);
@@ -611,7 +611,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(binding.trusted_scopes(), vec![(None, None)]);
+        assert_eq!(binding.trusted_scopes(), vec![(None, None, None)]);
         let resolve_requests = binding.resolve_requests();
         assert_eq!(resolve_requests.len(), 1);
         assert_eq!(resolve_requests[0].requested_agent_id, None);
@@ -1017,7 +1017,7 @@ mod tests {
         ProjectId::new("project").unwrap()
     }
 
-    type TrustedScopeRecord = (Option<AgentId>, Option<ProjectId>);
+    type TrustedScopeRecord = (Option<AgentId>, Option<ProjectId>, Option<UserId>);
     type TrustedScopeRecords = Arc<Mutex<Vec<TrustedScopeRecord>>>;
 
     #[derive(Clone)]
@@ -1044,7 +1044,7 @@ mod tests {
             self.resolve_requests.lock().unwrap().clone()
         }
 
-        fn trusted_scopes(&self) -> Vec<(Option<AgentId>, Option<ProjectId>)> {
+        fn trusted_scopes(&self) -> Vec<(Option<AgentId>, Option<ProjectId>, Option<UserId>)> {
             self.trusted_scopes.lock().unwrap().clone()
         }
     }
@@ -1066,10 +1066,11 @@ mod tests {
             trusted_owner_user_id: Option<UserId>,
         ) -> Result<ConversationBindingResolution, InboundTurnError> {
             self.resolve_requests.lock().unwrap().push(request.clone());
-            self.trusted_scopes
-                .lock()
-                .unwrap()
-                .push((trusted_agent_id.clone(), trusted_project_id.clone()));
+            self.trusted_scopes.lock().unwrap().push((
+                trusted_agent_id.clone(),
+                trusted_project_id.clone(),
+                trusted_owner_user_id.clone(),
+            ));
             self.inner
                 .resolve_or_create_binding_with_trusted_scope(
                     request,
@@ -1116,7 +1117,7 @@ mod tests {
             }
         }
 
-        fn trusted_scopes(&self) -> Vec<(Option<AgentId>, Option<ProjectId>)> {
+        fn trusted_scopes(&self) -> Vec<(Option<AgentId>, Option<ProjectId>, Option<UserId>)> {
             self.trusted_scopes.lock().unwrap().clone()
         }
 
@@ -1139,13 +1140,14 @@ mod tests {
             request: crate::ResolveConversationRequest,
             trusted_agent_id: Option<AgentId>,
             trusted_project_id: Option<ProjectId>,
-            _trusted_owner_user_id: Option<UserId>,
+            trusted_owner_user_id: Option<UserId>,
         ) -> Result<ConversationBindingResolution, InboundTurnError> {
             self.resolve_requests.lock().unwrap().push(request);
-            self.trusted_scopes
-                .lock()
-                .unwrap()
-                .push((trusted_agent_id, trusted_project_id));
+            self.trusted_scopes.lock().unwrap().push((
+                trusted_agent_id,
+                trusted_project_id,
+                trusted_owner_user_id,
+            ));
             Err(InboundTurnError::BindingRequired {
                 adapter_kind: "trusted".to_string(),
                 external_actor_id: "trusted".to_string(),

--- a/crates/ironclaw_conversations/src/inbound.rs
+++ b/crates/ironclaw_conversations/src/inbound.rs
@@ -53,7 +53,8 @@ where
         &self,
         request: TrustedInboundTurnRequest,
     ) -> Result<InboundTurnResponse, InboundTurnError> {
-        let (request, trusted_agent_id, trusted_project_id) = request.into_parts();
+        let (request, trusted_agent_id, trusted_project_id, _trusted_owner_user_id) =
+            request.into_parts();
         self.handle_inbound_turn_inner(
             request,
             BindingResolutionPolicy::Trusted {
@@ -341,6 +342,7 @@ fn trusted_inbound_request_from_trigger(
         },
         fire.agent_id,
         fire.project_id,
+        None,
     ))
 }
 
@@ -890,6 +892,7 @@ mod tests {
             },
             trusted_agent_id,
             trusted_project_id,
+            None,
         )
     }
 

--- a/crates/ironclaw_conversations/src/inbound.rs
+++ b/crates/ironclaw_conversations/src/inbound.rs
@@ -53,8 +53,12 @@ where
         &self,
         request: TrustedInboundTurnRequest,
     ) -> Result<InboundTurnResponse, InboundTurnError> {
-        let (request, trusted_agent_id, trusted_project_id, trusted_owner_user_id) =
-            request.into_parts();
+        let TrustedInboundTurnRequest {
+            request,
+            trusted_agent_id,
+            trusted_project_id,
+            trusted_owner_user_id,
+        } = request;
         self.handle_inbound_turn_inner(
             request,
             BindingResolutionPolicy::Trusted {
@@ -453,7 +457,9 @@ mod tests {
     use ironclaw_host_api::{AgentId, ProjectId, TenantId, ThreadId, UserId};
     use ironclaw_triggers::{
         TRIGGER_TRUSTED_ADAPTER_INSTALLATION_ID, TRIGGER_TRUSTED_ADAPTER_KIND,
-        TRIGGER_TRUSTED_EXTERNAL_ACTOR_NAMESPACE, TrustedTriggerFireSubmitOutcome,
+        TRIGGER_TRUSTED_EXTERNAL_ACTOR_NAMESPACE, TriggerFire, TriggerFireIdentity, TriggerId,
+        TriggerInboundContentRef, TriggerMaterializedPrompt, TrustedTriggerFireSubmitOutcome,
+        TrustedTriggerSubmitRequest,
     };
     use ironclaw_turns::{
         AcceptedMessageRef, AdmissionRejection, AdmissionRejectionReason, CancelRunRequest,
@@ -463,7 +469,10 @@ mod tests {
         TurnError, TurnId, TurnRunId, TurnRunState, TurnScope, TurnStatus,
     };
 
-    use super::{classify_trusted_trigger_inbound_error, submit_trusted_trigger_outcome};
+    use super::{
+        classify_trusted_trigger_inbound_error, submit_trusted_trigger_outcome,
+        trusted_trigger_fire_submitter,
+    };
     use crate::types::TrustedInboundTurnRequest;
     use crate::{
         AcceptedInboundMessage, AdapterInstallationId, AdapterKind, ConversationBindingResolution,
@@ -478,7 +487,7 @@ mod tests {
     #[tokio::test]
     async fn trusted_inbound_with_real_services_creates_binding_records_message_and_replays_submission()
      {
-        let (inbound, services, coordinator) = trusted_test_facade().await;
+        let (inbound, services, coordinator) = trusted_inbound_service().await;
         let request = trusted_inbound_request(Some(agent()), Some(project()));
 
         let first = inbound
@@ -620,7 +629,7 @@ mod tests {
 
     #[tokio::test]
     async fn trusted_inbound_with_owner_resolves_explicit_user_turn_scope() {
-        let (facade, _services, _coordinator) = trusted_test_facade().await;
+        let (facade, _services, _coordinator) = trusted_inbound_service().await;
         let creator = UserId::new("user-creator").expect("user id");
 
         let request = TrustedInboundTurnRequest::new(
@@ -648,7 +657,7 @@ mod tests {
 
     #[tokio::test]
     async fn trusted_inbound_does_not_backfill_owner_on_existing_direct_binding() {
-        let (facade, _services, _coordinator) = trusted_test_facade().await;
+        let (facade, _services, _coordinator) = trusted_inbound_service().await;
         let creator = UserId::new("user-creator").expect("user id");
 
         // First fire: no owner (legacy-shaped binding).
@@ -684,6 +693,54 @@ mod tests {
             response.resolution.turn_scope.explicit_owner_user_id(),
             None,
             "Direct-route bindings must not retro-upgrade owner (legacy compat; recreate the trigger to fix delivery)"
+        );
+    }
+
+    #[tokio::test]
+    async fn submit_trusted_trigger_fire_surfaces_creator_as_explicit_turn_scope_owner() {
+        let (_inbound, services, coordinator) = trusted_inbound_service().await;
+
+        // Pair the trigger creator so the trusted binding resolution succeeds.
+        let creator = UserId::new("user-trigger-creator").expect("user id");
+        services
+            .pair_external_actor(
+                tenant(),
+                trigger_adapter(),
+                trigger_installation(),
+                external_actor(creator.as_str()),
+                creator.clone(),
+            )
+            .await;
+
+        let submitter = trusted_trigger_fire_submitter(services.clone(), services, coordinator);
+
+        let fire_slot = Utc.with_ymd_and_hms(2026, 6, 1, 9, 0, 0).unwrap();
+        let identity = TriggerFireIdentity::new(tenant(), TriggerId::new(), fire_slot);
+        let fire = TriggerFire {
+            identity: identity.clone(),
+            creator_user_id: creator.clone(),
+            agent_id: Some(agent()),
+            project_id: Some(project()),
+            prompt: "test trigger prompt".to_string(),
+        };
+        let content_ref =
+            TriggerInboundContentRef::new("content:test-trigger-creator").expect("content ref");
+        let materialized_prompt = TriggerMaterializedPrompt::for_fire(&fire, content_ref);
+        let request =
+            TrustedTriggerSubmitRequest::new_for_test(fire, materialized_prompt, fire_slot);
+
+        let outcome = submitter
+            .submit_trusted_trigger_fire(request)
+            .await
+            .expect("submit_trusted_trigger_fire succeeds");
+
+        let TrustedTriggerFireSubmitOutcome::Accepted { turn_scope, .. } = outcome else {
+            panic!("expected accepted trigger fire");
+        };
+        assert_eq!(
+            turn_scope.explicit_owner_user_id(),
+            Some(&creator),
+            "submit_trusted_trigger_fire must surface the creator as explicit turn-scope owner"
         );
     }
 
@@ -964,7 +1021,7 @@ mod tests {
     /// backed by `InMemoryConversationServices` with "alice" already paired so
     /// trusted binding resolution succeeds, plus the underlying services and
     /// coordinator for post-call inspection.
-    async fn trusted_test_facade() -> (
+    async fn trusted_inbound_service() -> (
         InboundTurnService<
             InMemoryConversationServices,
             InMemoryConversationServices,

--- a/crates/ironclaw_conversations/src/inbound.rs
+++ b/crates/ironclaw_conversations/src/inbound.rs
@@ -53,13 +53,14 @@ where
         &self,
         request: TrustedInboundTurnRequest,
     ) -> Result<InboundTurnResponse, InboundTurnError> {
-        let (request, trusted_agent_id, trusted_project_id, _trusted_owner_user_id) =
+        let (request, trusted_agent_id, trusted_project_id, trusted_owner_user_id) =
             request.into_parts();
         self.handle_inbound_turn_inner(
             request,
             BindingResolutionPolicy::Trusted {
                 trusted_agent_id,
                 trusted_project_id,
+                trusted_owner_user_id,
             },
         )
         .await
@@ -127,13 +128,14 @@ where
             BindingResolutionPolicy::Trusted {
                 trusted_agent_id,
                 trusted_project_id,
+                trusted_owner_user_id,
             } => {
                 self.binding_service
                     .resolve_or_create_binding_with_trusted_scope(
                         resolve_request,
                         trusted_agent_id,
                         trusted_project_id,
-                        None,
+                        trusted_owner_user_id,
                     )
                     .await?
             }
@@ -342,7 +344,7 @@ fn trusted_inbound_request_from_trigger(
         },
         fire.agent_id,
         fire.project_id,
-        None,
+        Some(fire.creator_user_id),
     ))
 }
 
@@ -352,6 +354,7 @@ enum BindingResolutionPolicy {
     Trusted {
         trusted_agent_id: Option<ironclaw_host_api::AgentId>,
         trusted_project_id: Option<ironclaw_host_api::ProjectId>,
+        trusted_owner_user_id: Option<ironclaw_host_api::UserId>,
     },
 }
 
@@ -475,19 +478,7 @@ mod tests {
     #[tokio::test]
     async fn trusted_inbound_with_real_services_creates_binding_records_message_and_replays_submission()
      {
-        let services = InMemoryConversationServices::default();
-        services
-            .pair_external_actor(
-                tenant(),
-                trigger_adapter(),
-                trigger_installation(),
-                external_actor("alice"),
-                user("alice"),
-            )
-            .await;
-        let coordinator = Arc::new(RecordingTurnCoordinator::default());
-        let inbound =
-            InboundTurnService::new(services.clone(), services.clone(), coordinator.clone());
+        let (inbound, services, coordinator) = trusted_test_facade().await;
         let request = trusted_inbound_request(Some(agent()), Some(project()));
 
         let first = inbound
@@ -625,6 +616,75 @@ mod tests {
         assert_eq!(resolve_requests.len(), 1);
         assert_eq!(resolve_requests[0].requested_agent_id, None);
         assert_eq!(resolve_requests[0].requested_project_id, None);
+    }
+
+    #[tokio::test]
+    async fn trusted_inbound_with_owner_resolves_explicit_user_turn_scope() {
+        let (facade, _services, _coordinator) = trusted_test_facade().await;
+        let creator = UserId::new("user-creator").expect("user id");
+
+        let request = TrustedInboundTurnRequest::new(
+            base_inbound_request(),
+            Some(agent()),
+            Some(project()),
+            Some(creator.clone()),
+        );
+
+        let response = facade
+            .handle_inbound_turn_with_trusted_scope(request)
+            .await
+            .expect("trusted inbound turn succeeds");
+
+        assert_eq!(
+            response
+                .resolution
+                .turn_scope
+                .explicit_owner_user_id()
+                .map(|u| u.as_str()),
+            Some("user-creator"),
+            "trusted owner must surface as ExplicitUser on the resolved TurnScope"
+        );
+    }
+
+    #[tokio::test]
+    async fn trusted_inbound_does_not_backfill_owner_on_existing_direct_binding() {
+        let (facade, _services, _coordinator) = trusted_test_facade().await;
+        let creator = UserId::new("user-creator").expect("user id");
+
+        // First fire: no owner (legacy-shaped binding).
+        let first = TrustedInboundTurnRequest::new(
+            base_inbound_request(),
+            Some(agent()),
+            Some(project()),
+            None,
+        );
+        facade
+            .handle_inbound_turn_with_trusted_scope(first)
+            .await
+            .expect("first trusted turn succeeds");
+
+        // Second fire on the same external conversation: owner now supplied.
+        // Must use a DIFFERENT external_event_id (same id replays the first
+        // submission instead of re-resolving the binding).
+        let mut second_request = base_inbound_request();
+        second_request.external_event_id =
+            ExternalEventId::new("trusted-event-2").expect("event id");
+        let second = TrustedInboundTurnRequest::new(
+            second_request,
+            Some(agent()),
+            Some(project()),
+            Some(creator),
+        );
+        let response = facade
+            .handle_inbound_turn_with_trusted_scope(second)
+            .await
+            .expect("second trusted turn succeeds");
+
+        assert_eq!(
+            response.resolution.turn_scope.explicit_owner_user_id(),
+            None,
+            "Direct-route bindings must not retro-upgrade owner (legacy compat; recreate the trigger to fix delivery)"
+        );
     }
 
     #[test]
@@ -868,32 +928,65 @@ mod tests {
         trusted_agent_id: Option<AgentId>,
         trusted_project_id: Option<ProjectId>,
     ) -> TrustedInboundTurnRequest {
-        let fire_slot = Utc.with_ymd_and_hms(2026, 5, 6, 12, 0, 0).unwrap();
         TrustedInboundTurnRequest::new(
-            InboundTurnRequest {
-                tenant_id: tenant(),
-                adapter_kind: trigger_adapter(),
-                adapter_installation_id: trigger_installation(),
-                external_actor_ref: external_actor("alice"),
-                external_conversation_ref: ExternalConversationRef::new(
-                    None,
-                    "trigger-test",
-                    Some("route-trigger-test"),
-                    None,
-                )
-                .unwrap(),
-                external_event_id: ExternalEventId::new("external-event-trigger-test").unwrap(),
-                route_kind: ConversationRouteKind::Direct,
-                content_ref: InboundMessageContentRef::new("content:trigger-test").unwrap(),
-                requested_agent_id: None,
-                requested_project_id: None,
-                received_at: fire_slot,
-                requested_run_profile: None,
-            },
+            base_inbound_request(),
             trusted_agent_id,
             trusted_project_id,
             None,
         )
+    }
+
+    fn base_inbound_request() -> InboundTurnRequest {
+        let fire_slot = Utc.with_ymd_and_hms(2026, 5, 6, 12, 0, 0).unwrap();
+        InboundTurnRequest {
+            tenant_id: tenant(),
+            adapter_kind: trigger_adapter(),
+            adapter_installation_id: trigger_installation(),
+            external_actor_ref: external_actor("alice"),
+            external_conversation_ref: ExternalConversationRef::new(
+                None,
+                "trigger-test",
+                Some("route-trigger-test"),
+                None,
+            )
+            .unwrap(),
+            external_event_id: ExternalEventId::new("external-event-trigger-test").unwrap(),
+            route_kind: ConversationRouteKind::Direct,
+            content_ref: InboundMessageContentRef::new("content:trigger-test").unwrap(),
+            requested_agent_id: None,
+            requested_project_id: None,
+            received_at: fire_slot,
+            requested_run_profile: None,
+        }
+    }
+
+    /// Returns `(facade, services, coordinator)` — a paired `InboundTurnService`
+    /// backed by `InMemoryConversationServices` with "alice" already paired so
+    /// trusted binding resolution succeeds, plus the underlying services and
+    /// coordinator for post-call inspection.
+    async fn trusted_test_facade() -> (
+        InboundTurnService<
+            InMemoryConversationServices,
+            InMemoryConversationServices,
+            RecordingTurnCoordinator,
+        >,
+        InMemoryConversationServices,
+        Arc<RecordingTurnCoordinator>,
+    ) {
+        let services = InMemoryConversationServices::default();
+        services
+            .pair_external_actor(
+                tenant(),
+                trigger_adapter(),
+                trigger_installation(),
+                external_actor("alice"),
+                user("alice"),
+            )
+            .await;
+        let coordinator = Arc::new(RecordingTurnCoordinator::default());
+        let facade =
+            InboundTurnService::new(services.clone(), services.clone(), coordinator.clone());
+        (facade, services, coordinator)
     }
 
     fn tenant() -> TenantId {

--- a/crates/ironclaw_conversations/src/types.rs
+++ b/crates/ironclaw_conversations/src/types.rs
@@ -167,10 +167,10 @@ pub struct InboundTurnRequest {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct TrustedInboundTurnRequest {
-    request: InboundTurnRequest,
-    trusted_agent_id: Option<AgentId>,
-    trusted_project_id: Option<ProjectId>,
-    trusted_owner_user_id: Option<UserId>,
+    pub(crate) request: InboundTurnRequest,
+    pub(crate) trusted_agent_id: Option<AgentId>,
+    pub(crate) trusted_project_id: Option<ProjectId>,
+    pub(crate) trusted_owner_user_id: Option<UserId>,
 }
 
 impl TrustedInboundTurnRequest {
@@ -186,22 +186,6 @@ impl TrustedInboundTurnRequest {
             trusted_project_id,
             trusted_owner_user_id,
         }
-    }
-
-    pub(crate) fn into_parts(
-        self,
-    ) -> (
-        InboundTurnRequest,
-        Option<AgentId>,
-        Option<ProjectId>,
-        Option<UserId>,
-    ) {
-        (
-            self.request,
-            self.trusted_agent_id,
-            self.trusted_project_id,
-            self.trusted_owner_user_id,
-        )
     }
 }
 

--- a/crates/ironclaw_conversations/src/types.rs
+++ b/crates/ironclaw_conversations/src/types.rs
@@ -170,6 +170,7 @@ pub(crate) struct TrustedInboundTurnRequest {
     request: InboundTurnRequest,
     trusted_agent_id: Option<AgentId>,
     trusted_project_id: Option<ProjectId>,
+    trusted_owner_user_id: Option<UserId>,
 }
 
 impl TrustedInboundTurnRequest {
@@ -177,16 +178,30 @@ impl TrustedInboundTurnRequest {
         request: InboundTurnRequest,
         trusted_agent_id: Option<AgentId>,
         trusted_project_id: Option<ProjectId>,
+        trusted_owner_user_id: Option<UserId>,
     ) -> Self {
         Self {
             request,
             trusted_agent_id,
             trusted_project_id,
+            trusted_owner_user_id,
         }
     }
 
-    pub(crate) fn into_parts(self) -> (InboundTurnRequest, Option<AgentId>, Option<ProjectId>) {
-        (self.request, self.trusted_agent_id, self.trusted_project_id)
+    pub(crate) fn into_parts(
+        self,
+    ) -> (
+        InboundTurnRequest,
+        Option<AgentId>,
+        Option<ProjectId>,
+        Option<UserId>,
+    ) {
+        (
+            self.request,
+            self.trusted_agent_id,
+            self.trusted_project_id,
+            self.trusted_owner_user_id,
+        )
     }
 }
 

--- a/crates/ironclaw_reborn_composition/src/trigger_poller.rs
+++ b/crates/ironclaw_reborn_composition/src/trigger_poller.rs
@@ -760,23 +760,33 @@ mod tests {
         }
 
         /// Inner submitter that always returns `Accepted` with a pre-set run_id
-        /// and scope. Used to exercise the wrapper without going through the
-        /// real submission pipeline.
+        /// and a scope derived from the request's creator. Used to exercise the
+        /// wrapper without going through the real submission pipeline.
         struct FixedAcceptedSubmitter {
             run_id: TurnRunId,
-            scope: TurnScope,
         }
 
         #[async_trait]
         impl TrustedTriggerFireSubmitter for FixedAcceptedSubmitter {
             async fn submit_trusted_trigger_fire(
                 &self,
-                _request: TrustedTriggerSubmitRequest,
+                request: TrustedTriggerSubmitRequest,
             ) -> Result<TrustedTriggerFireSubmitOutcome, TriggerError> {
+                let creator = request.fire().creator_user_id.clone();
+                // Mirror the post-Task-2 production shape: fabricate the scope
+                // with the trigger creator as explicit owner so the fixture
+                // matches what the real trusted-submit path now produces.
+                let scope = TurnScope::new_with_owner(
+                    wrapper_tenant(),
+                    Some(AgentId::new("hook-wrapper-agent").expect("agent")),
+                    None,
+                    ThreadId::new(format!("hook-wrapper-thread-{}", self.run_id)).expect("thread"),
+                    Some(creator),
+                );
                 Ok(TrustedTriggerFireSubmitOutcome::Accepted {
                     run_id: self.run_id,
                     submitted_at: Utc::now(),
-                    turn_scope: self.scope.clone(),
+                    turn_scope: scope,
                 })
             }
         }
@@ -885,11 +895,7 @@ mod tests {
             seed_due_trigger(&repo, fire_slot).await;
 
             let run_id = TurnRunId::new();
-            let scope = wrapper_scope(run_id);
-            let inner = Arc::new(FixedAcceptedSubmitter {
-                run_id,
-                scope: scope.clone(),
-            });
+            let inner = Arc::new(FixedAcceptedSubmitter { run_id });
             let hook_slot: Arc<OnceLock<Arc<dyn PostSubmitDeliveryHook>>> =
                 Arc::new(OnceLock::new());
 
@@ -928,10 +934,7 @@ mod tests {
 
             let run_id = TurnRunId::new();
             let scope = wrapper_scope(run_id);
-            let inner = Arc::new(FixedAcceptedSubmitter {
-                run_id,
-                scope: scope.clone(),
-            });
+            let inner = Arc::new(FixedAcceptedSubmitter { run_id });
             let hook_slot: Arc<OnceLock<Arc<dyn PostSubmitDeliveryHook>>> =
                 Arc::new(OnceLock::new());
 
@@ -959,7 +962,7 @@ mod tests {
             let calls = recording.calls();
             assert_eq!(calls.len(), 1, "hook must fire exactly once");
 
-            let (_, called_run_id, called_scope) = &calls[0];
+            let (recorded_fire, called_run_id, called_scope) = &calls[0];
             assert_eq!(
                 *called_run_id, run_id,
                 "hook must receive the accepted run_id"
@@ -967,6 +970,11 @@ mod tests {
             assert_eq!(
                 called_scope.thread_id, scope.thread_id,
                 "hook must receive the accepted turn_scope thread_id"
+            );
+            assert_eq!(
+                called_scope.explicit_owner_user_id(),
+                Some(&recorded_fire.creator_user_id),
+                "post-submit hook must receive a TurnScope owned by the trigger creator"
             );
         }
     }

--- a/crates/ironclaw_reborn_composition/src/trigger_poller.rs
+++ b/crates/ironclaw_reborn_composition/src/trigger_poller.rs
@@ -780,7 +780,7 @@ mod tests {
                     wrapper_tenant(),
                     Some(AgentId::new("hook-wrapper-agent").expect("agent")),
                     None,
-                    ThreadId::new(format!("hook-wrapper-thread-{}", self.run_id)).expect("thread"),
+                    hook_wrapper_thread_id(self.run_id),
                     Some(creator),
                 );
                 Ok(TrustedTriggerFireSubmitOutcome::Accepted {
@@ -824,10 +824,8 @@ mod tests {
             TenantId::new("hook-wrapper-tenant").expect("tenant")
         }
 
-        fn wrapper_scope(run_id: TurnRunId) -> TurnScope {
-            let agent = AgentId::new("hook-wrapper-agent").expect("agent");
-            let thread = ThreadId::new(format!("hook-wrapper-thread-{run_id}")).expect("thread");
-            TurnScope::new(wrapper_tenant(), Some(agent), None, thread)
+        fn hook_wrapper_thread_id(run_id: TurnRunId) -> ThreadId {
+            ThreadId::new(format!("hook-wrapper-thread-{run_id}")).expect("thread id")
         }
 
         /// Seed one due trigger in `repo` and return the fire slot timestamp.
@@ -933,7 +931,6 @@ mod tests {
             seed_due_trigger(&repo, fire_slot).await;
 
             let run_id = TurnRunId::new();
-            let scope = wrapper_scope(run_id);
             let inner = Arc::new(FixedAcceptedSubmitter { run_id });
             let hook_slot: Arc<OnceLock<Arc<dyn PostSubmitDeliveryHook>>> =
                 Arc::new(OnceLock::new());
@@ -967,8 +964,9 @@ mod tests {
                 *called_run_id, run_id,
                 "hook must receive the accepted run_id"
             );
+            let expected_thread_id = hook_wrapper_thread_id(run_id);
             assert_eq!(
-                called_scope.thread_id, scope.thread_id,
+                called_scope.thread_id, expected_thread_id,
                 "hook must receive the accepted turn_scope thread_id"
             );
             assert_eq!(

--- a/crates/ironclaw_reborn_composition/src/trigger_poller_trusted_submit.rs
+++ b/crates/ironclaw_reborn_composition/src/trigger_poller_trusted_submit.rs
@@ -187,7 +187,7 @@ where
                 resolve_request,
                 fire.agent_id.clone(),
                 fire.project_id.clone(),
-                None,
+                Some(fire.creator_user_id.clone()),
             )
             .await
             .map_err(classify_materializer_inbound_error)?;
@@ -448,7 +448,8 @@ mod tests {
         TriggerFireIdentity, TriggerId, TriggerInboundContentRef, TriggerMaterializedPrompt,
         TriggerPollerFailureReason, TriggerPollerFireOutcome, TriggerPollerWorker,
         TriggerPollerWorkerConfig, TriggerPollerWorkerDeps, TriggerRecord, TriggerRepository,
-        TriggerSchedule, TriggerSourceKind, TriggerState,
+        TriggerSchedule, TriggerSourceKind, TriggerState, TrustedTriggerFireSubmitOutcome,
+        TrustedTriggerFireSubmitter, TrustedTriggerSubmitRequest,
     };
     use ironclaw_turns::{
         AcceptedMessageRef, AdmissionRejection, AdmissionRejectionReason, CancelRunRequest,
@@ -1808,5 +1809,125 @@ mod tests {
             .await
             .expect("threads load");
         assert!(threads.threads.is_empty());
+    }
+
+    struct CapturingTrustedTriggerFireSubmitter {
+        inner: Arc<dyn TrustedTriggerFireSubmitter>,
+        captured: Arc<Mutex<Option<TrustedTriggerFireSubmitOutcome>>>,
+    }
+
+    #[async_trait]
+    impl TrustedTriggerFireSubmitter for CapturingTrustedTriggerFireSubmitter {
+        async fn submit_trusted_trigger_fire(
+            &self,
+            request: TrustedTriggerSubmitRequest,
+        ) -> Result<TrustedTriggerFireSubmitOutcome, TriggerError> {
+            let outcome = self.inner.submit_trusted_trigger_fire(request).await?;
+            *self.captured.lock().expect("captured lock") = Some(outcome.clone());
+            Ok(outcome)
+        }
+    }
+
+    #[tokio::test]
+    async fn materialize_and_submit_pipeline_persists_trigger_creator_as_explicit_thread_owner() {
+        let conversations = ironclaw_conversations::InMemoryConversationServices::default();
+        let thread_service = Arc::new(InMemorySessionThreadService::default());
+        let repo = Arc::new(InMemoryTriggerRepository::default());
+        let run_id = TurnRunId::new();
+        let tenant_id = TenantId::new("trigger-owner-scope-tenant").expect("tenant id");
+        let agent_id = AgentId::new("trigger-owner-scope-agent").expect("agent id");
+        let project_id = ProjectId::new("trigger-owner-scope-project").expect("project id");
+        let creator_user_id = UserId::new("trigger-owner-scope-user").expect("user id");
+        let trigger_id = TriggerId::new();
+        let fire_slot = Utc::now();
+        let prompt = "summarize unread mail for owner scope test";
+        conversations
+            .pair_external_actor(
+                tenant_id.clone(),
+                AdapterKind::new(TRIGGER_TRUSTED_ADAPTER_KIND).expect("adapter kind"),
+                AdapterInstallationId::new(TRIGGER_TRUSTED_ADAPTER_INSTALLATION_ID)
+                    .expect("installation id"),
+                ExternalActorRef::new(
+                    TRIGGER_TRUSTED_EXTERNAL_ACTOR_NAMESPACE,
+                    creator_user_id.as_str(),
+                )
+                .expect("actor ref"),
+                creator_user_id.clone(),
+            )
+            .await;
+        repo.upsert_trigger(TriggerRecord {
+            trigger_id,
+            tenant_id: tenant_id.clone(),
+            creator_user_id: creator_user_id.clone(),
+            agent_id: Some(agent_id.clone()),
+            project_id: Some(project_id.clone()),
+            name: "owner scope e2e".to_string(),
+            source: TriggerSourceKind::Schedule,
+            schedule: TriggerSchedule::cron("0 8 * * *").expect("valid cron"),
+            completion_policy: TriggerCompletionPolicy::Recurring,
+            prompt: prompt.to_string(),
+            state: TriggerState::Scheduled,
+            next_run_at: fire_slot,
+            last_run_at: None,
+            last_fired_slot: None,
+            last_status: None,
+            active_fire_slot: None,
+            active_run_ref: None,
+            created_at: fire_slot,
+        })
+        .await
+        .expect("trigger record stored");
+        let materializer = Arc::new(ConversationContentRefMaterializer::new(
+            conversations.clone(),
+            thread_service.clone(),
+            agent_id.clone(),
+            tenant_authorizer(&tenant_id),
+        ));
+        let captured = Arc::new(Mutex::new(None::<TrustedTriggerFireSubmitOutcome>));
+        let inner_submitter = trusted_trigger_fire_submitter(
+            conversations.clone(),
+            conversations,
+            Arc::new(RecordingTurnCoordinator { run_id }),
+        );
+        let capturing_submitter = Arc::new(CapturingTrustedTriggerFireSubmitter {
+            inner: inner_submitter,
+            captured: captured.clone(),
+        });
+        let worker = TriggerPollerWorker::new(
+            TriggerPollerWorkerConfig {
+                fires_per_tick: 1,
+                ..TriggerPollerWorkerConfig::default()
+            },
+            TriggerPollerWorkerDeps {
+                repository: repo,
+                source_provider: Arc::new(ScheduleTriggerSourceProvider),
+                materializer,
+                trusted_submitter: capturing_submitter,
+                active_run_lookup: Arc::new(MissingActiveRunLookup),
+            },
+        )
+        .expect("valid worker");
+
+        let report = worker.tick_once(fire_slot).await.expect("worker tick");
+
+        assert_eq!(
+            report.results.last().map(|r| &r.outcome),
+            Some(&TriggerPollerFireOutcome::Submitted { run_id }),
+            "worker must report Submitted"
+        );
+        let outcome = captured
+            .lock()
+            .expect("captured lock")
+            .take()
+            .expect("submitter must have captured an outcome");
+        let turn_scope = match outcome {
+            TrustedTriggerFireSubmitOutcome::Accepted { turn_scope, .. } => turn_scope,
+            other => panic!("expected Accepted outcome, got {other:?}"),
+        };
+        assert_eq!(
+            turn_scope.explicit_owner_user_id(),
+            Some(&creator_user_id),
+            "full materialize+submit pipeline must persist the trigger creator as thread owner"
+        );
     }
 }

--- a/crates/ironclaw_triggers/Cargo.toml
+++ b/crates/ironclaw_triggers/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 default = []
 libsql = ["dep:libsql"]
 postgres = ["dep:deadpool-postgres", "dep:tokio-postgres"]
+test-support = []
 
 [dependencies]
 async-trait = "0.1"

--- a/crates/ironclaw_triggers/src/worker/ports.rs
+++ b/crates/ironclaw_triggers/src/worker/ports.rs
@@ -51,6 +51,23 @@ impl TrustedTriggerSubmitRequest {
     pub fn into_parts(self) -> (TriggerFire, TriggerMaterializedPrompt, Timestamp) {
         (self.fire, self.materialized_prompt, self.received_at)
     }
+
+    /// Test-only constructor that bypasses the `pub(crate)` seal.
+    ///
+    /// Production code always creates submit requests inside the trigger worker
+    /// (`due_fire.rs`), which is the only caller allowed to pair a `TriggerFire`
+    /// with its materialized prompt. This helper lets downstream crates (e.g.
+    /// `ironclaw_conversations`) test their `TrustedTriggerFireSubmitter` impls
+    /// without pulling in the full worker. Gated on `test-support` feature so
+    /// it ships zero bytes in production binaries.
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn new_for_test(
+        fire: TriggerFire,
+        materialized_prompt: TriggerMaterializedPrompt,
+        received_at: Timestamp,
+    ) -> Self {
+        Self::new(fire, materialized_prompt, received_at)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]


### PR DESCRIPTION
## Problem

Triggered-event runs complete OK but their final reply never reaches the configured outbound default (Slack DM). The delivery driver records `Skipped` silently on every fire.

Root cause chain:
1. Trusted trigger submit resolved the conversation binding with `trusted_owner_user_id = None` — in **two** places: the prompt materializer (`ConversationContentRefMaterializer::materialize_prompt`) and the trusted inbound path. The materializer runs first and creates the binding, so it is the load-bearing call.
2. Ownerless binding → `TurnScope` with `TurnThreadOwner::ActorFallback`.
3. The Slack delivery driver reconstructs the message-lookup `ThreadScope` from that scope with `owner_user_id: None`, while `record_trigger_prompt` stored the thread under `owner_user_id: Some(actor)`.
4. `finalized_assistant_message_by_run` misses → outcome `Skipped`; the outbound-default preference is never consulted.

## Fix

Thread `TriggerFire.creator_user_id` (host-owned: written from the dispatch `ResourceScope` at trigger-creation time) through the trusted binding-resolution path:

- `TrustedInboundTurnRequest` carries `trusted_owner_user_id`; `BindingResolutionPolicy::Trusted` passes it to `resolve_or_create_binding_with_trusted_scope`.
- `trusted_inbound_request_from_trigger` and the prompt materializer both pass `Some(fire.creator_user_id)`.
- New first-fire bindings persist the creator as owner → triggered `TurnScope`s carry `ExplicitUser` → delivery lookup, preference resolution (`Personal(tenant, creator)`), and the WebUI timeline all line up.

## Deliberate non-goals

- **No backfill of existing bindings.** Direct-route bindings never retro-upgrade their owner (pinned by test). Backfilling would break `TurnScope` equality for in-flight runs and pending gates. **Release note: recreate existing triggers** — each trigger owns its conversation route, so a recreated trigger gets a fresh owner-bearing binding.
- Trust boundary unchanged: `creator_user_id` comes from the host-written `TriggerRecord`; no adapter-supplied value can reach the owner field. A tenant-membership check at binding time is a possible multi-tenant hardening follow-up (flagged by review, Medium/55).

## Behavior change

New triggered runs execute under the creator's resource scope (skills, memory, checkpoints, outbound state) instead of the `SYSTEM` sentinel — matching interactive runs.

## Testing

- TDD throughout; the end-to-end test `materialize_and_submit_pipeline_persists_trigger_creator_as_explicit_thread_owner` failed (`owner: None`) before the materializer fix and passes after.
- New tests: explicit-owner resolution, Direct-route no-backfill invariant, poller hook scope pass-through, conversations-boundary submitter assertion.
- Multi-agent code review run (8 reviewers): 4 findings fixed in the final commit, 1 (tenant-membership hardening) deferred as follow-up.
- `cargo fmt` / `clippy` clean; `ironclaw_conversations` 62 tests, trigger poller suites 42 tests green; workspace `cargo check --all-features` clean. (Full parallel composition runs show pre-existing local_dev flakes also present at base 671fd8449.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
