### PR TITLE
fix(reborn): prefer GitHub extension for repository data

### DIFF
--- a/crates/ironclaw_first_party_extensions/assets/web-access/manifest.toml
+++ b/crates/ironclaw_first_party_extensions/assets/web-access/manifest.toml
@@ -11,7 +11,7 @@ service = "web-access"
 
 [[capabilities]]
 id = "web-access.search"
-description = "Search the web with zero-config Exa MCP and return cited source results."
+description = "Search the web with zero-config Exa MCP and return cited source results. Prefer GitHub extension capabilities for GitHub repository, issue, pull request, release, or workflow data when they are available."
 effects = ["dispatch_capability", "network"]
 default_permission = "allow"
 visibility = "model"

--- a/crates/ironclaw_first_party_extensions/assets/web-access/prompts/web-access/search.md
+++ b/crates/ironclaw_first_party_extensions/assets/web-access/prompts/web-access/search.md
@@ -1,1 +1,3 @@
 Search the web when current external information or sourced references are needed. Prefer a small set of specific queries over one broad query.
+
+For GitHub repository, issue, pull request, release, or workflow data, prefer the GitHub extension capabilities when they are available. Use web search only when the GitHub extension is unavailable or when the user asks for general web coverage beyond GitHub API data.

--- a/crates/ironclaw_host_runtime/src/first_party_tools/http.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/http.rs
@@ -32,6 +32,7 @@ const MAX_NETWORK_EGRESS_BYTES: u64 = 256 * 1024;
 const MAX_HTTP_HEADERS: usize = 64;
 const MAX_HTTP_HEADER_NAME_BYTES: usize = 512;
 const MAX_HTTP_HEADER_VALUE_BYTES: usize = 8 * 1024;
+const GITHUB_EXTENSION_PREFERENCE: &str = "Prefer GitHub extension capabilities for GitHub repository, issue, pull request, release, or workflow data when they are available.";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum HttpSaveMode {
@@ -52,7 +53,7 @@ impl HttpSaveMode {
 pub(super) fn manifest() -> Result<CapabilityManifest, ExtensionError> {
     http_manifest(
         HTTP_CAPABILITY_ID,
-        "Perform an outbound HTTP request through host egress. Redirect responses are returned; the host transport does not follow them. Prefer GitHub extension capabilities for GitHub repository, issue, pull request, release, or workflow data when they are available.",
+        "Perform an outbound HTTP request through host egress. Redirect responses are returned; the host transport does not follow them.",
         vec![EffectKind::DispatchCapability, EffectKind::Network],
     )
 }
@@ -60,7 +61,7 @@ pub(super) fn manifest() -> Result<CapabilityManifest, ExtensionError> {
 pub(super) fn save_manifest() -> Result<CapabilityManifest, ExtensionError> {
     http_manifest(
         HTTP_SAVE_CAPABILITY_ID,
-        "Perform an outbound HTTP request through host egress and save the sanitized response body through scoped filesystem authority. Prefer GitHub extension capabilities for GitHub repository, issue, pull request, release, or workflow data when they are available.",
+        "Perform an outbound HTTP request through host egress and save the sanitized response body through scoped filesystem authority.",
         vec![
             EffectKind::DispatchCapability,
             EffectKind::Network,
@@ -74,9 +75,10 @@ fn http_manifest(
     description: &str,
     effects: Vec<EffectKind>,
 ) -> Result<CapabilityManifest, ExtensionError> {
+    let description = format!("{description} {GITHUB_EXTENSION_PREFERENCE}");
     first_party_capability_manifest(
         capability_id,
-        description,
+        &description,
         effects,
         PermissionMode::Ask,
         Some(http_resource_profile()),

--- a/crates/ironclaw_host_runtime/src/first_party_tools/http.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/http.rs
@@ -52,7 +52,7 @@ impl HttpSaveMode {
 pub(super) fn manifest() -> Result<CapabilityManifest, ExtensionError> {
     http_manifest(
         HTTP_CAPABILITY_ID,
-        "Perform an outbound HTTP request through host egress. Redirect responses are returned; the host transport does not follow them.",
+        "Perform an outbound HTTP request through host egress. Redirect responses are returned; the host transport does not follow them. Prefer GitHub extension capabilities for GitHub repository, issue, pull request, release, or workflow data when they are available.",
         vec![EffectKind::DispatchCapability, EffectKind::Network],
     )
 }
@@ -60,7 +60,7 @@ pub(super) fn manifest() -> Result<CapabilityManifest, ExtensionError> {
 pub(super) fn save_manifest() -> Result<CapabilityManifest, ExtensionError> {
     http_manifest(
         HTTP_SAVE_CAPABILITY_ID,
-        "Perform an outbound HTTP request through host egress and save the sanitized response body through scoped filesystem authority.",
+        "Perform an outbound HTTP request through host egress and save the sanitized response body through scoped filesystem authority. Prefer GitHub extension capabilities for GitHub repository, issue, pull request, release, or workflow data when they are available.",
         vec![
             EffectKind::DispatchCapability,
             EffectKind::Network,

--- a/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
@@ -118,6 +118,11 @@ async fn builtin_first_party_package_declares_expected_capabilities() {
         http.effects,
         vec![EffectKind::DispatchCapability, EffectKind::Network]
     );
+    assert!(
+        http.description
+            .contains("Prefer GitHub extension capabilities"),
+        "builtin.http should steer GitHub repository API tasks toward the GitHub extension"
+    );
     let http_save = package
         .capabilities
         .iter()
@@ -130,6 +135,12 @@ async fn builtin_first_party_package_declares_expected_capabilities() {
             EffectKind::Network,
             EffectKind::WriteFilesystem
         ]
+    );
+    assert!(
+        http_save
+            .description
+            .contains("Prefer GitHub extension capabilities"),
+        "builtin.http.save should steer GitHub repository API tasks toward the GitHub extension"
     );
 
     let memory_write = package

--- a/crates/ironclaw_reborn_composition/src/available_extensions.rs
+++ b/crates/ironclaw_reborn_composition/src/available_extensions.rs
@@ -1594,6 +1594,41 @@ mod tests {
     }
 
     #[test]
+    fn bundled_web_access_defers_github_repository_tasks_to_github_extension() {
+        let catalog = AvailableExtensionCatalog::from_first_party_assets().unwrap();
+        let package_ref =
+            LifecyclePackageRef::new(LifecyclePackageKind::Extension, "web-access").unwrap();
+        let package = catalog.resolve(&package_ref).unwrap();
+        let search = package
+            .package
+            .manifest
+            .capabilities
+            .iter()
+            .find(|capability| capability.id.as_str() == "web-access.search")
+            .expect("web access search capability");
+        assert!(
+            search
+                .description
+                .contains("Prefer GitHub extension capabilities"),
+            "web-access.search description should route GitHub repository data to GitHub tools"
+        );
+
+        let prompt_asset = package
+            .assets
+            .iter()
+            .find(|asset| asset.path == "prompts/web-access/search.md")
+            .expect("web access search prompt");
+        let AvailableExtensionAssetContent::Bytes(bytes) = &prompt_asset.content else {
+            panic!("web access prompt should be bundled bytes");
+        };
+        let prompt = std::str::from_utf8(bytes).expect("prompt should be UTF-8");
+        assert!(
+            prompt.contains("prefer the GitHub extension capabilities"),
+            "web-access.search prompt should route GitHub repository data to GitHub tools"
+        );
+    }
+
+    #[test]
     fn bundled_extension_summaries_include_onboarding_messages() {
         let catalog = AvailableExtensionCatalog::from_first_party_assets().unwrap();
 


### PR DESCRIPTION
## Summary

- Steer `builtin.http` and `builtin.http.save` descriptions toward GitHub extension capabilities for GitHub repository, issue, pull request, release, or workflow data.
- Add the same GitHub-extension preference to the Web Access search capability description and prompt.
- Add focused contract coverage for the builtin HTTP descriptions and bundled Web Access prompt/catalog content.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Closes #4867

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [ ] `cargo build`
- [x] Relevant tests pass: `cargo test -p ironclaw_host_runtime builtin_first_party_package_declares_expected_capabilities --locked --quiet`, `cargo test -p ironclaw_reborn_composition bundled_web_access_defers_github_repository_tasks_to_github_extension --locked --quiet`
- [ ] `cargo test --features integration` if database-backed or integration behavior changed
- [ ] Manual testing: Not applicable; model-facing routing copy is covered by contract tests.
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

Additional validation:
- `cargo test -p ironclaw_extensions --test manifest_v2_contract --locked`
- `git diff --check`

## Security Impact

None. This changes model-facing capability descriptions/prompts only; it does not add permissions, network access, secrets access, filesystem access, tool execution, or sandbox policy changes.

## Database Impact

None.

## Blast Radius

Limited to builtin HTTP tool descriptions and the bundled Web Access extension metadata/prompt. The runtime still permits raw HTTP when appropriate; this PR only nudges GitHub repository-style tasks toward the GitHub extension when available.

## Rollback Plan

Revert this PR to restore the previous generic HTTP/Web Access descriptions.

## Review Follow-Through

Reviewer judgment requested on whether this prompt-level routing is sufficient for #4867, or whether a later hard policy should block raw HTTP for GitHub API-style repository reads when the GitHub extension is installed.

---

**Review track**: B
