### PR TITLE
fix(agent-loop): surface resume-origin capability failures instead of dying as scope_mismatch

### DIFF
--- a/crates/ironclaw_agent_loop/src/executor/capabilities.rs
+++ b/crates/ironclaw_agent_loop/src/executor/capabilities.rs
@@ -4,9 +4,9 @@ use async_trait::async_trait;
 use ironclaw_turns::{
     LoopFailureKind, LoopResultRef,
     run_profile::{
-        CapabilityBatchInvocation, CapabilityCallCandidate, CapabilityFailureKind,
-        CapabilityOutcome, CapabilityProgress, CapabilityResultMessage, LoopDriverNoteKind,
-        LoopProgressEvent, VisibleCapabilitySurface,
+        CapabilityApprovalResume, CapabilityBatchInvocation, CapabilityCallCandidate,
+        CapabilityFailureKind, CapabilityOutcome, CapabilityProgress, CapabilityResultMessage,
+        LoopDriverNoteKind, LoopProgressEvent, VisibleCapabilitySurface,
     },
 };
 
@@ -634,6 +634,49 @@ impl CapabilityStage {
         mut model_observation: Option<ironclaw_turns::run_profile::ModelVisibleToolObservation>,
         capability_batch: &mut CapabilityBatchTurnSummary,
     ) -> Result<BatchStep, AgentLoopExecutorError> {
+        // Snapshot resume-origin flags for this call BEFORE clearing the pending
+        // slots.
+        //
+        // Safety invariants:
+        //   S1: A resume-origin failure must never surface as scope_mismatch /
+        //       terminal "Capability: unavailable".
+        //   S2: A side-effecting capability must never be silently re-executed by
+        //       a retry — the first resume dispatch already hit the backend.
+        //
+        // Part C-sub-A (primary guard): when this failure originated from an
+        // approval-resume OR auth-resume dispatch (`is_resume_origin == true`), we
+        // intercept any `RecoveryOutcome::Retry` outcome below and redirect it to
+        // `ToolErrorResult` instead.  This:
+        //   - Kills scope_mismatch (S1): no retry ever reaches the cross-run
+        //     input_ref without the resume context.
+        //   - Prevents double-exec (S2): the backend is not invoked a second time.
+        //   - Surfaces the real error to the model so the user can re-approve /
+        //     re-authenticate.
+        //
+        // Auth-resume note: `PendingAuthResume` carries `input_ref` only (no
+        // inline `input` value); a non-resume retry dispatched through
+        // `capability_invocation_from_candidate(call.clone(), None)` would reach
+        // the product adapter's `ensure_ref_scoped_to_run` check without the auth
+        // context and fail with `ScopeMismatch`.  The same surface-and-continue
+        // redirect is therefore the correct fix for both resume origins.
+        //
+        // Part A (belt-and-suspenders): if a retry IS dispatched (only possible
+        // when `is_resume_origin == false`, i.e. non-resume path), we always pass
+        // `None` as before.  If this logic ever changes to allow a resume-origin
+        // retry, the approval/auth context must be threaded into
+        // `capability_invocation_from_candidate` so the retry cannot reach the host
+        // without its resume context.
+        let captured_approval_resume: Option<CapabilityApprovalResume> = state
+            .pending_approval_resume
+            .as_ref()
+            .filter(|r| r.capability_id == call.capability_id)
+            .map(|r| r.to_approval_resume());
+        let captured_auth_resume_origin: bool = state
+            .pending_auth_resume
+            .as_ref()
+            .is_some_and(|r| r.capability_id == call.capability_id);
+        let is_resume_origin = captured_approval_resume.is_some() || captured_auth_resume_origin;
+
         clear_matching_pending_approval_resume(&mut state, &call);
         clear_matching_pending_auth_resume(&mut state, &call);
         for _ in 0..MAX_CAPABILITY_RETRIES {
@@ -692,6 +735,30 @@ impl CapabilityStage {
                     recovery, alter, ..
                 } => {
                     state.recovery_state = recovery;
+
+                    // Part C-sub-A: a resume-origin retryable failure must not be
+                    // silently re-dispatched.  The first dispatch already contacted
+                    // the backend (side-effect risk) and a retry without the
+                    // approval/auth context would cause scope_mismatch.  Surface
+                    // the real error to the model as a clean tool error and
+                    // continue the loop so the user can re-approve / re-auth.
+                    if is_resume_origin {
+                        append_blocked_capability_error_result(
+                            ctx.host,
+                            &mut state,
+                            &call,
+                            &summary,
+                            model_observation,
+                            capability_batch,
+                        )
+                        .await?;
+                        match CheckpointStage.cancel_if_requested(ctx, state).await? {
+                            CancelCheck::Continue(next) => state = *next,
+                            CancelCheck::Exit(exit) => return Ok(BatchStep::Exit(exit)),
+                        }
+                        return Ok(BatchStep::Continue(Box::new(state)));
+                    }
+
                     match CheckpointStage.cancel_if_requested(ctx, state).await? {
                         CancelCheck::Continue(next) => state = *next,
                         CancelCheck::Exit(exit) => return Ok(BatchStep::Exit(exit)),
@@ -711,6 +778,11 @@ impl CapabilityStage {
                             })?,
                         )
                         .await;
+                    // Part A: Non-resume-origin retry.  `is_resume_origin` is
+                    // `false` here (the Part C-sub-A guard above short-circuited
+                    // for both approval-resume and auth-resume cases), so passing
+                    // `None` is correct and safe — there is no cross-run input_ref
+                    // to protect.
                     let retry_result = ctx
                         .host
                         .invoke_capability(capability_invocation_from_candidate(call.clone(), None))

--- a/crates/ironclaw_agent_loop/src/executor/tests.rs
+++ b/crates/ironclaw_agent_loop/src/executor/tests.rs
@@ -4989,3 +4989,349 @@ async fn auth_resume_slot_consumed_on_first_batch_match_not_reused_for_second_ca
          (pre-fix: was Some, reusing the same resume_token)"
     );
 }
+
+// ── Resume-origin Backend failure must not die as scope_mismatch ─────────────
+
+/// Regression test for the terminal `scope_mismatch` / `HostUnavailable` failure
+/// that surfaces when a capability's approval-resume dispatch returns a transient
+/// `Backend` error.
+///
+/// # Bug (capabilities.rs, pre-fix)
+///
+/// 1. Executor dispatches the capability with `approval_resume` set (batch path).
+/// 2. Host returns `Failed(Backend)`.
+/// 3. `handle_capability_error` clears `state.pending_approval_resume` BEFORE
+///    asking the planner for a recovery outcome.
+/// 4. Planner returns `RecoveryOutcome::Retry`.
+/// 5. Retry dispatch calls `invoke_capability(…, None)` — `approval_resume` is
+///    dropped.
+/// 6. MockHost `invoke_capability` has no scripted outcome → returns
+///    `Err(Internal, "single script exhausted")` → `capability_host_error` →
+///    `AgentLoopExecutorError::HostUnavailable { stage: Capability }`.
+///    In production the host would instead fail with `ScopeMismatch` because the
+///    original run's `input_ref` has no approval context to validate against.
+///
+/// # Fix (Part C-sub-A)
+///
+/// When the failure originated from an approval-resume dispatch, intercept
+/// `RecoveryOutcome::Retry` and redirect it to `ToolErrorResult` instead.
+/// The model sees the real backend error and the user can re-approve — no retry
+/// of the side effect, no scope_mismatch.
+///
+/// # What this test asserts (observable, not implementation detail)
+///
+/// - **Pre-fix (RED)**: `execute_family` on Phase 2 returns
+///   `Err(AgentLoopExecutorError::HostUnavailable { stage: HostStage::Capability })`
+///   — the run terminally dies.
+/// - **Post-fix (GREEN)**: `execute_family` on Phase 2 returns `Ok(LoopExit::Completed(_))`
+///   — the model sees the backend error as a tool result, issues a final reply,
+///   and the run completes cleanly.
+#[tokio::test]
+async fn resume_origin_backend_failure_does_not_die_as_scope_mismatch() {
+    let cap1_request_id = ApprovalRequestId::new();
+    let cap1_resume_token =
+        CapabilityResumeToken::new("resume-token:sm-test-cap1").expect("valid token");
+    let cap1_correlation_id = CorrelationId::new();
+    let cap1_input_ref =
+        CapabilityInputRef::new("input:run-original:sm-cap1-uuid").expect("valid input ref");
+
+    let cap1_approval_resume = CapabilityApprovalResume {
+        approval_request_id: cap1_request_id,
+        resume_token: cap1_resume_token,
+        correlation_id: cap1_correlation_id,
+        input_ref: cap1_input_ref.clone(),
+        input: serde_json::json!({"action": "cap1"}),
+        estimate: ResourceEstimate::default(),
+    };
+
+    // Phase 1 model response: issues cap1 with original-run input_ref.
+    let cap1_model_response = ironclaw_turns::run_profile::LoopModelResponse {
+        chunks: Vec::new(),
+        safe_reasoning_deltas: Vec::new(),
+        output: ParentLoopOutput::CapabilityCalls(vec![CapabilityCallCandidate {
+            surface_version: surface_version(),
+            capability_id: capability_id(),
+            input_ref: cap1_input_ref,
+            effective_capability_ids: vec![capability_id()],
+            provider_replay: None,
+        }]),
+        effective_model_profile_id: ironclaw_turns::run_profile::ModelProfileId::new("model")
+            .expect("valid"),
+        usage: None,
+    };
+
+    // Batch outcomes:
+    //   [0] Phase 1: cap1 → ApprovalRequired → gate blocked.
+    //   [1] Phase 2: cap1 approval-resume → Failed(Backend) — the bug trigger.
+    let batch_outcomes = vec![
+        // [0] cap1 → ApprovalRequired (gate blocked).
+        ironclaw_turns::run_profile::CapabilityBatchOutcome {
+            outcomes: vec![CapabilityOutcome::ApprovalRequired {
+                gate_ref: LoopGateRef::new("gate:sm-test-cap1").expect("valid"),
+                safe_summary: "cap1 needs approval".to_string(),
+                approval_resume: Some(cap1_approval_resume),
+            }],
+            stopped_on_suspension: true,
+        },
+        // [1] cap1 approval-resume → Backend failure.
+        ironclaw_turns::run_profile::CapabilityBatchOutcome {
+            outcomes: vec![CapabilityOutcome::Failed(
+                ironclaw_turns::run_profile::CapabilityFailure {
+                    error_kind: CapabilityFailureKind::Backend,
+                    safe_summary: "transient backend error during cap1 resume".to_string(),
+                    detail: None,
+                },
+            )],
+            stopped_on_suspension: false,
+        },
+    ];
+
+    // Phase 1: one model turn (cap1); Phase 2: after Backend→ToolErrorResult
+    // the loop continues and needs a model turn to issue the final reply.
+    let host = MockHost::new(vec![
+        cap1_model_response, // Phase 1: issues cap1
+        reply_response(),    // Phase 2 (post-fix): model sees tool error, issues reply
+    ])
+    .with_batch_outcomes(batch_outcomes);
+    // Deliberately NO single_outcomes: pre-fix, the retry would consume one and
+    // get `Err(Internal)` → HostUnavailable.  Post-fix, no retry is attempted.
+
+    let executor = CanonicalAgentLoopExecutor;
+
+    // ── Phase 1: cap1 → ApprovalRequired → Blocked ───────────────────────────
+    let initial_state = LoopExecutionState::initial_for_run(host.run_context());
+    let phase1_exit = executor
+        .execute_family(&crate::families::default(), &host, initial_state)
+        .await
+        .expect("phase 1 must succeed (blocks on cap1 gate)");
+    assert!(
+        matches!(phase1_exit, LoopExit::Blocked(_)),
+        "phase 1 must block on cap1 approval gate; got {phase1_exit:?}"
+    );
+
+    // Recover the BeforeBlock checkpoint state to use as Phase 2 input.
+    let phase1_bb = final_staged_state_for_kind(&host, LoopCheckpointKind::BeforeBlock);
+    assert!(
+        phase1_bb.pending_approval_resume.is_some(),
+        "phase 1 BeforeBlock must carry pending_approval_resume"
+    );
+    assert_eq!(
+        phase1_bb
+            .pending_approval_resume
+            .as_ref()
+            .unwrap()
+            .approval_request_id,
+        cap1_request_id,
+        "phase 1 BeforeBlock pending_approval_resume must be for cap1"
+    );
+
+    // ── Phase 2: approve cap1 → approval-resume → Backend failure ─────────────
+    //
+    // BUG TRIGGER: the batch returns Failed(Backend) for the approval-resume
+    // dispatch.  On unfixed code:
+    //   handle_capability_error clears pending_approval_resume at L637 BEFORE
+    //   recovery decides → retry fires with None → invoke_capability has no
+    //   scripted outcome → Err(Internal) → HostUnavailable.
+    //
+    // After fix (Part C-sub-A):
+    //   Resume-origin Backend failure is intercepted before any retry → surfaced
+    //   as ToolErrorResult → loop continues → model issues final reply → Done.
+    let phase2_result = executor
+        .execute_family(&crate::families::default(), &host, phase1_bb)
+        .await;
+
+    // Primary assertion: the run must NOT die as HostUnavailable.
+    // Pre-fix this panics; post-fix it passes.
+    let phase2_exit = phase2_result.expect(
+        "REGRESSION: resume-origin Backend failure must not kill the run as HostUnavailable. \
+         Pre-fix: handle_capability_error clears pending_approval_resume BEFORE recovery \
+         decides to retry → retry fires invoke_capability with approval_resume=None → \
+         single script exhausted → HostUnavailable (in production: ScopeMismatch). \
+         Fix: intercept Retry for resume-origin failures and surface as ToolErrorResult \
+         so the model can re-approve without a terminal run death.",
+    );
+
+    // Post-fix: the model saw the tool error, issued a final reply → Completed.
+    assert!(
+        matches!(phase2_exit, LoopExit::Completed(_)),
+        "phase 2 must complete the run after Backend→ToolErrorResult; got {phase2_exit:?}"
+    );
+
+    // No single invoke_capability calls should have been made: the C-sub-A guard
+    // prevents the retry dispatch entirely for resume-origin failures.
+    assert!(
+        host.single_invocations().is_empty(),
+        "no single invoke_capability call must be made for a resume-origin Backend failure \
+         (retry is suppressed to avoid double-exec)"
+    );
+}
+
+/// Regression test for the terminal `scope_mismatch` / `HostUnavailable` failure
+/// that surfaces when a capability's **auth-resume** dispatch returns a transient
+/// `Backend` error.
+///
+/// # Bug (capabilities.rs, pre-fix)
+///
+/// 1. Phase 1: executor dispatches the capability; host returns `AuthRequired`.
+///    GateStage stores `pending_auth_resume` in the BeforeBlock checkpoint.
+/// 2. Phase 2: executor detects `pending_auth_resume` in the prompt stage,
+///    re-dispatches the capability via `invoke_capability_batch(auth_resume=…)`.
+/// 3. Host returns `Failed(Backend)` for the re-dispatch.
+/// 4. `handle_capability_error` clears `state.pending_auth_resume` at ~L667
+///    BEFORE asking the planner for a recovery outcome.
+/// 5. Planner returns `RecoveryOutcome::Retry`.
+/// 6. Retry calls `invoke_capability(…)` (single, non-batch) with no auth context.
+///    MockHost has no scripted single outcome → `Err(Internal, "single script
+///    exhausted")` → `capability_host_error` → `HostUnavailable { stage: Capability }`.
+///    In production the product adapter would instead fail with `ScopeMismatch`
+///    because the original run's `input_ref` has no auth context to validate against.
+///
+/// # Fix (Part C-sub-A extended to auth-resume)
+///
+/// Before clearing `pending_auth_resume`, snapshot whether this failure is
+/// auth-resume-origin (`captured_auth_resume_origin`).  When `is_resume_origin`
+/// is true (either approval- or auth-resume origin), intercept
+/// `RecoveryOutcome::Retry` and redirect it to `ToolErrorResult` instead.
+/// The model sees the real backend error and the user can re-authenticate —
+/// no retry of the side effect, no scope_mismatch.
+///
+/// # What this test asserts (observable, not implementation detail)
+///
+/// - **Pre-fix (RED)**: Phase 2 `execute_family` returns
+///   `Err(AgentLoopExecutorError::HostUnavailable { stage: HostStage::Capability })`
+///   — the run terminally dies.
+/// - **Post-fix (GREEN)**: Phase 2 returns `Ok(LoopExit::Completed(_))` — the
+///   model sees the backend error as a tool result, issues a final reply, and
+///   the run completes cleanly.
+#[tokio::test]
+async fn auth_resume_origin_backend_failure_does_not_die_as_scope_mismatch() {
+    let cap1_input_ref =
+        CapabilityInputRef::new("input:run-original:auth-sm-cap1-uuid").expect("valid input ref");
+
+    // Phase 1 model response: issues cap1 with original-run input_ref.
+    // (No provider_replay — this is a non-provider-backed auth resume, so
+    // Phase 2 reuses the stored input_ref directly via
+    // pending_auth_resume_staged_input_candidate.)
+    let cap1_model_response = ironclaw_turns::run_profile::LoopModelResponse {
+        chunks: Vec::new(),
+        safe_reasoning_deltas: Vec::new(),
+        output: ParentLoopOutput::CapabilityCalls(vec![CapabilityCallCandidate {
+            surface_version: surface_version(),
+            capability_id: capability_id(),
+            input_ref: cap1_input_ref,
+            effective_capability_ids: vec![capability_id()],
+            provider_replay: None,
+        }]),
+        effective_model_profile_id: ironclaw_turns::run_profile::ModelProfileId::new("model")
+            .expect("valid"),
+        usage: None,
+    };
+
+    // Batch outcomes:
+    //   [0] Phase 1: cap1 → AuthRequired → gate blocked.
+    //   [1] Phase 2: cap1 auth-resume → Failed(Backend) — the bug trigger.
+    let batch_outcomes = vec![
+        // [0] Phase 1: cap1 → AuthRequired (gate blocked).
+        ironclaw_turns::run_profile::CapabilityBatchOutcome {
+            outcomes: vec![CapabilityOutcome::AuthRequired {
+                gate_ref: LoopGateRef::new("gate:auth-sm-test-cap1").expect("valid"),
+                credential_requirements: Vec::new(),
+                safe_summary: "cap1 needs auth".to_string(),
+            }],
+            stopped_on_suspension: true,
+        },
+        // [1] Phase 2: cap1 auth-resume → Backend failure.
+        ironclaw_turns::run_profile::CapabilityBatchOutcome {
+            outcomes: vec![CapabilityOutcome::Failed(
+                ironclaw_turns::run_profile::CapabilityFailure {
+                    error_kind: CapabilityFailureKind::Backend,
+                    safe_summary: "transient backend error during cap1 auth-resume".to_string(),
+                    detail: None,
+                },
+            )],
+            stopped_on_suspension: false,
+        },
+    ];
+
+    // Phase 1: one model turn (cap1); Phase 2: after Backend→ToolErrorResult
+    // the loop continues and needs a model turn to issue the final reply.
+    // (Auth-resume Phase 2 skips the model for the capability re-dispatch but
+    // needs a model call AFTER the error is surfaced for the final reply.)
+    let host = MockHost::new(vec![
+        cap1_model_response, // Phase 1: issues cap1
+        reply_response(),    // Phase 2 (post-fix): model sees tool error, issues reply
+    ])
+    .with_batch_outcomes(batch_outcomes);
+    // Deliberately NO single_outcomes: pre-fix, the retry would consume one and
+    // get `Err(Internal)` → HostUnavailable.  Post-fix, no retry is attempted.
+
+    let executor = CanonicalAgentLoopExecutor;
+
+    // ── Phase 1: cap1 → AuthRequired → Blocked ──────────────────────────────
+    let initial_state = LoopExecutionState::initial_for_run(host.run_context());
+    let phase1_exit = executor
+        .execute_family(&crate::families::default(), &host, initial_state)
+        .await
+        .expect("phase 1 must succeed (blocks on cap1 auth gate)");
+    assert!(
+        matches!(phase1_exit, LoopExit::Blocked(_)),
+        "phase 1 must block on cap1 auth gate; got {phase1_exit:?}"
+    );
+
+    // Recover the BeforeBlock checkpoint state to use as Phase 2 input.
+    let phase1_bb = final_staged_state_for_kind(&host, LoopCheckpointKind::BeforeBlock);
+    assert!(
+        phase1_bb.pending_auth_resume.is_some(),
+        "phase 1 BeforeBlock must carry pending_auth_resume"
+    );
+    assert_eq!(
+        phase1_bb
+            .pending_auth_resume
+            .as_ref()
+            .unwrap()
+            .capability_id,
+        capability_id(),
+        "phase 1 BeforeBlock pending_auth_resume must be for cap1"
+    );
+
+    // ── Phase 2: OAuth completes → auth-resume → Backend failure ────────────
+    //
+    // BUG TRIGGER: the batch returns Failed(Backend) for the auth-resume
+    // dispatch.  On unfixed code:
+    //   handle_capability_error clears pending_auth_resume at ~L667 BEFORE
+    //   recovery decides → retry fires with None → invoke_capability has no
+    //   scripted outcome → Err(Internal) → HostUnavailable.
+    //
+    // After fix (Part C-sub-A extended to auth-resume):
+    //   Auth-resume-origin Backend failure is intercepted before any retry →
+    //   surfaced as ToolErrorResult → loop continues → model issues final
+    //   reply → Done.
+    let phase2_result = executor
+        .execute_family(&crate::families::default(), &host, phase1_bb)
+        .await;
+
+    // Primary assertion: the run must NOT die as HostUnavailable.
+    // Pre-fix this panics; post-fix it passes.
+    let phase2_exit = phase2_result.expect(
+        "REGRESSION: auth-resume-origin Backend failure must not kill the run as \
+         HostUnavailable. Pre-fix: handle_capability_error clears pending_auth_resume \
+         BEFORE recovery decides to retry → retry fires invoke_capability with \
+         auth_resume=None → single script exhausted → HostUnavailable (in production: \
+         ScopeMismatch). Fix: intercept Retry for auth-resume-origin failures and \
+         surface as ToolErrorResult so the model can re-auth without a terminal run death.",
+    );
+
+    // Post-fix: the model saw the tool error, issued a final reply → Completed.
+    assert!(
+        matches!(phase2_exit, LoopExit::Completed(_)),
+        "phase 2 must complete the run after Backend→ToolErrorResult; got {phase2_exit:?}"
+    );
+
+    // No single invoke_capability calls should have been made: the C-sub-A guard
+    // prevents the retry dispatch entirely for auth-resume-origin failures.
+    assert!(
+        host.single_invocations().is_empty(),
+        "no single invoke_capability call must be made for an auth-resume-origin Backend \
+         failure (retry is suppressed to avoid double-exec)"
+    );
+}


### PR DESCRIPTION
## Problem

A 2nd+ Slack **approval** (or **auth**) resume of a capability (e.g. `gmail.list_messages`) terminally fails with `scope_mismatch` — `"capability input ref is not scoped to this loop run"` → `HostUnavailable` → run dies as "Capability: unavailable". The first approval (e.g. a gmail send test) succeeds; later ones die.

### Root cause (two sequential failures, not a reclassification)
1. The resume dispatch (carrying `approval_resume`) reaches the backend and returns a **transient `Backend` error**. `host_runtime/services/runtime_adapters.rs`
2. Executor classifies `Backend` → `Unavailable` → `RecoveryOutcome::Retry`. `agent_loop/executor/mapping.rs`
3. `handle_capability_error` clears `pending_approval_resume` / `pending_auth_resume`, then the retry re-dispatches via `capability_invocation_from_candidate(call.clone(), None)` — **dropping the resume context**. `agent_loop/executor/capabilities.rs:716`
4. Without resume, the non-resume path resolves `call.input_ref = "input:<ORIGINAL_RUN>:uuid"` against the **resuming** run → `ensure_ref_scoped_to_run` fails. `reborn_composition/product_live_adapters.rs:408`

The `Backend` error is real (HTTP fired and failed); the current code masks it behind a misleading `scope_mismatch` and kills the run.

## Fix

Intercept `RecoveryOutcome::Retry` in `handle_capability_error` for **resume-origin** failures (both approval-resume and auth-resume). Instead of re-dispatching, surface the real backend error to the model as a clean tool result and continue the loop, so the user can re-approve / re-authenticate.

Safety invariants:
- **S1 — no scope_mismatch:** a resume-origin failure never reaches the cross-run `input_ref` path. Verified: the approval lease is **one-shot** (revoked on cleanup after a Backend dispatch error), so retrying in resume mode would fail differently anyway.
- **S2 — no double-exec:** the backend is not invoked a second time. There is no idempotency enforcement at this layer (the `loop-capability` idempotency key is advisory only), and the first dispatch may already have run the side effect.

Auth-resume is covered because `PendingAuthResume` carries `input_ref` only (no inline `input`), so its non-resume retry hits the identical `ensure_ref_scoped_to_run` failure — the same guard fixes both.

## Tests

Two regression tests in `executor/tests.rs`, each RED before the fix (run dies `HostUnavailable`) and GREEN after:
- `resume_origin_backend_failure_does_not_die_as_scope_mismatch` (approval-resume)
- `auth_resume_origin_backend_failure_does_not_die_as_scope_mismatch` (auth-resume)

`cargo test -p ironclaw_agent_loop` — all green (337). `cargo clippy -p ironclaw_agent_loop --all-targets` — 0 warnings. `cargo fmt --check` — clean.

## Follow-ups (not in this PR)
- Composition/Slack-delivery e2e test (approve→approve→deny→approve) — the unit tier is the closest layer that can inject a transient Backend-on-resume; the delivery harness may need a hook to drive it end to end.
- Whether transient resume-origin Backend errors should auto-retry **in resume mode** for known-idempotent capabilities (requires real idempotency enforcement + a fresh lease) — deferred; surfacing is the safe default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)