### PR TITLE
[codex] Fix Skills install validation clearing

### DIFF
--- a/crates/ironclaw_gateway/static/index.html
+++ b/crates/ironclaw_gateway/static/index.html
@@ -527,9 +527,15 @@
               </div>
               <div class="extensions-section">
                 <h3 data-i18n="skills.installByUrl">Install Skill by URL</h3>
-                <div class="ext-install-form">
-                  <input type="text" id="skill-install-name" data-i18n-placeholder="skills.namePlaceholder" placeholder="Skill name or slug">
-                  <input type="text" id="skill-install-url" data-i18n-placeholder="skills.urlPlaceholder" placeholder="HTTPS URL to SKILL.md (optional)">
+                <div class="ext-install-form skill-install-form" id="skill-install-form">
+                  <div class="skill-install-field">
+                    <input type="text" id="skill-install-name" data-i18n-placeholder="skills.namePlaceholder" placeholder="Skill name or slug">
+                    <div class="skill-install-error" id="skill-install-name-error" role="alert" aria-live="polite" hidden></div>
+                  </div>
+                  <div class="skill-install-field">
+                    <input type="text" id="skill-install-url" data-i18n-placeholder="skills.urlPlaceholder" placeholder="HTTPS URL to SKILL.md (optional)">
+                    <div class="skill-install-error" id="skill-install-url-error" role="alert" aria-live="polite" hidden></div>
+                  </div>
                   <button id="skill-install-btn" data-i18n="extensions.install">Install</button>
                 </div>
               </div>

--- a/crates/ironclaw_gateway/static/js/surfaces/skills.js
+++ b/crates/ironclaw_gateway/static/js/surfaces/skills.js
@@ -399,23 +399,83 @@ function removeSkill(name) {
   }, I18n.t('common.remove'), 'btn-danger');
 }
 
-function installSkillFromForm() {
-  var name = document.getElementById('skill-install-name').value.trim();
-  if (!name) { showToast(I18n.t('skills.nameRequired'), 'error'); return; }
-  var url = document.getElementById('skill-install-url').value.trim() || null;
-  if (url && !url.startsWith('https://')) {
-    showToast(I18n.t('skills.httpsRequired'), 'error');
-    return;
+function setSkillInstallFieldError(inputId, message) {
+  var input = document.getElementById(inputId);
+  var error = document.getElementById(inputId + '-error');
+  if (!input || !error) return;
+
+  if (message) {
+    error.textContent = message;
+    error.hidden = false;
+    input.setAttribute('aria-invalid', 'true');
+    input.setAttribute('aria-describedby', error.id);
+  } else {
+    error.textContent = '';
+    error.hidden = true;
+    input.removeAttribute('aria-invalid');
+    input.removeAttribute('aria-describedby');
   }
+}
+
+function validateSkillInstallName() {
+  var input = document.getElementById('skill-install-name');
+  var isValid = !!(input && input.value.trim());
+  setSkillInstallFieldError(
+    'skill-install-name',
+    isValid ? '' : I18n.t('skills.nameRequired')
+  );
+  return isValid;
+}
+
+function validateSkillInstallUrl() {
+  var input = document.getElementById('skill-install-url');
+  var value = input ? input.value.trim() : '';
+  var isValid = !value || value.startsWith('https://');
+  setSkillInstallFieldError(
+    'skill-install-url',
+    isValid ? '' : I18n.t('skills.httpsRequired')
+  );
+  return isValid;
+}
+
+function clearSkillInstallValidationForValidFields() {
+  var nameInput = document.getElementById('skill-install-name');
+  var urlInput = document.getElementById('skill-install-url');
+  if (nameInput && nameInput.value.trim()) {
+    setSkillInstallFieldError('skill-install-name', '');
+  }
+  if (urlInput) {
+    var url = urlInput.value.trim();
+    if (!url || url.startsWith('https://')) {
+      setSkillInstallFieldError('skill-install-url', '');
+    }
+  }
+}
+
+function installSkillFromForm() {
+  var nameInput = document.getElementById('skill-install-name');
+  var urlInput = document.getElementById('skill-install-url');
+  var name = nameInput.value.trim();
+  var url = urlInput.value.trim() || null;
+  var hasValidName = validateSkillInstallName();
+  var hasValidUrl = validateSkillInstallUrl();
+  if (!hasValidName) { showToast(I18n.t('skills.nameRequired'), 'error'); }
+  if (!hasValidUrl) { showToast(I18n.t('skills.httpsRequired'), 'error'); }
+  if (!hasValidName || !hasValidUrl) return;
+
   if (!confirm(I18n.t('skills.confirmInstall', { name: name }))) return;
   installSkill(name, url, null);
-  document.getElementById('skill-install-name').value = '';
-  document.getElementById('skill-install-url').value = '';
+  nameInput.value = '';
+  urlInput.value = '';
+  setSkillInstallFieldError('skill-install-name', '');
+  setSkillInstallFieldError('skill-install-url', '');
 }
 
 // Wire up Enter key on search input
 document.getElementById('skill-search-input').addEventListener('keydown', function(e) {
   if (e.key === 'Enter') searchClawHub();
 });
+document.getElementById('skill-install-name').addEventListener('input', clearSkillInstallValidationForValidFields);
+document.getElementById('skill-install-url').addEventListener('input', clearSkillInstallValidationForValidFields);
 
 // --- Tool Permissions ---

--- a/crates/ironclaw_gateway/static/js/surfaces/skills.test.mjs
+++ b/crates/ironclaw_gateway/static/js/surfaces/skills.test.mjs
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import vm from "node:vm";
+
+class FakeElement {
+  constructor(id) {
+    this.id = id;
+    this.attributes = new Map();
+    this.hidden = false;
+    this.listeners = {};
+    this.textContent = "";
+    this.value = "";
+  }
+
+  addEventListener(type, listener) {
+    this.listeners[type] = listener;
+  }
+
+  dispatch(type) {
+    if (this.listeners[type]) this.listeners[type]({ target: this });
+  }
+
+  removeAttribute(name) {
+    this.attributes.delete(name);
+  }
+
+  setAttribute(name, value) {
+    this.attributes.set(name, value);
+  }
+
+  getAttribute(name) {
+    return this.attributes.get(name) || null;
+  }
+}
+
+function createHarness() {
+  const elements = new Map();
+  for (const id of [
+    "skill-install-name",
+    "skill-install-name-error",
+    "skill-install-url",
+    "skill-install-url-error",
+    "skill-search-input",
+  ]) {
+    elements.set(id, new FakeElement(id));
+  }
+
+  const toasts = [];
+  const installs = [];
+  const context = {
+    I18n: {
+      t(key, values) {
+        if (key === "skills.nameRequired") return "Skill name is required";
+        if (key === "skills.httpsRequired") return "URL must use HTTPS";
+        if (key === "skills.confirmInstall") return `Install skill "${values.name}"?`;
+        return key;
+      },
+    },
+    apiFetch(url, options) {
+      installs.push({ url, options });
+      return Promise.resolve({ success: true });
+    },
+    confirm: () => true,
+    document: {
+      createElement: (tag) => new FakeElement(tag),
+      getElementById: (id) => elements.get(id) || null,
+    },
+    encodeURIComponent,
+    formatTimeAgo: () => "",
+    loadSkills: () => {},
+    Promise,
+    setSlashSkillEntries: () => {},
+    showConfirmModal: () => {},
+    showToast: (message, type) => toasts.push({ message, type }),
+  };
+
+  vm.runInNewContext(
+    readFileSync(new URL("./skills.js", import.meta.url), "utf8"),
+    context,
+  );
+
+  return { context, elements, installs, toasts };
+}
+
+test("skill install validation clears name error when the name becomes valid", () => {
+  const harness = createHarness();
+  const name = harness.elements.get("skill-install-name");
+  const error = harness.elements.get("skill-install-name-error");
+
+  harness.context.installSkillFromForm();
+
+  assert.equal(error.hidden, false);
+  assert.equal(error.textContent, "Skill name is required");
+  assert.equal(name.getAttribute("aria-invalid"), "true");
+
+  name.value = "summarizer";
+  name.dispatch("input");
+
+  assert.equal(error.hidden, true);
+  assert.equal(error.textContent, "");
+  assert.equal(name.getAttribute("aria-invalid"), null);
+});
+
+test("skill install validation clears url error when the url becomes valid", () => {
+  const harness = createHarness();
+  const name = harness.elements.get("skill-install-name");
+  const url = harness.elements.get("skill-install-url");
+  const error = harness.elements.get("skill-install-url-error");
+  name.value = "summarizer";
+  url.value = "http://example.com/SKILL.md";
+
+  harness.context.installSkillFromForm();
+
+  assert.equal(error.hidden, false);
+  assert.equal(error.textContent, "URL must use HTTPS");
+  assert.equal(url.getAttribute("aria-invalid"), "true");
+
+  url.value = "https://example.com/SKILL.md";
+  url.dispatch("input");
+
+  assert.equal(error.hidden, true);
+  assert.equal(error.textContent, "");
+  assert.equal(url.getAttribute("aria-invalid"), null);
+});

--- a/crates/ironclaw_gateway/static/styles/surfaces/skills.css
+++ b/crates/ironclaw_gateway/static/styles/surfaces/skills.css
@@ -78,3 +78,35 @@
   animation: skillFadeIn 0.3s ease-out both;
 }
 
+.skill-install-form {
+  align-items: flex-start;
+}
+
+.skill-install-field {
+  display: flex;
+  flex: 1 1 220px;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 180px;
+}
+
+.skill-install-field input {
+  width: 100%;
+}
+
+.skill-install-field input[aria-invalid="true"] {
+  border-color: var(--danger);
+  box-shadow: 0 0 0 3px var(--danger-error-bg);
+}
+
+.skill-install-error {
+  color: var(--danger);
+  font-size: var(--text-xs);
+  line-height: 1.35;
+  min-height: 1.35em;
+}
+
+.skill-install-error[hidden] {
+  display: block;
+  visibility: hidden;
+}


### PR DESCRIPTION
## Summary

Fixes #5007.

- Adds field-level validation state for the Skills install-by-URL form.
- Clears the stale name or URL validation message as soon as the corresponding input becomes valid.
- Keeps the existing toast behavior while adding accessible inline errors via `aria-invalid` and `aria-describedby`.
- Adds a focused Node test that drives `installSkillFromForm` and input events through the actual caller path.

## Root Cause

The Skills install form only showed validation failures on submit. There was no persistent field state or input listener to clear a previously shown validation error when the user corrected the field.

## Test Plan

- `node --test crates/ironclaw_gateway/static/js/surfaces/skills.test.mjs`
- `node --test crates/ironclaw_gateway/static/js/**/*.test.mjs`
- `cargo test -p ironclaw_gateway`

## Risk / Rollback

Low-risk static frontend change scoped to the Skills install form. Rollback is reverting this commit; the form returns to submit-only toast validation.