### PR TITLE
feat(vision): back the vision tool with the provider's real vision model on NEAR AI

### DIFF
--- a/crates/ironclaw_llm/src/lib.rs
+++ b/crates/ironclaw_llm/src/lib.rs
@@ -74,7 +74,9 @@ pub use host::{
     SessionSecrets, SharedSessionDb, SharedSessionKeyPersistor, SharedSessionRenewer,
     SharedSessionSecrets,
 };
-pub use nearai_chat::{DEFAULT_MODEL, ModelInfo, NearAiChatProvider, default_models};
+pub use nearai_chat::{
+    DEFAULT_MODEL, ModelInfo, NearAiChatProvider, default_models, fetch_image_capable_models,
+};
 pub use openai_codex_provider::OpenAiCodexProvider;
 pub use openai_codex_session::{DeviceCodeStart, OpenAiCodexSessionManager};
 pub use provider::sanitize_tool_messages;

--- a/crates/ironclaw_llm/src/nearai_chat.rs
+++ b/crates/ironclaw_llm/src/nearai_chat.rs
@@ -39,6 +39,24 @@ pub struct ModelInfo {
     /// Optional provider name.
     #[serde(default)]
     pub provider: Option<String>,
+    /// Input modalities the endpoint reports this model accepts (e.g.
+    /// `["text", "image"]`), sourced from `metadata.architecture.inputModalities`.
+    /// Empty when the provider does not publish modality metadata — callers must
+    /// treat empty as "unknown", not "text-only".
+    #[serde(default)]
+    pub input_modalities: Vec<String>,
+}
+
+impl ModelInfo {
+    /// Whether the provider's published modality metadata says this model
+    /// accepts image input. Returns `false` when modalities are unknown
+    /// (empty) — the authoritative signal is only present when the endpoint
+    /// reports it, so an unknown model is never assumed vision-capable here.
+    pub fn supports_image_input(&self) -> bool {
+        self.input_modalities
+            .iter()
+            .any(|m| m.eq_ignore_ascii_case("image"))
+    }
 }
 
 /// Parse a NEAR AI `/models` response body into [`ModelInfo`] entries.
@@ -48,11 +66,19 @@ pub struct ModelInfo {
 /// empty vec when no recognizable entries are found.
 fn parse_nearai_models(response_text: &str) -> Vec<ModelInfo> {
     #[derive(Deserialize)]
+    struct ArchitectureInner {
+        #[serde(default, alias = "inputModalities", alias = "input_modalities")]
+        input_modalities: Vec<String>,
+    }
+
+    #[derive(Deserialize)]
     struct ModelMetadataInner {
         #[serde(default)]
         name: Option<String>,
         #[serde(default, alias = "modelName", alias = "model_name")]
         model_name: Option<String>,
+        #[serde(default)]
+        architecture: Option<ArchitectureInner>,
     }
 
     #[derive(Deserialize)]
@@ -119,9 +145,16 @@ fn parse_nearai_models(response_text: &str) -> Vec<ModelInfo> {
             entries
                 .into_iter()
                 .filter_map(|e| {
+                    let input_modalities = e
+                        .metadata
+                        .as_ref()
+                        .and_then(|m| m.architecture.as_ref())
+                        .map(|a| a.input_modalities.clone())
+                        .unwrap_or_default();
                     e.resolve_id().map(|name| ModelInfo {
                         name,
                         provider: None,
+                        input_modalities,
                     })
                 })
                 .collect()
@@ -884,6 +917,61 @@ fn model_cost_to_decimal(mc: &ModelCost) -> Option<Decimal> {
     base.checked_mul(factor)
 }
 
+/// Fetch the ids of vision-capable models the NEAR AI endpoint serves, using
+/// the authoritative per-model modality metadata it publishes
+/// (`metadata.architecture.inputModalities`).
+///
+/// This is the correct signal for "does this endpoint accept image input for
+/// this model" — far more reliable than name heuristics, which both miss models
+/// the endpoint marks vision (e.g. `openai/gpt-4.1`, `Qwen/Qwen3-VL-*`) and
+/// wrongly flag ones it marks text-only (e.g. a `claude-opus-4-6` deployment
+/// whose modalities are `["text"]`). Returns only ids whose modalities include
+/// `image`.
+///
+/// Errors and an absent modality field are non-fatal: an endpoint that does not
+/// publish modalities yields an empty list, and callers should fall back to a
+/// name-based heuristic ([`crate::vision_models`]) in that case.
+pub async fn fetch_image_capable_models(
+    base_url: &str,
+    api_key: &str,
+) -> Result<Vec<String>, LlmError> {
+    let base = base_url.trim_end_matches('/');
+    let url = if base.ends_with("/v1") {
+        format!("{}/model/list", base)
+    } else {
+        format!("{}/v1/model/list", base)
+    };
+
+    let response = Client::new()
+        .get(&url)
+        .header("Authorization", format!("Bearer {}", api_key))
+        .timeout(std::time::Duration::from_secs(15))
+        .send()
+        .await
+        .map_err(|e| LlmError::RequestFailed {
+            provider: "nearai_chat".to_string(),
+            reason: format!("Failed to fetch model list: {}", e),
+        })?;
+
+    if !response.status().is_success() {
+        return Err(LlmError::RequestFailed {
+            provider: "nearai_chat".to_string(),
+            reason: format!("Model list endpoint returned HTTP {}", response.status()),
+        });
+    }
+
+    let body = response.text().await.map_err(|e| LlmError::RequestFailed {
+        provider: "nearai_chat".to_string(),
+        reason: format!("Failed to read model list response: {}", e),
+    })?;
+
+    Ok(parse_nearai_models(&body)
+        .into_iter()
+        .filter(ModelInfo::supports_image_input)
+        .map(|m| m.name)
+        .collect())
+}
+
 /// Fetch pricing from the NEAR AI `/v1/model/list` endpoint.
 ///
 /// Returns a map of model_id → (input_cost_per_token, output_cost_per_token).
@@ -1266,6 +1354,31 @@ mod tests {
         assert!(parse_nearai_models(r#"[{"unknown":"x"}]"#).is_empty());
         assert!(parse_nearai_models("not json").is_empty());
         assert!(parse_nearai_models("").is_empty());
+    }
+
+    #[test]
+    fn parse_models_captures_input_modalities_for_vision_detection() {
+        // Real NEAR AI `/v1/model/list` shape: modality lives under
+        // metadata.architecture.inputModalities. A model with "image" is
+        // vision-capable; a text-only model is not; a model that omits the
+        // field has unknown modality (not assumed vision).
+        let body = r#"{"models":[
+            {"modelId":"anthropic/claude-sonnet-4-6","metadata":{"architecture":{"inputModalities":["text","image"],"outputModalities":["text"]}}},
+            {"modelId":"deepseek/deepseek-v3.2","metadata":{"architecture":{"inputModalities":["text"]}}},
+            {"modelId":"legacy/no-architecture","metadata":{}}
+        ]}"#;
+        let models = parse_nearai_models(body);
+        let by_name = |name: &str| models.iter().find(|m| m.name == name).unwrap();
+
+        assert!(by_name("anthropic/claude-sonnet-4-6").supports_image_input());
+        assert!(!by_name("deepseek/deepseek-v3.2").supports_image_input());
+        // Unknown modality must not be assumed vision-capable.
+        assert!(!by_name("legacy/no-architecture").supports_image_input());
+        assert!(
+            by_name("legacy/no-architecture")
+                .input_modalities
+                .is_empty()
+        );
     }
 
     fn test_nearai_config(base_url: &str) -> NearAiConfig {
@@ -2342,6 +2455,7 @@ mod tests {
         let info = ModelInfo {
             name: "test-model".to_string(),
             provider: Some("nearai".to_string()),
+            input_modalities: Vec::new(),
         };
         let json = serde_json::to_value(&info).unwrap();
         // Serialization always uses the field name "name", not the aliases

--- a/crates/ironclaw_llm/src/vision_models.rs
+++ b/crates/ironclaw_llm/src/vision_models.rs
@@ -67,6 +67,48 @@ pub fn suggest_vision_model(models: &[String]) -> Option<&str> {
     })
 }
 
+/// Choose the model to back the vision (image-analysis) tool, given the
+/// configured chat model and the set of models the provider reports as
+/// image-capable via its authoritative modality metadata (see
+/// [`crate::fetch_image_capable_models`]).
+///
+/// Unlike [`suggest_vision_model`], this never relies on name heuristics to
+/// decide *capability* — `image_capable` is already the verified vision set.
+/// Name matching is used only to rank *quality* among that set. Policy:
+///
+/// 1. Prefer the configured model if it is itself image-capable — keeps the
+///    vision tool on the same model as the chat loop with no surprise routing.
+/// 2. Otherwise pick the highest-quality available model by family preference
+///    (Claude > GPT > Gemini > Qwen > anything else), matched case-insensitively
+///    as a substring so provider-prefixed ids (`anthropic/claude-sonnet-4-6`)
+///    and bare ids both work.
+/// 3. Otherwise fall back to the first image-capable model offered.
+///
+/// Returns `None` only when `image_capable` is empty, leaving the caller to use
+/// its own name-heuristic fallback.
+pub fn choose_vision_model<'a>(
+    configured: &'a str,
+    image_capable: &'a [String],
+) -> Option<&'a str> {
+    if image_capable.is_empty() {
+        return None;
+    }
+    let cfg = configured.to_lowercase();
+    if image_capable.iter().any(|m| m.to_lowercase() == cfg) {
+        return Some(configured);
+    }
+    const FAMILY_PREFERENCE: &[&str] = &["claude", "gpt-5", "gpt-4", "gemini", "qwen"];
+    for family in FAMILY_PREFERENCE {
+        if let Some(model) = image_capable
+            .iter()
+            .find(|m| m.to_lowercase().contains(family))
+        {
+            return Some(model.as_str());
+        }
+    }
+    image_capable.first().map(String::as_str)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -134,5 +176,49 @@ mod tests {
     fn returns_none_when_no_vision_models() {
         let models = vec!["gpt-3.5-turbo".to_string(), "llama-3.1-70b".to_string()];
         assert_eq!(suggest_vision_model(&models), None);
+    }
+
+    fn strings(v: &[&str]) -> Vec<String> {
+        v.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn choose_prefers_configured_model_when_image_capable() {
+        let capable = strings(&["anthropic/claude-sonnet-4-6", "openai/gpt-4.1"]);
+        assert_eq!(
+            choose_vision_model("openai/gpt-4.1", &capable),
+            Some("openai/gpt-4.1")
+        );
+    }
+
+    #[test]
+    fn choose_falls_back_to_best_family_when_configured_is_text_only() {
+        // Configured model (deepseek) is not in the image-capable set; Claude
+        // outranks the GPT/Gemini alternatives.
+        let capable = strings(&[
+            "openai/gpt-4.1",
+            "anthropic/claude-sonnet-4-6",
+            "google/gemini-2.5-pro",
+        ]);
+        assert_eq!(
+            choose_vision_model("deepseek/deepseek-v3.2", &capable),
+            Some("anthropic/claude-sonnet-4-6")
+        );
+    }
+
+    #[test]
+    fn choose_returns_first_capable_when_no_family_matches() {
+        // A vision model the family-preference list does not name (e.g. a
+        // VL model) is still returned rather than dropped.
+        let capable = strings(&["Qwen/Qwen3-VL-30B-A3B-Instruct"]);
+        assert_eq!(
+            choose_vision_model("deepseek/deepseek-v3.2", &capable),
+            Some("Qwen/Qwen3-VL-30B-A3B-Instruct")
+        );
+    }
+
+    #[test]
+    fn choose_returns_none_for_empty_capable_set() {
+        assert_eq!(choose_vision_model("anything", &[]), None);
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -673,10 +673,44 @@ impl AppBuilder {
                     .to_string();
                 tools.register_image_tools(api_base.clone(), api_key.clone(), gen_model, None);
 
-                // Check for vision models
-                let vision_model = ironclaw_llm::vision_models::suggest_vision_model(&models)
-                    .unwrap_or(&model_name)
-                    .to_string();
+                // Check for vision models. Prefer the provider's authoritative
+                // per-model modality metadata (NEAR AI publishes
+                // `inputModalities` on `/v1/model/list`) so the vision tool is
+                // backed by a real image-capable model even when the configured
+                // chat model is text-only. Only the NEAR AI path (no explicit
+                // `provider` override) speaks that endpoint shape; everything
+                // else falls back to the name heuristic. The fetch is
+                // best-effort — any error degrades to the heuristic.
+                let use_modality_metadata = self.config.llm.provider.is_none();
+                let mut vision_model: Option<String> = None;
+                if use_modality_metadata {
+                    match ironclaw_llm::fetch_image_capable_models(&api_base, &api_key).await {
+                        Ok(capable) => {
+                            vision_model = ironclaw_llm::vision_models::choose_vision_model(
+                                &model_name,
+                                &capable,
+                            )
+                            .map(str::to_string);
+                            if vision_model.is_none() {
+                                tracing::debug!(
+                                    "Model list reported no image-capable models; \
+                                     falling back to name heuristic for vision tool"
+                                );
+                            }
+                        }
+                        Err(e) => tracing::debug!(
+                            error = %e,
+                            "Could not fetch model modality metadata; \
+                             falling back to name heuristic for vision tool"
+                        ),
+                    }
+                }
+                let vision_model = vision_model.unwrap_or_else(|| {
+                    ironclaw_llm::vision_models::suggest_vision_model(&models)
+                        .unwrap_or(&model_name)
+                        .to_string()
+                });
+                tracing::debug!(vision_model = %vision_model, "Registering vision tool model");
                 tools.register_vision_tools(api_base, api_key, vision_model, None);
             }
         }


### PR DESCRIPTION
## Problem

The vision (image-analysis) tool is registered with the single **configured chat model**:

```rust
let models = vec![model_name.clone()];
let vision_model = suggest_vision_model(&models).unwrap_or(&model_name).to_string();
```

So if your configured NEAR AI model is text-only (e.g. `deepseek-v3.2`), the vision tool gets wired to a model that **cannot accept images**. (The image-gen tool right above doesn't have this problem — it falls back to a known-good model, `FLUX.2-klein-4B`.)

Separately, the name-based `VISION_PATTERNS` heuristic is unreliable for NEAR AI. Checked against the **46 models the endpoint actually serves**, the substring heuristic disagrees with the API's authoritative modality metadata **15 times**:

- **Misses real vision models:** the entire `openai/gpt-4.1`/`gpt-5`/`o3`/`o4-mini` family, `Qwen3-VL`, `gemini-3.5-flash`, `gemma-4`, `kimi-k2.6`.
- **Wrongly claims vision:** a `claude-opus-4-6` deployment and `gemini-2.5-flash-lite` that the endpoint reports as **text-only** — matching them would push images at a model that rejects them.

## Fix

Use the provider's own per-model modality metadata (`metadata.architecture.inputModalities`) instead of guessing from names.

- **`nearai_chat.rs`** — capture `inputModalities` into `ModelInfo` (+ `supports_image_input()`); add `fetch_image_capable_models(base_url, api_key)` returning the ids the endpoint marks image-capable.
- **`vision_models.rs`** — add `choose_vision_model(configured, image_capable)`: prefer the configured model if it's itself image-capable, else best-available by family (Claude > GPT > Gemini > Qwen > other), else the first capable one. (Pure + unit-tested.)
- **`app.rs`** — on the NEAR AI path, pick the vision-tool model from the verified image-capable set; fall back to the existing name heuristic on any fetch error or for non-NEAR-AI providers.

Heuristic-only providers (OpenAI-direct, Bedrock, Ollama, `openai_compatible`) are unchanged — they don't publish this metadata, so they keep using `VISION_PATTERNS`.

## Notes / tradeoffs
- The fetch is one best-effort HTTP call at tool-registration time; any error degrades silently to the prior behavior.
- The fallback selection requires a model the account is entitled to — same assumption the existing image-gen FLUX fallback already makes.
- Only the NEAR AI config path (no explicit `provider` override) speaks the `/v1/model/list` shape, so the metadata path is gated to it.

## Validation
- `cargo build -p ironclaw_llm` and `cargo build --bin ironclaw` — clean
- `cargo clippy -p ironclaw_llm --tests` and `cargo clippy --bin ironclaw` — no warnings
- New tests: `choose_vision_model` (4 cases) + `parse_models_captures_input_modalities_for_vision_detection`; full `vision_models` suite 11/11

## Context
Follow-up from review discussion on the merged #4871. Independent of #4945 (the post-merge review fixes).