### PR TITLE
fix(attachments): post-merge review follow-ups for image vision (#4871)

### DIFF
--- a/crates/ironclaw_llm/src/vision_models.rs
+++ b/crates/ironclaw_llm/src/vision_models.rs
@@ -43,9 +43,18 @@ pub fn is_vision_model(model: &str) -> bool {
 ///
 /// Priority: Claude > GPT-4 > Gemini > others.
 pub fn suggest_vision_model(models: &[String]) -> Option<&str> {
+    // Tier-first slugs are load-bearing here for the same reason as
+    // `VISION_PATTERNS`: `claude-4` is not a substring of `claude-opus-4-8`,
+    // so without the `claude-{opus,sonnet,haiku,fable}-` prefixes a current-gen
+    // Claude model would lose priority to GPT-4. Opus > Sonnet > Haiku ordering
+    // preserves the "best Claude first" intent.
     let priorities: &[&str] = &[
         "claude-3",
         "claude-4",
+        "claude-opus-",
+        "claude-sonnet-",
+        "claude-haiku-",
+        "claude-fable-",
         "gpt-4o",
         "gpt-4-turbo",
         "gpt-4-vision",

--- a/crates/ironclaw_loop_support/src/lib.rs
+++ b/crates/ironclaw_loop_support/src/lib.rs
@@ -1456,8 +1456,8 @@ where
     }
 }
 
-/// Host-managed text-only model gateway. Implementations own provider selection,
-/// profile policy, retry/circuit behavior, and sanitization.
+/// Host-managed model gateway. Implementations own provider selection,
+/// profile policy, retry/circuit behavior, multimodal shaping, and sanitization.
 #[async_trait]
 pub trait HostManagedModelGateway: Send + Sync {
     async fn stream_model(

--- a/crates/ironclaw_product_workflow/src/reborn_services.rs
+++ b/crates/ironclaw_product_workflow/src/reborn_services.rs
@@ -3118,24 +3118,6 @@ impl RebornServices {
         })
     }
 
-    /// Fallback timeline fetch for automation-trigger threads.
-    ///
-    /// Automation-trigger threads are created under the trigger creator's
-    /// scope, not the caller's session scope. The normal user-scoped
-    /// `list_thread_history` therefore always misses them. This fallback is
-    /// only reached when the user-scoped lookup returned `UnknownThread` or
-    /// `ThreadScopeMismatch`.
-    ///
-    /// Authorization: the thread_id must appear in at least one `recent_run`
-    /// for an automation returned by `list_automations` for this caller. That
-    /// is the same authorization check the Automations list endpoint applies,
-    /// so no new trust boundary is introduced. Authorization is revalidated on
-    /// every call — no caching.
-    ///
-    /// On authorization success, the history is loaded with the trigger-owned
-    /// scope. On authorization failure (thread not in any of the caller's
-    /// automation runs), the `original_not_found_error` is returned so the
-    /// response is indistinguishable from a genuinely absent thread.
     /// Resolve a caller-visible thread's history together with the thread scope
     /// it actually lives under.
     ///
@@ -3143,8 +3125,9 @@ impl RebornServices {
     /// it applies the automation-trigger fallback: trigger-fired threads are
     /// stored under the creator's scope, not the WebUI caller's session scope,
     /// so the user-scoped lookup always misses them. If the thread belongs to
-    /// one of the caller's automations (`list_automations` applies the same
-    /// authorization), the history is re-fetched under the trigger-owned scope.
+    /// one of the caller's automations (`resolve_run_thread_scope` performs the
+    /// caller-scoped authorization lookup), the history is re-fetched under the
+    /// trigger-owned scope.
     /// Both `UnknownThread` and `ThreadScopeMismatch` are eligible for the
     /// fallback; backend/serialization errors propagate as-is.
     ///

--- a/crates/ironclaw_webui_v2/src/handlers.rs
+++ b/crates/ironclaw_webui_v2/src/handlers.rs
@@ -158,8 +158,12 @@ pub struct TimelineQuery {
 /// message_id, attachment_id)` triple addresses the attachment; the caller's
 /// authority comes from the authenticated session, and the facade derives the
 /// scope and resolves the storage path server-side. The response sets the
-/// authoritative `Content-Type` from the stored ref plus `nosniff` and a short
-/// private cache so the browser can reuse the bytes without re-fetching.
+/// authoritative `Content-Type` from the stored ref plus `nosniff`, forces
+/// `Content-Disposition: attachment` so a direct navigation can never render
+/// the bytes inline, and a short private cache so the browser can reuse the
+/// bytes without re-fetching. The SPA reads bytes via `fetch` and renders
+/// previews through `data:`/`blob:` URLs, so the attachment disposition is
+/// purely defensive — it does not affect in-app preview.
 pub async fn get_attachment(
     State(state): State<WebUiV2State>,
     Extension(caller): Extension<WebUiAuthenticatedCaller>,
@@ -190,6 +194,14 @@ pub async fn get_attachment(
     headers.insert(
         header::CACHE_CONTROL,
         HeaderValue::from_static("private, max-age=300"),
+    );
+    // Defense-in-depth: force download semantics so a direct navigation to this
+    // endpoint can never execute a mis-classified payload inline. The SPA fetches
+    // bytes via JS and previews them through data:/blob: URLs, so this does not
+    // affect in-app rendering.
+    headers.insert(
+        header::CONTENT_DISPOSITION,
+        HeaderValue::from_static("attachment"),
     );
     Ok((StatusCode::OK, headers, attachment.bytes).into_response())
 }


### PR DESCRIPTION
Follow-up to the merged #4871, addressing CodeRabbit/Copilot review findings that landed after merge.

## Changes
- **`vision_models.rs` (correctness)** — `suggest_vision_model` only prioritized `claude-3`/`claude-4`. As the `VISION_PATTERNS` doc already notes, `claude-4` is *not* a substring of tier-first ids like `claude-opus-4-8` / `claude-sonnet-4-6`, so a current-gen Claude model would lose priority to GPT-4. Added the `claude-{opus,sonnet,haiku,fable}-` prefixes to the priority list.
- **`handlers.rs` (defense-in-depth)** — force `Content-Disposition: attachment` on the attachment bytes endpoint so a direct navigation can never render a mis-classified payload inline. The SPA fetches bytes via JS and previews through `data:`/`blob:` URLs, so in-app preview is unaffected.
- **`loop_support/lib.rs` (doc)** — the host-managed model gateway doc said "text-only model gateway"; it now carries `image_parts`, so corrected to describe multimodal shaping.
- **`reborn_services.rs` (doc)** — removed a stale duplicate "Fallback timeline fetch" docstring left above `resolve_thread_history_for_caller`, and corrected the surviving doc's authorization reference from `list_automations` to `resolve_run_thread_scope` (the actual mechanism).

## Out of scope (intentionally not included)
CodeRabbit's re-review after the rebase also flagged main's pre-existing trace-commons code (`trace_credits`/`authorize_trace_hold` docstrings, `runtime.rs` flush-worker shutdown order) — those are not part of this feature and belong in a separate change. The `AttachmentStorageKey` newtype refactor, `ThreadBackedLoopModelGateway` wiring, and test scope-assertion hardening were also deferred.

## Validation
- `cargo build` — clean across `ironclaw_llm`, `ironclaw_loop_support`, `ironclaw_product_workflow`, and `ironclaw_webui_v2 --features webui-v2-beta`
- `cargo clippy -p ironclaw_webui_v2 --features webui-v2-beta` — no warnings
- `cargo test -p ironclaw_llm vision_models` — 7 passed