### PR TITLE
feat(bench): forward NEARAI_API_KEY so /benchmark reborn runs use NEAR cloud

### DIFF
--- a/.github/workflows/nearai-bench.yml
+++ b/.github/workflows/nearai-bench.yml
@@ -10,8 +10,9 @@
 # Setup / usage docs:
 # https://github.com/nearai/benchmarks/blob/main/docs/ci/README.md
 #
-# Requires `OPENROUTER_API_KEY` as an org-level (or repo-level) secret.
-# Only that one secret is forwarded — `secrets: inherit` is intentionally
+# Requires `OPENROUTER_API_KEY` as an org-level (or repo-level) secret, plus
+# `NEARAI_API_KEY` for ironclaw-reborn runs (agent routes to NEAR AI cloud).
+# Only those secrets are forwarded — `secrets: inherit` is intentionally
 # NOT used (supply-chain hardening).
 
 name: nearai-bench
@@ -231,3 +232,7 @@ jobs:
     # to every secret available here.
     secrets:
       OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+      # ironclaw-reborn runs route the agent to NEAR AI cloud; the reusable
+      # workflow reads this for LLM_BACKEND=nearai. Optional there, so legacy
+      # ironclaw runs (OpenRouter) are unaffected if it's unset.
+      NEARAI_API_KEY: ${{ secrets.NEARAI_API_KEY }}


### PR DESCRIPTION
## Why

The benchmarks reusable workflow now routes **ironclaw-reborn** agent runs to **NEAR AI cloud** instead of OpenRouter (nearai/benchmarks#129). For that to work over `/benchmark`, this dispatcher must forward a `NEARAI_API_KEY` secret to the reusable.

## What

- Add `NEARAI_API_KEY: ${{ secrets.NEARAI_API_KEY }}` to the `secrets:` block forwarded to the reusable workflow.
- The judge still uses `OPENROUTER_API_KEY`; legacy ironclaw runs stay on OpenRouter (the reusable treats `NEARAI_API_KEY` as optional).

## Depends on

- nearai/benchmarks#129 (reusable + daily reborn→NEAR routing)
- A **`NEARAI_API_KEY` org/repo secret** must exist (like `OPENROUTER_API_KEY`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)