### PR TITLE
fix(reborn): unify extension registry flow

### DIFF
--- a/crates/ironclaw_reborn_composition/src/available_extensions.rs
+++ b/crates/ironclaw_reborn_composition/src/available_extensions.rs
@@ -112,19 +112,15 @@ fn onboarding(package_id: &str) -> Option<LifecycleExtensionOnboarding> {
         )),
         "gmail" => Some(onboarding_message(
             "Gmail needs Google OAuth authorization before mail tools can run.",
-            Some(
-                "Install Gmail first. Activation will open the Google OAuth prompt for the account IronClaw should use.",
-            ),
+            Some("Authorize the Google account that IronClaw should use for Gmail."),
             None,
-            "Install Gmail, then activate it to open OAuth and publish its tools.",
+            "After authorization completes, activate Gmail to publish its tools.",
         )),
         "google-calendar" => Some(onboarding_message(
             "Google Calendar needs Google OAuth authorization before calendar tools can run.",
-            Some(
-                "Install Google Calendar first. Activation will open the Google OAuth prompt for calendar access.",
-            ),
+            Some("Authorize the Google account that IronClaw should use for Google Calendar."),
             None,
-            "Install Google Calendar, then activate it to open OAuth and publish its tools.",
+            "After authorization completes, activate Google Calendar to publish its tools.",
         )),
         "notion" => Some(onboarding_message(
             "Notion needs OAuth authorization before MCP tools can run.",
@@ -1625,13 +1621,37 @@ mod tests {
                 onboarding.credential_next_step.is_some(),
                 "{extension_id} must include the next user step"
             );
-            assert!(
-                onboarding
-                    .credential_next_step
-                    .as_deref()
-                    .is_some_and(|step| step.contains("Install") && step.contains("activate")),
-                "{extension_id} onboarding should preserve install-then-activate ordering"
-            );
+            if matches!(extension_id, "gmail" | "google-calendar") {
+                assert!(
+                    onboarding
+                        .credential_instructions
+                        .as_deref()
+                        .is_some_and(|instructions| {
+                            instructions.contains("Authorize the Google account")
+                                && !instructions.contains("Install")
+                        }),
+                    "{extension_id} configure onboarding should not repeat install-first copy"
+                );
+                assert!(
+                    onboarding
+                        .credential_next_step
+                        .as_deref()
+                        .is_some_and(|step| {
+                            step.starts_with("After authorization completes")
+                                && step.contains("activate")
+                                && !step.contains("Install")
+                        }),
+                    "{extension_id} configure next step should describe post-authorization activation"
+                );
+            } else {
+                assert!(
+                    onboarding
+                        .credential_next_step
+                        .as_deref()
+                        .is_some_and(|step| step.contains("Install") && step.contains("activate")),
+                    "{extension_id} onboarding should preserve install-then-activate ordering"
+                );
+            }
         }
     }
 

--- a/crates/ironclaw_reborn_composition/src/available_extensions.rs
+++ b/crates/ironclaw_reborn_composition/src/available_extensions.rs
@@ -124,11 +124,9 @@ fn onboarding(package_id: &str) -> Option<LifecycleExtensionOnboarding> {
         )),
         "notion" => Some(onboarding_message(
             "Notion needs OAuth authorization before MCP tools can run.",
-            Some(
-                "Install Notion first. Activation will open the OAuth prompt for the workspace IronClaw should access.",
-            ),
+            Some("Authorize the Notion workspace that IronClaw should access."),
             None,
-            "Install Notion, then activate it to open OAuth and publish its MCP tools.",
+            "After authorization completes, activate Notion to publish its MCP tools.",
         )),
         "nearai" => Some(onboarding_message(
             "NEAR AI needs an API key before its MCP tools can run.",
@@ -1621,13 +1619,13 @@ mod tests {
                 onboarding.credential_next_step.is_some(),
                 "{extension_id} must include the next user step"
             );
-            if matches!(extension_id, "gmail" | "google-calendar") {
+            if matches!(extension_id, "gmail" | "google-calendar" | "notion") {
                 assert!(
                     onboarding
                         .credential_instructions
                         .as_deref()
                         .is_some_and(|instructions| {
-                            instructions.contains("Authorize the Google account")
+                            instructions.starts_with("Authorize ")
                                 && !instructions.contains("Install")
                         }),
                     "{extension_id} configure onboarding should not repeat install-first copy"

--- a/crates/ironclaw_reborn_composition/src/available_extensions.rs
+++ b/crates/ironclaw_reborn_composition/src/available_extensions.rs
@@ -105,10 +105,10 @@ fn onboarding(package_id: &str) -> Option<LifecycleExtensionOnboarding> {
         "github" => Some(onboarding_message(
             "GitHub needs a personal access token before its repository and pull request tools can run.",
             Some(
-                "Install GitHub first. Activation will open the secure credential prompt for a GitHub personal access token with the repository permissions you want IronClaw to use.",
+                "Create a GitHub personal access token with the repository permissions you want IronClaw to use, then paste it here.",
             ),
             Some("https://github.com/settings/personal-access-tokens/new"),
-            "Install GitHub, then activate it to open the token prompt and publish its tools.",
+            "After saving the token, activate GitHub to publish its tools.",
         )),
         "gmail" => Some(onboarding_message(
             "Gmail needs Google OAuth authorization before mail tools can run.",
@@ -130,11 +130,9 @@ fn onboarding(package_id: &str) -> Option<LifecycleExtensionOnboarding> {
         )),
         "nearai" => Some(onboarding_message(
             "NEAR AI needs an API key before its MCP tools can run.",
-            Some(
-                "Install NEAR AI first. Activation will open the secure credential prompt for the API key IronClaw should use.",
-            ),
+            Some("Paste the NEAR AI API key IronClaw should use."),
             None,
-            "Install NEAR AI, then activate it to open the API key prompt and publish its MCP tools.",
+            "After saving the API key, activate NEAR AI to publish its MCP tools.",
         )),
         "web-access" => Some(onboarding_message(
             "Web Access does not need credentials. Activate it to make web search and saved-result retrieval tools available.",
@@ -1640,6 +1638,28 @@ mod tests {
                                 && !step.contains("Install")
                         }),
                     "{extension_id} configure next step should describe post-authorization activation"
+                );
+            } else if matches!(extension_id, "github" | "nearai") {
+                assert!(
+                    onboarding
+                        .credential_instructions
+                        .as_deref()
+                        .is_some_and(|instructions| {
+                            (instructions.contains("Paste") || instructions.contains("paste"))
+                                && !instructions.contains("Install")
+                        }),
+                    "{extension_id} configure onboarding should describe token entry without install-first copy"
+                );
+                assert!(
+                    onboarding
+                        .credential_next_step
+                        .as_deref()
+                        .is_some_and(|step| {
+                            step.starts_with("After saving")
+                                && step.contains("activate")
+                                && !step.contains("Install")
+                        }),
+                    "{extension_id} configure next step should describe activation after saving credentials"
                 );
             } else {
                 assert!(

--- a/crates/ironclaw_webui_v2_static/src/assets.rs
+++ b/crates/ironclaw_webui_v2_static/src/assets.rs
@@ -371,4 +371,40 @@ mod tests {
             "OAuth setup must refresh setup state before waiting for popup close"
         );
     }
+
+    #[test]
+    fn extension_registry_keeps_installed_entries_visible_first() {
+        let use_extensions = asset_text("js/pages/extensions/hooks/useExtensions.js");
+        let registry_tab = asset_text("js/pages/extensions/components/registry-tab.js");
+        let extensions_page = asset_text("js/pages/extensions/extensions-page.js");
+        let routes = asset_text("js/app/routes.js");
+        let schema = asset_text("js/pages/extensions/lib/extensions-schema.js");
+
+        assert!(
+            use_extensions.contains("catalogEntries"),
+            "extensions hook should expose a merged installed-plus-registry catalog"
+        );
+        assert!(
+            use_extensions
+                .contains("if (a.installed !== b.installed) return a.installed ? -1 : 1;"),
+            "merged extension catalog should sort installed entries before available entries"
+        );
+        assert!(
+            registry_tab.contains("installedEntries") && registry_tab.contains("availableEntries"),
+            "registry tab should render installed and available sections from one catalog"
+        );
+        assert!(
+            registry_tab.contains("<${ExtensionCard}") && registry_tab.contains("<${RegistryCard}"),
+            "installed registry entries should keep management actions while available entries keep install actions"
+        );
+        assert!(
+            extensions_page.contains("tab = \"registry\"")
+                && extensions_page.contains("to=\"/extensions/registry\""),
+            "extensions page should default and redirect to the unified registry surface"
+        );
+        assert!(
+            !routes.contains("id: \"installed\"") && !schema.contains("id: \"installed\""),
+            "installed should no longer be a separate extensions navigation tab"
+        );
+    }
 }

--- a/crates/ironclaw_webui_v2_static/src/assets.rs
+++ b/crates/ironclaw_webui_v2_static/src/assets.rs
@@ -385,13 +385,23 @@ mod tests {
             "extensions hook should expose a merged installed-plus-registry catalog"
         );
         assert!(
+            use_extensions.contains("catalogId(\"registry\", entry, index)")
+                && use_extensions.contains("catalogId(\"installed\", extension, index)"),
+            "merged extension catalog should use stable fallback keys for id-less entries"
+        );
+        assert!(
             use_extensions
-                .contains("if (a.installed !== b.installed) return a.installed ? -1 : 1;"),
+                .contains("if (a.installed !== b.installed) return a.installed ? -1 : 1;")
+                && use_extensions.contains("displayName(a.entry || a.extension)"),
             "merged extension catalog should sort installed entries before available entries"
         );
         assert!(
             registry_tab.contains("installedEntries") && registry_tab.contains("availableEntries"),
             "registry tab should render installed and available sections from one catalog"
+        );
+        assert!(
+            registry_tab.contains("return entry.entry || entry.extension || {};"),
+            "registry search should prefer richer registry metadata when installed entries are available"
         );
         assert!(
             registry_tab.contains("<${ExtensionCard}") && registry_tab.contains("<${RegistryCard}"),

--- a/crates/ironclaw_webui_v2_static/static/js/app/routes.js
+++ b/crates/ironclaw_webui_v2_static/static/js/app/routes.js
@@ -45,10 +45,9 @@ export const SETTINGS_SUB_ROUTES = [
 ];
 
 export const EXTENSIONS_SUB_ROUTES = [
-  { id: "installed", labelKey: "extensions.installed", icon: "bolt" },
+  { id: "registry", labelKey: "extensions.registry", icon: "plus" },
   { id: "channels", labelKey: "extensions.channels", icon: "send" },
   { id: "mcp", labelKey: "extensions.mcp", icon: "pulse" },
-  { id: "registry", labelKey: "extensions.registry", icon: "plus" },
 ];
 
 export const ADMIN_SUB_ROUTES = [

--- a/crates/ironclaw_webui_v2_static/static/js/pages/extensions/components/extension-card.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/extensions/components/extension-card.js
@@ -242,18 +242,22 @@ export function ExtensionCard({ ext, onActivate, onConfigure, onRemove, isBusy }
   `;
 }
 
-export function RegistryCard({ entry, onInstall, isBusy }) {
+export function RegistryCard({ entry, onInstall, isBusy, statusLabel }) {
   const t = useT();
   const kindLabel = t(`extensions.kind.${entry.kind}`) || KIND_LABELS[entry.kind] || entry.kind;
   const displayName = entry.display_name || packageId(entry);
-  const canInstall = Boolean(entry.package_ref);
+  const canInstall = Boolean(entry.package_ref && onInstall);
   const keywords = entry.keywords || [];
   const [kwOpen, setKwOpen] = React.useState(false);
 
   return html`
     <div className=${CARD}>
       <div className="flex items-start gap-2">
-        <${Badge} tone="muted" label=${t("extensions.state.available") || "available"} size="sm" />
+        <${Badge}
+          tone="muted"
+          label=${statusLabel || t("extensions.state.available") || "available"}
+          size="sm"
+        />
         <span className="min-w-0 flex-1 truncate text-sm font-semibold text-[var(--v2-text-strong)]">
           ${displayName}
         </span>

--- a/crates/ironclaw_webui_v2_static/static/js/pages/extensions/components/registry-tab.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/extensions/components/registry-tab.js
@@ -35,7 +35,11 @@ export function RegistryTab({
       })
     : catalogEntries;
 
-  const installedEntries = filtered.filter((entry) => entry.installed);
+  const installedEntries = filtered.filter((entry) => entry.installed && entry.extension);
+  const registryOnlyInstalledEntries = filtered.filter(
+    (entry) => entry.installed && !entry.extension && entry.entry
+  );
+  const installedCount = installedEntries.length + registryOnlyInstalledEntries.length;
   const availableEntries = filtered.filter((entry) => !entry.installed && entry.entry);
 
   if (catalogEntries.length === 0) {
@@ -72,7 +76,7 @@ export function RegistryTab({
               ${t("ext.registry.noMatch")}
             </p>`
           : html`
-              ${installedEntries.length > 0 &&
+              ${installedCount > 0 &&
               html`
                 <h3
                   className="mb-4 font-mono text-[11px] uppercase tracking-[0.14em] text-signal"
@@ -92,6 +96,16 @@ export function RegistryTab({
                       />
                     `
                   )}
+                  ${registryOnlyInstalledEntries.map(
+                    (entry) => html`
+                      <${RegistryCard}
+                        key=${entry.id}
+                        entry=${entry.entry}
+                        statusLabel=${t("extensions.installed")}
+                        isBusy=${isBusy}
+                      />
+                    `
+                  )}
                 </div>
               `}
 
@@ -100,7 +114,7 @@ export function RegistryTab({
                 <h3
                   className=${[
                     "mb-4 font-mono text-[11px] uppercase tracking-[0.14em] text-signal",
-                    installedEntries.length > 0 ? "mt-6" : "",
+                    installedCount > 0 ? "mt-6" : "",
                   ].join(" ")}
                 >
                   ${t("ext.registry.availableTitle")}

--- a/crates/ironclaw_webui_v2_static/static/js/pages/extensions/components/registry-tab.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/extensions/components/registry-tab.js
@@ -7,7 +7,7 @@ function packageId(item) {
 }
 
 function catalogItem(entry) {
-  return entry.extension || entry.entry || {};
+  return entry.entry || entry.extension || {};
 }
 
 export function RegistryTab({

--- a/crates/ironclaw_webui_v2_static/static/js/pages/extensions/components/registry-tab.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/extensions/components/registry-tab.js
@@ -1,36 +1,44 @@
 import { React, html } from "../../../lib/html.js";
 import { useT } from "../../../lib/i18n.js";
-import { RegistryCard } from "./extension-card.js";
+import { ExtensionCard, RegistryCard } from "./extension-card.js";
 
-function packageId(entry) {
-  return entry.package_ref?.id || "";
+function packageId(item) {
+  return item?.package_ref?.id || "";
+}
+
+function catalogItem(entry) {
+  return entry.extension || entry.entry || {};
 }
 
 export function RegistryTab({
-  toolRegistry,
-  channelRegistry,
-  mcpRegistry,
+  catalogEntries,
   onInstall,
+  onActivate,
+  onConfigure,
+  onRemove,
   isBusy,
 }) {
   const t = useT();
-  const allAvailable = [...toolRegistry, ...channelRegistry, ...mcpRegistry];
   const [filter, setFilter] = React.useState("");
+  const query = filter.trim().toLowerCase();
 
-  const filtered = filter
-    ? allAvailable.filter(
-        (e) =>
-          (e.display_name || packageId(e))
-            .toLowerCase()
-            .includes(filter.toLowerCase()) ||
-          (e.description || "").toLowerCase().includes(filter.toLowerCase()) ||
-          (e.keywords || []).some((kw) =>
-            kw.toLowerCase().includes(filter.toLowerCase())
+  const filtered = query
+    ? catalogEntries.filter((entry) => {
+        const item = catalogItem(entry);
+        return (
+          (item.display_name || packageId(item)).toLowerCase().includes(query) ||
+          (item.description || "").toLowerCase().includes(query) ||
+          (item.keywords || []).some((kw) =>
+            kw.toLowerCase().includes(query)
           )
-      )
-    : allAvailable;
+        );
+      })
+    : catalogEntries;
 
-  if (allAvailable.length === 0) {
+  const installedEntries = filtered.filter((entry) => entry.installed);
+  const availableEntries = filtered.filter((entry) => !entry.installed && entry.entry);
+
+  if (catalogEntries.length === 0) {
     return html`
       <div className="v2-panel rounded-[18px] p-6 sm:p-8">
         <h3 className="text-lg font-semibold text-white">
@@ -54,32 +62,63 @@ export function RegistryTab({
           className="h-9 flex-1 rounded-md border border-white/12 bg-white/[0.04] px-3 text-sm text-iron-100 outline-none placeholder:text-iron-700 focus:border-signal/45"
         />
         <span className="font-mono text-[11px] text-iron-700">
-          ${filtered.length} / ${allAvailable.length}
+          ${filtered.length} / ${catalogEntries.length}
         </span>
       </div>
 
       <div className="v2-panel rounded-[18px] p-5 sm:p-6">
-        <h3
-          className="mb-4 font-mono text-[11px] uppercase tracking-[0.14em] text-signal"
-        >
-          ${t("ext.registry.availableTitle")}
-        </h3>
         ${filtered.length === 0
           ? html`<p className="py-4 text-sm text-iron-300">
               ${t("ext.registry.noMatch")}
             </p>`
-          : html`<div className="grid grid-cols-1 gap-3 sm:grid-cols-2 2xl:grid-cols-3">
-              ${filtered.map(
-                (entry) => html`
-                  <${RegistryCard}
-                    key=${packageId(entry)}
-                    entry=${entry}
-                    onInstall=${onInstall}
-                    isBusy=${isBusy}
-                  />
-                `
-              )}
-            </div>`}
+          : html`
+              ${installedEntries.length > 0 &&
+              html`
+                <h3
+                  className="mb-4 font-mono text-[11px] uppercase tracking-[0.14em] text-signal"
+                >
+                  ${t("extensions.installed")}
+                </h3>
+                <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 2xl:grid-cols-3">
+                  ${installedEntries.map(
+                    (entry) => html`
+                      <${ExtensionCard}
+                        key=${entry.id}
+                        ext=${entry.extension || entry.entry}
+                        onActivate=${onActivate}
+                        onConfigure=${onConfigure}
+                        onRemove=${onRemove}
+                        isBusy=${isBusy}
+                      />
+                    `
+                  )}
+                </div>
+              `}
+
+              ${availableEntries.length > 0 &&
+              html`
+                <h3
+                  className=${[
+                    "mb-4 font-mono text-[11px] uppercase tracking-[0.14em] text-signal",
+                    installedEntries.length > 0 ? "mt-6" : "",
+                  ].join(" ")}
+                >
+                  ${t("ext.registry.availableTitle")}
+                </h3>
+                <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 2xl:grid-cols-3">
+                  ${availableEntries.map(
+                    (entry) => html`
+                      <${RegistryCard}
+                        key=${entry.id}
+                        entry=${entry.entry}
+                        onInstall=${onInstall}
+                        isBusy=${isBusy}
+                      />
+                    `
+                  )}
+                </div>
+              `}
+            `}
       </div>
     </div>
   `;

--- a/crates/ironclaw_webui_v2_static/static/js/pages/extensions/components/registry-tab.test.mjs
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/extensions/components/registry-tab.test.mjs
@@ -1,0 +1,155 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import vm from "node:vm";
+
+function registryTabSourceForTest() {
+  const source = readFileSync(new URL("./registry-tab.js", import.meta.url), "utf8");
+  const lines = [];
+  for (const line of source.split("\n")) {
+    if (line.startsWith("import ")) continue;
+    lines.push(line.replace(/^export function /, "function "));
+  }
+  return `${lines.join("\n")}\nglobalThis.__testExports = { RegistryTab };`;
+}
+
+function renderRegistryTab(props, filter = "") {
+  const context = {
+    ExtensionCard() {},
+    RegistryCard() {},
+    React: {
+      useState: () => [filter, () => {}],
+    },
+    globalThis: {},
+    html(strings, ...values) {
+      return { strings: Array.from(strings), values };
+    },
+    useT: () => (key) => {
+      if (key === "extensions.installed") return "Installed";
+      if (key === "ext.registry.availableTitle") return "Available extensions";
+      if (key === "ext.registry.searchPlaceholder") return "Search extensions...";
+      return key;
+    },
+  };
+  vm.runInNewContext(registryTabSourceForTest(), context);
+  return {
+    ...context,
+    rendered: context.globalThis.__testExports.RegistryTab(props),
+  };
+}
+
+function collectComponentValues(node, component, matches = []) {
+  if (Array.isArray(node)) {
+    for (const item of node) collectComponentValues(item, component, matches);
+    return matches;
+  }
+  if (!node || typeof node !== "object" || !Array.isArray(node.values)) {
+    return matches;
+  }
+  for (let index = 0; index < node.values.length; index += 1) {
+    if (node.values[index] === component) {
+      matches.push(node.values.slice(index, index + 7));
+    }
+    collectComponentValues(node.values[index], component, matches);
+  }
+  return matches;
+}
+
+test("RegistryTab renders only real installed extensions with management actions", () => {
+  const onInstall = () => {};
+  const installedExtension = {
+    package_ref: { kind: "extension", id: "google-calendar" },
+    display_name: "Google Runtime",
+    kind: "wasm_tool",
+    active: true,
+  };
+  const registryOnlyInstalled = {
+    package_ref: { kind: "extension", id: "calendar-registry-only" },
+    display_name: "Calendar Registry Only",
+    kind: "wasm_tool",
+    installed: true,
+  };
+  const availableEntry = {
+    package_ref: { kind: "extension", id: "github" },
+    display_name: "GitHub",
+    kind: "mcp_server",
+  };
+  const { ExtensionCard, RegistryCard, rendered } = renderRegistryTab({
+    catalogEntries: [
+      {
+        id: "google-calendar",
+        installed: true,
+        entry: {
+          package_ref: installedExtension.package_ref,
+          display_name: "Google Calendar",
+          description: "Calendar metadata",
+          kind: "wasm_tool",
+        },
+        extension: installedExtension,
+      },
+      {
+        id: "calendar-registry-only",
+        installed: true,
+        entry: registryOnlyInstalled,
+        extension: null,
+      },
+      {
+        id: "github",
+        installed: false,
+        entry: availableEntry,
+        extension: null,
+      },
+    ],
+    onInstall,
+    onActivate: () => {},
+    onConfigure: () => {},
+    onRemove: () => {},
+    isBusy: false,
+  });
+
+  const extensionCards = collectComponentValues(rendered, ExtensionCard);
+  assert.equal(extensionCards.length, 1);
+  assert.equal(extensionCards[0][2], installedExtension);
+
+  const registryCards = collectComponentValues(rendered, RegistryCard);
+  assert.equal(registryCards.length, 2);
+  assert.equal(registryCards[0][2], registryOnlyInstalled);
+  assert.equal(registryCards[0][3], "Installed");
+  assert.equal(registryCards[1][2], availableEntry);
+  assert.equal(registryCards[1][3], onInstall);
+});
+
+test("RegistryTab searches installed entries using registry metadata", () => {
+  const installedExtension = {
+    package_ref: { kind: "extension", id: "google-calendar" },
+    display_name: "Runtime Name",
+    kind: "wasm_tool",
+    active: true,
+  };
+  const { ExtensionCard, rendered } = renderRegistryTab(
+    {
+      catalogEntries: [
+        {
+          id: "google-calendar",
+          installed: true,
+          entry: {
+            package_ref: installedExtension.package_ref,
+            display_name: "Google Calendar",
+            description: "Calendar integration",
+            keywords: ["schedule"],
+            kind: "wasm_tool",
+          },
+          extension: installedExtension,
+        },
+      ],
+      onInstall: () => {},
+      onActivate: () => {},
+      onConfigure: () => {},
+      onRemove: () => {},
+      isBusy: false,
+    },
+    "calendar",
+  );
+
+  assert.equal(collectComponentValues(rendered, ExtensionCard).length, 1);
+});

--- a/crates/ironclaw_webui_v2_static/static/js/pages/extensions/extensions-page.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/extensions/extensions-page.js
@@ -3,24 +3,21 @@ import { React, html } from "../../lib/html.js";
 import { ActionToast } from "./components/action-toast.js";
 import { ChannelsTab } from "./components/channels-tab.js";
 import { ConfigureModal } from "./components/configure-modal.js";
-import { InstalledTab } from "./components/installed-tab.js";
 import { McpTab } from "./components/mcp-tab.js";
 import { RegistryTab } from "./components/registry-tab.js";
 import { useExtensions } from "./hooks/useExtensions.js";
 
 export function ExtensionsPage() {
-  const { tab = "installed" } = useParams();
+  const { tab = "registry" } = useParams();
   const [configuring, setConfiguring] = React.useState(null);
 
   const {
     status,
-    extensions,
     channels,
     mcpServers,
-    tools,
     channelRegistry,
     mcpRegistry,
-    toolRegistry,
+    catalogEntries,
     connectableChannels,
     isLoading,
     isBusy,
@@ -69,14 +66,11 @@ export function ExtensionsPage() {
     `;
   }
 
+  if (tab === "installed") {
+    return html`<${Navigate} to="/extensions/registry" replace />`;
+  }
+
   const tabContent = {
-    installed: html`<${InstalledTab}
-      extensions=${extensions}
-      onActivate=${activate}
-      onConfigure=${handleConfigure}
-      onRemove=${remove}
-      isBusy=${isBusy}
-    />`,
     channels: html`<${ChannelsTab}
       status=${status}
       channels=${channels}
@@ -98,16 +92,17 @@ export function ExtensionsPage() {
       isBusy=${isBusy}
     />`,
     registry: html`<${RegistryTab}
-      toolRegistry=${toolRegistry}
-      channelRegistry=${channelRegistry}
-      mcpRegistry=${mcpRegistry}
+      catalogEntries=${catalogEntries}
       onInstall=${install}
+      onActivate=${activate}
+      onConfigure=${handleConfigure}
+      onRemove=${remove}
       isBusy=${isBusy}
     />`,
   };
 
   if (!tabContent[tab]) {
-    return html`<${Navigate} to="/extensions/installed" replace />`;
+    return html`<${Navigate} to="/extensions/registry" replace />`;
   }
 
   return html`

--- a/crates/ironclaw_webui_v2_static/static/js/pages/extensions/extensions-page.test.mjs
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/extensions/extensions-page.test.mjs
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import vm from "node:vm";
+
+function extensionsPageSourceForTest() {
+  const source = readFileSync(new URL("./extensions-page.js", import.meta.url), "utf8");
+  const lines = [];
+  for (const line of source.split("\n")) {
+    if (line.startsWith("import ")) continue;
+    lines.push(line.replace(/^export function /, "function "));
+  }
+  return `${lines.join("\n")}\nglobalThis.__testExports = { ExtensionsPage };`;
+}
+
+function renderExtensionsPage(tab) {
+  const context = {
+    ActionToast() {},
+    ChannelsTab() {},
+    ConfigureModal() {},
+    McpTab() {},
+    Navigate() {},
+    React: {
+      useCallback: (fn) => fn,
+      useState: (initial) => [typeof initial === "function" ? initial() : initial, () => {}],
+    },
+    RegistryTab() {},
+    globalThis: {},
+    html(strings, ...values) {
+      return { strings: Array.from(strings), values };
+    },
+    useExtensions: () => ({
+      status: {},
+      channels: [],
+      mcpServers: [],
+      channelRegistry: [],
+      mcpRegistry: [],
+      catalogEntries: [],
+      connectableChannels: [],
+      isLoading: false,
+      isBusy: false,
+      actionResult: null,
+      clearResult: () => {},
+      install: () => {},
+      activate: () => {},
+      remove: () => {},
+      invalidate: () => {},
+    }),
+    useParams: () => ({ tab }),
+  };
+  vm.runInNewContext(extensionsPageSourceForTest(), context);
+  return {
+    ...context,
+    rendered: context.globalThis.__testExports.ExtensionsPage(),
+  };
+}
+
+for (const tab of ["installed", "unknown"]) {
+  test(`ExtensionsPage redirects ${tab} tab to registry`, () => {
+    const { Navigate, rendered } = renderExtensionsPage(tab);
+
+    assert.equal(rendered.values[0], Navigate);
+    assert.match(rendered.strings.join(""), /to="\/extensions\/registry"/);
+  });
+}

--- a/crates/ironclaw_webui_v2_static/static/js/pages/extensions/hooks/useExtensions-catalog.test.mjs
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/extensions/hooks/useExtensions-catalog.test.mjs
@@ -1,0 +1,134 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import vm from "node:vm";
+
+function useExtensionsSourceForTest() {
+  const source = readFileSync(new URL("./useExtensions.js", import.meta.url), "utf8");
+  const lines = [];
+  let skippingImport = false;
+  for (const line of source.split("\n")) {
+    if (!skippingImport && line.startsWith("import ")) {
+      skippingImport = !line.trimEnd().endsWith(";");
+      continue;
+    }
+    if (skippingImport) {
+      skippingImport = !line.trimEnd().endsWith(";");
+      continue;
+    }
+    lines.push(line.replace(/^export function /, "function "));
+  }
+  return `${lines.join("\n")}\nglobalThis.__testExports = { useExtensions };`;
+}
+
+function useExtensionsForTest({ extensions, registry }) {
+  const queryData = new Map([
+    ["extensions", { extensions }],
+    ["extension-registry", { entries: registry }],
+    ["connectable-channels", { channels: [] }],
+    ["gateway-status-extensions", {}],
+  ]);
+  const context = {
+    React: {
+      useCallback: (fn) => fn,
+      useEffect: () => {},
+      useRef: () => ({ current: null }),
+      useState: (initial) => [typeof initial === "function" ? initial() : initial, () => {}],
+    },
+    activateExtension: () => {},
+    approvePairingCode: () => {},
+    fetchExtensionRegistry: () => {},
+    fetchExtensionSetup: () => {},
+    fetchExtensions: () => {},
+    fetchPairingRequests: () => {},
+    gatewayStatus: () => {},
+    globalThis: {},
+    installExtension: () => {},
+    listConnectableChannels: () => {},
+    removeExtension: () => {},
+    startExtensionOauth: () => {},
+    submitExtensionSetup: () => {},
+    useMutation: () => ({ isPending: false, mutate: () => {} }),
+    useQuery: (config) => ({
+      data: queryData.get(config.queryKey[0]) || {},
+      isLoading: false,
+    }),
+    useQueryClient: () => ({ invalidateQueries: () => {} }),
+    window: { clearInterval: () => {}, setInterval: () => 1 },
+  };
+  vm.runInNewContext(useExtensionsSourceForTest(), context);
+  return context.globalThis.__testExports.useExtensions();
+}
+
+test("useExtensions merges registry and installed entries with installed first", () => {
+  const googleRef = { kind: "extension", id: "google-calendar" };
+  const githubRef = { kind: "extension", id: "github" };
+  const localRef = { kind: "extension", id: "local-tool" };
+
+  const result = useExtensionsForTest({
+    extensions: [
+      {
+        package_ref: googleRef,
+        display_name: "Google Runtime",
+        kind: "wasm_tool",
+        active: true,
+      },
+      {
+        package_ref: localRef,
+        display_name: "Local Tool",
+        kind: "wasm_tool",
+        active: true,
+      },
+      {
+        display_name: "Local No ID",
+        kind: "wasm_tool",
+        active: true,
+      },
+    ],
+    registry: [
+      {
+        package_ref: googleRef,
+        display_name: "Google Calendar",
+        description: "Calendar access",
+        keywords: ["calendar"],
+        kind: "wasm_tool",
+        installed: true,
+      },
+      {
+        package_ref: githubRef,
+        display_name: "GitHub",
+        kind: "mcp_server",
+        installed: false,
+      },
+      {
+        display_name: "Registry No ID",
+        kind: "wasm_tool",
+        installed: false,
+      },
+    ],
+  });
+
+  const { catalogEntries } = result;
+  assert.deepEqual(
+    Array.from(catalogEntries, (entry) => Boolean(entry.installed)),
+    [true, true, true, false, false],
+    "installed entries sort ahead of available registry entries",
+  );
+  assert.equal(
+    catalogEntries.filter((entry) => entry.id === "google-calendar").length,
+    1,
+    "matching registry/runtime entries are de-duplicated",
+  );
+  const google = catalogEntries.find((entry) => entry.id === "google-calendar");
+  assert.equal(google.entry.display_name, "Google Calendar");
+  assert.equal(google.extension.display_name, "Google Runtime");
+  assert.ok(
+    catalogEntries.some((entry) => entry.extension?.package_ref?.id === "local-tool" && !entry.entry),
+    "installed entries missing from the registry are retained",
+  );
+  assert.equal(
+    new Set(catalogEntries.map((entry) => entry.id)).size,
+    catalogEntries.length,
+    "id-less registry and installed entries receive stable fallback ids",
+  );
+});

--- a/crates/ironclaw_webui_v2_static/static/js/pages/extensions/hooks/useExtensions.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/extensions/hooks/useExtensions.js
@@ -19,17 +19,21 @@ const OAUTH_SETUP_REFRESH_MS = 2000;
 const OAUTH_SETUP_TIMEOUT_MS = 10 * 60 * 1000;
 
 function packageId(item) {
-  return item?.package_ref?.id || "";
+  return item?.package_ref?.id || null;
 }
 
 function displayName(item) {
-  return item?.display_name || packageId(item);
+  return item?.display_name || packageId(item) || "";
+}
+
+function catalogId(prefix, item, index) {
+  return packageId(item) || `${prefix}:${displayName(item) || "unknown"}:${index}`;
 }
 
 function catalogSort(a, b) {
   if (a.installed !== b.installed) return a.installed ? -1 : 1;
-  return displayName(a.extension || a.entry).localeCompare(
-    displayName(b.extension || b.entry)
+  return displayName(a.entry || a.extension).localeCompare(
+    displayName(b.entry || b.extension)
   );
 }
 
@@ -141,22 +145,30 @@ export function useExtensions() {
   const extensions = extensionsQuery.data?.extensions || [];
   const registry = registryQuery.data?.entries || [];
   const connectableChannels = connectableChannelsQuery.data?.channels || [];
-  const extensionById = new Map(extensions.map((extension) => [packageId(extension), extension]));
-  const registryIds = new Set(registry.map((entry) => packageId(entry)));
+  const extensionById = new Map(
+    extensions
+      .map((extension) => [packageId(extension), extension])
+      .filter(([id]) => Boolean(id))
+  );
+  const registryIds = new Set(registry.map((entry) => packageId(entry)).filter(Boolean));
   const catalogEntries = [
-    ...registry.map((entry) => {
-      const extension = extensionById.get(packageId(entry)) || null;
+    ...registry.map((entry, index) => {
+      const id = packageId(entry);
+      const extension = id ? extensionById.get(id) || null : null;
       return {
-        id: packageId(entry),
+        id: catalogId("registry", entry, index),
         installed: Boolean(extension || entry.installed),
         entry,
         extension,
       };
     }),
     ...extensions
-      .filter((extension) => !registryIds.has(packageId(extension)))
-      .map((extension) => ({
-        id: packageId(extension),
+      .filter((extension) => {
+        const id = packageId(extension);
+        return !id || !registryIds.has(id);
+      })
+      .map((extension, index) => ({
+        id: catalogId("installed", extension, index),
         installed: true,
         entry: null,
         extension,

--- a/crates/ironclaw_webui_v2_static/static/js/pages/extensions/hooks/useExtensions.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/extensions/hooks/useExtensions.js
@@ -18,6 +18,21 @@ import {
 const OAUTH_SETUP_REFRESH_MS = 2000;
 const OAUTH_SETUP_TIMEOUT_MS = 10 * 60 * 1000;
 
+function packageId(item) {
+  return item?.package_ref?.id || "";
+}
+
+function displayName(item) {
+  return item?.display_name || packageId(item);
+}
+
+function catalogSort(a, b) {
+  if (a.installed !== b.installed) return a.installed ? -1 : 1;
+  return displayName(a.extension || a.entry).localeCompare(
+    displayName(b.extension || b.entry)
+  );
+}
+
 export function useExtensions() {
   const queryClient = useQueryClient();
 
@@ -126,6 +141,27 @@ export function useExtensions() {
   const extensions = extensionsQuery.data?.extensions || [];
   const registry = registryQuery.data?.entries || [];
   const connectableChannels = connectableChannelsQuery.data?.channels || [];
+  const extensionById = new Map(extensions.map((extension) => [packageId(extension), extension]));
+  const registryIds = new Set(registry.map((entry) => packageId(entry)));
+  const catalogEntries = [
+    ...registry.map((entry) => {
+      const extension = extensionById.get(packageId(entry)) || null;
+      return {
+        id: packageId(entry),
+        installed: Boolean(extension || entry.installed),
+        entry,
+        extension,
+      };
+    }),
+    ...extensions
+      .filter((extension) => !registryIds.has(packageId(extension)))
+      .map((extension) => ({
+        id: packageId(extension),
+        installed: true,
+        entry: null,
+        extension,
+      })),
+  ].sort(catalogSort);
 
   const channels = extensions.filter((e) => e.kind === "wasm_channel");
   const mcpServers = extensions.filter((e) => e.kind === "mcp_server");
@@ -154,6 +190,7 @@ export function useExtensions() {
     mcpRegistry,
     toolRegistry,
     registry,
+    catalogEntries,
     connectableChannels,
     isLoading,
     isBusy,

--- a/crates/ironclaw_webui_v2_static/static/js/pages/extensions/lib/extensions-schema.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/extensions/lib/extensions-schema.js
@@ -1,8 +1,7 @@
 export const EXTENSIONS_TABS = [
-  { id: "installed", label: "Installed", icon: "bolt" },
+  { id: "registry", label: "Registry", icon: "plus" },
   { id: "channels", label: "Channels", icon: "send" },
   { id: "mcp", label: "MCP Servers", icon: "pulse" },
-  { id: "registry", label: "Registry", icon: "plus" },
 ];
 
 export const KIND_LABELS = {


### PR DESCRIPTION
## Summary

- Merged the Installed and Registry extension surfaces so installed entries stay visible at the top of Registry instead of disappearing into a separate tab.
- Preserved installed extension management actions in Registry while keeping install actions for available catalog entries.
- Redirected the legacy Installed route to Registry and removed Installed from extensions navigation.
- Added static asset coverage for the unified catalog ordering and navigation shape.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Closes #4890
Closes #4886

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [ ] `cargo build`
- [x] Relevant tests pass: `cargo test -p ironclaw_webui_v2_static --locked --quiet`
- [ ] `cargo test --features integration` if database-backed or integration behavior changed
- [x] Manual testing: started Reborn WebUI locally and verified `/v2/extensions/registry` returns 200.
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

Additional validation:
- `node --check` on the changed WebUI JS files
- `cargo clippy -p ironclaw_webui_v2_static --all-targets --locked -- -D warnings`
- `git diff --check`

## Security Impact

None. This only reshapes the WebUI extension catalog/navigation; it does not change extension install, activation, auth, secret handling, or backend permissions.

## Database Impact

None.

## Blast Radius

Limited to Reborn WebUI v2 extension catalog/navigation static assets and asset contract tests.

## Rollback Plan

Revert this PR to restore the separate Installed tab and prior Registry-only-available listing.

## Review Follow-Through

Reviewer judgment requested on whether the installed-first alphabetical ordering is the right default, or whether setup/auth-required entries should sort above already-active entries later.

---

**Review track**: B
