### PR TITLE
fix(ironclaw_agent_loop): break loop on repeated identical failing call

### DIFF
--- a/crates/ironclaw_agent_loop/src/executor/capabilities.rs
+++ b/crates/ironclaw_agent_loop/src/executor/capabilities.rs
@@ -700,6 +700,11 @@ impl CapabilityStage {
                 state
                     .recent_failure_kinds
                     .push(capability_failure_kind(&failure.error_kind));
+                // Record the failing signature so a repeated identical failing
+                // call that has already been warned can terminalize the loop
+                // (see `DefaultStopConditionStrategy` repetition escape) instead
+                // of retrying to the wall-clock turn timeout.
+                capability_batch.record_failed_signature(capability_call_signature(&call)?);
                 let model_observation =
                     Some(model_visible_capability_failure_observation(&failure));
                 let summary = CapabilityErrorSummary {

--- a/crates/ironclaw_agent_loop/src/executor/tests.rs
+++ b/crates/ironclaw_agent_loop/src/executor/tests.rs
@@ -1433,6 +1433,7 @@ async fn capability_stage_returns_after_batch_summary() {
                         observed_signatures: vec![signature.clone()],
                         made_progress_signatures: vec![signature],
                         no_change_signatures: Vec::new(),
+                        failed_signatures: Vec::new(),
                     },
                 )
             );
@@ -1799,6 +1800,7 @@ async fn stop_stage_preserves_ack_and_returns_stop_kind() {
                         observed_signatures: Vec::new(),
                         made_progress_signatures: Vec::new(),
                         no_change_signatures: Vec::new(),
+                        failed_signatures: Vec::new(),
                     },
                 ),
                 pending_input_ack,

--- a/crates/ironclaw_agent_loop/src/strategies/stop.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/stop.rs
@@ -111,6 +111,13 @@ pub(crate) struct CapabilityBatchTurnSummary {
     /// output-stagnation, never on failing/blocked calls.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub no_change_signatures: Vec<CapabilityCallSignature>,
+    /// Signatures of capability calls that returned a non-recoverable `Failed`
+    /// outcome this batch. Used to terminalize the repeated-call warning when
+    /// the model retries the *same* failing call without adapting — otherwise
+    /// such a loop runs to the wall-clock turn timeout instead of surfacing a
+    /// terminal, model-visible explanation.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub failed_signatures: Vec<CapabilityCallSignature>,
 }
 
 impl CapabilityBatchTurnSummary {
@@ -122,7 +129,15 @@ impl CapabilityBatchTurnSummary {
             observed_signatures: Vec::new(),
             made_progress_signatures: Vec::new(),
             no_change_signatures: Vec::new(),
+            failed_signatures: Vec::new(),
         }
+    }
+
+    /// Records the signature of a capability call that returned a `Failed`
+    /// outcome this batch. A repeated identical failing call that has already
+    /// been warned terminalizes the loop instead of retrying to the timeout.
+    pub(crate) fn record_failed_signature(&mut self, signature: CapabilityCallSignature) {
+        push_unique_signature(&mut self.failed_signatures, signature);
     }
 
     pub(crate) fn record_result(
@@ -213,8 +228,11 @@ pub(crate) enum StopKind {
 /// 3. **Repetition escape**: the same `CapabilityCallSignature` is observed
 ///    in `repetition_threshold` (default 3) of the last `repetition_window`
 ///    (default 5) iterations → render a model-visible warning. If the warning
-///    was rendered and the same repeated call then reports no progress →
-///    `Stop { NoProgressDetected }`.
+///    was rendered and the same repeated call then reports no progress — either
+///    a `NoChange` completion or a non-recoverable `Failed` outcome — →
+///    `Stop { NoProgressDetected }`. The failing-call arm stops a model that
+///    retries the identical failing operation without adapting before the run
+///    reaches its wall-clock turn timeout.
 /// 4. **Typed no-progress escape**: completed capability batches whose results
 ///    all report `NoChange` or `Blocked` progress for
 ///    `typed_progress_run_threshold` turns in a row →
@@ -447,7 +465,9 @@ fn transition_existing_warning(
         RepeatedCallWarningPhase::Rendered => {
             if signature_made_progress(just_completed, &signature) {
                 None
-            } else if signature_no_change(just_completed, &signature) {
+            } else if signature_no_change(just_completed, &signature)
+                || signature_failed(just_completed, &signature)
+            {
                 Some(RepeatedCallWarningState::terminal_ready(signature))
             } else {
                 Some(RepeatedCallWarningState::rendered(signature))
@@ -475,6 +495,14 @@ fn signature_made_progress(
         && just_completed
             .capability_batch
             .made_progress_signatures
+            .contains(signature)
+}
+
+fn signature_failed(just_completed: &TurnSummary, signature: &CapabilityCallSignature) -> bool {
+    just_completed.kind == TurnEndKind::AfterCapabilityBatch
+        && just_completed
+            .capability_batch
+            .failed_signatures
             .contains(signature)
 }
 
@@ -901,6 +929,43 @@ mod tests {
                 .stop_state
                 .repeated_call_warning
                 .expect("repeated call warning should terminalize");
+            assert_eq!(warning.signature, signature);
+            assert_eq!(warning.phase, RepeatedCallWarningPhase::TerminalReady);
+        }
+
+        #[tokio::test]
+        async fn rendered_repeated_signature_warning_and_failed_call_triggers_no_progress() {
+            // A model that keeps retrying the SAME failing capability call must
+            // terminalize after the repeated-call warning is rendered, rather
+            // than looping to the wall-clock turn timeout.
+            let strategy = DefaultStopConditionStrategy::default();
+            let mut state = LoopExecutionState::initial_for_run(&test_run_context());
+            let signature = CapabilityCallSignature::from_call(
+                CapabilityId::new("demo.echo").expect("valid"),
+                &json!({"x": 1}),
+            )
+            .expect("valid call signature");
+            for _ in 0..3 {
+                state.recent_call_signatures.push(signature.clone());
+            }
+            state.stop_state.repeated_call_warning =
+                Some(RepeatedCallWarningState::rendered(signature.clone()));
+            let mut capability_batch = CapabilityBatchTurnSummary::for_invocation_count(1);
+            capability_batch.record_failed_signature(signature.clone());
+            let summary = after_batch_with_capability_summary(capability_batch);
+
+            let (state, outcome) = observe_and_decide(&strategy, state, summary).await;
+
+            assert!(matches!(
+                outcome,
+                StopOutcome::Stop {
+                    kind: StopKind::NoProgressDetected
+                }
+            ));
+            let warning = state
+                .stop_state
+                .repeated_call_warning
+                .expect("repeated call warning should terminalize on repeated failure");
             assert_eq!(warning.signature, signature);
             assert_eq!(warning.phase, RepeatedCallWarningPhase::TerminalReady);
         }


### PR DESCRIPTION
## Root cause

`sys-005` ("reborn turn timed out") shows the agent loop reaching iteration 30+ while the model replays the *same* failing capability call (`detail.failure_kind=operation_failed/generic_failure`, `recovery_hint=respect_failure_constraint`) without adapting. The repeated-call machinery in `DefaultStopConditionStrategy` already arms and renders a model-visible warning when the same `CapabilityCallSignature` repeats, but a failing call can never *terminalize* that warning: terminalization only fires on a `NoChange` completion (`no_change_signatures`) or clears on `MadeProgress` (`made_progress_signatures`), and a `CapabilityOutcome::Failed` records into neither. So a model wedged on an identical failing call loops until the wall-clock turn timeout instead of stopping with a terminal, model-visible explanation.

## The change

- Add `failed_signatures` to `CapabilityBatchTurnSummary` and record the signature of each `CapabilityOutcome::Failed` call (`handle_capability_outcome`, `capabilities.rs`).
- In `DefaultStopConditionStrategy`, let an already-*rendered* repeated-call warning terminalize into `StopKind::NoProgressDetected` when the same signature fails again — symmetric with the existing `NoChange` arm. `MadeProgress` still wins (clears the warning), so a call that recovers is unaffected.

The model still gets the existing repeated-call warning first (a chance to adapt); only an identical failure *after* the warning terminalizes. The executor resolves `NoProgressDetected` to a typed, model-visible `LoopFailureKind::NoProgressDetected` (or graceful final-answer nudge), not a canned success.

## Why it's minimal/safe

- Reuses the existing, well-tested repeated-call-warning state machine (window 5 / threshold 3 + one warned repeat) — no new counters, thresholds, or per-iteration cap.
- Purely additive field with `#[serde(default, skip_serializing_if)]` — old checkpoints stay decodable.
- Does **not** touch the `record_result` `NoChange`/`Blocked` semantics: completed-but-`Blocked` results still don't count toward no-progress; only non-recoverable `Failed` *outcomes* of a repeated identical call do.
- `same_failure_kind_three_times_does_not_trigger_no_progress` is unaffected (it pushes failure kinds without matching repeated signatures).
- One focused unit test added (`rendered_repeated_signature_warning_and_failed_call_triggers_no_progress`).

## Targeted failing benchmark tasks (blast radius)

`acct-005-financial-statements`, `bio-003-gene-expression`, `cs-005-api-design`, `data-013-outlier-detection`, `doc-008-document-restructuring`, `mag-004-project-decomposition`, `mem-001-recall-given-name`, `mem-003-context-carry-over`, `mem-004-contradiction-resolution`, `mm-003-code-doc-extraction`, `mm-004-log-analysis-config`, `mm-009-markdown-report`, `sys-005-cron-expression-parser`, `web-010-html-diff-report`, `xdom-011-data-migration-plan`, `xdom-015-automated-code-review-report`.

## Related (not fixed here)

The taxonomy notes this is compounded by an "opaque-observation" defect (the model can't see *what* to change in the replayed failure), and the underlying `operation_failed` source for these tasks was not root-caused from the bundle. This PR bounds the wasted iterations; it does not make the failure observation more actionable. The same terminalization could reasonably extend to repeated `Denied` outcomes — left out to keep this change targeted.

`cargo check -p ironclaw_agent_loop` (lib + tests) passes; `cargo test` is not runnable in the headless build environment.

Validation: the bench-hillclimb agent will run these tasks against this branch; a maintainer reviews before merge.