### PR TITLE
feat(admin): persist Engine V2 LLM usage

### DIFF
--- a/crates/ironclaw_engine/src/executor/orchestrator.rs
+++ b/crates/ironclaw_engine/src/executor/orchestrator.rs
@@ -22,8 +22,6 @@ use std::sync::Arc;
 use std::sync::OnceLock;
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use std::collections::HashMap;
-
 use monty::{
     ExtFunctionResult, LimitedTracker, MontyObject, MontyRun, NameLookupResult, PrintWriter,
     ResourceLimits, RunProgress,
@@ -63,34 +61,6 @@ pub struct OrchestratorResult {
     pub outcome: ThreadOutcome,
     /// Total tokens used by LLM calls within the orchestrator.
     pub tokens_used: TokenUsage,
-}
-
-fn llm_usage_metadata(thread: &Thread, purpose: &str) -> HashMap<String, String> {
-    let mut metadata = HashMap::from([
-        ("thread_id".to_string(), thread.id.0.to_string()),
-        ("user_id".to_string(), thread.user_id.clone()),
-        ("purpose".to_string(), purpose.to_string()),
-    ]);
-
-    if let Some(scope) = thread
-        .metadata
-        .get("conversation_scope")
-        .and_then(|v| v.as_str())
-    {
-        metadata.insert("conversation_scope".to_string(), scope.to_string());
-    }
-    if let Some(conversation_id) = thread
-        .metadata
-        .get("v1_conversation_id")
-        .and_then(|v| v.as_str())
-    {
-        metadata.insert(
-            "v1_conversation_id".to_string(),
-            conversation_id.to_string(),
-        );
-    }
-
-    metadata
 }
 
 fn apply_snapshot_inventory(
@@ -831,7 +801,7 @@ async fn handle_llm_complete(
             .and_then(|cfg| cfg.get("model"))
             .and_then(|v| v.as_str())
             .map(String::from),
-        metadata: llm_usage_metadata(thread, "chat"),
+        metadata: thread.llm_usage_metadata("chat"),
     };
 
     match deps.llm.complete(&messages, &actions, &config).await {

--- a/crates/ironclaw_engine/src/executor/orchestrator.rs
+++ b/crates/ironclaw_engine/src/executor/orchestrator.rs
@@ -65,6 +65,34 @@ pub struct OrchestratorResult {
     pub tokens_used: TokenUsage,
 }
 
+fn llm_usage_metadata(thread: &Thread, purpose: &str) -> HashMap<String, String> {
+    let mut metadata = HashMap::from([
+        ("thread_id".to_string(), thread.id.0.to_string()),
+        ("user_id".to_string(), thread.user_id.clone()),
+        ("purpose".to_string(), purpose.to_string()),
+    ]);
+
+    if let Some(scope) = thread
+        .metadata
+        .get("conversation_scope")
+        .and_then(|v| v.as_str())
+    {
+        metadata.insert("conversation_scope".to_string(), scope.to_string());
+    }
+    if let Some(conversation_id) = thread
+        .metadata
+        .get("v1_conversation_id")
+        .and_then(|v| v.as_str())
+    {
+        metadata.insert(
+            "v1_conversation_id".to_string(),
+            conversation_id.to_string(),
+        );
+    }
+
+    metadata
+}
+
 fn apply_snapshot_inventory(
     exec_ctx: &mut ThreadExecutionContext,
     inventory: Option<Arc<crate::types::capability::ActionInventory>>,
@@ -803,7 +831,7 @@ async fn handle_llm_complete(
             .and_then(|cfg| cfg.get("model"))
             .and_then(|v| v.as_str())
             .map(String::from),
-        metadata: HashMap::new(),
+        metadata: llm_usage_metadata(thread, "chat"),
     };
 
     match deps.llm.complete(&messages, &actions, &config).await {

--- a/crates/ironclaw_engine/src/executor/orchestrator.rs
+++ b/crates/ironclaw_engine/src/executor/orchestrator.rs
@@ -44,7 +44,7 @@ use crate::types::message::ThreadMessage;
 use crate::types::project::ProjectId;
 use crate::types::shared_owner_id;
 use crate::types::step::{ActionCall, StepId, TokenUsage};
-use crate::types::thread::{ActiveSkillProvenance, Thread, ThreadState};
+use crate::types::thread::{ActiveSkillProvenance, LlmCallPurpose, Thread, ThreadState};
 
 /// The compiled-in default orchestrator (v0).
 pub(crate) const DEFAULT_ORCHESTRATOR: &str = include_str!("../../orchestrator/default.py");
@@ -801,7 +801,7 @@ async fn handle_llm_complete(
             .and_then(|cfg| cfg.get("model"))
             .and_then(|v| v.as_str())
             .map(String::from),
-        metadata: thread.llm_usage_metadata("chat"),
+        metadata: thread.llm_usage_metadata(LlmCallPurpose::Chat),
     };
 
     match deps.llm.complete(&messages, &actions, &config).await {
@@ -4245,11 +4245,11 @@ mod tests {
 
     // ── handle_llm_complete model forwarding ────────────────────
 
-    /// LLM backend that records the model from each `complete()` call.
+    /// LLM backend that records each `complete()` config.
     /// Used to verify the orchestrator's __llm_complete__ host fn forwards
-    /// `explicit_config["model"]` onto `LlmCallConfig.model`.
+    /// `explicit_config` and thread metadata onto `LlmCallConfig`.
     struct ModelCapturingLlm {
-        captured: tokio::sync::Mutex<Vec<Option<String>>>,
+        captured: tokio::sync::Mutex<Vec<LlmCallConfig>>,
     }
 
     #[async_trait::async_trait]
@@ -4264,7 +4264,7 @@ mod tests {
             _actions: &[crate::types::capability::ActionDef],
             config: &LlmCallConfig,
         ) -> Result<crate::traits::llm::LlmOutput, EngineError> {
-            self.captured.lock().await.push(config.model.clone());
+            self.captured.lock().await.push(config.clone());
             Ok(crate::traits::llm::LlmOutput {
                 response: crate::types::step::LlmResponse::Text("ok".into()),
                 usage: crate::types::step::TokenUsage::default(),
@@ -4480,7 +4480,66 @@ mod tests {
         assert!(matches!(result, ExtFunctionResult::Return(_)));
         let captured = concrete.captured.lock().await;
         assert_eq!(captured.len(), 1);
-        assert_eq!(captured[0].as_deref(), Some("gpt-4o"));
+        assert_eq!(captured[0].model.as_deref(), Some("gpt-4o"));
+    }
+
+    #[tokio::test]
+    async fn execute_orchestrator_llm_complete_forwards_thread_usage_metadata() {
+        let concrete = Arc::new(ModelCapturingLlm {
+            captured: tokio::sync::Mutex::new(Vec::new()),
+        });
+        let llm: Arc<dyn LlmBackend> = Arc::clone(&concrete) as Arc<dyn LlmBackend>;
+        let effects: Arc<dyn EffectExecutor> = Arc::new(NoopEffects);
+        let leases = Arc::new(LeaseManager::new());
+        let policy = Arc::new(PolicyEngine::new());
+        let store: Arc<dyn Store> = Arc::new(crate::tests::InMemoryStore::with_docs(vec![]));
+        let (_signal_tx, mut signal_rx) = crate::runtime::messaging::signal_channel(1);
+        let gate_controller = crate::gate::CancellingGateController::arc();
+
+        let mut thread = Thread::new(
+            "goal",
+            crate::types::thread::ThreadType::Foreground,
+            ProjectId::new(),
+            "test-user",
+            crate::types::thread::ThreadConfig::default(),
+        );
+        thread.metadata = serde_json::json!({
+            "conversation_scope": uuid::Uuid::new_v4().to_string(),
+            "v1_conversation_id": uuid::Uuid::new_v4().to_string(),
+        });
+        thread.transition_to(ThreadState::Running, None).unwrap();
+
+        let result = execute_orchestrator(
+            r#"
+llm_result = __llm_complete__([{"role": "user", "content": "hi"}], [], {})
+FINAL({"outcome": "completed", "response": llm_result["content"]})
+"#,
+            &mut thread,
+            &llm,
+            &effects,
+            &leases,
+            &policy,
+            &mut signal_rx,
+            None,
+            None,
+            Some(&store),
+            None,
+            &gate_controller,
+            &serde_json::json!({}),
+        )
+        .await
+        .expect("execute orchestrator");
+
+        assert!(matches!(
+            result.outcome,
+            ThreadOutcome::Completed { response: Some(_) }
+        ));
+        let captured = concrete.captured.lock().await;
+        assert_eq!(captured.len(), 1);
+        assert_eq!(
+            captured[0].metadata,
+            thread.llm_usage_metadata(LlmCallPurpose::Chat)
+        );
     }
 
     #[tokio::test]
@@ -4524,7 +4583,7 @@ mod tests {
 
         let captured = concrete.captured.lock().await;
         assert_eq!(captured.len(), 1);
-        assert_eq!(captured[0], None);
+        assert_eq!(captured[0].model, None);
     }
 
     #[tokio::test]

--- a/crates/ironclaw_engine/src/executor/scripting.rs
+++ b/crates/ironclaw_engine/src/executor/scripting.rs
@@ -3940,8 +3940,15 @@ except Exception as e:
     // ── llm_query model parameter plumbing ─────────────────────
 
     /// LLM backend that records every call's model + prompt for assertions.
+    #[derive(Clone)]
+    struct CapturedLlmCall {
+        model: Option<String>,
+        prompt: String,
+        metadata: HashMap<String, String>,
+    }
+
     struct CapturingLlm {
-        calls: tokio::sync::Mutex<Vec<(Option<String>, String, HashMap<String, String>)>>,
+        calls: tokio::sync::Mutex<Vec<CapturedLlmCall>>,
     }
 
     impl CapturingLlm {
@@ -3969,11 +3976,11 @@ except Exception as e:
                 .find(|m| matches!(m.role, crate::types::message::MessageRole::User))
                 .map(|m| m.content.clone())
                 .unwrap_or_default();
-            self.calls.lock().await.push((
-                config.model.clone(),
-                user_prompt.clone(),
-                config.metadata.clone(),
-            ));
+            self.calls.lock().await.push(CapturedLlmCall {
+                model: config.model.clone(),
+                prompt: user_prompt.clone(),
+                metadata: config.metadata.clone(),
+            });
             Ok(crate::traits::llm::LlmOutput {
                 response: crate::types::step::LlmResponse::Text(format!(
                     "ack:{}:{user_prompt}",
@@ -4014,8 +4021,8 @@ except Exception as e:
 
         let calls = llm.calls.lock().await;
         assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0].0.as_deref(), Some("gpt-4o"));
-        assert_eq!(calls[0].1, "what is 2+2?");
+        assert_eq!(calls[0].model.as_deref(), Some("gpt-4o"));
+        assert_eq!(calls[0].prompt, "what is 2+2?");
     }
 
     #[tokio::test]
@@ -4032,7 +4039,7 @@ except Exception as e:
 
         let calls = llm.calls.lock().await;
         assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0].0, None);
+        assert_eq!(calls[0].model, None);
     }
 
     #[tokio::test]
@@ -4078,8 +4085,11 @@ answer = await llm_query("summarize")
         );
         let calls = llm.calls.lock().await;
         assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0].1, "summarize");
-        assert_eq!(calls[0].2, thread.llm_usage_metadata(LlmCallPurpose::Chat));
+        assert_eq!(calls[0].prompt, "summarize");
+        assert_eq!(
+            calls[0].metadata,
+            thread.llm_usage_metadata(LlmCallPurpose::Chat)
+        );
     }
 
     #[tokio::test]
@@ -4112,11 +4122,11 @@ answer = await llm_query("summarize")
         }
 
         let mut calls = llm.calls.lock().await;
-        calls.sort_by(|a, b| a.0.cmp(&b.0));
+        calls.sort_by(|a, b| a.model.cmp(&b.model));
         assert_eq!(calls.len(), 3);
-        assert_eq!(calls[0].0.as_deref(), Some("claude-sonnet-4-20250514"));
-        assert_eq!(calls[1].0.as_deref(), Some("gpt-4o"));
-        assert_eq!(calls[2].0.as_deref(), Some("llama-3.1-70b-instruct"));
+        assert_eq!(calls[0].model.as_deref(), Some("claude-sonnet-4-20250514"));
+        assert_eq!(calls[1].model.as_deref(), Some("gpt-4o"));
+        assert_eq!(calls[2].model.as_deref(), Some("llama-3.1-70b-instruct"));
     }
 
     #[tokio::test]
@@ -4140,7 +4150,11 @@ answer = await llm_query("summarize")
 
         let calls = llm.calls.lock().await;
         assert_eq!(calls.len(), 2);
-        assert!(calls.iter().all(|(m, _, _)| m.as_deref() == Some("gpt-4o")));
+        assert!(
+            calls
+                .iter()
+                .all(|call| call.model.as_deref() == Some("gpt-4o"))
+        );
     }
 
     #[tokio::test]
@@ -4166,7 +4180,7 @@ answer = await llm_query("summarize")
 
         let calls = llm.calls.lock().await;
         assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0].0, None);
+        assert_eq!(calls[0].model, None);
     }
 
     #[tokio::test]
@@ -4209,7 +4223,7 @@ answer = await llm_query("summarize")
 
         let calls = llm.calls.lock().await;
         assert_eq!(calls.len(), 2);
-        assert!(calls.iter().all(|(m, _, _)| m.is_none()));
+        assert!(calls.iter().all(|call| call.model.is_none()));
     }
 
     #[tokio::test]
@@ -4242,7 +4256,11 @@ answer = await llm_query("summarize")
 
         let calls = llm.calls.lock().await;
         assert_eq!(calls.len(), 2);
-        assert!(calls.iter().all(|(m, _, _)| m.as_deref() == Some("gpt-4o")));
+        assert!(
+            calls
+                .iter()
+                .all(|call| call.model.as_deref() == Some("gpt-4o"))
+        );
     }
 
     #[tokio::test]
@@ -4271,10 +4289,10 @@ answer = await llm_query("summarize")
 
         assert!(matches!(result, ExtFunctionResult::Return(_)));
         let mut calls = llm.calls.lock().await;
-        calls.sort_by(|a, b| a.0.cmp(&b.0));
+        calls.sort_by(|a, b| a.model.cmp(&b.model));
         assert_eq!(calls.len(), 2);
-        assert_eq!(calls[0].0.as_deref(), Some("claude-sonnet-4-6"));
-        assert_eq!(calls[1].0.as_deref(), Some("gpt-4o"));
+        assert_eq!(calls[0].model.as_deref(), Some("claude-sonnet-4-6"));
+        assert_eq!(calls[1].model.as_deref(), Some("gpt-4o"));
     }
 
     #[tokio::test]
@@ -4299,7 +4317,7 @@ answer = await llm_query("summarize")
         assert!(matches!(result, ExtFunctionResult::Return(_)));
         let calls = llm.calls.lock().await;
         assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0].0, None);
+        assert_eq!(calls[0].model, None);
     }
 
     #[tokio::test]
@@ -4373,10 +4391,16 @@ answer = await llm_query("summarize")
         let calls = llm.calls.lock().await;
         assert_eq!(calls.len(), 2);
         // Slot 0 was None — must remain None, not become "claude-sonnet-4-20250514".
-        let slot_a = calls.iter().find(|(_, p, _)| p == "a").expect("call for a");
-        let slot_b = calls.iter().find(|(_, p, _)| p == "b").expect("call for b");
-        assert_eq!(slot_a.0, None);
-        assert_eq!(slot_b.0.as_deref(), Some("gpt-4o"));
+        let slot_a = calls
+            .iter()
+            .find(|call| call.prompt == "a")
+            .expect("call for a");
+        let slot_b = calls
+            .iter()
+            .find(|call| call.prompt == "b")
+            .expect("call for b");
+        assert_eq!(slot_a.model, None);
+        assert_eq!(slot_b.model.as_deref(), Some("gpt-4o"));
     }
 
     #[tokio::test]

--- a/crates/ironclaw_engine/src/executor/scripting.rs
+++ b/crates/ironclaw_engine/src/executor/scripting.rs
@@ -600,7 +600,7 @@ async fn execute_code_with_skills_inner(
     let mut events = Vec::new();
     let mut recursive_tokens = TokenUsage::default();
     let mut final_answer: Option<String> = None;
-    let llm_metadata = llm_usage_metadata(thread, "chat");
+    let llm_metadata = thread.llm_usage_metadata("chat");
 
     // Build context variables including persisted state from prior steps
     let (input_names, input_values) = build_context_inputs(thread, persisted_state);
@@ -1684,34 +1684,6 @@ async fn preflight_action(
     }
 
     PreflightResult::Approved(lease)
-}
-
-fn llm_usage_metadata(thread: &Thread, purpose: &str) -> HashMap<String, String> {
-    let mut metadata = HashMap::from([
-        ("thread_id".to_string(), thread.id.0.to_string()),
-        ("user_id".to_string(), thread.user_id.clone()),
-        ("purpose".to_string(), purpose.to_string()),
-    ]);
-
-    if let Some(scope) = thread
-        .metadata
-        .get("conversation_scope")
-        .and_then(|v| v.as_str())
-    {
-        metadata.insert("conversation_scope".to_string(), scope.to_string());
-    }
-    if let Some(conversation_id) = thread
-        .metadata
-        .get("v1_conversation_id")
-        .and_then(|v| v.as_str())
-    {
-        metadata.insert(
-            "v1_conversation_id".to_string(),
-            conversation_id.to_string(),
-        );
-    }
-
-    metadata
 }
 
 // ── llm_query() — recursive subagent (RLM 3.5) ─────────────

--- a/crates/ironclaw_engine/src/executor/scripting.rs
+++ b/crates/ironclaw_engine/src/executor/scripting.rs
@@ -68,7 +68,7 @@ use crate::types::error::EngineError;
 use crate::types::event::EventKind;
 use crate::types::message::{MessageRole, ThreadMessage};
 use crate::types::step::{ActionResult, CodeExecutionFailure, LlmResponse, TokenUsage};
-use crate::types::thread::Thread;
+use crate::types::thread::{LlmCallPurpose, Thread};
 use ironclaw_common::ValidTimezone;
 
 // ── Configuration ───────────────────────────────────────────
@@ -600,7 +600,7 @@ async fn execute_code_with_skills_inner(
     let mut events = Vec::new();
     let mut recursive_tokens = TokenUsage::default();
     let mut final_answer: Option<String> = None;
-    let llm_metadata = thread.llm_usage_metadata("chat");
+    let llm_metadata = thread.llm_usage_metadata(LlmCallPurpose::Chat);
 
     // Build context variables including persisted state from prior steps
     let (input_names, input_values) = build_context_inputs(thread, persisted_state);
@@ -3941,7 +3941,7 @@ except Exception as e:
 
     /// LLM backend that records every call's model + prompt for assertions.
     struct CapturingLlm {
-        calls: tokio::sync::Mutex<Vec<(Option<String>, String)>>,
+        calls: tokio::sync::Mutex<Vec<(Option<String>, String, HashMap<String, String>)>>,
     }
 
     impl CapturingLlm {
@@ -3969,10 +3969,11 @@ except Exception as e:
                 .find(|m| matches!(m.role, crate::types::message::MessageRole::User))
                 .map(|m| m.content.clone())
                 .unwrap_or_default();
-            self.calls
-                .lock()
-                .await
-                .push((config.model.clone(), user_prompt.clone()));
+            self.calls.lock().await.push((
+                config.model.clone(),
+                user_prompt.clone(),
+                config.metadata.clone(),
+            ));
             Ok(crate::traits::llm::LlmOutput {
                 response: crate::types::step::LlmResponse::Text(format!(
                     "ack:{}:{user_prompt}",
@@ -4035,6 +4036,53 @@ except Exception as e:
     }
 
     #[tokio::test]
+    async fn execute_code_llm_query_forwards_thread_usage_metadata() {
+        let llm = Arc::new(CapturingLlm::new());
+        let effects: Arc<dyn EffectExecutor> = Arc::new(MockEffects::new(vec![], vec![]));
+        let leases = LeaseManager::new();
+        let policy = PolicyEngine::new();
+        let mut thread = make_test_thread();
+        let conversation_scope = uuid::Uuid::new_v4();
+        let v1_conversation_id = uuid::Uuid::new_v4();
+        thread.metadata = serde_json::json!({
+            "conversation_scope": conversation_scope.to_string(),
+            "v1_conversation_id": v1_conversation_id.to_string(),
+        });
+        let ctx = make_exec_context(&thread);
+
+        leases
+            .grant(thread.id, "tools", GrantedActions::All, None, None)
+            .await
+            .unwrap();
+
+        let result = execute_code(
+            r#"
+answer = await llm_query("summarize")
+"#,
+            &thread,
+            &(Arc::clone(&llm) as Arc<dyn crate::traits::llm::LlmBackend>),
+            &effects,
+            &leases,
+            &policy,
+            &ctx,
+            &[],
+            &serde_json::json!({}),
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            result.failure.is_none(),
+            "unexpected failure: {:?}",
+            result.failure
+        );
+        let calls = llm.calls.lock().await;
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].1, "summarize");
+        assert_eq!(calls[0].2, thread.llm_usage_metadata(LlmCallPurpose::Chat));
+    }
+
+    #[tokio::test]
     async fn llm_query_batched_broadcasts_with_models_list() {
         let llm = Arc::new(CapturingLlm::new());
         let mut tokens = crate::types::step::TokenUsage::default();
@@ -4092,7 +4140,7 @@ except Exception as e:
 
         let calls = llm.calls.lock().await;
         assert_eq!(calls.len(), 2);
-        assert!(calls.iter().all(|(m, _)| m.as_deref() == Some("gpt-4o")));
+        assert!(calls.iter().all(|(m, _, _)| m.as_deref() == Some("gpt-4o")));
     }
 
     #[tokio::test]
@@ -4161,7 +4209,7 @@ except Exception as e:
 
         let calls = llm.calls.lock().await;
         assert_eq!(calls.len(), 2);
-        assert!(calls.iter().all(|(m, _)| m.is_none()));
+        assert!(calls.iter().all(|(m, _, _)| m.is_none()));
     }
 
     #[tokio::test]
@@ -4194,7 +4242,7 @@ except Exception as e:
 
         let calls = llm.calls.lock().await;
         assert_eq!(calls.len(), 2);
-        assert!(calls.iter().all(|(m, _)| m.as_deref() == Some("gpt-4o")));
+        assert!(calls.iter().all(|(m, _, _)| m.as_deref() == Some("gpt-4o")));
     }
 
     #[tokio::test]
@@ -4325,8 +4373,8 @@ except Exception as e:
         let calls = llm.calls.lock().await;
         assert_eq!(calls.len(), 2);
         // Slot 0 was None — must remain None, not become "claude-sonnet-4-20250514".
-        let slot_a = calls.iter().find(|(_, p)| p == "a").expect("call for a");
-        let slot_b = calls.iter().find(|(_, p)| p == "b").expect("call for b");
+        let slot_a = calls.iter().find(|(_, p, _)| p == "a").expect("call for a");
+        let slot_b = calls.iter().find(|(_, p, _)| p == "b").expect("call for b");
         assert_eq!(slot_a.0, None);
         assert_eq!(slot_b.0.as_deref(), Some("gpt-4o"));
     }

--- a/crates/ironclaw_engine/src/executor/scripting.rs
+++ b/crates/ironclaw_engine/src/executor/scripting.rs
@@ -600,6 +600,7 @@ async fn execute_code_with_skills_inner(
     let mut events = Vec::new();
     let mut recursive_tokens = TokenUsage::default();
     let mut final_answer: Option<String> = None;
+    let llm_metadata = llm_usage_metadata(thread, "chat");
 
     // Build context variables including persisted state from prior steps
     let (input_names, input_values) = build_context_inputs(thread, persisted_state);
@@ -786,8 +787,12 @@ async fn execute_code_with_skills_inner(
                         let args = call.args.clone();
                         let kwargs = call.kwargs.clone();
                         let llm = llm.clone();
+                        let metadata = llm_metadata.clone();
                         let handle = tokio::spawn(async move {
-                            handle_llm_query_standalone(&args, &kwargs, &llm).await
+                            handle_llm_query_standalone_with_metadata(
+                                &args, &kwargs, &llm, metadata,
+                            )
+                            .await
                         });
                         pending_futures.insert(monty_call_id, PendingFuture::Llm { handle });
                         None // handled as async below
@@ -796,8 +801,12 @@ async fn execute_code_with_skills_inner(
                         let args = call.args.clone();
                         let kwargs = call.kwargs.clone();
                         let llm = llm.clone();
+                        let metadata = llm_metadata.clone();
                         let handle = tokio::spawn(async move {
-                            handle_llm_query_batched_standalone(&args, &kwargs, &llm).await
+                            handle_llm_query_batched_standalone_with_metadata(
+                                &args, &kwargs, &llm, metadata,
+                            )
+                            .await
                         });
                         pending_futures.insert(monty_call_id, PendingFuture::Llm { handle });
                         None
@@ -1677,14 +1686,53 @@ async fn preflight_action(
     PreflightResult::Approved(lease)
 }
 
+fn llm_usage_metadata(thread: &Thread, purpose: &str) -> HashMap<String, String> {
+    let mut metadata = HashMap::from([
+        ("thread_id".to_string(), thread.id.0.to_string()),
+        ("user_id".to_string(), thread.user_id.clone()),
+        ("purpose".to_string(), purpose.to_string()),
+    ]);
+
+    if let Some(scope) = thread
+        .metadata
+        .get("conversation_scope")
+        .and_then(|v| v.as_str())
+    {
+        metadata.insert("conversation_scope".to_string(), scope.to_string());
+    }
+    if let Some(conversation_id) = thread
+        .metadata
+        .get("v1_conversation_id")
+        .and_then(|v| v.as_str())
+    {
+        metadata.insert(
+            "v1_conversation_id".to_string(),
+            conversation_id.to_string(),
+        );
+    }
+
+    metadata
+}
+
 // ── llm_query() — recursive subagent (RLM 3.5) ─────────────
 
 /// Handle `llm_query(prompt, context)` — single recursive sub-call.
+#[cfg(test)]
 async fn handle_llm_query(
     args: &[MontyObject],
     kwargs: &[(MontyObject, MontyObject)],
     llm: &Arc<dyn LlmBackend>,
     recursive_tokens: &mut TokenUsage,
+) -> ExtFunctionResult {
+    handle_llm_query_with_metadata(args, kwargs, llm, recursive_tokens, &HashMap::new()).await
+}
+
+async fn handle_llm_query_with_metadata(
+    args: &[MontyObject],
+    kwargs: &[(MontyObject, MontyObject)],
+    llm: &Arc<dyn LlmBackend>,
+    recursive_tokens: &mut TokenUsage,
+    metadata: &HashMap<String, String>,
 ) -> ExtFunctionResult {
     let prompt = extract_string_arg(args, kwargs, "prompt", 0);
     let context_arg = extract_string_arg(args, kwargs, "context", 1);
@@ -1724,6 +1772,7 @@ async fn handle_llm_query(
     let config = LlmCallConfig {
         force_text: true,
         model: model_arg,
+        metadata: metadata.clone(),
         ..LlmCallConfig::default()
     };
 
@@ -1750,11 +1799,23 @@ async fn handle_llm_query(
 ///
 /// Takes a list of prompt strings and dispatches them concurrently.
 /// Returns a list of response strings in the same order.
+#[cfg(test)]
 async fn handle_llm_query_batched(
     args: &[MontyObject],
     kwargs: &[(MontyObject, MontyObject)],
     llm: &Arc<dyn LlmBackend>,
     recursive_tokens: &mut TokenUsage,
+) -> ExtFunctionResult {
+    handle_llm_query_batched_with_metadata(args, kwargs, llm, recursive_tokens, &HashMap::new())
+        .await
+}
+
+async fn handle_llm_query_batched_with_metadata(
+    args: &[MontyObject],
+    kwargs: &[(MontyObject, MontyObject)],
+    llm: &Arc<dyn LlmBackend>,
+    recursive_tokens: &mut TokenUsage,
+    metadata: &HashMap<String, String>,
 ) -> ExtFunctionResult {
     // Extract prompts list (first arg or kwarg "prompts")
     let prompts_obj = args.first().or_else(|| {
@@ -1878,6 +1939,7 @@ async fn handle_llm_query_batched(
         let config = LlmCallConfig {
             force_text: true,
             model: model_override,
+            metadata: metadata.clone(),
             ..LlmCallConfig::default()
         };
         handles.push(tokio::spawn(async move {
@@ -2088,25 +2150,26 @@ async fn handle_rlm_query(
 
 // ── Standalone async handlers (for tokio::spawn) ────────────
 
-/// `llm_query()` — standalone version that returns `(ExtFunctionResult, TokenUsage)`.
-async fn handle_llm_query_standalone(
+async fn handle_llm_query_standalone_with_metadata(
     args: &[MontyObject],
     kwargs: &[(MontyObject, MontyObject)],
     llm: &Arc<dyn LlmBackend>,
+    metadata: HashMap<String, String>,
 ) -> (ExtFunctionResult, TokenUsage) {
     let mut tokens = TokenUsage::default();
-    let result = handle_llm_query(args, kwargs, llm, &mut tokens).await;
+    let result = handle_llm_query_with_metadata(args, kwargs, llm, &mut tokens, &metadata).await;
     (result, tokens)
 }
 
-/// `llm_query_batched()` — standalone version.
-async fn handle_llm_query_batched_standalone(
+async fn handle_llm_query_batched_standalone_with_metadata(
     args: &[MontyObject],
     kwargs: &[(MontyObject, MontyObject)],
     llm: &Arc<dyn LlmBackend>,
+    metadata: HashMap<String, String>,
 ) -> (ExtFunctionResult, TokenUsage) {
     let mut tokens = TokenUsage::default();
-    let result = handle_llm_query_batched(args, kwargs, llm, &mut tokens).await;
+    let result =
+        handle_llm_query_batched_with_metadata(args, kwargs, llm, &mut tokens, &metadata).await;
     (result, tokens)
 }
 

--- a/crates/ironclaw_engine/src/lib.rs
+++ b/crates/ironclaw_engine/src/lib.rs
@@ -53,7 +53,7 @@ pub use types::step::{
     StepStatus, TokenUsage,
 };
 pub use types::thread::{
-    ActiveSkillProvenance, Thread, ThreadConfig, ThreadId, ThreadState, ThreadType,
+    ActiveSkillProvenance, LlmCallPurpose, Thread, ThreadConfig, ThreadId, ThreadState, ThreadType,
 };
 
 // ── Re-exports: traits ──────────────────────────────────────

--- a/crates/ironclaw_engine/src/types/thread.rs
+++ b/crates/ironclaw_engine/src/types/thread.rs
@@ -111,6 +111,19 @@ pub enum ThreadType {
     Mission,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum LlmCallPurpose {
+    Chat,
+}
+
+impl LlmCallPurpose {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Chat => "chat",
+        }
+    }
+}
+
 // ── Thread configuration ────────────────────────────────────
 
 /// Execution parameters for a thread.
@@ -311,11 +324,11 @@ impl Thread {
     }
 
     /// Metadata attached to engine LLM usage accounting records.
-    pub fn llm_usage_metadata(&self, purpose: &str) -> HashMap<String, String> {
+    pub fn llm_usage_metadata(&self, purpose: LlmCallPurpose) -> HashMap<String, String> {
         let mut metadata = HashMap::from([
             ("thread_id".to_string(), self.id.0.to_string()),
             ("user_id".to_string(), self.user_id.clone()),
-            ("purpose".to_string(), purpose.to_string()),
+            ("purpose".to_string(), purpose.as_str().to_string()),
         ]);
 
         if let Some(scope) = self
@@ -608,7 +621,7 @@ mod tests {
             "ignored_non_string": 123,
         });
 
-        let metadata = thread.llm_usage_metadata("chat");
+        let metadata = thread.llm_usage_metadata(LlmCallPurpose::Chat);
 
         assert_eq!(metadata.get("thread_id"), Some(&thread.id.0.to_string()));
         assert_eq!(metadata.get("user_id"), Some(&thread.user_id));

--- a/crates/ironclaw_engine/src/types/thread.rs
+++ b/crates/ironclaw_engine/src/types/thread.rs
@@ -19,6 +19,8 @@ use crate::types::project::ProjectId;
 
 use super::{OwnerId, default_user_id};
 
+const LLM_USAGE_METADATA_USER_ID_MAX_LEN: usize = 255;
+
 /// Strongly-typed thread identifier.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ThreadId(pub Uuid);
@@ -328,9 +330,11 @@ impl Thread {
     pub fn llm_usage_metadata(&self, purpose: LlmCallPurpose) -> HashMap<String, String> {
         let mut metadata = HashMap::from([
             ("thread_id".to_string(), self.id.0.to_string()),
-            ("user_id".to_string(), self.user_id.clone()),
             ("purpose".to_string(), purpose.as_str().to_string()),
         ]);
+        if !self.user_id.is_empty() && self.user_id.len() <= LLM_USAGE_METADATA_USER_ID_MAX_LEN {
+            metadata.insert("user_id".to_string(), self.user_id.clone());
+        }
 
         if let Some(scope) = self
             .metadata
@@ -636,6 +640,18 @@ mod tests {
             Some(&"conv-1".to_string())
         );
         assert!(!metadata.contains_key("ignored_non_string"));
+    }
+
+    #[test]
+    fn llm_usage_metadata_omits_invalid_user_id() {
+        let mut thread = make_thread();
+        thread.user_id = "u".repeat(LLM_USAGE_METADATA_USER_ID_MAX_LEN + 1);
+
+        let metadata = thread.llm_usage_metadata(LlmCallPurpose::Chat);
+
+        assert!(!metadata.contains_key("user_id"));
+        assert_eq!(metadata.get("thread_id"), Some(&thread.id.0.to_string()));
+        assert_eq!(metadata.get("purpose"), Some(&"chat".to_string()));
     }
 
     // ── Title derivation ─────────────────────────────────────

--- a/crates/ironclaw_engine/src/types/thread.rs
+++ b/crates/ironclaw_engine/src/types/thread.rs
@@ -112,6 +112,7 @@ pub enum ThreadType {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum LlmCallPurpose {
     Chat,
 }

--- a/crates/ironclaw_engine/src/types/thread.rs
+++ b/crates/ironclaw_engine/src/types/thread.rs
@@ -7,6 +7,7 @@
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use uuid::Uuid;
 
 use crate::types::capability::LeaseId;
@@ -309,6 +310,35 @@ impl Thread {
         self.owner_id().matches_user(user_id)
     }
 
+    /// Metadata attached to engine LLM usage accounting records.
+    pub fn llm_usage_metadata(&self, purpose: &str) -> HashMap<String, String> {
+        let mut metadata = HashMap::from([
+            ("thread_id".to_string(), self.id.0.to_string()),
+            ("user_id".to_string(), self.user_id.clone()),
+            ("purpose".to_string(), purpose.to_string()),
+        ]);
+
+        if let Some(scope) = self
+            .metadata
+            .get("conversation_scope")
+            .and_then(|v| v.as_str())
+        {
+            metadata.insert("conversation_scope".to_string(), scope.to_string());
+        }
+        if let Some(conversation_id) = self
+            .metadata
+            .get("v1_conversation_id")
+            .and_then(|v| v.as_str())
+        {
+            metadata.insert(
+                "v1_conversation_id".to_string(),
+                conversation_id.to_string(),
+            );
+        }
+
+        metadata
+    }
+
     /// Persist active skill provenance in thread metadata.
     pub fn set_active_skills(
         &mut self,
@@ -567,6 +597,31 @@ mod tests {
         )
         .with_parent(parent.id);
         assert_eq!(child.parent_id, Some(parent.id));
+    }
+
+    #[test]
+    fn llm_usage_metadata_includes_thread_identity_and_conversation_context() {
+        let mut thread = make_thread();
+        thread.metadata = serde_json::json!({
+            "conversation_scope": "scope-1",
+            "v1_conversation_id": "conv-1",
+            "ignored_non_string": 123,
+        });
+
+        let metadata = thread.llm_usage_metadata("chat");
+
+        assert_eq!(metadata.get("thread_id"), Some(&thread.id.0.to_string()));
+        assert_eq!(metadata.get("user_id"), Some(&thread.user_id));
+        assert_eq!(metadata.get("purpose"), Some(&"chat".to_string()));
+        assert_eq!(
+            metadata.get("conversation_scope"),
+            Some(&"scope-1".to_string())
+        );
+        assert_eq!(
+            metadata.get("v1_conversation_id"),
+            Some(&"conv-1".to_string())
+        );
+        assert!(!metadata.contains_key("ignored_non_string"));
     }
 
     // ── Title derivation ─────────────────────────────────────

--- a/src/bridge/llm_adapter.rs
+++ b/src/bridge/llm_adapter.rs
@@ -21,6 +21,8 @@ use ironclaw_llm::{
 };
 
 const EMPTY_CLEANED_RESPONSE_FALLBACK: &str = "I'm not sure how to respond to that.";
+const LLM_CALL_PURPOSE_CHAT: &str = "chat";
+const LLM_CALL_PURPOSE_MAX_LEN: usize = 32;
 
 /// Compute the USD cost of a single completion response, honoring the
 /// provider's prompt-caching pricing. Mirrors the formula in
@@ -100,10 +102,17 @@ impl LlmUsageRecorder {
         cost_guard: Arc<CostGuard>,
         provider_name: impl Into<String>,
     ) -> Self {
+        let provider_name = provider_name.into();
+        if db.is_none() && provider_name != "test-disabled" {
+            tracing::warn!(
+                provider = %provider_name,
+                "engine v2 LLM usage recorder initialized without database; durable usage persistence disabled"
+            );
+        }
         Self {
             db,
             cost_guard,
-            provider_name: provider_name.into(),
+            provider_name,
         }
     }
 
@@ -114,6 +123,12 @@ impl LlmUsageRecorder {
         tokens: LlmTokenBuckets,
     ) -> Result<(), EngineError> {
         let model = provider.effective_model_name(config.model.as_deref());
+        let db = self.db.as_ref();
+        let purpose = if db.is_some() {
+            validate_llm_call_purpose(config.metadata.get("purpose"))?
+        } else {
+            None
+        };
         let cost_per_token = if config.model.is_some() {
             None
         } else {
@@ -152,7 +167,7 @@ impl LlmUsageRecorder {
             }
         };
 
-        let Some(db) = self.db.as_ref() else {
+        let Some(db) = db else {
             return Ok(());
         };
 
@@ -166,7 +181,6 @@ impl LlmUsageRecorder {
                     .get("conversation_scope")
                     .and_then(|value| Uuid::parse_str(value).ok())
             });
-        let purpose = config.metadata.get("purpose").map(String::as_str);
         let record = LlmCallRecord {
             job_id: None,
             conversation_id,
@@ -185,6 +199,26 @@ impl LlmUsageRecorder {
             })?;
         Ok(())
     }
+}
+
+fn validate_llm_call_purpose(value: Option<&String>) -> Result<Option<&str>, EngineError> {
+    let Some(purpose) = value.map(String::as_str) else {
+        return Ok(None);
+    };
+    if purpose.len() > LLM_CALL_PURPOSE_MAX_LEN {
+        return Err(EngineError::Store {
+            reason: format!(
+                "invalid engine v2 LLM usage purpose: length {} exceeds {LLM_CALL_PURPOSE_MAX_LEN}",
+                purpose.len()
+            ),
+        });
+    }
+    if purpose != LLM_CALL_PURPOSE_CHAT {
+        return Err(EngineError::Store {
+            reason: format!("invalid engine v2 LLM usage purpose: {purpose}"),
+        });
+    }
+    Ok(Some(purpose))
 }
 
 impl LlmBridgeAdapter {
@@ -1113,6 +1147,41 @@ mod tests {
         assert!(
             err.to_string()
                 .contains("failed to persist engine v2 LLM usage"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[cfg(feature = "libsql")]
+    #[tokio::test]
+    async fn complete_rejects_invalid_engine_v2_usage_purpose() {
+        use crate::agent::cost_guard::{CostGuard, CostGuardConfig};
+        use crate::db::Database;
+
+        let backend = crate::db::libsql::LibSqlBackend::new_memory()
+            .await
+            .expect("LibSqlBackend");
+        let db: Arc<dyn Database> = Arc::new(backend);
+        let cost_guard = Arc::new(CostGuard::new(CostGuardConfig::default()));
+        let provider: Arc<dyn LlmProvider> = Arc::new(PricedProvider);
+        let adapter = LlmBridgeAdapter::new(
+            provider,
+            None,
+            Arc::new(LlmUsageRecorder::new(Some(db), cost_guard, "test-backend")),
+        );
+        let mut config = LlmCallConfig::default();
+        config
+            .metadata
+            .insert("purpose".to_string(), "billing".to_string());
+
+        let err = adapter
+            .complete(&[ThreadMessage::user("hello")], &[], &config)
+            .await
+            .expect_err("invalid durable usage purpose must fail");
+
+        assert!(matches!(err, EngineError::Store { .. }));
+        assert!(
+            err.to_string()
+                .contains("invalid engine v2 LLM usage purpose"),
             "unexpected error: {err}"
         );
     }

--- a/src/bridge/llm_adapter.rs
+++ b/src/bridge/llm_adapter.rs
@@ -10,7 +10,11 @@ use ironclaw_engine::{
 };
 use rust_decimal::Decimal;
 use rust_decimal::prelude::ToPrimitive;
+use uuid::Uuid;
 
+use crate::agent::cost_guard::CostGuard;
+use crate::db::Database;
+use crate::history::LlmCallRecord;
 use ironclaw_llm::{
     ChatMessage, LlmProvider, Role, ToolCall, ToolCompletionRequest, ToolDefinition,
     clean_response, recover_tool_calls_from_content, sanitize_tool_messages,
@@ -73,6 +77,102 @@ pub struct LlmBridgeAdapter {
     provider: Arc<dyn LlmProvider>,
     /// Optional cheaper provider for sub-calls (depth > 0).
     cheap_provider: Option<Arc<dyn LlmProvider>>,
+    usage_recorder: Option<Arc<LlmUsageRecorder>>,
+}
+
+pub struct LlmUsageRecorder {
+    db: Option<Arc<dyn Database>>,
+    cost_guard: Arc<CostGuard>,
+    provider_name: String,
+}
+
+impl LlmUsageRecorder {
+    pub fn new(
+        db: Option<Arc<dyn Database>>,
+        cost_guard: Arc<CostGuard>,
+        provider_name: impl Into<String>,
+    ) -> Self {
+        Self {
+            db,
+            cost_guard,
+            provider_name: provider_name.into(),
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn record(
+        &self,
+        provider: &Arc<dyn LlmProvider>,
+        config: &LlmCallConfig,
+        input_tokens: u32,
+        output_tokens: u32,
+        cache_read_input_tokens: u32,
+        cache_creation_input_tokens: u32,
+    ) {
+        let model = provider.effective_model_name(config.model.as_deref());
+        let cost_per_token = if config.model.is_some() {
+            None
+        } else {
+            Some(provider.cost_per_token())
+        };
+        let user_id = config.metadata.get("user_id");
+        let cost = match user_id {
+            Some(user_id) => {
+                self.cost_guard
+                    .record_llm_call_for_user(
+                        user_id,
+                        &model,
+                        input_tokens,
+                        output_tokens,
+                        cache_read_input_tokens,
+                        cache_creation_input_tokens,
+                        provider.cache_read_discount(),
+                        provider.cache_write_multiplier(),
+                        cost_per_token,
+                    )
+                    .await
+            }
+            None => {
+                self.cost_guard
+                    .record_llm_call(
+                        &model,
+                        input_tokens,
+                        output_tokens,
+                        cache_read_input_tokens,
+                        cache_creation_input_tokens,
+                        provider.cache_read_discount(),
+                        provider.cache_write_multiplier(),
+                        cost_per_token,
+                    )
+                    .await
+            }
+        };
+
+        let Some(db) = self.db.as_ref() else {
+            return;
+        };
+
+        let conversation_id = config
+            .metadata
+            .get("v1_conversation_id")
+            .or_else(|| config.metadata.get("conversation_scope"))
+            .and_then(|value| Uuid::parse_str(value).ok());
+        let purpose = config.metadata.get("purpose").map(String::as_str);
+        let record = LlmCallRecord {
+            job_id: None,
+            conversation_id,
+            provider: &self.provider_name,
+            model: &model,
+            input_tokens,
+            output_tokens,
+            cost,
+            purpose,
+        };
+
+        if let Err(e) = db.record_llm_call(&record).await {
+            tracing::warn!("Failed to persist engine v2 LLM call to DB: {e}");
+        }
+    }
 }
 
 impl LlmBridgeAdapter {
@@ -83,7 +183,13 @@ impl LlmBridgeAdapter {
         Self {
             provider,
             cheap_provider,
+            usage_recorder: None,
         }
+    }
+
+    pub fn with_usage_recorder(mut self, usage_recorder: Arc<LlmUsageRecorder>) -> Self {
+        self.usage_recorder = Some(usage_recorder);
+        self
     }
 
     fn provider_for_depth(&self, depth: u32) -> &Arc<dyn LlmProvider> {
@@ -91,6 +197,29 @@ impl LlmBridgeAdapter {
             self.cheap_provider.as_ref().unwrap_or(&self.provider)
         } else {
             &self.provider
+        }
+    }
+
+    async fn record_usage(
+        &self,
+        provider: &Arc<dyn LlmProvider>,
+        config: &LlmCallConfig,
+        input_tokens: u32,
+        output_tokens: u32,
+        cache_read_input_tokens: u32,
+        cache_creation_input_tokens: u32,
+    ) {
+        if let Some(recorder) = self.usage_recorder.as_ref() {
+            recorder
+                .record(
+                    provider,
+                    config,
+                    input_tokens,
+                    output_tokens,
+                    cache_read_input_tokens,
+                    cache_creation_input_tokens,
+                )
+                .await;
         }
     }
 }
@@ -152,6 +281,15 @@ impl LlmBackend for LlmBridgeAdapter {
                 .map_err(|e| EngineError::Llm {
                     reason: e.to_string(),
                 })?;
+            self.record_usage(
+                provider,
+                config,
+                response.input_tokens,
+                response.output_tokens,
+                response.cache_read_input_tokens,
+                response.cache_creation_input_tokens,
+            )
+            .await;
 
             let cleaned_text = clean_response(&response.content);
 
@@ -195,6 +333,15 @@ impl LlmBackend for LlmBridgeAdapter {
                 .map_err(|e| EngineError::Llm {
                     reason: e.to_string(),
                 })?;
+        self.record_usage(
+            provider,
+            config,
+            response.input_tokens,
+            response.output_tokens,
+            response.cache_read_input_tokens,
+            response.cache_creation_input_tokens,
+        )
+        .await;
 
         // Convert response — check for code blocks (CodeAct/RLM pattern)
         let llm_response = if !response.tool_calls.is_empty() {
@@ -795,6 +942,123 @@ mod tests {
         assert_eq!(sent[2].content, "[Tool `search` returned: result payload]");
         assert!(sent[2].tool_call_id.is_none());
         assert!(sent[2].name.is_none());
+    }
+
+    #[cfg(feature = "libsql")]
+    #[tokio::test]
+    async fn complete_records_engine_v2_usage_for_admin_aggregates() {
+        use chrono::Utc;
+
+        use crate::agent::cost_guard::{CostGuard, CostGuardConfig};
+        use crate::db::{Database, UserRecord};
+
+        struct PricedUsageProvider;
+
+        #[async_trait]
+        impl LlmProvider for PricedUsageProvider {
+            fn model_name(&self) -> &str {
+                "priced-usage-model"
+            }
+
+            fn cost_per_token(&self) -> (Decimal, Decimal) {
+                (Decimal::new(1, 2), Decimal::new(2, 2))
+            }
+
+            async fn complete(
+                &self,
+                _req: ironclaw_llm::CompletionRequest,
+            ) -> Result<ironclaw_llm::CompletionResponse, LlmError> {
+                Ok(ironclaw_llm::CompletionResponse {
+                    content: "ok".to_string(),
+                    input_tokens: 3,
+                    output_tokens: 2,
+                    finish_reason: ironclaw_llm::FinishReason::Stop,
+                    reasoning: None,
+                    cache_read_input_tokens: 0,
+                    cache_creation_input_tokens: 0,
+                })
+            }
+
+            async fn complete_with_tools(
+                &self,
+                _req: ToolCompletionRequest,
+            ) -> Result<ToolCompletionResponse, LlmError> {
+                unreachable!()
+            }
+        }
+
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let db_path = temp_dir.path().join("usage.db");
+        let backend = crate::db::libsql::LibSqlBackend::new_local(&db_path)
+            .await
+            .expect("LibSqlBackend");
+        backend.run_migrations().await.expect("migrations");
+        let db: Arc<dyn Database> = Arc::new(backend);
+        db.create_user(&UserRecord {
+            id: "alice".to_string(),
+            email: Some("alice@example.com".to_string()),
+            display_name: "alice".to_string(),
+            status: "active".to_string(),
+            role: "member".to_string(),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            last_login_at: None,
+            created_by: None,
+            metadata: serde_json::json!({}),
+        })
+        .await
+        .expect("create user");
+        let conversation_id = db
+            .create_conversation("web", "alice", Some("thread-1"))
+            .await
+            .expect("create conversation");
+
+        let cost_guard = Arc::new(CostGuard::new(CostGuardConfig::default()));
+        let provider: Arc<dyn LlmProvider> = Arc::new(PricedUsageProvider);
+        let adapter = LlmBridgeAdapter::new(provider, None).with_usage_recorder(Arc::new(
+            LlmUsageRecorder::new(
+                Some(Arc::clone(&db)),
+                Arc::clone(&cost_guard),
+                "test-backend",
+            ),
+        ));
+        let mut config = LlmCallConfig::default();
+        config
+            .metadata
+            .insert("user_id".to_string(), "alice".to_string());
+        config.metadata.insert(
+            "v1_conversation_id".to_string(),
+            conversation_id.to_string(),
+        );
+        config
+            .metadata
+            .insert("purpose".to_string(), "chat".to_string());
+
+        adapter
+            .complete(&[ThreadMessage::user("hello")], &[], &config)
+            .await
+            .expect("complete");
+
+        let usage = db
+            .user_usage_stats(Some("alice"), Utc::now() - chrono::Duration::hours(1))
+            .await
+            .expect("usage stats");
+        assert_eq!(usage.len(), 1);
+        assert_eq!(usage[0].user_id, "alice");
+        assert_eq!(usage[0].model, "priced-usage-model");
+        assert_eq!(usage[0].call_count, 1);
+        assert_eq!(usage[0].input_tokens, 3);
+        assert_eq!(usage[0].output_tokens, 2);
+        assert!(usage[0].total_cost > Decimal::ZERO);
+
+        let summaries = db
+            .user_summary_stats(Some("alice"))
+            .await
+            .expect("summary stats");
+        assert_eq!(summaries.len(), 1);
+        assert_eq!(summaries[0].user_id, "alice");
+        assert!(summaries[0].last_active_at.is_some());
+        assert_eq!(cost_guard.actions_this_hour().await, 1);
     }
 
     #[tokio::test]

--- a/src/bridge/llm_adapter.rs
+++ b/src/bridge/llm_adapter.rs
@@ -72,11 +72,21 @@ fn cost_usd_from(
     cost.to_f64().unwrap_or(0.0)
 }
 
+#[derive(Clone, Copy)]
+struct LlmTokenBuckets {
+    input_tokens: u32,
+    output_tokens: u32,
+    cache_read_input_tokens: u32,
+    cache_creation_input_tokens: u32,
+}
+
 /// Wraps an existing `LlmProvider` to implement the engine's `LlmBackend` trait.
 pub struct LlmBridgeAdapter {
     provider: Arc<dyn LlmProvider>,
     /// Optional cheaper provider for sub-calls (depth > 0).
     cheap_provider: Option<Arc<dyn LlmProvider>>,
+    /// Optional for unit tests and hostless adapter use; production engine
+    /// initialization attaches a recorder in `bridge::router::init_engine`.
     usage_recorder: Option<Arc<LlmUsageRecorder>>,
 }
 
@@ -99,16 +109,12 @@ impl LlmUsageRecorder {
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
     async fn record(
         &self,
         provider: &Arc<dyn LlmProvider>,
         config: &LlmCallConfig,
-        input_tokens: u32,
-        output_tokens: u32,
-        cache_read_input_tokens: u32,
-        cache_creation_input_tokens: u32,
-    ) {
+        tokens: LlmTokenBuckets,
+    ) -> Result<(), EngineError> {
         let model = provider.effective_model_name(config.model.as_deref());
         let cost_per_token = if config.model.is_some() {
             None
@@ -122,10 +128,10 @@ impl LlmUsageRecorder {
                     .record_llm_call_for_user(
                         user_id,
                         &model,
-                        input_tokens,
-                        output_tokens,
-                        cache_read_input_tokens,
-                        cache_creation_input_tokens,
+                        tokens.input_tokens,
+                        tokens.output_tokens,
+                        tokens.cache_read_input_tokens,
+                        tokens.cache_creation_input_tokens,
                         provider.cache_read_discount(),
                         provider.cache_write_multiplier(),
                         cost_per_token,
@@ -136,10 +142,10 @@ impl LlmUsageRecorder {
                 self.cost_guard
                     .record_llm_call(
                         &model,
-                        input_tokens,
-                        output_tokens,
-                        cache_read_input_tokens,
-                        cache_creation_input_tokens,
+                        tokens.input_tokens,
+                        tokens.output_tokens,
+                        tokens.cache_read_input_tokens,
+                        tokens.cache_creation_input_tokens,
                         provider.cache_read_discount(),
                         provider.cache_write_multiplier(),
                         cost_per_token,
@@ -149,29 +155,37 @@ impl LlmUsageRecorder {
         };
 
         let Some(db) = self.db.as_ref() else {
-            return;
+            return Ok(());
         };
 
         let conversation_id = config
             .metadata
             .get("v1_conversation_id")
-            .or_else(|| config.metadata.get("conversation_scope"))
-            .and_then(|value| Uuid::parse_str(value).ok());
+            .and_then(|value| Uuid::parse_str(value).ok())
+            .or_else(|| {
+                config
+                    .metadata
+                    .get("conversation_scope")
+                    .and_then(|value| Uuid::parse_str(value).ok())
+            });
         let purpose = config.metadata.get("purpose").map(String::as_str);
         let record = LlmCallRecord {
             job_id: None,
             conversation_id,
             provider: &self.provider_name,
             model: &model,
-            input_tokens,
-            output_tokens,
+            input_tokens: tokens.input_tokens,
+            output_tokens: tokens.output_tokens,
             cost,
             purpose,
         };
 
-        if let Err(e) = db.record_llm_call(&record).await {
-            tracing::warn!("Failed to persist engine v2 LLM call to DB: {e}");
-        }
+        db.record_llm_call(&record)
+            .await
+            .map_err(|e| EngineError::Store {
+                reason: format!("failed to persist engine v2 LLM usage: {e}"),
+            })?;
+        Ok(())
     }
 }
 
@@ -204,23 +218,12 @@ impl LlmBridgeAdapter {
         &self,
         provider: &Arc<dyn LlmProvider>,
         config: &LlmCallConfig,
-        input_tokens: u32,
-        output_tokens: u32,
-        cache_read_input_tokens: u32,
-        cache_creation_input_tokens: u32,
-    ) {
+        tokens: LlmTokenBuckets,
+    ) -> Result<(), EngineError> {
         if let Some(recorder) = self.usage_recorder.as_ref() {
-            recorder
-                .record(
-                    provider,
-                    config,
-                    input_tokens,
-                    output_tokens,
-                    cache_read_input_tokens,
-                    cache_creation_input_tokens,
-                )
-                .await;
+            recorder.record(provider, config, tokens).await?;
         }
+        Ok(())
     }
 }
 
@@ -284,12 +287,14 @@ impl LlmBackend for LlmBridgeAdapter {
             self.record_usage(
                 provider,
                 config,
-                response.input_tokens,
-                response.output_tokens,
-                response.cache_read_input_tokens,
-                response.cache_creation_input_tokens,
+                LlmTokenBuckets {
+                    input_tokens: response.input_tokens,
+                    output_tokens: response.output_tokens,
+                    cache_read_input_tokens: response.cache_read_input_tokens,
+                    cache_creation_input_tokens: response.cache_creation_input_tokens,
+                },
             )
-            .await;
+            .await?;
 
             let cleaned_text = clean_response(&response.content);
 
@@ -336,12 +341,14 @@ impl LlmBackend for LlmBridgeAdapter {
         self.record_usage(
             provider,
             config,
-            response.input_tokens,
-            response.output_tokens,
-            response.cache_read_input_tokens,
-            response.cache_creation_input_tokens,
+            LlmTokenBuckets {
+                input_tokens: response.input_tokens,
+                output_tokens: response.output_tokens,
+                cache_read_input_tokens: response.cache_read_input_tokens,
+                cache_creation_input_tokens: response.cache_creation_input_tokens,
+            },
         )
-        .await;
+        .await?;
 
         // Convert response — check for code blocks (CodeAct/RLM pattern)
         let llm_response = if !response.tool_calls.is_empty() {
@@ -1026,8 +1033,11 @@ mod tests {
         config
             .metadata
             .insert("user_id".to_string(), "alice".to_string());
+        config
+            .metadata
+            .insert("v1_conversation_id".to_string(), "not-a-uuid".to_string());
         config.metadata.insert(
-            "v1_conversation_id".to_string(),
+            "conversation_scope".to_string(),
             conversation_id.to_string(),
         );
         config
@@ -1059,6 +1069,39 @@ mod tests {
         assert_eq!(summaries[0].user_id, "alice");
         assert!(summaries[0].last_active_at.is_some());
         assert_eq!(cost_guard.actions_this_hour().await, 1);
+    }
+
+    #[cfg(feature = "libsql")]
+    #[tokio::test]
+    async fn complete_fails_when_engine_v2_usage_persistence_fails() {
+        use crate::agent::cost_guard::{CostGuard, CostGuardConfig};
+        use crate::db::Database;
+
+        let backend = crate::db::libsql::LibSqlBackend::new_memory()
+            .await
+            .expect("LibSqlBackend");
+        let db: Arc<dyn Database> = Arc::new(backend);
+        let cost_guard = Arc::new(CostGuard::new(CostGuardConfig::default()));
+        let provider: Arc<dyn LlmProvider> = Arc::new(PricedProvider);
+        let adapter = LlmBridgeAdapter::new(provider, None).with_usage_recorder(Arc::new(
+            LlmUsageRecorder::new(Some(db), cost_guard, "test-backend"),
+        ));
+
+        let err = adapter
+            .complete(
+                &[ThreadMessage::user("hello")],
+                &[],
+                &LlmCallConfig::default(),
+            )
+            .await
+            .expect_err("unmigrated DB must fail durable usage recording");
+
+        assert!(matches!(err, EngineError::Store { .. }));
+        assert!(
+            err.to_string()
+                .contains("failed to persist engine v2 LLM usage"),
+            "unexpected error: {err}"
+        );
     }
 
     #[tokio::test]

--- a/src/bridge/llm_adapter.rs
+++ b/src/bridge/llm_adapter.rs
@@ -23,6 +23,7 @@ use ironclaw_llm::{
 const EMPTY_CLEANED_RESPONSE_FALLBACK: &str = "I'm not sure how to respond to that.";
 const LLM_CALL_PURPOSE_CHAT: &str = "chat";
 const LLM_CALL_PURPOSE_MAX_LEN: usize = 32;
+const LLM_METADATA_USER_ID_MAX_LEN: usize = 255;
 
 /// Compute the USD cost of a single completion response, honoring the
 /// provider's prompt-caching pricing. Mirrors the formula in
@@ -123,18 +124,10 @@ impl LlmUsageRecorder {
         tokens: LlmTokenBuckets,
     ) -> Result<(), EngineError> {
         let model = provider.effective_model_name(config.model.as_deref());
+        let purpose = validate_llm_call_purpose(config.metadata.get("purpose"))?;
+        let user_id = validate_llm_metadata_user_id(config.metadata.get("user_id"))?;
         let db = self.db.as_ref();
-        let purpose = if db.is_some() {
-            validate_llm_call_purpose(config.metadata.get("purpose"))?
-        } else {
-            None
-        };
-        let cost_per_token = if config.model.is_some() {
-            None
-        } else {
-            Some(provider.cost_per_token())
-        };
-        let user_id = config.metadata.get("user_id");
+        let cost_per_token = Some(provider.cost_per_token());
         let cost = match user_id {
             Some(user_id) => {
                 self.cost_guard
@@ -192,6 +185,9 @@ impl LlmUsageRecorder {
             purpose,
         };
 
+        // Keep usage accounting fail-loud and per-call. Batching this path
+        // would need a durable queue plus backpressure so accepted LLM calls
+        // cannot disappear before admin usage aggregation sees them.
         db.record_llm_call(&record)
             .await
             .map_err(|e| EngineError::Store {
@@ -219,6 +215,26 @@ fn validate_llm_call_purpose(value: Option<&String>) -> Result<Option<&str>, Eng
         });
     }
     Ok(Some(purpose))
+}
+
+fn validate_llm_metadata_user_id(value: Option<&String>) -> Result<Option<&str>, EngineError> {
+    let Some(user_id) = value.map(String::as_str) else {
+        return Ok(None);
+    };
+    if user_id.is_empty() {
+        return Err(EngineError::Store {
+            reason: "invalid engine v2 LLM usage user_id: empty".to_string(),
+        });
+    }
+    if user_id.len() > LLM_METADATA_USER_ID_MAX_LEN {
+        return Err(EngineError::Store {
+            reason: format!(
+                "invalid engine v2 LLM usage user_id: length {} exceeds {LLM_METADATA_USER_ID_MAX_LEN}",
+                user_id.len()
+            ),
+        });
+    }
+    Ok(Some(user_id))
 }
 
 impl LlmBridgeAdapter {
@@ -1182,6 +1198,51 @@ mod tests {
         assert!(
             err.to_string()
                 .contains("invalid engine v2 LLM usage purpose"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn complete_rejects_invalid_engine_v2_usage_purpose_without_db() {
+        let provider: Arc<dyn LlmProvider> = Arc::new(PricedProvider);
+        let adapter = LlmBridgeAdapter::new_without_usage_recorder_for_testing(provider, None);
+        let mut config = LlmCallConfig::default();
+        config
+            .metadata
+            .insert("purpose".to_string(), "billing".to_string());
+
+        let err = adapter
+            .complete(&[ThreadMessage::user("hello")], &[], &config)
+            .await
+            .expect_err("invalid usage purpose must fail before DB availability checks");
+
+        assert!(matches!(err, EngineError::Store { .. }));
+        assert!(
+            err.to_string()
+                .contains("invalid engine v2 LLM usage purpose"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn complete_rejects_overlong_engine_v2_usage_user_id() {
+        let provider: Arc<dyn LlmProvider> = Arc::new(PricedProvider);
+        let adapter = LlmBridgeAdapter::new_without_usage_recorder_for_testing(provider, None);
+        let mut config = LlmCallConfig::default();
+        config.metadata.insert(
+            "user_id".to_string(),
+            "u".repeat(LLM_METADATA_USER_ID_MAX_LEN + 1),
+        );
+
+        let err = adapter
+            .complete(&[ThreadMessage::user("hello")], &[], &config)
+            .await
+            .expect_err("overlong usage user_id must fail");
+
+        assert!(matches!(err, EngineError::Store { .. }));
+        assert!(
+            err.to_string()
+                .contains("invalid engine v2 LLM usage user_id"),
             "unexpected error: {err}"
         );
     }
@@ -2225,6 +2286,43 @@ And also check the token price:\n\
             "expected cost_usd ≈ {EXPECTED_COST_USD}, got {}",
             output.usage.cost_usd
         );
+    }
+
+    #[tokio::test]
+    async fn complete_model_override_records_provider_pricing_in_cost_guard() {
+        use crate::agent::cost_guard::{CostGuard, CostGuardConfig};
+
+        let cost_guard = Arc::new(CostGuard::new(CostGuardConfig::default()));
+        let provider: Arc<dyn LlmProvider> = Arc::new(PricedProvider);
+        let adapter = LlmBridgeAdapter::new(
+            provider,
+            None,
+            Arc::new(LlmUsageRecorder::new(
+                None,
+                Arc::clone(&cost_guard),
+                "test-disabled",
+            )),
+        );
+        let mut config = LlmCallConfig {
+            model: Some("unknown-override-model".to_string()),
+            ..LlmCallConfig::default()
+        };
+        config
+            .metadata
+            .insert("purpose".to_string(), "chat".to_string());
+
+        adapter
+            .complete(&[ThreadMessage::user("hi")], &[], &config)
+            .await
+            .expect("complete");
+
+        let usage = cost_guard.model_usage().await;
+        let tokens = usage
+            .get("unknown-override-model")
+            .expect("model override usage");
+        assert_eq!(tokens.input_tokens, 1000);
+        assert_eq!(tokens.output_tokens, 500);
+        assert_eq!(tokens.cost, rust_decimal_macros::dec!(0.010500));
     }
 
     #[tokio::test]

--- a/src/bridge/llm_adapter.rs
+++ b/src/bridge/llm_adapter.rs
@@ -127,7 +127,11 @@ impl LlmUsageRecorder {
         let purpose = validate_llm_call_purpose(config.metadata.get("purpose"))?;
         let user_id = validate_llm_metadata_user_id(config.metadata.get("user_id"))?;
         let db = self.db.as_ref();
-        let cost_per_token = Some(provider.cost_per_token());
+        let cost_per_token = if config.model.is_some() {
+            None
+        } else {
+            Some(provider.cost_per_token())
+        };
         let cost = match user_id {
             Some(user_id) => {
                 self.cost_guard
@@ -2289,7 +2293,7 @@ And also check the token price:\n\
     }
 
     #[tokio::test]
-    async fn complete_model_override_records_provider_pricing_in_cost_guard() {
+    async fn complete_model_override_uses_static_pricing_in_cost_guard() {
         use crate::agent::cost_guard::{CostGuard, CostGuardConfig};
 
         let cost_guard = Arc::new(CostGuard::new(CostGuardConfig::default()));
@@ -2304,7 +2308,7 @@ And also check the token price:\n\
             )),
         );
         let mut config = LlmCallConfig {
-            model: Some("unknown-override-model".to_string()),
+            model: Some("gpt-4o-mini".to_string()),
             ..LlmCallConfig::default()
         };
         config
@@ -2317,12 +2321,10 @@ And also check the token price:\n\
             .expect("complete");
 
         let usage = cost_guard.model_usage().await;
-        let tokens = usage
-            .get("unknown-override-model")
-            .expect("model override usage");
+        let tokens = usage.get("gpt-4o-mini").expect("model override usage");
         assert_eq!(tokens.input_tokens, 1000);
         assert_eq!(tokens.output_tokens, 500);
-        assert_eq!(tokens.cost, rust_decimal_macros::dec!(0.010500));
+        assert_eq!(tokens.cost, rust_decimal_macros::dec!(0.00045));
     }
 
     #[tokio::test]

--- a/src/bridge/llm_adapter.rs
+++ b/src/bridge/llm_adapter.rs
@@ -85,9 +85,7 @@ pub struct LlmBridgeAdapter {
     provider: Arc<dyn LlmProvider>,
     /// Optional cheaper provider for sub-calls (depth > 0).
     cheap_provider: Option<Arc<dyn LlmProvider>>,
-    /// Optional for unit tests and hostless adapter use; production engine
-    /// initialization attaches a recorder in `bridge::router::init_engine`.
-    usage_recorder: Option<Arc<LlmUsageRecorder>>,
+    usage_recorder: Arc<LlmUsageRecorder>,
 }
 
 pub struct LlmUsageRecorder {
@@ -193,17 +191,31 @@ impl LlmBridgeAdapter {
     pub fn new(
         provider: Arc<dyn LlmProvider>,
         cheap_provider: Option<Arc<dyn LlmProvider>>,
+        usage_recorder: Arc<LlmUsageRecorder>,
     ) -> Self {
         Self {
             provider,
             cheap_provider,
-            usage_recorder: None,
+            usage_recorder,
         }
     }
 
-    pub fn with_usage_recorder(mut self, usage_recorder: Arc<LlmUsageRecorder>) -> Self {
-        self.usage_recorder = Some(usage_recorder);
-        self
+    #[cfg(test)]
+    fn new_without_usage_recorder_for_testing(
+        provider: Arc<dyn LlmProvider>,
+        cheap_provider: Option<Arc<dyn LlmProvider>>,
+    ) -> Self {
+        Self::new(
+            provider,
+            cheap_provider,
+            Arc::new(LlmUsageRecorder::new(
+                None,
+                Arc::new(crate::agent::cost_guard::CostGuard::new(
+                    crate::agent::cost_guard::CostGuardConfig::default(),
+                )),
+                "test-disabled",
+            )),
+        )
     }
 
     fn provider_for_depth(&self, depth: u32) -> &Arc<dyn LlmProvider> {
@@ -220,10 +232,7 @@ impl LlmBridgeAdapter {
         config: &LlmCallConfig,
         tokens: LlmTokenBuckets,
     ) -> Result<(), EngineError> {
-        if let Some(recorder) = self.usage_recorder.as_ref() {
-            recorder.record(provider, config, tokens).await?;
-        }
-        Ok(())
+        self.usage_recorder.record(provider, config, tokens).await
     }
 }
 
@@ -887,7 +896,7 @@ mod tests {
         let provider: Arc<dyn LlmProvider> = Arc::new(CapturingProvider {
             state: state.clone(),
         });
-        let adapter = LlmBridgeAdapter::new(provider, None);
+        let adapter = LlmBridgeAdapter::new_without_usage_recorder_for_testing(provider, None);
         let messages = vec![
             ThreadMessage::user("Find the docs"),
             ThreadMessage::assistant("I checked a tool earlier."),
@@ -924,7 +933,7 @@ mod tests {
         let provider: Arc<dyn LlmProvider> = Arc::new(CapturingProvider {
             state: state.clone(),
         });
-        let adapter = LlmBridgeAdapter::new(provider, None);
+        let adapter = LlmBridgeAdapter::new_without_usage_recorder_for_testing(provider, None);
         let messages = vec![
             ThreadMessage::user("Find the docs"),
             ThreadMessage::assistant("I checked a tool earlier."),
@@ -1022,13 +1031,15 @@ mod tests {
 
         let cost_guard = Arc::new(CostGuard::new(CostGuardConfig::default()));
         let provider: Arc<dyn LlmProvider> = Arc::new(PricedUsageProvider);
-        let adapter = LlmBridgeAdapter::new(provider, None).with_usage_recorder(Arc::new(
-            LlmUsageRecorder::new(
+        let adapter = LlmBridgeAdapter::new(
+            provider,
+            None,
+            Arc::new(LlmUsageRecorder::new(
                 Some(Arc::clone(&db)),
                 Arc::clone(&cost_guard),
                 "test-backend",
-            ),
-        ));
+            )),
+        );
         let mut config = LlmCallConfig::default();
         config
             .metadata
@@ -1083,9 +1094,11 @@ mod tests {
         let db: Arc<dyn Database> = Arc::new(backend);
         let cost_guard = Arc::new(CostGuard::new(CostGuardConfig::default()));
         let provider: Arc<dyn LlmProvider> = Arc::new(PricedProvider);
-        let adapter = LlmBridgeAdapter::new(provider, None).with_usage_recorder(Arc::new(
-            LlmUsageRecorder::new(Some(db), cost_guard, "test-backend"),
-        ));
+        let adapter = LlmBridgeAdapter::new(
+            provider,
+            None,
+            Arc::new(LlmUsageRecorder::new(Some(db), cost_guard, "test-backend")),
+        );
 
         let err = adapter
             .complete(
@@ -1110,7 +1123,7 @@ mod tests {
         let provider: Arc<dyn LlmProvider> = Arc::new(CapturingProvider {
             state: state.clone(),
         });
-        let adapter = LlmBridgeAdapter::new(provider, None);
+        let adapter = LlmBridgeAdapter::new_without_usage_recorder_for_testing(provider, None);
         let messages = vec![
             ThreadMessage::user("Find the docs"),
             ThreadMessage::assistant_with_actions(
@@ -1232,7 +1245,7 @@ mod tests {
         let provider: Arc<dyn LlmProvider> = Arc::new(FlattenedToolCallProvider {
             content: "Now let me list your installed extensions and start Pi:\n\n[Called tool `shell` with arguments: {\"command\":\"pi list 2>&1\",\"timeout\":10,\"workdir\":\".\"}]".to_string(),
         });
-        let adapter = LlmBridgeAdapter::new(provider, None);
+        let adapter = LlmBridgeAdapter::new_without_usage_recorder_for_testing(provider, None);
 
         let output = adapter
             .complete(
@@ -1262,7 +1275,7 @@ mod tests {
         let provider: Arc<dyn LlmProvider> = Arc::new(FlattenedToolCallProvider {
             content: "Let me check.\n[Called tool `unknown_tool` with arguments: {}]".to_string(),
         });
-        let adapter = LlmBridgeAdapter::new(provider, None);
+        let adapter = LlmBridgeAdapter::new_without_usage_recorder_for_testing(provider, None);
 
         let output = adapter
             .complete(
@@ -1323,7 +1336,7 @@ mod tests {
         let provider: Arc<dyn LlmProvider> = Arc::new(FlattenedPlainTextProvider {
             content: "Let me check.\n[Called tool `shell` with arguments: {}]".to_string(),
         });
-        let adapter = LlmBridgeAdapter::new(provider, None);
+        let adapter = LlmBridgeAdapter::new_without_usage_recorder_for_testing(provider, None);
 
         let output = adapter
             .complete(
@@ -1347,7 +1360,7 @@ mod tests {
         let provider: Arc<dyn LlmProvider> = Arc::new(FlattenedToolCallProvider {
             content: "[Called tool `unknown_tool` with arguments: {}]".to_string(),
         });
-        let adapter = LlmBridgeAdapter::new(provider, None);
+        let adapter = LlmBridgeAdapter::new_without_usage_recorder_for_testing(provider, None);
 
         let output = adapter
             .complete(
@@ -1371,7 +1384,7 @@ mod tests {
         let provider: Arc<dyn LlmProvider> = Arc::new(FlattenedPlainTextProvider {
             content: "[Called tool `shell` with arguments: {}]".to_string(),
         });
-        let adapter = LlmBridgeAdapter::new(provider, None);
+        let adapter = LlmBridgeAdapter::new_without_usage_recorder_for_testing(provider, None);
 
         let output = adapter
             .complete(
@@ -1396,7 +1409,7 @@ mod tests {
         let provider: Arc<dyn LlmProvider> = Arc::new(CapturingProvider {
             state: state.clone(),
         });
-        let adapter = LlmBridgeAdapter::new(provider, None);
+        let adapter = LlmBridgeAdapter::new_without_usage_recorder_for_testing(provider, None);
 
         let config = ironclaw_engine::LlmCallConfig {
             model: Some("gpt-4o".into()),
@@ -1439,7 +1452,7 @@ mod tests {
         let provider: Arc<dyn LlmProvider> = Arc::new(CapturingProvider {
             state: state.clone(),
         });
-        let adapter = LlmBridgeAdapter::new(provider, None);
+        let adapter = LlmBridgeAdapter::new_without_usage_recorder_for_testing(provider, None);
 
         adapter
             .complete(
@@ -1473,7 +1486,7 @@ mod tests {
         let provider: Arc<dyn LlmProvider> = Arc::new(CapturingProvider {
             state: state.clone(),
         });
-        let adapter = LlmBridgeAdapter::new(provider, None);
+        let adapter = LlmBridgeAdapter::new_without_usage_recorder_for_testing(provider, None);
 
         let result = adapter
             .complete(
@@ -1543,7 +1556,7 @@ mod tests {
         let provider: Arc<dyn LlmProvider> = Arc::new(CapturingProvider {
             state: state.clone(),
         });
-        let adapter = LlmBridgeAdapter::new(provider, None);
+        let adapter = LlmBridgeAdapter::new_without_usage_recorder_for_testing(provider, None);
 
         let result = adapter
             .complete(
@@ -2018,7 +2031,7 @@ And also check the token price:\n\
     #[tokio::test]
     async fn complete_resolves_template_refs_through_adapter() {
         let provider: Arc<dyn LlmProvider> = Arc::new(TemplateRefProvider);
-        let adapter = LlmBridgeAdapter::new(provider, None);
+        let adapter = LlmBridgeAdapter::new_without_usage_recorder_for_testing(provider, None);
 
         // Conversation history: user asked to create a project, tool returned
         // a result with project_id, now the LLM wants to create a mission
@@ -2127,7 +2140,7 @@ And also check the token price:\n\
     #[tokio::test]
     async fn complete_no_tools_populates_cost_usd_through_adapter() {
         let provider: Arc<dyn LlmProvider> = Arc::new(PricedProvider);
-        let adapter = LlmBridgeAdapter::new(provider, None);
+        let adapter = LlmBridgeAdapter::new_without_usage_recorder_for_testing(provider, None);
 
         let output = adapter
             .complete(
@@ -2148,7 +2161,7 @@ And also check the token price:\n\
     #[tokio::test]
     async fn complete_with_tools_populates_cost_usd_through_adapter() {
         let provider: Arc<dyn LlmProvider> = Arc::new(PricedProvider);
-        let adapter = LlmBridgeAdapter::new(provider, None);
+        let adapter = LlmBridgeAdapter::new_without_usage_recorder_for_testing(provider, None);
 
         let output = adapter
             .complete(
@@ -2205,7 +2218,8 @@ And also check the token price:\n\
 
         let primary: Arc<dyn LlmProvider> = Arc::new(PricedProvider);
         let cheap: Arc<dyn LlmProvider> = Arc::new(ZeroProvider);
-        let adapter = LlmBridgeAdapter::new(primary, Some(cheap));
+        let adapter =
+            LlmBridgeAdapter::new_without_usage_recorder_for_testing(primary, Some(cheap));
 
         let output = adapter
             .complete(
@@ -2264,7 +2278,7 @@ And also check the token price:\n\
         }
 
         let provider: Arc<dyn LlmProvider> = Arc::new(SubscriptionProvider);
-        let adapter = LlmBridgeAdapter::new(provider, None);
+        let adapter = LlmBridgeAdapter::new_without_usage_recorder_for_testing(provider, None);
 
         let output = adapter
             .complete(&[ThreadMessage::user("hi")], &[], &LlmCallConfig::default())
@@ -2335,7 +2349,7 @@ And also check the token price:\n\
         }
 
         let provider: Arc<dyn LlmProvider> = Arc::new(AnthropicCachingProvider);
-        let adapter = LlmBridgeAdapter::new(provider, None);
+        let adapter = LlmBridgeAdapter::new_without_usage_recorder_for_testing(provider, None);
 
         let output = adapter
             .complete(&[ThreadMessage::user("hi")], &[], &LlmCallConfig::default())

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -1783,10 +1783,11 @@ pub async fn init_engine(agent: &Agent) -> Result<(), Error> {
         Arc::clone(&agent.deps.cost_guard),
         agent.deps.llm_backend.clone(),
     ));
-    let llm_adapter = Arc::new(
-        LlmBridgeAdapter::new(agent.llm().clone(), Some(agent.cheap_llm().clone()))
-            .with_usage_recorder(usage_recorder),
-    );
+    let llm_adapter = Arc::new(LlmBridgeAdapter::new(
+        agent.llm().clone(),
+        Some(agent.cheap_llm().clone()),
+        usage_recorder,
+    ));
 
     let effect_adapter = Arc::new(
         EffectBridgeAdapter::new(

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -59,6 +59,8 @@ const EXTERNAL_TOOL_CATALOG_SWEEP_INTERVAL: std::time::Duration =
 /// it. One hour matches typical pending-gate TTLs and gives callers
 /// plenty of headroom to resume a paused tool call.
 const EXTERNAL_TOOL_CATALOG_TTL: chrono::Duration = chrono::Duration::hours(1);
+const ENGINE_METADATA_V1_CONVERSATION_RESOLVE_TIMEOUT: std::time::Duration =
+    std::time::Duration::from_secs(2);
 
 /// Check if the engine v2 is enabled via `ENGINE_V2=true` environment variable.
 pub fn is_engine_v2_enabled() -> bool {
@@ -1478,6 +1480,39 @@ async fn resolve_v1_conversation_for_message(
 
     db.get_or_create_assistant_conversation(&message.user_id, &message.channel)
         .await
+}
+
+async fn resolve_v1_conversation_for_engine_metadata(
+    db: &Arc<dyn crate::db::Database>,
+    message: &IncomingMessage,
+) -> Option<uuid::Uuid> {
+    match tokio::time::timeout(
+        ENGINE_METADATA_V1_CONVERSATION_RESOLVE_TIMEOUT,
+        resolve_v1_conversation_for_message(db, message),
+    )
+    .await
+    {
+        Ok(Ok(cid)) => Some(cid),
+        Ok(Err(e)) => {
+            // silent-ok: v1 conversation resolution for engine metadata only enriches
+            // admin usage joins; engine v2 execution can proceed without this optional id.
+            tracing::warn!(
+                message_id = %message.id,
+                "failed to resolve v1 conversation for engine metadata: {e}"
+            );
+            None
+        }
+        Err(_) => {
+            // silent-ok: v1 conversation resolution for engine metadata is bounded so a
+            // slow DB cannot block engine v2 execution; usage is still recorded by thread.
+            tracing::warn!(
+                message_id = %message.id,
+                timeout_ms = ENGINE_METADATA_V1_CONVERSATION_RESOLVE_TIMEOUT.as_millis(),
+                "timed out resolving v1 conversation for engine metadata"
+            );
+            None
+        }
+    }
 }
 
 async fn reconcile_pending_gate_state(
@@ -4694,16 +4729,7 @@ async fn handle_with_engine_inner(
     // bridge's post-spawn `transfer` and miss caller tools on the
     // first turn.
     let v1_conversation_id = if let Some(ref db) = state.db {
-        match resolve_v1_conversation_for_message(db, message).await {
-            Ok(cid) => Some(cid),
-            Err(e) => {
-                tracing::warn!(
-                    message_id = %message.id,
-                    "failed to resolve v1 conversation for engine metadata: {e}"
-                );
-                None
-            }
-        }
+        resolve_v1_conversation_for_engine_metadata(db, message).await
     } else {
         None
     };

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -18,7 +18,7 @@ use crate::agent::Agent;
 use crate::auth::extension::AuthManager;
 use crate::bridge::effect_adapter::EffectBridgeAdapter;
 use crate::bridge::engine_actions::mission_capability_actions;
-use crate::bridge::llm_adapter::LlmBridgeAdapter;
+use crate::bridge::llm_adapter::{LlmBridgeAdapter, LlmUsageRecorder};
 use crate::bridge::store_adapter::HybridStore;
 use crate::channels::web::GATEWAY_CHANNEL_NAME;
 use crate::channels::web::sse::SseManager;
@@ -1743,10 +1743,15 @@ pub async fn init_engine(agent: &Agent) -> Result<(), Error> {
 
     debug!("engine v2: initializing engine state");
 
-    let llm_adapter = Arc::new(LlmBridgeAdapter::new(
-        agent.llm().clone(),
-        Some(agent.cheap_llm().clone()),
+    let usage_recorder = Arc::new(LlmUsageRecorder::new(
+        agent.deps.store.clone(),
+        Arc::clone(&agent.deps.cost_guard),
+        agent.deps.llm_backend.clone(),
     ));
+    let llm_adapter = Arc::new(
+        LlmBridgeAdapter::new(agent.llm().clone(), Some(agent.cheap_llm().clone()))
+            .with_usage_recorder(usage_recorder),
+    );
 
     let effect_adapter = Arc::new(
         EffectBridgeAdapter::new(
@@ -4688,15 +4693,40 @@ async fn handle_with_engine_inner(
     // executor task that starts immediately after spawn would race the
     // bridge's post-spawn `transfer` and miss caller tools on the
     // first turn.
+    let v1_conversation_id = if let Some(ref db) = state.db {
+        match resolve_v1_conversation_for_message(db, message).await {
+            Ok(cid) => Some(cid),
+            Err(e) => {
+                tracing::warn!(
+                    message_id = %message.id,
+                    "failed to resolve v1 conversation for engine metadata: {e}"
+                );
+                None
+            }
+        }
+    } else {
+        None
+    };
+
     let scope_uuid = parse_engine_thread_id(scope);
-    let extra_metadata = scope_uuid.map(|tid| {
+    let extra_metadata = if scope_uuid.is_some() || v1_conversation_id.is_some() {
         let mut map = serde_json::Map::new();
-        map.insert(
-            "conversation_scope".into(),
-            serde_json::Value::String(tid.0.to_string()),
-        );
-        map
-    });
+        if let Some(tid) = scope_uuid {
+            map.insert(
+                "conversation_scope".into(),
+                serde_json::Value::String(tid.0.to_string()),
+            );
+        }
+        if let Some(cid) = v1_conversation_id {
+            map.insert(
+                "v1_conversation_id".into(),
+                serde_json::Value::String(cid.to_string()),
+            );
+        }
+        Some(map)
+    } else {
+        None
+    };
 
     // Pre-bind per-execution context BEFORE the engine spawns the
     // thread. `handle_user_message` allocates and starts the engine
@@ -4788,16 +4818,16 @@ async fn handle_with_engine_inner(
     // are not UUIDs, so they are mapped to stable UUID conversation IDs while
     // preserving the original scope in `conversations.thread_id`.
     if let Some(ref db) = state.db {
-        match resolve_v1_conversation_for_message(db, message).await {
-            Ok(cid) => {
+        match v1_conversation_id {
+            Some(cid) => {
                 let _ = db
                     .add_conversation_message(cid, "user", effective_content)
                     .await;
             }
-            Err(e) => {
+            None => {
                 tracing::warn!(
                     message_id = %message.id,
-                    "failed to resolve v1 conversation for user message persist: {e}"
+                    "failed to persist user message because v1 conversation was not resolved"
                 );
             }
         }

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -59,6 +59,13 @@ const EXTERNAL_TOOL_CATALOG_SWEEP_INTERVAL: std::time::Duration =
 /// it. One hour matches typical pending-gate TTLs and gives callers
 /// plenty of headroom to resume a paused tool call.
 const EXTERNAL_TOOL_CATALOG_TTL: chrono::Duration = chrono::Duration::hours(1);
+/// Bound v1 conversation lookup before spawning Engine V2 work.
+///
+/// Two seconds keeps this optional enrichment below the normal interactive
+/// request budget while still giving cold libSQL/Postgres lookups room to
+/// complete. If it expires, the Engine V2 thread remains the durable source of
+/// truth and the v1 history mirror is skipped with a warning rather than
+/// blocking the user turn.
 const ENGINE_METADATA_V1_CONVERSATION_RESOLVE_TIMEOUT: std::time::Duration =
     std::time::Duration::from_secs(2);
 
@@ -1504,7 +1511,8 @@ async fn resolve_v1_conversation_for_engine_metadata(
         }
         Err(_) => {
             // silent-ok: v1 conversation resolution for engine metadata is bounded so a
-            // slow DB cannot block engine v2 execution; usage is still recorded by thread.
+            // slow DB cannot block engine v2 execution; the engine thread remains the
+            // durable source of truth and v1 history mirroring is skipped later.
             tracing::warn!(
                 message_id = %message.id,
                 timeout_ms = ENGINE_METADATA_V1_CONVERSATION_RESOLVE_TIMEOUT.as_millis(),
@@ -4852,6 +4860,9 @@ async fn handle_with_engine_inner(
                     .await;
             }
             None => {
+                // silent-ok: when the bounded v1 lookup fails, the Engine V2 thread
+                // store remains the durable source for this turn. The v1 gateway
+                // history mirror cannot attach the user message without a conversation id.
                 tracing::warn!(
                     message_id = %message.id,
                     "failed to persist user message because v1 conversation was not resolved"


### PR DESCRIPTION
## Summary
- Record Engine V2 LLM completions through CostGuard and `llm_calls` so admin usage aggregates include Engine V2 traffic.
- Propagate Engine thread/user/v1 conversation metadata into root and recursive LLM calls for correct user attribution.
- Resolve the v1 conversation before Engine execution so the first Engine V2 completion can be joined by `/api/admin/usage` and user summary stats.

Fixes #4985

## Tests
- `CARGO_INCREMENTAL=0 cargo +1.92.0 test complete_records_engine_v2_usage_for_admin_aggregates --lib`
- `CARGO_INCREMENTAL=0 cargo +1.92.0 test bridge::llm_adapter --lib`
- `CARGO_INCREMENTAL=0 cargo +1.92.0 test -p ironclaw_engine executor::scripting:: --lib`