### PR TITLE
test(reborn-qa): port project-setup automation-workflow benchmarks to QA record/replay

### DIFF
--- a/tests/fixtures/llm_traces/reborn_qa/project_setup/README.md
+++ b/tests/fixtures/llm_traces/reborn_qa/project_setup/README.md
@@ -1,0 +1,9 @@
+Project-setup Reborn QA fixtures are recorded manually with live keys.
+
+Do not fabricate fixtures in this directory. Record them with:
+
+```bash
+ANTHROPIC_API_KEY=... GITHUB_TOKEN=... \
+  cargo test --test reborn_qa_project_setup record_ \
+    -- --ignored --test-threads=1 --nocapture
+```

--- a/tests/reborn_qa_project_setup.rs
+++ b/tests/reborn_qa_project_setup.rs
@@ -1,0 +1,561 @@
+//! Recorded-trace scaffold for the project-setup automation-workflow benchmarks.
+//!
+//! Source scenarios:
+//! `nearai/benchmarks/datasets/automation-workflows/v1/project-setup/`.
+//!
+//! Three tiers mirror `tests/reborn_qa_recorded_behavior.rs`:
+//!
+//! 1. **Recorder tests** (`#[ignore]`): seed the benchmark world
+//!    (`SOUL.md` as scenario identity plus workspace memory documents), drive
+//!    the benchmark turn(s) through the real Reborn runtime, real Anthropic,
+//!    and real tools, then flush fixtures under
+//!    `tests/fixtures/llm_traces/reborn_qa/project_setup/`.
+//! 2. **Contract tests** (`#[ignore]` until fixtures exist): parse the fixture
+//!    and pin the benchmark's required and forbidden tool choices plus key
+//!    memory-write arguments.
+//! 3. **Replay tests** (`#[ignore]` until fixtures exist): replay the fixture
+//!    through the real Reborn runtime and assert the resulting memory files.
+//!
+//! Record all seven fixtures with:
+//!
+//! ```bash
+//! ANTHROPIC_API_KEY=... GITHUB_TOKEN=... \
+//!   cargo test --test reborn_qa_project_setup record_ \
+//!     -- --ignored --test-threads=1 --nocapture
+//! ```
+//!
+//! Env by scenario:
+//! - `ANTHROPIC_API_KEY`: all scenarios.
+//! - `GITHUB_TOKEN`: `bind-repo-and-workflow` when the live run exercises the
+//!   GitHub surface while installing `github-workflow`.
+//! - Google credentials: not required for these project-setup scenarios.
+//!
+//! Do not commit fabricated fixtures. A human records and scrubs them with
+//! live keys after this scaffold lands.
+
+#[allow(dead_code)]
+#[path = "support/reborn/mod.rs"]
+mod reborn_support;
+mod support;
+
+use std::sync::Arc;
+
+use reborn_support::{
+    model_replay::RebornTraceReplayModelGateway,
+    qa_trace::{
+        QaTraceScenarioSetup, QaTraceSetupDocument, build_qa_trace_runtime_with_http_exchanges,
+        load_qa_trace, read_qa_memory_document, record_qa_scenario, recorded_tool_calls,
+        seed_qa_trace_world, send_qa_turns, strip_expected_tool_results,
+    },
+};
+use support::trace_llm::{LlmTrace, TraceResponse};
+
+struct ExpectedDocument {
+    path: &'static str,
+    fragments: &'static [&'static str],
+}
+
+struct ProjectSetupScenario {
+    fixture: &'static str,
+    setup: QaTraceScenarioSetup<'static>,
+    turns: &'static [&'static str],
+    tools_used: &'static [&'static str],
+    tools_not_used: &'static [&'static str],
+    response_contains: &'static [&'static str],
+    expected_documents: &'static [ExpectedDocument],
+}
+
+const PROJECT_SETUP_TOOLS_USED: &[&str] = &["builtin.memory_write"];
+const PROJECT_SETUP_TOOLS_NOT_USED: &[&str] = &["gmail", "slack", "google-calendar"];
+
+const ACCEPT_SETUP_DOCS: &[QaTraceSetupDocument<'static>] = &[QaTraceSetupDocument {
+    path: "projects/README.md",
+    content: "# Projects\nOne directory per project. Spec lives at spec.yaml.",
+}];
+const ACCEPT_EXPECTED: &[ExpectedDocument] = &[ExpectedDocument {
+    path: "projects/realtime-notifications/spec.yaml",
+    fragments: &[
+        "Realtime Notifications",
+        "realtime-notifications",
+        "websocket",
+        "alex",
+        "priya",
+        "P95",
+        "500ms",
+    ],
+}];
+const ACCEPT_PROJECT_BRIEF: ProjectSetupScenario = ProjectSetupScenario {
+    fixture: "project_setup/accept-project-brief",
+    setup: QaTraceScenarioSetup {
+        identity_prompt: Some(
+            "You are a project-setup assistant. Convert any user brief into \
+             projects/<slug>/spec.yaml with fields: name, slug (kebab-case), \
+             scope (1-3 sentences), stakeholders[] (each with name, role), \
+             target_date, success_criteria[]. If any required field is \
+             missing, list it under 'open_questions' inside the spec - do not \
+             invent.",
+        ),
+        memory_documents: ACCEPT_SETUP_DOCS,
+    },
+    turns: &[
+        "Start a project called 'Realtime Notifications'. Goal: ship websocket-based push notifications in the web app by end of Q3. Stakeholders: me (PM), alex (eng lead), priya (design). Success: P95 delivery latency < 500ms, opt-in rate > 30%.",
+    ],
+    tools_used: PROJECT_SETUP_TOOLS_USED,
+    tools_not_used: PROJECT_SETUP_TOOLS_NOT_USED,
+    response_contains: &["Realtime Notifications", "alex", "priya", "P95", "500ms"],
+    expected_documents: ACCEPT_EXPECTED,
+};
+
+const BIND_SETUP_DOCS: &[QaTraceSetupDocument<'static>] = &[QaTraceSetupDocument {
+    path: "projects/realtime-notifications/spec.yaml",
+    content: "name: Realtime Notifications\nslug: realtime-notifications\ntype: dev\n",
+}];
+const BIND_EXPECTED: &[ExpectedDocument] = &[
+    ExpectedDocument {
+        path: "projects/realtime-notifications/spec.yaml",
+        fragments: &["repo:", "integrations/github.yaml"],
+    },
+    ExpectedDocument {
+        path: "projects/realtime-notifications/integrations/github.yaml",
+        fragments: &["acme/web-app", "main", "github-workflow"],
+    },
+];
+const BIND_REPO_AND_WORKFLOW: ProjectSetupScenario = ProjectSetupScenario {
+    fixture: "project_setup/bind-repo-and-workflow",
+    setup: QaTraceScenarioSetup {
+        identity_prompt: Some(
+            "You are a project-setup assistant. For dev projects, write \
+             projects/<slug>/integrations/github.yaml with repo (owner/name), \
+             default_branch, and workflows[] = ['github-workflow']. Also \
+             append to projects/<slug>/spec.yaml a `repo:` field pointing at \
+             the integration file.",
+        ),
+        memory_documents: BIND_SETUP_DOCS,
+    },
+    turns: &[
+        "Bind realtime-notifications to repo acme/web-app on default branch main and install github-workflow.",
+    ],
+    tools_used: PROJECT_SETUP_TOOLS_USED,
+    tools_not_used: PROJECT_SETUP_TOOLS_NOT_USED,
+    response_contains: &["acme/web-app", "main", "github-workflow"],
+    expected_documents: BIND_EXPECTED,
+};
+
+const TRACKER_SETUP_DOCS: &[QaTraceSetupDocument<'static>] = &[QaTraceSetupDocument {
+    path: "projects/realtime-notifications/spec.yaml",
+    content: "name: Realtime Notifications\nslug: realtime-notifications\n",
+}];
+const TRACKER_EXPECTED: &[ExpectedDocument] = &[
+    ExpectedDocument {
+        path: "projects/realtime-notifications/spec.yaml",
+        fragments: &[
+            "tracker:",
+            "linear",
+            "linear.app/acme/project/realtime-notifications-abc123",
+            "REA-12",
+        ],
+    },
+    ExpectedDocument {
+        path: "projects/realtime-notifications/integrations/tracker.yaml",
+        fragments: &[
+            "linear",
+            "linear.app/acme/project/realtime-notifications-abc123",
+            "REA-12",
+            "access_method",
+        ],
+    },
+];
+const CREATE_TRACKER_HOME: ProjectSetupScenario = ProjectSetupScenario {
+    fixture: "project_setup/create-tracker-home",
+    setup: QaTraceScenarioSetup {
+        identity_prompt: Some(
+            "You are a project-setup assistant. When binding a tracker: (1) \
+             append a `tracker:` block to projects/<slug>/spec.yaml with \
+             provider, url, id; (2) write \
+             projects/<slug>/integrations/tracker.yaml with the same plus \
+             access_method (api/web). Never invent a tracker URL - only record \
+             what the user gave you.",
+        ),
+        memory_documents: TRACKER_SETUP_DOCS,
+    },
+    turns: &[
+        "Bind the realtime-notifications project to Linear: https://linear.app/acme/project/realtime-notifications-abc123, id REA-12.",
+    ],
+    tools_used: PROJECT_SETUP_TOOLS_USED,
+    tools_not_used: PROJECT_SETUP_TOOLS_NOT_USED,
+    response_contains: &[
+        "linear.app/acme/project/realtime-notifications-abc123",
+        "REA-12",
+    ],
+    expected_documents: TRACKER_EXPECTED,
+};
+
+const STRUCTURE_SETUP_DOCS: &[QaTraceSetupDocument<'static>] = &[QaTraceSetupDocument {
+    path: "projects/realtime-notifications/spec.yaml",
+    content: "name: Realtime Notifications\nslug: realtime-notifications\nscope: ship websocket push notifications in web by end of Q3\nstakeholders:\n  - {name: sam, role: PM}\n  - {name: alex, role: eng-lead}\n  - {name: priya, role: design}\n",
+}];
+const STRUCTURE_EXPECTED: &[ExpectedDocument] = &[
+    ExpectedDocument {
+        path: "projects/realtime-notifications/README.md",
+        fragments: &["spec.yaml"],
+    },
+    ExpectedDocument {
+        path: "projects/realtime-notifications/commitments/open/.keep",
+        fragments: &[],
+    },
+    ExpectedDocument {
+        path: "projects/realtime-notifications/commitments/resolved/.keep",
+        fragments: &[],
+    },
+    ExpectedDocument {
+        path: "projects/realtime-notifications/decisions/.keep",
+        fragments: &[],
+    },
+    ExpectedDocument {
+        path: "projects/realtime-notifications/meetings/.keep",
+        fragments: &[],
+    },
+    ExpectedDocument {
+        path: "projects/realtime-notifications/notes/.keep",
+        fragments: &[],
+    },
+];
+const CREATE_WORKSPACE_STRUCTURE: ProjectSetupScenario = ProjectSetupScenario {
+    fixture: "project_setup/create-workspace-structure",
+    setup: QaTraceScenarioSetup {
+        identity_prompt: Some(
+            "You are a project-setup assistant. The standard scaffold under \
+             projects/<slug>/ is: README.md (one-line description + links), \
+             commitments/open/.keep, commitments/resolved/.keep, \
+             decisions/.keep, meetings/.keep, notes/.keep. README must link \
+             to spec.yaml.",
+        ),
+        memory_documents: STRUCTURE_SETUP_DOCS,
+    },
+    turns: &["Scaffold the workspace for the realtime-notifications project."],
+    tools_used: PROJECT_SETUP_TOOLS_USED,
+    tools_not_used: PROJECT_SETUP_TOOLS_NOT_USED,
+    response_contains: &["README", "commitments", "decisions", "meetings", "notes"],
+    expected_documents: STRUCTURE_EXPECTED,
+};
+
+const DASHBOARD_SETUP_DOCS: &[QaTraceSetupDocument<'static>] = &[
+    QaTraceSetupDocument {
+        path: "projects/realtime-notifications/spec.yaml",
+        content: "name: Realtime Notifications\nslug: realtime-notifications\n",
+    },
+    QaTraceSetupDocument {
+        path: "dashboard/README.md",
+        content: "# Dashboard\nWidget configs in widgets.",
+    },
+];
+const DASHBOARD_EXPECTED: &[ExpectedDocument] = &[ExpectedDocument {
+    path: "dashboard/widgets/realtime-notifications.yaml",
+    fragments: &[
+        "realtime-notifications",
+        "status_card",
+        "open_commitments",
+        "last_update",
+        "owner",
+        "15",
+    ],
+}];
+const DASHBOARD_WIDGET: ProjectSetupScenario = ProjectSetupScenario {
+    fixture: "project_setup/dashboard-widget",
+    setup: QaTraceScenarioSetup {
+        identity_prompt: Some(
+            "You are a project-setup assistant. A dashboard widget is a YAML \
+             file at dashboard/widgets/<slug>.yaml with: title, project_slug, \
+             type (status_card), metrics[] (open_commitments, last_update, \
+             owner), refresh_minutes. Default refresh_minutes=15.",
+        ),
+        memory_documents: DASHBOARD_SETUP_DOCS,
+    },
+    turns: &["Add a dashboard widget for realtime-notifications."],
+    tools_used: PROJECT_SETUP_TOOLS_USED,
+    tools_not_used: PROJECT_SETUP_TOOLS_NOT_USED,
+    response_contains: &[
+        "realtime-notifications",
+        "open_commitments",
+        "last_update",
+        "owner",
+    ],
+    expected_documents: DASHBOARD_EXPECTED,
+};
+
+const ROUTINE_SETUP_DOCS: &[QaTraceSetupDocument<'static>] = &[QaTraceSetupDocument {
+    path: "projects/realtime-notifications/spec.yaml",
+    content: "name: Realtime Notifications\nslug: realtime-notifications\ntimezone: America/Los_Angeles\n",
+}];
+const ROUTINE_EXPECTED: &[ExpectedDocument] = &[
+    ExpectedDocument {
+        path: "projects/realtime-notifications/routines/weekly-status.yaml",
+        fragments: &["weekly-status", "#realtime-notifications", "0 9", "enabled"],
+    },
+    ExpectedDocument {
+        path: "projects/realtime-notifications/routines/standup-digest.yaml",
+        fragments: &[
+            "standup-digest",
+            "#realtime-notifications",
+            "0 10",
+            "enabled",
+        ],
+    },
+];
+const INSTALL_RECURRING_ROUTINES: ProjectSetupScenario = ProjectSetupScenario {
+    fixture: "project_setup/install-recurring-routines",
+    setup: QaTraceScenarioSetup {
+        identity_prompt: Some(
+            "You are a project-setup assistant. Routines live under \
+             projects/<slug>/routines/<name>.yaml with: name, cron (5-field), \
+             action, channel, enabled (default true). Use standard cron syntax \
+             in the project's local TZ.",
+        ),
+        memory_documents: ROUTINE_SETUP_DOCS,
+    },
+    turns: &[
+        "Install two routines for realtime-notifications: 'weekly-status' Mondays 9am posting to #realtime-notifications, and 'standup-digest' weekdays 10am posting to the same channel.",
+    ],
+    tools_used: PROJECT_SETUP_TOOLS_USED,
+    tools_not_used: PROJECT_SETUP_TOOLS_NOT_USED,
+    response_contains: &["weekly-status", "standup-digest", "#realtime-notifications"],
+    expected_documents: ROUTINE_EXPECTED,
+};
+
+const STAKEHOLDER_SETUP_DOCS: &[QaTraceSetupDocument<'static>] = &[QaTraceSetupDocument {
+    path: "projects/realtime-notifications/spec.yaml",
+    content: "name: Realtime Notifications\nslug: realtime-notifications\n",
+}];
+const STAKEHOLDER_EXPECTED: &[ExpectedDocument] = &[
+    ExpectedDocument {
+        path: "projects/realtime-notifications/stakeholders/sam-acme-com.yaml",
+        fragments: &["sam@acme.com", "PM", "slack", "email", "daily"],
+    },
+    ExpectedDocument {
+        path: "projects/realtime-notifications/stakeholders/alex-acme-com.yaml",
+        fragments: &["alex@acme.com", "eng", "slack", "weekly"],
+    },
+    ExpectedDocument {
+        path: "projects/realtime-notifications/stakeholders/priya-acme-com.yaml",
+        fragments: &["priya@acme.com", "design", "email", "weekly"],
+    },
+];
+const REGISTER_STAKEHOLDERS: ProjectSetupScenario = ProjectSetupScenario {
+    fixture: "project_setup/register-stakeholders",
+    setup: QaTraceScenarioSetup {
+        identity_prompt: Some(
+            "You are a project-setup assistant. Persist each stakeholder as \
+             projects/<slug>/stakeholders/<email-slug>.yaml with: name, email, \
+             role, notification_channels[] (slack/email), digest_frequency \
+             (daily/weekly/none). Default digest_frequency is weekly for \
+             non-PMs.",
+        ),
+        memory_documents: STAKEHOLDER_SETUP_DOCS,
+    },
+    turns: &[
+        "Register stakeholders for realtime-notifications: sam@acme.com (PM, slack+email daily), alex@acme.com (eng lead, slack weekly), priya@acme.com (design, email weekly).",
+    ],
+    tools_used: PROJECT_SETUP_TOOLS_USED,
+    tools_not_used: PROJECT_SETUP_TOOLS_NOT_USED,
+    response_contains: &[
+        "sam@acme.com",
+        "alex@acme.com",
+        "priya@acme.com",
+        "daily",
+        "weekly",
+    ],
+    expected_documents: STAKEHOLDER_EXPECTED,
+};
+
+macro_rules! project_setup_tests {
+    ($record:ident, $contract:ident, $replay:ident, $case:expr) => {
+        #[tokio::test]
+        #[ignore = "records against live Anthropic/tools; set ANTHROPIC_API_KEY and run explicitly"]
+        async fn $record() {
+            let case = &$case;
+            record_qa_scenario(case.fixture, &case.setup, case.turns).await;
+        }
+
+        #[tokio::test]
+        #[ignore = "requires a human-recorded project-setup fixture"]
+        async fn $contract() {
+            assert_project_setup_contract(&$case);
+        }
+
+        #[tokio::test]
+        #[ignore = "requires a human-recorded project-setup fixture"]
+        async fn $replay() {
+            replay_project_setup_scenario(&$case).await;
+        }
+    };
+}
+
+project_setup_tests!(
+    record_accept_project_brief,
+    contract_accept_project_brief,
+    replay_accept_project_brief,
+    ACCEPT_PROJECT_BRIEF
+);
+project_setup_tests!(
+    record_bind_repo_and_workflow,
+    contract_bind_repo_and_workflow,
+    replay_bind_repo_and_workflow,
+    BIND_REPO_AND_WORKFLOW
+);
+project_setup_tests!(
+    record_create_tracker_home,
+    contract_create_tracker_home,
+    replay_create_tracker_home,
+    CREATE_TRACKER_HOME
+);
+project_setup_tests!(
+    record_create_workspace_structure,
+    contract_create_workspace_structure,
+    replay_create_workspace_structure,
+    CREATE_WORKSPACE_STRUCTURE
+);
+project_setup_tests!(
+    record_dashboard_widget,
+    contract_dashboard_widget,
+    replay_dashboard_widget,
+    DASHBOARD_WIDGET
+);
+project_setup_tests!(
+    record_install_recurring_routines,
+    contract_install_recurring_routines,
+    replay_install_recurring_routines,
+    INSTALL_RECURRING_ROUTINES
+);
+project_setup_tests!(
+    record_register_stakeholders,
+    contract_register_stakeholders,
+    replay_register_stakeholders,
+    REGISTER_STAKEHOLDERS
+);
+
+fn final_text_reply(trace: &LlmTrace) -> Option<String> {
+    trace
+        .turns
+        .iter()
+        .flat_map(|turn| turn.steps.iter())
+        .rev()
+        .find_map(|step| match &step.response {
+            TraceResponse::Text { content, .. } => Some(content.clone()),
+            _ => None,
+        })
+}
+
+fn assert_project_setup_contract(case: &ProjectSetupScenario) {
+    let trace = load_qa_trace(case.fixture);
+    let calls = recorded_tool_calls(&trace);
+    for tool in case.tools_used {
+        assert!(
+            calls.iter().any(|(name, _)| name == *tool),
+            "expected {tool} to be used for {}; recorded calls: {calls:#?}",
+            case.fixture
+        );
+    }
+    for forbidden in case.tools_not_used {
+        assert!(
+            calls
+                .iter()
+                .all(|(name, arguments)| { !forbidden_tool_matches(name, arguments, forbidden) }),
+            "expected {forbidden} not to be used for {}; recorded calls: {calls:#?}",
+            case.fixture
+        );
+    }
+    for document in case.expected_documents {
+        assert_memory_write_for_document(case, &calls, document);
+    }
+    let reply = final_text_reply(&trace).unwrap_or_else(|| {
+        panic!(
+            "project-setup fixture {} should end with a text reply",
+            case.fixture
+        )
+    });
+    for fragment in case.response_contains {
+        assert!(
+            reply.contains(fragment),
+            "reply for {} should contain {fragment:?}; reply: {reply:?}",
+            case.fixture
+        );
+    }
+}
+
+fn forbidden_tool_matches(name: &str, arguments: &str, forbidden: &str) -> bool {
+    let legacy = forbidden.replace('-', "_");
+    name == forbidden
+        || name == legacy
+        || name.starts_with(&format!("{forbidden}."))
+        || name.starts_with(&format!("{legacy}."))
+        || arguments.contains(&format!("\"{forbidden}\""))
+        || arguments.contains(&format!("\"{legacy}\""))
+}
+
+fn assert_memory_write_for_document(
+    case: &ProjectSetupScenario,
+    calls: &[(String, String)],
+    document: &ExpectedDocument,
+) {
+    let matched = calls.iter().any(|(name, arguments)| {
+        name == "builtin.memory_write"
+            && arguments.contains(document.path)
+            && document
+                .fragments
+                .iter()
+                .all(|fragment| arguments.contains(fragment))
+    });
+    assert!(
+        matched,
+        "expected {} to write {} with fragments {:?}; recorded calls: {calls:#?}",
+        case.fixture, document.path, document.fragments
+    );
+}
+
+async fn replay_project_setup_scenario(case: &ProjectSetupScenario) {
+    let mut trace = load_qa_trace(case.fixture);
+    let http_exchanges = trace.http_exchanges.clone();
+    strip_expected_tool_results(&mut trace);
+    let gateway =
+        RebornTraceReplayModelGateway::from_trace(trace).expect("replay gateway from fixture");
+
+    let root = tempfile::tempdir().expect("tempdir");
+    let runtime = build_qa_trace_runtime_with_http_exchanges(
+        &root,
+        Arc::new(gateway.clone()),
+        http_exchanges,
+    )
+    .await;
+    seed_qa_trace_world(&root, &runtime, &case.setup).await;
+
+    let replies = send_qa_turns(&runtime, case.turns).await;
+    assert_eq!(
+        replies.len(),
+        case.turns.len(),
+        "replayed {} should produce one reply per turn",
+        case.fixture
+    );
+    for reply in replies {
+        assert!(
+            reply.is_successful_final_reply(),
+            "replayed {} should finalize successfully; status {:?}",
+            case.fixture,
+            reply.status
+        );
+    }
+    gateway.assert_exhausted();
+
+    for document in case.expected_documents {
+        let content = read_qa_memory_document(&runtime, document.path).await;
+        for fragment in document.fragments {
+            assert!(
+                content.contains(fragment),
+                "replayed {} document {} should contain {fragment:?}; content: {content:?}",
+                case.fixture,
+                document.path
+            );
+        }
+    }
+
+    runtime.shutdown().await.expect("runtime shutdown");
+}

--- a/tests/support/LIVE_TESTING.md
+++ b/tests/support/LIVE_TESTING.md
@@ -149,6 +149,32 @@ Notes:
   case, add a contract assertion over the selected tool/request/end state, and
   commit the scrubbed fixture.
 
+## Reborn QA Project-Setup Fixtures
+
+`tests/reborn_qa_project_setup.rs` ports the seven
+`automation-workflows/v1/project-setup` benchmarks into the same Reborn QA
+record/replay shape. The committed scaffold contains ignored recorder,
+contract, and replay tiers; a human records fixtures later with live keys.
+
+Record all project-setup fixtures with:
+
+```bash
+ANTHROPIC_API_KEY=... GITHUB_TOKEN=... \
+  cargo test --test reborn_qa_project_setup record_ \
+    -- --ignored --test-threads=1 --nocapture
+```
+
+Env by scenario:
+
+- `ANTHROPIC_API_KEY`: all seven scenarios.
+- `GITHUB_TOKEN`: `bind-repo-and-workflow` when the live run exercises the
+  GitHub surface while installing `github-workflow`.
+- Google credentials: not required for these project-setup scenarios.
+
+Fixtures land in
+`tests/fixtures/llm_traces/reborn_qa/project_setup/<scenario>.json`.
+Scrub them with the PII checklist above before committing.
+
 ## Adding a New Live Test
 
 1. Add a `#[tokio::test]` + `#[ignore]` (live tier — never runs in the

--- a/tests/support/reborn/qa_trace.rs
+++ b/tests/support/reborn/qa_trace.rs
@@ -27,7 +27,14 @@ use ironclaw_auth::{
 };
 use ironclaw_first_party_extensions::GoogleCredentialResolver;
 use ironclaw_host_api::{
-    AgentId, ExtensionId, InvocationId, ResourceScope, SecretHandle, TenantId, UserId,
+    AgentId, CapabilityGrant, CapabilityGrantId, CapabilityId, CapabilitySet, CorrelationId,
+    EffectKind, ExecutionContext, ExtensionId, GrantConstraints, InvocationId, MountAlias,
+    MountGrant, MountPermissions, MountView, NetworkPolicy, Principal, ResourceScope, RuntimeKind,
+    SecretHandle, TenantId, TrustClass, UserId, VirtualPath,
+};
+use ironclaw_host_runtime::{
+    MEMORY_READ_CAPABILITY_ID, MEMORY_WRITE_CAPABILITY_ID, RuntimeCapabilityOutcome,
+    RuntimeCapabilityRequest,
 };
 use ironclaw_llm::{
     LlmConfig, LlmProvider, NearAiConfig, ProviderProtocol, RegistryProviderConfig, SessionConfig,
@@ -52,8 +59,10 @@ use ironclaw_reborn_composition::{
 };
 use ironclaw_reborn_config::{RebornConfigFile, RebornHome};
 use ironclaw_triggers::TriggerPollerWorkerConfig;
+use ironclaw_trust::{AuthorityCeiling, EffectiveTrustClass, TrustDecision, TrustProvenance};
 use ironclaw_turns::{ReplyTargetBindingRef, TurnStatus, run_profile::ModelProfileId};
 use secrecy::{ExposeSecret, SecretString};
+use serde_json::{Value, json};
 
 use crate::support::trace_llm::{LlmTrace, TraceResponse};
 
@@ -402,6 +411,245 @@ pub async fn send_qa_phrase(runtime: &RebornRuntime, phrase: &str) -> AssistantR
         .send_user_message(&conversation, phrase)
         .await
         .expect("QA phrase turn reaches a terminal state")
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct QaTraceSetupDocument<'a> {
+    pub path: &'a str,
+    pub content: &'a str,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct QaTraceScenarioSetup<'a> {
+    pub identity_prompt: Option<&'a str>,
+    pub memory_documents: &'a [QaTraceSetupDocument<'a>],
+}
+
+impl<'a> QaTraceScenarioSetup<'a> {
+    pub const fn empty() -> Self {
+        Self {
+            identity_prompt: None,
+            memory_documents: &[],
+        }
+    }
+}
+
+/// Seed the Reborn QA scenario world into the local-dev runtime before the
+/// first recorded/replayed turn. Memory documents go through the same
+/// host-runtime memory tool the agent uses, so setup state lands under the
+/// same tenant/user/agent scope as replayed tool calls.
+pub async fn seed_qa_trace_world(
+    root: &tempfile::TempDir,
+    runtime: &RebornRuntime,
+    setup: &QaTraceScenarioSetup<'_>,
+) {
+    if let Some(identity_prompt) = setup.identity_prompt {
+        append_qa_identity_prompt(root, identity_prompt);
+    }
+    for document in setup.memory_documents {
+        write_qa_memory_document(runtime, document.path, document.content).await;
+    }
+}
+
+fn append_qa_identity_prompt(root: &tempfile::TempDir, identity_prompt: &str) {
+    let prompt_path = root
+        .path()
+        .join("local-dev")
+        .join("system/prompts/default-system.md");
+    let mut prompt = std::fs::read_to_string(&prompt_path).unwrap_or_else(|error| {
+        panic!(
+            "QA trace scenario could not read default prompt {}: {error}",
+            prompt_path.display()
+        )
+    });
+    prompt.push_str("\n\n## Scenario Identity (SOUL.md)\n\n");
+    prompt.push_str(identity_prompt);
+    prompt.push('\n');
+    std::fs::write(&prompt_path, prompt).unwrap_or_else(|error| {
+        panic!(
+            "QA trace scenario could not write default prompt {}: {error}",
+            prompt_path.display()
+        )
+    });
+}
+
+pub async fn send_qa_turns(runtime: &RebornRuntime, turns: &[&str]) -> Vec<AssistantReply> {
+    let conversation = runtime
+        .new_conversation()
+        .await
+        .expect("new QA scenario conversation");
+    let mut replies = Vec::new();
+    for turn in turns {
+        replies.push(
+            runtime
+                .send_user_message(&conversation, turn)
+                .await
+                .expect("QA scenario turn reaches a terminal state"),
+        );
+    }
+    replies
+}
+
+pub async fn send_qa_turns_until_gate(
+    runtime: &RebornRuntime,
+    turns: &[&str],
+) -> Vec<RebornTurnDriveOutcome> {
+    let conversation = runtime
+        .new_conversation()
+        .await
+        .expect("new QA scenario conversation");
+    let mut outcomes = Vec::new();
+    for turn in turns {
+        let outcome = runtime
+            .send_user_message_until_gate(&conversation, turn)
+            .await
+            .expect("QA scenario turn reaches a terminal status or a gate");
+        let blocked = matches!(outcome, RebornTurnDriveOutcome::BlockedOnGate { .. });
+        outcomes.push(outcome);
+        if blocked {
+            break;
+        }
+    }
+    outcomes
+}
+
+pub async fn write_qa_memory_document(runtime: &RebornRuntime, path: &str, content: &str) {
+    let output = invoke_qa_memory_tool(
+        runtime,
+        MEMORY_WRITE_CAPABILITY_ID,
+        json!({
+            "target": path,
+            "content": content,
+            "append": false
+        }),
+    )
+    .await;
+    assert_eq!(
+        output.get("status").and_then(Value::as_str),
+        Some("written"),
+        "QA setup memory write to {path:?} should report written; output: {output}"
+    );
+}
+
+pub async fn read_qa_memory_document(runtime: &RebornRuntime, path: &str) -> String {
+    let output =
+        invoke_qa_memory_tool(runtime, MEMORY_READ_CAPABILITY_ID, json!({ "path": path })).await;
+    output
+        .get("content")
+        .and_then(Value::as_str)
+        .unwrap_or_else(|| panic!("QA memory read for {path:?} returned no content: {output}"))
+        .to_string()
+}
+
+async fn invoke_qa_memory_tool(
+    runtime: &RebornRuntime,
+    capability_id: &str,
+    input: Value,
+) -> Value {
+    let host_runtime = runtime
+        .services()
+        .host_runtime
+        .as_ref()
+        .expect("QA trace runtime exposes host runtime");
+    let capability = CapabilityId::new(capability_id).expect("QA capability id");
+    let outcome = host_runtime
+        .invoke_capability(RuntimeCapabilityRequest::new(
+            qa_memory_execution_context([MEMORY_WRITE_CAPABILITY_ID, MEMORY_READ_CAPABILITY_ID]),
+            capability.clone(),
+            ironclaw_host_api::ResourceEstimate::default(),
+            input,
+            qa_memory_trust_decision(),
+        ))
+        .await
+        .expect("QA memory capability invocation reaches host runtime");
+    match outcome {
+        RuntimeCapabilityOutcome::Completed(completed) => completed.output,
+        other => panic!("QA memory capability {capability_id} did not complete: {other:?}"),
+    }
+}
+
+fn qa_memory_execution_context<const N: usize>(capabilities: [&str; N]) -> ExecutionContext {
+    let mounts = MountView::new(vec![MountGrant::new(
+        MountAlias::new("/memory").expect("memory mount alias"),
+        VirtualPath::new("/memory").expect("memory mount target"),
+        MountPermissions::read_write_list_delete(),
+    )])
+    .expect("QA memory mounts");
+    let extension_id = ExtensionId::new("reborn-qa").expect("QA caller extension id");
+    let invocation_id = InvocationId::new();
+    let tenant_id = TenantId::new(QA_TENANT).expect("QA tenant id");
+    let user_id = UserId::new(QA_USER).expect("QA user id");
+    let agent_id = AgentId::new(QA_AGENT).expect("QA agent id");
+    let grants = CapabilitySet {
+        grants: capabilities
+            .into_iter()
+            .map(|capability| CapabilityGrant {
+                id: CapabilityGrantId::new(),
+                capability: CapabilityId::new(capability).expect("QA granted capability id"),
+                grantee: Principal::Extension(extension_id.clone()),
+                issued_by: Principal::HostRuntime,
+                constraints: GrantConstraints {
+                    allowed_effects: qa_memory_effects(),
+                    mounts: mounts.clone(),
+                    network: NetworkPolicy::default(),
+                    secrets: Vec::new(),
+                    resource_ceiling: None,
+                    expires_at: None,
+                    max_invocations: None,
+                },
+            })
+            .collect(),
+    };
+    let resource_scope = ResourceScope {
+        tenant_id: tenant_id.clone(),
+        user_id: user_id.clone(),
+        agent_id: Some(agent_id.clone()),
+        project_id: None,
+        mission_id: None,
+        thread_id: None,
+        invocation_id,
+    };
+    let context = ExecutionContext {
+        invocation_id,
+        correlation_id: CorrelationId::new(),
+        process_id: None,
+        parent_process_id: None,
+        tenant_id,
+        user_id,
+        agent_id: Some(agent_id),
+        project_id: None,
+        mission_id: None,
+        thread_id: None,
+        extension_id,
+        runtime: RuntimeKind::FirstParty,
+        trust: TrustClass::FirstParty,
+        grants,
+        mounts,
+        resource_scope,
+    };
+    context.validate().expect("QA memory execution context");
+    context
+}
+
+fn qa_memory_effects() -> Vec<EffectKind> {
+    vec![
+        EffectKind::DispatchCapability,
+        EffectKind::ReadFilesystem,
+        EffectKind::WriteFilesystem,
+        EffectKind::DeleteFilesystem,
+    ]
+}
+
+fn qa_memory_trust_decision() -> TrustDecision {
+    TrustDecision {
+        effective_trust: EffectiveTrustClass::user_trusted(),
+        authority_ceiling: AuthorityCeiling {
+            allowed_effects: qa_memory_effects(),
+            max_resource_ceiling: None,
+        },
+        provenance: TrustProvenance::Default,
+        evaluated_at: chrono::Utc::now(),
+    }
 }
 
 fn live_credentials_for_fixture(fixture_name: &str) -> &'static [&'static LiveCredentialSeed] {
@@ -1451,6 +1699,107 @@ pub async fn record_qa_phrase(fixture_name: &str, phrase: &str) {
 
     // Give the recording a 2s settle so background turn-state writes finish
     // before the tempdir drops.
+    tokio::time::sleep(Duration::from_secs(2)).await;
+}
+
+/// Record a QA scenario with explicit setup and one or more user turns.
+/// Scenario-specific tool and end-state contracts belong in the test module
+/// that defines the scenario; this helper only records the live trace and
+/// verifies every turn reached a successful terminal reply.
+pub async fn record_qa_scenario(
+    fixture_name: &str,
+    setup: &QaTraceScenarioSetup<'_>,
+    turns: &[&str],
+) {
+    let api_key = std::env::var(QA_RECORD_KEY_ENV).unwrap_or_else(|_| {
+        panic!("{QA_RECORD_KEY_ENV} must be set to record QA traces against the live API")
+    });
+    let model = std::env::var(QA_RECORD_MODEL_ENV)
+        .ok()
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| QA_RECORD_DEFAULT_MODEL.to_string());
+
+    let mut live_secret_values = Vec::new();
+    live_secret_values.push((QA_RECORD_KEY_ENV, api_key.clone()));
+    if let Ok(github_token) = std::env::var("GITHUB_TOKEN")
+        && !github_token.is_empty()
+    {
+        live_secret_values.push(("GITHUB_TOKEN", github_token));
+    }
+
+    let config = anthropic_llm_config(api_key, &model);
+    let session = create_session_manager(config.session.clone()).await;
+    let provider = build_static_provider_chain(&config, session)
+        .await
+        .expect("anthropic provider chain builds");
+
+    let fixture_path = qa_fixture_path(fixture_name);
+    if let Some(parent) = fixture_path.parent() {
+        std::fs::create_dir_all(parent).expect("fixture directory");
+    }
+    let recorder = Arc::new(RecordingLlm::new(
+        provider,
+        fixture_path.clone(),
+        format!("recorded-qa-{fixture_name}"),
+    ));
+
+    let profile = ModelProfileId::new(INTERACTIVE_MODEL_PROFILE).expect("model profile id");
+    let policy = LlmModelProfilePolicy::new().allow_model_profile(profile, None);
+    let gateway =
+        LlmProviderModelGateway::new(Arc::clone(&recorder) as Arc<dyn LlmProvider>, policy);
+
+    let root = tempfile::tempdir().expect("tempdir");
+    let runtime = build_qa_trace_runtime_with_http_interceptor(
+        &root,
+        Arc::new(gateway),
+        Some((recorder.http_interceptor(), TraceHttpNetworkMode::Recording)),
+    )
+    .await;
+    seed_qa_trace_world(&root, &runtime, setup).await;
+    live_secret_values.extend(seed_live_credentials_for_fixture(&runtime, fixture_name).await);
+
+    let outcomes = send_qa_turns_until_gate(&runtime, turns).await;
+    runtime.shutdown().await.expect("runtime shutdown");
+
+    recorder.flush().await.expect("flush recorded QA trace");
+    assert_fixture_does_not_contain_live_secret_values(&fixture_path, &live_secret_values);
+    assert_eq!(
+        outcomes.len(),
+        turns.len(),
+        "recorded QA scenario {fixture_name:?} paused before all turns completed; \
+         trace was flushed to {} for inspection",
+        fixture_path.display()
+    );
+    for (index, outcome) in outcomes.into_iter().enumerate() {
+        match outcome {
+            RebornTurnDriveOutcome::Terminal(reply) if reply.is_successful_final_reply() => {}
+            RebornTurnDriveOutcome::Terminal(reply) => {
+                panic!(
+                    "recorded QA scenario {fixture_name:?} turn {index} ended with non-success \
+                     status {:?}; trace was flushed to {} for inspection",
+                    reply.status,
+                    fixture_path.display()
+                );
+            }
+            RebornTurnDriveOutcome::BlockedOnGate {
+                status, gate_ref, ..
+            } => {
+                panic!(
+                    "recorded QA scenario {fixture_name:?} turn {index} paused at gate status \
+                     {:?} ({}); trace was flushed to {} for inspection",
+                    status,
+                    gate_ref.as_str(),
+                    fixture_path.display()
+                );
+            }
+        }
+    }
+
+    println!(
+        "recorded QA scenario trace {} ({} turn(s))",
+        fixture_path.display(),
+        turns.len()
+    );
     tokio::time::sleep(Duration::from_secs(2)).await;
 }
 


### PR DESCRIPTION
## Summary

Ports all seven `automation-workflows/v1/project-setup` benchmarks from `nearai/benchmarks` into the Reborn QA recorded trace harness:

- `accept-project-brief`
- `bind-repo-and-workflow`
- `create-tracker-home`
- `create-workspace-structure`
- `dashboard-widget`
- `install-recurring-routines`
- `register-stakeholders`

This PR is stacked on #5095 / `codex/reborn-qa-http-fixtures`.

## Shape

- Adds `tests/reborn_qa_project_setup.rs` with the same three-tier structure as `reborn_qa_recorded_behavior.rs`:
  - ignored live recorder tests that seed the benchmark world and flush fixtures to `tests/fixtures/llm_traces/reborn_qa/project_setup/<scenario>.json`
  - ignored contract tests that parse fixtures and pin required/forbidden tool choices plus key memory-write args
  - ignored replay tests that replay fixtures through the real Reborn runtime and assert resulting memory files
- Extends `tests/support/reborn/qa_trace.rs` minimally for scenario setup, multi-turn sends, and scoped memory read/write assertions.
- Adds a placeholder README under the project-setup fixture directory. No fabricated fixtures are committed.
- Updates `tests/support/LIVE_TESTING.md` with recording instructions.

## Recording

Fixtures are intentionally recorded later by a human with live keys:

```bash
ANTHROPIC_API_KEY=... GITHUB_TOKEN=... \
  cargo test --test reborn_qa_project_setup record_ \
    -- --ignored --test-threads=1 --nocapture
```

Env by scenario:

- `ANTHROPIC_API_KEY`: all seven scenarios.
- `GITHUB_TOKEN`: `bind-repo-and-workflow` when the live run exercises the GitHub surface while installing `github-workflow`.
- Google credentials: not required for these project-setup scenarios.

Contract and replay tests are `#[ignore]` until those human-recorded fixtures land, so this scaffold should not make CI red for missing fixtures.

## Validation

- `cargo fmt -- tests/reborn_qa_project_setup.rs tests/support/reborn/qa_trace.rs`
- `cargo test --no-run --test reborn_qa_project_setup`

Automated agent-authored change.
