### PR TITLE
fix(reborn): surface approval-gate denial to model instead of cancelling the run

### DIFF
--- a/crates/ironclaw_agent_loop/src/executor/capabilities.rs
+++ b/crates/ironclaw_agent_loop/src/executor/capabilities.rs
@@ -1031,6 +1031,7 @@ impl CapabilityStage {
     ///
     /// Both summaries are compile-time `&'static str` and are validated by
     /// `SanitizedStrategySummary::from_trusted_static` at the call site.
+    // arch-exempt: too_many_args, denied-resume short-circuit threads the capability-batch dispatch context (ctx/state/signatures/batch); needs a dispatch-context bundle, plan #4954
     #[allow(clippy::too_many_arguments)]
     async fn short_circuit_denied_resume(
         &self,

--- a/crates/ironclaw_agent_loop/src/executor/capabilities.rs
+++ b/crates/ironclaw_agent_loop/src/executor/capabilities.rs
@@ -37,6 +37,22 @@ pub(crate) struct CapabilityStage;
 
 const MAX_SAFE_SUMMARY_BYTES: usize = 512;
 
+/// Outcome of [`CapabilityStage::short_circuit_denied_resume`].
+///
+/// The helper processes the denied call(s) from a gate denial (auth or approval)
+/// and returns either:
+/// - `TurnDone` — all visible calls belonged to the denied capability; the turn
+///   is already completed and the caller should propagate the step directly.
+/// - `Remaining` — one or more calls are for unrelated capabilities and should
+///   proceed through the normal batch dispatch path.
+enum DeniedResumeOutcome {
+    TurnDone(TurnCompletedStep),
+    Remaining {
+        state: Box<LoopExecutionState>,
+        visible_calls: Vec<CapabilityCallCandidate>,
+    },
+}
+
 pub(super) struct CapabilityInput {
     pub(super) state: LoopExecutionState,
     pub(super) surface: VisibleCapabilitySurface,
@@ -124,7 +140,7 @@ impl ExecutorStage<CapabilityInput> for CapabilityStage {
         if let Some(pending) = state.pending_auth_resume.as_ref().filter(|p| {
             matches!(
                 p.disposition.as_ref(),
-                Some(ironclaw_turns::AuthResumeDisposition::Denied)
+                Some(ironclaw_turns::GateResumeDisposition::Denied)
             )
         }) {
             let denied_cap_id = pending.capability_id.clone();
@@ -133,57 +149,68 @@ impl ExecutorStage<CapabilityInput> for CapabilityStage {
             // auth_denied_calls is empty — preventing a stale Denied disposition
             // from leaking into the fall-through batch.
             state.pending_auth_resume = None;
-            let (auth_denied_calls, remaining_calls): (Vec<_>, Vec<_>) = visible_calls
-                .into_iter()
-                .partition(|call| call.capability_id == denied_cap_id);
-
-            for call in auth_denied_calls {
-                push_call_signature_once(&mut state, &mut signatures, &call)?;
-                let failure = ironclaw_turns::run_profile::CapabilityFailure {
-                    error_kind: CapabilityFailureKind::Authorization,
-                    // Intentionally empty: model-visible text comes from
-                    // `model_visible_capability_failure_observation` and the
-                    // planner summary from `from_trusted_static` below.
-                    safe_summary: String::new(),
-                    detail: None,
-                };
-                state
-                    .recent_failure_kinds
-                    .push(capability_failure_kind(&failure.error_kind));
-                let model_observation =
-                    Some(model_visible_capability_failure_observation(&failure));
-                let summary = CapabilityErrorSummary {
-                    class: capability_error_class(&failure.error_kind),
-                    safe_summary: SanitizedStrategySummary::from_trusted_static(
-                        "auth gate denied by user",
-                    ),
-                    diagnostic_ref: None,
-                };
-                match self
-                    .handle_capability_error(
-                        ctx,
-                        state,
-                        call,
-                        summary,
-                        model_observation,
-                        &mut capability_batch,
-                    )
-                    .await?
-                {
-                    BatchStep::Continue(next) => state = *next,
-                    BatchStep::Exit(exit) => return Ok(TurnCompletedStep::Exit(exit)),
+            match self
+                .short_circuit_denied_resume(
+                    ctx,
+                    state,
+                    &mut signatures,
+                    &mut capability_batch,
+                    result_refs_start,
+                    denied_cap_id,
+                    "auth gate denied by user",
+                    visible_calls,
+                )
+                .await?
+            {
+                DeniedResumeOutcome::TurnDone(step) => return Ok(step),
+                DeniedResumeOutcome::Remaining {
+                    state: next,
+                    visible_calls: remaining,
+                } => {
+                    state = *next;
+                    visible_calls = remaining;
                 }
             }
+        }
 
-            if remaining_calls.is_empty() {
-                return self
-                    .completed_turn(ctx, state, result_refs_start, capability_batch)
-                    .await;
+        // A run resumed from a user-DENIED approval gate must not re-dispatch
+        // the parked capability (re-dispatch → re-block → infinite loop).
+        // Mirror the auth-gate pattern above: surface a model-visible
+        // Authorization failure for only the denied call, let other parallel
+        // calls in the same batch proceed normally.
+        if let Some(pending) = state.pending_approval_resume.as_ref().filter(|p| {
+            matches!(
+                p.disposition.as_ref(),
+                Some(ironclaw_turns::GateResumeDisposition::Denied)
+            )
+        }) {
+            let denied_cap_id = pending.capability_id.clone();
+            // Clear the slot unconditionally — even if the partition yields no
+            // matching calls, a stale Denied disposition must not bleed into the
+            // fall-through batch.
+            state.pending_approval_resume = None;
+            match self
+                .short_circuit_denied_resume(
+                    ctx,
+                    state,
+                    &mut signatures,
+                    &mut capability_batch,
+                    result_refs_start,
+                    denied_cap_id,
+                    "approval gate denied by user",
+                    visible_calls,
+                )
+                .await?
+            {
+                DeniedResumeOutcome::TurnDone(step) => return Ok(step),
+                DeniedResumeOutcome::Remaining {
+                    state: next,
+                    visible_calls: remaining,
+                } => {
+                    state = *next;
+                    visible_calls = remaining;
+                }
             }
-
-            // Continue with only the non-denied calls; policy is computed below
-            // from this reduced set so batch sizing and progress events are accurate.
-            visible_calls = remaining_calls;
         }
 
         // Compute batch policy from the final set of calls that will actually
@@ -983,6 +1010,93 @@ impl CapabilityStage {
             checked.state,
             Some(checked.checkpoint_id),
         )?))
+    }
+
+    /// Shared denied-resume short-circuit for both auth and approval gates.
+    ///
+    /// Partitions `visible_calls` by `denied_cap_id`.  For every call that
+    /// matches the denied capability, synthesises a model-visible
+    /// `Authorization` failure (retry `Forbidden`) via `handle_capability_error`
+    /// and uses `planner_summary` as the planner-visible strategy summary
+    /// (must pass `validate_loop_safe_summary`).  Calls for unrelated
+    /// capabilities are returned as `DeniedResumeOutcome::Remaining` so the
+    /// caller can dispatch them through the normal batch path.
+    ///
+    /// # Callers
+    ///
+    /// - Auth-gate denial: `state.pending_auth_resume = None` before calling;
+    ///   `planner_summary = "auth gate denied by user"`.
+    /// - Approval-gate denial: `state.pending_approval_resume = None` before
+    ///   calling; `planner_summary = "approval gate denied by user"`.
+    ///
+    /// Both summaries are compile-time `&'static str` and are validated by
+    /// `SanitizedStrategySummary::from_trusted_static` at the call site.
+    #[allow(clippy::too_many_arguments)]
+    async fn short_circuit_denied_resume(
+        &self,
+        ctx: StageContext<'_>,
+        mut state: LoopExecutionState,
+        signatures: &mut HashSet<crate::state::CapabilityCallSignature>,
+        capability_batch: &mut CapabilityBatchTurnSummary,
+        result_refs_start: usize,
+        denied_cap_id: ironclaw_host_api::CapabilityId,
+        planner_summary: &'static str,
+        visible_calls: Vec<CapabilityCallCandidate>,
+    ) -> Result<DeniedResumeOutcome, AgentLoopExecutorError> {
+        let (denied_calls, remaining_calls): (Vec<_>, Vec<_>) = visible_calls
+            .into_iter()
+            .partition(|call| call.capability_id == denied_cap_id);
+
+        for call in denied_calls {
+            push_call_signature_once(&mut state, signatures, &call)?;
+            let failure = ironclaw_turns::run_profile::CapabilityFailure {
+                error_kind: CapabilityFailureKind::Authorization,
+                // Intentionally empty: model-visible text comes from
+                // `model_visible_capability_failure_observation` and the
+                // planner summary from `from_trusted_static` below.
+                safe_summary: String::new(),
+                detail: None,
+            };
+            state
+                .recent_failure_kinds
+                .push(capability_failure_kind(&failure.error_kind));
+            let model_observation = Some(model_visible_capability_failure_observation(&failure));
+            let summary = CapabilityErrorSummary {
+                class: capability_error_class(&failure.error_kind),
+                safe_summary: SanitizedStrategySummary::from_trusted_static(planner_summary),
+                diagnostic_ref: None,
+            };
+            match self
+                .handle_capability_error(
+                    ctx,
+                    state,
+                    call,
+                    summary,
+                    model_observation,
+                    capability_batch,
+                )
+                .await?
+            {
+                BatchStep::Continue(next) => state = *next,
+                BatchStep::Exit(exit) => {
+                    return Ok(DeniedResumeOutcome::TurnDone(TurnCompletedStep::Exit(exit)));
+                }
+            }
+        }
+
+        if remaining_calls.is_empty() {
+            let done = self
+                .completed_turn(ctx, state, result_refs_start, capability_batch.clone())
+                .await?;
+            return Ok(DeniedResumeOutcome::TurnDone(done));
+        }
+
+        // Continue with only the non-denied calls; batch policy is recomputed
+        // from this reduced set so sizing and progress events are accurate.
+        Ok(DeniedResumeOutcome::Remaining {
+            state: Box::new(state),
+            visible_calls: remaining_calls,
+        })
     }
 }
 

--- a/crates/ironclaw_agent_loop/src/executor/capabilities.rs
+++ b/crates/ironclaw_agent_loop/src/executor/capabilities.rs
@@ -1,4 +1,5 @@
 use std::collections::HashSet;
+use std::ops::ControlFlow;
 
 use async_trait::async_trait;
 use ironclaw_turns::{
@@ -36,22 +37,6 @@ use super::{
 pub(crate) struct CapabilityStage;
 
 const MAX_SAFE_SUMMARY_BYTES: usize = 512;
-
-/// Outcome of [`CapabilityStage::short_circuit_denied_resume`].
-///
-/// The helper processes the denied call(s) from a gate denial (auth or approval)
-/// and returns either:
-/// - `TurnDone` — all visible calls belonged to the denied capability; the turn
-///   is already completed and the caller should propagate the step directly.
-/// - `Remaining` — one or more calls are for unrelated capabilities and should
-///   proceed through the normal batch dispatch path.
-enum DeniedResumeOutcome {
-    TurnDone(TurnCompletedStep),
-    Remaining {
-        state: Box<LoopExecutionState>,
-        visible_calls: Vec<CapabilityCallCandidate>,
-    },
-}
 
 pub(super) struct CapabilityInput {
     pub(super) state: LoopExecutionState,
@@ -155,21 +140,22 @@ impl ExecutorStage<CapabilityInput> for CapabilityStage {
                     state,
                     &mut signatures,
                     &mut capability_batch,
-                    result_refs_start,
                     denied_cap_id,
                     "auth gate denied by user",
                     visible_calls,
                 )
                 .await?
             {
-                DeniedResumeOutcome::TurnDone(step) => return Ok(step),
-                DeniedResumeOutcome::Remaining {
-                    state: next,
-                    visible_calls: remaining,
-                } => {
-                    state = *next;
+                ControlFlow::Break(exit) => return Ok(exit),
+                ControlFlow::Continue((next, remaining)) => {
+                    state = next;
                     visible_calls = remaining;
                 }
+            }
+            if visible_calls.is_empty() {
+                return self
+                    .completed_turn(ctx, state, result_refs_start, capability_batch)
+                    .await;
             }
         }
 
@@ -195,21 +181,22 @@ impl ExecutorStage<CapabilityInput> for CapabilityStage {
                     state,
                     &mut signatures,
                     &mut capability_batch,
-                    result_refs_start,
                     denied_cap_id,
                     "approval gate denied by user",
                     visible_calls,
                 )
                 .await?
             {
-                DeniedResumeOutcome::TurnDone(step) => return Ok(step),
-                DeniedResumeOutcome::Remaining {
-                    state: next,
-                    visible_calls: remaining,
-                } => {
-                    state = *next;
+                ControlFlow::Break(exit) => return Ok(exit),
+                ControlFlow::Continue((next, remaining)) => {
+                    state = next;
                     visible_calls = remaining;
                 }
+            }
+            if visible_calls.is_empty() {
+                return self
+                    .completed_turn(ctx, state, result_refs_start, capability_batch)
+                    .await;
             }
         }
 
@@ -1018,9 +1005,14 @@ impl CapabilityStage {
     /// matches the denied capability, synthesises a model-visible
     /// `Authorization` failure (retry `Forbidden`) via `handle_capability_error`
     /// and uses `planner_summary` as the planner-visible strategy summary
-    /// (must pass `validate_loop_safe_summary`).  Calls for unrelated
-    /// capabilities are returned as `DeniedResumeOutcome::Remaining` so the
-    /// caller can dispatch them through the normal batch path.
+    /// (must pass `validate_loop_safe_summary`).
+    ///
+    /// Returns `ControlFlow::Break(step)` if `handle_capability_error` produced
+    /// an `Exit` (caller should propagate it immediately), or
+    /// `ControlFlow::Continue((state, remaining_calls))` with the surviving
+    /// state and the calls that did *not* match the denied capability.  The
+    /// caller is responsible for checking whether `remaining_calls` is empty
+    /// and calling `completed_turn` when it is.
     ///
     /// # Callers
     ///
@@ -1039,11 +1031,13 @@ impl CapabilityStage {
         mut state: LoopExecutionState,
         signatures: &mut HashSet<crate::state::CapabilityCallSignature>,
         capability_batch: &mut CapabilityBatchTurnSummary,
-        result_refs_start: usize,
         denied_cap_id: ironclaw_host_api::CapabilityId,
         planner_summary: &'static str,
         visible_calls: Vec<CapabilityCallCandidate>,
-    ) -> Result<DeniedResumeOutcome, AgentLoopExecutorError> {
+    ) -> Result<
+        ControlFlow<TurnCompletedStep, (LoopExecutionState, Vec<CapabilityCallCandidate>)>,
+        AgentLoopExecutorError,
+    > {
         let (denied_calls, remaining_calls): (Vec<_>, Vec<_>) = visible_calls
             .into_iter()
             .partition(|call| call.capability_id == denied_cap_id);
@@ -1080,24 +1074,15 @@ impl CapabilityStage {
             {
                 BatchStep::Continue(next) => state = *next,
                 BatchStep::Exit(exit) => {
-                    return Ok(DeniedResumeOutcome::TurnDone(TurnCompletedStep::Exit(exit)));
+                    return Ok(ControlFlow::Break(TurnCompletedStep::Exit(exit)));
                 }
             }
         }
 
-        if remaining_calls.is_empty() {
-            let done = self
-                .completed_turn(ctx, state, result_refs_start, capability_batch.clone())
-                .await?;
-            return Ok(DeniedResumeOutcome::TurnDone(done));
-        }
-
-        // Continue with only the non-denied calls; batch policy is recomputed
-        // from this reduced set so sizing and progress events are accurate.
-        Ok(DeniedResumeOutcome::Remaining {
-            state: Box::new(state),
-            visible_calls: remaining_calls,
-        })
+        // Return surviving state + remaining calls to the caller.
+        // The caller checks remaining_calls.is_empty() and calls completed_turn
+        // when there is nothing left to dispatch.
+        Ok(ControlFlow::Continue((state, remaining_calls)))
     }
 }
 

--- a/crates/ironclaw_agent_loop/src/executor/gates.rs
+++ b/crates/ironclaw_agent_loop/src/executor/gates.rs
@@ -81,6 +81,10 @@ impl ExecutorStage<GateInput> for GateStage {
                         provider_replay: call.provider_replay.clone(),
                         input: resume.input,
                         estimate: resume.estimate,
+                        // Disposition is stamped by PlannedDriver at resume time;
+                        // GateStage writes the initial (blocking) checkpoint where
+                        // no denial has occurred yet.
+                        disposition: None,
                     });
                 if matches!(kind, GateKind::Auth) {
                     // CapabilityStage shapes auth-resume metadata; GateStage

--- a/crates/ironclaw_agent_loop/src/executor/tests.rs
+++ b/crates/ironclaw_agent_loop/src/executor/tests.rs
@@ -2021,6 +2021,59 @@ async fn approval_resume_metadata_is_replayed_after_before_block_checkpoint() {
     assert_eq!(final_staged_state(&host).result_refs, vec![completed_ref]);
 }
 
+/// Focused regression for gates.rs:85 — `GateStage` must stamp
+/// `disposition: None` on the initial (blocking) `PendingApprovalResume`
+/// checkpoint.  A denial has not yet occurred at block time; writing any
+/// non-`None` disposition here would short-circuit the capability stage
+/// incorrectly on the very next resume, before any user deny action.
+#[tokio::test]
+async fn approval_gate_before_block_checkpoint_disposition_is_none() {
+    let approval_resume = CapabilityApprovalResume {
+        approval_request_id: ApprovalRequestId::new(),
+        resume_token: CapabilityResumeToken::new("resume-token:disposition-none-test")
+            .expect("valid token"),
+        correlation_id: CorrelationId::new(),
+        input_ref: CapabilityInputRef::new("input:disposition-none-test").expect("valid"),
+        input: serde_json::json!({ "message": "needs approval" }),
+        estimate: ResourceEstimate::default(),
+    };
+    let host = MockHost::new(vec![calls_response()]).with_batch_outcomes(vec![
+        ironclaw_turns::run_profile::CapabilityBatchOutcome {
+            outcomes: vec![CapabilityOutcome::ApprovalRequired {
+                gate_ref: LoopGateRef::new("gate:approval-disposition-none").expect("valid"),
+                safe_summary: "approval required".to_string(),
+                approval_resume: Some(approval_resume.clone()),
+            }],
+            stopped_on_suspension: true,
+        },
+    ]);
+    let executor = CanonicalAgentLoopExecutor;
+    let state = LoopExecutionState::initial_for_run(host.run_context());
+
+    let exit = executor
+        .execute_family(&crate::families::default(), &host, state)
+        .await
+        .expect("execute");
+
+    assert!(matches!(exit, LoopExit::Blocked(_)));
+
+    let before_block_state = final_staged_state_for_kind(&host, LoopCheckpointKind::BeforeBlock);
+    let pending_resume = before_block_state
+        .pending_approval_resume
+        .as_ref()
+        .expect("BeforeBlock checkpoint must carry pending_approval_resume");
+
+    // Key regression assertion: disposition must be None at the first-block
+    // checkpoint.  A non-None value here means GateStage pre-stamped a denial
+    // that hasn't happened yet, which would cause the capability stage to
+    // incorrectly short-circuit on the very next resume.
+    assert_eq!(
+        pending_resume.disposition, None,
+        "pending_approval_resume.disposition must be None at the initial BeforeBlock checkpoint \
+         (no denial has occurred yet — GateStage must not pre-stamp a disposition)"
+    );
+}
+
 #[tokio::test]
 async fn gate_stage_skips_and_continues_records_skipped_summary() {
     let family = family_with_gate_outcome(GateOutcome::SkipAndContinue {
@@ -6443,5 +6496,149 @@ async fn capability_stage_denied_approval_resume_only_fails_matching_call_remain
     assert!(
         final_state.result_refs.contains(&y_result_ref),
         "final_state.result_refs must contain Y's completed result ref"
+    );
+}
+
+/// No-match variant of the denied-approval short-circuit test.
+///
+/// When `pending_approval_resume` is set with `disposition = Some(Denied)` for
+/// capability X but the model emits *only* calls for capability Y (no X in
+/// `visible_calls`), the executor must:
+///
+/// 1. NOT surface X as an Authorization failure (X is absent from the batch).
+/// 2. Dispatch Y normally and record its outcome.
+/// 3. Clear `pending_approval_resume` after processing the batch.
+/// 4. Return `TurnCompletedStep::Continue` (loop proceeds).
+///
+/// This ensures the stale denied state is always evicted even when the model
+/// does not reproduce the denied call in the next turn.
+#[tokio::test]
+async fn capability_stage_denied_approval_resume_no_matching_call_dispatches_unrelated_normally() {
+    let y_result_ref = LoopResultRef::new("result:approval-no-match-y").expect("valid");
+
+    // Only capability Y is needed in the batch outcome; X is never submitted.
+    let host = MockHost::new(Vec::new())
+        .with_extra_capability_descriptors(vec![
+            ironclaw_turns::run_profile::CapabilityDescriptorView {
+                capability_id: other_capability_id(),
+                provider: None,
+                runtime: ironclaw_host_api::RuntimeKind::FirstParty,
+                safe_name: "demo_list".to_string(),
+                safe_description: "demo list capability".to_string(),
+                concurrency_hint: ironclaw_turns::run_profile::ConcurrencyHint::SafeForParallel,
+                parameters_schema: serde_json::json!({"type":"object","properties":{}}),
+            },
+        ])
+        .with_batch_outcomes(vec![ironclaw_turns::run_profile::CapabilityBatchOutcome {
+            outcomes: vec![CapabilityOutcome::Completed(CapabilityResultMessage {
+                result_ref: y_result_ref.clone(),
+                safe_summary: "list done no-match".to_string(),
+                progress: ironclaw_turns::run_profile::CapabilityProgress::MadeProgress,
+                terminate_hint: false,
+                byte_len: 0,
+            })],
+            stopped_on_suspension: false,
+        }]);
+
+    let family = crate::families::default();
+    let ctx = StageContext {
+        planner: family.planner(),
+        host: &host,
+    };
+
+    // Seed pending_approval_resume for capability X = capability_id(), Denied.
+    // The model will emit ONLY capability Y calls — X is absent from visible_calls.
+    let mut state = LoopExecutionState::initial_for_run(host.run_context());
+    state.pending_approval_resume = Some(PendingApprovalResume {
+        gate_ref: LoopGateRef::new("gate:approval-deny-no-match").expect("valid"),
+        capability_id: capability_id(),
+        approval_request_id: ApprovalRequestId::new(),
+        resume_token: CapabilityResumeToken::new("00000000-0000-0000-0000-000000000099")
+            .expect("valid"),
+        correlation_id: ironclaw_host_api::CorrelationId::new(),
+        surface_version: surface_version(),
+        input_ref: CapabilityInputRef::new("input:approval-deny-no-match-x").expect("valid"),
+        effective_capability_ids: vec![capability_id()],
+        provider_replay: None,
+        input: serde_json::json!({"extension_id": "slack"}),
+        estimate: ironclaw_host_api::ResourceEstimate::default(),
+        disposition: Some(ironclaw_turns::GateResumeDisposition::Denied),
+    });
+
+    // The model emits ONLY call Y (other_capability_id); no X in this batch.
+    let calls = vec![ironclaw_turns::run_profile::CapabilityCallCandidate {
+        surface_version: surface_version(),
+        capability_id: other_capability_id(),
+        input_ref: CapabilityInputRef::new("input:y-no-match-approval").expect("valid"),
+        effective_capability_ids: vec![other_capability_id()],
+        provider_replay: None,
+    }];
+
+    let step = CapabilityStage
+        .process(
+            ctx,
+            CapabilityInput {
+                state,
+                surface: ironclaw_turns::run_profile::LoopCapabilityPort::visible_capabilities(
+                    &host,
+                    VisibleCapabilityRequest,
+                )
+                .await
+                .expect("visible surface"),
+                calls,
+            },
+        )
+        .await
+        .expect("capability stage");
+
+    // 1. Must return Continue — the loop proceeds.
+    let final_state = match step {
+        TurnCompletedStep::Continue { state, .. } => state,
+        TurnCompletedStep::Exit(exit) => {
+            panic!("expected Continue when denied X is absent from the batch, got Exit: {exit:?}")
+        }
+    };
+
+    // 2. X must NOT appear as a failure — it was not in the visible batch.
+    let appended = host.appended_result_refs();
+    assert!(
+        !appended.iter().any(|r| r
+            .model_observation
+            .as_ref()
+            .is_some_and(|o| o.summary == "Capability failed with authorization.")),
+        "X must NOT be surfaced as an Authorization failure when it is absent from visible_calls"
+    );
+
+    // 3. Y dispatches normally: exactly one batch invocation containing Y.
+    let batches = host.batch_invocations();
+    assert_eq!(
+        batches.len(),
+        1,
+        "exactly one batch invocation must occur for call Y"
+    );
+    assert!(
+        batches[0]
+            .invocations
+            .iter()
+            .all(|inv| inv.capability_id == other_capability_id()),
+        "the batch must contain only call Y"
+    );
+
+    // 4. Y's result ref is present in appended refs and final_state.
+    assert!(
+        appended.iter().any(|r| r.result_ref == y_result_ref),
+        "Y's completed result ref must be appended"
+    );
+    assert!(
+        final_state.result_refs.contains(&y_result_ref),
+        "final_state.result_refs must contain Y's completed result ref"
+    );
+
+    // 5. pending_approval_resume is cleared after the batch — stale denied
+    //    state must not survive into the next iteration.
+    assert!(
+        final_state.pending_approval_resume.is_none(),
+        "pending_approval_resume must be cleared even when the denied capability X was absent \
+         from the model's batch"
     );
 }

--- a/crates/ironclaw_agent_loop/src/executor/tests.rs
+++ b/crates/ironclaw_agent_loop/src/executor/tests.rs
@@ -18,8 +18,8 @@ use ironclaw_turns::{
 
 use crate::state::{
     CapabilityCallSignature, CheckpointKind, DeferredCompactionWatermark, IndexedMessageKind,
-    LoopExecutionState, MessageIndexEntry, PendingAuthResume, RepeatedCallWarningPhase,
-    RepeatedCallWarningState,
+    LoopExecutionState, MessageIndexEntry, PendingApprovalResume, PendingAuthResume,
+    RepeatedCallWarningPhase, RepeatedCallWarningState,
 };
 use crate::strategies::{
     CapabilityBatchTurnSummary, CapabilityFilter, DefaultCompactionStrategy, GateKind, GateOutcome,
@@ -5578,7 +5578,7 @@ async fn capability_stage_denied_auth_resume_surfaces_authorization_failure_and_
         resume_token: None,
         prior_approval: None,
         replay: None,
-        disposition: Some(ironclaw_turns::AuthResumeDisposition::Denied),
+        disposition: Some(ironclaw_turns::GateResumeDisposition::Denied),
     });
 
     // Use provider_calls_response so provider_replay is set, enabling the
@@ -5713,7 +5713,7 @@ async fn capability_stage_denied_auth_resume_only_fails_matching_call_remaining_
         resume_token: None,
         prior_approval: None,
         replay: None,
-        disposition: Some(ironclaw_turns::AuthResumeDisposition::Denied),
+        disposition: Some(ironclaw_turns::GateResumeDisposition::Denied),
     });
 
     // Build a batch with two calls:
@@ -5948,7 +5948,7 @@ async fn capability_stage_denied_auth_resume_one_denied_two_remaining_all_dispat
         resume_token: None,
         prior_approval: None,
         replay: None,
-        disposition: Some(ironclaw_turns::AuthResumeDisposition::Denied),
+        disposition: Some(ironclaw_turns::GateResumeDisposition::Denied),
     });
 
     // Three calls: X (denied), Y (unrelated), Z (unrelated).
@@ -6119,5 +6119,329 @@ async fn capability_stage_denied_auth_resume_one_denied_two_remaining_all_dispat
     assert!(
         final_state.result_refs.contains(&z_result_ref),
         "final_state.result_refs must contain Z's completed result ref"
+    );
+}
+
+// ── Approval-gate denial tests ────────────────────────────────────────────────
+//
+// These mirror the auth-gate denial tests above for the approval path.
+// The shared `short_circuit_denied_resume` helper must behave identically
+// regardless of which gate kind triggered the denial.
+
+/// Caller-level regression test for the approval-deny short-circuit in
+/// `CapabilityStage::process`.
+///
+/// When a run resumes from a user-DENIED approval gate (i.e.
+/// `pending_approval_resume` is set and `disposition = Some(Denied)`), the
+/// executor must NOT re-dispatch the parked capability (re-dispatch → re-block
+/// → infinite loop). It must:
+///
+/// 1. Return `TurnCompletedStep::Continue` (loop proceeds, not Blocked/Exit).
+/// 2. Clear `pending_approval_resume` so the next iteration prompts the model
+///    normally.
+/// 3. Append a model-visible Authorization failure observation with
+///    `status = Error` and `same_call_retry = Forbidden`.
+/// 4. Issue zero batch-invoke calls to the capability host.
+#[tokio::test]
+async fn capability_stage_denied_approval_resume_surfaces_authorization_failure_and_continues() {
+    let host = MockHost::new(Vec::new());
+    let family = crate::families::default();
+    let ctx = StageContext {
+        planner: family.planner(),
+        host: &host,
+    };
+
+    let mut state = LoopExecutionState::initial_for_run(host.run_context());
+    state.pending_approval_resume = Some(PendingApprovalResume {
+        gate_ref: LoopGateRef::new("gate:approval-deny-test").expect("valid"),
+        capability_id: capability_id(),
+        approval_request_id: ApprovalRequestId::new(),
+        resume_token: CapabilityResumeToken::new("00000000-0000-0000-0000-000000000042")
+            .expect("valid"),
+        correlation_id: ironclaw_host_api::CorrelationId::new(),
+        surface_version: surface_version(),
+        input_ref: CapabilityInputRef::new("input:approval-deny-test").expect("valid"),
+        effective_capability_ids: vec![capability_id()],
+        provider_replay: None,
+        input: serde_json::json!({"extension_id": "slack"}),
+        estimate: ironclaw_host_api::ResourceEstimate::default(),
+        disposition: Some(ironclaw_turns::GateResumeDisposition::Denied),
+    });
+
+    // Use provider_calls_response so provider_replay is set, which enables the
+    // model-visible observation to be written to appended_result_refs.
+    let calls = match provider_calls_response().output {
+        ParentLoopOutput::CapabilityCalls(calls) => calls,
+        ParentLoopOutput::AssistantReply(_) => panic!("expected provider calls fixture"),
+    };
+
+    let step = CapabilityStage
+        .process(
+            ctx,
+            CapabilityInput {
+                state,
+                surface: ironclaw_turns::run_profile::LoopCapabilityPort::visible_capabilities(
+                    &host,
+                    VisibleCapabilityRequest,
+                )
+                .await
+                .expect("visible surface"),
+                calls,
+            },
+        )
+        .await
+        .expect("capability stage");
+
+    // 1. Must return Continue — loop proceeds, not Blocked/Exit.
+    let final_state = match step {
+        TurnCompletedStep::Continue { state, .. } => state,
+        TurnCompletedStep::Exit(exit) => {
+            panic!("expected Continue after denied approval resume, got Exit: {exit:?}")
+        }
+    };
+
+    // 2. pending_approval_resume must be cleared after the denied-resume path.
+    assert!(
+        final_state.pending_approval_resume.is_none(),
+        "pending_approval_resume must be cleared after surfacing the deny failure"
+    );
+
+    // 3. Zero batch invocations: the short-circuit fired before invoke_capability_batch.
+    assert!(
+        host.batch_invocations().is_empty(),
+        "denied approval resume must not dispatch any capability batch invocations"
+    );
+
+    // 4. One model-visible observation appended with Authorization error + Forbidden retry.
+    let appended = host.appended_result_refs();
+    assert_eq!(
+        appended.len(),
+        1,
+        "exactly one model-visible result ref must be appended for the deny failure"
+    );
+    let observation = appended[0]
+        .model_observation
+        .as_ref()
+        .expect("model_observation must be Some for an Authorization failure");
+    assert_eq!(
+        observation.status,
+        ToolObservationStatus::Error,
+        "observation status must be Error"
+    );
+    assert_eq!(
+        observation.summary, "Capability failed with authorization.",
+        "observation summary must describe the authorization failure"
+    );
+    let recovery = observation
+        .recovery
+        .as_ref()
+        .expect("recovery must be present");
+    assert_eq!(
+        recovery.same_call_retry,
+        SameCallRetryConstraint::Forbidden,
+        "Authorization failure must map to Forbidden retry constraint (model must not retry)"
+    );
+}
+
+/// When a resumed run carries `pending_approval_resume` with
+/// `disposition = Some(Denied)` and the parallel batch contains BOTH the
+/// denied capability (X = `capability_id()`) AND an unrelated capability
+/// (Y = `other_capability_id()`), only X must receive an Authorization
+/// failure. Y must be dispatched normally and its outcome must appear in
+/// the result refs. The loop must continue, and `pending_approval_resume`
+/// must be cleared.
+#[tokio::test]
+async fn capability_stage_denied_approval_resume_only_fails_matching_call_remaining_dispatched() {
+    let y_result_ref = LoopResultRef::new("result:approval-y-outcome").expect("valid");
+
+    let host = MockHost::new(Vec::new())
+        .with_extra_capability_descriptors(vec![
+            ironclaw_turns::run_profile::CapabilityDescriptorView {
+                capability_id: other_capability_id(),
+                provider: None,
+                runtime: ironclaw_host_api::RuntimeKind::FirstParty,
+                safe_name: "demo_list".to_string(),
+                safe_description: "demo list capability".to_string(),
+                concurrency_hint: ironclaw_turns::run_profile::ConcurrencyHint::SafeForParallel,
+                parameters_schema: serde_json::json!({"type":"object","properties":{}}),
+            },
+        ])
+        .with_batch_outcomes(vec![ironclaw_turns::run_profile::CapabilityBatchOutcome {
+            outcomes: vec![CapabilityOutcome::Completed(CapabilityResultMessage {
+                result_ref: y_result_ref.clone(),
+                safe_summary: "list done".to_string(),
+                progress: ironclaw_turns::run_profile::CapabilityProgress::MadeProgress,
+                terminate_hint: false,
+                byte_len: 0,
+            })],
+            stopped_on_suspension: false,
+        }]);
+
+    let family = crate::families::default();
+    let ctx = StageContext {
+        planner: family.planner(),
+        host: &host,
+    };
+
+    // Seed pending_approval_resume for capability X = capability_id(), Denied.
+    let mut state = LoopExecutionState::initial_for_run(host.run_context());
+    state.pending_approval_resume = Some(PendingApprovalResume {
+        gate_ref: LoopGateRef::new("gate:approval-deny-multi").expect("valid"),
+        capability_id: capability_id(),
+        approval_request_id: ApprovalRequestId::new(),
+        resume_token: CapabilityResumeToken::new("00000000-0000-0000-0000-000000000043")
+            .expect("valid"),
+        correlation_id: ironclaw_host_api::CorrelationId::new(),
+        surface_version: surface_version(),
+        input_ref: CapabilityInputRef::new("input:approval-deny-x").expect("valid"),
+        effective_capability_ids: vec![capability_id()],
+        provider_replay: None,
+        input: serde_json::json!({"extension_id": "slack"}),
+        estimate: ironclaw_host_api::ResourceEstimate::default(),
+        disposition: Some(ironclaw_turns::GateResumeDisposition::Denied),
+    });
+
+    // Build a batch with two calls:
+    //   call X: capability_id() ("demo.echo")  — matches denied pending_approval_resume
+    //   call Y: other_capability_id() ("demo.list") — unrelated, must proceed normally
+    let calls = vec![
+        // call X — denied
+        ironclaw_turns::run_profile::CapabilityCallCandidate {
+            surface_version: surface_version(),
+            capability_id: capability_id(),
+            input_ref: CapabilityInputRef::new("input:x-approval-denied").expect("valid"),
+            effective_capability_ids: vec![capability_id()],
+            provider_replay: Some(ironclaw_turns::run_profile::ProviderToolCallReplay {
+                provider_id: "test-provider".to_string(),
+                provider_model_id: "test-model".to_string(),
+                provider_turn_id: "turn_1".to_string(),
+                provider_call_id: "call_x".to_string(),
+                provider_tool_name: "demo__echo".to_string(),
+                arguments: serde_json::json!({"message": "x"}),
+                response_reasoning: None,
+                reasoning: None,
+                signature: None,
+            }),
+        },
+        // call Y — unrelated, must dispatch normally
+        ironclaw_turns::run_profile::CapabilityCallCandidate {
+            surface_version: surface_version(),
+            capability_id: other_capability_id(),
+            input_ref: CapabilityInputRef::new("input:y-approval-unrelated").expect("valid"),
+            effective_capability_ids: vec![other_capability_id()],
+            provider_replay: None,
+        },
+    ];
+
+    let step = CapabilityStage
+        .process(
+            ctx,
+            CapabilityInput {
+                state,
+                surface: ironclaw_turns::run_profile::LoopCapabilityPort::visible_capabilities(
+                    &host,
+                    VisibleCapabilityRequest,
+                )
+                .await
+                .expect("visible surface"),
+                calls,
+            },
+        )
+        .await
+        .expect("capability stage");
+
+    // 1. Must return Continue — the loop must proceed, not exit.
+    let final_state = match step {
+        TurnCompletedStep::Continue { state, .. } => state,
+        TurnCompletedStep::Exit(exit) => {
+            panic!("expected Continue after partial approval-deny, got Exit: {exit:?}")
+        }
+    };
+
+    // 2. pending_approval_resume must be cleared — the denial was consumed.
+    assert!(
+        final_state.pending_approval_resume.is_none(),
+        "pending_approval_resume must be cleared after the denied call was surfaced"
+    );
+
+    // 3. Exactly one batch invocation containing only call Y (not X).
+    let batches = host.batch_invocations();
+    assert_eq!(
+        batches.len(),
+        1,
+        "exactly one batch invocation must occur for the remaining (non-denied) call Y"
+    );
+    let batch_ids: Vec<_> = batches[0]
+        .invocations
+        .iter()
+        .map(|inv| &inv.capability_id)
+        .collect();
+    assert!(
+        batch_ids.iter().all(|id| **id == other_capability_id()),
+        "the batch must contain only call Y (other_capability_id), not call X"
+    );
+    assert_eq!(
+        batch_ids.len(),
+        1,
+        "batch must contain exactly one invocation (call Y)"
+    );
+
+    // 4. Two result refs appended total:
+    //    - one Authorization failure observation for X
+    //    - one Completed result for Y
+    let appended = host.appended_result_refs();
+    assert_eq!(
+        appended.len(),
+        2,
+        "expected two appended result refs: one Authorization failure for X, one Completed for Y"
+    );
+
+    // The Authorization failure for X must carry a model-visible observation.
+    let failure_entry = appended
+        .iter()
+        .find(|r| r.model_observation.is_some())
+        .expect("one appended result ref must be the Authorization failure for X");
+    let obs = failure_entry.model_observation.as_ref().unwrap();
+    assert_eq!(
+        obs.status,
+        ToolObservationStatus::Error,
+        "X failure observation status must be Error"
+    );
+    assert_eq!(
+        obs.summary, "Capability failed with authorization.",
+        "X failure observation summary must describe the authorization failure"
+    );
+    let recovery = obs
+        .recovery
+        .as_ref()
+        .expect("recovery must be present for X");
+    assert_eq!(
+        recovery.same_call_retry,
+        SameCallRetryConstraint::Forbidden,
+        "X failure must map to Forbidden retry"
+    );
+
+    // The Completed result for Y must be present.
+    let y_completed = appended
+        .iter()
+        .find(|r| r.result_ref == y_result_ref)
+        .expect("Y's completed result ref must be appended");
+    assert!(
+        y_completed.model_observation.is_none()
+            || y_completed
+                .model_observation
+                .as_ref()
+                .is_some_and(|o| o.status != ToolObservationStatus::Error),
+        "Y's result must not be an Authorization failure"
+    );
+
+    // 5. final_state.result_refs must carry BOTH refs.
+    assert!(
+        final_state.result_refs.contains(&failure_entry.result_ref),
+        "final_state.result_refs must contain the Authorization failure ref for X"
+    );
+    assert!(
+        final_state.result_refs.contains(&y_result_ref),
+        "final_state.result_refs must contain Y's completed result ref"
     );
 }

--- a/crates/ironclaw_agent_loop/src/state.rs
+++ b/crates/ironclaw_agent_loop/src/state.rs
@@ -112,6 +112,11 @@ pub struct PendingApprovalResume {
     pub provider_replay: Option<ProviderToolCallReplay>,
     pub input: serde_json::Value,
     pub estimate: ResourceEstimate,
+    /// Set when the user denied this approval gate. The loop surfaces a
+    /// model-visible failure for the parked call instead of re-dispatching.
+    /// Mirrors `PendingAuthResume::disposition`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub disposition: Option<ironclaw_turns::GateResumeDisposition>,
 }
 
 impl PendingApprovalResume {
@@ -148,9 +153,9 @@ impl PendingApprovalResume {
 /// case `resume_token` and `replay` are unused.
 ///
 /// Field-name note: `PendingAuthResume::disposition` is intentionally kept
-/// short because the enclosing type already scopes it to auth-resume context.
+/// short because the enclosing type already scopes it to gate-resume context.
 /// Turn-layer structs that carry a similar field from a wider scope use the
-/// qualified name `auth_resume_disposition` to avoid ambiguity.
+/// qualified name `resume_disposition` to avoid ambiguity.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct PendingAuthResume {
     pub gate_ref: LoopGateRef,
@@ -179,7 +184,7 @@ pub struct PendingAuthResume {
     /// Set when the user denied this auth gate. The loop surfaces a
     /// model-visible failure for the parked call instead of re-dispatching.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub disposition: Option<ironclaw_turns::AuthResumeDisposition>,
+    pub disposition: Option<ironclaw_turns::GateResumeDisposition>,
 }
 
 impl LoopExecutionState {
@@ -275,7 +280,7 @@ pub enum CheckpointPayloadError {
 mod tests {
     use ironclaw_host_api::{CapabilityId, TenantId, ThreadId};
     use ironclaw_turns::{
-        AgentLoopDriverDescriptor, AuthResumeDisposition, RunProfileId, RunProfileVersion, TurnId,
+        AgentLoopDriverDescriptor, GateResumeDisposition, RunProfileId, RunProfileVersion, TurnId,
         TurnRunId, TurnScope,
         run_profile::{
             CancellationPolicy, CapabilitySurfaceProfileId, CheckpointPolicy, CheckpointSchemaId,
@@ -760,7 +765,7 @@ mod tests {
             resume_token: None,
             prior_approval: None,
             replay: None,
-            disposition: Some(AuthResumeDisposition::Denied),
+            disposition: Some(GateResumeDisposition::Denied),
         });
         let payload = encode_payload(&state);
         let restored =
@@ -771,7 +776,7 @@ mod tests {
                 .pending_auth_resume
                 .as_ref()
                 .and_then(|r| r.disposition.as_ref()),
-            Some(&AuthResumeDisposition::Denied),
+            Some(&GateResumeDisposition::Denied),
             "PendingAuthResume with Denied disposition must survive checkpoint encode/decode"
         );
         assert_eq!(
@@ -960,6 +965,75 @@ mod tests {
         assert!(
             legacy_pending.disposition.is_none(),
             "disposition absent from checkpoint payload must decode to None"
+        );
+    }
+
+    #[test]
+    fn pending_approval_resume_denied_disposition_round_trips_through_checkpoint_payload() {
+        // Mirror of `pending_auth_resume_denied_disposition_round_trips_through_checkpoint_payload`.
+        // The `Some(Denied)` disposition stamped on `pending_approval_resume` before the
+        // capability stage must survive the checkpoint encode/decode cycle so that a
+        // resumed run still sees the approval denial.
+        use ironclaw_host_api::{ApprovalRequestId, CorrelationId, ResourceEstimate};
+        use ironclaw_turns::run_profile::CapabilityResumeToken;
+
+        let context = test_run_context();
+        let mut state = LoopExecutionState::initial_for_run(&context);
+        let resume_token =
+            CapabilityResumeToken::new("00000000-0000-0000-0000-000000000099").expect("valid");
+        state.pending_approval_resume = Some(super::PendingApprovalResume {
+            gate_ref: LoopGateRef::new("gate:approval-denied-test").expect("valid gate ref"),
+            capability_id: CapabilityId::new("extensions.install").expect("valid cap id"),
+            approval_request_id: ApprovalRequestId::new(),
+            resume_token,
+            correlation_id: CorrelationId::new(),
+            surface_version: CapabilitySurfaceVersion::new("surface-v1")
+                .expect("valid surface version"),
+            input_ref: CapabilityInputRef::new("input:approval-denied").expect("valid input ref"),
+            effective_capability_ids: vec![],
+            provider_replay: None,
+            input: serde_json::json!({"extension_id": "slack"}),
+            estimate: ResourceEstimate::default(),
+            disposition: Some(GateResumeDisposition::Denied),
+        });
+        let payload = encode_payload(&state);
+        let restored =
+            LoopExecutionState::from_checkpoint_payload(&payload, CheckpointKind::BeforeBlock)
+                .expect("decode checkpoint payload");
+        assert_eq!(
+            restored
+                .pending_approval_resume
+                .as_ref()
+                .and_then(|r| r.disposition.as_ref()),
+            Some(&GateResumeDisposition::Denied),
+            "PendingApprovalResume with Denied disposition must survive checkpoint encode/decode"
+        );
+        assert_eq!(
+            restored.pending_approval_resume, state.pending_approval_resume,
+            "entire PendingApprovalResume must round-trip without loss when disposition is Some(Denied)"
+        );
+
+        // Compat: strip the `disposition` field to simulate a checkpoint written
+        // before the field was added. Decoding must yield `None`, not an error.
+        let mut value: serde_json::Value = serde_json::from_slice(&payload).expect("parse");
+        value
+            .as_object_mut()
+            .expect("state is object")
+            .get_mut("pending_approval_resume")
+            .expect("pending_approval_resume present")
+            .as_object_mut()
+            .expect("pending_approval_resume is object")
+            .remove("disposition");
+        let stripped = serde_json::to_vec(&value).expect("re-encode");
+        let from_legacy =
+            LoopExecutionState::from_checkpoint_payload(&stripped, CheckpointKind::BeforeBlock)
+                .expect("decode legacy checkpoint without disposition field");
+        assert!(
+            from_legacy
+                .pending_approval_resume
+                .as_ref()
+                .is_some_and(|r| r.disposition.is_none()),
+            "disposition absent from legacy checkpoint must decode to None"
         );
     }
 }

--- a/crates/ironclaw_agent_loop/src/state.rs
+++ b/crates/ironclaw_agent_loop/src/state.rs
@@ -114,7 +114,7 @@ pub struct PendingApprovalResume {
     pub estimate: ResourceEstimate,
     /// Set when the user denied this approval gate. The loop surfaces a
     /// model-visible failure for the parked call instead of re-dispatching.
-    /// Mirrors `PendingAuthResume::disposition`.
+    /// See the field-name note on `PendingAuthResume::disposition`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub disposition: Option<ironclaw_turns::GateResumeDisposition>,
 }
@@ -152,10 +152,11 @@ impl PendingApprovalResume {
 /// authorization failure for the parked call and SKIPS re-dispatch; in that
 /// case `resume_token` and `replay` are unused.
 ///
-/// Field-name note: `PendingAuthResume::disposition` is intentionally kept
-/// short because the enclosing type already scopes it to gate-resume context.
-/// Turn-layer structs that carry a similar field from a wider scope use the
-/// qualified name `resume_disposition` to avoid ambiguity.
+/// Field-name note: each pending-resume type scopes `disposition` to ONE
+/// parked gate (auth or approval), so the short name is unambiguous within
+/// the struct.  Turn-layer records that are gate-agnostic use the fuller
+/// `resume_disposition` to distinguish the field from other disposition-like
+/// values in a wider context.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct PendingAuthResume {
     pub gate_ref: LoopGateRef,

--- a/crates/ironclaw_loop_support/src/cancellation_port.rs
+++ b/crates/ironclaw_loop_support/src/cancellation_port.rs
@@ -601,7 +601,7 @@ mod tests {
             failure: None,
             event_cursor: EventCursor(1),
             product_context: None,
-            auth_resume_disposition: None,
+            resume_disposition: None,
         }
     }
 

--- a/crates/ironclaw_loop_support/src/subagent_spawn_port/tests.rs
+++ b/crates/ironclaw_loop_support/src/subagent_spawn_port/tests.rs
@@ -1040,7 +1040,7 @@ fn turn_record(run_context: &LoopRunContext, subagent_depth: u32) -> TurnRunReco
         subagent_depth,
         spawn_tree_root_run_id: lineage_root,
         product_context: None,
-        auth_resume_disposition: None,
+        resume_disposition: None,
     }
 }
 

--- a/crates/ironclaw_product_workflow/src/approval_interaction/service.rs
+++ b/crates/ironclaw_product_workflow/src/approval_interaction/service.rs
@@ -8,8 +8,8 @@ use ironclaw_approvals::{
 use ironclaw_host_api::{Action, Principal};
 use ironclaw_run_state::ApprovalStatus;
 use ironclaw_turns::{
-    GateRef, GateResumeDisposition, GetRunStateRequest, ResumeTurnPrecondition, ResumeTurnRequest,
-    ResumeTurnResponse, TurnCoordinator, TurnError, TurnErrorCategory, TurnRunId, TurnStatus,
+    GateRef, GateResumeDisposition, ResumeTurnPrecondition, ResumeTurnRequest, TurnCoordinator,
+    TurnError, TurnErrorCategory, TurnRunId, TurnStatus,
 };
 
 use super::gate_ref::{approval_reply_binding_ref, approval_source_binding_ref};
@@ -359,56 +359,28 @@ impl DefaultApprovalInteractionService {
         request: ResolveApprovalInteractionRequest,
         run_id: TurnRunId,
     ) -> Result<ResolveApprovalInteractionResponse, ProductWorkflowError> {
-        // Idempotent replay: the first Deny already resumed the run with a
-        // denial disposition.  Fetch current state to reflect the outcome
-        // without issuing a new resume or cancel call.
-        let state = self
+        // Route through resume_turn with the SAME idempotency key as the first
+        // Deny.  TurnCoordinator::resume_turn returns the cached
+        // ResumeTurnResponse for a repeated key before running the precondition
+        // check, so this is idempotent regardless of current run state.  A
+        // fresh key on a finished run still errors via the precondition
+        // (correctly StaleGate).
+        let response = self
             .turn_coordinator
-            .get_run_state(GetRunStateRequest {
-                scope: request.scope.clone(),
+            .resume_turn(ResumeTurnRequest {
+                scope: request.scope,
+                actor: request.actor,
                 run_id,
+                gate_resolution_ref: request.gate_ref.clone(),
+                precondition: ResumeTurnPrecondition::BlockedApprovalGate,
+                source_binding_ref: approval_source_binding_ref(&request.gate_ref)?,
+                reply_target_binding_ref: approval_reply_binding_ref(&request.gate_ref)?,
+                idempotency_key: request.idempotency_key,
+                resume_disposition: Some(GateResumeDisposition::Denied),
             })
             .await
             .map_err(map_approval_resume_error)?;
-        if state.status == TurnStatus::Cancelled {
-            // The run was cancelled before or instead of being denial-resumed —
-            // return a Resumed response reflecting the disposition we carried,
-            // or fall through; the simplest safe answer is StaleGate because
-            // we have no CancelRunResponse to return for the Resumed variant.
-            // Mirror auth: a Cancelled run in the replay-denied arm means
-            // something cancelled it before our first Deny could resume it.
-            return Err(approval_rejected(
-                ApprovalInteractionRejectionKind::StaleGate,
-            ));
-        }
-        if state.status.is_terminal() {
-            // Run is in some other terminal state (Completed, Failed, etc.)
-            // A replay-denied cannot be applied to a finished run.
-            return Err(approval_rejected(
-                ApprovalInteractionRejectionKind::StaleGate,
-            ));
-        }
-        if matches!(
-            state.resume_disposition.as_ref(),
-            Some(GateResumeDisposition::Denied)
-        ) {
-            // Run is non-terminal and carries our denial marker — the first
-            // Deny successfully resumed it with a denial disposition.
-            // Replay that outcome idempotently.
-            return Ok(ResolveApprovalInteractionResponse::Resumed(
-                ResumeTurnResponse {
-                    run_id,
-                    status: state.status,
-                    event_cursor: state.event_cursor,
-                },
-            ));
-        }
-        // Run is non-terminal but no denial marker — the record was denied via
-        // the approval store, but the run was not yet denial-resumed by us.
-        // Treat as stale; the gate cannot be safely replayed here.
-        Err(approval_rejected(
-            ApprovalInteractionRejectionKind::StaleGate,
-        ))
+        Ok(ResolveApprovalInteractionResponse::Resumed(response))
     }
 }
 

--- a/crates/ironclaw_product_workflow/src/approval_interaction/service.rs
+++ b/crates/ironclaw_product_workflow/src/approval_interaction/service.rs
@@ -388,7 +388,10 @@ impl DefaultApprovalInteractionService {
                 ApprovalInteractionRejectionKind::StaleGate,
             ));
         }
-        if state.resume_disposition.is_some() {
+        if matches!(
+            state.resume_disposition.as_ref(),
+            Some(GateResumeDisposition::Denied)
+        ) {
             // Run is non-terminal and carries our denial marker — the first
             // Deny successfully resumed it with a denial disposition.
             // Replay that outcome idempotently.

--- a/crates/ironclaw_product_workflow/src/approval_interaction/service.rs
+++ b/crates/ironclaw_product_workflow/src/approval_interaction/service.rs
@@ -8,8 +8,8 @@ use ironclaw_approvals::{
 use ironclaw_host_api::{Action, Principal};
 use ironclaw_run_state::ApprovalStatus;
 use ironclaw_turns::{
-    CancelRunRequest, GateRef, ResumeTurnPrecondition, ResumeTurnRequest, SanitizedCancelReason,
-    TurnCoordinator, TurnError, TurnErrorCategory, TurnRunId, TurnStatus,
+    GateRef, GateResumeDisposition, GetRunStateRequest, ResumeTurnPrecondition, ResumeTurnRequest,
+    ResumeTurnResponse, TurnCoordinator, TurnError, TurnErrorCategory, TurnRunId, TurnStatus,
 };
 
 use super::gate_ref::{approval_reply_binding_ref, approval_source_binding_ref};
@@ -215,7 +215,7 @@ impl DefaultApprovalInteractionService {
                 source_binding_ref: approval_source_binding_ref(&request.gate_ref)?,
                 reply_target_binding_ref: approval_reply_binding_ref(&request.gate_ref)?,
                 idempotency_key: request.idempotency_key,
-                auth_resume_disposition: None,
+                resume_disposition: None,
             })
             .await
             .map_err(map_approval_resume_error)
@@ -315,16 +315,20 @@ impl DefaultApprovalInteractionService {
         }
         let response = self
             .turn_coordinator
-            .cancel_run(CancelRunRequest {
+            .resume_turn(ResumeTurnRequest {
                 scope: request.scope,
                 actor: request.actor,
                 run_id,
-                reason: SanitizedCancelReason::UserRequested,
+                gate_resolution_ref: request.gate_ref.clone(),
+                precondition: ResumeTurnPrecondition::BlockedApprovalGate,
+                source_binding_ref: approval_source_binding_ref(&request.gate_ref)?,
+                reply_target_binding_ref: approval_reply_binding_ref(&request.gate_ref)?,
                 idempotency_key: request.idempotency_key,
+                resume_disposition: Some(GateResumeDisposition::Denied),
             })
             .await
             .map_err(map_approval_resume_error)?;
-        Ok(ResolveApprovalInteractionResponse::Denied(response))
+        Ok(ResolveApprovalInteractionResponse::Resumed(response))
     }
 
     async fn replay_approved_gate(
@@ -343,7 +347,7 @@ impl DefaultApprovalInteractionService {
                 source_binding_ref: approval_source_binding_ref(&request.gate_ref)?,
                 reply_target_binding_ref: approval_reply_binding_ref(&request.gate_ref)?,
                 idempotency_key: request.idempotency_key,
-                auth_resume_disposition: None,
+                resume_disposition: None,
             })
             .await
             .map_err(map_approval_resume_error)?;
@@ -355,18 +359,53 @@ impl DefaultApprovalInteractionService {
         request: ResolveApprovalInteractionRequest,
         run_id: TurnRunId,
     ) -> Result<ResolveApprovalInteractionResponse, ProductWorkflowError> {
-        let response = self
+        // Idempotent replay: the first Deny already resumed the run with a
+        // denial disposition.  Fetch current state to reflect the outcome
+        // without issuing a new resume or cancel call.
+        let state = self
             .turn_coordinator
-            .cancel_run(CancelRunRequest {
-                scope: request.scope,
-                actor: request.actor,
+            .get_run_state(GetRunStateRequest {
+                scope: request.scope.clone(),
                 run_id,
-                reason: SanitizedCancelReason::UserRequested,
-                idempotency_key: request.idempotency_key,
             })
             .await
             .map_err(map_approval_resume_error)?;
-        Ok(ResolveApprovalInteractionResponse::Denied(response))
+        if state.status == TurnStatus::Cancelled {
+            // The run was cancelled before or instead of being denial-resumed —
+            // return a Resumed response reflecting the disposition we carried,
+            // or fall through; the simplest safe answer is StaleGate because
+            // we have no CancelRunResponse to return for the Resumed variant.
+            // Mirror auth: a Cancelled run in the replay-denied arm means
+            // something cancelled it before our first Deny could resume it.
+            return Err(approval_rejected(
+                ApprovalInteractionRejectionKind::StaleGate,
+            ));
+        }
+        if state.status.is_terminal() {
+            // Run is in some other terminal state (Completed, Failed, etc.)
+            // A replay-denied cannot be applied to a finished run.
+            return Err(approval_rejected(
+                ApprovalInteractionRejectionKind::StaleGate,
+            ));
+        }
+        if state.resume_disposition.is_some() {
+            // Run is non-terminal and carries our denial marker — the first
+            // Deny successfully resumed it with a denial disposition.
+            // Replay that outcome idempotently.
+            return Ok(ResolveApprovalInteractionResponse::Resumed(
+                ResumeTurnResponse {
+                    run_id,
+                    status: state.status,
+                    event_cursor: state.event_cursor,
+                },
+            ));
+        }
+        // Run is non-terminal but no denial marker — the record was denied via
+        // the approval store, but the run was not yet denial-resumed by us.
+        // Treat as stale; the gate cannot be safely replayed here.
+        Err(approval_rejected(
+            ApprovalInteractionRejectionKind::StaleGate,
+        ))
     }
 }
 

--- a/crates/ironclaw_product_workflow/src/approval_interaction/service.rs
+++ b/crates/ironclaw_product_workflow/src/approval_interaction/service.rs
@@ -313,6 +313,22 @@ impl DefaultApprovalInteractionService {
                 ));
             }
         }
+        // The denial side effect is local to the first-time path; the resume +
+        // response mapping is shared with `replay_denied_gate`.
+        self.resume_denied(request, run_id).await
+    }
+
+    /// Resume a run whose approval gate was denied, carrying
+    /// `GateResumeDisposition::Denied`. Shared by the first-time deny
+    /// (`deny_gate`, after the durable `resolver.deny`) and the idempotent
+    /// replay (`replay_denied_gate`). `TurnCoordinator::resume_turn` replays the
+    /// cached response for a repeated idempotency key, so both callers are safe
+    /// regardless of current run state.
+    async fn resume_denied(
+        &self,
+        request: ResolveApprovalInteractionRequest,
+        run_id: TurnRunId,
+    ) -> Result<ResolveApprovalInteractionResponse, ProductWorkflowError> {
         let response = self
             .turn_coordinator
             .resume_turn(ResumeTurnRequest {
@@ -359,28 +375,12 @@ impl DefaultApprovalInteractionService {
         request: ResolveApprovalInteractionRequest,
         run_id: TurnRunId,
     ) -> Result<ResolveApprovalInteractionResponse, ProductWorkflowError> {
-        // Route through resume_turn with the SAME idempotency key as the first
-        // Deny.  TurnCoordinator::resume_turn returns the cached
-        // ResumeTurnResponse for a repeated key before running the precondition
-        // check, so this is idempotent regardless of current run state.  A
-        // fresh key on a finished run still errors via the precondition
-        // (correctly StaleGate).
-        let response = self
-            .turn_coordinator
-            .resume_turn(ResumeTurnRequest {
-                scope: request.scope,
-                actor: request.actor,
-                run_id,
-                gate_resolution_ref: request.gate_ref.clone(),
-                precondition: ResumeTurnPrecondition::BlockedApprovalGate,
-                source_binding_ref: approval_source_binding_ref(&request.gate_ref)?,
-                reply_target_binding_ref: approval_reply_binding_ref(&request.gate_ref)?,
-                idempotency_key: request.idempotency_key,
-                resume_disposition: Some(GateResumeDisposition::Denied),
-            })
-            .await
-            .map_err(map_approval_resume_error)?;
-        Ok(ResolveApprovalInteractionResponse::Resumed(response))
+        // Idempotent replay: the SAME idempotency key as the first Deny.
+        // TurnCoordinator::resume_turn returns the cached ResumeTurnResponse for
+        // a repeated key before running the precondition check, so this is
+        // idempotent regardless of current run state. A fresh key on a finished
+        // run still errors via the precondition (correctly StaleGate).
+        self.resume_denied(request, run_id).await
     }
 }
 

--- a/crates/ironclaw_product_workflow/src/approval_interaction/types.rs
+++ b/crates/ironclaw_product_workflow/src/approval_interaction/types.rs
@@ -4,7 +4,7 @@ use ironclaw_host_api::{
 use ironclaw_product_adapters::ProductWorkflowRejectionKind;
 use ironclaw_run_state::ApprovalStatus;
 use ironclaw_turns::{
-    CancelRunResponse, GateRef, IdempotencyKey, ResumeTurnResponse, TurnActor, TurnRunId, TurnScope,
+    GateRef, IdempotencyKey, ResumeTurnResponse, TurnActor, TurnRunId, TurnScope,
 };
 use serde::{Deserialize, Serialize};
 
@@ -282,7 +282,7 @@ pub struct ResolveApprovalInteractionRequest {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ResolveApprovalInteractionResponse {
     Approved(ResumeTurnResponse),
-    Denied(CancelRunResponse),
+    Resumed(ResumeTurnResponse),
 }
 
 fn display_safe_summary() -> String {

--- a/crates/ironclaw_product_workflow/src/auth_continuation.rs
+++ b/crates/ironclaw_product_workflow/src/auth_continuation.rs
@@ -106,7 +106,7 @@ impl ProductAuthTurnGateResumeDispatcher {
                 reply_target_binding_ref,
                 idempotency_key,
                 precondition: ResumeTurnPrecondition::BlockedAuthGate,
-                auth_resume_disposition: None,
+                resume_disposition: None,
             })
             .await
             .map_err(map_auth_resume_error)?;
@@ -499,7 +499,7 @@ mod tests {
             failure: None,
             event_cursor: EventCursor::default(),
             product_context: None,
-            auth_resume_disposition: None,
+            resume_disposition: None,
         }
     }
 

--- a/crates/ironclaw_product_workflow/src/auth_interaction/service.rs
+++ b/crates/ironclaw_product_workflow/src/auth_interaction/service.rs
@@ -6,9 +6,9 @@ use ironclaw_auth::{
     CredentialAccountId, CredentialSelectionInput,
 };
 use ironclaw_turns::{
-    CancelRunRequest, CancelRunResponse, GateRef, GateResumeDisposition, GetRunStateRequest,
-    ResumeTurnPrecondition, ResumeTurnRequest, ResumeTurnResponse, SanitizedCancelReason,
-    TurnCoordinator, TurnError, TurnErrorCategory, TurnRunId, TurnStatus,
+    CancelRunRequest, GateRef, GateResumeDisposition, GetRunStateRequest, ResumeTurnPrecondition,
+    ResumeTurnRequest, SanitizedCancelReason, TurnCoordinator, TurnError, TurnErrorCategory,
+    TurnRunId, TurnStatus,
 };
 
 use super::types::is_pending_auth_status;
@@ -282,6 +282,43 @@ impl DefaultAuthInteractionService {
         Ok(ResolveAuthInteractionResponse::Resumed(response))
     }
 
+    async fn replay_denied_auth(
+        &self,
+        request: ResolveAuthInteractionRequest,
+        run_id: TurnRunId,
+    ) -> Result<ResolveAuthInteractionResponse, ProductWorkflowError> {
+        // Route through resume_turn with the SAME idempotency key as the first
+        // Deny.  TurnCoordinator::resume_turn returns the cached
+        // ResumeTurnResponse for a repeated key before running the precondition
+        // check, so this is idempotent regardless of current run state.  A
+        // fresh key on a finished run still errors via the precondition
+        // (correctly StaleAuth).
+        let state = self
+            .turn_coordinator
+            .get_run_state(GetRunStateRequest {
+                scope: request.scope.clone(),
+                run_id,
+            })
+            .await
+            .map_err(map_auth_resume_error)?;
+        let response = self
+            .turn_coordinator
+            .resume_turn(ResumeTurnRequest {
+                scope: request.scope,
+                actor: request.actor,
+                run_id,
+                gate_resolution_ref: request.gate_ref,
+                precondition: ResumeTurnPrecondition::BlockedAuthGate,
+                source_binding_ref: state.source_binding_ref,
+                reply_target_binding_ref: state.reply_target_binding_ref,
+                idempotency_key: request.idempotency_key,
+                resume_disposition: Some(GateResumeDisposition::Denied),
+            })
+            .await
+            .map_err(map_auth_resume_error)?;
+        Ok(ResolveAuthInteractionResponse::Resumed(response))
+    }
+
     async fn cancel_auth_run(
         &self,
         request: ResolveAuthInteractionRequest,
@@ -400,61 +437,9 @@ impl AuthInteractionService for DefaultAuthInteractionService {
             (BlockedGateState::NotParkedOnGate, AuthInteractionDecision::Deny) => {
                 let gate = self.refresh_gate(&gate).await?;
                 if gate.status() != AuthFlowStatus::Canceled {
-                    // Flow is not in a terminal-denied state but the run is no
-                    // longer parked — genuinely stale, nothing to replay.
                     return Err(auth_rejected(AuthInteractionRejectionKind::StaleAuth));
                 }
-                // The gate was already resolved by a prior Deny (or concurrently).
-                // Do NOT call cancel_run — the run may already be resumed and
-                // executing.  Instead fetch current run state and return an
-                // idempotent replay response that matches what the first Deny
-                // produced.
-                let state = self
-                    .turn_coordinator
-                    .get_run_state(GetRunStateRequest {
-                        scope: request.scope.clone(),
-                        run_id,
-                    })
-                    .await
-                    .map_err(map_auth_resume_error)?;
-                if state.status == TurnStatus::Cancelled {
-                    // The run was genuinely cancelled (e.g. by some other path
-                    // before our first Deny resumed it).  Reflect that terminal
-                    // state without issuing a new cancel_run call.
-                    Ok(ResolveAuthInteractionResponse::Canceled(
-                        CancelRunResponse {
-                            run_id,
-                            status: state.status,
-                            event_cursor: state.event_cursor,
-                            already_terminal: true,
-                            // actor: None is intentional — this is an idempotent replay
-                            // reflecting existing state; no new cancel lifecycle event fires.
-                            actor: None,
-                        },
-                    ))
-                } else if state.status.is_terminal() {
-                    // Run is in a different terminal state (Completed, Failed,
-                    // RecoveryRequired).  A Deny cannot be applied to a
-                    // finished run — this is a stale interaction.
-                    Err(auth_rejected(AuthInteractionRejectionKind::StaleAuth))
-                } else if state.resume_disposition.is_some() {
-                    // Run is non-terminal and carries our deny marker — the first
-                    // Deny successfully resumed it with a denial disposition.
-                    // Replay that outcome idempotently.
-                    Ok(ResolveAuthInteractionResponse::Resumed(
-                        ResumeTurnResponse {
-                            run_id,
-                            status: state.status,
-                            event_cursor: state.event_cursor,
-                        },
-                    ))
-                } else {
-                    // The flow was Canceled but this run was NOT deny-resumed by us
-                    // (no resume_disposition marker).  The flow reached Canceled
-                    // via some other path — treat as stale; the gate cannot be
-                    // resolved as a deny here.
-                    Err(auth_rejected(AuthInteractionRejectionKind::StaleAuth))
-                }
+                self.replay_denied_auth(request, run_id).await
             }
         }
     }

--- a/crates/ironclaw_product_workflow/src/auth_interaction/service.rs
+++ b/crates/ironclaw_product_workflow/src/auth_interaction/service.rs
@@ -6,7 +6,7 @@ use ironclaw_auth::{
     CredentialAccountId, CredentialSelectionInput,
 };
 use ironclaw_turns::{
-    AuthResumeDisposition, CancelRunRequest, CancelRunResponse, GateRef, GetRunStateRequest,
+    CancelRunRequest, CancelRunResponse, GateRef, GateResumeDisposition, GetRunStateRequest,
     ResumeTurnPrecondition, ResumeTurnRequest, ResumeTurnResponse, SanitizedCancelReason,
     TurnCoordinator, TurnError, TurnErrorCategory, TurnRunId, TurnStatus,
 };
@@ -177,7 +177,7 @@ impl DefaultAuthInteractionService {
                 source_binding_ref: state.source_binding_ref,
                 reply_target_binding_ref: state.reply_target_binding_ref,
                 idempotency_key: request.idempotency_key,
-                auth_resume_disposition: None,
+                resume_disposition: None,
             })
             .await
             .map_err(map_auth_resume_error)?;
@@ -275,7 +275,7 @@ impl DefaultAuthInteractionService {
                 source_binding_ref: state.source_binding_ref,
                 reply_target_binding_ref: state.reply_target_binding_ref,
                 idempotency_key: request.idempotency_key,
-                auth_resume_disposition: Some(AuthResumeDisposition::Denied),
+                resume_disposition: Some(GateResumeDisposition::Denied),
             })
             .await
             .map_err(map_auth_resume_error)?;
@@ -437,7 +437,7 @@ impl AuthInteractionService for DefaultAuthInteractionService {
                     // RecoveryRequired).  A Deny cannot be applied to a
                     // finished run — this is a stale interaction.
                     Err(auth_rejected(AuthInteractionRejectionKind::StaleAuth))
-                } else if state.auth_resume_disposition.is_some() {
+                } else if state.resume_disposition.is_some() {
                     // Run is non-terminal and carries our deny marker — the first
                     // Deny successfully resumed it with a denial disposition.
                     // Replay that outcome idempotently.
@@ -450,9 +450,9 @@ impl AuthInteractionService for DefaultAuthInteractionService {
                     ))
                 } else {
                     // The flow was Canceled but this run was NOT deny-resumed by us
-                    // (no auth_resume_disposition marker).  The flow reached
-                    // Canceled via some other path — treat as stale; the gate
-                    // cannot be resolved as a deny here.
+                    // (no resume_disposition marker).  The flow reached Canceled
+                    // via some other path — treat as stale; the gate cannot be
+                    // resolved as a deny here.
                     Err(auth_rejected(AuthInteractionRejectionKind::StaleAuth))
                 }
             }

--- a/crates/ironclaw_product_workflow/src/reborn_services.rs
+++ b/crates/ironclaw_product_workflow/src/reborn_services.rs
@@ -3320,11 +3320,9 @@ impl RebornServices {
             .await
             .map_err(|error| map_adapter_error(error.into()))?;
         match response {
-            ResolveApprovalInteractionResponse::Approved(response) => {
+            ResolveApprovalInteractionResponse::Approved(response)
+            | ResolveApprovalInteractionResponse::Resumed(response) => {
                 Ok(RebornResolveGateResponse::Resumed(response.into()))
-            }
-            ResolveApprovalInteractionResponse::Denied(response) => {
-                Ok(RebornResolveGateResponse::Cancelled(response.into()))
             }
         }
     }
@@ -3447,7 +3445,7 @@ impl RebornServices {
                             &binding_id,
                         )?,
                         idempotency_key: client_action_id,
-                        auth_resume_disposition: None,
+                        resume_disposition: None,
                     })
                     .await
                     .map_err(map_turn_error)?;

--- a/crates/ironclaw_product_workflow/src/reborn_services.rs
+++ b/crates/ironclaw_product_workflow/src/reborn_services.rs
@@ -3300,9 +3300,7 @@ impl RebornServices {
                     ApprovalInteractionDecision::ApproveOnce
                 }
             }
-            WebUiGateResolution::Denied | WebUiGateResolution::Cancelled => {
-                ApprovalInteractionDecision::Deny
-            }
+            WebUiGateResolution::Declined => ApprovalInteractionDecision::Deny,
             WebUiGateResolution::CredentialProvided { .. } => {
                 return Err(blocked_authentication_unavailable());
             }
@@ -3380,9 +3378,7 @@ impl RebornServices {
                         .map_err(map_auth_interaction_error)?,
                 }
             }
-            WebUiGateResolution::Denied | WebUiGateResolution::Cancelled => {
-                AuthInteractionDecision::Deny
-            }
+            WebUiGateResolution::Declined => AuthInteractionDecision::Deny,
             WebUiGateResolution::Approved { .. } => {
                 return Err(blocked_authentication_unavailable());
             }
@@ -3454,7 +3450,7 @@ impl RebornServices {
             WebUiGateResolution::CredentialProvided { .. } => {
                 Err(blocked_authentication_unavailable())
             }
-            WebUiGateResolution::Denied | WebUiGateResolution::Cancelled => {
+            WebUiGateResolution::Declined => {
                 assert_generic_run_parked_on_gate(
                     self.turn_coordinator.as_ref(),
                     &scope,

--- a/crates/ironclaw_product_workflow/src/webui_inbound.rs
+++ b/crates/ironclaw_product_workflow/src/webui_inbound.rs
@@ -321,12 +321,13 @@ pub enum WebUiGateResolution {
         #[serde(default)]
         always: bool,
     },
-    Denied,
+    /// Unified decline variant — covers both user-initiated approval denial
+    /// ("denied") and auth-gate cancellation ("cancelled"). Both legacy wire
+    /// strings deserialize to this variant; new serializations use "declined".
+    #[serde(alias = "denied", alias = "cancelled")]
+    Declined,
     /// A host-stored credential reference, not a raw secret/token.
-    CredentialProvided {
-        credential_ref: String,
-    },
-    Cancelled,
+    CredentialProvided { credential_ref: String },
 }
 
 /// Canonical route-independent WebUI command produced after validation.
@@ -546,7 +547,7 @@ fn parse_gate_resolution(
         "approved" => Ok(WebUiGateResolution::Approved {
             always: always.unwrap_or(false),
         }),
-        "denied" => Ok(WebUiGateResolution::Denied),
+        "denied" | "cancelled" => Ok(WebUiGateResolution::Declined),
         "credential_provided" => Ok(WebUiGateResolution::CredentialProvided {
             credential_ref: required_text(
                 "credential_ref",
@@ -555,7 +556,6 @@ fn parse_gate_resolution(
                 TextMode::Token,
             )?,
         }),
-        "cancelled" => Ok(WebUiGateResolution::Cancelled),
         _ => Err(WebUiInboundValidationError::new(
             "resolution",
             WebUiInboundValidationCode::InvalidValue,

--- a/crates/ironclaw_product_workflow/src/workflow.rs
+++ b/crates/ironclaw_product_workflow/src/workflow.rs
@@ -1182,8 +1182,8 @@ async fn dispatch_auth_resolution(
 
 fn run_id_from_approval_resolution(response: ResolveApprovalInteractionResponse) -> TurnRunId {
     match response {
-        ResolveApprovalInteractionResponse::Approved(response) => response.run_id,
-        ResolveApprovalInteractionResponse::Denied(response) => response.run_id,
+        ResolveApprovalInteractionResponse::Approved(response)
+        | ResolveApprovalInteractionResponse::Resumed(response) => response.run_id,
     }
 }
 

--- a/crates/ironclaw_product_workflow/tests/approval_interaction_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/approval_interaction_contract.rs
@@ -200,6 +200,8 @@ struct RecordingApprovalResolver {
     dispatch_lease_retries: Mutex<Vec<RecordedApproval>>,
     spawn_lease_retries: Mutex<Vec<RecordedApproval>>,
     denials: Mutex<Vec<(ResourceScope, ApprovalRequestId, Principal)>>,
+    /// Shared ordered event log for call-ordering tests; None by default.
+    event_log: Mutex<Option<Arc<Mutex<Vec<&'static str>>>>>,
 }
 
 #[derive(Clone)]
@@ -229,6 +231,10 @@ impl RecordingApprovalResolver {
 
     fn approvals(&self) -> Vec<RecordedApproval> {
         self.approvals.lock().expect("lock").clone()
+    }
+
+    fn set_event_log(&self, log: Arc<Mutex<Vec<&'static str>>>) {
+        *self.event_log.lock().expect("lock") = Some(log);
     }
 }
 
@@ -313,6 +319,9 @@ impl ApprovalResolutionPort for RecordingApprovalResolver {
             .lock()
             .expect("lock")
             .push((scope.clone(), request_id, denial.denied_by));
+        if let Some(log) = self.event_log.lock().expect("lock").as_ref() {
+            log.lock().expect("lock").push("deny");
+        }
         Ok(())
     }
 }
@@ -420,6 +429,8 @@ struct FakeTurnCoordinator {
     /// A second resume_turn call with the same key returns the cached response
     /// before any precondition or status check, mirroring real TurnCoordinator behaviour.
     resume_cache: Mutex<HashMap<(TurnRunId, IdempotencyKey), ResumeTurnResponse>>,
+    /// Shared ordered event log for call-ordering tests; None by default.
+    event_log: Mutex<Option<Arc<Mutex<Vec<&'static str>>>>>,
 }
 
 impl FakeTurnCoordinator {
@@ -432,7 +443,12 @@ impl FakeTurnCoordinator {
             cancellations: Mutex::new(Vec::new()),
             resume_error: Mutex::new(None),
             resume_cache: Mutex::new(HashMap::new()),
+            event_log: Mutex::new(None),
         }
+    }
+
+    fn set_event_log(&self, log: Arc<Mutex<Vec<&'static str>>>) {
+        *self.event_log.lock().expect("lock") = Some(log);
     }
 
     fn set_status(&self, status: TurnStatus) {
@@ -510,6 +526,9 @@ impl TurnCoordinator for FakeTurnCoordinator {
         let run_id = request.run_id;
         let cache_key = (run_id, request.idempotency_key.clone());
         self.resumptions.lock().expect("lock").push(request);
+        if let Some(log) = self.event_log.lock().expect("lock").as_ref() {
+            log.lock().expect("lock").push("resume");
+        }
         // Idempotency: return cached response for a repeated key before any
         // other check, matching real TurnCoordinator behaviour.
         if let Some(cached) = self
@@ -1987,7 +2006,14 @@ async fn deny_marks_pending_gate_denied_then_propagates_resume_error_without_can
     // The durable denial write must complete before resume is attempted.
     // When resume_turn fails (Unavailable → Transient), the error propagates
     // and cancel_run must NOT be called.
+    //
+    // An ordered event log is shared between both fakes to verify that the
+    // resolver's deny() is called strictly before the coordinator's resume_turn().
+    let call_order: Arc<Mutex<Vec<&'static str>>> = Arc::new(Mutex::new(Vec::new()));
+
     let (service, resolver, coordinator, run_id, gate_ref) = service_fixture("delete a file");
+    resolver.set_event_log(Arc::clone(&call_order));
+    coordinator.set_event_log(Arc::clone(&call_order));
     coordinator.set_resume_error(TurnError::Unavailable {
         reason: "coordinator unavailable".to_string(),
     });
@@ -2024,6 +2050,13 @@ async fn deny_marks_pending_gate_denied_then_propagates_resume_error_without_can
         coordinator.cancellation_count(),
         0,
         "cancel must not be called on deny path"
+    );
+    // Ordering: deny must be recorded strictly before resume_turn.
+    let recorded = call_order.lock().expect("lock").clone();
+    assert_eq!(
+        recorded,
+        vec!["deny", "resume"],
+        "deny must be called before resume_turn; got: {recorded:?}"
     );
 }
 

--- a/crates/ironclaw_product_workflow/tests/approval_interaction_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/approval_interaction_contract.rs
@@ -27,10 +27,10 @@ use ironclaw_product_workflow::{
 use ironclaw_run_state::{ApprovalRequestStore, ApprovalStatus, InMemoryApprovalRequestStore};
 use ironclaw_turns::{
     AcceptedMessageRef, CancelRunRequest, CancelRunResponse, EventCursor, GateRef,
-    GetRunStateRequest, IdempotencyKey, ReplyTargetBindingRef, ResumeTurnPrecondition,
-    ResumeTurnRequest, ResumeTurnResponse, RunProfileId, RunProfileVersion, SourceBindingRef,
-    SubmitTurnRequest, SubmitTurnResponse, TurnActor, TurnCoordinator, TurnError, TurnId,
-    TurnRunId, TurnRunState, TurnScope, TurnStatus,
+    GateResumeDisposition, GetRunStateRequest, IdempotencyKey, ReplyTargetBindingRef,
+    ResumeTurnPrecondition, ResumeTurnRequest, ResumeTurnResponse, RunProfileId, RunProfileVersion,
+    SourceBindingRef, SubmitTurnRequest, SubmitTurnResponse, TurnActor, TurnCoordinator, TurnError,
+    TurnId, TurnRunId, TurnRunState, TurnScope, TurnStatus,
 };
 
 #[derive(Default)]
@@ -414,6 +414,8 @@ struct FakeTurnCoordinator {
     gate_ref: Mutex<Option<GateRef>>,
     resumptions: Mutex<Vec<ResumeTurnRequest>>,
     cancellations: Mutex<Vec<CancelRunRequest>>,
+    resume_disposition: Mutex<Option<GateResumeDisposition>>,
+    get_run_state_error: Mutex<Option<TurnError>>,
 }
 
 impl FakeTurnCoordinator {
@@ -424,11 +426,21 @@ impl FakeTurnCoordinator {
             gate_ref: Mutex::new(Some(gate_ref)),
             resumptions: Mutex::new(Vec::new()),
             cancellations: Mutex::new(Vec::new()),
+            resume_disposition: Mutex::new(None),
+            get_run_state_error: Mutex::new(None),
         }
     }
 
     fn set_status(&self, status: TurnStatus) {
         *self.status.lock().expect("lock") = status;
+    }
+
+    fn set_resume_disposition(&self, disposition: Option<GateResumeDisposition>) {
+        *self.resume_disposition.lock().expect("lock") = disposition;
+    }
+
+    fn set_get_run_state_error(&self, error: TurnError) {
+        *self.get_run_state_error.lock().expect("lock") = Some(error);
     }
 
     fn resumption_count(&self) -> usize {
@@ -453,6 +465,14 @@ impl FakeTurnCoordinator {
             .expect("lock")
             .last()
             .map(|request| request.run_id)
+    }
+
+    fn last_resumption_disposition(&self) -> Option<GateResumeDisposition> {
+        self.resumptions
+            .lock()
+            .expect("lock")
+            .last()
+            .and_then(|request| request.resume_disposition.clone())
     }
 }
 
@@ -495,6 +515,9 @@ impl TurnCoordinator for FakeTurnCoordinator {
     }
 
     async fn get_run_state(&self, request: GetRunStateRequest) -> Result<TurnRunState, TurnError> {
+        if let Some(error) = self.get_run_state_error.lock().expect("lock").clone() {
+            return Err(error);
+        }
         Ok(TurnRunState {
             scope: request.scope,
             actor: Some(self.actor.clone()),
@@ -514,7 +537,7 @@ impl TurnCoordinator for FakeTurnCoordinator {
             failure: None,
             event_cursor: EventCursor(17),
             product_context: None,
-            auth_resume_disposition: None,
+            resume_disposition: self.resume_disposition.lock().expect("lock").clone(),
         })
     }
 }
@@ -1597,7 +1620,10 @@ async fn already_approved_product_replay_without_run_hint_recovers_historical_ru
 }
 
 #[tokio::test]
-async fn already_denied_gate_cancels_without_reissuing_denial() {
+async fn already_denied_gate_resumes_without_reissuing_denial() {
+    // Gate is already Denied but run is still parked (BlockedApproval).
+    // deny_gate no-ops the durable write and resumes the run with a denial
+    // disposition — it must NOT re-issue a denial or cancel the run.
     let (service, resolver, coordinator, run_id, gate_ref) = service_fixture_for_request_status(
         approval_request("delete a file"),
         ApprovalStatus::Denied,
@@ -1617,19 +1643,60 @@ async fn already_denied_gate_cancels_without_reissuing_denial() {
 
     assert!(matches!(
         response,
-        ResolveApprovalInteractionResponse::Denied(_)
+        ResolveApprovalInteractionResponse::Resumed(_)
     ));
     assert_eq!(resolver.denial_count(), 0);
-    assert_eq!(coordinator.cancellation_count(), 1);
+    assert_eq!(coordinator.cancellation_count(), 0);
+    assert_eq!(coordinator.resumption_count(), 1);
+    assert_eq!(
+        coordinator.last_resumption_disposition(),
+        Some(GateResumeDisposition::Denied)
+    );
 }
 
 #[tokio::test]
-async fn already_denied_replay_reaches_turn_coordinator_when_run_is_not_parked() {
+async fn already_denied_replay_returns_stale_when_run_is_cancelled_with_no_disposition() {
+    // NotParkedOnGate + Denied gate + Cancelled run + no resume_disposition →
+    // run was cancelled before our first Deny could resume it; replay returns StaleGate.
     let (service, resolver, coordinator, run_id, gate_ref) = service_fixture_for_request_status(
         approval_request("delete a file"),
         ApprovalStatus::Denied,
     );
     coordinator.set_status(TurnStatus::Cancelled);
+
+    let error = service
+        .resolve(ResolveApprovalInteractionRequest {
+            scope: scope(),
+            actor: actor("user-alpha"),
+            run_id_hint: Some(run_id),
+            gate_ref,
+            decision: ApprovalInteractionDecision::Deny,
+            idempotency_key: IdempotencyKey::new("replay-denied-cancelled").expect("idempotency"),
+        })
+        .await
+        .expect_err("cancelled run with no disposition must return StaleGate");
+
+    assert!(matches!(
+        error,
+        ironclaw_product_workflow::ProductWorkflowError::ApprovalInteractionRejected {
+            kind: ApprovalInteractionRejectionKind::StaleGate
+        }
+    ));
+    assert_eq!(resolver.denial_count(), 0);
+    assert_eq!(coordinator.cancellation_count(), 0);
+    assert_eq!(coordinator.resumption_count(), 0);
+}
+
+#[tokio::test]
+async fn already_denied_replay_resumes_idempotently_when_disposition_marker_present() {
+    // NotParkedOnGate + Denied gate + non-terminal run + resume_disposition set →
+    // the first Deny already resumed it; idempotent replay returns Resumed.
+    let (service, _resolver, coordinator, run_id, gate_ref) = service_fixture_for_request_status(
+        approval_request("delete a file"),
+        ApprovalStatus::Denied,
+    );
+    coordinator.set_status(TurnStatus::Queued);
+    coordinator.set_resume_disposition(Some(GateResumeDisposition::Denied));
 
     let response = service
         .resolve(ResolveApprovalInteractionRequest {
@@ -1638,21 +1705,54 @@ async fn already_denied_replay_reaches_turn_coordinator_when_run_is_not_parked()
             run_id_hint: Some(run_id),
             gate_ref,
             decision: ApprovalInteractionDecision::Deny,
-            idempotency_key: IdempotencyKey::new("replay-denied").expect("idempotency"),
+            idempotency_key: IdempotencyKey::new("replay-denied-idempotent").expect("idempotency"),
         })
         .await
-        .expect("replay denied");
+        .expect("idempotent replay must succeed");
 
     assert!(matches!(
         response,
-        ResolveApprovalInteractionResponse::Denied(_)
+        ResolveApprovalInteractionResponse::Resumed(_)
     ));
-    assert_eq!(resolver.denial_count(), 0);
-    assert_eq!(coordinator.cancellation_count(), 1);
+    // Idempotent: no new resume or cancel calls issued.
+    assert_eq!(coordinator.resumption_count(), 0);
+    assert_eq!(coordinator.cancellation_count(), 0);
 }
 
 #[tokio::test]
-async fn deny_marks_pending_gate_denied_then_cancels_run() {
+async fn already_denied_replay_returns_stale_when_run_is_other_terminal_state() {
+    // NotParkedOnGate + Denied gate + other terminal run (Completed) →
+    // replay returns StaleGate — a finished run cannot be denial-resumed.
+    let (service, _resolver, coordinator, run_id, gate_ref) = service_fixture_for_request_status(
+        approval_request("delete a file"),
+        ApprovalStatus::Denied,
+    );
+    coordinator.set_status(TurnStatus::Completed);
+
+    let error = service
+        .resolve(ResolveApprovalInteractionRequest {
+            scope: scope(),
+            actor: actor("user-alpha"),
+            run_id_hint: Some(run_id),
+            gate_ref,
+            decision: ApprovalInteractionDecision::Deny,
+            idempotency_key: IdempotencyKey::new("replay-denied-completed").expect("idempotency"),
+        })
+        .await
+        .expect_err("completed run must return StaleGate");
+
+    assert!(matches!(
+        error,
+        ironclaw_product_workflow::ProductWorkflowError::ApprovalInteractionRejected {
+            kind: ApprovalInteractionRejectionKind::StaleGate
+        }
+    ));
+    assert_eq!(coordinator.resumption_count(), 0);
+    assert_eq!(coordinator.cancellation_count(), 0);
+}
+
+#[tokio::test]
+async fn deny_marks_pending_gate_denied_then_resumes_run_with_disposition() {
     let (service, resolver, coordinator, run_id, gate_ref) = service_fixture("delete a file");
     let response = service
         .resolve(ResolveApprovalInteractionRequest {
@@ -1668,11 +1768,54 @@ async fn deny_marks_pending_gate_denied_then_cancels_run() {
 
     assert!(matches!(
         response,
-        ResolveApprovalInteractionResponse::Denied(_)
+        ResolveApprovalInteractionResponse::Resumed(_)
     ));
     assert_eq!(resolver.approval_count(), 0);
     assert_eq!(resolver.denial_count(), 1);
-    assert_eq!(coordinator.cancellation_count(), 1);
+    // Run is resumed with denial disposition, NOT cancelled.
+    assert_eq!(coordinator.cancellation_count(), 0);
+    assert_eq!(coordinator.resumption_count(), 1);
+    assert_eq!(
+        coordinator.last_resumption_disposition(),
+        Some(GateResumeDisposition::Denied)
+    );
+    assert_eq!(
+        coordinator.last_resumption_precondition(),
+        Some(ResumeTurnPrecondition::BlockedApprovalGate)
+    );
+}
+
+#[tokio::test]
+async fn replay_denied_gate_returns_stale_when_get_run_state_errors() {
+    // NotParkedOnGate + Denied gate + get_run_state fails → error propagates as StaleGate.
+    let (service, _resolver, coordinator, run_id, gate_ref) = service_fixture_for_request_status(
+        approval_request("delete a file"),
+        ApprovalStatus::Denied,
+    );
+    // Force the run state check to look non-parked (non-blocked status).
+    coordinator.set_status(TurnStatus::Queued);
+    coordinator.set_get_run_state_error(TurnError::Unavailable {
+        reason: "store down".to_string(),
+    });
+
+    let error = service
+        .resolve(ResolveApprovalInteractionRequest {
+            scope: scope(),
+            actor: actor("user-alpha"),
+            run_id_hint: Some(run_id),
+            gate_ref,
+            decision: ApprovalInteractionDecision::Deny,
+            idempotency_key: IdempotencyKey::new("replay-denied-state-error").expect("idempotency"),
+        })
+        .await
+        .expect_err("get_run_state failure must propagate");
+
+    assert!(matches!(
+        error,
+        ironclaw_product_workflow::ProductWorkflowError::Transient { .. }
+    ));
+    assert_eq!(coordinator.resumption_count(), 0);
+    assert_eq!(coordinator.cancellation_count(), 0);
 }
 
 #[tokio::test]

--- a/crates/ironclaw_product_workflow/tests/approval_interaction_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/approval_interaction_contract.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
@@ -414,9 +415,11 @@ struct FakeTurnCoordinator {
     gate_ref: Mutex<Option<GateRef>>,
     resumptions: Mutex<Vec<ResumeTurnRequest>>,
     cancellations: Mutex<Vec<CancelRunRequest>>,
-    resume_disposition: Mutex<Option<GateResumeDisposition>>,
-    get_run_state_error: Mutex<Option<TurnError>>,
     resume_error: Mutex<Option<TurnError>>,
+    /// Idempotency cache: maps (run_id, idempotency_key) → cached ResumeTurnResponse.
+    /// A second resume_turn call with the same key returns the cached response
+    /// before any precondition or status check, mirroring real TurnCoordinator behaviour.
+    resume_cache: Mutex<HashMap<(TurnRunId, IdempotencyKey), ResumeTurnResponse>>,
 }
 
 impl FakeTurnCoordinator {
@@ -427,9 +430,8 @@ impl FakeTurnCoordinator {
             gate_ref: Mutex::new(Some(gate_ref)),
             resumptions: Mutex::new(Vec::new()),
             cancellations: Mutex::new(Vec::new()),
-            resume_disposition: Mutex::new(None),
-            get_run_state_error: Mutex::new(None),
             resume_error: Mutex::new(None),
+            resume_cache: Mutex::new(HashMap::new()),
         }
     }
 
@@ -437,16 +439,22 @@ impl FakeTurnCoordinator {
         *self.status.lock().expect("lock") = status;
     }
 
-    fn set_resume_disposition(&self, disposition: Option<GateResumeDisposition>) {
-        *self.resume_disposition.lock().expect("lock") = disposition;
-    }
-
-    fn set_get_run_state_error(&self, error: TurnError) {
-        *self.get_run_state_error.lock().expect("lock") = Some(error);
-    }
-
     fn set_resume_error(&self, error: TurnError) {
         *self.resume_error.lock().expect("lock") = Some(error);
+    }
+
+    /// Pre-seed the idempotency cache so that a replay call with `key` returns
+    /// `response` without needing a real first-Deny call in the same test.
+    fn seed_resume_cache(
+        &self,
+        run_id: TurnRunId,
+        key: IdempotencyKey,
+        response: ResumeTurnResponse,
+    ) {
+        self.resume_cache
+            .lock()
+            .expect("lock")
+            .insert((run_id, key), response);
     }
 
     fn resumption_count(&self) -> usize {
@@ -500,15 +508,33 @@ impl TurnCoordinator for FakeTurnCoordinator {
         request: ResumeTurnRequest,
     ) -> Result<ResumeTurnResponse, TurnError> {
         let run_id = request.run_id;
+        let cache_key = (run_id, request.idempotency_key.clone());
         self.resumptions.lock().expect("lock").push(request);
+        // Idempotency: return cached response for a repeated key before any
+        // other check, matching real TurnCoordinator behaviour.
+        if let Some(cached) = self
+            .resume_cache
+            .lock()
+            .expect("lock")
+            .get(&cache_key)
+            .cloned()
+        {
+            return Ok(cached);
+        }
+        // Explicit error injection fires for fresh (uncached) keys.
         if let Some(error) = self.resume_error.lock().expect("lock").clone() {
             return Err(error);
         }
-        Ok(ResumeTurnResponse {
+        let response = ResumeTurnResponse {
             run_id,
             status: TurnStatus::Queued,
             event_cursor: EventCursor(11),
-        })
+        };
+        self.resume_cache
+            .lock()
+            .expect("lock")
+            .insert(cache_key, response.clone());
+        Ok(response)
     }
 
     async fn cancel_run(&self, request: CancelRunRequest) -> Result<CancelRunResponse, TurnError> {
@@ -524,9 +550,6 @@ impl TurnCoordinator for FakeTurnCoordinator {
     }
 
     async fn get_run_state(&self, request: GetRunStateRequest) -> Result<TurnRunState, TurnError> {
-        if let Some(error) = self.get_run_state_error.lock().expect("lock").clone() {
-            return Err(error);
-        }
         Ok(TurnRunState {
             scope: request.scope,
             actor: Some(self.actor.clone()),
@@ -546,7 +569,7 @@ impl TurnCoordinator for FakeTurnCoordinator {
             failure: None,
             event_cursor: EventCursor(17),
             product_context: None,
-            resume_disposition: self.resume_disposition.lock().expect("lock").clone(),
+            resume_disposition: None,
         })
     }
 }
@@ -1664,14 +1687,21 @@ async fn already_denied_gate_resumes_without_reissuing_denial() {
 }
 
 #[tokio::test]
-async fn already_denied_replay_returns_stale_when_run_is_cancelled_with_no_disposition() {
-    // NotParkedOnGate + Denied gate + Cancelled run + no resume_disposition →
-    // run was cancelled before our first Deny could resume it; replay returns StaleGate.
+async fn already_denied_replay_returns_stale_when_resume_turn_fails_precondition() {
+    // NotParkedOnGate + Denied gate + fresh idempotency key (no cache entry) →
+    // resume_turn fails the precondition check (run is no longer parked) →
+    // map_approval_resume_error maps InvalidRequest → StaleGate.
+    // This covers both the Cancelled case and any other non-parked terminal state.
     let (service, resolver, coordinator, run_id, gate_ref) = service_fixture_for_request_status(
         approval_request("delete a file"),
         ApprovalStatus::Denied,
     );
     coordinator.set_status(TurnStatus::Cancelled);
+    // Inject the error the real coordinator returns when BlockedApprovalGate
+    // precondition fails (run is no longer parked).
+    coordinator.set_resume_error(TurnError::InvalidRequest {
+        reason: "precondition BlockedApprovalGate failed: run is Cancelled".to_string(),
+    });
 
     let error = service
         .resolve(ResolveApprovalInteractionRequest {
@@ -1683,8 +1713,9 @@ async fn already_denied_replay_returns_stale_when_run_is_cancelled_with_no_dispo
             idempotency_key: IdempotencyKey::new("replay-denied-cancelled").expect("idempotency"),
         })
         .await
-        .expect_err("cancelled run with no disposition must return StaleGate");
+        .expect_err("fresh key on non-parked run must return StaleGate");
 
+    // map_approval_resume_error maps InvalidRequest → StaleGate.
     assert!(matches!(
         error,
         ironclaw_product_workflow::ProductWorkflowError::ApprovalInteractionRejected {
@@ -1693,19 +1724,31 @@ async fn already_denied_replay_returns_stale_when_run_is_cancelled_with_no_dispo
     ));
     assert_eq!(resolver.denial_count(), 0);
     assert_eq!(coordinator.cancellation_count(), 0);
-    assert_eq!(coordinator.resumption_count(), 0);
+    // resume_turn IS called once (records the call, then returns the injected error).
+    assert_eq!(coordinator.resumption_count(), 1);
 }
 
 #[tokio::test]
 async fn already_denied_replay_resumes_idempotently_when_disposition_marker_present() {
-    // NotParkedOnGate + Denied gate + non-terminal run + resume_disposition set →
-    // the first Deny already resumed it; idempotent replay returns Resumed.
+    // NotParkedOnGate + Denied gate + non-terminal run → idempotent replay via
+    // resume_turn idempotency cache.  The cache is pre-seeded to simulate the
+    // response the first Deny would have produced.
     let (service, _resolver, coordinator, run_id, gate_ref) = service_fixture_for_request_status(
         approval_request("delete a file"),
         ApprovalStatus::Denied,
     );
     coordinator.set_status(TurnStatus::Queued);
-    coordinator.set_resume_disposition(Some(GateResumeDisposition::Denied));
+    // Pre-seed the idempotency cache with the response the first Deny produced.
+    let cached_response = ResumeTurnResponse {
+        run_id,
+        status: TurnStatus::Queued,
+        event_cursor: EventCursor(11),
+    };
+    coordinator.seed_resume_cache(
+        run_id,
+        IdempotencyKey::new("replay-denied-idempotent").expect("idempotency"),
+        cached_response.clone(),
+    );
 
     let response = service
         .resolve(ResolveApprovalInteractionRequest {
@@ -1723,20 +1766,26 @@ async fn already_denied_replay_resumes_idempotently_when_disposition_marker_pres
         response,
         ResolveApprovalInteractionResponse::Resumed(_)
     ));
-    // Idempotent: no new resume or cancel calls issued.
-    assert_eq!(coordinator.resumption_count(), 0);
+    // The cache hit still counts as a resume_turn call — it just returns the
+    // cached result instead of executing the precondition.
+    assert_eq!(coordinator.resumption_count(), 1);
     assert_eq!(coordinator.cancellation_count(), 0);
 }
 
 #[tokio::test]
 async fn already_denied_replay_returns_stale_when_run_is_other_terminal_state() {
-    // NotParkedOnGate + Denied gate + other terminal run (Completed) →
-    // replay returns StaleGate — a finished run cannot be denial-resumed.
+    // NotParkedOnGate + Denied gate + other terminal run (Completed) + fresh key →
+    // replay returns StaleGate — a finished run rejects a fresh resume_turn call.
     let (service, _resolver, coordinator, run_id, gate_ref) = service_fixture_for_request_status(
         approval_request("delete a file"),
         ApprovalStatus::Denied,
     );
     coordinator.set_status(TurnStatus::Completed);
+    // Inject the error the real coordinator returns when the precondition fails
+    // (run is Completed, not BlockedApproval).
+    coordinator.set_resume_error(TurnError::InvalidRequest {
+        reason: "precondition BlockedApprovalGate failed: run is Completed".to_string(),
+    });
 
     let error = service
         .resolve(ResolveApprovalInteractionRequest {
@@ -1756,7 +1805,8 @@ async fn already_denied_replay_returns_stale_when_run_is_other_terminal_state() 
             kind: ApprovalInteractionRejectionKind::StaleGate
         }
     ));
-    assert_eq!(coordinator.resumption_count(), 0);
+    // resume_turn IS called once (records the call, then returns the injected error).
+    assert_eq!(coordinator.resumption_count(), 1);
     assert_eq!(coordinator.cancellation_count(), 0);
 }
 
@@ -1795,16 +1845,115 @@ async fn deny_marks_pending_gate_denied_then_resumes_run_with_disposition() {
 }
 
 #[tokio::test]
-async fn replay_denied_gate_returns_stale_when_get_run_state_errors() {
-    // NotParkedOnGate + Denied gate + get_run_state fails → error propagates as Transient.
+async fn idempotent_deny_replay_returns_same_resumed_response_as_first_deny() {
+    // First Deny (ParkedOnGate + Pending) produces Resumed(R).
+    // A second resolve() with the SAME idempotency key (NotParkedOnGate + Denied)
+    // must return the SAME Resumed(R) via resume_turn idempotency caching — even
+    // though the run is no longer parked.
+    //
+    // Two services are used: service1 drives the first Deny; service2 shares the
+    // same run_id and coordinator so the cache seeded in service1 is replayed by
+    // service2 (which sees the gate as already Denied, status Queued).
+    let request = approval_request("delete a file");
+    let request_id = request.id;
+    let (service, resolver, coordinator, run_id, gate_ref) = service_fixture_for_request(request);
+
+    // ── First call: fresh Deny on a parked, pending gate ──────────────────────
+    let first_response = service
+        .resolve(ResolveApprovalInteractionRequest {
+            scope: scope(),
+            actor: actor("user-alpha"),
+            run_id_hint: Some(run_id),
+            gate_ref: gate_ref.clone(),
+            decision: ApprovalInteractionDecision::Deny,
+            idempotency_key: IdempotencyKey::new("idem-deny-replay").expect("idempotency"),
+        })
+        .await
+        .expect("first deny");
+
+    let first_run_id = match &first_response {
+        ResolveApprovalInteractionResponse::Resumed(r) => r.run_id,
+        other => panic!("expected Resumed, got {other:?}"),
+    };
+    assert_eq!(resolver.denial_count(), 1);
+    assert_eq!(coordinator.resumption_count(), 1);
+    assert_eq!(coordinator.cancellation_count(), 0);
+
+    // Simulate the transition: run left BlockedApproval and the gate is now Denied.
+    coordinator.set_status(TurnStatus::Queued);
+
+    // ── Second call: replay Deny with SAME key, gate now Denied ───────────────
+    // Build service2 with the gate pre-set to Denied and the SAME run_id/coordinator
+    // so the cache entry seeded by service1's first Deny is visible.
+    // Gate must use the same request_id so approval_gate_ref(request_id) == gate_ref.
+    let denied_request = ApprovalRequest {
+        id: request_id,
+        correlation_id: CorrelationId::new(),
+        requested_by: Principal::User(actor("user-alpha").user_id.clone()),
+        action: Box::new(Action::Dispatch {
+            capability: CapabilityId::new("demo.echo").expect("capability"),
+            estimated_resources: ResourceEstimate::default(),
+        }),
+        invocation_fingerprint: None,
+        reason: "delete a file".to_string(),
+        reusable_scope: None,
+    };
+    let denied_gate = ApprovalGateRecord::with_status(
+        resource_scope(&actor("user-alpha")),
+        run_id,
+        gate_ref.clone(),
+        denied_request,
+        ApprovalStatus::Denied,
+    )
+    .expect("denied gate with correct run_id");
+    let resolver2 = Arc::new(RecordingApprovalResolver::default());
+    let service2 = DefaultApprovalInteractionService::new(
+        Arc::new(FakeReadModel::with_gate(denied_gate)),
+        Arc::new(FixedLeaseTermsProvider),
+        resolver2.clone(),
+        // Reuse the SAME coordinator — it carries the idempotency cache from service1.
+        coordinator.clone(),
+    );
+
+    let second_response = service2
+        .resolve(ResolveApprovalInteractionRequest {
+            scope: scope(),
+            actor: actor("user-alpha"),
+            run_id_hint: Some(run_id),
+            gate_ref,
+            decision: ApprovalInteractionDecision::Deny,
+            idempotency_key: IdempotencyKey::new("idem-deny-replay").expect("idempotency"),
+        })
+        .await
+        .expect("idempotent replay must succeed");
+
+    let second_run_id = match &second_response {
+        ResolveApprovalInteractionResponse::Resumed(r) => r.run_id,
+        other => panic!("expected Resumed, got {other:?}"),
+    };
+    // Must return the SAME run_id as the first response (same cached result).
+    assert_eq!(first_run_id, second_run_id);
+    // Replay went through resume_turn (one more call → total 2), not cancel_run.
+    assert_eq!(coordinator.resumption_count(), 2);
+    assert_eq!(coordinator.cancellation_count(), 0);
+    // No new denial written — gate was already Denied.
+    assert_eq!(resolver2.denial_count(), 0);
+}
+
+#[tokio::test]
+async fn replay_denied_gate_returns_transient_when_resume_turn_errors() {
+    // NotParkedOnGate + Denied gate + resume_turn fails → error propagates as Transient.
+    // replay_denied_gate routes through resume_turn (not get_run_state), so injecting
+    // a resume_error is the right way to test transient backend failures on replay.
     let (service, _resolver, coordinator, run_id, gate_ref) = service_fixture_for_request_status(
         approval_request("delete a file"),
         ApprovalStatus::Denied,
     );
-    // Force the run state check to look non-parked (non-blocked status).
     coordinator.set_status(TurnStatus::Queued);
-    coordinator.set_get_run_state_error(TurnError::Unavailable {
-        reason: "store down".to_string(),
+    // Inject a transient error for the fresh key — resume_error fires after the
+    // cache miss, before any precondition check.
+    coordinator.set_resume_error(TurnError::Unavailable {
+        reason: "coordinator unavailable".to_string(),
     });
 
     let error = service
@@ -1814,16 +1963,21 @@ async fn replay_denied_gate_returns_stale_when_get_run_state_errors() {
             run_id_hint: Some(run_id),
             gate_ref,
             decision: ApprovalInteractionDecision::Deny,
-            idempotency_key: IdempotencyKey::new("replay-denied-state-error").expect("idempotency"),
+            idempotency_key: IdempotencyKey::new("replay-denied-resume-error")
+                .expect("idempotency"),
         })
         .await
-        .expect_err("get_run_state failure must propagate");
+        .expect_err("resume_turn failure must propagate");
 
-    assert!(matches!(
-        error,
-        ironclaw_product_workflow::ProductWorkflowError::Transient { .. }
-    ));
-    assert_eq!(coordinator.resumption_count(), 0);
+    // map_approval_resume_error maps Unavailable → Transient.
+    assert!(
+        matches!(
+            error,
+            ironclaw_product_workflow::ProductWorkflowError::Transient { .. }
+        ),
+        "expected Transient, got: {error:?}"
+    );
+    assert_eq!(coordinator.resumption_count(), 1);
     assert_eq!(coordinator.cancellation_count(), 0);
 }
 

--- a/crates/ironclaw_product_workflow/tests/approval_interaction_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/approval_interaction_contract.rs
@@ -1890,8 +1890,8 @@ async fn idempotent_deny_replay_returns_same_resumed_response_as_first_deny() {
         .await
         .expect("first deny");
 
-    let first_run_id = match &first_response {
-        ResolveApprovalInteractionResponse::Resumed(r) => r.run_id,
+    let first_resumed = match &first_response {
+        ResolveApprovalInteractionResponse::Resumed(r) => r.clone(),
         other => panic!("expected Resumed, got {other:?}"),
     };
     assert_eq!(resolver.denial_count(), 1);
@@ -1946,12 +1946,12 @@ async fn idempotent_deny_replay_returns_same_resumed_response_as_first_deny() {
         .await
         .expect("idempotent replay must succeed");
 
-    let second_run_id = match &second_response {
-        ResolveApprovalInteractionResponse::Resumed(r) => r.run_id,
+    let second_resumed = match &second_response {
+        ResolveApprovalInteractionResponse::Resumed(r) => r.clone(),
         other => panic!("expected Resumed, got {other:?}"),
     };
-    // Must return the SAME run_id as the first response (same cached result).
-    assert_eq!(first_run_id, second_run_id);
+    // Must return the SAME full response as the first (same cached result).
+    assert_eq!(first_resumed, second_resumed);
     // Replay went through resume_turn (one more call → total 2), not cancel_run.
     assert_eq!(coordinator.resumption_count(), 2);
     assert_eq!(coordinator.cancellation_count(), 0);

--- a/crates/ironclaw_product_workflow/tests/approval_interaction_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/approval_interaction_contract.rs
@@ -416,6 +416,7 @@ struct FakeTurnCoordinator {
     cancellations: Mutex<Vec<CancelRunRequest>>,
     resume_disposition: Mutex<Option<GateResumeDisposition>>,
     get_run_state_error: Mutex<Option<TurnError>>,
+    resume_error: Mutex<Option<TurnError>>,
 }
 
 impl FakeTurnCoordinator {
@@ -428,6 +429,7 @@ impl FakeTurnCoordinator {
             cancellations: Mutex::new(Vec::new()),
             resume_disposition: Mutex::new(None),
             get_run_state_error: Mutex::new(None),
+            resume_error: Mutex::new(None),
         }
     }
 
@@ -441,6 +443,10 @@ impl FakeTurnCoordinator {
 
     fn set_get_run_state_error(&self, error: TurnError) {
         *self.get_run_state_error.lock().expect("lock") = Some(error);
+    }
+
+    fn set_resume_error(&self, error: TurnError) {
+        *self.resume_error.lock().expect("lock") = Some(error);
     }
 
     fn resumption_count(&self) -> usize {
@@ -495,6 +501,9 @@ impl TurnCoordinator for FakeTurnCoordinator {
     ) -> Result<ResumeTurnResponse, TurnError> {
         let run_id = request.run_id;
         self.resumptions.lock().expect("lock").push(request);
+        if let Some(error) = self.resume_error.lock().expect("lock").clone() {
+            return Err(error);
+        }
         Ok(ResumeTurnResponse {
             run_id,
             status: TurnStatus::Queued,
@@ -1787,7 +1796,7 @@ async fn deny_marks_pending_gate_denied_then_resumes_run_with_disposition() {
 
 #[tokio::test]
 async fn replay_denied_gate_returns_stale_when_get_run_state_errors() {
-    // NotParkedOnGate + Denied gate + get_run_state fails → error propagates as StaleGate.
+    // NotParkedOnGate + Denied gate + get_run_state fails → error propagates as Transient.
     let (service, _resolver, coordinator, run_id, gate_ref) = service_fixture_for_request_status(
         approval_request("delete a file"),
         ApprovalStatus::Denied,
@@ -1816,6 +1825,52 @@ async fn replay_denied_gate_returns_stale_when_get_run_state_errors() {
     ));
     assert_eq!(coordinator.resumption_count(), 0);
     assert_eq!(coordinator.cancellation_count(), 0);
+}
+
+#[tokio::test]
+async fn deny_marks_pending_gate_denied_then_propagates_resume_error_without_cancelling() {
+    // ParkedOnGate (BlockedApproval) + Pending gate → fresh deny path.
+    // The durable denial write must complete before resume is attempted.
+    // When resume_turn fails (Unavailable → Transient), the error propagates
+    // and cancel_run must NOT be called.
+    let (service, resolver, coordinator, run_id, gate_ref) = service_fixture("delete a file");
+    coordinator.set_resume_error(TurnError::Unavailable {
+        reason: "coordinator unavailable".to_string(),
+    });
+
+    let error = service
+        .resolve(ResolveApprovalInteractionRequest {
+            scope: scope(),
+            actor: actor("user-alpha"),
+            run_id_hint: Some(run_id),
+            gate_ref,
+            decision: ApprovalInteractionDecision::Deny,
+            idempotency_key: IdempotencyKey::new("deny-resume-error").expect("idempotency"),
+        })
+        .await
+        .expect_err("resume failure must propagate");
+
+    // map_approval_resume_error maps Unavailable → Transient.
+    assert!(
+        matches!(
+            error,
+            ironclaw_product_workflow::ProductWorkflowError::Transient { .. }
+        ),
+        "expected Transient, got {error:?}"
+    );
+    // Durable denial write happened before the resume attempt.
+    assert_eq!(
+        resolver.denial_count(),
+        1,
+        "denial must be written before resume"
+    );
+    // resume_turn was called (and failed), but cancel_run must never be called.
+    assert_eq!(coordinator.resumption_count(), 1);
+    assert_eq!(
+        coordinator.cancellation_count(),
+        0,
+        "cancel must not be called on deny path"
+    );
 }
 
 #[tokio::test]

--- a/crates/ironclaw_product_workflow/tests/auth_interaction_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/auth_interaction_contract.rs
@@ -898,8 +898,8 @@ async fn idempotent_auth_deny_replay_returns_same_resumed_response_as_first_deny
         .await
         .expect("first deny");
 
-    let first_run_id = match &first_response {
-        ResolveAuthInteractionResponse::Resumed(r) => r.run_id,
+    let first_resumed = match &first_response {
+        ResolveAuthInteractionResponse::Resumed(r) => r.clone(),
         other => panic!("expected Resumed, got {other:?}"),
     };
     assert_eq!(flow_manager.cancellations().len(), 1);
@@ -949,12 +949,12 @@ async fn idempotent_auth_deny_replay_returns_same_resumed_response_as_first_deny
         .await
         .expect("idempotent auth replay must succeed");
 
-    let second_run_id = match &second_response {
-        ResolveAuthInteractionResponse::Resumed(r) => r.run_id,
+    let second_resumed = match &second_response {
+        ResolveAuthInteractionResponse::Resumed(r) => r.clone(),
         other => panic!("expected Resumed, got {other:?}"),
     };
-    // Must return the SAME run_id as the first response.
-    assert_eq!(first_run_id, second_run_id);
+    // Must return the SAME full response as the first (same cached result).
+    assert_eq!(first_resumed, second_resumed);
     // Replay went through resume_turn (cache hit), not cancel_run.
     assert_eq!(coordinator2.resumes().len(), 1);
     assert_eq!(coordinator2.cancellations().len(), 0);

--- a/crates/ironclaw_product_workflow/tests/auth_interaction_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/auth_interaction_contract.rs
@@ -21,11 +21,11 @@ use ironclaw_product_workflow::{
     ProductWorkflowError, ResolveAuthInteractionRequest, ResolveAuthInteractionResponse,
 };
 use ironclaw_turns::{
-    AcceptedMessageRef, AuthResumeDisposition, CancelRunRequest, CancelRunResponse, EventCursor,
-    GateRef, GetRunStateRequest, IdempotencyKey, ReplyTargetBindingRef, ResumeTurnPrecondition,
-    ResumeTurnRequest, ResumeTurnResponse, RunProfileId, RunProfileVersion, SourceBindingRef,
-    SubmitTurnRequest, SubmitTurnResponse, TurnActor, TurnCoordinator, TurnError, TurnId,
-    TurnRunId, TurnRunState, TurnScope, TurnStatus,
+    AcceptedMessageRef, CancelRunRequest, CancelRunResponse, EventCursor, GateRef,
+    GateResumeDisposition, GetRunStateRequest, IdempotencyKey, ReplyTargetBindingRef,
+    ResumeTurnPrecondition, ResumeTurnRequest, ResumeTurnResponse, RunProfileId, RunProfileVersion,
+    SourceBindingRef, SubmitTurnRequest, SubmitTurnResponse, TurnActor, TurnCoordinator, TurnError,
+    TurnId, TurnRunId, TurnRunState, TurnScope, TurnStatus,
 };
 
 #[derive(Default)]
@@ -234,7 +234,7 @@ struct RecordingTurnCoordinator {
     gate_ref: Mutex<Option<GateRef>>,
     resumes: Mutex<Vec<ResumeTurnRequest>>,
     cancellations: Mutex<Vec<CancelRunRequest>>,
-    auth_resume_disposition: Mutex<Option<AuthResumeDisposition>>,
+    resume_disposition: Mutex<Option<GateResumeDisposition>>,
     get_run_state_error: Mutex<Option<TurnError>>,
 }
 
@@ -246,7 +246,7 @@ impl RecordingTurnCoordinator {
             gate_ref: Mutex::new(Some(gate_ref)),
             resumes: Mutex::new(Vec::new()),
             cancellations: Mutex::new(Vec::new()),
-            auth_resume_disposition: Mutex::new(None),
+            resume_disposition: Mutex::new(None),
             get_run_state_error: Mutex::new(None),
         }
     }
@@ -263,8 +263,8 @@ impl RecordingTurnCoordinator {
         *self.status.lock().expect("lock") = status;
     }
 
-    fn set_auth_resume_disposition(&self, disposition: Option<AuthResumeDisposition>) {
-        *self.auth_resume_disposition.lock().expect("lock") = disposition;
+    fn set_resume_disposition(&self, disposition: Option<GateResumeDisposition>) {
+        *self.resume_disposition.lock().expect("lock") = disposition;
     }
 
     fn set_get_run_state_error(&self, error: TurnError) {
@@ -333,7 +333,7 @@ impl TurnCoordinator for RecordingTurnCoordinator {
             failure: None,
             event_cursor: EventCursor(47),
             product_context: None,
-            auth_resume_disposition: self.auth_resume_disposition.lock().expect("lock").clone(),
+            resume_disposition: self.resume_disposition.lock().expect("lock").clone(),
         })
     }
 }
@@ -816,8 +816,8 @@ async fn denied_auth_on_parked_gate_cancels_flow_and_resumes_with_denial_disposi
         ResumeTurnPrecondition::BlockedAuthGate
     );
     assert!(matches!(
-        resumes[0].auth_resume_disposition,
-        Some(AuthResumeDisposition::Denied)
+        resumes[0].resume_disposition,
+        Some(GateResumeDisposition::Denied)
     ));
     assert!(coordinator.cancellations().is_empty());
 }
@@ -975,7 +975,7 @@ async fn duplicate_denied_auth_on_already_resumed_run_is_idempotent() {
     // The first Deny set this marker on the run when it resumed with a denial
     // disposition.  Without it the service cannot distinguish "we denied it"
     // from "some other path cancelled the flow".
-    coordinator.set_auth_resume_disposition(Some(AuthResumeDisposition::Denied));
+    coordinator.set_resume_disposition(Some(GateResumeDisposition::Denied));
 
     let response = service
         .resolve(ResolveAuthInteractionRequest {
@@ -1006,7 +1006,7 @@ async fn duplicate_denied_auth_on_already_resumed_run_is_idempotent() {
 #[tokio::test]
 async fn deny_on_canceled_flow_without_deny_marker_returns_stale_auth() {
     // Scenario: NotParkedOnGate + Deny, flow=Canceled, run is non-terminal,
-    // BUT auth_resume_disposition is None — the flow was canceled by some other
+    // BUT resume_disposition is None — the flow was canceled by some other
     // path (not by our deny).  The service must NOT fabricate a Resumed
     // response, and must NOT issue a cancel_run call.  It should return StaleAuth.
     let actor = TurnActor::new(UserId::new("alice").unwrap());
@@ -1023,12 +1023,12 @@ async fn deny_on_canceled_flow_without_deny_marker_returns_stale_auth() {
         setup_challenge(),
     );
     // The run is non-terminal (e.g. still Queued from some other resumption
-    // path), and the coordinator returns auth_resume_disposition=None — no
+    // path), and the coordinator returns resume_disposition=None — no
     // deny marker was stamped by us.
     let (service, _flow_manager, coordinator) =
         service_parts(flow.clone(), vec![flow], actor.clone(), gate_ref.clone());
     coordinator.set_status(TurnStatus::Queued);
-    // auth_resume_disposition deliberately left as None (the default): this
+    // resume_disposition deliberately left as None (the default): this
     // simulates a flow canceled by a path other than our Deny.
 
     let error = service

--- a/crates/ironclaw_product_workflow/tests/auth_interaction_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/auth_interaction_contract.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
@@ -234,8 +235,12 @@ struct RecordingTurnCoordinator {
     gate_ref: Mutex<Option<GateRef>>,
     resumes: Mutex<Vec<ResumeTurnRequest>>,
     cancellations: Mutex<Vec<CancelRunRequest>>,
-    resume_disposition: Mutex<Option<GateResumeDisposition>>,
     get_run_state_error: Mutex<Option<TurnError>>,
+    resume_error: Mutex<Option<TurnError>>,
+    /// Idempotency cache: maps (run_id, idempotency_key) → cached ResumeTurnResponse.
+    /// A second resume_turn call with the same key returns the cached response
+    /// before any precondition or status check, mirroring real TurnCoordinator behaviour.
+    resume_cache: Mutex<HashMap<(TurnRunId, IdempotencyKey), ResumeTurnResponse>>,
 }
 
 impl RecordingTurnCoordinator {
@@ -246,8 +251,9 @@ impl RecordingTurnCoordinator {
             gate_ref: Mutex::new(Some(gate_ref)),
             resumes: Mutex::new(Vec::new()),
             cancellations: Mutex::new(Vec::new()),
-            resume_disposition: Mutex::new(None),
             get_run_state_error: Mutex::new(None),
+            resume_error: Mutex::new(None),
+            resume_cache: Mutex::new(HashMap::new()),
         }
     }
 
@@ -263,12 +269,26 @@ impl RecordingTurnCoordinator {
         *self.status.lock().expect("lock") = status;
     }
 
-    fn set_resume_disposition(&self, disposition: Option<GateResumeDisposition>) {
-        *self.resume_disposition.lock().expect("lock") = disposition;
-    }
-
     fn set_get_run_state_error(&self, error: TurnError) {
         *self.get_run_state_error.lock().expect("lock") = Some(error);
+    }
+
+    fn set_resume_error(&self, error: TurnError) {
+        *self.resume_error.lock().expect("lock") = Some(error);
+    }
+
+    /// Pre-seed the idempotency cache so that a replay call with `key` returns
+    /// `response` without needing a real first-Deny call in the same test.
+    fn seed_resume_cache(
+        &self,
+        run_id: TurnRunId,
+        key: IdempotencyKey,
+        response: ResumeTurnResponse,
+    ) {
+        self.resume_cache
+            .lock()
+            .expect("lock")
+            .insert((run_id, key), response);
     }
 }
 
@@ -290,12 +310,33 @@ impl TurnCoordinator for RecordingTurnCoordinator {
         request: ResumeTurnRequest,
     ) -> Result<ResumeTurnResponse, TurnError> {
         let run_id = request.run_id;
+        let cache_key = (run_id, request.idempotency_key.clone());
         self.resumes.lock().expect("lock").push(request);
-        Ok(ResumeTurnResponse {
+        // Idempotency: return cached response for a repeated key before any
+        // other check, matching real TurnCoordinator behaviour.
+        if let Some(cached) = self
+            .resume_cache
+            .lock()
+            .expect("lock")
+            .get(&cache_key)
+            .cloned()
+        {
+            return Ok(cached);
+        }
+        // Explicit error injection fires for fresh (uncached) keys.
+        if let Some(error) = self.resume_error.lock().expect("lock").clone() {
+            return Err(error);
+        }
+        let response = ResumeTurnResponse {
             run_id,
             status: TurnStatus::Queued,
             event_cursor: EventCursor(41),
-        })
+        };
+        self.resume_cache
+            .lock()
+            .expect("lock")
+            .insert(cache_key, response.clone());
+        Ok(response)
     }
 
     async fn cancel_run(&self, request: CancelRunRequest) -> Result<CancelRunResponse, TurnError> {
@@ -333,7 +374,7 @@ impl TurnCoordinator for RecordingTurnCoordinator {
             failure: None,
             event_cursor: EventCursor(47),
             product_context: None,
-            resume_disposition: self.resume_disposition.lock().expect("lock").clone(),
+            resume_disposition: None,
         })
     }
 }
@@ -823,6 +864,103 @@ async fn denied_auth_on_parked_gate_cancels_flow_and_resumes_with_denial_disposi
 }
 
 #[tokio::test]
+async fn idempotent_auth_deny_replay_returns_same_resumed_response_as_first_deny() {
+    // First Deny (ParkedOnGate + AwaitingUser) produces Resumed(R).
+    // A second resolve() with the SAME idempotency key (NotParkedOnGate + Canceled)
+    // must return the SAME Resumed(R) via resume_turn idempotency caching — even
+    // though the run is no longer parked.
+    let actor = TurnActor::new(UserId::new("alice").unwrap());
+    let scope = turn_scope("alice", "thread-a");
+    let run_id = TurnRunId::new();
+    let gate_ref = make_gate_ref("gate:auth-idem-deny-replay");
+    let flow = auth_flow(
+        AuthFlowStatus::AwaitingUser,
+        &scope,
+        &actor,
+        run_id,
+        &gate_ref,
+        None,
+        setup_challenge(),
+    );
+    let (service, flow_manager, coordinator) =
+        service_parts(flow.clone(), vec![flow], actor.clone(), gate_ref.clone());
+
+    // ── First call: Deny on a parked gate ─────────────────────────────────────
+    let first_response = service
+        .resolve(ResolveAuthInteractionRequest {
+            scope: scope.clone(),
+            actor: actor.clone(),
+            run_id_hint: Some(run_id),
+            gate_ref: gate_ref.clone(),
+            decision: AuthInteractionDecision::Deny,
+            idempotency_key: IdempotencyKey::new("idem-auth-deny").unwrap(),
+        })
+        .await
+        .expect("first deny");
+
+    let first_run_id = match &first_response {
+        ResolveAuthInteractionResponse::Resumed(r) => r.run_id,
+        other => panic!("expected Resumed, got {other:?}"),
+    };
+    assert_eq!(flow_manager.cancellations().len(), 1);
+    assert_eq!(coordinator.resumes().len(), 1);
+
+    // Simulate transition: run moved out of BlockedAuth, flow is now Canceled.
+    coordinator.set_status(TurnStatus::Queued);
+
+    // ── Second call: replay with SAME idempotency key ─────────────────────────
+    // Use a separate fixture with the gate pre-set to Canceled flow status.
+    let canceled_flow = auth_flow(
+        AuthFlowStatus::Canceled,
+        &scope,
+        &actor,
+        run_id,
+        &gate_ref,
+        None,
+        setup_challenge(),
+    );
+    let (service2, _flow_manager2, coordinator2) = service_parts(
+        canceled_flow.clone(),
+        vec![canceled_flow],
+        actor.clone(),
+        gate_ref.clone(),
+    );
+    coordinator2.set_status(TurnStatus::Queued);
+    // Seed the cache with the first Deny's response.
+    coordinator2.seed_resume_cache(
+        run_id,
+        IdempotencyKey::new("idem-auth-deny").unwrap(),
+        ResumeTurnResponse {
+            run_id,
+            status: TurnStatus::Queued,
+            event_cursor: EventCursor(41),
+        },
+    );
+
+    let second_response = service2
+        .resolve(ResolveAuthInteractionRequest {
+            scope,
+            actor,
+            run_id_hint: Some(run_id),
+            gate_ref,
+            decision: AuthInteractionDecision::Deny,
+            idempotency_key: IdempotencyKey::new("idem-auth-deny").unwrap(),
+        })
+        .await
+        .expect("idempotent auth replay must succeed");
+
+    let second_run_id = match &second_response {
+        ResolveAuthInteractionResponse::Resumed(r) => r.run_id,
+        other => panic!("expected Resumed, got {other:?}"),
+    };
+    // Must return the SAME run_id as the first response.
+    assert_eq!(first_run_id, second_run_id);
+    // Replay went through resume_turn (cache hit), not cancel_run.
+    assert_eq!(coordinator2.resumes().len(), 1);
+    assert_eq!(coordinator2.cancellations().len(), 0);
+}
+
+#[tokio::test]
 async fn denied_auth_without_flow_record_cancels_parked_auth_run() {
     let actor = TurnActor::new(UserId::new("alice").unwrap());
     let scope = turn_scope("alice", "thread-a");
@@ -952,8 +1090,7 @@ async fn duplicate_denied_auth_on_already_resumed_run_is_idempotent() {
     // Scenario: first Deny already resolved the gate (flow=Canceled) and
     // resumed the run (now Queued/Running).  A duplicate Deny (double-click,
     // lost response, client retry) must NOT cancel the live resumed run.
-    // Expected: Resumed replay reflecting current run state, zero
-    // cancel_run calls.
+    // Expected: Resumed replay reflecting cached response, zero cancel_run calls.
     let actor = TurnActor::new(UserId::new("alice").unwrap());
     let scope = turn_scope("alice", "thread-a");
     let run_id = TurnRunId::new();
@@ -972,10 +1109,18 @@ async fn duplicate_denied_auth_on_already_resumed_run_is_idempotent() {
     let (service, _flow_manager, coordinator) =
         service_parts(flow.clone(), vec![flow], actor.clone(), gate_ref.clone());
     coordinator.set_status(TurnStatus::Queued);
-    // The first Deny set this marker on the run when it resumed with a denial
-    // disposition.  Without it the service cannot distinguish "we denied it"
-    // from "some other path cancelled the flow".
-    coordinator.set_resume_disposition(Some(GateResumeDisposition::Denied));
+    // Pre-seed the idempotency cache with the response the first Deny produced.
+    // This models resume_turn returning the cached result for a repeated key
+    // without re-running the precondition check.
+    coordinator.seed_resume_cache(
+        run_id,
+        IdempotencyKey::new("auth-action-replay-denied").unwrap(),
+        ResumeTurnResponse {
+            run_id,
+            status: TurnStatus::Queued,
+            event_cursor: EventCursor(41),
+        },
+    );
 
     let response = service
         .resolve(ResolveAuthInteractionRequest {
@@ -1000,15 +1145,20 @@ async fn duplicate_denied_auth_on_already_resumed_run_is_idempotent() {
         0,
         "duplicate Deny must not cancel the already-resumed run"
     );
-    assert_eq!(coordinator.resumes().len(), 0);
+    // The cache hit still counts as a resume_turn call — it returns the cached
+    // result instead of executing the precondition.
+    assert_eq!(
+        coordinator.resumes().len(),
+        1,
+        "replay_denied_auth calls resume_turn once (cache hit)"
+    );
 }
 
 #[tokio::test]
 async fn deny_on_canceled_flow_without_deny_marker_returns_stale_auth() {
     // Scenario: NotParkedOnGate + Deny, flow=Canceled, run is non-terminal,
-    // BUT resume_disposition is None — the flow was canceled by some other
-    // path (not by our deny).  The service must NOT fabricate a Resumed
-    // response, and must NOT issue a cancel_run call.  It should return StaleAuth.
+    // but NO idempotency cache entry — the flow was canceled by some other
+    // path (not by our deny).  resume_turn fails precondition → StaleAuth.
     let actor = TurnActor::new(UserId::new("alice").unwrap());
     let scope = turn_scope("alice", "thread-a");
     let run_id = TurnRunId::new();
@@ -1022,14 +1172,16 @@ async fn deny_on_canceled_flow_without_deny_marker_returns_stale_auth() {
         None,
         setup_challenge(),
     );
-    // The run is non-terminal (e.g. still Queued from some other resumption
-    // path), and the coordinator returns resume_disposition=None — no
-    // deny marker was stamped by us.
+    // The run is non-terminal (Queued) and there is no cached response for this
+    // idempotency key — the flow was canceled by a path other than our Deny.
     let (service, _flow_manager, coordinator) =
         service_parts(flow.clone(), vec![flow], actor.clone(), gate_ref.clone());
     coordinator.set_status(TurnStatus::Queued);
-    // resume_disposition deliberately left as None (the default): this
-    // simulates a flow canceled by a path other than our Deny.
+    // Inject the error the real coordinator returns when the precondition fails
+    // (run is no longer BlockedAuth — it was resumed by some other path).
+    coordinator.set_resume_error(TurnError::InvalidRequest {
+        reason: "precondition BlockedAuthGate failed: run is Queued".to_string(),
+    });
 
     let error = service
         .resolve(ResolveAuthInteractionRequest {
@@ -1050,7 +1202,7 @@ async fn deny_on_canceled_flow_without_deny_marker_returns_stale_auth() {
                 kind: AuthInteractionRejectionKind::StaleAuth
             }
         ),
-        "expected StaleAuth (no deny marker), got: {error:?}"
+        "expected StaleAuth (no idempotency cache entry), got: {error:?}"
     );
     // Must not issue a cancel_run — the run was not parked by us.
     assert_eq!(
@@ -1058,15 +1210,20 @@ async fn deny_on_canceled_flow_without_deny_marker_returns_stale_auth() {
         0,
         "must not call cancel_run when the flow was canceled by another path"
     );
-    assert_eq!(coordinator.resumes().len(), 0);
+    // resume_turn IS called once (records the call, then returns the injected error).
+    assert_eq!(
+        coordinator.resumes().len(),
+        1,
+        "replay_denied_auth calls resume_turn once before precondition rejects"
+    );
 }
 
 #[tokio::test]
-async fn duplicate_denied_auth_on_cancelled_run_returns_canceled_without_new_cancel_run() {
+async fn duplicate_denied_auth_on_cancelled_run_with_same_key_returns_resumed() {
     // Scenario: flow=Canceled (first Deny already resolved the gate) but the
-    // run ended up Cancelled by some other path (e.g. a concurrent cancel
-    // arrived before the first Deny could resume it).  The duplicate Deny
-    // must reflect the terminal state idempotently — no new cancel_run call.
+    // run ended up Cancelled before our Deny could resume it.  A duplicate
+    // Deny with the SAME idempotency key as the first must return the cached
+    // Resumed response — no new cancel_run call.
     let actor = TurnActor::new(UserId::new("alice").unwrap());
     let scope = turn_scope("alice", "thread-a");
     let run_id = TurnRunId::new();
@@ -1084,6 +1241,17 @@ async fn duplicate_denied_auth_on_cancelled_run_returns_canceled_without_new_can
         service_parts(flow.clone(), vec![flow], actor.clone(), gate_ref.clone());
     // Run is already in terminal Cancelled state.
     coordinator.set_status(TurnStatus::Cancelled);
+    // Seed the cache: the first Deny produced this Resumed response before the
+    // run was cancelled.
+    coordinator.seed_resume_cache(
+        run_id,
+        IdempotencyKey::new("auth-action-replay-denied-terminal").unwrap(),
+        ResumeTurnResponse {
+            run_id,
+            status: TurnStatus::Queued,
+            event_cursor: EventCursor(41),
+        },
+    );
 
     let response = service
         .resolve(ResolveAuthInteractionRequest {
@@ -1095,20 +1263,79 @@ async fn duplicate_denied_auth_on_cancelled_run_returns_canceled_without_new_can
             idempotency_key: IdempotencyKey::new("auth-action-replay-denied-terminal").unwrap(),
         })
         .await
-        .expect("duplicate denied auth on terminal run must be idempotent");
+        .expect("duplicate denied auth with same key must return cached Resumed");
 
-    // The run is already Cancelled — reflect that, but do NOT issue a new
-    // cancel_run call (that would double-fire side effects).
+    // The cached response from the first Deny is returned — Resumed, not Canceled.
     assert!(
-        matches!(response, ResolveAuthInteractionResponse::Canceled(_)),
-        "expected Canceled reflection for terminal run, got: {response:?}"
+        matches!(response, ResolveAuthInteractionResponse::Resumed(_)),
+        "expected Resumed (cache hit), got: {response:?}"
     );
     assert_eq!(
         coordinator.cancellations().len(),
         0,
-        "duplicate Deny on Cancelled run must not call cancel_run again"
+        "duplicate Deny must not call cancel_run"
     );
-    assert_eq!(coordinator.resumes().len(), 0);
+    assert_eq!(
+        coordinator.resumes().len(),
+        1,
+        "replay_denied_auth calls resume_turn once (cache hit)"
+    );
+}
+
+#[tokio::test]
+async fn deny_on_cancelled_run_with_fresh_key_returns_stale_auth() {
+    // Scenario: flow=Canceled + run=Cancelled, but using a fresh idempotency
+    // key (not the same as the first Deny).  No cache entry → resume_turn
+    // fails precondition → StaleAuth.
+    let actor = TurnActor::new(UserId::new("alice").unwrap());
+    let scope = turn_scope("alice", "thread-a");
+    let run_id = TurnRunId::new();
+    let gate_ref = make_gate_ref("gate:auth-replay-cancelled-fresh-key");
+    let flow = auth_flow(
+        AuthFlowStatus::Canceled,
+        &scope,
+        &actor,
+        run_id,
+        &gate_ref,
+        None,
+        setup_challenge(),
+    );
+    let (service, _flow_manager, coordinator) =
+        service_parts(flow.clone(), vec![flow], actor.clone(), gate_ref.clone());
+    coordinator.set_status(TurnStatus::Cancelled);
+    // Inject the error the real coordinator returns for a fresh key on a
+    // terminal run (precondition BlockedAuthGate fails).
+    coordinator.set_resume_error(TurnError::InvalidRequest {
+        reason: "precondition BlockedAuthGate failed: run is Cancelled".to_string(),
+    });
+
+    let error = service
+        .resolve(ResolveAuthInteractionRequest {
+            scope,
+            actor,
+            run_id_hint: Some(run_id),
+            gate_ref,
+            decision: AuthInteractionDecision::Deny,
+            idempotency_key: IdempotencyKey::new("auth-action-cancelled-fresh-key").unwrap(),
+        })
+        .await
+        .expect_err("fresh key on Cancelled run must return StaleAuth");
+
+    assert!(
+        matches!(
+            error,
+            ProductWorkflowError::AuthInteractionRejected {
+                kind: AuthInteractionRejectionKind::StaleAuth
+            }
+        ),
+        "expected StaleAuth (fresh key, no cache), got: {error:?}"
+    );
+    assert_eq!(coordinator.cancellations().len(), 0);
+    assert_eq!(
+        coordinator.resumes().len(),
+        1,
+        "replay_denied_auth calls resume_turn once (precondition fails)"
+    );
 }
 
 #[tokio::test]

--- a/crates/ironclaw_product_workflow/tests/product_workflow_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/product_workflow_contract.rs
@@ -254,12 +254,10 @@ impl ApprovalInteractionService for RecordingApprovalInteractionService {
                     })
                 }
                 ApprovalInteractionDecision::Deny => {
-                    ResolveApprovalInteractionResponse::Denied(CancelRunResponse {
+                    ResolveApprovalInteractionResponse::Resumed(ResumeTurnResponse {
                         run_id,
-                        status: TurnStatus::Cancelled,
+                        status: TurnStatus::Queued,
                         event_cursor: EventCursor(22),
-                        already_terminal: false,
-                        actor: None,
                     })
                 }
             },

--- a/crates/ironclaw_product_workflow/tests/reborn_services_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/reborn_services_contract.rs
@@ -458,7 +458,7 @@ impl TurnCoordinator for FakeTurnCoordinator {
             failure: None,
             event_cursor: EventCursor(17),
             product_context: None,
-            auth_resume_disposition: None,
+            resume_disposition: None,
         })
     }
 }
@@ -554,7 +554,7 @@ impl TurnCoordinator for BlockingSubmitCoordinator {
             failure: None,
             event_cursor: EventCursor(29),
             product_context: None,
-            auth_resume_disposition: None,
+            resume_disposition: None,
         })
     }
 }
@@ -600,12 +600,10 @@ impl ApprovalInteractionService for RecordingApprovalInteractionService {
                 })
             }
             ApprovalInteractionDecision::Deny => {
-                ResolveApprovalInteractionResponse::Denied(CancelRunResponse {
+                ResolveApprovalInteractionResponse::Resumed(ResumeTurnResponse {
                     run_id,
-                    status: TurnStatus::Cancelled,
+                    status: TurnStatus::Queued,
                     event_cursor: EventCursor(23),
-                    already_terminal: false,
-                    actor: None,
                 })
             }
         })
@@ -3809,7 +3807,7 @@ async fn approval_gate_denial_uses_approval_interaction_service_and_returns_canc
         .await
         .expect("approval gate denial succeeds");
 
-    assert!(matches!(response, RebornResolveGateResponse::Cancelled(_)));
+    assert!(matches!(response, RebornResolveGateResponse::Resumed(_)));
     assert_eq!(approval_interactions.resolution_count(), 1);
     assert_eq!(coordinator.cancellation_count(), 0);
     assert_eq!(

--- a/crates/ironclaw_product_workflow/tests/webui_inbound_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/webui_inbound_contract.rs
@@ -482,3 +482,40 @@ fn decode_attachments_empty_is_ok() {
             .is_empty()
     );
 }
+
+/// Wire-stability: both legacy strings ("denied" and "cancelled") must still
+/// deserialize to `WebUiGateResolution::Declined` after the unification.
+/// This guards against accidental serde rename breakage.
+#[test]
+fn legacy_denied_wire_string_deserializes_to_declined() {
+    let request: WebUiResolveGateRequest = serde_json::from_value(json!({
+        "client_action_id": "gate-1",
+        "thread_id": "thread-alpha",
+        "run_id": run_id(),
+        "gate_ref": "gate-alpha",
+        "resolution": "denied"
+    }))
+    .expect("denied request json");
+    let command = request.into_command(caller()).expect("valid command");
+    let WebUiInboundCommand::ResolveGate { resolution, .. } = command else {
+        panic!("expected resolve-gate command");
+    };
+    assert_eq!(resolution, WebUiGateResolution::Declined);
+}
+
+#[test]
+fn legacy_cancelled_wire_string_deserializes_to_declined() {
+    let request: WebUiResolveGateRequest = serde_json::from_value(json!({
+        "client_action_id": "gate-1",
+        "thread_id": "thread-alpha",
+        "run_id": run_id(),
+        "gate_ref": "gate-alpha",
+        "resolution": "cancelled"
+    }))
+    .expect("cancelled request json");
+    let command = request.into_command(caller()).expect("valid command");
+    let WebUiInboundCommand::ResolveGate { resolution, .. } = command else {
+        panic!("expected resolve-gate command");
+    };
+    assert_eq!(resolution, WebUiGateResolution::Declined);
+}

--- a/crates/ironclaw_reborn/src/loop_exit_applier/tests/support.rs
+++ b/crates/ironclaw_reborn/src/loop_exit_applier/tests/support.rs
@@ -89,7 +89,7 @@ pub(super) fn running_run_state(
         failure: None,
         event_cursor: EventCursor(0),
         product_context: None,
-        auth_resume_disposition: None,
+        resume_disposition: None,
     }
 }
 
@@ -319,7 +319,7 @@ pub(super) fn claimed_run() -> ClaimedTurnRun {
             failure: None,
             event_cursor: EventCursor(0),
             product_context: None,
-            auth_resume_disposition: None,
+            resume_disposition: None,
         },
         resolved_run_profile: profile,
         runner_id: TurnRunnerId::new(),
@@ -577,6 +577,6 @@ fn state_for_mapping(
         failure,
         event_cursor: EventCursor(0),
         product_context: None,
-        auth_resume_disposition: None,
+        resume_disposition: None,
     }
 }

--- a/crates/ironclaw_reborn/src/planned_driver.rs
+++ b/crates/ironclaw_reborn/src/planned_driver.rs
@@ -247,6 +247,10 @@ fn validate_descriptor_assignment(
 /// gate fires mid-re-dispatch). Matching on `last_gate` ensures the denial is
 /// attributed only to the slot that corresponds to the current blocking gate,
 /// leaving the other slot untouched.
+///
+/// If BOTH slots carry the same `gate_ref` as `last_gate` (should never happen
+/// in practice), the function stamps NEITHER and emits a `warn!` — failing
+/// closed rather than misattributing the denial.
 fn stamp_resume_disposition(
     state: &mut ironclaw_agent_loop::state::LoopExecutionState,
     disposition: ironclaw_turns::GateResumeDisposition,
@@ -254,18 +258,38 @@ fn stamp_resume_disposition(
     let Some(last_gate) = state.last_gate.clone() else {
         return;
     };
-    // Stamp only the pending slot whose gate_ref matches the blocking gate.
-    // Both slots can be populated at once (GateStage preserves a pending auth
-    // resume when a non-auth gate blocks mid-re-dispatch), so stamping both
-    // would misattribute the denial. Neither matched: stamp neither (defensive).
-    if let Some(pending) = state.pending_auth_resume.as_mut()
-        && pending.gate_ref == last_gate
-    {
-        pending.disposition = Some(disposition);
-    } else if let Some(pending) = state.pending_approval_resume.as_mut()
-        && pending.gate_ref == last_gate
-    {
-        pending.disposition = Some(disposition);
+    // Compute matches before taking mutable borrows.
+    let auth_matches = state
+        .pending_auth_resume
+        .as_ref()
+        .is_some_and(|p| p.gate_ref == last_gate);
+    let approval_matches = state
+        .pending_approval_resume
+        .as_ref()
+        .is_some_and(|p| p.gate_ref == last_gate);
+    // Explicit 4-way match — fail closed when both slots claim the same gate.
+    match (auth_matches, approval_matches) {
+        (true, false) => {
+            if let Some(pending) = state.pending_auth_resume.as_mut() {
+                pending.disposition = Some(disposition);
+            }
+        }
+        (false, true) => {
+            if let Some(pending) = state.pending_approval_resume.as_mut() {
+                pending.disposition = Some(disposition);
+            }
+        }
+        (false, false) => {
+            // Neither slot matches last_gate — stamp neither (defensive no-op).
+        }
+        (true, true) => {
+            // Should never happen: two pending slots share the same gate_ref.
+            // Refuse to stamp either rather than misattribute the denial.
+            tracing::warn!(
+                ?last_gate,
+                "ambiguous gate resume disposition; refusing to stamp"
+            );
+        }
     }
 }
 
@@ -1518,6 +1542,118 @@ mod tests {
         assert!(
             matches!(approval_disposition, GateResumeDisposition::Denied),
             "pending_approval_resume.disposition must be Denied, got {approval_disposition:?}"
+        );
+    }
+
+    // ---- ambiguous-gate fail-closed test -----------------------------------------
+
+    /// Helper: build a `LoopExecutionState` where BOTH `pending_auth_resume` AND
+    /// `pending_approval_resume` carry the SAME `gate_ref`, and `last_gate` is
+    /// set to that same ref.  This is the impossible-in-practice state that
+    /// `stamp_resume_disposition` must handle by stamping NEITHER slot.
+    fn state_with_both_slots_same_gate_ref(
+        context: &LoopRunContext,
+    ) -> ironclaw_agent_loop::state::LoopExecutionState {
+        use ironclaw_agent_loop::state::{PendingApprovalResume, PendingAuthResume};
+        use ironclaw_host_api::{ApprovalRequestId, CapabilityId, CorrelationId, ResourceEstimate};
+        use ironclaw_turns::LoopGateRef;
+        use ironclaw_turns::run_profile::{
+            CapabilityInputRef, CapabilityResumeToken, CapabilitySurfaceVersion,
+        };
+
+        let gate_ref = LoopGateRef::new("gate:ambiguous-shared").expect("valid gate ref");
+        let mut state = ironclaw_agent_loop::state::LoopExecutionState::initial_for_run(context);
+        state.last_gate = Some(gate_ref.clone());
+        state.pending_auth_resume = Some(PendingAuthResume {
+            gate_ref: gate_ref.clone(),
+            capability_id: CapabilityId::new("test.capability.auth").expect("valid capability id"),
+            surface_version: CapabilitySurfaceVersion::new("surface:v1")
+                .expect("valid surface version"),
+            input_ref: CapabilityInputRef::new("input:ambiguous-auth").expect("valid input ref"),
+            effective_capability_ids: Vec::new(),
+            provider_replay: None,
+            resume_token: None,
+            prior_approval: None,
+            replay: None,
+            disposition: None,
+        });
+        state.pending_approval_resume = Some(PendingApprovalResume {
+            gate_ref,
+            capability_id: CapabilityId::new("test.capability.approval")
+                .expect("valid capability id"),
+            approval_request_id: ApprovalRequestId::new(),
+            resume_token: CapabilityResumeToken::new("00000000-0000-0000-0000-000000000003")
+                .expect("valid resume token"),
+            correlation_id: CorrelationId::new(),
+            surface_version: CapabilitySurfaceVersion::new("surface:v1")
+                .expect("valid surface version"),
+            input_ref: CapabilityInputRef::new("input:ambiguous-approval")
+                .expect("valid input ref"),
+            effective_capability_ids: Vec::new(),
+            provider_replay: None,
+            input: serde_json::Value::Null,
+            estimate: ResourceEstimate::default(),
+            disposition: None,
+        });
+        state
+    }
+
+    /// Fail-closed safety test: when BOTH `pending_auth_resume` and
+    /// `pending_approval_resume` carry the same `gate_ref` as `last_gate`,
+    /// `stamp_resume_disposition` must stamp NEITHER slot rather than
+    /// misattribute the denial to whichever slot the old `else if` happened
+    /// to evaluate first.
+    #[test]
+    fn stamp_resume_disposition_fails_closed_when_both_slots_match_last_gate() {
+        use ironclaw_turns::GateResumeDisposition;
+
+        let registry = build_loop_family_registry().expect("registry");
+        let driver = PlannedDriver::default_from_registry(&registry).expect("driver");
+        let context = run_context_for_driver(&driver);
+
+        let mut state = state_with_both_slots_same_gate_ref(&context);
+
+        // Precondition: both slots start without a disposition.
+        assert!(
+            state
+                .pending_auth_resume
+                .as_ref()
+                .expect("pending_auth_resume must be set")
+                .disposition
+                .is_none(),
+            "pending_auth_resume must start with disposition: None"
+        );
+        assert!(
+            state
+                .pending_approval_resume
+                .as_ref()
+                .expect("pending_approval_resume must be set")
+                .disposition
+                .is_none(),
+            "pending_approval_resume must start with disposition: None"
+        );
+
+        // Call with the ambiguous state — should warn and stamp neither.
+        stamp_resume_disposition(&mut state, GateResumeDisposition::Denied);
+
+        // BOTH dispositions must remain None — fail closed.
+        assert!(
+            state
+                .pending_auth_resume
+                .as_ref()
+                .expect("pending_auth_resume must survive")
+                .disposition
+                .is_none(),
+            "pending_auth_resume.disposition must remain None when both slots are ambiguous"
+        );
+        assert!(
+            state
+                .pending_approval_resume
+                .as_ref()
+                .expect("pending_approval_resume must survive")
+                .disposition
+                .is_none(),
+            "pending_approval_resume.disposition must remain None when both slots are ambiguous"
         );
     }
 }

--- a/crates/ironclaw_reborn/src/planned_driver.rs
+++ b/crates/ironclaw_reborn/src/planned_driver.rs
@@ -156,15 +156,23 @@ impl AgentLoopDriver for PlannedDriver {
             }
         };
 
-        // A run resumed from a user-denied auth gate carries the denial
-        // disposition in the resume request. Stamp it onto the parked auth-resume
-        // so the executor surfaces a model-visible denial and continues instead
-        // of re-dispatching the capability (which would re-block on the still-
-        // missing credential — the infinite auth/deny loop this fixes).
-        if let Some(disposition) = request.auth_resume_disposition.clone()
-            && let Some(pending) = initial.pending_auth_resume.as_mut()
-        {
-            pending.disposition = Some(disposition);
+        // A run resumed from a user-denied gate carries the denial disposition
+        // in the resume request. Stamp it onto whichever parked resume is
+        // present so the executor surfaces a model-visible denial and continues
+        // instead of re-dispatching the capability (which would re-block on the
+        // still-missing credential/approval — the infinite deny loop this fixes).
+        //
+        // A run is blocked on exactly one gate at a time, so at most one of
+        // pending_auth_resume / pending_approval_resume will be set; stamping
+        // both is safe and avoids requiring a per-gate precondition field on
+        // AgentLoopDriverResumeRequest.
+        if let Some(disposition) = request.resume_disposition.clone() {
+            if let Some(pending) = initial.pending_auth_resume.as_mut() {
+                pending.disposition = Some(disposition.clone());
+            }
+            if let Some(pending) = initial.pending_approval_resume.as_mut() {
+                pending.disposition = Some(disposition);
+            }
         }
 
         self.executor
@@ -539,7 +547,7 @@ mod tests {
                     run_id: context.run_id,
                     checkpoint_id: TurnCheckpointId::new(),
                     resolved_run_profile: context.resolved_run_profile.clone(),
-                    auth_resume_disposition: None,
+                    resume_disposition: None,
                 },
                 &host,
             )
@@ -577,7 +585,7 @@ mod tests {
                     run_id: context.run_id,
                     checkpoint_id,
                     resolved_run_profile: context.resolved_run_profile.clone(),
-                    auth_resume_disposition: None,
+                    resume_disposition: None,
                 },
                 &host,
             )
@@ -612,7 +620,7 @@ mod tests {
                     run_id: context.run_id,
                     checkpoint_id: TurnCheckpointId::new(),
                     resolved_run_profile,
-                    auth_resume_disposition: None,
+                    resume_disposition: None,
                 },
                 &host,
             )
@@ -654,7 +662,7 @@ mod tests {
                     run_id: context.run_id,
                     checkpoint_id,
                     resolved_run_profile: context.resolved_run_profile.clone(),
-                    auth_resume_disposition: None,
+                    resume_disposition: None,
                 },
                 &host,
             )
@@ -706,7 +714,7 @@ mod tests {
                     run_id: context.run_id,
                     checkpoint_id,
                     resolved_run_profile: context.resolved_run_profile.clone(),
-                    auth_resume_disposition: None,
+                    resume_disposition: None,
                 },
                 &host,
             )
@@ -745,7 +753,7 @@ mod tests {
                     run_id: context.run_id,
                     checkpoint_id,
                     resolved_run_profile: context.resolved_run_profile.clone(),
-                    auth_resume_disposition: None,
+                    resume_disposition: None,
                 },
                 &host,
             )
@@ -1036,7 +1044,7 @@ mod tests {
         state
     }
 
-    /// Verifies that the `resume` method stamps `AuthResumeDisposition::Denied`
+    /// Verifies that the `resume` method stamps `GateResumeDisposition::Denied`
     /// onto `pending_auth_resume` when the run context carries a denial, then
     /// passes the modified state to the executor.
     ///
@@ -1050,7 +1058,7 @@ mod tests {
     /// not the injection snippet in isolation.
     #[tokio::test]
     async fn resume_with_auth_deny_disposition_stamps_denial_onto_pending_auth_resume() {
-        use ironclaw_turns::AuthResumeDisposition;
+        use ironclaw_turns::GateResumeDisposition;
 
         let registry = build_loop_family_registry().expect("registry");
         let driver = PlannedDriver::default_from_registry(&registry).expect("driver");
@@ -1058,7 +1066,7 @@ mod tests {
         // Build a run context (no disposition on context — disposition travels
         // via the resume request, not the host context).
         let context = run_context_for_driver(&driver);
-        let disposition = Some(AuthResumeDisposition::Denied);
+        let disposition = Some(GateResumeDisposition::Denied);
 
         // Stage a checkpoint payload whose execution state has a parked auth
         // resume (disposition: None — as it would be when written at block time).
@@ -1087,7 +1095,7 @@ mod tests {
                     run_id: context.run_id,
                     checkpoint_id,
                     resolved_run_profile: context.resolved_run_profile.clone(),
-                    auth_resume_disposition: disposition,
+                    resume_disposition: disposition,
                 },
                 &host,
             )
@@ -1100,7 +1108,7 @@ mod tests {
             result.expect("resume should produce a terminal loop exit")
         {
             panic!(
-                "resume with AuthResumeDisposition::Denied must not re-block on auth; \
+                "resume with GateResumeDisposition::Denied must not re-block on auth; \
                  the executor must surface a model-visible denial and continue"
             );
         }
@@ -1113,7 +1121,7 @@ mod tests {
     #[test]
     fn auth_deny_disposition_is_stamped_onto_pending_auth_resume_before_execution() {
         use ironclaw_agent_loop::state::LoopExecutionState;
-        use ironclaw_turns::AuthResumeDisposition;
+        use ironclaw_turns::GateResumeDisposition;
         use ironclaw_turns::run_profile::LoopCheckpointKind;
 
         let registry = build_loop_family_registry().expect("registry");
@@ -1121,8 +1129,8 @@ mod tests {
 
         // Disposition now travels via the resume request, not the host context.
         let context = run_context_for_driver(&driver);
-        let request_disposition: Option<AuthResumeDisposition> =
-            Some(AuthResumeDisposition::Denied);
+        let request_disposition: Option<GateResumeDisposition> =
+            Some(GateResumeDisposition::Denied);
 
         let staged_state = state_with_pending_auth_resume(&context);
         // Confirm the state starts with no disposition (precondition).
@@ -1157,7 +1165,7 @@ mod tests {
             .disposition
             .expect("disposition must be Some after injection");
         assert!(
-            matches!(disposition, AuthResumeDisposition::Denied),
+            matches!(disposition, GateResumeDisposition::Denied),
             "disposition must be Denied after injection, got {disposition:?}"
         );
     }
@@ -1167,7 +1175,7 @@ mod tests {
     #[test]
     fn auth_deny_disposition_injection_is_noop_when_disposition_is_none() {
         use ironclaw_agent_loop::state::LoopExecutionState;
-        use ironclaw_turns::AuthResumeDisposition;
+        use ironclaw_turns::GateResumeDisposition;
         use ironclaw_turns::run_profile::LoopCheckpointKind;
 
         let registry = build_loop_family_registry().expect("registry");
@@ -1175,7 +1183,7 @@ mod tests {
 
         let context = run_context_for_driver(&driver);
         // Disposition now travels via the resume request, not the host context.
-        let request_disposition: Option<AuthResumeDisposition> = None;
+        let request_disposition: Option<GateResumeDisposition> = None;
 
         let staged_state = state_with_pending_auth_resume(&context);
         let payload_bytes = serde_json::to_vec(&staged_state).expect("serialize checkpoint state");
@@ -1199,7 +1207,153 @@ mod tests {
                 .expect("pending_auth_resume must survive round-trip")
                 .disposition
                 .is_none(),
-            "disposition must remain None when request auth_resume_disposition is None"
+            "disposition must remain None when request resume_disposition is None"
+        );
+    }
+
+    // ---- approval-deny disposition injection tests -----------------------------
+
+    /// Helper: build a `LoopExecutionState` with a parked `pending_approval_resume`
+    /// so we can assert the injection path stamps the disposition onto it.
+    fn state_with_pending_approval_resume(
+        context: &LoopRunContext,
+    ) -> ironclaw_agent_loop::state::LoopExecutionState {
+        use ironclaw_agent_loop::state::PendingApprovalResume;
+        use ironclaw_host_api::{ApprovalRequestId, CapabilityId, CorrelationId, ResourceEstimate};
+        use ironclaw_turns::LoopGateRef;
+        use ironclaw_turns::run_profile::{
+            CapabilityInputRef, CapabilityResumeToken, CapabilitySurfaceVersion,
+        };
+
+        let mut state = ironclaw_agent_loop::state::LoopExecutionState::initial_for_run(context);
+        state.pending_approval_resume = Some(PendingApprovalResume {
+            gate_ref: LoopGateRef::new("gate:test-approval-deny").expect("valid gate ref"),
+            capability_id: CapabilityId::new("test.capability").expect("valid capability id"),
+            approval_request_id: ApprovalRequestId::new(),
+            resume_token: CapabilityResumeToken::new("00000000-0000-0000-0000-000000000001")
+                .expect("valid resume token"),
+            correlation_id: CorrelationId::new(),
+            surface_version: CapabilitySurfaceVersion::new("surface:v1")
+                .expect("valid surface version"),
+            input_ref: CapabilityInputRef::new("input:test-approval-deny")
+                .expect("valid input ref"),
+            effective_capability_ids: Vec::new(),
+            provider_replay: None,
+            input: serde_json::Value::Null,
+            estimate: ResourceEstimate::default(),
+            disposition: None,
+        });
+        state
+    }
+
+    /// Unit-level smoke test: confirm that the disposition injection in `resume`
+    /// stamps `Some(Denied)` onto `pending_approval_resume.disposition` (and NOT
+    /// onto `pending_auth_resume`, which is absent) before passing the state to
+    /// the executor.
+    #[test]
+    fn approval_deny_disposition_is_stamped_onto_pending_approval_resume_before_execution() {
+        use ironclaw_agent_loop::state::LoopExecutionState;
+        use ironclaw_turns::GateResumeDisposition;
+        use ironclaw_turns::run_profile::LoopCheckpointKind;
+
+        let registry = build_loop_family_registry().expect("registry");
+        let driver = PlannedDriver::default_from_registry(&registry).expect("driver");
+
+        let context = run_context_for_driver(&driver);
+        let request_disposition: Option<GateResumeDisposition> =
+            Some(GateResumeDisposition::Denied);
+
+        let staged_state = state_with_pending_approval_resume(&context);
+        // Confirm preconditions: approval resume has no disposition; auth resume absent.
+        assert!(
+            staged_state
+                .pending_approval_resume
+                .as_ref()
+                .expect("pending_approval_resume must be set")
+                .disposition
+                .is_none(),
+            "staged pending_approval_resume must start with disposition: None"
+        );
+        assert!(
+            staged_state.pending_auth_resume.is_none(),
+            "pending_auth_resume must be absent in this fixture"
+        );
+
+        // Apply the same injection logic as the production `resume` path.
+        let payload_bytes = serde_json::to_vec(&staged_state).expect("serialize checkpoint state");
+        let checkpoint_kind = resumable_checkpoint_kind_from_host(LoopCheckpointKind::BeforeModel)
+            .expect("BeforeModel is resumable");
+        let mut loaded_state =
+            LoopExecutionState::from_checkpoint_payload(&payload_bytes, checkpoint_kind)
+                .expect("decode checkpoint state");
+
+        if let Some(disposition) = request_disposition.clone() {
+            if let Some(pending) = loaded_state.pending_auth_resume.as_mut() {
+                pending.disposition = Some(disposition.clone());
+            }
+            if let Some(pending) = loaded_state.pending_approval_resume.as_mut() {
+                pending.disposition = Some(disposition);
+            }
+        }
+
+        // Assert the disposition was stamped onto the approval resume.
+        let disposition = loaded_state
+            .pending_approval_resume
+            .expect("pending_approval_resume must survive round-trip")
+            .disposition
+            .expect("disposition must be Some after injection");
+        assert!(
+            matches!(disposition, GateResumeDisposition::Denied),
+            "disposition must be Denied after injection, got {disposition:?}"
+        );
+        // Auth resume must remain absent — the stamping must not create it.
+        assert!(
+            loaded_state.pending_auth_resume.is_none(),
+            "pending_auth_resume must remain absent when only approval resume is present"
+        );
+    }
+
+    /// Confirm that the injection is a no-op for `pending_approval_resume` when
+    /// the resume request carries no disposition — do not regress the normal
+    /// (non-deny) approval resume path.
+    #[test]
+    fn approval_deny_disposition_injection_is_noop_when_disposition_is_none() {
+        use ironclaw_agent_loop::state::LoopExecutionState;
+        use ironclaw_turns::GateResumeDisposition;
+        use ironclaw_turns::run_profile::LoopCheckpointKind;
+
+        let registry = build_loop_family_registry().expect("registry");
+        let driver = PlannedDriver::default_from_registry(&registry).expect("driver");
+
+        let context = run_context_for_driver(&driver);
+        let request_disposition: Option<GateResumeDisposition> = None;
+
+        let staged_state = state_with_pending_approval_resume(&context);
+        let payload_bytes = serde_json::to_vec(&staged_state).expect("serialize checkpoint state");
+        let checkpoint_kind = resumable_checkpoint_kind_from_host(LoopCheckpointKind::BeforeModel)
+            .expect("BeforeModel is resumable");
+        let mut loaded_state =
+            LoopExecutionState::from_checkpoint_payload(&payload_bytes, checkpoint_kind)
+                .expect("decode checkpoint state");
+
+        // Apply injection (disposition is None — the outer `if let Some` guard fires false).
+        if let Some(disposition) = request_disposition.clone() {
+            if let Some(pending) = loaded_state.pending_auth_resume.as_mut() {
+                pending.disposition = Some(disposition.clone());
+            }
+            if let Some(pending) = loaded_state.pending_approval_resume.as_mut() {
+                pending.disposition = Some(disposition);
+            }
+        }
+
+        // Disposition must remain None — no-op.
+        assert!(
+            loaded_state
+                .pending_approval_resume
+                .expect("pending_approval_resume must survive round-trip")
+                .disposition
+                .is_none(),
+            "disposition must remain None when request resume_disposition is None"
         );
     }
 }

--- a/crates/ironclaw_reborn/src/planned_driver.rs
+++ b/crates/ironclaw_reborn/src/planned_driver.rs
@@ -157,22 +157,23 @@ impl AgentLoopDriver for PlannedDriver {
         };
 
         // A run resumed from a user-denied gate carries the denial disposition
-        // in the resume request. Stamp it onto whichever parked resume is
-        // present so the executor surfaces a model-visible denial and continues
-        // instead of re-dispatching the capability (which would re-block on the
-        // still-missing credential/approval — the infinite deny loop this fixes).
+        // in the resume request. Stamp it onto whichever pending resume slot's
+        // `gate_ref` matches `last_gate` — the gate the run is blocked on.
         //
-        // A run is blocked on exactly one gate at a time, so at most one of
-        // pending_auth_resume / pending_approval_resume will be set; stamping
-        // both is safe and avoids requiring a per-gate precondition field on
-        // AgentLoopDriverResumeRequest.
+        // Why match by gate_ref: GateStage (executor/gates.rs) intentionally
+        // PRESERVES `pending_auth_resume` when a non-auth (approval/resource)
+        // gate fires mid-re-dispatch, so a checkpoint can carry BOTH slots
+        // simultaneously. Stamping both blindly would corrupt the unrelated
+        // auth resume when the user denies only the approval gate (and vice
+        // versa). `state.last_gate` records the exact gate_ref set at the
+        // blocking `GateOutcome::Block` branch, so comparing against it
+        // identifies the one slot whose denial should be surfaced.
+        //
+        // If neither slot's gate_ref matches (e.g. state was written before
+        // last_gate was introduced), we stamp neither rather than risking a
+        // misattribution. The executor will re-dispatch normally in that case.
         if let Some(disposition) = request.resume_disposition.clone() {
-            if let Some(pending) = initial.pending_auth_resume.as_mut() {
-                pending.disposition = Some(disposition.clone());
-            }
-            if let Some(pending) = initial.pending_approval_resume.as_mut() {
-                pending.disposition = Some(disposition);
-            }
+            stamp_resume_disposition(&mut initial, disposition);
         }
 
         self.executor
@@ -236,6 +237,36 @@ fn validate_descriptor_assignment(
         });
     }
     Ok(())
+}
+
+/// Stamps `disposition` onto the single pending resume slot whose `gate_ref`
+/// matches `state.last_gate` (the gate the run is blocked on).
+///
+/// Both `pending_auth_resume` and `pending_approval_resume` can be populated
+/// simultaneously (GateStage preserves `pending_auth_resume` when a non-auth
+/// gate fires mid-re-dispatch). Matching on `last_gate` ensures the denial is
+/// attributed only to the slot that corresponds to the current blocking gate,
+/// leaving the other slot untouched.
+fn stamp_resume_disposition(
+    state: &mut ironclaw_agent_loop::state::LoopExecutionState,
+    disposition: ironclaw_turns::GateResumeDisposition,
+) {
+    let Some(last_gate) = state.last_gate.clone() else {
+        return;
+    };
+    // Stamp only the pending slot whose gate_ref matches the blocking gate.
+    // Both slots can be populated at once (GateStage preserves a pending auth
+    // resume when a non-auth gate blocks mid-re-dispatch), so stamping both
+    // would misattribute the denial. Neither matched: stamp neither (defensive).
+    if let Some(pending) = state.pending_auth_resume.as_mut()
+        && pending.gate_ref == last_gate
+    {
+        pending.disposition = Some(disposition);
+    } else if let Some(pending) = state.pending_approval_resume.as_mut()
+        && pending.gate_ref == last_gate
+    {
+        pending.disposition = Some(disposition);
+    }
 }
 
 pub(crate) fn map_executor_error(error: AgentLoopExecutorError) -> AgentLoopDriverError {
@@ -1019,6 +1050,9 @@ mod tests {
 
     /// Helper: build a `LoopExecutionState` with a parked `pending_auth_resume`
     /// so we can assert the injection path stamps the disposition onto it.
+    ///
+    /// `last_gate` is set to the same gate_ref as `pending_auth_resume` so the
+    /// narrowed stamping logic (which matches on `last_gate`) targets this slot.
     fn state_with_pending_auth_resume(
         context: &LoopRunContext,
     ) -> ironclaw_agent_loop::state::LoopExecutionState {
@@ -1027,9 +1061,11 @@ mod tests {
         use ironclaw_turns::LoopGateRef;
         use ironclaw_turns::run_profile::{CapabilityInputRef, CapabilitySurfaceVersion};
 
+        let gate_ref = LoopGateRef::new("gate:test-auth-deny").expect("valid gate ref");
         let mut state = ironclaw_agent_loop::state::LoopExecutionState::initial_for_run(context);
+        state.last_gate = Some(gate_ref.clone());
         state.pending_auth_resume = Some(PendingAuthResume {
-            gate_ref: LoopGateRef::new("gate:test-auth-deny").expect("valid gate ref"),
+            gate_ref,
             capability_id: CapabilityId::new("test.capability").expect("valid capability id"),
             surface_version: CapabilitySurfaceVersion::new("surface:v1")
                 .expect("valid surface version"),
@@ -1114,28 +1150,21 @@ mod tests {
         }
     }
 
-    /// Unit-level smoke test: confirm that the disposition injection in `resume`
-    /// stamps `Some(Denied)` onto `pending_auth_resume.disposition` before
-    /// passing the state to the executor, by inspecting the deserialized state
-    /// after applying the same conditional logic the production path uses.
+    /// Unit-level smoke test: confirm that `stamp_resume_disposition` stamps
+    /// `Some(Denied)` onto `pending_auth_resume.disposition` when `last_gate`
+    /// matches the auth slot's gate_ref — exercises the real helper, not a copy.
     #[test]
     fn auth_deny_disposition_is_stamped_onto_pending_auth_resume_before_execution() {
-        use ironclaw_agent_loop::state::LoopExecutionState;
         use ironclaw_turns::GateResumeDisposition;
-        use ironclaw_turns::run_profile::LoopCheckpointKind;
 
         let registry = build_loop_family_registry().expect("registry");
         let driver = PlannedDriver::default_from_registry(&registry).expect("driver");
-
-        // Disposition now travels via the resume request, not the host context.
         let context = run_context_for_driver(&driver);
-        let request_disposition: Option<GateResumeDisposition> =
-            Some(GateResumeDisposition::Denied);
 
-        let staged_state = state_with_pending_auth_resume(&context);
+        let mut state = state_with_pending_auth_resume(&context);
         // Confirm the state starts with no disposition (precondition).
         assert!(
-            staged_state
+            state
                 .pending_auth_resume
                 .as_ref()
                 .expect("pending_auth_resume must be set")
@@ -1144,70 +1173,46 @@ mod tests {
             "staged pending_auth_resume must start with disposition: None"
         );
 
-        // Apply the same injection logic as the production `resume` path.
-        let payload_bytes = serde_json::to_vec(&staged_state).expect("serialize checkpoint state");
-        let checkpoint_kind = resumable_checkpoint_kind_from_host(LoopCheckpointKind::BeforeModel)
-            .expect("BeforeModel is resumable");
-        let mut loaded_state =
-            LoopExecutionState::from_checkpoint_payload(&payload_bytes, checkpoint_kind)
-                .expect("decode checkpoint state");
+        // Call the real helper — not an inline copy of the logic.
+        stamp_resume_disposition(&mut state, GateResumeDisposition::Denied);
 
-        if let Some(disposition) = request_disposition.clone()
-            && let Some(pending) = loaded_state.pending_auth_resume.as_mut()
-        {
-            pending.disposition = Some(disposition);
-        }
-
-        // Assert the disposition was stamped.
-        let disposition = loaded_state
+        // Assert the disposition was stamped onto the auth slot.
+        let disposition = state
             .pending_auth_resume
             .expect("pending_auth_resume must survive round-trip")
             .disposition
-            .expect("disposition must be Some after injection");
+            .expect("disposition must be Some after stamp_resume_disposition");
         assert!(
             matches!(disposition, GateResumeDisposition::Denied),
-            "disposition must be Denied after injection, got {disposition:?}"
+            "disposition must be Denied after stamp_resume_disposition, got {disposition:?}"
         );
     }
 
-    /// Confirm the injection is a no-op when the resume request carries no
-    /// disposition — do not regress the normal (non-deny) resume path.
+    /// Confirm the injection is a no-op when `last_gate` is `None` — do not
+    /// regress the normal (non-deny) resume path where no gate was recorded.
     #[test]
-    fn auth_deny_disposition_injection_is_noop_when_disposition_is_none() {
-        use ironclaw_agent_loop::state::LoopExecutionState;
+    fn auth_deny_disposition_injection_is_noop_when_last_gate_is_none() {
         use ironclaw_turns::GateResumeDisposition;
-        use ironclaw_turns::run_profile::LoopCheckpointKind;
 
         let registry = build_loop_family_registry().expect("registry");
         let driver = PlannedDriver::default_from_registry(&registry).expect("driver");
-
         let context = run_context_for_driver(&driver);
-        // Disposition now travels via the resume request, not the host context.
-        let request_disposition: Option<GateResumeDisposition> = None;
 
-        let staged_state = state_with_pending_auth_resume(&context);
-        let payload_bytes = serde_json::to_vec(&staged_state).expect("serialize checkpoint state");
-        let checkpoint_kind = resumable_checkpoint_kind_from_host(LoopCheckpointKind::BeforeModel)
-            .expect("BeforeModel is resumable");
-        let mut loaded_state =
-            LoopExecutionState::from_checkpoint_payload(&payload_bytes, checkpoint_kind)
-                .expect("decode checkpoint state");
+        let mut state = state_with_pending_auth_resume(&context);
+        // Clear last_gate to simulate a checkpoint without a recorded gate.
+        state.last_gate = None;
 
-        // Apply injection (disposition is None — the `if let Some` guard fires false).
-        if let Some(disposition) = request_disposition.clone()
-            && let Some(pending) = loaded_state.pending_auth_resume.as_mut()
-        {
-            pending.disposition = Some(disposition);
-        }
+        // stamp_resume_disposition should be a no-op when last_gate is None.
+        stamp_resume_disposition(&mut state, GateResumeDisposition::Denied);
 
         // Disposition must remain None — no-op.
         assert!(
-            loaded_state
+            state
                 .pending_auth_resume
-                .expect("pending_auth_resume must survive round-trip")
+                .expect("pending_auth_resume must survive")
                 .disposition
                 .is_none(),
-            "disposition must remain None when request resume_disposition is None"
+            "disposition must remain None when last_gate is None"
         );
     }
 
@@ -1215,6 +1220,9 @@ mod tests {
 
     /// Helper: build a `LoopExecutionState` with a parked `pending_approval_resume`
     /// so we can assert the injection path stamps the disposition onto it.
+    ///
+    /// `last_gate` is set to the same gate_ref as `pending_approval_resume` so
+    /// the narrowed stamping logic (which matches on `last_gate`) targets this slot.
     fn state_with_pending_approval_resume(
         context: &LoopRunContext,
     ) -> ironclaw_agent_loop::state::LoopExecutionState {
@@ -1225,9 +1233,11 @@ mod tests {
             CapabilityInputRef, CapabilityResumeToken, CapabilitySurfaceVersion,
         };
 
+        let gate_ref = LoopGateRef::new("gate:test-approval-deny").expect("valid gate ref");
         let mut state = ironclaw_agent_loop::state::LoopExecutionState::initial_for_run(context);
+        state.last_gate = Some(gate_ref.clone());
         state.pending_approval_resume = Some(PendingApprovalResume {
-            gate_ref: LoopGateRef::new("gate:test-approval-deny").expect("valid gate ref"),
+            gate_ref,
             capability_id: CapabilityId::new("test.capability").expect("valid capability id"),
             approval_request_id: ApprovalRequestId::new(),
             resume_token: CapabilityResumeToken::new("00000000-0000-0000-0000-000000000001")
@@ -1246,27 +1256,22 @@ mod tests {
         state
     }
 
-    /// Unit-level smoke test: confirm that the disposition injection in `resume`
-    /// stamps `Some(Denied)` onto `pending_approval_resume.disposition` (and NOT
-    /// onto `pending_auth_resume`, which is absent) before passing the state to
-    /// the executor.
+    /// Unit-level smoke test: confirm that `stamp_resume_disposition` stamps
+    /// `Some(Denied)` onto `pending_approval_resume.disposition` when `last_gate`
+    /// matches the approval slot's gate_ref, and does NOT stamp the absent auth
+    /// slot — exercises the real helper, not a copy.
     #[test]
     fn approval_deny_disposition_is_stamped_onto_pending_approval_resume_before_execution() {
-        use ironclaw_agent_loop::state::LoopExecutionState;
         use ironclaw_turns::GateResumeDisposition;
-        use ironclaw_turns::run_profile::LoopCheckpointKind;
 
         let registry = build_loop_family_registry().expect("registry");
         let driver = PlannedDriver::default_from_registry(&registry).expect("driver");
-
         let context = run_context_for_driver(&driver);
-        let request_disposition: Option<GateResumeDisposition> =
-            Some(GateResumeDisposition::Denied);
 
-        let staged_state = state_with_pending_approval_resume(&context);
+        let mut state = state_with_pending_approval_resume(&context);
         // Confirm preconditions: approval resume has no disposition; auth resume absent.
         assert!(
-            staged_state
+            state
                 .pending_approval_resume
                 .as_ref()
                 .expect("pending_approval_resume must be set")
@@ -1275,85 +1280,244 @@ mod tests {
             "staged pending_approval_resume must start with disposition: None"
         );
         assert!(
-            staged_state.pending_auth_resume.is_none(),
+            state.pending_auth_resume.is_none(),
             "pending_auth_resume must be absent in this fixture"
         );
 
-        // Apply the same injection logic as the production `resume` path.
-        let payload_bytes = serde_json::to_vec(&staged_state).expect("serialize checkpoint state");
-        let checkpoint_kind = resumable_checkpoint_kind_from_host(LoopCheckpointKind::BeforeModel)
-            .expect("BeforeModel is resumable");
-        let mut loaded_state =
-            LoopExecutionState::from_checkpoint_payload(&payload_bytes, checkpoint_kind)
-                .expect("decode checkpoint state");
+        // Call the real helper — not an inline copy.
+        stamp_resume_disposition(&mut state, GateResumeDisposition::Denied);
 
-        if let Some(disposition) = request_disposition.clone() {
-            if let Some(pending) = loaded_state.pending_auth_resume.as_mut() {
-                pending.disposition = Some(disposition.clone());
-            }
-            if let Some(pending) = loaded_state.pending_approval_resume.as_mut() {
-                pending.disposition = Some(disposition);
-            }
-        }
-
-        // Assert the disposition was stamped onto the approval resume.
-        let disposition = loaded_state
+        // Assert the disposition was stamped onto the approval slot.
+        let disposition = state
             .pending_approval_resume
             .expect("pending_approval_resume must survive round-trip")
             .disposition
-            .expect("disposition must be Some after injection");
+            .expect("disposition must be Some after stamp_resume_disposition");
         assert!(
             matches!(disposition, GateResumeDisposition::Denied),
-            "disposition must be Denied after injection, got {disposition:?}"
+            "disposition must be Denied after stamp_resume_disposition, got {disposition:?}"
         );
-        // Auth resume must remain absent — the stamping must not create it.
+        // Auth resume must remain absent — stamping must not create it.
         assert!(
-            loaded_state.pending_auth_resume.is_none(),
+            state.pending_auth_resume.is_none(),
             "pending_auth_resume must remain absent when only approval resume is present"
         );
     }
 
-    /// Confirm that the injection is a no-op for `pending_approval_resume` when
-    /// the resume request carries no disposition — do not regress the normal
-    /// (non-deny) approval resume path.
+    /// Confirm that `stamp_resume_disposition` is a no-op when `last_gate` is
+    /// `None` — do not regress the normal (non-deny) approval resume path.
     #[test]
-    fn approval_deny_disposition_injection_is_noop_when_disposition_is_none() {
-        use ironclaw_agent_loop::state::LoopExecutionState;
+    fn approval_deny_disposition_injection_is_noop_when_last_gate_is_none() {
         use ironclaw_turns::GateResumeDisposition;
-        use ironclaw_turns::run_profile::LoopCheckpointKind;
 
         let registry = build_loop_family_registry().expect("registry");
         let driver = PlannedDriver::default_from_registry(&registry).expect("driver");
-
         let context = run_context_for_driver(&driver);
-        let request_disposition: Option<GateResumeDisposition> = None;
 
-        let staged_state = state_with_pending_approval_resume(&context);
-        let payload_bytes = serde_json::to_vec(&staged_state).expect("serialize checkpoint state");
-        let checkpoint_kind = resumable_checkpoint_kind_from_host(LoopCheckpointKind::BeforeModel)
-            .expect("BeforeModel is resumable");
-        let mut loaded_state =
-            LoopExecutionState::from_checkpoint_payload(&payload_bytes, checkpoint_kind)
-                .expect("decode checkpoint state");
+        let mut state = state_with_pending_approval_resume(&context);
+        // Clear last_gate to simulate a checkpoint without a recorded gate.
+        state.last_gate = None;
 
-        // Apply injection (disposition is None — the outer `if let Some` guard fires false).
-        if let Some(disposition) = request_disposition.clone() {
-            if let Some(pending) = loaded_state.pending_auth_resume.as_mut() {
-                pending.disposition = Some(disposition.clone());
-            }
-            if let Some(pending) = loaded_state.pending_approval_resume.as_mut() {
-                pending.disposition = Some(disposition);
-            }
-        }
+        stamp_resume_disposition(&mut state, GateResumeDisposition::Denied);
 
         // Disposition must remain None — no-op.
         assert!(
-            loaded_state
+            state
                 .pending_approval_resume
                 .expect("pending_approval_resume must survive round-trip")
                 .disposition
                 .is_none(),
-            "disposition must remain None when request resume_disposition is None"
+            "disposition must remain None when last_gate is None"
+        );
+    }
+
+    // ---- dual-slot regression test -----------------------------------------------
+
+    /// Helper: build a `LoopExecutionState` carrying BOTH `pending_auth_resume`
+    /// (gate_ref = `gate:dual-auth`) AND `pending_approval_resume`
+    /// (gate_ref = `gate:dual-approval`), with `last_gate` pointing to the
+    /// approval gate.
+    ///
+    /// This mirrors the real scenario GateStage produces: an auth gate blocked
+    /// during the first dispatch, then a non-auth (approval) gate fired mid-
+    /// re-dispatch — leaving both slots populated simultaneously.
+    fn state_with_both_resumes_last_gate_approval(
+        context: &LoopRunContext,
+    ) -> ironclaw_agent_loop::state::LoopExecutionState {
+        use ironclaw_agent_loop::state::{PendingApprovalResume, PendingAuthResume};
+        use ironclaw_host_api::{ApprovalRequestId, CapabilityId, CorrelationId, ResourceEstimate};
+        use ironclaw_turns::LoopGateRef;
+        use ironclaw_turns::run_profile::{
+            CapabilityInputRef, CapabilityResumeToken, CapabilitySurfaceVersion,
+        };
+
+        let auth_gate_ref = LoopGateRef::new("gate:dual-auth").expect("valid gate ref");
+        let approval_gate_ref = LoopGateRef::new("gate:dual-approval").expect("valid gate ref");
+
+        let mut state = ironclaw_agent_loop::state::LoopExecutionState::initial_for_run(context);
+        // last_gate = approval — the run is currently blocked on this gate.
+        state.last_gate = Some(approval_gate_ref.clone());
+        state.pending_auth_resume = Some(PendingAuthResume {
+            gate_ref: auth_gate_ref,
+            capability_id: CapabilityId::new("test.capability.auth").expect("valid capability id"),
+            surface_version: CapabilitySurfaceVersion::new("surface:v1")
+                .expect("valid surface version"),
+            input_ref: CapabilityInputRef::new("input:dual-auth").expect("valid input ref"),
+            effective_capability_ids: Vec::new(),
+            provider_replay: None,
+            resume_token: None,
+            prior_approval: None,
+            replay: None,
+            disposition: None,
+        });
+        state.pending_approval_resume = Some(PendingApprovalResume {
+            gate_ref: approval_gate_ref,
+            capability_id: CapabilityId::new("test.capability.approval")
+                .expect("valid capability id"),
+            approval_request_id: ApprovalRequestId::new(),
+            resume_token: CapabilityResumeToken::new("00000000-0000-0000-0000-000000000002")
+                .expect("valid resume token"),
+            correlation_id: CorrelationId::new(),
+            surface_version: CapabilitySurfaceVersion::new("surface:v1")
+                .expect("valid surface version"),
+            input_ref: CapabilityInputRef::new("input:dual-approval").expect("valid input ref"),
+            effective_capability_ids: Vec::new(),
+            provider_replay: None,
+            input: serde_json::Value::Null,
+            estimate: ResourceEstimate::default(),
+            disposition: None,
+        });
+        state
+    }
+
+    /// Bug-regression: when BOTH `pending_auth_resume` and
+    /// `pending_approval_resume` are set and `last_gate` points to the approval
+    /// gate, denying the approval must stamp ONLY the approval slot. The auth
+    /// slot must remain `disposition: None`.
+    ///
+    /// This is the scenario the old "stamp both" code got wrong: the auth resume
+    /// would have been corrupted with `Some(Denied)`, causing CapabilityStage to
+    /// misattribute the denial and lose the auth context on the next tick.
+    ///
+    /// Drives `PlannedDriver::resume()` end-to-end to exercise the real
+    /// stamping path, not an inline copy.
+    #[tokio::test]
+    async fn resume_with_approval_deny_does_not_corrupt_unrelated_auth_resume() {
+        use ironclaw_turns::GateResumeDisposition;
+
+        let registry = build_loop_family_registry().expect("registry");
+        let driver = PlannedDriver::default_from_registry(&registry).expect("driver");
+        let context = run_context_for_driver(&driver);
+
+        // Build a checkpoint with BOTH resumes populated; last_gate = approval.
+        let staged_state = state_with_both_resumes_last_gate_approval(&context);
+        // Precondition: both slots start without a disposition.
+        assert!(
+            staged_state
+                .pending_auth_resume
+                .as_ref()
+                .expect("auth resume must be set")
+                .disposition
+                .is_none(),
+            "pending_auth_resume must start with disposition: None"
+        );
+        assert!(
+            staged_state
+                .pending_approval_resume
+                .as_ref()
+                .expect("approval resume must be set")
+                .disposition
+                .is_none(),
+            "pending_approval_resume must start with disposition: None"
+        );
+
+        let payload_bytes =
+            serde_json::to_vec(&staged_state).expect("serialize dual-slot checkpoint state");
+        let loaded = LoadedCheckpointPayload {
+            kind: LoopCheckpointKind::BeforeModel,
+            schema_id: context.checkpoint_schema_id.clone(),
+            schema_version: context.checkpoint_schema_version,
+            payload: RedactedCheckpointPayload::new(payload_bytes)
+                .expect("valid checkpoint payload"),
+        };
+        let checkpoint_id = TurnCheckpointId::new();
+
+        let (inner, _checkpoints) = MockAgentLoopDriverHost::builder()
+            .run_context(context.clone())
+            .build();
+        let host = ResumePayloadHost::new(inner, checkpoint_id, loaded);
+
+        // Resume with approval denied — the key assertion is that the executor
+        // does NOT re-block (which would happen if both dispositions were stamped,
+        // confusing the capability stage) and that the auth slot was NOT corrupted.
+        // We capture the result to check it isn't a blocked exit; the primary
+        // regression proof is in the unit-level assertion below that drives the
+        // helper directly.
+        let result = driver
+            .resume(
+                AgentLoopDriverResumeRequest {
+                    turn_id: context.turn_id,
+                    run_id: context.run_id,
+                    checkpoint_id,
+                    resolved_run_profile: context.resolved_run_profile.clone(),
+                    resume_disposition: Some(GateResumeDisposition::Denied),
+                },
+                &host,
+            )
+            .await;
+
+        // The loop must not re-block on the approval gate — the denial is stamped
+        // and the executor surfaces it as a model-visible failure.
+        if let ironclaw_turns::LoopExit::Blocked(_) =
+            result.expect("resume should produce a terminal loop exit")
+        {
+            panic!(
+                "resume with approval GateResumeDisposition::Denied must not re-block; \
+                 the executor must surface a model-visible denial and continue"
+            );
+        }
+    }
+
+    /// Unit-level regression assertion for the dual-slot scenario: drives
+    /// `stamp_resume_disposition` directly and asserts that the auth slot's
+    /// `disposition` remains `None` while the approval slot receives `Denied`.
+    ///
+    /// This complements the async `resume` test above with a precise assertion
+    /// on the intermediate state — the auth slot disposition — that the
+    /// executor-level test cannot cheaply inspect after the fact.
+    #[test]
+    fn stamp_resume_disposition_does_not_corrupt_auth_slot_when_approval_gate_is_last() {
+        use ironclaw_turns::GateResumeDisposition;
+
+        let registry = build_loop_family_registry().expect("registry");
+        let driver = PlannedDriver::default_from_registry(&registry).expect("driver");
+        let context = run_context_for_driver(&driver);
+
+        let mut state = state_with_both_resumes_last_gate_approval(&context);
+
+        stamp_resume_disposition(&mut state, GateResumeDisposition::Denied);
+
+        // CRITICAL: auth slot must NOT be corrupted — this is the bug assertion.
+        assert!(
+            state
+                .pending_auth_resume
+                .as_ref()
+                .expect("pending_auth_resume must still be present after stamp")
+                .disposition
+                .is_none(),
+            "BUG REGRESSION: pending_auth_resume.disposition must remain None \
+             when the denial is for the approval gate, not the auth gate"
+        );
+
+        // Approval slot must be stamped.
+        let approval_disposition = state
+            .pending_approval_resume
+            .expect("pending_approval_resume must still be present after stamp")
+            .disposition
+            .expect("pending_approval_resume.disposition must be Some(Denied) after stamp");
+        assert!(
+            matches!(approval_disposition, GateResumeDisposition::Denied),
+            "pending_approval_resume.disposition must be Denied, got {approval_disposition:?}"
         );
     }
 }

--- a/crates/ironclaw_reborn/src/planned_driver.rs
+++ b/crates/ironclaw_reborn/src/planned_driver.rs
@@ -285,7 +285,7 @@ fn stamp_resume_disposition(
         (true, true) => {
             // Should never happen: two pending slots share the same gate_ref.
             // Refuse to stamp either rather than misattribute the denial.
-            tracing::warn!(
+            tracing::debug!(
                 ?last_gate,
                 "ambiguous gate resume disposition; refusing to stamp"
             );

--- a/crates/ironclaw_reborn/src/subagent/completion_observer.rs
+++ b/crates/ironclaw_reborn/src/subagent/completion_observer.rs
@@ -480,7 +480,7 @@ where
                 // termination cannot unblock a parent that is actually
                 // waiting on an unrelated approval/auth/resource gate.
                 precondition: ResumeTurnPrecondition::BlockedDependentRunGate,
-                auth_resume_disposition: None,
+                resume_disposition: None,
             })
             .await
             .map(|_| ())
@@ -1791,7 +1791,7 @@ mod tests {
             failure: None,
             event_cursor: EventCursor(1),
             product_context: None,
-            auth_resume_disposition: None,
+            resume_disposition: None,
         }
     }
 
@@ -1819,7 +1819,7 @@ mod tests {
             failure: None,
             event_cursor: EventCursor(1),
             product_context: None,
-            auth_resume_disposition: None,
+            resume_disposition: None,
         }
     }
 
@@ -1860,7 +1860,7 @@ mod tests {
             subagent_depth,
             spawn_tree_root_run_id,
             product_context: None,
-            auth_resume_disposition: None,
+            resume_disposition: None,
         }
     }
 
@@ -1900,7 +1900,7 @@ mod tests {
             subagent_depth: 1,
             spawn_tree_root_run_id: None,
             product_context: None,
-            auth_resume_disposition: None,
+            resume_disposition: None,
         }
     }
 
@@ -2383,7 +2383,7 @@ mod tests {
             failure: None,
             event_cursor: EventCursor(1),
             product_context: None,
-            auth_resume_disposition: None,
+            resume_disposition: None,
         };
         let observer = SubagentCompletionObserver::new(
             Arc::new(BoundedSubagentGateResolutionStore::new()),

--- a/crates/ironclaw_reborn/src/turn_runner.rs
+++ b/crates/ironclaw_reborn/src/turn_runner.rs
@@ -467,7 +467,7 @@ impl TurnRunnerWorker {
                     run_id,
                     checkpoint_id,
                     resolved_run_profile: claimed.resolved_run_profile.clone(),
-                    auth_resume_disposition: claimed.state.auth_resume_disposition.clone(),
+                    resume_disposition: claimed.state.resume_disposition.clone(),
                 };
                 driver
                     .resume(request, host.as_ref())

--- a/crates/ironclaw_reborn/src/turn_runner/tests/mod.rs
+++ b/crates/ironclaw_reborn/src/turn_runner/tests/mod.rs
@@ -131,7 +131,7 @@ fn test_run_state(scope: TurnScope, status: TurnStatus) -> TurnRunState {
         failure: None,
         event_cursor: EventCursor(0),
         product_context: None,
-        auth_resume_disposition: None,
+        resume_disposition: None,
     }
 }
 

--- a/crates/ironclaw_reborn/tests/hooks_integration.rs
+++ b/crates/ironclaw_reborn/tests/hooks_integration.rs
@@ -1078,7 +1078,7 @@ impl Fixture {
             failure: None,
             event_cursor: EventCursor(1),
             product_context: None,
-            auth_resume_disposition: None,
+            resume_disposition: None,
         };
         let claimed = ClaimedTurnRun {
             state,

--- a/crates/ironclaw_reborn/tests/loop_driver_host.rs
+++ b/crates/ironclaw_reborn/tests/loop_driver_host.rs
@@ -2299,7 +2299,7 @@ async fn turn_runner_blocks_on_approval_then_coordinator_resume_completes_same_r
             source_binding_ref: SourceBindingRef::new("source-web-resumed").unwrap(),
             reply_target_binding_ref: ReplyTargetBindingRef::new("reply-web-resumed").unwrap(),
             idempotency_key: IdempotencyKey::new("resume-approval-once").unwrap(),
-            auth_resume_disposition: None,
+            resume_disposition: None,
         })
         .await
         .unwrap();
@@ -7748,7 +7748,7 @@ impl HostFixture {
             failure: None,
             event_cursor: EventCursor(1),
             product_context: None,
-            auth_resume_disposition: None,
+            resume_disposition: None,
         };
         let claimed = ClaimedTurnRun {
             state,

--- a/crates/ironclaw_reborn/tests/loop_milestone_event_projection.rs
+++ b/crates/ironclaw_reborn/tests/loop_milestone_event_projection.rs
@@ -792,7 +792,7 @@ impl HostFixture {
             failure: None,
             event_cursor: EventCursor(1),
             product_context: None,
-            auth_resume_disposition: None,
+            resume_disposition: None,
         };
         let claimed = ClaimedTurnRun {
             state,

--- a/crates/ironclaw_reborn/tests/planned_driver_e2e.rs
+++ b/crates/ironclaw_reborn/tests/planned_driver_e2e.rs
@@ -66,7 +66,7 @@ fn resume_request(
         run_id: context.run_id,
         checkpoint_id,
         resolved_run_profile: context.resolved_run_profile.clone(),
-        auth_resume_disposition: None,
+        resume_disposition: None,
     }
 }
 

--- a/crates/ironclaw_reborn_composition/src/factory/auth_tests.rs
+++ b/crates/ironclaw_reborn_composition/src/factory/auth_tests.rs
@@ -87,7 +87,7 @@ fn auth_error_mapping_run_state(request: &GetRunStateRequest) -> TurnRunState {
         failure: None,
         event_cursor: EventCursor::default(),
         product_context: None,
-        auth_resume_disposition: None,
+        resume_disposition: None,
     }
 }
 

--- a/crates/ironclaw_reborn_composition/src/projection/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/tests.rs
@@ -384,6 +384,6 @@ fn turn_run_state(
         failure: None,
         event_cursor: cursor,
         product_context: None,
-        auth_resume_disposition: None,
+        resume_disposition: None,
     }
 }

--- a/crates/ironclaw_reborn_composition/src/slack_delivery.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_delivery.rs
@@ -2536,7 +2536,7 @@ mod tests {
                 failure: None,
                 event_cursor: EventCursor(1),
                 product_context: None,
-                auth_resume_disposition: None,
+                resume_disposition: None,
             })
         }
 

--- a/crates/ironclaw_reborn_composition/src/slack_serve/e2e_tests.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_serve/e2e_tests.rs
@@ -1862,7 +1862,7 @@ fn turn_state(
         failure: None,
         event_cursor: EventCursor::default(),
         product_context: None,
-        auth_resume_disposition: None,
+        resume_disposition: None,
     }
 }
 

--- a/crates/ironclaw_reborn_composition/src/trigger_poller.rs
+++ b/crates/ironclaw_reborn_composition/src/trigger_poller.rs
@@ -646,7 +646,7 @@ mod tests {
             subagent_depth: 0,
             spawn_tree_root_run_id: None,
             product_context: None,
-            auth_resume_disposition: None,
+            resume_disposition: None,
         }
     }
 

--- a/crates/ironclaw_turns/src/events.rs
+++ b/crates/ironclaw_turns/src/events.rs
@@ -520,7 +520,7 @@ mod tests {
             failure: None,
             event_cursor: EventCursor(1),
             product_context: None,
-            auth_resume_disposition: None,
+            resume_disposition: None,
         };
 
         let event = TurnLifecycleEvent::from_run_state(&state, TurnEventKind::Blocked, None);

--- a/crates/ironclaw_turns/src/lib.rs
+++ b/crates/ironclaw_turns/src/lib.rs
@@ -73,7 +73,7 @@ pub use origin::{
     ProductTurnContext, RunOriginAdapter, TurnOriginKind, TurnOwner, TurnSurfaceType,
 };
 pub use request::{
-    AuthResumeDisposition, CancelRunRequest, GetRunStateRequest, ResumeTurnPrecondition,
+    CancelRunRequest, GateResumeDisposition, GetRunStateRequest, ResumeTurnPrecondition,
     ResumeTurnRequest, SubmitChildRunRequest, SubmitTurnRequest, TurnTimestamp,
 };
 pub use response::{CancelRunResponse, ResumeTurnResponse, SubmitTurnResponse, ThreadBusy};

--- a/crates/ironclaw_turns/src/memory.rs
+++ b/crates/ironclaw_turns/src/memory.rs
@@ -135,7 +135,7 @@ struct RunRecord {
     subagent_depth: u32,
     spawn_tree_root_run_id: Option<TurnRunId>,
     product_context: Option<crate::ProductTurnContext>,
-    auth_resume_disposition: Option<crate::AuthResumeDisposition>,
+    resume_disposition: Option<crate::GateResumeDisposition>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -624,7 +624,7 @@ impl TurnStateStore for InMemoryTurnStateStore {
             subagent_depth: 0,
             spawn_tree_root_run_id: None,
             product_context: request.product_context,
-            auth_resume_disposition: None,
+            resume_disposition: None,
         };
         inner.turns.insert(turn_id, turn_record);
         inner.active_locks.insert(
@@ -1044,7 +1044,7 @@ impl TurnSpawnTreeStateStore for InMemoryTurnStateStore {
             subagent_depth,
             spawn_tree_root_run_id: Some(root_run_id),
             product_context: parent_product_context,
-            auth_resume_disposition: None,
+            resume_disposition: None,
         };
         inner.turns.insert(turn_id, turn_record);
         inner.active_locks.insert(
@@ -1475,7 +1475,7 @@ impl Inner {
                     subagent_depth: run.subagent_depth,
                     spawn_tree_root_run_id: run.spawn_tree_root_run_id,
                     product_context: run.product_context,
-                    auth_resume_disposition: run.auth_resume_disposition,
+                    resume_disposition: run.resume_disposition,
                 },
             );
         }
@@ -1941,7 +1941,7 @@ impl Inner {
             }
             let now = Utc::now();
             record.status = TurnStatus::Queued;
-            record.auth_resume_disposition = request.auth_resume_disposition.clone();
+            record.resume_disposition = request.resume_disposition.clone();
             record.gate_ref = None;
             record.credential_requirements = Vec::new();
             record.source_binding_ref = request.source_binding_ref.clone();
@@ -2596,7 +2596,7 @@ impl RunRecord {
             subagent_depth: self.subagent_depth,
             spawn_tree_root_run_id: self.spawn_tree_root_run_id,
             product_context: self.product_context.clone(),
-            auth_resume_disposition: self.auth_resume_disposition.clone(),
+            resume_disposition: self.resume_disposition.clone(),
         }
     }
 
@@ -2620,7 +2620,7 @@ impl RunRecord {
             failure: self.failure.clone(),
             event_cursor: self.event_cursor,
             product_context: self.product_context.clone(),
-            auth_resume_disposition: self.auth_resume_disposition.clone(),
+            resume_disposition: self.resume_disposition.clone(),
         }
     }
 }

--- a/crates/ironclaw_turns/src/request.rs
+++ b/crates/ironclaw_turns/src/request.rs
@@ -11,9 +11,10 @@ pub type TurnTimestamp = DateTime<Utc>;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
-pub enum AuthResumeDisposition {
-    /// The user explicitly declined the auth gate. The executor surfaces this to
-    /// the model as an authorization failure rather than re-dispatching the gate.
+pub enum GateResumeDisposition {
+    /// The user explicitly declined the gate (auth OR approval). The executor
+    /// surfaces this to the model as a non-retryable authorization failure rather
+    /// than re-dispatching the gate.
     ///
     /// New variants (e.g. `Deferred`) may be added here as needs arise.
     Denied,
@@ -104,8 +105,12 @@ pub struct ResumeTurnRequest {
     pub idempotency_key: IdempotencyKey,
     #[serde(default, skip_serializing_if = "ResumeTurnPrecondition::is_default")]
     pub precondition: ResumeTurnPrecondition,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub auth_resume_disposition: Option<AuthResumeDisposition>,
+    #[serde(
+        rename = "auth_resume_disposition",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub resume_disposition: Option<GateResumeDisposition>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -129,7 +134,7 @@ mod tests {
 
     use super::*;
 
-    fn make_resume_request(disposition: Option<AuthResumeDisposition>) -> ResumeTurnRequest {
+    fn make_resume_request(disposition: Option<GateResumeDisposition>) -> ResumeTurnRequest {
         ResumeTurnRequest {
             scope: TurnScope {
                 tenant_id: TenantId::from_trusted("tenant:test".to_string()),
@@ -146,32 +151,31 @@ mod tests {
                 .expect("valid reply target ref"),
             idempotency_key: IdempotencyKey::new("idempotency-key").expect("valid idempotency key"),
             precondition: ResumeTurnPrecondition::default(),
-            auth_resume_disposition: disposition,
+            resume_disposition: disposition,
         }
     }
 
     #[test]
-    fn auth_resume_disposition_denied_round_trips() {
-        let disposition = AuthResumeDisposition::Denied;
+    fn gate_resume_disposition_denied_round_trips() {
+        let disposition = GateResumeDisposition::Denied;
         let json = serde_json::to_string(&disposition).expect("serialize");
         assert!(json.contains("denied"), "wire value is snake_case: {json}");
-        let decoded: AuthResumeDisposition = serde_json::from_str(&json).expect("deserialize");
+        let decoded: GateResumeDisposition = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(disposition, decoded);
     }
 
-    /// Asserts the `#[serde(default, skip_serializing_if = "Option::is_none")]`
-    /// contract on `ResumeTurnRequest.auth_resume_disposition`:
+    /// Asserts the serde contract on `ResumeTurnRequest.resume_disposition`:
     ///
     /// 1. **Backward-compat deserialize**: a JSON object for a full
     ///    `ResumeTurnRequest` that omits the `auth_resume_disposition` key must
-    ///    deserialize with `auth_resume_disposition == None`.
-    /// 2. **Absent-field serialize**: when `auth_resume_disposition` is `None`,
+    ///    deserialize with `resume_disposition == None`.
+    /// 2. **Absent-field serialize**: when `resume_disposition` is `None`,
     ///    serializing the struct must NOT emit the `auth_resume_disposition` key.
-    /// 3. **Some round-trip**: when `auth_resume_disposition` is `Some(Denied)`,
+    /// 3. **Some round-trip**: when `resume_disposition` is `Some(Denied)`,
     ///    the key is present in serialized JSON as the snake_case string `"denied"`
     ///    and round-trips correctly.
     #[test]
-    fn resume_turn_request_auth_resume_disposition_serde_contract() {
+    fn resume_turn_request_resume_disposition_serde_contract() {
         // --- 1. Backward-compat: omitted key → None ---
         let base = make_resume_request(None);
         let mut json_value = serde_json::to_value(&base).expect("serialize base request");
@@ -183,7 +187,7 @@ mod tests {
         let deserialized: ResumeTurnRequest = serde_json::from_value(json_value)
             .expect("deserialize without auth_resume_disposition");
         assert_eq!(
-            deserialized.auth_resume_disposition, None,
+            deserialized.resume_disposition, None,
             "omitted auth_resume_disposition key must default to None"
         );
 
@@ -199,7 +203,7 @@ mod tests {
         );
 
         // --- 3. Some round-trip: Denied (unit variant) ---
-        let disposition = AuthResumeDisposition::Denied;
+        let disposition = GateResumeDisposition::Denied;
         let some_request = make_resume_request(Some(disposition.clone()));
         let some_json = serde_json::to_value(&some_request).expect("serialize Some request");
         let disposition_value = some_json
@@ -211,14 +215,61 @@ mod tests {
         assert_eq!(
             disposition_value,
             &serde_json::Value::String("denied".to_string()),
-            "auth_resume_disposition must serialize as snake_case string 'denied': {disposition_value}"
+            "resume_disposition must serialize under the legacy key 'auth_resume_disposition' as 'denied': {disposition_value}"
         );
         let roundtrip: ResumeTurnRequest =
             serde_json::from_value(some_json).expect("deserialize Some request");
         assert_eq!(
-            roundtrip.auth_resume_disposition,
+            roundtrip.resume_disposition,
             Some(disposition),
-            "auth_resume_disposition must round-trip correctly"
+            "resume_disposition must round-trip correctly"
+        );
+    }
+
+    /// Proves that a `ResumeTurnRequest` serialized with the OLD wire key
+    /// `"auth_resume_disposition"` (from before the rename to `resume_disposition`)
+    /// still deserializes into the new `resume_disposition` field, and that a
+    /// missing field defaults to `None`.
+    ///
+    /// Strategy: round-trip through `make_resume_request` (gives us a valid
+    /// struct), then overwrite/inject the key in the JSON map to simulate
+    /// what pre-rename code would have written.
+    #[test]
+    fn resume_disposition_deserializes_legacy_auth_key() {
+        // --- Part 1: old key "auth_resume_disposition" lands on resume_disposition ---
+        // Start from a valid serialized request (no disposition set).
+        let base = make_resume_request(None);
+        let mut json_value = serde_json::to_value(&base).expect("serialize base");
+        // Inject the old wire key with the "denied" variant value — as pre-rename
+        // code would have written it.
+        json_value.as_object_mut().expect("object").insert(
+            "auth_resume_disposition".to_string(),
+            serde_json::json!("denied"),
+        );
+
+        let deserialized: ResumeTurnRequest =
+            serde_json::from_value(json_value).expect("legacy JSON must deserialize");
+        assert_eq!(
+            deserialized.resume_disposition,
+            Some(GateResumeDisposition::Denied),
+            "legacy 'auth_resume_disposition' key must deserialize into resume_disposition"
+        );
+
+        // --- Part 2: completely missing field defaults to None ---
+        let base_none = make_resume_request(None);
+        let mut json_none = serde_json::to_value(&base_none).expect("serialize base_none");
+        // Remove the key entirely (it won't be present for None due to skip_serializing_if,
+        // but remove defensively in case the serializer ever changes).
+        json_none
+            .as_object_mut()
+            .expect("object")
+            .remove("auth_resume_disposition");
+
+        let deserialized_none: ResumeTurnRequest =
+            serde_json::from_value(json_none).expect("missing-field JSON must deserialize");
+        assert_eq!(
+            deserialized_none.resume_disposition, None,
+            "missing auth_resume_disposition key must default to None"
         );
     }
 }

--- a/crates/ironclaw_turns/src/run_profile/driver.rs
+++ b/crates/ironclaw_turns/src/run_profile/driver.rs
@@ -64,8 +64,12 @@ pub struct AgentLoopDriverResumeRequest {
     pub run_id: TurnRunId,
     pub checkpoint_id: TurnCheckpointId,
     pub resolved_run_profile: ResolvedRunProfile,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub auth_resume_disposition: Option<crate::AuthResumeDisposition>,
+    #[serde(
+        rename = "auth_resume_disposition",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub resume_disposition: Option<crate::GateResumeDisposition>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]

--- a/crates/ironclaw_turns/src/status.rs
+++ b/crates/ironclaw_turns/src/status.rs
@@ -322,8 +322,12 @@ pub struct TurnRunState {
     pub event_cursor: EventCursor,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub product_context: Option<ProductTurnContext>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub auth_resume_disposition: Option<crate::AuthResumeDisposition>,
+    #[serde(
+        rename = "auth_resume_disposition",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub resume_disposition: Option<crate::GateResumeDisposition>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/ironclaw_turns/src/store.rs
+++ b/crates/ironclaw_turns/src/store.rs
@@ -463,21 +463,106 @@ pub struct TurnPersistenceSnapshot {
 
 #[cfg(test)]
 mod tests {
-    use crate::GateResumeDisposition;
+    use crate::{
+        AcceptedMessageRef, EventCursor, GateResumeDisposition, ReplyTargetBindingRef,
+        SourceBindingRef, TurnRunId, TurnRunRecord, TurnScope, TurnStatus,
+    };
+    use ironclaw_host_api::{AgentId, ProjectId, TenantId, ThreadId};
+
+    fn minimal_turn_run_record() -> TurnRunRecord {
+        // Build a TurnRunRecord by serializing a struct-literal then
+        // deserializing back so serde fills in all optional defaults.
+        // We construct the profile via the same JSON shortcut used elsewhere
+        // in test helpers (no ResolvedRunProfile needed).
+        let scope = TurnScope::new(
+            TenantId::new("tenant-store-test").unwrap(),
+            Some(AgentId::new("agent-store-test").unwrap()),
+            Some(ProjectId::new("project-store-test").unwrap()),
+            ThreadId::new("thread-store-test").unwrap(),
+        );
+        let profile: crate::TurnRunProfile = serde_json::from_value(serde_json::json!({
+            "id": "default",
+            "version": 1,
+            "allow_steering": false,
+            "auto_queue_followups": false,
+        }))
+        .expect("profile deserialization");
+        TurnRunRecord {
+            run_id: TurnRunId::new(),
+            turn_id: crate::TurnId::new(),
+            scope,
+            accepted_message_ref: AcceptedMessageRef::new("accepted-store-test").unwrap(),
+            source_binding_ref: SourceBindingRef::new("source-store-test").unwrap(),
+            reply_target_binding_ref: ReplyTargetBindingRef::new("reply-store-test").unwrap(),
+            status: TurnStatus::Completed,
+            profile,
+            resolved_model_route: None,
+            checkpoint_id: None,
+            gate_ref: None,
+            credential_requirements: vec![],
+            failure: None,
+            event_cursor: EventCursor(0),
+            runner_id: None,
+            lease_token: None,
+            lease_expires_at: None,
+            last_heartbeat_at: None,
+            claim_count: 0,
+            received_at: chrono::DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")
+                .unwrap()
+                .with_timezone(&chrono::Utc),
+            parent_run_id: None,
+            subagent_depth: 0,
+            spawn_tree_root_run_id: None,
+            product_context: None,
+            resume_disposition: None,
+        }
+    }
 
     #[test]
     fn turn_run_record_resume_disposition_defaults_to_none_when_absent() {
-        // Simulates old persisted JSON without the field — must deserialize cleanly.
-        // The absence of the field must not be an error (backward compat).
-        let disposition_absent: Option<GateResumeDisposition> = None;
-        let serialized = serde_json::to_string(&disposition_absent).expect("serialize None");
-        assert_eq!(serialized, "null");
+        // (a) Deserialize a real TurnRunRecord JSON with auth_resume_disposition key ABSENT.
+        // This proves #[serde(default)] is in place on the field.
+        let record = minimal_turn_run_record();
+        let mut json_val =
+            serde_json::to_value(&record).expect("serialize TurnRunRecord with None disposition");
 
-        let denied = GateResumeDisposition::Denied;
-        let serialized_denied = serde_json::to_value(&denied).expect("serialize Denied");
-        assert_eq!(serialized_denied, serde_json::json!("denied"));
-        let roundtrip: GateResumeDisposition =
-            serde_json::from_value(serialized_denied).expect("roundtrip");
-        assert_eq!(roundtrip, denied);
+        // The key must already be absent due to skip_serializing_if = "Option::is_none".
+        let obj = json_val
+            .as_object_mut()
+            .expect("TurnRunRecord must serialize to JSON object");
+        assert!(
+            !obj.contains_key("auth_resume_disposition"),
+            "auth_resume_disposition must be absent when resume_disposition is None"
+        );
+
+        // Belt-and-suspenders: forcibly remove the key then deserialize.
+        obj.remove("auth_resume_disposition");
+        let deserialized: TurnRunRecord =
+            serde_json::from_value(json_val).expect("deserialize TurnRunRecord missing key");
+        assert_eq!(
+            deserialized.resume_disposition, None,
+            "resume_disposition must default to None when the JSON key is absent"
+        );
+
+        // (b) Deserialize a real TurnRunRecord JSON carrying the LEGACY key
+        // "auth_resume_disposition": "denied". This proves the serde rename/back-compat.
+        let record2 = minimal_turn_run_record();
+        let mut json_val2 =
+            serde_json::to_value(&record2).expect("serialize TurnRunRecord for legacy key test");
+        let obj2 = json_val2
+            .as_object_mut()
+            .expect("TurnRunRecord must serialize to JSON object");
+        obj2.insert(
+            "auth_resume_disposition".to_string(),
+            serde_json::json!("denied"),
+        );
+
+        let deserialized2: TurnRunRecord =
+            serde_json::from_value(json_val2).expect("deserialize TurnRunRecord with legacy key");
+        assert_eq!(
+            deserialized2.resume_disposition,
+            Some(GateResumeDisposition::Denied),
+            "resume_disposition must be Some(Denied) when legacy key auth_resume_disposition is present"
+        );
     }
 }

--- a/crates/ironclaw_turns/src/store.rs
+++ b/crates/ironclaw_turns/src/store.rs
@@ -193,8 +193,12 @@ pub struct TurnRunRecord {
     pub spawn_tree_root_run_id: Option<TurnRunId>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub product_context: Option<crate::ProductTurnContext>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub auth_resume_disposition: Option<crate::AuthResumeDisposition>,
+    #[serde(
+        rename = "auth_resume_disposition",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub resume_disposition: Option<crate::GateResumeDisposition>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -459,20 +463,20 @@ pub struct TurnPersistenceSnapshot {
 
 #[cfg(test)]
 mod tests {
-    use crate::AuthResumeDisposition;
+    use crate::GateResumeDisposition;
 
     #[test]
-    fn turn_run_record_auth_resume_disposition_defaults_to_none_when_absent() {
+    fn turn_run_record_resume_disposition_defaults_to_none_when_absent() {
         // Simulates old persisted JSON without the field — must deserialize cleanly.
         // The absence of the field must not be an error (backward compat).
-        let disposition_absent: Option<AuthResumeDisposition> = None;
+        let disposition_absent: Option<GateResumeDisposition> = None;
         let serialized = serde_json::to_string(&disposition_absent).expect("serialize None");
         assert_eq!(serialized, "null");
 
-        let denied = AuthResumeDisposition::Denied;
+        let denied = GateResumeDisposition::Denied;
         let serialized_denied = serde_json::to_value(&denied).expect("serialize Denied");
         assert_eq!(serialized_denied, serde_json::json!("denied"));
-        let roundtrip: AuthResumeDisposition =
+        let roundtrip: GateResumeDisposition =
             serde_json::from_value(serialized_denied).expect("roundtrip");
         assert_eq!(roundtrip, denied);
     }

--- a/crates/ironclaw_turns/tests/agent_loop_host_contract.rs
+++ b/crates/ironclaw_turns/tests/agent_loop_host_contract.rs
@@ -2150,7 +2150,7 @@ async fn loop_prompt_bundle_public_serialization_hides_raw_content() {
         failure: None,
         event_cursor: EventCursor(0),
         product_context: None,
-        auth_resume_disposition: None,
+        resume_disposition: None,
     };
     let public_json = serde_json::to_string(&(bundle, host.milestones(), status)).unwrap();
     assert!(public_json.contains("prompt_bundle_built"));
@@ -3811,7 +3811,7 @@ async fn turn_run_state_product_context_defaults_to_none_when_missing_from_json(
         failure: None,
         event_cursor: EventCursor(0),
         product_context: None,
-        auth_resume_disposition: None,
+        resume_disposition: None,
     };
 
     // Serialize without the product_context field (simulate old wire).
@@ -3846,10 +3846,11 @@ async fn turn_run_state_product_context_defaults_to_none_when_missing_from_json(
 }
 
 #[tokio::test]
-async fn turn_run_state_auth_resume_disposition_defaults_to_none_when_missing_from_json() {
-    // Guard the #[serde(default)] backward-compat contract for auth_resume_disposition:
+async fn turn_run_state_resume_disposition_defaults_to_none_when_missing_from_json() {
+    // Guard the #[serde(default)] backward-compat contract for resume_disposition
+    // (serialized under the legacy key "auth_resume_disposition"):
     // old persisted TurnRunState payloads that pre-date the field must deserialize
-    // cleanly with auth_resume_disposition == None.
+    // cleanly with resume_disposition == None.
     let context = claimed_run_context().await;
     let state = TurnRunState {
         scope: context.scope.clone(),
@@ -3870,7 +3871,7 @@ async fn turn_run_state_auth_resume_disposition_defaults_to_none_when_missing_fr
         failure: None,
         event_cursor: EventCursor(0),
         product_context: None,
-        auth_resume_disposition: None,
+        resume_disposition: None,
     };
 
     // Serialize, remove the auth_resume_disposition key (simulates a legacy checkpoint
@@ -3883,8 +3884,8 @@ async fn turn_run_state_auth_resume_disposition_defaults_to_none_when_missing_fr
         .remove("auth_resume_disposition");
     let decoded: TurnRunState = serde_json::from_value(json).unwrap();
     assert!(
-        decoded.auth_resume_disposition.is_none(),
-        "auth_resume_disposition must default to None when absent from legacy JSON"
+        decoded.resume_disposition.is_none(),
+        "resume_disposition must default to None when absent from legacy JSON"
     );
 }
 

--- a/crates/ironclaw_turns/tests/checkpoint_state_store_contract.rs
+++ b/crates/ironclaw_turns/tests/checkpoint_state_store_contract.rs
@@ -440,7 +440,7 @@ fn turn_run_state_actor_is_serde_backward_compatible() {
         failure: None,
         event_cursor: EventCursor(1),
         product_context: None,
-        auth_resume_disposition: None,
+        resume_disposition: None,
     };
 
     let legacy_wire = serde_json::to_value(&state).unwrap();
@@ -491,7 +491,7 @@ fn turn_checkpoint_public_status_does_not_expose_checkpoint_payload() {
         failure: None,
         event_cursor: EventCursor(1),
         product_context: None,
-        auth_resume_disposition: None,
+        resume_disposition: None,
     };
     let event = TurnLifecycleEvent {
         cursor: EventCursor(2),
@@ -736,12 +736,13 @@ async fn put_test_state(
 }
 
 #[test]
-fn turn_persistence_snapshot_legacy_run_defaults_auth_resume_disposition_to_none() {
+fn turn_persistence_snapshot_legacy_run_defaults_resume_disposition_to_none() {
     // Simulate a legacy TurnPersistenceSnapshot JSON where TurnRunRecord objects were
-    // persisted before auth_resume_disposition was added. Deserializing such a snapshot
-    // must succeed and the field must default to None (via #[serde(default)]).
+    // persisted before resume_disposition (stored under "auth_resume_disposition") was
+    // added. Deserializing such a snapshot must succeed and the field must default to
+    // None (via #[serde(default)]).
     //
-    // Because auth_resume_disposition uses skip_serializing_if = "Option::is_none",
+    // Because resume_disposition uses skip_serializing_if = "Option::is_none",
     // serializing a record with None naturally produces JSON without the key —
     // which is exactly what a legacy snapshot looks like.
     let run_id = TurnRunId::new();
@@ -841,10 +842,11 @@ fn turn_persistence_snapshot_legacy_run_defaults_auth_resume_disposition_to_none
         subagent_depth: 0,
         spawn_tree_root_run_id: None,
         product_context: None,
-        auth_resume_disposition: None,
+        resume_disposition: None,
     };
 
-    // Serialize the snapshot — auth_resume_disposition must be absent in the output.
+    // Serialize the snapshot — auth_resume_disposition (the wire key) must be absent
+    // in the output when resume_disposition is None.
     let snapshot = TurnPersistenceSnapshot {
         runs: vec![record],
         ..TurnPersistenceSnapshot::default()
@@ -872,8 +874,8 @@ fn turn_persistence_snapshot_legacy_run_defaults_auth_resume_disposition_to_none
         "snapshot must contain exactly one run"
     );
     assert_eq!(
-        deserialized.runs[0].auth_resume_disposition, None,
-        "auth_resume_disposition must default to None when absent in legacy snapshot"
+        deserialized.runs[0].resume_disposition, None,
+        "resume_disposition must default to None when absent in legacy snapshot"
     );
 }
 

--- a/crates/ironclaw_turns/tests/checkpoint_state_store_contract.rs
+++ b/crates/ironclaw_turns/tests/checkpoint_state_store_contract.rs
@@ -879,6 +879,147 @@ fn turn_persistence_snapshot_legacy_run_defaults_resume_disposition_to_none() {
     );
 }
 
+#[test]
+fn turn_persistence_snapshot_legacy_run_preserves_denied_resume_disposition() {
+    // Mirror of turn_persistence_snapshot_legacy_run_defaults_resume_disposition_to_none,
+    // but instead of an absent key we inject the LEGACY wire key
+    // "auth_resume_disposition": "denied" into the serialized run JSON.
+    // This proves the serde rename provides back-compat for persisted records
+    // that carried a non-None value under the old field name.
+    let run_id = TurnRunId::new();
+    let turn_id = TurnId::new();
+    let scope = turn_scope("thread-legacy-denied-resume");
+
+    let descriptor = AgentLoopDriverDescriptor {
+        id: LoopDriverId::new("legacy-denied-resume-driver").expect("valid driver id"),
+        version: RunProfileVersion::new(1),
+        checkpoint_schema_id: Some(
+            CheckpointSchemaId::new("legacy_denied_resume_checkpoint").expect("valid"),
+        ),
+        checkpoint_schema_version: Some(RunProfileVersion::new(1)),
+    };
+    let resolved = ResolvedRunProfile {
+        run_class_id: RunClassId::new("legacy-denied-resume-class").expect("valid"),
+        profile_id: RunProfileId::default_profile(),
+        profile_version: RunProfileVersion::new(1),
+        loop_driver: descriptor.clone(),
+        checkpoint_schema_id: descriptor
+            .checkpoint_schema_id
+            .clone()
+            .expect("descriptor checkpoint id"),
+        checkpoint_schema_version: descriptor
+            .checkpoint_schema_version
+            .expect("descriptor checkpoint version"),
+        model_profile_id: ModelProfileId::new("legacy-denied-resume-model").expect("valid"),
+        capability_surface_profile_id: CapabilitySurfaceProfileId::new(
+            "legacy-denied-resume-capabilities",
+        )
+        .expect("valid"),
+        context_profile_id: ContextProfileId::new("legacy-denied-resume-context").expect("valid"),
+        steering_policy: SteeringPolicy {
+            allow_steering: false,
+            allow_interrupt: false,
+            allow_driver_specific_nudges: false,
+        },
+        cancellation_policy: CancellationPolicy {
+            allow_cancel: false,
+            require_checkpoint_before_cancel: false,
+        },
+        checkpoint_policy: CheckpointPolicy {
+            require_before_model: false,
+            require_before_side_effect: false,
+            require_before_block: false,
+            max_checkpoint_bytes: 64 * 1024,
+            require_final_checkpoint: false,
+            allow_no_reply_completion: false,
+        },
+        resource_budget_policy: ResourceBudgetPolicy {
+            tier: ResourceBudgetTier::new("legacy-denied-resume-tier").expect("valid"),
+            max_model_calls: 16,
+            max_capability_invocations: 32,
+        },
+        personal_context_policy: ironclaw_turns::run_profile::PersonalContextPolicy::Excluded,
+        runtime_constraints: RuntimeProfileConstraints {
+            allow_raw_runtime_backend_selection: false,
+            allow_broad_capability_surface: false,
+        },
+        runner_pool_id: None,
+        scheduling_class: SchedulingClass::new("interactive").expect("valid"),
+        concurrency_class: ConcurrencyClass::new("thread_serial").expect("valid"),
+        resolution_fingerprint: RunProfileFingerprint::new("legacy-denied-resume-fingerprint")
+            .expect("valid"),
+        provenance: RedactedRunProfileProvenance {
+            sources: vec![],
+            effective_privileges: vec![],
+        },
+    };
+
+    // Build a record with resume_disposition = None so the key is absent in
+    // serialized form (skip_serializing_if = "Option::is_none"), then inject
+    // the legacy wire key before deserializing.
+    let record = TurnRunRecord {
+        run_id,
+        turn_id,
+        scope: scope.clone(),
+        accepted_message_ref: AcceptedMessageRef::new("accepted-legacy-denied").unwrap(),
+        source_binding_ref: SourceBindingRef::new("source-legacy-denied").unwrap(),
+        reply_target_binding_ref: ReplyTargetBindingRef::new("reply-legacy-denied").unwrap(),
+        status: TurnStatus::Completed,
+        profile: TurnRunProfile::from_resolved(resolved),
+        resolved_model_route: None,
+        checkpoint_id: None,
+        gate_ref: None,
+        credential_requirements: vec![],
+        failure: None,
+        event_cursor: EventCursor(0),
+        runner_id: None,
+        lease_token: None,
+        lease_expires_at: None,
+        last_heartbeat_at: None,
+        claim_count: 0,
+        received_at: fixed_time(),
+        parent_run_id: None,
+        subagent_depth: 0,
+        spawn_tree_root_run_id: None,
+        product_context: None,
+        resume_disposition: None,
+    };
+
+    let snapshot = TurnPersistenceSnapshot {
+        runs: vec![record],
+        ..TurnPersistenceSnapshot::default()
+    };
+    let mut json_val = serde_json::to_value(&snapshot).expect("serialize snapshot");
+
+    // Inject the legacy key into the run object to simulate a persisted record
+    // that carried auth_resume_disposition = "denied" under the old field name.
+    let run_obj = json_val["runs"][0]
+        .as_object_mut()
+        .expect("runs[0] must be an object");
+    assert!(
+        !run_obj.contains_key("auth_resume_disposition"),
+        "auth_resume_disposition must be absent before injection"
+    );
+    run_obj.insert(
+        "auth_resume_disposition".to_string(),
+        serde_json::json!("denied"),
+    );
+
+    let deserialized: TurnPersistenceSnapshot =
+        serde_json::from_value(json_val).expect("deserialize legacy snapshot with denied key");
+
+    assert_eq!(
+        deserialized.runs.len(),
+        1,
+        "snapshot must contain exactly one run"
+    );
+    assert_eq!(
+        deserialized.runs[0].resume_disposition,
+        Some(ironclaw_turns::GateResumeDisposition::Denied),
+        "resume_disposition must be Some(Denied) when legacy auth_resume_disposition key is present"
+    );
+}
+
 fn turn_scope(thread_id: &str) -> TurnScope {
     TurnScope::new(
         TenantId::new("tenant-checkpoint").unwrap(),

--- a/crates/ironclaw_turns/tests/turn_coordinator_contract.rs
+++ b/crates/ironclaw_turns/tests/turn_coordinator_contract.rs
@@ -816,7 +816,7 @@ async fn blocked_dependent_run_can_resume_and_cancel_directly() {
             reply_target_binding_ref: ReplyTargetBindingRef::new("reply-web-resumed").unwrap(),
             idempotency_key: IdempotencyKey::new("idem-dependent-resume").unwrap(),
             precondition: ironclaw_turns::ResumeTurnPrecondition::BlockedDependentRunGate,
-            auth_resume_disposition: None,
+            resume_disposition: None,
         })
         .await
         .unwrap();
@@ -941,7 +941,7 @@ async fn default_turn_coordinator_dedupes_idempotency_replay_events_by_cursor() 
         reply_target_binding_ref: ReplyTargetBindingRef::new("reply-web-resumed").unwrap(),
         idempotency_key: IdempotencyKey::new("idem-event-replay-resume").unwrap(),
         precondition: ironclaw_turns::ResumeTurnPrecondition::BlockedDependentRunGate,
-        auth_resume_disposition: None,
+        resume_disposition: None,
     };
     coordinator.resume_turn(resume.clone()).await.unwrap();
     coordinator.resume_turn(resume).await.unwrap();
@@ -1659,7 +1659,7 @@ async fn lifecycle_publishing_store_propagates_required_observer_error_on_resume
             reply_target_binding_ref: ReplyTargetBindingRef::new("reply-web-resumed").unwrap(),
             idempotency_key: IdempotencyKey::new("idem-required-resume-error").unwrap(),
             precondition: ironclaw_turns::ResumeTurnPrecondition::BlockedDependentRunGate,
-            auth_resume_disposition: None,
+            resume_disposition: None,
         })
         .await
         .unwrap_err();
@@ -1865,7 +1865,7 @@ async fn turn_lifecycle_projection_replays_submit_block_resume_complete_without_
             )
             .unwrap(),
             idempotency_key: IdempotencyKey::new("idem-turn-events-resume").unwrap(),
-            auth_resume_disposition: None,
+            resume_disposition: None,
         })
         .await
         .unwrap();
@@ -2493,7 +2493,7 @@ async fn resume_turn_wakes_runner_for_same_run_after_requeue() {
             source_binding_ref: SourceBindingRef::new("source-web-resumed").unwrap(),
             reply_target_binding_ref: ReplyTargetBindingRef::new("reply-web-resumed").unwrap(),
             idempotency_key: IdempotencyKey::new("idem-resume-a").unwrap(),
-            auth_resume_disposition: None,
+            resume_disposition: None,
         })
         .await
         .unwrap();
@@ -2620,7 +2620,7 @@ async fn resume_turn_ignores_wake_notification_panic_after_requeue() {
             source_binding_ref: SourceBindingRef::new("source-web-resumed").unwrap(),
             reply_target_binding_ref: ReplyTargetBindingRef::new("reply-web-resumed").unwrap(),
             idempotency_key: IdempotencyKey::new("idem-resume-a").unwrap(),
-            auth_resume_disposition: None,
+            resume_disposition: None,
         })
         .await
         .unwrap();
@@ -3824,7 +3824,7 @@ async fn blocked_resume_then_recovery_failure_releases_admission_reservation() {
             source_binding_ref: SourceBindingRef::new("source-web-resumed").unwrap(),
             reply_target_binding_ref: ReplyTargetBindingRef::new("reply-web-resumed").unwrap(),
             idempotency_key: IdempotencyKey::new("idem-resume-a").unwrap(),
-            auth_resume_disposition: None,
+            resume_disposition: None,
         })
         .await
         .unwrap();
@@ -4125,7 +4125,7 @@ async fn resume_updates_persisted_run_binding_refs_and_replay_envelope() {
         source_binding_ref: SourceBindingRef::new("source-web-resumed").unwrap(),
         reply_target_binding_ref: ReplyTargetBindingRef::new("reply-web-resumed").unwrap(),
         idempotency_key: IdempotencyKey::new("idem-resume-a").unwrap(),
-        auth_resume_disposition: None,
+        resume_disposition: None,
     };
 
     let resumed = coordinator
@@ -4473,7 +4473,7 @@ async fn idempotency_persistence_snapshot_retains_each_operation_kind_capacity()
             source_binding_ref: SourceBindingRef::new("source-web-resumed").unwrap(),
             reply_target_binding_ref: ReplyTargetBindingRef::new("reply-web-resumed").unwrap(),
             idempotency_key: IdempotencyKey::new("idem-resume-a").unwrap(),
-            auth_resume_disposition: None,
+            resume_disposition: None,
         })
         .await
         .unwrap();
@@ -4572,7 +4572,7 @@ async fn idempotency_replay_helpers_require_matching_operation_kind() {
             source_binding_ref: SourceBindingRef::new("source-web-resumed").unwrap(),
             reply_target_binding_ref: ReplyTargetBindingRef::new("reply-web-resumed").unwrap(),
             idempotency_key: IdempotencyKey::new("idem-resume-a").unwrap(),
-            auth_resume_disposition: None,
+            resume_disposition: None,
         })
         .await
         .unwrap();
@@ -5374,7 +5374,7 @@ async fn blocked_run_persists_checkpoint_and_keeps_same_thread_lock_until_resume
         source_binding_ref: SourceBindingRef::new("source-web").unwrap(),
         reply_target_binding_ref: ReplyTargetBindingRef::new("reply-web").unwrap(),
         idempotency_key: IdempotencyKey::new("idem-resume-a").unwrap(),
-        auth_resume_disposition: None,
+        resume_disposition: None,
     };
     let resumed = coordinator
         .resume_turn(resume_request.clone())
@@ -5432,7 +5432,7 @@ async fn resume_turn_rejects_unexpected_blocked_status_without_requeueing_run() 
             source_binding_ref: SourceBindingRef::new("source-web").unwrap(),
             reply_target_binding_ref: ReplyTargetBindingRef::new("reply-web").unwrap(),
             idempotency_key: IdempotencyKey::new("idem-resume-wrong-status").unwrap(),
-            auth_resume_disposition: None,
+            resume_disposition: None,
         })
         .await
         .unwrap_err();
@@ -5500,7 +5500,7 @@ async fn resume_turn_from_foreign_actor_is_denied_without_requeueing_run() {
             source_binding_ref: SourceBindingRef::new("source-web").unwrap(),
             reply_target_binding_ref: ReplyTargetBindingRef::new("reply-web").unwrap(),
             idempotency_key: IdempotencyKey::new("idem-resume-foreign-actor").unwrap(),
-            auth_resume_disposition: None,
+            resume_disposition: None,
         })
         .await
         .unwrap_err();
@@ -5643,7 +5643,7 @@ async fn resume_turn_with_wrong_gate_resolution_ref_is_invalid_request() {
             source_binding_ref: SourceBindingRef::new("source-web").unwrap(),
             reply_target_binding_ref: ReplyTargetBindingRef::new("reply-web").unwrap(),
             idempotency_key: IdempotencyKey::new("idem-resume-wrong-gate").unwrap(),
-            auth_resume_disposition: None,
+            resume_disposition: None,
         })
         .await
         .unwrap_err();
@@ -6072,7 +6072,7 @@ async fn any_blocked_gate_resume_does_not_resume_dependent_run_gate() {
             source_binding_ref: SourceBindingRef::new("source-web").unwrap(),
             reply_target_binding_ref: ReplyTargetBindingRef::new("reply-web").unwrap(),
             idempotency_key: IdempotencyKey::new("idem-dependent-resume-any").unwrap(),
-            auth_resume_disposition: None,
+            resume_disposition: None,
         })
         .await
         .unwrap_err();
@@ -6610,7 +6610,7 @@ impl TurnRunTransitionPort for AtomicLoopExitPort {
             failure: None,
             event_cursor: EventCursor(1),
             product_context: None,
-            auth_resume_disposition: None,
+            resume_disposition: None,
         })
     }
 }
@@ -7246,10 +7246,10 @@ async fn submit_child_run_inherits_parent_product_context() {
     );
 }
 
-// Persistence path: resume_turn with auth_resume_disposition writes the field onto the run
+// Persistence path: resume_turn with resume_disposition writes the field onto the run
 // record, and claim_next_run returns a TurnRunState that carries the same value.
 #[tokio::test]
-async fn resume_turn_auth_resume_disposition_is_persisted_and_visible_on_claim() {
+async fn resume_turn_resume_disposition_is_persisted_and_visible_on_claim() {
     let (coordinator, store) = coordinator();
     let run_id = accepted_run_id(
         &coordinator
@@ -7306,7 +7306,7 @@ async fn resume_turn_auth_resume_disposition_is_persisted_and_visible_on_claim()
     );
 
     // Resume with Denied disposition — this is the auth-deny path.
-    let denied_disposition = ironclaw_turns::AuthResumeDisposition::Denied;
+    let denied_disposition = ironclaw_turns::GateResumeDisposition::Denied;
     coordinator
         .resume_turn(ResumeTurnRequest {
             scope: scope("thread-auth-deny-persist"),
@@ -7317,12 +7317,12 @@ async fn resume_turn_auth_resume_disposition_is_persisted_and_visible_on_claim()
             source_binding_ref: SourceBindingRef::new("source-auth-deny").unwrap(),
             reply_target_binding_ref: ReplyTargetBindingRef::new("reply-auth-deny").unwrap(),
             idempotency_key: IdempotencyKey::new("idem-auth-deny-persist-resume").unwrap(),
-            auth_resume_disposition: Some(denied_disposition.clone()),
+            resume_disposition: Some(denied_disposition.clone()),
         })
         .await
         .unwrap();
 
-    // Claim the re-queued run and assert auth_resume_disposition is propagated.
+    // Claim the re-queued run and assert resume_disposition is propagated.
     let claimed = store
         .claim_next_run(ClaimRunRequest {
             runner_id: TurnRunnerId::new(),
@@ -7334,9 +7334,9 @@ async fn resume_turn_auth_resume_disposition_is_persisted_and_visible_on_claim()
         .expect("run must be claimable after auth-deny resume");
 
     assert_eq!(
-        claimed.state.auth_resume_disposition,
+        claimed.state.resume_disposition,
         Some(denied_disposition),
-        "auth_resume_disposition must be visible on the claimed TurnRunState"
+        "resume_disposition must be visible on the claimed TurnRunState"
     );
 
     // Self-clearing contract: a subsequent normal resume (disposition: None) clears the field.
@@ -7368,7 +7368,7 @@ async fn resume_turn_auth_resume_disposition_is_persisted_and_visible_on_claim()
             source_binding_ref: SourceBindingRef::new("source-auth-deny-2").unwrap(),
             reply_target_binding_ref: ReplyTargetBindingRef::new("reply-auth-deny-2").unwrap(),
             idempotency_key: IdempotencyKey::new("idem-auth-deny-persist-resume-2").unwrap(),
-            auth_resume_disposition: None,
+            resume_disposition: None,
         })
         .await
         .unwrap();
@@ -7384,8 +7384,8 @@ async fn resume_turn_auth_resume_disposition_is_persisted_and_visible_on_claim()
         .expect("run must be claimable after second resume");
 
     assert_eq!(
-        claimed2.state.auth_resume_disposition, None,
-        "auth_resume_disposition must be None after a resume that supplies no disposition"
+        claimed2.state.resume_disposition, None,
+        "resume_disposition must be None after a resume that supplies no disposition"
     );
 }
 

--- a/crates/ironclaw_webui_v2_static/src/assets.rs
+++ b/crates/ironclaw_webui_v2_static/src/assets.rs
@@ -111,14 +111,13 @@ mod tests {
     }
 
     #[test]
-    fn chat_cancelled_gate_resolution_exits_processing_state() {
+    fn chat_gate_resolution_always_resumes_run() {
         let use_chat = asset_text("js/pages/chat/hooks/useChat.js");
-        assert!(
-            use_chat
-                .contains("resolution === \"approved\" || resolution === \"credential_provided\"")
-        );
-        assert!(use_chat.contains("setIsProcessing(shouldContinueProcessing);"));
-        assert!(use_chat.contains("setActiveRun(null);"));
+        // Every gate resolution resumes the run; there is no shouldContinueProcessing
+        // conditional. The terminal run_status SSE event is what clears processing.
+        assert!(use_chat.contains("setPendingGate(null);\n      setIsProcessing(true);"));
+        // activeRun is NOT cleared inside resolveGate — the run keeps going.
+        assert!(!use_chat.contains("setIsProcessing(shouldContinueProcessing);"));
 
         let events = asset_text("js/pages/chat/lib/useChatEvents.js");
         assert!(events.contains("TERMINAL_RUN_STATUSES.has(status)"));

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/hooks/useChat.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/hooks/useChat.js
@@ -440,13 +440,13 @@ export function useChat(threadId) {
         always: opts.always,
         credentialRef: opts.credentialRef,
       });
-      const shouldContinueProcessing =
-        resolution === "approved" || resolution === "credential_provided";
+      // Every gate resolution (approved, denied, credential_provided, cancelled)
+      // resumes the run on the backend. Keep processing and preserve activeRun so
+      // the browser stays in sync with the continuing run. The terminal run_status
+      // SSE event (completed/failed/cancelled) is what clears processing naturally.
+      // Run termination is the separate cancelRun (X button) path.
       setPendingGate(null);
-      setIsProcessing(shouldContinueProcessing);
-      if (!shouldContinueProcessing) {
-        setActiveRun(null);
-      }
+      setIsProcessing(true);
     },
     [pendingGate, threadId],
   );

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/useChat-send.test.mjs
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/useChat-send.test.mjs
@@ -840,3 +840,124 @@ test("useChat.send: connectable channel fetch failures submit the prompt", async
   assert.equal(response.thread_id, "thread-created");
   assert.equal(loggedErrors[0][0], "Failed to resolve connectable channels:");
 });
+
+function createResolveGateContext({ stateUpdates = [] } = {}) {
+  // useChat state call order: cooldownUntil(0), now(1), activeRun(2),
+  // channelConnectAction(3), isProcessing(4), pendingGate(5).
+  const pendingGate = { runId: "run-1", gateRef: "gate-1" };
+  const context = {
+    AbortController,
+    Date,
+    Error,
+    Map,
+    Math,
+    React: createReactStub({
+      initialByIndex: new Map([
+        [2, { runId: "run-1", threadId: "thread-1", status: "running" }],
+        [4, true],
+        [5, pendingGate],
+      ]),
+      setCalls: stateUpdates,
+    }),
+    addPending,
+    toRenderAttachment,
+    toWireAttachment,
+    cancelRunRequest: async () => {},
+    clearTimeout,
+    createThreadRequest: async () => {
+      throw new Error("createThread should not run");
+    },
+    globalThis: {},
+    listConnectableChannels: async () => ({ channels: [] }),
+    looksLikeChannelConnectCommand,
+    queryClient: {
+      fetchQuery: async () => ({ channels: [] }),
+      invalidateQueries: () => {},
+    },
+    recordAcceptedMessageRef,
+    removePending,
+    resolveChannelConnectCommand,
+    resolveGateRequest: async () => {},
+    sendMessage: async () => {
+      throw new Error("sendMessage should not run");
+    },
+    setInterval,
+    setTimeout,
+    submitManualToken: async () => {},
+    useChatEvents: () => () => {},
+    useHistory: () => ({
+      messages: [],
+      hasMore: false,
+      nextCursor: null,
+      isLoading: false,
+      loadHistory: () => {},
+      setMessages: () => {},
+    }),
+    useSSE: () => ({ status: "idle" }),
+  };
+  return context;
+}
+
+test("useChat.resolveGate: denied keeps isProcessing true and does not clear activeRun", async () => {
+  const stateUpdates = [];
+  const context = createResolveGateContext({ stateUpdates });
+
+  vm.runInNewContext(useChatSourceForTest(), context);
+
+  const chat = context.globalThis.__testExports.useChat("thread-1");
+  await chat.resolveGate("denied");
+
+  // pendingGate (index 5) is cleared
+  const pendingGateUpdates = stateUpdates.filter((u) => u.index === 5);
+  assert.equal(pendingGateUpdates.length, 1);
+  assert.equal(pendingGateUpdates[0].value, null);
+
+  // isProcessing (index 4) is set to true — run continues
+  const isProcessingUpdates = stateUpdates.filter((u) => u.index === 4);
+  assert.ok(isProcessingUpdates.length > 0, "isProcessing should be updated");
+  const lastIsProcessing = isProcessingUpdates[isProcessingUpdates.length - 1];
+  assert.equal(lastIsProcessing.value, true);
+
+  // activeRun (index 2) is NOT cleared by resolveGate
+  const activeRunClears = stateUpdates.filter(
+    (u) => u.index === 2 && u.value === null,
+  );
+  assert.equal(activeRunClears.length, 0, "resolveGate must not clear activeRun");
+});
+
+test("useChat.resolveGate: cancelled keeps isProcessing true and does not clear activeRun", async () => {
+  const stateUpdates = [];
+  const context = createResolveGateContext({ stateUpdates });
+
+  vm.runInNewContext(useChatSourceForTest(), context);
+
+  const chat = context.globalThis.__testExports.useChat("thread-1");
+  await chat.resolveGate("cancelled");
+
+  // isProcessing (index 4) is set to true — run continues
+  const isProcessingUpdates = stateUpdates.filter((u) => u.index === 4);
+  assert.ok(isProcessingUpdates.length > 0, "isProcessing should be updated");
+  const lastIsProcessing = isProcessingUpdates[isProcessingUpdates.length - 1];
+  assert.equal(lastIsProcessing.value, true);
+
+  // activeRun (index 2) is NOT cleared
+  const activeRunClears = stateUpdates.filter(
+    (u) => u.index === 2 && u.value === null,
+  );
+  assert.equal(activeRunClears.length, 0, "resolveGate must not clear activeRun");
+});
+
+test("useChat.resolveGate: approved also keeps isProcessing true", async () => {
+  const stateUpdates = [];
+  const context = createResolveGateContext({ stateUpdates });
+
+  vm.runInNewContext(useChatSourceForTest(), context);
+
+  const chat = context.globalThis.__testExports.useChat("thread-1");
+  await chat.resolveGate("approved");
+
+  const isProcessingUpdates = stateUpdates.filter((u) => u.index === 4);
+  assert.ok(isProcessingUpdates.length > 0);
+  const lastIsProcessing = isProcessingUpdates[isProcessingUpdates.length - 1];
+  assert.equal(lastIsProcessing.value, true);
+});

--- a/docs/plans/2026-06-15-reborn-approval-deny-continue.md
+++ b/docs/plans/2026-06-15-reborn-approval-deny-continue.md
@@ -159,6 +159,6 @@ extension-install loop is only fully resolved when both land.
 - Executor: denied approval-resume fails only the matching capability,
   unrelated parallel calls proceed; batch policy recomputed; disposition
   consumed once; checkpoint round-trip of
-  `Some(ApprovalResumeDisposition::Denied)`.
+  `Some(GateResumeDisposition::Denied)`.
 - Serde: `ResumeTurnRequest` / `TurnRunRecord` missing-field defaults to
   None.

--- a/docs/plans/2026-06-15-reborn-approval-deny-continue.md
+++ b/docs/plans/2026-06-15-reborn-approval-deny-continue.md
@@ -138,12 +138,23 @@ extension-install loop is only fully resolved when both land.
   approval store (product_workflow boundary), so carry the disposition
   via the resume request rather than reading durable `ApprovalStatus`
   in the executor.
-- **Q3 — RESOLVED (maintainer). Both continue.** Keep both
-  `WebUiGateResolution::Denied` and `::Cancelled` → `Deny` → resume +
-  continue, consistent with #4944. No `Cancel` decision variant. The
-  approach reviewer's dismiss-vs-refuse distinction is acknowledged but
-  not adopted: consistency with the auth path and minimal surface win.
-  (Step 5 stands as written.)
+- **Q3 — RESOLVED (maintainer). Both continue; deny/cancel unified.**
+  Every *gate resolution* the UI sends now resumes the run: the approval
+  card sends `denied`; the auth cards send `cancelled` (their only
+  negative = "won't provide credential"). Neither gate has a separate
+  stop button — **run termination is the separate X → `cancelRun` route**,
+  not a gate resolution. Because `Denied` and `Cancelled` are therefore
+  treated identically everywhere, the two `WebUiGateResolution` variants
+  were unified into a single **`Declined`** variant (serde aliases
+  `"denied"`/`"cancelled"` keep the wire stable; no JS change). Facade
+  maps `Declined → Deny` for both auth and approval. No `Cancel` decision
+  variant — stopping is `cancelRun`, already separate.
+- **#6 (WebUI) — RESOLVED.** `useChat.resolveGate` previously kept
+  processing only for `approved`/`credential_provided`, dropping
+  processing + `activeRun` on `denied`/`cancelled` — but those now
+  resume. Fixed: `resolveGate` always keeps processing/`activeRun` (the
+  terminal `run_status` SSE event clears it; the X/`cancelRun` is the
+  only stop). Also fixes the latent auth-`cancelled` desync from #4944.
 - **Q4 — RESOLVED (maintainer). Separate PRs, rollout-gated together.**
   This plan (PR1) ships only approval deny → continue. The
   `extension_install`/`extension_search` model-visible observation fix

--- a/docs/plans/2026-06-15-reborn-approval-deny-continue.md
+++ b/docs/plans/2026-06-15-reborn-approval-deny-continue.md
@@ -1,0 +1,164 @@
+# Reborn approval-gate denial: surface to model and continue (mirror #4944)
+
+Status: PLAN (reviewed — approach/local-patterns/maintainability)
+Date: 2026-06-15
+Mirrors: #4944 (auth-gate deny → resume + continue) — MERGED to main as
+c3b4a4d94. The auth disposition plumbing this plan generalizes is already
+on main; this is not a stacked branch. (Local checkout 883c576f6 predates
+the merge — pull main before implementing.)
+
+## Problem
+
+Approval-gate denial in Reborn cancels the run instead of telling the
+model. When a `BlockedApproval` run is denied:
+
+- `DefaultApprovalInteractionService::deny_gate`
+  (`crates/ironclaw_product_workflow/src/approval_interaction/service.rs:290`)
+  marks the approval record `Denied`, then calls
+  `turn_coordinator.cancel_run(...)` and returns
+  `ResolveApprovalInteractionResponse::Denied(CancelRunResponse)`.
+- The idempotent replay arm `replay_denied_gate` (service.rs:351) also
+  `cancel_run`s.
+- The WebUI facade maps BOTH resolutions to deny:
+  `WebUiGateResolution::Denied | ::Cancelled => ApprovalInteractionDecision::Deny`
+  (`crates/ironclaw_product_workflow/src/reborn_services.rs:3105`).
+
+This is the same loop class #4944 just removed for auth gates: the run
+terminates `Cancelled`, the model never learns the user declined the
+action, and the next trigger re-issues the same approval-gated
+capability and re-blocks. The user-visible symptom (extension-install
+flow): pressing Deny/Cancel "didn't return anything from the LLM and
+just put me in the same loop."
+
+## Goal
+
+Mirror #4944 for approval gates: denial RESUMES the parked run carrying
+a denial disposition. The capability stage converts ONLY the
+approval-gated call into a model-visible non-retryable failure
+(Authorization / `SameCallRetryConstraint::Forbidden`) and the loop
+continues. Other parallel calls in the same batch are unaffected.
+
+Non-goal: changing approval *approve* behavior, persistent
+always-allow policy, lease issuance, or signing/attested approvals.
+
+## Existing reusable plumbing (from #4944)
+
+- `ResumeTurnRequest` already carries a typed disposition for auth
+  (`auth_resume_disposition`); `TurnRunRecord`/`TurnRunState` persist it
+  via serde-default (no DB migration — run record is a JSON blob).
+- `PendingApprovalResume` already exists as the approval analog of
+  `PendingAuthResume` (`crates/ironclaw_agent_loop/src/state.rs:101`),
+  and the capability stage already gates approval-resume by
+  `capability_id` (the approval match path the #4944 reviewers cited at
+  capabilities.rs:212).
+- The capability-stage denied-resume short-circuit pattern (partition
+  `visible_calls` by `capability_id`, synthesize one Forbidden failure
+  via `handle_capability_error` with empty `safe_summary` + planner
+  summary, recompute batch policy after partition, single-ownership
+  take) is already implemented for auth and is the template to reuse.
+- Durable `ApprovalStatus::Denied` already exists in run-state
+  (`crates/ironclaw_run_state/src/lib.rs:67`).
+
+## Proposed change
+
+1. **Carrier (UNIFIED — resolves Q1 per maintainability review).** Do
+   NOT add a parallel `ApprovalResumeDisposition`. Instead rename
+   `AuthResumeDisposition` → `GateResumeDisposition` (one shared enum in
+   `ironclaw_turns`, unit variant `Denied`) and collapse
+   `ResumeTurnRequest.auth_resume_disposition` → `resume_disposition:
+   Option<GateResumeDisposition>`. Both `PendingAuthResume.disposition`
+   and the new `PendingApprovalResume.disposition` become
+   `Option<GateResumeDisposition>`. The `precondition`
+   (`BlockedAuthGate` vs `BlockedApprovalGate`) already carries the
+   gate-kind branch, so the disposition needs no per-kind type. Two
+   consumers exist today (auth + approval) — this is de-duplication, not
+   speculative generality. Persisted on `TurnRunRecord`/`TurnRunState`
+   via serde-default; the rename is serde-compatible only if the wire
+   tag is held stable (keep `#[serde(rename = "auth_resume_disposition")]`
+   on the field, or add a `#[serde(alias)]`, and add a legacy-JSON
+   round-trip test — the field is in persisted run records).
+
+2. **Service.** Replace `deny_gate`'s `cancel_run` with a
+   `resume_denied_approval` that:
+   - marks the approval record `Denied` (unchanged durable write), then
+   - `resume_turn(precondition = BlockedApprovalGate,
+     approval_resume_disposition = Some(Denied))`, returning
+     `ResolveApprovalInteractionResponse::Resumed(ResumeTurnResponse)`.
+   - `replay_denied_gate` becomes an idempotent resume with the same
+     terminal-run guard #4944 added (`TurnStatus::is_terminal()` →
+     Cancelled maps to a cancelled response, other terminal → StaleGate,
+     non-terminal + disposition present → Resumed).
+
+3. **Executor (SHARED HELPER — resolves code-judo review).**
+   `PlannedDriver::resume` stamps `pending_approval_resume.disposition`
+   from `request.resume_disposition`. Do NOT copy the auth denied
+   short-circuit a second time. Extract the existing auth block in
+   `CapabilityStage::process` into one private helper
+   `short_circuit_denied_resume(state, denied_capability_id,
+   planner_summary, batch)` that: partitions `visible_calls` by the
+   denied `capability_id`, fails only the matching call with
+   `CapabilityFailureKind::Authorization` + empty `safe_summary`,
+   recomputes batch policy after partition, consumes the disposition
+   once. Both the auth path and the approval path call it; each call
+   site is one `if disposition == Denied` check plus the shared call.
+   Planner summary: `"approval gate denied by user"` (mirrors the auth
+   sibling `"auth gate denied by user"`; passes `validate_loop_safe_summary`
+   since it contains neither `"authorization:"`).
+
+4. **Response type.** `ResolveApprovalInteractionResponse` gains
+   `Resumed(ResumeTurnResponse)`; `Denied(CancelRunResponse)` is removed
+   (mirrors #4944 L-b deleting `DenialResumed`). Callers in
+   `workflow.rs` / `reborn_services.rs` collapse to the resumed path.
+
+5. **Cancel vs Deny.** Keep both `WebUiGateResolution::Denied` and
+   `::Cancelled` mapping to `ApprovalInteractionDecision::Deny` →
+   resume + continue, matching #4944's final decision and the user's
+   stated intent ("approval cancel also doing the same"). No new
+   `Cancel` decision variant.
+
+## Separate but related: extension-install observation gap
+
+Even with deny→continue, the resumed model stays blind if the tool
+result carries no model-visible observation. `extension_install` /
+`extension_search` return results that hit the
+`append_capability_safe_summary_ref` path
+(`crates/ironclaw_agent_loop/src/executor/capabilities.rs:870`) with
+`model_observation = None` (capabilities.rs:807), so the model sees
+"safe summary only" and re-calls. This is an orthogonal
+missing-observation bug, not fixed by the deny path. Tracked
+separately; the deny-continue plan does not depend on it, but the
+extension-install loop is only fully resolved when both land.
+
+## Decisions
+
+- **Q1 — RESOLVED (maintainability review).** Use one unified
+  `GateResumeDisposition`, not a parallel approval-specific enum. See
+  Step 1.
+- **Q2 — RESOLVED.** `ironclaw_agent_loop` must not depend on the
+  approval store (product_workflow boundary), so carry the disposition
+  via the resume request rather than reading durable `ApprovalStatus`
+  in the executor.
+- **Q3 — RESOLVED (maintainer). Both continue.** Keep both
+  `WebUiGateResolution::Denied` and `::Cancelled` → `Deny` → resume +
+  continue, consistent with #4944. No `Cancel` decision variant. The
+  approach reviewer's dismiss-vs-refuse distinction is acknowledged but
+  not adopted: consistency with the auth path and minimal surface win.
+  (Step 5 stands as written.)
+- **Q4 — RESOLVED (maintainer). Separate PRs, rollout-gated together.**
+  This plan (PR1) ships only approval deny → continue. The
+  `extension_install`/`extension_search` model-visible observation fix
+  is a separate PR2. Neither enables the user-visible extension-install
+  path until BOTH land — gate the rollout so deny-continue cannot
+  produce a new blind loop on its own. PR1 must carry a note that the
+  extension-install loop is not closed until PR2 ships.
+
+## Test plan
+
+- Service: parked approval gate + Deny resumes (not cancels); idempotent
+  replay against terminal vs non-terminal run; get_run_state error path.
+- Executor: denied approval-resume fails only the matching capability,
+  unrelated parallel calls proceed; batch policy recomputed; disposition
+  consumed once; checkpoint round-trip of
+  `Some(ApprovalResumeDisposition::Denied)`.
+- Serde: `ResumeTurnRequest` / `TurnRunRecord` missing-field defaults to
+  None.

--- a/tests/support/reborn/harness.rs
+++ b/tests/support/reborn/harness.rs
@@ -1184,7 +1184,7 @@ impl RebornBinaryE2EHarness {
                 source_binding_ref: SourceBindingRef::new("src:resume")?,
                 reply_target_binding_ref: ReplyTargetBindingRef::new("reply:resume")?,
                 idempotency_key: IdempotencyKey::new(idempotency_key.into())?,
-                auth_resume_disposition: None,
+                resume_disposition: None,
             })
             .await?;
         if response.status != TurnStatus::Queued {


### PR DESCRIPTION
## Problem

Approval-gate denial in Reborn **cancelled the run** (`deny_gate` /
`replay_denied_gate` → `cancel_run`), so the model never learned the user
declined and the next trigger re-issued the same approval-gated capability and
re-blocked — the same loop class #4944 removed for **auth** gates. User-visible
symptom (extension-install flow): pressing Deny/Cancel "didn't return anything
from the LLM and just put me in the same loop."

## Fix

Mirror #4944 for approval gates: denial now **resumes** the parked run carrying a
denial disposition. The capability stage converts **only** the approval-gated
call into a model-visible non-retryable `Authorization` failure (`"approval gate
denied by user"`, `SameCallRetryConstraint::Forbidden`) and the loop continues.
Unrelated parallel calls in the same batch are unaffected (partition-by-
capability-id, batch policy recomputed after partition — the guarantees #4944's
review established).

## Unify, don't duplicate (per plan review — maintainability lens)

- **`ironclaw_turns`** — `AuthResumeDisposition` → **`GateResumeDisposition`** (one
  gate-agnostic enum); field `auth_resume_disposition` → `resume_disposition` on
  `ResumeTurnRequest`/`TurnRunRecord`/`TurnRunState`/`AgentLoopDriverResumeRequest`.
  Serde key pinned to `"auth_resume_disposition"` (rename attr) so persisted run
  records still deserialize; **legacy-key round-trip test added**.
- **`ironclaw_agent_loop`** — `PendingApprovalResume` gains a `disposition`; the
  auth denied short-circuit in `CapabilityStage::process` is extracted into **one
  shared `short_circuit_denied_resume` helper** used by both auth and approval
  paths (no second copy).
- **`ironclaw_product_workflow`** — approval `deny_gate` / `replay_denied_gate`
  resume instead of cancel; `ResolveApprovalInteractionResponse::Denied(
  CancelRunResponse)` → `Resumed(ResumeTurnResponse)`; idempotent replay guarded
  by terminal run status.
- **`ironclaw_reborn`** — `PlannedDriver::resume` stamps the disposition onto the
  pending resume that is set (auth or approval).

## Decisions

Plan: `docs/plans/2026-06-15-reborn-approval-deny-continue.md` (reviewed in
plan-mode by approach / local-patterns / maintainability lenses).

- **Q3 — both `Denied` and `Cancelled` continue**, consistent with #4944. No
  `Cancel` decision variant.
- **Q4 — the `extension_install`/`extension_search` missing-observation gap is a
  separate PR2.** The user-visible extension-install loop is only fully closed
  when both land — gate the rollout so deny-continue cannot produce a new blind
  loop on its own.

## Test plan

- Phased build (turns keystone → agent_loop ∥ product_workflow ∥ loop_support →
  reborn → composition).
- New coverage: legacy-key serde round-trip (turns); `PendingApprovalResume`
  denied-disposition checkpoint round-trip; caller-level denied-approval
  short-circuit fails only the matching call while an unrelated parallel call
  proceeds (agent_loop); parked-gate deny resumes + idempotent terminal-run
  replay guard + `get_run_state` error path (product_workflow); precondition
  stamping (reborn).
- `cargo fmt --all` clean · `cargo check --workspace --all-features` clean ·
  `cargo clippy --all --benches --tests --examples --all-features` **zero
  warnings** · `cargo check -p ironclaw_reborn_composition --features
  slack-v2-host-beta` clean · `cargo test --workspace` green (one pre-existing
  flaky SQLite-pool test `identity_files_not_in_list_from_secondary_scope`,
  file untouched by this branch, passes in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)