### PR TITLE
fix(turn-scheduler): self-healing drain so the runner can't wedge under load

### DIFF
--- a/crates/ironclaw_host_runtime/Cargo.toml
+++ b/crates/ironclaw_host_runtime/Cargo.toml
@@ -70,7 +70,7 @@ hex = "0.4"
 ironclaw_event_projections = { path = "../ironclaw_event_projections" }
 sha2 = "0.10"
 tempfile = "3"
-tokio = { version = "1", features = ["macros", "rt", "sync", "time"] }
+tokio = { version = "1", features = ["macros", "rt", "sync", "test-util", "time"] }
 tokio-postgres = "0.7"
 zeroize = "1"
 wat = "1.245.1"

--- a/crates/ironclaw_host_runtime/src/turn_scheduler.rs
+++ b/crates/ironclaw_host_runtime/src/turn_scheduler.rs
@@ -1,4 +1,4 @@
-use std::{error::Error, fmt, panic::AssertUnwindSafe, sync::Arc, time::Duration};
+use std::{error::Error, fmt, panic::AssertUnwindSafe, pin::Pin, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use chrono::Utc;
@@ -14,7 +14,7 @@ use ironclaw_turns::{
 use tokio::{
     sync::{Semaphore, mpsc},
     task::{JoinHandle, JoinSet},
-    time::{MissedTickBehavior, interval, sleep},
+    time::{Instant, MissedTickBehavior, Sleep, interval, sleep_until},
 };
 use tracing::debug;
 
@@ -229,7 +229,6 @@ impl TurnRunSchedulerHandle {
 enum SchedulerCommand {
     Wake(TurnRunWake),
     Drain,
-    RetryDrain,
     Shutdown,
 }
 
@@ -264,67 +263,49 @@ async fn run_scheduler_loop(
         config,
         runner_id,
     };
-    let mut claim_retry_pending = false;
+    // Single in-loop retry for claim-store errors. `retry_at` is the logical state
+    // (`Some` = a retry is pending, which also coalesces wakes); `retry_timer` is a
+    // pinned `Sleep` kept in lockstep with it via `arm_retry`. Keeping the timer
+    // inside the `select!` (vs the old detached `RetryDrain` task) means it cannot
+    // be lost to a runtime/shutdown race — the original wedge — and the single
+    // deadline means a sustained outage cannot compound retries into a thundering
+    // herd. Pinning + `reset` avoids rebuilding the timer future every iteration.
+    let mut retry_at: Option<Instant> = None;
+    let retry_timer = sleep_until(Instant::now());
+    tokio::pin!(retry_timer);
 
     loop {
         tokio::select! {
             Some(command) = command_rx.recv() => {
                 match command {
                     SchedulerCommand::Wake(wake) => {
-                        // Prefer the woken scope for locality; if that scope has no
-                        // claimable work, fall back to the global queue below.
-                        if !claim_retry_pending
-                            && drain_queued_runs(
+                        // Prefer the woken scope for locality; fall back to the
+                        // global queue. Skip entirely while a retry is pending so a
+                        // wake storm coalesces behind the single scheduled retry.
+                        if retry_at.is_none() {
+                            let claim_errored = drain_queued_runs(
                                 &context,
                                 Some(wake.scope),
                                 &mut executor_tasks,
-                            ).await
-                        {
-                            claim_retry_pending = true;
-                            schedule_drain_after(
-                                context.command_tx.clone(),
-                                context.config.claim_error_backoff(),
-                            );
-                        }
-                        if !claim_retry_pending
-                            && drain_queued_runs(
-                                &context,
-                                None,
-                                &mut executor_tasks,
-                            ).await
-                        {
-                            claim_retry_pending = true;
-                            schedule_drain_after(
-                                context.command_tx.clone(),
-                                context.config.claim_error_backoff(),
-                            );
+                            )
+                            .await
+                                || drain_queued_runs(&context, None, &mut executor_tasks).await;
+                            if claim_errored {
+                                arm_retry(
+                                    &mut retry_at,
+                                    retry_timer.as_mut(),
+                                    context.config.claim_error_backoff(),
+                                );
+                            }
                         }
                     }
                     SchedulerCommand::Drain => {
-                        if !claim_retry_pending
-                            && drain_queued_runs(
-                                &context,
-                                None,
-                                &mut executor_tasks,
-                            ).await
+                        if retry_at.is_none()
+                            && drain_queued_runs(&context, None, &mut executor_tasks).await
                         {
-                            claim_retry_pending = true;
-                            schedule_drain_after(
-                                context.command_tx.clone(),
-                                context.config.claim_error_backoff(),
-                            );
-                        }
-                    }
-                    SchedulerCommand::RetryDrain => {
-                        claim_retry_pending = false;
-                        if drain_queued_runs(
-                            &context,
-                            None,
-                            &mut executor_tasks,
-                        ).await {
-                            claim_retry_pending = true;
-                            schedule_drain_after(
-                                context.command_tx.clone(),
+                            arm_retry(
+                                &mut retry_at,
+                                retry_timer.as_mut(),
                                 context.config.claim_error_backoff(),
                             );
                         }
@@ -332,22 +313,41 @@ async fn run_scheduler_loop(
                     SchedulerCommand::Shutdown => {
                         executor_tasks.shutdown().await;
                         break;
-                    },
+                    }
+                }
+            }
+            _ = &mut retry_timer, if retry_at.is_some() => {
+                // Scheduled backoff retry after a claim error. Re-drain and re-arm
+                // only if the claim errors again; a clean drain clears the retry.
+                // This single in-loop retry replaces the detached, losable
+                // RetryDrain timer, so a runtime/shutdown race can no longer strand
+                // the queue.
+                if drain_queued_runs(&context, None, &mut executor_tasks).await {
+                    arm_retry(
+                        &mut retry_at,
+                        retry_timer.as_mut(),
+                        context.config.claim_error_backoff(),
+                    );
+                } else {
+                    retry_at = None;
                 }
             }
             _ = poll_tick.tick() => {
-                if !claim_retry_pending
-                    && drain_queued_runs(
-                        &context,
-                        None,
-                        &mut executor_tasks,
-                    ).await
-                {
-                    claim_retry_pending = true;
-                    schedule_drain_after(
-                        context.command_tx.clone(),
-                        context.config.claim_error_backoff(),
-                    );
+                // Unconditional self-healing backstop: drain regardless of any
+                // pending retry. The retry timer cannot be lost, but the poll tick
+                // still guarantees forward progress if anything ever leaves a stale
+                // deadline. On a claim error arm a retry only if none is pending
+                // (keep the earlier deadline); a clean drain clears any pending one.
+                if drain_queued_runs(&context, None, &mut executor_tasks).await {
+                    if retry_at.is_none() {
+                        arm_retry(
+                            &mut retry_at,
+                            retry_timer.as_mut(),
+                            context.config.claim_error_backoff(),
+                        );
+                    }
+                } else {
+                    retry_at = None;
                 }
             }
             Some(result) = executor_tasks.join_next(), if !executor_tasks.is_empty() => {
@@ -360,6 +360,17 @@ async fn run_scheduler_loop(
             }
         }
     }
+}
+
+/// Arm (or re-arm) the single claim-error retry: compute the next deadline from
+/// `backoff`, reset the pinned timer to it, and record it in `retry_at`. Keeping
+/// the timer and `retry_at` in lockstep here is what lets the `select!` branch
+/// guard (`if retry_at.is_some()`) gate a reused `Sleep` without rebuilding the
+/// timer future every loop iteration.
+fn arm_retry(retry_at: &mut Option<Instant>, retry_timer: Pin<&mut Sleep>, backoff: Duration) {
+    let deadline = Instant::now() + backoff;
+    retry_timer.reset(deadline);
+    *retry_at = Some(deadline);
 }
 
 async fn drain_queued_runs(
@@ -539,12 +550,4 @@ async fn recover_expired_leases(transitions: Arc<dyn TurnRunTransitionPort>) {
     if let Err(error) = result {
         debug!(error = %error, "turn run scheduler lease recovery failed");
     }
-}
-
-fn schedule_drain_after(command_tx: mpsc::Sender<SchedulerCommand>, delay: Duration) {
-    // Best-effort timer: if shutdown closes the command channel first, send fails harmlessly.
-    tokio::spawn(async move {
-        sleep(delay).await;
-        let _ = command_tx.send(SchedulerCommand::RetryDrain).await;
-    });
 }

--- a/crates/ironclaw_host_runtime/tests/turn_scheduler_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/turn_scheduler_contract.rs
@@ -721,6 +721,184 @@ impl TurnRunTransitionPort for ClaimRecordingTransitions {
     }
 }
 
+/// Delegates every transition to a real store, but errors the first
+/// `remaining_failures` claim attempts to simulate a transient run-queue
+/// outage that arms the scheduler's claim-error retry deadline.
+struct FlakyClaimTransitions {
+    store: Arc<InMemoryTurnStateStore>,
+    remaining_failures: AtomicUsize,
+    claim_attempts: AtomicUsize,
+}
+
+impl FlakyClaimTransitions {
+    fn new(store: Arc<InMemoryTurnStateStore>, failures: usize) -> Self {
+        Self {
+            store,
+            remaining_failures: AtomicUsize::new(failures),
+            claim_attempts: AtomicUsize::new(0),
+        }
+    }
+
+    fn claim_attempts(&self) -> usize {
+        self.claim_attempts.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl TurnRunTransitionPort for FlakyClaimTransitions {
+    async fn claim_next_run(
+        &self,
+        request: ClaimRunRequest,
+    ) -> Result<Option<ClaimedTurnRun>, TurnError> {
+        self.claim_attempts.fetch_add(1, Ordering::SeqCst);
+        // fetch_update returns Err when already at zero; only fail while
+        // failures remain, then delegate to the real store.
+        if self
+            .remaining_failures
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                remaining.checked_sub(1)
+            })
+            .is_ok()
+        {
+            return Err(TurnError::Unavailable {
+                reason: "claim store transiently unavailable".to_string(),
+            });
+        }
+        self.store.claim_next_run(request).await
+    }
+
+    async fn heartbeat(
+        &self,
+        request: HeartbeatRequest,
+    ) -> Result<ironclaw_turns::EventCursor, TurnError> {
+        self.store.heartbeat(request).await
+    }
+
+    async fn recover_expired_leases(
+        &self,
+        request: RecoverExpiredLeasesRequest,
+    ) -> Result<RecoverExpiredLeasesResponse, TurnError> {
+        self.store.recover_expired_leases(request).await
+    }
+
+    async fn record_model_route_snapshot(
+        &self,
+        request: RecordModelRouteSnapshotRequest,
+    ) -> Result<TurnRunState, TurnError> {
+        self.store.record_model_route_snapshot(request).await
+    }
+
+    async fn block_run(&self, request: BlockRunRequest) -> Result<TurnRunState, TurnError> {
+        self.store.block_run(request).await
+    }
+
+    async fn complete_run(&self, request: CompleteRunRequest) -> Result<TurnRunState, TurnError> {
+        self.store.complete_run(request).await
+    }
+
+    async fn cancel_run(
+        &self,
+        request: CancelRunCompletionRequest,
+    ) -> Result<TurnRunState, TurnError> {
+        self.store.cancel_run(request).await
+    }
+
+    async fn fail_run(&self, request: FailRunRequest) -> Result<TurnRunState, TurnError> {
+        self.store.fail_run(request).await
+    }
+
+    async fn record_runner_failure(
+        &self,
+        request: RecordRunnerFailureRequest,
+    ) -> Result<TurnRunState, TurnError> {
+        self.store.record_runner_failure(request).await
+    }
+
+    async fn apply_validated_loop_exit(
+        &self,
+        request: ApplyValidatedLoopExitRequest,
+    ) -> Result<TurnRunState, TurnError> {
+        self.store.apply_validated_loop_exit(request).await
+    }
+}
+
+/// Regression for the P0 wedge: a transient claim error arms the scheduler's
+/// retry deadline; if the periodic backstop stays gated behind it, a lost retry
+/// strands every Queued run forever. The `claim_error_backoff` is set far past
+/// the test window so the scheduled retry cannot fire — only a self-healing poll
+/// tick can drain the queued run.
+#[tokio::test(start_paused = true)]
+async fn periodic_backstop_drains_after_claim_error_arms_retry_deadline() {
+    let store = Arc::new(InMemoryTurnStateStore::default());
+    let transitions = Arc::new(FlakyClaimTransitions::new(store.clone(), 1));
+    let transition_port: Arc<dyn TurnRunTransitionPort> = transitions.clone();
+    let executor = Arc::new(CompletingExecutor::default());
+    let scheduler = TurnRunScheduler::new(
+        transition_port,
+        executor.clone(),
+        fast_config()
+            .with_poll_interval(Duration::from_millis(20))
+            .with_lease_recovery_interval(Duration::from_secs(3600))
+            .with_claim_error_backoff(Duration::from_secs(3600)),
+    );
+    let handle = scheduler.start();
+    // No wake is delivered, so the first drain comes from the poll tick. That
+    // claim errors and arms the retry deadline; before the fix the poll tick was
+    // gated behind that state and every later tick was a no-op, so the run never
+    // executed.
+    let coordinator = DefaultTurnCoordinator::new(store.clone())
+        .with_wake_notifier(Arc::new(NoopTurnRunWakeNotifier));
+
+    coordinator
+        .submit_turn(submit_turn_request("thread-wedge", "idem-wedge"))
+        .await
+        .unwrap();
+
+    executor.wait_for_started(1).await;
+    assert!(
+        transitions.claim_attempts() >= 2,
+        "poll-tick backstop did not retry the claim after the retry deadline was armed"
+    );
+    handle.shutdown().await;
+}
+
+/// Under a sustained claim-store outage the unconditional poll-tick backstop
+/// must NOT schedule a fresh retry timer on every tick — doing so would inject a
+/// new self-sustaining retry chain per tick and compound claims into a thundering
+/// herd. The scheduler keeps a single retry deadline, so with the poll interval
+/// equal to the backoff and no wakes, claims over a window stay bounded by the
+/// poll/retry cadence, not its square.
+#[tokio::test(start_paused = true)]
+async fn poll_backstop_does_not_compound_claims_during_outage() {
+    let transitions = Arc::new(FailingClaimTransitions::default());
+    let transition_port: Arc<dyn TurnRunTransitionPort> = transitions.clone();
+    let executor = Arc::new(CompletingExecutor::default());
+    let scheduler = TurnRunScheduler::new(
+        transition_port,
+        executor,
+        fast_config()
+            .with_poll_interval(Duration::from_millis(20))
+            .with_lease_recovery_interval(Duration::from_secs(3600))
+            .with_claim_error_backoff(Duration::from_millis(20)),
+    );
+    let handle = scheduler.start();
+
+    // First poll tick arms the retry deadline. No wakes are delivered, so without
+    // the accumulation bug the claims are the ~one-per-20ms poll ticks plus the
+    // single retry chain (~20 over 200ms). The buggy variant scheduled a fresh
+    // retry timer per poll tick, compounding to one-per-tick-times-ticks-elapsed
+    // (50+ over the same window).
+    transitions.wait_for_claim_attempts(1).await;
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    let attempts = transitions.claim_attempts();
+    assert!(
+        attempts <= 30,
+        "poll backstop compounded claims during outage: {attempts} attempts in ~200ms \
+         (expected roughly one per 20ms poll, not a compounding retry-timer chain)"
+    );
+    handle.shutdown().await;
+}
+
 #[test]
 fn executor_error_exposes_typed_sanitized_failure() {
     let error = TurnRunExecutorError::new("scheduler_test_error").unwrap();


### PR DESCRIPTION
## Summary

- Replace the turn scheduler's `bool` retry latch + detached `RetryDrain` timer with a single in-loop retry deadline (a pinned `Sleep` kept in lockstep with `retry_at: Option<Instant>`).
- Fixes the P0 where a lost retry signal wedged the run queue permanently — turns stuck at `submitted`, no self-recovery even across a restart.
- Keeps at most one pending retry (no thundering herd) and makes the poll tick an unconditional self-healing backstop.

## Problem

Under sustained load the turn runner wedges and does not self-recover: new turns stay at `status: submitted`, the timeline shows only the user message, and no tool calls / assistant / failure ever appear. Killing and restarting the sidecar does **not** clear it — the state lives in the libSQL run queue, not the process, so a restart re-enqueues into the same wedge.

## Root cause

`run_scheduler_loop` used a `bool` retry latch plus a **detached** `schedule_drain_after` task that sent a `RetryDrain` command after `claim_error_backoff`. When `claim_next_run` errored, the latch armed and *every* drain trigger — including the periodic `poll_tick` backstop — was gated behind it. The only thing that cleared the latch was the detached timer's best-effort `RetryDrain` send; if it was lost (shutdown/runtime race, channel drop), the latch stayed armed forever and the scheduler stopped draining entirely.

## Fix

Replace the `bool` latch + detached timer with a single **in-loop retry deadline**. `retry_at: Option<Instant>` is the logical state (also coalesces wakes); a pinned `Sleep` is reset in lockstep via `arm_retry`. The retry lives inside the `select!`, so it **cannot be lost**; there is **at most one** pending retry, so a sustained outage cannot compound retries into a thundering herd; and the poll tick is an **unconditional** self-healing backstop. Pinning + `reset` avoids rebuilding the timer future each loop iteration.

## Change Type

- [x] Bug fix

## Linked Issue

None

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy ... -D warnings` (crate `ironclaw_host_runtime`, clean)
- [x] `cargo build`
- [x] Relevant tests pass: `turn_scheduler_contract` (22 tests), incl. new `periodic_backstop_drains_after_claim_error_arms_retry_deadline` and `poll_backstop_does_not_compound_claims_during_outage` (both `#[tokio::test(start_paused = true)]` for determinism) and existing `claim_errors_coalesce_wakes_during_backoff`.
- [ ] `cargo test --features integration` — N/A (no DB/integration behavior changed; scheduler is store-agnostic, tests use in-memory doubles)
- [x] Manual testing: the regression tests fail on the pre-fix gated poll and pass on the fix.

## Security Impact

None. No change to permissions, network calls, secrets, file access, tool execution, or sandbox policy. Scheduler control-flow only.

## Reborn Trust-Boundary Checklist

- Queues/maps/buffers/counters have bounds: **yes** — this change removes an unbounded failure mode (compounding retry timers) and enforces at most one pending retry with overflow-safe `Instant + Duration` arithmetic.
- Driver/operator-visible error class semantics unchanged — claim errors still flow through the existing transient-retry path.
- All other items: N/A — no new public policy/evidence/trust types, no prompt/envelope or escaping changes, no hashes, no new status/exit/policy/serde variants, no sandbox/native/host naming changes.

## Database Impact

None. No migrations or schema changes. Behavior is identical across PostgreSQL and libSQL (the scheduler is store-agnostic; tests use in-memory store doubles).

## Blast Radius

`ironclaw_host_runtime::turn_scheduler` only — the turn run-queue drain loop. If wrong, it could change when queued turns are claimed/executed. Mitigated by the unconditional poll-tick backstop and the regression tests.

## Rollback Plan

Revert this commit. The change is confined to `turn_scheduler.rs` (+ a dev-only `test-util` tokio feature and tests); reverting restores the prior detached-timer scheduler with no schema or state migration.

## Review Follow-Through

Addressed automated review: adopted the pinned-`Sleep` + `reset` pattern (avoids rebuilding the timer future per iteration) and marked the two time-dependent tests `start_paused` for determinism under CI.

---

**Review track**: C (security/runtime/DB/CI)
