### PR TITLE
[codex] Wire dynamic Slack routine delivery

### DIFF
--- a/crates/ironclaw_reborn_composition/src/slack_host_beta.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_host_beta.rs
@@ -473,11 +473,15 @@ pub fn build_triggered_run_delivery_hook(
     config: &SlackHostBetaConfig,
     delivery_store: Arc<dyn TriggeredRunDeliveryStore>,
 ) -> Result<Arc<TriggeredRunDeliveryDriver>, SlackHostBetaBuildError> {
-    let local_runtime = runtime
-        .services()
-        .local_runtime
-        .as_ref()
-        .ok_or(SlackHostBetaBuildError::DurableHostStateUnavailable)?;
+    let parts = SlackHostBetaRuntimeParts::from_runtime(runtime)?;
+    build_triggered_run_delivery_hook_from_parts(&parts, config, delivery_store)
+}
+
+fn build_triggered_run_delivery_hook_from_parts(
+    parts: &SlackHostBetaRuntimeParts,
+    config: &SlackHostBetaConfig,
+    delivery_store: Arc<dyn TriggeredRunDeliveryStore>,
+) -> Result<Arc<TriggeredRunDeliveryDriver>, SlackHostBetaBuildError> {
     let token_handle = slack_bot_token_handle()?;
     let adapter_id = ProductAdapterId::new(SLACK_V2_ADAPTER_ID)
         .map_err(|reason| invalid_config("adapter_id", reason.to_string()))?;
@@ -487,28 +491,29 @@ pub fn build_triggered_run_delivery_hook(
         egress_credential_handle: token_handle.clone(),
         auth_requirement: slack_request_signature_auth_requirement(),
     }));
-    let egress = slack_protocol_egress(runtime, config, token_handle)?;
-    let outbound_store: Arc<dyn OutboundStateStore> = Arc::clone(&local_runtime.outbound_state);
+    let egress = slack_protocol_egress_from_parts(parts, config, token_handle)?;
+    let outbound_store: Arc<dyn OutboundStateStore> =
+        Arc::clone(&parts.local_runtime.outbound_state);
     let route_store: Arc<dyn DeliveredGateRouteStore> =
-        Arc::clone(&local_runtime.delivered_gate_routes);
+        Arc::clone(&parts.local_runtime.delivered_gate_routes);
     let preferences: Arc<dyn ironclaw_outbound::CommunicationPreferenceRepository> =
-        Arc::clone(&local_runtime.outbound_preferences);
+        Arc::clone(&parts.local_runtime.outbound_preferences);
     let delivery_sink: Arc<dyn OutboundDeliverySink> = Arc::new(NoopSlackDeliverySink);
     let binding_service: Arc<dyn ConversationBindingService> =
         Arc::new(NoopConversationBindingService);
     let services = SlackFinalReplyDeliveryServices {
         binding_service,
-        thread_service: runtime.webui_thread_service(),
-        turn_coordinator: runtime.webui_turn_coordinator(),
+        thread_service: Arc::clone(&parts.thread_service),
+        turn_coordinator: Arc::clone(&parts.turn_coordinator),
         outbound_store,
         route_store: Arc::clone(&route_store),
         communication_preferences: preferences,
         adapter,
         egress,
         delivery_sink,
-        auth_challenges: runtime.auth_challenge_provider(),
-        auth_flow_canceller: runtime.blocked_auth_flow_canceller(),
-        approval_requests: Some(Arc::clone(&local_runtime.approval_requests)
+        auth_challenges: parts.auth_challenge_provider.clone(),
+        auth_flow_canceller: parts.auth_flow_canceller.clone(),
+        approval_requests: Some(Arc::clone(&parts.local_runtime.approval_requests)
             as Arc<dyn ironclaw_run_state::ApprovalRequestStore>),
     };
     // Pass config.agent_id as the fallback so the ThreadScope key matches the
@@ -4258,6 +4263,39 @@ mod tests {
 
     #[tokio::test]
     async fn build_slack_host_beta_mounts_wires_trigger_delivery_hook_writes_record() {
+        let (runtime, _tmp) = runtime_with_trigger_poller().await;
+
+        // Wire the delivery hook by calling the production mount builder.
+        let _mounts =
+            build_slack_host_beta_mounts(&runtime, config()).expect("mounts should build");
+
+        assert_due_personal_trigger_writes_delivery_record(&runtime, "hook-wiring-e2e").await;
+        runtime.shutdown().await.expect("runtime shutdown");
+    }
+
+    #[tokio::test]
+    async fn build_slack_host_beta_runtime_mounts_wires_dynamic_trigger_delivery_hook_writes_record()
+     {
+        let (runtime, _tmp) = runtime_with_trigger_poller().await;
+
+        // Wire the delivery hook by calling the dynamic production mount builder
+        // used by WebUI-managed Slack setup.
+        let _mounts = build_slack_host_beta_runtime_mounts(
+            &runtime,
+            dynamic_runtime_config_without_legacy_actor(),
+        )
+        .await
+        .expect("dynamic mounts should build");
+
+        assert_due_personal_trigger_writes_delivery_record(&runtime, "dynamic-hook-wiring-e2e")
+            .await;
+        runtime.shutdown().await.expect("runtime shutdown");
+    }
+
+    async fn assert_due_personal_trigger_writes_delivery_record(
+        runtime: &RebornRuntime,
+        trigger_name: &str,
+    ) {
         use std::time::Instant;
 
         use chrono::Utc;
@@ -4267,12 +4305,6 @@ mod tests {
             TRIGGER_TRUSTED_EXTERNAL_ACTOR_NAMESPACE, TriggerId, TriggerRecord, TriggerSchedule,
             TriggerSourceKind, TriggerState,
         };
-
-        let (runtime, _tmp) = runtime_with_trigger_poller().await;
-
-        // Wire the delivery hook by calling the production mount builder.
-        let _mounts =
-            build_slack_host_beta_mounts(&runtime, config()).expect("mounts should build");
 
         // Pair the trigger actor so the trusted submitter can resolve the
         // creator's user binding (fails closed for unpaired actors by design).
@@ -4305,10 +4337,10 @@ mod tests {
             creator_user_id: user_id.clone(),
             agent_id: Some(AgentId::new(AGENT).expect("agent")),
             project_id: None,
-            name: "hook-wiring-e2e".to_string(),
+            name: trigger_name.to_string(),
             source: TriggerSourceKind::Schedule,
             schedule: TriggerSchedule::cron("* * * * *").expect("valid cron"),
-            prompt: "hook-wiring-e2e-prompt-marker".to_string(),
+            prompt: format!("{trigger_name}-prompt-marker"),
             state: TriggerState::Scheduled,
             next_run_at: Utc::now() - chrono::Duration::seconds(120),
             last_run_at: None,
@@ -4363,8 +4395,6 @@ mod tests {
                 tokio::time::sleep(std::time::Duration::from_millis(50)).await;
             }
         }
-
-        runtime.shutdown().await.expect("runtime shutdown");
 
         assert!(
             fired_run_id.is_some(),

--- a/crates/ironclaw_reborn_composition/src/slack_host_beta/runtime_setup.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_host_beta/runtime_setup.rs
@@ -514,13 +514,17 @@ impl DynamicSlackTriggeredRunDeliveryHook {
             return Ok(None);
         };
         let revision = setup.revision;
-        let mut cached_driver = self.cached_driver.lock().await;
-        if let Some(cached) = cached_driver
-            .as_ref()
-            .filter(|cached| cached.revision == revision)
+
         {
-            return Ok(Some(Arc::clone(&cached.driver)));
+            let cached_driver = self.cached_driver.lock().await;
+            if let Some(cached) = cached_driver
+                .as_ref()
+                .filter(|cached| cached.revision == revision)
+            {
+                return Ok(Some(Arc::clone(&cached.driver)));
+            }
         }
+
         let config = slack_host_beta_config_from_setup(&self.setup_service, setup)
             .await
             .map_err(|error| error.to_string())?
@@ -531,6 +535,14 @@ impl DynamicSlackTriggeredRunDeliveryHook {
             Arc::clone(&self.delivery_store),
         )
         .map_err(|error| error.to_string())?;
+
+        let mut cached_driver = self.cached_driver.lock().await;
+        if let Some(cached) = cached_driver
+            .as_ref()
+            .filter(|cached| cached.revision >= revision)
+        {
+            return Ok(Some(Arc::clone(&cached.driver)));
+        }
         *cached_driver = Some(DynamicSlackTriggeredRunDeliveryDriver {
             revision,
             driver: Arc::clone(&driver),
@@ -542,22 +554,25 @@ impl DynamicSlackTriggeredRunDeliveryHook {
 #[async_trait::async_trait]
 impl PostSubmitDeliveryHook for DynamicSlackTriggeredRunDeliveryHook {
     async fn on_trigger_submitted(&self, fire: TriggerFire, run_id: TurnRunId, scope: TurnScope) {
-        match self.current_driver().await {
-            Ok(Some(driver)) => driver.on_trigger_submitted(fire, run_id, scope).await,
-            Ok(None) => {
-                tracing::debug!(
-                    %run_id,
-                    "Slack dynamic triggered-run delivery skipped: Slack setup is not configured"
-                );
+        let hook = self.clone();
+        tokio::spawn(async move {
+            match hook.current_driver().await {
+                Ok(Some(driver)) => driver.on_trigger_submitted(fire, run_id, scope).await,
+                Ok(None) => {
+                    tracing::debug!(
+                        %run_id,
+                        "Slack dynamic triggered-run delivery skipped: Slack setup is not configured"
+                    );
+                }
+                Err(error) => {
+                    tracing::warn!(
+                        %run_id,
+                        %error,
+                        "Slack dynamic triggered-run delivery skipped: delivery hook unavailable"
+                    );
+                }
             }
-            Err(error) => {
-                tracing::warn!(
-                    %run_id,
-                    %error,
-                    "Slack dynamic triggered-run delivery skipped: delivery hook unavailable"
-                );
-            }
-        }
+        });
     }
 }
 

--- a/crates/ironclaw_reborn_composition/src/slack_host_beta/runtime_setup.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_host_beta/runtime_setup.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use ironclaw_host_api::{AgentId, ProjectId, TenantId};
+use ironclaw_outbound::TriggeredRunDeliveryStore;
 use ironclaw_product_adapters::{
     AdapterInstallationId, EgressCredentialHandle, EgressRequest, EgressResponse,
     ProtocolHttpEgress, ProtocolHttpEgressError, RedactedString,
@@ -9,7 +10,8 @@ use ironclaw_product_workflow::{
     ProductConversationSubjectRouteResolver, RebornOutboundDeliveryTargetId, RebornServicesError,
     RebornServicesErrorCode, RebornServicesErrorKind, WebUiAuthenticatedCaller,
 };
-use ironclaw_turns::ReplyTargetBindingRef;
+use ironclaw_triggers::TriggerFire;
+use ironclaw_turns::{ReplyTargetBindingRef, TurnRunId, TurnScope};
 use sha2::{Digest, Sha256};
 use tokio::sync::Mutex;
 
@@ -26,6 +28,7 @@ use crate::slack_channel_routes::{
     SlackChannelRouteAdminRouteConfig, SlackChannelRouteAssignment, SlackChannelRouteError,
     SlackChannelRouteStore, SlackChannelRouteSubjectResolver,
 };
+use crate::slack_delivery::{PostSubmitDeliveryHook, TriggeredRunDeliveryDriver};
 use crate::slack_host_state::FilesystemSlackHostState;
 use crate::slack_outbound_targets::{
     SlackHostBetaOutboundTargetProvider, SlackOutboundTargetProviderConfig, SlackPersonalDmTarget,
@@ -60,7 +63,8 @@ use super::{
     SlackHostBetaActorUserResolver, SlackHostBetaBuildError, SlackHostBetaConfig,
     SlackHostBetaConfigInput, SlackHostBetaMounts, SlackHostBetaRuntimeConfig,
     SlackHostBetaRuntimeParts, build_slack_installation_record_with_resolvers,
-    slack_bot_token_handle, slack_protocol_egress_from_parts,
+    build_triggered_run_delivery_hook_from_parts, slack_bot_token_handle,
+    slack_protocol_egress_from_parts,
 };
 
 pub(super) async fn build_runtime_mounts(
@@ -144,7 +148,7 @@ pub(super) async fn build_runtime_mounts(
                 agent_id: config.agent_id.clone(),
                 project_id: config.project_id.clone(),
             },
-            setup_service,
+            Arc::clone(&setup_service),
             channel_route_store,
             personal_dm_target_store,
         ));
@@ -174,6 +178,20 @@ pub(super) async fn build_runtime_mounts(
                 });
             }
         }
+    }
+    let delivery_store: Arc<dyn TriggeredRunDeliveryStore> =
+        Arc::clone(&parts.local_runtime.triggered_run_delivery);
+    let trigger_delivery_hook: Arc<dyn PostSubmitDeliveryHook> =
+        Arc::new(DynamicSlackTriggeredRunDeliveryHook::new(
+            Arc::clone(&parts),
+            Arc::clone(&setup_service),
+            delivery_store,
+        ));
+    let hook_set = runtime.set_trigger_post_submit_hook(trigger_delivery_hook);
+    if !hook_set && runtime.trigger_post_submit_hook_is_set() && !provider_already_registered {
+        return Err(SlackHostBetaBuildError::OutboundDeliveryTargetRegistration {
+            reason: "Slack dynamic triggered-run delivery hook is already wired for a different Slack host config".to_string(),
+        });
     }
 
     Ok(SlackHostBetaMounts {
@@ -455,6 +473,91 @@ impl SlackPersonalDmTargetProvisioning for DynamicSlackPersonalDmTargetProvision
             .await?
             .provision_for_user(user_id, slack_user_id)
             .await
+    }
+}
+
+#[derive(Clone)]
+struct DynamicSlackTriggeredRunDeliveryHook {
+    parts: Arc<SlackHostBetaRuntimeParts>,
+    setup_service: Arc<SlackSetupService>,
+    delivery_store: Arc<dyn TriggeredRunDeliveryStore>,
+    cached_driver: Arc<Mutex<Option<DynamicSlackTriggeredRunDeliveryDriver>>>,
+}
+
+#[derive(Clone)]
+struct DynamicSlackTriggeredRunDeliveryDriver {
+    revision: u64,
+    driver: Arc<TriggeredRunDeliveryDriver>,
+}
+
+impl DynamicSlackTriggeredRunDeliveryHook {
+    fn new(
+        parts: Arc<SlackHostBetaRuntimeParts>,
+        setup_service: Arc<SlackSetupService>,
+        delivery_store: Arc<dyn TriggeredRunDeliveryStore>,
+    ) -> Self {
+        Self {
+            parts,
+            setup_service,
+            delivery_store,
+            cached_driver: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    async fn current_driver(&self) -> Result<Option<Arc<TriggeredRunDeliveryDriver>>, String> {
+        let Some(setup) = self
+            .setup_service
+            .current_setup()
+            .await
+            .map_err(|error| error.to_string())?
+        else {
+            return Ok(None);
+        };
+        let revision = setup.revision;
+        let mut cached_driver = self.cached_driver.lock().await;
+        if let Some(cached) = cached_driver
+            .as_ref()
+            .filter(|cached| cached.revision == revision)
+        {
+            return Ok(Some(Arc::clone(&cached.driver)));
+        }
+        let config = slack_host_beta_config_from_setup(&self.setup_service, setup)
+            .await
+            .map_err(|error| error.to_string())?
+            .map_err(|error| error.to_string())?;
+        let driver = build_triggered_run_delivery_hook_from_parts(
+            &self.parts,
+            &config,
+            Arc::clone(&self.delivery_store),
+        )
+        .map_err(|error| error.to_string())?;
+        *cached_driver = Some(DynamicSlackTriggeredRunDeliveryDriver {
+            revision,
+            driver: Arc::clone(&driver),
+        });
+        Ok(Some(driver))
+    }
+}
+
+#[async_trait::async_trait]
+impl PostSubmitDeliveryHook for DynamicSlackTriggeredRunDeliveryHook {
+    async fn on_trigger_submitted(&self, fire: TriggerFire, run_id: TurnRunId, scope: TurnScope) {
+        match self.current_driver().await {
+            Ok(Some(driver)) => driver.on_trigger_submitted(fire, run_id, scope).await,
+            Ok(None) => {
+                tracing::debug!(
+                    %run_id,
+                    "Slack dynamic triggered-run delivery skipped: Slack setup is not configured"
+                );
+            }
+            Err(error) => {
+                tracing::warn!(
+                    %run_id,
+                    %error,
+                    "Slack dynamic triggered-run delivery skipped: delivery hook unavailable"
+                );
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Wire WebUI-managed Slack setup into the triggered-run delivery hook, matching the static Slack host-beta setup path.
- Reuse the existing `TriggeredRunDeliveryDriver` construction through a shared helper instead of adding a second delivery implementation.
- Cache the dynamic delivery driver by Slack setup revision so setup updates rebuild the driver while normal routine fires keep the existing driver semantics.
- Add dynamic hook regression coverage that drives the trigger poller and verifies a triggered-run delivery record is written.

## Context
PR #5164 restored dynamic Slack outbound target registration and pairing-time personal DM target provisioning. This follow-up keeps that merged fix separate and covers the adjacent production delivery-hook wiring for routines created after WebUI Slack setup.

## Tests
- cargo fmt --package ironclaw_reborn_composition
- cargo test -p ironclaw_reborn_composition --features slack-v2-host-beta build_slack_host_beta_runtime_mounts_wires_dynamic_trigger_delivery_hook_writes_record
- cargo test -p ironclaw_reborn_composition --features slack-v2-host-beta build_slack_host_beta_mounts_wires_trigger_delivery_hook_writes_record
- cargo test -p ironclaw_reborn_composition --features slack-v2-host-beta dynamic_slack_setup_pairing_registers_runtime_personal_dm_target
- cargo clippy -p ironclaw_reborn_composition --features slack-v2-host-beta --all-targets -- -D warnings
- git diff --check