### PR TITLE
feat(reborn): add WebUI code block syntax highlighting

### DIFF
--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/components/markdown-renderer.test.mjs
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/components/markdown-renderer.test.mjs
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const rendererSource = readFileSync(
+  new URL("./markdown-renderer.js", import.meta.url),
+  "utf8",
+);
+const appCssSource = readFileSync(
+  new URL("../../../../styles/app.css", import.meta.url),
+  "utf8",
+);
+
+test("markdown code blocks are passed through highlight.js when available", () => {
+  assert.match(
+    rendererSource,
+    /window\.hljs\.highlightElement\(codeEl\)/,
+    "markdown code blocks should be enhanced by highlight.js after rendering",
+  );
+});
+
+test("highlight.js token classes have local readable styles", () => {
+  for (const selector of [
+    ".markdown-body pre code.hljs",
+    ".markdown-body .hljs-keyword",
+    ".markdown-body .hljs-string",
+    ".markdown-body .hljs-comment",
+    ".markdown-body .hljs-title",
+  ]) {
+    assert.ok(
+      appCssSource.includes(selector),
+      `expected local syntax-highlighting style for ${selector}`,
+    );
+  }
+  assert.match(
+    appCssSource,
+    /\.markdown-body pre code \{ color: var\(--v2-text\); \}/,
+    "plain or unknown-language code blocks should remain readable without highlighted tokens",
+  );
+});

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/components/markdown-renderer.test.mjs
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/components/markdown-renderer.test.mjs
@@ -34,7 +34,7 @@ test("highlight.js token classes have local readable styles", () => {
   }
   assert.match(
     appCssSource,
-    /\.markdown-body pre code \{ color: var\(--v2-text\); \}/,
+    /\.markdown-body\s+pre\s+code\s*\{\s*color:\s*var\(--v2-text\);\s*\}/,
     "plain or unknown-language code blocks should remain readable without highlighted tokens",
   );
 });

--- a/crates/ironclaw_webui_v2_static/static/styles/app.css
+++ b/crates/ironclaw_webui_v2_static/static/styles/app.css
@@ -393,3 +393,46 @@ input:focus, select:focus, textarea:focus {
 }
 .markdown-body th { background: var(--v2-surface-soft); font-weight: 600; }
 .markdown-body hr { border: 0; border-top: 1px solid var(--v2-panel-border); margin: 1em 0; }
+.markdown-body pre code { color: var(--v2-text); }
+.markdown-body pre code.hljs {
+  display: block;
+  background: transparent;
+  color: var(--v2-text);
+}
+.markdown-body .hljs-keyword,
+.markdown-body .hljs-selector-tag,
+.markdown-body .hljs-built_in,
+.markdown-body .hljs-type {
+  color: var(--v2-accent-text);
+}
+.markdown-body .hljs-string,
+.markdown-body .hljs-regexp,
+.markdown-body .hljs-template-variable {
+  color: var(--v2-positive-text);
+}
+.markdown-body .hljs-number,
+.markdown-body .hljs-literal,
+.markdown-body .hljs-symbol,
+.markdown-body .hljs-bullet {
+  color: var(--v2-warning-text);
+}
+.markdown-body .hljs-comment,
+.markdown-body .hljs-quote {
+  color: var(--v2-text-muted);
+  font-style: italic;
+}
+.markdown-body .hljs-title,
+.markdown-body .hljs-section,
+.markdown-body .hljs-name {
+  color: var(--v2-info-text);
+}
+.markdown-body .hljs-attr,
+.markdown-body .hljs-attribute,
+.markdown-body .hljs-variable,
+.markdown-body .hljs-params {
+  color: var(--v2-text-strong);
+}
+.markdown-body .hljs-meta,
+.markdown-body .hljs-doctag {
+  color: var(--v2-danger-text);
+}


### PR DESCRIPTION
## Summary

Fixes #4708.

- Add local highlight.js token styles for markdown-rendered conversation code blocks.
- Preserve readable styling for unknown or no-language code fences through the existing plain `pre code` rule.
- Add focused static coverage that pins the renderer's highlight.js integration and the local token styles.

## Validation

- `node --test crates/ironclaw_webui_v2_static/static/js/pages/chat/components/markdown-renderer.test.mjs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved markdown code block rendering with syntax highlighting and clearer styling for a wider range of token types and languages.
* **Tests**
  * Added automated checks to ensure the markdown renderer triggers highlight.js when available and that required highlight styles and readable fallbacks are present.
* **Style**
  * Updated app CSS with scoped Highlight.js token styles within markdown content and a fallback for plain/unknown-language code blocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->