### PR TITLE
fix(reborn): unify outbound state store so WebUI delivery defaults reach Slack delivery

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -6,3 +6,7 @@ cognitive-complexity-threshold = 15  # default: 25 (only active when lint is ena
 too-many-lines-threshold = 100      # default: 100 (only active when lint is enabled)
 too-many-arguments-threshold = 7    # default: 7 (keep default, avoids new violations)
 type-complexity-threshold = 250     # default: 250 (keep default, avoids new violations)
+
+[[disallowed-methods]]
+path = "ironclaw_outbound::FilesystemOutboundStateStore::new"
+reason = "outbound stores are composition-owned: take handles from RebornLocalRuntimeServices (built once in ironclaw_reborn_composition::factory). A second store over a different mount silently splits reads from writes (see docs/plans/2026-05-29-trigger-loop-delivery-resolution-implementation.md carry-forward)."

--- a/crates/ironclaw_outbound/src/filesystem_store.rs
+++ b/crates/ironclaw_outbound/src/filesystem_store.rs
@@ -1041,6 +1041,7 @@ fn map_fs_error(error: FilesystemError) -> OutboundError {
 }
 
 #[cfg(test)]
+#[allow(clippy::disallowed_methods)] // contract tests construct the store under test
 mod tests {
     use std::sync::Arc;
 

--- a/crates/ironclaw_outbound/tests/outbound_state_store_contract.rs
+++ b/crates/ironclaw_outbound/tests/outbound_state_store_contract.rs
@@ -1,3 +1,6 @@
+// Contract tests construct the store directly under test.
+#![allow(clippy::disallowed_methods)]
+
 use std::sync::Arc;
 
 use async_trait::async_trait;

--- a/crates/ironclaw_reborn_composition/CLAUDE.md
+++ b/crates/ironclaw_reborn_composition/CLAUDE.md
@@ -4,6 +4,7 @@
 - Expose facade-shaped handles only: `HostRuntime`, `TurnCoordinator`, product-auth `RebornProductAuthServices`, WebUI `RebornServicesApi`, readiness.
 - Keep lower substrate handles private to factories and owning crates.
 - Substrate handles MAY be exposed via `#[cfg(any(test, feature = "test-support"))]` pub accessors on `RebornRuntime` when downstream integration tests need to drive production-shape state the facade doesn't yet surface (e.g. seeding `TriggerRecord` rows, `pair_external_actor` calls). These seams ship zero bytes in production binaries. New test-support accessors must carry a doc-comment naming the production call site they mirror and an explicit note that the handle is for tests only.
+- Outbound state stores are composition-owned via `RebornLocalRuntimeServices`; do not construct `FilesystemOutboundStateStore` in consumer modules (lint-enforced via `clippy::disallowed-methods`).
 - Do not depend on the root `ironclaw` crate or `src/` modules.
 - Do not add legacy bridge modes here until an accepted migration contract exists.
 - Do not route live v1/product traffic here; callers must opt in through explicit Reborn adapters.

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -64,6 +64,10 @@ use ironclaw_outbound::CommunicationPreferenceRepository;
 use ironclaw_outbound::FilesystemOutboundStateStore;
 #[cfg(not(feature = "libsql"))]
 use ironclaw_outbound::InMemoryOutboundStateStore;
+#[cfg(feature = "slack-v2-host-beta")]
+use ironclaw_outbound::{DeliveredGateRouteStore, OutboundStateStore, TriggeredRunDeliveryStore};
+#[cfg(all(not(feature = "libsql"), feature = "slack-v2-host-beta"))]
+use ironclaw_outbound::{InMemoryDeliveredGateRouteStore, InMemoryTriggeredRunDeliveryStore};
 use ironclaw_processes::ProcessServices;
 use ironclaw_product_workflow::ProductAuthTurnGateResumeDispatcher;
 use ironclaw_resources::InMemoryResourceGovernor;
@@ -395,6 +399,12 @@ pub(crate) struct RebornLocalRuntimeServices {
     pub(crate) turn_state: Arc<LocalDevTurnStateStore>,
     pub(crate) trigger_repository: Arc<dyn TriggerRepository>,
     pub(crate) outbound_preferences: Arc<dyn CommunicationPreferenceRepository>,
+    #[cfg(feature = "slack-v2-host-beta")]
+    pub(crate) outbound_state: Arc<dyn OutboundStateStore>,
+    #[cfg(feature = "slack-v2-host-beta")]
+    pub(crate) delivered_gate_routes: Arc<dyn DeliveredGateRouteStore>,
+    #[cfg(feature = "slack-v2-host-beta")]
+    pub(crate) triggered_run_delivery: Arc<dyn TriggeredRunDeliveryStore>,
     #[cfg(not(any(feature = "libsql", feature = "postgres")))]
     pub(crate) trigger_conversation_services: InMemoryConversationServices,
     #[cfg(any(feature = "libsql", feature = "postgres"))]
@@ -1237,7 +1247,7 @@ fn build_local_dev_store_graph(
     let host_state_filesystem = local_dev_slack_host_state_filesystem(Arc::clone(&filesystem));
     let skill_management =
         build_local_skill_management_port(owner_user_id, Arc::clone(&filesystem))?;
-    let outbound_preferences = local_dev_outbound_preferences(Arc::clone(&filesystem));
+    let outbound_stores = local_dev_outbound_store(Arc::clone(&filesystem));
     let local_runtime = Arc::new(RebornLocalRuntimeServices {
         approval_requests: Arc::clone(&approval_requests),
         capability_leases: Arc::clone(&capability_leases),
@@ -1245,7 +1255,13 @@ fn build_local_dev_store_graph(
         persistent_approval_policies: Arc::clone(&persistent_approval_policies),
         turn_state: Arc::clone(&turn_state),
         trigger_repository: Arc::clone(&trigger_repository),
-        outbound_preferences,
+        outbound_preferences: outbound_stores.outbound_preferences,
+        #[cfg(feature = "slack-v2-host-beta")]
+        outbound_state: outbound_stores.outbound_state,
+        #[cfg(feature = "slack-v2-host-beta")]
+        delivered_gate_routes: outbound_stores.delivered_gate_routes,
+        #[cfg(feature = "slack-v2-host-beta")]
+        triggered_run_delivery: outbound_stores.triggered_run_delivery,
         #[cfg(not(any(feature = "libsql", feature = "postgres")))]
         trigger_conversation_services,
         #[cfg(any(feature = "libsql", feature = "postgres"))]
@@ -1353,7 +1369,7 @@ fn build_local_dev_store_graph(
         build_local_skill_management_port(owner_user_id, Arc::clone(&filesystem))?;
     #[cfg(not(any(feature = "libsql", feature = "postgres")))]
     let trigger_conversation_services = local_dev_trigger_conversation_services();
-    let outbound_preferences = local_dev_outbound_preferences(Arc::clone(&filesystem));
+    let outbound_stores = local_dev_outbound_store(Arc::clone(&filesystem));
     let local_runtime = Arc::new(RebornLocalRuntimeServices {
         approval_requests: Arc::clone(&approval_requests),
         capability_leases: Arc::clone(&capability_leases),
@@ -1361,7 +1377,13 @@ fn build_local_dev_store_graph(
         persistent_approval_policies: Arc::clone(&persistent_approval_policies),
         turn_state: Arc::clone(&turn_state),
         trigger_repository: Arc::clone(&trigger_repository),
-        outbound_preferences,
+        outbound_preferences: outbound_stores.outbound_preferences,
+        #[cfg(feature = "slack-v2-host-beta")]
+        outbound_state: outbound_stores.outbound_state,
+        #[cfg(feature = "slack-v2-host-beta")]
+        delivered_gate_routes: outbound_stores.delivered_gate_routes,
+        #[cfg(feature = "slack-v2-host-beta")]
+        triggered_run_delivery: outbound_stores.triggered_run_delivery,
         #[cfg(not(any(feature = "libsql", feature = "postgres")))]
         trigger_conversation_services,
         #[cfg(any(feature = "libsql", feature = "postgres"))]
@@ -1930,20 +1952,73 @@ fn local_dev_scoped_filesystem(
     crate::wrap_scoped(filesystem)
 }
 
+/// Unified bundle of outbound store handles returned by both cfg variants of
+/// [`local_dev_outbound_store`].
+///
+/// All four trait roles must be satisfied on construction.  In the libsql
+/// build every role is an `Arc` clone of a single
+/// `FilesystemOutboundStateStore`, so the WebUI delivery-defaults facade and
+/// the Slack delivery path share one backing tree.  In the non-libsql build
+/// `InMemoryOutboundStateStore` covers the preference and state roles;
+/// `DeliveredGateRouteStore` and `TriggeredRunDeliveryStore` use separate
+/// in-memory instances — the cross-store invariant that matters (WebUI-written
+/// preferences visible to the Slack triggered-delivery hook) only involves the
+/// preference role.
+/// See docs/plans/2026-05-29-trigger-loop-delivery-resolution-implementation.md.
+pub(crate) struct LocalDevOutboundStores {
+    pub(crate) outbound_preferences: Arc<dyn CommunicationPreferenceRepository>,
+    #[cfg(feature = "slack-v2-host-beta")]
+    pub(crate) outbound_state: Arc<dyn OutboundStateStore>,
+    #[cfg(feature = "slack-v2-host-beta")]
+    pub(crate) delivered_gate_routes: Arc<dyn DeliveredGateRouteStore>,
+    #[cfg(feature = "slack-v2-host-beta")]
+    pub(crate) triggered_run_delivery: Arc<dyn TriggeredRunDeliveryStore>,
+}
+
 #[cfg(feature = "libsql")]
-fn local_dev_outbound_preferences(
-    filesystem: Arc<LocalDevRootFilesystem>,
-) -> Arc<dyn CommunicationPreferenceRepository> {
-    Arc::new(FilesystemOutboundStateStore::new(
-        local_dev_scoped_filesystem(filesystem),
-    ))
+fn local_dev_outbound_store(filesystem: Arc<LocalDevRootFilesystem>) -> LocalDevOutboundStores {
+    // One store instance over the composition-owned per-user scoped filesystem
+    // (`/outbound` → `/tenants/<t>/users/<u>/outbound`). All four outbound
+    // roles — preferences, state, delivered-gate routes, triggered-run delivery
+    // — are Arc-cloned from this single instance so the WebUI delivery-defaults
+    // facade and the Slack delivery path share the same backing tree.
+    // composition-owned construction site, the only one allowed.
+    #[allow(clippy::disallowed_methods)]
+    let store: Arc<FilesystemOutboundStateStore<LocalDevRootFilesystem>> = Arc::new(
+        FilesystemOutboundStateStore::new(local_dev_scoped_filesystem(filesystem)),
+    );
+    LocalDevOutboundStores {
+        outbound_preferences: Arc::clone(&store) as Arc<dyn CommunicationPreferenceRepository>,
+        #[cfg(feature = "slack-v2-host-beta")]
+        outbound_state: Arc::clone(&store) as Arc<dyn OutboundStateStore>,
+        #[cfg(feature = "slack-v2-host-beta")]
+        delivered_gate_routes: Arc::clone(&store) as Arc<dyn DeliveredGateRouteStore>,
+        #[cfg(feature = "slack-v2-host-beta")]
+        triggered_run_delivery: store as Arc<dyn TriggeredRunDeliveryStore>,
+    }
 }
 
 #[cfg(not(feature = "libsql"))]
-fn local_dev_outbound_preferences(
-    _filesystem: Arc<LocalDevRootFilesystem>,
-) -> Arc<dyn CommunicationPreferenceRepository> {
-    Arc::new(InMemoryOutboundStateStore::default())
+fn local_dev_outbound_store(_filesystem: Arc<LocalDevRootFilesystem>) -> LocalDevOutboundStores {
+    // In the non-filesystem (no libsql/postgres) profile, InMemoryOutboundStateStore
+    // implements both CommunicationPreferenceRepository and OutboundStateStore, so a
+    // single Arc covers both roles.  The other two roles (DeliveredGateRouteStore and
+    // TriggeredRunDeliveryStore) are not implemented by InMemoryOutboundStateStore and
+    // therefore use separate in-memory instances; this is acceptable because the
+    // cross-store invariant that matters — WebUI-written preferences being visible to
+    // the Slack triggered-delivery hook — only involves the preference role.  The libsql
+    // build avoids this gap entirely by sharing one FilesystemOutboundStateStore across
+    // all four roles.
+    let outbound = Arc::new(InMemoryOutboundStateStore::default());
+    LocalDevOutboundStores {
+        outbound_preferences: Arc::clone(&outbound) as Arc<dyn CommunicationPreferenceRepository>,
+        #[cfg(feature = "slack-v2-host-beta")]
+        outbound_state: outbound as Arc<dyn OutboundStateStore>,
+        #[cfg(feature = "slack-v2-host-beta")]
+        delivered_gate_routes: Arc::new(InMemoryDeliveredGateRouteStore::default()),
+        #[cfg(feature = "slack-v2-host-beta")]
+        triggered_run_delivery: Arc::new(InMemoryTriggeredRunDeliveryStore::default()),
+    }
 }
 
 #[cfg(all(
@@ -3218,6 +3293,12 @@ mod tests {
             turn_state: Arc::clone(&base_runtime.turn_state),
             trigger_repository: Arc::clone(&base_runtime.trigger_repository),
             outbound_preferences: Arc::clone(&base_runtime.outbound_preferences),
+            #[cfg(feature = "slack-v2-host-beta")]
+            outbound_state: Arc::clone(&base_runtime.outbound_state),
+            #[cfg(feature = "slack-v2-host-beta")]
+            delivered_gate_routes: Arc::clone(&base_runtime.delivered_gate_routes),
+            #[cfg(feature = "slack-v2-host-beta")]
+            triggered_run_delivery: Arc::clone(&base_runtime.triggered_run_delivery),
             #[cfg(not(any(feature = "libsql", feature = "postgres")))]
             trigger_conversation_services: base_runtime.trigger_conversation_services.clone(),
             #[cfg(any(feature = "libsql", feature = "postgres"))]
@@ -4692,6 +4773,46 @@ mod tests {
 
     fn skill_md(name: &str, description: &str, prompt: &str) -> String {
         format!("---\nname: {name}\ndescription: {description}\n---\n{prompt}\n")
+    }
+
+    /// Verify that the libsql `local_dev_outbound_store` bundle shares a single
+    /// `FilesystemOutboundStateStore` allocation across all four trait-object roles.
+    ///
+    /// The assertion reads the four trait-object pointers from the built
+    /// `RebornLocalRuntimeServices` and compares their data halves via
+    /// `std::ptr::addr_eq` (trait objects of different traits cannot be compared
+    /// with `Arc::ptr_eq` directly).
+    #[cfg(all(feature = "libsql", feature = "slack-v2-host-beta"))]
+    #[tokio::test]
+    async fn local_dev_outbound_store_libsql_shares_one_allocation_across_all_roles() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let services = build_reborn_services(RebornBuildInput::local_dev(
+            "outbound-store-alloc-owner",
+            dir.path().join("local-dev"),
+        ))
+        .await
+        .expect("local-dev services build");
+
+        let local_runtime = services.local_runtime.as_ref().expect("local runtime");
+
+        // Cast each fat-pointer's data half to *const () for cross-trait comparison.
+        let pref_ptr = Arc::as_ptr(&local_runtime.outbound_preferences) as *const ();
+        let state_ptr = Arc::as_ptr(&local_runtime.outbound_state) as *const ();
+        let gate_ptr = Arc::as_ptr(&local_runtime.delivered_gate_routes) as *const ();
+        let delivery_ptr = Arc::as_ptr(&local_runtime.triggered_run_delivery) as *const ();
+
+        assert!(
+            std::ptr::addr_eq(pref_ptr, state_ptr),
+            "outbound_preferences and outbound_state must share one allocation"
+        );
+        assert!(
+            std::ptr::addr_eq(pref_ptr, gate_ptr),
+            "outbound_preferences and delivered_gate_routes must share one allocation"
+        );
+        assert!(
+            std::ptr::addr_eq(pref_ptr, delivery_ptr),
+            "outbound_preferences and triggered_run_delivery must share one allocation"
+        );
     }
 }
 

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -60,13 +60,16 @@ use ironclaw_host_runtime::{
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 use ironclaw_loop_support::FilesystemCheckpointStateStore;
 use ironclaw_outbound::CommunicationPreferenceRepository;
-#[cfg(feature = "libsql")]
+#[cfg(any(feature = "libsql", feature = "postgres"))]
 use ironclaw_outbound::FilesystemOutboundStateStore;
-#[cfg(not(feature = "libsql"))]
+#[cfg(not(any(feature = "libsql", feature = "postgres")))]
 use ironclaw_outbound::InMemoryOutboundStateStore;
 #[cfg(feature = "slack-v2-host-beta")]
 use ironclaw_outbound::{DeliveredGateRouteStore, OutboundStateStore, TriggeredRunDeliveryStore};
-#[cfg(all(not(feature = "libsql"), feature = "slack-v2-host-beta"))]
+#[cfg(all(
+    not(any(feature = "libsql", feature = "postgres")),
+    feature = "slack-v2-host-beta"
+))]
 use ironclaw_outbound::{InMemoryDeliveredGateRouteStore, InMemoryTriggeredRunDeliveryStore};
 use ironclaw_processes::ProcessServices;
 use ironclaw_product_workflow::ProductAuthTurnGateResumeDispatcher;
@@ -1955,10 +1958,10 @@ fn local_dev_scoped_filesystem(
 /// Unified bundle of outbound store handles returned by both cfg variants of
 /// [`local_dev_outbound_store`].
 ///
-/// All four trait roles must be satisfied on construction.  In the libsql
-/// build every role is an `Arc` clone of a single
+/// All four trait roles must be satisfied on construction.  In the durable
+/// build (libsql or postgres) every role is an `Arc` clone of a single
 /// `FilesystemOutboundStateStore`, so the WebUI delivery-defaults facade and
-/// the Slack delivery path share one backing tree.  In the non-libsql build
+/// the Slack delivery path share one backing tree.  In the non-durable build
 /// `InMemoryOutboundStateStore` covers the preference and state roles;
 /// `DeliveredGateRouteStore` and `TriggeredRunDeliveryStore` use separate
 /// in-memory instances — the cross-store invariant that matters (WebUI-written
@@ -1975,7 +1978,7 @@ pub(crate) struct LocalDevOutboundStores {
     pub(crate) triggered_run_delivery: Arc<dyn TriggeredRunDeliveryStore>,
 }
 
-#[cfg(feature = "libsql")]
+#[cfg(any(feature = "libsql", feature = "postgres"))]
 fn local_dev_outbound_store(filesystem: Arc<LocalDevRootFilesystem>) -> LocalDevOutboundStores {
     // One store instance over the composition-owned per-user scoped filesystem
     // (`/outbound` → `/tenants/<t>/users/<u>/outbound`). All four outbound
@@ -1998,7 +2001,7 @@ fn local_dev_outbound_store(filesystem: Arc<LocalDevRootFilesystem>) -> LocalDev
     }
 }
 
-#[cfg(not(feature = "libsql"))]
+#[cfg(not(any(feature = "libsql", feature = "postgres")))]
 fn local_dev_outbound_store(_filesystem: Arc<LocalDevRootFilesystem>) -> LocalDevOutboundStores {
     // In the non-filesystem (no libsql/postgres) profile, InMemoryOutboundStateStore
     // implements both CommunicationPreferenceRepository and OutboundStateStore, so a
@@ -2006,9 +2009,9 @@ fn local_dev_outbound_store(_filesystem: Arc<LocalDevRootFilesystem>) -> LocalDe
     // TriggeredRunDeliveryStore) are not implemented by InMemoryOutboundStateStore and
     // therefore use separate in-memory instances; this is acceptable because the
     // cross-store invariant that matters — WebUI-written preferences being visible to
-    // the Slack triggered-delivery hook — only involves the preference role.  The libsql
-    // build avoids this gap entirely by sharing one FilesystemOutboundStateStore across
-    // all four roles.
+    // the Slack triggered-delivery hook — only involves the preference role.  The durable
+    // build (libsql or postgres) avoids this gap entirely by sharing one
+    // FilesystemOutboundStateStore across all four roles.
     let outbound = Arc::new(InMemoryOutboundStateStore::default());
     LocalDevOutboundStores {
         outbound_preferences: Arc::clone(&outbound) as Arc<dyn CommunicationPreferenceRepository>,
@@ -4775,16 +4778,20 @@ mod tests {
         format!("---\nname: {name}\ndescription: {description}\n---\n{prompt}\n")
     }
 
-    /// Verify that the libsql `local_dev_outbound_store` bundle shares a single
-    /// `FilesystemOutboundStateStore` allocation across all four trait-object roles.
+    /// Verify that the durable `local_dev_outbound_store` bundle (libsql or postgres)
+    /// shares a single `FilesystemOutboundStateStore` allocation across all four
+    /// trait-object roles.
     ///
     /// The assertion reads the four trait-object pointers from the built
     /// `RebornLocalRuntimeServices` and compares their data halves via
     /// `std::ptr::addr_eq` (trait objects of different traits cannot be compared
     /// with `Arc::ptr_eq` directly).
-    #[cfg(all(feature = "libsql", feature = "slack-v2-host-beta"))]
+    #[cfg(all(
+        any(feature = "libsql", feature = "postgres"),
+        feature = "slack-v2-host-beta"
+    ))]
     #[tokio::test]
-    async fn local_dev_outbound_store_libsql_shares_one_allocation_across_all_roles() {
+    async fn local_dev_outbound_store_durable_shares_one_allocation_across_all_roles() {
         let dir = tempfile::tempdir().expect("tempdir");
         let services = build_reborn_services(RebornBuildInput::local_dev(
             "outbound-store-alloc-owner",

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -775,11 +775,6 @@ pub(crate) fn slack_host_state_mount_view(
             ))?,
             MountPermissions::read_write_list_delete(),
         ),
-        MountGrant::new(
-            MountAlias::new("/outbound")?,
-            VirtualPath::new(format!("/tenants/{tenant_id}/shared/slack-outbound"))?,
-            MountPermissions::read_write_list_delete(),
-        ),
     ])
 }
 
@@ -1032,11 +1027,6 @@ mod mount_view_tests {
                 "/engine/product_workflow/idempotency/actions/action.json",
                 "slack-product-workflow/idempotency/actions/action.json",
             ),
-            (
-                "/outbound",
-                "/outbound/deliveries/delivery.json",
-                "slack-outbound/deliveries/delivery.json",
-            ),
         ] {
             let (resolved, grant) = view
                 .resolve_with_grant(&ScopedPath::new(path).unwrap())
@@ -1051,6 +1041,13 @@ mod mount_view_tests {
                 MountPermissions::read_write_list_delete()
             );
         }
+        // /outbound is no longer in the slack-host-state mount; outbound state is
+        // served via the composition-owned per-user scoped filesystem instead.
+        assert!(
+            view.resolve(&ScopedPath::new("/outbound/deliveries/delivery.json").unwrap())
+                .is_err(),
+            "/outbound must not resolve through the slack-host-state mount after store unification"
+        );
         assert!(
             view.resolve(&ScopedPath::new("/tenant-shared/other.json").unwrap())
                 .is_err()

--- a/crates/ironclaw_reborn_composition/src/slack_delivery.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_delivery.rs
@@ -1138,6 +1138,21 @@ impl TriggeredRunDeliveryDriver {
     pub fn try_acquire_pending_permit(&self) -> Option<tokio::sync::OwnedSemaphorePermit> {
         Arc::clone(&self.pending_permits).try_acquire_owned().ok()
     }
+
+    /// Returns the `CommunicationPreferenceRepository` wired into this driver's
+    /// `SlackFinalReplyDeliveryServices.communication_preferences`.
+    ///
+    /// Production call site: `build_triggered_run_delivery_hook` in
+    /// `slack_host_beta.rs` — the store it passes here must be pointer-equal to
+    /// `local_runtime.outbound_preferences` so WebUI-written preferences are
+    /// visible to Slack delivery.  Use `Arc::ptr_eq` in tests to assert this.
+    /// This accessor is for tests only and compiles to nothing in production binaries.
+    #[cfg(test)]
+    pub(crate) fn communication_preferences(
+        &self,
+    ) -> Arc<dyn ironclaw_outbound::CommunicationPreferenceRepository> {
+        Arc::clone(&self.services.communication_preferences)
+    }
 }
 
 #[async_trait]

--- a/crates/ironclaw_reborn_composition/src/slack_delivery.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_delivery.rs
@@ -1148,7 +1148,7 @@ impl TriggeredRunDeliveryDriver {
     /// visible to Slack delivery.  Use `Arc::ptr_eq` in tests to assert this.
     /// This accessor is for tests only and compiles to nothing in production binaries.
     #[cfg(test)]
-    pub(crate) fn communication_preferences(
+    pub(crate) fn communication_preferences_for_test(
         &self,
     ) -> Arc<dyn ironclaw_outbound::CommunicationPreferenceRepository> {
         Arc::clone(&self.services.communication_preferences)

--- a/crates/ironclaw_reborn_composition/src/slack_host_beta.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_host_beta.rs
@@ -11,9 +11,7 @@ use std::time::Duration;
 
 use ironclaw_conversations::InMemoryConversationServices;
 use ironclaw_host_api::{AgentId, ProjectId, ResourceScope, TenantId, UserId};
-use ironclaw_outbound::{
-    FilesystemOutboundStateStore, OutboundStateStore, TriggeredRunDeliveryStore,
-};
+use ironclaw_outbound::{DeliveredGateRouteStore, OutboundStateStore, TriggeredRunDeliveryStore};
 use ironclaw_product_adapters::{
     AdapterInstallationId, DeclaredEgressHost, DeclaredEgressTarget, DeliveryStatus,
     EgressCredentialHandle, ExternalActorRef, OutboundDeliverySink, ProductAdapter,
@@ -269,15 +267,35 @@ pub fn build_slack_events_route_mount(
 /// Build a [`PostSubmitDeliveryHook`] that delivers triggered-run results to
 /// the creator's personal Slack DM.
 ///
-/// The hook shares the same egress and outbound-state infrastructure as the
-/// Slack events route: bot token, `FilesystemOutboundStateStore`, and
-/// `SlackV2Adapter`. The `delivery_store` is a separate store for recording
-/// per-run delivery outcomes (best-effort, personal scope only).
+/// Delegates to [`build_triggered_run_delivery_driver`] and erases the
+/// concrete return type to `Arc<dyn PostSubmitDeliveryHook>`.
 pub fn build_triggered_run_delivery_hook(
     runtime: &RebornRuntime,
     config: &SlackHostBetaConfig,
     delivery_store: Arc<dyn TriggeredRunDeliveryStore>,
 ) -> Result<Arc<dyn PostSubmitDeliveryHook>, SlackHostBetaBuildError> {
+    let driver = build_triggered_run_delivery_driver(runtime, config, delivery_store)?;
+    Ok(driver as Arc<dyn PostSubmitDeliveryHook>)
+}
+
+/// Single wiring path for the triggered-run delivery driver.
+///
+/// Returns `Arc<TriggeredRunDeliveryDriver>` so callers that need the
+/// concrete type (e.g. tests inspecting
+/// [`TriggeredRunDeliveryDriver::communication_preferences_for_test`] via
+/// `Arc::ptr_eq`) can use it directly.  The production entry point
+/// [`build_triggered_run_delivery_hook`] erases the type to
+/// `Arc<dyn PostSubmitDeliveryHook>`.
+///
+/// Preferences and outbound state come from the composition-owned store (the
+/// same instance the WebUI delivery-defaults facade writes through), so a
+/// preference set via the WebUI is visible to Slack delivery.
+/// See docs/plans/2026-05-29-trigger-loop-delivery-resolution-implementation.md.
+fn build_triggered_run_delivery_driver(
+    runtime: &RebornRuntime,
+    config: &SlackHostBetaConfig,
+    delivery_store: Arc<dyn TriggeredRunDeliveryStore>,
+) -> Result<Arc<TriggeredRunDeliveryDriver>, SlackHostBetaBuildError> {
     let local_runtime = runtime
         .services()
         .local_runtime
@@ -293,12 +311,11 @@ pub fn build_triggered_run_delivery_hook(
         auth_requirement: slack_request_signature_auth_requirement(),
     }));
     let egress = slack_protocol_egress(runtime, config, token_handle)?;
-    let outbound = Arc::new(FilesystemOutboundStateStore::new(Arc::clone(
-        &local_runtime.host_state_filesystem,
-    )));
-    let outbound_store: Arc<dyn OutboundStateStore> = outbound.clone();
-    let route_store: Arc<dyn ironclaw_outbound::DeliveredGateRouteStore> = outbound.clone();
-    let preferences: Arc<dyn ironclaw_outbound::CommunicationPreferenceRepository> = outbound;
+    let outbound_store: Arc<dyn OutboundStateStore> = Arc::clone(&local_runtime.outbound_state);
+    let route_store: Arc<dyn DeliveredGateRouteStore> =
+        Arc::clone(&local_runtime.delivered_gate_routes);
+    let preferences: Arc<dyn ironclaw_outbound::CommunicationPreferenceRepository> =
+        Arc::clone(&local_runtime.outbound_preferences);
     let delivery_sink: Arc<dyn OutboundDeliverySink> = Arc::new(NoopSlackDeliverySink);
     let binding_service: Arc<dyn ConversationBindingService> =
         Arc::new(NoopConversationBindingService);
@@ -414,15 +431,14 @@ pub fn build_slack_host_beta_mounts(
     )
     .with_allowed_subject_user_ids(allowed_route_subjects);
 
-    // Wire the triggered-run delivery hook. The delivery store lives on the
-    // same `host_state_filesystem` mount as every other outbound store, so it
-    // inherits tenant isolation for free. `set_trigger_post_submit_hook` is
-    // idempotent: a second call (if this function is called more than once) is
-    // silently ignored.
+    // Wire the triggered-run delivery hook. The delivery store comes from the
+    // composition-owned outbound store, shared with preferences so the same
+    // backing tree is used for all outbound roles. `set_trigger_post_submit_hook`
+    // is idempotent: a second call (if this function is called more than once)
+    // is silently ignored.
     {
-        let delivery_store: Arc<dyn TriggeredRunDeliveryStore> = Arc::new(
-            FilesystemOutboundStateStore::new(Arc::clone(&local_runtime.host_state_filesystem)),
-        );
+        let delivery_store: Arc<dyn TriggeredRunDeliveryStore> =
+            Arc::clone(&local_runtime.triggered_run_delivery);
         match build_triggered_run_delivery_hook(runtime, &config, delivery_store) {
             Ok(hook) => {
                 runtime.set_trigger_post_submit_hook(hook);
@@ -561,9 +577,7 @@ fn build_slack_events_route_mount_with_resolvers(
         .with_approval_interaction_service(Arc::new(
             crate::delivered_gate_routing::DeliveredGateRoutingApprovalService::new(
                 runtime.webui_approval_interaction_service(),
-                Arc::new(FilesystemOutboundStateStore::new(Arc::clone(
-                    &local_runtime.host_state_filesystem,
-                ))),
+                Arc::clone(&local_runtime.delivered_gate_routes),
             ),
         ))
         .with_auth_interaction_service(runtime.webui_auth_interaction_service()),
@@ -586,11 +600,9 @@ fn build_slack_events_route_mount_with_resolvers(
     ));
 
     let egress = slack_protocol_egress(runtime, &config, token_handle)?;
-    let outbound = Arc::new(FilesystemOutboundStateStore::new(Arc::clone(
-        &local_runtime.host_state_filesystem,
-    )));
-    let outbound_store: Arc<dyn OutboundStateStore> = outbound.clone();
-    let preferences: Arc<dyn ironclaw_outbound::CommunicationPreferenceRepository> = outbound;
+    let outbound_store: Arc<dyn OutboundStateStore> = Arc::clone(&local_runtime.outbound_state);
+    let preferences: Arc<dyn ironclaw_outbound::CommunicationPreferenceRepository> =
+        Arc::clone(&local_runtime.outbound_preferences);
     let delivery_sink: Arc<dyn OutboundDeliverySink> = Arc::new(NoopSlackDeliverySink);
     let observer = Arc::new(SlackFinalReplyDeliveryObserver::with_settings(
         SlackFinalReplyDeliveryServices {
@@ -3818,7 +3830,6 @@ mod tests {
 
         use chrono::Utc;
         use ironclaw_conversations::{AdapterInstallationId, AdapterKind, ExternalActorRef};
-        use ironclaw_outbound::{FilesystemOutboundStateStore, TriggeredRunDeliveryStore};
         use ironclaw_triggers::{
             TRIGGER_TRUSTED_ADAPTER_INSTALLATION_ID, TRIGGER_TRUSTED_ADAPTER_KIND,
             TRIGGER_TRUSTED_EXTERNAL_ACTOR_NAMESPACE, TriggerCompletionPolicy, TriggerId,
@@ -3897,17 +3908,15 @@ mod tests {
             }
         }
 
-        // Build a delivery store over the same host_state_filesystem the
-        // production hook uses.  `local_runtime` and `host_state_filesystem`
-        // are `pub(crate)` — accessible here because this test lives in the
-        // same crate.
+        // Read delivery records from the unified outbound store that the
+        // production hook writes through.  `local_runtime` is `pub(crate)`
+        // — accessible here because this test lives in the same crate.
         let local_runtime = runtime
             .services()
             .local_runtime
             .as_ref()
             .expect("local-dev runtime has local_runtime services");
-        let delivery_store =
-            FilesystemOutboundStateStore::new(Arc::clone(&local_runtime.host_state_filesystem));
+        let delivery_store = Arc::clone(&local_runtime.triggered_run_delivery);
 
         // Poll briefly for the delivery record.  The driver spawns a background
         // task; for the `NoDefaultConfigured` fast-path it should complete well
@@ -3934,6 +3943,67 @@ mod tests {
             delivery_record.is_some(),
             "no TriggeredRunDeliveryRecord written after trigger fire — \
              hook → driver wiring broken; fired_run_id={fired_run_id:?}"
+        );
+    }
+
+    /// Regression guard: `build_triggered_run_delivery_hook` must wire the same
+    /// `CommunicationPreferenceRepository` Arc that the WebUI
+    /// `RebornOutboundPreferencesFacade` writes through
+    /// (`local_runtime.outbound_preferences`) into
+    /// `SlackFinalReplyDeliveryServices.communication_preferences`.
+    ///
+    /// Pre-fix bug: `build_triggered_run_delivery_hook` constructed a fresh
+    /// `FilesystemOutboundStateStore::new(Arc::clone(&local_runtime.host_state_filesystem))`
+    /// as the `communication_preferences` argument, while the WebUI facade wrote
+    /// through `local_runtime.outbound_preferences` — a different store backed by the
+    /// same filesystem path but carrying independent in-memory state.  Any preference
+    /// saved through the WebUI was therefore never seen by the delivery hook.
+    ///
+    /// This test uses `Arc::ptr_eq` to verify both sides hold the *same pointer*,
+    /// which is the only invariant that guarantees a write on one side is immediately
+    /// visible on the other without filesystem round-trips.  If
+    /// `build_triggered_run_delivery_hook` is regressed to create a new store this
+    /// assertion fails deterministically and immediately, without needing an E2E run
+    /// that could be silenced by an unrelated `Skipped` outcome.
+    #[tokio::test]
+    async fn webui_saved_preference_is_visible_to_triggered_slack_delivery() {
+        use ironclaw_outbound::TriggeredRunDeliveryStore;
+
+        let (runtime, _tmp) = runtime_with_trigger_poller().await;
+
+        let local_runtime = runtime
+            .services()
+            .local_runtime
+            .as_ref()
+            .expect("local-dev runtime has local_runtime services");
+
+        // Build the delivery driver via the test-support twin of
+        // `build_triggered_run_delivery_hook`.  The twin replicates the same
+        // wiring; using it (rather than the production hook) gives us back the
+        // concrete `Arc<TriggeredRunDeliveryDriver>` so we can inspect
+        // `communication_preferences_for_test`.
+        let delivery_store: Arc<dyn TriggeredRunDeliveryStore> =
+            Arc::clone(&local_runtime.triggered_run_delivery);
+        let driver = build_triggered_run_delivery_driver(&runtime, &config(), delivery_store)
+            .expect("build_triggered_run_delivery_driver should succeed");
+
+        // The pointer stored in the driver must be the same Arc that the WebUI
+        // delivery-defaults facade uses.  Arc::ptr_eq compares allocation identity
+        // (for trait objects, data and vtable pointers); it passes only when both
+        // handles came from the same composition-owned store instance.  If
+        // `build_triggered_run_delivery_hook` is regressed to
+        // `Arc::new(FilesystemOutboundStateStore::new(...))`, the new allocation
+        // will produce a different pointer pair and this assertion fails.
+        let driver_store = driver.communication_preferences();
+        let facade_store: Arc<dyn ironclaw_outbound::CommunicationPreferenceRepository> =
+            Arc::clone(&local_runtime.outbound_preferences);
+        assert!(
+            Arc::ptr_eq(&driver_store, &facade_store),
+            "build_triggered_run_delivery_hook wired a DIFFERENT CommunicationPreferenceRepository \
+             than local_runtime.outbound_preferences — any preference written through the WebUI \
+             delivery-defaults facade (RebornOutboundPreferencesFacade) will NOT be visible to \
+             the Slack triggered-delivery hook; the hook must use \
+             Arc::clone(&local_runtime.outbound_preferences) as `communication_preferences`"
         );
     }
 }

--- a/crates/ironclaw_reborn_composition/src/slack_host_beta.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_host_beta.rs
@@ -43,7 +43,7 @@ use crate::slack_channel_routes::{
     SlackChannelRouteAdminRouteConfig, SlackChannelRouteStore, SlackChannelRouteSubjectResolver,
 };
 use crate::slack_delivery::{
-    PostSubmitDeliveryHook, SlackFinalReplyDeliveryObserver, SlackFinalReplyDeliveryServices,
+    SlackFinalReplyDeliveryObserver, SlackFinalReplyDeliveryServices,
     SlackFinalReplyDeliverySettings, TriggeredRunDeliveryDriver,
 };
 use crate::slack_egress::{SlackProtocolHttpEgress, StaticSlackEgressCredentialProvider};
@@ -264,34 +264,21 @@ pub fn build_slack_events_route_mount(
     build_slack_host_beta_mounts(runtime, config).map(|mounts| mounts.events)
 }
 
-/// Build a [`PostSubmitDeliveryHook`] that delivers triggered-run results to
-/// the creator's personal Slack DM.
+/// Build a [`TriggeredRunDeliveryDriver`] that delivers triggered-run results
+/// to the creator's personal Slack DM.
 ///
-/// Delegates to [`build_triggered_run_delivery_driver`] and erases the
-/// concrete return type to `Arc<dyn PostSubmitDeliveryHook>`.
-pub fn build_triggered_run_delivery_hook(
-    runtime: &RebornRuntime,
-    config: &SlackHostBetaConfig,
-    delivery_store: Arc<dyn TriggeredRunDeliveryStore>,
-) -> Result<Arc<dyn PostSubmitDeliveryHook>, SlackHostBetaBuildError> {
-    let driver = build_triggered_run_delivery_driver(runtime, config, delivery_store)?;
-    Ok(driver as Arc<dyn PostSubmitDeliveryHook>)
-}
-
-/// Single wiring path for the triggered-run delivery driver.
-///
-/// Returns `Arc<TriggeredRunDeliveryDriver>` so callers that need the
-/// concrete type (e.g. tests inspecting
-/// [`TriggeredRunDeliveryDriver::communication_preferences_for_test`] via
-/// `Arc::ptr_eq`) can use it directly.  The production entry point
-/// [`build_triggered_run_delivery_hook`] erases the type to
-/// `Arc<dyn PostSubmitDeliveryHook>`.
+/// Returns the concrete `Arc<TriggeredRunDeliveryDriver>` so tests can assert
+/// store-pointer identity through this production entry point (via
+/// [`TriggeredRunDeliveryDriver::communication_preferences_for_test`] and
+/// `Arc::ptr_eq`).  Call sites that wire the hook into the runtime coerce the
+/// concrete Arc to `Arc<dyn PostSubmitDeliveryHook>` implicitly when passing
+/// it to [`RebornRuntime::set_trigger_post_submit_hook`].
 ///
 /// Preferences and outbound state come from the composition-owned store (the
 /// same instance the WebUI delivery-defaults facade writes through), so a
 /// preference set via the WebUI is visible to Slack delivery.
 /// See docs/plans/2026-05-29-trigger-loop-delivery-resolution-implementation.md.
-fn build_triggered_run_delivery_driver(
+pub fn build_triggered_run_delivery_hook(
     runtime: &RebornRuntime,
     config: &SlackHostBetaConfig,
     delivery_store: Arc<dyn TriggeredRunDeliveryStore>,
@@ -3977,15 +3964,15 @@ mod tests {
             .as_ref()
             .expect("local-dev runtime has local_runtime services");
 
-        // Build the delivery driver via the test-support twin of
-        // `build_triggered_run_delivery_hook`.  The twin replicates the same
-        // wiring; using it (rather than the production hook) gives us back the
-        // concrete `Arc<TriggeredRunDeliveryDriver>` so we can inspect
-        // `communication_preferences_for_test`.
+        // Build the delivery driver via the production entry point.
+        // `build_triggered_run_delivery_hook` now returns the concrete
+        // `Arc<TriggeredRunDeliveryDriver>` directly, so we can inspect
+        // `communication_preferences_for_test` through the same code path
+        // that the production call site uses.
         let delivery_store: Arc<dyn TriggeredRunDeliveryStore> =
             Arc::clone(&local_runtime.triggered_run_delivery);
-        let driver = build_triggered_run_delivery_driver(&runtime, &config(), delivery_store)
-            .expect("build_triggered_run_delivery_driver should succeed");
+        let driver = build_triggered_run_delivery_hook(&runtime, &config(), delivery_store)
+            .expect("build_triggered_run_delivery_hook should succeed");
 
         // The pointer stored in the driver must be the same Arc that the WebUI
         // delivery-defaults facade uses.  Arc::ptr_eq compares allocation identity
@@ -3994,15 +3981,16 @@ mod tests {
         // `build_triggered_run_delivery_hook` is regressed to
         // `Arc::new(FilesystemOutboundStateStore::new(...))`, the new allocation
         // will produce a different pointer pair and this assertion fails.
-        let driver_store = driver.communication_preferences();
+        let driver_store = driver.communication_preferences_for_test();
         let facade_store: Arc<dyn ironclaw_outbound::CommunicationPreferenceRepository> =
             Arc::clone(&local_runtime.outbound_preferences);
         assert!(
             Arc::ptr_eq(&driver_store, &facade_store),
-            "build_triggered_run_delivery_hook wired a DIFFERENT CommunicationPreferenceRepository \
-             than local_runtime.outbound_preferences — any preference written through the WebUI \
-             delivery-defaults facade (RebornOutboundPreferencesFacade) will NOT be visible to \
-             the Slack triggered-delivery hook; the hook must use \
+            "build_triggered_run_delivery_hook (production entry point) wired a DIFFERENT \
+             CommunicationPreferenceRepository than local_runtime.outbound_preferences — any \
+             preference written through the WebUI delivery-defaults facade \
+             (RebornOutboundPreferencesFacade) will NOT be visible to the Slack \
+             triggered-delivery hook; the hook must use \
              Arc::clone(&local_runtime.outbound_preferences) as `communication_preferences`"
         );
     }

--- a/crates/ironclaw_reborn_composition/src/slack_host_beta.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_host_beta.rs
@@ -3993,5 +3993,7 @@ mod tests {
              triggered-delivery hook; the hook must use \
              Arc::clone(&local_runtime.outbound_preferences) as `communication_preferences`"
         );
+
+        runtime.shutdown().await.expect("runtime shuts down");
     }
 }

--- a/docs/plans/2026-06-05-trigger-delivery-default-outbound-e2e-plan.md
+++ b/docs/plans/2026-06-05-trigger-delivery-default-outbound-e2e-plan.md
@@ -60,6 +60,14 @@ progress/projection payloads and non-text modality defaults remain deferred.
 - Slack final-reply delivery reads the shared
   `local_runtime.outbound_preferences` repository instead of a private
   in-memory preference repository.
+- **Resolved 2026-06-11 (PR #4782):** the carry-forward finding from the
+  2026-05-29 plan (Slack host-beta constructing its own outbound state store)
+  is closed. `RebornLocalRuntimeServices` now owns a single outbound store
+  exposing preferences, state, gate-routes, and triggered-delivery handles;
+  `slack_host_beta` consumes those handles rather than constructing a private
+  `FilesystemOutboundStateStore`. The `/outbound` grant was removed from
+  `slack_host_state_mount_view`, and a `clippy::disallowed-methods` lint bans
+  `FilesystemOutboundStateStore::new` outside the factory.
 - The staged Slack provider is not yet wired into the WebUI/API bundle and
   should not become user-selectable until the scoped authority model below is
   implemented.


### PR DESCRIPTION
## Problem

Setting a Slack DM delivery default in the WebUI had no effect on triggered-run delivery: every fire ended `outcome=NoDefaultConfigured` and the user got nothing in Slack — no approval prompt, no result, no error.

Root cause: two `FilesystemOutboundStateStore` instances over different mount views. The WebUI delivery-defaults facade wrote preferences via the composition-owned store (`invocation_mount_view`: `/outbound` → `/tenants/<t>/users/<u>/outbound`), while Slack host-beta delivery constructed its own store over `slack_host_state_mount_view` (`/outbound` → `/tenants/<t>/shared/slack-outbound`). Same key, same record, different physical trees — delivery read a tree nothing ever wrote preferences into.

This was the documented carry-forward in `docs/plans/2026-05-29-trigger-loop-delivery-resolution-implementation.md` ("the Slack integration must bridge this split" before claiming e2e); #4730 shipped without it. Diagnosed live on the QA Railway deployment: `GET /outbound/preferences` returned the saved Slack DM target while delivery logged `NoDefaultConfigured` on the same runs (17:00Z, 17:10Z, 18:08Z on 2026-06-11).

## Fix

- `RebornLocalRuntimeServices` exposes `outbound_preferences`, `outbound_state`, `delivered_gate_routes`, `triggered_run_delivery` — all cloned from one composition-owned store in libsql builds. New fields are `slack-v2-host-beta`-gated, mirroring `host_state_filesystem`. Both cfg construction paths return one `LocalDevOutboundStores` bundle, so the libsql/non-libsql sites are symmetric.
- `slack_host_beta` consumers (triggered-run delivery driver, final-reply observer, `DeliveredGateRoutingApprovalService`) take the `local_runtime` handles; all private store constructions removed. Single `build_triggered_run_delivery_driver` wiring fn; the post-submit hook delegates to it.
- `/outbound` MountGrant removed from `slack_host_state_mount_view`. The orphaned `shared/slack-outbound` tree held only ephemeral delivery-outcome records and swept gate routes — no migration.
- clippy `disallowed-methods` bans `FilesystemOutboundStateStore::new` outside the factory, killing the bug class at lint time (fire-proven against a planted violation). Owning-crate contract tests carry explicit allows.

## Tests

- `slack_host_beta::tests::webui_saved_preference_is_visible_to_triggered_slack_delivery` — preference handle the WebUI facade writes through is pointer-identical to the one the delivery driver reads. Verified to FAIL on the pre-fix wiring and pass on the fixed wiring.
- `factory::tests::local_dev_outbound_store_libsql_shares_one_allocation_across_all_roles` — all four role handles share one allocation.
- `slack_host_state_mount_view_grants_delete_only_to_slack_state_roots` updated: `/outbound` no longer resolves through the slack-host mount.
- `cargo clippy --all-features --tests` zero warnings; `--no-default-features`, `libsql`-only, and `slack-v2-host-beta`-only combos compile clean; full `--lib` suite green modulo the pre-existing `runtime::tests` parallel-timeout flakes (all pass solo, same as main).

## Deploy notes

- Saved delivery defaults become visible to delivery immediately — no re-save needed.
- Runs already stuck `BlockedApproval` from before the fix (e.g. `d062beca`, `94694028` on QA) still need manual approve/cancel in the WebUI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)