### PR TITLE
fix(reborn): gate triggered Slack OAuth URL on a verified personal DM

### DIFF
--- a/crates/ironclaw_product_workflow/src/error.rs
+++ b/crates/ironclaw_product_workflow/src/error.rs
@@ -340,4 +340,22 @@ mod tests {
             }
         }
     }
+
+    #[test]
+    fn outbound_target_not_direct_message_maps_to_workflow_rejected() {
+        let err: ProductAdapterError = ProductWorkflowError::OutboundTargetNotDirectMessage.into();
+        match err {
+            ProductAdapterError::WorkflowRejected {
+                kind,
+                status_code,
+                retryable,
+                ..
+            } => {
+                assert_eq!(kind, ProductWorkflowRejectionKind::Unauthorized);
+                assert_eq!(status_code, 403);
+                assert!(!retryable);
+            }
+            other => panic!("expected typed workflow rejection, got {other:?}"),
+        }
+    }
 }

--- a/crates/ironclaw_product_workflow/src/error.rs
+++ b/crates/ironclaw_product_workflow/src/error.rs
@@ -111,6 +111,11 @@ pub enum ProductWorkflowError {
     /// The requested action kind is not supported by this workflow version.
     #[error("unsupported action kind: {kind}")]
     UnsupportedActionKind { kind: String },
+
+    /// The resolved outbound target is not a direct message, but the payload
+    /// requires a DM-only target (e.g. carries an OAuth authorization_url).
+    #[error("outbound target is not a direct message but the payload requires one")]
+    OutboundTargetNotDirectMessage,
 }
 
 fn workflow_rejection_kind(category: TurnErrorCategory) -> ProductWorkflowRejectionKind {
@@ -238,6 +243,16 @@ impl From<ProductWorkflowError> for ProductAdapterError {
             ProductWorkflowError::UnsupportedActionKind { kind } => ProductAdapterError::Internal {
                 detail: RedactedString::new(format!("unsupported action kind: {kind}")),
             },
+            ProductWorkflowError::OutboundTargetNotDirectMessage => {
+                ProductAdapterError::WorkflowRejected {
+                    kind: ProductWorkflowRejectionKind::Unauthorized,
+                    status_code: 403,
+                    retryable: false,
+                    reason: RedactedString::new(
+                        "outbound target is not a direct message but the payload requires one",
+                    ),
+                }
+            }
         }
     }
 }

--- a/crates/ironclaw_product_workflow/src/outbound_delivery.rs
+++ b/crates/ironclaw_product_workflow/src/outbound_delivery.rs
@@ -31,9 +31,14 @@ pub trait ProductOutboundTargetResolver: Send + Sync {
     ///
     /// Implementations must use a trusted conversation-binding lookup keyed by
     /// the sealed target. They must not choose or substitute a reply target.
+    ///
+    /// When `require_direct_message` is true, implementations must return
+    /// [`ProductWorkflowError::OutboundTargetNotDirectMessage`] if the resolved
+    /// target is not a personal direct message.
     async fn resolve_product_outbound_target_metadata(
         &self,
         target: &ValidatedReplyTargetBinding,
+        require_direct_message: bool,
     ) -> Result<VerifiedProductOutboundTargetMetadata, ProductWorkflowError>;
 }
 
@@ -45,6 +50,11 @@ pub struct ProductOutboundDeliveryRequest<'a> {
     pub adapter: &'a dyn ProductAdapter,
     pub egress: &'a dyn ProtocolHttpEgress,
     pub delivery_sink: &'a dyn OutboundDeliverySink,
+    /// When true, the target resolver must enforce that the resolved outbound
+    /// target is a personal direct message. Payloads carrying an OAuth
+    /// `authorization_url` must set this to `true` to prevent the URL from
+    /// being delivered to a shared channel.
+    pub require_direct_message_target: bool,
 }
 
 /// Non-fatal failure while recording a post-render delivery status.
@@ -113,6 +123,7 @@ pub async fn prepare_and_render_product_outbound(
 ) -> Result<ProductOutboundDeliveryOutcome, ProductOutboundDeliveryError> {
     let delivery_kind = OutboundPushKind::from(request.delivery.resolution_request.delivery_kind());
     let payload_kind = outbound_push_kind_for_payload(&request.payload);
+    let require_direct_message = request.require_direct_message_target;
 
     let Some(decision) = outbound_policy
         .prepare_communication_delivery_attempt(request.delivery, communication_preferences)
@@ -139,7 +150,7 @@ pub async fn prepare_and_render_product_outbound(
     }
 
     let metadata = match target_resolver
-        .resolve_product_outbound_target_metadata(&target)
+        .resolve_product_outbound_target_metadata(&target, require_direct_message)
         .await
     {
         Ok(metadata) => metadata,

--- a/crates/ironclaw_product_workflow/src/outbound_delivery.rs
+++ b/crates/ironclaw_product_workflow/src/outbound_delivery.rs
@@ -297,7 +297,8 @@ fn delivery_failure_kind_for_workflow_error(error: &ProductWorkflowError) -> Del
         ProductWorkflowError::BindingAccessDenied
         | ProductWorkflowError::BindingRequired { .. }
         | ProductWorkflowError::UnknownInstallation
-        | ProductWorkflowError::InvalidBindingRequest { .. } => DeliveryFailureKind::Rejected,
+        | ProductWorkflowError::InvalidBindingRequest { .. }
+        | ProductWorkflowError::OutboundTargetNotDirectMessage => DeliveryFailureKind::Rejected,
         _ => DeliveryFailureKind::Unknown,
     }
 }

--- a/crates/ironclaw_product_workflow/src/reborn_services/lifecycle_setup.rs
+++ b/crates/ironclaw_product_workflow/src/reborn_services/lifecycle_setup.rs
@@ -149,6 +149,7 @@ pub(super) fn map_lifecycle_error(error: ProductWorkflowError) -> RebornServices
         | ProductWorkflowError::AuthContinuationRejected { .. }
         | ProductWorkflowError::BeforeInboundPolicyFailed { .. }
         | ProductWorkflowError::DuplicateAction { .. }
+        | ProductWorkflowError::OutboundTargetNotDirectMessage
         | ProductWorkflowError::UnknownInstallation => RebornServicesError::internal_invariant(),
     }
 }

--- a/crates/ironclaw_product_workflow/src/workflow.rs
+++ b/crates/ironclaw_product_workflow/src/workflow.rs
@@ -1832,6 +1832,13 @@ mod tests {
     }
 
     #[test]
+    fn terminal_ack_for_error_keeps_outbound_target_not_direct_message_unsettled() {
+        assert!(
+            terminal_ack_for_error(&ProductWorkflowError::OutboundTargetNotDirectMessage).is_none()
+        );
+    }
+
+    #[test]
     fn terminal_success_ack_excludes_deferred_busy() {
         assert!(should_settle_ack(&ProductInboundAck::NoOp));
         assert!(!should_settle_ack(&ProductInboundAck::DeferredBusy {

--- a/crates/ironclaw_product_workflow/src/workflow.rs
+++ b/crates/ironclaw_product_workflow/src/workflow.rs
@@ -1601,6 +1601,7 @@ fn terminal_ack_for_error(error: &ProductWorkflowError) -> Option<ProductInbound
         | ProductWorkflowError::BeforeInboundPolicyFailed {
             permanent: false, ..
         }
+        | ProductWorkflowError::OutboundTargetNotDirectMessage
         | ProductWorkflowError::DuplicateAction { .. } => None,
     }
 }

--- a/crates/ironclaw_product_workflow/tests/outbound_delivery_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/outbound_delivery_contract.rs
@@ -220,6 +220,7 @@ impl ProductOutboundTargetResolver for FakeProductOutboundTargetResolver {
     async fn resolve_product_outbound_target_metadata(
         &self,
         target: &ironclaw_outbound::ValidatedReplyTargetBinding,
+        _require_direct_message: bool,
     ) -> Result<VerifiedProductOutboundTargetMetadata, ProductWorkflowError> {
         self.calls
             .lock()
@@ -700,6 +701,7 @@ async fn authorized_final_reply_renders_through_telegram_egress_after_validation
             adapter: &adapter,
             egress: &egress,
             delivery_sink: &sink,
+            require_direct_message_target: false,
         },
     )
     .await
@@ -770,6 +772,7 @@ async fn synchronous_response_marks_attempt_delivered() {
             adapter: &adapter,
             egress: &egress,
             delivery_sink: &sink,
+            require_direct_message_target: false,
         },
     )
     .await
@@ -816,6 +819,7 @@ async fn deferred_render_keeps_attempt_pending_and_skips_delivery_status_side_ef
             adapter: &adapter,
             egress: &egress,
             delivery_sink: &sink,
+            require_direct_message_target: false,
         },
     )
     .await
@@ -867,6 +871,7 @@ async fn status_update_failure_after_render_does_not_turn_send_into_failure() {
             adapter: &adapter,
             egress: &egress,
             delivery_sink: &sink,
+            require_direct_message_target: false,
         },
     )
     .await
@@ -944,6 +949,7 @@ async fn requested_outbound_preserves_actor_and_modality_before_rendering() {
             adapter: &adapter,
             egress: &egress,
             delivery_sink: &sink,
+            require_direct_message_target: false,
         },
     )
     .await
@@ -998,6 +1004,7 @@ async fn mismatched_payload_kind_marks_authorized_attempt_failed_without_render(
             adapter: &adapter,
             egress: &egress,
             delivery_sink: &sink,
+            require_direct_message_target: false,
         },
     )
     .await
@@ -1056,6 +1063,7 @@ async fn payload_kind_mismatch_preserves_status_update_failure() {
             adapter: &adapter,
             egress: &egress,
             delivery_sink: &sink,
+            require_direct_message_target: false,
         },
     )
     .await
@@ -1125,6 +1133,7 @@ async fn target_metadata_failure_with_status_update_failure_preserves_workflow_e
             adapter: &adapter,
             egress: &egress,
             delivery_sink: &sink,
+            require_direct_message_target: false,
         },
     )
     .await
@@ -1192,6 +1201,7 @@ async fn target_metadata_failure_marks_attempt_failed_without_render() {
             adapter: &adapter,
             egress: &egress,
             delivery_sink: &sink,
+            require_direct_message_target: false,
         },
     )
     .await
@@ -1262,6 +1272,7 @@ async fn target_metadata_rejection_errors_mark_attempt_failed_rejected() {
                 adapter: &adapter,
                 egress: &egress,
                 delivery_sink: &sink,
+                require_direct_message_target: false,
             },
         )
         .await
@@ -1322,6 +1333,7 @@ async fn keep_alive_payload_marks_authorized_attempt_failed_without_render() {
             adapter: &adapter,
             egress: &egress,
             delivery_sink: &sink,
+            require_direct_message_target: false,
         },
     )
     .await
@@ -1381,6 +1393,7 @@ async fn adapter_render_failure_is_returned_and_marks_attempt_failed() {
             adapter: &adapter,
             egress: &egress,
             delivery_sink: &sink,
+            require_direct_message_target: false,
         },
     )
     .await
@@ -1462,6 +1475,7 @@ async fn adapter_non_retryable_errors_mark_attempt_failed_rejected() {
                 adapter: &adapter,
                 egress: &egress,
                 delivery_sink: &sink,
+                require_direct_message_target: false,
             },
         )
         .await
@@ -1524,6 +1538,7 @@ async fn adapter_render_failure_preserves_adapter_error_when_status_update_fails
             adapter: &adapter,
             egress: &egress,
             delivery_sink: &sink,
+            require_direct_message_target: false,
         },
     )
     .await
@@ -1584,6 +1599,7 @@ async fn revoked_or_rejected_target_does_not_call_render_or_egress() {
             adapter: &adapter,
             egress: &egress,
             delivery_sink: &sink,
+            require_direct_message_target: false,
         },
     )
     .await
@@ -1629,6 +1645,7 @@ async fn no_delivery_system_event_does_not_call_render_or_egress() {
             adapter: &adapter,
             egress: &egress,
             delivery_sink: &sink,
+            require_direct_message_target: false,
         },
     )
     .await

--- a/crates/ironclaw_product_workflow/tests/outbound_delivery_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/outbound_delivery_contract.rs
@@ -245,6 +245,44 @@ impl ProductOutboundTargetResolver for FakeProductOutboundTargetResolver {
     }
 }
 
+/// A resolver that returns `OutboundTargetNotDirectMessage` when
+/// `require_direct_message == true`, and succeeds otherwise.  Used to verify
+/// that the `require_direct_message_target` flag threads from the delivery
+/// request all the way through to the resolver and produces the right
+/// `DeliveryFailureKind::Rejected` audit classification.
+#[derive(Default)]
+struct DmRequiringFakeProductOutboundTargetResolver {
+    calls: Mutex<Vec<(ReplyTargetBindingRef, bool)>>,
+}
+
+impl DmRequiringFakeProductOutboundTargetResolver {
+    fn calls(&self) -> Vec<(ReplyTargetBindingRef, bool)> {
+        self.calls.lock().expect("dm resolver lock").clone()
+    }
+}
+
+#[async_trait]
+impl ProductOutboundTargetResolver for DmRequiringFakeProductOutboundTargetResolver {
+    async fn resolve_product_outbound_target_metadata(
+        &self,
+        target: &ironclaw_outbound::ValidatedReplyTargetBinding,
+        require_direct_message: bool,
+    ) -> Result<VerifiedProductOutboundTargetMetadata, ProductWorkflowError> {
+        self.calls
+            .lock()
+            .expect("dm resolver lock")
+            .push((target.target().clone(), require_direct_message));
+        if require_direct_message {
+            return Err(ProductWorkflowError::OutboundTargetNotDirectMessage);
+        }
+        Ok(VerifiedProductOutboundTargetMetadata {
+            external_conversation_ref: ExternalConversationRef::new(None, "tg-chat-dm", None, None)
+                .expect("valid external conversation"),
+            external_actor_ref: None,
+        })
+    }
+}
+
 #[derive(Default)]
 struct StatusFailingOutboundStore {
     inner: InMemoryOutboundStateStore,
@@ -1666,5 +1704,124 @@ async fn no_delivery_system_event_does_not_call_render_or_egress() {
             .await
             .unwrap()
             .is_empty()
+    );
+}
+
+// ── require_direct_message_target flag threading ──────────────────────────────
+//
+// Verify that the flag is forwarded to the resolver and that a resolver
+// returning `OutboundTargetNotDirectMessage` maps to `Rejected` in the audit
+// trail (Fix 1 + Fix 5 contract).
+
+#[tokio::test]
+async fn require_direct_message_true_propagates_to_resolver_and_maps_to_rejected() {
+    let scope = scope();
+    let store = InMemoryOutboundStateStore::default();
+    let validator = FakeReplyTargetBindingValidator::default();
+    validator.allow(validated_reply_target());
+    let preferences = FakePreferenceRepository::default();
+    seed_preference(&preferences, &scope);
+    let resolver = DmRequiringFakeProductOutboundTargetResolver::default();
+    let policy = configured_policy(&store, &validator);
+    let adapter = telegram_adapter();
+    let egress = FakeProtocolHttpEgress::new(["api.telegram.org".to_string()]);
+    let sink = FakeOutboundDeliverySink::new();
+
+    let err = prepare_and_render_product_outbound(
+        &policy,
+        &preferences,
+        &resolver,
+        ProductOutboundDeliveryRequest {
+            delivery: delivery_request(scope.clone()),
+            payload: final_reply_payload(),
+            projection_cursor: ProjectionCursor::new("cursor:dm-required-true")
+                .expect("valid cursor"),
+            adapter: &adapter,
+            egress: &egress,
+            delivery_sink: &sink,
+            require_direct_message_target: true,
+        },
+    )
+    .await
+    .expect_err("require_direct_message=true with non-DM resolver must fail");
+
+    // The error must be Workflow { source: OutboundTargetNotDirectMessage }.
+    assert!(
+        matches!(
+            err,
+            ironclaw_product_workflow::ProductOutboundDeliveryError::Workflow {
+                source: ProductWorkflowError::OutboundTargetNotDirectMessage,
+                status_update_error: None,
+                ..
+            }
+        ),
+        "unexpected error: {err:?}"
+    );
+    // The flag must have been forwarded to the resolver.
+    let calls = resolver.calls();
+    assert_eq!(calls.len(), 1);
+    assert!(
+        calls[0].1,
+        "require_direct_message must be true at resolver"
+    );
+    // Audit trail must record Rejected (not Unknown).
+    let attempts = store.list_delivery_attempts(scope).await.unwrap();
+    assert_eq!(attempts.len(), 1);
+    assert_eq!(
+        attempts[0].failure_kind,
+        Some(ironclaw_outbound::DeliveryFailureKind::Rejected),
+        "OutboundTargetNotDirectMessage must map to Rejected, not Unknown"
+    );
+}
+
+#[tokio::test]
+async fn require_direct_message_false_does_not_trigger_dm_rejection() {
+    let scope = scope();
+    let store = InMemoryOutboundStateStore::default();
+    let validator = FakeReplyTargetBindingValidator::default();
+    validator.allow(validated_reply_target());
+    let preferences = FakePreferenceRepository::default();
+    seed_preference(&preferences, &scope);
+    let resolver = DmRequiringFakeProductOutboundTargetResolver::default();
+    let policy = configured_policy(&store, &validator);
+    let adapter = telegram_adapter();
+    let egress = FakeProtocolHttpEgress::new(["api.telegram.org".to_string()]);
+    egress.allow_credential_handle("telegram_bot_token");
+    let sink = FakeOutboundDeliverySink::new();
+
+    let outcome = prepare_and_render_product_outbound(
+        &policy,
+        &preferences,
+        &resolver,
+        ProductOutboundDeliveryRequest {
+            delivery: delivery_request(scope.clone()),
+            payload: final_reply_payload(),
+            projection_cursor: ProjectionCursor::new("cursor:dm-required-false")
+                .expect("valid cursor"),
+            adapter: &adapter,
+            egress: &egress,
+            delivery_sink: &sink,
+            require_direct_message_target: false,
+        },
+    )
+    .await
+    .expect("require_direct_message=false must not trigger DM rejection");
+
+    assert!(
+        matches!(outcome, ProductOutboundDeliveryOutcome::Rendered { .. }),
+        "unexpected outcome: {outcome:?}"
+    );
+    // Flag must have been forwarded as false.
+    let calls = resolver.calls();
+    assert_eq!(calls.len(), 1);
+    assert!(
+        !calls[0].1,
+        "require_direct_message must be false at resolver"
+    );
+    let attempts = store.list_delivery_attempts(scope).await.unwrap();
+    assert_eq!(attempts.len(), 1);
+    assert_eq!(
+        attempts[0].status,
+        ironclaw_outbound::OutboundDeliveryStatus::Delivered
     );
 }

--- a/crates/ironclaw_reborn_composition/src/slack_delivery.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_delivery.rs
@@ -1969,7 +1969,6 @@ async fn deliver_triggered_run(
     // Use the scope's agent_id when present; otherwise fall back to the configured
     // fallback_agent_id — the same value record_trigger_prompt uses — so the key
     // matches the thread that was stored at submit time.
-    let _thread_id = scope.thread_id.clone();
     let thread_scope = ThreadScope {
         tenant_id: scope.tenant_id.clone(),
         agent_id: scope
@@ -2109,7 +2108,13 @@ async fn deliver_triggered_run(
                     )
                     .await;
                 }
-                if let Some(marker) = next_blocked_marker {
+                if let Some(marker) = next_blocked_marker
+                    && matches!(
+                        event_kind,
+                        RunNotificationEventKind::ApprovalNeeded
+                            | RunNotificationEventKind::AuthRequired
+                    )
+                {
                     if event_kind == RunNotificationEventKind::AuthRequired {
                         messages_to_delete_after_final.extend(posted_messages);
                     }
@@ -2928,6 +2933,9 @@ mod tests {
         scope_not_found: bool,
         calls: Mutex<usize>,
         cancel_calls: Mutex<Vec<TurnRunId>>,
+        /// When set, `cancel_run` returns `Err(TurnError::Unavailable)` instead of
+        /// the normal success response. Used to test the OAuth backstop cancel-failure path.
+        cancel_should_fail: std::sync::atomic::AtomicBool,
     }
 
     impl ScriptedTurnCoordinator {
@@ -2938,6 +2946,7 @@ mod tests {
                 scope_not_found: false,
                 calls: Mutex::new(0),
                 cancel_calls: Mutex::new(Vec::new()),
+                cancel_should_fail: std::sync::atomic::AtomicBool::new(false),
             }
         }
 
@@ -3052,6 +3061,14 @@ mod tests {
                 .lock()
                 .expect("cancel calls lock")
                 .push(request.run_id);
+            if self
+                .cancel_should_fail
+                .load(std::sync::atomic::Ordering::Acquire)
+            {
+                return Err(TurnError::Unavailable {
+                    reason: "ScriptedTurnCoordinator: cancel_should_fail is set".to_string(),
+                });
+            }
             Ok(ironclaw_turns::CancelRunResponse {
                 run_id: request.run_id,
                 status: TurnStatus::Cancelled,
@@ -5795,6 +5812,223 @@ mod tests {
                 .iter()
                 .any(|b| b.contains(SLACK_AUTH_UNAVAILABLE_MESSAGE)),
             "expected the auth-unavailable notice to be posted; got: {posted:?}"
+        );
+    }
+
+    // ── BUG1 regression + OAuth backstop cancel-failure tests ─────────────────
+    //
+    // BUG1: when a triggered run reaches BlockedAuth with a non-OAuth challenge,
+    // `triggered_notification_for_state` cancels the run inline and returns a
+    // terminal FinalReplyReady notification. The delivery loop previously treated
+    // any Some(next_blocked_marker) as "still waiting", causing the loop to
+    // continue after a successful terminal delivery, read the now-Cancelled run
+    // state, hit Ok(None), and record Skipped instead of Delivered.
+
+    /// BUG1 regression: a triggered run that hits BlockedAuth with a non-OAuth
+    /// challenge (no authorization_url) must record `Delivered` — NOT `Skipped`.
+    ///
+    /// The non-OAuth deny branch in `triggered_notification_for_state` cancels the
+    /// run inline and returns a terminal `FinalReplyReady` notification. After the
+    /// notice is successfully posted, the delivery loop must fall through to the
+    /// terminal `Delivered` path rather than looping back and seeing the now-Cancelled
+    /// run as `Ok(None)` → `Skipped`.
+    #[tokio::test]
+    async fn triggered_non_oauth_auth_denial_records_delivered() {
+        let install = "test-install";
+        let gate_ref_str = "gate:non-oauth-denial-delivered";
+        let scope = personal_turn_scope();
+        let run_id = TurnRunId::new();
+        let binding_ref =
+            test_slack_binding_ref(install, scope.agent_id.as_ref().expect("agent").as_str());
+
+        // First poll → BlockedAuth (non-OAuth: no auth_challenges wired, so no
+        // authorization_url → deny branch fires inline cancel + FinalReplyReady).
+        // Second poll → Cancelled (terminal, no finalized message → Ok(None)).
+        // Without the BUG1 fix the loop continues to the second poll and records
+        // Skipped. With the fix, after the FinalReplyReady delivery the loop
+        // falls through to Delivered without polling again.
+        let coordinator = Arc::new(ScriptedTurnCoordinator::with_states(vec![
+            scripted_state(TurnStatus::BlockedAuth, Some(gate_ref_str)),
+            scripted_state(TurnStatus::Cancelled, None),
+        ]));
+        // No finalized assistant message needed: the terminal delivery is the
+        // auth-unavailable notice, not a Completed assistant reply.
+
+        let outbound = Arc::new(InMemoryOutboundStateStore::default());
+        seed_personal_preference(&outbound, &scope, binding_ref).await;
+
+        let egress = Arc::new(FakeProtocolHttpEgress::new(vec!["slack.com".to_string()]));
+        egress.allow_credential_handle("slack_bot_token");
+        // One postMessage for the auth-unavailable notice.
+        egress.program_response(
+            "slack.com",
+            Ok(EgressResponse::new(
+                200,
+                slack_post_ok_json("D456", "bug1.1"),
+            )),
+        );
+
+        let delivery_store = Arc::new(InMemoryTriggeredRunDeliveryStore::default());
+        let route_store = Arc::new(InMemoryDeliveredGateRouteStore::default());
+        let services = make_services(
+            coordinator.clone(),
+            Arc::new(InMemorySessionThreadService::default()),
+            egress.clone(),
+            outbound,
+            install,
+        );
+        let settings = SlackFinalReplyDeliverySettings {
+            poll_interval: std::time::Duration::ZERO,
+            max_wait: std::time::Duration::from_secs(5),
+            max_concurrent_deliveries: NonZeroUsize::new(1).unwrap(),
+            max_pending_deliveries: NonZeroUsize::new(8).unwrap(),
+        };
+        let driver = TriggeredRunDeliveryDriver::with_settings(
+            services,
+            settings,
+            delivery_store.clone(),
+            route_store.clone(),
+            scope.agent_id.clone().expect("test scope has agent"),
+        );
+
+        let fire = minimal_trigger_fire(None);
+        driver
+            .on_trigger_submitted(fire, run_id, scope.clone())
+            .await;
+        let record = wait_for_delivery_record(&delivery_store, run_id).await;
+
+        // BUG1 regression: outcome must be Delivered, not Skipped.
+        assert_eq!(
+            record.outcome,
+            TriggeredRunDeliveryOutcomeKind::Delivered,
+            "non-OAuth auth denial must record Delivered (not Skipped); got: {:?}",
+            record.outcome
+        );
+
+        // The auth-unavailable notice must have been posted.
+        let posted: Vec<String> = egress
+            .calls()
+            .iter()
+            .filter(|c| c.path == "/api/chat.postMessage")
+            .map(|c| String::from_utf8_lossy(&c.body).to_string())
+            .collect();
+        assert!(
+            posted
+                .iter()
+                .any(|b| b.contains(SLACK_AUTH_UNAVAILABLE_MESSAGE)),
+            "auth-unavailable notice must be posted; got: {posted:?}"
+        );
+
+        // cancel_run was called exactly once (inline by triggered_notification_for_state).
+        assert_eq!(
+            coordinator.cancel_call_count(),
+            1,
+            "cancel_run must be called exactly once for non-OAuth auth denial"
+        );
+    }
+
+    /// OAuth backstop cancel-failure path: when `cancel_auth_blocked_run` fails in
+    /// the `OAuthTargetNotDm` error arm, the outcome must be `Failed` and NO
+    /// `/api/chat.delete` calls must be made (we must not strip the auth prompt
+    /// while the run may still be live).
+    #[tokio::test]
+    async fn triggered_oauth_auth_backstop_cancel_failure_records_failed() {
+        let install = "test-install";
+        let gate_ref_str = "gate:oauth-backstop-cancel-fail";
+        let scope = personal_turn_scope();
+        let run_id = TurnRunId::new();
+
+        // Use a SHARED CHANNEL binding ref so the OAuth backstop trips.
+        let binding_ref = test_slack_shared_channel_binding_ref(
+            install,
+            scope.agent_id.as_ref().expect("agent").as_str(),
+        );
+
+        // First poll → BlockedAuth; second poll is never reached because the
+        // cancel fails and we return Failed immediately.
+        let coordinator = Arc::new(ScriptedTurnCoordinator::with_states(vec![scripted_state(
+            TurnStatus::BlockedAuth,
+            Some(gate_ref_str),
+        )]));
+        // Make cancel_run fail so the OAuthTargetNotDm backstop arm returns Failed.
+        coordinator
+            .cancel_should_fail
+            .store(true, std::sync::atomic::Ordering::Release);
+
+        let outbound = Arc::new(InMemoryOutboundStateStore::default());
+        // Seed preference with the shared-channel binding so the OAuth guard trips.
+        seed_personal_preference(&outbound, &scope, binding_ref).await;
+
+        let egress = Arc::new(FakeProtocolHttpEgress::new(vec!["slack.com".to_string()]));
+        egress.allow_credential_handle("slack_bot_token");
+        // The initial auth-prompt delivery to the shared channel returns success
+        // (the backstop fires only after the delivery attempt when the authority
+        // detects the non-DM binding).  We do NOT program a postMessage response
+        // because the backstop intercepts BEFORE delivery via the
+        // `require_personal_dm_for_oauth` guard — no actual HTTP call is made.
+        // (The guard is checked inside `deliver_triggered_notification`; it
+        // returns `OAuthTargetNotDm` without posting.)
+
+        let delivery_store = Arc::new(InMemoryTriggeredRunDeliveryStore::default());
+        let route_store = Arc::new(InMemoryDeliveredGateRouteStore::default());
+        let mut services = make_services(
+            coordinator.clone(),
+            Arc::new(InMemorySessionThreadService::default()),
+            egress.clone(),
+            outbound,
+            install,
+        );
+        // Wire up an OAuth challenge provider so the BlockedAuth state generates
+        // an authorization_url, triggering the DM-only guard.
+        services.auth_challenges = Some(Arc::new(OAuthAuthChallengeProvider {
+            url: "https://provider.example/oauth-cancel-fail".to_string(),
+        }));
+
+        let settings = SlackFinalReplyDeliverySettings {
+            poll_interval: std::time::Duration::ZERO,
+            max_wait: std::time::Duration::from_secs(5),
+            max_concurrent_deliveries: NonZeroUsize::new(1).unwrap(),
+            max_pending_deliveries: NonZeroUsize::new(8).unwrap(),
+        };
+        let driver = TriggeredRunDeliveryDriver::with_settings(
+            services,
+            settings,
+            delivery_store.clone(),
+            route_store.clone(),
+            scope.agent_id.clone().expect("test scope has agent"),
+        );
+
+        let fire = minimal_trigger_fire(None);
+        driver
+            .on_trigger_submitted(fire, run_id, scope.clone())
+            .await;
+        let record = wait_for_delivery_record(&delivery_store, run_id).await;
+
+        // The cancel failed → outcome must be Failed.
+        assert_eq!(
+            record.outcome,
+            TriggeredRunDeliveryOutcomeKind::Failed,
+            "OAuth backstop cancel failure must record Failed; got: {:?}",
+            record.outcome
+        );
+
+        // No chat.delete calls: the auth prompt must not be removed when the
+        // cancel failed (the run may still be live).
+        let delete_call_count = egress
+            .calls()
+            .into_iter()
+            .filter(|c| c.path == "/api/chat.delete")
+            .count();
+        assert_eq!(
+            delete_call_count, 0,
+            "no chat.delete must be issued when backstop cancel fails; got {delete_call_count} calls"
+        );
+
+        // cancel_run was attempted exactly once.
+        assert_eq!(
+            coordinator.cancel_call_count(),
+            1,
+            "cancel_run must be attempted exactly once in the backstop arm"
         );
     }
 

--- a/crates/ironclaw_reborn_composition/src/slack_delivery.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_delivery.rs
@@ -16,13 +16,13 @@ use async_trait::async_trait;
 use chrono::Utc;
 use ironclaw_outbound::{
     CommunicationDeliveryIntent, CommunicationDeliveryResolutionRequest, CommunicationModality,
-    CommunicationPreferenceKey, CommunicationPreferenceRepository, DeliveredGateRouteRecord,
-    DeliveredGateRouteStore, OutboundError, OutboundPolicyService, OutboundStateStore,
-    ProjectionUpdateRef, ReplyTargetBindingClaim, ReplyTargetBindingValidator,
-    ReplyTargetValidationRequest, RunNotificationContext, RunNotificationEventKind,
-    RunNotificationOrigin, SourceRouteContext, TriggerCommunicationContext, TriggerFireSlot,
-    TriggerOriginRef, TriggerSourceKind, TriggeredRunDeliveryOutcomeKind,
-    TriggeredRunDeliveryRecord, TriggeredRunDeliveryStore, ValidatedReplyTargetBinding,
+    CommunicationPreferenceRepository, DeliveredGateRouteRecord, DeliveredGateRouteStore,
+    OutboundError, OutboundPolicyService, OutboundStateStore, ProjectionUpdateRef,
+    ReplyTargetBindingClaim, ReplyTargetBindingValidator, ReplyTargetValidationRequest,
+    RunNotificationContext, RunNotificationEventKind, RunNotificationOrigin, SourceRouteContext,
+    TriggerCommunicationContext, TriggerFireSlot, TriggerOriginRef, TriggerSourceKind,
+    TriggeredRunDeliveryOutcomeKind, TriggeredRunDeliveryRecord, TriggeredRunDeliveryStore,
+    ValidatedReplyTargetBinding,
 };
 use ironclaw_product_adapters::{
     ApprovalPromptContextView, DeclaredEgressHost, EgressCredentialHandle, EgressHeader,
@@ -1991,64 +1991,6 @@ async fn deliver_triggered_run(
         oauth_target_not_dm: std::sync::atomic::AtomicBool::new(false),
     };
 
-    // Pre-check: determine whether the creator's preferred delivery target is a
-    // verified personal DM. OAuth `authorization_url` values must ONLY be posted
-    // to a personal DM — posting one to a shared channel would leak the OAuth
-    // setup URL to every member of that channel. We resolve the preference once
-    // here (it does not change during delivery) so `triggered_notification_for_state`
-    // can gate the OAuth post without performing an async lookup on every loop
-    // iteration. Fail closed: if the preference cannot be read or the binding ref
-    // does not parse as a personal DM, treat the target as non-DM.
-    let target_is_verified_dm = {
-        // Resolve the preference owner: for owner-scoped runs the preference is
-        // stored under the owner identity, not the acting principal. Using the
-        // actor here would read a different (potentially absent) record and
-        // fail-close even when the owner has a valid personal-DM target.
-        let pref_owner_user_id = scope
-            .explicit_owner_user_id()
-            .cloned()
-            .unwrap_or_else(|| actor.user_id.clone());
-        let pref_key =
-            CommunicationPreferenceKey::personal(scope.tenant_id.clone(), pref_owner_user_id);
-        match services
-            .communication_preferences
-            .load_communication_preference(pref_key)
-            .await
-        {
-            Ok(Some(versioned)) => {
-                let record = &versioned.record;
-                // Gate on the EXACT target the auth prompt will resolve to, not
-                // "any stored target". The resolution engine resolves an
-                // auth-prompt intent as `auth_prompt_target.or(final_reply_target)`
-                // (see `resolution_engine.rs` `PreferenceTargetKind::AuthPrompt`) —
-                // `approval_prompt_target` is not in the auth chain, and the
-                // fallback only applies when `auth_prompt_target` is absent. A
-                // looser `.any()` would wrongly pass when `auth_prompt_target` is a
-                // shared channel but `final_reply_target` happens to be a DM, and
-                // still leak the OAuth URL to the channel.
-                let effective_auth_target = record
-                    .auth_prompt_target
-                    .as_ref()
-                    .or(record.final_reply_target.as_ref());
-                match effective_auth_target {
-                    Some(target) => slack_reply_target_is_personal_dm(target),
-                    None => false,
-                }
-            }
-            Ok(None) => false,
-            Err(err) => {
-                tracing::debug!(
-                    target = "ironclaw::reborn::slack_delivery",
-                    %run_id,
-                    error = %err,
-                    "triggered delivery: failed to load communication preference for DM check; \
-                     treating target as non-DM (fail closed)"
-                );
-                false
-            }
-        }
-    };
-
     let mut delivered_blocked_marker: Option<BlockedActionableMarker> = None;
     let mut messages_to_delete_after_final = Vec::new();
 
@@ -2088,7 +2030,6 @@ async fn deliver_triggered_run(
             &state,
             run_id,
             &trigger_label,
-            target_is_verified_dm,
         )
         .await
         {
@@ -2395,8 +2336,6 @@ fn triggered_label_from_prompt(prompt: &str) -> String {
 /// the DM's own scope — it never reaches the triggered run. If you extend this
 /// function, preserve that boundary: do not mint conversational/streaming payloads
 /// here, and do not assume inbound free-text can address a triggered run.
-// arch-exempt: too_many_args, needs a TriggeredNotificationContext bundle (services + scope + actor + state + labels + dm flag), plan #4953
-#[allow(clippy::too_many_arguments)]
 async fn triggered_notification_for_state(
     services: &SlackFinalReplyDeliveryServices,
     scope: &TurnScope,
@@ -2405,7 +2344,6 @@ async fn triggered_notification_for_state(
     state: &TurnRunState,
     run_id: TurnRunId,
     trigger_label: &str,
-    target_is_verified_dm: bool,
 ) -> Result<Option<SlackActionableNotification>, SlackFinalReplyDeliveryError> {
     match state.status {
         TurnStatus::Completed => {
@@ -2487,32 +2425,22 @@ async fn triggered_notification_for_state(
             )
             .await?;
             view.body.push_str(&triggered_gate_footer(trigger_label));
-            // Only link-based OAuth is allowed over Slack, AND only when the
-            // resolved delivery target is a verified personal DM. Posting an
-            // OAuth `authorization_url` to a shared channel would leak the
-            // setup link to every member of that channel.
-            //
-            // Fail-closed rule: if the target cannot be verified as a personal
-            // DM (`target_is_verified_dm` is false), treat the OAuth challenge
-            // the same as a non-OAuth challenge — cancel the run and post the
-            // auth-unavailable notice. When the target IS a personal DM and the
-            // challenge is link-based OAuth (`authorization_url` is Some), post
-            // the OAuth prompt; the callback resumes the run server-side.
-            if view.authorization_url.is_some() && target_is_verified_dm {
+            // Only link-based OAuth is allowed over Slack. The send-time authority
+            // backstop in `TriggeredSlackReplyTargetAuthority::resolve_product_outbound_target_metadata`
+            // enforces that the `authorization_url` only reaches a personal DM at the
+            // exact moment of delivery — it will trip and return `OAuthTargetNotDm` if
+            // the resolved binding is not a personal DM, causing `deliver_triggered_run`
+            // to cancel the run and post the auth-unavailable notice. We do not need to
+            // pre-check the DM status here: the backstop is the single enforcement point.
+            if view.authorization_url.is_some() {
                 Ok(Some(SlackActionableNotification {
                     event_kind: RunNotificationEventKind::AuthRequired,
                     payload: ProductOutboundPayload::AuthPrompt(view),
                     gate_ref_for_routing: Some(gate_ref.as_str().to_string()),
                 }))
             } else {
-                if view.authorization_url.is_some() {
-                    tracing::debug!(
-                        target = "ironclaw::reborn::slack_delivery",
-                        %run_id,
-                        "triggered run OAuth auth blocked: delivery target is not a verified \
-                         personal DM; cancelling run to avoid leaking authorization_url"
-                    );
-                }
+                // Non-OAuth challenge (manual token / API-key entry). Deny: cancel the
+                // parked run and post the auth-unavailable notice directly.
                 cancel_auth_blocked_run(
                     services.turn_coordinator.as_ref(),
                     scope,
@@ -2775,14 +2703,12 @@ impl ProductOutboundTargetResolver for TriggeredSlackReplyTargetAuthority {
         &self,
         target: &ValidatedReplyTargetBinding,
     ) -> Result<VerifiedProductOutboundTargetMetadata, ProductWorkflowError> {
-        // Authority backstop: if the current delivery carries an OAuth
-        // `authorization_url`, enforce that the EXACT send-time binding is a
-        // personal DM. This closes the snapshot-vs-send race: the pre-loop
-        // `target_is_verified_dm` snapshot can go stale while the run waits in
-        // BlockedAuth; this guard is checked against the binding resolved NOW
-        // (at send time), not the one read earlier. On a trip we set the typed
-        // `oauth_target_not_dm` signal so `deliver_triggered_notification` can
-        // classify the failure as `OAuthTargetNotDm` without matching a magic
+        // Authority backstop — single enforcement point for the OAuth DM rule: if
+        // the current delivery carries an OAuth `authorization_url`, enforce that
+        // the EXACT send-time binding is a personal DM. This is checked against the
+        // binding resolved NOW (at send time), making it race-free. On a trip we set
+        // the typed `oauth_target_not_dm` signal so `deliver_triggered_notification`
+        // can classify the failure as `OAuthTargetNotDm` without matching a magic
         // reason string on the cross-crate error.
         if self
             .require_personal_dm_for_oauth
@@ -7215,251 +7141,22 @@ mod tests {
         );
     }
 
-    // ── Authority backstop: snapshot-vs-send race tests ───────────────────────
+    // ── Authority backstop tests ──────────────────────────────────────────────
     //
-    // These tests cover the `require_personal_dm_for_oauth` backstop that closes
-    // the race between the pre-loop `target_is_verified_dm` snapshot and the
-    // binding resolved at send time inside
-    // `TriggeredSlackReplyTargetAuthority::resolve_product_outbound_target_metadata`.
+    // These tests cover the `require_personal_dm_for_oauth` backstop in
+    // `TriggeredSlackReplyTargetAuthority::resolve_product_outbound_target_metadata`,
+    // which is now the single enforcement point ensuring OAuth authorization_urls
+    // only reach personal DMs. The pre-loop snapshot was removed; the backstop is
+    // authoritative.
 
-    /// A `CommunicationPreferenceRepository` whose `load_communication_preference`
-    /// flips the returned binding between calls. The first call returns a
-    /// personal-DM binding (making `target_is_verified_dm = true` in the pre-loop
-    /// snapshot); all subsequent calls return a shared-channel binding (the
-    /// send-time preference flip).
+    /// Backstop regression: when the send-time binding resolves to a shared
+    /// channel, the `require_personal_dm_for_oauth` backstop must catch it and
+    /// suppress the OAuth URL. The run must be cancelled and the auth-unavailable
+    /// notice must be posted. No gate route must be recorded.
     ///
-    /// This simulates the snapshot-vs-send race: the snapshot says DM but the
-    /// actual send-time target is a shared channel.
-    struct FlippingPreferenceRepository {
-        call_count: std::sync::atomic::AtomicU32,
-        dm_record: ironclaw_outbound::CommunicationPreferenceRecord,
-        shared_record: ironclaw_outbound::CommunicationPreferenceRecord,
-    }
-
-    impl FlippingPreferenceRepository {
-        fn new(
-            dm_binding: ReplyTargetBindingRef,
-            shared_binding: ReplyTargetBindingRef,
-            scope: &TurnScope,
-        ) -> Self {
-            let tenant = scope.tenant_id.clone();
-            let user = scope
-                .explicit_owner_user_id()
-                .cloned()
-                .expect("owner user id");
-            let updated_by = user.clone();
-            let dm_record = ironclaw_outbound::CommunicationPreferenceRecord {
-                scope: ironclaw_outbound::DeliveryDefaultScope::personal(
-                    tenant.clone(),
-                    user.clone(),
-                ),
-                final_reply_target: Some(dm_binding.clone()),
-                progress_target: None,
-                approval_prompt_target: Some(dm_binding),
-                auth_prompt_target: None,
-                default_modality: None,
-                updated_at: Utc::now(),
-                updated_by: updated_by.clone(),
-            };
-            let shared_record = ironclaw_outbound::CommunicationPreferenceRecord {
-                scope: ironclaw_outbound::DeliveryDefaultScope::personal(tenant, user),
-                final_reply_target: Some(shared_binding.clone()),
-                progress_target: None,
-                approval_prompt_target: Some(shared_binding),
-                auth_prompt_target: None,
-                default_modality: None,
-                updated_at: Utc::now(),
-                updated_by,
-            };
-            Self {
-                call_count: std::sync::atomic::AtomicU32::new(0),
-                dm_record,
-                shared_record,
-            }
-        }
-    }
-
-    #[async_trait]
-    impl CommunicationPreferenceRepository for FlippingPreferenceRepository {
-        async fn load_communication_preference(
-            &self,
-            _key: CommunicationPreferenceKey,
-        ) -> Result<
-            Option<ironclaw_outbound::VersionedCommunicationPreferenceRecord>,
-            ironclaw_outbound::OutboundError,
-        > {
-            let n = self
-                .call_count
-                .fetch_add(1, std::sync::atomic::Ordering::AcqRel);
-            let record = if n == 0 {
-                // First call (pre-loop snapshot): return personal DM.
-                self.dm_record.clone()
-            } else {
-                // All subsequent calls (send-time resolution): return shared channel.
-                self.shared_record.clone()
-            };
-            Ok(Some(
-                ironclaw_outbound::VersionedCommunicationPreferenceRecord {
-                    record,
-                    version: ironclaw_outbound::CommunicationPreferenceVersion::from_raw(1),
-                },
-            ))
-        }
-
-        async fn write_communication_preference(
-            &self,
-            _request: ironclaw_outbound::WriteCommunicationPreferenceRequest,
-        ) -> Result<
-            ironclaw_outbound::VersionedCommunicationPreferenceRecord,
-            ironclaw_outbound::OutboundError,
-        > {
-            Err(ironclaw_outbound::OutboundError::AccessDenied)
-        }
-    }
-
-    /// A `CommunicationPreferenceRepository` that errors on the FIRST
-    /// `load_communication_preference` call (simulating a transient backend error
-    /// during the pre-loop snapshot read) and delegates all subsequent calls to a
-    /// real `InMemoryOutboundStateStore`.
-    ///
-    /// This lets us verify that a snapshot-read error is fail-closed
-    /// (`target_is_verified_dm = false`) while still allowing the delivery itself
-    /// to proceed (since the outbound policy calls the repo again at send time).
-    struct FirstCallErrorPreferenceRepository {
-        call_count: std::sync::atomic::AtomicU32,
-        delegate: Arc<InMemoryOutboundStateStore>,
-    }
-
-    impl FirstCallErrorPreferenceRepository {
-        fn new(delegate: Arc<InMemoryOutboundStateStore>) -> Self {
-            Self {
-                call_count: std::sync::atomic::AtomicU32::new(0),
-                delegate,
-            }
-        }
-    }
-
-    #[async_trait]
-    impl CommunicationPreferenceRepository for FirstCallErrorPreferenceRepository {
-        async fn load_communication_preference(
-            &self,
-            key: CommunicationPreferenceKey,
-        ) -> Result<
-            Option<ironclaw_outbound::VersionedCommunicationPreferenceRecord>,
-            ironclaw_outbound::OutboundError,
-        > {
-            let n = self
-                .call_count
-                .fetch_add(1, std::sync::atomic::Ordering::AcqRel);
-            if n == 0 {
-                // First call (pre-loop snapshot): simulate a backend error.
-                Err(ironclaw_outbound::OutboundError::Backend)
-            } else {
-                // Subsequent calls (send-time delivery resolution): delegate.
-                self.delegate.load_communication_preference(key).await
-            }
-        }
-
-        async fn write_communication_preference(
-            &self,
-            request: ironclaw_outbound::WriteCommunicationPreferenceRequest,
-        ) -> Result<
-            ironclaw_outbound::VersionedCommunicationPreferenceRecord,
-            ironclaw_outbound::OutboundError,
-        > {
-            self.delegate.write_communication_preference(request).await
-        }
-    }
-
-    /// A `CommunicationPreferenceRepository` that returns `Ok(None)` on the
-    /// FIRST `load_communication_preference` call (simulating an absent record
-    /// during the pre-loop snapshot read) and delegates all subsequent calls to
-    /// a real `InMemoryOutboundStateStore`.
-    ///
-    /// This lets us verify that a snapshot-read of `Ok(None)` is fail-closed
-    /// (`target_is_verified_dm = false`) while still allowing the delivery itself
-    /// to proceed (since the outbound policy calls the repo again at send time
-    /// and finds the seeded preference).
-    struct FirstCallNonePreferenceRepository {
-        call_count: std::sync::atomic::AtomicU32,
-        delegate: Arc<InMemoryOutboundStateStore>,
-    }
-
-    impl FirstCallNonePreferenceRepository {
-        fn new(delegate: Arc<InMemoryOutboundStateStore>) -> Self {
-            Self {
-                call_count: std::sync::atomic::AtomicU32::new(0),
-                delegate,
-            }
-        }
-    }
-
-    #[async_trait]
-    impl CommunicationPreferenceRepository for FirstCallNonePreferenceRepository {
-        async fn load_communication_preference(
-            &self,
-            key: CommunicationPreferenceKey,
-        ) -> Result<
-            Option<ironclaw_outbound::VersionedCommunicationPreferenceRecord>,
-            ironclaw_outbound::OutboundError,
-        > {
-            let n = self
-                .call_count
-                .fetch_add(1, std::sync::atomic::Ordering::AcqRel);
-            if n == 0 {
-                // First call (pre-loop snapshot): simulate absent preference.
-                Ok(None)
-            } else {
-                // Subsequent calls (send-time delivery resolution): delegate.
-                self.delegate.load_communication_preference(key).await
-            }
-        }
-
-        async fn write_communication_preference(
-            &self,
-            request: ironclaw_outbound::WriteCommunicationPreferenceRequest,
-        ) -> Result<
-            ironclaw_outbound::VersionedCommunicationPreferenceRecord,
-            ironclaw_outbound::OutboundError,
-        > {
-            self.delegate.write_communication_preference(request).await
-        }
-    }
-
-    /// Build `SlackFinalReplyDeliveryServices` with a custom
-    /// `CommunicationPreferenceRepository` that is separate from the outbound store
-    /// (the outbound store is used for delivery-state only; preference reads go
-    /// through the injected repo).
-    fn make_services_with_prefs(
-        coordinator: Arc<dyn TurnCoordinator>,
-        thread_service: Arc<dyn ironclaw_threads::SessionThreadService>,
-        egress: Arc<FakeProtocolHttpEgress>,
-        outbound: Arc<InMemoryOutboundStateStore>,
-        prefs: Arc<dyn CommunicationPreferenceRepository>,
-        installation_id: &str,
-    ) -> SlackFinalReplyDeliveryServices {
-        SlackFinalReplyDeliveryServices {
-            binding_service: Arc::new(TestNoopConversationBindingService),
-            thread_service,
-            turn_coordinator: coordinator,
-            outbound_store: outbound,
-            route_store: Arc::new(InMemoryDeliveredGateRouteStore::default()),
-            communication_preferences: prefs,
-            adapter: test_adapter(installation_id),
-            egress,
-            delivery_sink: Arc::new(FakeOutboundDeliverySink::default()),
-            auth_challenges: None,
-            approval_requests: None,
-        }
-    }
-
-    /// RACE regression: the pre-loop DM snapshot says DM but the preference flips
-    /// to a shared channel before the send-time binding is resolved.
-    ///
-    /// The authority backstop (`require_personal_dm_for_oauth`) must catch this
-    /// and suppress the OAuth URL. The run must be cancelled and the
-    /// auth-unavailable notice must be posted to the shared channel. No gate
-    /// route must be recorded.
+    /// Previously named `triggered_oauth_auth_dm_snapshot_but_channel_at_send_suppresses_url`
+    /// (tested the snapshot-vs-send race); simplified now that the backstop is the
+    /// only enforcement point and no pre-loop snapshot exists.
     #[tokio::test]
     async fn triggered_oauth_auth_dm_snapshot_but_channel_at_send_suppresses_url() {
         let install = "test-install";
@@ -7468,9 +7165,7 @@ mod tests {
         let run_id = TurnRunId::new();
         let agent = scope.agent_id.as_ref().expect("agent").as_str();
 
-        // The personal-DM binding is returned on the FIRST load (snapshot).
-        let dm_binding = test_slack_binding_ref(install, agent);
-        // The shared-channel binding is returned on the SECOND+ loads (send time).
+        // Shared-channel binding: the backstop must catch this at send time.
         let shared_binding = test_slack_shared_channel_binding_ref(install, agent);
 
         // First poll → BlockedAuth with OAuth gate; second poll → Completed.
@@ -7487,19 +7182,8 @@ mod tests {
         )
         .await;
 
-        // Outbound store: seed the shared-channel binding so the policy service
-        // resolves it (the FlippingPreferenceRepository drives the snapshot vs
-        // send-time distinction).
         let outbound = Arc::new(InMemoryOutboundStateStore::default());
-        seed_personal_preference(&outbound, &scope, shared_binding.clone()).await;
-
-        // The flipping preference repo: DM on first call, shared-channel on
-        // subsequent calls.
-        let prefs = Arc::new(FlippingPreferenceRepository::new(
-            dm_binding,
-            shared_binding,
-            &scope,
-        ));
+        seed_personal_preference(&outbound, &scope, shared_binding).await;
 
         let egress = Arc::new(FakeProtocolHttpEgress::new(vec!["slack.com".to_string()]));
         egress.allow_credential_handle("slack_bot_token");
@@ -7511,7 +7195,7 @@ mod tests {
                 slack_post_ok_json("C0SHARED", "race-test.1"),
             )),
         );
-        // Final reply after Completed (the loop re-runs once after cancel).
+        // Second response (available if loop re-runs; not required to be consumed).
         egress.program_response(
             "slack.com",
             Ok(EgressResponse::new(
@@ -7522,12 +7206,11 @@ mod tests {
 
         let delivery_store = Arc::new(InMemoryTriggeredRunDeliveryStore::default());
         let route_store = Arc::new(InMemoryDeliveredGateRouteStore::default());
-        let mut services = make_services_with_prefs(
+        let mut services = make_services(
             coordinator,
             thread_service,
             egress.clone(),
             outbound,
-            prefs,
             install,
         );
         // Wire up an OAuth challenge provider so authorization_url would be set
@@ -7567,7 +7250,7 @@ mod tests {
             assert!(
                 !body.contains("https://provider.example/oauth-race"),
                 "authorization_url must NOT be posted when send-time target is a shared channel \
-                 (race backstop); got: {body}"
+                 (backstop); got: {body}"
             );
         }
 
@@ -7592,267 +7275,13 @@ mod tests {
         );
     }
 
-    /// Fail-closed: `load_communication_preference` returns `Err` on the
-    /// pre-loop snapshot read → `target_is_verified_dm = false` → OAuth URL
-    /// suppressed → auth-unavailable notice posted. No gate route recorded.
-    ///
-    /// Covers reviewer item Y: a preference-read error must not allow the OAuth
-    /// URL to leak by default-treating the target as a DM.
-    #[tokio::test]
-    async fn triggered_oauth_auth_preference_read_error_suppresses_authorization_url() {
-        let install = "test-install";
-        let gate_ref_str = "gate:oauth-pref-error";
-        let scope = personal_turn_scope();
-        let run_id = TurnRunId::new();
-        let agent = scope.agent_id.as_ref().expect("agent").as_str();
+    // Removed: triggered_oauth_auth_preference_read_error_suppresses_authorization_url
+    // — tested the pre-loop snapshot fail-closed behavior on preference-read error;
+    // redundant now that the snapshot was removed and the backstop is the sole
+    // enforcement point (shared-channel delivery is already covered by
+    // `triggered_oauth_auth_to_shared_channel_suppresses_authorization_url`).
 
-        // The shared-channel binding is seeded in the outbound store so the
-        // outbound policy can resolve it. The preference repo always errors, so
-        // the snapshot is false (fail-closed).
-        let shared_binding = test_slack_shared_channel_binding_ref(install, agent);
-
-        let coordinator = Arc::new(ScriptedTurnCoordinator::with_states(vec![
-            scripted_state(TurnStatus::BlockedAuth, Some(gate_ref_str)),
-            scripted_state(TurnStatus::Completed, None),
-        ]));
-        let thread_service = Arc::new(InMemorySessionThreadService::default());
-        seed_finalized_assistant_message(
-            &thread_service,
-            &scope,
-            run_id,
-            "Run complete after auth.",
-        )
-        .await;
-
-        let outbound = Arc::new(InMemoryOutboundStateStore::default());
-        seed_personal_preference(&outbound, &scope, shared_binding).await;
-
-        // First-call-error preference repository: errors on the pre-loop snapshot
-        // read, then delegates to the real outbound store for delivery-time calls.
-        // This ensures `target_is_verified_dm = false` (fail-closed) while still
-        // letting the delivery succeed so we can observe the auth-unavailable notice.
-        let prefs = Arc::new(FirstCallErrorPreferenceRepository::new(Arc::clone(
-            &outbound,
-        )));
-
-        let egress = Arc::new(FakeProtocolHttpEgress::new(vec!["slack.com".to_string()]));
-        egress.allow_credential_handle("slack_bot_token");
-        // auth-unavailable notice.
-        egress.program_response(
-            "slack.com",
-            Ok(EgressResponse::new(
-                200,
-                slack_post_ok_json("C0SHARED", "pref-err.1"),
-            )),
-        );
-        // Final reply after Completed.
-        egress.program_response(
-            "slack.com",
-            Ok(EgressResponse::new(
-                200,
-                slack_post_ok_json("C0SHARED", "pref-err.2"),
-            )),
-        );
-
-        let delivery_store = Arc::new(InMemoryTriggeredRunDeliveryStore::default());
-        let route_store = Arc::new(InMemoryDeliveredGateRouteStore::default());
-        let mut services = make_services_with_prefs(
-            coordinator,
-            thread_service,
-            egress.clone(),
-            outbound,
-            prefs,
-            install,
-        );
-        services.auth_challenges = Some(Arc::new(OAuthAuthChallengeProvider {
-            url: "https://provider.example/oauth-pref-error".to_string(),
-        }));
-
-        let settings = SlackFinalReplyDeliverySettings {
-            poll_interval: std::time::Duration::ZERO,
-            max_wait: std::time::Duration::from_secs(5),
-            max_concurrent_deliveries: NonZeroUsize::new(1).unwrap(),
-            max_pending_deliveries: NonZeroUsize::new(8).unwrap(),
-        };
-        let driver = TriggeredRunDeliveryDriver::with_settings(
-            services,
-            settings,
-            delivery_store.clone(),
-            route_store.clone(),
-            scope.agent_id.clone().expect("test scope has agent"),
-        );
-
-        driver
-            .on_trigger_submitted(minimal_trigger_fire(None), run_id, scope.clone())
-            .await;
-        wait_for_delivery_record(&delivery_store, run_id).await;
-
-        let posted: Vec<String> = egress
-            .calls()
-            .iter()
-            .filter(|c| c.path == "/api/chat.postMessage")
-            .map(|c| String::from_utf8_lossy(&c.body).to_string())
-            .collect();
-
-        // The OAuth URL must NOT appear anywhere.
-        for body in &posted {
-            assert!(
-                !body.contains("https://provider.example/oauth-pref-error"),
-                "authorization_url must NOT be posted when preference read errors (fail closed); \
-                 got: {body}"
-            );
-        }
-
-        // The auth-unavailable notice must be posted.
-        assert!(
-            posted
-                .iter()
-                .any(|b| b.contains(SLACK_AUTH_UNAVAILABLE_MESSAGE)),
-            "auth-unavailable notice must be posted when preference read errors; got: {posted:?}"
-        );
-
-        // No gate route recorded.
-        let creator = ironclaw_host_api::UserId::new("creator-user").expect("user id");
-        let route = route_store
-            .load_delivered_gate_route(&scope.tenant_id, &creator, gate_ref_str)
-            .await
-            .expect("load route");
-        assert!(
-            route.is_none(),
-            "no gate route must be recorded when OAuth is suppressed due to preference read error"
-        );
-    }
-
-    /// Fail-closed: `load_communication_preference` returns `Ok(None)` (no
-    /// preference record stored) on the pre-loop snapshot read →
-    /// `target_is_verified_dm = false` → OAuth URL suppressed →
-    /// auth-unavailable notice posted instead. No gate route recorded.
-    ///
-    /// Regression for A5/A3: an absent preference must not be treated as a DM.
-    #[tokio::test]
-    async fn triggered_oauth_auth_no_preference_suppresses_authorization_url() {
-        let install = "test-install";
-        let gate_ref_str = "gate:oauth-no-preference";
-        let scope = personal_turn_scope();
-        let run_id = TurnRunId::new();
-        let agent = scope.agent_id.as_ref().expect("agent").as_str();
-
-        // Shared-channel binding seeded in the outbound store so delivery can
-        // resolve it. The preference repo (the default empty InMemoryOutboundStateStore)
-        // has NO communication preference record, so the snapshot read returns
-        // Ok(None) → fail-closed.
-        let shared_binding = test_slack_shared_channel_binding_ref(install, agent);
-
-        let coordinator = Arc::new(ScriptedTurnCoordinator::with_states(vec![
-            scripted_state(TurnStatus::BlockedAuth, Some(gate_ref_str)),
-            scripted_state(TurnStatus::Completed, None),
-        ]));
-        let thread_service = Arc::new(InMemorySessionThreadService::default());
-        seed_finalized_assistant_message(
-            &thread_service,
-            &scope,
-            run_id,
-            "Run complete after auth.",
-        )
-        .await;
-
-        // The outbound store is seeded with the delivery-target binding so the
-        // FinalReply notice can be posted.  The preference repo (FirstCallNonePreferenceRepository)
-        // returns Ok(None) on the first (pre-loop snapshot) call → fail-closed, then
-        // delegates to the real store on subsequent (send-time) calls so delivery
-        // can proceed.
-        let outbound = Arc::new(InMemoryOutboundStateStore::default());
-        seed_personal_preference(&outbound, &scope, shared_binding).await;
-
-        let prefs = Arc::new(FirstCallNonePreferenceRepository::new(Arc::clone(
-            &outbound,
-        )));
-
-        let egress = Arc::new(FakeProtocolHttpEgress::new(vec!["slack.com".to_string()]));
-        egress.allow_credential_handle("slack_bot_token");
-        // auth-unavailable notice.
-        egress.program_response(
-            "slack.com",
-            Ok(EgressResponse::new(
-                200,
-                slack_post_ok_json("C0SHARED", "no-pref.1"),
-            )),
-        );
-        // Final reply after Completed.
-        egress.program_response(
-            "slack.com",
-            Ok(EgressResponse::new(
-                200,
-                slack_post_ok_json("C0SHARED", "no-pref.2"),
-            )),
-        );
-
-        let delivery_store = Arc::new(InMemoryTriggeredRunDeliveryStore::default());
-        let route_store = Arc::new(InMemoryDeliveredGateRouteStore::default());
-        let mut services = make_services_with_prefs(
-            coordinator,
-            thread_service,
-            egress.clone(),
-            outbound,
-            prefs,
-            install,
-        );
-        services.auth_challenges = Some(Arc::new(OAuthAuthChallengeProvider {
-            url: "https://provider.example/oauth-no-preference".to_string(),
-        }));
-
-        let settings = SlackFinalReplyDeliverySettings {
-            poll_interval: std::time::Duration::ZERO,
-            max_wait: std::time::Duration::from_secs(5),
-            max_concurrent_deliveries: NonZeroUsize::new(1).unwrap(),
-            max_pending_deliveries: NonZeroUsize::new(8).unwrap(),
-        };
-        let driver = TriggeredRunDeliveryDriver::with_settings(
-            services,
-            settings,
-            delivery_store.clone(),
-            route_store.clone(),
-            scope.agent_id.clone().expect("test scope has agent"),
-        );
-
-        driver
-            .on_trigger_submitted(minimal_trigger_fire(None), run_id, scope.clone())
-            .await;
-        wait_for_delivery_record(&delivery_store, run_id).await;
-
-        let posted: Vec<String> = egress
-            .calls()
-            .iter()
-            .filter(|c| c.path == "/api/chat.postMessage")
-            .map(|c| String::from_utf8_lossy(&c.body).to_string())
-            .collect();
-
-        // The OAuth URL must NOT appear anywhere (no preference → fail closed).
-        for body in &posted {
-            assert!(
-                !body.contains("https://provider.example/oauth-no-preference"),
-                "authorization_url must NOT be posted when no preference is stored (fail closed); \
-                 got: {body}"
-            );
-        }
-
-        // The auth-unavailable notice must be posted.
-        assert!(
-            posted
-                .iter()
-                .any(|b| b.contains(SLACK_AUTH_UNAVAILABLE_MESSAGE)),
-            "auth-unavailable notice must be posted when no preference is stored; got: {posted:?}"
-        );
-
-        // No gate route recorded.
-        let creator = ironclaw_host_api::UserId::new("creator-user").expect("user id");
-        let route = route_store
-            .load_delivered_gate_route(&scope.tenant_id, &creator, gate_ref_str)
-            .await
-            .expect("load route");
-        assert!(
-            route.is_none(),
-            "no gate route must be recorded when OAuth is suppressed due to absent preference"
-        );
-    }
+    // Removed: triggered_oauth_auth_no_preference_suppresses_authorization_url
+    // — tested the pre-loop snapshot fail-closed behavior for an absent preference
+    // record; redundant after snapshot removal for the same reason as above.
 }

--- a/crates/ironclaw_reborn_composition/src/slack_delivery.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_delivery.rs
@@ -591,6 +591,7 @@ impl SlackFinalReplyDeliveryObserver {
                 adapter: self.services.adapter.as_ref(),
                 egress: &tracked_egress,
                 delivery_sink: self.services.delivery_sink.as_ref(),
+                require_direct_message_target: false,
             },
         )
         .await?;
@@ -1439,9 +1440,14 @@ impl ProductOutboundTargetResolver for ObservedSlackReplyTargetAuthority {
     async fn resolve_product_outbound_target_metadata(
         &self,
         target: &ValidatedReplyTargetBinding,
+        require_direct_message: bool,
     ) -> Result<VerifiedProductOutboundTargetMetadata, ProductWorkflowError> {
         if target.target() != &self.expected_target {
             return Err(ProductWorkflowError::BindingAccessDenied);
+        }
+        // Defense in depth: honor the DM requirement even on the live-path resolver.
+        if require_direct_message && !slack_reply_target_is_personal_dm(target.target()) {
+            return Err(ProductWorkflowError::OutboundTargetNotDirectMessage);
         }
         Ok(VerifiedProductOutboundTargetMetadata {
             external_conversation_ref: self.external_conversation_ref.clone(),
@@ -1986,8 +1992,6 @@ async fn deliver_triggered_run(
         actor: actor.clone(),
         trigger_context: trigger_context.clone(),
         resolved_space_id: std::sync::Mutex::new(None),
-        require_personal_dm_for_oauth: std::sync::atomic::AtomicBool::new(false),
-        oauth_target_not_dm: std::sync::atomic::AtomicBool::new(false),
     };
 
     let mut delivered_blocked_marker: Option<BlockedActionableMarker> = None;
@@ -2056,18 +2060,15 @@ async fn deliver_triggered_run(
         let event_kind = notification.event_kind;
         let gate_ref_for_routing = notification.gate_ref_for_routing.clone();
 
-        // Set the per-delivery OAuth guard BEFORE moving `notification` into the call.
-        // If the payload is an AuthPrompt with an authorization_url, the authority
-        // backstop in `resolve_product_outbound_target_metadata` will enforce that the
-        // send-time binding is a personal DM, closing the snapshot-vs-send race.
-        let payload_has_oauth_url = matches!(
+        // Compute the DM requirement from the payload BEFORE it is moved into the call.
+        // AuthPrompt payloads with an authorization_url must only be delivered to a
+        // personal DM; pass this requirement through the delivery request so the
+        // resolver enforces it at send time (closing the snapshot-vs-send race).
+        let require_direct_message_target = matches!(
             &notification.payload,
             ProductOutboundPayload::AuthPrompt(view)
                 if view.authorization_url.is_some()
         );
-        authority
-            .require_personal_dm_for_oauth
-            .store(payload_has_oauth_url, std::sync::atomic::Ordering::Release);
 
         // Build the delivery request and deliver.
         let delivery_result = deliver_triggered_notification(
@@ -2078,6 +2079,7 @@ async fn deliver_triggered_run(
             &state,
             &authority,
             notification,
+            require_direct_message_target,
         )
         .await;
 
@@ -2165,11 +2167,9 @@ async fn deliver_triggered_run(
                     record_triggered_run_outcome(delivery_store, run_id, outcome).await;
                     return outcome;
                 }
-                // Reset the guard so the notice delivery is not blocked.
-                authority
-                    .require_personal_dm_for_oauth
-                    .store(false, std::sync::atomic::Ordering::Release);
                 // Post the auth-unavailable notice as a terminal FinalReply.
+                // require_direct_message_target is false: the notice is plain text
+                // with no OAuth URL, so no DM restriction applies.
                 let notice = SlackActionableNotification {
                     event_kind: RunNotificationEventKind::FinalReplyReady,
                     payload: ProductOutboundPayload::FinalReply(FinalReplyView {
@@ -2183,7 +2183,7 @@ async fn deliver_triggered_run(
                     gate_ref_for_routing: None,
                 };
                 let outcome = match deliver_triggered_notification(
-                    services, &scope, &actor, run_id, &state, &authority, notice,
+                    services, &scope, &actor, run_id, &state, &authority, notice, false,
                 )
                 .await
                 {
@@ -2430,13 +2430,13 @@ async fn triggered_notification_for_state(
             )
             .await?;
             view.body.push_str(&triggered_gate_footer(trigger_label));
-            // Only link-based OAuth is allowed over Slack. The send-time authority
-            // backstop in `TriggeredSlackReplyTargetAuthority::resolve_product_outbound_target_metadata`
-            // enforces that the `authorization_url` only reaches a personal DM at the
-            // exact moment of delivery — it will trip and return `OAuthTargetNotDm` if
-            // the resolved binding is not a personal DM, causing `deliver_triggered_run`
-            // to cancel the run and post the auth-unavailable notice. We do not need to
-            // pre-check the DM status here: the backstop is the single enforcement point.
+            // Only link-based OAuth is allowed over Slack. The `require_direct_message_target`
+            // flag is set on the `ProductOutboundDeliveryRequest` when the payload carries
+            // an `authorization_url`, and the resolver enforces the DM constraint at send
+            // time — it returns `OutboundTargetNotDirectMessage` if the resolved binding is
+            // not a personal DM, which `classify_delivery_error` maps to `OAuthTargetNotDm`,
+            // causing `deliver_triggered_run` to cancel the run and post the auth-unavailable
+            // notice. We do not need to pre-check the DM status here.
             if view.authorization_url.is_some() {
                 Ok(Some(SlackActionableNotification {
                     event_kind: RunNotificationEventKind::AuthRequired,
@@ -2480,12 +2480,11 @@ enum TriggeredNotificationFailure {
     Denied,
     /// The payload carries an OAuth `authorization_url` but the send-time
     /// binding resolved to a non-personal-DM target. Posting the OAuth URL
-    /// to a shared channel would leak it to every member. The authority
-    /// backstop in `TriggeredSlackReplyTargetAuthority` raises this when
-    /// `require_personal_dm_for_oauth` is set and the resolved binding is not
-    /// a personal DM. `classify_delivery_error` maps the sentinel reason to
-    /// this variant; `deliver_triggered_run` handles it by cancelling the run
-    /// and posting the auth-unavailable notice.
+    /// to a shared channel would leak it to every member. The resolver returns
+    /// [`ProductWorkflowError::OutboundTargetNotDirectMessage`] when
+    /// `require_direct_message_target` is true and the binding is not a DM;
+    /// `classify_delivery_error` maps that to this variant. `deliver_triggered_run`
+    /// handles it by cancelling the run and posting the auth-unavailable notice.
     OAuthTargetNotDm,
     /// Any other delivery or transport failure.
     Other(String),
@@ -2508,6 +2507,7 @@ impl std::fmt::Display for TriggeredNotificationFailure {
 }
 
 /// Delivers a triggered-run notification, returning the list of posted Slack messages.
+#[allow(clippy::too_many_arguments)]
 async fn deliver_triggered_notification(
     services: &SlackFinalReplyDeliveryServices,
     scope: &TurnScope,
@@ -2516,6 +2516,7 @@ async fn deliver_triggered_notification(
     state: &TurnRunState,
     authority: &TriggeredSlackReplyTargetAuthority,
     notification: SlackActionableNotification,
+    require_direct_message_target: bool,
 ) -> Result<Vec<PostedSlackMessage>, TriggeredNotificationFailure> {
     let SlackActionableNotification {
         event_kind,
@@ -2568,21 +2569,12 @@ async fn deliver_triggered_notification(
             adapter: services.adapter.as_ref(),
             egress: &tracked_egress,
             delivery_sink: services.delivery_sink.as_ref(),
+            require_direct_message_target,
         },
     )
     .await;
 
     if let Err(error) = render_result {
-        // Typed handshake with the resolver: if the OAuth-DM backstop tripped,
-        // the resolver set `oauth_target_not_dm`. Read-and-clear it here so the
-        // failure is classified as `OAuthTargetNotDm` without inspecting the
-        // cross-crate error's reason string.
-        if authority
-            .oauth_target_not_dm
-            .swap(false, std::sync::atomic::Ordering::AcqRel)
-        {
-            return Err(TriggeredNotificationFailure::OAuthTargetNotDm);
-        }
         return Err(classify_delivery_error(error));
     }
 
@@ -2597,15 +2589,16 @@ fn classify_delivery_error(
     use ironclaw_outbound::OutboundError;
     use ironclaw_product_workflow::ProductOutboundDeliveryError;
     match &error {
+        ProductOutboundDeliveryError::Workflow {
+            source: ProductWorkflowError::OutboundTargetNotDirectMessage,
+            ..
+        } => TriggeredNotificationFailure::OAuthTargetNotDm,
         ProductOutboundDeliveryError::Outbound(OutboundError::PreferenceTargetMissing {
             ..
         }) => TriggeredNotificationFailure::NoDefaultConfigured,
         ProductOutboundDeliveryError::Outbound(OutboundError::AccessDenied) => {
             TriggeredNotificationFailure::Denied
         }
-        // Note: the OAuth-DM backstop trip is NOT classified here — it is detected
-        // via the authority's typed `oauth_target_not_dm` signal in
-        // `deliver_triggered_notification` before this function is reached.
         _ => TriggeredNotificationFailure::Other(error.to_string()),
     }
 }
@@ -2673,18 +2666,6 @@ struct TriggeredSlackReplyTargetAuthority {
     /// refs so inbound replies (which carry team_id as space_id)
     /// fingerprint-match the recorded ref.
     resolved_space_id: std::sync::Mutex<Option<String>>,
-    /// Set per-delivery: true when the current delivery's payload carries an OAuth
-    /// `authorization_url` that may ONLY be posted to a personal DM. The resolver
-    /// enforces this against the EXACT binding resolved at send time, closing the
-    /// snapshot-vs-send race (the pre-loop DM snapshot can go stale while the run
-    /// waits in BlockedAuth).
-    require_personal_dm_for_oauth: std::sync::atomic::AtomicBool,
-    /// Output signal: set by the resolver when `require_personal_dm_for_oauth`
-    /// is true and the resolved send-time binding is NOT a personal DM. Read
-    /// (and cleared) by `deliver_triggered_notification` to classify the delivery
-    /// failure as `OAuthTargetNotDm` — a typed handshake that avoids matching a
-    /// magic reason string on the cross-crate `ProductWorkflowError`.
-    oauth_target_not_dm: std::sync::atomic::AtomicBool,
 }
 
 #[async_trait]
@@ -2707,24 +2688,15 @@ impl ProductOutboundTargetResolver for TriggeredSlackReplyTargetAuthority {
     async fn resolve_product_outbound_target_metadata(
         &self,
         target: &ValidatedReplyTargetBinding,
+        require_direct_message: bool,
     ) -> Result<VerifiedProductOutboundTargetMetadata, ProductWorkflowError> {
-        // Authority backstop — single enforcement point for the OAuth DM rule: if
-        // the current delivery carries an OAuth `authorization_url`, enforce that
-        // the EXACT send-time binding is a personal DM. This is checked against the
-        // binding resolved NOW (at send time), making it race-free. On a trip we set
-        // the typed `oauth_target_not_dm` signal so `deliver_triggered_notification`
-        // can classify the failure as `OAuthTargetNotDm` without matching a magic
-        // reason string on the cross-crate error.
-        if self
-            .require_personal_dm_for_oauth
-            .load(std::sync::atomic::Ordering::Acquire)
-            && !slack_reply_target_is_personal_dm(target.target())
-        {
-            self.oauth_target_not_dm
-                .store(true, std::sync::atomic::Ordering::Release);
-            return Err(ProductWorkflowError::BindingResolutionFailed {
-                reason: "OAuth authorization_url requires a personal DM target".to_string(),
-            });
+        // Single enforcement point for the OAuth DM rule: when the delivery request
+        // requires a direct-message target (i.e. the payload carries an OAuth
+        // authorization_url), enforce that the EXACT send-time binding is a personal
+        // DM. Checked against the binding resolved NOW (at send time), making it
+        // race-free against the pre-loop preference snapshot going stale.
+        if require_direct_message && !slack_reply_target_is_personal_dm(target.target()) {
+            return Err(ProductWorkflowError::OutboundTargetNotDirectMessage);
         }
 
         // Decode the DM channel ID from the binding ref. The ref was built by

--- a/crates/ironclaw_reborn_composition/src/slack_delivery.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_delivery.rs
@@ -66,6 +66,12 @@ const SLACK_AUTH_CANCELED_MESSAGE: &str = "Authentication canceled.";
 /// Posted when a run blocks on a credential-entry (non-OAuth) auth challenge:
 /// entering a secret in chat is a security risk, so it must be done in the web app.
 const SLACK_AUTH_UNAVAILABLE_MESSAGE: &str = "Setting this up needs a credential (an API key or token). Sharing one here is a security risk — anything entered in chat is stored in the conversation — so credential-based connections can only be set up in the Ironclaw web app. Connect it there, then ask me again here.";
+/// Sentinel reason string used inside `TriggeredSlackReplyTargetAuthority` to signal
+/// that the delivery was rejected because the send-time target was not a personal DM
+/// despite the payload carrying an OAuth `authorization_url`. This is an internal
+/// marker only — it is matched in `classify_delivery_error` to map to
+/// `TriggeredNotificationFailure::OAuthTargetNotDm` and is never shown to users.
+const OAUTH_TARGET_NOT_DM_MARKER: &str = "__oauth_url_requires_personal_dm__";
 const SLACK_DELIVERY_TIMEOUT_MESSAGE: &str =
     "This is taking longer than expected — check the WebUI for the result.";
 const SLACK_DELIVERY_ERROR_MESSAGE: &str =
@@ -1987,6 +1993,7 @@ async fn deliver_triggered_run(
         actor: actor.clone(),
         trigger_context: trigger_context.clone(),
         resolved_space_id: std::sync::Mutex::new(None),
+        require_personal_dm_for_oauth: std::sync::atomic::AtomicBool::new(false),
     };
 
     // Pre-check: determine whether the creator's preferred delivery target is a
@@ -2027,7 +2034,7 @@ async fn deliver_triggered_run(
             }
             Ok(None) => false,
             Err(err) => {
-                tracing::warn!(
+                tracing::debug!(
                     target = "ironclaw::reborn::slack_delivery",
                     %run_id,
                     error = %err,
@@ -2106,6 +2113,19 @@ async fn deliver_triggered_run(
         let event_kind = notification.event_kind;
         let gate_ref_for_routing = notification.gate_ref_for_routing.clone();
 
+        // Set the per-delivery OAuth guard BEFORE moving `notification` into the call.
+        // If the payload is an AuthPrompt with an authorization_url, the authority
+        // backstop in `resolve_product_outbound_target_metadata` will enforce that the
+        // send-time binding is a personal DM, closing the snapshot-vs-send race.
+        let payload_has_oauth_url = matches!(
+            &notification.payload,
+            ProductOutboundPayload::AuthPrompt(view)
+                if view.authorization_url.is_some()
+        );
+        authority
+            .require_personal_dm_for_oauth
+            .store(payload_has_oauth_url, std::sync::atomic::Ordering::Release);
+
         // Build the delivery request and deliver.
         let delivery_result = deliver_triggered_notification(
             services,
@@ -2161,6 +2181,59 @@ async fn deliver_triggered_run(
                 record_triggered_run_outcome(delivery_store, run_id, outcome).await;
                 return outcome;
             }
+            Err(TriggeredNotificationFailure::OAuthTargetNotDm) => {
+                // Authority backstop tripped: the payload carried an OAuth
+                // authorization_url but the send-time binding was not a personal DM.
+                // Suppress the URL (fail closed), cancel the blocked run, then post
+                // the auth-unavailable notice as a terminal FinalReply — mirrors the
+                // non-OAuth deny branch in `triggered_notification_for_state`.
+                tracing::debug!(
+                    target = "ironclaw::reborn::slack_delivery",
+                    %run_id,
+                    "triggered run OAuth URL suppressed by send-time backstop: resolved \
+                     target is not a personal DM; cancelling run"
+                );
+                // Cancel the blocked run.
+                if let Err(err) = cancel_auth_blocked_run(
+                    services.turn_coordinator.as_ref(),
+                    &scope,
+                    actor.clone(),
+                    run_id,
+                )
+                .await
+                {
+                    tracing::debug!(
+                        target = "ironclaw::reborn::slack_delivery",
+                        %run_id,
+                        error = %err,
+                        "triggered run OAuth backstop: cancel_auth_blocked_run failed (continuing)"
+                    );
+                }
+                // Reset the guard so the notice delivery is not blocked.
+                authority
+                    .require_personal_dm_for_oauth
+                    .store(false, std::sync::atomic::Ordering::Release);
+                // Post the auth-unavailable notice as a terminal FinalReply.
+                let notice = SlackActionableNotification {
+                    event_kind: RunNotificationEventKind::FinalReplyReady,
+                    payload: ProductOutboundPayload::FinalReply(FinalReplyView {
+                        turn_run_id: run_id,
+                        text: format!(
+                            "{SLACK_AUTH_UNAVAILABLE_MESSAGE}{}",
+                            triggered_update_footer(&trigger_label)
+                        ),
+                        generated_at: Utc::now(),
+                    }),
+                    gate_ref_for_routing: None,
+                };
+                let _ = deliver_triggered_notification(
+                    services, &scope, &actor, run_id, &state, &authority, notice,
+                )
+                .await;
+                let outcome = TriggeredRunDeliveryOutcomeKind::Delivered;
+                record_triggered_run_outcome(delivery_store, run_id, outcome).await;
+                return outcome;
+            }
             Err(failure) => {
                 tracing::warn!(
                     target = "ironclaw::reborn::slack_delivery",
@@ -2173,6 +2246,10 @@ async fn deliver_triggered_run(
                         TriggeredRunDeliveryOutcomeKind::NoDefaultConfigured
                     }
                     TriggeredNotificationFailure::Denied => TriggeredRunDeliveryOutcomeKind::Denied,
+                    TriggeredNotificationFailure::OAuthTargetNotDm => {
+                        // Handled in the dedicated arm above; unreachable here.
+                        TriggeredRunDeliveryOutcomeKind::Failed
+                    }
                     TriggeredNotificationFailure::Other(_) => {
                         TriggeredRunDeliveryOutcomeKind::Failed
                     }
@@ -2288,6 +2365,7 @@ fn triggered_label_from_prompt(prompt: &str) -> String {
 /// the DM's own scope — it never reaches the triggered run. If you extend this
 /// function, preserve that boundary: do not mint conversational/streaming payloads
 /// here, and do not assume inbound free-text can address a triggered run.
+// arch-exempt: too_many_args, needs a TriggeredNotificationContext bundle (services + scope + actor + state + labels + dm flag), plan #4953
 #[allow(clippy::too_many_arguments)]
 async fn triggered_notification_for_state(
     services: &SlackFinalReplyDeliveryServices,
@@ -2398,7 +2476,7 @@ async fn triggered_notification_for_state(
                 }))
             } else {
                 if view.authorization_url.is_some() {
-                    tracing::warn!(
+                    tracing::debug!(
                         target = "ironclaw::reborn::slack_delivery",
                         %run_id,
                         "triggered run OAuth auth blocked: delivery target is not a verified \
@@ -2437,6 +2515,15 @@ enum TriggeredNotificationFailure {
     NoDefaultConfigured,
     /// The resolved target is inaccessible or rejected the delivery.
     Denied,
+    /// The payload carries an OAuth `authorization_url` but the send-time
+    /// binding resolved to a non-personal-DM target. Posting the OAuth URL
+    /// to a shared channel would leak it to every member. The authority
+    /// backstop in `TriggeredSlackReplyTargetAuthority` raises this when
+    /// `require_personal_dm_for_oauth` is set and the resolved binding is not
+    /// a personal DM. `classify_delivery_error` maps the sentinel reason to
+    /// this variant; `deliver_triggered_run` handles it by cancelling the run
+    /// and posting the auth-unavailable notice.
+    OAuthTargetNotDm,
     /// Any other delivery or transport failure.
     Other(String),
 }
@@ -2446,6 +2533,12 @@ impl std::fmt::Display for TriggeredNotificationFailure {
         match self {
             Self::NoDefaultConfigured => write!(f, "no default delivery target configured"),
             Self::Denied => write!(f, "delivery target access denied"),
+            Self::OAuthTargetNotDm => {
+                write!(
+                    f,
+                    "OAuth authorization_url suppressed: send-time target is not a personal DM"
+                )
+            }
             Self::Other(reason) => write!(f, "{reason}"),
         }
     }
@@ -2526,7 +2619,7 @@ fn classify_delivery_error(
     error: ironclaw_product_workflow::ProductOutboundDeliveryError,
 ) -> TriggeredNotificationFailure {
     use ironclaw_outbound::OutboundError;
-    use ironclaw_product_workflow::ProductOutboundDeliveryError;
+    use ironclaw_product_workflow::{ProductOutboundDeliveryError, ProductWorkflowError};
     match &error {
         ProductOutboundDeliveryError::Outbound(OutboundError::PreferenceTargetMissing {
             ..
@@ -2534,6 +2627,16 @@ fn classify_delivery_error(
         ProductOutboundDeliveryError::Outbound(OutboundError::AccessDenied) => {
             TriggeredNotificationFailure::Denied
         }
+        // Authority backstop trip: the resolver returned BindingResolutionFailed
+        // with the sentinel reason, meaning the send-time target was not a
+        // personal DM despite the payload carrying an OAuth authorization_url.
+        // The sentinel is matched directly from the Workflow source; if it is
+        // not reachable via pattern (e.g. due to wrapping changes), the
+        // `to_string().contains` fallback below would catch it instead.
+        ProductOutboundDeliveryError::Workflow {
+            source: ProductWorkflowError::BindingResolutionFailed { reason },
+            ..
+        } if reason == OAUTH_TARGET_NOT_DM_MARKER => TriggeredNotificationFailure::OAuthTargetNotDm,
         _ => TriggeredNotificationFailure::Other(error.to_string()),
     }
 }
@@ -2601,6 +2704,12 @@ struct TriggeredSlackReplyTargetAuthority {
     /// refs so inbound replies (which carry team_id as space_id)
     /// fingerprint-match the recorded ref.
     resolved_space_id: std::sync::Mutex<Option<String>>,
+    /// Set per-delivery: true when the current delivery's payload carries an OAuth
+    /// `authorization_url` that may ONLY be posted to a personal DM. The resolver
+    /// enforces this against the EXACT binding resolved at send time, closing the
+    /// snapshot-vs-send race (the pre-loop DM snapshot can go stale while the run
+    /// waits in BlockedAuth).
+    require_personal_dm_for_oauth: std::sync::atomic::AtomicBool,
 }
 
 #[async_trait]
@@ -2624,6 +2733,23 @@ impl ProductOutboundTargetResolver for TriggeredSlackReplyTargetAuthority {
         &self,
         target: &ValidatedReplyTargetBinding,
     ) -> Result<VerifiedProductOutboundTargetMetadata, ProductWorkflowError> {
+        // Authority backstop: if the current delivery carries an OAuth
+        // `authorization_url`, enforce that the EXACT send-time binding is a
+        // personal DM. This closes the snapshot-vs-send race: the pre-loop
+        // `target_is_verified_dm` snapshot can go stale while the run waits in
+        // BlockedAuth; this guard is checked against the binding resolved NOW
+        // (at send time), not the one read earlier. The reason string is matched
+        // in `classify_delivery_error` to map to `OAuthTargetNotDm`.
+        if self
+            .require_personal_dm_for_oauth
+            .load(std::sync::atomic::Ordering::Acquire)
+            && !slack_reply_target_is_personal_dm(target.target())
+        {
+            return Err(ProductWorkflowError::BindingResolutionFailed {
+                reason: OAUTH_TARGET_NOT_DM_MARKER.to_string(),
+            });
+        }
+
         // Decode the DM channel ID from the binding ref. The ref was built by
         // `slack_personal_dm_reply_target_binding_ref` / `slack_shared_channel_reply_target_binding_ref`
         // and encodes space + conversation in length-prefixed segments. We extract
@@ -7040,6 +7166,459 @@ mod tests {
             post_calls.len(),
             1,
             "transport retry of the same event must be deduplicated (only one hint posted)"
+        );
+    }
+
+    // ── Authority backstop: snapshot-vs-send race tests ───────────────────────
+    //
+    // These tests cover the `require_personal_dm_for_oauth` backstop that closes
+    // the race between the pre-loop `target_is_verified_dm` snapshot and the
+    // binding resolved at send time inside
+    // `TriggeredSlackReplyTargetAuthority::resolve_product_outbound_target_metadata`.
+
+    /// A `CommunicationPreferenceRepository` whose `load_communication_preference`
+    /// flips the returned binding between calls. The first call returns a
+    /// personal-DM binding (making `target_is_verified_dm = true` in the pre-loop
+    /// snapshot); all subsequent calls return a shared-channel binding (the
+    /// send-time preference flip).
+    ///
+    /// This simulates the snapshot-vs-send race: the snapshot says DM but the
+    /// actual send-time target is a shared channel.
+    struct FlippingPreferenceRepository {
+        call_count: std::sync::atomic::AtomicU32,
+        dm_record: ironclaw_outbound::CommunicationPreferenceRecord,
+        shared_record: ironclaw_outbound::CommunicationPreferenceRecord,
+    }
+
+    impl FlippingPreferenceRepository {
+        fn new(
+            dm_binding: ReplyTargetBindingRef,
+            shared_binding: ReplyTargetBindingRef,
+            scope: &TurnScope,
+        ) -> Self {
+            let tenant = scope.tenant_id.clone();
+            let user = scope
+                .explicit_owner_user_id()
+                .cloned()
+                .expect("owner user id");
+            let updated_by = user.clone();
+            let dm_record = ironclaw_outbound::CommunicationPreferenceRecord {
+                scope: ironclaw_outbound::DeliveryDefaultScope::personal(
+                    tenant.clone(),
+                    user.clone(),
+                ),
+                final_reply_target: Some(dm_binding.clone()),
+                progress_target: None,
+                approval_prompt_target: Some(dm_binding),
+                auth_prompt_target: None,
+                default_modality: None,
+                updated_at: Utc::now(),
+                updated_by: updated_by.clone(),
+            };
+            let shared_record = ironclaw_outbound::CommunicationPreferenceRecord {
+                scope: ironclaw_outbound::DeliveryDefaultScope::personal(tenant, user),
+                final_reply_target: Some(shared_binding.clone()),
+                progress_target: None,
+                approval_prompt_target: Some(shared_binding),
+                auth_prompt_target: None,
+                default_modality: None,
+                updated_at: Utc::now(),
+                updated_by,
+            };
+            Self {
+                call_count: std::sync::atomic::AtomicU32::new(0),
+                dm_record,
+                shared_record,
+            }
+        }
+    }
+
+    #[async_trait]
+    impl CommunicationPreferenceRepository for FlippingPreferenceRepository {
+        async fn load_communication_preference(
+            &self,
+            _key: CommunicationPreferenceKey,
+        ) -> Result<
+            Option<ironclaw_outbound::VersionedCommunicationPreferenceRecord>,
+            ironclaw_outbound::OutboundError,
+        > {
+            let n = self
+                .call_count
+                .fetch_add(1, std::sync::atomic::Ordering::AcqRel);
+            let record = if n == 0 {
+                // First call (pre-loop snapshot): return personal DM.
+                self.dm_record.clone()
+            } else {
+                // All subsequent calls (send-time resolution): return shared channel.
+                self.shared_record.clone()
+            };
+            Ok(Some(
+                ironclaw_outbound::VersionedCommunicationPreferenceRecord {
+                    record,
+                    version: ironclaw_outbound::CommunicationPreferenceVersion::from_raw(1),
+                },
+            ))
+        }
+
+        async fn write_communication_preference(
+            &self,
+            _request: ironclaw_outbound::WriteCommunicationPreferenceRequest,
+        ) -> Result<
+            ironclaw_outbound::VersionedCommunicationPreferenceRecord,
+            ironclaw_outbound::OutboundError,
+        > {
+            Err(ironclaw_outbound::OutboundError::AccessDenied)
+        }
+    }
+
+    /// A `CommunicationPreferenceRepository` that errors on the FIRST
+    /// `load_communication_preference` call (simulating a transient backend error
+    /// during the pre-loop snapshot read) and delegates all subsequent calls to a
+    /// real `InMemoryOutboundStateStore`.
+    ///
+    /// This lets us verify that a snapshot-read error is fail-closed
+    /// (`target_is_verified_dm = false`) while still allowing the delivery itself
+    /// to proceed (since the outbound policy calls the repo again at send time).
+    struct FirstCallErrorPreferenceRepository {
+        call_count: std::sync::atomic::AtomicU32,
+        delegate: Arc<InMemoryOutboundStateStore>,
+    }
+
+    impl FirstCallErrorPreferenceRepository {
+        fn new(delegate: Arc<InMemoryOutboundStateStore>) -> Self {
+            Self {
+                call_count: std::sync::atomic::AtomicU32::new(0),
+                delegate,
+            }
+        }
+    }
+
+    #[async_trait]
+    impl CommunicationPreferenceRepository for FirstCallErrorPreferenceRepository {
+        async fn load_communication_preference(
+            &self,
+            key: CommunicationPreferenceKey,
+        ) -> Result<
+            Option<ironclaw_outbound::VersionedCommunicationPreferenceRecord>,
+            ironclaw_outbound::OutboundError,
+        > {
+            let n = self
+                .call_count
+                .fetch_add(1, std::sync::atomic::Ordering::AcqRel);
+            if n == 0 {
+                // First call (pre-loop snapshot): simulate a backend error.
+                Err(ironclaw_outbound::OutboundError::Backend)
+            } else {
+                // Subsequent calls (send-time delivery resolution): delegate.
+                self.delegate.load_communication_preference(key).await
+            }
+        }
+
+        async fn write_communication_preference(
+            &self,
+            request: ironclaw_outbound::WriteCommunicationPreferenceRequest,
+        ) -> Result<
+            ironclaw_outbound::VersionedCommunicationPreferenceRecord,
+            ironclaw_outbound::OutboundError,
+        > {
+            self.delegate.write_communication_preference(request).await
+        }
+    }
+
+    /// Build `SlackFinalReplyDeliveryServices` with a custom
+    /// `CommunicationPreferenceRepository` that is separate from the outbound store
+    /// (the outbound store is used for delivery-state only; preference reads go
+    /// through the injected repo).
+    fn make_services_with_prefs(
+        coordinator: Arc<dyn TurnCoordinator>,
+        thread_service: Arc<dyn ironclaw_threads::SessionThreadService>,
+        egress: Arc<FakeProtocolHttpEgress>,
+        outbound: Arc<InMemoryOutboundStateStore>,
+        prefs: Arc<dyn CommunicationPreferenceRepository>,
+        installation_id: &str,
+    ) -> SlackFinalReplyDeliveryServices {
+        SlackFinalReplyDeliveryServices {
+            binding_service: Arc::new(TestNoopConversationBindingService),
+            thread_service,
+            turn_coordinator: coordinator,
+            outbound_store: outbound,
+            route_store: Arc::new(InMemoryDeliveredGateRouteStore::default()),
+            communication_preferences: prefs,
+            adapter: test_adapter(installation_id),
+            egress,
+            delivery_sink: Arc::new(FakeOutboundDeliverySink::default()),
+            auth_challenges: None,
+            approval_requests: None,
+        }
+    }
+
+    /// RACE regression: the pre-loop DM snapshot says DM but the preference flips
+    /// to a shared channel before the send-time binding is resolved.
+    ///
+    /// The authority backstop (`require_personal_dm_for_oauth`) must catch this
+    /// and suppress the OAuth URL. The run must be cancelled and the
+    /// auth-unavailable notice must be posted to the shared channel. No gate
+    /// route must be recorded.
+    #[tokio::test]
+    async fn triggered_oauth_auth_dm_snapshot_but_channel_at_send_suppresses_url() {
+        let install = "test-install";
+        let gate_ref_str = "gate:oauth-race-snapshot-dm-send-channel";
+        let scope = personal_turn_scope();
+        let run_id = TurnRunId::new();
+        let agent = scope.agent_id.as_ref().expect("agent").as_str();
+
+        // The personal-DM binding is returned on the FIRST load (snapshot).
+        let dm_binding = test_slack_binding_ref(install, agent);
+        // The shared-channel binding is returned on the SECOND+ loads (send time).
+        let shared_binding = test_slack_shared_channel_binding_ref(install, agent);
+
+        // First poll → BlockedAuth with OAuth gate; second poll → Completed.
+        let coordinator = Arc::new(ScriptedTurnCoordinator::with_states(vec![
+            scripted_state(TurnStatus::BlockedAuth, Some(gate_ref_str)),
+            scripted_state(TurnStatus::Completed, None),
+        ]));
+        let thread_service = Arc::new(InMemorySessionThreadService::default());
+        seed_finalized_assistant_message(
+            &thread_service,
+            &scope,
+            run_id,
+            "Run complete after auth.",
+        )
+        .await;
+
+        // Outbound store: seed the shared-channel binding so the policy service
+        // resolves it (the FlippingPreferenceRepository drives the snapshot vs
+        // send-time distinction).
+        let outbound = Arc::new(InMemoryOutboundStateStore::default());
+        seed_personal_preference(&outbound, &scope, shared_binding.clone()).await;
+
+        // The flipping preference repo: DM on first call, shared-channel on
+        // subsequent calls.
+        let prefs = Arc::new(FlippingPreferenceRepository::new(
+            dm_binding,
+            shared_binding,
+            &scope,
+        ));
+
+        let egress = Arc::new(FakeProtocolHttpEgress::new(vec!["slack.com".to_string()]));
+        egress.allow_credential_handle("slack_bot_token");
+        // auth-unavailable notice (after backstop trip).
+        egress.program_response(
+            "slack.com",
+            Ok(EgressResponse::new(
+                200,
+                slack_post_ok_json("C0SHARED", "race-test.1"),
+            )),
+        );
+        // Final reply after Completed (the loop re-runs once after cancel).
+        egress.program_response(
+            "slack.com",
+            Ok(EgressResponse::new(
+                200,
+                slack_post_ok_json("C0SHARED", "race-test.2"),
+            )),
+        );
+
+        let delivery_store = Arc::new(InMemoryTriggeredRunDeliveryStore::default());
+        let route_store = Arc::new(InMemoryDeliveredGateRouteStore::default());
+        let mut services = make_services_with_prefs(
+            coordinator,
+            thread_service,
+            egress.clone(),
+            outbound,
+            prefs,
+            install,
+        );
+        // Wire up an OAuth challenge provider so authorization_url would be set
+        // if the backstop were absent.
+        services.auth_challenges = Some(Arc::new(OAuthAuthChallengeProvider {
+            url: "https://provider.example/oauth-race".to_string(),
+        }));
+
+        let settings = SlackFinalReplyDeliverySettings {
+            poll_interval: std::time::Duration::ZERO,
+            max_wait: std::time::Duration::from_secs(5),
+            max_concurrent_deliveries: NonZeroUsize::new(1).unwrap(),
+            max_pending_deliveries: NonZeroUsize::new(8).unwrap(),
+        };
+        let driver = TriggeredRunDeliveryDriver::with_settings(
+            services,
+            settings,
+            delivery_store.clone(),
+            route_store.clone(),
+            scope.agent_id.clone().expect("test scope has agent"),
+        );
+
+        driver
+            .on_trigger_submitted(minimal_trigger_fire(None), run_id, scope.clone())
+            .await;
+        wait_for_delivery_record(&delivery_store, run_id).await;
+
+        let posted: Vec<String> = egress
+            .calls()
+            .iter()
+            .filter(|c| c.path == "/api/chat.postMessage")
+            .map(|c| String::from_utf8_lossy(&c.body).to_string())
+            .collect();
+
+        // The OAuth URL must NOT appear in any posted message.
+        for body in &posted {
+            assert!(
+                !body.contains("https://provider.example/oauth-race"),
+                "authorization_url must NOT be posted when send-time target is a shared channel \
+                 (race backstop); got: {body}"
+            );
+        }
+
+        // The auth-unavailable notice must appear (backstop tripped).
+        assert!(
+            posted
+                .iter()
+                .any(|b| b.contains(SLACK_AUTH_UNAVAILABLE_MESSAGE)),
+            "auth-unavailable notice must be posted when backstop suppresses OAuth URL; \
+             got: {posted:?}"
+        );
+
+        // No gate route must be recorded (the auth was cancelled).
+        let creator = ironclaw_host_api::UserId::new("creator-user").expect("user id");
+        let route = route_store
+            .load_delivered_gate_route(&scope.tenant_id, &creator, gate_ref_str)
+            .await
+            .expect("load route");
+        assert!(
+            route.is_none(),
+            "no gate route must be recorded when backstop cancels OAuth delivery"
+        );
+    }
+
+    /// Fail-closed: `load_communication_preference` returns `Err` on the
+    /// pre-loop snapshot read → `target_is_verified_dm = false` → OAuth URL
+    /// suppressed → auth-unavailable notice posted. No gate route recorded.
+    ///
+    /// Covers reviewer item Y: a preference-read error must not allow the OAuth
+    /// URL to leak by default-treating the target as a DM.
+    #[tokio::test]
+    async fn triggered_oauth_auth_preference_read_error_suppresses_authorization_url() {
+        let install = "test-install";
+        let gate_ref_str = "gate:oauth-pref-error";
+        let scope = personal_turn_scope();
+        let run_id = TurnRunId::new();
+        let agent = scope.agent_id.as_ref().expect("agent").as_str();
+
+        // The shared-channel binding is seeded in the outbound store so the
+        // outbound policy can resolve it. The preference repo always errors, so
+        // the snapshot is false (fail-closed).
+        let shared_binding = test_slack_shared_channel_binding_ref(install, agent);
+
+        let coordinator = Arc::new(ScriptedTurnCoordinator::with_states(vec![
+            scripted_state(TurnStatus::BlockedAuth, Some(gate_ref_str)),
+            scripted_state(TurnStatus::Completed, None),
+        ]));
+        let thread_service = Arc::new(InMemorySessionThreadService::default());
+        seed_finalized_assistant_message(
+            &thread_service,
+            &scope,
+            run_id,
+            "Run complete after auth.",
+        )
+        .await;
+
+        let outbound = Arc::new(InMemoryOutboundStateStore::default());
+        seed_personal_preference(&outbound, &scope, shared_binding).await;
+
+        // First-call-error preference repository: errors on the pre-loop snapshot
+        // read, then delegates to the real outbound store for delivery-time calls.
+        // This ensures `target_is_verified_dm = false` (fail-closed) while still
+        // letting the delivery succeed so we can observe the auth-unavailable notice.
+        let prefs = Arc::new(FirstCallErrorPreferenceRepository::new(Arc::clone(
+            &outbound,
+        )));
+
+        let egress = Arc::new(FakeProtocolHttpEgress::new(vec!["slack.com".to_string()]));
+        egress.allow_credential_handle("slack_bot_token");
+        // auth-unavailable notice.
+        egress.program_response(
+            "slack.com",
+            Ok(EgressResponse::new(
+                200,
+                slack_post_ok_json("C0SHARED", "pref-err.1"),
+            )),
+        );
+        // Final reply after Completed.
+        egress.program_response(
+            "slack.com",
+            Ok(EgressResponse::new(
+                200,
+                slack_post_ok_json("C0SHARED", "pref-err.2"),
+            )),
+        );
+
+        let delivery_store = Arc::new(InMemoryTriggeredRunDeliveryStore::default());
+        let route_store = Arc::new(InMemoryDeliveredGateRouteStore::default());
+        let mut services = make_services_with_prefs(
+            coordinator,
+            thread_service,
+            egress.clone(),
+            outbound,
+            prefs,
+            install,
+        );
+        services.auth_challenges = Some(Arc::new(OAuthAuthChallengeProvider {
+            url: "https://provider.example/oauth-pref-error".to_string(),
+        }));
+
+        let settings = SlackFinalReplyDeliverySettings {
+            poll_interval: std::time::Duration::ZERO,
+            max_wait: std::time::Duration::from_secs(5),
+            max_concurrent_deliveries: NonZeroUsize::new(1).unwrap(),
+            max_pending_deliveries: NonZeroUsize::new(8).unwrap(),
+        };
+        let driver = TriggeredRunDeliveryDriver::with_settings(
+            services,
+            settings,
+            delivery_store.clone(),
+            route_store.clone(),
+            scope.agent_id.clone().expect("test scope has agent"),
+        );
+
+        driver
+            .on_trigger_submitted(minimal_trigger_fire(None), run_id, scope.clone())
+            .await;
+        wait_for_delivery_record(&delivery_store, run_id).await;
+
+        let posted: Vec<String> = egress
+            .calls()
+            .iter()
+            .filter(|c| c.path == "/api/chat.postMessage")
+            .map(|c| String::from_utf8_lossy(&c.body).to_string())
+            .collect();
+
+        // The OAuth URL must NOT appear anywhere.
+        for body in &posted {
+            assert!(
+                !body.contains("https://provider.example/oauth-pref-error"),
+                "authorization_url must NOT be posted when preference read errors (fail closed); \
+                 got: {body}"
+            );
+        }
+
+        // The auth-unavailable notice must be posted.
+        assert!(
+            posted
+                .iter()
+                .any(|b| b.contains(SLACK_AUTH_UNAVAILABLE_MESSAGE)),
+            "auth-unavailable notice must be posted when preference read errors; got: {posted:?}"
+        );
+
+        // No gate route recorded.
+        let creator = ironclaw_host_api::UserId::new("creator-user").expect("user id");
+        let route = route_store
+            .load_delivered_gate_route(&scope.tenant_id, &creator, gate_ref_str)
+            .await
+            .expect("load route");
+        assert!(
+            route.is_none(),
+            "no gate route must be recorded when OAuth is suppressed due to preference read error"
         );
     }
 }

--- a/crates/ironclaw_reborn_composition/src/slack_delivery.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_delivery.rs
@@ -1411,6 +1411,18 @@ enum SlackFinalReplyDeliveryError {
     InvalidProjectionRef { reason: String },
 }
 
+/// Fail closed when a delivery that must reach a personal DM (e.g. carries an
+/// OAuth authorization_url) resolves to a non-DM target.
+fn enforce_direct_message_if_required(
+    target: &ReplyTargetBindingRef,
+    require_direct_message: bool,
+) -> Result<(), ProductWorkflowError> {
+    if require_direct_message && !slack_reply_target_is_personal_dm(target) {
+        return Err(ProductWorkflowError::OutboundTargetNotDirectMessage);
+    }
+    Ok(())
+}
+
 struct ObservedSlackReplyTargetAuthority {
     scope: TurnScope,
     actor: TurnActor,
@@ -1446,9 +1458,7 @@ impl ProductOutboundTargetResolver for ObservedSlackReplyTargetAuthority {
             return Err(ProductWorkflowError::BindingAccessDenied);
         }
         // Defense in depth: honor the DM requirement even on the live-path resolver.
-        if require_direct_message && !slack_reply_target_is_personal_dm(target.target()) {
-            return Err(ProductWorkflowError::OutboundTargetNotDirectMessage);
-        }
+        enforce_direct_message_if_required(target.target(), require_direct_message)?;
         Ok(VerifiedProductOutboundTargetMetadata {
             external_conversation_ref: self.external_conversation_ref.clone(),
             external_actor_ref: self.external_actor_ref.clone(),
@@ -2223,8 +2233,7 @@ async fn deliver_triggered_run(
                     }
                     TriggeredNotificationFailure::Denied => TriggeredRunDeliveryOutcomeKind::Denied,
                     TriggeredNotificationFailure::OAuthTargetNotDm => {
-                        // Handled in the dedicated arm above; unreachable here.
-                        TriggeredRunDeliveryOutcomeKind::Failed
+                        unreachable!("OAuthTargetNotDm is handled by the dedicated arm above")
                     }
                     TriggeredNotificationFailure::Other(_) => {
                         TriggeredRunDeliveryOutcomeKind::Failed
@@ -2507,6 +2516,7 @@ impl std::fmt::Display for TriggeredNotificationFailure {
 }
 
 /// Delivers a triggered-run notification, returning the list of posted Slack messages.
+// arch-exempt: too_many_args, needs a delivery-request bundle (services + scope + actor + state + authority + notification), plan #4953
 #[allow(clippy::too_many_arguments)]
 async fn deliver_triggered_notification(
     services: &SlackFinalReplyDeliveryServices,
@@ -2695,9 +2705,7 @@ impl ProductOutboundTargetResolver for TriggeredSlackReplyTargetAuthority {
         // authorization_url), enforce that the EXACT send-time binding is a personal
         // DM. Checked against the binding resolved NOW (at send time), making it
         // race-free against the pre-loop preference snapshot going stale.
-        if require_direct_message && !slack_reply_target_is_personal_dm(target.target()) {
-            return Err(ProductWorkflowError::OutboundTargetNotDirectMessage);
-        }
+        enforce_direct_message_if_required(target.target(), require_direct_message)?;
 
         // Decode the DM channel ID from the binding ref. The ref was built by
         // `slack_personal_dm_reply_target_binding_ref` / `slack_shared_channel_reply_target_binding_ref`
@@ -7490,4 +7498,51 @@ mod tests {
     // Removed: triggered_oauth_auth_no_preference_suppresses_authorization_url
     // — tested the pre-loop snapshot fail-closed behavior for an absent preference
     // record; redundant after snapshot removal for the same reason as above.
+
+    // ── enforce_direct_message_if_required ────────────────────────────────────
+    //
+    // Direct unit tests for the shared helper that both ObservedSlackReplyTargetAuthority
+    // and TriggeredSlackReplyTargetAuthority delegate to (Fix 3 / Fix 6).
+    //
+    // The helper takes `&ReplyTargetBindingRef` so no ValidatedReplyTargetBinding
+    // scaffolding is required — we test the guard logic directly.
+
+    #[test]
+    fn enforce_direct_message_shared_channel_require_true_returns_err() {
+        let install = "test-install";
+        let agent = "test-agent";
+        let binding_ref = test_slack_shared_channel_binding_ref(install, agent);
+        let result = enforce_direct_message_if_required(&binding_ref, true);
+        assert!(
+            matches!(
+                result,
+                Err(ProductWorkflowError::OutboundTargetNotDirectMessage)
+            ),
+            "shared channel + require=true must return OutboundTargetNotDirectMessage"
+        );
+    }
+
+    #[test]
+    fn enforce_direct_message_shared_channel_require_false_returns_ok() {
+        let install = "test-install";
+        let agent = "test-agent";
+        let binding_ref = test_slack_shared_channel_binding_ref(install, agent);
+        let result = enforce_direct_message_if_required(&binding_ref, false);
+        assert!(
+            result.is_ok(),
+            "shared channel + require=false must not be rejected"
+        );
+    }
+
+    #[test]
+    fn enforce_direct_message_dm_binding_require_true_returns_ok() {
+        let install = "test-install";
+        let agent = "test-agent";
+        let binding_ref = test_slack_binding_ref(install, agent);
+        let result = enforce_direct_message_if_required(&binding_ref, true);
+        assert!(
+            result.is_ok(),
+            "personal DM binding + require=true must not be rejected"
+        );
+    }
 }

--- a/crates/ironclaw_reborn_composition/src/slack_delivery.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_delivery.rs
@@ -2005,8 +2005,16 @@ async fn deliver_triggered_run(
     // iteration. Fail closed: if the preference cannot be read or the binding ref
     // does not parse as a personal DM, treat the target as non-DM.
     let target_is_verified_dm = {
+        // Resolve the preference owner: for owner-scoped runs the preference is
+        // stored under the owner identity, not the acting principal. Using the
+        // actor here would read a different (potentially absent) record and
+        // fail-close even when the owner has a valid personal-DM target.
+        let pref_owner_user_id = scope
+            .explicit_owner_user_id()
+            .cloned()
+            .unwrap_or_else(|| actor.user_id.clone());
         let pref_key =
-            CommunicationPreferenceKey::personal(scope.tenant_id.clone(), actor.user_id.clone());
+            CommunicationPreferenceKey::personal(scope.tenant_id.clone(), pref_owner_user_id);
         match services
             .communication_preferences
             .load_communication_preference(pref_key)
@@ -2193,6 +2201,13 @@ async fn deliver_triggered_run(
                     "triggered run OAuth URL suppressed by send-time backstop: resolved \
                      target is not a personal DM; cancelling run"
                 );
+                // Clean up any OAuth auth-prompt messages that were posted to a DM in
+                // earlier loop iterations. Both return paths in this arm must not
+                // leave those messages lingering — drain once here, before the first
+                // possible return.
+                for message in messages_to_delete_after_final.drain(..) {
+                    delete_triggered_slack_message(services, message).await;
+                }
                 // Cancel the blocked run.
                 if let Err(err) = cancel_auth_blocked_run(
                     services.turn_coordinator.as_ref(),
@@ -7337,6 +7352,61 @@ mod tests {
         }
     }
 
+    /// A `CommunicationPreferenceRepository` that returns `Ok(None)` on the
+    /// FIRST `load_communication_preference` call (simulating an absent record
+    /// during the pre-loop snapshot read) and delegates all subsequent calls to
+    /// a real `InMemoryOutboundStateStore`.
+    ///
+    /// This lets us verify that a snapshot-read of `Ok(None)` is fail-closed
+    /// (`target_is_verified_dm = false`) while still allowing the delivery itself
+    /// to proceed (since the outbound policy calls the repo again at send time
+    /// and finds the seeded preference).
+    struct FirstCallNonePreferenceRepository {
+        call_count: std::sync::atomic::AtomicU32,
+        delegate: Arc<InMemoryOutboundStateStore>,
+    }
+
+    impl FirstCallNonePreferenceRepository {
+        fn new(delegate: Arc<InMemoryOutboundStateStore>) -> Self {
+            Self {
+                call_count: std::sync::atomic::AtomicU32::new(0),
+                delegate,
+            }
+        }
+    }
+
+    #[async_trait]
+    impl CommunicationPreferenceRepository for FirstCallNonePreferenceRepository {
+        async fn load_communication_preference(
+            &self,
+            key: CommunicationPreferenceKey,
+        ) -> Result<
+            Option<ironclaw_outbound::VersionedCommunicationPreferenceRecord>,
+            ironclaw_outbound::OutboundError,
+        > {
+            let n = self
+                .call_count
+                .fetch_add(1, std::sync::atomic::Ordering::AcqRel);
+            if n == 0 {
+                // First call (pre-loop snapshot): simulate absent preference.
+                Ok(None)
+            } else {
+                // Subsequent calls (send-time delivery resolution): delegate.
+                self.delegate.load_communication_preference(key).await
+            }
+        }
+
+        async fn write_communication_preference(
+            &self,
+            request: ironclaw_outbound::WriteCommunicationPreferenceRequest,
+        ) -> Result<
+            ironclaw_outbound::VersionedCommunicationPreferenceRecord,
+            ironclaw_outbound::OutboundError,
+        > {
+            self.delegate.write_communication_preference(request).await
+        }
+    }
+
     /// Build `SlackFinalReplyDeliveryServices` with a custom
     /// `CommunicationPreferenceRepository` that is separate from the outbound store
     /// (the outbound store is used for delivery-state only; preference reads go
@@ -7631,6 +7701,139 @@ mod tests {
         assert!(
             route.is_none(),
             "no gate route must be recorded when OAuth is suppressed due to preference read error"
+        );
+    }
+
+    /// Fail-closed: `load_communication_preference` returns `Ok(None)` (no
+    /// preference record stored) on the pre-loop snapshot read →
+    /// `target_is_verified_dm = false` → OAuth URL suppressed →
+    /// auth-unavailable notice posted instead. No gate route recorded.
+    ///
+    /// Regression for A5/A3: an absent preference must not be treated as a DM.
+    #[tokio::test]
+    async fn triggered_oauth_auth_no_preference_suppresses_authorization_url() {
+        let install = "test-install";
+        let gate_ref_str = "gate:oauth-no-preference";
+        let scope = personal_turn_scope();
+        let run_id = TurnRunId::new();
+        let agent = scope.agent_id.as_ref().expect("agent").as_str();
+
+        // Shared-channel binding seeded in the outbound store so delivery can
+        // resolve it. The preference repo (the default empty InMemoryOutboundStateStore)
+        // has NO communication preference record, so the snapshot read returns
+        // Ok(None) → fail-closed.
+        let shared_binding = test_slack_shared_channel_binding_ref(install, agent);
+
+        let coordinator = Arc::new(ScriptedTurnCoordinator::with_states(vec![
+            scripted_state(TurnStatus::BlockedAuth, Some(gate_ref_str)),
+            scripted_state(TurnStatus::Completed, None),
+        ]));
+        let thread_service = Arc::new(InMemorySessionThreadService::default());
+        seed_finalized_assistant_message(
+            &thread_service,
+            &scope,
+            run_id,
+            "Run complete after auth.",
+        )
+        .await;
+
+        // The outbound store is seeded with the delivery-target binding so the
+        // FinalReply notice can be posted.  The preference repo (FirstCallNonePreferenceRepository)
+        // returns Ok(None) on the first (pre-loop snapshot) call → fail-closed, then
+        // delegates to the real store on subsequent (send-time) calls so delivery
+        // can proceed.
+        let outbound = Arc::new(InMemoryOutboundStateStore::default());
+        seed_personal_preference(&outbound, &scope, shared_binding).await;
+
+        let prefs = Arc::new(FirstCallNonePreferenceRepository::new(Arc::clone(
+            &outbound,
+        )));
+
+        let egress = Arc::new(FakeProtocolHttpEgress::new(vec!["slack.com".to_string()]));
+        egress.allow_credential_handle("slack_bot_token");
+        // auth-unavailable notice.
+        egress.program_response(
+            "slack.com",
+            Ok(EgressResponse::new(
+                200,
+                slack_post_ok_json("C0SHARED", "no-pref.1"),
+            )),
+        );
+        // Final reply after Completed.
+        egress.program_response(
+            "slack.com",
+            Ok(EgressResponse::new(
+                200,
+                slack_post_ok_json("C0SHARED", "no-pref.2"),
+            )),
+        );
+
+        let delivery_store = Arc::new(InMemoryTriggeredRunDeliveryStore::default());
+        let route_store = Arc::new(InMemoryDeliveredGateRouteStore::default());
+        let mut services = make_services_with_prefs(
+            coordinator,
+            thread_service,
+            egress.clone(),
+            outbound,
+            prefs,
+            install,
+        );
+        services.auth_challenges = Some(Arc::new(OAuthAuthChallengeProvider {
+            url: "https://provider.example/oauth-no-preference".to_string(),
+        }));
+
+        let settings = SlackFinalReplyDeliverySettings {
+            poll_interval: std::time::Duration::ZERO,
+            max_wait: std::time::Duration::from_secs(5),
+            max_concurrent_deliveries: NonZeroUsize::new(1).unwrap(),
+            max_pending_deliveries: NonZeroUsize::new(8).unwrap(),
+        };
+        let driver = TriggeredRunDeliveryDriver::with_settings(
+            services,
+            settings,
+            delivery_store.clone(),
+            route_store.clone(),
+            scope.agent_id.clone().expect("test scope has agent"),
+        );
+
+        driver
+            .on_trigger_submitted(minimal_trigger_fire(None), run_id, scope.clone())
+            .await;
+        wait_for_delivery_record(&delivery_store, run_id).await;
+
+        let posted: Vec<String> = egress
+            .calls()
+            .iter()
+            .filter(|c| c.path == "/api/chat.postMessage")
+            .map(|c| String::from_utf8_lossy(&c.body).to_string())
+            .collect();
+
+        // The OAuth URL must NOT appear anywhere (no preference → fail closed).
+        for body in &posted {
+            assert!(
+                !body.contains("https://provider.example/oauth-no-preference"),
+                "authorization_url must NOT be posted when no preference is stored (fail closed); \
+                 got: {body}"
+            );
+        }
+
+        // The auth-unavailable notice must be posted.
+        assert!(
+            posted
+                .iter()
+                .any(|b| b.contains(SLACK_AUTH_UNAVAILABLE_MESSAGE)),
+            "auth-unavailable notice must be posted when no preference is stored; got: {posted:?}"
+        );
+
+        // No gate route recorded.
+        let creator = ironclaw_host_api::UserId::new("creator-user").expect("user id");
+        let route = route_store
+            .load_delivered_gate_route(&scope.tenant_id, &creator, gate_ref_str)
+            .await
+            .expect("load route");
+        assert!(
+            route.is_none(),
+            "no gate route must be recorded when OAuth is suppressed due to absent preference"
         );
     }
 }

--- a/crates/ironclaw_reborn_composition/src/slack_delivery.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_delivery.rs
@@ -16,13 +16,13 @@ use async_trait::async_trait;
 use chrono::Utc;
 use ironclaw_outbound::{
     CommunicationDeliveryIntent, CommunicationDeliveryResolutionRequest, CommunicationModality,
-    CommunicationPreferenceRepository, DeliveredGateRouteRecord, DeliveredGateRouteStore,
-    OutboundError, OutboundPolicyService, OutboundStateStore, ProjectionUpdateRef,
-    ReplyTargetBindingClaim, ReplyTargetBindingValidator, ReplyTargetValidationRequest,
-    RunNotificationContext, RunNotificationEventKind, RunNotificationOrigin, SourceRouteContext,
-    TriggerCommunicationContext, TriggerFireSlot, TriggerOriginRef, TriggerSourceKind,
-    TriggeredRunDeliveryOutcomeKind, TriggeredRunDeliveryRecord, TriggeredRunDeliveryStore,
-    ValidatedReplyTargetBinding,
+    CommunicationPreferenceKey, CommunicationPreferenceRepository, DeliveredGateRouteRecord,
+    DeliveredGateRouteStore, OutboundError, OutboundPolicyService, OutboundStateStore,
+    ProjectionUpdateRef, ReplyTargetBindingClaim, ReplyTargetBindingValidator,
+    ReplyTargetValidationRequest, RunNotificationContext, RunNotificationEventKind,
+    RunNotificationOrigin, SourceRouteContext, TriggerCommunicationContext, TriggerFireSlot,
+    TriggerOriginRef, TriggerSourceKind, TriggeredRunDeliveryOutcomeKind,
+    TriggeredRunDeliveryRecord, TriggeredRunDeliveryStore, ValidatedReplyTargetBinding,
 };
 use ironclaw_product_adapters::{
     ApprovalPromptContextView, DeclaredEgressHost, EgressCredentialHandle, EgressHeader,
@@ -52,7 +52,9 @@ use tokio::sync::Semaphore;
 
 use crate::AuthChallengeProvider;
 use crate::auth_prompt::auth_prompt_view_for_blocked_auth;
-use crate::slack_outbound_targets::slack_conversation_id_from_reply_target_binding_ref;
+use crate::slack_outbound_targets::{
+    slack_conversation_id_from_reply_target_binding_ref, slack_reply_target_is_personal_dm,
+};
 
 const MAX_SLACK_RUN_POLL_INTERVAL: Duration = Duration::from_secs(5);
 const DEFAULT_TRIGGERED_RUN_DELIVERY_MAX_WAIT: Duration = Duration::from_secs(30 * 60);
@@ -1987,6 +1989,56 @@ async fn deliver_triggered_run(
         resolved_space_id: std::sync::Mutex::new(None),
     };
 
+    // Pre-check: determine whether the creator's preferred delivery target is a
+    // verified personal DM. OAuth `authorization_url` values must ONLY be posted
+    // to a personal DM — posting one to a shared channel would leak the OAuth
+    // setup URL to every member of that channel. We resolve the preference once
+    // here (it does not change during delivery) so `triggered_notification_for_state`
+    // can gate the OAuth post without performing an async lookup on every loop
+    // iteration. Fail closed: if the preference cannot be read or the binding ref
+    // does not parse as a personal DM, treat the target as non-DM.
+    let target_is_verified_dm = {
+        let pref_key =
+            CommunicationPreferenceKey::personal(scope.tenant_id.clone(), actor.user_id.clone());
+        match services
+            .communication_preferences
+            .load_communication_preference(pref_key)
+            .await
+        {
+            Ok(Some(versioned)) => {
+                let record = &versioned.record;
+                // Gate on the EXACT target the auth prompt will resolve to, not
+                // "any stored target". The resolution engine resolves an
+                // auth-prompt intent as `auth_prompt_target.or(final_reply_target)`
+                // (see `resolution_engine.rs` `PreferenceTargetKind::AuthPrompt`) —
+                // `approval_prompt_target` is not in the auth chain, and the
+                // fallback only applies when `auth_prompt_target` is absent. A
+                // looser `.any()` would wrongly pass when `auth_prompt_target` is a
+                // shared channel but `final_reply_target` happens to be a DM, and
+                // still leak the OAuth URL to the channel.
+                let effective_auth_target = record
+                    .auth_prompt_target
+                    .as_ref()
+                    .or(record.final_reply_target.as_ref());
+                match effective_auth_target {
+                    Some(target) => slack_reply_target_is_personal_dm(target),
+                    None => false,
+                }
+            }
+            Ok(None) => false,
+            Err(err) => {
+                tracing::warn!(
+                    target = "ironclaw::reborn::slack_delivery",
+                    %run_id,
+                    error = %err,
+                    "triggered delivery: failed to load communication preference for DM check; \
+                     treating target as non-DM (fail closed)"
+                );
+                false
+            }
+        }
+    };
+
     let mut delivered_blocked_marker: Option<BlockedActionableMarker> = None;
     let mut messages_to_delete_after_final = Vec::new();
 
@@ -2026,6 +2078,7 @@ async fn deliver_triggered_run(
             &state,
             run_id,
             &trigger_label,
+            target_is_verified_dm,
         )
         .await
         {
@@ -2235,6 +2288,7 @@ fn triggered_label_from_prompt(prompt: &str) -> String {
 /// the DM's own scope — it never reaches the triggered run. If you extend this
 /// function, preserve that boundary: do not mint conversational/streaming payloads
 /// here, and do not assume inbound free-text can address a triggered run.
+#[allow(clippy::too_many_arguments)]
 async fn triggered_notification_for_state(
     services: &SlackFinalReplyDeliveryServices,
     scope: &TurnScope,
@@ -2243,6 +2297,7 @@ async fn triggered_notification_for_state(
     state: &TurnRunState,
     run_id: TurnRunId,
     trigger_label: &str,
+    target_is_verified_dm: bool,
 ) -> Result<Option<SlackActionableNotification>, SlackFinalReplyDeliveryError> {
     match state.status {
         TurnStatus::Completed => {
@@ -2324,20 +2379,32 @@ async fn triggered_notification_for_state(
             )
             .await?;
             view.body.push_str(&triggered_gate_footer(trigger_label));
-            // Same policy as the live path: only link-based OAuth is allowed over
-            // Slack. A triggered run delivers to the creator's private DM, so the
-            // OAuth `authorization_url` is safe to post there and the callback
-            // resumes the run server-side (a reply in the thread is not required).
-            // Any non-OAuth challenge (manual token / API-key entry) is denied:
-            // cancel the run and post a notice — nothing secret is solicited in
-            // the channel.
-            if view.authorization_url.is_some() {
+            // Only link-based OAuth is allowed over Slack, AND only when the
+            // resolved delivery target is a verified personal DM. Posting an
+            // OAuth `authorization_url` to a shared channel would leak the
+            // setup link to every member of that channel.
+            //
+            // Fail-closed rule: if the target cannot be verified as a personal
+            // DM (`target_is_verified_dm` is false), treat the OAuth challenge
+            // the same as a non-OAuth challenge — cancel the run and post the
+            // auth-unavailable notice. When the target IS a personal DM and the
+            // challenge is link-based OAuth (`authorization_url` is Some), post
+            // the OAuth prompt; the callback resumes the run server-side.
+            if view.authorization_url.is_some() && target_is_verified_dm {
                 Ok(Some(SlackActionableNotification {
                     event_kind: RunNotificationEventKind::AuthRequired,
                     payload: ProductOutboundPayload::AuthPrompt(view),
                     gate_ref_for_routing: Some(gate_ref.as_str().to_string()),
                 }))
             } else {
+                if view.authorization_url.is_some() {
+                    tracing::warn!(
+                        target = "ironclaw::reborn::slack_delivery",
+                        %run_id,
+                        "triggered run OAuth auth blocked: delivery target is not a verified \
+                         personal DM; cancelling run to avoid leaking authorization_url"
+                    );
+                }
                 cancel_auth_blocked_run(
                     services.turn_coordinator.as_ref(),
                     scope,
@@ -2982,6 +3049,41 @@ mod tests {
             progress_target: None,
             approval_prompt_target: Some(binding_ref),
             auth_prompt_target: None,
+            default_modality: None,
+            updated_at: Utc::now(),
+            updated_by,
+        };
+        store
+            .write_communication_preference(WriteCommunicationPreferenceRequest {
+                record,
+                expected_version: None,
+            })
+            .await
+            .expect("seed preference");
+    }
+
+    /// Seed a personal preference with distinct `auth_prompt_target` and
+    /// `final_reply_target` binding refs. Used to prove the OAuth DM gate keys on
+    /// the EFFECTIVE auth target (`auth_prompt_target.or(final_reply_target)`),
+    /// not "any stored target".
+    async fn seed_personal_preference_with_auth_target(
+        store: &InMemoryOutboundStateStore,
+        scope: &TurnScope,
+        auth_prompt_target: ReplyTargetBindingRef,
+        final_reply_target: ReplyTargetBindingRef,
+    ) {
+        let tenant = scope.tenant_id.clone();
+        let user = scope
+            .explicit_owner_user_id()
+            .cloned()
+            .expect("owner user id for preference seed");
+        let updated_by = user.clone();
+        let record = CommunicationPreferenceRecord {
+            scope: DeliveryDefaultScope::personal(tenant, user),
+            final_reply_target: Some(final_reply_target),
+            progress_target: None,
+            approval_prompt_target: None,
+            auth_prompt_target: Some(auth_prompt_target),
             default_modality: None,
             updated_at: Utc::now(),
             updated_by,
@@ -5595,6 +5697,407 @@ mod tests {
                 .iter()
                 .any(|b| b.contains(SLACK_AUTH_UNAVAILABLE_MESSAGE)),
             "expected the auth-unavailable notice to be posted; got: {posted:?}"
+        );
+    }
+
+    // ── DM-gate security tests ─────────────────────────────────────────────────
+    //
+    // These tests verify the fail-closed gate that prevents OAuth
+    // `authorization_url` values from leaking onto shared Slack channels.
+
+    /// Fake `AuthChallengeProvider` that always returns an OAuth challenge
+    /// with the given `authorization_url`.
+    struct OAuthAuthChallengeProvider {
+        url: String,
+    }
+
+    #[async_trait]
+    impl AuthChallengeProvider for OAuthAuthChallengeProvider {
+        async fn challenge_for_gate(
+            &self,
+            _scope: &TurnScope,
+            _owner_user_id: &ironclaw_host_api::UserId,
+            _run_id: TurnRunId,
+            _gate_ref: &str,
+            _credential_requirements: &[ironclaw_host_api::RuntimeCredentialAuthRequirement],
+        ) -> Result<Option<crate::auth_prompt::AuthChallengeView>, ironclaw_auth::AuthProductError>
+        {
+            Ok(Some(crate::auth_prompt::AuthChallengeView {
+                kind: ironclaw_product_adapters::AuthPromptChallengeKind::OAuthUrl,
+                provider: ironclaw_auth::AuthProviderId::new("test-provider").expect("provider"),
+                account_label: None,
+                authorization_url: Some(
+                    ironclaw_auth::OAuthAuthorizationUrl::new(self.url.clone()).expect("url"),
+                ),
+                expires_at: None,
+            }))
+        }
+    }
+
+    /// Build a shared-channel binding ref for use in tests (no actor segments).
+    fn test_slack_shared_channel_binding_ref(
+        installation_id: &str,
+        agent_id: &str,
+    ) -> ReplyTargetBindingRef {
+        fn seg(name: &str, value: &str) -> String {
+            format!("{}:{}:{};", name, value.len(), value)
+        }
+        let raw = format!(
+            "{}{}{}{}{}{}{}",
+            seg("adapter", "slack_v2"),
+            seg("installation", installation_id),
+            seg("agent", agent_id),
+            seg("project", ""),
+            seg("space", "T123"),
+            seg("conversation", "C0SHARED"),
+            seg("topic", ""),
+        );
+        crate::slack_outbound_targets::slack_reply_target_binding_ref_from_raw(raw)
+            .expect("test shared-channel binding ref")
+    }
+
+    /// Security regression: triggered OAuth auth whose delivery target is a SHARED
+    /// CHANNEL must NOT post the `authorization_url`. The run must be cancelled and
+    /// the auth-unavailable notice must be posted instead.
+    ///
+    /// This is the "fail closed" path: if the binding ref does not parse as a
+    /// personal DM, the OAuth URL is suppressed regardless of `authorization_url`
+    /// being set.
+    #[tokio::test]
+    async fn triggered_oauth_auth_to_shared_channel_suppresses_authorization_url() {
+        let install = "test-install";
+        let gate_ref_str = "gate:oauth-shared-channel-leak";
+        let scope = personal_turn_scope();
+        let run_id = TurnRunId::new();
+
+        // Use a shared-channel binding ref (no actor_kind / actor segments).
+        let binding_ref = test_slack_shared_channel_binding_ref(
+            install,
+            scope.agent_id.as_ref().expect("agent").as_str(),
+        );
+
+        // First poll → BlockedAuth; second poll → Completed (after cancel the run
+        // reaches Completed or the test exits — we only care about what is posted).
+        let coordinator = Arc::new(ScriptedTurnCoordinator::with_states(vec![
+            scripted_state(TurnStatus::BlockedAuth, Some(gate_ref_str)),
+            scripted_state(TurnStatus::Completed, None),
+        ]));
+        let thread_service = Arc::new(InMemorySessionThreadService::default());
+        seed_finalized_assistant_message(
+            &thread_service,
+            &scope,
+            run_id,
+            "Run complete after auth.",
+        )
+        .await;
+
+        let outbound = Arc::new(InMemoryOutboundStateStore::default());
+        // Seed the preference with a SHARED CHANNEL binding ref (not a DM).
+        seed_personal_preference(&outbound, &scope, binding_ref).await;
+
+        let egress = Arc::new(FakeProtocolHttpEgress::new(vec!["slack.com".to_string()]));
+        egress.allow_credential_handle("slack_bot_token");
+        // Expect one chat.postMessage call for the auth-unavailable notice.
+        egress.program_response(
+            "slack.com",
+            Ok(EgressResponse::new(
+                200,
+                slack_post_ok_json("C0SHARED", "7001.1"),
+            )),
+        );
+        // And a second for the final reply after Completed.
+        egress.program_response(
+            "slack.com",
+            Ok(EgressResponse::new(
+                200,
+                slack_post_ok_json("C0SHARED", "7001.2"),
+            )),
+        );
+
+        let delivery_store = Arc::new(InMemoryTriggeredRunDeliveryStore::default());
+        let route_store = Arc::new(InMemoryDeliveredGateRouteStore::default());
+        let mut services = make_services(
+            coordinator,
+            thread_service,
+            egress.clone(),
+            outbound,
+            install,
+        );
+        // Wire up an OAuth challenge provider so the BlockedAuth state WOULD
+        // produce an authorization_url — the gate must suppress it.
+        services.auth_challenges = Some(Arc::new(OAuthAuthChallengeProvider {
+            url: "https://provider.example/oauth-auth".to_string(),
+        }));
+
+        let settings = SlackFinalReplyDeliverySettings {
+            poll_interval: std::time::Duration::ZERO,
+            max_wait: std::time::Duration::from_secs(5),
+            max_concurrent_deliveries: NonZeroUsize::new(1).unwrap(),
+            max_pending_deliveries: NonZeroUsize::new(8).unwrap(),
+        };
+        let driver = TriggeredRunDeliveryDriver::with_settings(
+            services,
+            settings,
+            delivery_store.clone(),
+            route_store.clone(),
+            scope.agent_id.clone().expect("test scope has agent"),
+        );
+
+        let fire = minimal_trigger_fire(None);
+        driver
+            .on_trigger_submitted(fire, run_id, scope.clone())
+            .await;
+        wait_for_delivery_record(&delivery_store, run_id).await;
+
+        let posted: Vec<String> = egress
+            .calls()
+            .iter()
+            .filter(|c| c.path == "/api/chat.postMessage")
+            .map(|c| String::from_utf8_lossy(&c.body).to_string())
+            .collect();
+
+        // The OAuth URL must NOT appear in any posted message.
+        for body in &posted {
+            assert!(
+                !body.contains("https://provider.example/oauth-auth"),
+                "authorization_url must NOT be posted to a shared channel; got: {body}"
+            );
+        }
+
+        // The auth-unavailable notice must appear instead.
+        assert!(
+            posted
+                .iter()
+                .any(|b| b.contains(SLACK_AUTH_UNAVAILABLE_MESSAGE)),
+            "auth-unavailable notice must be posted when OAuth is suppressed for non-DM target; \
+             got: {posted:?}"
+        );
+
+        // No gate route must be recorded (the auth was cancelled).
+        let creator = ironclaw_host_api::UserId::new("creator-user").expect("user id");
+        let route = route_store
+            .load_delivered_gate_route(&scope.tenant_id, &creator, gate_ref_str)
+            .await
+            .expect("load route");
+        assert!(
+            route.is_none(),
+            "no gate route must be recorded when OAuth is suppressed for non-DM target"
+        );
+    }
+
+    /// Positive case: triggered OAuth auth whose delivery target IS a personal DM
+    /// must post the `authorization_url` (unchanged from pre-fix behavior).
+    #[tokio::test]
+    async fn triggered_oauth_auth_to_personal_dm_posts_authorization_url() {
+        let install = "test-install";
+        let gate_ref_str = "gate:oauth-dm-allowed";
+        let scope = personal_turn_scope();
+        let run_id = TurnRunId::new();
+        // Use the personal-DM binding ref (has actor_kind / actor segments, D-prefixed channel).
+        let binding_ref =
+            test_slack_binding_ref(install, scope.agent_id.as_ref().expect("agent").as_str());
+
+        // First poll → BlockedAuth; second → Completed.
+        let coordinator = Arc::new(ScriptedTurnCoordinator::with_states(vec![
+            scripted_state(TurnStatus::BlockedAuth, Some(gate_ref_str)),
+            scripted_state(TurnStatus::Completed, None),
+        ]));
+        let thread_service = Arc::new(InMemorySessionThreadService::default());
+        seed_finalized_assistant_message(
+            &thread_service,
+            &scope,
+            run_id,
+            "Run complete after OAuth.",
+        )
+        .await;
+
+        let outbound = Arc::new(InMemoryOutboundStateStore::default());
+        seed_personal_preference(&outbound, &scope, binding_ref).await;
+
+        let egress = Arc::new(FakeProtocolHttpEgress::new(vec!["slack.com".to_string()]));
+        egress.allow_credential_handle("slack_bot_token");
+        // OAuth auth-prompt response.
+        egress.program_response(
+            "slack.com",
+            Ok(EgressResponse::new(
+                200,
+                slack_post_ok_json("D456", "8001.1"),
+            )),
+        );
+        // Final-reply response.
+        egress.program_response(
+            "slack.com",
+            Ok(EgressResponse::new(
+                200,
+                slack_post_ok_json("D456", "8001.2"),
+            )),
+        );
+        // Auth message deleted after final reply.
+        egress.program_response(
+            "slack.com",
+            Ok(EgressResponse::new(
+                200,
+                serde_json::json!({"ok": true}).to_string().into_bytes(),
+            )),
+        );
+
+        let delivery_store = Arc::new(InMemoryTriggeredRunDeliveryStore::default());
+        let route_store = Arc::new(InMemoryDeliveredGateRouteStore::default());
+        let mut services = make_services(
+            coordinator,
+            thread_service,
+            egress.clone(),
+            outbound,
+            install,
+        );
+        // Wire up an OAuth challenge provider so authorization_url is set.
+        services.auth_challenges = Some(Arc::new(OAuthAuthChallengeProvider {
+            url: "https://provider.example/oauth-auth-dm".to_string(),
+        }));
+
+        let settings = SlackFinalReplyDeliverySettings {
+            poll_interval: std::time::Duration::ZERO,
+            max_wait: std::time::Duration::from_secs(5),
+            max_concurrent_deliveries: NonZeroUsize::new(1).unwrap(),
+            max_pending_deliveries: NonZeroUsize::new(8).unwrap(),
+        };
+        let driver = TriggeredRunDeliveryDriver::with_settings(
+            services,
+            settings,
+            delivery_store.clone(),
+            route_store.clone(),
+            scope.agent_id.clone().expect("test scope has agent"),
+        );
+
+        let fire = minimal_trigger_fire(None);
+        driver
+            .on_trigger_submitted(fire, run_id, scope.clone())
+            .await;
+        wait_for_delivery_record(&delivery_store, run_id).await;
+
+        let posted: Vec<String> = egress
+            .calls()
+            .iter()
+            .filter(|c| c.path == "/api/chat.postMessage")
+            .map(|c| String::from_utf8_lossy(&c.body).to_string())
+            .collect();
+
+        // The OAuth URL MUST appear in the auth-prompt message sent to the DM.
+        assert!(
+            posted
+                .iter()
+                .any(|b| b.contains("https://provider.example/oauth-auth-dm")),
+            "authorization_url must be posted to a verified personal DM; got: {posted:?}"
+        );
+
+        // The auth-unavailable notice must NOT appear.
+        assert!(
+            !posted
+                .iter()
+                .any(|b| b.contains(SLACK_AUTH_UNAVAILABLE_MESSAGE)),
+            "auth-unavailable notice must NOT appear when OAuth is sent to a personal DM; \
+             got: {posted:?}"
+        );
+    }
+
+    /// Precedence guard: when `auth_prompt_target` is a SHARED CHANNEL but
+    /// `final_reply_target` is a personal DM, the OAuth gate must key on the
+    /// EFFECTIVE auth target (`auth_prompt_target.or(final_reply_target)` — see
+    /// `resolution_engine.rs` `PreferenceTargetKind::AuthPrompt`), i.e. the shared
+    /// channel. The URL must be SUPPRESSED. A naive "any stored target is a DM"
+    /// check would wrongly pass here and leak the OAuth URL to the channel.
+    #[tokio::test]
+    async fn triggered_oauth_auth_prefers_auth_target_over_dm_fallback() {
+        let install = "test-install";
+        let gate_ref_str = "gate:oauth-auth-target-shared";
+        let scope = personal_turn_scope();
+        let run_id = TurnRunId::new();
+        let agent = scope.agent_id.as_ref().expect("agent").as_str();
+        // auth_prompt_target → shared channel (the effective auth target);
+        // final_reply_target → personal DM (must NOT rescue the OAuth post).
+        let auth_target = test_slack_shared_channel_binding_ref(install, agent);
+        let final_target = test_slack_binding_ref(install, agent);
+
+        let coordinator = Arc::new(ScriptedTurnCoordinator::with_states(vec![
+            scripted_state(TurnStatus::BlockedAuth, Some(gate_ref_str)),
+            scripted_state(TurnStatus::Completed, None),
+        ]));
+        let thread_service = Arc::new(InMemorySessionThreadService::default());
+        seed_finalized_assistant_message(&thread_service, &scope, run_id, "Run complete.").await;
+
+        let outbound = Arc::new(InMemoryOutboundStateStore::default());
+        seed_personal_preference_with_auth_target(&outbound, &scope, auth_target, final_target)
+            .await;
+
+        let egress = Arc::new(FakeProtocolHttpEgress::new(vec!["slack.com".to_string()]));
+        egress.allow_credential_handle("slack_bot_token");
+        // auth-unavailable notice, then final reply.
+        egress.program_response(
+            "slack.com",
+            Ok(EgressResponse::new(
+                200,
+                slack_post_ok_json("C0SHARED", "9001.1"),
+            )),
+        );
+        egress.program_response(
+            "slack.com",
+            Ok(EgressResponse::new(
+                200,
+                slack_post_ok_json("C0SHARED", "9001.2"),
+            )),
+        );
+
+        let delivery_store = Arc::new(InMemoryTriggeredRunDeliveryStore::default());
+        let route_store = Arc::new(InMemoryDeliveredGateRouteStore::default());
+        let mut services = make_services(
+            coordinator,
+            thread_service,
+            egress.clone(),
+            outbound,
+            install,
+        );
+        services.auth_challenges = Some(Arc::new(OAuthAuthChallengeProvider {
+            url: "https://provider.example/oauth-auth-target".to_string(),
+        }));
+
+        let settings = SlackFinalReplyDeliverySettings {
+            poll_interval: std::time::Duration::ZERO,
+            max_wait: std::time::Duration::from_secs(5),
+            max_concurrent_deliveries: NonZeroUsize::new(1).unwrap(),
+            max_pending_deliveries: NonZeroUsize::new(8).unwrap(),
+        };
+        let driver = TriggeredRunDeliveryDriver::with_settings(
+            services,
+            settings,
+            delivery_store.clone(),
+            route_store.clone(),
+            scope.agent_id.clone().expect("test scope has agent"),
+        );
+
+        driver
+            .on_trigger_submitted(minimal_trigger_fire(None), run_id, scope.clone())
+            .await;
+        wait_for_delivery_record(&delivery_store, run_id).await;
+
+        let posted: Vec<String> = egress
+            .calls()
+            .iter()
+            .filter(|c| c.path == "/api/chat.postMessage")
+            .map(|c| String::from_utf8_lossy(&c.body).to_string())
+            .collect();
+
+        for body in &posted {
+            assert!(
+                !body.contains("https://provider.example/oauth-auth-target"),
+                "authorization_url must NOT post when the effective auth target is a shared \
+                 channel, even if final_reply_target is a DM; got: {body}"
+            );
+        }
+        assert!(
+            posted
+                .iter()
+                .any(|b| b.contains(SLACK_AUTH_UNAVAILABLE_MESSAGE)),
+            "auth-unavailable notice must be posted when OAuth is suppressed; got: {posted:?}"
         );
     }
 

--- a/crates/ironclaw_reborn_composition/src/slack_delivery.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_delivery.rs
@@ -2206,8 +2206,11 @@ async fn deliver_triggered_run(
                         target = "ironclaw::reborn::slack_delivery",
                         %run_id,
                         error = %err,
-                        "triggered run OAuth backstop: cancel_auth_blocked_run failed (continuing)"
+                        "triggered run OAuth backstop: cancel_auth_blocked_run failed"
                     );
+                    let outcome = TriggeredRunDeliveryOutcomeKind::Failed;
+                    record_triggered_run_outcome(delivery_store, run_id, outcome).await;
+                    return outcome;
                 }
                 // Reset the guard so the notice delivery is not blocked.
                 authority
@@ -2226,11 +2229,23 @@ async fn deliver_triggered_run(
                     }),
                     gate_ref_for_routing: None,
                 };
-                let _ = deliver_triggered_notification(
+                let outcome = match deliver_triggered_notification(
                     services, &scope, &actor, run_id, &state, &authority, notice,
                 )
-                .await;
-                let outcome = TriggeredRunDeliveryOutcomeKind::Delivered;
+                .await
+                {
+                    Ok(_) => TriggeredRunDeliveryOutcomeKind::Delivered,
+                    Err(TriggeredNotificationFailure::NoDefaultConfigured) => {
+                        TriggeredRunDeliveryOutcomeKind::NoDefaultConfigured
+                    }
+                    Err(TriggeredNotificationFailure::Denied) => {
+                        TriggeredRunDeliveryOutcomeKind::Denied
+                    }
+                    Err(TriggeredNotificationFailure::OAuthTargetNotDm)
+                    | Err(TriggeredNotificationFailure::Other(_)) => {
+                        TriggeredRunDeliveryOutcomeKind::Failed
+                    }
+                };
                 record_triggered_run_outcome(delivery_store, run_id, outcome).await;
                 return outcome;
             }
@@ -2627,12 +2642,9 @@ fn classify_delivery_error(
         ProductOutboundDeliveryError::Outbound(OutboundError::AccessDenied) => {
             TriggeredNotificationFailure::Denied
         }
-        // Authority backstop trip: the resolver returned BindingResolutionFailed
-        // with the sentinel reason, meaning the send-time target was not a
-        // personal DM despite the payload carrying an OAuth authorization_url.
-        // The sentinel is matched directly from the Workflow source; if it is
-        // not reachable via pattern (e.g. due to wrapping changes), the
-        // `to_string().contains` fallback below would catch it instead.
+        // Authority backstop trip: the resolver wraps BindingResolutionFailed as
+        // Workflow { source: BindingResolutionFailed { reason } }, so the sentinel
+        // reason is reachable by direct pattern match below. There is no fallback.
         ProductOutboundDeliveryError::Workflow {
             source: ProductWorkflowError::BindingResolutionFailed { reason },
             ..

--- a/crates/ironclaw_reborn_composition/src/slack_delivery.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_delivery.rs
@@ -2196,14 +2196,11 @@ async fn deliver_triggered_run(
                     "triggered run OAuth URL suppressed by send-time backstop: resolved \
                      target is not a personal DM; cancelling run"
                 );
-                // Clean up any OAuth auth-prompt messages that were posted to a DM in
-                // earlier loop iterations. Both return paths in this arm must not
-                // leave those messages lingering — drain once here, before the first
-                // possible return.
-                for message in messages_to_delete_after_final.drain(..) {
-                    delete_triggered_slack_message(services, message).await;
-                }
-                // Cancel the blocked run.
+                // Cancel the blocked run FIRST. Do NOT remove the existing auth
+                // prompt until the run is actually canceled: a transient cancel
+                // failure must leave the prompt in place (the user may still be able
+                // to finish), so on failure we record `Failed` and return without
+                // deleting anything.
                 if let Err(err) = cancel_auth_blocked_run(
                     services.turn_coordinator.as_ref(),
                     &scope,
@@ -2256,6 +2253,14 @@ async fn deliver_triggered_run(
                         TriggeredRunDeliveryOutcomeKind::Failed
                     }
                 };
+                // The run is now canceled, so any OAuth auth-prompt messages posted
+                // to a DM in earlier iterations are stale — remove them. This runs
+                // only after a successful cancel and after the replacement notice has
+                // been attempted, so we never strip the prompt while the run is still
+                // live.
+                for message in messages_to_delete_after_final.drain(..) {
+                    delete_triggered_slack_message(services, message).await;
+                }
                 record_triggered_run_outcome(delivery_store, run_id, outcome).await;
                 return outcome;
             }

--- a/crates/ironclaw_reborn_composition/src/slack_delivery.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_delivery.rs
@@ -66,12 +66,6 @@ const SLACK_AUTH_CANCELED_MESSAGE: &str = "Authentication canceled.";
 /// Posted when a run blocks on a credential-entry (non-OAuth) auth challenge:
 /// entering a secret in chat is a security risk, so it must be done in the web app.
 const SLACK_AUTH_UNAVAILABLE_MESSAGE: &str = "Setting this up needs a credential (an API key or token). Sharing one here is a security risk — anything entered in chat is stored in the conversation — so credential-based connections can only be set up in the Ironclaw web app. Connect it there, then ask me again here.";
-/// Sentinel reason string used inside `TriggeredSlackReplyTargetAuthority` to signal
-/// that the delivery was rejected because the send-time target was not a personal DM
-/// despite the payload carrying an OAuth `authorization_url`. This is an internal
-/// marker only — it is matched in `classify_delivery_error` to map to
-/// `TriggeredNotificationFailure::OAuthTargetNotDm` and is never shown to users.
-const OAUTH_TARGET_NOT_DM_MARKER: &str = "__oauth_url_requires_personal_dm__";
 const SLACK_DELIVERY_TIMEOUT_MESSAGE: &str =
     "This is taking longer than expected — check the WebUI for the result.";
 const SLACK_DELIVERY_ERROR_MESSAGE: &str =
@@ -1994,6 +1988,7 @@ async fn deliver_triggered_run(
         trigger_context: trigger_context.clone(),
         resolved_space_id: std::sync::Mutex::new(None),
         require_personal_dm_for_oauth: std::sync::atomic::AtomicBool::new(false),
+        oauth_target_not_dm: std::sync::atomic::AtomicBool::new(false),
     };
 
     // Pre-check: determine whether the creator's preferred delivery target is a
@@ -2621,7 +2616,7 @@ async fn deliver_triggered_notification(
     };
 
     let tracked_egress = TrackingSlackPostEgress::new(Arc::clone(&services.egress));
-    prepare_and_render_product_outbound(
+    let render_result = prepare_and_render_product_outbound(
         &outbound_policy,
         services.communication_preferences.as_ref(),
         authority,
@@ -2637,8 +2632,21 @@ async fn deliver_triggered_notification(
             delivery_sink: services.delivery_sink.as_ref(),
         },
     )
-    .await
-    .map_err(classify_delivery_error)?;
+    .await;
+
+    if let Err(error) = render_result {
+        // Typed handshake with the resolver: if the OAuth-DM backstop tripped,
+        // the resolver set `oauth_target_not_dm`. Read-and-clear it here so the
+        // failure is classified as `OAuthTargetNotDm` without inspecting the
+        // cross-crate error's reason string.
+        if authority
+            .oauth_target_not_dm
+            .swap(false, std::sync::atomic::Ordering::AcqRel)
+        {
+            return Err(TriggeredNotificationFailure::OAuthTargetNotDm);
+        }
+        return Err(classify_delivery_error(error));
+    }
 
     Ok(tracked_egress.take_posted_messages())
 }
@@ -2649,7 +2657,7 @@ fn classify_delivery_error(
     error: ironclaw_product_workflow::ProductOutboundDeliveryError,
 ) -> TriggeredNotificationFailure {
     use ironclaw_outbound::OutboundError;
-    use ironclaw_product_workflow::{ProductOutboundDeliveryError, ProductWorkflowError};
+    use ironclaw_product_workflow::ProductOutboundDeliveryError;
     match &error {
         ProductOutboundDeliveryError::Outbound(OutboundError::PreferenceTargetMissing {
             ..
@@ -2657,13 +2665,9 @@ fn classify_delivery_error(
         ProductOutboundDeliveryError::Outbound(OutboundError::AccessDenied) => {
             TriggeredNotificationFailure::Denied
         }
-        // Authority backstop trip: the resolver wraps BindingResolutionFailed as
-        // Workflow { source: BindingResolutionFailed { reason } }, so the sentinel
-        // reason is reachable by direct pattern match below. There is no fallback.
-        ProductOutboundDeliveryError::Workflow {
-            source: ProductWorkflowError::BindingResolutionFailed { reason },
-            ..
-        } if reason == OAUTH_TARGET_NOT_DM_MARKER => TriggeredNotificationFailure::OAuthTargetNotDm,
+        // Note: the OAuth-DM backstop trip is NOT classified here — it is detected
+        // via the authority's typed `oauth_target_not_dm` signal in
+        // `deliver_triggered_notification` before this function is reached.
         _ => TriggeredNotificationFailure::Other(error.to_string()),
     }
 }
@@ -2737,6 +2741,12 @@ struct TriggeredSlackReplyTargetAuthority {
     /// snapshot-vs-send race (the pre-loop DM snapshot can go stale while the run
     /// waits in BlockedAuth).
     require_personal_dm_for_oauth: std::sync::atomic::AtomicBool,
+    /// Output signal: set by the resolver when `require_personal_dm_for_oauth`
+    /// is true and the resolved send-time binding is NOT a personal DM. Read
+    /// (and cleared) by `deliver_triggered_notification` to classify the delivery
+    /// failure as `OAuthTargetNotDm` — a typed handshake that avoids matching a
+    /// magic reason string on the cross-crate `ProductWorkflowError`.
+    oauth_target_not_dm: std::sync::atomic::AtomicBool,
 }
 
 #[async_trait]
@@ -2765,15 +2775,19 @@ impl ProductOutboundTargetResolver for TriggeredSlackReplyTargetAuthority {
         // personal DM. This closes the snapshot-vs-send race: the pre-loop
         // `target_is_verified_dm` snapshot can go stale while the run waits in
         // BlockedAuth; this guard is checked against the binding resolved NOW
-        // (at send time), not the one read earlier. The reason string is matched
-        // in `classify_delivery_error` to map to `OAuthTargetNotDm`.
+        // (at send time), not the one read earlier. On a trip we set the typed
+        // `oauth_target_not_dm` signal so `deliver_triggered_notification` can
+        // classify the failure as `OAuthTargetNotDm` without matching a magic
+        // reason string on the cross-crate error.
         if self
             .require_personal_dm_for_oauth
             .load(std::sync::atomic::Ordering::Acquire)
             && !slack_reply_target_is_personal_dm(target.target())
         {
+            self.oauth_target_not_dm
+                .store(true, std::sync::atomic::Ordering::Release);
             return Err(ProductWorkflowError::BindingResolutionFailed {
-                reason: OAUTH_TARGET_NOT_DM_MARKER.to_string(),
+                reason: "OAuth authorization_url requires a personal DM target".to_string(),
             });
         }
 

--- a/crates/ironclaw_reborn_composition/src/slack_outbound_targets.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_outbound_targets.rs
@@ -863,7 +863,17 @@ fn decode_slack_reply_target_binding_ref(
     // Consume the optional actor_kind + actor segments (personal-DM only).
     let (actor_kind, actor_id, rest) = match take_product_binding_segment(rest, "actor_kind") {
         Some((kind, after_kind)) => match take_product_binding_segment(after_kind, "actor") {
-            Some((id, after_actor)) => (Some(kind.to_string()), Some(id.to_string()), after_actor),
+            Some((id, after_actor)) => {
+                // Map an empty actor value to None so the type matches the
+                // doc-comment ("Present only when the `actor` segment exists
+                // with a non-empty value").
+                let actor_id = if id.is_empty() {
+                    None
+                } else {
+                    Some(id.to_string())
+                };
+                (Some(kind.to_string()), actor_id, after_actor)
+            }
             None => (Some(kind.to_string()), None, after_kind),
         },
         None => (None, None, rest),
@@ -892,6 +902,10 @@ fn decode_slack_reply_target_binding_ref(
 /// preference.
 ///
 /// Returns `None` if the ref is not a Slack reply target or is malformed.
+///
+/// Note: adapter identity is enforced by [`decode_slack_reply_target_binding_ref`],
+/// so refs with a non-Slack adapter now return `None` where they previously
+/// returned `Some`.
 pub(crate) fn slack_conversation_id_from_reply_target_binding_ref(
     target: &ironclaw_turns::ReplyTargetBindingRef,
 ) -> Option<(String, Option<String>)> {
@@ -941,10 +955,11 @@ pub(crate) fn slack_reply_target_is_personal_dm(
     if !decoded.topic_present {
         return false;
     }
-    // actor_kind must be the Slack user kind; actor must be non-empty; no
+    // actor_kind must be the Slack user kind; actor_id is Some only when the
+    // actor segment is non-empty (invariant enforced at decode time); no
     // further segments are permitted.
     decoded.actor_kind.as_deref() == Some(SLACK_USER_ACTOR_KIND)
-        && decoded.actor_id.as_deref().is_some_and(|id| !id.is_empty())
+        && decoded.actor_id.is_some()
         && decoded.fully_consumed
 }
 
@@ -1812,6 +1827,66 @@ mod tests {
         assert!(
             !slack_reply_target_is_personal_dm(&binding_ref),
             "non-Slack adapter ref must NOT be identified as a personal DM"
+        );
+    }
+
+    // ── slack_reply_target_is_personal_dm: missing actor segment (not just empty) ──
+
+    #[test]
+    fn slack_reply_target_is_personal_dm_returns_false_for_missing_actor_segment() {
+        // A ref with actor_kind present but NO actor segment at all (label absent,
+        // not just empty value).  The decoder returns actor_id = None because
+        // take_product_binding_segment for "actor" fails; the DM predicate must
+        // return false (actor_id is None).
+        fn seg(name: &str, value: &str) -> String {
+            format!("{}:{}:{};", name, value.len(), value)
+        }
+        let raw = format!(
+            "{}{}{}{}{}{}{}{}",
+            seg("adapter", SLACK_V2_ADAPTER_ID),
+            seg("installation", INSTALLATION),
+            seg("agent", AGENT),
+            seg("project", PROJECT),
+            seg("space", TEAM),
+            seg("conversation", "D0HOST"),
+            seg("topic", ""),
+            seg("actor_kind", SLACK_USER_ACTOR_KIND),
+            // actor segment intentionally absent
+        );
+        let binding_ref =
+            slack_reply_target_binding_ref_from_raw(raw).expect("builds syntactically");
+        assert!(
+            !slack_reply_target_is_personal_dm(&binding_ref),
+            "ref with actor_kind but no actor segment must NOT be identified as a personal DM"
+        );
+    }
+
+    // ── slack_conversation_id_from_reply_target_binding_ref: adapter contract ──
+
+    #[test]
+    fn slack_conversation_id_from_reply_target_binding_ref_returns_none_for_non_slack_adapter() {
+        // A syntactically valid ref with a non-Slack adapter value must return
+        // None, pinning the adapter-validation contract that the shared decoder
+        // now enforces for this function as well.
+        fn seg(name: &str, value: &str) -> String {
+            format!("{}:{}:{};", name, value.len(), value)
+        }
+        let raw = format!(
+            "{}{}{}{}{}{}{}",
+            seg("adapter", "not_slack_v2"),
+            seg("installation", INSTALLATION),
+            seg("agent", AGENT),
+            seg("project", PROJECT),
+            seg("space", TEAM),
+            seg("conversation", "C0HOST"),
+            seg("topic", ""),
+        );
+        let binding_ref =
+            slack_reply_target_binding_ref_from_raw(raw).expect("builds syntactically");
+        assert!(
+            slack_conversation_id_from_reply_target_binding_ref(&binding_ref).is_none(),
+            "non-Slack adapter ref must return None from \
+             slack_conversation_id_from_reply_target_binding_ref"
         );
     }
 }

--- a/crates/ironclaw_reborn_composition/src/slack_outbound_targets.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_outbound_targets.rs
@@ -1609,4 +1609,61 @@ mod tests {
             "ref with empty actor must NOT be identified as a personal DM"
         );
     }
+
+    /// Tests the two reject predicates not covered by the sibling tests:
+    ///
+    /// (a) A syntactically correct personal-DM ref whose `actor_kind` segment
+    ///     contains a non-Slack actor kind must return `false` — the predicate
+    ///     requires `actor_kind == SLACK_USER_ACTOR_KIND`.
+    ///
+    /// (b) A personal-DM ref with an EXTRA trailing segment appended after
+    ///     `actor` must return `false` — the predicate requires `rest.is_empty()`
+    ///     after consuming the `actor` segment.
+    #[test]
+    fn slack_reply_target_is_personal_dm_rejects_wrong_actor_kind_and_trailing_segments() {
+        fn seg(name: &str, value: &str) -> String {
+            format!("{}:{}:{};", name, value.len(), value)
+        }
+
+        // (a) Wrong actor_kind: use a non-Slack actor kind.
+        let raw_wrong_kind = format!(
+            "{}{}{}{}{}{}{}{}{}",
+            seg("adapter", "slack_v2"),
+            seg("installation", INSTALLATION),
+            seg("agent", AGENT),
+            seg("project", PROJECT),
+            seg("space", TEAM),
+            seg("conversation", "D0HOST"),
+            seg("topic", ""),
+            seg("actor_kind", "not_a_slack_user"),
+            seg("actor", SLACK_USER),
+        );
+        let binding_ref_wrong_kind =
+            slack_reply_target_binding_ref_from_raw(raw_wrong_kind).expect("builds syntactically");
+        assert!(
+            !slack_reply_target_is_personal_dm(&binding_ref_wrong_kind),
+            "actor_kind != slack_user must NOT be identified as a personal DM"
+        );
+
+        // (b) Extra trailing segment after the actor segment.
+        let raw_trailing = format!(
+            "{}{}{}{}{}{}{}{}{}{}",
+            seg("adapter", "slack_v2"),
+            seg("installation", INSTALLATION),
+            seg("agent", AGENT),
+            seg("project", PROJECT),
+            seg("space", TEAM),
+            seg("conversation", "D0HOST"),
+            seg("topic", ""),
+            seg("actor_kind", "slack_user"),
+            seg("actor", SLACK_USER),
+            seg("extra", "unexpected"),
+        );
+        let binding_ref_trailing =
+            slack_reply_target_binding_ref_from_raw(raw_trailing).expect("builds syntactically");
+        assert!(
+            !slack_reply_target_is_personal_dm(&binding_ref_trailing),
+            "trailing segment after actor must NOT be identified as a personal DM"
+        );
+    }
 }

--- a/crates/ironclaw_reborn_composition/src/slack_outbound_targets.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_outbound_targets.rs
@@ -924,6 +924,13 @@ pub(crate) fn slack_reply_target_is_personal_dm(
     let Some(decoded) = decode_slack_reply_target_binding_ref(target) else {
         return false;
     };
+    // A well-formed Slack reply target always carries the team/space binding. An
+    // empty `space` segment (`space:0:`) decodes to `None` here; reject it so a
+    // corrupted or forged preference missing the space cannot satisfy the
+    // OAuth-DM gate.
+    if decoded.space_id.is_none() {
+        return false;
+    }
     // DM channel ids start with uppercase 'D'.
     if !decoded.conversation_id.starts_with('D') {
         return false;
@@ -1745,6 +1752,36 @@ mod tests {
         assert!(
             !slack_reply_target_is_personal_dm(&binding_ref),
             "ref missing topic segment must NOT be identified as a personal DM"
+        );
+    }
+
+    // ── slack_reply_target_is_personal_dm: empty space segment ───────────────
+
+    #[test]
+    fn slack_reply_target_is_personal_dm_returns_false_for_empty_space_segment() {
+        // A ref with an empty `space` segment (`space:0:`) decodes space_id to
+        // None. A forged/corrupted preference missing the team/space binding must
+        // NOT satisfy the OAuth-DM gate.
+        fn seg(name: &str, value: &str) -> String {
+            format!("{}:{}:{};", name, value.len(), value)
+        }
+        let raw = format!(
+            "{}{}{}{}{}{}{}{}{}",
+            seg("adapter", SLACK_V2_ADAPTER_ID),
+            seg("installation", INSTALLATION),
+            seg("agent", AGENT),
+            seg("project", PROJECT),
+            seg("space", ""),
+            seg("conversation", "D0HOST"),
+            seg("topic", ""),
+            seg("actor_kind", SLACK_USER_ACTOR_KIND),
+            seg("actor", SLACK_USER),
+        );
+        let binding_ref =
+            slack_reply_target_binding_ref_from_raw(raw).expect("builds syntactically");
+        assert!(
+            !slack_reply_target_is_personal_dm(&binding_ref),
+            "ref with empty space segment must NOT be identified as a personal DM"
         );
     }
 

--- a/crates/ironclaw_reborn_composition/src/slack_outbound_targets.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_outbound_targets.rs
@@ -798,6 +798,84 @@ fn take_product_binding_segment<'a>(raw: &'a str, name: &str) -> Option<(&'a str
     Some((value, raw))
 }
 
+/// Decoded fields from a Slack reply-target binding ref segment walk.
+///
+/// Produced by [`decode_slack_reply_target_binding_ref`]; consumed by both
+/// [`slack_conversation_id_from_reply_target_binding_ref`] and
+/// [`slack_reply_target_is_personal_dm`] so that the segment format is
+/// parsed in exactly one place.
+struct DecodedSlackReplyTarget {
+    conversation_id: String,
+    space_id: Option<String>,
+    /// `true` iff a `topic` segment was successfully consumed after
+    /// `conversation` — required for the personal-DM predicate to mirror
+    /// the original behaviour, which demanded `topic` be present.
+    topic_present: bool,
+    /// Present only when the ref carries trailing `actor_kind` + `actor`
+    /// segments (personal-DM refs).
+    actor_kind: Option<String>,
+    /// Present only when the ref carries a non-empty `actor` segment value.
+    actor_id: Option<String>,
+    /// `true` iff the segment walk consumed the entire ref with no leftover
+    /// bytes — required for the personal-DM predicate to reject trailing
+    /// garbage.
+    fully_consumed: bool,
+}
+
+/// Walk the length-prefixed segment format shared by both
+/// [`slack_shared_channel_reply_target_binding_ref`] and
+/// [`slack_personal_dm_reply_target_binding_ref`] and return the decoded
+/// fields.
+///
+/// Returns `None` if the ref does not start with `reply:`, if any of the
+/// required prefix segments (adapter / installation / agent / project / space /
+/// conversation) are missing or malformed, or if the conversation id is empty.
+/// Optional trailing segments (topic / actor_kind / actor) are consumed when
+/// present but are not required; whether they were found is recorded in
+/// `topic_present`, `actor_kind`, and `actor_id`.
+fn decode_slack_reply_target_binding_ref(
+    target: &ironclaw_turns::ReplyTargetBindingRef,
+) -> Option<DecodedSlackReplyTarget> {
+    let mut raw = target.as_str().strip_prefix("reply:")?;
+    // Skip adapter, installation, agent, project — not validated here.
+    for name in &["adapter", "installation", "agent", "project"] {
+        let (_, rest) = take_product_binding_segment(raw, name)?;
+        raw = rest;
+    }
+    // Consume the required conversation fingerprint segments: space / conversation.
+    let (space_id, rest) = take_product_binding_segment(raw, "space")?;
+    let (conversation_id, rest) = take_product_binding_segment(rest, "conversation")?;
+    if conversation_id.is_empty() {
+        return None;
+    }
+    // Consume the optional topic segment (present in both shared-channel and
+    // personal-DM refs built by the constructors in this module).
+    let (topic_present, rest) = match take_product_binding_segment(rest, "topic") {
+        Some((_, after_topic)) => (true, after_topic),
+        None => (false, rest),
+    };
+    // Consume the optional actor_kind + actor segments (personal-DM only).
+    let (actor_kind, actor_id, rest) = match take_product_binding_segment(rest, "actor_kind") {
+        Some((kind, after_kind)) => match take_product_binding_segment(after_kind, "actor") {
+            Some((id, after_actor)) => (Some(kind.to_string()), Some(id.to_string()), after_actor),
+            None => (Some(kind.to_string()), None, after_kind),
+        },
+        None => (None, None, rest),
+    };
+    Some(DecodedSlackReplyTarget {
+        conversation_id: conversation_id.to_string(),
+        space_id: if space_id.is_empty() {
+            None
+        } else {
+            Some(space_id.to_string())
+        },
+        topic_present,
+        actor_kind,
+        actor_id,
+        fully_consumed: rest.is_empty(),
+    })
+}
+
 /// Extract the Slack channel ID encoded in a Slack reply-target binding ref.
 ///
 /// Parses the length-prefixed segment format produced by
@@ -811,25 +889,8 @@ fn take_product_binding_segment<'a>(raw: &'a str, name: &str) -> Option<(&'a str
 pub(crate) fn slack_conversation_id_from_reply_target_binding_ref(
     target: &ironclaw_turns::ReplyTargetBindingRef,
 ) -> Option<(String, Option<String>)> {
-    let mut raw = target.as_str().strip_prefix("reply:")?;
-    // Skip adapter, installation, agent, project — we don't validate them here.
-    for name in &["adapter", "installation", "agent", "project"] {
-        let (_, rest) = take_product_binding_segment(raw, name)?;
-        raw = rest;
-    }
-    let (space_id, rest) = take_product_binding_segment(raw, "space")?;
-    let (conversation_id, _) = take_product_binding_segment(rest, "conversation")?;
-    if conversation_id.is_empty() {
-        return None;
-    }
-    Some((
-        conversation_id.to_string(),
-        if space_id.is_empty() {
-            None
-        } else {
-            Some(space_id.to_string())
-        },
-    ))
+    let decoded = decode_slack_reply_target_binding_ref(target)?;
+    Some((decoded.conversation_id, decoded.space_id))
 }
 
 /// Returns `true` iff `target` is a verified personal-DM Slack reply-target
@@ -854,40 +915,24 @@ pub(crate) fn slack_conversation_id_from_reply_target_binding_ref(
 pub(crate) fn slack_reply_target_is_personal_dm(
     target: &ironclaw_turns::ReplyTargetBindingRef,
 ) -> bool {
-    let Some(mut raw) = target.as_str().strip_prefix("reply:") else {
-        return false;
-    };
-    // Skip adapter, installation, agent, project — not validated here.
-    for name in &["adapter", "installation", "agent", "project"] {
-        let Some((_, rest)) = take_product_binding_segment(raw, name) else {
-            return false;
-        };
-        raw = rest;
-    }
-    // Consume the conversation fingerprint: space / conversation / topic.
-    let Some((_, rest)) = take_product_binding_segment(raw, "space") else {
-        return false;
-    };
-    let Some((conversation_id, rest)) = take_product_binding_segment(rest, "conversation") else {
-        return false;
-    };
-    let Some((_, rest)) = take_product_binding_segment(rest, "topic") else {
+    let Some(decoded) = decode_slack_reply_target_binding_ref(target) else {
         return false;
     };
     // DM channel ids start with uppercase 'D'.
-    if !conversation_id.starts_with('D') {
+    if !decoded.conversation_id.starts_with('D') {
         return false;
     }
-    // Personal-DM refs carry trailing actor_kind + actor segments.
-    let Some((actor_kind, rest)) = take_product_binding_segment(rest, "actor_kind") else {
+    // The conversation fingerprint must include a topic segment (as produced by
+    // `ExternalConversationRef::conversation_fingerprint`); refs missing it are
+    // not well-formed personal-DM refs.
+    if !decoded.topic_present {
         return false;
-    };
-    let Some((actor_id, rest)) = take_product_binding_segment(rest, "actor") else {
-        return false;
-    };
+    }
     // actor_kind must be the Slack user kind; actor must be non-empty; no
     // further segments are permitted.
-    actor_kind == SLACK_USER_ACTOR_KIND && !actor_id.is_empty() && rest.is_empty()
+    decoded.actor_kind.as_deref() == Some(SLACK_USER_ACTOR_KIND)
+        && decoded.actor_id.as_deref().is_some_and(|id| !id.is_empty())
+        && decoded.fully_consumed
 }
 
 fn map_slack_target_route_error(error: SlackChannelRouteError) -> RebornServicesError {

--- a/crates/ironclaw_reborn_composition/src/slack_outbound_targets.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_outbound_targets.rs
@@ -832,6 +832,64 @@ pub(crate) fn slack_conversation_id_from_reply_target_binding_ref(
     ))
 }
 
+/// Returns `true` iff `target` is a verified personal-DM Slack reply-target
+/// binding ref.
+///
+/// A personal-DM ref has two structural markers beyond the shared segment
+/// prefix (adapter / installation / agent / project / space / conversation /
+/// topic):
+///
+/// 1. Trailing `actor_kind` + `actor` segments are **present** — this is the
+///    distinguishing property that [`slack_personal_dm_reply_target_binding_ref`]
+///    adds and [`slack_shared_channel_reply_target_binding_ref`] omits.
+/// 2. The decoded conversation id (the DM channel id) **starts with uppercase
+///    `'D'`** — the Slack-assigned prefix for all DM channels.
+///
+/// Any parse failure (malformed segment encoding, missing fields, non-`D`
+/// channel id) returns `false` — fail closed.
+///
+/// This does NOT validate the installation, agent, project, or space values
+/// against a live provider config. It is a structural parse only: safe to
+/// call before a provider is available.
+pub(crate) fn slack_reply_target_is_personal_dm(
+    target: &ironclaw_turns::ReplyTargetBindingRef,
+) -> bool {
+    let Some(mut raw) = target.as_str().strip_prefix("reply:") else {
+        return false;
+    };
+    // Skip adapter, installation, agent, project — not validated here.
+    for name in &["adapter", "installation", "agent", "project"] {
+        let Some((_, rest)) = take_product_binding_segment(raw, name) else {
+            return false;
+        };
+        raw = rest;
+    }
+    // Consume the conversation fingerprint: space / conversation / topic.
+    let Some((_, rest)) = take_product_binding_segment(raw, "space") else {
+        return false;
+    };
+    let Some((conversation_id, rest)) = take_product_binding_segment(rest, "conversation") else {
+        return false;
+    };
+    let Some((_, rest)) = take_product_binding_segment(rest, "topic") else {
+        return false;
+    };
+    // DM channel ids start with uppercase 'D'.
+    if !conversation_id.starts_with('D') {
+        return false;
+    }
+    // Personal-DM refs carry trailing actor_kind + actor segments.
+    let Some((actor_kind, rest)) = take_product_binding_segment(rest, "actor_kind") else {
+        return false;
+    };
+    let Some((actor_id, rest)) = take_product_binding_segment(rest, "actor") else {
+        return false;
+    };
+    // actor_kind must be the Slack user kind; actor must be non-empty; no
+    // further segments are permitted.
+    actor_kind == SLACK_USER_ACTOR_KIND && !actor_id.is_empty() && rest.is_empty()
+}
+
 fn map_slack_target_route_error(error: SlackChannelRouteError) -> RebornServicesError {
     match error {
         SlackChannelRouteError::InvalidRoute => slack_target_not_found_error(),
@@ -1432,6 +1490,123 @@ mod tests {
             result.is_none(),
             "cross-tenant caller must not resolve personal DM target; got: {:?}",
             result.map(|e| e.summary.target_id.as_str().to_string())
+        );
+    }
+
+    // ── slack_reply_target_is_personal_dm ─────────────────────────────────────
+
+    /// Build a personal-DM binding ref from raw segment strings (no provider needed).
+    fn dm_binding_ref(dm_channel_id: &str, slack_user_id: &str) -> ReplyTargetBindingRef {
+        let installation_id = AdapterInstallationId::new(INSTALLATION).expect("installation");
+        let agent_id = AgentId::new(AGENT).expect("agent");
+        let project_id = ProjectId::new(PROJECT).expect("project");
+        let team_id = SlackTeamId::new(TEAM);
+        let slack_user = SlackUserId::new(slack_user_id);
+        slack_personal_dm_reply_target_binding_ref(
+            &installation_id,
+            &agent_id,
+            Some(&project_id),
+            &team_id,
+            dm_channel_id,
+            &slack_user,
+        )
+        .expect("personal DM binding ref")
+    }
+
+    /// Build a shared-channel binding ref from raw segment strings (no provider needed).
+    fn shared_channel_binding_ref(channel_id: &str) -> ReplyTargetBindingRef {
+        let installation_id = AdapterInstallationId::new(INSTALLATION).expect("installation");
+        let agent_id = AgentId::new(AGENT).expect("agent");
+        let project_id = ProjectId::new(PROJECT).expect("project");
+        let team_id = SlackTeamId::new(TEAM);
+        slack_shared_channel_reply_target_binding_ref(
+            &installation_id,
+            &agent_id,
+            Some(&project_id),
+            &team_id,
+            channel_id,
+        )
+        .expect("shared channel binding ref")
+    }
+
+    #[test]
+    fn slack_reply_target_is_personal_dm_returns_true_for_dm_ref() {
+        let binding_ref = dm_binding_ref("D0HOST", SLACK_USER);
+        assert!(
+            slack_reply_target_is_personal_dm(&binding_ref),
+            "personal-DM binding ref must be identified as a personal DM"
+        );
+    }
+
+    #[test]
+    fn slack_reply_target_is_personal_dm_returns_false_for_shared_channel_ref() {
+        let binding_ref = shared_channel_binding_ref("C0HOST");
+        assert!(
+            !slack_reply_target_is_personal_dm(&binding_ref),
+            "shared-channel binding ref must NOT be identified as a personal DM"
+        );
+    }
+
+    #[test]
+    fn slack_reply_target_is_personal_dm_returns_false_for_non_d_prefixed_channel() {
+        // Build a raw ref with actor_kind/actor but a non-'D' channel id
+        // (e.g. a group DM channel starting with 'G'). The parser must reject it.
+        fn seg(name: &str, value: &str) -> String {
+            format!("{}:{}:{};", name, value.len(), value)
+        }
+        let raw = format!(
+            "{}{}{}{}{}{}{}{}{}",
+            seg("adapter", "slack_v2"),
+            seg("installation", INSTALLATION),
+            seg("agent", AGENT),
+            seg("project", PROJECT),
+            seg("space", TEAM),
+            seg("conversation", "G0GROUP"),
+            seg("topic", ""),
+            seg("actor_kind", "slack_user"),
+            seg("actor", SLACK_USER),
+        );
+        let binding_ref =
+            slack_reply_target_binding_ref_from_raw(raw).expect("builds syntactically");
+        assert!(
+            !slack_reply_target_is_personal_dm(&binding_ref),
+            "non-'D'-prefixed channel must NOT be identified as a personal DM"
+        );
+    }
+
+    #[test]
+    fn slack_reply_target_is_personal_dm_returns_false_for_malformed_ref() {
+        let malformed = ReplyTargetBindingRef::new("reply:not-a-valid-segment-format".to_string())
+            .expect("syntactically valid ref");
+        assert!(
+            !slack_reply_target_is_personal_dm(&malformed),
+            "malformed ref must return false (fail closed)"
+        );
+    }
+
+    #[test]
+    fn slack_reply_target_is_personal_dm_returns_false_for_empty_actor() {
+        // Build a ref that has actor_kind but empty actor id — must be rejected.
+        fn seg(name: &str, value: &str) -> String {
+            format!("{}:{}:{};", name, value.len(), value)
+        }
+        let raw = format!(
+            "{}{}{}{}{}{}{}{}{}",
+            seg("adapter", "slack_v2"),
+            seg("installation", INSTALLATION),
+            seg("agent", AGENT),
+            seg("project", PROJECT),
+            seg("space", TEAM),
+            seg("conversation", "D0HOST"),
+            seg("topic", ""),
+            seg("actor_kind", "slack_user"),
+            seg("actor", ""),
+        );
+        let binding_ref =
+            slack_reply_target_binding_ref_from_raw(raw).expect("builds syntactically");
+        assert!(
+            !slack_reply_target_is_personal_dm(&binding_ref),
+            "ref with empty actor must NOT be identified as a personal DM"
         );
     }
 }

--- a/crates/ironclaw_reborn_composition/src/slack_outbound_targets.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_outbound_targets.rs
@@ -837,8 +837,14 @@ fn decode_slack_reply_target_binding_ref(
     target: &ironclaw_turns::ReplyTargetBindingRef,
 ) -> Option<DecodedSlackReplyTarget> {
     let mut raw = target.as_str().strip_prefix("reply:")?;
-    // Skip adapter, installation, agent, project — not validated here.
-    for name in &["adapter", "installation", "agent", "project"] {
+    // Validate the adapter segment — reject non-Slack adapter refs fail-closed.
+    let (adapter_id, rest) = take_product_binding_segment(raw, "adapter")?;
+    if adapter_id != SLACK_V2_ADAPTER_ID {
+        return None;
+    }
+    raw = rest;
+    // Skip installation, agent, project — values not validated here.
+    for name in &["installation", "agent", "project"] {
         let (_, rest) = take_product_binding_segment(raw, name)?;
         raw = rest;
     }
@@ -1709,6 +1715,66 @@ mod tests {
         assert!(
             !slack_reply_target_is_personal_dm(&binding_ref_trailing),
             "trailing segment after actor must NOT be identified as a personal DM"
+        );
+    }
+
+    // ── slack_reply_target_is_personal_dm: missing topic segment ─────────────
+
+    #[test]
+    fn slack_reply_target_is_personal_dm_returns_false_for_missing_topic_segment() {
+        // Build a ref that has all DM segments EXCEPT the topic segment.
+        // The decoder records topic_present=false when the topic segment is
+        // absent, and the DM predicate requires topic_present=true.
+        fn seg(name: &str, value: &str) -> String {
+            format!("{}:{}:{};", name, value.len(), value)
+        }
+        let raw = format!(
+            "{}{}{}{}{}{}{}{}",
+            seg("adapter", SLACK_V2_ADAPTER_ID),
+            seg("installation", INSTALLATION),
+            seg("agent", AGENT),
+            seg("project", PROJECT),
+            seg("space", TEAM),
+            seg("conversation", "D0HOST"),
+            // topic segment intentionally omitted
+            seg("actor_kind", SLACK_USER_ACTOR_KIND),
+            seg("actor", SLACK_USER),
+        );
+        let binding_ref =
+            slack_reply_target_binding_ref_from_raw(raw).expect("builds syntactically");
+        assert!(
+            !slack_reply_target_is_personal_dm(&binding_ref),
+            "ref missing topic segment must NOT be identified as a personal DM"
+        );
+    }
+
+    // ── slack_reply_target_is_personal_dm: wrong adapter ─────────────────────
+
+    #[test]
+    fn slack_reply_target_is_personal_dm_rejects_non_slack_adapter() {
+        // Build a ref identical to a valid personal-DM ref but with a
+        // non-Slack adapter id.  The decoder must fail-closed and return None,
+        // so the DM predicate must return false.
+        fn seg(name: &str, value: &str) -> String {
+            format!("{}:{}:{};", name, value.len(), value)
+        }
+        let raw = format!(
+            "{}{}{}{}{}{}{}{}{}",
+            seg("adapter", "other_adapter"),
+            seg("installation", INSTALLATION),
+            seg("agent", AGENT),
+            seg("project", PROJECT),
+            seg("space", TEAM),
+            seg("conversation", "D0HOST"),
+            seg("topic", ""),
+            seg("actor_kind", SLACK_USER_ACTOR_KIND),
+            seg("actor", SLACK_USER),
+        );
+        let binding_ref =
+            slack_reply_target_binding_ref_from_raw(raw).expect("builds syntactically");
+        assert!(
+            !slack_reply_target_is_personal_dm(&binding_ref),
+            "non-Slack adapter ref must NOT be identified as a personal DM"
         );
     }
 }


### PR DESCRIPTION
## Summary

Security follow-up from #4946 review (coderabbit). On the **triggered-run** Slack delivery path, a `BlockedAuth` run with a link-based OAuth challenge posted the OAuth `authorization_url` into Slack on the assumption that a triggered run always delivers to the creator's private DM.

That assumption is not enforced: the triggered delivery target resolves from the creator's **personal communication preference**, and shared-channel outbound targets advertise `auth_prompts: true` (`slack_outbound_targets.rs` `entry_for_shared_channel_route`). So if a creator's preference resolves to a shared channel, the OAuth setup URL leaks onto a shared Slack surface.

## Fix (fail closed)

OAuth `authorization_url` may only be posted to a **verified personal DM**.

- **`slack_outbound_targets.rs`** — new `slack_reply_target_is_personal_dm()`: strictly parses the binding-ref segment chain, returning `true` only for a personal-DM ref (trailing `actor_kind=slack_user` / `actor` segments present **and** a `D`-prefixed channel id). Any parse failure → `false`.
- **`slack_delivery.rs`** — `deliver_triggered_run` resolves the creator's preference once and computes `target_is_verified_dm` against the **effective** auth target: `auth_prompt_target.or(final_reply_target)`, mirroring `resolution_engine.rs` `PreferenceTargetKind::AuthPrompt`. A looser "any stored target is a DM" check would wrongly pass when `auth_prompt_target` is a shared channel but `final_reply_target` is a DM. Preference-read failure or no target → `false` (fail closed).
- The `BlockedAuth` arm keeps `authorization_url` only when `target_is_verified_dm`; otherwise it cancels the run and posts the existing `SLACK_AUTH_UNAVAILABLE_MESSAGE` notice (same treatment as the non-OAuth manual-token path).

## Tests

- `triggered_oauth_auth_to_shared_channel_suppresses_authorization_url` — URL suppressed, notice posted, no gate route recorded.
- `triggered_oauth_auth_to_personal_dm_posts_authorization_url` — DM target still posts the URL.
- `triggered_oauth_auth_prefers_auth_target_over_dm_fallback` — precedence guard: `auth_prompt_target`=shared + `final_reply_target`=DM ⇒ suppressed.
- 5 unit tests for `slack_reply_target_is_personal_dm` (DM→true; shared→false; non-`D` channel→false; malformed→false; empty actor→false).

`cargo fmt`/`clippy --features slack-v2-host-beta --tests` clean.

## Not in this PR

- **Stale `AuthFlow` on Slack auto-deny** (#4952): the auth auto-deny path cancels the run via `TurnCoordinator` but skips `AuthFlowManager::cancel_flow`. Wiring an auth-flow/auth-service handle into `SlackFinalReplyDeliveryServices` is a separate dependency change; tracked in #4952.

> Note: `slack_host_beta::…wires_trigger_delivery_hook_writes_record` is a pre-existing flaky (timeout under parallel load; flakes on `origin/main` too), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)