### PR TITLE
feat(serve): collapse per-channel host-ingress mount sprawl into one generic plan (Move 4)

### DIFF
--- a/crates/ironclaw_first_party_extensions/assets/slack/manifest.toml
+++ b/crates/ironclaw_first_party_extensions/assets/slack/manifest.toml
@@ -83,3 +83,28 @@ product_adapter_section = "product_adapter.inbound"
 [host_ingress.events.auth]
 verifier = "webhook_signature"
 credential_handles = ["slack_signing_secret"]
+
+[[metadata.connectable.channels]]
+channel = "slack"
+display_name = "Slack"
+strategy = "inbound_proof_code"
+requires_route_ids = ["slack.events", "webui.v2.extensions.pairing.redeem"]
+title = "Slack account connection"
+instructions = "Message the Slack app, then enter the code here."
+input_placeholder = "Enter Slack pairing code..."
+submit_label = "Connect"
+success_message = "Slack account connected."
+error_message = "Invalid or expired Slack pairing code."
+command_aliases = ["slack", "slack account", "slack pairing"]
+
+[[metadata.connectable.channels]]
+channel = "slack"
+display_name = "Slack"
+strategy = "admin_managed_channels"
+requires_route_ids = ["webui.v2.channels.slack.routes.list"]
+title = "Slack team agents"
+instructions = "Map Slack channels to the team agents that should answer there."
+input_placeholder = "C0123456789"
+submit_label = "Save channels"
+success_message = "Slack channels saved."
+error_message = "Slack channel update failed."

--- a/crates/ironclaw_first_party_extensions/assets/telegram/manifest.toml
+++ b/crates/ironclaw_first_party_extensions/assets/telegram/manifest.toml
@@ -82,3 +82,16 @@ product_adapter_section = "product_adapter.inbound"
 [host_ingress.updates.auth]
 verifier = "shared_secret_header"
 credential_handles = ["telegram_webhook_secret"]
+
+[[metadata.connectable.channels]]
+channel = "telegram"
+display_name = "Telegram"
+strategy = "inbound_proof_code"
+requires_route_ids = ["telegram.updates"]
+title = "Telegram account connection"
+instructions = "Open your bot in Telegram, send /start (or any message), then enter the pairing code it replies with here."
+input_placeholder = "Enter Telegram pairing code..."
+submit_label = "Connect"
+success_message = "Telegram account connected."
+error_message = "Invalid or expired Telegram pairing code."
+command_aliases = ["telegram", "telegram account", "telegram pairing"]

--- a/crates/ironclaw_reborn_cli/src/commands/serve.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/serve.rs
@@ -7,25 +7,14 @@ use anyhow::{Context, anyhow};
 use clap::Args;
 #[cfg(feature = "openai-compat-beta")]
 use ironclaw_reborn_composition::build_openai_compat_route_mount;
-#[cfg(not(feature = "slack-v2-host-beta"))]
-use ironclaw_reborn_composition::build_webui_services;
 use ironclaw_reborn_composition::host_api::{AgentId, ProjectId, TenantId, UserId};
 use ironclaw_reborn_composition::{
-    GoogleOAuthRouteConfig, LocalTriggerAccessReconciliation, LocalTriggerAccessRole,
-    LocalTriggerAccessSource, RebornBuildInput, RebornReadiness, RebornRuntimeIdentity,
-    RebornRuntimeInput, RebornWebuiBundle, WebuiAuthenticator, WebuiServeConfig,
-    build_reborn_runtime, open_local_trigger_access_store, webui_v2_app_with_lifecycle,
-};
-#[cfg(feature = "slack-v2-host-beta")]
-use ironclaw_reborn_composition::{
-    SlackOperatorRouteVisibility, build_slack_events_host_ingress_mount_from_enabled_extensions,
-    build_slack_host_beta_mounts, build_webui_services_with_slack_host_beta_mounts,
-    import_slack_host_beta_config_as_extension_installation,
-};
-#[cfg(feature = "telegram-v2-host-beta")]
-use ironclaw_reborn_composition::{
-    build_telegram_updates_host_ingress_mount_from_enabled_extensions,
-    import_telegram_host_beta_config_as_extension_installation,
+    GoogleOAuthRouteConfig, HostIngressServePlanInput, LocalTriggerAccessReconciliation,
+    LocalTriggerAccessRole, LocalTriggerAccessSource, RebornBuildInput, RebornReadiness,
+    RebornRuntimeIdentity, RebornRuntimeInput, RebornWebuiBundle, WebuiAuthenticator,
+    WebuiServeConfig, build_host_ingress_serve_plan, build_reborn_runtime,
+    build_webui_services_with_host_ingress_plan, open_local_trigger_access_store,
+    webui_v2_app_with_lifecycle,
 };
 use ironclaw_reborn_config::{IdentitySection, seed_default_config_file_if_missing};
 use ironclaw_reborn_webui_ingress::{
@@ -185,12 +174,6 @@ impl ServeCommand {
         )?;
         #[cfg(not(feature = "slack-v2-host-beta"))]
         let _ = slack_host_beta_config;
-        #[cfg(feature = "slack-v2-host-beta")]
-        let slack_host_ingress_mode = config_file
-            .as_ref()
-            .and_then(|file| file.slack.as_ref())
-            .map(|slack| slack.host_ingress_mode)
-            .unwrap_or_default();
 
         let telegram_host_beta_config =
             crate::commands::serve_telegram::resolve_telegram_config_for_serve(
@@ -203,12 +186,10 @@ impl ServeCommand {
             )?;
         #[cfg(not(feature = "telegram-v2-host-beta"))]
         let _ = telegram_host_beta_config;
-        #[cfg(feature = "telegram-v2-host-beta")]
-        let telegram_host_ingress_mode = config_file
-            .as_ref()
-            .and_then(|file| file.telegram.as_ref())
-            .map(|telegram| telegram.host_ingress_mode)
-            .unwrap_or_default();
+        let slack_section_for_host_ingress =
+            config_file.as_ref().and_then(|file| file.slack.clone());
+        let telegram_section_for_host_ingress =
+            config_file.as_ref().and_then(|file| file.telegram.clone());
 
         // Resolve listen address with explicit precedence:
         //   CLI flag (Some(...)) > config file > compile-time default.
@@ -387,145 +368,41 @@ impl ServeCommand {
             let runtime = build_reborn_runtime(runtime_input)
                 .await
                 .context("failed to assemble Reborn runtime for `serve`")?;
-            #[cfg(feature = "slack-v2-host-beta")]
-            let extension_slack_events_mount;
-            #[cfg(feature = "slack-v2-host-beta")]
-            let slack_mounts = if let Some(slack_config) = slack_host_beta_config {
-                import_slack_host_beta_config_as_extension_installation(&runtime, &slack_config)
-                    .await
-                    .context("failed to import Slack config into extension state")?;
-                let projected_slack_events_mount = if slack_host_ingress_mode.is_generic_shadow()
-                    || slack_host_ingress_mode.is_generic()
-                {
-                    build_slack_events_host_ingress_mount_from_enabled_extensions(&runtime)
-                        .await
-                        .context("failed to compose Slack extension host-ingress events route")?
-                } else {
-                    None
-                };
-                Some(if slack_host_ingress_mode.is_generic_shadow() {
-                    let mounts = build_slack_host_beta_mounts(&runtime, slack_config.clone())
-                        .context("failed to compose Slack host-beta routes")?;
-                    if projected_slack_events_mount.is_none() {
-                        anyhow::bail!(
-                            "Slack config import did not produce an enabled Slack extension events route"
-                        );
-                    }
-                    tracing::debug!(
-                        target = "ironclaw::reborn::cli::serve",
-                        "Slack extension host-ingress route projection validated",
-                    );
-                    extension_slack_events_mount = projected_slack_events_mount;
-                    mounts
-                } else if slack_host_ingress_mode.is_generic() {
-                    let mut mounts = build_slack_host_beta_mounts(&runtime, slack_config.clone())
-                        .context("failed to compose Slack host-beta routes")?;
-                    mounts.events = projected_slack_events_mount.ok_or_else(|| {
-                        anyhow!(
-                            "Slack config import did not produce an enabled Slack extension events route"
-                        )
-                    })?;
-                    extension_slack_events_mount = None;
-                    mounts
-                } else {
-                    extension_slack_events_mount = projected_slack_events_mount;
-                    build_slack_host_beta_mounts(&runtime, slack_config)
-                        .context("failed to compose Slack host-beta routes")?
-                })
-            } else {
-                extension_slack_events_mount =
-                    build_slack_events_host_ingress_mount_from_enabled_extensions(&runtime)
-                        .await
-                        .context("failed to compose Slack extension host-ingress events route")?;
-                None
-            };
-            // Telegram updates webhook route, projected from enabled extension
-            // state. Telegram has no legacy direct-build path, so `generic` mounts
-            // the projected route, `generic_shadow` builds+validates it without
-            // serving, and `disabled` (the default) mounts nothing.
-            #[cfg(feature = "telegram-v2-host-beta")]
-            let extension_telegram_updates_mount = if let Some(telegram_config) =
-                telegram_host_beta_config
-            {
-                import_telegram_host_beta_config_as_extension_installation(&runtime, &telegram_config)
-                    .await
-                    .context("failed to import Telegram config into extension state")?;
-                let projected = if telegram_host_ingress_mode.is_generic_shadow()
-                    || telegram_host_ingress_mode.is_generic()
-                {
-                    build_telegram_updates_host_ingress_mount_from_enabled_extensions(&runtime)
-                        .await
-                        .context("failed to compose Telegram extension host-ingress updates route")?
-                } else {
-                    None
-                };
-                if (telegram_host_ingress_mode.is_generic()
-                    || telegram_host_ingress_mode.is_generic_shadow())
-                    && projected.is_none()
-                {
-                    anyhow::bail!(
-                        "Telegram config import did not produce an enabled Telegram extension updates route"
-                    );
-                }
-                if telegram_host_ingress_mode.is_generic_shadow() {
-                    tracing::debug!(
-                        target = "ironclaw::reborn::cli::serve",
-                        "Telegram extension host-ingress route projection validated",
-                    );
-                    None
-                } else if telegram_host_ingress_mode.is_generic() {
-                    projected
-                } else {
-                    None
-                }
-            } else {
-                // Self-project an already-enabled Telegram extension with no [telegram] config.
-                build_telegram_updates_host_ingress_mount_from_enabled_extensions(&runtime)
-                    .await
-                    .context("failed to compose Telegram extension host-ingress updates route")?
-            };
-            #[cfg(feature = "slack-v2-host-beta")]
-            let operator_route_visibility = if sso_startup.is_none() {
-                SlackOperatorRouteVisibility::Visible
-            } else {
-                SlackOperatorRouteVisibility::Hidden
-            };
-            // Advertise Telegram in `/api/webchat/v2/channels/connectable` only
-            // when its updates route is actually mounted (generic mode).
-            #[cfg(feature = "telegram-v2-host-beta")]
-            let telegram_connectable_channels: Vec<
-                ironclaw_reborn_composition::RebornConnectableChannelInfo,
-            > = if extension_telegram_updates_mount.is_some() {
-                vec![ironclaw_reborn_composition::telegram_inbound_proof_code_connectable_channel()]
-            } else {
-                Vec::new()
-            };
-            #[cfg(feature = "slack-v2-host-beta")]
-            let bundle: RebornWebuiBundle = build_webui_services_with_slack_host_beta_mounts(
+            // TODO(move-5): genericize host-beta config import through the
+            // extension_setup contract. For this move, config import stays in
+            // the channel-specific helpers and the mount/connectable path below
+            // consumes one generic plan.
+            crate::commands::serve_slack::import_slack_config_for_serve(
                 &runtime,
-                None,
-                slack_mounts.as_ref(),
-                operator_route_visibility,
-                #[cfg(feature = "telegram-v2-host-beta")]
-                telegram_connectable_channels,
-                #[cfg(not(feature = "telegram-v2-host-beta"))]
-                Vec::new(),
-            )?;
-            #[cfg(all(
-                not(feature = "slack-v2-host-beta"),
-                feature = "telegram-v2-host-beta"
-            ))]
+                &slack_host_beta_config,
+            )
+            .await?;
+            crate::commands::serve_telegram::import_telegram_config_for_serve(
+                &runtime,
+                &telegram_host_beta_config,
+            )
+            .await?;
+
+            let host_ingress_plan_input = HostIngressServePlanInput::new();
+            let host_ingress_plan_input =
+                crate::commands::serve_slack::configure_slack_host_ingress_plan_for_serve(
+                    host_ingress_plan_input,
+                    slack_host_beta_config,
+                    slack_section_for_host_ingress.as_ref(),
+                    sso_startup.is_none(),
+                );
+            let host_ingress_plan_input =
+                crate::commands::serve_telegram::configure_telegram_host_ingress_plan_for_serve(
+                    host_ingress_plan_input,
+                    telegram_host_beta_config,
+                    telegram_section_for_host_ingress.as_ref(),
+                );
+            let host_ingress_plan =
+                build_host_ingress_serve_plan(&runtime, host_ingress_plan_input)
+                    .await
+                    .context("failed to compose extension host-ingress serve plan")?;
             let bundle: RebornWebuiBundle =
-                ironclaw_reborn_composition::build_webui_services_with_telegram_connectable_channel(
-                    &runtime,
-                    None,
-                    !telegram_connectable_channels.is_empty(),
-                )?;
-            #[cfg(all(
-                not(feature = "slack-v2-host-beta"),
-                not(feature = "telegram-v2-host-beta")
-            ))]
-            let bundle: RebornWebuiBundle = build_webui_services(&runtime, None)?;
+                build_webui_services_with_host_ingress_plan(&runtime, None, &host_ingress_plan)?;
             #[cfg(feature = "openai-compat-beta")]
             let openai_compat_mount = build_openai_compat_route_mount(
                 &runtime,
@@ -626,19 +503,7 @@ impl ServeCommand {
             if let Some(host) = canonical_host {
                 serve_config = serve_config.with_canonical_host(host);
             }
-            #[cfg(feature = "slack-v2-host-beta")]
-            if let Some(slack_mounts) = slack_mounts {
-                serve_config = serve_config
-                    .with_public_route_mount(slack_mounts.events)
-                    .with_slack_personal_binding_pairing(slack_mounts.personal_binding_pairing)
-                    .with_slack_channel_routes(slack_mounts.channel_routes);
-            } else if let Some(events_mount) = extension_slack_events_mount {
-                serve_config = serve_config.with_public_route_mount(events_mount);
-            }
-            #[cfg(feature = "telegram-v2-host-beta")]
-            if let Some(updates_mount) = extension_telegram_updates_mount {
-                serve_config = serve_config.with_public_route_mount(updates_mount);
-            }
+            serve_config = host_ingress_plan.apply_to_webui_serve_config(serve_config);
             // Public NEAR AI login callback route (token redirect target). Built
             // from the runtime's LLM seam; absent when no LLM was wired.
             #[cfg(feature = "root-llm-provider")]

--- a/crates/ironclaw_reborn_cli/src/commands/serve_slack.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/serve_slack.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "slack-v2-host-beta")]
-use anyhow::anyhow;
+use anyhow::{Context, anyhow};
 
 #[cfg(feature = "slack-v2-host-beta")]
 use std::env;
@@ -8,7 +8,9 @@ use std::path::Path;
 
 #[cfg(feature = "slack-v2-host-beta")]
 use ironclaw_reborn_composition::{
-    SlackHostBetaChannelRoute, SlackHostBetaConfig, SlackHostBetaConfigInput, SlackTeamId,
+    ConfiguredHostIngressProjectionMode, HostIngressOperatorRouteVisibility,
+    HostIngressServePlanInput, RebornRuntime, SlackHostBetaChannelRoute, SlackHostBetaConfig,
+    SlackHostBetaConfigInput, SlackTeamId, import_slack_host_beta_config_as_extension_installation,
 };
 #[cfg(feature = "slack-v2-host-beta")]
 use secrecy::SecretString;
@@ -35,6 +37,66 @@ pub(crate) fn resolve_slack_config_for_serve(
         default_user_id,
         config_path,
     )
+}
+
+#[cfg(feature = "slack-v2-host-beta")]
+pub(crate) async fn import_slack_config_for_serve(
+    runtime: &RebornRuntime,
+    config: &Option<SlackHostBetaConfig>,
+) -> anyhow::Result<()> {
+    if let Some(config) = config {
+        import_slack_host_beta_config_as_extension_installation(runtime, config)
+            .await
+            .map_err(anyhow::Error::from)
+            .context("failed to import Slack config into extension state")?;
+    }
+    Ok(())
+}
+
+#[cfg(not(feature = "slack-v2-host-beta"))]
+pub(crate) async fn import_slack_config_for_serve(
+    _runtime: &ironclaw_reborn_composition::RebornRuntime,
+    _config: &Option<()>,
+) -> anyhow::Result<()> {
+    Ok(())
+}
+
+#[cfg(feature = "slack-v2-host-beta")]
+pub(crate) fn configure_slack_host_ingress_plan_for_serve(
+    input: HostIngressServePlanInput,
+    config: Option<SlackHostBetaConfig>,
+    section: Option<&ironclaw_reborn_config::SlackSection>,
+    operator_routes_visible: bool,
+) -> HostIngressServePlanInput {
+    let Some(config) = config else {
+        return input;
+    };
+    let mode = section
+        .map(|slack| slack.host_ingress_mode)
+        .unwrap_or_default();
+    let projection_mode = if mode.is_generic() {
+        ConfiguredHostIngressProjectionMode::Serve
+    } else if mode.is_generic_shadow() {
+        ConfiguredHostIngressProjectionMode::ValidateOnly
+    } else {
+        ConfiguredHostIngressProjectionMode::Suppress
+    };
+    let operator_route_visibility = if operator_routes_visible {
+        HostIngressOperatorRouteVisibility::Visible
+    } else {
+        HostIngressOperatorRouteVisibility::Hidden
+    };
+    input.with_slack_host_beta(config, projection_mode, operator_route_visibility)
+}
+
+#[cfg(not(feature = "slack-v2-host-beta"))]
+pub(crate) fn configure_slack_host_ingress_plan_for_serve(
+    input: ironclaw_reborn_composition::HostIngressServePlanInput,
+    _config: Option<()>,
+    _section: Option<&ironclaw_reborn_config::SlackSection>,
+    _operator_routes_visible: bool,
+) -> ironclaw_reborn_composition::HostIngressServePlanInput {
+    input
 }
 
 #[cfg(not(feature = "slack-v2-host-beta"))]

--- a/crates/ironclaw_reborn_cli/src/commands/serve_telegram.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/serve_telegram.rs
@@ -6,7 +6,7 @@
 //! the values never live in the config file.
 
 #[cfg(feature = "telegram-v2-host-beta")]
-use anyhow::anyhow;
+use anyhow::{Context, anyhow};
 
 #[cfg(feature = "telegram-v2-host-beta")]
 use std::env;
@@ -14,7 +14,10 @@ use std::env;
 use std::path::Path;
 
 #[cfg(feature = "telegram-v2-host-beta")]
-use ironclaw_reborn_composition::TelegramHostBetaConfig;
+use ironclaw_reborn_composition::{
+    ConfiguredHostIngressProjectionMode, HostIngressServePlanInput, RebornRuntime,
+    TelegramHostBetaConfig, import_telegram_host_beta_config_as_extension_installation,
+};
 #[cfg(feature = "telegram-v2-host-beta")]
 use secrecy::SecretString;
 
@@ -40,6 +43,63 @@ pub(crate) fn resolve_telegram_config_for_serve(
         default_user_id,
         config_path,
     )
+}
+
+#[cfg(feature = "telegram-v2-host-beta")]
+pub(crate) async fn import_telegram_config_for_serve(
+    runtime: &RebornRuntime,
+    config: &Option<TelegramHostBetaConfig>,
+) -> anyhow::Result<()> {
+    if let Some(config) = config {
+        import_telegram_host_beta_config_as_extension_installation(runtime, config)
+            .await
+            .map_err(anyhow::Error::from)
+            .context("failed to import Telegram config into extension state")?;
+    }
+    Ok(())
+}
+
+#[cfg(not(feature = "telegram-v2-host-beta"))]
+pub(crate) async fn import_telegram_config_for_serve(
+    _runtime: &ironclaw_reborn_composition::RebornRuntime,
+    _config: &Option<()>,
+) -> anyhow::Result<()> {
+    Ok(())
+}
+
+#[cfg(feature = "telegram-v2-host-beta")]
+pub(crate) fn configure_telegram_host_ingress_plan_for_serve(
+    input: HostIngressServePlanInput,
+    config: Option<TelegramHostBetaConfig>,
+    section: Option<&ironclaw_reborn_config::TelegramSection>,
+) -> HostIngressServePlanInput {
+    let Some(_config) = config else {
+        return input;
+    };
+    let mode = section
+        .map(|telegram| telegram.host_ingress_mode)
+        .unwrap_or_default();
+    let projection_mode = match mode {
+        ironclaw_reborn_config::TelegramHostIngressMode::Disabled => {
+            ConfiguredHostIngressProjectionMode::Suppress
+        }
+        ironclaw_reborn_config::TelegramHostIngressMode::GenericShadow => {
+            ConfiguredHostIngressProjectionMode::ValidateOnly
+        }
+        ironclaw_reborn_config::TelegramHostIngressMode::Generic => {
+            ConfiguredHostIngressProjectionMode::Serve
+        }
+    };
+    input.with_telegram_host_beta(projection_mode)
+}
+
+#[cfg(not(feature = "telegram-v2-host-beta"))]
+pub(crate) fn configure_telegram_host_ingress_plan_for_serve(
+    input: ironclaw_reborn_composition::HostIngressServePlanInput,
+    _config: Option<()>,
+    _section: Option<&ironclaw_reborn_config::TelegramSection>,
+) -> ironclaw_reborn_composition::HostIngressServePlanInput {
+    input
 }
 
 #[cfg(not(feature = "telegram-v2-host-beta"))]

--- a/crates/ironclaw_reborn_composition/src/host_ingress_serve_plan.rs
+++ b/crates/ironclaw_reborn_composition/src/host_ingress_serve_plan.rs
@@ -1,0 +1,790 @@
+use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::sync::Arc;
+
+use ironclaw_extensions::ExtensionManifestRecord;
+use ironclaw_host_api::ingress::IngressRouteDescriptor;
+#[cfg(any(feature = "slack-v2-host-beta", feature = "telegram-v2-host-beta"))]
+use ironclaw_host_ingress_registry::{HostIngressRuntimeEntry, list_enabled_host_ingress_entries};
+use ironclaw_product_adapters::ProjectionStream;
+use ironclaw_product_workflow::{
+    ConnectableChannelsProductFacade, RebornChannelConnectAction, RebornChannelConnectStrategy,
+    RebornConnectableChannelInfo, StaticConnectableChannelsProductFacade,
+};
+use serde::Deserialize;
+
+use crate::webui::build_webui_services_with_connectable_channels;
+use crate::webui_serve::{PublicRouteMount, WebuiServeConfig};
+use crate::{RebornBuildError, RebornRuntime, RebornWebuiBundle};
+
+#[cfg(feature = "slack-v2-host-beta")]
+use crate::slack_channel_routes::{
+    SlackChannelRouteAdminRouteConfig, slack_channel_route_admin_descriptors,
+};
+#[cfg(feature = "slack-v2-host-beta")]
+use crate::slack_host_beta::{
+    SlackHostBetaBuildError, SlackHostBetaConfig,
+    build_slack_events_host_ingress_mount_from_entries, build_slack_host_beta_mounts,
+};
+#[cfg(feature = "slack-v2-host-beta")]
+use crate::slack_host_ingress::SLACK_EVENTS_HOST_INGRESS_ROUTE_ID;
+#[cfg(feature = "slack-v2-host-beta")]
+use crate::slack_personal_binding_pairing_serve::{
+    SlackPersonalBindingPairingRouteConfig, slack_personal_binding_pairing_route_descriptors,
+};
+#[cfg(feature = "telegram-v2-host-beta")]
+use crate::telegram_host_beta::{
+    TelegramHostBetaBuildError, build_telegram_updates_host_ingress_mount_from_entries,
+};
+#[cfg(feature = "telegram-v2-host-beta")]
+use crate::telegram_host_ingress::TELEGRAM_UPDATES_HOST_INGRESS_ROUTE_ID;
+
+const HOST_INGRESS_LOG_TARGET: &str = "ironclaw::reborn::host_ingress_serve_plan";
+
+#[cfg(feature = "slack-v2-host-beta")]
+const SLACK_CONFIG_IMPORT_MISSING_ROUTE: &str =
+    "Slack config import did not produce an enabled Slack extension events route";
+#[cfg(feature = "telegram-v2-host-beta")]
+const TELEGRAM_CONFIG_IMPORT_MISSING_ROUTE: &str =
+    "Telegram config import did not produce an enabled Telegram extension updates route";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConfiguredHostIngressProjectionMode {
+    Suppress,
+    ValidateOnly,
+    Serve,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HostIngressOperatorRouteVisibility {
+    Hidden,
+    Visible,
+}
+
+#[derive(Default)]
+pub struct HostIngressServePlanInput {
+    #[cfg(feature = "slack-v2-host-beta")]
+    slack: Option<SlackHostIngressServeInput>,
+    #[cfg(feature = "telegram-v2-host-beta")]
+    telegram: Option<TelegramHostIngressServeInput>,
+}
+
+impl HostIngressServePlanInput {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    #[cfg(feature = "slack-v2-host-beta")]
+    pub fn with_slack_host_beta(
+        mut self,
+        config: SlackHostBetaConfig,
+        projection_mode: ConfiguredHostIngressProjectionMode,
+        operator_route_visibility: HostIngressOperatorRouteVisibility,
+    ) -> Self {
+        self.slack = Some(SlackHostIngressServeInput {
+            config,
+            projection_mode,
+            operator_route_visibility,
+        });
+        self
+    }
+
+    #[cfg(feature = "telegram-v2-host-beta")]
+    pub fn with_telegram_host_beta(
+        mut self,
+        projection_mode: ConfiguredHostIngressProjectionMode,
+    ) -> Self {
+        self.telegram = Some(TelegramHostIngressServeInput { projection_mode });
+        self
+    }
+}
+
+#[cfg(feature = "slack-v2-host-beta")]
+struct SlackHostIngressServeInput {
+    config: SlackHostBetaConfig,
+    projection_mode: ConfiguredHostIngressProjectionMode,
+    operator_route_visibility: HostIngressOperatorRouteVisibility,
+}
+
+#[cfg(feature = "telegram-v2-host-beta")]
+struct TelegramHostIngressServeInput {
+    projection_mode: ConfiguredHostIngressProjectionMode,
+}
+
+#[derive(Clone, Default)]
+pub struct HostIngressServePlan {
+    public_route_mounts: Vec<PublicRouteMount>,
+    connectable_channels: Vec<RebornConnectableChannelInfo>,
+    requires_outbound_delivery_target_provider: bool,
+    #[cfg(feature = "slack-v2-host-beta")]
+    slack_personal_binding_pairing: Option<SlackPersonalBindingPairingRouteConfig>,
+    #[cfg(feature = "slack-v2-host-beta")]
+    slack_channel_routes: Option<SlackChannelRouteAdminRouteConfig>,
+}
+
+impl HostIngressServePlan {
+    pub fn public_route_mounts(&self) -> &[PublicRouteMount] {
+        &self.public_route_mounts
+    }
+
+    pub fn connectable_channels(&self) -> &[RebornConnectableChannelInfo] {
+        &self.connectable_channels
+    }
+
+    pub fn public_route_ids(&self) -> Vec<String> {
+        let mut route_ids = Vec::new();
+        for mount in &self.public_route_mounts {
+            route_ids.extend(mount_route_ids(mount));
+        }
+        route_ids
+    }
+
+    pub fn apply_to_webui_serve_config(&self, mut config: WebuiServeConfig) -> WebuiServeConfig {
+        for mount in &self.public_route_mounts {
+            config = config.with_public_route_mount(mount.clone());
+        }
+        #[cfg(feature = "slack-v2-host-beta")]
+        {
+            if let Some(pairing) = &self.slack_personal_binding_pairing {
+                config = config.with_slack_personal_binding_pairing(pairing.clone());
+            }
+            if let Some(channel_routes) = &self.slack_channel_routes {
+                config = config.with_slack_channel_routes(channel_routes.clone());
+            }
+        }
+        config
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum HostIngressServePlanError {
+    #[error("host-ingress projection requires durable host state")]
+    DurableHostStateUnavailable,
+    #[error("host-ingress projection requires extension lifecycle state")]
+    ExtensionLifecycleUnavailable,
+    #[error(transparent)]
+    HostIngressRegistry(#[from] ironclaw_host_ingress_registry::Error),
+    #[cfg(feature = "slack-v2-host-beta")]
+    #[error(transparent)]
+    SlackHostBeta(#[from] SlackHostBetaBuildError),
+    #[cfg(feature = "telegram-v2-host-beta")]
+    #[error(transparent)]
+    TelegramHostBeta(#[from] TelegramHostBetaBuildError),
+    #[error("{reason}")]
+    RequiredProjectionMissing { reason: &'static str },
+    #[error("invalid connectable-channel metadata in extension `{extension_id}`: {reason}")]
+    InvalidConnectableMetadata {
+        extension_id: String,
+        reason: String,
+    },
+}
+
+pub async fn build_host_ingress_serve_plan(
+    runtime: &RebornRuntime,
+    input: HostIngressServePlanInput,
+) -> Result<HostIngressServePlan, HostIngressServePlanError> {
+    #[cfg(not(any(feature = "slack-v2-host-beta", feature = "telegram-v2-host-beta")))]
+    let _ = input;
+    let mut plan = HostIngressServePlan::default();
+    let mut projection_policy = ProjectionPolicy::default();
+    let mut active_route_ids = BTreeSet::new();
+
+    #[cfg(feature = "slack-v2-host-beta")]
+    if let Some(slack) = input.slack {
+        let mounts = build_slack_host_beta_mounts(runtime, slack.config)?;
+        plan.requires_outbound_delivery_target_provider = true;
+        collect_descriptor_route_ids(
+            slack_personal_binding_pairing_route_descriptors().iter(),
+            &mut active_route_ids,
+        );
+        if slack.operator_route_visibility == HostIngressOperatorRouteVisibility::Visible {
+            collect_descriptor_route_ids(
+                slack_channel_route_admin_descriptors().iter(),
+                &mut active_route_ids,
+            );
+        }
+        plan.slack_personal_binding_pairing = Some(mounts.personal_binding_pairing);
+        plan.slack_channel_routes = Some(mounts.channel_routes);
+        match slack.projection_mode {
+            ConfiguredHostIngressProjectionMode::Suppress => {
+                projection_policy.set(
+                    SLACK_EVENTS_HOST_INGRESS_ROUTE_ID,
+                    ProjectionRouteMode::Suppress,
+                    None,
+                );
+                record_mount_route_ids(&mounts.events, &mut active_route_ids);
+                plan.public_route_mounts.push(mounts.events);
+            }
+            ConfiguredHostIngressProjectionMode::ValidateOnly => {
+                projection_policy.set(
+                    SLACK_EVENTS_HOST_INGRESS_ROUTE_ID,
+                    ProjectionRouteMode::Suppress,
+                    Some(SLACK_CONFIG_IMPORT_MISSING_ROUTE),
+                );
+                record_mount_route_ids(&mounts.events, &mut active_route_ids);
+                plan.public_route_mounts.push(mounts.events);
+            }
+            ConfiguredHostIngressProjectionMode::Serve => {
+                projection_policy.set(
+                    SLACK_EVENTS_HOST_INGRESS_ROUTE_ID,
+                    ProjectionRouteMode::Serve,
+                    Some(SLACK_CONFIG_IMPORT_MISSING_ROUTE),
+                );
+            }
+        }
+    }
+
+    #[cfg(feature = "telegram-v2-host-beta")]
+    if let Some(telegram) = input.telegram {
+        let mode = match telegram.projection_mode {
+            ConfiguredHostIngressProjectionMode::Suppress => ProjectionRouteMode::Suppress,
+            ConfiguredHostIngressProjectionMode::ValidateOnly => ProjectionRouteMode::Suppress,
+            ConfiguredHostIngressProjectionMode::Serve => ProjectionRouteMode::Serve,
+        };
+        let required = match telegram.projection_mode {
+            ConfiguredHostIngressProjectionMode::Suppress => None,
+            ConfiguredHostIngressProjectionMode::ValidateOnly
+            | ConfiguredHostIngressProjectionMode::Serve => {
+                Some(TELEGRAM_CONFIG_IMPORT_MISSING_ROUTE)
+            }
+        };
+        projection_policy.set(TELEGRAM_UPDATES_HOST_INGRESS_ROUTE_ID, mode, required);
+    }
+
+    for mount in build_host_ingress_mounts_from_enabled_extensions(runtime).await? {
+        projection_policy.record_seen(&mount);
+        if projection_policy.should_serve(&mount) {
+            record_mount_route_ids(&mount, &mut active_route_ids);
+            plan.public_route_mounts.push(mount);
+        }
+    }
+    projection_policy.validate_required()?;
+
+    plan.connectable_channels =
+        project_enabled_connectable_channels(runtime, &active_route_ids).await?;
+
+    Ok(plan)
+}
+
+pub async fn build_host_ingress_mounts_from_enabled_extensions(
+    runtime: &RebornRuntime,
+) -> Result<Vec<PublicRouteMount>, HostIngressServePlanError> {
+    #[cfg(not(any(feature = "slack-v2-host-beta", feature = "telegram-v2-host-beta")))]
+    {
+        let _ = runtime;
+        Ok(Vec::new())
+    }
+    #[cfg(any(feature = "slack-v2-host-beta", feature = "telegram-v2-host-beta"))]
+    {
+        let entries = enabled_host_ingress_entries(runtime).await?;
+        build_host_ingress_mounts_from_entries(runtime, &entries).await
+    }
+}
+
+pub fn build_webui_services_with_host_ingress_plan(
+    runtime: &RebornRuntime,
+    event_stream: Option<Arc<dyn ProjectionStream>>,
+    plan: &HostIngressServePlan,
+) -> Result<RebornWebuiBundle, RebornBuildError> {
+    if plan.requires_outbound_delivery_target_provider
+        && runtime.outbound_delivery_target_provider().is_none()
+    {
+        return Err(RebornBuildError::InvalidConfig {
+            reason: "outbound delivery target providers require local runtime services".to_string(),
+        });
+    }
+    let connectable_channels = (!plan.connectable_channels.is_empty()).then(|| {
+        Arc::new(StaticConnectableChannelsProductFacade::new(
+            plan.connectable_channels.clone(),
+        )) as Arc<dyn ConnectableChannelsProductFacade>
+    });
+    build_webui_services_with_connectable_channels(
+        runtime,
+        event_stream,
+        connectable_channels,
+        Vec::new(),
+    )
+}
+
+#[cfg(any(feature = "slack-v2-host-beta", feature = "telegram-v2-host-beta"))]
+async fn enabled_host_ingress_entries(
+    runtime: &RebornRuntime,
+) -> Result<Vec<HostIngressRuntimeEntry>, HostIngressServePlanError> {
+    let local_runtime = runtime
+        .services()
+        .local_runtime
+        .as_ref()
+        .ok_or(HostIngressServePlanError::DurableHostStateUnavailable)?;
+    let extension_management = local_runtime
+        .extension_management
+        .as_ref()
+        .ok_or(HostIngressServePlanError::ExtensionLifecycleUnavailable)?;
+    let store = extension_management.installation_store();
+    Ok(list_enabled_host_ingress_entries(store.as_ref()).await?)
+}
+
+#[cfg(any(feature = "slack-v2-host-beta", feature = "telegram-v2-host-beta"))]
+async fn build_host_ingress_mounts_from_entries(
+    runtime: &RebornRuntime,
+    entries: &[HostIngressRuntimeEntry],
+) -> Result<Vec<PublicRouteMount>, HostIngressServePlanError> {
+    let mut mounts = Vec::new();
+    #[cfg(feature = "slack-v2-host-beta")]
+    if let Some(mount) =
+        build_slack_events_host_ingress_mount_from_entries(runtime, entries).await?
+    {
+        mounts.push(mount);
+    }
+    #[cfg(feature = "telegram-v2-host-beta")]
+    if let Some(mount) =
+        build_telegram_updates_host_ingress_mount_from_entries(runtime, entries).await?
+    {
+        mounts.push(mount);
+    }
+    Ok(mounts)
+}
+
+#[derive(Default)]
+struct ProjectionPolicy {
+    routes: BTreeMap<&'static str, ProjectionRoutePolicy>,
+}
+
+impl ProjectionPolicy {
+    #[cfg(any(feature = "slack-v2-host-beta", feature = "telegram-v2-host-beta"))]
+    fn set(
+        &mut self,
+        route_id: &'static str,
+        mode: ProjectionRouteMode,
+        required_error: Option<&'static str>,
+    ) {
+        self.routes.insert(
+            route_id,
+            ProjectionRoutePolicy {
+                mode,
+                required_error,
+                seen: false,
+            },
+        );
+    }
+
+    fn record_seen(&mut self, mount: &PublicRouteMount) {
+        for route_id in mount_route_ids(mount) {
+            if let Some(policy) = self.routes.get_mut(route_id.as_str()) {
+                policy.seen = true;
+                if policy.required_error.is_some() && policy.mode == ProjectionRouteMode::Suppress {
+                    tracing::debug!(
+                        target = HOST_INGRESS_LOG_TARGET,
+                        route_id,
+                        "extension host-ingress route projection validated",
+                    );
+                }
+            }
+        }
+    }
+
+    fn should_serve(&self, mount: &PublicRouteMount) -> bool {
+        let route_ids = mount_route_ids(mount);
+        if route_ids.is_empty() {
+            return false;
+        }
+        route_ids.iter().any(|route_id| {
+            self.routes
+                .get(route_id.as_str())
+                .map(|policy| policy.mode == ProjectionRouteMode::Serve)
+                .unwrap_or(true)
+        })
+    }
+
+    fn validate_required(&self) -> Result<(), HostIngressServePlanError> {
+        for policy in self.routes.values() {
+            if let Some(reason) = policy.required_error
+                && !policy.seen
+            {
+                return Err(HostIngressServePlanError::RequiredProjectionMissing { reason });
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProjectionRouteMode {
+    Suppress,
+    Serve,
+}
+
+struct ProjectionRoutePolicy {
+    mode: ProjectionRouteMode,
+    required_error: Option<&'static str>,
+    seen: bool,
+}
+
+async fn project_enabled_connectable_channels(
+    runtime: &RebornRuntime,
+    active_route_ids: &BTreeSet<String>,
+) -> Result<Vec<RebornConnectableChannelInfo>, HostIngressServePlanError> {
+    if active_route_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    let local_runtime = runtime
+        .services()
+        .local_runtime
+        .as_ref()
+        .ok_or(HostIngressServePlanError::DurableHostStateUnavailable)?;
+    let extension_management = local_runtime
+        .extension_management
+        .as_ref()
+        .ok_or(HostIngressServePlanError::ExtensionLifecycleUnavailable)?;
+    let store = extension_management.installation_store();
+    let manifests = store
+        .list_manifests()
+        .await
+        .map_err(ironclaw_host_ingress_registry::Error::from)?;
+    let manifest_by_extension: BTreeMap<_, _> = manifests
+        .iter()
+        .map(|manifest| (manifest.extension_id().clone(), manifest))
+        .collect();
+    let mut seen = HashSet::new();
+    let mut channels = Vec::new();
+
+    for installation in store
+        .list_enabled_installations()
+        .await
+        .map_err(ironclaw_host_ingress_registry::Error::from)?
+    {
+        let Some(manifest) = manifest_by_extension.get(installation.extension_id()) else {
+            return Err(HostIngressServePlanError::HostIngressRegistry(
+                ironclaw_host_ingress_registry::Error::UnknownManifest {
+                    extension_id: installation.extension_id().to_string(),
+                },
+            ));
+        };
+        for declaration in connectable_channel_metadata(manifest)? {
+            if !declaration
+                .requires_route_ids
+                .iter()
+                .all(|route_id| active_route_ids.contains(route_id))
+            {
+                continue;
+            }
+            let strategy_key = declaration.strategy.as_str().to_string();
+            let channel = declaration.into_channel_info(manifest)?;
+            if seen.insert((channel.channel.clone(), strategy_key)) {
+                channels.push(channel);
+            }
+        }
+    }
+
+    Ok(channels)
+}
+
+fn connectable_channel_metadata(
+    manifest: &ExtensionManifestRecord,
+) -> Result<Vec<ConnectableChannelMetadata>, HostIngressServePlanError> {
+    let document: toml::Value = toml::from_str(manifest.raw_toml()).map_err(|error| {
+        HostIngressServePlanError::InvalidConnectableMetadata {
+            extension_id: manifest.extension_id().to_string(),
+            reason: error.to_string(),
+        }
+    })?;
+    let Some(channels) = document
+        .get("metadata")
+        .and_then(|value| value.get("connectable"))
+        .and_then(|value| value.get("channels"))
+    else {
+        return Ok(Vec::new());
+    };
+    let Some(items) = channels.as_array() else {
+        return Err(HostIngressServePlanError::InvalidConnectableMetadata {
+            extension_id: manifest.extension_id().to_string(),
+            reason: "metadata.connectable.channels must be an array".to_string(),
+        });
+    };
+    items
+        .iter()
+        .map(|item| {
+            item.clone().try_into().map_err(|error: toml::de::Error| {
+                HostIngressServePlanError::InvalidConnectableMetadata {
+                    extension_id: manifest.extension_id().to_string(),
+                    reason: error.to_string(),
+                }
+            })
+        })
+        .collect()
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ConnectableChannelMetadata {
+    channel: String,
+    #[serde(default)]
+    display_name: Option<String>,
+    strategy: ConnectableChannelStrategyMetadata,
+    #[serde(default)]
+    requires_route_ids: Vec<String>,
+    title: String,
+    instructions: String,
+    input_placeholder: String,
+    submit_label: String,
+    success_message: String,
+    error_message: String,
+    #[serde(default)]
+    command_aliases: Vec<String>,
+}
+
+impl ConnectableChannelMetadata {
+    fn into_channel_info(
+        self,
+        manifest: &ExtensionManifestRecord,
+    ) -> Result<RebornConnectableChannelInfo, HostIngressServePlanError> {
+        validate_connectable_field(manifest, "channel", &self.channel)?;
+        validate_connectable_field(manifest, "title", &self.title)?;
+        validate_connectable_field(manifest, "instructions", &self.instructions)?;
+        validate_connectable_field(manifest, "input_placeholder", &self.input_placeholder)?;
+        validate_connectable_field(manifest, "submit_label", &self.submit_label)?;
+        validate_connectable_field(manifest, "success_message", &self.success_message)?;
+        validate_connectable_field(manifest, "error_message", &self.error_message)?;
+        for route_id in &self.requires_route_ids {
+            validate_connectable_field(manifest, "requires_route_ids", route_id)?;
+        }
+        let display_name = self
+            .display_name
+            .unwrap_or_else(|| manifest.manifest().name.clone());
+        validate_connectable_field(manifest, "display_name", &display_name)?;
+        Ok(RebornConnectableChannelInfo {
+            channel: self.channel,
+            display_name,
+            strategy: self.strategy.into(),
+            action: RebornChannelConnectAction {
+                title: self.title,
+                instructions: self.instructions,
+                input_placeholder: self.input_placeholder,
+                submit_label: self.submit_label,
+                success_message: self.success_message,
+                error_message: self.error_message,
+            },
+            command_aliases: self.command_aliases,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum ConnectableChannelStrategyMetadata {
+    InboundProofCode,
+    AdminManagedChannels,
+}
+
+impl ConnectableChannelStrategyMetadata {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::InboundProofCode => "inbound_proof_code",
+            Self::AdminManagedChannels => "admin_managed_channels",
+        }
+    }
+}
+
+impl From<ConnectableChannelStrategyMetadata> for RebornChannelConnectStrategy {
+    fn from(value: ConnectableChannelStrategyMetadata) -> Self {
+        match value {
+            ConnectableChannelStrategyMetadata::InboundProofCode => Self::InboundProofCode,
+            ConnectableChannelStrategyMetadata::AdminManagedChannels => Self::AdminManagedChannels,
+        }
+    }
+}
+
+fn validate_connectable_field(
+    manifest: &ExtensionManifestRecord,
+    field: &str,
+    value: &str,
+) -> Result<(), HostIngressServePlanError> {
+    if value.trim().is_empty() {
+        return Err(HostIngressServePlanError::InvalidConnectableMetadata {
+            extension_id: manifest.extension_id().to_string(),
+            reason: format!("{field} must not be empty"),
+        });
+    }
+    Ok(())
+}
+
+fn record_mount_route_ids(mount: &PublicRouteMount, route_ids: &mut BTreeSet<String>) {
+    collect_descriptor_route_ids(mount.descriptors.iter(), route_ids);
+}
+
+fn collect_descriptor_route_ids<'a>(
+    descriptors: impl IntoIterator<Item = &'a IngressRouteDescriptor>,
+    route_ids: &mut BTreeSet<String>,
+) {
+    for descriptor in descriptors {
+        route_ids.insert(descriptor.route_id().as_str().to_string());
+    }
+}
+
+fn mount_route_ids(mount: &PublicRouteMount) -> Vec<String> {
+    mount
+        .descriptors
+        .iter()
+        .map(|descriptor| descriptor.route_id().as_str().to_string())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use ironclaw_extensions::{
+        ExtensionManifestRecord, HostApiContractRegistry, ManifestHash, ManifestSource,
+    };
+    use ironclaw_host_api::HostPortCatalog;
+    use ironclaw_host_ingress_registry::HostIngressHostApiContract;
+
+    use super::*;
+
+    #[test]
+    fn connectable_metadata_projects_channel_info() {
+        let manifest = manifest_record(
+            r#"
+[[metadata.connectable.channels]]
+channel = "demo"
+strategy = "inbound_proof_code"
+requires_route_ids = ["demo.events"]
+title = "Demo account connection"
+instructions = "Message the app, then enter the code here."
+input_placeholder = "Enter code..."
+submit_label = "Connect"
+success_message = "Connected."
+error_message = "Invalid code."
+command_aliases = ["demo"]
+"#,
+        );
+
+        let metadata = connectable_channel_metadata(&manifest).expect("metadata parses");
+        assert_eq!(metadata.len(), 1);
+        let channel = metadata
+            .into_iter()
+            .next()
+            .expect("metadata includes one channel")
+            .into_channel_info(&manifest)
+            .expect("channel projects");
+
+        assert_eq!(channel.channel, "demo");
+        assert_eq!(channel.display_name, "Demo");
+        assert_eq!(
+            channel.strategy,
+            RebornChannelConnectStrategy::InboundProofCode
+        );
+        assert_eq!(channel.command_aliases, vec!["demo"]);
+    }
+
+    #[test]
+    fn connectable_metadata_rejects_empty_required_route_id() {
+        let manifest = manifest_record(
+            r#"
+[[metadata.connectable.channels]]
+channel = "demo"
+strategy = "inbound_proof_code"
+requires_route_ids = [""]
+title = "Demo account connection"
+instructions = "Message the app, then enter the code here."
+input_placeholder = "Enter code..."
+submit_label = "Connect"
+success_message = "Connected."
+error_message = "Invalid code."
+"#,
+        );
+
+        let metadata = connectable_channel_metadata(&manifest).expect("metadata parses");
+        let error = metadata
+            .into_iter()
+            .next()
+            .expect("metadata includes one channel")
+            .into_channel_info(&manifest)
+            .expect_err("empty route id rejected");
+
+        assert!(
+            error
+                .to_string()
+                .contains("requires_route_ids must not be empty")
+        );
+    }
+
+    fn manifest_record(metadata_toml: &str) -> ExtensionManifestRecord {
+        let raw_toml = format!(
+            r#"
+schema_version = "reborn.extension_manifest.v2"
+id = "demo"
+name = "Demo"
+version = "0.1.0"
+description = "Demo channel."
+trust = "first_party_requested"
+
+[runtime]
+kind = "first_party"
+service = "demo"
+
+[[host_api]]
+id = "ironclaw.host_ingress/v1"
+section = "host_ingress.events"
+
+[host_ingress.events]
+
+[host_ingress.events.transport]
+kind = "webhook"
+route_id = "demo.events"
+method = "post"
+path = "/webhooks/demo/events"
+ack = "immediate"
+drain = "drain_before_runtime_shutdown"
+
+[host_ingress.events.policy]
+listener_class = "public_webhook"
+scope_source = "host_resolved"
+cors = "not_applicable"
+websocket_origin = "not_applicable"
+streaming = "none"
+audit = "public_callback"
+
+[host_ingress.events.policy.auth]
+type = "required"
+schemes = ["shared_secret_header"]
+
+[host_ingress.events.policy.body_limit]
+type = "limited"
+max_bytes = 1024
+
+[host_ingress.events.policy.rate_limit]
+type = "limited"
+scope = "global"
+max_requests = 10
+window_seconds = 60
+
+[host_ingress.events.policy.effect_path]
+type = "product_workflow"
+
+[host_ingress.events.target]
+type = "product_adapter_inbound"
+capability_id = "demo.events"
+product_adapter_section = "product_adapter.inbound"
+
+[host_ingress.events.auth]
+verifier = "shared_secret_header"
+credential_handles = ["demo_secret"]
+
+{metadata_toml}
+"#
+        );
+        let mut contracts = HostApiContractRegistry::new();
+        contracts
+            .register(Arc::new(
+                HostIngressHostApiContract::new().expect("host ingress contract"),
+            ))
+            .expect("register host ingress contract");
+        ExtensionManifestRecord::from_toml_with_contracts(
+            raw_toml,
+            ManifestSource::HostBundled,
+            &HostPortCatalog::empty(),
+            Some(ManifestHash::new("test-hash").expect("hash")),
+            &contracts,
+        )
+        .expect("manifest record")
+    }
+}

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -50,6 +50,8 @@ mod gsuite;
 mod hooks;
 #[cfg(any(feature = "slack-v2-host-beta", feature = "telegram-v2-host-beta"))]
 pub mod host_ingress;
+#[cfg(feature = "webui-v2-beta")]
+mod host_ingress_serve_plan;
 mod input;
 mod lifecycle;
 #[cfg(feature = "root-llm-provider")]
@@ -200,6 +202,13 @@ pub use hooks::{
     MAX_TOTAL_HOOKS_PER_TENANT, ThirdPartyDiscoveryInput, build_hook_dispatcher_builder_factory,
     build_hook_dispatcher_builder_factory_for_tenant, build_hook_projection_registry,
     tenant_extension_root,
+};
+#[cfg(feature = "webui-v2-beta")]
+pub use host_ingress_serve_plan::{
+    ConfiguredHostIngressProjectionMode, HostIngressOperatorRouteVisibility, HostIngressServePlan,
+    HostIngressServePlanError, HostIngressServePlanInput,
+    build_host_ingress_mounts_from_enabled_extensions, build_host_ingress_serve_plan,
+    build_webui_services_with_host_ingress_plan,
 };
 pub use input::{OAuthClientConfig, RebornBuildInput, RebornRuntimeProcessBinding};
 #[cfg(feature = "webui-v2-beta")]

--- a/crates/ironclaw_reborn_composition/src/slack_host_beta.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_host_beta.rs
@@ -20,7 +20,7 @@ use ironclaw_host_api::ingress::{
 use ironclaw_host_api::{
     AgentId, ExtensionId, InvocationId, ProjectId, ResourceScope, SecretHandle, TenantId, UserId,
 };
-use ironclaw_host_ingress_registry::list_enabled_host_ingress_entries;
+use ironclaw_host_ingress_registry::{HostIngressRuntimeEntry, list_enabled_host_ingress_entries};
 use ironclaw_outbound::{DeliveredGateRouteStore, OutboundStateStore, TriggeredRunDeliveryStore};
 use ironclaw_product_adapters::{
     AdapterInstallationId, DeclaredEgressHost, DeclaredEgressTarget, DeliveryStatus,
@@ -588,15 +588,27 @@ pub async fn build_slack_events_host_ingress_mount_from_enabled_extensions(
         .extension_management
         .as_ref()
         .ok_or(SlackHostBetaBuildError::ExtensionLifecycleUnavailable)?;
+    let store = extension_management.installation_store();
+    let entries = list_enabled_host_ingress_entries(store.as_ref()).await?;
+    build_slack_events_host_ingress_mount_from_entries(runtime, &entries).await
+}
+
+pub(crate) async fn build_slack_events_host_ingress_mount_from_entries(
+    runtime: &RebornRuntime,
+    entries: &[HostIngressRuntimeEntry],
+) -> Result<Option<PublicRouteMount>, SlackHostBetaBuildError> {
+    let local_runtime = runtime
+        .services()
+        .local_runtime
+        .as_ref()
+        .ok_or(SlackHostBetaBuildError::DurableHostStateUnavailable)?;
     let secret_store = local_runtime
         .secret_store
         .clone()
         .ok_or(SlackHostBetaBuildError::SecretStoreUnavailable)?;
-    let store = extension_management.installation_store();
     let settings_store = FilesystemSlackExtensionSettingsStore::new(Arc::clone(
         &local_runtime.host_state_filesystem,
     ));
-    let entries = list_enabled_host_ingress_entries(store.as_ref()).await?;
     let mut installations = Vec::new();
     let mut credential_bindings = Vec::new();
     let mut projected_declaration = None;

--- a/crates/ironclaw_reborn_composition/src/telegram_host_beta.rs
+++ b/crates/ironclaw_reborn_composition/src/telegram_host_beta.rs
@@ -30,7 +30,7 @@ use ironclaw_host_api::ingress::{
 use ironclaw_host_api::{
     AgentId, ExtensionId, InvocationId, ProjectId, ResourceScope, SecretHandle, TenantId, UserId,
 };
-use ironclaw_host_ingress_registry::list_enabled_host_ingress_entries;
+use ironclaw_host_ingress_registry::{HostIngressRuntimeEntry, list_enabled_host_ingress_entries};
 use ironclaw_product_adapters::{
     AdapterInstallationId, AuthRequirement, DeclaredEgressHost, DeclaredEgressTarget,
     EgressCredentialHandle, ProductAdapter, ProductAdapterId, ProtocolHttpEgress,
@@ -280,15 +280,27 @@ pub async fn build_telegram_updates_host_ingress_mount_from_enabled_extensions(
         .extension_management
         .as_ref()
         .ok_or(TelegramHostBetaBuildError::ExtensionLifecycleUnavailable)?;
+    let store = extension_management.installation_store();
+    let entries = list_enabled_host_ingress_entries(store.as_ref()).await?;
+    build_telegram_updates_host_ingress_mount_from_entries(runtime, &entries).await
+}
+
+pub(crate) async fn build_telegram_updates_host_ingress_mount_from_entries(
+    runtime: &RebornRuntime,
+    entries: &[HostIngressRuntimeEntry],
+) -> Result<Option<PublicRouteMount>, TelegramHostBetaBuildError> {
+    let local_runtime = runtime
+        .services()
+        .local_runtime
+        .as_ref()
+        .ok_or(TelegramHostBetaBuildError::DurableHostStateUnavailable)?;
     let secret_store = local_runtime
         .secret_store
         .clone()
         .ok_or(TelegramHostBetaBuildError::SecretStoreUnavailable)?;
-    let store = extension_management.installation_store();
     let settings_store = FilesystemTelegramExtensionSettingsStore::new(Arc::clone(
         &local_runtime.host_state_filesystem,
     ));
-    let entries = list_enabled_host_ingress_entries(store.as_ref()).await?;
     let telegram_extension_id = telegram_extension_id()?;
     let mut installations = Vec::new();
     let mut credential_bindings = Vec::new();


### PR DESCRIPTION
## Summary

**Move 4** — the payoff. `serve.rs` carried near-identical Slack and Telegram host-ingress mount blocks (each cloning the `disabled | generic_shadow | generic` mode logic) plus a connectable-channel `#[cfg]` permutation matrix (slack-only / telegram-only / both / neither). This replaces all of it with **one generic, data-driven path** — so adding a channel touches **zero lines** in `serve.rs`.

## What changed

- New `ironclaw_reborn_composition::host_ingress_serve_plan`:
  - `build_host_ingress_serve_plan(&runtime, input) -> HostIngressServePlan`
  - `build_host_ingress_mounts_from_enabled_extensions(&runtime)` — mounts **every** enabled host-ingress route from its manifest-projected declaration (no per-channel filter)
  - `build_webui_services_with_host_ingress_plan(...)`
- `serve.rs` now: builds one `HostIngressServePlanInput`, lets the channel-owned `serve_slack`/`serve_telegram` helpers contribute projection policy, calls the generic plan builder, and applies the result in a loop. **No Slack-vs-Telegram mount block, no connectable cfg matrix.**
- Connectable-channel advertisement moved to manifest metadata (`[[metadata.connectable.channels]]`) — no hardcoded `*_connectable_channel()` in serve.rs.
- Per-channel `#[cfg(feature)]` confined to composition + the channel-owned CLI helpers (per CLAUDE.md module-owned feature gating).

## Deletion bar

```
rg 'slack_events|telegram_updates|inbound_proof_code' crates/ironclaw_reborn_cli/src/commands/serve.rs
→ no matches
```

## Behavior preserved

All per-channel `disabled`/`generic_shadow`/`generic` semantics unchanged (legacy direct mount on `disabled`, build-but-don't-serve on `generic_shadow`, projected route on `generic`), and the config-import mismatch errors are byte-identical. Connectable channels appear only when their route IDs are active.

## Scope / left for Move 5

Per-channel config **import** (`import_*_host_beta_config_as_extension_installation`, reading `[slack]`/`[telegram]` TOML into extension state) is intentionally **not** genericized here — that's Move 5's `extension_setup` contract. `serve.rs` keeps a marked `TODO(move-5)` import section routed through the channel helpers.

## Verification (on host)

`cargo fmt` · `clippy -p ironclaw_reborn_cli -p ironclaw_reborn_composition --all-targets --all-features -D warnings` → green · serve-plan tests pass. **Full feature matrix compiles** — each → exit 0:
- `webui-v2-beta,slack-v2-host-beta`
- `webui-v2-beta,telegram-v2-host-beta`
- `webui-v2-beta,slack-v2-host-beta,telegram-v2-host-beta`
- `webui-v2-beta`

## Stacking

Base is `move1/ingress-policy-projectable` (#5103); diff is only Move 4. Stack: #5100 → #5103 → **#5104 (this)**. Companion: #5102 (credential coherence). Will retarget when the chain merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)