### PR TITLE
[codex] Decouple runner heartbeat timeout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -371,6 +371,7 @@ SAFETY_INJECTION_CHECK_ENABLED=true
 # IRONCLAW_REBORN_SECRET_MASTER_KEY=replace-with-independent-secret-key-material
 # IRONCLAW_REBORN_SERVE_HOST=127.0.0.1
 # IRONCLAW_REBORN_SERVE_PORT=3000
+# IRONCLAW_REBORN_RUNNER_HEARTBEAT_TIMEOUT_SECS=20   # runner heartbeat write deadline override (integer seconds, 1..=60)
 # IRONCLAW_REBORN_SLACK_ENABLED=true        # accepts 1/true to enable Slack, 0/false as a kill switch
 # IRONCLAW_REBORN_CONFIRM_HOST_ACCESS=false
 #

--- a/crates/ironclaw_host_runtime/src/turn_scheduler.rs
+++ b/crates/ironclaw_host_runtime/src/turn_scheduler.rs
@@ -28,6 +28,7 @@ pub struct TurnRunSchedulerConfig {
     poll_interval: Duration,
     lease_recovery_interval: Duration,
     runner_heartbeat_interval: Duration,
+    runner_heartbeat_timeout: Duration,
     claim_error_backoff: Duration,
     wake_channel_capacity: usize,
 }
@@ -39,6 +40,7 @@ impl Default for TurnRunSchedulerConfig {
             poll_interval: Duration::from_secs(5),
             lease_recovery_interval: Duration::from_secs(10),
             runner_heartbeat_interval: Duration::from_secs(30),
+            runner_heartbeat_timeout: Duration::from_secs(30),
             claim_error_backoff: Duration::from_secs(1),
             wake_channel_capacity: 128,
         }
@@ -70,6 +72,10 @@ impl TurnRunSchedulerConfig {
         self.runner_heartbeat_interval
     }
 
+    pub fn runner_heartbeat_timeout(&self) -> Duration {
+        self.runner_heartbeat_timeout
+    }
+
     pub fn claim_error_backoff(&self) -> Duration {
         self.claim_error_backoff
     }
@@ -95,6 +101,11 @@ impl TurnRunSchedulerConfig {
 
     pub fn with_runner_heartbeat_interval(mut self, runner_heartbeat_interval: Duration) -> Self {
         self.runner_heartbeat_interval = non_zero_duration(runner_heartbeat_interval);
+        self
+    }
+
+    pub fn with_runner_heartbeat_timeout(mut self, runner_heartbeat_timeout: Duration) -> Self {
+        self.runner_heartbeat_timeout = non_zero_duration(runner_heartbeat_timeout);
         self
     }
 
@@ -577,7 +588,7 @@ async fn drain_queued_runs(
                     Arc::clone(&context.executor),
                     context.command_tx.clone(),
                     permit,
-                    context.config.runner_heartbeat_interval(),
+                    context.config.clone(),
                     executor_tasks,
                 );
             }
@@ -601,7 +612,7 @@ fn spawn_executor_task(
     executor: Arc<dyn TurnRunExecutor>,
     command_tx: mpsc::Sender<SchedulerCommand>,
     permit: tokio::sync::OwnedSemaphorePermit,
-    runner_heartbeat_interval: Duration,
+    config: TurnRunSchedulerConfig,
     executor_tasks: &mut JoinSet<TurnRunId>,
 ) {
     // Tag every tracing event emitted while this run executes with its
@@ -631,7 +642,8 @@ fn spawn_executor_task(
                 run_id = %recovery_run_id_for_start,
                 "turn run started",
             );
-            let mut heartbeat_tick = interval(runner_heartbeat_interval);
+            let runner_heartbeat_timeout = config.runner_heartbeat_timeout();
+            let mut heartbeat_tick = interval(config.runner_heartbeat_interval());
             heartbeat_tick.set_missed_tick_behavior(MissedTickBehavior::Delay);
             // Consume the immediate first tick so the heartbeat loop never fires
             // at t=0. The run's lease was just issued and valid; a t=0 heartbeat
@@ -664,7 +676,7 @@ fn spawn_executor_task(
                             recovery_run_id,
                             recovery_runner_id,
                             recovery_lease_token,
-                            runner_heartbeat_interval,
+                            runner_heartbeat_timeout,
                         );
                     }
                     Some(heartbeat) = heartbeats.join(), if heartbeats.is_running() => {

--- a/crates/ironclaw_host_runtime/src/turn_scheduler/tests.rs
+++ b/crates/ironclaw_host_runtime/src/turn_scheduler/tests.rs
@@ -342,6 +342,22 @@ async fn heartbeat_does_not_deadlock_executor_holding_transition_lock() {
     handle.shutdown().await;
 }
 
+#[test]
+fn scheduler_config_keeps_heartbeat_interval_and_timeout_separate() {
+    let config = TurnRunSchedulerConfig::default()
+        .with_runner_heartbeat_interval(std::time::Duration::from_secs(5))
+        .with_runner_heartbeat_timeout(std::time::Duration::from_secs(20));
+
+    assert_eq!(
+        config.runner_heartbeat_interval(),
+        std::time::Duration::from_secs(5)
+    );
+    assert_eq!(
+        config.runner_heartbeat_timeout(),
+        std::time::Duration::from_secs(20)
+    );
+}
+
 /// `is_stopped()` returns `false` while the scheduler is running and the
 /// supervisor task becomes finished after `shutdown()` completes.
 ///

--- a/crates/ironclaw_host_runtime/tests/turn_scheduler_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/turn_scheduler_contract.rs
@@ -1496,7 +1496,8 @@ async fn scheduler_records_failure_when_heartbeat_call_times_out() {
         executor.clone(),
         fast_config()
             .with_poll_interval(Duration::from_secs(60))
-            .with_runner_heartbeat_interval(Duration::from_millis(10)),
+            .with_runner_heartbeat_interval(Duration::from_millis(10))
+            .with_runner_heartbeat_timeout(Duration::from_millis(25)),
     );
     let handle = scheduler.start();
     let coordinator =

--- a/crates/ironclaw_reborn/src/runtime.rs
+++ b/crates/ironclaw_reborn/src/runtime.rs
@@ -71,6 +71,13 @@ pub const DEFAULT_TURN_RUNNER_WORKER_COUNT: std::num::NonZeroUsize =
         None => std::num::NonZeroUsize::MIN,
     };
 
+pub const DEFAULT_TURN_RUNNER_HEARTBEAT_INTERVAL: std::time::Duration =
+    std::time::Duration::from_secs(5);
+pub const DEFAULT_TURN_RUNNER_HEARTBEAT_TIMEOUT: std::time::Duration =
+    std::time::Duration::from_secs(20);
+pub const MAX_TURN_RUNNER_HEARTBEAT_INTERVAL_SECS: u64 = 60;
+pub const MAX_TURN_RUNNER_HEARTBEAT_TIMEOUT_SECS: u64 = 60;
+
 /// Default per-`(tenant, ScheduledTrigger)` concurrency cap.
 ///
 /// Set below [`DEFAULT_TURN_RUNNER_WORKER_COUNT`] so background triggers can
@@ -95,6 +102,7 @@ pub const DEFAULT_MAX_CONCURRENT_RUNS_PER_USER: std::num::NonZeroU32 =
 #[derive(Debug, Clone)]
 pub struct DefaultPlannedRuntimeConfig {
     pub heartbeat_interval: std::time::Duration,
+    pub heartbeat_timeout: std::time::Duration,
     pub poll_interval: std::time::Duration,
     pub worker_count: std::num::NonZeroUsize,
     pub text_only_driver: TextOnlyModelReplyDriverConfig,
@@ -104,7 +112,8 @@ pub struct DefaultPlannedRuntimeConfig {
 impl Default for DefaultPlannedRuntimeConfig {
     fn default() -> Self {
         Self {
-            heartbeat_interval: std::time::Duration::from_secs(10),
+            heartbeat_interval: DEFAULT_TURN_RUNNER_HEARTBEAT_INTERVAL,
+            heartbeat_timeout: DEFAULT_TURN_RUNNER_HEARTBEAT_TIMEOUT,
             poll_interval: std::time::Duration::from_secs(5),
             worker_count: DEFAULT_TURN_RUNNER_WORKER_COUNT,
             text_only_driver: TextOnlyModelReplyDriverConfig::default(),
@@ -659,6 +668,7 @@ where
     let scheduler_config = TurnRunSchedulerConfig::default()
         .with_max_concurrent_runs(parts.config.worker_count.get())
         .with_runner_heartbeat_interval(parts.config.heartbeat_interval)
+        .with_runner_heartbeat_timeout(parts.config.heartbeat_timeout)
         .with_poll_interval(parts.config.poll_interval);
     let scheduler = TurnRunScheduler::new(Arc::clone(&transition_port), executor, scheduler_config);
     let scheduler_handle = wake_wiring.start(scheduler);

--- a/crates/ironclaw_reborn_cli/src/commands/config/init.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/config/init.rs
@@ -181,7 +181,13 @@ default_owner  = "reborn-cli"
 # id = "red-team"
 
 [runner]
+# How often claimed runs refresh their lease.
+# Must be in 1..=60; keep it below the 90s runner lease.
 heartbeat_interval_secs = 5
+# How long a heartbeat write may take before the runner treats it as failed.
+# Can be overridden at startup with IRONCLAW_REBORN_RUNNER_HEARTBEAT_TIMEOUT_SECS.
+# Must be in 1..=60.
+heartbeat_timeout_secs  = 20
 poll_interval_ms        = 200
 
 [skills]

--- a/crates/ironclaw_reborn_cli/src/runtime/mod.rs
+++ b/crates/ironclaw_reborn_cli/src/runtime/mod.rs
@@ -10,8 +10,9 @@ use ironclaw_reborn_composition::host_api::{AgentId, TenantId};
 #[cfg(feature = "postgres")]
 use ironclaw_reborn_composition::hosted_single_tenant_runtime_policy;
 use ironclaw_reborn_composition::{
-    CredentialRefreshSettings, DEFAULT_TURN_RUNNER_WORKER_COUNT, OAuthClientConfig,
-    OperatorLogLayer, PollSettings, RebornBuildInput, RebornCompositionProfile,
+    CredentialRefreshSettings, DEFAULT_TURN_RUNNER_WORKER_COUNT,
+    MAX_TURN_RUNNER_HEARTBEAT_INTERVAL_SECS, MAX_TURN_RUNNER_HEARTBEAT_TIMEOUT_SECS,
+    OAuthClientConfig, OperatorLogLayer, PollSettings, RebornBuildInput, RebornCompositionProfile,
     RebornLocalRuntimeProfileOptions, RebornRuntimeIdentity, RebornRuntimeInput,
     TurnRunnerSettings, build_reborn_runtime, local_runtime_build_input_with_options,
     nearai_mcp_bootstrap_config_from_env,
@@ -28,6 +29,7 @@ use secrecy::SecretString;
 use tokio_util::sync::CancellationToken;
 
 use crate::context::RebornCliContext;
+use crate::operator_env::{strict_env_var, truncate_env_value_for_display};
 
 #[cfg(test)]
 mod test_env;
@@ -933,6 +935,7 @@ fn reject_unsupported_runtime_sections(
 }
 
 const MAX_WORKER_COUNT: usize = 32;
+const RUNNER_HEARTBEAT_TIMEOUT_SECS_ENV: &str = "IRONCLAW_REBORN_RUNNER_HEARTBEAT_TIMEOUT_SECS";
 
 /// Resolve a `[runner]` concurrency cap against the in-effect default.
 ///
@@ -951,18 +954,48 @@ fn resolve_concurrency_cap(
     }
 }
 
+fn runner_bounded_duration(source: &str, secs: u64, max_secs: u64) -> anyhow::Result<Duration> {
+    if secs == 0 {
+        anyhow::bail!("{source} must be greater than 0");
+    }
+    if secs > max_secs {
+        anyhow::bail!("{source} must be in 1..={max_secs}; got {secs}");
+    }
+    Ok(Duration::from_secs(secs))
+}
+
+fn runner_heartbeat_timeout_from_env(raw: &str) -> anyhow::Result<Duration> {
+    let secs = raw.trim().parse::<u64>().map_err(|error| {
+        let display = truncate_env_value_for_display(raw);
+        anyhow::anyhow!(
+            "{RUNNER_HEARTBEAT_TIMEOUT_SECS_ENV} must be a positive integer, got {display:?}: {error}"
+        )
+    })?;
+    runner_bounded_duration(
+        RUNNER_HEARTBEAT_TIMEOUT_SECS_ENV,
+        secs,
+        MAX_TURN_RUNNER_HEARTBEAT_TIMEOUT_SECS,
+    )
+}
+
 fn runner_settings(
     config_file: Option<&ironclaw_reborn_config::RebornConfigFile>,
 ) -> anyhow::Result<TurnRunnerSettings> {
     let mut settings = TurnRunnerSettings::default();
     if let Some(runner) = config_file.and_then(|file| file.runner.as_ref()) {
         if let Some(secs) = runner.heartbeat_interval_secs {
-            if secs == 0 {
-                anyhow::bail!(
-                    "config file [runner].heartbeat_interval_secs must be greater than 0"
-                );
-            }
-            settings.heartbeat_interval = Duration::from_secs(secs);
+            settings.heartbeat_interval = runner_bounded_duration(
+                "config file [runner].heartbeat_interval_secs",
+                secs,
+                MAX_TURN_RUNNER_HEARTBEAT_INTERVAL_SECS,
+            )?;
+        }
+        if let Some(secs) = runner.heartbeat_timeout_secs {
+            settings.heartbeat_timeout = runner_bounded_duration(
+                "config file [runner].heartbeat_timeout_secs",
+                secs,
+                MAX_TURN_RUNNER_HEARTBEAT_TIMEOUT_SECS,
+            )?;
         }
         if let Some(ms) = runner.poll_interval_ms {
             if ms == 0 {
@@ -1006,27 +1039,32 @@ fn runner_settings(
             settings.max_concurrent_conversation_runs,
         );
     }
+    if let Some(raw) = strict_env_var(RUNNER_HEARTBEAT_TIMEOUT_SECS_ENV)? {
+        settings.heartbeat_timeout = runner_heartbeat_timeout_from_env(&raw)?;
+    }
     Ok(settings)
 }
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::{collections::HashMap, time::Duration};
 
     use ironclaw_reborn_composition::{
-        CredentialRefreshSettings, RebornCompositionProfile, TurnStatus,
-        test_support::assistant_reply_without_text_for_test,
+        CredentialRefreshSettings, DEFAULT_TURN_RUNNER_HEARTBEAT_INTERVAL,
+        DEFAULT_TURN_RUNNER_HEARTBEAT_TIMEOUT, MAX_TURN_RUNNER_HEARTBEAT_INTERVAL_SECS,
+        MAX_TURN_RUNNER_HEARTBEAT_TIMEOUT_SECS, RebornCompositionProfile, TurnRunnerSettings,
+        TurnStatus, test_support::assistant_reply_without_text_for_test,
     };
     #[cfg(feature = "webui-v2-beta")]
     use ironclaw_reborn_composition::{LocalTriggerAccessRole, LocalTriggerAccessSource};
     use ironclaw_reborn_config::RebornBootConfig;
 
-    use super::test_env::{EnvGuard, lock_trigger_env};
+    use super::test_env::{EnvGuard, lock_runtime_env, lock_trigger_env};
     #[cfg(feature = "webui-v2-beta")]
     use super::with_run_local_trigger_fire_access_checker;
     use super::{
-        MAX_WORKER_COUNT, RuntimeInputCaller, RuntimeInputOptions,
-        apply_credential_refresh_override, block_on_cli, build_runtime_input,
+        MAX_WORKER_COUNT, RUNNER_HEARTBEAT_TIMEOUT_SECS_ENV, RuntimeInputCaller,
+        RuntimeInputOptions, apply_credential_refresh_override, block_on_cli, build_runtime_input,
         build_runtime_input_with_options, no_assistant_text_message, protect_reborn_log_filter,
         resolve_google_oauth_config, runner_settings,
     };
@@ -1040,12 +1078,28 @@ mod tests {
         .expect("must parse")
     }
 
+    fn runner_settings_without_heartbeat_timeout_env(
+        config_file: Option<&ironclaw_reborn_config::RebornConfigFile>,
+    ) -> TurnRunnerSettings {
+        let _lock = lock_runtime_env();
+        let _heartbeat_timeout = EnvGuard::clear(RUNNER_HEARTBEAT_TIMEOUT_SECS_ENV);
+        runner_settings(config_file).expect("should succeed")
+    }
+
     #[test]
     fn runner_settings_absent_runner_gives_defaults() {
-        let settings = runner_settings(None).expect("should succeed");
+        let settings = runner_settings_without_heartbeat_timeout_env(None);
         assert_eq!(
             settings.worker_count.get(),
             DEFAULT_TURN_RUNNER_WORKER_COUNT.get()
+        );
+        assert_eq!(
+            settings.heartbeat_interval,
+            DEFAULT_TURN_RUNNER_HEARTBEAT_INTERVAL
+        );
+        assert_eq!(
+            settings.heartbeat_timeout,
+            DEFAULT_TURN_RUNNER_HEARTBEAT_TIMEOUT
         );
         // Out-of-box: per-user + trigger caps protect live chat from a
         // trigger storm; conversations stay uncapped.
@@ -1065,7 +1119,7 @@ mod tests {
         // A `[runner]` section that only tunes worker_count must NOT silently
         // wipe the protective cap defaults.
         let cfg = parse_runner_section("[runner]\nworker_count = 7\n");
-        let settings = runner_settings(Some(&cfg)).expect("should succeed");
+        let settings = runner_settings_without_heartbeat_timeout_env(Some(&cfg));
         assert_eq!(settings.worker_count.get(), 7);
         assert_eq!(
             settings.max_concurrent_runs_per_user.map(|v| v.get()),
@@ -1081,7 +1135,7 @@ mod tests {
     #[test]
     fn runner_settings_zero_worker_count_gives_default() {
         let cfg = parse_runner_section("[runner]\nworker_count = 0\n");
-        let settings = runner_settings(Some(&cfg)).expect("should succeed");
+        let settings = runner_settings_without_heartbeat_timeout_env(Some(&cfg));
         assert_eq!(
             settings.worker_count.get(),
             DEFAULT_TURN_RUNNER_WORKER_COUNT.get()
@@ -1091,7 +1145,7 @@ mod tests {
     #[test]
     fn runner_settings_present_worker_count_round_trips() {
         let cfg = parse_runner_section("[runner]\nworker_count = 7\n");
-        let settings = runner_settings(Some(&cfg)).expect("should succeed");
+        let settings = runner_settings_without_heartbeat_timeout_env(Some(&cfg));
         assert_eq!(settings.worker_count.get(), 7);
     }
 
@@ -1099,7 +1153,7 @@ mod tests {
     fn runner_settings_clamps_worker_count_at_max() {
         let toml = format!("[runner]\nworker_count = {}\n", MAX_WORKER_COUNT + 10);
         let cfg = parse_runner_section(&toml);
-        let settings = runner_settings(Some(&cfg)).expect("should succeed");
+        let settings = runner_settings_without_heartbeat_timeout_env(Some(&cfg));
         assert_eq!(settings.worker_count.get(), MAX_WORKER_COUNT);
     }
 
@@ -1108,7 +1162,7 @@ mod tests {
         let cfg = parse_runner_section(
             "[runner]\nmax_concurrent_runs_per_user = 0\nmax_concurrent_trigger_runs = 0\nmax_concurrent_conversation_runs = 0\n",
         );
-        let settings = runner_settings(Some(&cfg)).expect("should succeed");
+        let settings = runner_settings_without_heartbeat_timeout_env(Some(&cfg));
         assert!(settings.max_concurrent_runs_per_user.is_none());
         assert!(settings.max_concurrent_trigger_runs.is_none());
         assert!(settings.max_concurrent_conversation_runs.is_none());
@@ -1119,7 +1173,7 @@ mod tests {
         let cfg = parse_runner_section(
             "[runner]\nmax_concurrent_runs_per_user = 3\nmax_concurrent_trigger_runs = 5\nmax_concurrent_conversation_runs = 2\n",
         );
-        let settings = runner_settings(Some(&cfg)).expect("should succeed");
+        let settings = runner_settings_without_heartbeat_timeout_env(Some(&cfg));
         assert_eq!(
             settings.max_concurrent_runs_per_user.map(|v| v.get()),
             Some(3)
@@ -1131,6 +1185,98 @@ mod tests {
         assert_eq!(
             settings.max_concurrent_conversation_runs.map(|v| v.get()),
             Some(2)
+        );
+    }
+
+    #[test]
+    fn runner_settings_env_overrides_config_heartbeat_timeout_only() {
+        let _lock = lock_runtime_env();
+        let _heartbeat_timeout = EnvGuard::set(RUNNER_HEARTBEAT_TIMEOUT_SECS_ENV, "20");
+        let cfg = parse_runner_section(
+            "[runner]\nheartbeat_interval_secs = 5\nheartbeat_timeout_secs = 10\n",
+        );
+
+        let settings = runner_settings(Some(&cfg)).expect("should succeed");
+
+        assert_eq!(settings.heartbeat_interval, Duration::from_secs(5));
+        assert_eq!(settings.heartbeat_timeout, Duration::from_secs(20));
+    }
+
+    #[test]
+    fn runner_settings_rejects_invalid_heartbeat_env() {
+        let _lock = lock_runtime_env();
+        let _heartbeat_timeout = EnvGuard::set(RUNNER_HEARTBEAT_TIMEOUT_SECS_ENV, "10s");
+
+        let err = runner_settings(None).expect_err("invalid heartbeat env must fail loud");
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains(RUNNER_HEARTBEAT_TIMEOUT_SECS_ENV) && msg.contains("10s"),
+            "error should identify invalid heartbeat env value: {msg}"
+        );
+    }
+
+    #[test]
+    fn runner_settings_rejects_zero_heartbeat_env() {
+        let _lock = lock_runtime_env();
+        let _heartbeat_timeout = EnvGuard::set(RUNNER_HEARTBEAT_TIMEOUT_SECS_ENV, "0");
+
+        let err = runner_settings(None).expect_err("zero heartbeat env must fail loud");
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains(RUNNER_HEARTBEAT_TIMEOUT_SECS_ENV) && msg.contains("greater than 0"),
+            "error should identify zero heartbeat env value: {msg}"
+        );
+    }
+
+    #[test]
+    fn runner_settings_rejects_too_large_heartbeat_env() {
+        let _lock = lock_runtime_env();
+        let too_large = (MAX_TURN_RUNNER_HEARTBEAT_TIMEOUT_SECS + 1).to_string();
+        let _heartbeat_timeout = EnvGuard::set(RUNNER_HEARTBEAT_TIMEOUT_SECS_ENV, &too_large);
+
+        let err = runner_settings(None).expect_err("oversized heartbeat env must fail loud");
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains(RUNNER_HEARTBEAT_TIMEOUT_SECS_ENV) && msg.contains(&too_large),
+            "error should identify oversized heartbeat env value: {msg}"
+        );
+    }
+
+    #[test]
+    fn runner_settings_rejects_too_large_config_heartbeat_interval() {
+        let _lock = lock_runtime_env();
+        let _heartbeat_timeout = EnvGuard::clear(RUNNER_HEARTBEAT_TIMEOUT_SECS_ENV);
+        let too_large = MAX_TURN_RUNNER_HEARTBEAT_INTERVAL_SECS + 1;
+        let cfg = parse_runner_section(&format!(
+            "[runner]\nheartbeat_interval_secs = {too_large}\n"
+        ));
+
+        let err = runner_settings(Some(&cfg)).expect_err("oversized config heartbeat must fail");
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("heartbeat_interval_secs") && msg.contains(&too_large.to_string()),
+            "error should identify oversized config heartbeat value: {msg}"
+        );
+    }
+
+    #[test]
+    fn runner_settings_rejects_too_large_config_heartbeat_timeout() {
+        let _lock = lock_runtime_env();
+        let _heartbeat_timeout = EnvGuard::clear(RUNNER_HEARTBEAT_TIMEOUT_SECS_ENV);
+        let too_large = MAX_TURN_RUNNER_HEARTBEAT_TIMEOUT_SECS + 1;
+        let cfg =
+            parse_runner_section(&format!("[runner]\nheartbeat_timeout_secs = {too_large}\n"));
+
+        let err = runner_settings(Some(&cfg)).expect_err("oversized config heartbeat must fail");
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("heartbeat_timeout_secs") && msg.contains(&too_large.to_string()),
+            "error should identify oversized config heartbeat value: {msg}"
         );
     }
 

--- a/crates/ironclaw_reborn_cli/src/runtime/test_env.rs
+++ b/crates/ironclaw_reborn_cli/src/runtime/test_env.rs
@@ -1,22 +1,26 @@
 //! Shared test-only env-var harness for `runtime::tests` and
-//! `runtime::trigger_poller::tests`. Both modules read or mutate the
-//! `IRONCLAW_TRIGGER_POLLER_*` env vars; without a single lock + single
-//! `EnvGuard` they would race in the same test binary.
+//! `runtime::trigger_poller::tests`. Both modules read or mutate operator
+//! control env vars; without a single lock + single `EnvGuard` they would race
+//! in the same test binary.
 //!
 //! Not exposed outside `#[cfg(test)]`.
 
 use std::sync::{LazyLock, Mutex, MutexGuard};
 
-/// Serializes every test that touches `IRONCLAW_TRIGGER_*` env vars so
-/// they cannot race each other. cargo test runs tests in parallel by
-/// default; without this each env-mutating test would observe sibling
-/// tests' mutations. Held for the whole body of every env-touching test.
+/// Serializes every test that touches operator-control env vars so they cannot
+/// race each other. cargo test runs tests in parallel by default; without this
+/// each env-mutating test would observe sibling tests' mutations. Held for the
+/// whole body of every env-touching test.
 static TRIGGER_ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
 pub(super) fn lock_trigger_env() -> MutexGuard<'static, ()> {
     TRIGGER_ENV_LOCK
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+pub(super) fn lock_runtime_env() -> MutexGuard<'static, ()> {
+    lock_trigger_env()
 }
 
 /// RAII guard that snapshots an env var on construction and restores it

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -264,9 +264,10 @@ pub use runtime::{
 };
 pub use runtime_input::{
     CredentialRefreshSettings, DEFAULT_TURN_RUNNER_HEARTBEAT_INTERVAL,
-    DEFAULT_TURN_RUNNER_POLL_INTERVAL, PollSettings, RebornRuntimeIdentity, RebornRuntimeInput,
-    TriggerFireAccessCheck, TriggerFireAccessChecker, TriggerFireAccessDecision,
-    TriggerFireAccessError, TriggerPollerSettings, TurnRunnerSettings,
+    DEFAULT_TURN_RUNNER_HEARTBEAT_TIMEOUT, DEFAULT_TURN_RUNNER_POLL_INTERVAL,
+    MAX_TURN_RUNNER_HEARTBEAT_INTERVAL_SECS, MAX_TURN_RUNNER_HEARTBEAT_TIMEOUT_SECS, PollSettings,
+    RebornRuntimeIdentity, RebornRuntimeInput, TriggerFireAccessCheck, TriggerFireAccessChecker,
+    TriggerFireAccessDecision, TriggerFireAccessError, TriggerPollerSettings, TurnRunnerSettings,
 };
 #[cfg(feature = "root-llm-provider")]
 pub use runtime_input::{RebornProviderFactory, ResolvedRebornLlm};

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -2971,6 +2971,7 @@ pub async fn build_reborn_runtime(
         loop_exit_evidence,
         config: DefaultPlannedRuntimeConfig {
             heartbeat_interval: runner.heartbeat_interval,
+            heartbeat_timeout: runner.heartbeat_timeout,
             poll_interval: runner.poll_interval,
             worker_count: runner.worker_count,
             ..DefaultPlannedRuntimeConfig::default()

--- a/crates/ironclaw_reborn_composition/src/runtime_input.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime_input.rs
@@ -6,8 +6,8 @@
 //! - **LLM configuration** (optional, behind the `root-llm-provider` feature).
 //!   Used by the composition root to construct an `LlmProviderModelGateway`
 //!   that satisfies the loop-support `HostManagedModelGateway` contract.
-//! - **Turn-runner configuration** — poll/heartbeat intervals for the worker
-//!   loop.
+//! - **Turn-runner configuration** — poll interval, heartbeat cadence, and
+//!   heartbeat write timeout for the worker loop.
 //! - **Completion polling configuration** — interval/timeout policy for
 //!   waiting on submitted turns to finish.
 //! - **Runtime identity** — tenant/agent and source/reply binding identifiers
@@ -30,7 +30,11 @@ use ironclaw_loop_support::HostManagedModelGateway;
 use ironclaw_loop_support::HostSkillContextSource;
 use ironclaw_reborn::runtime::{
     DEFAULT_MAX_CONCURRENT_RUNS_PER_USER, DEFAULT_MAX_CONCURRENT_TRIGGER_RUNS,
+    DEFAULT_TURN_RUNNER_HEARTBEAT_INTERVAL as REBORN_DEFAULT_TURN_RUNNER_HEARTBEAT_INTERVAL,
+    DEFAULT_TURN_RUNNER_HEARTBEAT_TIMEOUT as REBORN_DEFAULT_TURN_RUNNER_HEARTBEAT_TIMEOUT,
     DEFAULT_TURN_RUNNER_WORKER_COUNT,
+    MAX_TURN_RUNNER_HEARTBEAT_INTERVAL_SECS as REBORN_MAX_TURN_RUNNER_HEARTBEAT_INTERVAL_SECS,
+    MAX_TURN_RUNNER_HEARTBEAT_TIMEOUT_SECS as REBORN_MAX_TURN_RUNNER_HEARTBEAT_TIMEOUT_SECS,
 };
 use ironclaw_reborn_config::BudgetDefaults;
 #[cfg(feature = "root-llm-provider")]
@@ -70,7 +74,14 @@ impl Default for RebornRuntimeIdentity {
     }
 }
 
-pub const DEFAULT_TURN_RUNNER_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
+pub const DEFAULT_TURN_RUNNER_HEARTBEAT_INTERVAL: Duration =
+    REBORN_DEFAULT_TURN_RUNNER_HEARTBEAT_INTERVAL;
+pub const DEFAULT_TURN_RUNNER_HEARTBEAT_TIMEOUT: Duration =
+    REBORN_DEFAULT_TURN_RUNNER_HEARTBEAT_TIMEOUT;
+pub const MAX_TURN_RUNNER_HEARTBEAT_INTERVAL_SECS: u64 =
+    REBORN_MAX_TURN_RUNNER_HEARTBEAT_INTERVAL_SECS;
+pub const MAX_TURN_RUNNER_HEARTBEAT_TIMEOUT_SECS: u64 =
+    REBORN_MAX_TURN_RUNNER_HEARTBEAT_TIMEOUT_SECS;
 pub const DEFAULT_TURN_RUNNER_POLL_INTERVAL: Duration = Duration::from_millis(200);
 
 /// Fire-time access request for a persisted trigger.
@@ -200,6 +211,7 @@ impl ResolvedRebornLlm {
 #[derive(Debug, Clone)]
 pub struct TurnRunnerSettings {
     pub heartbeat_interval: Duration,
+    pub heartbeat_timeout: Duration,
     pub poll_interval: Duration,
     /// Number of concurrent turn-runner worker tasks.
     pub worker_count: std::num::NonZeroUsize,
@@ -218,6 +230,7 @@ impl Default for TurnRunnerSettings {
     fn default() -> Self {
         Self {
             heartbeat_interval: DEFAULT_TURN_RUNNER_HEARTBEAT_INTERVAL,
+            heartbeat_timeout: DEFAULT_TURN_RUNNER_HEARTBEAT_TIMEOUT,
             poll_interval: DEFAULT_TURN_RUNNER_POLL_INTERVAL,
             worker_count: DEFAULT_TURN_RUNNER_WORKER_COUNT,
             max_concurrent_runs_per_user: Some(DEFAULT_MAX_CONCURRENT_RUNS_PER_USER),

--- a/crates/ironclaw_reborn_config/src/config_file.rs
+++ b/crates/ironclaw_reborn_config/src/config_file.rs
@@ -154,6 +154,7 @@ pub struct HarnessSection {
 #[serde(deny_unknown_fields)]
 pub struct RunnerSection {
     pub heartbeat_interval_secs: Option<u64>,
+    pub heartbeat_timeout_secs: Option<u64>,
     pub poll_interval_ms: Option<u64>,
     /// Number of concurrent turn-runner worker tasks. `None` or `0` defaults to 4. Clamped to 32.
     pub worker_count: Option<usize>,
@@ -1145,6 +1146,7 @@ mod tests {
         let toml = r#"
 [runner]
 heartbeat_interval_secs = 10
+heartbeat_timeout_secs = 20
 poll_interval_ms = 100
 worker_count = 3
 max_concurrent_runs_per_user = 2
@@ -1154,6 +1156,7 @@ max_concurrent_conversation_runs = 4
         let cfg = RebornConfigFile::parse_text(toml, &attributed()).expect("must parse");
         let runner = cfg.runner.as_ref().expect("runner section present");
         assert_eq!(runner.heartbeat_interval_secs, Some(10));
+        assert_eq!(runner.heartbeat_timeout_secs, Some(20));
         assert_eq!(runner.poll_interval_ms, Some(100));
         assert_eq!(runner.worker_count, Some(3));
         assert_eq!(runner.max_concurrent_runs_per_user, Some(2));
@@ -1179,6 +1182,7 @@ max_concurrent_conversation_runs = 5
         let cfg = RebornConfigFile::parse_text(toml, &attributed()).expect("must parse");
         let runner = cfg.runner.as_ref().expect("runner section present");
         assert_eq!(runner.heartbeat_interval_secs, None);
+        assert_eq!(runner.heartbeat_timeout_secs, None);
         assert_eq!(runner.poll_interval_ms, None);
         assert_eq!(runner.worker_count, Some(8));
         assert_eq!(runner.max_concurrent_runs_per_user, Some(1));
@@ -1213,6 +1217,7 @@ id = "red-team"
 
 [runner]
 heartbeat_interval_secs = 5
+heartbeat_timeout_secs = 20
 poll_interval_ms = 200
 
 [skills]

--- a/docker/reborn/config.hosted-single-tenant.toml
+++ b/docker/reborn/config.hosted-single-tenant.toml
@@ -9,7 +9,13 @@ tenant = "reborn-cli"
 default_agent = "reborn-cli-agent"
 
 [runner]
+# How often claimed runs refresh their lease.
+# Must be in 1..=60; keep it below the 90s runner lease.
 heartbeat_interval_secs = 5
+# How long a heartbeat write may take before the runner treats it as failed.
+# Can be overridden at startup with IRONCLAW_REBORN_RUNNER_HEARTBEAT_TIMEOUT_SECS.
+# Must be in 1..=60.
+heartbeat_timeout_secs = 20
 poll_interval_ms = 200
 
 [skills]

--- a/docker/reborn/config.production.toml
+++ b/docker/reborn/config.production.toml
@@ -13,7 +13,13 @@ deployment_mode = "hosted_multi_tenant"
 default_profile = "secure_default"
 
 [runner]
+# How often claimed runs refresh their lease.
+# Must be in 1..=60; keep it below the 90s runner lease.
 heartbeat_interval_secs = 5
+# How long a heartbeat write may take before the runner treats it as failed.
+# Can be overridden at startup with IRONCLAW_REBORN_RUNNER_HEARTBEAT_TIMEOUT_SECS.
+# Must be in 1..=60.
+heartbeat_timeout_secs = 20
 poll_interval_ms = 200
 # Number of concurrent turn-runner worker tasks (default 4; clamped to 32).
 # worker_count = 4

--- a/docker/reborn/config.toml
+++ b/docker/reborn/config.toml
@@ -9,7 +9,13 @@ tenant = "reborn-cli"
 default_agent = "reborn-cli-agent"
 
 [runner]
+# How often claimed runs refresh their lease.
+# Must be in 1..=60; keep it below the 90s runner lease.
 heartbeat_interval_secs = 5
+# How long a heartbeat write may take before the runner treats it as failed.
+# Can be overridden at startup with IRONCLAW_REBORN_RUNNER_HEARTBEAT_TIMEOUT_SECS.
+# Must be in 1..=60.
+heartbeat_timeout_secs = 20
 poll_interval_ms = 200
 # Number of concurrent turn-runner worker tasks (default 4; clamped to 32).
 # worker_count = 4

--- a/docs/reborn/deploy-reborn-cli-docker.md
+++ b/docs/reborn/deploy-reborn-cli-docker.md
@@ -36,6 +36,7 @@ IRONCLAW_REBORN_SERVE_PORT=3000
 IRONCLAW_REBORN_PROFILE=local-dev
 IRONCLAW_REBORN_WEBUI_TOKEN=<random-hex-32-bytes-or-longer>
 IRONCLAW_REBORN_WEBUI_USER_ID=reborn-cli
+IRONCLAW_REBORN_RUNNER_HEARTBEAT_TIMEOUT_SECS=20
 NEARAI_BASE_URL=https://cloud-api.near.ai
 NEARAI_API_KEY=<nearai-api-key>
 ```
@@ -43,6 +44,10 @@ NEARAI_API_KEY=<nearai-api-key>
 The bundled Docker config selects NearAI in `[llm.default]`; set
 `NEARAI_API_KEY` for that provider. To change provider or model, mount a custom
 config and point `IRONCLAW_REBORN_DEFAULT_CONFIG` at it for the first start.
+`IRONCLAW_REBORN_RUNNER_HEARTBEAT_TIMEOUT_SECS` overrides
+`[runner].heartbeat_timeout_secs` at startup; use it to raise the runner
+heartbeat write deadline on already-seeded deployments without slowing the
+heartbeat cadence. Values must be integer seconds in `1..=60`.
 
 Google product-auth setup:
 


### PR DESCRIPTION
## Summary

Decouples the runner heartbeat cadence from the heartbeat write timeout so slow turn-state writes do not force operators to slow down heartbeat reporting.

## Root Cause

The scheduler used `runner_heartbeat_interval` for both the tick cadence and the `tokio::time::timeout` around the heartbeat write. Raising the interval from 5s to avoid false `scheduler_heartbeat_failed` failures also reduced heartbeat freshness.

## Changes

- Adds a separate `runner_heartbeat_timeout` through host runtime, Reborn runtime config, composition settings, and CLI config parsing.
- Keeps the default heartbeat cadence at 5s and sets the default heartbeat write timeout to 20s.
- Adds `[runner].heartbeat_timeout_secs` and startup override `IRONCLAW_REBORN_RUNNER_HEARTBEAT_TIMEOUT_SECS`.
- Updates Docker configs, seeded config, `.env.example`, and deployment docs.
- Adds regression coverage for separated scheduler config and CLI env/config validation.

## Validation

- `cargo fmt --all`
- `cargo test -p ironclaw_reborn_cli runner_settings -- --nocapture`
- `cargo test -p ironclaw_host_runtime scheduler_config_keeps_heartbeat_interval_and_timeout_separate -- --nocapture`
- `cargo test -p ironclaw_reborn_config runner_section_new_fields_round_trip -- --nocapture`
- `cargo test -p ironclaw_reborn_config full_file_round_trips -- --nocapture`
- `cargo test -p ironclaw_reborn_composition --test runtime --no-run`
- `cargo test -p ironclaw_reborn --test loop_driver_host --no-run`
- `git diff --check origin/main...HEAD`
