### PR TITLE
Fix Slack admin setup visibility for WebUI operator tokens

### DIFF
--- a/crates/ironclaw_product_workflow/src/webui_inbound.rs
+++ b/crates/ironclaw_product_workflow/src/webui_inbound.rs
@@ -72,6 +72,12 @@ pub struct WebUiAuthenticatedCaller {
     pub agent_id: Option<AgentId>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub project_id: Option<ProjectId>,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub operator_webui_config: bool,
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
 }
 
 impl WebUiAuthenticatedCaller {
@@ -86,7 +92,13 @@ impl WebUiAuthenticatedCaller {
             user_id,
             agent_id,
             project_id,
+            operator_webui_config: false,
         }
+    }
+
+    pub fn with_operator_webui_config(mut self, operator_webui_config: bool) -> Self {
+        self.operator_webui_config = operator_webui_config;
+        self
     }
 
     pub fn actor(&self) -> TurnActor {

--- a/crates/ironclaw_reborn_cli/src/commands/serve.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/serve.rs
@@ -383,11 +383,8 @@ impl ServeCommand {
                 None
             };
             #[cfg(feature = "slack-v2-host-beta")]
-            let operator_route_visibility = if sso_startup.is_none() {
-                SlackOperatorRouteVisibility::Visible
-            } else {
-                SlackOperatorRouteVisibility::Hidden
-            };
+            let operator_route_visibility =
+                slack_operator_route_visibility_for_authenticator(env_authenticator.as_ref());
             #[cfg(feature = "slack-v2-host-beta")]
             let bundle: RebornWebuiBundle = build_webui_services_with_slack_host_beta_mounts(
                 &runtime,
@@ -802,6 +799,17 @@ fn resolve_webui_runtime_owner(
     Ok(webui_user_id.to_string())
 }
 
+#[cfg(feature = "slack-v2-host-beta")]
+fn slack_operator_route_visibility_for_authenticator(
+    authenticator: &dyn WebuiAuthenticator,
+) -> SlackOperatorRouteVisibility {
+    if authenticator.mounts_operator_webui_config_routes() {
+        SlackOperatorRouteVisibility::Visible
+    } else {
+        SlackOperatorRouteVisibility::Hidden
+    }
+}
+
 fn print_serve_banner(
     listen_addr: SocketAddr,
     env_token_var: &str,
@@ -903,6 +911,47 @@ mod tests {
         let message = error.to_string();
         assert!(message.contains("reborn-cli"), "message: {message}");
         assert!(message.contains("local-user"), "message: {message}");
+    }
+
+    #[cfg(feature = "slack-v2-host-beta")]
+    #[test]
+    fn slack_operator_route_visibility_follows_authenticator_route_mount_capability() {
+        struct HiddenAuth;
+
+        #[async_trait::async_trait]
+        impl WebuiAuthenticator for HiddenAuth {
+            async fn authenticate(
+                &self,
+                _token: &str,
+            ) -> Option<ironclaw_reborn_composition::WebuiAuthentication> {
+                None
+            }
+        }
+
+        struct OperatorRouteAuth;
+
+        #[async_trait::async_trait]
+        impl WebuiAuthenticator for OperatorRouteAuth {
+            async fn authenticate(
+                &self,
+                _token: &str,
+            ) -> Option<ironclaw_reborn_composition::WebuiAuthentication> {
+                None
+            }
+
+            fn mounts_operator_webui_config_routes(&self) -> bool {
+                true
+            }
+        }
+
+        assert_eq!(
+            slack_operator_route_visibility_for_authenticator(&HiddenAuth),
+            SlackOperatorRouteVisibility::Hidden
+        );
+        assert_eq!(
+            slack_operator_route_visibility_for_authenticator(&OperatorRouteAuth),
+            SlackOperatorRouteVisibility::Visible
+        );
     }
 
     #[tokio::test]

--- a/crates/ironclaw_reborn_composition/src/slack_channel_routes.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_channel_routes.rs
@@ -925,6 +925,9 @@ fn ensure_authorized_operator(
     if &caller.tenant_id != config.tenant_id() {
         return Err(SlackRouteError::NotFound);
     }
+    if !caller.operator_webui_config {
+        return Err(SlackRouteError::Forbidden);
+    }
     if &caller.user_id != config.operator_user_id() {
         return Err(SlackRouteError::Forbidden);
     }
@@ -1187,6 +1190,26 @@ mod tests {
                 r#"{"channel_id":"C0ENG","subject_user_id":"user:eng-team-agent"}"#,
                 TENANT,
                 "user:member",
+            ))
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn route_admin_rejects_operator_user_without_operator_capability() {
+        let mount = slack_channel_route_admin_route_mount(route_config(Arc::new(
+            InMemorySlackChannelRouteStore::new(),
+        )));
+
+        let response = mount
+            .protected
+            .oneshot(request_without_operator_capability(
+                "PUT",
+                r#"{"channel_id":"C0ENG","subject_user_id":"user:eng-team-agent"}"#,
+                TENANT,
+                "user:admin",
             ))
             .await
             .expect("response");
@@ -1882,6 +1905,17 @@ mod tests {
         )
     }
 
+    fn request_without_operator_capability(
+        method: &str,
+        body: &str,
+        tenant_id: &str,
+        user_id: &str,
+    ) -> Request<Body> {
+        let mut caller = caller(tenant_id, user_id);
+        caller.operator_webui_config = false;
+        request_to_path_with_caller(method, WEBUI_V2_CHANNELS_SLACK_ROUTES_PATH, body, caller)
+    }
+
     fn request_to_path(
         method: &str,
         path: &str,
@@ -1902,12 +1936,32 @@ mod tests {
             .expect("request builds")
     }
 
+    fn request_to_path_with_caller(
+        method: &str,
+        path: &str,
+        body: &str,
+        caller: WebUiAuthenticatedCaller,
+    ) -> Request<Body> {
+        let mut builder = Request::builder()
+            .method(method)
+            .uri(path)
+            .header("content-type", "application/json")
+            .extension(caller);
+        if method == "GET" {
+            builder = builder.header("content-length", "0");
+        }
+        builder
+            .body(Body::from(body.to_string()))
+            .expect("request builds")
+    }
+
     fn caller(tenant_id: &str, user_id: &str) -> WebUiAuthenticatedCaller {
         WebUiAuthenticatedCaller {
             tenant_id: TenantId::new(tenant_id).expect("tenant"),
             user_id: UserId::new(user_id).expect("user"),
             agent_id: None,
             project_id: None,
+            operator_webui_config: true,
         }
     }
 }

--- a/crates/ironclaw_reborn_composition/src/slack_channel_routes/allowed/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_channel_routes/allowed/tests.rs
@@ -815,6 +815,7 @@ fn request_for_caller(method: &str, body: &str, tenant_id: &str, user_id: &str) 
             user_id: UserId::new(user_id).expect("user"),
             agent_id: None,
             project_id: None,
+            operator_webui_config: true,
         });
     if method == "GET" {
         builder = builder.header("content-length", "0");

--- a/crates/ironclaw_reborn_composition/src/slack_connectable_channel.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_connectable_channel.rs
@@ -113,6 +113,7 @@ impl ConnectableChannelsProductFacade for SlackConnectableChannelsProductFacade 
         let mut channels = vec![slack_inbound_proof_code_connectable_channel()];
         if self.visibility
             == SlackConnectableChannelVisibility::PersonalPairingAndAdminChannelManagement
+            && caller.operator_webui_config
             && caller.tenant_id == self.tenant_id
             && caller.user_id == self.operator_user_id
         {
@@ -247,7 +248,8 @@ mod tests {
             UserId::new(SLACK_OPERATOR_USER).expect("user"),
             Some(AgentId::new("slack-webui-agent").expect("agent")),
             None,
-        );
+        )
+        .with_operator_webui_config(true);
 
         let response = bundle
             .api
@@ -267,6 +269,53 @@ mod tests {
         assert_eq!(
             channel_admin.strategy,
             RebornChannelConnectStrategy::AdminManagedChannels
+        );
+
+        runtime.shutdown().await.expect("runtime shutdown");
+    }
+
+    #[tokio::test]
+    async fn slack_mounts_hide_channel_admin_action_from_operator_user_without_operator_capability()
+    {
+        let root = tempfile::tempdir().expect("tempdir");
+        let runtime = build_reborn_runtime(
+            RebornRuntimeInput::from_services(
+                RebornBuildInput::local_dev("slack-webui-owner", root.path().join("local-dev"))
+                    .with_runtime_policy(local_dev_runtime_policy().expect("local policy")),
+            )
+            .with_identity(RebornRuntimeIdentity {
+                tenant_id: "slack-webui-tenant".to_string(),
+                agent_id: "slack-webui-agent".to_string(),
+                source_binding_id: "slack-webui-source".to_string(),
+                reply_target_binding_id: "slack-webui-reply".to_string(),
+            })
+            .with_model_gateway_override(Arc::new(StaticGateway)),
+        )
+        .await
+        .expect("runtime builds");
+        let bundle = build_webui_services_with_slack_connectable_channel(
+            &runtime,
+            None,
+            SlackConnectableChannelVisibility::PersonalPairingAndAdminChannelManagement,
+        )
+        .expect("webui bundle");
+        let caller = WebUiAuthenticatedCaller::new(
+            TenantId::new(SLACK_OPERATOR_TENANT).expect("tenant"),
+            UserId::new(SLACK_OPERATOR_USER).expect("user"),
+            Some(AgentId::new("slack-webui-agent").expect("agent")),
+            None,
+        );
+
+        let response = bundle
+            .api
+            .list_connectable_channels(caller)
+            .await
+            .expect("connectable channels");
+
+        assert_eq!(response.channels.len(), 1);
+        assert_eq!(
+            response.channels[0].strategy,
+            RebornChannelConnectStrategy::InboundProofCode
         );
 
         runtime.shutdown().await.expect("runtime shutdown");
@@ -301,7 +350,8 @@ mod tests {
             UserId::new("user:not-operator").expect("user"),
             Some(AgentId::new("slack-webui-agent").expect("agent")),
             None,
-        );
+        )
+        .with_operator_webui_config(true);
 
         let response = bundle
             .api
@@ -347,7 +397,8 @@ mod tests {
             UserId::new(SLACK_OPERATOR_USER).expect("user"),
             Some(AgentId::new("slack-webui-agent").expect("agent")),
             None,
-        );
+        )
+        .with_operator_webui_config(true);
 
         let response = bundle
             .api
@@ -393,7 +444,8 @@ mod tests {
             UserId::new(SLACK_OPERATOR_USER).expect("user"),
             Some(AgentId::new("slack-webui-agent").expect("agent")),
             None,
-        );
+        )
+        .with_operator_webui_config(true);
 
         let response = bundle
             .api

--- a/crates/ironclaw_reborn_composition/src/slack_host_beta.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_host_beta.rs
@@ -1117,6 +1117,27 @@ mod tests {
         }
     }
 
+    struct MixedSessionAndOperatorAuthenticator;
+
+    #[async_trait]
+    impl WebuiAuthenticator for MixedSessionAndOperatorAuthenticator {
+        async fn authenticate(&self, token: &str) -> Option<WebuiAuthentication> {
+            match token {
+                "session-token" => {
+                    Some(WebuiAuthentication::user(UserId::new(USER).expect("user")))
+                }
+                "operator-token" => Some(WebuiAuthentication::operator(
+                    UserId::new(USER).expect("user"),
+                )),
+                _ => None,
+            }
+        }
+
+        fn mounts_operator_webui_config_routes(&self) -> bool {
+            true
+        }
+    }
+
     struct HiddenOperatorRouteAuthenticator;
 
     #[async_trait]
@@ -1486,6 +1507,7 @@ mod tests {
                         user_id: UserId::new(USER).expect("user"),
                         agent_id: Some(AgentId::new(AGENT).expect("agent")),
                         project_id: Some(ProjectId::new(PROJECT).expect("project")),
+                        operator_webui_config: false,
                     })
                     .body(Body::from(redeem_body))
                     .expect("redeem request builds"),
@@ -1650,6 +1672,7 @@ mod tests {
                         user_id: UserId::new(USER).expect("user"),
                         agent_id: Some(AgentId::new(AGENT).expect("agent")),
                         project_id: Some(ProjectId::new(PROJECT).expect("project")),
+                        operator_webui_config: true,
                     })
                     .body(Body::from(format!(
                         r#"{{"channel_id":"C0HOST","subject_user_id":"{SHARED_SUBJECT}"}}"#
@@ -1799,6 +1822,155 @@ mod tests {
                     "subject_display_name": save_body["channels"][1]["subject_display_name"].clone()
                 }
             ])
+        );
+
+        runtime.shutdown().await.expect("runtime shuts down");
+    }
+
+    #[tokio::test]
+    async fn slack_connectable_channels_advertise_admin_action_to_operator_token() {
+        let (runtime, _root) = runtime().await;
+        let mounts = build_slack_host_beta_mounts(&runtime, config_without_channel_routes())
+            .expect("mounts");
+        let bundle = build_webui_services_with_slack_host_beta_mounts(
+            &runtime,
+            None,
+            Some(&mounts),
+            SlackOperatorRouteVisibility::Visible,
+        )
+        .expect("webui bundle");
+        let app = webui_v2_app(
+            bundle,
+            WebuiServeConfig::new(
+                TenantId::new(TENANT).expect("tenant"),
+                Arc::new(OperatorTokenAuthenticator),
+                Vec::new(),
+            )
+            .with_default_agent_id(AgentId::new(AGENT).expect("agent"))
+            .with_default_project_id(ProjectId::new(PROJECT).expect("project"))
+            .with_slack_channel_routes(mounts.channel_routes),
+        )
+        .expect("webui app");
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/api/webchat/v2/channels/connectable")
+                    .header("authorization", "Bearer operator-token")
+                    .body(Body::empty())
+                    .expect("request builds"),
+            )
+            .await
+            .expect("route responds");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 64 * 1024)
+            .await
+            .expect("response body");
+        let body: serde_json::Value = serde_json::from_slice(&body).expect("response json");
+        let strategies: Vec<_> = body["channels"]
+            .as_array()
+            .expect("channels")
+            .iter()
+            .map(|channel| channel["strategy"].as_str().expect("strategy"))
+            .collect();
+        assert!(
+            strategies.contains(&"admin_managed_channels"),
+            "operator token should see Slack admin channel setup: {body}"
+        );
+        assert!(
+            strategies.contains(&"inbound_proof_code"),
+            "operator token should still see personal Slack pairing: {body}"
+        );
+
+        runtime.shutdown().await.expect("runtime shuts down");
+    }
+
+    #[tokio::test]
+    async fn slack_connectable_channels_hide_admin_action_from_sso_session_token() {
+        let (runtime, _root) = runtime().await;
+        let mounts = build_slack_host_beta_mounts(&runtime, config_without_channel_routes())
+            .expect("mounts");
+        let bundle = build_webui_services_with_slack_host_beta_mounts(
+            &runtime,
+            None,
+            Some(&mounts),
+            SlackOperatorRouteVisibility::Visible,
+        )
+        .expect("webui bundle");
+        let app = webui_v2_app(
+            bundle,
+            WebuiServeConfig::new(
+                TenantId::new(TENANT).expect("tenant"),
+                Arc::new(MixedSessionAndOperatorAuthenticator),
+                Vec::new(),
+            )
+            .with_default_agent_id(AgentId::new(AGENT).expect("agent"))
+            .with_default_project_id(ProjectId::new(PROJECT).expect("project"))
+            .with_slack_channel_routes(mounts.channel_routes),
+        )
+        .expect("webui app");
+
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/api/webchat/v2/channels/connectable")
+                    .header("authorization", "Bearer session-token")
+                    .body(Body::empty())
+                    .expect("request builds"),
+            )
+            .await
+            .expect("route responds");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 64 * 1024)
+            .await
+            .expect("response body");
+        let body: serde_json::Value = serde_json::from_slice(&body).expect("response json");
+        let session_strategies: Vec<_> = body["channels"]
+            .as_array()
+            .expect("channels")
+            .iter()
+            .map(|channel| channel["strategy"].as_str().expect("strategy"))
+            .collect();
+        assert!(
+            !session_strategies.contains(&"admin_managed_channels"),
+            "SSO session token should not see Slack admin setup: {body}"
+        );
+        assert!(
+            session_strategies.contains(&"inbound_proof_code"),
+            "SSO session token should still see personal Slack pairing: {body}"
+        );
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/api/webchat/v2/channels/connectable")
+                    .header("authorization", "Bearer operator-token")
+                    .body(Body::empty())
+                    .expect("request builds"),
+            )
+            .await
+            .expect("route responds");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 64 * 1024)
+            .await
+            .expect("response body");
+        let body: serde_json::Value = serde_json::from_slice(&body).expect("response json");
+        let operator_strategies: Vec<_> = body["channels"]
+            .as_array()
+            .expect("channels")
+            .iter()
+            .map(|channel| channel["strategy"].as_str().expect("strategy"))
+            .collect();
+        assert!(
+            operator_strategies.contains(&"admin_managed_channels"),
+            "operator token should see Slack admin setup: {body}"
         );
 
         runtime.shutdown().await.expect("runtime shuts down");
@@ -2597,6 +2769,7 @@ mod tests {
                         user_id: UserId::new(USER).expect("user"),
                         agent_id: Some(AgentId::new(AGENT).expect("agent")),
                         project_id: Some(ProjectId::new(PROJECT).expect("project")),
+                        operator_webui_config: false,
                     })
                     .body(Body::from(redeem_body))
                     .expect("redeem request builds"),
@@ -2842,6 +3015,7 @@ mod tests {
                         user_id: UserId::new(USER).expect("user"),
                         agent_id: Some(AgentId::new(AGENT).expect("agent")),
                         project_id: Some(ProjectId::new(PROJECT).expect("project")),
+                        operator_webui_config: false,
                     })
                     .body(Body::from(redeem_body))
                     .expect("redeem request builds"),

--- a/crates/ironclaw_reborn_composition/src/slack_personal_binding_pairing_serve.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_personal_binding_pairing_serve.rs
@@ -359,6 +359,7 @@ mod tests {
                 user_id: UserId::new("user:alice").unwrap(),
                 agent_id: None,
                 project_id: None,
+                operator_webui_config: false,
             })
             .body(Body::from(body))
             .unwrap()

--- a/crates/ironclaw_reborn_composition/src/webui_serve.rs
+++ b/crates/ironclaw_reborn_composition/src/webui_serve.rs
@@ -906,7 +906,8 @@ async fn authenticate_request(
         auth.user_id,
         state.default_agent_id.clone(),
         state.default_project_id.clone(),
-    );
+    )
+    .with_operator_webui_config(auth.capabilities.operator_webui_config);
     request.extensions_mut().insert(caller);
     request.extensions_mut().insert(auth.capabilities);
     #[cfg(feature = "openai-compat-beta")]

--- a/crates/ironclaw_webui_v2_static/src/assets.rs
+++ b/crates/ironclaw_webui_v2_static/src/assets.rs
@@ -278,7 +278,7 @@ mod tests {
         assert!(setup_panel.contains("<${SlackChannelPicker} action=${action} />"));
 
         let channels_tab = asset_text("js/pages/extensions/components/channels-tab.js");
-        assert!(channels_tab.contains("showLegacySlackConnectActions"));
+        assert!(channels_tab.contains("showBuiltinSlackConnectActions"));
         assert!(channels_tab.contains("admin_managed_channels"));
         assert!(channels_tab.contains("inbound_proof_code"));
         assert!(channels_tab.contains("SlackAdminManagedSection"));

--- a/crates/ironclaw_webui_v2_static/static/dist/app.js
+++ b/crates/ironclaw_webui_v2_static/static/dist/app.js
@@ -5013,7 +5013,7 @@ ${$e}`;if(X.current.gateKey!==He&&(X.current={gateKey:He,credentialRef:null,inFl
             name=${c("channels.slack")||"Slack"}
             description=${c("channels.slackDesc")||"Tenant app channel for DMs and app mentions"}
             enabled=${!1}
-            statusLabel="legacy"
+            statusLabel="setup"
             statusTone="muted"
             detail=${c("channels.slackDetail")||"Tenant Slack app install"}
           >

--- a/crates/ironclaw_webui_v2_static/static/js/pages/extensions/components/channels-tab.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/extensions/components/channels-tab.js
@@ -75,7 +75,7 @@ export function ChannelsTab({
   const enabledChannels = status.enabled_channels || [];
   const slackConnectActions = findSlackConnectActions(connectableChannels);
   const hasInstalledSlackPackage = installedChannels.some(isSlackPackage);
-  const showLegacySlackConnectActions =
+  const showBuiltinSlackConnectActions =
     slackConnectActions.length > 0 && !hasInstalledSlackPackage;
 
   return html`
@@ -113,13 +113,13 @@ export function ChannelsTab({
           enabled=${enabledChannels.includes("repl")}
           detail="ironclaw run --repl"
         />
-        ${showLegacySlackConnectActions &&
+        ${showBuiltinSlackConnectActions &&
         html`
           <${BuiltinRow}
             name=${t("channels.slack") || "Slack"}
             description=${t("channels.slackDesc") || "Tenant app channel for DMs and app mentions"}
             enabled=${false}
-            statusLabel="legacy"
+            statusLabel="setup"
             statusTone="muted"
             detail=${t("channels.slackDetail") || "Tenant Slack app install"}
           >

--- a/crates/ironclaw_webui_v2_static/static/js/pages/extensions/components/channels-tab.test.mjs
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/extensions/components/channels-tab.test.mjs
@@ -194,7 +194,7 @@ test("SlackConnectActionSections renders every supported Slack action", () => {
   assert.equal(unhandledView.rendered, null);
 });
 
-test("ChannelsTab keeps Slack controls in the legacy builtin location when Slack is not installed", () => {
+test("ChannelsTab keeps Slack controls in the builtin location when Slack is not installed", () => {
   const view = channelsTabForTest({
     status: { enabled_channels: [], sse_connections: 0, ws_connections: 0 },
     channels: [],
@@ -214,7 +214,7 @@ test("ChannelsTab keeps Slack controls in the legacy builtin location when Slack
     view.rendered,
     view.SlackConnectActionSections,
   );
-  assert.notEqual(builtinSlackSection, undefined, "expected legacy Slack section");
+  assert.notEqual(builtinSlackSection, undefined, "expected builtin Slack section");
   assert.equal(renderedContainsComponent(builtinSlackSection, view.SlackConnectActionSections), true);
   assert.equal(renderedContainsSlackActionPair(builtinSlackSection), true);
 


### PR DESCRIPTION
## Summary
- expose Slack admin setup metadata based on the operator WebUI authenticator instead of hiding it whenever SSO is configured
- carry the matched token's operator_webui_config capability into WebUI product callers
- gate Slack admin route listings and mutations on the per-request operator capability

## Railway notes
- hosted Reborn should use railway.reborn.toml / Dockerfile.reborn
- Dockerfile.reborn builds ironclaw_reborn_cli with webui-v2-beta, slack-v2-host-beta, and postgres
- config.hosted-single-tenant.toml intentionally seeds [slack].enabled=false; IRONCLAW_REBORN_SLACK_ENABLED=true overrides it at runtime

## Tests
- cargo test -p ironclaw_reborn_composition --features webui-v2-beta,slack-v2-host-beta slack_connectable_channels_advertise_admin_action_to_operator_token -j1
- cargo test -p ironclaw_reborn_composition --features webui-v2-beta,slack-v2-host-beta operator_capability -j1
- cargo test -p ironclaw_reborn_cli --features webui-v2-beta,slack-v2-host-beta,postgres slack_operator_route_visibility_follows_authenticator_route_mount_capability -j1
- cargo test -p ironclaw_webui_v2 operator_capability -j1
- git diff --check