### PR TITLE
fix(security): tool boundary checks

### DIFF
--- a/src/tools/builtin/file.rs
+++ b/src/tools/builtin/file.rs
@@ -997,6 +997,33 @@ mod tests {
         assert_eq!(std::fs::read_to_string(&file_path).unwrap(), "hello world");
     }
 
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_write_file_rejects_dangling_final_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let sandbox = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+        let outside_target = outside.path().join("owned.txt");
+        symlink(&outside_target, sandbox.path().join("jump")).unwrap();
+
+        let tool = WriteFileTool::new().with_base_dir(sandbox.path().to_path_buf());
+        let ctx = JobContext::default();
+
+        let result = tool
+            .execute(
+                serde_json::json!({
+                    "path": "jump",
+                    "content": "pwned"
+                }),
+                &ctx,
+            )
+            .await;
+
+        assert!(result.is_err());
+        assert!(!outside_target.exists());
+    }
+
     #[tokio::test]
     async fn test_apply_patch() {
         let dir = TempDir::new().unwrap();

--- a/src/tools/builtin/path_utils.rs
+++ b/src/tools/builtin/path_utils.rs
@@ -97,6 +97,14 @@ pub fn validate_path(path_str: &str, base_dir: Option<&Path>) -> Result<PathBuf,
         // all `..` components, so starts_with is reliable.
         let check_path = if resolved.exists() {
             resolved.canonicalize().unwrap_or_else(|_| resolved.clone())
+        } else if std::fs::symlink_metadata(&resolved)
+            .map(|m| m.file_type().is_symlink())
+            .unwrap_or(false)
+        {
+            return Err(ToolError::NotAuthorized(format!(
+                "Path is a dangling symlink: {}",
+                path_str
+            )));
         } else {
             // Walk up to the nearest existing ancestor directory, canonicalize it,
             // then re-append the remaining tail. This handles the case where a
@@ -247,5 +255,19 @@ mod tests {
         // This should be allowed as it stays within the sandbox
         let result = validate_path("a/b/../c.txt", Some(dir.path()));
         assert!(result.is_ok());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_validate_path_rejects_dangling_final_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let sandbox = tempdir().unwrap();
+        let outside = tempdir().unwrap();
+        let outside_target = outside.path().join("owned.txt");
+        symlink(&outside_target, sandbox.path().join("jump")).unwrap();
+
+        let result = validate_path("jump", Some(sandbox.path()));
+        assert!(result.is_err());
     }
 }

--- a/src/tools/builtin/path_utils.rs
+++ b/src/tools/builtin/path_utils.rs
@@ -97,10 +97,16 @@ pub fn validate_path(path_str: &str, base_dir: Option<&Path>) -> Result<PathBuf,
         // all `..` components, so starts_with is reliable.
         let check_path = if resolved.exists() {
             resolved.canonicalize().unwrap_or_else(|_| resolved.clone())
-        } else if std::fs::symlink_metadata(&resolved)
-            .map(|m| m.file_type().is_symlink())
-            .unwrap_or(false)
-        {
+        } else if match std::fs::symlink_metadata(&resolved) {
+            Ok(metadata) => metadata.file_type().is_symlink(),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => false,
+            Err(err) => {
+                return Err(ToolError::ExecutionFailed(format!(
+                    "Failed to inspect path metadata for {}: {}",
+                    path_str, err
+                )));
+            }
+        } {
             return Err(ToolError::NotAuthorized(format!(
                 "Path is a dangling symlink: {}",
                 path_str

--- a/src/tools/builtin/shell.rs
+++ b/src/tools/builtin/shell.rs
@@ -425,6 +425,9 @@ fn delegated_env_command(tokens: &[String]) -> Option<Vec<String>> {
         if token == "-S" || token == "--split-string" {
             return tokens.get(idx + 1).map(|script| shell_tokens(script));
         }
+        if let Some(script) = token.strip_prefix("-S").filter(|script| !script.is_empty()) {
+            return Some(shell_tokens(script));
+        }
         if let Some(script) = token.strip_prefix("--split-string=") {
             return Some(shell_tokens(script));
         }

--- a/src/tools/builtin/shell.rs
+++ b/src/tools/builtin/shell.rs
@@ -337,6 +337,168 @@ fn matches_command_pattern(segment: &str, pattern: &str) -> bool {
     }
 }
 
+fn shell_tokens(segment: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    let mut quote: Option<char> = None;
+    let mut escaped = false;
+
+    for ch in segment.chars() {
+        if escaped {
+            current.push(ch);
+            escaped = false;
+            continue;
+        }
+
+        if ch == '\\' && quote != Some('\'') {
+            escaped = true;
+            continue;
+        }
+
+        if let Some(q) = quote {
+            if ch == q {
+                quote = None;
+            } else {
+                current.push(ch);
+            }
+            continue;
+        }
+
+        match ch {
+            '\'' | '"' => quote = Some(ch),
+            c if c.is_whitespace() => {
+                if !current.is_empty() {
+                    tokens.push(std::mem::take(&mut current));
+                }
+            }
+            _ => current.push(ch),
+        }
+    }
+
+    if !current.is_empty() {
+        tokens.push(current);
+    }
+
+    tokens
+}
+
+fn command_basename(token: &str) -> &str {
+    token.rsplit('/').next().unwrap_or(token)
+}
+
+fn is_env_assignment(token: &str) -> bool {
+    token
+        .split_once('=')
+        .is_some_and(|(name, _)| !name.is_empty() && !name.contains('/'))
+}
+
+fn shell_script_arg<'a>(tokens: &'a [String], start: usize) -> Option<&'a str> {
+    let mut idx = start;
+    while idx < tokens.len() {
+        let token = tokens[idx].as_str();
+        if token == "-c" {
+            return tokens.get(idx + 1).map(String::as_str);
+        }
+        if token.starts_with('-') && token.contains('c') && token.len() > 2 {
+            return tokens.get(idx + 1).map(String::as_str);
+        }
+        idx += 1;
+    }
+    None
+}
+
+fn delegated_env_command(tokens: &[String]) -> Option<&[String]> {
+    let mut idx = 1;
+    while idx < tokens.len() {
+        let token = tokens[idx].as_str();
+        if token.starts_with('-') {
+            idx += 1;
+            continue;
+        }
+        if is_env_assignment(token) {
+            idx += 1;
+            continue;
+        }
+        return Some(&tokens[idx..]);
+    }
+    None
+}
+
+fn delegated_time_command(tokens: &[String]) -> Option<&[String]> {
+    let mut idx = 1;
+    while idx < tokens.len() {
+        let token = tokens[idx].as_str();
+        if token.starts_with('-') {
+            idx += 1;
+            continue;
+        }
+        return Some(&tokens[idx..]);
+    }
+    None
+}
+
+fn sort_invokes_external_helper(tokens: &[String]) -> bool {
+    tokens
+        .iter()
+        .skip(1)
+        .any(|token| token == "--compress-program" || token.starts_with("--compress-program="))
+}
+
+fn classify_tokens_for_wrappers(tokens: &[String], depth: usize) -> Option<RiskLevel> {
+    if depth >= 4 || tokens.is_empty() {
+        return None;
+    }
+
+    let command = command_basename(&tokens[0]).to_lowercase();
+    match command.as_str() {
+        "sort" if sort_invokes_external_helper(tokens) => Some(RiskLevel::High),
+        "sh" | "bash" | "zsh" | "dash" => {
+            shell_script_arg(tokens, 1).map(|script| classify_command_risk_inner(script, depth + 1))
+        }
+        "env" => delegated_env_command(tokens).and_then(|delegated| {
+            let delegated_command = command_basename(&delegated[0]).to_lowercase();
+            if matches!(delegated_command.as_str(), "sh" | "bash" | "zsh" | "dash") {
+                classify_tokens_for_wrappers(delegated, depth + 1)
+            } else {
+                Some(classify_command_risk_inner(&delegated.join(" "), depth + 1))
+            }
+        }),
+        "time" => delegated_time_command(tokens)
+            .map(|delegated| classify_command_risk_inner(&delegated.join(" "), depth + 1)),
+        _ => None,
+    }
+}
+
+fn classify_segment_risk(segment: &str, depth: usize) -> RiskLevel {
+    let seg_lower = segment.to_lowercase();
+    if NEVER_AUTO_APPROVE_PATTERNS
+        .iter()
+        .any(|p| matches_command_pattern(&seg_lower, &p.to_lowercase()))
+    {
+        return RiskLevel::High;
+    }
+
+    let tokens = shell_tokens(segment);
+    if classify_tokens_for_wrappers(&tokens, depth).is_some_and(|risk| risk == RiskLevel::High) {
+        return RiskLevel::High;
+    }
+
+    if LOW_RISK_PATTERNS
+        .iter()
+        .any(|p| matches_command_pattern(&seg_lower, p))
+    {
+        RiskLevel::Low
+    } else if MEDIUM_RISK_PATTERNS
+        .iter()
+        .any(|p| matches_command_pattern(&seg_lower, p))
+    {
+        RiskLevel::Medium
+    } else {
+        // Unknown commands default to Medium (safer than auto-approving).
+        RiskLevel::Medium
+    }
+}
+
 /// Classify a shell command into a [`RiskLevel`].
 ///
 /// The command is split on `|`, `&`, `;` and each segment is classified
@@ -353,33 +515,16 @@ fn matches_command_pattern(segment: &str, pattern: &str) -> bool {
 /// prevent false positives like `"makeshutdownscript"` matching `"shutdown"` or
 /// `"lsblk"` matching `"ls"`.
 pub fn classify_command_risk(command: &str) -> RiskLevel {
+    classify_command_risk_inner(command, 0)
+}
+
+fn classify_command_risk_inner(command: &str, depth: usize) -> RiskLevel {
     // For pipelines/chains, take the maximum risk across all segments.
-    command
-        .split(['|', '&', ';'])
+    split_shell_segments(command)
+        .into_iter()
         .map(str::trim)
         .filter(|s| !s.is_empty())
-        .map(|segment| {
-            let seg_lower = segment.to_lowercase();
-            if NEVER_AUTO_APPROVE_PATTERNS
-                .iter()
-                .any(|p| matches_command_pattern(&seg_lower, &p.to_lowercase()))
-            {
-                RiskLevel::High
-            } else if LOW_RISK_PATTERNS
-                .iter()
-                .any(|p| matches_command_pattern(&seg_lower, p))
-            {
-                RiskLevel::Low
-            } else if MEDIUM_RISK_PATTERNS
-                .iter()
-                .any(|p| matches_command_pattern(&seg_lower, p))
-            {
-                RiskLevel::Medium
-            } else {
-                // Unknown commands default to Medium (safer than auto-approving).
-                RiskLevel::Medium
-            }
-        })
+        .map(|segment| classify_segment_risk(segment, depth))
         .max()
         .unwrap_or(RiskLevel::Medium)
 }
@@ -604,7 +749,7 @@ fn check_sensitive_file_access(cmd: &str) -> Option<String> {
     None
 }
 
-/// Split a command string on shell separators (`&&`, `||`, `|`, `;`).
+/// Split a command string on shell separators (`&&`, `||`, `|`, `;`, newline).
 ///
 /// Splits on multi-character operators first to avoid fragmenting `&&` into
 /// empty segments (which would happen with single-char `&` splitting).
@@ -617,7 +762,8 @@ fn split_shell_segments(cmd: &str) -> Vec<&str> {
     while i < len {
         let is_double =
             (bytes[i] == b'&' || bytes[i] == b'|') && i + 1 < len && bytes[i + 1] == bytes[i];
-        let is_single = bytes[i] == b'|' || bytes[i] == b';';
+        let is_single =
+            bytes[i] == b'|' || bytes[i] == b';' || bytes[i] == b'\n' || bytes[i] == b'\r';
         if is_double {
             segments.push(&cmd[start..i]);
             i += 2;
@@ -625,6 +771,9 @@ fn split_shell_segments(cmd: &str) -> Vec<&str> {
         } else if is_single {
             segments.push(&cmd[start..i]);
             i += 1;
+            if bytes[i - 1] == b'\r' && i < len && bytes[i] == b'\n' {
+                i += 1;
+            }
             start = i;
         } else {
             i += 1;

--- a/src/tools/builtin/shell.rs
+++ b/src/tools/builtin/shell.rs
@@ -399,7 +399,7 @@ fn is_env_assignment(token: &str) -> bool {
         .is_some_and(|(name, _)| !name.is_empty() && !name.contains('/') && !name.contains('\\'))
 }
 
-fn shell_script_arg<'a>(tokens: &'a [String], start: usize) -> Option<&'a str> {
+fn shell_script_arg(tokens: &[String], start: usize) -> Option<&str> {
     let mut idx = start;
     while idx < tokens.len() {
         let token = tokens[idx].as_str();

--- a/src/tools/builtin/shell.rs
+++ b/src/tools/builtin/shell.rs
@@ -423,7 +423,11 @@ fn delegated_env_command(tokens: &[String]) -> Option<Vec<String>> {
     while idx < tokens.len() {
         let token = tokens[idx].as_str();
         if token == "-S" || token == "--split-string" {
-            return tokens.get(idx + 1).map(|script| shell_tokens(script));
+            return Some(
+                tokens
+                    .get(idx + 1)
+                    .map_or_else(Vec::new, |script| shell_tokens(script)),
+            );
         }
         if let Some(script) = token.strip_prefix("-S").filter(|script| !script.is_empty()) {
             return Some(shell_tokens(script));
@@ -436,6 +440,9 @@ fn delegated_env_command(tokens: &[String]) -> Option<Vec<String>> {
             "-u" | "--unset"
                 | "-C"
                 | "--chdir"
+                | "-P"
+                | "-a"
+                | "--argv0"
                 | "--block-signal"
                 | "--default-signal"
                 | "--ignore-signal"
@@ -492,7 +499,10 @@ fn classify_tokens_for_wrappers(tokens: &[String], depth: usize) -> Option<RiskL
             shell_script_arg(tokens, 1).map(|script| classify_command_risk_inner(script, depth + 1))
         }
         "env" => delegated_env_command(tokens).and_then(|delegated| {
-            let delegated_command = command_basename(&delegated[0]).to_lowercase();
+            let Some(delegated_command) = delegated.first() else {
+                return Some(RiskLevel::Medium);
+            };
+            let delegated_command = command_basename(delegated_command).to_lowercase();
             if matches!(delegated_command.as_str(), "sh" | "bash" | "zsh" | "dash") {
                 classify_tokens_for_wrappers(&delegated, depth + 1)
             } else {
@@ -515,8 +525,8 @@ fn classify_segment_risk(segment: &str, depth: usize) -> RiskLevel {
     }
 
     let tokens = shell_tokens(segment);
-    if classify_tokens_for_wrappers(&tokens, depth).is_some_and(|risk| risk == RiskLevel::High) {
-        return RiskLevel::High;
+    if let Some(risk) = classify_tokens_for_wrappers(&tokens, depth) {
+        return risk;
     }
 
     if LOW_RISK_PATTERNS

--- a/src/tools/builtin/shell.rs
+++ b/src/tools/builtin/shell.rs
@@ -343,7 +343,8 @@ fn shell_tokens(segment: &str) -> Vec<String> {
     let mut quote: Option<char> = None;
     let mut escaped = false;
 
-    for ch in segment.chars() {
+    let mut chars = segment.chars().peekable();
+    while let Some(ch) = chars.next() {
         if escaped {
             current.push(ch);
             escaped = false;
@@ -351,7 +352,13 @@ fn shell_tokens(segment: &str) -> Vec<String> {
         }
 
         if ch == '\\' && quote != Some('\'') {
-            escaped = true;
+            if chars.peek().is_some_and(|next| {
+                next.is_whitespace() || matches!(next, '\'' | '"' | '\\' | '$' | '`')
+            }) {
+                escaped = true;
+            } else {
+                current.push(ch);
+            }
             continue;
         }
 
@@ -383,13 +390,13 @@ fn shell_tokens(segment: &str) -> Vec<String> {
 }
 
 fn command_basename(token: &str) -> &str {
-    token.rsplit('/').next().unwrap_or(token)
+    token.rsplit(['/', '\\']).next().unwrap_or(token)
 }
 
 fn is_env_assignment(token: &str) -> bool {
     token
         .split_once('=')
-        .is_some_and(|(name, _)| !name.is_empty() && !name.contains('/'))
+        .is_some_and(|(name, _)| !name.is_empty() && !name.contains('/') && !name.contains('\\'))
 }
 
 fn shell_script_arg<'a>(tokens: &'a [String], start: usize) -> Option<&'a str> {
@@ -399,7 +406,11 @@ fn shell_script_arg<'a>(tokens: &'a [String], start: usize) -> Option<&'a str> {
         if token == "-c" {
             return tokens.get(idx + 1).map(String::as_str);
         }
-        if token.starts_with('-') && token.contains('c') && token.len() > 2 {
+        if token.starts_with('-')
+            && !token.starts_with("--")
+            && token.contains('c')
+            && token.len() > 2
+        {
             return tokens.get(idx + 1).map(String::as_str);
         }
         idx += 1;
@@ -411,6 +422,20 @@ fn delegated_env_command(tokens: &[String]) -> Option<&[String]> {
     let mut idx = 1;
     while idx < tokens.len() {
         let token = tokens[idx].as_str();
+        if matches!(
+            token,
+            "-u" | "--unset"
+                | "-C"
+                | "--chdir"
+                | "-S"
+                | "--split-string"
+                | "--block-signal"
+                | "--default-signal"
+                | "--ignore-signal"
+        ) {
+            idx += 2;
+            continue;
+        }
         if token.starts_with('-') {
             idx += 1;
             continue;
@@ -428,6 +453,10 @@ fn delegated_time_command(tokens: &[String]) -> Option<&[String]> {
     let mut idx = 1;
     while idx < tokens.len() {
         let token = tokens[idx].as_str();
+        if matches!(token, "-o" | "--output" | "-f" | "--format") {
+            idx += 2;
+            continue;
+        }
         if token.starts_with('-') {
             idx += 1;
             continue;

--- a/src/tools/builtin/shell.rs
+++ b/src/tools/builtin/shell.rs
@@ -418,17 +418,21 @@ fn shell_script_arg(tokens: &[String], start: usize) -> Option<&str> {
     None
 }
 
-fn delegated_env_command(tokens: &[String]) -> Option<&[String]> {
+fn delegated_env_command(tokens: &[String]) -> Option<Vec<String>> {
     let mut idx = 1;
     while idx < tokens.len() {
         let token = tokens[idx].as_str();
+        if token == "-S" || token == "--split-string" {
+            return tokens.get(idx + 1).map(|script| shell_tokens(script));
+        }
+        if let Some(script) = token.strip_prefix("--split-string=") {
+            return Some(shell_tokens(script));
+        }
         if matches!(
             token,
             "-u" | "--unset"
                 | "-C"
                 | "--chdir"
-                | "-S"
-                | "--split-string"
                 | "--block-signal"
                 | "--default-signal"
                 | "--ignore-signal"
@@ -444,7 +448,7 @@ fn delegated_env_command(tokens: &[String]) -> Option<&[String]> {
             idx += 1;
             continue;
         }
-        return Some(&tokens[idx..]);
+        return Some(tokens[idx..].to_vec());
     }
     None
 }
@@ -487,7 +491,7 @@ fn classify_tokens_for_wrappers(tokens: &[String], depth: usize) -> Option<RiskL
         "env" => delegated_env_command(tokens).and_then(|delegated| {
             let delegated_command = command_basename(&delegated[0]).to_lowercase();
             if matches!(delegated_command.as_str(), "sh" | "bash" | "zsh" | "dash") {
-                classify_tokens_for_wrappers(delegated, depth + 1)
+                classify_tokens_for_wrappers(&delegated, depth + 1)
             } else {
                 Some(classify_command_risk_inner(&delegated.join(" "), depth + 1))
             }
@@ -778,7 +782,7 @@ fn check_sensitive_file_access(cmd: &str) -> Option<String> {
     None
 }
 
-/// Split a command string on shell separators (`&&`, `||`, `|`, `;`, newline).
+/// Split a command string on shell separators (`&&`, `||`, `|`, `&`, `;`, newline).
 ///
 /// Splits on multi-character operators first to avoid fragmenting `&&` into
 /// empty segments (which would happen with single-char `&` splitting).
@@ -791,8 +795,11 @@ fn split_shell_segments(cmd: &str) -> Vec<&str> {
     while i < len {
         let is_double =
             (bytes[i] == b'&' || bytes[i] == b'|') && i + 1 < len && bytes[i + 1] == bytes[i];
-        let is_single =
-            bytes[i] == b'|' || bytes[i] == b';' || bytes[i] == b'\n' || bytes[i] == b'\r';
+        let is_single = bytes[i] == b'&'
+            || bytes[i] == b'|'
+            || bytes[i] == b';'
+            || bytes[i] == b'\n'
+            || bytes[i] == b'\r';
         if is_double {
             segments.push(&cmd[start..i]);
             i += 2;

--- a/tests/shell_risk_regression.rs
+++ b/tests/shell_risk_regression.rs
@@ -179,6 +179,22 @@ async fn newline_chains_take_max_risk() {
 }
 
 #[tokio::test]
+async fn crlf_chains_take_max_risk() {
+    let tool = shell_tool().await;
+    let cmd = "echo control\r\nrm -rf /tmp/crlf-marker";
+    assert_eq!(risk(&tool, cmd), RiskLevel::High);
+    assert_eq!(approval(&tool, cmd), ApprovalRequirement::Always);
+}
+
+#[tokio::test]
+async fn background_chains_take_max_risk() {
+    let tool = shell_tool().await;
+    let cmd = "echo control & rm -rf /tmp/background-marker";
+    assert_eq!(risk(&tool, cmd), RiskLevel::High);
+    assert_eq!(approval(&tool, cmd), ApprovalRequirement::Always);
+}
+
+#[tokio::test]
 async fn transparent_shell_wrappers_reveal_high_risk_payloads() {
     let tool = shell_tool().await;
     let cmds = [
@@ -222,6 +238,20 @@ async fn env_wrapper_options_with_arguments_are_skipped() {
         r#"env -u PATH sh -c "git reset --hard""#,
         r#"env --unset PATH bash -lc "rm -rf /tmp/env-unset-marker""#,
         r#"env --chdir /tmp sh -c "chmod 777 /tmp/env-chdir-marker""#,
+    ];
+    for cmd in &cmds {
+        assert_eq!(risk(&tool, cmd), RiskLevel::High);
+        assert_eq!(approval(&tool, cmd), ApprovalRequirement::Always);
+    }
+}
+
+#[tokio::test]
+async fn env_split_string_payloads_are_classified() {
+    let tool = shell_tool().await;
+    let cmds = [
+        r#"env -S "bash -c 'rm -rf /tmp/env-split-marker'""#,
+        r#"env --split-string "chmod 777 /tmp/env-split-marker""#,
+        r#"env --split-string="echo control & rm -rf /tmp/env-split-background""#,
     ];
     for cmd in &cmds {
         assert_eq!(risk(&tool, cmd), RiskLevel::High);

--- a/tests/shell_risk_regression.rs
+++ b/tests/shell_risk_regression.rs
@@ -238,6 +238,9 @@ async fn env_wrapper_options_with_arguments_are_skipped() {
         r#"env -u PATH sh -c "git reset --hard""#,
         r#"env --unset PATH bash -lc "rm -rf /tmp/env-unset-marker""#,
         r#"env --chdir /tmp sh -c "chmod 777 /tmp/env-chdir-marker""#,
+        r#"env -P /bin sh -c "rm -rf /tmp/env-path-marker""#,
+        r#"env -a custom_name sh -c "chmod 777 /tmp/env-argv0-marker""#,
+        r#"env --argv0 custom_name bash -lc "git reset --hard""#,
     ];
     for cmd in &cmds {
         assert_eq!(risk(&tool, cmd), RiskLevel::High);
@@ -257,6 +260,23 @@ async fn env_split_string_payloads_are_classified() {
     for cmd in &cmds {
         assert_eq!(risk(&tool, cmd), RiskLevel::High);
         assert_eq!(approval(&tool, cmd), ApprovalRequirement::Always);
+    }
+}
+
+#[tokio::test]
+async fn env_empty_split_string_payloads_are_conservative() {
+    let tool = shell_tool().await;
+    let cmds = [
+        r#"env --split-string="#,
+        r#"env --split-string="""#,
+        r#"env -S """#,
+    ];
+    for cmd in &cmds {
+        assert_eq!(risk(&tool, cmd), RiskLevel::Medium);
+        assert_eq!(
+            approval(&tool, cmd),
+            ApprovalRequirement::UnlessAutoApproved
+        );
     }
 }
 

--- a/tests/shell_risk_regression.rs
+++ b/tests/shell_risk_regression.rs
@@ -170,6 +170,57 @@ async fn pipeline_takes_max_risk() {
     );
 }
 
+#[tokio::test]
+async fn newline_chains_take_max_risk() {
+    let tool = shell_tool().await;
+    let cmd = "echo control\nrm -rf /tmp/newline-marker";
+    assert_eq!(risk(&tool, cmd), RiskLevel::High);
+    assert_eq!(approval(&tool, cmd), ApprovalRequirement::Always);
+}
+
+#[tokio::test]
+async fn transparent_shell_wrappers_reveal_high_risk_payloads() {
+    let tool = shell_tool().await;
+    let cmds = [
+        r#"/usr/bin/env bash -lc "rm -rf /tmp/env-marker""#,
+        r#"env /bin/sh -c 'chmod 777 /tmp/env-marker'"#,
+        r#"bash -lc "git reset --hard HEAD~1""#,
+    ];
+    for cmd in &cmds {
+        assert_eq!(
+            risk(&tool, cmd),
+            RiskLevel::High,
+            "command `{cmd}` should unwrap to High risk"
+        );
+        assert_eq!(
+            approval(&tool, cmd),
+            ApprovalRequirement::Always,
+            "command `{cmd}` should require per-call approval"
+        );
+    }
+}
+
+#[tokio::test]
+async fn transparent_non_shell_wrappers_reveal_high_risk_payloads() {
+    let tool = shell_tool().await;
+    let cmd = "/usr/bin/time -p rm -rf /tmp/time-marker";
+    assert_eq!(risk(&tool, cmd), RiskLevel::High);
+    assert_eq!(approval(&tool, cmd), ApprovalRequirement::Always);
+}
+
+#[tokio::test]
+async fn sort_compress_program_requires_always_approval() {
+    let tool = shell_tool().await;
+    let cmds = [
+        "sort --compress-program=/tmp/helper payload.txt",
+        "sort --compress-program /tmp/helper payload.txt",
+    ];
+    for cmd in &cmds {
+        assert_eq!(risk(&tool, cmd), RiskLevel::High);
+        assert_eq!(approval(&tool, cmd), ApprovalRequirement::Always);
+    }
+}
+
 // ---------------------------------------------------------------------------
 // 4. Redirect bypass regression (Low → UnlessAutoApproved, not Never)
 // ---------------------------------------------------------------------------

--- a/tests/shell_risk_regression.rs
+++ b/tests/shell_risk_regression.rs
@@ -185,6 +185,8 @@ async fn transparent_shell_wrappers_reveal_high_risk_payloads() {
         r#"/usr/bin/env bash -lc "rm -rf /tmp/env-marker""#,
         r#"env /bin/sh -c 'chmod 777 /tmp/env-marker'"#,
         r#"bash -lc "git reset --hard HEAD~1""#,
+        r#"bash --rcfile "echo safe" -c "rm -rf /tmp/rcfile-marker""#,
+        r#"C:\Windows\System32\bash -lc "rm -rf C:\tmp\windows-marker""#,
     ];
     for cmd in &cmds {
         assert_eq!(
@@ -203,9 +205,28 @@ async fn transparent_shell_wrappers_reveal_high_risk_payloads() {
 #[tokio::test]
 async fn transparent_non_shell_wrappers_reveal_high_risk_payloads() {
     let tool = shell_tool().await;
-    let cmd = "/usr/bin/time -p rm -rf /tmp/time-marker";
-    assert_eq!(risk(&tool, cmd), RiskLevel::High);
-    assert_eq!(approval(&tool, cmd), ApprovalRequirement::Always);
+    let cmds = [
+        "/usr/bin/time -p rm -rf /tmp/time-marker",
+        "/usr/bin/time -o /tmp/time.log rm -rf /tmp/time-marker",
+    ];
+    for cmd in &cmds {
+        assert_eq!(risk(&tool, cmd), RiskLevel::High);
+        assert_eq!(approval(&tool, cmd), ApprovalRequirement::Always);
+    }
+}
+
+#[tokio::test]
+async fn env_wrapper_options_with_arguments_are_skipped() {
+    let tool = shell_tool().await;
+    let cmds = [
+        r#"env -u PATH sh -c "git reset --hard""#,
+        r#"env --unset PATH bash -lc "rm -rf /tmp/env-unset-marker""#,
+        r#"env --chdir /tmp sh -c "chmod 777 /tmp/env-chdir-marker""#,
+    ];
+    for cmd in &cmds {
+        assert_eq!(risk(&tool, cmd), RiskLevel::High);
+        assert_eq!(approval(&tool, cmd), ApprovalRequirement::Always);
+    }
 }
 
 #[tokio::test]

--- a/tests/shell_risk_regression.rs
+++ b/tests/shell_risk_regression.rs
@@ -250,6 +250,7 @@ async fn env_split_string_payloads_are_classified() {
     let tool = shell_tool().await;
     let cmds = [
         r#"env -S "bash -c 'rm -rf /tmp/env-split-marker'""#,
+        r#"env -S'rm -rf /tmp/env-adjacent-marker'"#,
         r#"env --split-string "chmod 777 /tmp/env-split-marker""#,
         r#"env --split-string="echo control & rm -rf /tmp/env-split-background""#,
     ];


### PR DESCRIPTION
## Summary

Fixes the validated security issues around built-in filesystem and shell tool boundaries:

- reject dangling final symlinks during sandbox path validation so `write_file` cannot follow them outside `base_dir`
- classify newline-separated shell commands as chained commands
- inspect transparent shell wrappers such as `env ... sh -c`, direct shell `-c`, and `time ...` before reusing session-level shell auto-approval
- force `sort --compress-program` through the high-risk approval floor
- add regression coverage through both helper and caller-path tests

## Root Cause

`write_file` validated non-existent paths by checking the nearest existing ancestor while the final write sink followed symlinks. For shell execution, risk classification only inspected shallow command segments, so dangerous payloads hidden behind newlines or wrappers could be downgraded to `UnlessAutoApproved` and inherit prior session approval.

## Validation

- `cargo fmt`
- `cargo test --test shell_risk_regression`
- `cargo test --lib tools::builtin::path_utils::tests`
- `cargo test --lib tools::builtin::file::tests::test_write_file_rejects_dangling_final_symlink`

Fixes #4797.
Fixes #4861.
Fixes #4862.
Fixes #4863.
Fixes #4864.
Fixes #4865.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * File writes and path validation now reject attempts to use dangling symlinks that resolve outside the sandbox.
* **New Features**
  * Shell command risk detection is more robust, using quote/escape-aware parsing and recognizing common wrapper/delegation patterns, including newline and CRLF handling.
* **Tests**
  * Added Unix-only coverage for dangling-symlink write rejection.
  * Added shell-risk regression cases for newline/CRLF chaining and embedded high-risk payloads (including `env` and `sort --compress-program`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->