### PR TITLE
[codex] fix recurring trigger poller hang

### DIFF
--- a/crates/ironclaw_reborn_composition/src/slack_delivery.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_delivery.rs
@@ -1808,8 +1808,11 @@ fn is_accepted_auth_denial(envelope: &ProductInboundEnvelope, ack: &ProductInbou
 #[async_trait]
 pub trait PostSubmitDeliveryHook: Send + Sync {
     /// Called with the original trigger fire, the submitted run id, and the
-    /// turn scope the run was submitted under. Must not block the poller —
-    /// implementations must spawn their own tasks.
+    /// turn scope the run was submitted under. The trigger poller owns the
+    /// non-blocking handoff by invoking this hook from a detached task, so hook
+    /// latency cannot delay fire settlement. Implementations may still spawn
+    /// their own longer-lived delivery tasks when they need bounded admission or
+    /// shutdown tracking.
     async fn on_trigger_submitted(&self, fire: TriggerFire, run_id: TurnRunId, scope: TurnScope);
 }
 

--- a/crates/ironclaw_reborn_composition/src/trigger_poller.rs
+++ b/crates/ironclaw_reborn_composition/src/trigger_poller.rs
@@ -148,7 +148,7 @@ impl TrustedTriggerFireSubmitter for PostSubmitHookWrappedSubmitter {
                     hook.on_trigger_submitted(fire, run_id, scope).await;
                 });
             } else {
-                tracing::warn!(
+                tracing::debug!(
                     target = "ironclaw::reborn::trigger_poller",
                     %run_id,
                     "triggered run accepted but post-submit hook slot not yet set (startup window); delivery skipped for this fire"

--- a/crates/ironclaw_reborn_composition/src/trigger_poller.rs
+++ b/crates/ironclaw_reborn_composition/src/trigger_poller.rs
@@ -140,8 +140,11 @@ impl TrustedTriggerFireSubmitter for PostSubmitHookWrappedSubmitter {
         {
             // Cheap atomic read: if the slot is not yet filled the hook simply
             // doesn't fire — the poller is not restarted.
-            if let Some(hook) = self.hook_slot.get() {
-                hook.on_trigger_submitted(fire, run_id, scope.clone()).await;
+            if let Some(hook) = self.hook_slot.get().cloned() {
+                let scope = scope.clone();
+                tokio::spawn(async move {
+                    hook.on_trigger_submitted(fire, run_id, scope).await;
+                });
             } else {
                 tracing::warn!(
                     target = "ironclaw::reborn::trigger_poller",
@@ -778,6 +781,7 @@ mod tests {
 
     #[cfg(feature = "slack-v2-host-beta")]
     mod hook_wrapper {
+        use std::sync::atomic::{AtomicBool, Ordering};
         use std::sync::{Arc, Mutex, OnceLock};
         use std::time::Duration;
 
@@ -794,6 +798,7 @@ mod tests {
             TrustedTriggerSubmitRequest,
         };
         use ironclaw_turns::{TurnRunId, TurnScope};
+        use tokio::sync::Notify;
 
         use super::super::PostSubmitHookWrappedSubmitter;
         use crate::slack_delivery::PostSubmitDeliveryHook;
@@ -864,11 +869,25 @@ mod tests {
         #[derive(Default)]
         struct RecordingHook {
             calls: Mutex<Vec<(TriggerFire, TurnRunId, TurnScope)>>,
+            notify: Notify,
         }
 
         impl RecordingHook {
             fn calls(&self) -> Vec<(TriggerFire, TurnRunId, TurnScope)> {
                 self.calls.lock().unwrap_or_else(|p| p.into_inner()).clone()
+            }
+
+            async fn wait_for_calls(
+                &self,
+                expected: usize,
+            ) -> Vec<(TriggerFire, TurnRunId, TurnScope)> {
+                loop {
+                    let calls = self.calls();
+                    if calls.len() >= expected {
+                        return calls;
+                    }
+                    self.notify.notified().await;
+                }
             }
         }
 
@@ -884,6 +903,27 @@ mod tests {
                     .lock()
                     .unwrap_or_else(|p| p.into_inner())
                     .push((fire, run_id, scope));
+                self.notify.notify_one();
+            }
+        }
+
+        struct BlockingHook {
+            entered: Arc<Notify>,
+            release: Arc<Notify>,
+            completed: Arc<AtomicBool>,
+        }
+
+        #[async_trait]
+        impl PostSubmitDeliveryHook for BlockingHook {
+            async fn on_trigger_submitted(
+                &self,
+                _fire: TriggerFire,
+                _run_id: TurnRunId,
+                _scope: TurnScope,
+            ) {
+                self.entered.notify_one();
+                self.release.notified().await;
+                self.completed.store(true, Ordering::SeqCst);
             }
         }
 
@@ -1024,7 +1064,9 @@ mod tests {
             assert_eq!(report.due_records, 1, "one due trigger must be processed");
 
             // Hook was invoked exactly once.
-            let calls = recording.calls();
+            let calls = tokio::time::timeout(Duration::from_secs(1), recording.wait_for_calls(1))
+                .await
+                .expect("hook should be invoked asynchronously");
             assert_eq!(calls.len(), 1, "hook must fire exactly once");
 
             let (recorded_fire, called_run_id, called_scope) = &calls[0];
@@ -1042,6 +1084,75 @@ mod tests {
                 Some(&recorded_fire.creator_user_id),
                 "post-submit hook must receive a TurnScope owned by the trigger creator"
             );
+        }
+
+        /// A slow hook must not delay the poller from persisting the accepted
+        /// run id; otherwise the trigger remains claim-only active and blocks
+        /// later slots until the delivery task finishes.
+        #[tokio::test]
+        async fn filled_slot_slow_hook_does_not_block_trigger_settlement() {
+            let repo = Arc::new(InMemoryTriggerRepository::default());
+            let fire_slot = Utc::now() - chrono::Duration::seconds(1);
+            let trigger_id = seed_due_trigger(&repo, fire_slot).await;
+
+            let run_id = TurnRunId::new();
+            let inner = Arc::new(FixedAcceptedSubmitter { run_id });
+            let hook_slot: Arc<OnceLock<Arc<dyn PostSubmitDeliveryHook>>> =
+                Arc::new(OnceLock::new());
+
+            let entered = Arc::new(Notify::new());
+            let release = Arc::new(Notify::new());
+            let completed = Arc::new(AtomicBool::new(false));
+            hook_slot
+                .set(Arc::new(BlockingHook {
+                    entered: Arc::clone(&entered),
+                    release: Arc::clone(&release),
+                    completed: Arc::clone(&completed),
+                }) as Arc<dyn PostSubmitDeliveryHook>)
+                .unwrap_or_else(|_| panic!("slot set should succeed on first call"));
+
+            let wrapper = Arc::new(PostSubmitHookWrappedSubmitter {
+                inner: inner as Arc<dyn TrustedTriggerFireSubmitter>,
+                hook_slot: Arc::clone(&hook_slot),
+            });
+
+            let worker = build_worker_with_repo(
+                Arc::clone(&repo),
+                wrapper as Arc<dyn TrustedTriggerFireSubmitter>,
+            );
+            let report = tokio::time::timeout(Duration::from_secs(1), worker.tick_once(Utc::now()))
+                .await
+                .expect("slow post-submit hook must not block tick_once")
+                .expect("tick_once succeeds");
+            assert_eq!(report.due_records, 1, "one due trigger must be processed");
+
+            tokio::time::timeout(Duration::from_secs(1), entered.notified())
+                .await
+                .expect("hook task should have started");
+            assert!(
+                !completed.load(Ordering::SeqCst),
+                "hook must still be blocked until the test releases it"
+            );
+
+            let persisted = repo
+                .get_trigger(wrapper_tenant(), trigger_id)
+                .await
+                .expect("load trigger")
+                .expect("trigger present");
+            assert_eq!(
+                persisted.active_run_ref,
+                Some(run_id),
+                "accepted run id must be persisted before delivery hook completes"
+            );
+
+            release.notify_one();
+            tokio::time::timeout(Duration::from_secs(1), async {
+                while !completed.load(Ordering::SeqCst) {
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                }
+            })
+            .await
+            .expect("hook task should complete after release");
         }
     }
 }

--- a/crates/ironclaw_reborn_composition/src/trigger_poller.rs
+++ b/crates/ironclaw_reborn_composition/src/trigger_poller.rs
@@ -112,10 +112,12 @@ pub(crate) fn spawn_trigger_poller(
     Ok(Some(TriggerPollerRuntimeHandle { cancel, handle }))
 }
 
-/// Wraps a `TrustedTriggerFireSubmitter` to invoke a post-submit hook after
-/// each successful fire submission. The hook is stored in a `OnceLock` slot so
-/// it can be wired after the poller is spawned (late-binding). If the slot is
-/// empty at submit time the hook is simply skipped.
+/// Wraps a `TrustedTriggerFireSubmitter` to start a post-submit hook after each
+/// successful fire submission. The hook is detached from the poller tick so
+/// delivery latency cannot delay fire settlement. The hook is stored in a
+/// `OnceLock` slot so it can be wired after the poller is spawned
+/// (late-binding). If the slot is empty at submit time the hook is simply
+/// skipped.
 #[cfg(feature = "slack-v2-host-beta")]
 pub(crate) struct PostSubmitHookWrappedSubmitter {
     pub(crate) inner: Arc<dyn TrustedTriggerFireSubmitter>,

--- a/crates/ironclaw_reborn_composition/tests/trigger_poller_e2e.rs
+++ b/crates/ironclaw_reborn_composition/tests/trigger_poller_e2e.rs
@@ -57,6 +57,14 @@ impl RecordingGateway {
             .flat_map(|req| req.messages.iter().map(|m| m.content.clone()))
             .collect()
     }
+
+    async fn request_count_containing(&self, needle: &str) -> usize {
+        let snapshot = self.requests.lock().await;
+        snapshot
+            .iter()
+            .filter(|req| req.messages.iter().any(|m| m.content.contains(needle)))
+            .count()
+    }
 }
 
 #[async_trait]
@@ -108,6 +116,30 @@ where
         tokio::time::sleep(Duration::from_millis(50)).await;
     }
     last.expect("at least one read should have succeeded in wait_for_settled")
+}
+
+async fn recent_due_slot_after_with_future_next(
+    schedule: &TriggerSchedule,
+    after: Option<chrono::DateTime<Utc>>,
+) -> chrono::DateTime<Utc> {
+    let stop = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < stop {
+        let now = Utc::now();
+        let slot = now - chrono::Duration::milliseconds(500);
+        if after.map(|previous| slot <= previous).unwrap_or(false) {
+            tokio::time::sleep(Duration::from_millis(25)).await;
+            continue;
+        }
+        let next = schedule
+            .next_slot_after(slot)
+            .expect("valid recurring schedule")
+            .expect("recurring schedule should have a next slot");
+        if next > now {
+            return slot;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    panic!("could not choose a due slot whose next recurring slot is still in the future");
 }
 
 /// Shared runtime builder. Every test passes the `TriggerPollerSettings` it
@@ -505,6 +537,130 @@ async fn builtin_trigger_create_pairs_creator_and_poller_submits_turn() {
     assert!(
         settled.last_run_at.is_some(),
         "builtin-created trigger should record last_run_at after poller fire"
+    );
+}
+
+#[tokio::test]
+async fn builtin_created_recurring_trigger_fires_again_after_first_run_settles() {
+    let root = tempfile::tempdir().expect("tempdir");
+    let recording_gateway = Arc::new(RecordingGateway {
+        requests: Arc::new(TokioMutex::new(Vec::new())),
+    });
+
+    let runtime = build_runtime_with(
+        &root,
+        Arc::clone(&recording_gateway),
+        TriggerPollerSettings::enabled_with_tenant_scoped_authorizer_for_test().with_worker_config(
+            TriggerPollerWorkerConfig {
+                poll_interval: Duration::from_millis(20),
+                ..Default::default()
+            },
+        ),
+    )
+    .await;
+
+    let created = invoke_trigger_create(
+        &runtime,
+        json!({
+            "name": "trigger-e2e-created-by-tool-fires-twice",
+            "prompt": TRIGGER_PROMPT,
+            "schedule": { "kind": "cron", "expression": "* * * * *", "timezone": "UTC" }
+        }),
+    )
+    .await;
+
+    let repo = runtime
+        .trigger_repository()
+        .expect("local-dev runtime exposes trigger repository");
+    let tenant_id = TenantId::new(TENANT).expect("tenant id");
+    let trigger_id = TriggerId::parse(
+        created["trigger"]["trigger_id"]
+            .as_str()
+            .expect("created trigger id"),
+    )
+    .expect("valid trigger id");
+
+    let mut record = repo
+        .get_trigger(tenant_id.clone(), trigger_id)
+        .await
+        .expect("get created trigger")
+        .expect("created trigger persisted");
+    let first_due_slot = recent_due_slot_after_with_future_next(&record.schedule, None).await;
+    record.next_run_at = first_due_slot;
+    repo.upsert_trigger(record.clone())
+        .await
+        .expect("make first recurring slot due");
+
+    let first = wait_for_settled(
+        &repo,
+        &tenant_id,
+        trigger_id,
+        Duration::from_secs(15),
+        |r| {
+            r.last_fired_slot.is_some()
+                && r.last_run_at.is_some()
+                && r.last_status == Some(TriggerRunStatus::Ok)
+                && r.active_fire_slot.is_none()
+                && r.active_run_ref.is_none()
+                && r.next_run_at > first_due_slot
+        },
+    )
+    .await;
+    assert!(
+        recording_gateway
+            .request_count_containing(TRIGGER_PROMPT)
+            .await
+            >= 1,
+        "first recurring trigger fire should submit a model request"
+    );
+
+    let first_fired_slot = first.last_fired_slot.expect("first fire slot");
+    let mut second_record = first.clone();
+    let second_due_slot =
+        recent_due_slot_after_with_future_next(&second_record.schedule, Some(first_fired_slot))
+            .await;
+    second_record.next_run_at = second_due_slot;
+    second_record.active_fire_slot = None;
+    second_record.active_run_ref = None;
+    repo.upsert_trigger(second_record)
+        .await
+        .expect("make second recurring slot due");
+
+    let second = wait_for_settled(
+        &repo,
+        &tenant_id,
+        trigger_id,
+        Duration::from_secs(15),
+        |r| {
+            r.last_fired_slot
+                .map(|slot| slot > first_fired_slot)
+                .unwrap_or(false)
+                && r.last_status == Some(TriggerRunStatus::Ok)
+                && r.active_fire_slot.is_none()
+                && r.active_run_ref.is_none()
+                && r.next_run_at > second_due_slot
+        },
+    )
+    .await;
+
+    runtime.shutdown().await.expect("runtime shutdown");
+
+    let request_count = recording_gateway
+        .request_count_containing(TRIGGER_PROMPT)
+        .await;
+    assert!(
+        request_count >= 2,
+        "recurring trigger should submit once per due slot — requests containing prompt: {request_count}"
+    );
+    assert_eq!(
+        second.state,
+        TriggerState::Scheduled,
+        "recurring trigger must remain Scheduled after the second fire — record: {second:?}"
+    );
+    assert_eq!(
+        second.last_status,
+        Some(TriggerRunStatus::Ok),
+        "second fire should settle successfully — record: {second:?}"
     );
 }
 

--- a/crates/ironclaw_reborn_composition/tests/trigger_poller_e2e.rs
+++ b/crates/ironclaw_reborn_composition/tests/trigger_poller_e2e.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
-use chrono::Utc;
+use chrono::{TimeZone, Utc};
 use ironclaw_conversations::{AdapterInstallationId, AdapterKind, ExternalActorRef};
 use ironclaw_host_api::{
     AgentId, CapabilityGrant, CapabilityGrantId, CapabilityId, CapabilitySet, EffectKind,
@@ -118,28 +118,12 @@ where
     last.expect("at least one read should have succeeded in wait_for_settled")
 }
 
-async fn recent_due_slot_after_with_future_next(
-    schedule: &TriggerSchedule,
-    after: Option<chrono::DateTime<Utc>>,
-) -> chrono::DateTime<Utc> {
-    let stop = Instant::now() + Duration::from_secs(5);
-    while Instant::now() < stop {
-        let now = Utc::now();
-        let slot = now - chrono::Duration::milliseconds(500);
-        if after.map(|previous| slot <= previous).unwrap_or(false) {
-            tokio::time::sleep(Duration::from_millis(25)).await;
-            continue;
-        }
-        let next = schedule
-            .next_slot_after(slot)
-            .expect("valid recurring schedule")
-            .expect("recurring schedule should have a next slot");
-        if next > now {
-            return slot;
-        }
-        tokio::time::sleep(Duration::from_millis(25)).await;
-    }
-    panic!("could not choose a due slot whose next recurring slot is still in the future");
+fn current_minute_slot() -> chrono::DateTime<Utc> {
+    let now_seconds = Utc::now().timestamp();
+    let minute_seconds = now_seconds - now_seconds.rem_euclid(60);
+    Utc.timestamp_opt(minute_seconds, 0)
+        .single()
+        .expect("valid minute timestamp")
 }
 
 /// Shared runtime builder. Every test passes the `TriggerPollerSettings` it
@@ -585,46 +569,16 @@ async fn builtin_created_recurring_trigger_fires_again_after_first_run_settles()
         .await
         .expect("get created trigger")
         .expect("created trigger persisted");
-    let first_due_slot = recent_due_slot_after_with_future_next(&record.schedule, None).await;
+    let first_due_slot = current_minute_slot() - chrono::Duration::minutes(1);
+    let second_due_slot = record
+        .schedule
+        .next_slot_after(first_due_slot)
+        .expect("valid recurring schedule")
+        .expect("recurring schedule should have a second slot");
     record.next_run_at = first_due_slot;
     repo.upsert_trigger(record.clone())
         .await
         .expect("make first recurring slot due");
-
-    let first = wait_for_settled(
-        &repo,
-        &tenant_id,
-        trigger_id,
-        Duration::from_secs(15),
-        |r| {
-            r.last_fired_slot.is_some()
-                && r.last_run_at.is_some()
-                && r.last_status == Some(TriggerRunStatus::Ok)
-                && r.active_fire_slot.is_none()
-                && r.active_run_ref.is_none()
-                && r.next_run_at > first_due_slot
-        },
-    )
-    .await;
-    assert!(
-        recording_gateway
-            .request_count_containing(TRIGGER_PROMPT)
-            .await
-            >= 1,
-        "first recurring trigger fire should submit a model request"
-    );
-
-    let first_fired_slot = first.last_fired_slot.expect("first fire slot");
-    let mut second_record = first.clone();
-    let second_due_slot =
-        recent_due_slot_after_with_future_next(&second_record.schedule, Some(first_fired_slot))
-            .await;
-    second_record.next_run_at = second_due_slot;
-    second_record.active_fire_slot = None;
-    second_record.active_run_ref = None;
-    repo.upsert_trigger(second_record)
-        .await
-        .expect("make second recurring slot due");
 
     let second = wait_for_settled(
         &repo,
@@ -633,8 +587,9 @@ async fn builtin_created_recurring_trigger_fires_again_after_first_run_settles()
         Duration::from_secs(15),
         |r| {
             r.last_fired_slot
-                .map(|slot| slot > first_fired_slot)
+                .map(|slot| slot >= second_due_slot)
                 .unwrap_or(false)
+                && r.last_run_at.is_some()
                 && r.last_status == Some(TriggerRunStatus::Ok)
                 && r.active_fire_slot.is_none()
                 && r.active_run_ref.is_none()


### PR DESCRIPTION
## Summary

- make trigger post-submit delivery hooks run asynchronously from the poller wrapper
- add a regression for slow Slack delivery hooks so accepted trigger runs still persist immediately
- add a full-path regression proving a builtin-created recurring trigger can settle one fire and submit a later due slot
- address CodeRabbit review feedback by documenting the poller-owned hook handoff and downgrading the startup-window diagnostic to debug

## Change type

Bug fix with regression coverage.

## Linked issue

No linked GitHub issue. This was reproduced from hosted single-tenant/Postgres routine logs where recurring routines stopped after one fire.

## Root cause

In hosted single-tenant/Postgres deployments, a trigger fire could be claimed and then block inside post-submit delivery before `active_run_ref` was persisted. That left a durable claim-only active row (`active_fire_slot` set, `active_run_ref` null), so later poller ticks saw active records but no due records and routines stopped recurring.

## Security impact

No intentional auth, secret-handling, network, listener, CORS, approval, or sandbox behavior change.

## Trust-boundary checklist

- Trusted trigger submission path remains unchanged.
- Post-submit delivery is still invoked only after an accepted trusted trigger fire.
- Slack delivery side effects stay behind the existing `slack-v2-host-beta` hook and delivery driver.
- Startup-window diagnostics are debug-level internal telemetry, not user-facing warnings.

## Database impact

No schema or migration changes. The fix changes when the poller awaits post-submit delivery, allowing existing trigger settlement writes to complete before delivery work continues asynchronously.

## Blast radius

Scoped to the composition trigger poller and Slack host-beta post-submit delivery hook behavior. Expected user-visible impact is that recurring routines/triggers can advance after each accepted fire instead of getting stuck behind slow delivery work.

## Rollback plan

Revert this PR to restore the previous inline post-submit hook behavior. Operationally, stuck trigger records may still need cleanup if they already have `active_fire_slot` set without `active_run_ref`.

## Review follow-through

- CodeRabbit hook-contract documentation feedback addressed.
- CodeRabbit startup-window logging feedback addressed.
- Separate log findings around post-ACK webhook drops, projection stream failures, and unknown-thread display preview failures are intentionally not fixed in this PR.

## Validation

- `cargo test -p ironclaw_reborn_composition --test trigger_poller_e2e -- --nocapture`
- `cargo test -p ironclaw_reborn_composition --features slack-v2-host-beta hook_wrapper --lib -- --nocapture`
- `cargo test --test reborn_qa_routines reborn_qa_routine_created_by_tool_fires_and_runs_routine_prompt -- --nocapture`
- `cargo test -p ironclaw_reborn_composition --test trigger_poller_e2e builtin_created_recurring_trigger_fires_again_after_first_run_settles -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `bash scripts/pre-commit-safety.sh`

Note: `ironclaw_reborn_composition` still emits the pre-existing `secret_store` dead-code warning during some test builds.