### PR TITLE
fix(runtime-context): key comms preferences by run owner + cover JoinError gaps

### DIFF
--- a/crates/ironclaw_reborn_composition/src/communication_context.rs
+++ b/crates/ironclaw_reborn_composition/src/communication_context.rs
@@ -81,9 +81,21 @@ async fn fetch_communication_context(
     actor: Option<TurnActor>,
 ) -> Option<CommunicationRuntimeContext> {
     let actor = actor?;
+    // Key outbound preferences by the run's *owner*, not the acting principal.
+    // Product inbound and trusted-trigger runs can carry an explicit thread
+    // owner (subject/creator) that differs from `actor`; the owner is who the
+    // stored delivery preference belongs to. Fall back to the actor when no
+    // explicit owner is set, matching `TurnScope::to_resource_scope`'s owner
+    // resolution. Without this, shared/channel inbound and trigger runs would
+    // render the actor's delivery target (or "none set") instead of the
+    // owner's, producing wrong delivery guidance.
+    let owner_user_id = scope
+        .explicit_owner_user_id()
+        .cloned()
+        .unwrap_or_else(|| actor.user_id.clone());
     let caller = WebUiAuthenticatedCaller::new(
         scope.tenant_id.clone(),
-        actor.user_id.clone(),
+        owner_user_id,
         scope.agent_id.clone(),
         scope.project_id.clone(),
     );
@@ -491,6 +503,97 @@ mod tests {
             .resolve(false)
             .await;
         assert!(result.is_none(), "actor None must return None");
+    }
+
+    // --- Tests: preference lookup is keyed by the run owner, not the actor ---
+
+    /// Preferences facade that records the `user_id` of the caller it received,
+    /// so tests can assert the provider keys the lookup by the run owner rather
+    /// than the acting principal.
+    struct CaptureCallerPreferencesFacade {
+        seen_user_id: Arc<std::sync::Mutex<Option<String>>>,
+    }
+
+    #[async_trait]
+    impl OutboundPreferencesProductFacade for CaptureCallerPreferencesFacade {
+        async fn get_outbound_preferences(
+            &self,
+            caller: WebUiAuthenticatedCaller,
+        ) -> Result<RebornOutboundPreferencesResponse, RebornServicesError> {
+            *self.seen_user_id.lock().expect("lock") = Some(caller.user_id.as_str().to_string());
+            Ok(RebornOutboundPreferencesResponse::default())
+        }
+
+        async fn set_outbound_preferences(
+            &self,
+            _caller: WebUiAuthenticatedCaller,
+            _request: RebornSetOutboundPreferencesRequest,
+        ) -> Result<RebornOutboundPreferencesResponse, RebornServicesError> {
+            Ok(RebornOutboundPreferencesResponse::default())
+        }
+
+        async fn list_outbound_delivery_targets(
+            &self,
+            _caller: WebUiAuthenticatedCaller,
+        ) -> Result<RebornOutboundDeliveryTargetListResponse, RebornServicesError> {
+            Ok(RebornOutboundDeliveryTargetListResponse {
+                targets: Vec::new(),
+                next_cursor: None,
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn preferences_keyed_by_explicit_owner_not_actor() {
+        let seen_user_id = Arc::new(std::sync::Mutex::new(None));
+        let facade = CaptureCallerPreferencesFacade {
+            seen_user_id: Arc::clone(&seen_user_id),
+        };
+        let provider = RuntimeCommunicationContextProvider::new(Arc::new(facade));
+
+        // Scope owned by a subject/creator distinct from the acting principal
+        // (e.g. a trusted trigger or shared/channel inbound run).
+        let owned_scope = TurnScope::new_with_owner(
+            TenantId::new("tenant-test").unwrap(),
+            Some(AgentId::new("agent-test").unwrap()),
+            Some(ProjectId::new("project-test").unwrap()),
+            ironclaw_host_api::ThreadId::new("thread-test").unwrap(),
+            Some(UserId::new("owner-test").unwrap()),
+        );
+
+        provider
+            .begin_communication_context(owned_scope, Some(actor()))
+            .resolve(false)
+            .await
+            .expect("context");
+
+        assert_eq!(
+            seen_user_id.lock().expect("lock").as_deref(),
+            Some("owner-test"),
+            "preference lookup must be keyed by the explicit run owner, not the actor",
+        );
+    }
+
+    #[tokio::test]
+    async fn preferences_fall_back_to_actor_without_explicit_owner() {
+        let seen_user_id = Arc::new(std::sync::Mutex::new(None));
+        let facade = CaptureCallerPreferencesFacade {
+            seen_user_id: Arc::clone(&seen_user_id),
+        };
+        let provider = RuntimeCommunicationContextProvider::new(Arc::new(facade));
+
+        // `scope()` uses `TurnThreadOwner::ActorFallback` (no explicit owner).
+        provider
+            .begin_communication_context(scope(), Some(actor()))
+            .resolve(false)
+            .await
+            .expect("context");
+
+        assert_eq!(
+            seen_user_id.lock().expect("lock").as_deref(),
+            Some("user-test"),
+            "with no explicit owner the lookup must fall back to the actor",
+        );
     }
 
     // --- Tests: delivery target state branches ---

--- a/crates/ironclaw_turns/src/run_profile/runtime_context.rs
+++ b/crates/ironclaw_turns/src/run_profile/runtime_context.rs
@@ -1112,4 +1112,36 @@ mod tests {
             text.len()
         );
     }
+
+    // --- CommunicationContextFetch::resolve JoinError degradation ---
+
+    #[tokio::test]
+    async fn fetch_join_error_without_actor_resolves_to_none() {
+        // A task that panics yields a `JoinError`. With `actor_present = false`
+        // the slice is not applicable, so resolve must degrade to `None` rather
+        // than fabricating an `Unknown` communication slice for an actorless run.
+        let handle = tokio::spawn(async { panic!("simulated communication fetch failure") });
+        let fetch = CommunicationContextFetch::from_handle(handle, false);
+        let resolved = fetch.resolve(false).await;
+        assert!(
+            resolved.is_none(),
+            "actorless JoinError must degrade to None, got {resolved:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn fetch_join_error_with_actor_resolves_to_unknown() {
+        // With `actor_present = true` the same `JoinError` must degrade to a
+        // `Some(Unknown…)` slice so the actor-present / no-actor distinction is
+        // preserved on the failure path.
+        let handle = tokio::spawn(async { panic!("simulated communication fetch failure") });
+        let fetch = CommunicationContextFetch::from_handle(handle, true);
+        let resolved = fetch
+            .resolve(false)
+            .await
+            .expect("actor-present JoinError must degrade to Some(Unknown)");
+        assert_eq!(resolved.connected_channels, ConnectedChannelsState::Unknown);
+        assert_eq!(resolved.delivery_target, DeliveryTargetState::Unknown);
+        assert!(!resolved.delivery_tools_visible);
+    }
 }

--- a/docs/superpowers/plans/2026-06-13-product-context-factory.md
+++ b/docs/superpowers/plans/2026-06-13-product-context-factory.md
@@ -96,10 +96,15 @@ pub enum TurnSurfaceType {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RunOriginAdapter(String);
 
+/// Mirrors `AdapterKind`'s validation bound in `ironclaw_conversations` so that
+/// any valid `AdapterKind` always converts without silent narrowing. If
+/// `AdapterKind`'s limit changes, update this constant to match.
+const MAX_RUN_ORIGIN_ADAPTER_BYTES: usize = 512;
+
 impl RunOriginAdapter {
     pub fn new(value: impl Into<String>) -> Result<Self, crate::TurnError> {
         let value = value.into();
-        if value.is_empty() || value.len() > 256 {
+        if value.is_empty() || value.len() > MAX_RUN_ORIGIN_ADAPTER_BYTES {
             return Err(crate::TurnError::InvalidRunOriginAdapter);
         }
         Ok(Self(value))
@@ -139,7 +144,7 @@ pub struct ProductTurnContext {
 - [ ] **Step 4: Add the error variant** — in `crates/ironclaw_turns/src/status.rs` (find the `TurnError` enum; if errors live elsewhere, grep `enum TurnError`), add:
 
 ```rust
-    #[error("invalid run-origin adapter: must be 1..=256 bytes")]
+    #[error("invalid run-origin adapter: must be 1..=512 bytes")]
     InvalidRunOriginAdapter,
 ```
 


### PR DESCRIPTION
Post-merge review follow-ups for #4836 (review [#pullrequestreview-4493753996](https://github.com/nearai/ironclaw/pull/4836#pullrequestreview-4493753996)). Verified all 7 findings against merged `main`; 3 are real and fixed, 4 are no-action (false positive / already fixed / owned by #4851 / already mitigated).

## Fixed

- **Bug (Medium) — comms preferences keyed by actor, not run owner** (`crates/ironclaw_reborn_composition/src/communication_context.rs`)
  `fetch_communication_context` built the `WebUiAuthenticatedCaller` from `actor.user_id`, but outbound preferences are keyed by the caller's user. Product inbound and trusted-trigger runs can carry an explicit thread owner (subject/creator) distinct from the actor, so those runs rendered the *actor's* delivery target (or `none set`) instead of the owner's — wrong delivery guidance/warnings. Now resolves via `scope.explicit_owner_user_id()` with actor fallback, matching `TurnScope::to_resource_scope`. Adds two regression tests (owner vs actor) via a caller-capturing facade.

- **Tests (Medium) — JoinError branches uncovered** (`crates/ironclaw_turns/src/run_profile/runtime_context.rs`)
  `CommunicationContextFetch::resolve`'s panic/abort degradation was untested. Adds two tests: actorless failure → `None`; actor-present failure → `Some(Unknown)`.

- **Docs (Low) — stale adapter bound** (`docs/superpowers/plans/2026-06-13-product-context-factory.md`)
  Plan still specified the rejected 256-byte `RunOriginAdapter` cap; updated to the as-built 512-byte bound (mirrors `AdapterKind`) so follow-up work doesn't reintroduce the narrowing.

## No action (verified)

- **`model_safe_label` injection** — false positive. Label sources (channel names, delivery-target display names, adapter ids) are admin/system-set, not per-turn attacker text; the sanitizer strips structural characters and existing hostile-input tests pass.
- **Shared-route surface assertion** — already covered by `shared_user_message_records_channel_surface_type`.
- **String-based trigger helper** (`is_trusted_trigger_adapter_kind`) — zero callers on `main`; owned by issue #4851's committed plan.
- **RunOriginAdapter byte-mirror** — already mitigated by a named const + cross-ref docs + boundary tests.

## Validation
- `cargo fmt` — clean
- `cargo clippy -p ironclaw_turns -p ironclaw_reborn_composition --tests --all-features` — zero warnings
- `cargo test -p ironclaw_turns -p ironclaw_reborn_composition` — green (new tests pass)

Relates to #4836. Defers trigger-classification concern to #4851.

🤖 Generated with [Claude Code](https://claude.com/claude-code)