### PR TITLE
fix(llm): enable the circuit breaker by default to fast-fail a degraded provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,16 @@ DATABASE_POOL_SIZE=30  # multi-tenant default; reduce to 5-10 for single-user or
 # LLM_BACKEND=nearai           # default
 # Possible values: nearai, ollama, openai_compatible, openai, anthropic, github_copilot, tinfoil, openai_codex, gemini_oauth
 # LLM_REQUEST_TIMEOUT_SECS=120  # Increase for local LLMs (Ollama, vLLM, LM Studio)
+# Circuit breaker (enabled by default, threshold 5): after N consecutive transient
+# provider failures the breaker opens and fast-fails for the recovery window, so a
+# dead upstream can't wedge every run on retries+timeouts. It is process-global —
+# when open, all users fast-fail until a probe succeeds. Raise the threshold to be
+# more tolerant of timeout blips; set it to 0 to DISABLE the breaker entirely
+# (kill switch — takes effect on restart, no redeploy needed).
+# LLM_CIRCUIT_BREAKER_THRESHOLD=5
+# Recovery window before a probe is allowed; kept short so a false trip is a brief
+# blip rather than a long instance-wide outage.
+# LLM_CIRCUIT_BREAKER_RECOVERY_SECS=10
 
 # === Anthropic Direct ===
 # Two auth modes:

--- a/crates/ironclaw_llm/src/resolution.rs
+++ b/crates/ironclaw_llm/src/resolution.rs
@@ -18,6 +18,21 @@ use crate::error::{LlmConfigError, LlmError};
 use crate::registry::{ProviderDefinition, ProviderProtocol, ProviderRegistry};
 use crate::session::SessionConfig;
 
+/// Default circuit-breaker failure threshold applied when no env override is set.
+///
+/// Enables the breaker by default so an unreachable/degraded provider trips the
+/// circuit and fast-fails instead of wedging every concurrent run on
+/// retries+timeouts. Override with `LLM_CIRCUIT_BREAKER_THRESHOLD`; set it to `0`
+/// to disable the breaker entirely.
+const DEFAULT_CIRCUIT_BREAKER_THRESHOLD: u32 = 5;
+
+/// Default circuit-breaker recovery window (seconds) before a probe is allowed.
+///
+/// Kept short so a false trip on an otherwise-healthy provider self-heals
+/// quickly instead of locking out every user for a long window. Override with
+/// `LLM_CIRCUIT_BREAKER_RECOVERY_SECS`.
+const DEFAULT_CIRCUIT_BREAKER_RECOVERY_SECS: u64 = 10;
+
 /// Already-resolved provider input from env or a catalog selection.
 #[derive(Debug, Clone)]
 pub enum ResolvedProviderConfig {
@@ -542,8 +557,14 @@ impl Default for ChainSettings {
             cheap_model: None,
             smart_routing_cascade: true,
             max_retries: 3,
-            circuit_breaker_threshold: None,
-            circuit_breaker_recovery_secs: 30,
+            // Trip the breaker after this many consecutive transient provider
+            // failures so a dead upstream fast-fails every run instead of each
+            // one independently exhausting retries/timeouts.
+            circuit_breaker_threshold: Some(DEFAULT_CIRCUIT_BREAKER_THRESHOLD),
+            // Short recovery window so a false trip (e.g. a brief burst of
+            // timeouts on an otherwise-healthy provider) is a ~10s blip rather
+            // than a long instance-wide outage; the breaker probes again sooner.
+            circuit_breaker_recovery_secs: DEFAULT_CIRCUIT_BREAKER_RECOVERY_SECS,
             response_cache_enabled: false,
             response_cache_ttl_secs: 3600,
             response_cache_max_entries: 1000,
@@ -569,11 +590,16 @@ impl ChainSettings {
                 "llm_config",
             )?
             .unwrap_or(defaults.max_retries),
+            // Kill switch: `*_THRESHOLD=0` disables the breaker entirely (maps to
+            // None → no CircuitBreakerProvider in the chain), so a misbehaving
+            // breaker can be turned off via env with no redeploy.
             circuit_breaker_threshold: parse_option_env_with_fallback::<u32>(
                 "LLM_CIRCUIT_BREAKER_THRESHOLD",
                 "CIRCUIT_BREAKER_THRESHOLD",
                 "llm_config",
-            )?,
+            )?
+            .or(defaults.circuit_breaker_threshold)
+            .filter(|&threshold| threshold != 0),
             circuit_breaker_recovery_secs: parse_option_env_with_fallback::<u64>(
                 "LLM_CIRCUIT_BREAKER_RECOVERY_SECS",
                 "CIRCUIT_BREAKER_RECOVERY_SECS",
@@ -845,6 +871,43 @@ mod tests {
         assert!(config.response_cache_enabled);
         assert_eq!(config.response_cache_ttl_secs, 23);
         assert_eq!(config.response_cache_max_entries, 29);
+    }
+
+    #[test]
+    fn circuit_breaker_enabled_by_default_without_env_override() {
+        // Regression: a dead/degraded provider must fast-fail rather than wedge
+        // every concurrent run on retries+timeouts. With no env override the
+        // breaker is on at the default threshold so the chain wraps a
+        // CircuitBreakerProvider.
+        let _env_lock = ironclaw_common::env_helpers::lock_env();
+        let _env = EnvGuard::clear(CHAIN_ENV_VARS);
+
+        let config = build_llm_config_from_resolved_provider(registry_resolved_provider())
+            .expect("default chain resolution should succeed");
+
+        assert_eq!(
+            config.circuit_breaker_threshold,
+            Some(DEFAULT_CIRCUIT_BREAKER_THRESHOLD)
+        );
+        assert_eq!(
+            config.circuit_breaker_recovery_secs,
+            DEFAULT_CIRCUIT_BREAKER_RECOVERY_SECS
+        );
+    }
+
+    #[test]
+    fn circuit_breaker_threshold_zero_disables_breaker() {
+        // Kill switch: operators must be able to disable the instance-wide
+        // breaker via env (no redeploy) if it ever fast-fails healthy traffic.
+        // `THRESHOLD=0` must resolve to None so no CircuitBreakerProvider is built.
+        let _env_lock = ironclaw_common::env_helpers::lock_env();
+        let env = EnvGuard::clear(CHAIN_ENV_VARS);
+        env.set("LLM_CIRCUIT_BREAKER_THRESHOLD", "0");
+
+        let config = build_llm_config_from_resolved_provider(registry_resolved_provider())
+            .expect("threshold=0 should resolve");
+
+        assert_eq!(config.circuit_breaker_threshold, None);
     }
 
     #[test]

--- a/src/config/llm.rs
+++ b/src/config/llm.rs
@@ -16,6 +16,15 @@ use ironclaw_llm::session::SessionConfig;
 
 static LOG_LLM_BACKEND_RESOLUTION: Once = Once::new();
 
+/// Default circuit-breaker failure threshold when no env override is set.
+/// Enables the breaker by default for fast-fail on a degraded provider.
+/// Set the env override to `0` to disable the breaker entirely.
+const DEFAULT_CIRCUIT_BREAKER_THRESHOLD: u32 = 5;
+
+/// Default circuit-breaker recovery window (seconds). Kept short so a false trip
+/// self-heals quickly instead of locking out every user for a long window.
+const DEFAULT_CIRCUIT_BREAKER_RECOVERY_SECS: u64 = 10;
+
 fn selected_model_override(settings: &Settings) -> Option<String> {
     ironclaw_llm::normalized_model_override(settings.selected_model.as_deref()).map(str::to_string)
 }
@@ -357,7 +366,10 @@ pub fn resolve(settings: &Settings) -> Result<LlmConfig, ConfigError> {
                 key: "CIRCUIT_BREAKER_THRESHOLD".to_string(),
                 message: format!("must be a positive integer: {e}"),
             })?,
-        circuit_breaker_recovery_secs: parse_optional_env("CIRCUIT_BREAKER_RECOVERY_SECS", 30)?,
+        circuit_breaker_recovery_secs: parse_optional_env(
+            "CIRCUIT_BREAKER_RECOVERY_SECS",
+            DEFAULT_CIRCUIT_BREAKER_RECOVERY_SECS,
+        )?,
         response_cache_enabled: parse_optional_env("RESPONSE_CACHE_ENABLED", false)?,
         response_cache_ttl_secs: parse_optional_env("RESPONSE_CACHE_TTL_SECS", 3600)?,
         response_cache_max_entries: parse_optional_env("RESPONSE_CACHE_MAX_ENTRIES", 1000)?,
@@ -471,7 +483,13 @@ pub fn resolve(settings: &Settings) -> Result<LlmConfig, ConfigError> {
             key: "LLM_CIRCUIT_BREAKER_THRESHOLD".to_string(),
             message: format!("must be a positive integer: {e}"),
         })?
-        .or(nearai.circuit_breaker_threshold);
+        .or(nearai.circuit_breaker_threshold)
+        // Enable the circuit breaker by default so an unreachable/degraded
+        // provider fast-fails instead of wedging every run on retries+timeouts.
+        // Override with LLM_CIRCUIT_BREAKER_THRESHOLD / CIRCUIT_BREAKER_THRESHOLD;
+        // set it to 0 to disable the breaker entirely (kill switch, no redeploy).
+        .or(Some(DEFAULT_CIRCUIT_BREAKER_THRESHOLD))
+        .filter(|&threshold| threshold != 0);
 
     let circuit_breaker_recovery_secs = optional_env("LLM_CIRCUIT_BREAKER_RECOVERY_SECS")?
         .map(|s| s.parse::<u64>())


### PR DESCRIPTION
## Problem

A NEAR AI outage made the hosted reborn instance lag for **every** user. Each request to a dead/hung provider retried and recovered for tens of minutes, wedging every bounded run slot so the whole instance felt frozen, and the existing "model unavailable" failure message never surfaced because runs never reached a terminal state in bounded time.

The per-request/connect-timeout hardening landed separately in **#5204** (shared `config::hardened_client_builder` with `connect_timeout` + `tcp_keepalive` across all LLM clients). **This PR adds the remaining piece:** turning a degraded provider into a *fast, bounded* failure instead of a slow instance-wide wedge.

## Change (circuit-breaker only)

- **Enable the existing (default-disabled) circuit breaker by default**, threshold 5, in both config paths (`resolution.rs` for reborn, `config/llm.rs` for the monolith). Once ~5 consecutive transient failures accumulate **post-retry/failover**, the breaker opens and fast-fails — a dead upstream can't wedge every run. Runs reach a terminal state in seconds → the existing failure message surfaces promptly.

## Blast radius (please read before approving)

The circuit breaker is **process-global**: one instance shared by all users/threads via the single model gateway. When it opens, **all users fast-fail** until a probe succeeds. Correct for the incident (a *shared* upstream outage), but it means a genuine outage shows every user an error at once. To bound the downside of a false trip:

- **Kill switch:** `LLM_CIRCUIT_BREAKER_THRESHOLD=0` disables the breaker entirely (resolves to `None` → no breaker in the chain). Takes effect on restart — no redeploy.
- **Short recovery:** default cut **30s → 10s**, so a false trip is a ~10s blip, not a long outage; it probes sooner.
- **Tunable threshold** via `LLM_CIRCUIT_BREAKER_THRESHOLD`.

It only opens on **5 consecutive failures with no interleaved success, after retries and failover** — i.e. only when the provider is failing nearly everything, not on intermittent timeouts.

## Rebased + scoped down per review

Rebased onto current `main`. The original revision also added a `connect_timeout` in `nearai_chat.rs`; that was **dropped** now that #5204 provides it via the shared `hardened_client_builder`. This PR no longer touches `nearai_chat.rs` — only the circuit-breaker config in `resolution.rs` / `config/llm.rs` (+ `.env.example` docs).

## Tests

- `circuit_breaker_enabled_by_default_without_env_override` — breaker on by default at threshold 5, recovery 10s.
- `circuit_breaker_threshold_zero_disables_breaker` — kill switch resolves to `None`.
- Existing env-override resolution test still passes (explicit threshold/recovery win).

## Verified locally

`cargo fmt --check` clean · `cargo clippy -p ironclaw_llm --all-features` and `-p ironclaw --all-features` clean · `ironclaw_llm` resolution + circuit_breaker tests pass. Full workspace `cargo test` deferred to CI.

## Out of scope

Tool-context bloat (~37K input tokens/call from 130 tool defs — the steady-state latency/timeout cure, tracked separately); horizontal scaling; the unrelated error cluster (live-progress projection failures, Slack auth-gate-over-unpaired-actor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)