### PR TITLE
fix(triggers): recover stale claim-only fires

### DIFF
--- a/crates/ironclaw_reborn_composition/src/trigger_poller.rs
+++ b/crates/ironclaw_reborn_composition/src/trigger_poller.rs
@@ -463,6 +463,7 @@ mod tests {
                     poll_interval: Duration::from_millis(50),
                     fires_per_tick: 1,
                     max_concurrent_fires_per_trigger: 1,
+                    ..TriggerPollerWorkerConfig::default()
                 },
                 TriggerPollerWorkerDeps {
                     repository: repo,

--- a/crates/ironclaw_triggers/src/worker/active_cleanup.rs
+++ b/crates/ironclaw_triggers/src/worker/active_cleanup.rs
@@ -6,7 +6,7 @@ use crate::{
 use super::{
     TriggerActiveRunState, TriggerActiveRunStateRequest, TriggerPollerFailureReason,
     TriggerPollerFireOutcome, TriggerPollerFireReport, TriggerPollerTickReport,
-    TriggerPollerWorker,
+    TriggerPollerWorker, failure::classify_failure,
 };
 
 struct ActiveLookupItem {
@@ -40,22 +40,33 @@ impl TriggerPollerWorker {
                 continue;
             };
             let Some(run_id) = record.active_run_ref else {
-                // Keep claim-only rows blocked until recovery has lease or age
-                // evidence that clearing cannot double-submit after a crash.
-                // Still advance the scan cursor: otherwise one claim-only row
-                // at the front of a page can starve every later active run.
-                if first_unadvanced_cursor.is_none() {
-                    next_cursor = Some(record_cursor);
-                }
+                let outcome = match self
+                    .recover_stale_claim_only_fire(record.clone(), fire_slot, report.now)
+                    .await
+                {
+                    Ok(Some(outcome)) => outcome,
+                    Ok(None) => TriggerPollerFireOutcome::SkippedAlreadyActive {
+                        active_fire_slot: fire_slot,
+                        active_run_ref: None,
+                    },
+                    Err(error) => {
+                        let classification = classify_failure(&error);
+                        TriggerPollerFireOutcome::DueFireFailed {
+                            reason: classification.reason,
+                        }
+                    }
+                };
                 report.results.push(TriggerPollerFireReport {
                     tenant_id: record.tenant_id,
                     trigger_id: record.trigger_id,
                     fire_slot,
-                    outcome: TriggerPollerFireOutcome::SkippedAlreadyActive {
-                        active_fire_slot: fire_slot,
-                        active_run_ref: None,
-                    },
+                    outcome,
                 });
+                // Advance the scan cursor even when recovery is deferred or
+                // fails, so one claim-only row cannot starve later active runs.
+                if first_unadvanced_cursor.is_none() {
+                    next_cursor = Some(record_cursor);
+                }
                 continue;
             };
             let result_index = lookup_requests.len();
@@ -176,6 +187,32 @@ impl TriggerPollerWorker {
         }
         self.set_active_scan_cursor(next_cursor)?;
         Ok(())
+    }
+
+    async fn recover_stale_claim_only_fire(
+        &self,
+        record: TriggerRecord,
+        fire_slot: chrono::DateTime<chrono::Utc>,
+        now: chrono::DateTime<chrono::Utc>,
+    ) -> Result<Option<TriggerPollerFireOutcome>, TriggerError> {
+        let runs = self
+            .deps
+            .repository
+            .list_trigger_run_history(record.tenant_id.clone(), record.trigger_id, 1)
+            .await?;
+        let Some(run) = runs.into_iter().find(|run| run.fire_slot == fire_slot) else {
+            return Ok(None);
+        };
+        let Ok(age) = now.signed_duration_since(run.submitted_at).to_std() else {
+            return Ok(None);
+        };
+        if age < self.config.claim_only_recovery_grace {
+            return Ok(None);
+        }
+
+        self.process_claimed_fire(record, fire_slot, now)
+            .await
+            .map(Some)
     }
 
     async fn list_active_cleanup_page(

--- a/crates/ironclaw_triggers/src/worker/config.rs
+++ b/crates/ironclaw_triggers/src/worker/config.rs
@@ -9,6 +9,7 @@ pub struct TriggerPollerWorkerConfig {
     pub poll_interval: Duration,
     pub fires_per_tick: usize,
     pub max_concurrent_fires_per_trigger: usize,
+    pub claim_only_recovery_grace: Duration,
 }
 
 impl Default for TriggerPollerWorkerConfig {
@@ -17,6 +18,7 @@ impl Default for TriggerPollerWorkerConfig {
             poll_interval: Duration::from_secs(30),
             fires_per_tick: 32,
             max_concurrent_fires_per_trigger: 1,
+            claim_only_recovery_grace: Duration::from_secs(120),
         }
     }
 }
@@ -36,6 +38,11 @@ impl TriggerPollerWorkerConfig {
         if self.max_concurrent_fires_per_trigger != 1 {
             return Err(TriggerError::InvalidPollerConfig {
                 reason: "V1 supports exactly one concurrent fire per trigger".to_string(),
+            });
+        }
+        if self.claim_only_recovery_grace.is_zero() {
+            return Err(TriggerError::InvalidPollerConfig {
+                reason: "claim_only_recovery_grace must be non-zero".to_string(),
             });
         }
         Ok(())

--- a/crates/ironclaw_triggers/src/worker/config.rs
+++ b/crates/ironclaw_triggers/src/worker/config.rs
@@ -18,7 +18,7 @@ impl Default for TriggerPollerWorkerConfig {
             poll_interval: Duration::from_secs(30),
             fires_per_tick: 32,
             max_concurrent_fires_per_trigger: 1,
-            claim_only_recovery_grace: Duration::from_secs(120),
+            claim_only_recovery_grace: Duration::from_secs(60),
         }
     }
 }

--- a/crates/ironclaw_triggers/src/worker/due_fire.rs
+++ b/crates/ironclaw_triggers/src/worker/due_fire.rs
@@ -63,7 +63,7 @@ impl TriggerPollerWorker {
         Ok(outcome)
     }
 
-    async fn process_claimed_fire(
+    pub(super) async fn process_claimed_fire(
         &self,
         record: TriggerRecord,
         fire_slot: Timestamp,

--- a/crates/ironclaw_triggers/src/worker/tests.rs
+++ b/crates/ironclaw_triggers/src/worker/tests.rs
@@ -101,6 +101,15 @@ fn worker_config_rejects_noop_or_unsupported_settings() {
         config.validate(),
         Err(TriggerError::InvalidPollerConfig { .. })
     ));
+
+    let config = TriggerPollerWorkerConfig {
+        claim_only_recovery_grace: Duration::ZERO,
+        ..TriggerPollerWorkerConfig::default()
+    };
+    assert!(matches!(
+        config.validate(),
+        Err(TriggerError::InvalidPollerConfig { .. })
+    ));
 }
 
 #[test]
@@ -1403,14 +1412,21 @@ async fn tick_keeps_missing_active_run_blocked() {
 }
 
 #[tokio::test]
-async fn tick_keeps_claim_only_active_fire_blocked() {
+async fn tick_keeps_fresh_claim_only_active_fire_blocked() {
     let repo = Arc::new(InMemoryTriggerRepository::default());
     let trigger_id = TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid");
     let fire_slot = ts(1_704_067_200);
-    let mut record = sample_record(trigger_id, tenant("tenant-a"), fire_slot);
-    record.active_fire_slot = Some(fire_slot);
-    record.active_run_ref = None;
-    repo.upsert_trigger(record).await.expect("insert active");
+    repo.upsert_trigger(sample_record(trigger_id, tenant("tenant-a"), fire_slot))
+        .await
+        .expect("insert active");
+    repo.claim_due_fire(ClaimDueFireRequest {
+        tenant_id: tenant("tenant-a"),
+        trigger_id,
+        fire_slot,
+        now: fire_slot,
+    })
+    .await
+    .expect("claim fire");
     let materializer = Arc::new(RecordingMaterializer::success("content:trigger-fire"));
     let submitter = Arc::new(RecordingSubmitter::with_outcomes(Vec::new()));
     let active_lookup = Arc::new(RecordingActiveRunLookup::with_state(
@@ -1425,7 +1441,10 @@ async fn tick_keeps_claim_only_active_fire_blocked() {
         active_lookup.clone(),
     );
 
-    let report = worker.tick_once(fire_slot).await.expect("tick succeeds");
+    let report = worker
+        .tick_once(fire_slot + chrono::Duration::seconds(30))
+        .await
+        .expect("tick succeeds");
 
     assert!(matches!(
         report.results.first().map(|result| &result.outcome),
@@ -1444,6 +1463,75 @@ async fn tick_keeps_claim_only_active_fire_blocked() {
         .expect("record present");
     assert_eq!(persisted.active_fire_slot, Some(fire_slot));
     assert_eq!(persisted.active_run_ref, None);
+}
+
+#[tokio::test]
+async fn tick_recovers_stale_claim_only_active_fire_by_replaying_submit() {
+    let repo = Arc::new(InMemoryTriggerRepository::default());
+    let trigger_id = TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid");
+    let fire_slot = ts(1_704_067_200);
+    let replayed_run_id = TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f5a").expect("run id");
+    let thread_id = ThreadId::new("recovered-trigger-thread").expect("thread id");
+    repo.upsert_trigger(sample_record(trigger_id, tenant("tenant-a"), fire_slot))
+        .await
+        .expect("insert active");
+    repo.claim_due_fire(ClaimDueFireRequest {
+        tenant_id: tenant("tenant-a"),
+        trigger_id,
+        fire_slot,
+        now: fire_slot,
+    })
+    .await
+    .expect("claim fire");
+    let materializer = Arc::new(RecordingMaterializer::success("content:trigger-fire"));
+    let submitter = Arc::new(RecordingSubmitter::with_outcomes(vec![Ok(
+        TrustedTriggerFireSubmitOutcome::Replayed {
+            original_run_id: replayed_run_id,
+            replayed_at: fire_slot + chrono::Duration::seconds(121),
+            thread_id: Some(thread_id.clone()),
+        },
+    )]));
+    let active_lookup = Arc::new(RecordingActiveRunLookup::default());
+    let worker = worker_with_config(
+        repo.clone(),
+        Arc::new(crate::ScheduleTriggerSourceProvider),
+        materializer.clone(),
+        submitter.clone(),
+        active_lookup.clone(),
+        TriggerPollerWorkerConfig {
+            claim_only_recovery_grace: Duration::from_secs(120),
+            ..TriggerPollerWorkerConfig::default()
+        },
+    );
+
+    let report = worker
+        .tick_once(fire_slot + chrono::Duration::seconds(121))
+        .await
+        .expect("tick succeeds");
+
+    assert_eq!(
+        report.results.first().map(|result| &result.outcome),
+        Some(&TriggerPollerFireOutcome::Replayed {
+            original_run_id: replayed_run_id
+        })
+    );
+    assert_eq!(materializer.fires().len(), 1);
+    assert_eq!(submitter.requests().len(), 1);
+    assert_eq!(active_lookup.requests().len(), 0);
+    let persisted = repo
+        .get_trigger(tenant("tenant-a"), trigger_id)
+        .await
+        .expect("load")
+        .expect("record present");
+    assert_eq!(persisted.active_fire_slot, Some(fire_slot));
+    assert_eq!(persisted.active_run_ref, Some(replayed_run_id));
+    assert_eq!(persisted.last_fired_slot, Some(fire_slot));
+    let runs = repo
+        .list_trigger_run_history(tenant("tenant-a"), trigger_id, 1)
+        .await
+        .expect("load run history");
+    assert_eq!(runs[0].run_id, Some(replayed_run_id));
+    assert_eq!(runs[0].thread_id, Some(thread_id));
 }
 
 #[tokio::test]

--- a/crates/ironclaw_triggers/src/worker/tests.rs
+++ b/crates/ironclaw_triggers/src/worker/tests.rs
@@ -1487,7 +1487,7 @@ async fn tick_recovers_stale_claim_only_active_fire_by_replaying_submit() {
     let submitter = Arc::new(RecordingSubmitter::with_outcomes(vec![Ok(
         TrustedTriggerFireSubmitOutcome::Replayed {
             original_run_id: replayed_run_id,
-            replayed_at: fire_slot + chrono::Duration::seconds(121),
+            replayed_at: fire_slot + chrono::Duration::seconds(61),
             thread_id: Some(thread_id.clone()),
         },
     )]));
@@ -1499,13 +1499,13 @@ async fn tick_recovers_stale_claim_only_active_fire_by_replaying_submit() {
         submitter.clone(),
         active_lookup.clone(),
         TriggerPollerWorkerConfig {
-            claim_only_recovery_grace: Duration::from_secs(120),
+            claim_only_recovery_grace: Duration::from_secs(60),
             ..TriggerPollerWorkerConfig::default()
         },
     );
 
     let report = worker
-        .tick_once(fire_slot + chrono::Duration::seconds(121))
+        .tick_once(fire_slot + chrono::Duration::seconds(61))
         .await
         .expect("tick succeeds");
 

--- a/docs/reborn/contracts/triggers.md
+++ b/docs/reborn/contracts/triggers.md
@@ -369,6 +369,12 @@ Slot bookkeeping is tied to acceptance, not merely polling:
   in that order; `active_fire_slot` is written before turn submission and
   `active_run_ref` is populated only after the accepted/replayed submit result
   returns a `TurnRunId`;
+- stale claim-only rows with `active_fire_slot` but no `active_run_ref` are
+  recovered by re-entering the same trusted submit path after a grace period.
+  The deterministic fire identity and trusted conversation binding must replay
+  any already accepted turn and backfill `active_run_ref` plus run-history
+  `thread_id`, instead of clearing the claim or minting a separate recovery
+  ledger;
 - retryable submit failures write `last_status = Error`, clear
   `active_fire_slot` and `active_run_ref`, leave `last_fired_slot` and
   `last_run_at` unchanged, and keep `next_run_at` at or before the failed


### PR DESCRIPTION
## Summary
- recover stale trigger fires that were claimed but never settled with `active_run_ref` after turn submission
- replay stale claim-only fires through the existing trusted submit path so deterministic fire identity backfills the original run/thread mapping
- keep fresh claim-only rows blocked during a grace period and document the recovery contract

## Root cause
A poller crash or backend failure after trusted turn submission but before `mark_fire_accepted`/`mark_fire_replayed` left `trigger_records.active_fire_slot` set while `active_run_ref` and `trigger_run_history.thread_id` stayed null. Slack delivery could still happen from the in-memory accepted turn scope, but WebUI automation links and trigger-thread fallback depend on run history, so the thread became inaccessible and future fires stayed blocked.

## Tests
- `cargo test -p ironclaw_triggers claim_only`
- `cargo test -p ironclaw_triggers`
- `cargo check -p ironclaw_reborn_composition`
- `git diff --check`