### PR TITLE
fix(reborn): sidebar new conversation button style

### DIFF
--- a/crates/ironclaw_webui_v2_static/src/assets.rs
+++ b/crates/ironclaw_webui_v2_static/src/assets.rs
@@ -276,6 +276,14 @@ mod tests {
     }
 
     #[test]
+    fn sidebar_new_chat_label_owns_typography() {
+        let sidebar_nav = asset_text("js/components/sidebar-nav.js");
+
+        assert!(sidebar_nav.contains("<span className=\"text-[13px] font-medium\""));
+        assert!(sidebar_nav.contains("t(\"chat.newThread\")"));
+    }
+
+    #[test]
     fn sidebar_trace_credits_card_assets_are_embedded() {
         // The compact card is mounted in the sidebar above the conversation
         // list and reuses the existing trace-credits hook + endpoint.

--- a/crates/ironclaw_webui_v2_static/static/js/components/sidebar-nav.js
+++ b/crates/ironclaw_webui_v2_static/static/js/components/sidebar-nav.js
@@ -117,12 +117,14 @@ export function SidebarNav({ onNewChat, isCreating, isAdmin = false, onNavigate 
         className=${cn(
           "flex items-center gap-2.5 rounded-[10px] px-3 py-2",
           "border border-[color-mix(in_srgb,var(--v2-accent)_30%,var(--v2-panel-border))]",
-          "bg-[var(--v2-accent-soft)] text-[13px] font-medium text-[var(--v2-accent-text)]",
+          "bg-[var(--v2-accent-soft)] text-[var(--v2-accent-text)]",
           "hover:bg-[color-mix(in_srgb,var(--v2-accent)_18%,transparent)] disabled:opacity-50"
         )}
       >
         <${Icon} name="plus" className="h-4 w-4 shrink-0" />
-        <span>${isCreating ? t("chat.creating") : t("chat.newThread")}</span>
+        <span className="text-[13px] font-medium">
+          ${isCreating ? t("chat.creating") : t("chat.newThread")}
+        </span>
       </button>
 
       <nav className="mt-2 flex flex-col gap-1">


### PR DESCRIPTION
## Summary

- Move the Reborn sidebar `New` label typography onto the inner label span so it is not affected by the global button font reset.
- Keep the existing button layout, click behavior, disabled behavior, and route handling unchanged.
- Add an embedded-asset regression check for the sidebar `New` label typography.

## Root Cause

The global `button { font: inherit; }` / `.v2-button` reset can override utility typography applied directly to the `New` button element. Neighboring sidebar labels are rendered inside link text nodes, so the `New` action could appear larger than adjacent navigation labels.

## Validation

- `cargo +1.92.0 fmt --package ironclaw_webui_v2_static --check`
- `cargo +1.92.0 test -p ironclaw_webui_v2_static`

Closes #4972