### PR TITLE
ci(review): keep CodeRabbit summaries out of PR descriptions

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -24,6 +24,7 @@ tone_instructions: "Terse, evidence-first senior Rust review. Cite the repo inva
 reviews:
   profile: assertive # full strength for the head-to-head trial against the other AI reviewers
   request_changes_workflow: false # advisory only; merge gating stays with the ruleset's required checks
+  high_level_summary_in_walkthrough: true # keep PR descriptions owner-authored; put generated summaries in the walkthrough comment
 
   # Review everything except generated / vendored / fixture / binary content.
   path_filters:


### PR DESCRIPTION
## Summary

- Set `reviews.high_level_summary_in_walkthrough: true` in `.coderabbit.yaml`.
- Keeps CodeRabbit's generated high-level summary in the walkthrough comment instead of editing the GitHub PR description.

## Why

CodeRabbit defaults to generating high-level summaries in the PR description. IronClaw PR descriptions should remain owner-authored while still preserving CodeRabbit's generated summary in its review walkthrough.

## Validation

- Validated `.coderabbit.yaml` against CodeRabbit's published schema: `schema-valid`.
