### PR TITLE
fix(triggers): complete once permanent failures

### DIFF
--- a/crates/ironclaw_triggers/src/worker/due_fire.rs
+++ b/crates/ironclaw_triggers/src/worker/due_fire.rs
@@ -69,17 +69,15 @@ impl TriggerPollerWorker {
         fire_slot: Timestamp,
         now: Timestamp,
     ) -> Result<TriggerPollerFireOutcome, TriggerError> {
-        let permanent_failure_disposition =
-            permanent_failure_disposition(&record.schedule, fire_slot)?;
-
         let fire = match self.deps.source_provider.evaluate(&record, now).await {
             Ok(Some(fire)) => fire,
             Ok(None) => {
+                let disposition = permanent_failure_disposition(&record.schedule, fire_slot)?;
                 return self
                     .persist_failed_fire(
                         record,
                         fire_slot,
-                        permanent_failure_disposition,
+                        disposition,
                         TriggerPollerFailureReason::SourceNoFire,
                     )
                     .await;
@@ -88,7 +86,9 @@ impl TriggerPollerWorker {
                 let classification = classify_failure(&error);
                 let disposition = match classification.kind {
                     SubmitFailureKind::Retryable => FailedFireDisposition::Retryable,
-                    SubmitFailureKind::Permanent => permanent_failure_disposition,
+                    SubmitFailureKind::Permanent => {
+                        permanent_failure_disposition(&record.schedule, fire_slot)?
+                    }
                 };
                 return self
                     .persist_failed_fire(record, fire_slot, disposition, classification.reason)
@@ -106,7 +106,9 @@ impl TriggerPollerWorker {
                 let classification = classify_failure(&error);
                 let disposition = match classification.kind {
                     SubmitFailureKind::Retryable => FailedFireDisposition::Retryable,
-                    SubmitFailureKind::Permanent => permanent_failure_disposition,
+                    SubmitFailureKind::Permanent => {
+                        permanent_failure_disposition(&record.schedule, fire_slot)?
+                    }
                 };
                 return self
                     .persist_failed_fire(record, fire_slot, disposition, classification.reason)
@@ -177,7 +179,9 @@ impl TriggerPollerWorker {
                 let classification = classify_failure(&error);
                 let disposition = match classification.kind {
                     SubmitFailureKind::Retryable => FailedFireDisposition::Retryable,
-                    SubmitFailureKind::Permanent => permanent_failure_disposition,
+                    SubmitFailureKind::Permanent => {
+                        permanent_failure_disposition(&record.schedule, fire_slot)?
+                    }
                 };
                 self.persist_failed_fire(record, fire_slot, disposition, classification.reason)
                     .await

--- a/crates/ironclaw_triggers/src/worker/due_fire.rs
+++ b/crates/ironclaw_triggers/src/worker/due_fire.rs
@@ -1,14 +1,22 @@
 use crate::{
     ClaimDueFireOutcome, ClaimDueFireRequest, FireAcceptedRequest, FirePermanentFailedRequest,
-    FireReplayedRequest, FireRetryableFailedRequest, TriggerError, TriggerRecord,
+    FireReplayedRequest, FireRetryableFailedRequest, FireTerminalFailedRequest, TriggerError,
+    TriggerRecord, TriggerSchedule,
 };
 use ironclaw_host_api::Timestamp;
 
 use super::{
     TriggerPollerFailureReason, TriggerPollerFireOutcome, TriggerPollerWorker,
     TrustedTriggerFireSubmitOutcome, TrustedTriggerSubmitRequest,
-    failure::{FireFailureDisposition, SubmitFailureKind, classify_failure},
+    failure::{SubmitFailureKind, classify_failure},
 };
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FailedFireDisposition {
+    Retryable,
+    RecurringPermanentReschedule(Timestamp),
+    OncePermanentComplete,
+}
 
 impl TriggerPollerWorker {
     pub(super) async fn process_due_record(
@@ -61,15 +69,8 @@ impl TriggerPollerWorker {
         fire_slot: Timestamp,
         now: Timestamp,
     ) -> Result<TriggerPollerFireOutcome, TriggerError> {
-        // Compute the permanent-failure disposition up front:
-        // - Retryable failure → always Retryable (unchanged)
-        // - Permanent failure → reschedule to next slot if Some; else leave Scheduled (fail-closed)
-        //   (Once triggers and exhausted Crons both return None from next_slot_after)
-        // A trigger only reaches Completed via clear_active_fire after a real run terminates.
-        let permanent_failure_disposition = match record.schedule.next_slot_after(fire_slot)? {
-            Some(next) => FireFailureDisposition::PermanentReschedule(next),
-            None => FireFailureDisposition::Retryable, // fail-closed: keep Scheduled
-        };
+        let permanent_failure_disposition =
+            permanent_failure_disposition(&record.schedule, fire_slot)?;
 
         let fire = match self.deps.source_provider.evaluate(&record, now).await {
             Ok(Some(fire)) => fire,
@@ -86,7 +87,7 @@ impl TriggerPollerWorker {
             Err(error) => {
                 let classification = classify_failure(&error);
                 let disposition = match classification.kind {
-                    SubmitFailureKind::Retryable => FireFailureDisposition::Retryable,
+                    SubmitFailureKind::Retryable => FailedFireDisposition::Retryable,
                     SubmitFailureKind::Permanent => permanent_failure_disposition,
                 };
                 return self
@@ -104,7 +105,7 @@ impl TriggerPollerWorker {
             Err(error) => {
                 let classification = classify_failure(&error);
                 let disposition = match classification.kind {
-                    SubmitFailureKind::Retryable => FireFailureDisposition::Retryable,
+                    SubmitFailureKind::Retryable => FailedFireDisposition::Retryable,
                     SubmitFailureKind::Permanent => permanent_failure_disposition,
                 };
                 return self
@@ -175,7 +176,7 @@ impl TriggerPollerWorker {
             Err(error) => {
                 let classification = classify_failure(&error);
                 let disposition = match classification.kind {
-                    SubmitFailureKind::Retryable => FireFailureDisposition::Retryable,
+                    SubmitFailureKind::Retryable => FailedFireDisposition::Retryable,
                     SubmitFailureKind::Permanent => permanent_failure_disposition,
                 };
                 self.persist_failed_fire(record, fire_slot, disposition, classification.reason)
@@ -188,11 +189,11 @@ impl TriggerPollerWorker {
         &self,
         record: TriggerRecord,
         fire_slot: Timestamp,
-        disposition: FireFailureDisposition,
+        disposition: FailedFireDisposition,
         reason: TriggerPollerFailureReason,
     ) -> Result<TriggerPollerFireOutcome, TriggerError> {
         match disposition {
-            FireFailureDisposition::Retryable => {
+            FailedFireDisposition::Retryable => {
                 self.deps
                     .repository
                     .mark_fire_retryable_failed(FireRetryableFailedRequest {
@@ -203,7 +204,7 @@ impl TriggerPollerWorker {
                     .await?;
                 Ok(TriggerPollerFireOutcome::RetryableFailed { reason })
             }
-            FireFailureDisposition::PermanentReschedule(next_run_at) => {
+            FailedFireDisposition::RecurringPermanentReschedule(next_run_at) => {
                 self.deps
                     .repository
                     .mark_fire_permanently_failed(FirePermanentFailedRequest {
@@ -215,6 +216,30 @@ impl TriggerPollerWorker {
                     .await?;
                 Ok(TriggerPollerFireOutcome::PermanentFailed { reason })
             }
+            FailedFireDisposition::OncePermanentComplete => {
+                self.deps
+                    .repository
+                    .mark_fire_terminally_failed(FireTerminalFailedRequest {
+                        tenant_id: record.tenant_id,
+                        trigger_id: record.trigger_id,
+                        fire_slot,
+                    })
+                    .await?;
+                Ok(TriggerPollerFireOutcome::OncePermanentFailed { reason })
+            }
         }
+    }
+}
+
+fn permanent_failure_disposition(
+    schedule: &TriggerSchedule,
+    fire_slot: Timestamp,
+) -> Result<FailedFireDisposition, TriggerError> {
+    match schedule {
+        TriggerSchedule::Once { .. } => Ok(FailedFireDisposition::OncePermanentComplete),
+        TriggerSchedule::Cron { .. } => match schedule.next_slot_after(fire_slot)? {
+            Some(next) => Ok(FailedFireDisposition::RecurringPermanentReschedule(next)),
+            None => Ok(FailedFireDisposition::Retryable),
+        },
     }
 }

--- a/crates/ironclaw_triggers/src/worker/failure.rs
+++ b/crates/ironclaw_triggers/src/worker/failure.rs
@@ -1,5 +1,3 @@
-use ironclaw_host_api::Timestamp;
-
 use crate::TriggerError;
 
 use super::TriggerPollerFailureReason;
@@ -8,12 +6,6 @@ use super::TriggerPollerFailureReason;
 pub(super) enum SubmitFailureKind {
     Retryable,
     Permanent,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) enum FireFailureDisposition {
-    Retryable,
-    PermanentReschedule(Timestamp),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/ironclaw_triggers/src/worker/report.rs
+++ b/crates/ironclaw_triggers/src/worker/report.rs
@@ -44,6 +44,11 @@ pub enum TriggerPollerFireOutcome {
     PermanentFailed {
         reason: TriggerPollerFailureReason,
     },
+    /// A `Once` trigger hit a permanent pre-submission failure and was
+    /// completed so it cannot re-fire the same terminal schedule slot forever.
+    OncePermanentFailed {
+        reason: TriggerPollerFailureReason,
+    },
     ClearedTerminalActive {
         run_id: TurnRunId,
     },

--- a/crates/ironclaw_triggers/src/worker/tests.rs
+++ b/crates/ironclaw_triggers/src/worker/tests.rs
@@ -2327,18 +2327,15 @@ async fn tick_recurring_blocked_active_run_clears_as_failed() {
 }
 
 #[tokio::test]
-async fn tick_fire_once_permanent_submit_failure_stays_scheduled_for_retry() {
-    // A CompleteAfterFirstFire trigger whose submitter returns a Permanent
-    // failure (e.g. unpaired actor, bad materialization) has NOT fired — the
-    // one-shot must remain Scheduled so it can retry once the cause is fixed.
-    // It must NOT be marked Completed; that only happens via clear_active_fire
-    // after a real run terminates.
+async fn tick_fire_once_permanent_submit_failure_completes_once_trigger() {
+    // Once triggers must key permanent failure handling on the schedule kind, not
+    // on next_slot_after(None). Exhausted cron schedules also have no next slot
+    // but must keep the existing fail-closed Retryable behavior.
     let repo = Arc::new(InMemoryTriggerRepository::default());
     let trigger_id = TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid");
     let fire_slot = ts(1_704_067_200);
     let mut record = sample_record(trigger_id, tenant("tenant-a"), fire_slot);
     record.schedule = TriggerSchedule::once(fire_slot, "UTC").expect("valid once");
-    let original_next_run_at = record.next_run_at;
     repo.upsert_trigger(record).await.expect("insert");
     let worker = worker(
         repo.clone(),
@@ -2353,35 +2350,92 @@ async fn tick_fire_once_permanent_submit_failure_stays_scheduled_for_retry() {
 
     let report = worker.tick_once(fire_slot).await.expect("tick succeeds");
 
-    // Permanent pre-submission failure for a fire-once triggers Retryable (fail-closed).
     assert!(
         matches!(
             report.results.last().map(|r| &r.outcome),
-            Some(TriggerPollerFireOutcome::RetryableFailed { .. })
+            Some(TriggerPollerFireOutcome::OncePermanentFailed {
+                reason: TriggerPollerFailureReason::InvalidMaterialization,
+            })
         ),
-        "fire-once permanent submit failure must produce RetryableFailed (fail-closed, not PermanentFailed)"
+        "fire-once permanent submit failure must complete the once trigger, not remain retryable"
     );
     let persisted = repo
         .get_trigger(tenant("tenant-a"), trigger_id)
         .await
         .expect("load")
         .expect("record present");
-    assert_ne!(
+    assert_eq!(
         persisted.state,
         TriggerState::Completed,
-        "fire-once that never fired must NOT be Completed — it must remain Scheduled"
-    );
-    assert_eq!(
-        persisted.state,
-        TriggerState::Scheduled,
-        "fire-once permanent submit failure must leave trigger Scheduled"
-    );
-    assert_eq!(
-        persisted.next_run_at, original_next_run_at,
-        "fire-once trigger must NOT advance next_run_at on permanent failure"
+        "fire-once permanent submit failure must mark the once trigger Completed"
     );
     assert_eq!(persisted.active_fire_slot, None);
     assert_eq!(persisted.active_run_ref, None);
+    let due = repo
+        .list_due_triggers(fire_slot, 10)
+        .await
+        .expect("due query");
+    assert!(
+        due.iter().all(|r| r.trigger_id != trigger_id),
+        "completed fire-once trigger must not appear in due list"
+    );
+}
+
+#[tokio::test]
+async fn tick_fire_once_permanent_pre_submit_failures_complete_once_trigger() {
+    let fire_slot = ts(1_704_067_200);
+    let cases = [
+        (
+            "01HZZZZZZZZZZZZZZZZZZZZZZY",
+            Arc::new(NullSourceProvider) as Arc<dyn TriggerSourceProvider>,
+            Arc::new(RecordingMaterializer::success("content:fire-once")),
+            TriggerPollerFailureReason::SourceNoFire,
+        ),
+        (
+            "01HZZZZZZZZZZZZZZZZZZZZZZX",
+            Arc::new(crate::ScheduleTriggerSourceProvider) as Arc<dyn TriggerSourceProvider>,
+            Arc::new(RecordingMaterializer::failure(
+                TriggerError::InvalidMaterialization {
+                    reason: "bad prompt content ref for once trigger".to_string(),
+                },
+            )),
+            TriggerPollerFailureReason::InvalidMaterialization,
+        ),
+    ];
+
+    for (trigger_id, source_provider, materializer, expected_reason) in cases {
+        let repo = Arc::new(InMemoryTriggerRepository::default());
+        let trigger_id = TriggerId::parse(trigger_id).expect("ulid");
+        let mut record = sample_record(trigger_id, tenant("tenant-a"), fire_slot);
+        record.schedule = TriggerSchedule::once(fire_slot, "UTC").expect("valid once");
+        repo.upsert_trigger(record).await.expect("insert");
+        let worker = worker_with_source_provider(
+            repo.clone(),
+            source_provider,
+            materializer,
+            Arc::new(RecordingSubmitter::with_outcomes(Vec::new())),
+            Arc::new(RecordingActiveRunLookup::default()),
+        );
+
+        let report = worker.tick_once(fire_slot).await.expect("tick succeeds");
+
+        assert!(
+            matches!(
+                report.results.last().map(|r| &r.outcome),
+                Some(TriggerPollerFireOutcome::OncePermanentFailed { reason })
+                    if *reason == expected_reason
+            ),
+            "fire-once permanent pre-submit failure must complete the once trigger"
+        );
+        let persisted = repo
+            .get_trigger(tenant("tenant-a"), trigger_id)
+            .await
+            .expect("load")
+            .expect("record present");
+        assert_eq!(persisted.state, TriggerState::Completed);
+        assert_eq!(persisted.active_fire_slot, None);
+        assert_eq!(persisted.active_run_ref, None);
+    }
 }
 
 #[tokio::test]

--- a/docs/plans/2026-06-18-trigger-schedule-once-rework.md
+++ b/docs/plans/2026-06-18-trigger-schedule-once-rework.md
@@ -49,14 +49,14 @@ Replaces the `completion_policy == CompleteAfterFirstFire` CASE.
 ### 5. Worker (`crates/ironclaw_triggers/src/worker/due_fire.rs`)
 - Remove `is_fire_once`, `recurring_next_run_at`, and the `failure_disposition` Terminal-vs-Reschedule
   split keyed on fire-once.
-- Pre-submit failure axis is "did the run execute?" — these paths never ran the turn, so they must
-  NOT complete the trigger (fail-closed):
+- Pre-submit failure handling is keyed on the schedule kind:
   - Retryable failure → `Retryable` (leave Scheduled at fire_slot; retries next poll). Unchanged.
-  - Permanent failure → reschedule to `schedule.next_slot_after(fire_slot)` if `Some`; if `None`
-    (a `Once`, or exhausted cron), **leave Scheduled at fire_slot** (fail-closed retry) — do NOT
-    mark Completed. (This is what makes the `trigger_poller_does_not_submit_turn_for_unpaired_actor`
-    test pass: an unpaired one-shot is never Completed.)
-  - A trigger only reaches `Completed` via `clear_active_fire` after a real run terminates.
+  - `Once` permanent failure → mark `Completed` so the one-shot slot cannot refire forever.
+  - Cron permanent failure → reschedule to `schedule.next_slot_after(fire_slot)` if `Some`;
+    exhausted Cron stays `Scheduled`/retryable and remains visible for manual investigation
+    or removal.
+  - A trigger reaches `Completed` via `clear_active_fire` after a real run terminates, and `Once`
+    can also reach `Completed` on a terminal pre-submit permanent failure.
 - `active_cleanup.rs`: the "blocked fire-once stays pending" rule now keys on the schedule being
   `Once` (i.e. `next_slot_after(fire_slot).is_none()`-style / `matches!(schedule, Once{..})`),
   not on `completion_policy`.

--- a/docs/reborn/contracts/triggers.md
+++ b/docs/reborn/contracts/triggers.md
@@ -86,9 +86,12 @@ It is the source of truth for fire eligibility.
 - `Paused` means the trigger is retained but must not fire.
 - `Completed` is the terminal state reached when a `complete_after_first_fire`
   trigger fires successfully. `clear_active_fire` transitions the trigger to
-  `Completed` (soft-complete) after the run reaches a terminal outcome.
-  Completed triggers are retained and remain queryable — the model-visible
-  `trigger_list` capability surfaces all states, and
+  `Completed` (soft-complete) after the run reaches a terminal outcome; the
+  same path also soft-completes successful `Once` fires after their terminal
+  run outcome. `Once` triggers also complete on a terminal pre-submit failure
+  so the same one-shot slot does not refire forever. Completed triggers are
+  retained and remain queryable — the model-visible `trigger_list` capability
+  surfaces all states, and
   `GET /api/webchat/v2/automations?include_completed=true` returns them — but
   the default WebUI automations panel excludes `Completed` entries to avoid
   cluttering the active list with triggers that will never fire again.
@@ -111,6 +114,10 @@ It is the source of truth for fire eligibility.
   slot) combined with `complete_after_first_fire` is the V1 one-shot
   implementation. Subsequent poll ticks skip the trigger because its state is
   `Completed`.
+
+Pre-submit permanent failures are handled separately by the worker: `Once`
+triggers complete on failure so the one-shot slot is retired, while exhausted
+Cron triggers stay `Scheduled`/retryable for manual investigation or removal.
 
 Run threads for completed triggers remain accessible by design; their history is
 retained user data and must not become unreachable when the trigger transitions
@@ -362,14 +369,17 @@ Slot bookkeeping is tied to acceptance, not merely polling:
   `active_fire_slot` and `active_run_ref`, leave `last_fired_slot` and
   `last_run_at` unchanged, and keep `next_run_at` at or before the failed
   fire_slot so the poller can retry it on the next tick;
-- permanent validation or authorization failures write `last_status = Error`,
-  clear `active_fire_slot` and `active_run_ref`, leave `last_fired_slot` and
-  `last_run_at` unchanged, and advance `next_run_at` beyond the failed
-  fire_slot;
-- permanent failures on a schedule with no future fire slot mark the trigger
+- permanent validation or authorization failures on Cron write `last_status =
+  Error`, clear `active_fire_slot` and `active_run_ref`, leave
+  `last_fired_slot` and `last_run_at` unchanged, and advance `next_run_at`
+  beyond the failed fire_slot;
+- permanent validation or authorization failures on `Once` mark the trigger
   `Completed`, write `last_status = Error`, clear active-fire fields, and leave
-  `next_run_at` at the failed fire slot. The `Completed` state, not a sentinel
-  timestamp, removes the trigger from future due queries.
+  `next_run_at` at the failed fire slot so the one-shot slot is retired. The
+  `Completed` state, not a sentinel timestamp, removes the trigger from future
+  due queries;
+- exhausted Cron permanent pre-submit failures stay `Scheduled`/retryable so
+  they remain visible for manual review and removal.
 
 Turn terminal lookup and clearing are a narrow seam layered above fire-claim
 and submit-result bookkeeping:


### PR DESCRIPTION
## Summary
- complete `Once` triggers after permanent pre-submission failures so they do not re-fire the same slot forever
- keep exhausted Cron permanent failures fail-closed as `RetryableFailed`
- add caller-level worker coverage for Once submit/source/materializer permanent failures and the existing exhausted-Cron guard

## Root Cause
The worker previously derived permanent-failure handling from `next_slot_after`. That conflated `Once` schedules and exhausted Cron schedules because both can return `None`.

## Validation
- `cargo test -p ironclaw_triggers`
- `cargo clippy -p ironclaw_triggers --all-targets --all-features -- -D warnings`
- `cargo fmt --check`
