### PR TITLE
ci: run Reborn E2E in the merge queue with internal scope gating

### DIFF
--- a/.github/workflows/reborn-e2e.yml
+++ b/.github/workflows/reborn-e2e.yml
@@ -8,19 +8,20 @@ on:
         required: false
         type: string
   workflow_dispatch:
+  # Scope gating for pull_request and merge_group happens in the `changes`
+  # job below (via scripts/ci/classify-test-scope.sh) instead of workflow-level
+  # `paths:` filters: merge_group events ignore path filters entirely, and a
+  # path-filtered workflow never reports a status on non-matching PRs, which
+  # breaks required-check protection. The `reborn-e2e` roll-up job always
+  # reports, passing fast when the change is out of scope.
   pull_request:
     branches:
       - main
-    paths:
-      - "crates/ironclaw_*/**"
-      - "docs/reborn/**"
-      - "scripts/reborn-e2e-rust.sh"
-      - "tests/e2e/**"
-      - "build.rs"
-      - "providers.json"
-      - "Cargo.toml"
-      - "Cargo.lock"
-      - ".github/workflows/reborn-e2e.yml"
+  merge_group:
+    branches:
+      - main
+    types:
+      - checks_requested
   push:
     branches:
       - main
@@ -43,8 +44,55 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect Reborn E2E scope
+    runs-on: ubuntu-latest
+    outputs:
+      docs_only: ${{ steps.non_diff.outputs.docs_only || steps.diff.outputs.docs_only }}
+      has_reborn_tests: ${{ steps.non_diff.outputs.has_reborn_tests || steps.diff.outputs.has_reborn_tests }}
+      has_e2e_harness: ${{ steps.non_diff.outputs.has_e2e_harness || steps.diff.outputs.has_e2e_harness }}
+    steps:
+      - id: non_diff
+        if: github.event_name != 'pull_request' && github.event_name != 'merge_group'
+        run: |
+          echo "docs_only=false" >> "$GITHUB_OUTPUT"
+          echo "has_reborn_tests=true" >> "$GITHUB_OUTPUT"
+          echo "has_e2e_harness=true" >> "$GITHUB_OUTPUT"
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - id: diff
+        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+        env:
+          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+        run: |
+          CHANGED_FILES="$(git diff --name-only "$BASE_SHA"..."$HEAD_SHA")"
+
+          echo "Changed files:"
+          if [ -n "$CHANGED_FILES" ]; then
+            printf '%s\n' "$CHANGED_FILES"
+          else
+            echo "<none>"
+          fi
+
+          printf '%s\n' "$CHANGED_FILES" | scripts/ci/classify-test-scope.sh >> "$GITHUB_OUTPUT"
+
+          # The gateway and WebUI v2 smoke jobs run on the Python E2E harness,
+          # so harness changes outside the reborn-specific scenario files must
+          # still trigger this workflow.
+          if printf '%s\n' "$CHANGED_FILES" | grep -q '^tests/e2e/'; then
+            echo "has_e2e_harness=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_e2e_harness=false" >> "$GITHUB_OUTPUT"
+          fi
+
   rust-reborn:
     name: Rust Reborn (${{ matrix.group }})
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true' && (needs.changes.outputs.has_reborn_tests == 'true' || needs.changes.outputs.has_e2e_harness == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 35
     strategy:
@@ -77,6 +125,8 @@ jobs:
 
   gateway-smoke:
     name: Reborn gateway smoke
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true' && (needs.changes.outputs.has_reborn_tests == 'true' || needs.changes.outputs.has_e2e_harness == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -122,6 +172,8 @@ jobs:
 
   webui-v2-smoke:
     name: Reborn WebUI v2 smoke
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true' && (needs.changes.outputs.has_reborn_tests == 'true' || needs.changes.outputs.has_e2e_harness == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -170,12 +222,28 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     needs:
+      - changes
       - rust-reborn
       - gateway-smoke
       - webui-v2-smoke
     steps:
       - name: Check Reborn E2E jobs
         run: |
+          if [[ "${{ needs.changes.result }}" != "success" ]]; then
+            echo "Scope detection failed: ${{ needs.changes.result }}"
+            exit 1
+          fi
+
+          if [[ "${{ needs.changes.outputs.docs_only }}" == "true" ]]; then
+            echo "Docs-only change detected — Reborn E2E roll-up passes fast"
+            exit 0
+          fi
+
+          if [[ "${{ needs.changes.outputs.has_reborn_tests }}" != "true" && "${{ needs.changes.outputs.has_e2e_harness }}" != "true" ]]; then
+            echo "No Reborn E2E scope detected — Reborn E2E roll-up passes fast"
+            exit 0
+          fi
+
           if [[ "${{ needs.rust-reborn.result }}" != "success" ]]; then
             echo "Rust Reborn E2E failed"
             exit 1


### PR DESCRIPTION
## Summary

The merge queue currently runs zero Reborn E2E: [`reborn-e2e.yml`](https://github.com/nearai/ironclaw/blob/main/.github/workflows/reborn-e2e.yml) has no `merge_group` trigger, so Reborn changes merge without the deterministic Rust contract gate or the gateway/WebUI v2 Playwright smoke running against the queued (post-rebase) state. This PR closes that gap.

### Changes

- **Add `merge_group` trigger** (`checks_requested` on `main`), matching `reborn-tests.yml`.
- **Replace the `pull_request` workflow-level `paths:` filter with an internal `changes` scope-detection job**, for two reasons:
  - `merge_group` events ignore `paths:` filters entirely — a trigger-only change would run the full gate on every queue entry, including docs-only and legacy-only changes.
  - A path-filtered workflow never reports a status on non-matching PRs, which makes its check impossible to require in branch protection.

  The `changes` job classifies the PR/merge-group diff via `scripts/ci/classify-test-scope.sh` (same pattern and same `BASE_SHA`/`HEAD_SHA` handling as `reborn-tests.yml`), plus a workflow-local `has_e2e_harness` output (`tests/e2e/**`) so Python harness changes outside the reborn-specific scenario files still trigger the smoke jobs — preserving the old path filter's coverage.
- **Roll-up job `Reborn E2E` now always reports**: passes fast on docs-only / out-of-scope changes, fails if scope detection or any gated job fails. This makes it safe to add as a **required status check**.
- `push` keeps its path filters (required checks don't apply to push); `workflow_call` (nightly, #4829) and `workflow_dispatch` run the full gate via the non-diff branch of the `changes` job, unchanged in behavior.

### Post-merge action required

Add **`Reborn E2E`** (the roll-up job) to the required status checks for `main` — the merge queue only waits on required checks, so without that settings change this workflow runs in the queue but does not block it.

### Verification

- `python3 yaml.safe_load` parses the workflow; triggers = `workflow_call, workflow_dispatch, pull_request, merge_group, push`; jobs = `changes, rust-reborn, gateway-smoke, webui-v2-smoke, reborn-e2e`.
- Gating expressions and diff classification copied from the proven `reborn-tests.yml` `changes` job (already running on every PR and merge-queue entry).
- Not verified live: an actual merge-queue dispatch of this workflow — observe the first queued PR after merge, or trigger `workflow_dispatch` for a full-gate dry run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * E2E test workflow now dynamically determines test scope based on changed files
  * Documentation-only changes skip E2E test execution
  * Updated merge group configuration for the main branch

<!-- end of auto-generated comment: release notes by coderabbit.ai -->