### PR TITLE
[codex] Use WebUI base URL for OAuth callback origins

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -410,11 +410,12 @@ SAFETY_INJECTION_CHECK_ENABLED=true
 # domain(s).
 # IRONCLAW_REBORN_WEBUI_ALLOWED_EMAIL_DOMAINS=example.com,team.example.com
 #
-# Public base URL used to build the OAuth callback URLs for the login
-# providers above. Reborn-scoped only — it does NOT fall back to the v1
-# gateway's OAUTH_BASE_URL, so a legacy v1 setting cannot rewrite Reborn
-# callback URLs. Absent this var, the bound listener address is used. Set
-# it to your public URL in production.
+# Public base URL used to build the OAuth callback URLs for Reborn WebUI
+# login and product-auth flows, including Notion MCP. Reborn-scoped only —
+# it does NOT fall back to the v1 gateway's OAUTH_BASE_URL, so a legacy v1
+# setting cannot rewrite Reborn callback URLs. Absent this var, Reborn uses
+# the bound listener address. Set it to your public URL in production. Google
+# product-auth still uses IRONCLAW_REBORN_GOOGLE_OAUTH_REDIRECT_URI explicitly.
 # IRONCLAW_REBORN_WEBUI_BASE_URL=https://myapp.example.com
 #
 # Optional per-call HTTP timeout (whole seconds) for the OAuth provider

--- a/README.md
+++ b/README.md
@@ -263,17 +263,17 @@ Required WebUI env vars:
 | `IRONCLAW_REBORN_WEBUI_TOKEN` | Bearer token for WebUI requests. If SSO is enabled, this also signs sessions and must be at least 32 bytes. |
 | `IRONCLAW_REBORN_WEBUI_USER_ID` | Reborn owner/user id for env-bearer requests. If `[identity].default_owner` is configured, it must match this value. |
 
-Optional WebUI SSO env vars:
+Optional WebUI OAuth env vars:
 
 | Variable | Purpose |
 | --- | --- |
+| `IRONCLAW_REBORN_WEBUI_BASE_URL` | Public base URL used for WebUI login and product-auth OAuth callbacks. Non-loopback deployments must use `https://`. |
 | `IRONCLAW_REBORN_WEBUI_GOOGLE_CLIENT_ID` | Enables Google SSO when set. |
 | `IRONCLAW_REBORN_WEBUI_GOOGLE_CLIENT_SECRET` | Required when Google SSO is enabled. |
 | `IRONCLAW_REBORN_WEBUI_GOOGLE_ALLOWED_HD` | Optional Google hosted-domain restriction. |
 | `IRONCLAW_REBORN_WEBUI_GITHUB_CLIENT_ID` | Enables GitHub SSO when set. |
 | `IRONCLAW_REBORN_WEBUI_GITHUB_CLIENT_SECRET` | Required when GitHub SSO is enabled. |
 | `IRONCLAW_REBORN_WEBUI_ALLOWED_EMAIL_DOMAINS` | Required when any SSO provider is enabled. Comma-separated verified email domains. |
-| `IRONCLAW_REBORN_WEBUI_BASE_URL` | Public base URL used for OAuth callbacks. Non-loopback deployments must use `https://`. |
 | `IRONCLAW_REBORN_WEBUI_OAUTH_HTTP_TIMEOUT_SECS` | Optional OAuth HTTP timeout override. |
 
 For Google SSO, create a Google OAuth web client and register the Reborn WebUI
@@ -290,11 +290,13 @@ the authorized redirect URI in Google Cloud is:
 https://ironclaw.example.com/auth/callback/google
 ```
 
-Do not include a trailing slash in `IRONCLAW_REBORN_WEBUI_BASE_URL`; Reborn
-trims it before building callback URLs. If the base URL is omitted, Reborn uses
-the actual listener address, such as `http://127.0.0.1:3000`, which is suitable
-only for loopback/local OAuth testing. Public or non-loopback SSO deployments
-must set an `https://` base URL.
+Notion MCP and other product-auth OAuth setup flows use the same public WebUI
+base URL when registering provider callback URLs. Do not include a trailing
+slash in `IRONCLAW_REBORN_WEBUI_BASE_URL`; Reborn trims it before building
+callback URLs. If the base URL is omitted, Reborn uses the actual listener
+address, such as `http://127.0.0.1:3000`, which is suitable only for
+loopback/local OAuth testing. Public or non-loopback OAuth deployments must set
+an `https://` base URL.
 
 Complete Google SSO startup env:
 

--- a/crates/ironclaw_reborn_cli/src/commands/serve.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/serve.rs
@@ -241,9 +241,12 @@ impl ServeCommand {
 
         let listen_addr = SocketAddr::new(host, port);
         reject_non_loopback_privileged_local_runtime(host, &runtime_input)?;
-        if let Some(callback_origin) =
-            webui_oauth_callback_origin(listen_addr, canonical_host.as_deref())
-        {
+        let public_base_url = crate::commands::serve_sso::webui_public_base_url_from_env();
+        if let Some(callback_origin) = webui_oauth_callback_origin(
+            listen_addr,
+            public_base_url.as_deref(),
+            canonical_host.as_deref(),
+        ) {
             let services = runtime_input.services.take().ok_or_else(|| {
                 anyhow!("WebChat v2 serve requires Reborn runtime services before OAuth wiring")
             })?;
@@ -567,8 +570,12 @@ fn with_notion_dcr_oauth_backend(
 
 fn webui_oauth_callback_origin(
     listen_addr: SocketAddr,
+    public_base_url: Option<&str>,
     canonical_host: Option<&str>,
 ) -> Option<String> {
+    if let Some(base_url) = public_base_url {
+        return Some(base_url.trim_end_matches('/').to_string());
+    }
     if let Some(host) = canonical_host {
         return Some(format!(
             "{}://{}",
@@ -983,7 +990,8 @@ mod tests {
     #[test]
     fn webui_oauth_callback_origin_uses_loopback_http() {
         assert_eq!(
-            webui_oauth_callback_origin(SocketAddr::from(([127, 0, 0, 1], 3000)), None).as_deref(),
+            webui_oauth_callback_origin(SocketAddr::from(([127, 0, 0, 1], 3000)), None, None)
+                .as_deref(),
             Some("http://127.0.0.1:3000")
         );
     }
@@ -991,7 +999,8 @@ mod tests {
     #[test]
     fn webui_oauth_callback_origin_maps_unspecified_bind_to_localhost() {
         assert_eq!(
-            webui_oauth_callback_origin(SocketAddr::from(([0, 0, 0, 0], 3000)), None).as_deref(),
+            webui_oauth_callback_origin(SocketAddr::from(([0, 0, 0, 0], 3000)), None, None)
+                .as_deref(),
             Some("http://localhost:3000")
         );
     }
@@ -1001,7 +1010,7 @@ mod tests {
         let listen_addr = SocketAddr::new(IpAddr::from_str("::1").unwrap(), 3000);
 
         assert_eq!(
-            webui_oauth_callback_origin(listen_addr, None).as_deref(),
+            webui_oauth_callback_origin(listen_addr, None, None).as_deref(),
             Some("http://[::1]:3000")
         );
     }
@@ -1009,11 +1018,11 @@ mod tests {
     #[test]
     fn webui_oauth_callback_origin_skips_unstable_or_non_loopback_origin() {
         assert_eq!(
-            webui_oauth_callback_origin(SocketAddr::from(([127, 0, 0, 1], 0)), None),
+            webui_oauth_callback_origin(SocketAddr::from(([127, 0, 0, 1], 0)), None, None),
             None
         );
         assert_eq!(
-            webui_oauth_callback_origin(SocketAddr::from(([192, 168, 1, 42], 3000)), None),
+            webui_oauth_callback_origin(SocketAddr::from(([192, 168, 1, 42], 3000)), None, None),
             None
         );
     }
@@ -1023,6 +1032,7 @@ mod tests {
         assert_eq!(
             webui_oauth_callback_origin(
                 SocketAddr::from(([0, 0, 0, 0], 3000)),
+                None,
                 Some("app.example.com"),
             )
             .as_deref(),
@@ -1035,6 +1045,7 @@ mod tests {
         assert_eq!(
             webui_oauth_callback_origin(
                 SocketAddr::from(([0, 0, 0, 0], 3000)),
+                None,
                 Some("127.0.0.1:3000"),
             )
             .as_deref(),
@@ -1045,9 +1056,22 @@ mod tests {
     #[test]
     fn webui_oauth_callback_origin_brackets_ipv6_canonical_host() {
         assert_eq!(
-            webui_oauth_callback_origin(SocketAddr::from(([0, 0, 0, 0], 3000)), Some("::1"))
+            webui_oauth_callback_origin(SocketAddr::from(([0, 0, 0, 0], 3000)), None, Some("::1"))
                 .as_deref(),
             Some("http://[::1]")
+        );
+    }
+
+    #[test]
+    fn webui_oauth_callback_origin_prefers_public_base_url_for_hosted_oauth() {
+        assert_eq!(
+            webui_oauth_callback_origin(
+                SocketAddr::from(([0, 0, 0, 0], 8080)),
+                Some("https://qa-ironclaw.up.railway.app/"),
+                Some("internal.example.com"),
+            )
+            .as_deref(),
+            Some("https://qa-ironclaw.up.railway.app")
         );
     }
 
@@ -1080,10 +1104,39 @@ mod tests {
             RebornBuildInput::local_dev("notion-dcr-owner", dir.path().join("local-dev")),
             webui_oauth_callback_origin(
                 SocketAddr::from(([0, 0, 0, 0], 3000)),
+                None,
                 Some("app.example.com"),
             )
             .as_deref()
             .expect("canonical callback origin"),
+        )
+        .expect("notion dcr wiring");
+        let services = ironclaw_reborn_composition::build_reborn_services(services_input)
+            .await
+            .expect("reborn services build");
+
+        assert!(
+            services
+                .product_auth
+                .as_ref()
+                .and_then(|product_auth| product_auth.as_auth_challenge_provider())
+                .is_some(),
+            "serve wiring must expose the DCR-backed auth challenge provider"
+        );
+    }
+
+    #[tokio::test]
+    async fn webui_serve_wires_notion_dcr_with_public_base_url_origin() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let services_input = with_notion_dcr_oauth_backend(
+            RebornBuildInput::local_dev("notion-dcr-owner", dir.path().join("local-dev")),
+            webui_oauth_callback_origin(
+                SocketAddr::from(([0, 0, 0, 0], 8080)),
+                Some("https://qa-ironclaw.up.railway.app/"),
+                None,
+            )
+            .as_deref()
+            .expect("public callback origin"),
         )
         .expect("notion dcr wiring");
         let services = ironclaw_reborn_composition::build_reborn_services(services_input)

--- a/crates/ironclaw_reborn_cli/src/commands/serve.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/serve.rs
@@ -241,13 +241,9 @@ impl ServeCommand {
 
         let listen_addr = SocketAddr::new(host, port);
         reject_non_loopback_privileged_local_runtime(host, &runtime_input)?;
-        let public_base_url = crate::commands::serve_sso::webui_public_base_url_from_env()
-            .context("invalid hosted WebUI OAuth base URL")?;
-        if let Some(callback_origin) = webui_oauth_callback_origin(
-            listen_addr,
-            public_base_url.as_deref(),
-            canonical_host.as_deref(),
-        ) {
+        let callback_origin =
+            webui_notion_dcr_callback_origin(listen_addr, canonical_host.as_deref())?;
+        if let Some(callback_origin) = callback_origin {
             let services = runtime_input.services.take().ok_or_else(|| {
                 anyhow!("WebChat v2 serve requires Reborn runtime services before OAuth wiring")
             })?;
@@ -569,6 +565,24 @@ fn with_notion_dcr_oauth_backend(
         .map_err(|error| anyhow!("Notion DCR OAuth backend rejected callback origin: {error}"))
 }
 
+fn webui_notion_dcr_callback_origin(
+    listen_addr: SocketAddr,
+    canonical_host: Option<&str>,
+) -> anyhow::Result<Option<String>> {
+    let public_base_url = crate::commands::serve_sso::webui_public_base_url_from_env()
+        .context("invalid hosted WebUI OAuth base URL from IRONCLAW_REBORN_WEBUI_BASE_URL")?;
+    crate::commands::serve_sso::validate_webui_public_base_url(
+        public_base_url.as_deref(),
+        listen_addr,
+    )
+    .context("invalid hosted WebUI OAuth base URL from IRONCLAW_REBORN_WEBUI_BASE_URL")?;
+    Ok(webui_oauth_callback_origin(
+        listen_addr,
+        public_base_url.as_deref(),
+        canonical_host,
+    ))
+}
+
 fn webui_oauth_callback_origin(
     listen_addr: SocketAddr,
     public_base_url: Option<&str>,
@@ -579,7 +593,9 @@ fn webui_oauth_callback_origin(
         if base_url.is_empty() {
             return None;
         }
-        if is_cleartext_http_scheme(base_url) && !listen_addr.ip().is_loopback() {
+        if crate::commands::serve_sso::is_cleartext_http_scheme(base_url)
+            && !listen_addr.ip().is_loopback()
+        {
             return None;
         }
         return Some(base_url.to_string());
@@ -603,12 +619,6 @@ fn webui_oauth_callback_origin(
         IpAddr::V6(host) if host.is_loopback() => Some(format!("http://[{host}]:{port}")),
         _ => None,
     }
-}
-
-fn is_cleartext_http_scheme(base_url: &str) -> bool {
-    base_url
-        .split_once("://")
-        .is_some_and(|(scheme, _)| scheme.eq_ignore_ascii_case("http"))
 }
 
 fn callback_origin_scheme(host: &str) -> &'static str {
@@ -747,6 +757,14 @@ fn print_serve_banner(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const WEBUI_BASE_URL_ENV: &str = "IRONCLAW_REBORN_WEBUI_BASE_URL";
+
+    fn clear_webui_env() {
+        // SAFETY: tests are serialized by `WEBUI_BASE_URL_ENV_LOCK`; no other
+        // thread reads or writes this env var while the guard is held.
+        unsafe { std::env::remove_var(WEBUI_BASE_URL_ENV) };
+    }
 
     #[test]
     fn webui_default_agent_falls_back_to_runtime_identity() {
@@ -1165,17 +1183,30 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn webui_serve_wires_notion_dcr_with_public_base_url_origin() {
+    async fn webui_serve_wires_notion_dcr_with_public_base_url_env_origin() {
+        let callback_origin = {
+            let _guard = crate::commands::serve_sso::WEBUI_BASE_URL_ENV_LOCK
+                .lock()
+                .expect("env lock");
+            clear_webui_env();
+            // SAFETY: serialized by WEBUI_BASE_URL_ENV_LOCK; cleaned up before the guard drops.
+            unsafe {
+                std::env::set_var(WEBUI_BASE_URL_ENV, " https://configured.example/ ");
+            }
+
+            let callback_origin =
+                webui_notion_dcr_callback_origin(SocketAddr::from(([0, 0, 0, 0], 8080)), None)
+                    .expect("resolve callback origin from env")
+                    .expect("public base url env should enable DCR wiring");
+            assert_eq!(callback_origin, "https://configured.example");
+            clear_webui_env();
+            callback_origin
+        };
+
         let dir = tempfile::tempdir().expect("tempdir");
         let services_input = with_notion_dcr_oauth_backend(
             RebornBuildInput::local_dev("notion-dcr-owner", dir.path().join("local-dev")),
-            webui_oauth_callback_origin(
-                SocketAddr::from(([0, 0, 0, 0], 8080)),
-                Some("https://app.example.com/"),
-                None,
-            )
-            .as_deref()
-            .expect("public callback origin"),
+            &callback_origin,
         )
         .expect("notion dcr wiring");
         let services = ironclaw_reborn_composition::build_reborn_services(services_input)
@@ -1190,5 +1221,52 @@ mod tests {
                 .is_some(),
             "serve wiring must expose the DCR-backed auth challenge provider"
         );
+    }
+
+    #[test]
+    fn webui_notion_dcr_callback_origin_rejects_slash_only_public_base_url_env() {
+        let _guard = crate::commands::serve_sso::WEBUI_BASE_URL_ENV_LOCK
+            .lock()
+            .expect("env lock");
+        clear_webui_env();
+        // SAFETY: serialized by WEBUI_BASE_URL_ENV_LOCK; cleaned up before the guard drops.
+        unsafe {
+            std::env::set_var(WEBUI_BASE_URL_ENV, "/");
+        }
+
+        let error = webui_notion_dcr_callback_origin(SocketAddr::from(([0, 0, 0, 0], 8080)), None)
+            .expect_err("slash-only base URL must fail closed");
+        assert!(
+            error.to_string().contains(WEBUI_BASE_URL_ENV),
+            "error should name the invalid env var, got: {error}"
+        );
+
+        clear_webui_env();
+    }
+
+    #[test]
+    fn webui_notion_dcr_callback_origin_rejects_public_cleartext_base_url_env() {
+        let _guard = crate::commands::serve_sso::WEBUI_BASE_URL_ENV_LOCK
+            .lock()
+            .expect("env lock");
+        clear_webui_env();
+        // SAFETY: serialized by WEBUI_BASE_URL_ENV_LOCK; cleaned up before the guard drops.
+        unsafe {
+            std::env::set_var(WEBUI_BASE_URL_ENV, "http://configured.example");
+        }
+
+        let error = webui_notion_dcr_callback_origin(SocketAddr::from(([0, 0, 0, 0], 8080)), None)
+            .expect_err("public cleartext base URL must fail closed");
+        let message = error.to_string();
+        assert!(
+            message.contains(WEBUI_BASE_URL_ENV),
+            "error should name the invalid env var, got: {message}"
+        );
+        assert!(
+            message.contains("hosted WebUI OAuth base URL"),
+            "error should describe the hosted WebUI OAuth URL, got: {message}"
+        );
+
+        clear_webui_env();
     }
 }

--- a/crates/ironclaw_reborn_cli/src/commands/serve.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/serve.rs
@@ -241,7 +241,8 @@ impl ServeCommand {
 
         let listen_addr = SocketAddr::new(host, port);
         reject_non_loopback_privileged_local_runtime(host, &runtime_input)?;
-        let public_base_url = crate::commands::serve_sso::webui_public_base_url_from_env();
+        let public_base_url = crate::commands::serve_sso::webui_public_base_url_from_env()
+            .context("invalid hosted WebUI OAuth base URL")?;
         if let Some(callback_origin) = webui_oauth_callback_origin(
             listen_addr,
             public_base_url.as_deref(),
@@ -574,7 +575,14 @@ fn webui_oauth_callback_origin(
     canonical_host: Option<&str>,
 ) -> Option<String> {
     if let Some(base_url) = public_base_url {
-        return Some(base_url.trim_end_matches('/').to_string());
+        let base_url = base_url.trim().trim_end_matches('/');
+        if base_url.is_empty() {
+            return None;
+        }
+        if is_cleartext_http_scheme(base_url) && !listen_addr.ip().is_loopback() {
+            return None;
+        }
+        return Some(base_url.to_string());
     }
     if let Some(host) = canonical_host {
         return Some(format!(
@@ -595,6 +603,12 @@ fn webui_oauth_callback_origin(
         IpAddr::V6(host) if host.is_loopback() => Some(format!("http://[{host}]:{port}")),
         _ => None,
     }
+}
+
+fn is_cleartext_http_scheme(base_url: &str) -> bool {
+    base_url
+        .split_once("://")
+        .is_some_and(|(scheme, _)| scheme.eq_ignore_ascii_case("http"))
 }
 
 fn callback_origin_scheme(host: &str) -> &'static str {
@@ -1067,11 +1081,36 @@ mod tests {
         assert_eq!(
             webui_oauth_callback_origin(
                 SocketAddr::from(([0, 0, 0, 0], 8080)),
-                Some("https://qa-ironclaw.up.railway.app/"),
+                Some("https://app.example.com/"),
                 Some("internal.example.com"),
             )
             .as_deref(),
-            Some("https://qa-ironclaw.up.railway.app")
+            Some("https://app.example.com")
+        );
+    }
+
+    #[test]
+    fn webui_oauth_callback_origin_rejects_cleartext_public_origin_on_non_loopback() {
+        assert_eq!(
+            webui_oauth_callback_origin(
+                SocketAddr::from(([192, 168, 1, 42], 8080)),
+                Some("http://app.example.com/"),
+                None,
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn webui_oauth_callback_origin_keeps_loopback_http_public_origin() {
+        assert_eq!(
+            webui_oauth_callback_origin(
+                SocketAddr::from(([127, 0, 0, 1], 8080)),
+                Some("http://127.0.0.1:8080/"),
+                None,
+            )
+            .as_deref(),
+            Some("http://127.0.0.1:8080")
         );
     }
 
@@ -1132,7 +1171,7 @@ mod tests {
             RebornBuildInput::local_dev("notion-dcr-owner", dir.path().join("local-dev")),
             webui_oauth_callback_origin(
                 SocketAddr::from(([0, 0, 0, 0], 8080)),
-                Some("https://qa-ironclaw.up.railway.app/"),
+                Some("https://app.example.com/"),
                 None,
             )
             .as_deref()

--- a/crates/ironclaw_reborn_cli/src/commands/serve_sso.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/serve_sso.rs
@@ -26,6 +26,9 @@ use ironclaw_reborn_webui_ingress::{
 };
 use secrecy::SecretString;
 
+const WEBUI_BASE_URL_ENV: &str = "IRONCLAW_REBORN_WEBUI_BASE_URL";
+const RAILWAY_PUBLIC_DOMAIN_ENV: &str = "RAILWAY_PUBLIC_DOMAIN";
+
 /// Resolved SSO startup config: the providers to mount plus the public
 /// base URL their callback URLs are built from. Constructed by
 /// [`sso_startup_config_from_env`]; consumed by `serve.rs`, which adds
@@ -57,22 +60,7 @@ pub(crate) fn sso_startup_config_from_env(
         return Ok(None);
     }
 
-    // Reborn-scoped base URL only — deliberately NOT falling back to the
-    // v1 gateway's `OAUTH_BASE_URL`, so a legacy v1 setting can never
-    // silently rewrite Reborn WebChat callback URLs. Absent the Reborn
-    // var, use the bound listener address.
-    //
-    // Trim surrounding whitespace and trailing slashes: callback URLs are
-    // built as `{base_url}/auth/callback/{provider}`, so a value like
-    // `https://app.example.com/` would otherwise yield a double-slash
-    // `…com//auth/callback/google` that does not match the registered
-    // OAuth redirect URI.
-    let base_url = env::var("IRONCLAW_REBORN_WEBUI_BASE_URL")
-        .ok()
-        .map(|raw| raw.trim().trim_end_matches('/').to_string())
-        .filter(|trimmed| !trimmed.is_empty())
-        .unwrap_or_else(|| format!("http://{listen_addr}"));
-
+    let base_url = webui_oauth_base_url_from_env(listen_addr);
     reject_cleartext_oauth(&base_url, listen_addr)?;
 
     let allowed_email_domains = parse_allowed_email_domains(
@@ -87,6 +75,36 @@ pub(crate) fn sso_startup_config_from_env(
         base_url,
         allowed_email_domains,
     }))
+}
+
+/// Resolve the externally visible WebUI base URL used for OAuth redirects.
+///
+/// Precedence stays Reborn-scoped: explicit Reborn env first, then Railway's
+/// hosted-domain env, then the bound listener address for local development.
+pub(crate) fn webui_oauth_base_url_from_env(listen_addr: SocketAddr) -> String {
+    webui_public_base_url_from_env().unwrap_or_else(|| format!("http://{listen_addr}"))
+}
+
+/// Resolve a hosted WebUI base URL from deployment env without falling back to
+/// the listener address. Product-auth uses this to avoid turning `0.0.0.0`
+/// hosted deployments into provider-visible `localhost` callbacks.
+pub(crate) fn webui_public_base_url_from_env() -> Option<String> {
+    non_empty_env(WEBUI_BASE_URL_ENV)
+        .map(normalize_base_url)
+        .or_else(|| non_empty_env(RAILWAY_PUBLIC_DOMAIN_ENV).map(railway_public_domain_base_url))
+}
+
+fn normalize_base_url(raw: impl AsRef<str>) -> String {
+    raw.as_ref().trim().trim_end_matches('/').to_string()
+}
+
+fn railway_public_domain_base_url(raw: impl AsRef<str>) -> String {
+    let domain = normalize_base_url(raw);
+    if domain.contains("://") {
+        domain
+    } else {
+        format!("https://{domain}")
+    }
 }
 
 /// Parse the comma-separated verified-email-domain allowlist, trimmed,
@@ -338,7 +356,8 @@ mod tests {
         "IRONCLAW_REBORN_WEBUI_GOOGLE_ALLOWED_HD",
         "IRONCLAW_REBORN_WEBUI_GITHUB_CLIENT_ID",
         "IRONCLAW_REBORN_WEBUI_GITHUB_CLIENT_SECRET",
-        "IRONCLAW_REBORN_WEBUI_BASE_URL",
+        WEBUI_BASE_URL_ENV,
+        RAILWAY_PUBLIC_DOMAIN_ENV,
         "IRONCLAW_REBORN_WEBUI_ALLOWED_EMAIL_DOMAINS",
     ];
 
@@ -436,5 +455,51 @@ mod tests {
         let resolved = sso_startup_config_from_env(addr("127.0.0.1:3000"))
             .expect("no provider configured is not an error");
         assert!(resolved.is_none(), "no CLIENT_ID → no SSO config mounted",);
+    }
+
+    #[test]
+    fn webui_oauth_base_url_prefers_explicit_reborn_env() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        clear_sso_env();
+        // SAFETY: serialized by ENV_LOCK; cleaned up before the guard drops.
+        unsafe {
+            std::env::set_var(WEBUI_BASE_URL_ENV, " https://configured.example/ ");
+            std::env::set_var(RAILWAY_PUBLIC_DOMAIN_ENV, "railway.example");
+        }
+
+        assert_eq!(
+            webui_oauth_base_url_from_env(addr("0.0.0.0:8080")),
+            "https://configured.example"
+        );
+
+        clear_sso_env();
+    }
+
+    #[test]
+    fn webui_oauth_base_url_uses_railway_public_domain() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        clear_sso_env();
+        // SAFETY: serialized by ENV_LOCK; cleaned up before the guard drops.
+        unsafe {
+            std::env::set_var(RAILWAY_PUBLIC_DOMAIN_ENV, "qa-ironclaw.up.railway.app");
+        }
+
+        assert_eq!(
+            webui_oauth_base_url_from_env(addr("0.0.0.0:8080")),
+            "https://qa-ironclaw.up.railway.app"
+        );
+
+        clear_sso_env();
+    }
+
+    #[test]
+    fn webui_oauth_base_url_falls_back_to_listener() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        clear_sso_env();
+
+        assert_eq!(
+            webui_oauth_base_url_from_env(addr("127.0.0.1:3000")),
+            "http://127.0.0.1:3000"
+        );
     }
 }

--- a/crates/ironclaw_reborn_cli/src/commands/serve_sso.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/serve_sso.rs
@@ -27,7 +27,6 @@ use ironclaw_reborn_webui_ingress::{
 use secrecy::SecretString;
 
 const WEBUI_BASE_URL_ENV: &str = "IRONCLAW_REBORN_WEBUI_BASE_URL";
-const RAILWAY_PUBLIC_DOMAIN_ENV: &str = "RAILWAY_PUBLIC_DOMAIN";
 
 /// Resolved SSO startup config: the providers to mount plus the public
 /// base URL their callback URLs are built from. Constructed by
@@ -60,7 +59,7 @@ pub(crate) fn sso_startup_config_from_env(
         return Ok(None);
     }
 
-    let base_url = webui_oauth_base_url_from_env(listen_addr);
+    let base_url = webui_oauth_base_url_from_env(listen_addr)?;
     reject_cleartext_oauth(&base_url, listen_addr)?;
 
     let allowed_email_domains = parse_allowed_email_domains(
@@ -79,31 +78,28 @@ pub(crate) fn sso_startup_config_from_env(
 
 /// Resolve the externally visible WebUI base URL used for OAuth redirects.
 ///
-/// Precedence stays Reborn-scoped: explicit Reborn env first, then Railway's
-/// hosted-domain env, then the bound listener address for local development.
-pub(crate) fn webui_oauth_base_url_from_env(listen_addr: SocketAddr) -> String {
-    webui_public_base_url_from_env().unwrap_or_else(|| format!("http://{listen_addr}"))
+/// Precedence stays Reborn-scoped: explicit Reborn env first, then the bound
+/// listener address for local development.
+pub(crate) fn webui_oauth_base_url_from_env(listen_addr: SocketAddr) -> anyhow::Result<String> {
+    Ok(webui_public_base_url_from_env()?.unwrap_or_else(|| format!("http://{listen_addr}")))
 }
 
 /// Resolve a hosted WebUI base URL from deployment env without falling back to
 /// the listener address. Product-auth uses this to avoid turning `0.0.0.0`
 /// hosted deployments into provider-visible `localhost` callbacks.
-pub(crate) fn webui_public_base_url_from_env() -> Option<String> {
-    non_empty_env(WEBUI_BASE_URL_ENV)
-        .map(normalize_base_url)
-        .or_else(|| non_empty_env(RAILWAY_PUBLIC_DOMAIN_ENV).map(railway_public_domain_base_url))
+pub(crate) fn webui_public_base_url_from_env() -> anyhow::Result<Option<String>> {
+    if let Some(raw) = non_empty_env(WEBUI_BASE_URL_ENV) {
+        return Ok(Some(normalize_base_url(WEBUI_BASE_URL_ENV, raw)?));
+    }
+    Ok(None)
 }
 
-fn normalize_base_url(raw: impl AsRef<str>) -> String {
-    raw.as_ref().trim().trim_end_matches('/').to_string()
-}
-
-fn railway_public_domain_base_url(raw: impl AsRef<str>) -> String {
-    let domain = normalize_base_url(raw);
-    if domain.contains("://") {
-        domain
+fn normalize_base_url(env_var: &'static str, raw: impl AsRef<str>) -> anyhow::Result<String> {
+    let normalized = raw.as_ref().trim().trim_end_matches('/');
+    if normalized.is_empty() {
+        anyhow::bail!("{env_var} must not be empty after trimming whitespace and trailing slashes")
     } else {
-        format!("https://{domain}")
+        Ok(normalized.to_string())
     }
 }
 
@@ -357,7 +353,6 @@ mod tests {
         "IRONCLAW_REBORN_WEBUI_GITHUB_CLIENT_ID",
         "IRONCLAW_REBORN_WEBUI_GITHUB_CLIENT_SECRET",
         WEBUI_BASE_URL_ENV,
-        RAILWAY_PUBLIC_DOMAIN_ENV,
         "IRONCLAW_REBORN_WEBUI_ALLOWED_EMAIL_DOMAINS",
     ];
 
@@ -464,11 +459,10 @@ mod tests {
         // SAFETY: serialized by ENV_LOCK; cleaned up before the guard drops.
         unsafe {
             std::env::set_var(WEBUI_BASE_URL_ENV, " https://configured.example/ ");
-            std::env::set_var(RAILWAY_PUBLIC_DOMAIN_ENV, "railway.example");
         }
 
         assert_eq!(
-            webui_oauth_base_url_from_env(addr("0.0.0.0:8080")),
+            webui_oauth_base_url_from_env(addr("0.0.0.0:8080")).expect("base url"),
             "https://configured.example"
         );
 
@@ -476,17 +470,54 @@ mod tests {
     }
 
     #[test]
-    fn webui_oauth_base_url_uses_railway_public_domain() {
+    fn webui_public_base_url_from_env_rejects_blank_normalized_values() {
         let _guard = ENV_LOCK.lock().expect("env lock");
         clear_sso_env();
         // SAFETY: serialized by ENV_LOCK; cleaned up before the guard drops.
         unsafe {
-            std::env::set_var(RAILWAY_PUBLIC_DOMAIN_ENV, "qa-ironclaw.up.railway.app");
+            std::env::set_var(WEBUI_BASE_URL_ENV, "/");
+        }
+        let error = webui_public_base_url_from_env()
+            .expect_err("slash-only explicit base URL must fail closed");
+        assert!(
+            error.to_string().contains(WEBUI_BASE_URL_ENV),
+            "error should name env var, got: {error}"
+        );
+
+        // SAFETY: serialized by ENV_LOCK; cleaned up before the guard drops.
+        unsafe {
+            std::env::set_var(WEBUI_BASE_URL_ENV, " / ");
+        }
+        assert!(
+            webui_public_base_url_from_env().is_err(),
+            "normalized-empty explicit base URL must fail closed"
+        );
+
+        clear_sso_env();
+    }
+
+    #[test]
+    fn sso_startup_config_uses_explicit_webui_base_url() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        clear_sso_env();
+        // SAFETY: serialized by ENV_LOCK; cleaned up before the guard drops.
+        unsafe {
+            std::env::set_var("IRONCLAW_REBORN_WEBUI_GOOGLE_CLIENT_ID", "client-id");
+            std::env::set_var(
+                "IRONCLAW_REBORN_WEBUI_GOOGLE_CLIENT_SECRET",
+                "client-secret",
+            );
+            std::env::set_var("IRONCLAW_REBORN_WEBUI_ALLOWED_EMAIL_DOMAINS", "example.com");
+            std::env::set_var(WEBUI_BASE_URL_ENV, " https://configured.example/ ");
         }
 
+        let resolved = sso_startup_config_from_env(addr("0.0.0.0:8080"))
+            .expect("configured provider and allowlist should start")
+            .expect("providers configured → Some(config)");
+
         assert_eq!(
-            webui_oauth_base_url_from_env(addr("0.0.0.0:8080")),
-            "https://qa-ironclaw.up.railway.app"
+            resolved.base_url, "https://configured.example",
+            "explicit WebUI base URL must become the SSO callback base URL"
         );
 
         clear_sso_env();
@@ -498,7 +529,7 @@ mod tests {
         clear_sso_env();
 
         assert_eq!(
-            webui_oauth_base_url_from_env(addr("127.0.0.1:3000")),
+            webui_oauth_base_url_from_env(addr("127.0.0.1:3000")).expect("base url"),
             "http://127.0.0.1:3000"
         );
     }

--- a/crates/ironclaw_reborn_cli/src/commands/serve_sso.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/serve_sso.rs
@@ -28,6 +28,9 @@ use secrecy::SecretString;
 
 const WEBUI_BASE_URL_ENV: &str = "IRONCLAW_REBORN_WEBUI_BASE_URL";
 
+#[cfg(test)]
+pub(crate) static WEBUI_BASE_URL_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 /// Resolved SSO startup config: the providers to mount plus the public
 /// base URL their callback URLs are built from. Constructed by
 /// [`sso_startup_config_from_env`]; consumed by `serve.rs`, which adds
@@ -94,6 +97,22 @@ pub(crate) fn webui_public_base_url_from_env() -> anyhow::Result<Option<String>>
     Ok(None)
 }
 
+/// Validate the hosted WebUI OAuth base URL against the current listen address.
+///
+/// This keeps the cleartext-OAuth policy local to the reborn CLI command
+/// module while letting `serve.rs` fail startup instead of silently skipping
+/// product-auth wiring when an explicit public `http://` base URL is bound to a
+/// non-loopback interface.
+pub(crate) fn validate_webui_public_base_url(
+    public_base_url: Option<&str>,
+    listen_addr: SocketAddr,
+) -> anyhow::Result<()> {
+    if let Some(base_url) = public_base_url {
+        reject_cleartext_oauth(base_url, listen_addr)?;
+    }
+    Ok(())
+}
+
 fn normalize_base_url(env_var: &'static str, raw: impl AsRef<str>) -> anyhow::Result<String> {
     let normalized = raw.as_ref().trim().trim_end_matches('/');
     if normalized.is_empty() {
@@ -137,7 +156,7 @@ fn require_admission_allowlist(allowed_email_domains: &[String]) -> anyhow::Resu
 fn reject_cleartext_oauth(base_url: &str, listen_addr: SocketAddr) -> anyhow::Result<()> {
     if is_cleartext_http_scheme(base_url) && !listen_addr.ip().is_loopback() {
         anyhow::bail!(
-            "WebChat v2 SSO base URL `{base_url}` uses http:// on a non-loopback interface, \
+            "hosted WebUI OAuth base URL `{base_url}` uses http:// on a non-loopback interface, \
              which would transmit OAuth authorization codes in cleartext. Set \
              IRONCLAW_REBORN_WEBUI_BASE_URL to an https:// URL."
         );
@@ -151,7 +170,7 @@ fn reject_cleartext_oauth(base_url: &str, listen_addr: SocketAddr) -> anyhow::Re
 /// `IRONCLAW_REBORN_WEBUI_BASE_URL=HTTP://example.com` slip past the
 /// non-loopback guard while still building a cleartext callback URL —
 /// comparing the scheme case-insensitively closes that bypass.
-fn is_cleartext_http_scheme(base_url: &str) -> bool {
+pub(crate) fn is_cleartext_http_scheme(base_url: &str) -> bool {
     base_url
         .split_once("://")
         .is_some_and(|(scheme, _)| scheme.eq_ignore_ascii_case("http"))
@@ -324,6 +343,29 @@ mod tests {
     }
 
     #[test]
+    fn hosted_webui_public_base_url_validation_fails_closed_for_public_cleartext() {
+        let public = addr("203.0.113.1:3000");
+        let error = validate_webui_public_base_url(Some("http://example.com"), public)
+            .expect_err("public cleartext base URL must abort startup");
+        let message = error.to_string();
+        assert!(
+            message.contains(WEBUI_BASE_URL_ENV),
+            "message should name {WEBUI_BASE_URL_ENV}, got: {message}"
+        );
+        assert!(
+            message.contains("hosted WebUI OAuth base URL"),
+            "message should mention hosted WebUI OAuth base URL, got: {message}"
+        );
+    }
+
+    #[test]
+    fn hosted_webui_public_base_url_validation_allows_loopback_cleartext() {
+        let loopback = addr("127.0.0.1:3000");
+        assert!(validate_webui_public_base_url(Some("http://127.0.0.1:3000"), loopback).is_ok());
+        assert!(validate_webui_public_base_url(None, loopback).is_ok());
+    }
+
+    #[test]
     fn allowed_email_domains_are_trimmed_lowercased_and_deblanked() {
         assert_eq!(
             parse_allowed_email_domains(" Example.com , ,team.EXAMPLE.org ,"),
@@ -341,11 +383,6 @@ mod tests {
         assert!(require_admission_allowlist(&["example.com".to_string()]).is_ok());
     }
 
-    /// Serializes the env-mutating tests below: `sso_startup_config_from_env`
-    /// reads process-global env vars, so two of these running concurrently
-    /// would clobber each other.
-    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
     const SSO_ENV_VARS: &[&str] = &[
         "IRONCLAW_REBORN_WEBUI_GOOGLE_CLIENT_ID",
         "IRONCLAW_REBORN_WEBUI_GOOGLE_CLIENT_SECRET",
@@ -358,7 +395,7 @@ mod tests {
 
     fn clear_sso_env() {
         for var in SSO_ENV_VARS {
-            // SAFETY: tests are serialized by `ENV_LOCK`; no other thread
+            // SAFETY: tests are serialized by `WEBUI_BASE_URL_ENV_LOCK`; no other thread
             // reads or writes these vars while the guard is held.
             unsafe { std::env::remove_var(var) };
         }
@@ -372,9 +409,9 @@ mod tests {
     /// same caller succeeds once the allowlist is supplied.
     #[test]
     fn startup_fails_closed_when_providers_set_but_allowlist_missing() {
-        let _guard = ENV_LOCK.lock().expect("env lock");
+        let _guard = WEBUI_BASE_URL_ENV_LOCK.lock().expect("env lock");
         clear_sso_env();
-        // SAFETY: serialized by ENV_LOCK; cleaned up before the guard drops.
+        // SAFETY: serialized by WEBUI_BASE_URL_ENV_LOCK; cleaned up before the guard drops.
         unsafe {
             std::env::set_var("IRONCLAW_REBORN_WEBUI_GOOGLE_CLIENT_ID", "client-id");
             std::env::set_var(
@@ -391,7 +428,7 @@ mod tests {
         );
 
         // Blank allowlist → same fail-closed result.
-        // SAFETY: serialized by ENV_LOCK.
+        // SAFETY: serialized by WEBUI_BASE_URL_ENV_LOCK.
         unsafe {
             std::env::set_var("IRONCLAW_REBORN_WEBUI_ALLOWED_EMAIL_DOMAINS", "  , ,");
         }
@@ -401,7 +438,7 @@ mod tests {
         );
 
         // Supplying the allowlist makes the same caller succeed.
-        // SAFETY: serialized by ENV_LOCK.
+        // SAFETY: serialized by WEBUI_BASE_URL_ENV_LOCK.
         unsafe {
             std::env::set_var("IRONCLAW_REBORN_WEBUI_ALLOWED_EMAIL_DOMAINS", "example.com");
         }
@@ -422,14 +459,14 @@ mod tests {
     /// caller `sso_startup_config_from_env`, since the helper is private.
     #[test]
     fn client_id_without_secret_fails_startup() {
-        let _guard = ENV_LOCK.lock().expect("env lock");
+        let _guard = WEBUI_BASE_URL_ENV_LOCK.lock().expect("env lock");
 
         for id_var in [
             "IRONCLAW_REBORN_WEBUI_GOOGLE_CLIENT_ID",
             "IRONCLAW_REBORN_WEBUI_GITHUB_CLIENT_ID",
         ] {
             clear_sso_env();
-            // SAFETY: serialized by ENV_LOCK; cleared before/after.
+            // SAFETY: serialized by WEBUI_BASE_URL_ENV_LOCK; cleared before/after.
             unsafe { std::env::set_var(id_var, "client-id") };
             assert!(
                 sso_startup_config_from_env(addr("127.0.0.1:3000")).is_err(),
@@ -445,7 +482,7 @@ mod tests {
     /// since the allowlist gate only fires once a provider is configured.)
     #[test]
     fn no_provider_configured_returns_none() {
-        let _guard = ENV_LOCK.lock().expect("env lock");
+        let _guard = WEBUI_BASE_URL_ENV_LOCK.lock().expect("env lock");
         clear_sso_env();
         let resolved = sso_startup_config_from_env(addr("127.0.0.1:3000"))
             .expect("no provider configured is not an error");
@@ -454,9 +491,9 @@ mod tests {
 
     #[test]
     fn webui_oauth_base_url_prefers_explicit_reborn_env() {
-        let _guard = ENV_LOCK.lock().expect("env lock");
+        let _guard = WEBUI_BASE_URL_ENV_LOCK.lock().expect("env lock");
         clear_sso_env();
-        // SAFETY: serialized by ENV_LOCK; cleaned up before the guard drops.
+        // SAFETY: serialized by WEBUI_BASE_URL_ENV_LOCK; cleaned up before the guard drops.
         unsafe {
             std::env::set_var(WEBUI_BASE_URL_ENV, " https://configured.example/ ");
         }
@@ -471,9 +508,9 @@ mod tests {
 
     #[test]
     fn webui_public_base_url_from_env_rejects_blank_normalized_values() {
-        let _guard = ENV_LOCK.lock().expect("env lock");
+        let _guard = WEBUI_BASE_URL_ENV_LOCK.lock().expect("env lock");
         clear_sso_env();
-        // SAFETY: serialized by ENV_LOCK; cleaned up before the guard drops.
+        // SAFETY: serialized by WEBUI_BASE_URL_ENV_LOCK; cleaned up before the guard drops.
         unsafe {
             std::env::set_var(WEBUI_BASE_URL_ENV, "/");
         }
@@ -484,7 +521,7 @@ mod tests {
             "error should name env var, got: {error}"
         );
 
-        // SAFETY: serialized by ENV_LOCK; cleaned up before the guard drops.
+        // SAFETY: serialized by WEBUI_BASE_URL_ENV_LOCK; cleaned up before the guard drops.
         unsafe {
             std::env::set_var(WEBUI_BASE_URL_ENV, " / ");
         }
@@ -498,9 +535,9 @@ mod tests {
 
     #[test]
     fn sso_startup_config_uses_explicit_webui_base_url() {
-        let _guard = ENV_LOCK.lock().expect("env lock");
+        let _guard = WEBUI_BASE_URL_ENV_LOCK.lock().expect("env lock");
         clear_sso_env();
-        // SAFETY: serialized by ENV_LOCK; cleaned up before the guard drops.
+        // SAFETY: serialized by WEBUI_BASE_URL_ENV_LOCK; cleaned up before the guard drops.
         unsafe {
             std::env::set_var("IRONCLAW_REBORN_WEBUI_GOOGLE_CLIENT_ID", "client-id");
             std::env::set_var(
@@ -525,7 +562,7 @@ mod tests {
 
     #[test]
     fn webui_oauth_base_url_falls_back_to_listener() {
-        let _guard = ENV_LOCK.lock().expect("env lock");
+        let _guard = WEBUI_BASE_URL_ENV_LOCK.lock().expect("env lock");
         clear_sso_env();
 
         assert_eq!(

--- a/docs/reborn/deploy-reborn-cli-docker.md
+++ b/docs/reborn/deploy-reborn-cli-docker.md
@@ -111,6 +111,11 @@ To seed a custom config instead of the bundled default, mount it under
 start, the entrypoint copies that file into `$IRONCLAW_REBORN_HOME/config.toml`;
 later starts preserve the existing home config.
 
+Railway provides `RAILWAY_PUBLIC_DOMAIN`, and Reborn uses it as the hosted
+WebUI OAuth base URL when `IRONCLAW_REBORN_WEBUI_BASE_URL` is unset. Set
+`IRONCLAW_REBORN_WEBUI_BASE_URL` explicitly when using a custom public domain or
+when you need to override Railway's generated domain.
+
 For public WebUI Google login, use the Reborn WebUI SSO variables and an HTTPS
 base URL that matches the deployed Railway domain:
 
@@ -128,6 +133,11 @@ Register this WebUI login callback in the Google OAuth client:
 ```text
 https://<railway-domain>/auth/callback/google
 ```
+
+Notion MCP and other product-auth OAuth setup flows use the same hosted WebUI
+base URL for provider callbacks. On Railway this means their redirect URIs use
+`https://$RAILWAY_PUBLIC_DOMAIN/...` by default instead of a local listener
+address.
 
 Product-auth Google credentials are a separate flow. Configure
 `IRONCLAW_REBORN_GOOGLE_OAUTH_REDIRECT_URI` only when the deployment should let

--- a/docs/reborn/deploy-reborn-cli-docker.md
+++ b/docs/reborn/deploy-reborn-cli-docker.md
@@ -111,11 +111,6 @@ To seed a custom config instead of the bundled default, mount it under
 start, the entrypoint copies that file into `$IRONCLAW_REBORN_HOME/config.toml`;
 later starts preserve the existing home config.
 
-Railway provides `RAILWAY_PUBLIC_DOMAIN`, and Reborn uses it as the hosted
-WebUI OAuth base URL when `IRONCLAW_REBORN_WEBUI_BASE_URL` is unset. Set
-`IRONCLAW_REBORN_WEBUI_BASE_URL` explicitly when using a custom public domain or
-when you need to override Railway's generated domain.
-
 For public WebUI Google login, use the Reborn WebUI SSO variables and an HTTPS
 base URL that matches the deployed Railway domain:
 
@@ -135,9 +130,10 @@ https://<railway-domain>/auth/callback/google
 ```
 
 Notion MCP and other product-auth OAuth setup flows use the same hosted WebUI
-base URL for provider callbacks. On Railway this means their redirect URIs use
-`https://$RAILWAY_PUBLIC_DOMAIN/...` by default instead of a local listener
-address.
+base URL for provider callbacks. Set `IRONCLAW_REBORN_WEBUI_BASE_URL` to the
+same public host so product-auth providers see the public callback origin rather
+than the local listener address. Google product-auth is separate and still uses
+`IRONCLAW_REBORN_GOOGLE_OAUTH_REDIRECT_URI` explicitly.
 
 Product-auth Google credentials are a separate flow. Configure
 `IRONCLAW_REBORN_GOOGLE_OAUTH_REDIRECT_URI` only when the deployment should let


### PR DESCRIPTION
## Summary

- resolves hosted WebUI OAuth callback origins only from `IRONCLAW_REBORN_WEBUI_BASE_URL`
- feeds that hosted origin into Notion DCR/product-auth callback wiring before local listener fallback
- rejects empty normalized base URL values and cleartext public callback origins on non-loopback binds
- documents that WebUI login and product-auth OAuth flows share the Reborn WebUI base URL

## Root Cause

Reborn WebUI `serve` wired Notion DCR OAuth callback origin from `[webui].canonical_host` or the local listener address. A public deployment with a wildcard/non-loopback listener and no canonical host could therefore produce provider-visible local callback origins unless the Reborn WebUI base URL was explicitly used by every OAuth surface.

## Impact

Hosted WebUI login and product-auth OAuth callbacks now use the same Reborn-scoped public base URL when `IRONCLAW_REBORN_WEBUI_BASE_URL` is configured. Local loopback behavior is preserved when no public base URL is set.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p ironclaw_reborn_cli --features webui-v2-beta webui_ -- --nocapture`
- `cargo clippy -p ironclaw_reborn_cli --features webui-v2-beta --all-targets -- -D warnings`

Fixes #4928
