### PR TITLE
perf(ci): adopt mold linker and lift CARGO_BUILD_JOBS=1 on Reborn CI

### DIFF
--- a/.github/workflows/reborn-integration.yml
+++ b/.github/workflows/reborn-integration.yml
@@ -32,9 +32,10 @@ env:
   # cfg!(test) covers unit tests; this covers integration/e2e that link the
   # non-cfg(test) library.
   IRONCLAW_DISABLE_OS_KEYCHAIN: "1"
-  # GitHub-hosted runners can crash lld with bus errors when several large
-  # Reborn test binaries link concurrently.
-  CARGO_BUILD_JOBS: "1"
+  # PR #5086 measured mold linking the heaviest Reborn build in parallel with
+  # no OOM, so keep Cargo's default parallelism. If runner OOMs recur, restore
+  # the previous one-job Cargo build serialization as the one-line fallback.
+  RUSTFLAGS: "-C linker=clang -C link-arg=--ld-path=/usr/bin/mold"
   CARGO_PROFILE_DEV_DEBUG: 0
   CARGO_PROFILE_TEST_DEBUG: 0
 
@@ -118,6 +119,9 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
+      - name: Install mold and clang
+        run: sudo apt-get update && sudo apt-get install -y clang mold
+
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
@@ -167,6 +171,25 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: Install mold and clang
+        run: sudo apt-get update && sudo apt-get install -y clang mold
+
+      - name: Verify mold linker is active
+        run: |
+          clang_output="$(
+            printf 'int main(void) { return 0; }\n' \
+              | clang --ld-path=/usr/bin/mold -Wl,--version -x c - -o /tmp/clang-mold-check 2>&1
+          )"
+          printf '%s\n' "$clang_output"
+          grep -qi mold <<< "$clang_output"
+
+          printf 'fn main() { println!("mold-link-ok"); }\n' > /tmp/mold-link-check.rs
+          rustc /tmp/mold-link-check.rs \
+            -C linker=clang \
+            -C link-arg=--ld-path=/usr/bin/mold \
+            -o /tmp/mold-link-check
+          test "$(/tmp/mold-link-check)" = "mold-link-ok"
 
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2

--- a/.github/workflows/reborn-tests.yml
+++ b/.github/workflows/reborn-tests.yml
@@ -38,9 +38,10 @@ env:
   # cfg!(test) covers unit tests; this covers integration/e2e that link the
   # non-cfg(test) library.
   IRONCLAW_DISABLE_OS_KEYCHAIN: "1"
-  # GitHub-hosted runners can crash lld with bus errors when several large
-  # Reborn test binaries link concurrently.
-  CARGO_BUILD_JOBS: "1"
+  # PR #5086 measured mold linking the heaviest Reborn build in parallel with
+  # no OOM, so keep Cargo's default parallelism. If runner OOMs recur, restore
+  # the previous one-job Cargo build serialization as the one-line fallback.
+  RUSTFLAGS: "-C linker=clang -C link-arg=--ld-path=/usr/bin/mold"
   CARGO_PROFILE_DEV_DEBUG: 0
   CARGO_PROFILE_TEST_DEBUG: 0
 
@@ -161,6 +162,9 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
+      - name: Install mold and clang
+        run: sudo apt-get update && sudo apt-get install -y clang mold
+
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
@@ -176,8 +180,7 @@ jobs:
           feature_flags="$(scripts/ci/package-feature-flags.sh "$PACKAGE")"
 
           if [ "$PACKAGE" = "ironclaw_reborn_composition" ]; then
-            echo "Serializing ironclaw_reborn_composition test builds to keep runner disk usage bounded."
-            export CARGO_BUILD_JOBS=1
+            echo "Disabling incremental compilation for ironclaw_reborn_composition to keep runner disk usage bounded."
             export CARGO_INCREMENTAL=0
           fi
 
@@ -221,6 +224,25 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: Install mold and clang
+        run: sudo apt-get update && sudo apt-get install -y clang mold
+
+      - name: Verify mold linker is active
+        run: |
+          clang_output="$(
+            printf 'int main(void) { return 0; }\n' \
+              | clang --ld-path=/usr/bin/mold -Wl,--version -x c - -o /tmp/clang-mold-check 2>&1
+          )"
+          printf '%s\n' "$clang_output"
+          grep -qi mold <<< "$clang_output"
+
+          printf 'fn main() { println!("mold-link-ok"); }\n' > /tmp/mold-link-check.rs
+          rustc /tmp/mold-link-check.rs \
+            -C linker=clang \
+            -C link-arg=--ld-path=/usr/bin/mold \
+            -o /tmp/mold-link-check
+          test "$(/tmp/mold-link-check)" = "mold-link-ok"
 
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2


### PR DESCRIPTION
## Summary

Adopts the PR #5086-proven mold linker setup for the real Reborn CI workflows and removes the `CARGO_BUILD_JOBS=1` serial-link tax so Cargo can use its default parallelism. PR #5086 measured mold on the heaviest Reborn build (`--workspace --all-targets --all-features`) and proved parallel linking succeeds with no OOM, unlocking the measured ~4x build potential without the prior lld bus-error workaround.

## Workflow Changes

- `.github/workflows/reborn-tests.yml`: adds global mold `RUSTFLAGS`, installs `clang` and `mold` in the Rust crate-test matrix and root partition jobs, removes the workflow-level build serialization, and removes the composition crate's local build-job serialization while preserving its `CARGO_INCREMENTAL=0` disk guard.
- `.github/workflows/reborn-integration.yml`: adds global mold `RUSTFLAGS`, installs `clang` and `mold` in the Rust crate-test matrix and root partition jobs, and removes the workflow-level build serialization.

Both workflows use the proven linker flags: `-C linker=clang -C link-arg=--ld-path=/usr/bin/mold`, with apt install via `sudo apt-get update && sudo apt-get install -y clang mold`.

## Verification Step

Each workflow's root partition job now verifies mold is active by checking that `clang --ld-path=/usr/bin/mold -Wl,--version` reports mold during a real clang link invocation, then compiling and running a tiny Rust binary with `rustc -C linker=clang -C link-arg=--ld-path=/usr/bin/mold`. This avoids the false-negative pattern of grepping successful rustc linker stdout.

## Fallback

If runner OOMs recur, the one-line fallback is to restore `CARGO_BUILD_JOBS=1`.

## Local Validation

- `python3 -c "import yaml;[yaml.safe_load(open(f)) for f in ['.github/workflows/reborn-tests.yml','.github/workflows/reborn-integration.yml']];print('yaml ok')"` -> `yaml ok`
- `! grep -rn CARGO_BUILD_JOBS .github/workflows/reborn-tests.yml .github/workflows/reborn-integration.yml`
- Confirmed mold `RUSTFLAGS`, install steps, and root-job verification are present in both workflows.
- `git diff --check`
- `git diff --name-only` showed only `.github/workflows/reborn-tests.yml` and `.github/workflows/reborn-integration.yml` before commit.
- `actionlint` was not available in this environment.

Automated agent-authored change.
