### PR TITLE
test(setup): clear DATABASE_URL after wizard reloads .env in libsql test

### DIFF
--- a/src/setup/wizard.rs
+++ b/src/setup/wizard.rs
@@ -4733,11 +4733,17 @@ mod tests {
 
         let _backend_guard = EnvGuard::set("DATABASE_BACKEND", "libsql");
         let _path_guard = EnvGuard::set("LIBSQL_PATH", db_path.to_str().unwrap());
-        // Ensure no postgres env interferes
-        let _pg_guard = EnvGuard::clear("DATABASE_URL");
 
         let mut wizard = SetupWizard::new();
         wizard.config.quick = true;
+
+        // `SetupWizard::new()` reloads the bootstrap `~/.ironclaw/.env` via
+        // dotenvy, which sets any currently-unset variable. Clear `DATABASE_URL`
+        // *after* that reload so a developer's postgres `~/.ironclaw/.env` can't
+        // repopulate it and force `auto_setup_database` down the postgres path,
+        // leaving the libsql `db_backend` unset. (The base dir is `LazyLock`
+        // cached, so redirecting HOME / IRONCLAW_BASE_DIR is not reliable here.)
+        let _pg_guard = EnvGuard::clear("DATABASE_URL");
 
         wizard.auto_setup_database().await.unwrap();
 


### PR DESCRIPTION
## Problem

`test_auto_setup_database_runs_migrations_with_existing_env` fails on any
machine whose `~/.ironclaw/.env` defines `DATABASE_URL` (e.g. a postgres dev
setup). CI and clean checkouts pass, so it only bites contributors with a
populated bootstrap `.env`.

Root cause: the test clears `DATABASE_URL` to force the libsql path, but
`SetupWizard::new()` reloads the bootstrap `~/.ironclaw/.env` via dotenvy, which
sets any currently-unset variable. That repopulates `DATABASE_URL` and sends
`auto_setup_database` down the postgres branch (`finish_postgres_auto_setup`),
leaving the libsql `db_backend` unset, so `assert!(db_backend.is_some())` fails.

## Fix

Clear `DATABASE_URL` *after* `SetupWizard::new()`, so the `.env` reload can't
undo it before `auto_setup_database` runs.

Redirecting `HOME` / `IRONCLAW_BASE_DIR` is not reliable here: the base dir is
`LazyLock`-cached, so an earlier test in the suite fixes it to the real home
before this test runs.

## Test plan

- Before: with a postgres-configured `~/.ironclaw/.env` present, the test fails
  (`auto_setup_database must establish db_backend`).
- After: same `.env` present, the test passes — verified both in isolation and
  with the full `setup::wizard` suite (so the base-dir `LazyLock` is already
  initialized).
- `cargo test --lib setup::wizard::tests` passes (38/38).
