### PR TITLE
fix(ironclaw_first_party_extensions): read_file limit=0 reads whole file

### DIFF
--- a/crates/ironclaw_first_party_extensions/src/coding/file.rs
+++ b/crates/ironclaw_first_party_extensions/src/coding/file.rs
@@ -38,7 +38,10 @@ pub(super) async fn read_file(
 ) -> Result<Value, CodingCapabilityError> {
     let resolved = resolve_required_path(request, "path", FilesystemOperation::ReadFile)?;
     let offset = optional_usize(request.input, "offset")?.unwrap_or(0);
-    let limit = optional_usize(request.input, "limit")?;
+    // `limit: 0` is a natural way to ask for "the whole file"; treat it as no
+    // explicit limit rather than selecting zero lines, which would otherwise
+    // return an empty body with a misleading lines-limit notice.
+    let limit = optional_usize(request.input, "limit")?.filter(|&n| n > 0);
     let has_explicit_range = offset > 0 || limit.is_some();
     let stat = request
         .filesystem
@@ -250,9 +253,9 @@ fn read_file_text_output(
     let lines_shown = rendered.len();
     let last_line_shown = start_line + lines_shown;
     // A continuation notice only makes sense once at least one line was rendered.
-    // An explicit `limit: 0` selects no lines, so there is nothing to continue
-    // from and "[Showing lines 1-0 ...]" would be a nonsensical inverted range.
-    // Suppressing the notice here keeps the zero-value path byte-for-byte v1.
+    // An empty selection (an `offset` past EOF, or an empty file) has nothing to
+    // continue from, and "[Showing lines 1-0 ...]" would be a nonsensical
+    // inverted range, so suppress the notice in that case.
     let has_more = lines_shown > 0 && last_line_shown < total_lines;
     let next_offset = has_more.then_some(last_line_shown + 1);
     let truncated_by = if truncated_by_bytes {

--- a/crates/ironclaw_first_party_extensions/src/coding/mod.rs
+++ b/crates/ironclaw_first_party_extensions/src/coding/mod.rs
@@ -360,6 +360,59 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn read_file_limit_zero_returns_whole_file() {
+        let temp_root = tempfile::TempDir::new().expect("temp root");
+        let mut local_filesystem = LocalFilesystem::new();
+        local_filesystem
+            .mount_local(
+                VirtualPath::new("/projects").expect("virtual path"),
+                HostPath::from_path_buf(temp_root.path().to_path_buf()),
+            )
+            .expect("projects mount");
+        let filesystem: Arc<dyn RootFilesystem> = Arc::new(local_filesystem);
+        let mounts = workspace_mounts();
+        let scope = ResourceScope::local_default(
+            UserId::new("limit-zero-user").expect("user id"),
+            InvocationId::new(),
+        )
+        .expect("resource scope");
+        let state = super::CodingCapabilityState::default();
+
+        let write_input = json!({
+            "path": "workspace/demo/lines.txt",
+            "content": "alpha\nbeta\ngamma"
+        });
+        let write_request = super::CodingCapabilityRequest::new(
+            super::CodingCapabilityKind::WriteFile,
+            &scope,
+            Some(&mounts),
+            Arc::clone(&filesystem),
+            &write_input,
+        );
+        state.dispatch(&write_request).await.expect("write file");
+
+        // `limit: 0` must read the whole file, not select zero lines. Regression
+        // for the empty-body / misleading lines-limit notice bug.
+        let read_input = json!({ "path": "workspace/demo/lines.txt", "limit": 0 });
+        let read_request = super::CodingCapabilityRequest::new(
+            super::CodingCapabilityKind::ReadFile,
+            &scope,
+            Some(&mounts),
+            Arc::clone(&filesystem),
+            &read_input,
+        );
+        let read_output = state.dispatch(&read_request).await.expect("read file");
+
+        assert_eq!(read_output.output["total_lines"].as_u64(), Some(3));
+        assert_eq!(read_output.output["lines_shown"].as_u64(), Some(3));
+        assert_eq!(read_output.output["truncated"].as_bool(), Some(false));
+        assert_eq!(
+            read_output.output["content"].as_str(),
+            Some("     1│ alpha\n     2│ beta\n     3│ gamma")
+        );
+    }
+
     fn workspace_mounts() -> MountView {
         MountView::new(vec![MountGrant::new(
             MountAlias::new("/workspace").expect("mount alias"),


### PR DESCRIPTION
## Root cause

In the reborn coding `read_file` capability (`crates/ironclaw_first_party_extensions/src/coding/file.rs`), the parsed `limit` was passed through unmodified, so `limit: 0` produced `line_end == start_line` in `read_file_text_output` and selected **zero lines**. The tool then succeeded but returned an empty body with a misleading lines-limit notice. `limit: 0` is a natural way for a model to express "read the whole file", and the tool punished it.

## Fix

Normalize the parsed limit with `.filter(|&n| n > 0)` at the parse site, so `limit: 0` is treated as "no explicit limit" — it falls through to the default-2000 / full-file branch and also no longer flips `has_explicit_range`. This keeps `limit: N (N>0)` and `offset` behavior byte-for-byte unchanged. The stale comment that documented the old "zero lines" path is updated to describe the remaining empty-selection case (offset past EOF / empty file).

## Failing benchmark tasks (blast radius)

- `doc-009-markdown-table-formatter`
- `sci-003-matrix-decomposition`

## Why this is minimal/safe

One-line behavioral change plus a comment update, scoped to the single live reborn read path. A regression test (`read_file_limit_zero_returns_whole_file`) drives the full `CodingCapabilityState::dispatch` caller (per the "test through the caller" rule) and asserts `limit: 0` now returns the full file with `truncated: false`. The legacy `src/tools/builtin/file.rs` tree (not executed by reborn) is deliberately left untouched.

`cargo check -p ironclaw_first_party_extensions --tests` passes.

Validation: the bench-hillclimb agent will run these tasks against this branch; a maintainer reviews before merge.
