### PR TITLE
test(safety,auth): fix three stale provider/OAuth guard tests broken on main

### DIFF
--- a/crates/ironclaw_auth/tests/auth_product_contract/oauth_helpers_contract.rs
+++ b/crates/ironclaw_auth/tests/auth_product_contract/oauth_helpers_contract.rs
@@ -248,7 +248,11 @@ fn google_callback_state_round_trips_through_validated_encoded_state() {
 
 #[test]
 fn google_callback_state_rejects_unapproved_requested_scopes() {
-    let invalid_scope = ProviderScope::new("https://www.googleapis.com/auth/drive").unwrap();
+    // `gmail.insert` is a real, sensitive Gmail scope deliberately kept out of
+    // the approved GSuite set (`is_allowed_google_scope`). The approved set grew
+    // to include the Drive/Docs/Sheets/Slides scopes in #4326, so this guards the
+    // boundary with a scope that is still outside it.
+    let invalid_scope = ProviderScope::new("https://www.googleapis.com/auth/gmail.insert").unwrap();
 
     assert_invalid_request(GoogleOAuthCallbackState::new(
         AuthFlowId::new(),

--- a/crates/ironclaw_loop_support/src/capability_port/provider_validation.rs
+++ b/crates/ironclaw_loop_support/src/capability_port/provider_validation.rs
@@ -91,13 +91,19 @@ mod tests {
 
     #[test]
     fn provider_tool_call_validation_rejects_sensitive_metadata() {
+        // Arguments carrying a real secret-like token are rejected by the
+        // entropy-based leak scan, which is the canonical guard after #5001
+        // dropped the crude bare-word substring markers.
         let mut call = provider_tool_call();
         let api_key = format!("sk-proj-{}", "a".repeat(24));
         call.arguments = serde_json::json!({"password": api_key});
         assert!(validate_provider_tool_call(&call).is_err());
 
+        // The same leak scan runs over model-emitted reasoning, so a leaked
+        // secret-like token there is rejected even though bare words like
+        // "traceback" are now intentionally allowed (#5001, PinchBench bucket D).
         let mut call = provider_tool_call();
-        call.reasoning = Some("provider error included traceback".to_string());
+        call.reasoning = Some(format!("provider error leaked sk-proj-{}", "b".repeat(24)));
         assert!(validate_provider_tool_call(&call).is_err());
     }
 

--- a/crates/ironclaw_threads/src/tool_result_reference.rs
+++ b/crates/ironclaw_threads/src/tool_result_reference.rs
@@ -880,13 +880,20 @@ mod tests {
 
     #[test]
     fn provider_reference_validation_rejects_sensitive_arguments_and_text() {
+        // Arguments carrying a real secret-like token are rejected by the
+        // entropy-based leak scan, which is the canonical guard after #5001
+        // dropped the crude bare-word substring markers.
         let mut envelope = provider_reference();
         let api_key = format!("sk-proj-{}", "a".repeat(24));
         envelope.arguments = serde_json::json!({"api_key": api_key});
         assert!(envelope.validate().is_err());
 
+        // Provider reasoning text flows through the same leak scan, so a leaked
+        // secret-like token there is rejected even though bare words like
+        // "stack trace" are now intentionally allowed (#5001, PinchBench bucket D).
         let mut envelope = provider_reference();
-        envelope.response_reasoning = Some("raw provider error included a stack trace".to_string());
+        envelope.response_reasoning =
+            Some(format!("provider error leaked sk-proj-{}", "b".repeat(24)));
         assert!(envelope.validate().is_err());
     }
 


### PR DESCRIPTION
## Summary

Three security-relevant guard tests fail on `main` even with `--all-features`. They went undetected because these crates were outside the reborn CI closure. Investigation shows **all three are stale tests asserting pre-change behavior — not guard regressions**. In each case I confirmed the real guard still fires before updating the test, so the tests now assert the *actual* contract instead of reverting shipped behavior.

| Test | Stale assertion | Actual guard today | Intentional change |
|---|---|---|---|
| `provider_tool_call_validation_rejects_sensitive_metadata` (`ironclaw_loop_support`) | bare word `traceback` in reasoning is rejected | only **real secret-like tokens** rejected (entropy-based `LeakDetector`); bare words allowed | [#5001](https://github.com/nearai/ironclaw/pull/5001) dropped bare-word markers to stop give-up loops |
| `provider_reference_validation_rejects_sensitive_arguments_and_text` (`ironclaw_threads`) | bare phrase `stack trace` in reasoning is rejected | same `LeakDetector` path via `ironclaw_safety::provider_validation` | [#5001](https://github.com/nearai/ironclaw/pull/5001) (same root cause) |
| `google_callback_state_rejects_unapproved_requested_scopes` (`ironclaw_auth`) | `.../auth/drive` is unapproved | Drive is approved; scopes outside the GSuite set still rejected | [#4326](https://github.com/nearai/ironclaw/pull/4326) added Drive/Docs/Sheets/Slides to support GSuite capabilities |

## Why these are stale tests, not code bugs

- **#1/#2:** [#5001](https://github.com/nearai/ironclaw/pull/5001) deliberately removed the crude substring markers on model-emitted reasoning/metadata text and locked the new behavior in with updated tests *inside the safety crate itself*. The secret-token half of each downstream test already passed (`sk-proj-…` is caught by `LeakDetector`); only the bare-word half failed. That commit updated `loop_support`'s production code but left its test body untouched, and never touched the `threads` test.
- **#3:** [#4326](https://github.com/nearai/ironclaw/pull/4326) added the Drive/Docs/Sheets/Slides scope consts **and** the matching `is_allowed_google_scope` arms together (a Drive capability needs that scope). The test had picked `drive` as its "obviously unapproved" example one day before it became approved.

## Fix (test-only — no production behavior change)

- #1/#2: assert a **real secret-like token** in reasoning/`response_reasoning` so the test verifies the guard that actually exists (secrets leaked into reasoning text are rejected).
- #3: use `.../auth/gmail.insert` — a real, sensitive Gmail scope still **outside** the approved GSuite set — so the test keeps guarding the real boundary.

## Verification

- All three previously-failing tests pass.
- Full test suites of `ironclaw_loop_support`, `ironclaw_threads`, `ironclaw_auth` green (`--all-features`, 0 failures).
- `cargo clippy --tests --all-features` and `cargo fmt` clean on all three crates.

## Note

These tests only stay protected if these crates are exercised by CI — they weren't, which is why the staleness went unnoticed. Keeping them in the reborn CI closure is the complementary piece (tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)