### PR TITLE
fix(reborn): repair oversized provider tool arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4895,6 +4895,7 @@ dependencies = [
  "ironclaw_processes",
  "ironclaw_reborn_event_store",
  "ironclaw_resources",
+ "ironclaw_safety",
  "ironclaw_scripts",
  "ironclaw_secrets",
  "ironclaw_skills",

--- a/crates/ironclaw_reborn/Cargo.toml
+++ b/crates/ironclaw_reborn/Cargo.toml
@@ -48,6 +48,7 @@ ironclaw_host_api = { path = "../ironclaw_host_api", version = "0.1.0" }
 ironclaw_host_runtime = { path = "../ironclaw_host_runtime", version = "0.1.0" }
 ironclaw_llm = { path = "../ironclaw_llm", version = "0.1.0", optional = true, default-features = false }
 ironclaw_loop_support = { path = "../ironclaw_loop_support", version = "0.1.0" }
+ironclaw_safety = { path = "../ironclaw_safety", version = "0.2.2" }
 ironclaw_secrets = { path = "../ironclaw_secrets", version = "0.1.0", optional = true }
 ironclaw_filesystem = { path = "../ironclaw_filesystem", version = "0.1.0", optional = true }
 ironclaw_threads = { path = "../ironclaw_threads", version = "0.1.0" }

--- a/crates/ironclaw_reborn/src/model_gateway.rs
+++ b/crates/ironclaw_reborn/src/model_gateway.rs
@@ -52,6 +52,10 @@ use crate::{
 };
 
 const MODEL_CREDITS_EXHAUSTED_SUMMARY: &str = "model provider account is out of credits";
+const PROVIDER_TOOL_ARGUMENTS_TOO_LARGE_SUMMARY: &str =
+    "provider tool arguments exceed 16384 bytes";
+const PROVIDER_TOOL_ARGUMENTS_OMITTED_MARKER: &str =
+    "arguments omitted because they exceeded the host provider-tool limit";
 
 /// Fail-closed routing policy from resolved Reborn model profile ids to the
 /// host-selected provider/model envelope.
@@ -833,20 +837,54 @@ where
                 ToolCompletionRequest::from_completion_request(completion, llm_tool_definitions);
             debug!("reborn model gateway dispatching tool-capable provider request");
             let response = provider
-                .complete_with_tools(tool_request)
+                .complete_with_tools(tool_request.clone())
                 .await
                 .map_err(map_provider_error)?;
             let response =
                 recover_textual_tool_calls_from_tool_response(response, &recovery_tool_names)?;
-            return tool_response_to_host(
-                response,
-                capabilities,
+            match tool_response_to_host(
+                response.clone(),
+                Arc::clone(&capabilities),
                 provider_turn_scope
                     .as_deref()
                     .unwrap_or("model_call=unknown"),
                 &replay_identity,
             )
-            .await;
+            .await
+            {
+                Ok(response) => return Ok(response),
+                Err(error) if is_repairable_provider_tool_output_error(&error) => {
+                    debug!(
+                        safe_summary = error.safe_summary.as_str(),
+                        "reborn model gateway retrying after repairable provider tool output"
+                    );
+                    let mut repair_request = tool_request;
+                    repair_request
+                        .messages
+                        .extend(provider_tool_repair_messages(
+                            &response,
+                            error.safe_summary.as_str(),
+                        ));
+                    let response = provider
+                        .complete_with_tools(repair_request)
+                        .await
+                        .map_err(map_provider_error)?;
+                    let response = recover_textual_tool_calls_from_tool_response(
+                        response,
+                        &recovery_tool_names,
+                    )?;
+                    return tool_response_to_host(
+                        response,
+                        capabilities,
+                        provider_turn_scope
+                            .as_deref()
+                            .unwrap_or("model_call=unknown"),
+                        &replay_identity,
+                    )
+                    .await;
+                }
+                Err(error) => return Err(error),
+            }
         }
         debug!(
             "reborn model gateway falling back to text-only provider request because no provider tool definitions were available"
@@ -1161,6 +1199,54 @@ fn map_provider_tool_output_error(error: AgentLoopHostError) -> HostManagedModel
             )
         }
         _ => map_capability_host_error(error),
+    }
+}
+
+fn is_repairable_provider_tool_output_error(error: &HostManagedModelError) -> bool {
+    error.kind == HostManagedModelErrorKind::InvalidOutput
+        && error.safe_summary == PROVIDER_TOOL_ARGUMENTS_TOO_LARGE_SUMMARY
+}
+
+fn provider_tool_repair_messages(
+    response: &ToolCompletionResponse,
+    safe_summary: &str,
+) -> Vec<ChatMessage> {
+    if response.tool_calls.is_empty() {
+        return Vec::new();
+    }
+
+    let assistant = ChatMessage::assistant_with_tool_calls(
+        response.content.clone(),
+        response
+            .tool_calls
+            .iter()
+            .map(provider_tool_call_for_repair)
+            .collect(),
+    )
+    .with_reasoning(response.reasoning.clone());
+    std::iter::once(assistant)
+        .chain(response.tool_calls.iter().map(|tool_call| {
+            ChatMessage::tool_result(
+                tool_call.id.clone(),
+                tool_call.name.clone(),
+                format!(
+                    "Tool call batch rejected by host: {safe_summary}. None of this response's tool calls were executed. Retry with smaller arguments or answer directly without this tool if it is not needed."
+                ),
+            )
+        }))
+        .collect()
+}
+
+fn provider_tool_call_for_repair(tool_call: &ToolCall) -> ToolCall {
+    ToolCall {
+        id: tool_call.id.clone(),
+        name: tool_call.name.clone(),
+        arguments: serde_json::json!({
+            "error": PROVIDER_TOOL_ARGUMENTS_OMITTED_MARKER,
+        }),
+        reasoning: tool_call.reasoning.clone(),
+        signature: tool_call.signature.clone(),
+        arguments_parse_error: tool_call.arguments_parse_error.clone(),
     }
 }
 

--- a/crates/ironclaw_reborn/src/model_gateway.rs
+++ b/crates/ironclaw_reborn/src/model_gateway.rs
@@ -28,6 +28,9 @@ use ironclaw_loop_support::{
     ModelCost, StaticModelCostTable, ThreadBackedLoopContextPort, ThreadBackedLoopModelPort,
     ThreadContextWindowCache,
 };
+use ironclaw_safety::{
+    is_provider_arguments_too_large_summary, provider_arguments_exceed_max_bytes,
+};
 use ironclaw_threads::{ProviderToolCallReferenceEnvelope, SessionThreadService, ThreadScope};
 use ironclaw_turns::run_profile::LoopModelUsage;
 use ironclaw_turns::{
@@ -52,8 +55,6 @@ use crate::{
 };
 
 const MODEL_CREDITS_EXHAUSTED_SUMMARY: &str = "model provider account is out of credits";
-const PROVIDER_TOOL_ARGUMENTS_TOO_LARGE_SUMMARY: &str =
-    "provider tool arguments exceed 16384 bytes";
 const PROVIDER_TOOL_ARGUMENTS_OMITTED_MARKER: &str =
     "arguments omitted because they exceeded the host provider-tool limit";
 
@@ -865,14 +866,16 @@ where
                             &response,
                             error.safe_summary.as_str(),
                         ));
+                    let rejected_response = response;
                     let response = provider
                         .complete_with_tools(repair_request)
                         .await
                         .map_err(map_provider_error)?;
-                    let response = recover_textual_tool_calls_from_tool_response(
+                    let mut response = recover_textual_tool_calls_from_tool_response(
                         response,
                         &recovery_tool_names,
                     )?;
+                    accumulate_tool_response_usage(&mut response, &rejected_response);
                     return tool_response_to_host(
                         response,
                         capabilities,
@@ -905,6 +908,24 @@ where
         "reborn model gateway received text-only provider response"
     );
     response_to_host_reply(response)
+}
+
+fn accumulate_tool_response_usage(
+    response: &mut ToolCompletionResponse,
+    additional: &ToolCompletionResponse,
+) {
+    response.input_tokens = response
+        .input_tokens
+        .saturating_add(additional.input_tokens);
+    response.output_tokens = response
+        .output_tokens
+        .saturating_add(additional.output_tokens);
+    response.cache_read_input_tokens = response
+        .cache_read_input_tokens
+        .saturating_add(additional.cache_read_input_tokens);
+    response.cache_creation_input_tokens = response
+        .cache_creation_input_tokens
+        .saturating_add(additional.cache_creation_input_tokens);
 }
 
 fn recover_textual_tool_calls_from_tool_response(
@@ -1204,7 +1225,7 @@ fn map_provider_tool_output_error(error: AgentLoopHostError) -> HostManagedModel
 
 fn is_repairable_provider_tool_output_error(error: &HostManagedModelError) -> bool {
     error.kind == HostManagedModelErrorKind::InvalidOutput
-        && error.safe_summary == PROVIDER_TOOL_ARGUMENTS_TOO_LARGE_SUMMARY
+        && is_provider_arguments_too_large_summary(&error.safe_summary)
 }
 
 fn provider_tool_repair_messages(
@@ -1238,13 +1259,19 @@ fn provider_tool_repair_messages(
 }
 
 fn provider_tool_call_for_repair(tool_call: &ToolCall) -> ToolCall {
+    let arguments = if provider_arguments_exceed_max_bytes(&tool_call.arguments) {
+        serde_json::json!({
+            "error": PROVIDER_TOOL_ARGUMENTS_OMITTED_MARKER,
+        })
+    } else {
+        tool_call.arguments.clone()
+    };
+
     ToolCall {
         id: tool_call.id.clone(),
         name: tool_call.name.clone(),
-        arguments: serde_json::json!({
-            "error": PROVIDER_TOOL_ARGUMENTS_OMITTED_MARKER,
-        }),
-        reasoning: tool_call.reasoning.clone(),
+        arguments,
+        reasoning: None,
         signature: tool_call.signature.clone(),
         arguments_parse_error: tool_call.arguments_parse_error.clone(),
     }

--- a/crates/ironclaw_reborn/src/model_gateway.rs
+++ b/crates/ironclaw_reborn/src/model_gateway.rs
@@ -1271,7 +1271,7 @@ fn provider_tool_call_for_repair(tool_call: &ToolCall) -> ToolCall {
         id: tool_call.id.clone(),
         name: tool_call.name.clone(),
         arguments,
-        reasoning: None,
+        reasoning: tool_call.reasoning.clone(),
         signature: tool_call.signature.clone(),
         arguments_parse_error: tool_call.arguments_parse_error.clone(),
     }

--- a/crates/ironclaw_reborn/tests/llm_gateway.rs
+++ b/crates/ironclaw_reborn/tests/llm_gateway.rs
@@ -614,10 +614,13 @@ async fn gateway_repairs_oversized_provider_tool_arguments_before_registration()
             "error": "arguments omitted because they exceeded the host provider-tool limit"
         })
     );
-    assert!(
-        repair_tool_calls
-            .iter()
-            .all(|call| call.reasoning.is_none())
+    assert_eq!(
+        repair_tool_calls[0].reasoning.as_deref(),
+        Some("valid call reasoning")
+    );
+    assert_eq!(
+        repair_tool_calls[1].reasoning.as_deref(),
+        Some("oversized call reasoning")
     );
     let repair_tool_result = repair_messages
         .iter()

--- a/crates/ironclaw_reborn/tests/llm_gateway.rs
+++ b/crates/ironclaw_reborn/tests/llm_gateway.rs
@@ -536,7 +536,7 @@ async fn gateway_repairs_oversized_provider_tool_arguments_before_registration()
                     id: "call_1".to_string(),
                     name: "demo__echo".to_string(),
                     arguments: serde_json::json!({"message":"one"}),
-                    reasoning: None,
+                    reasoning: Some("valid call reasoning".to_string()),
                     signature: None,
                     arguments_parse_error: None,
                 },
@@ -544,7 +544,7 @@ async fn gateway_repairs_oversized_provider_tool_arguments_before_registration()
                     id: "call_2".to_string(),
                     name: "demo__echo".to_string(),
                     arguments: serde_json::json!({"message": oversized_message}),
-                    reasoning: None,
+                    reasoning: Some("oversized call reasoning".to_string()),
                     signature: None,
                     arguments_parse_error: None,
                 },
@@ -580,6 +580,12 @@ async fn gateway_repairs_oversized_provider_tool_arguments_before_registration()
         .await
         .unwrap();
 
+    let usage = response
+        .usage
+        .expect("repaired response reports accumulated provider usage");
+    assert_eq!(usage.input_tokens, 3);
+    assert_eq!(usage.output_tokens, 3);
+
     let ParentLoopOutput::AssistantReply(reply) = response.output else {
         panic!("expected repaired assistant reply");
     };
@@ -599,10 +605,19 @@ async fn gateway_repairs_oversized_provider_tool_arguments_before_registration()
         .expect("tool calls replayed");
     assert_eq!(repair_tool_calls.len(), 2);
     assert_eq!(
+        repair_tool_calls[0].arguments,
+        serde_json::json!({"message":"one"})
+    );
+    assert_eq!(
         repair_tool_calls[1].arguments,
         serde_json::json!({
             "error": "arguments omitted because they exceeded the host provider-tool limit"
         })
+    );
+    assert!(
+        repair_tool_calls
+            .iter()
+            .all(|call| call.reasoning.is_none())
     );
     let repair_tool_result = repair_messages
         .iter()

--- a/crates/ironclaw_reborn/tests/llm_gateway.rs
+++ b/crates/ironclaw_reborn/tests/llm_gateway.rs
@@ -1,4 +1,7 @@
-use std::sync::{Arc, Mutex};
+use std::{
+    collections::VecDeque,
+    sync::{Arc, Mutex},
+};
 
 use async_trait::async_trait;
 use ironclaw_host_api::{AgentId, CapabilityId, ProjectId, TenantId, ThreadId, UserId};
@@ -523,40 +526,96 @@ async fn gateway_rejects_unknown_provider_tool_call_before_registration() {
 }
 
 #[tokio::test]
-async fn gateway_rejects_invalid_provider_tool_batch_before_any_registration() {
-    let provider = Arc::new(ToolAwareProvider::tool_calls(vec![
-        ToolCall {
-            id: "call_1".to_string(),
-            name: "demo__echo".to_string(),
-            arguments: serde_json::json!({"message":"one"}),
-            reasoning: None,
-            signature: None,
-            arguments_parse_error: None,
+async fn gateway_repairs_oversized_provider_tool_arguments_before_registration() {
+    let oversized_message = "x".repeat(20 * 1024);
+    let provider = Arc::new(ToolAwareProvider::tool_response_sequence(vec![
+        ToolCompletionResponse {
+            content: None,
+            tool_calls: vec![
+                ToolCall {
+                    id: "call_1".to_string(),
+                    name: "demo__echo".to_string(),
+                    arguments: serde_json::json!({"message":"one"}),
+                    reasoning: None,
+                    signature: None,
+                    arguments_parse_error: None,
+                },
+                ToolCall {
+                    id: "call_2".to_string(),
+                    name: "demo__echo".to_string(),
+                    arguments: serde_json::json!({"message": oversized_message}),
+                    reasoning: None,
+                    signature: None,
+                    arguments_parse_error: None,
+                },
+            ],
+            input_tokens: 1,
+            output_tokens: 1,
+            finish_reason: FinishReason::ToolUse,
+            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: 0,
+            reasoning: Some("response reasoning".to_string()),
         },
-        ToolCall {
-            id: "call_2".to_string(),
-            name: "demo__echo".to_string(),
-            arguments: serde_json::json!({"message":"x".repeat(20 * 1024)}),
+        ToolCompletionResponse {
+            content: Some("Finished after repair.".to_string()),
+            tool_calls: Vec::new(),
+            input_tokens: 2,
+            output_tokens: 2,
+            finish_reason: FinishReason::Stop,
+            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: 0,
             reasoning: None,
-            signature: None,
-            arguments_parse_error: None,
         },
     ]));
     let gateway = LlmProviderModelGateway::with_provider_identity(
         STATIC_PROVIDER_ID,
-        provider,
+        provider.clone(),
         LlmModelProfilePolicy::new()
             .allow_model_profile(interactive_model(), Some("host-selected-model".to_string())),
     );
     let capabilities = Arc::new(GatewayCapabilityPort::with_tool_surface());
 
-    let error = gateway
+    let response = gateway
         .stream_model_with_capabilities(model_request(interactive_model()), capabilities.clone())
         .await
-        .unwrap_err();
+        .unwrap();
 
-    assert_eq!(error.kind, HostManagedModelErrorKind::InvalidOutput);
+    let ParentLoopOutput::AssistantReply(reply) = response.output else {
+        panic!("expected repaired assistant reply");
+    };
+    assert_eq!(reply.content, "Finished after repair.");
     assert!(capabilities.registered.lock().unwrap().is_empty());
+
+    let tool_requests = provider.tool_requests.lock().unwrap();
+    assert_eq!(tool_requests.len(), 2);
+    let repair_messages = &tool_requests[1].messages;
+    let repair_assistant = repair_messages
+        .iter()
+        .find(|message| message.role == Role::Assistant && message.tool_calls.is_some())
+        .expect("repair request includes assistant tool call replay");
+    let repair_tool_calls = repair_assistant
+        .tool_calls
+        .as_ref()
+        .expect("tool calls replayed");
+    assert_eq!(repair_tool_calls.len(), 2);
+    assert_eq!(
+        repair_tool_calls[1].arguments,
+        serde_json::json!({
+            "error": "arguments omitted because they exceeded the host provider-tool limit"
+        })
+    );
+    let repair_tool_result = repair_messages
+        .iter()
+        .find(|message| {
+            message.role == Role::Tool && message.tool_call_id.as_deref() == Some("call_2")
+        })
+        .expect("repair request includes rejected tool result");
+    assert!(
+        repair_tool_result
+            .content
+            .contains("provider tool arguments exceed 16384 bytes")
+    );
+    assert!(!repair_tool_result.content.contains("xxxxx"));
 }
 
 #[tokio::test]
@@ -2688,7 +2747,7 @@ struct ToolAwareProvider {
     complete_requests: Mutex<Vec<CompletionRequest>>,
     tool_requests: Mutex<Vec<ToolCompletionRequest>>,
     plain_response: Mutex<Option<CompletionResponse>>,
-    tool_response: Mutex<Option<ToolCompletionResponse>>,
+    tool_responses: Mutex<VecDeque<ToolCompletionResponse>>,
 }
 
 impl ToolAwareProvider {
@@ -2705,7 +2764,7 @@ impl ToolAwareProvider {
                 cache_read_input_tokens: 0,
                 cache_creation_input_tokens: 0,
             })),
-            tool_response: Mutex::new(None),
+            tool_responses: Mutex::new(VecDeque::new()),
         }
     }
 
@@ -2736,11 +2795,15 @@ impl ToolAwareProvider {
     }
 
     fn tool_response(response: ToolCompletionResponse) -> Self {
+        Self::tool_response_sequence(vec![response])
+    }
+
+    fn tool_response_sequence(responses: Vec<ToolCompletionResponse>) -> Self {
         Self {
             complete_requests: Mutex::new(Vec::new()),
             tool_requests: Mutex::new(Vec::new()),
             plain_response: Mutex::new(None),
-            tool_response: Mutex::new(Some(response)),
+            tool_responses: Mutex::new(responses.into()),
         }
     }
 }
@@ -2771,10 +2834,10 @@ impl LlmProvider for ToolAwareProvider {
     ) -> Result<ToolCompletionResponse, LlmError> {
         self.tool_requests.lock().unwrap().push(request);
         Ok(self
-            .tool_response
+            .tool_responses
             .lock()
             .unwrap()
-            .take()
+            .pop_front()
             .expect("tool response configured"))
     }
 }

--- a/crates/ironclaw_safety/src/lib.rs
+++ b/crates/ironclaw_safety/src/lib.rs
@@ -27,7 +27,8 @@ pub use leak_detector::{
 pub use policy::{Policy, PolicyAction, PolicyRule, Severity};
 pub use prompt_validation::{PromptSafetyRejection, validate_trusted_trigger_prompt};
 pub use provider_validation::{
-    PROVIDER_TOOL_NAME_MAX_BYTES, ProviderValidationError,
+    PROVIDER_ARGUMENTS_MAX_BYTES, PROVIDER_TOOL_NAME_MAX_BYTES, ProviderValidationError,
+    is_provider_arguments_too_large_summary, provider_arguments_exceed_max_bytes,
     validate_optional_provider_metadata_text, validate_provider_arguments,
     validate_provider_identity, validate_provider_token, validate_provider_tool_name,
 };

--- a/crates/ironclaw_safety/src/provider_validation.rs
+++ b/crates/ironclaw_safety/src/provider_validation.rs
@@ -3,8 +3,7 @@ use std::sync::OnceLock;
 use crate::LeakDetector;
 
 pub const PROVIDER_TOOL_NAME_MAX_BYTES: usize = 64;
-
-const PROVIDER_ARGUMENTS_MAX_BYTES: usize = 16 * 1024;
+pub const PROVIDER_ARGUMENTS_MAX_BYTES: usize = 16 * 1024;
 const PROVIDER_ARGUMENTS_MAX_DEPTH: usize = 16;
 
 const SENSITIVE_PROVIDER_TEXT_MARKERS: [&str; 18] = [
@@ -122,11 +121,25 @@ pub fn validate_provider_arguments(
         .map_err(|error| ProviderValidationError::new(error.to_string()))?
         .len();
     if arguments_len > PROVIDER_ARGUMENTS_MAX_BYTES {
-        return Err(ProviderValidationError::new(format!(
-            "provider tool arguments exceed {PROVIDER_ARGUMENTS_MAX_BYTES} bytes"
-        )));
+        return Err(ProviderValidationError::new(
+            provider_arguments_too_large_summary(),
+        ));
     }
     validate_provider_json_value(arguments, "provider arguments", 0)
+}
+
+pub fn provider_arguments_exceed_max_bytes(arguments: &serde_json::Value) -> bool {
+    serde_json::to_vec(arguments)
+        .map(|bytes| bytes.len() > PROVIDER_ARGUMENTS_MAX_BYTES)
+        .unwrap_or(false)
+}
+
+pub fn is_provider_arguments_too_large_summary(value: &str) -> bool {
+    value == provider_arguments_too_large_summary()
+}
+
+fn provider_arguments_too_large_summary() -> String {
+    format!("provider tool arguments exceed {PROVIDER_ARGUMENTS_MAX_BYTES} bytes")
 }
 
 pub fn validate_optional_provider_metadata_text(
@@ -264,6 +277,16 @@ mod tests {
         .expect_err("non-whitespace control character should fail");
 
         assert!(error.to_string().contains("NUL/control characters"));
+    }
+
+    #[test]
+    fn provider_arguments_too_large_summary_matches_validator_error() {
+        let arguments = serde_json::json!({"content": "x".repeat(PROVIDER_ARGUMENTS_MAX_BYTES)});
+        assert!(provider_arguments_exceed_max_bytes(&arguments));
+
+        let error = validate_provider_arguments(&arguments)
+            .expect_err("arguments exceeding the provider byte limit should fail");
+        assert!(is_provider_arguments_too_large_summary(&error.to_string()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Repair provider tool-call batches when host validation rejects oversized arguments before capability registration.
- Replay the rejected assistant tool calls with oversized arguments replaced by a safe marker, then ask the provider to retry with smaller arguments or answer directly.
- Keep the repair fail-closed: if the retry still returns invalid tool output, the gateway returns the original validation path instead of executing tools.
- Add regression coverage proving oversized provider arguments are repaired before any tool registration/execution.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [x] Security
- [ ] Dependencies

## Linked Issue

Closes #4751

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [ ] `cargo build`
- [x] Relevant tests pass: `cargo test -p ironclaw_reborn --features root-llm-provider --test llm_gateway gateway_repairs_oversized_provider_tool_arguments_before_registration`
- [ ] `cargo test --features integration` if database-backed or integration behavior changed
- [ ] Manual testing: Not applicable; live LLM testing cannot reliably force oversized provider tool arguments without risking real tool calls.
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

Additional validation:
- `git diff --check`

## Security Impact

Yes. This touches the provider-tool boundary before capability registration/execution. Oversized provider tool arguments are not registered or executed; they are replaced with a safe marker in a single repair retry. The retry remains fail-closed if provider output is still invalid.

## Database Impact

None.

## Blast Radius

Limited to `ironclaw_reborn` model gateway handling of provider tool-call output and the `llm_gateway` regression test fixture. Normal assistant replies and valid tool calls should continue through the existing path.

## Rollback Plan

Revert this PR to restore the previous behavior where oversized provider tool arguments fail immediately during host validation.

## Review Follow-Through

Reviewer judgment requested on whether repair should remain scoped to the current host-validation safe summary only, or also cover provider-adapter `LlmError::InvalidResponse` shapes in a later follow-up.

---

**Review track**: C

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic repair-and-retry when provider tool arguments exceed size limits, recovering responses and preserving token accounting from the rejected attempt.
  * Repaired flows now return a repaired assistant reply when appropriate and retry provider calls with truncated/omitted argument payloads to avoid repeat failures.

* **Tests**
  * Added end-to-end tests validating oversized-tool-argument detection, repaired retry behavior, and correct token usage accounting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->