### PR TITLE
[codex] make nearai base url optional

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,8 +42,9 @@ DATABASE_POOL_SIZE=30  # multi-tenant default; reduce to 5-10 for single-user or
 #      Base URL defaults to https://private.near.ai
 #   2. API key: Set NEARAI_API_KEY to use API key auth from cloud.near.ai.
 #      Base URL defaults to https://cloud-api.near.ai
-#      When both NEARAI_BASE_URL and NEARAI_API_KEY are set at startup,
-#      IronClaw bootstraps the `nearai` MCP integration automatically:
+#      When NEARAI_API_KEY is set at startup, IronClaw bootstraps the
+#      `nearai` MCP integration automatically, using the default endpoint
+#      unless NEARAI_BASE_URL is also set:
 #      legacy startup persists a `nearai` MCP server, and Reborn local-dev
 #      seeds product-auth and activates the bundled NEAR AI MCP extension.
 # Leave NEARAI_MODEL / NEARAI_BASE_URL unset to use the built-in defaults

--- a/crates/ironclaw_reborn_composition/src/nearai_mcp.rs
+++ b/crates/ironclaw_reborn_composition/src/nearai_mcp.rs
@@ -30,14 +30,16 @@ pub struct NearAiMcpBootstrapConfig {
     api_key: SecretString,
 }
 
+const DEFAULT_NEARAI_MCP_BASE_URL: &str = "https://cloud-api.near.ai";
+
 impl NearAiMcpBootstrapConfig {
     pub fn new(
         base_url: impl Into<String>,
         api_key: SecretString,
     ) -> Result<Self, NearAiMcpBootstrapConfigError> {
-        let base_url = base_url.into().trim().to_string();
+        let mut base_url = base_url.into().trim().to_string();
         if base_url.is_empty() {
-            return Err(NearAiMcpBootstrapConfigError::MissingBaseUrl);
+            base_url = DEFAULT_NEARAI_MCP_BASE_URL.to_string();
         }
         if api_key.expose_secret().trim().is_empty() {
             return Err(NearAiMcpBootstrapConfigError::MissingApiKey);
@@ -57,7 +59,10 @@ impl NearAiMcpBootstrapConfig {
         match (base_url, api_key) {
             (Some(base_url), Some(api_key)) => Self::new(base_url, api_key).map(Some),
             (None, None) => Ok(None),
-            (None, Some(_)) => Err(NearAiMcpBootstrapConfigError::MissingBaseUrl),
+            (None, Some(api_key)) => Ok(Some(Self {
+                base_url: DEFAULT_NEARAI_MCP_BASE_URL.to_string(),
+                api_key,
+            })),
             (Some(_), None) => Err(NearAiMcpBootstrapConfigError::MissingApiKey),
         }
     }
@@ -69,16 +74,12 @@ impl NearAiMcpBootstrapConfig {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum NearAiMcpBootstrapConfigError {
-    MissingBaseUrl,
     MissingApiKey,
 }
 
 impl std::fmt::Display for NearAiMcpBootstrapConfigError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::MissingBaseUrl => {
-                write!(f, "NEARAI_BASE_URL is required when NEARAI_API_KEY is set")
-            }
             Self::MissingApiKey => {
                 write!(f, "NEARAI_API_KEY is required when NEARAI_BASE_URL is set")
             }
@@ -89,8 +90,7 @@ impl std::fmt::Display for NearAiMcpBootstrapConfigError {
 impl std::error::Error for NearAiMcpBootstrapConfigError {}
 
 pub(crate) fn nearai_mcp_endpoint_from_env() -> Result<NearAiMcpEndpoint, String> {
-    let configured_base = std::env::var("NEARAI_BASE_URL")
-        .ok()
+    let configured_base = ironclaw_common::env_helpers::env_or_override("NEARAI_BASE_URL")
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty());
     nearai_mcp_endpoint_from_base(configured_base.as_deref())
@@ -98,12 +98,10 @@ pub(crate) fn nearai_mcp_endpoint_from_env() -> Result<NearAiMcpEndpoint, String
 
 pub fn nearai_mcp_bootstrap_config_from_env()
 -> Result<Option<NearAiMcpBootstrapConfig>, NearAiMcpBootstrapConfigError> {
-    let configured_base = std::env::var("NEARAI_BASE_URL")
-        .ok()
+    let configured_base = ironclaw_common::env_helpers::env_or_override("NEARAI_BASE_URL")
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty());
-    let api_key = std::env::var("NEARAI_API_KEY")
-        .ok()
+    let api_key = ironclaw_common::env_helpers::env_or_override("NEARAI_API_KEY")
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty())
         .map(SecretString::from);
@@ -113,7 +111,7 @@ pub fn nearai_mcp_bootstrap_config_from_env()
 pub(crate) fn nearai_mcp_endpoint_from_base(
     configured_base: Option<&str>,
 ) -> Result<NearAiMcpEndpoint, String> {
-    let base = configured_base.unwrap_or("https://private.near.ai");
+    let base = configured_base.unwrap_or(DEFAULT_NEARAI_MCP_BASE_URL);
     let mut url = url::Url::parse(base)
         .map_err(|error| format!("NEARAI_BASE_URL must be an absolute URL: {error}"))?;
     if url.scheme() != "https" {
@@ -313,6 +311,42 @@ fn is_nearai_mcp_disabled_or_removed(error: &RebornServicesError) -> bool {
 mod tests {
     use super::*;
 
+    struct NearAiEnvGuard {
+        _lock: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl NearAiEnvGuard {
+        fn new() -> Self {
+            let lock = ironclaw_common::env_helpers::lock_env();
+            assert!(
+                std::env::var_os("NEARAI_BASE_URL").is_none(),
+                "NEARAI_BASE_URL must be unset for deterministic env tests"
+            );
+            assert!(
+                std::env::var_os("NEARAI_API_KEY").is_none(),
+                "NEARAI_API_KEY must be unset for deterministic env tests"
+            );
+            ironclaw_common::env_helpers::remove_runtime_env("NEARAI_BASE_URL");
+            ironclaw_common::env_helpers::remove_runtime_env("NEARAI_API_KEY");
+            Self { _lock: lock }
+        }
+
+        fn set_base_url(&self, value: &str) {
+            ironclaw_common::env_helpers::set_runtime_env("NEARAI_BASE_URL", value);
+        }
+
+        fn set_api_key(&self, value: &str) {
+            ironclaw_common::env_helpers::set_runtime_env("NEARAI_API_KEY", value);
+        }
+    }
+
+    impl Drop for NearAiEnvGuard {
+        fn drop(&mut self) {
+            ironclaw_common::env_helpers::remove_runtime_env("NEARAI_BASE_URL");
+            ironclaw_common::env_helpers::remove_runtime_env("NEARAI_API_KEY");
+        }
+    }
+
     #[test]
     fn endpoint_validation_normalizes_custom_https_base() {
         let endpoint = nearai_mcp_endpoint_from_base(Some("https://search.example.test/v1/"))
@@ -372,19 +406,85 @@ mod tests {
     }
 
     #[test]
-    fn bootstrap_config_from_optional_parts_rejects_partial_values() {
+    fn bootstrap_config_from_optional_parts_defaults_base_url_when_api_key_is_present() {
+        let config = NearAiMcpBootstrapConfig::from_optional_parts(
+            None::<String>,
+            Some(SecretString::from("nearai-test-key")),
+        )
+        .expect("default base url")
+        .expect("present config");
+
+        assert_eq!(config.base_url, DEFAULT_NEARAI_MCP_BASE_URL);
         assert_eq!(
-            NearAiMcpBootstrapConfig::from_optional_parts(
-                None::<String>,
-                Some(SecretString::from("nearai-test-key"))
-            )
-            .expect_err("missing base url"),
-            NearAiMcpBootstrapConfigError::MissingBaseUrl
+            config.endpoint().expect("endpoint").url,
+            "https://cloud-api.near.ai/mcp"
         );
+    }
+
+    #[test]
+    fn bootstrap_config_from_optional_parts_defaults_whitespace_base_url_when_api_key_is_present() {
+        let config = NearAiMcpBootstrapConfig::from_optional_parts(
+            Some("   "),
+            Some(SecretString::from("nearai-test-key")),
+        )
+        .expect("default base url")
+        .expect("present config");
+
+        assert_eq!(config.base_url, DEFAULT_NEARAI_MCP_BASE_URL);
+        assert_eq!(
+            config.endpoint().expect("endpoint").url,
+            "https://cloud-api.near.ai/mcp"
+        );
+    }
+
+    #[test]
+    fn bootstrap_config_from_optional_parts_rejects_base_url_without_api_key() {
         assert_eq!(
             NearAiMcpBootstrapConfig::from_optional_parts(Some("https://private.near.ai"), None)
                 .expect_err("missing api key"),
             NearAiMcpBootstrapConfigError::MissingApiKey
+        );
+    }
+
+    #[test]
+    fn bootstrap_config_from_env_defaults_base_url_when_only_api_key_set() {
+        let env = NearAiEnvGuard::new();
+        env.set_api_key("nearai-test-key");
+
+        let config = nearai_mcp_bootstrap_config_from_env()
+            .expect("env config")
+            .expect("present config");
+
+        assert_eq!(config.base_url, DEFAULT_NEARAI_MCP_BASE_URL);
+        assert_eq!(config.api_key.expose_secret(), "nearai-test-key");
+    }
+
+    #[test]
+    fn bootstrap_config_from_env_uses_both_env_vars_when_set() {
+        let env = NearAiEnvGuard::new();
+        env.set_base_url(" https://search.example.test/v1/ ");
+        env.set_api_key(" nearai-test-key ");
+
+        let config = nearai_mcp_bootstrap_config_from_env()
+            .expect("env config")
+            .expect("present config");
+
+        assert_eq!(config.base_url, "https://search.example.test/v1/");
+        assert_eq!(config.api_key.expose_secret(), "nearai-test-key");
+        assert_eq!(
+            config.endpoint().expect("endpoint").url,
+            "https://search.example.test/mcp"
+        );
+    }
+
+    #[test]
+    fn bootstrap_config_from_env_returns_none_when_no_env_vars() {
+        let _env = NearAiEnvGuard::new();
+
+        assert!(
+            nearai_mcp_bootstrap_config_from_env()
+                .expect("env config")
+                .is_none()
         );
     }
 }


### PR DESCRIPTION
## Summary

- Default Reborn's NEAR AI MCP bootstrap base URL to `https://cloud-api.near.ai` when `NEARAI_API_KEY` is present but `NEARAI_BASE_URL` is omitted, matching NEAR AI inference API-key auth.
- Keep rejecting the inverse partial config, where `NEARAI_BASE_URL` is set without `NEARAI_API_KEY`.
- Update `.env.example` to document `NEARAI_BASE_URL` as an optional endpoint override.

## Root Cause

The inference provider already had built-in NEAR AI base URL defaults, but the Reborn NEAR AI MCP bootstrap path treated `NEARAI_API_KEY` without `NEARAI_BASE_URL` as invalid. That made the env contract stricter than the chat provider behavior.

## Validation

- `cargo test -p ironclaw_reborn_composition nearai_mcp`