### PR TITLE
fix(slack): single-flight gate delivery per run_id (resolution-ack fanout)

### DIFF
--- a/crates/ironclaw_reborn_composition/src/slack_delivery.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_delivery.rs
@@ -151,6 +151,29 @@ pub struct SlackFinalReplyDeliveryObserver {
     active_delivery_run_ids: Mutex<HashSet<TurnRunId>>,
 }
 
+/// RAII guard that removes a `run_id` from `active_delivery_run_ids` on drop.
+///
+/// Acquired before the delivery semaphore permit so that a concurrent ack for
+/// the same run_id is rejected immediately — without competing for a permit and
+/// without the TOCTOU window that existed when the permit was acquired first.
+///
+/// Panic-safe: `Drop` uses `unwrap_or_else(|e| e.into_inner())` to tolerate a
+/// poisoned mutex, so the run_id is always removed even if `deliver_final_reply`
+/// panics.
+struct RunDeliveryGuard<'a> {
+    set: &'a Mutex<HashSet<TurnRunId>>,
+    run_id: TurnRunId,
+}
+
+impl Drop for RunDeliveryGuard<'_> {
+    fn drop(&mut self) {
+        self.set
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(&self.run_id);
+    }
+}
+
 impl SlackFinalReplyDeliveryObserver {
     pub fn new(services: SlackFinalReplyDeliveryServices) -> Self {
         Self::with_settings(services, SlackFinalReplyDeliverySettings::default())
@@ -1065,13 +1088,6 @@ impl ImmediateAckWorkflowObserver for SlackFinalReplyDeliveryObserver {
             }
             return;
         }
-        let Ok(_permit) = self.delivery_permits.clone().acquire_owned().await else {
-            tracing::warn!(
-                target = "ironclaw::reborn::slack_delivery",
-                "Slack final reply delivery skipped because delivery semaphore was closed"
-            );
-            return;
-        };
         // Single-flight guard: at most one live delivery loop per run_id.
         //
         // A gate-resolution ack (ApprovalResolution(Allow) / AuthResolution(Allowed))
@@ -1084,8 +1100,16 @@ impl ImmediateAckWorkflowObserver for SlackFinalReplyDeliveryObserver {
         // `should_deliver_after_ack` only filters Deny resolutions; Allow resolutions
         // pass through here. We guard by run_id rather than by ack type so the fix
         // is robust to future ack variants that may also target an existing run.
-        let run_id_for_guard = submitted_run_id(&ack);
-        if let Some(run_id) = run_id_for_guard {
+        //
+        // IMPORTANT: the guard is checked and inserted BEFORE acquiring the delivery
+        // semaphore permit. Without this ordering, a second ack (L2) for the same
+        // run_id could block on the permit while L1 is delivering; when L1 releases
+        // the permit and removes the run_id, L2 would wake and pass a now-empty guard
+        // set — the exact TOCTOU race this ordering closes.
+        //
+        // The `RunDeliveryGuard` RAII type ensures the run_id is removed on drop even
+        // if `deliver_final_reply` panics, preventing a permanent delivery block.
+        let _delivery_guard = if let Some(run_id) = submitted_run_id(&ack) {
             let already_delivering = {
                 let mut guard = self
                     .active_delivery_run_ids
@@ -1106,16 +1130,25 @@ impl ImmediateAckWorkflowObserver for SlackFinalReplyDeliveryObserver {
                 );
                 return;
             }
-        }
+            Some(RunDeliveryGuard {
+                set: &self.active_delivery_run_ids,
+                run_id,
+            })
+        } else {
+            None
+        };
+        let Ok(_permit) = self.delivery_permits.clone().acquire_owned().await else {
+            tracing::warn!(
+                target = "ironclaw::reborn::slack_delivery",
+                "Slack final reply delivery skipped because delivery semaphore was closed"
+            );
+            return;
+        };
         let delivery_result = self.deliver_final_reply(envelope.clone(), ack).await;
-        // Release the single-flight guard for this run before handling the error so
-        // a future retry (e.g. after a process restart) is not permanently blocked.
-        if let Some(run_id) = run_id_for_guard {
-            self.active_delivery_run_ids
-                .lock()
-                .unwrap_or_else(|e| e.into_inner())
-                .remove(&run_id);
-        }
+        // `_delivery_guard` is dropped here automatically, removing the run_id from
+        // `active_delivery_run_ids` even if `deliver_final_reply` returned an error.
+        // Explicit drop makes the cleanup point visible at the call site.
+        drop(_delivery_guard);
         if let Err(error) = delivery_result {
             tracing::warn!(
                 target = "ironclaw::reborn::slack_delivery",
@@ -5308,5 +5341,181 @@ mod tests {
             recorded[0].scope, expected_scope,
             "GetRunStateRequest scope must be derived from the authorized binding"
         );
+    }
+
+    /// A delivery that errors or times out must NOT leave the run_id in
+    /// `active_delivery_run_ids` permanently. A subsequent `observe_workflow_ack`
+    /// for the same run_id must proceed to delivery instead of being rejected by
+    /// the guard.
+    ///
+    /// Test setup: the coordinator always returns `Running`; `max_wait = 1 ms`
+    /// forces a timeout on every attempt. After the first timeout the RAII guard
+    /// drops the run_id, so the second attempt reaches `wait_for_actionable` and
+    /// polls `get_run_state` at least once more.
+    ///
+    /// If the guard were NOT released after an error, the second call would return
+    /// early without ever calling `get_run_state`, and the total call count would
+    /// equal the first attempt's count.
+    #[tokio::test]
+    async fn guard_is_released_after_delivery_error_so_subsequent_ack_proceeds() {
+        let install = "test-install";
+        let coordinator = Arc::new(ScriptedTurnCoordinator::with_single_status(
+            TurnStatus::Running,
+        ));
+        let egress = Arc::new(FakeProtocolHttpEgress::new(vec!["slack.com".to_string()]));
+        egress.allow_credential_handle("slack_bot_token");
+        let outbound = Arc::new(InMemoryOutboundStateStore::default());
+
+        // Build an observer with a very short max_wait so delivery times out quickly.
+        let thread_service = Arc::new(InMemorySessionThreadService::default());
+        let services = SlackFinalReplyDeliveryServices {
+            binding_service: Arc::new(
+                ironclaw_product_workflow::FakeConversationBindingService::new(),
+            ),
+            thread_service,
+            turn_coordinator: coordinator.clone(),
+            outbound_store: outbound.clone(),
+            route_store: Arc::new(InMemoryDeliveredGateRouteStore::default()),
+            communication_preferences: outbound,
+            adapter: test_adapter(install),
+            egress: egress.clone(),
+            delivery_sink: Arc::new(FakeOutboundDeliverySink::default()),
+            auth_challenges: None,
+        };
+        let settings = SlackFinalReplyDeliverySettings {
+            poll_interval: std::time::Duration::ZERO,
+            max_wait: std::time::Duration::from_millis(1),
+            max_concurrent_deliveries: NonZeroUsize::new(4).unwrap(),
+            max_pending_deliveries: NonZeroUsize::new(8).unwrap(),
+        };
+        let observer = SlackFinalReplyDeliveryObserver::with_settings(services, settings);
+
+        let run_id = TurnRunId::new();
+        let ack = ProductInboundAck::Accepted {
+            accepted_message_ref: AcceptedMessageRef::new("msg:guard-release-test")
+                .expect("accepted message ref"), // safety: static test ref is valid.
+            submitted_run_id: run_id,
+        };
+        let env = envelope(user_message_payload());
+
+        // First delivery: times out; guard must be released on return.
+        observer
+            .observe_workflow_ack(env.clone(), ack.clone())
+            .await;
+        let calls_after_first = {
+            let c = coordinator.calls.lock().expect("coordinator calls lock");
+            *c
+        };
+        assert!(
+            calls_after_first >= 1,
+            "first delivery attempt must poll get_run_state at least once; got {calls_after_first}"
+        );
+
+        // Second delivery for the same run_id: if the guard were not released the
+        // observer would return early and get_run_state would not be called again.
+        observer.observe_workflow_ack(env, ack).await;
+        let calls_after_second = {
+            let c = coordinator.calls.lock().expect("coordinator calls lock");
+            *c
+        };
+        assert!(
+            calls_after_second > calls_after_first,
+            "second delivery attempt must reach get_run_state (guard was not released after the first error); \
+             calls after first={calls_after_first}, calls after second={calls_after_second}"
+        );
+    }
+
+    /// Single-flight fanout regression: while one delivery loop is in flight for a
+    /// run_id, a second ack carrying the SAME run_id must be rejected by the guard
+    /// WITHOUT competing for the delivery semaphore permit.
+    ///
+    /// Real-world case: an `AuthResolution(Allowed)` / `ApprovalResolution(Allow)`
+    /// resolution resumes the pre-existing run and is ack'd with the original
+    /// `submitted_run_id`. The original loop is still watching, so a second loop
+    /// would post gate N a second time (N resolutions ⇒ N+1 loops).
+    ///
+    /// This locks the TOCTOU ordering specifically: with `max_concurrent_deliveries
+    /// = 1`, the first (blocked) delivery holds the only permit. If the guard were
+    /// checked AFTER acquiring the permit, the second call would block on the
+    /// semaphore and the `timeout` below would elapse. Because the guard is checked
+    /// and inserted BEFORE the permit, the second call returns immediately.
+    #[tokio::test]
+    async fn concurrent_ack_for_same_run_id_is_rejected_before_acquiring_permit() {
+        let install = "test-install";
+        // Always-Running coordinator + large max_wait ⇒ the first delivery blocks in
+        // wait_for_actionable, holding the single delivery permit for the test's life.
+        let coordinator = Arc::new(ScriptedTurnCoordinator::with_single_status(
+            TurnStatus::Running,
+        ));
+        let egress = Arc::new(FakeProtocolHttpEgress::new(vec!["slack.com".to_string()]));
+        egress.allow_credential_handle("slack_bot_token");
+        let outbound = Arc::new(InMemoryOutboundStateStore::default());
+        let thread_service = Arc::new(InMemorySessionThreadService::default());
+        let services = SlackFinalReplyDeliveryServices {
+            binding_service: Arc::new(
+                ironclaw_product_workflow::FakeConversationBindingService::new(),
+            ),
+            thread_service,
+            turn_coordinator: coordinator.clone(),
+            outbound_store: outbound.clone(),
+            route_store: Arc::new(InMemoryDeliveredGateRouteStore::default()),
+            communication_preferences: outbound,
+            adapter: test_adapter(install),
+            egress: egress.clone(),
+            delivery_sink: Arc::new(FakeOutboundDeliverySink::default()),
+            auth_challenges: None,
+        };
+        let settings = SlackFinalReplyDeliverySettings {
+            poll_interval: std::time::Duration::from_millis(1),
+            max_wait: std::time::Duration::from_secs(60),
+            max_concurrent_deliveries: NonZeroUsize::new(1).unwrap(),
+            max_pending_deliveries: NonZeroUsize::new(8).unwrap(),
+        };
+        let observer = Arc::new(SlackFinalReplyDeliveryObserver::with_settings(
+            services, settings,
+        ));
+
+        let run_id = TurnRunId::new();
+        let make_ack = |slug: &str| ProductInboundAck::Accepted {
+            accepted_message_ref: AcceptedMessageRef::new(slug).expect("accepted message ref"),
+            submitted_run_id: run_id,
+        };
+        let env = envelope(user_message_payload());
+
+        // First delivery: acquires the guard + the only permit, then blocks.
+        let first = {
+            let observer = observer.clone();
+            let env = env.clone();
+            let ack = make_ack("msg:first");
+            tokio::spawn(async move { observer.observe_workflow_ack(env, ack).await })
+        };
+
+        // Wait until the first loop registered the run_id in the single-flight set.
+        loop {
+            let registered = observer
+                .active_delivery_run_ids
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .contains(&run_id);
+            if registered {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+        }
+
+        // Second ack for the SAME run_id while the first still holds the permit.
+        // Must return promptly via the guard skip, NOT block on the semaphore.
+        let second = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            observer.observe_workflow_ack(env, make_ack("msg:second")),
+        )
+        .await;
+        assert!(
+            second.is_ok(),
+            "second ack for an in-flight run_id must be rejected by the single-flight guard \
+             before acquiring the delivery permit; it blocked on the semaphore instead"
+        );
+
+        first.abort();
     }
 }

--- a/crates/ironclaw_reborn_composition/src/slack_delivery.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_delivery.rs
@@ -139,6 +139,16 @@ pub struct SlackFinalReplyDeliveryObserver {
     /// Caps Slack API usage per blocked run; bounded FIFO eviction keeps memory O(1);
     /// a false-negative after eviction just means one extra hint, harmless.
     hint_seen: HintSeenSet,
+    /// Single-flight guard: at most one live `deliver_final_reply` loop per run_id.
+    ///
+    /// A gate-resolution ack (`ApprovalResolution(Allow)` / `AuthResolution(Allowed)`)
+    /// carries the same `submitted_run_id` as the original user-message ack because it
+    /// resumes the pre-existing run rather than creating a new one. Without this guard,
+    /// each resolution ack would spawn a second delivery loop for the same run while the
+    /// original loop is still watching — N resolutions ⇒ N+1 concurrent loops ⇒ gate N
+    /// posted N times. The original loop detects the unblock and posts the next gate
+    /// exactly once, so resolution-ack loops are always redundant duplicates.
+    active_delivery_run_ids: Mutex<HashSet<TurnRunId>>,
 }
 
 impl SlackFinalReplyDeliveryObserver {
@@ -155,6 +165,7 @@ impl SlackFinalReplyDeliveryObserver {
             settings,
             delivery_permits: Arc::new(Semaphore::new(settings.max_concurrent_deliveries.get())),
             hint_seen: Mutex::new((VecDeque::new(), HashSet::new())),
+            active_delivery_run_ids: Mutex::new(HashSet::new()),
         }
     }
 
@@ -1061,7 +1072,51 @@ impl ImmediateAckWorkflowObserver for SlackFinalReplyDeliveryObserver {
             );
             return;
         };
-        if let Err(error) = self.deliver_final_reply(envelope.clone(), ack).await {
+        // Single-flight guard: at most one live delivery loop per run_id.
+        //
+        // A gate-resolution ack (ApprovalResolution(Allow) / AuthResolution(Allowed))
+        // carries the same submitted_run_id as the original user-message ack because
+        // it resumes the pre-existing run. The original loop is still alive and will
+        // observe the unblock on its next poll, posting the next gate or final reply
+        // exactly once. Spawning a second loop for the same run_id would produce
+        // duplicate posts (N resolutions ⇒ N+1 loops ⇒ gate N posted N times).
+        //
+        // `should_deliver_after_ack` only filters Deny resolutions; Allow resolutions
+        // pass through here. We guard by run_id rather than by ack type so the fix
+        // is robust to future ack variants that may also target an existing run.
+        let run_id_for_guard = submitted_run_id(&ack);
+        if let Some(run_id) = run_id_for_guard {
+            let already_delivering = {
+                let mut guard = self
+                    .active_delivery_run_ids
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner());
+                if guard.contains(&run_id) {
+                    true
+                } else {
+                    guard.insert(run_id);
+                    false
+                }
+            };
+            if already_delivering {
+                tracing::debug!(
+                    target = "ironclaw::reborn::slack_delivery",
+                    %run_id,
+                    "skipping redundant delivery loop: a loop is already watching this run"
+                );
+                return;
+            }
+        }
+        let delivery_result = self.deliver_final_reply(envelope.clone(), ack).await;
+        // Release the single-flight guard for this run before handling the error so
+        // a future retry (e.g. after a process restart) is not permanently blocked.
+        if let Some(run_id) = run_id_for_guard {
+            self.active_delivery_run_ids
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .remove(&run_id);
+        }
+        if let Err(error) = delivery_result {
             tracing::warn!(
                 target = "ironclaw::reborn::slack_delivery",
                 error = %error,

--- a/crates/ironclaw_reborn_composition/src/slack_serve/e2e_tests.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_serve/e2e_tests.rs
@@ -191,7 +191,16 @@ impl Harness {
 }
 
 async fn build_harness(mode: TurnMode) -> Harness {
-    build_harness_with_actor_user_resolver(mode, static_personal_actor_user_resolver()).await
+    build_harness_with_max_wait(mode, Duration::from_secs(2)).await
+}
+
+async fn build_harness_with_max_wait(mode: TurnMode, max_wait: Duration) -> Harness {
+    build_harness_with_actor_user_resolver_and_max_wait(
+        mode,
+        static_personal_actor_user_resolver(),
+        max_wait,
+    )
+    .await
 }
 
 async fn build_harness_with_actor_user_resolver(
@@ -202,10 +211,33 @@ async fn build_harness_with_actor_user_resolver(
         .await
 }
 
+async fn build_harness_with_actor_user_resolver_and_max_wait(
+    mode: TurnMode,
+    actor_user_resolver: Arc<dyn ProductActorUserResolver>,
+    max_wait: Duration,
+) -> Harness {
+    build_harness_with_full_settings(mode, actor_user_resolver, None, max_wait).await
+}
+
 async fn build_harness_with_actor_user_resolver_and_auth_challenges(
     mode: TurnMode,
     actor_user_resolver: Arc<dyn ProductActorUserResolver>,
     auth_challenges: Option<Arc<dyn AuthChallengeProvider>>,
+) -> Harness {
+    build_harness_with_full_settings(
+        mode,
+        actor_user_resolver,
+        auth_challenges,
+        Duration::from_secs(2),
+    )
+    .await
+}
+
+async fn build_harness_with_full_settings(
+    mode: TurnMode,
+    actor_user_resolver: Arc<dyn ProductActorUserResolver>,
+    auth_challenges: Option<Arc<dyn AuthChallengeProvider>>,
+    max_wait: Duration,
 ) -> Harness {
     let conversations = Arc::new(InMemoryConversationServices::default());
     let conversation_port: Arc<dyn ironclaw_conversations::ConversationBindingService> =
@@ -298,7 +330,7 @@ async fn build_harness_with_actor_user_resolver_and_auth_challenges(
         },
         SlackFinalReplyDeliverySettings {
             poll_interval: Duration::from_millis(1),
-            max_wait: Duration::from_secs(2),
+            max_wait,
             max_concurrent_deliveries: std::num::NonZeroUsize::new(4).expect("nonzero"), // safety: static test literal is non-zero.
             max_pending_deliveries: std::num::NonZeroUsize::new(16).expect("nonzero"), // safety: static test literal is non-zero.
         },
@@ -1140,6 +1172,97 @@ async fn slack_approval_reply_resumes_and_delivers_final_reply() {
     assert_eq!(approvals[0].gate_ref.as_str(), GATE);
 }
 
+/// Regression test: each gate prompt is posted exactly once even when the
+/// delivery loop for the original user message (L1) is still alive when the
+/// approval ack arrives.
+///
+/// Pre-fix behaviour (bug): the approval resolution ack carried the same
+/// `submitted_run_id` as the original user-message ack (it resumes the
+/// pre-existing run). `should_deliver_after_ack` returned `true` for
+/// `ApprovalResolution(Allow)`, so a second `deliver_final_reply` loop (L2)
+/// was spawned with `delivered_blocked_marker = None`. L2 immediately saw the
+/// run as `Completed` (the approval service calls `complete_run` inline) and
+/// posted the final reply; L1, still alive and polling, also saw `Completed`
+/// and posted it again. Result: 3 messages total (approval prompt + 2 final
+/// replies) instead of 2.
+///
+/// Post-fix behaviour: the single-flight guard in `observe_workflow_ack`
+/// detects that L1 is already watching `run_id` and returns early for L2.
+/// Only L1 delivers the final reply exactly once.
+///
+/// To keep L1 alive (not timed-out) when the approval ack arrives, we use a
+/// long `max_wait` (10 s) and poll for the approval prompt before posting
+/// the approve event, mirroring the pattern in
+/// `slack_dm_delivers_final_reply_after_auth_completes_outside_slack`.
+#[tokio::test]
+async fn gate_prompt_is_posted_exactly_once_when_approval_ack_races_live_delivery_loop() {
+    // Use a long max_wait so L1 is still alive when the approval ack arrives.
+    let harness =
+        build_harness_with_max_wait(TurnMode::BlockApproval, Duration::from_secs(10)).await;
+
+    // Post user message — L1 spawns, polls, sees BlockedApproval, posts the
+    // approval prompt, then waits for the run to advance.
+    let first = harness
+        .post_event(dm_message("Ev-fanout-block", "needs approval fanout"))
+        .await;
+    assert_eq!(first.status(), StatusCode::OK);
+
+    // Poll until the approval prompt appears (L1 has posted it and is looping).
+    for _ in 0..200 {
+        if harness.slack_messages().len() == 1 {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    let messages = harness.slack_messages();
+    assert_eq!(
+        messages.len(),
+        1,
+        "expected exactly one approval prompt before the approve event; got {}: {:?}",
+        messages.len(),
+        messages
+    );
+    assert!(
+        messages[0]["text"]
+            .as_str()
+            .is_some_and(|t| t.contains("Approval needed")),
+        "first message must be the approval prompt; got {:?}",
+        messages[0]["text"]
+    );
+
+    // Post the approve event while L1 is still alive.
+    // RecordingApprovalInteractionService::resolve immediately marks the run
+    // as Completed. Without the fix, the resolution ack spawns L2 which also
+    // sees Completed and posts a second final reply, giving 3 messages total.
+    let second = harness
+        .post_event(dm_message("Ev-fanout-approve", "approve"))
+        .await;
+    assert_eq!(second.status(), StatusCode::OK);
+
+    // Drain all tasks (L1 + the approval-ack task). L1 observes Completed and
+    // posts the final reply; the single-flight guard prevents L2 from also
+    // delivering, so the final reply is posted exactly once.
+    harness.drain().await;
+
+    let messages = harness.slack_messages();
+    assert_eq!(
+        messages.len(),
+        2,
+        "expected exactly 2 messages: approval prompt + final reply, not {} (duplicate final reply was posted without the fix)",
+        messages.len()
+    );
+    assert!(
+        messages[0]["text"]
+            .as_str()
+            .is_some_and(|t| t.contains("Approval needed")),
+        "messages[0] must be the approval prompt"
+    );
+    assert_eq!(
+        messages[1]["text"], "approved and finished",
+        "messages[1] must be the final reply"
+    );
+}
+
 #[tokio::test]
 async fn slack_thread_auth_deny_with_bot_mention_cancels_auth_gate_without_agent_turn() {
     let harness = build_harness(TurnMode::BlockAuth).await;
@@ -1835,6 +1958,9 @@ fn dm_message(event_id: &'static str, text: &'static str) -> &'static str {
         ("Ev-identity", "hello") => DM_IDENTITY,
         ("Ev-auth", "needs auth") => DM_AUTH,
         ("Ev-working", "think") => DM_WORKING,
+        // Gate-fanout regression fixtures
+        ("Ev-fanout-block", "needs approval fanout") => DM_FANOUT_BLOCK,
+        ("Ev-fanout-approve", "approve") => DM_FANOUT_APPROVE,
         _ => panic!("unknown fixture"),
     }
 }
@@ -1979,4 +2105,26 @@ const DM_APPROVE_EXPLICIT_GATE: &str = r#"{
   "api_app_id":"A-slack",
   "event_id":"Ev-approve-explicit",
   "event":{"type":"message","channel_type":"im","user":"U123","channel":"D123","text":"approve gate:approve-slack","ts":"1710000000.000005"}
+}"#;
+
+// ── Gate-fanout regression fixtures ──────────────────────────────────────────
+// Used by `gate_prompt_is_posted_exactly_once_when_approval_ack_races_live_delivery_loop`.
+// Distinct event_ids avoid idempotency-ledger collisions with all other fixtures.
+
+/// User message that triggers a BlockApproval turn (gate-fanout regression).
+const DM_FANOUT_BLOCK: &str = r#"{
+  "type":"event_callback",
+  "team_id":"T-A",
+  "api_app_id":"A-slack",
+  "event_id":"Ev-fanout-block",
+  "event":{"type":"message","channel_type":"im","user":"U123","channel":"D123","text":"needs approval fanout","ts":"1710000002.000001"}
+}"#;
+
+/// Approve event for the gate-fanout regression (resolves the BlockApproval gate).
+const DM_FANOUT_APPROVE: &str = r#"{
+  "type":"event_callback",
+  "team_id":"T-A",
+  "api_app_id":"A-slack",
+  "event_id":"Ev-fanout-approve",
+  "event":{"type":"message","channel_type":"im","user":"U123","channel":"D123","text":"approve","ts":"1710000002.000002"}
 }"#;

--- a/crates/ironclaw_reborn_composition/src/slack_serve/e2e_tests.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_serve/e2e_tests.rs
@@ -20,9 +20,12 @@ use ironclaw_outbound::{
     CommunicationPreferenceRepository, InMemoryOutboundStateStore, OutboundStateStore,
 };
 use ironclaw_product_adapters::{
-    AdapterInstallationId, DeliveryStatus, EgressCredentialHandle, EgressRequest, EgressResponse,
-    ExternalActorRef, OutboundDeliverySink, ProductAdapter, ProtocolHttpEgress,
-    ProtocolHttpEgressError,
+    AdapterInstallationId, AuthRequirement, AuthResolutionPayload, AuthResolutionResult,
+    DeliveryStatus, EgressCredentialHandle, EgressRequest, EgressResponse, ExternalActorRef,
+    ExternalConversationRef, ExternalEventId, OutboundDeliverySink, ParsedProductInbound,
+    ProductAdapter, ProductAdapterId, ProductInboundAck, ProductInboundEnvelope,
+    ProductInboundPayload, ProtocolAuthEvidence, ProtocolHttpEgress, ProtocolHttpEgressError,
+    TrustedInboundContext,
 };
 use ironclaw_product_workflow::{
     ApprovalInteractionActionView, ApprovalInteractionDecision, ApprovalInteractionScope,
@@ -50,7 +53,8 @@ use ironclaw_turns::{
     TurnError, TurnId, TurnRunId, TurnRunState, TurnScope, TurnStatus,
 };
 use ironclaw_wasm_product_adapters::{
-    HmacWebhookAuth, NativeProductAdapterRunner, NativeProductAdapterRunnerConfig, WebhookAuth,
+    HmacWebhookAuth, ImmediateAckWorkflowObserver, NativeProductAdapterRunner,
+    NativeProductAdapterRunnerConfig, WebhookAuth,
 };
 use tower::ServiceExt;
 
@@ -2128,3 +2132,293 @@ const DM_FANOUT_APPROVE: &str = r#"{
   "event_id":"Ev-fanout-approve",
   "event":{"type":"message","channel_type":"im","user":"U123","channel":"D123","text":"approve","ts":"1710000002.000002"}
 }"#;
+
+// ── Auth-resolution fanout regression fixtures ────────────────────────────────
+// Used by `auth_prompt_is_posted_exactly_once_when_auth_resolution_ack_races_live_delivery_loop`.
+// Distinct event_ids avoid idempotency-ledger collisions with all other fixtures.
+
+/// User message that triggers a BlockAuth turn (auth-fanout regression).
+const DM_AUTH_FANOUT_BLOCK: &str = r#"{
+  "type":"event_callback",
+  "team_id":"T-A",
+  "api_app_id":"A-slack",
+  "event_id":"Ev-auth-fanout-block",
+  "event":{"type":"message","channel_type":"im","user":"U123","channel":"D123","text":"needs auth fanout","ts":"1710000003.000001"}
+}"#;
+
+/// Build a `ProductInboundEnvelope` carrying an `AuthResolution(CallbackCompleted)` payload.
+///
+/// Mirrors the shape that the WebUI gate-resolve endpoint would produce when an
+/// OAuth callback completes and calls `observe_workflow_ack` directly (not via
+/// any Slack text command — the Slack adapter has no "auth allow" syntax).
+fn auth_resolution_allowed_envelope(callback_ref: &str) -> ProductInboundEnvelope {
+    let adapter_id = ProductAdapterId::new(ADAPTER).expect("adapter id"); // safety: static test adapter id is valid.
+    let installation_id = AdapterInstallationId::new(INSTALLATION).expect("installation id"); // safety: static test installation id is valid.
+    let evidence = ProtocolAuthEvidence::test_verified(
+        AuthRequirement::SharedSecretHeader {
+            header_name: SLACK_SIGNATURE_HEADER.to_string(),
+        },
+        installation_id.as_str(),
+    );
+    let context = TrustedInboundContext::from_verified_evidence(
+        adapter_id,
+        installation_id,
+        chrono::Utc::now(),
+        &evidence,
+    )
+    .expect("trusted context"); // safety: static test context is valid.
+    let payload = ProductInboundPayload::AuthResolution(
+        AuthResolutionPayload::new(
+            AUTH_GATE,
+            AuthResolutionResult::CallbackCompleted {
+                callback_ref: callback_ref.to_string(),
+            },
+        )
+        .expect("auth resolution payload"), // safety: static test auth gate ref is valid.
+    );
+    let parsed = ParsedProductInbound::new(
+        ExternalEventId::new("evt:auth-fanout-resolve").expect("event id"), // safety: static test event id is valid.
+        ExternalActorRef::new(SLACK_USER_ACTOR_KIND, SLACK_USER, None::<String>)
+            .expect("actor ref"), // safety: static test actor ref is valid.
+        ExternalConversationRef::new(Some(TEAM), CHANNEL, None, None).expect("conversation ref"), // safety: static test conversation ref is valid.
+        payload,
+    )
+    .expect("parsed inbound"); // safety: static test inbound is valid.
+    ProductInboundEnvelope::from_trusted_parse(context, parsed).expect("envelope") // safety: static test envelope is valid.
+}
+
+/// Build a harness for auth-fanout tests and return the observer alongside it.
+///
+/// The observer is needed because `AuthResolution(Allowed)` does not arrive via
+/// Slack text — it arrives from the WebUI gate-resolve path which calls
+/// `observe_workflow_ack` directly. Exposing the observer lets the test inject
+/// the resolution ack without going through the Slack route.
+async fn build_harness_for_auth_fanout_test(
+    max_wait: Duration,
+) -> (Harness, Arc<SlackFinalReplyDeliveryObserver>) {
+    let auth_provider = Arc::new(FakeAuthChallengeProvider::default());
+    let auth_challenges: Arc<dyn AuthChallengeProvider> = auth_provider;
+
+    let conversations = Arc::new(InMemoryConversationServices::default());
+    let conversation_port: Arc<dyn ironclaw_conversations::ConversationBindingService> =
+        conversations.clone();
+    let actor_pairings: Arc<dyn ironclaw_conversations::ConversationActorPairingService> =
+        conversations.clone();
+
+    let adapter_id = ProductAdapterId::new(ADAPTER).expect("adapter id"); // safety: static test adapter id is valid.
+    let installation_id = AdapterInstallationId::new(INSTALLATION).expect("installation id"); // safety: static test installation id is valid.
+    let adapter: Arc<dyn ProductAdapter> = Arc::new(SlackV2Adapter::new(SlackV2AdapterConfig {
+        adapter_id: adapter_id.clone(),
+        installation_id: installation_id.clone(),
+        egress_credential_handle: EgressCredentialHandle::new("slack_bot_token").expect("handle"), // safety: static test handle is valid.
+        auth_requirement: slack_request_signature_auth_requirement(),
+    }));
+
+    let scope = ProductInstallationScope::with_default_scope(
+        TenantId::new(TENANT).expect("tenant"), // safety: static test tenant id is valid.
+        AgentId::new(AGENT).expect("agent"),    // safety: static test agent id is valid.
+        Some(ProjectId::new(PROJECT).expect("project")), // safety: static test project id is valid.
+    )
+    .with_default_subject_user_id(UserId::new(USER).expect("user")) // safety: static test user id is valid.
+    .with_actor_user_resolver(static_personal_actor_user_resolver(), actor_pairings);
+    let resolver = StaticProductInstallationResolver::new([(
+        ProductInstallationKey::new(adapter_id, installation_id.clone()),
+        scope,
+    )]);
+    let binding = ProductConversationBindingService::new(conversation_port, resolver);
+
+    let threads = InMemorySessionThreadService::default();
+    let coordinator = RecordingTurnCoordinator::new(threads.clone(), TurnMode::BlockAuth);
+    let approvals = Arc::new(RecordingApprovalInteractionService::new(
+        coordinator.clone(),
+        threads.clone(),
+    ));
+    let auths = Arc::new(RecordingAuthInteractionService::new(coordinator.clone()));
+    let route_store: Arc<dyn ironclaw_outbound::DeliveredGateRouteStore> =
+        Arc::new(ironclaw_outbound::InMemoryDeliveredGateRouteStore::default());
+
+    let inbound = Arc::new(DefaultInboundTurnService::new(
+        binding.clone(),
+        threads.clone(),
+        coordinator.clone(),
+    ));
+    let workflow = Arc::new(
+        DefaultProductWorkflow::new(
+            inbound,
+            Arc::new(InMemoryIdempotencyLedger::new()),
+            Arc::new(binding.clone()),
+        )
+        .with_approval_interaction_service(approvals.clone())
+        .with_auth_interaction_service(auths.clone())
+        .with_delivered_gate_routes(route_store.clone()),
+    );
+
+    let runner = Arc::new(NativeProductAdapterRunner::with_config(
+        adapter.clone(),
+        workflow,
+        WebhookAuth::Hmac(HmacWebhookAuth::new(
+            SLACK_SIGNATURE_HEADER,
+            SLACK_TIMESTAMP_HEADER,
+            SECRET.as_bytes().to_vec(),
+            INSTALLATION,
+        )),
+        NativeProductAdapterRunnerConfig::new(
+            Duration::from_secs(2),
+            NonZeroUsize::new(4).expect("nonzero"), // safety: 4 is non-zero.
+        ),
+    ));
+
+    let outbound = Arc::new(InMemoryOutboundStateStore::default());
+    let outbound_store: Arc<dyn OutboundStateStore> = outbound.clone();
+    let preferences: Arc<dyn CommunicationPreferenceRepository> = outbound;
+    let egress = RecordingEgress::default();
+    let sink = RecordingDeliverySink::default();
+    let observer = Arc::new(SlackFinalReplyDeliveryObserver::with_settings(
+        SlackFinalReplyDeliveryServices {
+            binding_service: Arc::new(binding),
+            thread_service: Arc::new(threads),
+            turn_coordinator: Arc::new(coordinator.clone()),
+            outbound_store,
+            route_store: route_store.clone(),
+            communication_preferences: preferences,
+            adapter,
+            egress: Arc::new(egress.clone()),
+            delivery_sink: Arc::new(sink),
+            auth_challenges: Some(auth_challenges),
+        },
+        SlackFinalReplyDeliverySettings {
+            poll_interval: Duration::from_millis(1),
+            max_wait,
+            max_concurrent_deliveries: NonZeroUsize::new(4).expect("nonzero"), // safety: 4 is non-zero.
+            max_pending_deliveries: NonZeroUsize::new(16).expect("nonzero"), // safety: 16 is non-zero.
+        },
+    ));
+
+    let slack_resolver = StaticSlackInstallationResolver::new(vec![
+        SlackInstallationRecord::new(
+            TenantId::new(TENANT).expect("tenant"), // safety: static test tenant id is valid.
+            installation_id,
+            SlackInstallationSelector::team(TEAM),
+            runner,
+        )
+        .with_workflow_observer(observer.clone() as Arc<dyn ImmediateAckWorkflowObserver>),
+    ]);
+    let state = SlackEventsRouteState::from_resolver(Arc::new(slack_resolver));
+    let mount = slack_events_route_mount(state.clone());
+
+    let harness = Harness {
+        mount,
+        state,
+        egress,
+        coordinator: Arc::new(coordinator),
+        approvals,
+        auths,
+        route_store,
+    };
+    (harness, observer)
+}
+
+/// Regression test: auth prompt is posted exactly once even when an
+/// `AuthResolution(Allowed)` ack races the live delivery loop (L1).
+///
+/// Pre-fix behaviour (bug): the auth-resolution ack carried the same
+/// `submitted_run_id` as the original user-message ack. The guard check
+/// happened AFTER acquiring the semaphore permit, so L2 could block on the
+/// permit while L1 held it. When L1 released the permit and removed the
+/// run_id, L2 would wake, pass the now-empty guard, and spawn a second delivery
+/// loop. L2 immediately saw the run as Completed and posted a duplicate final
+/// reply. Result: 3 messages (auth prompt + 2 final replies) instead of 2.
+///
+/// Post-fix behaviour: the guard is checked and the run_id is inserted BEFORE
+/// acquiring the permit. L2 hits the already-populated guard set and returns
+/// early without ever competing for a permit. Only L1 delivers the final reply.
+///
+/// The comment in the original PR mentioned `AuthResolution(Allowed)` as an
+/// equal trigger to `ApprovalResolution(Allow)`, but only the approval case was
+/// tested. This test closes that gap.
+#[cfg(feature = "slack-v2-host-beta")]
+#[tokio::test]
+async fn auth_prompt_is_posted_exactly_once_when_auth_resolution_ack_races_live_delivery_loop() {
+    // Long max_wait keeps L1 alive (polling) when the auth-resolution ack arrives.
+    let (harness, observer) = build_harness_for_auth_fanout_test(Duration::from_secs(10)).await;
+
+    // Post user message — L1 spawns, polls, sees BlockedAuth, posts the auth
+    // prompt, then waits for the run to advance.
+    let first = harness.post_event(DM_AUTH_FANOUT_BLOCK).await;
+    assert_eq!(first.status(), StatusCode::OK);
+
+    // Poll until the auth prompt appears (L1 has posted it and is now looping).
+    for _ in 0..200 {
+        if harness.slack_messages().len() == 1 {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    let messages = harness.slack_messages();
+    assert_eq!(
+        messages.len(),
+        1,
+        "expected exactly one auth prompt before the auth-resolution ack; got {}: {:?}",
+        messages.len(),
+        messages
+    );
+    assert!(
+        messages[0]["text"]
+            .as_str()
+            .is_some_and(|t| t.contains("Authentication required")),
+        "first message must be the auth prompt; got {:?}",
+        messages[0]["text"]
+    );
+
+    // Get the run_id of the blocked run so we can build a matching ack.
+    let blocked_run_id = harness
+        .coordinator
+        .blocked_run_id()
+        .expect("run must be blocked after auth-fanout message"); // safety: E2E test assertion.
+
+    // Inject an `AuthResolution(Allowed)` ack directly — this simulates the
+    // WebUI gate-resolve path (not a Slack text command). The ack carries the
+    // same `submitted_run_id` as L1, so without the guard fix this would spawn
+    // L2, which would see Completed and post a duplicate final reply.
+    let auth_ack = ProductInboundAck::Accepted {
+        accepted_message_ref: AcceptedMessageRef::new("msg:auth-fanout-resolve")
+            .expect("accepted message ref"), // safety: static test ref is valid.
+        submitted_run_id: blocked_run_id,
+    };
+    let auth_envelope = auth_resolution_allowed_envelope("callback:test-fanout");
+    observer.observe_workflow_ack(auth_envelope, auth_ack).await;
+
+    // Complete the blocked run so L1 can finish and post the final reply.
+    harness
+        .coordinator
+        .resume_blocked_run_to_running()
+        .await
+        .expect("resume auth-blocked run");
+    harness
+        .coordinator
+        .complete_active_run("auth completed and finished")
+        .await
+        .expect("complete resumed auth run");
+
+    // Drain all tasks. The guard prevents L2 from ever starting, so only L1
+    // delivers the final reply. Total: 1 auth prompt + 1 final reply = 2.
+    harness.drain().await;
+
+    let messages = harness.slack_messages();
+    assert_eq!(
+        messages.len(),
+        2,
+        "expected exactly 2 messages: auth prompt + final reply, not {} (duplicate final reply was posted without the fix)",
+        messages.len()
+    );
+    assert!(
+        messages[0]["text"]
+            .as_str()
+            .is_some_and(|t| t.contains("Authentication required")),
+        "messages[0] must be the auth prompt"
+    );
+    assert_eq!(
+        messages[1]["text"], "auth completed and finished",
+        "messages[1] must be the final reply"
+    );
+}


### PR DESCRIPTION
## Problem

Bug 3 of the Slack re-approval-loop triage. A gate-resolution ack
(`ApprovalResolution(Allow)` / `AuthResolution(Allowed)`) carries the
**same** `submitted_run_id` as the original user-message ack because it
resumes the pre-existing run. The original delivery loop (L1) is still
alive and will observe the unblock on its next poll and post the next
gate / final reply exactly once.

Before this fix, each resolution ack spawned its **own** delivery loop:
N resolutions ⇒ N+1 concurrent loops ⇒ gate N posted N times. That is
the user-visible "spanning approval loop" — the same gate prompt
re-posted on every resolution.

## Fix

`SlackFinalReplyDeliveryObserver` keeps a single-flight set
(`active_delivery_run_ids`): at most one live delivery loop per run_id.
A second ack for an in-flight run_id is rejected before doing any work.

Two ordering/safety properties matter and are now locked by tests:

- **Guard before permit (TOCTOU).** The guard is checked and the run_id
  inserted *before* acquiring the delivery semaphore permit. If it were
  checked after, a second ack could block on the permit while L1 holds
  it; when L1 releases the permit and clears the run_id, the second loop
  would wake against a now-empty guard set — the exact race this
  ordering closes.
- **RAII release.** `RunDeliveryGuard` removes the run_id on `Drop`
  (poison-tolerant), so a delivery error *or* panic never leaves the
  run_id stuck and blocking all future delivery for that run.

## Tests

- `concurrent_ack_for_same_run_id_is_rejected_before_acquiring_permit`
  (unit) — blocked first delivery holds the only permit
  (`max_concurrent_deliveries = 1`); a second ack for the same run_id
  must return promptly via the guard skip, not block on the semaphore.
- `auth_prompt_is_posted_exactly_once_when_auth_resolution_ack_races_live_delivery_loop`
  (e2e) — full Slack ingress → blocked-auth turn → live loop, then an
  injected `AuthResolution(CallbackCompleted)` ack on the original
  run_id (the WebUI gate-resolve path). Asserts exactly one auth prompt
  + one final reply. Closes the gap where only the `ApprovalResolution`
  variant was covered end-to-end.
- `guard_is_released_after_delivery_error_so_subsequent_ack_proceeds`
  (e2e) — delivery timeout releases the guard so a later ack proceeds.

`cargo test -p ironclaw_reborn_composition --features slack-v2-host-beta,test-support`
(65 relevant tests) and `cargo clippy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate Slack message deliveries by implementing single-flight delivery enforcement for workflow acknowledgements.
  * Resolved race conditions preventing multiple approval gate and authentication prompts from being posted concurrently for the same workflow run.
  * Improved handling of concurrent acknowledgements to ensure reliable, non-redundant message delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->