### PR TITLE
fix: Gmail auth-resume failure — stop run-borking + restore persistent-approval grant

### DIFF
--- a/crates/ironclaw_host_runtime/src/production.rs
+++ b/crates/ironclaw_host_runtime/src/production.rs
@@ -735,6 +735,26 @@ impl HostRuntime for DefaultHostRuntime {
         context.trust = trust_decision.effective_trust.class();
 
         let registry = self.registry.snapshot();
+        // Re-apply the persistent-approval grant on the auth-resume preflight,
+        // mirroring `dispatch_capability`. The original dispatch injected this
+        // grant so the authorizer returned `Allow`; the loop re-dispatches the
+        // resume with a freshly built context that does not carry it. Without
+        // this, a capability authorized only by a persistent-approval grant
+        // (e.g. `extension_activate` under admin-config FirstParty trust) is
+        // re-authorized grant-less after the user supplies the missing
+        // credential and is denied — so the credential gate resumes only to
+        // fail authorization, even though a subsequent fresh dispatch succeeds.
+        // The helper is a no-op when no matching policy/grant exists, so
+        // capabilities that genuinely require fresh approval are unaffected.
+        self.apply_persistent_approval_policy(
+            &mut context,
+            &registry,
+            PersistentApprovalAction::Dispatch,
+            &capability_id,
+            &estimate,
+            &trust_decision,
+        )
+        .await;
         let host = self.capability_host(&registry);
         let auth_resume = CapabilityAuthResumeRequest {
             context,

--- a/crates/ironclaw_host_runtime/tests/host_runtime_persistent_approvals_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_persistent_approvals_contract.rs
@@ -16,13 +16,15 @@ use ironclaw_extensions::{ExtensionManifest, ExtensionPackage, ExtensionRegistry
 use ironclaw_filesystem::{InMemoryBackend, ScopedFilesystem};
 use ironclaw_host_api::*;
 use ironclaw_host_runtime::{
-    CapabilitySurfaceVersion, DefaultHostRuntime, HostRuntime, RuntimeCapabilityRequest,
-    RuntimeFailureKind,
+    CapabilitySurfaceVersion, DefaultHostRuntime, HostRuntime, RuntimeCapabilityAuthResumeRequest,
+    RuntimeCapabilityRequest, RuntimeFailureKind,
 };
 use ironclaw_processes::{
     ProcessError, ProcessManager, ProcessRecord, ProcessStart, ProcessStatus,
 };
-use ironclaw_run_state::{InMemoryApprovalRequestStore, InMemoryRunStateStore};
+use ironclaw_run_state::{
+    InMemoryApprovalRequestStore, InMemoryRunStateStore, RunStart, RunStateStore, RunStatus,
+};
 use ironclaw_trust::{
     AdminConfig, AdminEntry, AuthorityCeiling, EffectiveTrustClass, HostTrustAssignment,
     HostTrustPolicy, TrustDecision, TrustProvenance,
@@ -91,6 +93,110 @@ async fn default_runtime_uses_persistent_policy_as_dispatch_authority() {
         other => panic!("expected Completed outcome, got {:?}", other),
     }
     assert!(dispatcher.has_request());
+}
+
+// Regression: an auth-resume (BlockedAuth → credential supplied → resume) for a
+// capability authorized only by a persistent-approval grant must re-apply that
+// grant on the resume preflight, exactly as the initial dispatch did. Before the
+// fix, `auth_resume_capability` skipped `apply_persistent_approval_policy`, so the
+// resume re-authorized a grant-less context and was denied — the credential gate
+// resumed only to fail authorization (observed when connecting Gmail: OAuth
+// completed, but the `extension_activate` auth-resume failed `authorization`,
+// while a later fresh dispatch succeeded). With `approval_request_id = None`
+// there is no approval lease to carry the grant, so the persistent policy is the
+// only authority and must be re-applied.
+#[tokio::test]
+async fn default_runtime_uses_persistent_policy_as_auth_resume_authority() {
+    let registry = Arc::new(registry_with_echo_capability());
+    let dispatcher = Arc::new(RecordingDispatcher::default());
+    let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
+    let run_state = Arc::new(InMemoryRunStateStore::new());
+    let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
+    let policies = Arc::new(InMemoryPersistentApprovalPolicyStore::new());
+    let context = execution_context_without_grants();
+    let scope = context.resource_scope.clone();
+    let invocation_id = context.invocation_id;
+    policies
+        .allow(PersistentApprovalPolicyInput {
+            scope: context.resource_scope.clone(),
+            action: PersistentApprovalAction::Dispatch,
+            capability_id: capability_id(),
+            grantee: Principal::Extension(context.extension_id.clone()),
+            approved_by: Principal::User(context.user_id.clone()),
+            constraints: GrantConstraints {
+                allowed_effects: vec![EffectKind::DispatchCapability],
+                mounts: MountView::default(),
+                network: NetworkPolicy::default(),
+                secrets: Vec::new(),
+                resource_ceiling: None,
+                expires_at: None,
+                max_invocations: Some(1),
+            },
+            source_approval_request_id: None,
+        })
+        .await
+        .expect("seed persistent policy");
+    let policy_store: Arc<dyn PersistentApprovalPolicyStore> = policies;
+
+    // Park the invocation in BlockedAuth, mirroring the state after the initial
+    // dispatch raised AuthRequired and opened the credential gate.
+    run_state
+        .start(RunStart {
+            invocation_id,
+            capability_id: capability_id(),
+            scope: scope.clone(),
+        })
+        .await
+        .expect("seed running invocation");
+    run_state
+        .block_auth(&scope, invocation_id, "AuthRequired".to_string())
+        .await
+        .expect("park invocation in BlockedAuth");
+
+    let runtime = DefaultHostRuntime::new(
+        registry,
+        dispatcher.clone(),
+        authorizer,
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+        local_test_runtime_policy(),
+    )
+    .with_trust_policy(Arc::new(local_manifest_trust_policy()))
+    .with_run_state(run_state.clone())
+    .with_approval_requests(approval_requests)
+    .with_persistent_approval_policies(policy_store);
+
+    // Auth-resume carries approval_request_id = None: there is no approval lease,
+    // so the persistent-approval grant is the only authority for the re-dispatch.
+    let outcome = runtime
+        .auth_resume_capability(RuntimeCapabilityAuthResumeRequest::new(
+            context,
+            capability_id(),
+            ResourceEstimate::default(),
+            json!({"message": "hello"}),
+            trust_decision_with_dispatch_authority(),
+            None,
+        ))
+        .await
+        .unwrap();
+
+    match outcome {
+        ironclaw_host_runtime::RuntimeCapabilityOutcome::Completed(completed) => {
+            assert_eq!(completed.capability_id, capability_id());
+            assert_eq!(completed.output, json!({"ok": true}));
+        }
+        other => panic!(
+            "expected Completed auth-resume outcome (persistent grant re-applied), got {:?}",
+            other
+        ),
+    }
+    assert!(dispatcher.has_request());
+
+    let resumed = run_state.get(&scope, invocation_id).await.unwrap().unwrap();
+    assert_eq!(
+        resumed.status,
+        RunStatus::Completed,
+        "auth-resume authorized by the persistent grant must complete the run"
+    );
 }
 
 #[tokio::test]

--- a/crates/ironclaw_loop_support/src/capability_port.rs
+++ b/crates/ironclaw_loop_support/src/capability_port.rs
@@ -2280,7 +2280,7 @@ fn runtime_model_visible_failure_to_loop(
         RuntimeFailureKind::Authorization | RuntimeFailureKind::PolicyDenied
     ) {
         return Ok(CapabilityOutcome::Denied(CapabilityDenied {
-            reason_kind: capability_denied_reason_kind(failure.kind.as_str())?,
+            reason_kind: denied_reason_kind_for(failure.kind)?,
             safe_summary: runtime_failure_safe_summary(&failure, "capability authorization denied"),
         }));
     }
@@ -2355,6 +2355,31 @@ fn ensure_runtime_outcome_matches(
         ));
     }
     Ok(())
+}
+
+/// Maps an authorization/policy runtime failure to a leak-safe denied reason
+/// identifier.
+///
+/// `RuntimeFailureKind::Authorization.as_str()` is the literal string
+/// `"authorization"`, which the loop-safe identifier validator rejects as a
+/// sensitive marker (it guards against leaking `Authorization:` header
+/// material into identifiers). Passing it straight into
+/// `capability_denied_reason_kind` therefore turned every authorization denial
+/// into an internal "could not be represented" error, which the executor
+/// mapped to `HostUnavailable` and the planned driver recorded as a terminal
+/// "driver unavailable" failure — borking the whole run (observed when a Gmail
+/// extension activation failed authorization on auth-resume). Use stable,
+/// non-leaky tags so the denial surfaces to the model as a clean `Denied`
+/// outcome instead.
+fn denied_reason_kind_for(
+    kind: RuntimeFailureKind,
+) -> Result<CapabilityDeniedReasonKind, AgentLoopHostError> {
+    let reason = match kind {
+        RuntimeFailureKind::Authorization => "auth_denied",
+        RuntimeFailureKind::PolicyDenied => "policy_denied",
+        other => other.as_str(),
+    };
+    capability_denied_reason_kind(reason)
 }
 
 fn capability_denied_reason_kind(
@@ -2728,6 +2753,27 @@ mod tests {
             CapabilityOutcome::Denied(denied)
                 if denied.reason_kind.as_str() == "policy_denied"
                     && denied.safe_summary == "policy denied request"
+        ));
+
+        // Regression: RuntimeFailureKind::Authorization.as_str() is the literal
+        // "authorization", which the loop-safe identifier validator rejects as a
+        // sensitive marker. Feeding it straight into the denied reason kind used
+        // to fail conversion with an internal "could not be represented" error,
+        // which the executor mapped to HostUnavailable and the planned driver
+        // turned into a terminal "driver unavailable" failure — borking the run
+        // (e.g. a Gmail activation that failed authorization on auth-resume).
+        // The conversion must instead yield a clean, leak-safe Denied outcome.
+        let auth_denied = runtime_failure_to_loop(RuntimeCapabilityFailure::new(
+            capability_id.clone(),
+            RuntimeFailureKind::Authorization,
+            Some("capability requires authentication".to_string()),
+        ))
+        .expect("convert authorization denial without borking the run");
+        assert!(matches!(
+            auth_denied,
+            CapabilityOutcome::Denied(denied)
+                if denied.reason_kind.as_str() == "auth_denied"
+                    && denied.safe_summary == "capability requires authentication"
         ));
 
         let operation_failed = runtime_failure_to_loop(RuntimeCapabilityFailure::new(


### PR DESCRIPTION
## Problem

Connecting Gmail failed with a misleading **"the execution driver was temporarily unavailable"** error, even though OAuth completed successfully (and the account connected on a later retry). Two distinct defects compounded:

1. **The auth-resume re-authorization was denied** — the *root cause*.
2. **That denial borked the entire run** instead of surfacing cleanly — the *symptom* the user saw.

## Root cause

In the `reborn-cli` / admin-config FirstParty local-dev runtime, `extension_activate` is authorized **only** by a persistent-approval grant. The initial dispatch injects that grant (`apply_persistent_approval_policy`) before authorizing; the handler then raises `AuthRequired` (missing Google token) and the run parks as `BlockedAuth` with a credential gate.

On resume, `auth_resume_capability` rebuilt the execution context **without** re-applying the persistent-approval policy. With `approval_request_id = None` there is no approval lease to carry a grant, so `dispatch_resumed_capability` re-authorized a grant-less context → `AuthorizationDenied`. The denial then hit a second bug: the denied reason-kind was built from `RuntimeFailureKind::Authorization.as_str()` = `"authorization"`, which the loop-safe identifier validator rejects as a sensitive marker → internal "could not be represented" error → mapped to `HostUnavailable` → terminal driver-unavailable failure.

## Fixes

**`fix(loop)` — stop authorization denials from borking the run**
Map `Authorization`/`PolicyDenied` runtime failures to leak-safe denied reason tags (`auth_denied`/`policy_denied`) via `denied_reason_kind_for()` instead of passing the raw kind string through the identifier validator. Authorization denials now surface to the model as a clean `Denied` outcome and the run continues.

**`fix(host-runtime)` — re-apply persistent-approval grant on auth-resume**
`auth_resume_capability` now calls `apply_persistent_approval_policy` (action = `Dispatch`) before building the resume request, mirroring `dispatch_capability`. The helper is a no-op when no matching policy/grant exists, so capabilities requiring fresh approval are unaffected.

`resume_spawn_capability` is intentionally **not** changed: it only handles `BlockedApproval` resumes, which always carry an `approval_request_id` and claim a fingerprinted approval lease that injects the grant — so it does not have this gap.

## Tests

- `runtime_failure_to_loop_honors_model_visible_disposition` — added an `Authorization` case (existing coverage was `PolicyDenied`-only, which validates cleanly and missed the bug).
- `default_runtime_uses_persistent_policy_as_auth_resume_authority` — drives `auth_resume_capability` end-to-end against a `BlockedAuth` run authorized only by a persistent grant; asserts the run completes (fails pre-fix). The persistent-approvals contract previously covered only dispatch and spawn authority.

## Verification

- `host_runtime_persistent_approvals_contract`: 11/11 pass.
- `ironclaw_loop_support` lib `runtime_failure_to_loop` tests pass.
- `cargo clippy -p ironclaw_host_runtime --tests --all-features`: clean.
- `cargo fmt --all --check`: clean.

Scope note: verification covered the two affected packages and their tests, not a full-workspace gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)