### PR TITLE
fix(reborn): recover tool input/output on every terminal run

### DIFF
--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/hooks/useChat.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/hooks/useChat.js
@@ -240,15 +240,19 @@ export function useChat(threadId) {
     setActiveRun,
     activeRunRef,
     // Reborn's projection bridge does not yet emit `Text` items for
-    // assistant replies, so the SSE stream only delivers `run_status`.
-    // On terminal success, refetch the timeline so the assistant
-    // message that landed in the thread becomes visible in the UI.
-    // Clear pending optimistic messages first so the real user
-    // message from the server doesn't render alongside its
+    // assistant replies, and never emits `capability_display_preview`
+    // items in the projection state — the assistant reply and the rich
+    // tool input/output cards live only in the thread timeline. Refetch
+    // the timeline on EVERY terminal run (success or not) so both become
+    // visible; a failed/cancelled run still recovers the tool previews for
+    // tools that completed before it terminated. `preserveClientOnly`
+    // keeps the client-side `err-*` failure bubble across the reload.
+    // On success, clear pending optimistic messages first so the real
+    // user message from the server doesn't render alongside its
     // pre-submit optimistic twin.
-    onRunCompleted: () => {
-      setPendingMessages([]);
-      loadHistory();
+    onRunSettled: (_runId, { success }) => {
+      if (success) setPendingMessages([]);
+      loadHistory(undefined, { preserveClientOnly: true });
     },
   });
 

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/hooks/useHistory.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/hooks/useHistory.js
@@ -71,13 +71,13 @@ export function useHistory(threadId, options = {}) {
   threadIdRef.current = threadId;
 
   const loadHistory = React.useCallback(
-    async (cursor, options = {}) => {
+    async (cursor, loadOptions = {}) => {
       // `preserveClientOnly` keeps client-synthesized messages that never
       // appear in the timeline (run-failure `err-*` bubbles) when a full
       // reload replaces the list. A settle-triggered reload (any terminal
       // run status) uses this so recovering tool input/output previews from
       // the durable timeline doesn't erase a visible failure notice.
-      const { preserveClientOnly = false } = options;
+      const { preserveClientOnly = false } = loadOptions;
       if (!threadId) {
         setState({ messages: [], nextCursor: null, isLoading: false, loadError: null });
         return;
@@ -111,11 +111,18 @@ export function useHistory(threadId, options = {}) {
 
         // A full (non-paginated) load can be cached without the previous
         // state, so refresh the cache even if the user has since switched
-        // threads. Always under the issuing identity's key. A
-        // preserve-client-only reload needs the previous messages to merge,
-        // so its cache write happens inside setState below instead.
-        if (!cursor && !preserveClientOnly) {
-          putCache(key, { messages: renderable, nextCursor });
+        // threads — the cache write must not be deferred into `setState`,
+        // which bails on a stale thread and would leave the cache stale
+        // (forcing a re-fetch + flicker on return). A preserve-client-only
+        // reload merges over the *cached* messages so the client-only
+        // `err-*` bubbles survive in the cache too. Always under the
+        // issuing identity's key.
+        if (!cursor) {
+          const cachedMessages = historyCache.get(key)?.messages || [];
+          const cacheMerged = preserveClientOnly
+            ? mergePreservingClientOnly(renderable, cachedMessages)
+            : renderable;
+          putCache(key, { messages: cacheMerged, nextCursor });
         }
 
         setState((prev) => {
@@ -130,7 +137,7 @@ export function useHistory(threadId, options = {}) {
           } else {
             merged = renderable;
           }
-          if (cursor || preserveClientOnly) putCache(key, { messages: merged, nextCursor });
+          if (cursor) putCache(key, { messages: merged, nextCursor });
           return {
             messages: merged,
             nextCursor,
@@ -207,10 +214,13 @@ function mergePage(older, current) {
 // status and never persist as timeline records; a settle-triggered reload
 // must keep them, appended after the authoritative timeline messages.
 function mergePreservingClientOnly(timeline, current) {
-  const ids = new Set(timeline.map((m) => m.id));
+  const ids = new Set(timeline.map((m) => m?.id).filter(Boolean));
   const preserved = current.filter(
     (m) =>
-      !ids.has(m.id) && typeof m.id === "string" && m.id.startsWith("err-"),
+      m &&
+      typeof m.id === "string" &&
+      !ids.has(m.id) &&
+      m.id.startsWith("err-"),
   );
   return [...timeline, ...preserved];
 }

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/hooks/useHistory.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/hooks/useHistory.js
@@ -71,7 +71,13 @@ export function useHistory(threadId, options = {}) {
   threadIdRef.current = threadId;
 
   const loadHistory = React.useCallback(
-    async (cursor) => {
+    async (cursor, options = {}) => {
+      // `preserveClientOnly` keeps client-synthesized messages that never
+      // appear in the timeline (run-failure `err-*` bubbles) when a full
+      // reload replaces the list. A settle-triggered reload (any terminal
+      // run status) uses this so recovering tool input/output previews from
+      // the durable timeline doesn't erase a visible failure notice.
+      const { preserveClientOnly = false } = options;
       if (!threadId) {
         setState({ messages: [], nextCursor: null, isLoading: false, loadError: null });
         return;
@@ -105,8 +111,10 @@ export function useHistory(threadId, options = {}) {
 
         // A full (non-paginated) load can be cached without the previous
         // state, so refresh the cache even if the user has since switched
-        // threads. Always under the issuing identity's key.
-        if (!cursor) {
+        // threads. Always under the issuing identity's key. A
+        // preserve-client-only reload needs the previous messages to merge,
+        // so its cache write happens inside setState below instead.
+        if (!cursor && !preserveClientOnly) {
           putCache(key, { messages: renderable, nextCursor });
         }
 
@@ -114,10 +122,15 @@ export function useHistory(threadId, options = {}) {
           // Stale resolve for a thread that's no longer active: leave the
           // live view alone (the cache above already captured the result).
           if (threadIdRef.current !== threadId) return prev;
-          const merged = cursor
-            ? mergePage(renderable, prev.messages)
-            : renderable;
-          if (cursor) putCache(key, { messages: merged, nextCursor });
+          let merged;
+          if (cursor) {
+            merged = mergePage(renderable, prev.messages);
+          } else if (preserveClientOnly) {
+            merged = mergePreservingClientOnly(renderable, prev.messages);
+          } else {
+            merged = renderable;
+          }
+          if (cursor || preserveClientOnly) putCache(key, { messages: merged, nextCursor });
           return {
             messages: merged,
             nextCursor,
@@ -186,4 +199,18 @@ export function useHistory(threadId, options = {}) {
 function mergePage(older, current) {
   const ids = new Set(current.map((m) => m.id));
   return [...older.filter((m) => !ids.has(m.id)), ...current];
+}
+
+// Merge a fresh full timeline over the current view while keeping
+// client-synthesized messages the timeline can't carry. Run-failure
+// bubbles (`err-*`) are appended client-side on a terminal failed/recovery
+// status and never persist as timeline records; a settle-triggered reload
+// must keep them, appended after the authoritative timeline messages.
+function mergePreservingClientOnly(timeline, current) {
+  const ids = new Set(timeline.map((m) => m.id));
+  const preserved = current.filter(
+    (m) =>
+      !ids.has(m.id) && typeof m.id === "string" && m.id.startsWith("err-"),
+  );
+  return [...timeline, ...preserved];
 }

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/hooks/useHistory.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/hooks/useHistory.js
@@ -58,7 +58,7 @@ export function useHistory(threadId, options = {}) {
     loadError: null,
   });
   // Synchronous reentrancy guard, tracked PER THREAD — `isLoading` in state is
-  // async so it can't gate overlapping calls (scroll-to-load + onRunCompleted
+  // async so it can't gate overlapping calls (scroll-to-load + onRunSettled
   // refetch can fire in the same tick). It must be per-thread, not a single
   // boolean: a boolean held by an in-flight load of thread A would block a
   // switch to an uncached thread B, leaving B stuck loading. Each entry is

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/useChatEvents.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/useChatEvents.js
@@ -36,12 +36,15 @@ export function useChatEvents({
   setPendingGate,
   setActiveRun,
   activeRunRef,
-  onRunCompleted,
+  onRunSettled,
 }) {
-  // Track which runIds we've already announced completion for so that
-  // SSE replays (reconnect with `last-event-id`, repeated snapshots)
-  // don't trigger duplicate timeline refetches.
-  const completedRunsRef = React.useRef(new Set());
+  // Track which runIds we've already settled so that SSE replays
+  // (reconnect with `last-event-id`, repeated snapshots) don't trigger
+  // duplicate timeline refetches. A run settles on ANY terminal status,
+  // not only success — every terminal run reloads the timeline so tool
+  // input/output previews are recovered from the durable record even when
+  // the run failed, was cancelled, or needs recovery.
+  const settledRunsRef = React.useRef(new Set());
   // Last `run_status.run_id` we've observed, persisted across event
   // frames. Used by `applyProjectionItems` to correlate an `item.gate`
   // (which doesn't carry `run_id`) with the active run so resolveGate
@@ -146,9 +149,12 @@ export function useChatEvents({
         }
 
         case "cancelled": {
+          const runId =
+            frame.run_state?.run_id || activeRunRef?.current?.runId || null;
           setPendingGate(null);
           setIsProcessing(false);
           setActiveRun?.(null);
+          settleRun(settledRunsRef, onRunSettled, runId, false);
           return;
         }
 
@@ -164,6 +170,7 @@ export function useChatEvents({
             failureCategory: failureCategoryFromRunState(runState),
             failureSummary: null,
           });
+          settleRun(settledRunsRef, onRunSettled, runId, false);
           return;
         }
 
@@ -177,8 +184,8 @@ export function useChatEvents({
             setIsProcessing,
             setPendingGate,
             setActiveRun,
-            onRunCompleted,
-            completedRunsRef,
+            onRunSettled,
+            settledRunsRef,
             latestRunIdRef,
             promptRunIdRef,
             activeRunRef,
@@ -198,9 +205,19 @@ export function useChatEvents({
       setPendingGate,
       setActiveRun,
       activeRunRef,
-      onRunCompleted,
+      onRunSettled,
     ],
   );
+}
+
+// Fire the settle callback exactly once per runId. A run settles on any
+// terminal status; the consumer reloads the timeline so tool input/output
+// previews are recovered from the durable record. Deduped because SSE
+// replays the same terminal projection on every reconnect.
+function settleRun(settledRunsRef, onRunSettled, runId, success) {
+  if (!onRunSettled || !runId || settledRunsRef?.current.has(runId)) return;
+  settledRunsRef.current.add(runId);
+  onRunSettled(runId, { success });
 }
 
 const TERMINAL_RUN_STATUSES = new Set([
@@ -246,8 +263,8 @@ function applyProjectionItems({
   setIsProcessing,
   setPendingGate,
   setActiveRun,
-  onRunCompleted,
-  completedRunsRef,
+  onRunSettled,
+  settledRunsRef,
   latestRunIdRef,
   promptRunIdRef,
   activeRunRef,
@@ -311,21 +328,20 @@ function applyProjectionItems({
         if (runId && promptRunIdRef?.current === runId) {
           promptRunIdRef.current = null;
         }
-        if (
-          SUCCESS_RUN_STATUSES.has(status) &&
-          onRunCompleted &&
-          runId &&
-          !completedRunsRef?.current.has(runId)
-        ) {
-          // Reborn's projection bridge does not currently emit `Text`
-          // items for assistant replies — the reply lives only in the
-          // thread timeline. Trigger a timeline refetch on terminal
-          // success so the assistant message becomes visible. Dedup
-          // by runId because SSE replays the same projection on every
-          // reconnect.
-          completedRunsRef.current.add(runId);
-          onRunCompleted(runId);
-        }
+        // Reborn's projection bridge does not currently emit `Text` items
+        // for assistant replies, nor `capability_display_preview` items in
+        // the projection state — both the assistant reply and the rich tool
+        // input/output cards live only in the thread timeline. Reload the
+        // timeline on EVERY terminal status (not only success) so a failed,
+        // cancelled, or recovery-required run still recovers the tool
+        // previews for the tools that completed before it terminated. The
+        // reload preserves the client-side `err-*` failure bubble.
+        settleRun(
+          settledRunsRef,
+          onRunSettled,
+          runId,
+          SUCCESS_RUN_STATUSES.has(status),
+        );
         if (status === "failed" || status === "recovery_required") {
           appendRunFailureMessage(setMessages, {
             runId,

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/useChatEvents.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/useChatEvents.js
@@ -215,7 +215,8 @@ export function useChatEvents({
 // previews are recovered from the durable record. Deduped because SSE
 // replays the same terminal projection on every reconnect.
 function settleRun(settledRunsRef, onRunSettled, runId, success) {
-  if (!onRunSettled || !runId || settledRunsRef?.current.has(runId)) return;
+  if (!onRunSettled || !runId || !settledRunsRef?.current) return;
+  if (settledRunsRef.current.has(runId)) return;
   settledRunsRef.current.add(runId);
   onRunSettled(runId, { success });
 }

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/useChatEvents.test.mjs
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/useChatEvents.test.mjs
@@ -41,7 +41,8 @@ function createUseChatEventsHarness({
   let isProcessing = false;
   let activeRun = null;
   const activeRunRef = { current: null };
-  const completedRuns = [];
+  // [{ runId, success }] in fire order; one entry per settled run.
+  const settledRuns = [];
   const context = {
     Date,
     React: {
@@ -76,7 +77,7 @@ function createUseChatEventsHarness({
       activeRunRef.current = activeRun;
     },
     activeRunRef,
-    onRunCompleted: (runId) => completedRuns.push(runId),
+    onRunSettled: (runId, { success }) => settledRuns.push({ runId, success }),
   });
 
   return {
@@ -97,8 +98,8 @@ function createUseChatEventsHarness({
       activeRun = run;
       activeRunRef.current = run;
     },
-    get completedRuns() {
-      return completedRuns;
+    get settledRuns() {
+      return settledRuns;
     },
   };
 }
@@ -551,11 +552,110 @@ test("useChatEvents: stale completed run status does not refetch timeline", () =
     },
   });
 
-  assert.deepEqual(harness.completedRuns, []);
+  assert.deepEqual(harness.settledRuns, []);
   assert.equal(harness.isProcessing, true);
   assert.deepEqual(plain(harness.activeRun), {
     runId: "run-2",
     threadId: "thread-1",
     status: "running",
   });
+});
+
+test("useChatEvents: terminal success settles the run once", () => {
+  const harness = createUseChatEventsHarness();
+
+  harness.handleEvent({
+    type: "projection_update",
+    frame: {
+      state: {
+        items: [{ run_status: { run_id: "run-1", status: "running" } }],
+      },
+    },
+  });
+  harness.handleEvent({
+    type: "projection_update",
+    frame: {
+      state: {
+        items: [{ run_status: { run_id: "run-1", status: "completed" } }],
+      },
+    },
+  });
+  // Replay of the same terminal projection must not settle twice.
+  harness.handleEvent({
+    type: "projection_update",
+    frame: {
+      state: {
+        items: [{ run_status: { run_id: "run-1", status: "completed" } }],
+      },
+    },
+  });
+
+  assert.deepEqual(harness.settledRuns, [{ runId: "run-1", success: true }]);
+});
+
+test("useChatEvents: terminal failure settles the run as not successful", () => {
+  const harness = createUseChatEventsHarness();
+
+  harness.handleEvent({
+    type: "projection_update",
+    frame: {
+      state: {
+        items: [{ run_status: { run_id: "run-1", status: "running" } }],
+      },
+    },
+  });
+  harness.handleEvent({
+    type: "projection_update",
+    frame: {
+      state: {
+        items: [{ run_status: { run_id: "run-1", status: "failed" } }],
+      },
+    },
+  });
+
+  // A failed run still settles so the timeline reload recovers tool
+  // input/output previews for tools that ran before it terminated.
+  assert.deepEqual(harness.settledRuns, [{ runId: "run-1", success: false }]);
+});
+
+test("useChatEvents: terminal cancellation settles the run as not successful", () => {
+  const harness = createUseChatEventsHarness();
+
+  harness.handleEvent({
+    type: "projection_update",
+    frame: {
+      state: {
+        items: [{ run_status: { run_id: "run-1", status: "running" } }],
+      },
+    },
+  });
+  harness.handleEvent({
+    type: "projection_update",
+    frame: {
+      state: {
+        items: [{ run_status: { run_id: "run-1", status: "cancelled" } }],
+      },
+    },
+  });
+
+  assert.deepEqual(harness.settledRuns, [{ runId: "run-1", success: false }]);
+});
+
+test("useChatEvents: typed failed event settles the run as not successful", () => {
+  const harness = createUseChatEventsHarness();
+
+  harness.handleEvent({
+    type: "failed",
+    frame: {
+      run_state: {
+        run_id: "run-typed-failed-1",
+        status: "Failed",
+        failure: { category: "model_unavailable" },
+      },
+    },
+  });
+
+  assert.deepEqual(harness.settledRuns, [
+    { runId: "run-typed-failed-1", success: false },
+  ]);
 });

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/useHistory.test.mjs
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/useHistory.test.mjs
@@ -19,9 +19,11 @@ function useHistorySourceForTest() {
       skippingImport = !line.trimEnd().endsWith(";");
       continue;
     }
-    lines.push(line.replace("export function useHistory", "function useHistory"));
+    lines.push(line.replace(/^export function /, "function "));
   }
-  return `${lines.join("\n")}\nglobalThis.__testExports = { useHistory };`;
+  return `${lines.join(
+    "\n",
+  )}\nglobalThis.__testExports = { useHistory, mergePreservingClientOnly };`;
 }
 
 function createReactStub({ setCalls = [] } = {}) {
@@ -53,6 +55,7 @@ test("useHistory records a load error when timeline fetch fails", async () => {
   const setCalls = [];
   const consoleErrors = [];
   const context = {
+    authScope: () => "scope-1",
     console: {
       error: (...args) => consoleErrors.push(args),
     },
@@ -76,4 +79,33 @@ test("useHistory records a load error when timeline fetch fails", async () => {
     "Failed to load conversation history.",
   );
   assert.equal(consoleErrors.length, 1);
+});
+
+test("mergePreservingClientOnly keeps err-* bubbles and lets the timeline win otherwise", () => {
+  const context = { globalThis: {}, React: createReactStub() };
+  vm.runInNewContext(useHistorySourceForTest(), context);
+  const { mergePreservingClientOnly } = context.globalThis.__testExports;
+
+  const timeline = [
+    { id: "msg-user-1", role: "user" },
+    { id: "tool-abc", role: "tool_activity", toolParameters: "{}", toolResultPreview: "ok" },
+    { id: "msg-assistant-1", role: "assistant" },
+  ];
+  const current = [
+    { id: "msg-user-1", role: "user" },
+    { id: "tool-abc", role: "tool_activity", toolParameters: null, toolResultPreview: null },
+    { id: "err-run-1", role: "error", content: "run failed" },
+  ];
+
+  const merged = mergePreservingClientOnly(timeline, current);
+
+  // Timeline order is authoritative and the rich tool card replaces the
+  // sparse live one; the client-only err-* bubble is preserved at the end.
+  assert.equal(
+    merged.map((m) => m.id).join(","),
+    "msg-user-1,tool-abc,msg-assistant-1,err-run-1",
+  );
+  const toolCard = merged.find((m) => m.id === "tool-abc");
+  assert.equal(toolCard.toolParameters, "{}");
+  assert.equal(toolCard.toolResultPreview, "ok");
 });


### PR DESCRIPTION
## Summary
- Reloads the WebChat v2 timeline on **every terminal run status** (failed, cancelled, recovery_required — not just success) so tool input/output cards are recovered from the durable record even when a run doesn't complete cleanly
- Replaces the success-only `onRunCompleted` callback with `onRunSettled(runId, { success })`, fired once per run and deduped against SSE projection replays
- Adds a `preserveClientOnly` reload mode to `loadHistory` that merges the fresh timeline over the current view while keeping client-synthesized `err-*` failure bubbles, which never persist as timeline records
- Wires the same settle path through the typed `failed`/`cancelled` SSE events for forwards-compat with the projection bridge

## Context / Problem
Tool input/output reaches the UI only via the live `capability_display_preview` SSE frame or the durable timeline — the projection state carries only the sparse `capability_activity` item (no input/output). When the live preview frame is dropped (the resumable drain can mark a completed-but-unrecorded preview `NotApplicable` past its 10s grace window), the timeline reload is the only recovery, but it previously fired solely on terminal success. Failed/cancelled/gate-interrupted runs left the tools that completed before termination without their input/output, until a manual refresh. This is the residual gap left by the live-stream fix in #4770.

## Validation
- `node --test useChatEvents.test.mjs` ✓ (16 pass — adds success/failure/cancellation/typed-failed settle coverage)
- `node --test useHistory.test.mjs` ✓ (2 pass — adds `mergePreservingClientOnly` coverage; also fixes the source-loader stripper so the previously unparseable file runs)
- Full `pages/chat` JS suite: 88 pass; the only 2 remaining failures (`chat-input`, `useChat-send`) are pre-existing vm import-stripper issues unrelated to this change

## Security Impact
None. Frontend-only change to timeline reload/merge behavior; no change to auth, sanitization, or what data crosses the wire.

## Database Impact
No schema or migration changes.

## Blast Radius
Limited to the WebChat v2 SPA chat surface (`crates/ironclaw_webui_v2_static/static/js/pages/chat/`): `useChatEvents`, `useChat`, `useHistory`, and their tests.

## Rollback Plan
Reverting restores the previous behavior where the timeline reloads only on terminal success; the live preview frame remains the sole path for tool input/output on non-success runs.

## Notes
This is a frontend safety-net hardening. The backend 10s `NotApplicable` window still exists; this guarantees that as long as a tool result reaches the durable timeline, the UI recovers it at run termination. Deployments without `durable_previews` wired still depend on the live frame.
