### PR TITLE
fix(webui-v2): anchor run failure messages

### DIFF
--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/hooks/useHistory.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/hooks/useHistory.js
@@ -252,7 +252,63 @@ function mergeFullRefresh(fresh, current, options = {}) {
     if (isSeededOptimisticMessage(message)) return true;
     return preserveClientOnly && message.id.startsWith("err-");
   });
-  return preserved.length > 0 ? [...hydratedFresh, ...preserved] : hydratedFresh;
+  return mergePreservedMessages(hydratedFresh, preserved);
+}
+
+function mergePreservedMessages(fresh, preserved) {
+  if (preserved.length === 0) return fresh;
+
+  const lastFreshIndexByRun = new Map();
+  for (let index = 0; index < fresh.length; index += 1) {
+    const runId = anchoredRunId(fresh[index]);
+    if (runId) lastFreshIndexByRun.set(runId, index);
+  }
+
+  const anchoredByRun = new Map();
+  const appendOnly = [];
+  for (const message of preserved) {
+    const runId = shouldAnchorPreservedMessage(message)
+      ? anchoredRunId(message)
+      : null;
+    if (runId && lastFreshIndexByRun.has(runId)) {
+      const anchored = anchoredByRun.get(runId) || [];
+      anchored.push(message);
+      anchoredByRun.set(runId, anchored);
+    } else {
+      appendOnly.push(message);
+    }
+  }
+
+  if (anchoredByRun.size === 0) return [...fresh, ...appendOnly];
+
+  const merged = [];
+  for (let index = 0; index < fresh.length; index += 1) {
+    const message = fresh[index];
+    merged.push(message);
+    const runId = anchoredRunId(message);
+    if (runId && lastFreshIndexByRun.get(runId) === index) {
+      merged.push(...(anchoredByRun.get(runId) || []));
+    }
+  }
+  return appendOnly.length > 0 ? [...merged, ...appendOnly] : merged;
+}
+
+function shouldAnchorPreservedMessage(message) {
+  return isRuntimeActivityMessage(message) || isRunFailureMessage(message);
+}
+
+function isRunFailureMessage(message) {
+  return (
+    message?.role === "error" &&
+    typeof message.id === "string" &&
+    message.id.startsWith("err-")
+  );
+}
+
+function anchoredRunId(message) {
+  return typeof message?.turnRunId === "string" && message.turnRunId
+    ? message.turnRunId
+    : null;
 }
 
 function isSeededOptimisticMessage(message) {

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/useChatEvents.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/useChatEvents.js
@@ -666,6 +666,7 @@ function appendRunFailureMessage(
   // (SSE reconnect with `last-event-id`, or repeated updates carrying
   // the same terminal status) collapse to one bubble instead of stacking.
   const messageId = `err-${runId || "unknown"}`;
+  const turnRunId = typeof runId === "string" && runId ? runId : null;
   setMessages((prev) => {
     const existing = prev.findIndex((m) => m.id === messageId);
     const content = failureMessageForRunStatus({
@@ -674,11 +675,18 @@ function appendRunFailureMessage(
       failureSummary,
     });
     if (existing >= 0) {
-      if (!failureSummary || prev[existing].content === content) return prev;
+      const contentChanged = Boolean(
+        failureSummary && prev[existing].content !== content,
+      );
+      const runAnchorChanged = Boolean(
+        turnRunId && prev[existing].turnRunId !== turnRunId,
+      );
+      if (!contentChanged && !runAnchorChanged) return prev;
       const next = [...prev];
       next[existing] = {
         ...next[existing],
-        content,
+        ...(contentChanged && { content }),
+        ...(runAnchorChanged && { turnRunId }),
       };
       return next;
     }
@@ -689,6 +697,7 @@ function appendRunFailureMessage(
         role: "error",
         content,
         timestamp: new Date().toISOString(),
+        ...(turnRunId && { turnRunId }),
       },
     ];
   });

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/useChatEvents.test.mjs
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/useChatEvents.test.mjs
@@ -635,6 +635,7 @@ test("useChatEvents: failed terminal projection appends visible error", () => {
   assert.equal(harness.messages.length, 1);
   assert.equal(harness.messages[0].id, "err-run-failed-1");
   assert.equal(harness.messages[0].role, "error");
+  assert.equal(harness.messages[0].turnRunId, "run-failed-1");
   assert.equal(
     harness.messages[0].content,
     "The run failed because the execution driver rejected the request.",
@@ -667,6 +668,7 @@ test("useChatEvents: typed failed event appends visible error", () => {
   assert.equal(harness.messages.length, 1);
   assert.equal(harness.messages[0].id, "err-run-typed-failed-1");
   assert.equal(harness.messages[0].role, "error");
+  assert.equal(harness.messages[0].turnRunId, "run-typed-failed-1");
   assert.equal(harness.messages[0].content, "category:model_unavailable");
   assert.deepEqual(plain(seenFailureInputs), [
     {

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/useHistory.test.mjs
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/useHistory.test.mjs
@@ -333,14 +333,43 @@ test("mergeFullRefresh keeps requested client-only bubbles and lets the timeline
   const { mergeFullRefresh } = context.globalThis.__testExports;
 
   const timeline = [
-    { id: "msg-user-1", role: "user" },
-    { id: "tool-abc", role: "tool_activity", toolParameters: "{}", toolResultPreview: "ok" },
-    { id: "msg-assistant-1", role: "assistant" },
+    { id: "msg-user-1", role: "user", turnRunId: "run-1" },
+    {
+      id: "tool-abc",
+      role: "tool_activity",
+      toolParameters: "{}",
+      toolResultPreview: "ok",
+      turnRunId: "run-1",
+    },
+    {
+      id: "msg-assistant-1",
+      role: "assistant",
+      isFinalReply: true,
+      turnRunId: "run-1",
+    },
+    { id: "msg-user-2", role: "user", turnRunId: "run-2" },
+    {
+      id: "msg-assistant-2",
+      role: "assistant",
+      isFinalReply: true,
+      turnRunId: "run-2",
+    },
   ];
   const current = [
-    { id: "msg-user-1", role: "user" },
-    { id: "tool-abc", role: "tool_activity", toolParameters: null, toolResultPreview: null },
-    { id: "err-run-1", role: "error", content: "run failed" },
+    { id: "msg-user-1", role: "user", turnRunId: "run-1" },
+    {
+      id: "tool-abc",
+      role: "tool_activity",
+      toolParameters: null,
+      toolResultPreview: null,
+      turnRunId: "run-1",
+    },
+    {
+      id: "err-run-1",
+      role: "error",
+      content: "run failed",
+      turnRunId: "run-1",
+    },
   ];
 
   const merged = mergeFullRefresh(timeline, current, {
@@ -348,10 +377,10 @@ test("mergeFullRefresh keeps requested client-only bubbles and lets the timeline
   });
 
   // Timeline order is authoritative and the rich tool card replaces the
-  // sparse live one; the client-only err-* bubble is preserved at the end.
+  // sparse live one; the client-only err-* bubble stays anchored to its run.
   assert.equal(
     merged.map((m) => m.id).join(","),
-    "msg-user-1,tool-abc,msg-assistant-1,err-run-1",
+    "msg-user-1,tool-abc,msg-assistant-1,err-run-1,msg-user-2,msg-assistant-2",
   );
   const toolCard = merged.find((m) => m.id === "tool-abc");
   assert.equal(toolCard.toolParameters, "{}");


### PR DESCRIPTION
## Summary
- add run ids to client-side run failure bubbles
- keep preserved failure bubbles anchored to their original run during full timeline refreshes
- update WebChat v2 regression tests so old failures do not drift below newer turns

Fixes #5227

## Tests
- node --test crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/useHistory.test.mjs
- node --test crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/useChatEvents.test.mjs
- node --test crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/message-groups.test.mjs
- cargo test -p ironclaw_webui_v2_static
- git diff --check