### PR TITLE
fix(ironclaw_turns): subagent goal body rejected by 512-byte safe-summary cap

### DIFF
--- a/crates/ironclaw_loop_support/src/subagent_prompt_port.rs
+++ b/crates/ironclaw_loop_support/src/subagent_prompt_port.rs
@@ -209,7 +209,11 @@ pub fn materialize_goal_message(
             ),
         ));
     }
-    let safe_body = LoopSafeSummary::new(safe_body).map_err(|reason| {
+    // The goal is a prompt *body*, not a short result *summary*, so it carries
+    // the larger inline-message-body ceiling rather than the 512-byte safe
+    // summary cap. The budget checks above already bound it; this only applies
+    // the shared delimiter/marker safety scan.
+    let safe_body = LoopSafeSummary::new_inline_message_body(safe_body).map_err(|reason| {
         AgentLoopHostError::new(
             AgentLoopHostErrorKind::Invalid,
             format!("invalid subagent goal prompt: {reason}"),
@@ -358,6 +362,28 @@ mod tests {
         .expect("collapsed goal should fit");
 
         assert_eq!(goal.safe_body.as_str(), "Subagent task: answer briefly");
+    }
+
+    #[test]
+    fn multi_kilobyte_goal_composes_past_the_safe_summary_cap() {
+        // A goal between the 512-byte safe-summary cap and the default
+        // multi-KB budget must compose: it is a prompt body, not a result
+        // summary. Regression guard for goals that passed the budget checks but
+        // were rejected by the 512-byte `LoopSafeSummary` validator.
+        let task = "a".repeat(1024);
+        assert!(task.len() > 512);
+        let goal = materialize_goal_message(
+            &SubagentPromptGoal {
+                task: task.clone(),
+                handoff: None,
+            },
+            SubagentPromptLimits::default(),
+        )
+        .expect("multi-kilobyte goal should compose");
+
+        assert_eq!(goal.role, LoopInlineMessageRole::User);
+        assert!(goal.safe_body.as_str().contains(&task));
+        assert!(goal.safe_body.as_str().len() > 512);
     }
 
     #[test]

--- a/crates/ironclaw_turns/src/run_profile/host.rs
+++ b/crates/ironclaw_turns/src/run_profile/host.rs
@@ -146,17 +146,40 @@ fn validate_loop_safe_identifier(
     Ok(value)
 }
 
+/// Maximum byte length for an inline prompt-message body.
+///
+/// Inline message bodies (subagent goals, direction markdown, control nudges)
+/// are full prompt *bodies*, not short result *summaries*, so they use this
+/// larger ceiling instead of the 512-byte summary cap. It mirrors the
+/// model-safe-summary surface cap enforced downstream during instruction-bundle
+/// materialization (`prompt_text::MODEL_SAFE_SUMMARY_MAX_BYTES`); raising it past
+/// that bound would only move the rejection to a later layer.
+const LOOP_INLINE_MESSAGE_BODY_MAX_BYTES: usize = 4096;
+
 fn validate_loop_safe_summary(value: String) -> Result<String, String> {
-    let value = validate_bounded_loop_string(value, "loop safe summary", 512)?;
+    validate_loop_safe_text(value, "loop safe summary", 512)
+}
+
+/// Shared delimiter/marker/control safety scan for sanitized loop strings.
+///
+/// `max_bytes` is the only axis that differs between the 512-byte result-summary
+/// cap and the larger inline-message-body cap — the redaction policy is
+/// identical so the two surfaces cannot drift.
+fn validate_loop_safe_text(
+    value: String,
+    label: &'static str,
+    max_bytes: usize,
+) -> Result<String, String> {
+    let value = validate_bounded_loop_string(value, label, max_bytes)?;
     if value.chars().any(|character| {
         matches!(
             character,
             '{' | '}' | '[' | ']' | '`' | '<' | '>' | '/' | '\\'
         )
     }) {
-        return Err(
-            "loop safe summary must not contain raw payload or path delimiters".to_string(),
-        );
+        return Err(format!(
+            "{label} must not contain raw payload or path delimiters"
+        ));
     }
 
     let lower = value.to_ascii_lowercase();
@@ -182,7 +205,7 @@ fn validate_loop_safe_summary(value: String) -> Result<String, String> {
     ] {
         if lower.contains(forbidden) {
             return Err(format!(
-                "loop safe summary must not contain sensitive marker `{forbidden}`"
+                "{label} must not contain sensitive marker `{forbidden}`"
             ));
         }
     }
@@ -190,7 +213,7 @@ fn validate_loop_safe_summary(value: String) -> Result<String, String> {
         .split(|character: char| !character.is_ascii_alphanumeric() && character != '-')
         .any(|token| token.starts_with("sk-"))
     {
-        return Err("loop safe summary must not contain API-key-like tokens".to_string());
+        return Err(format!("{label} must not contain API-key-like tokens"));
     }
     Ok(value)
 }
@@ -384,6 +407,25 @@ pub struct LoopSafeSummary(String);
 impl LoopSafeSummary {
     pub fn new(value: impl Into<String>) -> Result<Self, String> {
         validate_loop_safe_summary(value.into()).map(Self)
+    }
+
+    /// Build an inline prompt-message body.
+    ///
+    /// Inline message bodies (e.g. a subagent goal) are full prompt bodies, not
+    /// short result summaries, so this applies the same delimiter/marker/control
+    /// safety scan as [`Self::new`] but with the larger
+    /// [`LOOP_INLINE_MESSAGE_BODY_MAX_BYTES`] ceiling. The 512-byte cap on
+    /// [`Self::new`] stays reserved for actual tool-result summaries. Inline
+    /// message bodies are transient, in-process prompt-construction values; they
+    /// are re-validated against the model-safe-summary surface during
+    /// instruction-bundle materialization.
+    pub fn new_inline_message_body(value: impl Into<String>) -> Result<Self, String> {
+        validate_loop_safe_text(
+            value.into(),
+            "loop inline message body",
+            LOOP_INLINE_MESSAGE_BODY_MAX_BYTES,
+        )
+        .map(Self)
     }
 
     pub fn model_gateway_failed() -> Self {


### PR DESCRIPTION
## Root cause

`materialize_goal_message` (`crates/ironclaw_loop_support/src/subagent_prompt_port.rs`) validates the subagent goal body against the KB-scale `SubagentPromptLimits` budget, then wraps the *same* body in `LoopSafeSummary::new`. `LoopSafeSummary` runs `validate_loop_safe_summary` (`crates/ironclaw_turns/src/run_profile/host.rs`), whose 512-byte ceiling is meant for short result *summaries*, not prompt *bodies*. A goal between 512 bytes and the goal budget passes the budget check and is then rejected by the summary cap with `invalid subagent goal prompt: loop safe summary must be at most 512 bytes`. That surfaces as a terminal `HostUnavailable { Prompt }` that kills the planned-subagent driver (falling back to planned-default). The inline-message body type was conflated with the safe-summary type.

## Fix

Give inline message bodies a body-appropriate length limit while keeping the exact same delimiter/marker/control safety scan:

- Extract the shared scan into `validate_loop_safe_text(value, label, max_bytes)`; `validate_loop_safe_summary` now delegates to it with the existing 512-byte cap (error messages unchanged).
- Add `LoopSafeSummary::new_inline_message_body`, which applies the shared scan at `LOOP_INLINE_MESSAGE_BODY_MAX_BYTES` (4096). This mirrors the model-safe-summary surface cap already enforced downstream in `prompt_text.rs` during instruction-bundle materialization, so the new ceiling does not just move the rejection to a later layer.
- `materialize_goal_message` now uses `new_inline_message_body` for the goal. The pre-existing raw/sanitized budget checks still bound the body first.

The 512-byte cap stays reserved for actual tool-result summaries (`LoopSafeSummary::new` is unchanged), and the redaction policy is identical across both surfaces so they cannot drift.

## Blast radius (targeted failing tasks)

`UID0059`, `UID0147`, `mm-002-csv-json-merge`, `mm-006-schema-migration` — subagent goals in the 0.5–4 KB range that previously died on the summary cap.

## Why minimal / safe

- Two files; the behavioral change is one constructor swap plus a non-functional refactor that preserves the existing summary path byte-for-byte (same messages, same 512 cap).
- Same delimiter/marker/secret scan as before — only the length ceiling for *bodies* is raised, and only to the value already enforced one layer down.
- One focused regression test asserts a >512-byte goal now composes.

## Note (not fixed here — second concern)

A fully type-safe variant would introduce a distinct `LoopInlineMessageBody` newtype for `LoopInlineMessage.safe_body` instead of overloading `LoopSafeSummary`, but that ripples across every inline-message producer in `ironclaw_agent_loop`/`ironclaw_loop_support` (5+ files) and is out of scope for this localized fix. Separately, the delimiter scan still rejects goal bodies containing raw `{ } [ ] ` `` ` `` `< > / \` — goals carrying JSON/code fragments may need a follow-up; this PR only addresses the length conflation.

Validation: the bench-hillclimb agent will run these tasks against this branch; a maintainer reviews before merge.
