### PR TITLE
fix(reborn): reconcile scheduler concurrency default and guard worker_count=1

### DIFF
--- a/crates/ironclaw_host_runtime/CLAUDE.md
+++ b/crates/ironclaw_host_runtime/CLAUDE.md
@@ -13,6 +13,18 @@
 
 - `turn_scheduler.rs` owns scheduler-backed run concurrency. It does not own the
   canonical loop tick or product inbound serialization.
+  - Concurrency invariant: the scheduler runs up to `max_concurrent_runs` runs in
+    parallel, one `tokio::spawn` + `OwnedSemaphorePermit` per run. The single
+    `TurnRunnerId` is the scheduler *instance*, not a per-run worker — seeing one
+    `TurnRunnerId` is expected and does NOT mean serial execution.
+  - `TurnRunSchedulerConfig::default().max_concurrent_runs` must equal
+    `DEFAULT_MAX_CONCURRENT_RUNS` (do not re-introduce a divergent literal —
+    `Default` previously hard-coded `4` while production used `16`). The
+    production worker-count default `ironclaw_reborn::DEFAULT_TURN_RUNNER_WORKER_COUNT`
+    is *derived from* `DEFAULT_MAX_CONCURRENT_RUNS`, so the scheduler cap and the
+    worker-count default are the same value by construction; keep the constant
+    above `1`. A configured `worker_count = 1` is legal but serializes all runs
+    through one slot — the CLI resolver warns on it.
 - `surface.rs` owns host-runtime capability-surface shaping and versions.
 - `production.rs` and `services.rs` compose runtime services and readiness
   evidence used by Reborn loop wiring.

--- a/crates/ironclaw_host_runtime/src/lib.rs
+++ b/crates/ironclaw_host_runtime/src/lib.rs
@@ -128,8 +128,9 @@ pub use services::{
 };
 pub use surface::{CapabilitySurfacePolicy, VisibleCapability, VisibleCapabilityAccess};
 pub use turn_scheduler::{
-    SchedulerTurnRunWakeNotifier, TurnRunExecutor, TurnRunExecutorError, TurnRunScheduler,
-    TurnRunSchedulerConfig, TurnRunSchedulerHandle, TurnRunWakeChannel,
+    DEFAULT_MAX_CONCURRENT_RUNS, SchedulerTurnRunWakeNotifier, TurnRunExecutor,
+    TurnRunExecutorError, TurnRunScheduler, TurnRunSchedulerConfig, TurnRunSchedulerHandle,
+    TurnRunWakeChannel,
 };
 
 /// Stable, validated idempotency key supplied by upper turn/loop services.

--- a/crates/ironclaw_host_runtime/src/turn_scheduler.rs
+++ b/crates/ironclaw_host_runtime/src/turn_scheduler.rs
@@ -22,6 +22,21 @@ use tokio_util::sync::CancellationToken;
 use tracing::Instrument;
 use tracing::debug;
 
+/// Canonical default for the scheduler's concurrent-run cap (the number of turn
+/// runs that may be `Running` at once on a single scheduler instance).
+///
+/// This is the single source of truth for the scheduler default. The production
+/// composition (`ironclaw_reborn`) always overrides the running config via
+/// [`TurnRunSchedulerConfig::with_max_concurrent_runs`] using its
+/// `DEFAULT_TURN_RUNNER_WORKER_COUNT` knob, which is itself *derived from* this
+/// constant — so the worker-count default and the scheduler cap are the same
+/// value by construction. (The derivation only works one way: `ironclaw_reborn`
+/// depends on `ironclaw_host_runtime`, not the reverse.)
+///
+/// `1` is a legal value but degenerate: it serializes every run through one
+/// permit. Keep this comfortably above 1.
+pub const DEFAULT_MAX_CONCURRENT_RUNS: usize = 16;
+
 #[derive(Debug, Clone)]
 pub struct TurnRunSchedulerConfig {
     max_concurrent_runs: usize,
@@ -35,7 +50,7 @@ pub struct TurnRunSchedulerConfig {
 impl Default for TurnRunSchedulerConfig {
     fn default() -> Self {
         Self {
-            max_concurrent_runs: 4,
+            max_concurrent_runs: DEFAULT_MAX_CONCURRENT_RUNS,
             poll_interval: Duration::from_secs(5),
             lease_recovery_interval: Duration::from_secs(10),
             runner_heartbeat_interval: Duration::from_secs(30),

--- a/crates/ironclaw_host_runtime/src/turn_scheduler/tests.rs
+++ b/crates/ironclaw_host_runtime/src/turn_scheduler/tests.rs
@@ -17,7 +17,46 @@ use ironclaw_turns::{
     },
 };
 
-use super::{TurnRunExecutor, TurnRunExecutorError, TurnRunScheduler, TurnRunSchedulerConfig};
+use super::{
+    DEFAULT_MAX_CONCURRENT_RUNS, TurnRunExecutor, TurnRunExecutorError, TurnRunScheduler,
+    TurnRunSchedulerConfig,
+};
+
+// ── Config defaults ───────────────────────────────────────────────────────
+
+/// The scheduler's `Default` concurrent-run cap must equal the canonical
+/// constant. This pins the historical regression where `Default` hard-coded `4`
+/// while the production composition used `16`, so a `Default`-only caller would
+/// silently under-provision the pool. Before the fix this asserted against `4`
+/// and failed.
+#[test]
+fn default_config_uses_canonical_max_concurrent_runs() {
+    // The default pool must allow concurrency (>1); 1 serializes all runs.
+    // Checked at compile time so the invariant holds even if the constant moves.
+    const _: () = assert!(DEFAULT_MAX_CONCURRENT_RUNS > 1);
+
+    assert_eq!(
+        TurnRunSchedulerConfig::default().max_concurrent_runs(),
+        DEFAULT_MAX_CONCURRENT_RUNS,
+        "Default scheduler config must use DEFAULT_MAX_CONCURRENT_RUNS, not a divergent literal"
+    );
+}
+
+/// `with_max_concurrent_runs` floors to a non-zero value: 0 must not produce a
+/// scheduler that can never claim a run.
+#[test]
+fn with_max_concurrent_runs_floors_zero_to_one() {
+    let config = TurnRunSchedulerConfig::default().with_max_concurrent_runs(0);
+    assert_eq!(config.max_concurrent_runs(), 1);
+}
+
+/// The exact floor boundary: an explicit `1` must be preserved as `1` (not
+/// floored up to 2, not dropped to 0). Guards a refactor that mis-edits `.max`.
+#[test]
+fn with_max_concurrent_runs_keeps_one() {
+    let config = TurnRunSchedulerConfig::default().with_max_concurrent_runs(1);
+    assert_eq!(config.max_concurrent_runs(), 1);
+}
 
 // ── Minimal fakes ────────────────────────────────────────────────────────
 

--- a/crates/ironclaw_reborn/src/runtime.rs
+++ b/crates/ironclaw_reborn/src/runtime.rs
@@ -60,14 +60,17 @@ use crate::{
 
 /// Default number of turn-runner worker tasks spawned per runtime instance.
 ///
-/// Used by [`DefaultPlannedRuntimeConfig`] and [`TurnRunnerSettings`] so the
-/// value is defined exactly once and shared across all crates in the stack.
+/// Derived from the scheduler's own
+/// [`ironclaw_host_runtime::DEFAULT_MAX_CONCURRENT_RUNS`] so the worker-count
+/// default and the scheduler's concurrent-run cap are the same value by
+/// construction (no literal duplication, no drift). Used by
+/// [`DefaultPlannedRuntimeConfig`] and [`TurnRunnerSettings`].
 pub const DEFAULT_TURN_RUNNER_WORKER_COUNT: std::num::NonZeroUsize =
-    match std::num::NonZeroUsize::new(16) {
+    match std::num::NonZeroUsize::new(ironclaw_host_runtime::DEFAULT_MAX_CONCURRENT_RUNS) {
         Some(v) => v,
-        // 16 is a non-zero compile-time constant so this arm is never reached.
-        // `NonZeroUsize::MIN` (= 1) is used as a non-panicking fallback so the
-        // CI "no panics in production code" check stays green.
+        // DEFAULT_MAX_CONCURRENT_RUNS is a non-zero compile-time constant so this
+        // arm is never reached. `NonZeroUsize::MIN` (= 1) is a non-panicking
+        // fallback so the CI "no panics in production code" check stays green.
         None => std::num::NonZeroUsize::MIN,
     };
 
@@ -781,6 +784,25 @@ mod tests {
     use ironclaw_loop_support::{
         DecoratingLoopCapabilityPortFactory, LoopCapabilityPortDecorator, LoopCapabilityPortFactory,
     };
+
+    /// The worker-count default is derived from the scheduler's canonical
+    /// concurrency default, so the two are equal by construction. This test
+    /// documents and locks that contract — and asserts the shared value allows
+    /// real concurrency (> 1), which is the property a misconfiguration or a
+    /// future literal-override would silently break.
+    #[test]
+    fn worker_count_default_matches_scheduler_default() {
+        assert_eq!(
+            super::DEFAULT_TURN_RUNNER_WORKER_COUNT.get(),
+            ironclaw_host_runtime::DEFAULT_MAX_CONCURRENT_RUNS,
+            "DEFAULT_TURN_RUNNER_WORKER_COUNT must stay equal to \
+             ironclaw_host_runtime::DEFAULT_MAX_CONCURRENT_RUNS"
+        );
+        assert!(
+            super::DEFAULT_TURN_RUNNER_WORKER_COUNT.get() > 1,
+            "the default worker pool must allow concurrency (> 1)"
+        );
+    }
 
     async fn test_run_context() -> LoopRunContext {
         let tenant_id = TenantId::new("tenant-runtime-test").unwrap();

--- a/crates/ironclaw_reborn_cli/src/runtime/mod.rs
+++ b/crates/ironclaw_reborn_cli/src/runtime/mod.rs
@@ -991,6 +991,19 @@ fn runner_settings(
             })?
         };
 
+        // A worker_count of 1 is legal but degenerate: it serializes every turn
+        // run through a single scheduler permit. Operators almost never want
+        // this for a multi-trigger / multi-user deployment. We honour the
+        // explicit value (silently overriding it would be surprising) but make
+        // the loss of concurrency loud at boot.
+        if settings.worker_count.get() == 1 {
+            tracing::warn!(
+                worker_count = 1,
+                "config file [runner].worker_count = 1 serializes all turn runs through one \
+                 scheduler slot; set it to >= 2 for concurrent runs"
+            );
+        }
+
         // Each cap: absent in the file → keep the struct default already in
         // `settings`; explicit `0` → "unlimited" sentinel (None); positive → cap.
         settings.max_concurrent_runs_per_user = resolve_concurrency_cap(
@@ -1101,6 +1114,81 @@ mod tests {
         let cfg = parse_runner_section(&toml);
         let settings = runner_settings(Some(&cfg)).expect("should succeed");
         assert_eq!(settings.worker_count.get(), MAX_WORKER_COUNT);
+    }
+
+    #[test]
+    fn runner_settings_worker_count_one_is_honoured() {
+        // `1` is a legal-but-degenerate value: the resolver must keep it (it
+        // does NOT silently override the operator), so the scheduler will be
+        // single-slot. The accompanying warn is asserted separately below.
+        let cfg = parse_runner_section("[runner]\nworker_count = 1\n");
+        let settings = runner_settings(Some(&cfg)).expect("should succeed");
+        assert_eq!(settings.worker_count.get(), 1);
+    }
+
+    /// Run `runner_settings` for the given `[runner]` TOML under a capturing
+    /// tracing subscriber and return whether a WARN mentioning `worker_count`
+    /// was emitted. Driving the REAL resolver is the point — a unit test on the
+    /// predicate alone would not catch the warn being dropped from the path.
+    fn resolver_emits_worker_count_warn(runner_toml: &str) -> bool {
+        use std::sync::{Arc, Mutex};
+        use tracing_subscriber::Layer;
+        use tracing_subscriber::layer::Context;
+        use tracing_subscriber::prelude::*;
+
+        #[derive(Clone, Default)]
+        struct CaptureLayer {
+            events: Arc<Mutex<Vec<(tracing::Level, String)>>>,
+        }
+        struct MessageVisitor(String);
+        impl tracing::field::Visit for MessageVisitor {
+            fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+                if field.name() == "message" {
+                    self.0 = format!("{value:?}");
+                }
+            }
+        }
+        impl<S: tracing::Subscriber> Layer<S> for CaptureLayer {
+            fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
+                let mut visitor = MessageVisitor(String::new());
+                event.record(&mut visitor);
+                self.events
+                    .lock()
+                    .expect("lock")
+                    .push((*event.metadata().level(), visitor.0));
+            }
+        }
+
+        let layer = CaptureLayer::default();
+        let events = Arc::clone(&layer.events);
+        let subscriber = tracing_subscriber::registry().with(layer);
+
+        let cfg = parse_runner_section(runner_toml);
+        tracing::subscriber::with_default(subscriber, || {
+            runner_settings(Some(&cfg)).expect("should succeed");
+        });
+
+        events
+            .lock()
+            .expect("lock")
+            .iter()
+            .any(|(level, msg)| *level == tracing::Level::WARN && msg.contains("worker_count"))
+    }
+
+    #[test]
+    fn runner_settings_warns_on_degenerate_worker_count_one() {
+        assert!(
+            resolver_emits_worker_count_warn("[runner]\nworker_count = 1\n"),
+            "worker_count = 1 must emit a WARN about serialized runs"
+        );
+    }
+
+    #[test]
+    fn runner_settings_no_warn_on_normal_worker_count() {
+        assert!(
+            !resolver_emits_worker_count_warn("[runner]\nworker_count = 7\n"),
+            "a normal worker_count must NOT emit the serialization WARN"
+        );
     }
 
     #[test]

--- a/crates/ironclaw_reborn_config/src/config_file.rs
+++ b/crates/ironclaw_reborn_config/src/config_file.rs
@@ -155,7 +155,9 @@ pub struct HarnessSection {
 pub struct RunnerSection {
     pub heartbeat_interval_secs: Option<u64>,
     pub poll_interval_ms: Option<u64>,
-    /// Number of concurrent turn-runner worker tasks. `None` or `0` defaults to 4. Clamped to 32.
+    /// Number of concurrent turn-runner worker tasks. `None` or `0` defaults to
+    /// 16 (`DEFAULT_TURN_RUNNER_WORKER_COUNT`); clamped to 32. `1` is accepted
+    /// but serializes all runs through one slot, so prefer `>= 2`.
     pub worker_count: Option<usize>,
     /// Max concurrent runs in `TurnStatus::Running` per (tenant_id, owner user_id). `None` or `0` = unlimited.
     pub max_concurrent_runs_per_user: Option<u32>,

--- a/docs/plans/2026-06-25-runner-concurrency.md
+++ b/docs/plans/2026-06-25-runner-concurrency.md
@@ -1,6 +1,6 @@
 # Runner concurrency investigation — 2026-06-25
 
-Track: `fix/reborn-runner-concurrency` (off main `4f28febbe`).
+Track: `fix/reborn-runner-concurrency` (off main `3cbde9b21`).
 
 ## TL;DR — root cause determination
 
@@ -8,7 +8,7 @@ Track: `fix/reborn-runner-concurrency` (off main `4f28febbe`).
 single `TurnRunnerId` serving serially → effective concurrency ≈ 1") is NOT a
 runner-scheduler regression, and NOT a `worker_count=1` config foot-gun.**
 
-Hard log evidence (`/Users/henry/Downloads/logs.1782348290172.log`, ANSI-stripped)
+Hard log evidence (operator-provided `logs.1782348290172.log`, ANSI-stripped)
 shows the scheduler running **multiple runs concurrently**:
 
 - 23:30 window — three runs overlap:

--- a/docs/plans/2026-06-25-runner-concurrency.md
+++ b/docs/plans/2026-06-25-runner-concurrency.md
@@ -1,0 +1,131 @@
+# Runner concurrency investigation — 2026-06-25
+
+Track: `fix/reborn-runner-concurrency` (off main `4f28febbe`).
+
+## TL;DR — root cause determination
+
+**The reported symptom ("7 of 23 triggered runs never reached `turn run started`;
+single `TurnRunnerId` serving serially → effective concurrency ≈ 1") is NOT a
+runner-scheduler regression, and NOT a `worker_count=1` config foot-gun.**
+
+Hard log evidence (`/Users/henry/Downloads/logs.1782348290172.log`, ANSI-stripped)
+shows the scheduler running **multiple runs concurrently**:
+
+- 23:30 window — three runs overlap:
+  - `81de47f4` started 23:30:07.45, finished 23:30:16.85
+  - `6200c910` started 23:30:10.59, finished 23:30:23.70
+  - `9461329b` started 23:30:13.01, finished 23:30:24.67
+  → all three in-flight simultaneously ~23:30:13–23:30:16.
+- Same pattern at 00:00 (`747d989b`/`281df473`/`a5a06cb6`) and 00:30
+  (`36356f89`/`6c5f386c`/`5ad0055f`).
+
+So production is decidedly **not** running at `worker_count=1`. The single
+`TurnRunnerId(ce43288a…)` is one scheduler *instance* (one process), which is by
+design — it is NOT a per-run worker. Concurrency is genuinely > 1.
+
+### What actually produced the symptom (different track — do NOT fix here)
+
+The "never started" / "did not finish before Slack delivery timeout" lines all
+originate in `ironclaw_reborn_composition::slack_delivery`, not the scheduler:
+
+- Real runs reach `BlockedApproval` within ~7s (e.g. `5e46d384`: started
+  23:20:32, BlockedApproval 23:20:39, "turn run finished" 23:20:40).
+- The Slack triggered-run delivery (`deliver_triggered_run` →
+  `wait_for_actionable_triggered`, `slack_delivery.rs:2308`) delivers the first
+  gate, records `delivered_blocked_marker`, then loops and waits for the *next*
+  actionable transition. Because the approval is never answered, that second wait
+  runs the full `max_wait` (`DEFAULT_TRIGGERED_RUN_DELIVERY_MAX_WAIT = 30*60s`,
+  `slack_delivery.rs:60`) and finally logs "wait failed … did not finish before
+  Slack delivery timeout" → `outcome=Failed`. The timeout fires exactly 30 min
+  after the run blocked (`5e46d384` blocked 23:20:39 → wait-failed 23:50:45;
+  `58ddc152` blocked 23:15:39 → wait-failed 23:45:45).
+- The 8 "orphan" run_ids (`62aa9709`, …) that appear only in slack_delivery and
+  never in the coordinator are prior-cycle / duplicate delivery waits, not
+  starved scheduler runs.
+
+This is an availability issue in the Slack delivery layer
+(`slack_delivery.rs` / `runner_immediate_ack.rs`), explicitly assigned to a
+separate track. It is out of scope here.
+
+## Scheduler facts (verified, file:line)
+
+- `TurnRunScheduler` (`crates/ironclaw_host_runtime/src/turn_scheduler.rs:154`)
+  bounds concurrency with a `tokio::sync::Semaphore::new(max_concurrent_runs)`
+  created in `run_scheduler_loop` (`:392`). Each claimed run is `tokio::spawn`ed
+  onto a `JoinSet`, holding an `OwnedSemaphorePermit` for the run's lifetime
+  (`spawn_executor_task`, permit dropped at "turn run finished"). Up to
+  `max_concurrent_runs` runs execute concurrently. The model is sound (this is
+  PR #5085's design) — confirmed.
+- Production wiring: `crates/ironclaw_reborn/src/runtime.rs:659-660` builds the
+  config as `TurnRunSchedulerConfig::default().with_max_concurrent_runs(worker_count)`.
+  `worker_count` default = `DEFAULT_TURN_RUNNER_WORKER_COUNT = 16`
+  (`crates/ironclaw_reborn/src/runtime.rs:65`); per-user cap 3, per-trigger 8 —
+  none of which can floor concurrency to 1.
+- `worker_count` is config-file only (`[runner].worker_count`), no env var;
+  resolved in `runner_settings` (`crates/ironclaw_reborn_cli/src/runtime/mod.rs:954`).
+
+## Real (low-severity) gaps worth a small guardrail
+
+These are genuine, independently verifiable defects — not the reported symptom,
+but real maintainability hazards uncovered while verifying. Each is testable.
+
+1. **Divergent default.** `TurnRunSchedulerConfig::default().max_concurrent_runs`
+   is the literal `4` (`turn_scheduler.rs:38`), while the production constant is
+   `16`. Any `Default`-only caller silently under-provisions. `host_runtime`
+   cannot import `ironclaw_reborn`'s constant (that would be a dependency cycle —
+   `reborn` depends on `host_runtime`), so define the canonical default as a
+   `pub const DEFAULT_MAX_CONCURRENT_RUNS` in `host_runtime` (the crate that owns
+   `TurnRunSchedulerConfig`), set to `16`, and make `Default` use it.
+   `ironclaw_reborn::DEFAULT_TURN_RUNNER_WORKER_COUNT` then *derives* from that
+   constant (it depends on `host_runtime`, so the import is legal), making the
+   two equal by construction — no literal duplication, no drift risk. (This is
+   the code-review-improved form of the original "duplicate + pin-with-test"
+   plan: the test stays as a documented invariant lock + a `> 1` assertion.)
+
+2. **Stale doc.** `crates/ironclaw_reborn_config/src/config_file.rs:158` says
+   `worker_count` "defaults to 4" — the real default is 16. Fix the comment and
+   note that `1` serializes all runs.
+
+3. **Silent degenerate value.** `runner_settings` accepts an explicit
+   `worker_count = 1` with no signal. A `1` is technically valid but serializes
+   the whole pool. Emit a startup `warn!` (not a silent override — respect the
+   operator's explicit value) when the resolved worker_count is 1. This is the
+   cheap recurrence-prevention guardrail.
+
+   Note: production was NOT at `worker_count=1` (the data shows concurrency > 1),
+   so this guards a hypothetical misconfiguration, not the observed incident. It
+   is included only because it is one line, directly testable, and the project's
+   guardrail-placement preference favors making a degenerate config loud.
+
+## Plan
+
+- `host_runtime`: add `pub const DEFAULT_MAX_CONCURRENT_RUNS: usize = 16;`, make
+  `TurnRunSchedulerConfig::default()` use it. Add a unit test pinning
+  `default().max_concurrent_runs() == DEFAULT_MAX_CONCURRENT_RUNS`.
+- `ironclaw_reborn`: add a test asserting
+  `DEFAULT_TURN_RUNNER_WORKER_COUNT.get() == ironclaw_host_runtime::DEFAULT_MAX_CONCURRENT_RUNS`
+  so the two defaults cannot drift.
+- `reborn_cli` `runner_settings`: emit `warn!` when resolved `worker_count == 1`.
+  Add a test driving the real resolver that asserts the resolved value is 1 for
+  `[runner].worker_count = 1` (the warn path), and that `Default` resolution is
+  16. (Test the resolver — the caller — per "Test Through the Caller".)
+- `reborn_config`: fix the stale doc comment.
+- Spec: add the concurrency invariant to
+  `crates/ironclaw_host_runtime/CLAUDE.md` so a future agent does not
+  re-introduce a divergent default or assume the scheduler is serial.
+
+## Explicit non-goals
+
+- No scheduler behavioral change — the scheduler is correct.
+- No Slack delivery change — that is the separate availability track.
+- No fabricated "concurrency regression" — none exists; the data shows
+  concurrency > 1.
+
+## Red→green for the guardrail
+
+The default-divergence test is the meaningful red→green: on the unpatched base,
+`TurnRunSchedulerConfig::default().max_concurrent_runs()` is `4`, so a test
+asserting it equals the production default (16) FAILS red; after the fix it is
+`16` → GREEN. The cross-crate drift test likewise fails red (4 ≠ 16) and passes
+green. The warn-on-1 resolver test asserts the resolved value for an explicit
+`worker_count = 1`.


### PR DESCRIPTION
## Root cause: NOT a scheduler concurrency regression, and NOT a `worker_count=1` config foot-gun

This started as an investigation of a production report — *"triggered runs starving; 7 of 23 never reached `turn run started`; a single `TurnRunnerId` serving runs serially → effective concurrency ≈ 1."*

**The log evidence disproves the starvation hypothesis.** From `logs.1782348290172.log`:

- The scheduler runs runs **concurrently** — three runs overlap in-flight in multiple windows:
  - 23:30 — `81de47f4` (07.45→16.85), `6200c910` (10.59→23.70), `9461329b` (13.01→24.67) all in flight ~23:30:13–16.
  - Same 3-way overlap at 00:00 and 00:30.
- The single `TurnRunnerId(ce43288a…)` is **one scheduler instance** (one process), by design — it is not a per-run worker. Concurrency is genuinely > 1, so production is **not** running at `worker_count=1`.
- The `"… did not finish before Slack delivery timeout"` / "never started" lines all originate in `ironclaw_reborn_composition::slack_delivery`, not the scheduler. Real runs reach `BlockedApproval` within ~7s (`5e46d384`: started 23:20:32, blocked 23:20:39, finished 23:20:40). The Slack triggered-run delivery delivers the first gate, then re-waits on the now-permanently-blocked run for the full `DEFAULT_TRIGGERED_RUN_DELIVERY_MAX_WAIT` (30 min) and finally reports `Failed` — the timeout fires *exactly 30 min* after the run blocked (`5e46d384` blocked 23:20:39 → wait-failed 23:50:45). The "orphan" run_ids are prior-cycle / duplicate delivery waits.

That Slack-delivery availability behavior is a **separate track** and is intentionally not touched here.

## What this PR ships

Since the scheduler is healthy, there is no behavioral fix. This PR ships only the genuine, independently-verified **config-hygiene gaps** uncovered while verifying:

1. **Reconcile the divergent default.** `TurnRunSchedulerConfig::default().max_concurrent_runs` was the literal `4`, while production overrides with `worker_count` (default `16`) — so any `Default`-only caller silently under-provisioned. Introduce `ironclaw_host_runtime::DEFAULT_MAX_CONCURRENT_RUNS = 16` as the single source of truth; `Default` uses it; `ironclaw_reborn::DEFAULT_TURN_RUNNER_WORKER_COUNT` now **derives** from it (legal one-way import), making the two equal **by construction** — no literal duplication, no drift.
2. **Guard the degenerate value.** The CLI resolver (`runner_settings`) now emits a startup `warn!` when `worker_count` resolves to `1` (legal, but serializes all runs through one slot). The operator's explicit value is honoured, not silently overridden.
3. **Fix the stale doc.** `[runner].worker_count` "defaults to 4" → corrected to 16.
4. **Record the invariant** in `crates/ironclaw_host_runtime/CLAUDE.md` so a future agent does not re-introduce a divergent default or assume the scheduler is serial.

## Tests (red→green verified on the unpatched base)

- `ironclaw_host_runtime`: `default_config_uses_canonical_max_concurrent_runs` (asserts `16`; on base `Default` was `4` → **red**), plus `with_max_concurrent_runs` floor boundaries (`0→1`, `1→1`).
- `ironclaw_reborn`: `worker_count_default_matches_scheduler_default` (equals the scheduler constant and is `> 1`).
- `ironclaw_reborn_cli`: drives the **real** `runner_settings` resolver — asserts a `WARN` fires for `worker_count = 1` (removing the warn → **red**) and does **not** fire for a normal value, per "Test Through the Caller".

## Quality gate

- `cargo fmt --all` — clean.
- `cargo clippy -p ironclaw_host_runtime -p ironclaw_reborn_cli -p ironclaw_reborn -p ironclaw_reborn_config --all-targets --all-features` — **0 warnings**.
- All new/touched tests pass. (3 pre-existing `sandbox_process` tests fail locally only because no Docker daemon is present — unrelated to this diff.)

## Review

Ran the multi-agent `/code-review` skill. The strongest finding (derive the worker-count const from the scheduler const instead of duplicating the literal `16` + pinning with a test) was **applied** — it is strictly better and removes the drift failure mode entirely. The stale-doc and two test-coverage findings were also addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)