### PR TITLE
fix(reborn): normalize bare workspace tool paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4423,6 +4423,7 @@ dependencies = [
  "regex",
  "serde_json",
  "similar",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/crates/ironclaw_first_party_extensions/Cargo.toml
+++ b/crates/ironclaw_first_party_extensions/Cargo.toml
@@ -29,4 +29,5 @@ tokio = { version = "1", features = ["rt", "sync"] }
 tracing = "0.1"
 
 [dev-dependencies]
+tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt"] }

--- a/crates/ironclaw_first_party_extensions/src/coding/mod.rs
+++ b/crates/ironclaw_first_party_extensions/src/coding/mod.rs
@@ -319,7 +319,7 @@ mod tests {
             super::CodingCapabilityKind::WriteFile,
             &scope,
             Some(&mounts),
-            filesystem,
+            Arc::clone(&filesystem),
             &url_like_input,
         );
         let err = state
@@ -334,6 +334,28 @@ mod tests {
                 .join("workspace/http:/example.com/a.txt")
                 .exists(),
             "URL-like path must not be normalized into a writable scoped path"
+        );
+
+        let reserved_workspace_file_input = json!({
+            "path": "workspace//HEARTBEAT.md",
+            "content": "blocked"
+        });
+        let reserved_workspace_file_request = super::CodingCapabilityRequest::new(
+            super::CodingCapabilityKind::WriteFile,
+            &scope,
+            Some(&mounts),
+            filesystem,
+            &reserved_workspace_file_input,
+        );
+        let err = state
+            .dispatch(&reserved_workspace_file_request)
+            .await
+            .expect_err("empty alias segments preserve reserved workspace file guard");
+
+        assert_eq!(err.kind(), RuntimeDispatchErrorKind::InputEncode);
+        assert!(
+            !temp_root.path().join("workspace/HEARTBEAT.md").exists(),
+            "reserved workspace memory file must not be written through empty alias segments"
         );
     }
 

--- a/crates/ironclaw_first_party_extensions/src/coding/mod.rs
+++ b/crates/ironclaw_first_party_extensions/src/coding/mod.rs
@@ -191,7 +191,7 @@ mod tests {
     use ironclaw_filesystem::{LocalFilesystem, RootFilesystem};
     use ironclaw_host_api::{
         HostPath, InvocationId, MountAlias, MountGrant, MountPermissions, MountView, ResourceScope,
-        UserId, VirtualPath,
+        RuntimeDispatchErrorKind, UserId, VirtualPath,
     };
     use serde_json::json;
 
@@ -297,7 +297,7 @@ mod tests {
             super::CodingCapabilityKind::ReadFile,
             &scope,
             Some(&mounts),
-            filesystem,
+            Arc::clone(&filesystem),
             &read_input,
         );
         let read_output = state.dispatch(&read_request).await.expect("read file");
@@ -309,6 +309,31 @@ mod tests {
         assert_eq!(
             read_output.output["content"].as_str(),
             Some("     1│ hello")
+        );
+
+        let url_like_input = json!({
+            "path": "workspace/http://example.com/a.txt",
+            "content": "blocked"
+        });
+        let url_like_request = super::CodingCapabilityRequest::new(
+            super::CodingCapabilityKind::WriteFile,
+            &scope,
+            Some(&mounts),
+            filesystem,
+            &url_like_input,
+        );
+        let err = state
+            .dispatch(&url_like_request)
+            .await
+            .expect_err("URL-like workspace alias path rejected");
+
+        assert_eq!(err.kind(), RuntimeDispatchErrorKind::InputEncode);
+        assert!(
+            !temp_root
+                .path()
+                .join("workspace/http:/example.com/a.txt")
+                .exists(),
+            "URL-like path must not be normalized into a writable scoped path"
         );
     }
 

--- a/crates/ironclaw_first_party_extensions/src/coding/mod.rs
+++ b/crates/ironclaw_first_party_extensions/src/coding/mod.rs
@@ -186,6 +186,15 @@ fn bound_safe_summary(summary: String) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use ironclaw_filesystem::{LocalFilesystem, RootFilesystem};
+    use ironclaw_host_api::{
+        HostPath, InvocationId, MountAlias, MountGrant, MountPermissions, MountView, ResourceScope,
+        UserId, VirtualPath,
+    };
+    use serde_json::json;
+
     #[test]
     fn coding_tools_do_not_select_runtime_backends() {
         let sources = [
@@ -213,5 +222,102 @@ mod tests {
         let input = "x".repeat(512);
 
         assert_eq!(super::bound_safe_summary(input.clone()), input);
+    }
+
+    #[tokio::test]
+    async fn coding_file_tools_treat_bare_workspace_prefix_as_scoped_alias() {
+        let temp_root = tempfile::TempDir::new().expect("temp root");
+        let mut local_filesystem = LocalFilesystem::new();
+        local_filesystem
+            .mount_local(
+                VirtualPath::new("/projects").expect("virtual path"),
+                HostPath::from_path_buf(temp_root.path().to_path_buf()),
+            )
+            .expect("projects mount");
+        let filesystem: Arc<dyn RootFilesystem> = Arc::new(local_filesystem);
+        let mounts = workspace_mounts();
+        let scope = ResourceScope::local_default(
+            UserId::new("workspace-alias-user").expect("user id"),
+            InvocationId::new(),
+        )
+        .expect("resource scope");
+        let state = super::CodingCapabilityState::default();
+
+        let write_input = json!({
+            "path": "workspace/demo/a.txt",
+            "content": "hello"
+        });
+        let write_request = super::CodingCapabilityRequest::new(
+            super::CodingCapabilityKind::WriteFile,
+            &scope,
+            Some(&mounts),
+            Arc::clone(&filesystem),
+            &write_input,
+        );
+        let write_output = state.dispatch(&write_request).await.expect("write file");
+
+        assert_eq!(
+            write_output.output["path"].as_str(),
+            Some("/workspace/demo/a.txt")
+        );
+        let write_preview = write_output
+            .display_preview
+            .as_ref()
+            .expect("write preview");
+        assert_eq!(
+            write_preview.subtitle.as_deref(),
+            Some("/workspace/demo/a.txt")
+        );
+        assert!(
+            write_preview
+                .output_preview
+                .contains("--- a/workspace/demo/a.txt\n+++ b/workspace/demo/a.txt"),
+            "preview should use normalized path, got: {}",
+            write_preview.output_preview
+        );
+        assert_eq!(
+            filesystem
+                .read_file(
+                    &VirtualPath::new("/projects/workspace/demo/a.txt").expect("virtual path")
+                )
+                .await
+                .expect("normalized write path exists"),
+            b"hello".to_vec()
+        );
+        assert!(temp_root.path().join("workspace/demo/a.txt").exists());
+        assert!(
+            !temp_root
+                .path()
+                .join("workspace/workspace/demo/a.txt")
+                .exists()
+        );
+
+        let read_input = json!({ "path": "workspace/demo/a.txt" });
+        let read_request = super::CodingCapabilityRequest::new(
+            super::CodingCapabilityKind::ReadFile,
+            &scope,
+            Some(&mounts),
+            filesystem,
+            &read_input,
+        );
+        let read_output = state.dispatch(&read_request).await.expect("read file");
+
+        assert_eq!(
+            read_output.output["path"].as_str(),
+            Some("/workspace/demo/a.txt")
+        );
+        assert_eq!(
+            read_output.output["content"].as_str(),
+            Some("     1│ hello")
+        );
+    }
+
+    fn workspace_mounts() -> MountView {
+        MountView::new(vec![MountGrant::new(
+            MountAlias::new("/workspace").expect("mount alias"),
+            VirtualPath::new("/projects/workspace").expect("virtual path"),
+            MountPermissions::read_write(),
+        )])
+        .expect("mount view")
     }
 }

--- a/crates/ironclaw_first_party_extensions/src/coding/paths.rs
+++ b/crates/ironclaw_first_party_extensions/src/coding/paths.rs
@@ -89,7 +89,14 @@ fn workspace_scoped_alias(path: &str) -> Option<String> {
     }
 
     path.strip_prefix("workspace/")
-        .map(|relative| format!("{DEFAULT_SCOPED_ROOT}/{relative}"))
+        .map(|relative| relative.trim_start_matches('/'))
+        .map(|relative| {
+            if relative.is_empty() {
+                DEFAULT_SCOPED_ROOT.to_string()
+            } else {
+                format!("{DEFAULT_SCOPED_ROOT}/{relative}")
+            }
+        })
 }
 
 fn strip_leading_current_dir_segments(mut path: &str) -> &str {

--- a/crates/ironclaw_first_party_extensions/src/coding/paths.rs
+++ b/crates/ironclaw_first_party_extensions/src/coding/paths.rs
@@ -1,5 +1,3 @@
-use std::path::{Component, Path};
-
 use ironclaw_filesystem::{FileStat, FilesystemError, FilesystemOperation};
 use ironclaw_host_api::{RuntimeDispatchErrorKind, ScopedPath, VirtualPath};
 use ironclaw_safety::sensitive_paths::is_sensitive_path_str;
@@ -85,29 +83,20 @@ fn scoped_path_input(path: &str) -> String {
 }
 
 fn workspace_scoped_alias(path: &str) -> Option<String> {
-    let mut components = Path::new(path).components().peekable();
-    while matches!(components.peek(), Some(Component::CurDir)) {
-        components.next();
+    let path = strip_leading_current_dir_segments(path);
+    if path == "workspace" {
+        return Some(DEFAULT_SCOPED_ROOT.to_string());
     }
 
-    match components.next()? {
-        Component::Normal(segment) if segment == "workspace" => {}
-        _ => return None,
-    }
+    path.strip_prefix("workspace/")
+        .map(|relative| format!("{DEFAULT_SCOPED_ROOT}/{relative}"))
+}
 
-    let mut scoped_path = DEFAULT_SCOPED_ROOT.to_string();
-    for component in components {
-        match component {
-            Component::Normal(segment) => {
-                scoped_path.push('/');
-                scoped_path.push_str(segment.to_str()?);
-            }
-            Component::CurDir => {}
-            Component::ParentDir => scoped_path.push_str("/.."),
-            Component::RootDir | Component::Prefix(_) => return None,
-        }
+fn strip_leading_current_dir_segments(mut path: &str) -> &str {
+    while let Some(stripped) = path.strip_prefix("./") {
+        path = stripped;
     }
-    Some(scoped_path)
+    path
 }
 
 pub(super) fn operation_allowed(

--- a/crates/ironclaw_first_party_extensions/src/coding/paths.rs
+++ b/crates/ironclaw_first_party_extensions/src/coding/paths.rs
@@ -1,3 +1,5 @@
+use std::path::{Component, Path};
+
 use ironclaw_filesystem::{FileStat, FilesystemError, FilesystemOperation};
 use ironclaw_host_api::{RuntimeDispatchErrorKind, ScopedPath, VirtualPath};
 use ironclaw_safety::sensitive_paths::is_sensitive_path_str;
@@ -74,9 +76,38 @@ fn scoped_path_input(path: &str) -> String {
         DEFAULT_SCOPED_ROOT.to_string()
     } else if path.starts_with('/') {
         path.to_string()
+    } else if let Some(scoped_workspace_path) = workspace_scoped_alias(path) {
+        scoped_workspace_path
     } else {
-        format!("{}/{}", DEFAULT_SCOPED_ROOT, path.trim_start_matches("./"))
+        let relative = path.trim_start_matches("./");
+        format!("{DEFAULT_SCOPED_ROOT}/{relative}")
     }
+}
+
+fn workspace_scoped_alias(path: &str) -> Option<String> {
+    let mut components = Path::new(path).components().peekable();
+    while matches!(components.peek(), Some(Component::CurDir)) {
+        components.next();
+    }
+
+    match components.next()? {
+        Component::Normal(segment) if segment == "workspace" => {}
+        _ => return None,
+    }
+
+    let mut scoped_path = DEFAULT_SCOPED_ROOT.to_string();
+    for component in components {
+        match component {
+            Component::Normal(segment) => {
+                scoped_path.push('/');
+                scoped_path.push_str(segment.to_str()?);
+            }
+            Component::CurDir => {}
+            Component::ParentDir => scoped_path.push_str("/.."),
+            Component::RootDir | Component::Prefix(_) => return None,
+        }
+    }
+    Some(scoped_path)
 }
 
 pub(super) fn operation_allowed(


### PR DESCRIPTION
## Summary

- Normalize bare `workspace/...` file-tool paths to the existing `/workspace/...` scoped root instead of nesting them under `/workspace/workspace/...`.
- Add caller-level regression coverage through the coding file tool dispatch path for write/read behavior and UI-facing path previews.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Closes #4759

## Validation

- [x] `cargo fmt --all -- --check`
- [x] Relevant tests pass: `cargo test -p ironclaw_first_party_extensions coding_file_tools_treat_bare_workspace_prefix_as_scoped_alias --locked`, `cargo test -p ironclaw_first_party_extensions --lib --locked`
- [x] `cargo clippy -p ironclaw_first_party_extensions --all-targets --locked -- -D warnings`
- [x] `git diff --check`
- [ ] `cargo build`
- [ ] `cargo test --features integration` if database-backed or integration behavior changed
- [ ] Manual testing: Not applicable; covered by caller-level coding tool regression test.

## Security Impact

None. This only changes path normalization/display for first-party coding file tools within the existing scoped `/workspace` mount.

## Database Impact

None.

## Blast Radius

Limited to first-party coding file tool path normalization for bare `workspace/...` inputs and associated path previews.

## Rollback Plan

Revert this PR to restore the previous `workspace/...` handling behavior.

## Review Follow-Through

Reviewer judgment requested on whether other scoped-root aliases beyond `workspace/...` should be accepted later; this PR keeps the fix intentionally narrow.

---

**Review track**: A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Tests**
  * Added an async test covering workspace-scoped read/write using bare `workspace/...` paths, validating normalized `/workspace/...` output, preview/diff content, correct on-disk write location, and rejection of duplicated-prefix and URL-like workspace alias inputs, plus an error case for invalid alias segments.

* **Bug Fixes**
  * Improved scoped path resolution to prioritize `workspace`-scoped relative inputs (including `./workspace`) before applying the default root mapping, ensuring consistent path normalization for later checks.

* **Chores**
  * Added a temporary-file utility to development dependencies for enhanced test support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->