### PR TITLE
[codex] Remove extension_remove from local-dev profile

### DIFF
--- a/crates/ironclaw_reborn_composition/src/local_dev_capability_policy.toml
+++ b/crates/ironclaw_reborn_composition/src/local_dev_capability_policy.toml
@@ -193,12 +193,6 @@ mounts = "ambient"
 network = "local_dev_wildcard"
 
 [[grants]]
-capability = "builtin.extension_remove"
-effects = ["dispatch_capability", "read_filesystem", "write_filesystem"]
-mounts = "ambient"
-network = "default"
-
-[[grants]]
 capability = "builtin.skill_list"
 effects = ["dispatch_capability", "read_filesystem", "write_filesystem"]
 mounts = "skill_management"

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/tests.rs
@@ -917,15 +917,23 @@ mod tests {
             NetworkPolicy::default()
         );
 
-        for capability_id in [
-            EXTENSION_INSTALL_CAPABILITY_ID,
-            EXTENSION_REMOVE_CAPABILITY_ID,
-        ] {
-            let grant = grant_for(capability_id);
-            assert_eq!(grant.constraints.allowed_effects, local_dev_allowed_effects);
-            assert!(grant.constraints.mounts.mounts.is_empty());
-            assert_eq!(grant.constraints.network, NetworkPolicy::default());
-        }
+        let extension_install_grant = grant_for(EXTENSION_INSTALL_CAPABILITY_ID);
+        assert_eq!(
+            extension_install_grant.constraints.allowed_effects,
+            local_dev_allowed_effects
+        );
+        assert!(extension_install_grant.constraints.mounts.mounts.is_empty());
+        assert_eq!(
+            extension_install_grant.constraints.network,
+            NetworkPolicy::default()
+        );
+        assert!(
+            !grants
+                .grants
+                .iter()
+                .any(|grant| { grant.capability.as_str() == EXTENSION_REMOVE_CAPABILITY_ID }),
+            "local-dev profile must not grant builtin.extension_remove"
+        );
         let extension_activate_grant = grant_for(EXTENSION_ACTIVATE_CAPABILITY_ID);
         assert_eq!(
             extension_activate_grant.constraints.allowed_effects,


### PR DESCRIPTION
## Summary
- Remove the local-dev capability grant for `builtin.extension_remove`
- Update local-dev capability surface coverage to assert the remove capability is no longer granted

## Impact
Local-dev Reborn runs should no longer expose or authorize the model-visible extension removal capability through the local-dev profile. Extension install/search/activate remain unchanged.

## Validation
- `cargo test -p ironclaw_reborn_composition local_dev_builtin_surface_grants_capability_classes -- --nocapture`
- `cargo test -p ironclaw_reborn_composition local_dev_capability_policy -- --nocapture`
- `cargo fmt --check`
- `git diff --check`