### PR TITLE
fix(reborn): order Recent threads by last interaction

### DIFF
--- a/crates/ironclaw_product_workflow/tests/reborn_services_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/reborn_services_contract.rs
@@ -146,6 +146,8 @@ fn fake_thread_history(owner: &WebUiAuthenticatedCaller, thread_id: &str) -> Thr
             title: Some("M2 facade contract thread".to_string()),
             metadata_json: None,
             goal: None,
+            created_at: None,
+            updated_at: None,
         },
         messages: vec![ThreadMessageRecord {
             message_id: ThreadMessageId::new(),
@@ -1558,6 +1560,8 @@ impl SessionThreadService for ScriptedThreadService {
                     title: None,
                     metadata_json: None,
                     goal: None,
+                    created_at: None,
+                    updated_at: None,
                 },
                 messages: Vec::new(),
                 summary_artifacts: Vec::new(),
@@ -8199,6 +8203,8 @@ async fn list_threads_breaks_out_when_cursor_does_not_advance_for_automation_thr
             "trigger-scheduled-summary",
         )),
         goal: None,
+        created_at: None,
+        updated_at: None,
     };
     let stalled_cursor = "cursor-stalled".to_string();
     let thread_service = Arc::new(ScriptedThreadService::list_pages(vec![
@@ -8262,6 +8268,8 @@ async fn list_threads_caps_filtered_pages_when_automation_threads_dominate() {
             "trigger-scheduled-summary",
         )),
         goal: None,
+        created_at: None,
+        updated_at: None,
     };
     let responses = (0..20)
         .map(|index| ListThreadsForScopeResponse {
@@ -8322,6 +8330,34 @@ async fn list_threads_skips_hidden_automation_threads_when_filling_page() {
     let second_visible_thread_id =
         ThreadId::new("thread-c-visible").expect("second visible thread id");
 
+    // Threads list newest-activity first, so create them oldest → newest:
+    // second visible, then first visible, then the automation thread last.
+    // That yields a candidate order of [automation, first, second], so the
+    // facade has to skip the leading hidden automation thread while filling
+    // the first page — the behavior under test. 1ms gaps keep the
+    // `created_at` stamps strictly ordered regardless of clock resolution.
+    thread_service
+        .ensure_thread(EnsureThreadRequest {
+            scope: thread_scope_for(&caller),
+            thread_id: Some(second_visible_thread_id.clone()),
+            created_by_actor_id: caller.user_id.as_str().to_string(),
+            title: Some("Second visible chat".to_string()),
+            metadata_json: Some(json!({ "source": "webui" }).to_string()),
+        })
+        .await
+        .expect("second visible thread");
+    std::thread::sleep(std::time::Duration::from_millis(1));
+    thread_service
+        .ensure_thread(EnsureThreadRequest {
+            scope: thread_scope_for(&caller),
+            thread_id: Some(first_visible_thread_id.clone()),
+            created_by_actor_id: caller.user_id.as_str().to_string(),
+            title: Some("First visible chat".to_string()),
+            metadata_json: Some(json!({ "source": "webui" }).to_string()),
+        })
+        .await
+        .expect("first visible thread");
+    std::thread::sleep(std::time::Duration::from_millis(1));
     thread_service
         .ensure_thread(EnsureThreadRequest {
             scope: thread_scope_for(&caller),
@@ -8334,26 +8370,6 @@ async fn list_threads_skips_hidden_automation_threads_when_filling_page() {
         })
         .await
         .expect("automation thread");
-    thread_service
-        .ensure_thread(EnsureThreadRequest {
-            scope: thread_scope_for(&caller),
-            thread_id: Some(first_visible_thread_id.clone()),
-            created_by_actor_id: caller.user_id.as_str().to_string(),
-            title: Some("First visible chat".to_string()),
-            metadata_json: Some(json!({ "source": "webui" }).to_string()),
-        })
-        .await
-        .expect("first visible thread");
-    thread_service
-        .ensure_thread(EnsureThreadRequest {
-            scope: thread_scope_for(&caller),
-            thread_id: Some(second_visible_thread_id.clone()),
-            created_by_actor_id: caller.user_id.as_str().to_string(),
-            title: Some("Second visible chat".to_string()),
-            metadata_json: Some(json!({ "source": "webui" }).to_string()),
-        })
-        .await
-        .expect("second visible thread");
 
     let first_page = services
         .list_threads(

--- a/crates/ironclaw_product_workflow/tests/reborn_services_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/reborn_services_contract.rs
@@ -88,6 +88,16 @@ fn caller() -> WebUiAuthenticatedCaller {
     caller_for_user("user-alpha")
 }
 
+/// Wait until the wall clock is strictly past `floor`, so the next thread
+/// created/used gets a later activity timestamp — deterministic regardless
+/// of clock resolution. Uses async sleep to avoid blocking the test runtime
+/// (`std::thread::sleep` would block the tokio executor).
+async fn wait_until_after(floor: chrono::DateTime<Utc>) {
+    while Utc::now() <= floor {
+        tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+    }
+}
+
 fn caller_for_user(user_id: &str) -> WebUiAuthenticatedCaller {
     caller_for_user_with_project(user_id, Some("project-alpha"))
 }
@@ -8334,9 +8344,9 @@ async fn list_threads_skips_hidden_automation_threads_when_filling_page() {
     // second visible, then first visible, then the automation thread last.
     // That yields a candidate order of [automation, first, second], so the
     // facade has to skip the leading hidden automation thread while filling
-    // the first page — the behavior under test. 1ms gaps keep the
-    // `created_at` stamps strictly ordered regardless of clock resolution.
-    thread_service
+    // the first page — the behavior under test. Waiting past each stamp
+    // keeps the `created_at` order strict regardless of clock resolution.
+    let second = thread_service
         .ensure_thread(EnsureThreadRequest {
             scope: thread_scope_for(&caller),
             thread_id: Some(second_visible_thread_id.clone()),
@@ -8346,8 +8356,8 @@ async fn list_threads_skips_hidden_automation_threads_when_filling_page() {
         })
         .await
         .expect("second visible thread");
-    std::thread::sleep(std::time::Duration::from_millis(1));
-    thread_service
+    wait_until_after(second.updated_at.expect("activity stamp")).await;
+    let first = thread_service
         .ensure_thread(EnsureThreadRequest {
             scope: thread_scope_for(&caller),
             thread_id: Some(first_visible_thread_id.clone()),
@@ -8357,7 +8367,7 @@ async fn list_threads_skips_hidden_automation_threads_when_filling_page() {
         })
         .await
         .expect("first visible thread");
-    std::thread::sleep(std::time::Duration::from_millis(1));
+    wait_until_after(first.updated_at.expect("activity stamp")).await;
     thread_service
         .ensure_thread(EnsureThreadRequest {
             scope: thread_scope_for(&caller),

--- a/crates/ironclaw_reborn_composition/tests/webui_v2_serve.rs
+++ b/crates/ironclaw_reborn_composition/tests/webui_v2_serve.rs
@@ -842,6 +842,8 @@ impl RebornServicesApi for StubServices {
                 title: None,
                 metadata_json: None,
                 goal: None,
+                created_at: None,
+                updated_at: None,
             },
         })
     }
@@ -894,6 +896,8 @@ impl RebornServicesApi for StubServices {
                 title: None,
                 metadata_json: None,
                 goal: None,
+                created_at: None,
+                updated_at: None,
             },
             messages: Vec::new(),
             summary_artifacts: Vec::new(),

--- a/crates/ironclaw_reborn_webui_ingress/tests/session_round_trip.rs
+++ b/crates/ironclaw_reborn_webui_ingress/tests/session_round_trip.rs
@@ -102,6 +102,8 @@ impl RebornServicesApi for StubServices {
                 title: None,
                 metadata_json: None,
                 goal: None,
+                created_at: None,
+                updated_at: None,
             },
         })
     }

--- a/crates/ironclaw_reborn_webui_ingress/tests/signed_session_multi_user.rs
+++ b/crates/ironclaw_reborn_webui_ingress/tests/signed_session_multi_user.rs
@@ -90,6 +90,8 @@ impl RebornServicesApi for RecordingServices {
                 title: None,
                 metadata_json: None,
                 goal: None,
+                created_at: None,
+                updated_at: None,
             },
         })
     }

--- a/crates/ironclaw_reborn_webui_ingress/tests/support/harness.rs
+++ b/crates/ironclaw_reborn_webui_ingress/tests/support/harness.rs
@@ -93,6 +93,8 @@ impl RebornServicesApi for StubServices {
                 title: None,
                 metadata_json: None,
                 goal: None,
+                created_at: None,
+                updated_at: None,
             },
         })
     }

--- a/crates/ironclaw_threads/Cargo.toml
+++ b/crates/ironclaw_threads/Cargo.toml
@@ -34,4 +34,4 @@ test-support = []
 
 [dev-dependencies]
 ironclaw_threads = { path = ".", features = ["test-support"] }
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }

--- a/crates/ironclaw_threads/src/contract.rs
+++ b/crates/ironclaw_threads/src/contract.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, Utc};
 use ironclaw_common::AttachmentRef;
 use ironclaw_host_api::{AgentId, MissionId, ProjectId, TenantId, ThreadId, UserId};
 use serde::{Deserialize, Serialize};
@@ -183,6 +184,15 @@ pub struct SessionThreadRecord {
     pub metadata_json: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub goal: Option<ThreadGoal>,
+    /// When the thread was created. `None` for legacy records persisted
+    /// before activity timestamps existed; such records sort oldest.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<DateTime<Utc>>,
+    /// Last time the thread saw activity (a message was appended). Drives
+    /// the sidebar "Recent" ordering — newest activity first. Bumped on
+    /// every append; `None` for legacy records (sorts oldest).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<DateTime<Utc>>,
 }
 
 /// Transcript message snapshot for UI/projection reads.

--- a/crates/ironclaw_threads/src/filesystem_service.rs
+++ b/crates/ironclaw_threads/src/filesystem_service.rs
@@ -40,6 +40,7 @@ use std::{
 };
 
 use async_trait::async_trait;
+use chrono::Utc;
 use futures::{StreamExt, future::join_all};
 use ironclaw_filesystem::{
     CasExpectation, ContentType, Entry, FileType, FilesystemError, FilesystemOperation,
@@ -553,6 +554,11 @@ where
                 })?;
             let assigned = stored.next_sequence;
             stored.next_sequence = assigned + 1;
+            // Every appended message is thread activity; bump the
+            // last-activity stamp so the sidebar surfaces freshly-used
+            // threads first. Reserving a sequence is the single choke
+            // point all append paths share.
+            stored.record.updated_at = Some(Utc::now());
             let entry = Self::thread_entry(&stored)?;
             match put_with_cas(
                 self.filesystem.as_ref(),
@@ -671,6 +677,7 @@ where
         // path-keyed read above only catches same-scope existence; sibling
         // existence is racy across an outer caller. For now we rely on the
         // path uniqueness — a sibling scope cannot create the same path.
+        let now = Utc::now();
         let record = SessionThreadRecord {
             scope: request.scope,
             thread_id: thread_id.clone(),
@@ -678,6 +685,8 @@ where
             title: request.title,
             metadata_json: request.metadata_json,
             goal: None,
+            created_at: Some(now),
+            updated_at: Some(now),
         };
         let stored = StoredThreadRecord {
             record: record.clone(),
@@ -1505,17 +1514,21 @@ where
         request: ListThreadsForScopeRequest,
     ) -> Result<ListThreadsForScopeResponse, SessionThreadError> {
         // Per-request work scales with total thread count, not page
-        // size: `list_dir` materializes every entry, we sort, then
-        // slice. The current `ScopedFilesystem` port doesn't expose a
-        // cursor-paginated directory listing, and adding one belongs
-        // upstream of this crate. Acceptable today because:
+        // size. Activity ordering (newest interaction first) requires
+        // every record's timestamp, so we read all records under the
+        // scope, sort by activity, then slice the requested page. The
+        // current `ScopedFilesystem` port exposes neither a
+        // cursor-paginated directory listing nor a timestamp index, and
+        // adding either belongs upstream of this crate. Acceptable today
+        // because:
         //   * local-dev / single-tenant deployments keep the per-scope
         //     thread count bounded (per agent + project + owner).
-        //   * names are short strings; the dominant per-page cost is
-        //     the parallel `get` fan-out, not the directory scan.
+        //   * the record-read fan-out is concurrency-bounded, and the
+        //     heavier title-derivation probes still run only for the
+        //     sliced page.
         // When a tenant grows past low thousands of threads under a
         // single scope, replace this with a storage-level paginator
-        // (e.g. a secondary index keyed by `(scope, thread_id)`).
+        // (e.g. a secondary index keyed by `(scope, updated_at)`).
         let limit = request
             .limit
             .map(|n| (n as usize).clamp(1, LIST_THREADS_MAX_PAGE_SIZE))
@@ -1532,50 +1545,36 @@ where
             }
             Err(error) => return Err(error.into()),
         };
-        let mut thread_ids: Vec<String> = entries
+        let thread_ids: Vec<ThreadId> = entries
             .into_iter()
             .filter(|entry| entry.file_type == FileType::Directory)
-            .map(|entry| entry.name)
-            .collect();
-        thread_ids.sort();
-        let start_index = match request.cursor.as_deref() {
-            Some(cursor) => thread_ids
-                .iter()
-                .position(|id| id.as_str() > cursor)
-                .unwrap_or(thread_ids.len()),
-            None => 0,
-        };
-        let end_index = start_index.saturating_add(limit).min(thread_ids.len());
-        let thread_ids_page: Vec<ThreadId> = thread_ids[start_index..end_index]
-            .iter()
-            .map(|name| ThreadId::new(name.clone()).map_err(invalid_path))
+            .map(|entry| ThreadId::new(entry.name).map_err(invalid_path))
             .collect::<Result<_, _>>()?;
-        // Parallelize the per-thread reads. `list_dir` only returns
-        // names, so each entry still requires a `get` to materialize
-        // the record — issuing them concurrently turns an N-sequential
-        // page (up to 200 reads) into a single bounded fan-out.
-        let reads = thread_ids_page
-            .iter()
-            .map(|tid| self.read_thread_versioned(&request.scope, tid));
-        let results: Vec<Result<Option<(StoredThreadRecord, RecordVersion)>, SessionThreadError>> =
-            futures::future::join_all(reads).await;
-        let mut page: Vec<SessionThreadRecord> = Vec::with_capacity(thread_ids_page.len());
-        // Records whose `title` is `None` need a sidebar-friendly
-        // label derived from their first user message. We collect
-        // their page indices here and fan-out the indexed first-user
-        // reads below so we don't serialize N transcript probes
-        // behind the thread-record fan-out.
-        let mut needs_title: Vec<(usize, ThreadId, u64)> = Vec::new();
-        for (thread_id, result) in thread_ids_page.iter().zip(results) {
+        // Read every record to obtain its activity timestamp. `list_dir`
+        // only returns names, so each entry still requires a `get`.
+        // Bound the concurrency so a large scope can't fan out an
+        // unbounded burst of filesystem reads; ordering is irrelevant
+        // here since we sort by activity immediately after.
+        let scope = &request.scope;
+        let reads: Vec<(
+            ThreadId,
+            Result<Option<(StoredThreadRecord, RecordVersion)>, _>,
+        )> = futures::stream::iter(thread_ids)
+            .map(|tid| async move {
+                let result = self.read_thread_versioned(scope, &tid).await;
+                (tid, result)
+            })
+            .buffer_unordered(LIST_THREADS_RECORD_READ_CONCURRENCY)
+            .collect()
+            .await;
+        // Keep present, scope-matching records paired with their
+        // `next_sequence` (needed for page-scoped title derivation).
+        let mut listed: Vec<(SessionThreadRecord, u64)> = Vec::with_capacity(reads.len());
+        for (thread_id, result) in reads {
             match result {
                 Ok(Some((stored, _))) if stored.record.scope == request.scope => {
-                    let needs_derive = stored.record.title.is_none();
                     let next_sequence = stored.next_sequence;
-                    let idx = page.len();
-                    page.push(stored.record);
-                    if needs_derive {
-                        needs_title.push((idx, thread_id.clone(), next_sequence));
-                    }
+                    listed.push((stored.record, next_sequence));
                 }
                 Ok(_) => {
                     // Absent record or scope-mismatched payload (e.g.
@@ -1596,6 +1595,45 @@ where
                     );
                 }
             }
+        }
+        // Newest activity first (`updated_at`, falling back to
+        // `created_at`). Legacy records without timestamps sort last.
+        // Tie-break on thread_id ascending so the order is stable and
+        // opaque cursors stay resumable — and to match the web sidebar's
+        // `byActivityDesc` comparator.
+        listed.sort_by(|(a, _), (b, _)| {
+            let a_key = a.updated_at.or(a.created_at);
+            let b_key = b.updated_at.or(b.created_at);
+            std::cmp::Reverse(a_key)
+                .cmp(&std::cmp::Reverse(b_key))
+                .then_with(|| a.thread_id.as_str().cmp(b.thread_id.as_str()))
+        });
+        // Opaque cursor is the last thread_id of the previous page; find
+        // it in the freshly-sorted list and resume after it. A cursor
+        // that no longer resolves (thread deleted between pages) ends the
+        // stream rather than restarting from the top.
+        let start_index = match request.cursor.as_deref() {
+            Some(cursor) => listed
+                .iter()
+                .position(|(record, _)| record.thread_id.as_str() == cursor)
+                .map(|index| index + 1)
+                .unwrap_or(listed.len()),
+            None => 0,
+        };
+        let end_index = start_index.saturating_add(limit).min(listed.len());
+        let has_more = end_index < listed.len();
+        let mut page: Vec<SessionThreadRecord> = Vec::with_capacity(end_index - start_index);
+        // Records whose `title` is `None` need a sidebar-friendly label
+        // derived from their first user message. We collect their page
+        // indices here and fan-out the indexed first-user reads below so
+        // we don't serialize N transcript probes inline.
+        let mut needs_title: Vec<(usize, ThreadId, u64)> = Vec::new();
+        for (record, next_sequence) in listed.drain(start_index..end_index) {
+            let idx = page.len();
+            if record.title.is_none() {
+                needs_title.push((idx, record.thread_id.clone(), next_sequence));
+            }
+            page.push(record);
         }
         // Derive titles in parallel from each thread's first user
         // message. v1's libSQL list path did the same thing in SQL
@@ -1644,15 +1682,12 @@ where
                 }
             }
         }
-        // Cursor must reflect the last *attempted* thread_id in this
-        // slice, not the last *successful* one — otherwise a page
-        // where every record was unreadable or scope-mismatched
-        // would return `next_cursor: None` and the caller would treat
-        // a transient corruption as end-of-stream. Using the slice's
-        // last id guarantees the next request advances strictly past
-        // the inspected range.
-        let next_cursor = if end_index < thread_ids.len() {
-            thread_ids_page.last().map(|tid| tid.as_str().to_string())
+        // The cursor is the last thread_id on this page; the next
+        // request resumes after it in the activity-sorted order. Only
+        // emit one when more records remain beyond this slice.
+        let next_cursor = if has_more {
+            page.last()
+                .map(|record| record.thread_id.as_str().to_string())
         } else {
             None
         };
@@ -1665,6 +1700,10 @@ where
 
 const LIST_THREADS_DEFAULT_PAGE_SIZE: usize = 50;
 const LIST_THREADS_MAX_PAGE_SIZE: usize = 200;
+/// Bounded fan-out for reading every thread record during an
+/// activity-sorted list. Caps concurrent filesystem reads so a large
+/// scope can't burst an unbounded number of `get`s.
+const LIST_THREADS_RECORD_READ_CONCURRENCY: usize = 16;
 
 // ── Idempotency key shape ──────────────────────────────────────
 //

--- a/crates/ironclaw_threads/src/filesystem_service.rs
+++ b/crates/ironclaw_threads/src/filesystem_service.rs
@@ -776,9 +776,6 @@ where
             }
         }
 
-        let sequence = self
-            .reserve_sequence(&request.scope, &request.thread_id)
-            .await?;
         let message_id = ThreadMessageId::new();
         // Borrow `request` for the idempotency key before moving `content` out,
         // so the content (now carrying attachment refs) is consumed by move
@@ -786,6 +783,14 @@ where
         let idempotency_key = InboundIdempotencyKey::from_request(&request);
         let (content_text, attachments) = request.content.into_parts();
         crate::contract::validate_attachment_refs(&attachments)?;
+        // Reserve the sequence only after the payload validates. Because
+        // `reserve_sequence` persists the thread's last-activity stamp, a
+        // rejected attachment must not run first — otherwise an invalid
+        // message would bump the thread to the top of the sidebar without
+        // ever being appended.
+        let sequence = self
+            .reserve_sequence(&request.scope, &request.thread_id)
+            .await?;
         let message = ThreadMessageRecord {
             message_id,
             thread_id: request.thread_id.clone(),
@@ -1583,11 +1588,11 @@ where
                 }
                 Err(error) => {
                     // silent-ok: list_threads is a sidebar read; one
-                    // corrupted record must not blank out the whole
-                    // page. The error is surfaced through tracing so
-                    // operators see it without the user losing the
-                    // rest of their thread list.
-                    tracing::warn!(
+                    // corrupted record must not blank out the whole page.
+                    // Logged at `debug!` (not `warn!`) — this is an internal
+                    // diagnostic, and `info!`/`warn!` corrupt the REPL/TUI
+                    // display per the project logging rule.
+                    tracing::debug!(
                         thread_id = %thread_id.as_str(),
                         scope = ?request.scope,
                         ?error,
@@ -1672,7 +1677,9 @@ where
                         }
                     }
                     Err(error) => {
-                        tracing::warn!(
+                        // Internal diagnostic — `debug!`, not `warn!`, to keep
+                        // the REPL/TUI display intact (project logging rule).
+                        tracing::debug!(
                             thread_id = %thread_id.as_str(),
                             scope = ?request.scope,
                             ?error,

--- a/crates/ironclaw_threads/src/in_memory.rs
+++ b/crates/ironclaw_threads/src/in_memory.rs
@@ -148,13 +148,17 @@ impl SessionThreadService for InMemorySessionThreadService {
         let key = InboundIdempotencyKey::from_request(&request);
         let thread = get_thread_mut(&mut state, &request.scope, &request.thread_id)?;
         let message_id = ThreadMessageId::new();
+        // Validate the payload before mutating any thread state. A rejected
+        // attachment must not increment the sequence or bump the
+        // last-activity stamp, or an invalid message would surface the
+        // thread at the top of the sidebar without being appended.
+        let (content_text, attachments) = request.content.into_parts();
+        crate::contract::validate_attachment_refs(&attachments)?;
         let sequence = thread.next_sequence;
         thread.next_sequence += 1;
         // Appending a message is thread activity; bump the last-activity
         // stamp so activity-ordered listings surface this thread first.
         thread.record.updated_at = Some(Utc::now());
-        let (content_text, attachments) = request.content.into_parts();
-        crate::contract::validate_attachment_refs(&attachments)?;
         thread.messages.push(ThreadMessageRecord {
             message_id,
             thread_id: request.thread_id.clone(),

--- a/crates/ironclaw_threads/src/in_memory.rs
+++ b/crates/ironclaw_threads/src/in_memory.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use async_trait::async_trait;
+use chrono::Utc;
 use ironclaw_host_api::ThreadId;
 use tokio::sync::Mutex;
 use uuid::Uuid;
@@ -85,6 +86,7 @@ impl SessionThreadService for InMemorySessionThreadService {
             return Ok(existing.record.clone());
         }
 
+        let now = Utc::now();
         let record = SessionThreadRecord {
             scope: request.scope,
             thread_id: thread_id.clone(),
@@ -92,6 +94,8 @@ impl SessionThreadService for InMemorySessionThreadService {
             title: request.title,
             metadata_json: request.metadata_json,
             goal: None,
+            created_at: Some(now),
+            updated_at: Some(now),
         };
         state.threads.insert(
             thread_id,
@@ -146,6 +150,9 @@ impl SessionThreadService for InMemorySessionThreadService {
         let message_id = ThreadMessageId::new();
         let sequence = thread.next_sequence;
         thread.next_sequence += 1;
+        // Appending a message is thread activity; bump the last-activity
+        // stamp so activity-ordered listings surface this thread first.
+        thread.record.updated_at = Some(Utc::now());
         let (content_text, attachments) = request.content.into_parts();
         crate::contract::validate_attachment_refs(&attachments)?;
         thread.messages.push(ThreadMessageRecord {
@@ -283,6 +290,9 @@ impl SessionThreadService for InMemorySessionThreadService {
             redaction_ref: None,
         };
         thread.next_sequence += 1;
+        // Appending a message is thread activity; bump the last-activity
+        // stamp so activity-ordered listings surface this thread first.
+        thread.record.updated_at = Some(Utc::now());
         thread.messages.push(message.clone());
         Ok(message)
     }
@@ -364,6 +374,9 @@ impl SessionThreadService for InMemorySessionThreadService {
             redaction_ref: None,
         };
         thread.next_sequence += 1;
+        // Appending a message is thread activity; bump the last-activity
+        // stamp so activity-ordered listings surface this thread first.
+        thread.record.updated_at = Some(Utc::now());
         thread.messages.push(message.clone());
         Ok(message)
     }
@@ -412,6 +425,9 @@ impl SessionThreadService for InMemorySessionThreadService {
             redaction_ref: None,
         };
         thread.next_sequence += 1;
+        // Appending a message is thread activity; bump the last-activity
+        // stamp so activity-ordered listings surface this thread first.
+        thread.record.updated_at = Some(Utc::now());
         thread.messages.push(message.clone());
         Ok(message)
     }
@@ -727,24 +743,31 @@ impl SessionThreadService for InMemorySessionThreadService {
                 record
             })
             .collect();
-        // Stable order so opaque cursor → resumption is deterministic.
-        matching.sort_by(|a, b| a.thread_id.as_str().cmp(b.thread_id.as_str()));
+        // Newest activity first (`updated_at`, falling back to
+        // `created_at`); legacy records without timestamps sort last.
+        // Tie-break on thread_id ascending so the order is stable and
+        // opaque cursors stay resumable, matching the filesystem backend
+        // and the web sidebar's `byActivityDesc` comparator.
+        matching.sort_by(|a, b| {
+            let a_key = a.updated_at.or(a.created_at);
+            let b_key = b.updated_at.or(b.created_at);
+            std::cmp::Reverse(a_key)
+                .cmp(&std::cmp::Reverse(b_key))
+                .then_with(|| a.thread_id.as_str().cmp(b.thread_id.as_str()))
+        });
 
+        // Opaque cursor is the last thread_id of the previous page; find
+        // it in the activity-sorted list and resume after it. A cursor
+        // that no longer resolves ends the stream rather than restarting.
         let start_index = match request.cursor.as_deref() {
             Some(cursor) => matching
                 .iter()
-                .position(|record| record.thread_id.as_str() > cursor)
+                .position(|record| record.thread_id.as_str() == cursor)
+                .map(|index| index + 1)
                 .unwrap_or(matching.len()),
             None => 0,
         };
         let end_index = start_index.saturating_add(limit).min(matching.len());
-        // Cursor reflects the last *attempted* id in the slice (vs. the
-        // last successful), so a page that ends up empty due to
-        // upstream filtering still produces a cursor that moves
-        // forward. Today every entry in `matching` survives because
-        // the scope filter is the only predicate, but lining this up
-        // with the filesystem backend keeps the contract identical
-        // when future predicates land.
         let next_cursor = if end_index < matching.len() {
             matching[start_index..end_index]
                 .last()

--- a/crates/ironclaw_threads/tests/filesystem_session_thread_contract.rs
+++ b/crates/ironclaw_threads/tests/filesystem_session_thread_contract.rs
@@ -819,6 +819,16 @@ async fn assert_reopened_history(
     assert!(wrong_scope.is_err());
 }
 
+/// Wait until the wall clock is strictly past `floor`, so the next thread
+/// created/used gets a later activity timestamp — deterministic regardless
+/// of clock resolution. Uses async sleep to avoid blocking the test runtime
+/// (`std::thread::sleep` would block the tokio executor).
+async fn wait_until_after(floor: chrono::DateTime<Utc>) {
+    while Utc::now() <= floor {
+        tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+    }
+}
+
 #[tokio::test]
 async fn filesystem_list_threads_for_scope_is_scope_filtered_and_paginated() {
     use ironclaw_threads::ListThreadsForScopeRequest;
@@ -849,7 +859,7 @@ async fn filesystem_list_threads_for_scope_is_scope_filtered_and_paginated() {
     // encodes scope axes, this also verifies the directory walk
     // doesn't leak across `(agent, project, owner)` cells.
     for id in ["t-a-001", "t-a-002", "t-a-003"] {
-        service
+        let record = service
             .ensure_thread(EnsureThreadRequest {
                 scope: scope_a.clone(),
                 thread_id: Some(ThreadId::new(id).unwrap()),
@@ -859,9 +869,9 @@ async fn filesystem_list_threads_for_scope_is_scope_filtered_and_paginated() {
             })
             .await
             .unwrap();
-        // 1ms gap → strictly increasing `created_at`, so the
-        // activity-desc ordering below is deterministic.
-        std::thread::sleep(std::time::Duration::from_millis(1));
+        // Wait past this thread's activity stamp → strictly increasing
+        // `created_at`, so the activity-desc ordering below is deterministic.
+        wait_until_after(record.updated_at.expect("new thread has activity stamp")).await;
     }
     service
         .ensure_thread(EnsureThreadRequest {
@@ -967,9 +977,10 @@ async fn filesystem_list_threads_orders_by_last_activity_not_creation() {
     let scope_a = scope("activity");
 
     // Create "older" first, then "newer" — newer has the later
-    // `created_at`. A 1ms gap makes the stamps strictly ordered.
+    // `created_at`. Waiting past each stamp keeps them strictly ordered.
+    let mut newer_stamp = None;
     for id in ["t-older", "t-newer"] {
-        service
+        let record = service
             .ensure_thread(EnsureThreadRequest {
                 scope: scope_a.clone(),
                 thread_id: Some(ThreadId::new(id).unwrap()),
@@ -979,7 +990,9 @@ async fn filesystem_list_threads_orders_by_last_activity_not_creation() {
             })
             .await
             .unwrap();
-        std::thread::sleep(std::time::Duration::from_millis(1));
+        let stamp = record.updated_at.expect("new thread has activity stamp");
+        newer_stamp = Some(stamp);
+        wait_until_after(stamp).await;
     }
 
     // Initially newest-created is first.
@@ -999,8 +1012,9 @@ async fn filesystem_list_threads_orders_by_last_activity_not_creation() {
     assert_eq!(before_ids, ["t-newer", "t-older"]);
 
     // Interact with the older thread — appending a message must bump its
-    // last-activity stamp above the newer thread's creation time.
-    std::thread::sleep(std::time::Duration::from_millis(1));
+    // last-activity stamp above the newer thread's creation time. Wait
+    // past the newer thread's stamp so the append is unambiguously later.
+    wait_until_after(newer_stamp.expect("created both threads")).await;
     service
         .accept_inbound_message(AcceptInboundMessageRequest {
             scope: scope_a.clone(),
@@ -1661,6 +1675,7 @@ async fn filesystem_persists_multiple_attachment_refs_in_order() {
 
 #[tokio::test]
 async fn filesystem_accept_rejects_duplicate_attachment_ids() {
+    use ironclaw_threads::ListThreadsForScopeRequest;
     // The accept path validates attachment refs before persisting. Drive the
     // real caller (not just the helper) so a regression that drops the check
     // would fail here, and assert nothing was written on rejection.
@@ -1678,6 +1693,12 @@ async fn filesystem_accept_rejects_duplicate_attachment_ids() {
         })
         .await
         .unwrap();
+
+    // Capture the creation activity stamp and let the clock advance, so a
+    // spurious activity bump on the rejected accept would be strictly later
+    // and therefore observable below.
+    let created_activity = thread.updated_at.expect("new thread has activity stamp");
+    wait_until_after(created_activity).await;
 
     let dup = AttachmentRef {
         id: "att-dup".into(),
@@ -1705,12 +1726,34 @@ async fn filesystem_accept_rejects_duplicate_attachment_ids() {
     // Rejection must not leave a half-written message behind.
     let history = service
         .list_thread_history(ThreadHistoryRequest {
-            scope,
-            thread_id: thread.thread_id,
+            scope: scope.clone(),
+            thread_id: thread.thread_id.clone(),
         })
         .await
         .unwrap();
     assert!(history.messages.is_empty());
+
+    // Rejection must also not bump the thread's last-activity stamp —
+    // otherwise an invalid message would float the thread to the top of
+    // the sidebar without ever being appended.
+    let listed = service
+        .list_threads_for_scope(ListThreadsForScopeRequest {
+            scope,
+            limit: None,
+            cursor: None,
+        })
+        .await
+        .unwrap();
+    let record = listed
+        .threads
+        .iter()
+        .find(|record| record.thread_id == thread.thread_id)
+        .expect("thread is still listed");
+    assert_eq!(
+        record.updated_at,
+        Some(created_activity),
+        "rejected attachment must not bump last-activity",
+    );
 }
 
 /// Mirrors `summary_spanning_interior_rejected_busy_is_applied` from the

--- a/crates/ironclaw_threads/tests/filesystem_session_thread_contract.rs
+++ b/crates/ironclaw_threads/tests/filesystem_session_thread_contract.rs
@@ -859,6 +859,9 @@ async fn filesystem_list_threads_for_scope_is_scope_filtered_and_paginated() {
             })
             .await
             .unwrap();
+        // 1ms gap → strictly increasing `created_at`, so the
+        // activity-desc ordering below is deterministic.
+        std::thread::sleep(std::time::Duration::from_millis(1));
     }
     service
         .ensure_thread(EnsureThreadRequest {
@@ -871,7 +874,11 @@ async fn filesystem_list_threads_for_scope_is_scope_filtered_and_paginated() {
         .await
         .unwrap();
 
-    // Scope filter: A sees only A's threads, sorted deterministically.
+    // Scope filter: A sees only A's threads, newest activity first.
+    // The threads were created sequentially (with real backend I/O
+    // between each `ensure_thread`), so their `created_at`/`updated_at`
+    // stamps strictly increase — the activity-desc ordering therefore
+    // surfaces the last-created thread (003) first.
     let scope_a_all = service
         .list_threads_for_scope(ListThreadsForScopeRequest {
             scope: scope_a.clone(),
@@ -885,13 +892,13 @@ async fn filesystem_list_threads_for_scope_is_scope_filtered_and_paginated() {
         .iter()
         .map(|record| record.thread_id.as_str())
         .collect();
-    assert_eq!(ids, ["t-a-001", "t-a-002", "t-a-003"]);
+    assert_eq!(ids, ["t-a-003", "t-a-002", "t-a-001"]);
     assert!(
         scope_a_all.next_cursor.is_none(),
         "no more pages when page size > total",
     );
 
-    // Pagination: limit=2 → first page is [001, 002] with cursor=002.
+    // Pagination: limit=2 → first page is [003, 002] with cursor=002.
     let page_1 = service
         .list_threads_for_scope(ListThreadsForScopeRequest {
             scope: scope_a.clone(),
@@ -905,10 +912,10 @@ async fn filesystem_list_threads_for_scope_is_scope_filtered_and_paginated() {
         .iter()
         .map(|record| record.thread_id.as_str())
         .collect();
-    assert_eq!(page_1_ids, ["t-a-001", "t-a-002"]);
+    assert_eq!(page_1_ids, ["t-a-003", "t-a-002"]);
     assert_eq!(page_1.next_cursor.as_deref(), Some("t-a-002"));
 
-    // Follow-up: cursor=002 → next page is [003] with no further cursor.
+    // Follow-up: cursor=002 → next page is [001] with no further cursor.
     let page_2 = service
         .list_threads_for_scope(ListThreadsForScopeRequest {
             scope: scope_a.clone(),
@@ -922,7 +929,7 @@ async fn filesystem_list_threads_for_scope_is_scope_filtered_and_paginated() {
         .iter()
         .map(|record| record.thread_id.as_str())
         .collect();
-    assert_eq!(page_2_ids, ["t-a-003"]);
+    assert_eq!(page_2_ids, ["t-a-001"]);
     assert!(page_2.next_cursor.is_none());
 
     // Cross-scope safety: scope B sees only its own thread, never A's.
@@ -943,6 +950,85 @@ async fn filesystem_list_threads_for_scope_is_scope_filtered_and_paginated() {
         .map(|record| record.thread_id.as_str())
         .collect();
     assert_eq!(ids_b, ["t-b-001"]);
+}
+
+/// Regression: the "Recent" list must order by last interaction, not by
+/// creation time or thread id. Appending a message to the *older* thread
+/// has to bump it ahead of a more recently *created* one. Before this
+/// fix, records carried no timestamp and the backend sorted by random
+/// UUID, so a freshly-used thread could land anywhere in the list.
+#[tokio::test]
+async fn filesystem_list_threads_orders_by_last_activity_not_creation() {
+    use ironclaw_threads::ListThreadsForScopeRequest;
+
+    let backend = Arc::new(InMemoryBackend::new());
+    let scoped = scoped_threads_fs_at(backend, "tenant-activity-fs", "alice");
+    let service = FilesystemSessionThreadService::new(scoped);
+    let scope_a = scope("activity");
+
+    // Create "older" first, then "newer" — newer has the later
+    // `created_at`. A 1ms gap makes the stamps strictly ordered.
+    for id in ["t-older", "t-newer"] {
+        service
+            .ensure_thread(EnsureThreadRequest {
+                scope: scope_a.clone(),
+                thread_id: Some(ThreadId::new(id).unwrap()),
+                created_by_actor_id: "actor-a".into(),
+                title: Some(id.into()),
+                metadata_json: None,
+            })
+            .await
+            .unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(1));
+    }
+
+    // Initially newest-created is first.
+    let before = service
+        .list_threads_for_scope(ListThreadsForScopeRequest {
+            scope: scope_a.clone(),
+            limit: None,
+            cursor: None,
+        })
+        .await
+        .unwrap();
+    let before_ids: Vec<&str> = before
+        .threads
+        .iter()
+        .map(|record| record.thread_id.as_str())
+        .collect();
+    assert_eq!(before_ids, ["t-newer", "t-older"]);
+
+    // Interact with the older thread — appending a message must bump its
+    // last-activity stamp above the newer thread's creation time.
+    std::thread::sleep(std::time::Duration::from_millis(1));
+    service
+        .accept_inbound_message(AcceptInboundMessageRequest {
+            scope: scope_a.clone(),
+            thread_id: ThreadId::new("t-older").unwrap(),
+            actor_id: "actor-a".into(),
+            source_binding_id: Some("binding-activity".into()),
+            reply_target_binding_id: None,
+            external_event_id: Some("event-activity".into()),
+            content: MessageContent::text("ping the old thread"),
+        })
+        .await
+        .unwrap();
+
+    // The freshly-used thread now leads the Recent list.
+    let after = service
+        .list_threads_for_scope(ListThreadsForScopeRequest {
+            scope: scope_a,
+            limit: None,
+            cursor: None,
+        })
+        .await
+        .unwrap();
+    let after_ids: Vec<&str> = after
+        .threads
+        .iter()
+        .map(|record| record.thread_id.as_str())
+        .collect();
+    assert_eq!(after_ids, ["t-older", "t-newer"]);
 }
 
 #[tokio::test]

--- a/crates/ironclaw_threads/tests/session_thread_contract.rs
+++ b/crates/ironclaw_threads/tests/session_thread_contract.rs
@@ -2490,6 +2490,16 @@ fn message_ids_are_stable_values() {
     assert_eq!(ThreadMessageId::parse(&id.to_string()).unwrap(), id);
 }
 
+/// Wait until the wall clock is strictly past `floor`, so the next thread
+/// created/used gets a later activity timestamp — deterministic regardless
+/// of clock resolution. Uses async sleep to avoid blocking the test runtime
+/// (`std::thread::sleep` would block the tokio executor).
+async fn wait_until_after(floor: chrono::DateTime<Utc>) {
+    while Utc::now() <= floor {
+        tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+    }
+}
+
 #[tokio::test]
 async fn list_threads_for_scope_is_scope_filtered_and_paginated() {
     let service = InMemorySessionThreadService::default();
@@ -2510,12 +2520,12 @@ async fn list_threads_for_scope_is_scope_filtered_and_paginated() {
 
     // Seed: 3 threads in scope A with deterministic ids so the
     // pagination assertion is stable. 1 thread in scope B that the
-    // scope-A enumeration must not see. A 1ms gap between creations
-    // guarantees strictly increasing `created_at` stamps regardless of
-    // clock resolution, so the activity-desc ordering is deterministic
+    // scope-A enumeration must not see. Waiting until the clock passes
+    // each thread's activity stamp guarantees strictly increasing
+    // `created_at`, so the activity-desc ordering is deterministic
     // (003 newest → first).
     for id in ["t-a-001", "t-a-002", "t-a-003"] {
-        service
+        let record = service
             .ensure_thread(EnsureThreadRequest {
                 scope: scope_a.clone(),
                 thread_id: Some(ThreadId::new(id).unwrap()),
@@ -2525,7 +2535,7 @@ async fn list_threads_for_scope_is_scope_filtered_and_paginated() {
             })
             .await
             .unwrap();
-        std::thread::sleep(std::time::Duration::from_millis(1));
+        wait_until_after(record.updated_at.expect("new thread has activity stamp")).await;
     }
     service
         .ensure_thread(EnsureThreadRequest {

--- a/crates/ironclaw_threads/tests/session_thread_contract.rs
+++ b/crates/ironclaw_threads/tests/session_thread_contract.rs
@@ -2510,7 +2510,10 @@ async fn list_threads_for_scope_is_scope_filtered_and_paginated() {
 
     // Seed: 3 threads in scope A with deterministic ids so the
     // pagination assertion is stable. 1 thread in scope B that the
-    // scope-A enumeration must not see.
+    // scope-A enumeration must not see. A 1ms gap between creations
+    // guarantees strictly increasing `created_at` stamps regardless of
+    // clock resolution, so the activity-desc ordering is deterministic
+    // (003 newest → first).
     for id in ["t-a-001", "t-a-002", "t-a-003"] {
         service
             .ensure_thread(EnsureThreadRequest {
@@ -2522,6 +2525,7 @@ async fn list_threads_for_scope_is_scope_filtered_and_paginated() {
             })
             .await
             .unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(1));
     }
     service
         .ensure_thread(EnsureThreadRequest {
@@ -2534,7 +2538,7 @@ async fn list_threads_for_scope_is_scope_filtered_and_paginated() {
         .await
         .unwrap();
 
-    // Scope filter: A sees only A's threads, sorted deterministically.
+    // Scope filter: A sees only A's threads, newest activity first.
     let scope_a_all = service
         .list_threads_for_scope(ListThreadsForScopeRequest {
             scope: scope_a.clone(),
@@ -2548,13 +2552,13 @@ async fn list_threads_for_scope_is_scope_filtered_and_paginated() {
         .iter()
         .map(|record| record.thread_id.as_str())
         .collect();
-    assert_eq!(ids, ["t-a-001", "t-a-002", "t-a-003"]);
+    assert_eq!(ids, ["t-a-003", "t-a-002", "t-a-001"]);
     assert!(
         scope_a_all.next_cursor.is_none(),
         "no more pages when page size > total",
     );
 
-    // Pagination: limit=2 → first page is [001, 002] with cursor=002.
+    // Pagination: limit=2 → first page is [003, 002] with cursor=002.
     let page_1 = service
         .list_threads_for_scope(ListThreadsForScopeRequest {
             scope: scope_a.clone(),
@@ -2568,10 +2572,10 @@ async fn list_threads_for_scope_is_scope_filtered_and_paginated() {
         .iter()
         .map(|record| record.thread_id.as_str())
         .collect();
-    assert_eq!(page_1_ids, ["t-a-001", "t-a-002"]);
+    assert_eq!(page_1_ids, ["t-a-003", "t-a-002"]);
     assert_eq!(page_1.next_cursor.as_deref(), Some("t-a-002"));
 
-    // Follow-up: cursor=002 → next page is [003] with no further cursor.
+    // Follow-up: cursor=002 → next page is [001] with no further cursor.
     let page_2 = service
         .list_threads_for_scope(ListThreadsForScopeRequest {
             scope: scope_a.clone(),
@@ -2585,7 +2589,7 @@ async fn list_threads_for_scope_is_scope_filtered_and_paginated() {
         .iter()
         .map(|record| record.thread_id.as_str())
         .collect();
-    assert_eq!(page_2_ids, ["t-a-003"]);
+    assert_eq!(page_2_ids, ["t-a-001"]);
     assert!(page_2.next_cursor.is_none());
 
     // Cross-scope safety: scope B sees only its own thread, never A's.

--- a/crates/ironclaw_webui_v2/tests/webui_v2_handlers_contract.rs
+++ b/crates/ironclaw_webui_v2/tests/webui_v2_handlers_contract.rs
@@ -354,6 +354,8 @@ impl RebornServicesApi for StubServices {
                     .as_ref()
                     .map(|id| format!("{{\"client_action_id\":\"{id}\"}}")),
                 goal: None,
+                created_at: None,
+                updated_at: None,
             },
         })
     }
@@ -424,6 +426,8 @@ impl RebornServicesApi for StubServices {
                 title: None,
                 metadata_json: None,
                 goal: None,
+                created_at: None,
+                updated_at: None,
             },
             messages: Vec::new(),
             summary_artifacts: Vec::new(),

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/hooks/useThreads.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/hooks/useThreads.js
@@ -63,8 +63,10 @@ export function useThreads() {
   //   never spuriously render.
   // - `created_at`/`updated_at` are emitted by the v2 backend now
   //   (updated_at bumped on every message append); they flow through
-  //   the spread and drive the sidebar's activity ordering. `null`
-  //   fallback covers legacy records persisted before timestamps.
+  //   the spread and drive the sidebar's activity ordering. The backend
+  //   omits them (`skip_serializing_if`) for legacy records persisted
+  //   before timestamps, so they arrive `undefined` and normalize to
+  //   `null` here.
   const threads = React.useMemo(() => {
     const records = query.data?.threads || [];
     return records.map((record) => ({

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/hooks/useThreads.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/hooks/useThreads.js
@@ -58,9 +58,13 @@ export function useThreads() {
 
   // Normalize v2 SessionThreadRecord → fork's expected shape:
   // - v2 carries `thread_id`; fork's thread-sidebar reads `thread.id`
-  // - v2 has no `state`, `turn_count`, `updated_at` fields
-  //   (those are v1 metadata). Fill safe defaults so the UI's
-  //   "Processing" pip and turn count never spuriously render.
+  // - v2 has no `state`/`turn_count` fields (those are v1 metadata).
+  //   Fill safe defaults so the UI's "Processing" pip and turn count
+  //   never spuriously render.
+  // - `created_at`/`updated_at` are emitted by the v2 backend now
+  //   (updated_at bumped on every message append); they flow through
+  //   the spread and drive the sidebar's activity ordering. `null`
+  //   fallback covers legacy records persisted before timestamps.
   const threads = React.useMemo(() => {
     const records = query.data?.threads || [];
     return records.map((record) => ({


### PR DESCRIPTION
## Problem

In the Reborn webui v2, starting a new conversation does **not** put it first in the **Recent** list, and the list is generally not ordered by last interaction.

## Root cause

Ordering was effectively **random**, and it was a missing-data problem, not a frontend sort bug:

- Thread IDs are random UUIDv4 (`generated_thread_id`), so they carry no time information.
- The filesystem backend "sorted" by that ID (`thread_ids.sort()` in `list_threads_for_scope`).
- `SessionThreadRecord` carried **no timestamp field at all**.
- The frontend comparator (`lib/thread-meta.js` `byActivityDesc`) wanted to sort by `updated_at`/`created_at`, but those fields never existed on the wire, so it fell through to its tiebreaker — re-sorting by the same random UUIDs.

A new conversation therefore landed wherever its random UUID happened to fall.

## Fix — last-interaction ordering

`crates/ironclaw_threads/` (the contract crate that owns these records):

- **`contract.rs`** — add `created_at` / `updated_at: Option<DateTime<Utc>>` to `SessionThreadRecord`, serde-defaulted + `skip_serializing_if` so legacy on-disk records that predate timestamps still deserialize (and sort oldest).
- **`filesystem_service.rs`** (production path):
  - `ensure_thread` stamps both timestamps at creation.
  - `reserve_sequence` — the single choke point every message append shares — bumps `updated_at` on each append, so a thread you reply in jumps to the top.
  - `list_threads_for_scope` rewritten to read all records (bounded, concurrency-capped fan-out), sort newest-activity-first with a stable `thread_id` tiebreak, then cursor-slice. The opaque cursor stays a `thread_id`, resumed by position in the sorted list.
- **`in_memory.rs`** — same stamping/bumping/activity sort kept in parity.

Frontend needed **no logic change** — its comparator was already correct, it just lacked the data. Only a stale comment in `useThreads.js` was updated to note the backend now emits these fields.

## Tests

- New regression test `filesystem_list_threads_orders_by_last_activity_not_creation`: creates an older + newer thread, confirms newest-first, then appends a message to the **older** one and asserts it moves to the front.
- Updated the two existing pagination contract tests to newest-first ordering (1ms seed gaps for deterministic stamps), and reordered the product-workflow hidden-automation test's setup to preserve its intent under activity sorting.

**Gate:** `cargo fmt`, `cargo clippy --workspace --tests -- -D warnings`, and all affected suites (threads, product_workflow, webui_v2, composition, ingress — including feature-gated ones) pass clean.

## Follow-up (non-blocking)

Activity-sorted listing reads every thread record per request (no timestamp index). The existing code comment already flagged this as acceptable for bounded per-scope thread counts; at low-thousands scale it'd want a storage-level index keyed by `(scope, updated_at)`.