### PR TITLE
[codex] Suppress stale extension search credential prompts

### DIFF
--- a/crates/ironclaw_reborn_composition/src/extension_lifecycle.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_lifecycle.rs
@@ -13,9 +13,9 @@ use ironclaw_host_api::{
     sha256_digest_token,
 };
 use ironclaw_product_workflow::{
-    LifecycleInstalledExtensionSummary, LifecyclePackageKind, LifecyclePackageRef, LifecyclePhase,
-    LifecycleProductPayload, LifecycleProductResponse, LifecycleSearchExtensionSummary,
-    ProductWorkflowError,
+    LifecycleExtensionSummary, LifecycleInstalledExtensionSummary, LifecyclePackageKind,
+    LifecyclePackageRef, LifecyclePhase, LifecycleProductPayload, LifecycleProductResponse,
+    LifecycleSearchExtensionSummary, ProductWorkflowError,
 };
 use tokio::sync::Mutex;
 
@@ -311,6 +311,7 @@ impl RebornLocalExtensionManagementPort {
         credential_gate: Option<&RuntimeExtensionActivationCredentialGate>,
     ) -> Result<LifecycleSearchExtensionSummary, ProductWorkflowError> {
         let mut summary = extension.summary();
+        suppress_search_credential_onboarding(&mut summary);
         let Some(installation) = self.search_installation(&extension.package.id).await? else {
             return Ok(LifecycleSearchExtensionSummary {
                 summary,
@@ -318,10 +319,6 @@ impl RebornLocalExtensionManagementPort {
             });
         };
         let phase = search_installation_phase(extension, &installation, credential_gate).await?;
-        if search_setup_is_complete(phase) {
-            summary.credential_requirements.clear();
-            summary.onboarding = None;
-        }
         Ok(LifecycleSearchExtensionSummary {
             summary,
             installation_phase: Some(phase),
@@ -571,7 +568,7 @@ impl RebornLocalExtensionManagementPort {
             },
         );
         response.message = Some(
-            "Extension activation succeeded and its tools are now available. No additional authorization or configuration is needed unless a later tool call reports auth_required."
+            "Extension activation succeeded and its tools are now available. No additional authorization or configuration is needed, including for write-capable tools, unless a later tool call reports auth_required. Do not ask the user for a token, OAuth, authorization, or configuration after activated=true."
                 .to_string(),
         );
         Ok(response)
@@ -1216,14 +1213,9 @@ async fn search_credentials_configured(
         .is_empty())
 }
 
-fn search_setup_is_complete(phase: LifecyclePhase) -> bool {
-    matches!(
-        phase,
-        LifecyclePhase::Configured
-            | LifecyclePhase::Activating
-            | LifecyclePhase::Active
-            | LifecyclePhase::Disabled
-    )
+fn suppress_search_credential_onboarding(summary: &mut LifecycleExtensionSummary) {
+    summary.credential_requirements.clear();
+    summary.onboarding = None;
 }
 
 fn extension_search_has_ready_result(payload: Option<&LifecycleProductPayload>) -> bool {

--- a/crates/ironclaw_reborn_composition/src/extension_lifecycle_capabilities.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_lifecycle_capabilities.rs
@@ -69,7 +69,7 @@ fn manifests() -> Result<Vec<CapabilityManifest>, ExtensionError> {
         )?,
         lifecycle_manifest(
             EXTENSION_ACTIVATE_CAPABILITY_ID,
-            "Activate an installed Reborn extension for the model-visible local-dev capability surface. Use after install succeeds or when install reports the extension is already installed. This is the step that opens the credential/auth gate when required; do not ask the user for credentials before calling it. If activation returns activated=true, the extension is ready; ignore earlier search onboarding or credential hints from this turn unless a later tool call raises auth_required.",
+            "Activate an installed Reborn extension for the model-visible local-dev capability surface. Use after install succeeds or when install reports the extension is already installed. This is the step that opens the credential/auth gate when required; do not ask the user for credentials before calling it. If activation returns activated=true, the extension is ready for read and write-capable tools; ignore earlier search/install onboarding or credential hints from this turn unless a later tool call raises auth_required.",
             vec![
                 EffectKind::ReadFilesystem,
                 EffectKind::WriteFilesystem,
@@ -348,7 +348,8 @@ mod tests {
                 && activate.description.contains("activated=true")
                 && activate
                     .description
-                    .contains("ignore earlier search onboarding"),
+                    .contains("ignore earlier search/install onboarding")
+                && activate.description.contains("write-capable tools"),
             "extension_activate description should teach the model to raise auth through activation: {}",
             activate.description
         );
@@ -509,6 +510,30 @@ mod tests {
         .await
         .expect("local-dev services build");
 
+        let available_search = invoke_json(
+            &services,
+            EXTENSION_SEARCH_CAPABILITY_ID,
+            serde_json::json!({"query": "github"}),
+        )
+        .await
+        .expect("available search succeeds");
+        let available_extensions = available_search["payload"]["extensions"]
+            .as_array()
+            .expect("extensions array");
+        let available_github = available_extensions
+            .iter()
+            .find(|extension| extension["package_ref"]["id"] == "github")
+            .expect("github search result");
+        assert_eq!(available_github.get("installation_phase"), None);
+        assert!(
+            available_github.get("credential_requirements").is_none(),
+            "available GitHub model-visible search results must not expose PAT requirements before activation"
+        );
+        assert!(
+            available_github.get("onboarding").is_none(),
+            "available GitHub model-visible search results must not expose PAT setup onboarding before activation"
+        );
+
         invoke_json(
             &services,
             EXTENSION_INSTALL_CAPABILITY_ID,
@@ -533,12 +558,12 @@ mod tests {
             .expect("github search result");
         assert_eq!(installed_github["installation_phase"], "installed");
         assert!(
-            installed_github.get("credential_requirements").is_some(),
-            "installed inactive GitHub model-visible search results should expose PAT requirements"
+            installed_github.get("credential_requirements").is_none(),
+            "installed inactive GitHub model-visible search results must not expose stale PAT requirements before activation"
         );
         assert!(
-            installed_github.get("onboarding").is_some(),
-            "installed inactive GitHub model-visible search results should retain setup onboarding"
+            installed_github.get("onboarding").is_none(),
+            "installed inactive GitHub model-visible search results must not expose stale PAT setup onboarding before activation"
         );
 
         let activate_context = execution_context([EXTENSION_ACTIVATE_CAPABILITY_ID]);


### PR DESCRIPTION
## Summary
- Make `extension_search` discovery-only by stripping credential requirements/onboarding from model-facing search results.
- Strengthen activation success copy so `activated=true` explicitly covers write-capable tools and tells the model not to ask for token/OAuth/config unless a later tool reports `auth_required`.
- Add regression coverage for available, installed, configured, and active GitHub search results plus activation descriptor/message behavior.

## Root Cause
After #5034, activation correctly succeeded and reported that no additional authorization was needed, but earlier same-turn `extension_search`/installed search results could still carry GitHub PAT onboarding. The model combined that stale setup copy with the activation success and added a bogus “PAT for write operations” caveat. Search should only discover extensions; activation/tool execution should be the only place that asks for credentials.

## Validation
- `cargo fmt --all --check`
- `cargo test -p ironclaw_reborn_composition --lib local_dev_extension_search_hides_onboarding_after_credentialed_activation`
- `cargo test -p ironclaw_reborn_composition --lib local_dev_extension_lifecycle_tools_manage_visible_extension_surface`
- `cargo test -p ironclaw_reborn_composition --lib local_dev_agent_surface_exposes_extension_lifecycle_tools`
- `cargo test -p ironclaw_reborn_composition --lib local_dev_extension_activate_returns_auth_gate_when_account_lacks_required_scope`
