### PR TITLE
fix(llm): map HTTP 402 to non-retryable PaymentRequired (fail fast, no silent retry hang)

### DIFF
--- a/crates/ironclaw_agent_loop/src/executor/mapping.rs
+++ b/crates/ironclaw_agent_loop/src/executor/mapping.rs
@@ -204,6 +204,20 @@ mod tests {
     }
 
     #[test]
+    fn credential_unavailable_is_unclassified_so_the_loop_aborts_immediately() {
+        // Out-of-credits (HTTP 402) maps to `CredentialUnavailable` at the
+        // model-gateway boundary. `model_error_class` must return `None` for it
+        // so `ModelStage` takes the immediate-abort path
+        // (`HostUnavailableWithDiagnostics`) instead of handing it to the
+        // recovery strategy, which would retry a permanently-failing call.
+        let error = AgentLoopHostError::new(
+            AgentLoopHostErrorKind::CredentialUnavailable,
+            "model provider account is out of credits",
+        );
+        assert!(model_error_class(&error).is_none());
+    }
+
+    #[test]
     fn protocol_and_policy_failure_kinds_remain_distinct() {
         assert_eq!(
             capability_failure_kind(&CapabilityFailureKind::InvalidOutput),

--- a/crates/ironclaw_llm/src/circuit_breaker.rs
+++ b/crates/ironclaw_llm/src/circuit_breaker.rs
@@ -223,8 +223,11 @@ impl CircuitBreakerProvider {
 /// Includes `SessionExpired` because repeated session failures signal backend
 /// auth infrastructure trouble.
 ///
-/// Excludes client errors that are the caller's problem, not backend trouble:
-/// `AuthFailed`, `ContextLengthExceeded`, `ModelNotAvailable`, `Json`.
+/// Excludes client/account errors that are the caller's problem, not backend
+/// trouble: `AuthFailed`, `PaymentRequired`, `ContextLengthExceeded`,
+/// `ModelNotAvailable`, `Json`. In particular HTTP 402 (`PaymentRequired`)
+/// means the account is out of credits — the backend is healthy, so it must
+/// not push the breaker toward Open and start failing healthy sibling calls.
 ///
 /// See also `retry::is_retryable()` which answers a different question:
 /// "could retrying this exact request succeed?"
@@ -565,6 +568,11 @@ mod tests {
         assert!(!is_transient(&LlmError::ModelNotAvailable {
             provider: "p".into(),
             model: "m".into(),
+        }));
+        // HTTP 402: the account is out of credits, the backend is healthy — it
+        // must not count toward tripping the breaker.
+        assert!(!is_transient(&LlmError::PaymentRequired {
+            provider: "nearai_chat".into(),
         }));
         assert!(!is_transient(&LlmError::Json(
             serde_json::from_str::<String>("bad").unwrap_err()

--- a/crates/ironclaw_llm/src/codex_chatgpt.rs
+++ b/crates/ironclaw_llm/src/codex_chatgpt.rs
@@ -575,6 +575,21 @@ impl CodexChatGptProvider {
             });
         }
 
+        // HTTP 402: the account/key is out of credits. Permanent until the
+        // user tops up — map it to a dedicated variant so the
+        // retry/circuit-breaker/failover layers leave it alone and the loop
+        // aborts immediately with a clear "out of credits" message. Handled
+        // before reading the body so account/billing detail can't be carried
+        // across the channel boundary. (The OpenAI Codex provider can be
+        // pointed at metered NEAR AI cloud endpoints, which return 402.)
+        if status.as_u16() == 402 {
+            // Drain the body to release the connection back to the pool.
+            let _ = tokio::time::timeout(Duration::from_secs(5), resp.text()).await;
+            return Err(LlmError::PaymentRequired {
+                provider: "codex_chatgpt".to_string(),
+            });
+        }
+
         if !status.is_success() {
             // Read the error body with a timeout to avoid hanging
             let body_text = tokio::time::timeout(Duration::from_secs(5), resp.text())
@@ -1572,6 +1587,32 @@ data: {"response":{"usage":{"input_tokens":3,"output_tokens":2}}}
     }
 
     #[tokio::test]
+    async fn complete_maps_http_402_to_payment_required() {
+        let base_url = responses_api_test_server::spawn_with_responses_status(
+            "402 Payment Required",
+            r#"{"error":{"message":"Credit limit exceeded","type":"insufficient_credits"}}"#,
+        )
+        .await;
+        let provider = CodexChatGptProvider::new(&base_url, "test-key", "gpt-4o");
+
+        let err = provider
+            .complete(CompletionRequest::new(vec![ChatMessage::user("hi")]))
+            .await
+            .expect_err("402 should fail the completion");
+
+        // The billing detail in the body must NOT cross the error boundary.
+        let rendered = err.to_string();
+        assert!(
+            !rendered.contains("Credit limit exceeded"),
+            "402 body must not leak into the error: {rendered}"
+        );
+        match err {
+            LlmError::PaymentRequired { provider } => assert_eq!(provider, "codex_chatgpt"),
+            other => panic!("expected PaymentRequired, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
     async fn complete_with_tools_accepts_data_only_text_response() {
         let base_url = responses_api_test_server::spawn(
             r#"data: {"type":"response.output_text.delta","delta":"Hello from data-only SSE."}
@@ -1716,13 +1757,64 @@ data: {"response":{"usage":{"input_tokens":5,"output_tokens":5}}}
             format!("http://{addr}")
         }
 
+        /// Variant of [`spawn`] that returns a caller-chosen HTTP status for
+        /// `POST /responses` (model resolution via `GET /models` still
+        /// succeeds). Used to exercise error-status mapping at the real HTTP
+        /// boundary.
+        pub(super) async fn spawn_with_responses_status(
+            status_line: &'static str,
+            body: &'static str,
+        ) -> String {
+            let listener = TcpListener::bind("127.0.0.1:0")
+                .await
+                .expect("bind test server");
+            let addr = listener.local_addr().expect("local addr");
+            tokio::spawn(async move {
+                for _ in 0..4 {
+                    let Ok((mut socket, _)) = listener.accept().await else {
+                        break;
+                    };
+                    let mut request = [0u8; 4096];
+                    let Ok(bytes_read) = socket.read(&mut request).await else {
+                        continue;
+                    };
+                    let request = String::from_utf8_lossy(&request[..bytes_read]);
+                    if request.starts_with("GET /models") {
+                        write_status_response(
+                            &mut socket,
+                            "200 OK",
+                            "application/json",
+                            r#"{"models":[{"slug":"gpt-4o"}]}"#,
+                        )
+                        .await;
+                    } else if request.starts_with("POST /responses") {
+                        write_status_response(&mut socket, status_line, "application/json", body)
+                            .await;
+                    } else {
+                        write_status_response(&mut socket, "404 Not Found", "text/plain", "nope")
+                            .await;
+                    }
+                }
+            });
+            format!("http://{addr}")
+        }
+
         async fn write_response(
             socket: &mut tokio::net::TcpStream,
             content_type: &str,
             body: &str,
         ) {
+            write_status_response(socket, "200 OK", content_type, body).await;
+        }
+
+        async fn write_status_response(
+            socket: &mut tokio::net::TcpStream,
+            status_line: &str,
+            content_type: &str,
+            body: &str,
+        ) {
             let response = format!(
-                "HTTP/1.1 200 OK\r\ncontent-type: {content_type}\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                "HTTP/1.1 {status_line}\r\ncontent-type: {content_type}\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
                 body.len()
             );
             socket

--- a/crates/ironclaw_llm/src/error.rs
+++ b/crates/ironclaw_llm/src/error.rs
@@ -121,7 +121,9 @@ pub(crate) fn context_length_error(status_code: u16, response_text: &str) -> Opt
 /// avoid false positives (a bare "402" can appear in unrelated text); each
 /// shorter form (`insufficient credit`, `not enough credit`) also matches its
 /// pluralised variant via substring containment.
-pub(crate) fn is_payment_required_message(lower: &str) -> bool {
+/// Shared across crates (e.g. `ironclaw_reborn`'s model gateway) so the
+/// credit-exhaustion string list has a single source of truth and cannot drift.
+pub fn is_payment_required_message(lower: &str) -> bool {
     const PAYMENT_PATTERNS: &[&str] = &[
         "http 402",
         "402 payment required",

--- a/crates/ironclaw_llm/src/error.rs
+++ b/crates/ironclaw_llm/src/error.rs
@@ -43,6 +43,21 @@ pub enum LlmError {
         retry_after: Option<Duration>,
     },
 
+    /// Upstream provider rejected the request with HTTP 402 (Payment Required):
+    /// the account or key is out of credits, or has hit its spend limit.
+    ///
+    /// This is a *permanent* failure until the user tops up. It must NOT be
+    /// retried by [`crate::retry`], must NOT count as a transient backend
+    /// failure in [`crate::circuit_breaker`], and must NOT trigger provider
+    /// failover in [`crate::failover`] — sibling providers usually share the
+    /// same billing account, and even when they don't, burning retries on an
+    /// out-of-credits key only delays the user-visible "out of credits"
+    /// message that motivated this variant. The response body is intentionally
+    /// NOT carried: upstream 402 bodies can contain account/billing detail that
+    /// must not cross the channel boundary (see `.claude/rules/error-handling.md`).
+    #[error("Provider {provider} payment required (HTTP 402): account is out of credits")]
+    PaymentRequired { provider: String },
+
     #[error("Invalid response from {provider}: {reason}")]
     InvalidResponse { provider: String, reason: String },
 
@@ -90,6 +105,38 @@ pub(crate) fn context_length_error(status_code: u16, response_text: &str) -> Opt
 
     let (used, limit) = parse_context_token_counts(&lower);
     Some(LlmError::ContextLengthExceeded { used, limit })
+}
+
+/// Detect an HTTP 402 / out-of-credits signal in a *lowercased* provider error
+/// message.
+///
+/// Direct-HTTP providers (`nearai_chat`, `codex_chatgpt`) match the 402 status
+/// code directly and never need this. It exists for string-only error paths —
+/// e.g. [`crate::rig_adapter`]'s `map_rig_error`, which only sees a rendered
+/// message — so a credit-exhaustion failure there is still classified as
+/// [`LlmError::PaymentRequired`] instead of a retryable `RequestFailed` that
+/// the retry/circuit-breaker/failover layers would churn on for minutes.
+///
+/// The substrings are chosen to be specific to billing/credit exhaustion to
+/// avoid false positives (a bare "402" can appear in unrelated text); each
+/// shorter form (`insufficient credit`, `not enough credit`) also matches its
+/// pluralised variant via substring containment.
+pub(crate) fn is_payment_required_message(lower: &str) -> bool {
+    const PAYMENT_PATTERNS: &[&str] = &[
+        "http 402",
+        "402 payment required",
+        "payment required",
+        "insufficient_credits",
+        "insufficient credit",
+        "not enough credit",
+        "credit limit exceeded",
+        "credits exhausted",
+        "out of credits",
+    ];
+
+    PAYMENT_PATTERNS
+        .iter()
+        .any(|pattern| lower.contains(pattern))
 }
 
 pub(crate) fn is_context_length_error_message(lower: &str) -> bool {
@@ -287,6 +334,52 @@ mod tests {
         assert!(auth_guidance("groq").contains("GROQ_API_KEY"));
         assert!(auth_guidance("ollama").contains("Ollama is running"));
         assert!(auth_guidance("bedrock").contains("AWS"));
+    }
+
+    #[test]
+    fn payment_required_error_renders_without_leaking_body() {
+        let err = LlmError::PaymentRequired {
+            provider: "nearai_chat".to_string(),
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("nearai_chat"),
+            "should name the provider: {msg}"
+        );
+        assert!(msg.contains("402"), "should mention the HTTP status: {msg}");
+        assert!(
+            msg.contains("out of credits"),
+            "should give the actionable cause: {msg}"
+        );
+    }
+
+    #[test]
+    fn is_payment_required_message_matches_credit_exhaustion_signals() {
+        // The exact shape returned by cloud-api.near.ai on 402 (see repro in
+        // the bug report): {"error":{"message":"Credit limit exceeded...",
+        // "type":"insufficient_credits"}}.
+        assert!(is_payment_required_message(
+            r#"{"error":{"message":"credit limit exceeded for this key","type":"insufficient_credits"}}"#
+        ));
+        assert!(is_payment_required_message("http 402 payment required"));
+        assert!(is_payment_required_message("payment required"));
+        assert!(is_payment_required_message("insufficient credits"));
+        assert!(is_payment_required_message("insufficient credit"));
+        assert!(is_payment_required_message("not enough credits remaining"));
+        assert!(is_payment_required_message("you are out of credits"));
+    }
+
+    #[test]
+    fn is_payment_required_message_ignores_unrelated_text() {
+        // A bare "402" or generic failure must not be misread as out-of-credits.
+        assert!(!is_payment_required_message(
+            "http 500 internal server error"
+        ));
+        assert!(!is_payment_required_message(
+            "request 402 of 1000 processed"
+        ));
+        assert!(!is_payment_required_message("rate limit exceeded"));
+        assert!(!is_payment_required_message("connection refused"));
     }
 
     #[test]

--- a/crates/ironclaw_llm/src/nearai_chat.rs
+++ b/crates/ironclaw_llm/src/nearai_chat.rs
@@ -395,6 +395,20 @@ impl NearAiChatProvider {
                 });
             }
 
+            // HTTP 402: the account/key is out of credits (cloud-api.near.ai
+            // returns `{"error":{"type":"insufficient_credits",...}}`). This is
+            // permanent until the user tops up — map it to a dedicated variant
+            // so the retry/circuit-breaker/failover layers leave it alone and
+            // the agent loop aborts immediately with a clear "out of credits"
+            // message instead of churning for minutes. The body is dropped: it
+            // can carry account/billing detail that must not cross the channel
+            // boundary.
+            if status_code == 402 {
+                return Err(LlmError::PaymentRequired {
+                    provider: "nearai_chat".to_string(),
+                });
+            }
+
             if status_code == 429 {
                 // Preserve existing rate-limit behavior: fall back to a 60s
                 // default when the server omits Retry-After. Long sleeps are
@@ -1476,6 +1490,67 @@ mod tests {
             262144,
         )
         .await;
+    }
+
+    #[tokio::test]
+    async fn complete_maps_http_402_to_payment_required() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut socket, _)) = listener.accept().await else {
+                    break;
+                };
+                let mut request = vec![0_u8; 4096];
+                let Ok(n) = socket.read(&mut request).await else {
+                    continue;
+                };
+                let request = String::from_utf8_lossy(&request[..n]);
+                let (status, body) = if request.starts_with("POST /v1/chat/completions ") {
+                    (
+                        "402 Payment Required",
+                        // The exact shape cloud-api.near.ai returns on 402.
+                        serde_json::json!({
+                            "error": {
+                                "message": "Credit limit exceeded. Top up to continue.",
+                                "type": "insufficient_credits"
+                            }
+                        })
+                        .to_string(),
+                    )
+                } else {
+                    ("200 OK", serde_json::json!({ "models": [] }).to_string())
+                };
+                let response = format!(
+                    "HTTP/1.1 {status}\r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                let _ = socket.write_all(response.as_bytes()).await;
+            }
+        });
+
+        let provider = NearAiChatProvider::new(test_nearai_config(&base_url), test_session())
+            .expect("provider");
+        let err = provider
+            .complete(CompletionRequest::new(vec![ChatMessage::user("hi")]))
+            .await
+            .expect_err("402 should fail the completion");
+
+        // The billing detail in the response body must NOT cross the error
+        // boundary (see `.claude/rules/error-handling.md`).
+        let rendered = err.to_string();
+        assert!(
+            !rendered.contains("Credit limit exceeded"),
+            "402 body must not leak into the error: {rendered}"
+        );
+        match err {
+            LlmError::PaymentRequired { provider } => assert_eq!(provider, "nearai_chat"),
+            other => panic!("expected PaymentRequired, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/ironclaw_llm/src/retry.rs
+++ b/crates/ironclaw_llm/src/retry.rs
@@ -34,9 +34,12 @@ pub(crate) const MAX_RETRY_AFTER_SECS: u64 = 3600;
 /// Retryable: `RequestFailed`, `RateLimited`, `BadGateway`, `InvalidResponse`,
 /// `SessionRenewalFailed`, `Http`, `Io`.
 ///
-/// Non-retryable: `AuthFailed`, `SessionExpired`, `ContextLengthExceeded`,
-/// `ModelNotAvailable`, `Json`.
+/// Non-retryable: `AuthFailed`, `SessionExpired`, `PaymentRequired`,
+/// `ContextLengthExceeded`, `ModelNotAvailable`, `Json`.
 /// - `SessionExpired` — handled by session renewal layer, not by retry
+/// - `PaymentRequired` — HTTP 402, the account is out of credits; retrying (or
+///   failing over to a sibling provider on the same billing account) only
+///   delays the user-visible "out of credits" message until the user tops up
 /// - `ModelNotAvailable` — the model won't appear between attempts
 /// - `Json` — a serde parse bug, not a transient failure
 ///
@@ -426,6 +429,18 @@ mod tests {
         assert!(!is_retryable(&LlmError::ModelNotAvailable {
             provider: "p".into(),
             model: "m".into(),
+        }));
+    }
+
+    /// HTTP 402 is permanent until the user tops up. Retrying the same key — or
+    /// failing over to a sibling provider that shares the billing account —
+    /// only burns the retry budget and delays the user-visible "out of credits"
+    /// message. `FailoverProvider` shares this classifier, so this assertion
+    /// also pins down "no failover on 402".
+    #[test]
+    fn payment_required_is_not_retryable() {
+        assert!(!is_retryable(&LlmError::PaymentRequired {
+            provider: "nearai_chat".into(),
         }));
     }
 

--- a/crates/ironclaw_llm/src/rig_adapter.rs
+++ b/crates/ironclaw_llm/src/rig_adapter.rs
@@ -1013,6 +1013,15 @@ fn map_rig_error(model_name: &str, e: impl std::fmt::Display) -> LlmError {
         let (used, limit) = crate::error::parse_context_token_counts(&lower);
         return LlmError::ContextLengthExceeded { used, limit };
     }
+    // HTTP 402 / out-of-credits arrives here as a rendered message (rig-core
+    // only hands us a `Display` error). Classify it as PaymentRequired so the
+    // retry/circuit-breaker/failover layers leave it alone instead of churning
+    // for minutes — same reasoning as the direct-HTTP `nearai_chat` 402 branch.
+    if crate::error::is_payment_required_message(&lower) {
+        return LlmError::PaymentRequired {
+            provider: model_name.to_string(),
+        };
+    }
     LlmError::RequestFailed {
         provider: model_name.to_string(),
         reason: msg,
@@ -2889,6 +2898,21 @@ mod tests {
             matches!(err, LlmError::RequestFailed { .. }),
             "Generic error should be RequestFailed: {err:?}"
         );
+    }
+
+    #[test]
+    fn test_map_rig_error_detects_payment_required() {
+        // A 402 reaching the rig path as a rendered message must classify as
+        // PaymentRequired (non-retryable) rather than RequestFailed (retryable),
+        // or the retry/circuit-breaker/failover layers churn for minutes.
+        let err = map_rig_error(
+            "nearai",
+            r#"HTTP 402 Payment Required: {"error":{"message":"Credit limit exceeded","type":"insufficient_credits"}}"#,
+        );
+        match err {
+            LlmError::PaymentRequired { provider } => assert_eq!(provider, "nearai"),
+            other => panic!("Expected PaymentRequired, got: {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/ironclaw_reborn/src/model_gateway.rs
+++ b/crates/ironclaw_reborn/src/model_gateway.rs
@@ -1572,6 +1572,14 @@ fn map_provider_error(error: LlmError) -> HostManagedModelError {
 }
 
 fn is_credit_exhaustion_error(error: &LlmError) -> bool {
+    // Preferred path: providers now classify HTTP 402 at the source as a
+    // dedicated variant, so it never reaches the retry/circuit-breaker/failover
+    // layers and arrives here unambiguously.
+    if matches!(error, LlmError::PaymentRequired { .. }) {
+        return true;
+    }
+    // Fallback for any provider that still surfaces credit exhaustion as a
+    // generic RequestFailed with the signal in the rendered message.
     let LlmError::RequestFailed { reason, .. } = error else {
         return false;
     };
@@ -1656,6 +1664,38 @@ mod tests {
 
         let err = request_failed("rate limit exceeded");
         assert!(!is_credit_exhaustion_error(&err));
+    }
+
+    #[test]
+    fn is_credit_exhaustion_error_matches_payment_required_variant() {
+        // Providers now classify HTTP 402 at the source, so the dedicated
+        // variant — not a string match — is the primary signal.
+        let err = LlmError::PaymentRequired {
+            provider: "nearai_chat".to_string(),
+        };
+        assert!(is_credit_exhaustion_error(&err));
+    }
+
+    #[test]
+    fn map_provider_error_maps_payment_required_to_credits_exhausted_abort() {
+        // The full contract that makes the loop abort with a user-visible "out
+        // of credits" message: PaymentRequired -> CredentialUnavailable host
+        // error carrying the credits-exhausted reason kind. CredentialUnavailable
+        // is the kind that `model_error_class` declines to classify (returns
+        // None), which the executor turns into an immediate abort rather than a
+        // recovery-strategy retry.
+        let mapped = map_provider_error(LlmError::PaymentRequired {
+            provider: "nearai_chat".to_string(),
+        });
+        assert_eq!(
+            mapped.kind,
+            HostManagedModelErrorKind::CredentialUnavailable
+        );
+        assert_eq!(
+            mapped.reason_kind,
+            Some(MODEL_CREDITS_EXHAUSTED_REASON_KIND)
+        );
+        assert_eq!(mapped.safe_summary, MODEL_CREDITS_EXHAUSTED_SUMMARY);
     }
 
     #[test]

--- a/crates/ironclaw_reborn/src/model_gateway.rs
+++ b/crates/ironclaw_reborn/src/model_gateway.rs
@@ -1579,20 +1579,14 @@ fn is_credit_exhaustion_error(error: &LlmError) -> bool {
         return true;
     }
     // Fallback for any provider that still surfaces credit exhaustion as a
-    // generic RequestFailed with the signal in the rendered message.
+    // generic RequestFailed with the signal in the rendered message. Delegate to
+    // ironclaw_llm's canonical detector so this list cannot drift from the one
+    // the providers use (it previously missed the real cloud-api 402 body
+    // wording — `insufficient_credits`, `credit limit exceeded`).
     let LlmError::RequestFailed { reason, .. } = error else {
         return false;
     };
-    let lower = reason.to_ascii_lowercase();
-    lower.contains("http 402")
-        || lower.contains("402 payment required")
-        || lower.contains("payment required")
-        || lower.contains("insufficient credit")
-        || lower.contains("insufficient credits")
-        || lower.contains("not enough credit")
-        || lower.contains("not enough credits")
-        || lower.contains("credits exhausted")
-        || lower.contains("out of credits")
+    ironclaw_llm::error::is_payment_required_message(&reason.to_ascii_lowercase())
 }
 
 #[cfg(test)]

--- a/crates/ironclaw_reborn_traces/src/contribution.rs
+++ b/crates/ironclaw_reborn_traces/src/contribution.rs
@@ -8278,7 +8278,8 @@ fn trace_queue_telemetry_failure_kind_for_llm_error(
         | ironclaw_llm::error::LlmError::SessionRenewalFailed { .. } => {
             Some(TraceQueueTelemetryFailureKind::Credential)
         }
-        ironclaw_llm::error::LlmError::RateLimited { .. } => {
+        ironclaw_llm::error::LlmError::RateLimited { .. }
+        | ironclaw_llm::error::LlmError::PaymentRequired { .. } => {
             Some(TraceQueueTelemetryFailureKind::HttpRejection)
         }
         ironclaw_llm::error::LlmError::RequestFailed { .. } => {
@@ -11785,6 +11786,20 @@ mod tests {
         assert!(!failure.reason.contains("super-secret-token"));
 
         let _ = std::fs::remove_dir_all(trace_contribution_dir_for_scope(Some(&scope)));
+    }
+
+    #[test]
+    fn payment_required_llm_error_classifies_as_http_rejection() {
+        // A 402 is a provider HTTP-status rejection, like a 429 rate limit — it
+        // must produce meaningful telemetry, not fall through to `None`/Unknown.
+        assert_eq!(
+            trace_queue_telemetry_failure_kind_for_llm_error(
+                &ironclaw_llm::error::LlmError::PaymentRequired {
+                    provider: "nearai_chat".to_string(),
+                }
+            ),
+            Some(TraceQueueTelemetryFailureKind::HttpRejection)
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
QA showed tool turns hanging for minutes and answers never appearing when
the NEAR AI account is out of credits. The 402 was classified as a generic
RequestFailed, which is_retryable() treats as transient -> 3x provider
backoff x loop retry = a multi-minute silent hang, and the run never surfaced
an out-of-credits message.

Add a dedicated LlmError::PaymentRequired variant and map HTTP 402 to it in
nearai_chat, codex_chatgpt, and rig_adapter. Exclude it from is_retryable()
(retry.rs), is_transient() (circuit_breaker), and provider failover, and map
it to a model_credits_exhausted terminal failure (model_gateway,
executor/mapping) so the run fails in seconds and the frontend renders an
out-of-credits bubble instead of hanging. Body is not carried on the variant
(billing detail must not cross the channel boundary). Adapts ironclaw_reborn_traces.

Verified: cargo build + targeted tests green (9 payment/402 tests pass);
cargo check across reborn/agent_loop/host_runtime/traces.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
