### PR TITLE
feat(reborn): show tool arguments live while the tool is running

### DIFF
--- a/crates/ironclaw_loop_support/src/capability_port.rs
+++ b/crates/ironclaw_loop_support/src/capability_port.rs
@@ -245,6 +245,20 @@ pub trait LoopCapabilityResultWriter: Send + Sync {
     ) -> Result<(), AgentLoopHostError> {
         Ok(())
     }
+
+    /// Note that the invocation `invocation_id` has started executing with the
+    /// input staged under `input_ref`. Links the two so the still-running
+    /// activity frame can surface the input (inline argument + parameters)
+    /// before the result lands — the input was recorded under `input_ref` at
+    /// registration, but the activity projection only knows the `invocation_id`.
+    /// Default no-op: only writers that own a display-preview store implement it.
+    fn record_running_invocation(
+        &self,
+        _run_context: &LoopRunContext,
+        _invocation_id: InvocationId,
+        _input_ref: &CapabilityInputRef,
+    ) {
+    }
 }
 
 pub struct CapabilityResultWrite<'a> {
@@ -1510,6 +1524,14 @@ impl LoopCapabilityPort for HostRuntimeLoopCapabilityPort {
         let requested_capability_id = request.capability_id.clone();
         let provider = capability.provider.clone();
         let runtime = capability.runtime;
+        // Link this invocation to its staged input ref now that both are known,
+        // so the still-running activity frame can surface the input argument
+        // before the result completes.
+        self.result_writer.record_running_invocation(
+            &self.run_context,
+            invocation_id,
+            effective_input_ref,
+        );
         let capability_activity_id = CapabilityActivityId::from_uuid(invocation_id.as_uuid());
         self.emit_capability_milestone(LoopHostMilestoneKind::CapabilityInvoked {
             activity_id: capability_activity_id,

--- a/crates/ironclaw_product_adapters/src/outbound.rs
+++ b/crates/ironclaw_product_adapters/src/outbound.rs
@@ -227,6 +227,12 @@ pub struct CapabilityActivityView {
     pub process_id: Option<ProcessId>,
     pub output_bytes: Option<u64>,
     pub error_kind: Option<String>,
+    /// Inline primary-argument detail for the activity row, surfaced while the
+    /// invocation is still running (the completed card carries its own).
+    pub subtitle: Option<String>,
+    /// Per-tool parameter summary, surfaced while the invocation is still
+    /// running so the row's Parameters tab is populated before the result.
+    pub input_summary: Option<String>,
     pub updated_at: DateTime<Utc>,
     pub activity_order: Option<u64>,
 }
@@ -251,6 +257,10 @@ impl Serialize for CapabilityActivityView {
             process_id: &'a Option<ProcessId>,
             output_bytes: Option<u64>,
             error_kind: &'a Option<String>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            subtitle: &'a Option<String>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            input_summary: &'a Option<String>,
             updated_at: &'a DateTime<Utc>,
             #[serde(skip_serializing_if = "Option::is_none")]
             activity_order: Option<u64>,
@@ -267,6 +277,8 @@ impl Serialize for CapabilityActivityView {
             process_id: &self.process_id,
             output_bytes: self.output_bytes,
             error_kind: &self.error_kind,
+            subtitle: &self.subtitle,
+            input_summary: &self.input_summary,
             updated_at: &self.updated_at,
             activity_order: self.activity_order,
         }
@@ -287,6 +299,8 @@ impl CapabilityActivityView {
             process_id: input.process_id,
             output_bytes: input.output_bytes,
             error_kind: input.error_kind,
+            subtitle: input.subtitle,
+            input_summary: input.input_summary,
             updated_at: input.updated_at,
             activity_order: input.activity_order,
         };
@@ -314,6 +328,8 @@ pub struct CapabilityActivityViewInput {
     pub process_id: Option<ProcessId>,
     pub output_bytes: Option<u64>,
     pub error_kind: Option<String>,
+    pub subtitle: Option<String>,
+    pub input_summary: Option<String>,
     pub updated_at: DateTime<Utc>,
     pub activity_order: Option<u64>,
 }
@@ -336,6 +352,10 @@ impl<'de> Deserialize<'de> for CapabilityActivityView {
             process_id: Option<ProcessId>,
             output_bytes: Option<u64>,
             error_kind: Option<String>,
+            #[serde(default)]
+            subtitle: Option<String>,
+            #[serde(default)]
+            input_summary: Option<String>,
             updated_at: DateTime<Utc>,
             activity_order: Option<u64>,
         }
@@ -351,6 +371,8 @@ impl<'de> Deserialize<'de> for CapabilityActivityView {
             process_id: wire.process_id,
             output_bytes: wire.output_bytes,
             error_kind: wire.error_kind,
+            subtitle: wire.subtitle,
+            input_summary: wire.input_summary,
             updated_at: wire.updated_at,
             activity_order: wire.activity_order,
         })
@@ -1377,6 +1399,8 @@ mod tests {
                     process_id: None,
                     output_bytes: None,
                     error_kind: None,
+                    subtitle: None,
+                    input_summary: None,
                     updated_at: Utc::now(),
                     activity_order: None,
                 })
@@ -1707,6 +1731,8 @@ mod tests {
             process_id: None,
             output_bytes: Some(12),
             error_kind: None,
+            subtitle: None,
+            input_summary: None,
             updated_at: Utc::now(),
             activity_order: None,
         })
@@ -1937,6 +1963,8 @@ mod tests {
             process_id: None,
             output_bytes: None,
             error_kind: Some("/tmp/private-host-path".to_string()),
+            subtitle: None,
+            input_summary: None,
             updated_at: Utc::now(),
             activity_order: None,
         };

--- a/crates/ironclaw_product_adapters/src/outbound.rs
+++ b/crates/ironclaw_product_adapters/src/outbound.rs
@@ -312,6 +312,20 @@ impl CapabilityActivityView {
         if let Some(error_kind) = self.error_kind.as_deref() {
             validate_error_kind("capability_activity_error_kind", error_kind)?;
         }
+        // The running-frame input fields are sanitized/byte-bounded upstream;
+        // re-validate them at the product boundary (as `error_kind` is) so an
+        // upstream regression can't leak unbounded/control-char text to the
+        // browser.
+        validate_optional_display_text(
+            "capability_activity_subtitle",
+            self.subtitle.as_deref(),
+            CAPABILITY_DISPLAY_SUMMARY_MAX_BYTES,
+        )?;
+        validate_optional_display_text(
+            "capability_activity_input_summary",
+            self.input_summary.as_deref(),
+            CAPABILITY_DISPLAY_SUMMARY_MAX_BYTES,
+        )?;
         Ok(())
     }
 }
@@ -1993,5 +2007,52 @@ mod tests {
             view.error_kind.as_deref(),
             Some(CAPABILITY_ACTIVITY_UNCLASSIFIED_ERROR_KIND)
         );
+    }
+
+    fn capability_activity_view_input_for_detail_test() -> CapabilityActivityViewInput {
+        CapabilityActivityViewInput {
+            invocation_id: InvocationId::new(),
+            turn_run_id: Some(TurnRunId::new()),
+            thread_id: Some(ThreadId::new("thread-tool-activity").expect("thread id")),
+            capability_id: CapabilityId::new("nearai.web_search").expect("capability id"),
+            status: CapabilityActivityStatusView::Started,
+            provider: None,
+            runtime: None,
+            process_id: None,
+            output_bytes: None,
+            error_kind: None,
+            subtitle: None,
+            input_summary: None,
+            updated_at: Utc::now(),
+            activity_order: None,
+        }
+    }
+
+    #[test]
+    fn capability_activity_view_rejects_oversized_running_input_fields() {
+        let oversized = "a".repeat(CAPABILITY_DISPLAY_SUMMARY_MAX_BYTES + 1);
+
+        let subtitle_input = CapabilityActivityViewInput {
+            subtitle: Some(oversized.clone()),
+            ..capability_activity_view_input_for_detail_test()
+        };
+        assert!(CapabilityActivityView::new(subtitle_input).is_err());
+
+        let summary_input = CapabilityActivityViewInput {
+            input_summary: Some(oversized),
+            ..capability_activity_view_input_for_detail_test()
+        };
+        assert!(CapabilityActivityView::new(summary_input).is_err());
+    }
+
+    #[test]
+    fn capability_activity_view_rejects_control_char_running_input_on_serialize() {
+        let view = CapabilityActivityView {
+            subtitle: Some("query\u{0}with-nul".to_string()),
+            ..CapabilityActivityView::new(capability_activity_view_input_for_detail_test())
+                .expect("base view")
+        };
+
+        assert!(serde_json::to_value(view).is_err());
     }
 }

--- a/crates/ironclaw_reborn_composition/src/product_live_adapters.rs
+++ b/crates/ironclaw_reborn_composition/src/product_live_adapters.rs
@@ -14,8 +14,8 @@ use thiserror::Error;
 use uuid::Uuid;
 
 use ironclaw_host_api::{
-    CapabilityId, CapabilitySet, EffectKind, ExecutionContext, ExtensionId, MountView, RuntimeKind,
-    TrustClass, UserId,
+    CapabilityId, CapabilitySet, EffectKind, ExecutionContext, ExtensionId, InvocationId,
+    MountView, RuntimeKind, TrustClass, UserId,
 };
 use ironclaw_host_runtime::{
     CapabilitySurfacePolicy, HostRuntime, SurfaceKind, VisibleCapabilityRequest,
@@ -300,6 +300,16 @@ impl LoopCapabilityResultWriter for ProductLiveCapabilityIo {
             display_preview.as_ref(),
         );
         Ok((result_ref, byte_len as u64))
+    }
+
+    fn record_running_invocation(
+        &self,
+        _run_context: &LoopRunContext,
+        invocation_id: InvocationId,
+        input_ref: &CapabilityInputRef,
+    ) {
+        self.display_previews
+            .record_running_invocation(invocation_id, input_ref);
     }
 
     async fn update_capability_result(

--- a/crates/ironclaw_reborn_composition/src/projection.rs
+++ b/crates/ironclaw_reborn_composition/src/projection.rs
@@ -621,7 +621,7 @@ async fn item_to_payloads(
                     .await
                 }
                 ironclaw_event_streams::ProductProjectionEnvelope::ThreadLiveUpdate(update) => {
-                    live_update_payloads(scope, update, cursor, last_live_cursor)
+                    live_update_payloads(scope, display_previews, update, cursor, last_live_cursor)
                 }
                 _ => Err(internal_projection_error(
                     "unexpected projection update envelope",
@@ -653,6 +653,7 @@ async fn item_to_payloads(
 
 fn live_update_payloads(
     scope: &TurnScope,
+    display_previews: &dyn CapabilityDisplayPreviewSource,
     update: &ThreadLiveProjectionUpdate,
     cursor: EventProjectionCursor,
     last_live_cursor: Option<EventCursor>,
@@ -660,7 +661,7 @@ fn live_update_payloads(
     if last_live_cursor.is_some_and(|last| cursor.runtime <= last) {
         return Ok(None);
     }
-    let items = product_items_for_live_update(update);
+    let items = product_items_for_live_update(display_previews, update);
     if items.is_empty() {
         return Ok(None);
     }
@@ -885,6 +886,10 @@ async fn runtime_payload_from_candidate(
         }
         RuntimePayloadCandidate::CapabilityActivity(activity) => {
             let activity_order = activity.activity_order_cursor().as_u64();
+            // Surface the staged input on the still-running activity frame so
+            // the row shows `tool   <arg>` (and a populated Parameters tab)
+            // live, instead of a bare tool name until the result lands.
+            let running = display_previews.running_input(activity.invocation_id);
             CapabilityActivityView::new(CapabilityActivityViewInput {
                 invocation_id: activity.invocation_id,
                 turn_run_id: activity
@@ -898,6 +903,8 @@ async fn runtime_payload_from_candidate(
                 process_id: activity.process_id,
                 output_bytes: activity.output_bytes,
                 error_kind: activity.error_kind,
+                subtitle: running.as_ref().and_then(|input| input.subtitle.clone()),
+                input_summary: running.and_then(|input| input.input_summary),
                 updated_at: activity.updated_at,
                 activity_order: Some(activity_order),
             })

--- a/crates/ironclaw_reborn_composition/src/projection/display_preview.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/display_preview.rs
@@ -32,6 +32,12 @@ pub(super) trait CapabilityDisplayPreviewSource: Send + Sync {
         activity: &CapabilityActivityProjection,
     ) -> Result<CapabilityDisplayPreviewResolution, ProductAdapterError>;
 
+    /// Input a still-running invocation should display inline, or `None` if the
+    /// invocation is not in-flight (or has no recorded input). Default `None`.
+    fn running_input(&self, _invocation_id: InvocationId) -> Option<CapabilityRunningInput> {
+        None
+    }
+
     #[cfg(test)]
     async fn preview(
         &self,
@@ -73,6 +79,18 @@ pub(crate) struct CapabilityDisplayPreviewStore {
 struct CapabilityDisplayPendingInputs {
     by_ref: HashMap<String, CapabilityDisplayInputPreview>,
     refs_by_run: HashMap<String, Vec<String>>,
+    /// `invocation_id -> input_ref`, established when the invocation starts
+    /// executing (the activity frame only knows the invocation id, but the
+    /// input was recorded under its ref at registration). Lets the
+    /// still-running activity frame surface the input before the result lands.
+    input_ref_by_invocation: HashMap<String, String>,
+}
+
+/// The input a still-running invocation shows in its activity row.
+#[derive(Debug, Clone, Default)]
+pub(super) struct CapabilityRunningInput {
+    pub(super) subtitle: Option<String>,
+    pub(super) input_summary: Option<String>,
 }
 
 #[derive(Default)]
@@ -173,6 +191,20 @@ impl CapabilityDisplayPreviewStore {
             .push(input_ref);
     }
 
+    /// Link a now-running invocation to the ref its input was recorded under,
+    /// so the running activity frame can surface that input before completion.
+    pub(crate) fn record_running_invocation(
+        &self,
+        invocation_id: InvocationId,
+        input_ref: &CapabilityInputRef,
+    ) {
+        if let Ok(mut pending) = self.pending.lock() {
+            pending
+                .input_ref_by_invocation
+                .insert(invocation_id.to_string(), input_ref.as_str().to_string());
+        }
+    }
+
     #[cfg(test)]
     pub(crate) fn record_result(&self, result: CapabilityDisplayPreviewResult<'_>) {
         self.record_result_with_preview(result, None);
@@ -183,10 +215,15 @@ impl CapabilityDisplayPreviewStore {
         result: CapabilityDisplayPreviewResult<'_>,
         display_preview: Option<&CapabilityDisplayOutputPreview>,
     ) {
-        let input = self
-            .lock_pending_inputs()
-            .by_ref
-            .remove(result.input_ref.as_str());
+        let input = {
+            let mut pending = self.lock_pending_inputs();
+            // The result has landed: drop the running-input link so the
+            // activity frame stops surfacing it as in-flight.
+            pending
+                .input_ref_by_invocation
+                .remove(&result.invocation_id.to_string());
+            pending.by_ref.remove(result.input_ref.as_str())
+        };
         let title = input
             .as_ref()
             .map(|input| input.title.clone())
@@ -223,9 +260,13 @@ impl CapabilityDisplayPreviewStore {
     pub(crate) fn prune_run(&self, run_id: &str) {
         let mut pending = self.lock_pending_inputs();
         if let Some(input_refs) = pending.refs_by_run.remove(run_id) {
-            for input_ref in input_refs {
-                pending.by_ref.remove(&input_ref);
+            let pruned: std::collections::HashSet<String> = input_refs.into_iter().collect();
+            for input_ref in &pruned {
+                pending.by_ref.remove(input_ref);
             }
+            pending
+                .input_ref_by_invocation
+                .retain(|_, input_ref| !pruned.contains(input_ref));
         }
         drop(pending);
 
@@ -266,6 +307,18 @@ impl CapabilityDisplayPreviewSource for CapabilityDisplayPreviewStore {
         activity: &CapabilityActivityProjection,
     ) -> Result<CapabilityDisplayPreviewResolution, ProductAdapterError> {
         capability_display_preview_resolution_from_store(self, activity)
+    }
+
+    fn running_input(&self, invocation_id: InvocationId) -> Option<CapabilityRunningInput> {
+        let pending = self.pending.lock().ok()?;
+        let input_ref = pending
+            .input_ref_by_invocation
+            .get(&invocation_id.to_string())?;
+        let input = pending.by_ref.get(input_ref)?;
+        Some(CapabilityRunningInput {
+            subtitle: input.subtitle.clone(),
+            input_summary: input.input_summary.clone(),
+        })
     }
 }
 

--- a/crates/ironclaw_reborn_composition/src/projection/display_preview.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/display_preview.rs
@@ -158,7 +158,7 @@ impl CapabilityDisplayPreviewStore {
         let input_summary = input_summary(tool_name, arguments);
         let input = CapabilityDisplayInputPreview {
             title: bounded_display_text(tool_name, CAPABILITY_DISPLAY_SUMMARY_MAX_BYTES).text,
-            subtitle: safe_path_subtitle(arguments),
+            subtitle: primary_arg_subtitle(tool_name, arguments),
             truncated: input_summary
                 .as_ref()
                 .is_some_and(|summary| summary.truncated),
@@ -732,6 +732,56 @@ fn safe_path_subtitle(value: &serde_json::Value) -> Option<String> {
         .or_else(|| value.get("target"))?
         .as_str()?;
     safe_display_path(path)
+}
+
+/// A compact, display-safe "primary argument" for the activity row's inline
+/// detail — the single most salient input for a tool, so the row reads like
+/// `nearai.web_search   <query>` / `shell   <command>` / `read_file   <path>`
+/// instead of a bare tool name. Reuses the same sanitizing formatters as
+/// `input_summary` (URL stripping, shell redaction, byte bounds) and falls back
+/// to the path subtitle for tools without a recognized primary argument.
+fn primary_arg_subtitle(capability_id: &str, value: &serde_json::Value) -> Option<String> {
+    // Search-shaped tools → the query string.
+    if (capability_matches(capability_id, "memory_search")
+        || capability_id == "web_search"
+        || capability_id == "llm_context"
+        || capability_id.ends_with(".web_search")
+        || capability_id.ends_with(".search")
+        || capability_id == "web-access.search"
+        || capability_id == "nearai.web_search")
+        && let Some(query) = string_arg(value, &["query", "q", "text", "pattern"])
+    {
+        return non_empty(bounded_summary_value(query).text);
+    }
+
+    // Shell → the command (with the existing secret-redacting formatter).
+    if capability_matches(capability_id, "shell")
+        && let Some(command) = string_arg(value, &["command"])
+    {
+        return non_empty(shell_command_display_text(command).text);
+    }
+
+    // HTTP / fetch → the URL (sensitive parts stripped).
+    if (capability_matches(capability_id, "http")
+        || capability_matches(capability_id, "http.save")
+        || capability_id == "web_fetch"
+        || capability_id.ends_with(".web_fetch")
+        || capability_id == "web-access.get_content")
+        && let Some(url) = string_arg(value, &["url"])
+    {
+        return non_empty(safe_url_display(url).text);
+    }
+
+    // Glob / grep → the pattern.
+    if (capability_matches(capability_id, "glob") || capability_matches(capability_id, "grep"))
+        && let Some(pattern) = string_arg(value, &["pattern"])
+    {
+        return non_empty(bounded_summary_value(pattern).text);
+    }
+
+    // Everything else (read_file, write_file, list_dir, apply_patch, memory_*)
+    // → the path/target.
+    safe_path_subtitle(value)
 }
 
 /// Returns `true` when the path contains characters that are inherently unsafe

--- a/crates/ironclaw_reborn_composition/src/projection/display_preview.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/display_preview.rs
@@ -134,7 +134,7 @@ pub(crate) struct CapabilityDisplayPreviewResult<'a> {
 impl CapabilityDisplayPreviewStore {
     fn lock_pending_inputs(&self) -> MutexGuard<'_, CapabilityDisplayPendingInputs> {
         self.pending.lock().unwrap_or_else(|poisoned| {
-            tracing::warn!(
+            tracing::debug!(
                 "capability display preview pending input store was poisoned; recovering"
             );
             poisoned.into_inner()
@@ -143,7 +143,7 @@ impl CapabilityDisplayPreviewStore {
 
     fn lock_completed_previews(&self) -> MutexGuard<'_, CapabilityDisplayCompletedPreviews> {
         self.completed.lock().unwrap_or_else(|poisoned| {
-            tracing::warn!(
+            tracing::debug!(
                 "capability display preview completed preview store was poisoned; recovering"
             );
             poisoned.into_inner()
@@ -198,11 +198,10 @@ impl CapabilityDisplayPreviewStore {
         invocation_id: InvocationId,
         input_ref: &CapabilityInputRef,
     ) {
-        if let Ok(mut pending) = self.pending.lock() {
-            pending
-                .input_ref_by_invocation
-                .insert(invocation_id.to_string(), input_ref.as_str().to_string());
-        }
+        let mut pending = self.lock_pending_inputs();
+        pending
+            .input_ref_by_invocation
+            .insert(invocation_id.to_string(), input_ref.as_str().to_string());
     }
 
     #[cfg(test)]
@@ -310,7 +309,7 @@ impl CapabilityDisplayPreviewSource for CapabilityDisplayPreviewStore {
     }
 
     fn running_input(&self, invocation_id: InvocationId) -> Option<CapabilityRunningInput> {
-        let pending = self.pending.lock().ok()?;
+        let pending = self.lock_pending_inputs();
         let input_ref = pending
             .input_ref_by_invocation
             .get(&invocation_id.to_string())?;
@@ -796,12 +795,9 @@ fn safe_path_subtitle(value: &serde_json::Value) -> Option<String> {
 fn primary_arg_subtitle(capability_id: &str, value: &serde_json::Value) -> Option<String> {
     // Search-shaped tools → the query string.
     if (capability_matches(capability_id, "memory_search")
-        || capability_id == "web_search"
-        || capability_id == "llm_context"
-        || capability_id.ends_with(".web_search")
-        || capability_id.ends_with(".search")
-        || capability_id == "web-access.search"
-        || capability_id == "nearai.web_search")
+        || capability_matches(capability_id, "web_search")
+        || capability_matches(capability_id, "search")
+        || capability_matches(capability_id, "llm_context"))
         && let Some(query) = string_arg(value, &["query", "q", "text", "pattern"])
     {
         return non_empty(bounded_summary_value(query).text);
@@ -817,9 +813,8 @@ fn primary_arg_subtitle(capability_id: &str, value: &serde_json::Value) -> Optio
     // HTTP / fetch → the URL (sensitive parts stripped).
     if (capability_matches(capability_id, "http")
         || capability_matches(capability_id, "http.save")
-        || capability_id == "web_fetch"
-        || capability_id.ends_with(".web_fetch")
-        || capability_id == "web-access.get_content")
+        || capability_matches(capability_id, "web_fetch")
+        || capability_matches(capability_id, "get_content"))
         && let Some(url) = string_arg(value, &["url"])
     {
         return non_empty(safe_url_display(url).text);

--- a/crates/ironclaw_reborn_composition/src/projection/live_progress.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/live_progress.rs
@@ -145,6 +145,7 @@ impl LiveProjectionPublisher {
 }
 
 pub(super) fn product_items_for_live_update(
+    display_previews: &dyn super::display_preview::CapabilityDisplayPreviewSource,
     update: &ThreadLiveProjectionUpdate,
 ) -> Vec<ProductProjectionItem> {
     update
@@ -162,31 +163,36 @@ pub(super) fn product_items_for_live_update(
                 run_id,
                 invocation_id,
                 capability_id,
-            } => match CapabilityActivityView::new(CapabilityActivityViewInput {
-                invocation_id: *invocation_id,
-                turn_run_id: Some(*run_id),
-                thread_id: Some(update.thread_id.clone()),
-                capability_id: capability_id.clone(),
-                status: CapabilityActivityStatusView::Started,
-                provider: None,
-                runtime: None,
-                process_id: None,
-                output_bytes: None,
-                error_kind: None,
-                updated_at: Utc::now(),
-                activity_order: None,
-            }) {
-                Ok(activity) => Some(ProductProjectionItem::CapabilityActivity(activity)),
-                Err(error) => {
-                    tracing::debug!(
-                        error = %error,
-                        invocation_id = %invocation_id,
-                        capability_id = %capability_id,
-                        "live capability activity rejected by product adapter boundary"
-                    );
-                    None
+            } => {
+                let running = display_previews.running_input(*invocation_id);
+                match CapabilityActivityView::new(CapabilityActivityViewInput {
+                    invocation_id: *invocation_id,
+                    turn_run_id: Some(*run_id),
+                    thread_id: Some(update.thread_id.clone()),
+                    capability_id: capability_id.clone(),
+                    status: CapabilityActivityStatusView::Started,
+                    provider: None,
+                    runtime: None,
+                    process_id: None,
+                    output_bytes: None,
+                    error_kind: None,
+                    subtitle: running.as_ref().and_then(|input| input.subtitle.clone()),
+                    input_summary: running.and_then(|input| input.input_summary),
+                    updated_at: Utc::now(),
+                    activity_order: None,
+                }) {
+                    Ok(activity) => Some(ProductProjectionItem::CapabilityActivity(activity)),
+                    Err(error) => {
+                        tracing::debug!(
+                            error = %error,
+                            invocation_id = %invocation_id,
+                            capability_id = %capability_id,
+                            "live capability activity rejected by product adapter boundary"
+                        );
+                        None
+                    }
                 }
-            },
+            }
             ThreadLiveProjectionItem::WorkSummary {
                 id,
                 run_id,

--- a/crates/ironclaw_reborn_composition/src/projection/tests/display_preview.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/tests/display_preview.rs
@@ -469,6 +469,65 @@ async fn capability_display_preview_store_summarizes_search_and_memory_inputs() 
 }
 
 #[tokio::test]
+async fn running_input_surfaces_staged_input_until_result_lands() {
+    let run_id = TurnRunId::new();
+    let input_ref = preview_input_ref("running-web-search");
+    let invocation_id = InvocationId::new();
+    let store = CapabilityDisplayPreviewStore::default();
+
+    // Nothing to show before the invocation is linked to its input.
+    assert!(store.running_input(invocation_id).is_none());
+
+    store.record_input(
+        &run_id.to_string(),
+        &input_ref,
+        "nearai.web_search",
+        &serde_json::json!({"query": "deploy status token: sk-secret", "limit": 5}),
+    );
+    store.record_running_invocation(invocation_id, &input_ref);
+
+    // While running, the inline subtitle and parameters are surfaced — and they
+    // carry the same projection-sanitized text the preview frame uses, so the
+    // secret never reaches the activity frame.
+    let running = store.running_input(invocation_id).expect("running input");
+    assert!(
+        running
+            .subtitle
+            .as_deref()
+            .is_some_and(|s| s.contains("deploy status")),
+        "subtitle should carry the query, got {:?}",
+        running.subtitle,
+    );
+    assert!(
+        running
+            .input_summary
+            .as_deref()
+            .is_some_and(|s| s.contains("query: deploy status")),
+    );
+    assert!(!running.subtitle.as_deref().unwrap().contains("sk-secret"));
+    assert!(
+        !running
+            .input_summary
+            .as_deref()
+            .unwrap()
+            .contains("sk-secret")
+    );
+
+    // Once the result lands, the pending input is consumed and no longer
+    // surfaced as in-flight (the completed preview takes over).
+    store.record_result(CapabilityDisplayPreviewResult {
+        run_id: &run_id.to_string(),
+        input_ref: &input_ref,
+        invocation_id,
+        capability_id: &CapabilityId::new("nearai.web_search").unwrap(),
+        result_ref: "result:running",
+        output: &serde_json::json!({"results": []}),
+        output_bytes: 12,
+    });
+    assert!(store.running_input(invocation_id).is_none());
+}
+
+#[tokio::test]
 async fn capability_display_preview_store_uses_primary_arg_subtitle_for_non_path_tools() {
     // shell → the command (the inline row reads `shell   <command>`).
     let shell = completed_preview_for_input(

--- a/crates/ironclaw_reborn_composition/src/projection/tests/display_preview.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/tests/display_preview.rs
@@ -444,6 +444,12 @@ async fn capability_display_preview_store_summarizes_search_and_memory_inputs() 
     assert!(search_summary.contains("query: deployment status token: [redacted]"));
     assert!(search_summary.contains("limit: 5"));
     assert!(!search_summary.contains("sk-secret"));
+    // The inline row subtitle is the primary argument (the query), redacted
+    // the same way the summary is — so the row reads `web_search   <query>`
+    // instead of a bare tool name.
+    let search_subtitle = search_preview.subtitle.as_deref().unwrap();
+    assert!(search_subtitle.contains("deployment status"));
+    assert!(!search_subtitle.contains("sk-secret"));
 
     let memory_preview = completed_preview_for_input(
         "builtin.memory_write",
@@ -460,6 +466,49 @@ async fn capability_display_preview_store_summarizes_search_and_memory_inputs() 
     assert!(memory_summary.contains("append: true"));
     assert!(memory_summary.contains("content_bytes: 16"));
     assert!(!memory_summary.contains("sk-secret"));
+}
+
+#[tokio::test]
+async fn capability_display_preview_store_uses_primary_arg_subtitle_for_non_path_tools() {
+    // shell → the command (the inline row reads `shell   <command>`).
+    let shell = completed_preview_for_input(
+        "shell",
+        "builtin.shell",
+        serde_json::json!({"command": "cargo test -p ironclaw"}),
+    )
+    .await;
+    assert!(
+        shell
+            .subtitle
+            .as_deref()
+            .is_some_and(|s| s.contains("cargo test")),
+        "shell subtitle should carry the command, got {:?}",
+        shell.subtitle,
+    );
+
+    // http / web_fetch → the URL (sensitive parts stripped).
+    let http = completed_preview_for_input(
+        "web_fetch",
+        "builtin.web_fetch",
+        serde_json::json!({"url": "https://example.com/docs"}),
+    )
+    .await;
+    assert!(
+        http.subtitle
+            .as_deref()
+            .is_some_and(|s| s.contains("example.com")),
+        "web_fetch subtitle should carry the url, got {:?}",
+        http.subtitle,
+    );
+
+    // Path-based tools keep the workspace-relative path subtitle.
+    let read = completed_preview_for_input(
+        "read_file",
+        "builtin.read_file",
+        serde_json::json!({"path": "/workspace/src/main.rs"}),
+    )
+    .await;
+    assert_eq!(read.subtitle.as_deref(), Some("src/main.rs"));
 }
 
 #[tokio::test]

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev.rs
@@ -577,6 +577,16 @@ impl LoopCapabilityResultWriter for LocalDevCapabilityIo {
         Ok((result_ref, output_bytes))
     }
 
+    fn record_running_invocation(
+        &self,
+        _run_context: &LoopRunContext,
+        invocation_id: InvocationId,
+        input_ref: &CapabilityInputRef,
+    ) {
+        self.display_previews
+            .record_running_invocation(invocation_id, input_ref);
+    }
+
     async fn update_capability_result(
         &self,
         run_context: &LoopRunContext,

--- a/crates/ironclaw_webui_v2/CLAUDE.md
+++ b/crates/ironclaw_webui_v2/CLAUDE.md
@@ -219,10 +219,18 @@ The per-poll ownership probe goes through `SessionThreadService::read_thread`
 not reload the full message transcript every second.
 
 `capability_activity` SSE frames are projection-derived lifecycle metadata for
-tool/capability execution. They expose only the safe activity DTO
+tool/capability execution. They expose the safe activity DTO
 (`invocation_id`, `capability_id`, status, provider/runtime/process metadata,
-byte counts, sanitized error kind, timestamp) and must not carry raw tool
-arguments, raw results, command strings, host paths, or provider payloads.
+byte counts, sanitized error kind, timestamp) plus — while the invocation is
+still running — the optional `subtitle` (inline primary argument) and
+`input_summary` (parameter summary). These two carry the **same bounded,
+sanitized input projection the `capability_display_preview` frame already
+exposes** (secret-redacted via `sanitize_text`, host paths rejected/relativized,
+URLs stripped, byte-bounded); they exist so the running tool row can show
+`tool   <arg>` before the result lands instead of a bare tool name. They must
+never carry the *raw, unsanitized* tool arguments, raw results, host paths, or
+provider payloads — only the projection-sanitized summaries. Full output stays
+behind the scoped `result_ref` fetch path.
 
 `capability_display_preview` SSE frames are separate sanitized display artifacts
 for WebUI tool blocks. They may carry bounded summaries/previews only: summaries

--- a/crates/ironclaw_webui_v2/tests/webui_v2_handlers_contract.rs
+++ b/crates/ironclaw_webui_v2/tests/webui_v2_handlers_contract.rs
@@ -3583,6 +3583,8 @@ fn make_capability_activity_envelope(cursor: &str) -> ProductOutboundEnvelope {
             process_id: None,
             output_bytes: None,
             error_kind: None,
+            subtitle: None,
+            input_summary: None,
             updated_at: chrono::Utc::now(),
             activity_order: None,
         }),

--- a/crates/ironclaw_webui_v2/tests/webui_v2_schema_contract.rs
+++ b/crates/ironclaw_webui_v2/tests/webui_v2_schema_contract.rs
@@ -42,6 +42,8 @@ fn capability_activity() -> CapabilityActivityView {
         process_id: None,
         output_bytes: None,
         error_kind: None,
+        subtitle: Some("src/main.rs".to_string()),
+        input_summary: Some("path: src/main.rs".to_string()),
         updated_at: Utc::now(),
         activity_order: Some(42),
     }

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/history-messages.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/history-messages.js
@@ -208,9 +208,11 @@ export function toolCardFromPreview(preview) {
 }
 
 // Map a `CapabilityActivityView` (SSE lifecycle frame) into the same
-// card shape. Activity frames carry only metadata — no title, no
-// parameters, no output — so the resulting card is intentionally
-// sparse and is meant to be enriched by the next preview frame.
+// card shape. While the invocation is still running the backend now
+// carries the staged input on the activity frame (`subtitle` =
+// inline primary argument, `input_summary` = parameters), so the row
+// shows `tool   <arg>` live instead of a bare name. Output fields stay
+// empty until the preview frame lands at completion.
 export function toolCardFromActivity(activity) {
   const activityOrder = numericActivityOrder(activity.activity_order);
   return {
@@ -219,8 +221,8 @@ export function toolCardFromActivity(activity) {
     capabilityId: activity.capability_id || null,
     toolName: toolDisplayName(activity.capability_id) || "tool",
     toolStatus: toolStatusFromActivityStatus(activity.status),
-    toolDetail: null,
-    toolParameters: null,
+    toolDetail: activity.subtitle || null,
+    toolParameters: activity.input_summary || null,
     toolResultPreview: null,
     toolError: activity.error_kind || null,
     toolDurationMs: null,

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/useChatEvents.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/useChatEvents.js
@@ -665,3 +665,35 @@ function isLocallyResolvedGate(locallyResolvedGatesRef, runId, gateRef) {
   if (!runId || !gateRef) return false;
   return Boolean(locallyResolvedGatesRef?.current?.has(`${runId}\n${gateRef}`));
 }
+
+function upsertToolFromActivity(setMessages, invocationId, card) {
+  const id = `tool-${invocationId}`;
+  setMessages((prev) => {
+    const existing = prev.findIndex((m) => m.id === id);
+    if (existing >= 0) {
+      const current = prev[existing];
+      // A late lifecycle frame can carry `running` after the preview
+      // already set `success` / `error`. Don't downgrade terminal
+      // state — but do let the next terminal state through.
+      const nextStatus =
+        isTerminalToolStatus(current.toolStatus) && card.toolStatus === "running"
+          ? current.toolStatus
+          : card.toolStatus;
+      const copy = [...prev];
+      copy[existing] = {
+        ...current,
+        toolStatus: nextStatus,
+        toolError: card.toolError || current.toolError,
+        // Enrich with the live input if a later frame carries it and the
+        // current card doesn't yet (e.g. the first frame raced ahead of the
+        // input link). Never clobber a populated value with null.
+        toolDetail: current.toolDetail || card.toolDetail || null,
+        toolParameters: current.toolParameters || card.toolParameters || null,
+        updatedAt: card.updatedAt || current.updatedAt,
+        turnRunId: card.turnRunId || current.turnRunId || null,
+      };
+      return copy;
+    }
+    return [...prev, { id, role: "tool_activity", ...card }];
+  });
+}


### PR DESCRIPTION
## What

Closes #4852

Completes the Activity-view tool-argument work: the inline argument (and the Parameters tab) now appear **while the tool is still running**, not only after it finishes.

```
● run  nearai.web_search   climate policy 2026      ← live, during the run
● ok   nearai.web_search   climate policy 2026      ← after completion
```

Previously the argument only landed with the terminal-gated `capability_display_preview` frame, so the running row showed a bare tool name.

## Why it was hard

The during-run frame is `capability_activity`, which only knows the `invocation_id`; the input was recorded under a separate `input_ref` at registration, and the two were only linked at result time (too late). Also, the `capability_activity` frame is documented as lifecycle-only.

## Mechanism

- **Link at invoke time.** The display-preview store already records each tool's input (sanitized subtitle + parameter summary) at registration. A new `invocation_id → input_ref` link is recorded when the invocation starts executing — the one point in `invoke_capability` where the port has both ids — exposed via `running_input`. `LoopCapabilityResultWriter::record_running_invocation` (default no-op) drives it; both composition adapters implement it. The link is cleared when the result lands (the completed preview takes over).
- **Carry on the activity frame.** `CapabilityActivityView` gains optional `subtitle`/`input_summary`, populated from `running_input` in both the runtime and live-progress projections.
- **Frontend.** `toolCardFromActivity` renders them, and the activity upsert carries them forward so a frame that races ahead of the link still enriches.

## Security / contract

These fields carry the **same projection-sanitized, byte-bounded, secret-redacted** summaries the `capability_display_preview` frame *already* sends to the browser — just delivered during the run instead of only after. So no new data reaches the client.

This is a **deliberate, documented extension** of the `capability_activity` contract (the frame was previously lifecycle-only). The `ironclaw_webui_v2` CLAUDE.md is updated to describe the new sanitized fields and the guarantee that raw/unsanitized args still never appear. A regression test asserts a secret-bearing query is redacted in both `subtitle` and `input_summary`. *(Flagging for reviewer attention — this is the one judgment call in the PR.)*

## Relationship to other PRs

This branch cherry-picks #5012 (capability-id keying) and #5023 (primary-argument subtitle) so it works as one unit. Merge order if taken separately: #5012 → #5023 → this. If this lands first, it supersedes both.

## Tests / gate

- `running_input_surfaces_staged_input_until_result_lands` — surfaced while running, consumed at result, secret redacted.
- Wire round-trip + webui_v2 schema/handler contracts updated for the new fields.
- `cargo fmt`, `cargo clippy -p ironclaw_product_adapters -p ironclaw_loop_support -p ironclaw_reborn_composition -p ironclaw_webui_v2 --tests -- -D warnings`, and the affected suites pass. (A pre-existing `product_adapter_contract.rs` inference failure is unrelated — it fails identically on the clean tree.)