### PR TITLE
fix(agent-loop): admit one-line answers that name a __-tool

### DIFF
--- a/crates/ironclaw_agent_loop/src/executor/tests.rs
+++ b/crates/ironclaw_agent_loop/src/executor/tests.rs
@@ -1279,7 +1279,11 @@ async fn repeated_reply_rejections_stop_as_invalid_model_output() {
 #[tokio::test]
 async fn default_reply_admission_rejects_tool_history_echo_and_continues() {
     let host = MockHost::new(vec![
-        reply_response_with_text("Previous tool event: demo__echo was invoked."),
+        // Multi-line, all provider-transcript-artifact lines: a replayed-history
+        // echo (still rejected under the multi-line artifact rule).
+        reply_response_with_text(
+            "Previous tool event: demo__echo was invoked.\nTool result from demo__echo: hi",
+        ),
         reply_response_with_text("done"),
     ]);
     let executor = CanonicalAgentLoopExecutor;

--- a/crates/ironclaw_agent_loop/src/strategies/reply_admission.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/reply_admission.rs
@@ -59,7 +59,22 @@ impl ReplyAdmissionStrategy for DefaultReplyAdmissionStrategy {
 }
 
 fn is_non_final_reply_artifact(content: &str) -> bool {
-    content.trim().is_empty() || is_only_provider_transcript_artifact_lines(content)
+    let trimmed = content.trim();
+    if trimmed.is_empty() {
+        return true;
+    }
+    // Only treat content as a replayed provider-transcript artifact when it is
+    // MULTI-line. A genuine one-line answer that merely names a `__`-bearing tool
+    // (e.g. "Tool result from web__fetch: near.ai returned 200 OK") is a real
+    // final reply, not an echo of provider history — rejecting it on the
+    // single-line shape was eating valid answers. A weak model echoing replayed
+    // transcript reproduces multiple history lines, which this still catches.
+    trimmed
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .count()
+        > 1
+        && is_only_provider_transcript_artifact_lines(content)
 }
 
 pub(crate) fn reply_admission_control_message(
@@ -124,10 +139,14 @@ mod tests {
 
     #[tokio::test]
     async fn default_reply_admission_rejects_flattened_tool_history_echo() {
+        // A weak model echoing replayed provider history reproduces MULTIPLE
+        // transcript lines — that multi-line, all-artifact shape is still rejected.
         let context = test_run_context("default-reply-admission-tool-history");
         let state = LoopExecutionState::initial_for_run(&context);
         let reply = AssistantReply {
-            content: "Previous tool event: demo__echo was invoked.".to_string(),
+            content:
+                "Previous tool event: demo__echo was invoked.\nTool result from demo__echo: hi"
+                    .to_string(),
         };
 
         let outcome = DefaultReplyAdmissionStrategy
@@ -135,6 +154,23 @@ mod tests {
             .await;
 
         assert!(matches!(outcome, ReplyAdmissionOutcome::RejectFinal { .. }));
+    }
+
+    #[tokio::test]
+    async fn default_reply_admission_accepts_single_line_answer_naming_a_tool() {
+        // F3: a one-line final answer that names a `__`-bearing tool is a real
+        // reply, not a replayed-transcript artifact — it must be admitted.
+        let context = test_run_context("default-reply-admission-single-line-tool");
+        let state = LoopExecutionState::initial_for_run(&context);
+        let reply = AssistantReply {
+            content: "Tool result from web__fetch: near.ai returned 200 OK.".to_string(),
+        };
+
+        let outcome = DefaultReplyAdmissionStrategy
+            .admit_reply(&state, &reply)
+            .await;
+
+        assert_eq!(outcome, ReplyAdmissionOutcome::AcceptFinal);
     }
 
     #[tokio::test]


### PR DESCRIPTION
A genuine single-line final answer that mentions a `__`-bearing tool (e.g.
"Tool result from web__fetch: near.ai returned 200 OK") was misclassified as a
replayed provider-transcript artifact and rejected, so the real answer vanished.
Only treat MULTI-line content as a transcript artifact; a weak model echoing
replayed history reproduces multiple lines, which is still caught. Reject tests
updated to multi-line; added a single-line accept test.

(F1 stalled-turn recovery intentionally NOT included: gating the nudge on any
tool call over-fires on pure-failure runs, and the target 3B hang is the runner
queue not draining — a separate P0, not a no-reply-at-exit. Doing F1 right needs
a successful-tool-call signal that state does not yet track.)

cargo test -p ironclaw_agent_loop: 317 passed, 0 failed.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
