### PR TITLE
fix(webui-v2): move active run logs link out of composer

### DIFF
--- a/crates/ironclaw_webui_v2_static/static/dist/app.js
+++ b/crates/ironclaw_webui_v2_static/static/dist/app.js
@@ -1891,6 +1891,19 @@ ${_e}`;if(Ue.current.gateKey!==N&&(Ue.current={gateKey:N,credentialRef:null,inFl
       <div className="flex min-w-0 flex-1 flex-col">
         <${D1} status=${x} />
 
+        ${c&&!d&&En&&l`
+          <div className="flex justify-end border-b border-[var(--v2-panel-border)] bg-[var(--v2-canvas-strong)] px-4 py-1.5">
+            <${Sn}
+              to=${En}
+              className="inline-flex h-8 items-center gap-1.5 rounded-[8px] px-2.5 text-xs font-semibold text-[var(--v2-text-muted)] hover:bg-[var(--v2-surface-muted)] hover:text-[var(--v2-text-strong)]"
+              title=${o("nav.logs")}
+            >
+              <${M} name="list" className="h-3.5 w-3.5" />
+              ${o("nav.logs")}
+            <//>
+          </div>
+        `}
+
         ${w&&l`
           <div
             className="mx-4 mt-3 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-800 dark:bg-red-950 dark:text-red-300"
@@ -1931,19 +1944,7 @@ ${_e}`;if(Ue.current.gateKey!==N&&(Ue.current={gateKey:N,credentialRef:null,inFl
                 onRecover=${O}
               />
             `}
-            ${c&&!d&&l`
-              <div className="flex flex-wrap items-center gap-3">
-                <${d2} />
-                ${En&&l`
-                  <${Sn}
-                    to=${En}
-                    className="text-xs font-medium text-signal hover:underline"
-                  >
-                    ${o("nav.logs")}
-                  <//>
-                `}
-              </div>
-            `}
+            ${c&&!d&&l`<${d2} />`}
             ${f&&l`
               <${E1}
                 connectAction=${f}

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/chat.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/chat.js
@@ -1,6 +1,7 @@
 import { React, html } from "../../lib/html.js";
 import { Link } from "react-router";
 import { useT } from "../../lib/i18n.js";
+import { Icon } from "../../design-system/icons.js";
 import {
   THREAD_STATE,
   clearThreadState,
@@ -226,6 +227,19 @@ export function Chat({
       <div className="flex min-w-0 flex-1 flex-col">
         <${ConnectionStatus} status=${sseStatus} />
 
+        ${isProcessing && !pendingGate && activeRunLogsPath && html`
+          <div className="flex justify-end border-b border-[var(--v2-panel-border)] bg-[var(--v2-canvas-strong)] px-4 py-1.5">
+            <${Link}
+              to=${activeRunLogsPath}
+              className="inline-flex h-8 items-center gap-1.5 rounded-[8px] px-2.5 text-xs font-semibold text-[var(--v2-text-muted)] hover:bg-[var(--v2-surface-muted)] hover:text-[var(--v2-text-strong)]"
+              title=${t("nav.logs")}
+            >
+              <${Icon} name="list" className="h-3.5 w-3.5" />
+              ${t("nav.logs")}
+            <//>
+          </div>
+        `}
+
         ${historyLoadError &&
         html`
           <div
@@ -270,19 +284,7 @@ export function Chat({
                 onRecover=${recoverHistory}
               />
             `}
-            ${isProcessing && !pendingGate && html`
-              <div className="flex flex-wrap items-center gap-3">
-                <${TypingIndicator} />
-                ${activeRunLogsPath && html`
-                  <${Link}
-                    to=${activeRunLogsPath}
-                    className="text-xs font-medium text-signal hover:underline"
-                  >
-                    ${t("nav.logs")}
-                  <//>
-                `}
-              </div>
-            `}
+            ${isProcessing && !pendingGate && html`<${TypingIndicator} />`}
             ${channelConnectAction &&
             html`
               <${ChannelConnectCard}

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/chat.test.mjs
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/chat.test.mjs
@@ -65,6 +65,7 @@ function renderChat({ hookState, activeThreadId = "thread-1" }) {
     ChatInput() {},
     ConnectionStatus() {},
     EmptyState() {},
+    Icon() {},
     KeyboardShortcuts() {},
     Link() {},
     MessageList() {},
@@ -362,6 +363,13 @@ test("Chat links to scoped logs for the active thread run", () => {
     "/v2/logs?thread_id=thread-1&run_id=run-1",
   );
   assert.ok(logsLink.values.includes("nav.logs"));
+
+  const messageList = findComponent(tree, components.MessageList);
+  assert.equal(
+    findComponent(messageList, components.Link),
+    null,
+    "active run logs link should not render in the message list footer near the composer",
+  );
 });
 
 test("Chat deny gate callback routes through approve compatibility path", () => {


### PR DESCRIPTION
## Summary

* Moves the active-run scoped `Logs` link out of the chat message-list footer so it no longer appears next to the composer while an agent is running.
* Keeps scoped log access available during active runs by rendering the link in a dedicated chat-level toolbar above the conversation body.
* Leaves the typing indicator as the only running-state element rendered at the bottom of the message list.
* Rebuilds the committed WebUI v2 bundle and adds caller-level JS coverage that asserts the logs link is not rendered inside `MessageList`.

## Linked Issue

Closes #5282

## Validation

* `git diff --check HEAD^ HEAD`
* `node --test crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/chat.test.mjs crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/chat-input.test.mjs`
* `cargo test -p ironclaw_webui_v2_static`

## Security Impact

No security-sensitive behavior changes. This is a WebUI v2 layout-only fix for an existing authenticated logs link.

## Database Impact

No schema or migration changes.

## Blast Radius

Limited to the Reborn WebUI v2 chat page static assets and generated SPA bundle.

## Rollback Plan

Revert this PR to return the active-run scoped `Logs` link to its previous placement beside the typing indicator.

---

Review track: A