### PR TITLE
Allow Slack enablement env override

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -371,6 +371,7 @@ SAFETY_INJECTION_CHECK_ENABLED=true
 # IRONCLAW_REBORN_SECRET_MASTER_KEY=replace-with-independent-secret-key-material
 # IRONCLAW_REBORN_SERVE_HOST=127.0.0.1
 # IRONCLAW_REBORN_SERVE_PORT=3000
+# IRONCLAW_REBORN_SLACK_ENABLED=true        # accepts 1/true to enable Slack, 0/false as a kill switch
 # IRONCLAW_REBORN_CONFIRM_HOST_ACCESS=false
 #
 # WebChat v2 SSO login (Google / GitHub). Setting either CLIENT_ID

--- a/README.md
+++ b/README.md
@@ -337,26 +337,29 @@ export IRONCLAW_REBORN_HOME="$PWD/.reborn-home"
 export OPENAI_API_KEY="sk-..." # or the required env var for your configured provider
 export IRONCLAW_REBORN_WEBUI_TOKEN="$(openssl rand -hex 32)"
 export IRONCLAW_REBORN_WEBUI_USER_ID="reborn-cli"
+export IRONCLAW_REBORN_SLACK_ENABLED="true"
 
 cargo run -q -p ironclaw_reborn_cli --features slack-v2-host-beta --bin ironclaw-reborn -- serve
 ```
 
-Add a `[slack]` section to `config.toml`:
+Enable Slack by setting `IRONCLAW_REBORN_SLACK_ENABLED=true`, or by adding a
+`[slack]` section to `config.toml`:
 
 ```toml
 [slack]
 enabled = true
 ```
 
-`enabled` is the only Slack boot setting. After the server starts, configure
-the Slack app ids, bot token, signing secret, and channel mappings from WebUI
-channel setup.
+The env var overrides only the Slack route enablement gate: `true`/`1` mounts
+Slack, while `false`/`0` acts as a deployment kill switch. After the server
+starts, configure the Slack app ids, bot token, signing secret, and channel
+mappings from WebUI channel setup.
 
 Required Slack settings:
 
 | Name | Purpose |
 | --- | --- |
-| `[slack].enabled = true` | Mounts the Slack route during `serve`. |
+| `[slack].enabled = true` or `IRONCLAW_REBORN_SLACK_ENABLED=true` | Mounts the Slack route during `serve`. |
 | WebUI Slack workspace setup | Stores Slack installation ids, channel mappings, and Slack bot/signing secrets. |
 
 More detailed Slack setup notes live in

--- a/crates/ironclaw_reborn_cli/Cargo.toml
+++ b/crates/ironclaw_reborn_cli/Cargo.toml
@@ -42,8 +42,9 @@ webui-v2-beta = [
     "dep:async-trait",
 ]
 # Compile in the Slack Events API host-beta mount for `ironclaw-reborn serve`.
-# Still requires `[slack].enabled = true` at runtime before the route is
-# mounted; ambient Slack env vars alone do not enable it.
+# Still requires effective Slack enablement at runtime before the route is
+# mounted: either `[slack].enabled = true` or
+# `IRONCLAW_REBORN_SLACK_ENABLED=true`.
 slack-v2-host-beta = [
     "webui-v2-beta",
     "ironclaw_reborn_composition/slack-v2-host-beta",

--- a/crates/ironclaw_reborn_cli/src/commands/config/init.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/config/init.rs
@@ -220,6 +220,7 @@ api_key_env = "OPENAI_API_KEY"
 # [slack]
 # # Host-beta Slack Events API route for `ironclaw-reborn serve`.
 # # Requires a binary built with `--features slack-v2-host-beta`.
+# # Can also be overridden by IRONCLAW_REBORN_SLACK_ENABLED.
 # enabled = false
 # # Configure Slack app ids, bot token, signing secret, and channel mappings
 # # from WebUI channel setup after the server starts.

--- a/crates/ironclaw_reborn_cli/src/commands/serve_slack.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/serve_slack.rs
@@ -13,6 +13,8 @@ use ironclaw_reborn_composition::{
 #[cfg(feature = "slack-v2-host-beta")]
 use secrecy::SecretString;
 
+use crate::operator_env::strict_bool_env_var;
+
 #[cfg(feature = "slack-v2-host-beta")]
 const DEFAULT_SLACK_SIGNING_SECRET_ENV_VAR: &str = "IRONCLAW_REBORN_SLACK_SIGNING_SECRET";
 #[cfg(feature = "slack-v2-host-beta")]
@@ -28,19 +30,19 @@ pub(crate) fn resolve_slack_config_for_serve(
     default_user_id: &ironclaw_reborn_composition::host_api::UserId,
     config_path: &Path,
 ) -> anyhow::Result<Option<SlackHostBetaRuntimeConfig>> {
-    let enabled = effective_slack_enabled(section)?;
-    if section.is_none() && !enabled {
-        return Ok(None);
-    }
-    if section.is_some_and(has_legacy_slack_setup) && !enabled {
+    let enablement = resolve_slack_enablement(section)?;
+    if !enablement.enabled {
+        if enablement.env_override == Some(false) || section.is_none() {
+            return Ok(None);
+        }
+        if !section.is_some_and(has_legacy_slack_setup) {
+            return Ok(None);
+        }
         anyhow::bail!(
             "[slack].enabled or {SLACK_ENABLED_ENV_VAR}=true must be set when legacy Slack setup \
              fields are present in {}",
             config_path.display()
         );
-    }
-    if !enabled {
-        return Ok(None);
     }
     let runtime_config = SlackHostBetaRuntimeConfig::new(
         tenant_id.clone(),
@@ -218,7 +220,7 @@ pub(crate) fn resolve_slack_config_for_serve(
 pub(crate) fn reject_enabled_slack_without_feature(
     section: Option<&ironclaw_reborn_config::SlackSection>,
 ) -> anyhow::Result<()> {
-    if effective_slack_enabled(section)? {
+    if resolve_slack_enablement(section)?.enabled {
         anyhow::bail!(
             "Slack enablement ([slack].enabled = true or {SLACK_ENABLED_ENV_VAR}=true) requires \
              an ironclaw-reborn binary built with the `slack-v2-host-beta` Cargo feature"
@@ -227,55 +229,21 @@ pub(crate) fn reject_enabled_slack_without_feature(
     Ok(())
 }
 
-fn effective_slack_enabled(
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct SlackEnablement {
+    enabled: bool,
+    env_override: Option<bool>,
+}
+
+fn resolve_slack_enablement(
     section: Option<&ironclaw_reborn_config::SlackSection>,
-) -> anyhow::Result<bool> {
-    let mut enabled = section.and_then(|section| section.enabled).unwrap_or(false);
-    if let Some(raw) = strict_env_var(SLACK_ENABLED_ENV_VAR)? {
-        enabled = parse_slack_enabled_env(&raw)?;
-    }
-    Ok(enabled)
-}
-
-fn strict_env_var(name: &str) -> anyhow::Result<Option<String>> {
-    match std::env::var(name) {
-        Ok(value) => {
-            if value.trim().is_empty() {
-                anyhow::bail!(
-                    "{name} is set but empty or whitespace-only; either unset it or provide a valid value"
-                );
-            }
-            Ok(Some(value))
-        }
-        Err(std::env::VarError::NotPresent) => Ok(None),
-        Err(std::env::VarError::NotUnicode(_)) => anyhow::bail!(
-            "{name} contains non-UTF-8 bytes; either unset it or provide a valid value"
-        ),
-    }
-}
-
-fn parse_slack_enabled_env(raw: &str) -> anyhow::Result<bool> {
-    match raw.trim().to_ascii_lowercase().as_str() {
-        "1" | "true" => Ok(true),
-        "0" | "false" => Ok(false),
-        _ => {
-            let display = truncate_env_value_for_display(raw);
-            anyhow::bail!(
-                "{SLACK_ENABLED_ENV_VAR} must be one of 1, true, 0, false (got {display:?})"
-            )
-        }
-    }
-}
-
-fn truncate_env_value_for_display(raw: &str) -> String {
-    const MAX_CHARS: usize = 64;
-    let mut iter = raw.chars();
-    let truncated: String = iter.by_ref().take(MAX_CHARS).collect();
-    if iter.next().is_some() {
-        format!("{truncated}...")
-    } else {
-        truncated
-    }
+) -> anyhow::Result<SlackEnablement> {
+    let config_enabled = section.and_then(|section| section.enabled).unwrap_or(false);
+    let env_override = strict_bool_env_var(SLACK_ENABLED_ENV_VAR)?;
+    Ok(SlackEnablement {
+        enabled: env_override.unwrap_or(config_enabled),
+        env_override,
+    })
 }
 
 #[cfg(test)]
@@ -426,7 +394,7 @@ mod tests {
 
     #[cfg(feature = "slack-v2-host-beta")]
     #[test]
-    fn slack_host_beta_runtime_config_env_disable_is_kill_switch() {
+    fn slack_host_beta_runtime_config_env_disable_is_webui_kill_switch() {
         let _lock = env_lock();
         let _enabled = EnvGuard::set(SLACK_ENABLED_ENV_VAR, "0");
         let section = ironclaw_reborn_config::SlackSection {
@@ -443,6 +411,30 @@ mod tests {
             std::path::Path::new("/tmp/reborn-config.toml"),
         )
         .expect("env-disabled Slack should resolve as disabled");
+
+        assert!(resolved.is_none());
+    }
+
+    #[cfg(feature = "slack-v2-host-beta")]
+    #[test]
+    fn slack_host_beta_runtime_config_env_disable_is_legacy_kill_switch() {
+        let _lock = env_lock();
+        let _enabled = EnvGuard::set(SLACK_ENABLED_ENV_VAR, "false");
+        let section = ironclaw_reborn_config::SlackSection {
+            enabled: Some(true),
+            installation_id: Some("install-alpha".to_string()),
+            ..Default::default()
+        };
+
+        let resolved = resolve_slack_config_for_serve(
+            Some(&section),
+            &tenant_id("tenant"),
+            &agent_id("agent"),
+            None,
+            &user_id("web-user"),
+            std::path::Path::new("/tmp/reborn-config.toml"),
+        )
+        .expect("env-disabled Slack should bypass legacy setup validation");
 
         assert!(resolved.is_none());
     }
@@ -466,6 +458,83 @@ mod tests {
         assert!(
             err.to_string().contains(SLACK_ENABLED_ENV_VAR),
             "error should identify the bad env var: {err}"
+        );
+    }
+
+    #[cfg(feature = "slack-v2-host-beta")]
+    #[test]
+    fn slack_host_beta_runtime_config_rejects_blank_enabled_env() {
+        let _lock = env_lock();
+        let _enabled = EnvGuard::set(SLACK_ENABLED_ENV_VAR, "   ");
+
+        let err = resolve_slack_config_for_serve(
+            None,
+            &tenant_id("tenant"),
+            &agent_id("agent"),
+            None,
+            &user_id("web-user"),
+            std::path::Path::new("/tmp/reborn-config.toml"),
+        )
+        .expect_err("blank Slack enabled env should fail loud");
+
+        assert!(
+            err.to_string().contains("empty or whitespace-only"),
+            "error should explain blank env value: {err}"
+        );
+    }
+
+    #[cfg(feature = "slack-v2-host-beta")]
+    #[test]
+    fn slack_host_beta_runtime_config_truncates_long_invalid_enabled_env() {
+        let _lock = env_lock();
+        let raw = "x".repeat(80);
+        let _enabled = EnvGuard::set(SLACK_ENABLED_ENV_VAR, &raw);
+
+        let err = resolve_slack_config_for_serve(
+            None,
+            &tenant_id("tenant"),
+            &agent_id("agent"),
+            None,
+            &user_id("web-user"),
+            std::path::Path::new("/tmp/reborn-config.toml"),
+        )
+        .expect_err("long invalid Slack enabled env should fail loud");
+        let msg = err.to_string();
+
+        assert!(
+            msg.contains('…'),
+            "truncation ellipsis should appear in error: {msg}"
+        );
+        assert!(
+            !msg.contains(&raw),
+            "full untruncated value should not appear in error: {msg}"
+        );
+    }
+
+    #[cfg(all(unix, feature = "slack-v2-host-beta"))]
+    #[test]
+    fn slack_host_beta_runtime_config_rejects_non_utf8_enabled_env() {
+        use std::os::unix::ffi::OsStringExt;
+
+        let _lock = env_lock();
+        let _enabled = EnvGuard::set_os(
+            SLACK_ENABLED_ENV_VAR,
+            std::ffi::OsString::from_vec(vec![0xff]),
+        );
+
+        let err = resolve_slack_config_for_serve(
+            None,
+            &tenant_id("tenant"),
+            &agent_id("agent"),
+            None,
+            &user_id("web-user"),
+            std::path::Path::new("/tmp/reborn-config.toml"),
+        )
+        .expect_err("non-UTF-8 Slack enabled env should fail loud");
+
+        assert!(
+            err.to_string().contains("non-UTF-8"),
+            "error should explain non-UTF-8 env value: {err}"
         );
     }
 
@@ -598,19 +667,27 @@ mod tests {
 
     struct EnvGuard {
         key: &'static str,
-        prior: Option<String>,
+        prior: Option<std::ffi::OsString>,
     }
 
     impl EnvGuard {
         fn set(key: &'static str, value: &str) -> Self {
-            let prior = std::env::var(key).ok();
+            let prior = std::env::var_os(key);
+            // SAFETY: tests hold TEST_ENV_LOCK while mutating process env.
+            unsafe { std::env::set_var(key, value) };
+            Self { key, prior }
+        }
+
+        #[cfg(all(unix, feature = "slack-v2-host-beta"))]
+        fn set_os(key: &'static str, value: std::ffi::OsString) -> Self {
+            let prior = std::env::var_os(key);
             // SAFETY: tests hold TEST_ENV_LOCK while mutating process env.
             unsafe { std::env::set_var(key, value) };
             Self { key, prior }
         }
 
         fn remove(key: &'static str) -> Self {
-            let prior = std::env::var(key).ok();
+            let prior = std::env::var_os(key);
             // SAFETY: tests hold TEST_ENV_LOCK while mutating process env.
             unsafe { std::env::remove_var(key) };
             Self { key, prior }

--- a/crates/ironclaw_reborn_cli/src/commands/serve_slack.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/serve_slack.rs
@@ -17,6 +17,7 @@ use secrecy::SecretString;
 const DEFAULT_SLACK_SIGNING_SECRET_ENV_VAR: &str = "IRONCLAW_REBORN_SLACK_SIGNING_SECRET";
 #[cfg(feature = "slack-v2-host-beta")]
 const DEFAULT_SLACK_BOT_TOKEN_ENV_VAR: &str = "IRONCLAW_REBORN_SLACK_BOT_TOKEN";
+const SLACK_ENABLED_ENV_VAR: &str = "IRONCLAW_REBORN_SLACK_ENABLED";
 
 #[cfg(feature = "slack-v2-host-beta")]
 pub(crate) fn resolve_slack_config_for_serve(
@@ -27,16 +28,18 @@ pub(crate) fn resolve_slack_config_for_serve(
     default_user_id: &ironclaw_reborn_composition::host_api::UserId,
     config_path: &Path,
 ) -> anyhow::Result<Option<SlackHostBetaRuntimeConfig>> {
-    let Some(section) = section else {
+    let enabled = effective_slack_enabled(section)?;
+    if section.is_none() && !enabled {
         return Ok(None);
-    };
-    if has_legacy_slack_setup(section) && section.enabled != Some(true) {
+    }
+    if section.is_some_and(has_legacy_slack_setup) && !enabled {
         anyhow::bail!(
-            "[slack].enabled must be true when legacy Slack setup fields are present in {}",
+            "[slack].enabled or {SLACK_ENABLED_ENV_VAR}=true must be set when legacy Slack setup \
+             fields are present in {}",
             config_path.display()
         );
     }
-    if section.enabled != Some(true) {
+    if !enabled {
         return Ok(None);
     }
     let runtime_config = SlackHostBetaRuntimeConfig::new(
@@ -45,6 +48,9 @@ pub(crate) fn resolve_slack_config_for_serve(
         default_project_id.cloned(),
         default_user_id.clone(),
     );
+    let Some(section) = section else {
+        return Ok(Some(runtime_config));
+    };
     let Some(legacy_setup) = resolve_legacy_slack_setup(section, default_user_id, config_path)?
     else {
         return Ok(Some(runtime_config));
@@ -212,13 +218,64 @@ pub(crate) fn resolve_slack_config_for_serve(
 pub(crate) fn reject_enabled_slack_without_feature(
     section: Option<&ironclaw_reborn_config::SlackSection>,
 ) -> anyhow::Result<()> {
-    if section.and_then(|section| section.enabled).unwrap_or(false) {
+    if effective_slack_enabled(section)? {
         anyhow::bail!(
-            "[slack].enabled = true requires an ironclaw-reborn binary built with \
-             the `slack-v2-host-beta` Cargo feature"
+            "Slack enablement ([slack].enabled = true or {SLACK_ENABLED_ENV_VAR}=true) requires \
+             an ironclaw-reborn binary built with the `slack-v2-host-beta` Cargo feature"
         );
     }
     Ok(())
+}
+
+fn effective_slack_enabled(
+    section: Option<&ironclaw_reborn_config::SlackSection>,
+) -> anyhow::Result<bool> {
+    let mut enabled = section.and_then(|section| section.enabled).unwrap_or(false);
+    if let Some(raw) = strict_env_var(SLACK_ENABLED_ENV_VAR)? {
+        enabled = parse_slack_enabled_env(&raw)?;
+    }
+    Ok(enabled)
+}
+
+fn strict_env_var(name: &str) -> anyhow::Result<Option<String>> {
+    match std::env::var(name) {
+        Ok(value) => {
+            if value.trim().is_empty() {
+                anyhow::bail!(
+                    "{name} is set but empty or whitespace-only; either unset it or provide a valid value"
+                );
+            }
+            Ok(Some(value))
+        }
+        Err(std::env::VarError::NotPresent) => Ok(None),
+        Err(std::env::VarError::NotUnicode(_)) => anyhow::bail!(
+            "{name} contains non-UTF-8 bytes; either unset it or provide a valid value"
+        ),
+    }
+}
+
+fn parse_slack_enabled_env(raw: &str) -> anyhow::Result<bool> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" => Ok(true),
+        "0" | "false" => Ok(false),
+        _ => {
+            let display = truncate_env_value_for_display(raw);
+            anyhow::bail!(
+                "{SLACK_ENABLED_ENV_VAR} must be one of 1, true, 0, false (got {display:?})"
+            )
+        }
+    }
+}
+
+fn truncate_env_value_for_display(raw: &str) -> String {
+    const MAX_CHARS: usize = 64;
+    let mut iter = raw.chars();
+    let truncated: String = iter.by_ref().take(MAX_CHARS).collect();
+    if iter.next().is_some() {
+        format!("{truncated}...")
+    } else {
+        truncated
+    }
 }
 
 #[cfg(test)]
@@ -228,9 +285,19 @@ mod tests {
     #[cfg(feature = "slack-v2-host-beta")]
     use secrecy::ExposeSecret;
 
+    static TEST_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+        TEST_ENV_LOCK
+            .lock()
+            .expect("Slack env-var tests should not poison the lock")
+    }
+
     #[cfg(feature = "slack-v2-host-beta")]
     #[test]
     fn slack_host_beta_runtime_config_is_disabled_unless_explicitly_enabled() {
+        let _lock = env_lock();
+        let _enabled = EnvGuard::remove(SLACK_ENABLED_ENV_VAR);
         let section = ironclaw_reborn_config::SlackSection {
             enabled: None,
             ..Default::default()
@@ -252,6 +319,8 @@ mod tests {
     #[cfg(feature = "slack-v2-host-beta")]
     #[test]
     fn slack_host_beta_runtime_config_rejects_legacy_fields_when_disabled() {
+        let _lock = env_lock();
+        let _enabled = EnvGuard::remove(SLACK_ENABLED_ENV_VAR);
         let section = ironclaw_reborn_config::SlackSection {
             enabled: Some(false),
             installation_id: Some("install-alpha".to_string()),
@@ -268,12 +337,14 @@ mod tests {
         )
         .expect_err("legacy Slack fields require enabled Slack");
 
-        assert!(err.to_string().contains("[slack].enabled must be true"));
+        assert!(err.to_string().contains("must be set"));
     }
 
     #[cfg(feature = "slack-v2-host-beta")]
     #[test]
     fn slack_host_beta_runtime_config_uses_webui_scope_when_enabled() {
+        let _lock = env_lock();
+        let _enabled = EnvGuard::remove(SLACK_ENABLED_ENV_VAR);
         let section = ironclaw_reborn_config::SlackSection {
             enabled: Some(true),
             ..Default::default()
@@ -303,7 +374,106 @@ mod tests {
 
     #[cfg(feature = "slack-v2-host-beta")]
     #[test]
+    fn slack_host_beta_runtime_config_uses_webui_scope_when_env_enabled_without_section() {
+        let _lock = env_lock();
+        let _enabled = EnvGuard::set(SLACK_ENABLED_ENV_VAR, "true");
+        let project_id = project_id("project");
+
+        let resolved = resolve_slack_config_for_serve(
+            None,
+            &tenant_id("tenant"),
+            &agent_id("agent"),
+            Some(&project_id),
+            &user_id("web-user"),
+            std::path::Path::new("/tmp/reborn-config.toml"),
+        )
+        .expect("env-enabled Slack resolves runtime scope")
+        .expect("Slack enabled");
+
+        assert_eq!(resolved.tenant_id.as_str(), "tenant");
+        assert_eq!(resolved.agent_id.as_str(), "agent");
+        assert_eq!(
+            resolved.project_id.as_ref().map(|id| id.as_str()),
+            Some("project")
+        );
+        assert_eq!(resolved.operator_user_id.as_str(), "web-user");
+        assert!(resolved.legacy_setup.is_none());
+    }
+
+    #[cfg(feature = "slack-v2-host-beta")]
+    #[test]
+    fn slack_host_beta_runtime_config_env_enables_disabled_webui_section() {
+        let _lock = env_lock();
+        let _enabled = EnvGuard::set(SLACK_ENABLED_ENV_VAR, "1");
+        let section = ironclaw_reborn_config::SlackSection {
+            enabled: Some(false),
+            ..Default::default()
+        };
+
+        let resolved = resolve_slack_config_for_serve(
+            Some(&section),
+            &tenant_id("tenant"),
+            &agent_id("agent"),
+            None,
+            &user_id("web-user"),
+            std::path::Path::new("/tmp/reborn-config.toml"),
+        )
+        .expect("env-enabled Slack resolves runtime scope")
+        .expect("Slack enabled");
+
+        assert!(resolved.legacy_setup.is_none());
+    }
+
+    #[cfg(feature = "slack-v2-host-beta")]
+    #[test]
+    fn slack_host_beta_runtime_config_env_disable_is_kill_switch() {
+        let _lock = env_lock();
+        let _enabled = EnvGuard::set(SLACK_ENABLED_ENV_VAR, "0");
+        let section = ironclaw_reborn_config::SlackSection {
+            enabled: Some(true),
+            ..Default::default()
+        };
+
+        let resolved = resolve_slack_config_for_serve(
+            Some(&section),
+            &tenant_id("tenant"),
+            &agent_id("agent"),
+            None,
+            &user_id("web-user"),
+            std::path::Path::new("/tmp/reborn-config.toml"),
+        )
+        .expect("env-disabled Slack should resolve as disabled");
+
+        assert!(resolved.is_none());
+    }
+
+    #[cfg(feature = "slack-v2-host-beta")]
+    #[test]
+    fn slack_host_beta_runtime_config_rejects_invalid_enabled_env() {
+        let _lock = env_lock();
+        let _enabled = EnvGuard::set(SLACK_ENABLED_ENV_VAR, "yes");
+
+        let err = resolve_slack_config_for_serve(
+            None,
+            &tenant_id("tenant"),
+            &agent_id("agent"),
+            None,
+            &user_id("web-user"),
+            std::path::Path::new("/tmp/reborn-config.toml"),
+        )
+        .expect_err("invalid Slack enabled env should fail loud");
+
+        assert!(
+            err.to_string().contains(SLACK_ENABLED_ENV_VAR),
+            "error should identify the bad env var: {err}"
+        );
+    }
+
+    #[cfg(feature = "slack-v2-host-beta")]
+    #[test]
     fn slack_host_beta_runtime_config_imports_legacy_setup_from_env_backed_config() {
+        let _lock = env_lock();
+        let _enabled = EnvGuard::remove(SLACK_ENABLED_ENV_VAR);
         const SIGNING_ENV: &str = "IRONCLAW_TEST_SLACK_LEGACY_SIGNING_SECRET";
         const BOT_ENV: &str = "IRONCLAW_TEST_SLACK_LEGACY_BOT_TOKEN";
         let _signing = EnvGuard::set(SIGNING_ENV, "legacy-signing-secret");
@@ -361,6 +531,8 @@ mod tests {
     #[cfg(not(feature = "slack-v2-host-beta"))]
     #[test]
     fn slack_config_rejects_enabled_section_without_feature() {
+        let _lock = env_lock();
+        let _enabled = EnvGuard::remove(SLACK_ENABLED_ENV_VAR);
         let section = ironclaw_reborn_config::SlackSection {
             enabled: Some(true),
             ..Default::default()
@@ -373,6 +545,35 @@ mod tests {
             err.to_string()
                 .contains("requires an ironclaw-reborn binary built with")
         );
+    }
+
+    #[cfg(not(feature = "slack-v2-host-beta"))]
+    #[test]
+    fn slack_config_rejects_enabled_env_without_feature() {
+        let _lock = env_lock();
+        let _enabled = EnvGuard::set(SLACK_ENABLED_ENV_VAR, "true");
+
+        let err = reject_enabled_slack_without_feature(None)
+            .expect_err("env-enabled Slack should require feature");
+
+        assert!(
+            err.to_string()
+                .contains("requires an ironclaw-reborn binary built with")
+        );
+    }
+
+    #[cfg(not(feature = "slack-v2-host-beta"))]
+    #[test]
+    fn slack_enabled_env_false_kills_enabled_section_without_feature() {
+        let _lock = env_lock();
+        let _enabled = EnvGuard::set(SLACK_ENABLED_ENV_VAR, "false");
+        let section = ironclaw_reborn_config::SlackSection {
+            enabled: Some(true),
+            ..Default::default()
+        };
+
+        reject_enabled_slack_without_feature(Some(&section))
+            .expect("env-disabled Slack should be a no-op without the host-beta feature");
     }
 
     #[cfg(feature = "slack-v2-host-beta")]
@@ -395,23 +596,27 @@ mod tests {
         ironclaw_reborn_composition::host_api::UserId::new(raw).expect("valid user")
     }
 
-    #[cfg(feature = "slack-v2-host-beta")]
     struct EnvGuard {
         key: &'static str,
         prior: Option<String>,
     }
 
-    #[cfg(feature = "slack-v2-host-beta")]
     impl EnvGuard {
         fn set(key: &'static str, value: &str) -> Self {
             let prior = std::env::var(key).ok();
-            // SAFETY: these test env names are unique to this module and restored on drop.
+            // SAFETY: tests hold TEST_ENV_LOCK while mutating process env.
             unsafe { std::env::set_var(key, value) };
+            Self { key, prior }
+        }
+
+        fn remove(key: &'static str) -> Self {
+            let prior = std::env::var(key).ok();
+            // SAFETY: tests hold TEST_ENV_LOCK while mutating process env.
+            unsafe { std::env::remove_var(key) };
             Self { key, prior }
         }
     }
 
-    #[cfg(feature = "slack-v2-host-beta")]
     impl Drop for EnvGuard {
         fn drop(&mut self) {
             match self.prior.take() {

--- a/crates/ironclaw_reborn_cli/src/main.rs
+++ b/crates/ironclaw_reborn_cli/src/main.rs
@@ -2,6 +2,7 @@ mod cli;
 mod commands;
 mod context;
 mod file_write;
+mod operator_env;
 mod runtime;
 
 fn main() -> anyhow::Result<()> {

--- a/crates/ironclaw_reborn_cli/src/operator_env.rs
+++ b/crates/ironclaw_reborn_cli/src/operator_env.rs
@@ -1,0 +1,55 @@
+/// Read an operator-control env var with strict presence semantics.
+///
+/// These env vars are control-plane knobs: presence is authoritative, not
+/// just non-empty content. Treat the var as:
+///
+/// - unset -> `Ok(None)` (fall through to the config/default layer)
+/// - set, empty or all-whitespace -> fatal
+/// - set, non-empty -> `Ok(Some(value))` (caller validates content)
+pub(crate) fn strict_env_var(name: &str) -> anyhow::Result<Option<String>> {
+    match std::env::var(name) {
+        Ok(value) => {
+            if value.trim().is_empty() {
+                anyhow::bail!(
+                    "{name} is set but empty or whitespace-only; either unset it or provide a valid value"
+                );
+            }
+            Ok(Some(value))
+        }
+        Err(std::env::VarError::NotPresent) => Ok(None),
+        Err(std::env::VarError::NotUnicode(_)) => anyhow::bail!(
+            "{name} contains non-UTF-8 bytes; either unset it or provide a valid value"
+        ),
+    }
+}
+
+pub(crate) fn strict_bool_env_var(name: &str) -> anyhow::Result<Option<bool>> {
+    strict_env_var(name)?
+        .map(|raw| parse_bool_env_var(name, &raw))
+        .transpose()
+}
+
+fn parse_bool_env_var(name: &str, raw: &str) -> anyhow::Result<bool> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" => Ok(true),
+        "0" | "false" => Ok(false),
+        _ => {
+            let display = truncate_env_value_for_display(raw);
+            anyhow::bail!("{name} must be one of 1, true, 0, false (got {display:?})")
+        }
+    }
+}
+
+/// Truncate an env-var value to a bounded length before echoing it in an
+/// error message. Prevents the value from blowing up startup logs if the
+/// operator accidentally pastes a long string into the env slot.
+pub(crate) fn truncate_env_value_for_display(raw: &str) -> String {
+    const MAX_CHARS: usize = 64;
+    let mut iter = raw.chars();
+    let truncated: String = iter.by_ref().take(MAX_CHARS).collect();
+    if iter.next().is_some() {
+        format!("{truncated}…")
+    } else {
+        truncated
+    }
+}

--- a/crates/ironclaw_reborn_cli/src/runtime/trigger_poller.rs
+++ b/crates/ironclaw_reborn_cli/src/runtime/trigger_poller.rs
@@ -2,40 +2,9 @@ use std::time::Duration;
 
 use ironclaw_reborn_composition::TriggerPollerSettings;
 
-use super::RuntimeInputCaller;
+use crate::operator_env::{strict_bool_env_var, strict_env_var, truncate_env_value_for_display};
 
-/// Read a trigger-poller env var with **strict** presence semantics.
-///
-/// `IRONCLAW_TRIGGER_POLLER_*` env vars are operator-control knobs: presence
-/// is authoritative, not just non-empty content. Treat the var as
-///
-/// - unset → `Ok(None)` (fall through to the config/default layer)
-/// - set, empty or all-whitespace → fatal (operator must unset or fix)
-/// - set, non-empty → `Ok(Some(value))` (caller validates content)
-///
-/// Distinct from the broader `optional_nonempty_env` used by optional-config
-/// callers (OAuth, etc.), which intentionally collapses present-blank to
-/// absent. Here, a present-but-blank env slot is almost always a bug — a
-/// shell typo, a half-set deployment template, or a credential injector
-/// that failed to populate the slot — and falling through silently would
-/// drop the operator's intended kill-switch or interval override with no
-/// visible signal.
-fn strict_env_var(name: &str) -> anyhow::Result<Option<String>> {
-    match std::env::var(name) {
-        Ok(value) => {
-            if value.trim().is_empty() {
-                anyhow::bail!(
-                    "{name} is set but empty or whitespace-only; either unset it or provide a valid value"
-                );
-            }
-            Ok(Some(value))
-        }
-        Err(std::env::VarError::NotPresent) => Ok(None),
-        Err(std::env::VarError::NotUnicode(_)) => anyhow::bail!(
-            "{name} contains non-UTF-8 bytes; either unset it or provide a valid value"
-        ),
-    }
-}
+use super::RuntimeInputCaller;
 
 /// Upper bound on `poll_interval_secs` (config) and
 /// `IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS` (env). One hour caps the
@@ -53,21 +22,6 @@ const MAX_JITTER_SECS: u64 = 3600;
 /// leaves plenty of headroom for a future high-throughput deployment
 /// while rejecting accidents like `u32::MAX` (~4B dispatches per tick).
 const MAX_FIRES_PER_TICK: u32 = 1000;
-
-/// Truncate an env-var value to a bounded length before echoing it in an
-/// error message. Prevents the value from blowing up startup logs if the
-/// operator accidentally pastes a long string (e.g. a credential) into the
-/// env slot. Char-aware so we cannot split a multi-byte UTF-8 codepoint.
-fn truncate_env_value_for_display(raw: &str) -> String {
-    const MAX_CHARS: usize = 64;
-    let mut iter = raw.chars();
-    let truncated: String = iter.by_ref().take(MAX_CHARS).collect();
-    if iter.next().is_some() {
-        format!("{truncated}…")
-    } else {
-        truncated
-    }
-}
 
 /// Build [`TriggerPollerSettings`] by merging three layers of configuration.
 ///
@@ -170,19 +124,8 @@ pub(super) fn trigger_poller_settings(
     // Layer 1: environment variable overrides. Uses strict presence
     // semantics — a present-but-blank value is fatal, not a silent
     // fall-through to config/default.
-    if let Some(raw) = strict_env_var("IRONCLAW_TRIGGER_POLLER_ENABLED")? {
-        match raw.trim().to_ascii_lowercase().as_str() {
-            "1" | "true" => settings.enabled = true,
-            "0" | "false" => settings.enabled = false,
-            _ => {
-                // Display the operator's original value (case preserved), not the
-                // lowercased match key — they need to find it in their config.
-                let display = truncate_env_value_for_display(&raw);
-                anyhow::bail!(
-                    "IRONCLAW_TRIGGER_POLLER_ENABLED must be one of 1, true, 0, false (got {display:?})"
-                )
-            }
-        }
+    if let Some(enabled) = strict_bool_env_var("IRONCLAW_TRIGGER_POLLER_ENABLED")? {
+        settings.enabled = enabled;
     }
 
     if let Some(raw) = strict_env_var("IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS")? {

--- a/crates/ironclaw_reborn_cli/tests/smoke.rs
+++ b/crates/ironclaw_reborn_cli/tests/smoke.rs
@@ -1476,6 +1476,123 @@ fn serve_with_env_auth_seeds_reborn_config_before_binding() {
     );
 }
 
+#[cfg(all(feature = "webui-v2-beta", feature = "slack-v2-host-beta"))]
+#[test]
+fn serve_env_slack_enabled_mounts_slack_events_route() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let reborn_home = temp.path().join("reborn-home");
+    let home = temp.path().join("home");
+    std::fs::create_dir_all(&home).expect("home dir");
+    let port = unused_local_port();
+
+    let mut child = Command::new(reborn_bin())
+        .args(["serve", "--host", "127.0.0.1", "--port"])
+        .arg(port.to_string())
+        .env_clear()
+        .env("HOME", &home)
+        .env("IRONCLAW_REBORN_HOME", &reborn_home)
+        .env("IRONCLAW_REBORN_WEBUI_TOKEN", "test-token")
+        .env("IRONCLAW_REBORN_WEBUI_USER_ID", "test-user")
+        .env("IRONCLAW_REBORN_SLACK_ENABLED", "true")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("ironclaw-reborn serve should start");
+    let stderr = child.stderr.take().expect("stderr should be piped");
+    let (stderr_tx, stderr_rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        for line in std::io::BufReader::new(stderr).lines() {
+            if stderr_tx.send(line).is_err() {
+                break;
+            }
+        }
+    });
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
+    let mut stderr_text = String::new();
+    loop {
+        if let Some(status) = child.try_wait().expect("serve child status") {
+            panic!("serve exited before binding with {status}; stderr: {stderr_text}");
+        }
+        if std::time::Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!("serve did not reach listener banner; stderr: {stderr_text}");
+        }
+        match stderr_rx.recv_timeout(std::time::Duration::from_millis(100)) {
+            Ok(Ok(line)) => {
+                stderr_text.push_str(&line);
+                stderr_text.push('\n');
+                if stderr_text.contains("ironclaw-reborn: WebChat v2 listener") {
+                    break;
+                }
+            }
+            Ok(Err(error)) => panic!("failed to read serve stderr: {error}"),
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                panic!("serve stderr closed before banner; stderr: {stderr_text}");
+            }
+        }
+    }
+
+    let status_line = match post_slack_events_status_line(port) {
+        Ok(status_line) => status_line,
+        Err(error) => {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!("{error}");
+        }
+    };
+
+    let _ = child.kill();
+    let _ = child.wait();
+    assert!(
+        !status_line.contains(" 404 "),
+        "env-enabled Slack route should be mounted, got status line: {status_line}"
+    );
+}
+
+#[cfg(all(feature = "webui-v2-beta", feature = "slack-v2-host-beta"))]
+fn unused_local_port() -> u16 {
+    std::net::TcpListener::bind(("127.0.0.1", 0))
+        .expect("bind ephemeral local port")
+        .local_addr()
+        .expect("ephemeral local addr")
+        .port()
+}
+
+#[cfg(all(feature = "webui-v2-beta", feature = "slack-v2-host-beta"))]
+fn post_slack_events_status_line(port: u16) -> Result<String, String> {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    let mut stream = loop {
+        match std::net::TcpStream::connect(("127.0.0.1", port)) {
+            Ok(stream) => break stream,
+            Err(_) if std::time::Instant::now() < deadline => {
+                std::thread::sleep(std::time::Duration::from_millis(50));
+            }
+            Err(error) => return Err(format!("connect to serve listener failed: {error}")),
+        }
+    };
+    let request = concat!(
+        "POST /webhooks/slack/events HTTP/1.1\r\n",
+        "Host: 127.0.0.1\r\n",
+        "Content-Type: application/json\r\n",
+        "Content-Length: 2\r\n",
+        "Connection: close\r\n",
+        "\r\n",
+        "{}"
+    );
+    stream
+        .write_all(request.as_bytes())
+        .map_err(|error| format!("write Slack route probe failed: {error}"))?;
+    let mut reader = std::io::BufReader::new(stream);
+    let mut status_line = String::new();
+    reader
+        .read_line(&mut status_line)
+        .map_err(|error| format!("read Slack route probe status line failed: {error}"))?;
+    Ok(status_line)
+}
+
 #[cfg(feature = "webui-v2-beta")]
 #[test]
 fn serve_rejects_malformed_host_before_webui_handoff() {

--- a/crates/ironclaw_reborn_config/src/config_file.rs
+++ b/crates/ironclaw_reborn_config/src/config_file.rs
@@ -294,15 +294,18 @@ pub struct WebuiSection {
 
 /// Slack Events API host-beta enablement.
 ///
-/// `enabled = true` mounts the Slack route. Installation identifiers, channel
-/// routing, and Slack secrets are configured through the WebUI channel setup
-/// surface. The deprecated fields below are accepted as a startup migration
-/// bridge for existing `config.toml` files; secret values still stay env-only.
+/// `enabled = true` or `IRONCLAW_REBORN_SLACK_ENABLED=true` mounts the Slack
+/// route. The env var overrides only this enablement gate. Installation
+/// identifiers, channel routing, and Slack secrets are configured through the
+/// WebUI channel setup surface. The deprecated fields below are accepted as a
+/// startup migration bridge for existing `config.toml` files; secret values
+/// still stay env-only.
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct SlackSection {
     /// Explicit host-beta enablement gate. Omitted/false means the Slack route
-    /// is not mounted by `ironclaw-reborn serve`.
+    /// is not mounted by `ironclaw-reborn serve` unless
+    /// `IRONCLAW_REBORN_SLACK_ENABLED` overrides it.
     pub enabled: Option<bool>,
     /// Deprecated: adapter installation id for legacy config-backed setup.
     pub installation_id: Option<String>,

--- a/docs/reborn/deploy-reborn-cli-docker.md
+++ b/docs/reborn/deploy-reborn-cli-docker.md
@@ -166,8 +166,18 @@ IRONCLAW_REBORN_GOOGLE_OAUTH_REDIRECT_URI=https://<railway-domain>/api/reborn/pr
 ## Slack
 
 Slack routes are compiled into the image, but they are disabled by the default
-config. To enable them, edit `$IRONCLAW_REBORN_HOME/config.toml` or mount a
-config file with:
+config. On Railway, prefer the env toggle so the seeded config can stay
+unchanged:
+
+```bash
+IRONCLAW_REBORN_SLACK_ENABLED=true
+```
+
+The env var overrides only the Slack route enablement gate. `true`/`1` enables
+Slack, while `false`/`0` forces Slack off for the deployment.
+
+You can also enable Slack by editing `$IRONCLAW_REBORN_HOME/config.toml` or
+mounting a config file with:
 
 ```toml
 [slack]

--- a/docs/reborn/setup-slack-for-reborn-binary.md
+++ b/docs/reborn/setup-slack-for-reborn-binary.md
@@ -6,7 +6,8 @@ not the legacy v1 Slack WASM channel.
 Slack support has two gates:
 
 1. The binary must be built with the `slack-v2-host-beta` Cargo feature.
-2. Runtime config must set `[slack].enabled = true`.
+2. Runtime config must set `[slack].enabled = true`, or the deployment env
+   must set `IRONCLAW_REBORN_SLACK_ENABLED=true`.
 
 Slack bot token and signing secret are configured in WebUI Slack setup and
 stored in the Reborn secret store. Do not put OAuth client secrets or LLM keys
@@ -89,6 +90,7 @@ IRONCLAW_REBORN_HOME=/data/ironclaw-reborn
 IRONCLAW_REBORN_PROFILE=local-dev
 IRONCLAW_REBORN_WEBUI_TOKEN=<random-hex-32-bytes-or-longer>
 IRONCLAW_REBORN_WEBUI_USER_ID=reborn-cli
+IRONCLAW_REBORN_SLACK_ENABLED=true
 OPENAI_API_KEY=sk-...
 ```
 
@@ -104,8 +106,13 @@ Minimal Slack config:
 enabled = true
 ```
 
-`enabled` is the only Slack boot setting. It mounts
-`POST /webhooks/slack/events` and exposes Slack channel setup in WebUI.
+`enabled` is the only Slack boot setting. You can also set
+`IRONCLAW_REBORN_SLACK_ENABLED=true` instead of editing config. The env var
+overrides only the route enablement gate: `true`/`1` mounts Slack, while
+`false`/`0` acts as a deployment kill switch.
+
+Slack enablement mounts `POST /webhooks/slack/events` and exposes Slack channel
+setup in WebUI.
 Slack installation ids, team/app ids, the bot token, the signing secret,
 and channel mappings are configured after startup from WebUI channel setup.
 
@@ -247,7 +254,7 @@ Verification checklist:
 
 ## Troubleshooting
 
-### [slack].enabled = true requires ... slack-v2-host-beta
+### Slack enablement requires ... slack-v2-host-beta
 
 Rebuild or rerun ironclaw-reborn with --features slack-v2-host-beta.
 


### PR DESCRIPTION
## Summary

- Add `IRONCLAW_REBORN_SLACK_ENABLED` as an env override for the Slack route enablement gate.
- Preserve the current WebUI-backed Slack setup path: env enablement mounts Slack without requiring legacy `[slack]` metadata.
- Document the Railway-friendly env toggle and add resolver coverage for env-only enable, kill switch, invalid values, and no-feature rejection.

## Replaces

Closes/replaces #5162, which was closed because it was stale and conflicted with the current WebUI-backed setup flow.

## Validation

- `cargo fmt`
- `git diff --check`
- `CARGO_INCREMENTAL=0 RUSTFLAGS="-C debuginfo=0" cargo test -p ironclaw_reborn_cli --no-default-features --features slack-v2-host-beta slack_host_beta_runtime_config -j1`
- `CARGO_INCREMENTAL=0 RUSTFLAGS="-C debuginfo=0" cargo test -p ironclaw_reborn_cli --no-default-features --features webui-v2-beta slack_config_ -j1`
- `CARGO_INCREMENTAL=0 RUSTFLAGS="-C debuginfo=0" cargo test -p ironclaw_reborn_cli --no-default-features --features webui-v2-beta slack_enabled_env_false_kills_enabled_section_without_feature -j1`

Note: the first full-size test attempt hit local disk exhaustion (`errno=28`) before `cargo clean`; the reduced feature-set commands above passed.
