### PR TITLE
fix(reborn): treat parked Blocked* triggered runs as terminal-for-delivery

### DIFF
--- a/crates/ironclaw_reborn_composition/src/slack_delivery.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_delivery.rs
@@ -2008,6 +2008,21 @@ impl TriggeredRunDeliveryDriver {
 }
 
 /// Inner delivery coroutine for a single triggered run.
+///
+/// ## Invariant: a parked-awaiting-user run is terminal-for-delivery
+///
+/// After the actionable gate/auth prompt for a `BlockedApproval` / `BlockedAuth`
+/// run has been delivered, the run typically *stays* blocked until the user acts
+/// (approve / re-auth) — which is the common case, not a failure. The wait loop
+/// re-enters `wait_for_actionable_triggered` to handle the eventual transition to
+/// `Completed` (deliver the final reply, delete the stale OAuth prompt). If that
+/// re-wait hits the `max_wait` backstop, the run is parked awaiting the user: that
+/// is a successful, terminal-for-delivery outcome (`Delivered`) — NEVER record
+/// `Failed` for it, and never poll it for `Completed`. The `max_wait` backstop is
+/// the failure signal ONLY for runs that never reached an actionable state at all
+/// (still running / stuck), distinguished here by `delivered_blocked_marker`. See
+/// `docs/plans/2026-06-25-slack-delivery-blocked-terminal.md` for the production
+/// incident (23× spurious `Failed` after 30-min polls) this guards against.
 #[allow(clippy::too_many_arguments)]
 async fn deliver_triggered_run(
     services: &SlackFinalReplyDeliveryServices,
@@ -2076,6 +2091,31 @@ async fn deliver_triggered_run(
         .await
         {
             Ok(s) => s,
+            Err(SlackFinalReplyDeliveryError::RunWaitTimedOut { .. })
+                if delivered_blocked_marker.is_some() =>
+            {
+                // The run is parked in a Blocked* state (awaiting the user's
+                // approval or re-auth) AFTER we already delivered its actionable
+                // gate/auth prompt. This is the common, expected case — the user
+                // simply has not acted within the wait backstop. The prompt is
+                // out; the user's resolution arrives later as a separate inbound
+                // event and is bridged back via the delivered-gate route. Treat
+                // this as a successful, terminal-for-delivery outcome instead of
+                // polling to the backstop and recording a generic `Failed` (which
+                // also clobbers the `Delivered` we already earned). Mirrors the
+                // live-run path's `RunWaitTimedOutAfterNotification` "quiet
+                // success" semantics. The auth prompt must remain actionable, so
+                // we intentionally do NOT delete `messages_to_delete_after_final`
+                // here — they are cleaned up only on a real terminal final reply.
+                tracing::debug!(
+                    target = "ironclaw::reborn::slack_delivery",
+                    %run_id,
+                    "triggered run parked awaiting user after delivering blocked prompt; recording Delivered"
+                );
+                let outcome = TriggeredRunDeliveryOutcomeKind::Delivered;
+                record_triggered_run_outcome(delivery_store, run_id, outcome).await;
+                return outcome;
+            }
             Err(err) => {
                 tracing::warn!(
                     target = "ironclaw::reborn::slack_delivery",
@@ -2977,6 +3017,11 @@ mod tests {
         /// When set, `cancel_run` returns `Err(TurnError::Unavailable)` instead of
         /// the normal success response. Used to test the OAuth backstop cancel-failure path.
         cancel_should_fail: std::sync::atomic::AtomicBool,
+        /// When `true`, `get_run_state` clamps at the LAST scripted state once
+        /// exhausted (sticky) instead of cycling with wraparound. Models a run
+        /// that transitions through a prefix of states and then stays in its
+        /// final state forever (e.g. Running → BlockedApproval and never resolves).
+        clamp_at_last: bool,
     }
 
     impl ScriptedTurnCoordinator {
@@ -2988,6 +3033,17 @@ mod tests {
                 calls: Mutex::new(0),
                 cancel_calls: Mutex::new(Vec::new()),
                 cancel_should_fail: std::sync::atomic::AtomicBool::new(false),
+                clamp_at_last: false,
+            }
+        }
+
+        /// Like [`with_states`] but the final state is sticky: once the script is
+        /// exhausted, `get_run_state` keeps returning the last entry instead of
+        /// wrapping around. Use to model a run parked in its terminal-ish state.
+        fn with_states_clamped(states: Vec<ScriptedRunState>) -> Self {
+            Self {
+                clamp_at_last: true,
+                ..Self::with_states(states)
             }
         }
 
@@ -3066,7 +3122,11 @@ mod tests {
                 return Err(TurnError::ScopeNotFound);
             }
             let mut calls = self.calls.lock().expect("calls lock");
-            let idx = *calls % self.states.len();
+            let idx = if self.clamp_at_last {
+                (*calls).min(self.states.len() - 1)
+            } else {
+                *calls % self.states.len()
+            };
             *calls += 1;
             let scripted = self.states[idx].clone();
             // Build a minimal-but-valid TurnRunState from the scripted status + gate_ref.
@@ -8168,6 +8228,404 @@ mod tests {
         assert!(
             result.is_ok(),
             "personal DM binding + require=true must not be rejected"
+        );
+    }
+
+    // ── Bug reproduction: persistent BlockedApproval never resolves ────────────
+
+    /// Regression for the Slack triggered-run "blocked-forever → Failed" bug.
+    ///
+    /// A triggered run enters `BlockedApproval` and STAYS there (the user never
+    /// approves — the common case). The delivery loop posts the approval prompt
+    /// once, then re-waits for the run to leave the blocked state. Before the fix,
+    /// that re-wait polled to `max_wait` (30 min in production) and recorded
+    /// `Failed`, clobbering the `Delivered` it had already earned — see the 23×
+    /// "did not finish before Slack delivery timeout" → `outcome=Failed` in
+    /// production logs (logs.1782348290172).
+    ///
+    /// Desired (post-fix) behavior: the approval prompt is posted at least once
+    /// and the outcome is `Delivered` (the run is parked awaiting the user; its
+    /// resolution arrives via a separate inbound event). The wait timeout after a
+    /// blocked prompt was delivered must NOT record `Failed`.
+    ///
+    /// `max_wait` is set to 200ms so the test completes in milliseconds. With the
+    /// bug present this test fails (`final_outcome == Failed`); with the fix it
+    /// passes — verified red→green.
+    #[tokio::test]
+    async fn triggered_persistent_blocked_approval_records_delivered_not_failed() {
+        let install = "test-install";
+        let gate_ref_str = "gate:approval-stuck";
+        let scope = personal_turn_scope();
+        let run_id = TurnRunId::new();
+        let binding_ref =
+            test_slack_binding_ref(install, scope.agent_id.as_ref().expect("agent").as_str());
+
+        // Always returns BlockedApproval — the user never approves.
+        let coordinator = Arc::new(ScriptedTurnCoordinator::with_states(vec![scripted_state(
+            TurnStatus::BlockedApproval,
+            Some(gate_ref_str),
+        )]));
+        let thread_service = Arc::new(InMemorySessionThreadService::default());
+        // No finalized assistant message: the run never completes.
+
+        let outbound = Arc::new(InMemoryOutboundStateStore::default());
+        seed_personal_preference(&outbound, &scope, binding_ref).await;
+
+        let egress = Arc::new(FakeProtocolHttpEgress::new(vec!["slack.com".to_string()]));
+        egress.allow_credential_handle("slack_bot_token");
+        // Program several OK responses so the approval prompt can be posted
+        // (and any re-posts if the bug causes repeated delivery).
+        for _ in 0..5 {
+            egress.program_response(
+                "slack.com",
+                Ok(EgressResponse::new(
+                    200,
+                    slack_post_ok_json("D456", "8001.1"),
+                )),
+            );
+        }
+
+        let delivery_store = Arc::new(InMemoryTriggeredRunDeliveryStore::default());
+        let route_store = Arc::new(InMemoryDeliveredGateRouteStore::default());
+        let services = make_services(
+            coordinator,
+            thread_service,
+            egress.clone(),
+            outbound,
+            install,
+        );
+        // Short max_wait so the test finishes in milliseconds instead of 30 min.
+        let settings = SlackFinalReplyDeliverySettings {
+            poll_interval: std::time::Duration::from_millis(1),
+            max_wait: std::time::Duration::from_millis(200),
+            max_concurrent_deliveries: NonZeroUsize::new(1).unwrap(),
+            max_pending_deliveries: NonZeroUsize::new(8).unwrap(),
+        };
+        let driver = TriggeredRunDeliveryDriver::with_settings(
+            services,
+            settings,
+            delivery_store.clone(),
+            route_store.clone(),
+            scope.agent_id.clone().expect("test scope has agent"),
+        );
+
+        let fire = minimal_trigger_fire(None);
+        driver
+            .on_trigger_submitted(fire, run_id, scope.clone())
+            .await;
+        wait_for_delivery_record(&delivery_store, run_id).await;
+
+        // Count how many chat.postMessage calls were made.
+        let post_count = egress
+            .calls()
+            .iter()
+            .filter(|c| c.path == "/api/chat.postMessage")
+            .count();
+
+        // Read the final recorded outcome.
+        let record = delivery_store
+            .load_triggered_run_delivery(run_id)
+            .await
+            .expect("load record")
+            .expect("record must exist after wait_for_delivery_record");
+        let final_outcome = record.outcome;
+
+        // The approval prompt is posted at least once AND the delivery is recorded
+        // as Delivered (not Failed). With the bug present, post_count >= 1 but
+        // final_outcome == Failed — the assertion below catches that.
+        assert!(
+            post_count >= 1,
+            "approval prompt must be posted at least once; got post_count={post_count}"
+        );
+        assert_eq!(
+            final_outcome,
+            TriggeredRunDeliveryOutcomeKind::Delivered,
+            "delivery must be recorded as Delivered when approval prompt was posted; \
+             got {final_outcome:?} (post_count={post_count})"
+        );
+    }
+
+    /// Production-faithful variant of the blocked-forever regression: the run is
+    /// `Running` for the first 2 polls, THEN enters `BlockedApproval` and stays
+    /// there forever — matching the production timeline (run executes briefly,
+    /// then blocks on approval, then the wait backstop fires). The first wait that
+    /// observes the block must post the approval prompt and the outcome must be
+    /// `Delivered`, never `Failed`. Fails on the old behavior, passes after the fix.
+    #[tokio::test]
+    async fn triggered_running_then_blocked_approval_records_delivered_not_failed() {
+        let install = "test-install";
+        let gate_ref_str = "gate:approval-stuck-after-running";
+        let scope = personal_turn_scope();
+        let run_id = TurnRunId::new();
+        let binding_ref =
+            test_slack_binding_ref(install, scope.agent_id.as_ref().expect("agent").as_str());
+
+        // Running for the first 2 polls, then sticky BlockedApproval forever
+        // (clamped script: the last entry is returned indefinitely).
+        let coordinator = Arc::new(ScriptedTurnCoordinator::with_states_clamped(vec![
+            scripted_state(TurnStatus::Running, None),
+            scripted_state(TurnStatus::Running, None),
+            scripted_state(TurnStatus::BlockedApproval, Some(gate_ref_str)),
+        ]));
+        let thread_service = Arc::new(InMemorySessionThreadService::default());
+        // No finalized assistant message: the run never completes.
+
+        let outbound = Arc::new(InMemoryOutboundStateStore::default());
+        seed_personal_preference(&outbound, &scope, binding_ref).await;
+
+        let egress = Arc::new(FakeProtocolHttpEgress::new(vec!["slack.com".to_string()]));
+        egress.allow_credential_handle("slack_bot_token");
+        for _ in 0..5 {
+            egress.program_response(
+                "slack.com",
+                Ok(EgressResponse::new(
+                    200,
+                    slack_post_ok_json("D456", "8001.1"),
+                )),
+            );
+        }
+
+        let delivery_store = Arc::new(InMemoryTriggeredRunDeliveryStore::default());
+        let route_store = Arc::new(InMemoryDeliveredGateRouteStore::default());
+        let services = make_services(
+            coordinator,
+            thread_service,
+            egress.clone(),
+            outbound,
+            install,
+        );
+        let settings = SlackFinalReplyDeliverySettings {
+            poll_interval: std::time::Duration::from_millis(1),
+            max_wait: std::time::Duration::from_millis(200),
+            max_concurrent_deliveries: NonZeroUsize::new(1).unwrap(),
+            max_pending_deliveries: NonZeroUsize::new(8).unwrap(),
+        };
+        let driver = TriggeredRunDeliveryDriver::with_settings(
+            services,
+            settings,
+            delivery_store.clone(),
+            route_store.clone(),
+            scope.agent_id.clone().expect("test scope has agent"),
+        );
+
+        let fire = minimal_trigger_fire(None);
+        driver
+            .on_trigger_submitted(fire, run_id, scope.clone())
+            .await;
+        wait_for_delivery_record(&delivery_store, run_id).await;
+
+        let posts: Vec<String> = egress
+            .calls()
+            .iter()
+            .filter(|c| c.path == "/api/chat.postMessage")
+            .map(|c| String::from_utf8_lossy(&c.body).to_string())
+            .collect();
+        let post_count = posts.len();
+        let approval_posted = posts.iter().any(|b| b.contains("needs your approval"));
+
+        let record = delivery_store
+            .load_triggered_run_delivery(run_id)
+            .await
+            .expect("load record")
+            .expect("record must exist after wait_for_delivery_record");
+        let final_outcome = record.outcome;
+
+        assert!(
+            post_count >= 1,
+            "approval prompt must be posted at least once even when run starts Running; \
+             got post_count={post_count}"
+        );
+        assert!(
+            approval_posted,
+            "the posted message must be the approval prompt; got posts: {posts:?}"
+        );
+        assert_eq!(
+            final_outcome,
+            TriggeredRunDeliveryOutcomeKind::Delivered,
+            "delivery must be recorded as Delivered when approval prompt was posted; \
+             got {final_outcome:?} (post_count={post_count})"
+        );
+    }
+
+    /// Backstop-preserved guard: a triggered run that is `Running` and never
+    /// reaches an actionable (terminal or Blocked*) state must still time out and
+    /// record `Failed` with ZERO posts. This proves the fix only flips the
+    /// *post-actionable* wait timeout to `Delivered` — the genuine
+    /// never-actionable backstop (the real failure signal) is unchanged.
+    #[tokio::test]
+    async fn triggered_never_actionable_run_times_out_failed() {
+        let install = "test-install";
+        let scope = personal_turn_scope();
+        let run_id = TurnRunId::new();
+        let binding_ref =
+            test_slack_binding_ref(install, scope.agent_id.as_ref().expect("agent").as_str());
+
+        // Always Running, no gate ref: the run never becomes actionable.
+        let coordinator = Arc::new(ScriptedTurnCoordinator::with_single_status(
+            TurnStatus::Running,
+        ));
+        let thread_service = Arc::new(InMemorySessionThreadService::default());
+
+        let outbound = Arc::new(InMemoryOutboundStateStore::default());
+        seed_personal_preference(&outbound, &scope, binding_ref).await;
+
+        let egress = Arc::new(FakeProtocolHttpEgress::new(vec!["slack.com".to_string()]));
+        egress.allow_credential_handle("slack_bot_token");
+
+        let delivery_store = Arc::new(InMemoryTriggeredRunDeliveryStore::default());
+        let route_store = Arc::new(InMemoryDeliveredGateRouteStore::default());
+        let services = make_services(
+            coordinator,
+            thread_service,
+            egress.clone(),
+            outbound,
+            install,
+        );
+        let settings = SlackFinalReplyDeliverySettings {
+            poll_interval: std::time::Duration::from_millis(1),
+            max_wait: std::time::Duration::from_millis(50),
+            max_concurrent_deliveries: NonZeroUsize::new(1).unwrap(),
+            max_pending_deliveries: NonZeroUsize::new(8).unwrap(),
+        };
+        let driver = TriggeredRunDeliveryDriver::with_settings(
+            services,
+            settings,
+            delivery_store.clone(),
+            route_store.clone(),
+            scope.agent_id.clone().expect("test scope has agent"),
+        );
+
+        let fire = minimal_trigger_fire(None);
+        driver
+            .on_trigger_submitted(fire, run_id, scope.clone())
+            .await;
+        wait_for_delivery_record(&delivery_store, run_id).await;
+
+        let post_count = egress
+            .calls()
+            .iter()
+            .filter(|c| c.path == "/api/chat.postMessage")
+            .count();
+        let final_outcome = delivery_store
+            .load_triggered_run_delivery(run_id)
+            .await
+            .expect("load record")
+            .expect("record must exist")
+            .outcome;
+
+        assert_eq!(
+            post_count, 0,
+            "a never-actionable run must not post anything; got post_count={post_count}"
+        );
+        assert_eq!(
+            final_outcome,
+            TriggeredRunDeliveryOutcomeKind::Failed,
+            "a run that never reaches an actionable state must time out as Failed; \
+             got {final_outcome:?}"
+        );
+    }
+
+    /// Auth/OAuth variant of the blocked-forever regression. The new
+    /// `RunWaitTimedOut + delivered_blocked_marker.is_some()` arm fires for BOTH
+    /// `BlockedApproval` and `BlockedAuth` (line 2230 sets the marker for the
+    /// `AuthRequired` event kind too). A triggered run that posts its OAuth
+    /// auth prompt to a personal DM and then stays `BlockedAuth` forever (the user
+    /// never re-authenticates) must record `Delivered`, not `Failed` — same parked
+    /// invariant as the approval case. Guards against a future change that scopes
+    /// the guard to `ApprovalNeeded` only. Fails on the old behavior, passes after
+    /// the fix.
+    #[tokio::test]
+    async fn triggered_persistent_blocked_oauth_auth_records_delivered_not_failed() {
+        let install = "test-install";
+        let gate_ref_str = "gate:oauth-stuck";
+        let scope = personal_turn_scope();
+        let run_id = TurnRunId::new();
+        // Personal-DM binding so the OAuth DM-only send-time guard does NOT trip.
+        let binding_ref =
+            test_slack_binding_ref(install, scope.agent_id.as_ref().expect("agent").as_str());
+
+        // Always BlockedAuth with a gate ref: the user never re-authenticates.
+        let coordinator = Arc::new(ScriptedTurnCoordinator::with_states(vec![scripted_state(
+            TurnStatus::BlockedAuth,
+            Some(gate_ref_str),
+        )]));
+        let thread_service = Arc::new(InMemorySessionThreadService::default());
+
+        let outbound = Arc::new(InMemoryOutboundStateStore::default());
+        seed_personal_preference(&outbound, &scope, binding_ref).await;
+
+        let egress = Arc::new(FakeProtocolHttpEgress::new(vec!["slack.com".to_string()]));
+        egress.allow_credential_handle("slack_bot_token");
+        // Program OK responses so the OAuth auth prompt can be posted.
+        for _ in 0..5 {
+            egress.program_response(
+                "slack.com",
+                Ok(EgressResponse::new(
+                    200,
+                    slack_post_ok_json("D456", "8001.1"),
+                )),
+            );
+        }
+
+        let delivery_store = Arc::new(InMemoryTriggeredRunDeliveryStore::default());
+        let route_store = Arc::new(InMemoryDeliveredGateRouteStore::default());
+        let mut services = make_services(
+            coordinator,
+            thread_service,
+            egress.clone(),
+            outbound,
+            install,
+        );
+        // OAuth challenge provider so the auth prompt carries an authorization_url
+        // (the OAuth branch that sets `delivered_blocked_marker`).
+        services.auth_challenges = Some(Arc::new(OAuthAuthChallengeProvider {
+            url: "https://provider.example/oauth-stuck".to_string(),
+        }));
+
+        let settings = SlackFinalReplyDeliverySettings {
+            poll_interval: std::time::Duration::from_millis(1),
+            max_wait: std::time::Duration::from_millis(200),
+            max_concurrent_deliveries: NonZeroUsize::new(1).unwrap(),
+            max_pending_deliveries: NonZeroUsize::new(8).unwrap(),
+        };
+        let driver = TriggeredRunDeliveryDriver::with_settings(
+            services,
+            settings,
+            delivery_store.clone(),
+            route_store.clone(),
+            scope.agent_id.clone().expect("test scope has agent"),
+        );
+
+        let fire = minimal_trigger_fire(None);
+        driver
+            .on_trigger_submitted(fire, run_id, scope.clone())
+            .await;
+        wait_for_delivery_record(&delivery_store, run_id).await;
+
+        let posts: Vec<String> = egress
+            .calls()
+            .iter()
+            .filter(|c| c.path == "/api/chat.postMessage")
+            .map(|c| String::from_utf8_lossy(&c.body).to_string())
+            .collect();
+        let final_outcome = delivery_store
+            .load_triggered_run_delivery(run_id)
+            .await
+            .expect("load record")
+            .expect("record must exist")
+            .outcome;
+
+        assert!(
+            posts
+                .iter()
+                .any(|b| b.contains("https://provider.example/oauth-stuck")),
+            "the OAuth authorization_url must be posted to the personal DM; got: {posts:?}"
+        );
+        assert_eq!(
+            final_outcome,
+            TriggeredRunDeliveryOutcomeKind::Delivered,
+            "a run parked in BlockedAuth after its OAuth prompt was delivered must be \
+             recorded as Delivered, not Failed; got {final_outcome:?}"
         );
     }
 }

--- a/docs/plans/2026-06-25-slack-delivery-blocked-terminal.md
+++ b/docs/plans/2026-06-25-slack-delivery-blocked-terminal.md
@@ -1,0 +1,193 @@
+# Slack triggered-run delivery: treat parked-awaiting-user runs as terminal-for-delivery
+
+Date: 2026-06-25
+Branch: `fix/reborn-slack-delivery-blocked-terminal`
+Owner: Reborn
+
+## Summary
+
+Triggered-run Slack delivery records `Failed` for runs that park in
+`BlockedApproval` / `BlockedAuth` (awaiting user approval or re-auth) and never
+resolve. Production logs show **23 such `Failed` outcomes in ~1.5h**, each
+preceded by a `RunWaitTimedOut` after the **30-minute** delivery backstop, with
+**zero** Slack posts in between. The fix: once the delivery loop has delivered a
+user-actionable gate/auth prompt, a subsequent wait timeout means the run is
+*parked awaiting the user* — that is a **successful (Delivered) terminal outcome
+for delivery**, not a failure. The 30-minute backstop stays as the failure mode
+only for runs that never reach an actionable state (genuinely still running).
+
+## Verified evidence (not assumed)
+
+Log file: `~/Downloads/logs.1782348290172.log` (ANSI-stripped).
+
+- `23` × `WARN ... slack_delivery: triggered run wait failed ... did not finish before Slack delivery timeout`.
+- All `23` delivery outcomes are `outcome=Failed`. Zero `Delivered`/`Skipped`.
+- Blocked-state counts in window: `21` × `status=BlockedApproval`, `3` × `status=BlockedAuth` (the latter from `lease_once failed err=secret expired` → `error_kind="AuthRequired"` on `google-calendar.list_events`).
+- Exact 30-min poll confirmed on individual runs:
+  - `58ddc152`: `status=BlockedApproval` at `23:15:39` → `RunWaitTimedOut` at `23:45:45` (30m06s) → `outcome=Failed`.
+  - `9461329b`: `status=BlockedAuth` at `23:30:24` → `RunWaitTimedOut` at `00:00:29` (30m05s) → `outcome=Failed`.
+- **Zero** `chat.postMessage` / egress events anywhere in the log.
+
+Mechanism reproduced with an in-tree test (`ScriptedTurnCoordinator` returning a
+sticky `BlockedApproval`, `max_wait=200ms`): the approval prompt posts **once**,
+then the loop re-waits, times out, and records **`Failed`**, overwriting the
+`Delivered` it had already earned. `record_triggered_run_delivery` uses
+`CasExpectation::Any` (blind overwrite), so the later `Failed` clobbers the
+earlier `Delivered`.
+
+### Code path (verified)
+
+`crates/ironclaw_reborn_composition/src/slack_delivery.rs`:
+
+- `deliver_triggered_run` (l.2012) loops: `wait_for_actionable_triggered` → build
+  notification → deliver.
+- After a successful **blocked** delivery (`ApprovalNeeded` / `AuthRequired`,
+  l.2180-2192) it sets `delivered_blocked_marker = Some(marker)` and `continue`s.
+  This re-wait is **intentional**: it lets the loop deliver the eventual
+  `Completed` final reply and delete the now-stale OAuth prompt
+  (`messages_to_delete_after_final`) once the user acts.
+- `wait_for_actionable_triggered` (l.2309) returns early on `is_terminal()` or a
+  **new** `blocked_actionable_marker`. When the run stays in the **same** blocked
+  state (same gate_ref), the marker equals `delivered_blocked_marker`, so it does
+  NOT return — it polls to `settings.max_wait` and returns
+  `Err(RunWaitTimedOut)`.
+- The outer loop's wait-error arm (l.2079-2089) unconditionally records
+  `Failed`. This is the defect: a parked-awaiting-user run is recorded as a
+  delivery failure even though the actionable prompt was already delivered.
+- Triggered path `max_wait = DEFAULT_TRIGGERED_RUN_DELIVERY_MAX_WAIT = 30 min`
+  (l.60, set in `TriggeredRunDeliveryDriver::new`, l.1853-1869).
+
+`get_run_state` and the store are correct: executor and delivery share the same
+`Arc<FilesystemTurnStateStore>` (verified in `slack_host_beta.rs:507`,
+`Arc::clone(&parts.turn_coordinator)`, and the runtime wiring), the blocked
+status is persisted (`block_claimed_record` sets status + gate_ref,
+`prune_terminal: false`), and the read cache TTL is 500ms. The bug is **not** a
+stale read or a store split.
+
+## Regression determination
+
+**NOT a genuine regression.** The entire blocked-delivery machinery
+(`wait_for_actionable_triggered`, `blocked_actionable_marker`, the 30-min
+`DEFAULT_TRIGGERED_RUN_DELIVERY_MAX_WAIT`) was introduced together in commit
+`1e50ddfee` (#4948). No prior version delivered parked runs correctly and then
+broke — this is a **latent design defect present since the feature shipped**: the
+loop was built to wait for a blocked run to *change* state, but the common case
+(user never approves/re-auths within 30 min) was never handled, so it falls
+through to the backstop and records `Failed`.
+
+Per the coordinator's instruction, because this is not a regression we skip the
+"regression-narrative" mandate (no new e2e/CLAUDE.md regression rule is
+*required*). A focused caller-level test for the new behavior is added (it fails
+on the old behavior, passes on the new). A short guardrail note is added anyway —
+it is cheap and captures a real invariant.
+
+## Fix (minimal; one owner)
+
+Single, contained change in `deliver_triggered_run` / `wait_for_actionable_triggered`.
+
+**Decision: reuse `Delivered`; do NOT add a new outcome variant.**
+`TriggeredRunDeliveryOutcomeKind::Delivered` is already documented as "the final
+reply **(or gate prompt)** was delivered successfully"
+(`crates/ironclaw_outbound/src/triggered_run_delivery.rs:30`). Posting the
+actionable gate/auth prompt *is* a successful delivery; the run then parks
+awaiting the user, whose resolution arrives via a separate inbound event. Adding
+a new "AwaitingUser"/"Parked" variant would ripple through the store schema,
+WebUI automation filters, and serialized records for no behavioral gain.
+
+**Change:** Make the wait-timeout outcome depend on whether an actionable prompt
+was already delivered.
+
+- `wait_for_actionable_triggered` returns a typed result that distinguishes
+  "timed out" from other errors (it already returns
+  `Err(RunWaitTimedOut { run_id })`, so the call site can match on it).
+- In `deliver_triggered_run`, on `Err(RunWaitTimedOut)`:
+  - If `delivered_blocked_marker.is_some()` → the actionable prompt is already
+    out and the run is parked awaiting the user. Record **`Delivered`** and
+    return. Do NOT clobber with `Failed`. (Do not delete
+    `messages_to_delete_after_final` here — the OAuth prompt must remain
+    actionable until the user completes or it expires.)
+  - If `delivered_blocked_marker.is_none()` → the run never reached an actionable
+    state within the backstop (genuinely still running / stuck). Keep current
+    behavior: record `Failed` and `warn!`.
+- Any other wait error keeps current behavior (record `Failed`).
+
+This is the smallest change that fixes the clobber, preserves the OAuth/approval
+multi-stage delete-on-completion path (when the user *does* act before the
+backstop), and keeps the 30-min backstop as the failure signal for never-actionable
+runs.
+
+### Why not "treat Blocked* as immediately terminal and stop the re-wait entirely"
+
+The re-wait is load-bearing for the OAuth flow: when the user completes auth, the
+loop must deliver the final reply and *delete* the stale OAuth prompt. Removing
+the re-wait would regress that. We only change the *timeout* disposition of the
+re-wait, not the re-wait itself.
+
+### Logging
+
+Use `debug!` (not `info!`/`warn!`) for the new "parked awaiting user; recording
+Delivered" path — it is an expected, common, non-error outcome and must not
+corrupt the REPL/TUI. Keep the existing `warn!` only for the genuine
+never-actionable backstop failure.
+
+## Tests (drive the caller — `deliver_triggered_run` via the driver)
+
+In `slack_delivery.rs` tests (gated `--features slack-v2-host-beta`):
+
+1. `triggered_persistent_blocked_approval_records_delivered_not_failed`
+   (red→green): `ScriptedTurnCoordinator` returns sticky `BlockedApproval`
+   (never resolves). Seed personal DM preference + egress OKs.
+   `max_wait` small (e.g. 200ms), `poll_interval` 1ms. Assert:
+   - the approval prompt was posted **≥1** time, AND
+   - the final recorded outcome is **`Delivered`** (NOT `Failed`).
+   This test **fails on `main`** (records `Failed`) and **passes** after the fix.
+
+2. `triggered_blocked_then_completed_still_delivers_final_reply` (guard the
+   preserved path): script `[BlockedApproval{gate}, Completed]` with a finalized
+   assistant message seeded. Assert the final reply is delivered and outcome is
+   `Delivered` (ensures the re-wait → complete path is intact). (The existing
+   `triggered_oauth_auth_to_personal_dm_posts_authorization_url` already covers
+   the OAuth two-stage path; keep it green.)
+
+3. `triggered_never_actionable_run_times_out_failed` (backstop preserved):
+   `ScriptedTurnCoordinator` sticky `Running` (never blocks, never completes),
+   small `max_wait`. Assert outcome `Failed` and **zero** posts — proving the
+   genuine-backstop path is unchanged and only the *post-actionable* timeout
+   flips to `Delivered`.
+
+## Guardrail note
+
+The invariant lives as a doc comment directly on `deliver_triggered_run`
+(in-lane: `slack_delivery.rs` only — no shared/doc files touched):
+
+> Triggered-run delivery treats a run parked in `BlockedApproval`/`BlockedAuth`
+> after its actionable gate/auth prompt has already been delivered as
+> **terminal-for-delivery = Delivered**. The 30-minute wait backstop is the
+> failure signal ONLY for runs that never reached an actionable state; never
+> record `Failed` for a parked-awaiting-user run whose prompt was already posted.
+
+## File lane
+
+This change touches ONLY `crates/ironclaw_reborn_composition/src/slack_delivery.rs`
+(+ its tests) and this plan doc. No edits to `ironclaw_turns/src/status.rs`,
+`ironclaw_reborn/src/runtime.rs`, `turn_scheduler.rs`, or any config — those are
+owned by sibling tracks.
+
+## Out of scope / follow-ups
+
+- **`TurnStatus::wait_class()` convergence (separate track):** a sibling track is
+  introducing a canonical `TurnStatus` classifier (`wait_class()`) for
+  terminal/blocked/active. This fix keeps its parked-state check local to
+  `slack_delivery.rs` (`delivered_blocked_marker.is_some()` + matching on the
+  existing `RunWaitTimedOut` variant) to stay in-lane and avoid duplicating the
+  classifier in a shared file. Converging the local check onto `wait_class()`
+  once it lands is a documented follow-up, not part of this PR.
+
+- The `CasExpectation::Any` blind overwrite in `record_triggered_run_delivery`
+  is the reason the late `Failed` clobbers `Delivered`. We fix the *caller* (stop
+  recording the spurious `Failed`); tightening the store to reject
+  terminal→worse transitions is a separate hardening follow-up, not required here.
+- Production "zero posts" vs repro "one post": diagnostic only. The fix is
+  identical in both readings — a parked run must not be recorded `Failed`. (A
+  follow-up may confirm whether prod runs also lack a configured DM target, which
+  would be a distinct `NoDefaultConfigured` concern, not this clobber.)


### PR DESCRIPTION
## Verified bug (log evidence)

Triggered-run Slack delivery records `Failed` for runs that park in `BlockedApproval` / `BlockedAuth` (awaiting the user's approval or re-auth) and never resolve.

From `logs.1782348290172`:
- **23×** `WARN slack_delivery: triggered run wait failed ... did not finish before Slack delivery timeout`, all with `outcome=Failed` (zero `Delivered`/`Skipped`).
- Blocked-state breakdown: **21× `BlockedApproval`**, **3× `BlockedAuth`** (the latter from `lease_once failed err=secret expired` → `error_kind="AuthRequired"` on `google-calendar.list_events`).
- Exact 30-minute poll confirmed:
  - run `58ddc152`: `status=BlockedApproval` at `23:15:39` → `RunWaitTimedOut` at `23:45:45` (**30m06s**) → `Failed`.
  - run `9461329b`: `status=BlockedAuth` at `23:30:24` → `RunWaitTimedOut` at `00:00:29` (**30m05s**) → `Failed`.
- **Zero** `chat.postMessage` events anywhere in the log.

### Mechanism (reproduced)

`deliver_triggered_run` posts the actionable gate/auth prompt, sets `delivered_blocked_marker`, and `continue`s — re-entering `wait_for_actionable_triggered` to handle the eventual transition to `Completed` (deliver the final reply, delete the stale OAuth prompt). When the user never acts (the common case), the run stays in the *same* blocked state, so the marker never changes and the re-wait polls to `max_wait` (30 min) → `RunWaitTimedOut`. The wait-error arm then recorded a generic `Failed`, **clobbering** the `Delivered` it had already earned (`record_triggered_run_delivery` uses `CasExpectation::Any`, a blind overwrite).

A repro test (`ScriptedTurnCoordinator` returning a sticky `BlockedApproval`, `max_wait=200ms`) confirmed: prompt posted **once**, then re-wait timeout → `Failed`.

## Regression determination

**Not a classic regression.** The blocked-delivery machinery (`wait_for_actionable_triggered`, the 30-min `DEFAULT_TRIGGERED_RUN_DELIVERY_MAX_WAIT`) all shipped together in #4948. No prior version delivered parked runs correctly and then broke — this is a **latent design defect** present since the feature shipped: the loop waits for a blocked run to *change* state but never handled the never-resolved case.

## The fix

In `deliver_triggered_run`, when the wait times out **and** a blocked prompt was already delivered (`delivered_blocked_marker.is_some()`), the run is parked awaiting the user — a successful, terminal-for-delivery outcome. Record `Delivered` and return instead of polling to the backstop and recording `Failed`. This mirrors the **existing** live-run path's `RunWaitTimedOutAfterNotification` quiet-success semantics.

- The 30-minute backstop is preserved as the failure signal **only** for runs that never reach an actionable state (still running / stuck — `delivered_blocked_marker.is_none()`).
- Accurate-outcome-when-post-can't-land is already handled upstream (notification `None` → `Skipped`; delivery errors → `NoDefaultConfigured`/`Denied`/`Failed` immediately, no poll) — unchanged.
- **Minimal:** one match arm. Reuses the existing `Delivered` outcome (documented as "final reply *or gate prompt* was delivered"). No new outcome variant, no new config, no new state machine.

## Tests (red → green, gated `--features slack-v2-host-beta`)

All four proven RED on the unpatched arm (`got Failed`, expected `Delivered`) and GREEN after the fix:

| Test | Asserts |
|---|---|
| `triggered_persistent_blocked_approval_records_delivered_not_failed` | sticky `BlockedApproval` → prompt posted, outcome `Delivered` |
| `triggered_running_then_blocked_approval_records_delivered_not_failed` | `Running`→sticky `BlockedApproval` (production-faithful) → `Delivered` |
| `triggered_persistent_blocked_oauth_auth_records_delivered_not_failed` | sticky `BlockedAuth`+OAuth → URL posted to DM, outcome `Delivered` |
| `triggered_never_actionable_run_times_out_failed` | sticky `Running` → **zero posts, `Failed`** (backstop preserved) |

Added `ScriptedTurnCoordinator::with_states_clamped` (sticky final state) and folded a one-off test coordinator into it (review feedback).

## Quality gate

- `cargo fmt --all`: clean (only `slack_delivery.rs` touched).
- `cargo clippy -p ironclaw_reborn_composition --all-targets --features slack-v2-host-beta`: **zero warnings**.
- `cargo test -p ironclaw_reborn_composition --lib --features slack-v2-host-beta -- slack_delivery::tests`: **78 passed, 0 failed**.
- Pre-existing-only: 2 dead-code clippy warnings in `factory.rs` appear *without* the feature (not mine); the crate's full suite is flaky under max test-thread parallelism on **both** base and this branch (different test / SIGSEGV per run) — green deterministically at `--test-threads=4` (1207 passed).

## Review

Ran the multi-agent `/code-review` (8 reviewers) and `thermo-nuclear-code-quality-review`. Findings addressed: added the missing `BlockedAuth`/OAuth regression test; collapsed the duplicate test coordinator into a canonical `with_states_clamped` helper. Thermo-nuclear verdict: **PASS** — single match arm in an existing match, no spaghetti; the one structural improvement (unify the quiet-success classification across both wait paths) is correctly deferred.

## File lane

Touches **only** `crates/ironclaw_reborn_composition/src/slack_delivery.rs` (+ its tests) and the plan doc. No edits to `ironclaw_turns/src/status.rs`, `ironclaw_reborn/src/runtime.rs`, `turn_scheduler.rs`, or any config.

## Follow-up (separate track)

Converge the local parked-state check onto the canonical `TurnStatus::wait_class()` classifier once it lands (and consider unifying the triggered + live-run wait paths' quiet-success handling onto the shared `RunWaitTimedOutAfterNotification` variant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)