### PR TITLE
fix(ironclaw_agent_loop): break non-converging identical-failure retry loops

### DIFF
--- a/crates/ironclaw_agent_loop/src/strategies/stop.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/stop.rs
@@ -222,6 +222,13 @@ pub(crate) enum StopKind {
 /// 5. **Rejected-reply escape**: reply admission rejects
 ///    `rejected_reply_threshold` replies in a row →
 ///    `Stop { Aborted(InvalidModelOutput) }`.
+/// 6. **Repeated-failure escape**: the same capability call signature
+///    dominates the recent window AND the trailing `recent_failure_kinds`
+///    are an unbroken run of the same kind for `repeated_failure_threshold`
+///    entries → the model is retrying an identical failing operation without
+///    adapting → `Stop { NoProgressDetected }`. Without this, such a run burns
+///    iterations until the wall-clock turn timeout instead of terminating with
+///    a model-visible no-progress failure.
 ///
 /// On no signal, returns `Continue`.
 #[derive(Debug, Clone, Copy)]
@@ -249,6 +256,14 @@ pub struct DefaultStopConditionStrategy {
     /// Min trailing run length of completed capability batches whose typed
     /// progress reported no new evidence/state.
     pub typed_progress_run_threshold: usize,
+    /// Min trailing run length of identical `recent_failure_kinds` required —
+    /// in combination with a dominant repeated call signature — to treat the
+    /// loop as wedged on a non-converging retry (`failure_run` in the family
+    /// fingerprint). Gating on the repeated signature as well keeps unrelated,
+    /// transient failures that merely share a coarse `LoopFailureKind` from
+    /// tripping the escape; those are bounded by recovery and the iteration
+    /// limit instead. `0` disables the check.
+    pub repeated_failure_threshold: usize,
 }
 
 impl Default for DefaultStopConditionStrategy {
@@ -262,6 +277,7 @@ impl Default for DefaultStopConditionStrategy {
             min_delta_tokens: 4,
             noprogress_window: 4,
             typed_progress_run_threshold: 3,
+            repeated_failure_threshold: 3,
         }
     }
 }
@@ -382,6 +398,26 @@ impl StopConditionStrategy for DefaultStopConditionStrategy {
         if state.stop_state.trailing_rejected_replies as usize >= self.rejected_reply_threshold {
             return StopOutcome::Stop {
                 kind: StopKind::Aborted(LoopFailureKind::InvalidModelOutput),
+            };
+        }
+
+        // (g) repeated-failure escape — the model is retrying an identical
+        // failing capability call without adapting. A failing call reports
+        // `Blocked` progress (not `NoChange`), so the repeated-call warning at
+        // (d) never terminalizes for it; left unchecked the run burns
+        // iterations until the wall-clock turn timeout. Fire only when BOTH
+        // signals agree: the same call signature dominates the recent window
+        // AND the trailing failure kinds are an unbroken run of the same kind.
+        // The conjunction is deliberate — `recent_failure_kinds` alone is too
+        // coarse (unrelated calls can share a `LoopFailureKind`), so the
+        // signature gate confirms it is the *same* operation being retried.
+        if self.repeated_failure_threshold > 0
+            && state.recent_failure_kinds.same_run_length() >= self.repeated_failure_threshold
+            && dominant_repeated_call(state, self.repetition_window, self.repetition_threshold)
+                .is_some()
+        {
+            return StopOutcome::Stop {
+                kind: StopKind::NoProgressDetected,
             };
         }
 
@@ -714,6 +750,7 @@ mod tests {
             assert_eq!(strategy.repetition_threshold, 3);
             assert_eq!(strategy.rejected_reply_threshold, 3);
             assert_eq!(strategy.typed_progress_run_threshold, 3);
+            assert_eq!(strategy.repeated_failure_threshold, 3);
         }
 
         #[tokio::test]
@@ -1081,12 +1118,73 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn same_failure_kind_three_times_does_not_trigger_no_progress() {
+        async fn same_failure_kind_three_times_without_repeated_signature_continues() {
+            // Failure-kind run alone is too coarse to terminate — a repeated
+            // call signature must agree (escape (g) is a conjunction). With no
+            // signatures recorded, the loop continues.
             let strategy = DefaultStopConditionStrategy::default();
             let mut state = LoopExecutionState::initial_for_run(&test_run_context());
             for _ in 0..3 {
                 state.recent_failure_kinds.push(LoopFailureKind::ModelError);
             }
+
+            let (_state, outcome) = observe_and_decide(&strategy, state, after_batch()).await;
+
+            assert!(matches!(outcome, StopOutcome::Continue { .. }));
+        }
+
+        #[tokio::test]
+        async fn repeated_failing_signature_triggers_no_progress() {
+            // The model retries the identical failing capability call: the same
+            // signature dominates the window AND the trailing failure kinds are
+            // an unbroken run of the same kind. Escape (g) terminalizes as
+            // no-progress instead of looping to the wall-clock turn timeout.
+            let strategy = DefaultStopConditionStrategy::default();
+            let mut state = LoopExecutionState::initial_for_run(&test_run_context());
+            let signature = CapabilityCallSignature::from_call(
+                CapabilityId::new("demo.failing").expect("valid"),
+                &json!({"x": 1}),
+            )
+            .expect("valid call signature");
+            for _ in 0..3 {
+                state.recent_call_signatures.push(signature.clone());
+                state
+                    .recent_failure_kinds
+                    .push(LoopFailureKind::CapabilityProtocolError);
+            }
+
+            let (_state, outcome) = observe_and_decide(&strategy, state, after_batch()).await;
+
+            assert!(matches!(
+                outcome,
+                StopOutcome::Stop {
+                    kind: StopKind::NoProgressDetected
+                }
+            ));
+        }
+
+        #[tokio::test]
+        async fn repeated_signature_with_broken_failure_run_continues() {
+            // Same repeated signature, but the failure kinds are not an unbroken
+            // run (a differing kind landed last) — escape (g) must not fire; the
+            // existing recovery/iteration bounds own this case.
+            let strategy = DefaultStopConditionStrategy::default();
+            let mut state = LoopExecutionState::initial_for_run(&test_run_context());
+            let signature = CapabilityCallSignature::from_call(
+                CapabilityId::new("demo.failing").expect("valid"),
+                &json!({"x": 1}),
+            )
+            .expect("valid call signature");
+            for _ in 0..3 {
+                state.recent_call_signatures.push(signature.clone());
+            }
+            state
+                .recent_failure_kinds
+                .push(LoopFailureKind::CapabilityProtocolError);
+            state
+                .recent_failure_kinds
+                .push(LoopFailureKind::CapabilityProtocolError);
+            state.recent_failure_kinds.push(LoopFailureKind::ModelError);
 
             let (_state, outcome) = observe_and_decide(&strategy, state, after_batch()).await;
 


### PR DESCRIPTION
## Root cause

`reborn` turns that hit a non-converging retry loop (`sys-005` and friends) run to the wall-clock turn timeout instead of terminating cleanly. The model retries the *same* failing capability call with the same `failure_kind` (`operation_failed`/`generic_failure` → `LoopFailureKind::CapabilityProtocolError`) on every iteration. The existing repeated-call-warning escape in `DefaultStopConditionStrategy` only *terminalizes* when a repeated signature reports `NoChange` progress; a failing call reports `Blocked`, so that escape arms a warning but never stops the loop. With no repeated-identical-*failure* breaker, the loop burns iterations (30+) until the turn times out rather than surfacing a model-visible no-progress failure.

Notably, the default loop-family fingerprint already advertised this breaker — `stop:DefaultStopConditionStrategy(window=5,repeat=3,failure_run=3,...)` in `crates/ironclaw_agent_loop/src/families/{mod,subagent}.rs` — but the `failure_run` parameter and its logic were never implemented in the strategy. This PR implements exactly that advertised `failure_run=3` behavior, so the committed family digest is unchanged.

## Change (minimal, single concern)

Adds escape **(g)** to `DefaultStopConditionStrategy::should_stop_after_observed_turn`: when the same capability call signature dominates the recent window (existing `repetition_window`/`repetition_threshold`) **AND** the trailing `recent_failure_kinds` are an unbroken run of the same kind for `repeated_failure_threshold` (default 3) entries, return `Stop { NoProgressDetected }`. The executor already resolves that into an honest terminal (typed no-progress failure, or a final-answer nudge where enabled) — no new exit path.

The conjunction is deliberate: `recent_failure_kinds` alone is too coarse (unrelated calls can share a `LoopFailureKind`, and transient model errors should stay bounded by recovery + the iteration limit), so the repeated-signature gate confirms it is the *same operation* being retried. The pre-existing `recent_failure_kinds` ring was already populated by the capability error paths but read by no strategy — this is its first consumer; no new state, no new wire shape.

## Why it's safe

- One file, ~12 lines of logic (rest is docs + 3 unit tests).
- The existing "failure-kind-alone does not stop" test still passes — escape (g) requires the signature gate too.
- Pure-model-error loops never push a capability signature, so they don't trip this; they remain governed by recovery and the budget/iteration limit.
- No change to checkpoint shape, family digest, or any exit type.

## Blast radius (failing benchmark tasks this targets)

`acct-005-financial-statements`, `bio-003-gene-expression`, `cs-005-api-design`, `data-013-outlier-detection`, `doc-008-document-restructuring`, `mag-004-project-decomposition`, `mem-001-recall-given-name`, `mem-003-context-carry-over`, `mem-004-contradiction-resolution`, `mm-003-code-doc-extraction`, `mm-004-log-analysis-config`, `mm-009-markdown-report`, `sys-005-cron-expression-parser`, `web-010-html-diff-report`, `xdom-011-data-migration-plan`, `xdom-015-automated-code-review-report`

Note (unrelated, not fixed here): the candidate also flagged an opaque-observation defect (the model can't see *what* to change in a failing observation). That is a separate concern and out of scope for this breaker.

Validation: the bench-hillclimb agent will run these tasks against this branch; a maintainer reviews before merge.
