### PR TITLE
fix(reborn): improve WebUI conversation typography

### DIFF
--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/components/message-bubble.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/components/message-bubble.js
@@ -141,7 +141,7 @@ function MessageBubbleImpl({ message, onRetry }) {
         `}
         <div
           className=${[
-            "text-sm leading-6",
+            "text-base leading-7",
             ROLE_STYLES[role] || ROLE_STYLES.assistant,
             isOptimistic ? "opacity-70" : "",
           ].join(" ")}

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/components/message-bubble.test.mjs
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/components/message-bubble.test.mjs
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const messageBubbleSource = readFileSync(
+  new URL("./message-bubble.js", import.meta.url),
+  "utf8",
+);
+const appCssSource = readFileSync(
+  new URL("../../../../styles/app.css", import.meta.url),
+  "utf8",
+);
+
+test("conversation message bubbles use readable typography", () => {
+  assert.match(
+    messageBubbleSource,
+    /"text-base leading-7"/,
+    "chat message content should render at a readable base size",
+  );
+  assert.doesNotMatch(
+    messageBubbleSource,
+    /"text-sm leading-6"/,
+    "chat message content should not regress to the compact body size",
+  );
+});
+
+test("markdown body and code blocks inherit readable message sizing", () => {
+  assert.match(
+    appCssSource,
+    /\.markdown-body\s*\{\s*font-size: 1em; line-height: 1\.7; \}/,
+    "markdown prose should inherit the message bubble size with readable leading",
+  );
+  assert.match(
+    appCssSource,
+    /\.markdown-body pre code \{[^}]*font-size: 0\.9em; line-height: 1\.65;/,
+    "fenced code should stay close to body size instead of shrinking below readability",
+  );
+});

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/components/message-bubble.test.mjs
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/components/message-bubble.test.mjs
@@ -14,12 +14,12 @@ const appCssSource = readFileSync(
 test("conversation message bubbles use readable typography", () => {
   assert.match(
     messageBubbleSource,
-    /"text-base leading-7"/,
+    /['"`]text-base\s+leading-7['"`]/,
     "chat message content should render at a readable base size",
   );
   assert.doesNotMatch(
     messageBubbleSource,
-    /"text-sm leading-6"/,
+    /['"`]text-sm\s+leading-6['"`]/,
     "chat message content should not regress to the compact body size",
   );
 });
@@ -27,12 +27,12 @@ test("conversation message bubbles use readable typography", () => {
 test("markdown body and code blocks inherit readable message sizing", () => {
   assert.match(
     appCssSource,
-    /\.markdown-body\s*\{\s*font-size: 1em; line-height: 1\.7; \}/,
+    /\.markdown-body\s*\{\s*font-size:\s*1em;\s*line-height:\s*1\.7;\s*\}/,
     "markdown prose should inherit the message bubble size with readable leading",
   );
   assert.match(
     appCssSource,
-    /\.markdown-body pre code \{[^}]*font-size: 0\.9em; line-height: 1\.65;/,
+    /\.markdown-body\s+pre\s+code\s*\{[^}]*font-size:\s*0\.9em;\s*line-height:\s*1\.65;/,
     "fenced code should stay close to body size instead of shrinking below readability",
   );
 });

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/components/message-bubble.test.mjs
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/components/message-bubble.test.mjs
@@ -27,7 +27,7 @@ test("conversation message bubbles use readable typography", () => {
 test("markdown body and code blocks inherit readable message sizing", () => {
   assert.match(
     appCssSource,
-    /\.markdown-body\s*\{\s*font-size:\s*1em;\s*line-height:\s*1\.7;\s*\}/,
+    /\.markdown-body\s*\{[^}]*font-size:\s*1em;[^}]*line-height:\s*1\.7;/,
     "markdown prose should inherit the message bubble size with readable leading",
   );
   assert.match(

--- a/crates/ironclaw_webui_v2_static/static/styles/app.css
+++ b/crates/ironclaw_webui_v2_static/static/styles/app.css
@@ -368,19 +368,20 @@ input:focus, select:focus, textarea:focus {
   margin-top: 1em; margin-bottom: 0.5em; font-weight: 600;
   color: var(--v2-text-strong);
 }
-.markdown-body p              { margin-bottom: 0.75em; line-height: 1.65; }
+.markdown-body                { font-size: 1em; line-height: 1.7; }
+.markdown-body p              { margin-bottom: 0.8em; line-height: inherit; }
 .markdown-body ul,.markdown-body ol { margin-bottom: 0.75em; padding-left: 1.5em; }
 .markdown-body li             { margin-bottom: 0.25em; }
 .markdown-body code {
   font-family: "Geist Mono","SF Mono","JetBrains Mono",ui-monospace,monospace;
-  font-size: 0.875em; background: var(--v2-surface-muted);
+  font-size: 0.9em; background: var(--v2-surface-muted);
   padding: 0.15em 0.4em; border-radius: 4px;
 }
 .markdown-body pre {
   background: var(--v2-surface-soft); border: 1px solid var(--v2-panel-border);
   border-radius: 8px; padding: 0.75em 1em; overflow-x: auto; margin-bottom: 0.75em;
 }
-.markdown-body pre code { background: transparent; padding: 0; border-radius: 0; font-size: 0.8125em; }
+.markdown-body pre code { background: transparent; padding: 0; border-radius: 0; font-size: 0.9em; line-height: 1.65; }
 .markdown-body blockquote {
   border-left: 3px solid var(--v2-panel-border); padding-left: 1em;
   margin-left: 0; margin-bottom: 0.75em; color: var(--v2-text-muted);


### PR DESCRIPTION
## Summary

Fixes #4707.

- Increase WebUI chat message content from compact `text-sm/leading-6` to `text-base/leading-7`.
- Keep markdown prose, inline code, and fenced code blocks aligned with the larger message body scale.
- Add focused static coverage for the conversation typography contract.

## Validation

- `node --test crates/ironclaw_webui_v2_static/static/js/pages/chat/components/message-bubble.test.mjs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat message readability by increasing message bubble typography (larger font size and updated line height).
  * Refreshed Markdown rendering in chat, including paragraph spacing and clearer fenced code block sizing.

* **Tests**
  * Added a regression test to ensure the chat message typography and Markdown/code styles remain consistent, including fenced code block font sizing and line height.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->