### PR TITLE
perf(ci): extend mold linker to reborn-e2e and replay-gate Rust jobs

### DIFF
--- a/.github/workflows/reborn-e2e.yml
+++ b/.github/workflows/reborn-e2e.yml
@@ -42,6 +42,9 @@ concurrency:
   group: reborn-e2e-${{ github.event_name }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
+env:
+  RUSTFLAGS: "-C linker=clang -C link-arg=--ld-path=/usr/bin/mold"
+
 jobs:
   rust-reborn:
     name: Rust Reborn (${{ matrix.group }})
@@ -63,6 +66,25 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: Install mold and clang
+        run: sudo apt-get update && sudo apt-get install -y clang mold
+
+      - name: Verify mold linker is active
+        run: |
+          clang_output="$(
+            printf 'int main(void) { return 0; }\n' \
+              | clang --ld-path=/usr/bin/mold -Wl,--version -x c - -o /tmp/clang-mold-check 2>&1
+          )"
+          printf '%s\n' "$clang_output"
+          grep -qi mold <<< "$clang_output"
+
+          printf 'fn main() { println!("mold-link-ok"); }\n' > /tmp/mold-link-check.rs
+          rustc /tmp/mold-link-check.rs \
+            -C linker=clang \
+            -C link-arg=--ld-path=/usr/bin/mold \
+            -o /tmp/mold-link-check
+          test "$(/tmp/mold-link-check)" = "mold-link-ok"
 
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
@@ -88,6 +110,9 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: Install mold and clang
+        run: sudo apt-get update && sudo apt-get install -y clang mold
 
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
@@ -133,6 +158,9 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: Install mold and clang
+        run: sudo apt-get update && sudo apt-get install -y clang mold
 
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2

--- a/.github/workflows/replay-gate.yml
+++ b/.github/workflows/replay-gate.yml
@@ -27,6 +27,9 @@ on:
 permissions:
   contents: read
 
+env:
+  RUSTFLAGS: "-C linker=clang -C link-arg=--ld-path=/usr/bin/mold"
+
 jobs:
   replay-snapshots:
     name: Replay snapshot gate
@@ -41,6 +44,25 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: Install mold and clang
+        run: sudo apt-get update && sudo apt-get install -y clang mold
+
+      - name: Verify mold linker is active
+        run: |
+          clang_output="$(
+            printf 'int main(void) { return 0; }\n' \
+              | clang --ld-path=/usr/bin/mold -Wl,--version -x c - -o /tmp/clang-mold-check 2>&1
+          )"
+          printf '%s\n' "$clang_output"
+          grep -qi mold <<< "$clang_output"
+
+          printf 'fn main() { println!("mold-link-ok"); }\n' > /tmp/mold-link-check.rs
+          rustc /tmp/mold-link-check.rs \
+            -C linker=clang \
+            -C link-arg=--ld-path=/usr/bin/mold \
+            -o /tmp/mold-link-check
+          test "$(/tmp/mold-link-check)" = "mold-link-ok"
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:


### PR DESCRIPTION
## Summary

Extends the proven #5089 mold linker recipe to the remaining link-bound Reborn Rust CI jobs. This keeps the same explicit linker flags: `-C linker=clang -C link-arg=--ld-path=/usr/bin/mold`.

The expected win here is mold-vs-lld only, so it should be smaller than #5089's ~40% improvement. That earlier win mostly came from removing `CARGO_BUILD_JOBS=1`; these jobs never had that setting and already linked in parallel.

## Jobs changed

- `.github/workflows/reborn-e2e.yml`: `rust-reborn` matrix, `gateway-smoke`, `webui-v2-smoke`
- `.github/workflows/replay-gate.yml`: `replay-snapshots`

## Deliberately skipped

- Clippy/check-only jobs were not changed because mold only helps linking.
- Legacy `test.yml` was not changed because it is being sunset.
- `coverage.yml` is left as a deliberate follow-up because it is main-only/nightly and not a PR gate.

## Validation

- YAML parse check for `.github/workflows/reborn-e2e.yml` and `.github/workflows/replay-gate.yml`: passed.
- Targeted Python check confirmed workflow-level `--ld-path=/usr/bin/mold` `RUSTFLAGS` and the mold install step in each modified linking job.
- `git diff --check`: passed.
- Confirmed no `CARGO_BUILD_JOBS` or `-fuse-ld=mold` was added.
- `git diff --name-only origin/main` shows only the two intended workflow files.
- `actionlint` was not available in the local environment.

Automated agent-authored change.