### PR TITLE
ci(bench): validate /benchmark suite against benchmarks main, not a stale pin

### DIFF
--- a/.github/workflows/nearai-bench.yml
+++ b/.github/workflows/nearai-bench.yml
@@ -93,11 +93,14 @@ jobs:
           PR: ${{ github.event.issue.number }}
           REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Pinned reviewed commit on nearai/benchmarks main. Must match
-          # the SHA in the `bench` job's `uses:` below — bump in both
-          # places together. Used here to validate the requested suite
-          # exists at the same SHA we'd actually run against.
-          BENCH_PIN: 67effacd8c8a7f6f43b422e30a1810822b9d6d5f
+          # Ref on nearai/benchmarks used to validate the requested suite
+          # exists. Must match the ref the `bench` job actually runs against
+          # (its `uses:` below) so the pre-dispatch check gives the same
+          # answer as the dispatched workflow. That `uses:` is `@main`, so a
+          # pinned SHA here drifts stale and rejects suites that already exist
+          # on main (e.g. pinchbench26, officeqa, terminal-bench-2). Track
+          # `main` so the two stay in lock-step.
+          BENCH_PIN: main
         run: |
           set -euo pipefail
           # Grammar: /benchmark <suite> [--model <model-id>] [--framework <ironclaw|ironclaw-reborn>]


### PR DESCRIPTION
## Problem

`/benchmark pinchbench26 --framework ironclaw-reborn` is rejected with:

> Unknown suite `pinchbench26`. Available: ironclaw, ironclaw-smoke, pinchbench, spot, swe-bench, terminal-bench, trajectory, zclaw-security-chn, zclaw-security-eng

…even though `suites/pinchbench26.toml` is on `nearai/benchmarks` `main` and the run would find it.

## Root cause

The pre-dispatch suite validation in `.github/workflows/nearai-bench.yml` looks up the suite TOML at a hardcoded `BENCH_PIN` SHA:

```
BENCH_PIN: 67effacd8c8a7f6f43b422e30a1810822b9d6d5f
gh api "repos/nearai/benchmarks/contents/suites/${suite}.toml?ref=${BENCH_PIN}"
```

But the `bench` job that actually runs uses `nearai/benchmarks/.github/workflows/bench-pr-reusable.yml@main` — and its own comment says it **intentionally tracks benchmarks `main`**. The pin had drifted behind `main`, so the validation list is stale and rejects suites that already exist there: `pinchbench26`, `officeqa`, `terminal-bench-2`, etc. The check is supposed to "give the same answer the dispatched workflow would" — but it wasn't.

## Fix

Point `BENCH_PIN` at `main` so the validation ref matches the ref we run against. They stay in lock-step, and new suites work the moment they land on benchmarks `main` — no manual pin bump per suite. Same trust boundary the run already accepts (`uses: …@main`), so no new supply-chain delta.

## Verification
- `pinchbench26`, `officeqa`, `terminal-bench-2` (all on benchmarks `main`) now pass the existence check.
- Unknown names still fail and list the current `suites/` contents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)