### PR TITLE
Fix Reborn credential delete and reauth

### DIFF
--- a/crates/ironclaw_auth/src/credential.rs
+++ b/crates/ironclaw_auth/src/credential.rs
@@ -512,14 +512,13 @@ pub trait CredentialAccountService: Send + Sync {
         scope: &AuthProductScope,
         account_id: CredentialAccountId,
         expected_updated_at: Timestamp,
+        requester_extension: Option<ExtensionId>,
     ) -> Result<Option<CredentialAccount>, AuthProductError> {
-        let Some(account) = self
-            .get_account(CredentialAccountLookupRequest::new(
-                scope.clone(),
-                account_id,
-            ))
-            .await?
-        else {
+        let mut lookup = CredentialAccountLookupRequest::new(scope.clone(), account_id);
+        if let Some(requester_extension) = requester_extension {
+            lookup = lookup.for_extension(requester_extension);
+        }
+        let Some(account) = self.get_account(lookup).await? else {
             return Ok(None);
         };
         if account.updated_at != expected_updated_at {
@@ -1031,9 +1030,10 @@ impl CredentialAccountService for ProviderBackedCredentialAccountService {
         scope: &AuthProductScope,
         account_id: CredentialAccountId,
         expected_updated_at: Timestamp,
+        requester_extension: Option<ExtensionId>,
     ) -> Result<Option<CredentialAccount>, AuthProductError> {
         self.accounts
-            .revoke_if_unchanged(scope, account_id, expected_updated_at)
+            .revoke_if_unchanged(scope, account_id, expected_updated_at, requester_extension)
             .await
     }
 

--- a/crates/ironclaw_auth/src/credential.rs
+++ b/crates/ironclaw_auth/src/credential.rs
@@ -507,6 +507,48 @@ pub trait CredentialAccountService: Send + Sync {
         status: CredentialAccountStatus,
     ) -> Result<CredentialAccount, AuthProductError>;
 
+    async fn revoke_if_unchanged(
+        &self,
+        scope: &AuthProductScope,
+        account_id: CredentialAccountId,
+        expected_updated_at: Timestamp,
+    ) -> Result<Option<CredentialAccount>, AuthProductError> {
+        let Some(account) = self
+            .get_account(CredentialAccountLookupRequest::new(
+                scope.clone(),
+                account_id,
+            ))
+            .await?
+        else {
+            return Ok(None);
+        };
+        if account.updated_at != expected_updated_at {
+            return Ok(None);
+        }
+        self.update_status(scope, account_id, CredentialAccountStatus::Revoked)
+            .await
+            .map(Some)
+    }
+
+    async fn refresh_if_unchanged(
+        &self,
+        request: CredentialRefreshRequest,
+        expected_updated_at: Timestamp,
+    ) -> Result<Option<CredentialRefreshReport>, AuthProductError> {
+        let mut lookup =
+            CredentialAccountLookupRequest::new(request.scope.clone(), request.account_id);
+        if let Some(requester_extension) = request.requester_extension.clone() {
+            lookup = lookup.for_extension(requester_extension);
+        }
+        let Some(account) = self.get_account(lookup).await? else {
+            return Ok(None);
+        };
+        if account.updated_at != expected_updated_at {
+            return Ok(None);
+        }
+        self.refresh_account(request).await.map(Some)
+    }
+
     async fn select_unique_configured_account(
         &self,
         request: CredentialAccountSelectionRequest,
@@ -830,6 +872,126 @@ impl ProviderBackedCredentialAccountService {
             .await?;
         self.report_for(&updated, requester_extension, false).await
     }
+
+    async fn refresh_account_from_snapshot(
+        &self,
+        request: CredentialRefreshRequest,
+        lookup_request: CredentialAccountLookupRequest,
+        initial_account: CredentialAccount,
+        expected_updated_at: Option<Timestamp>,
+    ) -> Result<Option<CredentialRefreshReport>, AuthProductError> {
+        if expected_updated_at.is_some_and(|expected| initial_account.updated_at != expected) {
+            return Ok(None);
+        }
+        Self::validate_refresh_target(&initial_account, &request)?;
+        let refresh_lock = self.acquire_refresh_lock(initial_account.id).await;
+        let result = async {
+            let account = self
+                .accounts
+                .get_account(lookup_request.clone())
+                .await?
+                .ok_or(AuthProductError::CredentialMissing)?;
+            if expected_updated_at.is_some_and(|expected| account.updated_at != expected) {
+                return Ok(None);
+            }
+            if account != initial_account {
+                return match expected_updated_at {
+                    Some(_) => Ok(None),
+                    None => self
+                        .report_for(&account, request.requester_extension.as_ref(), false)
+                        .await
+                        .map(Some),
+                };
+            }
+
+            let Some(refresh_secret) = account.refresh_secret.clone() else {
+                let updated = self
+                    .setup
+                    .create_or_update_account(Self::account_update(
+                        &account,
+                        account.access_secret.clone(),
+                        account.refresh_secret.clone(),
+                        CredentialAccountStatus::RefreshFailed,
+                        account.scopes.clone(),
+                    ))
+                    .await?;
+                return self
+                    .report_for(&updated, request.requester_extension.as_ref(), false)
+                    .await
+                    .map(Some);
+            };
+
+            let provider_request = OAuthProviderRefreshRequest {
+                provider: account.provider.clone(),
+                scope: account.scope.clone(),
+                account_id: account.id,
+                refresh_secret: refresh_secret.clone(),
+                scopes: account.scopes.clone(),
+            };
+
+            match self.provider.refresh_token(provider_request).await {
+                Ok(refresh) => {
+                    let current = self
+                        .accounts
+                        .get_account(lookup_request.clone())
+                        .await?
+                        .ok_or(AuthProductError::CredentialMissing)?;
+                    if current != account {
+                        return match expected_updated_at {
+                            Some(_) => Ok(None),
+                            None => self
+                                .report_for(&current, request.requester_extension.as_ref(), false)
+                                .await
+                                .map(Some),
+                        };
+                    }
+                    if refresh.provider != current.provider {
+                        return Err(AuthProductError::CrossScopeDenied);
+                    }
+                    let refresh_secret = refresh
+                        .refresh_secret
+                        .or_else(|| current.refresh_secret.clone());
+                    let updated = self
+                        .setup
+                        .create_or_update_account(Self::account_update(
+                            &current,
+                            Some(refresh.access_secret),
+                            refresh_secret,
+                            CredentialAccountStatus::Configured,
+                            refresh.scopes,
+                        ))
+                        .await?;
+                    self.report_for(&updated, request.requester_extension.as_ref(), true)
+                        .await
+                        .map(Some)
+                }
+                Err(AuthProductError::InvalidGrant) => self
+                    .report_terminal_refresh_status(
+                        &lookup_request,
+                        &account,
+                        request.requester_extension.as_ref(),
+                        CredentialAccountStatus::Revoked,
+                    )
+                    .await
+                    .map(Some),
+                Err(AuthProductError::RefreshFailed | AuthProductError::TokenExchangeFailed) => {
+                    self.report_terminal_refresh_status(
+                        &lookup_request,
+                        &account,
+                        request.requester_extension.as_ref(),
+                        CredentialAccountStatus::RefreshFailed,
+                    )
+                    .await
+                    .map(Some)
+                }
+                Err(error) => Err(error),
+            }
+        }
+        .await;
+        drop(refresh_lock);
+        self.release_refresh_lock(initial_account.id);
+        result
+    }
 }
 
 #[async_trait]
@@ -862,6 +1024,36 @@ impl CredentialAccountService for ProviderBackedCredentialAccountService {
         status: CredentialAccountStatus,
     ) -> Result<CredentialAccount, AuthProductError> {
         self.accounts.update_status(scope, account_id, status).await
+    }
+
+    async fn revoke_if_unchanged(
+        &self,
+        scope: &AuthProductScope,
+        account_id: CredentialAccountId,
+        expected_updated_at: Timestamp,
+    ) -> Result<Option<CredentialAccount>, AuthProductError> {
+        self.accounts
+            .revoke_if_unchanged(scope, account_id, expected_updated_at)
+            .await
+    }
+
+    async fn refresh_if_unchanged(
+        &self,
+        request: CredentialRefreshRequest,
+        expected_updated_at: Timestamp,
+    ) -> Result<Option<CredentialRefreshReport>, AuthProductError> {
+        let lookup_request = Self::refresh_lookup_request(&request);
+        let initial_account = match self.accounts.get_account(lookup_request.clone()).await? {
+            Some(account) => account,
+            None => return Ok(None),
+        };
+        self.refresh_account_from_snapshot(
+            request,
+            lookup_request,
+            initial_account,
+            Some(expected_updated_at),
+        )
+        .await
     }
 
     async fn select_unique_configured_account(
@@ -897,100 +1089,9 @@ impl CredentialAccountService for ProviderBackedCredentialAccountService {
             .get_account(lookup_request.clone())
             .await?
             .ok_or(AuthProductError::CredentialMissing)?;
-        Self::validate_refresh_target(&initial_account, &request)?;
-        let refresh_lock = self.acquire_refresh_lock(initial_account.id).await;
-        let result = async {
-            let account = self
-                .accounts
-                .get_account(lookup_request.clone())
-                .await?
-                .ok_or(AuthProductError::CredentialMissing)?;
-            if account != initial_account {
-                return self
-                    .report_for(&account, request.requester_extension.as_ref(), false)
-                    .await;
-            }
-
-            let Some(refresh_secret) = account.refresh_secret.clone() else {
-                let updated = self
-                    .setup
-                    .create_or_update_account(Self::account_update(
-                        &account,
-                        account.access_secret.clone(),
-                        account.refresh_secret.clone(),
-                        CredentialAccountStatus::RefreshFailed,
-                        account.scopes.clone(),
-                    ))
-                    .await?;
-                return self
-                    .report_for(&updated, request.requester_extension.as_ref(), false)
-                    .await;
-            };
-
-            let provider_request = OAuthProviderRefreshRequest {
-                provider: account.provider.clone(),
-                scope: account.scope.clone(),
-                account_id: account.id,
-                refresh_secret: refresh_secret.clone(),
-                scopes: account.scopes.clone(),
-            };
-
-            match self.provider.refresh_token(provider_request).await {
-                Ok(refresh) => {
-                    let current = self
-                        .accounts
-                        .get_account(lookup_request.clone())
-                        .await?
-                        .ok_or(AuthProductError::CredentialMissing)?;
-                    if current != account {
-                        return self
-                            .report_for(&current, request.requester_extension.as_ref(), false)
-                            .await;
-                    }
-                    if refresh.provider != current.provider {
-                        return Err(AuthProductError::CrossScopeDenied);
-                    }
-                    let refresh_secret = refresh
-                        .refresh_secret
-                        .or_else(|| current.refresh_secret.clone());
-                    let updated = self
-                        .setup
-                        .create_or_update_account(Self::account_update(
-                            &current,
-                            Some(refresh.access_secret),
-                            refresh_secret,
-                            CredentialAccountStatus::Configured,
-                            refresh.scopes,
-                        ))
-                        .await?;
-                    self.report_for(&updated, request.requester_extension.as_ref(), true)
-                        .await
-                }
-                Err(AuthProductError::InvalidGrant) => {
-                    self.report_terminal_refresh_status(
-                        &lookup_request,
-                        &account,
-                        request.requester_extension.as_ref(),
-                        CredentialAccountStatus::Revoked,
-                    )
-                    .await
-                }
-                Err(AuthProductError::RefreshFailed | AuthProductError::TokenExchangeFailed) => {
-                    self.report_terminal_refresh_status(
-                        &lookup_request,
-                        &account,
-                        request.requester_extension.as_ref(),
-                        CredentialAccountStatus::RefreshFailed,
-                    )
-                    .await
-                }
-                Err(error) => Err(error),
-            }
-        }
-        .await;
-        drop(refresh_lock);
-        self.release_refresh_lock(initial_account.id);
-        result
+        self.refresh_account_from_snapshot(request, lookup_request, initial_account, None)
+            .await?
+            .ok_or(AuthProductError::CredentialMissing)
     }
 }
 

--- a/crates/ironclaw_auth/src/fakes.rs
+++ b/crates/ironclaw_auth/src/fakes.rs
@@ -577,6 +577,7 @@ impl CredentialAccountService for InMemoryAuthProductServices {
         scope: &crate::AuthProductScope,
         account_id: CredentialAccountId,
         expected_updated_at: Timestamp,
+        requester_extension: Option<ExtensionId>,
     ) -> Result<Option<CredentialAccount>, AuthProductError> {
         let now = Utc::now();
         let mut state = self.lock_state();
@@ -584,6 +585,9 @@ impl CredentialAccountService for InMemoryAuthProductServices {
             return Ok(None);
         };
         if !scope_matches(scope, &account.scope) {
+            return Err(AuthProductError::CrossScopeDenied);
+        }
+        if !account_is_authorized_for_requester(account, requester_extension.as_ref()) {
             return Err(AuthProductError::CrossScopeDenied);
         }
         if account.updated_at != expected_updated_at {

--- a/crates/ironclaw_auth/src/fakes.rs
+++ b/crates/ironclaw_auth/src/fakes.rs
@@ -572,6 +572,29 @@ impl CredentialAccountService for InMemoryAuthProductServices {
         Ok(account.clone())
     }
 
+    async fn revoke_if_unchanged(
+        &self,
+        scope: &crate::AuthProductScope,
+        account_id: CredentialAccountId,
+        expected_updated_at: Timestamp,
+    ) -> Result<Option<CredentialAccount>, AuthProductError> {
+        let now = Utc::now();
+        let mut state = self.lock_state();
+        let Some(account) = state.accounts.get_mut(&account_id) else {
+            return Ok(None);
+        };
+        if !scope_matches(scope, &account.scope) {
+            return Err(AuthProductError::CrossScopeDenied);
+        }
+        if account.updated_at != expected_updated_at {
+            return Ok(None);
+        }
+        validate_credential_status_transition(account.status, CredentialAccountStatus::Revoked)?;
+        account.status = CredentialAccountStatus::Revoked;
+        account.updated_at = now;
+        Ok(Some(account.clone()))
+    }
+
     async fn select_unique_configured_account(
         &self,
         request: CredentialAccountSelectionRequest,

--- a/crates/ironclaw_auth/tests/auth_product_contract/refresh_contract.rs
+++ b/crates/ironclaw_auth/tests/auth_product_contract/refresh_contract.rs
@@ -528,6 +528,94 @@ async fn provider_backed_refresh_preserves_requester_for_authorized_extensions()
 }
 
 #[tokio::test]
+async fn provider_backed_refresh_if_unchanged_refreshes_authorized_extension_account() {
+    let services = Arc::new(InMemoryAuthProductServices::new());
+    let auth = provider_backed_auth(services.clone());
+    let owner = scope("alice");
+    let extension = ExtensionId::new("github-refresh-extension").unwrap();
+    let old_access = SecretHandle::new("github-refresh-if-unchanged-access").unwrap();
+    let account = auth
+        .create_account(NewCredentialAccount {
+            scope: owner.clone(),
+            provider: provider(),
+            label: label("extension owned"),
+            status: CredentialAccountStatus::Configured,
+            ownership: CredentialOwnership::ExtensionOwned,
+            owner_extension: Some(extension.clone()),
+            granted_extensions: Vec::new(),
+            access_secret: Some(old_access.clone()),
+            refresh_secret: Some(SecretHandle::new("github-refresh-if-unchanged-refresh").unwrap()),
+            scopes: provider_scopes(&["repo"]),
+        })
+        .await
+        .expect("extension-owned account");
+
+    let report = auth
+        .refresh_if_unchanged(
+            CredentialRefreshRequest::new(owner.clone(), provider(), account.id)
+                .for_extension(extension.clone()),
+            account.updated_at,
+        )
+        .await
+        .expect("conditional refresh")
+        .expect("fresh marker should refresh account");
+
+    assert!(report.refreshed);
+    let stored = auth
+        .get_account(
+            CredentialAccountLookupRequest::new(owner, account.id).for_extension(extension),
+        )
+        .await
+        .expect("lookup")
+        .expect("refreshed account");
+    assert_eq!(stored.status, CredentialAccountStatus::Configured);
+    assert_ne!(stored.access_secret, Some(old_access));
+}
+
+#[tokio::test]
+async fn provider_backed_refresh_if_unchanged_skips_stale_marker() {
+    let services = Arc::new(InMemoryAuthProductServices::new());
+    let auth = provider_backed_auth(services.clone());
+    let owner = scope("alice");
+    let old_access = SecretHandle::new("github-stale-marker-access").unwrap();
+    let account = auth
+        .create_account(NewCredentialAccount {
+            scope: owner.clone(),
+            provider: provider(),
+            label: label("stale marker"),
+            status: CredentialAccountStatus::Configured,
+            ownership: CredentialOwnership::UserReusable,
+            owner_extension: None,
+            granted_extensions: Vec::new(),
+            access_secret: Some(old_access.clone()),
+            refresh_secret: Some(SecretHandle::new("github-stale-marker-refresh").unwrap()),
+            scopes: provider_scopes(&["repo"]),
+        })
+        .await
+        .expect("configured account");
+    auth.update_status(&owner, account.id, CredentialAccountStatus::Expired)
+        .await
+        .expect("touch account after marker staging");
+
+    let report = auth
+        .refresh_if_unchanged(
+            CredentialRefreshRequest::new(owner.clone(), provider(), account.id),
+            account.updated_at,
+        )
+        .await
+        .expect("conditional refresh");
+
+    assert_eq!(report, None);
+    let stored = auth
+        .get_account(CredentialAccountLookupRequest::new(owner, account.id))
+        .await
+        .expect("lookup")
+        .expect("stale account");
+    assert_eq!(stored.status, CredentialAccountStatus::Expired);
+    assert_eq!(stored.access_secret, Some(old_access));
+}
+
+#[tokio::test]
 async fn credential_refresh_rejects_terminal_statuses_even_with_refresh_secret() {
     let services = InMemoryAuthProductServices::new();
     let owner = scope("alice");

--- a/crates/ironclaw_first_party_extensions/src/gsuite/handlers.rs
+++ b/crates/ironclaw_first_party_extensions/src/gsuite/handlers.rs
@@ -1346,6 +1346,7 @@ mod tests {
             request_bytes: 0,
             response_bytes: 0,
             redaction_applied: false,
+            credential_unauthorized: None,
         };
         assert!(is_google_auth_expired_response(&response));
 
@@ -1357,6 +1358,7 @@ mod tests {
             request_bytes: 0,
             response_bytes: 0,
             redaction_applied: false,
+            credential_unauthorized: None,
         };
         assert!(!is_google_auth_expired_response(&response));
     }
@@ -1485,6 +1487,7 @@ mod tests {
             request_bytes: 0,
             response_bytes: 0,
             redaction_applied: false,
+            credential_unauthorized: None,
         };
         assert_eq!(
             response_etag(&response, &serde_json::json!({"etag": "body-etag"})),

--- a/crates/ironclaw_first_party_extensions/src/web_access.rs
+++ b/crates/ironclaw_first_party_extensions/src/web_access.rs
@@ -839,6 +839,7 @@ mod tests {
                 request_bytes: 10,
                 response_bytes: 20,
                 redaction_applied: false,
+                credential_unauthorized: None,
             }
         }
 
@@ -851,6 +852,7 @@ mod tests {
                 request_bytes: 5,
                 response_bytes: 0,
                 redaction_applied: false,
+                credential_unauthorized: None,
             }
         }
 

--- a/crates/ironclaw_first_party_extensions/tests/support/mod.rs
+++ b/crates/ironclaw_first_party_extensions/tests/support/mod.rs
@@ -82,6 +82,7 @@ impl RecordingEgress {
             body,
             saved_body: None,
             redaction_applied: true,
+            credential_unauthorized: None,
         }
     }
 
@@ -94,6 +95,7 @@ impl RecordingEgress {
             request_bytes: 123,
             response_bytes: 0,
             redaction_applied: true,
+            credential_unauthorized: None,
         }
     }
 
@@ -110,6 +112,7 @@ impl RecordingEgress {
             body,
             saved_body: None,
             redaction_applied: true,
+            credential_unauthorized: None,
         }
     }
 
@@ -122,6 +125,7 @@ impl RecordingEgress {
             body: b"{".to_vec(),
             saved_body: None,
             redaction_applied: true,
+            credential_unauthorized: None,
         }
     }
 

--- a/crates/ironclaw_host_api/src/http.rs
+++ b/crates/ironclaw_host_api/src/http.rs
@@ -11,8 +11,8 @@ use thiserror::Error;
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use crate::{
-    CapabilityId, HostApiError, MountGrant, NetworkMethod, NetworkPolicy, ResourceScope,
-    RuntimeKind, ScopedPath, SecretHandle,
+    CapabilityId, ExtensionId, HostApiError, MountGrant, NetworkMethod, NetworkPolicy,
+    ResourceScope, RuntimeCredentialAccountProviderId, RuntimeKind, ScopedPath, SecretHandle,
 };
 
 /// Runtime HTTP request accepted by the host-owned egress service.
@@ -107,6 +107,61 @@ pub struct RuntimeCredentialInjection {
     pub source: RuntimeCredentialSource,
     pub target: RuntimeCredentialTarget,
     pub required: bool,
+}
+
+/// Product-auth account identity associated with a host-staged runtime
+/// credential.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RuntimeCredentialAccountIdentity {
+    pub scope: ResourceScope,
+    pub account_provider: RuntimeCredentialAccountProviderId,
+    pub account_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub account_updated_at: Option<crate::Timestamp>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requester_extension: Option<ExtensionId>,
+    #[serde(default)]
+    pub unauthorized_policy: RuntimeCredentialUnauthorizedPolicy,
+}
+
+impl RuntimeCredentialAccountIdentity {
+    pub fn new(
+        scope: ResourceScope,
+        account_provider: RuntimeCredentialAccountProviderId,
+        account_id: impl Into<String>,
+        account_updated_at: Option<crate::Timestamp>,
+        unauthorized_policy: RuntimeCredentialUnauthorizedPolicy,
+    ) -> Self {
+        Self {
+            scope,
+            account_provider,
+            account_id: account_id.into(),
+            account_updated_at,
+            requester_extension: None,
+            unauthorized_policy,
+        }
+    }
+
+    pub fn with_requester_extension(mut self, requester_extension: Option<ExtensionId>) -> Self {
+        self.requester_extension = requester_extension;
+        self
+    }
+
+    pub fn marker_on_unauthorized(&self) -> Option<RuntimeCredentialUnauthorized> {
+        if self.account_updated_at.is_some() {
+            Some(self.clone())
+        } else {
+            None
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeCredentialUnauthorizedPolicy {
+    #[default]
+    RevokeAccount,
+    RefreshAccount,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -255,6 +310,8 @@ pub struct RuntimeHttpEgressResponse {
     pub request_bytes: u64,
     pub response_bytes: u64,
     pub redaction_applied: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub credential_unauthorized: Option<RuntimeCredentialUnauthorized>,
 }
 
 pub const RUNTIME_HTTP_REASON_RESPONSE_BODY_LIMIT_EXCEEDED: &str = "response_body_limit_exceeded";
@@ -274,6 +331,10 @@ pub struct RuntimeHttpSavedBody {
     pub path: ScopedPath,
     pub bytes_written: u64,
 }
+
+/// Typed signal that a response came back unauthorized for an injected
+/// product-auth credential.
+pub type RuntimeCredentialUnauthorized = RuntimeCredentialAccountIdentity;
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum RuntimeHttpEgressError {

--- a/crates/ironclaw_host_api/src/http.rs
+++ b/crates/ironclaw_host_api/src/http.rs
@@ -12,7 +12,8 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use crate::{
     CapabilityId, ExtensionId, HostApiError, MountGrant, NetworkMethod, NetworkPolicy,
-    ResourceScope, RuntimeCredentialAccountProviderId, RuntimeKind, ScopedPath, SecretHandle,
+    ResourceScope, RuntimeCredentialAccountProviderId, RuntimeCredentialAuthRequirement,
+    RuntimeKind, ScopedPath, SecretHandle,
 };
 
 /// Runtime HTTP request accepted by the host-owned egress service.
@@ -120,6 +121,8 @@ pub struct RuntimeCredentialAccountIdentity {
     pub account_updated_at: Option<crate::Timestamp>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub requester_extension: Option<ExtensionId>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auth_requirement: Option<RuntimeCredentialAuthRequirement>,
     #[serde(default)]
     pub unauthorized_policy: RuntimeCredentialUnauthorizedPolicy,
 }
@@ -138,6 +141,7 @@ impl RuntimeCredentialAccountIdentity {
             account_id: account_id.into(),
             account_updated_at,
             requester_extension: None,
+            auth_requirement: None,
             unauthorized_policy,
         }
     }
@@ -147,12 +151,24 @@ impl RuntimeCredentialAccountIdentity {
         self
     }
 
+    pub fn with_auth_requirement(
+        mut self,
+        auth_requirement: RuntimeCredentialAuthRequirement,
+    ) -> Self {
+        self.auth_requirement = Some(auth_requirement);
+        self
+    }
+
     pub fn marker_on_unauthorized(&self) -> Option<RuntimeCredentialUnauthorized> {
-        if self.account_updated_at.is_some() {
-            Some(self.clone())
-        } else {
-            None
-        }
+        Some(RuntimeCredentialUnauthorized {
+            scope: self.scope.clone(),
+            account_provider: self.account_provider.clone(),
+            account_id: self.account_id.clone(),
+            account_updated_at: self.account_updated_at?,
+            requester_extension: self.requester_extension.clone(),
+            auth_requirement: self.auth_requirement.clone()?,
+            unauthorized_policy: self.unauthorized_policy,
+        })
     }
 }
 
@@ -334,7 +350,37 @@ pub struct RuntimeHttpSavedBody {
 
 /// Typed signal that a response came back unauthorized for an injected
 /// product-auth credential.
-pub type RuntimeCredentialUnauthorized = RuntimeCredentialAccountIdentity;
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RuntimeCredentialUnauthorized {
+    pub scope: ResourceScope,
+    pub account_provider: RuntimeCredentialAccountProviderId,
+    pub account_id: String,
+    pub account_updated_at: crate::Timestamp,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requester_extension: Option<ExtensionId>,
+    pub auth_requirement: RuntimeCredentialAuthRequirement,
+    #[serde(default)]
+    pub unauthorized_policy: RuntimeCredentialUnauthorizedPolicy,
+}
+
+impl RuntimeCredentialUnauthorized {
+    pub fn account_key(&self) -> RuntimeCredentialUnauthorizedAccountKey {
+        RuntimeCredentialUnauthorizedAccountKey {
+            scope: self.scope.clone(),
+            account_provider: self.account_provider.clone(),
+            account_id: self.account_id.clone(),
+            account_updated_at: self.account_updated_at,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RuntimeCredentialUnauthorizedAccountKey {
+    pub scope: ResourceScope,
+    pub account_provider: RuntimeCredentialAccountProviderId,
+    pub account_id: String,
+    pub account_updated_at: crate::Timestamp,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum RuntimeHttpEgressError {

--- a/crates/ironclaw_host_api/tests/host_api_contract.rs
+++ b/crates/ironclaw_host_api/tests/host_api_contract.rs
@@ -1124,6 +1124,7 @@ fn runtime_http_egress_response_defaults_optional_saved_body() {
         request_bytes: 0,
         response_bytes: 2,
         redaction_applied: false,
+        credential_unauthorized: None,
     })
     .unwrap();
 
@@ -1131,6 +1132,60 @@ fn runtime_http_egress_response_defaults_optional_saved_body() {
 
     let response: RuntimeHttpEgressResponse = serde_json::from_value(value).unwrap();
     assert_eq!(response.saved_body, None);
+}
+
+#[test]
+fn runtime_http_egress_response_round_trips_optional_credential_unauthorized() {
+    let invocation_id = InvocationId::new();
+    let scope = ResourceScope::local_default(UserId::new("alice").unwrap(), invocation_id).unwrap();
+    let updated_at = Timestamp::from_timestamp_secs(1).unwrap();
+    let mut value = serde_json::to_value(RuntimeHttpEgressResponse {
+        status: 401,
+        headers: vec![],
+        body: b"unauthorized".to_vec(),
+        saved_body: None,
+        request_bytes: 32,
+        response_bytes: 12,
+        redaction_applied: true,
+        credential_unauthorized: Some(
+            RuntimeCredentialUnauthorized::new(
+                scope.clone(),
+                RuntimeCredentialAccountProviderId::new("github").unwrap(),
+                "account-123",
+                Some(updated_at),
+                RuntimeCredentialUnauthorizedPolicy::RevokeAccount,
+            )
+            .with_requester_extension(Some(ExtensionId::new("github").unwrap())),
+        ),
+    })
+    .unwrap();
+
+    let response: RuntimeHttpEgressResponse = serde_json::from_value(value.clone()).unwrap();
+    let rejected = response
+        .credential_unauthorized
+        .expect("populated marker should round-trip");
+    assert_eq!(rejected.scope, scope);
+    assert_eq!(
+        rejected.account_provider,
+        RuntimeCredentialAccountProviderId::new("github").unwrap()
+    );
+    assert_eq!(rejected.account_id, "account-123");
+    assert_eq!(rejected.account_updated_at, Some(updated_at));
+    assert_eq!(
+        rejected.requester_extension,
+        Some(ExtensionId::new("github").unwrap())
+    );
+    assert_eq!(
+        rejected.unauthorized_policy,
+        RuntimeCredentialUnauthorizedPolicy::RevokeAccount
+    );
+
+    value
+        .as_object_mut()
+        .unwrap()
+        .remove("credential_unauthorized");
+    let response_without_marker: RuntimeHttpEgressResponse = serde_json::from_value(value).unwrap();
+    assert_eq!(response_without_marker.credential_unauthorized, None);
 }
 
 #[test]

--- a/crates/ironclaw_host_api/tests/host_api_contract.rs
+++ b/crates/ironclaw_host_api/tests/host_api_contract.rs
@@ -1147,16 +1147,20 @@ fn runtime_http_egress_response_round_trips_optional_credential_unauthorized() {
         request_bytes: 32,
         response_bytes: 12,
         redaction_applied: true,
-        credential_unauthorized: Some(
-            RuntimeCredentialUnauthorized::new(
-                scope.clone(),
-                RuntimeCredentialAccountProviderId::new("github").unwrap(),
-                "account-123",
-                Some(updated_at),
-                RuntimeCredentialUnauthorizedPolicy::RevokeAccount,
-            )
-            .with_requester_extension(Some(ExtensionId::new("github").unwrap())),
-        ),
+        credential_unauthorized: Some(RuntimeCredentialUnauthorized {
+            scope: scope.clone(),
+            account_provider: RuntimeCredentialAccountProviderId::new("github").unwrap(),
+            account_id: "account-123".to_string(),
+            account_updated_at: updated_at,
+            requester_extension: Some(ExtensionId::new("github").unwrap()),
+            auth_requirement: RuntimeCredentialAuthRequirement {
+                provider: RuntimeCredentialAccountProviderId::new("github").unwrap(),
+                setup: RuntimeCredentialAccountSetup::ManualToken,
+                requester_extension: ExtensionId::new("github").unwrap(),
+                provider_scopes: Vec::new(),
+            },
+            unauthorized_policy: RuntimeCredentialUnauthorizedPolicy::RevokeAccount,
+        }),
     })
     .unwrap();
 
@@ -1170,7 +1174,11 @@ fn runtime_http_egress_response_round_trips_optional_credential_unauthorized() {
         RuntimeCredentialAccountProviderId::new("github").unwrap()
     );
     assert_eq!(rejected.account_id, "account-123");
-    assert_eq!(rejected.account_updated_at, Some(updated_at));
+    assert_eq!(rejected.account_updated_at, updated_at);
+    assert_eq!(
+        rejected.auth_requirement.provider,
+        RuntimeCredentialAccountProviderId::new("github").unwrap()
+    );
     assert_eq!(
         rejected.requester_extension,
         Some(ExtensionId::new("github").unwrap())

--- a/crates/ironclaw_host_runtime/src/egress/credential.rs
+++ b/crates/ironclaw_host_runtime/src/egress/credential.rs
@@ -1,14 +1,15 @@
 use ironclaw_host_api::{
-    CapabilityId, RuntimeCredentialInjection, RuntimeCredentialSource, RuntimeCredentialTarget,
+    CapabilityId, RuntimeCredentialAccountIdentity, RuntimeCredentialInjection,
+    RuntimeCredentialSource, RuntimeCredentialTarget, RuntimeCredentialUnauthorized,
     RuntimeHttpEgressError, RuntimeHttpEgressRequest, RuntimeKind, SecretHandle,
 };
 use ironclaw_network::is_rfc3986_unreserved_segment;
 use ironclaw_safety::redaction_values_for_secret;
-use ironclaw_secrets::{SecretMaterial, SecretStore, SecretStoreError};
+use ironclaw_secrets::{SecretStore, SecretStoreError};
 use secrecy::ExposeSecret;
 use std::sync::LazyLock;
 
-use crate::obligations::RuntimeSecretInjectionStore;
+use crate::obligations::{RuntimeSecretInjectionStore, RuntimeStagedSecretMaterial};
 
 #[derive(Clone, PartialEq, Eq)]
 enum CredentialCacheKey {
@@ -28,7 +29,12 @@ struct CredentialCacheEntry {
     /// end of the egress call. Holding plaintext as `String` here instead
     /// would leave the credential on the heap for the duration of the request,
     /// defeating `SecretMaterial::ZeroizeOnDrop`.
-    value: Option<SecretMaterial>,
+    value: Option<RuntimeStagedSecretMaterial>,
+}
+
+pub(super) struct CredentialInjectionResult {
+    pub(super) redaction_values: Vec<String>,
+    pub(super) credential_unauthorized: Option<RuntimeCredentialUnauthorized>,
 }
 
 enum CredentialSourceStrategy<'a> {
@@ -88,7 +94,7 @@ impl<'a> CredentialSourceStrategy<'a> {
         secret_injections: Option<&RuntimeSecretInjectionStore>,
         request: &RuntimeHttpEgressRequest,
         injection: &RuntimeCredentialInjection,
-    ) -> Result<Option<SecretMaterial>, RuntimeHttpEgressError>
+    ) -> Result<Option<RuntimeStagedSecretMaterial>, RuntimeHttpEgressError>
     where
         S: SecretStore,
     {
@@ -114,12 +120,14 @@ pub(super) fn apply_credential_injections<S>(
     secrets: &S,
     secret_injections: Option<&RuntimeSecretInjectionStore>,
     request: &mut RuntimeHttpEgressRequest,
-) -> Result<Vec<String>, RuntimeHttpEgressError>
+) -> Result<CredentialInjectionResult, RuntimeHttpEgressError>
 where
     S: SecretStore,
 {
     let mut redaction_values = Vec::new();
     let mut credential_materials = Vec::new();
+    let mut unauthorized_identity = None::<RuntimeCredentialUnauthorized>;
+    let mut ambiguous_unauthorized_identity = false;
     let mut parsed_url = None;
     let credential_injections = std::mem::take(&mut request.credential_injections);
     for injection in &credential_injections {
@@ -148,7 +156,12 @@ where
         // injection because the network layer and response-body scanner
         // consume raw bytes, but the cache itself never holds a non-zeroizing
         // copy.
-        let plaintext = value.expose_secret();
+        record_unauthorized_identity(
+            &value.credential_account,
+            &mut unauthorized_identity,
+            &mut ambiguous_unauthorized_identity,
+        );
+        let plaintext = value.material.expose_secret();
         if let Err(error) =
             apply_credential_injection(request, &mut parsed_url, &injection.target, plaintext)
         {
@@ -161,7 +174,14 @@ where
     if let Some(url) = parsed_url {
         request.url = url.to_string();
     }
-    Ok(redaction_values)
+    Ok(CredentialInjectionResult {
+        redaction_values,
+        credential_unauthorized: if ambiguous_unauthorized_identity {
+            None
+        } else {
+            unauthorized_identity
+        },
+    })
 }
 
 fn restore_staged_secrets(
@@ -181,14 +201,18 @@ fn restore_staged_secrets(
                 capability_id,
                 handle,
             },
-            Some(material),
+            Some(staged),
         ) = (entry.key, entry.value)
         else {
             continue;
         };
-        if let Err(error) =
-            secret_injections.insert(&request.scope, &capability_id, &handle, material)
-        {
+        if let Err(error) = secret_injections.insert_with_credential_account(
+            &request.scope,
+            &capability_id,
+            &handle,
+            staged.material,
+            staged.credential_account,
+        ) {
             tracing::debug!(
                 error = ?error,
                 capability_id = %capability_id,
@@ -204,7 +228,7 @@ fn credential_value_for_injection<'cache, S>(
     secret_injections: Option<&RuntimeSecretInjectionStore>,
     request: &RuntimeHttpEgressRequest,
     injection: &RuntimeCredentialInjection,
-) -> Result<Option<&'cache SecretMaterial>, RuntimeHttpEgressError>
+) -> Result<Option<&'cache RuntimeStagedSecretMaterial>, RuntimeHttpEgressError>
 where
     S: SecretStore,
 {
@@ -233,14 +257,18 @@ fn staged_secret_for_injection(
     request: &RuntimeHttpEgressRequest,
     capability_id: &CapabilityId,
     injection: &RuntimeCredentialInjection,
-) -> Result<Option<SecretMaterial>, RuntimeHttpEgressError> {
+) -> Result<Option<RuntimeStagedSecretMaterial>, RuntimeHttpEgressError> {
     let Some(secret_injections) = secret_injections else {
         return missing_runtime_credential(injection.required);
     };
     let material = if runtime_reuses_staged_credentials(request.runtime) {
-        secret_injections.clone_material(&request.scope, capability_id, &injection.handle)
+        secret_injections.clone_material_with_metadata(
+            &request.scope,
+            capability_id,
+            &injection.handle,
+        )
     } else {
-        secret_injections.take(&request.scope, capability_id, &injection.handle)
+        secret_injections.take_with_metadata(&request.scope, capability_id, &injection.handle)
     };
     match material {
         Ok(Some(material)) => Ok(Some(material)),
@@ -248,6 +276,26 @@ fn staged_secret_for_injection(
         Err(_) => Err(RuntimeHttpEgressError::Credential {
             reason: "runtime credential injection store unavailable".to_string(),
         }),
+    }
+}
+
+fn record_unauthorized_identity(
+    account: &Option<RuntimeCredentialAccountIdentity>,
+    unauthorized_identity: &mut Option<RuntimeCredentialUnauthorized>,
+    ambiguous_unauthorized_identity: &mut bool,
+) {
+    let Some(account) = account else {
+        return;
+    };
+    let Some(candidate) = account.marker_on_unauthorized() else {
+        return;
+    };
+    if let Some(existing) = unauthorized_identity {
+        if existing != &candidate {
+            *ambiguous_unauthorized_identity = true;
+        }
+    } else {
+        *unauthorized_identity = Some(candidate);
     }
 }
 
@@ -259,7 +307,7 @@ fn runtime_reuses_staged_credentials(runtime: RuntimeKind) -> bool {
 
 fn missing_runtime_credential(
     required: bool,
-) -> Result<Option<SecretMaterial>, RuntimeHttpEgressError> {
+) -> Result<Option<RuntimeStagedSecretMaterial>, RuntimeHttpEgressError> {
     if required {
         Err(RuntimeHttpEgressError::Credential {
             reason: "required credential is unavailable".to_string(),
@@ -273,7 +321,7 @@ fn lease_secret_for_injection<S>(
     secrets: &S,
     request: &RuntimeHttpEgressRequest,
     injection: &RuntimeCredentialInjection,
-) -> Result<Option<SecretMaterial>, RuntimeHttpEgressError>
+) -> Result<Option<RuntimeStagedSecretMaterial>, RuntimeHttpEgressError>
 where
     S: SecretStore,
 {
@@ -287,7 +335,10 @@ where
             .await?;
         secrets.consume(&request.scope, lease.id).await.map(Some)
     }) {
-        Ok(Some(material)) => Ok(Some(material)),
+        Ok(Some(material)) => Ok(Some(RuntimeStagedSecretMaterial {
+            material,
+            credential_account: None,
+        })),
         Ok(None) => missing_runtime_credential(injection.required),
         Err(SecretStoreError::UnknownSecret { .. }) => {
             missing_runtime_credential(injection.required)
@@ -461,7 +512,7 @@ fn parsed_request_url<'a>(
 const _: fn(&CredentialCacheEntry) = |entry| {
     fn require_zeroize_on_drop<T: ?Sized + secrecy::zeroize::ZeroizeOnDrop>(_: &T) {}
     if let Some(value) = entry.value.as_ref() {
-        require_zeroize_on_drop(value);
+        require_zeroize_on_drop(&value.material);
     }
 };
 
@@ -472,6 +523,7 @@ mod tests {
         InvocationId, NetworkMethod, NetworkPolicy, ResourceScope, RuntimeKind, TenantId,
         Timestamp, UserId,
     };
+    use ironclaw_secrets::SecretMaterial;
     use ironclaw_secrets::{
         InMemorySecretStore, SecretLease, SecretLeaseId, SecretMetadata, SecretStoreError,
     };
@@ -600,7 +652,7 @@ mod tests {
                 .expect("tokio-backed secret store should resolve through the sync bridge")
                 .expect("required credential should be present");
 
-        assert_eq!(material.expose_secret(), "sk-test-secret");
+        assert_eq!(material.material.expose_secret(), "sk-test-secret");
     }
 
     fn credential_reason(error: &RuntimeHttpEgressError) -> &str {

--- a/crates/ironclaw_host_runtime/src/egress/host_port.rs
+++ b/crates/ironclaw_host_runtime/src/egress/host_port.rs
@@ -5,9 +5,10 @@ use ironclaw_capabilities::{
 };
 use ironclaw_host_api::{
     CapabilityId, CapabilitySet, ExecutionContext, ExtensionId, MountView, Obligation,
-    ResourceEstimate, ResourceScope, RuntimeCredentialInjection, RuntimeCredentialSource,
-    RuntimeCredentialTarget, RuntimeHttpEgress, RuntimeHttpEgressError, RuntimeHttpEgressRequest,
-    RuntimeHttpEgressResponse, RuntimeKind, SecretHandle, TrustClass,
+    ResourceEstimate, ResourceScope, RuntimeCredentialAccountIdentity, RuntimeCredentialInjection,
+    RuntimeCredentialSource, RuntimeCredentialTarget, RuntimeCredentialUnauthorized,
+    RuntimeHttpEgress, RuntimeHttpEgressError, RuntimeHttpEgressRequest, RuntimeHttpEgressResponse,
+    RuntimeKind, SecretHandle, TrustClass,
 };
 use ironclaw_secrets::SecretMaterial;
 
@@ -40,8 +41,32 @@ impl RuntimeSecretMaterialStager {
         handle: &SecretHandle,
         material: SecretMaterial,
     ) -> Result<(), RuntimeSecretStageError> {
+        self.stage_secret_material_once_with_account(
+            target_scope,
+            capability_id,
+            handle,
+            material,
+            None,
+        )
+        .await
+    }
+
+    pub async fn stage_secret_material_once_with_account(
+        &self,
+        target_scope: &ResourceScope,
+        capability_id: &CapabilityId,
+        handle: &SecretHandle,
+        material: SecretMaterial,
+        credential_account: Option<RuntimeCredentialAccountIdentity>,
+    ) -> Result<(), RuntimeSecretStageError> {
         self.secret_injection_store
-            .insert(target_scope, capability_id, handle, material)
+            .insert_with_credential_account(
+                target_scope,
+                capability_id,
+                handle,
+                material,
+                credential_account,
+            )
             .map_err(|_| RuntimeSecretStageError::Backend)
     }
 
@@ -82,6 +107,7 @@ pub struct HostRuntimeCredentialMaterial {
     pub material: SecretMaterial,
     pub target: RuntimeCredentialTarget,
     pub required: bool,
+    pub credential_account: Option<RuntimeCredentialAccountIdentity>,
 }
 
 impl HostRuntimeHttpEgressPort {
@@ -111,17 +137,32 @@ impl HostRuntimeHttpEgressPort {
         let staged_scope = request.request.scope.clone();
         let staged_capability_id = request.request.capability_id.clone();
         let staged_credentials = !request.credentials.is_empty();
-        if let Err(error) = self
+        let staged_unauthorized_identity = match self
             .stage_credentials(&mut request.request, request.credentials)
             .await
         {
-            if staged_credentials {
-                self.secret_stager
-                    .discard_secret_material_for_capability(&staged_scope, &staged_capability_id);
+            Ok(identity) => identity,
+            Err(error) => {
+                if staged_credentials {
+                    self.secret_stager.discard_secret_material_for_capability(
+                        &staged_scope,
+                        &staged_capability_id,
+                    );
+                }
+                return Err(error);
             }
-            return Err(error);
-        }
-        let result = self.runtime_http_egress.execute(request.request).await;
+        };
+        let result = self
+            .runtime_http_egress
+            .execute(request.request)
+            .await
+            .map(|mut response| {
+                super::attach_credential_unauthorized_on_401(
+                    &mut response,
+                    staged_unauthorized_identity,
+                );
+                response
+            });
         if staged_credentials {
             self.secret_stager
                 .discard_secret_material_for_capability(&staged_scope, &staged_capability_id);
@@ -133,19 +174,34 @@ impl HostRuntimeHttpEgressPort {
         &self,
         request: &mut RuntimeHttpEgressRequest,
         credentials: Vec<HostRuntimeCredentialMaterial>,
-    ) -> Result<(), RuntimeHttpEgressError> {
+    ) -> Result<Option<RuntimeCredentialUnauthorized>, RuntimeHttpEgressError> {
+        let mut unauthorized_identity = None::<RuntimeCredentialUnauthorized>;
+        let mut ambiguous_unauthorized_identity = false;
         for credential in credentials {
+            let credential_account = credential.credential_account.clone();
             self.secret_stager
-                .stage_secret_material_once(
+                .stage_secret_material_once_with_account(
                     &request.scope,
                     &request.capability_id,
                     &credential.handle,
                     credential.material,
+                    credential_account.clone(),
                 )
                 .await
                 .map_err(|_| RuntimeHttpEgressError::Credential {
                     reason: "host credential material could not be staged".to_string(),
                 })?;
+            if let Some(account) = credential_account
+                && let Some(candidate) = account.marker_on_unauthorized()
+            {
+                if let Some(existing) = &unauthorized_identity {
+                    if existing != &candidate {
+                        ambiguous_unauthorized_identity = true;
+                    }
+                } else {
+                    unauthorized_identity = Some(candidate);
+                }
+            }
             request
                 .credential_injections
                 .push(RuntimeCredentialInjection {
@@ -157,7 +213,11 @@ impl HostRuntimeHttpEgressPort {
                     required: credential.required,
                 });
         }
-        Ok(())
+        Ok(if ambiguous_unauthorized_identity {
+            None
+        } else {
+            unauthorized_identity
+        })
     }
 
     async fn authorize_network_egress(
@@ -238,6 +298,7 @@ mod tests {
     };
     use ironclaw_host_api::{
         InvocationId, NetworkMethod, NetworkPolicy, NetworkScheme, NetworkTargetPattern,
+        RuntimeCredentialAccountProviderId, RuntimeCredentialUnauthorizedPolicy,
         RuntimeHttpEgressResponse, UserId,
     };
 
@@ -276,16 +337,21 @@ mod tests {
 
     impl RecordingRuntimeHttpEgress {
         fn ok() -> Self {
+            Self::responding(200)
+        }
+
+        fn responding(status: u16) -> Self {
             Self {
                 calls: AtomicUsize::new(0),
                 response: Ok(RuntimeHttpEgressResponse {
-                    status: 200,
+                    status,
                     headers: Vec::new(),
                     body: Vec::new(),
                     saved_body: None,
                     request_bytes: 0,
                     response_bytes: 0,
                     redaction_applied: false,
+                    credential_unauthorized: None,
                 }),
             }
         }
@@ -382,6 +448,7 @@ mod tests {
                 prefix: Some("Bearer ".to_string()),
             },
             required: true,
+            credential_account: None,
         });
 
         let error = port
@@ -396,6 +463,155 @@ mod tests {
                 .expect("staged secret store should be readable")
                 .is_none(),
             "host-staged material should be discarded after delegate failure"
+        );
+    }
+
+    #[tokio::test]
+    async fn host_runtime_http_egress_attaches_credential_unauthorized_marker_on_401_only() {
+        let egress = Arc::new(RecordingRuntimeHttpEgress::responding(401));
+        let port = host_port(egress, Arc::new(AllowObligations), secret_store());
+        let mut request = host_request();
+        let scope = request.request.scope.clone();
+        let account_id = "product-auth-account-123".to_string();
+        request.credentials.push(HostRuntimeCredentialMaterial {
+            handle: SecretHandle::new(account_id.clone()).expect("secret handle"),
+            material: SecretMaterial::from("host-held-token"),
+            target: RuntimeCredentialTarget::Header {
+                name: "authorization".to_string(),
+                prefix: Some("Bearer ".to_string()),
+            },
+            required: true,
+            credential_account: Some(RuntimeCredentialAccountIdentity {
+                scope: scope.clone(),
+                account_provider: RuntimeCredentialAccountProviderId::new("github")
+                    .expect("provider"),
+                account_id: account_id.clone(),
+                account_updated_at: Some(chrono::Utc::now()),
+                requester_extension: None,
+                unauthorized_policy: RuntimeCredentialUnauthorizedPolicy::RevokeAccount,
+            }),
+        });
+
+        let response = port
+            .execute(request)
+            .await
+            .expect("401 response should still succeed");
+
+        let rejection = response
+            .credential_unauthorized
+            .expect("401 with an injected credential should attach unauthorized marker");
+        assert_eq!(rejection.scope, scope);
+        assert_eq!(rejection.account_id, account_id);
+    }
+
+    #[tokio::test]
+    async fn host_runtime_http_egress_skips_credential_unauthorized_marker_when_ambiguous() {
+        let egress = Arc::new(RecordingRuntimeHttpEgress::responding(401));
+        let port = host_port(egress, Arc::new(AllowObligations), secret_store());
+        let mut request = host_request();
+        let scope = request.request.scope.clone();
+        for account_id in ["product-auth-account-123", "product-auth-account-456"] {
+            request.credentials.push(HostRuntimeCredentialMaterial {
+                handle: SecretHandle::new(account_id).expect("secret handle"),
+                material: SecretMaterial::from("host-held-token"),
+                target: RuntimeCredentialTarget::Header {
+                    name: format!("x-token-{account_id}"),
+                    prefix: None,
+                },
+                required: true,
+                credential_account: Some(RuntimeCredentialAccountIdentity {
+                    scope: scope.clone(),
+                    account_provider: RuntimeCredentialAccountProviderId::new("github")
+                        .expect("provider"),
+                    account_id: account_id.to_string(),
+                    account_updated_at: Some(chrono::Utc::now()),
+                    requester_extension: None,
+                    unauthorized_policy: RuntimeCredentialUnauthorizedPolicy::RevokeAccount,
+                }),
+            });
+        }
+
+        let response = port
+            .execute(request)
+            .await
+            .expect("401 response should still succeed");
+
+        assert!(
+            response.credential_unauthorized.is_none(),
+            "a 401 with multiple credential accounts must not guess which account was rejected"
+        );
+    }
+
+    #[tokio::test]
+    async fn host_runtime_http_egress_does_not_attach_credential_unauthorized_marker_on_403() {
+        let egress = Arc::new(RecordingRuntimeHttpEgress::responding(403));
+        let port = host_port(egress, Arc::new(AllowObligations), secret_store());
+        let mut request = host_request();
+        request.credentials.push(HostRuntimeCredentialMaterial {
+            handle: secret_handle(),
+            material: SecretMaterial::from("host-held-token"),
+            target: RuntimeCredentialTarget::Header {
+                name: "authorization".to_string(),
+                prefix: Some("Bearer ".to_string()),
+            },
+            required: true,
+            credential_account: Some(RuntimeCredentialAccountIdentity {
+                scope: request.request.scope.clone(),
+                account_provider: RuntimeCredentialAccountProviderId::new("github")
+                    .expect("provider"),
+                account_id: "product-auth-account-123".to_string(),
+                account_updated_at: Some(chrono::Utc::now()),
+                requester_extension: None,
+                unauthorized_policy: RuntimeCredentialUnauthorizedPolicy::RevokeAccount,
+            }),
+        });
+
+        let response = port
+            .execute(request)
+            .await
+            .expect("403 response should still succeed");
+
+        assert!(
+            response.credential_unauthorized.is_none(),
+            "403 must not attach a credential unauthorized marker"
+        );
+    }
+
+    #[tokio::test]
+    async fn host_runtime_http_egress_attaches_refresh_policy_marker_on_401() {
+        let egress = Arc::new(RecordingRuntimeHttpEgress::responding(401));
+        let port = host_port(egress, Arc::new(AllowObligations), secret_store());
+        let mut request = host_request();
+        request.credentials.push(HostRuntimeCredentialMaterial {
+            handle: secret_handle(),
+            material: SecretMaterial::from("host-held-oauth-access-token"),
+            target: RuntimeCredentialTarget::Header {
+                name: "authorization".to_string(),
+                prefix: Some("Bearer ".to_string()),
+            },
+            required: true,
+            credential_account: Some(RuntimeCredentialAccountIdentity {
+                scope: request.request.scope.clone(),
+                account_provider: RuntimeCredentialAccountProviderId::new("google")
+                    .expect("provider"),
+                account_id: "oauth-account-123".to_string(),
+                account_updated_at: Some(chrono::Utc::now()),
+                requester_extension: None,
+                unauthorized_policy: RuntimeCredentialUnauthorizedPolicy::RefreshAccount,
+            }),
+        });
+
+        let response = port
+            .execute(request)
+            .await
+            .expect("401 response should still succeed");
+
+        assert_eq!(
+            response
+                .credential_unauthorized
+                .expect("refreshable account should emit a recovery marker")
+                .unauthorized_policy,
+            RuntimeCredentialUnauthorizedPolicy::RefreshAccount
         );
     }
 

--- a/crates/ironclaw_host_runtime/src/egress/host_port.rs
+++ b/crates/ironclaw_host_runtime/src/egress/host_port.rs
@@ -297,8 +297,9 @@ mod tests {
         CapabilityObligationError, CapabilityObligationFailureKind, CapabilityObligationRequest,
     };
     use ironclaw_host_api::{
-        InvocationId, NetworkMethod, NetworkPolicy, NetworkScheme, NetworkTargetPattern,
-        RuntimeCredentialAccountProviderId, RuntimeCredentialUnauthorizedPolicy,
+        ExtensionId, InvocationId, NetworkMethod, NetworkPolicy, NetworkScheme,
+        NetworkTargetPattern, RuntimeCredentialAccountProviderId, RuntimeCredentialAccountSetup,
+        RuntimeCredentialAuthRequirement, RuntimeCredentialUnauthorizedPolicy,
         RuntimeHttpEgressResponse, UserId,
     };
 
@@ -488,6 +489,7 @@ mod tests {
                 account_id: account_id.clone(),
                 account_updated_at: Some(chrono::Utc::now()),
                 requester_extension: None,
+                auth_requirement: Some(auth_requirement("github")),
                 unauthorized_policy: RuntimeCredentialUnauthorizedPolicy::RevokeAccount,
             }),
         });
@@ -526,6 +528,7 @@ mod tests {
                     account_id: account_id.to_string(),
                     account_updated_at: Some(chrono::Utc::now()),
                     requester_extension: None,
+                    auth_requirement: Some(auth_requirement("github")),
                     unauthorized_policy: RuntimeCredentialUnauthorizedPolicy::RevokeAccount,
                 }),
             });
@@ -539,6 +542,65 @@ mod tests {
         assert!(
             response.credential_unauthorized.is_none(),
             "a 401 with multiple credential accounts must not guess which account was rejected"
+        );
+    }
+
+    #[tokio::test]
+    async fn host_runtime_http_egress_skips_credential_unauthorized_marker_when_recovery_metadata_differs()
+     {
+        let egress = Arc::new(RecordingRuntimeHttpEgress::responding(401));
+        let port = host_port(egress, Arc::new(AllowObligations), secret_store());
+        let mut request = host_request();
+        let scope = request.request.scope.clone();
+        let account_id = "product-auth-account-123".to_string();
+        let account_updated_at = chrono::Utc::now();
+        for (header, requester_extension, unauthorized_policy) in [
+            (
+                "x-token-primary",
+                "github",
+                RuntimeCredentialUnauthorizedPolicy::RevokeAccount,
+            ),
+            (
+                "x-token-secondary",
+                "github-alt",
+                RuntimeCredentialUnauthorizedPolicy::RefreshAccount,
+            ),
+        ] {
+            request.credentials.push(HostRuntimeCredentialMaterial {
+                handle: SecretHandle::new(header).expect("secret handle"),
+                material: SecretMaterial::from("host-held-token"),
+                target: RuntimeCredentialTarget::Header {
+                    name: header.to_string(),
+                    prefix: None,
+                },
+                required: true,
+                credential_account: Some(RuntimeCredentialAccountIdentity {
+                    scope: scope.clone(),
+                    account_provider: RuntimeCredentialAccountProviderId::new("github")
+                        .expect("provider"),
+                    account_id: account_id.clone(),
+                    account_updated_at: Some(account_updated_at),
+                    requester_extension: Some(
+                        ExtensionId::new(requester_extension).expect("extension id"),
+                    ),
+                    auth_requirement: Some(RuntimeCredentialAuthRequirement {
+                        requester_extension: ExtensionId::new(requester_extension)
+                            .expect("extension id"),
+                        ..auth_requirement("github")
+                    }),
+                    unauthorized_policy,
+                }),
+            });
+        }
+
+        let response = port
+            .execute(request)
+            .await
+            .expect("401 response should still succeed");
+
+        assert!(
+            response.credential_unauthorized.is_none(),
+            "a 401 with conflicting recovery metadata must not guess which recovery flow to run"
         );
     }
 
@@ -562,6 +624,7 @@ mod tests {
                 account_id: "product-auth-account-123".to_string(),
                 account_updated_at: Some(chrono::Utc::now()),
                 requester_extension: None,
+                auth_requirement: Some(auth_requirement("github")),
                 unauthorized_policy: RuntimeCredentialUnauthorizedPolicy::RevokeAccount,
             }),
         });
@@ -597,6 +660,7 @@ mod tests {
                 account_id: "oauth-account-123".to_string(),
                 account_updated_at: Some(chrono::Utc::now()),
                 requester_extension: None,
+                auth_requirement: Some(auth_requirement("google")),
                 unauthorized_policy: RuntimeCredentialUnauthorizedPolicy::RefreshAccount,
             }),
         });
@@ -674,6 +738,15 @@ mod tests {
             }],
             deny_private_ip_ranges: true,
             max_egress_bytes: Some(1024),
+        }
+    }
+
+    fn auth_requirement(provider: &str) -> RuntimeCredentialAuthRequirement {
+        RuntimeCredentialAuthRequirement {
+            provider: RuntimeCredentialAccountProviderId::new(provider).expect("provider"),
+            setup: RuntimeCredentialAccountSetup::ManualToken,
+            requester_extension: ExtensionId::new("test_extension").expect("extension id"),
+            provider_scopes: Vec::new(),
         }
     }
 }

--- a/crates/ironclaw_host_runtime/src/egress/mod.rs
+++ b/crates/ironclaw_host_runtime/src/egress/mod.rs
@@ -5,8 +5,8 @@ mod sanitize;
 
 use async_trait::async_trait;
 use ironclaw_host_api::{
-    CapabilityId, NetworkPolicy, ResourceScope, RuntimeHttpEgress, RuntimeHttpEgressError,
-    RuntimeHttpEgressRequest, RuntimeHttpEgressResponse,
+    CapabilityId, NetworkPolicy, ResourceScope, RuntimeCredentialUnauthorized, RuntimeHttpEgress,
+    RuntimeHttpEgressError, RuntimeHttpEgressRequest, RuntimeHttpEgressResponse,
 };
 use ironclaw_network::{NetworkHttpEgress, NetworkHttpError};
 use ironclaw_safety::LeakDetector;
@@ -300,5 +300,15 @@ pub(super) fn runtime_response(
         request_bytes: response.usage.request_bytes,
         response_bytes: response.usage.response_bytes,
         redaction_applied,
+        credential_unauthorized: None,
+    }
+}
+
+pub(super) fn attach_credential_unauthorized_on_401(
+    response: &mut RuntimeHttpEgressResponse,
+    marker: Option<RuntimeCredentialUnauthorized>,
+) {
+    if response.status == 401 && response.credential_unauthorized.is_none() {
+        response.credential_unauthorized = marker;
     }
 }

--- a/crates/ironclaw_host_runtime/src/egress/pipeline.rs
+++ b/crates/ironclaw_host_runtime/src/egress/pipeline.rs
@@ -49,7 +49,7 @@ where
         .map_err(PipelineError::pre_transport)?;
     let scope = request.scope.clone();
     let capability_id = request.capability_id.clone();
-    let redaction_values = super::credential::apply_credential_injections(
+    let credential_result = super::credential::apply_credential_injections(
         service.secrets(),
         service.secret_injections(),
         &mut request,
@@ -61,10 +61,10 @@ where
     } else {
         dispatch_network(service, request, network_policy).await?
     };
-    let credentials_injected = !redaction_values.is_empty();
+    let credentials_injected = !credential_result.redaction_values.is_empty();
     let (response, response_redacted) = super::sanitize::sanitize_runtime_response(
         response,
-        &redaction_values,
+        &credential_result.redaction_values,
         service.leak_detector(),
     )
     .map_err(PipelineError::post_transport)?;
@@ -76,11 +76,16 @@ where
         &capability_id,
     )
     .map_err(PipelineError::post_transport)?;
-    Ok(runtime_response(
+    let mut response = runtime_response(
         response,
         credentials_injected || response_redacted,
         saved_body,
-    ))
+    );
+    super::attach_credential_unauthorized_on_401(
+        &mut response,
+        credential_result.credential_unauthorized,
+    );
+    Ok(response)
 }
 
 fn authorize_body_store<N, S>(

--- a/crates/ironclaw_host_runtime/src/obligations.rs
+++ b/crates/ironclaw_host_runtime/src/obligations.rs
@@ -21,8 +21,9 @@ use ironclaw_host_api::{
     CapabilityDispatchResult, CapabilityId, CredentialStageError, DecisionSummary, EffectKind,
     ExtensionId, MountView, NetworkPolicy, Obligation, ProcessId, ResourceCeiling,
     ResourceEstimate, ResourceReservation, ResourceScope, ResourceUsage,
-    RuntimeCredentialAccountProviderId, RuntimeCredentialAccountSetup,
-    RuntimeCredentialAuthRequirement, RuntimeHttpEgress, SandboxQuota, SecretHandle, Timestamp,
+    RuntimeCredentialAccountIdentity, RuntimeCredentialAccountProviderId,
+    RuntimeCredentialAccountSetup, RuntimeCredentialAuthRequirement, RuntimeHttpEgress,
+    SandboxQuota, SecretHandle, Timestamp,
 };
 use ironclaw_network::NetworkHttpEgress;
 use ironclaw_processes::{ProcessError, ProcessRecord, ProcessStart, ProcessStore};
@@ -54,6 +55,7 @@ pub struct RuntimeCredentialAccountRequest<'a> {
 pub struct RuntimeCredentialAccessSecret {
     pub scope: ResourceScope,
     pub handle: SecretHandle,
+    pub credential_account: Option<RuntimeCredentialAccountIdentity>,
 }
 
 #[async_trait]
@@ -91,7 +93,14 @@ struct RuntimeSecretInjectionState {
 
 struct RuntimeSecretInjectionEntry {
     material: SecretMaterial,
+    credential_account: Option<RuntimeCredentialAccountIdentity>,
     expires_at: Instant,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct RuntimeStagedSecretMaterial {
+    pub(crate) material: SecretMaterial,
+    pub(crate) credential_account: Option<RuntimeCredentialAccountIdentity>,
 }
 
 impl RuntimeSecretInjectionStore {
@@ -115,6 +124,17 @@ impl RuntimeSecretInjectionStore {
         handle: &SecretHandle,
         material: SecretMaterial,
     ) -> Result<(), RuntimeSecretInjectionStoreError> {
+        self.insert_with_credential_account(scope, capability_id, handle, material, None)
+    }
+
+    pub(crate) fn insert_with_credential_account(
+        &self,
+        scope: &ResourceScope,
+        capability_id: &CapabilityId,
+        handle: &SecretHandle,
+        material: SecretMaterial,
+        credential_account: Option<RuntimeCredentialAccountIdentity>,
+    ) -> Result<(), RuntimeSecretInjectionStoreError> {
         let now = Instant::now();
         let expires_at = now.checked_add(self.state.ttl).unwrap_or(now);
         let mut secrets = self.lock()?;
@@ -123,6 +143,7 @@ impl RuntimeSecretInjectionStore {
             RuntimeSecretInjectionKey::new(scope, capability_id, handle),
             RuntimeSecretInjectionEntry {
                 material,
+                credential_account,
                 expires_at,
             },
         );
@@ -147,12 +168,33 @@ impl RuntimeSecretInjectionStore {
             .map(|entry| entry.material))
     }
 
-    pub(crate) fn clone_material(
+    pub(crate) fn take_with_metadata(
         &self,
         scope: &ResourceScope,
         capability_id: &CapabilityId,
         handle: &SecretHandle,
-    ) -> Result<Option<SecretMaterial>, RuntimeSecretInjectionStoreError> {
+    ) -> Result<Option<RuntimeStagedSecretMaterial>, RuntimeSecretInjectionStoreError> {
+        let now = Instant::now();
+        let mut secrets = self.lock()?;
+        prune_expired_entries(&mut secrets, now);
+        Ok(secrets
+            .remove(&RuntimeSecretInjectionKey::new(
+                scope,
+                capability_id,
+                handle,
+            ))
+            .map(|entry| RuntimeStagedSecretMaterial {
+                material: entry.material,
+                credential_account: entry.credential_account,
+            }))
+    }
+
+    pub(crate) fn clone_material_with_metadata(
+        &self,
+        scope: &ResourceScope,
+        capability_id: &CapabilityId,
+        handle: &SecretHandle,
+    ) -> Result<Option<RuntimeStagedSecretMaterial>, RuntimeSecretInjectionStoreError> {
         let now = Instant::now();
         let mut secrets = self.lock()?;
         prune_expired_entries(&mut secrets, now);
@@ -162,7 +204,10 @@ impl RuntimeSecretInjectionStore {
                 capability_id,
                 handle,
             ))
-            .map(|entry| SecretMaterial::from(entry.material.expose_secret())))
+            .map(|entry| RuntimeStagedSecretMaterial {
+                material: SecretMaterial::from(entry.material.expose_secret()),
+                credential_account: entry.credential_account.clone(),
+            }))
     }
 
     /// Discard all staged secrets for a scoped capability before process ownership exists.
@@ -1333,6 +1378,7 @@ impl BuiltinObligationHandler {
                 request.capability_id,
                 &access_secret.handle,
                 obligation.handle,
+                access_secret.credential_account,
             )
             .await
             .map_err(|error| {
@@ -1838,6 +1884,7 @@ async fn stage_credential_material(
     capability_id: &CapabilityId,
     source: &SecretHandle,
     target: &SecretHandle,
+    credential_account: Option<RuntimeCredentialAccountIdentity>,
 ) -> Result<(), CredentialStageError> {
     let lease = secret_store
         .lease_once(source_scope, source)
@@ -1854,7 +1901,13 @@ async fn stage_credential_material(
             crate::services::stage_secret_error(e)
         })?;
     secret_injections
-        .insert(target_scope, capability_id, target, secret)
+        .insert_with_credential_account(
+            target_scope,
+            capability_id,
+            target,
+            secret,
+            credential_account,
+        )
         .map_err(|e| {
             tracing::debug!(err = %e, "stage_credential_material: insert failed");
             CredentialStageError::Backend

--- a/crates/ironclaw_host_runtime/src/services/tests.rs
+++ b/crates/ironclaw_host_runtime/src/services/tests.rs
@@ -235,6 +235,7 @@ async fn host_runtime_http_egress_port_executes_with_host_staged_credentials() {
                 prefix: Some("Bearer ".to_string()),
             },
             required: true,
+            credential_account: None,
         }],
     })
     .await

--- a/crates/ironclaw_host_runtime/src/wasm_credentials.rs
+++ b/crates/ironclaw_host_runtime/src/wasm_credentials.rs
@@ -177,11 +177,12 @@ impl RuntimeCredentialRestager {
             .await
             .map_err(crate::services::stage_secret_error)?;
         self.secret_injections
-            .insert(
+            .insert_with_credential_account(
                 &request.scope,
                 &request.capability_id,
                 &credential.handle,
                 material,
+                access_secret.credential_account,
             )
             .map_err(|_| CredentialStageError::Backend)
     }

--- a/crates/ironclaw_host_runtime/tests/builtin_obligation_handler_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/builtin_obligation_handler_contract.rs
@@ -1281,6 +1281,7 @@ impl RuntimeCredentialAccountResolver for FixedHandleResolver {
         Ok(RuntimeCredentialAccessSecret {
             scope: request.scope.clone(),
             handle: self.0.clone(),
+            credential_account: None,
         })
     }
 }
@@ -1300,6 +1301,7 @@ impl RuntimeCredentialAccountResolver for SourceScopedHandleResolver {
         Ok(RuntimeCredentialAccessSecret {
             scope: self.source_scope.clone(),
             handle: self.handle.clone(),
+            credential_account: None,
         })
     }
 }

--- a/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
@@ -8681,6 +8681,7 @@ impl RuntimeHttpEgress for RecordingRuntimeHttpEgress {
             request_bytes: request.body.len() as u64,
             response_bytes: self.response_bytes_override.unwrap_or(body.len() as u64),
             redaction_applied: self.redaction_applied,
+            credential_unauthorized: None,
         })
     }
 }

--- a/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
@@ -8725,6 +8725,7 @@ impl RuntimeHttpEgress for SleepingRuntimeHttpEgress {
             saved_body: None,
             request_bytes: request.body.len() as u64,
             redaction_applied: false,
+            credential_unauthorized: None,
         })
     }
 }

--- a/crates/ironclaw_host_runtime/tests/first_party_runtime_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_runtime_contract.rs
@@ -755,7 +755,6 @@ impl FirstPartyCapabilityHandler for HttpFirstPartyHandler {
                         prefix: Some("Bearer ".to_string()),
                     },
                     required: true,
-                    credential_account: None,
                 }],
                 response_body_limit: Some(4096),
                 save_body_to: None,

--- a/crates/ironclaw_host_runtime/tests/first_party_runtime_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_runtime_contract.rs
@@ -755,6 +755,7 @@ impl FirstPartyCapabilityHandler for HttpFirstPartyHandler {
                         prefix: Some("Bearer ".to_string()),
                     },
                     required: true,
+                    credential_account: None,
                 }],
                 response_body_limit: Some(4096),
                 save_body_to: None,

--- a/crates/ironclaw_host_runtime/tests/github_wasm_runtime_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/github_wasm_runtime_contract.rs
@@ -1403,6 +1403,7 @@ impl RuntimeCredentialAccountResolver for FixedRuntimeCredentialAccountResolver 
             .map(|handle| RuntimeCredentialAccessSecret {
                 scope: request.scope.clone(),
                 handle,
+                credential_account: None,
             })
     }
 }
@@ -1431,6 +1432,7 @@ impl RuntimeCredentialAccountResolver for FixedGoogleRuntimeCredentialAccountRes
             .map(|handle| RuntimeCredentialAccessSecret {
                 scope: request.scope.clone(),
                 handle,
+                credential_account: None,
             })
     }
 }

--- a/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
@@ -6448,7 +6448,6 @@ impl WasmRuntimeCredentialProvider for SecretStoreLeaseCredentials {
                 prefix: Some("Bearer ".to_string()),
             },
             required: true,
-            credential_account: None,
         }])
     }
 }

--- a/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
@@ -6448,6 +6448,7 @@ impl WasmRuntimeCredentialProvider for SecretStoreLeaseCredentials {
                 prefix: Some("Bearer ".to_string()),
             },
             required: true,
+            credential_account: None,
         }])
     }
 }
@@ -6505,6 +6506,7 @@ impl RuntimeHttpEgress for RecordingRuntimeHttpEgress {
             request_bytes: request.body.len() as u64,
             response_bytes: 0,
             redaction_applied: false,
+            credential_unauthorized: None,
         })
     }
 }

--- a/crates/ironclaw_host_runtime/tests/obligation_services_composition_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/obligation_services_composition_contract.rs
@@ -248,7 +248,6 @@ impl CapabilityDispatcher for ObligationAwareDispatcher {
                         prefix: Some("Bearer ".to_string()),
                     },
                     required: true,
-                    credential_account: None,
                 }],
                 response_body_limit: None,
                 save_body_to: None,

--- a/crates/ironclaw_host_runtime/tests/obligation_services_composition_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/obligation_services_composition_contract.rs
@@ -248,6 +248,7 @@ impl CapabilityDispatcher for ObligationAwareDispatcher {
                         prefix: Some("Bearer ".to_string()),
                     },
                     required: true,
+                    credential_account: None,
                 }],
                 response_body_limit: None,
                 save_body_to: None,

--- a/crates/ironclaw_host_runtime/tests/reborn_e2e_gate.rs
+++ b/crates/ironclaw_host_runtime/tests/reborn_e2e_gate.rs
@@ -596,6 +596,7 @@ async fn reborn_e2e_gate_host_http_consumes_staged_policy_and_secret_once() {
                 prefix: Some("Bearer ".to_string()),
             },
             required: true,
+            credential_account: None,
         }],
         response_body_limit: Some(4096),
         save_body_to: None,

--- a/crates/ironclaw_host_runtime/tests/reborn_e2e_gate.rs
+++ b/crates/ironclaw_host_runtime/tests/reborn_e2e_gate.rs
@@ -596,7 +596,6 @@ async fn reborn_e2e_gate_host_http_consumes_staged_policy_and_secret_once() {
                 prefix: Some("Bearer ".to_string()),
             },
             required: true,
-            credential_account: None,
         }],
         response_body_limit: Some(4096),
         save_body_to: None,

--- a/crates/ironclaw_host_runtime/tests/runtime_http_egress_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/runtime_http_egress_contract.rs
@@ -4497,6 +4497,7 @@ impl RuntimeCredentialAccountResolver for SourceScopedCredentialAccountResolver 
         Ok(RuntimeCredentialAccessSecret {
             scope: self.source_scope.clone(),
             handle: self.handle.clone(),
+            credential_account: None,
         })
     }
 }

--- a/crates/ironclaw_mcp/tests/mcp_adapter_contract.rs
+++ b/crates/ironclaw_mcp/tests/mcp_adapter_contract.rs
@@ -1351,6 +1351,7 @@ impl RuntimeHttpEgress for RecordingRuntimeEgress {
                 request_bytes: request.body.len() as u64,
                 response_bytes: 24,
                 redaction_applied: false,
+                credential_unauthorized: None,
             });
         }
         match method.as_str() {
@@ -1380,6 +1381,7 @@ impl RuntimeHttpEgress for RecordingRuntimeEgress {
                 request_bytes: request.body.len() as u64,
                 response_bytes: 0,
                 redaction_applied: false,
+                credential_unauthorized: None,
             }),
             "tools/call" => {
                 let id = json_rpc_id(&request.body);
@@ -1553,6 +1555,7 @@ fn runtime_json_response(
         saved_body: None,
         request_bytes: 0,
         redaction_applied: false,
+        credential_unauthorized: None,
     }
 }
 
@@ -1571,6 +1574,7 @@ fn runtime_sse_response(id: Option<u64>, result: serde_json::Value) -> RuntimeHt
         saved_body: None,
         request_bytes: 0,
         redaction_applied: false,
+        credential_unauthorized: None,
     }
 }
 
@@ -1620,6 +1624,7 @@ impl RuntimeHttpEgress for ScopedSessionRuntimeEgress {
                 request_bytes: request.body.len() as u64,
                 response_bytes: 0,
                 redaction_applied: false,
+                credential_unauthorized: None,
             }),
             "tools/call" => Ok(runtime_json_response(
                 json_rpc_id(&request.body),
@@ -1674,6 +1679,7 @@ impl RuntimeHttpEgress for RotatingSessionRuntimeEgress {
                 request_bytes: request.body.len() as u64,
                 response_bytes: 0,
                 redaction_applied: false,
+                credential_unauthorized: None,
             }),
             "tools/call" => Ok(runtime_json_response(
                 json_rpc_id(&request.body),
@@ -1737,6 +1743,7 @@ impl RuntimeHttpEgress for MissingIdRuntimeEgress {
                 request_bytes: request.body.len() as u64,
                 response_bytes: 0,
                 redaction_applied: false,
+                credential_unauthorized: None,
             }),
             "tools/call" => Ok(runtime_json_response(
                 None,
@@ -1791,6 +1798,7 @@ impl RuntimeHttpEgress for ErrorSessionRuntimeEgress {
                         request_bytes: request.body.len() as u64,
                         response_bytes: "server error".len() as u64,
                         redaction_applied: false,
+                        credential_unauthorized: None,
                     });
                 }
                 Ok(runtime_json_response(
@@ -1811,6 +1819,7 @@ impl RuntimeHttpEgress for ErrorSessionRuntimeEgress {
                 request_bytes: request.body.len() as u64,
                 response_bytes: 0,
                 redaction_applied: false,
+                credential_unauthorized: None,
             }),
             "tools/call" => Ok(runtime_json_response(
                 json_rpc_id(&request.body),

--- a/crates/ironclaw_reborn_composition/src/auth_dcr_tests.rs
+++ b/crates/ironclaw_reborn_composition/src/auth_dcr_tests.rs
@@ -159,6 +159,7 @@ impl RuntimeHttpEgress for FailingDcrEgress {
             body: Vec::new(),
             saved_body: None,
             redaction_applied: false,
+            credential_unauthorized: None,
         })
     }
 }

--- a/crates/ironclaw_reborn_composition/src/extension_lifecycle.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_lifecycle.rs
@@ -4021,6 +4021,7 @@ mod tests {
             saved_body: None,
             request_bytes: 0,
             redaction_applied: false,
+            credential_unauthorized: None,
         })
     }
 

--- a/crates/ironclaw_reborn_composition/src/extension_lifecycle/hosted_mcp_test_support.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_lifecycle/hosted_mcp_test_support.rs
@@ -125,5 +125,6 @@ fn runtime_json_response(
         saved_body: None,
         request_bytes: 0,
         redaction_applied: false,
+        credential_unauthorized: None,
     })
 }

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -324,6 +324,32 @@ where
         })
 }
 
+fn attach_runtime_credential_unauthorized_recovery<F, G, S, R>(
+    services: HostRuntimeServices<F, G, S, R>,
+    credential_accounts: Arc<dyn ironclaw_auth::CredentialAccountService>,
+) -> Result<HostRuntimeServices<F, G, S, R>, RebornBuildError>
+where
+    F: ironclaw_filesystem::RootFilesystem + 'static,
+    G: ironclaw_resources::ResourceGovernor + 'static,
+    S: ironclaw_processes::ProcessStore + 'static,
+    R: ironclaw_processes::ProcessResultStore + 'static,
+{
+    let runtime_http_egress =
+        services
+            .runtime_http_egress()
+            .ok_or_else(|| RebornBuildError::InvalidConfig {
+                reason:
+                    "runtime HTTP egress unavailable for credential unauthorized recovery consumer"
+                        .to_string(),
+            })?;
+    Ok(services.with_runtime_http_egress(Arc::new(
+        crate::runtime_credential_unauthorized::RuntimeCredentialUnauthorizedRecoveryEgress::new(
+            runtime_http_egress,
+            credential_accounts,
+        ),
+    )))
+}
+
 fn attach_hosted_mcp_runtime<F, G, S, R>(
     services: HostRuntimeServices<F, G, S, R>,
 ) -> Result<HostRuntimeServices<F, G, S, R>, RebornBuildError>
@@ -1197,6 +1223,10 @@ async fn build_local_runtime(input: RebornBuildInput) -> Result<RebornServices, 
             }
         }
     };
+    services = attach_runtime_credential_unauthorized_recovery(
+        services,
+        product_auth.credential_account_service(),
+    )?;
     services = services.with_runtime_credential_account_resolver(Arc::new(
         ProductAuthRuntimeCredentialResolver::new_with_refresh(
             product_auth.runtime_credential_account_selection_service(),
@@ -3790,6 +3820,10 @@ where
         None => CredentialRefreshWorkerReady::Absent,
     };
     let product_auth_ready = true;
+    let services = attach_runtime_credential_unauthorized_recovery(
+        services,
+        product_auth_services.credential_account_service(),
+    )?;
     // Wire ProductAuthAccount runtime credential resolver before
     // host_runtime_for_production so WASM extensions whose manifest declares a
     // ProductAuthAccount runtime credential source resolve through

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -327,6 +327,7 @@ where
 fn attach_runtime_credential_unauthorized_recovery<F, G, S, R>(
     services: HostRuntimeServices<F, G, S, R>,
     credential_accounts: Arc<dyn ironclaw_auth::CredentialAccountService>,
+    reauth_bridge: Arc<crate::runtime_credential_reauth::RuntimeCredentialReauthBridge>,
 ) -> Result<HostRuntimeServices<F, G, S, R>, RebornBuildError>
 where
     F: ironclaw_filesystem::RootFilesystem + 'static,
@@ -346,6 +347,7 @@ where
         crate::runtime_credential_unauthorized::RuntimeCredentialUnauthorizedRecoveryEgress::new(
             runtime_http_egress,
             credential_accounts,
+            reauth_bridge,
         ),
     )))
 }
@@ -1223,9 +1225,12 @@ async fn build_local_runtime(input: RebornBuildInput) -> Result<RebornServices, 
             }
         }
     };
+    let reauth_bridge =
+        Arc::new(crate::runtime_credential_reauth::RuntimeCredentialReauthBridge::default());
     services = attach_runtime_credential_unauthorized_recovery(
         services,
         product_auth.credential_account_service(),
+        Arc::clone(&reauth_bridge),
     )?;
     services = services.with_runtime_credential_account_resolver(Arc::new(
         ProductAuthRuntimeCredentialResolver::new_with_refresh(
@@ -1342,6 +1347,12 @@ async fn build_local_runtime(input: RebornBuildInput) -> Result<RebornServices, 
 
     let host_runtime: Arc<dyn ironclaw_host_runtime::HostRuntime> =
         Arc::new(services.host_runtime_for_local_testing());
+    let host_runtime: Arc<dyn ironclaw_host_runtime::HostRuntime> = Arc::new(
+        crate::runtime_credential_reauth::RuntimeCredentialReauthHostRuntime::new(
+            host_runtime,
+            reauth_bridge,
+        ),
+    );
 
     Ok(RebornServices {
         host_runtime: Some(host_runtime),
@@ -3820,9 +3831,12 @@ where
         None => CredentialRefreshWorkerReady::Absent,
     };
     let product_auth_ready = true;
+    let reauth_bridge =
+        Arc::new(crate::runtime_credential_reauth::RuntimeCredentialReauthBridge::default());
     let services = attach_runtime_credential_unauthorized_recovery(
         services,
         product_auth_services.credential_account_service(),
+        Arc::clone(&reauth_bridge),
     )?;
     // Wire ProductAuthAccount runtime credential resolver before
     // host_runtime_for_production so WASM extensions whose manifest declares a
@@ -3850,6 +3864,12 @@ where
 
     let host_runtime: Arc<dyn ironclaw_host_runtime::HostRuntime> =
         Arc::new(services.host_runtime_for_production(&wiring_config)?);
+    let host_runtime: Arc<dyn ironclaw_host_runtime::HostRuntime> = Arc::new(
+        crate::runtime_credential_reauth::RuntimeCredentialReauthHostRuntime::new(
+            host_runtime,
+            reauth_bridge,
+        ),
+    );
 
     Ok(RebornServices {
         host_runtime: Some(host_runtime),

--- a/crates/ironclaw_reborn_composition/src/factory/auth_tests.rs
+++ b/crates/ironclaw_reborn_composition/src/factory/auth_tests.rs
@@ -161,6 +161,7 @@ impl RuntimeHttpEgress for RecordingOAuthEgress {
             request_bytes: 0,
             response_bytes: 0,
             redaction_applied: true,
+            credential_unauthorized: None,
         })
     }
 }

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -108,6 +108,7 @@ mod provider_admin_product_command;
 mod provider_repo;
 mod readiness;
 mod runtime;
+mod runtime_credential_unauthorized;
 mod runtime_input;
 mod runtime_profile_approval_policy;
 mod skill_learning;

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -108,6 +108,7 @@ mod provider_admin_product_command;
 mod provider_repo;
 mod readiness;
 mod runtime;
+mod runtime_credential_reauth;
 mod runtime_credential_unauthorized;
 mod runtime_input;
 mod runtime_profile_approval_policy;

--- a/crates/ironclaw_reborn_composition/src/oauth_dcr.rs
+++ b/crates/ironclaw_reborn_composition/src/oauth_dcr.rs
@@ -1804,6 +1804,7 @@ mod tests {
                 body,
                 saved_body: None,
                 redaction_applied: false,
+                credential_unauthorized: None,
             })
         }
     }
@@ -1959,6 +1960,7 @@ mod tests {
                 body,
                 saved_body: None,
                 redaction_applied: false,
+                credential_unauthorized: None,
             })
         }
     }

--- a/crates/ironclaw_reborn_composition/src/oauth_provider_client.rs
+++ b/crates/ironclaw_reborn_composition/src/oauth_provider_client.rs
@@ -261,11 +261,11 @@ impl HostOAuthProviderClient {
             if (500..600).contains(&response.status) {
                 return Err(AuthProductError::BackendUnavailable);
             }
-            // For 4xx errors on a refresh request, check for invalid_grant to
-            // distinguish permanent revocation from transient failure.
-            // REDACTION: extract only the `error` code string — never log, serialize,
-            // or return the raw body, access token, refresh token, or any secret.
             if refresh_request {
+                // For 4xx errors on a refresh request, check for invalid_grant to
+                // distinguish permanent revocation from transient failure.
+                // REDACTION: extract only the `error` code string — never log, serialize,
+                // or return the raw body, access token, refresh token, or any secret.
                 let error_code = serde_json::from_slice::<OAuthErrorResponseBody>(&response.body)
                     .ok()
                     .and_then(|body| body.error);

--- a/crates/ironclaw_reborn_composition/src/oauth_provider_client/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/oauth_provider_client/tests.rs
@@ -620,6 +620,7 @@ impl RuntimeHttpEgress for RecordingEgress {
             request_bytes: 0,
             response_bytes: 0,
             redaction_applied: true,
+            credential_unauthorized: None,
         })
     }
 }

--- a/crates/ironclaw_reborn_composition/src/product_auth_durable/accounts.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_durable/accounts.rs
@@ -15,7 +15,7 @@ use ironclaw_auth::{
     CredentialAccountRecordSource, CredentialAccountSelectionRequest, CredentialAccountService,
     CredentialAccountStatus, CredentialRecoveryProjection, CredentialRecoveryReason,
     CredentialRecoveryRequest, CredentialRefreshReport, CredentialRefreshRequest,
-    CredentialSetupService, NewCredentialAccount,
+    CredentialSetupService, NewCredentialAccount, Timestamp,
 };
 
 #[async_trait]
@@ -106,6 +106,31 @@ where
         self.write_account(&account, CasExpectation::Version(version))
             .await?;
         Ok(account)
+    }
+
+    async fn revoke_if_unchanged(
+        &self,
+        scope: &ironclaw_auth::AuthProductScope,
+        account_id: CredentialAccountId,
+        expected_updated_at: Timestamp,
+    ) -> Result<Option<CredentialAccount>, AuthProductError> {
+        let lock = self.lock_for(format!("account:{account_id}"));
+        let _guard = lock.lock().await;
+        let Some((mut account, version)) = self.read_account(scope, account_id).await? else {
+            return Ok(None);
+        };
+        if !scope_matches(scope, &account.scope) {
+            return Err(AuthProductError::CrossScopeDenied);
+        }
+        if account.updated_at != expected_updated_at {
+            return Ok(None);
+        }
+        validate_credential_status_transition(account.status, CredentialAccountStatus::Revoked)?;
+        account.status = CredentialAccountStatus::Revoked;
+        account.updated_at = Utc::now();
+        self.write_account(&account, CasExpectation::Version(version))
+            .await?;
+        Ok(Some(account))
     }
 
     async fn select_unique_configured_account(

--- a/crates/ironclaw_reborn_composition/src/product_auth_durable/accounts.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_durable/accounts.rs
@@ -17,6 +17,7 @@ use ironclaw_auth::{
     CredentialRecoveryRequest, CredentialRefreshReport, CredentialRefreshRequest,
     CredentialSetupService, NewCredentialAccount, Timestamp,
 };
+use ironclaw_host_api::ExtensionId;
 
 #[async_trait]
 impl<F> CredentialAccountService for FilesystemAuthProductServices<F>
@@ -113,6 +114,7 @@ where
         scope: &ironclaw_auth::AuthProductScope,
         account_id: CredentialAccountId,
         expected_updated_at: Timestamp,
+        requester_extension: Option<ExtensionId>,
     ) -> Result<Option<CredentialAccount>, AuthProductError> {
         let lock = self.lock_for(format!("account:{account_id}"));
         let _guard = lock.lock().await;
@@ -120,6 +122,9 @@ where
             return Ok(None);
         };
         if !scope_matches(scope, &account.scope) {
+            return Err(AuthProductError::CrossScopeDenied);
+        }
+        if !account_is_authorized_for_requester(&account, requester_extension.as_ref()) {
             return Err(AuthProductError::CrossScopeDenied);
         }
         if account.updated_at != expected_updated_at {

--- a/crates/ironclaw_reborn_composition/src/product_auth_providers.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_providers.rs
@@ -711,6 +711,7 @@ mod tests {
                 request_bytes: 0,
                 response_bytes: 0,
                 redaction_applied: true,
+                credential_unauthorized: None,
             })
         }
     }

--- a/crates/ironclaw_reborn_composition/src/product_auth_runtime_credentials.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_runtime_credentials.rs
@@ -497,11 +497,13 @@ impl RuntimeCredentialAccountResolver for ProductAuthRuntimeCredentialResolver {
             .await
             .map_err(map_account_error)?;
         let unauthorized_policy = unauthorized_policy_for_account(&setup, &account);
-        let recovery_requester_extension = match unauthorized_policy {
-            RuntimeCredentialUnauthorizedPolicy::RefreshAccount => {
-                refresh_requester_for_account(&account, requester_extension.as_ref())
-            }
-            RuntimeCredentialUnauthorizedPolicy::RevokeAccount => None,
+        let recovery_requester_extension =
+            refresh_requester_for_account(&account, requester_extension.as_ref());
+        let auth_requirement = RuntimeCredentialAuthRequirement {
+            provider: request.provider.clone(),
+            setup: request.setup.clone(),
+            requester_extension: request.requester_extension.clone(),
+            provider_scopes: request.provider_scopes.to_vec(),
         };
         if account.status != CredentialAccountStatus::Configured {
             return Err(CredentialStageError::AuthRequired);
@@ -525,6 +527,7 @@ impl RuntimeCredentialAccountResolver for ProductAuthRuntimeCredentialResolver {
                 account_id: account.id.to_string(),
                 account_updated_at: Some(account.updated_at),
                 requester_extension: recovery_requester_extension,
+                auth_requirement: Some(auth_requirement),
                 unauthorized_policy,
             }),
         })

--- a/crates/ironclaw_reborn_composition/src/product_auth_runtime_credentials.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_runtime_credentials.rs
@@ -9,8 +9,9 @@ use ironclaw_auth::{
     select_latest_duplicate_user_reusable_account,
 };
 use ironclaw_host_api::{
-    CredentialStageError, ExtensionId, ResourceScope, RuntimeCredentialAccountProviderId,
-    RuntimeCredentialAccountSetup, RuntimeCredentialAuthRequirement,
+    CredentialStageError, ExtensionId, ResourceScope, RuntimeCredentialAccountIdentity,
+    RuntimeCredentialAccountProviderId, RuntimeCredentialAccountSetup,
+    RuntimeCredentialAuthRequirement, RuntimeCredentialUnauthorizedPolicy,
 };
 use ironclaw_host_runtime::{
     RuntimeCredentialAccessSecret, RuntimeCredentialAccountRequest,
@@ -488,11 +489,20 @@ impl RuntimeCredentialAccountResolver for ProductAuthRuntimeCredentialResolver {
             .select_unique_configured_runtime_account(selection_request.clone())
             .await
             .map_err(map_account_error)?;
+        let setup = selection_request.setup.clone();
+        let requester_extension = selection_request.lookup.requester_extension.clone();
         let account = self
             .refresher
             .refresh_configured_runtime_account(selection_request, account, self.accounts.as_ref())
             .await
             .map_err(map_account_error)?;
+        let unauthorized_policy = unauthorized_policy_for_account(&setup, &account);
+        let recovery_requester_extension = match unauthorized_policy {
+            RuntimeCredentialUnauthorizedPolicy::RefreshAccount => {
+                refresh_requester_for_account(&account, requester_extension.as_ref())
+            }
+            RuntimeCredentialUnauthorizedPolicy::RevokeAccount => None,
+        };
         if account.status != CredentialAccountStatus::Configured {
             return Err(CredentialStageError::AuthRequired);
         }
@@ -502,10 +512,21 @@ impl RuntimeCredentialAccountResolver for ProductAuthRuntimeCredentialResolver {
         // both together; cleanup/uninstall clears status to Revoked together with
         // the handle), so this branch can only fire on corrupt state. Return
         // Backend so the caller does not loop through re-auth.
-        let handle = account.access_secret.ok_or(CredentialStageError::Backend)?;
+        let handle = account
+            .access_secret
+            .clone()
+            .ok_or(CredentialStageError::Backend)?;
         Ok(RuntimeCredentialAccessSecret {
-            scope: account.scope.resource,
+            scope: account.scope.resource.clone(),
             handle,
+            credential_account: Some(RuntimeCredentialAccountIdentity {
+                scope: account.scope.resource,
+                account_provider: request.provider.clone(),
+                account_id: account.id.to_string(),
+                account_updated_at: Some(account.updated_at),
+                requester_extension: recovery_requester_extension,
+                unauthorized_policy,
+            }),
         })
     }
 }
@@ -565,6 +586,23 @@ fn credential_setup_requires_stored_scopes(setup: &RuntimeCredentialAccountSetup
     match setup {
         RuntimeCredentialAccountSetup::OAuth { .. } => true,
         RuntimeCredentialAccountSetup::ManualToken => false,
+    }
+}
+
+fn unauthorized_policy_for_account(
+    setup: &RuntimeCredentialAccountSetup,
+    account: &CredentialAccount,
+) -> RuntimeCredentialUnauthorizedPolicy {
+    match setup {
+        RuntimeCredentialAccountSetup::ManualToken => {
+            RuntimeCredentialUnauthorizedPolicy::RevokeAccount
+        }
+        RuntimeCredentialAccountSetup::OAuth { .. } if account.refresh_secret.is_some() => {
+            RuntimeCredentialUnauthorizedPolicy::RefreshAccount
+        }
+        RuntimeCredentialAccountSetup::OAuth { .. } => {
+            RuntimeCredentialUnauthorizedPolicy::RevokeAccount
+        }
     }
 }
 

--- a/crates/ironclaw_reborn_composition/src/product_auth_runtime_credentials/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_runtime_credentials/tests.rs
@@ -5,8 +5,8 @@ use ironclaw_auth::{
 };
 use ironclaw_host_api::{
     ExtensionId, InvocationId, MissionId, ResourceScope, RuntimeCredentialAccountProviderId,
-    RuntimeCredentialAccountSetup, RuntimeCredentialAuthRequirement, SecretHandle, ThreadId,
-    UserId,
+    RuntimeCredentialAccountSetup, RuntimeCredentialAuthRequirement,
+    RuntimeCredentialUnauthorizedPolicy, SecretHandle, ThreadId, UserId,
 };
 use ironclaw_secrets::{InMemorySecretStore, SecretStore};
 
@@ -442,6 +442,14 @@ async fn resolver_returns_configured_product_auth_access_secret() {
 
     assert_eq!(resolved.handle, access_secret);
     assert_eq!(resolved.scope, scope);
+    assert_eq!(
+        resolved
+            .credential_account
+            .as_ref()
+            .expect("product-auth account identity")
+            .unauthorized_policy,
+        RuntimeCredentialUnauthorizedPolicy::RevokeAccount
+    );
 }
 
 #[tokio::test]
@@ -478,6 +486,17 @@ async fn resolver_refreshes_oauth_account_before_staging_access_secret() {
             .handle
             .as_str()
             .starts_with("oauth-refreshed-access")
+    );
+    let credential_account = resolved
+        .credential_account
+        .expect("product-auth account identity");
+    assert_eq!(
+        credential_account.unauthorized_policy,
+        RuntimeCredentialUnauthorizedPolicy::RefreshAccount
+    );
+    assert_eq!(
+        credential_account.requester_extension,
+        Some(ExtensionId::new("google-drive").unwrap())
     );
 }
 
@@ -591,6 +610,14 @@ async fn resolver_stages_oauth_access_secret_when_refresh_secret_is_absent() {
 
     assert_eq!(resolved.handle, access_secret);
     assert_eq!(resolved.scope, scope);
+    assert_eq!(
+        resolved
+            .credential_account
+            .as_ref()
+            .expect("product-auth account identity")
+            .unauthorized_policy,
+        RuntimeCredentialUnauthorizedPolicy::RevokeAccount
+    );
 }
 
 #[tokio::test]
@@ -623,6 +650,14 @@ async fn resolver_stages_oauth_access_secret_when_proactive_refresh_backend_is_u
 
     assert_eq!(resolved.handle, access_secret);
     assert_eq!(resolved.scope, scope);
+    assert_eq!(
+        resolved
+            .credential_account
+            .as_ref()
+            .expect("product-auth account identity")
+            .unauthorized_policy,
+        RuntimeCredentialUnauthorizedPolicy::RefreshAccount
+    );
 }
 
 #[tokio::test]

--- a/crates/ironclaw_reborn_composition/src/product_auth_serve/accounts.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_serve/accounts.rs
@@ -113,3 +113,23 @@ pub(super) async fn accounts_refresh_handler(
 
     Ok(Json(report))
 }
+
+pub(super) async fn accounts_revoke_handler(
+    State(state): State<ProductAuthRouteState>,
+    Extension(caller): Extension<WebUiAuthenticatedCaller>,
+    Json(request): Json<AccountsRevokeRequest>,
+) -> Result<Json<CredentialAccountProjection>, ProductAuthRouteFailure> {
+    let scope =
+        scope_from_authenticated_caller_parts_requiring_invocation(&caller, &request.scope)?;
+    let account_id = parse_credential_account_id(&request.account_id)?;
+
+    let account = run_with_backend_timeout(
+        state
+            .product_auth
+            .credential_account_service()
+            .update_status(&scope, account_id, CredentialAccountStatus::Revoked),
+    )
+    .await?;
+
+    Ok(Json(account.projection()))
+}

--- a/crates/ironclaw_reborn_composition/src/product_auth_serve/mod.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_serve/mod.rs
@@ -81,6 +81,7 @@ pub(crate) const ACCOUNTS_LIST_PATH: &str = "/api/reborn/product-auth/accounts/l
 pub(crate) const ACCOUNTS_SELECT_PATH: &str = "/api/reborn/product-auth/accounts/select";
 pub(crate) const ACCOUNTS_RECOVERY_PATH: &str = "/api/reborn/product-auth/accounts/recovery";
 pub(crate) const ACCOUNTS_REFRESH_PATH: &str = "/api/reborn/product-auth/accounts/refresh";
+pub(crate) const ACCOUNTS_REVOKE_PATH: &str = "/api/reborn/product-auth/accounts/revoke";
 pub(crate) const LIFECYCLE_CLEANUP_PATH: &str = "/api/reborn/product-auth/lifecycle/cleanup";
 
 const OAUTH_START_ROUTE_ID: &str = "product_auth.oauth.start";
@@ -95,6 +96,7 @@ const ACCOUNTS_LIST_ROUTE_ID: &str = "product_auth.accounts.list";
 const ACCOUNTS_SELECT_ROUTE_ID: &str = "product_auth.accounts.select";
 const ACCOUNTS_RECOVERY_ROUTE_ID: &str = "product_auth.accounts.recovery";
 const ACCOUNTS_REFRESH_ROUTE_ID: &str = "product_auth.accounts.refresh";
+const ACCOUNTS_REVOKE_ROUTE_ID: &str = "product_auth.accounts.revoke";
 const LIFECYCLE_CLEANUP_ROUTE_ID: &str = "product_auth.lifecycle.cleanup";
 const OAUTH_PKCE_VERIFIER_CACHE_CAPACITY: NonZeroUsize = match NonZeroUsize::new(1024) {
     Some(value) => value,
@@ -343,6 +345,10 @@ pub(crate) fn product_auth_route_mount(state: ProductAuthRouteState) -> ProductA
                 post(accounts::accounts_refresh_handler),
             )
             .route(
+                ACCOUNTS_REVOKE_PATH,
+                post(accounts::accounts_revoke_handler),
+            )
+            .route(
                 LIFECYCLE_CLEANUP_PATH,
                 post(lifecycle::lifecycle_cleanup_handler),
             )
@@ -376,6 +382,7 @@ pub(crate) fn product_auth_route_descriptors() -> Vec<IngressRouteDescriptor> {
         (ACCOUNTS_SELECT_ROUTE_ID, ACCOUNTS_SELECT_PATH),
         (ACCOUNTS_RECOVERY_ROUTE_ID, ACCOUNTS_RECOVERY_PATH),
         // accounts/refresh omitted here — uses tighter rate limit below.
+        (ACCOUNTS_REVOKE_ROUTE_ID, ACCOUNTS_REVOKE_PATH),
         (LIFECYCLE_CLEANUP_ROUTE_ID, LIFECYCLE_CLEANUP_PATH),
     ];
     let mut descriptors: Vec<IngressRouteDescriptor> = PROTECTED_MUTATIONS
@@ -640,6 +647,13 @@ pub(super) struct AccountsRefreshRequest {
     provider: String,
     account_id: String,
     requester_extension: Option<String>,
+    #[serde(flatten)]
+    scope: ScopeFields,
+}
+
+#[derive(Deserialize)]
+pub(super) struct AccountsRevokeRequest {
+    account_id: String,
     #[serde(flatten)]
     scope: ScopeFields,
 }
@@ -1991,6 +2005,75 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn accounts_revoke_route_marks_account_revoked() {
+        let shared = Arc::new(ironclaw_auth::InMemoryAuthProductServices::new());
+        let product_auth = Arc::new(RebornProductAuthServices::from_shared(
+            shared.clone(),
+            Arc::new(NoopDispatcher),
+        ));
+        let resource = test_resource_scope();
+        let scope = AuthProductScope::new(resource.clone(), AuthSurface::Callback);
+        let account = shared
+            .create_account(NewCredentialAccount {
+                scope: scope.clone(),
+                provider: AuthProviderId::new(GOOGLE_PROVIDER_ID).expect("provider"),
+                label: CredentialAccountLabel::new("google account").expect("label"),
+                status: CredentialAccountStatus::Configured,
+                ownership: CredentialOwnership::UserReusable,
+                owner_extension: None,
+                granted_extensions: Vec::new(),
+                access_secret: None,
+                refresh_secret: None,
+                scopes: vec![
+                    ProviderScope::new("https://www.googleapis.com/auth/drive")
+                        .expect("provider scope"),
+                ],
+            })
+            .await
+            .expect("seed account");
+        let state = ProductAuthRouteState::new(
+            product_auth,
+            TenantId::new("tenant-alpha").expect("tenant"),
+            None,
+            None,
+        );
+        let app = product_auth_route_mount(state)
+            .protected
+            .layer(axum::Extension(test_caller()));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri(ACCOUNTS_REVOKE_PATH)
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        serde_json::json!({
+                            "account_id": account.id.to_string(),
+                            "invocation_id": resource.invocation_id.to_string(),
+                        })
+                        .to_string(),
+                    ))
+                    .expect("request"),
+            )
+            .await
+            .expect("route response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("response body");
+        let json: serde_json::Value = serde_json::from_slice(&body).expect("revoke json");
+        assert_eq!(json["status"], "revoked");
+        let stored = shared
+            .get_account(CredentialAccountLookupRequest::new(scope, account.id))
+            .await
+            .expect("lookup")
+            .expect("stored account");
+        assert_eq!(stored.status, CredentialAccountStatus::Revoked);
+    }
+
     #[derive(Debug)]
     struct PanickingDcrEgress;
 
@@ -2036,6 +2119,7 @@ mod tests {
                 body,
                 saved_body: None,
                 redaction_applied: false,
+                credential_unauthorized: None,
             })
         }
     }

--- a/crates/ironclaw_reborn_composition/src/product_auth_serve/oauth_start_tests.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_serve/oauth_start_tests.rs
@@ -94,6 +94,7 @@ mod tests {
                 body,
                 saved_body: None,
                 redaction_applied: false,
+                credential_unauthorized: None,
             })
         }
     }

--- a/crates/ironclaw_reborn_composition/src/projection/tests/turn_stream_auth.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/tests/turn_stream_auth.rs
@@ -464,6 +464,7 @@ async fn webui_event_stream_creates_notion_dcr_oauth_prompt_for_runtime_credenti
                 body,
                 saved_body: None,
                 redaction_applied: false,
+                credential_unauthorized: None,
             })
         }
     }

--- a/crates/ironclaw_reborn_composition/src/runtime_credential_reauth.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime_credential_reauth.rs
@@ -1,0 +1,230 @@
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use ironclaw_host_api::{
+    CapabilityId, InvocationId, ResourceScope, RuntimeCredentialAuthRequirement,
+    sha256_digest_token,
+};
+use ironclaw_host_runtime::{
+    CancelRuntimeWorkOutcome, CancelRuntimeWorkRequest, HostRuntime, HostRuntimeError,
+    HostRuntimeHealth, HostRuntimeStatus, RuntimeAuthGate, RuntimeBlockedReason,
+    RuntimeCapabilityAuthResumeRequest, RuntimeCapabilityOutcome, RuntimeCapabilityRequest,
+    RuntimeCapabilityResumeRequest, RuntimeGateId, RuntimeStatusRequest, VisibleCapabilityRequest,
+    VisibleCapabilitySurface,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RuntimeCredentialReauthRequest {
+    pub(crate) capability_id: CapabilityId,
+    pub(crate) credential_requirements: Vec<RuntimeCredentialAuthRequirement>,
+}
+
+/// Composition-owned handoff between the runtime HTTP recovery wrapper and the
+/// outer host-runtime outcome wrapper.
+///
+/// The two wrappers are separated by the capability runtime call boundary:
+/// `RuntimeHttpEgress` observes the 401 response inside a tool invocation, while
+/// `HostRuntime` is the layer that can return `AuthRequired` to the loop. Keep
+/// this bridge private to Reborn composition so it cannot become a generic host
+/// event bus.
+#[derive(Clone, Default)]
+pub(crate) struct RuntimeCredentialReauthBridge {
+    inner: Arc<Mutex<Vec<RuntimeCredentialReauthRecord>>>,
+}
+
+impl RuntimeCredentialReauthBridge {
+    pub(crate) fn record_recovered_auth_required(
+        &self,
+        scope: &ResourceScope,
+        capability_id: &CapabilityId,
+        credential_requirements: Vec<RuntimeCredentialAuthRequirement>,
+    ) {
+        if credential_requirements.is_empty() {
+            return;
+        }
+        let record = RuntimeCredentialReauthRecord {
+            invocation_id: scope.invocation_id,
+            capability_id: capability_id.clone(),
+            credential_requirements,
+        };
+        match self.inner.lock() {
+            Ok(mut records) => records.push(record),
+            Err(poisoned) => poisoned.into_inner().push(record),
+        }
+    }
+
+    pub(crate) fn take_recovered_auth_required(
+        &self,
+        scope: &ResourceScope,
+        capability_id: &CapabilityId,
+    ) -> Option<RuntimeCredentialReauthRequest> {
+        let mut records = match self.inner.lock() {
+            Ok(records) => records,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        let mut credential_requirements = Vec::new();
+        records.retain(|record| {
+            let matches = record.invocation_id == scope.invocation_id
+                && &record.capability_id == capability_id;
+            if matches {
+                credential_requirements.extend(record.credential_requirements.clone());
+            }
+            !matches
+        });
+        if credential_requirements.is_empty() {
+            return None;
+        }
+        Some(RuntimeCredentialReauthRequest {
+            capability_id: capability_id.clone(),
+            credential_requirements,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+struct RuntimeCredentialReauthRecord {
+    invocation_id: InvocationId,
+    capability_id: CapabilityId,
+    credential_requirements: Vec<RuntimeCredentialAuthRequirement>,
+}
+
+pub(crate) struct RuntimeCredentialReauthHostRuntime {
+    inner: Arc<dyn HostRuntime>,
+    bridge: Arc<RuntimeCredentialReauthBridge>,
+}
+
+impl RuntimeCredentialReauthHostRuntime {
+    pub(crate) fn new(
+        inner: Arc<dyn HostRuntime>,
+        bridge: Arc<RuntimeCredentialReauthBridge>,
+    ) -> Self {
+        Self { inner, bridge }
+    }
+
+    fn apply_reauth(
+        &self,
+        scope: &ResourceScope,
+        capability_id: &CapabilityId,
+        fallback: RuntimeCapabilityOutcome,
+    ) -> RuntimeCapabilityOutcome {
+        self.bridge
+            .take_recovered_auth_required(scope, capability_id)
+            .map(auth_required_outcome)
+            .unwrap_or(fallback)
+    }
+}
+
+#[async_trait]
+impl HostRuntime for RuntimeCredentialReauthHostRuntime {
+    async fn invoke_capability(
+        &self,
+        request: RuntimeCapabilityRequest,
+    ) -> Result<RuntimeCapabilityOutcome, HostRuntimeError> {
+        let scope = request.context.resource_scope.clone();
+        let capability_id = request.capability_id.clone();
+        let outcome = self.inner.invoke_capability(request).await?;
+        Ok(self.apply_reauth(&scope, &capability_id, outcome))
+    }
+
+    async fn spawn_capability(
+        &self,
+        request: RuntimeCapabilityRequest,
+    ) -> Result<RuntimeCapabilityOutcome, HostRuntimeError> {
+        let scope = request.context.resource_scope.clone();
+        let capability_id = request.capability_id.clone();
+        let outcome = self.inner.spawn_capability(request).await?;
+        Ok(self.apply_reauth(&scope, &capability_id, outcome))
+    }
+
+    async fn resume_capability(
+        &self,
+        request: RuntimeCapabilityResumeRequest,
+    ) -> Result<RuntimeCapabilityOutcome, HostRuntimeError> {
+        let scope = request.context.resource_scope.clone();
+        let capability_id = request.capability_id.clone();
+        let outcome = self.inner.resume_capability(request).await?;
+        Ok(self.apply_reauth(&scope, &capability_id, outcome))
+    }
+
+    async fn auth_resume_capability(
+        &self,
+        request: RuntimeCapabilityAuthResumeRequest,
+    ) -> Result<RuntimeCapabilityOutcome, HostRuntimeError> {
+        let scope = request.context.resource_scope.clone();
+        let capability_id = request.capability_id.clone();
+        let outcome = self.inner.auth_resume_capability(request).await?;
+        Ok(self.apply_reauth(&scope, &capability_id, outcome))
+    }
+
+    async fn resume_spawn_capability(
+        &self,
+        request: RuntimeCapabilityResumeRequest,
+    ) -> Result<RuntimeCapabilityOutcome, HostRuntimeError> {
+        let scope = request.context.resource_scope.clone();
+        let capability_id = request.capability_id.clone();
+        let outcome = self.inner.resume_spawn_capability(request).await?;
+        Ok(self.apply_reauth(&scope, &capability_id, outcome))
+    }
+
+    async fn visible_capabilities(
+        &self,
+        request: VisibleCapabilityRequest,
+    ) -> Result<VisibleCapabilitySurface, HostRuntimeError> {
+        self.inner.visible_capabilities(request).await
+    }
+
+    async fn cancel_work(
+        &self,
+        request: CancelRuntimeWorkRequest,
+    ) -> Result<CancelRuntimeWorkOutcome, HostRuntimeError> {
+        self.inner.cancel_work(request).await
+    }
+
+    async fn runtime_status(
+        &self,
+        request: RuntimeStatusRequest,
+    ) -> Result<HostRuntimeStatus, HostRuntimeError> {
+        self.inner.runtime_status(request).await
+    }
+
+    async fn health(&self) -> Result<HostRuntimeHealth, HostRuntimeError> {
+        self.inner.health().await
+    }
+}
+
+fn auth_required_outcome(request: RuntimeCredentialReauthRequest) -> RuntimeCapabilityOutcome {
+    RuntimeCapabilityOutcome::AuthRequired(RuntimeAuthGate {
+        gate_id: stable_auth_gate_id(&request.capability_id, &request.credential_requirements),
+        capability_id: request.capability_id,
+        reason: RuntimeBlockedReason::AuthRequired,
+        required_secrets: Vec::new(),
+        credential_requirements: request.credential_requirements,
+    })
+}
+
+fn stable_auth_gate_id(
+    capability_id: &CapabilityId,
+    credential_requirements: &[RuntimeCredentialAuthRequirement],
+) -> RuntimeGateId {
+    let mut parts = vec![format!("capability={}", capability_id.as_str())];
+    let mut requirements = credential_requirements
+        .iter()
+        .map(|requirement| {
+            let mut scopes = requirement.provider_scopes.clone();
+            scopes.sort();
+            format!(
+                "credential={}:{}:{}",
+                requirement.provider.as_str(),
+                requirement.requester_extension.as_str(),
+                scopes.join(",")
+            )
+        })
+        .collect::<Vec<_>>();
+    requirements.sort();
+    parts.extend(requirements);
+
+    let digest = sha256_digest_token(parts.join("\n").as_bytes());
+    let suffix = digest.strip_prefix("sha256:").unwrap_or(&digest);
+    RuntimeGateId::from_stable_suffix(&format!("auth-{suffix}"))
+        .unwrap_or_else(|_| RuntimeGateId::new())
+}

--- a/crates/ironclaw_reborn_composition/src/runtime_credential_unauthorized.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime_credential_unauthorized.rs
@@ -1,32 +1,42 @@
 use std::sync::Arc;
 
+use crate::runtime_credential_reauth::RuntimeCredentialReauthBridge;
 use async_trait::async_trait;
 use ironclaw_auth::{
     AuthProductScope, AuthProviderId, AuthSurface, CredentialAccountId, CredentialAccountService,
-    CredentialRefreshRequest,
+    CredentialAccountStatus, CredentialRefreshRequest,
 };
 use ironclaw_host_api::{
-    RuntimeCredentialUnauthorized, RuntimeCredentialUnauthorizedPolicy, RuntimeHttpEgress,
-    RuntimeHttpEgressError, RuntimeHttpEgressRequest, RuntimeHttpEgressResponse,
+    CapabilityId, ResourceScope, RuntimeCredentialUnauthorized,
+    RuntimeCredentialUnauthorizedPolicy, RuntimeHttpEgress, RuntimeHttpEgressError,
+    RuntimeHttpEgressRequest, RuntimeHttpEgressResponse,
 };
 
 pub(crate) struct RuntimeCredentialUnauthorizedRecoveryEgress {
     inner: Arc<dyn RuntimeHttpEgress>,
     credential_accounts: Arc<dyn CredentialAccountService>,
+    reauth_bridge: Arc<RuntimeCredentialReauthBridge>,
 }
 
 impl RuntimeCredentialUnauthorizedRecoveryEgress {
     pub(crate) fn new(
         inner: Arc<dyn RuntimeHttpEgress>,
         credential_accounts: Arc<dyn CredentialAccountService>,
+        reauth_bridge: Arc<RuntimeCredentialReauthBridge>,
     ) -> Self {
         Self {
             inner,
             credential_accounts,
+            reauth_bridge,
         }
     }
 
-    async fn recover_unauthorized_credential(&self, response: &RuntimeHttpEgressResponse) {
+    async fn recover_unauthorized_credential(
+        &self,
+        request_scope: &ResourceScope,
+        capability_id: &CapabilityId,
+        response: &RuntimeHttpEgressResponse,
+    ) {
         let Some(unauthorized) = &response.credential_unauthorized else {
             return;
         };
@@ -39,23 +49,43 @@ impl RuntimeCredentialUnauthorizedRecoveryEgress {
         };
         let account_id = CredentialAccountId::from_uuid(account_uuid);
         let scope = AuthProductScope::credential_owner(&unauthorized.scope, AuthSurface::Api);
-        let Some(account_updated_at) = unauthorized.account_updated_at else {
-            tracing::warn!(
-                account_id = %unauthorized.account_id,
-                "runtime HTTP credential unauthorized marker did not carry an account freshness marker"
-            );
-            return;
-        };
+        let account_updated_at = unauthorized.account_updated_at;
         match unauthorized.unauthorized_policy {
             RuntimeCredentialUnauthorizedPolicy::RevokeAccount => {
-                self.revoke_if_unchanged(&scope, account_id, account_updated_at)
-                    .await;
+                if self
+                    .revoke_if_unchanged(
+                        &scope,
+                        account_id,
+                        account_updated_at,
+                        unauthorized.requester_extension.clone(),
+                    )
+                    .await
+                {
+                    self.record_recovered_auth_required(request_scope, capability_id, unauthorized);
+                }
             }
             RuntimeCredentialUnauthorizedPolicy::RefreshAccount => {
-                self.refresh_if_unchanged(&scope, account_id, account_updated_at, unauthorized)
-                    .await;
+                if self
+                    .refresh_if_unchanged(&scope, account_id, account_updated_at, unauthorized)
+                    .await
+                {
+                    self.record_recovered_auth_required(request_scope, capability_id, unauthorized);
+                }
             }
         }
+    }
+
+    fn record_recovered_auth_required(
+        &self,
+        request_scope: &ResourceScope,
+        capability_id: &CapabilityId,
+        unauthorized: &RuntimeCredentialUnauthorized,
+    ) {
+        self.reauth_bridge.record_recovered_auth_required(
+            request_scope,
+            capability_id,
+            vec![unauthorized.auth_requirement.clone()],
+        );
     }
 
     async fn revoke_if_unchanged(
@@ -63,27 +93,28 @@ impl RuntimeCredentialUnauthorizedRecoveryEgress {
         scope: &AuthProductScope,
         account_id: CredentialAccountId,
         account_updated_at: ironclaw_host_api::Timestamp,
-    ) {
+        requester_extension: Option<ironclaw_host_api::ExtensionId>,
+    ) -> bool {
         let account_id_for_log = account_id.to_string();
         match self
             .credential_accounts
-            .revoke_if_unchanged(&scope, account_id, account_updated_at)
+            .revoke_if_unchanged(&scope, account_id, account_updated_at, requester_extension)
             .await
         {
-            Ok(Some(_)) => {}
+            Ok(Some(_)) => true,
             Ok(None) => {
                 tracing::info!(
                     account_id = %account_id_for_log,
                     "runtime HTTP credential unauthorized recovery skipped because account changed or disappeared after staging"
                 );
-                return;
+                false
             }
             Err(error) => {
                 tracing::warn!(
                     err = %error,
                     "runtime HTTP credential unauthorized recovery could not conditionally revoke account"
                 );
-                return;
+                false
             }
         }
     }
@@ -94,31 +125,45 @@ impl RuntimeCredentialUnauthorizedRecoveryEgress {
         account_id: CredentialAccountId,
         account_updated_at: ironclaw_host_api::Timestamp,
         unauthorized: &RuntimeCredentialUnauthorized,
-    ) {
+    ) -> bool {
         let Ok(request) = refresh_request(scope, account_id, unauthorized) else {
             tracing::warn!(
                 provider = %unauthorized.account_provider.as_str(),
                 "runtime HTTP credential unauthorized marker carried an invalid provider id"
             );
-            return;
+            return false;
         };
         match self
             .credential_accounts
             .refresh_if_unchanged(request, account_updated_at)
             .await
         {
-            Ok(Some(_)) => {}
+            Ok(Some(report)) => {
+                if report.account.status != CredentialAccountStatus::Configured {
+                    return true;
+                }
+                if !report.refreshed {
+                    tracing::info!(
+                        account_id = %unauthorized.account_id,
+                        "runtime HTTP credential unauthorized recovery refresh left account unchanged; requiring re-auth"
+                    );
+                    return true;
+                }
+                false
+            }
             Ok(None) => {
                 tracing::info!(
                     account_id = %unauthorized.account_id,
                     "runtime HTTP credential unauthorized recovery skipped refresh because account changed or disappeared after staging"
                 );
+                false
             }
             Err(error) => {
                 tracing::warn!(
                     err = %error,
                     "runtime HTTP credential unauthorized recovery could not refresh account"
                 );
+                false
             }
         }
     }
@@ -144,399 +189,14 @@ impl RuntimeHttpEgress for RuntimeCredentialUnauthorizedRecoveryEgress {
         &self,
         request: RuntimeHttpEgressRequest,
     ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {
+        let request_scope = request.scope.clone();
+        let capability_id = request.capability_id.clone();
         let response = self.inner.execute(request).await?;
-        self.recover_unauthorized_credential(&response).await;
+        self.recover_unauthorized_credential(&request_scope, &capability_id, &response)
+            .await;
         Ok(response)
     }
 }
 
 #[cfg(test)]
-mod tests {
-    use std::sync::Arc;
-
-    use ironclaw_auth::{
-        AuthProviderId, CredentialAccountLabel, CredentialAccountLookupRequest,
-        CredentialAccountStatus, CredentialOwnership, InMemoryAuthProductServices,
-        NewCredentialAccount, ProviderScope,
-    };
-    use ironclaw_host_api::{
-        CapabilityId, CredentialStageError, ExtensionId, InvocationId, NetworkMethod,
-        NetworkPolicy, ResourceScope, RuntimeCredentialAccountProviderId,
-        RuntimeCredentialAccountSetup, RuntimeCredentialUnauthorized,
-        RuntimeCredentialUnauthorizedPolicy, RuntimeKind, UserId,
-    };
-    use ironclaw_host_runtime::{
-        RuntimeCredentialAccountRequest, RuntimeCredentialAccountResolver,
-    };
-
-    use super::*;
-
-    #[tokio::test]
-    async fn runtime_credential_unauthorized_recovery_revokes_marked_401_account() {
-        let accounts = Arc::new(InMemoryAuthProductServices::new());
-        let resource_scope = resource_scope();
-        let auth_scope = AuthProductScope::credential_owner(&resource_scope, AuthSurface::Api);
-        let account = seed_account(&accounts, auth_scope.clone()).await;
-        let egress = Arc::new(FixedEgress {
-            status: 401,
-            credential_unauthorized: Some(RuntimeCredentialUnauthorized::new(
-                resource_scope.clone(),
-                RuntimeCredentialAccountProviderId::new("github").expect("provider"),
-                account.id.to_string(),
-                Some(account.updated_at),
-                RuntimeCredentialUnauthorizedPolicy::RevokeAccount,
-            )),
-        });
-        let wrapper = RuntimeCredentialUnauthorizedRecoveryEgress::new(egress, accounts.clone());
-
-        wrapper
-            .execute(request(resource_scope))
-            .await
-            .expect("egress response should pass through");
-
-        let stored = accounts
-            .get_account(CredentialAccountLookupRequest::new(auth_scope, account.id))
-            .await
-            .expect("lookup")
-            .expect("account");
-        assert_eq!(stored.status, CredentialAccountStatus::Revoked);
-    }
-
-    #[tokio::test]
-    async fn runtime_credential_unauthorized_recovery_makes_pat_auth_required_on_next_resolve() {
-        let accounts = Arc::new(InMemoryAuthProductServices::new());
-        let resource_scope = resource_scope();
-        let auth_scope = AuthProductScope::credential_owner(&resource_scope, AuthSurface::Api);
-        let account = seed_account(&accounts, auth_scope).await;
-        let egress = Arc::new(FixedEgress {
-            status: 401,
-            credential_unauthorized: Some(RuntimeCredentialUnauthorized::new(
-                resource_scope.clone(),
-                RuntimeCredentialAccountProviderId::new("github").expect("provider"),
-                account.id.to_string(),
-                Some(account.updated_at),
-                RuntimeCredentialUnauthorizedPolicy::RevokeAccount,
-            )),
-        });
-        let wrapper = RuntimeCredentialUnauthorizedRecoveryEgress::new(egress, accounts.clone());
-
-        wrapper
-            .execute(request(resource_scope.clone()))
-            .await
-            .expect("egress response should pass through");
-
-        let resolver = runtime_credential_resolver(accounts);
-        let error = resolver
-            .resolve_access_secret(RuntimeCredentialAccountRequest {
-                scope: &resource_scope,
-                provider: &RuntimeCredentialAccountProviderId::new("github").expect("provider"),
-                setup: &RuntimeCredentialAccountSetup::ManualToken,
-                provider_scopes: &[],
-                requester_extension: &ExtensionId::new("github").expect("extension id"),
-            })
-            .await
-            .expect_err("revoked PAT should require auth on next resolution");
-        assert_eq!(error, CredentialStageError::AuthRequired);
-    }
-
-    #[tokio::test]
-    async fn runtime_credential_unauthorized_recovery_refreshes_marked_401_account() {
-        let accounts = Arc::new(InMemoryAuthProductServices::new());
-        let resource_scope = resource_scope();
-        let auth_scope = AuthProductScope::credential_owner(&resource_scope, AuthSurface::Api);
-        let account = seed_oauth_account(&accounts, auth_scope.clone()).await;
-        let egress = Arc::new(FixedEgress {
-            status: 401,
-            credential_unauthorized: Some(RuntimeCredentialUnauthorized::new(
-                resource_scope.clone(),
-                RuntimeCredentialAccountProviderId::new("google").expect("provider"),
-                account.id.to_string(),
-                Some(account.updated_at),
-                RuntimeCredentialUnauthorizedPolicy::RefreshAccount,
-            )),
-        });
-        let wrapper = RuntimeCredentialUnauthorizedRecoveryEgress::new(egress, accounts.clone());
-
-        wrapper
-            .execute(request(resource_scope))
-            .await
-            .expect("egress response should pass through");
-
-        let stored = accounts
-            .get_account(CredentialAccountLookupRequest::new(auth_scope, account.id))
-            .await
-            .expect("lookup")
-            .expect("account");
-        assert_eq!(stored.status, CredentialAccountStatus::Configured);
-        assert_ne!(stored.access_secret, account.access_secret);
-    }
-
-    #[tokio::test]
-    async fn runtime_credential_unauthorized_recovery_refreshes_oauth_before_next_resolve() {
-        let accounts = Arc::new(InMemoryAuthProductServices::new());
-        let resource_scope = resource_scope();
-        let auth_scope = AuthProductScope::credential_owner(&resource_scope, AuthSurface::Api);
-        let account = seed_oauth_account(&accounts, auth_scope).await;
-        let old_access = account
-            .access_secret
-            .clone()
-            .expect("seed oauth access secret");
-        let egress = Arc::new(FixedEgress {
-            status: 401,
-            credential_unauthorized: Some(RuntimeCredentialUnauthorized::new(
-                resource_scope.clone(),
-                RuntimeCredentialAccountProviderId::new("google").expect("provider"),
-                account.id.to_string(),
-                Some(account.updated_at),
-                RuntimeCredentialUnauthorizedPolicy::RefreshAccount,
-            )),
-        });
-        let wrapper = RuntimeCredentialUnauthorizedRecoveryEgress::new(egress, accounts.clone());
-
-        wrapper
-            .execute(request(resource_scope.clone()))
-            .await
-            .expect("egress response should pass through");
-
-        let resolver = runtime_credential_resolver(accounts);
-        let provider_scopes = vec!["drive".to_string()];
-        let resolved = resolver
-            .resolve_access_secret(RuntimeCredentialAccountRequest {
-                scope: &resource_scope,
-                provider: &RuntimeCredentialAccountProviderId::new("google").expect("provider"),
-                setup: &RuntimeCredentialAccountSetup::OAuth { scopes: Vec::new() },
-                provider_scopes: &provider_scopes,
-                requester_extension: &ExtensionId::new("google-drive").expect("extension id"),
-            })
-            .await
-            .expect("refreshed OAuth account should resolve on next use");
-        assert_ne!(resolved.handle, old_access);
-    }
-
-    #[tokio::test]
-    async fn runtime_credential_unauthorized_recovery_refreshes_with_carried_requester() {
-        let accounts = Arc::new(InMemoryAuthProductServices::new());
-        let resource_scope = resource_scope();
-        let auth_scope = AuthProductScope::credential_owner(&resource_scope, AuthSurface::Api);
-        let owner_extension = ExtensionId::new("google-drive").expect("extension id");
-        let account = seed_oauth_account_with_ownership(
-            &accounts,
-            auth_scope.clone(),
-            CredentialOwnership::ExtensionOwned,
-            Some(owner_extension.clone()),
-        )
-        .await;
-        let egress = Arc::new(FixedEgress {
-            status: 401,
-            credential_unauthorized: Some(
-                RuntimeCredentialUnauthorized::new(
-                    resource_scope.clone(),
-                    RuntimeCredentialAccountProviderId::new("google").expect("provider"),
-                    account.id.to_string(),
-                    Some(account.updated_at),
-                    RuntimeCredentialUnauthorizedPolicy::RefreshAccount,
-                )
-                .with_requester_extension(Some(owner_extension.clone())),
-            ),
-        });
-        let wrapper = RuntimeCredentialUnauthorizedRecoveryEgress::new(egress, accounts.clone());
-
-        wrapper
-            .execute(request(resource_scope))
-            .await
-            .expect("egress response should pass through");
-
-        let stored = accounts
-            .get_account(
-                CredentialAccountLookupRequest::new(auth_scope, account.id)
-                    .for_extension(owner_extension),
-            )
-            .await
-            .expect("lookup")
-            .expect("account");
-        assert_eq!(stored.status, CredentialAccountStatus::Configured);
-        assert_ne!(stored.access_secret, account.access_secret);
-    }
-
-    #[tokio::test]
-    async fn runtime_credential_unauthorized_recovery_skips_stale_marker() {
-        let accounts = Arc::new(InMemoryAuthProductServices::new());
-        let resource_scope = resource_scope();
-        let auth_scope = AuthProductScope::credential_owner(&resource_scope, AuthSurface::Api);
-        let account = seed_account(&accounts, auth_scope.clone()).await;
-        accounts
-            .update_status(&auth_scope, account.id, CredentialAccountStatus::Inactive)
-            .await
-            .expect("touch account after staging");
-        let egress = Arc::new(FixedEgress {
-            status: 401,
-            credential_unauthorized: Some(RuntimeCredentialUnauthorized::new(
-                resource_scope.clone(),
-                RuntimeCredentialAccountProviderId::new("github").expect("provider"),
-                account.id.to_string(),
-                Some(account.updated_at),
-                RuntimeCredentialUnauthorizedPolicy::RevokeAccount,
-            )),
-        });
-        let wrapper = RuntimeCredentialUnauthorizedRecoveryEgress::new(egress, accounts.clone());
-
-        wrapper
-            .execute(request(resource_scope))
-            .await
-            .expect("egress response should pass through");
-
-        let stored = accounts
-            .get_account(CredentialAccountLookupRequest::new(auth_scope, account.id))
-            .await
-            .expect("lookup")
-            .expect("account");
-        assert_eq!(stored.status, CredentialAccountStatus::Inactive);
-    }
-
-    #[tokio::test]
-    async fn runtime_credential_unauthorized_recovery_leaves_unmarked_403_configured() {
-        let accounts = Arc::new(InMemoryAuthProductServices::new());
-        let resource_scope = resource_scope();
-        let auth_scope = AuthProductScope::credential_owner(&resource_scope, AuthSurface::Api);
-        let account = seed_account(&accounts, auth_scope.clone()).await;
-        let egress = Arc::new(FixedEgress {
-            status: 403,
-            credential_unauthorized: None,
-        });
-        let wrapper = RuntimeCredentialUnauthorizedRecoveryEgress::new(egress, accounts.clone());
-
-        wrapper
-            .execute(request(resource_scope))
-            .await
-            .expect("egress response should pass through");
-
-        let stored = accounts
-            .get_account(CredentialAccountLookupRequest::new(auth_scope, account.id))
-            .await
-            .expect("lookup")
-            .expect("account");
-        assert_eq!(stored.status, CredentialAccountStatus::Configured);
-    }
-
-    struct FixedEgress {
-        status: u16,
-        credential_unauthorized: Option<RuntimeCredentialUnauthorized>,
-    }
-
-    #[async_trait]
-    impl RuntimeHttpEgress for FixedEgress {
-        async fn execute(
-            &self,
-            _request: RuntimeHttpEgressRequest,
-        ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {
-            Ok(RuntimeHttpEgressResponse {
-                status: self.status,
-                headers: Vec::new(),
-                body: Vec::new(),
-                saved_body: None,
-                request_bytes: 0,
-                response_bytes: 0,
-                redaction_applied: false,
-                credential_unauthorized: self.credential_unauthorized.clone(),
-            })
-        }
-    }
-
-    async fn seed_account(
-        accounts: &InMemoryAuthProductServices,
-        scope: AuthProductScope,
-    ) -> ironclaw_auth::CredentialAccount {
-        accounts
-            .create_account(NewCredentialAccount {
-                scope,
-                provider: AuthProviderId::new("github").expect("provider"),
-                label: CredentialAccountLabel::new("github account").expect("label"),
-                status: CredentialAccountStatus::Configured,
-                ownership: CredentialOwnership::UserReusable,
-                owner_extension: None,
-                granted_extensions: Vec::new(),
-                access_secret: Some(
-                    ironclaw_host_api::SecretHandle::new("github-access")
-                        .expect("access secret handle"),
-                ),
-                refresh_secret: None,
-                scopes: vec![ProviderScope::new("repo").expect("scope")],
-            })
-            .await
-            .expect("seed account")
-    }
-
-    async fn seed_oauth_account(
-        accounts: &InMemoryAuthProductServices,
-        scope: AuthProductScope,
-    ) -> ironclaw_auth::CredentialAccount {
-        seed_oauth_account_with_ownership(accounts, scope, CredentialOwnership::UserReusable, None)
-            .await
-    }
-
-    async fn seed_oauth_account_with_ownership(
-        accounts: &InMemoryAuthProductServices,
-        scope: AuthProductScope,
-        ownership: CredentialOwnership,
-        owner_extension: Option<ExtensionId>,
-    ) -> ironclaw_auth::CredentialAccount {
-        accounts
-            .create_account(NewCredentialAccount {
-                scope,
-                provider: AuthProviderId::new("google").expect("provider"),
-                label: CredentialAccountLabel::new("google account").expect("label"),
-                status: CredentialAccountStatus::Configured,
-                ownership,
-                owner_extension,
-                granted_extensions: Vec::new(),
-                access_secret: Some(
-                    ironclaw_host_api::SecretHandle::new("google-old-access")
-                        .expect("access secret handle"),
-                ),
-                refresh_secret: Some(
-                    ironclaw_host_api::SecretHandle::new("google-refresh")
-                        .expect("refresh secret handle"),
-                ),
-                scopes: vec![ProviderScope::new("drive").expect("scope")],
-            })
-            .await
-            .expect("seed oauth account")
-    }
-
-    fn runtime_credential_resolver(
-        accounts: Arc<InMemoryAuthProductServices>,
-    ) -> crate::product_auth_runtime_credentials::ProductAuthRuntimeCredentialResolver {
-        crate::product_auth_runtime_credentials::ProductAuthRuntimeCredentialResolver::new(
-            Arc::new(
-                crate::product_auth_runtime_credentials::ProductAuthRuntimeCredentialAccountSelector::new(
-                    accounts,
-                ),
-            ),
-        )
-    }
-
-    fn resource_scope() -> ResourceScope {
-        ResourceScope::local_default(UserId::new("alice").unwrap(), InvocationId::new()).unwrap()
-    }
-
-    fn request(scope: ResourceScope) -> RuntimeHttpEgressRequest {
-        RuntimeHttpEgressRequest {
-            runtime: RuntimeKind::Wasm,
-            scope,
-            capability_id: CapabilityId::new("github.search").unwrap(),
-            method: NetworkMethod::Get,
-            url: "https://api.github.com/user".to_string(),
-            headers: Vec::new(),
-            body: Vec::new(),
-            network_policy: NetworkPolicy {
-                allowed_targets: Vec::new(),
-                deny_private_ip_ranges: true,
-                max_egress_bytes: None,
-            },
-            credential_injections: Vec::new(),
-            response_body_limit: None,
-            save_body_to: None,
-            timeout_ms: None,
-        }
-    }
-}
+mod tests;

--- a/crates/ironclaw_reborn_composition/src/runtime_credential_unauthorized.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime_credential_unauthorized.rs
@@ -1,0 +1,542 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use ironclaw_auth::{
+    AuthProductScope, AuthProviderId, AuthSurface, CredentialAccountId, CredentialAccountService,
+    CredentialRefreshRequest,
+};
+use ironclaw_host_api::{
+    RuntimeCredentialUnauthorized, RuntimeCredentialUnauthorizedPolicy, RuntimeHttpEgress,
+    RuntimeHttpEgressError, RuntimeHttpEgressRequest, RuntimeHttpEgressResponse,
+};
+
+pub(crate) struct RuntimeCredentialUnauthorizedRecoveryEgress {
+    inner: Arc<dyn RuntimeHttpEgress>,
+    credential_accounts: Arc<dyn CredentialAccountService>,
+}
+
+impl RuntimeCredentialUnauthorizedRecoveryEgress {
+    pub(crate) fn new(
+        inner: Arc<dyn RuntimeHttpEgress>,
+        credential_accounts: Arc<dyn CredentialAccountService>,
+    ) -> Self {
+        Self {
+            inner,
+            credential_accounts,
+        }
+    }
+
+    async fn recover_unauthorized_credential(&self, response: &RuntimeHttpEgressResponse) {
+        let Some(unauthorized) = &response.credential_unauthorized else {
+            return;
+        };
+        let Ok(account_uuid) = uuid::Uuid::parse_str(&unauthorized.account_id) else {
+            tracing::warn!(
+                account_id = %unauthorized.account_id,
+                "runtime HTTP credential unauthorized marker carried an invalid account id"
+            );
+            return;
+        };
+        let account_id = CredentialAccountId::from_uuid(account_uuid);
+        let scope = AuthProductScope::credential_owner(&unauthorized.scope, AuthSurface::Api);
+        let Some(account_updated_at) = unauthorized.account_updated_at else {
+            tracing::warn!(
+                account_id = %unauthorized.account_id,
+                "runtime HTTP credential unauthorized marker did not carry an account freshness marker"
+            );
+            return;
+        };
+        match unauthorized.unauthorized_policy {
+            RuntimeCredentialUnauthorizedPolicy::RevokeAccount => {
+                self.revoke_if_unchanged(&scope, account_id, account_updated_at)
+                    .await;
+            }
+            RuntimeCredentialUnauthorizedPolicy::RefreshAccount => {
+                self.refresh_if_unchanged(&scope, account_id, account_updated_at, unauthorized)
+                    .await;
+            }
+        }
+    }
+
+    async fn revoke_if_unchanged(
+        &self,
+        scope: &AuthProductScope,
+        account_id: CredentialAccountId,
+        account_updated_at: ironclaw_host_api::Timestamp,
+    ) {
+        let account_id_for_log = account_id.to_string();
+        match self
+            .credential_accounts
+            .revoke_if_unchanged(&scope, account_id, account_updated_at)
+            .await
+        {
+            Ok(Some(_)) => {}
+            Ok(None) => {
+                tracing::info!(
+                    account_id = %account_id_for_log,
+                    "runtime HTTP credential unauthorized recovery skipped because account changed or disappeared after staging"
+                );
+                return;
+            }
+            Err(error) => {
+                tracing::warn!(
+                    err = %error,
+                    "runtime HTTP credential unauthorized recovery could not conditionally revoke account"
+                );
+                return;
+            }
+        }
+    }
+
+    async fn refresh_if_unchanged(
+        &self,
+        scope: &AuthProductScope,
+        account_id: CredentialAccountId,
+        account_updated_at: ironclaw_host_api::Timestamp,
+        unauthorized: &RuntimeCredentialUnauthorized,
+    ) {
+        let Ok(request) = refresh_request(scope, account_id, unauthorized) else {
+            tracing::warn!(
+                provider = %unauthorized.account_provider.as_str(),
+                "runtime HTTP credential unauthorized marker carried an invalid provider id"
+            );
+            return;
+        };
+        match self
+            .credential_accounts
+            .refresh_if_unchanged(request, account_updated_at)
+            .await
+        {
+            Ok(Some(_)) => {}
+            Ok(None) => {
+                tracing::info!(
+                    account_id = %unauthorized.account_id,
+                    "runtime HTTP credential unauthorized recovery skipped refresh because account changed or disappeared after staging"
+                );
+            }
+            Err(error) => {
+                tracing::warn!(
+                    err = %error,
+                    "runtime HTTP credential unauthorized recovery could not refresh account"
+                );
+            }
+        }
+    }
+}
+
+fn refresh_request(
+    scope: &AuthProductScope,
+    account_id: CredentialAccountId,
+    unauthorized: &RuntimeCredentialUnauthorized,
+) -> Result<CredentialRefreshRequest, ironclaw_auth::AuthProductError> {
+    let provider = AuthProviderId::new(unauthorized.account_provider.as_str())
+        .map_err(|_| ironclaw_auth::AuthProductError::MalformedConfig)?;
+    let mut request = CredentialRefreshRequest::new(scope.clone(), provider, account_id);
+    if let Some(requester_extension) = unauthorized.requester_extension.clone() {
+        request = request.for_extension(requester_extension);
+    }
+    Ok(request)
+}
+
+#[async_trait]
+impl RuntimeHttpEgress for RuntimeCredentialUnauthorizedRecoveryEgress {
+    async fn execute(
+        &self,
+        request: RuntimeHttpEgressRequest,
+    ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {
+        let response = self.inner.execute(request).await?;
+        self.recover_unauthorized_credential(&response).await;
+        Ok(response)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use ironclaw_auth::{
+        AuthProviderId, CredentialAccountLabel, CredentialAccountLookupRequest,
+        CredentialAccountStatus, CredentialOwnership, InMemoryAuthProductServices,
+        NewCredentialAccount, ProviderScope,
+    };
+    use ironclaw_host_api::{
+        CapabilityId, CredentialStageError, ExtensionId, InvocationId, NetworkMethod,
+        NetworkPolicy, ResourceScope, RuntimeCredentialAccountProviderId,
+        RuntimeCredentialAccountSetup, RuntimeCredentialUnauthorized,
+        RuntimeCredentialUnauthorizedPolicy, RuntimeKind, UserId,
+    };
+    use ironclaw_host_runtime::{
+        RuntimeCredentialAccountRequest, RuntimeCredentialAccountResolver,
+    };
+
+    use super::*;
+
+    #[tokio::test]
+    async fn runtime_credential_unauthorized_recovery_revokes_marked_401_account() {
+        let accounts = Arc::new(InMemoryAuthProductServices::new());
+        let resource_scope = resource_scope();
+        let auth_scope = AuthProductScope::credential_owner(&resource_scope, AuthSurface::Api);
+        let account = seed_account(&accounts, auth_scope.clone()).await;
+        let egress = Arc::new(FixedEgress {
+            status: 401,
+            credential_unauthorized: Some(RuntimeCredentialUnauthorized::new(
+                resource_scope.clone(),
+                RuntimeCredentialAccountProviderId::new("github").expect("provider"),
+                account.id.to_string(),
+                Some(account.updated_at),
+                RuntimeCredentialUnauthorizedPolicy::RevokeAccount,
+            )),
+        });
+        let wrapper = RuntimeCredentialUnauthorizedRecoveryEgress::new(egress, accounts.clone());
+
+        wrapper
+            .execute(request(resource_scope))
+            .await
+            .expect("egress response should pass through");
+
+        let stored = accounts
+            .get_account(CredentialAccountLookupRequest::new(auth_scope, account.id))
+            .await
+            .expect("lookup")
+            .expect("account");
+        assert_eq!(stored.status, CredentialAccountStatus::Revoked);
+    }
+
+    #[tokio::test]
+    async fn runtime_credential_unauthorized_recovery_makes_pat_auth_required_on_next_resolve() {
+        let accounts = Arc::new(InMemoryAuthProductServices::new());
+        let resource_scope = resource_scope();
+        let auth_scope = AuthProductScope::credential_owner(&resource_scope, AuthSurface::Api);
+        let account = seed_account(&accounts, auth_scope).await;
+        let egress = Arc::new(FixedEgress {
+            status: 401,
+            credential_unauthorized: Some(RuntimeCredentialUnauthorized::new(
+                resource_scope.clone(),
+                RuntimeCredentialAccountProviderId::new("github").expect("provider"),
+                account.id.to_string(),
+                Some(account.updated_at),
+                RuntimeCredentialUnauthorizedPolicy::RevokeAccount,
+            )),
+        });
+        let wrapper = RuntimeCredentialUnauthorizedRecoveryEgress::new(egress, accounts.clone());
+
+        wrapper
+            .execute(request(resource_scope.clone()))
+            .await
+            .expect("egress response should pass through");
+
+        let resolver = runtime_credential_resolver(accounts);
+        let error = resolver
+            .resolve_access_secret(RuntimeCredentialAccountRequest {
+                scope: &resource_scope,
+                provider: &RuntimeCredentialAccountProviderId::new("github").expect("provider"),
+                setup: &RuntimeCredentialAccountSetup::ManualToken,
+                provider_scopes: &[],
+                requester_extension: &ExtensionId::new("github").expect("extension id"),
+            })
+            .await
+            .expect_err("revoked PAT should require auth on next resolution");
+        assert_eq!(error, CredentialStageError::AuthRequired);
+    }
+
+    #[tokio::test]
+    async fn runtime_credential_unauthorized_recovery_refreshes_marked_401_account() {
+        let accounts = Arc::new(InMemoryAuthProductServices::new());
+        let resource_scope = resource_scope();
+        let auth_scope = AuthProductScope::credential_owner(&resource_scope, AuthSurface::Api);
+        let account = seed_oauth_account(&accounts, auth_scope.clone()).await;
+        let egress = Arc::new(FixedEgress {
+            status: 401,
+            credential_unauthorized: Some(RuntimeCredentialUnauthorized::new(
+                resource_scope.clone(),
+                RuntimeCredentialAccountProviderId::new("google").expect("provider"),
+                account.id.to_string(),
+                Some(account.updated_at),
+                RuntimeCredentialUnauthorizedPolicy::RefreshAccount,
+            )),
+        });
+        let wrapper = RuntimeCredentialUnauthorizedRecoveryEgress::new(egress, accounts.clone());
+
+        wrapper
+            .execute(request(resource_scope))
+            .await
+            .expect("egress response should pass through");
+
+        let stored = accounts
+            .get_account(CredentialAccountLookupRequest::new(auth_scope, account.id))
+            .await
+            .expect("lookup")
+            .expect("account");
+        assert_eq!(stored.status, CredentialAccountStatus::Configured);
+        assert_ne!(stored.access_secret, account.access_secret);
+    }
+
+    #[tokio::test]
+    async fn runtime_credential_unauthorized_recovery_refreshes_oauth_before_next_resolve() {
+        let accounts = Arc::new(InMemoryAuthProductServices::new());
+        let resource_scope = resource_scope();
+        let auth_scope = AuthProductScope::credential_owner(&resource_scope, AuthSurface::Api);
+        let account = seed_oauth_account(&accounts, auth_scope).await;
+        let old_access = account
+            .access_secret
+            .clone()
+            .expect("seed oauth access secret");
+        let egress = Arc::new(FixedEgress {
+            status: 401,
+            credential_unauthorized: Some(RuntimeCredentialUnauthorized::new(
+                resource_scope.clone(),
+                RuntimeCredentialAccountProviderId::new("google").expect("provider"),
+                account.id.to_string(),
+                Some(account.updated_at),
+                RuntimeCredentialUnauthorizedPolicy::RefreshAccount,
+            )),
+        });
+        let wrapper = RuntimeCredentialUnauthorizedRecoveryEgress::new(egress, accounts.clone());
+
+        wrapper
+            .execute(request(resource_scope.clone()))
+            .await
+            .expect("egress response should pass through");
+
+        let resolver = runtime_credential_resolver(accounts);
+        let provider_scopes = vec!["drive".to_string()];
+        let resolved = resolver
+            .resolve_access_secret(RuntimeCredentialAccountRequest {
+                scope: &resource_scope,
+                provider: &RuntimeCredentialAccountProviderId::new("google").expect("provider"),
+                setup: &RuntimeCredentialAccountSetup::OAuth { scopes: Vec::new() },
+                provider_scopes: &provider_scopes,
+                requester_extension: &ExtensionId::new("google-drive").expect("extension id"),
+            })
+            .await
+            .expect("refreshed OAuth account should resolve on next use");
+        assert_ne!(resolved.handle, old_access);
+    }
+
+    #[tokio::test]
+    async fn runtime_credential_unauthorized_recovery_refreshes_with_carried_requester() {
+        let accounts = Arc::new(InMemoryAuthProductServices::new());
+        let resource_scope = resource_scope();
+        let auth_scope = AuthProductScope::credential_owner(&resource_scope, AuthSurface::Api);
+        let owner_extension = ExtensionId::new("google-drive").expect("extension id");
+        let account = seed_oauth_account_with_ownership(
+            &accounts,
+            auth_scope.clone(),
+            CredentialOwnership::ExtensionOwned,
+            Some(owner_extension.clone()),
+        )
+        .await;
+        let egress = Arc::new(FixedEgress {
+            status: 401,
+            credential_unauthorized: Some(
+                RuntimeCredentialUnauthorized::new(
+                    resource_scope.clone(),
+                    RuntimeCredentialAccountProviderId::new("google").expect("provider"),
+                    account.id.to_string(),
+                    Some(account.updated_at),
+                    RuntimeCredentialUnauthorizedPolicy::RefreshAccount,
+                )
+                .with_requester_extension(Some(owner_extension.clone())),
+            ),
+        });
+        let wrapper = RuntimeCredentialUnauthorizedRecoveryEgress::new(egress, accounts.clone());
+
+        wrapper
+            .execute(request(resource_scope))
+            .await
+            .expect("egress response should pass through");
+
+        let stored = accounts
+            .get_account(
+                CredentialAccountLookupRequest::new(auth_scope, account.id)
+                    .for_extension(owner_extension),
+            )
+            .await
+            .expect("lookup")
+            .expect("account");
+        assert_eq!(stored.status, CredentialAccountStatus::Configured);
+        assert_ne!(stored.access_secret, account.access_secret);
+    }
+
+    #[tokio::test]
+    async fn runtime_credential_unauthorized_recovery_skips_stale_marker() {
+        let accounts = Arc::new(InMemoryAuthProductServices::new());
+        let resource_scope = resource_scope();
+        let auth_scope = AuthProductScope::credential_owner(&resource_scope, AuthSurface::Api);
+        let account = seed_account(&accounts, auth_scope.clone()).await;
+        accounts
+            .update_status(&auth_scope, account.id, CredentialAccountStatus::Inactive)
+            .await
+            .expect("touch account after staging");
+        let egress = Arc::new(FixedEgress {
+            status: 401,
+            credential_unauthorized: Some(RuntimeCredentialUnauthorized::new(
+                resource_scope.clone(),
+                RuntimeCredentialAccountProviderId::new("github").expect("provider"),
+                account.id.to_string(),
+                Some(account.updated_at),
+                RuntimeCredentialUnauthorizedPolicy::RevokeAccount,
+            )),
+        });
+        let wrapper = RuntimeCredentialUnauthorizedRecoveryEgress::new(egress, accounts.clone());
+
+        wrapper
+            .execute(request(resource_scope))
+            .await
+            .expect("egress response should pass through");
+
+        let stored = accounts
+            .get_account(CredentialAccountLookupRequest::new(auth_scope, account.id))
+            .await
+            .expect("lookup")
+            .expect("account");
+        assert_eq!(stored.status, CredentialAccountStatus::Inactive);
+    }
+
+    #[tokio::test]
+    async fn runtime_credential_unauthorized_recovery_leaves_unmarked_403_configured() {
+        let accounts = Arc::new(InMemoryAuthProductServices::new());
+        let resource_scope = resource_scope();
+        let auth_scope = AuthProductScope::credential_owner(&resource_scope, AuthSurface::Api);
+        let account = seed_account(&accounts, auth_scope.clone()).await;
+        let egress = Arc::new(FixedEgress {
+            status: 403,
+            credential_unauthorized: None,
+        });
+        let wrapper = RuntimeCredentialUnauthorizedRecoveryEgress::new(egress, accounts.clone());
+
+        wrapper
+            .execute(request(resource_scope))
+            .await
+            .expect("egress response should pass through");
+
+        let stored = accounts
+            .get_account(CredentialAccountLookupRequest::new(auth_scope, account.id))
+            .await
+            .expect("lookup")
+            .expect("account");
+        assert_eq!(stored.status, CredentialAccountStatus::Configured);
+    }
+
+    struct FixedEgress {
+        status: u16,
+        credential_unauthorized: Option<RuntimeCredentialUnauthorized>,
+    }
+
+    #[async_trait]
+    impl RuntimeHttpEgress for FixedEgress {
+        async fn execute(
+            &self,
+            _request: RuntimeHttpEgressRequest,
+        ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {
+            Ok(RuntimeHttpEgressResponse {
+                status: self.status,
+                headers: Vec::new(),
+                body: Vec::new(),
+                saved_body: None,
+                request_bytes: 0,
+                response_bytes: 0,
+                redaction_applied: false,
+                credential_unauthorized: self.credential_unauthorized.clone(),
+            })
+        }
+    }
+
+    async fn seed_account(
+        accounts: &InMemoryAuthProductServices,
+        scope: AuthProductScope,
+    ) -> ironclaw_auth::CredentialAccount {
+        accounts
+            .create_account(NewCredentialAccount {
+                scope,
+                provider: AuthProviderId::new("github").expect("provider"),
+                label: CredentialAccountLabel::new("github account").expect("label"),
+                status: CredentialAccountStatus::Configured,
+                ownership: CredentialOwnership::UserReusable,
+                owner_extension: None,
+                granted_extensions: Vec::new(),
+                access_secret: Some(
+                    ironclaw_host_api::SecretHandle::new("github-access")
+                        .expect("access secret handle"),
+                ),
+                refresh_secret: None,
+                scopes: vec![ProviderScope::new("repo").expect("scope")],
+            })
+            .await
+            .expect("seed account")
+    }
+
+    async fn seed_oauth_account(
+        accounts: &InMemoryAuthProductServices,
+        scope: AuthProductScope,
+    ) -> ironclaw_auth::CredentialAccount {
+        seed_oauth_account_with_ownership(accounts, scope, CredentialOwnership::UserReusable, None)
+            .await
+    }
+
+    async fn seed_oauth_account_with_ownership(
+        accounts: &InMemoryAuthProductServices,
+        scope: AuthProductScope,
+        ownership: CredentialOwnership,
+        owner_extension: Option<ExtensionId>,
+    ) -> ironclaw_auth::CredentialAccount {
+        accounts
+            .create_account(NewCredentialAccount {
+                scope,
+                provider: AuthProviderId::new("google").expect("provider"),
+                label: CredentialAccountLabel::new("google account").expect("label"),
+                status: CredentialAccountStatus::Configured,
+                ownership,
+                owner_extension,
+                granted_extensions: Vec::new(),
+                access_secret: Some(
+                    ironclaw_host_api::SecretHandle::new("google-old-access")
+                        .expect("access secret handle"),
+                ),
+                refresh_secret: Some(
+                    ironclaw_host_api::SecretHandle::new("google-refresh")
+                        .expect("refresh secret handle"),
+                ),
+                scopes: vec![ProviderScope::new("drive").expect("scope")],
+            })
+            .await
+            .expect("seed oauth account")
+    }
+
+    fn runtime_credential_resolver(
+        accounts: Arc<InMemoryAuthProductServices>,
+    ) -> crate::product_auth_runtime_credentials::ProductAuthRuntimeCredentialResolver {
+        crate::product_auth_runtime_credentials::ProductAuthRuntimeCredentialResolver::new(
+            Arc::new(
+                crate::product_auth_runtime_credentials::ProductAuthRuntimeCredentialAccountSelector::new(
+                    accounts,
+                ),
+            ),
+        )
+    }
+
+    fn resource_scope() -> ResourceScope {
+        ResourceScope::local_default(UserId::new("alice").unwrap(), InvocationId::new()).unwrap()
+    }
+
+    fn request(scope: ResourceScope) -> RuntimeHttpEgressRequest {
+        RuntimeHttpEgressRequest {
+            runtime: RuntimeKind::Wasm,
+            scope,
+            capability_id: CapabilityId::new("github.search").unwrap(),
+            method: NetworkMethod::Get,
+            url: "https://api.github.com/user".to_string(),
+            headers: Vec::new(),
+            body: Vec::new(),
+            network_policy: NetworkPolicy {
+                allowed_targets: Vec::new(),
+                deny_private_ip_ranges: true,
+                max_egress_bytes: None,
+            },
+            credential_injections: Vec::new(),
+            response_body_limit: None,
+            save_body_to: None,
+            timeout_ms: None,
+        }
+    }
+}

--- a/crates/ironclaw_reborn_composition/src/runtime_credential_unauthorized/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime_credential_unauthorized/tests.rs
@@ -1,0 +1,830 @@
+use std::sync::Arc;
+
+use ironclaw_auth::{
+    AuthProductError, AuthProviderId, CredentialAccountLabel, CredentialAccountLookupRequest,
+    CredentialAccountProjection, CredentialAccountStatus, CredentialOwnership,
+    CredentialRecoveryProjection, CredentialRefreshReport, CredentialRefreshRequest,
+    InMemoryAuthProductServices, NewCredentialAccount, ProviderScope,
+};
+use ironclaw_host_api::{
+    CapabilityId, CapabilitySet, CorrelationId, CredentialStageError, ExecutionContext,
+    ExtensionId, InvocationId, MountView, NetworkMethod, NetworkPolicy, ResourceEstimate,
+    ResourceScope, ResourceUsage, RuntimeCredentialAccountProviderId,
+    RuntimeCredentialAccountSetup, RuntimeCredentialAuthRequirement, RuntimeCredentialUnauthorized,
+    RuntimeCredentialUnauthorizedPolicy, RuntimeKind, TrustClass, UserId,
+};
+use ironclaw_host_runtime::{
+    CancelRuntimeWorkOutcome, CancelRuntimeWorkRequest, HostRuntime, HostRuntimeError,
+    HostRuntimeHealth, HostRuntimeStatus, RuntimeCapabilityCompleted, RuntimeCapabilityOutcome,
+    RuntimeCapabilityRequest, RuntimeCapabilityResumeRequest, RuntimeCredentialAccountRequest,
+    RuntimeCredentialAccountResolver, RuntimeStatusRequest, VisibleCapabilityRequest,
+    VisibleCapabilitySurface,
+};
+use ironclaw_trust::{AuthorityCeiling, EffectiveTrustClass, TrustDecision, TrustProvenance};
+
+use crate::runtime_credential_reauth::RuntimeCredentialReauthHostRuntime;
+
+use super::*;
+
+#[tokio::test]
+async fn runtime_credential_unauthorized_recovery_revokes_marked_401_account() {
+    let accounts = Arc::new(InMemoryAuthProductServices::new());
+    let resource_scope = resource_scope();
+    let auth_scope = AuthProductScope::credential_owner(&resource_scope, AuthSurface::Api);
+    let account = seed_account(&accounts, auth_scope.clone()).await;
+    let egress = Arc::new(FixedEgress {
+        status: 401,
+        credential_unauthorized: Some(unauthorized_marker(
+            &resource_scope,
+            "github",
+            &account,
+            RuntimeCredentialUnauthorizedPolicy::RevokeAccount,
+            github_auth_requirement(),
+            None,
+        )),
+    });
+    let reauth_bridge = Arc::new(RuntimeCredentialReauthBridge::default());
+    let wrapper =
+        RuntimeCredentialUnauthorizedRecoveryEgress::new(egress, accounts.clone(), reauth_bridge);
+
+    wrapper
+        .execute(request(resource_scope))
+        .await
+        .expect("egress response should pass through");
+
+    let stored = accounts
+        .get_account(CredentialAccountLookupRequest::new(auth_scope, account.id))
+        .await
+        .expect("lookup")
+        .expect("account");
+    assert_eq!(stored.status, CredentialAccountStatus::Revoked);
+}
+
+#[tokio::test]
+async fn runtime_credential_unauthorized_recovery_records_same_run_auth_required_signal() {
+    let accounts = Arc::new(InMemoryAuthProductServices::new());
+    let resource_scope = resource_scope();
+    let auth_scope = AuthProductScope::credential_owner(&resource_scope, AuthSurface::Api);
+    let account = seed_account(&accounts, auth_scope).await;
+    let egress = Arc::new(FixedEgress {
+        status: 401,
+        credential_unauthorized: Some(unauthorized_marker(
+            &resource_scope,
+            "github",
+            &account,
+            RuntimeCredentialUnauthorizedPolicy::RevokeAccount,
+            github_auth_requirement(),
+            None,
+        )),
+    });
+    let reauth_bridge = Arc::new(RuntimeCredentialReauthBridge::default());
+    let wrapper = RuntimeCredentialUnauthorizedRecoveryEgress::new(
+        egress,
+        accounts,
+        Arc::clone(&reauth_bridge),
+    );
+    let runtime_request = request(resource_scope.clone());
+    let capability_id = runtime_request.capability_id.clone();
+
+    wrapper
+        .execute(runtime_request)
+        .await
+        .expect("egress response should pass through");
+
+    let signal = reauth_bridge
+        .take_recovered_auth_required(&resource_scope, &capability_id)
+        .expect("revoke should record same-run auth required");
+    assert_eq!(
+        signal.credential_requirements,
+        vec![github_auth_requirement()]
+    );
+}
+
+#[tokio::test]
+async fn runtime_credential_unauthorized_recovery_requires_auth_when_refresh_leaves_token_unchanged()
+ {
+    let inner = Arc::new(InMemoryAuthProductServices::new());
+    let resource_scope = resource_scope();
+    let auth_scope = AuthProductScope::credential_owner(&resource_scope, AuthSurface::Api);
+    let account = seed_oauth_account(&inner, auth_scope).await;
+    let accounts = Arc::new(NoopRefreshCredentialAccounts {
+        inner: Arc::clone(&inner),
+    });
+    let egress = Arc::new(FixedEgress {
+        status: 401,
+        credential_unauthorized: Some(unauthorized_marker(
+            &resource_scope,
+            "google",
+            &account,
+            RuntimeCredentialUnauthorizedPolicy::RefreshAccount,
+            google_auth_requirement(),
+            None,
+        )),
+    });
+    let reauth_bridge = Arc::new(RuntimeCredentialReauthBridge::default());
+    let wrapper = RuntimeCredentialUnauthorizedRecoveryEgress::new(
+        egress,
+        accounts,
+        Arc::clone(&reauth_bridge),
+    );
+    let runtime_request = request(resource_scope.clone());
+    let capability_id = runtime_request.capability_id.clone();
+
+    wrapper
+        .execute(runtime_request)
+        .await
+        .expect("egress response should pass through");
+
+    let signal = reauth_bridge
+        .take_recovered_auth_required(&resource_scope, &capability_id)
+        .expect("unchanged refresh after 401 should require same-run auth");
+    assert_eq!(
+        signal.credential_requirements,
+        vec![google_auth_requirement()]
+    );
+}
+
+#[tokio::test]
+async fn runtime_credential_reauth_host_runtime_opens_auth_gate_from_recovered_401() {
+    let accounts = Arc::new(InMemoryAuthProductServices::new());
+    let resource_scope = resource_scope();
+    let auth_scope = AuthProductScope::credential_owner(&resource_scope, AuthSurface::Api);
+    let account = seed_account(&accounts, auth_scope.clone()).await;
+    let reauth_bridge = Arc::new(RuntimeCredentialReauthBridge::default());
+    let recovery_egress = Arc::new(RuntimeCredentialUnauthorizedRecoveryEgress::new(
+        Arc::new(FixedEgress {
+            status: 401,
+            credential_unauthorized: Some(unauthorized_marker(
+                &resource_scope,
+                "github",
+                &account,
+                RuntimeCredentialUnauthorizedPolicy::RevokeAccount,
+                github_auth_requirement(),
+                None,
+            )),
+        }),
+        accounts.clone(),
+        Arc::clone(&reauth_bridge),
+    ));
+    let runtime = RuntimeCredentialReauthHostRuntime::new(
+        Arc::new(EgressCallingHostRuntime {
+            egress: recovery_egress,
+        }),
+        reauth_bridge,
+    );
+
+    let outcome = runtime
+        .invoke_capability(runtime_request(resource_scope.clone()))
+        .await
+        .expect("invoke should complete through reauth wrapper");
+
+    let RuntimeCapabilityOutcome::AuthRequired(gate) = outcome else {
+        panic!("expected auth gate from recovered 401, got {outcome:?}");
+    };
+    assert_eq!(gate.capability_id, capability_id());
+    assert!(gate.required_secrets.is_empty());
+    assert_eq!(
+        gate.credential_requirements,
+        vec![github_auth_requirement()]
+    );
+    let stored = accounts
+        .get_account(CredentialAccountLookupRequest::new(auth_scope, account.id))
+        .await
+        .expect("lookup")
+        .expect("account");
+    assert_eq!(stored.status, CredentialAccountStatus::Revoked);
+}
+
+#[tokio::test]
+async fn runtime_credential_reauth_host_runtime_leaves_unmarked_403_completed() {
+    let accounts = Arc::new(InMemoryAuthProductServices::new());
+    let resource_scope = resource_scope();
+    let auth_scope = AuthProductScope::credential_owner(&resource_scope, AuthSurface::Api);
+    let account = seed_account(&accounts, auth_scope.clone()).await;
+    let reauth_bridge = Arc::new(RuntimeCredentialReauthBridge::default());
+    let recovery_egress = Arc::new(RuntimeCredentialUnauthorizedRecoveryEgress::new(
+        Arc::new(FixedEgress {
+            status: 403,
+            credential_unauthorized: None,
+        }),
+        accounts.clone(),
+        Arc::clone(&reauth_bridge),
+    ));
+    let runtime = RuntimeCredentialReauthHostRuntime::new(
+        Arc::new(EgressCallingHostRuntime {
+            egress: recovery_egress,
+        }),
+        reauth_bridge,
+    );
+
+    let outcome = runtime
+        .invoke_capability(runtime_request(resource_scope))
+        .await
+        .expect("invoke should complete");
+
+    assert!(matches!(outcome, RuntimeCapabilityOutcome::Completed(_)));
+    let stored = accounts
+        .get_account(CredentialAccountLookupRequest::new(auth_scope, account.id))
+        .await
+        .expect("lookup")
+        .expect("account");
+    assert_eq!(stored.status, CredentialAccountStatus::Configured);
+}
+
+#[tokio::test]
+async fn runtime_credential_unauthorized_recovery_makes_pat_auth_required_on_next_resolve() {
+    let accounts = Arc::new(InMemoryAuthProductServices::new());
+    let resource_scope = resource_scope();
+    let auth_scope = AuthProductScope::credential_owner(&resource_scope, AuthSurface::Api);
+    let account = seed_account(&accounts, auth_scope).await;
+    let egress = Arc::new(FixedEgress {
+        status: 401,
+        credential_unauthorized: Some(unauthorized_marker(
+            &resource_scope,
+            "github",
+            &account,
+            RuntimeCredentialUnauthorizedPolicy::RevokeAccount,
+            github_auth_requirement(),
+            None,
+        )),
+    });
+    let reauth_bridge = Arc::new(RuntimeCredentialReauthBridge::default());
+    let wrapper =
+        RuntimeCredentialUnauthorizedRecoveryEgress::new(egress, accounts.clone(), reauth_bridge);
+
+    wrapper
+        .execute(request(resource_scope.clone()))
+        .await
+        .expect("egress response should pass through");
+
+    let resolver = runtime_credential_resolver(accounts);
+    let error = resolver
+        .resolve_access_secret(RuntimeCredentialAccountRequest {
+            scope: &resource_scope,
+            provider: &RuntimeCredentialAccountProviderId::new("github").expect("provider"),
+            setup: &RuntimeCredentialAccountSetup::ManualToken,
+            provider_scopes: &[],
+            requester_extension: &ExtensionId::new("github").expect("extension id"),
+        })
+        .await
+        .expect_err("revoked PAT should require auth on next resolution");
+    assert_eq!(error, CredentialStageError::AuthRequired);
+}
+
+#[tokio::test]
+async fn runtime_credential_unauthorized_recovery_refreshes_marked_401_account() {
+    let accounts = Arc::new(InMemoryAuthProductServices::new());
+    let resource_scope = resource_scope();
+    let auth_scope = AuthProductScope::credential_owner(&resource_scope, AuthSurface::Api);
+    let account = seed_oauth_account(&accounts, auth_scope.clone()).await;
+    let egress = Arc::new(FixedEgress {
+        status: 401,
+        credential_unauthorized: Some(unauthorized_marker(
+            &resource_scope,
+            "google",
+            &account,
+            RuntimeCredentialUnauthorizedPolicy::RefreshAccount,
+            google_auth_requirement(),
+            None,
+        )),
+    });
+    let reauth_bridge = Arc::new(RuntimeCredentialReauthBridge::default());
+    let wrapper =
+        RuntimeCredentialUnauthorizedRecoveryEgress::new(egress, accounts.clone(), reauth_bridge);
+
+    wrapper
+        .execute(request(resource_scope))
+        .await
+        .expect("egress response should pass through");
+
+    let stored = accounts
+        .get_account(CredentialAccountLookupRequest::new(auth_scope, account.id))
+        .await
+        .expect("lookup")
+        .expect("account");
+    assert_eq!(stored.status, CredentialAccountStatus::Configured);
+    assert_ne!(stored.access_secret, account.access_secret);
+}
+
+#[tokio::test]
+async fn runtime_credential_unauthorized_recovery_refreshes_oauth_before_next_resolve() {
+    let accounts = Arc::new(InMemoryAuthProductServices::new());
+    let resource_scope = resource_scope();
+    let auth_scope = AuthProductScope::credential_owner(&resource_scope, AuthSurface::Api);
+    let account = seed_oauth_account(&accounts, auth_scope).await;
+    let old_access = account
+        .access_secret
+        .clone()
+        .expect("seed oauth access secret");
+    let egress = Arc::new(FixedEgress {
+        status: 401,
+        credential_unauthorized: Some(unauthorized_marker(
+            &resource_scope,
+            "google",
+            &account,
+            RuntimeCredentialUnauthorizedPolicy::RefreshAccount,
+            google_auth_requirement(),
+            None,
+        )),
+    });
+    let reauth_bridge = Arc::new(RuntimeCredentialReauthBridge::default());
+    let wrapper =
+        RuntimeCredentialUnauthorizedRecoveryEgress::new(egress, accounts.clone(), reauth_bridge);
+
+    wrapper
+        .execute(request(resource_scope.clone()))
+        .await
+        .expect("egress response should pass through");
+
+    let resolver = runtime_credential_resolver(accounts);
+    let provider_scopes = vec!["drive".to_string()];
+    let resolved = resolver
+        .resolve_access_secret(RuntimeCredentialAccountRequest {
+            scope: &resource_scope,
+            provider: &RuntimeCredentialAccountProviderId::new("google").expect("provider"),
+            setup: &RuntimeCredentialAccountSetup::OAuth { scopes: Vec::new() },
+            provider_scopes: &provider_scopes,
+            requester_extension: &ExtensionId::new("google-drive").expect("extension id"),
+        })
+        .await
+        .expect("refreshed OAuth account should resolve on next use");
+    assert_ne!(resolved.handle, old_access);
+}
+
+#[tokio::test]
+async fn runtime_credential_unauthorized_recovery_refreshes_with_carried_requester() {
+    let accounts = Arc::new(InMemoryAuthProductServices::new());
+    let resource_scope = resource_scope();
+    let auth_scope = AuthProductScope::credential_owner(&resource_scope, AuthSurface::Api);
+    let owner_extension = ExtensionId::new("google-drive").expect("extension id");
+    let account = seed_oauth_account_with_ownership(
+        &accounts,
+        auth_scope.clone(),
+        CredentialOwnership::ExtensionOwned,
+        Some(owner_extension.clone()),
+    )
+    .await;
+    let egress = Arc::new(FixedEgress {
+        status: 401,
+        credential_unauthorized: Some(unauthorized_marker(
+            &resource_scope,
+            "google",
+            &account,
+            RuntimeCredentialUnauthorizedPolicy::RefreshAccount,
+            google_auth_requirement(),
+            Some(owner_extension.clone()),
+        )),
+    });
+    let reauth_bridge = Arc::new(RuntimeCredentialReauthBridge::default());
+    let wrapper =
+        RuntimeCredentialUnauthorizedRecoveryEgress::new(egress, accounts.clone(), reauth_bridge);
+
+    wrapper
+        .execute(request(resource_scope))
+        .await
+        .expect("egress response should pass through");
+
+    let stored = accounts
+        .get_account(
+            CredentialAccountLookupRequest::new(auth_scope, account.id)
+                .for_extension(owner_extension),
+        )
+        .await
+        .expect("lookup")
+        .expect("account");
+    assert_eq!(stored.status, CredentialAccountStatus::Configured);
+    assert_ne!(stored.access_secret, account.access_secret);
+}
+
+#[tokio::test]
+async fn runtime_credential_unauthorized_recovery_skips_stale_marker() {
+    let accounts = Arc::new(InMemoryAuthProductServices::new());
+    let resource_scope = resource_scope();
+    let auth_scope = AuthProductScope::credential_owner(&resource_scope, AuthSurface::Api);
+    let account = seed_account(&accounts, auth_scope.clone()).await;
+    accounts
+        .update_status(&auth_scope, account.id, CredentialAccountStatus::Inactive)
+        .await
+        .expect("touch account after staging");
+    let egress = Arc::new(FixedEgress {
+        status: 401,
+        credential_unauthorized: Some(unauthorized_marker(
+            &resource_scope,
+            "github",
+            &account,
+            RuntimeCredentialUnauthorizedPolicy::RevokeAccount,
+            github_auth_requirement(),
+            None,
+        )),
+    });
+    let reauth_bridge = Arc::new(RuntimeCredentialReauthBridge::default());
+    let wrapper =
+        RuntimeCredentialUnauthorizedRecoveryEgress::new(egress, accounts.clone(), reauth_bridge);
+
+    wrapper
+        .execute(request(resource_scope))
+        .await
+        .expect("egress response should pass through");
+
+    let stored = accounts
+        .get_account(CredentialAccountLookupRequest::new(auth_scope, account.id))
+        .await
+        .expect("lookup")
+        .expect("account");
+    assert_eq!(stored.status, CredentialAccountStatus::Inactive);
+}
+
+#[tokio::test]
+async fn runtime_credential_unauthorized_recovery_leaves_unmarked_403_configured() {
+    let accounts = Arc::new(InMemoryAuthProductServices::new());
+    let resource_scope = resource_scope();
+    let auth_scope = AuthProductScope::credential_owner(&resource_scope, AuthSurface::Api);
+    let account = seed_account(&accounts, auth_scope.clone()).await;
+    let egress = Arc::new(FixedEgress {
+        status: 403,
+        credential_unauthorized: None,
+    });
+    let reauth_bridge = Arc::new(RuntimeCredentialReauthBridge::default());
+    let wrapper =
+        RuntimeCredentialUnauthorizedRecoveryEgress::new(egress, accounts.clone(), reauth_bridge);
+
+    wrapper
+        .execute(request(resource_scope))
+        .await
+        .expect("egress response should pass through");
+
+    let stored = accounts
+        .get_account(CredentialAccountLookupRequest::new(auth_scope, account.id))
+        .await
+        .expect("lookup")
+        .expect("account");
+    assert_eq!(stored.status, CredentialAccountStatus::Configured);
+}
+
+struct FixedEgress {
+    status: u16,
+    credential_unauthorized: Option<RuntimeCredentialUnauthorized>,
+}
+
+#[async_trait]
+impl RuntimeHttpEgress for FixedEgress {
+    async fn execute(
+        &self,
+        _request: RuntimeHttpEgressRequest,
+    ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {
+        Ok(RuntimeHttpEgressResponse {
+            status: self.status,
+            headers: Vec::new(),
+            body: Vec::new(),
+            saved_body: None,
+            request_bytes: 0,
+            response_bytes: 0,
+            redaction_applied: false,
+            credential_unauthorized: self.credential_unauthorized.clone(),
+        })
+    }
+}
+
+struct NoopRefreshCredentialAccounts {
+    inner: Arc<InMemoryAuthProductServices>,
+}
+
+#[async_trait]
+impl CredentialAccountService for NoopRefreshCredentialAccounts {
+    async fn create_account(
+        &self,
+        _: NewCredentialAccount,
+    ) -> Result<ironclaw_auth::CredentialAccount, AuthProductError> {
+        unreachable!("noop-refresh fake only supports refresh_if_unchanged")
+    }
+
+    async fn get_account(
+        &self,
+        request: CredentialAccountLookupRequest,
+    ) -> Result<Option<ironclaw_auth::CredentialAccount>, AuthProductError> {
+        self.inner.get_account(request).await
+    }
+
+    async fn list_accounts(
+        &self,
+        _: ironclaw_auth::CredentialAccountListRequest,
+    ) -> Result<ironclaw_auth::CredentialAccountListPage, AuthProductError> {
+        unreachable!("noop-refresh fake only supports refresh_if_unchanged")
+    }
+
+    async fn update_status(
+        &self,
+        _: &AuthProductScope,
+        _: CredentialAccountId,
+        _: CredentialAccountStatus,
+    ) -> Result<ironclaw_auth::CredentialAccount, AuthProductError> {
+        unreachable!("noop-refresh fake only supports refresh_if_unchanged")
+    }
+
+    async fn refresh_if_unchanged(
+        &self,
+        request: CredentialRefreshRequest,
+        expected_updated_at: ironclaw_host_api::Timestamp,
+    ) -> Result<Option<CredentialRefreshReport>, AuthProductError> {
+        let Some(account) = self
+            .inner
+            .get_account(CredentialAccountLookupRequest::new(
+                request.scope.clone(),
+                request.account_id,
+            ))
+            .await?
+        else {
+            return Ok(None);
+        };
+        if account.updated_at != expected_updated_at {
+            return Ok(None);
+        }
+        let projection = account.projection();
+        Ok(Some(CredentialRefreshReport {
+            account: projection.clone(),
+            recovery: CredentialRecoveryProjection::configured(
+                account.provider.clone(),
+                projection,
+            ),
+            refreshed: false,
+        }))
+    }
+
+    async fn select_unique_configured_account(
+        &self,
+        _: ironclaw_auth::CredentialAccountSelectionRequest,
+    ) -> Result<CredentialAccountProjection, AuthProductError> {
+        unreachable!("noop-refresh fake only supports refresh_if_unchanged")
+    }
+
+    async fn project_credential_recovery(
+        &self,
+        _: ironclaw_auth::CredentialRecoveryRequest,
+    ) -> Result<CredentialRecoveryProjection, AuthProductError> {
+        unreachable!("noop-refresh fake only supports refresh_if_unchanged")
+    }
+
+    async fn select_configured_account(
+        &self,
+        _: ironclaw_auth::CredentialAccountChoiceRequest,
+    ) -> Result<CredentialAccountProjection, AuthProductError> {
+        unreachable!("noop-refresh fake only supports refresh_if_unchanged")
+    }
+
+    async fn refresh_account(
+        &self,
+        _: CredentialRefreshRequest,
+    ) -> Result<CredentialRefreshReport, AuthProductError> {
+        unreachable!("noop-refresh fake only supports refresh_if_unchanged")
+    }
+}
+
+struct EgressCallingHostRuntime {
+    egress: Arc<dyn RuntimeHttpEgress>,
+}
+
+#[async_trait]
+impl HostRuntime for EgressCallingHostRuntime {
+    async fn invoke_capability(
+        &self,
+        request: RuntimeCapabilityRequest,
+    ) -> Result<RuntimeCapabilityOutcome, HostRuntimeError> {
+        self.egress
+            .execute(RuntimeHttpEgressRequest {
+                runtime: RuntimeKind::Wasm,
+                scope: request.context.resource_scope.clone(),
+                capability_id: request.capability_id.clone(),
+                method: NetworkMethod::Get,
+                url: "https://api.example.test/requires-auth".to_string(),
+                headers: Vec::new(),
+                body: Vec::new(),
+                network_policy: NetworkPolicy::default(),
+                credential_injections: Vec::new(),
+                response_body_limit: None,
+                save_body_to: None,
+                timeout_ms: None,
+            })
+            .await
+            .map_err(|error| HostRuntimeError::unavailable(error.to_string()))?;
+        Ok(RuntimeCapabilityOutcome::Completed(Box::new(
+            RuntimeCapabilityCompleted {
+                capability_id: request.capability_id,
+                output: serde_json::json!({"ok": true}),
+                display_preview: None,
+                usage: ResourceUsage::default(),
+            },
+        )))
+    }
+
+    async fn resume_capability(
+        &self,
+        _request: RuntimeCapabilityResumeRequest,
+    ) -> Result<RuntimeCapabilityOutcome, HostRuntimeError> {
+        unreachable!("test runtime only invokes")
+    }
+
+    async fn visible_capabilities(
+        &self,
+        _request: VisibleCapabilityRequest,
+    ) -> Result<VisibleCapabilitySurface, HostRuntimeError> {
+        unreachable!("test runtime does not expose a surface")
+    }
+
+    async fn cancel_work(
+        &self,
+        _request: CancelRuntimeWorkRequest,
+    ) -> Result<CancelRuntimeWorkOutcome, HostRuntimeError> {
+        unreachable!("test runtime does not track cancellable work")
+    }
+
+    async fn runtime_status(
+        &self,
+        _request: RuntimeStatusRequest,
+    ) -> Result<HostRuntimeStatus, HostRuntimeError> {
+        unreachable!("test runtime does not report status")
+    }
+
+    async fn health(&self) -> Result<HostRuntimeHealth, HostRuntimeError> {
+        unreachable!("test runtime does not report health")
+    }
+}
+
+async fn seed_account(
+    accounts: &InMemoryAuthProductServices,
+    scope: AuthProductScope,
+) -> ironclaw_auth::CredentialAccount {
+    accounts
+        .create_account(NewCredentialAccount {
+            scope,
+            provider: AuthProviderId::new("github").expect("provider"),
+            label: CredentialAccountLabel::new("github account").expect("label"),
+            status: CredentialAccountStatus::Configured,
+            ownership: CredentialOwnership::UserReusable,
+            owner_extension: None,
+            granted_extensions: Vec::new(),
+            access_secret: Some(
+                ironclaw_host_api::SecretHandle::new("github-access")
+                    .expect("access secret handle"),
+            ),
+            refresh_secret: None,
+            scopes: vec![ProviderScope::new("repo").expect("scope")],
+        })
+        .await
+        .expect("seed account")
+}
+
+async fn seed_oauth_account(
+    accounts: &InMemoryAuthProductServices,
+    scope: AuthProductScope,
+) -> ironclaw_auth::CredentialAccount {
+    seed_oauth_account_with_ownership(accounts, scope, CredentialOwnership::UserReusable, None)
+        .await
+}
+
+async fn seed_oauth_account_with_ownership(
+    accounts: &InMemoryAuthProductServices,
+    scope: AuthProductScope,
+    ownership: CredentialOwnership,
+    owner_extension: Option<ExtensionId>,
+) -> ironclaw_auth::CredentialAccount {
+    accounts
+        .create_account(NewCredentialAccount {
+            scope,
+            provider: AuthProviderId::new("google").expect("provider"),
+            label: CredentialAccountLabel::new("google account").expect("label"),
+            status: CredentialAccountStatus::Configured,
+            ownership,
+            owner_extension,
+            granted_extensions: Vec::new(),
+            access_secret: Some(
+                ironclaw_host_api::SecretHandle::new("google-old-access")
+                    .expect("access secret handle"),
+            ),
+            refresh_secret: Some(
+                ironclaw_host_api::SecretHandle::new("google-refresh")
+                    .expect("refresh secret handle"),
+            ),
+            scopes: vec![ProviderScope::new("drive").expect("scope")],
+        })
+        .await
+        .expect("seed oauth account")
+}
+
+fn runtime_credential_resolver(
+    accounts: Arc<InMemoryAuthProductServices>,
+) -> crate::product_auth_runtime_credentials::ProductAuthRuntimeCredentialResolver {
+    crate::product_auth_runtime_credentials::ProductAuthRuntimeCredentialResolver::new(Arc::new(
+        crate::product_auth_runtime_credentials::ProductAuthRuntimeCredentialAccountSelector::new(
+            accounts,
+        ),
+    ))
+}
+
+fn resource_scope() -> ResourceScope {
+    ResourceScope::local_default(UserId::new("alice").unwrap(), InvocationId::new()).unwrap()
+}
+
+fn capability_id() -> CapabilityId {
+    CapabilityId::new("github.search").unwrap()
+}
+
+fn request(scope: ResourceScope) -> RuntimeHttpEgressRequest {
+    RuntimeHttpEgressRequest {
+        runtime: RuntimeKind::Wasm,
+        scope,
+        capability_id: capability_id(),
+        method: NetworkMethod::Get,
+        url: "https://api.github.com/user".to_string(),
+        headers: Vec::new(),
+        body: Vec::new(),
+        network_policy: NetworkPolicy {
+            allowed_targets: Vec::new(),
+            deny_private_ip_ranges: true,
+            max_egress_bytes: None,
+        },
+        credential_injections: Vec::new(),
+        response_body_limit: None,
+        save_body_to: None,
+        timeout_ms: None,
+    }
+}
+
+fn runtime_request(scope: ResourceScope) -> RuntimeCapabilityRequest {
+    RuntimeCapabilityRequest::new(
+        execution_context_for_scope(scope),
+        capability_id(),
+        ResourceEstimate::default(),
+        serde_json::json!({}),
+        trust_decision(),
+    )
+}
+
+fn execution_context_for_scope(scope: ResourceScope) -> ExecutionContext {
+    ExecutionContext {
+        invocation_id: scope.invocation_id,
+        correlation_id: CorrelationId::new(),
+        process_id: None,
+        parent_process_id: None,
+        tenant_id: scope.tenant_id.clone(),
+        user_id: scope.user_id.clone(),
+        agent_id: scope.agent_id.clone(),
+        project_id: scope.project_id.clone(),
+        mission_id: scope.mission_id.clone(),
+        thread_id: scope.thread_id.clone(),
+        extension_id: ExtensionId::new("github").expect("extension id"),
+        runtime: RuntimeKind::Wasm,
+        trust: TrustClass::UserTrusted,
+        grants: CapabilitySet::default(),
+        mounts: MountView::default(),
+        resource_scope: scope,
+    }
+}
+
+fn trust_decision() -> TrustDecision {
+    TrustDecision {
+        effective_trust: EffectiveTrustClass::user_trusted(),
+        authority_ceiling: AuthorityCeiling {
+            allowed_effects: vec![],
+            max_resource_ceiling: None,
+        },
+        provenance: TrustProvenance::Default,
+        evaluated_at: chrono::Utc::now(),
+    }
+}
+
+fn github_auth_requirement() -> RuntimeCredentialAuthRequirement {
+    RuntimeCredentialAuthRequirement {
+        provider: RuntimeCredentialAccountProviderId::new("github").expect("provider"),
+        setup: RuntimeCredentialAccountSetup::ManualToken,
+        requester_extension: ExtensionId::new("github").expect("extension id"),
+        provider_scopes: Vec::new(),
+    }
+}
+
+fn google_auth_requirement() -> RuntimeCredentialAuthRequirement {
+    RuntimeCredentialAuthRequirement {
+        provider: RuntimeCredentialAccountProviderId::new("google").expect("provider"),
+        setup: RuntimeCredentialAccountSetup::OAuth { scopes: Vec::new() },
+        requester_extension: ExtensionId::new("google-drive").expect("extension id"),
+        provider_scopes: vec!["drive".to_string()],
+    }
+}
+
+fn unauthorized_marker(
+    resource_scope: &ResourceScope,
+    provider: &str,
+    account: &ironclaw_auth::CredentialAccount,
+    unauthorized_policy: RuntimeCredentialUnauthorizedPolicy,
+    auth_requirement: RuntimeCredentialAuthRequirement,
+    requester_extension: Option<ExtensionId>,
+) -> RuntimeCredentialUnauthorized {
+    RuntimeCredentialUnauthorized {
+        scope: resource_scope.clone(),
+        account_provider: RuntimeCredentialAccountProviderId::new(provider).expect("provider"),
+        account_id: account.id.to_string(),
+        account_updated_at: account.updated_at,
+        requester_extension,
+        auth_requirement,
+        unauthorized_policy,
+    }
+}

--- a/crates/ironclaw_reborn_composition/src/slack_egress.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_egress.rs
@@ -226,6 +226,7 @@ impl SlackProtocolHttpEgress {
                 prefix: Some("Bearer ".to_string()),
             },
             required: true,
+            credential_account: None,
         }])
     }
 }

--- a/crates/ironclaw_reborn_composition/tests/gsuite.rs
+++ b/crates/ironclaw_reborn_composition/tests/gsuite.rs
@@ -101,6 +101,7 @@ impl RuntimeHttpEgress for RecordingEgress {
             request_bytes: 123,
             response_bytes: 21,
             redaction_applied: true,
+            credential_unauthorized: None,
         })
     }
 }

--- a/crates/ironclaw_scripts/tests/script_http_adapter_contract.rs
+++ b/crates/ironclaw_scripts/tests/script_http_adapter_contract.rs
@@ -18,6 +18,7 @@ async fn script_host_http_adapter_uses_shared_runtime_egress() {
         request_bytes: 7,
         response_bytes: 11,
         redaction_applied: false,
+        credential_unauthorized: None,
     });
     let adapter = ScriptRuntimeHttpAdapter::new(Arc::new(egress.clone()));
     let scope = sample_scope();
@@ -64,6 +65,7 @@ async fn script_host_http_adapter_forwards_host_supplied_policy_credentials_time
         request_bytes: 13,
         response_bytes: 0,
         redaction_applied: false,
+        credential_unauthorized: None,
     });
     let adapter = ScriptRuntimeHttpAdapter::new(Arc::new(egress.clone()));
     let scope = sample_scope();

--- a/crates/ironclaw_wasm/tests/wasm_dispatch_integration.rs
+++ b/crates/ironclaw_wasm/tests/wasm_dispatch_integration.rs
@@ -138,6 +138,7 @@ async fn wasm_lane_execution_failure_reconciles_preserved_usage_from_runtime() {
         request_bytes: 5,
         response_bytes: 0,
         redaction_applied: false,
+        credential_unauthorized: None,
     }));
     let wasm_http = Arc::new(
         WasmRuntimeHttpAdapter::new(
@@ -470,6 +471,7 @@ async fn wasm_lane_caps_overdue_host_import_at_dispatch_execution_deadline() {
         request_bytes: 5,
         response_bytes: 0,
         redaction_applied: false,
+        credential_unauthorized: None,
     }));
     let wasm_http = Arc::new(
         WasmRuntimeHttpAdapter::new(

--- a/crates/ironclaw_wasm/tests/wasm_http_adapter_contract.rs
+++ b/crates/ironclaw_wasm/tests/wasm_http_adapter_contract.rs
@@ -23,6 +23,7 @@ async fn wasm_runtime_http_adapter_uses_shared_runtime_egress() {
         request_bytes: 7,
         response_bytes: 11,
         redaction_applied: false,
+        credential_unauthorized: None,
     });
     let scope = sample_scope();
     let policy = sample_policy();
@@ -83,6 +84,7 @@ async fn wasm_runtime_http_adapter_works_inside_current_thread_runtime() {
         request_bytes: 0,
         response_bytes: 0,
         redaction_applied: false,
+        credential_unauthorized: None,
     });
     let adapter = WasmRuntimeHttpAdapter::new(
         Arc::new(egress.clone()),
@@ -115,6 +117,7 @@ fn wasm_runtime_http_adapter_reuses_worker_runtime_without_active_tokio_runtime(
         request_bytes: 0,
         response_bytes: 0,
         redaction_applied: false,
+        credential_unauthorized: None,
     });
     let adapter = WasmRuntimeHttpAdapter::new(
         Arc::new(egress.clone()),
@@ -172,6 +175,7 @@ async fn wasm_runtime_http_adapter_strips_sensitive_response_headers() {
         request_bytes: 0,
         response_bytes: 2,
         redaction_applied: true,
+        credential_unauthorized: None,
     });
     let adapter = WasmRuntimeHttpAdapter::new(
         Arc::new(egress),
@@ -223,6 +227,7 @@ async fn wasm_runtime_http_adapter_combines_duplicate_response_headers() {
         request_bytes: 0,
         response_bytes: 2,
         redaction_applied: false,
+        credential_unauthorized: None,
     });
     let adapter = WasmRuntimeHttpAdapter::new(
         Arc::new(egress),
@@ -261,6 +266,7 @@ async fn wasm_runtime_http_adapter_resolves_credentials_per_request_destination(
         request_bytes: 0,
         response_bytes: 2,
         redaction_applied: true,
+        credential_unauthorized: None,
     });
     let injection = sample_injection();
     let adapter = WasmRuntimeHttpAdapter::new(
@@ -299,6 +305,7 @@ async fn wasm_runtime_http_adapter_does_not_reuse_credentials_for_other_destinat
         request_bytes: 0,
         response_bytes: 2,
         redaction_applied: true,
+        credential_unauthorized: None,
     });
     let adapter = WasmRuntimeHttpAdapter::new(
         Arc::new(egress.clone()),
@@ -336,6 +343,7 @@ async fn wasm_runtime_http_adapter_can_build_staged_obligation_credentials() {
         request_bytes: 0,
         response_bytes: 2,
         redaction_applied: true,
+        credential_unauthorized: None,
     });
     let capability_id = sample_capability_id();
     let handle = SecretHandle::new("api-token").unwrap();
@@ -391,6 +399,7 @@ async fn wasm_runtime_http_adapter_rejects_invalid_guest_headers_before_egress()
         request_bytes: 0,
         response_bytes: 0,
         redaction_applied: false,
+        credential_unauthorized: None,
     });
     let adapter = WasmRuntimeHttpAdapter::new(
         Arc::new(egress.clone()),
@@ -609,6 +618,7 @@ async fn wasm_runtime_http_adapter_redacts_credential_provider_errors() {
             request_bytes: 0,
             response_bytes: 2,
             redaction_applied: false,
+            credential_unauthorized: None,
         })),
         sample_scope(),
         sample_capability_id(),
@@ -643,6 +653,7 @@ async fn wasm_runtime_http_adapter_discards_staged_policy_on_pre_egress_request_
         request_bytes: 0,
         response_bytes: 2,
         redaction_applied: false,
+        credential_unauthorized: None,
     });
     let discarder = Arc::new(RecordingPolicyDiscarder::default());
     let scope = sample_scope();
@@ -680,6 +691,7 @@ async fn wasm_runtime_http_adapter_discards_staged_policy_on_credential_provider
         request_bytes: 0,
         response_bytes: 2,
         redaction_applied: false,
+        credential_unauthorized: None,
     });
     let discarder = Arc::new(RecordingPolicyDiscarder::default());
     let scope = sample_scope();

--- a/tests/support/reborn/harness.rs
+++ b/tests/support/reborn/harness.rs
@@ -2801,6 +2801,7 @@ impl RuntimeCredentialAccountResolver for FixedRuntimeCredentialAccountResolver 
             .map(|handle| RuntimeCredentialAccessSecret {
                 scope: request.scope.clone(),
                 handle,
+                credential_account: None,
             })
     }
 }
@@ -3004,6 +3005,7 @@ impl RuntimeHttpEgress for RecordingRuntimeHttpEgress {
             request_bytes,
             response_bytes: body.len() as u64,
             redaction_applied: false,
+            credential_unauthorized: None,
         })
     }
 }


### PR DESCRIPTION
## Summary
- add Reborn product-auth account revoke/delete handling and route coverage
- stage product-auth account identity through host runtime HTTP egress and mark only 401 responses for unauthorized credential recovery
- centralize Reborn post-egress recovery in product-auth composition: PAT/manual-token and refreshless OAuth revoke on 401; refresh-capable OAuth refreshes with requester-aware, freshness-checked service ownership

## Verification
- cargo fmt --check
- git diff --check
- cargo test -p ironclaw_host_api runtime_http_egress_response_round_trips_optional_credential_unauthorized
- cargo test -p ironclaw_host_runtime --lib host_runtime_http_egress_
- cargo test -p ironclaw_reborn_composition --lib runtime_credential_unauthorized_recovery
- cargo test -p ironclaw_reborn_composition --lib resolver_
- cargo test -p ironclaw_auth refresh
- cargo test -p ironclaw_auth refresh_if_unchanged
- cargo test -p ironclaw_reborn_composition --features webui-v2-beta --lib accounts_revoke_route_marks_account_revoked

Started but did not complete in-session before user requested PR: `cargo test --features integration -- --test-threads=1`. It compiled into the test phase and emitted only the existing Reborn composition `secret_store` dead-code warning before the session was interrupted.

## Scope
Reborn-only behavior; no legacy `src/` v1/v2 paths are modified.