### PR TITLE
feat(tools): add Slack personal (user-token) tool

### DIFF
--- a/registry/tools/slack_user_tool.json
+++ b/registry/tools/slack_user_tool.json
@@ -1,0 +1,33 @@
+{
+  "name": "slack_user_tool",
+  "display_name": "Slack (personal)",
+  "kind": "tool",
+  "version": "0.1.0",
+  "wit_version": "0.3.0",
+  "description": "Act as you in Slack via a personal user token: search all your messages, read your DMs and channel history, and post as you",
+  "keywords": [
+    "messaging",
+    "chat",
+    "workspace",
+    "search",
+    "history",
+    "dms"
+  ],
+  "source": {
+    "dir": "tools-src/slack_user",
+    "capabilities": "slack_user-tool.capabilities.json",
+    "crate_name": "slack-user-tool"
+  },
+  "auth_summary": {
+    "method": "manual",
+    "provider": "Slack",
+    "secrets": [
+      "slack_user_token"
+    ],
+    "shared_auth": null,
+    "setup_url": "https://api.slack.com/apps"
+  },
+  "tags": [
+    "messaging"
+  ]
+}

--- a/tools-src/slack_user/Cargo.toml
+++ b/tools-src/slack_user/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "slack-user-tool"
+version = "0.1.0"
+edition = "2021"
+description = "Slack personal (user-token) tool for IronClaw (WASM component)"
+license = "MIT OR Apache-2.0"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wit-bindgen = "=0.36"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+# Auto-derives JSON Schema from the SlackUserAction tagged enum so the
+# advertised schema mirrors the serde-enforced contract.
+schemars = "1"
+
+[profile.release]
+opt-level = "s"
+lto = true
+strip = true
+codegen-units = 1
+
+[workspace]

--- a/tools-src/slack_user/README.md
+++ b/tools-src/slack_user/README.md
@@ -1,0 +1,67 @@
+# Slack Personal (User-Token) WASM Tool
+
+A standalone WASM component that lets IronClaw act **as you** in Slack, using a
+personal **user token** (`xoxp-`) rather than a bot token. This is what enables
+reading your full message history, your DMs, and searching everything you can
+see — things a bot token fundamentally cannot do.
+
+This is the user-identity counterpart to the bot-identity `slack` tool. The two
+are deliberately separate tools with **separate secrets** (`slack_user_token`
+vs `slack_bot_token`) so the personal token never collides with the bot token
+used by the Slack channel or the `slack` tool.
+
+## Features
+
+- **search_messages**: Search across all messages you can see (DMs, group DMs,
+  and channels you belong to). Supports Slack search operators like
+  `from:@me`, `in:#channel`, `after:2024-01-01`.
+- **list_conversations**: List channels, private channels, DMs (`im`), and
+  group DMs (`mpim`) you belong to — use this to discover DM conversation IDs.
+- **get_conversation_history**: Read history of any channel or DM by ID, with
+  `latest`/`oldest` pagination cursors.
+- **get_user_info**: Look up a user's name, real name, and email.
+- **send_message**: Post a message as you (requires `chat:write`).
+
+## Prerequisites
+
+1. **Rust toolchain** with the WASM target:
+   ```bash
+   rustup target add wasm32-wasip2
+   ```
+
+2. **cargo-component** for building WASM components:
+   ```bash
+   cargo install cargo-component --locked
+   ```
+
+3. A **Slack User OAuth Token** (`xoxp-`). Create a private app at
+   https://api.slack.com/apps and, under **OAuth & Permissions**, add these
+   **User Token Scopes** (not Bot Token Scopes):
+   - `search:read` — search your messages
+   - `channels:history`, `groups:history`, `im:history`, `mpim:history` — read
+     public/private channels, DMs, group DMs
+   - `channels:read`, `groups:read`, `im:read`, `mpim:read` — enumerate them
+   - `users:read` — resolve user info
+   - `chat:write` — post as you (optional)
+
+   Install the app to your workspace and copy the **User OAuth Token**.
+
+## Building
+
+```bash
+cd tools-src/slack_user
+cargo component build --release --target wasm32-wasip2
+```
+
+## Configuring
+
+Store your user token under the `slack_user_token` secret (via the Extensions
+UI for "Slack (personal)", which offers a single token-paste field). The token
+is injected as a bearer credential at the host boundary; the WASM component
+never sees it.
+
+## Security
+
+A user token acts as you and can read your private conversations. Treat it like
+a password. IronClaw stores it encrypted in the secrets store and scans all tool
+output for credential leakage before returning it.

--- a/tools-src/slack_user/slack_user-tool.capabilities.json
+++ b/tools-src/slack_user/slack_user-tool.capabilities.json
@@ -1,0 +1,45 @@
+{
+  "version": "0.1.0",
+  "wit_version": "0.3.0",
+  "description": "Act as you in Slack via a personal user token (xoxp-): search all your messages, list and read your DMs and group DMs, read channel history, and post as you.",
+  "http": {
+    "allowlist": [
+      {
+        "host": "slack.com",
+        "path_prefix": "/api/",
+        "methods": ["GET", "POST"]
+      }
+    ],
+    "credentials": {
+      "slack_user_token": {
+        "secret_name": "slack_user_token",
+        "location": { "type": "bearer" },
+        "host_patterns": ["slack.com"]
+      }
+    },
+    "rate_limit": {
+      "requests_per_minute": 50,
+      "requests_per_hour": 1000
+    },
+    "timeout_secs": 30
+  },
+  "secrets": {
+    "allowed_names": ["slack_user_token"]
+  },
+  "auth": {
+    "secret_name": "slack_user_token",
+    "display_name": "Slack (personal)",
+    "instructions": "1. Create a private Slack app at https://api.slack.com/apps (From scratch, your workspace).\n2. Under OAuth & Permissions, add USER Token Scopes (not Bot Token Scopes):\n   search:read, channels:history, groups:history, im:history, mpim:history,\n   channels:read, groups:read, im:read, mpim:read, users:read, and chat:write\n   (chat:write only if you want it to post as you).\n3. Install the app to your workspace and authorize.\n4. Copy the User OAuth Token (starts with xoxp-) and paste it here.",
+    "setup_url": "https://api.slack.com/apps",
+    "token_hint": "Starts with 'xoxp-'",
+    "env_var": "SLACK_USER_TOKEN"
+  },
+  "setup": {
+    "required_secrets": [
+      {
+        "name": "slack_user_token",
+        "prompt": "Slack User OAuth Token (starts with xoxp-, from api.slack.com/apps > OAuth & Permissions)"
+      }
+    ]
+  }
+}

--- a/tools-src/slack_user/src/api.rs
+++ b/tools-src/slack_user/src/api.rs
@@ -1,0 +1,238 @@
+//! Slack Web API implementation for the personal (user-token) tool.
+//!
+//! All API calls go through the host's HTTP capability, which injects the
+//! `slack_user_token` secret as a bearer token and scans responses for
+//! leaks. The WASM tool never sees the actual token.
+
+use crate::near::agent::host;
+use crate::types::*;
+
+const SLACK_API_BASE: &str = "https://slack.com/api";
+
+/// Percent-encode a string for use as a URL query parameter value.
+fn url_encode(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for b in s.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(b as char);
+            }
+            _ => {
+                out.push('%');
+                out.push(char::from(b"0123456789ABCDEF"[(b >> 4) as usize]));
+                out.push(char::from(b"0123456789ABCDEF"[(b & 0xf) as usize]));
+            }
+        }
+    }
+    out
+}
+
+/// Make a Slack API call and return the parsed JSON value, surfacing
+/// Slack's `ok: false` errors as `Err`.
+fn slack_api_call(
+    method: &str,
+    endpoint: &str,
+    body: Option<&str>,
+) -> Result<serde_json::Value, String> {
+    let url = format!("{}/{}", SLACK_API_BASE, endpoint);
+
+    let headers = if body.is_some() {
+        r#"{"Content-Type": "application/json; charset=utf-8"}"#
+    } else {
+        "{}"
+    };
+
+    let body_bytes = body.map(|b| b.as_bytes().to_vec());
+
+    host::log(
+        host::LogLevel::Debug,
+        &format!("Slack API: {} {}", method, endpoint),
+    );
+
+    let response = host::http_request(method, &url, headers, body_bytes.as_deref(), None)?;
+
+    if response.status < 200 || response.status >= 300 {
+        return Err(format!(
+            "Slack API returned status {}: {}",
+            response.status,
+            String::from_utf8_lossy(&response.body)
+        ));
+    }
+
+    let parsed: serde_json::Value = serde_json::from_slice(&response.body)
+        .map_err(|e| format!("Failed to parse response: {}", e))?;
+
+    if !parsed["ok"].as_bool().unwrap_or(false) {
+        let error = parsed["error"].as_str().unwrap_or("unknown_error");
+        return Err(format!("Slack API error: {}", error));
+    }
+
+    Ok(parsed)
+}
+
+/// Search all messages visible to the user token.
+pub fn search_messages(
+    query: &str,
+    count: u32,
+    sort: Option<&str>,
+) -> Result<SearchMessagesResult, String> {
+    let count = count.clamp(1, 100);
+    let mut url = format!(
+        "search.messages?query={}&count={}",
+        url_encode(query),
+        count
+    );
+    if let Some(sort) = sort {
+        url.push_str(&format!("&sort={}", url_encode(sort)));
+    }
+
+    let parsed = slack_api_call("GET", &url, None)?;
+
+    let messages = &parsed["messages"];
+    let total = messages["total"].as_u64().unwrap_or(0);
+    let matches = messages["matches"]
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .map(|m| SearchMatch {
+                    ts: m["ts"].as_str().unwrap_or("").to_string(),
+                    text: m["text"].as_str().unwrap_or("").to_string(),
+                    user: m["user"].as_str().map(|s| s.to_string()),
+                    username: m["username"].as_str().map(|s| s.to_string()),
+                    channel_id: m["channel"]["id"].as_str().map(|s| s.to_string()),
+                    channel_name: m["channel"]["name"].as_str().map(|s| s.to_string()),
+                    permalink: m["permalink"].as_str().map(|s| s.to_string()),
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    Ok(SearchMessagesResult {
+        ok: true,
+        total,
+        matches,
+    })
+}
+
+/// List conversations the user belongs to (channels, DMs, group DMs).
+pub fn list_conversations(types: &str, limit: u32) -> Result<ListConversationsResult, String> {
+    let url = format!(
+        "conversations.list?types={}&limit={}&exclude_archived=true",
+        url_encode(types),
+        limit
+    );
+
+    let parsed = slack_api_call("GET", &url, None)?;
+
+    let conversations = parsed["channels"]
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .map(|c| Conversation {
+                    id: c["id"].as_str().unwrap_or("").to_string(),
+                    name: c["name"].as_str().map(|s| s.to_string()),
+                    is_channel: c["is_channel"].as_bool().unwrap_or(false),
+                    is_private: c["is_private"].as_bool().unwrap_or(false),
+                    is_im: c["is_im"].as_bool().unwrap_or(false),
+                    is_mpim: c["is_mpim"].as_bool().unwrap_or(false),
+                    user: c["user"].as_str().map(|s| s.to_string()),
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    Ok(ListConversationsResult {
+        ok: true,
+        conversations,
+    })
+}
+
+/// Read message history from any conversation (channel, DM, or group DM).
+pub fn get_conversation_history(
+    channel: &str,
+    limit: u32,
+    latest: Option<&str>,
+    oldest: Option<&str>,
+) -> Result<ConversationHistoryResult, String> {
+    let mut url = format!(
+        "conversations.history?channel={}&limit={}",
+        url_encode(channel),
+        limit
+    );
+    if let Some(latest) = latest {
+        url.push_str(&format!("&latest={}", url_encode(latest)));
+    }
+    if let Some(oldest) = oldest {
+        url.push_str(&format!("&oldest={}", url_encode(oldest)));
+    }
+
+    let parsed = slack_api_call("GET", &url, None)?;
+
+    let has_more = parsed["has_more"].as_bool().unwrap_or(false);
+    let messages = parsed["messages"]
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .map(|m| HistoryMessage {
+                    ts: m["ts"].as_str().unwrap_or("").to_string(),
+                    text: m["text"].as_str().unwrap_or("").to_string(),
+                    user: m["user"].as_str().map(|s| s.to_string()),
+                    msg_type: m["type"].as_str().unwrap_or("message").to_string(),
+                    thread_ts: m["thread_ts"].as_str().map(|s| s.to_string()),
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    Ok(ConversationHistoryResult {
+        ok: true,
+        messages,
+        has_more,
+    })
+}
+
+/// Get information about a user.
+pub fn get_user_info(user_id: &str) -> Result<GetUserInfoResult, String> {
+    let url = format!("users.info?user={}", url_encode(user_id));
+
+    let parsed = slack_api_call("GET", &url, None)?;
+
+    let user = &parsed["user"];
+    let profile = &user["profile"];
+
+    Ok(GetUserInfoResult {
+        ok: true,
+        user: UserInfo {
+            id: user["id"].as_str().unwrap_or("").to_string(),
+            name: user["name"].as_str().unwrap_or("").to_string(),
+            real_name: profile["real_name"].as_str().map(|s| s.to_string()),
+            display_name: profile["display_name"].as_str().map(|s| s.to_string()),
+            email: profile["email"].as_str().map(|s| s.to_string()),
+            is_bot: user["is_bot"].as_bool().unwrap_or(false),
+        },
+    })
+}
+
+/// Send a message as the user.
+pub fn send_message(
+    channel: &str,
+    text: &str,
+    thread_ts: Option<&str>,
+) -> Result<SendMessageResult, String> {
+    let mut payload = serde_json::json!({
+        "channel": channel,
+        "text": text,
+    });
+    if let Some(ts) = thread_ts {
+        payload["thread_ts"] = serde_json::Value::String(ts.to_string());
+    }
+
+    let body = serde_json::to_string(&payload).map_err(|e| e.to_string())?;
+    let parsed = slack_api_call("POST", "chat.postMessage", Some(&body))?;
+
+    Ok(SendMessageResult {
+        ok: true,
+        channel: parsed["channel"].as_str().unwrap_or(channel).to_string(),
+        ts: parsed["ts"].as_str().unwrap_or("").to_string(),
+    })
+}

--- a/tools-src/slack_user/src/lib.rs
+++ b/tools-src/slack_user/src/lib.rs
@@ -1,0 +1,136 @@
+//! Slack personal (user-token) WASM Tool for IronClaw.
+//!
+//! Unlike the bot-token `slack` tool, this tool authenticates with a Slack
+//! **user token** (`xoxp-`) stored under the `slack_user_token` secret, so it
+//! acts as the user. That lets it search all of the user's messages, list and
+//! read their DMs and group DMs, read channel history, and post as them.
+//!
+//! # Capabilities Required
+//!
+//! - HTTP: `slack.com/api/*` (GET, POST)
+//! - Secrets: `slack_user_token` (injected automatically as a bearer token)
+//!
+//! # Supported Actions
+//!
+//! - `search_messages`: Search all messages the user can see
+//! - `list_conversations`: List channels, DMs, and group DMs the user is in
+//! - `get_conversation_history`: Read history of any channel or DM
+//! - `get_user_info`: Get information about a Slack user
+//! - `send_message`: Post a message as the user
+//!
+//! # Example Usage
+//!
+//! ```json
+//! {"action": "search_messages", "query": "from:@me project plan", "count": 20}
+//! ```
+
+mod api;
+mod types;
+
+use types::SlackUserAction;
+
+// Generate bindings from the WIT interface.
+wit_bindgen::generate!({
+    world: "sandboxed-tool",
+    path: "../../wit/tool.wit",
+});
+
+/// Implementation of the tool interface.
+struct SlackUserTool;
+
+impl exports::near::agent::tool::Guest for SlackUserTool {
+    fn execute(req: exports::near::agent::tool::Request) -> exports::near::agent::tool::Response {
+        match execute_inner(&req.params) {
+            Ok(result) => exports::near::agent::tool::Response {
+                output: Some(result),
+                error: None,
+            },
+            Err(e) => exports::near::agent::tool::Response {
+                output: None,
+                error: Some(e),
+            },
+        }
+    }
+
+    fn schema() -> String {
+        // Derived from `SlackUserAction` via `schemars::JsonSchema` so the
+        // advertised schema can never drift from the serde contract.
+        let schema = schemars::schema_for!(types::SlackUserAction);
+        serde_json::to_string(&schema).expect("schema serialization is infallible")
+    }
+
+    fn description() -> String {
+        "Slack personal tool that acts as you via a user token (xoxp-): search all your \
+         messages, list and read your DMs and group DMs, read channel history, look up users, \
+         and post as you. Requires a Slack user token with scopes such as search:read, \
+         channels:history, groups:history, im:history, mpim:history, users:read, and \
+         chat:write (for posting)."
+            .to_string()
+    }
+}
+
+/// Inner execution logic with proper error handling.
+fn execute_inner(params: &str) -> Result<String, String> {
+    // Check that the Slack user token is configured.
+    if !crate::near::agent::host::secret_exists("slack_user_token") {
+        return Err(
+            "Slack user token not configured. Please add the 'slack_user_token' secret \
+             (a user OAuth token starting with 'xoxp-')."
+                .to_string(),
+        );
+    }
+
+    let action: SlackUserAction =
+        serde_json::from_str(params).map_err(|e| format!("Invalid parameters: {}", e))?;
+
+    crate::near::agent::host::log(
+        crate::near::agent::host::LogLevel::Debug,
+        &format!("Executing Slack user action: {:?}", action),
+    );
+
+    let result = match action {
+        SlackUserAction::SearchMessages { query, count, sort } => {
+            let result = api::search_messages(&query, count, sort.as_deref())?;
+            serde_json::to_string(&result).map_err(|e| e.to_string())?
+        }
+
+        SlackUserAction::ListConversations { types, limit } => {
+            let result = api::list_conversations(&types, limit)?;
+            serde_json::to_string(&result).map_err(|e| e.to_string())?
+        }
+
+        SlackUserAction::GetConversationHistory {
+            channel,
+            limit,
+            latest,
+            oldest,
+        } => {
+            let result = api::get_conversation_history(
+                &channel,
+                limit,
+                latest.as_deref(),
+                oldest.as_deref(),
+            )?;
+            serde_json::to_string(&result).map_err(|e| e.to_string())?
+        }
+
+        SlackUserAction::GetUserInfo { user_id } => {
+            let result = api::get_user_info(&user_id)?;
+            serde_json::to_string(&result).map_err(|e| e.to_string())?
+        }
+
+        SlackUserAction::SendMessage {
+            channel,
+            text,
+            thread_ts,
+        } => {
+            let result = api::send_message(&channel, &text, thread_ts.as_deref())?;
+            serde_json::to_string(&result).map_err(|e| e.to_string())?
+        }
+    };
+
+    Ok(result)
+}
+
+// Export the tool implementation.
+export!(SlackUserTool);

--- a/tools-src/slack_user/src/types.rs
+++ b/tools-src/slack_user/src/types.rs
@@ -1,0 +1,187 @@
+//! Types for Slack user-token API requests and responses.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Input parameters for the Slack personal (user-token) tool.
+///
+/// `JsonSchema` is derived so the advertised tool schema mirrors the
+/// serde-enforced contract: each variant becomes a `oneOf` entry with
+/// its own `required` array.
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(tag = "action", rename_all = "snake_case")]
+pub enum SlackUserAction {
+    /// Search across all messages you can see (DMs, group DMs, and
+    /// channels you are a member of). Requires the `search:read` user scope.
+    SearchMessages {
+        /// Search query. Supports Slack search operators such as
+        /// `from:@me`, `in:#channel`, `after:2024-01-01`, `has:link`.
+        query: String,
+        /// Maximum number of matches to return (default: 20, max: 100).
+        #[serde(default = "default_search_count")]
+        count: u32,
+        /// Sort by `score` (relevance, default) or `timestamp` (recency).
+        #[serde(default)]
+        sort: Option<String>,
+    },
+
+    /// List conversations you belong to: channels, private channels,
+    /// DMs, and group DMs. Use this to discover DM conversation IDs.
+    ListConversations {
+        /// Comma-separated conversation types to include. Defaults to
+        /// `public_channel,private_channel,im,mpim` (everything you're in).
+        #[serde(default = "default_conversation_types")]
+        types: String,
+        /// Maximum number of conversations to return (default: 200).
+        #[serde(default = "default_list_limit")]
+        limit: u32,
+    },
+
+    /// Read message history from any conversation you can see — a channel,
+    /// a DM, or a group DM — identified by its conversation ID.
+    GetConversationHistory {
+        /// Conversation ID (e.g. `C123...` for a channel, `D123...` for a DM).
+        channel: String,
+        /// Maximum number of messages to return (default: 50).
+        #[serde(default = "default_history_limit")]
+        limit: u32,
+        /// Only return messages before this timestamp (pagination cursor).
+        #[serde(default)]
+        latest: Option<String>,
+        /// Only return messages after this timestamp.
+        #[serde(default)]
+        oldest: Option<String>,
+    },
+
+    /// Get information about a user (name, real name, email).
+    GetUserInfo {
+        /// User ID (e.g., "U1234567890").
+        user_id: String,
+    },
+
+    /// Send a message as you to a channel or DM. Requires the `chat:write`
+    /// user scope. The message will appear to come from your account.
+    SendMessage {
+        /// Channel ID or name (e.g., "#general" or "C1234567890"), or a
+        /// DM conversation ID.
+        channel: String,
+        /// Message text (supports Slack mrkdwn formatting).
+        text: String,
+        /// Optional thread timestamp to reply in a thread.
+        #[serde(default)]
+        thread_ts: Option<String>,
+    },
+}
+
+fn default_search_count() -> u32 {
+    20
+}
+
+fn default_conversation_types() -> String {
+    "public_channel,private_channel,im,mpim".to_string()
+}
+
+fn default_list_limit() -> u32 {
+    200
+}
+
+fn default_history_limit() -> u32 {
+    50
+}
+
+/// A single message match from search.messages.
+#[derive(Debug, Serialize)]
+pub struct SearchMatch {
+    pub ts: String,
+    pub text: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub username: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub channel_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub channel_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub permalink: Option<String>,
+}
+
+/// Result from search_messages.
+#[derive(Debug, Serialize)]
+pub struct SearchMessagesResult {
+    pub ok: bool,
+    pub total: u64,
+    pub matches: Vec<SearchMatch>,
+}
+
+/// A conversation (channel, private channel, DM, or group DM).
+#[derive(Debug, Serialize)]
+pub struct Conversation {
+    pub id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    pub is_channel: bool,
+    pub is_private: bool,
+    pub is_im: bool,
+    pub is_mpim: bool,
+    /// For DMs (`im`), the user ID on the other side.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user: Option<String>,
+}
+
+/// Result from list_conversations.
+#[derive(Debug, Serialize)]
+pub struct ListConversationsResult {
+    pub ok: bool,
+    pub conversations: Vec<Conversation>,
+}
+
+/// A message from conversation history.
+#[derive(Debug, Serialize)]
+pub struct HistoryMessage {
+    pub ts: String,
+    pub text: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user: Option<String>,
+    #[serde(rename = "type")]
+    pub msg_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thread_ts: Option<String>,
+}
+
+/// Result from get_conversation_history.
+#[derive(Debug, Serialize)]
+pub struct ConversationHistoryResult {
+    pub ok: bool,
+    pub messages: Vec<HistoryMessage>,
+    pub has_more: bool,
+}
+
+/// User information.
+#[derive(Debug, Serialize)]
+pub struct UserInfo {
+    pub id: String,
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub real_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub email: Option<String>,
+    pub is_bot: bool,
+}
+
+/// Result from get_user_info.
+#[derive(Debug, Serialize)]
+pub struct GetUserInfoResult {
+    pub ok: bool,
+    pub user: UserInfo,
+}
+
+/// Result from send_message.
+#[derive(Debug, Serialize)]
+pub struct SendMessageResult {
+    pub ok: bool,
+    pub channel: String,
+    pub ts: String,
+}


### PR DESCRIPTION
## What

Adds a new `slack_user_tool` WASM tool that lets IronClaw act **as the user** in Slack via a personal **user token** (`xoxp-`), distinct from the existing bot-token `slack` tool.

This enables capabilities a bot token fundamentally cannot provide:
- **search_messages** — search across all messages the user can see (`search.messages`, user-token only)
- **list_conversations** — enumerate channels, private channels, DMs (`im`), and group DMs (`mpim`)
- **get_conversation_history** — read history of any channel or DM by ID, with pagination
- **get_user_info** — look up users
- **send_message** — post as the user (requires `chat:write`)

## Why a separate tool (not a mode of the bot tool)

- **Secret isolation.** Uses its own `slack_user_token` secret, so the personal user token never collides with the `slack_bot_token` shared by the Slack channel and bot `slack` tool. This matches the `credential_name` separation in the auth invariants.
- **No registry conflict.** The bot `slack_tool` is a sha-pinned registry artifact; locally editing it would fight upstream updates.
- **Explicit privilege boundary.** "Acts as you and can read your entire history" is a meaningfully higher-privilege capability and is auditable as its own tool.

## Auth

Manual token entry (`auth_summary.method: "manual"`, no OAuth client credentials), so the Extensions UI presents a single token-paste field for the `xoxp-` token. Required user scopes are documented in the capabilities `instructions` and the tool README.

## Verification

- `cargo component build --release --target wasm32-wasip2` → clean component
- `cargo fmt` + `cargo clippy --release --target wasm32-wasip2 --all-targets` → clean
- `ironclaw tool info slack_user_tool` → loads, schema parses, HTTP allowlist + rate limits correct
- `ironclaw registry list` → appears as a separate tool alongside `slack` (channel) and `slack_tool` (bot)

## Notes

- Local-only for now: the registry manifest has no release artifact (loads from `~/.ironclaw/tools/`). Publishing a release artifact + sha for cross-machine `registry install` is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)