### PR TITLE
fix(reborn): skip NEAR AI MCP without durable auth storage

### DIFF
--- a/crates/ironclaw_reborn_composition/src/available_extensions.rs
+++ b/crates/ironclaw_reborn_composition/src/available_extensions.rs
@@ -22,7 +22,8 @@ use crate::extension_credential_requirements::{
     product_auth_credential_source,
 };
 use crate::nearai_mcp::{
-    NearAiMcpBootstrapConfig, NearAiMcpEndpoint, nearai_mcp_endpoint_from_env,
+    NearAiMcpBootstrapConfig, NearAiMcpEndpoint, durable_product_auth_storage_enabled,
+    nearai_mcp_endpoint_from_base, nearai_mcp_endpoint_from_env,
 };
 
 const GITHUB_MANIFEST: &str =
@@ -550,9 +551,13 @@ pub(crate) fn slack_manifest_digest() -> String {
 pub(crate) fn nearai_mcp_manifest_toml_for_config(
     config: Option<&NearAiMcpBootstrapConfig>,
 ) -> Result<String, ProductWorkflowError> {
-    let endpoint = match config {
-        Some(config) => config.endpoint().map_err(map_binding_error)?,
-        None => nearai_mcp_endpoint_from_env().map_err(map_binding_error)?,
+    let endpoint = if durable_product_auth_storage_enabled() {
+        match config {
+            Some(config) => config.endpoint().map_err(map_binding_error)?,
+            None => nearai_mcp_endpoint_from_env().map_err(map_binding_error)?,
+        }
+    } else {
+        nearai_mcp_endpoint_from_base(None).map_err(map_binding_error)?
     };
     nearai_mcp_manifest_toml_for_endpoint(&endpoint)
 }
@@ -1596,8 +1601,6 @@ mod tests {
     };
 
     use super::*;
-    use crate::nearai_mcp::nearai_mcp_endpoint_from_base;
-
     #[test]
     fn visible_capability_ids_include_write_effects() {
         let extension = test_extension_package();
@@ -2209,6 +2212,24 @@ handle = "web_token"
         assert_eq!(
             manifest["capabilities"][0]["runtime_credentials"][0]["audience"]["port"].as_integer(),
             Some(8443)
+        );
+    }
+
+    #[cfg(not(any(feature = "libsql", feature = "postgres")))]
+    #[test]
+    fn nearai_manifest_renderer_ignores_config_endpoint_without_durable_product_auth() {
+        let config = NearAiMcpBootstrapConfig::new(
+            "http://invalid-nearai.example.test",
+            secrecy::SecretString::from("nearai-test-key"),
+        )
+        .unwrap();
+
+        let manifest_toml = nearai_mcp_manifest_toml_for_config(Some(&config)).unwrap();
+        let manifest: Value = toml::from_str(&manifest_toml).unwrap();
+
+        assert_eq!(
+            manifest["runtime"]["url"].as_str(),
+            Some("https://cloud-api.near.ai/mcp")
         );
     }
 

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -5414,13 +5414,14 @@ mod tests {
     async fn local_dev_nearai_mcp_skips_auto_activation_without_durable_product_auth() {
         let dir = tempfile::tempdir().expect("tempdir");
         let owner = "local-dev-nearai-mcp-no-durable-owner";
-        let services = build_reborn_services(nearai_bootstrap_input(
+        let services = build_reborn_services(nearai_bootstrap_input_with_base(
             owner,
             dir.path().join("local-dev"),
+            "http://private.near.ai",
             "nearai-test-key",
         ))
         .await
-        .expect("local-dev services build");
+        .expect("local-dev services build should ignore invalid NEAR AI MCP endpoint without durable product auth");
         let local_runtime = services.local_runtime.as_ref().expect("local runtime");
         let extension_management = local_runtime
             .extension_management

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -3058,7 +3058,7 @@ fn notion_mcp_allowed_effects() -> Vec<EffectKind> {
     ]
 }
 
-#[cfg(test)]
+#[cfg(all(test, any(feature = "libsql", feature = "postgres")))]
 fn nearai_allowed_effects() -> Vec<EffectKind> {
     vec![
         EffectKind::DispatchCapability,
@@ -3992,9 +3992,12 @@ mod tests {
         CapabilityGrant, CapabilityGrantId, CapabilityId, CapabilitySet, EffectKind,
         ExecutionContext, ExtensionId, GrantConstraints, InvocationId, MountAlias, MountGrant,
         MountPermissions, NetworkPolicy, NetworkScheme, NetworkTargetPattern, Principal,
-        ResourceEstimate, ResourceScope, RuntimeCredentialAccountProviderId,
-        RuntimeCredentialRequirementSource, RuntimeKind, ScopedPath, SecretHandle, TenantId,
+        ResourceEstimate, ResourceScope, RuntimeKind, ScopedPath, SecretHandle, TenantId,
         TrustClass, UserId, VirtualPath,
+    };
+    #[cfg(any(feature = "libsql", feature = "postgres"))]
+    use ironclaw_host_api::{
+        RuntimeCredentialAccountProviderId, RuntimeCredentialRequirementSource,
     };
     use ironclaw_host_runtime::{
         MEMORY_SEARCH_CAPABILITY_ID, MEMORY_TREE_CAPABILITY_ID, MEMORY_WRITE_CAPABILITY_ID,
@@ -5329,6 +5332,7 @@ mod tests {
         );
     }
 
+    #[cfg(any(feature = "libsql", feature = "postgres"))]
     #[tokio::test]
     async fn local_dev_nearai_mcp_auto_bootstraps_from_injected_config() {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -5405,6 +5409,63 @@ mod tests {
         assert!(nearai_account.access_secret.is_some());
     }
 
+    #[cfg(not(any(feature = "libsql", feature = "postgres")))]
+    #[tokio::test]
+    async fn local_dev_nearai_mcp_skips_auto_activation_without_durable_product_auth() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let owner = "local-dev-nearai-mcp-no-durable-owner";
+        let services = build_reborn_services(nearai_bootstrap_input(
+            owner,
+            dir.path().join("local-dev"),
+            "nearai-test-key",
+        ))
+        .await
+        .expect("local-dev services build");
+        let local_runtime = services.local_runtime.as_ref().expect("local runtime");
+        let extension_management = local_runtime
+            .extension_management
+            .as_ref()
+            .expect("extension management");
+        let nearai_ref =
+            LifecyclePackageRef::new(LifecyclePackageKind::Extension, "nearai").expect("valid ref");
+
+        let projection = extension_management
+            .project(nearai_ref)
+            .await
+            .expect("NEAR AI MCP projected");
+        assert_eq!(projection.phase, LifecyclePhase::Discovered);
+
+        let capabilities = extension_management
+            .active_model_visible_capabilities()
+            .await
+            .expect("active capabilities");
+        assert!(
+            capabilities
+                .iter()
+                .all(|capability| capability.id.as_str() != "nearai.web_search")
+        );
+
+        let auth_scope = AuthProductScope::new(
+            local_dev_nearai_mcp_owner_scope(UserId::new(owner).unwrap(), None)
+                .expect("NEAR AI MCP owner scope"),
+            AuthSurface::Api,
+        );
+        let accounts = services
+            .product_auth
+            .as_ref()
+            .expect("product auth")
+            .credential_account_record_source()
+            .accounts_for_owner(&auth_scope)
+            .await
+            .expect("credential accounts load");
+        assert!(
+            accounts
+                .iter()
+                .all(|account| account.provider.as_str() != "nearai")
+        );
+    }
+
+    #[cfg(any(feature = "libsql", feature = "postgres"))]
     #[tokio::test]
     async fn local_dev_nearai_mcp_rebootstrap_reuses_existing_account() {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -5481,6 +5542,7 @@ mod tests {
         );
     }
 
+    #[cfg(any(feature = "libsql", feature = "postgres"))]
     #[tokio::test]
     async fn local_dev_nearai_mcp_bootstrap_reinstalls_discovered_reused_credential() {
         let dir = tempfile::tempdir().expect("tempdir");

--- a/crates/ironclaw_reborn_composition/src/nearai_mcp.rs
+++ b/crates/ironclaw_reborn_composition/src/nearai_mcp.rs
@@ -212,6 +212,12 @@ pub(crate) async fn bootstrap_nearai_mcp(
         .map_err(|error| RebornBuildError::InvalidConfig {
             reason: format!("NEAR AI MCP auto-enable skipped: invalid NEARAI_BASE_URL: {error}"),
         })?;
+    if !durable_product_auth_storage_enabled() {
+        tracing::debug!(
+            "NEAR AI MCP credentials are present, but durable product-auth secret storage is not enabled; skipping auto-activation"
+        );
+        return Ok(NearAiMcpBootstrapOutcome::SkippedUnsupportedStorage);
+    }
 
     let package_ref =
         LifecyclePackageRef::new(LifecyclePackageKind::Extension, "nearai").map_err(|error| {
@@ -355,6 +361,7 @@ pub(crate) enum NearAiMcpBootstrapOutcome {
     NotConfigured,
     SkippedDisabled,
     SkippedUnavailable,
+    SkippedUnsupportedStorage,
     SkippedPreservedRemoved,
     SkippedNonActivatable,
     ReusedCredential,
@@ -368,6 +375,7 @@ impl NearAiMcpBootstrapOutcome {
             Self::NotConfigured => tracing::debug!("NEAR AI MCP bootstrap is not configured"),
             Self::SkippedDisabled
             | Self::SkippedUnavailable
+            | Self::SkippedUnsupportedStorage
             | Self::SkippedPreservedRemoved
             | Self::SkippedNonActivatable => tracing::debug!(
                 outcome = ?self,
@@ -378,6 +386,10 @@ impl NearAiMcpBootstrapOutcome {
             }
         }
     }
+}
+
+fn durable_product_auth_storage_enabled() -> bool {
+    cfg!(any(feature = "libsql", feature = "postgres"))
 }
 
 fn nearai_mcp_bootstrap_account_is_usable(
@@ -498,6 +510,14 @@ mod tests {
             created_at: chrono::DateTime::from_timestamp(updated_at_secs, 0).expect("timestamp"),
             updated_at: chrono::DateTime::from_timestamp(updated_at_secs, 0).expect("timestamp"),
         }
+    }
+
+    #[test]
+    fn durable_product_auth_storage_flag_matches_features() {
+        assert_eq!(
+            durable_product_auth_storage_enabled(),
+            cfg!(any(feature = "libsql", feature = "postgres"))
+        );
     }
 
     #[test]

--- a/crates/ironclaw_reborn_composition/src/nearai_mcp.rs
+++ b/crates/ironclaw_reborn_composition/src/nearai_mcp.rs
@@ -207,17 +207,17 @@ pub(crate) async fn bootstrap_nearai_mcp(
     let Some(config) = config else {
         return Ok(NearAiMcpBootstrapOutcome::NotConfigured);
     };
-    config
-        .endpoint()
-        .map_err(|error| RebornBuildError::InvalidConfig {
-            reason: format!("NEAR AI MCP auto-enable skipped: invalid NEARAI_BASE_URL: {error}"),
-        })?;
     if !durable_product_auth_storage_enabled() {
         tracing::debug!(
             "NEAR AI MCP credentials are present, but durable product-auth secret storage is not enabled; skipping auto-activation"
         );
         return Ok(NearAiMcpBootstrapOutcome::SkippedUnsupportedStorage);
     }
+    config
+        .endpoint()
+        .map_err(|error| RebornBuildError::InvalidConfig {
+            reason: format!("NEAR AI MCP auto-enable skipped: invalid NEARAI_BASE_URL: {error}"),
+        })?;
 
     let package_ref =
         LifecyclePackageRef::new(LifecyclePackageKind::Extension, "nearai").map_err(|error| {
@@ -388,7 +388,7 @@ impl NearAiMcpBootstrapOutcome {
     }
 }
 
-fn durable_product_auth_storage_enabled() -> bool {
+pub(crate) fn durable_product_auth_storage_enabled() -> bool {
     cfg!(any(feature = "libsql", feature = "postgres"))
 }
 
@@ -510,14 +510,6 @@ mod tests {
             created_at: chrono::DateTime::from_timestamp(updated_at_secs, 0).expect("timestamp"),
             updated_at: chrono::DateTime::from_timestamp(updated_at_secs, 0).expect("timestamp"),
         }
-    }
-
-    #[test]
-    fn durable_product_auth_storage_flag_matches_features() {
-        assert_eq!(
-            durable_product_auth_storage_enabled(),
-            cfg!(any(feature = "libsql", feature = "postgres"))
-        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Skip NEAR AI MCP auto-bootstrap when durable product-auth secret storage is not enabled.
- Keep existing auto-activation behavior for durable `libsql`/`postgres` builds.
- Add coverage for the no-durable local-dev path so `nearai.web_search` stays inactive instead of exposing a dangling credential handle.

## Why
In `root-llm-provider`-only downstream builds, local-dev product auth uses the in-memory fake path. That path can create a configured credential account with a handle, but it does not write backing secret material into `SecretStore`, so the active NEAR AI MCP tool later blocks on `UnknownSecret` during credential injection.

Fixes #5139

## Tests
- `cargo fmt`
- `cargo test -p ironclaw_reborn_composition local_dev_nearai_mcp_skips_auto_activation_without_durable_product_auth`
- `cargo test -p ironclaw_reborn_composition --features libsql local_dev_nearai_mcp`
- `cargo test -p ironclaw_reborn_composition durable_product_auth_storage_flag_matches_features`
- `git diff --check`
