### PR TITLE
[codex] fix gsuite refresh auth classification

### DIFF
--- a/crates/ironclaw_first_party_extensions/src/gsuite/handlers.rs
+++ b/crates/ironclaw_first_party_extensions/src/gsuite/handlers.rs
@@ -145,8 +145,10 @@ impl GsuiteExecutor {
                     CapabilityExecutionOutcome::AuthExpired {
                         network_egress_bytes: retry_network_egress_bytes,
                     } => {
-                        return Err(GsuiteDispatchError::new(RuntimeDispatchErrorKind::Backend)
-                            .with_reason(GsuiteCredentialDispatchReason::BackendAuth)
+                        return Err(GsuiteDispatchError::new(RuntimeDispatchErrorKind::Client)
+                            .with_reason(GsuiteCredentialDispatchReason::AuthRequired {
+                                required_secrets: vec![refreshed.access_secret.clone()],
+                            })
                             .with_usage(ResourceUsage {
                                 network_egress_bytes: network_egress_bytes
                                     .saturating_add(retry_network_egress_bytes),

--- a/crates/ironclaw_first_party_extensions/tests/gsuite_core.rs
+++ b/crates/ironclaw_first_party_extensions/tests/gsuite_core.rs
@@ -376,12 +376,21 @@ async fn gsuite_handler_errors_when_refresh_retry_is_still_auth_expired() {
         .await
         .expect_err("retry auth expiry should fail");
 
-    assert_eq!(error.kind(), RuntimeDispatchErrorKind::Backend);
+    assert_eq!(error.kind(), RuntimeDispatchErrorKind::Client);
+    assert!(
+        error.is_auth_required(),
+        "refreshed credential rejected by Google must trigger auth reauthorization; got {error:?}"
+    );
+    let requests = egress.requests();
+    assert_eq!(requests.len(), 2);
+    let refreshed_access = requests[1].credential_injections[0].handle.clone();
     assert_eq!(
         error.reason(),
-        Some(&GsuiteCredentialDispatchReason::BackendAuth)
+        Some(&GsuiteCredentialDispatchReason::AuthRequired {
+            required_secrets: vec![refreshed_access.clone()]
+        })
     );
-    assert_eq!(egress.requests().len(), 2);
+    assert_eq!(error.auth_requirement(), Some(vec![refreshed_access]));
     assert_eq!(
         error.usage().map(|usage| usage.network_egress_bytes),
         Some(246)


### PR DESCRIPTION
## Summary

- classify a refreshed Google credential that is still rejected by Gmail as auth-required instead of backend auth
- preserve network usage accounting on the retry failure path
- update the GSuite regression test to assert the retry credential handle is surfaced for reauthorization

## Root Cause

The GSuite first-party executor refreshed an expired Google credential, retried the API call, and then treated a second Google `UNAUTHENTICATED` response as `BackendAuth`. `BackendAuth` intentionally does not trigger the auth gate, so the runtime surfaced a backend/tool failure instead of asking the user to reauthorize.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p ironclaw_first_party_extensions gsuite_handler_errors_when_refresh_retry_is_still_auth_expired`
- `cargo test -p ironclaw_first_party_extensions gsuite_handler_refreshes_expired_google_token_once_and_retries`
- `cargo test -p ironclaw_first_party_extensions gsuite_handler_stage_credential_failure_on_refresh_retry_returns_auth_required`
- `cargo test -p ironclaw_reborn_composition --test gsuite bundled_gsuite_handler_projects_stage_auth_required_to_first_party_auth_required`

## Notes

A broader `cargo test -p ironclaw_first_party_extensions --test gsuite_core` run still has an unrelated pre-existing failure in `gsuite_handler_fails_before_egress_when_google_account_is_missing_or_ambiguous`; that test also fails when run alone.