### PR TITLE
Fix terminal driver_unavailable on multi-tool-call capability batches

### DIFF
--- a/crates/ironclaw_agent_loop/src/executor/capabilities.rs
+++ b/crates/ironclaw_agent_loop/src/executor/capabilities.rs
@@ -129,7 +129,7 @@ impl ExecutorStage<CapabilityInput> for CapabilityStage {
             .await;
 
         let mut pending_approval_resume = state.pending_approval_resume.clone();
-        let batch = ctx
+        let batch_result = ctx
             .host
             .invoke_capability_batch(CapabilityBatchInvocation {
                 invocations: visible_calls
@@ -153,8 +153,48 @@ impl ExecutorStage<CapabilityInput> for CapabilityStage {
                     .collect(),
                 stop_on_first_suspension,
             })
-            .await
-            .map_err(capability_host_error)?;
+            .await;
+
+        let batch = match batch_result {
+            Ok(batch) => batch,
+            Err(ref error)
+                if error.kind
+                    == ironclaw_turns::run_profile::AgentLoopHostErrorKind::StaleSurface =>
+            {
+                let stale_summary = SanitizedStrategySummary::from_trusted_static(
+                    "capability surface changed before execution; re-issue the call",
+                );
+                for call in visible_calls {
+                    push_call_signature_once(&mut state, &mut signatures, &call)?;
+                    state
+                        .recent_failure_kinds
+                        .push(LoopFailureKind::PolicyDenied);
+                    let summary = CapabilityErrorSummary {
+                        class: CapabilityErrorClass::PolicyDenied,
+                        safe_summary: stale_summary.clone(),
+                        diagnostic_ref: None,
+                    };
+                    match self
+                        .handle_capability_error(
+                            ctx,
+                            state,
+                            call,
+                            summary,
+                            None,
+                            &mut capability_batch,
+                        )
+                        .await?
+                    {
+                        BatchStep::Continue(next) => state = *next,
+                        BatchStep::Exit(exit) => return Ok(TurnCompletedStep::Exit(exit)),
+                    }
+                }
+                return self
+                    .completed_turn(ctx, state, result_refs_start, capability_batch)
+                    .await;
+            }
+            Err(error) => return Err(capability_host_error(error)),
+        };
 
         if batch.outcomes.is_empty()
             || batch.outcomes.len() > visible_calls.len()
@@ -650,11 +690,28 @@ impl CapabilityStage {
                             })?,
                         )
                         .await;
-                    let retry = ctx
+                    let retry_result = ctx
                         .host
                         .invoke_capability(capability_invocation_from_candidate(call.clone(), None))
-                        .await
-                        .map_err(capability_host_error)?;
+                        .await;
+                    let retry = match retry_result {
+                        Ok(outcome) => outcome,
+                        Err(ref error)
+                            if error.kind
+                                == ironclaw_turns::run_profile::AgentLoopHostErrorKind::StaleSurface =>
+                        {
+                            summary = CapabilityErrorSummary {
+                                class: CapabilityErrorClass::PolicyDenied,
+                                safe_summary: SanitizedStrategySummary::from_trusted_static(
+                                    "capability surface changed before execution; re-issue the call",
+                                ),
+                                diagnostic_ref: None,
+                            };
+                            model_observation = None;
+                            continue;
+                        }
+                        Err(error) => return Err(capability_host_error(error)),
+                    };
                     match retry {
                         CapabilityOutcome::Failed(failure) => {
                             if failure.error_kind == CapabilityFailureKind::Cancelled {

--- a/crates/ironclaw_agent_loop/src/executor/mapping.rs
+++ b/crates/ironclaw_agent_loop/src/executor/mapping.rs
@@ -113,6 +113,11 @@ pub(super) fn capability_host_error(error: AgentLoopHostError) -> AgentLoopExecu
     if error.kind == AgentLoopHostErrorKind::Cancelled {
         return AgentLoopExecutorError::Cancelled;
     }
+    tracing::warn!(
+        kind = error.kind.as_str(),
+        safe_summary = error.safe_summary.as_str(),
+        "capability host error mapped to HostUnavailable"
+    );
     AgentLoopExecutorError::HostUnavailable {
         stage: HostStage::Capability,
     }

--- a/crates/ironclaw_agent_loop/src/executor/tests.rs
+++ b/crates/ironclaw_agent_loop/src/executor/tests.rs
@@ -4431,3 +4431,41 @@ async fn gate_stage_skip_does_not_clear_auth_resume_for_different_capability() {
         "surviving pending_auth_resume.gate_ref must be unchanged"
     );
 }
+
+#[tokio::test]
+async fn stale_surface_batch_failure_is_recoverable() {
+    let host = MockHost::new(vec![calls_response(), reply_response()])
+        .fail_batch_with(AgentLoopHostErrorKind::StaleSurface);
+    let executor = CanonicalAgentLoopExecutor;
+    let state = LoopExecutionState::initial_for_run(host.run_context());
+
+    let exit = executor
+        .execute_family(&crate::families::default(), &host, state)
+        .await
+        .expect("StaleSurface batch error must not kill the run");
+
+    assert!(
+        matches!(exit, LoopExit::Completed(_)),
+        "run must complete after a StaleSurface batch error; got {exit:?}"
+    );
+}
+
+#[tokio::test]
+async fn non_stale_batch_failure_stays_terminal() {
+    let host =
+        MockHost::new(vec![calls_response()]).fail_batch_with(AgentLoopHostErrorKind::Unavailable);
+    let executor = CanonicalAgentLoopExecutor;
+    let state = LoopExecutionState::initial_for_run(host.run_context());
+
+    let error = executor
+        .execute_family(&crate::families::default(), &host, state)
+        .await
+        .expect_err("non-StaleSurface batch error must propagate as terminal error");
+
+    assert_eq!(
+        error,
+        AgentLoopExecutorError::HostUnavailable {
+            stage: HostStage::Capability
+        }
+    );
+}

--- a/crates/ironclaw_agent_loop/src/executor/tests/support.rs
+++ b/crates/ironclaw_agent_loop/src/executor/tests/support.rs
@@ -77,6 +77,7 @@ pub(super) struct MockHost {
     fail_checkpoint: Arc<Mutex<Option<LoopCheckpointKind>>>,
     fail_visible_capabilities: bool,
     fail_prompt_bundle: bool,
+    fail_batch_with: Arc<Mutex<Option<AgentLoopHostErrorKind>>>,
 }
 
 impl MockHost {
@@ -115,6 +116,7 @@ impl MockHost {
             fail_checkpoint: Arc::new(Mutex::new(None)),
             fail_visible_capabilities: false,
             fail_prompt_bundle: false,
+            fail_batch_with: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -161,6 +163,11 @@ impl MockHost {
 
     pub(super) fn with_failing_prompt_bundle(mut self) -> Self {
         self.fail_prompt_bundle = true;
+        self
+    }
+
+    pub(super) fn fail_batch_with(self, kind: AgentLoopHostErrorKind) -> Self {
+        *self.fail_batch_with.lock().expect("lock") = Some(kind);
         self
     }
 
@@ -670,6 +677,9 @@ impl ironclaw_turns::run_profile::LoopCapabilityPort for MockHost {
         request: CapabilityBatchInvocation,
     ) -> Result<ironclaw_turns::run_profile::CapabilityBatchOutcome, AgentLoopHostError> {
         self.batch_invocations.lock().expect("lock").push(request);
+        if let Some(kind) = *self.fail_batch_with.lock().expect("lock") {
+            return Err(AgentLoopHostError::new(kind, "scripted batch failure"));
+        }
         let outcome = self
             .batch_outcomes
             .lock()

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -6608,4 +6608,264 @@ mod tests {
 
         runtime.shutdown().await.expect("runtime shutdown");
     }
+
+    /// Multi-call model response with a mid-register surface change must not kill the run.
+    ///
+    /// Scenario: the scripted gateway (a) registers tool call #1, (b) activates an extension
+    /// (deterministic surface-content change), (c) registers tool call #2, then returns both
+    /// candidates together.  Before the fix, register #2 rebuilt the inner port, wiping the
+    /// snapshot that candidate #1 referred to; the executor hit StaleSurface on the first
+    /// candidate and collapsed to a terminal HostUnavailable failure.  After the fix, both
+    /// candidates carry the same (prompt-stage) surface version and the run completes.
+    #[tokio::test]
+    async fn multi_tool_call_response_survives_surface_change_mid_register() {
+        use ironclaw_product_workflow::{
+            LifecycleProductAction, LifecycleProductContext, LifecycleProductFacade,
+            LifecycleProductSurfaceContext,
+        };
+        use std::sync::OnceLock;
+
+        // Gateway state seeded after runtime build.
+        struct LifecycleFacadeHandle {
+            facade: crate::lifecycle::RebornLocalLifecycleFacade,
+        }
+
+        impl std::fmt::Debug for LifecycleFacadeHandle {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.debug_struct("LifecycleFacadeHandle").finish()
+            }
+        }
+
+        struct MultiToolCallGateway {
+            calls: StdMutex<usize>,
+            facade_slot: Arc<OnceLock<LifecycleFacadeHandle>>,
+        }
+
+        #[async_trait]
+        impl HostManagedModelGateway for MultiToolCallGateway {
+            async fn stream_model(
+                &self,
+                _request: HostManagedModelRequest,
+            ) -> Result<HostManagedModelResponse, HostManagedModelError> {
+                Err(HostManagedModelError::safe(
+                    HostManagedModelErrorKind::InvalidRequest,
+                    "expected capability-aware model path",
+                ))
+            }
+
+            async fn stream_model_with_capabilities(
+                &self,
+                _request: HostManagedModelRequest,
+                capabilities: Arc<dyn ironclaw_turns::run_profile::LoopCapabilityPort>,
+            ) -> Result<HostManagedModelResponse, HostManagedModelError> {
+                let call_index = {
+                    let mut calls = self.calls.lock().expect("multi-tool gateway lock poisoned");
+                    let idx = *calls;
+                    *calls += 1;
+                    idx
+                };
+
+                if call_index > 0 {
+                    // Second model call: capability results have been fed back — finish the run.
+                    return Ok(HostManagedModelResponse::assistant_reply(
+                        "multi-tool surface-change ok",
+                    ));
+                }
+
+                // ── First model call ──────────────────────────────────────────────────
+                // Trigger prompt-stage surface snapshot (establishes V1).
+                capabilities
+                    .visible_capabilities(VisibleCapabilityRequest)
+                    .await
+                    .map_err(model_capability_error)?;
+
+                // Find the builtin echo tool.
+                let echo_id =
+                    ironclaw_host_api::CapabilityId::new("builtin.echo").expect("echo id");
+                let echo_tool = capabilities
+                    .tool_definitions()
+                    .map_err(model_capability_error)?
+                    .into_iter()
+                    .find(|def| def.capability_id == echo_id)
+                    .expect("echo provider tool definition");
+
+                // Register call #1 — candidate carries surface version V1.
+                let mut call1 = ProviderToolCall {
+                    provider_id: "test-provider".to_string(),
+                    provider_model_id: "test-model".to_string(),
+                    turn_id: Some("provider-turn-multi".to_string()),
+                    id: "call-multi-1".to_string(),
+                    name: echo_tool.name.clone(),
+                    arguments: serde_json::json!({"message": "hello from call 1"}),
+                    response_reasoning: None,
+                    reasoning: None,
+                    signature: None,
+                };
+                let candidate1 = capabilities
+                    .register_provider_tool_call(call1.clone())
+                    .await
+                    .map_err(model_capability_error)?;
+
+                // Activate the github extension — deterministic surface-content change.
+                // Pre-fix: this rebuilds the inner port, wiping candidate1's snapshot.
+                let facade_handle = self
+                    .facade_slot
+                    .get()
+                    .expect("lifecycle facade must be seeded before send_user_message");
+                let package_ref =
+                    LifecyclePackageRef::new(LifecyclePackageKind::Extension, "github")
+                        .expect("valid github ref");
+                let ctx = LifecycleProductContext::Surface(LifecycleProductSurfaceContext {
+                    tenant_id: TenantId::new("tenant-multi-tool-surface").expect("tenant id"),
+                    user_id: UserId::new("user-multi-tool-surface").expect("user id"),
+                    agent_id: None,
+                    project_id: None,
+                });
+                facade_handle
+                    .facade
+                    .execute(
+                        ctx.clone(),
+                        LifecycleProductAction::ExtensionInstall {
+                            package_ref: package_ref.clone(),
+                        },
+                    )
+                    .await
+                    .expect("install github extension");
+                facade_handle
+                    .facade
+                    .execute(
+                        ctx,
+                        LifecycleProductAction::ExtensionActivate { package_ref },
+                    )
+                    .await
+                    .expect("activate github extension");
+
+                // Register call #2 — after surface change.
+                // Post-fix: reuses current port, so both candidates carry the same surface version.
+                call1.id = "call-multi-2".to_string();
+                call1.arguments = serde_json::json!({"message": "hello from call 2"});
+                let candidate2 = capabilities
+                    .register_provider_tool_call(call1)
+                    .await
+                    .map_err(model_capability_error)?;
+
+                // Both candidates must carry the same surface version after the fix.
+                // (We cannot assert this here without breaking the pre-fix path,
+                //  so we rely on the run-completion assertion in the test body.)
+                Ok(HostManagedModelResponse::capability_calls(
+                    vec![candidate1, candidate2],
+                    "",
+                ))
+            }
+        }
+
+        // ── Test body ──────────────────────────────────────────────────────────────
+        let root = tempfile::tempdir().expect("tempdir");
+        let facade_slot: Arc<OnceLock<LifecycleFacadeHandle>> = Arc::new(OnceLock::new());
+        let gateway = Arc::new(MultiToolCallGateway {
+            calls: StdMutex::new(0),
+            facade_slot: Arc::clone(&facade_slot),
+        });
+        let gateway_for_runtime: Arc<dyn HostManagedModelGateway> = gateway;
+
+        let input = RebornRuntimeInput::from_services(
+            RebornBuildInput::local_dev(
+                "runtime-multi-tool-surface-owner",
+                root.path().join("local-dev"),
+            )
+            .with_runtime_policy(local_dev_runtime_policy()),
+        )
+        .with_identity(RebornRuntimeIdentity {
+            tenant_id: "runtime-multi-tool-surface-tenant".to_string(),
+            agent_id: "runtime-multi-tool-surface-agent".to_string(),
+            source_binding_id: "runtime-multi-tool-surface-source".to_string(),
+            reply_target_binding_id: "runtime-multi-tool-surface-reply".to_string(),
+        })
+        .with_poll_settings(PollSettings {
+            interval: Duration::from_millis(10),
+            max_total: Duration::from_secs(10),
+        })
+        .with_model_gateway_override(gateway_for_runtime);
+
+        let runtime = build_reborn_runtime(input).await.expect("runtime builds");
+
+        // Seed the lifecycle facade before the model gateway runs.
+        let local_runtime = runtime
+            .services
+            .local_runtime
+            .as_ref()
+            .expect("local runtime substrate");
+        let extension_management = local_runtime
+            .extension_management
+            .as_ref()
+            .expect("extension management")
+            .clone();
+        let facade = crate::lifecycle::RebornLocalLifecycleFacade::new(
+            local_runtime.skill_management.clone(),
+        )
+        .with_extension_management(extension_management)
+        .with_runtime_credential_accounts(Arc::new(MultiToolConfiguredCredentials));
+        facade_slot
+            .set(LifecycleFacadeHandle { facade })
+            .expect("facade slot should be empty before seeding");
+
+        let conversation = runtime.new_conversation().await.expect("conversation");
+        let reply = tokio::time::timeout(
+            RUNTIME_SEND_TIMEOUT,
+            runtime.send_user_message(&conversation, "use echo tool twice"),
+        )
+        .await
+        .expect("runtime send should finish within timeout")
+        .expect("runtime send should succeed");
+
+        assert_eq!(
+            reply.status,
+            TurnStatus::Completed,
+            "multi-tool response with mid-register surface change must not produce terminal failure; status={:?} text={:?}",
+            reply.status,
+            reply.text,
+        );
+        assert_eq!(reply.text.as_deref(), Some("multi-tool surface-change ok"));
+
+        runtime.shutdown().await.expect("runtime shutdown");
+    }
+
+    struct MultiToolConfiguredCredentials;
+
+    #[async_trait]
+    impl crate::product_auth_runtime_credentials::RuntimeCredentialAccountSelectionService
+        for MultiToolConfiguredCredentials
+    {
+        async fn select_unique_configured_runtime_account(
+            &self,
+            _request: crate::product_auth_runtime_credentials::RuntimeCredentialAccountSelectionRequest,
+        ) -> Result<ironclaw_auth::CredentialAccount, ironclaw_auth::AuthProductError> {
+            let now = chrono::Utc::now();
+            Ok(ironclaw_auth::CredentialAccount {
+                id: ironclaw_auth::CredentialAccountId::new(),
+                scope: ironclaw_auth::AuthProductScope::new(
+                    ironclaw_host_api::ResourceScope::local_default(
+                        UserId::new("multi-tool-credential-user").expect("user id"),
+                        ironclaw_host_api::InvocationId::new(),
+                    )
+                    .expect("resource scope"),
+                    ironclaw_auth::AuthSurface::Api,
+                ),
+                provider: ironclaw_auth::AuthProviderId::new("test-provider").expect("provider id"),
+                label: ironclaw_auth::CredentialAccountLabel::new("test-provider")
+                    .expect("account label"),
+                status: ironclaw_auth::CredentialAccountStatus::Configured,
+                ownership: ironclaw_auth::CredentialOwnership::UserReusable,
+                owner_extension: None,
+                granted_extensions: Vec::new(),
+                access_secret: Some(
+                    ironclaw_host_api::SecretHandle::new("test-secret").expect("secret handle"),
+                ),
+                refresh_secret: None,
+                scopes: Vec::new(),
+                created_at: now,
+                updated_at: now,
+            })
+        }
+    }
 }

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/refreshing_capability_port.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/refreshing_capability_port.rs
@@ -208,9 +208,8 @@ impl LoopCapabilityPort for RefreshingLocalDevCapabilityPort {
         &self,
         tool_call: ProviderToolCall,
     ) -> Result<CapabilityCallCandidate, AgentLoopHostError> {
-        self.refresh_current(VisibleCapabilityRequest {})
+        self.current_or_refresh()
             .await?
-            .0
             .register_provider_tool_call(tool_call)
             .await
     }

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/tests.rs
@@ -1742,18 +1742,6 @@ mod tests {
             .await
             .expect("activate github extension");
 
-        let staged_after_activation = port
-            .register_provider_tool_call(provider_tool_call_with_name(
-                "github__search_issues",
-                serde_json::json!({"query": "repo:nearai/ironclaw is:issue"}),
-            ))
-            .await
-            .expect("provider registration should refresh newly activated extension surface");
-        assert_eq!(
-            staged_after_activation.capability_id.as_str(),
-            "github.search_issues"
-        );
-
         let active_surface = port
             .visible_capabilities(VisibleCapabilityRequest {})
             .await
@@ -1767,6 +1755,18 @@ mod tests {
         assert!(active_capability_ids.contains(&"github.get_issue"));
         assert!(active_capability_ids.contains(&"github.comment_issue"));
 
+        let staged_after_activation = port
+            .register_provider_tool_call(provider_tool_call_with_name(
+                "github__search_issues",
+                serde_json::json!({"query": "repo:nearai/ironclaw is:issue"}),
+            ))
+            .await
+            .expect("provider registration resolves github after prompt-stage refresh");
+        assert_eq!(
+            staged_after_activation.capability_id.as_str(),
+            "github.search_issues"
+        );
+
         let tool_definitions = port.tool_definitions().expect("tool definitions");
         let tool_definition_ids = tool_definitions
             .iter()
@@ -1776,6 +1776,138 @@ mod tests {
             tool_definition_ids.contains(&"github.search_issues"),
             "refreshed provider tools should include github after activation"
         );
+    }
+
+    #[tokio::test]
+    async fn register_does_not_rebuild_surface_mid_response() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let storage_root = dir.path().join("local-dev");
+        let services = crate::build_reborn_services(
+            crate::RebornBuildInput::local_dev_with_profile(
+                crate::RebornCompositionProfile::LocalDevYolo,
+                "local-dev-mid-response-owner",
+                storage_root,
+            )
+            .with_runtime_policy(local_dev_minimal_approval_policy()),
+        )
+        .await
+        .expect("local-dev services build");
+        let run_context = run_context("mid-response").await;
+        let thread_scope = ThreadScope {
+            tenant_id: run_context.scope.tenant_id.clone(),
+            agent_id: run_context.scope.agent_id.clone().expect("agent id"),
+            project_id: run_context.scope.project_id.clone(),
+            owner_user_id: None,
+            mission_id: None,
+        };
+        let wiring = capability_wiring(
+            &services,
+            Arc::new(InMemorySessionThreadService::default()),
+            thread_scope,
+            UserId::new("local-dev-mid-response-user").expect("user id"),
+            Arc::new(
+                crate::local_dev_capability_policy::local_dev_capability_policy()
+                    .expect("policy parses"),
+            ),
+            Arc::new(UnavailableModelGateway),
+            Arc::new(InMemoryLoopHostMilestoneSink::default()),
+            None,
+        )
+        .expect("local-dev capability wiring");
+        let port = wiring
+            .capability_factory
+            .create_capability_port(&run_context)
+            .await
+            .expect("capability port");
+
+        port.visible_capabilities(VisibleCapabilityRequest {})
+            .await
+            .expect("prompt-stage surface refresh");
+
+        let mut call1 = provider_tool_call_with_name(
+            "builtin__read_file",
+            serde_json::json!({"path": "/host/nonexistent.txt"}),
+        );
+        call1.id = "call-mid-response-1".to_string();
+        let candidate1 = port
+            .register_provider_tool_call(call1)
+            .await
+            .expect("first register");
+
+        let local_runtime = services
+            .local_runtime
+            .as_ref()
+            .expect("local runtime substrate");
+        let extension_management = local_runtime
+            .extension_management
+            .as_ref()
+            .expect("extension management")
+            .clone();
+        let facade = crate::lifecycle::RebornLocalLifecycleFacade::new(
+            local_runtime.skill_management.clone(),
+        )
+        .with_extension_management(extension_management)
+        .with_runtime_credential_accounts(Arc::new(ConfiguredRuntimeCredentialAccounts));
+        let package_ref = LifecyclePackageRef::new(LifecyclePackageKind::Extension, "github")
+            .expect("valid github ref");
+        facade
+            .execute(
+                lifecycle_context("mid-response-install"),
+                LifecycleProductAction::ExtensionInstall {
+                    package_ref: package_ref.clone(),
+                },
+            )
+            .await
+            .expect("install github extension");
+        facade
+            .execute(
+                lifecycle_context("mid-response-activate"),
+                LifecycleProductAction::ExtensionActivate { package_ref },
+            )
+            .await
+            .expect("activate github extension");
+
+        let mut call2 = provider_tool_call_with_name(
+            "builtin__read_file",
+            serde_json::json!({"path": "/host/other.txt"}),
+        );
+        call2.id = "call-mid-response-2".to_string();
+        let candidate2 = port
+            .register_provider_tool_call(call2)
+            .await
+            .expect("second register after extension activation");
+
+        assert_eq!(
+            candidate1.surface_version, candidate2.surface_version,
+            "both candidates must carry the same surface version so invoke_capability_batch can serve them from one snapshot"
+        );
+
+        let batch_result = port
+            .invoke_capability_batch(ironclaw_turns::run_profile::CapabilityBatchInvocation {
+                invocations: vec![
+                    ironclaw_turns::run_profile::CapabilityInvocation {
+                        surface_version: candidate1.surface_version,
+                        capability_id: candidate1.capability_id,
+                        input_ref: candidate1.input_ref,
+                        approval_resume: None,
+                    },
+                    ironclaw_turns::run_profile::CapabilityInvocation {
+                        surface_version: candidate2.surface_version,
+                        capability_id: candidate2.capability_id,
+                        input_ref: candidate2.input_ref,
+                        approval_resume: None,
+                    },
+                ],
+                stop_on_first_suspension: false,
+            })
+            .await;
+        if let Err(ref error) = batch_result {
+            assert_ne!(
+                error.kind,
+                ironclaw_turns::run_profile::AgentLoopHostErrorKind::StaleSurface,
+                "invoke_capability_batch must not fail with StaleSurface: {error:?}"
+            );
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Fixes #4789 — Reborn runs terminally failing with `HostUnavailable { stage: Capability }` ("The run failed because the execution driver was temporarily unavailable") whenever a model response carried multiple tool calls (e.g. 5× `gmail__get_message`).

## Root cause

`RefreshingLocalDevCapabilityPort::register_provider_tool_call` (introduced in #4744) rebuilt the entire inner capability port — wiping its single surface snapshot (`snapshots.clear()`) — on **every** model tool call. A response with N tool calls triggered N rebuilds. The surface version hash includes volatile inputs (OAuth credential `expires_at`, re-staged per rebuild), so a rebuild mid-register-loop could produce a new version; candidates registered earlier then cited a deleted snapshot. At execution, `snapshot_for` missed → `StaleSurface` → `capability_host_error` collapsed it into terminal `HostUnavailable { stage: Capability }` → run dead with a misleading "system unavailable" message.

## Fixes

1. **Pin the surface within one model-response cycle** — `register_provider_tool_call` now reuses the current port (`current_or_refresh`) instead of rebuilding. The surface still refreshes at every executor prompt stage, which is where newly activated extensions and refreshed credentials legitimately become visible (this also covers the auth-resume story #4744's per-register refresh was added for — resume re-enters through the prompt stage).
2. **`StaleSurface` is recoverable, not terminal** — a `StaleSurface` error from capability invocation now converts to graceful, model-visible per-call failures (PolicyDenied recovery path); the model re-issues calls against the fresh surface and the run continues. All other host error kinds keep terminal behavior. `capability_host_error` also logs the original error kind before collapsing, so future failures of this class self-identify in logs.

## Verification (all red→green: each test written first, shown failing on pre-fix code, passing after)

| Tier | Test | Red (pre-fix) | Green (fixed) |
|---|---|---|---|
| Port | `register_does_not_rebuild_surface_mid_response` (composition) | candidates stamped with two different surface versions | same version, batch executes |
| Executor | `stale_surface_batch_failure_is_recoverable` + `non_stale_batch_failure_stays_terminal` (agent_loop) | run killed with `HostUnavailable` | run continues; non-StaleSurface kinds still terminal |
| Full loop | `multi_tool_call_response_survives_surface_change_mid_register` (composition, scripted gateway through `send_user_message` → planned driver → executor → real port) | `status=Failed` (terminal) | `status=Completed` |

Also updated `local_dev_capability_port_refreshes_extensions_after_activation` to assert extension pickup at its true refresh point (prompt stage) rather than register time.

`cargo fmt`, workspace `clippy --all --all-features` (zero warnings), `cargo test -p ironclaw_reborn_composition` (574), `-p ironclaw_agent_loop` (329), `-p ironclaw_reborn` (472) all green.

## Follow-ups (out of scope)

- Snapshot history retention in `HostRuntimeLoopCapabilityPort` (covers suspend/resume staleness across refreshes).
- Remove volatile credential `expires_at` from the surface version hash so token rotation stops producing spurious "new" surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)