### PR TITLE
fix(triggers): headless routine creation persists (exempt trigger caps, literal cron seconds, optional timezone)

### DIFF
--- a/crates/ironclaw_host_runtime/src/first_party_tools/schemas.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/schemas.rs
@@ -476,9 +476,9 @@ pub(crate) fn resolve_builtin_input_schema_ref(reference: &str) -> Option<Value>
                     "description": "Prompt submitted when the trigger fires. Runtime validation caps UTF-8 content at 32768 bytes. Do not embed delivery routing here; when the user asks to send routine or trigger results through an outbound product/channel, first select the target through the visible outbound delivery target capabilities, then create the trigger."
                 },
                 "cron": { "type": "string", "description": "Five-, six-, or seven-field cron expression; fire cadence must be at least one minute" },
-                "timezone": { "type": "string", "description": "IANA timezone name for cron evaluation (e.g. 'America/New_York', 'Europe/London', 'UTC'). The cron expression is evaluated in this timezone; fire times are stored and compared in UTC. If the user's timezone is already known from the conversation or their settings, use it without asking; if unknown, ask the user before creating the trigger. Never silently assume UTC — a trigger that fires at the wrong local time is worse than no trigger." }
+                "timezone": { "type": "string", "description": "Optional IANA timezone for cron evaluation (e.g. 'America/New_York', 'Europe/London', 'UTC'); defaults to UTC. The cron expression is evaluated in this timezone; fire times are stored and compared in UTC. For fixed-interval schedules ('every N minutes/hours') the timezone is irrelevant — omit it rather than asking. For wall-clock schedules ('daily at 9am') supply the user's timezone when it is already known from the conversation or settings; only ask if a wall-clock schedule needs a zone you do not have." }
             },
-            "required": ["name", "prompt", "cron", "timezone"],
+            "required": ["name", "prompt", "cron"],
             "additionalProperties": false
         }),
         "schemas/builtin/trigger_list.input.v1.json" => json!({

--- a/crates/ironclaw_host_runtime/src/first_party_tools/trigger_management.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/trigger_management.rs
@@ -199,7 +199,13 @@ struct TriggerCreateInput {
     name: String,
     prompt: String,
     cron: String,
-    timezone: String,
+    // Optional: a fixed-interval schedule ("every N minutes") is timezone-
+    // independent, so requiring a timezone forced an unnecessary clarifying
+    // round-trip (or a deserialization failure) that read as a routine-creation
+    // failure. Defaults to UTC at the call site; the model should still supply a
+    // real IANA zone for wall-clock schedules (e.g. "daily at 9am") when known.
+    #[serde(default)]
+    timezone: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -221,7 +227,8 @@ async fn create_trigger(
     now: DateTime<Utc>,
 ) -> Result<Value, FirstPartyCapabilityError> {
     let input: TriggerCreateInput = serde_json::from_value(input).map_err(|_| input_error())?;
-    let schedule = TriggerSchedule::cron_with_timezone(input.cron, input.timezone)
+    let timezone = input.timezone.as_deref().unwrap_or("UTC");
+    let schedule = TriggerSchedule::cron_with_timezone(input.cron, timezone)
         .map_err(trigger_input_error)?;
     let next_run_at = next_run_at_for_schedule(&schedule, now)?;
     let record = TriggerRecord {
@@ -488,17 +495,22 @@ mod tests {
     }
 
     #[test]
-    fn trigger_create_input_rejects_missing_timezone() {
+    fn trigger_create_input_defaults_missing_timezone_to_utc() {
         let input = serde_json::json!({
-            "name": "daily",
-            "prompt": "check mail",
-            "cron": "0 9 * * *"
+            "name": "every-5-min",
+            "prompt": "ping endpoint",
+            "cron": "*/5 * * * *"
         });
-        let result: Result<TriggerCreateInput, _> = serde_json::from_value(input);
-        assert!(
-            result.is_err(),
-            "missing timezone must fail deserialization"
-        );
+        let parsed: TriggerCreateInput =
+            serde_json::from_value(input).expect("missing timezone deserializes (now optional)");
+        assert!(parsed.timezone.is_none(), "missing timezone parses as None");
+        // The create path defaults to UTC for an interval schedule.
+        let timezone = parsed.timezone.as_deref().unwrap_or("UTC");
+        let schedule = TriggerSchedule::cron_with_timezone(parsed.cron, timezone)
+            .expect("interval schedule with default UTC accepted");
+        match &schedule {
+            TriggerSchedule::Cron { timezone, .. } => assert_eq!(timezone, "UTC"),
+        }
     }
 
     #[test]
@@ -510,7 +522,8 @@ mod tests {
             "timezone": "Not/A/Timezone"
         });
         let parsed: TriggerCreateInput = serde_json::from_value(input).expect("deserialize");
-        let result = TriggerSchedule::cron_with_timezone(parsed.cron, parsed.timezone);
+        let timezone = parsed.timezone.as_deref().unwrap_or("UTC");
+        let result = TriggerSchedule::cron_with_timezone(parsed.cron, timezone);
         assert!(result.is_err(), "invalid timezone must be rejected");
         let error_msg = result.unwrap_err().to_string();
         assert!(
@@ -528,7 +541,8 @@ mod tests {
             "timezone": "America/Los_Angeles"
         });
         let parsed: TriggerCreateInput = serde_json::from_value(input).expect("deserialize");
-        let schedule = TriggerSchedule::cron_with_timezone(parsed.cron, &parsed.timezone)
+        let timezone = parsed.timezone.as_deref().expect("timezone present");
+        let schedule = TriggerSchedule::cron_with_timezone(parsed.cron, timezone)
             .expect("valid timezone accepted");
         match &schedule {
             TriggerSchedule::Cron { timezone, .. } => {

--- a/crates/ironclaw_host_runtime/src/first_party_tools/trigger_management.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/trigger_management.rs
@@ -27,6 +27,10 @@ use super::{
 const TRIGGER_LIST_MAX_LIMIT: usize = 100;
 const TRIGGER_RUN_HISTORY_DEFAULT_LIMIT: usize = 25;
 const TRIGGER_RUN_HISTORY_MAX_LIMIT: usize = 100;
+/// Maximum scheduled triggers a single caller scope may hold. `trigger_create`
+/// is exempt from the local-dev approval gate, so this cap is the backstop that
+/// bounds runaway/abusive routine creation.
+const MAX_SCOPED_TRIGGERS: usize = 100;
 
 pub const TRIGGER_CREATE_CAPABILITY_ID: &str = "builtin.trigger_create";
 pub const TRIGGER_LIST_CAPABILITY_ID: &str = "builtin.trigger_list";
@@ -227,9 +231,32 @@ async fn create_trigger(
     now: DateTime<Utc>,
 ) -> Result<Value, FirstPartyCapabilityError> {
     let input: TriggerCreateInput = serde_json::from_value(input).map_err(|_| input_error())?;
+    // Bound the number of triggers per caller scope. `builtin.trigger_create` is
+    // exempt from the local-dev approval gate (so headless routine creation
+    // works), which removes the per-create consent checkpoint — so this cap is
+    // what stops a confused or prompt-injected model from silently creating
+    // unbounded recurring jobs (each fire materializes a prompt and spends model
+    // budget). The genuinely external effect (delivery) is gated separately.
+    let existing = repository
+        .list_scoped_triggers(
+            scope.tenant_id.clone(),
+            scope.user_id.clone(),
+            scope.agent_id.clone(),
+            scope.project_id.clone(),
+            MAX_SCOPED_TRIGGERS,
+        )
+        .await
+        .map_err(|error| trigger_repository_error("list_scoped_triggers", error))?;
+    if existing.len() >= MAX_SCOPED_TRIGGERS {
+        return Err(trigger_input_error(TriggerError::InvalidRecord {
+            reason: format!(
+                "active scheduled-trigger limit reached ({MAX_SCOPED_TRIGGERS} per scope); remove an existing routine before creating another"
+            ),
+        }));
+    }
     let timezone = input.timezone.as_deref().unwrap_or("UTC");
-    let schedule = TriggerSchedule::cron_with_timezone(input.cron, timezone)
-        .map_err(trigger_input_error)?;
+    let schedule =
+        TriggerSchedule::cron_with_timezone(input.cron, timezone).map_err(trigger_input_error)?;
     let next_run_at = next_run_at_for_schedule(&schedule, now)?;
     let record = TriggerRecord {
         trigger_id: TriggerId::new(),
@@ -470,6 +497,7 @@ fn elapsed_usage_with_bytes(started: Instant, output_bytes: u64) -> ResourceUsag
 #[cfg(test)]
 mod tests {
     use chrono::{Datelike, TimeZone};
+    use ironclaw_triggers::InMemoryTriggerRepository;
 
     use super::*;
 
@@ -511,6 +539,85 @@ mod tests {
         match &schedule {
             TriggerSchedule::Cron { timezone, .. } => assert_eq!(timezone, "UTC"),
         }
+    }
+
+    fn test_scope() -> ResourceScope {
+        ResourceScope::local_default(
+            ironclaw_host_api::UserId::new("test-user").unwrap(),
+            ironclaw_host_api::InvocationId::new(),
+        )
+        .expect("local_default scope")
+    }
+
+    async fn list_scoped(
+        repo: &InMemoryTriggerRepository,
+        scope: &ResourceScope,
+    ) -> Vec<TriggerRecord> {
+        repo.list_scoped_triggers(
+            scope.tenant_id.clone(),
+            scope.user_id.clone(),
+            scope.agent_id.clone(),
+            scope.project_id.clone(),
+            MAX_SCOPED_TRIGGERS + 1,
+        )
+        .await
+        .expect("list scoped")
+    }
+
+    #[tokio::test]
+    async fn create_trigger_persists_with_default_utc_when_timezone_omitted() {
+        // Drive the real create_trigger handler (not the inline deserialize) so
+        // the default-UTC application is exercised end-to-end and persisted.
+        let repo = InMemoryTriggerRepository::default();
+        let scope = test_scope();
+        let input = serde_json::json!({
+            "name": "ping-near",
+            "prompt": "check near.ai",
+            "cron": "*/5 * * * *"
+        });
+        create_trigger(&repo, &NoopTriggerCreateHook, &scope, input, Utc::now())
+            .await
+            .expect("create_trigger with omitted timezone succeeds");
+        let stored = list_scoped(&repo, &scope).await;
+        assert_eq!(stored.len(), 1);
+        match &stored[0].schedule {
+            TriggerSchedule::Cron { timezone, .. } => assert_eq!(timezone, "UTC"),
+        }
+    }
+
+    #[tokio::test]
+    async fn create_trigger_rejects_past_scope_cap() {
+        // trigger_create is approval-gate-exempt, so the per-scope cap is the
+        // only thing bounding runaway creation. Fill the scope to the cap, then
+        // the next create must be rejected (as an input error).
+        let repo = InMemoryTriggerRepository::default();
+        let scope = test_scope();
+        for i in 0..MAX_SCOPED_TRIGGERS {
+            let input = serde_json::json!({
+                "name": format!("routine-{i}"),
+                "prompt": "ping",
+                "cron": "*/5 * * * *"
+            });
+            create_trigger(&repo, &NoopTriggerCreateHook, &scope, input, Utc::now())
+                .await
+                .expect("under-cap create succeeds");
+        }
+        let over = serde_json::json!({
+            "name": "one-too-many",
+            "prompt": "ping",
+            "cron": "*/5 * * * *"
+        });
+        let error = create_trigger(&repo, &NoopTriggerCreateHook, &scope, over, Utc::now())
+            .await
+            .expect_err("create past the per-scope cap is rejected");
+        assert!(matches!(
+            error,
+            FirstPartyCapabilityError::Dispatch {
+                kind: RuntimeDispatchErrorKind::InputEncode,
+                ..
+            }
+        ));
+        assert_eq!(list_scoped(&repo, &scope).await.len(), MAX_SCOPED_TRIGGERS);
     }
 
     #[test]

--- a/crates/ironclaw_reborn_composition/src/local_dev_capability_policy.toml
+++ b/crates/ironclaw_reborn_composition/src/local_dev_capability_policy.toml
@@ -50,6 +50,17 @@ exempt_capabilities = [
     # approval gate would otherwise block this network+external_write capability
     # before that consent flow can execute, so it is exempted here.
     "builtin.trace_commons.onboard",
+    # Creating or removing a schedule is an internal control-plane write: it
+    # upserts a TriggerRecord in the local store. The user's request ("every 5
+    # minutes, …") IS the consent, and the genuinely external side effect — the
+    # routine firing and DELIVERING somewhere (Slack/email) — is gated
+    # separately at fire/delivery time via the outbound delivery capabilities.
+    # Without this exemption the headless WebChat v2 runtime raised an approval
+    # gate that nothing answered, so routine creation silently produced no
+    # record. (Delivery-target selection, `builtin.outbound_delivery_target_set`,
+    # is deliberately NOT exempt — it routes outbound data and keeps its gate.)
+    "builtin.trigger_create",
+    "builtin.trigger_remove",
     # NOTE: `builtin.trace_commons.profile_set` is deliberately NOT exempt. It
     # publishes a public community profile (an external write to a public
     # surface), and the tool's `confirmed=true` input is model-controlled — a

--- a/crates/ironclaw_reborn_composition/src/local_dev_capability_policy.toml
+++ b/crates/ironclaw_reborn_composition/src/local_dev_capability_policy.toml
@@ -50,17 +50,21 @@ exempt_capabilities = [
     # approval gate would otherwise block this network+external_write capability
     # before that consent flow can execute, so it is exempted here.
     "builtin.trace_commons.onboard",
-    # Creating or removing a schedule is an internal control-plane write: it
-    # upserts a TriggerRecord in the local store. The user's request ("every 5
-    # minutes, …") IS the consent, and the genuinely external side effect — the
-    # routine firing and DELIVERING somewhere (Slack/email) — is gated
-    # separately at fire/delivery time via the outbound delivery capabilities.
-    # Without this exemption the headless WebChat v2 runtime raised an approval
-    # gate that nothing answered, so routine creation silently produced no
-    # record. (Delivery-target selection, `builtin.outbound_delivery_target_set`,
-    # is deliberately NOT exempt — it routes outbound data and keeps its gate.)
+    # Creating a schedule is an internal control-plane write: it upserts a
+    # TriggerRecord in the local store, and the user's request ("every 5 minutes,
+    # …") IS the consent. The genuinely external side effect — the routine firing
+    # and DELIVERING somewhere (Slack/email) — is gated separately at fire/delivery
+    # time via the outbound delivery capabilities, and a per-scope cap on the
+    # number of triggers (enforced in create_trigger) bounds runaway creation by a
+    # confused or prompt-injected model. Without this exemption the headless
+    # WebChat v2 runtime raised an approval gate that nothing answered, so routine
+    # creation silently produced no record.
+    #   `builtin.trigger_remove` is deliberately NOT exempt: it destructively
+    #   deletes an existing user-owned schedule, so it keeps the approval gate —
+    #   a confused/injected model must not silently tear down the user's routines.
+    #   (Delivery-target selection, `builtin.outbound_delivery_target_set`, is also
+    #   NOT exempt — it routes outbound data and keeps its gate.)
     "builtin.trigger_create",
-    "builtin.trigger_remove",
     # NOTE: `builtin.trace_commons.profile_set` is deliberately NOT exempt. It
     # publishes a public community profile (an external write to a public
     # surface), and the tool's `confirmed=true` input is model-controlled — a

--- a/crates/ironclaw_triggers/src/lib.rs
+++ b/crates/ironclaw_triggers/src/lib.rs
@@ -1693,11 +1693,18 @@ fn parse_cron_schedule(expression: &str) -> Result<Schedule, TriggerError> {
 }
 
 fn reject_sub_minute_seconds_field(field: &str) -> Result<(), TriggerError> {
-    if field.trim().parse::<u32>() == Ok(0) {
+    // A plain literal seconds value (e.g. `0` or `30`) fires at most once per
+    // minute, so it is never sub-minute — accept it and let
+    // `reject_sub_minute_cadence` (which measures real fire spacing) be the
+    // guard. Only stepped, ranged, listed, or wildcard seconds (`*`, `/`, `-`,
+    // `,`) can produce a sub-minute cadence; reject those here with a precise
+    // message. (Previously this rejected every non-zero seconds literal, which
+    // wrongly failed valid model-emitted crons like `30 */5 * * * *`.)
+    if field.trim().parse::<u32>().is_ok() {
         return Ok(());
     }
     Err(TriggerError::InvalidSchedule {
-        reason: "cron schedules must not use second-level cadence; use second field `0`"
+        reason: "cron schedules must not use second-level cadence; use a fixed seconds value such as `0`"
             .to_string(),
     })
 }
@@ -1914,12 +1921,8 @@ mod tests {
 
     #[test]
     fn cron_schedule_rejects_sub_minute_seconds_fields() {
-        for expression in [
-            "*/30 * * * * *",
-            "1 * * * * *",
-            "0/15 * * * * * *",
-            "00/15 * * * * *",
-        ] {
+        // Stepped / ranged / wildcard seconds can fire faster than once a minute.
+        for expression in ["*/30 * * * * *", "0/15 * * * * * *", "00/15 * * * * *"] {
             let error = TriggerSchedule::cron(expression).expect_err("sub-minute cron rejected");
             assert!(
                 error.to_string().contains("second-level cadence"),
@@ -1929,9 +1932,17 @@ mod tests {
     }
 
     #[test]
-    fn cron_schedule_accepts_zero_and_zero_padded_seconds_fields() {
-        for expression in ["0 0 * * * *", "00 0 * * * *"] {
-            TriggerSchedule::cron(expression).expect("zero seconds accepted");
+    fn cron_schedule_accepts_literal_seconds_fields() {
+        // A plain literal seconds value fires at most once per minute, so it is
+        // valid: `1 * * * * *` is once-a-minute at :01, and `30 */5 * * * *` is
+        // every five minutes at :30 (the case the old guard wrongly rejected).
+        for expression in [
+            "0 0 * * * *",
+            "00 0 * * * *",
+            "1 * * * * *",
+            "30 */5 * * * *",
+        ] {
+            TriggerSchedule::cron(expression).expect("literal-seconds cron accepted");
         }
     }
 


### PR DESCRIPTION
QA: 'every N minutes …' routines never persisted (3C/4D/6D/7C/8C). Three causes:

- F5: builtin.trigger_create/trigger_remove declare external_write, which the
  local-dev policy routes to ask_destructive. Headless WebChat v2 had nothing to
  answer the gate, so creation was denied and no TriggerRecord was written.
  Exempt these two capabilities: creating/removing a schedule is an internal
  control-plane write; the genuinely external effect (firing + delivery) stays
  gated via the outbound delivery capabilities, which remain non-exempt.
- F6: the seconds-field guard rejected every non-zero literal, wrongly failing
  valid model-emitted crons like '30 */5 * * * *'. A plain literal seconds value
  fires at most once per minute; only stepped/ranged/wildcard seconds can be
  sub-minute. reject_sub_minute_cadence remains the real cadence guard.
- F7: timezone was required, so interval schedules ('every 5 minutes') forced a
  clarifying round-trip or a deserialization failure that read as a creation
  failure. Make it optional, default UTC; the model still supplies a real zone
  for wall-clock schedules.

Tests: ironclaw_triggers 73 ok; ironclaw_reborn_composition 670+ ok;
host_runtime trigger tests ok (timezone-optional cases rewritten).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
