### PR TITLE
feat(reborn): show each tool's primary argument inline in Activity rows

### DIFF
--- a/crates/ironclaw_reborn_composition/src/projection/display_preview.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/display_preview.rs
@@ -121,7 +121,7 @@ impl CapabilityDisplayPreviewStore {
         let input_summary = input_summary(tool_name, arguments);
         let input = CapabilityDisplayInputPreview {
             title: bounded_display_text(tool_name, CAPABILITY_DISPLAY_SUMMARY_MAX_BYTES).text,
-            subtitle: safe_path_subtitle(arguments),
+            subtitle: primary_arg_subtitle(tool_name, arguments),
             truncated: input_summary
                 .as_ref()
                 .is_some_and(|summary| summary.truncated),
@@ -698,6 +698,56 @@ fn safe_path_subtitle(value: &serde_json::Value) -> Option<String> {
         .or_else(|| value.get("target"))?
         .as_str()?;
     safe_display_path(path)
+}
+
+/// A compact, display-safe "primary argument" for the activity row's inline
+/// detail — the single most salient input for a tool, so the row reads like
+/// `nearai.web_search   <query>` / `shell   <command>` / `read_file   <path>`
+/// instead of a bare tool name. Reuses the same sanitizing formatters as
+/// `input_summary` (URL stripping, shell redaction, byte bounds) and falls back
+/// to the path subtitle for tools without a recognized primary argument.
+fn primary_arg_subtitle(capability_id: &str, value: &serde_json::Value) -> Option<String> {
+    // Search-shaped tools → the query string.
+    if (capability_matches(capability_id, "memory_search")
+        || capability_id == "web_search"
+        || capability_id == "llm_context"
+        || capability_id.ends_with(".web_search")
+        || capability_id.ends_with(".search")
+        || capability_id == "web-access.search"
+        || capability_id == "nearai.web_search")
+        && let Some(query) = string_arg(value, &["query", "q", "text", "pattern"])
+    {
+        return non_empty(bounded_summary_value(query).text);
+    }
+
+    // Shell → the command (with the existing secret-redacting formatter).
+    if capability_matches(capability_id, "shell")
+        && let Some(command) = string_arg(value, &["command"])
+    {
+        return non_empty(shell_command_display_text(command).text);
+    }
+
+    // HTTP / fetch → the URL (sensitive parts stripped).
+    if (capability_matches(capability_id, "http")
+        || capability_matches(capability_id, "http.save")
+        || capability_id == "web_fetch"
+        || capability_id.ends_with(".web_fetch")
+        || capability_id == "web-access.get_content")
+        && let Some(url) = string_arg(value, &["url"])
+    {
+        return non_empty(safe_url_display(url).text);
+    }
+
+    // Glob / grep → the pattern.
+    if (capability_matches(capability_id, "glob") || capability_matches(capability_id, "grep"))
+        && let Some(pattern) = string_arg(value, &["pattern"])
+    {
+        return non_empty(bounded_summary_value(pattern).text);
+    }
+
+    // Everything else (read_file, write_file, list_dir, apply_patch, memory_*)
+    // → the path/target.
+    safe_path_subtitle(value)
 }
 
 /// Returns `true` when the path contains characters that are inherently unsafe

--- a/crates/ironclaw_reborn_composition/src/projection/tests/display_preview.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/tests/display_preview.rs
@@ -440,6 +440,12 @@ async fn capability_display_preview_store_summarizes_search_and_memory_inputs() 
     assert!(search_summary.contains("query: deployment status token: [redacted]"));
     assert!(search_summary.contains("limit: 5"));
     assert!(!search_summary.contains("sk-secret"));
+    // The inline row subtitle is the primary argument (the query), redacted
+    // the same way the summary is — so the row reads `web_search   <query>`
+    // instead of a bare tool name.
+    let search_subtitle = search_preview.subtitle.as_deref().unwrap();
+    assert!(search_subtitle.contains("deployment status"));
+    assert!(!search_subtitle.contains("sk-secret"));
 
     let memory_preview = completed_preview_for_input(
         "builtin.memory_write",
@@ -456,6 +462,49 @@ async fn capability_display_preview_store_summarizes_search_and_memory_inputs() 
     assert!(memory_summary.contains("append: true"));
     assert!(memory_summary.contains("content_bytes: 16"));
     assert!(!memory_summary.contains("sk-secret"));
+}
+
+#[tokio::test]
+async fn capability_display_preview_store_uses_primary_arg_subtitle_for_non_path_tools() {
+    // shell → the command (the inline row reads `shell   <command>`).
+    let shell = completed_preview_for_input(
+        "shell",
+        "builtin.shell",
+        serde_json::json!({"command": "cargo test -p ironclaw"}),
+    )
+    .await;
+    assert!(
+        shell
+            .subtitle
+            .as_deref()
+            .is_some_and(|s| s.contains("cargo test")),
+        "shell subtitle should carry the command, got {:?}",
+        shell.subtitle,
+    );
+
+    // http / web_fetch → the URL (sensitive parts stripped).
+    let http = completed_preview_for_input(
+        "web_fetch",
+        "builtin.web_fetch",
+        serde_json::json!({"url": "https://example.com/docs"}),
+    )
+    .await;
+    assert!(
+        http.subtitle
+            .as_deref()
+            .is_some_and(|s| s.contains("example.com")),
+        "web_fetch subtitle should carry the url, got {:?}",
+        http.subtitle,
+    );
+
+    // Path-based tools keep the workspace-relative path subtitle.
+    let read = completed_preview_for_input(
+        "read_file",
+        "builtin.read_file",
+        serde_json::json!({"path": "/workspace/src/main.rs"}),
+    )
+    .await;
+    assert_eq!(read.subtitle.as_deref(), Some("src/main.rs"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Context

Follow-on to #5012 (which fixed tool arguments never being recorded). With args now recorded, this improves how they're shown: the Activity row's inline detail was only populated for **path-style** tools (`read_file`, `write_file`) — `subtitle` came from `safe_path_subtitle`. So `nearai.web_search`, `shell`, `web_fetch`, etc. rendered as a bare tool name with nothing inline; you had to expand the row to see what the tool was doing.

## Change

Generalize the subtitle to a compact, display-safe **primary argument** per tool family, so the row reads:

```
● ok   nearai.web_search   climate policy 2026
● ok   read_file   src/main.rs
● ok   shell   cargo test -p ironclaw
● ok   web_fetch   example.com/docs
```

(This is the "name + muted arg" format chosen for the row.)

- search/`web_search`/`memory_search` → query
- `shell` → command
- `http`/`web_fetch` → url
- `glob`/`grep` → pattern
- file tools (`read_file`, `write_file`, `list_dir`, `apply_patch`, `memory_*`) → workspace-relative path (unchanged)

Reuses the **same sanitizing formatters** as `input_summary` — secret redaction via `sanitize_text`, URL stripping, shell redaction, byte bounds — so secrets never reach the row (regression-tested with an `sk-secret` query).

**No frontend change needed:** the row already renders this `subtitle` as `toolDetail`; it just had no value for non-path tools before. The full key/value breakdown remains in the Parameters tab.

## Tests

`capability_display_preview_store_uses_primary_arg_subtitle_for_non_path_tools` (shell command, web_fetch url, read_file path fallback) plus subtitle assertions added to the existing search test (redacted query carried, `sk-secret` absent).

Gate: `cargo fmt`, `cargo clippy -p ironclaw_reborn_composition --tests -- -D warnings`, and the `display_preview` suite (29 tests) pass.

## Scope note

This surfaces the argument on the **completed/persisted** tool card. Showing it **live during the run** additionally requires carrying the detail on the `capability_activity` lifecycle frame (a new wire field + a small port hook linking `invocation_id`→input + projection plumbing — ~4 crates). I scoped that as a separate follow-up; happy to do it next if wanted.

Depends on #5012 for the effect to be visible in production (without it, `record_input` isn't called and neither subtitle nor parameters are recorded).