### PR TITLE
refactor(reborn): temporarily disable spawn_subagent capability

### DIFF
--- a/crates/ironclaw_loop_support/src/capability_surface_filter.rs
+++ b/crates/ironclaw_loop_support/src/capability_surface_filter.rs
@@ -1504,4 +1504,138 @@ mod tests {
 
         assert_eq!(surface.version.as_str(), "surface-v1");
     }
+
+    // ── CapabilitySurfaceDenyFilter tests ────────────────────────────────────
+
+    #[test]
+    fn deny_filter_strips_denied_tool_definitions() {
+        let inner = Arc::new(SpyPort::default());
+        *inner
+            .tool_definitions
+            .lock()
+            .expect("tool definitions lock") = vec![
+            provider_definition("builtin.spawn_subagent", "builtin__spawn_subagent"),
+            provider_definition("builtin.echo", "builtin__echo"),
+        ];
+        let filter =
+            CapabilitySurfaceDenyFilter::new(inner, [capability_id("builtin.spawn_subagent")]);
+
+        let definitions = filter.tool_definitions().expect("tool definitions");
+
+        assert_eq!(
+            definitions
+                .iter()
+                .map(|definition| (definition.capability_id.as_str(), definition.name.as_str()))
+                .collect::<Vec<_>>(),
+            vec![("builtin.echo", "builtin__echo")]
+        );
+    }
+
+    #[tokio::test]
+    async fn deny_filter_strips_denied_visible_descriptors() {
+        let inner = Arc::new(SpyPort::default());
+        *inner.surface.lock().expect("surface lock") = Some(VisibleCapabilitySurface {
+            version: surface_version(),
+            descriptors: vec![
+                descriptor("builtin.spawn_subagent"),
+                descriptor("builtin.echo"),
+            ],
+        });
+        let filter =
+            CapabilitySurfaceDenyFilter::new(inner, [capability_id("builtin.spawn_subagent")]);
+
+        let surface = filter
+            .visible_capabilities(VisibleCapabilityRequest)
+            .await
+            .expect("surface");
+
+        assert_eq!(surface.version, surface_version());
+        assert_eq!(
+            surface
+                .descriptors
+                .iter()
+                .map(|descriptor| descriptor.capability_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["builtin.echo"]
+        );
+    }
+
+    #[tokio::test]
+    async fn deny_filter_rejects_provider_tool_call_for_denied_capability() {
+        let inner = Arc::new(SpyPort::default());
+        *inner
+            .tool_definitions
+            .lock()
+            .expect("tool definitions lock") = vec![
+            provider_definition("builtin.spawn_subagent", "builtin__spawn_subagent"),
+            provider_definition("builtin.echo", "builtin__echo"),
+        ];
+        let filter = CapabilitySurfaceDenyFilter::new(
+            inner.clone(),
+            [capability_id("builtin.spawn_subagent")],
+        );
+
+        let error = filter
+            .register_provider_tool_call(provider_call("builtin__spawn_subagent"))
+            .await
+            .expect_err("denied provider call should fail before staging");
+
+        assert_eq!(error.kind, AgentLoopHostErrorKind::InvalidInvocation);
+        assert!(
+            inner
+                .provider_calls
+                .lock()
+                .expect("provider calls lock")
+                .is_empty()
+        );
+
+        // Allowed call succeeds and reaches the inner port.
+        filter
+            .register_provider_tool_call(provider_call("builtin__echo"))
+            .await
+            .expect("allowed provider call should succeed");
+        assert_eq!(
+            inner
+                .provider_calls
+                .lock()
+                .expect("provider calls lock")
+                .len(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn deny_filter_denies_invoke_of_denied_capability() {
+        let inner = Arc::new(SpyPort::default());
+        let filter = CapabilitySurfaceDenyFilter::new(
+            inner.clone(),
+            [capability_id("builtin.spawn_subagent")],
+        );
+
+        let outcome = filter
+            .invoke_capability(invocation("builtin.spawn_subagent", "input:denied"))
+            .await
+            .expect("outcome");
+
+        assert_eq!(denied_reason(&outcome), Some("model_view_denied"));
+        assert!(
+            inner
+                .invocations
+                .lock()
+                .expect("invocation lock")
+                .is_empty()
+        );
+
+        // Allowed id passes through to inner.
+        let allowed_outcome = filter
+            .invoke_capability(invocation("builtin.echo", "input:allowed"))
+            .await
+            .expect("outcome");
+
+        assert!(
+            matches!(allowed_outcome, CapabilityOutcome::Completed(_)),
+            "allowed capability should complete"
+        );
+        assert_eq!(inner.invocations.lock().expect("invocation lock").len(), 1);
+    }
 }

--- a/crates/ironclaw_loop_support/src/capability_surface_filter.rs
+++ b/crates/ironclaw_loop_support/src/capability_surface_filter.rs
@@ -146,6 +146,126 @@ impl LoopCapabilityPort for CapabilitySurfaceVisibleFilter {
     }
 }
 
+/// Removes a fixed set of capability ids from the model-facing surface and
+/// rejects any attempt to invoke them.
+///
+/// Unlike [`CapabilitySurfaceProfileFilter`] (which narrows to a profile
+/// allow-set and is a no-op for [`CapabilityAllowSet::All`]), this is an
+/// explicit deny list that takes effect regardless of the resolved allow-set.
+/// It is the canonical way to disable an individual capability as an explicit
+/// composition decision rather than a profile-scoped narrowing.
+#[derive(Clone)]
+pub struct CapabilitySurfaceDenyFilter {
+    inner: Arc<dyn LoopCapabilityPort>,
+    denied_capability_ids: Arc<HashSet<CapabilityId>>,
+    staged_invocations: Arc<Mutex<HashMap<StagedInvocationKey, Vec<CapabilityId>>>>,
+}
+
+impl CapabilitySurfaceDenyFilter {
+    pub fn new(
+        inner: Arc<dyn LoopCapabilityPort>,
+        denied_capability_ids: impl IntoIterator<Item = CapabilityId>,
+    ) -> Self {
+        Self {
+            inner,
+            denied_capability_ids: Arc::new(denied_capability_ids.into_iter().collect()),
+            staged_invocations: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    fn permits(&self, capability_id: &CapabilityId) -> bool {
+        !self.denied_capability_ids.contains(capability_id)
+    }
+}
+
+#[async_trait]
+impl LoopCapabilityPort for CapabilitySurfaceDenyFilter {
+    fn tool_definitions(&self) -> Result<Vec<ProviderToolDefinition>, AgentLoopHostError> {
+        let mut definitions = self.inner.tool_definitions()?;
+        definitions.retain(|definition| {
+            provider_capability_permitted(&definition.capability_id, |capability_id| {
+                self.permits(capability_id)
+            })
+        });
+        Ok(definitions)
+    }
+
+    fn validate_provider_tool_call(
+        &self,
+        tool_call: &ProviderToolCall,
+    ) -> Result<(), AgentLoopHostError> {
+        validate_provider_tool_call_capability_scope(
+            self.inner.provider_tool_call_capability_ids(tool_call)?,
+            |capability_id| self.permits(capability_id),
+            "provider tool call targets a disabled capability",
+        )?;
+        self.inner.validate_provider_tool_call(tool_call)
+    }
+
+    async fn register_provider_tool_call(
+        &self,
+        tool_call: ProviderToolCall,
+    ) -> Result<CapabilityCallCandidate, AgentLoopHostError> {
+        validate_provider_tool_call_capability_scope(
+            self.inner.provider_tool_call_capability_ids(&tool_call)?,
+            |capability_id| self.permits(capability_id),
+            "provider tool call targets a disabled capability",
+        )?;
+        let candidate = self.inner.register_provider_tool_call(tool_call).await?;
+        validate_provider_tool_call_capability_scope(
+            candidate_capability_ids(&candidate),
+            |capability_id| self.permits(capability_id),
+            "provider tool call targets a disabled capability",
+        )?;
+        record_staged_invocation(&self.staged_invocations, &candidate)?;
+        Ok(candidate)
+    }
+
+    async fn visible_capabilities(
+        &self,
+        request: VisibleCapabilityRequest,
+    ) -> Result<VisibleCapabilitySurface, AgentLoopHostError> {
+        let mut surface = self.inner.visible_capabilities(request).await?;
+        surface.descriptors.retain(|descriptor| {
+            provider_capability_permitted(&descriptor.capability_id, |capability_id| {
+                self.permits(capability_id)
+            })
+        });
+        Ok(surface)
+    }
+
+    async fn invoke_capability(
+        &self,
+        request: CapabilityInvocation,
+    ) -> Result<CapabilityOutcome, AgentLoopHostError> {
+        if !invocation_capability_permitted(&self.staged_invocations, &request, |capability_id| {
+            self.permits(capability_id)
+        })? {
+            return Ok(model_view_denied_outcome());
+        }
+        self.inner.invoke_capability(request).await
+    }
+
+    async fn invoke_capability_batch(
+        &self,
+        request: CapabilityBatchInvocation,
+    ) -> Result<CapabilityBatchOutcome, AgentLoopHostError> {
+        invoke_filtered_batch(
+            &*self.inner,
+            request,
+            |invocation| {
+                invocation_capability_permitted(
+                    &self.staged_invocations,
+                    invocation,
+                    |capability_id| self.permits(capability_id),
+                )
+            },
+            model_view_denied_outcome,
+        )
+        .await
+    }
+}
+
 #[async_trait]
 impl LoopCapabilityPort for CapabilitySurfaceProfileFilter {
     fn tool_definitions(&self) -> Result<Vec<ProviderToolDefinition>, AgentLoopHostError> {

--- a/crates/ironclaw_loop_support/src/lib.rs
+++ b/crates/ironclaw_loop_support/src/lib.rs
@@ -61,7 +61,7 @@ pub use capability_port::{
     loop_driver_execution_extension_id,
 };
 pub use capability_surface_filter::{
-    CapabilitySurfaceProfileFilter, CapabilitySurfaceVisibleFilter,
+    CapabilitySurfaceDenyFilter, CapabilitySurfaceProfileFilter, CapabilitySurfaceVisibleFilter,
 };
 pub use compaction_task::{
     ACTIVE_TASK_COMPACTION_PROMPT_ID, DEFAULT_COMPACTION_PROMPT_ID, HostManagedLoopCompactionPort,

--- a/crates/ironclaw_reborn/src/runtime.rs
+++ b/crates/ironclaw_reborn/src/runtime.rs
@@ -552,7 +552,12 @@ where
             Arc::clone(&parts.thread_service),
         ));
     let subagent_prompt_composer = SubagentPromptComposer::new(Arc::clone(&subagent_prompt_source));
-    let spawn_decorator = Arc::new(SubagentSpawnCapabilityDecorator::new(
+    // TEMP(disable-spawn-subagents): spawn_subagent tool removed from the
+    // model-facing capability surface. Constructed but bound to `_` so all
+    // `parts.*` fields stay used (no unused-field warnings) while the decorator
+    // is NOT installed below — the model never sees/calls spawn_subagent.
+    // Revert: rename back to `spawn_decorator` and re-add `.with_decorator(...)`.
+    let _spawn_decorator = Arc::new(SubagentSpawnCapabilityDecorator::new(
         SubagentSpawnDeps {
             coordinator: Arc::clone(&coordinator) as Arc<dyn ironclaw_turns::TurnCoordinator>,
             child_runs,
@@ -568,10 +573,8 @@ where
         parts.subagent_spawn_limits,
         flavors::builtin_flavor_catalog(),
     )?);
-    let capability_factory: Arc<dyn LoopCapabilityPortFactory> = Arc::new(
-        DecoratingLoopCapabilityPortFactory::new(parts.capability_factory)
-            .with_decorator(spawn_decorator),
-    );
+    let capability_factory: Arc<dyn LoopCapabilityPortFactory> =
+        Arc::new(DecoratingLoopCapabilityPortFactory::new(parts.capability_factory));
     let capability_surface_resolver: Arc<dyn CapabilitySurfaceProfileResolver> =
         Arc::new(SubagentCapabilitySurfaceResolver::new(
             parts.capability_surface_resolver,

--- a/crates/ironclaw_reborn/src/runtime.rs
+++ b/crates/ironclaw_reborn/src/runtime.rs
@@ -5,7 +5,7 @@ use std::{error::Error, fmt, sync::Arc};
 use ironclaw_events::SecurityAuditSink;
 use ironclaw_host_api::CapabilityId;
 use ironclaw_loop_support::{
-    CapabilitySurfaceProfileResolver, CompositeTurnRunWakeNotifier,
+    CapabilitySurfaceDenyFilter, CapabilitySurfaceProfileResolver, CompositeTurnRunWakeNotifier,
     DecoratingLoopCapabilityPortFactory, HostIdentityContextSource, HostInputQueue,
     HostManagedModelGateway, HostSkillContextSource, HostUserProfileSource, LoopAttachmentReadPort,
     LoopCapabilityPortDecorator, LoopCapabilityPortFactory, LoopCapabilityResultWriter,
@@ -552,12 +552,7 @@ where
             Arc::clone(&parts.thread_service),
         ));
     let subagent_prompt_composer = SubagentPromptComposer::new(Arc::clone(&subagent_prompt_source));
-    // TEMP(disable-spawn-subagents): spawn_subagent tool removed from the
-    // model-facing capability surface. Constructed but bound to `_` so all
-    // `parts.*` fields stay used (no unused-field warnings) while the decorator
-    // is NOT installed below — the model never sees/calls spawn_subagent.
-    // Revert: rename back to `spawn_decorator` and re-add `.with_decorator(...)`.
-    let _spawn_decorator = Arc::new(SubagentSpawnCapabilityDecorator::new(
+    let spawn_decorator = Arc::new(SubagentSpawnCapabilityDecorator::new(
         SubagentSpawnDeps {
             coordinator: Arc::clone(&coordinator) as Arc<dyn ironclaw_turns::TurnCoordinator>,
             child_runs,
@@ -573,8 +568,28 @@ where
         parts.subagent_spawn_limits,
         flavors::builtin_flavor_catalog(),
     )?);
+    // TEMP(disable-spawn-subagents): explicit composition decision to remove the
+    // spawn_subagent capability from the model-facing surface across all
+    // profiles. Applied as the OUTERMOST decorator so it strips the capability
+    // whether it was surfaced by `spawn_decorator` (the rich flavor-aware tool)
+    // or by the host-runtime first-party manifest (the bare authorization stub).
+    // This is a deny list — it takes effect regardless of the resolved profile
+    // allow-set (which is `All` for top-level runs, making a profile allow-set
+    // narrowing a no-op). Empty `DISABLED_CAPABILITY_IDS` to re-enable.
+    let disabled = DISABLED_CAPABILITY_IDS
+        .iter()
+        .map(|id| CapabilityId::new(*id))
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| DefaultPlannedRuntimeBuildError::RunProfile(error.to_string()))?;
+    let mut capability_factory_builder =
+        DecoratingLoopCapabilityPortFactory::new(parts.capability_factory)
+            .with_decorator(spawn_decorator);
+    if !disabled.is_empty() {
+        capability_factory_builder = capability_factory_builder
+            .with_decorator(Arc::new(DisabledCapabilitiesDecorator::new(disabled)));
+    }
     let capability_factory: Arc<dyn LoopCapabilityPortFactory> =
-        Arc::new(DecoratingLoopCapabilityPortFactory::new(parts.capability_factory));
+        Arc::new(capability_factory_builder);
     let capability_surface_resolver: Arc<dyn CapabilitySurfaceProfileResolver> =
         Arc::new(SubagentCapabilitySurfaceResolver::new(
             parts.capability_surface_resolver,
@@ -657,6 +672,40 @@ where
             scheduler_handle,
         },
     )
+}
+
+/// Outermost decorator that strips a caller-supplied deny list from every loop
+/// capability surface (tool definitions, visible descriptors, and invocation),
+/// regardless of the resolved profile allow-set.
+/// Capabilities temporarily removed from the model-facing surface as an
+/// explicit composition decision. Applied via an outermost
+/// [`CapabilitySurfaceDenyFilter`]. Empty this slice to re-enable everything.
+const DISABLED_CAPABILITY_IDS: &[&str] =
+    &[ironclaw_loop_support::DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID];
+
+struct DisabledCapabilitiesDecorator {
+    denied_capability_ids: Vec<CapabilityId>,
+}
+
+impl DisabledCapabilitiesDecorator {
+    fn new(denied_capability_ids: Vec<CapabilityId>) -> Self {
+        Self {
+            denied_capability_ids,
+        }
+    }
+}
+
+impl LoopCapabilityPortDecorator for DisabledCapabilitiesDecorator {
+    fn decorate(
+        &self,
+        _run_context: &LoopRunContext,
+        inner: Arc<dyn LoopCapabilityPort>,
+    ) -> Arc<dyn LoopCapabilityPort> {
+        Arc::new(CapabilitySurfaceDenyFilter::new(
+            inner,
+            self.denied_capability_ids.iter().cloned(),
+        ))
+    }
 }
 
 struct SubagentSpawnCapabilityDecorator {

--- a/tests/reborn_subagent_spawn_e2e.rs
+++ b/tests/reborn_subagent_spawn_e2e.rs
@@ -20,6 +20,7 @@ use reborn_support::{
 };
 
 #[tokio::test]
+#[ignore = "TEMP(disable-spawn-subagents): spawn_subagent temporarily disabled via capability deny filter; re-enable by emptying DISABLED_CAPABILITY_IDS"]
 async fn blocking_spawn_parks_parent_then_resumes_with_child_result() {
     let model_gateway = RebornTraceReplayModelGateway::with_scripted_steps([
         RebornModelReplayStep::ProviderToolCalls {
@@ -84,6 +85,7 @@ async fn blocking_spawn_parks_parent_then_resumes_with_child_result() {
 }
 
 #[tokio::test]
+#[ignore = "TEMP(disable-spawn-subagents): spawn_subagent temporarily disabled via capability deny filter; re-enable by emptying DISABLED_CAPABILITY_IDS"]
 async fn legacy_explicit_blocking_spawn_still_parks_parent_and_resumes() {
     let model_gateway = RebornTraceReplayModelGateway::with_scripted_steps([
         RebornModelReplayStep::ProviderToolCalls {
@@ -142,6 +144,7 @@ async fn legacy_explicit_blocking_spawn_still_parks_parent_and_resumes() {
 }
 
 #[tokio::test]
+#[ignore = "TEMP(disable-spawn-subagents): spawn_subagent temporarily disabled via capability deny filter; re-enable by emptying DISABLED_CAPABILITY_IDS"]
 async fn background_spawn_is_rejected_before_child_run_or_auth_invocation() {
     let model_gateway = RebornTraceReplayModelGateway::with_scripted_steps([
         RebornModelReplayStep::ProviderToolCalls {
@@ -195,6 +198,7 @@ async fn background_spawn_is_rejected_before_child_run_or_auth_invocation() {
 }
 
 #[tokio::test]
+#[ignore = "TEMP(disable-spawn-subagents): spawn_subagent temporarily disabled via capability deny filter; re-enable by emptying DISABLED_CAPABILITY_IDS"]
 async fn blocking_spawn_waits_while_child_is_blocked_on_approval_then_resumes() {
     let model_gateway = RebornTraceReplayModelGateway::with_scripted_steps([
         RebornModelReplayStep::ProviderToolCalls {
@@ -304,6 +308,7 @@ async fn blocking_spawn_waits_while_child_is_blocked_on_approval_then_resumes() 
 }
 
 #[tokio::test]
+#[ignore = "TEMP(disable-spawn-subagents): spawn_subagent temporarily disabled via capability deny filter; re-enable by emptying DISABLED_CAPABILITY_IDS"]
 async fn parallel_blocking_spawn_resumes_once_after_last_child() {
     let model_gateway = RebornTraceReplayModelGateway::with_scripted_steps([
         RebornModelReplayStep::ProviderToolCalls {

--- a/tests/reborn_trace_first_party_tool_coverage.rs
+++ b/tests/reborn_trace_first_party_tool_coverage.rs
@@ -154,15 +154,15 @@ async fn reborn_trace_process_first_party_tools_parity() {
             .any(|message| message.content.contains(shell.as_str())),
         "shell must be advertised on the Reborn model-facing first-party surface"
     );
-    // Subagent spawning is a special loop path covered by
-    // tests/reborn_subagent_spawn_e2e.rs; this first-party tool trace only
-    // verifies it remains advertised on the model-facing surface.
+    // TEMP(disable-spawn-subagents): spawn_subagent is temporarily disabled via
+    // the outermost capability deny filter in the default planned runtime, so it
+    // must NOT appear on the model-facing surface.
     assert!(
-        requests[0]
+        !requests[0]
             .messages
             .iter()
             .any(|message| message.content.contains(spawn_subagent.as_str())),
-        "spawn_subagent must be advertised on the Reborn model-facing first-party surface"
+        "spawn_subagent must NOT be advertised while temporarily disabled"
     );
     assert_eq!(tool_result_count(&requests[1]), 1);
     assert_milestone_order(
@@ -176,6 +176,7 @@ async fn reborn_trace_process_first_party_tools_parity() {
 }
 
 #[tokio::test]
+#[ignore = "TEMP(disable-spawn-subagents): spawn_subagent temporarily disabled via capability deny filter; re-enable by emptying DISABLED_CAPABILITY_IDS"]
 async fn reborn_trace_spawn_subagent_is_surface_text_and_structured_tool() {
     let spawn_subagent =
         CapabilityId::new(SPAWN_SUBAGENT_CAPABILITY_ID).expect("valid capability id");


### PR DESCRIPTION
## Change Type
- [x] Refactor / runtime composition (temporary capability disable)

## Linked Issue
None (temporary operational change).

## What

Temporarily disables the **`spawn_subagent`** capability so the model cannot spawn child subagent runs.

- `crates/ironclaw_reborn/src/runtime.rs` — default planned runtime composition no longer installs `SubagentSpawnCapabilityDecorator` (`.with_decorator(spawn_decorator)` removed). The decorator is the site that advertises the rich flavor-aware spawn tool + intercepts spawn invocation.

## Why all profiles

`builtin_extension_registry()` is shared by local-dev and production composition, so `spawn_subagent` was never profile-gated — this applies everywhere.

## ⚠️ Open design decision (review feedback)

Codex (P1) / CodeRabbit (Major) correctly flag that the decorator removal **alone is not a complete disable**: the host-runtime first-party manifest still publishes `builtin.spawn_subagent` (manifest + base-registry handler + authorization stub). Without the decorator, the model can still see/call `builtin__spawn_subagent` via the inner surface — it hits the no-op authorization stub (`{authorized:true}`) instead of spawning.

CodeRabbit also flags that the disable should be an **explicit profile/readiness decision** (per `crates/ironclaw_reborn` guideline) rather than a TEMP `_`-bound dead decorator that can still error the build.

Resolving both before merge — see thread.

## Validation
- [x] `cargo build -p ironclaw_reborn` — exit 0, no warnings
- [x] `cargo clippy -p ironclaw_reborn --all-features` — exit 0, no warnings
- [ ] Full test suite (pending final approach)
- [ ] Integration tests asserting spawn-tool presence updated (expected to fail by design until approach finalized)

## Security Impact
Removes a capability (spawn child runs) from the model-facing surface — strictly narrows the trust boundary. Open item above is about making the narrowing *complete*.

## Review Track
C (runtime composition)

🤖 Generated with [Claude Code](https://claude.com/claude-code)