### PR TITLE
docs: land user-context-profile design docs (#5008)

### DIFF
--- a/docs/reborn/2026-06-16-memory-how-it-works.md
+++ b/docs/reborn/2026-06-16-memory-how-it-works.md
@@ -1,0 +1,381 @@
+# How Memory Works in Reborn IronClaw
+
+_Status: current-state explainer (2026-06-16). Describes the Reborn memory subsystem as implemented, to ground a redesign discussion. Not a contract. The frozen contract is `docs/reborn/contracts/memory.md`._
+
+## TL;DR
+
+- Reborn memory is **document-oriented**, not row-oriented. A "memory" is a Markdown/text **document** at a scoped virtual path, stored through `RootFilesystem` (libSQL/Postgres-backed). It is not a `(key, value, embedding)` row.
+- There are **four capabilities**: `builtin.memory_write`, `builtin.memory_search`, `builtin.memory_read`, `builtin.memory_tree`. All memory mutation and retrieval goes through these.
+- **Writes are explicit only.** The model decides to call `memory_write`. There is **no implicit/automatic extraction** of facts from a conversation in Reborn today.
+- **Two prompt-injection paths exist**, but only one is live:
+  - **Identity files** (`AGENTS.md`, `SOUL.md`, `USER.md`, `MEMORY.md`, …) — injected as system messages every turn. **Live.**
+  - **RAG memory snippets** (semantic-search relevant memories auto-spliced into context) — fully plumbed but **not wired**; `ThreadBackedLoopContextPort` hardcodes `memory_snippets: Vec::new()`.
+- Search is **hybrid FTS + vector with RRF fusion**, but in the default Reborn build **no embedding provider is wired**, so vector search is inactive and only FTS runs.
+
+---
+
+## 1. Data Model — a memory is a scoped document
+
+There is no `MemoryItem` struct. A memory is identified by a **scope** + a **relative path**.
+
+### Scope (the isolation key)
+
+`MemoryDocumentScope` (`crates/ironclaw_memory/src/path.rs:10`):
+
+```rust
+pub struct MemoryDocumentScope {
+    tenant_id: String,            // required
+    user_id: String,              // required
+    agent_id: Option<String>,     // optional
+    project_id: Option<String>,   // optional
+}
+```
+
+The full uniqueness key is the 4-tuple `(tenant_id, user_id, agent_id, project_id, relative_path)`.
+
+### Virtual path
+
+`MemoryDocumentPath` = scope + relative path, rendered as a virtual filesystem path:
+
+```
+/memory/tenants/{tenant}/users/{user}/agents/{agent-or-_none}/projects/{project-or-_none}/{relative/path}
+```
+
+So `USER.md` for user `u123` becomes a document at a fully-scoped path. Every backend query is prefixed with this scope, giving **physical namespace isolation** between users/tenants.
+
+### Storage layout (per document)
+
+The filesystem repo stores four record kinds for each logical document (`crates/ironclaw_memory/src/repo/filesystem.rs`):
+
+| Purpose | Path | Kind |
+|---|---|---|
+| Document body | `<scope>/<relative>` | `memory_document` |
+| Metadata sidecar | `<scope>/<relative>.meta` | (file) |
+| Chunk projection (for search) | `<scope>/<relative>.chunks/<n>` | `memory_chunk` |
+| Version history | `<scope>/<relative>.versions/<n>` | `memory_document_version` |
+
+### Metadata
+
+`DocumentMetadata` (`src/metadata.rs:19`) — `skip_indexing`, `skip_versioning`, `hygiene { enabled, retention_days=30 }`, `schema` (JSON-schema validation of content), plus a forward-compat `extra` map. Metadata is **inherited** from ancestor `.config` files, with the document's own overlay winning.
+
+### Persistence & parity
+
+The single Reborn repo is `FilesystemMemoryDocumentRepository`, wrapping `Arc<dyn RootFilesystem>`. **PostgreSQL/libSQL parity is owned by `ironclaw_filesystem`, not by `ironclaw_memory`** — the memory crate gained native FTS/vector/CAS by delegating to the filesystem layer instead of having per-backend SQL repos.
+
+### Versioning & delete
+
+- Every content-changing write archives the prior content to `.versions/<n>` (unless `skip_versioning` or content unchanged or first-create).
+- **No soft-delete / "never delete" flag is implemented.** `delete` capability defaults to `false`; `retention_days` is modeled but **not enforced** (no hygiene sweeper). `DocumentDeleted` is a declared event kind but the current backend only emits `DocumentWritten`, `DocumentIndexed`, `SearchPerformed`.
+
+---
+
+## 2. The Four Capabilities
+
+Defined in `crates/ironclaw_host_runtime/src/first_party_tools/memory.rs:27`:
+
+```rust
+pub const MEMORY_SEARCH_CAPABILITY_ID: &str = "builtin.memory_search";
+pub const MEMORY_WRITE_CAPABILITY_ID:  &str = "builtin.memory_write";
+pub const MEMORY_READ_CAPABILITY_ID:   &str = "builtin.memory_read";
+pub const MEMORY_TREE_CAPABILITY_ID:   &str = "builtin.memory_tree";
+```
+
+| Capability | Params | Effect |
+|---|---|---|
+| `memory_write` | `content`, `target`, `append`(default true), `metadata`, `old_string`/`new_string`/`replace_all` (patch mode), `timezone` | `ReadFilesystem`+`WriteFilesystem`, `PermissionMode::Allow` (no approval gate) |
+| `memory_search` | `query`/`q`/`text`/`pattern`, `limit` (1–20, default 5) | hybrid search |
+| `memory_read` | `path` | read one doc |
+| `memory_tree` | `path` (root), `depth` (1–10, default 1) | list as tree |
+
+**`target` shortcuts** for `memory_write`: `"memory"`→`MEMORY.md`, `"daily_log"`→`daily/{date}.md`, `"heartbeat"`→`HEARTBEAT.md`, `"bootstrap"`→clears `BOOTSTRAP.md`, or any relative path.
+
+**Write sub-operations:** `Append` (CAS loop, up to 8 retries), `Patch` (read→replace `old_string`→compare-and-write), `Replace` (full overwrite), `ClearBootstrap`.
+
+---
+
+## 3. Use Case: Explicit Save ("remember X")
+
+There is **no separate "save to memory" intent**. The user asks the model to remember something; the model emits a `builtin.memory_write` tool call. End-to-end:
+
+```
+User: "Remember that I prefer dark roast coffee."
+  │
+  ▼
+Model emits tool call: builtin.memory_write
+  { target: "memory", append: true,
+    content: "- Prefers dark roast coffee" }
+  │
+  ▼
+Agent loop  (ironclaw_agent_loop/executor/capabilities.rs)
+  │   CapabilityInvocation
+  ▼
+LoopCapabilityPort → HostRuntimeLoopCapabilityPort
+  │
+  ▼
+CapabilityHost  (ironclaw_capabilities/src/host.rs)
+  ├─ descriptor exists in ExtensionRegistry?
+  ├─ TrustAwareCapabilityDispatchAuthorizer.authorize_dispatch_with_trust
+  ├─ claim CapabilityLease (if approval-gated; memory_write is Allow, so no gate)
+  └─ on Allow → CapabilityDispatcher.dispatch_json
+  │
+  ▼
+BuiltinFirstPartyTools::dispatch → memory::dispatch  (first_party_tools/memory.rs:186)
+  ├─ memory_services(): build MemoryDocumentScope from request.scope
+  │                      ensure /memory mount grants {read,list,write,delete}
+  │                      build MemoryContext (+ audit context, correlation id)
+  └─ dispatch_write → parse_write_command → append/patch/replace
+  │
+  ▼
+RepositoryMemoryBackend::write_document_with_backend_options  (backend.rs:472)
+  ├─ ensure_path_matches_context   (scope defense-in-depth)
+  ├─ validate UTF-8
+  ├─ enforce_prompt_write_safety   (injection scan for protected paths)
+  ├─ resolve_write_metadata        (inherit .config ancestry)
+  ├─ optional JSON-schema validation
+  ├─ repository.write_document_with_options   (CAS write + version archive)
+  ├─ persist .meta sidecar
+  ├─ emit MemorySignificantEvent::document_written
+  └─ indexer.reindex_document      (re-chunk + FTS index)
+  │
+  ▼
+FilesystemMemoryDocumentRepository → RootFilesystem (libSQL/Postgres)
+```
+
+**Result:** the document `MEMORY.md` for that user's scope now contains the appended line, versioned, FTS-indexed.
+
+### "User interaction saves to memory" (implicit) — NOT present
+
+Reborn has **no automatic memory extraction**. There is no post-turn hook that observes the conversation and decides to persist a fact. `PostCapabilityStage` only does compaction and subagent drain. `MemoryPromptContextService` is read-only. The only way memory is written is an explicit model-issued `memory_write`. (This is a notable gap and a likely redesign target.)
+
+---
+
+## 4. Use Case: Fetch on Request (model searches mid-turn)
+
+```
+Model emits tool call: builtin.memory_search { query: "coffee preference", limit: 5 }
+  │
+  ▼
+CapabilityHost → memory::dispatch → dispatch_search  (memory.rs:331)
+  │
+  ▼
+RepositoryMemoryBackend::search(context, request)  (ironclaw_memory/src/backend.rs)
+  │
+  ▼
+MemoryDocumentRepository::search_documents  (repo/filesystem.rs)
+  ├─ FTS branch     (libSQL FTS5 / pg FTS)        → ranked chunk hits
+  ├─ vector branch  (Filter::VectorNearest)        → ranked chunk hits  [inactive: no embeddings wired]
+  ├─ group chunks by document relative_path
+  ├─ RRF fusion: score = 1/(k+rank), k=60          (or WeightedScore)
+  ├─ normalize to [0,1], apply min_score, sort
+  └─ truncate to limit
+  │
+  ▼
+post-filter: results.retain(|r| r.path.scope() == context.scope())   (no cross-user leak)
+  │
+  ▼
+Results returned to model as a tool result in the transcript
+```
+
+`MemorySearchResult` = `{ path, score, snippet, full_text_rank, vector_rank }`. Search defaults: `limit` 20 (capped per capability schema to ≤20), `pre_fusion_limit` 50, both branches on, RRF k=60.
+
+**Caveat:** the default Reborn `build_backend` wiring passes **no embedding provider**, so the vector branch is inert; only FTS contributes. Hybrid search is built but runs single-modality until an embedding provider is wired at the host boundary.
+
+---
+
+## 5. Use Case: Prompt Injection (auto-context at turn start)
+
+Two distinct slots in `LoopContextBundle`.
+
+### 5a. Identity files — LIVE
+
+A fixed allow-list of protected documents (`crates/ironclaw_memory/src/safety.rs:153`):
+
+```
+SOUL.md, AGENTS.md, USER.md, IDENTITY.md, SYSTEM.md,
+MEMORY.md, TOOLS.md, HEARTBEAT.md, BOOTSTRAP.md,
+context/assistant-directives.md, context/profile.json
+```
+
+Flow:
+
+```
+ThreadBackedLoopContextPort::load_loop_context()   (ironclaw_loop_support/src/lib.rs)
+  └─ build_identity_messages()   (identity_context.rs:192)
+        for each HostIdentityContextCandidate:
+          fetch via HostIdentityContextSource
+          wrap as LoopContextMessage → LoopContextBundle.identity_messages
+  │
+  ▼
+InstructionBundleBuilder::build()   (ironclaw_turns/run_profile/instruction_bundle.rs:244)
+  └─ push each as a system-role message, section label "identity"
+```
+
+So `USER.md` / `MEMORY.md` content lands in the system prompt **every turn**, automatically.
+
+### 5b. RAG memory snippets — PLUMBED BUT NOT WIRED
+
+The slot `LoopContextBundle.memory_snippets` and its `InstructionBundleBuilder` handling (`instruction_bundle.rs:326`, section label `"memory"`) are fully built. The service trait `MemoryPromptContextService` and production impl `ProductionMemoryPromptContextService` exist. Scope derivation, `MemoryContextPolicy::Disabled` escape hatch — all present.
+
+**But the wire is missing:** `ThreadBackedLoopContextPort` has no `MemoryPromptContextService` field and hardcodes:
+
+```rust
+// ironclaw_loop_support/src/lib.rs:401
+memory_snippets: Vec::new(),
+```
+
+So **semantic retrieval-augmented injection does not happen today.** Memory only enters context via (a) the fixed identity files, or (b) an explicit `memory_search` tool call the model chooses to make.
+
+---
+
+## 6. Scope Isolation (how a user only sees their own memory)
+
+Enforced at three layers:
+
+1. **Capability dispatch:** `memory_services()` builds `MemoryDocumentScope` straight from the authorized `request.scope` (tenant/user/agent/project). The host has already authorized this scope.
+2. **Backend defense-in-depth:** `ensure_path_matches_context` / `ensure_scope_matches_context` reject any read/write/list whose path scope ≠ context scope (`backend.rs:380`). Backends must not infer broader authority from their own config.
+3. **Search post-filter:** results are re-filtered `r.path.scope() == context.scope()` so even an unexpected backend row can't leak across users/tenants.
+
+`ironclaw_memory/CLAUDE.md`: *"Every read/list/search/write/version/chunk operation must filter by the full `(tenant_id, user_id, agent_id, project_id)` tuple."*
+
+---
+
+## 7. Summary Table — what exists vs. what's missing
+
+| Capability | Status |
+|---|---|
+| Document storage (scoped, versioned, CAS) | ✅ Live |
+| `memory_write` / `read` / `search` / `tree` tools | ✅ Live |
+| FTS search | ✅ Live |
+| Vector / hybrid RRF search | ⚠️ Built, **no embedding provider wired** → FTS-only |
+| Identity-file prompt injection | ✅ Live (every turn) |
+| RAG memory-snippet auto-injection | ⚠️ Plumbed, **not wired** (`memory_snippets: Vec::new()`) |
+| Implicit/automatic memory extraction from conversation | ❌ Not present |
+| Soft-delete / "never delete" retention enforcement | ❌ Modeled (`retention_days`) but **not enforced**; no delete path |
+| Approval gate on memory_write | ❌ `PermissionMode::Allow` (no gate) |
+
+These four ⚠️/❌ rows are the natural seams for a new memory-system design.
+
+---
+
+## Key File Map
+
+| Topic | File |
+|---|---|
+| Scope & path model | `crates/ironclaw_memory/src/path.rs` |
+| Metadata / hygiene | `crates/ironclaw_memory/src/metadata.rs` |
+| Filesystem repo, storage layout, CAS, versions | `crates/ironclaw_memory/src/repo/filesystem.rs` |
+| Backend, scope guards, capabilities | `crates/ironclaw_memory/src/backend.rs` |
+| Search, RRF fusion | `crates/ironclaw_memory/src/search.rs` |
+| Chunking | `crates/ironclaw_memory/src/chunking.rs` |
+| Indexer + embedding fallback | `crates/ironclaw_memory/src/indexer.rs` |
+| Embedding provider seam | `crates/ironclaw_memory/src/embedding.rs` |
+| Protected identity paths, prompt-write safety | `crates/ironclaw_memory/src/safety.rs` |
+| Capability handlers (write/read/search/tree) | `crates/ironclaw_host_runtime/src/first_party_tools/memory.rs` |
+| Identity injection | `crates/ironclaw_loop_support/src/identity_context.rs`, `.../src/lib.rs` |
+| Memory-snippet RAG slot (unwired) | `crates/ironclaw_turns/src/run_profile/memory_context.rs`, `host.rs`, `instruction_bundle.rs` |
+| Frozen contract | `docs/reborn/contracts/memory.md` |
+
+---
+
+## 8. Cross-System Comparison
+
+How three other local agent harnesses handle memory, vs. IronClaw Reborn. Source codebases: `~/Code/hermes-agent`, `~/Code/pi`, `~/Code/claude-code`. (A web survey of industry systems — MemGPT/Letta, Mem0, Zep, Generative Agents, etc. — is appended in §9.)
+
+### 8.1 One-paragraph characterization
+
+- **IronClaw Reborn** — Document-oriented, scoped (`tenant/user/agent/project`) virtual-filesystem memory with CAS + version history. Hybrid FTS+vector search (vector inert: no embeddings wired). Identity files auto-inject; RAG snippets plumbed-but-unwired. **Writes explicit-only; no auto-extraction.**
+- **Hermes** — The richest. A compact, char-capped built-in `MEMORY.md`/`USER.md` (frozen-snapshot system-prompt injection) + a SQLite FTS5 store of *every* transcript turn (`session_search`) + **pluggable external backends** (Holographic HRR vectors, Hindsight knowledge graph, Honcho user-modeling, Mem0). A **periodic background "review agent"** (every ~10 turns) auto-decides what to save. External backends do per-turn RAG injection via `<memory-context>` fence blocks.
+- **Pi** — Effectively *no* persistent memory system. A session is a singly-linked JSONL tree of entries; context = linear replay from leaf to root. The only memory mechanism is **LLM compaction**: when the token budget is exceeded, old turns are summarized into a structured Markdown `CompactionEntry`. No search, no embeddings, no cross-session recall, no selectivity.
+- **Claude Code** — Plain `.md` files, no DB/vectors. Two layers: (1) always-loaded **CLAUDE.md hierarchy** (managed > user > project > local) + a capped `MEMORY.md` index; (2) per-project **auto-memory** topic files with YAML frontmatter, selected per-turn by an **LLM-as-selector** (a Sonnet side-call ranks files by their `description`, ≤5/turn) — *not* embeddings. A **background `extractMemories` forked agent** auto-writes after every turn; a periodic `/dream` agent consolidates and prunes.
+
+### 8.2 Comparison table
+
+| Dimension | **IronClaw Reborn** | **Hermes** | **Pi** | **Claude Code** |
+|---|---|---|---|---|
+| Storage format | Scoped docs over `RootFilesystem` (libSQL/PG), CAS + versions | Flat `§`-delimited `.md` + SQLite FTS + pluggable backends | Append-only JSONL session tree | Plain `.md` files (CLAUDE.md + auto-memory dir) |
+| Scoping | `tenant/user/agent/project` 4-tuple, enforced | Profile (+ bank/session for plugins) | Filesystem cwd only | Global/user/project/local + per-git-root auto-mem |
+| Keyword/FTS search | ✅ FTS (libSQL FTS5 / PG) | ✅ FTS5 over all transcripts (`session_search`) | ❌ none | ⚠️ Grep fallback only (model-driven) |
+| Vector/embeddings | ⚠️ Built (RRF) but **no provider wired** | ⚠️ Plugin-only (Holographic HRR = hashed, not neural; Hindsight/Honcho server-side) | ❌ none | ❌ none (LLM-as-selector over descriptions instead) |
+| Graph/tree memory | ❌ | ⚠️ Hindsight knowledge graph (plugin) | tree = session lineage (not semantic) | ❌ (hierarchical file precedence) |
+| Write — explicit tool call | ✅ `memory_write` | ✅ `memory` tool | n/a (auto-records all) | ✅ inline model writes + `/memory` |
+| Write — automatic extraction | ❌ **none** | ✅ background review agent every ~10 turns + per-turn backend sync | ❌ (records verbatim, no extraction) | ✅ background `extractMemories` agent post-turn |
+| Write — reflection/consolidation | ❌ | ⚠️ holographic auto-extract (opt-in); compaction insights | summarization compaction only | ✅ `/dream` periodic consolidation + prune |
+| Prompt injection — always-on | identity files (every turn) | built-in MEMORY/USER frozen snapshot | system prompt (AGENTS/CLAUDE.md) | CLAUDE.md hierarchy + MEMORY.md index |
+| Prompt injection — RAG/retrieved | ⚠️ slot exists, **unwired** | ✅ per-turn `<memory-context>` fence (backends) | ❌ | ✅ `relevant_memories` attachments (≤5, LLM-selected) |
+| Selectivity (what to remember) | model decides (explicit only) | tiered: high-value built-in vs full transcript in DB | none — everything verbatim | model + extractor decide; 4 types (user/feedback/project/reference) |
+| Lifecycle / forgetting | ❌ retention modeled, not enforced | char caps + dedup; optional temporal decay (holographic) | token-budget compaction (raw kept) | no TTL; `/dream` prunes; staleness warnings on age |
+| Dedup | ❌ | ✅ exact-match + load-time dedup | ❌ | via consolidation agent |
+| Approval gate on write | ❌ (`Allow`) | ⚠️ optional write-approval gate | n/a | model self-governed |
+
+### 8.3 Patterns worth stealing for the redesign
+
+1. **Background extraction agent** (Hermes review-agent, Claude Code `extractMemories`) — both run a *forked* agent sharing the conversation/prompt-cache to decide what to persist, decoupled from the main turn. Directly fills Reborn's #1 gap (no auto-save). Note the mutual-exclusion guard: skip the extractor if the main agent already wrote memory this turn.
+2. **LLM-as-selector vs. embeddings** (Claude Code) — ranking memory files by a one-line `description` via a cheap side-call sidesteps the "no embedding provider wired" problem entirely and is prompt-cache friendly. A pragmatic stop-gap (or permanent choice) before committing to a vector stack.
+3. **Tiered storage** (Hermes) — a tiny, always-injected high-value layer (preferences/corrections) separate from a large, search-only transcript layer. Maps cleanly onto Reborn's identity-files vs. searchable-docs split.
+4. **Consolidation/decay loop** (Claude Code `/dream`, Hermes temporal decay) — periodic prune/merge keeps the always-injected layer small and the index prompt-cache stable. Fills Reborn's unenforced-retention gap.
+5. **Frozen-snapshot injection for cache stability** (Hermes) — capture identity/memory once at session start so the provider prefix-cache isn't busted mid-session. Relevant to how Reborn wires the RAG slot.
+6. **Staleness signaling** (Claude Code age headers) — annotate injected memories with age rather than silently serving stale facts.
+
+---
+
+## 9. Industry / Web Survey — AI Agent Memory Systems
+
+_Survey of how modern AI agent / LLM-harness memory systems work across the industry (mid-2026), with named systems and source URLs. From a parallel web-research pass with adversarial claim verification._
+
+> **Mapping note:** the survey below references IronClaw's hybrid search as `src/workspace/search.rs` (the **legacy** workspace). Reborn's equivalent is `crates/ironclaw_memory/src/search.rs` — same paradigm (FTS + vector, **RRF k=60** default, `WeightedScore` alt, `pre_fusion_limit=50`, dual-backend), confirmed in §1/§5 above. Read "IronClaw" in §9 as applying to the Reborn `ironclaw_memory` crate.
+
+### 9.0 Paradigm comparison table
+
+| Paradigm | Example systems | Storage/structure | Retrieval | Write strategy | Injection | Key tradeoffs |
+|---|---|---|---|---|---|---|
+| **Flat document/file** | Claude Code `CLAUDE.md`; MemGPT/Letta **core memory** blocks | Plain Markdown/XML, no index | None — whole file loaded | Hand-edited (CLAUDE.md) or agent self-edit `core_memory_append/replace` (MemGPT) | **Always-on** in system prompt | Zero latency, human-readable, git-versionable; overflows context at scale (~500 facts ≈ 15K tok), no semantic search, goes stale |
+| **Key-value / fact store** | Mem0 facts; LangGraph `BaseStore`; Redis Agent Memory Server; Generative Agents stream | Atomic NL statements + metadata (id, hash, scope, timestamps) | Key lookup (<1ms) or query | LLM extraction into atomic facts; explicit `put` | Per-turn RAG | Structured, scoped, auditable; needs extraction pipeline; granularity matters |
+| **Vector / embeddings** | MemGPT archival; LangMem; LlamaIndex; dense leg of every hybrid | float32 vectors (384–3072d) + payload; HNSW/IVFFlat/PQ | Dense ANN (cosine), MMR, temporal-decay reweighting | Embed-on-write | Per-turn RAG | Semantic recall, language-robust; misses exact IDs/codes/names, big footprint, stale on re-index |
+| **Graph / KG** | **Zep/Graphiti**, **Mem0g**, **Cognee**, MS GraphRAG | Entity nodes + typed edges (Neo4j/Kuzu); bi-temporal edges (Zep) | BFS n-hop fused with cosine + BM25 via RRF/MMR | 2-stage LLM extraction (entities→triplets) + entity resolution/dedup | Per-turn RAG | Multi-hop + temporal reasoning, no LLM in read path (Zep ~300ms p95); high write cost, schema overhead, cold start |
+| **Tree / hierarchical** | MemGPT paging; **RAPTOR**; Gen Agents reflection tree; GraphRAG communities | Multi-level summaries (leaves→root); OS tiers | ANN over flattened nodes ("collapsed tree" beats traversal) | Recursive LLM summarization; reflection | Paged virtual-context or per-turn | Multi-doc synthesis, long-convo compression; expensive build, lossy |
+| **Keyword / FTS** | SQLite FTS5 (IronClaw, zero-infra); ES/OpenSearch BM25; Neo4j Lucene (under Graphiti) | Inverted index | BM25 (sub-ms FTS5) | Tokenize-on-write (cheap) | Per-turn RAG | Exact-match recall (IDs/codes/dates), cheap; misses paraphrase — never used alone |
+| **Hybrid (BM25+ANN+RRF)** | **Mem0 v3**, **Zep**, **IronClaw**, LangMem, Perplexity, Glean | Dual sparse+dense index | BM25 + vector (+ graph BFS) fused by **RRF (k=60)**; optional cross-encoder rerank | Per-leg | Per-turn RAG | Best general recall, calibration-free fusion, ~+10ms over vector; needs two indices |
+
+### 9.1 Storage paradigms (highlights)
+
+Six paradigms; production systems combine several. Flat-file = MemGPT core blocks / Claude Code CLAUDE.md (overflow at scale). KV fact store = Mem0 / LangGraph `BaseStore` / Redis Agent Memory Server. Vector = MemGPT archival, dominant models OpenAI `text-embedding-3-small`, BGE (384d Letta default, 1024d Zep); indexes HNSW/IVFFlat/PQ. **Graph** = Zep/Graphiti (Neo4j, bi-temporal, 94.8% DMR vs MemGPT 93.4%, +18.5% LongMemEval at ~90% lower latency — [arXiv:2501.13956](https://arxiv.org/abs/2501.13956)), Mem0g, Cognee (decoupled Kuzu/LanceDB/SQLite). Tree = MemGPT tiers, RAPTOR (UMAP+GMM cluster→summarize; flatten-then-ANN beats traversal — [arXiv:2401.18059](https://arxiv.org/abs/2401.18059)). FTS = SQLite FTS5 (sub-ms, zero-infra) — always a hybrid leg, never alone.
+
+### 9.2 Retrieval — the dominant finding
+
+**Retrieval strategy dominates storage strategy.** Ablation ([arXiv:2603.02473](https://arxiv.org/html/2603.02473)): *how* you retrieve drives a ~20pt accuracy spread on LoCoMo (BM25 57.1% → cosine 73.4% → hybrid+rerank 77.2%); *what/how you store* moves only 3–8pt.
+
+- **BM25** — exact IDs/codes/names; blind to paraphrase; unbounded scores break raw-score fusion.
+- **Dense** — semantic/cross-lingual; fails exact IDs, clusters antonyms.
+- **Hybrid via RRF** = production default. `RRF(d)=Σ 1/(k+rank)`, **k=60**. Sidesteps BM25↔cosine scale mismatch, no calibration. MS data: hybrid 48.4 vs vector 43.8 vs keyword 40.6; +25–30% recall on exact-match at +10ms.
+- **Graph BFS** — surfaces n-hop context (Alice→employer→projects) neither BM25 nor vectors reach. Graphiti: cosine+BM25+BFS via RRF, **no LLM in read path** (~300ms p95 vs MemGPT 28.9s).
+- **Recency+importance** (Gen Agents): `score = recency + importance + relevance`, `recency=0.995^hours` ([arXiv:2304.03442](https://arxiv.org/abs/2304.03442)).
+- **Two-stage rerank**: hybrid→top50→cross-encoder→top10 (+50–100ms, best precision).
+
+### 9.3 Write / what-to-remember
+
+Five patterns by trigger/cost: **explicit tool call** (ChatGPT `bio`, LangGraph store-nodes; 0 extra LLM calls). **Automatic LLM extraction** (Mem0: per message-pair, Stage1 fact-extract → Stage2 ADD/UPDATE/DELETE/NOOP; ~7K tok/convo — [arXiv:2504.19413](https://arxiv.org/html/2504.19413v1)). **Reflection** (Gen Agents: fires at cumulative importance ≥150, ~2–3×/day → salient questions → insights). **Buffer summarization** (LangChain rolling summary; **LangMem** adds *background* `ReflectionExecutor`, debounced, post-response — no in-turn latency). **MemGPT self-editing** (inner monologue → `core_memory_append/replace`, `request_heartbeat` chains ops). **ChatGPT "Dreaming"** = background consolidation (vendor self-report 41.5%→82.8%, unverified).
+
+**Key caveat:** raw chunked storage (zero LLM write cost) *matched or beat* LLM-extracted facts (81.1% vs 77.3%) — write-time filtering is an **efficiency lever, not an accuracy lever**.
+
+### 9.4 Prompt injection
+
+Four modes: **always-on core** (system prompt; MemGPT core ~86 tok, CLAUDE.md ~2.3–3.6K; best for persona/rules/profile; prompt-cache friendly). **Per-turn RAG** (workhorse; retrieve→inject before question at recency position; Mem0 ~6.9K vs ~26K full-context). **Paged virtual-context** (MemGPT: context=RAM, store=disk; page in via `archival_memory_search`, out via summarization at ~0.85× window; all state persisted — matches "never delete"). **Pointer indirection** (store big outputs externally, inject short ref).
+
+Token budget: summarize at 70–80%; chunks 256–1024 tok, 10–20% overlap. **Placement matters** ("lost in the middle" U-shaped recall): static rules/persona at system-prompt top (primacy + cache), dynamic retrieved memory at end of user turn (recency) — [Anthropic context engineering](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents).
+
+### 9.5 Selectivity, dedup, decay
+
+**Importance**: Gen Agents 1–10 poignancy (stored once); Mem0 binary LLM gate. **Conflict handling** is the differentiator: Mem0 **hard-deletes**; LangMem LLM-decides (`enable_deletes=False` default); **Zep never deletes** — bi-temporal edge invalidation. No major system publicly discloses its cosine dedup cutoff (0.85/0.9 figures untraceable). **Episodic vs semantic**: converged taxonomy, divergent impl; MemGPT does *not* formally separate (tiers by location). **Forgetting/decay**: exponential `0.995^hours` (Gen Agents), Ebbinghaus spaced-repetition (MemoryBank), and the gold standard **Zep bi-temporal edges** (4 timestamps, invalidation not deletion → "who was Alice's employer in Nov 2023?" still resolves). Memora: **64% of memory errors = failure to invalidate stale memories** — active forgetting is the most under-built capability. **Selective vs store-everything**: full-context *beats* RAG by 15–25pt for first ~150 convos; RAG wins past ~300 on *cost* not accuracy ([ConvoMem arXiv:2511.10523](https://arxiv.org/abs/2511.10523)).
+
+### 9.6 Implications for IronClaw (Reborn)
+
+1. **Hybrid+RRF foundation is already correct.** `ironclaw_memory/src/search.rs` (FTS+vector, RRF k=60, dual-backend) matches the gold standard. Since retrieval dominates, highest-leverage upgrade = optional **cross-encoder rerank** (top-50→top-10). *Prerequisite: wire an embedding provider — vector leg is currently inert (§4).*
+2. **"Never delete LLM data" is vindicated.** Zep invalidation + Letta persist-evict = IronClaw's principle. Gap to close = **active invalidation**: mark contradicted facts stale (`valid_at/invalid_at`), not delete. Fits "mark with timestamps, make filterable, always retain." Maps onto Reborn's unenforced `retention_days` (§1).
+3. **Empirical case against eager extraction at IronClaw's scale.** Raw chunks beat extracted facts; full-context beats RAG below ~150–300 convos. Treat auto-extraction (Reborn's #1 gap) as an *efficiency/scoping* tool layered on raw episodes, not a correctness requirement.
+4. **Two-tier injection mirrors the industry split.** Identity files = always-on core; memory tools = per-turn RAG. Formalize token budget (summarize 70–80%) + placement (identity at top for cache+primacy; retrieved memory at turn-end for recency). Directly informs wiring the unwired RAG snippet slot (§5b).
+5. **Graph layer = clear future direction, high cost.** Multi-hop/temporal is what flat hybrid can't do. If pursued: keep LLM out of read path (Graphiti BFS+BM25+cosine via RRF ~300ms), reuse existing RRF fusion, don't build a parallel one.
+6. **Distrust vendor/cross-paper benchmarks** — LoCoMo/LongMemEval swing 58–92% on harness alone. Validate any change against IronClaw's own tasks.
+
+**Primary sources:** [Generative Agents 2304.03442](https://arxiv.org/abs/2304.03442) · [Zep/Graphiti 2501.13956](https://arxiv.org/abs/2501.13956) · [Mem0 2504.19413](https://arxiv.org/pdf/2504.19413) · [MemGPT 2310.08560](https://arxiv.org/abs/2310.08560) · [Retrieval-vs-Utilization 2603.02473](https://arxiv.org/html/2603.02473) · [Survey 2603.07670](https://arxiv.org/html/2603.07670v1) · [Anthropic Context Engineering](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents)
+
+_Confidence note: vendor self-benchmarks (Mem0 73% token reduction; ChatGPT Dreaming 82.8%) and undisclosed dedup thresholds (0.85/0.9) are flagged unverified — not hard numbers._

--- a/docs/superpowers/plans/2026-06-16-persistent-user-context-profile.md
+++ b/docs/superpowers/plans/2026-06-16-persistent-user-context-profile.md
@@ -1,0 +1,1012 @@
+# Persistent User Context (Agent-Context Profile) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give IronClaw Reborn a per-user, always-injected agent-context profile (timezone, locale, location) the model can read every turn and update via a typed capability, plus the freeform `USER.md` prose already injected.
+
+**Architecture:** Three changes across clear ownership boundaries. (1) `ironclaw_turns` gains a plain `UserProfileContext` struct + a `user_profile` field on `LoopRuntimeContext`, rendered into the model prompt. (2) A `HostUserProfileSource` trait (in `ironclaw_loop_support`, impl in `ironclaw_host_runtime`) reads `context/profile.json` and is wired into the loop-driver host factory to fill `user_timezone` + `user_profile` at loop start — mirroring the existing `HostIdentityContextSource` pattern so `ironclaw_reborn` never imports `ironclaw_memory`. (3) A new `builtin.profile_set` first-party capability does typed-validated, field-merge writes to `context/profile.json`.
+
+**Tech Stack:** Rust, tokio, `chrono` / `chrono-tz`, `serde_json`, the Reborn memory backend (`ironclaw_memory`), first-party capability framework (`ironclaw_host_runtime`).
+
+**Spec:** `docs/superpowers/specs/2026-06-16-persistent-user-context-profile-design.md`
+
+---
+
+## Design invariants (apply to every task)
+
+- **Never guess a timezone.** A missing/invalid value → `None` → "unknown", never a host default (mirrors the existing `user_timezone` doc comment, `runtime_context.rs:16`).
+- **Profile scope is `(tenant, user, agent=None, project=None)`** regardless of the run's scope. All path construction goes through one helper (Task 4) so the decision lives in one place.
+- **Logging:** background/producer diagnostics use `debug!`, never `info!`/`warn!` (REPL/TUI corruption rule).
+- **`ironclaw_turns` must not import `ironclaw_memory`** (forbidden, `reborn_dependency_boundaries.rs:2568`). `UserProfileContext` carries primitives only.
+- **System config is excluded.** `profile_set`'s field enum cannot name provider/model/approval (spec §9).
+- After any cross-crate API/boundary change, run `cargo test -p ironclaw_architecture`.
+
+---
+
+## File map
+
+| File | Change | Responsibility |
+|---|---|---|
+| `crates/ironclaw_turns/src/run_profile/runtime_context.rs` | modify | `UserProfileContext`, `Locale`, `LoopRuntimeContext.user_profile`, render line + elicitation hint |
+| `crates/ironclaw_loop_support/src/user_profile_context.rs` | create | `HostUserProfileSource` trait + `EmptyUserProfileSource` default |
+| `crates/ironclaw_loop_support/src/lib.rs` | modify | module decl + re-export |
+| `crates/ironclaw_host_runtime/src/user_profile_source.rs` | create | production `HostUserProfileSource` impl (reads `context/profile.json`) |
+| `crates/ironclaw_host_runtime/src/lib.rs` | modify | module decl + export |
+| `crates/ironclaw_host_runtime/src/first_party_tools/profile_set.rs` | create | `builtin.profile_set` capability |
+| `crates/ironclaw_host_runtime/src/first_party_tools/mod.rs` | modify | manifest + handler + dispatch wiring |
+| `crates/ironclaw_host_runtime/src/first_party_tools/schemas.rs` | modify | `profile_set.input.v1.json` schema arm |
+| `src/workspace/reborn_identity_context.rs` | modify | drop `context/profile.json` from prose identity allow-list (Task 3B) |
+| `crates/ironclaw_reborn/src/loop_driver_host.rs` | modify | `with_user_profile_source` builder + fill at construction site (~1563) |
+| `crates/ironclaw_reborn_composition/src/...` | modify | wire production source into the factory |
+| `crates/ironclaw_reborn/tests/` or composition tests | create | caller-level integration test (both DB backends) |
+
+---
+
+## Task 1: `UserProfileContext` type + render in `ironclaw_turns`
+
+**Files:**
+- Modify: `crates/ironclaw_turns/src/run_profile/runtime_context.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the `#[cfg(test)] mod tests` block (after `renders_unknown_timezone_fallback`, ~line 490). Uses existing `stamp()` helper.
+
+```rust
+fn profile(locale: Option<&str>, location: Option<&str>) -> UserProfileContext {
+    UserProfileContext {
+        locale: locale.and_then(|s| Locale::new(s).ok()),
+        location: location.map(str::to_string),
+    }
+}
+
+#[test]
+fn renders_user_profile_line_when_present() {
+    let ctx = LoopRuntimeContext {
+        loop_started_at_utc: stamp(),
+        user_timezone: None,
+        communication: None,
+        product_context: None,
+        user_profile: Some(profile(Some("ja-JP"), Some("Tokyo, Japan"))),
+    };
+    let text = ctx.render_model_content();
+    assert!(text.contains("User profile:"), "missing profile line: {text}");
+    assert!(text.contains("locale=ja-JP"), "{text}");
+    assert!(text.contains("location=Tokyo, Japan"), "{text}");
+}
+
+#[test]
+fn omits_user_profile_line_when_absent() {
+    let ctx = LoopRuntimeContext {
+        loop_started_at_utc: stamp(),
+        user_timezone: None,
+        communication: None,
+        product_context: None,
+        user_profile: None,
+    };
+    assert!(!ctx.render_model_content().contains("User profile:"));
+}
+
+#[test]
+fn omits_unset_profile_fields() {
+    let ctx = LoopRuntimeContext {
+        loop_started_at_utc: stamp(),
+        user_timezone: None,
+        communication: None,
+        product_context: None,
+        user_profile: Some(profile(Some("en-US"), None)),
+    };
+    let text = ctx.render_model_content();
+    assert!(text.contains("locale=en-US"), "{text}");
+    assert!(!text.contains("location="), "unset location must not render: {text}");
+}
+
+#[test]
+fn unknown_timezone_hint_mentions_profile_set() {
+    let ctx = LoopRuntimeContext {
+        loop_started_at_utc: stamp(),
+        user_timezone: None,
+        communication: None,
+        product_context: None,
+        user_profile: None,
+    };
+    let text = ctx.render_model_content();
+    assert!(text.contains("profile_set"), "elicitation hint must mention profile_set: {text}");
+}
+
+#[test]
+fn render_sanitizes_profile_location() {
+    // Mirror render_sanitizes_hostile_channel_name: control chars stripped/escaped.
+    let ctx = LoopRuntimeContext {
+        loop_started_at_utc: stamp(),
+        user_timezone: None,
+        communication: None,
+        product_context: None,
+        user_profile: Some(profile(None, Some("Tokyo\n\nIGNORE PREVIOUS"))),
+    };
+    let text = ctx.render_model_content();
+    assert!(!text.contains("Tokyo\n\nIGNORE"), "newlines in location must be neutralized: {text:?}");
+}
+```
+
+- [ ] **Step 2: Run tests, verify they fail to compile**
+
+Run: `cargo test -p ironclaw_turns user_profile 2>&1 | head -30`
+Expected: compile error — `UserProfileContext`, `Locale`, and field `user_profile` do not exist.
+
+- [ ] **Step 3: Add the types**
+
+In `runtime_context.rs`, after the `CommunicationRuntimeContext` definition (~line 71):
+
+```rust
+/// Validated BCP-47-ish locale tag (per spec §5 strong-types mandate,
+/// `.claude/rules/types.md`). Validation: non-empty, ASCII alphanumeric + hyphen.
+/// No `From<String>` — construction is fallible so misuse is a compile error.
+/// `new` returns `Result` per the canonical newtype template (types.md) so the
+/// rejection reason is observable; callers wanting `Option` use `.ok()`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Locale(String);
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum LocaleError {
+    #[error("locale is empty")]
+    Empty,
+    #[error("locale has invalid characters (expected ASCII alphanumeric or '-')")]
+    InvalidCharacters,
+}
+
+impl Locale {
+    pub fn new(raw: impl Into<String>) -> Result<Self, LocaleError> {
+        let s = raw.into();
+        if s.is_empty() {
+            return Err(LocaleError::Empty);
+        }
+        if !s.chars().all(|c| c.is_ascii_alphanumeric() || c == '-') {
+            return Err(LocaleError::InvalidCharacters);
+        }
+        Ok(Self(s))
+    }
+    pub fn as_str(&self) -> &str { &self.0 }
+}
+
+/// Host-resolved, sanitized agent-context profile rendered into the prompt
+/// each turn. Carries only primitives/local newtypes — never raw
+/// `context/profile.json` bytes and never `ironclaw_memory` types (this crate
+/// forbids that dependency). The producer validates and sanitizes first.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct UserProfileContext {
+    pub locale: Option<Locale>,
+    pub location: Option<String>,
+}
+
+impl UserProfileContext {
+    fn is_empty(&self) -> bool {
+        self.locale.is_none() && self.location.is_none()
+    }
+}
+```
+
+- [ ] **Step 4: Add the field to `LoopRuntimeContext`**
+
+In the struct (~line 13), add as the last field:
+
+```rust
+    /// Host-resolved user agent-context profile (locale/location), rendered
+    /// into the runtime-context prompt section. `None` when no profile is set.
+    pub user_profile: Option<UserProfileContext>,
+```
+
+Update the in-crate test helper `time_only_ctx` (~line 445) and every existing test constructor in this file to add `user_profile: None,` (the compiler lists them).
+
+- [ ] **Step 5: Render the profile line + elicitation hint**
+
+In `render_model_content`, change the `None` arm of `time_line` (~line 84) to mention `profile_set`:
+
+```rust
+            None => format!(
+                "Current date/time at loop start: {utc}. The user's timezone is \
+                 unknown - if local time matters, ask the user and offer to save \
+                 it with the profile_set capability, or use the time capability if \
+                 it is visible."
+            ),
+```
+
+After `let mut parts = vec![time_line];` (~line 93), insert:
+
+```rust
+        if let Some(profile) = &self.user_profile {
+            if !profile.is_empty() {
+                let mut fields = Vec::new();
+                if let Some(locale) = &profile.locale {
+                    // Locale is already validated (ascii-alnum/hyphen) — no sanitize needed.
+                    fields.push(format!("locale={}", locale.as_str()));
+                }
+                if let Some(location) = &profile.location {
+                    // location is free text — sanitize via the existing helper.
+                    fields.push(format!("location={}", sanitize_prompt_string(location)));
+                }
+                parts.push(format!("User profile: {}.", fields.join(", ")));
+            }
+        }
+```
+
+Reuse the **existing** helper `sanitize_prompt_string` (`runtime_context.rs:245`, used by the channel-name/delivery-target render path) — do not invent a new `sanitize_inline`. This keeps behavior identical to `render_sanitizes_hostile_channel_name`.
+
+- [ ] **Step 6: Run tests, verify pass**
+
+Run: `cargo test -p ironclaw_turns 2>&1 | tail -20`
+Expected: PASS (new tests + existing `renders_*` tests).
+
+- [ ] **Step 7: Update the contract test**
+
+`crates/ironclaw_turns/tests/agent_loop_host_contract.rs:501` (`instruction_bundle_renders_runtime_context_section`) constructs a `LoopRuntimeContext` — add `user_profile: None,` and, if useful, assert the profile line is absent when `None`.
+
+Run: `cargo test -p ironclaw_turns --test agent_loop_host_contract 2>&1 | tail -15`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/ironclaw_turns/src/run_profile/runtime_context.rs crates/ironclaw_turns/tests/agent_loop_host_contract.rs
+git commit -m "feat(turns): add UserProfileContext to LoopRuntimeContext render"
+```
+
+---
+
+## Task 2: `HostUserProfileSource` trait + resolved DTO
+
+**Files:**
+- Create: `crates/ironclaw_loop_support/src/user_profile_context.rs` (trait **and** `ResolvedUserProfile`)
+- Modify: `crates/ironclaw_loop_support/src/lib.rs`
+
+> **Design update (timezone folds into the profile):** `user_timezone` is no longer a standalone `LoopRuntimeContext` field — it lives in `UserProfileContext.timezone` (done in Wave 1). So there is **no `ResolvedUserProfile` DTO** — the trait returns `Option<UserProfileContext>` directly (timezone + locale + location all in one). Simpler: one type, no split.
+>
+> **Review fix (approach + local-patterns):** the trait takes `&LoopRunContext` — exactly mirroring the sibling `HostIdentityContextSource::load_identity_candidates` (`identity_context.rs:17-20`) — not decomposed `(TurnScope, TurnActor)`. This keeps a uniform call shape at `loop_driver_host.rs` and preserves access to `resolved_run_profile` for a future privacy gate.
+
+- [ ] **Step 1: Write the trait + failing default test**
+
+Create `crates/ironclaw_loop_support/src/user_profile_context.rs`:
+
+```rust
+//! Host source for the per-user agent-context profile, read at loop start.
+//!
+//! Mirrors `HostIdentityContextSource`: the trait lives here so the loop driver
+//! depends only on a neutral port, while the concrete implementation (which
+//! reads `context/profile.json` from the memory backend) lives in
+//! `ironclaw_host_runtime`, keeping `ironclaw_memory` out of `ironclaw_reborn`.
+
+use async_trait::async_trait;
+use ironclaw_turns::run_profile::host::LoopRunContext;     // match identity_context.rs import
+use ironclaw_turns::run_profile::runtime_context::UserProfileContext;
+
+/// Resolves the per-user agent-context profile for a run. Returns the validated
+/// `UserProfileContext` (timezone/locale/location), or `None` when no profile is
+/// set or it cannot be resolved. Implementations must never fabricate values
+/// (e.g. a guessed timezone) — fail to `None` instead.
+#[async_trait]
+pub trait HostUserProfileSource: Send + Sync {
+    async fn resolve_user_profile(
+        &self,
+        run_context: &LoopRunContext,
+    ) -> Option<UserProfileContext>;
+}
+
+/// Default no-op source: always `None`. Used when no profile source is wired.
+#[derive(Debug, Default, Clone)]
+pub struct EmptyUserProfileSource;
+
+#[async_trait]
+impl HostUserProfileSource for EmptyUserProfileSource {
+    async fn resolve_user_profile(
+        &self,
+        _run_context: &LoopRunContext,
+    ) -> Option<UserProfileContext> {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    // Build a sample LoopRunContext the same way the identity_context tests do —
+    // grep `LoopRunContext` in this crate's tests for the existing constructor.
+    use crate::tests_support::sample_loop_run_context;
+
+    #[tokio::test]
+    async fn empty_source_returns_none() {
+        let run_context = sample_loop_run_context();
+        assert!(EmptyUserProfileSource.resolve_user_profile(&run_context).await.is_none());
+    }
+}
+```
+
+> Note: confirm the exact import path for `LoopRunContext` (match the `use` line in `identity_context.rs`) and the existing test constructor for it. Match how `UserProfileContext` is re-exported.
+
+- [ ] **Step 2: Declare the module (`pub mod`)**
+
+In `crates/ironclaw_loop_support/src/lib.rs`, mirror the `pub mod identity_context;` declaration (`lib.rs:28`). The crate sets `#![warn(unreachable_pub)]`, so a private `mod` + `pub use` would warn — use `pub mod`:
+
+```rust
+pub mod user_profile_context;
+pub use user_profile_context::{EmptyUserProfileSource, HostUserProfileSource};
+```
+
+Confirm `async-trait` is a dependency of `ironclaw_loop_support` (used by sibling host-source traits). No `chrono-tz` needed here now — the trait returns `UserProfileContext` (which owns the `Tz`) from `ironclaw_turns`, an existing dependency.
+
+- [ ] **Step 3: Run the test**
+
+Run: `cargo test -p ironclaw_loop_support user_profile 2>&1 | tail -20`
+Expected: PASS (after fixing import paths per the Step 1 note).
+
+- [ ] **Step 4: Architecture + commit**
+
+```bash
+cargo test -p ironclaw_architecture 2>&1 | tail -15   # expect PASS — no new forbidden edges
+git add crates/ironclaw_loop_support/src/user_profile_context.rs crates/ironclaw_loop_support/src/lib.rs
+git commit -m "feat(loop-support): add HostUserProfileSource port + ResolvedUserProfile DTO"
+```
+
+---
+
+## Task 3: Production `HostUserProfileSource` impl (reads `context/profile.json`)
+
+**Files:**
+- Create: `crates/ironclaw_host_runtime/src/user_profile_source.rs`
+- Modify: `crates/ironclaw_host_runtime/src/lib.rs`
+
+This impl owns the `ironclaw_memory` read and all parsing/validation, then returns a fully-resolved `ResolvedUserProfile`.
+
+- [ ] **Step 1: Write the failing test (in-memory filesystem)**
+
+Create `crates/ironclaw_host_runtime/src/user_profile_source.rs` with a test that writes a `context/profile.json` via the memory backend and asserts the source parses it. Mirror how `first_party_tools/memory.rs` tests build a `RootFilesystem` (grep for `InMemoryBackend`/`InMemory` in `ironclaw_memory` tests and reuse that constructor).
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn resolves_timezone_locale_location_from_profile_doc() {
+        let fs = in_memory_root_filesystem();           // helper per memory tests
+        let scope = sample_turn_scope_with_user("tenant-a", "user-1");
+        write_profile_json(&fs, &scope, r#"{"timezone":"Asia/Tokyo","locale":"ja-JP","location":"Tokyo, Japan"}"#).await;
+
+        let source = MemoryBackedUserProfileSource::new(fs);
+        let resolved = source.resolve_user_profile(&run_context_for(&scope, "user-1")).await.unwrap();
+
+        assert_eq!(resolved.timezone.map(|tz| tz.name()), Some("Asia/Tokyo"));
+        assert_eq!(resolved.locale.map(|l| l.as_str().to_string()).as_deref(), Some("ja-JP"));
+        assert_eq!(resolved.location.as_deref(), Some("Tokyo, Japan"));
+    }
+
+    #[tokio::test]
+    async fn invalid_timezone_resolves_to_none_not_guess() {
+        let fs = in_memory_root_filesystem();
+        let scope = sample_turn_scope_with_user("tenant-a", "user-1");
+        write_profile_json(&fs, &scope, r#"{"timezone":"Pacific Time","locale":"en-US"}"#).await;
+
+        let source = MemoryBackedUserProfileSource::new(fs);
+        let resolved = source.resolve_user_profile(&run_context_for(&scope, "user-1")).await.unwrap();
+
+        assert!(resolved.timezone.is_none(), "invalid IANA name must not be guessed");
+        assert_eq!(resolved.locale.map(|l| l.as_str().to_string()).as_deref(), Some("en-US"));
+    }
+
+    #[tokio::test]
+    async fn missing_doc_resolves_to_none() {
+        let fs = in_memory_root_filesystem();
+        let scope = sample_turn_scope_with_user("tenant-a", "user-1");
+        let source = MemoryBackedUserProfileSource::new(fs);
+        assert!(source.resolve_user_profile(&run_context_for(&scope, "user-1")).await.is_none());
+    }
+}
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `cargo test -p ironclaw_host_runtime user_profile_source 2>&1 | head -30`
+Expected: compile error — `MemoryBackedUserProfileSource` undefined.
+
+- [ ] **Step 3: Implement the source**
+
+```rust
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use chrono_tz::Tz;
+use ironclaw_loop_support::HostUserProfileSource;
+use ironclaw_memory::{
+    FilesystemMemoryDocumentRepository, MemoryContext, MemoryDocumentPath, MemoryDocumentScope,
+    RepositoryMemoryBackend, MemoryBackend,
+};
+use ironclaw_filesystem::RootFilesystem;
+use ironclaw_turns::run_profile::host::LoopRunContext;
+use ironclaw_turns::run_profile::runtime_context::{Locale, UserProfileContext};
+use serde::Deserialize;
+
+// This module is a loop-start PRODUCER (host service boundary), not a capability
+// handler — that is why it lives at top-level `src/` rather than under
+// `first_party_tools/` (per crate CLAUDE.md, runtime services get their own module).
+
+/// Relative path of the per-user agent-context profile document.
+pub const PROFILE_DOCUMENT_PATH: &str = "context/profile.json";
+
+/// Single home for the profile scope decision: keyed to the human user at
+/// `agent=None, project=None` (spec §10) regardless of run scope. BOTH the
+/// producer (read) and `profile_merge_write` (write) call this so the scope
+/// narrowing — and any future project-override — lives in exactly one place.
+pub(crate) fn profile_scope_and_path(
+    tenant_id: &str,
+    user_id: &str,
+) -> Result<(MemoryDocumentScope, MemoryDocumentPath), ()> {
+    let scope = MemoryDocumentScope::new_with_agent(tenant_id, user_id, None, None).map_err(|_| ())?;
+    let path = MemoryDocumentPath::new_with_agent(
+        tenant_id, user_id, None, None, PROFILE_DOCUMENT_PATH,
+    ).map_err(|_| ())?;
+    Ok((scope, path))
+}
+
+/// Reads `context/profile.json` for the run owner and resolves it into a
+/// validated `ResolvedUserProfile`. Owns the `ironclaw_memory` dependency so the
+/// loop driver and `ironclaw_reborn` never import it.
+pub struct MemoryBackedUserProfileSource {
+    filesystem: Arc<dyn RootFilesystem>,
+}
+
+impl MemoryBackedUserProfileSource {
+    pub fn new(filesystem: Arc<dyn RootFilesystem>) -> Self {
+        Self { filesystem }
+    }
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct ProfileJson {
+    #[serde(default)]
+    timezone: Option<String>,
+    #[serde(default)]
+    locale: Option<String>,
+    #[serde(default)]
+    location: Option<String>,
+}
+
+#[async_trait]
+impl HostUserProfileSource for MemoryBackedUserProfileSource {
+    async fn resolve_user_profile(
+        &self,
+        run_context: &LoopRunContext,
+    ) -> Option<UserProfileContext> {
+        // Profile is keyed to the human user at agent=None, project=None
+        // (spec §10) regardless of the run's agent/project scope.
+        let scope = &run_context.scope;
+        let user_id = run_context.actor.as_ref().map(|a| a.user_id.as_str())?;
+        // Shared scope helper — same keying as the writer (no duplicated decision).
+        let (doc_scope, path) = profile_scope_and_path(scope.tenant_id.as_str(), user_id).ok()?;
+        let context = MemoryContext::new(doc_scope);
+
+        let repository = Arc::new(FilesystemMemoryDocumentRepository::new(Arc::clone(&self.filesystem)));
+        let backend = RepositoryMemoryBackend::new(repository);
+
+        let bytes = match backend.read_document(&context, &path).await {
+            Ok(Some(bytes)) => bytes,
+            Ok(None) => return None,
+            Err(error) => {
+                tracing::debug!(error = %error, "user profile read failed; continuing without profile");
+                return None;
+            }
+        };
+
+        let parsed: ProfileJson = match serde_json::from_slice(&bytes) {
+            Ok(parsed) => parsed,
+            Err(error) => {
+                tracing::debug!(error = %error, "user profile JSON parse failed; continuing without profile");
+                return None;
+            }
+        };
+
+        // Never guess: invalid IANA name → None. Timezone lives in the profile.
+        let timezone = parsed
+            .timezone
+            .as_deref()
+            .and_then(|name| name.trim().parse::<Tz>().ok());
+        let profile = UserProfileContext {
+            timezone,
+            // validated newtype; invalid → None, with a debug trail per types.md
+            locale: parsed.locale.and_then(|s| match Locale::new(s) {
+                Ok(l) => Some(l),
+                Err(error) => {
+                    tracing::debug!(%error, "locale in profile rejected; dropping field");
+                    None
+                }
+            }),
+            location: parsed.location.filter(|s| !s.trim().is_empty()),
+        };
+
+        if profile == UserProfileContext::default() {
+            return None;
+        }
+        Some(profile)
+    }
+}
+```
+
+> Confirm exact re-export names (`FilesystemMemoryDocumentRepository`, `RepositoryMemoryBackend`, `MemoryDocumentPath::new_with_agent`, `MemoryContext::new`) against `ironclaw_memory`'s public surface; the explorer cited all of these. If `new_with_agent` rejects `agent=None` here, that's caught by Task 6's integration test.
+
+- [ ] **Step 4: Declare the module + export**
+
+In `crates/ironclaw_host_runtime/src/lib.rs`:
+
+```rust
+mod user_profile_source;
+pub use user_profile_source::{MemoryBackedUserProfileSource, PROFILE_DOCUMENT_PATH};
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `cargo test -p ironclaw_host_runtime user_profile_source 2>&1 | tail -20`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/ironclaw_host_runtime/src/user_profile_source.rs crates/ironclaw_host_runtime/src/lib.rs
+git commit -m "feat(host-runtime): MemoryBackedUserProfileSource reads context/profile.json"
+```
+
+---
+
+## Task 3B: Stop prose-injecting `context/profile.json`
+
+**Review fix (approach, intent-mismatch 80):** spec §4a says the structured profile must **not** also be dumped as a raw-JSON identity message once the typed render exists — otherwise every turn injects the blob twice (raw JSON via the identity path + the `User profile:` line), giving the model two sources that can disagree. `context/profile.json` is currently in `DEFAULT_PROMPT_PROTECTED_PATHS` (`crates/ironclaw_memory/src/safety.rs:164`) and surfaces through the identity allow-list (`src/workspace/reborn_identity_context.rs` `stable_identity_paths()` / `STABLE_IDENTITY_PATHS`).
+
+**Files:**
+- Modify: `src/workspace/reborn_identity_context.rs` (the identity-path allow-list)
+
+> **Important:** do NOT remove `context/profile.json` from `DEFAULT_PROMPT_PROTECTED_PATHS` in `ironclaw_memory` — that list also governs prompt-**write** safety (injection scanning on write), which we still want. Only drop it from the **identity injection** allow-list so it stops being rendered as prose; keep it protected on write.
+
+- [ ] **Step 1: Write the failing test**
+
+In the test module for `reborn_identity_context.rs`, assert `context/profile.json` is NOT among the stable identity paths:
+
+```rust
+#[test]
+fn profile_json_is_not_prose_injected() {
+    let paths = stable_identity_paths();   // or the equivalent accessor
+    assert!(!paths.iter().any(|p| p == "context/profile.json"),
+        "context/profile.json must be consumed by the typed producer, not prose-injected");
+}
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `cargo test -p <crate-of-reborn_identity_context> profile_json_is_not_prose 2>&1 | head -20`
+Expected: FAIL — the path is currently included.
+
+- [ ] **Step 3: Remove it from the identity allow-list**
+
+In `src/workspace/reborn_identity_context.rs`, omit `"context/profile.json"` from `STABLE_IDENTITY_PATHS` (the allow-list filtered against `DEFAULT_PROMPT_PROTECTED_PATHS`). Add a comment: `// context/profile.json is rendered via LoopRuntimeContext (typed), not prose-injected — see profile design §4a`.
+
+- [ ] **Step 4: Run, verify pass + commit**
+
+```bash
+cargo test -p <crate> profile_json 2>&1 | tail -15
+git add src/workspace/reborn_identity_context.rs
+git commit -m "fix(workspace): stop prose-injecting context/profile.json (typed render owns it)"
+```
+
+---
+
+## Task 4: `builtin.profile_set` capability
+
+**Files:**
+- Create: `crates/ironclaw_host_runtime/src/first_party_tools/profile_set.rs`
+- Modify: `crates/ironclaw_host_runtime/src/first_party_tools/mod.rs`
+- Modify: `crates/ironclaw_host_runtime/src/first_party_tools/schemas.rs`
+
+The handler does typed validation of each field (authoritative), then read-modify-write field-merge of `context/profile.json` using the shared profile-path helper.
+
+- [ ] **Step 1: Write the failing handler test**
+
+In `profile_set.rs`, mirror the memory dispatch tests. Build a `FirstPartyCapabilityRequest` with `input = {"timezone":"Asia/Tokyo"}`, dispatch, then read the doc back and assert it contains the field; then a second call with `{"locale":"ja-JP"}` and assert **both** fields persist (merge, no clobber); then an invalid `{"timezone":"Pacific Time"}` returns an error.
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn sets_then_merges_fields_without_clobber() {
+        let state = MemoryCapabilityState::default();
+        let req1 = profile_set_request(json!({"timezone": "Asia/Tokyo"}));
+        dispatch(&state, &req1).await.unwrap();
+        let req2 = profile_set_request(json!({"locale": "ja-JP"}));
+        dispatch(&state, &req2).await.unwrap();
+
+        let doc = read_profile_doc(&req2).await;     // helper reads context/profile.json
+        assert_eq!(doc["timezone"], "Asia/Tokyo");   // preserved across the second write
+        assert_eq!(doc["locale"], "ja-JP");
+    }
+
+    #[tokio::test]
+    async fn rejects_invalid_timezone() {
+        let state = MemoryCapabilityState::default();
+        let req = profile_set_request(json!({"timezone": "Pacific Time"}));
+        let err = dispatch(&state, &req).await.unwrap_err();
+        assert!(format!("{err:?}").to_lowercase().contains("timezone"));
+    }
+
+    #[tokio::test]
+    async fn rejects_unknown_field() {
+        let state = MemoryCapabilityState::default();
+        // System-config-style field must be refused by the closed surface.
+        let req = profile_set_request(json!({"always_approve": true}));
+        assert!(dispatch(&state, &req).await.is_err());
+    }
+}
+```
+
+> The trait takes one arg (`&LoopRunContext`). Add a test helper `run_context_for(scope: &..., user_id: &str) -> LoopRunContext` that builds a `LoopRunContext` from the scope + a `TurnActor` for `user_id`, mirroring how `identity_context.rs` tests construct `LoopRunContext` (grep `LoopRunContext::new` in that crate's tests). Reuse the request/filesystem builders the existing `memory.rs` tests use (grep `FirstPartyCapabilityRequest` test constructors in `first_party_tools/`).
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `cargo test -p ironclaw_host_runtime profile_set 2>&1 | head -30`
+Expected: compile error — module/functions undefined.
+
+- [ ] **Step 3: Implement the capability**
+
+```rust
+use chrono_tz::Tz;
+use ironclaw_extensions::{CapabilityManifest, ExtensionError};
+use ironclaw_host_api::{EffectKind, PermissionMode};
+use serde_json::{json, Map, Value};
+
+use crate::first_party::{FirstPartyCapabilityRequest, FirstPartyCapabilityResult};
+use crate::FirstPartyCapabilityError;
+use super::memory::{self, MemoryCapabilityState};
+use super::{first_party_capability_manifest, input_error, resource_profile};
+
+pub const PROFILE_SET_CAPABILITY_ID: &str = "builtin.profile_set";
+
+pub(super) fn manifest() -> Result<CapabilityManifest, ExtensionError> {
+    first_party_capability_manifest(
+        PROFILE_SET_CAPABILITY_ID,
+        "Record a known structured fact about the user: timezone (IANA name), \
+         locale (BCP-47), or location (free label). Use \
+         whenever the user states one of these so future answers stay correct.",
+        vec![EffectKind::ReadFilesystem, EffectKind::WriteFilesystem],
+        PermissionMode::Allow,
+        resource_profile(),
+    )
+}
+
+/// Validate the closed field set into a JSON object to merge. Unknown fields and
+/// invalid values are rejected here — this typed boundary is the authoritative
+/// enforcement (the doc JSON-schema is defense-in-depth).
+fn validated_fields(input: &Value) -> Result<Map<String, Value>, FirstPartyCapabilityError> {
+    let obj = input.as_object().ok_or_else(input_error)?;
+    let mut out = Map::new();
+    for (key, value) in obj {
+        match key.as_str() {
+            "timezone" => {
+                let s = value.as_str().ok_or_else(input_error)?;
+                s.trim().parse::<Tz>().map_err(|_| input_error())?; // reject non-IANA
+                out.insert("timezone".into(), json!(s.trim()));
+            }
+            "locale" => {
+                let s = value.as_str().ok_or_else(input_error)?;
+                // light BCP-47 shape check: non-empty, ascii-alnum/hyphen
+                if s.is_empty() || !s.chars().all(|c| c.is_ascii_alphanumeric() || c == '-') {
+                    return Err(input_error());
+                }
+                out.insert("locale".into(), json!(s));
+            }
+            "location" => {
+                let s = value.as_str().ok_or_else(input_error)?;
+                if s.is_empty() || s.chars().count() > 200 {
+                    return Err(input_error());
+                }
+                out.insert("location".into(), json!(s));
+            }
+            _ => return Err(input_error()), // closed surface: refuse unknown/system-config fields
+        }
+    }
+    if out.is_empty() {
+        return Err(input_error());
+    }
+    Ok(out)
+}
+
+pub(super) async fn dispatch(
+    state: &MemoryCapabilityState,
+    request: &FirstPartyCapabilityRequest,
+) -> Result<FirstPartyCapabilityResult, FirstPartyCapabilityError> {
+    let fields = validated_fields(&request.input)?;
+    // Reuse the memory services/backend resolution; profile_merge_write keys the
+    // doc via the shared profile_scope_and_path helper (agent=None, project=None).
+    memory::profile_merge_write(state, request, fields).await
+}
+```
+
+- [ ] **Step 4: Add `profile_merge_write` to `memory.rs`**
+
+This read-modify-writes the profile doc at the user-only scope. Add to `crates/ironclaw_host_runtime/src/first_party_tools/memory.rs`:
+
+```rust
+/// Compare-and-write field-merge for the structured user profile doc. Keys the
+/// doc via the shared `profile_scope_and_path` helper (single scope-decision
+/// home). Validated field map is merged over existing JSON under a CAS retry
+/// loop so concurrent `profile_set` calls cannot lose a field.
+pub(super) async fn profile_merge_write(
+    state: &MemoryCapabilityState,
+    request: &FirstPartyCapabilityRequest,
+    fields: serde_json::Map<String, serde_json::Value>,
+) -> Result<FirstPartyCapabilityResult, FirstPartyCapabilityError> {
+    use crate::user_profile_source::profile_scope_and_path;
+
+    ensure_memory_mount(request, /* write */ true)?;
+    let (scope, path) = profile_scope_and_path(
+        request.scope.tenant_id.as_str(),
+        request.scope.user_id.as_str(),
+    ).map_err(|_| input_error())?;
+    let context = MemoryContext::new(scope)
+        .with_audit_context(request.scope.clone(), ironclaw_host_api::CorrelationId::new());
+    let backend = state.backend_for(request)?;
+    let options = MemoryBackendWriteOptions::default();
+
+    // CAS retry loop — mirrors `patch_document`'s MAX_MEMORY_PATCH_RETRIES pattern.
+    // Read current bytes + hash, merge fields, compare-and-write; retry on hash
+    // mismatch (a concurrent writer raced in). `validated_fields()` is the sole
+    // authoritative validator (no schema overlay — see review-fix note).
+    for _ in 0..MAX_MEMORY_PATCH_RETRIES {
+        let current = backend.read_document(&context, &path).await.map_err(|_| operation_error())?;
+        let expected_hash = current.as_deref().map(content_bytes_sha256);   // existing helper in memory.rs
+        let mut doc: serde_json::Map<String, serde_json::Value> = match &current {
+            Some(bytes) => serde_json::from_slice(bytes).unwrap_or_default(),
+            None => serde_json::Map::new(),
+        };
+        for (k, v) in &fields { doc.insert(k.clone(), v.clone()); }
+        let bytes = serde_json::to_vec(&serde_json::Value::Object(doc)).map_err(|_| operation_error())?;
+
+        let outcome = backend.compare_and_write_document_with_backend_options(
+            &context, &path, expected_hash.as_deref(), &bytes, &options,
+        ).await.map_err(|_| operation_error())?;
+        if outcome.committed() {                  // match the real MemoryWriteOutcome API
+            return Ok(FirstPartyCapabilityResult::new(json!({ "status": "ok" }), ResourceUsage::default()));
+        }
+        // else: hash moved under us — loop and re-merge onto the newer doc.
+    }
+    Err(operation_error())
+}
+```
+
+> `operation_error()`/`input_error()`/`ensure_memory_mount`/`backend_for` already exist in `memory.rs` (explorer-confirmed). Reuse them. Confirm the `ResourceUsage`/`FirstPartyCapabilityResult::new` shape against the other dispatch fns in this file.
+
+- [ ] **Step 5: (removed by review — duplicate truth)**
+
+**Review fix (maintainability, duplicate-truth 85):** the original plan added a `profile_write_options()` metadata schema overlay duplicating `validated_fields()` and the `schemas.rs` arm — a third hand-edited copy of the field set with no sync mechanism. **Dropped.** `validated_fields()` (Step 3) is the single authoritative enforcement: any write path other than `profile_set` is already blocked because the capability is the only writer of `context/profile.json`. The `schemas.rs` arm (Step 7) remains solely as the **LLM-visible tool description** (a different concern — what the model sees), not a second validator. Two artifacts, two distinct purposes; no duplicated truth.
+
+- [ ] **Step 6: Register the capability in `mod.rs`**
+
+1. Add `PROFILE_SET_CAPABILITY_ID` to the manifest vec in `builtin_first_party_package()` (~`mod.rs:162`): `profile_set::manifest()?,`.
+2. Add the handler in `builtin_first_party_base_registry()` (~`mod.rs:247`): `.with_handler(CapabilityId::new(profile_set::PROFILE_SET_CAPABILITY_ID)?, handler.clone())`.
+3. Add a dispatch arm in `BuiltinFirstPartyTools::dispatch` (~`mod.rs:347`), early-return like memory (it manages its own `ResourceUsage`):
+
+```rust
+        profile_set::PROFILE_SET_CAPABILITY_ID => {
+            let mut result = profile_set::dispatch(&self.memory_state, request).await?;
+            result.usage.output_bytes = bounded_output_bytes(&result.output, FIRST_PARTY_MAX_OUTPUT_BYTES)?;
+            return Ok(result);
+        }
+```
+
+4. Add `mod profile_set;` to the module list at the top of `mod.rs`.
+
+- [ ] **Step 7: Add the input schema arm in `schemas.rs`**
+
+In the `resolve_builtin_input_schema_ref` match (~`schemas.rs:3`):
+
+```rust
+        "schemas/builtin/profile_set.input.v1.json" => json!({
+            "type": "object",
+            "properties": {
+                "timezone": { "type": "string", "description": "IANA timezone name, e.g. America/Los_Angeles" },
+                "locale":   { "type": "string", "description": "BCP-47 tag, e.g. en-US" },
+                "location": { "type": "string", "description": "Free-text location label" }
+            },
+            "additionalProperties": false
+        }),
+```
+
+- [ ] **Step 8: Run tests**
+
+Run: `cargo test -p ironclaw_host_runtime profile_set 2>&1 | tail -25`
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add crates/ironclaw_host_runtime/src/first_party_tools/
+git commit -m "feat(host-runtime): add builtin.profile_set capability with field-merge write"
+```
+
+---
+
+## Task 5: Wire the producer into the loop-driver host factory
+
+**Files:**
+- Modify: `crates/ironclaw_reborn/src/loop_driver_host.rs`
+- Modify: `crates/ironclaw_reborn_composition/src/...` (the factory construction site that builds `RebornLoopDriverHostFactory`)
+
+- [ ] **Step 1: Add the optional source field + builder to the factory**
+
+In `loop_driver_host.rs`, on `RebornLoopDriverHostFactory` (struct ~line 885), mirror `identity_context_source`:
+
+```rust
+    user_profile_source: Option<Arc<dyn HostUserProfileSource>>,
+```
+
+Add the builder (mirror `with_identity_context_source`, ~line 1273):
+
+```rust
+    pub fn with_user_profile_source(mut self, source: Arc<dyn HostUserProfileSource>) -> Self {
+        self.user_profile_source = Some(source);
+        self
+    }
+```
+
+Initialize the field to `None` in the constructor/`Default` path. Add `use ironclaw_loop_support::HostUserProfileSource;`.
+
+> Per `.claude/rules/architecture.md` smell #2 (`Option<Arc<…>>` + `with_*`): production wires this every time, so guard against the "optional but always-set" lint by either (a) wiring it unconditionally in composition (Step 4) and keeping `Option` only for the test/no-profile path, or (b) defaulting to `Arc::new(EmptyUserProfileSource)`. Prefer (b): make the field non-optional `Arc<dyn HostUserProfileSource>` defaulting to `EmptyUserProfileSource`, and rename the builder to set it. This avoids the optional-Arc smell entirely.
+
+Revised field:
+
+```rust
+    user_profile_source: Arc<dyn HostUserProfileSource>,   // defaults to EmptyUserProfileSource
+```
+
+- [ ] **Step 2: Fill the runtime context at the construction site**
+
+At the `LoopRuntimeContext` build (~line 1563), before constructing it, resolve the profile:
+
+```rust
+        // Timezone lives inside the profile — no split. `None` when unset.
+        let user_profile = self
+            .user_profile_source
+            .resolve_user_profile(&run_context)
+            .await;
+```
+
+Then change the struct literal (note: `user_timezone` field no longer exists on `LoopRuntimeContext` — Wave 1 removed it):
+
+```rust
+        .with_runtime_context(LoopRuntimeContext {
+            loop_started_at_utc: chrono::Utc::now(),
+            communication,
+            product_context: run_context.product_context.clone(),
+            user_profile,
+        });
+```
+
+> Performance: this awaits a memory read on the loop-start path. v1 accepts a single bounded read here (the existing `communication` slice already does backend fetches at loop start). If profiling shows it matters, a follow-up can move it onto the same concurrent fetch budget as `CommunicationContextProvider`. Note this tradeoff inline; do not pre-optimize.
+
+- [ ] **Step 3: Add a host-level test with a fake source**
+
+In `loop_driver_host.rs` tests (or the crate's test module), add a fake `HostUserProfileSource` returning a known `ResolvedUserProfile`, build the host, and assert the rendered runtime context contains the local-time line + profile line. If the host-build path is hard to exercise in a unit test, defer this assertion to Task 6's integration test and keep a smaller unit test that the factory stores and calls the source.
+
+- [ ] **Step 4: Wire the production source in composition**
+
+In `ironclaw_reborn_composition` where `RebornLoopDriverHostFactory` is built, construct `MemoryBackedUserProfileSource::new(root_filesystem)` from the same `RootFilesystem` the host runtime already uses, and pass `.with_user_profile_source(Arc::new(source))`. Match how `with_identity_context_source` is wired in the same composition file.
+
+- [ ] **Step 5: Run + architecture check**
+
+```bash
+cargo test -p ironclaw_reborn 2>&1 | tail -20
+cargo test -p ironclaw_architecture 2>&1 | tail -15   # confirm ironclaw_reborn did NOT gain an ironclaw_memory edge
+```
+Expected: PASS, and `ironclaw_reborn/Cargo.toml` has **no** `ironclaw_memory` dependency (the read lives behind the trait in `ironclaw_host_runtime`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/ironclaw_reborn/src/loop_driver_host.rs crates/ironclaw_reborn_composition/
+git commit -m "feat(reborn): fill LoopRuntimeContext user profile via HostUserProfileSource"
+```
+
+---
+
+## Task 6: Caller-level integration test (both DB backends)
+
+**Files:**
+- Create: `crates/ironclaw_reborn/tests/user_profile_roundtrip.rs` (or extend an existing composition integration test)
+
+Per `.claude/rules/testing.md` — drive the real callers end-to-end, across PostgreSQL + libSQL.
+
+- [ ] **Step 1: Write the round-trip test**
+
+Drive: (1) dispatch `builtin.profile_set` with `{"timezone":"Asia/Tokyo","locale":"ja-JP","location":"Tokyo, Japan"}` through the real capability dispatch path for a run scoped with a non-None agent/project; (2) build the loop-driver host for the same user; (3) assert the rendered runtime context contains `Asia/Tokyo` local time and `User profile: locale=ja-JP, location=Tokyo, Japan`. This proves the **scope-narrowing** (write at agent/project-scoped run, read back at user-only `(tenant,user,None,None)`) actually works through the backend's scope isolation.
+
+```rust
+#[tokio::test]
+async fn profile_set_then_runtime_context_renders_local_time() {
+    // ... build harness with InMemory or test DB backend ...
+    // 1. profile_set
+    // 2. start a run, capture rendered runtime context
+    // 3. assert contains "Asia/Tokyo" and "User profile:"
+}
+```
+
+- [ ] **Step 2: Run on both backends**
+
+```bash
+cargo test -p ironclaw_reborn --test user_profile_roundtrip 2>&1 | tail -20
+cargo test --features integration user_profile_roundtrip 2>&1 | tail -20   # PostgreSQL
+```
+Expected: PASS on both. **If the user-only-scope read fails under an agent-scoped run**, this is the scope-narrowing risk surfacing — fix in the single `profile_merge_write` / source path (the only two places that build the profile path), e.g. by confirming the memory backend authorizes a same-user narrower context, or adjust the documented scope.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/ironclaw_reborn/tests/user_profile_roundtrip.rs
+git commit -m "test(reborn): integration round-trip profile_set -> runtime context render"
+```
+
+---
+
+## Task 7: Full quality gate + docs
+
+- [ ] **Step 1: Format, lint, test**
+
+```bash
+cargo fmt
+cargo clippy --all --benches --tests --examples --all-features 2>&1 | tail -20   # zero warnings
+cargo test 2>&1 | tail -20
+```
+
+- [ ] **Step 2: Update the explainer doc**
+
+Add a short note to `docs/reborn/2026-06-16-memory-how-it-works.md` §7 table: `builtin.profile_set` now exists; `user_timezone` now has a producer. Keep it factual.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add -A
+git commit -m "docs: record profile_set capability and user_timezone producer"
+```
+
+---
+
+## Review revisions (round 1 applied)
+
+Three plan-mode reviewers (approach / local-patterns / maintainability) produced 9 findings; resolutions:
+
+| # | Finding (reviewer, conf) | Resolution |
+|---|---|---|
+| 1 | Trait takes decomposed `(TurnScope, TurnActor)` not `&LoopRunContext` like sibling (approach 75, local 75) | **Fixed** — trait + impl + call site now take `&LoopRunContext` |
+| 2 | `ResolvedUserProfile` in wrong crate `ironclaw_turns` (maint 78) | **Fixed** — moved to `ironclaw_loop_support` next to the trait |
+| 3 | Profile field schema in 3 unsynchronized places (maint 85) | **Fixed** — dropped the metadata schema overlay (Step 5); `validated_fields()` is sole enforcement |
+| 4 | `Option<String>` locale violates spec §5 strong-types (approach 75) | **Fixed** — added `Locale` newtype; `UserProfileContext.locale: Option<Locale>` |
+| 5 | `mod` vs `pub mod` under `#![warn(unreachable_pub)]` (local 90) | **Fixed** — `pub mod user_profile_context;` |
+| 6 | Invented `sanitize_inline` vs existing `sanitize_prompt_string` (local 80) | **Fixed** — reuse `sanitize_prompt_string` (`runtime_context.rs:245`) |
+| 7 | `%error` vs `error = %error` log form (local 75) | **Fixed** — `error = %error` |
+| 8 | Test helper could shadow `dispatch` (local 85) | Note added — tests call `super::dispatch` via `use super::*`; rename local builders to `profile_set_request`/`call_profile_set` if any collision arises |
+| 9 | `user_profile_source.rs` top-level placement (local 65) | **Fixed** — added a placement comment explaining it's a producer, not a capability |
+
+Speculative-generality on the trait (single real impl) was **considered and not flagged** by the maintainability reviewer: `EmptyUserProfileSource` is a real test double and the trait is the established boundary pattern (`HostIdentityContextSource`), so it passes the GOOD-abstraction test.
+
+## Review revisions (round 2 applied)
+
+Second plan-mode pass produced 6 findings; resolutions:
+
+| # | Finding (reviewer, conf) | Resolution |
+|---|---|---|
+| 1 | `context/profile.json` double-injected (prose + typed render) (approach 80) | **Fixed** — new **Task 3B** drops it from the identity allow-list (keeps it write-protected) |
+| 2 | RMW merge ignores available CAS → lost writes (maint 75) | **Fixed** — `profile_merge_write` now uses `compare_and_write_*` in a `MAX_MEMORY_PATCH_RETRIES` loop |
+| 3 | Scope key duplicated in reader + writer (maint 75) | **Fixed** — single `profile_scope_and_path` helper; both producer and writer call it |
+| 4 | Task 3 test snippet used stale 2-arg signature (local 75) | **Fixed** — tests build `LoopRunContext` via `run_context_for` helper |
+| 5 | `Locale::new` returns `Option`, template wants `Result` (local 65) | **Fixed** — returns `Result<Self, LocaleError>`; producer logs + `.ok()` |
+| 6 | Carry `Option<String>` not `Tz` to avoid chrono-tz on loop_support (approach 55) | **Rejected** — keeping `Tz` avoids a stringly-typed re-parse (types.md favors it) and the reviewer's fix would instead push `chrono-tz` onto `ironclaw_reborn` (worse). `chrono-tz` on `loop_support` is a small, honest dep already transitive. |
+
+## Self-review notes (addressed)
+
+- **Spec coverage:** structured store (Task 4 `context/profile.json`), `profile_set` typed capability (Task 4), producer→runtime (Tasks 2/3/5), render + elicitation §6 (Task 1), field set v1 §5 (Task 4 `validated_fields`), scope §10 (single `profile_merge_write`/source helper, agent=None/project=None), security §9 (closed enum rejects unknown fields — Task 4 `rejects_unknown_field`), testing §11 (Tasks 1–6, both backends Task 6), error handling §7 (typed errors + `debug!` fail-soft Task 3).
+- **Prose container (USER.md)** needs no code — already injected; documented in spec.
+- **Out of scope** (geo→tz derivation, project override, system-config migration): not implemented; `location` is a label only (Task 4).
+- **Optional-Arc smell:** resolved by defaulting `user_profile_source` to `EmptyUserProfileSource` (Task 5 Step 1) rather than `Option<Arc<…>>`.

--- a/docs/superpowers/specs/2026-06-16-persistent-user-context-profile-design.md
+++ b/docs/superpowers/specs/2026-06-16-persistent-user-context-profile-design.md
@@ -1,0 +1,181 @@
+# Persistent User Context (Agent-Context Profile) — Design Spec
+
+_Date: 2026-06-16. Status: design, pending implementation plan._
+_Companion: `docs/reborn/2026-06-16-memory-how-it-works.md` (current-state explainer + industry survey)._
+
+## 1. Goal & Scope
+
+Give IronClaw Reborn a per-user, **always-injected** context layer so it behaves as a competent general assistant — knowing the user's timezone, locale, and soft preferences without being told each turn.
+
+This is **part 1 of a two-part memory split**:
+1. **(this spec)** Persistent context injected into the prompt every turn, user-scoped.
+2. *(later, separate spec)* Searchable / indexed memory.
+
+**In scope:** the LLM-visible `agent_context` only — a structured profile (timezone, locale, location) plus the existing freeform prose file.
+
+**Explicitly out of scope** (named, not silently dropped):
+- Searchable/indexed memory (part 2).
+- All **system config** — LLM provider/model selection, approval policy (`always-approve`), sandbox defaults. These keep their existing owners and are **never** absorbed into this profile (see §9).
+- geo→timezone *derivation*.
+- Project-scope override.
+- Migrating legacy engine `ValidTimezone` / thread-metadata timezone plumbing.
+
+## 2. Background — what already exists
+
+From the current-state explainer, two always-injected layers already exist in Reborn:
+
+1. **Identity files** (`USER.md`, `AGENTS.md`, `SOUL.md`, `MEMORY.md`, … and a structured `context/profile.json`) — loaded each turn into `LoopContextBundle.identity_messages` via `build_identity_messages` (`crates/ironclaw_loop_support/src/identity_context.rs`). Allow-list in `crates/ironclaw_memory/src/safety.rs:153`.
+2. **Runtime context** — `LoopRuntimeContext` (`crates/ironclaw_turns/src/run_profile/runtime_context.rs:13`), re-rendered per turn by `render_model_content` (`:74`). It already carries a typed `user_timezone: Option<Tz>` and renders correct DST-aware local time via `chrono-tz` **when the timezone is known** — but the field has **no production producer**: the sole construction site, `crates/ironclaw_reborn/src/loop_driver_host.rs:1563`, passes `user_timezone: None`. So today the model always sees UTC + "timezone unknown."
+
+Also relevant:
+- **`builtin.time`** (`crates/ironclaw_host_runtime/src/first_party_tools/time.rs`) is a real, authoritative capability: `chrono` + `chrono_tz` (real IANA tzdata → DST-correct), ops `now/parse/convert/format/diff`. Used for arbitrary date math on demand. It even errors on ambiguous/nonexistent local times rather than guessing.
+- **`memory_write`** (`crates/ironclaw_host_runtime/src/first_party_tools/memory.rs`) already writes scoped, versioned, schema-validatable memory documents. `DocumentMetadata.schema` supports JSON-schema validation at write time; `.config` ancestor metadata is inherited.
+
+This design **fills the missing producer** and **adds a typed write path** rather than inventing new storage.
+
+## 3. Architecture — two containers, by data shape
+
+The core principle: **a value that must come out typed (a `Tz`) cannot live in a freeform `.md`** — a Markdown file has no enforced schema, and a model editing it anytime can corrupt any convention. So structured and prose data get different containers, different write verbs, and different render paths. Zero overlap.
+
+```
+STRUCTURED  → context/profile.json (schema-validated memory doc)
+   fields: timezone, locale, location
+   written by: builtin.profile_set   (typed, closed enum)
+   read by:    producer at loop start → LoopRuntimeContext
+   rendered:   render_model_content() — deterministic, every turn
+
+PROSE       → USER.md (freeform)
+   content: role, communication style, soft preferences
+   written by: memory_write          (existing, free text)
+   rendered:   build_identity_messages() → identity_messages (existing path)
+
+ON-DEMAND   → builtin.time (unchanged)
+   arbitrary date math / conversions the ambient line can't cover
+```
+
+Disambiguation between the two write verbs is structural, not hoped-for: `profile_set` has a **closed field enum** (can't hold prose), and the profile **self-advertises its slots** in the injected context each turn (the model sees `location=(unset)` and a tool whose description names exactly that slot). Mis-routing is low-harm and self-correcting (an unset field just falls back to `builtin.time` / "ask the user").
+
+## 4. Components
+
+### 4a. Structured profile store
+- A schema-validated memory document at relative path **`context/profile.json`**, user-scoped (`project_id = None`).
+- JSON schema enforced **server-side** via `.config` metadata inheritance — the model writes through `profile_set` (§4b), never authors the schema itself; an invalid value is rejected at write time.
+- Reuses the memory backend (CAS writes, version history, PostgreSQL/libSQL parity). **No new table.**
+- `context/profile.json` is already in the protected-path allow-list (`safety.rs:164`). Because the structured fields are now rendered via runtime context (§4c), the **raw JSON is not also injected as prose** — avoid double-injection/noise. (Implementation detail: ensure the structured profile doc is consumed by the producer and not additionally dumped into `identity_messages`. Confirm during implementation whether to drop it from the prose allow-list or leave it injected; default is **not** to inject the raw JSON.)
+
+### 4b. `builtin.profile_set` capability (new)
+- **Closed typed param set** — one or more of `timezone | locale | location` per call. The enum deliberately **cannot name** any system-config field (§9).
+- Handler pipeline:
+  1. Validate each supplied field (§5).
+  2. **Field-level merge** into the existing profile (set `timezone` without clobbering `locale`).
+  3. Write `context/profile.json` via the memory backend (validated against the server-owned schema).
+  4. Invalidate the producer cache (§4c) for this scope.
+- `PermissionMode::Allow`. Routed through `ToolDispatcher::dispatch` — inherits audit (`ActionRecord`), param validation, redaction, output sanitization. Everything-goes-through-tools compliant.
+- Lives under `crates/ironclaw_host_runtime/src/first_party_tools/` as its own file (per crate guidance: one first-party tool per capability). Manifest + handler registered in `first_party_tools/mod.rs`; input schema in `schemas.rs`.
+
+### 4c. Producer → runtime wiring
+- Introduce a typed `UserProfileContext { locale: Option<Locale>, location: Option<String> }` carried on `LoopRuntimeContext` **alongside** the existing `user_timezone: Option<Tz>`.
+- At loop start — **`crates/ironclaw_reborn/src/loop_driver_host.rs:1563`** — read `context/profile.json` for the run's scope, parse, and populate:
+  - `user_timezone` ← validated `Tz` (replacing the hardcoded `None`).
+  - `UserProfileContext` ← the remaining fields.
+- Extend `render_model_content` (`runtime_context.rs:74`) to append one profile line after the existing time line, e.g.:
+  `User profile: locale=ja-JP, location=Tokyo, Japan.`
+  The timezone continues to flow through the existing time-rendering branch (correct DST local time).
+- **Never guess** (honors the existing `user_timezone` invariant — `None` means unknown, never a host default): any field that is missing or fails to parse renders as unset.
+- **Performance:** the profile read joins the existing concurrent loop-start fetch budget (mirroring `CommunicationContextProvider`'s already-running fetch with a bounded timeout), and/or is cached per scope with invalidation on `profile_set` write. It must not block loop start on the critical path. Producer wiring follows the module-owned-initialization rule (factory in the owning module, orchestrated from composition).
+
+### 4d. Prose container
+- `USER.md` remains the freeform identity file injected via the existing `build_identity_messages` path. No mechanism change — this spec only **documents it as the home** for soft prefs and ensures the guidance (§6) points the model there for non-structured facts.
+
+## 5. Field set (v1)
+
+| Field | Type / validation | Feeds | Notes |
+|---|---|---|---|
+| `timezone` | IANA string, validated by `parse::<Tz>()` (chrono-tz) | `user_timezone` → DST-correct local-time render | The high-value field. Must be an explicit IANA name. |
+| `locale` | BCP-47 tag (e.g. `en-US`), light syntactic validation | profile line | Language / date / number hints |
+| `location` | Free-text label (e.g. `"Tokyo, Japan"`), bounded length | profile line | **Model context only — NOT a timezone source in v1** |
+
+- Use strong types (per `.claude/rules/types.md`): a `ValidTimezone`-style newtype around `Tz`, a `Locale` newtype. No stringly-typed internals.
+- **Deferred:** geo→timezone derivation. v1 requires an explicit IANA `timezone`; `location` is a context label only. This preserves the never-guess invariant and needs no geo database.
+
+## 6. Behavioral requirement — proactive elicitation
+
+The model should help the user populate the profile, since an unset profile is invisible to the user.
+
+- **Primary (reliable):** when a profile field is **unset** and the current request **needs it**, the model should ask the user for it and **offer to save it** via `profile_set`. This is driven by the always-injected render lines, generalizing the existing tz-unknown hint:
+  - timezone unset + local time matters → "The user's timezone is unknown — ask, then offer to save it with `profile_set` so future answers are correct." (extends the current `render_model_content` `None` branch to mention `profile_set`).
+  - other fields → a compact "unset profile fields: location — ask and offer to save if relevant" hint when any are unset.
+- **Secondary (best-effort, explicitly soft):** if the user *alludes* to a field ("it's getting late here") without stating it, the model *may* offer to save it. This is prompt-only guidance with **no guarantee** — flagged as such; not a code path, not a success criterion.
+- Elicitation guidance is **prompt/render text**, not new control flow. It must not nag: guidance is conditioned on the field being unset *and* relevant.
+
+## 7. Data flow
+
+**Write.** User: "I'm in Tokyo, use 24-hour time." → model calls `profile_set(timezone="Asia/Tokyo", location="Tokyo, Japan")` → handler validates (`parse::<Tz>()` ok), merges, writes `context/profile.json`, invalidates cache.
+
+**Read / inject (every turn).** Loop start (`loop_driver_host.rs:1563`) → producer reads profile → fills `user_timezone = Asia/Tokyo` + `UserProfileContext{ locale, location }` → `render_model_content` emits:
+`Current date/time at loop start: 2026-06-16T00:14Z (09:14 Tue, Asia/Tokyo). ... User profile: locale=ja-JP, location=Tokyo, Japan.`
+
+## 8. Error handling
+- **Write path:** per-field validation at the `profile_set` boundary; an invalid value returns a clear, field-level error the model can correct and retry. Merge is per-field — no partial corruption of other fields.
+- **Read path:** a parse failure on any field → that field renders unset, with a `debug!` log (never `info!`/`warn!` — REPL/TUI corruption rule). The run continues. Fail-soft, never fabricate a value.
+- Follow `.claude/rules/error-handling.md`: no `unwrap_or_default()` masking a store error on the profile read; a genuine store failure is surfaced/logged, not silently turned into an empty profile without a `// silent-ok:` justification.
+
+## 9. Security boundary (non-negotiable)
+
+System config is **never** part of this profile:
+- `profile_set`'s closed enum **cannot name** provider/model, approval policy, sandbox defaults, or any authorization-affecting field. The producer reads **only** `agent_context`.
+- Rationale: `always-approve` is an authorization-bypass switch — if the model could see it that is prompt-injection recon; if it could write it that is privilege escalation. Provider/model selection must not be model-rerouteable.
+- These configs already have owners and must stay there (no parallel authorization/settings path — per `.claude/rules/architecture.md` and Reborn boundary rules):
+  - Provider/model/db/security → `src/settings.rs` `Settings` (instance-level; `owner_id` is the instance owner scope, plus a per-user DB settings table for some fields).
+  - Approval policy → **computed, not stored** — resolved from a `RuntimeProfile` by `RuntimeProfileApprovalGatePolicy` (`crates/ironclaw_reborn_composition/src/runtime_profile_approval_policy.rs`), per run/scope.
+
+## 10. Scope model & configuration scope map
+
+### 10.1 This profile's scope
+- **v1: user-scoped only** — the profile describes the human user, independent of agent or project, so it is keyed at `(tenant_id, user_id)` with **`agent_id = None` and `project_id = None`**. One profile per user, applies everywhere.
+- **Reserved, not built:** project-level override. The memory document's 4-tuple scope already supports it; a later slice would merge project-over-user in the producer.
+
+### 10.2 Configuration scope map
+
+Where every per-X configuration/context item lives, to make this profile's boundary explicit. Scope axis: **User** (the human) · **Agent** (the assistant persona) · **Project** (a workspace) · **Thread** (one conversation/run) · **Instance** (the whole IronClaw deployment — shown because provider/approval surfaced in discussion, though outside the four core scopes). "Sees" = injected into / visible to the LLM. "Writes" = the LLM can mutate it via a capability.
+
+| Item | Scope | Sees | Writes | Store / owner | This spec |
+|---|---|---|---|---|---|
+| timezone | User | ✅ | ✅ `profile_set` | `context/profile.json` | **builds** |
+| locale | User | ✅ | ✅ `profile_set` | `context/profile.json` | **builds** |
+| location | User | ✅ | ✅ `profile_set` | `context/profile.json` | **builds** |
+| communication style / soft prefs | User | ✅ | ✅ `memory_write` | `USER.md` (prose) | documents |
+| agent persona / identity | Agent | ✅ | ✅ `memory_write` | `AGENTS.md`, `SOUL.md` (agent-scoped) | existing |
+| agent tool/capability set | Agent | ✅ (as tools) | ❌ | extension registry / runtime policy | existing |
+| project instructions / context | Project | ✅ | ✅ `memory_write` | project-scoped memory docs | existing |
+| project sandbox / container policy | Project | ❌ | ❌ | sandbox config (system) | existing |
+| project-scoped memory/notes | Project | on search | ✅ `memory_write` | memory docs (`project_id` set) | part 2 |
+| current date/time at loop start | Thread | ✅ | ❌ (system) | `LoopRuntimeContext` (per-run) | touched (tz render) |
+| run origin / surface / adapter | Thread | ✅ | ❌ | `LoopRuntimeContext.product_context` | existing |
+| reply delivery target | Thread | ✅ (advisory) | ❌ | communication context (owner-keyed) | existing |
+| connected channels | User/Thread | ✅ (advisory) | ❌ | communication context | existing |
+| conversation history / compaction | Thread | ✅ | n/a | thread store | existing |
+| active-run lock | Thread | ❌ | ❌ | `ironclaw_turns` (scoped thread key) | existing |
+| LLM provider / model | Instance | ❌ | ❌ | `src/settings.rs` `Settings` | **excluded (§9)** |
+| db backend / secrets key | Instance | ❌ | ❌ | `src/settings.rs` `Settings` | **excluded (§9)** |
+| approval policy (`always-approve`) | Run/scope | ❌ | ❌ | **computed** from `RuntimeProfile` (`runtime_profile_approval_policy.rs`) — not stored | **excluded (§9)** |
+
+Reading the table: everything this spec **builds** is User-scoped and both LLM-visible and LLM-writable. Everything Instance-scoped is neither visible nor writable (the §9 safety boundary). Thread-scoped runtime context is visible but system-owned (the LLM never writes it) — this spec only *touches* it by giving the existing `user_timezone` slot a producer. Approval policy is special: it is **computed per run**, not stored anywhere as a toggle, which is the deeper reason it cannot be consolidated into a profile record.
+
+## 11. Testing
+- Unit: field validators (`timezone` IANA parse incl. a rejecting case; `locale` syntax; `location` length bound).
+- **Caller-level (per `.claude/rules/testing.md` — "Test Through the Caller"):**
+  - Drive the `profile_set` **handler**: assert `context/profile.json` field-merge (set one field, others preserved) and schema rejection of an invalid value.
+  - Drive the **producer** at the `loop_driver_host` construction site: assert `user_timezone` is populated from the stored profile and that `render_model_content` output contains the correct local-time line and profile line.
+- Run at the integration tier across **both** DB backends (PostgreSQL + libSQL) for memory-doc parity.
+- `cargo test -p ironclaw_architecture` after any public-API / boundary / dependency change (new capability + new `LoopRuntimeContext` field).
+- Render snapshot/replay coverage where the runtime-context fingerprint is asserted (model-visible rendering only).
+
+## 12. Open implementation details (decide during planning, not blockers)
+- Whether to drop `context/profile.json` from the prose injection allow-list or keep it injected (default: do not inject raw JSON; render via runtime context only).
+- Exact cache vs. concurrent-read strategy for the loop-start profile read.
+- Newtype names / module placement for `ValidTimezone`, `Locale`, `UserProfileContext` (reuse legacy `ValidTimezone` shape if cleanly extractable, else define fresh in the runtime-context crate).
+- JSON schema document content + where the `.config` carrying it is provisioned.
+
+## 13. Out of scope (restated)
+Searchable memory (part 2); geo→timezone derivation; project-scope override; system-config consolidation/migration; legacy `ValidTimezone`/thread-metadata timezone migration.


### PR DESCRIPTION
Lands the design artifacts for the per-user agent-context profile feature merged in #5008 (part 1 of the two-part memory split). These were written during brainstorming/planning but never committed to the branch.

- `docs/reborn/2026-06-16-memory-how-it-works.md` — how Reborn memory/context injection works, with a comparison table vs pi/hermes/claude-code and other harness memory systems.
- `docs/superpowers/specs/2026-06-16-persistent-user-context-profile-design.md` — the approved spec (scope, `timezone`/`locale`/`location` field set, scope table, capability-vs-memory decision).
- `docs/superpowers/plans/2026-06-16-persistent-user-context-profile.md` — the implementation plan.

Docs-only, no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)