### PR TITLE
[codex] Recover invalid model output in loop

### DIFF
--- a/crates/ironclaw_agent_loop/src/executor/canonical.rs
+++ b/crates/ironclaw_agent_loop/src/executor/canonical.rs
@@ -137,6 +137,7 @@ impl DefaultExecutorPipeline {
                             ModelInput {
                                 state,
                                 messages: prompt.messages,
+                                inline_messages: prompt.inline_messages,
                                 surface_version: prompt.surface.version.clone(),
                                 capability_view: prompt.capability_view,
                             },

--- a/crates/ironclaw_agent_loop/src/executor/capabilities.rs
+++ b/crates/ironclaw_agent_loop/src/executor/capabilities.rs
@@ -15,7 +15,7 @@ use crate::{
     state::{CheckpointKind, LoopExecutionState},
     strategies::{
         BatchPolicy, CapabilityBatchTurnSummary, CapabilityErrorClass, CapabilityErrorSummary,
-        GateKind, RecoveryOutcome, SanitizedStrategySummary, TurnSummary,
+        GateKind, RecoveryOutcome, RetryAlteration, SanitizedStrategySummary, TurnSummary,
     },
 };
 
@@ -844,6 +844,14 @@ impl CapabilityStage {
                     match CheckpointStage.cancel_if_requested(ctx, state).await? {
                         CancelCheck::Continue(next) => state = *next,
                         CancelCheck::Exit(exit) => return Ok(BatchStep::Exit(exit)),
+                    }
+                    if matches!(
+                        alter.as_ref(),
+                        Some(RetryAlteration::RepairInvalidModelOutput)
+                    ) {
+                        return Err(AgentLoopExecutorError::PlannerContract {
+                            detail: "invalid model output repair retry requires model scope",
+                        });
                     }
                     honor_retry_alteration(alter.as_ref())?;
                     CheckpointStage

--- a/crates/ironclaw_agent_loop/src/executor/loop_exit.rs
+++ b/crates/ironclaw_agent_loop/src/executor/loop_exit.rs
@@ -69,6 +69,7 @@ pub(super) async fn try_final_answer_nudge(
         role: LoopInlineMessageRole::User,
         safe_body,
     });
+    let inline_messages = request.inline_messages.clone();
     let bundle = ctx.host.build_prompt_bundle(request).await.map_err(|_| {
         AgentLoopExecutorError::HostUnavailable {
             stage: HostStage::Prompt,
@@ -86,6 +87,7 @@ pub(super) async fn try_final_answer_nudge(
     // *text*, not from the provider tool array, so it is not sufficient on its own.
     let model_request = LoopModelRequest {
         messages: bundle.messages,
+        inline_messages,
         surface_version: None,
         model_preference,
         capability_view: Some(LoopModelCapabilityView {

--- a/crates/ironclaw_agent_loop/src/executor/mapping.rs
+++ b/crates/ironclaw_agent_loop/src/executor/mapping.rs
@@ -90,6 +90,7 @@ pub(super) fn model_error_class(error: &AgentLoopHostError) -> Option<ModelError
     match error.kind {
         AgentLoopHostErrorKind::Unavailable => Some(ModelErrorClass::Unavailable),
         AgentLoopHostErrorKind::Internal => Some(ModelErrorClass::Internal),
+        AgentLoopHostErrorKind::InvalidOutput => Some(ModelErrorClass::InvalidOutput),
         AgentLoopHostErrorKind::BudgetExceeded => Some(ModelErrorClass::ContextOverflow),
         AgentLoopHostErrorKind::BudgetAccountingFailed => Some(ModelErrorClass::Unavailable),
         // Budget approval requirement is a gate, not a transient model
@@ -212,6 +213,19 @@ mod tests {
         assert_eq!(
             capability_failure_kind(&CapabilityFailureKind::PolicyDenied),
             LoopFailureKind::PolicyDenied
+        );
+    }
+
+    #[test]
+    fn invalid_model_output_is_distinct_from_unavailable() {
+        let error = AgentLoopHostError::new(
+            AgentLoopHostErrorKind::InvalidOutput,
+            "model output was structurally invalid",
+        );
+
+        assert_eq!(
+            model_error_class(&error),
+            Some(ModelErrorClass::InvalidOutput)
         );
     }
 }

--- a/crates/ironclaw_agent_loop/src/executor/model.rs
+++ b/crates/ironclaw_agent_loop/src/executor/model.rs
@@ -177,6 +177,7 @@ impl ExecutorStage<ModelInput> for ModelStage {
                                 &state,
                                 surface_version.clone(),
                                 capability_view.clone(),
+                                alter.as_ref(),
                             )
                             .await?;
                             match CheckpointStage.cancel_if_requested(ctx, state).await? {
@@ -244,6 +245,13 @@ async fn apply_model_retry_alteration(
             }
             state.compaction_state.force_compact_on_next_iteration = true;
             return Ok(ModelRetryAction::RetryIteration);
+        }
+        Some(RetryAlteration::RepairInvalidModelOutput) => {
+            if scope != RetryScope::Call {
+                return Err(AgentLoopExecutorError::PlannerContract {
+                    detail: "invalid model output repair retry requires call scope",
+                });
+            }
         }
         Some(RetryAlteration::AdvanceFallback) | None => {}
     }

--- a/crates/ironclaw_agent_loop/src/executor/model.rs
+++ b/crates/ironclaw_agent_loop/src/executor/model.rs
@@ -10,7 +10,10 @@ use tracing::debug;
 
 use crate::{
     state::{CheckpointKind, LoopExecutionState},
-    strategies::{ModelErrorSummary, RecoveryOutcome, RetryAlteration, RetryScope},
+    strategies::{
+        ModelErrorSummary, RecoveryOutcome, RetryAlteration, RetryScope,
+        model_error_to_failure_kind,
+    },
 };
 
 use super::prompt::build_prompt_bundle_for_surface;
@@ -26,6 +29,7 @@ pub(crate) struct ModelStage;
 pub(super) struct ModelInput {
     pub(super) state: LoopExecutionState,
     pub(super) messages: Vec<ironclaw_turns::run_profile::LoopModelMessage>,
+    pub(super) inline_messages: Vec<ironclaw_turns::run_profile::LoopInlineMessage>,
     pub(super) surface_version: ironclaw_turns::run_profile::CapabilitySurfaceVersion,
     pub(super) capability_view: LoopModelCapabilityView,
 }
@@ -69,6 +73,7 @@ impl ExecutorStage<ModelInput> for ModelStage {
         let surface_version = input.surface_version;
         let capability_view = input.capability_view;
         let mut request = LoopModelRequest {
+            inline_messages: input.inline_messages,
             messages: input.messages,
             surface_version: Some(surface_version.clone()),
             model_preference,
@@ -128,7 +133,9 @@ impl ExecutorStage<ModelInput> for ModelStage {
                         });
                     };
                     if !recorded_failure {
-                        state.recent_failure_kinds.push(LoopFailureKind::ModelError);
+                        state
+                            .recent_failure_kinds
+                            .push(model_error_to_failure_kind(class));
                         recorded_failure = true;
                     }
                     let summary = ModelErrorSummary {
@@ -180,6 +187,7 @@ impl ExecutorStage<ModelInput> for ModelStage {
                                 alter.as_ref(),
                             )
                             .await?;
+                            request.inline_messages = bundle.inline_messages();
                             match CheckpointStage.cancel_if_requested(ctx, state).await? {
                                 CancelCheck::Continue(next) => state = *next,
                                 CancelCheck::Exit(exit) => return Ok(ModelStep::Exit(exit)),

--- a/crates/ironclaw_agent_loop/src/executor/prompt.rs
+++ b/crates/ironclaw_agent_loop/src/executor/prompt.rs
@@ -5,9 +5,9 @@ use ironclaw_turns::{
     run_profile::{
         CapabilitySurfaceVersion, CompactionInitiator, LoopCompactionError, LoopCompactionMode,
         LoopCompactionOutcome, LoopCompactionRequest, LoopContextCompactionKind,
-        LoopContextCompactionMetadata, LoopModelCapabilityView, LoopModelMessage,
-        LoopProgressEvent, LoopSafeSummary, SystemInferenceTaskId, VisibleCapabilityRequest,
-        VisibleCapabilitySurface,
+        LoopContextCompactionMetadata, LoopInlineMessage, LoopModelCapabilityView,
+        LoopModelMessage, LoopProgressEvent, LoopSafeSummary, SystemInferenceTaskId,
+        VisibleCapabilityRequest, VisibleCapabilitySurface,
     },
 };
 use std::time::Duration;
@@ -46,6 +46,7 @@ pub(super) struct PromptOutput {
     pub(super) pending_input_ack: PendingInputAck,
     pub(super) surface: VisibleCapabilitySurface,
     pub(super) messages: Vec<ironclaw_turns::run_profile::LoopModelMessage>,
+    pub(super) inline_messages: Vec<LoopInlineMessage>,
     pub(super) capability_view: LoopModelCapabilityView,
     pub(super) rendered_repeated_call_warning: bool,
 }
@@ -87,6 +88,7 @@ pub(super) enum PromptStep {
 
 pub(super) struct BuiltPromptBundle {
     messages: Vec<LoopModelMessage>,
+    inline_messages: Vec<LoopInlineMessage>,
     compaction_message_index: Vec<LoopContextCompactionMetadata>,
     rendered_reply_admission_control: bool,
     rendered_repeated_call_warning: bool,
@@ -112,6 +114,10 @@ impl BuiltPromptBundle {
     ) -> Vec<LoopModelMessage> {
         refresh_compaction_prompt_from_index(state, &self.compaction_message_index);
         self.messages
+    }
+
+    pub(super) fn inline_messages(&self) -> Vec<LoopInlineMessage> {
+        self.inline_messages.clone()
     }
 }
 
@@ -164,8 +170,8 @@ impl FinalPromptBundle {
         Ok(Self { bundle })
     }
 
-    fn into_messages(self) -> Vec<LoopModelMessage> {
-        self.bundle.messages
+    fn into_model_parts(self) -> (Vec<LoopModelMessage>, Vec<LoopInlineMessage>) {
+        (self.bundle.messages, self.bundle.inline_messages)
     }
 
     fn rendered_reply_admission_control(&self) -> bool {
@@ -314,11 +320,14 @@ impl<'a> PromptPlanningPipeline<'a> {
         }
         let rendered_repeated_call_warning = final_bundle.rendered_repeated_call_warning();
 
+        let (messages, inline_messages) = final_bundle.into_model_parts();
+
         Ok(PromptStep::Prepared(Box::new(PromptOutput {
             state: self.state,
             pending_input_ack: self.pending_input_ack,
             surface,
-            messages: final_bundle.into_messages(),
+            messages,
+            inline_messages,
             capability_view,
             rendered_repeated_call_warning,
         })))
@@ -633,6 +642,7 @@ pub(super) async fn build_prompt_bundle_for_surface(
             .inline_messages
             .push(invalid_model_output_repair_control_message());
     }
+    let inline_messages = context_request.inline_messages.clone();
     let prompt_mode = context_request.mode;
     let rendered_reply_admission_control = context_plan.emitted_admission_control;
     let rendered_repeated_call_warning = context_plan.emitted_repeated_call_warning;
@@ -663,6 +673,7 @@ pub(super) async fn build_prompt_bundle_for_surface(
 
     Ok(BuiltPromptBundle {
         messages: prompt_bundle.messages,
+        inline_messages,
         compaction_message_index: prompt_bundle.compaction_message_index,
         rendered_reply_admission_control,
         rendered_repeated_call_warning,

--- a/crates/ironclaw_agent_loop/src/executor/prompt.rs
+++ b/crates/ironclaw_agent_loop/src/executor/prompt.rs
@@ -17,7 +17,9 @@ use crate::state::{
     CheckpointKind, CompactionPromptSnapshot, DeferredCompactionWatermark, IndexedMessageKind,
     LoopExecutionState, MessageIndexEntry,
 };
-use crate::strategies::CompactionDecision;
+use crate::strategies::{
+    CompactionDecision, RetryAlteration, invalid_model_output_repair_control_message,
+};
 
 use super::{
     AgentLoopExecutorError, CancelCheck, CheckpointStage, ExecutorStage, HostStage,
@@ -98,7 +100,8 @@ impl BuiltPromptBundle {
         capability_view: LoopModelCapabilityView,
     ) -> Result<Self, AgentLoopExecutorError> {
         let bundle =
-            build_prompt_bundle_for_surface(ctx, state, surface_version, capability_view).await?;
+            build_prompt_bundle_for_surface(ctx, state, surface_version, capability_view, None)
+                .await?;
         refresh_compaction_prompt_from_index(state, &bundle.compaction_message_index);
         Ok(bundle)
     }
@@ -616,11 +619,20 @@ pub(super) async fn build_prompt_bundle_for_surface(
     state: &LoopExecutionState,
     surface_version: CapabilitySurfaceVersion,
     capability_view: LoopModelCapabilityView,
+    retry_alteration: Option<&RetryAlteration>,
 ) -> Result<BuiltPromptBundle, AgentLoopExecutorError> {
     let context_plan = ctx.planner.context().plan_context_request(state).await;
     let mut context_request = context_plan.request;
     context_request.surface_version = Some(surface_version);
     context_request.capability_view = Some(capability_view);
+    if matches!(
+        retry_alteration,
+        Some(RetryAlteration::RepairInvalidModelOutput)
+    ) {
+        context_request
+            .inline_messages
+            .push(invalid_model_output_repair_control_message());
+    }
     let prompt_mode = context_request.mode;
     let rendered_reply_admission_control = context_plan.emitted_admission_control;
     let rendered_repeated_call_warning = context_plan.emitted_repeated_call_warning;

--- a/crates/ironclaw_agent_loop/src/executor/tests.rs
+++ b/crates/ironclaw_agent_loop/src/executor/tests.rs
@@ -937,6 +937,33 @@ async fn model_shrink_context_call_scope_returns_planner_contract() {
 }
 
 #[tokio::test]
+async fn model_repair_invalid_output_iteration_scope_returns_planner_contract() {
+    let host =
+        MockHost::new(vec![reply_response()]).with_model_errors(vec![AgentLoopHostError::new(
+            AgentLoopHostErrorKind::InvalidOutput,
+            "model output was structurally invalid",
+        )]);
+    let executor = CanonicalAgentLoopExecutor;
+    let state = LoopExecutionState::initial_for_run(host.run_context());
+
+    let err = executor
+        .execute_family(
+            &family_with_repair_invalid_output_iteration_scope_recovery(),
+            &host,
+            state,
+        )
+        .await
+        .expect_err("iteration-scoped invalid-output repair must violate the planner contract");
+
+    assert!(matches!(
+        err,
+        AgentLoopExecutorError::PlannerContract {
+            detail: "invalid model output repair retry requires call scope"
+        }
+    ));
+}
+
+#[tokio::test]
 async fn input_stage_steering_drain_carries_pending_ack() {
     let host = MockHost::new(Vec::new());
     let run_context = host.run_context().clone();
@@ -1153,7 +1180,8 @@ async fn reply_admission_rejects_candidate_before_finalizing_and_continues() {
         .expect("execute");
 
     assert!(matches!(exit, LoopExit::Completed(_)));
-    assert_eq!(host.model_requests().len(), 3);
+    let model_requests = host.model_requests();
+    assert_eq!(model_requests.len(), 3);
     let prompt_requests = host.prompt_requests();
     assert_eq!(prompt_requests.len(), 3);
     assert!(prompt_requests[0].inline_messages.is_empty());
@@ -1163,6 +1191,10 @@ async fn reply_admission_rejects_candidate_before_finalizing_and_continues() {
         "loop control reply rejected stop condition not met continue"
     );
     assert!(prompt_requests[2].inline_messages.is_empty());
+    assert_eq!(
+        model_requests[1].inline_messages,
+        prompt_requests[1].inline_messages
+    );
 
     let before_model_states = host
         .staged_payloads()
@@ -2359,7 +2391,8 @@ async fn model_invalid_output_retry_adds_repair_hint_and_recovers() {
         .expect("execute");
 
     assert!(matches!(exit, LoopExit::Completed(_)));
-    assert_eq!(host.model_requests().len(), 2);
+    let model_requests = host.model_requests();
+    assert_eq!(model_requests.len(), 2);
     let prompt_requests = host.prompt_requests();
     assert_eq!(prompt_requests.len(), 2);
     assert!(prompt_requests[0].inline_messages.is_empty());
@@ -2367,6 +2400,10 @@ async fn model_invalid_output_retry_adds_repair_hint_and_recovers() {
     assert_eq!(
         prompt_requests[1].inline_messages[0].safe_body.as_str(),
         INVALID_MODEL_OUTPUT_REPAIR_CONTROL_TEXT
+    );
+    assert_eq!(
+        model_requests[1].inline_messages,
+        prompt_requests[1].inline_messages
     );
     assert_eq!(final_staged_state(&host).recovery_state, Default::default());
 }
@@ -2401,7 +2438,8 @@ async fn repeated_model_invalid_output_fails_as_invalid_model_output() {
         }
         other => panic!("expected failed invalid-model-output exit, got {other:?}"),
     }
-    assert_eq!(host.model_requests().len(), 3);
+    let model_requests = host.model_requests();
+    assert_eq!(model_requests.len(), 3);
     let prompt_requests = host.prompt_requests();
     assert_eq!(prompt_requests.len(), 3);
     assert!(prompt_requests[0].inline_messages.is_empty());
@@ -2411,6 +2449,16 @@ async fn repeated_model_invalid_output_fails_as_invalid_model_output() {
             .iter()
             .any(|message| message.safe_body.as_str() == INVALID_MODEL_OUTPUT_REPAIR_CONTROL_TEXT)
     }));
+    assert_eq!(
+        model_requests[1].inline_messages,
+        prompt_requests[1].inline_messages
+    );
+    assert!(
+        final_staged_state(&host)
+            .recent_failure_kinds
+            .iter()
+            .any(|kind| *kind == LoopFailureKind::InvalidModelOutput)
+    );
 }
 
 #[tokio::test]
@@ -2625,6 +2673,40 @@ async fn policy_denied_capability_error_honors_retry_recovery() {
     assert!(matches!(exit, LoopExit::Completed(_))); // safety: test-only assertion
     assert_eq!(host.single_invocations().len(), 1); // safety: test-only assertion
     assert_eq!(final_staged_state(&host).recovery_state, Default::default()); // safety: test-only assertion
+}
+
+#[tokio::test]
+async fn capability_repair_invalid_model_output_alteration_is_rejected() {
+    let host = MockHost::new(vec![calls_response()]).with_batch_outcomes(vec![
+        ironclaw_turns::run_profile::CapabilityBatchOutcome {
+            outcomes: vec![CapabilityOutcome::Denied(
+                ironclaw_turns::run_profile::CapabilityDenied {
+                    reason_kind:
+                        ironclaw_turns::run_profile::CapabilityDeniedReasonKind::EmptySurface,
+                    safe_summary: "provider call denied".to_string(),
+                },
+            )],
+            stopped_on_suspension: false,
+        },
+    ]);
+    let executor = CanonicalAgentLoopExecutor;
+    let state = LoopExecutionState::initial_for_run(host.run_context());
+
+    let error = executor
+        .execute_family(
+            &family_with_capability_repair_invalid_output_recovery(),
+            &host,
+            state,
+        )
+        .await
+        .expect_err("capability-scoped invalid-output repair must violate the planner contract");
+
+    assert!(matches!(
+        error,
+        AgentLoopExecutorError::PlannerContract {
+            detail: "invalid model output repair retry requires model scope"
+        }
+    ));
 }
 
 #[tokio::test]

--- a/crates/ironclaw_agent_loop/src/executor/tests.rs
+++ b/crates/ironclaw_agent_loop/src/executor/tests.rs
@@ -23,7 +23,7 @@ use crate::state::{
 };
 use crate::strategies::{
     CapabilityBatchTurnSummary, CapabilityFilter, DefaultCompactionStrategy, GateKind, GateOutcome,
-    StopKind, TurnSummary,
+    INVALID_MODEL_OUTPUT_REPAIR_CONTROL_TEXT, StopKind, TurnSummary,
 };
 use crate::test_support::compaction::{
     active_task_preserving_compaction_index, compaction_metadata,
@@ -2341,6 +2341,76 @@ async fn model_retry_success_clears_recovery_state() {
         ]
     );
     assert_eq!(final_state.compaction_prompt.observed_prompt_tokens, 50);
+}
+
+#[tokio::test]
+async fn model_invalid_output_retry_adds_repair_hint_and_recovers() {
+    let host =
+        MockHost::new(vec![reply_response()]).with_model_errors(vec![AgentLoopHostError::new(
+            AgentLoopHostErrorKind::InvalidOutput,
+            "model output was structurally invalid",
+        )]);
+    let executor = CanonicalAgentLoopExecutor;
+    let state = LoopExecutionState::initial_for_run(host.run_context());
+
+    let exit = executor
+        .execute_family(&crate::families::default(), &host, state)
+        .await
+        .expect("execute");
+
+    assert!(matches!(exit, LoopExit::Completed(_)));
+    assert_eq!(host.model_requests().len(), 2);
+    let prompt_requests = host.prompt_requests();
+    assert_eq!(prompt_requests.len(), 2);
+    assert!(prompt_requests[0].inline_messages.is_empty());
+    assert_eq!(prompt_requests[1].inline_messages.len(), 1);
+    assert_eq!(
+        prompt_requests[1].inline_messages[0].safe_body.as_str(),
+        INVALID_MODEL_OUTPUT_REPAIR_CONTROL_TEXT
+    );
+    assert_eq!(final_staged_state(&host).recovery_state, Default::default());
+}
+
+#[tokio::test]
+async fn repeated_model_invalid_output_fails_as_invalid_model_output() {
+    let host = MockHost::new(Vec::new()).with_model_errors(vec![
+        AgentLoopHostError::new(
+            AgentLoopHostErrorKind::InvalidOutput,
+            "model output was structurally invalid",
+        ),
+        AgentLoopHostError::new(
+            AgentLoopHostErrorKind::InvalidOutput,
+            "model output was structurally invalid",
+        ),
+        AgentLoopHostError::new(
+            AgentLoopHostErrorKind::InvalidOutput,
+            "model output was structurally invalid",
+        ),
+    ]);
+    let executor = CanonicalAgentLoopExecutor;
+    let state = LoopExecutionState::initial_for_run(host.run_context());
+
+    let exit = executor
+        .execute_family(&crate::families::default(), &host, state)
+        .await
+        .expect("execute");
+
+    match exit {
+        LoopExit::Failed(failed) => {
+            assert_eq!(failed.reason_kind, LoopFailureKind::InvalidModelOutput);
+        }
+        other => panic!("expected failed invalid-model-output exit, got {other:?}"),
+    }
+    assert_eq!(host.model_requests().len(), 3);
+    let prompt_requests = host.prompt_requests();
+    assert_eq!(prompt_requests.len(), 3);
+    assert!(prompt_requests[0].inline_messages.is_empty());
+    assert!(prompt_requests[1..].iter().all(|request| {
+        request
+            .inline_messages
+            .iter()
+            .any(|message| message.safe_body.as_str() == INVALID_MODEL_OUTPUT_REPAIR_CONTROL_TEXT)
+    }));
 }
 
 #[tokio::test]

--- a/crates/ironclaw_agent_loop/src/executor/tests/support.rs
+++ b/crates/ironclaw_agent_loop/src/executor/tests/support.rs
@@ -491,6 +491,62 @@ impl RecoveryStrategy for ShrinkContextCallScopeRecoveryStrategy {
     }
 }
 
+pub(super) struct RepairInvalidOutputIterationScopeRecoveryStrategy;
+
+#[async_trait]
+impl RecoveryStrategy for RepairInvalidOutputIterationScopeRecoveryStrategy {
+    async fn on_capability_error(
+        &self,
+        state: &LoopExecutionState,
+        _err: &CapabilityErrorSummary,
+    ) -> RecoveryOutcome {
+        RecoveryOutcome::Abort {
+            recovery: state.recovery_state.clone(),
+            failure_kind: LoopFailureKind::CapabilityProtocolError,
+        }
+    }
+
+    async fn on_model_error(
+        &self,
+        state: &LoopExecutionState,
+        _err: &ModelErrorSummary,
+    ) -> RecoveryOutcome {
+        RecoveryOutcome::Retry {
+            recovery: state.recovery_state.clone(),
+            scope: RetryScope::Iteration,
+            alter: Some(RetryAlteration::RepairInvalidModelOutput),
+        }
+    }
+}
+
+pub(super) struct CapabilityRepairInvalidOutputRecoveryStrategy;
+
+#[async_trait]
+impl RecoveryStrategy for CapabilityRepairInvalidOutputRecoveryStrategy {
+    async fn on_capability_error(
+        &self,
+        state: &LoopExecutionState,
+        _err: &CapabilityErrorSummary,
+    ) -> RecoveryOutcome {
+        RecoveryOutcome::Retry {
+            recovery: state.recovery_state.clone(),
+            scope: RetryScope::Call,
+            alter: Some(RetryAlteration::RepairInvalidModelOutput),
+        }
+    }
+
+    async fn on_model_error(
+        &self,
+        state: &LoopExecutionState,
+        _err: &ModelErrorSummary,
+    ) -> RecoveryOutcome {
+        RecoveryOutcome::Abort {
+            recovery: state.recovery_state.clone(),
+            failure_kind: LoopFailureKind::DriverBug,
+        }
+    }
+}
+
 impl ironclaw_turns::run_profile::LoopRunInfoPort for MockHost {
     fn run_context(&self) -> &LoopRunContext {
         &self.context
@@ -1147,6 +1203,30 @@ pub(super) fn family_with_shrink_context_call_scope_recovery() -> LoopFamily {
     let version = ComponentIdentity::from_static(
         "executor-shrink-context-call-scope-test",
         ComponentDigest([9; 32]),
+    );
+    LoopFamily::new(id, version, Arc::new(planner))
+}
+
+pub(super) fn family_with_repair_invalid_output_iteration_scope_recovery() -> LoopFamily {
+    let planner = DefaultPlanner::compose_default()
+        .with_recovery(Arc::new(RepairInvalidOutputIterationScopeRecoveryStrategy));
+    let id = LoopFamilyId::new("executor-repair-invalid-output-iteration-scope-test")
+        .expect("valid test family id");
+    let version = ComponentIdentity::from_static(
+        "executor-repair-invalid-output-iteration-scope-test",
+        ComponentDigest([10; 32]),
+    );
+    LoopFamily::new(id, version, Arc::new(planner))
+}
+
+pub(super) fn family_with_capability_repair_invalid_output_recovery() -> LoopFamily {
+    let planner = DefaultPlanner::compose_default()
+        .with_recovery(Arc::new(CapabilityRepairInvalidOutputRecoveryStrategy));
+    let id = LoopFamilyId::new("executor-capability-repair-invalid-output-test")
+        .expect("valid test family id");
+    let version = ComponentIdentity::from_static(
+        "executor-capability-repair-invalid-output-test",
+        ComponentDigest([11; 32]),
     );
     LoopFamily::new(id, version, Arc::new(planner))
 }

--- a/crates/ironclaw_agent_loop/src/state/slots.rs
+++ b/crates/ironclaw_agent_loop/src/state/slots.rs
@@ -267,6 +267,7 @@ pub enum RecoveryAttemptClass {
     CapabilityInternal,
     ModelTransient,
     ModelContextOverflow,
+    ModelInvalidOutput,
     ModelUnavailable,
     ModelInternal,
 }

--- a/crates/ironclaw_agent_loop/src/strategies/context.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/context.rs
@@ -7,6 +7,7 @@ use crate::state::{LoopExecutionState, RepeatedCallWarningPhase};
 use crate::strategies::reply_admission::reply_admission_control_message;
 
 pub(crate) const REPEATED_CALL_WARNING_CONTROL_TEXT: &str = "loop control repeated capability call detected change strategy explain new evidence or answer from current evidence";
+pub(crate) const INVALID_MODEL_OUTPUT_REPAIR_CONTROL_TEXT: &str = "loop control previous model response was empty or structurally invalid call an available tool with valid arguments or provide a final answer do not return an empty response";
 
 /// Decides what context the host should materialize for the next model call.
 ///
@@ -123,6 +124,14 @@ pub(crate) fn repeated_call_warning_control_message() -> LoopInlineMessage {
     }
 }
 
+pub(crate) fn invalid_model_output_repair_control_message() -> LoopInlineMessage {
+    LoopInlineMessage {
+        role: LoopInlineMessageRole::System,
+        safe_body: LoopSafeSummary::new(INVALID_MODEL_OUTPUT_REPAIR_CONTROL_TEXT)
+            .expect("static loop-control text is non-empty and safe"), // safety: static safe ASCII words.
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use ironclaw_host_api::{TenantId, ThreadId};
@@ -137,7 +146,9 @@ mod tests {
         },
     };
 
-    use super::{ContextStrategy, DefaultContextStrategy};
+    use super::{
+        ContextStrategy, DefaultContextStrategy, invalid_model_output_repair_control_message,
+    };
     use crate::state::{
         CapabilityCallSignature, LoopExecutionState, RepeatedCallWarningState,
         ReplyAdmissionRejection,
@@ -325,5 +336,19 @@ mod tests {
         assert!(!request.emitted_admission_control);
         assert!(!request.emitted_repeated_call_warning);
         assert!(request.request.inline_messages.is_empty());
+    }
+
+    #[test]
+    fn invalid_model_output_repair_control_message_is_safe_system_inline_message() {
+        let message = invalid_model_output_repair_control_message();
+
+        assert_eq!(
+            message.role,
+            ironclaw_turns::run_profile::LoopInlineMessageRole::System
+        );
+        assert_eq!(
+            message.safe_body.as_str(),
+            super::INVALID_MODEL_OUTPUT_REPAIR_CONTROL_TEXT
+        );
     }
 }

--- a/crates/ironclaw_agent_loop/src/strategies/mod.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/mod.rs
@@ -41,7 +41,10 @@ pub(crate) use compaction::{
     ByteCapStrategy, CompactionDecision, CompactionForceStrategy, CompactionStrategy,
     DefaultCompactionStrategy,
 };
-pub(crate) use context::{ContextPlan, ContextStrategy, DefaultContextStrategy};
+pub(crate) use context::{
+    ContextPlan, ContextStrategy, DefaultContextStrategy, INVALID_MODEL_OUTPUT_REPAIR_CONTROL_TEXT,
+    invalid_model_output_repair_control_message,
+};
 pub(crate) use drain::{DefaultInputDrainStrategy, InputDrainStrategy};
 pub(crate) use gate::{
     DefaultGateHandlingStrategy, GateHandlingStrategy, GateKind, GateOutcome, GateSummary,

--- a/crates/ironclaw_agent_loop/src/strategies/mod.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/mod.rs
@@ -53,7 +53,7 @@ pub(crate) use model::{DefaultModelStrategy, ModelPreference, ModelStrategy};
 pub(crate) use recovery::{
     BackoffDelayMs, CapabilityErrorClass, CapabilityErrorSummary, DefaultRecoveryStrategy,
     ModelErrorClass, ModelErrorSummary, RecoveryOutcome, RecoveryStrategy, RetryAlteration,
-    RetryScope, SanitizedStrategySummary,
+    RetryScope, SanitizedStrategySummary, model_error_to_failure_kind,
 };
 pub(crate) use reply_admission::{
     DefaultReplyAdmissionStrategy, ReplyAdmissionOutcome, ReplyAdmissionStrategy,

--- a/crates/ironclaw_agent_loop/src/strategies/recovery.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/recovery.rs
@@ -418,7 +418,7 @@ fn capability_error_to_failure_kind(class: CapabilityErrorClass) -> LoopFailureK
 }
 
 /// Maps a sanitized model error class to the loop-level failure kind.
-fn model_error_to_failure_kind(class: ModelErrorClass) -> LoopFailureKind {
+pub(crate) fn model_error_to_failure_kind(class: ModelErrorClass) -> LoopFailureKind {
     match class {
         ModelErrorClass::Transient
         | ModelErrorClass::ContextOverflow

--- a/crates/ironclaw_agent_loop/src/strategies/recovery.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/recovery.rs
@@ -130,6 +130,8 @@ pub(crate) enum ModelErrorClass {
     ContextOverflow,
     /// Provider rejected or filtered the content.
     ContentFiltered,
+    /// Provider/model output was structurally invalid for the loop contract.
+    InvalidOutput,
     /// Model route, credentials, or provider is unavailable.
     Unavailable,
     /// Model gateway failed internally without safe caller detail.
@@ -187,8 +189,8 @@ pub(crate) enum RetryScope {
 /// - Retries capability transient, unavailable, and internal errors up to
 ///   [`Self::max_attempts_per_class`] times with `Backoff`, then returns a
 ///   model-visible tool error result.
-/// - Retries model transient, unavailable, and internal errors up to the same
-///   budget, then aborts the run.
+/// - Retries model transient, unavailable, invalid-output, and internal errors
+///   up to the same budget, then aborts the run.
 /// - Retries `ContextOverflow` at iteration scope with `ShrinkContext`.
 #[derive(Debug, Clone, Copy)]
 pub struct DefaultRecoveryStrategy {
@@ -275,6 +277,22 @@ impl RecoveryStrategy for DefaultRecoveryStrategy {
                     kind,
                     RetryScope::Iteration,
                     |_| Some(RetryAlteration::ShrinkContext),
+                )
+            }
+            ModelErrorClass::InvalidOutput => {
+                let Some(attempt_class) = model_retry_attempt_class(err.class) else {
+                    return RecoveryOutcome::Abort {
+                        recovery: state.recovery_state.cleared_attempts(),
+                        failure_kind: LoopFailureKind::DriverBug,
+                    };
+                };
+                retry_or_abort(
+                    state,
+                    attempt_class,
+                    self.max_attempts_per_class,
+                    kind,
+                    RetryScope::Call,
+                    |_| Some(RetryAlteration::RepairInvalidModelOutput),
                 )
             }
             ModelErrorClass::Transient
@@ -378,6 +396,7 @@ fn model_retry_attempt_class(class: ModelErrorClass) -> Option<RecoveryAttemptCl
     match class {
         ModelErrorClass::Transient => Some(RecoveryAttemptClass::ModelTransient),
         ModelErrorClass::ContextOverflow => Some(RecoveryAttemptClass::ModelContextOverflow),
+        ModelErrorClass::InvalidOutput => Some(RecoveryAttemptClass::ModelInvalidOutput),
         ModelErrorClass::Unavailable => Some(RecoveryAttemptClass::ModelUnavailable),
         ModelErrorClass::Internal => Some(RecoveryAttemptClass::ModelInternal),
         ModelErrorClass::ContentFiltered => None,
@@ -406,6 +425,7 @@ fn model_error_to_failure_kind(class: ModelErrorClass) -> LoopFailureKind {
         | ModelErrorClass::ContentFiltered
         | ModelErrorClass::Unavailable
         | ModelErrorClass::Internal => LoopFailureKind::ModelError,
+        ModelErrorClass::InvalidOutput => LoopFailureKind::InvalidModelOutput,
     }
 }
 
@@ -429,6 +449,10 @@ pub(crate) enum RetryAlteration {
     ShrinkContext,
     /// Backoff before retry (executor honors as a sleep).
     Backoff { delay_ms: BackoffDelayMs },
+    /// Rebuild the next model prompt with a model-visible invalid-output repair
+    /// hint. Used when the provider/model returned an empty or structurally
+    /// invalid response for the active loop contract.
+    RepairInvalidModelOutput,
     /// Reserved for future `ModelRouteChain` landing. Skeleton executor MUST
     /// reject this alteration with `LoopFailureKind::DriverBug` until the
     /// chain mechanism lands.
@@ -651,6 +675,18 @@ mod tests {
     fn retry_alteration_advance_fallback_round_trips() {
         let alteration = RetryAlteration::AdvanceFallback;
         let value = serde_json::to_value(&alteration).expect("serialize");
+        let restored: RetryAlteration = serde_json::from_value(value).expect("deserialize");
+        assert_eq!(restored, alteration);
+    }
+
+    #[test]
+    fn retry_alteration_repair_invalid_model_output_round_trips() {
+        let alteration = RetryAlteration::RepairInvalidModelOutput;
+        let value = serde_json::to_value(&alteration).expect("serialize");
+        assert_eq!(
+            value,
+            serde_json::json!({"alteration": "repair_invalid_model_output"})
+        );
         let restored: RetryAlteration = serde_json::from_value(value).expect("deserialize");
         assert_eq!(restored, alteration);
     }
@@ -1037,6 +1073,43 @@ mod tests {
                 .on_model_error(&state, &model_err(ModelErrorClass::Transient))
                 .await;
             assert!(matches!(outcome, RecoveryOutcome::Abort { .. }));
+        }
+
+        #[tokio::test]
+        async fn model_invalid_output_retries_with_repair_then_aborts_at_budget() {
+            let strategy = DefaultRecoveryStrategy::default();
+
+            let state = state_with_no_attempts();
+            let outcome = strategy
+                .on_model_error(&state, &model_err(ModelErrorClass::InvalidOutput))
+                .await;
+            match outcome {
+                RecoveryOutcome::Retry {
+                    recovery,
+                    scope,
+                    alter,
+                } => {
+                    assert_eq!(
+                        recovery.attempts_for(RecoveryAttemptClass::ModelInvalidOutput),
+                        1
+                    );
+                    assert_eq!(scope, RetryScope::Call);
+                    assert_eq!(alter, Some(RetryAlteration::RepairInvalidModelOutput));
+                }
+                other => panic!("expected invalid-output repair retry, got {other:?}"),
+            }
+
+            let state = state_with_attempts_for(2, RecoveryAttemptClass::ModelInvalidOutput);
+            let outcome = strategy
+                .on_model_error(&state, &model_err(ModelErrorClass::InvalidOutput))
+                .await;
+            assert!(matches!(
+                outcome,
+                RecoveryOutcome::Abort {
+                    failure_kind: LoopFailureKind::InvalidModelOutput,
+                    ..
+                }
+            ));
         }
 
         #[tokio::test]

--- a/crates/ironclaw_agent_loop/tests/state_lifecycle.rs
+++ b/crates/ironclaw_agent_loop/tests/state_lifecycle.rs
@@ -3,8 +3,8 @@ use ironclaw_agent_loop::{
     families,
     state::{
         CapabilityCallSignature, CheckpointKind, CheckpointPayloadError,
-        DeferredCompactionWatermark, LoopExecutionState, RepeatedCallWarningPhase,
-        RepeatedCallWarningState,
+        DeferredCompactionWatermark, LoopExecutionState, RecoveryAttemptClass,
+        RecoveryStrategyState, RepeatedCallWarningPhase, RepeatedCallWarningState,
     },
     test_support::{
         LoopExecutionStateBuilder, MockAgentLoopDriverHost, ScenarioScript, capability_id,
@@ -53,6 +53,27 @@ fn state_serializes_round_trips_with_last_deferred_compaction_watermark() {
             through_seq: 42,
             prompt_fingerprint: 7_777,
         })
+    );
+}
+
+#[test]
+fn model_invalid_output_recovery_attempts_survive_checkpoint_reload() {
+    let context = test_run_context("model-invalid-output-recovery-round-trip");
+    let mut state = LoopExecutionState::initial_for_run(&context);
+    state.recovery_state =
+        RecoveryStrategyState::with_attempts_for(RecoveryAttemptClass::ModelInvalidOutput, 2);
+
+    let payload = serde_json::to_vec(&state).expect("state should serialize");
+    let restored =
+        LoopExecutionState::from_checkpoint_payload(&payload, CheckpointKind::BeforeModel)
+            .expect("checkpoint payload should reload");
+
+    assert_eq!(restored.recovery_state, state.recovery_state);
+    assert_eq!(
+        restored
+            .recovery_state
+            .attempts_for(RecoveryAttemptClass::ModelInvalidOutput),
+        2
     );
 }
 

--- a/crates/ironclaw_hooks/src/middleware/model_port.rs
+++ b/crates/ironclaw_hooks/src/middleware/model_port.rs
@@ -162,6 +162,7 @@ mod tests {
 
     fn request() -> LoopModelRequest {
         LoopModelRequest {
+            inline_messages: Vec::new(),
             messages: Vec::new(),
             surface_version: None,
             model_preference: None,

--- a/crates/ironclaw_loop_support/src/budget_accountant.rs
+++ b/crates/ironclaw_loop_support/src/budget_accountant.rs
@@ -744,6 +744,7 @@ mod tests {
 
     fn sample_request() -> LoopModelRequest {
         LoopModelRequest {
+            inline_messages: Vec::new(),
             messages: vec![],
             surface_version: None,
             model_preference: None,

--- a/crates/ironclaw_loop_support/src/lib.rs
+++ b/crates/ironclaw_loop_support/src/lib.rs
@@ -1674,8 +1674,7 @@ pub enum HostManagedModelErrorKind {
     /// Caller-side misuse of the host model port (unknown tool, malformed request).
     InvalidRequest,
     /// Provider/model output was structurally invalid for the active loop contract.
-    /// This is model-side bad output, not caller misuse — mapped to Unavailable so
-    /// loops can retry on transient provider anomalies.
+    /// This is model-side bad output, not caller misuse.
     #[serde(alias = "invalid_output")]
     InvalidOutput,
     PolicyDenied,
@@ -2022,7 +2021,7 @@ fn model_gateway_error(error: HostManagedModelError) -> AgentLoopHostError {
 fn model_error_kind(kind: HostManagedModelErrorKind) -> AgentLoopHostErrorKind {
     match kind {
         HostManagedModelErrorKind::InvalidRequest => AgentLoopHostErrorKind::InvalidInvocation,
-        HostManagedModelErrorKind::InvalidOutput => AgentLoopHostErrorKind::Unavailable,
+        HostManagedModelErrorKind::InvalidOutput => AgentLoopHostErrorKind::InvalidOutput,
         HostManagedModelErrorKind::PolicyDenied => AgentLoopHostErrorKind::PolicyDenied,
         HostManagedModelErrorKind::ConfigurationError => AgentLoopHostErrorKind::Unavailable,
         HostManagedModelErrorKind::BudgetExceeded => AgentLoopHostErrorKind::BudgetExceeded,

--- a/crates/ironclaw_loop_support/tests/thread_loop_support_contract.rs
+++ b/crates/ironclaw_loop_support/tests/thread_loop_support_contract.rs
@@ -198,6 +198,7 @@ async fn model_port_empty_request_applies_prompt_token_budget_to_context_fallbac
     issue_prompt_grant(&fixture.run_context, &[]);
 
     port.stream_model(LoopModelRequest {
+        inline_messages: Vec::new(),
         messages: Vec::new(),
         surface_version: None,
         model_preference: None,
@@ -254,6 +255,7 @@ async fn prompt_and_model_ports_share_cached_context_window_for_one_request() {
 
     model_port
         .stream_model(LoopModelRequest {
+            inline_messages: Vec::new(),
             messages: prompt_bundle.messages,
             surface_version: prompt_bundle.surface_version,
             model_preference: None,
@@ -346,6 +348,7 @@ async fn context_window_cache_does_not_cross_thread_scope_boundaries() {
 
     model_port
         .stream_model(LoopModelRequest {
+            inline_messages: Vec::new(),
             messages: prompt_bundle.messages,
             surface_version: prompt_bundle.surface_version,
             model_preference: None,
@@ -1226,6 +1229,7 @@ async fn prompt_and_model_ports_materialize_trusted_identity_content() {
 
     model_port
         .stream_model(LoopModelRequest {
+            inline_messages: Vec::new(),
             messages: prompt_bundle.messages,
             surface_version: None,
             model_preference: None,
@@ -1265,6 +1269,7 @@ async fn model_port_limits_provider_tool_definitions_to_model_visible_capability
 
     model_port
         .stream_model(LoopModelRequest {
+            inline_messages: Vec::new(),
             messages,
             surface_version: None,
             model_preference: None,
@@ -1306,6 +1311,7 @@ async fn model_port_maps_invalid_model_output_to_recoverable_model_error() {
 
     let error = model_port
         .stream_model(LoopModelRequest {
+            inline_messages: Vec::new(),
             messages,
             surface_version: None,
             model_preference: None,
@@ -1349,6 +1355,7 @@ async fn model_port_preserves_capability_info_for_filtered_capability_view() {
 
     model_port
         .stream_model(LoopModelRequest {
+            inline_messages: Vec::new(),
             messages,
             surface_version: None,
             model_preference: None,
@@ -1619,6 +1626,7 @@ async fn prompt_and_model_ports_send_selected_skill_context_to_gateway() {
 
     model_port
         .stream_model(LoopModelRequest {
+            inline_messages: Vec::new(),
             messages: prompt_bundle.messages,
             surface_version: None,
             model_preference: None,
@@ -1720,6 +1728,7 @@ async fn prompt_and_model_ports_resolve_skill_refs_after_prompt_sorting() {
 
     model_port
         .stream_model(LoopModelRequest {
+            inline_messages: Vec::new(),
             messages: prompt_bundle.messages,
             surface_version: None,
             model_preference: None,
@@ -1807,6 +1816,7 @@ async fn prompt_and_model_ports_resolve_instruction_memory_and_identity_refs() {
 
     model_port
         .stream_model(LoopModelRequest {
+            inline_messages: Vec::new(),
             messages: prompt_bundle.messages,
             surface_version: None,
             model_preference: None,
@@ -1853,6 +1863,7 @@ async fn model_port_rejects_policy_denied_identity_ref_before_gateway_call() {
 
     let error = model_port
         .stream_model(LoopModelRequest {
+            inline_messages: Vec::new(),
             messages,
             surface_version: None,
             model_preference: None,
@@ -2052,6 +2063,7 @@ async fn prompt_and_model_ports_keep_duplicate_skill_names_distinct() {
 
     model_port
         .stream_model(LoopModelRequest {
+            inline_messages: Vec::new(),
             messages: prompt_bundle.messages,
             surface_version: None,
             model_preference: None,
@@ -2119,6 +2131,7 @@ async fn model_port_rejects_skill_context_refs_when_source_changes_after_prompt_
 
     let error = model_port
         .stream_model(LoopModelRequest {
+            inline_messages: Vec::new(),
             messages: prompt_bundle.messages,
             surface_version: None,
             model_preference: None,
@@ -2830,6 +2843,7 @@ async fn model_port_resolves_thread_message_refs_and_delegates_to_gateway() {
 
     let response = port
         .stream_model(LoopModelRequest {
+            inline_messages: Vec::new(),
             messages,
             surface_version: None,
             model_preference: None,
@@ -2930,6 +2944,7 @@ async fn model_port_reads_image_attachment_bytes_into_model_image_parts() {
     issue_prompt_grant(&fixture.run_context, &messages);
 
     port.stream_model(LoopModelRequest {
+        inline_messages: Vec::new(),
         messages,
         surface_version: None,
         model_preference: None,
@@ -2975,6 +2990,7 @@ async fn model_port_threads_resolved_model_route_snapshot_to_gateway() {
     issue_prompt_grant(&fixture.run_context, &messages);
 
     port.stream_model(LoopModelRequest {
+        inline_messages: Vec::new(),
         messages,
         surface_version: None,
         model_preference: None,
@@ -3018,6 +3034,7 @@ async fn model_port_resolves_explicit_refs_that_fall_outside_context_window() {
     issue_prompt_grant(&fixture.run_context, &messages);
 
     port.stream_model(LoopModelRequest {
+        inline_messages: Vec::new(),
         messages,
         surface_version: None,
         model_preference: None,
@@ -3087,6 +3104,7 @@ async fn model_port_preserves_provider_metadata_for_explicit_refs_outside_contex
     issue_prompt_grant(&fixture.run_context, &messages);
 
     port.stream_model(LoopModelRequest {
+        inline_messages: Vec::new(),
         messages,
         surface_version: None,
         model_preference: None,
@@ -3208,6 +3226,7 @@ async fn model_port_round_trips_tool_result_reference_context_as_typed_model_inp
 
     model_port
         .stream_model(LoopModelRequest {
+            inline_messages: Vec::new(),
             messages,
             surface_version: None,
             model_preference: None,
@@ -3257,6 +3276,7 @@ async fn model_port_rejects_malformed_tool_result_reference_content() {
 
     let error = model_port
         .stream_model(LoopModelRequest {
+            inline_messages: Vec::new(),
             messages,
             surface_version: None,
             model_preference: None,
@@ -3292,6 +3312,7 @@ async fn model_port_emits_model_milestones_without_prompt_or_output_payloads() {
 
     let response = port
         .stream_model(LoopModelRequest {
+            inline_messages: Vec::new(),
             messages,
             surface_version: None,
             model_preference: Some(
@@ -3355,6 +3376,7 @@ async fn model_port_emits_started_and_failed_milestones_when_gateway_fails() {
 
     let error = port
         .stream_model(LoopModelRequest {
+            inline_messages: Vec::new(),
             messages,
             surface_version: None,
             model_preference: None,
@@ -3412,6 +3434,7 @@ async fn model_port_logs_model_started_milestone_failure_without_losing_response
 
     let response = port
         .stream_model(LoopModelRequest {
+            inline_messages: Vec::new(),
             messages,
             surface_version: None,
             model_preference: None,
@@ -3452,6 +3475,7 @@ async fn model_port_logs_model_completed_milestone_failure_without_losing_respon
 
     let response = port
         .stream_model(LoopModelRequest {
+            inline_messages: Vec::new(),
             messages,
             surface_version: None,
             model_preference: None,
@@ -3490,6 +3514,7 @@ async fn model_port_rejects_message_role_that_disagrees_with_thread_record() {
 
     let error = port
         .stream_model(LoopModelRequest {
+            inline_messages: Vec::new(),
             messages,
             surface_version: None,
             model_preference: None,
@@ -3518,6 +3543,7 @@ async fn model_port_surfaces_fail_closed_gateway_policy_errors_without_raw_detai
 
     let error = port
         .stream_model(LoopModelRequest {
+            inline_messages: Vec::new(),
             messages,
             surface_version: None,
             model_preference: None,
@@ -3549,6 +3575,7 @@ async fn model_port_replaces_invalid_gateway_safe_summary_with_stable_summary() 
 
     let error = port
         .stream_model(LoopModelRequest {
+            inline_messages: Vec::new(),
             messages,
             surface_version: None,
             model_preference: None,
@@ -3591,6 +3618,7 @@ async fn model_port_preserves_gateway_safe_reason_kind() {
 
     let error = port
         .stream_model(LoopModelRequest {
+            inline_messages: Vec::new(),
             messages,
             surface_version: None,
             model_preference: None,

--- a/crates/ironclaw_loop_support/tests/thread_loop_support_contract.rs
+++ b/crates/ironclaw_loop_support/tests/thread_loop_support_contract.rs
@@ -1314,7 +1314,7 @@ async fn model_port_maps_invalid_model_output_to_recoverable_model_error() {
         .await
         .unwrap_err();
 
-    assert_eq!(error.kind, AgentLoopHostErrorKind::Unavailable);
+    assert_eq!(error.kind, AgentLoopHostErrorKind::InvalidOutput);
     assert_eq!(
         error.safe_summary,
         "model returned a tool call outside the advertised capability surface"

--- a/crates/ironclaw_reborn/src/model_gateway.rs
+++ b/crates/ironclaw_reborn/src/model_gateway.rs
@@ -231,7 +231,7 @@ where
                 surface_version: request.surface_version.clone(),
                 checkpoint_state_ref: None,
                 max_messages: Some(self.max_messages.min(u32::MAX as usize) as u32),
-                inline_messages: Vec::new(),
+                inline_messages: request.inline_messages.clone(),
                 capability_view: None,
             })
             .await

--- a/crates/ironclaw_reborn/src/model_gateway.rs
+++ b/crates/ironclaw_reborn/src/model_gateway.rs
@@ -1205,6 +1205,7 @@ fn map_capability_host_error(error: AgentLoopHostError) -> HostManagedModelError
         | AgentLoopHostErrorKind::ScopeMismatch
         | AgentLoopHostErrorKind::StaleSurface => HostManagedModelErrorKind::InvalidRequest,
         AgentLoopHostErrorKind::Unavailable
+        | AgentLoopHostErrorKind::InvalidOutput
         | AgentLoopHostErrorKind::CheckpointRejected
         | AgentLoopHostErrorKind::TranscriptWriteFailed
         | AgentLoopHostErrorKind::Internal => HostManagedModelErrorKind::Unavailable,
@@ -1214,12 +1215,12 @@ fn map_capability_host_error(error: AgentLoopHostError) -> HostManagedModelError
 
 fn map_provider_tool_output_error(error: AgentLoopHostError) -> HostManagedModelError {
     match error.kind {
-        AgentLoopHostErrorKind::Invalid | AgentLoopHostErrorKind::InvalidInvocation => {
-            HostManagedModelError::safe(
-                HostManagedModelErrorKind::InvalidOutput,
-                error.safe_summary,
-            )
-        }
+        AgentLoopHostErrorKind::Invalid
+        | AgentLoopHostErrorKind::InvalidInvocation
+        | AgentLoopHostErrorKind::InvalidOutput => HostManagedModelError::safe(
+            HostManagedModelErrorKind::InvalidOutput,
+            error.safe_summary,
+        ),
         _ => map_capability_host_error(error),
     }
 }

--- a/crates/ironclaw_reborn/src/text_loop_driver.rs
+++ b/crates/ironclaw_reborn/src/text_loop_driver.rs
@@ -81,6 +81,7 @@ impl AgentLoopDriver for TextOnlyModelReplyDriver {
 
         let model_response = host
             .stream_model(LoopModelRequest {
+                inline_messages: Vec::new(),
                 messages: prompt_bundle.messages,
                 surface_version: prompt_bundle.surface_version,
                 model_preference: None,
@@ -307,6 +308,25 @@ mod tests {
             mapped,
             AgentLoopDriverError::Failed {
                 reason_kind: MODEL_CREDENTIALS_UNAVAILABLE_CATEGORY.to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn model_invalid_output_maps_to_invalid_model_output_failure() {
+        let mapped = map_host_error(
+            STAGE_MODEL,
+            AgentLoopHostError::new(
+                AgentLoopHostErrorKind::InvalidOutput,
+                "model output was structurally invalid",
+            ),
+        );
+
+        assert_eq!(
+            mapped,
+            AgentLoopDriverError::Failed {
+                reason_kind: loop_failure_kind_name(LoopFailureKind::InvalidModelOutput)
+                    .to_string()
             }
         );
     }

--- a/crates/ironclaw_reborn/src/text_loop_driver.rs
+++ b/crates/ironclaw_reborn/src/text_loop_driver.rs
@@ -210,6 +210,9 @@ fn map_host_error(stage: &'static str, error: AgentLoopHostError) -> AgentLoopDr
         | AgentLoopHostErrorKind::PolicyDenied => AgentLoopDriverError::Failed {
             reason_kind: loop_failure_kind_name(LoopFailureKind::ModelError).to_string(),
         },
+        AgentLoopHostErrorKind::InvalidOutput => AgentLoopDriverError::Failed {
+            reason_kind: loop_failure_kind_name(LoopFailureKind::InvalidModelOutput).to_string(),
+        },
         AgentLoopHostErrorKind::CredentialUnavailable => AgentLoopDriverError::Failed {
             reason_kind: loop_failure_kind_name(LoopFailureKind::ModelError).to_string(),
         },

--- a/crates/ironclaw_reborn/tests/hooks_integration.rs
+++ b/crates/ironclaw_reborn/tests/hooks_integration.rs
@@ -3693,6 +3693,7 @@ async fn after_model_fires_exactly_once_at_durable_boundary() {
         .await
         .expect("build_prompt_bundle succeeds before stream_model");
     host.stream_model(LoopModelRequest {
+        inline_messages: Vec::new(),
         messages: bundle.messages.clone(),
         surface_version: None,
         model_preference: None,

--- a/crates/ironclaw_reborn/tests/llm_gateway.rs
+++ b/crates/ironclaw_reborn/tests/llm_gateway.rs
@@ -357,16 +357,9 @@ async fn gateway_with_tool_surface_calls_complete_with_tools_and_returns_capabil
 
 #[tokio::test]
 async fn gateway_rejects_empty_tool_capable_stop_response_without_text_only_retry() {
-    let provider = Arc::new(ToolAwareProvider::tool_response(ToolCompletionResponse {
-        content: None,
-        tool_calls: Vec::new(),
-        input_tokens: 1,
-        output_tokens: 1,
-        finish_reason: FinishReason::Stop,
-        cache_read_input_tokens: 0,
-        cache_creation_input_tokens: 0,
-        reasoning: None,
-    }));
+    let provider = Arc::new(ToolAwareProvider::tool_response(
+        empty_tool_capable_stop_response(),
+    ));
     let gateway = LlmProviderModelGateway::with_provider_identity(
         STATIC_PROVIDER_ID,
         provider.clone(),
@@ -2639,6 +2632,19 @@ fn resolved_tool_result_content() -> Option<HostManagedToolResultContent> {
     Some(HostManagedToolResultContent::Resolved {
         safe_summary: ToolResultSafeSummary::new("tool completed").unwrap(),
     })
+}
+
+fn empty_tool_capable_stop_response() -> ToolCompletionResponse {
+    ToolCompletionResponse {
+        content: None,
+        tool_calls: Vec::new(),
+        input_tokens: 1,
+        output_tokens: 1,
+        finish_reason: FinishReason::Stop,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+        reasoning: None,
+    }
 }
 
 struct IgnoresModelOverrideProvider {

--- a/crates/ironclaw_reborn/tests/llm_gateway.rs
+++ b/crates/ironclaw_reborn/tests/llm_gateway.rs
@@ -33,9 +33,10 @@ use ironclaw_turns::{
         HostManagedLoopModelPort, HostManagedLoopPromptPort,
         InMemoryInstructionMaterializationStore, InMemoryLoopHostMilestoneSink,
         InMemoryRunProfileResolver, InstructionMaterializationStore, InstructionSafetyContext,
-        LoopCapabilityPort, LoopHostMilestoneKind, LoopModelGateway, LoopModelGatewayRequest,
-        LoopModelMessage, LoopModelPort, LoopModelRequest, LoopPromptBundleRequest, LoopPromptPort,
-        LoopRunContext, LoopRuntimeContext, ModelProfileId, ParentLoopOutput, PromptMode,
+        LoopCapabilityPort, LoopHostMilestoneKind, LoopInlineMessage, LoopInlineMessageRole,
+        LoopModelGateway, LoopModelGatewayRequest, LoopModelMessage, LoopModelPort,
+        LoopModelRequest, LoopPromptBundleRequest, LoopPromptPort, LoopRunContext,
+        LoopRuntimeContext, LoopSafeSummary, ModelProfileId, ParentLoopOutput, PromptMode,
         ProviderToolCall, ProviderToolCallReplay, ProviderToolDefinition, VisibleCapabilityRequest,
         VisibleCapabilitySurface,
     },
@@ -510,6 +511,36 @@ async fn gateway_rejects_unknown_provider_tool_call_before_registration() {
             .allow_model_profile(interactive_model(), Some("host-selected-model".to_string())),
     );
     let capabilities = Arc::new(GatewayCapabilityPort::with_tool_surface());
+
+    let error = gateway
+        .stream_model_with_capabilities(model_request(interactive_model()), capabilities.clone())
+        .await
+        .unwrap_err();
+
+    assert_eq!(error.kind, HostManagedModelErrorKind::InvalidOutput);
+    assert!(capabilities.registered.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn gateway_preserves_invalid_output_from_provider_tool_validation() {
+    let provider = Arc::new(ToolAwareProvider::tool_calls(vec![ToolCall {
+        id: "call_1".to_string(),
+        name: "demo__echo".to_string(),
+        arguments: serde_json::json!({"message":"hello"}),
+        reasoning: None,
+        signature: None,
+        arguments_parse_error: None,
+    }]));
+    let gateway = LlmProviderModelGateway::with_provider_identity(
+        STATIC_PROVIDER_ID,
+        provider,
+        LlmModelProfilePolicy::new()
+            .allow_model_profile(interactive_model(), Some("host-selected-model".to_string())),
+    );
+    let capabilities = Arc::new(
+        GatewayCapabilityPort::with_tool_surface()
+            .with_provider_tool_validation_error(AgentLoopHostErrorKind::InvalidOutput),
+    );
 
     let error = gateway
         .stream_model_with_capabilities(model_request(interactive_model()), capabilities.clone())
@@ -1653,6 +1684,59 @@ async fn production_loop_model_gateway_resolves_thread_refs_and_emits_milestones
     ));
 }
 
+#[tokio::test]
+async fn production_loop_model_gateway_accepts_inline_prompt_messages() {
+    let fixture = ThreadFixture::new().await;
+    let provider = Arc::new(RecordingLlmProvider::reply("inline response"));
+    let provider_gateway = Arc::new(LlmProviderModelGateway::with_provider_identity(
+        STATIC_PROVIDER_ID,
+        provider.clone(),
+        LlmModelProfilePolicy::new()
+            .allow_model_profile(interactive_model(), Some("host-selected-model".to_string())),
+    ));
+    let model_gateway = Arc::new(ThreadBackedLoopModelGateway::new(
+        Arc::clone(&fixture.thread_service),
+        fixture.thread_scope.clone(),
+        provider_gateway,
+        16,
+        local_development_safety_context(),
+    ));
+    let milestones = Arc::new(InMemoryLoopHostMilestoneSink::default());
+    let port = HostManagedLoopModelPort::new(
+        fixture.run_context.clone(),
+        model_gateway,
+        milestones.clone(),
+    );
+    let inline_text = "loop control previous model response was empty or structurally invalid";
+
+    let response = port
+        .stream_model(
+            production_loop_request_with_inline_messages(
+                &fixture,
+                None,
+                vec![LoopInlineMessage {
+                    role: LoopInlineMessageRole::System,
+                    safe_body: LoopSafeSummary::new(inline_text).unwrap(),
+                }],
+            )
+            .await,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.chunks[0].safe_text_delta, "inline response");
+    let requests = provider.requests.lock().unwrap();
+    assert_eq!(requests.len(), 1);
+    assert!(
+        requests[0]
+            .messages
+            .iter()
+            .any(|message| message.role == Role::System && message.content.contains(inline_text)),
+        "provider messages did not include inline control text: {:?}",
+        requests[0].messages
+    );
+}
+
 /// Proves that `HostManagedLoopPromptPort::with_runtime_context` stamps the
 /// loop-start time into the prompt bundle messages and that the materialized
 /// content is resolvable from the shared instruction store. This is
@@ -1997,6 +2081,7 @@ async fn production_loop_model_gateway_rejects_forged_context_summary_before_pro
 
     let error = port
         .stream_model(LoopModelRequest {
+            inline_messages: Vec::new(),
             messages: vec![LoopModelMessage {
                 role: "user".to_string(),
                 content_ref: forged_ref.clone(),
@@ -2044,6 +2129,7 @@ async fn production_loop_model_gateway_rejects_unvalidated_surface_before_provid
 
     let error = port
         .stream_model(LoopModelRequest {
+            inline_messages: Vec::new(),
             messages: vec![LoopModelMessage {
                 role: "user".to_string(),
                 content_ref: LoopMessageRef::new(format!("msg:{}", fixture.user_message_id))
@@ -2460,6 +2546,35 @@ async fn production_loop_request_with_safety(
     model_preference: Option<ModelProfileId>,
     safety_context: InstructionSafetyContext,
 ) -> LoopModelRequest {
+    production_loop_request_with_safety_and_inline_messages(
+        fixture,
+        model_preference,
+        safety_context,
+        Vec::new(),
+    )
+    .await
+}
+
+async fn production_loop_request_with_inline_messages(
+    fixture: &ThreadFixture,
+    model_preference: Option<ModelProfileId>,
+    inline_messages: Vec<LoopInlineMessage>,
+) -> LoopModelRequest {
+    production_loop_request_with_safety_and_inline_messages(
+        fixture,
+        model_preference,
+        InstructionSafetyContext::local_development_noop(),
+        inline_messages,
+    )
+    .await
+}
+
+async fn production_loop_request_with_safety_and_inline_messages(
+    fixture: &ThreadFixture,
+    model_preference: Option<ModelProfileId>,
+    safety_context: InstructionSafetyContext,
+    inline_messages: Vec<LoopInlineMessage>,
+) -> LoopModelRequest {
     let context_port = Arc::new(ThreadBackedLoopContextPort::new(
         Arc::clone(&fixture.thread_service),
         fixture.thread_scope.clone(),
@@ -2482,13 +2597,14 @@ async fn production_loop_request_with_safety(
             surface_version: None,
             checkpoint_state_ref: None,
             max_messages: Some(16),
-            inline_messages: Vec::new(),
+            inline_messages: inline_messages.clone(),
             capability_view: None,
         })
         .await
         .expect("test prompt bundle should build");
     LoopModelRequest {
         messages: prompt_bundle.messages,
+        inline_messages,
         surface_version: None,
         model_preference,
         capability_view: None,
@@ -2956,6 +3072,7 @@ impl LlmProvider for ToolAwareProvider {
 struct GatewayCapabilityPort {
     definitions: Vec<ProviderToolDefinition>,
     registered: Mutex<Vec<ProviderToolCall>>,
+    validation_error: Option<AgentLoopHostErrorKind>,
 }
 
 impl GatewayCapabilityPort {
@@ -2973,7 +3090,13 @@ impl GatewayCapabilityPort {
                 }),
             }],
             registered: Mutex::new(Vec::new()),
+            validation_error: None,
         }
+    }
+
+    fn with_provider_tool_validation_error(mut self, kind: AgentLoopHostErrorKind) -> Self {
+        self.validation_error = Some(kind);
+        self
     }
 }
 
@@ -2989,6 +3112,12 @@ impl LoopCapabilityPort for GatewayCapabilityPort {
         &self,
         tool_call: &ProviderToolCall,
     ) -> Result<(), ironclaw_turns::run_profile::AgentLoopHostError> {
+        if let Some(kind) = self.validation_error {
+            return Err(ironclaw_turns::run_profile::AgentLoopHostError::new(
+                kind,
+                "provider tool output was structurally invalid",
+            ));
+        }
         if !self
             .definitions
             .iter()

--- a/crates/ironclaw_reborn/tests/loop_driver_host.rs
+++ b/crates/ironclaw_reborn/tests/loop_driver_host.rs
@@ -220,6 +220,7 @@ async fn text_only_host_factory_builds_complete_agent_loop_driver_host() {
 
     let model_response = host_dyn
         .stream_model(LoopModelRequest {
+            inline_messages: Vec::new(),
             messages: prompt_bundle.messages,
             surface_version: Some(surface.version.clone()),
             model_preference: None,
@@ -334,6 +335,7 @@ async fn text_only_host_factory_sanitizes_gateway_error_summaries() {
 
     let error = host
         .stream_model(LoopModelRequest {
+            inline_messages: Vec::new(),
             messages: prompt_bundle.messages,
             surface_version: None,
             model_preference: None,
@@ -390,6 +392,7 @@ async fn text_only_host_factory_invokes_model_budget_accountant() {
         .unwrap();
 
     host.stream_model(LoopModelRequest {
+        inline_messages: Vec::new(),
         messages: prompt_bundle.messages,
         surface_version: None,
         model_preference: None,
@@ -1431,6 +1434,7 @@ async fn text_only_host_factory_includes_safety_context_in_prompt_bundle() {
         .unwrap();
     host_dyn
         .stream_model(LoopModelRequest {
+            inline_messages: Vec::new(),
             messages: prompt_bundle.messages,
             surface_version: None,
             model_preference: None,
@@ -1482,6 +1486,7 @@ async fn text_only_host_factory_uses_explicit_local_noop_safety_context() {
         .unwrap();
     host_dyn
         .stream_model(LoopModelRequest {
+            inline_messages: Vec::new(),
             messages: prompt_bundle.messages,
             surface_version: None,
             model_preference: None,
@@ -2405,6 +2410,7 @@ async fn text_only_host_e2e_keeps_persisted_model_route_through_full_flow() {
         .unwrap();
     let model_response = host_dyn
         .stream_model(LoopModelRequest {
+            inline_messages: Vec::new(),
             messages: prompt_bundle.messages,
             surface_version: None,
             model_preference: None,
@@ -3496,6 +3502,7 @@ async fn product_live_runtime_builds_when_all_required_adapters_are_present() {
         .unwrap();
     host_dyn
         .stream_model(LoopModelRequest {
+            inline_messages: Vec::new(),
             messages: prompt_bundle.messages,
             surface_version: None,
             model_preference: None,
@@ -3647,6 +3654,7 @@ async fn text_only_host_factory_threads_model_route_snapshot_to_gateway() {
 
     host_dyn
         .stream_model(LoopModelRequest {
+            inline_messages: Vec::new(),
             messages: host_dyn
                 .build_prompt_bundle(LoopPromptBundleRequest {
                     mode: PromptMode::TextOnly,
@@ -3924,6 +3932,7 @@ async fn text_only_host_e2e_flow_persists_checkpoint_mapping_in_turn_state_store
         .unwrap();
     let model_response = host_dyn
         .stream_model(LoopModelRequest {
+            inline_messages: Vec::new(),
             messages: prompt_bundle.messages,
             surface_version: Some(surface_version.clone()),
             model_preference: None,
@@ -4252,6 +4261,7 @@ async fn text_only_host_factory_threads_identity_source_to_prompt_and_model() {
 
     host_dyn
         .stream_model(LoopModelRequest {
+            inline_messages: Vec::new(),
             messages: prompt_bundle.messages,
             surface_version: Some(surface.version),
             model_preference: None,
@@ -4933,6 +4943,7 @@ async fn text_only_host_prompt_bundle_includes_surface_metadata_and_still_stream
     assert_eq!(prompt_bundle.messages.len(), 4);
 
     host.stream_model(LoopModelRequest {
+        inline_messages: Vec::new(),
         messages: prompt_bundle.messages,
         surface_version: Some(surface.version),
         model_preference: None,
@@ -7365,6 +7376,7 @@ impl AgentLoopDriver for ScriptCapabilityFinalReplyDriver {
             .map_err(driver_host_error)?;
         let model_response = host
             .stream_model(LoopModelRequest {
+                inline_messages: Vec::new(),
                 messages: prompt_bundle.messages,
                 surface_version: Some(surface.version),
                 model_preference: None,
@@ -7488,6 +7500,7 @@ impl AgentLoopDriver for TextOnlyFinalReplyDriver {
             .map_err(driver_host_error)?;
         let model_response = host
             .stream_model(LoopModelRequest {
+                inline_messages: Vec::new(),
                 messages: prompt_bundle.messages,
                 surface_version: Some(surface.version),
                 model_preference: None,

--- a/crates/ironclaw_reborn/tests/loop_milestone_event_projection.rs
+++ b/crates/ironclaw_reborn/tests/loop_milestone_event_projection.rs
@@ -337,6 +337,7 @@ async fn drive_model_reply_milestones_and_assert_projection(
         .unwrap();
     let model_response = success_host
         .stream_model(LoopModelRequest {
+            inline_messages: Vec::new(),
             messages: success_prompt.messages,
             surface_version: None,
             model_preference: None,
@@ -412,6 +413,7 @@ async fn drive_model_reply_milestones_and_assert_projection(
         .unwrap();
     let error = failure_host
         .stream_model(LoopModelRequest {
+            inline_messages: Vec::new(),
             messages: failure_prompt.messages,
             surface_version: None,
             model_preference: None,

--- a/crates/ironclaw_reborn_composition/src/budget.rs
+++ b/crates/ironclaw_reborn_composition/src/budget.rs
@@ -116,6 +116,7 @@ mod tests {
         // Drive one `pre_model_call` to fire the seeding policy.
         let context = test_run_context("tenant-shared-helper", "alice-shared-helper");
         let request = ironclaw_turns::run_profile::LoopModelRequest {
+            inline_messages: Vec::new(),
             messages: vec![],
             surface_version: None,
             model_preference: None,

--- a/crates/ironclaw_turns/src/run_profile/host.rs
+++ b/crates/ironclaw_turns/src/run_profile/host.rs
@@ -935,6 +935,8 @@ pub struct LoopModelCapabilityView {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LoopModelRequest {
     pub messages: Vec<LoopModelMessage>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub inline_messages: Vec<LoopInlineMessage>,
     pub surface_version: Option<CapabilitySurfaceVersion>,
     pub model_preference: Option<ModelProfileId>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/ironclaw_turns/src/run_profile/host.rs
+++ b/crates/ironclaw_turns/src/run_profile/host.rs
@@ -620,6 +620,8 @@ pub enum AgentLoopHostErrorKind {
     /// The request payload itself is well-formed but its content is invalid in
     /// the current host state (e.g. schema id/version mismatch on checkpoint load).
     Invalid,
+    /// The model/provider output was structurally invalid for the active loop contract.
+    InvalidOutput,
     PolicyDenied,
     BudgetExceeded,
     /// The model call would push utilization past the configured pause
@@ -647,6 +649,7 @@ impl AgentLoopHostErrorKind {
             Self::StaleSurface => "stale_surface",
             Self::InvalidInvocation => "invalid_invocation",
             Self::Invalid => "invalid",
+            Self::InvalidOutput => "invalid_output",
             Self::PolicyDenied => "policy_denied",
             Self::BudgetExceeded => "budget_exceeded",
             Self::BudgetApprovalRequired => "budget_approval_required",

--- a/crates/ironclaw_turns/tests/agent_loop_host_contract.rs
+++ b/crates/ironclaw_turns/tests/agent_loop_host_contract.rs
@@ -186,6 +186,7 @@ async fn host_managed_model_port_routes_gateway_and_emits_model_milestones() {
 
     let response = port
         .stream_model(LoopModelRequest {
+            inline_messages: Vec::new(),
             messages: vec![LoopModelMessage {
                 role: "user".to_string(),
                 content_ref: LoopMessageRef::new("msg:user-message").unwrap(),
@@ -240,6 +241,7 @@ async fn host_managed_model_port_returns_response_when_model_started_milestone_f
 
     let response = port
         .stream_model(LoopModelRequest {
+            inline_messages: Vec::new(),
             messages: Vec::new(),
             surface_version: None,
             model_preference: None,
@@ -280,6 +282,7 @@ async fn host_managed_model_port_returns_response_when_model_completed_milestone
 
     let response = port
         .stream_model(LoopModelRequest {
+            inline_messages: Vec::new(),
             messages: Vec::new(),
             surface_version: None,
             model_preference: None,
@@ -317,6 +320,7 @@ async fn host_managed_model_port_sanitizes_gateway_errors() {
 
     let error = port
         .stream_model(LoopModelRequest {
+            inline_messages: Vec::new(),
             messages: Vec::new(),
             surface_version: None,
             model_preference: None,
@@ -2450,6 +2454,7 @@ impl AgentLoopDriver for ReplyDriver {
         assert_eq!(prompt.messages.len(), 1);
         let response = host
             .stream_model(LoopModelRequest {
+                inline_messages: Vec::new(),
                 messages: prompt.messages,
                 surface_version: prompt.surface_version,
                 model_preference: Some(
@@ -3243,6 +3248,7 @@ impl LoopModelBudgetAccountant for RecordingBudgetAccountant {
 
 fn simple_model_request(context: &LoopRunContext) -> LoopModelRequest {
     LoopModelRequest {
+        inline_messages: Vec::new(),
         messages: vec![LoopModelMessage {
             role: "user".to_string(),
             content_ref: LoopMessageRef::new("msg:user-message").unwrap(),
@@ -3692,6 +3698,10 @@ async fn error_kind_mapping_through_host_managed_port() {
         (
             AgentLoopHostErrorKind::CredentialUnavailable,
             "credential not available for requested model",
+        ),
+        (
+            AgentLoopHostErrorKind::InvalidOutput,
+            "model output was structurally invalid",
         ),
     ];
 

--- a/docs/reborn/contracts/agent-loop-protocol.md
+++ b/docs/reborn/contracts/agent-loop-protocol.md
@@ -165,6 +165,11 @@ Those blocked states are host-managed transitions driven by approval or auth ser
 - Repeated rejected reply candidates fail as invalid model output rather than
   generic no-progress, so recovery can distinguish bad final-answer candidates
   from repeated capability work.
+- Host-managed model responses that are empty or structurally invalid for the
+  active loop contract surface as `invalid_output`, not `unavailable`. The
+  agent loop owns recovery: it retries the model call with a model-visible
+  repair hint in the prompt bundle, and exhausted retries fail the run as
+  `invalid_model_output`.
 - `BlockedApproval` / `BlockedAuth` is host control-plane state
 
 These must not be collapsed into a single vague text outcome.


### PR DESCRIPTION
## Summary

- Preserve invalid model output as a distinct host/model recovery class instead of collapsing it to generic unavailable.
- Move empty or malformed model-output recovery out of the Reborn gateway and into the agent-loop recovery strategy.
- Render a model-visible repair hint through the prompt bundle path on invalid-output retries, and fail as `invalid_model_output` when retries are exhausted.

## Root Cause

Empty tool-capable model responses were rejected by the gateway as invalid output, but loop support mapped that error to `Unavailable`. The agent loop could only perform a blind retry, and repeated failures could surface as a confusing driver/protocol failure rather than a clear invalid-model-output failure.

## Validation

- `cargo test -p ironclaw_agent_loop`
- `cargo test -p ironclaw_reborn --features root-llm-provider --test llm_gateway`
- `cargo test -p ironclaw_loop_support --test thread_loop_support_contract`
- `cargo test -p ironclaw_turns`
- `cargo fmt`
- `git diff --check`