### PR TITLE
[codex] Guard Reborn debug logs from compiler spam

### DIFF
--- a/crates/ironclaw_reborn_cli/AGENTS.md
+++ b/crates/ironclaw_reborn_cli/AGENTS.md
@@ -17,6 +17,11 @@ This crate owns the standalone `ironclaw-reborn` command surface. Keep it small,
 - no v1 runtime imports: do not depend on root `ironclaw`, `src/agent`, channels, worker, DB, setup, service, sandbox, or `ironclaw_engine`.
 - Do not add workspace dependencies beyond `ironclaw_reborn_composition`, `ironclaw_reborn_config`, `ironclaw_reborn_traces`, and `ironclaw_reborn_webui_ingress` (host-owned WebUI serve lifecycle) without an architecture test update and explicit PR rationale. Provider registry/auth/model UX should enter through the Reborn composition provider-admin facade, not a separate CLI-only path.
 
+## Logging
+
+- `IRONCLAW_REBORN_LOG=debug` is operator-facing stderr logging in hosted deployments. Broad debug filters must keep low-level dependency spam suppressed unless an operator names the dependency target explicitly.
+- When adding runtime dependencies that can emit high-volume DEBUG logs during normal startup or request handling, add them to `REBORN_NOISY_LOG_TARGETS` and extend `reborn_log_filter_suppresses_noisy_targets_for_broad_debug`.
+
 ## Adding a command
 
 1. Add `src/commands/<name>.rs` with a clap `Args` type and an `execute` method.

--- a/crates/ironclaw_reborn_cli/src/runtime/mod.rs
+++ b/crates/ironclaw_reborn_cli/src/runtime/mod.rs
@@ -1,5 +1,7 @@
 use std::io::{IsTerminal, Write};
-use std::path::{Path, PathBuf};
+#[cfg(feature = "webui-v2-beta")]
+use std::path::Path;
+use std::path::PathBuf;
 #[cfg(feature = "webui-v2-beta")]
 use std::sync::Arc;
 use std::time::Duration;
@@ -79,6 +81,8 @@ const REBORN_NOISY_LOG_TARGETS: &[(&str, &str)] = &[
     ("rustls", "warn"),
     ("tower", "warn"),
     ("tower_http", "warn"),
+    ("cranelift_codegen", "warn"),
+    ("wasmtime_internal_cranelift", "warn"),
     ("ironclaw_llm", "info"),
 ];
 
@@ -1190,6 +1194,8 @@ mod tests {
         assert!(filter.contains("rustls=warn"));
         assert!(filter.contains("tower=warn"));
         assert!(filter.contains("tower_http=warn"));
+        assert!(filter.contains("cranelift_codegen=warn"));
+        assert!(filter.contains("wasmtime_internal_cranelift=warn"));
         assert!(filter.contains("ironclaw_llm=info"));
     }
 


### PR DESCRIPTION
## Summary

Fixes #5237.

Broad hosted Reborn debug logging (`IRONCLAW_REBORN_LOG=debug`) currently preserves the broad `debug` directive and only suppresses the dependency targets listed in `REBORN_NOISY_LOG_TARGETS`. Production Railway logs showed `cranelift_codegen` and `wasmtime_internal_cranelift` DEBUG compiler timing output flooding the deployment and triggering Railway log drops.

This PR:

- adds `cranelift_codegen=warn` and `wasmtime_internal_cranelift=warn` to the Reborn noisy-target guard
- extends the existing broad-debug regression test to pin those targets
- documents the hosted debug logging invariant in `crates/ironclaw_reborn_cli/AGENTS.md`
- keeps explicit operator target directives working, so an operator can still opt into compiler internals deliberately

## Evidence

Railway retained log examples from deployment `3e28add8-824b-42c1-bea4-d2533fdddc48` at commit `44f063d97fcf204d78cde198c262c9881a704bb3`:

```text
2026-06-25T12:09:15.808605851Z ... DEBUG cranelift_codegen::timing::enabled: timing: Starting Compilation passes, (during <no pass>)
2026-06-25T12:09:15.818014621Z ... DEBUG wasmtime_internal_cranelift::compiler: `component-trampolines[14]-array-call-component-lower-import[8]` compiled in 0ns
2026-06-25T12:09:19.307141663Z Railway rate limit of 500 logs/sec reached for replica ... Messages dropped: 9101
2026-06-25T12:09:29.307033290Z Railway rate limit of 500 logs/sec reached for replica ... Messages dropped: 7228
```

## Regression Proof

First, I added only the new assertions on unpatched `origin/main` and ran:

```bash
cargo test -p ironclaw_reborn_cli reborn_log_filter_suppresses_noisy_targets_for_broad_debug -- --nocapture
```

That failed with:

```text
assertion failed: filter.contains("cranelift_codegen=warn")
```

After the fix, the focused test and full package suite pass.

## Validation

```bash
cargo test -p ironclaw_reborn_cli reborn_log_filter -- --nocapture
cargo test -p ironclaw_reborn_cli
cargo fmt --check
cargo test -p ironclaw_architecture reborn
cargo clippy -p ironclaw_reborn_cli --all-targets -- -D warnings
```

## Maintainability Review

The fix is intentionally a data-list extension in the existing filter guard plus regression assertions. It adds no new logging mode, no branching, and no new abstraction. The existing `log_filter_mentions_target` behavior still preserves explicit operator opt-ins for dependency targets.
