### PR TITLE
feat(extensions): cross-contract credential coherence in v2 manifest projection (Move 3)

### DIFF
--- a/crates/ironclaw_extensions/src/credential_coherence.rs
+++ b/crates/ironclaw_extensions/src/credential_coherence.rs
@@ -1,0 +1,48 @@
+use std::collections::BTreeSet;
+
+use ironclaw_host_api::CredentialHandle;
+
+use crate::v2::{HostApiId, ManifestSectionPath, ManifestV2Error};
+
+/// Credential handle reference reported by one host-api manifest contract.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReferencedCredential {
+    pub handle: CredentialHandle,
+    pub host_api: HostApiId,
+    pub section: ManifestSectionPath,
+}
+
+impl ReferencedCredential {
+    pub fn new(
+        handle: CredentialHandle,
+        host_api: HostApiId,
+        section: ManifestSectionPath,
+    ) -> Self {
+        Self {
+            handle,
+            host_api,
+            section,
+        }
+    }
+}
+
+pub(crate) fn reject_dangling_credentials(
+    declared_credentials: &[CredentialHandle],
+    referenced_credentials: &[ReferencedCredential],
+) -> Result<(), ManifestV2Error> {
+    if declared_credentials.is_empty() {
+        return Ok(());
+    }
+
+    let declared: BTreeSet<_> = declared_credentials.iter().collect();
+    for reference in referenced_credentials {
+        if !declared.contains(&reference.handle) {
+            return Err(ManifestV2Error::DanglingCredentialHandle {
+                handle: reference.handle.clone(),
+                host_api: reference.host_api.clone(),
+                section: reference.section.clone(),
+            });
+        }
+    }
+    Ok(())
+}

--- a/crates/ironclaw_extensions/src/credential_coherence.rs
+++ b/crates/ironclaw_extensions/src/credential_coherence.rs
@@ -1,8 +1,10 @@
 use std::collections::BTreeSet;
 
-use ironclaw_host_api::CredentialHandle;
+use ironclaw_host_api::{CredentialHandle, CredentialHandleError};
 
-use crate::v2::{HostApiId, ManifestSectionPath, ManifestV2Error};
+use crate::v2::{
+    HostApiId, HostApiManifestProjection, HostApiRefV2, ManifestSectionPath, ManifestV2Error,
+};
 
 /// Credential handle reference reported by one host-api manifest contract.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -12,17 +14,39 @@ pub struct ReferencedCredential {
     pub section: ManifestSectionPath,
 }
 
-impl ReferencedCredential {
-    pub fn new(
-        handle: CredentialHandle,
-        host_api: HostApiId,
-        section: ManifestSectionPath,
-    ) -> Self {
-        Self {
-            handle,
-            host_api,
-            section,
+impl HostApiManifestProjection {
+    pub fn declare_credential_handles<I, S>(
+        &mut self,
+        handles: I,
+    ) -> Result<(), CredentialHandleError>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        for handle in handles {
+            self.declared_credentials
+                .push(CredentialHandle::new(handle.as_ref())?);
         }
+        Ok(())
+    }
+
+    pub fn reference_credential_handles<I, S>(
+        &mut self,
+        host_api: &HostApiRefV2,
+        handles: I,
+    ) -> Result<(), CredentialHandleError>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        for handle in handles {
+            self.referenced_credentials.push(ReferencedCredential {
+                handle: CredentialHandle::new(handle.as_ref())?,
+                host_api: host_api.id.clone(),
+                section: host_api.section.clone(),
+            });
+        }
+        Ok(())
     }
 }
 

--- a/crates/ironclaw_extensions/src/credential_coherence.rs
+++ b/crates/ironclaw_extensions/src/credential_coherence.rs
@@ -8,10 +8,10 @@ use crate::v2::{
 
 /// Credential handle reference reported by one host-api manifest contract.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ReferencedCredential {
-    pub handle: CredentialHandle,
-    pub host_api: HostApiId,
-    pub section: ManifestSectionPath,
+pub(crate) struct ReferencedCredential {
+    handle: CredentialHandle,
+    host_api: HostApiId,
+    section: ManifestSectionPath,
 }
 
 impl HostApiManifestProjection {
@@ -23,10 +23,11 @@ impl HostApiManifestProjection {
         I: IntoIterator<Item = S>,
         S: AsRef<str>,
     {
-        for handle in handles {
-            self.declared_credentials
-                .push(CredentialHandle::new(handle.as_ref())?);
-        }
+        let handles = handles
+            .into_iter()
+            .map(|handle| CredentialHandle::new(handle.as_ref()))
+            .collect::<Result<Vec<_>, _>>()?;
+        self.declared_credentials.extend(handles);
         Ok(())
     }
 
@@ -39,13 +40,17 @@ impl HostApiManifestProjection {
         I: IntoIterator<Item = S>,
         S: AsRef<str>,
     {
-        for handle in handles {
-            self.referenced_credentials.push(ReferencedCredential {
-                handle: CredentialHandle::new(handle.as_ref())?,
-                host_api: host_api.id.clone(),
-                section: host_api.section.clone(),
-            });
-        }
+        let references = handles
+            .into_iter()
+            .map(|handle| {
+                Ok(ReferencedCredential {
+                    handle: CredentialHandle::new(handle.as_ref())?,
+                    host_api: host_api.id.clone(),
+                    section: host_api.section.clone(),
+                })
+            })
+            .collect::<Result<Vec<_>, CredentialHandleError>>()?;
+        self.referenced_credentials.extend(references);
         Ok(())
     }
 }

--- a/crates/ironclaw_extensions/src/host_api/capability_provider.rs
+++ b/crates/ironclaw_extensions/src/host_api/capability_provider.rs
@@ -1,12 +1,11 @@
 use std::collections::BTreeSet;
 
-use ironclaw_host_api::{CredentialHandle, RuntimeCredentialRequirementSource};
+use ironclaw_host_api::RuntimeCredentialRequirementSource;
 use serde::Deserialize;
 
 use crate::v2::{
     CapabilityDeclV2, HostApiId, HostApiManifestContext, HostApiManifestContract,
     HostApiManifestProjection, HostApiRefV2, ManifestSectionPath, ManifestV2Error, RawCapabilityV2,
-    ReferencedCredential,
 };
 
 pub const CAPABILITY_PROVIDER_HOST_API_ID: &str = "ironclaw.capability_provider/v1";
@@ -59,12 +58,15 @@ impl HostApiManifestContract for CapabilityProviderHostApiContract {
         section: &toml::Value,
     ) -> Result<HostApiManifestProjection, String> {
         let capabilities = project_capabilities(context, section)?;
-        let referenced_credentials = referenced_runtime_credentials(&capabilities, host_api)?;
-        Ok(HostApiManifestProjection {
-            capabilities,
-            declared_credentials: Vec::new(),
-            referenced_credentials,
-        })
+        let mut projection = HostApiManifestProjection::default();
+        projection
+            .reference_credential_handles(
+                host_api,
+                secret_runtime_credential_handles(&capabilities),
+            )
+            .map_err(|error| error.to_string())?;
+        projection.capabilities = capabilities;
+        Ok(projection)
     }
 }
 
@@ -97,26 +99,16 @@ fn project_capabilities(
     Ok(capabilities)
 }
 
-fn referenced_runtime_credentials(
+fn secret_runtime_credential_handles(
     capabilities: &[CapabilityDeclV2],
-    host_api: &HostApiRefV2,
-) -> Result<Vec<ReferencedCredential>, String> {
-    let mut referenced_credentials = Vec::new();
-    for capability in capabilities {
-        for credential in &capability.runtime_credentials {
-            if credential.source != RuntimeCredentialRequirementSource::SecretHandle {
-                continue;
-            }
-            let handle = CredentialHandle::new(credential.handle.as_str())
-                .map_err(|error| error.to_string())?;
-            referenced_credentials.push(ReferencedCredential::new(
-                handle,
-                host_api.id.clone(),
-                host_api.section.clone(),
-            ));
-        }
-    }
-    Ok(referenced_credentials)
+) -> impl Iterator<Item = &str> {
+    capabilities
+        .iter()
+        .flat_map(|capability| capability.runtime_credentials.iter())
+        .filter_map(|credential| {
+            (credential.source == RuntimeCredentialRequirementSource::SecretHandle)
+                .then_some(credential.handle.as_str())
+        })
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/ironclaw_extensions/src/host_api/capability_provider.rs
+++ b/crates/ironclaw_extensions/src/host_api/capability_provider.rs
@@ -1,10 +1,12 @@
 use std::collections::BTreeSet;
 
+use ironclaw_host_api::{CredentialHandle, RuntimeCredentialRequirementSource};
 use serde::Deserialize;
 
 use crate::v2::{
     CapabilityDeclV2, HostApiId, HostApiManifestContext, HostApiManifestContract,
     HostApiManifestProjection, HostApiRefV2, ManifestSectionPath, ManifestV2Error, RawCapabilityV2,
+    ReferencedCredential,
 };
 
 pub const CAPABILITY_PROVIDER_HOST_API_ID: &str = "ironclaw.capability_provider/v1";
@@ -53,11 +55,15 @@ impl HostApiManifestContract for CapabilityProviderHostApiContract {
     fn project_section_with_context(
         &self,
         context: &HostApiManifestContext<'_>,
-        _host_api: &HostApiRefV2,
+        host_api: &HostApiRefV2,
         section: &toml::Value,
     ) -> Result<HostApiManifestProjection, String> {
+        let capabilities = project_capabilities(context, section)?;
+        let referenced_credentials = referenced_runtime_credentials(&capabilities, host_api)?;
         Ok(HostApiManifestProjection {
-            capabilities: project_capabilities(context, section)?,
+            capabilities,
+            declared_credentials: Vec::new(),
+            referenced_credentials,
         })
     }
 }
@@ -89,6 +95,28 @@ fn project_capabilities(
         capabilities.push(capability);
     }
     Ok(capabilities)
+}
+
+fn referenced_runtime_credentials(
+    capabilities: &[CapabilityDeclV2],
+    host_api: &HostApiRefV2,
+) -> Result<Vec<ReferencedCredential>, String> {
+    let mut referenced_credentials = Vec::new();
+    for capability in capabilities {
+        for credential in &capability.runtime_credentials {
+            if credential.source != RuntimeCredentialRequirementSource::SecretHandle {
+                continue;
+            }
+            let handle = CredentialHandle::new(credential.handle.as_str())
+                .map_err(|error| error.to_string())?;
+            referenced_credentials.push(ReferencedCredential::new(
+                handle,
+                host_api.id.clone(),
+                host_api.section.clone(),
+            ));
+        }
+    }
+    Ok(referenced_credentials)
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/ironclaw_extensions/src/lib.rs
+++ b/crates/ironclaw_extensions/src/lib.rs
@@ -428,7 +428,6 @@ pub use v2::{
     HostApiManifestContract, HostApiManifestProjection, HostApiMultiplicity, HostApiRefV2,
     MANIFEST_SCHEMA_VERSION, MAX_HOOK_ENTRY_BYTES, MAX_MANIFEST_BYTES, MAX_MANIFEST_HOOKS,
     ManifestSectionPath, ManifestSource, ManifestV2Error, RESERVED_HOST_BUNDLED_ID_PREFIX,
-    ReferencedCredential,
 };
 
 pub type CapabilityManifest = CapabilityDeclV2;

--- a/crates/ironclaw_extensions/src/lib.rs
+++ b/crates/ironclaw_extensions/src/lib.rs
@@ -407,6 +407,7 @@ fn descriptors_match_except_schema(
         })
 }
 
+mod credential_coherence;
 pub mod host_api;
 mod hosted_mcp_discovery;
 mod installations;
@@ -427,6 +428,7 @@ pub use v2::{
     HostApiManifestContract, HostApiManifestProjection, HostApiMultiplicity, HostApiRefV2,
     MANIFEST_SCHEMA_VERSION, MAX_HOOK_ENTRY_BYTES, MAX_MANIFEST_BYTES, MAX_MANIFEST_HOOKS,
     ManifestSectionPath, ManifestSource, ManifestV2Error, RESERVED_HOST_BUNDLED_ID_PREFIX,
+    ReferencedCredential,
 };
 
 pub type CapabilityManifest = CapabilityDeclV2;

--- a/crates/ironclaw_extensions/src/v2.rs
+++ b/crates/ironclaw_extensions/src/v2.rs
@@ -37,10 +37,12 @@
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::sync::Arc;
 
+pub use crate::credential_coherence::ReferencedCredential;
+use crate::credential_coherence::reject_dangling_credentials;
 use ironclaw_host_api::{
-    CapabilityId, CapabilityProfileId, CapabilityProfileSchemaRef, EffectKind, ExtensionId,
-    HostApiError, HostPortCatalog, HostPortId, NetworkScheme, NetworkTargetPattern, PermissionMode,
-    RequestedTrustClass, ResourceProfile, RuntimeCredentialRequirement,
+    CapabilityId, CapabilityProfileId, CapabilityProfileSchemaRef, CredentialHandle, EffectKind,
+    ExtensionId, HostApiError, HostPortCatalog, HostPortId, NetworkScheme, NetworkTargetPattern,
+    PermissionMode, RequestedTrustClass, ResourceProfile, RuntimeCredentialRequirement,
     RuntimeCredentialRequirementSource, RuntimeCredentialTarget, RuntimeKind, SecretHandle,
     TrustClass,
 };
@@ -238,6 +240,8 @@ pub struct HostApiManifestContext<'a> {
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct HostApiManifestProjection {
     pub capabilities: Vec<CapabilityDeclV2>,
+    pub declared_credentials: Vec<CredentialHandle>,
+    pub referenced_credentials: Vec<ReferencedCredential>,
 }
 
 /// Host API contract validator registered by composition.
@@ -352,8 +356,22 @@ impl HostApiContractRegistry {
                 }
                 projected.capabilities.push(capability);
             }
+            projected
+                .declared_credentials
+                .extend(section_projection.declared_credentials);
+            projected
+                .referenced_credentials
+                .extend(section_projection.referenced_credentials);
         }
         sections.reject_unreferenced_operational_sections(&manifest.host_apis)?;
+        // TODO(move-1-integration): host_ingress contract should report
+        // host_ingress.*.auth.credential_handles as referenced credentials.
+        // Once that lands, tighten this from "no contradiction when a declared
+        // set exists" to "every referenced handle requires a declaration".
+        reject_dangling_credentials(
+            &projected.declared_credentials,
+            &projected.referenced_credentials,
+        )?;
         Ok(projected)
     }
 }
@@ -501,6 +519,14 @@ pub enum ManifestV2Error {
         id: HostApiId,
         section: ManifestSectionPath,
         reason: String,
+    },
+    #[error(
+        "host API {host_api} section {section} references undeclared credential handle {handle}"
+    )]
+    DanglingCredentialHandle {
+        handle: CredentialHandle,
+        host_api: HostApiId,
+        section: ManifestSectionPath,
     },
     #[error("manifest section {section} was referenced by host_api but does not exist")]
     MissingHostApiSection { section: ManifestSectionPath },

--- a/crates/ironclaw_extensions/src/v2.rs
+++ b/crates/ironclaw_extensions/src/v2.rs
@@ -37,8 +37,7 @@
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::sync::Arc;
 
-pub use crate::credential_coherence::ReferencedCredential;
-use crate::credential_coherence::reject_dangling_credentials;
+use crate::credential_coherence::{ReferencedCredential, reject_dangling_credentials};
 use ironclaw_host_api::{
     CapabilityId, CapabilityProfileId, CapabilityProfileSchemaRef, CredentialHandle, EffectKind,
     ExtensionId, HostApiError, HostPortCatalog, HostPortId, NetworkScheme, NetworkTargetPattern,
@@ -240,8 +239,8 @@ pub struct HostApiManifestContext<'a> {
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct HostApiManifestProjection {
     pub capabilities: Vec<CapabilityDeclV2>,
-    pub declared_credentials: Vec<CredentialHandle>,
-    pub referenced_credentials: Vec<ReferencedCredential>,
+    pub(crate) declared_credentials: Vec<CredentialHandle>,
+    pub(crate) referenced_credentials: Vec<ReferencedCredential>,
 }
 
 /// Host API contract validator registered by composition.

--- a/crates/ironclaw_extensions/tests/manifest_v2_contract.rs
+++ b/crates/ironclaw_extensions/tests/manifest_v2_contract.rs
@@ -6,11 +6,10 @@ use ironclaw_extensions::{
     CapabilityVisibility, ExtensionManifestV2, ExtensionRuntimeV2, HostApiContractRegistry,
     HostApiId, HostApiManifestContract, HostApiManifestProjection, HostApiMultiplicity,
     HostApiRefV2, MANIFEST_SCHEMA_VERSION, ManifestSectionPath, ManifestSource, ManifestV2Error,
-    ReferencedCredential,
 };
 use ironclaw_host_api::{
-    CapabilityProfileId, CredentialHandle, ExtensionId, HostPortCatalog, HostPortCatalogEntry,
-    HostPortId, NetworkScheme, NetworkTargetPattern, PermissionMode, RequestedTrustClass,
+    CapabilityProfileId, ExtensionId, HostPortCatalog, HostPortCatalogEntry, HostPortId,
+    NetworkScheme, NetworkTargetPattern, PermissionMode, RequestedTrustClass,
     RuntimeCredentialAccountProviderId, RuntimeCredentialRequirementSource,
     RuntimeCredentialTarget, RuntimeKind, SecretHandle, TrustClass,
 };
@@ -1219,31 +1218,14 @@ impl HostApiManifestContract for FakeHostApiContract {
         section: &toml::Value,
     ) -> Result<HostApiManifestProjection, String> {
         self.validate_section_with_context(context, host_api, section)?;
-        let declared_credentials = self
-            .declared_credentials
-            .iter()
-            .map(|handle| CredentialHandle::new(*handle).map_err(|error| error.to_string()))
-            .collect::<Result<Vec<_>, _>>()?;
-        let referenced_credentials = self
-            .referenced_credentials
-            .iter()
-            .map(|handle| {
-                CredentialHandle::new(*handle)
-                    .map_err(|error| error.to_string())
-                    .map(|handle| {
-                        ReferencedCredential::new(
-                            handle,
-                            host_api.id.clone(),
-                            host_api.section.clone(),
-                        )
-                    })
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-        Ok(HostApiManifestProjection {
-            capabilities: Vec::new(),
-            declared_credentials,
-            referenced_credentials,
-        })
+        let mut projection = HostApiManifestProjection::default();
+        projection
+            .declare_credential_handles(self.declared_credentials.iter().copied())
+            .map_err(|error| error.to_string())?;
+        projection
+            .reference_credential_handles(host_api, self.referenced_credentials.iter().copied())
+            .map_err(|error| error.to_string())?;
+        Ok(projection)
     }
 }
 

--- a/crates/ironclaw_extensions/tests/manifest_v2_contract.rs
+++ b/crates/ironclaw_extensions/tests/manifest_v2_contract.rs
@@ -4,12 +4,13 @@ use std::sync::Arc;
 
 use ironclaw_extensions::{
     CapabilityVisibility, ExtensionManifestV2, ExtensionRuntimeV2, HostApiContractRegistry,
-    HostApiId, HostApiManifestContract, HostApiMultiplicity, HostApiRefV2, MANIFEST_SCHEMA_VERSION,
-    ManifestSectionPath, ManifestSource, ManifestV2Error,
+    HostApiId, HostApiManifestContract, HostApiManifestProjection, HostApiMultiplicity,
+    HostApiRefV2, MANIFEST_SCHEMA_VERSION, ManifestSectionPath, ManifestSource, ManifestV2Error,
+    ReferencedCredential,
 };
 use ironclaw_host_api::{
-    CapabilityProfileId, ExtensionId, HostPortCatalog, HostPortCatalogEntry, HostPortId,
-    NetworkScheme, NetworkTargetPattern, PermissionMode, RequestedTrustClass,
+    CapabilityProfileId, CredentialHandle, ExtensionId, HostPortCatalog, HostPortCatalogEntry,
+    HostPortId, NetworkScheme, NetworkTargetPattern, PermissionMode, RequestedTrustClass,
     RuntimeCredentialAccountProviderId, RuntimeCredentialRequirementSource,
     RuntimeCredentialTarget, RuntimeKind, SecretHandle, TrustClass,
 };
@@ -1148,6 +1149,8 @@ struct FakeHostApiContract {
     prefix: &'static str,
     multiplicity: HostApiMultiplicity,
     required_key: &'static str,
+    declared_credentials: Vec<&'static str>,
+    referenced_credentials: Vec<&'static str>,
 }
 
 impl FakeHostApiContract {
@@ -1162,7 +1165,19 @@ impl FakeHostApiContract {
             prefix,
             multiplicity,
             required_key,
+            declared_credentials: Vec::new(),
+            referenced_credentials: Vec::new(),
         }
+    }
+
+    fn declares(mut self, handles: Vec<&'static str>) -> Self {
+        self.declared_credentials = handles;
+        self
+    }
+
+    fn references(mut self, handles: Vec<&'static str>) -> Self {
+        self.referenced_credentials = handles;
+        self
     }
 }
 
@@ -1195,6 +1210,40 @@ impl HostApiManifestContract for FakeHostApiContract {
         } else {
             Err(format!("missing required key {}", self.required_key))
         }
+    }
+
+    fn project_section_with_context(
+        &self,
+        context: &ironclaw_extensions::HostApiManifestContext<'_>,
+        host_api: &HostApiRefV2,
+        section: &toml::Value,
+    ) -> Result<HostApiManifestProjection, String> {
+        self.validate_section_with_context(context, host_api, section)?;
+        let declared_credentials = self
+            .declared_credentials
+            .iter()
+            .map(|handle| CredentialHandle::new(*handle).map_err(|error| error.to_string()))
+            .collect::<Result<Vec<_>, _>>()?;
+        let referenced_credentials = self
+            .referenced_credentials
+            .iter()
+            .map(|handle| {
+                CredentialHandle::new(*handle)
+                    .map_err(|error| error.to_string())
+                    .map(|handle| {
+                        ReferencedCredential::new(
+                            handle,
+                            host_api.id.clone(),
+                            host_api.section.clone(),
+                        )
+                    })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(HostApiManifestProjection {
+            capabilities: Vec::new(),
+            declared_credentials,
+            referenced_credentials,
+        })
     }
 }
 
@@ -1439,6 +1488,54 @@ output_schema_ref = "schemas/telegram/legacy.output.v1.json"
     )
     .unwrap_err();
     assert!(matches!(err, ManifestV2Error::Invalid { .. }), "{err:?}");
+}
+
+#[test]
+fn rejects_cross_contract_dangling_credential_handle() {
+    let product = Arc::new(
+        FakeHostApiContract::new(
+            "ironclaw.product_adapter/v1",
+            "product_adapter",
+            HostApiMultiplicity::Multiple,
+            "surface_kind",
+        )
+        .declares(vec!["telegram_bot_token"]),
+    );
+    let capabilities = Arc::new(
+        FakeHostApiContract::new(
+            "ironclaw.capability_provider/v1",
+            "capability_provider",
+            HostApiMultiplicity::Single,
+            "capabilities",
+        )
+        .references(vec!["github_token"]),
+    );
+    let mut registry = HostApiContractRegistry::new();
+    registry.register(product).unwrap();
+    registry.register(capabilities).unwrap();
+
+    let err = ExtensionManifestV2::parse_with_host_api_contracts(
+        &telegram_multi_host_api_manifest(),
+        ManifestSource::InstalledLocal,
+        &catalog(),
+        &registry,
+    )
+    .unwrap_err();
+
+    assert!(
+        matches!(
+            err,
+            ManifestV2Error::DanglingCredentialHandle {
+                ref handle,
+                ref host_api,
+                ref section,
+            }
+                if handle.as_str() == "github_token"
+                    && host_api.as_str() == "ironclaw.capability_provider/v1"
+                    && section.as_str() == "capability_provider.tools"
+        ),
+        "{err:?}"
+    );
 }
 
 #[test]

--- a/crates/ironclaw_host_api/src/ids.rs
+++ b/crates/ironclaw_host_api/src/ids.rs
@@ -7,6 +7,7 @@
 //! smuggled into manifests, mount paths, approvals, or audit records.
 
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 use uuid::Uuid;
 
 use crate::HostApiError;
@@ -207,6 +208,86 @@ string_id!(
 );
 string_id!(SystemServiceId, "system_service", validate_name_segment);
 
+/// Canonical extension-manifest credential binding handle.
+///
+/// Domain contracts may keep narrower handle newtypes for their local schema
+/// vocabulary. They convert into this shared handle only when reporting
+/// declared/referenced credentials into the v2 manifest projection boundary.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(try_from = "String")]
+pub struct CredentialHandle(String);
+
+impl CredentialHandle {
+    fn validate(value: &str) -> Result<(), CredentialHandleError> {
+        if value.is_empty() {
+            return Err(CredentialHandleError::Invalid {
+                value: value.to_string(),
+                reason: "must not be empty",
+            });
+        }
+        if value.len() > 256 {
+            return Err(CredentialHandleError::Invalid {
+                value: value.to_string(),
+                reason: "must be at most 256 bytes",
+            });
+        }
+        if has_forbidden_control(value) {
+            return Err(CredentialHandleError::Invalid {
+                value: value.to_string(),
+                reason: "NUL/control characters are not allowed",
+            });
+        }
+        Ok(())
+    }
+
+    pub fn new(raw: impl Into<String>) -> Result<Self, CredentialHandleError> {
+        let value = raw.into();
+        Self::validate(&value)?;
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn into_inner(self) -> String {
+        self.0
+    }
+}
+
+impl TryFrom<String> for CredentialHandle {
+    type Error = CredentialHandleError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::validate(&value)?;
+        Ok(Self(value))
+    }
+}
+
+impl AsRef<str> for CredentialHandle {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for CredentialHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl From<CredentialHandle> for String {
+    fn from(handle: CredentialHandle) -> Self {
+        handle.0
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum CredentialHandleError {
+    #[error("invalid credential handle '{value}': {reason}")]
+    Invalid { value: String, reason: &'static str },
+}
+
 /// Extension-prefixed capability identifier.
 ///
 /// Capability IDs require at least two dot-separated segments and may use
@@ -278,3 +359,27 @@ uuid_id!(ResourceReservationId);
 uuid_id!(ApprovalRequestId);
 uuid_id!(AuditEventId);
 uuid_id!(CorrelationId);
+
+#[cfg(test)]
+mod tests {
+    use super::CredentialHandle;
+
+    #[test]
+    fn credential_handle_accepts_manifest_safe_values() {
+        let handle = CredentialHandle::new("telegram_bot_token").unwrap();
+        assert_eq!(handle.as_str(), "telegram_bot_token");
+
+        let parsed: CredentialHandle = serde_json::from_str("\"slack.signing-secret\"").unwrap();
+        assert_eq!(parsed.as_str(), "slack.signing-secret");
+    }
+
+    #[test]
+    fn credential_handle_rejects_malformed_values() {
+        for raw in ["", "telegram\nsecret", "x\0y"] {
+            assert!(
+                CredentialHandle::new(raw).is_err(),
+                "expected {raw:?} to be rejected"
+            );
+        }
+    }
+}

--- a/crates/ironclaw_product_adapter_registry/src/lib.rs
+++ b/crates/ironclaw_product_adapter_registry/src/lib.rs
@@ -18,10 +18,11 @@ use std::sync::Arc;
 use ironclaw_extensions::{
     ExtensionInstallation, ExtensionInstallationError, ExtensionInstallationStore,
     ExtensionManifestRecord, ExtensionManifestV2, HostApiContractRegistry, HostApiId,
-    HostApiManifestContext, HostApiManifestContract, HostApiMultiplicity, HostApiRefV2,
-    ManifestSectionPath, ManifestSource, ManifestV2Error,
+    HostApiManifestContext, HostApiManifestContract, HostApiManifestProjection,
+    HostApiMultiplicity, HostApiRefV2, ManifestSectionPath, ManifestSource, ManifestV2Error,
+    ReferencedCredential,
 };
-use ironclaw_host_api::{ExtensionId, HostPortCatalog};
+use ironclaw_host_api::{CredentialHandle, ExtensionId, HostPortCatalog};
 use ironclaw_product_adapters::{
     AuthRequirement, DeclaredEgressTarget, EgressCredentialHandle, ProductAdapterCapabilities,
     ProductAdapterId, ProductCapabilityFlag, ProductSurfaceKind,
@@ -317,6 +318,41 @@ impl HostApiManifestContract for ProductAdapterHostApiContract {
         .map(|_| ())
         .map_err(|e| e.to_string())
     }
+
+    fn project_section_with_context(
+        &self,
+        context: &HostApiManifestContext<'_>,
+        host_api: &HostApiRefV2,
+        section: &toml::Value,
+    ) -> Result<HostApiManifestProjection, String> {
+        let adapter = ProductAdapterHostApiSection::from_value(
+            context.extension_id,
+            host_api.section.clone(),
+            section.clone(),
+        )
+        .map_err(|error| error.to_string())?;
+        let declared_credentials = adapter
+            .required_credentials()
+            .iter()
+            .map(canonical_credential_handle)
+            .collect::<Result<Vec<_>, _>>()?;
+        let referenced_credentials = adapter
+            .declared_egress()
+            .iter()
+            .filter_map(|target| target.credential_handle.as_ref())
+            .map(|handle| {
+                canonical_credential_handle(handle).map(|handle| {
+                    ReferencedCredential::new(handle, host_api.id.clone(), host_api.section.clone())
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(HostApiManifestProjection {
+            capabilities: Vec::new(),
+            declared_credentials,
+            referenced_credentials,
+        })
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -417,6 +453,12 @@ fn validate_installation_against_one_manifest(
         }
     }
     Ok(())
+}
+
+fn canonical_credential_handle(
+    handle: &EgressCredentialHandle,
+) -> Result<CredentialHandle, String> {
+    CredentialHandle::new(handle.as_str()).map_err(|error| error.to_string())
 }
 
 fn validate_auth_requirement(requirement: &AuthRequirement) -> Result<(), RegistryError> {

--- a/crates/ironclaw_product_adapter_registry/src/lib.rs
+++ b/crates/ironclaw_product_adapter_registry/src/lib.rs
@@ -20,9 +20,8 @@ use ironclaw_extensions::{
     ExtensionManifestRecord, ExtensionManifestV2, HostApiContractRegistry, HostApiId,
     HostApiManifestContext, HostApiManifestContract, HostApiManifestProjection,
     HostApiMultiplicity, HostApiRefV2, ManifestSectionPath, ManifestSource, ManifestV2Error,
-    ReferencedCredential,
 };
-use ironclaw_host_api::{CredentialHandle, ExtensionId, HostPortCatalog};
+use ironclaw_host_api::{ExtensionId, HostPortCatalog};
 use ironclaw_product_adapters::{
     AuthRequirement, DeclaredEgressTarget, EgressCredentialHandle, ProductAdapterCapabilities,
     ProductAdapterId, ProductCapabilityFlag, ProductSurfaceKind,
@@ -331,27 +330,27 @@ impl HostApiManifestContract for ProductAdapterHostApiContract {
             section.clone(),
         )
         .map_err(|error| error.to_string())?;
-        let declared_credentials = adapter
-            .required_credentials()
-            .iter()
-            .map(canonical_credential_handle)
-            .collect::<Result<Vec<_>, _>>()?;
-        let referenced_credentials = adapter
-            .declared_egress()
-            .iter()
-            .filter_map(|target| target.credential_handle.as_ref())
-            .map(|handle| {
-                canonical_credential_handle(handle).map(|handle| {
-                    ReferencedCredential::new(handle, host_api.id.clone(), host_api.section.clone())
-                })
-            })
-            .collect::<Result<Vec<_>, _>>()?;
+        let mut projection = HostApiManifestProjection::default();
+        projection
+            .declare_credential_handles(
+                adapter
+                    .required_credentials()
+                    .iter()
+                    .map(EgressCredentialHandle::as_str),
+            )
+            .map_err(|error| error.to_string())?;
+        projection
+            .reference_credential_handles(
+                host_api,
+                adapter
+                    .declared_egress()
+                    .iter()
+                    .filter_map(|target| target.credential_handle.as_ref())
+                    .map(EgressCredentialHandle::as_str),
+            )
+            .map_err(|error| error.to_string())?;
 
-        Ok(HostApiManifestProjection {
-            capabilities: Vec::new(),
-            declared_credentials,
-            referenced_credentials,
-        })
+        Ok(projection)
     }
 }
 
@@ -453,12 +452,6 @@ fn validate_installation_against_one_manifest(
         }
     }
     Ok(())
-}
-
-fn canonical_credential_handle(
-    handle: &EgressCredentialHandle,
-) -> Result<CredentialHandle, String> {
-    CredentialHandle::new(handle.as_str()).map_err(|error| error.to_string())
 }
 
 fn validate_auth_requirement(requirement: &AuthRequirement) -> Result<(), RegistryError> {

--- a/crates/ironclaw_product_adapter_registry/tests/manifest_ingestion.rs
+++ b/crates/ironclaw_product_adapter_registry/tests/manifest_ingestion.rs
@@ -1,9 +1,21 @@
-use ironclaw_extensions::{ExtensionManifestRecord, MANIFEST_SCHEMA_VERSION, ManifestSource};
+use std::sync::Arc;
+
+use ironclaw_extensions::{
+    ExtensionManifestRecord, ExtensionManifestV2, HostApiContractRegistry, HostApiId,
+    HostApiManifestContract, HostApiRefV2, MANIFEST_SCHEMA_VERSION, ManifestSectionPath,
+    ManifestSource,
+};
 use ironclaw_host_api::HostPortCatalog;
 use ironclaw_product_adapter_registry::{
-    ManifestHash, RegistryError, parse_product_adapter_manifest_record, product_adapter_sections,
+    ManifestHash, ProductAdapterHostApiContract, RegistryError,
+    parse_product_adapter_manifest_record, product_adapter_sections,
 };
 use ironclaw_product_adapters::{AuthRequirement, ProductCapabilityFlag, ProductSurfaceKind};
+
+const TELEGRAM_MANIFEST: &str =
+    include_str!("../../ironclaw_first_party_extensions/assets/telegram/manifest.toml");
+const SLACK_MANIFEST: &str =
+    include_str!("../../ironclaw_first_party_extensions/assets/slack/manifest.toml");
 
 fn manifest(extra: &str) -> String {
     format!(
@@ -188,4 +200,70 @@ flags = ["inbound_messages"]
         err.to_string().contains("invalid adapter_id"),
         "expected adapter_id validation error, got {err:?}"
     );
+}
+
+#[test]
+fn real_first_party_product_adapter_manifests_project_cleanly() {
+    let mut contracts = HostApiContractRegistry::new();
+    contracts
+        .register(Arc::new(ProductAdapterHostApiContract::new().unwrap()))
+        .unwrap();
+    contracts
+        .register(Arc::new(FakeHostIngressContract {
+            id: HostApiId::new("ironclaw.host_ingress/v1").unwrap(),
+        }))
+        .unwrap();
+
+    for raw in [TELEGRAM_MANIFEST, SLACK_MANIFEST] {
+        ExtensionManifestV2::parse_with_host_api_contracts(
+            raw,
+            ManifestSource::HostBundled,
+            &HostPortCatalog::empty(),
+            &contracts,
+        )
+        .unwrap();
+        assert_eq!(product_adapter_sections_from_manifest(raw, &contracts), 1);
+    }
+}
+
+fn product_adapter_sections_from_manifest(raw: &str, contracts: &HostApiContractRegistry) -> usize {
+    let record = ExtensionManifestRecord::from_toml_with_contracts(
+        raw,
+        ManifestSource::HostBundled,
+        &HostPortCatalog::empty(),
+        Some(ManifestHash::new("sha256:real-manifest-test").unwrap()),
+        contracts,
+    )
+    .unwrap();
+    product_adapter_sections(&record).unwrap().len()
+}
+
+struct FakeHostIngressContract {
+    id: HostApiId,
+}
+
+impl HostApiManifestContract for FakeHostIngressContract {
+    fn id(&self) -> &HostApiId {
+        &self.id
+    }
+
+    fn accepts_section_path(&self, section: &ManifestSectionPath) -> bool {
+        section
+            .as_str()
+            .strip_prefix("host_ingress")
+            .is_some_and(|rest| rest.is_empty() || rest.starts_with('.'))
+    }
+
+    fn validate_section(
+        &self,
+        _host_api: &HostApiRefV2,
+        section: &toml::Value,
+    ) -> Result<(), String> {
+        section
+            .as_table()
+            .and_then(|table| table.get("route_id"))
+            .and_then(toml::Value::as_str)
+            .ok_or_else(|| "host_ingress route_id is required".to_string())?;
+        Ok(())
+    }
 }


### PR DESCRIPTION
## Summary

Adds a **single cross-contract credential coherence invariant** to the v2 extension-manifest projection. Today each `[[host_api]]` contract validates its credential references in isolation (product_adapter checks egress handles within its own section; host_ingress declares `credential_handles` under a *separate* newtype). Nothing checks them against **one declared credential set** for the extension — the exact "same fact spelled in two sections, drifts" failure mode that has shipped four times in this codebase (bug #2574 family; see `.claude/rules/types.md`).

This wires the check at `HostApiContractRegistry::project_manifest` — the single point where every contract's section converges.

## What changed

- **Canonical `CredentialHandle`** in `ironclaw_host_api::ids` — carries credential identity across the per-domain newtypes (`EgressCredentialHandle`, `IngressCredentialHandle`); contracts convert at the projection boundary only, so no stringly-typed cross-newtype compares.
- **`HostApiManifestProjection`** gains `declared_credentials` + `referenced_credentials` (each reference carries `host_api` + section provenance).
- **`ManifestV2Error::DanglingCredentialHandle { handle, host_api, section }`** — fail-closed; names the offending section.
- **Contracts wired:** product-adapter (declared = `required_credentials`, referenced = egress `credential_handle`s) and capability-provider (referenced = `SecretHandle` runtime credentials).
- **Tests:** dangling cross-contract handle rejected with correct provenance; real Slack/Telegram product_adapter sections still project cleanly; canonical handle validation.

## Verification

`cargo fmt` · `clippy -p ironclaw_extensions -p ironclaw_product_adapter_registry -p ironclaw_host_api --all-targets -D warnings` (exit 0) · `cargo test` on the same crates (13 passed, 0 failed + doc-tests). Run on host (agent sandbox has no network for a full `cargo check --workspace`).

## Stacking / review note

This is **Move 3** of the manifest-driven-channels plan (see the plan doc committed in the Move 1 PR, #5103). Base is `stack/5100-telegram-ingress` — a snapshot of #5100's tip pushed to origin so this PR shows **only Move 3's changes** (+440/−14). It will be retargeted/rebased onto #5100's branch (or `main`) once #5100 merges.

**Move 1 ↔ Move 3 seam:** the host-ingress contract will report its `credential_handles` as referenced (~3 lines, marked TODO in `v2.rs`) when Move 1 merges; the empty-declared-set rule tightens then.

Move 3 is independent of Move 1 (disjoint crates) and was implemented in parallel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
