### PR TITLE
[codex] Gate operator logs in WebUI v2

### DIFF
--- a/crates/ironclaw_webui_v2_static/static/js/app/app.js
+++ b/crates/ironclaw_webui_v2_static/static/js/app/app.js
@@ -93,6 +93,13 @@ function AdminRoute({ auth }) {
   return html`<${AdminPage} />`;
 }
 
+function OperatorRoute({ auth, children }) {
+  if (!auth.isAdmin) {
+    return html`<${Navigate} to=${defaultRoute} replace />`;
+  }
+  return children;
+}
+
 export function App() {
   const auth = useAuthSession();
 
@@ -121,7 +128,7 @@ export function App() {
           <${Route} path="automations" element=${html`<${AutomationsPage} />`} />
           <${Route} path="extensions" element=${html`<${ExtensionsPage} />`} />
           <${Route} path="extensions/:tab" element=${html`<${ExtensionsPage} />`} />
-          <${Route} path="logs" element=${html`<${LogsPage} />`} />
+          <${Route} path="logs" element=${html`<${OperatorRoute} auth=${auth}><${LogsPage} /><//>`} />
           <${Route} path="settings" element=${html`<${SettingsPage} />`} />
           <${Route} path="settings/:tab" element=${html`<${SettingsPage} />`} />
           <${Route} path="admin" element=${html`<${AdminRoute} auth=${auth} />`} />

--- a/crates/ironclaw_webui_v2_static/static/js/components/page-header.js
+++ b/crates/ironclaw_webui_v2_static/static/js/components/page-header.js
@@ -8,7 +8,7 @@ import { TeeShield } from "./tee-shield.js";
 
 const DOCS_URL = "https://docs.ironclaw.com";
 
-export function PageHeader({ threadsState, onToggleSidebar }) {
+export function PageHeader({ threadsState, onToggleSidebar, isAdmin = false }) {
   const t = useT();
   const location = useLocation();
 
@@ -89,17 +89,20 @@ export function PageHeader({ threadsState, onToggleSidebar }) {
 
       <div className="ml-auto flex shrink-0 items-center gap-1">
         <${TeeShield} />
-        <${NavLink}
-          to="/logs"
-          className=${({ isActive }) =>
-            cn(
-              "grid h-8 w-8 place-items-center rounded-[8px] text-[var(--v2-text-muted)] hover:bg-[var(--v2-surface-muted)] hover:text-[var(--v2-text-strong)]",
-              isActive && "bg-[var(--v2-accent-soft)] text-[var(--v2-accent-text)]"
-            )}
-          title=${t("nav.logs")}
-        >
-          <${Icon} name="list" className="h-4 w-4" />
-        <//>
+        ${isAdmin &&
+        html`
+          <${NavLink}
+            to="/logs"
+            className=${({ isActive }) =>
+              cn(
+                "grid h-8 w-8 place-items-center rounded-[8px] text-[var(--v2-text-muted)] hover:bg-[var(--v2-surface-muted)] hover:text-[var(--v2-text-strong)]",
+                isActive && "bg-[var(--v2-accent-soft)] text-[var(--v2-accent-text)]"
+              )}
+            title=${t("nav.logs")}
+          >
+            <${Icon} name="list" className="h-4 w-4" />
+          <//>
+        `}
         <a
           href=${DOCS_URL}
           target="_blank"

--- a/crates/ironclaw_webui_v2_static/static/js/layout/gateway-layout.js
+++ b/crates/ironclaw_webui_v2_static/static/js/layout/gateway-layout.js
@@ -118,6 +118,7 @@ export function GatewayLayout({ token, profile, isChecking = false, isAdmin, onS
         <${PageHeader}
           threadsState=${threadsState}
           onToggleSidebar=${sidebar.toggle}
+          isAdmin=${isAdmin}
         />
         <main className="min-h-0 min-w-0 flex-1 overflow-hidden">
           ${statusQuery.error &&

--- a/crates/ironclaw_webui_v2_static/static/js/pages/logs/hooks/useLogs.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/logs/hooks/useLogs.js
@@ -70,7 +70,7 @@ export function useLogs() {
       if (requestId !== requestIdRef.current) return;
       if (TERMINAL_UNSUPPORTED_STATUSES.has(err?.status)) {
         setEntries([]);
-        setError(null);
+        setError(err);
         setIsUnsupported(true);
         return;
       }

--- a/crates/ironclaw_webui_v2_static/static/js/pages/logs/hooks/useLogs.test.mjs
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/logs/hooks/useLogs.test.mjs
@@ -25,6 +25,7 @@ function depsChanged(previous, next) {
 function createHookHarness({ search = "" } = {}) {
   const calls = [];
   const intervals = [];
+  const harness = { rejectWith: null };
   let location = { search };
   let hookIndex = 0;
   const hooks = [];
@@ -86,6 +87,9 @@ function createHookHarness({ search = "" } = {}) {
     }),
     queryOperatorLogs: async (request) => {
       calls.push(request);
+      if (harness.rejectWith) {
+        throw harness.rejectWith;
+      }
       return { entries: [{ id: String(calls.length) }] };
     },
     setInterval: (fn, ms) => {
@@ -98,7 +102,7 @@ function createHookHarness({ search = "" } = {}) {
 
   vm.runInNewContext(useLogsSourceForTest(), context);
 
-  return {
+  return Object.assign(harness, {
     calls,
     intervals,
     render() {
@@ -117,7 +121,7 @@ function createHookHarness({ search = "" } = {}) {
     setSearch(nextSearch) {
       location = { search: nextSearch };
     },
-  };
+  });
 }
 
 test("useLogs reloads scoped logs once when scope changes while paused", async () => {
@@ -141,5 +145,20 @@ test("useLogs reloads scoped logs once when scope changes while paused", async (
   assert.equal(result.paused, true);
   assert.equal(harness.calls.length, 2);
   assert.equal(harness.calls[1].threadId, "thread-b");
+  assert.equal(harness.intervals.length, 1);
+});
+
+test("useLogs surfaces operator-log permission failures instead of empty logs", async () => {
+  const forbidden = Object.assign(new Error("Forbidden"), { status: 403 });
+  const harness = createHookHarness();
+  harness.rejectWith = forbidden;
+
+  let result = harness.render();
+  await harness.runEffects();
+  result = harness.render();
+
+  assert.equal(result.entries.length, 0);
+  assert.equal(result.error, forbidden);
+  assert.equal(result.status, "error");
   assert.equal(harness.intervals.length, 1);
 });


### PR DESCRIPTION
## What changed

- Hide the global WebUI v2 Logs nav item unless the current session has `operator_webui_config`.
- Add a client-side `/v2/logs` route guard so non-operator sessions are redirected back to the default route instead of loading the operator logs surface.
- Preserve terminal operator-log fetch failures such as 403/404 as hook errors, so the Logs page surfaces the permission/unavailable state instead of presenting an empty stream.

## Why

The backend operator logs API already requires the `operator_webui_config` capability and returns 403 when the caller does not have it. The WebUI still exposed the Logs entry point globally, and the hook treated terminal 403/404 responses as unsupported-without-error, which made non-operator users land on an apparently empty Logs page.

Fixes #4892.

## Validation

- `node --test crates/ironclaw_webui_v2_static/static/js/pages/logs/hooks/useLogs.test.mjs`
- `node --test crates/ironclaw_webui_v2_static/static/js/pages/logs/lib/logs-data.test.mjs crates/ironclaw_webui_v2_static/static/js/pages/logs/hooks/useLogs.test.mjs`
- `node --check crates/ironclaw_webui_v2_static/static/js/app/app.js crates/ironclaw_webui_v2_static/static/js/components/page-header.js crates/ironclaw_webui_v2_static/static/js/layout/gateway-layout.js crates/ironclaw_webui_v2_static/static/js/pages/logs/hooks/useLogs.js`
- `cargo test -p ironclaw_webui_v2_static`
- Browser smoke: admin/operator session can still open `/v2/logs` and see log entries after reload.