### PR TITLE
ci(reborn): share one Rust cache across the closure (fix per-crate cache LRU eviction)

### DIFF
--- a/.github/workflows/reborn-tests.yml
+++ b/.github/workflows/reborn-tests.yml
@@ -203,7 +203,15 @@ jobs:
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
-          key: reborn-tests-${{ matrix.package }}
+          # ONE shared cache for all ~60 crate-test jobs instead of a per-crate
+          # key. Per-crate keys produced ~60 caches (registry + target each,
+          # ~0.4-0.7 GB), which blew far past GitHub's ~10 GB repo cache LRU and
+          # evicted each other — so most jobs hit "No cache found", re-downloaded
+          # the crates.io registry from cold, and were exposed to transient
+          # download flakes (mitigated separately by CARGO_NET_RETRY). A single
+          # shared key keeps the registry + shared-dep build in one small,
+          # always-resident entry, so the registry is downloaded once, not ~60x.
+          shared-key: reborn-tests-crates
           # Keep saves to protected-branch and merge_group runs so the ~10 GB
           # repo cache LRU is seeded by shared states, not arbitrary PR branches.
           save-if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'merge_group' }}
@@ -285,7 +293,12 @@ jobs:
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
-          key: reborn-tests-root-${{ matrix.partition }}
+          # All 4 root partitions compile the *same* root-package build (they
+          # only run different test partitions), so one shared cache is strictly
+          # better than 4 per-partition copies (~1 GB each) — the cached target
+          # is fully valid for every partition, and it stops the 4 copies from
+          # crowding the shared LRU.
+          shared-key: reborn-tests-root
           # Keep saves to protected-branch and merge_group runs so the ~10 GB
           # repo cache LRU is seeded by shared states, not arbitrary PR branches.
           save-if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'merge_group' }}


### PR DESCRIPTION
## Problem (root cause of the closure's re-downloads + flakes)

The closure's crate-tests matrix used a **per-crate** cache key (`reborn-tests-<crate>`), so it produced **~60 caches** (registry + target each, ~0.4–0.7 GB) plus **4 per-partition root caches** (~1 GB each) → **~30+ GB** competing for GitHub's **~10 GB** per-repo cache LRU.

They evict each other almost as fast as they're written. Live snapshot when we investigated:
```
24 total repo caches, 18.0 GB  (limit ~10 GB → actively evicting)
only 10 of 64 closure crates had a cache present
```
So most jobs hit **"No cache found"** → re-download the crates.io registry from cold every run → and ~60 parallel cold downloads amplify transient registry flakes (the `SSL_ERROR_SYSCALL` / HTTP2 reds). **It was LRU eviction, not code changes** — the keys were valid; the entries were just evicted.

## Fix
Switch both matrices to rust-cache **`shared-key`**:
- **crate-tests** → `shared-key: reborn-tests-crates` — one entry for all crate jobs; the registry + shared-dep build is downloaded/compiled **once and stays resident**, not ~60×.
- **root partitions** → `shared-key: reborn-tests-root` — all 4 partitions compile the *identical* root build, so one shared cache is strictly better than 4 copies.

Drops the reborn-tests cache footprint from **~30+ GB / 68 entries → ~2 entries** that comfortably fit the LRU → the registry stays resident → no more cold re-downloads.

## Trade-off
Crate-test **target** caching is now shared rather than per-crate, so a given crate may recompile its own (small) crate-specific code more often — but the **shared dependency build** (the bulk) and the **registry** (the download-relevant part) are always cached. The download/flake fix is the priority; if per-crate compile time regresses, we can add a separate per-crate target cache later.

## Relationship to #5115
Complementary: this removes the *cause* of cold downloads (cache eviction); `CARGO_NET_RETRY` (#5115) remains the safety net for the now-rare cold download.

_Automated agent-authored._