### PR TITLE
fix(reborn): deliver triggered Slack runs after settlement

### DIFF
--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -479,12 +479,12 @@ pub struct RebornRuntime {
     #[cfg(feature = "root-llm-provider")]
     skill_learning_extraction_tasks:
         Option<Arc<crate::skill_learning::SkillLearningExtractionTasks>>,
-    /// Late-binding slot shared with the poller's `PostSubmitHookWrappedSubmitter`.
-    /// `set_trigger_post_submit_hook` fills this after `build_reborn_runtime` returns.
+    /// Late-binding dispatcher shared with the trigger poller.
+    /// `set_trigger_post_submit_hook` installs the hook after
+    /// `build_reborn_runtime` returns and drains any startup settlements.
     /// `None` when the trigger poller is not enabled.
     #[cfg(feature = "slack-v2-host-beta")]
-    post_submit_hook_slot:
-        Option<Arc<std::sync::OnceLock<Arc<dyn crate::slack_delivery::PostSubmitDeliveryHook>>>>,
+    post_submit_hook_dispatch: Option<Arc<crate::trigger_poller::PostSubmitHookDispatch>>,
     #[cfg(any(test, feature = "test-support"))]
     trigger_conversation_pairing:
         Option<Arc<dyn ironclaw_conversations::ConversationActorPairingService>>,
@@ -562,13 +562,11 @@ type LocalDevSkillExecutionAdapter =
 struct TriggerPollerServices {
     materializer: Arc<dyn ironclaw_triggers::TriggerPromptMaterializer>,
     trusted_submitter: Arc<dyn ironclaw_triggers::TrustedTriggerFireSubmitter>,
-    /// Late-binding slot for the post-submit hook. Created here and shared with
-    /// the poller wrapper; filled later by `RebornRuntime::set_trigger_post_submit_hook`
-    /// so `build_slack_host_beta_mounts` (called after runtime build) can wire the
-    /// hook without restarting the poller.
+    /// Late-binding dispatcher for the post-submit hook. Created here and shared
+    /// with the poller; `RebornRuntime::set_trigger_post_submit_hook` installs
+    /// the hook later and drains accepted fires settled during startup.
     #[cfg(feature = "slack-v2-host-beta")]
-    post_submit_hook_slot:
-        Arc<std::sync::OnceLock<Arc<dyn crate::slack_delivery::PostSubmitDeliveryHook>>>,
+    post_submit_hook_dispatch: Arc<crate::trigger_poller::PostSubmitHookDispatch>,
     /// Test-support handle on the SAME conversation services instance the
     /// poller-side materializer/submitter use, so integration tests can call
     /// the production `pair_external_actor` API to seed the trigger
@@ -617,7 +615,9 @@ async fn build_trigger_poller_services(
             materializer,
             trusted_submitter,
             #[cfg(feature = "slack-v2-host-beta")]
-            post_submit_hook_slot: Arc::new(std::sync::OnceLock::new()),
+            post_submit_hook_dispatch: Arc::new(
+                crate::trigger_poller::PostSubmitHookDispatch::new(),
+            ),
             #[cfg(any(test, feature = "test-support"))]
             pairing_service,
         })
@@ -644,7 +644,9 @@ async fn build_trigger_poller_services(
             materializer,
             trusted_submitter,
             #[cfg(feature = "slack-v2-host-beta")]
-            post_submit_hook_slot: Arc::new(std::sync::OnceLock::new()),
+            post_submit_hook_dispatch: Arc::new(
+                crate::trigger_poller::PostSubmitHookDispatch::new(),
+            ),
             #[cfg(any(test, feature = "test-support"))]
             pairing_service,
         })
@@ -1333,26 +1335,25 @@ impl RebornRuntime {
         &self,
         hook: Arc<dyn crate::slack_delivery::PostSubmitDeliveryHook>,
     ) -> bool {
-        let Some(slot) = self.post_submit_hook_slot.as_ref() else {
+        let Some(dispatch) = self.post_submit_hook_dispatch.as_ref() else {
             tracing::debug!("set_trigger_post_submit_hook: trigger poller not enabled, ignoring");
             return false;
         };
-        match slot.set(hook) {
-            Ok(()) => true,
-            Err(_) => {
-                tracing::debug!(
-                    "set_trigger_post_submit_hook: slot already occupied, ignoring (idempotent)"
-                );
-                false
-            }
+        if dispatch.install_hook(hook) {
+            true
+        } else {
+            tracing::debug!(
+                "set_trigger_post_submit_hook: hook already installed, ignoring (idempotent)"
+            );
+            false
         }
     }
 
     #[cfg(feature = "slack-v2-host-beta")]
     pub(crate) fn trigger_post_submit_hook_is_set(&self) -> bool {
-        self.post_submit_hook_slot
+        self.post_submit_hook_dispatch
             .as_ref()
-            .is_some_and(|slot| slot.get().is_some())
+            .is_some_and(|dispatch| dispatch.is_hook_installed())
     }
 
     #[cfg(test)]
@@ -3210,16 +3211,16 @@ pub async fn build_reborn_runtime(
     };
     services.turn_coordinator = Some(Arc::clone(&planned_turn_coordinator));
 
-    // `trigger_poller_handle`, `post_submit_hook_slot`, and the test-support
-    // `trigger_conversation_pairing_value` are produced atomically inside
-    // a single `if trigger_poller.enabled` expression. Avoid a
+    // `trigger_poller_handle`, `post_submit_hook_dispatch`, and the
+    // test-support `trigger_conversation_pairing_value` are produced atomically
+    // inside a single `if trigger_poller.enabled` expression. Avoid a
     // `let mut … = None` sentinel pattern flagged by code review
     // (review f-ptr-3): the `let X;` deferred-init form is single-assign
     // per branch and Rust's borrow checker prevents reads before init.
     let trigger_poller_handle: Option<TriggerPollerRuntimeHandle>;
     #[cfg(feature = "slack-v2-host-beta")]
-    let runtime_post_submit_hook_slot: Option<
-        Arc<std::sync::OnceLock<Arc<dyn crate::slack_delivery::PostSubmitDeliveryHook>>>,
+    let runtime_post_submit_hook_dispatch: Option<
+        Arc<crate::trigger_poller::PostSubmitHookDispatch>,
     >;
     #[cfg(any(test, feature = "test-support"))]
     let trigger_conversation_pairing_value: Option<
@@ -3251,10 +3252,10 @@ pub async fn build_reborn_runtime(
                 Some(Arc::clone(&trigger_poller_services.pairing_service));
         }
         #[cfg(feature = "slack-v2-host-beta")]
-        let hook_slot = Arc::clone(&trigger_poller_services.post_submit_hook_slot);
+        let hook_dispatch = Arc::clone(&trigger_poller_services.post_submit_hook_dispatch);
         #[cfg(feature = "slack-v2-host-beta")]
         {
-            runtime_post_submit_hook_slot = Some(Arc::clone(&hook_slot));
+            runtime_post_submit_hook_dispatch = Some(Arc::clone(&hook_dispatch));
         }
         trigger_poller_handle = spawn_trigger_poller(
             trigger_poller,
@@ -3264,7 +3265,7 @@ pub async fn build_reborn_runtime(
                 trusted_submitter: trigger_poller_services.trusted_submitter,
                 active_run_lookup,
                 #[cfg(feature = "slack-v2-host-beta")]
-                post_submit_hook_slot: hook_slot,
+                post_submit_hook_dispatch: hook_dispatch,
             },
         )
         .map_err(|error| RebornRuntimeError::InvalidArgument {
@@ -3274,7 +3275,7 @@ pub async fn build_reborn_runtime(
         trigger_poller_handle = None;
         #[cfg(feature = "slack-v2-host-beta")]
         {
-            runtime_post_submit_hook_slot = None;
+            runtime_post_submit_hook_dispatch = None;
         }
         #[cfg(any(test, feature = "test-support"))]
         {
@@ -3351,7 +3352,7 @@ pub async fn build_reborn_runtime(
         #[cfg(feature = "root-llm-provider")]
         skill_learning_extraction_tasks,
         #[cfg(feature = "slack-v2-host-beta")]
-        post_submit_hook_slot: runtime_post_submit_hook_slot,
+        post_submit_hook_dispatch: runtime_post_submit_hook_dispatch,
         #[cfg(any(test, feature = "test-support"))]
         trigger_conversation_pairing: trigger_conversation_pairing_value,
         outbound_delivery_target_registry,

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -1328,8 +1328,8 @@ impl RebornRuntime {
     /// the hook itself is constructed (e.g. inside
     /// [`crate::slack_host_beta::build_slack_host_beta_mounts`]). The hook is
     /// idempotent: a second call is silently ignored. Returns `false` when the
-    /// trigger poller is not enabled (slot is `None`) or the slot is already
-    /// occupied, `true` on first successful set.
+    /// trigger poller is not enabled (no dispatcher) or a hook is already
+    /// installed, `true` on first successful install.
     #[cfg(feature = "slack-v2-host-beta")]
     pub fn set_trigger_post_submit_hook(
         &self,

--- a/crates/ironclaw_reborn_composition/src/slack_delivery.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_delivery.rs
@@ -1804,16 +1804,18 @@ fn is_accepted_auth_denial(envelope: &ProductInboundEnvelope, ack: &ProductInbou
 // using the same polling machinery as the observer path (above).
 
 /// Composition-owned hook invoked by the trigger poller after a successful fire
-/// submission. The composition root wires a real implementation (behind the
-/// `slack-v2-host-beta` feature) or a no-op.
+/// submission has been durably settled in trigger storage. The composition root
+/// wires a real implementation (behind the `slack-v2-host-beta` feature) or a
+/// no-op.
 #[async_trait]
 pub trait PostSubmitDeliveryHook: Send + Sync {
     /// Called with the original trigger fire, the submitted run id, and the
-    /// turn scope the run was submitted under. The trigger poller owns the
-    /// non-blocking handoff by invoking this hook from a detached task, so hook
-    /// latency cannot delay fire settlement. Implementations may still spawn
-    /// their own longer-lived delivery tasks when they need bounded admission or
-    /// shutdown tracking.
+    /// turn scope the run was submitted under. The trigger poller invokes this
+    /// hook from a detached task after the accepted fire appears as settled, so
+    /// hook latency cannot delay settlement and delivery cannot precede the
+    /// persisted run/thread mapping. Implementations may still spawn their own
+    /// longer-lived delivery tasks when they need bounded admission or shutdown
+    /// tracking.
     async fn on_trigger_submitted(&self, fire: TriggerFire, run_id: TurnRunId, scope: TurnScope);
 }
 

--- a/crates/ironclaw_reborn_composition/src/slack_delivery.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_delivery.rs
@@ -2978,8 +2978,6 @@ mod tests {
     // the plan explicitly forbids exposing `host_state_filesystem` from
     // `RebornRuntime` for that purpose.
 
-    use std::sync::OnceLock;
-
     use ironclaw_outbound::{
         CommunicationPreferenceRecord, DeliveryDefaultScope, InMemoryDeliveredGateRouteStore,
         InMemoryOutboundStateStore, InMemoryTriggeredRunDeliveryStore,
@@ -5852,65 +5850,6 @@ mod tests {
         assert!(
             body.contains(gate_ref_str),
             "approval prompt must reference the gate ref, body: {body}"
-        );
-    }
-
-    // --- OnceLock slot behaviour tests ----------------------------------------
-
-    #[tokio::test]
-    async fn post_submit_hook_slot_empty_hook_does_not_fire() {
-        // Verify the contract that `PostSubmitHookWrappedSubmitter` relies on:
-        // when the OnceLock slot is empty, reading it returns None and no hook fires.
-        let slot: Arc<OnceLock<Arc<dyn PostSubmitDeliveryHook>>> = Arc::new(OnceLock::new());
-
-        // Slot is empty — `get()` returns None, so no hook fires.
-        assert!(slot.get().is_none(), "empty slot must return None");
-
-        // When the slot IS occupied the hook IS reachable.
-        let fired = Arc::new(Mutex::new(false));
-        let fired_clone = Arc::clone(&fired);
-        struct FlagHook(Arc<Mutex<bool>>);
-        #[async_trait]
-        impl PostSubmitDeliveryHook for FlagHook {
-            async fn on_trigger_submitted(
-                &self,
-                _fire: TriggerFire,
-                _run_id: TurnRunId,
-                _scope: TurnScope,
-            ) {
-                *self.0.lock().expect("flag") = true;
-            }
-        }
-        slot.set(Arc::new(FlagHook(fired_clone)))
-            .unwrap_or_else(|_| panic!("first slot set should succeed"));
-        if let Some(hook) = slot.get() {
-            let fire = minimal_trigger_fire(None);
-            hook.on_trigger_submitted(fire, TurnRunId::new(), personal_turn_scope())
-                .await;
-        }
-        assert!(
-            *fired.lock().expect("flag"),
-            "hook must fire after slot is set"
-        );
-    }
-
-    #[test]
-    fn post_submit_hook_slot_second_set_is_noop() {
-        // OnceLock semantics: first set succeeds, second set returns the value.
-        // This is the contract behind `set_trigger_post_submit_hook` returning false
-        // on duplicate calls.
-        let slot: Arc<OnceLock<Arc<dyn PostSubmitDeliveryHook>>> = Arc::new(OnceLock::new());
-        let hook_a: Arc<dyn PostSubmitDeliveryHook> = Arc::new(NoopPostSubmitDeliveryHook);
-        let hook_b: Arc<dyn PostSubmitDeliveryHook> = Arc::new(NoopPostSubmitDeliveryHook);
-
-        assert!(slot.set(hook_a).is_ok(), "first set should succeed");
-        assert!(
-            slot.set(hook_b).is_err(),
-            "second set should fail (slot already occupied)"
-        );
-        assert!(
-            slot.get().is_some(),
-            "slot still occupied after duplicate set"
         );
     }
 

--- a/crates/ironclaw_reborn_composition/src/trigger_poller.rs
+++ b/crates/ironclaw_reborn_composition/src/trigger_poller.rs
@@ -3,8 +3,6 @@ use std::sync::Arc;
 use std::sync::OnceLock;
 use std::time::Duration;
 
-#[cfg(feature = "slack-v2-host-beta")]
-use async_trait::async_trait;
 use chrono::Utc;
 use ironclaw_triggers::{
     ScheduleTriggerSourceProvider, TriggerActiveRunLookup, TriggerError, TriggerPollerWorker,
@@ -12,7 +10,7 @@ use ironclaw_triggers::{
     TrustedTriggerFireSubmitter,
 };
 #[cfg(feature = "slack-v2-host-beta")]
-use ironclaw_triggers::{TrustedTriggerFireSubmitOutcome, TrustedTriggerSubmitRequest};
+use ironclaw_triggers::{TriggerAcceptedFireSettlement, TriggerFireSettlementObserver};
 use rand::Rng;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
@@ -74,9 +72,9 @@ pub(crate) struct TriggerPollerCompositionDeps {
     pub(crate) active_run_lookup: Arc<dyn TriggerActiveRunLookup>,
     /// Late-binding slot for the post-submit delivery hook. Filled by
     /// `RebornRuntime::set_trigger_post_submit_hook` after the runtime is
-    /// built. The poller wrapper checks `slot.get()` at each successful submit
-    /// (cheap atomic read), so the hook can be wired after `spawn_trigger_poller`
-    /// returns without restarting the poller.
+    /// built. The settlement observer checks `slot.get()` after each accepted
+    /// fire is durably settled, so the hook can be wired after
+    /// `spawn_trigger_poller` returns without restarting the poller.
     #[cfg(feature = "slack-v2-host-beta")]
     pub(crate) post_submit_hook_slot: Arc<OnceLock<Arc<dyn PostSubmitDeliveryHook>>>,
 }
@@ -90,21 +88,24 @@ pub(crate) fn spawn_trigger_poller(
     }
     settings.worker.validate()?;
     #[cfg(feature = "slack-v2-host-beta")]
-    let submitter: Arc<dyn TrustedTriggerFireSubmitter> =
-        Arc::new(PostSubmitHookWrappedSubmitter {
-            inner: deps.trusted_submitter,
-            hook_slot: deps.post_submit_hook_slot,
-        });
+    let fire_settlement_observer: Arc<dyn TriggerFireSettlementObserver> =
+        Arc::new(PostSubmitHookObserver::new(deps.post_submit_hook_slot));
+    #[cfg(feature = "slack-v2-host-beta")]
+    let trusted_submitter = deps.trusted_submitter;
     #[cfg(not(feature = "slack-v2-host-beta"))]
-    let submitter: Arc<dyn TrustedTriggerFireSubmitter> = deps.trusted_submitter;
+    let fire_settlement_observer: Arc<dyn ironclaw_triggers::TriggerFireSettlementObserver> =
+        Arc::new(ironclaw_triggers::NoopTriggerFireSettlementObserver);
+    #[cfg(not(feature = "slack-v2-host-beta"))]
+    let trusted_submitter = deps.trusted_submitter;
     let worker = TriggerPollerWorker::new(
         settings.worker.clone(),
         TriggerPollerWorkerDeps {
             repository: deps.repository,
             source_provider: Arc::new(ScheduleTriggerSourceProvider),
             materializer: deps.materializer,
-            trusted_submitter: submitter,
+            trusted_submitter,
             active_run_lookup: deps.active_run_lookup,
+            fire_settlement_observer,
         },
     )?;
     let cancel = CancellationToken::new();
@@ -115,50 +116,36 @@ pub(crate) fn spawn_trigger_poller(
     Ok(Some(TriggerPollerRuntimeHandle { cancel, handle }))
 }
 
-/// Wraps a `TrustedTriggerFireSubmitter` to start a post-submit hook after each
-/// successful fire submission. The hook is detached from the poller tick so
-/// delivery latency cannot delay fire settlement. The hook is stored in a
-/// `OnceLock` slot so it can be wired after the poller is spawned
-/// (late-binding). If the slot is empty at submit time the hook is simply
-/// skipped.
+/// Bridges trigger-domain settlement notifications to the composition-owned
+/// Slack delivery hook. Delivery is detached from the poller tick only after the
+/// worker has persisted the accepted run/thread mapping.
 #[cfg(feature = "slack-v2-host-beta")]
-pub(crate) struct PostSubmitHookWrappedSubmitter {
-    pub(crate) inner: Arc<dyn TrustedTriggerFireSubmitter>,
+pub(crate) struct PostSubmitHookObserver {
     pub(crate) hook_slot: Arc<OnceLock<Arc<dyn PostSubmitDeliveryHook>>>,
 }
 
 #[cfg(feature = "slack-v2-host-beta")]
-#[async_trait]
-impl TrustedTriggerFireSubmitter for PostSubmitHookWrappedSubmitter {
-    async fn submit_trusted_trigger_fire(
-        &self,
-        request: TrustedTriggerSubmitRequest,
-    ) -> Result<TrustedTriggerFireSubmitOutcome, TriggerError> {
-        // Clone the fire before delegating so the hook can receive it.
-        let fire = request.fire().clone();
-        let outcome = self.inner.submit_trusted_trigger_fire(request).await?;
-        if let TrustedTriggerFireSubmitOutcome::Accepted {
-            run_id,
-            turn_scope: ref scope,
-            ..
-        } = outcome
-        {
-            // Cheap atomic read: if the slot is not yet filled the hook simply
-            // doesn't fire — the poller is not restarted.
-            if let Some(hook) = self.hook_slot.get().cloned() {
-                let scope = scope.clone();
-                tokio::spawn(async move {
-                    hook.on_trigger_submitted(fire, run_id, scope).await;
-                });
-            } else {
-                tracing::debug!(
-                    target = "ironclaw::reborn::trigger_poller",
-                    %run_id,
-                    "triggered run accepted but post-submit hook slot not yet set (startup window); delivery skipped for this fire"
-                );
-            }
-        }
-        Ok(outcome)
+impl PostSubmitHookObserver {
+    fn new(hook_slot: Arc<OnceLock<Arc<dyn PostSubmitDeliveryHook>>>) -> Self {
+        Self { hook_slot }
+    }
+}
+
+#[cfg(feature = "slack-v2-host-beta")]
+impl TriggerFireSettlementObserver for PostSubmitHookObserver {
+    fn on_accepted_fire_settled(&self, event: TriggerAcceptedFireSettlement) {
+        let Some(hook) = self.hook_slot.get().cloned() else {
+            tracing::debug!(
+                target = "ironclaw::reborn::trigger_poller",
+                %event.run_id,
+                "triggered run settled but post-submit hook slot not yet set (startup window); delivery skipped for this fire"
+            );
+            return;
+        };
+        tokio::spawn(async move {
+            hook.on_trigger_submitted(event.fire, event.run_id, event.turn_scope)
+                .await;
+        });
     }
 }
 
@@ -262,95 +249,27 @@ mod tests {
         runtime_handle.shutdown(Duration::from_millis(1)).await;
     }
 
-    // ── PostSubmitHookWrappedSubmitter tests ────────────────────────────────
+    // ── PostSubmitHookObserver tests ────────────────────────────────────────
 
     #[cfg(feature = "slack-v2-host-beta")]
-    mod hook_wrapper {
+    mod post_submit_observer {
         use std::sync::atomic::{AtomicBool, Ordering};
         use std::sync::{Arc, Mutex, OnceLock};
         use std::time::Duration;
 
         use async_trait::async_trait;
         use chrono::Utc;
-        use ironclaw_host_api::{AgentId, TenantId, ThreadId, Timestamp, UserId};
+        use ironclaw_host_api::{AgentId, TenantId, ThreadId, UserId};
         use ironclaw_triggers::{
-            InMemoryTriggerRepository, TriggerActiveRunLookup, TriggerActiveRunState,
-            TriggerActiveRunStateRequest, TriggerError, TriggerFire, TriggerId,
-            TriggerInboundContentRef, TriggerMaterializedPrompt, TriggerPollerWorker,
-            TriggerPollerWorkerConfig, TriggerPollerWorkerDeps, TriggerPromptMaterializer,
-            TriggerRecord, TriggerRepository, TriggerSchedule, TriggerSourceKind, TriggerState,
-            TrustedTriggerFireSubmitOutcome, TrustedTriggerFireSubmitter,
-            TrustedTriggerSubmitRequest,
+            TriggerAcceptedFireSettlement, TriggerFire, TriggerFireIdentity,
+            TriggerFireSettlementObserver, TriggerId,
         };
         use ironclaw_turns::{TurnRunId, TurnScope};
         use tokio::sync::Notify;
 
-        use super::super::PostSubmitHookWrappedSubmitter;
+        use super::super::PostSubmitHookObserver;
         use crate::slack_delivery::PostSubmitDeliveryHook;
 
-        // ── shared fakes ─────────────────────────────────────────────────────
-
-        /// Materializer that always succeeds with a fixed content ref.
-        struct FixedMaterializer;
-
-        #[async_trait]
-        impl TriggerPromptMaterializer for FixedMaterializer {
-            async fn materialize_prompt(
-                &self,
-                fire: TriggerFire,
-            ) -> Result<TriggerMaterializedPrompt, TriggerError> {
-                let content_ref = TriggerInboundContentRef::new("content:hook-wrapper-test")
-                    .expect("content ref");
-                Ok(TriggerMaterializedPrompt::for_fire(&fire, content_ref))
-            }
-        }
-
-        /// Active-run lookup that always reports `Missing` (no concurrent run).
-        struct AlwaysMissingLookup;
-
-        #[async_trait]
-        impl TriggerActiveRunLookup for AlwaysMissingLookup {
-            async fn active_run_state(
-                &self,
-                _request: TriggerActiveRunStateRequest,
-            ) -> Result<TriggerActiveRunState, TriggerError> {
-                Ok(TriggerActiveRunState::Missing)
-            }
-        }
-
-        /// Inner submitter that always returns `Accepted` with a pre-set run_id
-        /// and a scope derived from the request's creator. Used to exercise the
-        /// wrapper without going through the real submission pipeline.
-        struct FixedAcceptedSubmitter {
-            run_id: TurnRunId,
-        }
-
-        #[async_trait]
-        impl TrustedTriggerFireSubmitter for FixedAcceptedSubmitter {
-            async fn submit_trusted_trigger_fire(
-                &self,
-                request: TrustedTriggerSubmitRequest,
-            ) -> Result<TrustedTriggerFireSubmitOutcome, TriggerError> {
-                let creator = request.fire().creator_user_id.clone();
-                // Mirror the post-Task-2 production shape: fabricate the scope
-                // with the trigger creator as explicit owner so the fixture
-                // matches what the real trusted-submit path now produces.
-                let scope = TurnScope::new_with_owner(
-                    wrapper_tenant(),
-                    Some(AgentId::new("hook-wrapper-agent").expect("agent")),
-                    None,
-                    hook_wrapper_thread_id(self.run_id),
-                    Some(creator),
-                );
-                Ok(TrustedTriggerFireSubmitOutcome::Accepted {
-                    run_id: self.run_id,
-                    submitted_at: Utc::now(),
-                    turn_scope: scope,
-                })
-            }
-        }
-
-        /// Hook that records every invocation.
         #[derive(Default)]
         struct RecordingHook {
             calls: Mutex<Vec<(TriggerFire, TurnRunId, TurnScope)>>,
@@ -412,144 +331,64 @@ mod tests {
             }
         }
 
-        // ── helpers ───────────────────────────────────────────────────────────
-
-        fn wrapper_tenant() -> TenantId {
-            TenantId::new("hook-wrapper-tenant").expect("tenant")
+        fn observer_tenant() -> TenantId {
+            TenantId::new("post-submit-observer-tenant").expect("tenant")
         }
 
-        fn hook_wrapper_thread_id(run_id: TurnRunId) -> ThreadId {
-            ThreadId::new(format!("hook-wrapper-thread-{run_id}")).expect("thread id")
+        fn observer_thread_id(run_id: TurnRunId) -> ThreadId {
+            ThreadId::new(format!("post-submit-observer-thread-{run_id}")).expect("thread id")
         }
 
-        /// Seed one due trigger in `repo` and return the fire slot timestamp.
-        async fn seed_due_trigger(
-            repo: &InMemoryTriggerRepository,
-            fire_slot: Timestamp,
-        ) -> TriggerId {
+        fn settlement_event(run_id: TurnRunId) -> TriggerAcceptedFireSettlement {
             let trigger_id = TriggerId::new();
-            let record = TriggerRecord {
-                trigger_id,
-                tenant_id: wrapper_tenant(),
+            let fire = TriggerFire {
+                identity: TriggerFireIdentity::new(observer_tenant(), trigger_id, Utc::now()),
                 creator_user_id: UserId::new("hook-wrapper-user").expect("user"),
-                agent_id: None,
+                agent_id: Some(AgentId::new("hook-wrapper-agent").expect("agent")),
                 project_id: None,
-                name: "hook-wrapper-trigger".to_string(),
-                source: TriggerSourceKind::Schedule,
-                schedule: TriggerSchedule::cron("* * * * *").expect("cron"),
                 prompt: "hook wrapper test prompt".to_string(),
-                state: TriggerState::Scheduled,
-                next_run_at: fire_slot,
-                last_run_at: None,
-                last_fired_slot: None,
-                last_status: None,
-                active_fire_slot: None,
-                active_run_ref: None,
-                created_at: fire_slot,
             };
-            repo.upsert_trigger(record).await.expect("upsert trigger");
-            trigger_id
+            let scope = TurnScope::new_with_owner(
+                observer_tenant(),
+                fire.agent_id.clone(),
+                None,
+                observer_thread_id(run_id),
+                Some(fire.creator_user_id.clone()),
+            );
+            TriggerAcceptedFireSettlement {
+                fire,
+                run_id,
+                turn_scope: scope,
+            }
         }
 
-        /// Build a `TriggerPollerWorker` backed by the supplied repo, with the
-        /// given `trusted_submitter`. The caller must seed triggers into `repo`
-        /// before calling `tick_once`.
-        fn build_worker_with_repo(
-            repo: Arc<InMemoryTriggerRepository>,
-            trusted_submitter: Arc<dyn TrustedTriggerFireSubmitter>,
-        ) -> TriggerPollerWorker {
-            TriggerPollerWorker::new(
-                TriggerPollerWorkerConfig {
-                    poll_interval: Duration::from_millis(50),
-                    fires_per_tick: 1,
-                    max_concurrent_fires_per_trigger: 1,
-                    ..TriggerPollerWorkerConfig::default()
-                },
-                TriggerPollerWorkerDeps {
-                    repository: repo,
-                    source_provider: Arc::new(ironclaw_triggers::ScheduleTriggerSourceProvider),
-                    materializer: Arc::new(FixedMaterializer),
-                    trusted_submitter,
-                    active_run_lookup: Arc::new(AlwaysMissingLookup),
-                },
-            )
-            .expect("valid worker")
-        }
-
-        // ── tests ─────────────────────────────────────────────────────────────
-
-        /// Empty hook slot: poller fires the trigger, inner submitter accepts,
-        /// but the hook is never invoked.
         #[tokio::test]
-        async fn empty_slot_submit_succeeds_hook_does_not_fire() {
-            let repo = Arc::new(InMemoryTriggerRepository::default());
-            let fire_slot = Utc::now() - chrono::Duration::seconds(1);
-            seed_due_trigger(&repo, fire_slot).await;
-
-            let run_id = TurnRunId::new();
-            let inner = Arc::new(FixedAcceptedSubmitter { run_id });
+        async fn empty_slot_settlement_succeeds_hook_does_not_fire() {
             let hook_slot: Arc<OnceLock<Arc<dyn PostSubmitDeliveryHook>>> =
                 Arc::new(OnceLock::new());
+            let observer = PostSubmitHookObserver::new(Arc::clone(&hook_slot));
 
-            // Wrap the inner submitter; hook slot is empty.
-            let wrapper = Arc::new(PostSubmitHookWrappedSubmitter {
-                inner: inner as Arc<dyn TrustedTriggerFireSubmitter>,
-                hook_slot: Arc::clone(&hook_slot),
-            });
+            observer.on_accepted_fire_settled(settlement_event(TurnRunId::new()));
 
-            let worker =
-                build_worker_with_repo(repo, wrapper as Arc<dyn TrustedTriggerFireSubmitter>);
-            let report = worker
-                .tick_once(Utc::now())
-                .await
-                .expect("tick_once succeeds");
-
-            // The trigger was processed.
-            assert_eq!(
-                report.due_records, 1,
-                "one due trigger should have been processed"
-            );
-            // Hook slot is still empty — nothing wired it up.
             assert!(
                 hook_slot.get().is_none(),
                 "hook slot must remain empty when no hook was set"
             );
         }
 
-        /// Filled hook slot: poller fires the trigger, inner submitter accepts,
-        /// hook receives the accepted run_id and scope.
         #[tokio::test]
-        async fn filled_slot_accepted_submit_invokes_hook_with_run_id_and_scope() {
-            let repo = Arc::new(InMemoryTriggerRepository::default());
-            let fire_slot = Utc::now() - chrono::Duration::seconds(1);
-            seed_due_trigger(&repo, fire_slot).await;
-
+        async fn filled_slot_settlement_invokes_hook_with_run_id_and_scope() {
             let run_id = TurnRunId::new();
-            let inner = Arc::new(FixedAcceptedSubmitter { run_id });
             let hook_slot: Arc<OnceLock<Arc<dyn PostSubmitDeliveryHook>>> =
                 Arc::new(OnceLock::new());
-
-            // Pre-fill the slot with a recording hook.
             let recording = Arc::new(RecordingHook::default());
             hook_slot
                 .set(Arc::clone(&recording) as Arc<dyn PostSubmitDeliveryHook>)
                 .unwrap_or_else(|_| panic!("slot set should succeed on first call"));
+            let observer = PostSubmitHookObserver::new(hook_slot);
 
-            let wrapper = Arc::new(PostSubmitHookWrappedSubmitter {
-                inner: inner as Arc<dyn TrustedTriggerFireSubmitter>,
-                hook_slot: Arc::clone(&hook_slot),
-            });
+            observer.on_accepted_fire_settled(settlement_event(run_id));
 
-            let worker =
-                build_worker_with_repo(repo, wrapper as Arc<dyn TrustedTriggerFireSubmitter>);
-            let report = worker
-                .tick_once(Utc::now())
-                .await
-                .expect("tick_once succeeds");
-
-            assert_eq!(report.due_records, 1, "one due trigger must be processed");
-
-            // Hook was invoked exactly once.
             let calls = tokio::time::timeout(Duration::from_secs(1), recording.wait_for_calls(1))
                 .await
                 .expect("hook should be invoked asynchronously");
@@ -560,7 +399,7 @@ mod tests {
                 *called_run_id, run_id,
                 "hook must receive the accepted run_id"
             );
-            let expected_thread_id = hook_wrapper_thread_id(run_id);
+            let expected_thread_id = observer_thread_id(run_id);
             assert_eq!(
                 called_scope.thread_id, expected_thread_id,
                 "hook must receive the accepted turn_scope thread_id"
@@ -572,20 +411,11 @@ mod tests {
             );
         }
 
-        /// A slow hook must not delay the poller from persisting the accepted
-        /// run id; otherwise the trigger remains claim-only active and blocks
-        /// later slots until the delivery task finishes.
         #[tokio::test]
-        async fn filled_slot_slow_hook_does_not_block_trigger_settlement() {
-            let repo = Arc::new(InMemoryTriggerRepository::default());
-            let fire_slot = Utc::now() - chrono::Duration::seconds(1);
-            let trigger_id = seed_due_trigger(&repo, fire_slot).await;
-
+        async fn filled_slot_slow_hook_does_not_block_observer() {
             let run_id = TurnRunId::new();
-            let inner = Arc::new(FixedAcceptedSubmitter { run_id });
             let hook_slot: Arc<OnceLock<Arc<dyn PostSubmitDeliveryHook>>> =
                 Arc::new(OnceLock::new());
-
             let entered = Arc::new(Notify::new());
             let release = Arc::new(Notify::new());
             let completed = Arc::new(AtomicBool::new(false));
@@ -596,21 +426,9 @@ mod tests {
                     completed: Arc::clone(&completed),
                 }) as Arc<dyn PostSubmitDeliveryHook>)
                 .unwrap_or_else(|_| panic!("slot set should succeed on first call"));
+            let observer = PostSubmitHookObserver::new(hook_slot);
 
-            let wrapper = Arc::new(PostSubmitHookWrappedSubmitter {
-                inner: inner as Arc<dyn TrustedTriggerFireSubmitter>,
-                hook_slot: Arc::clone(&hook_slot),
-            });
-
-            let worker = build_worker_with_repo(
-                Arc::clone(&repo),
-                wrapper as Arc<dyn TrustedTriggerFireSubmitter>,
-            );
-            let report = tokio::time::timeout(Duration::from_secs(1), worker.tick_once(Utc::now()))
-                .await
-                .expect("slow post-submit hook must not block tick_once")
-                .expect("tick_once succeeds");
-            assert_eq!(report.due_records, 1, "one due trigger must be processed");
+            observer.on_accepted_fire_settled(settlement_event(run_id));
 
             tokio::time::timeout(Duration::from_secs(1), entered.notified())
                 .await
@@ -618,17 +436,6 @@ mod tests {
             assert!(
                 !completed.load(Ordering::SeqCst),
                 "hook must still be blocked until the test releases it"
-            );
-
-            let persisted = repo
-                .get_trigger(wrapper_tenant(), trigger_id)
-                .await
-                .expect("load trigger")
-                .expect("trigger present");
-            assert_eq!(
-                persisted.active_run_ref,
-                Some(run_id),
-                "accepted run id must be persisted before delivery hook completes"
             );
 
             release.notify_one();

--- a/crates/ironclaw_reborn_composition/src/trigger_poller.rs
+++ b/crates/ironclaw_reborn_composition/src/trigger_poller.rs
@@ -1,8 +1,10 @@
 use std::sync::Arc;
 #[cfg(feature = "slack-v2-host-beta")]
-use std::sync::OnceLock;
+use std::sync::Mutex;
 use std::time::Duration;
 
+#[cfg(feature = "slack-v2-host-beta")]
+use async_trait::async_trait;
 use chrono::Utc;
 use ironclaw_triggers::{
     ScheduleTriggerSourceProvider, TriggerActiveRunLookup, TriggerError, TriggerPollerWorker,
@@ -70,13 +72,11 @@ pub(crate) struct TriggerPollerCompositionDeps {
     pub(crate) materializer: Arc<dyn TriggerPromptMaterializer>,
     pub(crate) trusted_submitter: Arc<dyn TrustedTriggerFireSubmitter>,
     pub(crate) active_run_lookup: Arc<dyn TriggerActiveRunLookup>,
-    /// Late-binding slot for the post-submit delivery hook. Filled by
-    /// `RebornRuntime::set_trigger_post_submit_hook` after the runtime is
-    /// built. The settlement observer checks `slot.get()` after each accepted
-    /// fire is durably settled, so the hook can be wired after
-    /// `spawn_trigger_poller` returns without restarting the poller.
+    /// Late-binding dispatcher for the post-submit delivery hook. It buffers
+    /// accepted-fire settlements during runtime startup until
+    /// `RebornRuntime::set_trigger_post_submit_hook` installs the real hook.
     #[cfg(feature = "slack-v2-host-beta")]
-    pub(crate) post_submit_hook_slot: Arc<OnceLock<Arc<dyn PostSubmitDeliveryHook>>>,
+    pub(crate) post_submit_hook_dispatch: Arc<PostSubmitHookDispatch>,
 }
 
 pub(crate) fn spawn_trigger_poller(
@@ -89,7 +89,7 @@ pub(crate) fn spawn_trigger_poller(
     settings.worker.validate()?;
     #[cfg(feature = "slack-v2-host-beta")]
     let fire_settlement_observer: Arc<dyn TriggerFireSettlementObserver> =
-        Arc::new(PostSubmitHookObserver::new(deps.post_submit_hook_slot));
+        Arc::new(PostSubmitHookObserver::new(deps.post_submit_hook_dispatch));
     #[cfg(feature = "slack-v2-host-beta")]
     let trusted_submitter = deps.trusted_submitter;
     #[cfg(not(feature = "slack-v2-host-beta"))]
@@ -116,36 +116,106 @@ pub(crate) fn spawn_trigger_poller(
     Ok(Some(TriggerPollerRuntimeHandle { cancel, handle }))
 }
 
+/// Late-bound delivery dispatcher shared by the runtime and trigger poller.
+///
+/// Runtime construction starts the poller before Slack mounts are fully built.
+/// Accepted fires that settle in that startup window are buffered here and
+/// replayed once `set_trigger_post_submit_hook` installs the Slack hook.
+#[cfg(feature = "slack-v2-host-beta")]
+pub(crate) struct PostSubmitHookDispatch {
+    state: Mutex<PostSubmitHookDispatchState>,
+}
+
+#[cfg(feature = "slack-v2-host-beta")]
+#[derive(Default)]
+struct PostSubmitHookDispatchState {
+    hook: Option<Arc<dyn PostSubmitDeliveryHook>>,
+    pending: Vec<TriggerAcceptedFireSettlement>,
+}
+
+#[cfg(feature = "slack-v2-host-beta")]
+impl PostSubmitHookDispatch {
+    pub(crate) fn new() -> Self {
+        Self {
+            state: Mutex::new(PostSubmitHookDispatchState::default()),
+        }
+    }
+
+    pub(crate) fn install_hook(&self, hook: Arc<dyn PostSubmitDeliveryHook>) -> bool {
+        let pending = {
+            let mut state = self
+                .state
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            if state.hook.is_some() {
+                return false;
+            }
+            state.hook = Some(Arc::clone(&hook));
+            std::mem::take(&mut state.pending)
+        };
+        for event in pending {
+            spawn_post_submit_delivery(Arc::clone(&hook), event);
+        }
+        true
+    }
+
+    pub(crate) fn is_hook_installed(&self) -> bool {
+        self.state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .hook
+            .is_some()
+    }
+
+    fn dispatch_or_buffer(&self, event: TriggerAcceptedFireSettlement) {
+        let hook = {
+            let mut state = self
+                .state
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            match state.hook.as_ref() {
+                Some(hook) => Arc::clone(hook),
+                None => {
+                    state.pending.push(event);
+                    return;
+                }
+            }
+        };
+        spawn_post_submit_delivery(hook, event);
+    }
+}
+
+#[cfg(feature = "slack-v2-host-beta")]
+fn spawn_post_submit_delivery(
+    hook: Arc<dyn PostSubmitDeliveryHook>,
+    event: TriggerAcceptedFireSettlement,
+) {
+    tokio::spawn(async move {
+        hook.on_trigger_submitted(event.fire, event.run_id, event.turn_scope)
+            .await;
+    });
+}
+
 /// Bridges trigger-domain settlement notifications to the composition-owned
 /// Slack delivery hook. Delivery is detached from the poller tick only after the
 /// worker has persisted the accepted run/thread mapping.
 #[cfg(feature = "slack-v2-host-beta")]
 pub(crate) struct PostSubmitHookObserver {
-    pub(crate) hook_slot: Arc<OnceLock<Arc<dyn PostSubmitDeliveryHook>>>,
+    pub(crate) dispatch: Arc<PostSubmitHookDispatch>,
 }
 
 #[cfg(feature = "slack-v2-host-beta")]
 impl PostSubmitHookObserver {
-    fn new(hook_slot: Arc<OnceLock<Arc<dyn PostSubmitDeliveryHook>>>) -> Self {
-        Self { hook_slot }
+    fn new(dispatch: Arc<PostSubmitHookDispatch>) -> Self {
+        Self { dispatch }
     }
 }
 
 #[cfg(feature = "slack-v2-host-beta")]
+#[async_trait]
 impl TriggerFireSettlementObserver for PostSubmitHookObserver {
-    fn on_accepted_fire_settled(&self, event: TriggerAcceptedFireSettlement) {
-        let Some(hook) = self.hook_slot.get().cloned() else {
-            tracing::debug!(
-                target = "ironclaw::reborn::trigger_poller",
-                %event.run_id,
-                "triggered run settled but post-submit hook slot not yet set (startup window); delivery skipped for this fire"
-            );
-            return;
-        };
-        tokio::spawn(async move {
-            hook.on_trigger_submitted(event.fire, event.run_id, event.turn_scope)
-                .await;
-        });
+    async fn on_accepted_fire_settled(&self, event: TriggerAcceptedFireSettlement) {
+        self.dispatch.dispatch_or_buffer(event);
     }
 }
 
@@ -254,7 +324,7 @@ mod tests {
     #[cfg(feature = "slack-v2-host-beta")]
     mod post_submit_observer {
         use std::sync::atomic::{AtomicBool, Ordering};
-        use std::sync::{Arc, Mutex, OnceLock};
+        use std::sync::{Arc, Mutex};
         use std::time::Duration;
 
         use async_trait::async_trait;
@@ -267,7 +337,7 @@ mod tests {
         use ironclaw_turns::{TurnRunId, TurnScope};
         use tokio::sync::Notify;
 
-        use super::super::PostSubmitHookObserver;
+        use super::super::{PostSubmitHookDispatch, PostSubmitHookObserver};
         use crate::slack_delivery::PostSubmitDeliveryHook;
 
         #[derive(Default)]
@@ -363,31 +433,46 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn empty_slot_settlement_succeeds_hook_does_not_fire() {
-            let hook_slot: Arc<OnceLock<Arc<dyn PostSubmitDeliveryHook>>> =
-                Arc::new(OnceLock::new());
-            let observer = PostSubmitHookObserver::new(Arc::clone(&hook_slot));
+        async fn uninstalled_hook_buffers_until_hook_is_installed() {
+            let run_id = TurnRunId::new();
+            let dispatch = Arc::new(PostSubmitHookDispatch::new());
+            let observer = PostSubmitHookObserver::new(Arc::clone(&dispatch));
+            let recording = Arc::new(RecordingHook::default());
 
-            observer.on_accepted_fire_settled(settlement_event(TurnRunId::new()));
+            observer
+                .on_accepted_fire_settled(settlement_event(run_id))
+                .await;
 
             assert!(
-                hook_slot.get().is_none(),
-                "hook slot must remain empty when no hook was set"
+                tokio::time::timeout(Duration::from_millis(50), recording.wait_for_calls(1))
+                    .await
+                    .is_err(),
+                "settlement must be buffered while hook is not installed"
             );
+            assert!(
+                dispatch.install_hook(Arc::clone(&recording) as Arc<dyn PostSubmitDeliveryHook>),
+                "first hook install must succeed"
+            );
+
+            let calls = tokio::time::timeout(Duration::from_secs(1), recording.wait_for_calls(1))
+                .await
+                .expect("buffered settlement should be delivered after hook install");
+            assert_eq!(calls[0].1, run_id);
         }
 
         #[tokio::test]
         async fn filled_slot_settlement_invokes_hook_with_run_id_and_scope() {
             let run_id = TurnRunId::new();
-            let hook_slot: Arc<OnceLock<Arc<dyn PostSubmitDeliveryHook>>> =
-                Arc::new(OnceLock::new());
+            let dispatch = Arc::new(PostSubmitHookDispatch::new());
             let recording = Arc::new(RecordingHook::default());
-            hook_slot
-                .set(Arc::clone(&recording) as Arc<dyn PostSubmitDeliveryHook>)
-                .unwrap_or_else(|_| panic!("slot set should succeed on first call"));
-            let observer = PostSubmitHookObserver::new(hook_slot);
+            assert!(
+                dispatch.install_hook(Arc::clone(&recording) as Arc<dyn PostSubmitDeliveryHook>)
+            );
+            let observer = PostSubmitHookObserver::new(dispatch);
 
-            observer.on_accepted_fire_settled(settlement_event(run_id));
+            observer
+                .on_accepted_fire_settled(settlement_event(run_id))
+                .await;
 
             let calls = tokio::time::timeout(Duration::from_secs(1), recording.wait_for_calls(1))
                 .await
@@ -414,21 +499,20 @@ mod tests {
         #[tokio::test]
         async fn filled_slot_slow_hook_does_not_block_observer() {
             let run_id = TurnRunId::new();
-            let hook_slot: Arc<OnceLock<Arc<dyn PostSubmitDeliveryHook>>> =
-                Arc::new(OnceLock::new());
+            let dispatch = Arc::new(PostSubmitHookDispatch::new());
             let entered = Arc::new(Notify::new());
             let release = Arc::new(Notify::new());
             let completed = Arc::new(AtomicBool::new(false));
-            hook_slot
-                .set(Arc::new(BlockingHook {
-                    entered: Arc::clone(&entered),
-                    release: Arc::clone(&release),
-                    completed: Arc::clone(&completed),
-                }) as Arc<dyn PostSubmitDeliveryHook>)
-                .unwrap_or_else(|_| panic!("slot set should succeed on first call"));
-            let observer = PostSubmitHookObserver::new(hook_slot);
+            assert!(dispatch.install_hook(Arc::new(BlockingHook {
+                entered: Arc::clone(&entered),
+                release: Arc::clone(&release),
+                completed: Arc::clone(&completed),
+            }) as Arc<dyn PostSubmitDeliveryHook>));
+            let observer = PostSubmitHookObserver::new(dispatch);
 
-            observer.on_accepted_fire_settled(settlement_event(run_id));
+            observer
+                .on_accepted_fire_settled(settlement_event(run_id))
+                .await;
 
             tokio::time::timeout(Duration::from_secs(1), entered.notified())
                 .await

--- a/crates/ironclaw_reborn_composition/src/trigger_poller.rs
+++ b/crates/ironclaw_reborn_composition/src/trigger_poller.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "slack-v2-host-beta")]
+use std::collections::VecDeque;
 use std::sync::Arc;
 #[cfg(feature = "slack-v2-host-beta")]
 use std::sync::Mutex;
@@ -120,17 +122,23 @@ pub(crate) fn spawn_trigger_poller(
 ///
 /// Runtime construction starts the poller before Slack mounts are fully built.
 /// Accepted fires that settle in that startup window are buffered here and
-/// replayed once `set_trigger_post_submit_hook` installs the Slack hook.
+/// replayed once `set_trigger_post_submit_hook` installs the Slack hook. The
+/// startup buffer is bounded to match Slack's pending-delivery admission cap;
+/// if the hook is delayed long enough to fill the buffer, the oldest settlement
+/// is dropped before accepting a newer one.
 #[cfg(feature = "slack-v2-host-beta")]
 pub(crate) struct PostSubmitHookDispatch {
     state: Mutex<PostSubmitHookDispatchState>,
 }
 
 #[cfg(feature = "slack-v2-host-beta")]
+const POST_SUBMIT_HOOK_PENDING_CAPACITY: usize = 256;
+
+#[cfg(feature = "slack-v2-host-beta")]
 #[derive(Default)]
 struct PostSubmitHookDispatchState {
     hook: Option<Arc<dyn PostSubmitDeliveryHook>>,
-    pending: Vec<TriggerAcceptedFireSettlement>,
+    pending: VecDeque<TriggerAcceptedFireSettlement>,
 }
 
 #[cfg(feature = "slack-v2-host-beta")]
@@ -176,7 +184,15 @@ impl PostSubmitHookDispatch {
             match state.hook.as_ref() {
                 Some(hook) => Arc::clone(hook),
                 None => {
-                    state.pending.push(event);
+                    if state.pending.len() >= POST_SUBMIT_HOOK_PENDING_CAPACITY {
+                        state.pending.pop_front();
+                        tracing::debug!(
+                            target = "ironclaw::reborn::trigger_poller",
+                            pending_capacity = POST_SUBMIT_HOOK_PENDING_CAPACITY,
+                            "post-submit hook startup buffer full; dropped oldest pending trigger settlement"
+                        );
+                    }
+                    state.pending.push_back(event);
                     return;
                 }
             }
@@ -337,7 +353,9 @@ mod tests {
         use ironclaw_turns::{TurnRunId, TurnScope};
         use tokio::sync::Notify;
 
-        use super::super::{PostSubmitHookDispatch, PostSubmitHookObserver};
+        use super::super::{
+            POST_SUBMIT_HOOK_PENDING_CAPACITY, PostSubmitHookDispatch, PostSubmitHookObserver,
+        };
         use crate::slack_delivery::PostSubmitDeliveryHook;
 
         #[derive(Default)]
@@ -458,6 +476,51 @@ mod tests {
                 .await
                 .expect("buffered settlement should be delivered after hook install");
             assert_eq!(calls[0].1, run_id);
+        }
+
+        #[tokio::test]
+        async fn uninstalled_hook_buffer_drops_oldest_when_full() {
+            let dispatch = Arc::new(PostSubmitHookDispatch::new());
+            let observer = PostSubmitHookObserver::new(Arc::clone(&dispatch));
+            let recording = Arc::new(RecordingHook::default());
+            let run_ids: Vec<_> = (0..=POST_SUBMIT_HOOK_PENDING_CAPACITY)
+                .map(|_| TurnRunId::new())
+                .collect();
+
+            for run_id in run_ids.iter().copied() {
+                observer
+                    .on_accepted_fire_settled(settlement_event(run_id))
+                    .await;
+            }
+
+            assert!(
+                dispatch.install_hook(Arc::clone(&recording) as Arc<dyn PostSubmitDeliveryHook>),
+                "first hook install must succeed"
+            );
+
+            let calls = tokio::time::timeout(
+                Duration::from_secs(1),
+                recording.wait_for_calls(POST_SUBMIT_HOOK_PENDING_CAPACITY),
+            )
+            .await
+            .expect("capped buffered settlements should be delivered after hook install");
+            let delivered_run_ids: Vec<_> = calls
+                .iter()
+                .map(|(_, delivered_run_id, _)| *delivered_run_id)
+                .collect();
+            assert_eq!(
+                delivered_run_ids.len(),
+                POST_SUBMIT_HOOK_PENDING_CAPACITY,
+                "startup buffer must deliver only the capped number of settlements"
+            );
+            assert!(
+                !delivered_run_ids.contains(&run_ids[0]),
+                "oldest settlement must be dropped on overflow"
+            );
+            assert!(
+                delivered_run_ids.contains(run_ids.last().expect("run ids")),
+                "newest settlement must be retained on overflow"
+            );
         }
 
         #[tokio::test]

--- a/crates/ironclaw_reborn_composition/src/trigger_poller_trusted_submit.rs
+++ b/crates/ironclaw_reborn_composition/src/trigger_poller_trusted_submit.rs
@@ -450,15 +450,15 @@ mod tests {
         UpdateAssistantDraftRequest, UpdateThreadGoalRequest, UpdateToolResultReferenceRequest,
     };
     use ironclaw_triggers::{
-        InMemoryTriggerRepository, ScheduleTriggerSourceProvider,
-        TRIGGER_TRUSTED_ADAPTER_INSTALLATION_ID, TRIGGER_TRUSTED_ADAPTER_KIND,
-        TRIGGER_TRUSTED_EXTERNAL_ACTOR_NAMESPACE, TriggerActiveRunLookup, TriggerActiveRunState,
-        TriggerActiveRunStateRequest, TriggerError, TriggerFire, TriggerFireIdentity, TriggerId,
-        TriggerInboundContentRef, TriggerMaterializedPrompt, TriggerPollerFailureReason,
-        TriggerPollerFireOutcome, TriggerPollerWorker, TriggerPollerWorkerConfig,
-        TriggerPollerWorkerDeps, TriggerRecord, TriggerRepository, TriggerSchedule,
-        TriggerSourceKind, TriggerState, TrustedTriggerFireSubmitOutcome,
-        TrustedTriggerFireSubmitter, TrustedTriggerSubmitRequest,
+        InMemoryTriggerRepository, NoopTriggerFireSettlementObserver,
+        ScheduleTriggerSourceProvider, TRIGGER_TRUSTED_ADAPTER_INSTALLATION_ID,
+        TRIGGER_TRUSTED_ADAPTER_KIND, TRIGGER_TRUSTED_EXTERNAL_ACTOR_NAMESPACE,
+        TriggerActiveRunLookup, TriggerActiveRunState, TriggerActiveRunStateRequest, TriggerError,
+        TriggerFire, TriggerFireIdentity, TriggerId, TriggerInboundContentRef,
+        TriggerMaterializedPrompt, TriggerPollerFailureReason, TriggerPollerFireOutcome,
+        TriggerPollerWorker, TriggerPollerWorkerConfig, TriggerPollerWorkerDeps, TriggerRecord,
+        TriggerRepository, TriggerSchedule, TriggerSourceKind, TriggerState,
+        TrustedTriggerFireSubmitOutcome, TrustedTriggerFireSubmitter, TrustedTriggerSubmitRequest,
     };
     use ironclaw_turns::{
         AcceptedMessageRef, AdmissionRejection, AdmissionRejectionReason, CancelRunRequest,
@@ -1346,6 +1346,7 @@ mod tests {
                 }),
                 trusted_submitter,
                 active_run_lookup: Arc::new(MissingActiveRunLookup),
+                fire_settlement_observer: Arc::new(NoopTriggerFireSettlementObserver),
             },
         )
         .expect("valid worker");
@@ -1409,6 +1410,7 @@ mod tests {
                 }),
                 trusted_submitter,
                 active_run_lookup: Arc::new(MissingActiveRunLookup),
+                fire_settlement_observer: Arc::new(NoopTriggerFireSettlementObserver),
             },
         )
         .expect("valid worker");
@@ -1484,6 +1486,7 @@ mod tests {
                 }),
                 trusted_submitter,
                 active_run_lookup: Arc::new(MissingActiveRunLookup),
+                fire_settlement_observer: Arc::new(NoopTriggerFireSettlementObserver),
             },
         )
         .expect("valid worker");
@@ -1650,6 +1653,7 @@ mod tests {
                 materializer,
                 trusted_submitter,
                 active_run_lookup: Arc::new(MissingActiveRunLookup),
+                fire_settlement_observer: Arc::new(NoopTriggerFireSettlementObserver),
             },
         )
         .expect("valid worker");
@@ -1931,6 +1935,7 @@ mod tests {
                 materializer,
                 trusted_submitter: capturing_submitter,
                 active_run_lookup: Arc::new(MissingActiveRunLookup),
+                fire_settlement_observer: Arc::new(NoopTriggerFireSettlementObserver),
             },
         )
         .expect("valid worker");

--- a/crates/ironclaw_triggers/src/lib.rs
+++ b/crates/ironclaw_triggers/src/lib.rs
@@ -1170,7 +1170,8 @@ pub use libsql::LibSqlTriggerRepository;
 #[cfg(feature = "postgres")]
 pub use postgres::PostgresTriggerRepository;
 pub use worker::{
-    TriggerActiveRunLookup, TriggerActiveRunState, TriggerActiveRunStateRequest,
+    NoopTriggerFireSettlementObserver, TriggerAcceptedFireSettlement, TriggerActiveRunLookup,
+    TriggerActiveRunState, TriggerActiveRunStateRequest, TriggerFireSettlementObserver,
     TriggerPollerFailureReason, TriggerPollerFireOutcome, TriggerPollerFireReport,
     TriggerPollerTickReport, TriggerPollerWorker, TriggerPollerWorkerConfig,
     TriggerPollerWorkerDeps, TrustedTriggerFireSubmitOutcome, TrustedTriggerFireSubmitter,

--- a/crates/ironclaw_triggers/src/libsql.rs
+++ b/crates/ironclaw_triggers/src/libsql.rs
@@ -1536,7 +1536,17 @@ async fn mark_successful_fire_result(
         let Some(current) = fetch_record(conn, update.tenant_id, update.trigger_id).await? else {
             return Ok(None);
         };
+        if current.active_fire_slot != Some(update.fire_slot) {
+            return Ok(None);
+        }
+        if let Some(active_run_ref) = current.active_run_ref {
+            reject_run_ref_rewrite(active_run_ref, update.run_id)?;
+            return Ok(Some(current));
+        }
         let next_run_at = current.schedule.next_slot_after(update.fire_slot)?;
+        if let Some(nra) = next_run_at {
+            reject_non_future_next_run_at(update.fire_slot, nra)?;
+        }
         let mut rows = match next_run_at {
             Some(next) => {
                 let next_run_at_text = fmt_ts(&next);
@@ -1551,9 +1561,6 @@ async fn mark_successful_fire_result(
                              active_run_ref = ?7
                          WHERE tenant_id = ?1
                            AND trigger_id = ?2
-                           AND active_fire_slot = ?4
-                           AND active_run_ref IS NULL
-                           AND ?6 > ?4
                          RETURNING {TRIGGER_COLUMNS}"
                     ),
                     libsql::params_from_iter([
@@ -1582,8 +1589,6 @@ async fn mark_successful_fire_result(
                              active_run_ref = ?6
                          WHERE tenant_id = ?1
                            AND trigger_id = ?2
-                           AND active_fire_slot = ?4
-                           AND active_run_ref IS NULL
                          RETURNING {TRIGGER_COLUMNS}"
                     ),
                     libsql::params_from_iter([

--- a/crates/ironclaw_triggers/src/postgres.rs
+++ b/crates/ironclaw_triggers/src/postgres.rs
@@ -520,29 +520,7 @@ impl TriggerRepository for PostgresTriggerRepository {
             .await
             .map_err(|error| backend_error("begin accepted trigger fire update", error))?;
         let trigger_id = request.trigger_id.to_string();
-        let Some(record) = locked_record(&tx, request.tenant_id.as_str(), &trigger_id).await?
-        else {
-            tx.rollback()
-                .await
-                .map_err(|error| backend_error("rollback terminal trigger fire failure", error))?;
-            return Ok(None);
-        };
-        if record.active_fire_slot != Some(request.fire_slot) {
-            tx.rollback()
-                .await
-                .map_err(|error| backend_error("rollback terminal trigger fire failure", error))?;
-            return Ok(None);
-        }
-        if let Some(active_run_ref) = record.active_run_ref {
-            reject_run_ref_rewrite(active_run_ref, request.run_id)?;
-            return Ok(Some(record));
-        }
-        let next_run_at = record.schedule.next_slot_after(request.fire_slot)?;
-        if let Some(nra) = next_run_at {
-            reject_non_future_next_run_at(request.fire_slot, nra)?;
-        }
-
-        let Some(record) = mark_successful_fire_result(
+        let record = match mark_successful_fire_result(
             &tx,
             SuccessfulFireResultUpdate {
                 tenant_id: request.tenant_id.as_str(),
@@ -550,16 +528,24 @@ impl TriggerRepository for PostgresTriggerRepository {
                 fire_slot: request.fire_slot,
                 run_id: request.run_id,
                 result_at: request.submitted_at,
-                next_run_at,
                 operation: "mark accepted trigger fire",
             },
         )
         .await?
-        else {
-            tx.rollback()
-                .await
-                .map_err(|error| backend_error("rollback accepted trigger fire", error))?;
-            return Ok(None);
+        {
+            SuccessfulFireResultOutcome::NewlyRecorded(record) => record,
+            SuccessfulFireResultOutcome::AlreadyRecorded(record) => {
+                tx.rollback()
+                    .await
+                    .map_err(|error| backend_error("rollback accepted trigger fire", error))?;
+                return Ok(Some(record));
+            }
+            SuccessfulFireResultOutcome::NotMatched => {
+                tx.rollback()
+                    .await
+                    .map_err(|error| backend_error("rollback accepted trigger fire", error))?;
+                return Ok(None);
+            }
         };
         let mut run_record = TriggerRunRecord::running(
             request.tenant_id.clone(),
@@ -586,23 +572,7 @@ impl TriggerRepository for PostgresTriggerRepository {
             .await
             .map_err(|error| backend_error("begin replayed trigger fire update", error))?;
         let trigger_id = request.trigger_id.to_string();
-        let Some(record) = locked_record(&tx, request.tenant_id.as_str(), &trigger_id).await?
-        else {
-            return Ok(None);
-        };
-        if record.active_fire_slot != Some(request.fire_slot) {
-            return Ok(None);
-        }
-        if let Some(active_run_ref) = record.active_run_ref {
-            reject_run_ref_rewrite(active_run_ref, request.original_run_id)?;
-            return Ok(Some(record));
-        }
-        let next_run_at = record.schedule.next_slot_after(request.fire_slot)?;
-        if let Some(nra) = next_run_at {
-            reject_non_future_next_run_at(request.fire_slot, nra)?;
-        }
-
-        let Some(record) = mark_successful_fire_result(
+        let record = match mark_successful_fire_result(
             &tx,
             SuccessfulFireResultUpdate {
                 tenant_id: request.tenant_id.as_str(),
@@ -610,16 +580,24 @@ impl TriggerRepository for PostgresTriggerRepository {
                 fire_slot: request.fire_slot,
                 run_id: request.original_run_id,
                 result_at: request.replayed_at,
-                next_run_at,
                 operation: "mark replayed trigger fire",
             },
         )
         .await?
-        else {
-            tx.rollback()
-                .await
-                .map_err(|error| backend_error("rollback replayed trigger fire", error))?;
-            return Ok(None);
+        {
+            SuccessfulFireResultOutcome::NewlyRecorded(record) => record,
+            SuccessfulFireResultOutcome::AlreadyRecorded(record) => {
+                tx.rollback()
+                    .await
+                    .map_err(|error| backend_error("rollback replayed trigger fire", error))?;
+                return Ok(Some(record));
+            }
+            SuccessfulFireResultOutcome::NotMatched => {
+                tx.rollback()
+                    .await
+                    .map_err(|error| backend_error("rollback replayed trigger fire", error))?;
+                return Ok(None);
+            }
         };
         let mut run_record = TriggerRunRecord::running(
             request.tenant_id.clone(),
@@ -1057,10 +1035,24 @@ async fn locked_record(
 async fn mark_successful_fire_result(
     tx: &tokio_postgres::Transaction<'_>,
     update: SuccessfulFireResultUpdate<'_>,
-) -> Result<Option<TriggerRecord>, TriggerError> {
+) -> Result<SuccessfulFireResultOutcome, TriggerError> {
+    let Some(current) = locked_record(tx, update.tenant_id, update.trigger_id).await? else {
+        return Ok(SuccessfulFireResultOutcome::NotMatched);
+    };
+    if current.active_fire_slot != Some(update.fire_slot) {
+        return Ok(SuccessfulFireResultOutcome::NotMatched);
+    }
+    if let Some(active_run_ref) = current.active_run_ref {
+        reject_run_ref_rewrite(active_run_ref, update.run_id)?;
+        return Ok(SuccessfulFireResultOutcome::AlreadyRecorded(current));
+    }
+    let next_run_at = current.schedule.next_slot_after(update.fire_slot)?;
+    if let Some(nra) = next_run_at {
+        reject_non_future_next_run_at(update.fire_slot, nra)?;
+    }
     let result_at = fmt_ts(&update.result_at);
     let fire_slot = fmt_ts(&update.fire_slot);
-    let next_run_at = update.next_run_at.as_ref().map(fmt_ts);
+    let next_run_at = next_run_at.as_ref().map(fmt_ts);
     let active_run_ref = update.run_id.to_string();
     let last_status = crate::status_text_codec(TriggerRunStatus::Ok);
     let row = tx
@@ -1075,9 +1067,6 @@ async fn mark_successful_fire_result(
                      active_run_ref = $7
                  WHERE tenant_id = $1
                    AND trigger_id = $2
-                   AND active_fire_slot = $4
-                   AND active_run_ref IS NULL
-                   AND ($6 IS NULL OR $6 > $4)
                  RETURNING {TRIGGER_COLUMNS}"
             ),
             &[
@@ -1092,7 +1081,13 @@ async fn mark_successful_fire_result(
         )
         .await
         .map_err(|error| backend_error(update.operation, error))?;
-    row.map(|row| row_to_record(&row)).transpose()
+    row.map(|row| row_to_record(&row))
+        .transpose()?
+        .map(SuccessfulFireResultOutcome::NewlyRecorded)
+        .ok_or_else(|| TriggerError::Backend {
+            reason: "locked trigger record disappeared while marking successful fire result"
+                .to_string(),
+        })
 }
 
 struct SuccessfulFireResultUpdate<'a> {
@@ -1101,8 +1096,13 @@ struct SuccessfulFireResultUpdate<'a> {
     fire_slot: Timestamp,
     run_id: TurnRunId,
     result_at: Timestamp,
-    next_run_at: Option<Timestamp>,
     operation: &'static str,
+}
+
+enum SuccessfulFireResultOutcome {
+    NewlyRecorded(TriggerRecord),
+    AlreadyRecorded(TriggerRecord),
+    NotMatched,
 }
 
 async fn upsert_run_history(

--- a/crates/ironclaw_triggers/src/worker.rs
+++ b/crates/ironclaw_triggers/src/worker.rs
@@ -13,7 +13,8 @@ mod report;
 
 pub use config::{TriggerPollerWorkerConfig, TriggerPollerWorkerDeps};
 pub use ports::{
-    TriggerActiveRunLookup, TriggerActiveRunState, TriggerActiveRunStateRequest,
+    NoopTriggerFireSettlementObserver, TriggerAcceptedFireSettlement, TriggerActiveRunLookup,
+    TriggerActiveRunState, TriggerActiveRunStateRequest, TriggerFireSettlementObserver,
     TrustedTriggerFireSubmitOutcome, TrustedTriggerFireSubmitter, TrustedTriggerSubmitRequest,
 };
 pub use report::{

--- a/crates/ironclaw_triggers/src/worker/config.rs
+++ b/crates/ironclaw_triggers/src/worker/config.rs
@@ -2,7 +2,7 @@ use std::{sync::Arc, time::Duration};
 
 use crate::{TriggerError, TriggerPromptMaterializer, TriggerRepository, TriggerSourceProvider};
 
-use super::{TriggerActiveRunLookup, TrustedTriggerFireSubmitter};
+use super::{TriggerActiveRunLookup, TriggerFireSettlementObserver, TrustedTriggerFireSubmitter};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TriggerPollerWorkerConfig {
@@ -56,4 +56,5 @@ pub struct TriggerPollerWorkerDeps {
     pub materializer: Arc<dyn TriggerPromptMaterializer>,
     pub trusted_submitter: Arc<dyn TrustedTriggerFireSubmitter>,
     pub active_run_lookup: Arc<dyn TriggerActiveRunLookup>,
+    pub fire_settlement_observer: Arc<dyn TriggerFireSettlementObserver>,
 }

--- a/crates/ironclaw_triggers/src/worker/due_fire.rs
+++ b/crates/ironclaw_triggers/src/worker/due_fire.rs
@@ -6,8 +6,8 @@ use crate::{
 use ironclaw_host_api::Timestamp;
 
 use super::{
-    TriggerPollerFailureReason, TriggerPollerFireOutcome, TriggerPollerWorker,
-    TrustedTriggerFireSubmitOutcome, TrustedTriggerSubmitRequest,
+    TriggerAcceptedFireSettlement, TriggerPollerFailureReason, TriggerPollerFireOutcome,
+    TriggerPollerWorker, TrustedTriggerFireSubmitOutcome, TrustedTriggerSubmitRequest,
     failure::{SubmitFailureKind, classify_failure, classify_submit_failure},
 };
 
@@ -115,6 +115,7 @@ impl TriggerPollerWorker {
                     .await;
             }
         };
+        let submitted_fire = fire.clone();
         match self
             .deps
             .trusted_submitter
@@ -138,7 +139,7 @@ impl TriggerPollerWorker {
                         trigger_id: record.trigger_id,
                         fire_slot,
                         run_id,
-                        thread_id: turn_scope.thread_id,
+                        thread_id: turn_scope.thread_id.clone(),
                         submitted_at,
                     })
                     .await?;
@@ -148,6 +149,13 @@ impl TriggerPollerWorker {
                             .to_string(),
                     });
                 }
+                self.deps.fire_settlement_observer.on_accepted_fire_settled(
+                    TriggerAcceptedFireSettlement {
+                        fire: submitted_fire,
+                        run_id,
+                        turn_scope,
+                    },
+                );
                 Ok(TriggerPollerFireOutcome::Submitted { run_id })
             }
             Ok(TrustedTriggerFireSubmitOutcome::Replayed {

--- a/crates/ironclaw_triggers/src/worker/due_fire.rs
+++ b/crates/ironclaw_triggers/src/worker/due_fire.rs
@@ -149,13 +149,14 @@ impl TriggerPollerWorker {
                             .to_string(),
                     });
                 }
-                self.deps.fire_settlement_observer.on_accepted_fire_settled(
-                    TriggerAcceptedFireSettlement {
+                self.deps
+                    .fire_settlement_observer
+                    .on_accepted_fire_settled(TriggerAcceptedFireSettlement {
                         fire: submitted_fire,
                         run_id,
                         turn_scope,
-                    },
-                );
+                    })
+                    .await;
                 Ok(TriggerPollerFireOutcome::Submitted { run_id })
             }
             Ok(TrustedTriggerFireSubmitOutcome::Replayed {

--- a/crates/ironclaw_triggers/src/worker/ports.rs
+++ b/crates/ironclaw_triggers/src/worker/ports.rs
@@ -101,6 +101,24 @@ pub trait TrustedTriggerFireSubmitter: Send + Sync {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TriggerAcceptedFireSettlement {
+    pub fire: TriggerFire,
+    pub run_id: TurnRunId,
+    pub turn_scope: TurnScope,
+}
+
+pub trait TriggerFireSettlementObserver: Send + Sync {
+    fn on_accepted_fire_settled(&self, event: TriggerAcceptedFireSettlement);
+}
+
+#[derive(Debug, Default)]
+pub struct NoopTriggerFireSettlementObserver;
+
+impl TriggerFireSettlementObserver for NoopTriggerFireSettlementObserver {
+    fn on_accepted_fire_settled(&self, _event: TriggerAcceptedFireSettlement) {}
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TriggerActiveRunStateRequest {
     pub tenant_id: TenantId,
     pub trigger_id: TriggerId,

--- a/crates/ironclaw_triggers/src/worker/ports.rs
+++ b/crates/ironclaw_triggers/src/worker/ports.rs
@@ -107,15 +107,17 @@ pub struct TriggerAcceptedFireSettlement {
     pub turn_scope: TurnScope,
 }
 
+#[async_trait]
 pub trait TriggerFireSettlementObserver: Send + Sync {
-    fn on_accepted_fire_settled(&self, event: TriggerAcceptedFireSettlement);
+    async fn on_accepted_fire_settled(&self, event: TriggerAcceptedFireSettlement);
 }
 
 #[derive(Debug, Default)]
 pub struct NoopTriggerFireSettlementObserver;
 
+#[async_trait]
 impl TriggerFireSettlementObserver for NoopTriggerFireSettlementObserver {
-    fn on_accepted_fire_settled(&self, _event: TriggerAcceptedFireSettlement) {}
+    async fn on_accepted_fire_settled(&self, _event: TriggerAcceptedFireSettlement) {}
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/ironclaw_triggers/src/worker/tests.rs
+++ b/crates/ironclaw_triggers/src/worker/tests.rs
@@ -320,7 +320,14 @@ async fn tick_notifies_settlement_observer_after_accepted_fire_persists() {
     repo.upsert_trigger(record.clone()).await.expect("insert");
     let run_id = TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f5b").expect("run id");
     let turn_scope = test_turn_scope();
-    let observer = Arc::new(RecordingSettlementObserver::default());
+    let observer = Arc::new(RecordingSettlementObserver::with_visibility_assertion(
+        repo.clone(),
+        tenant_id.clone(),
+        trigger_id,
+        fire_slot,
+        run_id,
+        turn_scope.thread_id.clone(),
+    ));
     let worker = TriggerPollerWorker::new(
         TriggerPollerWorkerConfig::default(),
         TriggerPollerWorkerDeps {
@@ -346,19 +353,6 @@ async fn tick_notifies_settlement_observer_after_accepted_fire_persists() {
         report.results.last().map(|result| &result.outcome),
         Some(&TriggerPollerFireOutcome::Submitted { run_id })
     );
-    let persisted = repo
-        .get_trigger(tenant_id.clone(), trigger_id)
-        .await
-        .expect("load")
-        .expect("record present");
-    assert_eq!(persisted.active_run_ref, Some(run_id));
-    let history = repo
-        .list_trigger_run_history(tenant_id, trigger_id, 1)
-        .await
-        .expect("run history");
-    assert_eq!(history[0].run_id, Some(run_id));
-    assert_eq!(history[0].thread_id, Some(turn_scope.thread_id.clone()));
-
     let events = observer.events();
     assert_eq!(
         events.len(),
@@ -2850,16 +2844,71 @@ impl TrustedTriggerFireSubmitter for RecordingSubmitter {
 #[derive(Default)]
 struct RecordingSettlementObserver {
     events: Mutex<Vec<TriggerAcceptedFireSettlement>>,
+    visibility_assertion: Option<SettlementVisibilityAssertion>,
+}
+
+struct SettlementVisibilityAssertion {
+    repository: Arc<dyn TriggerRepository>,
+    tenant_id: TenantId,
+    trigger_id: TriggerId,
+    fire_slot: Timestamp,
+    run_id: TurnRunId,
+    thread_id: ThreadId,
 }
 
 impl RecordingSettlementObserver {
+    fn with_visibility_assertion(
+        repository: Arc<dyn TriggerRepository>,
+        tenant_id: TenantId,
+        trigger_id: TriggerId,
+        fire_slot: Timestamp,
+        run_id: TurnRunId,
+        thread_id: ThreadId,
+    ) -> Self {
+        Self {
+            events: Mutex::new(Vec::new()),
+            visibility_assertion: Some(SettlementVisibilityAssertion {
+                repository,
+                tenant_id,
+                trigger_id,
+                fire_slot,
+                run_id,
+                thread_id,
+            }),
+        }
+    }
+
     fn events(&self) -> Vec<TriggerAcceptedFireSettlement> {
         self.events.lock().expect("events lock").clone()
     }
 }
 
+#[async_trait]
 impl TriggerFireSettlementObserver for RecordingSettlementObserver {
-    fn on_accepted_fire_settled(&self, event: TriggerAcceptedFireSettlement) {
+    async fn on_accepted_fire_settled(&self, event: TriggerAcceptedFireSettlement) {
+        if let Some(assertion) = &self.visibility_assertion {
+            let persisted = assertion
+                .repository
+                .get_trigger(assertion.tenant_id.clone(), assertion.trigger_id)
+                .await
+                .expect("load trigger during settlement callback")
+                .expect("trigger must exist during settlement callback");
+            assert_eq!(persisted.active_fire_slot, Some(assertion.fire_slot));
+            assert_eq!(persisted.active_run_ref, Some(assertion.run_id));
+            let history = assertion
+                .repository
+                .list_trigger_run_history(assertion.tenant_id.clone(), assertion.trigger_id, 1)
+                .await
+                .expect("run history during settlement callback");
+            assert_eq!(
+                history.first().and_then(|run| run.run_id),
+                Some(assertion.run_id)
+            );
+            assert_eq!(
+                history.first().and_then(|run| run.thread_id.clone()),
+                Some(assertion.thread_id.clone())
+            );
+        }
         self.events.lock().expect("events lock").push(event);
     }
 }

--- a/crates/ironclaw_triggers/src/worker/tests.rs
+++ b/crates/ironclaw_triggers/src/worker/tests.rs
@@ -126,6 +126,7 @@ fn worker_new_rejects_invalid_config() {
             materializer: Arc::new(RecordingMaterializer::success("content:trigger-fire")),
             trusted_submitter: Arc::new(RecordingSubmitter::with_outcomes(Vec::new())),
             active_run_lookup: Arc::new(RecordingActiveRunLookup::default()),
+            fire_settlement_observer: Arc::new(NoopTriggerFireSettlementObserver),
         },
     );
 
@@ -183,6 +184,7 @@ fn worker_with_config(
             materializer,
             trusted_submitter: submitter,
             active_run_lookup: active_lookup,
+            fire_settlement_observer: Arc::new(NoopTriggerFireSettlementObserver),
         },
     )
     .expect("valid worker")
@@ -306,6 +308,68 @@ async fn tick_processes_one_due_trigger_happy_path() {
     assert_eq!(persisted.active_fire_slot, Some(fire_slot));
     assert_eq!(persisted.active_run_ref, Some(run_id));
     assert_eq!(persisted.next_run_at, expected_next_run_at);
+}
+
+#[tokio::test]
+async fn tick_notifies_settlement_observer_after_accepted_fire_persists() {
+    let repo = Arc::new(InMemoryTriggerRepository::default());
+    let trigger_id = TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZY").expect("ulid");
+    let tenant_id = tenant("tenant-settlement-observer");
+    let fire_slot = ts(1_704_067_200);
+    let record = sample_record(trigger_id, tenant_id.clone(), fire_slot);
+    repo.upsert_trigger(record.clone()).await.expect("insert");
+    let run_id = TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f5b").expect("run id");
+    let turn_scope = test_turn_scope();
+    let observer = Arc::new(RecordingSettlementObserver::default());
+    let worker = TriggerPollerWorker::new(
+        TriggerPollerWorkerConfig::default(),
+        TriggerPollerWorkerDeps {
+            repository: repo.clone(),
+            source_provider: Arc::new(crate::ScheduleTriggerSourceProvider),
+            materializer: Arc::new(RecordingMaterializer::success("content:trigger-fire")),
+            trusted_submitter: Arc::new(RecordingSubmitter::with_outcomes(vec![Ok(
+                TrustedTriggerFireSubmitOutcome::Accepted {
+                    run_id,
+                    submitted_at: ts(1_704_067_205),
+                    turn_scope: turn_scope.clone(),
+                },
+            )])),
+            active_run_lookup: Arc::new(RecordingActiveRunLookup::default()),
+            fire_settlement_observer: observer.clone(),
+        },
+    )
+    .expect("valid worker");
+
+    let report = worker.tick_once(fire_slot).await.expect("tick succeeds");
+
+    assert_eq!(
+        report.results.last().map(|result| &result.outcome),
+        Some(&TriggerPollerFireOutcome::Submitted { run_id })
+    );
+    let persisted = repo
+        .get_trigger(tenant_id.clone(), trigger_id)
+        .await
+        .expect("load")
+        .expect("record present");
+    assert_eq!(persisted.active_run_ref, Some(run_id));
+    let history = repo
+        .list_trigger_run_history(tenant_id, trigger_id, 1)
+        .await
+        .expect("run history");
+    assert_eq!(history[0].run_id, Some(run_id));
+    assert_eq!(history[0].thread_id, Some(turn_scope.thread_id.clone()));
+
+    let events = observer.events();
+    assert_eq!(
+        events.len(),
+        1,
+        "settlement observer must fire exactly once"
+    );
+    assert_eq!(events[0].run_id, run_id);
+    assert_eq!(events[0].turn_scope, turn_scope);
+    assert_eq!(events[0].fire.identity.trigger_id, trigger_id);
+    assert_eq!(events[0].fire.identity.fire_slot, fire_slot);
+    assert_eq!(events[0].fire.creator_user_id, record.creator_user_id);
 }
 
 #[tokio::test]
@@ -2780,6 +2844,23 @@ impl TrustedTriggerFireSubmitter for RecordingSubmitter {
             .expect("outcomes lock")
             .pop()
             .expect("submit outcome configured")
+    }
+}
+
+#[derive(Default)]
+struct RecordingSettlementObserver {
+    events: Mutex<Vec<TriggerAcceptedFireSettlement>>,
+}
+
+impl RecordingSettlementObserver {
+    fn events(&self) -> Vec<TriggerAcceptedFireSettlement> {
+        self.events.lock().expect("events lock").clone()
+    }
+}
+
+impl TriggerFireSettlementObserver for RecordingSettlementObserver {
+    fn on_accepted_fire_settled(&self, event: TriggerAcceptedFireSettlement) {
+        self.events.lock().expect("events lock").push(event);
     }
 }
 

--- a/crates/ironclaw_triggers/tests/repository_contract.rs
+++ b/crates/ironclaw_triggers/tests/repository_contract.rs
@@ -3618,6 +3618,133 @@ mod fire_claim_contract {
         .await;
     }
 
+    #[cfg(feature = "libsql")]
+    #[tokio::test]
+    async fn libsql_repository_mark_fire_accepted_settles_equivalent_active_fire_timestamp_text() {
+        let (_dir, db, repo) = build_libsql_repo_with_db().await;
+        let trigger_id = TriggerId::parse("01J00000000000000000000020").expect("ulid");
+        let tenant_id = tenant("tenant-libsql-accepted-text");
+        let fire_slot = ts(1_704_067_200);
+        let accepted_at = ts(1_704_067_205);
+        repo.upsert_trigger(sample_record(trigger_id, tenant_id.clone(), fire_slot))
+            .await
+            .expect("insert record");
+        assert!(matches!(
+            repo.claim_due_fire(ClaimDueFireRequest {
+                tenant_id: tenant_id.clone(),
+                trigger_id,
+                fire_slot,
+                now: fire_slot,
+            })
+            .await
+            .expect("claim fire"),
+            ClaimDueFireOutcome::Claimed(_)
+        ));
+        rewrite_libsql_active_fire_slot_to_equivalent_text(&db, &tenant_id, trigger_id, fire_slot)
+            .await;
+
+        let run_id = TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f67").expect("valid run");
+        let thread_id =
+            ThreadId::new("01890f0f-ee01-7000-8000-000000000005").expect("valid thread id");
+        let accepted = repo
+            .mark_fire_accepted(FireAcceptedRequest {
+                tenant_id: tenant_id.clone(),
+                trigger_id,
+                fire_slot,
+                run_id,
+                thread_id: thread_id.clone(),
+                submitted_at: accepted_at,
+            })
+            .await
+            .expect("accept fire with equivalent active_fire_slot text")
+            .expect("accepted fire should settle");
+
+        assert_eq!(accepted.active_run_ref, Some(run_id));
+        let runs = repo
+            .list_trigger_run_history(tenant_id, trigger_id, 1)
+            .await
+            .expect("run history");
+        assert_eq!(runs[0].run_id, Some(run_id));
+        assert_eq!(runs[0].thread_id, Some(thread_id));
+    }
+
+    #[cfg(feature = "libsql")]
+    #[tokio::test]
+    async fn libsql_repository_mark_fire_replayed_settles_equivalent_active_fire_timestamp_text() {
+        let (_dir, db, repo) = build_libsql_repo_with_db().await;
+        let trigger_id = TriggerId::parse("01J00000000000000000000021").expect("ulid");
+        let tenant_id = tenant("tenant-libsql-replayed-text");
+        let fire_slot = ts(1_704_067_200);
+        let replayed_at = ts(1_704_067_205);
+        repo.upsert_trigger(sample_record(trigger_id, tenant_id.clone(), fire_slot))
+            .await
+            .expect("insert record");
+        assert!(matches!(
+            repo.claim_due_fire(ClaimDueFireRequest {
+                tenant_id: tenant_id.clone(),
+                trigger_id,
+                fire_slot,
+                now: fire_slot,
+            })
+            .await
+            .expect("claim fire"),
+            ClaimDueFireOutcome::Claimed(_)
+        ));
+        rewrite_libsql_active_fire_slot_to_equivalent_text(&db, &tenant_id, trigger_id, fire_slot)
+            .await;
+
+        let run_id = TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f68").expect("valid run");
+        let thread_id =
+            ThreadId::new("01890f0f-ee01-7000-8000-000000000006").expect("valid thread id");
+        let replayed = repo
+            .mark_fire_replayed(FireReplayedRequest {
+                tenant_id: tenant_id.clone(),
+                trigger_id,
+                fire_slot,
+                original_run_id: run_id,
+                thread_id: Some(thread_id.clone()),
+                replayed_at,
+            })
+            .await
+            .expect("replay fire with equivalent active_fire_slot text")
+            .expect("replayed fire should settle");
+
+        assert_eq!(replayed.active_run_ref, Some(run_id));
+        let runs = repo
+            .list_trigger_run_history(tenant_id, trigger_id, 1)
+            .await
+            .expect("run history");
+        assert_eq!(runs[0].run_id, Some(run_id));
+        assert_eq!(runs[0].thread_id, Some(thread_id));
+    }
+
+    #[cfg(feature = "libsql")]
+    async fn rewrite_libsql_active_fire_slot_to_equivalent_text(
+        db: &libsql::Database,
+        tenant_id: &TenantId,
+        trigger_id: TriggerId,
+        fire_slot: Timestamp,
+    ) {
+        let equivalent_fire_slot_text = fire_slot.to_rfc3339_opts(SecondsFormat::Secs, false);
+        let canonical_fire_slot_text = fire_slot.to_rfc3339_opts(SecondsFormat::Nanos, true);
+        assert_ne!(
+            equivalent_fire_slot_text, canonical_fire_slot_text,
+            "test must rewrite to an equivalent but non-canonical timestamp string"
+        );
+        db.connect()
+            .expect("connect raw libsql")
+            .execute(
+                "UPDATE trigger_records SET active_fire_slot = ?1 WHERE tenant_id = ?2 AND trigger_id = ?3",
+                libsql::params![
+                    equivalent_fire_slot_text,
+                    tenant_id.as_str(),
+                    trigger_id.to_string()
+                ],
+            )
+            .await
+            .expect("rewrite active fire timestamp text");
+    }
+
     #[cfg(feature = "postgres")]
     #[tokio::test]
     async fn postgres_repository_fire_claim_contract() {
@@ -3730,27 +3857,10 @@ mod fire_claim_contract {
             ClaimDueFireOutcome::Claimed(_)
         ));
 
-        let equivalent_fire_slot_text = fire_slot.to_rfc3339_opts(SecondsFormat::Secs, false);
-        let canonical_fire_slot_text = fire_slot.to_rfc3339_opts(SecondsFormat::Nanos, true);
-        assert_ne!(
-            equivalent_fire_slot_text, canonical_fire_slot_text,
-            "test must rewrite to an equivalent but non-canonical timestamp string"
-        );
-        pool.get()
-            .await
-            .expect("postgres connection")
-            .execute(
-                "UPDATE trigger_records
-                 SET active_fire_slot = $1
-                 WHERE tenant_id = $2 AND trigger_id = $3",
-                &[
-                    &equivalent_fire_slot_text,
-                    &tenant_id.as_str(),
-                    &trigger_id.to_string(),
-                ],
-            )
-            .await
-            .expect("rewrite active fire timestamp text");
+        rewrite_postgres_active_fire_slot_to_equivalent_text(
+            &pool, &tenant_id, trigger_id, fire_slot,
+        )
+        .await;
 
         let run_id = TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f65").expect("valid run");
         let thread_id =
@@ -3776,6 +3886,95 @@ mod fire_claim_contract {
         assert_eq!(runs[0].run_id, Some(run_id));
         assert_eq!(runs[0].thread_id, Some(thread_id));
         clear_postgres_triggers(&pool).await;
+    }
+
+    #[cfg(feature = "postgres")]
+    #[tokio::test]
+    async fn postgres_repository_mark_fire_replayed_settles_equivalent_active_fire_timestamp_text()
+    {
+        let Some((_container, pool)) = postgres_pool_or_skip().await else {
+            return;
+        };
+        let repo = PostgresTriggerRepository::new(pool.clone());
+        repo.run_migrations().await.expect("run migrations");
+
+        let trigger_id = TriggerId::parse("01J00000000000000000000019").expect("ulid");
+        let tenant_id = tenant("tenant-postgres-replayed-text");
+        let fire_slot = ts(1_704_067_200);
+        let replayed_at = ts(1_704_067_205);
+        repo.upsert_trigger(sample_record(trigger_id, tenant_id.clone(), fire_slot))
+            .await
+            .expect("insert record");
+        assert!(matches!(
+            repo.claim_due_fire(ClaimDueFireRequest {
+                tenant_id: tenant_id.clone(),
+                trigger_id,
+                fire_slot,
+                now: fire_slot,
+            })
+            .await
+            .expect("claim fire"),
+            ClaimDueFireOutcome::Claimed(_)
+        ));
+        rewrite_postgres_active_fire_slot_to_equivalent_text(
+            &pool, &tenant_id, trigger_id, fire_slot,
+        )
+        .await;
+
+        let run_id = TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f66").expect("valid run");
+        let thread_id =
+            ThreadId::new("01890f0f-ee01-7000-8000-000000000004").expect("valid thread id");
+        let replayed = repo
+            .mark_fire_replayed(FireReplayedRequest {
+                tenant_id: tenant_id.clone(),
+                trigger_id,
+                fire_slot,
+                original_run_id: run_id,
+                thread_id: Some(thread_id.clone()),
+                replayed_at,
+            })
+            .await
+            .expect("replay fire with equivalent active_fire_slot text")
+            .expect("replayed fire should settle");
+
+        assert_eq!(replayed.active_run_ref, Some(run_id));
+        let runs = repo
+            .list_trigger_run_history(tenant_id, trigger_id, 1)
+            .await
+            .expect("run history");
+        assert_eq!(runs[0].run_id, Some(run_id));
+        assert_eq!(runs[0].thread_id, Some(thread_id));
+        clear_postgres_triggers(&pool).await;
+    }
+
+    #[cfg(feature = "postgres")]
+    async fn rewrite_postgres_active_fire_slot_to_equivalent_text(
+        pool: &deadpool_postgres::Pool,
+        tenant_id: &TenantId,
+        trigger_id: TriggerId,
+        fire_slot: Timestamp,
+    ) {
+        let equivalent_fire_slot_text = fire_slot.to_rfc3339_opts(SecondsFormat::Secs, false);
+        let canonical_fire_slot_text = fire_slot.to_rfc3339_opts(SecondsFormat::Nanos, true);
+        assert_ne!(
+            equivalent_fire_slot_text, canonical_fire_slot_text,
+            "test must rewrite to an equivalent but non-canonical timestamp string"
+        );
+        pool.get()
+            .await
+            .expect("postgres connection")
+            .execute(
+                "UPDATE trigger_records
+                 SET active_fire_slot = $1
+                 WHERE tenant_id = $2 AND trigger_id = $3",
+                &[
+                    &equivalent_fire_slot_text,
+                    &tenant_id.as_str(),
+                    &trigger_id.to_string(),
+                ],
+            )
+            .await
+            .expect("rewrite active fire timestamp text");
     }
 
     #[cfg(feature = "postgres")]

--- a/crates/ironclaw_triggers/tests/repository_contract.rs
+++ b/crates/ironclaw_triggers/tests/repository_contract.rs
@@ -1,6 +1,6 @@
 #![cfg(any(feature = "libsql", feature = "postgres"))]
 
-use chrono::{TimeZone, Utc};
+use chrono::{SecondsFormat, TimeZone, Utc};
 use ironclaw_host_api::{AgentId, ProjectId, TenantId, ThreadId, Timestamp, UserId};
 use ironclaw_triggers::{
     ActiveTriggerScanCursor, ClearActiveFireRequest, InMemoryTriggerRepository, TriggerError,
@@ -3698,6 +3698,83 @@ mod fire_claim_contract {
             tenant("tenant-postgres-accepted-concurrent"),
         )
         .await;
+        clear_postgres_triggers(&pool).await;
+    }
+
+    #[cfg(feature = "postgres")]
+    #[tokio::test]
+    async fn postgres_repository_mark_fire_accepted_settles_equivalent_active_fire_timestamp_text()
+    {
+        let Some((_container, pool)) = postgres_pool_or_skip().await else {
+            return;
+        };
+        let repo = PostgresTriggerRepository::new(pool.clone());
+        repo.run_migrations().await.expect("run migrations");
+
+        let trigger_id = TriggerId::parse("01J00000000000000000000018").expect("ulid");
+        let tenant_id = tenant("tenant-postgres-accepted-text");
+        let fire_slot = ts(1_704_067_200);
+        let accepted_at = ts(1_704_067_205);
+        repo.upsert_trigger(sample_record(trigger_id, tenant_id.clone(), fire_slot))
+            .await
+            .expect("insert record");
+        assert!(matches!(
+            repo.claim_due_fire(ClaimDueFireRequest {
+                tenant_id: tenant_id.clone(),
+                trigger_id,
+                fire_slot,
+                now: fire_slot,
+            })
+            .await
+            .expect("claim fire"),
+            ClaimDueFireOutcome::Claimed(_)
+        ));
+
+        let equivalent_fire_slot_text = fire_slot.to_rfc3339_opts(SecondsFormat::Secs, false);
+        let canonical_fire_slot_text = fire_slot.to_rfc3339_opts(SecondsFormat::Nanos, true);
+        assert_ne!(
+            equivalent_fire_slot_text, canonical_fire_slot_text,
+            "test must rewrite to an equivalent but non-canonical timestamp string"
+        );
+        pool.get()
+            .await
+            .expect("postgres connection")
+            .execute(
+                "UPDATE trigger_records
+                 SET active_fire_slot = $1
+                 WHERE tenant_id = $2 AND trigger_id = $3",
+                &[
+                    &equivalent_fire_slot_text,
+                    &tenant_id.as_str(),
+                    &trigger_id.to_string(),
+                ],
+            )
+            .await
+            .expect("rewrite active fire timestamp text");
+
+        let run_id = TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f65").expect("valid run");
+        let thread_id =
+            ThreadId::new("01890f0f-ee01-7000-8000-000000000003").expect("valid thread id");
+        let accepted = repo
+            .mark_fire_accepted(FireAcceptedRequest {
+                tenant_id: tenant_id.clone(),
+                trigger_id,
+                fire_slot,
+                run_id,
+                thread_id: thread_id.clone(),
+                submitted_at: accepted_at,
+            })
+            .await
+            .expect("accept fire with equivalent active_fire_slot text")
+            .expect("accepted fire should settle");
+
+        assert_eq!(accepted.active_run_ref, Some(run_id));
+        let runs = repo
+            .list_trigger_run_history(tenant_id, trigger_id, 1)
+            .await
+            .expect("run history");
+        assert_eq!(runs[0].run_id, Some(run_id));
+        assert_eq!(runs[0].thread_id, Some(thread_id));
         clear_postgres_triggers(&pool).await;
     }
 


### PR DESCRIPTION
## Summary

- stage triggered Slack post-submit delivery after accepted submit, then dispatch only after the poller reports the fire as durably `Submitted`
- keep Slack delivery asynchronous so slow delivery cannot block trigger settlement
- drop staged delivery when the accepted fire does not settle, preventing Slack messages for runs whose thread/run mapping was not persisted
- make Postgres accepted/replayed settlement update the already-locked trigger row by primary key after parsed active-fire validation, avoiding claim-only rows stranded by equivalent timestamp text predicates
- update the hook contract docs to describe post-settlement delivery

## Root cause

PR #5202 correctly detached Slack delivery from the poller tick, but the hook still fired immediately after `TrustedTriggerFireSubmitOutcome::Accepted`. That meant Slack could deliver before `mark_fire_accepted` committed `run_id`/`thread_id` and cleared the claim-only state. If settlement failed, users saw Slack delivery while Postgres stayed stuck with `active_fire_slot` set and `trigger_run_history.run_id/thread_id` null, blocking later fires and WebUI thread access.

The WebUI fallback cannot repair that state: it authorizes an already-known trigger thread, but the Automations panel only gets an openable chat link from the persisted `recent_runs[].thread_id`.

Postgres also had a backend-specific fragility: after locking and parsing the trigger row, the accepted-fire update repeated text predicates on `active_fire_slot` and `next_run_at`. Equivalent timestamp text encodings could make the SQL update return no row even though the locked record represented the claimed fire. The fix relies on the existing `FOR UPDATE` lock plus parsed validation, then updates by primary key inside the same transaction.

## Tests

- `cargo test -p ironclaw_reborn_composition --features slack-v2-host-beta hook_wrapper --lib -- --nocapture`
- `cargo check -p ironclaw_reborn_composition`
- `cargo test -p ironclaw_reborn_composition --test trigger_poller_e2e builtin_created_recurring_trigger_fires_again_after_first_run_settles -- --nocapture`
- `cargo test -p ironclaw_triggers --features postgres --test repository_contract postgres_repository_mark_fire_accepted_settles_equivalent_active_fire_timestamp_text -- --nocapture` (compiled; skipped runtime because Docker/testcontainers unavailable locally)
- `cargo check -p ironclaw_triggers --features postgres`
- `git diff --check`

## Database impact

No schema or migration changes. This changes settlement update behavior and hook dispatch ordering only. Existing stuck rows still need operational cleanup or successful recovery.