### PR TITLE
[codex] Type provider tool names at model protocol boundaries

### DIFF
--- a/crates/ironclaw_agent_loop/src/executor/tests.rs
+++ b/crates/ironclaw_agent_loop/src/executor/tests.rs
@@ -1,4 +1,4 @@
-use ironclaw_host_api::{ApprovalRequestId, CorrelationId, ResourceEstimate};
+use ironclaw_host_api::{ApprovalRequestId, CorrelationId, ProviderToolName, ResourceEstimate};
 use ironclaw_turns::{
     CapabilityActivityId, GateResumeDisposition, LoopCancelledReasonKind, LoopCompletionKind,
     LoopDiagnosticRef, LoopExit, LoopFailureKind, LoopGateRef, LoopResultRef, TurnRunId,
@@ -1501,7 +1501,7 @@ fn sanitize_result_ref_suffix_handles_empty_special_chars_and_truncation() {
             provider_model_id: "test-model".to_string(),
             provider_turn_id: oversized,
             provider_call_id: "call/with space".to_string(),
-            provider_tool_name: "demo__echo".to_string(),
+            provider_tool_name: ProviderToolName::new("demo__echo").expect("provider tool name"),
             arguments: serde_json::json!({}),
             response_reasoning: None,
             reasoning: None,
@@ -2768,7 +2768,7 @@ async fn completed_provider_call_appends_provider_replay_metadata() {
         .expect("provider replay metadata");
     assert_eq!(provider_call.provider_turn_id, "turn_1");
     assert_eq!(provider_call.provider_call_id, "call_1");
-    assert_eq!(provider_call.provider_tool_name, "demo__echo");
+    assert_eq!(provider_call.provider_tool_name.as_str(), "demo__echo");
     assert_eq!(provider_call.capability_id, capability_id());
     assert_eq!(
         provider_call.arguments,
@@ -2832,7 +2832,10 @@ async fn denied_provider_call_appends_failure_tool_result_for_replay() {
         .expect("provider replay metadata");
     assert_eq!(denied_provider_call.provider_turn_id, "turn_1");
     assert_eq!(denied_provider_call.provider_call_id, "call_2");
-    assert_eq!(denied_provider_call.provider_tool_name, "demo__echo");
+    assert_eq!(
+        denied_provider_call.provider_tool_name.as_str(),
+        "demo__echo"
+    );
     match exit {
         LoopExit::Completed(completed) => {
             assert_eq!(
@@ -3160,7 +3163,7 @@ async fn model_visible_provider_tool_failures_append_failure_tool_result_for_rep
             .expect("provider replay metadata");
         assert_eq!(provider_call.provider_turn_id, "turn_1");
         assert_eq!(provider_call.provider_call_id, "call_1");
-        assert_eq!(provider_call.provider_tool_name, "demo__echo");
+        assert_eq!(provider_call.provider_tool_name.as_str(), "demo__echo");
         match exit {
             LoopExit::Completed(completed) => {
                 assert_eq!(completed.result_refs, vec![appended[0].result_ref.clone()]);
@@ -4317,7 +4320,8 @@ async fn resume_after_auth_gate_redispatches_original_call_without_model_turn() 
         "auth resume must restage exactly one provider tool call"
     );
     assert_eq!(
-        registered_provider_calls[0].name, "demo__echo",
+        registered_provider_calls[0].name.as_str(),
+        "demo__echo",
         "auth resume must restage the checkpointed provider tool name"
     );
     assert_eq!(
@@ -6208,7 +6212,8 @@ async fn capability_stage_denied_auth_resume_only_fails_matching_call_remaining_
                 provider_model_id: "test-model".to_string(),
                 provider_turn_id: "turn_1".to_string(),
                 provider_call_id: "call_x".to_string(),
-                provider_tool_name: "demo__echo".to_string(),
+                provider_tool_name: ProviderToolName::new("demo__echo")
+                    .expect("provider tool name"),
                 arguments: serde_json::json!({"message": "x"}),
                 response_reasoning: None,
                 reasoning: None,
@@ -6396,7 +6401,8 @@ async fn capability_stage_denied_auth_resume_only_fails_matching_activity_when_c
                 provider_model_id: "test-model".to_string(),
                 provider_turn_id: "turn_1".to_string(),
                 provider_call_id: "call_x_same_cap".to_string(),
-                provider_tool_name: "demo__echo".to_string(),
+                provider_tool_name: ProviderToolName::new("demo__echo")
+                    .expect("provider tool name"),
                 arguments: serde_json::json!({"message": "x"}),
                 response_reasoning: None,
                 reasoning: None,
@@ -6564,7 +6570,8 @@ async fn capability_stage_denied_auth_resume_one_denied_two_remaining_all_dispat
                 provider_model_id: "test-model".to_string(),
                 provider_turn_id: "turn_1".to_string(),
                 provider_call_id: "call_x".to_string(),
-                provider_tool_name: "demo__echo".to_string(),
+                provider_tool_name: ProviderToolName::new("demo__echo")
+                    .expect("provider tool name"),
                 arguments: serde_json::json!({"message": "x"}),
                 response_reasoning: None,
                 reasoning: None,
@@ -6797,7 +6804,8 @@ async fn capability_stage_denied_approval_resume_only_fails_matching_call_remain
                 provider_model_id: "test-model".to_string(),
                 provider_turn_id: "turn_1".to_string(),
                 provider_call_id: "call_x".to_string(),
-                provider_tool_name: "demo__echo".to_string(),
+                provider_tool_name: ProviderToolName::new("demo__echo")
+                    .expect("provider tool name"),
                 arguments: serde_json::json!({"message": "x"}),
                 response_reasoning: None,
                 reasoning: None,

--- a/crates/ironclaw_agent_loop/src/executor/tests/support.rs
+++ b/crates/ironclaw_agent_loop/src/executor/tests/support.rs
@@ -2,7 +2,7 @@ use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
-use ironclaw_host_api::{CapabilityId, RuntimeKind, TenantId, ThreadId};
+use ironclaw_host_api::{CapabilityId, ProviderToolName, RuntimeKind, TenantId, ThreadId};
 use ironclaw_turns::{
     AgentLoopDriverDescriptor, LoopFailureKind, LoopMessageRef, RunProfileId, RunProfileVersion,
     TurnCheckpointId, TurnId, TurnRunId, TurnScope,
@@ -936,7 +936,8 @@ pub(super) fn provider_calls_response() -> LoopModelResponse {
                 provider_model_id: "test-model".to_string(),
                 provider_turn_id: "turn_1".to_string(),
                 provider_call_id: "call_1".to_string(),
-                provider_tool_name: "demo__echo".to_string(),
+                provider_tool_name: ProviderToolName::new("demo__echo")
+                    .expect("provider tool name"),
                 arguments: serde_json::json!({"message":"hello"}),
                 response_reasoning: Some("response reasoning".to_string()),
                 reasoning: Some("call reasoning".to_string()),
@@ -964,7 +965,8 @@ pub(super) fn provider_two_calls_response() -> LoopModelResponse {
                     provider_model_id: "test-model".to_string(),
                     provider_turn_id: "turn_1".to_string(),
                     provider_call_id: "call_1".to_string(),
-                    provider_tool_name: "demo__echo".to_string(),
+                    provider_tool_name: ProviderToolName::new("demo__echo")
+                        .expect("provider tool name"),
                     arguments: serde_json::json!({"message":"first"}),
                     response_reasoning: Some("response reasoning".to_string()),
                     reasoning: Some("first call reasoning".to_string()),
@@ -982,7 +984,8 @@ pub(super) fn provider_two_calls_response() -> LoopModelResponse {
                     provider_model_id: "test-model".to_string(),
                     provider_turn_id: "turn_1".to_string(),
                     provider_call_id: "call_2".to_string(),
-                    provider_tool_name: "demo__echo".to_string(),
+                    provider_tool_name: ProviderToolName::new("demo__echo")
+                        .expect("provider tool name"),
                     arguments: serde_json::json!({"message":"second"}),
                     response_reasoning: Some("response reasoning".to_string()),
                     reasoning: Some("second call reasoning".to_string()),

--- a/crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs
+++ b/crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs
@@ -679,6 +679,59 @@ fn reborn_loop_support_llm_wiring_stays_out_of_root_src() {
     );
 }
 
+#[test]
+fn provider_tool_names_stay_at_model_protocol_boundaries() {
+    let root = workspace_root();
+    let mut uses = Vec::new();
+    collect_provider_tool_name_boundary_uses(&root.join("crates"), &root, &mut uses);
+
+    let allowed = BTreeSet::from([
+        // Type definition and provider-wire validation.
+        "crates/ironclaw_host_api/src/ids.rs",
+        "crates/ironclaw_safety/src/lib.rs",
+        "crates/ironclaw_safety/src/provider_validation.rs",
+        // Host loop/run/thread protocol structs that preserve exact model
+        // provider names for tool-result roundtrips and historical replay.
+        "crates/ironclaw_turns/src/run_profile/host.rs",
+        "crates/ironclaw_threads/src/tool_result_reference.rs",
+        // Loop support owns capability-id <-> provider-name surface snapshots,
+        // synthetic provider tools, provider-call registration, and replay refs.
+        "crates/ironclaw_loop_support/src/lib.rs",
+        "crates/ironclaw_loop_support/src/capability_info.rs",
+        "crates/ironclaw_loop_support/src/capability_port.rs",
+        "crates/ironclaw_loop_support/src/capability_port/provider_validation.rs",
+        "crates/ironclaw_loop_support/src/capability_port/surface_snapshot.rs",
+        "crates/ironclaw_loop_support/src/subagent_spawn_port.rs",
+        // The model gateway is the LLM wire boundary. Executor helpers may
+        // rebuild provider calls only from stored replay metadata.
+        "crates/ironclaw_reborn/src/model_gateway.rs",
+        "crates/ironclaw_agent_loop/src/executor/capability_helpers.rs",
+        // Composition-local protocol surfaces that reconstruct provider-shaped
+        // output or local-dev synthetic provider tools.
+        "crates/ironclaw_reborn_composition/src/openai_compat_serve.rs",
+        "crates/ironclaw_reborn_composition/src/runtime/local_dev/synthetic_capability.rs",
+        "crates/ironclaw_reborn_composition/src/trace_capture.rs",
+    ]);
+    let violations = uses
+        .into_iter()
+        .filter(|use_site| !allowed.contains(use_site.path.as_str()))
+        .map(|use_site| {
+            format!(
+                "{}:{} contains `{}`",
+                use_site.path, use_site.line_number, use_site.pattern
+            )
+        })
+        .collect::<Vec<_>>();
+
+    assert!(
+        violations.is_empty(),
+        "ProviderToolName/provider_tool_name is provider-protocol identity, not canonical \
+         capability identity. Product, frontend, workflow, and ordinary routing code must use \
+         CapabilityId and convert only at model-provider/replay boundaries. Unexpected uses:\n{}",
+        violations.join("\n")
+    );
+}
+
 /// Lock the narrowed `ironclaw_reborn` public surface in place.
 ///
 /// `ironclaw_reborn` previously exposed ~25 types as a wall of `pub use`
@@ -1599,6 +1652,106 @@ fn collect_forbidden_string_uses(
             );
         }
     }
+}
+
+struct ProviderToolNameUse {
+    path: String,
+    line_number: usize,
+    pattern: &'static str,
+}
+
+fn collect_provider_tool_name_boundary_uses(
+    dir: &std::path::Path,
+    root: &std::path::Path,
+    uses: &mut Vec<ProviderToolNameUse>,
+) {
+    let entries = std::fs::read_dir(dir)
+        .unwrap_or_else(|err| panic!("failed to read {}: {err}", dir.display()));
+    for entry in entries {
+        let entry = entry.unwrap_or_else(|err| panic!("failed to read dir entry: {err}"));
+        let path = entry.path();
+        if path.is_dir() {
+            collect_provider_tool_name_boundary_uses(&path, root, uses);
+            continue;
+        }
+        if path.extension().and_then(|ext| ext.to_str()) != Some("rs") {
+            continue;
+        }
+        let relative = path
+            .strip_prefix(root)
+            .unwrap_or(&path)
+            .to_string_lossy()
+            .to_string();
+        if is_rust_test_source_path(&relative) {
+            continue;
+        }
+        let contents = std::fs::read_to_string(&path)
+            .unwrap_or_else(|err| panic!("failed to read {}: {err}", path.display()));
+        collect_provider_tool_name_uses_in_source(&relative, &contents, uses);
+    }
+}
+
+fn is_rust_test_source_path(relative: &str) -> bool {
+    relative.contains("/tests/")
+        || relative.ends_with("/tests.rs")
+        || relative.ends_with("_tests.rs")
+}
+
+fn collect_provider_tool_name_uses_in_source(
+    relative: &str,
+    contents: &str,
+    uses: &mut Vec<ProviderToolNameUse>,
+) {
+    let mut pending_cfg_test = false;
+    let mut skipping_test_module_depth: Option<usize> = None;
+    for (index, line) in contents.lines().enumerate() {
+        let line_number = index + 1;
+        if let Some(depth) = skipping_test_module_depth {
+            let next_depth = update_brace_depth(depth, line);
+            if next_depth == 0 {
+                skipping_test_module_depth = None;
+            } else {
+                skipping_test_module_depth = Some(next_depth);
+            }
+            continue;
+        }
+
+        let trimmed = line.trim();
+        if trimmed.starts_with("#[cfg(test)]") {
+            pending_cfg_test = true;
+            continue;
+        }
+        if pending_cfg_test {
+            if trimmed.starts_with("#[") || trimmed.is_empty() {
+                continue;
+            }
+            if trimmed.starts_with("mod tests") && trimmed.contains('{') {
+                let depth = update_brace_depth(0, line);
+                if depth > 0 {
+                    skipping_test_module_depth = Some(depth);
+                }
+                pending_cfg_test = false;
+                continue;
+            }
+            pending_cfg_test = false;
+        }
+
+        for pattern in ["ProviderToolName", "provider_tool_name"] {
+            if line.contains(pattern) {
+                uses.push(ProviderToolNameUse {
+                    path: relative.to_string(),
+                    line_number,
+                    pattern,
+                });
+            }
+        }
+    }
+}
+
+fn update_brace_depth(depth: usize, line: &str) -> usize {
+    let opens = line.chars().filter(|character| *character == '{').count();
+    let closes = line.chars().filter(|character| *character == '}').count();
+    depth.saturating_add(opens).saturating_sub(closes)
 }
 
 struct BoundaryRule {

--- a/crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs
+++ b/crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs
@@ -1704,10 +1704,12 @@ fn collect_provider_tool_name_uses_in_source(
 ) {
     let mut pending_cfg_test = false;
     let mut skipping_test_module_depth: Option<usize> = None;
+    let mut in_block_comment = false;
     for (index, line) in contents.lines().enumerate() {
         let line_number = index + 1;
+        let code = strip_line_strings_and_comments(line, &mut in_block_comment);
         if let Some(depth) = skipping_test_module_depth {
-            let next_depth = update_brace_depth(depth, line);
+            let next_depth = update_brace_depth(depth, &code);
             if next_depth == 0 {
                 skipping_test_module_depth = None;
             } else {
@@ -1721,12 +1723,13 @@ fn collect_provider_tool_name_uses_in_source(
             pending_cfg_test = true;
             continue;
         }
+        let code_trimmed = code.trim();
         if pending_cfg_test {
-            if trimmed.starts_with("#[") || trimmed.is_empty() {
+            if code_trimmed.starts_with("#[") || code_trimmed.is_empty() {
                 continue;
             }
-            if trimmed.starts_with("mod tests") && trimmed.contains('{') {
-                let depth = update_brace_depth(0, line);
+            if code_trimmed.contains('{') {
+                let depth = update_brace_depth(0, &code);
                 if depth > 0 {
                     skipping_test_module_depth = Some(depth);
                 }
@@ -1737,7 +1740,7 @@ fn collect_provider_tool_name_uses_in_source(
         }
 
         for pattern in ["ProviderToolName", "provider_tool_name"] {
-            if line.contains(pattern) {
+            if code.contains(pattern) {
                 uses.push(ProviderToolNameUse {
                     path: relative.to_string(),
                     line_number,
@@ -1746,6 +1749,54 @@ fn collect_provider_tool_name_uses_in_source(
             }
         }
     }
+}
+
+fn strip_line_strings_and_comments(line: &str, in_block_comment: &mut bool) -> String {
+    let mut output = String::with_capacity(line.len());
+    let mut chars = line.chars().peekable();
+    let mut in_string = false;
+    let mut escaped = false;
+    while let Some(character) = chars.next() {
+        if *in_block_comment {
+            if character == '*' && chars.peek() == Some(&'/') {
+                chars.next();
+                *in_block_comment = false;
+                output.push(' ');
+                output.push(' ');
+            } else {
+                output.push(' ');
+            }
+            continue;
+        }
+        if in_string {
+            if escaped {
+                escaped = false;
+            } else if character == '\\' {
+                escaped = true;
+            } else if character == '"' {
+                in_string = false;
+            }
+            output.push(' ');
+            continue;
+        }
+        if character == '"' {
+            in_string = true;
+            output.push(' ');
+            continue;
+        }
+        if character == '/' && chars.peek() == Some(&'/') {
+            break;
+        }
+        if character == '/' && chars.peek() == Some(&'*') {
+            chars.next();
+            *in_block_comment = true;
+            output.push(' ');
+            output.push(' ');
+            continue;
+        }
+        output.push(character);
+    }
+    output
 }
 
 fn update_brace_depth(depth: usize, line: &str) -> usize {

--- a/crates/ironclaw_host_api/src/ids.rs
+++ b/crates/ironclaw_host_api/src/ids.rs
@@ -207,6 +207,85 @@ string_id!(
 );
 string_id!(SystemServiceId, "system_service", validate_name_segment);
 
+/// Provider-facing tool/function name.
+///
+/// Unlike [`CapabilityId`], this is the exact name advertised to or returned by
+/// model providers. It deliberately excludes dots because OpenAI Responses-style
+/// tool/function names accept only ASCII letters, digits, `_`, and `-`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct ProviderToolName(String);
+
+impl ProviderToolName {
+    pub const MAX_BYTES: usize = 64;
+
+    pub fn new(value: impl Into<String>) -> Result<Self, HostApiError> {
+        let value = value.into();
+        validate_provider_tool_name(&value)?;
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn into_string(self) -> String {
+        self.0
+    }
+}
+
+impl std::fmt::Display for ProviderToolName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl Serialize for ProviderToolName {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for ProviderToolName {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::new(value).map_err(serde::de::Error::custom)
+    }
+}
+
+fn validate_provider_tool_name(value: &str) -> Result<(), HostApiError> {
+    if value.is_empty() {
+        return Err(HostApiError::invalid_id(
+            "provider_tool_name",
+            value,
+            "must not be empty",
+        ));
+    }
+    if value.len() > ProviderToolName::MAX_BYTES {
+        return Err(HostApiError::invalid_id(
+            "provider_tool_name",
+            value,
+            "must be at most 64 bytes",
+        ));
+    }
+    if !value
+        .chars()
+        .all(|character| character.is_ascii_alphanumeric() || matches!(character, '_' | '-'))
+    {
+        return Err(HostApiError::invalid_id(
+            "provider_tool_name",
+            value,
+            "only ASCII letters, digits, '_', and '-' are allowed",
+        ));
+    }
+    Ok(())
+}
+
 /// Extension-prefixed capability identifier.
 ///
 /// Capability IDs require at least two dot-separated segments and may use

--- a/crates/ironclaw_loop_support/src/capability_info.rs
+++ b/crates/ironclaw_loop_support/src/capability_info.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeSet;
 
-use ironclaw_host_api::{CapabilityId, EffectKind, RuntimeKind};
+use ironclaw_host_api::{CapabilityId, EffectKind, ProviderToolName, RuntimeKind};
 use ironclaw_turns::run_profile::{
     AgentLoopHostError, AgentLoopHostErrorKind, ProviderToolDefinition,
 };
@@ -10,7 +10,7 @@ pub(crate) const CAPABILITY_ID: &str = "ironclaw.loop.capability_info";
 
 pub(super) struct CapabilityInfoEntry<'a> {
     pub(super) capability_id: &'a CapabilityId,
-    pub(super) provider_tool_name: &'a str,
+    pub(super) provider_tool_name: &'a ProviderToolName,
     pub(super) safe_description: &'a str,
     pub(super) parameters_schema: &'a serde_json::Value,
     pub(super) runtime: RuntimeKind,
@@ -90,10 +90,19 @@ pub(crate) fn is_capability_id(capability_id: &CapabilityId) -> bool {
 pub(super) fn tool_definition() -> Result<ProviderToolDefinition, AgentLoopHostError> {
     Ok(ProviderToolDefinition {
         capability_id: capability_id()?,
-        name: TOOL_NAME.to_string(),
+        name: provider_tool_name()?,
         description: "Get names, summary, or schema details for a currently visible capability."
             .to_string(),
         parameters: schema(),
+    })
+}
+
+pub(super) fn provider_tool_name() -> Result<ProviderToolName, AgentLoopHostError> {
+    ProviderToolName::new(TOOL_NAME).map_err(|_| {
+        AgentLoopHostError::new(
+            AgentLoopHostErrorKind::Internal,
+            "capability info provider tool name could not be represented",
+        )
     })
 }
 

--- a/crates/ironclaw_loop_support/src/capability_port.rs
+++ b/crates/ironclaw_loop_support/src/capability_port.rs
@@ -7,8 +7,8 @@ use async_trait::async_trait;
 use ironclaw_host_api::{
     CapabilityDisplayOutputPreview, CapabilityId, CapabilitySet, CorrelationId,
     DispatchFailureDetail, DispatchInputIssue, DispatchInputIssueCode, EffectKind,
-    ExecutionContext, ExtensionId, InvocationId, MountView, Principal, ResourceEstimate,
-    RuntimeKind, sha256_digest_token,
+    ExecutionContext, ExtensionId, InvocationId, MountView, Principal, ProviderToolName,
+    ResourceEstimate, RuntimeKind, sha256_digest_token,
 };
 use ironclaw_host_runtime::{
     CapabilityFailureDisposition, HostRuntime, HostRuntimeError, IdempotencyKey,
@@ -1951,15 +1951,15 @@ fn provider_schema_is_usable(schema: &serde_json::Value) -> bool {
 
 fn provider_tool_name(
     capability_id: &CapabilityId,
-    existing: &HashMap<String, CapabilityId>,
-) -> String {
+    existing: &HashMap<ProviderToolName, CapabilityId>,
+) -> ProviderToolName {
     let base = provider_tool_name_base(capability_id.as_str());
-    if base.len() <= PROVIDER_TOOL_NAME_MAX_BYTES
+    if let Ok(name) = ProviderToolName::new(base.clone())
         && existing
-            .get(&base)
+            .get(&name)
             .is_none_or(|existing_id| existing_id == capability_id)
     {
-        return base;
+        return name;
     }
     provider_tool_name_with_digest(&base, capability_id.as_str(), existing, 0)
 }
@@ -1967,9 +1967,9 @@ fn provider_tool_name(
 fn provider_tool_name_with_digest(
     base: &str,
     capability_id: &str,
-    existing: &HashMap<String, CapabilityId>,
+    existing: &HashMap<ProviderToolName, CapabilityId>,
     attempt: u16,
-) -> String {
+) -> ProviderToolName {
     let digest_input = if attempt == 0 {
         capability_id.to_string()
     } else {
@@ -1991,6 +1991,8 @@ fn provider_tool_name_with_digest(
         &base[..prefix_end] // safety: prefix_end comes from char_indices(), so it is a UTF-8 boundary.
     };
     let candidate = format!("{prefix}__{suffix}");
+    let candidate = ProviderToolName::new(candidate)
+        .expect("provider tool name generator must produce provider-safe names");
     if existing
         .get(&candidate)
         .is_none_or(|existing_id| existing_id.as_str() == capability_id)
@@ -3208,18 +3210,18 @@ mod tests {
         let capability_id = CapabilityId::new("demo.echo").expect("valid capability id");
         let mut existing = HashMap::new();
         existing.insert(
-            "demo__echo".to_string(),
+            ProviderToolName::new("demo__echo").expect("provider tool name"),
             CapabilityId::new("demo.other").expect("valid capability id"),
         );
         let name = provider_tool_name(&capability_id, &existing);
 
-        assert!(name.len() <= PROVIDER_TOOL_NAME_MAX_BYTES);
+        assert!(name.as_str().len() <= PROVIDER_TOOL_NAME_MAX_BYTES);
         assert!(
-            name.chars().all(
+            name.as_str().chars().all(
                 |character| character.is_ascii_alphanumeric() || matches!(character, '_' | '-')
             )
         );
-        let suffix = name.rsplit("__").next().expect("digest suffix");
+        let suffix = name.as_str().rsplit("__").next().expect("digest suffix");
         assert_eq!(suffix.len(), PROVIDER_TOOL_NAME_DIGEST_BYTES);
         assert!(
             suffix
@@ -3233,8 +3235,9 @@ mod tests {
         let capability_id = CapabilityId::new("demo.echo.v1").expect("valid capability id");
         let name = provider_tool_name(&capability_id, &HashMap::new());
 
-        assert_eq!(name, "demo__echo__v1");
-        provider_validation::validate_provider_tool_name(&name).expect("provider-safe name");
+        assert_eq!(name.as_str(), "demo__echo__v1");
+        provider_validation::validate_provider_tool_name(name.as_str())
+            .expect("provider-safe name");
     }
 
     #[test]
@@ -4049,7 +4052,7 @@ mod tests {
             provider_model_id: "model".to_string(),
             turn_id: Some("turn_1".to_string()),
             id: "call_1".to_string(),
-            name: "demo__echo".to_string(),
+            name: ProviderToolName::new("demo__echo").expect("provider tool name"),
             arguments: serde_json::json!({"message":"hello"}),
             response_reasoning: None,
             reasoning: None,
@@ -4589,18 +4592,18 @@ mod tests {
         assert!(
             filtered_tool_definitions
                 .iter()
-                .any(|definition| definition.name == capability_info::TOOL_NAME),
+                .any(|definition| definition.name.as_str() == capability_info::TOOL_NAME),
             "capability_info must survive the ordinary model-visible capability filter"
         );
         let tool_definitions = port.tool_definitions().expect("tool definitions");
         assert!(
             tool_definitions
                 .iter()
-                .any(|definition| definition.name == capability_info::TOOL_NAME)
+                .any(|definition| definition.name.as_str() == capability_info::TOOL_NAME)
         );
         let capability_info_definition = tool_definitions
             .iter()
-            .find(|definition| definition.name == capability_info::TOOL_NAME)
+            .find(|definition| definition.name.as_str() == capability_info::TOOL_NAME)
             .expect("capability_info definition is advertised");
         assert_eq!(
             capability_info_definition.parameters["required"],
@@ -4613,7 +4616,7 @@ mod tests {
         );
 
         let mut call = provider_tool_call();
-        call.name = capability_info::TOOL_NAME.to_string();
+        call.name = capability_info::provider_tool_name().expect("provider tool name");
         call.arguments = serde_json::json!({
             "capability_id": capability_id.as_str(),
             "include_schema": true
@@ -4687,7 +4690,7 @@ mod tests {
             .await
             .expect("visible capabilities load");
         let mut call = provider_tool_call();
-        call.name = capability_info::TOOL_NAME.to_string();
+        call.name = capability_info::provider_tool_name().expect("provider tool name");
         call.arguments = serde_json::json!({ "name": capability_id.as_str() });
         let candidate = port
             .register_provider_tool_call(RegisterProviderToolCallRequest::new(call))
@@ -4881,7 +4884,7 @@ mod tests {
             .await
             .expect("first visible surface loads");
         let mut provider_call = provider_tool_call();
-        provider_call.name = "demo__a__b".to_string();
+        provider_call.name = ProviderToolName::new("demo__a__b").expect("provider tool name");
         let first = port
             .register_provider_tool_call(RegisterProviderToolCallRequest::new(
                 provider_call.clone(),
@@ -5095,7 +5098,7 @@ mod tests {
             .name;
 
         let mut call = provider_tool_call();
-        call.name = capability_info::TOOL_NAME.to_string();
+        call.name = capability_info::provider_tool_name().expect("provider tool name");
         call.arguments = serde_json::json!({
             "name": provider_tool_name,
             "detail": "summary"
@@ -5170,7 +5173,7 @@ mod tests {
         {
             let mut call = provider_tool_call();
             call.id = format!("call_invalid_detail_{index}");
-            call.name = capability_info::TOOL_NAME.to_string();
+            call.name = capability_info::provider_tool_name().expect("provider tool name");
             call.arguments = arguments;
 
             port.validate_provider_tool_call(&call).expect(
@@ -5257,7 +5260,7 @@ mod tests {
         {
             let mut call = provider_tool_call();
             call.id = format!("call_invalid_name_{index}");
-            call.name = capability_info::TOOL_NAME.to_string();
+            call.name = capability_info::provider_tool_name().expect("provider tool name");
             call.arguments = arguments;
 
             port.validate_provider_tool_call(&call)
@@ -5327,7 +5330,7 @@ mod tests {
             .expect("visible capabilities load");
 
         let mut call = provider_tool_call();
-        call.name = capability_info::TOOL_NAME.to_string();
+        call.name = capability_info::provider_tool_name().expect("provider tool name");
         call.arguments = serde_json::json!({ "name": "demo.missing" });
         let error = port
             .provider_tool_call_capability_ids(&call)
@@ -5336,7 +5339,7 @@ mod tests {
 
         let mut malformed_call = provider_tool_call();
         malformed_call.id = "call_malformed_unknown_target".to_string();
-        malformed_call.name = capability_info::TOOL_NAME.to_string();
+        malformed_call.name = capability_info::provider_tool_name().expect("provider tool name");
         malformed_call.arguments =
             serde_json::json!({ "name": "demo.missing", "detail": "everything" });
         let error = port
@@ -5802,7 +5805,7 @@ mod tests {
 
         // Query by provider tool name
         let mut call = provider_tool_call();
-        call.name = capability_info::TOOL_NAME.to_string();
+        call.name = capability_info::provider_tool_name().expect("provider tool name");
         call.arguments = serde_json::json!({ "name": capability_info::TOOL_NAME });
         port.register_provider_tool_call(RegisterProviderToolCallRequest::new(call))
             .await
@@ -5811,7 +5814,7 @@ mod tests {
         // Query by canonical capability id
         let mut call2 = provider_tool_call();
         call2.id = "call_2".to_string();
-        call2.name = capability_info::TOOL_NAME.to_string();
+        call2.name = capability_info::provider_tool_name().expect("provider tool name");
         call2.arguments = serde_json::json!({ "name": capability_info::CAPABILITY_ID });
         port.register_provider_tool_call(RegisterProviderToolCallRequest::new(call2))
             .await
@@ -5861,7 +5864,7 @@ mod tests {
 
         for (detail, expected_summary) in [(None, false), (Some("summary"), true)] {
             let mut call = provider_tool_call();
-            call.name = capability_info::TOOL_NAME.to_string();
+            call.name = capability_info::provider_tool_name().expect("provider tool name");
             call.arguments = serde_json::json!({ "name": capability_id.as_str() });
             if let Some(detail) = detail {
                 call.arguments["detail"] = serde_json::json!(detail);
@@ -6735,7 +6738,7 @@ mod tests {
             safe_description: "demo capability".to_string(),
             parameters_schema: serde_json::json!({"type":"object"}),
             effects: vec![EffectKind::ReadFilesystem],
-            provider_tool_name: "demo__echo".to_string(),
+            provider_tool_name: ProviderToolName::new("demo__echo").expect("provider tool name"),
         };
 
         let err = invocation_context_from_visible(VisibleInvocationContextRequest {
@@ -6788,7 +6791,7 @@ mod tests {
             safe_description: "demo capability".to_string(),
             parameters_schema: serde_json::json!({"type":"object"}),
             effects: vec![EffectKind::ReadFilesystem],
-            provider_tool_name: "demo__echo".to_string(),
+            provider_tool_name: ProviderToolName::new("demo__echo").expect("provider tool name"),
         };
 
         let invocation_context = invocation_context_from_visible(VisibleInvocationContextRequest {
@@ -6838,7 +6841,7 @@ mod tests {
             safe_description: "demo capability".to_string(),
             parameters_schema: serde_json::json!({"type":"object"}),
             effects: vec![EffectKind::ReadFilesystem],
-            provider_tool_name: "demo__echo".to_string(),
+            provider_tool_name: ProviderToolName::new("demo__echo").expect("provider tool name"),
         };
 
         let invocation_context = invocation_context_from_visible(VisibleInvocationContextRequest {
@@ -6889,7 +6892,7 @@ mod tests {
             safe_description: "demo echo".to_string(),
             parameters_schema: serde_json::json!({ "type": "object" }),
             effects: vec![EffectKind::DispatchCapability],
-            provider_tool_name: "demo_echo".to_string(),
+            provider_tool_name: ProviderToolName::new("demo_echo").expect("provider tool name"),
         };
 
         let invocation_context = invocation_context_from_visible(VisibleInvocationContextRequest {
@@ -6973,7 +6976,7 @@ mod tests {
             safe_description: "demo capability".to_string(),
             parameters_schema: serde_json::json!({"type":"object"}),
             effects: vec![EffectKind::ExecuteCode],
-            provider_tool_name: "demo__echo".to_string(),
+            provider_tool_name: ProviderToolName::new("demo__echo").expect("provider tool name"),
         };
 
         let invocation_context = invocation_context_from_visible(VisibleInvocationContextRequest {

--- a/crates/ironclaw_loop_support/src/capability_port.rs
+++ b/crates/ironclaw_loop_support/src/capability_port.rs
@@ -1992,7 +1992,7 @@ fn provider_tool_name_with_digest(
     };
     let candidate = format!("{prefix}__{suffix}");
     let candidate = ProviderToolName::new(candidate)
-        .expect("provider tool name generator must produce provider-safe names");
+        .expect("provider tool name generator must produce provider-safe names"); // safety: `prefix` is sanitized and `suffix` is a fixed ASCII hex digest slice.
     if existing
         .get(&candidate)
         .is_none_or(|existing_id| existing_id.as_str() == capability_id)

--- a/crates/ironclaw_loop_support/src/capability_port/provider_validation.rs
+++ b/crates/ironclaw_loop_support/src/capability_port/provider_validation.rs
@@ -23,7 +23,7 @@ pub(super) fn validate_provider_tool_call(
     })?;
     validate_provider_token(turn_id, "provider turn id", 512).map_err(invalid_invocation)?;
     validate_provider_token(&tool_call.id, "provider call id", 512).map_err(invalid_invocation)?;
-    validate_provider_tool_name(&tool_call.name)?;
+    validate_provider_tool_name(tool_call.name.as_str())?;
     validate_provider_arguments(&tool_call.arguments)?;
     validate_optional_provider_metadata_text(
         tool_call.response_reasoning.as_deref(),
@@ -70,13 +70,15 @@ fn invalid_invocation(error: ProviderValidationError) -> AgentLoopHostError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ironclaw_host_api::ProviderToolName;
+
+    fn provider_name(value: &str) -> ProviderToolName {
+        ProviderToolName::new(value).expect("provider tool name")
+    }
 
     #[test]
     fn provider_tool_call_validation_rejects_provider_unsafe_tool_name() {
-        let mut call = provider_tool_call();
-        call.name = "demo.echo".to_string();
-
-        let error = validate_provider_tool_call(&call).expect_err("unsafe name rejected");
+        let error = validate_provider_tool_name("demo.echo").expect_err("unsafe name rejected");
         assert_eq!(error.kind, AgentLoopHostErrorKind::InvalidInvocation);
     }
 
@@ -155,7 +157,7 @@ mod tests {
             provider_model_id: "model".to_string(),
             turn_id: Some("turn_1".to_string()),
             id: "call_1".to_string(),
-            name: "demo__echo".to_string(),
+            name: provider_name("demo__echo"),
             arguments: serde_json::json!({"message":"hello"}),
             response_reasoning: None,
             reasoning: None,

--- a/crates/ironclaw_loop_support/src/capability_port/surface_snapshot.rs
+++ b/crates/ironclaw_loop_support/src/capability_port/surface_snapshot.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 
-use ironclaw_host_api::{CapabilityId, EffectKind, ExtensionId, ResourceEstimate, RuntimeKind};
+use ironclaw_host_api::{
+    CapabilityId, EffectKind, ExtensionId, ProviderToolName, ResourceEstimate, RuntimeKind,
+};
 use ironclaw_turns::run_profile::{
     AgentLoopHostError, AgentLoopHostErrorKind, CapabilityDescriptorView, ConcurrencyHint,
     ProviderToolCall, ProviderToolDefinition,
@@ -16,12 +18,12 @@ pub(super) struct RuntimeSurfaceCapabilitySnapshot {
     pub(super) safe_description: String,
     pub(super) parameters_schema: serde_json::Value,
     pub(super) effects: Vec<EffectKind>,
-    pub(super) provider_tool_name: String,
+    pub(super) provider_tool_name: ProviderToolName,
 }
 
 #[derive(Clone)]
 pub(super) struct SyntheticSurfaceCapabilitySnapshot {
-    provider_tool_name: String,
+    provider_tool_name: ProviderToolName,
     safe_description: String,
     parameters_schema: serde_json::Value,
     kind: SyntheticCapabilityKind,
@@ -41,7 +43,7 @@ pub(super) enum SurfaceCapabilitySnapshot {
 #[derive(Clone, Default)]
 pub(super) struct SurfaceSnapshot {
     pub(super) capabilities: HashMap<CapabilityId, SurfaceCapabilitySnapshot>,
-    pub(super) provider_names: HashMap<String, CapabilityId>,
+    pub(super) provider_names: HashMap<ProviderToolName, CapabilityId>,
 }
 
 pub(super) struct PreparedSurfaceCapabilityCall {
@@ -60,14 +62,13 @@ impl SurfaceSnapshot {
 
     fn insert_synthetic_capabilities(&mut self) -> Result<(), AgentLoopHostError> {
         let capability_id = capability_info::capability_id()?;
-        self.provider_names.insert(
-            capability_info::TOOL_NAME.to_string(),
-            capability_id.clone(),
-        );
+        let provider_tool_name = capability_info::provider_tool_name()?;
+        self.provider_names
+            .insert(provider_tool_name.clone(), capability_id.clone());
         self.capabilities.insert(
             capability_id,
             SurfaceCapabilitySnapshot::Synthetic(SyntheticSurfaceCapabilitySnapshot {
-                provider_tool_name: capability_info::TOOL_NAME.to_string(),
+                provider_tool_name,
                 safe_description: capability_info::tool_definition()?.description,
                 parameters_schema: capability_info::schema(),
                 kind: SyntheticCapabilityKind::CapabilityInfo,
@@ -77,9 +78,11 @@ impl SurfaceSnapshot {
     }
 
     pub(super) fn capability_info(&self, requested: &str) -> Option<CapabilityInfoEntry<'_>> {
-        if let Some(capability_id) = self.provider_names.get(requested) {
-            let capability = self.capabilities.get(capability_id)?;
-            return Some(capability.capability_info(capability_id));
+        if let Ok(provider_name) = ProviderToolName::new(requested) {
+            if let Some(capability_id) = self.provider_names.get(&provider_name) {
+                let capability = self.capabilities.get(capability_id)?;
+                return Some(capability.capability_info(capability_id));
+            }
         }
         let requested_id = CapabilityId::new(requested).ok()?;
         self.capabilities
@@ -89,7 +92,7 @@ impl SurfaceSnapshot {
 
     pub(super) fn provider_capability(
         &self,
-        provider_tool_name: &str,
+        provider_tool_name: &ProviderToolName,
     ) -> Result<(&CapabilityId, &SurfaceCapabilitySnapshot), AgentLoopHostError> {
         let Some(capability_id) = self.provider_names.get(provider_tool_name) else {
             return Err(AgentLoopHostError::new(
@@ -247,7 +250,7 @@ impl SyntheticSurfaceCapabilitySnapshot {
                     capability_id: capability_id.clone(),
                     provider: None,
                     runtime: RuntimeKind::System,
-                    safe_name: self.provider_tool_name.clone(),
+                    safe_name: self.provider_tool_name.as_str().to_string(),
                     safe_description: self.safe_description.clone(),
                     concurrency_hint: ConcurrencyHint::SafeForParallel,
                     parameters_schema: self.parameters_schema.clone(),

--- a/crates/ironclaw_loop_support/src/capability_port/surface_snapshot.rs
+++ b/crates/ironclaw_loop_support/src/capability_port/surface_snapshot.rs
@@ -78,11 +78,11 @@ impl SurfaceSnapshot {
     }
 
     pub(super) fn capability_info(&self, requested: &str) -> Option<CapabilityInfoEntry<'_>> {
-        if let Ok(provider_name) = ProviderToolName::new(requested) {
-            if let Some(capability_id) = self.provider_names.get(&provider_name) {
-                let capability = self.capabilities.get(capability_id)?;
-                return Some(capability.capability_info(capability_id));
-            }
+        if let Ok(provider_name) = ProviderToolName::new(requested)
+            && let Some(capability_id) = self.provider_names.get(&provider_name)
+        {
+            let capability = self.capabilities.get(capability_id)?;
+            return Some(capability.capability_info(capability_id));
         }
         let requested_id = CapabilityId::new(requested).ok()?;
         self.capabilities

--- a/crates/ironclaw_loop_support/src/capability_surface_filter.rs
+++ b/crates/ironclaw_loop_support/src/capability_surface_filter.rs
@@ -609,7 +609,7 @@ fn surface_profile_denied_kind() -> CapabilityDeniedReasonKind {
 mod tests {
     use std::{collections::HashMap, sync::Mutex};
 
-    use ironclaw_host_api::{CapabilityId, RuntimeKind};
+    use ironclaw_host_api::{CapabilityId, ProviderToolName, RuntimeKind};
     use ironclaw_turns::run_profile::{
         CapabilityDescriptorView, CapabilityInputRef, CapabilityResultMessage,
         CapabilitySurfaceVersion, ConcurrencyHint,
@@ -623,7 +623,8 @@ mod tests {
         surface: Mutex<Option<VisibleCapabilitySurface>>,
         batch_outcome: Mutex<Option<CapabilityBatchOutcome>>,
         tool_definitions: Mutex<Vec<ProviderToolDefinition>>,
-        provider_call_capability_ids: Mutex<HashMap<String, ProviderToolCallCapabilityIds>>,
+        provider_call_capability_ids:
+            Mutex<HashMap<ProviderToolName, ProviderToolCallCapabilityIds>>,
         registered_candidate_capability_ids: Mutex<Option<ProviderToolCallCapabilityIds>>,
         validated_provider_calls: Mutex<Vec<ProviderToolCall>>,
         provider_calls: Mutex<Vec<ProviderToolCall>>,
@@ -763,6 +764,10 @@ mod tests {
         CapabilityInputRef::new(value).expect("test input ref is valid")
     }
 
+    fn provider_name(value: &str) -> ProviderToolName {
+        ProviderToolName::new(value).expect("provider tool name")
+    }
+
     fn invocation(capability: &str, input: &str) -> CapabilityInvocation {
         CapabilityInvocation {
             activity_id: ironclaw_turns::CapabilityActivityId::new(),
@@ -789,7 +794,7 @@ mod tests {
     fn provider_definition(capability: &str, name: &str) -> ProviderToolDefinition {
         ProviderToolDefinition {
             capability_id: capability_id(capability),
-            name: name.to_string(),
+            name: ProviderToolName::new(name).expect("provider tool name"),
             description: format!("{capability} description"),
             parameters: serde_json::json!({"type":"object"}),
         }
@@ -812,7 +817,7 @@ mod tests {
             provider_model_id: "test-model".to_string(),
             turn_id: Some("turn_1".to_string()),
             id: "call_1".to_string(),
-            name: name.to_string(),
+            name: ProviderToolName::new(name).expect("provider tool name"),
             arguments: serde_json::json!({}),
             response_reasoning: None,
             reasoning: None,
@@ -1062,7 +1067,7 @@ mod tests {
             .lock()
             .expect("provider call capability ids lock")
             .insert(
-                capability_info::TOOL_NAME.to_string(),
+                provider_name(capability_info::TOOL_NAME),
                 provider_call_capability_ids(&[capability_info::CAPABILITY_ID, "demo.denied"]),
             );
         let filter = CapabilitySurfaceProfileFilter::new(
@@ -1105,7 +1110,7 @@ mod tests {
             .lock()
             .expect("provider call capability ids lock")
             .insert(
-                capability_info::TOOL_NAME.to_string(),
+                provider_name(capability_info::TOOL_NAME),
                 provider_call_capability_ids(&[capability_info::CAPABILITY_ID, "demo.allowed"]),
             );
         *inner
@@ -1181,7 +1186,7 @@ mod tests {
             .lock()
             .expect("provider call capability ids lock")
             .insert(
-                capability_info::TOOL_NAME.to_string(),
+                provider_name(capability_info::TOOL_NAME),
                 provider_call_capability_ids(&[capability_info::CAPABILITY_ID, "demo.allowed"]),
             );
         *inner
@@ -1235,7 +1240,7 @@ mod tests {
             .lock()
             .expect("provider call capability ids lock")
             .insert(
-                capability_info::TOOL_NAME.to_string(),
+                provider_name(capability_info::TOOL_NAME),
                 provider_call_capability_ids(&[capability_info::CAPABILITY_ID, "demo.allowed"]),
             );
         *inner
@@ -1300,7 +1305,7 @@ mod tests {
             .lock()
             .expect("provider call capability ids lock")
             .insert(
-                capability_info::TOOL_NAME.to_string(),
+                provider_name(capability_info::TOOL_NAME),
                 provider_call_capability_ids(&[capability_info::CAPABILITY_ID, "demo.allowed"]),
             );
         *inner
@@ -1354,7 +1359,7 @@ mod tests {
             .lock()
             .expect("provider call capability ids lock")
             .insert(
-                capability_info::TOOL_NAME.to_string(),
+                provider_name(capability_info::TOOL_NAME),
                 provider_call_capability_ids(&[capability_info::CAPABILITY_ID, "demo.denied"]),
             );
         let filter = CapabilitySurfaceProfileFilter::new(
@@ -1394,7 +1399,7 @@ mod tests {
             .lock()
             .expect("provider call capability ids lock")
             .insert(
-                capability_info::TOOL_NAME.to_string(),
+                provider_name(capability_info::TOOL_NAME),
                 provider_call_capability_ids(&[capability_info::CAPABILITY_ID, "demo.denied"]),
             );
         let filter =
@@ -1433,7 +1438,7 @@ mod tests {
             .lock()
             .expect("provider call capability ids lock")
             .insert(
-                capability_info::TOOL_NAME.to_string(),
+                provider_name(capability_info::TOOL_NAME),
                 provider_call_capability_ids(&[capability_info::CAPABILITY_ID, "demo.denied"]),
             );
         let filter =

--- a/crates/ironclaw_loop_support/src/subagent_spawn_port.rs
+++ b/crates/ironclaw_loop_support/src/subagent_spawn_port.rs
@@ -10,7 +10,7 @@ use std::{
 
 use async_trait::async_trait;
 use chrono::Utc;
-use ironclaw_host_api::{CapabilityId, InvocationId, RuntimeKind, ThreadId};
+use ironclaw_host_api::{CapabilityId, InvocationId, ProviderToolName, RuntimeKind, ThreadId};
 use ironclaw_threads::{
     AcceptInboundMessageRequest, EnsureThreadRequest, MessageContent, SessionThreadService,
     ThreadMessageId, ThreadScope,
@@ -535,14 +535,15 @@ impl SubagentSpawnCapabilityPort {
         capability_id == &self.spawn_id
     }
 
-    fn is_spawn_provider_tool_name(&self, tool_name: &str) -> bool {
-        tool_name == SPAWN_SUBAGENT_PROVIDER_TOOL_NAME
+    fn is_spawn_provider_tool_name(&self, tool_name: &ProviderToolName) -> bool {
+        tool_name.as_str() == SPAWN_SUBAGENT_PROVIDER_TOOL_NAME
     }
 
     fn spawn_tool_definition(&self) -> ProviderToolDefinition {
         ProviderToolDefinition {
             capability_id: self.spawn_id.clone(),
-            name: SPAWN_SUBAGENT_PROVIDER_TOOL_NAME.to_string(),
+            name: ProviderToolName::new(SPAWN_SUBAGENT_PROVIDER_TOOL_NAME)
+                .expect("spawn_subagent provider tool name is static and provider-safe"),
             description: SPAWN_SUBAGENT_DESCRIPTION.to_string(),
             parameters: (*self.parameters_schema).clone(),
         }

--- a/crates/ironclaw_loop_support/src/subagent_spawn_port.rs
+++ b/crates/ironclaw_loop_support/src/subagent_spawn_port.rs
@@ -543,7 +543,7 @@ impl SubagentSpawnCapabilityPort {
         ProviderToolDefinition {
             capability_id: self.spawn_id.clone(),
             name: ProviderToolName::new(SPAWN_SUBAGENT_PROVIDER_TOOL_NAME)
-                .expect("spawn_subagent provider tool name is static and provider-safe"),
+                .expect("spawn_subagent provider tool name is static and provider-safe"), // safety: static provider-safe literal covered by unit tests.
             description: SPAWN_SUBAGENT_DESCRIPTION.to_string(),
             parameters: (*self.parameters_schema).clone(),
         }

--- a/crates/ironclaw_loop_support/src/subagent_spawn_port/tests.rs
+++ b/crates/ironclaw_loop_support/src/subagent_spawn_port/tests.rs
@@ -1,5 +1,5 @@
 use chrono::Utc;
-use ironclaw_host_api::{AgentId, TenantId, UserId};
+use ironclaw_host_api::{AgentId, ProviderToolName, TenantId, UserId};
 use ironclaw_threads::{
     AcceptedInboundMessage, AcceptedInboundMessageReplay, AppendAssistantDraftRequest,
     AppendCapabilityDisplayPreviewRequest, AppendToolResultReferenceRequest, ContextMessages,
@@ -931,7 +931,7 @@ fn provider_tool_call(name: &str) -> ProviderToolCall {
         provider_model_id: "test-model".to_string(),
         turn_id: Some("provider-turn:test".to_string()),
         id: "call-spawn".to_string(),
-        name: name.to_string(),
+        name: ProviderToolName::new(name).expect("provider tool name"),
         arguments: json!({
             "flavor_id": "general",
             "task": "investigate"
@@ -949,7 +949,7 @@ fn spawn_provider_tool_call() -> ProviderToolCall {
 fn spawn_tool_definition() -> ProviderToolDefinition {
     ProviderToolDefinition {
         capability_id: CapabilityId::new(DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID).unwrap(),
-        name: SPAWN_SUBAGENT_PROVIDER_TOOL_NAME.to_string(),
+        name: ProviderToolName::new(SPAWN_SUBAGENT_PROVIDER_TOOL_NAME).expect("provider tool name"),
         description: SPAWN_SUBAGENT_DESCRIPTION.to_string(),
         parameters: build_spawn_subagent_parameters_schema(&[]),
     }
@@ -958,7 +958,7 @@ fn spawn_tool_definition() -> ProviderToolDefinition {
 fn custom_tool_definition() -> ProviderToolDefinition {
     ProviderToolDefinition {
         capability_id: CapabilityId::new("builtin.custom_tool").unwrap(),
-        name: "demo__custom".to_string(),
+        name: ProviderToolName::new("demo__custom").expect("provider tool name"),
         description: "Custom delegated tool".to_string(),
         parameters: json!({"type": "object"}),
     }
@@ -1333,7 +1333,7 @@ async fn spawn_tool_definition_is_present_in_structured_tools() {
         })
         .expect("spawn tool definition");
 
-    assert_eq!(definition.name, SPAWN_SUBAGENT_PROVIDER_TOOL_NAME);
+    assert_eq!(definition.name.as_str(), SPAWN_SUBAGENT_PROVIDER_TOOL_NAME);
     assert_eq!(
         definition.parameters["required"],
         json!(["subagent_type", "task"])

--- a/crates/ironclaw_loop_support/tests/host_capability_port_composition.rs
+++ b/crates/ironclaw_loop_support/tests/host_capability_port_composition.rs
@@ -7,8 +7,8 @@ use std::{
 use async_trait::async_trait;
 use ironclaw_host_api::{
     CapabilityDescriptor, CapabilityId, CapabilitySet, ExecutionContext, ExtensionId, MountAlias,
-    MountGrant, MountPermissions, MountView, PermissionMode, ResourceEstimate, ResourceUsage,
-    RuntimeKind, ThreadId, TrustClass, UserId, VirtualPath,
+    MountGrant, MountPermissions, MountView, PermissionMode, ProviderToolName, ResourceEstimate,
+    ResourceUsage, RuntimeKind, ThreadId, TrustClass, UserId, VirtualPath,
 };
 use ironclaw_host_runtime::{
     CancelRuntimeWorkOutcome, CancelRuntimeWorkRequest, CapabilitySurfaceVersion, HostRuntime,
@@ -184,7 +184,7 @@ async fn factory_stages_provider_tool_call_arguments_without_custom_resolver_ove
             provider_model_id: "model".to_string(),
             turn_id: Some("turn_1".to_string()),
             id: "call_1".to_string(),
-            name: "demo__echo".to_string(),
+            name: ProviderToolName::new("demo__echo").expect("provider tool name"),
             arguments: arguments.clone(),
             response_reasoning: None,
             reasoning: None,

--- a/crates/ironclaw_loop_support/tests/thread_loop_support_contract.rs
+++ b/crates/ironclaw_loop_support/tests/thread_loop_support_contract.rs
@@ -6,7 +6,8 @@ use std::sync::{
 
 use async_trait::async_trait;
 use ironclaw_host_api::{
-    AgentId, CapabilityId, MissionId, ProjectId, ResourceScope, TenantId, ThreadId, UserId,
+    AgentId, CapabilityId, MissionId, ProjectId, ProviderToolName, ResourceScope, TenantId,
+    ThreadId, UserId,
 };
 use ironclaw_loop_support::{
     EmptyLoopCapabilityPort, HostIdentityContextBuildError, HostIdentityContextCandidate,
@@ -2270,7 +2271,8 @@ async fn transcript_port_appends_tool_result_reference_envelope_idempotently() {
                 provider_model_id: "test-model".to_string(),
                 provider_turn_id: "turn_1".to_string(),
                 provider_call_id: "call_1".to_string(),
-                provider_tool_name: "demo__echo".to_string(),
+                provider_tool_name: ProviderToolName::new("demo__echo")
+                    .expect("provider tool name"),
                 capability_id: CapabilityId::new("demo.echo").unwrap(),
                 arguments: serde_json::json!({"message":"hello"}),
                 response_reasoning: Some("provider reasoning".to_string()),
@@ -2337,7 +2339,7 @@ async fn transcript_port_appends_tool_result_reference_envelope_idempotently() {
         .expect("provider call metadata");
     assert_eq!(provider_call.provider_turn_id, "turn_1");
     assert_eq!(provider_call.provider_call_id, "call_1");
-    assert_eq!(provider_call.provider_tool_name, "demo__echo");
+    assert_eq!(provider_call.provider_tool_name.as_str(), "demo__echo");
     assert_eq!(provider_call.capability_id.as_str(), "demo.echo");
     assert_eq!(
         provider_call.arguments,
@@ -3049,7 +3051,8 @@ async fn model_port_preserves_provider_metadata_for_explicit_refs_outside_contex
                 provider_model_id: "test-model".to_string(),
                 provider_turn_id: "turn_1".to_string(),
                 provider_call_id: "call_1".to_string(),
-                provider_tool_name: "demo__echo".to_string(),
+                provider_tool_name: ProviderToolName::new("demo__echo")
+                    .expect("provider tool name"),
                 capability_id: CapabilityId::new("demo.echo").unwrap(),
                 arguments: serde_json::json!({"message":"hello"}),
                 response_reasoning: Some("provider response reasoning".to_string()),
@@ -3106,7 +3109,7 @@ async fn model_port_preserves_provider_metadata_for_explicit_refs_outside_contex
     assert_eq!(provider_call.provider_id, "test-provider");
     assert_eq!(provider_call.provider_model_id, "test-model");
     assert_eq!(provider_call.provider_call_id, "call_1");
-    assert_eq!(provider_call.provider_tool_name, "demo__echo");
+    assert_eq!(provider_call.provider_tool_name.as_str(), "demo__echo");
 }
 
 #[tokio::test]
@@ -3877,13 +3880,10 @@ fn user_model_messages(fixture: &ThreadFixture) -> Vec<LoopModelMessage> {
     }]
 }
 
-fn provider_tool_definition(
-    capability_id: CapabilityId,
-    name: impl Into<String>,
-) -> ProviderToolDefinition {
+fn provider_tool_definition(capability_id: CapabilityId, name: &str) -> ProviderToolDefinition {
     ProviderToolDefinition {
         capability_id,
-        name: name.into(),
+        name: ProviderToolName::new(name).expect("provider tool name"),
         description: "test provider tool".to_string(),
         parameters: serde_json::json!({"type": "object"}),
     }

--- a/crates/ironclaw_reborn/src/model_gateway.rs
+++ b/crates/ironclaw_reborn/src/model_gateway.rs
@@ -13,7 +13,7 @@ use std::{
 };
 
 use async_trait::async_trait;
-use ironclaw_host_api::sha256_digest_token;
+use ironclaw_host_api::{ProviderToolName, sha256_digest_token};
 use ironclaw_llm::{
     ChatMessage, CompletionRequest, CompletionResponse, ContentPart, FinishReason, ImageUrl,
     LlmError, LlmProvider, Role, ToolCall, ToolCompletionRequest, ToolCompletionResponse,
@@ -832,7 +832,7 @@ where
             let llm_tool_definitions = tool_definitions
                 .into_iter()
                 .map(|definition| {
-                    recovery_tool_names.push(definition.name.clone());
+                    recovery_tool_names.push(definition.name.as_str().to_string());
                     provider_tool_definition_to_llm(definition)
                 })
                 .collect::<Vec<_>>();
@@ -970,7 +970,7 @@ fn recover_textual_tool_calls_from_tool_response(
 
 fn provider_tool_definition_to_llm(definition: ProviderToolDefinition) -> ToolDefinition {
     ToolDefinition {
-        name: definition.name,
+        name: definition.name.into_string(),
         description: definition.description,
         parameters: definition.parameters,
     }
@@ -1018,16 +1018,6 @@ async fn tool_response_to_host(
             .into_iter()
             .map(|definition| definition.name)
             .collect::<HashSet<_>>();
-        if response
-            .tool_calls
-            .iter()
-            .any(|tool_call| !advertised_tool_names.contains(&tool_call.name))
-        {
-            return Err(HostManagedModelError::safe(
-                HostManagedModelErrorKind::InvalidOutput,
-                "model returned a tool call outside the advertised capability surface",
-            ));
-        }
         let mut candidates = Vec::with_capacity(response.tool_calls.len());
         let provider_turn_id = provider_turn_id(provider_turn_scope, &response.tool_calls);
         let provider_calls = response
@@ -1041,7 +1031,16 @@ async fn tool_response_to_host(
                     replay_identity,
                 )
             })
-            .collect::<Vec<_>>();
+            .collect::<Result<Vec<_>, HostManagedModelError>>()?;
+        if provider_calls
+            .iter()
+            .any(|provider_call| !advertised_tool_names.contains(&provider_call.name))
+        {
+            return Err(HostManagedModelError::safe(
+                HostManagedModelErrorKind::InvalidOutput,
+                "model returned a tool call outside the advertised capability surface",
+            ));
+        }
         for provider_call in &provider_calls {
             capabilities
                 .validate_provider_tool_call(provider_call)
@@ -1115,18 +1114,24 @@ fn provider_tool_call_from_llm(
     response_reasoning: Option<String>,
     provider_turn_id: String,
     replay_identity: &ProviderReplayIdentity,
-) -> ProviderToolCall {
-    ProviderToolCall {
+) -> Result<ProviderToolCall, HostManagedModelError> {
+    let name = ProviderToolName::new(tool_call.name).map_err(|_| {
+        HostManagedModelError::safe(
+            HostManagedModelErrorKind::InvalidOutput,
+            "model returned an invalid provider tool name",
+        )
+    })?;
+    Ok(ProviderToolCall {
         provider_id: replay_identity.provider_id.clone(),
         provider_model_id: replay_identity.provider_model_id.clone(),
         turn_id: Some(provider_turn_id),
         id: tool_call.id,
-        name: tool_call.name,
+        name,
         arguments: tool_call.arguments,
         response_reasoning,
         reasoning: tool_call.reasoning,
         signature: tool_call.signature,
-    }
+    })
 }
 
 fn provider_turn_id(provider_turn_scope: &str, tool_calls: &[ToolCall]) -> String {
@@ -1514,7 +1519,7 @@ fn provider_tool_roundtrip_messages(
                 .map(|(provider_call, summary)| {
                     ChatMessage::tool_result(
                         provider_call.provider_call_id,
-                        provider_call.provider_tool_name,
+                        provider_call.provider_tool_name.into_string(),
                         summary,
                     )
                 }),
@@ -1527,7 +1532,7 @@ fn provider_tool_call_from_reference(
 ) -> ToolCall {
     ToolCall {
         id: provider_call.provider_call_id.clone(),
-        name: provider_call.provider_tool_name.clone(),
+        name: provider_call.provider_tool_name.as_str().to_string(),
         arguments: provider_call.arguments.clone(),
         reasoning: provider_call.reasoning.clone(),
         signature: provider_call.signature.clone(),

--- a/crates/ironclaw_reborn/src/model_gateway.rs
+++ b/crates/ironclaw_reborn/src/model_gateway.rs
@@ -1115,7 +1115,8 @@ fn provider_tool_call_from_llm(
     provider_turn_id: String,
     replay_identity: &ProviderReplayIdentity,
 ) -> Result<ProviderToolCall, HostManagedModelError> {
-    let name = ProviderToolName::new(tool_call.name).map_err(|_| {
+    let name = ProviderToolName::new(tool_call.name).map_err(|error| {
+        debug!(%error, "reborn model gateway rejected invalid provider tool name");
         HostManagedModelError::safe(
             HostManagedModelErrorKind::InvalidOutput,
             "model returned an invalid provider tool name",

--- a/crates/ironclaw_reborn/src/subagent/flavors.rs
+++ b/crates/ironclaw_reborn/src/subagent/flavors.rs
@@ -492,7 +492,8 @@ mod tests {
                     .iter()
                     .map(|id| ProviderToolDefinition {
                         capability_id: cap(id),
-                        name: id.replace('.', "__"),
+                        name: ironclaw_host_api::ProviderToolName::new(id.replace('.', "__"))
+                            .expect("provider tool name"),
                         description: format!("{id} description"),
                         parameters: serde_json::json!({"type":"object"}),
                     })

--- a/crates/ironclaw_reborn/tests/llm_gateway.rs
+++ b/crates/ironclaw_reborn/tests/llm_gateway.rs
@@ -4,7 +4,9 @@ use std::{
 };
 
 use async_trait::async_trait;
-use ironclaw_host_api::{AgentId, CapabilityId, ProjectId, TenantId, ThreadId, UserId};
+use ironclaw_host_api::{
+    AgentId, CapabilityId, ProjectId, ProviderToolName, TenantId, ThreadId, UserId,
+};
 use ironclaw_llm::{
     CompletionRequest, CompletionResponse, FinishReason, LlmError, LlmProvider, Role, ToolCall,
     ToolCompletionRequest, ToolCompletionResponse,
@@ -44,6 +46,10 @@ use rust_decimal::Decimal;
 use tokio::sync::Barrier;
 
 const STATIC_PROVIDER_ID: &str = "static-test-provider";
+
+fn provider_name(value: &str) -> ProviderToolName {
+    ProviderToolName::new(value).expect("provider tool name")
+}
 
 fn local_development_safety_context() -> InstructionSafetyContext {
     InstructionSafetyContext::local_development_noop()
@@ -336,7 +342,7 @@ async fn gateway_with_tool_surface_calls_complete_with_tools_and_returns_capabil
     assert_eq!(provider_replay.provider_id, STATIC_PROVIDER_ID);
     assert_eq!(provider_replay.provider_model_id, "host-selected-model");
     assert_eq!(provider_replay.provider_call_id, "call_1");
-    assert_eq!(provider_replay.provider_tool_name, "demo__echo");
+    assert_eq!(provider_replay.provider_tool_name.as_str(), "demo__echo");
     assert_eq!(
         provider_replay.arguments,
         serde_json::json!({"message":"hello"})
@@ -417,7 +423,7 @@ async fn gateway_recovers_capability_calls_from_textual_tool_syntax() {
 
     let registered = capabilities.registered.lock().unwrap();
     assert_eq!(registered.len(), 1);
-    assert_eq!(registered[0].name, "demo__echo");
+    assert_eq!(registered[0].name.as_str(), "demo__echo");
     assert_eq!(
         registered[0].arguments,
         serde_json::json!({"message":"hello"})
@@ -712,7 +718,7 @@ async fn gateway_reconstructs_provider_tool_roundtrip_from_tool_result_reference
         provider_model_id: "host-selected-model".to_string(),
         provider_turn_id: "turn_1".to_string(),
         provider_call_id: "call_1".to_string(),
-        provider_tool_name: "demo__echo".to_string(),
+        provider_tool_name: provider_name("demo__echo"),
         capability_id: CapabilityId::new("demo.echo").unwrap(),
         arguments: serde_json::json!({"message":"hello"}),
         response_reasoning: Some("provider reasoning".to_string()),
@@ -789,7 +795,7 @@ async fn gateway_replays_model_observation_from_tool_result_reference_before_saf
         provider_model_id: "host-selected-model".to_string(),
         provider_turn_id: "turn_1".to_string(),
         provider_call_id: "call_1".to_string(),
-        provider_tool_name: "demo__echo".to_string(),
+        provider_tool_name: provider_name("demo__echo"),
         capability_id: CapabilityId::new("demo.echo").unwrap(),
         arguments: serde_json::json!({"message":"hello"}),
         response_reasoning: Some("provider reasoning".to_string()),
@@ -843,7 +849,7 @@ async fn gateway_falls_back_to_safe_summary_for_invalid_model_observation() {
         provider_model_id: "host-selected-model".to_string(),
         provider_turn_id: "turn_1".to_string(),
         provider_call_id: "call_1".to_string(),
-        provider_tool_name: "demo__echo".to_string(),
+        provider_tool_name: provider_name("demo__echo"),
         capability_id: CapabilityId::new("demo.echo").unwrap(),
         arguments: serde_json::json!({"message":"hello"}),
         response_reasoning: None,
@@ -884,7 +890,7 @@ async fn gateway_replays_resolved_tool_result_content_instead_of_summary() {
         provider_model_id: "host-selected-model".to_string(),
         provider_turn_id: "turn_1".to_string(),
         provider_call_id: "call_1".to_string(),
-        provider_tool_name: "demo__echo".to_string(),
+        provider_tool_name: provider_name("demo__echo"),
         capability_id: CapabilityId::new("demo.echo").unwrap(),
         arguments: serde_json::json!({"message":"hello"}),
         response_reasoning: None,
@@ -1050,7 +1056,7 @@ async fn gateway_reconstructs_multi_tool_provider_turn_from_grouped_result_refer
         provider_model_id: "host-selected-model".to_string(),
         provider_turn_id: "turn_1".to_string(),
         provider_call_id: "call_1".to_string(),
-        provider_tool_name: "demo__echo".to_string(),
+        provider_tool_name: provider_name("demo__echo"),
         capability_id: CapabilityId::new("demo.echo").unwrap(),
         arguments: serde_json::json!({"message":"first"}),
         response_reasoning: Some("provider reasoning".to_string()),
@@ -1062,7 +1068,7 @@ async fn gateway_reconstructs_multi_tool_provider_turn_from_grouped_result_refer
         provider_model_id: "host-selected-model".to_string(),
         provider_turn_id: "turn_1".to_string(),
         provider_call_id: "call_2".to_string(),
-        provider_tool_name: "demo__echo".to_string(),
+        provider_tool_name: provider_name("demo__echo"),
         capability_id: CapabilityId::new("demo.echo").unwrap(),
         arguments: serde_json::json!({"message":"second"}),
         response_reasoning: Some("provider reasoning".to_string()),
@@ -1143,7 +1149,7 @@ async fn gateway_splits_adjacent_provider_tool_results_from_different_turns() {
         provider_model_id: "host-selected-model".to_string(),
         provider_turn_id: "turn_1".to_string(),
         provider_call_id: "call_1".to_string(),
-        provider_tool_name: "demo__echo".to_string(),
+        provider_tool_name: provider_name("demo__echo"),
         capability_id: CapabilityId::new("demo.echo").unwrap(),
         arguments: serde_json::json!({"message":"first"}),
         response_reasoning: Some("first provider reasoning".to_string()),
@@ -1155,7 +1161,7 @@ async fn gateway_splits_adjacent_provider_tool_results_from_different_turns() {
         provider_model_id: "host-selected-model".to_string(),
         provider_turn_id: "turn_2".to_string(),
         provider_call_id: "call_2".to_string(),
-        provider_tool_name: "demo__echo".to_string(),
+        provider_tool_name: provider_name("demo__echo"),
         capability_id: CapabilityId::new("demo.echo").unwrap(),
         arguments: serde_json::json!({"message":"second"}),
         response_reasoning: Some("second provider reasoning".to_string()),
@@ -1260,7 +1266,7 @@ async fn gateway_keeps_same_turn_provider_roundtrip_when_plain_tool_result_is_in
         provider_model_id: "host-selected-model".to_string(),
         provider_turn_id: "turn_1".to_string(),
         provider_call_id: "call_1".to_string(),
-        provider_tool_name: "demo__echo".to_string(),
+        provider_tool_name: provider_name("demo__echo"),
         capability_id: CapabilityId::new("demo.echo").unwrap(),
         arguments: serde_json::json!({"message":"first"}),
         response_reasoning: Some("provider reasoning".to_string()),
@@ -1272,7 +1278,7 @@ async fn gateway_keeps_same_turn_provider_roundtrip_when_plain_tool_result_is_in
         provider_model_id: "host-selected-model".to_string(),
         provider_turn_id: "turn_1".to_string(),
         provider_call_id: "call_2".to_string(),
-        provider_tool_name: "demo__echo".to_string(),
+        provider_tool_name: provider_name("demo__echo"),
         capability_id: CapabilityId::new("demo.echo").unwrap(),
         arguments: serde_json::json!({"message":"second"}),
         response_reasoning: Some("provider reasoning".to_string()),
@@ -1354,7 +1360,7 @@ async fn gateway_degrades_provider_tool_replay_from_different_provider_route_to_
         provider_model_id: "host-selected-model".to_string(),
         provider_turn_id: "turn_1".to_string(),
         provider_call_id: "call_1".to_string(),
-        provider_tool_name: "demo__echo".to_string(),
+        provider_tool_name: provider_name("demo__echo"),
         capability_id: CapabilityId::new("demo.echo").unwrap(),
         arguments: serde_json::json!({"message":"hello"}),
         response_reasoning: None,
@@ -1402,7 +1408,7 @@ async fn gateway_degrades_resolved_provider_mismatch_to_safe_summary() {
         provider_model_id: "host-selected-model".to_string(),
         provider_turn_id: "turn_1".to_string(),
         provider_call_id: "call_1".to_string(),
-        provider_tool_name: "demo__echo".to_string(),
+        provider_tool_name: provider_name("demo__echo"),
         capability_id: CapabilityId::new("demo.echo").unwrap(),
         arguments: serde_json::json!({"message":"hello"}),
         response_reasoning: None,
@@ -2959,7 +2965,7 @@ impl GatewayCapabilityPort {
         Self {
             definitions: vec![ProviderToolDefinition {
                 capability_id: CapabilityId::new("demo.echo").unwrap(),
-                name: "demo__echo".to_string(),
+                name: provider_name("demo__echo"),
                 description: "Echo input".to_string(),
                 parameters: serde_json::json!({
                     "type": "object",

--- a/crates/ironclaw_reborn_composition/src/openai_compat_serve.rs
+++ b/crates/ironclaw_reborn_composition/src/openai_compat_serve.rs
@@ -548,7 +548,7 @@ fn push_tool_output_items(
                 id: format!("fc_{call_id}"),
                 status: Some(OpenAiResponseOutputItemStatus::Completed),
                 call_id: call_id.clone(),
-                name: provider_call.provider_tool_name.clone(),
+                name: provider_call.provider_tool_name.as_str().to_string(),
                 arguments,
             });
             items.push(OpenAiResponseOutputItem::FunctionCallOutput {

--- a/crates/ironclaw_reborn_composition/src/openai_compat_serve/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/openai_compat_serve/tests.rs
@@ -3,7 +3,7 @@ use super::*;
 use std::collections::VecDeque;
 use std::sync::Mutex;
 
-use ironclaw_host_api::{CapabilityId, ThreadId};
+use ironclaw_host_api::{CapabilityId, ProviderToolName, ThreadId};
 use ironclaw_product_adapters::{
     AdapterInstallationId, ExternalConversationRef, ProductAdapterError, ProductAdapterId,
     ProductOutboundTarget, ProjectionCursor,
@@ -447,7 +447,7 @@ fn run_output_provider_call() -> ProviderToolCallReferenceEnvelope {
         provider_model_id: "gpt-test".to_string(),
         provider_turn_id: "turn-1".to_string(),
         provider_call_id: "call_abc".to_string(),
-        provider_tool_name: "web_search".to_string(),
+        provider_tool_name: ProviderToolName::new("web_search").expect("provider tool name"),
         capability_id: CapabilityId::new("web.search").expect("capability id"),
         arguments: serde_json::json!({ "query": "rust" }),
         response_reasoning: None,

--- a/crates/ironclaw_reborn_composition/src/product_live_adapters.rs
+++ b/crates/ironclaw_reborn_composition/src/product_live_adapters.rs
@@ -220,7 +220,7 @@ impl LoopCapabilityInputResolver for ProductLiveCapabilityIo {
         self.display_previews.record_input(
             &run_context.run_id.to_string(),
             &input_ref,
-            &tool_call.name,
+            tool_call.name.as_str(),
             &tool_call.arguments,
         );
         Ok(input_ref)
@@ -873,7 +873,7 @@ pub fn capability_allowlist(ids: impl IntoIterator<Item = CapabilityId>) -> Capa
 mod tests {
     use super::*;
     use ironclaw_host_api::{
-        AgentId, CapabilityDisplayOutputPreview, InvocationId, TenantId, ThreadId,
+        AgentId, CapabilityDisplayOutputPreview, InvocationId, ProviderToolName, TenantId, ThreadId,
     };
     use ironclaw_reborn::planned_driver_factory::default_planned_run_profile_resolver;
     use ironclaw_turns::{
@@ -889,7 +889,7 @@ mod tests {
             provider_model_id: "model".to_string(),
             turn_id: Some("turn_1".to_string()),
             id: "call_1".to_string(),
-            name: "read_file".to_string(),
+            name: ProviderToolName::new("read_file").expect("provider tool name"),
             arguments: serde_json::json!({"path": "src/main.rs", "api_key": "sk-secret"}),
             response_reasoning: None,
             reasoning: None,
@@ -950,7 +950,7 @@ mod tests {
             provider_model_id: "model".to_string(),
             turn_id: Some("turn_1".to_string()),
             id: "call_1".to_string(),
-            name: "nearai__web_search".to_string(),
+            name: ProviderToolName::new("nearai__web_search").expect("provider tool name"),
             arguments: serde_json::json!({"query": "deploy status"}),
             response_reasoning: None,
             reasoning: None,

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev.rs
@@ -524,7 +524,7 @@ impl LoopCapabilityInputResolver for LocalDevCapabilityIo {
         self.display_previews.record_input(
             &run_context.run_id.to_string(),
             &input_ref,
-            &tool_call.name,
+            tool_call.name.as_str(),
             &tool_call.arguments,
         );
         Ok(input_ref)

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/shell_tests.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/shell_tests.rs
@@ -1,6 +1,8 @@
 use std::sync::Arc;
 
-use ironclaw_host_api::{AgentId, CapabilityId, ProjectId, TenantId, ThreadId, UserId};
+use ironclaw_host_api::{
+    AgentId, CapabilityId, ProjectId, ProviderToolName, TenantId, ThreadId, UserId,
+};
 use ironclaw_host_runtime::SHELL_CAPABILITY_ID;
 use ironclaw_loop_support::{
     LoopCapabilityInputResolver, LoopCapabilityPortFactory, LoopCapabilityResultWriter,
@@ -41,7 +43,7 @@ fn provider_tool_call(arguments: serde_json::Value) -> ProviderToolCall {
         provider_model_id: "test-model".to_string(),
         turn_id: Some("provider-turn-1".to_string()),
         id: "call-1".to_string(),
-        name: "builtin_shell".to_string(),
+        name: ProviderToolName::new("builtin_shell").expect("provider tool name"),
         arguments,
         response_reasoning: None,
         reasoning: None,

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/shell_tests.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/shell_tests.rs
@@ -43,7 +43,7 @@ fn provider_tool_call(arguments: serde_json::Value) -> ProviderToolCall {
         provider_model_id: "test-model".to_string(),
         turn_id: Some("provider-turn-1".to_string()),
         id: "call-1".to_string(),
-        name: ProviderToolName::new("builtin_shell").expect("provider tool name"),
+        name: ProviderToolName::new("builtin_shell").expect("provider tool name"), // safety: test-only provider-safe literal.
         arguments,
         response_reasoning: None,
         reasoning: None,

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/synthetic_capability.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/synthetic_capability.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use async_trait::async_trait;
-use ironclaw_host_api::{CapabilityId, RuntimeKind};
+use ironclaw_host_api::{CapabilityId, ProviderToolName, RuntimeKind};
 use ironclaw_loop_support::{LoopCapabilityInputResolver, LoopCapabilityResultWriter};
 use ironclaw_turns::{
     CapabilityActivityId,
@@ -58,7 +58,7 @@ impl LocalDevSyntheticCapability {
 
 pub(super) struct LocalDevSyntheticCapabilityDescriptor {
     capability_id: CapabilityId,
-    provider_tool_name: String,
+    provider_tool_name: ProviderToolName,
     description: String,
     concurrency_hint: ConcurrencyHint,
     parameters_schema: serde_json::Value,
@@ -79,7 +79,12 @@ impl LocalDevSyntheticCapabilityDescriptor {
                     "synthetic capability id is invalid",
                 )
             })?,
-            provider_tool_name: provider_tool_name.to_string(),
+            provider_tool_name: ProviderToolName::new(provider_tool_name).map_err(|_| {
+                AgentLoopHostError::new(
+                    AgentLoopHostErrorKind::Internal,
+                    "synthetic provider tool name is invalid",
+                )
+            })?,
             description: description.to_string(),
             concurrency_hint,
             parameters_schema,
@@ -91,7 +96,7 @@ impl LocalDevSyntheticCapabilityDescriptor {
             capability_id: self.capability_id.clone(),
             provider: None,
             runtime: RuntimeKind::System,
-            safe_name: self.provider_tool_name.clone(),
+            safe_name: self.provider_tool_name.as_str().to_string(),
             safe_description: self.description.clone(),
             concurrency_hint: self.concurrency_hint,
             parameters_schema: self.parameters_schema.clone(),
@@ -134,7 +139,7 @@ struct LocalDevSyntheticCapabilityPort {
     input_resolver: Arc<dyn LoopCapabilityInputResolver>,
     result_writer: Arc<dyn LoopCapabilityResultWriter>,
     capabilities_by_id: HashMap<CapabilityId, LocalDevSyntheticCapability>,
-    capability_ids_by_provider_tool_name: HashMap<String, CapabilityId>,
+    capability_ids_by_provider_tool_name: HashMap<ProviderToolName, CapabilityId>,
     current_surface_version: StdMutex<Option<CapabilitySurfaceVersion>>,
     provider_tool_call_registrations:
         StdMutex<HashMap<String, SyntheticProviderToolCallRegistration>>,
@@ -716,7 +721,7 @@ mod tests {
             provider_model_id: "test-model".to_string(),
             turn_id: Some("provider-turn-1".to_string()),
             id: "provider-call-1".to_string(),
-            name: TEST_PROVIDER_TOOL_NAME.to_string(),
+            name: ProviderToolName::new(TEST_PROVIDER_TOOL_NAME).expect("provider tool name"),
             arguments: serde_json::json!({"message": "hello"}),
             response_reasoning: None,
             reasoning: None,

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/tests.rs
@@ -14,7 +14,7 @@ mod tests {
     use ironclaw_authorization::{CapabilityLeaseStatus, CapabilityLeaseStore};
     use ironclaw_host_api::{
         AgentId, CapabilityId, EffectKind, GrantConstraints, InvocationId, MountPermissions,
-        NetworkPolicy, Principal, ProjectId, TenantId, ThreadId, UserId,
+        NetworkPolicy, Principal, ProjectId, ProviderToolName, TenantId, ThreadId, UserId,
     };
     use ironclaw_host_runtime::{
         APPLY_PATCH_CAPABILITY_ID, GLOB_CAPABILITY_ID, GREP_CAPABILITY_ID, HTTP_CAPABILITY_ID,
@@ -188,16 +188,13 @@ mod tests {
         .expect("visible request")
     }
 
-    fn provider_tool_call_with_name(
-        name: impl Into<String>,
-        arguments: serde_json::Value,
-    ) -> ProviderToolCall {
+    fn provider_tool_call_with_name(name: &str, arguments: serde_json::Value) -> ProviderToolCall {
         ProviderToolCall {
             provider_id: "test-provider".to_string(),
             provider_model_id: "test-model".to_string(),
             turn_id: Some("provider-turn-1".to_string()),
             id: "call-1".to_string(),
-            name: name.into(),
+            name: ProviderToolName::new(name).expect("provider tool name"),
             arguments,
             response_reasoning: None,
             reasoning: None,
@@ -1616,13 +1613,19 @@ mod tests {
         let tool_definitions = port.tool_definitions().expect("tool definitions");
         let tool_definition_names = tool_definitions
             .iter()
-            .map(|definition| definition.name.clone())
+            .map(|definition| definition.name.as_str().to_string())
             .collect::<Vec<_>>();
-        assert!(tool_definition_names.contains(&"builtin__outbound_delivery_targets_list".into()));
-        assert!(tool_definition_names.contains(&"builtin__outbound_delivery_target_set".into()));
+        assert!(
+            tool_definition_names.contains(&"builtin__outbound_delivery_targets_list".to_string())
+        );
+        assert!(
+            tool_definition_names.contains(&"builtin__outbound_delivery_target_set".to_string())
+        );
         let list_tool = tool_definitions
             .iter()
-            .find(|definition| definition.name == "builtin__outbound_delivery_targets_list")
+            .find(|definition| {
+                definition.name.as_str() == "builtin__outbound_delivery_targets_list"
+            })
             .expect("list tool definition should exist");
         assert!(
             list_tool
@@ -1632,7 +1635,7 @@ mod tests {
         );
         let set_tool = tool_definitions
             .iter()
-            .find(|definition| definition.name == "builtin__outbound_delivery_target_set")
+            .find(|definition| definition.name.as_str() == "builtin__outbound_delivery_target_set")
             .expect("set tool definition should exist");
         assert!(
             set_tool
@@ -2153,10 +2156,14 @@ mod tests {
             .tool_definitions()
             .expect("tool definitions")
             .into_iter()
-            .map(|definition| definition.name)
+            .map(|definition| definition.name.as_str().to_string())
             .collect::<Vec<_>>();
-        assert!(!tool_definition_names.contains(&"builtin__outbound_delivery_targets_list".into()));
-        assert!(!tool_definition_names.contains(&"builtin__outbound_delivery_target_set".into()));
+        assert!(
+            !tool_definition_names.contains(&"builtin__outbound_delivery_targets_list".to_string())
+        );
+        assert!(
+            !tool_definition_names.contains(&"builtin__outbound_delivery_target_set".to_string())
+        );
     }
 
     #[tokio::test]
@@ -2939,7 +2946,7 @@ mod tests {
         let candidate = port
             .register_provider_tool_call(RegisterProviderToolCallRequest::new(
                 provider_tool_call_with_name(
-                    tool_definition.name,
+                    tool_definition.name.as_str(),
                     serde_json::json!({"query": "gmail"}),
                 ),
             ))
@@ -3127,11 +3134,11 @@ mod tests {
             .into_iter()
             .find(|definition| definition.capability_id.as_str() == "gmail.list_messages")
             .expect("gmail.list_messages tool definition");
-        assert_eq!(tool_definition.name, "gmail__list_messages");
+        assert_eq!(tool_definition.name.as_str(), "gmail__list_messages");
 
         let candidate = port
             .register_provider_tool_call(RegisterProviderToolCallRequest::new(
-                provider_tool_call_with_name(tool_definition.name, serde_json::json!({})),
+                provider_tool_call_with_name(tool_definition.name.as_str(), serde_json::json!({})),
             ))
             .await
             .expect("gmail provider tool call stages");

--- a/crates/ironclaw_reborn_composition/src/skill_learning.rs
+++ b/crates/ironclaw_reborn_composition/src/skill_learning.rs
@@ -909,7 +909,7 @@ mod learning {
                 && let Some(call) = message.tool_result_provider_call.as_ref()
             {
                 out.push_str("tool_call: ");
-                out.push_str(&call.provider_tool_name);
+                out.push_str(call.capability_id.as_str());
                 out.push('\n');
             }
             out.push_str(role);

--- a/crates/ironclaw_reborn_composition/src/skill_learning.rs
+++ b/crates/ironclaw_reborn_composition/src/skill_learning.rs
@@ -893,8 +893,8 @@ mod learning {
     }
 
     /// Render a context window into a role-labelled transcript for the
-    /// distiller. Tool-result rows are prefixed with the real tool name so the
-    /// distilled skill can name the exact tools that worked.
+    /// distiller. Tool-result rows are prefixed with the capability id so the
+    /// distilled skill can name the exact runtime capabilities that worked.
     fn format_transcript(window: &ContextWindow) -> String {
         let mut out = String::new();
         for message in &window.messages {

--- a/crates/ironclaw_reborn_composition/src/trace_capture.rs
+++ b/crates/ironclaw_reborn_composition/src/trace_capture.rs
@@ -417,7 +417,7 @@ fn tool_call_capture_json(
     let mut entry = serde_json::Map::new();
     entry.insert(
         "name".to_string(),
-        serde_json::Value::String(call.provider_tool_name.clone()),
+        serde_json::Value::String(call.provider_tool_name.as_str().to_string()),
     );
     if let Some(result) = result.filter(|content| !content.trim().is_empty()) {
         entry.insert(
@@ -660,7 +660,8 @@ mod tests {
             provider_model_id: "gpt".to_string(),
             provider_turn_id: "turn-1".to_string(),
             provider_call_id: "call-1".to_string(),
-            provider_tool_name: tool_name.to_string(),
+            provider_tool_name: ironclaw_host_api::ProviderToolName::new(tool_name)
+                .expect("provider tool name"),
             capability_id: CapabilityId::new(format!("builtin.{tool_name}"))
                 .expect("capability id"),
             arguments: serde_json::json!({ "url": "https://example.com" }),

--- a/crates/ironclaw_reborn_composition/tests/webui_v2_e2e.rs
+++ b/crates/ironclaw_reborn_composition/tests/webui_v2_e2e.rs
@@ -32,7 +32,8 @@ use ironclaw_host_api::runtime_policy::{
     NetworkMode, ProcessBackendKind, RuntimeProfile, SecretMode,
 };
 use ironclaw_host_api::{
-    AgentId, CapabilityId, InvocationId, ResourceScope, SecretHandle, TenantId, UserId,
+    AgentId, CapabilityId, InvocationId, ProviderToolName, ResourceScope, SecretHandle, TenantId,
+    UserId,
 };
 use ironclaw_loop_support::{
     HostManagedModelError, HostManagedModelErrorKind, HostManagedModelGateway,
@@ -240,7 +241,7 @@ struct WriteFileGateway {
 
 async fn register_write(
     capabilities: &Arc<dyn LoopCapabilityPort>,
-    tool_name: &str,
+    tool_name: ProviderToolName,
     call_id: &str,
     path: &str,
     content: &str,
@@ -251,7 +252,7 @@ async fn register_write(
             provider_model_id: "e2e-model".to_string(),
             turn_id: Some("e2e-write-turn".to_string()),
             id: call_id.to_string(),
-            name: tool_name.to_string(),
+            name: tool_name,
             arguments: json!({"path": path, "content": content}),
             response_reasoning: None,
             reasoning: None,
@@ -311,7 +312,7 @@ impl HostManagedModelGateway for WriteFileGateway {
         if call_index == 0 {
             let csv = register_write(
                 &capabilities,
-                &write_tool.name,
+                write_tool.name.clone(),
                 "e2e-write-csv",
                 CSV_PATH,
                 CSV_BODY,
@@ -319,7 +320,7 @@ impl HostManagedModelGateway for WriteFileGateway {
             .await?;
             let pdf = register_write(
                 &capabilities,
-                &write_tool.name,
+                write_tool.name,
                 "e2e-write-pdf",
                 PDF_PATH,
                 PDF_BODY,

--- a/crates/ironclaw_threads/src/tool_result_reference.rs
+++ b/crates/ironclaw_threads/src/tool_result_reference.rs
@@ -1,4 +1,4 @@
-use ironclaw_host_api::CapabilityId;
+use ironclaw_host_api::{CapabilityId, ProviderToolName};
 use ironclaw_safety::{
     validate_optional_provider_metadata_text, validate_provider_arguments,
     validate_provider_identity, validate_provider_token, validate_provider_tool_name,
@@ -113,7 +113,7 @@ pub struct ProviderToolCallReferenceEnvelope {
     pub provider_model_id: String,
     pub provider_turn_id: String,
     pub provider_call_id: String,
-    pub provider_tool_name: String,
+    pub provider_tool_name: ProviderToolName,
     pub capability_id: CapabilityId,
     pub arguments: serde_json::Value,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -134,7 +134,8 @@ impl ProviderToolCallReferenceEnvelope {
             .map_err(|error| error.to_string())?;
         validate_provider_token(&self.provider_call_id, "provider call id", 512)
             .map_err(|error| error.to_string())?;
-        validate_provider_tool_name(&self.provider_tool_name).map_err(|error| error.to_string())?;
+        validate_provider_tool_name(self.provider_tool_name.as_str())
+            .map_err(|error| error.to_string())?;
         validate_provider_arguments(&self.arguments).map_err(|error| error.to_string())?;
         validate_optional_provider_text(
             &self.response_reasoning,
@@ -824,7 +825,7 @@ fn is_disallowed_control_character(character: char) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use ironclaw_host_api::CapabilityId;
+    use ironclaw_host_api::{CapabilityId, ProviderToolName};
 
     use super::{
         ProviderToolCallReferenceEnvelope, ToolResultReferenceEnvelope, ToolResultSafeSummary,
@@ -1007,7 +1008,7 @@ mod tests {
             provider_model_id: "model".to_string(),
             provider_turn_id: "turn_1".to_string(),
             provider_call_id: "call_1".to_string(),
-            provider_tool_name: "demo__echo".to_string(),
+            provider_tool_name: ProviderToolName::new("demo__echo").expect("provider tool name"),
             capability_id: CapabilityId::new("demo.echo").expect("capability id"),
             arguments: serde_json::json!({"message":"hello"}),
             response_reasoning: None,

--- a/crates/ironclaw_threads/tests/session_thread_contract.rs
+++ b/crates/ironclaw_threads/tests/session_thread_contract.rs
@@ -1,7 +1,7 @@
 use chrono::Utc;
 use futures::future::join_all;
 use ironclaw_host_api::{
-    AgentId, CapabilityId, InvocationId, ProjectId, TenantId, ThreadId, UserId,
+    AgentId, CapabilityId, InvocationId, ProjectId, ProviderToolName, TenantId, ThreadId, UserId,
 };
 use ironclaw_threads::{
     AcceptInboundMessageRequest, AppendAssistantDraftRequest,
@@ -36,7 +36,7 @@ fn provider_call_reference() -> ProviderToolCallReferenceEnvelope {
         provider_model_id: "test-model".to_string(),
         provider_turn_id: "turn_1".to_string(),
         provider_call_id: "call_1".to_string(),
-        provider_tool_name: "demo__echo".to_string(),
+        provider_tool_name: ProviderToolName::new("demo__echo").expect("provider tool name"),
         capability_id: CapabilityId::new("demo.echo").unwrap(),
         arguments: serde_json::json!({"message":"hello"}),
         response_reasoning: Some("provider response reasoning".to_string()),
@@ -420,7 +420,8 @@ async fn append_tool_result_reference_accepts_multiline_provider_arguments() {
         .unwrap();
     let mut provider_call = provider_call_reference();
     provider_call.capability_id = CapabilityId::new("builtin.skill_install").unwrap();
-    provider_call.provider_tool_name = "builtin__skill_install".to_string();
+    provider_call.provider_tool_name =
+        ProviderToolName::new("builtin__skill_install").expect("provider tool name");
     provider_call.arguments = serde_json::json!({
         "content": "---\nname: pasted-skill\n---\n\nUse multiline Markdown.\n"
     });
@@ -503,7 +504,8 @@ async fn append_tool_result_reference_backfills_provider_metadata_on_idempotent_
             .tool_result_provider_call
             .as_ref()
             .expect("model context preserves backfilled metadata")
-            .provider_tool_name,
+            .provider_tool_name
+            .as_str(),
         "demo__echo"
     );
 }
@@ -1394,7 +1396,8 @@ async fn redaction_removes_tool_result_provider_metadata() {
                 provider_model_id: "test-model".to_string(),
                 provider_turn_id: "turn_1".to_string(),
                 provider_call_id: "call_1".to_string(),
-                provider_tool_name: "demo__echo".to_string(),
+                provider_tool_name: ProviderToolName::new("demo__echo")
+                    .expect("provider tool name"),
                 capability_id: CapabilityId::new("demo.echo").unwrap(),
                 arguments: serde_json::json!({"secret":"raw-provider-argument"}),
                 response_reasoning: Some("provider response reasoning".to_string()),
@@ -1464,7 +1467,8 @@ async fn thread_message_serialization_omits_provider_replay_metadata() {
                 provider_model_id: "test-model".to_string(),
                 provider_turn_id: "turn_1".to_string(),
                 provider_call_id: "call_1".to_string(),
-                provider_tool_name: "demo__echo".to_string(),
+                provider_tool_name: ProviderToolName::new("demo__echo")
+                    .expect("provider tool name"),
                 capability_id: CapabilityId::new("demo.echo").unwrap(),
                 arguments: serde_json::json!({"secret":"raw-provider-argument"}),
                 response_reasoning: Some("provider response reasoning".to_string()),
@@ -1508,7 +1512,8 @@ async fn exact_context_message_lookup_preserves_provider_metadata_while_history_
                 provider_model_id: "test-model".to_string(),
                 provider_turn_id: "turn_1".to_string(),
                 provider_call_id: "call_1".to_string(),
-                provider_tool_name: "demo__echo".to_string(),
+                provider_tool_name: ProviderToolName::new("demo__echo")
+                    .expect("provider tool name"),
                 capability_id: CapabilityId::new("demo.echo").unwrap(),
                 arguments: serde_json::json!({"message":"hello"}),
                 response_reasoning: Some("provider response reasoning".to_string()),
@@ -1544,7 +1549,7 @@ async fn exact_context_message_lookup_preserves_provider_metadata_while_history_
     assert_eq!(provider_call.provider_id, "test-provider");
     assert_eq!(provider_call.provider_model_id, "test-model");
     assert_eq!(provider_call.provider_call_id, "call_1");
-    assert_eq!(provider_call.provider_tool_name, "demo__echo");
+    assert_eq!(provider_call.provider_tool_name.as_str(), "demo__echo");
 }
 
 #[tokio::test]

--- a/crates/ironclaw_turns/src/run_profile/host.rs
+++ b/crates/ironclaw_turns/src/run_profile/host.rs
@@ -6,8 +6,8 @@ use std::{
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use ironclaw_host_api::{
-    ApprovalRequestId, CapabilityId, CorrelationId, ExtensionId, ResourceEstimate,
-    RuntimeCredentialAuthRequirement, RuntimeKind, ThreadId,
+    ApprovalRequestId, CapabilityId, CorrelationId, ExtensionId, ProviderToolName,
+    ResourceEstimate, RuntimeCredentialAuthRequirement, RuntimeKind, ThreadId,
 };
 use serde::{Deserialize, Deserializer, Serialize};
 use thiserror::Error;
@@ -1268,7 +1268,7 @@ pub struct ProviderToolCallReplay {
     /// Provider call id referenced by the matching tool result.
     pub provider_call_id: String,
     /// Provider-facing tool name advertised to the model.
-    pub provider_tool_name: String,
+    pub provider_tool_name: ProviderToolName,
     /// Provider-facing tool arguments captured from the model tool call.
     pub arguments: serde_json::Value,
     /// Provider response-level reasoning attached to the tool-call batch.
@@ -1334,7 +1334,7 @@ pub struct ProviderToolDefinition {
     /// Canonical IronClaw capability id backing this provider tool.
     pub capability_id: CapabilityId,
     /// Provider-safe tool name sent to the model.
-    pub name: String,
+    pub name: ProviderToolName,
     /// Provider-safe tool description sent to the model.
     pub description: String,
     /// JSON object schema for provider tool arguments.
@@ -1354,7 +1354,7 @@ pub struct ProviderToolCall {
     /// Provider call id referenced by the matching tool result.
     pub id: String,
     /// Provider-facing tool name returned by the model.
-    pub name: String,
+    pub name: ProviderToolName,
     /// Provider-facing tool arguments returned by the model.
     pub arguments: serde_json::Value,
     /// Provider response-level reasoning attached to the tool-call batch.
@@ -1380,7 +1380,7 @@ pub struct ProviderToolCallReference {
     /// Provider call id referenced by the matching tool result.
     pub provider_call_id: String,
     /// Provider-facing tool name returned by the model.
-    pub provider_tool_name: String,
+    pub provider_tool_name: ProviderToolName,
     /// Canonical IronClaw capability id backing this provider tool.
     pub capability_id: CapabilityId,
     /// Provider-facing tool arguments returned by the model.
@@ -2336,7 +2336,7 @@ mod tests {
             provider_model_id: "model".to_string(),
             turn_id: Some("turn".to_string()),
             id: "call".to_string(),
-            name: name.to_string(),
+            name: ProviderToolName::new(name).expect("provider tool name"),
             arguments: serde_json::json!({}),
             response_reasoning: None,
             reasoning: None,
@@ -2349,7 +2349,7 @@ mod tests {
         let port = DefinitionPort {
             definitions: vec![ProviderToolDefinition {
                 capability_id: CapabilityId::new("demo.allowed").expect("valid capability id"),
-                name: "demo__allowed".to_string(),
+                name: ProviderToolName::new("demo__allowed").expect("provider tool name"),
                 description: "allowed".to_string(),
                 parameters: serde_json::json!({"type": "object"}),
             }],

--- a/docs/internal/2026-06-26-legacy-vs-reborn-feature-comparison.md
+++ b/docs/internal/2026-06-26-legacy-vs-reborn-feature-comparison.md
@@ -1,0 +1,120 @@
+# Legacy vs Reborn Feature Comparison
+
+**Generated:** 2026-06-26
+**Scope:** Internal planning snapshot for comparing the current legacy IronClaw runtime with the Reborn runtime surface.
+**Primary inputs:** `FEATURE_PARITY.md`, `docs/reborn-binary.md`, `docs/reborn/2026-04-25-current-architecture-map.md`, and `docs/reborn/2026-04-27-product-manager-architecture-guide.md`.
+
+This document is a summary for planning and triage. It does not replace `FEATURE_PARITY.md`, which remains the detailed OpenClaw-to-IronClaw parity tracker. Here, **Legacy** means the current non-Reborn IronClaw product/runtime surface, and **Reborn** means the standalone Reborn architecture, CLI, WebUI beta, host runtime, and loop stack.
+
+## Status Legend
+
+| Status | Meaning |
+| --- | --- |
+| Available | Broadly usable in that runtime surface. |
+| Partial | Implemented slice exists, but important product or production gaps remain. |
+| Missing | Not implemented or intentionally not in scope for that runtime. |
+| Reborn-only | New Reborn architecture or capability without a direct legacy equivalent. |
+| Legacy-only | Existing legacy capability not yet carried into Reborn. |
+
+## Executive Summary
+
+| Area | Legacy | Reborn | Planning read |
+| --- | --- | --- | --- |
+| Product readiness | Available | Partial | Legacy remains the safer default for full-product operation. Reborn is an operator/testing surface with important end-to-end slices. |
+| Architecture direction | Mature monolith-style runtime with extracted crates | Reborn-only host/kernel boundary with userland loops | Reborn is the target architecture for authority, runtime isolation, and product workflow separation. |
+| Web gateway | Available | Partial | Legacy has the broader gateway/control-plane surface. Reborn WebChat v2 is usable behind `webui-v2-beta`, but still beta. |
+| CLI | Available | Partial | Reborn has a standalone CLI with selected commands; it does not replace `ironclaw` yet. |
+| Channels | Available | Partial | Legacy has broader channel parity. Reborn product-live channel/runtime wiring is still selective. |
+| Agent loop | Available | Partial | Legacy handles current product workflows. Reborn has the planned loop framework, capability calls, gates, subagent slices, and stronger run-state boundaries. |
+| Tools/extensions | Available | Partial | Legacy has WASM tools/channels and MCP support. Reborn adds host-mediated capability surfaces, product-auth, MCP runtime slices, and provider-safe tool projection. |
+| Security model | Available | Partial/Reborn-only | Legacy has many hardened paths. Reborn adds a clearer kernel-mediated authority model, but some production wiring remains incomplete. |
+| Automation | Available | Partial | Legacy cron/routines are available. Reborn trigger persistence, first-party trigger capabilities, WebUI controls, and one-shot triggers are in progress. |
+| Memory/workspace | Available | Partial | Legacy memory is broad and user-facing. Reborn memory/storage contracts and scoped filesystem substrates are architecturally stronger, but not all legacy UX is carried over. |
+
+## Feature Comparison
+
+| Feature area | Legacy status | Reborn status | Notes |
+| --- | --- | --- | --- |
+| Default runtime | Available | Missing | `ironclaw-reborn` is explicitly not the default runtime and does not replace `ironclaw` behavior yet. |
+| Standalone binary | Missing | Partial | `ironclaw-reborn` supports `run`, `repl`, `doctor`, `onboard`, `models`, `skills`, `hooks`, `logs`, `extension`, `profile`, and selected `channels` commands. |
+| Configuration and migration | Available | Partial | Reborn has its own home/config path. It intentionally does not yet support v1 config, DB, settings, secrets, or history migration. |
+| WebChat/UI | Available | Partial | Legacy has Web gateway chat and dashboard views. Reborn WebChat v2 is supported through `serve` only with `webui-v2-beta`; it is an early beta operator surface. |
+| Web gateway APIs | Available | Partial | Legacy includes health/status, chat, memory, jobs, logs, extensions, SSE/WebSocket, and OpenAI-compatible APIs. Reborn WebUI exposes browser-facing `/api/webchat/v2` flows and event projections, but production durable/live fanout remains follow-up work. |
+| Channel registry and channels | Available | Partial | Legacy supports CLI/TUI, HTTP webhook, REPL, WebChat, WASM channels, Telegram, Slack, Signal, and partial Discord/Feishu/WeCom/WeChat. Reborn channel registry is still not product-complete; `channels list` currently reports a deliberate empty/configured surface in the standalone CLI docs. |
+| Agent/session model | Available | Partial | Legacy supports per-sender sessions, compaction, custom prompts, skills, plugin tools, subagent framework, and approvals. Reborn has typed turn/run/thread state, loop family/executor architecture, capability calls, gates, and subagent slices, with product-complete replacement still pending. |
+| Capability/tool execution | Available | Partial/Reborn-only | Legacy uses built-in/WASM/MCP tools through the existing registry. Reborn models tools as host-mediated capabilities with provider-safe tool definitions, explicit capability IDs, authorization, approvals, leases, and runtime adapters. |
+| Tool-name model surface | Available | Reborn-only | Reborn separates internal dotted `CapabilityId` values from provider-safe tool names because provider APIs reject dots. The snapshot maps provider names back to canonical capability IDs. |
+| File/coding tools | Available | Partial | Legacy has file/shell tools and approvals. Reborn has first-party scoped read/write/list/glob/grep/apply_patch capabilities through HostRuntime; OpenClaw-compatible `agents.files.*` aliases and full hardening are still pending. |
+| MCP and hosted extensions | Available | Partial | Legacy has MCP clients and registries. Reborn composes host-mediated MCP runtime slices, hosted MCP activation, product-auth credential staging, and bundled Notion/NEAR AI slices, with live-recorded parity still follow-up. |
+| Google/GSuite tools | Available/Partial | Partial | Reborn has operation-level Google Drive/Docs/Sheets/Slides WASM packages with host-mediated HTTP egress and OAuth setup metadata; full parity remains follow-up. |
+| Model providers | Available | Partial | Legacy has broad provider coverage and failover. Reborn standalone CLI supports model provider listing/status and `set-provider`; the WebUI quick start supports NEAR AI, OpenAI, Anthropic, Ollama, and catalog-backed provider selection, but live fetching/OAuth/API-key login flows are not complete across all surfaces. |
+| Model features | Available | Partial | Legacy has failover, cooldowns, model selector, OpenAI-compatible support, and many provider adapters. Reborn is focused on host-managed model requests and tool-capable model gateway behavior; advanced catalog/pricing/thinking/replay parity is incomplete. |
+| Skills | Available | Partial | Legacy has prompt-based skills, grouped directories, CLI commands, and activation criteria. Reborn local-dev uses catalog/list-first model-selected activation before loading full skill context. |
+| Memory/workspace | Available | Partial | Legacy has vector memory, hybrid search, identity files, daily logs, heartbeat docs, flexible paths, and CLI commands. Reborn strengthens scoped filesystem/storage placement and project/tenant/user scoping, but not every legacy memory UX or backend is carried over. |
+| Automation/routines | Available | Partial | Legacy cron, heartbeat, hooks, and routines are available. Reborn scheduled triggers have persistence, backend parity work, atomic fire claim/update APIs, first-party `trigger_*` capabilities, WebUI controls, and first-class one-shot triggers; external delivery and production readiness remain follow-up. |
+| Background/process execution | Available | Partial/Reborn-only | Legacy has orchestrator/worker and jobs. Reborn adds a capability-backed process path through `CapabilityHost::spawn_json`, `ProcessManager`, `ProcessHost`, resource ownership, events, and runtime dispatch, but product completeness is still pending. |
+| Approval/auth gates | Available | Partial/Reborn-only | Legacy has TUI approvals and extension auth paths. Reborn models auth/approval as typed gate/resume paths with exact invocation identity, capability replay metadata, product auth, and WebUI SSO slices. |
+| WebUI SSO | Missing | Partial/Reborn-only | Reborn `serve` includes Google/GitHub browser SSO behind `webui-v2-beta`, with verified-email-domain admission and tenant-bound HMAC sessions. |
+| Security perimeter | Available | Partial/Reborn-only | Legacy has bearer auth, pairing, allowlists, SSRF guards, sandboxing, path traversal protections, prompt-injection defense, and leak detection. Reborn makes the kernel/host runtime the authority boundary for capability dispatch, secrets, network, mounts, resources, redaction, process state, and audit/events; production wiring is still incomplete in several areas. |
+| Sandboxing | Available | Partial/Reborn-only | Legacy has Docker sandbox and WASM sandbox support. Reborn process sandbox MVP adds typed process plans, backend-neutral sandbox backends, hardened Docker command construction, fail-closed network-host validation, timeout/cancel cleanup, and approval/lease spawn paths, with production MITM/product wiring still partial. |
+| Hooks/plugins | Available | Partial | Legacy has lifecycle hooks, declarative hooks, webhook hooks, WASM tools/channels, and extension lifecycle. Reborn supports selected hooks and host-mediated extension/runtime slices, but plugin route registration, provider plugins, registry repair, and many OpenClaw hook families remain missing. |
+| OpenAI-compatible API | Available | Missing/Partial | Legacy exposes OpenAI-compatible chat completions and request-level model override. Reborn currently focuses on WebChat v2 and host-managed model routing, not full legacy gateway API replacement. |
+| Media/TTS/STT | Partial | Missing/Partial | Legacy has some media handling and channel attachment paths, but broad OpenClaw media parity is still missing. Reborn PDF/read-file slices exist, but broad image/audio/video/TTS/STT parity is not product-complete. |
+| Mobile/macOS apps | Mostly out of scope | Missing | Legacy tracks these as out of scope or missing relative to OpenClaw. Reborn does not change that near-term. |
+| Trace Commons | Partial | Partial/Reborn-aligned | IronClaw retains local-first trace capture, queue/status/credit helpers, and client wrappers. Standalone server-side production infra moved out to `tracedao-server`; Reborn uses product facade patterns for local integration. |
+
+## Reborn Strengths
+
+| Strength | Why it matters |
+| --- | --- |
+| Kernel-mediated capability boundary | Side effects go through explicit authorization, approvals, leases, mounts, secrets, network policy, resources, redaction, and audit/event paths. |
+| Product workflow separation | Product behavior sits above the kernel instead of being mixed into low-level runtime dispatch. |
+| Typed run/thread/turn state | Reborn avoids stringly paths for pending auth, approvals, provider tool replay, capability activity, and result writing. |
+| Provider-safe tool projection | Dotted internal capability IDs stay stable while provider-facing names satisfy model API constraints. |
+| Product-auth and hosted runtime direction | OAuth/product credentials are staged by host-owned paths rather than exposed as raw tool inputs. |
+| Multi-runtime capability model | WASM, Script, MCP, first-party/system, and sandboxed process work converge behind common host contracts. |
+| Better future multi-user posture | Reborn docs and slices consistently model tenant/user/project/agent/resource scopes. |
+
+## Legacy Strengths
+
+| Strength | Why it matters |
+| --- | --- |
+| Broader day-to-day product coverage | Legacy remains better for existing user-facing gateway, channel, CLI, memory, model, and routine workflows. |
+| More complete channel surface | Telegram, Slack, Signal, WebChat, HTTP webhook, TUI/REPL, and WASM channels are already available or partially available. |
+| More mature operational commands | Existing `ironclaw` CLI covers run/onboard/config/status/memory/skills/pairing/sandbox/doctor/logs and more. |
+| Existing integration surface | Current tools, extensions, hooks, secrets, DB settings, and workspace memory have live usage paths. |
+| Lower migration risk today | Existing configs, settings, secrets, and data stores are wired for the current runtime. |
+
+## Notable Gaps Before Reborn Can Replace Legacy
+
+| Gap | Impact |
+| --- | --- |
+| v1 migration | Reborn does not yet migrate legacy config, DB, settings, secrets, or history. |
+| Production runtime services | Reborn `serve` is beta and not yet a production gateway replacement. |
+| Channel product parity | Reborn channel registry/product adapters are not complete enough to cover legacy channel behavior. |
+| Gateway API parity | OpenAI-compatible API, broader control-plane endpoints, diagnostics, and durable fanout need explicit replacement decisions. |
+| Extension/plugin parity | Provider plugins, auth plugins, memory/context plugins, route registration, registry management, and many hook families are missing. |
+| Model/provider feature parity | Catalog, OAuth/login flows, pricing, advanced thinking controls, replay normalization, and media generation support are incomplete. |
+| Memory UX parity | Reborn has stronger storage contracts, but not all legacy memory/search/identity UX is product-complete. |
+| Automation production readiness | Trigger loop follow-ups remain around external result delivery, readiness policy, active-run retention, and jitter. |
+| Docs and operator guidance | Reborn needs a migration guide, replacement readiness checklist, and explicit compatibility policy before defaulting users to it. |
+
+## Suggested Tracking Categories
+
+Use these categories when turning this comparison into work items:
+
+| Category | Suggested owner boundary |
+| --- | --- |
+| Replacement blockers | Runtime composition, config migration, gateway/API parity, channel parity. |
+| Product-visible deltas | WebUI behavior, CLI commands, logs/status, memory UX, automation UX. |
+| Security deltas | Auth, approvals, secrets, outbound network policy, sandboxing, audit/events. |
+| Extension deltas | WASM, MCP, product-auth, hosted extensions, plugin registry, hook families. |
+| Model deltas | Provider catalog, credential setup, tool-call replay, thinking controls, image/audio/video. |
+| Operational deltas | Doctor checks, logs, diagnostics export, service install, readiness, rollback. |
+
+## Source Notes
+
+- `FEATURE_PARITY.md` is OpenClaw vs IronClaw, not Legacy vs Reborn. This document reuses its legacy feature coverage and Reborn-specific notes where present.
+- `docs/reborn-binary.md` is the best current operator guide for the standalone Reborn binary and WebUI beta.
+- `docs/reborn/2026-04-25-current-architecture-map.md` describes implemented Reborn slices and explicit gaps; it cautions that most rows are slice-level, not product-complete claims.
+- `docs/reborn/2026-04-27-product-manager-architecture-guide.md` is PM-facing architecture guidance and should be used to place new product features in the correct Reborn layer.

--- a/tests/support/reborn/harness.rs
+++ b/tests/support/reborn/harness.rs
@@ -42,8 +42,8 @@ use ironclaw_host_api::{
     CapabilityId, CapabilitySet, CredentialStageError, Decision, EffectKind, ExecutionContext,
     ExtensionId, GrantConstraints, HostPath, InvocationId, MountAlias, MountGrant,
     MountPermissions, MountView, NetworkPolicy, NetworkScheme, NetworkTargetPattern, Obligation,
-    Obligations, PackageId, Principal, ProjectId, ResourceEstimate, ResourceScope,
-    RuntimeCredentialAccountProviderId, RuntimeHttpEgress, RuntimeHttpEgressError,
+    Obligations, PackageId, Principal, ProjectId, ProviderToolName, ResourceEstimate,
+    ResourceScope, RuntimeCredentialAccountProviderId, RuntimeHttpEgress, RuntimeHttpEgressError,
     RuntimeHttpEgressRequest, RuntimeHttpEgressResponse, RuntimeKind, SecretHandle, TenantId,
     ThreadId, TrustClass, UserId, VirtualPath,
 };
@@ -3388,7 +3388,7 @@ impl LoopCapabilityPort for RecordingTestCapabilityPort {
     fn tool_definitions(&self) -> Result<Vec<ProviderToolDefinition>, AgentLoopHostError> {
         let definitions = vec![ProviderToolDefinition {
             capability_id: self.primary_capability_id(),
-            name: self.primary_tool_name().to_string(),
+            name: ProviderToolName::new(self.primary_tool_name()).expect("provider tool name"),
             description: "Echo a test payload".to_string(),
             parameters: json!({
                 "type": "object",
@@ -3720,7 +3720,7 @@ pub fn trace_tool_call_response() -> ironclaw_loop_support::HostManagedModelResp
                 provider_model_id: "trace_replay".to_string(),
                 provider_turn_id: "trace-turn".to_string(),
                 provider_call_id: "call-1".to_string(),
-                provider_tool_name: "test_echo".to_string(),
+                provider_tool_name: ProviderToolName::new("test_echo").expect("provider tool name"),
                 arguments: json!({"message": "hi"}),
                 response_reasoning: None,
                 reasoning: None,

--- a/tests/support/reborn/model_replay.rs
+++ b/tests/support/reborn/model_replay.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use async_trait::async_trait;
-use ironclaw_host_api::CapabilityId;
+use ironclaw_host_api::{CapabilityId, ProviderToolName};
 use ironclaw_loop_support::{
     HostManagedModelError, HostManagedModelErrorKind, HostManagedModelGateway,
     HostManagedModelMessageRole, HostManagedModelRequest, HostManagedModelResponse,
@@ -31,6 +31,8 @@ pub enum RebornTraceReplayError {
     InvalidSurfaceVersion(String),
     #[error("invalid trace capability id for {name}: {reason}")]
     InvalidCapabilityId { name: String, reason: String },
+    #[error("invalid trace provider tool name for {name}: {reason}")]
+    InvalidProviderToolName { name: String, reason: String },
     #[error("invalid trace capability input ref for {id}: {reason}")]
     InvalidInputRef { id: String, reason: String },
 }
@@ -586,6 +588,7 @@ pub(crate) fn capability_call_from_trace_with_surface(
             reason: error.to_string(),
         }
     })?;
+    let provider_tool_name = trace_provider_tool_name(&call.name)?;
     let input_ref =
         CapabilityInputRef::new(format!("input:trace-{}", call.id)).map_err(|reason| {
             RebornTraceReplayError::InvalidInputRef {
@@ -604,12 +607,22 @@ pub(crate) fn capability_call_from_trace_with_surface(
             provider_model_id: "trace_replay".to_string(),
             provider_turn_id: "trace-turn".to_string(),
             provider_call_id: call.id,
-            provider_tool_name: call.name,
+            provider_tool_name,
             arguments: call.arguments,
             response_reasoning: None,
             reasoning: None,
             signature: None,
         }),
+    })
+}
+
+fn trace_provider_tool_name(name: &str) -> Result<ProviderToolName, RebornTraceReplayError> {
+    let provider_name = name.replace('.', "__");
+    ProviderToolName::new(provider_name).map_err(|error| {
+        RebornTraceReplayError::InvalidProviderToolName {
+            name: name.to_string(),
+            reason: error.to_string(),
+        }
     })
 }
 
@@ -626,7 +639,7 @@ fn validate_expected_tool_results(
                     .as_ref()
                     .is_some_and(|provider_call| {
                         provider_call.provider_call_id == expected_result.tool_call_id
-                            && provider_call.provider_tool_name == expected_result.name
+                            && provider_call.provider_tool_name.as_str() == expected_result.name
                     })
         });
         if !matched {

--- a/tests/support_unit_tests.rs
+++ b/tests/support_unit_tests.rs
@@ -866,7 +866,7 @@ mod reborn_support_tests {
         };
         let replay = calls[0].provider_replay.as_ref().expect("provider replay");
         assert_eq!(replay.provider_call_id, "provider-call-9");
-        assert_eq!(replay.provider_tool_name, "test.search");
+        assert_eq!(replay.provider_tool_name.as_str(), "test__search");
         assert_eq!(replay.arguments, serde_json::json!({"q": "near"}));
     }
 
@@ -2148,7 +2148,8 @@ mod reborn_support_tests {
                 provider_model_id: "trace_replay".to_string(),
                 provider_turn_id: "trace-turn".to_string(),
                 provider_call_id: provider_call_id.to_string(),
-                provider_tool_name: provider_tool_name.to_string(),
+                provider_tool_name: ironclaw_host_api::ProviderToolName::new(provider_tool_name)
+                    .expect("provider tool name"),
                 capability_id: CapabilityId::new(capability_id).expect("capability id"),
                 arguments: serde_json::json!({}),
                 response_reasoning: None,

--- a/tests/support_unit_tests.rs
+++ b/tests/support_unit_tests.rs
@@ -623,7 +623,7 @@ mod reborn_support_tests {
             },
             expected_tool_results: vec![ExpectedToolResult {
                 tool_call_id: "call-1".to_string(),
-                name: "test.echo".to_string(),
+                name: "test__echo".to_string(),
                 content: "tool output".to_string(),
             }],
         };
@@ -656,6 +656,7 @@ mod reborn_support_tests {
             substring
                 .stream_model(model_request(vec![tool_result_message(
                     "call-1",
+                    "test__echo",
                     "test.echo",
                     "tool output with suffix",
                 )]))
@@ -674,6 +675,7 @@ mod reborn_support_tests {
         matched
             .stream_model(model_request(vec![tool_result_message(
                 "call-1",
+                "test__echo",
                 "test.echo",
                 "tool output",
             )]))
@@ -689,7 +691,7 @@ mod reborn_support_tests {
                 response: HostManagedModelResponse::assistant_reply("after tool"),
                 expected_tool_results: vec![ExpectedToolResult {
                     tool_call_id: "call-scripted".to_string(),
-                    name: "builtin.write_file".to_string(),
+                    name: "builtin__write_file".to_string(),
                     content: "result:ref-123".to_string(),
                 }],
             }]);
@@ -707,6 +709,7 @@ mod reborn_support_tests {
         gateway
             .stream_model(model_request(vec![tool_result_message(
                 "call-scripted",
+                "builtin__write_file",
                 "builtin.write_file",
                 "result:ref-123",
             )]))
@@ -2123,12 +2126,13 @@ mod reborn_support_tests {
     fn tool_result_message(
         provider_call_id: &str,
         provider_tool_name: &str,
+        capability_id: &str,
         content: &str,
     ) -> HostManagedModelMessage {
         tool_result_message_with_capability_id(
             provider_call_id,
             provider_tool_name,
-            provider_tool_name,
+            capability_id,
             content,
         )
     }


### PR DESCRIPTION
## Summary

- Add a strict `ProviderToolName` type for model-provider tool/function names while keeping `CapabilityId` as the canonical host/product identity.
- Convert between capability IDs, provider tool names, and raw LLM strings only at explicit model-provider/replay boundaries.
- Add an architecture boundary test that prevents `ProviderToolName` / `provider_tool_name` from drifting into product, frontend, workflow, or ordinary routing code.
- Update Reborn/tool replay fixtures and add the dated internal legacy-vs-Reborn feature comparison document.

## Change Type

- Runtime/API typing hardening
- Test and architecture guardrail updates
- Internal documentation

## Linked Issue

- None

## Why

Provider-facing tool names cannot contain dots, while internal capability IDs are dotted. The previous stringly typed flow made it too easy for lossy provider names like `foo__bar` to leak into places that should use canonical `foo.bar` capability IDs.

## Security Impact

- Narrows a trust boundary by making provider-facing tool names explicit and validated.
- Preserves host-facing safe summaries while logging invalid provider tool-name causes for debugging.
- Does not change auth, approvals, sandboxing, network policy, secret storage, or listener behavior.

## Trust-Boundary Checklist

- Provider names are parsed into `ProviderToolName` at LLM/replay ingress.
- Provider names are serialized back to raw strings only when emitting provider/OpenAI-compatible protocol payloads.
- Host/product code continues to use `CapabilityId` for canonical identity.
- Architecture test guards against provider-name drift above the model protocol boundary.

## Blast Radius

- Reborn LLM gateway, loop-support capability surface lookup/registration, replay/test fixtures, and typed host protocol structs.
- No DB schema, config precedence, setup, auth, listener, or secret-handling changes.

## Rollback Plan

Revert this PR to return provider tool names to raw strings. Existing capability IDs and provider-safe generated names are deterministic, so rollback should not require data migration.

## Review Follow-Through

- Addressed CodeRabbit comments on stale skill-learning transcript comments, invalid support-test provider names, validation-cause logging, and broader test-only skip handling in the architecture guard.
- Fixed CI failures from no-panics, clippy, Reborn root support tests, and `webui_v2_e2e` typed provider-name compilation.

## Review Track

- Reborn/runtime correctness
- Tool/capability identity boundary
- Test infrastructure and architecture guardrails

## Validation

- `cargo fmt`
- `python3 scripts/check_no_panics.py --base origin/main --head HEAD`
- `cargo test --test support_unit_tests reborn_support_tests::scripted_response_step_validates_expected_tool_results`
- `cargo test --test support_unit_tests reborn_support_tests::trace_replay_requires_expected_tool_result_before_next_response`
- `cargo test -p ironclaw_architecture provider_tool_names_stay_at_model_protocol_boundaries`
- `cargo test -p ironclaw_reborn_composition --features webui-v2-beta,test-support --test webui_v2_e2e --no-run`
- `cargo test -p ironclaw_reborn_composition --all-features --no-run`
- `cargo clippy -p ironclaw_loop_support --all-features --all-targets -- -D warnings`
- `cargo clippy -p ironclaw_loop_support -p ironclaw_reborn -p ironclaw_reborn_composition -p ironclaw_architecture --all-features --all-targets -- -D warnings`
- `git diff --check`