### PR TITLE
fix(auth-resume): keep prior approval metadata atomic

### DIFF
--- a/crates/ironclaw_agent_loop/src/executor/capabilities.rs
+++ b/crates/ironclaw_agent_loop/src/executor/capabilities.rs
@@ -941,8 +941,8 @@ fn auth_resume_for_gate(
     match auth_resume.as_mut() {
         Some(resume) => {
             resume.resume_token = prior_approval.resume_token.clone();
-            resume.prior_approval.get_or_insert_with(prior_identity);
-            resume.replay.get_or_insert_with(prior_replay);
+            resume.prior_approval = Some(prior_identity());
+            resume.replay = Some(prior_replay());
             auth_resume
         }
         None => Some(CapabilityAuthResume {

--- a/crates/ironclaw_agent_loop/src/executor/tests.rs
+++ b/crates/ironclaw_agent_loop/src/executor/tests.rs
@@ -3,7 +3,8 @@ use ironclaw_turns::{
     LoopCancelledReasonKind, LoopCompletionKind, LoopDiagnosticRef, LoopExit, LoopFailureKind,
     LoopGateRef, LoopResultRef, TurnRunId,
     run_profile::{
-        AgentLoopHostError, AgentLoopHostErrorKind, CapabilityApprovalResume, CapabilityAuthResume,
+        AgentLoopHostError, AgentLoopHostErrorKind, AuthResumeApprovalIdentity,
+        CapabilityApprovalResume, CapabilityAuthResume, CapabilityAuthResumeReplay,
         CapabilityCallCandidate, CapabilityFailureDetail, CapabilityFailureKind,
         CapabilityInputIssue, CapabilityInputIssueCode, CapabilityInputRef, CapabilityInputRepair,
         CapabilityOutcome, CapabilityRecoveryHint, CapabilityResultMessage, CapabilityResumeToken,
@@ -4749,6 +4750,8 @@ async fn auth_resume_after_approval_carries_original_correlation_id() {
     let auth_gate_resume_token =
         CapabilityResumeToken::new("resume-token:corr-id-auth-gate").expect("valid token");
     let correlation_id = CorrelationId::new();
+    let auth_gate_approval_request_id = ApprovalRequestId::new();
+    let auth_gate_correlation_id = CorrelationId::new();
     let original_input_ref = CapabilityInputRef::new("input:corr-id-original").expect("valid");
     let completed_ref = LoopResultRef::new("result:corr-id-done").expect("valid");
 
@@ -4779,8 +4782,14 @@ async fn auth_resume_after_approval_carries_original_correlation_id() {
                 safe_summary: "auth required".to_string(),
                 auth_resume: Some(CapabilityAuthResume {
                     resume_token: auth_gate_resume_token,
-                    prior_approval: None,
-                    replay: None,
+                    prior_approval: Some(AuthResumeApprovalIdentity {
+                        approval_request_id: auth_gate_approval_request_id,
+                        correlation_id: auth_gate_correlation_id,
+                    }),
+                    replay: Some(CapabilityAuthResumeReplay {
+                        input: serde_json::json!({ "message": "wrong-source" }),
+                        estimate: ResourceEstimate::default(),
+                    }),
                 }),
             }],
             stopped_on_suspension: true,
@@ -4843,6 +4852,10 @@ async fn auth_resume_after_approval_carries_original_correlation_id() {
         .as_ref()
         .expect("pending_auth_resume.prior_approval must be set when approval preceded auth");
     assert_eq!(
+        pending_pa.approval_request_id, approval_request_id,
+        "pending_auth_resume.prior_approval.approval_request_id must equal the approval's id"
+    );
+    assert_eq!(
         pending_pa.correlation_id, correlation_id,
         "pending_auth_resume.prior_approval.correlation_id must equal the approval's correlation_id"
     );
@@ -4877,6 +4890,10 @@ async fn auth_resume_after_approval_carries_original_correlation_id() {
         .prior_approval
         .as_ref()
         .expect("phase 3 auth_resume.prior_approval must be set");
+    assert_eq!(
+        phase3_pa.approval_request_id, approval_request_id,
+        "phase 3 auth_resume.prior_approval.approval_request_id must match the original approval id"
+    );
     assert_eq!(
         phase3_pa.correlation_id, correlation_id,
         "phase 3 auth_resume.prior_approval.correlation_id must match the original approval correlation_id"


### PR DESCRIPTION
## Summary

- Make checkpointed prior approval metadata the sole source of truth when approval flows into auth resume.
- Prevent mixed auth-resume state where the token comes from one approval but identity/replay comes from another auth gate payload.
- Strengthen the approval-to-auth regression test with deliberately conflicting auth-gate metadata.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Follow-up to #4910 / discussion https://github.com/nearai/ironclaw/pull/4910#discussion_r3412175579

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [x] `cargo build`: `cargo check --workspace --quiet`
- [x] Relevant tests pass:
  - `cargo test -p ironclaw_agent_loop auth_resume_after_approval_carries_original_correlation_id --quiet`
  - `cargo test -p ironclaw_agent_loop --quiet`
- [ ] `cargo test --features integration` if database-backed or integration behavior changed
- [ ] Manual testing
- [x] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review: addressed CodeRabbit follow-up from #4910.

## Security Impact

Touches auth/approval resume state consistency. This tightens the behavior: when a checkpointed prior approval exists, its resume token, approval identity, and replay input are assigned together so auth resume cannot persist a mixed identity.

## Reborn Trust-Boundary Checklist

- [x] Public policy/evidence/trust-bearing types: who can construct them? No new types; existing `CapabilityAuthResume` is normalized by the agent-loop executor before checkpointing.
- [x] Untrusted content enters prompts only through an envelope/escaping primitive. No prompt path changed.
- [x] Hashes declare purpose; trust/binding/authenticity uses SHA-256/BLAKE3 or separate authenticity check. No hashing path changed.
- [x] New/changed status, exit, policy, runtime, or error variants: downstream match sites audited. Command/output: `cargo check --workspace --quiet`.
- [x] Security/durability `serde(default)` fields fail closed or have migration tests. No new serde fields; regression test covers mixed-state overwrite before checkpointing.
- [x] Queues/maps/buffers/counters have bounds and overflow-safe arithmetic. No queue/map/buffer/counter behavior changed.
- [x] Driver/operator-visible errors have stable class semantics (`Transient`, `Permanent`, `Misconfigured`, `PolicyDenied` or equivalent). No error class changes.
- [x] Sandbox/native/host names accurately describe trust boundary. No sandbox/native/host naming changes.

## Database Impact

None. No migrations or database schema changes.

## Blast Radius

Narrowly affects approval-to-auth capability resume normalization in `ironclaw_agent_loop`. Regressions would be limited to gated capability resume flows that pass through approval and then auth.

## Rollback Plan

Revert this PR. That would restore the merged #4910 behavior where an existing auth-resume prior approval/replay could be preserved while the token is overwritten from checkpointed prior approval.

## Review Follow-Through

Addresses CodeRabbit discussion https://github.com/nearai/ironclaw/pull/4910#discussion_r3412175579 after #4910 was merged.

---

**Review track**: C (runtime/auth resume path)
