### PR TITLE
fix(safety): relax provider-output validation to stop give-up loops (B+C+D)

### DIFF
--- a/crates/ironclaw_loop_support/src/capability_port/provider_validation.rs
+++ b/crates/ironclaw_loop_support/src/capability_port/provider_validation.rs
@@ -1,5 +1,6 @@
 use ironclaw_safety::{
-    ProviderValidationError, validate_optional_provider_metadata_text,
+    PROVIDER_METADATA_TEXT_MAX_BYTES, ProviderValidationError,
+    validate_optional_provider_metadata_text,
     validate_provider_arguments as validate_safety_provider_arguments, validate_provider_identity,
     validate_provider_token, validate_provider_tool_name as validate_safety_provider_tool_name,
 };
@@ -27,19 +28,19 @@ pub(super) fn validate_provider_tool_call(
     validate_optional_provider_metadata_text(
         tool_call.response_reasoning.as_deref(),
         "provider response reasoning",
-        4096,
+        PROVIDER_METADATA_TEXT_MAX_BYTES,
     )
     .map_err(invalid_invocation)?;
     validate_optional_provider_metadata_text(
         tool_call.reasoning.as_deref(),
         "provider reasoning",
-        4096,
+        PROVIDER_METADATA_TEXT_MAX_BYTES,
     )
     .map_err(invalid_invocation)?;
     validate_optional_provider_metadata_text(
         tool_call.signature.as_deref(),
         "provider signature",
-        4096,
+        PROVIDER_METADATA_TEXT_MAX_BYTES,
     )
     .map_err(invalid_invocation)?;
     Ok(())

--- a/crates/ironclaw_reborn/tests/llm_gateway.rs
+++ b/crates/ironclaw_reborn/tests/llm_gateway.rs
@@ -529,7 +529,10 @@ async fn gateway_rejects_unknown_provider_tool_call_before_registration() {
 
 #[tokio::test]
 async fn gateway_repairs_oversized_provider_tool_arguments_before_registration() {
-    let oversized_message = "x".repeat(20 * 1024);
+    // Must exceed the host provider-argument limit so the gateway exercises its
+    // repair path. Sized off the real constant (raised to 64 KiB in the
+    // provider-validation relaxation) so this never drifts when the cap moves.
+    let oversized_message = "x".repeat(ironclaw_safety::PROVIDER_ARGUMENTS_MAX_BYTES + 1024);
     let provider = Arc::new(ToolAwareProvider::tool_response_sequence(vec![
         ToolCompletionResponse {
             content: None,
@@ -630,11 +633,10 @@ async fn gateway_repairs_oversized_provider_tool_arguments_before_registration()
             message.role == Role::Tool && message.tool_call_id.as_deref() == Some("call_2")
         })
         .expect("repair request includes rejected tool result");
-    assert!(
-        repair_tool_result
-            .content
-            .contains("provider tool arguments exceed 16384 bytes")
-    );
+    assert!(repair_tool_result.content.contains(&format!(
+        "provider tool arguments exceed {} bytes",
+        ironclaw_safety::PROVIDER_ARGUMENTS_MAX_BYTES
+    )));
     assert!(!repair_tool_result.content.contains("xxxxx"));
 }
 
@@ -3001,10 +3003,15 @@ impl LoopCapabilityPort for GatewayCapabilityPort {
                 )
             })?
             .len();
-        if arguments_len > 16 * 1024 {
+        if arguments_len > ironclaw_safety::PROVIDER_ARGUMENTS_MAX_BYTES {
+            // Mirror the production summary exactly so the gateway recognizes this
+            // as a repairable oversized-args error (is_provider_arguments_too_large_summary).
             return Err(ironclaw_turns::run_profile::AgentLoopHostError::new(
                 AgentLoopHostErrorKind::InvalidInvocation,
-                "provider tool arguments exceed 16384 bytes",
+                format!(
+                    "provider tool arguments exceed {} bytes",
+                    ironclaw_safety::PROVIDER_ARGUMENTS_MAX_BYTES
+                ),
             ));
         }
         Ok(())

--- a/crates/ironclaw_safety/src/lib.rs
+++ b/crates/ironclaw_safety/src/lib.rs
@@ -32,10 +32,11 @@ pub use leak_detector::{
 pub use policy::{Policy, PolicyAction, PolicyRule, Severity};
 pub use prompt_validation::{PromptSafetyRejection, validate_trusted_trigger_prompt};
 pub use provider_validation::{
-    PROVIDER_ARGUMENTS_MAX_BYTES, PROVIDER_TOOL_NAME_MAX_BYTES, ProviderValidationError,
-    is_provider_arguments_too_large_summary, provider_arguments_exceed_max_bytes,
-    validate_optional_provider_metadata_text, validate_provider_arguments,
-    validate_provider_identity, validate_provider_token, validate_provider_tool_name,
+    PROVIDER_ARGUMENTS_MAX_BYTES, PROVIDER_METADATA_TEXT_MAX_BYTES, PROVIDER_TOOL_NAME_MAX_BYTES,
+    ProviderValidationError, is_provider_arguments_too_large_summary,
+    provider_arguments_exceed_max_bytes, validate_optional_provider_metadata_text,
+    validate_provider_arguments, validate_provider_identity, validate_provider_token,
+    validate_provider_tool_name,
 };
 pub use redaction::{redact_exact_values, redaction_values_for_secret};
 pub use sanitizer::{InjectionWarning, SanitizedOutput, Sanitizer};

--- a/crates/ironclaw_safety/src/provider_validation.rs
+++ b/crates/ironclaw_safety/src/provider_validation.rs
@@ -3,29 +3,23 @@ use std::sync::OnceLock;
 use crate::LeakDetector;
 
 pub const PROVIDER_TOOL_NAME_MAX_BYTES: usize = 64;
-pub const PROVIDER_ARGUMENTS_MAX_BYTES: usize = 16 * 1024;
+/// Max serialized size of a single provider tool call's JSON arguments.
+///
+/// This is a bound on *model output*, not a provider request limit, so raising
+/// it cannot cause provider-side rejection. 64 KiB covers legitimate large tool
+/// calls (writing an analyzed CSV/report, a multi-hunk `apply_patch`) that the
+/// previous 16 KiB cap rejected, which left the model unable to comply and
+/// retrying the same call into a give-up loop. It stays bounded — aligned with
+/// the 64 KiB checkpoint-state budget and far below the 4 MiB capability-I/O
+/// staging cap — and the per-string leak scan and depth guard below are
+/// unchanged. See nearai/benchmarks pinchbench failure taxonomy (bucket B).
+pub const PROVIDER_ARGUMENTS_MAX_BYTES: usize = 64 * 1024;
+/// Max size of model-emitted metadata text (reasoning / response reasoning /
+/// signature). Raised from 4 KiB, which truncated legitimate reasoning on
+/// analysis-heavy tasks and forced retries (taxonomy bucket C). Same rationale
+/// as `PROVIDER_ARGUMENTS_MAX_BYTES`: it bounds model output, not a request.
+pub const PROVIDER_METADATA_TEXT_MAX_BYTES: usize = 16 * 1024;
 const PROVIDER_ARGUMENTS_MAX_DEPTH: usize = 16;
-
-const SENSITIVE_PROVIDER_TEXT_MARKERS: [&str; 18] = [
-    "access token",
-    "api key",
-    "api_key",
-    "apikey",
-    "authorization:",
-    "bearer ",
-    "host path",
-    "invalid api key",
-    "invalid_api_key",
-    "password",
-    "passwd",
-    "provider error",
-    "raw runtime",
-    "secret",
-    "stack trace",
-    "tool input",
-    "tool_input",
-    "traceback",
-];
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 #[error("{message}")]
@@ -212,10 +206,14 @@ fn validate_provider_metadata_text(
             "{label} must not contain NUL/control characters"
         )));
     }
-    let lower = value.to_ascii_lowercase();
-    for forbidden in SENSITIVE_PROVIDER_TEXT_MARKERS {
-        reject_sensitive_provider_text_marker(&lower, label, forbidden)?;
-    }
+    // Sensitive content is gated by the entropy-based LeakDetector below, NOT by
+    // crude substring markers. Words like "password" / "traceback" / "secret"
+    // legitimately appear in model reasoning when analyzing logs, security
+    // findings, or auth flows; blocking the bare words produced false-positive
+    // rejections that the model could not satisfy, driving retry/give-up loops
+    // (nearai/benchmarks pinchbench taxonomy bucket D). The LeakDetector still
+    // catches actual secret-like tokens (API keys, high-entropy values), which
+    // is the real guard here.
     reject_provider_secret_leaks(value, label)
 }
 
@@ -231,19 +229,6 @@ fn validate_provider_argument_text(
         )));
     }
     reject_provider_secret_leaks(value, label)
-}
-
-fn reject_sensitive_provider_text_marker(
-    lower_value: &str,
-    label: &str,
-    forbidden: &'static str,
-) -> Result<(), ProviderValidationError> {
-    if lower_value.contains(forbidden) {
-        return Err(ProviderValidationError::new(format!(
-            "{label} must not contain sensitive marker `{forbidden}`"
-        )));
-    }
-    Ok(())
 }
 
 fn reject_provider_secret_leaks(value: &str, label: &str) -> Result<(), ProviderValidationError> {
@@ -290,19 +275,18 @@ mod tests {
     }
 
     #[test]
-    fn provider_metadata_rejects_sensitive_markers() {
-        let error = validate_optional_provider_metadata_text(
-            Some("provider error included traceback"),
+    fn provider_metadata_allows_sensitive_words_gated_only_by_leak_detector() {
+        // Bucket D fix: bare English words like "provider error" / "traceback" /
+        // "password" are no longer rejected by crude substring markers. They
+        // legitimately appear in model reasoning about logs, security findings,
+        // or auth flows. The entropy-based LeakDetector remains the sole guard
+        // and still catches actual secret-like tokens.
+        validate_optional_provider_metadata_text(
+            Some("provider error included a traceback; the user's password had expired"),
             "provider reasoning",
-            4096,
+            PROVIDER_METADATA_TEXT_MAX_BYTES,
         )
-        .expect_err("sensitive marker should fail");
-
-        assert!(
-            error
-                .to_string()
-                .contains("sensitive marker `provider error`")
-        );
+        .expect("sensitive English words must pass; only the LeakDetector gates real secrets");
     }
 
     #[test]


### PR DESCRIPTION
Addresses **buckets B, C, and D** of the [PinchBench failure taxonomy](https://github.com/nearai/benchmarks/blob/main/docs/reborn-pinchbench-failure-taxonomy.md) in one PR so the benchmark can measure them together. These are the taxonomy's **#1 and #2 recommended fixes** ("tiny diff, directly unblocks ~20 tasks + a chunk of the timeouts/loops").

The chain the taxonomy identifies: **provider-output validation rejects a legitimate turn → the model retries the same call → repetition/give-up loop (F) → turn timeout (A).** All three limits here bound **model output**, not a provider request — so raising them **cannot** cause provider-side rejection.

## Changes

**B — `PROVIDER_ARGUMENTS_MAX_BYTES` 16 KiB → 64 KiB** (`ironclaw_safety/src/provider_validation.rs`)
A single tool call's JSON args >16 KiB was rejected (writing an analyzed CSV/report, a multi-hunk `apply_patch`), which the model couldn't shrink → loop. 64 KiB stays **bounded**: aligned with the 64 KiB checkpoint-state budget, far below the 4 MiB capability-I/O staging cap. The depth-16 guard and the per-string `LeakDetector` scan are **unchanged**.

**C — reasoning/metadata cap 4 KiB → 16 KiB**
Long-but-legitimate reasoning on analysis-heavy tasks was truncated/rejected → retry. Introduces a named `PROVIDER_METADATA_TEXT_MAX_BYTES` const, used at the three `loop_support` call sites (`response_reasoning` / `reasoning` / `signature`) in place of the magic `4096`.

**D — drop the crude sensitive-marker substring scan**
`SENSITIVE_PROVIDER_TEXT_MARKERS` rejected model **reasoning** containing bare words like `"password"`, `"traceback"`, `"secret"`, `"stack trace"` — which legitimately appear when analyzing logs, security findings, or auth flows (false positives → loops). Removed. **The entropy-based `LeakDetector` (`reject_provider_secret_leaks`) still runs and remains the real guard** for actual secret-like tokens (API keys, high-entropy values) — i.e. detection now relies on the LeakDetector, not crude word-matching.

## Not in this PR (follow-up)
- **Redact-instead-of-reject** for actual `LeakDetector` hits on provider output (turn the boundary validator into a sanitizer that returns cleaned text — `sanitize_tool_output` already does this for tool *output*). Orthogonal to the benchmark; it's a safety-boundary refactor worth its own review.
- **E** (fuzzy `apply_patch` + corrective errors) — separate, larger.

## Validation
`cargo fmt` clean; edits verified consistent (crate-root re-export added, no dangling refs to the removed marker const/fn, the args-size test self-adjusts via the const, the marker test flipped to assert the new allowed behavior). **Full `clippy --all-features` + test gate deferred to CI** (local disk is full — see note to maintainer). Please watch CI before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)