### PR TITLE
Wire WebUI v2 operator logs

### DIFF
--- a/.github/workflows/reborn-tests.yml
+++ b/.github/workflows/reborn-tests.yml
@@ -168,12 +168,20 @@ jobs:
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
       - name: Run crate tests
+        env:
+          PACKAGE: ${{ matrix.package }}
         run: |
-          feature_flags="$(scripts/ci/package-feature-flags.sh "${{ matrix.package }}")"
+          feature_flags="$(scripts/ci/package-feature-flags.sh "$PACKAGE")"
+
+          if [ "$PACKAGE" = "ironclaw_reborn_composition" ]; then
+            echo "Serializing ironclaw_reborn_composition test builds to keep runner disk usage bounded."
+            export CARGO_BUILD_JOBS=1
+            export CARGO_INCREMENTAL=0
+          fi
 
           # shellcheck disable=SC2086 # feature_flags intentionally expands to zero or more Cargo args.
           timeout --signal=INT --kill-after=30s 28m \
-            cargo test -p "${{ matrix.package }}" ${feature_flags} --all-targets -- --nocapture
+            cargo test -p "$PACKAGE" ${feature_flags} --all-targets -- --nocapture
 
   root-reborn-parity-tests:
     name: Reborn root tests (${{ matrix.partition }})

--- a/.github/workflows/reborn-tests.yml
+++ b/.github/workflows/reborn-tests.yml
@@ -198,6 +198,7 @@ jobs:
       REBORN_ROOT_TEST_PARTITIONS: 4
       REBORN_ROOT_TEST_PARTITION: ${{ matrix.partition }}
       REBORN_ROOT_TEST_TIMEOUT: 28m
+      CARGO_INCREMENTAL: "0"
     strategy:
       fail-fast: true
       matrix:

--- a/crates/ironclaw_reborn_cli/src/runtime/mod.rs
+++ b/crates/ironclaw_reborn_cli/src/runtime/mod.rs
@@ -32,15 +32,79 @@ mod trigger_poller;
 use trigger_poller::trigger_poller_settings;
 
 pub(crate) fn init_tracing() {
+    use tracing::field::{Field, Visit};
     use tracing_subscriber::EnvFilter;
     use tracing_subscriber::fmt;
+    use tracing_subscriber::layer::Context;
+    use tracing_subscriber::prelude::*;
     let filter = EnvFilter::try_from_env("IRONCLAW_REBORN_LOG").unwrap_or_else(|_| {
         EnvFilter::new("info,ironclaw_reborn=info,ironclaw_reborn_composition=info")
     });
-    let _ = fmt()
-        .with_env_filter(filter)
-        .with_writer(std::io::stderr)
+    let _ = tracing_subscriber::registry()
+        .with(filter)
+        .with(fmt::layer().with_writer(std::io::stderr))
+        .with(OperatorLogLayer)
         .try_init();
+
+    struct OperatorLogLayer;
+
+    impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for OperatorLogLayer {
+        fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
+            let metadata = event.metadata();
+            let mut visitor = MessageVisitor::new();
+            event.record(&mut visitor);
+            ironclaw_reborn_composition::capture_tracing_log(
+                metadata.level(),
+                metadata.target(),
+                visitor.finish(),
+            );
+        }
+    }
+
+    struct MessageVisitor {
+        message: String,
+        fields: Vec<String>,
+    }
+
+    impl MessageVisitor {
+        fn new() -> Self {
+            Self {
+                message: String::new(),
+                fields: Vec::new(),
+            }
+        }
+
+        fn finish(self) -> String {
+            if self.fields.is_empty() {
+                self.message
+            } else {
+                format!("{} {}", self.message, self.fields.join(" "))
+            }
+        }
+    }
+
+    impl Visit for MessageVisitor {
+        fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+            if field.name() == "message" {
+                let rendered = format!("{value:?}");
+                self.message = rendered
+                    .strip_prefix('"')
+                    .and_then(|value| value.strip_suffix('"'))
+                    .unwrap_or(rendered.as_str())
+                    .to_string();
+            } else {
+                self.fields.push(format!("{}={value:?}", field.name()));
+            }
+        }
+
+        fn record_str(&mut self, field: &Field, value: &str) {
+            if field.name() == "message" {
+                self.message = value.to_string();
+            } else {
+                self.fields.push(format!("{}={value}", field.name()));
+            }
+        }
+    }
 }
 
 pub(crate) fn block_on_cli<F, T, E>(future: F) -> anyhow::Result<T>

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -71,6 +71,7 @@ mod oauth_gate;
 mod oauth_provider_client;
 #[cfg(feature = "openai-compat-beta")]
 mod openai_compat_serve;
+mod operator_logs;
 mod outbound_preferences;
 mod product_auth_durable;
 mod product_auth_providers;
@@ -210,6 +211,7 @@ pub use nearai_mcp::{
 };
 #[cfg(feature = "openai-compat-beta")]
 pub use openai_compat_serve::build_openai_compat_route_mount;
+pub use operator_logs::{capture_tracing_log, operator_log_buffer};
 pub use product_live_adapters::{
     ProductLiveCapabilityAuthorityResolver, ProductLiveCapabilityIo, ProductLiveModelRouteSettings,
     ProductLivePlannedRuntimeAdapterConfig, ProductLivePlannedRuntimeAdapterError,

--- a/crates/ironclaw_reborn_composition/src/operator_logs.rs
+++ b/crates/ironclaw_reborn_composition/src/operator_logs.rs
@@ -11,6 +11,9 @@ use ironclaw_safety::LeakDetector;
 
 const HISTORY_CAP: usize = 500;
 const DEFAULT_LIMIT: usize = 100;
+const MAX_LOG_MESSAGE_BYTES: usize = 16 * 1024;
+const MAX_LOG_RESPONSE_BYTES: usize = 256 * 1024;
+const LOG_TRUNCATED_SUFFIX: &str = " ... [truncated]";
 const SOURCE: &str = "in_memory_tracing";
 
 static OPERATOR_LOGS: LazyLock<Arc<OperatorLogBuffer>> =
@@ -54,6 +57,7 @@ impl OperatorLogBuffer {
             .leak_detector
             .scan_and_clean(&message)
             .unwrap_or_else(|_| "[log message redacted: contained blocked secret]".to_string());
+        let message = truncate_utf8_with_suffix(&message, MAX_LOG_MESSAGE_BYTES);
         let Ok(mut state) = self.state.lock() else {
             return;
         };
@@ -89,7 +93,9 @@ impl OperatorLogBuffer {
             };
         };
 
-        let mut selected = Vec::with_capacity((limit + 1).min(self.capacity));
+        let mut selected = Vec::with_capacity(limit.min(self.capacity));
+        let mut selected_bytes = 0usize;
+        let mut next_cursor = None;
         for entry in state.entries.iter().rev() {
             if before_id.is_some_and(|id| entry.id >= id) {
                 continue;
@@ -103,18 +109,24 @@ impl OperatorLogBuffer {
                 continue;
             }
 
-            selected.push(entry.clone());
-            if selected.len() > limit {
+            if selected.len() >= limit {
+                next_cursor = selected
+                    .last()
+                    .map(|entry: &StoredLogEntry| format!("before:{}", entry.id));
                 break;
             }
+            let entry_bytes = response_entry_bytes(entry);
+            if !selected.is_empty()
+                && selected_bytes.saturating_add(entry_bytes) > MAX_LOG_RESPONSE_BYTES
+            {
+                next_cursor = selected
+                    .last()
+                    .map(|entry: &StoredLogEntry| format!("before:{}", entry.id));
+                break;
+            }
+            selected_bytes = selected_bytes.saturating_add(entry_bytes);
+            selected.push(entry.clone());
         }
-
-        let next_cursor = if selected.len() > limit {
-            selected.truncate(limit);
-            selected.last().map(|entry| format!("before:{}", entry.id))
-        } else {
-            None
-        };
 
         RebornLogQueryResponse {
             source: SOURCE.to_string(),
@@ -124,6 +136,14 @@ impl OperatorLogBuffer {
             follow_supported: false,
         }
     }
+}
+
+fn response_entry_bytes(entry: &StoredLogEntry) -> usize {
+    entry.id.to_string().len()
+        + entry.timestamp.to_rfc3339().len()
+        + entry.target.len()
+        + entry.message.len()
+        + 64
 }
 
 impl From<StoredLogEntry> for RebornLogEntry {
@@ -171,6 +191,26 @@ fn parse_before_cursor(cursor: &str) -> Option<u64> {
     cursor
         .strip_prefix("before:")
         .and_then(|value| value.parse::<u64>().ok())
+}
+
+fn truncate_utf8_with_suffix(value: &str, max_bytes: usize) -> String {
+    if value.len() <= max_bytes {
+        return value.to_string();
+    }
+
+    if max_bytes <= LOG_TRUNCATED_SUFFIX.len() {
+        return LOG_TRUNCATED_SUFFIX[..max_bytes].to_string();
+    }
+
+    let mut end = max_bytes - LOG_TRUNCATED_SUFFIX.len();
+    while !value.is_char_boundary(end) {
+        end -= 1;
+    }
+
+    let mut truncated = String::with_capacity(max_bytes);
+    truncated.push_str(&value[..end]);
+    truncated.push_str(LOG_TRUNCATED_SUFFIX);
+    truncated
 }
 
 #[cfg(test)]
@@ -253,5 +293,51 @@ mod tests {
             response.entries[0].message,
             "[log message redacted: contained blocked secret]"
         );
+    }
+
+    #[test]
+    fn record_truncates_large_messages_on_utf8_boundary() {
+        let buffer = OperatorLogBuffer::new(10);
+        buffer.record(
+            RebornLogLevel::Info,
+            "ironclaw::test",
+            "\u{1F600}".repeat(MAX_LOG_MESSAGE_BYTES),
+        );
+
+        let response = buffer.query(RebornLogQueryRequest {
+            limit: Some(1),
+            ..RebornLogQueryRequest::default()
+        });
+
+        let message = &response.entries[0].message;
+        assert!(message.len() <= MAX_LOG_MESSAGE_BYTES);
+        assert!(message.ends_with(LOG_TRUNCATED_SUFFIX));
+        assert!(message.is_char_boundary(message.len()));
+    }
+
+    #[test]
+    fn query_enforces_response_byte_budget() {
+        let buffer = OperatorLogBuffer::new(100);
+        for index in 0..40 {
+            buffer.record(
+                RebornLogLevel::Info,
+                "ironclaw::test",
+                format!("{index}:{}", "x".repeat(MAX_LOG_MESSAGE_BYTES)),
+            );
+        }
+
+        let response = buffer.query(RebornLogQueryRequest {
+            limit: Some(100),
+            ..RebornLogQueryRequest::default()
+        });
+
+        let message_bytes = response
+            .entries
+            .iter()
+            .map(|entry| entry.message.len())
+            .sum::<usize>();
+        assert!(message_bytes <= MAX_LOG_RESPONSE_BYTES);
+        assert!(response.entries.len() < 40);
+        assert!(response.next_cursor.is_some());
     }
 }

--- a/crates/ironclaw_reborn_composition/src/operator_logs.rs
+++ b/crates/ironclaw_reborn_composition/src/operator_logs.rs
@@ -1,0 +1,246 @@
+use std::collections::VecDeque;
+use std::sync::{Arc, LazyLock, Mutex};
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use ironclaw_product_workflow::{
+    OperatorLogsService, RebornLogEntry, RebornLogLevel, RebornLogQueryRequest,
+    RebornLogQueryResponse, RebornServicesError, WebUiAuthenticatedCaller,
+};
+use ironclaw_safety::LeakDetector;
+
+const HISTORY_CAP: usize = 500;
+const DEFAULT_LIMIT: usize = 100;
+const SOURCE: &str = "in_memory_tracing";
+
+static OPERATOR_LOGS: LazyLock<Arc<OperatorLogBuffer>> =
+    LazyLock::new(|| Arc::new(OperatorLogBuffer::new(HISTORY_CAP)));
+
+#[derive(Debug, Clone)]
+struct StoredLogEntry {
+    id: u64,
+    timestamp: DateTime<Utc>,
+    level: RebornLogLevel,
+    target: String,
+    message: String,
+}
+
+#[derive(Debug)]
+struct OperatorLogState {
+    next_id: u64,
+    entries: VecDeque<StoredLogEntry>,
+}
+
+pub struct OperatorLogBuffer {
+    capacity: usize,
+    state: Mutex<OperatorLogState>,
+    leak_detector: LeakDetector,
+}
+
+impl OperatorLogBuffer {
+    fn new(capacity: usize) -> Self {
+        Self {
+            capacity,
+            state: Mutex::new(OperatorLogState {
+                next_id: 1,
+                entries: VecDeque::with_capacity(capacity),
+            }),
+            leak_detector: LeakDetector::new(),
+        }
+    }
+
+    pub fn record(&self, level: RebornLogLevel, target: &str, message: String) {
+        let message = self
+            .leak_detector
+            .scan_and_clean(&message)
+            .unwrap_or_else(|_| "[log message redacted: contained blocked secret]".to_string());
+        let Ok(mut state) = self.state.lock() else {
+            return;
+        };
+        let id = state.next_id;
+        state.next_id = state.next_id.saturating_add(1);
+        if state.entries.len() >= self.capacity {
+            state.entries.pop_front();
+        }
+        state.entries.push_back(StoredLogEntry {
+            id,
+            timestamp: Utc::now(),
+            level,
+            target: target.to_string(),
+            message,
+        });
+    }
+
+    fn query(&self, request: RebornLogQueryRequest) -> RebornLogQueryResponse {
+        let limit = request
+            .limit
+            .map(|value| value as usize)
+            .unwrap_or(DEFAULT_LIMIT)
+            .clamp(1, self.capacity);
+        let before_id = request.cursor.as_deref().and_then(parse_before_cursor);
+        let target_filter = request.target.map(|target| target.to_lowercase());
+        let entries = self
+            .state
+            .lock()
+            .map(|state| state.entries.iter().cloned().collect::<Vec<_>>())
+            .unwrap_or_default();
+
+        let mut selected = entries
+            .into_iter()
+            .rev()
+            .filter(|entry| before_id.is_none_or(|id| entry.id < id))
+            .filter(|entry| request.level.is_none_or(|level| entry.level == level))
+            .filter(|entry| {
+                target_filter
+                    .as_ref()
+                    .is_none_or(|target| entry.target.to_lowercase().contains(target.as_str()))
+            })
+            .take(limit + 1)
+            .collect::<Vec<_>>();
+
+        let next_cursor = if selected.len() > limit {
+            selected.truncate(limit);
+            selected.last().map(|entry| format!("before:{}", entry.id))
+        } else {
+            None
+        };
+
+        RebornLogQueryResponse {
+            source: SOURCE.to_string(),
+            entries: selected.into_iter().map(RebornLogEntry::from).collect(),
+            next_cursor,
+            tail_supported: true,
+            follow_supported: false,
+        }
+    }
+}
+
+impl From<StoredLogEntry> for RebornLogEntry {
+    fn from(entry: StoredLogEntry) -> Self {
+        Self {
+            id: entry.id.to_string(),
+            timestamp: entry.timestamp,
+            level: entry.level,
+            target: entry.target,
+            message: entry.message,
+        }
+    }
+}
+
+#[async_trait]
+impl OperatorLogsService for OperatorLogBuffer {
+    async fn query_logs(
+        &self,
+        _caller: WebUiAuthenticatedCaller,
+        request: RebornLogQueryRequest,
+    ) -> Result<RebornLogQueryResponse, RebornServicesError> {
+        Ok(self.query(request))
+    }
+}
+
+pub fn operator_log_buffer() -> Arc<OperatorLogBuffer> {
+    Arc::clone(&OPERATOR_LOGS)
+}
+
+pub fn capture_tracing_log(level: &tracing::Level, target: &str, message: String) {
+    operator_log_buffer().record(reborn_level_from_tracing(level), target, message);
+}
+
+fn reborn_level_from_tracing(level: &tracing::Level) -> RebornLogLevel {
+    match *level {
+        tracing::Level::TRACE => RebornLogLevel::Trace,
+        tracing::Level::DEBUG => RebornLogLevel::Debug,
+        tracing::Level::INFO => RebornLogLevel::Info,
+        tracing::Level::WARN => RebornLogLevel::Warn,
+        tracing::Level::ERROR => RebornLogLevel::Error,
+    }
+}
+
+fn parse_before_cursor(cursor: &str) -> Option<u64> {
+    cursor
+        .strip_prefix("before:")
+        .and_then(|value| value.parse::<u64>().ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn query_returns_newest_first_and_paginates() {
+        let buffer = OperatorLogBuffer::new(10);
+        for index in 0..5 {
+            buffer.record(
+                RebornLogLevel::Info,
+                "ironclaw::test",
+                format!("message {index}"),
+            );
+        }
+
+        let first = buffer.query(RebornLogQueryRequest {
+            limit: Some(2),
+            ..RebornLogQueryRequest::default()
+        });
+        assert_eq!(
+            first
+                .entries
+                .iter()
+                .map(|entry| entry.message.as_str())
+                .collect::<Vec<_>>(),
+            vec!["message 4", "message 3"]
+        );
+        let cursor = first.next_cursor.expect("older page cursor");
+
+        let second = buffer.query(RebornLogQueryRequest {
+            limit: Some(2),
+            cursor: Some(cursor),
+            ..RebornLogQueryRequest::default()
+        });
+        assert_eq!(
+            second
+                .entries
+                .iter()
+                .map(|entry| entry.message.as_str())
+                .collect::<Vec<_>>(),
+            vec!["message 2", "message 1"]
+        );
+    }
+
+    #[test]
+    fn query_filters_by_level_and_target() {
+        let buffer = OperatorLogBuffer::new(10);
+        buffer.record(RebornLogLevel::Info, "ironclaw::alpha", "alpha".to_string());
+        buffer.record(RebornLogLevel::Warn, "ironclaw::beta", "beta".to_string());
+        buffer.record(RebornLogLevel::Warn, "other::beta", "other".to_string());
+
+        let response = buffer.query(RebornLogQueryRequest {
+            limit: Some(10),
+            level: Some(RebornLogLevel::Warn),
+            target: Some("ironclaw".to_string()),
+            ..RebornLogQueryRequest::default()
+        });
+
+        assert_eq!(response.entries.len(), 1);
+        assert_eq!(response.entries[0].message, "beta");
+    }
+
+    #[test]
+    fn record_redacts_secret_shaped_messages() {
+        let buffer = OperatorLogBuffer::new(10);
+        buffer.record(
+            RebornLogLevel::Info,
+            "ironclaw::test",
+            "token sk-proj-test1234567890abcdefghij".to_string(),
+        );
+
+        let response = buffer.query(RebornLogQueryRequest {
+            limit: Some(1),
+            ..RebornLogQueryRequest::default()
+        });
+
+        assert_eq!(
+            response.entries[0].message,
+            "[log message redacted: contained blocked secret]"
+        );
+    }
+}

--- a/crates/ironclaw_reborn_composition/src/operator_logs.rs
+++ b/crates/ironclaw_reborn_composition/src/operator_logs.rs
@@ -79,24 +79,35 @@ impl OperatorLogBuffer {
             .clamp(1, self.capacity);
         let before_id = request.cursor.as_deref().and_then(parse_before_cursor);
         let target_filter = request.target.map(|target| target.to_lowercase());
-        let entries = self
-            .state
-            .lock()
-            .map(|state| state.entries.iter().cloned().collect::<Vec<_>>())
-            .unwrap_or_default();
+        let Ok(state) = self.state.lock() else {
+            return RebornLogQueryResponse {
+                source: SOURCE.to_string(),
+                entries: Vec::new(),
+                next_cursor: None,
+                tail_supported: true,
+                follow_supported: false,
+            };
+        };
 
-        let mut selected = entries
-            .into_iter()
-            .rev()
-            .filter(|entry| before_id.is_none_or(|id| entry.id < id))
-            .filter(|entry| request.level.is_none_or(|level| entry.level == level))
-            .filter(|entry| {
-                target_filter
-                    .as_ref()
-                    .is_none_or(|target| entry.target.to_lowercase().contains(target.as_str()))
-            })
-            .take(limit + 1)
-            .collect::<Vec<_>>();
+        let mut selected = Vec::with_capacity((limit + 1).min(self.capacity));
+        for entry in state.entries.iter().rev() {
+            if before_id.is_some_and(|id| entry.id >= id) {
+                continue;
+            }
+            if request.level.is_some_and(|level| entry.level != level) {
+                continue;
+            }
+            if let Some(target) = target_filter.as_ref()
+                && !entry.target.to_lowercase().contains(target.as_str())
+            {
+                continue;
+            }
+
+            selected.push(entry.clone());
+            if selected.len() > limit {
+                break;
+            }
+        }
 
         let next_cursor = if selected.len() > limit {
             selected.truncate(limit);

--- a/crates/ironclaw_reborn_composition/src/webui.rs
+++ b/crates/ironclaw_reborn_composition/src/webui.rs
@@ -184,6 +184,7 @@ pub(crate) fn build_webui_services_with_connectable_channels(
     api = api.with_operator_status_service(Arc::new(ReadinessOperatorStatusService::new(
         services.readiness.clone(),
     )));
+    api = api.with_operator_logs_service(crate::operator_log_buffer());
 
     // Compose the operator LLM-config settings service when the runtime was
     // assembled with a boot config. The secret store stays private to this

--- a/crates/ironclaw_webui_v2_static/static/js/lib/api.js
+++ b/crates/ironclaw_webui_v2_static/static/js/lib/api.js
@@ -207,6 +207,17 @@ export function setOutboundPreferences({ finalReplyTargetId } = {}) {
   });
 }
 
+// --- Operator logs ---
+
+export function queryOperatorLogs({ limit, cursor, level, target } = {}) {
+  const url = new URL(`${V2_BASE}/operator/logs`, window.location.origin);
+  if (limit != null) url.searchParams.set("limit", String(limit));
+  if (cursor) url.searchParams.set("cursor", cursor);
+  if (level) url.searchParams.set("level", level);
+  if (target) url.searchParams.set("target", target);
+  return apiFetch(url.pathname + url.search);
+}
+
 // --- Messages ---
 
 export function sendMessage({ threadId, content, clientActionId: clientId }) {

--- a/crates/ironclaw_webui_v2_static/static/js/pages/logs/hooks/useLogs.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/logs/hooks/useLogs.js
@@ -1,18 +1,10 @@
 import { React } from "../../../lib/html.js";
 import { queryOperatorLogs } from "../../../lib/api.js";
+import { normalizeOperatorLogsResponse } from "../lib/logs-data.js";
 
 const POLL_INTERVAL_MS = 2000;
 const LOG_LIMIT = 500;
-
-function normalizeEntry(entry) {
-  return {
-    id: String(entry.id ?? `${entry.timestamp}:${entry.target}:${entry.message}`),
-    timestamp: entry.timestamp || "",
-    level: String(entry.level || "info").toLowerCase(),
-    target: entry.target || "",
-    message: entry.message || "",
-  };
-}
+const HIDDEN_ENTRY_ID_CAP = 2000;
 
 export function useLogs() {
   const [entries, setEntries] = React.useState([]);
@@ -36,9 +28,8 @@ export function useLogs() {
       });
       if (requestId !== requestIdRef.current) return;
       const hidden = hiddenEntryIdsRef.current;
-      const nextEntries = (response.entries || [])
-        .map(normalizeEntry)
-        .filter((entry) => !hidden.has(entry.id));
+      const logs = normalizeOperatorLogsResponse(response);
+      const nextEntries = logs.entries.filter((entry) => !hidden.has(entry.id));
       setEntries(nextEntries);
       setError(null);
     } catch (err) {
@@ -63,10 +54,11 @@ export function useLogs() {
   }, []);
 
   const clearEntries = React.useCallback(() => {
-    hiddenEntryIdsRef.current = new Set([
+    const hidden = [
       ...hiddenEntryIdsRef.current,
       ...entries.map((entry) => entry.id),
-    ]);
+    ].slice(-HIDDEN_ENTRY_ID_CAP);
+    hiddenEntryIdsRef.current = new Set(hidden);
     setEntries([]);
   }, [entries]);
 

--- a/crates/ironclaw_webui_v2_static/static/js/pages/logs/hooks/useLogs.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/logs/hooks/useLogs.js
@@ -5,6 +5,7 @@ import { normalizeOperatorLogsResponse } from "../lib/logs-data.js";
 const POLL_INTERVAL_MS = 2000;
 const LOG_LIMIT = 500;
 const HIDDEN_ENTRY_ID_CAP = 2000;
+const TERMINAL_UNSUPPORTED_STATUSES = new Set([403, 404]);
 
 export function useLogs() {
   const [entries, setEntries] = React.useState([]);
@@ -14,10 +15,12 @@ export function useLogs() {
   const [autoScroll, setAutoScroll] = React.useState(true);
   const [isLoading, setIsLoading] = React.useState(true);
   const [error, setError] = React.useState(null);
+  const [isUnsupported, setIsUnsupported] = React.useState(false);
   const hiddenEntryIdsRef = React.useRef(new Set());
   const requestIdRef = React.useRef(0);
 
   const loadLogs = React.useCallback(async () => {
+    if (isUnsupported) return;
     const requestId = ++requestIdRef.current;
     setIsLoading(true);
     try {
@@ -34,20 +37,26 @@ export function useLogs() {
       setError(null);
     } catch (err) {
       if (requestId !== requestIdRef.current) return;
+      if (TERMINAL_UNSUPPORTED_STATUSES.has(err?.status)) {
+        setEntries([]);
+        setError(null);
+        setIsUnsupported(true);
+        return;
+      }
       setError(err);
     } finally {
       if (requestId === requestIdRef.current) {
         setIsLoading(false);
       }
     }
-  }, [levelFilter, targetFilter]);
+  }, [isUnsupported, levelFilter, targetFilter]);
 
   React.useEffect(() => {
-    if (paused) return undefined;
+    if (paused || isUnsupported) return undefined;
     loadLogs();
     const timer = setInterval(loadLogs, POLL_INTERVAL_MS);
     return () => clearInterval(timer);
-  }, [loadLogs, paused]);
+  }, [isUnsupported, loadLogs, paused]);
 
   const togglePause = React.useCallback(() => {
     setPaused((value) => !value);

--- a/crates/ironclaw_webui_v2_static/static/js/pages/logs/hooks/useLogs.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/logs/hooks/useLogs.js
@@ -1,21 +1,91 @@
 import { React } from "../../../lib/html.js";
+import { queryOperatorLogs } from "../../../lib/api.js";
 
-// TODO: requires v2 log-streaming endpoint. The v2 ingress only
-// exposes per-thread event streams; system-wide log tail is not in
-// the #3815 contract. Hook returns empty/static so the Logs page
-// renders an empty list without hitting any v1 path.
+const POLL_INTERVAL_MS = 2000;
+const LOG_LIMIT = 500;
+
+function normalizeEntry(entry) {
+  return {
+    id: String(entry.id ?? `${entry.timestamp}:${entry.target}:${entry.message}`),
+    timestamp: entry.timestamp || "",
+    level: String(entry.level || "info").toLowerCase(),
+    target: entry.target || "",
+    message: entry.message || "",
+  };
+}
+
 export function useLogs() {
-  const [level, setLevel] = React.useState("info");
+  const [entries, setEntries] = React.useState([]);
+  const [levelFilter, setLevelFilter] = React.useState("all");
+  const [targetFilter, setTargetFilter] = React.useState("");
+  const [paused, setPaused] = React.useState(false);
+  const [autoScroll, setAutoScroll] = React.useState(true);
+  const [isLoading, setIsLoading] = React.useState(true);
+  const [error, setError] = React.useState(null);
+  const hiddenEntryIdsRef = React.useRef(new Set());
+  const requestIdRef = React.useRef(0);
 
-  const updateLevel = React.useCallback(async (next) => {
-    setLevel(next); // local-only — no v2 endpoint to persist
+  const loadLogs = React.useCallback(async () => {
+    const requestId = ++requestIdRef.current;
+    setIsLoading(true);
+    try {
+      const response = await queryOperatorLogs({
+        limit: LOG_LIMIT,
+        level: levelFilter === "all" ? null : levelFilter,
+        target: targetFilter.trim() || null,
+      });
+      if (requestId !== requestIdRef.current) return;
+      const hidden = hiddenEntryIdsRef.current;
+      const nextEntries = (response.logs?.entries || [])
+        .map(normalizeEntry)
+        .filter((entry) => !hidden.has(entry.id));
+      setEntries(nextEntries);
+      setError(null);
+    } catch (err) {
+      if (requestId !== requestIdRef.current) return;
+      setError(err);
+    } finally {
+      if (requestId === requestIdRef.current) {
+        setIsLoading(false);
+      }
+    }
+  }, [levelFilter, targetFilter]);
+
+  React.useEffect(() => {
+    if (paused) return undefined;
+    loadLogs();
+    const timer = setInterval(loadLogs, POLL_INTERVAL_MS);
+    return () => clearInterval(timer);
+  }, [loadLogs, paused]);
+
+  const togglePause = React.useCallback(() => {
+    setPaused((value) => !value);
   }, []);
 
+  const clearEntries = React.useCallback(() => {
+    hiddenEntryIdsRef.current = new Set([
+      ...hiddenEntryIdsRef.current,
+      ...entries.map((entry) => entry.id),
+    ]);
+    setEntries([]);
+  }, [entries]);
+
   return {
-    entries: [],
-    level,
-    setLevel: updateLevel,
-    status: "todo",
-    isLoading: false,
+    entries,
+    totalCount: entries.length,
+    paused,
+    togglePause,
+    clearEntries,
+    levelFilter,
+    setLevelFilter,
+    targetFilter,
+    setTargetFilter,
+    autoScroll,
+    setAutoScroll,
+    serverLevel: null,
+    changeServerLevel: async () => {},
+    status: error ? "error" : isLoading ? "loading" : "ready",
+    isLoading,
+    error,
   };
 }

--- a/crates/ironclaw_webui_v2_static/static/js/pages/logs/hooks/useLogs.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/logs/hooks/useLogs.js
@@ -36,7 +36,7 @@ export function useLogs() {
       });
       if (requestId !== requestIdRef.current) return;
       const hidden = hiddenEntryIdsRef.current;
-      const nextEntries = (response.logs?.entries || [])
+      const nextEntries = (response.entries || [])
         .map(normalizeEntry)
         .filter((entry) => !hidden.has(entry.id));
       setEntries(nextEntries);

--- a/crates/ironclaw_webui_v2_static/static/js/pages/logs/lib/logs-data.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/logs/lib/logs-data.js
@@ -1,0 +1,22 @@
+export function normalizeLogEntry(entry) {
+  return {
+    id: String(entry?.id ?? `${entry?.timestamp}:${entry?.target}:${entry?.message}`),
+    timestamp: entry?.timestamp || "",
+    level: String(entry?.level || "info").toLowerCase(),
+    target: entry?.target || "",
+    message: entry?.message || "",
+  };
+}
+
+export function normalizeOperatorLogsResponse(response) {
+  const payload =
+    response?.logs && typeof response.logs === "object" ? response.logs : response || {};
+  const entries = Array.isArray(payload.entries) ? payload.entries : [];
+  return {
+    source: payload.source || "",
+    entries: entries.map(normalizeLogEntry),
+    nextCursor: payload.next_cursor || null,
+    tailSupported: Boolean(payload.tail_supported),
+    followSupported: Boolean(payload.follow_supported),
+  };
+}

--- a/crates/ironclaw_webui_v2_static/static/js/pages/logs/lib/logs-data.test.mjs
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/logs/lib/logs-data.test.mjs
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  normalizeLogEntry,
+  normalizeOperatorLogsResponse,
+} from "./logs-data.js";
+
+test("normalizeOperatorLogsResponse reads command-plane nested logs payload", () => {
+  const response = normalizeOperatorLogsResponse({
+    status: "available",
+    logs: {
+      source: "in_memory_tracing",
+      next_cursor: "before:4",
+      tail_supported: true,
+      follow_supported: false,
+      entries: [
+        {
+          id: "5",
+          timestamp: "2026-06-11T12:00:00.123Z",
+          level: "warn",
+          target: "ironclaw::test",
+          message: "something happened",
+        },
+      ],
+    },
+  });
+
+  assert.equal(response.source, "in_memory_tracing");
+  assert.equal(response.nextCursor, "before:4");
+  assert.equal(response.tailSupported, true);
+  assert.equal(response.followSupported, false);
+  assert.deepEqual(response.entries, [
+    {
+      id: "5",
+      timestamp: "2026-06-11T12:00:00.123Z",
+      level: "warn",
+      target: "ironclaw::test",
+      message: "something happened",
+    },
+  ]);
+});
+
+test("normalizeOperatorLogsResponse tolerates direct log payloads", () => {
+  const response = normalizeOperatorLogsResponse({
+    entries: [{ id: 7, level: "ERROR", message: "failed" }],
+  });
+
+  assert.deepEqual(response.entries, [
+    {
+      id: "7",
+      timestamp: "",
+      level: "error",
+      target: "",
+      message: "failed",
+    },
+  ]);
+});
+
+test("normalizeLogEntry creates a stable fallback id", () => {
+  assert.equal(
+    normalizeLogEntry({
+      timestamp: "2026-06-11T12:00:00Z",
+      target: "ironclaw::test",
+      message: "hello",
+    }).id,
+    "2026-06-11T12:00:00Z:ironclaw::test:hello",
+  );
+});

--- a/crates/ironclaw_webui_v2_static/static/js/pages/logs/logs-page.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/logs/logs-page.js
@@ -82,6 +82,8 @@ export function LogsPage() {
     setAutoScroll,
     serverLevel,
     changeServerLevel,
+    isLoading,
+    error,
   } = useLogs();
 
   const outputRef = React.useRef(null);
@@ -117,6 +119,10 @@ export function LogsPage() {
         />
 
         <div className="flex items-center gap-2 ml-auto">
+          <span className="hidden tabular-nums text-xs text-[var(--v2-text-muted)] sm:inline">
+            ${t("logs.entryCount", { count: totalCount })}
+          </span>
+
           <!-- Auto-scroll toggle -->
           <label className="flex cursor-pointer items-center gap-1.5 text-xs text-[var(--v2-text-muted)]">
             <input
@@ -177,7 +183,26 @@ export function LogsPage() {
         ref=${outputRef}
         className="min-h-0 flex-1 overflow-y-auto bg-[var(--v2-canvas)]"
       >
-        ${entries.length === 0
+        ${error
+          ? html`
+              <div
+                className="flex h-full items-center justify-center px-6 text-center text-sm text-red-300"
+              >
+                ${t("error.loadFailed", {
+                  what: t("nav.logs"),
+                  message: error.message || error.statusText || "Request failed",
+                })}
+              </div>
+            `
+          : isLoading && entries.length === 0
+            ? html`
+                <div
+                  className="flex h-full items-center justify-center text-sm text-[var(--v2-text-muted)]"
+                >
+                  ${t("common.loading")}
+                </div>
+              `
+            : entries.length === 0
           ? html`
               <div
                 className="flex h-full items-center justify-center text-sm text-[var(--v2-text-muted)]"

--- a/crates/ironclaw_webui_v2_static/static/js/pages/logs/logs-page.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/logs/logs-page.js
@@ -87,12 +87,19 @@ export function LogsPage() {
   } = useLogs();
 
   const outputRef = React.useRef(null);
+  const followLatestRef = React.useRef(true);
 
   React.useEffect(() => {
-    if (autoScroll && outputRef.current) {
+    if (autoScroll && followLatestRef.current && outputRef.current) {
       outputRef.current.scrollTop = 0;
     }
   }, [entries, autoScroll]);
+
+  const handleOutputScroll = React.useCallback((event) => {
+    followLatestRef.current = event.currentTarget.scrollTop <= 48;
+  }, []);
+
+  const hasEntries = entries.length > 0;
 
   return html`
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
@@ -181,9 +188,22 @@ export function LogsPage() {
       <!-- Log output -->
       <div
         ref=${outputRef}
+        onScroll=${handleOutputScroll}
         className="min-h-0 flex-1 overflow-y-auto bg-[var(--v2-canvas)]"
       >
-        ${error
+        ${error && hasEntries
+          ? html`
+              <div
+                className="sticky top-0 z-10 border-b border-red-500/25 bg-red-950/70 px-4 py-2 text-xs text-red-100 backdrop-blur"
+              >
+                ${t("error.loadFailed", {
+                  what: t("nav.logs"),
+                  message: error.message || error.statusText || "Request failed",
+                })}
+              </div>
+            `
+          : null}
+        ${error && !hasEntries
           ? html`
               <div
                 className="flex h-full items-center justify-center px-6 text-center text-sm text-red-300"
@@ -194,7 +214,7 @@ export function LogsPage() {
                 })}
               </div>
             `
-          : isLoading && entries.length === 0
+          : isLoading && !hasEntries
             ? html`
                 <div
                   className="flex h-full items-center justify-center text-sm text-[var(--v2-text-muted)]"
@@ -202,7 +222,7 @@ export function LogsPage() {
                   ${t("common.loading")}
                 </div>
               `
-            : entries.length === 0
+            : !hasEntries
           ? html`
               <div
                 className="flex h-full items-center justify-center text-sm text-[var(--v2-text-muted)]"

--- a/crates/ironclaw_webui_v2_static/static/js/pages/logs/logs-page.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/logs/logs-page.js
@@ -211,7 +211,7 @@ export function LogsPage() {
               </div>
             `
           : entries.map(
-              (entry, i) => html`<${LogEntry} key=${i} entry=${entry} />`
+              (entry) => html`<${LogEntry} key=${entry.id} entry=${entry} />`
             )}
       </div>
     </div>


### PR DESCRIPTION
## Summary

Fixes #4758. Part of #4692.

This wires the WebUI v2 Logs page to a real in-process operator log source instead of the previous empty TODO hook.

- add an in-memory Reborn operator log ring buffer with stable ids, newest-first pagination, level/target filters, and secret scrubbing via `LeakDetector`
- install a Reborn CLI tracing layer that records emitted tracing events into that buffer while preserving stderr logging
- wire the buffer into `RebornServices` as the `OperatorLogsService`, so `/api/webchat/v2/operator/logs` is no longer backed by `UnsupportedOperatorLogsService`
- update the WebUI v2 logs hook/page to poll the v2 operator logs endpoint, show loading/error states, support pause/clear/filter controls, and avoid rendering unsupported server-level controls
- fix a cfg-gated `OnceLock` import warning in `trigger_poller.rs`

## Notes

The current implementation is a bounded in-memory source for the active process. It does not add persisted log history and reports `follow_supported: false`; live display is handled by frontend polling.

## Verification

- `cargo check -p ironclaw_reborn_cli --features webui-v2-beta`
- `cargo test -p ironclaw_reborn_composition operator_logs --features webui-v2-beta`
- `cargo fmt --check`
- `cargo clippy -p ironclaw_reborn_cli --features webui-v2-beta -- -D warnings`
- ES module syntax check for the changed WebUI JS files