### PR TITLE
fix(reborn): Projects — address leftover review comments on the merged port

### DIFF
--- a/crates/ironclaw_product_workflow/src/reborn_services.rs
+++ b/crates/ironclaw_product_workflow/src/reborn_services.rs
@@ -4950,6 +4950,7 @@ mod project_error_mapping_tests {
 
         let unavailable = map_project_service_error(ProjectServiceError::Unavailable);
         assert_eq!(unavailable.code, RebornServicesErrorCode::Unavailable);
+        assert_eq!(unavailable.status_code, 503);
         assert!(unavailable.retryable, "unavailable is retryable");
 
         let internal = map_project_service_error(ProjectServiceError::Internal);
@@ -4957,11 +4958,15 @@ mod project_error_mapping_tests {
         assert_eq!(internal.status_code, 500);
     }
 
-    /// The default (unwired) facade reports project methods as unavailable so a
-    /// runtime without a wired `ProjectService` returns a clean 503, not a panic.
+    /// `require_project_service` returns `service_unavailable(false)` when no
+    /// project service is wired (see the helper in this file). This locks the
+    /// full shape of that sentinel — a clean, non-retryable 503 — so an unwired
+    /// runtime returns a stable error rather than a panic or a 500.
     #[test]
-    fn unwired_project_service_is_unavailable() {
+    fn unwired_project_service_sentinel_is_503() {
         let unavailable = RebornServicesError::service_unavailable(false);
         assert_eq!(unavailable.code, RebornServicesErrorCode::Unavailable);
+        assert_eq!(unavailable.status_code, 503);
+        assert!(!unavailable.retryable, "false-arg sentinel is non-retryable");
     }
 }

--- a/crates/ironclaw_product_workflow/src/reborn_services.rs
+++ b/crates/ironclaw_product_workflow/src/reborn_services.rs
@@ -4919,3 +4919,49 @@ fn generated_thread_id(
         }
     }
 }
+
+#[cfg(test)]
+mod project_error_mapping_tests {
+    use super::*;
+
+    /// Every `ProjectServiceError` variant projects to a sanitized facade error
+    /// with the expected coarse code/status, and `InvalidInput`'s field name is
+    /// carried through (it is a controlled constant, never backend text).
+    #[test]
+    fn project_service_error_maps_to_sanitized_facade_error() {
+        let not_found = map_project_service_error(ProjectServiceError::NotFound);
+        assert_eq!(not_found.code, RebornServicesErrorCode::NotFound);
+        assert_eq!(not_found.status_code, 404);
+
+        let denied = map_project_service_error(ProjectServiceError::Denied);
+        assert_eq!(denied.kind, RebornServicesErrorKind::ParticipantDenied);
+        assert_eq!(denied.status_code, 403);
+
+        let invalid = map_project_service_error(ProjectServiceError::InvalidInput {
+            field: "project_id".to_string(),
+        });
+        assert_eq!(invalid.code, RebornServicesErrorCode::InvalidRequest);
+        assert_eq!(invalid.status_code, 400);
+        assert_eq!(invalid.field.as_deref(), Some("project_id"));
+
+        let conflict = map_project_service_error(ProjectServiceError::Conflict);
+        assert_eq!(conflict.code, RebornServicesErrorCode::Conflict);
+        assert_eq!(conflict.status_code, 409);
+
+        let unavailable = map_project_service_error(ProjectServiceError::Unavailable);
+        assert_eq!(unavailable.code, RebornServicesErrorCode::Unavailable);
+        assert!(unavailable.retryable, "unavailable is retryable");
+
+        let internal = map_project_service_error(ProjectServiceError::Internal);
+        assert_eq!(internal.code, RebornServicesErrorCode::Internal);
+        assert_eq!(internal.status_code, 500);
+    }
+
+    /// The default (unwired) facade reports project methods as unavailable so a
+    /// runtime without a wired `ProjectService` returns a clean 503, not a panic.
+    #[test]
+    fn unwired_project_service_is_unavailable() {
+        let unavailable = RebornServicesError::service_unavailable(false);
+        assert_eq!(unavailable.code, RebornServicesErrorCode::Unavailable);
+    }
+}

--- a/crates/ironclaw_product_workflow/src/reborn_services.rs
+++ b/crates/ironclaw_product_workflow/src/reborn_services.rs
@@ -4921,7 +4921,7 @@ fn generated_thread_id(
 }
 
 #[cfg(test)]
-mod project_error_mapping_tests {
+mod tests {
     use super::*;
 
     /// Every `ProjectServiceError` variant projects to a sanitized facade error
@@ -4967,6 +4967,9 @@ mod project_error_mapping_tests {
         let unavailable = RebornServicesError::service_unavailable(false);
         assert_eq!(unavailable.code, RebornServicesErrorCode::Unavailable);
         assert_eq!(unavailable.status_code, 503);
-        assert!(!unavailable.retryable, "false-arg sentinel is non-retryable");
+        assert!(
+            !unavailable.retryable,
+            "false-arg sentinel is non-retryable"
+        );
     }
 }

--- a/crates/ironclaw_product_workflow/src/reborn_services/projects.rs
+++ b/crates/ironclaw_product_workflow/src/reborn_services/projects.rs
@@ -14,6 +14,7 @@
 //! `ironclaw_filesystem::FileType`).
 
 use async_trait::async_trait;
+use chrono::{DateTime, Utc};
 use ironclaw_host_api::{TenantId, UserId};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
@@ -28,7 +29,8 @@ pub struct ProjectCaller {
     pub user_id: UserId,
 }
 
-/// Access role a user holds on a project. Ordered `viewer < editor < owner`.
+/// Access role a user holds on a project. Privilege order, highest first:
+/// `Owner > Editor > Viewer` (matches the variant declaration order).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum RebornProjectRole {
@@ -68,8 +70,10 @@ pub struct RebornProjectInfo {
     pub state: RebornProjectState,
     /// The calling user's effective role on this project.
     pub role: RebornProjectRole,
-    pub created_at: String,
-    pub updated_at: String,
+    /// RFC3339 on the wire (serde-serialized `DateTime<Utc>`); typed here to
+    /// match the other WebUI facade DTOs rather than an ambiguous `String`.
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
 }
 
 /// Sanitized membership grant view returned to the WebUI.
@@ -79,8 +83,8 @@ pub struct RebornProjectMemberInfo {
     pub role: RebornProjectRole,
     pub status: RebornProjectMemberStatus,
     pub granted_by: String,
-    pub created_at: String,
-    pub updated_at: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
 }
 
 /// Browser body for listing the caller's projects.
@@ -186,9 +190,14 @@ pub struct RebornUpdateMemberRoleRequest {
 }
 
 /// Browser body for revoking a member.
+///
+/// `project_id` and `user_id` come from the route path (handler-overridden), so
+/// both carry `#[serde(default)]` like [`RebornUpdateMemberRoleRequest`].
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RebornRemoveMemberRequest {
+    #[serde(default)]
     pub project_id: String,
+    #[serde(default)]
     pub user_id: String,
 }
 
@@ -204,7 +213,7 @@ pub enum ProjectServiceError {
     NotFound,
     #[error("caller is not permitted to perform this project operation")]
     Denied,
-    #[error("invalid project input")]
+    #[error("invalid project input: {field}")]
     InvalidInput { field: String },
     #[error("project already exists")]
     Conflict,

--- a/crates/ironclaw_product_workflow/tests/reborn_services_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/reborn_services_contract.rs
@@ -1934,8 +1934,8 @@ impl ProjectService for AuthorizingProjectService {
                     metadata: serde_json::json!({}),
                     state: RebornProjectState::Active,
                     role: RebornProjectRole::Owner,
-                    created_at: "1970-01-01T00:00:00Z".to_string(),
-                    updated_at: "1970-01-01T00:00:00Z".to_string(),
+                    created_at: "1970-01-01T00:00:00Z".parse().expect("created at"),
+                    updated_at: "1970-01-01T00:00:00Z".parse().expect("updated at"),
                 },
             })
         } else {

--- a/crates/ironclaw_reborn_composition/src/project_service.rs
+++ b/crates/ironclaw_reborn_composition/src/project_service.rs
@@ -372,8 +372,8 @@ fn project_info(record: ProjectRecord, role: ProjectRole) -> RebornProjectInfo {
         metadata: record.metadata,
         state: project_state_to_product(record.state),
         role: project_role_to_product(role),
-        created_at: record.created_at.to_rfc3339(),
-        updated_at: record.updated_at.to_rfc3339(),
+        created_at: record.created_at,
+        updated_at: record.updated_at,
     }
 }
 
@@ -383,8 +383,8 @@ fn member_info(record: ProjectMemberRecord) -> RebornProjectMemberInfo {
         role: project_role_to_product(record.role),
         status: member_status_to_product(record.status),
         granted_by: record.granted_by.into_string(),
-        created_at: record.created_at.to_rfc3339(),
-        updated_at: record.updated_at.to_rfc3339(),
+        created_at: record.created_at,
+        updated_at: record.updated_at,
     }
 }
 

--- a/crates/ironclaw_webui_v2/tests/webui_v2_handlers_contract.rs
+++ b/crates/ironclaw_webui_v2/tests/webui_v2_handlers_contract.rs
@@ -4622,8 +4622,8 @@ fn sample_project_info(project_id: &str) -> RebornProjectInfo {
         metadata: serde_json::json!({}),
         state: RebornProjectState::Active,
         role: RebornProjectRole::Owner,
-        created_at: "2026-06-17T00:00:00Z".to_string(),
-        updated_at: "2026-06-17T00:00:00Z".to_string(),
+        created_at: "2026-06-17T00:00:00Z".parse().expect("created at"),
+        updated_at: "2026-06-17T00:00:00Z".parse().expect("updated at"),
     }
 }
 
@@ -4633,8 +4633,8 @@ fn sample_member_info(user_id: &str) -> RebornProjectMemberInfo {
         role: RebornProjectRole::Editor,
         status: RebornProjectMemberStatus::Active,
         granted_by: "user-alpha".to_string(),
-        created_at: "2026-06-17T00:00:00Z".to_string(),
-        updated_at: "2026-06-17T00:00:00Z".to_string(),
+        created_at: "2026-06-17T00:00:00Z".parse().expect("created at"),
+        updated_at: "2026-06-17T00:00:00Z".parse().expect("updated at"),
     }
 }
 


### PR DESCRIPTION
Follow-up addressing review comments left unaddressed on the **merged** Projects slices (#5015 crate, #5016 port) — they merged before triage during the stacked rollout.

## Fixed here (port DTOs / facade, `ironclaw_product_workflow`)
- **Typed timestamps** — `RebornProjectInfo` / `RebornProjectMemberInfo` `created_at`/`updated_at` are now `DateTime<Utc>`, matching the other WebUI facade DTOs. Wire output is unchanged (serde still emits RFC3339). *(Copilot ×2, CodeRabbit)*
- **Role doc order** — `RebornProjectRole` doc now matches the variant declaration order `Owner > Editor > Viewer`. *(Copilot)*
- **`RebornRemoveMemberRequest`** — `project_id`/`user_id` are path-driven → `#[serde(default)]`, consistent with `RebornUpdateMemberRoleRequest`. *(Copilot)*
- **`ProjectServiceError::InvalidInput`** — Display now includes `field`. *(Copilot)*
- **Contract test** — `ProjectServiceError → RebornServicesError` mapping (all six variants + `InvalidInput` field passthrough) and the unwired-service unavailable case. *(CodeRabbit)*

## Deferred with reasoning (replied on the threads)
- **Typed IDs in DTOs** (CodeRabbit) — `String` is the deliberate wire-boundary type per `.claude/rules/types.md`; the DTO is the boundary, the domain record is typed.
- **Tri-state update fields** `Option<Option<T>>` (CodeRabbit) — real but a semantic change that ripples into the `update_project` handler; tracked separately.
- **`InvalidInput` field → enum** (CodeRabbit) — the field values are already hardcoded constants (`project_id`/`user_id`/`project`/`member`), not backend text, so the leak risk is already mitigated.
- **`store.rs` orphan / read-then-write atomicity** (Copilot ×2, + the #5017 update/membership-race finds) — needs CAS/conditional-update semantics on the merged `ironclaw_projects` `ProjectRepository`; grouped into one repository-CAS follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)