### PR TITLE
[codex] Clarify trigger active state output

### DIFF
--- a/crates/ironclaw_host_runtime/src/first_party_tools/trigger_management.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/trigger_management.rs
@@ -335,6 +335,8 @@ async fn remove_trigger(
 }
 
 fn trigger_output(record: &TriggerRecord, recent_runs: &[TriggerRunRecord]) -> Value {
+    let is_enabled = record.state == TriggerState::Scheduled;
+    let has_active_fire = record.has_active_fire();
     json!({
         "trigger_id": record.trigger_id.to_string(),
         "agent_id": record.agent_id.as_ref().map(|id| id.as_str()),
@@ -348,7 +350,11 @@ fn trigger_output(record: &TriggerRecord, recent_runs: &[TriggerRunRecord]) -> V
         "last_run_at": record.last_run_at,
         "last_status": record.last_status,
         "recent_runs": recent_runs.iter().map(trigger_run_output).collect::<Vec<_>>(),
-        "is_active": record.has_active_fire(),
+        // Model-facing trigger status: `is_active` means the trigger is enabled
+        // to fire. In-flight run state is exposed separately as `has_active_fire`.
+        "is_enabled": is_enabled,
+        "is_active": is_enabled,
+        "has_active_fire": has_active_fire,
         "created_at": record.created_at,
     })
 }

--- a/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
@@ -54,7 +54,7 @@ use ironclaw_secrets::InMemorySecretStore;
 use ironclaw_triggers::{
     ClaimDueFireRequest, ClearActiveFireRequest, FireAcceptedRequest, InMemoryTriggerRepository,
     MAX_TRIGGER_NAME_BYTES, MAX_TRIGGER_PROMPT_BYTES, TriggerError, TriggerRecord,
-    TriggerRepository, TriggerRunHistoryStatus, TriggerRunRecord,
+    TriggerRepository, TriggerRunHistoryStatus, TriggerRunRecord, TriggerState,
 };
 use ironclaw_trust::{
     AdminConfig, AdminEntry, AuthorityCeiling, EffectiveTrustClass, HostTrustAssignment,
@@ -319,7 +319,9 @@ async fn builtin_trigger_create_stamps_caller_scope_and_persists_record() {
     assert_eq!(trigger["agent_id"], json!("default"));
     assert_eq!(trigger["project_id"], json!("bootstrap"));
     assert_eq!(trigger["last_status"], Value::Null);
-    assert_eq!(trigger["is_active"], json!(false));
+    assert_eq!(trigger["is_enabled"], json!(true));
+    assert_eq!(trigger["is_active"], json!(true));
+    assert_eq!(trigger["has_active_fire"], json!(false));
     assert!(trigger.get("last_fired_slot").is_none());
     assert!(trigger.get("active_fire_slot").is_none());
     assert!(trigger.get("active_run_ref").is_none());
@@ -748,7 +750,9 @@ async fn builtin_trigger_list_and_remove_are_caller_scoped() {
     .unwrap();
     assert_eq!(owner_list["triggers"].as_array().unwrap().len(), 1);
     assert!(owner_list["triggers"][0].get("last_status").is_some());
-    assert_eq!(owner_list["triggers"][0]["is_active"], json!(false));
+    assert_eq!(owner_list["triggers"][0]["is_enabled"], json!(true));
+    assert_eq!(owner_list["triggers"][0]["is_active"], json!(true));
+    assert_eq!(owner_list["triggers"][0]["has_active_fire"], json!(false));
     assert!(owner_list["triggers"][0].get("prompt").is_none());
     assert!(owner_list["triggers"][0].get("tenant_id").is_none());
     assert!(owner_list["triggers"][0].get("creator_user_id").is_none());
@@ -781,7 +785,7 @@ async fn builtin_trigger_list_and_remove_are_caller_scoped() {
 }
 
 #[tokio::test]
-async fn builtin_trigger_list_shows_active_state_without_run_identifiers() {
+async fn builtin_trigger_list_separates_enabled_state_from_active_fire_state() {
     let repository = Arc::new(InMemoryTriggerRepository::default());
     let runtime = runtime_with_trigger_repository(repository.clone());
     let context = execution_context([TRIGGER_CREATE_CAPABILITY_ID, TRIGGER_LIST_CAPABILITY_ID]);
@@ -799,23 +803,45 @@ async fn builtin_trigger_list_shows_active_state_without_run_identifiers() {
     )
     .await
     .unwrap();
-    assert_eq!(created["trigger"]["is_active"], json!(false));
+    assert_eq!(created["trigger"]["is_enabled"], json!(true));
+    assert_eq!(created["trigger"]["is_active"], json!(true));
+    assert_eq!(created["trigger"]["has_active_fire"], json!(false));
 
     let mut records = repository
         .list_triggers(context.resource_scope.tenant_id.clone())
         .await
         .unwrap();
     assert_eq!(records.len(), 1);
-    records[0].active_fire_slot = Some(records[0].next_run_at);
-    records[0].active_run_ref =
-        Some(TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f5a").unwrap());
-    repository.upsert_trigger(records.remove(0)).await.unwrap();
+    let mut record = records.remove(0);
+    record.state = TriggerState::Paused;
+    repository.upsert_trigger(record.clone()).await.unwrap();
+
+    let listed_paused = invoke_with_context(
+        &runtime,
+        TRIGGER_LIST_CAPABILITY_ID,
+        json!({}),
+        context.clone(),
+    )
+    .await
+    .unwrap();
+    let paused_trigger = &listed_paused["triggers"][0];
+    assert_eq!(paused_trigger["state"], json!("paused"));
+    assert_eq!(paused_trigger["is_enabled"], json!(false));
+    assert_eq!(paused_trigger["is_active"], json!(false));
+    assert_eq!(paused_trigger["has_active_fire"], json!(false));
+
+    record.state = TriggerState::Scheduled;
+    record.active_fire_slot = Some(record.next_run_at);
+    record.active_run_ref = Some(TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f5a").unwrap());
+    repository.upsert_trigger(record).await.unwrap();
 
     let listed = invoke_with_context(&runtime, TRIGGER_LIST_CAPABILITY_ID, json!({}), context)
         .await
         .unwrap();
     let trigger = &listed["triggers"][0];
+    assert_eq!(trigger["is_enabled"], json!(true));
     assert_eq!(trigger["is_active"], json!(true));
+    assert_eq!(trigger["has_active_fire"], json!(true));
     assert!(trigger.get("active_fire_slot").is_none());
     assert!(trigger.get("active_run_ref").is_none());
 }
@@ -867,7 +893,9 @@ async fn builtin_trigger_create_list_and_remove_use_full_request_scope() {
     assert!(trigger.get("creator_user_id").is_none());
     assert_eq!(trigger["agent_id"], json!("scoped-agent"));
     assert_eq!(trigger["project_id"], json!("scoped-project"));
-    assert_eq!(trigger["is_active"], json!(false));
+    assert_eq!(trigger["is_enabled"], json!(true));
+    assert_eq!(trigger["is_active"], json!(true));
+    assert_eq!(trigger["has_active_fire"], json!(false));
     assert!(trigger.get("prompt").is_none());
     assert!(trigger.get("last_fired_slot").is_none());
     assert!(trigger.get("active_fire_slot").is_none());
@@ -948,7 +976,9 @@ async fn builtin_trigger_create_round_trips_nullable_agent_and_project_scope() {
 
     assert_eq!(created["trigger"]["agent_id"], Value::Null);
     assert_eq!(created["trigger"]["project_id"], Value::Null);
-    assert_eq!(created["trigger"]["is_active"], json!(false));
+    assert_eq!(created["trigger"]["is_enabled"], json!(true));
+    assert_eq!(created["trigger"]["is_active"], json!(true));
+    assert_eq!(created["trigger"]["has_active_fire"], json!(false));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Clarify the model-facing trigger output so scheduled triggers report as active/enabled.
- Add `is_enabled` and `has_active_fire` to separate fire eligibility from an in-flight claimed run.
- Extend trigger capability tests across scheduled, paused, and active-fire states.

## Root cause

`is_active` previously reflected `TriggerRecord::has_active_fire()`, so newly-created scheduled triggers returned `is_active: false` even though the poller would correctly run them. That led agents to infer an approval or activation gate that does not exist.

## Validation

- `cargo test -p ironclaw_host_runtime builtin_trigger -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
