### PR TITLE
fix(ironclaw_host_runtime): map HTTP RequestDenied to PolicyDenied, not InputEncode

### DIFF
--- a/crates/ironclaw_host_runtime/src/first_party_tools/http.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/http.rs
@@ -452,7 +452,12 @@ fn http_error(error: RuntimeHttpEgressError) -> FirstPartyCapabilityError {
         // Host credential injection failures are backend/client integration faults;
         // production maps RuntimeDispatchErrorKind::Client to RuntimeFailureKind::Backend.
         RuntimeHttpEgressReasonCode::CredentialUnavailable => RuntimeDispatchErrorKind::Client,
-        RuntimeHttpEgressReasonCode::RequestDenied => RuntimeDispatchErrorKind::InputEncode,
+        // RequestDenied is a request-guard denial (blocked host, SSRF/private-IP
+        // guard, credential-shaped URL/header, manual-credential rejection,
+        // unauthorized network-egress policy). It is NOT malformed input, so it
+        // must not reach the model as InputEncode — that label invites a retry
+        // with reformatted args against a request policy will deny again.
+        RuntimeHttpEgressReasonCode::RequestDenied => RuntimeDispatchErrorKind::PolicyDenied,
         RuntimeHttpEgressReasonCode::PolicyDenied => RuntimeDispatchErrorKind::PolicyDenied,
         RuntimeHttpEgressReasonCode::NetworkError => RuntimeDispatchErrorKind::NetworkDenied,
         RuntimeHttpEgressReasonCode::ResponseError => RuntimeDispatchErrorKind::OperationFailed,
@@ -540,5 +545,26 @@ mod body_tests {
     fn json_object_body_is_serialized() {
         let input = json!({ "method": "post", "body": { "k": "v" } });
         assert_eq!(body(&input).expect("json body"), br#"{"k":"v"}"#.to_vec());
+    }
+}
+
+#[cfg(test)]
+mod http_error_tests {
+    use super::{RuntimeDispatchErrorKind, RuntimeHttpEgressError, http_error};
+
+    #[test]
+    fn request_denied_maps_to_policy_denied_not_input_encode() {
+        // A request-guard denial (e.g. a blocked host or credential-shaped URL)
+        // surfaces as RuntimeHttpEgressError::Request. The model must see this as
+        // PolicyDenied so it abandons rather than retrying with reformatted args.
+        let error = RuntimeHttpEgressError::Request {
+            reason: "manual_credentials_denied".to_string(),
+            request_bytes: 0,
+            response_bytes: 0,
+        };
+        assert_eq!(
+            http_error(error).kind(),
+            Some(RuntimeDispatchErrorKind::PolicyDenied)
+        );
     }
 }

--- a/crates/ironclaw_host_runtime/tests/first_party_runtime_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_runtime_contract.rs
@@ -335,7 +335,7 @@ async fn http_error_kind_maps_all_reason_codes() {
         ),
         (
             RuntimeHttpEgressReasonCode::RequestDenied,
-            RuntimeDispatchErrorKind::InputEncode,
+            RuntimeDispatchErrorKind::PolicyDenied,
         ),
         (
             RuntimeHttpEgressReasonCode::PolicyDenied,
@@ -779,7 +779,7 @@ impl FirstPartyCapabilityHandler for HttpFirstPartyHandler {
 fn http_error_kind(reason: RuntimeHttpEgressReasonCode) -> RuntimeDispatchErrorKind {
     match reason {
         RuntimeHttpEgressReasonCode::CredentialUnavailable => RuntimeDispatchErrorKind::Client,
-        RuntimeHttpEgressReasonCode::RequestDenied => RuntimeDispatchErrorKind::InputEncode,
+        RuntimeHttpEgressReasonCode::RequestDenied => RuntimeDispatchErrorKind::PolicyDenied,
         RuntimeHttpEgressReasonCode::PolicyDenied => RuntimeDispatchErrorKind::PolicyDenied,
         RuntimeHttpEgressReasonCode::NetworkError => RuntimeDispatchErrorKind::NetworkDenied,
         RuntimeHttpEgressReasonCode::ResponseError => RuntimeDispatchErrorKind::OperationFailed,


### PR DESCRIPTION
## Root cause

`first_party_tools/http.rs` mapped `RuntimeHttpEgressReasonCode::RequestDenied` to `RuntimeDispatchErrorKind::InputEncode`. But `RequestDenied` is never a malformed-input error — it is emitted only by request guards: blocked/credential-shaped URLs and headers, manual-credential rejection, credential-leak blocking (`egress/sanitize.rs`), unauthorized host network-egress policy (`egress/host_port.rs`), and response-body-store authorization (`egress/pipeline.rs`). Labeling a policy denial as `invalid_input` tells the model the *arguments* were wrong, so it retries the same blocked request with reformatted args (e.g. UID0227 replays the identical failure across iterations) instead of abandoning. This change maps `RequestDenied` to the dedicated `PolicyDenied` kind, which already exists and which the WASM egress path uses for the analogous `host_http_network_denied` case — the model-visible failure now says the request was *blocked*, not malformed.

## Targeted failing tasks (blast radius)

UID0113, UID0135, UID0175, UID0183, UID0214, UID0227

## Why this is minimal/safe

One-line behavioral change in the `http_error` reason-code match, plus its kept-in-sync mirror in the contract test and a focused regression test. No other reason-code mapping changes; `PolicyDenied` is an existing kind already wired through the dispatch/failure pipeline. `cargo check -p ironclaw_host_runtime --tests` passes.

## Out of scope (noted, not fixed)

The candidate also flags that argument-validation rejections in the coding/http tools (`input_error()`) return an empty result with no field-level diagnostic, giving the model nothing to repair. That is a separate, larger concern (see `docs/plans/2026-06-22-first-party-invalid-input-error-surfacing.md`) and is intentionally left for its own change to keep this PR single-concern.

Validation: the bench-hillclimb agent will run these tasks against this branch; a maintainer reviews before merge.
