### PR TITLE
fix(triggers): surface validation errors and clarify trigger state in tool output

### DIFF
--- a/crates/ironclaw_host_runtime/src/first_party_tools/schemas.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/schemas.rs
@@ -316,7 +316,7 @@ pub(crate) fn resolve_builtin_input_schema_ref(reference: &str) -> Option<Value>
                     "type": "string",
                     "description": "Prompt submitted when the trigger fires. Runtime validation caps UTF-8 content at 32768 bytes."
                 },
-                "cron": { "type": "string", "description": "Five-, six-, or seven-field cron expression; fire cadence must be at least one minute" },
+                "cron": { "type": "string", "description": "Cron expression controlling when the trigger fires. Use 5-field standard cron (minute hour dom month dow) as the safe default — e.g. every 10 minutes: `*/10 * * * *`; daily at 9am: `0 9 * * *`; hourly at :10 past: `10 * * * *`. 6- or 7-field Quartz format is also accepted but is seconds-FIRST; if you use it, the seconds field must be literal `0` (e.g. `0 30 8 * * *` = 8:30am daily). Fire cadence must be at least one minute." },
                 "timezone": { "type": "string", "description": "IANA timezone name for cron evaluation (e.g. 'America/New_York', 'Europe/London', 'UTC'). The cron expression is evaluated in this timezone; fire times are stored and compared in UTC. If the user's timezone is already known from the conversation or their settings, use it without asking; if unknown, ask the user before creating the trigger. Never silently assume UTC — a trigger that fires at the wrong local time is worse than no trigger." }
             },
             "required": ["name", "prompt", "cron", "timezone"],

--- a/crates/ironclaw_host_runtime/src/first_party_tools/trigger_management.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/trigger_management.rs
@@ -36,14 +36,14 @@ pub(super) fn manifests() -> Result<Vec<CapabilityManifest>, ExtensionError> {
     Ok(vec![
         first_party_capability_manifest(
             TRIGGER_CREATE_CAPABILITY_ID,
-            "Create a caller-scoped scheduled trigger; output includes run_in_flight (true only while a fire is in progress), enabled (true when scheduled to fire), and last_error (present when permanently failed — recreate to resume)",
+            "Create a caller-scoped scheduled trigger; output includes run_in_flight (true only while a fire is in progress), enabled (true when scheduled to fire), and last_error (present whenever the most recent fire failed; combine with enabled to distinguish failed-but-will-retry on schedule from failed-and-dead — recreate to resume when enabled=false)",
             vec![EffectKind::DispatchCapability, EffectKind::ExternalWrite],
             PermissionMode::Ask,
             resource_profile(),
         )?,
         first_party_capability_manifest(
             TRIGGER_LIST_CAPABILITY_ID,
-            "List scheduled triggers owned by the current caller scope; output fields: run_in_flight is true only while a fire is actively in progress (not an enabled/disabled indicator), enabled is true when the trigger is scheduled to fire again, last_error is present when the trigger has permanently failed and must be recreated",
+            "List scheduled triggers owned by the current caller scope; output fields: run_in_flight is true only while a fire is actively in progress (not an enabled/disabled indicator), enabled is true when the trigger is scheduled to fire again, last_error is present whenever the most recent fire failed — combine with enabled to distinguish failed-but-will-retry (enabled=true) from failed-and-dead (enabled=false, recreate to resume)",
             vec![EffectKind::DispatchCapability],
             PermissionMode::Allow,
             resource_profile(),
@@ -335,13 +335,18 @@ async fn remove_trigger(
 fn trigger_output(record: &TriggerRecord, recent_runs: &[TriggerRunRecord]) -> Value {
     let run_in_flight = record.has_active_fire();
     let enabled = record.state == TriggerState::Scheduled;
-    // Emit a human-readable explanation when a trigger reached terminal Completed state
-    // from a permanent failure so the LLM can advise the user without having to infer
-    // meaning from state=completed + last_status=error alone.
+    // Emit a human-readable explanation whenever the most recent fire failed so the LLM
+    // can advise the user without having to infer meaning from last_status=error alone.
+    // State distinguishes whether the trigger is dead or will retry:
+    //   - Completed (terminal): the trigger will not fire again; recreate it.
+    //   - Scheduled / Paused (non-terminal): the trigger will fire again on the next slot.
     let last_error: Option<&str> = match (record.state, record.last_status) {
-        (TriggerState::Completed, Some(TriggerRunStatus::Error)) => {
-            Some("schedule exhausted or permanently failed; recreate the trigger to resume")
-        }
+        (TriggerState::Completed, Some(TriggerRunStatus::Error)) => Some(
+            "schedule exhausted or permanently failed; trigger will not fire again; recreate it to resume",
+        ),
+        (TriggerState::Scheduled | TriggerState::Paused, Some(TriggerRunStatus::Error)) => Some(
+            "most recent fire failed; the trigger is still scheduled and will fire again at next_run_at",
+        ),
         _ => None,
     };
     json!({

--- a/crates/ironclaw_host_runtime/src/first_party_tools/trigger_management.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/trigger_management.rs
@@ -337,15 +337,20 @@ fn trigger_output(record: &TriggerRecord, recent_runs: &[TriggerRunRecord]) -> V
     let enabled = record.state == TriggerState::Scheduled;
     // Emit a human-readable explanation whenever the most recent fire failed so the LLM
     // can advise the user without having to infer meaning from last_status=error alone.
-    // State distinguishes whether the trigger is dead or will retry:
+    // State distinguishes what happens next:
     //   - Completed (terminal): the trigger will not fire again; recreate it.
-    //   - Scheduled / Paused (non-terminal): the trigger will fire again on the next slot.
+    //   - Scheduled: the trigger will fire again on the next slot.
+    //   - Paused: the poller only fires Scheduled triggers (is_due_at), so a paused
+    //     trigger must NOT be described as retrying automatically.
     let last_error: Option<&str> = match (record.state, record.last_status) {
         (TriggerState::Completed, Some(TriggerRunStatus::Error)) => Some(
             "schedule exhausted or permanently failed; trigger will not fire again; recreate it to resume",
         ),
-        (TriggerState::Scheduled | TriggerState::Paused, Some(TriggerRunStatus::Error)) => Some(
+        (TriggerState::Scheduled, Some(TriggerRunStatus::Error)) => Some(
             "most recent fire failed; the trigger is still scheduled and will fire again at next_run_at",
+        ),
+        (TriggerState::Paused, Some(TriggerRunStatus::Error)) => Some(
+            "most recent fire failed; the trigger is paused and will not fire again until resumed",
         ),
         _ => None,
     };
@@ -557,5 +562,40 @@ mod tests {
                 assert_eq!(timezone, "America/Los_Angeles");
             }
         }
+    }
+
+    #[test]
+    fn trigger_output_paused_after_failed_fire_does_not_promise_retry() {
+        let record = TriggerRecord {
+            trigger_id: TriggerId::new(),
+            tenant_id: ironclaw_host_api::TenantId::new("tenant-paused").expect("tenant id"),
+            creator_user_id: ironclaw_host_api::UserId::new("user-paused").expect("user id"),
+            agent_id: None,
+            project_id: None,
+            name: "paused-after-error".to_string(),
+            source: TriggerSourceKind::Schedule,
+            schedule: TriggerSchedule::cron_with_timezone("0 9 * * *", "UTC").expect("schedule"),
+            completion_policy: TriggerCompletionPolicy::Recurring,
+            prompt: "p".to_string(),
+            state: TriggerState::Paused,
+            next_run_at: chrono::Utc::now() + chrono::Duration::hours(1),
+            last_run_at: Some(chrono::Utc::now()),
+            last_fired_slot: None,
+            last_status: Some(TriggerRunStatus::Error),
+            active_fire_slot: None,
+            active_run_ref: None,
+            created_at: chrono::Utc::now(),
+        };
+        let output = trigger_output(&record, &[]);
+        assert_eq!(output["enabled"], serde_json::json!(false));
+        let last_error = output["last_error"].as_str().expect("last_error present");
+        assert!(
+            last_error.contains("paused") && last_error.contains("until resumed"),
+            "paused failure text must not promise automatic retry: {last_error}"
+        );
+        assert!(
+            !last_error.contains("will fire again at next_run_at"),
+            "paused trigger must not be described as retrying automatically: {last_error}"
+        );
     }
 }

--- a/crates/ironclaw_host_runtime/src/first_party_tools/trigger_management.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/trigger_management.rs
@@ -9,7 +9,7 @@ use ironclaw_host_api::{
 };
 use ironclaw_triggers::{
     TriggerCompletionPolicy, TriggerError, TriggerId, TriggerRecord, TriggerRepository,
-    TriggerRunRecord, TriggerSchedule, TriggerSourceKind, TriggerState,
+    TriggerRunRecord, TriggerRunStatus, TriggerSchedule, TriggerSourceKind, TriggerState,
 };
 use serde::Deserialize;
 use serde_json::{Value, json};
@@ -36,14 +36,14 @@ pub(super) fn manifests() -> Result<Vec<CapabilityManifest>, ExtensionError> {
     Ok(vec![
         first_party_capability_manifest(
             TRIGGER_CREATE_CAPABILITY_ID,
-            "Create a caller-scoped scheduled trigger",
+            "Create a caller-scoped scheduled trigger; output includes run_in_flight (true only while a fire is in progress), enabled (true when scheduled to fire), and last_error (present when permanently failed — recreate to resume)",
             vec![EffectKind::DispatchCapability, EffectKind::ExternalWrite],
             PermissionMode::Ask,
             resource_profile(),
         )?,
         first_party_capability_manifest(
             TRIGGER_LIST_CAPABILITY_ID,
-            "List scheduled triggers owned by the current caller scope",
+            "List scheduled triggers owned by the current caller scope; output fields: run_in_flight is true only while a fire is actively in progress (not an enabled/disabled indicator), enabled is true when the trigger is scheduled to fire again, last_error is present when the trigger has permanently failed and must be recreated",
             vec![EffectKind::DispatchCapability],
             PermissionMode::Allow,
             resource_profile(),
@@ -333,6 +333,17 @@ async fn remove_trigger(
 }
 
 fn trigger_output(record: &TriggerRecord, recent_runs: &[TriggerRunRecord]) -> Value {
+    let run_in_flight = record.has_active_fire();
+    let enabled = record.state == TriggerState::Scheduled;
+    // Emit a human-readable explanation when a trigger reached terminal Completed state
+    // from a permanent failure so the LLM can advise the user without having to infer
+    // meaning from state=completed + last_status=error alone.
+    let last_error: Option<&str> = match (record.state, record.last_status) {
+        (TriggerState::Completed, Some(TriggerRunStatus::Error)) => {
+            Some("schedule exhausted or permanently failed; recreate the trigger to resume")
+        }
+        _ => None,
+    };
     json!({
         "trigger_id": record.trigger_id.to_string(),
         "agent_id": record.agent_id.as_ref().map(|id| id.as_str()),
@@ -346,7 +357,13 @@ fn trigger_output(record: &TriggerRecord, recent_runs: &[TriggerRunRecord]) -> V
         "last_run_at": record.last_run_at,
         "last_status": record.last_status,
         "recent_runs": recent_runs.iter().map(trigger_run_output).collect::<Vec<_>>(),
-        "is_active": record.has_active_fire(),
+        // run_in_flight is true only while a fire is actively in progress.
+        // It is NOT a trigger-enabled indicator. Use `enabled` for that.
+        "run_in_flight": run_in_flight,
+        // enabled reflects whether the trigger is scheduled to fire again.
+        // false means the trigger is paused or has reached a terminal state.
+        "enabled": enabled,
+        "last_error": last_error,
         "created_at": record.created_at,
     })
 }
@@ -385,7 +402,15 @@ fn trigger_input_error(error: TriggerError) -> FirstPartyCapabilityError {
         trigger_error_kind = trigger_error_kind(&error),
         "trigger management capability input validation failed"
     );
-    input_error()
+    // Surface the validation message as a safe summary so the LLM can self-correct.
+    // TriggerError display text contains only user-supplied schedule expressions
+    // (cron strings, timezone names), never secrets or internal paths.
+    // Strip LoopSafeSummary-forbidden delimiters (backtick, slash, angle and curly brackets)
+    // that may appear in IANA timezone strings or quoted cron examples in the reason text.
+    let summary = error
+        .to_string()
+        .replace(['{', '}', '[', ']', '`', '<', '>', '/', '\\'], "");
+    FirstPartyCapabilityError::with_safe_summary(RuntimeDispatchErrorKind::InputEncode, summary)
 }
 
 fn trigger_repository_error(

--- a/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
@@ -511,7 +511,80 @@ async fn builtin_trigger_create_invalid_cron_surfaces_actionable_error_summary()
     );
 }
 
-// Fix 2 — trigger_output shape: run_in_flight, enabled, last_error fields.
+#[tokio::test]
+async fn builtin_trigger_create_invalid_timezone_summary_does_not_echo_user_value() {
+    let repository = Arc::new(InMemoryTriggerRepository::default());
+    let runtime = runtime_with_trigger_repository(repository.clone());
+    let context = execution_context([TRIGGER_CREATE_CAPABILITY_ID]);
+
+    let failure = invoke_failure_with_context(
+        &runtime,
+        TRIGGER_CREATE_CAPABILITY_ID,
+        json!({
+            "name": "Invalid timezone",
+            "prompt": "Run in the user's timezone",
+            "cron": "0 8 * * *",
+            "timezone": "secret/America"
+        }),
+        context.clone(),
+    )
+    .await;
+
+    assert_eq!(failure.kind, RuntimeFailureKind::InvalidInput);
+    let summary = failure
+        .safe_summary()
+        .expect("timezone validation error must carry a safe summary");
+    assert!(
+        summary.contains("invalid timezone"),
+        "summary should describe the invalid timezone, got: {summary}"
+    );
+    assert!(
+        !summary.contains("secret/America") && !summary.contains("secretAmerica"),
+        "safe summary must not echo the invalid timezone value: {summary}"
+    );
+    assert!(
+        !summary.chars().any(|character| matches!(
+            character,
+            '{' | '}' | '[' | ']' | '`' | '<' | '>' | '/' | '\\'
+        )),
+        "safe summary must not contain raw payload or path delimiters: {summary}"
+    );
+    assert!(
+        repository
+            .list_triggers(context.resource_scope.tenant_id)
+            .await
+            .unwrap()
+            .is_empty(),
+        "rejected trigger must not be persisted"
+    );
+}
+
+fn assert_trigger_output_state(
+    trigger: &Value,
+    run_in_flight: bool,
+    enabled: bool,
+    last_error_contains: Option<&str>,
+) {
+    assert_eq!(trigger["run_in_flight"], json!(run_in_flight));
+    assert_eq!(trigger["enabled"], json!(enabled));
+    match last_error_contains {
+        Some(expected) => {
+            let last_error = trigger["last_error"]
+                .as_str()
+                .expect("failed trigger must carry last_error");
+            assert!(
+                last_error.contains(expected),
+                "last_error should contain {expected:?}, got: {last_error}"
+            );
+        }
+        None => assert_eq!(trigger["last_error"], Value::Null),
+    }
+    assert!(
+        trigger.get("is_active").is_none(),
+        "is_active alias was dropped"
+    );
+}
+
 #[tokio::test]
 async fn builtin_trigger_output_run_in_flight_false_between_fires_and_enabled_true_when_scheduled()
 {
@@ -543,29 +616,7 @@ async fn builtin_trigger_output_run_in_flight_false_between_fires_and_enabled_tr
     .unwrap();
     let trigger = &listed["triggers"][0];
 
-    // Between fires, no run is in flight.
-    assert_eq!(
-        trigger["run_in_flight"],
-        json!(false),
-        "run_in_flight must be false between fires"
-    );
-    // A Scheduled trigger is enabled.
-    assert_eq!(
-        trigger["enabled"],
-        json!(true),
-        "Scheduled trigger must have enabled=true"
-    );
-    // No error on a healthy scheduled trigger.
-    assert_eq!(
-        trigger["last_error"],
-        Value::Null,
-        "healthy trigger must not carry last_error"
-    );
-    // is_active alias was dropped; field must be absent from tool output.
-    assert!(
-        trigger.get("is_active").is_none(),
-        "is_active alias was removed; field must not appear in trigger output"
-    );
+    assert_trigger_output_state(trigger, false, true, None);
 }
 
 #[tokio::test]
@@ -630,23 +681,7 @@ async fn builtin_trigger_output_enabled_false_and_last_error_present_for_termina
         .unwrap();
     let trigger = &listed["triggers"][0];
 
-    assert_eq!(
-        trigger["enabled"],
-        json!(false),
-        "terminal Completed trigger must have enabled=false"
-    );
-    assert_eq!(
-        trigger["run_in_flight"],
-        json!(false),
-        "terminal trigger has no active fire"
-    );
-    let last_error = trigger["last_error"]
-        .as_str()
-        .expect("terminal Completed+Error trigger must carry last_error");
-    assert!(
-        last_error.contains("recreate"),
-        "last_error should guide the user to recreate the trigger, got: {last_error}"
-    );
+    assert_trigger_output_state(trigger, false, false, Some("recreate"));
 }
 
 #[tokio::test]
@@ -716,26 +751,7 @@ async fn builtin_trigger_output_enabled_true_and_last_error_present_for_reschedu
         .unwrap();
     let trigger = &listed["triggers"][0];
 
-    // enabled=true: trigger is still scheduled to fire again.
-    assert_eq!(
-        trigger["enabled"],
-        json!(true),
-        "rescheduled-failure trigger must have enabled=true"
-    );
-    // run_in_flight=false: the failed fire has been cleared.
-    assert_eq!(
-        trigger["run_in_flight"],
-        json!(false),
-        "rescheduled-failure trigger has no active fire after permanent failure"
-    );
-    // last_error must be present and indicate the trigger will retry.
-    let last_error = trigger["last_error"]
-        .as_str()
-        .expect("Scheduled+Error trigger must carry last_error");
-    assert!(
-        last_error.contains("still scheduled"),
-        "last_error should tell the user the trigger will retry, got: {last_error}"
-    );
+    assert_trigger_output_state(trigger, false, true, Some("still scheduled"));
 }
 
 #[cfg(feature = "test-support")]

--- a/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
@@ -50,10 +50,10 @@ use ironclaw_network::{
 use ironclaw_resources::{InMemoryResourceGovernor, ResourceAccount};
 use ironclaw_secrets::InMemorySecretStore;
 use ironclaw_triggers::{
-    ClaimDueFireRequest, ClearActiveFireRequest, FireAcceptedRequest, FireTerminalFailedRequest,
-    InMemoryTriggerRepository, MAX_TRIGGER_NAME_BYTES, MAX_TRIGGER_PROMPT_BYTES, TriggerError,
-    TriggerRecord, TriggerRepository, TriggerRunHistoryStatus, TriggerRunRecord, TriggerRunStatus,
-    TriggerState,
+    ClaimDueFireRequest, ClearActiveFireRequest, FireAcceptedRequest, FirePermanentFailedRequest,
+    FireTerminalFailedRequest, InMemoryTriggerRepository, MAX_TRIGGER_NAME_BYTES,
+    MAX_TRIGGER_PROMPT_BYTES, TriggerError, TriggerRecord, TriggerRepository,
+    TriggerRunHistoryStatus, TriggerRunRecord, TriggerRunStatus, TriggerState,
 };
 use ironclaw_trust::{
     AdminConfig, AdminEntry, AuthorityCeiling, EffectiveTrustClass, HostTrustAssignment,
@@ -646,6 +646,95 @@ async fn builtin_trigger_output_enabled_false_and_last_error_present_for_termina
     assert!(
         last_error.contains("recreate"),
         "last_error should guide the user to recreate the trigger, got: {last_error}"
+    );
+}
+
+#[tokio::test]
+async fn builtin_trigger_output_enabled_true_and_last_error_present_for_rescheduled_permanent_failure()
+ {
+    let repository = Arc::new(InMemoryTriggerRepository::default());
+    let runtime = runtime_with_trigger_repository(repository.clone());
+    let context = execution_context([TRIGGER_CREATE_CAPABILITY_ID, TRIGGER_LIST_CAPABILITY_ID]);
+
+    invoke_with_context(
+        &runtime,
+        TRIGGER_CREATE_CAPABILITY_ID,
+        json!({
+            "name": "Rescheduled failure trigger",
+            "prompt": "Will fail but reschedule",
+            "cron": "0 8 * * *",
+            "timezone": "UTC"
+        }),
+        context.clone(),
+    )
+    .await
+    .unwrap();
+
+    // Drive the trigger into the Scheduled+Error state via mark_fire_permanently_failed.
+    // This path: claim the fire, then permanently-fail it with a future next_run_at.
+    // The trigger stays Scheduled (not Completed) and will fire again.
+    let records = repository
+        .list_triggers(context.resource_scope.tenant_id.clone())
+        .await
+        .unwrap();
+    assert_eq!(records.len(), 1);
+    let fire_slot = records[0].next_run_at;
+    // Advance next_run_at by one day so reject_non_future_next_run_at passes.
+    let next_run_at = fire_slot + chrono::Duration::days(1);
+    repository
+        .claim_due_fire(ClaimDueFireRequest {
+            tenant_id: records[0].tenant_id.clone(),
+            trigger_id: records[0].trigger_id,
+            fire_slot,
+            now: fire_slot,
+        })
+        .await
+        .unwrap();
+    repository
+        .mark_fire_permanently_failed(FirePermanentFailedRequest {
+            tenant_id: records[0].tenant_id.clone(),
+            trigger_id: records[0].trigger_id,
+            fire_slot,
+            next_run_at,
+        })
+        .await
+        .unwrap();
+
+    // Verify the repository landed in Scheduled+Error (still active, not terminal).
+    let rescheduled_records = repository
+        .list_triggers(context.resource_scope.tenant_id.clone())
+        .await
+        .unwrap();
+    assert_eq!(rescheduled_records[0].state, TriggerState::Scheduled);
+    assert_eq!(
+        rescheduled_records[0].last_status,
+        Some(TriggerRunStatus::Error)
+    );
+
+    let listed = invoke_with_context(&runtime, TRIGGER_LIST_CAPABILITY_ID, json!({}), context)
+        .await
+        .unwrap();
+    let trigger = &listed["triggers"][0];
+
+    // enabled=true: trigger is still scheduled to fire again.
+    assert_eq!(
+        trigger["enabled"],
+        json!(true),
+        "rescheduled-failure trigger must have enabled=true"
+    );
+    // run_in_flight=false: the failed fire has been cleared.
+    assert_eq!(
+        trigger["run_in_flight"],
+        json!(false),
+        "rescheduled-failure trigger has no active fire after permanent failure"
+    );
+    // last_error must be present and indicate the trigger will retry.
+    let last_error = trigger["last_error"]
+        .as_str()
+        .expect("Scheduled+Error trigger must carry last_error");
+    assert!(
+        last_error.contains("still scheduled"),
+        "last_error should tell the user the trigger will retry, got: {last_error}"
     );
 }
 

--- a/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
@@ -50,9 +50,10 @@ use ironclaw_network::{
 use ironclaw_resources::{InMemoryResourceGovernor, ResourceAccount};
 use ironclaw_secrets::InMemorySecretStore;
 use ironclaw_triggers::{
-    ClaimDueFireRequest, ClearActiveFireRequest, FireAcceptedRequest, InMemoryTriggerRepository,
-    MAX_TRIGGER_NAME_BYTES, MAX_TRIGGER_PROMPT_BYTES, TriggerError, TriggerRecord,
-    TriggerRepository, TriggerRunHistoryStatus, TriggerRunRecord,
+    ClaimDueFireRequest, ClearActiveFireRequest, FireAcceptedRequest, FireTerminalFailedRequest,
+    InMemoryTriggerRepository, MAX_TRIGGER_NAME_BYTES, MAX_TRIGGER_PROMPT_BYTES, TriggerError,
+    TriggerRecord, TriggerRepository, TriggerRunHistoryStatus, TriggerRunRecord, TriggerRunStatus,
+    TriggerState,
 };
 use ironclaw_trust::{
     AdminConfig, AdminEntry, AuthorityCeiling, EffectiveTrustClass, HostTrustAssignment,
@@ -304,7 +305,13 @@ async fn builtin_trigger_create_stamps_caller_scope_and_persists_record() {
     assert_eq!(trigger["agent_id"], json!("default"));
     assert_eq!(trigger["project_id"], json!("bootstrap"));
     assert_eq!(trigger["last_status"], Value::Null);
-    assert_eq!(trigger["is_active"], json!(false));
+    assert_eq!(trigger["run_in_flight"], json!(false));
+    assert_eq!(trigger["enabled"], json!(true));
+    assert_eq!(trigger["last_error"], Value::Null);
+    assert!(
+        trigger.get("is_active").is_none(),
+        "is_active alias was dropped"
+    );
     assert!(trigger.get("last_fired_slot").is_none());
     assert!(trigger.get("active_fire_slot").is_none());
     assert!(trigger.get("active_run_ref").is_none());
@@ -461,6 +468,184 @@ async fn builtin_trigger_create_rejects_sub_minute_schedule_before_persistence()
             .await
             .unwrap()
             .is_empty()
+    );
+}
+
+// Fix 1 — trigger_input_error surfaces the validation reason so the LLM can self-correct.
+#[tokio::test]
+async fn builtin_trigger_create_invalid_cron_surfaces_actionable_error_summary() {
+    let repository = Arc::new(InMemoryTriggerRepository::default());
+    let runtime = runtime_with_trigger_repository(repository.clone());
+    let context = execution_context([TRIGGER_CREATE_CAPABILITY_ID]);
+
+    // `* 10 * * * *` is a 6-field Quartz expression with a non-zero seconds field
+    // (* = every second), which triggers the "must not use second-level cadence" error.
+    let failure = invoke_failure_with_context(
+        &runtime,
+        TRIGGER_CREATE_CAPABILITY_ID,
+        json!({
+            "name": "Sub-second cron",
+            "prompt": "Run too fast",
+            "cron": "* 10 * * * *",
+            "timezone": "UTC"
+        }),
+        context.clone(),
+    )
+    .await;
+
+    assert_eq!(failure.kind, RuntimeFailureKind::InvalidInput);
+    let summary = failure
+        .safe_summary()
+        .expect("validation error must carry a safe summary");
+    assert!(
+        summary.contains("second") || summary.contains("cadence") || summary.contains("minute"),
+        "summary should describe the scheduling constraint, got: {summary}"
+    );
+    assert!(
+        repository
+            .list_triggers(context.resource_scope.tenant_id)
+            .await
+            .unwrap()
+            .is_empty(),
+        "rejected trigger must not be persisted"
+    );
+}
+
+// Fix 2 — trigger_output shape: run_in_flight, enabled, last_error fields.
+#[tokio::test]
+async fn builtin_trigger_output_run_in_flight_false_between_fires_and_enabled_true_when_scheduled()
+{
+    let repository = Arc::new(InMemoryTriggerRepository::default());
+    let runtime = runtime_with_trigger_repository(repository.clone());
+    let context = execution_context([TRIGGER_CREATE_CAPABILITY_ID, TRIGGER_LIST_CAPABILITY_ID]);
+
+    invoke_with_context(
+        &runtime,
+        TRIGGER_CREATE_CAPABILITY_ID,
+        json!({
+            "name": "Shape check trigger",
+            "prompt": "Verify output shape",
+            "cron": "0 8 * * *",
+            "timezone": "UTC"
+        }),
+        context.clone(),
+    )
+    .await
+    .unwrap();
+
+    let listed = invoke_with_context(
+        &runtime,
+        TRIGGER_LIST_CAPABILITY_ID,
+        json!({}),
+        context.clone(),
+    )
+    .await
+    .unwrap();
+    let trigger = &listed["triggers"][0];
+
+    // Between fires, no run is in flight.
+    assert_eq!(
+        trigger["run_in_flight"],
+        json!(false),
+        "run_in_flight must be false between fires"
+    );
+    // A Scheduled trigger is enabled.
+    assert_eq!(
+        trigger["enabled"],
+        json!(true),
+        "Scheduled trigger must have enabled=true"
+    );
+    // No error on a healthy scheduled trigger.
+    assert_eq!(
+        trigger["last_error"],
+        Value::Null,
+        "healthy trigger must not carry last_error"
+    );
+    // is_active alias was dropped; field must be absent from tool output.
+    assert!(
+        trigger.get("is_active").is_none(),
+        "is_active alias was removed; field must not appear in trigger output"
+    );
+}
+
+#[tokio::test]
+async fn builtin_trigger_output_enabled_false_and_last_error_present_for_terminal_completed_trigger()
+ {
+    let repository = Arc::new(InMemoryTriggerRepository::default());
+    let runtime = runtime_with_trigger_repository(repository.clone());
+    let context = execution_context([TRIGGER_CREATE_CAPABILITY_ID, TRIGGER_LIST_CAPABILITY_ID]);
+
+    invoke_with_context(
+        &runtime,
+        TRIGGER_CREATE_CAPABILITY_ID,
+        json!({
+            "name": "Terminal failure trigger",
+            "prompt": "Will fail terminally",
+            "cron": "0 8 * * *",
+            "timezone": "UTC"
+        }),
+        context.clone(),
+    )
+    .await
+    .unwrap();
+
+    // Drive the trigger into the Completed+Error terminal state that mark_fire_terminally_failed sets.
+    let records = repository
+        .list_triggers(context.resource_scope.tenant_id.clone())
+        .await
+        .unwrap();
+    assert_eq!(records.len(), 1);
+    let fire_slot = records[0].next_run_at;
+    repository
+        .claim_due_fire(ClaimDueFireRequest {
+            tenant_id: records[0].tenant_id.clone(),
+            trigger_id: records[0].trigger_id,
+            fire_slot,
+            now: fire_slot,
+        })
+        .await
+        .unwrap();
+    repository
+        .mark_fire_terminally_failed(FireTerminalFailedRequest {
+            tenant_id: records[0].tenant_id.clone(),
+            trigger_id: records[0].trigger_id,
+            fire_slot,
+        })
+        .await
+        .unwrap();
+
+    // Verify the state landed in Completed+Error as expected.
+    let terminal_records = repository
+        .list_triggers(context.resource_scope.tenant_id.clone())
+        .await
+        .unwrap();
+    assert_eq!(terminal_records[0].state, TriggerState::Completed);
+    assert_eq!(
+        terminal_records[0].last_status,
+        Some(TriggerRunStatus::Error)
+    );
+
+    let listed = invoke_with_context(&runtime, TRIGGER_LIST_CAPABILITY_ID, json!({}), context)
+        .await
+        .unwrap();
+    let trigger = &listed["triggers"][0];
+
+    assert_eq!(
+        trigger["enabled"],
+        json!(false),
+        "terminal Completed trigger must have enabled=false"
+    );
+    assert_eq!(
+        trigger["run_in_flight"],
+        json!(false),
+        "terminal trigger has no active fire"
+    );
+    let last_error = trigger["last_error"]
+        .as_str()
+        .expect("terminal Completed+Error trigger must carry last_error");
+    assert!(
+        last_error.contains("recreate"),
+        "last_error should guide the user to recreate the trigger, got: {last_error}"
     );
 }
 
@@ -733,7 +918,12 @@ async fn builtin_trigger_list_and_remove_are_caller_scoped() {
     .unwrap();
     assert_eq!(owner_list["triggers"].as_array().unwrap().len(), 1);
     assert!(owner_list["triggers"][0].get("last_status").is_some());
-    assert_eq!(owner_list["triggers"][0]["is_active"], json!(false));
+    assert_eq!(owner_list["triggers"][0]["run_in_flight"], json!(false));
+    assert_eq!(owner_list["triggers"][0]["enabled"], json!(true));
+    assert!(
+        owner_list["triggers"][0].get("is_active").is_none(),
+        "is_active alias was dropped"
+    );
     assert!(owner_list["triggers"][0].get("prompt").is_none());
     assert!(owner_list["triggers"][0].get("tenant_id").is_none());
     assert!(owner_list["triggers"][0].get("creator_user_id").is_none());
@@ -784,7 +974,12 @@ async fn builtin_trigger_list_shows_active_state_without_run_identifiers() {
     )
     .await
     .unwrap();
-    assert_eq!(created["trigger"]["is_active"], json!(false));
+    assert_eq!(created["trigger"]["run_in_flight"], json!(false));
+    assert_eq!(created["trigger"]["enabled"], json!(true));
+    assert!(
+        created["trigger"].get("is_active").is_none(),
+        "is_active alias was dropped"
+    );
 
     let mut records = repository
         .list_triggers(context.resource_scope.tenant_id.clone())
@@ -800,7 +995,12 @@ async fn builtin_trigger_list_shows_active_state_without_run_identifiers() {
         .await
         .unwrap();
     let trigger = &listed["triggers"][0];
-    assert_eq!(trigger["is_active"], json!(true));
+    assert_eq!(trigger["run_in_flight"], json!(true));
+    assert_eq!(trigger["enabled"], json!(true));
+    assert!(
+        trigger.get("is_active").is_none(),
+        "is_active alias was dropped"
+    );
     assert!(trigger.get("active_fire_slot").is_none());
     assert!(trigger.get("active_run_ref").is_none());
 }
@@ -852,7 +1052,12 @@ async fn builtin_trigger_create_list_and_remove_use_full_request_scope() {
     assert!(trigger.get("creator_user_id").is_none());
     assert_eq!(trigger["agent_id"], json!("scoped-agent"));
     assert_eq!(trigger["project_id"], json!("scoped-project"));
-    assert_eq!(trigger["is_active"], json!(false));
+    assert_eq!(trigger["run_in_flight"], json!(false));
+    assert_eq!(trigger["enabled"], json!(true));
+    assert!(
+        trigger.get("is_active").is_none(),
+        "is_active alias was dropped"
+    );
     assert!(trigger.get("prompt").is_none());
     assert!(trigger.get("last_fired_slot").is_none());
     assert!(trigger.get("active_fire_slot").is_none());
@@ -933,7 +1138,12 @@ async fn builtin_trigger_create_round_trips_nullable_agent_and_project_scope() {
 
     assert_eq!(created["trigger"]["agent_id"], Value::Null);
     assert_eq!(created["trigger"]["project_id"], Value::Null);
-    assert_eq!(created["trigger"]["is_active"], json!(false));
+    assert_eq!(created["trigger"]["run_in_flight"], json!(false));
+    assert_eq!(created["trigger"]["enabled"], json!(true));
+    assert!(
+        created["trigger"].get("is_active").is_none(),
+        "is_active alias was dropped"
+    );
 }
 
 #[tokio::test]

--- a/crates/ironclaw_host_runtime/tests/tool_surface_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/tool_surface_contract.rs
@@ -24,9 +24,9 @@ use ironclaw_host_api::*;
 use ironclaw_host_runtime::{
     CapabilitySurfacePolicy, CapabilitySurfaceVersion, DefaultHostRuntime, HTTP_CAPABILITY_ID,
     HostRuntime, MAX_HOT_PROMPT_BYTES, MAX_HOT_SCHEMA_BYTES, RuntimeCapabilityOutcome,
-    RuntimeCapabilityRequest, RuntimeFailureKind, SurfaceKind, VisibleCapabilityAccess,
-    VisibleCapabilityRequest, VisibleCapabilitySurface, builtin_first_party_package,
-    publish_hot_capability_catalog,
+    RuntimeCapabilityRequest, RuntimeFailureKind, SurfaceKind, TRIGGER_CREATE_CAPABILITY_ID,
+    VisibleCapabilityAccess, VisibleCapabilityRequest, VisibleCapabilitySurface,
+    builtin_first_party_package, publish_hot_capability_catalog,
 };
 use ironclaw_trust::{
     AdminConfig, AdminEntry, AuthorityCeiling, EffectiveTrustClass, HostTrustAssignment,
@@ -542,6 +542,21 @@ async fn visible_surface_resolves_builtin_first_party_input_schema_refs() {
     assert_schema_has_property(&surface, "builtin.skill_install", "content");
     assert_schema_has_property(&surface, "builtin.skill_install", "url");
     assert_schema_has_property(&surface, "builtin.skill_install", "name");
+    let trigger_create_schema = &surface
+        .capabilities
+        .iter()
+        .find(|capability| capability.descriptor.id == capability_id(TRIGGER_CREATE_CAPABILITY_ID))
+        .expect("builtin.trigger_create should be visible")
+        .descriptor
+        .parameters_schema;
+    let cron_description = trigger_create_schema["properties"]["cron"]["description"]
+        .as_str()
+        .expect("cron property should describe accepted syntax");
+    assert!(
+        cron_description.contains("5-field standard cron")
+            && cron_description.contains("seconds-FIRST"),
+        "trigger_create cron description should expose 5-field and Quartz seconds-FIRST guidance: {cron_description}"
+    );
 
     let http_schema = &surface
         .capabilities

--- a/crates/ironclaw_reborn_composition/tests/facade_factory.rs
+++ b/crates/ironclaw_reborn_composition/tests/facade_factory.rs
@@ -1130,6 +1130,9 @@ async fn local_dev_services_dispatch_trigger_management_through_composed_runtime
         .as_str()
         .expect("created trigger id")
         .to_string();
+    assert_eq!(created["trigger"]["run_in_flight"], json!(false));
+    assert_eq!(created["trigger"]["enabled"], json!(true));
+    assert_eq!(created["trigger"]["last_error"], Value::Null);
 
     let local_dev_db = libsql_db_at(dir.path().join("reborn-local-dev.db")).await;
     assert_eq!(libsql_trigger_record_count(&local_dev_db).await, 1);

--- a/crates/ironclaw_triggers/src/lib.rs
+++ b/crates/ironclaw_triggers/src/lib.rs
@@ -1579,11 +1579,12 @@ pub(crate) fn reject_failed_result_after_active_run(
 }
 
 fn parse_timezone(timezone: &str) -> Result<Tz, TriggerError> {
-    timezone.parse::<Tz>().map_err(|_| TriggerError::InvalidSchedule {
-        reason: format!(
-            "invalid timezone '{timezone}': must be a valid IANA timezone identifier, for example UTC"
-        ),
-    })
+    timezone
+        .parse::<Tz>()
+        .map_err(|_| TriggerError::InvalidSchedule {
+            reason: "invalid timezone: must be a valid IANA timezone identifier, for example UTC"
+                .to_string(),
+        })
 }
 
 fn normalize_cron_expression(expression: &str) -> Result<String, TriggerError> {

--- a/crates/ironclaw_triggers/src/lib.rs
+++ b/crates/ironclaw_triggers/src/lib.rs
@@ -1581,7 +1581,7 @@ pub(crate) fn reject_failed_result_after_active_run(
 fn parse_timezone(timezone: &str) -> Result<Tz, TriggerError> {
     timezone.parse::<Tz>().map_err(|_| TriggerError::InvalidSchedule {
         reason: format!(
-            "invalid timezone '{timezone}': must be a valid IANA timezone name (e.g. 'America/New_York', 'UTC')"
+            "invalid timezone '{timezone}': must be a valid IANA timezone identifier, for example UTC"
         ),
     })
 }

--- a/docs/reborn/contracts/triggers.md
+++ b/docs/reborn/contracts/triggers.md
@@ -85,9 +85,10 @@ It is the source of truth for fire eligibility.
 - `Scheduled` means the trigger may be polled and fired.
 - `Paused` means the trigger is retained but must not fire.
 - `Completed` is reserved for future finite schedules and must not be treated as a V1 cron-state requirement.
-- V1 does not expose a separate `enabled` field. Durable backends may add
-  denormalized indexes derived from `state == Scheduled`, but those indexes must
-  never become independent fire gates.
+- V1 tool output exposes `enabled` as a derived field for model/user
+  observability. It is `true` exactly when `state == Scheduled`; durable
+  backends may add denormalized indexes derived from `state == Scheduled`, but
+  those indexes must never become independent fire gates.
 
 ---
 
@@ -389,9 +390,13 @@ The trigger system must expose `trigger_create`, `trigger_list`, and `trigger_re
   The shared service preserves the conversation store's mutation lock across
   both paths and avoids racing optimistic durable-state writes.
 - `trigger_list` is caller-scoped and surfaces the current schedule state plus
-  `last_status` and a bounded `recent_runs` projection. Omitted `run_limit`
-  defaults to 25 recent runs per trigger; callers that do not need embedded run
-  history pass `run_limit = 0`.
+  `run_in_flight`, `enabled`, `last_status`, `last_error`, and a bounded
+  `recent_runs` projection. `run_in_flight` is true only while a fire is
+  actively claimed or accepted. `enabled` is derived from `state == Scheduled`.
+  `last_error` is present when the most recent fire failed and explains whether
+  the trigger will retry on schedule, is paused, or is terminally completed.
+  Omitted `run_limit` defaults to 25 recent runs per trigger; callers that do
+  not need embedded run history pass `run_limit = 0`.
 - `trigger_remove` is caller-scoped delete.
 - Local-dev builds compiled with `libsql` store trigger records in the
   local-dev libSQL database (`reborn-local-dev.db`) through the same


### PR DESCRIPTION
## Summary

Three observability gaps in the Reborn trigger tools caused an LLM agent (and its user) to misdiagnose a working trigger system as broken — confabulating explanations like "the system doesn't support recurring reminders" (real transcript):

1. **Validation errors were swallowed.** `trigger_input_error` logged the `TriggerError` reason at `debug!` and returned a generic `InputEncode` failure with no message. An invalid cron like `* 10 * * * *` gave the model zero feedback to self-correct with. Now the validation reason is passed through as the error's safe summary (e.g. `invalid schedule: cron schedules must not use second-level cadence; use second field 0`). Only input-validation errors get this — backend errors stay opaque. Error texts were also reworded at the source to avoid characters the `LoopSafeSummary` sanitizer strips (a slash-stripped IANA example would have rendered as the *invalid* name `AmericaNew_York`).

2. **`is_active` read as "disabled".** It is computed from `has_active_fire()` — true only while a fire is in flight, false between every fire of a healthy trigger. Renamed to `run_in_flight`, added `enabled` (derived from `TriggerState`), and `last_error` for terminally-completed triggers so a dead trigger explains itself. The old `is_active` key is dropped from tool output — its only consumer was the panel facade's JSON parse, deleted in #4745 (the wire-level `RebornAutomationInfo.is_active` is computed from the typed record and is unaffected).

3. **Zero cron guidance.** The model was guessing syntax. The `cron` schema description now states 5-field standard cron is the default, documents that 6/7-field Quartz is seconds-FIRST with a required literal `0`, and gives intent → expression examples (`*/10 * * * *`, `0 9 * * *`, `10 * * * *`). Output-field semantics (`run_in_flight` vs `enabled` vs `last_error`) are documented on the capability manifest descriptions.

Per the guidance-placement rule established in #4749: all of this lives on the capability surface (schema + manifest descriptions), not in `default-system.md` — the global prompt is untouched by this PR.

## Tests

- Caller-level: invalid cron returns the actionable summary; output asserts `run_in_flight`/`enabled`/`last_error` across scheduled, in-flight, and terminally-failed records; `is_active` asserted absent
- Fixed two composition tests that pre-dated the required `timezone` field (`facade_factory` dispatch, `trigger_poller_e2e` pairing)
- Full suites green; known environment-gated failures only (Docker sandbox tests, load-sensitive `local_dev_runtime_*` timeouts — verified flaky-only by isolation runs on this branch and clean main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)