### PR TITLE
feat(host-ingress): manifest-projected ingress policy + typed auth + transport discriminator

### DIFF
--- a/crates/ironclaw_first_party_extensions/assets/slack/manifest.toml
+++ b/crates/ironclaw_first_party_extensions/assets/slack/manifest.toml
@@ -44,9 +44,33 @@ credential_handle = "slack_bot_token"
 route_id = "slack.events"
 method = "post"
 path = "/webhooks/slack/events"
-policy_profile = "slack_events"
 ack = "immediate"
 drain = "drain_before_runtime_shutdown"
+
+[host_ingress.events.policy]
+listener_class = "public_webhook"
+scope_source = "host_resolved"
+cors = "not_applicable"
+websocket_origin = "not_applicable"
+streaming = "none"
+audit = "public_callback"
+
+[host_ingress.events.policy.auth]
+type = "required"
+schemes = ["webhook_signature"]
+
+[host_ingress.events.policy.body_limit]
+type = "limited"
+max_bytes = 1048576
+
+[host_ingress.events.policy.rate_limit]
+type = "limited"
+scope = "global"
+max_requests = 12000
+window_seconds = 60
+
+[host_ingress.events.policy.effect_path]
+type = "product_workflow"
 
 [host_ingress.events.target]
 type = "product_adapter_inbound"

--- a/crates/ironclaw_first_party_extensions/assets/slack/manifest.toml
+++ b/crates/ironclaw_first_party_extensions/assets/slack/manifest.toml
@@ -41,6 +41,9 @@ host = "slack.com"
 credential_handle = "slack_bot_token"
 
 [host_ingress.events]
+
+[host_ingress.events.transport]
+kind = "webhook"
 route_id = "slack.events"
 method = "post"
 path = "/webhooks/slack/events"
@@ -78,5 +81,5 @@ capability_id = "slack.events"
 product_adapter_section = "product_adapter.inbound"
 
 [host_ingress.events.auth]
-scheme = "slack_v0_hmac"
+verifier = "webhook_signature"
 credential_handles = ["slack_signing_secret"]

--- a/crates/ironclaw_first_party_extensions/assets/telegram/manifest.toml
+++ b/crates/ironclaw_first_party_extensions/assets/telegram/manifest.toml
@@ -40,6 +40,9 @@ host = "api.telegram.org"
 credential_handle = "telegram_bot_token"
 
 [host_ingress.updates]
+
+[host_ingress.updates.transport]
+kind = "webhook"
 route_id = "telegram.updates"
 method = "post"
 path = "/webhooks/telegram/updates"
@@ -77,5 +80,5 @@ capability_id = "telegram.updates"
 product_adapter_section = "product_adapter.inbound"
 
 [host_ingress.updates.auth]
-scheme = "telegram_secret_token"
+verifier = "shared_secret_header"
 credential_handles = ["telegram_webhook_secret"]

--- a/crates/ironclaw_first_party_extensions/assets/telegram/manifest.toml
+++ b/crates/ironclaw_first_party_extensions/assets/telegram/manifest.toml
@@ -43,9 +43,33 @@ credential_handle = "telegram_bot_token"
 route_id = "telegram.updates"
 method = "post"
 path = "/webhooks/telegram/updates"
-policy_profile = "telegram_updates"
 ack = "immediate"
 drain = "drain_before_runtime_shutdown"
+
+[host_ingress.updates.policy]
+listener_class = "public_webhook"
+scope_source = "host_resolved"
+cors = "not_applicable"
+websocket_origin = "not_applicable"
+streaming = "none"
+audit = "public_callback"
+
+[host_ingress.updates.policy.auth]
+type = "required"
+schemes = ["shared_secret_header"]
+
+[host_ingress.updates.policy.body_limit]
+type = "limited"
+max_bytes = 1048576
+
+[host_ingress.updates.policy.rate_limit]
+type = "limited"
+scope = "global"
+max_requests = 12000
+window_seconds = 60
+
+[host_ingress.updates.policy.effect_path]
+type = "product_workflow"
 
 [host_ingress.updates.target]
 type = "product_adapter_inbound"

--- a/crates/ironclaw_host_api/src/ingress.rs
+++ b/crates/ironclaw_host_api/src/ingress.rs
@@ -622,7 +622,12 @@ impl IngressAuthSchemeName {
     }
 
     pub fn declared_auth_scheme(&self) -> IngressAuthScheme {
-        IngressAuthScheme::WebhookSignature
+        match self.as_str() {
+            "telegram_secret_token" | "telegram_shared_secret" => {
+                IngressAuthScheme::SharedSecretHeader
+            }
+            _ => IngressAuthScheme::WebhookSignature,
+        }
     }
 }
 
@@ -780,6 +785,7 @@ pub enum IngressAuthScheme {
     Oidc,
     CsrfToken,
     WebhookSignature,
+    SharedSecretHeader,
     OAuthState,
     InternalToken,
 }
@@ -934,10 +940,13 @@ fn validate_listener_auth(
     }
 
     match listener_class {
-        ListenerClass::PublicWebhook => require_auth_scheme(
+        ListenerClass::PublicWebhook => require_any_auth_scheme(
             auth,
-            IngressAuthScheme::WebhookSignature,
-            "public webhook ingress requires webhook signature auth",
+            &[
+                IngressAuthScheme::WebhookSignature,
+                IngressAuthScheme::SharedSecretHeader,
+            ],
+            "public webhook ingress requires webhook signature or shared-secret header auth",
         ),
         ListenerClass::InternalWorker => require_auth_scheme(
             auth,
@@ -1368,6 +1377,10 @@ mod tests {
                 vec![IngressAuthScheme::WebhookSignature],
             ),
             (
+                ListenerClass::PublicWebhook,
+                vec![IngressAuthScheme::SharedSecretHeader],
+            ),
+            (
                 ListenerClass::InternalWorker,
                 vec![IngressAuthScheme::InternalToken],
             ),
@@ -1589,6 +1602,17 @@ mod tests {
         .expect_err("auth binding without credential handles must reject");
 
         assert!(err.to_string().contains("credential handle"));
+    }
+
+    #[test]
+    fn telegram_secret_token_declares_shared_secret_header_auth() {
+        let scheme =
+            IngressAuthSchemeName::new("telegram_secret_token").expect("valid auth scheme name");
+
+        assert_eq!(
+            scheme.declared_auth_scheme(),
+            IngressAuthScheme::SharedSecretHeader
+        );
     }
 
     #[test]

--- a/crates/ironclaw_host_api/src/ingress.rs
+++ b/crates/ironclaw_host_api/src/ingress.rs
@@ -548,37 +548,37 @@ pub enum HostIngressTarget {
     },
 }
 
-/// Binding from a code-built verifier name to opaque credential handles.
+/// Binding from a declared verifier kind to opaque credential handles.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(try_from = "IngressAuthBindingWire")]
 pub struct IngressAuthBinding {
-    scheme: IngressAuthSchemeName,
+    verifier: IngressAuthScheme,
     credential_handles: Vec<IngressCredentialHandle>,
 }
 
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
 struct IngressAuthBindingWire {
-    scheme: IngressAuthSchemeName,
+    verifier: IngressAuthScheme,
     credential_handles: Vec<IngressCredentialHandle>,
 }
 
 impl IngressAuthBinding {
     pub fn new(
-        scheme: IngressAuthSchemeName,
+        verifier: IngressAuthScheme,
         credential_handles: Vec<IngressCredentialHandle>,
     ) -> Result<Self, HostIngressDeclarationError> {
         if credential_handles.is_empty() {
-            return Err(HostIngressDeclarationError::AuthBindingMissingCredentials { scheme });
+            return Err(HostIngressDeclarationError::AuthBindingMissingCredentials { verifier });
         }
         Ok(Self {
-            scheme,
+            verifier,
             credential_handles,
         })
     }
 
-    pub fn scheme(&self) -> &IngressAuthSchemeName {
-        &self.scheme
+    pub fn verifier(&self) -> IngressAuthScheme {
+        self.verifier
     }
 
     pub fn credential_handles(&self) -> &[IngressCredentialHandle] {
@@ -590,71 +590,7 @@ impl TryFrom<IngressAuthBindingWire> for IngressAuthBinding {
     type Error = HostIngressDeclarationError;
 
     fn try_from(value: IngressAuthBindingWire) -> Result<Self, Self::Error> {
-        Self::new(value.scheme, value.credential_handles)
-    }
-}
-
-/// Name of a code-built ingress verifier.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
-#[serde(try_from = "String")]
-pub struct IngressAuthSchemeName(String);
-
-impl IngressAuthSchemeName {
-    fn validate(value: &str) -> Result<(), IngressAuthSchemeNameError> {
-        validate_host_ingress_token(value).map_err(|reason| IngressAuthSchemeNameError::Invalid {
-            value: value.to_owned(),
-            reason,
-        })
-    }
-
-    pub fn new(raw: impl Into<String>) -> Result<Self, IngressAuthSchemeNameError> {
-        let value = raw.into();
-        Self::validate(&value)?;
-        Ok(Self(value))
-    }
-
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
-
-    pub fn into_inner(self) -> String {
-        self.0
-    }
-
-    pub fn declared_auth_scheme(&self) -> IngressAuthScheme {
-        match self.as_str() {
-            "telegram_secret_token" | "telegram_shared_secret" => {
-                IngressAuthScheme::SharedSecretHeader
-            }
-            _ => IngressAuthScheme::WebhookSignature,
-        }
-    }
-}
-
-impl TryFrom<String> for IngressAuthSchemeName {
-    type Error = IngressAuthSchemeNameError;
-
-    fn try_from(value: String) -> Result<Self, Self::Error> {
-        Self::validate(&value)?;
-        Ok(Self(value))
-    }
-}
-
-impl AsRef<str> for IngressAuthSchemeName {
-    fn as_ref(&self) -> &str {
-        &self.0
-    }
-}
-
-impl fmt::Display for IngressAuthSchemeName {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.0)
-    }
-}
-
-impl From<IngressAuthSchemeName> for String {
-    fn from(id: IngressAuthSchemeName) -> Self {
-        id.0
+        Self::new(value.verifier, value.credential_handles)
     }
 }
 
@@ -737,21 +673,14 @@ pub enum HostIngressDeclarationError {
     RequiredAuthMissingBindings,
     #[error("public ingress auth policy must not declare auth bindings")]
     PublicAuthMustNotDeclareBindings,
-    #[error("ingress auth binding for scheme '{scheme}' must list at least one credential handle")]
-    AuthBindingMissingCredentials { scheme: IngressAuthSchemeName },
     #[error(
-        "ingress auth binding scheme '{scheme}' requires descriptor policy auth scheme '{required:?}'"
+        "ingress auth binding for verifier '{verifier:?}' must list at least one credential handle"
     )]
-    AuthBindingSchemeNotDeclared {
-        scheme: IngressAuthSchemeName,
-        required: IngressAuthScheme,
-    },
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Error)]
-pub enum IngressAuthSchemeNameError {
-    #[error("invalid ingress auth scheme name '{value}': {reason}")]
-    Invalid { value: String, reason: &'static str },
+    AuthBindingMissingCredentials { verifier: IngressAuthScheme },
+    #[error(
+        "ingress auth binding verifier '{verifier:?}' is not declared by descriptor policy auth"
+    )]
+    AuthBindingVerifierNotDeclared { verifier: IngressAuthScheme },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
@@ -1009,18 +938,12 @@ fn validate_ingress_auth_bindings(
             }
 
             for binding in auth {
-                if binding.credential_handles.is_empty() {
-                    return Err(HostIngressDeclarationError::AuthBindingMissingCredentials {
-                        scheme: binding.scheme.clone(),
-                    });
-                }
-
-                let required = binding.scheme.declared_auth_scheme();
-                if !schemes.contains(&required) {
-                    return Err(HostIngressDeclarationError::AuthBindingSchemeNotDeclared {
-                        scheme: binding.scheme.clone(),
-                        required,
-                    });
+                if !schemes.contains(&binding.verifier) {
+                    return Err(
+                        HostIngressDeclarationError::AuthBindingVerifierNotDeclared {
+                            verifier: binding.verifier,
+                        },
+                    );
                 }
             }
 
@@ -1207,7 +1130,7 @@ mod tests {
 
     fn hmac_auth_binding() -> IngressAuthBinding {
         IngressAuthBinding::new(
-            IngressAuthSchemeName::new("slack_v0_hmac").expect("valid auth scheme name"),
+            IngressAuthScheme::WebhookSignature,
             vec![
                 IngressCredentialHandle::new("slack_signing_secret")
                     .expect("valid credential handle"),
@@ -1500,7 +1423,10 @@ mod tests {
         assert_eq!(declaration.route().route_id().as_str(), "slack.events");
         assert_eq!(declaration.route().method(), NetworkMethod::Post);
         assert_eq!(declaration.auth().len(), 1);
-        assert_eq!(declaration.auth()[0].scheme().as_str(), "slack_v0_hmac");
+        assert_eq!(
+            declaration.auth()[0].verifier(),
+            IngressAuthScheme::WebhookSignature
+        );
         assert_eq!(declaration.ack(), IngressAckMode::Immediate);
         assert_eq!(
             declaration.drain(),
@@ -1595,28 +1521,14 @@ mod tests {
 
     #[test]
     fn auth_binding_requires_credential_handle() {
-        let err = IngressAuthBinding::new(
-            IngressAuthSchemeName::new("slack_v0_hmac").expect("valid auth scheme name"),
-            Vec::new(),
-        )
-        .expect_err("auth binding without credential handles must reject");
+        let err = IngressAuthBinding::new(IngressAuthScheme::WebhookSignature, Vec::new())
+            .expect_err("auth binding without credential handles must reject");
 
         assert!(err.to_string().contains("credential handle"));
     }
 
     #[test]
-    fn telegram_secret_token_declares_shared_secret_header_auth() {
-        let scheme =
-            IngressAuthSchemeName::new("telegram_secret_token").expect("valid auth scheme name");
-
-        assert_eq!(
-            scheme.declared_auth_scheme(),
-            IngressAuthScheme::SharedSecretHeader
-        );
-    }
-
-    #[test]
-    fn auth_binding_scheme_must_be_declared_by_policy() {
+    fn auth_binding_verifier_must_be_declared_by_policy() {
         let descriptor = IngressRouteDescriptor::new(
             "web_chat.send",
             NetworkMethod::Post,
@@ -1636,9 +1548,8 @@ mod tests {
 
         assert!(matches!(
             err,
-            HostIngressDeclarationError::AuthBindingSchemeNotDeclared {
-                required: IngressAuthScheme::WebhookSignature,
-                ..
+            HostIngressDeclarationError::AuthBindingVerifierNotDeclared {
+                verifier: IngressAuthScheme::WebhookSignature
             }
         ));
     }
@@ -1650,7 +1561,7 @@ mod tests {
         let json = serde_json::to_value(&declaration).expect("serialize declaration");
         assert_eq!(json["route"]["route_id"], "slack.events");
         assert_eq!(json["target"]["type"], "product_adapter_inbound");
-        assert_eq!(json["auth"][0]["scheme"], "slack_v0_hmac");
+        assert_eq!(json["auth"][0]["verifier"], "webhook_signature");
         assert_eq!(json["ack"], "immediate");
         assert_eq!(json["drain"], "drain_before_runtime_shutdown");
 

--- a/crates/ironclaw_host_ingress_registry/src/lib.rs
+++ b/crates/ironclaw_host_ingress_registry/src/lib.rs
@@ -23,7 +23,7 @@ use ironclaw_extensions::{
 };
 use ironclaw_host_api::{
     HostApiError, HostIngressDeclarationError, HostIngressRouteDeclaration, HostIngressTarget,
-    HostPortCatalog, IngressAckMode, IngressAuthBinding, IngressAuthSchemeName,
+    HostPortCatalog, IngressAckMode, IngressAuthBinding, IngressAuthScheme,
     IngressCredentialHandle, IngressDrainMode, IngressPolicy, IngressRouteDescriptor,
     IngressRouteId, IngressRoutePattern, NetworkMethod,
 };
@@ -174,8 +174,7 @@ impl HostApiManifestContract for HostIngressHostApiContract {
         host_api: &HostApiRefV2,
         section: &toml::Value,
     ) -> Result<(), String> {
-        HostIngressSection::from_value(host_api, section.clone())
-            .and_then(HostIngressSection::into_declaration)
+        project_host_ingress_section(host_api, section.clone())
             .map(|_| ())
             .map_err(|error| error.to_string())
     }
@@ -311,9 +310,10 @@ fn project_host_ingress_sections(
             continue;
         }
         let section_value = section_value(&value, &host_api.section)?;
-        sections.push(
-            HostIngressSection::from_value(host_api, section_value.clone())?.into_declaration()?,
-        );
+        sections.push(project_host_ingress_section(
+            host_api,
+            section_value.clone(),
+        )?);
     }
     Ok(sections)
 }
@@ -347,93 +347,84 @@ fn is_host_ingress_section_path(section: &ManifestSectionPath) -> bool {
 // Raw deserialization shapes for HostIngress sections
 // ---------------------------------------------------------------------------
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct HostIngressSection {
-    section: ManifestSectionPath,
-    route_id: IngressRouteId,
-    method: NetworkMethod,
-    path: IngressRoutePattern,
-    policy: IngressPolicy,
-    target: HostIngressTarget,
-    auth: IngressAuthBinding,
-    ack: IngressAckMode,
-    drain: IngressDrainMode,
-}
-
-impl HostIngressSection {
-    fn from_value(host_api: &HostApiRefV2, value: toml::Value) -> Result<Self, Error> {
-        if host_api.id.as_str() != HOST_INGRESS_HOST_API_ID {
-            return Err(Error::UnknownHostApiId {
-                id: host_api.id.as_str().to_owned(),
-            });
-        }
-        let raw: RawHostIngressSection =
-            value
-                .try_into()
-                .map_err(|error: toml::de::Error| Error::ManifestSectionParse {
-                    section: host_api.section.clone(),
-                    reason: error.to_string(),
-                })?;
-        Ok(Self {
-            section: host_api.section.clone(),
-            route_id: raw.route_id,
-            method: raw.method,
-            path: raw.path,
-            policy: raw.policy,
-            target: raw.target,
-            auth: raw.auth.into_binding(&host_api.section)?,
-            ack: raw.ack,
-            drain: raw.drain,
-        })
+fn project_host_ingress_section(
+    host_api: &HostApiRefV2,
+    value: toml::Value,
+) -> Result<HostIngressRouteDeclaration, Error> {
+    if host_api.id.as_str() != HOST_INGRESS_HOST_API_ID {
+        return Err(Error::UnknownHostApiId {
+            id: host_api.id.as_str().to_owned(),
+        });
     }
-
-    fn into_declaration(self) -> Result<HostIngressRouteDeclaration, Error> {
-        let HostIngressSection {
-            section,
-            route_id,
-            method,
-            path,
-            policy,
-            target,
-            auth,
-            ack,
-            drain,
-        } = self;
-        let descriptor =
-            IngressRouteDescriptor::new(route_id.as_str(), method, path.as_str(), policy).map_err(
-                |source| Error::RouteDescriptorBuild {
-                    section: section.clone(),
-                    source,
-                },
-            )?;
-        HostIngressRouteDeclaration::new(descriptor, target, vec![auth], ack, drain)
-            .map_err(|source| Error::DeclarationValidation { section, source })
-    }
+    let raw: RawHostIngressSection =
+        value
+            .try_into()
+            .map_err(|error: toml::de::Error| Error::ManifestSectionParse {
+                section: host_api.section.clone(),
+                reason: error.to_string(),
+            })?;
+    raw.into_declaration(&host_api.section)
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct RawHostIngressSection {
-    route_id: IngressRouteId,
-    method: NetworkMethod,
-    path: IngressRoutePattern,
+    transport: HostIngressTransport,
     policy: IngressPolicy,
     target: HostIngressTarget,
     auth: RawHostIngressAuth,
-    ack: IngressAckMode,
-    drain: IngressDrainMode,
+}
+
+impl RawHostIngressSection {
+    fn into_declaration(
+        self,
+        section: &ManifestSectionPath,
+    ) -> Result<HostIngressRouteDeclaration, Error> {
+        let auth = self.auth.into_binding(section)?;
+        let HostIngressTransport::Webhook {
+            route_id,
+            method,
+            path,
+            ack,
+            drain,
+        } = self.transport;
+        let descriptor =
+            IngressRouteDescriptor::new(route_id.as_str(), method, path.as_str(), self.policy)
+                .map_err(|source| Error::RouteDescriptorBuild {
+                    section: section.clone(),
+                    source,
+                })?;
+        HostIngressRouteDeclaration::new(descriptor, self.target, vec![auth], ack, drain).map_err(
+            |source| Error::DeclarationValidation {
+                section: section.clone(),
+                source,
+            },
+        )
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+enum HostIngressTransport {
+    Webhook {
+        route_id: IngressRouteId,
+        method: NetworkMethod,
+        path: IngressRoutePattern,
+        ack: IngressAckMode,
+        drain: IngressDrainMode,
+    },
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct RawHostIngressAuth {
-    scheme: IngressAuthSchemeName,
+    verifier: IngressAuthScheme,
     credential_handles: Vec<IngressCredentialHandle>,
 }
 
 impl RawHostIngressAuth {
     fn into_binding(self, section: &ManifestSectionPath) -> Result<IngressAuthBinding, Error> {
-        IngressAuthBinding::new(self.scheme, self.credential_handles).map_err(|source| {
+        IngressAuthBinding::new(self.verifier, self.credential_handles).map_err(|source| {
             Error::DeclarationValidation {
                 section: section.clone(),
                 source,
@@ -454,8 +445,9 @@ mod tests {
     };
     use ironclaw_host_api::{
         AllowedEffectPath, AuditTraceClass, BodyLimitPolicy, CapabilityId, CorsPolicy,
-        IngressAuthPolicy, IngressAuthScheme, IngressScopeSource, ListenerClass, RateLimitPolicy,
-        RateLimitScope, SecretHandle, StreamingMode, WebSocketOriginPolicy,
+        IngressAckMode, IngressAuthPolicy, IngressAuthScheme, IngressDrainMode, IngressScopeSource,
+        ListenerClass, NetworkMethod, RateLimitPolicy, RateLimitScope, SecretHandle, StreamingMode,
+        WebSocketOriginPolicy,
     };
 
     use super::*;
@@ -483,6 +475,9 @@ id = "ironclaw.host_ingress/v1"
 section = "host_ingress.events"
 
 [host_ingress.events]
+
+[host_ingress.events.transport]
+kind = "webhook"
 route_id = "slack.events"
 method = "post"
 path = "/webhooks/slack/events"
@@ -520,7 +515,7 @@ capability_id = "slack.events"
 product_adapter_section = "product_adapter.inbound"
 
 [host_ingress.events.auth]
-scheme = "slack_v0_hmac"
+verifier = "webhook_signature"
 credential_handles = ["slack_signing_secret"]
 
 {extra}
@@ -548,6 +543,9 @@ id = "ironclaw.host_ingress/v1"
 section = "host_ingress.updates"
 
 [host_ingress.updates]
+
+[host_ingress.updates.transport]
+kind = "webhook"
 route_id = "telegram.updates"
 method = "post"
 path = "/webhooks/telegram/updates"
@@ -585,7 +583,7 @@ capability_id = "telegram.updates"
 product_adapter_section = "product_adapter.inbound"
 
 [host_ingress.updates.auth]
-scheme = "telegram_secret_token"
+verifier = "shared_secret_header"
 credential_handles = ["telegram_webhook_secret"]
 
 {extra}
@@ -619,7 +617,7 @@ credential_handles = ["telegram_webhook_secret"]
         let value = section_value(&root, &host_api.section)
             .expect("test host ingress section must exist")
             .clone();
-        HostIngressSection::from_value(&host_api, value)?.into_declaration()
+        project_host_ingress_section(&host_api, value)
     }
 
     fn enabled_slack_installation() -> ExtensionInstallation {
@@ -730,7 +728,10 @@ credential_handles = ["telegram_webhook_secret"]
             }
         );
         assert_eq!(declaration.auth().len(), 1);
-        assert_eq!(declaration.auth()[0].scheme().as_str(), "slack_v0_hmac");
+        assert_eq!(
+            declaration.auth()[0].verifier(),
+            IngressAuthScheme::WebhookSignature
+        );
         assert_eq!(
             declaration.auth()[0].credential_handles()[0].as_str(),
             "slack_signing_secret"
@@ -772,6 +773,54 @@ credential_handles = ["telegram_webhook_secret"]
         assert!(matches!(
             error,
             Error::ManifestSectionParse { ref reason, .. } if reason.contains("public_webhooktypo")
+        ));
+    }
+
+    #[test]
+    fn unknown_auth_verifier_value_is_rejected_at_parse_time() {
+        let raw = slack_manifest("").replace(
+            r#"verifier = "webhook_signature""#,
+            r#"verifier = "webhook_signature_typo""#,
+        );
+        let error = project_single_section(&raw, "host_ingress.events")
+            .expect_err("unknown auth verifier enum value must reject");
+
+        assert!(matches!(
+            error,
+            Error::ManifestSectionParse { ref reason, .. }
+                if reason.contains("webhook_signature_typo")
+        ));
+    }
+
+    #[test]
+    fn auth_binding_verifier_must_be_allowed_by_policy() {
+        let raw = slack_manifest("").replace(
+            r#"verifier = "webhook_signature""#,
+            r#"verifier = "shared_secret_header""#,
+        );
+        let error = project_single_section(&raw, "host_ingress.events")
+            .expect_err("auth verifier outside policy scheme list must reject");
+
+        assert!(matches!(
+            error,
+            Error::DeclarationValidation {
+                source: HostIngressDeclarationError::AuthBindingVerifierNotDeclared {
+                    verifier: IngressAuthScheme::SharedSecretHeader
+                },
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn unsupported_transport_kind_is_rejected_at_parse_time() {
+        let raw = slack_manifest("").replace(r#"kind = "webhook""#, r#"kind = "websocket""#);
+        let error = project_single_section(&raw, "host_ingress.events")
+            .expect_err("unsupported transport kind must reject");
+
+        assert!(matches!(
+            error,
+            Error::ManifestSectionParse { ref reason, .. } if reason.contains("websocket")
         ));
     }
 

--- a/crates/ironclaw_host_ingress_registry/src/lib.rs
+++ b/crates/ironclaw_host_ingress_registry/src/lib.rs
@@ -13,7 +13,6 @@
 #![forbid(unsafe_code)]
 
 use std::collections::{BTreeSet, HashMap};
-use std::num::{NonZeroU32, NonZeroU64};
 use std::sync::Arc;
 
 use ironclaw_extensions::{
@@ -23,13 +22,10 @@ use ironclaw_extensions::{
     ManifestSectionPath, ManifestSource, ManifestV2Error,
 };
 use ironclaw_host_api::{
-    AllowedEffectPath, AuditTraceClass, BodyLimitPolicy, CorsPolicy, HostApiError,
-    HostIngressDeclarationError, HostIngressRouteDeclaration, HostIngressTarget, HostPortCatalog,
-    IngressAckMode, IngressAuthBinding, IngressAuthPolicy, IngressAuthScheme,
-    IngressAuthSchemeName, IngressCredentialHandle, IngressDrainMode, IngressPolicy,
-    IngressPolicyParts, IngressRouteDescriptor, IngressRouteId, IngressRoutePattern,
-    IngressScopeSource, ListenerClass, NetworkMethod, RateLimitPolicy, RateLimitScope,
-    StreamingMode, WebSocketOriginPolicy,
+    HostApiError, HostIngressDeclarationError, HostIngressRouteDeclaration, HostIngressTarget,
+    HostPortCatalog, IngressAckMode, IngressAuthBinding, IngressAuthSchemeName,
+    IngressCredentialHandle, IngressDrainMode, IngressPolicy, IngressRouteDescriptor,
+    IngressRouteId, IngressRoutePattern, NetworkMethod,
 };
 use serde::Deserialize;
 use thiserror::Error;
@@ -42,20 +38,6 @@ pub use ironclaw_extensions::ManifestHash;
 
 pub const HOST_INGRESS_HOST_API_ID: &str = "ironclaw.host_ingress/v1";
 pub const HOST_INGRESS_SECTION_PREFIX: &str = "host_ingress";
-
-pub const SLACK_EVENTS_POLICY_PROFILE: &str = "slack_events";
-pub const SLACK_EVENTS_ROUTE_ID: &str = "slack.events";
-pub const SLACK_EVENTS_PATH: &str = "/webhooks/slack/events";
-pub const SLACK_EVENTS_BODY_LIMIT_BYTES: u64 = 1024 * 1024;
-pub const SLACK_EVENTS_MAX_REQUESTS: u32 = 12_000;
-pub const SLACK_EVENTS_RATE_WINDOW_SECONDS: u32 = 60;
-
-pub const TELEGRAM_UPDATES_POLICY_PROFILE: &str = "telegram_updates";
-pub const TELEGRAM_UPDATES_ROUTE_ID: &str = "telegram.updates";
-pub const TELEGRAM_UPDATES_PATH: &str = "/webhooks/telegram/updates";
-pub const TELEGRAM_UPDATES_BODY_LIMIT_BYTES: u64 = 1024 * 1024;
-pub const TELEGRAM_UPDATES_MAX_REQUESTS: u32 = 12_000;
-pub const TELEGRAM_UPDATES_RATE_WINDOW_SECONDS: u32 = 60;
 
 pub fn parse_host_ingress_manifest_record(
     raw_toml: impl Into<String>,
@@ -158,182 +140,6 @@ pub async fn list_enabled_host_ingress_entries(
 }
 
 // ---------------------------------------------------------------------------
-// Policy profiles
-// ---------------------------------------------------------------------------
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub enum IngressPolicyProfile {
-    SlackEvents,
-    TelegramUpdates,
-}
-
-impl IngressPolicyProfile {
-    fn from_manifest_name(name: impl Into<String>) -> Result<Self, Error> {
-        let name = name.into();
-        match name.as_str() {
-            SLACK_EVENTS_POLICY_PROFILE => Ok(Self::SlackEvents),
-            TELEGRAM_UPDATES_POLICY_PROFILE => Ok(Self::TelegramUpdates),
-            _ => Err(Error::UnknownPolicyProfile { profile: name }),
-        }
-    }
-
-    pub fn as_str(self) -> &'static str {
-        match self {
-            Self::SlackEvents => SLACK_EVENTS_POLICY_PROFILE,
-            Self::TelegramUpdates => TELEGRAM_UPDATES_POLICY_PROFILE,
-        }
-    }
-
-    pub fn route_descriptor(self) -> Result<IngressRouteDescriptor, Error> {
-        match self {
-            Self::SlackEvents => slack_events_route_descriptor(),
-            Self::TelegramUpdates => telegram_updates_route_descriptor(),
-        }
-    }
-}
-
-impl std::fmt::Display for IngressPolicyProfile {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.as_str())
-    }
-}
-
-fn slack_events_route_descriptor() -> Result<IngressRouteDescriptor, Error> {
-    IngressRouteDescriptor::new(
-        SLACK_EVENTS_ROUTE_ID,
-        NetworkMethod::Post,
-        SLACK_EVENTS_PATH,
-        slack_events_policy()?,
-    )
-    .map_err(|source| Error::ProfileBuild {
-        profile: IngressPolicyProfile::SlackEvents,
-        source,
-    })
-}
-
-fn slack_events_policy() -> Result<IngressPolicy, Error> {
-    IngressPolicy::new(IngressPolicyParts {
-        listener_class: ListenerClass::PublicWebhook,
-        auth: IngressAuthPolicy::Required {
-            schemes: vec![IngressAuthScheme::WebhookSignature],
-        },
-        scope_source: IngressScopeSource::HostResolved,
-        body_limit: BodyLimitPolicy::Limited {
-            max_bytes: nonzero_u64(
-                SLACK_EVENTS_BODY_LIMIT_BYTES,
-                IngressPolicyProfile::SlackEvents,
-                "body_limit.max_bytes",
-            )?,
-        },
-        rate_limit: RateLimitPolicy::Limited {
-            scope: RateLimitScope::Global,
-            max_requests: nonzero_u32(
-                SLACK_EVENTS_MAX_REQUESTS,
-                IngressPolicyProfile::SlackEvents,
-                "rate_limit.max_requests",
-            )?,
-            window_seconds: nonzero_u32(
-                SLACK_EVENTS_RATE_WINDOW_SECONDS,
-                IngressPolicyProfile::SlackEvents,
-                "rate_limit.window_seconds",
-            )?,
-        },
-        cors: CorsPolicy::NotApplicable,
-        websocket_origin: WebSocketOriginPolicy::NotApplicable,
-        streaming: StreamingMode::None,
-        audit: AuditTraceClass::PublicCallback,
-        effect_path: AllowedEffectPath::ProductWorkflow,
-    })
-    .map_err(|source| Error::ProfileBuild {
-        profile: IngressPolicyProfile::SlackEvents,
-        source,
-    })
-}
-
-fn telegram_updates_route_descriptor() -> Result<IngressRouteDescriptor, Error> {
-    IngressRouteDescriptor::new(
-        TELEGRAM_UPDATES_ROUTE_ID,
-        NetworkMethod::Post,
-        TELEGRAM_UPDATES_PATH,
-        telegram_updates_policy()?,
-    )
-    .map_err(|source| Error::ProfileBuild {
-        profile: IngressPolicyProfile::TelegramUpdates,
-        source,
-    })
-}
-
-fn telegram_updates_policy() -> Result<IngressPolicy, Error> {
-    IngressPolicy::new(IngressPolicyParts {
-        listener_class: ListenerClass::PublicWebhook,
-        // A Telegram webhook authenticates via the shared-secret header
-        // (`X-Telegram-Bot-Api-Secret-Token`), but the policy vocabulary models
-        // every public-webhook auth as `WebhookSignature` (the scheme-name
-        // string + the handler's chosen verifier carry the HMAC-vs-shared-secret
-        // distinction). Mirror Slack here.
-        auth: IngressAuthPolicy::Required {
-            schemes: vec![IngressAuthScheme::WebhookSignature],
-        },
-        scope_source: IngressScopeSource::HostResolved,
-        body_limit: BodyLimitPolicy::Limited {
-            max_bytes: nonzero_u64(
-                TELEGRAM_UPDATES_BODY_LIMIT_BYTES,
-                IngressPolicyProfile::TelegramUpdates,
-                "body_limit.max_bytes",
-            )?,
-        },
-        rate_limit: RateLimitPolicy::Limited {
-            scope: RateLimitScope::Global,
-            max_requests: nonzero_u32(
-                TELEGRAM_UPDATES_MAX_REQUESTS,
-                IngressPolicyProfile::TelegramUpdates,
-                "rate_limit.max_requests",
-            )?,
-            window_seconds: nonzero_u32(
-                TELEGRAM_UPDATES_RATE_WINDOW_SECONDS,
-                IngressPolicyProfile::TelegramUpdates,
-                "rate_limit.window_seconds",
-            )?,
-        },
-        cors: CorsPolicy::NotApplicable,
-        websocket_origin: WebSocketOriginPolicy::NotApplicable,
-        streaming: StreamingMode::None,
-        audit: AuditTraceClass::PublicCallback,
-        effect_path: AllowedEffectPath::ProductWorkflow,
-    })
-    .map_err(|source| Error::ProfileBuild {
-        profile: IngressPolicyProfile::TelegramUpdates,
-        source,
-    })
-}
-
-fn nonzero_u32(
-    value: u32,
-    profile: IngressPolicyProfile,
-    field: &'static str,
-) -> Result<NonZeroU32, Error> {
-    NonZeroU32::new(value).ok_or_else(|| Error::ProfileBuild {
-        profile,
-        source: HostApiError::InvariantViolation {
-            reason: format!("{field} must be non-zero"),
-        },
-    })
-}
-
-fn nonzero_u64(
-    value: u64,
-    profile: IngressPolicyProfile,
-    field: &'static str,
-) -> Result<NonZeroU64, Error> {
-    NonZeroU64::new(value).ok_or_else(|| Error::ProfileBuild {
-        profile,
-        source: HostApiError::InvariantViolation {
-            reason: format!("{field} must be non-zero"),
-        },
-    })
-}
-
-// ---------------------------------------------------------------------------
 // HostIngress host-api contract validator
 // ---------------------------------------------------------------------------
 
@@ -397,32 +203,20 @@ pub enum Error {
     Manifest(#[from] ManifestV2Error),
     #[error("unknown host API id {id} for host ingress section")]
     UnknownHostApiId { id: String },
-    #[error("unknown host ingress policy profile {profile}")]
-    UnknownPolicyProfile { profile: String },
     #[error("host ingress manifest section {section} parse failed: {reason}")]
     ManifestSectionParse {
         section: ManifestSectionPath,
         reason: String,
     },
-    #[error("host ingress profile {profile} failed to build: {source}")]
-    ProfileBuild {
-        profile: IngressPolicyProfile,
+    #[error("host ingress route descriptor failed to build for {section}: {source}")]
+    RouteDescriptorBuild {
+        section: ManifestSectionPath,
         source: HostApiError,
     },
     #[error("host ingress declaration validation failed for {section}: {source}")]
     DeclarationValidation {
         section: ManifestSectionPath,
         source: HostIngressDeclarationError,
-    },
-    #[error(
-        "host ingress section {section} {field} does not match {profile} profile: expected {expected}, actual {actual}"
-    )]
-    ProfileRouteMismatch {
-        section: ManifestSectionPath,
-        profile: IngressPolicyProfile,
-        field: &'static str,
-        expected: String,
-        actual: String,
     },
     #[error("installation references unknown extension manifest {extension_id}")]
     UnknownManifest { extension_id: String },
@@ -559,7 +353,7 @@ struct HostIngressSection {
     route_id: IngressRouteId,
     method: NetworkMethod,
     path: IngressRoutePattern,
-    policy_profile: IngressPolicyProfile,
+    policy: IngressPolicy,
     target: HostIngressTarget,
     auth: IngressAuthBinding,
     ack: IngressAckMode,
@@ -585,7 +379,7 @@ impl HostIngressSection {
             route_id: raw.route_id,
             method: raw.method,
             path: raw.path,
-            policy_profile: IngressPolicyProfile::from_manifest_name(raw.policy_profile)?,
+            policy: raw.policy,
             target: raw.target,
             auth: raw.auth.into_binding(&host_api.section)?,
             ack: raw.ack,
@@ -594,53 +388,26 @@ impl HostIngressSection {
     }
 
     fn into_declaration(self) -> Result<HostIngressRouteDeclaration, Error> {
-        let descriptor = self.policy_profile.route_descriptor()?;
-        self.validate_profile_route_identity(&descriptor)?;
-        HostIngressRouteDeclaration::new(
-            descriptor,
-            self.target,
-            vec![self.auth],
-            self.ack,
-            self.drain,
-        )
-        .map_err(|source| Error::DeclarationValidation {
-            section: self.section,
-            source,
-        })
-    }
-
-    fn validate_profile_route_identity(
-        &self,
-        descriptor: &IngressRouteDescriptor,
-    ) -> Result<(), Error> {
-        if descriptor.route_id().as_str() != self.route_id.as_str() {
-            return Err(Error::ProfileRouteMismatch {
-                section: self.section.clone(),
-                profile: self.policy_profile,
-                field: "route_id",
-                expected: descriptor.route_id().as_str().to_owned(),
-                actual: self.route_id.as_str().to_owned(),
-            });
-        }
-        if descriptor.method() != self.method {
-            return Err(Error::ProfileRouteMismatch {
-                section: self.section.clone(),
-                profile: self.policy_profile,
-                field: "method",
-                expected: descriptor.method().to_string(),
-                actual: self.method.to_string(),
-            });
-        }
-        if descriptor.route_pattern().as_str() != self.path.as_str() {
-            return Err(Error::ProfileRouteMismatch {
-                section: self.section.clone(),
-                profile: self.policy_profile,
-                field: "path",
-                expected: descriptor.route_pattern().as_str().to_owned(),
-                actual: self.path.as_str().to_owned(),
-            });
-        }
-        Ok(())
+        let HostIngressSection {
+            section,
+            route_id,
+            method,
+            path,
+            policy,
+            target,
+            auth,
+            ack,
+            drain,
+        } = self;
+        let descriptor =
+            IngressRouteDescriptor::new(route_id.as_str(), method, path.as_str(), policy).map_err(
+                |source| Error::RouteDescriptorBuild {
+                    section: section.clone(),
+                    source,
+                },
+            )?;
+        HostIngressRouteDeclaration::new(descriptor, target, vec![auth], ack, drain)
+            .map_err(|source| Error::DeclarationValidation { section, source })
     }
 }
 
@@ -650,7 +417,7 @@ struct RawHostIngressSection {
     route_id: IngressRouteId,
     method: NetworkMethod,
     path: IngressRoutePattern,
-    policy_profile: String,
+    policy: IngressPolicy,
     target: HostIngressTarget,
     auth: RawHostIngressAuth,
     ack: IngressAckMode,
@@ -677,13 +444,19 @@ impl RawHostIngressAuth {
 
 #[cfg(test)]
 mod tests {
+    use std::num::{NonZeroU32, NonZeroU64};
+
     use chrono::Utc;
     use ironclaw_extensions::{
         ExtensionActivationState, ExtensionCredentialBinding, ExtensionCredentialHandle,
         ExtensionInstallationId, ExtensionManifestRef, InMemoryExtensionInstallationStore,
         MANIFEST_SCHEMA_VERSION,
     };
-    use ironclaw_host_api::{CapabilityId, SecretHandle};
+    use ironclaw_host_api::{
+        AllowedEffectPath, AuditTraceClass, BodyLimitPolicy, CapabilityId, CorsPolicy,
+        IngressAuthPolicy, IngressAuthScheme, IngressScopeSource, ListenerClass, RateLimitPolicy,
+        RateLimitScope, SecretHandle, StreamingMode, WebSocketOriginPolicy,
+    };
 
     use super::*;
 
@@ -713,9 +486,33 @@ section = "host_ingress.events"
 route_id = "slack.events"
 method = "post"
 path = "/webhooks/slack/events"
-policy_profile = "slack_events"
 ack = "immediate"
 drain = "drain_before_runtime_shutdown"
+
+[host_ingress.events.policy]
+listener_class = "public_webhook"
+scope_source = "host_resolved"
+cors = "not_applicable"
+websocket_origin = "not_applicable"
+streaming = "none"
+audit = "public_callback"
+
+[host_ingress.events.policy.auth]
+type = "required"
+schemes = ["webhook_signature"]
+
+[host_ingress.events.policy.body_limit]
+type = "limited"
+max_bytes = 1048576
+
+[host_ingress.events.policy.rate_limit]
+type = "limited"
+scope = "global"
+max_requests = 12000
+window_seconds = 60
+
+[host_ingress.events.policy.effect_path]
+type = "product_workflow"
 
 [host_ingress.events.target]
 type = "product_adapter_inbound"
@@ -732,6 +529,71 @@ credential_handles = ["slack_signing_secret"]
         )
     }
 
+    fn telegram_manifest(extra: &str) -> String {
+        format!(
+            r#"
+schema_version = "{schema}"
+id = "telegram"
+name = "Telegram"
+version = "0.1.0"
+description = "Telegram product adapter"
+trust = "third_party"
+
+[runtime]
+kind = "wasm"
+module = "adapters/telegram.wasm"
+
+[[host_api]]
+id = "ironclaw.host_ingress/v1"
+section = "host_ingress.updates"
+
+[host_ingress.updates]
+route_id = "telegram.updates"
+method = "post"
+path = "/webhooks/telegram/updates"
+ack = "immediate"
+drain = "drain_before_runtime_shutdown"
+
+[host_ingress.updates.policy]
+listener_class = "public_webhook"
+scope_source = "host_resolved"
+cors = "not_applicable"
+websocket_origin = "not_applicable"
+streaming = "none"
+audit = "public_callback"
+
+[host_ingress.updates.policy.auth]
+type = "required"
+schemes = ["shared_secret_header"]
+
+[host_ingress.updates.policy.body_limit]
+type = "limited"
+max_bytes = 1048576
+
+[host_ingress.updates.policy.rate_limit]
+type = "limited"
+scope = "global"
+max_requests = 12000
+window_seconds = 60
+
+[host_ingress.updates.policy.effect_path]
+type = "product_workflow"
+
+[host_ingress.updates.target]
+type = "product_adapter_inbound"
+capability_id = "telegram.updates"
+product_adapter_section = "product_adapter.inbound"
+
+[host_ingress.updates.auth]
+scheme = "telegram_secret_token"
+credential_handles = ["telegram_webhook_secret"]
+
+{extra}
+"#,
+            schema = MANIFEST_SCHEMA_VERSION,
+        )
+    }
+
     fn parse_slack(raw: &str) -> Result<ExtensionManifestRecord, Error> {
         parse_host_ingress_manifest_record(
             raw,
@@ -741,17 +603,19 @@ credential_handles = ["slack_signing_secret"]
         )
     }
 
-    fn host_ingress_ref() -> HostApiRefV2 {
+    fn host_ingress_ref(section: &str) -> HostApiRefV2 {
         HostApiRefV2 {
             id: HostApiId::new(HOST_INGRESS_HOST_API_ID).expect("test host API id must be valid"),
-            section: ManifestSectionPath::new("host_ingress.events")
-                .expect("test section path must be valid"),
+            section: ManifestSectionPath::new(section).expect("test section path must be valid"),
         }
     }
 
-    fn project_single_section(raw: &str) -> Result<HostIngressRouteDeclaration, Error> {
+    fn project_single_section(
+        raw: &str,
+        section: &str,
+    ) -> Result<HostIngressRouteDeclaration, Error> {
         let root: toml::Value = toml::from_str(raw).expect("test TOML must parse");
-        let host_api = host_ingress_ref();
+        let host_api = host_ingress_ref(section);
         let value = section_value(&root, &host_api.section)
             .expect("test host ingress section must exist")
             .clone();
@@ -778,22 +642,15 @@ credential_handles = ["slack_signing_secret"]
         .expect("test installation must be valid")
     }
 
-    #[test]
-    fn slack_events_profile_projects_expected_policy_constants() {
-        let descriptor = IngressPolicyProfile::SlackEvents
-            .route_descriptor()
-            .expect("Slack events profile must build");
-
-        assert_eq!(descriptor.route_id().as_str(), SLACK_EVENTS_ROUTE_ID);
-        assert_eq!(descriptor.method(), NetworkMethod::Post);
-        assert_eq!(descriptor.route_pattern().as_str(), SLACK_EVENTS_PATH);
-
-        let policy = descriptor.policy();
+    fn assert_public_webhook_policy(
+        policy: &IngressPolicy,
+        expected_schemes: Vec<IngressAuthScheme>,
+    ) {
         assert_eq!(policy.listener_class(), ListenerClass::PublicWebhook);
         assert_eq!(
             policy.auth(),
             &IngressAuthPolicy::Required {
-                schemes: vec![IngressAuthScheme::WebhookSignature],
+                schemes: expected_schemes,
             }
         );
         assert_eq!(policy.scope_source(), IngressScopeSource::HostResolved);
@@ -819,66 +676,35 @@ credential_handles = ["slack_signing_secret"]
         assert_eq!(policy.streaming(), StreamingMode::None);
         assert_eq!(policy.audit(), AuditTraceClass::PublicCallback);
         assert_eq!(policy.effect_path(), &AllowedEffectPath::ProductWorkflow);
-        // TODO(step): add a composition-side cross-check against
-        // `slack_events_policy()` once this dormant registry is wired there.
     }
 
     #[test]
-    fn telegram_updates_profile_projects_expected_policy_constants() {
-        let descriptor = IngressPolicyProfile::TelegramUpdates
-            .route_descriptor()
-            .expect("Telegram updates profile must build");
+    fn slack_events_manifest_projects_policy_from_manifest() {
+        let declaration = project_single_section(&slack_manifest(""), "host_ingress.events")
+            .expect("Slack events manifest policy must project");
 
-        assert_eq!(descriptor.route_id().as_str(), TELEGRAM_UPDATES_ROUTE_ID);
-        assert_eq!(descriptor.method(), NetworkMethod::Post);
-        assert_eq!(descriptor.route_pattern().as_str(), TELEGRAM_UPDATES_PATH);
-
-        let policy = descriptor.policy();
-        assert_eq!(policy.listener_class(), ListenerClass::PublicWebhook);
         assert_eq!(
-            policy.auth(),
-            &IngressAuthPolicy::Required {
-                schemes: vec![IngressAuthScheme::WebhookSignature],
-            }
+            declaration.route().route_pattern().as_str(),
+            "/webhooks/slack/events"
         );
-        assert_eq!(policy.scope_source(), IngressScopeSource::HostResolved);
-        assert_eq!(
-            policy.body_limit(),
-            BodyLimitPolicy::Limited {
-                max_bytes: NonZeroU64::new(TELEGRAM_UPDATES_BODY_LIMIT_BYTES)
-                    .expect("test value must be non-zero"),
-            }
+        assert_public_webhook_policy(
+            declaration.route().policy(),
+            vec![IngressAuthScheme::WebhookSignature],
         );
-        assert_eq!(
-            policy.rate_limit(),
-            &RateLimitPolicy::Limited {
-                scope: RateLimitScope::Global,
-                max_requests: NonZeroU32::new(TELEGRAM_UPDATES_MAX_REQUESTS)
-                    .expect("test value must be non-zero"),
-                window_seconds: NonZeroU32::new(TELEGRAM_UPDATES_RATE_WINDOW_SECONDS)
-                    .expect("test value must be non-zero"),
-            }
-        );
-        assert_eq!(policy.cors(), CorsPolicy::NotApplicable);
-        assert_eq!(
-            policy.websocket_origin(),
-            WebSocketOriginPolicy::NotApplicable
-        );
-        assert_eq!(policy.streaming(), StreamingMode::None);
-        assert_eq!(policy.audit(), AuditTraceClass::PublicCallback);
-        assert_eq!(policy.effect_path(), &AllowedEffectPath::ProductWorkflow);
     }
 
     #[test]
-    fn telegram_updates_profile_resolves_from_manifest_name() {
+    fn telegram_updates_manifest_projects_policy_from_manifest() {
+        let declaration = project_single_section(&telegram_manifest(""), "host_ingress.updates")
+            .expect("Telegram updates manifest policy must project");
+
         assert_eq!(
-            IngressPolicyProfile::from_manifest_name(TELEGRAM_UPDATES_POLICY_PROFILE)
-                .expect("telegram_updates profile name must resolve"),
-            IngressPolicyProfile::TelegramUpdates
+            declaration.route().route_pattern().as_str(),
+            "/webhooks/telegram/updates"
         );
-        assert_eq!(
-            IngressPolicyProfile::TelegramUpdates.as_str(),
-            TELEGRAM_UPDATES_POLICY_PROFILE
+        assert_public_webhook_policy(
+            declaration.route().policy(),
+            vec![IngressAuthScheme::SharedSecretHeader],
         );
     }
 
@@ -935,16 +761,29 @@ credential_handles = ["slack_signing_secret"]
     }
 
     #[test]
-    fn unknown_profile_name_returns_error() {
+    fn unknown_policy_enum_value_is_rejected() {
         let raw = slack_manifest("").replace(
-            r#"policy_profile = "slack_events""#,
-            r#"policy_profile = "other_events""#,
+            r#"listener_class = "public_webhook""#,
+            r#"listener_class = "public_webhooktypo""#,
         );
-        let error = project_single_section(&raw).expect_err("unknown profile must reject");
+        let error = project_single_section(&raw, "host_ingress.events")
+            .expect_err("unknown policy enum value must reject");
 
         assert!(matches!(
             error,
-            Error::UnknownPolicyProfile { ref profile } if profile == "other_events"
+            Error::ManifestSectionParse { ref reason, .. } if reason.contains("public_webhooktypo")
+        ));
+    }
+
+    #[test]
+    fn zero_policy_limit_is_rejected() {
+        let raw = slack_manifest("").replace("max_requests = 12000", "max_requests = 0");
+        let error = project_single_section(&raw, "host_ingress.events")
+            .expect_err("zero rate limit must reject");
+
+        assert!(matches!(
+            error,
+            Error::ManifestSectionParse { ref reason, .. } if reason.contains("nonzero")
         ));
     }
 
@@ -954,8 +793,8 @@ credential_handles = ["slack_signing_secret"]
             r#"drain = "drain_before_runtime_shutdown""#,
             r#"drain = "none""#,
         );
-        let error =
-            project_single_section(&raw).expect_err("immediate ack without drain must reject");
+        let error = project_single_section(&raw, "host_ingress.events")
+            .expect_err("immediate ack without drain must reject");
 
         assert!(matches!(
             error,

--- a/crates/ironclaw_host_runtime/tests/host_api_contract_composition.rs
+++ b/crates/ironclaw_host_runtime/tests/host_api_contract_composition.rs
@@ -217,9 +217,33 @@ section = "host_ingress.events"
 route_id = "slack.events"
 method = "post"
 path = "/webhooks/slack/events"
-policy_profile = "slack_events"
 ack = "immediate"
 drain = "drain_before_runtime_shutdown"
+
+[host_ingress.events.policy]
+listener_class = "public_webhook"
+scope_source = "host_resolved"
+cors = "not_applicable"
+websocket_origin = "not_applicable"
+streaming = "none"
+audit = "public_callback"
+
+[host_ingress.events.policy.auth]
+type = "required"
+schemes = ["webhook_signature"]
+
+[host_ingress.events.policy.body_limit]
+type = "limited"
+max_bytes = 1048576
+
+[host_ingress.events.policy.rate_limit]
+type = "limited"
+scope = "global"
+max_requests = 12000
+window_seconds = 60
+
+[host_ingress.events.policy.effect_path]
+type = "product_workflow"
 
 [host_ingress.events.target]
 type = "product_adapter_inbound"

--- a/crates/ironclaw_host_runtime/tests/host_api_contract_composition.rs
+++ b/crates/ironclaw_host_runtime/tests/host_api_contract_composition.rs
@@ -214,6 +214,9 @@ id = "ironclaw.host_ingress/v1"
 section = "host_ingress.events"
 
 [host_ingress.events]
+
+[host_ingress.events.transport]
+kind = "webhook"
 route_id = "slack.events"
 method = "post"
 path = "/webhooks/slack/events"
@@ -251,6 +254,6 @@ capability_id = "slack.events"
 product_adapter_section = "product_adapter.inbound"
 
 [host_ingress.events.auth]
-scheme = "slack_v0_hmac"
+verifier = "webhook_signature"
 credential_handles = ["slack_signing_secret"]
 "#;

--- a/crates/ironclaw_reborn_composition/src/host_ingress.rs
+++ b/crates/ironclaw_reborn_composition/src/host_ingress.rs
@@ -813,9 +813,9 @@ mod tests {
     use ironclaw_host_api::CapabilityId;
     use ironclaw_host_api::ingress::{
         AllowedEffectPath, AuditTraceClass, BodyLimitPolicy, CorsPolicy, HostIngressTarget,
-        IngressAckMode, IngressAuthBinding, IngressAuthPolicy, IngressAuthScheme,
-        IngressAuthSchemeName, IngressDrainMode, IngressPolicy, IngressPolicyParts,
-        IngressScopeSource, ListenerClass, StreamingMode, WebSocketOriginPolicy,
+        IngressAckMode, IngressAuthBinding, IngressAuthPolicy, IngressAuthScheme, IngressDrainMode,
+        IngressPolicy, IngressPolicyParts, IngressScopeSource, ListenerClass, StreamingMode,
+        WebSocketOriginPolicy,
     };
     use tower::ServiceExt;
 
@@ -940,10 +940,6 @@ mod tests {
         IngressCredentialHandle::new(value).expect("valid credential handle")
     }
 
-    fn auth_scheme() -> IngressAuthSchemeName {
-        IngressAuthSchemeName::new("test-signature").expect("valid auth scheme")
-    }
-
     fn declaration(
         route_id: &'static str,
         path: &'static str,
@@ -952,7 +948,8 @@ mod tests {
         let descriptor =
             IngressRouteDescriptor::new(route_id, NetworkMethod::Post, path, ingress_policy())
                 .expect("valid route descriptor");
-        let binding = IngressAuthBinding::new(auth_scheme(), handles).expect("valid auth binding");
+        let binding = IngressAuthBinding::new(IngressAuthScheme::WebhookSignature, handles)
+            .expect("valid auth binding");
         HostIngressRouteDeclaration::new(
             descriptor,
             HostIngressTarget::HostCapability {

--- a/crates/ironclaw_reborn_composition/src/slack_host_beta.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_host_beta.rs
@@ -50,7 +50,7 @@ use sha2::{Digest, Sha256};
 use thiserror::Error;
 
 use crate::RebornRuntime;
-use crate::host_ingress::public_ingress_route_mount;
+use crate::host_ingress::{HostIngressRegistration, public_ingress_route_mount};
 use crate::outbound_preferences::{
     OutboundDeliveryTargetProvider, OutboundDeliveryTargetRegistrationOutcome,
 };
@@ -599,6 +599,7 @@ pub async fn build_slack_events_host_ingress_mount_from_enabled_extensions(
     let entries = list_enabled_host_ingress_entries(store.as_ref()).await?;
     let mut installations = Vec::new();
     let mut credential_bindings = Vec::new();
+    let mut projected_declaration = None;
     let slack_extension_id = slack_extension_id()?;
 
     for entry in entries {
@@ -608,6 +609,10 @@ pub async fn build_slack_events_host_ingress_mount_from_enabled_extensions(
         }
         if !is_slack_events_declaration(entry.declaration()) {
             continue;
+        }
+        let declaration = entry.declaration().clone();
+        if projected_declaration.is_none() {
+            projected_declaration = Some(declaration.clone());
         }
         let settings = settings_store
             .get(installation.installation_id())
@@ -643,7 +648,7 @@ pub async fn build_slack_events_host_ingress_mount_from_enabled_extensions(
             egress_credentials,
             b"host-ingress-preverified".to_vec(),
         )?;
-        let credential_handles = declaration_credential_handles(entry.declaration());
+        let credential_handles = declaration_credential_handles(&declaration);
         for ingress_credential_handle in &credential_handles {
             let secret_handle =
                 extension_secret_handle(installation, ingress_credential_handle.as_str())?;
@@ -666,9 +671,9 @@ pub async fn build_slack_events_host_ingress_mount_from_enabled_extensions(
         );
     }
 
-    if installations.is_empty() {
+    let Some(declaration) = projected_declaration else {
         return Ok(None);
-    }
+    };
 
     let handler = Arc::new(SlackEventsIngressHandler::new(installations)?);
     let resolver = Arc::new(ExtensionInstallationIngressCredentialResolver::new(
@@ -676,7 +681,10 @@ pub async fn build_slack_events_host_ingress_mount_from_enabled_extensions(
         credential_bindings,
     )?);
     Ok(Some(public_ingress_route_mount(
-        slack_events_host_ingress_registrations(handler)?,
+        vec![HostIngressRegistration {
+            declaration,
+            handler,
+        }],
         resolver,
     )?))
 }

--- a/crates/ironclaw_reborn_composition/src/slack_host_beta.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_host_beta.rs
@@ -20,7 +20,7 @@ use ironclaw_host_api::ingress::{
 use ironclaw_host_api::{
     AgentId, ExtensionId, InvocationId, ProjectId, ResourceScope, SecretHandle, TenantId, UserId,
 };
-use ironclaw_host_ingress_registry::{SLACK_EVENTS_ROUTE_ID, list_enabled_host_ingress_entries};
+use ironclaw_host_ingress_registry::list_enabled_host_ingress_entries;
 use ironclaw_outbound::{DeliveredGateRouteStore, OutboundStateStore, TriggeredRunDeliveryStore};
 use ironclaw_product_adapters::{
     AdapterInstallationId, DeclaredEgressHost, DeclaredEgressTarget, DeliveryStatus,
@@ -71,7 +71,7 @@ use crate::slack_extension_settings::{
 };
 use crate::slack_host_ingress::{
     ExtensionInstallationIngressCredentialBinding, ExtensionInstallationIngressCredentialResolver,
-    SlackEventsIngressHandler, SlackHostIngressInstallation,
+    SLACK_EVENTS_HOST_INGRESS_ROUTE_ID, SlackEventsIngressHandler, SlackHostIngressInstallation,
     slack_events_host_ingress_registrations,
 };
 use crate::slack_host_state::FilesystemSlackHostState;
@@ -682,7 +682,7 @@ pub async fn build_slack_events_host_ingress_mount_from_enabled_extensions(
 }
 
 fn is_slack_events_declaration(declaration: &HostIngressRouteDeclaration) -> bool {
-    if declaration.route().route_id().as_str() != SLACK_EVENTS_ROUTE_ID {
+    if declaration.route().route_id().as_str() != SLACK_EVENTS_HOST_INGRESS_ROUTE_ID {
         return false;
     }
     matches!(

--- a/crates/ironclaw_reborn_composition/src/slack_host_ingress.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_host_ingress.rs
@@ -9,9 +9,9 @@ use axum::http::HeaderMap;
 use ironclaw_host_api::ingress::{
     AllowedEffectPath, AuditTraceClass, BodyLimitPolicy, CorsPolicy, HostIngressRouteDeclaration,
     HostIngressTarget, IngressAckMode, IngressAuthBinding, IngressAuthPolicy, IngressAuthScheme,
-    IngressAuthSchemeName, IngressCredentialHandle, IngressDrainMode, IngressPolicy,
-    IngressPolicyParts, IngressRouteDescriptor, IngressScopeSource, ListenerClass, RateLimitPolicy,
-    RateLimitScope, StreamingMode, WebSocketOriginPolicy,
+    IngressCredentialHandle, IngressDrainMode, IngressPolicy, IngressPolicyParts,
+    IngressRouteDescriptor, IngressScopeSource, ListenerClass, RateLimitPolicy, RateLimitScope,
+    StreamingMode, WebSocketOriginPolicy,
 };
 use ironclaw_host_api::{CapabilityId, NetworkMethod, ResourceScope, SecretHandle};
 use ironclaw_product_adapters::{ProtocolAuthEvidence, mark_request_signature_verified};
@@ -355,13 +355,12 @@ pub fn slack_events_host_ingress_declaration(
             "Slack events ingress descriptor did not validate: {error}"
         ))
     })?;
-    let auth = IngressAuthBinding::new(slack_hmac_auth_scheme()?, credential_handles).map_err(
-        |error| {
+    let auth = IngressAuthBinding::new(IngressAuthScheme::WebhookSignature, credential_handles)
+        .map_err(|error| {
             internal(format!(
                 "Slack events ingress auth binding did not validate: {error}"
             ))
-        },
-    )?;
+        })?;
     let capability_id = CapabilityId::new(SLACK_EVENTS_HOST_INGRESS_ROUTE_ID).map_err(|error| {
         internal(format!(
             "Slack events ingress capability id did not validate: {error}"
@@ -453,14 +452,6 @@ fn auth_failed(reason: impl Into<String>) -> HostIngressError {
     HostIngressError::AuthenticationFailed {
         reason: reason.into(),
     }
-}
-
-fn slack_hmac_auth_scheme() -> Result<IngressAuthSchemeName, HostIngressError> {
-    IngressAuthSchemeName::new("slack_v0_hmac").map_err(|error| {
-        internal(format!(
-            "Slack events ingress auth scheme did not validate: {error}"
-        ))
-    })
 }
 
 fn nonzero_u64(value: u64, field: &'static str) -> Result<NonZeroU64, HostIngressError> {

--- a/crates/ironclaw_reborn_composition/src/telegram_host_beta.rs
+++ b/crates/ironclaw_reborn_composition/src/telegram_host_beta.rs
@@ -6,8 +6,8 @@
 //! extension, and [`build_telegram_updates_host_ingress_mount_from_enabled_extensions`]
 //! projects the `/webhooks/telegram/updates` route from enabled extension state
 //! through the generic host-ingress registry. The mounted route's descriptor is
-//! the single source of truth (the registry `telegram_updates` policy profile),
-//! so there is no hand-maintained path that can drift out of the manifest.
+//! projected from the manifest, so there is no hand-maintained path that can
+//! drift out of the manifest.
 //!
 //! Two distinct secrets flow through here and must never be conflated:
 //! * the **webhook secret** authenticates inbound updates (the host verifies the
@@ -30,9 +30,7 @@ use ironclaw_host_api::ingress::{
 use ironclaw_host_api::{
     AgentId, ExtensionId, InvocationId, ProjectId, ResourceScope, SecretHandle, TenantId, UserId,
 };
-use ironclaw_host_ingress_registry::{
-    TELEGRAM_UPDATES_ROUTE_ID, list_enabled_host_ingress_entries,
-};
+use ironclaw_host_ingress_registry::list_enabled_host_ingress_entries;
 use ironclaw_product_adapters::{
     AdapterInstallationId, AuthRequirement, DeclaredEgressHost, DeclaredEgressTarget,
     EgressCredentialHandle, ProductAdapter, ProductAdapterId, ProtocolHttpEgress,
@@ -64,7 +62,8 @@ use crate::telegram_extension_settings::{
 };
 use crate::telegram_host_ingress::{
     ExtensionInstallationIngressCredentialBinding, ExtensionInstallationIngressCredentialResolver,
-    TELEGRAM_WEBHOOK_SECRET_HEADER, TelegramHostIngressInstallation, TelegramUpdatesIngressHandler,
+    TELEGRAM_UPDATES_HOST_INGRESS_ROUTE_ID, TELEGRAM_WEBHOOK_SECRET_HEADER,
+    TelegramHostIngressInstallation, TelegramUpdatesIngressHandler,
     telegram_updates_host_ingress_registrations,
 };
 use crate::webui_serve::PublicRouteMount;
@@ -370,7 +369,7 @@ pub async fn build_telegram_updates_host_ingress_mount_from_enabled_extensions(
 }
 
 fn is_telegram_updates_declaration(declaration: &HostIngressRouteDeclaration) -> bool {
-    if declaration.route().route_id().as_str() != TELEGRAM_UPDATES_ROUTE_ID {
+    if declaration.route().route_id().as_str() != TELEGRAM_UPDATES_HOST_INGRESS_ROUTE_ID {
         return false;
     }
     matches!(

--- a/crates/ironclaw_reborn_composition/src/telegram_host_beta.rs
+++ b/crates/ironclaw_reborn_composition/src/telegram_host_beta.rs
@@ -52,7 +52,7 @@ use secrecy::{ExposeSecret, SecretString};
 use thiserror::Error;
 
 use crate::RebornRuntime;
-use crate::host_ingress::{HostIngressError, public_ingress_route_mount};
+use crate::host_ingress::{HostIngressError, HostIngressRegistration, public_ingress_route_mount};
 use crate::telegram_delivery::{
     TelegramFinalReplyDeliveryObserver, TelegramFinalReplyDeliveryServices,
 };
@@ -64,7 +64,6 @@ use crate::telegram_host_ingress::{
     ExtensionInstallationIngressCredentialBinding, ExtensionInstallationIngressCredentialResolver,
     TELEGRAM_UPDATES_HOST_INGRESS_ROUTE_ID, TELEGRAM_WEBHOOK_SECRET_HEADER,
     TelegramHostIngressInstallation, TelegramUpdatesIngressHandler,
-    telegram_updates_host_ingress_registrations,
 };
 use crate::webui_serve::PublicRouteMount;
 
@@ -293,6 +292,7 @@ pub async fn build_telegram_updates_host_ingress_mount_from_enabled_extensions(
     let telegram_extension_id = telegram_extension_id()?;
     let mut installations = Vec::new();
     let mut credential_bindings = Vec::new();
+    let mut projected_declaration = None;
 
     for entry in entries {
         let installation = entry.installation();
@@ -301,6 +301,10 @@ pub async fn build_telegram_updates_host_ingress_mount_from_enabled_extensions(
         }
         if !is_telegram_updates_declaration(entry.declaration()) {
             continue;
+        }
+        let declaration = entry.declaration().clone();
+        if projected_declaration.is_none() {
+            projected_declaration = Some(declaration.clone());
         }
         let settings = settings_store
             .get(installation.installation_id())
@@ -332,7 +336,7 @@ pub async fn build_telegram_updates_host_ingress_mount_from_enabled_extensions(
         let (runner, observer) =
             build_telegram_runner_and_observer(runtime, &config, bot_token_handle, egress)?;
 
-        let credential_handles = declaration_credential_handles(entry.declaration());
+        let credential_handles = declaration_credential_handles(&declaration);
         for ingress_credential_handle in &credential_handles {
             let secret_handle =
                 extension_secret_handle(installation, ingress_credential_handle.as_str())?;
@@ -353,9 +357,9 @@ pub async fn build_telegram_updates_host_ingress_mount_from_enabled_extensions(
         );
     }
 
-    if installations.is_empty() {
+    let Some(declaration) = projected_declaration else {
         return Ok(None);
-    }
+    };
 
     let handler = Arc::new(TelegramUpdatesIngressHandler::new(installations)?);
     let resolver = Arc::new(ExtensionInstallationIngressCredentialResolver::new(
@@ -363,7 +367,10 @@ pub async fn build_telegram_updates_host_ingress_mount_from_enabled_extensions(
         credential_bindings,
     )?);
     Ok(Some(public_ingress_route_mount(
-        telegram_updates_host_ingress_registrations(handler)?,
+        vec![HostIngressRegistration {
+            declaration,
+            handler,
+        }],
         resolver,
     )?))
 }

--- a/crates/ironclaw_reborn_composition/src/telegram_host_ingress.rs
+++ b/crates/ironclaw_reborn_composition/src/telegram_host_ingress.rs
@@ -40,7 +40,7 @@ use ironclaw_wasm_product_adapters::{
 
 use crate::host_ingress::{
     HostIngressAuthCandidate, HostIngressCapabilityHandler, HostIngressCredentialResolver,
-    HostIngressError, HostIngressImmediateResponse, HostIngressRegistration, ResolvedIngressSecret,
+    HostIngressError, HostIngressImmediateResponse, ResolvedIngressSecret,
     UnverifiedHostIngressRequest, VerifiedHostIngressRequest,
 };
 
@@ -210,18 +210,6 @@ impl HostIngressCapabilityHandler for TelegramUpdatesIngressHandler {
             futures::future::join_all(drains).await;
         })
     }
-}
-
-pub fn telegram_updates_host_ingress_registrations(
-    handler: Arc<TelegramUpdatesIngressHandler>,
-) -> Result<Vec<HostIngressRegistration>, HostIngressError> {
-    let declaration =
-        telegram_updates_host_ingress_declaration(handler.declared_credential_handles())?;
-    let handler: Arc<dyn HostIngressCapabilityHandler> = handler;
-    Ok(vec![HostIngressRegistration {
-        declaration,
-        handler,
-    }])
 }
 
 pub fn telegram_updates_host_ingress_declaration(

--- a/crates/ironclaw_reborn_composition/src/telegram_host_ingress.rs
+++ b/crates/ironclaw_reborn_composition/src/telegram_host_ingress.rs
@@ -26,9 +26,9 @@ use async_trait::async_trait;
 use ironclaw_host_api::ingress::{
     AllowedEffectPath, AuditTraceClass, BodyLimitPolicy, CorsPolicy, HostIngressRouteDeclaration,
     HostIngressTarget, IngressAckMode, IngressAuthBinding, IngressAuthPolicy, IngressAuthScheme,
-    IngressAuthSchemeName, IngressCredentialHandle, IngressDrainMode, IngressPolicy,
-    IngressPolicyParts, IngressRouteDescriptor, IngressScopeSource, ListenerClass, RateLimitPolicy,
-    RateLimitScope, StreamingMode, WebSocketOriginPolicy,
+    IngressCredentialHandle, IngressDrainMode, IngressPolicy, IngressPolicyParts,
+    IngressRouteDescriptor, IngressScopeSource, ListenerClass, RateLimitPolicy, RateLimitScope,
+    StreamingMode, WebSocketOriginPolicy,
 };
 use ironclaw_host_api::{CapabilityId, NetworkMethod, ResourceScope, SecretHandle};
 use ironclaw_product_adapters::{AdapterInstallationId, AuthRequirement, ProtocolAuthEvidence};
@@ -51,8 +51,6 @@ pub const TELEGRAM_UPDATES_HOST_INGRESS_ROUTE_ID: &str = "telegram.updates";
 pub const TELEGRAM_UPDATES_HOST_INGRESS_PATH: &str = "/webhooks/telegram/updates";
 /// Header carrying the per-installation webhook shared secret.
 pub const TELEGRAM_WEBHOOK_SECRET_HEADER: &str = "X-Telegram-Bot-Api-Secret-Token";
-/// Auth scheme name recorded in the route declaration's auth binding.
-const TELEGRAM_SHARED_SECRET_AUTH_SCHEME: &str = "telegram_secret_token";
 /// Telegram updates can carry large payloads (e.g. captions, inline data); cap
 /// at 1 MiB to bound host memory while comfortably covering real updates.
 const TELEGRAM_UPDATES_BODY_LIMIT_BYTES: u64 = 1024 * 1024;
@@ -245,7 +243,7 @@ pub fn telegram_updates_host_ingress_declaration(
             "Telegram updates ingress descriptor did not validate: {error}"
         ))
     })?;
-    let auth = IngressAuthBinding::new(telegram_shared_secret_auth_scheme()?, credential_handles)
+    let auth = IngressAuthBinding::new(IngressAuthScheme::SharedSecretHeader, credential_handles)
         .map_err(|error| {
         internal(format!(
             "Telegram updates ingress auth binding did not validate: {error}"
@@ -309,14 +307,6 @@ fn verify_telegram_shared_secret(
             "Telegram shared-secret header verification failed: {failure}"
         ))),
     }
-}
-
-fn telegram_shared_secret_auth_scheme() -> Result<IngressAuthSchemeName, HostIngressError> {
-    IngressAuthSchemeName::new(TELEGRAM_SHARED_SECRET_AUTH_SCHEME).map_err(|error| {
-        internal(format!(
-            "Telegram updates ingress auth scheme did not validate: {error}"
-        ))
-    })
 }
 
 fn telegram_updates_ingress_policy() -> Result<IngressPolicy, HostIngressError> {
@@ -549,8 +539,8 @@ mod tests {
         }
         assert_eq!(declaration.auth().len(), 1);
         assert_eq!(
-            declaration.auth()[0].scheme().as_str(),
-            "telegram_secret_token"
+            declaration.auth()[0].verifier(),
+            IngressAuthScheme::SharedSecretHeader
         );
     }
 
@@ -559,15 +549,6 @@ mod tests {
         let error = telegram_updates_host_ingress_declaration(Vec::new())
             .expect_err("declaration without credential handles must reject");
         assert!(matches!(error, HostIngressError::Internal { .. }));
-    }
-
-    #[test]
-    fn telegram_shared_secret_auth_scheme_declares_shared_secret_header() {
-        let scheme = telegram_shared_secret_auth_scheme().expect("scheme validates");
-        assert_eq!(
-            scheme.declared_auth_scheme(),
-            IngressAuthScheme::SharedSecretHeader
-        );
     }
 
     #[test]

--- a/crates/ironclaw_reborn_composition/src/telegram_host_ingress.rs
+++ b/crates/ironclaw_reborn_composition/src/telegram_host_ingress.rs
@@ -51,9 +51,8 @@ pub const TELEGRAM_UPDATES_HOST_INGRESS_ROUTE_ID: &str = "telegram.updates";
 pub const TELEGRAM_UPDATES_HOST_INGRESS_PATH: &str = "/webhooks/telegram/updates";
 /// Header carrying the per-installation webhook shared secret.
 pub const TELEGRAM_WEBHOOK_SECRET_HEADER: &str = "X-Telegram-Bot-Api-Secret-Token";
-/// Auth scheme name recorded in the route declaration's auth binding. Its
-/// `declared_auth_scheme()` maps to `WebhookSignature`, matching the policy.
-const TELEGRAM_SHARED_SECRET_AUTH_SCHEME: &str = "telegram_shared_secret";
+/// Auth scheme name recorded in the route declaration's auth binding.
+const TELEGRAM_SHARED_SECRET_AUTH_SCHEME: &str = "telegram_secret_token";
 /// Telegram updates can carry large payloads (e.g. captions, inline data); cap
 /// at 1 MiB to bound host memory while comfortably covering real updates.
 const TELEGRAM_UPDATES_BODY_LIMIT_BYTES: u64 = 1024 * 1024;
@@ -324,7 +323,7 @@ fn telegram_updates_ingress_policy() -> Result<IngressPolicy, HostIngressError> 
     IngressPolicy::new(IngressPolicyParts {
         listener_class: ListenerClass::PublicWebhook,
         auth: IngressAuthPolicy::Required {
-            schemes: vec![IngressAuthScheme::WebhookSignature],
+            schemes: vec![IngressAuthScheme::SharedSecretHeader],
         },
         scope_source: IngressScopeSource::HostResolved,
         body_limit: BodyLimitPolicy::Limited {
@@ -551,7 +550,7 @@ mod tests {
         assert_eq!(declaration.auth().len(), 1);
         assert_eq!(
             declaration.auth()[0].scheme().as_str(),
-            "telegram_shared_secret"
+            "telegram_secret_token"
         );
     }
 
@@ -563,11 +562,11 @@ mod tests {
     }
 
     #[test]
-    fn telegram_shared_secret_auth_scheme_declares_webhook_signature() {
+    fn telegram_shared_secret_auth_scheme_declares_shared_secret_header() {
         let scheme = telegram_shared_secret_auth_scheme().expect("scheme validates");
         assert_eq!(
             scheme.declared_auth_scheme(),
-            IngressAuthScheme::WebhookSignature
+            IngressAuthScheme::SharedSecretHeader
         );
     }
 

--- a/docs/plans/2026-06-20-manifest-driven-channels.md
+++ b/docs/plans/2026-06-20-manifest-driven-channels.md
@@ -1,0 +1,131 @@
+# Manifest-Driven Channels — Sequencing Plan
+
+**Status:** in progress · **Started:** 2026-06-20
+**Goal:** Make channel/extension ingress, egress, secrets, and capabilities
+**manifest-defined** instead of provider-specific Rust, so adding a channel
+(Discord, WeCom, …) is a manifest authoring task — not an edit to `serve`,
+`factory`, the host-ingress registry, and N composition modules.
+
+This plan grew out of the review of [#5100] (project Telegram ingress from
+extension state), which correctly puts Telegram on the same manifest-projected
+path as Slack ([#5093]) but stops at declaring a *static contract*: the manifest
+still only carries selectors, and provider-specific Rust turns them into runtime
+behavior. The moves below convert those selectors into data, one keystone at a
+time, with a hard rule: **each move must delete Rust, not just rearrange it.**
+
+## Design decisions (locked)
+
+1. **Policy is manifest data, not a Rust-keyed selector.** The closed
+   `IngressPolicyProfile` enum (magic-string → Rust-constant policy) is replaced
+   by an `IngressPolicy` projected directly from the manifest section. (Move 1.)
+2. **One inbound-transport contract with a shared `IngressPolicy` envelope** plus
+   a transport discriminator (`webhook | websocket | polling`) — NOT sibling
+   `host_ingress` / `websocket` contracts that each re-declare
+   auth/scope/audit/effect-path/limits. The security envelope is declared once,
+   transport-agnostic. (Move 2.)
+3. **Cross-contract credential coherence is a single post-projection invariant.**
+   Every credential handle referenced by any contract must resolve to exactly one
+   declared credential; a canonical `CredentialHandle` carries identity across the
+   per-domain newtypes. (Move 3.)
+4. **Each move's success criterion is a named Rust deletion.** A move that adds a
+   parallel mechanism instead of replacing one has failed its bar.
+
+## Move sequence
+
+```
+Move 0 (this doc) ─► Move 1 (IngressPolicy, KEYSTONE) ─► Move 2 (transport union)
+                                                     └─► Move 3 (credential coherence)
+                            Move 2 + Move 3 ──────────► Move 4 (serve.rs collapse)
+                                                     └─► Move 5+ (setup, connectable, …)
+```
+
+### Move 1 — IngressPolicy projectable; delete the profile enum ✅ (this PR)
+
+Replace `policy_profile = "..."` (a selector into the closed
+`IngressPolicyProfile` enum) with an inline, typed `[host_ingress.*.policy]`
+declaration projected straight onto the existing `IngressPolicy` type. Route
+descriptor is built from the manifest's own `route_id`/`method`/`path`.
+
+- **Deleted:** `IngressPolicyProfile` + all impls, `slack_events_policy`,
+  `telegram_updates_policy`, the two `*_route_descriptor` fns, all `SLACK_EVENTS_*`
+  / `TELEGRAM_UPDATES_*` constants, the `policy_profile` field, and the
+  `ProfileRouteMismatch` / route-identity validation.
+- **Auth honesty:** added `IngressAuthScheme::SharedSecretHeader`; Telegram now
+  declares shared-secret-header auth, Slack stays webhook-signature. The lossy
+  "everything is `WebhookSignature`" coercion is partially removed.
+- **Fail-closed:** unknown enum value, zero limit, and missing field are rejected
+  with typed errors (tests added). Registry file shrank 968 → 807 lines.
+- **Both** Slack and Telegram manifests migrated; projected policy is
+  behavior-equal to the deleted Rust functions.
+
+### Move 2 — Unify the transport model behind one contract (NEXT)
+
+**Base:** stacks on Move 1. **Bar:** the webhook-specific policy fields collapse
+into the shared envelope; the residual string→scheme mapping is deleted.
+
+Scope:
+- Introduce a `transport = webhook { path, method, ack, drain } | websocket { url,
+  heartbeat, identify_credential } | polling { min_interval }` discriminator with
+  the shared `IngressPolicy` security envelope from Move 1. Re-express Slack and
+  Telegram webhook ingress as `transport = webhook`. **Do not implement the
+  websocket variant yet** — prove the webhook variant rides the unified shape;
+  websocket lands when a real second consumer (Discord/WeCom) exists. Avoid
+  speculative genericity (its own smell).
+- **Fail-closed auth hardening (carried from Move 1's deferral):**
+  `IngressAuthSchemeName::declared_auth_scheme()` currently maps the binding
+  scheme-*name* → `IngressAuthScheme` via a string `match` with a
+  `_ => WebhookSignature` **silent fallback** — stringly-typed and fail-*open* in
+  a security path. Move 2 carries the verifier kind directly through the auth
+  binding and makes an unknown scheme name a hard error (no `WebhookSignature`
+  default). This removes the last "magic string → auth kind" indirection.
+- **Deletion bar:** the `declared_auth_scheme()` string match and any
+  webhook-only policy duplication are gone after this move.
+
+Out of scope: `serve.rs` mount wiring (Move 4), websocket runtime,
+connectable/egress modules.
+
+### Move 3 — Cross-contract credential coherence ✅ (separate PR)
+
+Add a canonical `CredentialHandle` (`ironclaw_host_api::ids`) and a
+post-projection invariant in `HostApiContractRegistry::project_manifest`: every
+referenced credential handle must resolve to a declared credential. Closes the
+"same credential spelled in two sections, drifts" class (bug #2574 family).
+
+- Extended `HostApiManifestProjection` with `declared_credentials` +
+  `referenced_credentials` (with `host_api`/section provenance).
+- `ManifestV2Error::DanglingCredentialHandle { handle, host_api, section }`.
+- Wired product-adapter (declared = `required_credentials`, referenced = egress
+  handles) and capability-provider (referenced = `SecretHandle` runtime creds).
+- **Integration seam (done at Move 1 ↔ Move 3 merge):** the host-ingress contract
+  reports each `host_ingress.*.auth.credential_handles` entry as a
+  `ReferencedCredential` (≈3 lines in
+  `HostIngressHostApiContract::project_section_with_context`). Then tighten the
+  empty-declared-set rule to require a declaration for every referenced handle.
+
+### Move 4 — Collapse the `serve.rs` per-channel cfg sprawl
+
+Replace the `#[cfg(feature = "telegram-v2-host-beta")]` + nested
+`is_generic()/is_generic_shadow()` mount block (cloned from Slack) with a single
+loop that iterates enabled extensions and mounts whatever transports they project.
+**Bar:** "add a channel" touches zero lines in `serve.rs`.
+
+### Move 5+ — Remaining contracts (one per PR, each deleting Rust)
+
+- `ironclaw.extension_setup/v1` — deletes the provider-specific
+  `import_*_host_beta_config_as_extension_installation` path.
+- `ironclaw.connectable_channel/v1` — deletes the hardcoded
+  `*_inbound_proof_code_connectable_channel()` composition. References credentials
+  by handle; never re-declares them.
+- `channel_runtime` only if it deletes real branching (skip if it merely relocates
+  `capabilities.flags`).
+
+## Verification gate (every move)
+
+`cargo fmt` · `cargo clippy -D warnings` on touched crates ·
+`cargo test` on touched crates · `cargo check --workspace --all-features`.
+Agent sandboxes cannot reach the network, so the workspace check is run by the
+human/host reviewer before merge.
+
+[#5072]: https://github.com/nearai/ironclaw/pull/5072
+[#5093]: https://github.com/nearai/ironclaw/pull/5093
+[#5100]: https://github.com/nearai/ironclaw/pull/5100


### PR DESCRIPTION
## Summary

The **keystone** of the manifest-driven-channels work, now covering the full inbound ingress contract: policy *and* auth become typed manifest data instead of Rust-side selectors. (Originally split as Move 1 + Move 2 / #5104; folded together since they edit the same files, land together, and the auth fix cleans up a fail-open residual the policy change introduced.)

## 1. Policy projected from the manifest (delete the profile enum)

Replace the closed `IngressPolicyProfile` enum — a magic-string selector mapping `"slack_events"`/`"telegram_updates"` to a hardcoded Rust `IngressPolicy` — with an inline `[host_ingress.*.policy]` declaration projected straight onto the existing `IngressPolicy` type. Route descriptor is built from the manifest's own `route_id`/`method`/`path`.

Deleted: `IngressPolicyProfile` + all impls, `slack_events_policy`/`telegram_updates_policy`, both `*_route_descriptor` fns, all `SLACK_EVENTS_*`/`TELEGRAM_UPDATES_*` constants, the `policy_profile` field, and `ProfileRouteMismatch`/route-identity validation.

## 2. Typed auth verifier (fail-closed)

Delete `IngressAuthSchemeName` + `declared_auth_scheme()`, which derived the auth verifier *kind* from the scheme *name* string with a silent `_ => WebhookSignature` fallback — stringly-typed and **fail-open** in a security path. `IngressAuthBinding` now carries a typed `verifier: IngressAuthScheme` declared directly in the manifest (`verifier = "shared_secret_header"`); unknown values reject at parse, and a verifier not in the route policy's allowed `schemes` fails closed.

## 3. Transport discriminator

Group webhook route wiring under a single-variant `HostIngressTransport::Webhook`, leaving `policy`/`target`/`auth` as the transport-agnostic envelope. No speculative websocket/polling variants — the enum is the seam for a future transport. Route projection goes through `project_host_ingress_section` (no intermediate wrapper).

## Quality

- Both Slack + Telegram manifests migrated; projected policy + declarations are **behavior-equal** to the deleted Rust.
- Fail-closed tests: unknown policy enum value, zero limit, missing field, unknown verifier, verifier-not-in-policy, unsupported transport kind.
- Two thermo-nuclear review passes applied (wrapper deletion, duplicate-check removal, transport inlining, `host_runtime` fixture fix).
- `cargo fmt` · `clippy -p ironclaw_host_ingress_registry -p ironclaw_host_api -p ironclaw_reborn_composition --all-targets --all-features -D warnings` → green · registry + host_api + host_runtime fixture tests pass.

## Stacking

Base is `stack/5100-telegram-ingress` (a snapshot of #5100's tip on origin), so the diff is **only this work**. Stacks under the unmerged #5072 → #5093 → #5100 chain; will retarget to `main` once that lands. Companion: #5102 (cross-contract credential coherence, independent crates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)