### PR TITLE
fix(coding): read_file limit:0 footer + align stale concurrent-install test

### DIFF
--- a/crates/ironclaw_first_party_extensions/src/coding/file.rs
+++ b/crates/ironclaw_first_party_extensions/src/coding/file.rs
@@ -249,7 +249,11 @@ fn read_file_text_output(
 
     let lines_shown = rendered.len();
     let last_line_shown = start_line + lines_shown;
-    let has_more = last_line_shown < total_lines;
+    // A continuation notice only makes sense once at least one line was rendered.
+    // An explicit `limit: 0` selects no lines, so there is nothing to continue
+    // from and "[Showing lines 1-0 ...]" would be a nonsensical inverted range.
+    // Suppressing the notice here keeps the zero-value path byte-for-byte v1.
+    let has_more = lines_shown > 0 && last_line_shown < total_lines;
     let next_offset = has_more.then_some(last_line_shown + 1);
     let truncated_by = if truncated_by_bytes {
         Some(ReadTruncationReason::Bytes)

--- a/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
@@ -3707,13 +3707,29 @@ async fn builtin_skill_install_url_path_serializes_concurrent_fetches_from_same_
             context,
         )
     );
-    let mut outcomes = [first.map(|_| ()), second.map(|_| ())];
-    outcomes.sort_by_key(|result| result.is_err());
-
-    assert!(outcomes[0].is_ok());
-    assert_eq!(outcomes[1], Err(RuntimeFailureKind::OperationFailed));
+    // Both concurrent installs of the same URL fetch independently (egress == 2),
+    // then serialize on the per-skill mutation lock in
+    // ironclaw_skills::management::install_skill. Install is idempotent for
+    // identical content (replay-safety, nearai/ironclaw#4385): the second install
+    // observes the first's matching install and returns success instead of a
+    // conflict, so the skill is written exactly once.
+    assert!(
+        first.is_ok(),
+        "first concurrent install must succeed: {first:?}"
+    );
+    assert!(
+        second.is_ok(),
+        "second concurrent install of identical content must succeed idempotently: {second:?}"
+    );
     assert_eq!(egress.requests().len(), 2);
-    assert!(temp.path().join("concurrent-helper/SKILL.md").exists());
+    let installed = temp.path().join("concurrent-helper/SKILL.md");
+    assert!(installed.exists());
+    assert!(
+        std::fs::read_to_string(&installed)
+            .unwrap()
+            .contains("Fetched prompt."),
+        "installed SKILL.md must contain the fetched skill content"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What

Fixes the two **deterministic** host_runtime test failures surfaced by running the full `ironclaw_reborn_cli` crate closure on PR CI (see #5110). These tests don't run on today's PR matrix, so both regressions landed undetected.

### 1. `read_file` zero-value footer — real bug (from #5029)
`read_file` with `limit: 0` selects zero lines, but #5029's byte-budget rework still emitted a continuation notice → the nonsensical `"[Showing lines 1-0 of 1 (lines limit). Use offset=1 to continue.]"` (inverted `1-0` range) instead of `""`. Fix: only emit the notice once **≥1 line** was rendered, restoring the v1 zero-value contract. Regression-covered by the existing `builtin_coding_paths_are_relative_to_requested_root_and_zero_values_match_v1`.

### 2. concurrent skill-install test — stale test, not a product bug
`install_skill` serializes per skill name (`skill_mutation_lock`) **and** is idempotent for identical content (replay-safety, #4385). Two concurrent installs of the same URL both fetch and both succeed (the 2nd matches the 1st); the skill is written once. The test still asserted the **pre-#4385** strict-reject behavior. Aligned it to the idempotent contract — reverting the product to reject would re-break #4385's replay-safety.

## Verification
`cargo test -p ironclaw_host_runtime --features test-support,libsql --all-targets` → both tests green locally. host_runtime isn't on the current PR matrix, so these are validated locally + by #5110 once it lands.

## Out of scope
A third, **pre-existing load-flaky** test — `scheduler_executor_emits_thread_run_correlated_operator_log` (passes 8/8 in isolation, flakes under `--all-targets`) — is the known `..._correlated_operator_log` flaky class; tracked for deflake/quarantine in the closure bake phase, not fixed here.

## Sequence
Merge this first → #5110 (closure-on-PR) rebases → host_runtime goes green.

_Automated agent-authored._