### PR TITLE
fix(reborn): allow credential-free hosted MCP providers to dispatch

### DIFF
--- a/crates/ironclaw_reborn_composition/src/extension_lifecycle.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_lifecycle.rs
@@ -8,9 +8,9 @@ use ironclaw_extensions::{
 };
 use ironclaw_filesystem::RootFilesystem;
 use ironclaw_host_api::{
-    CapabilityDescriptor, CapabilityId, EffectKind, ExtensionId, PermissionMode, ResourceScope,
-    RuntimeCredentialAuthRequirement, RuntimeCredentialRequirement, RuntimeHttpEgress, VirtualPath,
-    sha256_digest_token,
+    CapabilityDescriptor, CapabilityId, EffectKind, ExtensionId, NetworkTargetPattern,
+    PermissionMode, ResourceScope, RuntimeCredentialAuthRequirement, RuntimeCredentialRequirement,
+    RuntimeHttpEgress, RuntimeKind, VirtualPath, sha256_digest_token,
 };
 use ironclaw_product_workflow::{
     LifecycleExtensionSummary, LifecycleInstalledExtensionSummary, LifecyclePackageKind,
@@ -33,6 +33,7 @@ use crate::extension_activation_credentials::{
 };
 use crate::extension_credential_requirements::package_runtime_credential_auth_requirements;
 use crate::lifecycle::response_with_payload;
+use crate::mcp::hosted_mcp_endpoint_target;
 use crate::mcp_discovery::{
     HostedMcpDiscoveryError, discover_hosted_mcp_package, is_hosted_http_mcp_package,
 };
@@ -64,6 +65,10 @@ pub(crate) struct ActiveExtensionCapability {
     pub(crate) effects: Vec<EffectKind>,
     pub(crate) default_permission: PermissionMode,
     pub(crate) runtime_credentials: Vec<RuntimeCredentialRequirement>,
+    /// Network targets the provider declares in its manifest (e.g. a hosted MCP
+    /// server's endpoint), independent of any credentials. Lets the dispatch
+    /// network policy allow a credential-free hosted MCP server.
+    pub(crate) declared_network_targets: Vec<NetworkTargetPattern>,
 }
 
 #[derive(Clone)]
@@ -76,13 +81,17 @@ pub(crate) enum ExtensionActivationMode {
 }
 
 impl ActiveExtensionCapability {
-    fn from_descriptor(descriptor: &CapabilityDescriptor) -> Self {
+    fn from_descriptor(
+        descriptor: &CapabilityDescriptor,
+        declared_network_targets: Vec<NetworkTargetPattern>,
+    ) -> Self {
         Self {
             id: descriptor.id.clone(),
             provider: descriptor.provider.clone(),
             effects: descriptor.effects.clone(),
             default_permission: descriptor.default_permission,
             runtime_credentials: descriptor.runtime_credentials.clone(),
+            declared_network_targets,
         }
     }
 }
@@ -272,7 +281,21 @@ impl RebornLocalExtensionManagementPort {
                     .unwrap_or(CapabilityVisibility::Model)
                     == CapabilityVisibility::Model
             })
-            .map(ActiveExtensionCapability::from_descriptor)
+            .map(|descriptor| {
+                // A hosted MCP provider's egress target lives on its manifest,
+                // not on a credential. Source it here so a credential-free MCP
+                // server still gets a dispatch network-policy allow-list entry.
+                let declared_network_targets = if descriptor.runtime == RuntimeKind::Mcp {
+                    registry
+                        .get_extension(&descriptor.provider)
+                        .and_then(hosted_mcp_endpoint_target)
+                        .into_iter()
+                        .collect()
+                } else {
+                    Vec::new()
+                };
+                ActiveExtensionCapability::from_descriptor(descriptor, declared_network_targets)
+            })
             .collect())
     }
 

--- a/crates/ironclaw_reborn_composition/src/extension_lifecycle.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_lifecycle.rs
@@ -1513,6 +1513,56 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn active_model_visible_capabilities_source_declared_network_targets_for_credential_free_hosted_mcp()
+     {
+        // Activate a real credential-free hosted-HTTP MCP package and read its
+        // model-visible capability back through `active_model_visible_capabilities`.
+        // The capability's `declared_network_targets` must be sourced from the
+        // manifest endpoint by the production `descriptor.runtime == Mcp` branch
+        // (the package carries no `runtime_credentials`), proving the mapping
+        // happens through the real call path rather than a hand-built capability.
+        let (_dir, _storage_root, port, _active_registry, _installation_store) =
+            extension_management_port_fixture_with_catalog_and_service(
+                AvailableExtensionCatalog::from_packages(
+                    vec![credential_free_hosted_mcp_package()],
+                ),
+                ExtensionLifecycleService::new(ExtensionRegistry::new()),
+            );
+        let package_ref = LifecyclePackageRef::new(LifecyclePackageKind::Extension, "example-mcp")
+            .expect("valid ref");
+        port.install(package_ref.clone())
+            .await
+            .expect("install credential-free hosted MCP");
+        port.activate_with_prechecked_credentials_for_test(
+            package_ref,
+            ExtensionActivationMode::Static,
+        )
+        .await
+        .expect("activate credential-free hosted MCP");
+
+        let capabilities = port
+            .active_model_visible_capabilities()
+            .await
+            .expect("active capabilities");
+        let ping = capabilities
+            .iter()
+            .find(|capability| capability.id == CapabilityId::new("example-mcp.ping").unwrap())
+            .expect("credential-free hosted MCP capability is model-visible");
+
+        // Credential-free provider: the egress allow-list cannot come from a
+        // credential audience, only from the manifest endpoint.
+        assert!(ping.runtime_credentials.is_empty());
+        assert_eq!(
+            ping.declared_network_targets,
+            vec![ironclaw_host_api::NetworkTargetPattern {
+                scheme: Some(ironclaw_host_api::NetworkScheme::Https),
+                host_pattern: "mcp.example.com".to_string(),
+                port: None,
+            }]
+        );
+    }
+
     #[test]
     fn activation_credential_requirements_coalesce_google_oauth_scope_sets() {
         let catalog =
@@ -4250,6 +4300,55 @@ visibility = "model"
 input_schema_ref = "schemas/search.input.json"
 output_schema_ref = "schemas/search.output.json"
 "#
+    }
+
+    /// A credential-free hosted-HTTP MCP package: `HostBundled` source,
+    /// `ExtensionRuntime::Mcp` http url, and no `runtime_credentials`. Mirrors
+    /// the bug scenario where the egress allow-list must come from the manifest
+    /// endpoint rather than a credential audience.
+    fn credential_free_hosted_mcp_package() -> AvailableExtensionPackage {
+        let manifest_toml = r#"
+schema_version = "reborn.extension_manifest.v2"
+id = "example-mcp"
+name = "Example MCP"
+version = "0.1.0"
+description = "Credential-free hosted MCP fixture"
+trust = "third_party"
+
+[runtime]
+kind = "mcp"
+transport = "http"
+url = "https://mcp.example.com/mcp"
+
+[[capabilities]]
+id = "example-mcp.ping"
+description = "Ping the example MCP server"
+effects = ["dispatch_capability", "network"]
+default_permission = "allow"
+visibility = "model"
+input_schema_ref = "schemas/example-mcp/ping.input.v1.json"
+output_schema_ref = "schemas/example-mcp/ping.output.v1.json"
+"#;
+        let manifest = ExtensionManifest::parse(
+            manifest_toml,
+            ManifestSource::HostBundled,
+            &HostPortCatalog::empty(),
+        )
+        .expect("hosted MCP manifest");
+        let root = VirtualPath::new("/system/extensions/example-mcp").expect("extension root");
+        let package = ExtensionPackage::from_manifest_toml(manifest, root, manifest_toml)
+            .expect("hosted MCP package");
+        AvailableExtensionPackage {
+            package_ref: LifecyclePackageRef::new(LifecyclePackageKind::Extension, "example-mcp")
+                .expect("hosted MCP package ref"),
+            manifest_toml: manifest_toml.to_string(),
+            package,
+            surface_kinds: Vec::new(),
+            assets: vec![AvailableExtensionAsset {
+                path: "manifest.toml".to_string(),
+                content: AvailableExtensionAssetContent::Bytes(manifest_toml.as_bytes().to_vec()),
+            }],
+        }
     }
 
     fn fixture_extension_package_from_manifest(manifest_toml: &str) -> AvailableExtensionPackage {

--- a/crates/ironclaw_reborn_composition/src/mcp.rs
+++ b/crates/ironclaw_reborn_composition/src/mcp.rs
@@ -157,6 +157,24 @@ pub(crate) fn hosted_http_mcp_endpoint(package: &ExtensionPackage) -> Option<Hos
     HostedMcpEndpoint::parse(url)
 }
 
+/// The network target a hosted-HTTP MCP package is allowed to reach: its
+/// manifest endpoint (always HTTPS, since [`HostedMcpEndpoint::parse`] rejects
+/// other schemes). Returns `None` for non-MCP / non-host-bundled packages.
+///
+/// The capability dispatch network policy uses this so a credential-free hosted
+/// MCP provider gets an allow-list entry from its manifest, rather than an empty
+/// one derived only from credentials.
+pub(crate) fn hosted_mcp_endpoint_target(
+    package: &ExtensionPackage,
+) -> Option<NetworkTargetPattern> {
+    let endpoint = hosted_http_mcp_endpoint(package)?;
+    Some(NetworkTargetPattern {
+        scheme: Some(NetworkScheme::Https),
+        host_pattern: endpoint.host_pattern,
+        port: endpoint.port,
+    })
+}
+
 /// Returns `true` only when `url` has scheme `https`, a host that
 /// case-insensitively matches `endpoint.host_pattern`, and a path that
 /// (ignoring trailing slashes) matches `endpoint.path`.
@@ -274,6 +292,31 @@ mod tests {
         assert_eq!(
             plan.network_policy.allowed_targets[0].host_pattern,
             "fixture.example.com"
+        );
+    }
+
+    #[test]
+    fn hosted_mcp_endpoint_target_uses_manifest_url() {
+        let registry = SharedExtensionRegistry::new(registry_with_provider(
+            "example-mcp",
+            "https://mcp.example.com:8443/mcp",
+            "example-mcp.ping",
+            "example_token",
+        ));
+        let snapshot = registry.snapshot();
+        let package = snapshot
+            .get_extension(&ExtensionId::new("example-mcp").unwrap())
+            .expect("package present");
+
+        let target = hosted_mcp_endpoint_target(package).expect("hosted MCP endpoint target");
+
+        assert_eq!(
+            target,
+            NetworkTargetPattern {
+                scheme: Some(NetworkScheme::Https),
+                host_pattern: "mcp.example.com".to_string(),
+                port: Some(8443),
+            }
         );
     }
 

--- a/crates/ironclaw_reborn_composition/src/mcp.rs
+++ b/crates/ironclaw_reborn_composition/src/mcp.rs
@@ -321,6 +321,47 @@ mod tests {
     }
 
     #[test]
+    fn hosted_mcp_endpoint_target_rejects_non_hosted_mcp_packages() {
+        // 1. Manifest is not host-bundled. A hosted MCP endpoint is only
+        //    honored for `ManifestSource::HostBundled`, so an installed-local
+        //    manifest with an otherwise-valid hosted MCP runtime yields no
+        //    target.
+        let non_host_bundled = package_with_runtime(
+            ManifestSource::InstalledLocal,
+            ExtensionRuntime::Mcp {
+                transport: "http".to_string(),
+                command: None,
+                args: Vec::new(),
+                url: Some("https://mcp.example.com/mcp".to_string()),
+            },
+        );
+        assert!(hosted_mcp_endpoint_target(&non_host_bundled).is_none());
+
+        // 2. Runtime is not a hosted-HTTP MCP server (here a WASM runtime), so
+        //    `hosted_http_mcp_endpoint` returns `None` regardless of source.
+        let non_mcp_runtime = package_with_runtime(
+            ManifestSource::HostBundled,
+            ExtensionRuntime::Wasm {
+                module: ironclaw_extensions::ExtensionAssetPath::new("wasm/example.wasm").unwrap(),
+            },
+        );
+        assert!(hosted_mcp_endpoint_target(&non_mcp_runtime).is_none());
+
+        // 3. MCP runtime whose URL is not HTTPS. `HostedMcpEndpoint::parse`
+        //    rejects non-https schemes, so the endpoint target is `None`.
+        let non_https_url = package_with_runtime(
+            ManifestSource::HostBundled,
+            ExtensionRuntime::Mcp {
+                transport: "http".to_string(),
+                command: None,
+                args: Vec::new(),
+                url: Some("http://mcp.example.com/mcp".to_string()),
+            },
+        );
+        assert!(hosted_mcp_endpoint_target(&non_https_url).is_none());
+    }
+
+    #[test]
     fn planner_denies_wrong_host_for_notion_provider() {
         let registry = Arc::new(SharedExtensionRegistry::new(registry_with_notion()));
         let planner = RegistryMcpEgressPlanner::new(registry);
@@ -499,6 +540,30 @@ mod tests {
             headers: &[],
             body: &[],
         }
+    }
+
+    /// Build a minimal package with the given manifest source and runtime. Only
+    /// `manifest.source` and `manifest.runtime` matter to
+    /// `hosted_mcp_endpoint_target`, so capabilities are left empty.
+    fn package_with_runtime(source: ManifestSource, runtime: ExtensionRuntime) -> ExtensionPackage {
+        ExtensionPackage::from_manifest(
+            ExtensionManifest {
+                schema_version: ironclaw_extensions::MANIFEST_SCHEMA_VERSION.to_string(),
+                id: ExtensionId::new("example-mcp").unwrap(),
+                name: "example-mcp".to_string(),
+                version: "0.1.0".to_string(),
+                description: "Hosted MCP".to_string(),
+                source,
+                requested_trust: ironclaw_host_api::RequestedTrustClass::ThirdParty,
+                descriptor_trust_default: TrustClass::Sandbox,
+                runtime,
+                host_apis: Vec::new(),
+                hooks: Vec::new(),
+                capabilities: Vec::new(),
+            },
+            VirtualPath::new("/system/extensions/example-mcp").unwrap(),
+        )
+        .unwrap()
     }
 
     fn registry_with_notion() -> ironclaw_extensions::ExtensionRegistry {

--- a/crates/ironclaw_reborn_composition/src/runtime/approval.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/approval.rs
@@ -248,6 +248,7 @@ mod tests {
                 effects: vec![EffectKind::Network, EffectKind::UseSecret],
                 default_permission: PermissionMode::Allow,
                 runtime_credentials: Vec::new(),
+                declared_network_targets: Vec::new(),
             }]),
         );
         let terms_provider = LocalDevApprovalLeaseTermsProvider::new(
@@ -318,6 +319,7 @@ mod tests {
                     },
                     required: true,
                 }],
+                declared_network_targets: Vec::new(),
             }]),
         );
         let terms_provider = LocalDevApprovalLeaseTermsProvider::new(
@@ -369,6 +371,7 @@ mod tests {
                 effects: vec![EffectKind::Network],
                 default_permission: PermissionMode::Allow,
                 runtime_credentials: Vec::new(),
+                declared_network_targets: Vec::new(),
             }]),
         );
         let terms_provider = LocalDevApprovalLeaseTermsProvider::new(
@@ -407,6 +410,7 @@ mod tests {
                 effects: vec![EffectKind::Network],
                 default_permission: PermissionMode::Ask,
                 runtime_credentials: Vec::new(),
+                declared_network_targets: Vec::new(),
             }]),
         );
         let terms_provider = LocalDevApprovalLeaseTermsProvider::new(
@@ -474,6 +478,7 @@ mod tests {
                 effects: vec![EffectKind::Network],
                 default_permission: PermissionMode::Deny,
                 runtime_credentials: Vec::new(),
+                declared_network_targets: Vec::new(),
             }]),
         );
         let terms_provider = LocalDevApprovalLeaseTermsProvider::new(

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/extension_surface.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/extension_surface.rs
@@ -165,6 +165,14 @@ fn extension_network_policy(capability: &ActiveExtensionCapability) -> NetworkPo
             targets.push(credential.audience.clone());
         }
     }
+    // Manifest-declared targets (e.g. a hosted MCP server's endpoint). Without
+    // these a credential-free hosted MCP provider gets an empty allow-list and
+    // is rejected by the obligation handler before it can connect.
+    for target in &capability.declared_network_targets {
+        if !targets.contains(target) {
+            targets.push(target.clone());
+        }
+    }
     let is_web_access_exa_mcp = capability.provider.as_str() == WEB_ACCESS_EXTENSION_ID
         && matches!(
             capability.id.as_str(),
@@ -202,6 +210,7 @@ mod tests {
             effects: vec![EffectKind::DispatchCapability, EffectKind::Network],
             default_permission: PermissionMode::Allow,
             runtime_credentials: Vec::new(),
+            declared_network_targets: Vec::new(),
         };
 
         let policy = extension_network_policy(&capability);
@@ -226,6 +235,7 @@ mod tests {
             effects: vec![EffectKind::DispatchCapability, EffectKind::Network],
             default_permission: PermissionMode::Allow,
             runtime_credentials: Vec::new(),
+            declared_network_targets: Vec::new(),
         };
 
         let policy = extension_network_policy(&capability);
@@ -264,12 +274,42 @@ mod tests {
                 },
                 required: true,
             }],
+            declared_network_targets: Vec::new(),
         };
 
         let policy = extension_network_policy(&capability);
 
         assert_eq!(policy.allowed_targets.len(), 1);
         assert_eq!(policy.max_egress_bytes, Some(NETWORK_EGRESS_LIMIT));
+    }
+
+    /// A credential-free hosted MCP provider (public/unauthenticated server, so
+    /// no `runtime_credentials`) is allowed to reach the endpoint declared on
+    /// its manifest. Before the manifest endpoint was sourced into the dispatch
+    /// policy, this capability got an empty `allowed_targets` and the obligation
+    /// handler rejected it as `Network` before it could connect.
+    #[test]
+    fn credential_free_capability_allows_declared_manifest_network_target() {
+        let endpoint = NetworkTargetPattern {
+            scheme: Some(NetworkScheme::Https),
+            host_pattern: "mcp.example.com".to_string(),
+            port: None,
+        };
+        let capability = ActiveExtensionCapability {
+            id: CapabilityId::new("example-mcp.ping").unwrap(),
+            provider: ExtensionId::new("example-mcp").unwrap(),
+            effects: vec![EffectKind::DispatchCapability, EffectKind::Network],
+            default_permission: PermissionMode::Allow,
+            runtime_credentials: Vec::new(),
+            declared_network_targets: vec![endpoint.clone()],
+        };
+
+        let policy = extension_network_policy(&capability);
+
+        assert_eq!(policy.allowed_targets, vec![endpoint]);
+        // Still public-IP only: the manifest endpoint is allowed, private
+        // ranges remain denied.
+        assert!(policy.deny_private_ip_ranges);
     }
 
     #[test]
@@ -285,6 +325,7 @@ mod tests {
             ],
             default_permission: PermissionMode::Allow,
             runtime_credentials: Vec::new(),
+            declared_network_targets: Vec::new(),
         };
 
         let policy = extension_network_policy(&capability);
@@ -305,6 +346,7 @@ mod tests {
             ],
             default_permission: PermissionMode::Allow,
             runtime_credentials: Vec::new(),
+            declared_network_targets: Vec::new(),
         };
 
         let policy = extension_network_policy(&capability);


### PR DESCRIPTION
## Problem

`extension_network_policy` builds a hosted-MCP capability's allowed network
targets only from its credential audiences (plus a hardcoded web-access/Exa
special case). A hosted MCP provider with no credentials, a public or
unauthenticated server, gets an empty allow-list. The obligation handler
rejects an empty allow-list, so the capability fails with a `Network` error
before the request leaves the process. The endpoint is on the manifest, but the
policy builder never reads it.

This is reachable today. Install a credential-free hosted MCP extension pointed
at a public HTTPS server and any dispatch fails with `obligation handling
failed: Network` before connecting. The existing Exa special case is a
workaround for this same gap.

## Fix

Source the manifest endpoint into the dispatch network policy. The hosted MCP
endpoint is resolved once when the active capability surface is built
(`active_model_visible_capabilities`), carried on `ActiveExtensionCapability`,
and folded into the policy alongside credential-derived targets.

`deny_private_ip_ranges` stays `true`. A credential-free provider can reach only
its declared HTTPS endpoint, nothing more. The web-access/Exa special case is
left in place: web-access is a `first_party` runtime, not an MCP manifest, so
the general path does not cover it. Giving first-party extensions a declarative
egress source is a separate follow-up that could later remove both the Exa and
gsuite hardcodes through this same mechanism.

## Test plan

Unit:

- New: `hosted_mcp_endpoint_target` resolves a hosted MCP package's manifest
  endpoint into a `NetworkTargetPattern`.
- New: `extension_network_policy` includes a capability's declared targets and
  keeps `deny_private_ip_ranges` true.
- `cargo test -p ironclaw_reborn_composition` 606 passed. `cargo clippy
  --all-targets` clean. `cargo fmt`.

Confirmed the test catches the defect. With the fix the regression test passes.
Reverting only the policy fold and running the same test:

```
assertion `left == right` failed
  left: []
 right: [NetworkTargetPattern { scheme: Some(Https), host_pattern: "mcp.example.com", port: None }]
```

Manual validation in a running `serve`. Same setup on two binaries, a
credential-free hosted MCP extension pointed at `https://example.com/mcp`,
dispatched through the agent loop:

```
before (base): "obligation handling failed: Network"   failure_kind: network
after  (fix):  "dispatch failed: Client"               failure_kind: backend
```

Before, the dispatch is rejected at the empty-targets network obligation before
any egress. After, it passes the obligation and the request reaches the MCP
transport (the host is not a real MCP server, hence the client error). A public
host is used so the check is isolated from `deny_private_ip_ranges`.
