### PR TITLE
[Reborn] feat(bedrock): wire bedrock feature through ironclaw-reborn + fix Converse tool schema

### DIFF
--- a/crates/ironclaw_llm/src/bedrock.rs
+++ b/crates/ironclaw_llm/src/bedrock.rs
@@ -567,10 +567,21 @@ fn build_tool_config(
     let bedrock_tools: Vec<Tool> = tools
         .iter()
         .map(|td| {
-            let input_schema = ToolInputSchema::Json(json_to_document(&td.parameters));
+            // Bedrock's Converse API rejects top-level `oneOf`/`allOf`/`anyOf`
+            // in a tool's input_schema (same constraint as Anthropic's native
+            // API). Flatten those combinators before sending, reusing the
+            // shared `FlattenOnly` policy NEAR AI applies — it does not impose
+            // OpenAI strict-mode nullable rewrites, which Bedrock does not need.
+            let mut description = td.description.clone();
+            let parameters = crate::tool_schema::shape_tool_schema(
+                crate::tool_schema::ToolSchemaPolicy::FlattenOnly,
+                &td.parameters,
+                &mut description,
+            );
+            let input_schema = ToolInputSchema::Json(json_to_document(&parameters));
             let spec = ToolSpecification::builder()
                 .name(&td.name)
-                .description(&td.description)
+                .description(description)
                 .input_schema(input_schema)
                 .build()
                 .map_err(|e| LlmError::RequestFailed {
@@ -1048,6 +1059,42 @@ mod tests {
 
         let result = build_tool_config(&tools, Some("auto")).unwrap();
         assert!(result.is_some());
+    }
+
+    #[test]
+    fn test_build_tool_config_flattens_top_level_combinators() {
+        // Regression: Bedrock's Converse API rejects a tool input_schema with a
+        // top-level `oneOf`/`allOf`/`anyOf` ("input_schema does not support
+        // oneOf, allOf, or anyOf at the top level"). `build_tool_config` must
+        // flatten those combinators (via the shared `FlattenOnly` policy)
+        // before sending, or every tool-enabled Bedrock turn fails.
+        let tools = vec![ToolDefinition {
+            name: "pick".to_string(),
+            description: "Choose a shape".to_string(),
+            parameters: serde_json::json!({
+                "oneOf": [
+                    {"type": "object", "properties": {"a": {"type": "string"}}},
+                    {"type": "object", "properties": {"b": {"type": "number"}}}
+                ]
+            }),
+        }];
+
+        let config = build_tool_config(&tools, Some("auto"))
+            .unwrap()
+            .expect("tool config present");
+        let tool = config.tools().first().expect("one tool");
+        let spec = tool.as_tool_spec().expect("tool spec");
+        let ToolInputSchema::Json(doc) = spec.input_schema().expect("input schema") else {
+            panic!("expected JSON input schema");
+        };
+        let schema = document_to_json(doc);
+        let obj = schema.as_object().expect("schema is an object");
+        assert!(
+            !obj.contains_key("oneOf") && !obj.contains_key("allOf") && !obj.contains_key("anyOf"),
+            "top-level combinators must be flattened before reaching Bedrock, got: {schema}"
+        );
+        // The flattened shape is a plain object the Converse API accepts.
+        assert_eq!(obj.get("type").and_then(|t| t.as_str()), Some("object"));
     }
 
     #[test]

--- a/crates/ironclaw_llm/src/bedrock.rs
+++ b/crates/ironclaw_llm/src/bedrock.rs
@@ -568,10 +568,21 @@ fn build_tool_config(
     let bedrock_tools: Vec<Tool> = tools
         .iter()
         .map(|td| {
-            let input_schema = ToolInputSchema::Json(json_to_document(&td.parameters));
+            // Bedrock's Converse API rejects top-level `oneOf`/`allOf`/`anyOf`
+            // in a tool's input_schema (same constraint as Anthropic's native
+            // API). Flatten those combinators before sending, reusing the
+            // shared `FlattenOnly` policy NEAR AI applies — it does not impose
+            // OpenAI strict-mode nullable rewrites, which Bedrock does not need.
+            let mut description = td.description.clone();
+            let parameters = crate::tool_schema::shape_tool_schema(
+                crate::tool_schema::ToolSchemaPolicy::FlattenOnly,
+                &td.parameters,
+                &mut description,
+            );
+            let input_schema = ToolInputSchema::Json(json_to_document(&parameters));
             let spec = ToolSpecification::builder()
                 .name(&td.name)
-                .description(&td.description)
+                .description(description)
                 .input_schema(input_schema)
                 .build()
                 .map_err(|e| LlmError::RequestFailed {
@@ -1049,6 +1060,42 @@ mod tests {
 
         let result = build_tool_config(&tools, Some("auto")).unwrap();
         assert!(result.is_some());
+    }
+
+    #[test]
+    fn test_build_tool_config_flattens_top_level_combinators() {
+        // Regression: Bedrock's Converse API rejects a tool input_schema with a
+        // top-level `oneOf`/`allOf`/`anyOf` ("input_schema does not support
+        // oneOf, allOf, or anyOf at the top level"). `build_tool_config` must
+        // flatten those combinators (via the shared `FlattenOnly` policy)
+        // before sending, or every tool-enabled Bedrock turn fails.
+        let tools = vec![ToolDefinition {
+            name: "pick".to_string(),
+            description: "Choose a shape".to_string(),
+            parameters: serde_json::json!({
+                "oneOf": [
+                    {"type": "object", "properties": {"a": {"type": "string"}}},
+                    {"type": "object", "properties": {"b": {"type": "number"}}}
+                ]
+            }),
+        }];
+
+        let config = build_tool_config(&tools, Some("auto"))
+            .unwrap()
+            .expect("tool config present");
+        let tool = config.tools().first().expect("one tool");
+        let spec = tool.as_tool_spec().expect("tool spec");
+        let ToolInputSchema::Json(doc) = spec.input_schema().expect("input schema") else {
+            panic!("expected JSON input schema");
+        };
+        let schema = document_to_json(doc);
+        let obj = schema.as_object().expect("schema is an object");
+        assert!(
+            !obj.contains_key("oneOf") && !obj.contains_key("allOf") && !obj.contains_key("anyOf"),
+            "top-level combinators must be flattened before reaching Bedrock, got: {schema}"
+        );
+        // The flattened shape is a plain object the Converse API accepts.
+        assert_eq!(obj.get("type").and_then(|t| t.as_str()), Some("object"));
     }
 
     #[test]

--- a/crates/ironclaw_reborn_cli/Cargo.toml
+++ b/crates/ironclaw_reborn_cli/Cargo.toml
@@ -56,6 +56,15 @@ openai-compat-beta = [
 postgres = [
     "ironclaw_reborn_composition/postgres",
 ]
+# Compile in the AWS Bedrock LLM provider for `ironclaw-reborn`. Forwards
+# to the composition crate's `bedrock` feature, which implies
+# `root-llm-provider` and links the AWS SDK in `ironclaw_llm`. Select the
+# backend at runtime with `LLM_BACKEND=bedrock` (or `ironclaw-reborn models
+# set-provider bedrock`); auth resolves from the standard AWS credential
+# chain (`AWS_PROFILE`, IAM env vars, SSO, instance roles).
+bedrock = [
+    "ironclaw_reborn_composition/bedrock",
+]
 [dependencies]
 anyhow = "1"
 async-trait = { version = "0.1", optional = true }

--- a/crates/ironclaw_reborn_cli/Cargo.toml
+++ b/crates/ironclaw_reborn_cli/Cargo.toml
@@ -70,6 +70,15 @@ libsql = [
 inmemory-turn-state = [
     "ironclaw_reborn_composition/inmemory-turn-state",
 ]
+# Compile in the AWS Bedrock LLM provider for `ironclaw-reborn`. Forwards
+# to the composition crate's `bedrock` feature, which implies
+# `root-llm-provider` and links the AWS SDK in `ironclaw_llm`. Select the
+# backend at runtime with `LLM_BACKEND=bedrock` (or `ironclaw-reborn models
+# set-provider bedrock`); auth resolves from the standard AWS credential
+# chain (`AWS_PROFILE`, IAM env vars, SSO, instance roles).
+bedrock = [
+    "ironclaw_reborn_composition/bedrock",
+]
 [dependencies]
 anyhow = "1"
 async-trait = { version = "0.1", optional = true }

--- a/crates/ironclaw_reborn_composition/Cargo.toml
+++ b/crates/ironclaw_reborn_composition/Cargo.toml
@@ -22,6 +22,15 @@ root-llm-provider = [
     "ironclaw_llm/registry-provider-factory",
     "ironclaw_reborn/root-llm-provider",
 ]
+# Compile in the AWS Bedrock provider (native Converse API via the AWS
+# SDK). Implies `root-llm-provider` because the Bedrock backend is only
+# reachable once a real LLM gateway is wired, and forwards the heavy
+# `aws-*` dependency gate to `ironclaw_llm`. Off by default so substrate
+# and non-AWS builds don't link the AWS SDK.
+bedrock = [
+    "root-llm-provider",
+    "ironclaw_llm/bedrock",
+]
 # Expose test-only helpers (mock LLM gateway, budget runtime accessors)
 # so integration tests in this crate's `tests/` directory and downstream
 # crates can drive `build_reborn_runtime` with a stub model gateway

--- a/crates/ironclaw_reborn_composition/Cargo.toml
+++ b/crates/ironclaw_reborn_composition/Cargo.toml
@@ -36,6 +36,15 @@ root-llm-provider = [
     "ironclaw_llm/registry-provider-factory",
     "ironclaw_reborn/root-llm-provider",
 ]
+# Compile in the AWS Bedrock provider (native Converse API via the AWS
+# SDK). Implies `root-llm-provider` because the Bedrock backend is only
+# reachable once a real LLM gateway is wired, and forwards the heavy
+# `aws-*` dependency gate to `ironclaw_llm`. Off by default so substrate
+# and non-AWS builds don't link the AWS SDK.
+bedrock = [
+    "root-llm-provider",
+    "ironclaw_llm/bedrock",
+]
 # Expose test-only helpers (mock LLM gateway, budget runtime accessors)
 # so integration tests in this crate's `tests/` directory and downstream
 # crates can drive `build_reborn_runtime` with a stub model gateway


### PR DESCRIPTION
Fixes #5058.

## Problem

AWS Bedrock could not be used with the standalone `ironclaw-reborn` binary, for two reasons:

1. **Feature unreachable.** `bedrock` is compile-gated in `ironclaw_llm`, but neither `ironclaw_reborn_cli` nor `ironclaw_reborn_composition` forwarded it. With `ironclaw_llm` not a direct dependency of the CLI crate, there was no way to enable Bedrock — selecting it at runtime returned *"Bedrock support not compiled. Rebuild with --features bedrock"*.
2. **Converse tool-schema crash.** `build_tool_config` sent `ToolDefinition.parameters` to the Converse API verbatim. Bedrock (like Anthropic's native API) rejects a tool `input_schema` with a top-level `oneOf`/`allOf`/`anyOf`, so **every** tool-enabled Bedrock turn aborted with a validation error before producing a reply.

## Changes

- **Feature passthrough:** `ironclaw_reborn_cli/bedrock` → `ironclaw_reborn_composition/bedrock` (implies `root-llm-provider`) → `ironclaw_llm/bedrock`. Mirrors the existing `postgres` passthrough; no new `#[cfg]` branching in code, off by default so non-AWS builds don't link the AWS SDK.
- **Tool-schema fix:** `build_tool_config` now normalizes each tool schema with the shared `FlattenOnly` policy (the same one NEAR AI uses) before sending — flattens top-level combinators without imposing OpenAI strict-mode nullable rewrites, which Bedrock doesn't need.
- **Regression test:** `test_build_tool_config_flattens_top_level_combinators` drives `build_tool_config` with a top-level `oneOf` and asserts the rendered Bedrock `input_schema` contains no combinators.

## How to use

```bash
cargo build -p ironclaw_reborn_cli --features bedrock,webui-v2-beta --bin ironclaw-reborn
ironclaw-reborn models set-provider bedrock --model anthropic.claude-opus-4-8
AWS_PROFILE=<profile> BEDROCK_REGION=us-east-1 BEDROCK_CROSS_REGION=us ironclaw-reborn serve
```
Auth resolves from the standard AWS credential chain (`AWS_PROFILE`, IAM env vars, SSO, instance roles).

## Verification

- Built `ironclaw-reborn --features bedrock,webui-v2-beta`; ran Bedrock `anthropic.claude-opus-4-8` (`us` cross-region) with an SSO profile. Single-turn `run` **and** a full WebUI v2 chat both returned a finalized assistant reply.
- `cargo fmt`: clean. `cargo clippy --all --benches --tests --examples --all-features`: zero warnings. `ironclaw_llm` lib tests pass (913 + the new regression test). The 17 pre-existing `--lib --all-features` failures in the root crate (`extensions::manager`, `channels::wasm::wrapper`) reproduce on clean `main` and are unrelated to this diff (environmental: OS keychain / secret store unavailable in the sandbox).