### PR TITLE
fix(reborn): show tool arguments in conversation Activity view

### DIFF
--- a/crates/ironclaw_loop_support/src/capability_port.rs
+++ b/crates/ironclaw_loop_support/src/capability_port.rs
@@ -107,20 +107,24 @@ pub trait LoopCapabilityInputResolver: Send + Sync {
     }
 
     /// Record the display-preview input for a provider tool call under
-    /// `input_ref`.
+    /// `input_ref`, keyed for display by the resolved dotted `capability_id`
+    /// (e.g. `nearai.web_search`) — NOT the provider tool name
+    /// (`nearai__web_search`), which is a lossy, digest-suffixed encoding that
+    /// both renders badly and defeats the per-tool summary/subtitle matchers.
     ///
     /// `ProviderToolCallInputResolver` decorates this trait and owns the
-    /// canonical (digest-based) `input_ref` for provider tool calls; it stages
-    /// the arguments itself and does NOT delegate
-    /// `register_provider_tool_call_input` to the inner resolver. Any host-side
-    /// side effect keyed on that ref — notably recording the activity-card
-    /// input summary — must therefore be driven through this hook so it lands
-    /// under the same ref the result write later uses. Default no-op: only
-    /// resolvers that own a display-preview store implement it.
+    /// canonical (digest-based) `input_ref`; it stages the arguments itself and
+    /// does NOT delegate `register_provider_tool_call_input` to the inner
+    /// resolver, so it forwards this hook to `inner` instead. The caller
+    /// (`register_provider_tool_call`) drives it after registration because that
+    /// is where the resolved `capability_id` and the canonical `input_ref` are
+    /// both in hand. Default no-op: only resolvers that own a display-preview
+    /// store implement it.
     fn record_provider_tool_call_display_input(
         &self,
         _run_context: &LoopRunContext,
         _input_ref: &CapabilityInputRef,
+        _capability_id: &CapabilityId,
         _tool_call: &ProviderToolCall,
     ) {
     }
@@ -178,33 +182,35 @@ impl LoopCapabilityInputResolver for ProviderToolCallInputResolver {
                 "provider tool-call input store is unavailable",
             )
         })?;
-        let newly_registered = if let Some(existing) = provider_inputs.get(input_ref.as_str()) {
+        if let Some(existing) = provider_inputs.get(input_ref.as_str()) {
             if existing != &tool_call.arguments {
                 return Err(AgentLoopHostError::new(
                     AgentLoopHostErrorKind::Internal,
                     "provider tool-call input ref collision",
                 ));
             }
-            false
         } else {
             provider_inputs.insert(input_ref.as_str().to_string(), tool_call.arguments.clone());
-            true
-        };
-        // Release the store lock before invoking the inner side-effect hook so
-        // we never hold it across the inner resolver's own locking.
-        drop(provider_inputs);
-        // This decorator owns the provider tool-call `input_ref` and bypasses
-        // the inner `register_provider_tool_call_input`. Drive the inner
-        // resolver's display-preview recording here so the activity-card input
-        // summary lands under the same ref the result write uses — otherwise
-        // the summary is never recorded and the UI shows tool calls with no
-        // arguments. Only on first registration, so a replay/retry of the same
-        // call doesn't re-record after the result already consumed the input.
-        if newly_registered {
-            self.inner
-                .record_provider_tool_call_display_input(run_context, &input_ref, tool_call);
         }
         Ok(input_ref)
+    }
+
+    fn record_provider_tool_call_display_input(
+        &self,
+        run_context: &LoopRunContext,
+        input_ref: &CapabilityInputRef,
+        capability_id: &CapabilityId,
+        tool_call: &ProviderToolCall,
+    ) {
+        // This decorator bypasses the inner `register_provider_tool_call_input`,
+        // so forward the display-recording side effect to `inner` (the resolver
+        // that owns the display-preview store).
+        self.inner.record_provider_tool_call_display_input(
+            run_context,
+            input_ref,
+            capability_id,
+            tool_call,
+        );
     }
 }
 
@@ -1163,6 +1169,16 @@ impl LoopCapabilityPort for HostRuntimeLoopCapabilityPort {
             .input_resolver
             .register_provider_tool_call_input(&self.run_context, &normalized_tool_call)
             .await?;
+        // Record the activity-card display input now that both the canonical
+        // `input_ref` and the resolved dotted `capability_id` are in hand, so
+        // the card shows `nearai.web_search   <query>` (not the lossy provider
+        // tool name `nearai__web_search`) and the per-tool summary matches.
+        self.input_resolver.record_provider_tool_call_display_input(
+            &self.run_context,
+            &input_ref,
+            &prepared.capability_id,
+            &normalized_tool_call,
+        );
         if prepared.capability_id.as_str() == crate::capability_info::CAPABILITY_ID {
             self.record_provider_tool_call_effective_capability_ids(
                 &input_ref,
@@ -3608,8 +3624,8 @@ mod tests {
 
     /// Inner resolver that records every
     /// `record_provider_tool_call_display_input` call, so a test can assert the
-    /// `ProviderToolCallInputResolver` decorator drives the inner's
-    /// display-preview hook under the canonical ref.
+    /// `ProviderToolCallInputResolver` decorator forwards the display hook with
+    /// the resolved capability id.
     #[derive(Default)]
     struct DisplayInputRecordingResolver {
         recorded: Mutex<Vec<(String, String, serde_json::Value)>>,
@@ -3632,11 +3648,12 @@ mod tests {
             &self,
             _run_context: &LoopRunContext,
             input_ref: &CapabilityInputRef,
+            capability_id: &CapabilityId,
             tool_call: &ProviderToolCall,
         ) {
             self.recorded.lock().expect("recorded lock").push((
                 input_ref.as_str().to_string(),
-                tool_call.name.clone(),
+                capability_id.as_str().to_string(),
                 tool_call.arguments.clone(),
             ));
         }
@@ -3661,41 +3678,40 @@ mod tests {
         assert_eq!(resolved, serde_json::json!({"message":"hello"}));
     }
 
-    /// Regression (#activity-card-args): the decorator owns the canonical
-    /// provider tool-call ref and bypasses the inner
-    /// `register_provider_tool_call_input`, so it MUST drive the inner's
-    /// display-preview recording hook under that same ref — otherwise the
-    /// activity-card input summary is never recorded and the UI shows tool
-    /// calls with no arguments. Fires exactly once even if the same call is
-    /// registered twice (replay/retry).
+    /// Regression (#activity-card-args): the decorator bypasses the inner
+    /// `register_provider_tool_call_input`, so it MUST forward the
+    /// display-preview hook to the inner resolver — and key it by the resolved
+    /// dotted capability id (`nearai.web_search`), not the lossy provider tool
+    /// name (`nearai__web_search`). Otherwise the activity card renders the
+    /// wrong name and the per-tool summary/subtitle matchers miss.
     #[tokio::test]
-    async fn provider_tool_call_input_resolver_drives_inner_display_input_hook() {
+    async fn provider_tool_call_input_resolver_forwards_display_input_hook_with_capability_id() {
         let run_context = loop_run_context(&execution_context("thread-display-input")).await;
         let inner = Arc::new(DisplayInputRecordingResolver::default());
         let resolver = ProviderToolCallInputResolver::new(inner.clone());
         let call = provider_tool_call();
+        let input_ref = provider_tool_call_input_ref(&run_context, &call).expect("ref");
+        let capability_id = CapabilityId::new("nearai.web_search").expect("capability id");
 
-        let input_ref = resolver
-            .register_provider_tool_call_input(&run_context, &call)
-            .await
-            .expect("provider input should stage");
-
-        // Registering the identical call again (replay/retry) must not
-        // re-record after the first registration.
-        resolver
-            .register_provider_tool_call_input(&run_context, &call)
-            .await
-            .expect("duplicate registration is idempotent");
+        resolver.record_provider_tool_call_display_input(
+            &run_context,
+            &input_ref,
+            &capability_id,
+            &call,
+        );
 
         let recorded = inner.recorded.lock().expect("recorded lock").clone();
-        assert_eq!(recorded.len(), 1, "display input recorded exactly once");
-        let (recorded_ref, recorded_name, recorded_args) = &recorded[0];
+        assert_eq!(recorded.len(), 1, "display input forwarded exactly once");
+        let (recorded_ref, recorded_capability, recorded_args) = &recorded[0];
         assert_eq!(
             recorded_ref,
             input_ref.as_str(),
             "display input must be recorded under the canonical ref the result write later uses",
         );
-        assert_eq!(recorded_name, &call.name);
+        assert_eq!(
+            recorded_capability, "nearai.web_search",
+            "display input must be keyed by the resolved dotted capability id",
+        );
         assert_eq!(recorded_args, &call.arguments);
     }
 

--- a/crates/ironclaw_loop_support/src/capability_port.rs
+++ b/crates/ironclaw_loop_support/src/capability_port.rs
@@ -105,6 +105,25 @@ pub trait LoopCapabilityInputResolver: Send + Sync {
             "provider tool-call input registration is not supported",
         ))
     }
+
+    /// Record the display-preview input for a provider tool call under
+    /// `input_ref`.
+    ///
+    /// `ProviderToolCallInputResolver` decorates this trait and owns the
+    /// canonical (digest-based) `input_ref` for provider tool calls; it stages
+    /// the arguments itself and does NOT delegate
+    /// `register_provider_tool_call_input` to the inner resolver. Any host-side
+    /// side effect keyed on that ref — notably recording the activity-card
+    /// input summary — must therefore be driven through this hook so it lands
+    /// under the same ref the result write later uses. Default no-op: only
+    /// resolvers that own a display-preview store implement it.
+    fn record_provider_tool_call_display_input(
+        &self,
+        _run_context: &LoopRunContext,
+        _input_ref: &CapabilityInputRef,
+        _tool_call: &ProviderToolCall,
+    ) {
+    }
 }
 
 struct ProviderToolCallInputResolver {
@@ -159,15 +178,31 @@ impl LoopCapabilityInputResolver for ProviderToolCallInputResolver {
                 "provider tool-call input store is unavailable",
             )
         })?;
-        if let Some(existing) = provider_inputs.get(input_ref.as_str()) {
+        let newly_registered = if let Some(existing) = provider_inputs.get(input_ref.as_str()) {
             if existing != &tool_call.arguments {
                 return Err(AgentLoopHostError::new(
                     AgentLoopHostErrorKind::Internal,
                     "provider tool-call input ref collision",
                 ));
             }
+            false
         } else {
             provider_inputs.insert(input_ref.as_str().to_string(), tool_call.arguments.clone());
+            true
+        };
+        // Release the store lock before invoking the inner side-effect hook so
+        // we never hold it across the inner resolver's own locking.
+        drop(provider_inputs);
+        // This decorator owns the provider tool-call `input_ref` and bypasses
+        // the inner `register_provider_tool_call_input`. Drive the inner
+        // resolver's display-preview recording here so the activity-card input
+        // summary lands under the same ref the result write uses — otherwise
+        // the summary is never recorded and the UI shows tool calls with no
+        // arguments. Only on first registration, so a replay/retry of the same
+        // call doesn't re-record after the result already consumed the input.
+        if newly_registered {
+            self.inner
+                .record_provider_tool_call_display_input(run_context, &input_ref, tool_call);
         }
         Ok(input_ref)
     }
@@ -3571,6 +3606,42 @@ mod tests {
         }
     }
 
+    /// Inner resolver that records every
+    /// `record_provider_tool_call_display_input` call, so a test can assert the
+    /// `ProviderToolCallInputResolver` decorator drives the inner's
+    /// display-preview hook under the canonical ref.
+    #[derive(Default)]
+    struct DisplayInputRecordingResolver {
+        recorded: Mutex<Vec<(String, String, serde_json::Value)>>,
+    }
+
+    #[async_trait]
+    impl LoopCapabilityInputResolver for DisplayInputRecordingResolver {
+        async fn resolve_capability_input(
+            &self,
+            _run_context: &LoopRunContext,
+            _input_ref: &CapabilityInputRef,
+        ) -> Result<serde_json::Value, AgentLoopHostError> {
+            Err(AgentLoopHostError::new(
+                AgentLoopHostErrorKind::InvalidInvocation,
+                "inner resolver should not resolve in this test",
+            ))
+        }
+
+        fn record_provider_tool_call_display_input(
+            &self,
+            _run_context: &LoopRunContext,
+            input_ref: &CapabilityInputRef,
+            tool_call: &ProviderToolCall,
+        ) {
+            self.recorded.lock().expect("recorded lock").push((
+                input_ref.as_str().to_string(),
+                tool_call.name.clone(),
+                tool_call.arguments.clone(),
+            ));
+        }
+    }
+
     #[tokio::test]
     async fn provider_tool_call_input_resolver_stages_arguments() {
         let run_context = loop_run_context(&execution_context("thread-provider-input")).await;
@@ -3588,6 +3659,44 @@ mod tests {
 
         assert!(input_ref.as_str().starts_with("input:provider-tool-"));
         assert_eq!(resolved, serde_json::json!({"message":"hello"}));
+    }
+
+    /// Regression (#activity-card-args): the decorator owns the canonical
+    /// provider tool-call ref and bypasses the inner
+    /// `register_provider_tool_call_input`, so it MUST drive the inner's
+    /// display-preview recording hook under that same ref — otherwise the
+    /// activity-card input summary is never recorded and the UI shows tool
+    /// calls with no arguments. Fires exactly once even if the same call is
+    /// registered twice (replay/retry).
+    #[tokio::test]
+    async fn provider_tool_call_input_resolver_drives_inner_display_input_hook() {
+        let run_context = loop_run_context(&execution_context("thread-display-input")).await;
+        let inner = Arc::new(DisplayInputRecordingResolver::default());
+        let resolver = ProviderToolCallInputResolver::new(inner.clone());
+        let call = provider_tool_call();
+
+        let input_ref = resolver
+            .register_provider_tool_call_input(&run_context, &call)
+            .await
+            .expect("provider input should stage");
+
+        // Registering the identical call again (replay/retry) must not
+        // re-record after the first registration.
+        resolver
+            .register_provider_tool_call_input(&run_context, &call)
+            .await
+            .expect("duplicate registration is idempotent");
+
+        let recorded = inner.recorded.lock().expect("recorded lock").clone();
+        assert_eq!(recorded.len(), 1, "display input recorded exactly once");
+        let (recorded_ref, recorded_name, recorded_args) = &recorded[0];
+        assert_eq!(
+            recorded_ref,
+            input_ref.as_str(),
+            "display input must be recorded under the canonical ref the result write later uses",
+        );
+        assert_eq!(recorded_name, &call.name);
+        assert_eq!(recorded_args, &call.arguments);
     }
 
     /// Captures every input callback the port forwards, so tests can drive the

--- a/crates/ironclaw_reborn_composition/src/product_live_adapters.rs
+++ b/crates/ironclaw_reborn_composition/src/product_live_adapters.rs
@@ -212,6 +212,10 @@ impl LoopCapabilityInputResolver for ProductLiveCapabilityIo {
         tool_call: &ProviderToolCall,
     ) -> Result<CapabilityInputRef, AgentLoopHostError> {
         let input_ref = self.stage_input(run_context, tool_call.arguments.clone())?;
+        // Records under this staging ref for direct callers. In the production
+        // loop the resolver is wrapped by `ProviderToolCallInputResolver`, which
+        // owns the canonical (digest) ref and bypasses this method — that path
+        // records via `record_provider_tool_call_display_input` below instead.
         self.display_previews.record_input(
             &run_context.run_id.to_string(),
             &input_ref,
@@ -219,6 +223,23 @@ impl LoopCapabilityInputResolver for ProductLiveCapabilityIo {
             &tool_call.arguments,
         );
         Ok(input_ref)
+    }
+
+    fn record_provider_tool_call_display_input(
+        &self,
+        run_context: &LoopRunContext,
+        input_ref: &CapabilityInputRef,
+        tool_call: &ProviderToolCall,
+    ) {
+        // Driven by the `ProviderToolCallInputResolver` decorator under the
+        // canonical (digest) provider tool-call ref, so the activity-card input
+        // summary lands under the same ref `write_capability_result` later uses.
+        self.display_previews.record_input(
+            &run_context.run_id.to_string(),
+            input_ref,
+            &tool_call.name,
+            &tool_call.arguments,
+        );
     }
 }
 
@@ -890,6 +911,65 @@ mod tests {
         assert_eq!(record.output_kind.as_deref(), Some("text"));
         let rendered = serde_json::to_string(&record.input_summary).unwrap();
         assert!(!rendered.contains("sk-secret"));
+    }
+
+    /// Regression (#activity-card-args): in production the loop wraps this
+    /// resolver with `ProviderToolCallInputResolver`, which owns the canonical
+    /// (digest) ref and bypasses `register_provider_tool_call_input` — it drives
+    /// the display-preview recording via `record_provider_tool_call_display_input`
+    /// instead. Recording under that canonical ref must still surface
+    /// `input_summary` when the result is written under the same ref; otherwise
+    /// the activity card shows the tool with no arguments.
+    #[tokio::test]
+    async fn capability_io_records_display_input_via_provider_tool_call_hook() {
+        let io = ProductLiveCapabilityIo::default();
+        let run_context = loop_run_context().await;
+        let tool_call = ProviderToolCall {
+            provider_id: "provider".to_string(),
+            provider_model_id: "model".to_string(),
+            turn_id: Some("turn_1".to_string()),
+            id: "call_1".to_string(),
+            name: "read_file".to_string(),
+            arguments: serde_json::json!({"path": "src/main.rs"}),
+            response_reasoning: None,
+            reasoning: None,
+            signature: None,
+        };
+        // The decorator owns this ref; it is NOT produced by
+        // `register_provider_tool_call_input` here.
+        let input_ref = CapabilityInputRef::new(format!(
+            "input:provider-tool-call:{}:digest",
+            run_context.run_id
+        ))
+        .expect("valid ref");
+
+        io.record_provider_tool_call_display_input(&run_context, &input_ref, &tool_call);
+
+        let invocation_id = InvocationId::new();
+        let capability_id = CapabilityId::new("builtin.read_file").unwrap();
+        io.write_capability_result(CapabilityResultWrite {
+            run_context: &run_context,
+            input_ref: &input_ref,
+            invocation_id,
+            capability_id: &capability_id,
+            output: serde_json::json!({"content": "fn main() {}"}),
+            display_preview: None,
+        })
+        .await
+        .map(|_| ())
+        .expect("result staged");
+
+        let record = io
+            .display_previews
+            .record_for_invocation(invocation_id)
+            .expect("preview recorded");
+        assert!(
+            record
+                .input_summary
+                .as_deref()
+                .is_some_and(|summary| summary.contains("path: src/main.rs")),
+            "input summary must be present for the hook-recorded provider tool call",
+        );
     }
 
     #[tokio::test]

--- a/crates/ironclaw_reborn_composition/src/product_live_adapters.rs
+++ b/crates/ironclaw_reborn_composition/src/product_live_adapters.rs
@@ -229,15 +229,18 @@ impl LoopCapabilityInputResolver for ProductLiveCapabilityIo {
         &self,
         run_context: &LoopRunContext,
         input_ref: &CapabilityInputRef,
+        capability_id: &CapabilityId,
         tool_call: &ProviderToolCall,
     ) {
         // Driven by the `ProviderToolCallInputResolver` decorator under the
         // canonical (digest) provider tool-call ref, so the activity-card input
         // summary lands under the same ref `write_capability_result` later uses.
+        // Key the display by the resolved dotted `capability_id`, not the lossy
+        // provider tool name, so the title and per-tool summary are correct.
         self.display_previews.record_input(
             &run_context.run_id.to_string(),
             input_ref,
-            &tool_call.name,
+            capability_id.as_str(),
             &tool_call.arguments,
         );
     }
@@ -924,17 +927,21 @@ mod tests {
     async fn capability_io_records_display_input_via_provider_tool_call_hook() {
         let io = ProductLiveCapabilityIo::default();
         let run_context = loop_run_context().await;
+        // The model-facing provider tool name is the lossy `__` encoding; the
+        // resolved capability id is the dotted form. The display must key off
+        // the capability id so the card title and per-tool summary are correct.
         let tool_call = ProviderToolCall {
             provider_id: "provider".to_string(),
             provider_model_id: "model".to_string(),
             turn_id: Some("turn_1".to_string()),
             id: "call_1".to_string(),
-            name: "read_file".to_string(),
-            arguments: serde_json::json!({"path": "src/main.rs"}),
+            name: "nearai__web_search".to_string(),
+            arguments: serde_json::json!({"query": "deploy status"}),
             response_reasoning: None,
             reasoning: None,
             signature: None,
         };
+        let capability_id = CapabilityId::new("nearai.web_search").unwrap();
         // The decorator owns this ref; it is NOT produced by
         // `register_provider_tool_call_input` here.
         let input_ref = CapabilityInputRef::new(format!(
@@ -943,16 +950,20 @@ mod tests {
         ))
         .expect("valid ref");
 
-        io.record_provider_tool_call_display_input(&run_context, &input_ref, &tool_call);
+        io.record_provider_tool_call_display_input(
+            &run_context,
+            &input_ref,
+            &capability_id,
+            &tool_call,
+        );
 
         let invocation_id = InvocationId::new();
-        let capability_id = CapabilityId::new("builtin.read_file").unwrap();
         io.write_capability_result(CapabilityResultWrite {
             run_context: &run_context,
             input_ref: &input_ref,
             invocation_id,
             capability_id: &capability_id,
-            output: serde_json::json!({"content": "fn main() {}"}),
+            output: serde_json::json!({"results": []}),
             display_preview: None,
         })
         .await
@@ -963,12 +974,17 @@ mod tests {
             .display_previews
             .record_for_invocation(invocation_id)
             .expect("preview recorded");
+        // Title is the dotted capability id, not the `__` provider tool name.
+        assert_eq!(record.title, "nearai.web_search");
+        // The per-tool web_search matcher fires (query summarized), rather than
+        // falling back to a raw JSON dump.
         assert!(
             record
                 .input_summary
                 .as_deref()
-                .is_some_and(|summary| summary.contains("path: src/main.rs")),
-            "input summary must be present for the hook-recorded provider tool call",
+                .is_some_and(|summary| summary.contains("query: deploy status")),
+            "input summary should use the web_search matcher, got {:?}",
+            record.input_summary,
         );
     }
 

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev.rs
@@ -496,15 +496,18 @@ impl LoopCapabilityInputResolver for LocalDevCapabilityIo {
         &self,
         run_context: &LoopRunContext,
         input_ref: &CapabilityInputRef,
+        capability_id: &CapabilityId,
         tool_call: &ProviderToolCall,
     ) {
         // Driven by the `ProviderToolCallInputResolver` decorator under the
         // canonical (digest) provider tool-call ref, so the activity-card input
         // summary lands under the same ref `write_capability_result` later uses.
+        // Key the display by the resolved dotted `capability_id`, not the lossy
+        // provider tool name, so the title and per-tool summary are correct.
         self.display_previews.record_input(
             &run_context.run_id.to_string(),
             input_ref,
-            &tool_call.name,
+            capability_id.as_str(),
             &tool_call.arguments,
         );
     }

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev.rs
@@ -474,21 +474,39 @@ impl LoopCapabilityInputResolver for LocalDevCapabilityIo {
         let mut inputs = self.inputs.lock().map_err(|_| capability_io_error())?;
         inputs
             .insert_without_eviction(input_ref.as_str().to_string(), tool_call.arguments.clone())?;
+        // Record the display-preview input under this staging ref for callers
+        // that drive the adapter directly (tests, non-decorated paths). In the
+        // production loop the resolver is wrapped by
+        // `ProviderToolCallInputResolver`, which owns a different (digest) ref
+        // and bypasses this method — that path records via
+        // `record_provider_tool_call_display_input` below instead. Trajectory
+        // inputs are separately observed at the port level
+        // (`HostRuntimeLoopCapabilityPort::invoke_capability`), which forwards
+        // the resolved dotted `CapabilityId`.
         self.display_previews.record_input(
             &run_context.run_id.to_string(),
             &input_ref,
             &tool_call.name,
             &tool_call.arguments,
         );
-        // Trajectory inputs are observed at the port level
-        // (`HostRuntimeLoopCapabilityPort::invoke_capability`), which forwards
-        // the *resolved* dotted `CapabilityId` per the observer contract. This
-        // staging point only has the provider tool name (`builtin_echo`), not
-        // the resolved id, and `ProviderToolCallInputResolver` doesn't delegate
-        // here for provider tool calls anyway — so emitting `on_capability_input`
-        // here would both never fire in practice and break call-id correlation.
-        // `LocalDevCapabilityIo` remains the source of `on_capability_result`.
         Ok(input_ref)
+    }
+
+    fn record_provider_tool_call_display_input(
+        &self,
+        run_context: &LoopRunContext,
+        input_ref: &CapabilityInputRef,
+        tool_call: &ProviderToolCall,
+    ) {
+        // Driven by the `ProviderToolCallInputResolver` decorator under the
+        // canonical (digest) provider tool-call ref, so the activity-card input
+        // summary lands under the same ref `write_capability_result` later uses.
+        self.display_previews.record_input(
+            &run_context.run_id.to_string(),
+            input_ref,
+            &tool_call.name,
+            &tool_call.arguments,
+        );
     }
 }
 


### PR DESCRIPTION
## Problem

In the WebChat v2 **Activity** view, tool calls (e.g. `read_file` and all builtin tools) render **without their arguments** — there's no "Parameters" tab and the args going into the tool are missing.

## Root cause

The activity card's Parameters tab only renders when `toolParameters` (= the preview's `input_summary`) is present (`tool-activity.js:206`). That summary is produced by `CapabilityDisplayPreviewStore::record_input`, which **never runs in production for tool calls**:

1. `HostRuntimeLoopCapabilityPort::new` always wraps the capability input resolver with `ProviderToolCallInputResolver` (`capability_port.rs:673`).
2. The decorator's `register_provider_tool_call_input` computes its own digest-based `input_ref`, stages the arguments for resolution, and **returns without delegating to `self.inner`** (`capability_port.rs:150`).
3. So the inner adapter's `register_provider_tool_call_input` — the one that calls `display_previews.record_input` and computes `input_summary` (`local_dev.rs`, `product_live_adapters.rs`) — is dead in the wrapped path.
4. At result time, `record_result_with_preview` looks up the pending input by ref, finds nothing, and leaves `input_summary: None` (`display_preview.rs:151-169`) → the frontend never renders the Parameters tab.

This hits **every** provider tool call (read_file + all builtins).

**Why tests missed it:** the adapter tests (`capability_io_records_read_file_display_preview`) drive `register_provider_tool_call_input` directly, bypassing the decorator that is always present in production — a textbook "test the helper, not the caller" gap.

## Fix

The decorator owns the digest `input_ref` (it's load-bearing — `is_provider_tool_call_input_ref` drives graceful bad-input handling), so the display-preview input must be recorded **under that same ref**. Added a defaulted `record_provider_tool_call_display_input` hook to `LoopCapabilityInputResolver`; the decorator drives it on first registration under the canonical ref, and the composition adapters implement it against their display-preview store. Correlation now holds end-to-end and `input_summary` survives to the UI.

No frontend change needed — the renderer already reads `input_summary`; it just never received it.

## Tests

- **loop_support**: the decorator drives the inner hook under the canonical ref, exactly once across replay/retry (`provider_tool_call_input_resolver_drives_inner_display_input_hook`).
- **composition**: a hook-recorded provider tool call surfaces `input_summary` when the result is written under the same ref (`capability_io_records_display_input_via_provider_tool_call_hook`).

Gate: `cargo fmt`, `cargo clippy -p ironclaw_loop_support -p ironclaw_reborn_composition --tests -- -D warnings`, and both crates' test suites pass (3 pre-existing `nearai_mcp` env-config failures are unrelated — they read `NEARAI_API_KEY` from the environment and pass with it unset).