### PR TITLE
ci(reborn): run the full reborn_cli dependency closure on every PR

### DIFF
--- a/.github/workflows/reborn-tests.yml
+++ b/.github/workflows/reborn-tests.yml
@@ -100,7 +100,9 @@ jobs:
       - id: packages
         name: Build package matrix from Reborn crate families
         run: |
-          packages="$(
+          # Reborn/product crate families that are always tested, including
+          # crates the shipped binary does not link (channel adapters, webui_v2).
+          allowlist_packages="$(
             cargo metadata --no-deps --format-version 1 \
               | jq -c '
                   [
@@ -118,6 +120,36 @@ jobs:
                   ]
                   | unique
                 '
+          )"
+
+          # The full ironclaw_reborn_cli dependency closure: every workspace
+          # crate the shipped Reborn binary links (normal + build deps). Running
+          # each crate's own suite on every PR is the "run everything on every
+          # PR" gate -- a green reborn-tests run means the whole closure is
+          # green, so the ~43 shared crates (auth, host_runtime, skills,
+          # extensions, ...) can no longer regress unnoticed.
+          closure_packages="$(
+            comm -12 \
+              <(cargo tree -p ironclaw_reborn_cli -e normal,build --prefix none \
+                | grep -oE 'ironclaw_[a-z0-9_]+' \
+                | sort -u) \
+              <(cargo metadata --no-deps --format-version 1 \
+                | jq -r '.packages[].name' \
+                | sort -u) \
+              | jq -R -s -c 'split("\n") | map(select(length > 0))'
+          )"
+
+          if [ -z "${closure_packages}" ] || [ "${closure_packages}" = "[]" ]; then
+            echo "No Reborn CLI workspace dependency closure crates discovered" >&2
+            exit 1
+          fi
+
+          # Union so closure coverage never drops the non-closure allowlist crates.
+          packages="$(
+            jq -n -c \
+              --argjson allowlist "${allowlist_packages}" \
+              --argjson closure "${closure_packages}" \
+              '$allowlist + $closure | unique'
           )"
 
           if [ -z "${packages}" ] || [ "${packages}" = "[]" ]; then

--- a/scripts/ci/package-feature-flags.sh
+++ b/scripts/ci/package-feature-flags.sh
@@ -6,7 +6,40 @@ if [ "$#" -ne 1 ]; then
   exit 2
 fi
 
-case "$1" in
+package="$1"
+
+# Default flags for closure crates without an explicit recipe above: opt into
+# `default` and `libsql` when the crate declares them, so storage-backed crates
+# build their libSQL paths. Crates with no matching features build bare.
+fallback_feature_flags() {
+  local metadata
+  metadata="$(cargo metadata --no-deps --format-version 1)"
+
+  local feature_list
+  feature_list="$(
+    jq -r --arg package "${package}" '
+      .packages[]
+      | select(.name == $package)
+      | .features
+      | keys[]
+    ' <<< "${metadata}"
+  )"
+
+  local features=()
+  if printf '%s\n' "${feature_list}" | grep -Fxq "default"; then
+    features+=("default")
+  fi
+  if printf '%s\n' "${feature_list}" | grep -Fxq "libsql"; then
+    features+=("libsql")
+  fi
+
+  if [ "${#features[@]}" -gt 0 ]; then
+    local IFS=,
+    printf '%s\n' "--features ${features[*]}"
+  fi
+}
+
+case "${package}" in
   ironclaw_reborn_cli)
     printf '%s\n' "--features webui-v2-beta,slack-v2-host-beta"
     ;;
@@ -34,6 +67,21 @@ case "$1" in
   ironclaw_webui_v2 | ironclaw_webui_v2_static)
     printf '%s\n' "--features webui-v2-beta"
     ;;
+  ironclaw_architecture | \
+  ironclaw_product_adapter_registry | \
+  ironclaw_product_context | \
+  ironclaw_reborn_config | \
+  ironclaw_reborn_identity | \
+  ironclaw_reborn_openai_compat | \
+  ironclaw_reborn_openai_compat_storage | \
+  ironclaw_reborn_traces | \
+  ironclaw_slack_v2_adapter | \
+  ironclaw_telegram_v2_adapter | \
+  ironclaw_wasm_product_adapters)
+    # Already on the allowlist with no feature flags; keep them flag-free now
+    # that the default branch derives fallback features for closure crates.
+    ;;
   *)
+    fallback_feature_flags
     ;;
 esac

--- a/scripts/ci/package-feature-flags.sh
+++ b/scripts/ci/package-feature-flags.sh
@@ -64,6 +64,13 @@ case "${package}" in
   ironclaw_reborn_webui_ingress)
     printf '%s\n' "--features dev-in-memory-session"
     ;;
+  ironclaw_host_runtime)
+    # Integration tests (tests/) link the lib as a normal dependency, so
+    # cfg(test) is false there; the deterministic test-mode behavior they assert
+    # is gated behind `feature = "test-support"`. libsql exercises the embedded
+    # DB paths without a Postgres server (which the crate-tests job has none of).
+    printf '%s\n' "--features test-support,libsql"
+    ;;
   ironclaw_webui_v2 | ironclaw_webui_v2_static)
     printf '%s\n' "--features webui-v2-beta"
     ;;


### PR DESCRIPTION
## What

Make PR CI's `reborn-tests` matrix run the **full `ironclaw_reborn_cli` dependency closure (64 crates)** instead of the 21-crate name-prefix allowlist.

## Why

Only **10 of the 21** allowlisted crates overlap the actual closure. **43 closure crates** the shipped Reborn binary links — `auth`, `host_runtime`, `skills`, `first_party_extensions`, `extensions`, `dispatcher`, `llm`, `safety`, `memory`, `network`, `turns`, `host_api`, `loop_support`, `threads`, … — ran their own test suites **only via the nightly/manual closure path, never on a PR** (only exercised indirectly by the 4 root integration partitions).

That's exactly the gap that let the bugs in #5105 / #5108 (github surface, skills TOCTOU, gsuite wrong-account egress, loop_support/threads/auth) through normal PR CI — they only surfaced when the closure was run by hand.

## How

- **package-matrix**: union of the existing allowlist and `cargo tree -p ironclaw_reborn_cli -e normal,build` ∩ workspace members = **64 crates**. Union (not replace) so channel adapters / webui_v2 are never dropped.
- **package-feature-flags.sh**: fallback features (`default`/`libsql` when declared) for closure crates without an explicit recipe; previously-allowlisted no-flag crates kept flag-free (behavior unchanged).

## Verification

The 3 closure reds this catches are already fixed on main (#5105, #5108), so the closure should be green. **This PR's own CI run is the 64/64 verification** — hence draft.

## Tradeoff / follow-ups

21 → 64 parallel crate jobs raises compute and, if runner concurrency is capped, may raise wall-clock as jobs queue.
1. build-once `nextest archive` + shard to cut redundant compiles (spike #5086)
2. bake a few runs → promote `reborn-tests` to a **required** check
3. cut v1 (`test.yml` / Tests (all-features), ~29m) → gate drops to ~10–12m

_Automated agent-authored._