### PR TITLE
fix(reborn): remove legacy Slack fields from hosted config

### DIFF
--- a/docker/reborn/config.hosted-single-tenant.toml
+++ b/docker/reborn/config.hosted-single-tenant.toml
@@ -43,5 +43,3 @@ api_key_env = "NEARAI_API_KEY"
 
 [slack]
 enabled = false
-signing_secret_env = "IRONCLAW_REBORN_SLACK_SIGNING_SECRET"
-bot_token_env = "IRONCLAW_REBORN_SLACK_BOT_TOKEN"

--- a/tests/dockerfile_runtime_home.rs
+++ b/tests/dockerfile_runtime_home.rs
@@ -187,6 +187,41 @@ fn reborn_hosted_single_tenant_seed_config_contains_postgres_storage() {
 }
 
 #[test]
+fn reborn_hosted_single_tenant_seed_config_keeps_disabled_slack_legacy_free() {
+    let config = read_repo_file("docker/reborn/config.hosted-single-tenant.toml");
+    let parsed = config
+        .parse::<toml::Value>()
+        .expect("hosted seed config should be valid TOML");
+    let slack = parsed
+        .get("slack")
+        .and_then(toml::Value::as_table)
+        .expect("hosted seed config should include [slack]");
+
+    assert_eq!(
+        slack.get("enabled").and_then(toml::Value::as_bool),
+        Some(false),
+        "hosted seed config should keep Slack disabled until WebUI setup enables it",
+    );
+
+    for legacy_field in [
+        "installation_id",
+        "team_id",
+        "api_app_id",
+        "slack_user_id",
+        "user_id",
+        "shared_subject_user_id",
+        "channel_routes",
+        "signing_secret_env",
+        "bot_token_env",
+    ] {
+        assert!(
+            !slack.contains_key(legacy_field),
+            "disabled hosted seed config must not include legacy Slack field `{legacy_field}`"
+        );
+    }
+}
+
+#[test]
 fn reborn_dockerfile_build_is_covered_by_ci() {
     // The Reborn Dockerfile build can live in any CI workflow — it moved from
     // test.yml to platform-and-compat.yml when the cross-cutting jobs were


### PR DESCRIPTION
## Summary
- remove deprecated legacy Slack env-key fields from the hosted single-tenant config template
- add a regression test that prevents disabled hosted Slack config from carrying legacy setup fields
- keep Slack disabled by default without tripping the new runtime validation

## Why
Railway deploys were exiting during startup with:

`[slack].enabled must be true when legacy Slack setup fields are present in /data/ironclaw-reborn/config.toml`

The hosted template had `[slack].enabled = false` plus legacy `signing_secret_env` / `bot_token_env` fields, which now correctly fails validation.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `rg -n "signing_secret_env|bot_token_env" docker/reborn README.md docs/reborn -g'*.toml' -g'*.md'` returned no matches

Note: I did not rerun the Rust test locally because this machine only has ~2.4 GiB free after clearing `target`, and the previous Cargo attempt failed with OS error 28 (no space left on device).