### PR TITLE
refactor(webui): replace Logs/Docs icons with text labels

### DIFF
--- a/crates/ironclaw_webui_v2_static/static/js/components/page-header.js
+++ b/crates/ironclaw_webui_v2_static/static/js/components/page-header.js
@@ -93,21 +93,21 @@ export function PageHeader({ threadsState, onToggleSidebar }) {
           to="/logs"
           className=${({ isActive }) =>
             cn(
-              "grid h-8 w-8 place-items-center rounded-[8px] text-[var(--v2-text-muted)] hover:bg-[var(--v2-surface-muted)] hover:text-[var(--v2-text-strong)]",
+              "inline-flex h-8 items-center rounded-[8px] px-2.5 text-xs font-semibold text-[var(--v2-text-muted)] hover:bg-[var(--v2-surface-muted)] hover:text-[var(--v2-text-strong)]",
               isActive && "bg-[var(--v2-accent-soft)] text-[var(--v2-accent-text)]"
             )}
           title=${t("nav.logs")}
         >
-          <${Icon} name="list" className="h-4 w-4" />
+          ${t("nav.logs")}
         <//>
         <a
           href=${DOCS_URL}
           target="_blank"
           rel="noopener noreferrer"
-          className="grid h-8 w-8 place-items-center rounded-[8px] text-[var(--v2-text-muted)] hover:bg-[var(--v2-surface-muted)] hover:text-[var(--v2-text-strong)]"
+          className="inline-flex h-8 items-center rounded-[8px] px-2.5 text-xs font-semibold text-[var(--v2-text-muted)] hover:bg-[var(--v2-surface-muted)] hover:text-[var(--v2-text-strong)]"
           title=${t("nav.docs")}
         >
-          <${Icon} name="file" className="h-4 w-4" />
+          ${t("nav.docs")}
         </a>
       </div>
     </header>

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/chat.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/chat.js
@@ -1,5 +1,4 @@
 import { React, html } from "../../lib/html.js";
-import { useT } from "../../lib/i18n.js";
 import {
   THREAD_STATE,
   clearThreadState,
@@ -21,7 +20,6 @@ import { TypingIndicator } from "./components/typing-indicator.js";
 import { useChat } from "./hooks/useChat.js";
 import { NEW_DRAFT_KEY } from "./lib/draft-store.js";
 import { buildRuntimeContext } from "./lib/runtime-context.js";
-import { buildScopedLogsPath } from "../logs/lib/logs-data.js";
 
 export function Chat({
   threads,
@@ -32,7 +30,6 @@ export function Chat({
   composerResetKey = "",
   gatewayStatus,
 }) {
-  const t = useT();
   const {
     messages,
     isProcessing,
@@ -84,16 +81,6 @@ export function Chat({
       isProcessing &&
       !pendingGate
   );
-  const scopedLogsHref = React.useMemo(() => {
-    if (!activeThreadId) return null;
-    const runId =
-      activeRun?.threadId === activeThreadId ? activeRun.runId : null;
-    return buildScopedLogsPath(
-      { threadId: activeThreadId, runId },
-      { absolute: true }
-    );
-  }, [activeRun, activeThreadId]);
-
   const handleSend = React.useCallback(
     async (content, { images = [], attachments = [] } = {}) => {
       const response = await send(content, {
@@ -178,18 +165,6 @@ export function Chat({
     <div className="flex h-full min-h-0 overflow-hidden">
       <div className="flex min-w-0 flex-1 flex-col">
         <${ConnectionStatus} status=${sseStatus} />
-
-        ${scopedLogsHref &&
-        html`
-          <div className="flex justify-end border-b border-[var(--v2-panel-border)] bg-[var(--v2-canvas-strong)] px-4 py-1.5">
-            <a
-              href=${scopedLogsHref}
-              className="rounded-[6px] px-2 py-1 text-xs font-medium text-[var(--v2-text-muted)] hover:bg-[var(--v2-surface-muted)] hover:text-[var(--v2-text-strong)]"
-            >
-              ${t("nav.logs")}
-            </a>
-          </div>
-        `}
 
         ${historyLoadError &&
         html`


### PR DESCRIPTION
## Summary

- Replace the top-right Logs and Docs icon buttons with text labels.
- Remove the extra scoped Logs strip from the chat page header area.

## Why

The previous icon-only navigation was ambiguous, and the chat page also rendered a separate Logs row under the header. This keeps the navigation explicit and removes the duplicate Logs affordance.

Fixes #4923

## Validation

- `git diff --check`
- `node --input-type=module --check < crates/ironclaw_webui_v2_static/static/js/components/page-header.js`
- `node --input-type=module --check < crates/ironclaw_webui_v2_static/static/js/pages/chat/chat.js`
- `cargo test -p ironclaw_webui_v2_static`