### PR TITLE
fix(ci): repair nightly full-E2E v2-engine matrix and guard against missing scenario files

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,10 +27,18 @@ jobs:
     outputs:
       matrix: ${{ steps.set.outputs.matrix }}
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+          persist-credentials: false
+
+      - name: Check E2E matrix scenario files
+        run: scripts/ci/check-e2e-matrix-files.sh
+
       - id: set
         run: |
           SMOKE='[{"group":"core","files":"tests/e2e/scenarios/test_connection.py tests/e2e/scenarios/test_chat.py tests/e2e/scenarios/test_sse_reconnect.py tests/e2e/scenarios/test_html_injection.py tests/e2e/scenarios/test_csp.py"}]'
-          FULL='[{"group":"core","files":"tests/e2e/scenarios/test_connection.py tests/e2e/scenarios/test_chat.py tests/e2e/scenarios/test_sse_reconnect.py tests/e2e/scenarios/test_html_injection.py tests/e2e/scenarios/test_csp.py"},{"group":"features","files":"tests/e2e/scenarios/test_skills.py tests/e2e/scenarios/test_tool_approval.py tests/e2e/scenarios/test_webhook.py"},{"group":"extensions","files":"tests/e2e/scenarios/test_extensions.py tests/e2e/scenarios/test_extension_oauth.py tests/e2e/scenarios/test_oauth_url_parameters.py tests/e2e/scenarios/test_telegram_token_validation.py tests/e2e/scenarios/test_telegram_hot_activation.py tests/e2e/scenarios/test_wasm_lifecycle.py tests/e2e/scenarios/test_tool_execution.py tests/e2e/scenarios/test_agent_loop_recovery.py tests/e2e/scenarios/test_pairing.py tests/e2e/scenarios/test_mcp_auth_flow.py tests/e2e/scenarios/test_oauth_credential_fallback.py tests/e2e/scenarios/test_routine_oauth_credential_injection.py tests/e2e/scenarios/test_telegram_pairing_chat_claim.py"},{"group":"routines","files":"tests/e2e/scenarios/test_owner_scope.py tests/e2e/scenarios/test_routine_event_batch.py"},{"group":"web-regressions","files":"tests/e2e/scenarios/test_auth_no_duplicate_response.py tests/e2e/scenarios/test_message_persistence.py tests/e2e/scenarios/test_pending_user_messages.py"},{"group":"v2-engine","files":"tests/e2e/scenarios/test_v2_engine_auth_flow.py tests/e2e/scenarios/test_v2_engine_approval_flow.py tests/e2e/scenarios/test_v2_engine_tool_lifecycle.py tests/e2e/scenarios/test_v2_tool_activate_surface.py tests/e2e/scenarios/test_v2_kernel_auth_gateway_flow.py tests/e2e/scenarios/test_v2_thread_visibility.py"}]'
+          FULL='[{"group":"core","files":"tests/e2e/scenarios/test_connection.py tests/e2e/scenarios/test_chat.py tests/e2e/scenarios/test_sse_reconnect.py tests/e2e/scenarios/test_html_injection.py tests/e2e/scenarios/test_csp.py"},{"group":"features","files":"tests/e2e/scenarios/test_skills.py tests/e2e/scenarios/test_tool_approval.py tests/e2e/scenarios/test_webhook.py"},{"group":"extensions","files":"tests/e2e/scenarios/test_extensions.py tests/e2e/scenarios/test_extension_oauth.py tests/e2e/scenarios/test_oauth_url_parameters.py tests/e2e/scenarios/test_telegram_token_validation.py tests/e2e/scenarios/test_telegram_hot_activation.py tests/e2e/scenarios/test_wasm_lifecycle.py tests/e2e/scenarios/test_tool_execution.py tests/e2e/scenarios/test_agent_loop_recovery.py tests/e2e/scenarios/test_pairing.py tests/e2e/scenarios/test_mcp_auth_flow.py tests/e2e/scenarios/test_oauth_credential_fallback.py tests/e2e/scenarios/test_routine_oauth_credential_injection.py tests/e2e/scenarios/test_telegram_pairing_chat_claim.py"},{"group":"routines","files":"tests/e2e/scenarios/test_owner_scope.py tests/e2e/scenarios/test_routine_event_batch.py"},{"group":"web-regressions","files":"tests/e2e/scenarios/test_auth_no_duplicate_response.py tests/e2e/scenarios/test_message_persistence.py tests/e2e/scenarios/test_pending_user_messages.py"},{"group":"v2-engine","files":"tests/e2e/scenarios/test_v2_engine_auth_flow.py tests/e2e/scenarios/test_v2_engine_approval_flow.py tests/e2e/scenarios/test_v2_engine_tool_lifecycle.py tests/e2e/scenarios/test_v2_kernel_auth_gateway_flow.py tests/e2e/scenarios/test_v2_thread_visibility.py"}]'
 
           if [ "${{ inputs.mode || 'full' }}" = "smoke" ]; then
             echo "matrix=${SMOKE}" >> "$GITHUB_OUTPUT"
@@ -124,4 +132,3 @@ jobs:
             echo "One or more E2E jobs failed"
             exit 1
           fi
-

--- a/scripts/ci/check-e2e-matrix-files.sh
+++ b/scripts/ci/check-e2e-matrix-files.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+workflow="${1:-.github/workflows/e2e.yml}"
+
+if [[ "${workflow}" != /* ]]; then
+  workflow="${repo_root}/${workflow}"
+fi
+
+python3 - "${repo_root}" "${workflow}" <<'PY'
+import json
+import re
+import sys
+from pathlib import Path
+
+repo_root = Path(sys.argv[1])
+workflow = Path(sys.argv[2])
+workflow_text = workflow.read_text(encoding="utf-8")
+
+path_re = re.compile(r"tests/e2e/scenarios/[A-Za-z0-9_./-]+\.py")
+paths = set(path_re.findall(workflow_text))
+
+
+def collect_paths(value):
+    if isinstance(value, str):
+        paths.update(path_re.findall(value))
+    elif isinstance(value, list):
+        for item in value:
+            collect_paths(item)
+    elif isinstance(value, dict):
+        for item in value.values():
+            collect_paths(item)
+
+
+matrix_assignment_re = re.compile(r"(?m)^\s*([A-Z][A-Z0-9_]*)='(\[[^\n]*\])'\s*$")
+parsed_matrix_count = 0
+
+for match in matrix_assignment_re.finditer(workflow_text):
+    matrix_name = match.group(1)
+    matrix_json = match.group(2)
+    try:
+        matrix = json.loads(matrix_json)
+    except json.JSONDecodeError as exc:
+        print(f"{workflow}: invalid JSON in {matrix_name}: {exc}", file=sys.stderr)
+        sys.exit(2)
+    parsed_matrix_count += 1
+    collect_paths(matrix)
+
+if parsed_matrix_count == 0:
+    print(
+        f"{workflow}: no inline JSON matrix assignments found; checked direct path references only",
+        file=sys.stderr,
+    )
+
+if not paths:
+    print(f"{workflow}: no tests/e2e/scenarios/*.py references found", file=sys.stderr)
+    sys.exit(2)
+
+missing = sorted(path for path in paths if not (repo_root / path).is_file())
+if missing:
+    print(
+        "Missing E2E scenario files referenced by .github/workflows/e2e.yml:",
+        file=sys.stderr,
+    )
+    for path in missing:
+        print(f"  {path}", file=sys.stderr)
+    sys.exit(1)
+
+print(f"All referenced E2E scenario files exist ({len(paths)} checked).")
+PY


### PR DESCRIPTION
## Summary

Fixes the nightly/full E2E `v2-engine` matrix, which still referenced `tests/e2e/scenarios/test_v2_tool_activate_surface.py`. That file no longer exists, so the nightly v2-engine E2E lane could fail on a missing pytest path or silently under-run depending on how the matrix was invoked.

Adds `scripts/ci/check-e2e-matrix-files.sh` so stale `tests/e2e/scenarios/*.py` references in `.github/workflows/e2e.yml` fail fast.

## Rename vs delete evidence

- `git log --oneline --all -- tests/e2e/scenarios/test_v2_tool_activate_surface.py` showed the file was added in `2ef7d2c98` and last touched/deleted in `4696a0a5a`.
- `git log --diff-filter=D --oneline -- '*test_v2_tool_activate_surface*'` showed deletion in `4696a0a5a`.
- `ls tests/e2e/scenarios/ | grep -i activate` found no current activate-named scenario.
- `rg` for `test_v2_tool_activate_surface`, `activate_surface`, `v2_tool_activate`, and `v2_tool_lifecycle` found no replacement filename.
- `git show 4696a0a5a` documents the intentional `tool_activate` removal and says equivalent coverage moved into bridge/engine tests plus the live mission Gmail E2E.

Based on that evidence this is a deletion/obsolete-coverage case, not a rename, so this PR removes the stale matrix entry rather than replacing it with another filename.

## Guard wiring

- New executable guard: `scripts/ci/check-e2e-matrix-files.sh`.
- The guard parses inline JSON matrix assignments in `.github/workflows/e2e.yml`, scans for referenced `tests/e2e/scenarios/*.py` paths, and exits non-zero with the missing path list when any file is absent.
- `.github/workflows/e2e.yml` now runs the guard inside `matrix-config` after checkout and before the Rust build job, so every `e2e.yml` invocation fails fast without building the binary.

## Validation

- `bash scripts/ci/check-e2e-matrix-files.sh` -> `All referenced E2E scenario files exist (31 checked).`
- Fake missing-file probe against a temp workflow copy -> reported `tests/e2e/scenarios/test_missing_guard_probe.py` and exited non-zero.
- `python3 -c "import sys,yaml; [yaml.safe_load(open(f)) for f in sys.argv[1:]]; print('yaml ok')" .github/workflows/e2e.yml` -> `yaml ok`.
- `scripts/ci/check-e2e-matrix-files.sh` -> `All referenced E2E scenario files exist (31 checked).`
- `bash -n scripts/ci/check-e2e-matrix-files.sh` and `git diff --check` exited 0.

Automated agent-authored PR.