### PR TITLE
fix(reborn): surface approval after auth resume

### DIFF
--- a/crates/ironclaw_capabilities/src/host.rs
+++ b/crates/ironclaw_capabilities/src/host.rs
@@ -3,9 +3,10 @@ use ironclaw_authorization::{
 };
 use ironclaw_extensions::ExtensionRegistry;
 use ironclaw_host_api::{
-    CapabilityDescriptor, CapabilityDispatchRequest, CapabilityDispatchResult,
-    CapabilityDispatcher, CapabilityGrantId, CapabilityId, Decision, DenyReason, ExecutionContext,
-    InvocationFingerprint, InvocationId, Obligation, ProcessId, ResourceEstimate, ResourceScope,
+    ApprovalRequest, ApprovalRequestId, CapabilityDescriptor, CapabilityDispatchRequest,
+    CapabilityDispatchResult, CapabilityDispatcher, CapabilityGrantId, CapabilityId, Decision,
+    DenyReason, ExecutionContext, InvocationFingerprint, InvocationId, Obligation, ProcessId,
+    ResourceEstimate, ResourceScope,
 };
 use ironclaw_processes::{ProcessManager, ProcessStart};
 use ironclaw_run_state::{
@@ -83,6 +84,8 @@ enum ResumedLeaseState<'r> {
 /// method preamble before the shared tail begins.
 struct ResumedDispatchParams<'r> {
     run_state: &'r dyn RunStateStore,
+    approval_requests: Option<&'r dyn ApprovalRequestStore>,
+    run_state_approval_store: Option<&'r dyn RunStateApprovalStore>,
     scope: ResourceScope,
     invocation_id: InvocationId,
     capability_id: CapabilityId,
@@ -93,6 +96,20 @@ struct ResumedDispatchParams<'r> {
     descriptor: &'r CapabilityDescriptor,
     /// Approval-lease state for this resume.  See [`ResumedLeaseState`].
     lease_state: ResumedLeaseState<'r>,
+}
+
+struct ApprovalBlockParams<'r> {
+    run_state: Option<&'r dyn RunStateStore>,
+    approval_requests: Option<&'r dyn ApprovalRequestStore>,
+    run_state_approval_store: Option<&'r dyn RunStateApprovalStore>,
+    scope: &'r ResourceScope,
+    invocation_id: InvocationId,
+    context: &'r ExecutionContext,
+    capability_id: &'r CapabilityId,
+    estimate: &'r ResourceEstimate,
+    action_kind: CapabilityActionKind,
+    invocation_fingerprint: &'r InvocationFingerprint,
+    rollback_context: &'static str,
 }
 
 impl<'a, D> CapabilityHost<'a, D>
@@ -324,169 +341,27 @@ where
                     approval_request_id = %approval_request_id,
                     "capability authorization requires approval"
                 );
-                if let Err(error) = validate_approval_request_matches_invocation(
-                    &approval,
-                    &request.context,
-                    &request.capability_id,
-                    &request.estimate,
-                    CapabilityActionKind::Dispatch,
-                ) {
-                    debug!(
-                        approval_request_id = %approval_request_id,
-                        "capability approval request did not match invocation"
-                    );
-                    fail_run_if_configured(
-                        self.run_state,
-                        &scope,
+                save_pending_and_block_approval(
+                    approval,
+                    ApprovalBlockParams {
+                        run_state: self.run_state,
+                        approval_requests: self.approval_requests,
+                        run_state_approval_store: self.run_state_approval_store,
+                        scope: &scope,
                         invocation_id,
-                        "ApprovalRequestMismatch",
-                    )
-                    .await;
-                    return Err(error);
-                }
-
-                if let Some(existing) = &approval.invocation_fingerprint {
-                    if existing != &invocation_fingerprint {
-                        debug!(
-                            approval_request_id = %approval_request_id,
-                            "capability approval fingerprint mismatch"
-                        );
-                        fail_run_if_configured(
-                            self.run_state,
-                            &scope,
-                            invocation_id,
-                            "InvocationFingerprintMismatch",
-                        )
-                        .await;
-                        return Err(CapabilityInvocationError::ApprovalFingerprintMismatch {
-                            capability: request.capability_id,
-                        });
-                    }
-                } else {
-                    approval.invocation_fingerprint = Some(invocation_fingerprint);
-                }
-
-                match (self.run_state, self.approval_requests) {
-                    (Some(run_state), Some(approval_requests)) => {
-                        if let Some(combined_store) = self.run_state_approval_store {
-                            if let Err(error) = combined_store
-                                .save_pending_and_block_approval(
-                                    scope.clone(),
-                                    invocation_id,
-                                    approval,
-                                )
-                                .await
-                            {
-                                debug!(
-                                    approval_request_id = %approval_request_id,
-                                    "capability approval block failed in combined store"
-                                );
-                                fail_run_if_configured(
-                                    Some(run_state),
-                                    &scope,
-                                    invocation_id,
-                                    "ApprovalBlock",
-                                )
-                                .await;
-                                return Err(CapabilityInvocationError::from(error));
-                            }
-                            debug!(
-                                approval_request_id = %approval_request_id,
-                                "capability approval persisted and run state blocked"
-                            );
-                        } else {
-                            let approval_id = approval.id;
-                            if let Err(error) = approval_requests
-                                .save_pending(scope.clone(), approval.clone())
-                                .await
-                            {
-                                debug!(
-                                    approval_request_id = %approval_id,
-                                    "capability approval request persistence failed"
-                                );
-                                fail_run_if_configured(
-                                    Some(run_state),
-                                    &scope,
-                                    invocation_id,
-                                    "ApprovalStore",
-                                )
-                                .await;
-                                return Err(CapabilityInvocationError::from(error));
-                            }
-                            if let Err(error) = run_state
-                                .block_approval(&scope, invocation_id, approval)
-                                .await
-                            {
-                                debug!(
-                                    approval_request_id = %approval_id,
-                                    "capability run state approval block failed"
-                                );
-                                if let Err(discard_error) =
-                                    approval_requests.discard_pending(&scope, approval_id).await
-                                {
-                                    warn!(
-                                        approval_request_id = %approval_id,
-                                        invocation_id = %invocation_id,
-                                        transition_error_kind = run_state_error_kind(&discard_error),
-                                        "approval rollback failed after run-state block transition failed",
-                                    );
-                                }
-                                fail_run_if_configured(
-                                    Some(run_state),
-                                    &scope,
-                                    invocation_id,
-                                    "ApprovalBlock",
-                                )
-                                .await;
-                                return Err(CapabilityInvocationError::from(error));
-                            }
-                            debug!(
-                                approval_request_id = %approval_id,
-                                "capability approval persisted and run state blocked"
-                            );
-                        }
-                    }
-                    (Some(run_state), None) => {
-                        debug!(
-                            approval_request_id = %approval_request_id,
-                            store = "approval_requests",
-                            "capability approval cannot block because store is missing"
-                        );
-                        fail_run_if_configured(
-                            Some(run_state),
-                            &scope,
-                            invocation_id,
-                            "ApprovalStoreMissing",
-                        )
-                        .await;
-                        return Err(CapabilityInvocationError::ApprovalStoreMissing {
-                            capability: request.capability_id,
-                            store: "approval_requests",
-                        });
-                    }
-                    (None, Some(_)) => {
-                        debug!(
-                            approval_request_id = %approval_request_id,
-                            store = "run_state",
-                            "capability approval cannot block because store is missing"
-                        );
-                        return Err(CapabilityInvocationError::ApprovalStoreMissing {
-                            capability: request.capability_id,
-                            store: "run_state",
-                        });
-                    }
-                    (None, None) => {
-                        debug!(
-                            approval_request_id = %approval_request_id,
-                            store = "run_state and approval_requests",
-                            "capability approval cannot block because stores are missing"
-                        );
-                        return Err(CapabilityInvocationError::ApprovalStoreMissing {
-                            capability: request.capability_id,
-                            store: "run_state and approval_requests",
-                        });
-                    }
-                }
+                        context: &request.context,
+                        capability_id: &request.capability_id,
+                        estimate: &request.estimate,
+                        action_kind: CapabilityActionKind::Dispatch,
+                        invocation_fingerprint: &invocation_fingerprint,
+                        rollback_context: "dispatch",
+                    },
+                )
+                .await?;
+                debug!(
+                    approval_request_id = %approval_request_id,
+                    "capability approval persisted and run state blocked"
+                );
                 return Err(CapabilityInvocationError::AuthorizationRequiresApproval {
                     capability: request.capability_id,
                 });
@@ -752,6 +627,8 @@ where
 
         self.dispatch_resumed_capability(ResumedDispatchParams {
             run_state,
+            approval_requests: self.approval_requests,
+            run_state_approval_store: self.run_state_approval_store,
             scope,
             invocation_id,
             capability_id,
@@ -1074,6 +951,8 @@ where
 
         self.dispatch_resumed_capability(ResumedDispatchParams {
             run_state,
+            approval_requests: self.approval_requests,
+            run_state_approval_store: self.run_state_approval_store,
             scope,
             invocation_id,
             capability_id,
@@ -1536,126 +1415,23 @@ where
                     &request.capability_id,
                     &request.input,
                 );
-                if let Err(error) = validate_approval_request_matches_invocation(
-                    &approval,
-                    &request.context,
-                    &request.capability_id,
-                    &request.estimate,
-                    CapabilityActionKind::Spawn,
-                ) {
-                    fail_run_if_configured(
-                        self.run_state,
-                        &scope,
+                save_pending_and_block_approval(
+                    approval,
+                    ApprovalBlockParams {
+                        run_state: self.run_state,
+                        approval_requests: self.approval_requests,
+                        run_state_approval_store: self.run_state_approval_store,
+                        scope: &scope,
                         invocation_id,
-                        "ApprovalRequestMismatch",
-                    )
-                    .await;
-                    return Err(error);
-                }
-
-                if let Some(existing) = &approval.invocation_fingerprint {
-                    if existing != &invocation_fingerprint {
-                        fail_run_if_configured(
-                            self.run_state,
-                            &scope,
-                            invocation_id,
-                            "InvocationFingerprintMismatch",
-                        )
-                        .await;
-                        return Err(CapabilityInvocationError::ApprovalFingerprintMismatch {
-                            capability: request.capability_id,
-                        });
-                    }
-                } else {
-                    approval.invocation_fingerprint = Some(invocation_fingerprint);
-                }
-
-                match (self.run_state, self.approval_requests) {
-                    (Some(run_state), Some(approval_requests)) => {
-                        if let Some(combined_store) = self.run_state_approval_store {
-                            if let Err(error) = combined_store
-                                .save_pending_and_block_approval(
-                                    scope.clone(),
-                                    invocation_id,
-                                    approval,
-                                )
-                                .await
-                            {
-                                fail_run_if_configured(
-                                    Some(run_state),
-                                    &scope,
-                                    invocation_id,
-                                    "ApprovalBlock",
-                                )
-                                .await;
-                                return Err(CapabilityInvocationError::from(error));
-                            }
-                        } else {
-                            let approval_id = approval.id;
-                            if let Err(error) = approval_requests
-                                .save_pending(scope.clone(), approval.clone())
-                                .await
-                            {
-                                fail_run_if_configured(
-                                    Some(run_state),
-                                    &scope,
-                                    invocation_id,
-                                    "ApprovalStore",
-                                )
-                                .await;
-                                return Err(CapabilityInvocationError::from(error));
-                            }
-                            if let Err(error) = run_state
-                                .block_approval(&scope, invocation_id, approval)
-                                .await
-                            {
-                                if let Err(discard_error) =
-                                    approval_requests.discard_pending(&scope, approval_id).await
-                                {
-                                    warn!(
-                                        approval_request_id = %approval_id,
-                                        invocation_id = %invocation_id,
-                                        transition_error_kind = run_state_error_kind(&discard_error),
-                                        "approval rollback failed after spawn run-state block transition failed",
-                                    );
-                                }
-                                fail_run_if_configured(
-                                    Some(run_state),
-                                    &scope,
-                                    invocation_id,
-                                    "ApprovalBlock",
-                                )
-                                .await;
-                                return Err(CapabilityInvocationError::from(error));
-                            }
-                        }
-                    }
-                    (Some(run_state), None) => {
-                        fail_run_if_configured(
-                            Some(run_state),
-                            &scope,
-                            invocation_id,
-                            "ApprovalStoreMissing",
-                        )
-                        .await;
-                        return Err(CapabilityInvocationError::ApprovalStoreMissing {
-                            capability: request.capability_id,
-                            store: "approval_requests",
-                        });
-                    }
-                    (None, Some(_)) => {
-                        return Err(CapabilityInvocationError::ApprovalStoreMissing {
-                            capability: request.capability_id,
-                            store: "run_state",
-                        });
-                    }
-                    (None, None) => {
-                        return Err(CapabilityInvocationError::ApprovalStoreMissing {
-                            capability: request.capability_id,
-                            store: "run_state and approval_requests",
-                        });
-                    }
-                }
+                        context: &request.context,
+                        capability_id: &request.capability_id,
+                        estimate: &request.estimate,
+                        action_kind: CapabilityActionKind::Spawn,
+                        invocation_fingerprint: &invocation_fingerprint,
+                        rollback_context: "spawn",
+                    },
+                )
+                .await?;
                 return Err(CapabilityInvocationError::AuthorizationRequiresApproval {
                     capability: request.capability_id,
                 });
@@ -1734,6 +1510,8 @@ where
     ) -> Result<CapabilityInvocationResult, CapabilityInvocationError> {
         let ResumedDispatchParams {
             run_state,
+            approval_requests,
+            run_state_approval_store,
             scope,
             invocation_id,
             capability_id,
@@ -1785,7 +1563,22 @@ where
                     reason,
                 });
             }
-            Decision::RequireApproval { .. } => {
+            Decision::RequireApproval { request: approval } => {
+                if matches!(lease_state, ResumedLeaseState::NoPriorLease) {
+                    return block_resumed_auth_for_approval(
+                        run_state,
+                        approval_requests,
+                        run_state_approval_store,
+                        approval,
+                        &scope,
+                        invocation_id,
+                        &authorized_context,
+                        &capability_id,
+                        &estimate,
+                        &input,
+                    )
+                    .await;
+                }
                 fail_run_if_configured(
                     Some(run_state),
                     &scope,
@@ -2145,6 +1938,180 @@ fn add_capability_input_display_hint(
     if command.truncated {
         reason.push_str("\n[truncated]");
     }
+}
+
+async fn save_pending_and_block_approval(
+    mut approval: ApprovalRequest,
+    params: ApprovalBlockParams<'_>,
+) -> Result<ApprovalRequestId, CapabilityInvocationError> {
+    let approval_request_id = approval.id;
+    if let Err(error) = validate_approval_request_matches_invocation(
+        &approval,
+        params.context,
+        params.capability_id,
+        params.estimate,
+        params.action_kind,
+    ) {
+        fail_run_if_configured(
+            params.run_state,
+            params.scope,
+            params.invocation_id,
+            "ApprovalRequestMismatch",
+        )
+        .await;
+        return Err(error);
+    }
+
+    if let Some(existing) = &approval.invocation_fingerprint {
+        if existing != params.invocation_fingerprint {
+            fail_run_if_configured(
+                params.run_state,
+                params.scope,
+                params.invocation_id,
+                "InvocationFingerprintMismatch",
+            )
+            .await;
+            return Err(CapabilityInvocationError::ApprovalFingerprintMismatch {
+                capability: params.capability_id.clone(),
+            });
+        }
+    } else {
+        approval.invocation_fingerprint = Some(params.invocation_fingerprint.clone());
+    }
+
+    let Some(run_state) = params.run_state else {
+        return Err(CapabilityInvocationError::ApprovalStoreMissing {
+            capability: params.capability_id.clone(),
+            store: if params.approval_requests.is_some() {
+                "run_state"
+            } else {
+                "run_state and approval_requests"
+            },
+        });
+    };
+    let Some(approval_requests) = params.approval_requests else {
+        fail_run_if_configured(
+            Some(run_state),
+            params.scope,
+            params.invocation_id,
+            "ApprovalStoreMissing",
+        )
+        .await;
+        return Err(CapabilityInvocationError::ApprovalStoreMissing {
+            capability: params.capability_id.clone(),
+            store: "approval_requests",
+        });
+    };
+
+    if let Some(combined_store) = params.run_state_approval_store {
+        if let Err(error) = combined_store
+            .save_pending_and_block_approval(params.scope.clone(), params.invocation_id, approval)
+            .await
+        {
+            fail_run_if_configured(
+                Some(run_state),
+                params.scope,
+                params.invocation_id,
+                "ApprovalBlock",
+            )
+            .await;
+            return Err(CapabilityInvocationError::from(error));
+        }
+    } else {
+        let approval_id = approval.id;
+        if let Err(error) = approval_requests
+            .save_pending(params.scope.clone(), approval.clone())
+            .await
+        {
+            fail_run_if_configured(
+                Some(run_state),
+                params.scope,
+                params.invocation_id,
+                "ApprovalStore",
+            )
+            .await;
+            return Err(CapabilityInvocationError::from(error));
+        }
+        if let Err(error) = run_state
+            .block_approval(params.scope, params.invocation_id, approval)
+            .await
+        {
+            if let Err(discard_error) = approval_requests
+                .discard_pending(params.scope, approval_id)
+                .await
+            {
+                warn!(
+                    approval_request_id = %approval_id,
+                    invocation_id = %params.invocation_id,
+                    transition_error_kind = run_state_error_kind(&discard_error),
+                    rollback_context = params.rollback_context,
+                    "approval rollback failed after run-state block transition failed",
+                );
+            }
+            fail_run_if_configured(
+                Some(run_state),
+                params.scope,
+                params.invocation_id,
+                "ApprovalBlock",
+            )
+            .await;
+            return Err(CapabilityInvocationError::from(error));
+        }
+    }
+
+    Ok(approval_request_id)
+}
+
+async fn block_resumed_auth_for_approval(
+    run_state: &dyn RunStateStore,
+    approval_requests: Option<&dyn ApprovalRequestStore>,
+    run_state_approval_store: Option<&dyn RunStateApprovalStore>,
+    approval: ApprovalRequest,
+    scope: &ResourceScope,
+    invocation_id: InvocationId,
+    context: &ExecutionContext,
+    capability_id: &CapabilityId,
+    estimate: &ResourceEstimate,
+    input: &serde_json::Value,
+) -> Result<CapabilityInvocationResult, CapabilityInvocationError> {
+    let invocation_fingerprint = invocation_fingerprint_for_kind(
+        CapabilityActionKind::Dispatch,
+        scope,
+        capability_id,
+        estimate,
+        input,
+    )
+    .map_err(|source| CapabilityInvocationError::InvocationFingerprint {
+        capability: capability_id.clone(),
+        source,
+    })?;
+    let approval_request_id = save_pending_and_block_approval(
+        approval,
+        ApprovalBlockParams {
+            run_state: Some(run_state),
+            approval_requests,
+            run_state_approval_store,
+            scope,
+            invocation_id,
+            context,
+            capability_id,
+            estimate,
+            action_kind: CapabilityActionKind::Dispatch,
+            invocation_fingerprint: &invocation_fingerprint,
+            rollback_context: "auth-resume",
+        },
+    )
+    .await?;
+
+    debug!(
+        approval_request_id = %approval_request_id,
+        invocation_id = %invocation_id,
+        capability_id = %capability_id,
+        "auth-resume without prior approval blocked for approval",
+    );
+    Err(CapabilityInvocationError::AuthorizationRequiresApproval {
+        capability: capability_id.clone(),
+    })
 }
 
 /// Cleans up a claimed lease after a resume-path error using best-effort

--- a/crates/ironclaw_capabilities/tests/capability_host_auth_resume_contract.rs
+++ b/crates/ironclaw_capabilities/tests/capability_host_auth_resume_contract.rs
@@ -687,6 +687,80 @@ async fn auth_resume_json_without_approval_request_id_skips_lease_path_and_dispa
     assert_eq!(run.status, RunStatus::Completed);
 }
 
+#[tokio::test]
+async fn auth_resume_json_without_approval_request_id_can_block_for_first_approval() {
+    // Credential preflight can block a capability before the user has approved
+    // the dispatch. After the user completes auth, auth-resume must be allowed
+    // to open that first approval gate instead of failing the blocked run.
+    let registry = registry_with_echo_capability();
+    let dispatcher = RecordingDispatcher::default();
+    let run_state = InMemoryRunStateStore::new();
+    let approval_requests = InMemoryApprovalRequestStore::new();
+
+    let context = execution_context(CapabilitySet::default());
+    let scope = context.resource_scope.clone();
+    let invocation_id = context.invocation_id;
+    let estimate = ResourceEstimate::default();
+    let input = json!({"message": "auth first, approval second"});
+
+    run_state
+        .start(RunStart {
+            invocation_id,
+            scope: scope.clone(),
+            capability_id: capability_id(),
+        })
+        .await
+        .unwrap();
+    run_state
+        .block_auth(&scope, invocation_id, "AuthRequired".to_string())
+        .await
+        .unwrap();
+
+    let host = CapabilityHost::new(&registry, &dispatcher, &ApprovalAuthorizer)
+        .with_run_state(&run_state)
+        .with_approval_requests(&approval_requests);
+
+    let err = host
+        .auth_resume_json(CapabilityAuthResumeRequest {
+            context,
+            capability_id: capability_id(),
+            estimate: estimate.clone(),
+            input: input.clone(),
+            trust_decision: trust_decision(),
+            approval_request_id: None,
+        })
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(
+            err,
+            CapabilityInvocationError::AuthorizationRequiresApproval { .. }
+        ),
+        "expected first approval gate from auth-resume, got {err:?}"
+    );
+    assert_eq!(
+        dispatcher.dispatch_count(),
+        0,
+        "auth-resume must not dispatch before the first approval is granted"
+    );
+    let run = run_state.get(&scope, invocation_id).await.unwrap().unwrap();
+    assert_eq!(run.status, RunStatus::BlockedApproval);
+    let approval_request_id = run
+        .approval_request_id
+        .expect("BlockedApproval run must point at approval request");
+    let approval = approval_requests
+        .get(&scope, approval_request_id)
+        .await
+        .unwrap()
+        .expect("approval request must be persisted");
+    assert_eq!(approval.status, ApprovalStatus::Pending);
+    assert!(
+        approval.request.invocation_fingerprint.is_some(),
+        "approval request must be fingerprinted for later resume"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // REAL-PATH BUG: lease is Revoked after resume_json dispatch auth bounce
 //

--- a/crates/ironclaw_host_runtime/src/production.rs
+++ b/crates/ironclaw_host_runtime/src/production.rs
@@ -691,6 +691,9 @@ impl HostRuntime for DefaultHostRuntime {
             approval_request_id,
         } = request;
         let idempotency_key = idempotency_key.map(|key| key.as_str().to_string());
+        let scope = context.resource_scope.clone();
+        let invocation_id = context.invocation_id;
+        let prior_approval_request_id = approval_request_id;
         if let Some(key) = idempotency_key.as_deref() {
             tracing::debug!(
                 capability_id = %capability_id,
@@ -766,6 +769,12 @@ impl HostRuntime for DefaultHostRuntime {
                         required_secrets,
                         credential_requirements,
                     )),
+                    CapabilityInvocationError::AuthorizationRequiresApproval { .. }
+                        if prior_approval_request_id.is_none() =>
+                    {
+                        self.translate_invocation_error(error, capability_id, scope, invocation_id)
+                            .await
+                    }
                     other => Ok(RuntimeCapabilityOutcome::Failed(failure_from(
                         other,
                         capability_id,

--- a/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
@@ -3128,6 +3128,56 @@ async fn host_runtime_services_auth_resume_dispatches_blocked_auth_run() {
     );
 }
 
+#[tokio::test]
+async fn host_runtime_services_auth_resume_without_prior_approval_returns_first_approval_gate() {
+    // This mirrors the extension-activation ordering that triggered the QA
+    // failure: credential preflight blocks at auth before the side-effecting
+    // activation has passed an approval gate. After auth completes, auth-resume
+    // must surface the first approval gate, not fail the run as a capability
+    // authorization error.
+    let fixture = approval_resume_fixture();
+    let runtime = fixture.services.host_runtime_for_local_testing();
+    let context = execution_context_without_grants();
+    let scope = context.resource_scope.clone();
+    let invocation_id = context.invocation_id;
+    let estimate = ResourceEstimate::default();
+    let input = json!({"message": "auth first, approval second"});
+
+    fixture
+        .run_state
+        .start(RunStart {
+            invocation_id,
+            scope: scope.clone(),
+            capability_id: script_capability_id(),
+        })
+        .await
+        .unwrap();
+    fixture
+        .run_state
+        .block_auth(&scope, invocation_id, "AuthRequired".to_string())
+        .await
+        .unwrap();
+
+    let outcome = runtime
+        .auth_resume_capability(RuntimeCapabilityAuthResumeRequest::new(
+            context,
+            script_capability_id(),
+            estimate,
+            input,
+            trust_decision_with_dispatch_authority(),
+            None,
+        ))
+        .await
+        .unwrap();
+
+    let gate = match outcome {
+        RuntimeCapabilityOutcome::ApprovalRequired(gate) => gate,
+        other => panic!("expected first approval gate after auth-resume, got {other:?}"),
+    };
+    assert_eq!(gate.capability_id, script_capability_id());
+    assert_blocked_approval_run(&fixture, &scope, invocation_id, gate.approval_request_id).await;
+}
+
 // ---------------------------------------------------------------------------
 // auth-resume preflight rejection must fail the BlockedAuth run record
 //

--- a/crates/ironclaw_loop_support/src/capability_port.rs
+++ b/crates/ironclaw_loop_support/src/capability_port.rs
@@ -2229,7 +2229,7 @@ fn runtime_model_visible_failure_to_loop(
         RuntimeFailureKind::Authorization | RuntimeFailureKind::PolicyDenied
     ) {
         return Ok(CapabilityOutcome::Denied(CapabilityDenied {
-            reason_kind: capability_denied_reason_kind(failure.kind.as_str())?,
+            reason_kind: runtime_denied_reason_kind(failure.kind)?,
             safe_summary: runtime_failure_safe_summary(&failure, "capability authorization denied"),
         }));
     }
@@ -2315,6 +2315,16 @@ fn capability_denied_reason_kind(
             "capability denied reason kind could not be represented",
         )
     })
+}
+
+fn runtime_denied_reason_kind(
+    kind: RuntimeFailureKind,
+) -> Result<CapabilityDeniedReasonKind, AgentLoopHostError> {
+    match kind {
+        RuntimeFailureKind::Authorization => capability_denied_reason_kind("access_denied"),
+        RuntimeFailureKind::PolicyDenied => capability_denied_reason_kind("policy_denied"),
+        _ => capability_denied_reason_kind(kind.as_str()),
+    }
 }
 
 fn capability_failure_kind(
@@ -2677,6 +2687,19 @@ mod tests {
             CapabilityOutcome::Denied(denied)
                 if denied.reason_kind.as_str() == "policy_denied"
                     && denied.safe_summary == "policy denied request"
+        ));
+
+        let authorization_denied = runtime_failure_to_loop(RuntimeCapabilityFailure::new(
+            capability_id.clone(),
+            RuntimeFailureKind::Authorization,
+            Some("capability access denied".to_string()),
+        ))
+        .expect("convert authorization denial");
+        assert!(matches!(
+            authorization_denied,
+            CapabilityOutcome::Denied(denied)
+                if denied.reason_kind.as_str() == "access_denied"
+                    && denied.safe_summary == "capability access denied"
         ));
 
         let operation_failed = runtime_failure_to_loop(RuntimeCapabilityFailure::new(

--- a/crates/ironclaw_loop_support/src/capability_port/tests/runtime_lifecycle_tests.rs
+++ b/crates/ironclaw_loop_support/src/capability_port/tests/runtime_lifecycle_tests.rs
@@ -724,6 +724,113 @@ async fn auth_resume_uses_replay_input_without_resolving_stale_input_ref() {
 }
 
 #[tokio::test]
+async fn auth_resume_without_prior_approval_surfaces_first_approval_gate() {
+    let capability_id = CapabilityId::new("gmail.list_messages").expect("valid capability id");
+    let provider_id = ExtensionId::new("gmail").expect("valid provider id");
+    let approval_request_id = ApprovalRequestId::new();
+    let runtime = Arc::new(
+        QueuedHostRuntime::new(
+            vec![visible_capability(
+                capability_id.clone(),
+                provider_id.clone(),
+            )],
+            vec![Ok(RuntimeCapabilityOutcome::AuthRequired(
+                RuntimeAuthGate {
+                    gate_id: RuntimeGateId::new(),
+                    capability_id: capability_id.clone(),
+                    reason: RuntimeBlockedReason::AuthRequired,
+                    required_secrets: Vec::new(),
+                    credential_requirements: Vec::new(),
+                },
+            ))],
+        )
+        .with_auth_resume_outcomes(vec![Ok(RuntimeCapabilityOutcome::ApprovalRequired(
+            RuntimeApprovalGate {
+                approval_request_id,
+                capability_id: capability_id.clone(),
+                reason: RuntimeBlockedReason::ApprovalRequired,
+            },
+        ))]),
+    );
+    let input = serde_json::json!({
+        "query": "newer_than:1d",
+        "max_results": 3
+    });
+    let resolver = Arc::new(OneShotInputResolver::new(input.clone()));
+    let context = execution_context("thread-auth-resume-first-approval");
+    let run_context = loop_run_context(&context).await;
+    let input_ref = CapabilityInputRef::new(format!("input:{}:gmail-list", run_context.run_id))
+        .expect("valid input ref");
+    let port = HostRuntimeLoopCapabilityPortFactory::new(
+        runtime.clone(),
+        visible_request(context).with_provider_trust(std::collections::BTreeMap::from([(
+            provider_id,
+            dispatch_trust_decision(),
+        )])),
+        resolver,
+        Arc::new(RecordingResultWriter::default()),
+        Arc::new(ironclaw_turns::run_profile::InMemoryLoopHostMilestoneSink::default()),
+    )
+    .port_for_run_context(run_context);
+    let surface = port
+        .visible_capabilities(VisibleCapabilityRequest {})
+        .await
+        .expect("visible capabilities load");
+
+    let auth_blocked = port
+        .invoke_capability(CapabilityInvocation {
+            surface_version: surface.version.clone(),
+            capability_id: capability_id.clone(),
+            input_ref: input_ref.clone(),
+            approval_resume: None,
+            auth_resume: None,
+        })
+        .await
+        .expect("first dispatch reaches auth gate");
+    let CapabilityOutcome::AuthRequired {
+        auth_resume: Some(auth_resume),
+        ..
+    } = auth_blocked
+    else {
+        panic!("auth gate must carry auth-resume metadata, got {auth_blocked:?}");
+    };
+    assert!(
+        auth_resume.prior_approval.is_none(),
+        "this regression covers auth before any approval was granted"
+    );
+
+    let auth_resumed = port
+        .invoke_capability(CapabilityInvocation {
+            surface_version: surface.version,
+            capability_id,
+            input_ref,
+            approval_resume: None,
+            auth_resume: Some(auth_resume),
+        })
+        .await
+        .expect("auth resume may surface the first approval gate");
+
+    let CapabilityOutcome::ApprovalRequired {
+        gate_ref,
+        safe_summary,
+        approval_resume: Some(approval_resume),
+    } = auth_resumed
+    else {
+        panic!("expected first approval gate after auth resume, got {auth_resumed:?}");
+    };
+    assert!(gate_ref.as_str().starts_with("gate:approval-"));
+    assert_eq!(safe_summary, "capability requires approval");
+    assert_eq!(approval_resume.approval_request_id, approval_request_id);
+    assert_eq!(approval_resume.input, input);
+    let requests = runtime.auth_resume_requests();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(
+        requests[0].approval_request_id, None,
+        "auth resume must preserve that no approval existed yet"
+    );
+}
+
+#[tokio::test]
 async fn runtime_capability_unknown_outcome_with_invalid_kind_does_not_emit_failure_milestone() {
     let capability_id = CapabilityId::new("demo.echo").expect("valid capability id");
     let provider_id = ExtensionId::new("demo").expect("valid provider id");


### PR DESCRIPTION
## Summary

- allow auth-resume without a prior approval lease to persist and surface the first approval gate
- translate that host-runtime path back into `ApprovalRequired` instead of a terminal authorization failure
- map runtime authorization denials to loop-safe denied reason kinds
- share approval blocking/persistence logic across dispatch, spawn, and auth-resume paths

Addresses #4907. Related to #4921.

## Tests

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p ironclaw_capabilities --test capability_host_auth_resume_contract`
- `cargo test -p ironclaw_host_runtime --test host_runtime_services_contract host_runtime_services_auth_resume`
- `cargo test -p ironclaw_loop_support auth_resume`
- `cargo test -p ironclaw_loop_support runtime_failure_to_loop_honors_model_visible_disposition`
- `cargo check -p ironclaw_capabilities -p ironclaw_host_runtime -p ironclaw_loop_support`