### PR TITLE
fix(reborn): refresh OAuth runtime credentials on staging

### DIFF
--- a/crates/ironclaw_reborn_composition/src/product_auth_runtime_credentials.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_runtime_credentials.rs
@@ -1,10 +1,10 @@
-use std::{collections::HashSet, sync::Arc};
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use ironclaw_auth::{
     AuthProductError, AuthProductScope, AuthProviderId, AuthSurface, CredentialAccount,
-    CredentialAccountId, CredentialAccountRecordSource, CredentialAccountSelectionRequest,
-    CredentialAccountStatus, CredentialRefreshReport, CredentialRefreshRequest, ProviderScope,
+    CredentialAccountRecordSource, CredentialAccountSelectionRequest, CredentialAccountStatus,
+    CredentialRefreshReport, CredentialRefreshRequest, ProviderScope,
     select_latest_duplicate_user_reusable_account,
 };
 use ironclaw_host_api::{
@@ -216,15 +216,11 @@ impl RuntimeCredentialAccountVisibilityPolicy for DefaultRuntimeCredentialAccoun
 
 pub(crate) struct ProductAuthRuntimeCredentialAccountRefresher {
     refresh_accounts: Arc<dyn RuntimeCredentialAccountRefreshPort>,
-    refreshed_account_ids: tokio::sync::Mutex<HashSet<CredentialAccountId>>,
 }
 
 impl ProductAuthRuntimeCredentialAccountRefresher {
     pub(crate) fn new(refresh_accounts: Arc<dyn RuntimeCredentialAccountRefreshPort>) -> Self {
-        Self {
-            refresh_accounts,
-            refreshed_account_ids: tokio::sync::Mutex::new(HashSet::new()),
-        }
+        Self { refresh_accounts }
     }
 }
 
@@ -377,13 +373,10 @@ impl RuntimeCredentialAccountRefreshService for ProductAuthRuntimeCredentialAcco
             return Ok(account);
         }
         let account_id = account.id;
-        let mut refreshed_account_ids = self.refreshed_account_ids.lock().await;
-        if refreshed_account_ids.contains(&account_id) {
-            return accounts
-                .select_unique_configured_runtime_account(request)
-                .await;
-        }
 
+        // Access-token expiry is not part of the credential account record, so
+        // refresh each OAuth staging instead of reusing a previously staged
+        // access secret indefinitely.
         let mut refresh_request = CredentialRefreshRequest::new(
             account.scope.clone(),
             account.provider.clone(),
@@ -400,7 +393,6 @@ impl RuntimeCredentialAccountRefreshService for ProductAuthRuntimeCredentialAcco
             .await
         {
             Ok(_) => {
-                refreshed_account_ids.insert(account_id);
                 accounts
                     .select_unique_configured_runtime_account(request)
                     .await

--- a/crates/ironclaw_reborn_composition/src/product_auth_runtime_credentials/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_runtime_credentials/tests.rs
@@ -518,7 +518,7 @@ async fn resolver_refreshes_gsuite_owned_account_with_owner_authority_for_siblin
 }
 
 #[tokio::test]
-async fn resolver_does_not_refresh_same_oauth_account_twice_during_runtime_staging() {
+async fn resolver_refreshes_oauth_account_for_each_runtime_staging() {
     let accounts = Arc::new(InMemoryAuthProductServices::new());
     let scope =
         ResourceScope::local_default(UserId::new("alice").unwrap(), InvocationId::new()).unwrap();
@@ -555,9 +555,9 @@ async fn resolver_does_not_refresh_same_oauth_account_twice_during_runtime_stagi
             requester_extension: &requester_extension,
         })
         .await
-        .expect("second OAuth staging reuses refreshed account");
+        .expect("second OAuth staging refreshes again");
 
-    assert_eq!(second.handle, first.handle);
+    assert_ne!(second.handle, first.handle);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- remove the per-process once-only refresh cache for OAuth runtime credentials
- refresh OAuth-backed ProductAuthAccount credentials whenever they are staged, so Google access tokens are not reused indefinitely after their provider TTL
- update the runtime credential regression test to assert repeated staging gets a fresh OAuth access secret

## Tests
- cargo test -p ironclaw_reborn_composition product_auth_runtime_credentials::tests
- cargo test -p ironclaw_reborn_composition product_auth_runtime_credentials::tests::resolver_refreshes_oauth_account_for_each_runtime_staging -- --exact
- cargo clippy -p ironclaw_reborn_composition --all-targets -- -D warnings