### PR TITLE
test: live-tier + multi-gate sequence coverage for resume-origin Backend fix (#4899)

### DIFF
--- a/crates/ironclaw_agent_loop/src/executor/tests.rs
+++ b/crates/ironclaw_agent_loop/src/executor/tests.rs
@@ -5335,3 +5335,465 @@ async fn auth_resume_origin_backend_failure_does_not_die_as_scope_mismatch() {
          failure (retry is suppressed to avoid double-exec)"
     );
 }
+
+/// Five-gate sequence: approve#1→OK, approve#2→OK, approve#3→Backend, deny, approve#4→OK.
+///
+/// Extended regression test that verifies the C-sub-A fix holds when two *clean*
+/// approval-resume cycles precede the Backend failure, and a final approval
+/// succeeds after a deny.  This exercises:
+/// - Two consecutive successful approval resumes before any error.
+/// - A Backend-on-resume that still surfaces as a clean ToolErrorResult (no retry).
+/// - A Denied that is cleanly rejected as a ToolErrorResult (not a Backend retry path).
+/// - A successful approval resume *after* the deny — proving the gate machinery
+///   recovered fully and is not poisoned by either the Backend or Denied outcome.
+///
+/// # Sequence (5 capability cycles in one session)
+///
+/// | Phase | Event | Expected outcome |
+/// |-------|-------|-----------------|
+/// | 1 | Model issues cap1 | `ApprovalRequired` → Blocked (gate 1) |
+/// | 2 | Approve gate 1 → cap1 resume → Completed; model issues cap2 (approve#2) | `ApprovalRequired` → Blocked (gate 2) |
+/// | 3 | Approve gate 2 → cap2 resume → Completed; model issues cap3 (approve#3) | `ApprovalRequired` → Blocked (gate 3) |
+/// | 4 | Approve gate 3 → cap3 resume → `Failed(Backend)` | C-sub-A: ToolErrorResult, loop continues; model→deny Denied; model→cap5 ApprovalRequired → Blocked (gate 5) |
+/// | 5 | Approve gate 5 → cap5 resume → Completed → final reply | `LoopExit::Completed` |
+///
+/// # What this test asserts
+///
+/// - Run never terminates with `HostUnavailable` / scope_mismatch at any point.
+/// - approve#1 (cap1) and approve#2 (cap2) both resume successfully (Completed).
+/// - approve#3 (cap3) Backend-on-resume surfaces as a clean model-visible tool
+///   error; loop continues; no single retry dispatch occurs.
+/// - The deny (cap4) is rejected cleanly as ToolErrorResult (not a Backend path).
+/// - approve#4 (cap5) resumes successfully (Completed) after the deny.
+/// - Run reaches `LoopExit::Completed`.
+/// - No `invoke_capability` single-path retry is made for the resume-origin Backend.
+#[tokio::test]
+async fn approve_sequence_backend_then_deny_then_approve_survives_and_completes() {
+    // ── shared IDs ────────────────────────────────────────────────────────────
+    // cap1: approve#1 → resume OK → Completed
+    let cap1_request_id = ApprovalRequestId::new();
+    let cap1_resume_token =
+        CapabilityResumeToken::new("resume-token:5g-cap1").expect("valid token");
+    let cap1_correlation_id = CorrelationId::new();
+    let cap1_input_ref =
+        CapabilityInputRef::new("input:run-original:5g-cap1-uuid").expect("valid input ref");
+
+    // cap2: approve#2 → resume OK → Completed (second clean approval)
+    let cap2_request_id = ApprovalRequestId::new();
+    let cap2_resume_token =
+        CapabilityResumeToken::new("resume-token:5g-cap2").expect("valid token");
+    let cap2_correlation_id = CorrelationId::new();
+    let cap2_input_ref =
+        CapabilityInputRef::new("input:run-original:5g-cap2-uuid").expect("valid input ref");
+
+    // cap3: approve#3 → resume Backend → ToolErrorResult (BUG TRIGGER)
+    let cap3_request_id = ApprovalRequestId::new();
+    let cap3_resume_token =
+        CapabilityResumeToken::new("resume-token:5g-cap3").expect("valid token");
+    let cap3_correlation_id = CorrelationId::new();
+    let cap3_input_ref =
+        CapabilityInputRef::new("input:run-original:5g-cap3-uuid").expect("valid input ref");
+
+    // cap4_deny: Denied(EmptySurface) → ToolErrorResult (no gate, no approval_resume)
+    let cap4_deny_input_ref =
+        CapabilityInputRef::new("input:run-original:5g-cap4deny-uuid").expect("valid input ref");
+
+    // cap5: approve#4 → resume OK → Completed (approval AFTER deny)
+    let cap5_request_id = ApprovalRequestId::new();
+    let cap5_resume_token =
+        CapabilityResumeToken::new("resume-token:5g-cap5").expect("valid token");
+    let cap5_correlation_id = CorrelationId::new();
+    let cap5_input_ref =
+        CapabilityInputRef::new("input:run-original:5g-cap5-uuid").expect("valid input ref");
+
+    // ── approval_resume metadata ──────────────────────────────────────────────
+    let cap1_approval_resume = CapabilityApprovalResume {
+        approval_request_id: cap1_request_id,
+        resume_token: cap1_resume_token,
+        correlation_id: cap1_correlation_id,
+        input_ref: cap1_input_ref.clone(),
+        input: serde_json::json!({"action": "cap1"}),
+        estimate: ResourceEstimate::default(),
+    };
+    let cap2_approval_resume = CapabilityApprovalResume {
+        approval_request_id: cap2_request_id,
+        resume_token: cap2_resume_token,
+        correlation_id: cap2_correlation_id,
+        input_ref: cap2_input_ref.clone(),
+        input: serde_json::json!({"action": "cap2"}),
+        estimate: ResourceEstimate::default(),
+    };
+    let cap3_approval_resume = CapabilityApprovalResume {
+        approval_request_id: cap3_request_id,
+        resume_token: cap3_resume_token,
+        correlation_id: cap3_correlation_id,
+        input_ref: cap3_input_ref.clone(),
+        input: serde_json::json!({"action": "cap3"}),
+        estimate: ResourceEstimate::default(),
+    };
+    let cap5_approval_resume = CapabilityApprovalResume {
+        approval_request_id: cap5_request_id,
+        resume_token: cap5_resume_token,
+        correlation_id: cap5_correlation_id,
+        input_ref: cap5_input_ref.clone(),
+        input: serde_json::json!({"action": "cap5"}),
+        estimate: ResourceEstimate::default(),
+    };
+
+    // ── model responses ───────────────────────────────────────────────────────
+    // Turn 1 (Phase 1): model issues cap1.
+    let cap1_model_response = ironclaw_turns::run_profile::LoopModelResponse {
+        chunks: Vec::new(),
+        safe_reasoning_deltas: Vec::new(),
+        output: ParentLoopOutput::CapabilityCalls(vec![CapabilityCallCandidate {
+            surface_version: surface_version(),
+            capability_id: capability_id(),
+            input_ref: cap1_input_ref.clone(),
+            effective_capability_ids: vec![capability_id()],
+            provider_replay: None,
+        }]),
+        effective_model_profile_id: ironclaw_turns::run_profile::ModelProfileId::new("model")
+            .expect("valid"),
+        usage: None,
+    };
+    // Turn 2 (Phase 2): after cap1 resume OK, model issues cap2 (approve#2).
+    let cap2_model_response = ironclaw_turns::run_profile::LoopModelResponse {
+        chunks: Vec::new(),
+        safe_reasoning_deltas: Vec::new(),
+        output: ParentLoopOutput::CapabilityCalls(vec![CapabilityCallCandidate {
+            surface_version: surface_version(),
+            capability_id: capability_id(),
+            input_ref: cap2_input_ref.clone(),
+            effective_capability_ids: vec![capability_id()],
+            provider_replay: None,
+        }]),
+        effective_model_profile_id: ironclaw_turns::run_profile::ModelProfileId::new("model")
+            .expect("valid"),
+        usage: None,
+    };
+    // Turn 3 (Phase 3): after cap2 resume OK, model issues cap3 (approve#3).
+    let cap3_model_response = ironclaw_turns::run_profile::LoopModelResponse {
+        chunks: Vec::new(),
+        safe_reasoning_deltas: Vec::new(),
+        output: ParentLoopOutput::CapabilityCalls(vec![CapabilityCallCandidate {
+            surface_version: surface_version(),
+            capability_id: capability_id(),
+            input_ref: cap3_input_ref.clone(),
+            effective_capability_ids: vec![capability_id()],
+            provider_replay: None,
+        }]),
+        effective_model_profile_id: ironclaw_turns::run_profile::ModelProfileId::new("model")
+            .expect("valid"),
+        usage: None,
+    };
+    // Turn 4 (Phase 4a): after cap3 resume Backend→ToolErrorResult, model issues cap4_deny.
+    let cap4_deny_model_response = ironclaw_turns::run_profile::LoopModelResponse {
+        chunks: Vec::new(),
+        safe_reasoning_deltas: Vec::new(),
+        output: ParentLoopOutput::CapabilityCalls(vec![CapabilityCallCandidate {
+            surface_version: surface_version(),
+            capability_id: capability_id(),
+            input_ref: cap4_deny_input_ref,
+            effective_capability_ids: vec![capability_id()],
+            provider_replay: None,
+        }]),
+        effective_model_profile_id: ironclaw_turns::run_profile::ModelProfileId::new("model")
+            .expect("valid"),
+        usage: None,
+    };
+    // Turn 5 (Phase 4b): after deny→ToolErrorResult, model issues cap5 (approve#4).
+    let cap5_model_response = ironclaw_turns::run_profile::LoopModelResponse {
+        chunks: Vec::new(),
+        safe_reasoning_deltas: Vec::new(),
+        output: ParentLoopOutput::CapabilityCalls(vec![CapabilityCallCandidate {
+            surface_version: surface_version(),
+            capability_id: capability_id(),
+            input_ref: cap5_input_ref.clone(),
+            effective_capability_ids: vec![capability_id()],
+            provider_replay: None,
+        }]),
+        effective_model_profile_id: ironclaw_turns::run_profile::ModelProfileId::new("model")
+            .expect("valid"),
+        usage: None,
+    };
+
+    // ── batch outcomes (9 total) ──────────────────────────────────────────────
+    // [0] Phase 1:  cap1 → ApprovalRequired → Blocked (gate 1).
+    // [1] Phase 2:  cap1 resume → Completed.
+    // [2] Phase 2:  cap2 → ApprovalRequired → Blocked (gate 2).
+    // [3] Phase 3:  cap2 resume → Completed.
+    // [4] Phase 3:  cap3 → ApprovalRequired → Blocked (gate 3).
+    // [5] Phase 4:  cap3 resume → Failed(Backend) — BUG TRIGGER.
+    //               C-sub-A fix: ToolErrorResult; no single-path retry; loop continues.
+    // [6] Phase 4:  cap4_deny → Denied(EmptySurface) → ToolErrorResult.
+    // [7] Phase 4:  cap5 → ApprovalRequired → Blocked (gate 5).
+    // [8] Phase 5:  cap5 resume → Completed → final reply → Done.
+    let batch_outcomes = vec![
+        // [0] Phase 1: cap1 → ApprovalRequired → Blocked.
+        ironclaw_turns::run_profile::CapabilityBatchOutcome {
+            outcomes: vec![CapabilityOutcome::ApprovalRequired {
+                gate_ref: LoopGateRef::new("gate:5g-cap1").expect("valid"),
+                safe_summary: "cap1 needs approval".to_string(),
+                approval_resume: Some(cap1_approval_resume),
+            }],
+            stopped_on_suspension: true,
+        },
+        // [1] Phase 2: cap1 approval-resume → Completed.
+        ironclaw_turns::run_profile::CapabilityBatchOutcome {
+            outcomes: vec![CapabilityOutcome::Completed(
+                ironclaw_turns::run_profile::CapabilityResultMessage {
+                    result_ref: LoopResultRef::new("result:5g-cap1").expect("valid"),
+                    safe_summary: "cap1 completed successfully".to_string(),
+                    progress: ironclaw_turns::run_profile::CapabilityProgress::MadeProgress,
+                    terminate_hint: false,
+                    byte_len: 0,
+                },
+            )],
+            stopped_on_suspension: false,
+        },
+        // [2] Phase 2 (continued): model issues cap2 → ApprovalRequired → Blocked.
+        ironclaw_turns::run_profile::CapabilityBatchOutcome {
+            outcomes: vec![CapabilityOutcome::ApprovalRequired {
+                gate_ref: LoopGateRef::new("gate:5g-cap2").expect("valid"),
+                safe_summary: "cap2 needs approval".to_string(),
+                approval_resume: Some(cap2_approval_resume),
+            }],
+            stopped_on_suspension: true,
+        },
+        // [3] Phase 3: cap2 approval-resume → Completed (clean second approve).
+        ironclaw_turns::run_profile::CapabilityBatchOutcome {
+            outcomes: vec![CapabilityOutcome::Completed(
+                ironclaw_turns::run_profile::CapabilityResultMessage {
+                    result_ref: LoopResultRef::new("result:5g-cap2").expect("valid"),
+                    safe_summary: "cap2 completed successfully".to_string(),
+                    progress: ironclaw_turns::run_profile::CapabilityProgress::MadeProgress,
+                    terminate_hint: false,
+                    byte_len: 0,
+                },
+            )],
+            stopped_on_suspension: false,
+        },
+        // [4] Phase 3 (continued): model issues cap3 → ApprovalRequired → Blocked.
+        ironclaw_turns::run_profile::CapabilityBatchOutcome {
+            outcomes: vec![CapabilityOutcome::ApprovalRequired {
+                gate_ref: LoopGateRef::new("gate:5g-cap3").expect("valid"),
+                safe_summary: "cap3 needs approval".to_string(),
+                approval_resume: Some(cap3_approval_resume),
+            }],
+            stopped_on_suspension: true,
+        },
+        // [5] Phase 4: cap3 approval-resume → Failed(Backend). BUG TRIGGER.
+        // C-sub-A fix: intercepted as ToolErrorResult; loop continues.
+        // No single_outcomes entry — no retry is dispatched.
+        ironclaw_turns::run_profile::CapabilityBatchOutcome {
+            outcomes: vec![CapabilityOutcome::Failed(
+                ironclaw_turns::run_profile::CapabilityFailure {
+                    error_kind: CapabilityFailureKind::Backend,
+                    safe_summary: "transient backend error during cap3 resume".to_string(),
+                    detail: None,
+                },
+            )],
+            stopped_on_suspension: false,
+        },
+        // [6] Phase 4 (continued): model issues cap4_deny → Denied(EmptySurface) → ToolErrorResult.
+        ironclaw_turns::run_profile::CapabilityBatchOutcome {
+            outcomes: vec![CapabilityOutcome::Denied(
+                ironclaw_turns::run_profile::CapabilityDenied {
+                    reason_kind:
+                        ironclaw_turns::run_profile::CapabilityDeniedReasonKind::EmptySurface,
+                    safe_summary: "cap4_deny is not permitted by surface policy".to_string(),
+                },
+            )],
+            stopped_on_suspension: false,
+        },
+        // [7] Phase 4 (continued): model issues cap5 → ApprovalRequired → Blocked (gate 5).
+        ironclaw_turns::run_profile::CapabilityBatchOutcome {
+            outcomes: vec![CapabilityOutcome::ApprovalRequired {
+                gate_ref: LoopGateRef::new("gate:5g-cap5").expect("valid"),
+                safe_summary: "cap5 needs approval".to_string(),
+                approval_resume: Some(cap5_approval_resume),
+            }],
+            stopped_on_suspension: true,
+        },
+        // [8] Phase 5: cap5 approval-resume → Completed. terminate_hint: false so the loop
+        // continues to a model turn for the final reply, exercising the full round-trip.
+        ironclaw_turns::run_profile::CapabilityBatchOutcome {
+            outcomes: vec![CapabilityOutcome::Completed(
+                ironclaw_turns::run_profile::CapabilityResultMessage {
+                    result_ref: LoopResultRef::new("result:5g-cap5").expect("valid"),
+                    safe_summary: "cap5 completed successfully".to_string(),
+                    progress: ironclaw_turns::run_profile::CapabilityProgress::MadeProgress,
+                    terminate_hint: false,
+                    byte_len: 0,
+                },
+            )],
+            stopped_on_suspension: false,
+        },
+    ];
+
+    // Model responses (in order):
+    //   Turn 1 (Phase 1):  cap1_model_response
+    //   Turn 2 (Phase 2):  cap2_model_response   (after cap1 resume OK)
+    //   Turn 3 (Phase 3):  cap3_model_response   (after cap2 resume OK)
+    //   Turn 4 (Phase 4a): cap4_deny_model_response (after cap3 resume Backend→ToolErrorResult)
+    //   Turn 5 (Phase 4b): cap5_model_response   (after deny→ToolErrorResult)
+    //   Turn 6 (Phase 5):  reply_response()       (after cap5 resume OK)
+    //
+    // Deliberately NO with_single_outcomes: the C-sub-A guard prevents any
+    // single-path retry dispatch for resume-origin Backend failures.
+    let host = MockHost::new(vec![
+        cap1_model_response,
+        cap2_model_response,
+        cap3_model_response,
+        cap4_deny_model_response,
+        cap5_model_response,
+        reply_response(),
+    ])
+    .with_batch_outcomes(batch_outcomes);
+
+    let executor = CanonicalAgentLoopExecutor;
+
+    // ── Phase 1: cap1 → ApprovalRequired → Blocked ───────────────────────────
+    let initial_state = LoopExecutionState::initial_for_run(host.run_context());
+    let phase1_exit = executor
+        .execute_family(&crate::families::default(), &host, initial_state)
+        .await
+        .expect("phase 1 must succeed (blocks on cap1 gate)");
+    assert!(
+        matches!(phase1_exit, LoopExit::Blocked(_)),
+        "phase 1 must block on cap1 approval gate; got {phase1_exit:?}"
+    );
+
+    let phase1_bb = final_staged_state_for_kind(&host, LoopCheckpointKind::BeforeBlock);
+    assert!(
+        phase1_bb.pending_approval_resume.is_some(),
+        "phase 1 BeforeBlock must carry pending_approval_resume for cap1"
+    );
+    assert_eq!(
+        phase1_bb
+            .pending_approval_resume
+            .as_ref()
+            .unwrap()
+            .approval_request_id,
+        cap1_request_id,
+        "phase 1 pending_approval_resume must be for cap1 (approve#1)"
+    );
+
+    // ── Phase 2: approve#1 (cap1) → Completed; model issues cap2 (approve#2) → Blocked ─────
+    let phase2_exit = executor
+        .execute_family(&crate::families::default(), &host, phase1_bb)
+        .await
+        .expect("phase 2 must succeed (cap1 resume Completed, blocks on cap2 gate)");
+    assert!(
+        matches!(phase2_exit, LoopExit::Blocked(_)),
+        "phase 2 must block on cap2 approval gate after cap1 completes; got {phase2_exit:?}"
+    );
+
+    let phase2_bb = final_staged_state_for_kind(&host, LoopCheckpointKind::BeforeBlock);
+    assert!(
+        phase2_bb.pending_approval_resume.is_some(),
+        "phase 2 BeforeBlock must carry pending_approval_resume for cap2 (approve#2)"
+    );
+    assert_eq!(
+        phase2_bb
+            .pending_approval_resume
+            .as_ref()
+            .unwrap()
+            .approval_request_id,
+        cap2_request_id,
+        "phase 2 pending_approval_resume must be for cap2 (approve#2)"
+    );
+
+    // ── Phase 3: approve#2 (cap2) → Completed; model issues cap3 (approve#3) → Blocked ─────
+    let phase3_exit = executor
+        .execute_family(&crate::families::default(), &host, phase2_bb)
+        .await
+        .expect("phase 3 must succeed (cap2 resume Completed, blocks on cap3 gate)");
+    assert!(
+        matches!(phase3_exit, LoopExit::Blocked(_)),
+        "phase 3 must block on cap3 approval gate after cap2 completes; got {phase3_exit:?}"
+    );
+
+    let phase3_bb = final_staged_state_for_kind(&host, LoopCheckpointKind::BeforeBlock);
+    assert!(
+        phase3_bb.pending_approval_resume.is_some(),
+        "phase 3 BeforeBlock must carry pending_approval_resume for cap3 (approve#3)"
+    );
+    assert_eq!(
+        phase3_bb
+            .pending_approval_resume
+            .as_ref()
+            .unwrap()
+            .approval_request_id,
+        cap3_request_id,
+        "phase 3 pending_approval_resume must be for cap3 (approve#3)"
+    );
+
+    // ── Phase 4: approve#3 (cap3) → Backend failure (BUG TRIGGER) ───────────
+    //
+    // cap3 resume returns Failed(Backend). C-sub-A fix intercepts this before
+    // any retry → ToolErrorResult → loop continues. Model then issues cap4_deny
+    // (Denied→ToolErrorResult) and cap5 (ApprovalRequired→Blocked).
+    //
+    // Pre-fix: this phase would return Err(HostUnavailable { stage: Capability })
+    // because handle_capability_error clears pending_approval_resume BEFORE
+    // recovery → retry fires with None → HostUnavailable / ScopeMismatch.
+    // Post-fix: phase 4 succeeds and blocks on cap5.
+    let phase4_result = executor
+        .execute_family(&crate::families::default(), &host, phase3_bb)
+        .await;
+
+    let phase4_exit = phase4_result.expect(
+        "REGRESSION: cap3 resume-origin Backend failure must not kill the run as HostUnavailable. \
+         C-sub-A fix must intercept Retry for resume-origin failures and surface as ToolErrorResult \
+         so the loop can continue through the deny and cap5 approval.",
+    );
+
+    // Phase 4 must block on cap5 after: cap3-Backend→ToolErrorResult, deny→ToolErrorResult.
+    assert!(
+        matches!(phase4_exit, LoopExit::Blocked(_)),
+        "phase 4 must block on cap5 approval gate after cap3 backend error and deny; \
+         got {phase4_exit:?}"
+    );
+
+    // No single invoke_capability retry must have been dispatched for the resume-origin failure.
+    assert!(
+        host.single_invocations().is_empty(),
+        "no single invoke_capability retry must be made for a resume-origin Backend failure \
+         (C-sub-A guard: retry suppressed, Backend error surfaced as ToolErrorResult)"
+    );
+
+    let phase4_bb = final_staged_state_for_kind(&host, LoopCheckpointKind::BeforeBlock);
+    assert!(
+        phase4_bb.pending_approval_resume.is_some(),
+        "phase 4 BeforeBlock must carry pending_approval_resume for cap5 (approve#4)"
+    );
+    assert_eq!(
+        phase4_bb
+            .pending_approval_resume
+            .as_ref()
+            .unwrap()
+            .approval_request_id,
+        cap5_request_id,
+        "phase 4 pending_approval_resume must be for cap5 (approve#4)"
+    );
+
+    // ── Phase 5: approve#4 (cap5) → Completed → final reply → Done ───────────
+    let phase5_exit = executor
+        .execute_family(&crate::families::default(), &host, phase4_bb)
+        .await
+        .expect("phase 5 (approve cap5) must complete the run");
+
+    assert!(
+        matches!(phase5_exit, LoopExit::Completed(_)),
+        "phase 5 (cap5 approval-resume) must complete the run; got {phase5_exit:?}"
+    );
+
+    // Total model calls: 6 (cap1, cap2, cap3, cap4_deny, cap5, final reply).
+    assert_eq!(
+        host.model_requests().len(),
+        6,
+        "full 5-gate sequence must make exactly 6 model calls: \
+         cap1 (gate1), cap2 (gate2), cap3 (gate3), cap3-backend+deny batch, cap5 (gate5), final reply"
+    );
+}

--- a/crates/ironclaw_host_runtime/tests/reborn_e2e_gate.rs
+++ b/crates/ironclaw_host_runtime/tests/reborn_e2e_gate.rs
@@ -4,7 +4,10 @@ use support::legacy_capability_fixture_to_v2;
 
 use std::{
     collections::BTreeMap,
-    sync::{Arc, Mutex},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, Ordering},
+    },
 };
 
 use async_trait::async_trait;
@@ -19,13 +22,18 @@ use ironclaw_events::{
     DurableEventLog, EventStreamKey, InMemoryAuditSink, InMemoryDurableEventLog, InMemoryEventSink,
     ReadScope, RuntimeEventKind,
 };
-use ironclaw_extensions::{ExtensionManifest, ExtensionPackage, ExtensionRegistry, ManifestSource};
+use ironclaw_extensions::{
+    CapabilityManifest, CapabilityVisibility, ExtensionManifest, ExtensionPackage,
+    ExtensionRegistry, ExtensionRuntime, MANIFEST_SCHEMA_VERSION, ManifestSource,
+};
 use ironclaw_filesystem::{InMemoryBackend, LocalFilesystem, RootFilesystem};
 use ironclaw_host_api::*;
 use ironclaw_host_runtime::{
-    BuiltinObligationServices, CapabilitySurfacePolicy, CapabilitySurfaceVersion, HostRuntime,
-    HostRuntimeServices, RuntimeCapabilityOutcome, RuntimeCapabilityRequest,
-    RuntimeCapabilityResumeRequest, RuntimeFailureKind, RuntimeStatusRequest, SurfaceKind,
+    BuiltinObligationServices, CapabilitySurfacePolicy, CapabilitySurfaceVersion,
+    FirstPartyCapabilityError, FirstPartyCapabilityHandler, FirstPartyCapabilityRegistry,
+    FirstPartyCapabilityRequest, FirstPartyCapabilityResult, HostRuntime, HostRuntimeServices,
+    RuntimeCapabilityOutcome, RuntimeCapabilityRequest, RuntimeCapabilityResumeRequest,
+    RuntimeFailureKind, RuntimeStatusRequest, SurfaceKind,
 };
 use ironclaw_network::{
     NetworkHttpEgress, NetworkHttpError, NetworkHttpRequest, NetworkHttpResponse, NetworkUsage,
@@ -994,6 +1002,221 @@ fn assert_failed_outcome(outcome: RuntimeCapabilityOutcome, expected: RuntimeFai
     match outcome {
         RuntimeCapabilityOutcome::Failed(failure) => assert_eq!(failure.kind, expected),
         other => panic!("expected failed outcome {expected:?}, got {other:?}"),
+    }
+}
+
+/// Regression test: a Backend failure from a first-party handler after approval
+/// resume must surface as `RuntimeCapabilityOutcome::Failed(Backend)` rather
+/// than causing scope_mismatch or a terminal `HostUnavailable` run death.
+///
+/// Flow:
+///   1. `invoke_capability` with no grants → `ApprovalThenGrantAuthorizer` returns
+///      `ApprovalRequired`.
+///   2. Approve the dispatch so the capability lease exists.
+///   3. `resume_capability` → `OnceFailingFirstPartyHandler` returns a Backend error
+///      on its first call.
+///   4. Assert the outcome is `Failed(Backend)` (the fix in PR #4899).
+#[tokio::test]
+async fn reborn_e2e_gate_resume_backend_error_surfaces_as_failed_backend() {
+    let handler = Arc::new(OnceFailingFirstPartyHandler::new());
+    let first_party = FirstPartyCapabilityRegistry::new()
+        .with_handler(first_party_capability_id(), Arc::clone(&handler));
+    let run_state = Arc::new(InMemoryRunStateStore::new());
+    let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
+    let capability_leases = Arc::new(InMemoryCapabilityLeaseStore::new());
+    let services = HostRuntimeServices::new(
+        Arc::new(first_party_registry_for_gate_test()),
+        Arc::new(LocalFilesystem::new()),
+        Arc::new(InMemoryResourceGovernor::new()),
+        Arc::new(ApprovalThenGrantAuthorizer),
+        ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_first_party_capabilities(Arc::new(first_party))
+    .with_trust_policy(Arc::new(first_party_trust_policy_for_gate_test()))
+    .with_run_state(Arc::clone(&run_state))
+    .with_approval_requests(approval_requests)
+    .with_capability_leases(Arc::clone(&capability_leases));
+    let runtime = services.host_runtime_for_local_testing();
+
+    // Step 1: invoke with no grants — should require approval.
+    let context = execution_context_without_grants_first_party();
+    let scope = context.resource_scope.clone();
+    let outcome = runtime
+        .invoke_capability(RuntimeCapabilityRequest::new(
+            context.clone(),
+            first_party_capability_id(),
+            ResourceEstimate::default(),
+            serde_json::json!({"message": "status"}),
+            trust_decision_first_party(),
+        ))
+        .await
+        .unwrap();
+    let gate = match outcome {
+        RuntimeCapabilityOutcome::ApprovalRequired(gate) => gate,
+        other => panic!("expected approval gate for first-party capability, got {other:?}"),
+    };
+    assert_eq!(gate.capability_id, first_party_capability_id());
+    let approval_request_id = gate.approval_request_id;
+
+    // Step 2: approve the dispatch.
+    approve_dispatch_for_services(&services, &scope, approval_request_id).await;
+
+    // Step 3: resume — handler fails with Backend on the first call.
+    // Re-use the same context (same invocation_id) so the run state record
+    // (BlockedApproval) can be found by the capability host, consistent with
+    // how existing approval-resume tests drive the runtime.
+    let resume = runtime
+        .resume_capability(RuntimeCapabilityResumeRequest::new(
+            context,
+            approval_request_id,
+            first_party_capability_id(),
+            ResourceEstimate::default(),
+            serde_json::json!({"message": "status"}),
+            trust_decision_first_party(),
+        ))
+        .await
+        .unwrap();
+
+    // Step 4: assert Backend failure (the fix in PR #4899).
+    assert_failed_outcome(resume, RuntimeFailureKind::Backend);
+    assert!(
+        handler.has_been_called(),
+        "handler must have been called during resume dispatch"
+    );
+}
+
+/// A first-party handler that returns a Backend error on its first call and
+/// succeeds on subsequent calls.  Used to simulate the transient backend
+/// failure that previously caused scope_mismatch / HostUnavailable run death.
+struct OnceFailingFirstPartyHandler {
+    has_been_called: AtomicBool,
+}
+
+impl OnceFailingFirstPartyHandler {
+    fn new() -> Self {
+        Self {
+            has_been_called: AtomicBool::new(false),
+        }
+    }
+
+    fn has_been_called(&self) -> bool {
+        self.has_been_called.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl FirstPartyCapabilityHandler for OnceFailingFirstPartyHandler {
+    async fn dispatch(
+        &self,
+        _request: FirstPartyCapabilityRequest,
+    ) -> Result<FirstPartyCapabilityResult, FirstPartyCapabilityError> {
+        let already_called = self.has_been_called.swap(true, Ordering::SeqCst);
+        if !already_called {
+            // First call: fail with Backend to exercise the resume-origin guard.
+            Err(FirstPartyCapabilityError::new(
+                RuntimeDispatchErrorKind::Backend,
+            ))
+        } else {
+            // Subsequent calls: succeed (should not be reached in this test).
+            Ok(FirstPartyCapabilityResult::new(
+                serde_json::json!({"status": "ok"}),
+                ResourceUsage::default(),
+            ))
+        }
+    }
+}
+
+fn first_party_capability_id() -> CapabilityId {
+    CapabilityId::new("host.status").unwrap()
+}
+
+fn first_party_provider_id() -> ExtensionId {
+    ExtensionId::new("host").unwrap()
+}
+
+fn first_party_registry_for_gate_test() -> ExtensionRegistry {
+    let package = ExtensionPackage::from_manifest(
+        ExtensionManifest {
+            schema_version: MANIFEST_SCHEMA_VERSION.to_string(),
+            id: first_party_provider_id(),
+            name: "Host".to_string(),
+            version: "0.1.0".to_string(),
+            description: "Host-owned first-party capabilities for gate test".to_string(),
+            source: ManifestSource::HostBundled,
+            requested_trust: RequestedTrustClass::FirstPartyRequested,
+            descriptor_trust_default: TrustClass::Sandbox,
+            runtime: ExtensionRuntime::FirstParty {
+                service: "host".to_string(),
+            },
+            host_apis: Vec::new(),
+            capabilities: vec![CapabilityManifest {
+                id: first_party_capability_id(),
+                implements: Vec::new(),
+                description: "Reports host status".to_string(),
+                effects: vec![EffectKind::DispatchCapability],
+                default_permission: PermissionMode::Allow,
+                visibility: CapabilityVisibility::Model,
+                input_schema_ref: CapabilityProfileSchemaRef::new(
+                    "schemas/host/status.input.v1.json",
+                )
+                .unwrap(),
+                output_schema_ref: CapabilityProfileSchemaRef::new(
+                    "schemas/host/status.output.v1.json",
+                )
+                .unwrap(),
+                prompt_doc_ref: Some(
+                    CapabilityProfileSchemaRef::new("prompts/host/status.md").unwrap(),
+                ),
+                required_host_ports: Vec::new(),
+                runtime_credentials: Vec::new(),
+                resource_profile: None,
+            }],
+            hooks: Vec::new(),
+        },
+        VirtualPath::new("/system/extensions/host").unwrap(),
+    )
+    .unwrap();
+    let mut registry = ExtensionRegistry::new();
+    registry.insert(package).unwrap();
+    registry
+}
+
+fn first_party_trust_policy_for_gate_test() -> HostTrustPolicy {
+    HostTrustPolicy::new(vec![Box::new(AdminConfig::with_entries(vec![
+        AdminEntry::for_local_manifest(
+            PackageId::new("host").unwrap(),
+            "/system/extensions/host/manifest.toml".to_string(),
+            None,
+            HostTrustAssignment::first_party(),
+            vec![EffectKind::DispatchCapability],
+            None,
+        ),
+    ]))])
+    .unwrap()
+}
+
+fn execution_context_without_grants_first_party() -> ExecutionContext {
+    ExecutionContext::local_default(
+        UserId::new("user").unwrap(),
+        ExtensionId::new("caller").unwrap(),
+        RuntimeKind::FirstParty,
+        TrustClass::FirstParty,
+        CapabilitySet::default(),
+        MountView::default(),
+    )
+    .unwrap()
+}
+
+fn trust_decision_first_party() -> TrustDecision {
+    TrustDecision {
+        effective_trust: EffectiveTrustClass::user_trusted(),
+        authority_ceiling: AuthorityCeiling {
+            allowed_effects: vec![EffectKind::DispatchCapability],
+            max_resource_ceiling: None,
+        },
+        provenance: TrustProvenance::Default,
+        evaluated_at: Utc::now(),
     }
 }
 

--- a/crates/ironclaw_reborn/tests/planned_driver_e2e.rs
+++ b/crates/ironclaw_reborn/tests/planned_driver_e2e.rs
@@ -1,6 +1,9 @@
 use std::{
     collections::VecDeque,
-    sync::atomic::{AtomicUsize, Ordering},
+    sync::{
+        Mutex,
+        atomic::{AtomicUsize, Ordering},
+    },
 };
 
 use chrono::Utc;
@@ -11,6 +14,9 @@ use ironclaw_agent_loop::{
         test_run_context,
     },
 };
+use ironclaw_host_api::{
+    ApprovalRequestId, CapabilityId, CorrelationId, ResourceEstimate, RuntimeKind,
+};
 use ironclaw_reborn::app_loop_family::build_loop_family_registry;
 use ironclaw_reborn::planned_driver::PlannedDriver;
 use ironclaw_reborn::planned_driver_factory::{
@@ -18,19 +24,22 @@ use ironclaw_reborn::planned_driver_factory::{
 };
 use ironclaw_turns::{
     AgentLoopDriverResumeRequest, AgentLoopDriverRunRequest, LoopCancelledReasonKind, LoopExit,
-    LoopMessageRef, TurnCheckpointId,
+    LoopGateRef, LoopMessageRef, RedactedCheckpointPayload, TurnCheckpointId,
     run_profile::{
         AgentLoopDriver, AgentLoopDriverError, AgentLoopHostError, AgentLoopHostErrorKind,
-        AppendCapabilityResultRef, BeginAssistantDraft, CapabilityBatchInvocation,
-        CapabilityBatchOutcome, CapabilityInvocation, CapabilityOutcome, FinalizeAssistantMessage,
-        LoadCheckpointPayloadRequest, LoadedCheckpointPayload, LoopCancelReasonKind,
-        LoopCancellationPort, LoopCancellationSignal, LoopCapabilityPort, LoopCheckpointPort,
+        AppendCapabilityResultRef, AssistantReply, BeginAssistantDraft, CapabilityApprovalResume,
+        CapabilityBatchInvocation, CapabilityBatchOutcome, CapabilityFailure,
+        CapabilityFailureKind, CapabilityInputRef, CapabilityInvocation, CapabilityOutcome,
+        CapabilityResumeToken, FinalizeAssistantMessage, LoadCheckpointPayloadRequest,
+        LoadedCheckpointPayload, LoopCancelReasonKind, LoopCancellationPort,
+        LoopCancellationSignal, LoopCapabilityPort, LoopCheckpointKind, LoopCheckpointPort,
         LoopCheckpointRequest, LoopCheckpointStateRef, LoopCompactionError, LoopCompactionOutcome,
         LoopCompactionPort, LoopCompactionRequest, LoopContextBundle, LoopContextPort,
         LoopContextRequest, LoopInput, LoopInputAckToken, LoopInputBatch, LoopInputCursor,
-        LoopInputPort, LoopModelPort, LoopModelRequest, LoopModelResponse, LoopProgressEvent,
-        LoopProgressPort, LoopPromptBundle, LoopPromptBundleRequest, LoopPromptPort,
-        LoopRunContext, LoopRunInfoPort, LoopSafeSummary, LoopTranscriptPort, RunProfileResolver,
+        LoopInputPort, LoopModelMessage, LoopModelPort, LoopModelRequest, LoopModelResponse,
+        LoopProgressEvent, LoopProgressPort, LoopPromptBundle, LoopPromptBundleRef,
+        LoopPromptBundleRequest, LoopPromptPort, LoopRunContext, LoopRunInfoPort, LoopSafeSummary,
+        LoopTranscriptPort, ModelStreamChunk, ParentLoopOutput, RunProfileResolver,
         StageCheckpointPayloadRequest, UpdateAssistantDraft, VisibleCapabilityRequest,
         VisibleCapabilitySurface,
     },
@@ -569,6 +578,470 @@ impl LoopCompactionPort for ForbiddenResumeHost {
 
 #[async_trait::async_trait]
 impl LoopCancellationPort for ForbiddenResumeHost {
+    fn observe_cancellation(&self) -> Option<LoopCancellationSignal> {
+        None
+    }
+
+    async fn cancellation_requested(&self) -> LoopCancellationSignal {
+        std::future::pending().await
+    }
+}
+
+/// Regression test for PR #4899: a resume-origin Backend failure must surface
+/// as a model-visible tool error rather than triggering a scope_mismatch /
+/// terminal `HostUnavailable` run death.
+///
+/// Before the fix, `handle_capability_error` returned `RecoveryOutcome::Retry`
+/// for a `Backend` failure and called `capability_invocation_from_candidate(call, None)`,
+/// dropping the resume context and causing scope_mismatch.  After the fix, the
+/// `is_resume_origin` guard intercepts the retry and surfaces the error as a
+/// `ToolErrorResult` so the model can re-approve.
+///
+/// Flow:
+///   1. `run()`: model returns a call to "demo.echo" → batch returns
+///      `ApprovalRequired { approval_resume: Some(...) }` → driver writes
+///      `BeforeBlock` checkpoint, exits `LoopExit::Blocked`.
+///   2. `resume()`: driver loads checkpoint (state has `pending_approval_resume`)
+///      → executor re-dispatches batch → batch returns
+///      `Failed { error_kind: Backend }` → fix intercepts retry, surfaces as
+///      tool error → model returns reply → `LoopExit::Completed`.
+///   3. Assert `invoke_capability` (single-call retry) was NOT called — the fix
+///      must NOT reach the re-dispatch path.
+#[tokio::test]
+async fn planned_driver_resume_approval_backend_failure_surfaces_as_tool_error_not_retry() {
+    let registry = build_loop_family_registry().expect("registry should build");
+    let driver = PlannedDriver::default_from_registry(&registry).expect("driver should build");
+    let context = run_context_for_driver(&driver);
+    let host = CapableResumeHost::new(context.clone());
+
+    // Run phase: model calls "demo.echo", batch returns ApprovalRequired with
+    // approval_resume populated.  Driver suspends with LoopExit::Blocked.
+    let run_req = capable_resume_run_request(&driver, &context);
+    let exit = driver
+        .run(run_req, &host)
+        .await
+        .expect("run should produce a loop exit");
+
+    let blocked = match exit {
+        LoopExit::Blocked(blocked) => blocked,
+        other => panic!("expected blocked exit from approval gate, got {other:?}"),
+    };
+    assert_eq!(blocked.kind, ironclaw_turns::LoopBlockedKind::Approval);
+    let checkpoint_id = blocked.checkpoint_id;
+
+    assert_eq!(
+        host.single_retry_call_count(),
+        0,
+        "invoke_capability must not be called during the run phase"
+    );
+
+    // Resume phase: driver loads checkpoint, executor sees pending_approval_resume,
+    // re-dispatches batch which returns Backend failure.  The fix surfaces it as a
+    // tool error, model returns a reply, loop completes.
+    let exit = driver
+        .resume(resume_request(&context, checkpoint_id), &host)
+        .await
+        .expect("resume should produce a loop exit");
+
+    assert!(
+        matches!(exit, LoopExit::Completed(_)),
+        "after Backend surface-and-continue, model reply should complete the loop; got {exit:?}"
+    );
+    assert_eq!(
+        host.single_retry_call_count(),
+        0,
+        "invoke_capability must NOT be called after resume-origin Backend failure (PR #4899 fix)"
+    );
+}
+
+/// A host that drives the approval-resume → Backend-failure scenario.
+///
+/// Phase 1 (run):
+///   - `stream_model` → one capability call to "demo.echo"
+///   - `invoke_capability_batch` → `ApprovalRequired { approval_resume: Some(...) }`
+///   - `stage_checkpoint_payload` + `checkpoint` → stores payload, returns ID
+///
+/// Phase 2 (resume):
+///   - `load_checkpoint_payload` → returns stored payload
+///   - `invoke_capability_batch` → `Failed { error_kind: Backend }`
+///   - `stream_model` → assistant reply (model sees the surfaced tool error)
+///
+/// `invoke_capability` must never be called in either phase (tracked separately).
+struct CapableResumeHost {
+    context: LoopRunContext,
+    /// Scripted model responses (pop_front each call).
+    model_responses: Mutex<VecDeque<LoopModelResponse>>,
+    /// Scripted batch outcomes (pop_front each call).
+    batch_outcomes: Mutex<VecDeque<Vec<CapabilityOutcome>>>,
+    /// Stores (payload_bytes, kind) staged between stage_checkpoint_payload and
+    /// checkpoint().  We only need to handle one pending payload at a time.
+    pending_payload: Mutex<Option<(Vec<u8>, LoopCheckpointKind)>>,
+    /// Stores the committed (checkpoint_id → (bytes, kind)) mapping.
+    committed_payloads: Mutex<Vec<(TurnCheckpointId, Vec<u8>, LoopCheckpointKind)>>,
+    /// Tracks calls to `invoke_capability` (single-call retry path).
+    single_retry_calls: AtomicUsize,
+}
+
+impl CapableResumeHost {
+    fn new(context: LoopRunContext) -> Self {
+        // Phase 1 model response: one capability call.
+        let phase1_model = LoopModelResponse {
+            chunks: vec![ModelStreamChunk {
+                safe_text_delta: String::new(),
+            }],
+            safe_reasoning_deltas: Vec::new(),
+            output: ParentLoopOutput::CapabilityCalls(vec![capable_resume_call()]),
+            effective_model_profile_id: ironclaw_turns::run_profile::ModelProfileId::new("model")
+                .unwrap(),
+            usage: None,
+        };
+        // Phase 2 model response: plain assistant reply (after the error is surfaced).
+        let phase2_model = LoopModelResponse {
+            chunks: vec![ModelStreamChunk {
+                safe_text_delta: String::new(),
+            }],
+            safe_reasoning_deltas: Vec::new(),
+            output: ParentLoopOutput::AssistantReply(AssistantReply {
+                content: "error noted, please re-approve".to_string(),
+            }),
+            effective_model_profile_id: ironclaw_turns::run_profile::ModelProfileId::new("model")
+                .unwrap(),
+            usage: None,
+        };
+
+        // Phase 1 batch outcome: ApprovalRequired with approval_resume.
+        let approval_request_id = ApprovalRequestId::new();
+        let resume_token = CapabilityResumeToken::new("resume-token:demo-echo").unwrap();
+        let correlation_id = CorrelationId::new();
+        let input_ref = CapabilityInputRef::new("input:demo-echo").expect("valid input ref");
+        let phase1_batch = vec![CapabilityOutcome::ApprovalRequired {
+            gate_ref: LoopGateRef::new("gate:demo-echo-approval").unwrap(),
+            safe_summary: "approval required for demo.echo".to_string(),
+            approval_resume: Some(CapabilityApprovalResume {
+                approval_request_id,
+                resume_token,
+                correlation_id,
+                input_ref,
+                input: serde_json::json!({"message": "hello"}),
+                estimate: ResourceEstimate::default(),
+            }),
+        }];
+        // Phase 2 batch outcome: Backend failure (triggers the PR #4899 fix path).
+        let phase2_batch = vec![CapabilityOutcome::Failed(CapabilityFailure {
+            error_kind: CapabilityFailureKind::Backend,
+            safe_summary: "backend unavailable during resume".to_string(),
+            detail: None,
+        })];
+
+        Self {
+            context,
+            model_responses: Mutex::new(VecDeque::from([phase1_model, phase2_model])),
+            batch_outcomes: Mutex::new(VecDeque::from([phase1_batch, phase2_batch])),
+            pending_payload: Mutex::new(None),
+            committed_payloads: Mutex::new(Vec::new()),
+            single_retry_calls: AtomicUsize::new(0),
+        }
+    }
+
+    fn single_retry_call_count(&self) -> usize {
+        self.single_retry_calls.load(Ordering::SeqCst)
+    }
+}
+
+/// Build an `AgentLoopDriverRunRequest` from a `CapableResumeHost` context,
+/// mirroring the logic of the `run_request` helper but without requiring a
+/// `MockAgentLoopDriverHost`.
+fn capable_resume_run_request(
+    driver: &PlannedDriver,
+    context: &LoopRunContext,
+) -> AgentLoopDriverRunRequest {
+    let mut profile = context.resolved_run_profile.clone();
+    let descriptor = driver.descriptor();
+    profile.loop_driver = descriptor.clone();
+    profile.checkpoint_schema_id = descriptor
+        .checkpoint_schema_id
+        .clone()
+        .expect("planned driver descriptor should carry checkpoint schema");
+    profile.checkpoint_schema_version = descriptor
+        .checkpoint_schema_version
+        .expect("planned driver descriptor should carry checkpoint version");
+    AgentLoopDriverRunRequest {
+        turn_id: context.turn_id,
+        run_id: context.run_id,
+        resolved_run_profile: profile,
+    }
+}
+
+fn capable_resume_call() -> ironclaw_turns::run_profile::CapabilityCallCandidate {
+    use ironclaw_turns::run_profile::{CapabilityCallCandidate, CapabilitySurfaceVersion};
+    CapabilityCallCandidate {
+        surface_version: CapabilitySurfaceVersion::new("surface:v1").unwrap(),
+        capability_id: CapabilityId::new("demo.echo").unwrap(),
+        input_ref: CapabilityInputRef::new("input:demo-echo").unwrap(),
+        effective_capability_ids: vec![CapabilityId::new("demo.echo").unwrap()],
+        provider_replay: None,
+    }
+}
+
+impl LoopRunInfoPort for CapableResumeHost {
+    fn run_context(&self) -> &LoopRunContext {
+        &self.context
+    }
+}
+
+#[async_trait::async_trait]
+impl LoopContextPort for CapableResumeHost {
+    async fn load_loop_context(
+        &self,
+        _request: LoopContextRequest,
+    ) -> Result<LoopContextBundle, AgentLoopHostError> {
+        Ok(LoopContextBundle {
+            identity_messages: Vec::new(),
+            messages: Vec::new(),
+            compaction_message_index: Vec::new(),
+            instruction_snippets: Vec::new(),
+            memory_snippets: Vec::new(),
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl LoopPromptPort for CapableResumeHost {
+    async fn build_prompt_bundle(
+        &self,
+        _request: LoopPromptBundleRequest,
+    ) -> Result<LoopPromptBundle, AgentLoopHostError> {
+        let bundle_ref = LoopPromptBundleRef::for_run(&self.context, "bundle")
+            .map_err(|e| AgentLoopHostError::new(AgentLoopHostErrorKind::Internal, e))?;
+        Ok(LoopPromptBundle {
+            bundle_ref,
+            messages: vec![LoopModelMessage {
+                role: "user".to_string(),
+                content_ref: LoopMessageRef::new("msg:user").unwrap(),
+            }],
+            surface_version: Some(
+                ironclaw_turns::run_profile::CapabilitySurfaceVersion::new("surface:v1").unwrap(),
+            ),
+            compaction_message_index: Vec::new(),
+            instruction_fingerprint: None,
+            identity_message_count: 0,
+            instruction_snippet_count: 0,
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl LoopInputPort for CapableResumeHost {
+    async fn poll_inputs(
+        &self,
+        after: LoopInputCursor,
+        _limit: usize,
+    ) -> Result<LoopInputBatch, AgentLoopHostError> {
+        Ok(LoopInputBatch {
+            inputs: Vec::new(),
+            input_acks: Vec::new(),
+            next_cursor: after,
+        })
+    }
+
+    async fn ack_inputs(&self, _tokens: Vec<LoopInputAckToken>) -> Result<(), AgentLoopHostError> {
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl LoopModelPort for CapableResumeHost {
+    async fn stream_model(
+        &self,
+        _request: LoopModelRequest,
+    ) -> Result<LoopModelResponse, AgentLoopHostError> {
+        let response = self
+            .model_responses
+            .lock()
+            .unwrap()
+            .pop_front()
+            .ok_or_else(|| {
+                AgentLoopHostError::new(
+                    AgentLoopHostErrorKind::Internal,
+                    "model script exhausted in CapableResumeHost",
+                )
+            })?;
+        Ok(response)
+    }
+}
+
+#[async_trait::async_trait]
+impl LoopCapabilityPort for CapableResumeHost {
+    async fn visible_capabilities(
+        &self,
+        _request: VisibleCapabilityRequest,
+    ) -> Result<VisibleCapabilitySurface, AgentLoopHostError> {
+        use ironclaw_turns::run_profile::{
+            CapabilityDescriptorView, CapabilitySurfaceVersion, ConcurrencyHint,
+        };
+        Ok(VisibleCapabilitySurface {
+            version: CapabilitySurfaceVersion::new("surface:v1").unwrap(),
+            descriptors: vec![CapabilityDescriptorView {
+                capability_id: CapabilityId::new("demo.echo").unwrap(),
+                provider: None,
+                runtime: RuntimeKind::FirstParty,
+                safe_name: "demo_echo".to_string(),
+                safe_description: "echo demo capability".to_string(),
+                concurrency_hint: ConcurrencyHint::Exclusive,
+                parameters_schema: serde_json::json!({"type": "object"}),
+            }],
+        })
+    }
+
+    async fn invoke_capability(
+        &self,
+        _request: CapabilityInvocation,
+    ) -> Result<CapabilityOutcome, AgentLoopHostError> {
+        // This must NOT be called after a resume-origin Backend failure.
+        self.single_retry_calls.fetch_add(1, Ordering::SeqCst);
+        Err(AgentLoopHostError::new(
+            AgentLoopHostErrorKind::Internal,
+            "invoke_capability must not be called in the resume-origin Backend failure path",
+        ))
+    }
+
+    async fn invoke_capability_batch(
+        &self,
+        request: CapabilityBatchInvocation,
+    ) -> Result<CapabilityBatchOutcome, AgentLoopHostError> {
+        let outcomes = self
+            .batch_outcomes
+            .lock()
+            .unwrap()
+            .pop_front()
+            .ok_or_else(|| {
+                AgentLoopHostError::new(
+                    AgentLoopHostErrorKind::Internal,
+                    "batch script exhausted in CapableResumeHost",
+                )
+            })?;
+        let stopped_on_suspension = request.stop_on_first_suspension
+            && outcomes.iter().any(CapabilityOutcome::is_suspension);
+        Ok(CapabilityBatchOutcome {
+            outcomes,
+            stopped_on_suspension,
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl LoopTranscriptPort for CapableResumeHost {
+    async fn begin_assistant_draft(
+        &self,
+        _request: BeginAssistantDraft,
+    ) -> Result<LoopMessageRef, AgentLoopHostError> {
+        Ok(LoopMessageRef::new("msg:draft").unwrap())
+    }
+
+    async fn update_assistant_draft(
+        &self,
+        _request: UpdateAssistantDraft,
+    ) -> Result<(), AgentLoopHostError> {
+        Ok(())
+    }
+
+    async fn finalize_assistant_message(
+        &self,
+        _request: FinalizeAssistantMessage,
+    ) -> Result<LoopMessageRef, AgentLoopHostError> {
+        Ok(LoopMessageRef::new("msg:assistant").unwrap())
+    }
+
+    async fn append_capability_result_ref(
+        &self,
+        _request: AppendCapabilityResultRef,
+    ) -> Result<LoopMessageRef, AgentLoopHostError> {
+        Ok(LoopMessageRef::new("msg:tool-result").unwrap())
+    }
+}
+
+#[async_trait::async_trait]
+impl LoopCheckpointPort for CapableResumeHost {
+    async fn checkpoint(
+        &self,
+        request: LoopCheckpointRequest,
+    ) -> Result<TurnCheckpointId, AgentLoopHostError> {
+        let id = TurnCheckpointId::new();
+        // Move the pending payload (staged by stage_checkpoint_payload) into the
+        // committed map, keyed by the new checkpoint ID.
+        let pending = self.pending_payload.lock().unwrap().take();
+        if let Some((bytes, _kind)) = pending {
+            self.committed_payloads
+                .lock()
+                .unwrap()
+                .push((id, bytes, request.kind));
+        }
+        Ok(id)
+    }
+
+    async fn stage_checkpoint_payload(
+        &self,
+        request: StageCheckpointPayloadRequest,
+    ) -> Result<LoopCheckpointStateRef, AgentLoopHostError> {
+        // Store the raw bytes with the kind so checkpoint() can commit them.
+        *self.pending_payload.lock().unwrap() = Some((request.payload, request.kind));
+        LoopCheckpointStateRef::for_run(&self.context, "state-payload")
+            .map_err(|e| AgentLoopHostError::new(AgentLoopHostErrorKind::Internal, e))
+    }
+
+    async fn load_checkpoint_payload(
+        &self,
+        request: LoadCheckpointPayloadRequest,
+    ) -> Result<LoadedCheckpointPayload, AgentLoopHostError> {
+        let committed = self.committed_payloads.lock().unwrap();
+        let (_, bytes, kind) = committed
+            .iter()
+            .find(|(id, _, _)| *id == request.checkpoint_id)
+            .ok_or_else(|| {
+                AgentLoopHostError::new(
+                    AgentLoopHostErrorKind::Unavailable,
+                    format!(
+                        "checkpoint {} not found in CapableResumeHost",
+                        request.checkpoint_id.as_uuid()
+                    ),
+                )
+            })?;
+        let payload = RedactedCheckpointPayload::new(bytes.clone())
+            .map_err(|e| AgentLoopHostError::new(AgentLoopHostErrorKind::Internal, e))?;
+        Ok(LoadedCheckpointPayload {
+            kind: *kind,
+            schema_id: request.expected_schema_id.clone(),
+            schema_version: request.expected_schema_version,
+            payload,
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl LoopProgressPort for CapableResumeHost {
+    async fn emit_loop_progress(
+        &self,
+        _event: LoopProgressEvent,
+    ) -> Result<(), AgentLoopHostError> {
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl LoopCompactionPort for CapableResumeHost {
+    async fn compact_loop_context(
+        &self,
+        _request: LoopCompactionRequest,
+    ) -> Result<LoopCompactionOutcome, LoopCompactionError> {
+        Err(LoopCompactionError::PersistenceFailed {
+            safe_summary: LoopSafeSummary::new("compaction not supported in test host")
+                .expect("valid"),
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl LoopCancellationPort for CapableResumeHost {
     fn observe_cancellation(&self) -> Option<LoopCancellationSignal> {
         None
     }

--- a/crates/ironclaw_reborn/tests/planned_driver_e2e.rs
+++ b/crates/ironclaw_reborn/tests/planned_driver_e2e.rs
@@ -2,7 +2,7 @@ use std::{
     collections::VecDeque,
     sync::{
         Mutex,
-        atomic::{AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
     },
 };
 
@@ -45,10 +45,7 @@ use ironclaw_turns::{
     },
 };
 
-fn run_request(
-    driver: &PlannedDriver,
-    host: &MockAgentLoopDriverHost,
-) -> AgentLoopDriverRunRequest {
+fn run_request(driver: &PlannedDriver, host: &impl LoopRunInfoPort) -> AgentLoopDriverRunRequest {
     let mut profile = host.run_context().resolved_run_profile.clone();
     let descriptor = driver.descriptor();
     profile.loop_driver = descriptor.clone();
@@ -616,7 +613,7 @@ async fn planned_driver_resume_approval_backend_failure_surfaces_as_tool_error_n
 
     // Run phase: model calls "demo.echo", batch returns ApprovalRequired with
     // approval_resume populated.  Driver suspends with LoopExit::Blocked.
-    let run_req = capable_resume_run_request(&driver, &context);
+    let run_req = run_request(&driver, &host);
     let exit = driver
         .run(run_req, &host)
         .await
@@ -652,6 +649,39 @@ async fn planned_driver_resume_approval_backend_failure_surfaces_as_tool_error_n
         0,
         "invoke_capability must NOT be called after resume-origin Backend failure (PR #4899 fix)"
     );
+
+    // --- Strengthened assertions (Codex P2 review) ---
+    // These ensure the test cannot false-green when the resume batch is skipped.
+
+    // (a) The resume-phase batch must have been invoked: total batch calls == 2
+    //     (one in run phase for ApprovalRequired, one in resume phase for Backend failure).
+    //     If checkpoint/resume regressed and the executor skipped invoke_capability_batch
+    //     during resume, this count would be 1, failing the test.
+    assert_eq!(
+        host.batch_call_count(),
+        2,
+        "invoke_capability_batch must be called exactly twice: once in run (ApprovalRequired) \
+         and once in resume (Backend failure); a count of 1 means the resume batch was skipped"
+    );
+
+    // (b) The resume batch must have carried approval_resume: Some(...) on its invocation.
+    //     This confirms the checkpoint's pending_approval_resume was correctly threaded
+    //     through to the re-dispatch.  If approval_resume were stripped (None), the
+    //     is_resume_origin guard would not fire and the PR #4899 fix would not apply.
+    assert!(
+        host.resume_batch_had_approval_resume(),
+        "the resume-phase batch must carry approval_resume: Some(...) so the Backend failure \
+         is intercepted by the is_resume_origin guard (PR #4899 fix path)"
+    );
+
+    // (c) Both scripted batch outcomes must be consumed.
+    //     A non-empty queue means the resume batch was never called and the scripted
+    //     Failed(Backend) outcome was never delivered, so the test exercised nothing.
+    assert!(
+        host.scripted_batch_outcomes_fully_consumed(),
+        "all scripted batch outcomes must be consumed: a leftover outcome means the resume \
+         invoke_capability_batch call was skipped and the Backend failure path was not exercised"
+    );
 }
 
 /// A host that drives the approval-resume → Backend-failure scenario.
@@ -680,6 +710,12 @@ struct CapableResumeHost {
     committed_payloads: Mutex<Vec<(TurnCheckpointId, Vec<u8>, LoopCheckpointKind)>>,
     /// Tracks calls to `invoke_capability` (single-call retry path).
     single_retry_calls: AtomicUsize,
+    /// Counts how many times `invoke_capability_batch` was called (both phases).
+    batch_call_count: AtomicUsize,
+    /// Set to true when any `invoke_capability_batch` call contained an invocation
+    /// with `approval_resume: Some(...)`.  This confirms the resume-origin path was
+    /// exercised and the checkpoint payload was correctly threaded through.
+    resume_batch_had_approval_resume: AtomicBool,
 }
 
 impl CapableResumeHost {
@@ -740,38 +776,36 @@ impl CapableResumeHost {
             pending_payload: Mutex::new(None),
             committed_payloads: Mutex::new(Vec::new()),
             single_retry_calls: AtomicUsize::new(0),
+            batch_call_count: AtomicUsize::new(0),
+            resume_batch_had_approval_resume: AtomicBool::new(false),
         }
     }
 
     fn single_retry_call_count(&self) -> usize {
         self.single_retry_calls.load(Ordering::SeqCst)
     }
+
+    /// Total number of times `invoke_capability_batch` was called across both phases.
+    fn batch_call_count(&self) -> usize {
+        self.batch_call_count.load(Ordering::SeqCst)
+    }
+
+    /// Whether any batch call carried `approval_resume: Some(...)` on its invocations.
+    /// True iff the resume path actually threaded the approval context through.
+    fn resume_batch_had_approval_resume(&self) -> bool {
+        self.resume_batch_had_approval_resume.load(Ordering::SeqCst)
+    }
+
+    /// Whether the scripted `batch_outcomes` queue was fully drained (all scripted
+    /// outcomes consumed).  A leftover outcome means the resume batch was never called.
+    fn scripted_batch_outcomes_fully_consumed(&self) -> bool {
+        self.batch_outcomes.lock().unwrap().is_empty()
+    }
 }
 
 /// Build an `AgentLoopDriverRunRequest` from a `CapableResumeHost` context,
 /// mirroring the logic of the `run_request` helper but without requiring a
 /// `MockAgentLoopDriverHost`.
-fn capable_resume_run_request(
-    driver: &PlannedDriver,
-    context: &LoopRunContext,
-) -> AgentLoopDriverRunRequest {
-    let mut profile = context.resolved_run_profile.clone();
-    let descriptor = driver.descriptor();
-    profile.loop_driver = descriptor.clone();
-    profile.checkpoint_schema_id = descriptor
-        .checkpoint_schema_id
-        .clone()
-        .expect("planned driver descriptor should carry checkpoint schema");
-    profile.checkpoint_schema_version = descriptor
-        .checkpoint_schema_version
-        .expect("planned driver descriptor should carry checkpoint version");
-    AgentLoopDriverRunRequest {
-        turn_id: context.turn_id,
-        run_id: context.run_id,
-        resolved_run_profile: profile,
-    }
-}
-
 fn capable_resume_call() -> ironclaw_turns::run_profile::CapabilityCallCandidate {
     use ironclaw_turns::run_profile::{CapabilityCallCandidate, CapabilitySurfaceVersion};
     CapabilityCallCandidate {
@@ -909,6 +943,20 @@ impl LoopCapabilityPort for CapableResumeHost {
         &self,
         request: CapabilityBatchInvocation,
     ) -> Result<CapabilityBatchOutcome, AgentLoopHostError> {
+        self.batch_call_count.fetch_add(1, Ordering::SeqCst);
+
+        // Record whether any invocation in this batch carries approval_resume.
+        // This is set on the resume-phase batch, confirming the checkpoint's
+        // pending_approval_resume was threaded through to the re-dispatch.
+        if request
+            .invocations
+            .iter()
+            .any(|inv| inv.approval_resume.is_some())
+        {
+            self.resume_batch_had_approval_resume
+                .store(true, Ordering::SeqCst);
+        }
+
         let outcomes = self
             .batch_outcomes
             .lock()


### PR DESCRIPTION
Follow-up test coverage for the fix merged in #4899 (resume-origin capability failures surfaced instead of dying as `scope_mismatch`). #4899 shipped with executor unit tests; this adds end-to-end coverage across the real runtime layers and a multi-gate sequence.

## Tests added

**1. Live host runtime** — `host_runtime/tests/reborn_e2e_gate.rs::reborn_e2e_gate_resume_backend_error_surfaces_as_failed_backend`
A real `FirstPartyCapabilityHandler` returning `Backend` on the resume dispatch (after an approval gate) surfaces as `RuntimeCapabilityOutcome::Failed(Backend)` — not `Authorization`/`ScopeMismatch`. Proves the host half: a genuine first-party backend error on resume reaches the caller cleanly (the input the executor fix relies on).

**2. Real reborn driver** — `reborn/tests/planned_driver_e2e.rs::planned_driver_resume_approval_backend_failure_surfaces_as_tool_error_not_retry`
Drives the real `PlannedLoopDriver` through a `run() -> resume()` cycle. A resume-origin `Backend` failure is surfaced as a model-visible tool error and the run completes — no `approval_resume=None` retry is dispatched. Reverting the `is_resume_origin` guard reproduces the pre-fix terminal `Unavailable { "Capability: unavailable" }`, confirming the test exercises the fix.

**3. Multi-gate sequence** — `agent_loop/executor/tests.rs::approve_sequence_backend_then_deny_then_approve_survives_and_completes`
Five gated cycles in one run: `approve(ok) -> approve(ok) -> approve(Backend) -> deny -> approve(ok)`, reaching `LoopExit::Completed`. Proves a mid-sequence backend blip no longer wedges later approvals, and a deny does not break the next approval — the realistic shape of the original "first approval works, later ones fail" symptom.

## Verification
- `cargo test` — agent_loop (307), host_runtime/reborn_e2e_gate (8), reborn/planned_driver_e2e (10, `--features root-llm-provider`): all green.
- `cargo clippy --all-targets` on all three crates: 0 warnings.
- `cargo fmt --check`: clean.
- Test-only change; no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)