### PR TITLE
fix(ironclaw_host_runtime): surface descriptive builtin.json errors

### DIFF
--- a/crates/ironclaw_host_runtime/src/first_party_tools/json.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/json.rs
@@ -1,12 +1,27 @@
 use ironclaw_extensions::{CapabilityManifest, ExtensionError};
-use ironclaw_host_api::{EffectKind, PermissionMode};
+use ironclaw_host_api::{EffectKind, PermissionMode, RuntimeDispatchErrorKind};
 use serde_json::{Value, json};
 
 use crate::FirstPartyCapabilityError;
 
-use super::{first_party_capability_manifest, input_error, operation_error, resource_profile};
+use super::{first_party_capability_manifest, resource_profile};
 
 pub const JSON_CAPABILITY_ID: &str = "builtin.json";
+
+/// Build an input-error carrying a descriptive, model-visible summary.
+///
+/// Without a `safe_summary`, a failed `builtin.json` call surfaces an empty
+/// observation to the model, which then re-reads or asks the user instead of
+/// correcting its input. The summaries are plain prose (no path/payload
+/// delimiters) so they survive `LoopSafeSummary` validation. See
+/// `.claude/rules/tool-evidence.md` ("Empty-Fast Outputs Are Errors").
+fn invalid(summary: &str) -> FirstPartyCapabilityError {
+    FirstPartyCapabilityError::with_safe_summary(RuntimeDispatchErrorKind::InputEncode, summary)
+}
+
+fn operation_failed(summary: &str) -> FirstPartyCapabilityError {
+    FirstPartyCapabilityError::with_safe_summary(RuntimeDispatchErrorKind::OperationFailed, summary)
+}
 
 pub(super) fn manifest() -> Result<CapabilityManifest, ExtensionError> {
     first_party_capability_manifest(
@@ -20,37 +35,50 @@ pub(super) fn manifest() -> Result<CapabilityManifest, ExtensionError> {
 
 pub(super) fn dispatch(input: &Value) -> Result<Value, FirstPartyCapabilityError> {
     if input.get("source_tool_call_id").is_some() {
-        return Err(input_error());
+        return Err(invalid("json does not accept a source_tool_call_id field"));
     }
     let operation = input
         .get("operation")
         .and_then(Value::as_str)
-        .ok_or_else(input_error)?;
+        .ok_or_else(|| {
+            invalid("json operation must be one of parse, query, stringify, or validate")
+        })?;
     match operation {
         "parse" => {
-            let data = input.get("data").ok_or_else(input_error)?;
-            let text = data.as_str().ok_or_else(input_error)?;
-            serde_json::from_str::<Value>(text).map_err(|_| input_error())
+            let data = input
+                .get("data")
+                .ok_or_else(|| invalid("json parse requires a data field"))?;
+            let text = data
+                .as_str()
+                .ok_or_else(|| invalid("json parse expects data to be a JSON-encoded string"))?;
+            serde_json::from_str::<Value>(text)
+                .map_err(|_| invalid("json parse failed: data is not valid JSON"))
         }
         "stringify" => {
-            let data = input.get("data").ok_or_else(input_error)?;
+            let data = input
+                .get("data")
+                .ok_or_else(|| invalid("json stringify requires a data field"))?;
             let value = if let Some(text) = data.as_str() {
-                serde_json::from_str::<Value>(text).map_err(|_| input_error())?
+                serde_json::from_str::<Value>(text)
+                    .map_err(|_| invalid("json stringify failed: data string is not valid JSON"))?
             } else {
                 data.clone()
             };
             serde_json::to_string_pretty(&value)
                 .map(Value::String)
-                .map_err(|_| operation_error())
+                .map_err(|_| operation_failed("json stringify could not serialize the value"))
         }
         "query" => {
-            let data = input.get("data").ok_or_else(input_error)?;
+            let data = input
+                .get("data")
+                .ok_or_else(|| invalid("json query requires a data field"))?;
             let path = input
                 .get("path")
                 .and_then(Value::as_str)
-                .ok_or_else(input_error)?;
+                .ok_or_else(|| invalid("json query requires a string path field"))?;
             let value = if let Some(text) = data.as_str() {
-                serde_json::from_str::<Value>(text).map_err(|_| input_error())?
+                serde_json::from_str::<Value>(text)
+                    .map_err(|_| invalid("json query failed: data string is not valid JSON"))?
             } else {
                 data.clone()
             };
@@ -64,7 +92,9 @@ pub(super) fn dispatch(input: &Value) -> Result<Value, FirstPartyCapabilityError
                 .unwrap_or(false);
             Ok(json!({ "valid": valid }))
         }
-        _ => Err(input_error()),
+        _ => Err(invalid(
+            "json operation must be one of parse, query, stringify, or validate",
+        )),
     }
 }
 
@@ -76,14 +106,55 @@ fn query_json<'a>(value: &'a Value, path: &str) -> Result<&'a Value, FirstPartyC
         }
         if let Some((field, rest)) = segment.split_once('[') {
             if !field.is_empty() {
-                current = current.get(field).ok_or_else(input_error)?;
+                current = current
+                    .get(field)
+                    .ok_or_else(|| invalid("json query path not found in the provided data"))?;
             }
-            let index_text = rest.strip_suffix(']').ok_or_else(input_error)?;
-            let index = index_text.parse::<usize>().map_err(|_| input_error())?;
-            current = current.get(index).ok_or_else(input_error)?;
+            let index_text = rest
+                .strip_suffix(']')
+                .ok_or_else(|| invalid("json query path has an unterminated array index"))?;
+            let index = index_text
+                .parse::<usize>()
+                .map_err(|_| invalid("json query path contains an invalid array index"))?;
+            current = current
+                .get(index)
+                .ok_or_else(|| invalid("json query array index is out of range"))?;
         } else {
-            current = current.get(segment).ok_or_else(input_error)?;
+            current = current
+                .get(segment)
+                .ok_or_else(|| invalid("json query path not found in the provided data"))?;
         }
     }
     Ok(current)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn summary(error: &FirstPartyCapabilityError) -> &str {
+        error
+            .safe_summary()
+            .expect("failed json dispatch must carry a model-visible summary")
+    }
+
+    #[test]
+    fn parse_of_non_json_data_returns_descriptive_error() {
+        // A path-like string (the reg-002 shape) is not valid JSON: the model
+        // must see why rather than an empty observation.
+        let error =
+            dispatch(&json!({ "operation": "parse", "data": "/workspace/report.csv" })).unwrap_err();
+        assert_eq!(summary(&error), "json parse failed: data is not valid JSON");
+    }
+
+    #[test]
+    fn query_missing_path_returns_descriptive_error() {
+        let error = dispatch(&json!({
+            "operation": "query",
+            "data": "{\"a\":1}",
+            "path": "b"
+        }))
+        .unwrap_err();
+        assert_eq!(summary(&error), "json query path not found in the provided data");
+    }
 }


### PR DESCRIPTION
## Root cause

A failed `builtin.json` call (the live reborn first-party tool at `crates/ironclaw_host_runtime/src/first_party_tools/json.rs`) constructed bare `FirstPartyCapabilityError::new(InputEncode | OperationFailed)` with **no `safe_summary`**. The model-visible failure message (`production.rs::dispatch_failure_message`) uses the dispatch `safe_summary` when present and otherwise falls back to a generic kind string — so a `builtin.json` failure reached the model as an effectively empty/opaque observation. In particular, `operation: "parse"` on data that isn't valid JSON (e.g. a file path handed in instead of JSON text) silently produced nothing explaining the cause, so the model re-read, re-listed, or asked the user. This is the unenforced invariant in `.claude/rules/tool-evidence.md` ("Empty-Fast Outputs Are Errors").

## Change

Attach a descriptive, model-visible `safe_summary` to **every** `builtin.json` failure path via `FirstPartyCapabilityError::with_safe_summary` (e.g. `"json parse failed: data is not valid JSON"`, `"json query path not found in the provided data"`). Summaries are plain prose with no path/payload delimiters so they pass `LoopSafeSummary` validation, and the error *kind* is unchanged (`InputEncode` / `OperationFailed`) — only the message the model sees improves. The summary then flows unchanged through `DispatchError::FirstParty` → `CapabilityInvocationError::Dispatch` → `sanitized_failure_message` to the loop observation. Adds two focused unit tests.

I scoped this to `builtin.json` only: `read_file` / `list_dir` already attach descriptive `safe_summary` strings via the coding-capability error path (`coding_error` in `mod.rs` + `safe_summary_path` in `ironclaw_first_party_extensions::coding::file`), so they were not opaque and needed no change. The candidate's original file list (`src/tools/...`) pointed at the legacy non-reborn tree; this lands on the live reborn path instead.

## Blast radius (targeted failing benchmark tasks)

- `reg-002-sox-controls` (builtin.json given a file path instead of JSON)
- `comm-009-meeting-notes`
- `doc-009-markdown-table-formatter`
- `mem-009-sequential-state-tracking`
- `mm-006-schema-migration`

## Why it's minimal / safe

Single file, single concern. No control-flow or error-kind changes — only adds descriptive summaries to existing error returns, so success paths and resource accounting are untouched. Summaries are delimiter-free prose validated against `LoopSafeSummary` (no paths/secrets leaked).

Validation: the bench-hillclimb agent will run these tasks against this branch; a maintainer reviews before merge.