### PR TITLE
[codex] Persist hosted trigger access via filesystem

### DIFF
--- a/crates/ironclaw_reborn/Cargo.toml
+++ b/crates/ironclaw_reborn/Cargo.toml
@@ -27,6 +27,7 @@ filesystem-goal-store = ["dep:ironclaw_filesystem"]
 # filesystem identity resolver, so this feature now only gates the
 # `local_trigger_access` module.
 webui-user-store = ["dep:libsql"]
+filesystem-local-trigger-access = ["dep:ironclaw_filesystem"]
 # Opt-in because the restart coverage opens real libSQL-backed turn/thread stores.
 # Keep separate from `libsql-secrets` so local `cargo test -p ironclaw_reborn`
 # stays fast, while CI can exercise process-restart persistence explicitly.

--- a/crates/ironclaw_reborn/src/lib.rs
+++ b/crates/ironclaw_reborn/src/lib.rs
@@ -20,7 +20,10 @@ pub mod app_loop_family;
 pub mod driver_registry;
 pub mod failure_categories;
 pub mod hook_gate_refs;
-#[cfg(feature = "webui-user-store")]
+#[cfg(any(
+    feature = "webui-user-store",
+    feature = "filesystem-local-trigger-access"
+))]
 pub mod local_trigger_access;
 pub mod loop_driver_host;
 pub mod loop_exit_applier;

--- a/crates/ironclaw_reborn/src/local_trigger_access/filesystem.rs
+++ b/crates/ironclaw_reborn/src/local_trigger_access/filesystem.rs
@@ -3,7 +3,8 @@ use std::sync::Arc;
 
 use chrono::{SecondsFormat, Utc};
 use ironclaw_filesystem::{
-    CasExpectation, ContentType, Entry, FileType, FilesystemError, RootFilesystem, ScopedFilesystem,
+    CasExpectation, Entry, FilesystemError, Filter, IndexKey, IndexKind, IndexName, IndexSpec,
+    IndexValue, Page, RecordKind, RootFilesystem, ScopedFilesystem, VersionedEntry,
 };
 use ironclaw_host_api::{
     AgentId, InvocationId, ProjectId, ResourceScope, ScopedPath, TenantId, UserId,
@@ -11,8 +12,9 @@ use ironclaw_host_api::{
 use serde::{Deserialize, Serialize};
 
 use super::types::{
-    LocalTriggerAccessReconciliation, LocalTriggerAccessSeed, LocalTriggerAccessSource,
-    LocalTriggerAccessStatus, LocalTriggerAccessStore, RebornLocalTriggerAccessStoreError, backend,
+    LocalTriggerAccessReconciliation, LocalTriggerAccessRole, LocalTriggerAccessSeed,
+    LocalTriggerAccessSource, LocalTriggerAccessStatus, LocalTriggerAccessStore,
+    RebornLocalTriggerAccessStoreError, backend, optional_scope_key,
 };
 
 /// Filesystem-backed local trigger access repository.
@@ -29,11 +31,19 @@ struct FilesystemLocalTriggerAccessRecord {
     user_id: String,
     agent_id: Option<String>,
     project_id: Option<String>,
-    role: String,
-    status: String,
-    source: String,
+    role: LocalTriggerAccessRole,
+    status: LocalTriggerAccessStatus,
+    source: LocalTriggerAccessSource,
     created_at: String,
     updated_at: String,
+}
+
+struct FilesystemReconciliationContext<'a> {
+    tenant_id: &'a TenantId,
+    agent_id: Option<&'a AgentId>,
+    project_id: Option<&'a ProjectId>,
+    source: LocalTriggerAccessSource,
+    allowed: &'a BTreeSet<String>,
 }
 
 impl<F> RebornFilesystemLocalTriggerAccessStore<F>
@@ -50,8 +60,38 @@ where
     fn record_entry(
         record: &FilesystemLocalTriggerAccessRecord,
     ) -> Result<Entry, RebornLocalTriggerAccessStoreError> {
-        let body = serde_json::to_vec_pretty(record).map_err(backend)?;
-        Ok(Entry::bytes(body).with_content_type(ContentType::json()))
+        let body = serde_json::to_value(record).map_err(backend)?;
+        let entry = Entry::record(trigger_access_record_kind()?, &body)
+            .map_err(backend)?
+            .with_indexed(
+                index_key_tenant_id()?,
+                IndexValue::Text(record.tenant_id.clone()),
+            )
+            .with_indexed(
+                index_key_user_id()?,
+                IndexValue::Text(record.user_id.clone()),
+            )
+            .with_indexed(
+                index_key_agent_id()?,
+                IndexValue::Text(optional_scope_key(record.agent_id.as_deref()).to_string()),
+            )
+            .with_indexed(
+                index_key_project_id()?,
+                IndexValue::Text(optional_scope_key(record.project_id.as_deref()).to_string()),
+            )
+            .with_indexed(
+                index_key_role()?,
+                IndexValue::Text(record.role.as_str().to_string()),
+            )
+            .with_indexed(
+                index_key_status()?,
+                IndexValue::Text(record.status.as_str().to_string()),
+            )
+            .with_indexed(
+                index_key_source()?,
+                IndexValue::Text(record.source.as_str().to_string()),
+            );
+        Ok(entry)
     }
 
     async fn read_record(
@@ -91,27 +131,33 @@ where
 
     async fn deactivate_stale_record(
         &self,
-        tenant_id: &TenantId,
+        context: &FilesystemReconciliationContext<'_>,
         path: &ScopedPath,
         user_id: &UserId,
-        agent_id: Option<&AgentId>,
-        project_id: Option<&ProjectId>,
-        source: LocalTriggerAccessSource,
-        allowed: &BTreeSet<&str>,
     ) -> Result<(), RebornLocalTriggerAccessStoreError> {
-        let scope = tenant_shared_scope(tenant_id, user_id, agent_id, project_id);
+        let scope = tenant_shared_scope(
+            context.tenant_id,
+            user_id,
+            context.agent_id,
+            context.project_id,
+        );
         for _ in 0..FILESYSTEM_CAS_RETRIES {
             let Some((mut record, version)) = self.read_record(&scope, path).await? else {
                 return Ok(());
             };
-            if !record_matches_scope(&record, tenant_id, user_id, agent_id, project_id)
-                || record.source != source.as_str()
-                || record.status != LocalTriggerAccessStatus::Active.as_str()
-                || allowed.contains(record.user_id.as_str())
+            if !record_matches_scope(
+                &record,
+                context.tenant_id,
+                user_id,
+                context.agent_id,
+                context.project_id,
+            ) || record.source != context.source
+                || record.status != LocalTriggerAccessStatus::Active
+                || context.allowed.contains(record.user_id.as_str())
             {
                 return Ok(());
             }
-            record.status = LocalTriggerAccessStatus::Inactive.as_str().to_string();
+            record.status = LocalTriggerAccessStatus::Inactive;
             record.updated_at = Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true);
             match self
                 .put_record(&scope, path, &record, CasExpectation::Version(version))
@@ -126,6 +172,67 @@ where
             "filesystem CAS retries exhausted for path {}",
             path.as_str()
         )))
+    }
+
+    async fn ensure_reconciliation_indexes(
+        &self,
+        scope: &ResourceScope,
+        users_root: &ScopedPath,
+    ) -> Result<(), RebornLocalTriggerAccessStoreError> {
+        self.ensure_exact_index(scope, users_root, index_name_source()?, index_key_source()?)
+            .await?;
+        self.ensure_exact_index(scope, users_root, index_name_status()?, index_key_status()?)
+            .await?;
+        Ok(())
+    }
+
+    async fn ensure_exact_index(
+        &self,
+        scope: &ResourceScope,
+        prefix: &ScopedPath,
+        name: IndexName,
+        key: IndexKey,
+    ) -> Result<(), RebornLocalTriggerAccessStoreError> {
+        let spec = IndexSpec::new(name, vec![key], IndexKind::Exact);
+        match self.filesystem.ensure_index(scope, prefix, &spec).await {
+            Ok(()) => Ok(()),
+            Err(FilesystemError::Unsupported { .. }) => Ok(()),
+            Err(error) => Err(backend(error)),
+        }
+    }
+
+    async fn query_active_reconciliation_records(
+        &self,
+        scope: &ResourceScope,
+        users_root: &ScopedPath,
+        source: LocalTriggerAccessSource,
+    ) -> Result<Vec<FilesystemLocalTriggerAccessRecord>, RebornLocalTriggerAccessStoreError> {
+        self.ensure_reconciliation_indexes(scope, users_root)
+            .await?;
+        let filter = active_reconciliation_filter(source)?;
+        let mut records = Vec::new();
+        let mut offset = 0;
+        loop {
+            let page = Page::new(offset, Page::MAX_LIMIT);
+            let entries = match self
+                .filesystem
+                .query(scope, users_root, &filter, page)
+                .await
+            {
+                Ok(entries) => entries,
+                Err(error) if is_not_found(&error) => return Ok(records),
+                Err(error) => return Err(backend(error)),
+            };
+            let received = entries.len();
+            for entry in entries {
+                records.push(deserialize_query_record(entry)?);
+            }
+            if received < Page::MAX_LIMIT as usize {
+                break;
+            }
+            offset = offset.saturating_add(received as u64);
+        }
+        Ok(records)
     }
 
     /// Seed the local trigger access row used by Reborn-owned fire-time trigger
@@ -147,9 +254,9 @@ where
             project_id: seed
                 .project_id
                 .map(|project_id| project_id.as_str().to_string()),
-            role: seed.role.as_str().to_string(),
-            status: LocalTriggerAccessStatus::Active.as_str().to_string(),
-            source: seed.source.as_str().to_string(),
+            role: seed.role,
+            status: LocalTriggerAccessStatus::Active,
+            source: seed.source,
             created_at: now.clone(),
             updated_at: now,
         };
@@ -168,7 +275,11 @@ where
         &self,
         reconciliation: LocalTriggerAccessReconciliation<'_>,
     ) -> Result<(), RebornLocalTriggerAccessStoreError> {
-        let allowed: BTreeSet<&str> = reconciliation.user_ids.iter().map(UserId::as_str).collect();
+        let allowed: BTreeSet<String> = reconciliation
+            .user_ids
+            .iter()
+            .map(|user_id| user_id.as_str().to_string())
+            .collect();
         let bootstrap_user = match reconciliation.user_ids.first() {
             Some(user_id) => user_id.clone(),
             None => trigger_access_bootstrap_user_id()?,
@@ -181,29 +292,24 @@ where
         );
         let users_root =
             access_scope_users_root(reconciliation.agent_id, reconciliation.project_id)?;
-        let entries = match self.filesystem.list_dir(&scope, &users_root).await {
-            Ok(entries) => entries,
-            Err(error) if is_not_found(&error) => Vec::new(),
-            Err(error) => return Err(backend(error)),
+        let context = FilesystemReconciliationContext {
+            tenant_id: reconciliation.tenant_id,
+            agent_id: reconciliation.agent_id,
+            project_id: reconciliation.project_id,
+            source: reconciliation.source,
+            allowed: &allowed,
         };
-        for entry in entries {
-            if entry.file_type != FileType::File || !entry.name.ends_with(".json") {
+        let records = self
+            .query_active_reconciliation_records(&scope, &users_root, reconciliation.source)
+            .await?;
+        for record in records {
+            let Ok(user_id) = UserId::new(record.user_id.clone()) else {
                 continue;
-            }
-            let user_key = entry.name.trim_end_matches(".json");
-            let user_id = UserId::new(user_key.to_string()).map_err(backend)?;
+            };
             let path =
                 access_record_path(reconciliation.agent_id, reconciliation.project_id, &user_id)?;
-            self.deactivate_stale_record(
-                reconciliation.tenant_id,
-                &path,
-                &user_id,
-                reconciliation.agent_id,
-                reconciliation.project_id,
-                reconciliation.source,
-                &allowed,
-            )
-            .await?;
+            self.deactivate_stale_record(&context, &path, &user_id)
+                .await?;
         }
 
         for user_id in reconciliation.user_ids {
@@ -236,11 +342,12 @@ where
         };
         Ok(
             record_matches_scope(&record, tenant_id, user_id, agent_id, project_id)
-                && record.status == LocalTriggerAccessStatus::Active.as_str(),
+                && record.status == LocalTriggerAccessStatus::Active,
         )
     }
 }
 
+#[derive(Debug)]
 enum FilesystemAccessPutError {
     VersionMismatch,
     Other(RebornLocalTriggerAccessStoreError),
@@ -248,6 +355,16 @@ enum FilesystemAccessPutError {
 
 const FILESYSTEM_CAS_RETRIES: usize = 8;
 const TRIGGER_ACCESS_ROOT: &str = "/tenant-shared/reborn-trigger-access";
+const TRIGGER_ACCESS_RECORD_KIND: &str = "reborn_trigger_access";
+const TRIGGER_ACCESS_SOURCE_INDEX_NAME: &str = "reborn_trigger_access_source";
+const TRIGGER_ACCESS_STATUS_INDEX_NAME: &str = "reborn_trigger_access_status";
+const TENANT_ID_INDEX_KEY: &str = "tenant_id";
+const USER_ID_INDEX_KEY: &str = "user_id";
+const AGENT_ID_INDEX_KEY: &str = "agent_id";
+const PROJECT_ID_INDEX_KEY: &str = "project_id";
+const ROLE_INDEX_KEY: &str = "role";
+const STATUS_INDEX_KEY: &str = "status";
+const SOURCE_INDEX_KEY: &str = "source";
 
 fn tenant_shared_scope(
     tenant_id: &TenantId,
@@ -316,6 +433,75 @@ fn record_matches_scope(
         && record.project_id.as_deref() == project_id.map(ProjectId::as_str)
 }
 
+fn deserialize_query_record(
+    entry: VersionedEntry,
+) -> Result<FilesystemLocalTriggerAccessRecord, RebornLocalTriggerAccessStoreError> {
+    serde_json::from_slice(&entry.entry.body).map_err(backend)
+}
+
+fn active_reconciliation_filter(
+    source: LocalTriggerAccessSource,
+) -> Result<Filter, RebornLocalTriggerAccessStoreError> {
+    Ok(Filter::And(vec![
+        Filter::Eq {
+            key: index_key_source()?,
+            value: IndexValue::Text(source.as_str().to_string()),
+        },
+        Filter::Eq {
+            key: index_key_status()?,
+            value: IndexValue::Text(LocalTriggerAccessStatus::Active.as_str().to_string()),
+        },
+    ]))
+}
+
+fn trigger_access_record_kind() -> Result<RecordKind, RebornLocalTriggerAccessStoreError> {
+    RecordKind::new(TRIGGER_ACCESS_RECORD_KIND).map_err(backend)
+}
+
+fn index_name(value: &'static str) -> Result<IndexName, RebornLocalTriggerAccessStoreError> {
+    IndexName::new(value).map_err(backend)
+}
+
+fn index_key(value: &'static str) -> Result<IndexKey, RebornLocalTriggerAccessStoreError> {
+    IndexKey::new(value).map_err(backend)
+}
+
+fn index_name_source() -> Result<IndexName, RebornLocalTriggerAccessStoreError> {
+    index_name(TRIGGER_ACCESS_SOURCE_INDEX_NAME)
+}
+
+fn index_name_status() -> Result<IndexName, RebornLocalTriggerAccessStoreError> {
+    index_name(TRIGGER_ACCESS_STATUS_INDEX_NAME)
+}
+
+fn index_key_tenant_id() -> Result<IndexKey, RebornLocalTriggerAccessStoreError> {
+    index_key(TENANT_ID_INDEX_KEY)
+}
+
+fn index_key_user_id() -> Result<IndexKey, RebornLocalTriggerAccessStoreError> {
+    index_key(USER_ID_INDEX_KEY)
+}
+
+fn index_key_agent_id() -> Result<IndexKey, RebornLocalTriggerAccessStoreError> {
+    index_key(AGENT_ID_INDEX_KEY)
+}
+
+fn index_key_project_id() -> Result<IndexKey, RebornLocalTriggerAccessStoreError> {
+    index_key(PROJECT_ID_INDEX_KEY)
+}
+
+fn index_key_role() -> Result<IndexKey, RebornLocalTriggerAccessStoreError> {
+    index_key(ROLE_INDEX_KEY)
+}
+
+fn index_key_status() -> Result<IndexKey, RebornLocalTriggerAccessStoreError> {
+    index_key(STATUS_INDEX_KEY)
+}
+
+fn index_key_source() -> Result<IndexKey, RebornLocalTriggerAccessStoreError> {
+    index_key(SOURCE_INDEX_KEY)
+}
+
 fn is_not_found(error: &FilesystemError) -> bool {
     matches!(error, FilesystemError::NotFound { .. })
 }
@@ -377,7 +563,7 @@ mod tests {
         let store = store();
         let tenant_id = TenantId::new("fs-trigger-tenant").expect("tenant id");
         let user_id = UserId::new("fs-trigger-user").expect("user id");
-        let stale_user_id = UserId::new("fs-trigger-stale").expect("stale user id");
+        let stale_user_id = UserId::new("fs-trigger-stale.json").expect("stale user id");
         let agent_id = AgentId::new("fs-trigger-agent").expect("agent id");
         let project_id = ProjectId::new("fs-trigger-project").expect("project id");
         let other_project_id = ProjectId::new("fs-trigger-other-project").expect("project id");
@@ -436,6 +622,72 @@ mod tests {
                 .await
                 .expect("check stale local access"),
             "reconciliation deactivates stale filesystem records for the same source"
+        );
+    }
+
+    #[tokio::test]
+    async fn filesystem_store_reconcile_skips_invalid_indexed_user_id() {
+        let store = store();
+        let tenant_id = TenantId::new("fs-trigger-tenant").expect("tenant id");
+        let valid_user_id = UserId::new("fs-trigger-user").expect("user id");
+        let agent_id = AgentId::new("fs-trigger-agent").expect("agent id");
+        let project_id = ProjectId::new("fs-trigger-project").expect("project id");
+        let scope = tenant_shared_scope(
+            &tenant_id,
+            &valid_user_id,
+            Some(&agent_id),
+            Some(&project_id),
+        );
+        let users_root =
+            access_scope_users_root(Some(&agent_id), Some(&project_id)).expect("access users root");
+        let malformed_path = ScopedPath::new(format!("{}/malformed.json", users_root.as_str()))
+            .expect("malformed record path");
+        let now = Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true);
+        let malformed_record = FilesystemLocalTriggerAccessRecord {
+            tenant_id: tenant_id.as_str().to_string(),
+            user_id: "bad/user".to_string(),
+            agent_id: Some(agent_id.as_str().to_string()),
+            project_id: Some(project_id.as_str().to_string()),
+            role: LocalTriggerAccessRole::Owner,
+            status: LocalTriggerAccessStatus::Active,
+            source: LocalTriggerAccessSource::LocalDevEnvBootstrap,
+            created_at: now.clone(),
+            updated_at: now,
+        };
+
+        store
+            .put_record(
+                &scope,
+                &malformed_path,
+                &malformed_record,
+                CasExpectation::Absent,
+            )
+            .await
+            .expect("seed malformed indexed access record");
+
+        store
+            .reconcile_local_access(LocalTriggerAccessReconciliation {
+                tenant_id: &tenant_id,
+                user_ids: std::slice::from_ref(&valid_user_id),
+                agent_id: Some(&agent_id),
+                project_id: Some(&project_id),
+                role: LocalTriggerAccessRole::Owner,
+                source: LocalTriggerAccessSource::LocalDevEnvBootstrap,
+            })
+            .await
+            .expect("invalid indexed user id should not abort reconciliation");
+
+        assert!(
+            store
+                .has_active_local_access(
+                    &tenant_id,
+                    &valid_user_id,
+                    Some(&agent_id),
+                    Some(&project_id),
+                )
+                .await
+                .expect("check valid local access"),
+            "reconciliation still seeds valid users when one indexed record is malformed"
         );
     }
 }

--- a/crates/ironclaw_reborn/src/local_trigger_access/filesystem.rs
+++ b/crates/ironclaw_reborn/src/local_trigger_access/filesystem.rs
@@ -1,0 +1,441 @@
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
+use chrono::{SecondsFormat, Utc};
+use ironclaw_filesystem::{
+    CasExpectation, ContentType, Entry, FileType, FilesystemError, RootFilesystem, ScopedFilesystem,
+};
+use ironclaw_host_api::{
+    AgentId, InvocationId, ProjectId, ResourceScope, ScopedPath, TenantId, UserId,
+};
+use serde::{Deserialize, Serialize};
+
+use super::types::{
+    LocalTriggerAccessReconciliation, LocalTriggerAccessSeed, LocalTriggerAccessSource,
+    LocalTriggerAccessStatus, LocalTriggerAccessStore, RebornLocalTriggerAccessStoreError, backend,
+};
+
+/// Filesystem-backed local trigger access repository.
+pub struct RebornFilesystemLocalTriggerAccessStore<F>
+where
+    F: RootFilesystem + 'static,
+{
+    filesystem: Arc<ScopedFilesystem<F>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct FilesystemLocalTriggerAccessRecord {
+    tenant_id: String,
+    user_id: String,
+    agent_id: Option<String>,
+    project_id: Option<String>,
+    role: String,
+    status: String,
+    source: String,
+    created_at: String,
+    updated_at: String,
+}
+
+impl<F> RebornFilesystemLocalTriggerAccessStore<F>
+where
+    F: RootFilesystem + 'static,
+{
+    /// Build a store over the host filesystem abstraction. The root
+    /// filesystem backend has already run its own migrations at composition
+    /// time; this store owns only JSON record shapes and scoped paths.
+    pub fn new(filesystem: Arc<ScopedFilesystem<F>>) -> Self {
+        Self { filesystem }
+    }
+
+    fn record_entry(
+        record: &FilesystemLocalTriggerAccessRecord,
+    ) -> Result<Entry, RebornLocalTriggerAccessStoreError> {
+        let body = serde_json::to_vec_pretty(record).map_err(backend)?;
+        Ok(Entry::bytes(body).with_content_type(ContentType::json()))
+    }
+
+    async fn read_record(
+        &self,
+        scope: &ResourceScope,
+        path: &ScopedPath,
+    ) -> Result<
+        Option<(
+            FilesystemLocalTriggerAccessRecord,
+            ironclaw_filesystem::RecordVersion,
+        )>,
+        RebornLocalTriggerAccessStoreError,
+    > {
+        let Some(versioned) = self.filesystem.get(scope, path).await.map_err(backend)? else {
+            return Ok(None);
+        };
+        let record = serde_json::from_slice(&versioned.entry.body).map_err(backend)?;
+        Ok(Some((record, versioned.version)))
+    }
+
+    async fn put_record(
+        &self,
+        scope: &ResourceScope,
+        path: &ScopedPath,
+        record: &FilesystemLocalTriggerAccessRecord,
+        cas: CasExpectation,
+    ) -> Result<(), FilesystemAccessPutError> {
+        let entry = Self::record_entry(record).map_err(FilesystemAccessPutError::Other)?;
+        match self.filesystem.put(scope, path, entry, cas).await {
+            Ok(_) => Ok(()),
+            Err(FilesystemError::VersionMismatch { .. }) => {
+                Err(FilesystemAccessPutError::VersionMismatch)
+            }
+            Err(error) => Err(FilesystemAccessPutError::Other(backend(error))),
+        }
+    }
+
+    async fn deactivate_stale_record(
+        &self,
+        tenant_id: &TenantId,
+        path: &ScopedPath,
+        user_id: &UserId,
+        agent_id: Option<&AgentId>,
+        project_id: Option<&ProjectId>,
+        source: LocalTriggerAccessSource,
+        allowed: &BTreeSet<&str>,
+    ) -> Result<(), RebornLocalTriggerAccessStoreError> {
+        let scope = tenant_shared_scope(tenant_id, user_id, agent_id, project_id);
+        for _ in 0..FILESYSTEM_CAS_RETRIES {
+            let Some((mut record, version)) = self.read_record(&scope, path).await? else {
+                return Ok(());
+            };
+            if !record_matches_scope(&record, tenant_id, user_id, agent_id, project_id)
+                || record.source != source.as_str()
+                || record.status != LocalTriggerAccessStatus::Active.as_str()
+                || allowed.contains(record.user_id.as_str())
+            {
+                return Ok(());
+            }
+            record.status = LocalTriggerAccessStatus::Inactive.as_str().to_string();
+            record.updated_at = Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true);
+            match self
+                .put_record(&scope, path, &record, CasExpectation::Version(version))
+                .await
+            {
+                Ok(()) => return Ok(()),
+                Err(FilesystemAccessPutError::VersionMismatch) => continue,
+                Err(FilesystemAccessPutError::Other(error)) => return Err(error),
+            }
+        }
+        Err(backend(format!(
+            "filesystem CAS retries exhausted for path {}",
+            path.as_str()
+        )))
+    }
+
+    /// Seed the local trigger access row used by Reborn-owned fire-time trigger
+    /// authorization. Existing rows are left untouched so an operator can
+    /// revoke or edit access without the next boot or login silently
+    /// re-granting it.
+    pub async fn seed_local_access(
+        &self,
+        seed: LocalTriggerAccessSeed<'_>,
+    ) -> Result<(), RebornLocalTriggerAccessStoreError> {
+        let scope =
+            tenant_shared_scope(seed.tenant_id, seed.user_id, seed.agent_id, seed.project_id);
+        let path = access_record_path(seed.agent_id, seed.project_id, seed.user_id)?;
+        let now = Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true);
+        let record = FilesystemLocalTriggerAccessRecord {
+            tenant_id: seed.tenant_id.as_str().to_string(),
+            user_id: seed.user_id.as_str().to_string(),
+            agent_id: seed.agent_id.map(|agent_id| agent_id.as_str().to_string()),
+            project_id: seed
+                .project_id
+                .map(|project_id| project_id.as_str().to_string()),
+            role: seed.role.as_str().to_string(),
+            status: LocalTriggerAccessStatus::Active.as_str().to_string(),
+            source: seed.source.as_str().to_string(),
+            created_at: now.clone(),
+            updated_at: now,
+        };
+        match self
+            .put_record(&scope, &path, &record, CasExpectation::Absent)
+            .await
+        {
+            Ok(()) => Ok(()),
+            Err(FilesystemAccessPutError::VersionMismatch) => Ok(()),
+            Err(FilesystemAccessPutError::Other(error)) => Err(error),
+        }
+    }
+
+    /// Reconcile bootstrap-owned local trigger access rows for one exact scope.
+    pub async fn reconcile_local_access(
+        &self,
+        reconciliation: LocalTriggerAccessReconciliation<'_>,
+    ) -> Result<(), RebornLocalTriggerAccessStoreError> {
+        let allowed: BTreeSet<&str> = reconciliation.user_ids.iter().map(UserId::as_str).collect();
+        let bootstrap_user = match reconciliation.user_ids.first() {
+            Some(user_id) => user_id.clone(),
+            None => trigger_access_bootstrap_user_id()?,
+        };
+        let scope = tenant_shared_scope(
+            reconciliation.tenant_id,
+            &bootstrap_user,
+            reconciliation.agent_id,
+            reconciliation.project_id,
+        );
+        let users_root =
+            access_scope_users_root(reconciliation.agent_id, reconciliation.project_id)?;
+        let entries = match self.filesystem.list_dir(&scope, &users_root).await {
+            Ok(entries) => entries,
+            Err(error) if is_not_found(&error) => Vec::new(),
+            Err(error) => return Err(backend(error)),
+        };
+        for entry in entries {
+            if entry.file_type != FileType::File || !entry.name.ends_with(".json") {
+                continue;
+            }
+            let user_key = entry.name.trim_end_matches(".json");
+            let user_id = UserId::new(user_key.to_string()).map_err(backend)?;
+            let path =
+                access_record_path(reconciliation.agent_id, reconciliation.project_id, &user_id)?;
+            self.deactivate_stale_record(
+                reconciliation.tenant_id,
+                &path,
+                &user_id,
+                reconciliation.agent_id,
+                reconciliation.project_id,
+                reconciliation.source,
+                &allowed,
+            )
+            .await?;
+        }
+
+        for user_id in reconciliation.user_ids {
+            self.seed_local_access(LocalTriggerAccessSeed {
+                tenant_id: reconciliation.tenant_id,
+                user_id,
+                agent_id: reconciliation.agent_id,
+                project_id: reconciliation.project_id,
+                role: reconciliation.role,
+                source: reconciliation.source,
+            })
+            .await?;
+        }
+        Ok(())
+    }
+
+    /// Return whether a local trigger user has active access for the exact
+    /// tenant/agent/project tuple on a trigger fire request.
+    pub async fn has_active_local_access(
+        &self,
+        tenant_id: &TenantId,
+        user_id: &UserId,
+        agent_id: Option<&AgentId>,
+        project_id: Option<&ProjectId>,
+    ) -> Result<bool, RebornLocalTriggerAccessStoreError> {
+        let scope = tenant_shared_scope(tenant_id, user_id, agent_id, project_id);
+        let path = access_record_path(agent_id, project_id, user_id)?;
+        let Some((record, _version)) = self.read_record(&scope, &path).await? else {
+            return Ok(false);
+        };
+        Ok(
+            record_matches_scope(&record, tenant_id, user_id, agent_id, project_id)
+                && record.status == LocalTriggerAccessStatus::Active.as_str(),
+        )
+    }
+}
+
+enum FilesystemAccessPutError {
+    VersionMismatch,
+    Other(RebornLocalTriggerAccessStoreError),
+}
+
+const FILESYSTEM_CAS_RETRIES: usize = 8;
+const TRIGGER_ACCESS_ROOT: &str = "/tenant-shared/reborn-trigger-access";
+
+fn tenant_shared_scope(
+    tenant_id: &TenantId,
+    user_id: &UserId,
+    agent_id: Option<&AgentId>,
+    project_id: Option<&ProjectId>,
+) -> ResourceScope {
+    ResourceScope {
+        tenant_id: tenant_id.clone(),
+        user_id: user_id.clone(),
+        agent_id: agent_id.cloned(),
+        project_id: project_id.cloned(),
+        mission_id: None,
+        thread_id: None,
+        invocation_id: InvocationId::new(),
+    }
+}
+
+fn trigger_access_bootstrap_user_id() -> Result<UserId, RebornLocalTriggerAccessStoreError> {
+    UserId::new("trigger-access-bootstrap").map_err(backend)
+}
+
+fn access_scope_users_root(
+    agent_id: Option<&AgentId>,
+    project_id: Option<&ProjectId>,
+) -> Result<ScopedPath, RebornLocalTriggerAccessStoreError> {
+    ScopedPath::new(format!(
+        "{}/agents/{}/projects/{}/users",
+        TRIGGER_ACCESS_ROOT,
+        optional_axis_path(agent_id.map(AgentId::as_str)),
+        optional_axis_path(project_id.map(ProjectId::as_str))
+    ))
+    .map_err(backend)
+}
+
+fn access_record_path(
+    agent_id: Option<&AgentId>,
+    project_id: Option<&ProjectId>,
+    user_id: &UserId,
+) -> Result<ScopedPath, RebornLocalTriggerAccessStoreError> {
+    ScopedPath::new(format!(
+        "{}/{}.json",
+        access_scope_users_root(agent_id, project_id)?.as_str(),
+        user_id.as_str()
+    ))
+    .map_err(backend)
+}
+
+fn optional_axis_path(value: Option<&str>) -> String {
+    match value {
+        Some(value) => format!("some/{value}"),
+        None => "none".to_string(),
+    }
+}
+
+fn record_matches_scope(
+    record: &FilesystemLocalTriggerAccessRecord,
+    tenant_id: &TenantId,
+    user_id: &UserId,
+    agent_id: Option<&AgentId>,
+    project_id: Option<&ProjectId>,
+) -> bool {
+    record.tenant_id == tenant_id.as_str()
+        && record.user_id == user_id.as_str()
+        && record.agent_id.as_deref() == agent_id.map(AgentId::as_str)
+        && record.project_id.as_deref() == project_id.map(ProjectId::as_str)
+}
+
+fn is_not_found(error: &FilesystemError) -> bool {
+    matches!(error, FilesystemError::NotFound { .. })
+}
+
+#[async_trait::async_trait]
+impl<F> LocalTriggerAccessStore for RebornFilesystemLocalTriggerAccessStore<F>
+where
+    F: RootFilesystem + 'static,
+{
+    async fn seed_local_access(
+        &self,
+        seed: LocalTriggerAccessSeed<'_>,
+    ) -> Result<(), RebornLocalTriggerAccessStoreError> {
+        RebornFilesystemLocalTriggerAccessStore::seed_local_access(self, seed).await
+    }
+
+    async fn reconcile_local_access(
+        &self,
+        reconciliation: LocalTriggerAccessReconciliation<'_>,
+    ) -> Result<(), RebornLocalTriggerAccessStoreError> {
+        RebornFilesystemLocalTriggerAccessStore::reconcile_local_access(self, reconciliation).await
+    }
+
+    async fn has_active_local_access(
+        &self,
+        tenant_id: &TenantId,
+        user_id: &UserId,
+        agent_id: Option<&AgentId>,
+        project_id: Option<&ProjectId>,
+    ) -> Result<bool, RebornLocalTriggerAccessStoreError> {
+        RebornFilesystemLocalTriggerAccessStore::has_active_local_access(
+            self, tenant_id, user_id, agent_id, project_id,
+        )
+        .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::local_trigger_access::{LocalTriggerAccessRole, LocalTriggerAccessSource};
+    use ironclaw_filesystem::{InMemoryBackend, ScopedFilesystem};
+    use ironclaw_host_api::{MountAlias, MountGrant, MountPermissions, MountView, VirtualPath};
+
+    fn store() -> RebornFilesystemLocalTriggerAccessStore<InMemoryBackend> {
+        let root = Arc::new(InMemoryBackend::default());
+        let view = MountView::new(vec![MountGrant::new(
+            MountAlias::new("/tenant-shared").expect("mount alias"),
+            VirtualPath::new("/tenants/fs-trigger/shared").expect("virtual path"),
+            MountPermissions::read_write_list_delete(),
+        )])
+        .expect("mount view");
+        let filesystem = Arc::new(ScopedFilesystem::with_fixed_view(root, view));
+        RebornFilesystemLocalTriggerAccessStore::new(filesystem)
+    }
+
+    #[tokio::test]
+    async fn filesystem_store_reconciles_and_checks_exact_scope() {
+        let store = store();
+        let tenant_id = TenantId::new("fs-trigger-tenant").expect("tenant id");
+        let user_id = UserId::new("fs-trigger-user").expect("user id");
+        let stale_user_id = UserId::new("fs-trigger-stale").expect("stale user id");
+        let agent_id = AgentId::new("fs-trigger-agent").expect("agent id");
+        let project_id = ProjectId::new("fs-trigger-project").expect("project id");
+        let other_project_id = ProjectId::new("fs-trigger-other-project").expect("project id");
+
+        store
+            .seed_local_access(LocalTriggerAccessSeed {
+                tenant_id: &tenant_id,
+                user_id: &stale_user_id,
+                agent_id: Some(&agent_id),
+                project_id: Some(&project_id),
+                role: LocalTriggerAccessRole::Owner,
+                source: LocalTriggerAccessSource::LocalDevEnvBootstrap,
+            })
+            .await
+            .expect("seed stale local access");
+
+        store
+            .reconcile_local_access(LocalTriggerAccessReconciliation {
+                tenant_id: &tenant_id,
+                user_ids: std::slice::from_ref(&user_id),
+                agent_id: Some(&agent_id),
+                project_id: Some(&project_id),
+                role: LocalTriggerAccessRole::Owner,
+                source: LocalTriggerAccessSource::LocalDevEnvBootstrap,
+            })
+            .await
+            .expect("reconcile local access");
+
+        assert!(
+            store
+                .has_active_local_access(&tenant_id, &user_id, Some(&agent_id), Some(&project_id))
+                .await
+                .expect("check active local access"),
+            "the reconciled filesystem record allows the exact scope"
+        );
+        assert!(
+            !store
+                .has_active_local_access(
+                    &tenant_id,
+                    &user_id,
+                    Some(&agent_id),
+                    Some(&other_project_id),
+                )
+                .await
+                .expect("check wrong project access"),
+            "filesystem trigger access is exact-project, not a wildcard"
+        );
+        assert!(
+            !store
+                .has_active_local_access(
+                    &tenant_id,
+                    &stale_user_id,
+                    Some(&agent_id),
+                    Some(&project_id),
+                )
+                .await
+                .expect("check stale local access"),
+            "reconciliation deactivates stale filesystem records for the same source"
+        );
+    }
+}

--- a/crates/ironclaw_reborn/src/local_trigger_access/libsql.rs
+++ b/crates/ironclaw_reborn/src/local_trigger_access/libsql.rs
@@ -1,116 +1,13 @@
-//! Local-dev trigger-fire access store.
-//!
-//! This is a Reborn-owned local bootstrap access store, separate from the
-//! WebChat identity store. It runs on the same libSQL substrate file, but owns
-//! only the local `local_reborn_access` table used to satisfy the fire-time
-//! trigger authorization contract during local development.
-//!
-//! This table is not the production agent/project membership source of truth.
-//! Production and multi-tenant runtimes must wire a real membership-backed
-//! trigger access checker instead of this local bootstrap store.
-
 use std::collections::BTreeSet;
 use std::sync::Arc;
 
 use chrono::{SecondsFormat, Utc};
 use ironclaw_host_api::{AgentId, ProjectId, TenantId, UserId};
-use thiserror::Error;
 
-/// Fixed local-dev access role persisted on trigger-fire access rows.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum LocalTriggerAccessRole {
-    /// Owner-level local trigger-fire access.
-    Owner,
-}
-
-impl LocalTriggerAccessRole {
-    fn as_str(self) -> &'static str {
-        match self {
-            Self::Owner => "owner",
-        }
-    }
-}
-
-/// Local-dev bootstrap path that owns a trigger-fire access row.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum LocalTriggerAccessSource {
-    /// Environment-token `serve` bootstrap path.
-    LocalDevEnvBootstrap,
-    /// SSO-admitted WebUI user bootstrap path.
-    LocalDevSsoBootstrap,
-    /// CLI `run` default-owner bootstrap path.
-    LocalDevRunBootstrap,
-}
-
-impl LocalTriggerAccessSource {
-    fn as_str(self) -> &'static str {
-        match self {
-            Self::LocalDevEnvBootstrap => "local_dev_env_bootstrap",
-            Self::LocalDevSsoBootstrap => "local_dev_sso_bootstrap",
-            Self::LocalDevRunBootstrap => "local_dev_run_bootstrap",
-        }
-    }
-}
-
-/// Fixed lifecycle state persisted on local-dev access rows.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum LocalTriggerAccessStatus {
-    Active,
-    Inactive,
-}
-
-impl LocalTriggerAccessStatus {
-    fn as_str(self) -> &'static str {
-        match self {
-            Self::Active => "active",
-            Self::Inactive => "inactive",
-        }
-    }
-}
-
-/// Failure modes of the libSQL local trigger access store.
-#[derive(Debug, Error)]
-pub enum RebornLocalTriggerAccessStoreError {
-    /// The libSQL backend (connect / migrate / query / commit) failed.
-    #[error("reborn local trigger access store backend failure: {0}")]
-    Backend(String),
-}
-
-/// Local-dev trigger access row to seed from trusted host/operator input.
-pub struct LocalTriggerAccessSeed<'a> {
-    /// Tenant scope for the local access row.
-    pub tenant_id: &'a TenantId,
-    /// User that is allowed to fire triggers for the exact scope.
-    pub user_id: &'a UserId,
-    /// Optional agent scope. `None` is stored as an exact no-agent scope, not
-    /// a wildcard.
-    pub agent_id: Option<&'a AgentId>,
-    /// Optional project scope. `None` is stored as an exact no-project scope,
-    /// not a wildcard.
-    pub project_id: Option<&'a ProjectId>,
-    /// Local role to persist on the access row.
-    pub role: LocalTriggerAccessRole,
-    /// Source for the host/operator seed path.
-    pub source: LocalTriggerAccessSource,
-}
-
-/// Current trusted local-dev access set for one bootstrap source and exact
-/// tenant/agent/project scope.
-pub struct LocalTriggerAccessReconciliation<'a> {
-    /// Tenant scope for the local access rows.
-    pub tenant_id: &'a TenantId,
-    /// Users that should keep active access for this bootstrap source/scope.
-    pub user_ids: &'a [UserId],
-    /// Optional agent scope. `None` is an exact no-agent scope, not a wildcard.
-    pub agent_id: Option<&'a AgentId>,
-    /// Optional project scope. `None` is an exact no-project scope, not a
-    /// wildcard.
-    pub project_id: Option<&'a ProjectId>,
-    /// Local role for newly inserted rows.
-    pub role: LocalTriggerAccessRole,
-    /// Source for this host/operator seed path.
-    pub source: LocalTriggerAccessSource,
-}
+use super::types::{
+    LocalTriggerAccessReconciliation, LocalTriggerAccessSeed, LocalTriggerAccessStatus,
+    LocalTriggerAccessStore, RebornLocalTriggerAccessStoreError, backend, optional_scope_key,
+};
 
 /// libSQL-backed local-dev trigger access repository.
 pub struct RebornLibSqlLocalTriggerAccessStore {
@@ -329,17 +226,40 @@ impl RebornLibSqlLocalTriggerAccessStore {
     }
 }
 
-fn backend(err: impl std::fmt::Display) -> RebornLocalTriggerAccessStoreError {
-    RebornLocalTriggerAccessStoreError::Backend(err.to_string())
-}
+#[async_trait::async_trait]
+impl LocalTriggerAccessStore for RebornLibSqlLocalTriggerAccessStore {
+    async fn seed_local_access(
+        &self,
+        seed: LocalTriggerAccessSeed<'_>,
+    ) -> Result<(), RebornLocalTriggerAccessStoreError> {
+        RebornLibSqlLocalTriggerAccessStore::seed_local_access(self, seed).await
+    }
 
-fn optional_scope_key(value: Option<&str>) -> &str {
-    value.unwrap_or("")
+    async fn reconcile_local_access(
+        &self,
+        reconciliation: LocalTriggerAccessReconciliation<'_>,
+    ) -> Result<(), RebornLocalTriggerAccessStoreError> {
+        RebornLibSqlLocalTriggerAccessStore::reconcile_local_access(self, reconciliation).await
+    }
+
+    async fn has_active_local_access(
+        &self,
+        tenant_id: &TenantId,
+        user_id: &UserId,
+        agent_id: Option<&AgentId>,
+        project_id: Option<&ProjectId>,
+    ) -> Result<bool, RebornLocalTriggerAccessStoreError> {
+        RebornLibSqlLocalTriggerAccessStore::has_active_local_access(
+            self, tenant_id, user_id, agent_id, project_id,
+        )
+        .await
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::local_trigger_access::{LocalTriggerAccessRole, LocalTriggerAccessSource};
 
     async fn store() -> RebornLibSqlLocalTriggerAccessStore {
         let tmp = tempfile::tempdir().expect("tempdir");

--- a/crates/ironclaw_reborn/src/local_trigger_access/mod.rs
+++ b/crates/ironclaw_reborn/src/local_trigger_access/mod.rs
@@ -1,0 +1,26 @@
+//! Local trigger-fire access store.
+//!
+//! This is a Reborn-owned bootstrap access store, separate from the WebChat
+//! identity store. It owns only the local access records used to satisfy the
+//! fire-time trigger authorization contract for local/operator-managed
+//! deployments. Backends may persist those records through the host filesystem
+//! abstraction or through the legacy local-dev libSQL sidecar.
+//!
+//! These records are not the general agent/project membership source of truth.
+//! Multi-tenant runtimes must wire a real membership-backed trigger access
+//! checker instead of this bootstrap store.
+
+#[cfg(feature = "filesystem-local-trigger-access")]
+mod filesystem;
+#[cfg(feature = "webui-user-store")]
+mod libsql;
+mod types;
+
+#[cfg(feature = "filesystem-local-trigger-access")]
+pub use filesystem::RebornFilesystemLocalTriggerAccessStore;
+#[cfg(feature = "webui-user-store")]
+pub use libsql::RebornLibSqlLocalTriggerAccessStore;
+pub use types::{
+    LocalTriggerAccessReconciliation, LocalTriggerAccessRole, LocalTriggerAccessSeed,
+    LocalTriggerAccessSource, LocalTriggerAccessStore, RebornLocalTriggerAccessStoreError,
+};

--- a/crates/ironclaw_reborn/src/local_trigger_access/types.rs
+++ b/crates/ironclaw_reborn/src/local_trigger_access/types.rs
@@ -1,0 +1,128 @@
+use ironclaw_host_api::{AgentId, ProjectId, TenantId, UserId};
+use thiserror::Error;
+
+/// Fixed local-dev access role persisted on trigger-fire access rows.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LocalTriggerAccessRole {
+    /// Owner-level local trigger-fire access.
+    Owner,
+}
+
+impl LocalTriggerAccessRole {
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            Self::Owner => "owner",
+        }
+    }
+}
+
+/// Local-dev bootstrap path that owns a trigger-fire access row.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LocalTriggerAccessSource {
+    /// Environment-token `serve` bootstrap path.
+    LocalDevEnvBootstrap,
+    /// SSO-admitted WebUI user bootstrap path.
+    LocalDevSsoBootstrap,
+    /// CLI `run` default-owner bootstrap path.
+    LocalDevRunBootstrap,
+}
+
+impl LocalTriggerAccessSource {
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            Self::LocalDevEnvBootstrap => "local_dev_env_bootstrap",
+            Self::LocalDevSsoBootstrap => "local_dev_sso_bootstrap",
+            Self::LocalDevRunBootstrap => "local_dev_run_bootstrap",
+        }
+    }
+}
+
+/// Fixed lifecycle state persisted on local-dev access rows.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum LocalTriggerAccessStatus {
+    Active,
+    Inactive,
+}
+
+impl LocalTriggerAccessStatus {
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            Self::Active => "active",
+            Self::Inactive => "inactive",
+        }
+    }
+}
+
+/// Failure modes of a local trigger access store.
+#[derive(Debug, Error)]
+pub enum RebornLocalTriggerAccessStoreError {
+    /// The backend (connect / migrate / query / commit) failed.
+    #[error("reborn local trigger access store backend failure: {0}")]
+    Backend(String),
+}
+
+/// Local-dev trigger access row to seed from trusted host/operator input.
+pub struct LocalTriggerAccessSeed<'a> {
+    /// Tenant scope for the local access row.
+    pub tenant_id: &'a TenantId,
+    /// User that is allowed to fire triggers for the exact scope.
+    pub user_id: &'a UserId,
+    /// Optional agent scope. `None` is stored as an exact no-agent scope, not
+    /// a wildcard.
+    pub agent_id: Option<&'a AgentId>,
+    /// Optional project scope. `None` is stored as an exact no-project scope,
+    /// not a wildcard.
+    pub project_id: Option<&'a ProjectId>,
+    /// Local role to persist on the access row.
+    pub role: LocalTriggerAccessRole,
+    /// Source for the host/operator seed path.
+    pub source: LocalTriggerAccessSource,
+}
+
+/// Current trusted local-dev access set for one bootstrap source and exact
+/// tenant/agent/project scope.
+pub struct LocalTriggerAccessReconciliation<'a> {
+    /// Tenant scope for the local access rows.
+    pub tenant_id: &'a TenantId,
+    /// Users that should keep active access for this bootstrap source/scope.
+    pub user_ids: &'a [UserId],
+    /// Optional agent scope. `None` is an exact no-agent scope, not a wildcard.
+    pub agent_id: Option<&'a AgentId>,
+    /// Optional project scope. `None` is an exact no-project scope, not a
+    /// wildcard.
+    pub project_id: Option<&'a ProjectId>,
+    /// Local role for newly inserted rows.
+    pub role: LocalTriggerAccessRole,
+    /// Source for this host/operator seed path.
+    pub source: LocalTriggerAccessSource,
+}
+
+/// Backend-neutral local trigger access repository contract.
+#[async_trait::async_trait]
+pub trait LocalTriggerAccessStore: Send + Sync {
+    async fn seed_local_access(
+        &self,
+        seed: LocalTriggerAccessSeed<'_>,
+    ) -> Result<(), RebornLocalTriggerAccessStoreError>;
+
+    async fn reconcile_local_access(
+        &self,
+        reconciliation: LocalTriggerAccessReconciliation<'_>,
+    ) -> Result<(), RebornLocalTriggerAccessStoreError>;
+
+    async fn has_active_local_access(
+        &self,
+        tenant_id: &TenantId,
+        user_id: &UserId,
+        agent_id: Option<&AgentId>,
+        project_id: Option<&ProjectId>,
+    ) -> Result<bool, RebornLocalTriggerAccessStoreError>;
+}
+
+pub(super) fn backend(err: impl std::fmt::Display) -> RebornLocalTriggerAccessStoreError {
+    RebornLocalTriggerAccessStoreError::Backend(err.to_string())
+}
+
+pub(super) fn optional_scope_key(value: Option<&str>) -> &str {
+    value.unwrap_or("")
+}

--- a/crates/ironclaw_reborn/src/local_trigger_access/types.rs
+++ b/crates/ironclaw_reborn/src/local_trigger_access/types.rs
@@ -1,8 +1,10 @@
 use ironclaw_host_api::{AgentId, ProjectId, TenantId, UserId};
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 /// Fixed local-dev access role persisted on trigger-fire access rows.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum LocalTriggerAccessRole {
     /// Owner-level local trigger-fire access.
     Owner,
@@ -17,7 +19,8 @@ impl LocalTriggerAccessRole {
 }
 
 /// Local-dev bootstrap path that owns a trigger-fire access row.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum LocalTriggerAccessSource {
     /// Environment-token `serve` bootstrap path.
     LocalDevEnvBootstrap,
@@ -38,7 +41,8 @@ impl LocalTriggerAccessSource {
 }
 
 /// Fixed lifecycle state persisted on local-dev access rows.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub(super) enum LocalTriggerAccessStatus {
     Active,
     Inactive,

--- a/crates/ironclaw_reborn_cli/src/commands/serve.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/serve.rs
@@ -12,9 +12,10 @@ use ironclaw_reborn_composition::build_webui_services;
 use ironclaw_reborn_composition::host_api::{AgentId, ProjectId, TenantId, UserId};
 use ironclaw_reborn_composition::{
     GoogleOAuthRouteConfig, LocalTriggerAccessReconciliation, LocalTriggerAccessRole,
-    LocalTriggerAccessSource, RebornBuildInput, RebornReadiness, RebornRuntimeIdentity,
-    RebornRuntimeInput, RebornWebuiBundle, WebuiAuthenticator, WebuiServeConfig,
-    build_reborn_runtime, open_local_trigger_access_store, webui_v2_app_with_lifecycle,
+    LocalTriggerAccessSource, LocalTriggerAccessStore, RebornBuildInput, RebornReadiness,
+    RebornRuntimeIdentity, RebornRuntimeInput, RebornWebuiBundle, WebuiAuthenticator,
+    WebuiServeConfig, build_reborn_runtime, local_trigger_access_fire_checker,
+    webui_v2_app_with_lifecycle,
 };
 #[cfg(feature = "slack-v2-host-beta")]
 use ironclaw_reborn_composition::{
@@ -29,7 +30,10 @@ use ironclaw_reborn_webui_ingress::{
 use secrecy::SecretString;
 
 use crate::context::RebornCliContext;
-use crate::runtime::{RuntimeInputOptions, resolve_google_oauth_config_from_env};
+use crate::runtime::{
+    RuntimeInputOptions, open_trigger_access_store_for_profile,
+    resolve_google_oauth_config_from_env,
+};
 
 const DEFAULT_SERVE_HOST: &str = "127.0.0.1";
 const DEFAULT_SERVE_PORT: u16 = 3000;
@@ -343,15 +347,30 @@ impl ServeCommand {
             .context("failed to build tokio runtime for `serve`")?;
 
         rt.block_on(async move {
-            runtime_input = with_local_trigger_fire_access_checker(
-                runtime_input,
-                &user_store_path,
-                &tenant_id,
-                &user_id,
-                &default_agent_id,
-                default_project_id.as_ref(),
-            )
-            .await?;
+            let trigger_poller_enabled = runtime_input.trigger_poller.enabled;
+            let sso_enabled = sso_startup.is_some();
+            let trigger_access_store = if trigger_poller_enabled || sso_enabled {
+                Some(
+                    open_trigger_access_store_for_profile(&runtime_input, profile, &user_store_path)
+                        .await?,
+                )
+            } else {
+                None
+            };
+            if trigger_poller_enabled {
+                let access_store = trigger_access_store
+                    .as_ref()
+                    .expect("trigger access store is opened when trigger poller is enabled");
+                runtime_input = with_local_trigger_fire_access_checker(
+                    runtime_input,
+                    Arc::clone(access_store),
+                    &tenant_id,
+                    &user_id,
+                    &default_agent_id,
+                    default_project_id.as_ref(),
+                )
+                .await?;
+            }
 
             let startup_serve = if profile == RebornProfile::HostedSingleTenant {
                 Some(start_hosted_single_tenant_startup_listener(listen_addr).await?)
@@ -404,16 +423,13 @@ impl ServeCommand {
             .await
             .context("failed to compose OpenAI-compatible Reborn routes")?;
 
-            // Open the canonical Reborn identity resolver on the runtime's
-            // existing substrate handle (the same `reborn-local-dev.db` the
-            // runtime owns) rather than opening a second handle to the file.
-            // Only SSO-enabled WebUI needs it: an env-bearer-only deployment
-            // resolves its single configured user without any identity store,
-            // so skip opening (and its legacy migration) when SSO is disabled
-            // — otherwise a disabled-SSO deployment could fail startup on an
-            // unused identity backend. `None` also covers the case where the
-            // runtime carries no local-runtime substrate; the auth surface
-            // fails closed when SSO is configured but no resolver is available.
+            // Only SSO-enabled WebUI needs the canonical Reborn identity
+            // resolver: an env-bearer-only deployment resolves its single
+            // configured user without any identity store, so skip opening (and
+            // its legacy migration) when SSO is disabled. `None` also covers
+            // the case where the runtime carries no local-runtime substrate;
+            // the auth surface fails closed when SSO is configured but no
+            // resolver is available.
             let identity_resolver = if sso_startup.is_some() {
                 match runtime.open_reborn_identity_resolver(&tenant_id).await {
                     Some(result) => {
@@ -440,14 +456,14 @@ impl ServeCommand {
                 tenant_id.clone(),
                 session_signing_secret,
                 env_authenticator,
-                Some(
+                trigger_access_store.as_ref().map(|store| {
                     crate::commands::webui_auth::LocalTriggerAccessBootstrapConfig {
-                        access_store_path: user_store_path.clone(),
+                        store: Arc::clone(store),
                         tenant_id: tenant_id.clone(),
                         agent_id: default_agent_id.clone(),
                         project_id: default_project_id.clone(),
-                    },
-                ),
+                    }
+                }),
             )
             .await?;
 
@@ -729,7 +745,7 @@ fn canonical_host_name(host: &str) -> &str {
 
 async fn with_local_trigger_fire_access_checker(
     runtime_input: RebornRuntimeInput,
-    user_store_path: &std::path::Path,
+    access_store: Arc<dyn LocalTriggerAccessStore>,
     tenant_id: &TenantId,
     user_id: &UserId,
     default_agent_id: &AgentId,
@@ -739,9 +755,6 @@ async fn with_local_trigger_fire_access_checker(
         return Ok(runtime_input);
     }
 
-    let access_store = open_local_trigger_access_store(user_store_path)
-        .await
-        .context("failed to initialize local trigger-fire access store")?;
     let user_ids = [user_id.clone()];
     access_store
         .reconcile_local_access(LocalTriggerAccessReconciliation {
@@ -754,7 +767,8 @@ async fn with_local_trigger_fire_access_checker(
         })
         .await
         .context("failed to reconcile local trigger-fire access")?;
-    Ok(runtime_input.with_trigger_fire_access_checker(access_store))
+    Ok(runtime_input
+        .with_trigger_fire_access_checker(local_trigger_access_fire_checker(access_store)))
 }
 
 fn resolve_webui_default_agent(
@@ -956,6 +970,38 @@ mod tests {
 
     #[tokio::test]
     async fn trigger_poller_disabled_does_not_wire_local_access_checker() {
+        struct PanicLocalTriggerAccessStore;
+
+        #[async_trait::async_trait]
+        impl LocalTriggerAccessStore for PanicLocalTriggerAccessStore {
+            async fn seed_local_access(
+                &self,
+                _seed: ironclaw_reborn_composition::LocalTriggerAccessSeed<'_>,
+            ) -> Result<(), ironclaw_reborn_composition::RebornLocalTriggerAccessStoreError>
+            {
+                panic!("disabled trigger poller must not seed local access")
+            }
+
+            async fn reconcile_local_access(
+                &self,
+                _reconciliation: LocalTriggerAccessReconciliation<'_>,
+            ) -> Result<(), ironclaw_reborn_composition::RebornLocalTriggerAccessStoreError>
+            {
+                panic!("disabled trigger poller must not reconcile local access")
+            }
+
+            async fn has_active_local_access(
+                &self,
+                _tenant_id: &TenantId,
+                _user_id: &UserId,
+                _agent_id: Option<&AgentId>,
+                _project_id: Option<&ProjectId>,
+            ) -> Result<bool, ironclaw_reborn_composition::RebornLocalTriggerAccessStoreError>
+            {
+                panic!("disabled trigger poller must not check local access")
+            }
+        }
+
         let dir = tempfile::tempdir().expect("tempdir");
         let tenant_id = TenantId::new("serve-trigger-disabled-tenant").expect("tenant id");
         let user_id = UserId::new("serve-trigger-disabled-user").expect("user id");
@@ -964,11 +1010,11 @@ mod tests {
             "serve-trigger-owner",
             dir.path().join("runtime"),
         ));
-        let missing_store_path = dir.path().join("missing").join("reborn-local-dev.db");
+        let access_store: Arc<dyn LocalTriggerAccessStore> = Arc::new(PanicLocalTriggerAccessStore);
 
         let runtime_input = with_local_trigger_fire_access_checker(
             runtime_input,
-            &missing_store_path,
+            access_store,
             &tenant_id,
             &user_id,
             &agent_id,
@@ -980,10 +1026,6 @@ mod tests {
         assert!(
             runtime_input.trigger_fire_access_checker.is_none(),
             "disabled trigger poller must not wire a local access checker"
-        );
-        assert!(
-            !missing_store_path.exists(),
-            "disabled trigger poller must not create the local access store"
         );
     }
 
@@ -1022,7 +1064,7 @@ mod tests {
 
         let runtime_input = with_local_trigger_fire_access_checker(
             runtime_input,
-            &user_store_path,
+            access_store,
             &tenant_id,
             &user_id,
             &agent_id,
@@ -1080,6 +1122,10 @@ mod tests {
         let agent_id = AgentId::new("serve-trigger-no-project-agent").expect("agent id");
         let project_id = ProjectId::new("serve-trigger-no-project-project").expect("project id");
         let user_store_path = dir.path().join("reborn-local-dev.db");
+        let access_store =
+            ironclaw_reborn_composition::open_local_trigger_access_store(&user_store_path)
+                .await
+                .expect("open local trigger access store");
         let runtime_input =
             RebornRuntimeInput::from_services(RebornBuildInput::local_dev(
                 "serve-trigger-owner",
@@ -1091,7 +1137,7 @@ mod tests {
 
         let runtime_input = with_local_trigger_fire_access_checker(
             runtime_input,
-            &user_store_path,
+            access_store,
             &tenant_id,
             &user_id,
             &agent_id,

--- a/crates/ironclaw_reborn_cli/src/commands/serve.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/serve.rs
@@ -349,6 +349,12 @@ impl ServeCommand {
         rt.block_on(async move {
             let trigger_poller_enabled = runtime_input.trigger_poller.enabled;
             let sso_enabled = sso_startup.is_some();
+            let startup_serve = if profile == RebornProfile::HostedSingleTenant {
+                Some(start_hosted_single_tenant_startup_listener(listen_addr).await?)
+            } else {
+                None
+            };
+
             let trigger_access_store = if trigger_poller_enabled || sso_enabled {
                 Some(
                     open_trigger_access_store_for_profile(&runtime_input, profile, &user_store_path)
@@ -360,7 +366,7 @@ impl ServeCommand {
             if trigger_poller_enabled {
                 let access_store = trigger_access_store
                     .as_ref()
-                    .expect("trigger access store is opened when trigger poller is enabled");
+                    .ok_or_else(|| anyhow!("trigger access store was not opened"))?;
                 runtime_input = with_local_trigger_fire_access_checker(
                     runtime_input,
                     Arc::clone(access_store),
@@ -371,12 +377,6 @@ impl ServeCommand {
                 )
                 .await?;
             }
-
-            let startup_serve = if profile == RebornProfile::HostedSingleTenant {
-                Some(start_hosted_single_tenant_startup_listener(listen_addr).await?)
-            } else {
-                None
-            };
 
             let runtime = build_reborn_runtime(runtime_input)
                 .await

--- a/crates/ironclaw_reborn_cli/src/commands/user_directory.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/user_directory.rs
@@ -23,8 +23,8 @@ use async_trait::async_trait;
 use ironclaw_reborn_composition::host_api::{AgentId, ProjectId, TenantId, UserId};
 use ironclaw_reborn_composition::{
     ExternalSubjectId, LocalTriggerAccessRole, LocalTriggerAccessSeed, LocalTriggerAccessSource,
-    ProviderKind, RebornIdentityResolver, RebornLibSqlLocalTriggerAccessStore,
-    ResolveExternalIdentity, SurfaceKind,
+    LocalTriggerAccessStore, ProviderKind, RebornIdentityResolver, ResolveExternalIdentity,
+    SurfaceKind,
 };
 use ironclaw_reborn_webui_ingress::{
     OAuthProviderName, OAuthUserProfile, UserDirectory, UserDirectoryError,
@@ -102,7 +102,7 @@ impl WebuiUserDirectory {
 
 /// Local-dev trigger access seed configuration for users admitted through SSO.
 pub(crate) struct LocalTriggerAccessBootstrap {
-    store: Arc<RebornLibSqlLocalTriggerAccessStore>,
+    store: Arc<dyn LocalTriggerAccessStore>,
     tenant_id: TenantId,
     agent_id: AgentId,
     project_id: Option<ProjectId>,
@@ -110,7 +110,7 @@ pub(crate) struct LocalTriggerAccessBootstrap {
 
 impl LocalTriggerAccessBootstrap {
     pub(crate) fn new(
-        store: Arc<RebornLibSqlLocalTriggerAccessStore>,
+        store: Arc<dyn LocalTriggerAccessStore>,
         tenant_id: TenantId,
         agent_id: AgentId,
         project_id: Option<ProjectId>,

--- a/crates/ironclaw_reborn_cli/src/commands/webui_auth.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/webui_auth.rs
@@ -33,9 +33,10 @@ pub(crate) struct WebuiAuthSurface {
 
 /// How to seed local-dev trigger-fire access for SSO users on login.
 ///
-/// Carries the substrate path of the local trigger-access store plus the
-/// scope an admitted user's access row is seeded under. The store is opened
-/// here (next to the rest of the auth wiring), not by `serve.rs`.
+/// Carries the already-open local trigger-access store plus the scope an
+/// admitted user's access row is seeded under. `serve.rs` opens the store once
+/// through the active runtime profile so SSO and trigger-poller wiring share
+/// the same backend.
 pub(crate) struct LocalTriggerAccessBootstrapConfig {
     pub(crate) store: Arc<dyn LocalTriggerAccessStore>,
     pub(crate) tenant_id: TenantId,

--- a/crates/ironclaw_reborn_cli/src/commands/webui_auth.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/webui_auth.rs
@@ -10,13 +10,12 @@
 //! ([`crate::commands::user_directory`]) and the startup config
 //! ([`crate::commands::serve_sso`]).
 
-use std::path::PathBuf;
 use std::sync::Arc;
 
-use anyhow::{Context, anyhow};
+use anyhow::anyhow;
 use ironclaw_reborn_composition::host_api::{AgentId, ProjectId, TenantId};
 use ironclaw_reborn_composition::{
-    PublicRouteMount, RebornIdentityResolver, WebuiAuthenticator, open_local_trigger_access_store,
+    LocalTriggerAccessStore, PublicRouteMount, RebornIdentityResolver, WebuiAuthenticator,
 };
 use ironclaw_reborn_webui_ingress::{SignedSessionLoginConfig, build_signed_session_login};
 use secrecy::SecretString;
@@ -38,7 +37,7 @@ pub(crate) struct WebuiAuthSurface {
 /// scope an admitted user's access row is seeded under. The store is opened
 /// here (next to the rest of the auth wiring), not by `serve.rs`.
 pub(crate) struct LocalTriggerAccessBootstrapConfig {
-    pub(crate) access_store_path: PathBuf,
+    pub(crate) store: Arc<dyn LocalTriggerAccessStore>,
     pub(crate) tenant_id: TenantId,
     pub(crate) agent_id: AgentId,
     pub(crate) project_id: Option<ProjectId>,
@@ -58,9 +57,9 @@ pub(crate) struct LocalTriggerAccessBootstrapConfig {
 /// this fails closed rather than minting users against a missing store.
 ///
 /// When `local_trigger_access` is present and SSO is configured, admitted
-/// users get a local-dev trigger-access row seeded on each login (via the
-/// admission adapter). There is no startup reconciliation: the bootstrap
-/// only seeds, it does not enumerate or revoke.
+/// users get a local trigger-access row seeded on each login (via the
+/// admission adapter). There is no startup reconciliation in this path: the
+/// bootstrap only seeds, it does not enumerate or revoke.
 pub(crate) async fn build_webui_auth_surface(
     sso_startup: Option<SsoStartupConfig>,
     identity_resolver: Option<Arc<dyn RebornIdentityResolver>>,
@@ -97,7 +96,7 @@ pub(crate) async fn build_webui_auth_surface(
     );
     if let Some(config) = local_trigger_access {
         user_directory =
-            user_directory.with_local_trigger_access(local_trigger_access_bootstrap(config).await?);
+            user_directory.with_local_trigger_access(local_trigger_access_bootstrap(config));
     }
 
     let wiring = build_signed_session_login(SignedSessionLoginConfig {
@@ -120,27 +119,16 @@ pub(crate) async fn build_webui_auth_surface(
     })
 }
 
-/// Open the local trigger-access store and build the per-login bootstrap the
-/// admission adapter seeds through. Opening lives here so `serve.rs` only
-/// carries the substrate path, never a substrate handle.
-async fn local_trigger_access_bootstrap(
+fn local_trigger_access_bootstrap(
     config: LocalTriggerAccessBootstrapConfig,
-) -> anyhow::Result<LocalTriggerAccessBootstrap> {
+) -> LocalTriggerAccessBootstrap {
     let LocalTriggerAccessBootstrapConfig {
-        access_store_path,
+        store,
         tenant_id,
         agent_id,
         project_id,
     } = config;
-    let access_store = open_local_trigger_access_store(&access_store_path)
-        .await
-        .context("failed to initialize local trigger access store for SSO")?;
-    Ok(LocalTriggerAccessBootstrap::new(
-        access_store,
-        tenant_id,
-        agent_id,
-        project_id,
-    ))
+    LocalTriggerAccessBootstrap::new(store, tenant_id, agent_id, project_id)
 }
 
 #[cfg(test)]
@@ -250,11 +238,15 @@ mod tests {
     #[tokio::test]
     async fn sso_with_local_trigger_access_bootstrap_builds_surface() {
         // SSO configured with a local-trigger-access bootstrap: the surface
-        // must open the access store, attach the per-login seeder to the
-        // admission adapter, and mount the public login routes — proving the
-        // bootstrap config is wired through, not silently dropped.
+        // must attach the per-login seeder to the admission adapter and mount
+        // the public login routes — proving the bootstrap config is wired
+        // through, not silently dropped.
         let tmp = tempfile::tempdir().expect("tempdir");
         let access_store_path = tmp.path().join("reborn-local-dev.db");
+        let access_store =
+            ironclaw_reborn_composition::open_local_trigger_access_store(&access_store_path)
+                .await
+                .expect("open local trigger access store");
         let sso = SsoStartupConfig {
             providers: vec![Arc::new(StubProvider(
                 OAuthProviderName::new("google").expect("provider name"),
@@ -272,7 +264,7 @@ mod tests {
             SecretString::from("operator-session-secret".to_string()),
             Arc::new(RejectingAuth),
             Some(LocalTriggerAccessBootstrapConfig {
-                access_store_path,
+                store: access_store,
                 tenant_id: TenantId::new("sso-bootstrap-tenant").expect("tenant"),
                 agent_id: AgentId::new("sso-bootstrap-agent").expect("agent"),
                 project_id: Some(ProjectId::new("sso-bootstrap-project").expect("project")),

--- a/crates/ironclaw_reborn_cli/src/runtime/mod.rs
+++ b/crates/ironclaw_reborn_cli/src/runtime/mod.rs
@@ -1,5 +1,7 @@
 use std::io::{IsTerminal, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+#[cfg(feature = "webui-v2-beta")]
+use std::sync::Arc;
 use std::time::Duration;
 use std::{future::Future, thread};
 
@@ -19,7 +21,7 @@ use ironclaw_reborn_composition::{
 #[cfg(feature = "webui-v2-beta")]
 use ironclaw_reborn_composition::{
     LocalTriggerAccessReconciliation, LocalTriggerAccessRole, LocalTriggerAccessSource,
-    open_local_trigger_access_store,
+    LocalTriggerAccessStore, local_trigger_access_fire_checker, open_local_trigger_access_store,
 };
 use ironclaw_reborn_config::{
     REBORN_PROFILE_ENV, RebornBootConfig, RebornProfile, seed_default_config_file_if_missing,
@@ -240,9 +242,9 @@ async fn with_run_local_trigger_fire_access_checker(
         let profile = effective_profile(config, config_file.as_ref())?;
         let user_store_path =
             local_runtime_storage_root(config, profile).join("reborn-local-dev.db");
-        let access_store = open_local_trigger_access_store(&user_store_path)
-            .await
-            .context("failed to initialize local trigger-fire access store for `run`")?;
+        let access_store =
+            open_trigger_access_store_for_profile(&runtime_input, profile, &user_store_path)
+                .await?;
         let user_ids = [user_id];
         access_store
             .reconcile_local_access(LocalTriggerAccessReconciliation {
@@ -256,7 +258,47 @@ async fn with_run_local_trigger_fire_access_checker(
             .await
             .context("failed to reconcile local trigger-fire access for `run`")?;
 
-        Ok(runtime_input.with_trigger_fire_access_checker(access_store))
+        Ok(runtime_input
+            .with_trigger_fire_access_checker(local_trigger_access_fire_checker(access_store)))
+    }
+}
+
+#[cfg(feature = "webui-v2-beta")]
+pub(crate) async fn open_trigger_access_store_for_profile(
+    runtime_input: &RebornRuntimeInput,
+    profile: RebornProfile,
+    local_store_path: &Path,
+) -> anyhow::Result<Arc<dyn LocalTriggerAccessStore>> {
+    match profile {
+        RebornProfile::HostedSingleTenant => {
+            #[cfg(feature = "postgres")]
+            {
+                let services = runtime_input.services.as_ref().context(
+                    "profile=hosted-single-tenant requires runtime services before trigger-fire access can be wired",
+                )?;
+                let store = services
+                    .open_hosted_single_tenant_trigger_access_store()
+                    .await
+                    .context("failed to initialize hosted trigger-fire access store")?;
+                let store: Arc<dyn LocalTriggerAccessStore> = store;
+                Ok(store)
+            }
+            #[cfg(not(feature = "postgres"))]
+            {
+                let _ = runtime_input;
+                let _ = local_store_path;
+                anyhow::bail!(
+                    "profile=hosted-single-tenant requires the `postgres` feature for trigger-fire access"
+                );
+            }
+        }
+        _ => {
+            let store = open_local_trigger_access_store(local_store_path)
+                .await
+                .context("failed to initialize local trigger-fire access store")?;
+            let store: Arc<dyn LocalTriggerAccessStore> = store;
+            Ok(store)
+        }
     }
 }
 

--- a/crates/ironclaw_reborn_composition/Cargo.toml
+++ b/crates/ironclaw_reborn_composition/Cargo.toml
@@ -83,6 +83,7 @@ postgres = [
     "ironclaw_filesystem/postgres",
     "ironclaw_host_runtime/postgres",
     "ironclaw_reborn/filesystem-goal-store",
+    "ironclaw_reborn/filesystem-local-trigger-access",
     "ironclaw_reborn_event_store/postgres",
     "ironclaw_resources/postgres",
     "ironclaw_run_state/postgres",

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -453,11 +453,7 @@ pub(crate) enum CredentialRefreshWorkerReady {
 impl RebornServices {
     /// The shared scoped secret store backing this composition.
     #[cfg_attr(
-        not(any(
-            feature = "root-llm-provider",
-            feature = "slack-v2-host-beta",
-            feature = "test-support"
-        )),
+        not(any(feature = "root-llm-provider", feature = "slack-v2-host-beta")),
         allow(dead_code)
     )]
     pub(crate) fn secret_store(&self) -> Arc<dyn SecretStore> {

--- a/crates/ironclaw_reborn_composition/src/input.rs
+++ b/crates/ironclaw_reborn_composition/src/input.rs
@@ -335,6 +335,31 @@ impl RebornBuildInput {
         ))
     }
 
+    /// Open the hosted-single-tenant trigger access store from this build
+    /// input's already-resolved PostgreSQL storage.
+    #[cfg(all(feature = "webui-v2-beta", feature = "postgres"))]
+    pub async fn open_hosted_single_tenant_trigger_access_store(
+        &self,
+    ) -> Result<Arc<dyn crate::LocalTriggerAccessStore>, crate::RebornLocalTriggerAccessStoreError>
+    {
+        let RebornStorageInput::HostedSingleTenantPostgres { pool, .. } = &self.storage else {
+            return Err(crate::RebornLocalTriggerAccessStoreError::Backend(
+                "hosted-single-tenant trigger access requires PostgreSQL-backed runtime storage"
+                    .to_string(),
+            ));
+        };
+        let filesystem = Arc::new(ironclaw_filesystem::PostgresRootFilesystem::new(
+            pool.clone(),
+        ));
+        filesystem.run_migrations().await.map_err(|error| {
+            crate::RebornLocalTriggerAccessStoreError::Backend(error.to_string())
+        })?;
+        let scoped = crate::wrap_scoped(filesystem);
+        Ok(Arc::new(
+            crate::RebornFilesystemLocalTriggerAccessStore::new(scoped),
+        ))
+    }
+
     pub fn with_local_runtime_workspace_root(mut self, workspace_root: PathBuf) -> Self {
         match &mut self.storage {
             RebornStorageInput::LocalDev {

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -361,48 +361,73 @@ pub mod host_api {
     pub use ironclaw_host_api::{AgentId, ProjectId, TenantId, UserId};
 }
 
+#[cfg(all(feature = "webui-v2-beta", feature = "postgres"))]
+pub use ironclaw_reborn::local_trigger_access::RebornFilesystemLocalTriggerAccessStore;
 /// Reborn-owned local trigger-fire access store, re-exported so host
 /// binaries reach it through this composition facade instead of taking a
 /// direct `ironclaw_reborn` dependency (the
 /// `reborn_cli_binary_crate_stays_separate_from_v1_root` architecture
-/// boundary forbids that). The store is a reborn-owned repository;
-/// [`open_local_trigger_access_store`] opens it so the libSQL substrate handle
-/// stays private to this facade and callers never construct one.
+/// boundary forbids that). The store is a reborn-owned repository. Local-dev
+/// callers use [`open_local_trigger_access_store`]; hosted-single-tenant
+/// callers use the filesystem-backed store through the host filesystem
+/// abstraction.
 #[cfg(feature = "webui-v2-beta")]
 pub use ironclaw_reborn::local_trigger_access::{
     LocalTriggerAccessReconciliation, LocalTriggerAccessRole, LocalTriggerAccessSeed,
-    LocalTriggerAccessSource, RebornLibSqlLocalTriggerAccessStore,
+    LocalTriggerAccessSource, LocalTriggerAccessStore, RebornLibSqlLocalTriggerAccessStore,
     RebornLocalTriggerAccessStoreError,
 };
 
 #[cfg(feature = "webui-v2-beta")]
+struct LocalTriggerAccessFireChecker {
+    store: std::sync::Arc<dyn LocalTriggerAccessStore>,
+}
+
+#[cfg(feature = "webui-v2-beta")]
+impl LocalTriggerAccessFireChecker {
+    fn new(store: std::sync::Arc<dyn LocalTriggerAccessStore>) -> Self {
+        Self { store }
+    }
+}
+
+/// Wrap a backend-neutral local trigger access store as the runtime fire-time
+/// authorizer.
+#[cfg(feature = "webui-v2-beta")]
+pub fn local_trigger_access_fire_checker(
+    store: std::sync::Arc<dyn LocalTriggerAccessStore>,
+) -> std::sync::Arc<dyn runtime_input::TriggerFireAccessChecker> {
+    std::sync::Arc::new(LocalTriggerAccessFireChecker::new(store))
+}
+
+#[cfg(feature = "webui-v2-beta")]
 #[async_trait::async_trait]
-impl runtime_input::TriggerFireAccessChecker for RebornLibSqlLocalTriggerAccessStore {
+impl runtime_input::TriggerFireAccessChecker for LocalTriggerAccessFireChecker {
     async fn check_trigger_fire_access(
         &self,
         request: runtime_input::TriggerFireAccessCheck,
     ) -> Result<runtime_input::TriggerFireAccessDecision, runtime_input::TriggerFireAccessError>
     {
-        self.has_active_local_access(
-            &request.tenant_id,
-            &request.creator_user_id,
-            request.agent_id.as_ref(),
-            request.project_id.as_ref(),
-        )
-        .await
-        .map_err(|error| runtime_input::TriggerFireAccessError::Unavailable {
-            reason: error.to_string(),
-        })
-        .map(|allowed| {
-            if allowed {
-                runtime_input::TriggerFireAccessDecision::Allowed
-            } else {
-                runtime_input::TriggerFireAccessDecision::Denied {
-                    reason: "trigger creator does not have active local access for this scope"
-                        .to_string(),
+        self.store
+            .has_active_local_access(
+                &request.tenant_id,
+                &request.creator_user_id,
+                request.agent_id.as_ref(),
+                request.project_id.as_ref(),
+            )
+            .await
+            .map_err(|error| runtime_input::TriggerFireAccessError::Unavailable {
+                reason: error.to_string(),
+            })
+            .map(|allowed| {
+                if allowed {
+                    runtime_input::TriggerFireAccessDecision::Allowed
+                } else {
+                    runtime_input::TriggerFireAccessDecision::Denied {
+                        reason: "trigger creator does not have active local access for this scope"
+                            .to_string(),
+                    }
                 }
-            }
-        })
+            })
     }
 }
 

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -511,9 +511,7 @@ pub async fn open_local_trigger_access_store(
 #[cfg(all(test, feature = "webui-v2-beta"))]
 mod webui_user_access_checker_tests {
     use super::*;
-    use crate::runtime_input::{
-        TriggerFireAccessCheck, TriggerFireAccessChecker, TriggerFireAccessDecision,
-    };
+    use crate::runtime_input::{TriggerFireAccessCheck, TriggerFireAccessDecision};
     use ironclaw_host_api::{AgentId, ProjectId, TenantId, UserId};
 
     #[tokio::test]
@@ -540,7 +538,9 @@ mod webui_user_access_checker_tests {
             .await
             .expect("seed local access");
 
-        let allowed = store
+        let checker = local_trigger_access_fire_checker(store);
+
+        let allowed = checker
             .check_trigger_fire_access(TriggerFireAccessCheck {
                 tenant_id: tenant_id.clone(),
                 creator_user_id: user_id,
@@ -553,7 +553,7 @@ mod webui_user_access_checker_tests {
             .expect("check access");
         assert_eq!(allowed, TriggerFireAccessDecision::Allowed);
 
-        let denied = store
+        let denied = checker
             .check_trigger_fire_access(TriggerFireAccessCheck {
                 tenant_id,
                 creator_user_id: other_user_id,

--- a/crates/ironclaw_reborn_composition/tests/facade_factory.rs
+++ b/crates/ironclaw_reborn_composition/tests/facade_factory.rs
@@ -7,6 +7,8 @@ use chrono::Utc;
 use deadpool_postgres::tokio_postgres;
 #[cfg(feature = "libsql")]
 use ironclaw_auth::{OAuthClientId, OAuthRedirectUri};
+#[cfg(all(feature = "postgres", feature = "webui-v2-beta"))]
+use ironclaw_host_api::{AgentId, ProjectId, TenantId};
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 use ironclaw_host_api::{
     AuditMode, DeploymentMode, EffectKind, FilesystemBackendKind, NetworkMode, PackageId,
@@ -31,6 +33,10 @@ use ironclaw_host_runtime::{
 };
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 use ironclaw_reborn_composition::RebornRuntimeProcessBinding;
+#[cfg(all(feature = "postgres", feature = "webui-v2-beta"))]
+use ironclaw_reborn_composition::{
+    LocalTriggerAccessRole, LocalTriggerAccessSeed, LocalTriggerAccessSource,
+};
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 use ironclaw_reborn_composition::{RebornBuildError, RebornCompositionProfile, RebornServices};
 use ironclaw_reborn_composition::{
@@ -42,6 +48,8 @@ use ironclaw_reborn_composition::{
     RebornReadinessDiagnosticComponent, RebornReadinessDiagnosticReason,
     RebornReadinessDiagnosticStatus,
 };
+#[cfg(all(feature = "postgres", feature = "webui-v2-beta"))]
+use ironclaw_reborn_config::{RebornConfigFile, StorageBackend, StorageSection};
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 use ironclaw_secrets::SecretMaterial;
 #[cfg(any(feature = "libsql", feature = "postgres"))]
@@ -63,6 +71,9 @@ use tokio::sync::Mutex;
 
 #[cfg(feature = "libsql")]
 static SECRETS_MASTER_KEY_ENV_LOCK: Mutex<()> = Mutex::const_new(());
+
+#[cfg(all(feature = "postgres", feature = "webui-v2-beta"))]
+static HOSTED_TRIGGER_ACCESS_ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
 #[cfg(feature = "libsql")]
 struct EnvVarGuard {
@@ -88,6 +99,49 @@ impl Drop for EnvVarGuard {
     fn drop(&mut self) {
         // SAFETY: EnvVarGuard is only constructed while
         // SECRETS_MASTER_KEY_ENV_LOCK is held by this test module.
+        unsafe {
+            match &self.previous {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+}
+
+#[cfg(all(feature = "postgres", feature = "webui-v2-beta"))]
+struct PostgresEnvVarGuard {
+    key: &'static str,
+    previous: Option<std::ffi::OsString>,
+}
+
+#[cfg(all(feature = "postgres", feature = "webui-v2-beta"))]
+impl PostgresEnvVarGuard {
+    fn set(key: &'static str, value: &str) -> Self {
+        let previous = std::env::var_os(key);
+        // SAFETY: tests serialize process-env mutation with
+        // HOSTED_TRIGGER_ACCESS_ENV_LOCK and restore the prior value on drop.
+        unsafe {
+            std::env::set_var(key, value);
+        }
+        Self { key, previous }
+    }
+
+    fn clear(key: &'static str) -> Self {
+        let previous = std::env::var_os(key);
+        // SAFETY: tests serialize process-env mutation with
+        // HOSTED_TRIGGER_ACCESS_ENV_LOCK and restore the prior value on drop.
+        unsafe {
+            std::env::remove_var(key);
+        }
+        Self { key, previous }
+    }
+}
+
+#[cfg(all(feature = "postgres", feature = "webui-v2-beta"))]
+impl Drop for PostgresEnvVarGuard {
+    fn drop(&mut self) {
+        // SAFETY: PostgresEnvVarGuard is only constructed while
+        // HOSTED_TRIGGER_ACCESS_ENV_LOCK is held by this test module.
         unsafe {
             match &self.previous {
                 Some(value) => std::env::set_var(self.key, value),
@@ -1377,6 +1431,81 @@ async fn production_postgres_services_migrate_trigger_repository_before_runtime_
         .expect("trigger table exists after production build");
     let count: i64 = row.get(0);
     assert_eq!(count, 0);
+}
+
+#[cfg(all(feature = "postgres", feature = "webui-v2-beta"))]
+#[tokio::test]
+async fn hosted_single_tenant_trigger_access_store_persists_across_reopen() {
+    let Some((_container, _pool, database_url)) = postgres_pool_or_skip().await else {
+        return;
+    };
+    let _env_lock = HOSTED_TRIGGER_ACCESS_ENV_LOCK.lock().await;
+    let _database_url = PostgresEnvVarGuard::set("IRONCLAW_REBORN_POSTGRES_URL", &database_url);
+    let _secret_master_key = PostgresEnvVarGuard::set(
+        "IRONCLAW_REBORN_SECRET_MASTER_KEY",
+        "01234567890123456789012345678901",
+    );
+    let _pool_max_size = PostgresEnvVarGuard::set("IRONCLAW_REBORN_POSTGRES_POOL_MAX_SIZE", "1");
+    let _allow_cleartext =
+        PostgresEnvVarGuard::set("IRONCLAW_REBORN_ALLOW_REMOTE_POSTGRES_CLEAR_TEXT", "true");
+    let _ssl_mode = PostgresEnvVarGuard::clear("DATABASE_SSLMODE");
+    let root = tempfile::tempdir().expect("runtime root");
+    let config = RebornConfigFile {
+        storage: Some(StorageSection {
+            backend: Some(StorageBackend::Postgres),
+            pool_max_size: Some(1),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    let tenant_id = TenantId::new("hosted-trigger-tenant").expect("tenant id");
+    let user_id = UserId::new("hosted-trigger-user").expect("user id");
+    let agent_id = AgentId::new("hosted-trigger-agent").expect("agent id");
+    let project_id = ProjectId::new("hosted-trigger-project").expect("project id");
+
+    let input = RebornBuildInput::hosted_single_tenant_postgres_from_config_and_env(
+        RebornCompositionProfile::HostedSingleTenant,
+        "hosted-trigger-owner",
+        root.path().to_path_buf(),
+        Some(&config),
+    )
+    .expect("hosted postgres build input resolves from env");
+    let store = input
+        .open_hosted_single_tenant_trigger_access_store()
+        .await
+        .expect("open hosted trigger access store");
+    store
+        .seed_local_access(LocalTriggerAccessSeed {
+            tenant_id: &tenant_id,
+            user_id: &user_id,
+            agent_id: Some(&agent_id),
+            project_id: Some(&project_id),
+            role: LocalTriggerAccessRole::Owner,
+            source: LocalTriggerAccessSource::LocalDevEnvBootstrap,
+        })
+        .await
+        .expect("seed hosted trigger access");
+    drop(store);
+
+    let reopened_input = RebornBuildInput::hosted_single_tenant_postgres_from_config_and_env(
+        RebornCompositionProfile::HostedSingleTenant,
+        "hosted-trigger-owner",
+        root.path().to_path_buf(),
+        Some(&config),
+    )
+    .expect("reopened hosted postgres build input resolves from env");
+    let reopened_store = reopened_input
+        .open_hosted_single_tenant_trigger_access_store()
+        .await
+        .expect("reopen hosted trigger access store");
+
+    assert!(
+        reopened_store
+            .has_active_local_access(&tenant_id, &user_id, Some(&agent_id), Some(&project_id))
+            .await
+            .expect("check reopened hosted trigger access"),
+        "hosted-single-tenant trigger access must persist through the filesystem-backed Postgres store"
+    );
 }
 
 #[cfg(feature = "postgres")]

--- a/docs/reborn/contracts/triggers.md
+++ b/docs/reborn/contracts/triggers.md
@@ -262,19 +262,23 @@ A trigger fire is synthetic inbound, not a parallel agent loop.
   is backed by the real agent/project access source of truth, a normal
   runtime must fail closed instead of enabling the trigger poller with the
   tenant-scope placeholder.
-- Local-dev `run` and `serve` may satisfy that contract by seeding active
-  access rows from trusted operator configuration at boot. `run` reconciles the
-  configured CLI owner for its tenant/agent/no-project scope because the generic
-  `run` path does not yet wire `[identity].default_project` into trigger create
-  scope. `serve` reconciles the env-bearer WebUI user and, when local-dev SSO is
-  enabled, existing admitted SSO users at boot plus each admitted SSO identity
-  at login. Both paths wire the same store as the fire-time access checker.
-  This local-dev access table is bootstrap authorization state only; it is not
-  the production agent/project membership source of truth and must not be used
-  to justify enabling trigger polling in a production or multi-tenant runtime.
-  Bootstrap-owned active rows no longer present in the trusted local admission
-  set are marked inactive, while manually inactive rows are not silently
-  reactivated. The seeded row is exact
+- Local-dev and hosted-single-tenant `run`/`serve` may satisfy that contract by
+  seeding active access rows from trusted operator configuration. Local-dev
+  stores those rows in the local `reborn-local-dev.db` sidecar. Hosted
+  single-tenant stores the same bootstrap records through the host filesystem
+  abstraction backed by its resolved PostgreSQL runtime storage, so access
+  survives process restarts and ephemeral local files without adding a
+  trigger-access-specific SQL table. `run` reconciles the configured CLI owner
+  for its tenant/agent/no-project scope because the generic `run` path does
+  not yet wire `[identity].default_project` into trigger create scope. `serve`
+  reconciles the env-bearer WebUI user at boot when trigger polling is enabled,
+  and SSO seeds each admitted identity at login when SSO is enabled. Both paths
+  wire the same store as the fire-time access checker. This bootstrap access
+  record set is authorization state only; it is not the general agent/project
+  membership source of truth and must not be used to justify enabling trigger
+  polling in a multi-tenant runtime. Bootstrap-owned active rows no longer
+  present in the trusted local admission set are marked inactive, while manually
+  inactive rows are not silently reactivated. The seeded row is exact
   `tenant_id`/`creator_user_id`/`agent_id`/`project_id` access; a missing
   project is not a wildcard.
 - The trusted inbound request is a host-owned synthetic inbound shape around the ordinary inbound fields. It carries only ingress identity and turn scope data needed to create the canonical turn, and it has no adapter-supplied requested-scope hints before binding resolution.


### PR DESCRIPTION
## Summary

- Persist hosted-single-tenant local trigger-fire access through the host filesystem abstraction backed by PostgreSQL.
- Keep local-dev trigger access on the existing libSQL sidecar while sharing a backend-neutral store contract.
- Split trigger access storage into backend-specific modules and centralize CLI profile-based store opening.
- Reuse one fire-access checker adapter for all trigger access backends.

## Root Cause

Hosted-single-tenant trigger-fire access was being treated like the local ephemeral sidecar path, so after restart the trigger poller could not find an active local access record and denied outbound Slack delivery.

## Validation

- `cargo check -p ironclaw_reborn_cli --features webui-v2-beta,postgres,slack-v2-host-beta`
- `cargo test -p ironclaw_reborn --features webui-user-store,filesystem-local-trigger-access local_trigger_access`
- `cargo test -p ironclaw_reborn_cli --no-default-features --features webui-v2-beta,postgres trigger_poller`
- `cargo test -p ironclaw_reborn_cli --no-default-features --features webui-v2-beta,postgres local_trigger`
- `git diff --check`
