### PR TITLE
fix(turns): remove prompt-assembly content denylist (#5169)

### DIFF
--- a/crates/ironclaw_turns/src/run_profile/instruction_bundle.rs
+++ b/crates/ironclaw_turns/src/run_profile/instruction_bundle.rs
@@ -916,4 +916,34 @@ mod tests {
 
         assert_eq!(error.kind, AgentLoopHostErrorKind::Internal);
     }
+
+    /// #5169 regression at the real call site: a (non-trusted) context snippet whose
+    /// body merely mentions security vocabulary / host paths must no longer be
+    /// rejected during prompt assembly.
+    #[test]
+    fn push_snippet_message_allows_benign_security_vocabulary() {
+        let mut messages: Vec<LoopModelMessage> = Vec::new();
+        let mut materialized: Vec<InstructionBundleMaterializedMessage> = Vec::new();
+        let mut fingerprint = Sha256::new();
+        let content_ref = LoopMessageRef::new("msg:instruction.source.0.deadbeefdeadbeef").unwrap();
+        let snippet = LoopContextSnippet {
+            snippet_ref: "memory:thread-history".to_string(),
+            model_content: "Never construct Authorization headers manually; the system \
+                            injects the bearer token. Logs go to /tmp/app."
+                .to_string(),
+            safe_summary: "github usage note".to_string(),
+            metadata: None,
+        };
+
+        push_snippet_message(
+            &mut messages,
+            &mut materialized,
+            &mut fingerprint,
+            "instruction",
+            0,
+            content_ref,
+            &snippet,
+        )
+        .expect("benign security vocabulary in a snippet must be allowed after #5169");
+    }
 }

--- a/crates/ironclaw_turns/src/run_profile/prompt_text.rs
+++ b/crates/ironclaw_turns/src/run_profile/prompt_text.rs
@@ -3,49 +3,6 @@ use super::{
 };
 
 const MODEL_SAFE_SUMMARY_MAX_BYTES: usize = 4096;
-const SENSITIVE_TERMS: &[SensitiveTerm] = &[
-    sensitive_term("access token", true, true),
-    sensitive_term("api key", true, true),
-    sensitive_term("api_key", true, true),
-    sensitive_term("api secret", true, true),
-    sensitive_term("authorization", true, true),
-    sensitive_term("bearer", true, true),
-    sensitive_term("client secret", true, true),
-    sensitive_term("invalid api key", true, false),
-    sensitive_term("password", true, true),
-    sensitive_term("passwd", true, true),
-    sensitive_term("secret key", true, true),
-    sensitive_term("secret-key", true, true),
-    sensitive_term("secret token", true, true),
-    sensitive_term("secret_token", true, true),
-    sensitive_term("shared secret", true, true),
-];
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct SensitiveTerm {
-    /// Some terms, such as "invalid api key", are phrase-only so ordinary
-    /// diagnostic prose after the phrase is not parsed as a credential value.
-    phrase: &'static str,
-    reject_as_phrase: bool,
-    reject_value_after_label: bool,
-}
-
-const fn sensitive_term(
-    phrase: &'static str,
-    reject_as_phrase: bool,
-    reject_value_after_label: bool,
-) -> SensitiveTerm {
-    SensitiveTerm {
-        phrase,
-        reject_as_phrase,
-        reject_value_after_label,
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct PromptTextPolicy {
-    reject_security_vocabulary: bool,
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum PromptTextSurface {
@@ -63,12 +20,6 @@ impl PromptTextSurface {
             }
         }
     }
-
-    const fn policy(self) -> PromptTextPolicy {
-        PromptTextPolicy {
-            reject_security_vocabulary: !matches!(self, Self::TrustedSkillInstruction),
-        }
-    }
 }
 
 pub(super) fn validate_model_safe_text(
@@ -78,6 +29,14 @@ pub(super) fn validate_model_safe_text(
     validate_prompt_text(value, label, PromptTextSurface::SafeSummary)
 }
 
+/// Validates host-assembled text bound for the model prompt.
+///
+/// This enforces only *structural* safety: non-empty, within the surface byte
+/// budget, and free of control characters. Content-based secret/vocabulary
+/// denylisting was removed — it false-positived constantly on ordinary skill
+/// and tool docs (which mention "authorization", "api key", host paths, etc.)
+/// and protected nothing that credential injection and egress credential
+/// blocking don't already cover. See #5169.
 pub(super) fn validate_prompt_text(
     value: String,
     label: &'static str,
@@ -98,193 +57,60 @@ pub(super) fn validate_prompt_text(
             format!("{label} contains control characters"),
         ));
     }
-    reject_sensitive_text(&value, label, surface)?;
     Ok(value)
 }
 
-fn reject_sensitive_text(
-    value: &str,
-    label: &'static str,
-    surface: PromptTextSurface,
-) -> Result<(), AgentLoopHostError> {
-    let lower = value.to_ascii_lowercase();
-    let policy = surface.policy();
-    for forbidden_path in [
-        "/users/",
-        "/home/",
-        "/private/",
-        "/tmp/", // safety: model-safety denylist literal, not a filesystem temp path.
-        "/var/",
-        "/etc/",
-    ] {
-        if lower.contains(forbidden_path) {
-            return non_model_safe(label);
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// #5169: host-assembled content (skill docs, instructions, memory) may freely
+    /// contain security vocabulary, host paths, and even credential-shaped values.
+    /// The prompt validator no longer denylists content — secrets are guarded by
+    /// credential injection + egress blocking, not here.
+    #[test]
+    fn content_is_not_denylisted_only_structurally_validated() {
+        for content in [
+            "Never construct Authorization headers manually; the system injects them.",
+            "Provide your api key in settings, then we use the bearer token for you.",
+            "Reset your password from the account page.",
+            "Build artifacts go to /tmp/build and config lives in /etc/myapp.",
+            "authorization: Bearer ey9aZ1c2d3e4f5g6h7",
+            "api key: AKIA1234567890ABCD",
+            "here is my key sk-abc123def456ghi789",
+        ] {
+            validate_prompt_text(
+                content.to_string(),
+                "context snippet content",
+                PromptTextSurface::GenericModelContent,
+            )
+            .unwrap_or_else(|error| {
+                panic!("content must pass structural validation; got {error:?}: {content:?}")
+            });
         }
     }
-    for term in SENSITIVE_TERMS {
-        if policy.reject_security_vocabulary
-            && term.reject_as_phrase
-            && contains_token_phrase(&lower, term.phrase)
-        {
-            return non_model_safe(label);
-        }
-        if term.reject_value_after_label
-            && contains_credential_value_after_label(&lower, term.phrase)
-        {
-            return non_model_safe(label);
-        }
+
+    /// Structural limits still apply: control characters are rejected.
+    #[test]
+    fn control_characters_are_still_rejected() {
+        let error = validate_prompt_text(
+            "bad\u{0007}content".to_string(),
+            "context snippet content",
+            PromptTextSurface::GenericModelContent,
+        )
+        .expect_err("control characters must be rejected");
+        assert_eq!(error.kind, AgentLoopHostErrorKind::PolicyDenied);
     }
-    if lower
-        .split(|character: char| !character.is_ascii_alphanumeric() && character != '-')
-        .any(|token| token.starts_with("sk-"))
-    {
-        return non_model_safe(label);
-    }
-    Ok(())
-}
 
-fn contains_credential_value_after_label(value: &str, label: &str) -> bool {
-    value.match_indices(label).any(|(start, matched)| {
-        let end = start + matched.len();
-        if !is_token_boundary(char_before(value, start)) || !is_token_boundary(char_at(value, end))
-        {
-            return false;
-        }
-        let suffix = &value[end..];
-        credential_value_candidate(suffix).is_some_and(is_secret_like_token)
-            || (label == "authorization"
-                && authorization_scheme_value_candidate(suffix).is_some_and(is_secret_like_token))
-    })
-}
-
-fn credential_value_candidate(suffix: &str) -> Option<&str> {
-    credential_value_candidates(suffix).next()
-}
-
-fn authorization_scheme_value_candidate(suffix: &str) -> Option<&str> {
-    let mut candidates = credential_value_candidates(suffix);
-    let scheme = candidates.next()?;
-    is_authorization_scheme(scheme)
-        .then(|| candidates.next())
-        .flatten()
-}
-
-fn credential_value_candidates(suffix: &str) -> impl Iterator<Item = &str> {
-    suffix
-        .trim_start_matches(|character: char| {
-            character.is_ascii_whitespace() || matches!(character, ':' | '=' | '\'' | '"' | '`')
-        })
-        .split(|character: char| character.is_ascii_whitespace() || matches!(character, ',' | ';'))
-        .map(|candidate| {
-            candidate.trim_matches(|character| {
-                matches!(
-                    character,
-                    '\'' | '"'
-                        | '`'
-                        | '.'
-                        | ','
-                        | ';'
-                        | ':'
-                        | '('
-                        | ')'
-                        | '['
-                        | ']'
-                        | '{'
-                        | '}'
-                        | '<'
-                        | '>'
-                )
-            })
-        })
-        .filter(|candidate| !candidate.is_empty())
-}
-
-fn is_authorization_scheme(candidate: &str) -> bool {
-    ["basic", "bearer", "digest", "negotiate", "oauth", "token"].contains(&candidate)
-}
-
-fn is_secret_like_token(candidate: &str) -> bool {
-    if candidate.starts_with('$') {
-        return false;
-    }
-    if [
-        "token",
-        "secret",
-        "password",
-        "key",
-        "value",
-        "example",
-        "placeholder",
-        "redacted",
-        "your-token",
-        "your_token",
-        "api-key",
-        "api_key",
-        "bearer",
-    ]
-    .contains(&candidate)
-        || candidate.contains("redacted")
-        || candidate.contains("placeholder")
-        || candidate.contains("example")
-        || candidate.contains("...")
-    {
-        return false;
-    }
-    if [
-        "ghp_",
-        "github_pat_",
-        "glpat-",
-        "xoxb-",
-        "xoxp-",
-        "akia",
-        "asiai",
-        "sk-",
-        "pk_",
-    ]
-    .iter()
-    .any(|prefix| candidate.starts_with(prefix))
-    {
-        return true;
-    }
-    let contains_alpha = candidate
-        .chars()
-        .any(|character| character.is_ascii_alphabetic());
-    let contains_digit = candidate
-        .chars()
-        .any(|character| character.is_ascii_digit());
-    if candidate.len() >= 6 && contains_alpha && contains_digit {
-        return true;
-    }
-    candidate.len() >= 16
-        && candidate.chars().all(|character| {
-            character.is_ascii_alphanumeric() || matches!(character, '_' | '-' | '.')
-        })
-}
-fn non_model_safe<T>(label: &'static str) -> Result<T, AgentLoopHostError> {
-    Err(AgentLoopHostError::new(
-        AgentLoopHostErrorKind::PolicyDenied,
-        format!("{label} contains non-model-safe content"),
-    ))
-}
-
-fn contains_token_phrase(value: &str, phrase: &str) -> bool {
-    value.match_indices(phrase).any(|(start, matched)| {
-        let end = start + matched.len();
-        is_token_boundary(char_before(value, start)) && is_token_boundary(char_at(value, end))
-    })
-}
-
-fn char_before(value: &str, byte_index: usize) -> Option<char> {
-    value.get(..byte_index)?.chars().next_back()
-}
-
-fn char_at(value: &str, byte_index: usize) -> Option<char> {
-    value.get(byte_index..)?.chars().next()
-}
-
-fn is_token_boundary(character: Option<char>) -> bool {
-    match character {
-        Some(character) => !character.is_ascii_alphanumeric() && character != '_',
-        None => true,
+    /// Structural limits still apply: empty content is rejected.
+    #[test]
+    fn empty_content_is_rejected() {
+        let error = validate_prompt_text(
+            String::new(),
+            "context snippet content",
+            PromptTextSurface::GenericModelContent,
+        )
+        .expect_err("empty content must be rejected");
+        assert_eq!(error.kind, AgentLoopHostErrorKind::PolicyDenied);
     }
 }

--- a/crates/ironclaw_turns/src/run_profile/runtime_context.rs
+++ b/crates/ironclaw_turns/src/run_profile/runtime_context.rs
@@ -348,9 +348,9 @@ fn sanitize_prompt_string(s: &str) -> String {
 /// Render an external label (channel name, delivery target, adapter) for the
 /// model-visible slice. Sanitizes control/format characters, then verifies the
 /// result against the same model-safe-text policy the prompt bundle enforces.
-/// A label that would still trip that policy (e.g. a channel literally named
-/// `#secret-alerts`) degrades to `placeholder` so it can never fail prompt
-/// construction — the slice degrades instead of the whole bundle.
+/// A label that would still trip that policy (e.g. one exceeding the byte
+/// budget) degrades to `placeholder` so it can never fail prompt construction —
+/// the slice degrades instead of the whole bundle.
 fn model_safe_label(value: &str, placeholder: &str) -> String {
     let sanitized = sanitize_prompt_string(value);
     match super::prompt_text::validate_model_safe_text(sanitized.clone(), "runtime context label") {
@@ -841,10 +841,44 @@ mod tests {
     }
 
     #[test]
-    fn delivery_target_label_tripping_model_safe_policy_degrades_to_placeholder() {
-        // A legitimate label can contain a word the model-safe-text policy rejects
-        // (e.g. "authorization"). It must degrade to a placeholder rather than
+    fn delivery_target_label_tripping_structural_policy_degrades_to_placeholder() {
+        // A label that trips the (structural) model-safe policy — here one that
+        // exceeds the byte budget — must degrade to a placeholder rather than
         // surviving into the slice and later failing prompt-bundle construction.
+        let oversized = "x".repeat(8192);
+        let ctx = LoopRuntimeContext {
+            loop_started_at_utc: stamp(),
+            communication: Some(CommunicationRuntimeContext {
+                connected_channels: ConnectedChannelsState::Unknown,
+                delivery_target: DeliveryTargetState::Set(DeliveryTargetSummary {
+                    display_name: oversized.clone(),
+                    channel: "slack".to_string(),
+                }),
+                delivery_tools_visible: false,
+            }),
+            product_context: None,
+            user_profile: None,
+        };
+        let text = ctx.render_model_content();
+        assert!(
+            !text.contains(&oversized),
+            "label tripping the policy must not survive into the slice"
+        );
+        assert!(
+            text.contains("Outbound delivery target: a configured target (slack)"),
+            "label degrades to placeholder, safe channel preserved: {text}"
+        );
+        // The rendered slice must itself pass the model-safe-text policy.
+        assert!(
+            super::super::prompt_text::validate_model_safe_text(text.clone(), "test").is_ok(),
+            "degraded slice must be model-safe: {text}"
+        );
+    }
+
+    #[test]
+    fn delivery_target_label_with_benign_security_word_survives() {
+        // #5169: a benign security *word* (e.g. "authorization") no longer trips the
+        // model-safe policy, so a legitimate label containing it survives intact.
         let ctx = LoopRuntimeContext {
             loop_started_at_utc: stamp(),
             communication: Some(CommunicationRuntimeContext {
@@ -860,17 +894,12 @@ mod tests {
         };
         let text = ctx.render_model_content();
         assert!(
-            !text.contains("authorization"),
-            "denylisted label word must not survive into the slice: {text}"
+            text.contains("Outbound delivery target: authorization (slack)"),
+            "benign security word must survive into the slice after #5169: {text}"
         );
-        assert!(
-            text.contains("Outbound delivery target: a configured target (slack)"),
-            "label degrades to placeholder, safe channel preserved: {text}"
-        );
-        // The rendered slice must itself pass the model-safe-text policy.
         assert!(
             super::super::prompt_text::validate_model_safe_text(text.clone(), "test").is_ok(),
-            "degraded slice must be model-safe: {text}"
+            "slice must be model-safe: {text}"
         );
     }
 

--- a/crates/ironclaw_turns/tests/agent_loop_host_contract.rs
+++ b/crates/ironclaw_turns/tests/agent_loop_host_contract.rs
@@ -873,11 +873,12 @@ async fn instruction_bundle_builder_allows_terms_inside_larger_words() {
 }
 
 #[tokio::test]
-async fn instruction_bundle_builder_rejects_secret_credential_phrases() {
+async fn instruction_bundle_builder_allows_security_vocabulary_without_a_value() {
+    // #5169: a bare credential *label* with no secret value after it is allowed.
     let context = claimed_run_context().await;
     let builder = InstructionBundleBuilder::new(context);
 
-    let error = builder
+    builder
         .build(InstructionBundleRequest {
             context_bundle: LoopContextBundle {
                 identity_messages: Vec::new(),
@@ -896,9 +897,7 @@ async fn instruction_bundle_builder_rejects_secret_credential_phrases() {
             inline_messages: Vec::new(),
             runtime_context: None,
         })
-        .unwrap_err();
-
-    assert_eq!(error.kind, AgentLoopHostErrorKind::PolicyDenied);
+        .expect("a bare credential label without a value must be allowed after #5169");
 }
 
 #[tokio::test]
@@ -1135,65 +1134,63 @@ async fn instruction_bundle_allows_security_vocabulary_in_model_content() {
 }
 
 #[tokio::test]
-async fn instruction_bundle_rejects_trusted_skill_actual_secret_value() {
+async fn instruction_bundle_allows_trusted_skill_credential_value() {
+    // #5169: content denylisting removed — even a credential-shaped value passes the
+    // prompt validator now (secrets are guarded by injection + egress, not here).
     let context = claimed_run_context().await;
-    let error = InstructionBundleBuilder::new(context)
+    InstructionBundleBuilder::new(context)
         .build(skill_instruction_request(
             "Use Authorization: Bearer ghp_secretvalue123",
             "GitHub skill",
             "trusted",
         ))
-        .unwrap_err();
-
-    assert_eq!(error.kind, AgentLoopHostErrorKind::PolicyDenied);
+        .expect("credential-shaped content must pass the validator after #5169");
 }
 
 #[tokio::test]
-async fn instruction_bundle_rejects_trusted_skill_authorization_scheme_secret_value() {
+async fn instruction_bundle_allows_trusted_skill_authorization_scheme_value() {
+    // #5169: an Authorization scheme + value in skill content passes the validator now.
     let context = claimed_run_context().await;
-    let error = InstructionBundleBuilder::new(context)
+    InstructionBundleBuilder::new(context)
         .build(skill_instruction_request(
             "Use Authorization: Basic QWxhZGRpbjpvcGVuIHNlc2FtZTEyMzQ",
             "GitHub skill",
             "trusted",
         ))
-        .unwrap_err();
-
-    assert_eq!(error.kind, AgentLoopHostErrorKind::PolicyDenied);
+        .expect("credential-shaped content must pass the validator after #5169");
 }
 
 #[tokio::test]
-async fn instruction_bundle_rejects_trusted_skill_security_vocabulary_in_summary() {
+async fn instruction_bundle_allows_trusted_skill_security_vocabulary_in_summary() {
+    // #5169: security vocabulary in a skill summary with no secret value is allowed.
     let context = claimed_run_context().await;
-    let error = InstructionBundleBuilder::new(context)
+    InstructionBundleBuilder::new(context)
         .build(skill_instruction_request(
             "Use the GitHub API with an Authorization header.",
             "Use Authorization: Bearer",
             "trusted",
         ))
-        .unwrap_err();
-
-    assert_eq!(error.kind, AgentLoopHostErrorKind::PolicyDenied);
+        .expect("security vocabulary without a value must be allowed after #5169");
 }
 
 #[tokio::test]
-async fn instruction_bundle_rejects_untrusted_skill_security_vocabulary() {
+async fn instruction_bundle_allows_untrusted_skill_security_vocabulary() {
+    // #5169: an untrusted skill mentioning security vocabulary (no value) is allowed.
     let context = claimed_run_context().await;
-    let error = InstructionBundleBuilder::new(context)
+    InstructionBundleBuilder::new(context)
         .build(skill_instruction_request(
             "Use the GitHub API with an Authorization: Bearer header.",
             "GitHub skill",
             "installed",
         ))
-        .unwrap_err();
-
-    assert_eq!(error.kind, AgentLoopHostErrorKind::PolicyDenied);
+        .expect("security vocabulary without a value must be allowed after #5169");
 }
 
 #[tokio::test]
-async fn instruction_bundle_rejects_generic_model_content_security_vocabulary() {
+async fn instruction_bundle_allows_generic_model_content_security_vocabulary() {
+    // #5169: generic (non-skill) instruction content may mention security vocabulary.
     let context = claimed_run_context().await;
-    let error = InstructionBundleBuilder::new(context)
+    InstructionBundleBuilder::new(context)
         .build(InstructionBundleRequest {
             context_bundle: LoopContextBundle {
                 identity_messages: Vec::new(),
@@ -1212,23 +1209,20 @@ async fn instruction_bundle_rejects_generic_model_content_security_vocabulary() 
             inline_messages: Vec::new(),
             runtime_context: None,
         })
-        .unwrap_err();
-
-    assert_eq!(error.kind, AgentLoopHostErrorKind::PolicyDenied);
+        .expect("security vocabulary in generic content must be allowed after #5169");
 }
 
 #[tokio::test]
-async fn instruction_bundle_rejects_trusted_skill_host_path() {
+async fn instruction_bundle_allows_trusted_skill_host_path() {
+    // #5169: host paths in skill content are allowed — a path is not a leak.
     let context = claimed_run_context().await;
-    let error = InstructionBundleBuilder::new(context)
+    InstructionBundleBuilder::new(context)
         .build(skill_instruction_request(
             "Read /Users/alice/.config/token before calling GitHub",
             "GitHub skill",
             "trusted",
         ))
-        .unwrap_err();
-
-    assert_eq!(error.kind, AgentLoopHostErrorKind::PolicyDenied);
+        .expect("a host path in skill content must be allowed after #5169");
 }
 
 #[tokio::test]
@@ -1276,11 +1270,13 @@ async fn instruction_bundle_orders_snippets_by_model_content_when_summary_matche
 }
 
 #[tokio::test]
-async fn instruction_bundle_builder_rejects_unsafe_instruction_context() {
+async fn instruction_bundle_builder_allows_credential_shaped_content() {
+    // #5169: content denylisting removed — credential-shaped content in generic
+    // instruction context passes the validator (guarded by injection + egress).
     let context = claimed_run_context().await;
     let builder = InstructionBundleBuilder::new(context);
 
-    let error = builder
+    builder
         .build(InstructionBundleRequest {
             context_bundle: LoopContextBundle {
                 identity_messages: Vec::new(),
@@ -1288,8 +1284,8 @@ async fn instruction_bundle_builder_rejects_unsafe_instruction_context() {
                 compaction_message_index: Vec::new(),
                 instruction_snippets: vec![LoopContextSnippet {
                     snippet_ref: "instruction:system".to_string(),
-                    model_content: "leaks /Users/alice/.ssh/id_rsa path".to_string(),
-                    safe_summary: "leaks /Users/alice/.ssh/id_rsa path".to_string(),
+                    model_content: "api key: ghp_realsecretvalue123abc".to_string(),
+                    safe_summary: "release review instruction".to_string(),
                     metadata: None,
                 }],
                 memory_snippets: Vec::new(),
@@ -1299,9 +1295,7 @@ async fn instruction_bundle_builder_rejects_unsafe_instruction_context() {
             inline_messages: Vec::new(),
             runtime_context: None,
         })
-        .unwrap_err();
-
-    assert_eq!(error.kind, AgentLoopHostErrorKind::PolicyDenied);
+        .expect("credential-shaped content must pass the validator after #5169");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Problem

The prompt-assembly validator (`run_profile/prompt_text.rs`) terminally failed any turn whose host-assembled content (skill docs, instructions, memory snippets) tripped a content denylist:
- a security **word** — `authorization`, `bearer`, `api key`, `password`
- a host **path** — `/tmp/`, `/etc/`, `/Users/…`
- a credential-shaped **value** — `Authorization: Bearer <token>`, `sk-…`

Skill and tool docs use these constantly, so a wide range of skills wedged (e.g. `github`, pulled in via `code-review`) — surfaced to users as the misleading **"The run failed because the execution driver was temporarily unavailable."**

## Why it's safe to remove the whole thing

The denylist protected nothing that isn't already covered:
- **Credentials never enter the prompt** — they're injected at the tool/network layer.
- **Exfiltration is blocked at egress** (credential-shaped outbound is rejected) and tool output is redacted.

The word/path checks were pure false-positive generators, and the secret-*value* detection was leaky (it only caught a standalone `sk-` or a label-preceded value) and redundant against the layers above. There was no realistic attack where this validator was the load-bearing control.

## What changes

`validate_prompt_text` now enforces **only structural safety**: non-empty, within the surface byte budget, and free of control characters.

All content denylisting — `SENSITIVE_TERMS`, the value-after-label detection, the `sk-` check, the host-path block, and ~150 lines of helpers — is removed (net −120 lines). `runtime_context` still degrades a *structurally*-invalid label (e.g. one over the byte budget) to a placeholder rather than failing the turn.

## Tests

Driven through the caller (`push_snippet_message` / `InstructionBundleBuilder`), per `.claude/rules/testing.md`:
- security vocabulary, host paths, and credential-shaped values **all pass** the validator;
- structural limits (control chars, empty, length) **still apply**.

## Note

With content denylisting gone, the `TrustedSkillInstruction` prompt surface is now behaviorally identical to `GenericModelContent` — could be collapsed in a follow-up.

Closes #5169.

🤖 Generated with [Claude Code](https://claude.com/claude-code)