### PR TITLE
fix(reborn): repair dead failure-category arms in failure-explanation path

### DIFF
--- a/crates/ironclaw_reborn_cli/src/runtime/mod.rs
+++ b/crates/ironclaw_reborn_cli/src/runtime/mod.rs
@@ -1257,7 +1257,10 @@ mod tests {
 
     #[test]
     fn no_assistant_text_message_formats_failed_reply_with_category() {
-        let reply = assistant_reply_without_text_for_test(TurnStatus::Failed, Some("driver_panic"));
+        let reply = assistant_reply_without_text_for_test(
+            TurnStatus::Failed,
+            Some("scheduler_executor_panic"),
+        );
 
         let message = no_assistant_text_message(&reply);
 
@@ -1266,7 +1269,7 @@ mod tests {
             "{message}"
         );
         assert!(
-            message.contains("failure_category=driver_panic"),
+            message.contains("failure_category=scheduler_executor_panic"),
             "{message}"
         );
         assert!(message.contains("status=Failed"), "{message}");

--- a/crates/ironclaw_reborn_composition/src/failure_summary.rs
+++ b/crates/ironclaw_reborn_composition/src/failure_summary.rs
@@ -22,12 +22,16 @@ pub fn reborn_failure_summary_for_category(category: Option<&str>) -> &'static s
         "driver_invalid_request" => {
             "The run failed because the execution driver rejected the request."
         }
-        "driver_panic" => "The run failed because the execution driver stopped unexpectedly.",
+        "scheduler_executor_panic" => {
+            "The run failed because the execution driver stopped unexpectedly."
+        }
         "host_creation_failed" => "The run failed while preparing the runtime host.",
         "route_snapshot_persistence_failed" => {
             "The run failed while saving the selected model route."
         }
-        "heartbeat_failed" => "The run failed after the runner heartbeat could not be recorded.",
+        "scheduler_heartbeat_failed" => {
+            "The run failed after the runner heartbeat could not be recorded."
+        }
         "exit_application_failed" => "The run failed while recording its final result.",
         "lease_expired" => "The run failed because its runner lease expired.",
         "interrupted_unexpectedly" => "The run stopped before it could complete cleanly.",
@@ -78,6 +82,40 @@ mod tests {
     fn reborn_failure_summary_falls_back_for_unknown_category() {
         assert_eq!(
             reborn_failure_summary_for_category(Some("unexpected_category")),
+            "The run failed before producing a reply."
+        );
+    }
+
+    // The scheduler emits `scheduler_heartbeat_failed` / `scheduler_executor_panic`
+    // (see `ironclaw_host_runtime::turn_scheduler`), not the previously-matched
+    // `heartbeat_failed` / `driver_panic`. These two assertions pin the live
+    // mapping to the real producer strings.
+    #[test]
+    fn reborn_failure_summary_describes_scheduler_heartbeat_failure() {
+        assert_eq!(
+            reborn_failure_summary_for_category(Some("scheduler_heartbeat_failed")),
+            "The run failed after the runner heartbeat could not be recorded."
+        );
+    }
+
+    #[test]
+    fn reborn_failure_summary_describes_scheduler_executor_panic() {
+        assert_eq!(
+            reborn_failure_summary_for_category(Some("scheduler_executor_panic")),
+            "The run failed because the execution driver stopped unexpectedly."
+        );
+    }
+
+    // Regression guard: the old, never-produced category strings must no longer
+    // be specially cased — they now fall through to the generic summary.
+    #[test]
+    fn reborn_failure_summary_treats_legacy_dead_categories_as_generic() {
+        assert_eq!(
+            reborn_failure_summary_for_category(Some("heartbeat_failed")),
+            "The run failed before producing a reply."
+        );
+        assert_eq!(
+            reborn_failure_summary_for_category(Some("driver_panic")),
             "The run failed before producing a reply."
         );
     }

--- a/crates/ironclaw_reborn_composition/src/projection.rs
+++ b/crates/ironclaw_reborn_composition/src/projection.rs
@@ -1090,11 +1090,13 @@ fn run_status_projection_state(
 }
 
 fn run_failure_category(run: &RunStatusProjection) -> Option<SanitizedFailure> {
-    // Runtime replay categories intentionally use the event-projection namespace
-    // (model_failed, dispatch_failed, process_killed, ...), while turn lifecycle
-    // events use runner/driver failure reasons (lease_expired, driver_failed, ...).
-    // Both are sanitized product categories; clients must treat the field as an
-    // opaque category and prefer failure_summary for user-facing copy.
+    // `error_kind` is a sanitized product category sourced from the runtime
+    // event log (see `ironclaw_event_projections::apply_run_event`). At
+    // `Failed`/`Killed` status its concrete values are the dispatcher error
+    // codes (`missing_runtime_backend`, `unknown_capability`, ...), the
+    // `LoopFailureKind` codes (`model_error`, `iteration_limit`, ...), or the
+    // process fallback `unknown`. Clients must treat the field as an opaque
+    // category and prefer `failure_summary` for user-facing copy.
     matches!(
         run.status,
         RunProjectionStatus::Failed | RunProjectionStatus::Killed
@@ -1113,13 +1115,13 @@ fn run_failure_summary(run: &RunStatusProjection) -> Option<String> {
 }
 
 fn runtime_failure_summary_for_category(category: &str) -> &'static str {
+    // `category` comes from `RunStatusProjection.error_kind` (see
+    // `run_failure_category`). The only sanitized value that resolves to a
+    // dedicated message is the process fallback `unknown`; every other
+    // produced value (dispatcher codes, `LoopFailureKind` codes) intentionally
+    // falls through to the generic summary.
     match category {
-        "model_failed" => "The run failed while waiting for the model.",
-        "dispatch_failed" => "The run failed while executing a capability.",
-        "process_failed" => "The run failed while executing a runtime process.",
-        "process_killed" => "The run stopped because its runtime process was killed.",
-        "hook_failed" => "The run failed while evaluating a runtime hook.",
-        "unknown" | "unclassified" => "The run failed for an unknown reason.",
+        "unknown" => "The run failed for an unknown reason.",
         _ => "The run failed before producing a reply.",
     }
 }

--- a/crates/ironclaw_reborn_composition/src/projection/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/tests.rs
@@ -91,6 +91,27 @@ fn contains_run_status(
     })
 }
 
+fn run_status_failure_summary(
+    events: &[ProductOutboundEnvelope],
+    invocation_id: InvocationId,
+) -> Option<String> {
+    let expected_run_id = TurnRunId::from_uuid(invocation_id.as_uuid());
+    events.iter().find_map(|event| match event.payload() {
+        ProductOutboundPayload::ProjectionSnapshot { state }
+        | ProductOutboundPayload::ProjectionUpdate { state } => {
+            state.items.iter().find_map(|item| match item {
+                ProductProjectionItem::RunStatus {
+                    run_id,
+                    failure_summary,
+                    ..
+                } if *run_id == expected_run_id => failure_summary.clone(),
+                _ => None,
+            })
+        }
+        _ => None,
+    })
+}
+
 struct FakeTurnEventSource {
     events: Vec<TurnLifecycleEvent>,
 }

--- a/crates/ironclaw_reborn_composition/src/projection/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/tests.rs
@@ -12,10 +12,10 @@ use ironclaw_event_projections::{
 use ironclaw_events::{InMemoryDurableEventLog, RuntimeEvent};
 use ironclaw_host_api::{
     Action, AgentId, ApprovalRequest, ApprovalRequestId, CapabilityId, CorrelationId, ExtensionId,
-    InvocationId, NetworkMethod, NetworkScheme, NetworkTarget, Principal, ResourceEstimate,
-    ResourceScope, RuntimeCredentialAccountProviderId, RuntimeCredentialAccountSetup,
-    RuntimeCredentialAuthRequirement, RuntimeHttpEgress, RuntimeHttpEgressRequest,
-    RuntimeHttpEgressResponse, RuntimeKind, TenantId, ThreadId, UserId,
+    InvocationId, NetworkMethod, NetworkScheme, NetworkTarget, Principal, ProcessId,
+    ResourceEstimate, ResourceScope, RuntimeCredentialAccountProviderId,
+    RuntimeCredentialAccountSetup, RuntimeCredentialAuthRequirement, RuntimeHttpEgress,
+    RuntimeHttpEgressRequest, RuntimeHttpEgressResponse, RuntimeKind, TenantId, ThreadId, UserId,
 };
 use ironclaw_product_adapters::{
     AuthPromptChallengeKind, CapabilityActivityStatusView, ProductOutboundEnvelope,

--- a/crates/ironclaw_reborn_composition/src/projection/tests/failure_explanation.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/tests/failure_explanation.rs
@@ -33,6 +33,26 @@ async fn webui_event_stream_projects_iteration_limit_failure_summary() {
     .await;
 }
 
+#[tokio::test]
+async fn webui_event_stream_projects_scheduler_heartbeat_failure_summary() {
+    assert_failed_run_status_summary(
+        "webui-events-scheduler-heartbeat-thread",
+        "scheduler_heartbeat_failed",
+        "The run failed after the runner heartbeat could not be recorded.",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn webui_event_stream_projects_scheduler_executor_panic_summary() {
+    assert_failed_run_status_summary(
+        "webui-events-scheduler-panic-thread",
+        "scheduler_executor_panic",
+        "The run failed because the execution driver stopped unexpectedly.",
+    )
+    .await;
+}
+
 async fn assert_failed_run_status_summary(
     thread_id: &str,
     failure_category: &str,
@@ -404,7 +424,7 @@ async fn failure_details_returns_fallback_when_model_gateway_times_out() {
                 status: TurnStatus::Failed,
                 kind: TurnEventKind::Failed,
                 blocked_gate: None,
-                sanitized_reason: Some("driver_panic".to_string()),
+                sanitized_reason: Some("scheduler_executor_panic".to_string()),
             }],
         }),
         Arc::new(FakeTurnCoordinator {

--- a/crates/ironclaw_reborn_composition/src/projection/tests/runtime_stream.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/tests/runtime_stream.rs
@@ -484,6 +484,135 @@ async fn webui_event_stream_preserves_sanitized_capability_activity_error_kind()
     }));
 }
 
+// `LoopFailed` error_kind values are the `LoopFailureKind` codes (e.g.
+// `model_error`); they are NOT the milestone-kind name `model_failed`. The
+// runtime failure-summary mapper therefore renders the generic copy for them.
+#[tokio::test]
+async fn webui_event_stream_renders_generic_summary_for_loop_failed_error_kind() {
+    let tenant_id = TenantId::new("webui-loop-failed-tenant").unwrap();
+    let user_id = UserId::new("webui-loop-failed-user").unwrap();
+    let agent_id = AgentId::new("webui-loop-failed-agent").unwrap();
+    let thread_id = ThreadId::new("webui-loop-failed-thread").unwrap();
+    let invocation_id = InvocationId::new();
+    let event_log = Arc::new(InMemoryDurableEventLog::new());
+    event_log
+        .append(RuntimeEvent::loop_failed(
+            resource_scope(&tenant_id, &user_id, &agent_id, &thread_id, invocation_id),
+            CapabilityId::new("loop.run").unwrap(),
+            "model_error",
+        ))
+        .await
+        .unwrap();
+
+    let event_log: Arc<dyn DurableEventLog> = event_log;
+    let actor = TurnActor::new(user_id);
+    let services = build_reborn_projection_services(
+        event_log,
+        ReplyTargetBindingRef::new("webui-loop-failed-reply").unwrap(),
+    );
+    let events = services
+        .webui_event_stream()
+        .drain(ProjectionSubscriptionRequest {
+            actor,
+            scope: TurnScope::new(tenant_id, Some(agent_id), None, thread_id),
+            after_cursor: None,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(
+        run_status_failure_summary(&events, invocation_id).as_deref(),
+        Some("The run failed before producing a reply.")
+    );
+}
+
+// `DispatchFailed` error_kind values are the `DispatchError::event_kind()`
+// codes (e.g. `missing_runtime_backend`); they are NOT the milestone-kind name
+// `dispatch_failed`. The runtime failure-summary mapper renders the generic
+// copy for them too.
+#[tokio::test]
+async fn webui_event_stream_renders_generic_summary_for_dispatch_failed_error_kind() {
+    let tenant_id = TenantId::new("webui-dispatch-failed-tenant").unwrap();
+    let user_id = UserId::new("webui-dispatch-failed-user").unwrap();
+    let agent_id = AgentId::new("webui-dispatch-failed-agent").unwrap();
+    let thread_id = ThreadId::new("webui-dispatch-failed-thread").unwrap();
+    let invocation_id = InvocationId::new();
+    let event_log = Arc::new(InMemoryDurableEventLog::new());
+    event_log
+        .append(RuntimeEvent::dispatch_failed(
+            resource_scope(&tenant_id, &user_id, &agent_id, &thread_id, invocation_id),
+            CapabilityId::new("loop.run").unwrap(),
+            Some(ExtensionId::new("script").unwrap()),
+            Some(RuntimeKind::Script),
+            "missing_runtime_backend",
+        ))
+        .await
+        .unwrap();
+
+    let event_log: Arc<dyn DurableEventLog> = event_log;
+    let actor = TurnActor::new(user_id);
+    let services = build_reborn_projection_services(
+        event_log,
+        ReplyTargetBindingRef::new("webui-dispatch-failed-reply").unwrap(),
+    );
+    let events = services
+        .webui_event_stream()
+        .drain(ProjectionSubscriptionRequest {
+            actor,
+            scope: TurnScope::new(tenant_id, Some(agent_id), None, thread_id),
+            after_cursor: None,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(
+        run_status_failure_summary(&events, invocation_id).as_deref(),
+        Some("The run failed before producing a reply.")
+    );
+}
+
+// `unknown` is the one runtime error_kind that resolves to a dedicated
+// message (produced by the process-failure fallback in
+// `ironclaw_host_runtime::obligations`).
+#[tokio::test]
+async fn webui_event_stream_renders_unknown_failure_summary() {
+    let tenant_id = TenantId::new("webui-unknown-tenant").unwrap();
+    let user_id = UserId::new("webui-unknown-user").unwrap();
+    let agent_id = AgentId::new("webui-unknown-agent").unwrap();
+    let thread_id = ThreadId::new("webui-unknown-thread").unwrap();
+    let invocation_id = InvocationId::new();
+    let event_log = Arc::new(InMemoryDurableEventLog::new());
+    event_log
+        .append(RuntimeEvent::loop_failed(
+            resource_scope(&tenant_id, &user_id, &agent_id, &thread_id, invocation_id),
+            CapabilityId::new("loop.run").unwrap(),
+            "unknown",
+        ))
+        .await
+        .unwrap();
+
+    let event_log: Arc<dyn DurableEventLog> = event_log;
+    let actor = TurnActor::new(user_id);
+    let services = build_reborn_projection_services(
+        event_log,
+        ReplyTargetBindingRef::new("webui-unknown-reply").unwrap(),
+    );
+    let events = services
+        .webui_event_stream()
+        .drain(ProjectionSubscriptionRequest {
+            actor,
+            scope: TurnScope::new(tenant_id, Some(agent_id), None, thread_id),
+            after_cursor: None,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(
+        run_status_failure_summary(&events, invocation_id).as_deref(),
+        Some("The run failed for an unknown reason.")
+    );
+}
+
 #[tokio::test]
 async fn webui_event_stream_drains_live_reasoning_projection_from_update_source() {
     let tenant_id = TenantId::new("webui-thinking-tenant").unwrap();

--- a/crates/ironclaw_reborn_composition/src/projection/tests/runtime_stream.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/tests/runtime_stream.rs
@@ -484,31 +484,34 @@ async fn webui_event_stream_preserves_sanitized_capability_activity_error_kind()
     }));
 }
 
-// `LoopFailed` error_kind values are the `LoopFailureKind` codes (e.g.
-// `model_error`); they are NOT the milestone-kind name `model_failed`. The
-// runtime failure-summary mapper therefore renders the generic copy for them.
-#[tokio::test]
-async fn webui_event_stream_renders_generic_summary_for_loop_failed_error_kind() {
-    let tenant_id = TenantId::new("webui-loop-failed-tenant").unwrap();
-    let user_id = UserId::new("webui-loop-failed-user").unwrap();
-    let agent_id = AgentId::new("webui-loop-failed-agent").unwrap();
-    let thread_id = ThreadId::new("webui-loop-failed-thread").unwrap();
+// Shared setup/drive/assert helper for runtime failure-summary tests.
+//
+// Derives per-test IDs from `test_id`, appends the event returned by
+// `event_fn`, drains the WebUI event stream, and asserts that the
+// run-status failure summary equals `expected_summary`.
+async fn assert_runtime_failure_summary(
+    test_id: &str,
+    event_fn: impl FnOnce(ResourceScope) -> RuntimeEvent,
+    expected_summary: &str,
+) {
+    let tenant_id = TenantId::new(format!("webui-{test_id}-tenant")).unwrap();
+    let user_id = UserId::new(format!("webui-{test_id}-user")).unwrap();
+    let agent_id = AgentId::new(format!("webui-{test_id}-agent")).unwrap();
+    let thread_id = ThreadId::new(format!("webui-{test_id}-thread")).unwrap();
     let invocation_id = InvocationId::new();
+
+    let scope = resource_scope(&tenant_id, &user_id, &agent_id, &thread_id, invocation_id);
     let event_log = Arc::new(InMemoryDurableEventLog::new());
     event_log
-        .append(RuntimeEvent::loop_failed(
-            resource_scope(&tenant_id, &user_id, &agent_id, &thread_id, invocation_id),
-            CapabilityId::new("loop.run").unwrap(),
-            "model_error",
-        ))
+        .append(event_fn(scope))
         .await
-        .unwrap();
+        .expect("test event append must succeed");
 
     let event_log: Arc<dyn DurableEventLog> = event_log;
     let actor = TurnActor::new(user_id);
     let services = build_reborn_projection_services(
         event_log,
-        ReplyTargetBindingRef::new("webui-loop-failed-reply").unwrap(),
+        ReplyTargetBindingRef::new(format!("webui-{test_id}-reply")).unwrap(),
     );
     let events = services
         .webui_event_stream()
@@ -518,12 +521,28 @@ async fn webui_event_stream_renders_generic_summary_for_loop_failed_error_kind()
             after_cursor: None,
         })
         .await
-        .unwrap();
+        .expect("event stream drain must succeed");
 
     assert_eq!(
         run_status_failure_summary(&events, invocation_id).as_deref(),
-        Some("The run failed before producing a reply.")
+        Some(expected_summary),
+        "test_id={test_id}: unexpected failure summary"
     );
+}
+
+// `LoopFailed` error_kind values are the `LoopFailureKind` codes (e.g.
+// `model_error`); they are NOT the milestone-kind name `model_failed`. The
+// runtime failure-summary mapper therefore renders the generic copy for them.
+#[tokio::test]
+async fn webui_event_stream_renders_generic_summary_for_loop_failed_error_kind() {
+    assert_runtime_failure_summary(
+        "loop-failed",
+        |scope| {
+            RuntimeEvent::loop_failed(scope, CapabilityId::new("loop.run").unwrap(), "model_error")
+        },
+        "The run failed before producing a reply.",
+    )
+    .await;
 }
 
 // `DispatchFailed` error_kind values are the `DispatchError::event_kind()`
@@ -532,43 +551,20 @@ async fn webui_event_stream_renders_generic_summary_for_loop_failed_error_kind()
 // copy for them too.
 #[tokio::test]
 async fn webui_event_stream_renders_generic_summary_for_dispatch_failed_error_kind() {
-    let tenant_id = TenantId::new("webui-dispatch-failed-tenant").unwrap();
-    let user_id = UserId::new("webui-dispatch-failed-user").unwrap();
-    let agent_id = AgentId::new("webui-dispatch-failed-agent").unwrap();
-    let thread_id = ThreadId::new("webui-dispatch-failed-thread").unwrap();
-    let invocation_id = InvocationId::new();
-    let event_log = Arc::new(InMemoryDurableEventLog::new());
-    event_log
-        .append(RuntimeEvent::dispatch_failed(
-            resource_scope(&tenant_id, &user_id, &agent_id, &thread_id, invocation_id),
-            CapabilityId::new("loop.run").unwrap(),
-            Some(ExtensionId::new("script").unwrap()),
-            Some(RuntimeKind::Script),
-            "missing_runtime_backend",
-        ))
-        .await
-        .unwrap();
-
-    let event_log: Arc<dyn DurableEventLog> = event_log;
-    let actor = TurnActor::new(user_id);
-    let services = build_reborn_projection_services(
-        event_log,
-        ReplyTargetBindingRef::new("webui-dispatch-failed-reply").unwrap(),
-    );
-    let events = services
-        .webui_event_stream()
-        .drain(ProjectionSubscriptionRequest {
-            actor,
-            scope: TurnScope::new(tenant_id, Some(agent_id), None, thread_id),
-            after_cursor: None,
-        })
-        .await
-        .unwrap();
-
-    assert_eq!(
-        run_status_failure_summary(&events, invocation_id).as_deref(),
-        Some("The run failed before producing a reply.")
-    );
+    assert_runtime_failure_summary(
+        "dispatch-failed",
+        |scope| {
+            RuntimeEvent::dispatch_failed(
+                scope,
+                CapabilityId::new("loop.run").unwrap(),
+                Some(ExtensionId::new("script").unwrap()),
+                Some(RuntimeKind::Script),
+                "missing_runtime_backend",
+            )
+        },
+        "The run failed before producing a reply.",
+    )
+    .await;
 }
 
 // `unknown` is the one runtime error_kind that resolves to a dedicated
@@ -576,41 +572,34 @@ async fn webui_event_stream_renders_generic_summary_for_dispatch_failed_error_ki
 // `ironclaw_host_runtime::obligations`).
 #[tokio::test]
 async fn webui_event_stream_renders_unknown_failure_summary() {
-    let tenant_id = TenantId::new("webui-unknown-tenant").unwrap();
-    let user_id = UserId::new("webui-unknown-user").unwrap();
-    let agent_id = AgentId::new("webui-unknown-agent").unwrap();
-    let thread_id = ThreadId::new("webui-unknown-thread").unwrap();
-    let invocation_id = InvocationId::new();
-    let event_log = Arc::new(InMemoryDurableEventLog::new());
-    event_log
-        .append(RuntimeEvent::loop_failed(
-            resource_scope(&tenant_id, &user_id, &agent_id, &thread_id, invocation_id),
-            CapabilityId::new("loop.run").unwrap(),
-            "unknown",
-        ))
-        .await
-        .unwrap();
+    assert_runtime_failure_summary(
+        "unknown",
+        |scope| RuntimeEvent::loop_failed(scope, CapabilityId::new("loop.run").unwrap(), "unknown"),
+        "The run failed for an unknown reason.",
+    )
+    .await;
+}
 
-    let event_log: Arc<dyn DurableEventLog> = event_log;
-    let actor = TurnActor::new(user_id);
-    let services = build_reborn_projection_services(
-        event_log,
-        ReplyTargetBindingRef::new("webui-unknown-reply").unwrap(),
-    );
-    let events = services
-        .webui_event_stream()
-        .drain(ProjectionSubscriptionRequest {
-            actor,
-            scope: TurnScope::new(tenant_id, Some(agent_id), None, thread_id),
-            after_cursor: None,
-        })
-        .await
-        .unwrap();
-
-    assert_eq!(
-        run_status_failure_summary(&events, invocation_id).as_deref(),
-        Some("The run failed for an unknown reason.")
-    );
+// `ProcessFailed` error_kind values (e.g. `model_error`) fall through the
+// generic `_` arm of the failure-summary mapper; they must render the same
+// generic copy as loop_failed / dispatch_failed for non-"unknown" kinds.
+#[tokio::test]
+async fn webui_event_stream_renders_generic_summary_for_process_failed_error_kind() {
+    assert_runtime_failure_summary(
+        "process-failed",
+        |scope| {
+            RuntimeEvent::process_failed(
+                scope,
+                CapabilityId::new("loop.run").unwrap(),
+                ExtensionId::new("script").unwrap(),
+                RuntimeKind::Script,
+                ProcessId::new(),
+                "model_error",
+            )
+        },
+        "The run failed before producing a reply.",
+    )
+    .await;
 }
 
 #[tokio::test]

--- a/docs/plans/2026-06-24-gapB-dead-failure-categories.md
+++ b/docs/plans/2026-06-24-gapB-dead-failure-categories.md
@@ -1,0 +1,166 @@
+# Gap B — Dead failure-category arms in Reborn failure-explanation path
+
+Date: 2026-06-24
+Branch: `fix/reborn-dead-failure-categories`
+
+## Summary
+
+The Reborn failure-explanation / safe-summary path has two independent
+category→message mappers. Several match arms are DEAD: the value the arm
+matches is never produced by the code that feeds the mapper, so execution
+falls through to the generic fallback (`"The run failed before producing a
+reply."` / `"The run failed for an unknown reason."`). Users see a useless
+generic message even when a specific category-aware message exists.
+
+This was verified end-to-end with codegraph + producer tracing (file:line
+evidence below), not assumed from the arm names.
+
+## The two mappers and their producers
+
+### Mapper A — `reborn_failure_summary_for_category`
+`crates/ironclaw_reborn_composition/src/failure_summary.rs:5`
+
+Fed by `TurnLifecycleEvent.sanitized_reason`
+(`crates/ironclaw_reborn_composition/src/projection/turn_events.rs:799-806`,
+`failure_category_for_turn_event`). `sanitized_reason` is set from
+`SanitizedFailure::category()` in
+`crates/ironclaw_turns/src/lifecycle.rs:450-458`
+(`sanitized_reason_for_state`) and the mirror in
+`crates/ironclaw_loop_support/src/turn_event_publisher.rs:76-84`.
+
+Exhaustive set of values `sanitized_reason` can take when status is
+`Failed`/`RecoveryRequired`:
+- `LoopFailureKind::as_str()` (`crates/ironclaw_turns/src/loop_exit.rs:449-464`):
+  `model_error`, `context_build_failed`, `capability_protocol_error`,
+  `iteration_limit`, `invalid_model_output`, `checkpoint_rejected`,
+  `checkpoint_unavailable`, `transcript_write_failed`, `driver_bug`,
+  `interrupted_unexpectedly`, `no_progress_detected`, `policy_denied`,
+  `compaction_unavailable`
+- `LoopExitViolationKind::failure_category()` (`loop_exit.rs:692-703`):
+  `interrupted_unexpectedly`, `driver_protocol_violation`
+- `RebornTurnRunExecutor` (`crates/ironclaw_reborn/src/turn_run_executor.rs`,
+  `turn_runner.rs`): `driver_not_found`, `host_creation_failed`,
+  `route_snapshot_persistence_failed`, `driver_invalid_request`,
+  `driver_unavailable`, `driver_failed`, `model_credits_exhausted`,
+  `model_credentials_unavailable`, `unknown_failure`, `exit_application_failed`
+- `TurnRunScheduler` (`crates/ironclaw_host_runtime/src/turn_scheduler.rs:655,668`):
+  **`scheduler_executor_panic`**, **`scheduler_heartbeat_failed`**
+- store paths (`crates/ironclaw_turns/src/memory/mod.rs:2284,2990`):
+  `interrupted_unexpectedly`, `lease_expired`
+
+LIVE/DEAD verdict for Mapper A arms:
+
+| Arm | Verdict | Evidence |
+|---|---|---|
+| `driver_not_found` | LIVE | turn_run_executor.rs:105 |
+| `driver_unavailable` | LIVE | turn_run_executor.rs:118 |
+| `driver_failed` | LIVE | turn_runner.rs:55,59 |
+| `driver_invalid_request` | LIVE | turn_run_executor.rs:115 |
+| `driver_panic` | **DEAD** | producer emits `scheduler_executor_panic` (turn_scheduler.rs:655); `driver_panic` only in test fixtures |
+| `host_creation_failed` | LIVE | turn_run_executor.rs:108 |
+| `route_snapshot_persistence_failed` | LIVE | turn_run_executor.rs:111 |
+| `heartbeat_failed` | **DEAD** | producer emits `scheduler_heartbeat_failed` (turn_scheduler.rs:668) |
+| `exit_application_failed` | LIVE | turn_run_executor.rs:283 |
+| `lease_expired` | LIVE | memory/mod.rs:2990 |
+| `interrupted_unexpectedly` | LIVE | memory/mod.rs:2284, loop_exit.rs:694 |
+| `no_progress_detected` | LIVE | loop_exit.rs:461 |
+| `iteration_limit` | LIVE | loop_exit.rs:454 |
+| `unknown_failure` | LIVE | turn_runner.rs:31 |
+
+### Mapper B — `runtime_failure_summary_for_category`
+`crates/ironclaw_reborn_composition/src/projection.rs:1115`
+
+Fed by `RunStatusProjection.error_kind` via `run_failure_category`
+(projection.rs:1092) → `SanitizedFailure::new(category).ok()`. `error_kind`
+is set in `apply_run_event`
+(`crates/ironclaw_event_projections/src/runtime_projection.rs:209-253`) from
+`RuntimeEvent.error_kind`, and is only read at `Failed`/`Killed` status.
+
+The error_kind values that reach Failed/Killed status come from:
+- `DispatchError::event_kind()`
+  (`crates/ironclaw_dispatcher/src/dispatch.rs:409-422`): `unknown_capability`,
+  `unknown_provider`, `runtime_mismatch`, `missing_runtime_backend`,
+  `unsupported_runtime`, `auth_required`, `backend`, ... `unknown`
+- `LoopFailureKind::as_str()` (loop_exit.rs:449): the loop-failure strings above
+- process failures: `obligations.rs:1027` passes `"unknown"` fallback;
+  `wrappers.rs:124` passes `"Unknown"` → sanitizes to `"Unclassified"` →
+  filtered out by `SanitizedFailure::new().ok()`
+
+LIVE/DEAD verdict for Mapper B arms:
+
+| Arm | Verdict | Evidence |
+|---|---|---|
+| `model_failed` | **DEAD** | `ModelFailed` event keeps status `Running`, never Failed/Killed (runtime_projection.rs:396-398). No producer emits the literal `model_failed` as error_kind at Failed/Killed. |
+| `dispatch_failed` | **DEAD** | `DispatchFailed` → Failed, but error_kind = `DispatchError::event_kind()` codes (e.g. `missing_runtime_backend`), never `dispatch_failed` (dispatch.rs:409-422) |
+| `process_failed` | **DEAD** | `ProcessFailed` → Failed, but error_kind = process-record string / `unknown` fallback, never `process_failed` (obligations.rs:1027) |
+| `process_killed` | **DEAD** | `RuntimeEvent::process_killed` sets `error_kind: None` (runtime_event.rs:589-590) |
+| `hook_failed` | **DEAD** | `HookFailed` never transitions to Failed/Killed and sets `error_kind: None` (runtime_event.rs) |
+| `process_killed` | (same row) | — |
+| `unknown` | LIVE | `obligations.rs:1027` fallback `"unknown"` |
+| `unclassified` | **DEAD** | sanitizer fallback is `Unclassified` (capital U) which fails `SanitizedFailure::new()`; lowercase `unclassified` never produced |
+
+## User-visible symptom (incident logs)
+
+`logs.1782330623559.log` / `logs.1782331100360.log` show the produced
+runtime values are `failure_category=lease_expired` and
+`error_kind="auth_required"` / `"authorization"` — i.e. the real values are
+NOT any of the dead arms; the dead arms are unreachable. `auth_required`
+falls through Mapper B's generic `_` arm, confirming the real values bypass
+the specific arms.
+
+## Decision
+
+Per-arm, choosing the correct AND simplest option:
+
+### Mapper A: WIRE (rename arms to the real produced strings)
+The producer emits a stable, specific value (`scheduler_heartbeat_failed`,
+`scheduler_executor_panic`). Renaming the dead arms to those exact strings
+makes them live with NO invented data — users get a specific message for the
+two scheduler-terminal failures. The existing copy is reused (heartbeat copy
+stays; panic gets a clear "stopped unexpectedly" message).
+
+- `"heartbeat_failed"` → `"scheduler_heartbeat_failed"`
+- `"driver_panic"` → `"scheduler_executor_panic"` (keep the same message text;
+  it already reads "stopped unexpectedly")
+
+### Mapper B: DELETE the dead arms
+The arms (`model_failed`, `dispatch_failed`, `process_failed`,
+`process_killed`, `hook_failed`, `unclassified`) match a namespace
+(milestone-kind names) the producer never emits as error_kind. Wiring would
+require inventing a coarsening map from the finer-grained producer namespace
+(`DispatchError` codes, `LoopFailureKind` codes) — data the producer does not
+supply in this form. That is exactly the DELETE criterion. The real produced
+values already fall through the generic `_` arm; that behavior is unchanged
+and pre-existing. Keep `unknown` (LIVE).
+
+The stale comment at projection.rs:1093-1097 (which claims `model_failed`,
+`dispatch_failed`, `process_killed` are runtime-replay categories) is also
+corrected to reflect reality.
+
+Nothing else depends on these arms (codegraph impact: only the mapper
+function and the file). No enum/type plumbing is removed — both mappers take
+`&str`, so there is no cross-crate type to clean up.
+
+## Tests (drive the caller, not just the helper)
+
+- Mapper A: assert `reborn_failure_summary_for_category(Some("scheduler_heartbeat_failed"))`
+  and `..("scheduler_executor_panic")` return the specific copy (was generic).
+  Add a regression test that the *old* dead strings are no longer specially
+  cased (fall through to generic), documenting the rename.
+- Mapper B (driven end-to-end through the runtime projection via real
+  `RuntimeEvent`s): assert `unknown` → specific copy, and that real produced
+  values hit the generic fallback for BOTH producer families — `model_error`
+  via `RuntimeEvent::loop_failed` (a `LoopFailureKind` code) and
+  `missing_runtime_backend` via `RuntimeEvent::dispatch_failed` (a
+  `DispatchError` code) — documenting that Mapper B intentionally only
+  specially-cases `unknown`.
+- Driver-level: the failure_explanation projection tests
+  (`crates/ironclaw_reborn_composition/src/projection/tests/failure_explanation.rs`)
+  already exercise `failure_details_for_turn_event`; update the `driver_panic`
+  fixture to the real `scheduler_executor_panic` string and assert the
+  specific summary so the caller path is covered.
+
+## Quality gate
+
+`cargo fmt --all`; `cargo clippy` + `cargo test` on
+`ironclaw_reborn_composition` (the only touched crate).


### PR DESCRIPTION
## The verified bug

The Reborn failure-explanation / safe-summary path has **two independent category→message mappers** whose match arms were **dead**: the value each arm matched is never produced by the code that feeds the mapper, so users fell through to the generic *"The run failed before producing a reply."* even when a category-specific message existed.

Verified end-to-end by tracing both producers (full file:line evidence in `docs/plans/2026-06-24-gapB-dead-failure-categories.md`):

### Mapper A — `failure_summary.rs::reborn_failure_summary_for_category`
Fed by `TurnLifecycleEvent.sanitized_reason` (← `SanitizedFailure::category()`).
The scheduler (`ironclaw_host_runtime::turn_scheduler.rs:655,668`) produces `scheduler_executor_panic` / `scheduler_heartbeat_failed`, but the arms matched **`driver_panic`** and **`heartbeat_failed`** — never produced. Dead.

### Mapper B — `projection.rs::runtime_failure_summary_for_category`
Fed by `RunStatusProjection.error_kind`. At `Failed`/`Killed` status, `error_kind` is a `DispatchError::event_kind()` code (`missing_runtime_backend`, `unknown_capability`, …) or a `LoopFailureKind` code (`model_error`, `iteration_limit`, …). The arms matched the **milestone-kind namespace** (`model_failed`, `dispatch_failed`, `process_failed`, `process_killed`, `hook_failed`, `unclassified`) which is never emitted as `error_kind`:
- `ModelFailed`/`HookFailed` events never transition the run to `Failed`/`Killed`.
- `process_killed` / `hook_failed` constructors set `error_kind: None`.
- `dispatch_failed`/`process_failed` carry the finer-grained code, not the literal arm string.
- `unclassified` sanitizes to `Unclassified` (capital U) which fails `SanitizedFailure::new()`.

All five suspected arms confirmed dead; only `unknown` (the process fallback in `obligations.rs`) is live.

### Symptom (incident logs)
`logs.1782330623559.log` / `logs.1782331100360.log` show the produced values are `failure_category=lease_expired` and `error_kind="auth_required"`/`"authorization"` — i.e. the real values never equal the dead arms and fall through the generic `_`.

## Decision: WIRE-or-DELETE, per mapper

- **Mapper A → WIRE.** The producer already supplies stable, specific strings, so rename the arms to the real values (`heartbeat_failed`→`scheduler_heartbeat_failed`, `driver_panic`→`scheduler_executor_panic`). No invented data; users now get the specific copy.
- **Mapper B → DELETE.** Wiring would require inventing a coarsening map from the finer producer namespace — data the producer doesn't supply. Delete the dead arms; keep only the live `unknown`. The real values already fall through the generic `_` (unchanged, pre-existing). Stale comments corrected to describe the real `error_kind` namespace.

## Tests (drive the caller, not just the helper)
- `failure_summary.rs`: scheduler categories → specific copy; regression guard that the old dead strings now fall through to generic.
- `failure_explanation.rs`: scheduler categories project the specific summary through the **turn-event** caller path; the `driver_panic` fixture updated to the real `scheduler_executor_panic`.
- `runtime_stream.rs`: `loop_failed` (`model_error`) and `dispatch_failed` (`missing_runtime_backend`) events project the generic summary; a `loop_failed` `unknown` projects the specific copy — exercising the **runtime projection** caller path for both producer families.

## Verification
- `cargo fmt --all` clean.
- `cargo test -p ironclaw_reborn_composition --lib` — all new + existing failure tests pass (50/50 in the `failure` filter).
- `cargo clippy -p ironclaw_reborn_composition --all-targets` — zero warnings from touched files (two pre-existing `factory.rs` dead-code warnings are unrelated; `factory.rs` is not in this diff).
- Pre-existing unrelated failure `factory::tests::local_dev_nearai_mcp_invalid_base_url_fails_build` also fails on the clean base (verified by stashing this diff) — not a regression.
- Reviewed with the multi-agent `/code-review` (6 reviewers, zero blocking findings) and `thermo-nuclear-code-quality-review` (no structural regressions; the change deletes complexity). The one sub-threshold tests-reviewer note — cover a `DispatchError` code in addition to a `LoopFailureKind` code — was addressed by adding the `dispatch_failed` test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)