### PR TITLE
fix(reborn): close tool activity after cancelled runs

### DIFF
--- a/crates/ironclaw_event_projections/src/lib.rs
+++ b/crates/ironclaw_event_projections/src/lib.rs
@@ -1326,8 +1326,10 @@ impl ReplayEventProjectionService {
     /// This is the bounded-memory replacement for collecting the entire
     /// prefix into a `Vec`. The fold visits each page in sequence and only
     /// retains state for invocations the caller already saw in the current
-    /// page, so allocation is `O(touched.len())` regardless of how many
-    /// runtime events the stream has produced. A hard cap of
+    /// page plus direct child capability activities of touched parent runs.
+    /// Emitted capability activities are bounded by `capability_activity_output_limit`
+    /// after the fold, so one terminal run event cannot return an unbounded
+    /// historical child-activity set. A hard cap of
     /// [`STATE_REPLAY_MAX_EVENTS`] events scanned per call protects against
     /// pathological histories — when exceeded, the caller is told to rebase.
     async fn fold_runtime_prefix(
@@ -1335,8 +1337,11 @@ impl ReplayEventProjectionService {
         scope: &ProjectionScope,
         until: EventCursor,
         touched: &HashSet<InvocationId>,
+        capability_activity_output_limit: usize,
     ) -> Result<RuntimeProjectionState, ProjectionError> {
-        let mut state = RuntimeProjectionState::without_capability_activity_output_limit();
+        let mut state = RuntimeProjectionState::with_capability_activity_output_limit(
+            capability_activity_output_limit,
+        );
         if touched.is_empty() || until == EventCursor::origin() {
             return Ok(state);
         }
@@ -1442,6 +1447,7 @@ impl EventProjectionService for ReplayEventProjectionService {
         request: ProjectionRequest,
     ) -> Result<ProjectionReplay, ProjectionError> {
         let scope = request.scope.clone();
+        let limit = request.limit;
         let page = self.read_runtime(request).await?;
         let capability_activity_transitions = page
             .entries
@@ -1457,7 +1463,7 @@ impl EventProjectionService for ReplayEventProjectionService {
             (Vec::new(), Vec::new())
         } else {
             let folded = self
-                .fold_runtime_prefix(&scope, page.next_cursor.runtime, &touched_runs)
+                .fold_runtime_prefix(&scope, page.next_cursor.runtime, &touched_runs, limit)
                 .await?;
             folded.into_parts()
         };

--- a/crates/ironclaw_event_projections/src/lib.rs
+++ b/crates/ironclaw_event_projections/src/lib.rs
@@ -1374,7 +1374,7 @@ impl ReplayEventProjectionService {
                         )),
                     });
                 }
-                if touched.contains(&entry.record.scope.invocation_id) {
+                if entry_touches_invocations(entry, touched) {
                     state.apply(entry);
                 }
                 if entry.cursor >= until {
@@ -1389,6 +1389,17 @@ impl ReplayEventProjectionService {
         }
         Ok(state)
     }
+}
+
+fn entry_touches_invocations(
+    entry: &EventLogEntry<RuntimeEvent>,
+    touched: &HashSet<InvocationId>,
+) -> bool {
+    touched.contains(&entry.record.scope.invocation_id)
+        || entry
+            .record
+            .parent_invocation_id
+            .is_some_and(|parent| touched.contains(&parent))
 }
 
 impl std::fmt::Debug for ReplayEventProjectionService {

--- a/crates/ironclaw_event_projections/src/runtime_projection.rs
+++ b/crates/ironclaw_event_projections/src/runtime_projection.rs
@@ -8,6 +8,8 @@ use crate::{
     RunStatusProjection,
 };
 
+const CANCELLED_ACTIVITY_ERROR_KIND: &str = "cancelled";
+
 pub(crate) struct RuntimeProjectionState {
     runs: HashMap<InvocationId, RunStatusProjection>,
     capability_activities: HashMap<InvocationId, CapabilityActivityProjection>,
@@ -15,14 +17,6 @@ pub(crate) struct RuntimeProjectionState {
 }
 
 impl RuntimeProjectionState {
-    pub(crate) fn without_capability_activity_output_limit() -> Self {
-        Self {
-            runs: HashMap::new(),
-            capability_activities: HashMap::new(),
-            capability_activity_output_limit: None,
-        }
-    }
-
     pub(crate) fn with_capability_activity_output_limit(limit: usize) -> Self {
         Self {
             runs: HashMap::new(),
@@ -283,7 +277,8 @@ fn apply_loop_terminal_to_child_activities(
         return;
     };
     let run_id = event.scope.invocation_id;
-    let sanitized_error_kind = event.error_kind.clone().map(sanitize_error_kind);
+    let terminal_error_kind =
+        child_activity_error_kind_for_loop_terminal(event.kind, event.error_kind.as_deref());
     for activity in activities.values_mut() {
         if activity.run_id != Some(run_id) || activity_is_terminal(activity.status) {
             continue;
@@ -291,8 +286,8 @@ fn apply_loop_terminal_to_child_activities(
         activity.status = status;
         if status == CapabilityActivityStatus::Completed {
             activity.error_kind = None;
-        } else if sanitized_error_kind.is_some() {
-            activity.error_kind = sanitized_error_kind.clone();
+        } else if let Some(error_kind) = terminal_error_kind.clone() {
+            activity.error_kind = Some(error_kind);
         }
         activity.last_cursor = entry.cursor;
         activity.updated_at = event.timestamp;
@@ -307,6 +302,22 @@ fn child_activity_status_for_loop_terminal(
         RuntimeEventKind::LoopCancelled | RuntimeEventKind::LoopFailed => {
             Some(CapabilityActivityStatus::Failed)
         }
+        _ => None,
+    }
+}
+
+fn child_activity_error_kind_for_loop_terminal(
+    kind: RuntimeEventKind,
+    error_kind: Option<&str>,
+) -> Option<String> {
+    match kind {
+        RuntimeEventKind::LoopCompleted => None,
+        RuntimeEventKind::LoopCancelled => Some(
+            error_kind
+                .map(sanitize_error_kind)
+                .unwrap_or_else(|| CANCELLED_ACTIVITY_ERROR_KIND.to_string()),
+        ),
+        RuntimeEventKind::LoopFailed => error_kind.map(sanitize_error_kind),
         _ => None,
     }
 }

--- a/crates/ironclaw_event_projections/src/runtime_projection.rs
+++ b/crates/ironclaw_event_projections/src/runtime_projection.rs
@@ -228,6 +228,7 @@ fn apply_capability_activity_event(
     entry: &EventLogEntry<RuntimeEvent>,
 ) {
     let event = &entry.record;
+    apply_loop_terminal_to_child_activities(activities, entry);
     let existing = activities.get(&event.scope.invocation_id);
     let Some(status) = capability_activity_status_for_event(
         event.kind,
@@ -271,6 +272,52 @@ fn apply_capability_activity_event(
     }
     activity.last_cursor = entry.cursor;
     activity.updated_at = event.timestamp;
+}
+
+fn apply_loop_terminal_to_child_activities(
+    activities: &mut HashMap<InvocationId, CapabilityActivityProjection>,
+    entry: &EventLogEntry<RuntimeEvent>,
+) {
+    let event = &entry.record;
+    let Some(status) = child_activity_status_for_loop_terminal(event.kind) else {
+        return;
+    };
+    let run_id = event.scope.invocation_id;
+    let sanitized_error_kind = event.error_kind.clone().map(sanitize_error_kind);
+    for activity in activities.values_mut() {
+        if activity.run_id != Some(run_id) || activity_is_terminal(activity.status) {
+            continue;
+        }
+        activity.status = status;
+        if status == CapabilityActivityStatus::Completed {
+            activity.error_kind = None;
+        } else if sanitized_error_kind.is_some() {
+            activity.error_kind = sanitized_error_kind.clone();
+        }
+        activity.last_cursor = entry.cursor;
+        activity.updated_at = event.timestamp;
+    }
+}
+
+fn child_activity_status_for_loop_terminal(
+    kind: RuntimeEventKind,
+) -> Option<CapabilityActivityStatus> {
+    match kind {
+        RuntimeEventKind::LoopCompleted => Some(CapabilityActivityStatus::Completed),
+        RuntimeEventKind::LoopCancelled | RuntimeEventKind::LoopFailed => {
+            Some(CapabilityActivityStatus::Failed)
+        }
+        _ => None,
+    }
+}
+
+fn activity_is_terminal(status: CapabilityActivityStatus) -> bool {
+    matches!(
+        status,
+        CapabilityActivityStatus::Completed
+            | CapabilityActivityStatus::Failed
+            | CapabilityActivityStatus::Killed
+    )
 }
 
 fn capability_activity_projection_for_entry(

--- a/crates/ironclaw_event_projections/tests/replay_projection_contract.rs
+++ b/crates/ironclaw_event_projections/tests/replay_projection_contract.rs
@@ -1099,6 +1099,10 @@ async fn replay_projection_marks_capability_activity_failed_when_loop_is_cancell
         snapshot.capability_activities[0].status,
         CapabilityActivityStatus::Failed
     );
+    assert_eq!(
+        snapshot.capability_activities[0].error_kind.as_deref(),
+        Some("cancelled")
+    );
     assert_eq!(snapshot.capability_activities[0].capability_id, capability);
 
     let replay = service
@@ -1124,6 +1128,62 @@ async fn replay_projection_marks_capability_activity_failed_when_loop_is_cancell
         replay.capability_activities[0].status,
         CapabilityActivityStatus::Failed
     );
+    assert_eq!(
+        replay.capability_activities[0].error_kind.as_deref(),
+        Some("cancelled")
+    );
+}
+
+#[tokio::test]
+async fn replay_projection_updates_bound_loop_cancelled_child_activities() {
+    let log = Arc::new(InMemoryDurableEventLog::new());
+    let service = ReplayEventProjectionService::new(Arc::clone(&log));
+    let run_invocation = InvocationId::new();
+    let run_scope = scope_for_thread_with_invocation(
+        ThreadId::new("thread-tool-activity-cancelled-window").unwrap(),
+        run_invocation,
+    );
+    let capability = capability_id();
+    let mut last_child_cursor = EventCursor::origin();
+
+    for _ in 0..5 {
+        let mut child_scope = run_scope.clone();
+        child_scope.invocation_id = InvocationId::new();
+        let mut requested =
+            RuntimeEvent::capability_activity_requested(child_scope, capability.clone());
+        requested.parent_invocation_id = Some(run_invocation);
+        last_child_cursor = log.append(requested).await.unwrap().cursor;
+    }
+    log.append(RuntimeEvent::loop_cancelled(
+        run_scope.clone(),
+        capability.clone(),
+    ))
+    .await
+    .unwrap();
+
+    let projection_scope = ProjectionScope::from_resource_scope(&run_scope);
+    let replay = service
+        .updates(ProjectionRequest {
+            scope: projection_scope.clone(),
+            after: Some(ProjectionCursor::for_scope(
+                projection_scope,
+                last_child_cursor,
+            )),
+            limit: 2,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(replay.updates.len(), 1);
+    assert_eq!(
+        replay.capability_activities.len(),
+        2,
+        "updates must not emit every historical child activity when one terminal run event is touched"
+    );
+    assert!(replay.capability_activities.iter().all(|activity| {
+        activity.status == CapabilityActivityStatus::Failed
+            && activity.error_kind.as_deref() == Some("cancelled")
+    }));
 }
 
 #[tokio::test]

--- a/crates/ironclaw_event_projections/tests/replay_projection_contract.rs
+++ b/crates/ironclaw_event_projections/tests/replay_projection_contract.rs
@@ -1052,6 +1052,81 @@ async fn replay_projection_folds_process_completed_into_completed_capability_act
 }
 
 #[tokio::test]
+async fn replay_projection_marks_capability_activity_failed_when_loop_is_cancelled() {
+    let log = Arc::new(InMemoryDurableEventLog::new());
+    let service = ReplayEventProjectionService::new(Arc::clone(&log));
+    let run_invocation = InvocationId::new();
+    let run_scope = scope_for_thread_with_invocation(
+        ThreadId::new("thread-tool-activity-cancelled").unwrap(),
+        run_invocation,
+    );
+    let tool_invocation = InvocationId::new();
+    let mut tool_scope = run_scope.clone();
+    tool_scope.invocation_id = tool_invocation;
+    let capability = capability_id();
+
+    let mut requested = RuntimeEvent::capability_activity_requested(tool_scope, capability.clone());
+    requested.parent_invocation_id = Some(run_invocation);
+    let started = log.append(requested).await.unwrap();
+    log.append(RuntimeEvent::loop_cancelled(
+        run_scope.clone(),
+        capability.clone(),
+    ))
+    .await
+    .unwrap();
+
+    let snapshot = service
+        .snapshot(ProjectionRequest {
+            scope: ProjectionScope::from_resource_scope(&run_scope),
+            after: None,
+            limit: 16,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(snapshot.runs.len(), 1);
+    assert_eq!(snapshot.runs[0].status, RunProjectionStatus::Cancelled);
+    assert_eq!(snapshot.capability_activities.len(), 1);
+    assert_eq!(
+        snapshot.capability_activities[0].invocation_id,
+        tool_invocation
+    );
+    assert_eq!(
+        snapshot.capability_activities[0].run_id,
+        Some(run_invocation)
+    );
+    assert_eq!(
+        snapshot.capability_activities[0].status,
+        CapabilityActivityStatus::Failed
+    );
+    assert_eq!(snapshot.capability_activities[0].capability_id, capability);
+
+    let replay = service
+        .updates(ProjectionRequest {
+            scope: ProjectionScope::from_resource_scope(&run_scope),
+            after: Some(ProjectionCursor::for_scope(
+                ProjectionScope::from_resource_scope(&run_scope),
+                started.cursor,
+            )),
+            limit: 16,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(replay.runs.len(), 1);
+    assert_eq!(replay.runs[0].status, RunProjectionStatus::Cancelled);
+    assert_eq!(replay.capability_activities.len(), 1);
+    assert_eq!(
+        replay.capability_activities[0].invocation_id,
+        tool_invocation
+    );
+    assert_eq!(
+        replay.capability_activities[0].status,
+        CapabilityActivityStatus::Failed
+    );
+}
+
+#[tokio::test]
 async fn replay_projection_snapshot_bounds_capability_activity_window_to_request_limit() {
     let log = Arc::new(InMemoryDurableEventLog::new());
     let service = ReplayEventProjectionService::new(Arc::clone(&log));


### PR DESCRIPTION
## Summary

- Ensures loop terminal events close still-open child capability activities in the runtime projection read model.
- Includes parent-invocation child events when folding touched run state, so live `updates()` after a run cancellation can emit the child activity terminal state instead of leaving it RUN/started.
- Adds regression coverage for a child GitHub-style capability activity followed by `LoopCancelled` across both snapshot and update projection paths.

## Linked Issue

Closes #4800

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p ironclaw_event_projections replay_projection_marks_capability_activity_failed_when_loop_is_cancelled --locked`
- [x] `cargo test -p ironclaw_event_projections --locked`
- [x] `cargo clippy -p ironclaw_event_projections --all-targets --locked -- -D warnings`
- [x] `cargo test -p ironclaw_reborn_composition runtime_stream --locked`
- [x] `git diff --check`

## Security Impact

No new permissions, network calls, secrets access, or sandbox changes. This tightens the user-facing projection boundary so cancelled/failed runs do not leave child capability activity in an active state.

## Database Impact

None.

## Blast Radius

Runtime projection read-model behavior for child capability activity status after loop terminal events. WebUI/SSE consumers may now see terminal Failed/Completed activity state instead of stale Started/Running for activities under terminal runs.

## Rollback Plan

Revert this PR to restore the previous projection behavior.

## Review Follow-Through

Reviewer judgment requested on whether a future public `cancelled` activity status should be added; this PR keeps the existing public enum and maps run cancellation to terminal failed activity state to avoid wire-shape churn.

---

**Review track**: B