### PR TITLE
[codex] restore GSuite duplicate account fallback

### DIFF
--- a/crates/ironclaw_first_party_extensions/src/gsuite/credential.rs
+++ b/crates/ironclaw_first_party_extensions/src/gsuite/credential.rs
@@ -4,7 +4,7 @@ use ironclaw_auth::{
     AuthProductError, AuthProductScope, AuthProviderId, AuthSurface, CredentialAccount,
     CredentialAccountId, CredentialAccountRecordSource, CredentialAccountService,
     CredentialAccountStatus, CredentialRecoveryProjection, CredentialRefreshRequest,
-    GOOGLE_PROVIDER_ID, ProviderScope,
+    GOOGLE_PROVIDER_ID, ProviderScope, select_latest_duplicate_user_reusable_account,
 };
 use ironclaw_host_api::{ExtensionId, ResourceScope, SecretHandle};
 use thiserror::Error;
@@ -267,7 +267,8 @@ impl GoogleCredentialResolver {
                 missing_scopes: required_scopes.to_vec(),
             }),
             [account] => Ok(account.clone()),
-            _ => Err(AuthProductError::AccountSelectionRequired.into()),
+            _ => select_latest_duplicate_user_reusable_account(&scoped)
+                .ok_or(AuthProductError::AccountSelectionRequired.into()),
         }
     }
 

--- a/crates/ironclaw_first_party_extensions/tests/gsuite_core.rs
+++ b/crates/ironclaw_first_party_extensions/tests/gsuite_core.rs
@@ -1047,7 +1047,7 @@ async fn gsuite_handler_maps_panicking_runtime_egress_to_backend() {
 }
 
 #[tokio::test]
-async fn gsuite_handler_fails_before_egress_when_google_account_is_missing_or_ambiguous() {
+async fn gsuite_handler_handles_missing_hidden_and_duplicate_google_accounts() {
     let scope = scope();
     let auth = Arc::new(InMemoryAuthProductServices::new());
     let egress = Arc::new(RecordingEgress::permissive_success());
@@ -1111,7 +1111,7 @@ async fn gsuite_handler_fails_before_egress_when_google_account_is_missing_or_am
         true,
     )
     .await;
-    let error = dispatch_error(
+    let output = dispatch_ok(
         auth,
         scope,
         GMAIL_SEND_MESSAGE_CAPABILITY_ID,
@@ -1120,13 +1120,8 @@ async fn gsuite_handler_fails_before_egress_when_google_account_is_missing_or_am
     )
     .await;
 
-    assert_eq!(error.kind(), RuntimeDispatchErrorKind::Client);
-    assert!(matches!(
-        error.reason(),
-        Some(GsuiteCredentialDispatchReason::Recovery(recovery))
-            if recovery.kind() == ironclaw_auth::CredentialRecoveryKind::AccountSelectionRequired
-    ));
-    assert!(egress.requests().is_empty());
+    assert_eq!(output["status"], 200);
+    assert_eq!(egress.requests().len(), 1);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- restore the GSuite resolver's latest-duplicate reusable Google account fallback
- update the caller-level GSuite test so missing/hidden accounts still fail before egress, while duplicate reusable accounts dispatch successfully

## Root Cause
PR #5108 removed the GSuite resolver's duplicate reusable account tie-breaker and always returned `AccountSelectionRequired` when multiple configured Google accounts matched. That regressed the auth-resume path for users with duplicate reusable Google account records: OAuth could complete and the generic product-auth resolver could see a fresh token, but the first-party GSuite resolver would still re-open an auth gate before egress.

## Impact
Users with pre-existing duplicate reusable Google account records can continue using the most recently updated configured account instead of being stuck behind a repeated Google auth gate.

## Validation
- `cargo fmt --check`
- `cargo test -q -p ironclaw_first_party_extensions gsuite_handler_handles_missing_hidden_and_duplicate_google_accounts`
- `git diff --check`
