### PR TITLE
docs(claude): add Reborn autonomous loop commands (build/deslop/review)

### DIFF
--- a/.claude/commands/build-reborn.md
+++ b/.claude/commands/build-reborn.md
@@ -1,0 +1,192 @@
+---
+description: One iteration of the supervised Reborn build loop — pick one Reborn-stack task, gate it, open a PR, stop.
+---
+
+You are running **ONE iteration** of the IronClaw **Reborn** autonomous build loop. Land exactly
+one PR-sized improvement to the Reborn stack, fully gated, then **STOP** — a human merges. Do not
+merge anything.
+
+## 0. Environment & state
+- **Scope is the Reborn binary, not the legacy v1 binary.** This workspace contains both: the
+  legacy `src/` tree (root `ironclaw` crate) and the Reborn stack (`crates/ironclaw_reborn_cli`
+  → binary `ironclaw-reborn` and everything it composes). A crate is in scope when it is in the
+  `crates/ironclaw_reborn*` family or reachable from `ironclaw_reborn_cli`'s dependency graph
+  (`cargo tree -p ironclaw_reborn_cli --features webui-v2-beta` decides membership — e.g.
+  `ironclaw_product_workflow`, `ironclaw_webui_v2`, `ironclaw_reborn_composition`,
+  `ironclaw_engine`, `ironclaw_host_runtime`, `ironclaw_agent_loop`, `ironclaw_turns`, …).
+  Legacy `src/` and the root crate are **out of scope** except deletions explicitly sanctioned by
+  a closeout issue.
+- You can locally prove: **fmt, clippy, per-crate unit tests, and the deterministic Reborn e2e
+  gate** (`scripts/reborn-e2e-rust.sh` — pure cargo tests, no DB or Docker needed).
+  **PostgreSQL-backed integration tests** (`cargo test --features integration`, the
+  `reborn-integration` CI workflow) run only if a local PostgreSQL is available — otherwise
+  implement the coverage fully and mark it **"verified in CI"** in the PR body. Same for
+  Playwright e2e (`tests/e2e/`) and Docker sandbox tests. Implement, don't skip.
+- **Spec-first:** before touching a crate, read its `CLAUDE.md` (most Reborn crates have one —
+  `crates/ironclaw_reborn_composition/CLAUDE.md`, `crates/ironclaw_webui_v2/CLAUDE.md`,
+  `crates/ironclaw_product_workflow/CLAUDE.md`, `crates/ironclaw_engine/CLAUDE.md`, …). Code
+  follows spec; spec is the tiebreaker. For any feature that crosses the stack
+  (product_workflow → composition → webui_v2 → runtime/serve → frontend), follow
+  `.claude/skills/reborn-feature/SKILL.md` — it exists precisely so you don't rebuild what's
+  already wired.
+- Read `.work/loop-ledger.md` (create if missing; `.work/` is gitignored). It lists **PARKED**
+  tasks (failed ≥2×, skip) and the **open-PR stack manifest** (§9) so you know what each
+  in-flight branch holds.
+- Run `gh pr list` to **map the in-flight stack** — which open branch holds which hot files. This
+  is *not* a blocklist: you may stack on top of an open PR (§2a). Only avoid picking the **same
+  task** another PR already implements.
+
+## 1. Pick ONE task — priority cascade, stop at first viable
+1. **Rebase a stale open Reborn PR** if one is `CONFLICTING` or has fallen behind `main` (check
+   `gh pr list` + `gh pr view <n> --json mergeable`). Un-sticking an orphaned PR beats opening a
+   new one. Rebase onto `main`, re-gate, push.
+2. **Open GitHub issues** labeled `reborn` or `module:M1-webui-product` … `module:M5-events-streaming`
+   (use `gh issue list --label reborn`) — human intent wins. **Skip issues that already have an
+   assignee** — an assignee means another agent/human is on it. On picking, *claim* it (§1b).
+   Large epics (e.g. QA automation, channel ports) are picked **one sub-task at a time**, never
+   whole.
+3. **Machine-discovered gaps** — often the highest-value output:
+   - `#[ignore]`d or `todo!()`/`unimplemented!()` markers in Reborn-stack crates
+   - drift between a crate's `CLAUDE.md` spec and its code
+   - WebUI v2 routes missing from `crates/ironclaw_webui_v2/tests/webui_v2_descriptors_contract.rs`, or facade methods
+     still returning default "unavailable" bodies that should be implemented
+   - dual-backend gaps (a persistence feature implemented for only one of PostgreSQL/libSQL)
+   - clippy / quality debt inside the Reborn stack
+4. **Roadmap decomposition**: one concrete sub-task from `docs/plans/` (engine-v2 architecture,
+   Reborn budgets follow-ups, channel port maps) or `docs/reborn/` — prefer tasks gateable on
+   this host; DB/e2e-dependent halves are implemented fully and marked "verified in CI".
+
+**Selection bias:** prefer work in **leaf crates / files no open PR holds** — it gates cleanly,
+merges independently, and never enters the rebase race. Skip PARKED tasks and any task another
+open PR already *implements* (stacking on top is allowed; duplicating is not).
+
+### Escalation when the free surface is thin — DO NOT default to a no-PR iteration
+"Nothing small, clean, and independent is left" is **not** "nothing to do." When the easy surface
+is dry, **escalate in this order** before considering a no-PR iteration:
+1. **Stack** on an open PR's branch (§2a) to reach work its files were blocking.
+2. **CI-deferred halves** — integration-test coverage, Playwright scenarios, Docker-path work you
+   can implement fully here and verify in CI. *Do not skip it just because it can't run locally.*
+3. **Larger multi-file Reborn features** — a facade method + composition impl + route + frontend
+   slice per the reborn-feature skill. Real, locally-gateable, and under-rated precisely because
+   they aren't one-file changes. Confirm the feature isn't already shipped under a different
+   design before starting. Scope to ONE coherent PR (§2); split if it sprawls.
+4. **Issue hygiene** — if a merged PR fully implemented an issue, close it (§8) so the backlog
+   reflects reality instead of looking artificially empty.
+
+Only after 1–4 yield nothing real is a **no-PR iteration** correct — and even then, never
+manufacture a marginal PR or weak test to fill the gap (§6).
+
+## 1b. Claim the issue — make "in progress" visible (parallel-safe)
+Multiple agents run this loop against the same repo, so an **unclaimed issue looks free even when
+someone is already on it**. The moment you commit to an **issue-backed** task:
+- **Assign it to yourself:** `gh issue edit <N> --add-assignee @me`. ("Assigned *at all*" — not
+  *who* — is the in-progress signal; that's why §1 rung 2 skips already-assigned issues.)
+- **Post your implementation plan as a comment:** `gh issue comment <N> --body "<plan>"` — a few
+  bullets: the approach, the crates/files you'll touch, and how you'll gate it. Keep it short;
+  it's a claim + sketch, not a design doc.
+- Do this **right after picking, before branching** (§3). If the issue turns out non-viable and
+  you drop it, `gh issue edit <N> --remove-assignee @me` so it reads as free again.
+
+Machine-discovered gaps / roadmap sub-tasks with **no** backing issue have nothing to claim — the
+branch + PR are the visibility. Rebasing a stale PR (§1 rung 1) is already claimed by that PR.
+
+## 2. FENCES (hard)
+- **Reborn stack only** (§0). Do NOT modify legacy `src/` paths, and do NOT add new code that
+  couples a Reborn crate to the root `ironclaw` crate — the
+  `reborn_dependency_boundaries` architecture test enforces this; respect it, never weaken it.
+- **Boundary invariants** (from the crate specs — violating any of these is an automatic redo):
+  - `ironclaw_webui_v2` handlers consume **only** `RebornServicesApi` — never the dispatcher,
+    host_runtime, stores, or DB directly.
+  - Tenant/user/agent identity comes from the **authenticated caller**, never the request body.
+  - New persistence supports **both** PostgreSQL and libSQL.
+  - **LLM data is never deleted** — mark, filter, retain; never strip or truncate.
+  - `credential_name` (backend secret identity) vs `extension_name` (user-facing identity) must
+    not be conflated.
+- Repo code style: no `.unwrap()`/`.expect()` in production code, `thiserror` error types,
+  prompt templates in files not Rust constants, `debug!` not `info!` for internals.
+- Scope = **ONE coherent PR**. If it sprawls, split and do the smaller, self-contained half.
+
+## 2a. Stacking — never idle waiting for a merge
+Throughput is bounded by human merge cadence, not your output. **Do not stall** when every clean
+free file is held by an open PR — **stack** instead:
+- **Branch off the dependency, not `main`.** If your task needs code from open PR `#N` (branch
+  `B`), `git switch -c <type>/<slug> B`. If it's independent, branch off `main` as usual.
+- **One logical change per PR still holds** — stacking means *ordering* PRs, not bundling them.
+- **Record the stack** in the ledger manifest (§9): `branch → base (main | #N) → holds <files>`.
+- **Rebase forward when a base merges.** When `#N` lands, rebase its children onto `main` and
+  re-gate them (this is also priority-cascade rung 1).
+- **Prefer independent leaf work first** (§1 selection bias); keep stacks **shallow**.
+- A **no-PR iteration is still valid** when there is genuinely no real task — *do not manufacture
+  a marginal PR or a weak test just to avoid idling* (§6).
+
+## 3. Branch
+`git switch -c <type>/<short-slug>` — type ∈ {feat, fix, refactor, perf, docs, test}. Work in an
+isolated worktree if your current one is dirty.
+
+## 4. Implement
+- If the task matches a skill, **follow it** as a gate, not a shortcut: `reborn-feature` for
+  cross-stack features, `add-sse-event` / `add-tool` for their scaffolds, the
+  thermo-nuclear-code-quality-review standards for your own diff (§7).
+- Match surrounding code style, comment density, and idiom. Read the crate `CLAUDE.md` first.
+
+## 5. Gates — ALL must pass locally (or be CI-deferred with a stated reason)
+```
+cargo fmt
+cargo clippy --all --benches --tests --examples --all-features   # zero warnings
+cargo test -p <each touched crate>                               # plus cargo test for wide changes
+scripts/reborn-e2e-rust.sh                                       # deterministic Reborn e2e gate
+```
+- Touched `ironclaw_webui_v2_static` JS → `node --check <file>` each touched file (no build step).
+- Touched WebUI v2 routes → `crates/ironclaw_webui_v2/tests/webui_v2_descriptors_contract.rs` must be updated and green.
+- PostgreSQL available → also run `cargo test --features integration` for touched persistence;
+  otherwise state "integration coverage verified in CI (`reborn-integration`)" in the PR body.
+- The pre-commit hook (`scripts/pre-commit-safety.sh`) must pass — never `--no-verify` past it.
+
+## 6. Anti-reward-hacking guard — inspect YOUR OWN diff before committing
+Reject and fix your own work if the diff:
+- adds a net-new `#[ignore]`, `todo!()`/`unimplemented!()`, or `#[allow]` **just to pass a gate**
+- **weakens** any test assertion, architecture boundary test, or descriptor contract
+- adds a `// dispatch-exempt:` or similar escape-hatch annotation to dodge the safety pipeline
+- pushes a file from **<1k to >1k lines** without strong justification
+
+The job is to **close** gaps, not silence the detectors.
+
+## 7. Self-review — thermo-nuclear code-quality pass (REQUIRED before every PR)
+Apply the **`thermo-nuclear-code-quality-review`** standards to your own diff and act on the
+findings *before* pushing. (The skill is `disable-model-invocation`, so follow its rules directly
+— read `.claude/skills/thermo-nuclear-code-quality-review/SKILL.md`, don't try to invoke it.)
+Specifically:
+- hunt for a "code-judo" reframing that **deletes** complexity rather than rearranging it;
+- no file pushed from <1k to >1k lines without a strong reason — decompose instead;
+- no new ad-hoc conditionals / special-case branches bolted onto existing flows;
+- no dead, redundant, or speculative branches;
+- no thin wrappers, casts, or optionality that obscure the real contract;
+- keep logic in its canonical layer (port → facade → impl → route, per the reborn-feature skill),
+  reuse existing helpers, don't leak substrate handles across crate boundaries.
+
+Record any **deliberate** tradeoff the review surfaced in the PR body.
+
+## 8. Land — stop at PR
+- Commit: `<type>(<scope>): <subject>`, reference the issue if any. End with your standard
+  `Co-Authored-By: Claude …` trailer.
+- Push and open the PR with `gh`. PR body: **what + why**, which gates ran locally, and what is
+  **CI-deferred** (integration / Playwright e2e / Docker). End with the Generated-with trailer.
+- **Issue hygiene:** if the PR fully implements an issue, put `Closes #N` in the body. If you
+  notice an *already-merged* PR that closed an issue without the keyword, close that issue
+  directly (`gh issue close`) with a pointer to the PR.
+- **STOP. Do not merge.**
+
+## 9. Record
+Append one line to `.work/loop-ledger.md`: task · branch · PR# · gate status. If the gates failed
+twice this iteration, mark the task **PARKED** with the reason and move on — do **not** open a
+broken PR.
+
+Maintain an **open-PR stack manifest** in the ledger so the next iteration can rebase in order:
+```
+## Stack (open PRs)
+| branch | base (main | #N) | holds (hot files) | status |
+```
+Update it whenever you open a stacked PR, and prune rows as PRs merge (rebasing any children onto
+`main`).
+
+Then end the turn; the loop paces the next iteration.

--- a/.claude/commands/deslop-reborn.md
+++ b/.claude/commands/deslop-reborn.md
@@ -1,0 +1,240 @@
+---
+description: One iteration of the Reborn de-slop loop — take ONE Reborn-stack crate, fan out parallel review sub-agents (thermo-nuclear quality, paranoid architect, API/spec/invariants, test-coverage/wiring), synthesize, apply fixes/refactors/missing tests, open a PR. Stop.
+argument-hint: "[crate-name]"
+---
+
+You are running **ONE iteration** of the IronClaw **Reborn de-slop** loop. Take exactly one
+Reborn-stack crate that has **not been de-slopped yet**, review it *deeply and from multiple
+angles using parallel sub-agents*, then **land one coherent PR** that fixes the findings —
+simplifications, refactors, spec/interface corrections, and any **missing unit/e2e tests** needed
+to keep the component correct forever. Then **STOP** — a human merges. Do not merge anything.
+
+Unlike `/review-reborn` (which reviews an open PR's diff), this loop reviews a **whole crate as it
+stands on `main`** and improves it. The unit of work is a **crate**, not a diff.
+
+If the user passed a crate name as an argument (`$ARGUMENTS`, e.g. `ironclaw_reborn_config`),
+de-slop **that** crate and skip the selection cascade in §1. Otherwise pick one per §1.
+
+## 0. Environment & state
+- **Scope is the Reborn stack.** Eligible crates are the `crates/ironclaw_reborn*` family plus
+  the substrate crates the `ironclaw-reborn` binary composes
+  (`cargo tree -p ironclaw_reborn_cli --features webui-v2-beta` decides membership —
+  `ironclaw_product_workflow`, `ironclaw_webui_v2`, `ironclaw_reborn_composition`,
+  `ironclaw_engine`, `ironclaw_host_runtime`, `ironclaw_agent_loop`, `ironclaw_turns`, …).
+  The legacy `src/` tree and root `ironclaw` crate are **out of scope**.
+- You can locally prove: **fmt, clippy, per-crate unit tests, and the deterministic Reborn e2e
+  gate** (`scripts/reborn-e2e-rust.sh`). PostgreSQL integration tests and Playwright e2e run only
+  if the local environment supports them — if your fixes touch those paths, implement them fully
+  and mark them **"verified in CI"** in the PR body. Never weaken or delete coverage just because
+  it can't run here.
+- Read `.work/deslop-ledger.md` (create if missing; `.work/` is gitignored). The **DESLOPPED**
+  list records crates this loop has already passed through — **skip them** so two iterations
+  don't re-chew the same crate. Also run `gh pr list`: **don't pick a crate an open PR is
+  actively reshaping** (you would collide on the same files); prefer a crate no open PR holds.
+
+## 1. Pick ONE un-de-slopped crate — stop at first viable
+List the eligible crates (§0). A crate is a **candidate** when ALL hold:
+- **not already in the ledger DESLOPPED list** (§0),
+- **not the hot surface of an open PR** (§0) — leave those to the build/review loops,
+- it has real source to review (a pure test-harness or static-asset crate is fair game only for
+  the coverage / interface angles).
+
+**Selection bias:** prefer **smaller / leaf crates first** — they fit entirely in context, gate
+cleanly, and merge independently. A crate whose `src` is **under ~2k lines** can and SHOULD be
+read in full (§3). Clear the small, high-leverage crates before taking on the giants
+(`ironclaw_engine`, `ironclaw_reborn_composition`, `ironclaw_webui_v2` are large — those need
+targeted reading, not a full load, and may warrant splitting the de-slop across iterations
+module-by-module). When unsure, prefer a crate that is **load-bearing for invariants** (identity,
+event store, config/secrets, product workflow facade, host runtime trust) over a purely
+mechanical one — a slop fix there protects the whole system.
+
+If **every** crate is ledger-recorded or PR-held, this is a **no-de-slop iteration**: record
+"nothing to de-slop" in the ledger and STOP. Do **not** manufacture a marginal PR to fill the gap.
+
+## 2. FENCES (hard)
+- **De-slop the crate — do not redesign its feature or change its observable contract.** Your
+  mandate is quality (structure, decomposition, spaghetti, abstraction, file size), **interface
+  hygiene** (public surface not over-exposed, crate `CLAUDE.md`/README accurate), **invariant
+  integrity**, and **test coverage** — not re-scoping what the crate does. If you conclude the
+  crate's *premise* or *layer* is wrong, write that up in the PR body / an issue and STOP — don't
+  silently rewrite it into something else.
+- **Scope = ONE coherent PR.** If the crate is huge and the findings sprawl, do the **smallest
+  self-contained slice** (one module / one invariant / one test gap) and record the rest in the
+  ledger for the next iteration. Never open a sprawling 4k-line refactor PR.
+- **Boundary invariants are findings when violated, never tools for "cleanup":**
+  - Reborn crates must not depend on the root `ironclaw` crate (`reborn_dependency_boundaries`
+    enforces this — never weaken it).
+  - `ironclaw_webui_v2` consumes only `RebornServicesApi`; substrate handles stay private to
+    factories/composition.
+  - Identity from the authenticated caller, never the request body.
+  - Dual-backend (PostgreSQL + libSQL) parity for persistence.
+  - **LLM data is never deleted** — "cleanup" means evicting caches, never deleting DB rows.
+- Repo code style: no `.unwrap()`/`.expect()` in production code, `thiserror`, prompt templates
+  in files, `debug!` not `info!` for internals. **Never add a log line that prints prompt
+  content, completions, key material, or secrets** — ids/counts/sizes/durations/error-types only.
+  Treat any such finding as a hard blocker and fix it.
+
+## 3. Load the crate & branch
+- Read the crate's **`CLAUDE.md`** (the spec — code follows spec; spec is the tiebreaker) and/or
+  `README.md` (note the absence of either as a finding), `Cargo.toml` (deps, features, `pub`
+  surface), and its `lib.rs`/`main.rs` to map the module tree.
+- **Small crate (`src` < ~2k lines): read every source file in full** so the review is complete,
+  not sampled. **Large crate: read the spec, the public API (`lib.rs` re-exports), and the
+  largest / hottest modules**, and scope the PR to the slice you fully understand (§2).
+- Branch off `main`: `git switch -c deslop/<crate-short-name>` (e.g. `deslop/reborn-config`).
+  Confirm it builds before you start.
+
+## 4. Fan out the review — PARALLEL sub-agents (this is the core of the loop)
+Spawn the following review sub-agents **concurrently** (issue them in a single message so they
+run in parallel via the Agent tool). Give **each** sub-agent the crate path, tell it to **read
+the crate's source itself**, and require it to return a **prioritized, structured findings list**
+where every finding names the **file/lines**, the **smell**, and a concrete **remedy** (not just
+the smell). Run **at least** these four angles:
+
+1. **Thermo-nuclear quality reviewer.** Instruct it: *read
+   `.claude/skills/thermo-nuclear-code-quality-review/SKILL.md` and apply it verbatim to the
+   entire crate as if it were one large diff* (the skill is `disable-model-invocation`, so it
+   must follow the rules directly, not try to invoke it). Hunt for **code-judo** reframings that
+   delete whole branches/helpers/modes; flag any file over ~1k lines that should be decomposed;
+   flag ad-hoc conditionals, thin wrappers, needless optionality/casts, dead/speculative
+   branches, canonical-helper duplication, and logic in the wrong layer. Output in the skill's
+   priority order.
+
+2. **Paranoid senior architect.** Give it this prompt, framed at the whole crate:
+   > You are a paranoid senior engineer and architect on this project. A junior engineer has
+   > shipped this crate as if it were a single pull request, and your job is to carefully review
+   > it for **correct architecture, completeness, and security**, and to ensure that **testing
+   > covers all edge cases and exercises the whole wiring — not just local unit tests**. Where
+   > the code is a **bug-fix-shaped** pattern, the goal is that this *whole class* of problem can
+   > never recur. Where it is a **feature**, ensure there will be **no future bug reports**
+   > against it. Enumerate concrete gaps (missing error handling, unhandled edge cases,
+   > race/replay/atomicity hazards, tenant-isolation or auth-boundary leaks, secrets/privacy
+   > leaks in logs or errors, partial-state bugs, dual-backend divergence, integration paths
+   > never exercised end-to-end) with file/line and the fix or the test that would close them.
+
+3. **Interface / spec / invariants auditor.** Instruct it to verify: the **public API is not
+   over-exposed** (every `pub`/`pub(crate)` item that doesn't need to be public should be
+   tightened — flag leaked internals, `pub` fields that should be private, raw substrate handles
+   escaping the facade, types re-exported needlessly); the **crate `CLAUDE.md` (and README if
+   present) exists and is accurate** (documents the crate's purpose, the real public surface, and
+   its core invariants — flag drift between spec and code in *both* directions); and the crate's
+   **core invariants actually hold** in code (find the documented/implied invariants and check
+   each is enforced at its boundary, not assumed). Output: over-exposed items to seal, spec
+   corrections, and any invariant that is stated-but-unenforced or enforced-but-undocumented.
+
+4. **Test-coverage & wiring auditor.** Instruct it to map what the crate's tests actually cover
+   vs. what they should: identify **untested public functions, error paths, and edge cases**, and
+   — critically — whether the crate is only **unit-tested in isolation** when it has a real
+   **integration / e2e path** that is never exercised through the full wiring. Apply the repo
+   rule "**test through the caller, not just the helper**" (`.claude/rules/testing.md`): a helper
+   that gates a side effect needs a test that drives the call site. Check whether the crate's
+   contracts appear in `scripts/reborn-e2e-rust.sh`'s test groups and whether persistence paths
+   are covered for **both** backends. Output: the specific **unit and e2e tests that are
+   missing**, each with the behavior it would pin down.
+
+Consider **additional angles** when the crate warrants it (spawn them too): a
+dependency/feature-flag hygiene pass (the Reborn feature matrix — `webui-v2-beta`,
+`openai-compat-beta`, `postgres`, `libsql` — breeds dead `cfg` branches), a
+concurrency/panic-safety pass, or a perf-smell pass. Right-size the fan-out to the crate.
+
+While the agents run, kick off `cargo build -p <crate> --all-targets` **in the background** to
+confirm a green baseline — don't block on it.
+
+**Treat every agent finding as a LEAD, not a fact.** The sub-agents read excerpts, not the whole
+workspace, so they routinely disagree with each other and get **external-usage claims wrong** —
+a `pub` item called "dead" or "test-only" may have production callers in another crate, and
+vice-versa. Any finding that asserts "X has no callers / only test callers / is over-exposed /
+is unused" is a hypothesis you MUST verify in §5 before acting on it.
+
+## 5. Synthesize the findings — then VERIFY before acting
+Collect every sub-agent's findings into **one deduplicated, prioritized list** (use the
+thermo-nuclear ordering: structural regressions → missed simplifications → spaghetti →
+boundary/type → file size → modularity → legibility, then fold in the architect's
+correctness/security/coverage gaps and the interface/spec/invariant items). Merge overlapping
+findings; drop low-value nits if bigger structural issues exist. For each kept finding, decide
+the **remedy** and whether it fits in this PR's scope (§2) or should be recorded for a later
+iteration.
+
+**Before you act on any finding that deletes or seals a public item, grep the workspace yourself
+to confirm the caller set** — the agents' external-usage claims (§4) are unreliable. For each
+`pub`/`pub(crate)` item, variant, or function you plan to **delete** or **tighten**:
+```
+grep -rn "<ItemName>" crates/ src/ --include=*.rs | grep -v "crates/<this-crate>/"
+```
+Distinguish **construction** from **field/value reads**, and **production** call sites from
+**test** ones — a `pub` field with a production reader in another crate is a different decision
+than one read only by a test. Only the grep result — not an agent's say-so — decides whether
+something is dead, over-exposed, or safe to seal.
+
+## 6. Apply the fixes
+Implement every in-scope finding, applying the skill's **preferred remedies** (delete a layer,
+collapse duplicate branches into one flow, extract a helper/module, replace a condition chain
+with a typed dispatcher, move logic to its canonical home, **tighten over-exposed `pub`**,
+**fix/author the crate spec**, **add the missing unit/e2e tests**). Match the crate's surrounding
+style, comment density, and idiom.
+
+If a finding is a **deliberate, justified tradeoff** (duplication genuinely clearer than the
+abstraction, an invariant deliberately checked elsewhere), don't force it — record the
+justification in the PR body. The bar is "every finding *resolved*" — fixed, or explicitly
+justified.
+
+**Let blast radius (from the §5 grep) decide scope, and keep the PR single-crate by default.** A
+seal/delete whose fallout is confined to this crate (+ its own tests) is in-scope — just do it.
+But when tightening a `pub` item would force edits to **other crates'** production code, that's a
+cross-crate change masquerading as de-slop: prefer to **defer it** (record in the PR body +
+ledger §9, optionally file an issue) rather than drag this PR into three crates. Likewise defer
+anything that **changes the crate's observable contract, its wire/event format, or adds a
+dependency** — those want their own focused, deliberately-reviewed PR. Fix the clean, contained
+findings now; record the ripple-y ones.
+
+### Anti-reward-hacking guard — inspect YOUR OWN diff
+Reject and redo your own change if it:
+- adds a net-new `#[ignore]`, `todo!()`/`unimplemented!()`, or `#[allow]` **just to pass a gate
+  or quiet a finding**;
+- **weakens** any existing test assertion, boundary test, or descriptor contract;
+- "addresses" a coverage finding with a test that asserts nothing, or a spec that documents the
+  bug instead of fixing it;
+- pushes a file from **<1k to >1k lines** without strong justification;
+- adds a log line that violates the privacy rule (§2).
+
+The job is to make the crate **cleaner, better-documented, and better-tested** — not to silence
+the detectors. A new test must actually pin behavior; a sealed `pub` must still compile the
+workspace.
+
+## 7. Gates — ALL must pass locally (or be CI-deferred with a stated reason)
+```
+cargo fmt
+cargo clippy --all --benches --tests --examples --all-features   # zero warnings
+cargo test -p <crate>            # plus -p each crate touched by fallout
+scripts/reborn-e2e-rust.sh       # deterministic Reborn e2e gate
+```
+Sealing a public item can break **other** crates — clippy `--all` and the e2e gate catch most of
+that; for wide fallout run a full `cargo test`. Touched `ironclaw_webui_v2_static` JS →
+`node --check` each file. PostgreSQL integration tests run if available, else note "verified in
+CI (`reborn-integration`)". Everything must be **green after your fixes**.
+
+## 8. Self thermo-nuclear pass + land — stop at PR
+1. **Re-run the thermo-nuclear standards on your OWN diff** (read the SKILL, apply directly). It
+   must clear the **Approval Bar**: no structural regression, no missed obvious simplification,
+   no unjustified file-size explosion, no spaghetti branching, no hacky/magical abstraction, no
+   needless wrapper/cast/optionality, no boundary leak or canonical-helper duplication. If a new
+   finding appears, loop back to §6.
+2. **Commit:** `refactor(<crate>): de-slop — <one-line summary>` (use `refactor` for structural
+   changes, `test` if the PR is mostly added coverage, `docs` if mostly spec, `fix` if you
+   corrected a real bug a finding exposed). End with your standard `Co-Authored-By: Claude …`
+   trailer.
+3. **Push and open the PR** with `gh`. PR body states: the **crate**, the **findings grouped by
+   angle** (quality / architecture & security / interface & spec & invariants / coverage), **what
+   you changed** for each, any **deliberate tradeoff** left in place with its justification,
+   which **gates ran locally** and what is **CI-deferred**, and any **out-of-scope findings
+   deferred** to a later iteration. End with the Generated-with trailer.
+4. **STOP. Do not merge.**
+
+## 9. Record
+Append one line to `.work/deslop-ledger.md`: crate · branch · PR# · gate status · what was fixed.
+Add the crate to the **DESLOPPED** list so the next iteration skips it. If you only de-slopped a
+**slice** of a large crate (§2), record the **remaining slices** so the next iteration continues
+it rather than marking the whole crate done. If the review concluded the crate's *premise* is
+wrong (§2) and you pushed no fixes, record that verdict instead so a human can decide.
+
+Then end the turn; the loop paces the next iteration.

--- a/.claude/commands/review-reborn.md
+++ b/.claude/commands/review-reborn.md
@@ -1,0 +1,164 @@
+---
+description: One iteration of the supervised Reborn review loop — take an un-reviewed open Reborn-stack PR, thermo-nuclear review it, fix every finding, re-review to approval, push, comment. Stop.
+argument-hint: "[PR number]"
+---
+
+You are running **ONE iteration** of the IronClaw **Reborn** autonomous review loop. Take exactly
+one open Reborn-stack PR that has **not been reviewed yet**, run the thermo-nuclear code-quality
+review against its diff, **address every finding**, re-run the review until it clears the
+approval bar, push the fixes back to the PR branch, and leave a note summarizing what changed.
+Then **STOP** — a human merges. Do not merge anything, and do not open a new feature PR.
+
+If the user passed a PR number as an argument (`$ARGUMENTS`), review **that** PR and skip the
+selection cascade in §1. Otherwise pick one per §1.
+
+## 0. Environment & state
+- **Scope is the Reborn stack.** A PR is in scope when its changed files live in the
+  `crates/ironclaw_reborn*` family or the substrate crates the `ironclaw-reborn` binary composes
+  (`ironclaw_product_workflow`, `ironclaw_webui_v2`, `ironclaw_webui_v2_static`,
+  `ironclaw_reborn_composition`, `ironclaw_engine`, `ironclaw_host_runtime`,
+  `ironclaw_agent_loop`, `ironclaw_turns`, …) — the `reborn` / `module:M1..M5` labels are a
+  strong hint, but the file list (`gh pr view <N> --json files`) decides. Legacy `src/`-only PRs
+  belong to a different loop; leave them.
+- You can locally prove: **fmt, clippy, per-crate unit tests, and the deterministic Reborn e2e
+  gate** (`scripts/reborn-e2e-rust.sh`). PostgreSQL integration tests and Playwright e2e run only
+  if the local environment supports them — if your fixes touch those paths, implement them fully
+  and mark them **"verified in CI"** in the note. Never weaken or delete coverage just because it
+  can't run on this host.
+- Read `.work/loop-ledger.md` (create if missing; `.work/` is gitignored). The **REVIEWED** list
+  records PRs this loop has already passed through — **skip them** so two iterations don't
+  re-chew the same PR. The open-PR stack manifest (§9 of the build loop) tells you which branch
+  bases on which, so a fix you push to a base branch is understood to flow to its children on
+  their next rebase.
+
+## 1. Pick ONE un-reviewed PR — stop at first viable
+Run `gh pr list --json number,title,reviewDecision,reviews,isDraft,mergeable,headRefName,author,labels`.
+A PR is a **candidate** when ALL hold:
+- **in Reborn scope** (§0),
+- **not a draft** (`isDraft == false`),
+- **never reviewed** — `reviews` is empty **and** `reviewDecision` is `""` (no `APPROVED` /
+  `CHANGES_REQUESTED` / `COMMENTED` from anyone, human or bot reviewer). A PR that already
+  carries a review is someone else's turn; leave it.
+- **not already in the ledger REVIEWED list** (§0),
+- **mergeable is not `CONFLICTING`** — a conflicted PR needs a rebase first (that's the build
+  loop's job, §1 rung 1); don't try to review a diff that won't apply.
+
+Among candidates, **prefer the oldest open PR** (lowest number) — un-reviewed PRs rot while the
+loop chases newer work; clearing the front of the queue is the point. If two agents could race
+the same PR, the review you post (§7) is the claim — check once more right before posting that no
+review landed in the meantime.
+
+If **no** candidate exists (every open PR is draft, already reviewed, conflicting, out of scope,
+or ledger-recorded), this is a **no-PR iteration**: record "nothing to review" in the ledger and
+STOP. Do **not** invent a review of an already-reviewed PR to fill the gap.
+
+## 2. FENCES (hard)
+- **You review and fix the PR you picked — you do not redesign its feature.** Your mandate is the
+  thermo-nuclear *quality* bar (structure, decomposition, spaghetti, abstraction, file size), not
+  re-scoping what the PR set out to do. If the PR's *premise* is wrong (wrong layer, duplicates
+  shipped work, violates a crate spec), say so in the review note and STOP — don't silently
+  rewrite it into a different PR.
+- **Keep the fix coherent with the PR.** Push only quality fixes for *this* PR's diff to *this*
+  PR's branch. Don't fold in unrelated changes, don't bump scope, don't merge.
+- **Boundary invariants are review findings when the PR violates them** (and your fixes must
+  never introduce a violation):
+  - `ironclaw_webui_v2` handlers consume only `RebornServicesApi`; no Reborn crate may depend on
+    the root `ironclaw` crate (`reborn_dependency_boundaries` enforces this — never weaken it).
+  - Identity from the authenticated caller, never the request body.
+  - Dual-backend (PostgreSQL + libSQL) parity for new persistence; **LLM data is never deleted**.
+  - `credential_name` vs `extension_name` must not be conflated.
+  - New WebUI v2 routes must appear in `crates/ironclaw_webui_v2/tests/webui_v2_descriptors_contract.rs`.
+- Repo code style: no `.unwrap()`/`.expect()` in production code, `thiserror`, prompt templates
+  in files, `debug!` not `info!` for internals, no log line that prints prompt content, key
+  material, or secrets.
+
+## 3. Check out the PR branch
+`gh pr checkout <N>` — this puts you on the PR's head branch with its commits. Confirm you are on
+the PR branch and that it builds **before** you start (a PR that's already red tells the review
+where to focus). Record the head SHA so you can diff your fixes later. Read the `CLAUDE.md` of
+each crate the PR touches — code follows spec; spec is the tiebreaker.
+
+## 4. Thermo-nuclear review (REQUIRED — this is the gate)
+The `thermo-nuclear-code-quality-review` skill is `disable-model-invocation`, so **follow its
+rules directly — read `.claude/skills/thermo-nuclear-code-quality-review/SKILL.md`, don't try to
+invoke it.** Apply it to the PR's **full diff vs `main`** (`git diff main...HEAD`), not just the
+latest commit. Be ambitious and demanding exactly as the skill prescribes:
+- hunt for a **"code-judo"** reframing that **deletes** whole branches/helpers/modes rather than
+  rearranging them;
+- flag any file the PR pushes from **<1k to >1k lines** — decompose instead;
+- flag new **ad-hoc conditionals / special-case branches** bolted onto existing flows;
+- flag thin wrappers, casts, needless optionality, dead/speculative branches, canonical-helper
+  duplication, and logic landing in the wrong layer/crate (port → facade → impl → route, per
+  `.claude/skills/reborn-feature/SKILL.md`).
+
+Produce a concrete, prioritized **findings list** (use the skill's ordering: structural
+regressions first, then missed simplifications, spaghetti, boundary/abstraction, file size,
+modularity, legibility). Each finding must name the file/lines and the **remedy**, not just the
+smell. If the diff genuinely clears the approval bar on the first pass with zero findings, jump
+to §7 and post an approval note — but hold the skill's bar honestly; a real review rarely finds
+nothing.
+
+## 5. Address EVERY finding
+Fix every finding the review raised, applying the skill's **preferred remedies** (delete a layer,
+collapse duplicate branches into one flow, extract a helper/module, replace a condition chain
+with a typed dispatcher, move logic to its canonical home). Match the PR's surrounding style,
+comment density, and idiom.
+
+If a finding is a **deliberate, justified tradeoff** the original author made (e.g. duplication
+that is genuinely clearer than the abstraction), don't force it — instead record the
+justification in the note (§7) so the human merger sees the reasoning. The bar is "every finding
+*resolved*" — fixed, or explicitly justified — not "every finding mechanically rewritten."
+
+### Anti-reward-hacking guard — inspect YOUR OWN fix diff
+Reject and redo your own change if it:
+- adds a net-new `#[ignore]`, `todo!()`/`unimplemented!()`, or `#[allow]` **just to pass a gate
+  or quiet the review**;
+- **weakens** any test assertion, boundary test, or descriptor contract the PR introduced;
+- "addresses" a finding by deleting the test/coverage that surfaced it;
+- pushes a file from **<1k to >1k lines** without strong justification.
+
+The job is to make the PR **cleaner**, not to silence the detectors. Suppressing a finding is
+worse than leaving it open with a note.
+
+## 6. Re-gate — ALL must pass locally (or be CI-deferred with a stated reason)
+```
+cargo fmt
+cargo clippy --all --benches --tests --examples --all-features   # zero warnings
+cargo test -p <each touched crate>
+scripts/reborn-e2e-rust.sh                                       # deterministic Reborn e2e gate
+```
+Touched `ironclaw_webui_v2_static` JS → `node --check` each file. PostgreSQL integration tests
+run if available, else note "verified in CI (`reborn-integration`)". The PR must be **green after
+your fixes**, including any test the original PR shipped.
+
+## 7. Re-review to approval, then push + comment
+1. **Re-run the thermo-nuclear pass (§4) on the now-fixed diff.** It must clear the skill's
+   **Approval Bar**: no structural regression, no obvious missed simplification, no unjustified
+   file-size explosion, no spaghetti branching, no hacky/magical abstraction, no needless
+   wrapper/cast/optionality, no boundary leak or canonical-helper duplication. If a *new* finding
+   appears, loop back to §5. Iterate §5→§6→§7 until the bar is clean (or a remaining item is
+   recorded as a justified tradeoff).
+2. **Commit your fixes** onto the PR branch:
+   `style|refactor(<scope>): address thermo-nuclear review findings` (use `refactor` for
+   structural changes, `fix` if you corrected a real bug the review exposed). End with your
+   standard `Co-Authored-By: Claude …` trailer.
+3. **Push to the PR branch** (the branch already has an upstream from `gh pr checkout`, so a
+   plain `git push` updates the PR). Never force-push someone else's branch unless you only
+   rebased it; for added fix commits a fast-forward `git push` is correct.
+4. **Post the review note as a PR review**, re-checking first that no other review landed (§1):
+   `gh pr review <N> --approve --body "<note>"` once the bar is clean, or
+   `gh pr review <N> --comment --body "<note>"` if you pushed fixes but want a human to look at a
+   recorded tradeoff. The note states: **the findings** (grouped by the skill's priority order),
+   **what you changed** for each (with the fix commit SHA), any **deliberate tradeoff** left in
+   place with its justification, which **gates ran locally** and what is **CI-deferred**
+   (integration / Playwright e2e), and a one-line **verdict**. End with the Generated-with
+   trailer.
+5. **STOP. Do not merge.**
+
+## 8. Record
+Append one line to `.work/loop-ledger.md`: PR# · what was fixed · gate status ·
+approved|commented. Add the PR to the **REVIEWED** list so the next iteration skips it. If the
+review concluded the PR's *premise* is wrong (§2) and you pushed no fixes, record that verdict
+instead so a human can decide.
+
+Then end the turn; the loop paces the next iteration.

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ trace_*.json
 .worktrees/
 .ironclaw/
 .review/
+.work/
 
 # Python cache
 __pycache__/


### PR DESCRIPTION
## What

Ports the supervised agent-loop workflow from [nearai/orchard's `.claude/commands`](https://github.com/nearai/orchard/tree/main/.claude/commands) (`build-orchard` / `deslop-orchard` / `review-orchard`) to IronClaw, adapted specifically to the **Reborn binary**:

| Command | One iteration does |
|---|---|
| `/build-reborn` | Pick one Reborn-stack task (stale-PR rebase → `reborn`-labeled issues → machine-discovered gaps → roadmap decomposition), claim the issue, implement, gate, open a PR, **stop** |
| `/deslop-reborn [crate]` | Pick one un-de-slopped Reborn crate, fan out 4 parallel review sub-agents (thermo-nuclear quality, paranoid architect, interface/spec/invariants, coverage/wiring), grep-verify findings, fix, open a PR, **stop** |
| `/review-reborn [PR#]` | Pick the oldest un-reviewed open Reborn-stack PR, thermo-nuclear review the full diff, fix every finding, re-gate, push fixes, post the review note, **stop** |

All three are single-iteration commands meant to be driven by a pacing loop (e.g. `/loop`), with humans doing every merge.

## Why

Orchard runs this three-loop workflow (build / de-slop / review) with multiple parallel agents and it has been effective there. This brings the same supervised workflow to the Reborn stack so agents can grind the `reborn` backlog the same way.

## Adaptations from the orchard originals

- **Scope** = the `ironclaw-reborn` dependency graph (`cargo tree -p ironclaw_reborn_cli --features webui-v2-beta` decides membership); legacy `src/` v1 is explicitly out of scope.
- **Gates** = repo CLAUDE.md quality gate (`cargo fmt` / clippy zero-warnings / per-crate tests) **plus** `scripts/reborn-e2e-rust.sh`; descriptor-contract and `node --check` steps for WebUI v2 surfaces.
- **CI-deferred work** = PostgreSQL integration tests + Playwright e2e (instead of orchard's MLX/Apple-hardware deferral) — implement fully, mark "verified in CI".
- **Task sources** = `reborn` + `module:M1..M5` labels, `docs/plans/`, `docs/reborn/` (instead of orchard's m5-plan).
- **Hard fences** encode the Reborn boundary invariants from the per-crate CLAUDE.md specs: `webui_v2` consumes only `RebornServicesApi`, `reborn_dependency_boundaries` never weakened, identity from authenticated caller, dual-backend persistence, LLM data never deleted, `credential_name` vs `extension_name`.
- **Skills reuse**: the loops lean on the existing `.claude/skills/thermo-nuclear-code-quality-review` (same skill orchard uses) and `.claude/skills/reborn-feature`.
- Loop ledgers live in `.work/` (added to `.gitignore`).

## Verification

- All referenced paths verified to exist: both SKILL.md files, `scripts/reborn-e2e-rust.sh`, `scripts/pre-commit-safety.sh`, `crates/ironclaw_webui_v2/tests/webui_v2_descriptors_contract.rs`, `.claude/rules/testing.md`.
- `cargo tree -p ironclaw_reborn_cli --features webui-v2-beta` confirmed working as the scope test.
- Doc-hygiene grep: no developer-local absolute paths.
- Docs-only change (3 new command docs + 1 `.gitignore` line) — no Rust code touched, so the cargo gate is N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)