### PR TITLE
fix(reborn): record Delivered (not Skipped) for non-OAuth auth-denied triggered runs

### DIFF
--- a/crates/ironclaw_reborn_composition/src/slack_delivery.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_delivery.rs
@@ -326,9 +326,18 @@ impl SlackFinalReplyDeliveryObserver {
             else {
                 return Ok(());
             };
-            let next_blocked_marker = blocked_actionable_marker(&actionable_state);
+            let mut next_blocked_marker = blocked_actionable_marker(&actionable_state);
             let event_kind = notification.event_kind;
             let gate_ref_for_routing = notification.gate_ref_for_routing.clone();
+            // A non-OAuth `BlockedAuth` gate is converted into a cancel + terminal
+            // `FinalReplyReady` notice by the notification builder. Once that notice
+            // is delivered the run is no longer waiting, so the pre-cancel blocked
+            // marker must not keep the delivery loop polling.
+            if matches!(actionable_state.status, TurnStatus::BlockedAuth)
+                && event_kind == RunNotificationEventKind::FinalReplyReady
+            {
+                next_blocked_marker = None;
+            }
             let posted_messages = self
                 .deliver_run_notification(
                     &envelope,
@@ -2049,9 +2058,20 @@ async fn deliver_triggered_run(
             }
         };
 
-        let next_blocked_marker = blocked_actionable_marker(&state);
+        let mut next_blocked_marker = blocked_actionable_marker(&state);
         let event_kind = notification.event_kind;
         let gate_ref_for_routing = notification.gate_ref_for_routing.clone();
+        // A non-OAuth `BlockedAuth` gate is converted into a cancel + terminal
+        // `FinalReplyReady` notice by `triggered_notification_for_state`. Once that
+        // notice is delivered the run is no longer waiting, so the pre-cancel
+        // blocked marker must not drive another poll cycle — otherwise the loop
+        // re-polls the cancelled run and records the outcome as `Skipped` (or a
+        // timeout) instead of `Delivered`.
+        if matches!(state.status, TurnStatus::BlockedAuth)
+            && event_kind == RunNotificationEventKind::FinalReplyReady
+        {
+            next_blocked_marker = None;
+        }
 
         // Build the delivery request and deliver.
         let delivery_result = deliver_triggered_notification(
@@ -5497,47 +5517,29 @@ mod tests {
         let binding_ref =
             test_slack_binding_ref(install, scope.agent_id.as_ref().expect("agent").as_str());
 
-        // First poll → BlockedAuth with gate_ref; second poll → Completed.
+        // First poll → BlockedAuth (non-OAuth) with gate_ref. The non-OAuth
+        // branch cancels the run and posts a terminal "auth unavailable" notice,
+        // so the second poll is the cancelled (terminal) state — never Completed.
+        // Regression: the pre-cancel blocked marker must not re-drive the loop,
+        // which would record the outcome as Skipped instead of Delivered.
         let coordinator = Arc::new(ScriptedTurnCoordinator::with_states(vec![
             scripted_state(TurnStatus::BlockedAuth, Some(gate_ref_str)),
-            scripted_state(TurnStatus::Completed, None),
+            scripted_state(TurnStatus::Cancelled, None),
         ]));
         let thread_service = Arc::new(InMemorySessionThreadService::default());
-        seed_finalized_assistant_message(
-            &thread_service,
-            &scope,
-            run_id,
-            "Run complete after auth.",
-        )
-        .await;
 
         let outbound = Arc::new(InMemoryOutboundStateStore::default());
         seed_personal_preference(&outbound, &scope, binding_ref).await;
 
         let egress = Arc::new(FakeProtocolHttpEgress::new(vec!["slack.com".to_string()]));
         egress.allow_credential_handle("slack_bot_token");
-        // Auth-prompt delivery response.
+        // The single "auth unavailable" notice post — the run is cancelled, so no
+        // further delivery happens.
         egress.program_response(
             "slack.com",
             Ok(EgressResponse::new(
                 200,
                 slack_post_ok_json("D456", "9999.1111"),
-            )),
-        );
-        // Final-reply response (after Completed).
-        egress.program_response(
-            "slack.com",
-            Ok(EgressResponse::new(
-                200,
-                slack_post_ok_json("D456", "9999.2222"),
-            )),
-        );
-        // Auth message is deleted after final; need a delete response.
-        egress.program_response(
-            "slack.com",
-            Ok(EgressResponse::new(
-                200,
-                serde_json::json!({"ok": true}).to_string().into_bytes(),
             )),
         );
 
@@ -5568,7 +5570,15 @@ mod tests {
         driver
             .on_trigger_submitted(fire, run_id, scope.clone())
             .await;
-        wait_for_delivery_record(&delivery_store, run_id).await;
+        let record = wait_for_delivery_record(&delivery_store, run_id).await;
+        // The auth-unavailable notice WAS delivered, so the outcome must be
+        // Delivered — not Skipped/timeout from re-polling the cancelled run on a
+        // stale pre-cancel blocked marker. This is the regression guard.
+        assert_eq!(
+            record.outcome,
+            TriggeredRunDeliveryOutcomeKind::Delivered,
+            "non-OAuth auth denial delivered a notice; outcome must be Delivered, not Skipped"
+        );
 
         let creator = ironclaw_host_api::UserId::new("creator-user").expect("user id");
         // Non-OAuth auth (no `authorization_url`) is DENIED over Slack: the run is


### PR DESCRIPTION
## Problem

A triggered (automation) run that blocks on **non-OAuth** auth (manual token / API key — which can't be safely solicited over Slack) is converted by the Slack notification builder into a **cancel + terminal "auth unavailable" `FinalReply` notice**. The notice *is* posted to the user, but the delivery loop records the wrong automation outcome.

**Root cause** (`slack_delivery.rs`, `deliver_triggered_run`): `next_blocked_marker` is computed from the **pre-cancel `BlockedAuth` state**. After the terminal notice is delivered, the `if let Some(marker) = next_blocked_marker` branch is taken, so the loop sets `delivered_blocked_marker` and `continue`s instead of returning `Delivered`. The next poll sees the now-cancelled run, builds no notification (`Ok(None)`), and records **`Skipped`** (or a timeout `Failed` if the cancel settles asynchronously).

Net effect: the user got the notice, but the automation run-history outcome is misclassified.

## Fix

When a non-OAuth `BlockedAuth` gate yields a terminal `FinalReplyReady` notice, clear `next_blocked_marker` so the loop falls through to the `Delivered` terminal path and returns.

Applied at **both** delivery loops that share this exact pattern:
- `deliver_triggered_run` — the outcome-recording path (the confirmed impact: `Skipped`→`Delivered`).
- the live `notification_for_actionable_state` delivery loop — same root cause; there it avoids a wasted extra poll cycle and a latent post-delivery `RunWaitTimedOutAfterNotification`.

## Test

`triggered_non_oauth_auth_is_denied_without_gate_route` previously scripted a **fictional** `BlockedAuth → Completed` sequence — but a cancelled run can't `Complete`, and that fiction is exactly what masked the bug (it recorded `Delivered` via the 2nd poll regardless). It now scripts the realistic `BlockedAuth → Cancelled` terminal and asserts the recorded outcome is `Delivered`:
- **Before** this fix: records `Skipped` → assertion fails.
- **After**: records `Delivered` → passes.

## Validation

Bounded, with `--features slack-v2-host-beta,root-llm-provider,libsql`:
- `cargo test … triggered_non_oauth_auth_is_denied_without_gate_route --lib` → **1 passed**
- `cargo clippy -p ironclaw_reborn_composition --tests … -- -D warnings` → clean
- `cargo fmt --check` → clean

## Notes

Found while triaging a CodeRabbit "Major" finding on #4944 against an unrelated PR. This is a standalone surgical fix off `main` (the affected code came from #4944 / #4730).

🤖 Generated with [Claude Code](https://claude.com/claude-code)