### PR TITLE
fix(filesystem): fold CAS put directory pre-check into one statement (3→1 round-trip)

### DIFF
--- a/crates/ironclaw_filesystem/src/postgres.rs
+++ b/crates/ironclaw_filesystem/src/postgres.rs
@@ -1077,6 +1077,83 @@ async fn cached_execute(
     client.execute(&statement, params).await
 }
 
+/// `CasExpectation::Absent` put: insert iff `path` is not an implicit directory
+/// (no descendant in the half-open `[prefix/, prefix0)` range); the `ON CONFLICT
+/// DO NOTHING` also blocks an explicit directory or existing file at `path`.
+#[cfg(feature = "postgres")]
+const PUT_ABSENT_SQL: &str = r#"
+    INSERT INTO root_filesystem_entries
+        (path, contents, is_dir, content_type, kind, indexed, version)
+    SELECT $1, $2, FALSE, $3, $4, $5, 1
+    WHERE NOT EXISTS (
+        SELECT 1 FROM root_filesystem_entries
+        WHERE path >= $6 AND path < $7
+        LIMIT 1
+    )
+    ON CONFLICT (path) DO NOTHING
+    "#;
+
+/// `CasExpectation::Version` put: update the file row at the expected version,
+/// rejecting an explicit directory (`is_dir = FALSE`) and — for parity with the
+/// insert arms — any implicit-directory descendant.
+#[cfg(feature = "postgres")]
+const PUT_VERSION_SQL: &str = r#"
+    UPDATE root_filesystem_entries
+    SET contents = $1,
+        content_type = $2,
+        kind = $3,
+        indexed = $4,
+        version = version + 1,
+        updated_at = NOW()
+    WHERE path = $5 AND is_dir = FALSE AND version = $6
+      AND NOT EXISTS (
+          SELECT 1 FROM root_filesystem_entries AS child
+          WHERE child.path >= $7 AND child.path < $8
+          LIMIT 1
+      )
+    "#;
+
+/// `CasExpectation::Any` put: upsert unless a descendant makes `path` an
+/// implicit directory; the `ON CONFLICT` guard rejects an explicit directory.
+/// `RETURNING version` removes the separate version read-back.
+#[cfg(feature = "postgres")]
+const PUT_ANY_SQL: &str = r#"
+    INSERT INTO root_filesystem_entries
+        (path, contents, is_dir, content_type, kind, indexed, version)
+    SELECT $1, $2, FALSE, $3, $4, $5, 1
+    WHERE NOT EXISTS (
+        SELECT 1 FROM root_filesystem_entries
+        WHERE path >= $6 AND path < $7
+        LIMIT 1
+    )
+    ON CONFLICT (path) DO UPDATE SET
+        contents = EXCLUDED.contents,
+        content_type = EXCLUDED.content_type,
+        kind = EXCLUDED.kind,
+        indexed = EXCLUDED.indexed,
+        version = root_filesystem_entries.version + 1,
+        updated_at = NOW()
+    WHERE root_filesystem_entries.is_dir = FALSE
+    RETURNING version
+    "#;
+
+/// CAS put for the Postgres backend.
+///
+/// **Round-trip budget: 1 statement on the happy path.** The directory
+/// invariant — reject writing a file where (a) an explicit directory exists at
+/// the exact path or (b) an implicit-directory child exists — is folded into the
+/// single write statement rather than issued as two separate `SELECT`
+/// pre-checks. Each CAS arm guards the write with a `NOT EXISTS` descendant scan
+/// over the half-open `[prefix/, prefix0)` range (rejecting implicit
+/// directories). An explicit directory at `path` is rejected by the
+/// `ON CONFLICT` clause in the INSERT arms and by `is_dir = FALSE` in the UPDATE
+/// arm, so a successful put costs exactly one round-trip (previously:
+/// exact-entry `SELECT` + child-scan `SELECT` + the write = three).
+///
+/// On the *rare* 0-row outcome we make one follow-up read
+/// (`diagnose_put_failure`) to reproduce the exact error the old pre-check and
+/// version read would have produced: `directory_write_error` for a directory
+/// conflict, `VersionMismatch` otherwise. The happy path never pays for it.
 #[cfg(feature = "postgres")]
 async fn postgres_put_with_client(
     client: &deadpool_postgres::Object,
@@ -1084,13 +1161,6 @@ async fn postgres_put_with_client(
     entry: Entry,
     cas: CasExpectation,
 ) -> Result<RecordVersion, FilesystemError> {
-    if matches!(
-        postgres_exact_entry_with_client(client, path).await?,
-        Some((_, FileType::Directory, _))
-    ) || postgres_has_child_entry_with_client(client, path).await?
-    {
-        return Err(directory_write_error(path.clone()));
-    }
     let indexed_json =
         serde_json::to_value(&entry.indexed).map_err(|_| FilesystemError::SerializeIndexed {
             path: path.clone(),
@@ -1100,51 +1170,43 @@ async fn postgres_put_with_client(
     let content_type_str = entry.content_type.as_str().to_string();
     let body = entry.body;
     let path_str = path.as_str();
+    let (child_lower, child_upper) = descendant_path_range(path);
 
     match cas {
         CasExpectation::Absent => {
+            // INSERT only when no descendant (implicit directory) exists; the
+            // half-open range excludes `path` itself, so it never sees the row
+            // being inserted. ON CONFLICT DO NOTHING also yields 0 rows when an
+            // explicit directory already occupies `path` — disambiguated below.
             let rows = cached_execute(
                 client,
-                r#"
-                    INSERT INTO root_filesystem_entries
-                        (path, contents, is_dir, content_type, kind, indexed, version)
-                    VALUES ($1, $2, FALSE, $3, $4, $5, 1)
-                    ON CONFLICT (path) DO NOTHING
-                    "#,
+                PUT_ABSENT_SQL,
                 &[
                     &path_str,
                     &body,
                     &content_type_str,
                     &kind_str,
                     &indexed_json,
+                    &child_lower,
+                    &child_upper,
                 ],
             )
             .await
             .map_err(|error| db_error(path.clone(), FilesystemOperation::WriteFile, error))?;
             if rows == 0 {
-                let found = postgres_current_version_with_client(client, path).await?;
-                return Err(FilesystemError::VersionMismatch {
-                    path: path.clone(),
-                    expected: None,
-                    found,
-                });
+                return Err(diagnose_put_failure(client, path, None).await?);
             }
             Ok(RecordVersion::from_backend(1))
         }
         CasExpectation::Version(expected) => {
             let expected_raw = record_version_to_i64(path, expected)?;
+            // A `Version` CAS implies the file row already exists, so a child
+            // under a file path is impossible by construction; the `NOT EXISTS`
+            // descendant guard is carried for defense-in-depth parity with the
+            // INSERT arms. `is_dir = FALSE` rejects an explicit directory.
             let rows = cached_execute(
                 client,
-                r#"
-                    UPDATE root_filesystem_entries
-                    SET contents = $1,
-                        content_type = $2,
-                        kind = $3,
-                        indexed = $4,
-                        version = version + 1,
-                        updated_at = NOW()
-                    WHERE path = $5 AND is_dir = FALSE AND version = $6
-                    "#,
+                PUT_VERSION_SQL,
                 &[
                     &body,
                     &content_type_str,
@@ -1152,43 +1214,32 @@ async fn postgres_put_with_client(
                     &indexed_json,
                     &path_str,
                     &expected_raw,
+                    &child_lower,
+                    &child_upper,
                 ],
             )
             .await
             .map_err(|error| db_error(path.clone(), FilesystemOperation::WriteFile, error))?;
             if rows == 0 {
-                let found = postgres_current_version_with_client(client, path).await?;
-                return Err(FilesystemError::VersionMismatch {
-                    path: path.clone(),
-                    expected: Some(expected),
-                    found,
-                });
+                return Err(diagnose_put_failure(client, path, Some(expected)).await?);
             }
             Ok(expected.next())
         }
         CasExpectation::Any => {
+            // Upsert unless a descendant makes `path` an implicit directory; the
+            // ON CONFLICT guard rejects an explicit directory at `path`. A 0-row
+            // RETURNING is therefore always a directory conflict for `Any`.
             let row = cached_query_opt(
                 client,
-                r#"
-                    INSERT INTO root_filesystem_entries
-                        (path, contents, is_dir, content_type, kind, indexed, version)
-                    VALUES ($1, $2, FALSE, $3, $4, $5, 1)
-                    ON CONFLICT (path) DO UPDATE SET
-                        contents = EXCLUDED.contents,
-                        content_type = EXCLUDED.content_type,
-                        kind = EXCLUDED.kind,
-                        indexed = EXCLUDED.indexed,
-                        version = root_filesystem_entries.version + 1,
-                        updated_at = NOW()
-                    WHERE root_filesystem_entries.is_dir = FALSE
-                    RETURNING version
-                    "#,
+                PUT_ANY_SQL,
                 &[
                     &path_str,
                     &body,
                     &content_type_str,
                     &kind_str,
                     &indexed_json,
+                    &child_lower,
+                    &child_upper,
                 ],
             )
             .await
@@ -1200,6 +1251,38 @@ async fn postgres_put_with_client(
             record_version_from_i64(path, version)
         }
     }
+}
+
+/// Diagnose the precise error for a CAS put that wrote 0 rows.
+///
+/// Only reached on the (rare) failure path. Distinguishes a directory conflict
+/// (explicit directory at `path`, or an implicit-directory child) from a CAS
+/// version mismatch — exactly the information the old pre-check + version read
+/// produced, but issued only when the write actually failed.
+///
+/// The return type is `Result<FilesystemError, FilesystemError>` because the
+/// diagnosis itself issues reads: the **`Ok`** value is the diagnosed error to
+/// surface to the caller, and the **`Err`** value is a backend failure that
+/// occurred *while* diagnosing. Call sites therefore wrap the result as
+/// `Err(diagnose_put_failure(..).await?)` — the `?` propagates a diagnosis-time
+/// backend error, and the `Err(..)` surfaces the diagnosed error.
+#[cfg(feature = "postgres")]
+async fn diagnose_put_failure(
+    client: &deadpool_postgres::Object,
+    path: &VirtualPath,
+    expected: Option<RecordVersion>,
+) -> Result<FilesystemError, FilesystemError> {
+    if postgres_is_dir_with_client(client, path).await?
+        || postgres_has_child_entry_with_client(client, path).await?
+    {
+        return Ok(directory_write_error(path.clone()));
+    }
+    let found = postgres_current_version_with_client(client, path).await?;
+    Ok(FilesystemError::VersionMismatch {
+        path: path.clone(),
+        expected,
+        found,
+    })
 }
 
 #[cfg(feature = "postgres")]
@@ -1276,32 +1359,24 @@ async fn postgres_current_version_with_client(
     .transpose()
 }
 
+/// Whether an explicit directory row exists at the exact `path`.
+///
+/// Used only on the rare CAS-put failure path. Selects the `is_dir` flag alone
+/// and never reads `OCTET_LENGTH(contents)`, so it does not touch the
+/// (potentially TOAST'd) body to answer a question that only needs one boolean.
 #[cfg(feature = "postgres")]
-async fn postgres_exact_entry_with_client(
+async fn postgres_is_dir_with_client(
     client: &deadpool_postgres::Object,
     path: &VirtualPath,
-) -> Result<Option<(u64, FileType, Option<std::time::SystemTime>)>, FilesystemError> {
+) -> Result<bool, FilesystemError> {
     let row = cached_query_opt(
         client,
-        "SELECT OCTET_LENGTH(contents)::bigint AS len, is_dir, EXTRACT(EPOCH FROM updated_at)::bigint AS updated_at_epoch FROM root_filesystem_entries WHERE path = $1",
+        "SELECT is_dir FROM root_filesystem_entries WHERE path = $1",
         &[&path.as_str()],
     )
     .await
     .map_err(|error| db_error(path.clone(), FilesystemOperation::Stat, error))?;
-    Ok(row.map(|row| {
-        let len: i64 = row.get("len");
-        let is_dir: bool = row.get("is_dir");
-        let updated_at_epoch: i64 = row.get("updated_at_epoch");
-        (
-            if is_dir { 0 } else { len.max(0) as u64 },
-            if is_dir {
-                FileType::Directory
-            } else {
-                FileType::File
-            },
-            system_time_from_unix_seconds(updated_at_epoch),
-        )
-    }))
+    Ok(row.is_some_and(|row| row.get::<_, bool>("is_dir")))
 }
 
 #[cfg(feature = "postgres")]
@@ -1595,5 +1670,76 @@ mod tests {
             postgres_migration_connect_backoff(20),
             POSTGRES_MIGRATION_CONNECT_MAX_BACKOFF
         );
+    }
+
+    /// Returns the number of top-level statements in a SQL string by counting
+    /// statement terminators (`;`) that are not inside a quoted literal. The
+    /// put statements use no string literals containing `;`, so a simple
+    /// non-empty trailing-segment count is exact here.
+    fn top_level_statement_count(sql: &str) -> usize {
+        sql.split(';').filter(|s| !s.trim().is_empty()).count()
+    }
+
+    /// The CAS put round-trip fix: each `CasExpectation` arm must issue exactly
+    /// ONE statement. Before the fix, a put ran three round-trips — an
+    /// exact-entry `SELECT`, a child-scan `SELECT`, then the write. The
+    /// directory invariant is now folded into the single write statement, so a
+    /// successful put costs one round-trip. This guards against a regression
+    /// re-splitting the pre-check back out into separate queries.
+    #[test]
+    fn put_statements_are_single_round_trip() {
+        for (name, sql) in [
+            ("absent", PUT_ABSENT_SQL),
+            ("version", PUT_VERSION_SQL),
+            ("any", PUT_ANY_SQL),
+        ] {
+            assert_eq!(
+                top_level_statement_count(sql),
+                1,
+                "{name} put must be a single statement (one round-trip), got: {sql}"
+            );
+        }
+    }
+
+    /// Each put statement must carry the folded directory invariant guard so it
+    /// rejects writing a file over a directory without a separate pre-check
+    /// round-trip. Every arm guards implicit directories with a `NOT EXISTS`
+    /// descendant scan. Explicit directories are rejected differently per arm:
+    /// the INSERT arms (`PUT_ABSENT_SQL`, `PUT_ANY_SQL`) rely on `ON CONFLICT`
+    /// (the existing directory row collides on the `path` primary key), while
+    /// the UPDATE arm (`PUT_VERSION_SQL`) and the `PUT_ANY_SQL` conflict clause
+    /// use an explicit `is_dir = FALSE` predicate.
+    #[test]
+    fn put_statements_fold_in_directory_guard() {
+        // Implicit-directory (descendant) guard — every arm.
+        assert!(PUT_ABSENT_SQL.contains("NOT EXISTS"));
+        assert!(PUT_VERSION_SQL.contains("NOT EXISTS"));
+        assert!(PUT_ANY_SQL.contains("NOT EXISTS"));
+        // Explicit-directory: INSERT arms reject via ON CONFLICT on the path PK.
+        assert!(PUT_ABSENT_SQL.contains("ON CONFLICT (path)"));
+        assert!(PUT_ANY_SQL.contains("ON CONFLICT (path)"));
+        // Explicit-directory: the UPDATE arm and the upsert conflict clause use
+        // an explicit is_dir = FALSE predicate.
+        assert!(PUT_VERSION_SQL.contains("is_dir = FALSE"));
+        assert!(PUT_ANY_SQL.contains("is_dir = FALSE"));
+    }
+
+    /// The descendant range is the half-open `[prefix/, prefix0)` band that the
+    /// folded `NOT EXISTS` child guard scans. A wrong bound would silently
+    /// mis-scope the directory invariant, so pin the exact bytes and the
+    /// sort-order invariant (`'/'` < real children < `'0'`).
+    #[test]
+    fn descendant_path_range_is_half_open_child_band() {
+        let path = VirtualPath::new("/secrets/a/b").unwrap();
+        let (lower, upper) = descendant_path_range(&path);
+        assert_eq!(lower, "/secrets/a/b/");
+        assert_eq!(upper, "/secrets/a/b0");
+        let (lower, upper) = (lower.as_str(), upper.as_str());
+        assert!(lower < upper);
+        // A real descendant sorts inside the band; the path itself and a
+        // sibling sharing the prefix do not.
+        assert!("/secrets/a/b/child" >= lower && "/secrets/a/b/child" < upper);
+        assert!("/secrets/a/b" < lower); // the path itself is excluded
+        assert!("/secrets/a/bb" >= upper); // prefix-sharing sibling excluded
     }
 }

--- a/crates/ironclaw_filesystem/src/postgres.rs
+++ b/crates/ironclaw_filesystem/src/postgres.rs
@@ -1267,6 +1267,18 @@ async fn postgres_put_with_client(
 /// occurred *while* diagnosing. Call sites therefore wrap the result as
 /// `Err(diagnose_put_failure(..).await?)` — the `?` propagates a diagnosis-time
 /// backend error, and the `Err(..)` surfaces the diagnosed error.
+///
+/// **Classification is best-effort and reflects current state, not the exact
+/// snapshot that failed the write.** The write's directory guard is enforced
+/// atomically within the single statement, so no incorrect write can ever
+/// commit — these follow-up reads only choose *which error variant* to report
+/// on an already-failed write. A concurrent writer mutating the directory/child
+/// row between the failed write and these reads can therefore flip the variant,
+/// but the reported variant always matches present reality, which is exactly
+/// what the canonical CAS-retry caller needs for its next attempt. We
+/// deliberately do not wrap the write + diagnosis in a transaction or higher
+/// isolation: that would add a serialization-retry error mode (and cost) to a
+/// rare path for no correctness gain.
 #[cfg(feature = "postgres")]
 async fn diagnose_put_failure(
     client: &deadpool_postgres::Object,

--- a/crates/ironclaw_filesystem/src/postgres.rs
+++ b/crates/ironclaw_filesystem/src/postgres.rs
@@ -1279,6 +1279,11 @@ async fn postgres_put_with_client(
 /// deliberately do not wrap the write + diagnosis in a transaction or higher
 /// isolation: that would add a serialization-retry error mode (and cost) to a
 /// rare path for no correctness gain.
+///
+/// This is benign *only because* the directory guard is atomic with the write.
+/// That atomicity is pinned by `put_statements_are_single_round_trip` +
+/// `put_statements_fold_in_directory_guard`; if either ever fails, the race
+/// below is no longer cosmetic and this best-effort diagnosis must be revisited.
 #[cfg(feature = "postgres")]
 async fn diagnose_put_failure(
     client: &deadpool_postgres::Object,
@@ -1699,6 +1704,24 @@ mod tests {
     /// directory invariant is now folded into the single write statement, so a
     /// successful put costs one round-trip. This guards against a regression
     /// re-splitting the pre-check back out into separate queries.
+    ///
+    /// **This is a correctness canary, not just a perf check.** Together with
+    /// `put_statements_fold_in_directory_guard` it pins the *atomicity* of the
+    /// directory invariant: the guard predicates (`NOT EXISTS` descendant scan,
+    /// `ON CONFLICT` / `is_dir = FALSE`) are evaluated in the *same* statement
+    /// that performs the write, against one consistent snapshot. That atomicity
+    /// is what makes the best-effort classification in `diagnose_put_failure`
+    /// safe (see its doc): the follow-up reads can race a concurrent writer, but
+    /// because no bad write can commit, the race only mislabels an
+    /// already-failed write's error variant — it never corrupts data.
+    ///
+    /// If a future change moves a guard back out into a separate pre-check
+    /// `SELECT`, this test (or its sibling) fails — and that failure is the
+    /// signal that the TOCTOU window has stopped being benign: a concurrent
+    /// `create_dir_all(path)` landing between the pre-check and the write would
+    /// let a file be written *over* a directory, committing a state the
+    /// invariant exists to forbid. Keep the guard in the write; do not "optimize"
+    /// it into a prior read.
     #[test]
     fn put_statements_are_single_round_trip() {
         for (name, sql) in [
@@ -1709,7 +1732,10 @@ mod tests {
             assert_eq!(
                 top_level_statement_count(sql),
                 1,
-                "{name} put must be a single statement (one round-trip), got: {sql}"
+                "{name} put must be a single statement (one round-trip). A split \
+                 here breaks directory-guard atomicity: a concurrent \
+                 create_dir_all() between a separate pre-check and the write \
+                 could let a file commit over a directory. Got: {sql}"
             );
         }
     }

--- a/crates/ironclaw_filesystem/src/postgres.rs
+++ b/crates/ironclaw_filesystem/src/postgres.rs
@@ -1268,22 +1268,25 @@ async fn postgres_put_with_client(
 /// `Err(diagnose_put_failure(..).await?)` — the `?` propagates a diagnosis-time
 /// backend error, and the `Err(..)` surfaces the diagnosed error.
 ///
-/// **Classification is best-effort and reflects current state, not the exact
-/// snapshot that failed the write.** The write's directory guard is enforced
-/// atomically within the single statement, so no incorrect write can ever
-/// commit — these follow-up reads only choose *which error variant* to report
-/// on an already-failed write. A concurrent writer mutating the directory/child
-/// row between the failed write and these reads can therefore flip the variant,
-/// but the reported variant always matches present reality, which is exactly
-/// what the canonical CAS-retry caller needs for its next attempt. We
+/// **Classification is best-effort: it only reflects what these follow-up reads
+/// observe, not the exact snapshot that failed the write.** This diagnosis runs
+/// purely to pick *which error variant* to report on an already-failed write —
+/// it never writes, so it cannot itself corrupt state. A concurrent writer
+/// mutating the directory/child row between the failed write and these reads can
+/// flip the variant; the reported variant reflects the reads' observed state,
+/// which is sufficient for the canonical CAS-retry caller's next attempt. We
 /// deliberately do not wrap the write + diagnosis in a transaction or higher
 /// isolation: that would add a serialization-retry error mode (and cost) to a
-/// rare path for no correctness gain.
+/// rare path for no gain in *this* classification.
 ///
-/// This is benign *only because* the directory guard is atomic with the write.
-/// That atomicity is pinned by `put_statements_are_single_round_trip` +
-/// `put_statements_fold_in_directory_guard`; if either ever fails, the race
-/// below is no longer cosmetic and this best-effort diagnosis must be revisited.
+/// Scope note: the put write statement evaluates its directory guard against a
+/// single snapshot, which removes the old separate-pre-check-then-write TOCTOUs
+/// for the *same* path. It does NOT serialize concurrent writes to *different*
+/// parent/child paths (e.g. `put(/a)` racing `put(/a/b)`), so the file-vs-dir
+/// invariant can still be violated under cross-path write-skew. That gap is
+/// pre-existing (the old 3-read pre-check had a wider window) and tracked
+/// separately — see `put_statements_are_single_round_trip` for the boundary of
+/// what the single-statement guard does and does not guarantee.
 #[cfg(feature = "postgres")]
 async fn diagnose_put_failure(
     client: &deadpool_postgres::Object,
@@ -1705,23 +1708,24 @@ mod tests {
     /// successful put costs one round-trip. This guards against a regression
     /// re-splitting the pre-check back out into separate queries.
     ///
-    /// **This is a correctness canary, not just a perf check.** Together with
-    /// `put_statements_fold_in_directory_guard` it pins the *atomicity* of the
-    /// directory invariant: the guard predicates (`NOT EXISTS` descendant scan,
-    /// `ON CONFLICT` / `is_dir = FALSE`) are evaluated in the *same* statement
-    /// that performs the write, against one consistent snapshot. That atomicity
-    /// is what makes the best-effort classification in `diagnose_put_failure`
-    /// safe (see its doc): the follow-up reads can race a concurrent writer, but
-    /// because no bad write can commit, the race only mislabels an
-    /// already-failed write's error variant — it never corrupts data.
+    /// What this pins, precisely: the directory guard is evaluated in the *same*
+    /// statement that performs the write (one round-trip), against one snapshot —
+    /// rather than as a separate pre-check `SELECT` followed by the write. That
+    /// is the property the PR delivers, and keeping the guard folded in is what
+    /// makes the rare-path error classification in `diagnose_put_failure`
+    /// coherent (same-snapshot guard, no separate-pre-check window for the same
+    /// path).
     ///
-    /// If a future change moves a guard back out into a separate pre-check
-    /// `SELECT`, this test (or its sibling) fails — and that failure is the
-    /// signal that the TOCTOU window has stopped being benign: a concurrent
-    /// `create_dir_all(path)` landing between the pre-check and the write would
-    /// let a file be written *over* a directory, committing a state the
-    /// invariant exists to forbid. Keep the guard in the write; do not "optimize"
-    /// it into a prior read.
+    /// What this does NOT pin — read before relying on it: single-statement
+    /// evaluation is not isolation. `NOT EXISTS` is a snapshot predicate with no
+    /// range lock, so concurrent writes to *different* parent/child paths
+    /// (`put(/a)` racing `put(/a/b)`) can each pass their own guard and both
+    /// commit, leaving `/a` a file with a descendant — the file-vs-directory
+    /// invariant violated by write-skew. This gap is pre-existing (the old
+    /// 3-read pre-check had a wider window) and closing it requires path-prefix
+    /// serialization across all backends (advisory lock / SERIALIZABLE + retry),
+    /// which is out of scope for a round-trip optimization. Tracked separately;
+    /// do not read this test as a concurrency guarantee.
     #[test]
     fn put_statements_are_single_round_trip() {
         for (name, sql) in [
@@ -1732,10 +1736,9 @@ mod tests {
             assert_eq!(
                 top_level_statement_count(sql),
                 1,
-                "{name} put must be a single statement (one round-trip). A split \
-                 here breaks directory-guard atomicity: a concurrent \
-                 create_dir_all() between a separate pre-check and the write \
-                 could let a file commit over a directory. Got: {sql}"
+                "{name} put must be a single statement (one round-trip); a split \
+                 back into a separate pre-check + write reintroduces the same-path \
+                 check-then-write window this PR removed. Got: {sql}"
             );
         }
     }

--- a/crates/ironclaw_filesystem/src/postgres.rs
+++ b/crates/ironclaw_filesystem/src/postgres.rs
@@ -1150,10 +1150,11 @@ const PUT_ANY_SQL: &str = r#"
 /// arm, so a successful put costs exactly one round-trip (previously:
 /// exact-entry `SELECT` + child-scan `SELECT` + the write = three).
 ///
-/// On the *rare* 0-row outcome we make one follow-up read
-/// (`diagnose_put_failure`) to reproduce the exact error the old pre-check and
-/// version read would have produced: `directory_write_error` for a directory
-/// conflict, `VersionMismatch` otherwise. The happy path never pays for it.
+/// On the *rare* 0-row outcome we make follow-up reads
+/// (`diagnose_put_failure`, up to three: `is_dir`, child-scan, then current
+/// version) to reproduce the exact error the old pre-check and version read
+/// would have produced: `directory_write_error` for a directory conflict,
+/// `VersionMismatch` otherwise. The happy path never pays for it.
 #[cfg(feature = "postgres")]
 async fn postgres_put_with_client(
     client: &deadpool_postgres::Object,

--- a/crates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
+++ b/crates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
@@ -1444,6 +1444,21 @@ mod postgres_tests {
         assert_eq!(got.entry.body, vec![2]);
     }
 
+    #[tokio::test]
+    async fn postgres_put_cas_any_inserts_missing_path_and_returns_version() {
+        let Some((fs, prefix)) = postgres_root().await else {
+            return;
+        };
+        let missing = vpath(&prefix, "cas_any_insert_missing");
+        let v1 = fs
+            .put(&missing, Entry::bytes(vec![7]), CasExpectation::Any)
+            .await
+            .expect("Any insert on a missing path must succeed");
+        assert_eq!(v1, ironclaw_filesystem::RecordVersion::from_backend(1));
+        let got = fs.get(&missing).await.unwrap().unwrap();
+        assert_eq!(got.entry.body, vec![7]);
+    }
+
     // CAS-put directory invariant (folded into the single write statement by
     // the round-trip fix). Mirrors the libsql `write_file` rejection tests but
     // drives `put` directly, which is the primitive the SQL fold changed.

--- a/crates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
+++ b/crates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
@@ -1400,6 +1400,28 @@ mod postgres_tests {
     }
 
     #[tokio::test]
+    async fn postgres_put_cas_version_on_missing_path_reports_no_found_version() {
+        let Some((fs, prefix)) = postgres_root().await else {
+            return;
+        };
+        let missing = vpath(&prefix, "cas_version_missing");
+        let err = fs
+            .put(
+                &missing,
+                Entry::bytes(vec![1]),
+                CasExpectation::Version(ironclaw_filesystem::RecordVersion::from_backend(1)),
+            )
+            .await
+            .expect_err("version CAS on a missing path must fail");
+        match err {
+            FilesystemError::VersionMismatch { found, .. } => {
+                assert!(found.is_none(), "missing path should report no found version, got: {found:?}");
+            }
+            other => panic!("expected VersionMismatch, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
     async fn postgres_native_put_cas_any_increments_existing_version() {
         let Some((fs, prefix)) = postgres_root().await else {
             return;

--- a/crates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
+++ b/crates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
@@ -1289,9 +1289,9 @@ async fn libsql_root() -> TestLibSqlRootFilesystem {
 mod postgres_tests {
     use super::*;
     use ironclaw_filesystem::{
-        Capability, CasExpectation, Entry, FilesystemError, FilesystemOperation, Filter, IndexKey,
-        IndexKind, IndexName, IndexSpec, IndexValue, Page, PostgresRootFilesystem, RecordKind,
-        SeqNo, TxnCapability,
+        Capability, CasExpectation, Entry, FileType, FilesystemError, FilesystemOperation, Filter,
+        IndexKey, IndexKind, IndexName, IndexSpec, IndexValue, Page, PostgresRootFilesystem,
+        RecordKind, SeqNo, TxnCapability,
     };
     use ironclaw_host_api::VirtualPath;
 
@@ -1417,6 +1417,85 @@ mod postgres_tests {
         let got = fs.get(&path).await.unwrap().unwrap();
         assert_eq!(got.version, v2);
         assert_eq!(got.entry.body, vec![2]);
+    }
+
+    // CAS-put directory invariant (folded into the single write statement by
+    // the round-trip fix). Mirrors the libsql `write_file` rejection tests but
+    // drives `put` directly, which is the primitive the SQL fold changed.
+
+    #[tokio::test]
+    async fn postgres_put_rejects_implicit_directory() {
+        let Some((fs, prefix)) = postgres_root().await else {
+            return;
+        };
+        // Writing a child first makes `dir` an implicit directory.
+        let dir = vpath(&prefix, "implicit");
+        let child = vpath(&prefix, "implicit/leaf");
+        fs.put(&child, Entry::bytes(vec![1]), CasExpectation::Absent)
+            .await
+            .unwrap();
+
+        // Every CAS arm must refuse to overwrite the implicit directory.
+        for cas in [
+            CasExpectation::Absent,
+            CasExpectation::Any,
+            CasExpectation::Version(ironclaw_filesystem::RecordVersion::from_backend(1)),
+        ] {
+            let err = fs
+                .put(&dir, Entry::bytes(vec![2]), cas)
+                .await
+                .expect_err("put over an implicit directory must fail");
+            assert!(
+                matches!(
+                    err,
+                    FilesystemError::Backend {
+                        operation: FilesystemOperation::WriteFile,
+                        ..
+                    }
+                ),
+                "expected directory-write Backend error, got: {err:?}"
+            );
+        }
+        // The child is untouched.
+        assert_eq!(fs.get(&child).await.unwrap().unwrap().entry.body, vec![1]);
+    }
+
+    #[tokio::test]
+    async fn postgres_put_rejects_existing_directory() {
+        let Some((fs, prefix)) = postgres_root().await else {
+            return;
+        };
+        let dir = VirtualPath::new(format!("{prefix}/explicit")).unwrap();
+        let child = vpath(&prefix, "explicit/leaf");
+        // create_dir_all materializes explicit directory rows (is_dir = TRUE).
+        fs.create_dir_all(&dir).await.unwrap();
+        fs.put(&child, Entry::bytes(vec![1]), CasExpectation::Absent)
+            .await
+            .unwrap();
+
+        // Every CAS arm (distinct SQL: PUT_ABSENT_SQL / PUT_VERSION_SQL /
+        // PUT_ANY_SQL) must refuse to overwrite the explicit directory.
+        for cas in [
+            CasExpectation::Absent,
+            CasExpectation::Any,
+            CasExpectation::Version(ironclaw_filesystem::RecordVersion::from_backend(1)),
+        ] {
+            let err = fs
+                .put(&dir, Entry::bytes(vec![2]), cas)
+                .await
+                .expect_err("put over an explicit directory must fail");
+            assert!(
+                matches!(
+                    err,
+                    FilesystemError::Backend {
+                        operation: FilesystemOperation::WriteFile,
+                        ..
+                    }
+                ),
+                "expected directory-write Backend error, got: {err:?}"
+            );
+        }
+        assert_eq!(fs.stat(&dir).await.unwrap().file_type, FileType::Directory);
     }
 
     #[tokio::test]

--- a/crates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
+++ b/crates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
@@ -1466,12 +1466,11 @@ mod postgres_tests {
             return;
         };
         let dir = VirtualPath::new(format!("{prefix}/explicit")).unwrap();
-        let child = vpath(&prefix, "explicit/leaf");
         // create_dir_all materializes explicit directory rows (is_dir = TRUE).
+        // Keep `dir` childless so the exact-path explicit-directory guard
+        // (ON CONFLICT / is_dir = FALSE) is what rejects the put, not the
+        // descendant scan (covered by postgres_put_rejects_implicit_directory).
         fs.create_dir_all(&dir).await.unwrap();
-        fs.put(&child, Entry::bytes(vec![1]), CasExpectation::Absent)
-            .await
-            .unwrap();
 
         // Every CAS arm (distinct SQL: PUT_ABSENT_SQL / PUT_VERSION_SQL /
         // PUT_ANY_SQL) must refuse to overwrite the explicit directory.

--- a/crates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
+++ b/crates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
@@ -1415,7 +1415,10 @@ mod postgres_tests {
             .expect_err("version CAS on a missing path must fail");
         match err {
             FilesystemError::VersionMismatch { found, .. } => {
-                assert!(found.is_none(), "missing path should report no found version, got: {found:?}");
+                assert!(
+                    found.is_none(),
+                    "missing path should report no found version, got: {found:?}"
+                );
             }
             other => panic!("expected VersionMismatch, got: {other:?}"),
         }

--- a/docs/plans/2026-06-25-cas-put-roundtrip.md
+++ b/docs/plans/2026-06-25-cas-put-roundtrip.md
@@ -1,0 +1,112 @@
+# CAS put: fold directory pre-check into the write statement (3 → 1 round-trip)
+
+Date: 2026-06-25
+Branch: `fix/reborn-cas-put-roundtrip`
+Crate: `ironclaw_filesystem`
+
+## Problem (verified)
+
+Every CAS `put` on the Postgres backend issues **3 DB round-trips on the happy
+path**, not 1. `postgres_put_with_client`
+(`crates/ironclaw_filesystem/src/postgres.rs:1081`) runs a directory pre-check
+on a single held connection before the write:
+
+1. `postgres_exact_entry_with_client` — `SELECT … WHERE path = $1`
+   (rejects if an explicit directory exists at the exact path).
+2. `postgres_has_child_entry_with_client` — `SELECT 1 … WHERE path >= $lower AND
+   path < $upper LIMIT 1` (rejects if an implicit-directory child exists).
+3. The `INSERT … ON CONFLICT` / `UPDATE` itself.
+
+On the error path a 4th query (`postgres_current_version_with_client`) builds the
+`VersionMismatch`. The pre-check (1 + 2) runs for **every** `CasExpectation`
+variant (`Absent` / `Version` / `Any`).
+
+At ~100–200 ms/round-trip cross-region, that is 300–600 ms per write, and a turn
+issues dozens of CAS puts → latency cascade and pooled-connection hold time that
+starves the small hosted pool.
+
+### Backend parity baseline (verified)
+
+- **in-memory** (`in_memory.rs:84`): whole `put` runs under one `tokio::Mutex`
+  guard, no await points — atomic, zero round-trips. Directory invariant
+  (implicit-child prefix scan) + CAS (`check_cas`) enforced in-proc. **No change.**
+- **libsql** (`libsql.rs:142`): same 3-round-trip (4 for `Any`) shape as
+  Postgres, but in this crate the connection is `Builder::new_local` (embedded
+  SQLite, sub-ms in-process). Remote Turso is only wired at the composition
+  layer. The cross-region latency cascade is the **Postgres production** path.
+  **No behavior change required; semantics stay identical.** (Lane note: libsql
+  `put` is left as-is to keep this PR minimal and Postgres-scoped; its
+  round-trip count is not a production latency concern because the production
+  RootFilesystem store is Postgres.)
+
+## Fix (Postgres only, minimal)
+
+Fold the directory pre-check into each CAS arm's single write statement using a
+`NOT EXISTS` child-existence guard plus the existing `is_dir = FALSE` guard, so
+the **happy path is 1 round-trip**.
+
+- `Absent`: `INSERT … SELECT … WHERE NOT EXISTS (child-scan) ON CONFLICT (path)
+  DO NOTHING`. The child-scan uses the half-open `[prefix/, prefix0)` range. If
+  the target path is itself an explicit directory, the existing row has
+  `is_dir = TRUE`; `ON CONFLICT DO NOTHING` writes 0 rows, same as a CAS clash —
+  disambiguated on the (rare) 0-row error path.
+- `Version`: `UPDATE … WHERE path = $p AND is_dir = FALSE AND version = $v`.
+  An explicit directory at `path` has `is_dir = TRUE` → 0 rows. A child existing
+  does not change that the target is a file row; but a `Version` CAS implies the
+  file already exists, so a child under a *file* path is impossible by
+  construction. We still add the `NOT EXISTS` child guard for defense-in-depth
+  parity with `Absent`/`Any`.
+- `Any`: `INSERT … SELECT … WHERE NOT EXISTS (child-scan) ON CONFLICT (path) DO
+  UPDATE … WHERE root_filesystem_entries.is_dir = FALSE RETURNING version`.
+  `RETURNING` removes the separate version read-back on the happy path.
+
+### Error-path disambiguation (rare, not the hot path)
+
+When the single statement affects 0 rows (or `RETURNING` yields nothing) we make
+follow-up reads to decide between `directory_write_error` and `VersionMismatch`
+— exactly the information the old pre-check produced, but only when the write
+actually failed. This is consolidated into one `diagnose_put_failure` helper
+shared by the `Absent` and `Version` arms (`Any` cannot version-mismatch, so it
+returns `directory_write_error` directly). The directory check uses a new
+`postgres_is_dir_with_client` that reads only the `is_dir` flag — it does not
+read `OCTET_LENGTH(contents)`, so it never touches the (possibly TOAST'd) body.
+The now-unused `postgres_exact_entry_with_client` free function is removed. The
+happy path never pays for any of this.
+
+Each folded `NOT EXISTS` child scan carries `LIMIT 1`, matching
+`postgres_has_child_entry_with_client`, so the planner can use a limit-aware
+plan when a directory has many children.
+
+### Invariants preserved
+
+- Reject writing a file where an explicit directory exists (`is_dir = TRUE`).
+- Reject writing a file where an implicit-directory child exists (child range).
+- CAS semantics (`Absent` / `Version(expected)` / `Any`) unchanged.
+
+## Red → green / perf proof
+
+This is a round-trip **count** fix, not a wrong-result fix. Proof strategy:
+
+1. **Correctness (no regression):** keep all existing directory-invariant + CAS
+   contract tests green, and add a `put`-level directory-rejection unit test for
+   the SQL fold (explicit-dir + implicit-child) that runs against the in-memory
+   path of the contract where possible; the Postgres SQL is exercised by the
+   `--features postgres` contract build + any live Postgres test harness.
+2. **Round-trip reduction:** show the happy-path SQL now issues **one**
+   statement per CAS arm (was three: exact-entry + child-scan + write). Evidence
+   = the diff (two pre-check helper calls removed from the happy path) + a
+   statement-count assertion where a countable seam exists.
+
+## Quality gate
+
+- `cargo fmt --all`
+- `cargo clippy -p ironclaw_filesystem --all-targets` (0 warnings)
+- `cargo test -p ironclaw_filesystem`
+- `cargo test -p ironclaw_filesystem --features postgres,libsql` (contract)
+
+## File lane
+
+Owned: `postgres.rs` `postgres_put_with_client` + its pre-check helpers (only
+where they stop being used by the put happy path), contract tests. **Not
+touched:** `append_file` / event-log path, `ironclaw_resources`, store crates,
+`cas.rs`.


### PR DESCRIPTION
## Problem (verified)

Every Postgres CAS `put` issued **3 DB round-trips on the happy path**, not 1. `postgres_put_with_client` ran a directory pre-check on a single held connection *before* the write:

1. `postgres_exact_entry_with_client` — `SELECT … WHERE path = $1` (rejects an explicit directory at the exact path).
2. `postgres_has_child_entry_with_client` — `SELECT 1 … WHERE path >= $lower AND path < $upper LIMIT 1` (rejects an implicit-directory child).
3. The `INSERT … ON CONFLICT` / `UPDATE` itself.

(A 4th query built the `VersionMismatch` on the error path.) The pre-check ran for **every** `CasExpectation` variant. At ~100–200 ms/round-trip cross-region that is 300–600 ms per write; a turn does dozens of CAS puts → latency cascade and pooled-connection hold time that starves the small hosted pool.

## Fix (Postgres only, minimal)

Fold the directory invariant into each CAS arm's **single** write statement:

- **Absent:** `INSERT … SELECT … WHERE NOT EXISTS (child-scan) ON CONFLICT (path) DO NOTHING`. The half-open `[prefix/, prefix0)` child scan rejects implicit directories; `ON CONFLICT` rejects an explicit directory or existing file at `path`.
- **Version:** `UPDATE … WHERE path = $p AND is_dir = FALSE AND version = $v AND NOT EXISTS (child-scan)`.
- **Any:** `INSERT … SELECT … WHERE NOT EXISTS (child-scan) ON CONFLICT (path) DO UPDATE … WHERE is_dir = FALSE RETURNING version` — `RETURNING` removes the separate version read-back.

A successful put is now **exactly 1 round-trip** (was 3). Each `NOT EXISTS` child scan carries `LIMIT 1` to match `postgres_has_child_entry_with_client` so the planner can short-circuit when a directory has many children.

### Round-trip count: before / after

| CAS arm | before | after (happy path) |
|---|---|---|
| Absent | exact-entry SELECT + child SELECT + INSERT = **3** | **1** |
| Version | exact-entry SELECT + child SELECT + UPDATE = **3** | **1** |
| Any | exact-entry SELECT + child SELECT + upsert + version read = **4** | **1** |

### Invariants preserved

- Reject writing a file where an **explicit directory** exists (`is_dir = TRUE`).
- Reject writing a file where an **implicit-directory child** exists (descendant range).
- CAS semantics (`Absent` / `Version(expected)` / `Any`) unchanged.

On the **rare** 0-row outcome, `diagnose_put_failure` makes follow-up reads to reproduce the exact pre-fix error (`directory_write_error` vs `VersionMismatch`) — the happy path never pays for it. As a side win, the folded statement closes the prior TOCTOU window between pre-check and write. The directory check reads only `is_dir` (new `postgres_is_dir_with_client`), not `OCTET_LENGTH(contents)`, so it never touches the (possibly TOAST'd) body. The now-dead `postgres_exact_entry_with_client` free function is removed.

## Tri-backend parity

- **in-memory** (`in_memory.rs`): whole `put` runs under one `tokio::Mutex` with no await points — atomic, zero round-trips; directory invariant + CAS enforced in-proc. **Unchanged.**
- **libsql** (`libsql.rs`): same pre-check shape, but in this crate the connection is embedded SQLite (`Builder::new_local`, sub-ms in-process); remote Turso is only wired at the composition layer. The cross-region latency cascade is the **Postgres production** path, so libsql is left as-is with identical semantics to keep the PR Postgres-scoped. **Unchanged.**

## Evidence (red/green is round-trip *count*, not a wrong result)

- **Round-trip reduction (DB-free):** `put_statements_are_single_round_trip` asserts each CAS arm SQL is exactly **one** statement (was three round-trips: exact-entry + child + write).
- **Invariant fold (DB-free):** `put_statements_fold_in_directory_guard` pins the per-arm directory guards; `descendant_path_range_is_half_open_child_band` pins the `[prefix/, prefix0)` bounds and sort-order invariant.
- **Correctness (live Postgres, skips gracefully without `DATABASE_URL`):** new `postgres_put_rejects_implicit_directory` and `postgres_put_rejects_existing_directory` drive `put` directly across **all three** CAS arms; existing `postgres_native_put_cas_*` CAS contract tests stay green.

## Quality gate

- `cargo fmt --all` ✓
- `cargo clippy -p ironclaw_filesystem --all-targets --features postgres,libsql` — 0 warnings ✓
- `cargo test -p ironclaw_filesystem` (in-memory) + `--features postgres,libsql` — all pass ✓ (the libsql `vector_index` test is a known parallel-suite flake — passes in isolation and under `--test-threads=1`; unrelated to this change)

Plan: `docs/plans/2026-06-25-cas-put-roundtrip.md`. Reviewed with `/code-review` (multi-agent) and `thermo-nuclear-code-quality-review`; valid findings addressed (LIMIT 1 on child scans, dedicated `is_dir` read to avoid TOAST, all-CAS-arm directory tests, `descendant_path_range` unit test, accurate guard docs, `diagnose_put_failure` rename + documented `Result<E, E>` contract).

🤖 Generated with [Claude Code](https://claude.com/claude-code)