### PR TITLE
ci(reborn): retry crates.io network failures in the closure (CARGO_NET_RETRY)

### DIFF
--- a/.github/workflows/reborn-tests.yml
+++ b/.github/workflows/reborn-tests.yml
@@ -44,6 +44,13 @@ env:
   RUSTFLAGS: "-C linker=clang -C link-arg=--ld-path=/usr/bin/mold"
   CARGO_PROFILE_DEV_DEBUG: 0
   CARGO_PROFILE_TEST_DEBUG: 0
+  # The 64-crate closure runs ~64 jobs that each resolve+download the dependency
+  # tree from crates.io in parallel, so a transient registry SSL/HTTP2 hiccup
+  # (e.g. "download of <crate> failed: curl [55] SSL_ERROR_SYSCALL") tends to hit
+  # many jobs at once and redden the whole run. Make Cargo retry network failures
+  # (default 3) far more aggressively, and use the git CLI for git deps.
+  CARGO_NET_RETRY: "10"
+  CARGO_NET_GIT_FETCH_WITH_CLI: "true"
 
 jobs:
   changes:


### PR DESCRIPTION
## Problem
The 64-crate closure (#5110) runs ~64 jobs that each resolve+download the dependency tree from crates.io **in parallel**. A transient registry SSL/HTTP2 hiccup hits many jobs at once and reddens the whole run — seen **twice** already:
- `download of once_cell_polyfill failed` (HTTP2 framing)
- `agent-client-protocol ... curl [55] OpenSSL SSL_ERROR_SYSCALL` (61 jobs red in one run)

Neither is a code failure — they pass on re-run.

## Fix
Add to `reborn-tests.yml` env:
- `CARGO_NET_RETRY: "10"` — Cargo retries network failures (default 3) far more aggressively, so transient download errors self-heal within the job.
- `CARGO_NET_GIT_FETCH_WITH_CLI: "true"` — use the git CLI for git deps (more robust than libgit2 under flaky networks).

2-line env change, applies to all reborn-tests jobs. Zero behavior change otherwise.

## Follow-up (not this PR)
The real scaling fix is build-once `cargo nextest archive` → shard the **run**, which eliminates the 64× parallel dependency resolution entirely. Tracked for the bake phase.

_Automated agent-authored._