### PR TITLE
Fix hosted-volume scoped tool service resolution

### DIFF
--- a/crates/ironclaw_host_runtime/src/invocation_services.rs
+++ b/crates/ironclaw_host_runtime/src/invocation_services.rs
@@ -12,10 +12,15 @@ use std::{fmt, sync::Arc};
 
 use async_trait::async_trait;
 use ironclaw_events::AuditSink;
-use ironclaw_filesystem::RootFilesystem;
+use ironclaw_filesystem::{
+    BackendCapabilities, CasExpectation, DirEntry, Entry, EventRecord, FileStat, FilesystemError,
+    FilesystemOperation, Filter, IndexSpec, Page, RecordVersion, RootFilesystem, SeqNo, StorageTxn,
+    VersionedEntry,
+};
 use ironclaw_host_api::{
-    MountView, ResourceScope, RuntimeDispatchErrorKind, RuntimeHttpEgress, RuntimeHttpEgressError,
-    RuntimeHttpEgressRequest, RuntimeHttpEgressResponse,
+    MountPermissions, MountView, ResourceScope, RuntimeDispatchErrorKind, RuntimeHttpEgress,
+    RuntimeHttpEgressError, RuntimeHttpEgressRequest, RuntimeHttpEgressResponse, ScopedPath,
+    VirtualPath,
     runtime_policy::{
         DeploymentMode, FilesystemBackendKind, NetworkMode, ProcessBackendKind, SecretMode,
     },
@@ -193,7 +198,7 @@ impl InvocationServicesResolver for LocalInvocationServicesResolver {
         request: InvocationServicesResolutionRequest<'_>,
     ) -> Result<InvocationServices, InvocationServicesError> {
         let plan = request.plan;
-        validate_filesystem_plan(plan, request.mounts)?;
+        let filesystem = self.filesystem_for_plan(plan, request.mounts)?;
         let process = if plan.requires_process {
             match plan.process_backend {
                 ProcessBackendKind::LocalHost
@@ -226,7 +231,7 @@ impl InvocationServicesResolver for LocalInvocationServicesResolver {
             return Err(InvocationServicesError::SecretAccessRequired);
         }
         Ok(InvocationServices {
-            filesystem: Arc::clone(&self.filesystem),
+            filesystem,
             runtime_http_egress: plan
                 .requires_network
                 .then(|| self.runtime_http_egress.clone())
@@ -250,23 +255,247 @@ impl InvocationServicesResolver for LocalInvocationServicesResolver {
     }
 }
 
-fn validate_filesystem_plan(
-    plan: &ExecutionPlan,
-    mounts: Option<&MountView>,
-) -> Result<(), InvocationServicesError> {
-    if !plan.requires_filesystem {
-        return Ok(());
-    }
-    match plan.filesystem_backend {
-        FilesystemBackendKind::HostWorkspace | FilesystemBackendKind::HostWorkspaceAndHome
-            if matches!(plan.deployment, DeploymentMode::LocalSingleUser) =>
-        {
-            Ok(())
+impl LocalInvocationServicesResolver {
+    fn filesystem_for_plan(
+        &self,
+        plan: &ExecutionPlan,
+        mounts: Option<&MountView>,
+    ) -> Result<Arc<dyn RootFilesystem>, InvocationServicesError> {
+        if !plan.requires_filesystem {
+            return Ok(Arc::new(MountScopedRootFilesystem::new(
+                Arc::clone(&self.filesystem),
+                MountView::default(),
+            )));
         }
-        FilesystemBackendKind::ScopedVirtual if mounts.is_some() => Ok(()),
-        _ => Err(InvocationServicesError::UnsupportedFilesystemBackend {
-            backend: plan.filesystem_backend,
-        }),
+        match plan.filesystem_backend {
+            FilesystemBackendKind::HostWorkspace | FilesystemBackendKind::HostWorkspaceAndHome
+                if matches!(plan.deployment, DeploymentMode::LocalSingleUser) =>
+            {
+                Ok(Arc::clone(&self.filesystem))
+            }
+            FilesystemBackendKind::ScopedVirtual => {
+                let mounts =
+                    mounts.ok_or(InvocationServicesError::UnsupportedFilesystemBackend {
+                        backend: plan.filesystem_backend,
+                    })?;
+                Ok(Arc::new(MountScopedRootFilesystem::new(
+                    Arc::clone(&self.filesystem),
+                    mounts.clone(),
+                )))
+            }
+            _ => Err(InvocationServicesError::UnsupportedFilesystemBackend {
+                backend: plan.filesystem_backend,
+            }),
+        }
+    }
+}
+
+struct MountScopedRootFilesystem {
+    root: Arc<dyn RootFilesystem>,
+    mounts: MountView,
+}
+
+impl MountScopedRootFilesystem {
+    fn new(root: Arc<dyn RootFilesystem>, mounts: MountView) -> Self {
+        Self { root, mounts }
+    }
+
+    fn resolve(
+        &self,
+        path: &VirtualPath,
+        operation: FilesystemOperation,
+    ) -> Result<VirtualPath, FilesystemError> {
+        let Some(grant) = self
+            .mounts
+            .mounts
+            .iter()
+            .filter(|grant| virtual_path_in_mount(&grant.target, path))
+            .max_by_key(|grant| grant.target.as_str().len())
+        else {
+            return Err(permission_denied(path, operation));
+        };
+        if !operation_allowed(&grant.permissions, operation) {
+            return Err(permission_denied(path, operation));
+        }
+        Ok(path.clone())
+    }
+}
+
+fn permission_denied(path: &VirtualPath, operation: FilesystemOperation) -> FilesystemError {
+    match ScopedPath::new(path.as_str().to_string())
+        .or_else(|_| ScopedPath::new("/unauthorized".to_string()))
+    {
+        Ok(path) => FilesystemError::PermissionDenied { path, operation },
+        Err(error) => FilesystemError::Contract(error),
+    }
+}
+
+fn virtual_path_in_mount(mount_root: &VirtualPath, path: &VirtualPath) -> bool {
+    let mount_root = mount_root.as_str();
+    let path = path.as_str();
+    mount_root == "/"
+        || path == mount_root
+        || path
+            .strip_prefix(mount_root)
+            .is_some_and(|tail| tail.starts_with('/'))
+}
+
+fn operation_allowed(permissions: &MountPermissions, operation: FilesystemOperation) -> bool {
+    match operation {
+        FilesystemOperation::ReadFile => permissions.read,
+        FilesystemOperation::WriteFile
+        | FilesystemOperation::AppendFile
+        | FilesystemOperation::CreateDirAll
+        | FilesystemOperation::EnsureIndex
+        | FilesystemOperation::BeginTxn
+        | FilesystemOperation::Append => permissions.write,
+        FilesystemOperation::ListDir => permissions.list,
+        FilesystemOperation::Stat => permissions.read || permissions.list,
+        FilesystemOperation::Delete => permissions.delete,
+        FilesystemOperation::MountLocal | FilesystemOperation::Connect => false,
+        FilesystemOperation::Query => permissions.read && permissions.list,
+        FilesystemOperation::Tail | FilesystemOperation::HeadSeq => permissions.read,
+    }
+}
+
+#[async_trait]
+impl RootFilesystem for MountScopedRootFilesystem {
+    fn capabilities(&self) -> BackendCapabilities {
+        self.root.capabilities()
+    }
+
+    async fn put(
+        &self,
+        path: &VirtualPath,
+        entry: Entry,
+        cas: CasExpectation,
+    ) -> Result<RecordVersion, FilesystemError> {
+        let path = self.resolve(path, FilesystemOperation::WriteFile)?;
+        self.root.put(&path, entry, cas).await
+    }
+
+    async fn get(&self, path: &VirtualPath) -> Result<Option<VersionedEntry>, FilesystemError> {
+        let path = self.resolve(path, FilesystemOperation::ReadFile)?;
+        self.root.get(&path).await
+    }
+
+    async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
+        let path = self.resolve(path, FilesystemOperation::ListDir)?;
+        self.root.list_dir(&path).await
+    }
+
+    async fn list_dir_bounded(
+        &self,
+        path: &VirtualPath,
+        max_entries: usize,
+    ) -> Result<Vec<DirEntry>, FilesystemError> {
+        let path = self.resolve(path, FilesystemOperation::ListDir)?;
+        self.root.list_dir_bounded(&path, max_entries).await
+    }
+
+    async fn query(
+        &self,
+        path: &VirtualPath,
+        filter: &Filter,
+        page: Page,
+    ) -> Result<Vec<VersionedEntry>, FilesystemError> {
+        let path = self.resolve(path, FilesystemOperation::Query)?;
+        self.root.query(&path, filter, page).await
+    }
+
+    async fn ensure_index(
+        &self,
+        path: &VirtualPath,
+        spec: &IndexSpec,
+    ) -> Result<(), FilesystemError> {
+        let path = self.resolve(path, FilesystemOperation::EnsureIndex)?;
+        self.root.ensure_index(&path, spec).await
+    }
+
+    async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
+        let path = self.resolve(path, FilesystemOperation::Stat)?;
+        self.root.stat(&path).await
+    }
+
+    async fn read_file_bounded(
+        &self,
+        path: &VirtualPath,
+        max_bytes: usize,
+    ) -> Result<Option<Vec<u8>>, FilesystemError> {
+        let path = self.resolve(path, FilesystemOperation::ReadFile)?;
+        self.root.read_file_bounded(&path, max_bytes).await
+    }
+
+    async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
+        let path = self.resolve(path, FilesystemOperation::Delete)?;
+        self.root.delete(&path).await
+    }
+
+    async fn begin(&self, path: &VirtualPath) -> Result<Box<dyn StorageTxn>, FilesystemError> {
+        let path = self.resolve(path, FilesystemOperation::BeginTxn)?;
+        self.root.begin(&path).await
+    }
+
+    async fn append(&self, path: &VirtualPath, payload: Vec<u8>) -> Result<SeqNo, FilesystemError> {
+        let path = self.resolve(path, FilesystemOperation::Append)?;
+        self.root.append(&path, payload).await
+    }
+
+    async fn append_batch(
+        &self,
+        path: &VirtualPath,
+        payloads: Vec<Vec<u8>>,
+    ) -> Result<Vec<SeqNo>, FilesystemError> {
+        let path = self.resolve(path, FilesystemOperation::Append)?;
+        self.root.append_batch(&path, payloads).await
+    }
+
+    async fn tail(
+        &self,
+        path: &VirtualPath,
+        from: SeqNo,
+    ) -> Result<Vec<EventRecord>, FilesystemError> {
+        let path = self.resolve(path, FilesystemOperation::Tail)?;
+        self.root.tail(&path, from).await
+    }
+
+    async fn tail_bounded(
+        &self,
+        path: &VirtualPath,
+        from: SeqNo,
+        max_records: usize,
+    ) -> Result<Vec<EventRecord>, FilesystemError> {
+        let path = self.resolve(path, FilesystemOperation::Tail)?;
+        self.root.tail_bounded(&path, from, max_records).await
+    }
+
+    async fn head_seq(
+        &self,
+        path: &VirtualPath,
+        from: SeqNo,
+    ) -> Result<Option<SeqNo>, FilesystemError> {
+        let path = self.resolve(path, FilesystemOperation::HeadSeq)?;
+        self.root.head_seq(&path, from).await
+    }
+
+    async fn read_file(&self, path: &VirtualPath) -> Result<Vec<u8>, FilesystemError> {
+        let path = self.resolve(path, FilesystemOperation::ReadFile)?;
+        self.root.read_file(&path).await
+    }
+
+    async fn write_file(&self, path: &VirtualPath, bytes: &[u8]) -> Result<(), FilesystemError> {
+        let path = self.resolve(path, FilesystemOperation::WriteFile)?;
+        self.root.write_file(&path, bytes).await
+    }
+
+    async fn append_file(&self, path: &VirtualPath, bytes: &[u8]) -> Result<(), FilesystemError> {
+        let path = self.resolve(path, FilesystemOperation::AppendFile)?;
+        self.root.append_file(&path, bytes).await
+    }
+
+    async fn create_dir_all(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
+        let path = self.resolve(path, FilesystemOperation::CreateDirAll)?;
+        self.root.create_dir_all(&path).await
     }
 }
 
@@ -305,775 +534,4 @@ fn validate_secret_plan(plan: &ExecutionPlan) -> Result<(), InvocationServicesEr
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use async_trait::async_trait;
-    use ironclaw_filesystem::LocalFilesystem;
-    use ironclaw_host_api::{
-        CapabilityId, MountAlias, MountGrant, MountPermissions, ResourceScope, VirtualPath,
-        runtime_policy::{RuntimeProfile, SecretMode},
-    };
-    use ironclaw_secrets::InMemorySecretStore;
-
-    use crate::{
-        CommandExecutionOutput, CommandExecutionRequest, RuntimeProcessError, RuntimeProcessPort,
-    };
-
-    #[derive(Debug)]
-    struct NoopProcessPort;
-
-    #[derive(Debug)]
-    struct NamedProcessPort(&'static str);
-
-    #[async_trait]
-    impl RuntimeProcessPort for NoopProcessPort {
-        async fn run_command(
-            &self,
-            _request: CommandExecutionRequest,
-        ) -> Result<CommandExecutionOutput, RuntimeProcessError> {
-            unreachable!("resolver tests must not execute commands")
-        }
-    }
-
-    struct NoopRuntimeHttpEgress;
-
-    #[async_trait]
-    impl ironclaw_host_api::RuntimeHttpEgress for NoopRuntimeHttpEgress {
-        async fn execute(
-            &self,
-            _request: ironclaw_host_api::RuntimeHttpEgressRequest,
-        ) -> Result<
-            ironclaw_host_api::RuntimeHttpEgressResponse,
-            ironclaw_host_api::RuntimeHttpEgressError,
-        > {
-            unreachable!("resolver tests must not execute HTTP requests")
-        }
-    }
-
-    #[async_trait]
-    impl RuntimeProcessPort for NamedProcessPort {
-        async fn run_command(
-            &self,
-            _request: CommandExecutionRequest,
-        ) -> Result<CommandExecutionOutput, RuntimeProcessError> {
-            Ok(CommandExecutionOutput {
-                output: self.0.to_string(),
-                saved_output: None,
-                exit_code: 0,
-                sandboxed: false,
-                duration: std::time::Duration::ZERO,
-            })
-        }
-    }
-
-    #[test]
-    fn local_resolver_accepts_local_required_process_backend() {
-        let resolver = resolver_without_http();
-        let plan = plan(
-            ProcessBackendKind::LocalHost,
-            true,
-            false,
-            NetworkMode::DirectLogged,
-            false,
-        );
-
-        let services = resolver
-            .resolve(InvocationServicesResolutionRequest {
-                plan: &plan,
-                scope: &ResourceScope::system(),
-                mounts: None,
-            })
-            .unwrap();
-
-        assert!(services.runtime_http_egress.is_none());
-    }
-
-    #[test]
-    fn local_resolver_rejects_sandbox_process_backend_without_local_fallback() {
-        let resolver = resolver_without_http();
-        let plan = plan(
-            ProcessBackendKind::TenantSandbox,
-            true,
-            false,
-            NetworkMode::Allowlist,
-            false,
-        );
-
-        let error = resolver
-            .resolve(InvocationServicesResolutionRequest {
-                plan: &plan,
-                scope: &ResourceScope::system(),
-                mounts: None,
-            })
-            .unwrap_err();
-
-        assert_eq!(error.kind(), RuntimeDispatchErrorKind::UnsupportedRunner);
-        assert!(matches!(
-            error,
-            InvocationServicesError::UnsupportedProcessBackend {
-                backend: ProcessBackendKind::TenantSandbox
-            }
-        ));
-    }
-
-    #[tokio::test]
-    async fn local_resolver_uses_configured_sandbox_process_backend() {
-        let resolver = resolver_without_http()
-            .with_tenant_sandbox_process_port(Arc::new(NamedProcessPort("sandbox")));
-        let plan = plan(
-            ProcessBackendKind::TenantSandbox,
-            true,
-            false,
-            NetworkMode::Allowlist,
-            false,
-        );
-
-        let services = resolver
-            .resolve(InvocationServicesResolutionRequest {
-                plan: &plan,
-                scope: &ResourceScope::system(),
-                mounts: None,
-            })
-            .unwrap();
-
-        let output = services
-            .process
-            .run_command(CommandExecutionRequest {
-                scope: ResourceScope::system(),
-                mounts: None,
-                command: "echo hi".to_string(),
-                workdir: None,
-                timeout_secs: None,
-                extra_env: Default::default(),
-            })
-            .await
-            .unwrap();
-        assert_eq!(output.output, "sandbox");
-    }
-
-    #[test]
-    fn local_resolver_rejects_unsupported_required_process_backend() {
-        let resolver = resolver_without_http();
-        let plan = plan(
-            ProcessBackendKind::Docker,
-            true,
-            false,
-            NetworkMode::Deny,
-            false,
-        );
-
-        let error = resolver
-            .resolve(InvocationServicesResolutionRequest {
-                plan: &plan,
-                scope: &ResourceScope::system(),
-                mounts: None,
-            })
-            .unwrap_err();
-
-        assert_eq!(error.kind(), RuntimeDispatchErrorKind::UnsupportedRunner);
-        assert!(matches!(
-            error,
-            InvocationServicesError::UnsupportedProcessBackend {
-                backend: ProcessBackendKind::Docker
-            }
-        ));
-    }
-
-    #[test]
-    fn local_resolver_does_not_require_process_for_pure_plan() {
-        let resolver = resolver_without_http();
-        let plan = plan(
-            ProcessBackendKind::None,
-            false,
-            false,
-            NetworkMode::Deny,
-            false,
-        );
-
-        resolver
-            .resolve(InvocationServicesResolutionRequest {
-                plan: &plan,
-                scope: &ResourceScope::system(),
-                mounts: None,
-            })
-            .unwrap();
-    }
-
-    #[test]
-    fn local_resolver_rejects_unsupported_filesystem_backend() {
-        let resolver = resolver_without_http();
-        let mut plan = plan(
-            ProcessBackendKind::None,
-            false,
-            false,
-            NetworkMode::Deny,
-            false,
-        );
-        plan.requires_filesystem = true;
-        plan.filesystem_backend = FilesystemBackendKind::TenantWorkspace;
-
-        let error = resolver
-            .resolve(InvocationServicesResolutionRequest {
-                plan: &plan,
-                scope: &ResourceScope::system(),
-                mounts: None,
-            })
-            .unwrap_err();
-
-        assert_eq!(error.kind(), RuntimeDispatchErrorKind::FilesystemDenied);
-        assert!(matches!(
-            error,
-            InvocationServicesError::UnsupportedFilesystemBackend {
-                backend: FilesystemBackendKind::TenantWorkspace
-            }
-        ));
-    }
-
-    #[test]
-    fn local_resolver_accepts_host_workspace_and_home_when_filesystem_required() {
-        let resolver = resolver_without_http();
-        let mut plan = plan(
-            ProcessBackendKind::None,
-            false,
-            false,
-            NetworkMode::Deny,
-            false,
-        );
-        plan.requires_filesystem = true;
-        plan.filesystem_backend = FilesystemBackendKind::HostWorkspaceAndHome;
-
-        let services = resolver
-            .resolve(InvocationServicesResolutionRequest {
-                plan: &plan,
-                scope: &ResourceScope::system(),
-                mounts: None,
-            })
-            .expect("local-yolo filesystem backend should resolve");
-
-        assert!(services.runtime_http_egress.is_none());
-    }
-
-    #[test]
-    fn local_resolver_accepts_hosted_scoped_virtual_filesystem_with_mounts() {
-        let resolver = resolver_without_http();
-        let mut plan = plan(
-            ProcessBackendKind::None,
-            false,
-            false,
-            NetworkMode::Deny,
-            false,
-        );
-        plan.deployment = DeploymentMode::HostedMultiTenant;
-        plan.resolved_profile = RuntimeProfile::SecureDefault;
-        plan.requires_filesystem = true;
-        plan.filesystem_backend = FilesystemBackendKind::ScopedVirtual;
-        let mounts = scoped_mount_view();
-
-        let services = resolver
-            .resolve(InvocationServicesResolutionRequest {
-                plan: &plan,
-                scope: &ResourceScope::system(),
-                mounts: Some(&mounts),
-            })
-            .expect("hosted scoped virtual filesystem should resolve with explicit mounts");
-
-        assert!(services.runtime_http_egress.is_none());
-    }
-
-    #[test]
-    fn local_resolver_rejects_hosted_scoped_virtual_filesystem_without_mounts() {
-        let resolver = resolver_without_http();
-        let mut plan = plan(
-            ProcessBackendKind::None,
-            false,
-            false,
-            NetworkMode::Deny,
-            false,
-        );
-        plan.deployment = DeploymentMode::HostedMultiTenant;
-        plan.resolved_profile = RuntimeProfile::SecureDefault;
-        plan.requires_filesystem = true;
-        plan.filesystem_backend = FilesystemBackendKind::ScopedVirtual;
-
-        let error = resolver
-            .resolve(InvocationServicesResolutionRequest {
-                plan: &plan,
-                scope: &ResourceScope::system(),
-                mounts: None,
-            })
-            .unwrap_err();
-
-        assert_eq!(error.kind(), RuntimeDispatchErrorKind::FilesystemDenied);
-        assert!(matches!(
-            error,
-            InvocationServicesError::UnsupportedFilesystemBackend {
-                backend: FilesystemBackendKind::ScopedVirtual
-            }
-        ));
-    }
-
-    #[test]
-    fn local_resolver_ignores_unsupported_filesystem_backend_when_not_required() {
-        let resolver = resolver_without_http();
-        let mut plan = plan(
-            ProcessBackendKind::None,
-            false,
-            false,
-            NetworkMode::Deny,
-            false,
-        );
-        plan.filesystem_backend = FilesystemBackendKind::TenantWorkspace;
-
-        resolver
-            .resolve(InvocationServicesResolutionRequest {
-                plan: &plan,
-                scope: &ResourceScope::system(),
-                mounts: None,
-            })
-            .expect("unused filesystem backend must not block pure invocations");
-    }
-
-    #[test]
-    fn local_resolver_rejects_denied_required_network() {
-        let resolver = resolver_without_http();
-        let plan = plan(
-            ProcessBackendKind::None,
-            false,
-            true,
-            NetworkMode::Deny,
-            false,
-        );
-
-        let error = resolver
-            .resolve(InvocationServicesResolutionRequest {
-                plan: &plan,
-                scope: &ResourceScope::system(),
-                mounts: None,
-            })
-            .unwrap_err();
-
-        assert_eq!(error.kind(), RuntimeDispatchErrorKind::NetworkDenied);
-        assert!(matches!(
-            error,
-            InvocationServicesError::UnsupportedNetworkMode {
-                mode: NetworkMode::Deny
-            }
-        ));
-    }
-
-    #[test]
-    fn local_resolver_rejects_required_network_when_egress_service_is_absent() {
-        let resolver = resolver_without_http();
-        let plan = plan(
-            ProcessBackendKind::None,
-            false,
-            true,
-            NetworkMode::DirectLogged,
-            false,
-        );
-
-        let error = resolver
-            .resolve(InvocationServicesResolutionRequest {
-                plan: &plan,
-                scope: &ResourceScope::system(),
-                mounts: None,
-            })
-            .unwrap_err();
-
-        assert_eq!(error.kind(), RuntimeDispatchErrorKind::NetworkDenied);
-        assert!(matches!(
-            error,
-            InvocationServicesError::UnsupportedNetworkMode {
-                mode: NetworkMode::DirectLogged
-            }
-        ));
-    }
-
-    #[test]
-    fn local_resolver_accepts_brokered_required_network_with_egress_service() {
-        let resolver = LocalInvocationServicesResolver::new(
-            Arc::new(LocalFilesystem::new()),
-            Some(Arc::new(NoopRuntimeHttpEgress)),
-            Arc::new(NoopProcessPort),
-            None,
-        );
-        let plan = plan(
-            ProcessBackendKind::None,
-            false,
-            true,
-            NetworkMode::Brokered,
-            false,
-        );
-
-        let services = resolver
-            .resolve(InvocationServicesResolutionRequest {
-                plan: &plan,
-                scope: &ResourceScope::system(),
-                mounts: None,
-            })
-            .unwrap();
-
-        assert!(services.runtime_http_egress.is_some());
-    }
-
-    #[test]
-    fn local_resolver_accepts_hosted_brokered_required_network() {
-        let resolver = LocalInvocationServicesResolver::new(
-            Arc::new(LocalFilesystem::new()),
-            Some(Arc::new(NoopRuntimeHttpEgress)),
-            Arc::new(NoopProcessPort),
-            None,
-        );
-        let mut plan = plan(
-            ProcessBackendKind::None,
-            false,
-            true,
-            NetworkMode::Brokered,
-            false,
-        );
-        plan.deployment = DeploymentMode::HostedMultiTenant;
-        plan.resolved_profile = RuntimeProfile::HostedSafe;
-
-        let services = resolver
-            .resolve(InvocationServicesResolutionRequest {
-                plan: &plan,
-                scope: &ResourceScope::system(),
-                mounts: None,
-            })
-            .expect("hosted brokered network should resolve through host egress");
-
-        assert!(services.runtime_http_egress.is_some());
-    }
-
-    #[test]
-    fn local_resolver_rejects_hosted_direct_required_network() {
-        let resolver = LocalInvocationServicesResolver::new(
-            Arc::new(LocalFilesystem::new()),
-            Some(Arc::new(NoopRuntimeHttpEgress)),
-            Arc::new(NoopProcessPort),
-            None,
-        );
-        let mut plan = plan(
-            ProcessBackendKind::None,
-            false,
-            true,
-            NetworkMode::Direct,
-            false,
-        );
-        plan.deployment = DeploymentMode::HostedMultiTenant;
-        plan.resolved_profile = RuntimeProfile::HostedSafe;
-
-        let error = resolver
-            .resolve(InvocationServicesResolutionRequest {
-                plan: &plan,
-                scope: &ResourceScope::system(),
-                mounts: None,
-            })
-            .unwrap_err();
-
-        assert_eq!(error.kind(), RuntimeDispatchErrorKind::NetworkDenied);
-        assert!(matches!(
-            error,
-            InvocationServicesError::UnsupportedNetworkMode {
-                mode: NetworkMode::Direct
-            }
-        ));
-    }
-
-    #[test]
-    fn local_resolver_accepts_direct_required_network_with_egress_service() {
-        let resolver = LocalInvocationServicesResolver::new(
-            Arc::new(LocalFilesystem::new()),
-            Some(Arc::new(NoopRuntimeHttpEgress)),
-            Arc::new(NoopProcessPort),
-            None,
-        );
-        let plan = plan(
-            ProcessBackendKind::None,
-            false,
-            true,
-            NetworkMode::Direct,
-            false,
-        );
-
-        let services = resolver
-            .resolve(InvocationServicesResolutionRequest {
-                plan: &plan,
-                scope: &ResourceScope::system(),
-                mounts: None,
-            })
-            .unwrap();
-
-        assert!(services.runtime_http_egress.is_some());
-    }
-
-    #[test]
-    fn local_resolver_allows_raw_diagnostics_only_for_local_dev_and_yolo() {
-        let resolver = LocalInvocationServicesResolver::new(
-            Arc::new(LocalFilesystem::new()),
-            Some(Arc::new(NoopRuntimeHttpEgress)),
-            Arc::new(NoopProcessPort),
-            None,
-        );
-        let mut plan = plan(
-            ProcessBackendKind::None,
-            false,
-            true,
-            NetworkMode::Direct,
-            false,
-        );
-
-        plan.resolved_profile = RuntimeProfile::LocalSafe;
-        let services = resolver
-            .resolve(InvocationServicesResolutionRequest {
-                plan: &plan,
-                scope: &ResourceScope::system(),
-                mounts: None,
-            })
-            .unwrap();
-        assert!(!services.unsafe_raw_diagnostics_allowed);
-
-        plan.resolved_profile = RuntimeProfile::LocalDev;
-        let services = resolver
-            .resolve(InvocationServicesResolutionRequest {
-                plan: &plan,
-                scope: &ResourceScope::system(),
-                mounts: None,
-            })
-            .unwrap();
-        assert!(services.unsafe_raw_diagnostics_allowed);
-
-        plan.resolved_profile = RuntimeProfile::LocalYolo;
-        let services = resolver
-            .resolve(InvocationServicesResolutionRequest {
-                plan: &plan,
-                scope: &ResourceScope::system(),
-                mounts: None,
-            })
-            .unwrap();
-        assert!(services.unsafe_raw_diagnostics_allowed);
-    }
-
-    #[test]
-    fn local_resolver_hides_runtime_http_egress_when_network_is_not_required() {
-        let resolver = LocalInvocationServicesResolver::new(
-            Arc::new(LocalFilesystem::new()),
-            Some(Arc::new(NoopRuntimeHttpEgress)),
-            Arc::new(NoopProcessPort),
-            None,
-        );
-        let plan = plan(
-            ProcessBackendKind::None,
-            false,
-            false,
-            NetworkMode::DirectLogged,
-            false,
-        );
-
-        let services = resolver
-            .resolve(InvocationServicesResolutionRequest {
-                plan: &plan,
-                scope: &ResourceScope::system(),
-                mounts: None,
-            })
-            .unwrap();
-
-        assert!(services.runtime_http_egress.is_none());
-    }
-
-    #[test]
-    fn local_resolver_hides_secret_store_when_secret_is_not_required() {
-        let resolver = LocalInvocationServicesResolver::new(
-            Arc::new(LocalFilesystem::new()),
-            None,
-            Arc::new(NoopProcessPort),
-            Some(Arc::new(InMemorySecretStore::new())),
-        );
-        let plan = plan(
-            ProcessBackendKind::None,
-            false,
-            false,
-            NetworkMode::Deny,
-            false,
-        );
-
-        let services = resolver
-            .resolve(InvocationServicesResolutionRequest {
-                plan: &plan,
-                scope: &ResourceScope::system(),
-                mounts: None,
-            })
-            .unwrap();
-
-        assert!(services.secret_store.is_none());
-    }
-
-    #[test]
-    fn local_resolver_rejects_required_secret_when_secret_store_is_absent() {
-        let resolver = resolver_without_http();
-        let plan = plan(
-            ProcessBackendKind::None,
-            false,
-            false,
-            NetworkMode::Deny,
-            true,
-        );
-
-        let error = resolver
-            .resolve(InvocationServicesResolutionRequest {
-                plan: &plan,
-                scope: &ResourceScope::system(),
-                mounts: None,
-            })
-            .unwrap_err();
-
-        assert_eq!(error.kind(), RuntimeDispatchErrorKind::SecretDenied);
-        assert!(matches!(
-            error,
-            InvocationServicesError::SecretAccessRequired
-        ));
-    }
-
-    #[test]
-    fn local_resolver_accepts_brokered_required_secret_with_secret_store() {
-        let resolver = LocalInvocationServicesResolver::new(
-            Arc::new(LocalFilesystem::new()),
-            None,
-            Arc::new(NoopProcessPort),
-            Some(Arc::new(InMemorySecretStore::new())),
-        );
-        let mut plan = plan(
-            ProcessBackendKind::None,
-            false,
-            false,
-            NetworkMode::Deny,
-            true,
-        );
-        plan.secret_mode = SecretMode::BrokeredHandles;
-
-        let services = resolver
-            .resolve(InvocationServicesResolutionRequest {
-                plan: &plan,
-                scope: &ResourceScope::system(),
-                mounts: None,
-            })
-            .expect("brokered handles should resolve with a configured secret store");
-
-        assert!(services.secret_store.is_some());
-    }
-
-    #[test]
-    fn local_resolver_rejects_hosted_inherited_env_secret() {
-        let resolver = LocalInvocationServicesResolver::new(
-            Arc::new(LocalFilesystem::new()),
-            None,
-            Arc::new(NoopProcessPort),
-            Some(Arc::new(InMemorySecretStore::new())),
-        );
-        let mut plan = plan(
-            ProcessBackendKind::None,
-            false,
-            false,
-            NetworkMode::Deny,
-            true,
-        );
-        plan.deployment = DeploymentMode::HostedMultiTenant;
-        plan.resolved_profile = RuntimeProfile::HostedSafe;
-        plan.secret_mode = SecretMode::InheritedEnv;
-
-        let error = resolver
-            .resolve(InvocationServicesResolutionRequest {
-                plan: &plan,
-                scope: &ResourceScope::system(),
-                mounts: None,
-            })
-            .unwrap_err();
-
-        assert_eq!(error.kind(), RuntimeDispatchErrorKind::SecretDenied);
-        assert!(matches!(
-            error,
-            InvocationServicesError::UnsupportedSecretMode {
-                mode: SecretMode::InheritedEnv
-            }
-        ));
-    }
-
-    #[test]
-    fn local_resolver_accepts_required_secret_when_secret_store_is_available() {
-        let resolver = LocalInvocationServicesResolver::new(
-            Arc::new(LocalFilesystem::new()),
-            None,
-            Arc::new(NoopProcessPort),
-            Some(Arc::new(InMemorySecretStore::new())),
-        );
-        let plan = plan(
-            ProcessBackendKind::None,
-            false,
-            false,
-            NetworkMode::Deny,
-            true,
-        );
-
-        let services = resolver
-            .resolve(InvocationServicesResolutionRequest {
-                plan: &plan,
-                scope: &ResourceScope::system(),
-                mounts: None,
-            })
-            .unwrap();
-
-        assert!(services.secret_store.is_some());
-    }
-
-    #[test]
-    fn first_party_tools_do_not_select_process_backends() {
-        let sources = [
-            include_str!("first_party_tools/shell.rs"),
-            include_str!("first_party_tools/http.rs"),
-        ];
-        for source in sources {
-            assert!(!source.contains("ProcessBackendKind"));
-            assert!(!source.contains("FilesystemBackendKind"));
-        }
-    }
-
-    fn resolver_without_http() -> LocalInvocationServicesResolver {
-        LocalInvocationServicesResolver::new(
-            Arc::new(LocalFilesystem::new()),
-            None,
-            Arc::new(NoopProcessPort),
-            None,
-        )
-    }
-
-    fn scoped_mount_view() -> MountView {
-        MountView::new(vec![MountGrant::new(
-            MountAlias::new("/system/extensions".to_string()).expect("mount alias"),
-            VirtualPath::new("/system/extensions".to_string()).expect("virtual path"),
-            MountPermissions::read_only(),
-        )])
-        .expect("mount view")
-    }
-
-    fn plan(
-        process_backend: ProcessBackendKind,
-        requires_process: bool,
-        requires_network: bool,
-        network_mode: NetworkMode,
-        requires_secret: bool,
-    ) -> ExecutionPlan {
-        ExecutionPlan {
-            capability: CapabilityId::new("test.capability".to_string()).unwrap(),
-            deployment: DeploymentMode::LocalSingleUser,
-            resolved_profile: RuntimeProfile::LocalDev,
-            filesystem_backend: FilesystemBackendKind::HostWorkspace,
-            process_backend,
-            network_mode,
-            secret_mode: SecretMode::ScrubbedEnv,
-            requires_filesystem: false,
-            requires_process,
-            requires_network,
-            requires_secret,
-        }
-    }
-}
+mod tests;

--- a/crates/ironclaw_host_runtime/src/invocation_services.rs
+++ b/crates/ironclaw_host_runtime/src/invocation_services.rs
@@ -505,6 +505,14 @@ fn validate_network_plan(plan: &ExecutionPlan) -> Result<(), InvocationServicesE
     }
     match plan.network_mode {
         NetworkMode::Brokered => Ok(()),
+        NetworkMode::Allowlist
+            if matches!(
+                plan.deployment,
+                DeploymentMode::HostedMultiTenant | DeploymentMode::EnterpriseDedicated
+            ) =>
+        {
+            Ok(())
+        }
         NetworkMode::DirectLogged | NetworkMode::Direct
             if matches!(plan.deployment, DeploymentMode::LocalSingleUser) =>
         {
@@ -521,7 +529,7 @@ fn validate_secret_plan(plan: &ExecutionPlan) -> Result<(), InvocationServicesEr
         return Ok(());
     }
     match plan.secret_mode {
-        SecretMode::BrokeredHandles => Ok(()),
+        SecretMode::BrokeredHandles | SecretMode::TenantBroker | SecretMode::OrgBroker => Ok(()),
         SecretMode::ScrubbedEnv | SecretMode::InheritedEnv
             if matches!(plan.deployment, DeploymentMode::LocalSingleUser) =>
         {

--- a/crates/ironclaw_host_runtime/src/invocation_services.rs
+++ b/crates/ironclaw_host_runtime/src/invocation_services.rs
@@ -193,22 +193,14 @@ impl InvocationServicesResolver for LocalInvocationServicesResolver {
         request: InvocationServicesResolutionRequest<'_>,
     ) -> Result<InvocationServices, InvocationServicesError> {
         let plan = request.plan;
-        if !matches!(plan.deployment, DeploymentMode::LocalSingleUser) {
-            return Err(unsupported_non_local_plan(plan));
-        }
-        if plan.requires_filesystem
-            && !matches!(
-                plan.filesystem_backend,
-                FilesystemBackendKind::HostWorkspace | FilesystemBackendKind::HostWorkspaceAndHome
-            )
-        {
-            return Err(InvocationServicesError::UnsupportedFilesystemBackend {
-                backend: plan.filesystem_backend,
-            });
-        }
+        validate_filesystem_plan(plan, request.mounts)?;
         let process = if plan.requires_process {
             match plan.process_backend {
-                ProcessBackendKind::LocalHost => Arc::clone(&self.process),
+                ProcessBackendKind::LocalHost
+                    if matches!(plan.deployment, DeploymentMode::LocalSingleUser) =>
+                {
+                    Arc::clone(&self.process)
+                }
                 ProcessBackendKind::TenantSandbox => self.tenant_sandbox_process.clone().ok_or(
                     InvocationServicesError::UnsupportedProcessBackend {
                         backend: plan.process_backend,
@@ -223,31 +215,13 @@ impl InvocationServicesResolver for LocalInvocationServicesResolver {
         } else {
             Arc::clone(&self.process)
         };
-        if plan.requires_network
-            && !matches!(
-                plan.network_mode,
-                NetworkMode::Brokered | NetworkMode::DirectLogged | NetworkMode::Direct
-            )
-        {
-            return Err(InvocationServicesError::UnsupportedNetworkMode {
-                mode: plan.network_mode,
-            });
-        }
+        validate_network_plan(plan)?;
         if plan.requires_network && self.runtime_http_egress.is_none() {
             return Err(InvocationServicesError::UnsupportedNetworkMode {
                 mode: plan.network_mode,
             });
         }
-        if plan.requires_secret
-            && !matches!(
-                plan.secret_mode,
-                SecretMode::ScrubbedEnv | SecretMode::InheritedEnv
-            )
-        {
-            return Err(InvocationServicesError::UnsupportedSecretMode {
-                mode: plan.secret_mode,
-            });
-        }
+        validate_secret_plan(plan)?;
         if plan.requires_secret && self.secret_store.is_none() {
             return Err(InvocationServicesError::SecretAccessRequired);
         }
@@ -276,29 +250,57 @@ impl InvocationServicesResolver for LocalInvocationServicesResolver {
     }
 }
 
-fn unsupported_non_local_plan(plan: &ExecutionPlan) -> InvocationServicesError {
-    if plan.requires_filesystem {
-        return InvocationServicesError::UnsupportedFilesystemBackend {
+fn validate_filesystem_plan(
+    plan: &ExecutionPlan,
+    mounts: Option<&MountView>,
+) -> Result<(), InvocationServicesError> {
+    if !plan.requires_filesystem {
+        return Ok(());
+    }
+    match plan.filesystem_backend {
+        FilesystemBackendKind::HostWorkspace | FilesystemBackendKind::HostWorkspaceAndHome
+            if matches!(plan.deployment, DeploymentMode::LocalSingleUser) =>
+        {
+            Ok(())
+        }
+        FilesystemBackendKind::ScopedVirtual if mounts.is_some() => Ok(()),
+        _ => Err(InvocationServicesError::UnsupportedFilesystemBackend {
             backend: plan.filesystem_backend,
-        };
+        }),
     }
-    if plan.requires_process {
-        return InvocationServicesError::UnsupportedProcessBackend {
-            backend: plan.process_backend,
-        };
+}
+
+fn validate_network_plan(plan: &ExecutionPlan) -> Result<(), InvocationServicesError> {
+    if !plan.requires_network {
+        return Ok(());
     }
-    if plan.requires_network {
-        return InvocationServicesError::UnsupportedNetworkMode {
+    match plan.network_mode {
+        NetworkMode::Brokered => Ok(()),
+        NetworkMode::DirectLogged | NetworkMode::Direct
+            if matches!(plan.deployment, DeploymentMode::LocalSingleUser) =>
+        {
+            Ok(())
+        }
+        _ => Err(InvocationServicesError::UnsupportedNetworkMode {
             mode: plan.network_mode,
-        };
+        }),
     }
-    if plan.requires_secret {
-        return InvocationServicesError::UnsupportedSecretMode {
+}
+
+fn validate_secret_plan(plan: &ExecutionPlan) -> Result<(), InvocationServicesError> {
+    if !plan.requires_secret {
+        return Ok(());
+    }
+    match plan.secret_mode {
+        SecretMode::BrokeredHandles => Ok(()),
+        SecretMode::ScrubbedEnv | SecretMode::InheritedEnv
+            if matches!(plan.deployment, DeploymentMode::LocalSingleUser) =>
+        {
+            Ok(())
+        }
+        _ => Err(InvocationServicesError::UnsupportedSecretMode {
             mode: plan.secret_mode,
-        };
-    }
-    InvocationServicesError::UnsupportedProcessBackend {
-        backend: plan.process_backend,
+        }),
     }
 }
 
@@ -308,7 +310,7 @@ mod tests {
     use async_trait::async_trait;
     use ironclaw_filesystem::LocalFilesystem;
     use ironclaw_host_api::{
-        CapabilityId, ResourceScope,
+        CapabilityId, MountAlias, MountGrant, MountPermissions, ResourceScope, VirtualPath,
         runtime_policy::{RuntimeProfile, SecretMode},
     };
     use ironclaw_secrets::InMemorySecretStore;
@@ -552,6 +554,65 @@ mod tests {
     }
 
     #[test]
+    fn local_resolver_accepts_hosted_scoped_virtual_filesystem_with_mounts() {
+        let resolver = resolver_without_http();
+        let mut plan = plan(
+            ProcessBackendKind::None,
+            false,
+            false,
+            NetworkMode::Deny,
+            false,
+        );
+        plan.deployment = DeploymentMode::HostedMultiTenant;
+        plan.resolved_profile = RuntimeProfile::SecureDefault;
+        plan.requires_filesystem = true;
+        plan.filesystem_backend = FilesystemBackendKind::ScopedVirtual;
+        let mounts = scoped_mount_view();
+
+        let services = resolver
+            .resolve(InvocationServicesResolutionRequest {
+                plan: &plan,
+                scope: &ResourceScope::system(),
+                mounts: Some(&mounts),
+            })
+            .expect("hosted scoped virtual filesystem should resolve with explicit mounts");
+
+        assert!(services.runtime_http_egress.is_none());
+    }
+
+    #[test]
+    fn local_resolver_rejects_hosted_scoped_virtual_filesystem_without_mounts() {
+        let resolver = resolver_without_http();
+        let mut plan = plan(
+            ProcessBackendKind::None,
+            false,
+            false,
+            NetworkMode::Deny,
+            false,
+        );
+        plan.deployment = DeploymentMode::HostedMultiTenant;
+        plan.resolved_profile = RuntimeProfile::SecureDefault;
+        plan.requires_filesystem = true;
+        plan.filesystem_backend = FilesystemBackendKind::ScopedVirtual;
+
+        let error = resolver
+            .resolve(InvocationServicesResolutionRequest {
+                plan: &plan,
+                scope: &ResourceScope::system(),
+                mounts: None,
+            })
+            .unwrap_err();
+
+        assert_eq!(error.kind(), RuntimeDispatchErrorKind::FilesystemDenied);
+        assert!(matches!(
+            error,
+            InvocationServicesError::UnsupportedFilesystemBackend {
+                backend: FilesystemBackendKind::ScopedVirtual
+            }
+        ));
+    }
+
+    #[test]
     fn local_resolver_ignores_unsupported_filesystem_backend_when_not_required() {
         let resolver = resolver_without_http();
         let mut plan = plan(
@@ -656,7 +717,7 @@ mod tests {
     }
 
     #[test]
-    fn local_resolver_rejects_hosted_brokered_required_network() {
+    fn local_resolver_accepts_hosted_brokered_required_network() {
         let resolver = LocalInvocationServicesResolver::new(
             Arc::new(LocalFilesystem::new()),
             Some(Arc::new(NoopRuntimeHttpEgress)),
@@ -668,6 +729,35 @@ mod tests {
             false,
             true,
             NetworkMode::Brokered,
+            false,
+        );
+        plan.deployment = DeploymentMode::HostedMultiTenant;
+        plan.resolved_profile = RuntimeProfile::HostedSafe;
+
+        let services = resolver
+            .resolve(InvocationServicesResolutionRequest {
+                plan: &plan,
+                scope: &ResourceScope::system(),
+                mounts: None,
+            })
+            .expect("hosted brokered network should resolve through host egress");
+
+        assert!(services.runtime_http_egress.is_some());
+    }
+
+    #[test]
+    fn local_resolver_rejects_hosted_direct_required_network() {
+        let resolver = LocalInvocationServicesResolver::new(
+            Arc::new(LocalFilesystem::new()),
+            Some(Arc::new(NoopRuntimeHttpEgress)),
+            Arc::new(NoopProcessPort),
+            None,
+        );
+        let mut plan = plan(
+            ProcessBackendKind::None,
+            false,
+            true,
+            NetworkMode::Direct,
             false,
         );
         plan.deployment = DeploymentMode::HostedMultiTenant;
@@ -685,7 +775,7 @@ mod tests {
         assert!(matches!(
             error,
             InvocationServicesError::UnsupportedNetworkMode {
-                mode: NetworkMode::Brokered
+                mode: NetworkMode::Direct
             }
         ));
     }
@@ -845,7 +935,7 @@ mod tests {
     }
 
     #[test]
-    fn local_resolver_rejects_brokered_required_secret_even_with_secret_store() {
+    fn local_resolver_accepts_brokered_required_secret_with_secret_store() {
         let resolver = LocalInvocationServicesResolver::new(
             Arc::new(LocalFilesystem::new()),
             None,
@@ -861,6 +951,36 @@ mod tests {
         );
         plan.secret_mode = SecretMode::BrokeredHandles;
 
+        let services = resolver
+            .resolve(InvocationServicesResolutionRequest {
+                plan: &plan,
+                scope: &ResourceScope::system(),
+                mounts: None,
+            })
+            .expect("brokered handles should resolve with a configured secret store");
+
+        assert!(services.secret_store.is_some());
+    }
+
+    #[test]
+    fn local_resolver_rejects_hosted_inherited_env_secret() {
+        let resolver = LocalInvocationServicesResolver::new(
+            Arc::new(LocalFilesystem::new()),
+            None,
+            Arc::new(NoopProcessPort),
+            Some(Arc::new(InMemorySecretStore::new())),
+        );
+        let mut plan = plan(
+            ProcessBackendKind::None,
+            false,
+            false,
+            NetworkMode::Deny,
+            true,
+        );
+        plan.deployment = DeploymentMode::HostedMultiTenant;
+        plan.resolved_profile = RuntimeProfile::HostedSafe;
+        plan.secret_mode = SecretMode::InheritedEnv;
+
         let error = resolver
             .resolve(InvocationServicesResolutionRequest {
                 plan: &plan,
@@ -873,7 +993,7 @@ mod tests {
         assert!(matches!(
             error,
             InvocationServicesError::UnsupportedSecretMode {
-                mode: SecretMode::BrokeredHandles
+                mode: SecretMode::InheritedEnv
             }
         ));
     }
@@ -924,6 +1044,15 @@ mod tests {
             Arc::new(NoopProcessPort),
             None,
         )
+    }
+
+    fn scoped_mount_view() -> MountView {
+        MountView::new(vec![MountGrant::new(
+            MountAlias::new("/system/extensions".to_string()).expect("mount alias"),
+            VirtualPath::new("/system/extensions".to_string()).expect("virtual path"),
+            MountPermissions::read_only(),
+        )])
+        .expect("mount view")
     }
 
     fn plan(

--- a/crates/ironclaw_host_runtime/src/invocation_services/tests.rs
+++ b/crates/ironclaw_host_runtime/src/invocation_services/tests.rs
@@ -1,4 +1,3 @@
-
 use super::*;
 use async_trait::async_trait;
 use ironclaw_filesystem::{
@@ -81,6 +80,36 @@ fn local_resolver_accepts_local_required_process_backend() {
         .unwrap();
 
     assert!(services.runtime_http_egress.is_none());
+}
+
+#[test]
+fn local_resolver_rejects_hosted_local_host_process_backend() {
+    let resolver = resolver_without_http();
+    let mut plan = plan(
+        ProcessBackendKind::LocalHost,
+        true,
+        false,
+        NetworkMode::Deny,
+        false,
+    );
+    plan.deployment = DeploymentMode::HostedMultiTenant;
+    plan.resolved_profile = RuntimeProfile::HostedSafe;
+
+    let error = resolver
+        .resolve(InvocationServicesResolutionRequest {
+            plan: &plan,
+            scope: &ResourceScope::system(),
+            mounts: None,
+        })
+        .unwrap_err();
+
+    assert_eq!(error.kind(), RuntimeDispatchErrorKind::UnsupportedRunner);
+    assert!(matches!(
+        error,
+        InvocationServicesError::UnsupportedProcessBackend {
+            backend: ProcessBackendKind::LocalHost
+        }
+    ));
 }
 
 #[test]
@@ -246,6 +275,42 @@ fn local_resolver_accepts_host_workspace_and_home_when_filesystem_required() {
         .expect("local-yolo filesystem backend should resolve");
 
     assert!(services.runtime_http_egress.is_none());
+}
+
+#[test]
+fn local_resolver_rejects_hosted_raw_host_filesystem_backends() {
+    let resolver = resolver_without_http();
+    for filesystem_backend in [
+        FilesystemBackendKind::HostWorkspace,
+        FilesystemBackendKind::HostWorkspaceAndHome,
+    ] {
+        let mut plan = plan(
+            ProcessBackendKind::None,
+            false,
+            false,
+            NetworkMode::Deny,
+            false,
+        );
+        plan.deployment = DeploymentMode::HostedMultiTenant;
+        plan.resolved_profile = RuntimeProfile::HostedSafe;
+        plan.requires_filesystem = true;
+        plan.filesystem_backend = filesystem_backend;
+
+        let error = resolver
+            .resolve(InvocationServicesResolutionRequest {
+                plan: &plan,
+                scope: &ResourceScope::system(),
+                mounts: None,
+            })
+            .unwrap_err();
+
+        assert_eq!(error.kind(), RuntimeDispatchErrorKind::FilesystemDenied);
+        assert!(matches!(
+            error,
+            InvocationServicesError::UnsupportedFilesystemBackend { backend }
+                if backend == filesystem_backend
+        ));
+    }
 }
 
 #[test]
@@ -554,6 +619,43 @@ fn local_resolver_accepts_hosted_brokered_required_network() {
 }
 
 #[test]
+fn local_resolver_accepts_hosted_and_enterprise_allowlist_required_network() {
+    let resolver = LocalInvocationServicesResolver::new(
+        Arc::new(LocalFilesystem::new()),
+        Some(Arc::new(NoopRuntimeHttpEgress)),
+        Arc::new(NoopProcessPort),
+        None,
+    );
+    for (deployment, profile) in [
+        (DeploymentMode::HostedMultiTenant, RuntimeProfile::HostedDev),
+        (
+            DeploymentMode::EnterpriseDedicated,
+            RuntimeProfile::EnterpriseDev,
+        ),
+    ] {
+        let mut plan = plan(
+            ProcessBackendKind::None,
+            false,
+            true,
+            NetworkMode::Allowlist,
+            false,
+        );
+        plan.deployment = deployment;
+        plan.resolved_profile = profile;
+
+        let services = resolver
+            .resolve(InvocationServicesResolutionRequest {
+                plan: &plan,
+                scope: &ResourceScope::system(),
+                mounts: None,
+            })
+            .expect("allowlisted network should resolve through host egress");
+
+        assert!(services.runtime_http_egress.is_some());
+    }
+}
+
+#[test]
 fn local_resolver_rejects_hosted_direct_required_network() {
     let resolver = LocalInvocationServicesResolver::new(
         Arc::new(LocalFilesystem::new()),
@@ -771,6 +873,49 @@ fn local_resolver_accepts_brokered_required_secret_with_secret_store() {
 }
 
 #[test]
+fn local_resolver_accepts_tenant_and_org_broker_required_secrets() {
+    let resolver = LocalInvocationServicesResolver::new(
+        Arc::new(LocalFilesystem::new()),
+        None,
+        Arc::new(NoopProcessPort),
+        Some(Arc::new(InMemorySecretStore::new())),
+    );
+    for (deployment, profile, secret_mode) in [
+        (
+            DeploymentMode::HostedMultiTenant,
+            RuntimeProfile::HostedSafe,
+            SecretMode::TenantBroker,
+        ),
+        (
+            DeploymentMode::EnterpriseDedicated,
+            RuntimeProfile::EnterpriseSafe,
+            SecretMode::OrgBroker,
+        ),
+    ] {
+        let mut plan = plan(
+            ProcessBackendKind::None,
+            false,
+            false,
+            NetworkMode::Deny,
+            true,
+        );
+        plan.deployment = deployment;
+        plan.resolved_profile = profile;
+        plan.secret_mode = secret_mode;
+
+        let services = resolver
+            .resolve(InvocationServicesResolutionRequest {
+                plan: &plan,
+                scope: &ResourceScope::system(),
+                mounts: None,
+            })
+            .expect("brokered hosted secrets should resolve with a configured secret store");
+
+        assert!(services.secret_store.is_some());
+    }
+}
+
+#[test]
 fn local_resolver_rejects_hosted_inherited_env_secret() {
     let resolver = LocalInvocationServicesResolver::new(
         Arc::new(LocalFilesystem::new()),
@@ -842,6 +987,8 @@ fn first_party_tools_do_not_select_process_backends() {
     for source in sources {
         assert!(!source.contains("ProcessBackendKind"));
         assert!(!source.contains("FilesystemBackendKind"));
+        assert!(!source.contains("NetworkMode"));
+        assert!(!source.contains("SecretMode"));
     }
 }
 

--- a/crates/ironclaw_host_runtime/src/invocation_services/tests.rs
+++ b/crates/ironclaw_host_runtime/src/invocation_services/tests.rs
@@ -1,0 +1,906 @@
+
+use super::*;
+use async_trait::async_trait;
+use ironclaw_filesystem::{
+    FilesystemError, FilesystemOperation, InMemoryBackend, LocalFilesystem, RootFilesystem,
+};
+use ironclaw_host_api::{
+    CapabilityId, MountAlias, MountGrant, MountPermissions, ResourceScope, VirtualPath,
+    runtime_policy::{RuntimeProfile, SecretMode},
+};
+use ironclaw_secrets::InMemorySecretStore;
+
+use crate::{
+    CommandExecutionOutput, CommandExecutionRequest, RuntimeProcessError, RuntimeProcessPort,
+};
+
+#[derive(Debug)]
+struct NoopProcessPort;
+
+#[derive(Debug)]
+struct NamedProcessPort(&'static str);
+
+#[async_trait]
+impl RuntimeProcessPort for NoopProcessPort {
+    async fn run_command(
+        &self,
+        _request: CommandExecutionRequest,
+    ) -> Result<CommandExecutionOutput, RuntimeProcessError> {
+        unreachable!("resolver tests must not execute commands")
+    }
+}
+
+struct NoopRuntimeHttpEgress;
+
+#[async_trait]
+impl ironclaw_host_api::RuntimeHttpEgress for NoopRuntimeHttpEgress {
+    async fn execute(
+        &self,
+        _request: ironclaw_host_api::RuntimeHttpEgressRequest,
+    ) -> Result<
+        ironclaw_host_api::RuntimeHttpEgressResponse,
+        ironclaw_host_api::RuntimeHttpEgressError,
+    > {
+        unreachable!("resolver tests must not execute HTTP requests")
+    }
+}
+
+#[async_trait]
+impl RuntimeProcessPort for NamedProcessPort {
+    async fn run_command(
+        &self,
+        _request: CommandExecutionRequest,
+    ) -> Result<CommandExecutionOutput, RuntimeProcessError> {
+        Ok(CommandExecutionOutput {
+            output: self.0.to_string(),
+            saved_output: None,
+            exit_code: 0,
+            sandboxed: false,
+            duration: std::time::Duration::ZERO,
+        })
+    }
+}
+
+#[test]
+fn local_resolver_accepts_local_required_process_backend() {
+    let resolver = resolver_without_http();
+    let plan = plan(
+        ProcessBackendKind::LocalHost,
+        true,
+        false,
+        NetworkMode::DirectLogged,
+        false,
+    );
+
+    let services = resolver
+        .resolve(InvocationServicesResolutionRequest {
+            plan: &plan,
+            scope: &ResourceScope::system(),
+            mounts: None,
+        })
+        .unwrap();
+
+    assert!(services.runtime_http_egress.is_none());
+}
+
+#[test]
+fn local_resolver_rejects_sandbox_process_backend_without_local_fallback() {
+    let resolver = resolver_without_http();
+    let plan = plan(
+        ProcessBackendKind::TenantSandbox,
+        true,
+        false,
+        NetworkMode::Allowlist,
+        false,
+    );
+
+    let error = resolver
+        .resolve(InvocationServicesResolutionRequest {
+            plan: &plan,
+            scope: &ResourceScope::system(),
+            mounts: None,
+        })
+        .unwrap_err();
+
+    assert_eq!(error.kind(), RuntimeDispatchErrorKind::UnsupportedRunner);
+    assert!(matches!(
+        error,
+        InvocationServicesError::UnsupportedProcessBackend {
+            backend: ProcessBackendKind::TenantSandbox
+        }
+    ));
+}
+
+#[tokio::test]
+async fn local_resolver_uses_configured_sandbox_process_backend() {
+    let resolver = resolver_without_http()
+        .with_tenant_sandbox_process_port(Arc::new(NamedProcessPort("sandbox")));
+    let plan = plan(
+        ProcessBackendKind::TenantSandbox,
+        true,
+        false,
+        NetworkMode::Allowlist,
+        false,
+    );
+
+    let services = resolver
+        .resolve(InvocationServicesResolutionRequest {
+            plan: &plan,
+            scope: &ResourceScope::system(),
+            mounts: None,
+        })
+        .unwrap();
+
+    let output = services
+        .process
+        .run_command(CommandExecutionRequest {
+            scope: ResourceScope::system(),
+            mounts: None,
+            command: "echo hi".to_string(),
+            workdir: None,
+            timeout_secs: None,
+            extra_env: Default::default(),
+        })
+        .await
+        .unwrap();
+    assert_eq!(output.output, "sandbox");
+}
+
+#[test]
+fn local_resolver_rejects_unsupported_required_process_backend() {
+    let resolver = resolver_without_http();
+    let plan = plan(
+        ProcessBackendKind::Docker,
+        true,
+        false,
+        NetworkMode::Deny,
+        false,
+    );
+
+    let error = resolver
+        .resolve(InvocationServicesResolutionRequest {
+            plan: &plan,
+            scope: &ResourceScope::system(),
+            mounts: None,
+        })
+        .unwrap_err();
+
+    assert_eq!(error.kind(), RuntimeDispatchErrorKind::UnsupportedRunner);
+    assert!(matches!(
+        error,
+        InvocationServicesError::UnsupportedProcessBackend {
+            backend: ProcessBackendKind::Docker
+        }
+    ));
+}
+
+#[test]
+fn local_resolver_does_not_require_process_for_pure_plan() {
+    let resolver = resolver_without_http();
+    let plan = plan(
+        ProcessBackendKind::None,
+        false,
+        false,
+        NetworkMode::Deny,
+        false,
+    );
+
+    resolver
+        .resolve(InvocationServicesResolutionRequest {
+            plan: &plan,
+            scope: &ResourceScope::system(),
+            mounts: None,
+        })
+        .unwrap();
+}
+
+#[test]
+fn local_resolver_rejects_unsupported_filesystem_backend() {
+    let resolver = resolver_without_http();
+    let mut plan = plan(
+        ProcessBackendKind::None,
+        false,
+        false,
+        NetworkMode::Deny,
+        false,
+    );
+    plan.requires_filesystem = true;
+    plan.filesystem_backend = FilesystemBackendKind::TenantWorkspace;
+
+    let error = resolver
+        .resolve(InvocationServicesResolutionRequest {
+            plan: &plan,
+            scope: &ResourceScope::system(),
+            mounts: None,
+        })
+        .unwrap_err();
+
+    assert_eq!(error.kind(), RuntimeDispatchErrorKind::FilesystemDenied);
+    assert!(matches!(
+        error,
+        InvocationServicesError::UnsupportedFilesystemBackend {
+            backend: FilesystemBackendKind::TenantWorkspace
+        }
+    ));
+}
+
+#[test]
+fn local_resolver_accepts_host_workspace_and_home_when_filesystem_required() {
+    let resolver = resolver_without_http();
+    let mut plan = plan(
+        ProcessBackendKind::None,
+        false,
+        false,
+        NetworkMode::Deny,
+        false,
+    );
+    plan.requires_filesystem = true;
+    plan.filesystem_backend = FilesystemBackendKind::HostWorkspaceAndHome;
+
+    let services = resolver
+        .resolve(InvocationServicesResolutionRequest {
+            plan: &plan,
+            scope: &ResourceScope::system(),
+            mounts: None,
+        })
+        .expect("local-yolo filesystem backend should resolve");
+
+    assert!(services.runtime_http_egress.is_none());
+}
+
+#[test]
+fn local_resolver_accepts_hosted_scoped_virtual_filesystem_with_mounts() {
+    let resolver = resolver_without_http();
+    let mut plan = plan(
+        ProcessBackendKind::None,
+        false,
+        false,
+        NetworkMode::Deny,
+        false,
+    );
+    plan.deployment = DeploymentMode::HostedMultiTenant;
+    plan.resolved_profile = RuntimeProfile::SecureDefault;
+    plan.requires_filesystem = true;
+    plan.filesystem_backend = FilesystemBackendKind::ScopedVirtual;
+    let mounts = scoped_mount_view();
+
+    let services = resolver
+        .resolve(InvocationServicesResolutionRequest {
+            plan: &plan,
+            scope: &ResourceScope::system(),
+            mounts: Some(&mounts),
+        })
+        .expect("hosted scoped virtual filesystem should resolve with explicit mounts");
+
+    assert!(services.runtime_http_egress.is_none());
+}
+
+#[tokio::test]
+async fn hosted_scoped_virtual_filesystem_services_enforce_mount_targets() {
+    let backing: Arc<dyn RootFilesystem> = Arc::new(InMemoryBackend::new());
+    backing
+        .write_file(&vpath("/system/extensions/catalog.json"), b"{\"ok\":true}")
+        .await
+        .unwrap();
+    backing
+        .write_file(&vpath("/users/user_test/private.txt"), b"secret")
+        .await
+        .unwrap();
+    let resolver = resolver_with_filesystem(Arc::clone(&backing));
+    let mut plan = plan(
+        ProcessBackendKind::None,
+        false,
+        false,
+        NetworkMode::Deny,
+        false,
+    );
+    plan.deployment = DeploymentMode::HostedMultiTenant;
+    plan.resolved_profile = RuntimeProfile::SecureDefault;
+    plan.requires_filesystem = true;
+    plan.filesystem_backend = FilesystemBackendKind::ScopedVirtual;
+    let mounts = scoped_mount_view();
+
+    let services = resolver
+        .resolve(InvocationServicesResolutionRequest {
+            plan: &plan,
+            scope: &ResourceScope::system(),
+            mounts: Some(&mounts),
+        })
+        .expect("hosted scoped virtual filesystem should resolve with explicit mounts");
+
+    let allowed = services
+        .filesystem
+        .read_file(&vpath("/system/extensions/catalog.json"))
+        .await
+        .unwrap();
+    assert_eq!(allowed, b"{\"ok\":true}");
+
+    let denied = services
+        .filesystem
+        .read_file(&vpath("/users/user_test/private.txt"))
+        .await
+        .unwrap_err();
+    assert_permission_denied(denied, FilesystemOperation::ReadFile);
+}
+
+#[tokio::test]
+async fn hosted_scoped_virtual_filesystem_services_enforce_mount_permissions() {
+    let resolver = resolver_with_filesystem(Arc::new(InMemoryBackend::new()));
+    let mut plan = plan(
+        ProcessBackendKind::None,
+        false,
+        false,
+        NetworkMode::Deny,
+        false,
+    );
+    plan.deployment = DeploymentMode::HostedMultiTenant;
+    plan.resolved_profile = RuntimeProfile::SecureDefault;
+    plan.requires_filesystem = true;
+    plan.filesystem_backend = FilesystemBackendKind::ScopedVirtual;
+    let mounts = scoped_mount_view();
+
+    let services = resolver
+        .resolve(InvocationServicesResolutionRequest {
+            plan: &plan,
+            scope: &ResourceScope::system(),
+            mounts: Some(&mounts),
+        })
+        .expect("hosted scoped virtual filesystem should resolve with explicit mounts");
+
+    let denied = services
+        .filesystem
+        .write_file(&vpath("/system/extensions/state.json"), b"mutate")
+        .await
+        .unwrap_err();
+    assert_permission_denied(denied, FilesystemOperation::WriteFile);
+}
+
+#[test]
+fn local_resolver_rejects_hosted_scoped_virtual_filesystem_without_mounts() {
+    let resolver = resolver_without_http();
+    let mut plan = plan(
+        ProcessBackendKind::None,
+        false,
+        false,
+        NetworkMode::Deny,
+        false,
+    );
+    plan.deployment = DeploymentMode::HostedMultiTenant;
+    plan.resolved_profile = RuntimeProfile::SecureDefault;
+    plan.requires_filesystem = true;
+    plan.filesystem_backend = FilesystemBackendKind::ScopedVirtual;
+
+    let error = resolver
+        .resolve(InvocationServicesResolutionRequest {
+            plan: &plan,
+            scope: &ResourceScope::system(),
+            mounts: None,
+        })
+        .unwrap_err();
+
+    assert_eq!(error.kind(), RuntimeDispatchErrorKind::FilesystemDenied);
+    assert!(matches!(
+        error,
+        InvocationServicesError::UnsupportedFilesystemBackend {
+            backend: FilesystemBackendKind::ScopedVirtual
+        }
+    ));
+}
+
+#[test]
+fn local_resolver_ignores_unsupported_filesystem_backend_when_not_required() {
+    let resolver = resolver_without_http();
+    let mut plan = plan(
+        ProcessBackendKind::None,
+        false,
+        false,
+        NetworkMode::Deny,
+        false,
+    );
+    plan.filesystem_backend = FilesystemBackendKind::TenantWorkspace;
+
+    resolver
+        .resolve(InvocationServicesResolutionRequest {
+            plan: &plan,
+            scope: &ResourceScope::system(),
+            mounts: None,
+        })
+        .expect("unused filesystem backend must not block pure invocations");
+}
+
+#[tokio::test]
+async fn unused_filesystem_backend_resolves_to_denied_filesystem_services() {
+    let backing: Arc<dyn RootFilesystem> = Arc::new(InMemoryBackend::new());
+    backing
+        .write_file(&vpath("/system/extensions/catalog.json"), b"catalog")
+        .await
+        .unwrap();
+    let resolver = resolver_with_filesystem(backing);
+    let mut plan = plan(
+        ProcessBackendKind::None,
+        false,
+        false,
+        NetworkMode::Deny,
+        false,
+    );
+    plan.filesystem_backend = FilesystemBackendKind::TenantWorkspace;
+
+    let services = resolver
+        .resolve(InvocationServicesResolutionRequest {
+            plan: &plan,
+            scope: &ResourceScope::system(),
+            mounts: None,
+        })
+        .expect("unused filesystem backend must not block pure invocations");
+
+    let denied = services
+        .filesystem
+        .read_file(&vpath("/system/extensions/catalog.json"))
+        .await
+        .unwrap_err();
+    assert_permission_denied(denied, FilesystemOperation::ReadFile);
+}
+
+#[test]
+fn local_resolver_rejects_denied_required_network() {
+    let resolver = resolver_without_http();
+    let plan = plan(
+        ProcessBackendKind::None,
+        false,
+        true,
+        NetworkMode::Deny,
+        false,
+    );
+
+    let error = resolver
+        .resolve(InvocationServicesResolutionRequest {
+            plan: &plan,
+            scope: &ResourceScope::system(),
+            mounts: None,
+        })
+        .unwrap_err();
+
+    assert_eq!(error.kind(), RuntimeDispatchErrorKind::NetworkDenied);
+    assert!(matches!(
+        error,
+        InvocationServicesError::UnsupportedNetworkMode {
+            mode: NetworkMode::Deny
+        }
+    ));
+}
+
+#[test]
+fn local_resolver_rejects_required_network_when_egress_service_is_absent() {
+    let resolver = resolver_without_http();
+    let plan = plan(
+        ProcessBackendKind::None,
+        false,
+        true,
+        NetworkMode::DirectLogged,
+        false,
+    );
+
+    let error = resolver
+        .resolve(InvocationServicesResolutionRequest {
+            plan: &plan,
+            scope: &ResourceScope::system(),
+            mounts: None,
+        })
+        .unwrap_err();
+
+    assert_eq!(error.kind(), RuntimeDispatchErrorKind::NetworkDenied);
+    assert!(matches!(
+        error,
+        InvocationServicesError::UnsupportedNetworkMode {
+            mode: NetworkMode::DirectLogged
+        }
+    ));
+}
+
+#[test]
+fn local_resolver_accepts_brokered_required_network_with_egress_service() {
+    let resolver = LocalInvocationServicesResolver::new(
+        Arc::new(LocalFilesystem::new()),
+        Some(Arc::new(NoopRuntimeHttpEgress)),
+        Arc::new(NoopProcessPort),
+        None,
+    );
+    let plan = plan(
+        ProcessBackendKind::None,
+        false,
+        true,
+        NetworkMode::Brokered,
+        false,
+    );
+
+    let services = resolver
+        .resolve(InvocationServicesResolutionRequest {
+            plan: &plan,
+            scope: &ResourceScope::system(),
+            mounts: None,
+        })
+        .unwrap();
+
+    assert!(services.runtime_http_egress.is_some());
+}
+
+#[test]
+fn local_resolver_accepts_hosted_brokered_required_network() {
+    let resolver = LocalInvocationServicesResolver::new(
+        Arc::new(LocalFilesystem::new()),
+        Some(Arc::new(NoopRuntimeHttpEgress)),
+        Arc::new(NoopProcessPort),
+        None,
+    );
+    let mut plan = plan(
+        ProcessBackendKind::None,
+        false,
+        true,
+        NetworkMode::Brokered,
+        false,
+    );
+    plan.deployment = DeploymentMode::HostedMultiTenant;
+    plan.resolved_profile = RuntimeProfile::HostedSafe;
+
+    let services = resolver
+        .resolve(InvocationServicesResolutionRequest {
+            plan: &plan,
+            scope: &ResourceScope::system(),
+            mounts: None,
+        })
+        .expect("hosted brokered network should resolve through host egress");
+
+    assert!(services.runtime_http_egress.is_some());
+}
+
+#[test]
+fn local_resolver_rejects_hosted_direct_required_network() {
+    let resolver = LocalInvocationServicesResolver::new(
+        Arc::new(LocalFilesystem::new()),
+        Some(Arc::new(NoopRuntimeHttpEgress)),
+        Arc::new(NoopProcessPort),
+        None,
+    );
+    let mut plan = plan(
+        ProcessBackendKind::None,
+        false,
+        true,
+        NetworkMode::Direct,
+        false,
+    );
+    plan.deployment = DeploymentMode::HostedMultiTenant;
+    plan.resolved_profile = RuntimeProfile::HostedSafe;
+
+    let error = resolver
+        .resolve(InvocationServicesResolutionRequest {
+            plan: &plan,
+            scope: &ResourceScope::system(),
+            mounts: None,
+        })
+        .unwrap_err();
+
+    assert_eq!(error.kind(), RuntimeDispatchErrorKind::NetworkDenied);
+    assert!(matches!(
+        error,
+        InvocationServicesError::UnsupportedNetworkMode {
+            mode: NetworkMode::Direct
+        }
+    ));
+}
+
+#[test]
+fn local_resolver_accepts_direct_required_network_with_egress_service() {
+    let resolver = LocalInvocationServicesResolver::new(
+        Arc::new(LocalFilesystem::new()),
+        Some(Arc::new(NoopRuntimeHttpEgress)),
+        Arc::new(NoopProcessPort),
+        None,
+    );
+    let plan = plan(
+        ProcessBackendKind::None,
+        false,
+        true,
+        NetworkMode::Direct,
+        false,
+    );
+
+    let services = resolver
+        .resolve(InvocationServicesResolutionRequest {
+            plan: &plan,
+            scope: &ResourceScope::system(),
+            mounts: None,
+        })
+        .unwrap();
+
+    assert!(services.runtime_http_egress.is_some());
+}
+
+#[test]
+fn local_resolver_allows_raw_diagnostics_only_for_local_dev_and_yolo() {
+    let resolver = LocalInvocationServicesResolver::new(
+        Arc::new(LocalFilesystem::new()),
+        Some(Arc::new(NoopRuntimeHttpEgress)),
+        Arc::new(NoopProcessPort),
+        None,
+    );
+    let mut plan = plan(
+        ProcessBackendKind::None,
+        false,
+        true,
+        NetworkMode::Direct,
+        false,
+    );
+
+    plan.resolved_profile = RuntimeProfile::LocalSafe;
+    let services = resolver
+        .resolve(InvocationServicesResolutionRequest {
+            plan: &plan,
+            scope: &ResourceScope::system(),
+            mounts: None,
+        })
+        .unwrap();
+    assert!(!services.unsafe_raw_diagnostics_allowed);
+
+    plan.resolved_profile = RuntimeProfile::LocalDev;
+    let services = resolver
+        .resolve(InvocationServicesResolutionRequest {
+            plan: &plan,
+            scope: &ResourceScope::system(),
+            mounts: None,
+        })
+        .unwrap();
+    assert!(services.unsafe_raw_diagnostics_allowed);
+
+    plan.resolved_profile = RuntimeProfile::LocalYolo;
+    let services = resolver
+        .resolve(InvocationServicesResolutionRequest {
+            plan: &plan,
+            scope: &ResourceScope::system(),
+            mounts: None,
+        })
+        .unwrap();
+    assert!(services.unsafe_raw_diagnostics_allowed);
+}
+
+#[test]
+fn local_resolver_hides_runtime_http_egress_when_network_is_not_required() {
+    let resolver = LocalInvocationServicesResolver::new(
+        Arc::new(LocalFilesystem::new()),
+        Some(Arc::new(NoopRuntimeHttpEgress)),
+        Arc::new(NoopProcessPort),
+        None,
+    );
+    let plan = plan(
+        ProcessBackendKind::None,
+        false,
+        false,
+        NetworkMode::DirectLogged,
+        false,
+    );
+
+    let services = resolver
+        .resolve(InvocationServicesResolutionRequest {
+            plan: &plan,
+            scope: &ResourceScope::system(),
+            mounts: None,
+        })
+        .unwrap();
+
+    assert!(services.runtime_http_egress.is_none());
+}
+
+#[test]
+fn local_resolver_hides_secret_store_when_secret_is_not_required() {
+    let resolver = LocalInvocationServicesResolver::new(
+        Arc::new(LocalFilesystem::new()),
+        None,
+        Arc::new(NoopProcessPort),
+        Some(Arc::new(InMemorySecretStore::new())),
+    );
+    let plan = plan(
+        ProcessBackendKind::None,
+        false,
+        false,
+        NetworkMode::Deny,
+        false,
+    );
+
+    let services = resolver
+        .resolve(InvocationServicesResolutionRequest {
+            plan: &plan,
+            scope: &ResourceScope::system(),
+            mounts: None,
+        })
+        .unwrap();
+
+    assert!(services.secret_store.is_none());
+}
+
+#[test]
+fn local_resolver_rejects_required_secret_when_secret_store_is_absent() {
+    let resolver = resolver_without_http();
+    let plan = plan(
+        ProcessBackendKind::None,
+        false,
+        false,
+        NetworkMode::Deny,
+        true,
+    );
+
+    let error = resolver
+        .resolve(InvocationServicesResolutionRequest {
+            plan: &plan,
+            scope: &ResourceScope::system(),
+            mounts: None,
+        })
+        .unwrap_err();
+
+    assert_eq!(error.kind(), RuntimeDispatchErrorKind::SecretDenied);
+    assert!(matches!(
+        error,
+        InvocationServicesError::SecretAccessRequired
+    ));
+}
+
+#[test]
+fn local_resolver_accepts_brokered_required_secret_with_secret_store() {
+    let resolver = LocalInvocationServicesResolver::new(
+        Arc::new(LocalFilesystem::new()),
+        None,
+        Arc::new(NoopProcessPort),
+        Some(Arc::new(InMemorySecretStore::new())),
+    );
+    let mut plan = plan(
+        ProcessBackendKind::None,
+        false,
+        false,
+        NetworkMode::Deny,
+        true,
+    );
+    plan.secret_mode = SecretMode::BrokeredHandles;
+
+    let services = resolver
+        .resolve(InvocationServicesResolutionRequest {
+            plan: &plan,
+            scope: &ResourceScope::system(),
+            mounts: None,
+        })
+        .expect("brokered handles should resolve with a configured secret store");
+
+    assert!(services.secret_store.is_some());
+}
+
+#[test]
+fn local_resolver_rejects_hosted_inherited_env_secret() {
+    let resolver = LocalInvocationServicesResolver::new(
+        Arc::new(LocalFilesystem::new()),
+        None,
+        Arc::new(NoopProcessPort),
+        Some(Arc::new(InMemorySecretStore::new())),
+    );
+    let mut plan = plan(
+        ProcessBackendKind::None,
+        false,
+        false,
+        NetworkMode::Deny,
+        true,
+    );
+    plan.deployment = DeploymentMode::HostedMultiTenant;
+    plan.resolved_profile = RuntimeProfile::HostedSafe;
+    plan.secret_mode = SecretMode::InheritedEnv;
+
+    let error = resolver
+        .resolve(InvocationServicesResolutionRequest {
+            plan: &plan,
+            scope: &ResourceScope::system(),
+            mounts: None,
+        })
+        .unwrap_err();
+
+    assert_eq!(error.kind(), RuntimeDispatchErrorKind::SecretDenied);
+    assert!(matches!(
+        error,
+        InvocationServicesError::UnsupportedSecretMode {
+            mode: SecretMode::InheritedEnv
+        }
+    ));
+}
+
+#[test]
+fn local_resolver_accepts_required_secret_when_secret_store_is_available() {
+    let resolver = LocalInvocationServicesResolver::new(
+        Arc::new(LocalFilesystem::new()),
+        None,
+        Arc::new(NoopProcessPort),
+        Some(Arc::new(InMemorySecretStore::new())),
+    );
+    let plan = plan(
+        ProcessBackendKind::None,
+        false,
+        false,
+        NetworkMode::Deny,
+        true,
+    );
+
+    let services = resolver
+        .resolve(InvocationServicesResolutionRequest {
+            plan: &plan,
+            scope: &ResourceScope::system(),
+            mounts: None,
+        })
+        .unwrap();
+
+    assert!(services.secret_store.is_some());
+}
+
+#[test]
+fn first_party_tools_do_not_select_process_backends() {
+    let sources = [
+        include_str!("../first_party_tools/shell.rs"),
+        include_str!("../first_party_tools/http.rs"),
+    ];
+    for source in sources {
+        assert!(!source.contains("ProcessBackendKind"));
+        assert!(!source.contains("FilesystemBackendKind"));
+    }
+}
+
+fn resolver_without_http() -> LocalInvocationServicesResolver {
+    LocalInvocationServicesResolver::new(
+        Arc::new(LocalFilesystem::new()),
+        None,
+        Arc::new(NoopProcessPort),
+        None,
+    )
+}
+
+fn resolver_with_filesystem(
+    filesystem: Arc<dyn RootFilesystem>,
+) -> LocalInvocationServicesResolver {
+    LocalInvocationServicesResolver::new(filesystem, None, Arc::new(NoopProcessPort), None)
+}
+
+fn scoped_mount_view() -> MountView {
+    MountView::new(vec![MountGrant::new(
+        MountAlias::new("/system/extensions".to_string()).expect("mount alias"),
+        VirtualPath::new("/system/extensions".to_string()).expect("virtual path"),
+        MountPermissions::read_only(),
+    )])
+    .expect("mount view")
+}
+
+fn vpath(path: &str) -> VirtualPath {
+    VirtualPath::new(path.to_string()).expect("virtual path")
+}
+
+fn assert_permission_denied(error: FilesystemError, expected_operation: FilesystemOperation) {
+    assert!(matches!(
+        error,
+        FilesystemError::PermissionDenied {
+            operation,
+            ..
+        } if operation == expected_operation
+    ));
+}
+
+fn plan(
+    process_backend: ProcessBackendKind,
+    requires_process: bool,
+    requires_network: bool,
+    network_mode: NetworkMode,
+    requires_secret: bool,
+) -> ExecutionPlan {
+    ExecutionPlan {
+        capability: CapabilityId::new("test.capability".to_string()).unwrap(),
+        deployment: DeploymentMode::LocalSingleUser,
+        resolved_profile: RuntimeProfile::LocalDev,
+        filesystem_backend: FilesystemBackendKind::HostWorkspace,
+        process_backend,
+        network_mode,
+        secret_mode: SecretMode::ScrubbedEnv,
+        requires_filesystem: false,
+        requires_process,
+        requires_network,
+        requires_secret,
+    }
+}

--- a/crates/ironclaw_host_runtime/src/services/tests.rs
+++ b/crates/ironclaw_host_runtime/src/services/tests.rs
@@ -954,6 +954,70 @@ async fn first_party_adapter_releases_reservation_when_invocation_service_resolu
 }
 
 #[tokio::test]
+async fn first_party_adapter_denies_hosted_unsupported_services_before_handler_dispatch() {
+    assert_first_party_denies_before_handler(
+        vec![EffectKind::ReadFilesystem],
+        hosted_policy_with(
+            FilesystemBackendKind::HostWorkspace,
+            ProcessBackendKind::None,
+            NetworkMode::Deny,
+            SecretMode::Deny,
+        ),
+        None,
+        RuntimeDispatchErrorKind::FilesystemDenied,
+    )
+    .await;
+    assert_first_party_denies_before_handler(
+        vec![EffectKind::ReadFilesystem],
+        hosted_policy_with(
+            FilesystemBackendKind::ScopedVirtual,
+            ProcessBackendKind::None,
+            NetworkMode::Deny,
+            SecretMode::Deny,
+        ),
+        None,
+        RuntimeDispatchErrorKind::FilesystemDenied,
+    )
+    .await;
+    assert_first_party_denies_before_handler(
+        vec![EffectKind::ExecuteCode],
+        hosted_policy_with(
+            FilesystemBackendKind::ScopedVirtual,
+            ProcessBackendKind::LocalHost,
+            NetworkMode::Deny,
+            SecretMode::Deny,
+        ),
+        None,
+        RuntimeDispatchErrorKind::UnsupportedRunner,
+    )
+    .await;
+    assert_first_party_denies_before_handler(
+        vec![EffectKind::Network],
+        hosted_policy_with(
+            FilesystemBackendKind::ScopedVirtual,
+            ProcessBackendKind::None,
+            NetworkMode::Direct,
+            SecretMode::Deny,
+        ),
+        None,
+        RuntimeDispatchErrorKind::NetworkDenied,
+    )
+    .await;
+    assert_first_party_denies_before_handler(
+        vec![EffectKind::UseSecret],
+        hosted_policy_with(
+            FilesystemBackendKind::ScopedVirtual,
+            ProcessBackendKind::None,
+            NetworkMode::Deny,
+            SecretMode::InheritedEnv,
+        ),
+        None,
+        RuntimeDispatchErrorKind::SecretDenied,
+    )
+    .await;
+}
+
+#[tokio::test]
 async fn first_party_adapter_releases_reservation_when_planner_denies() {
     let descriptor = test_descriptor(RuntimeKind::FirstParty, vec![EffectKind::Network]);
     let registry = Arc::new(
@@ -1100,6 +1164,73 @@ fn policy_with(
         approval_policy: ironclaw_host_api::runtime_policy::ApprovalPolicy::AskDestructive,
         audit_mode: ironclaw_host_api::runtime_policy::AuditMode::LocalMinimal,
     }
+}
+
+fn hosted_policy_with(
+    filesystem_backend: FilesystemBackendKind,
+    process_backend: ProcessBackendKind,
+    network_mode: NetworkMode,
+    secret_mode: SecretMode,
+) -> EffectiveRuntimePolicy {
+    let mut policy = policy_with(
+        filesystem_backend,
+        process_backend,
+        network_mode,
+        secret_mode,
+    );
+    policy.deployment = DeploymentMode::HostedMultiTenant;
+    policy.requested_profile = RuntimeProfile::HostedSafe;
+    policy.resolved_profile = RuntimeProfile::HostedSafe;
+    policy
+}
+
+async fn assert_first_party_denies_before_handler(
+    effects: Vec<EffectKind>,
+    policy: EffectiveRuntimePolicy,
+    mounts: Option<MountView>,
+    expected_kind: RuntimeDispatchErrorKind,
+) {
+    let descriptor = test_descriptor(RuntimeKind::FirstParty, effects);
+    let registry = Arc::new(
+        FirstPartyCapabilityRegistry::new()
+            .with_handler(descriptor.id.clone(), Arc::new(PanicFirstPartyHandler)),
+    );
+    let adapter = FirstPartyRuntimeAdapter::from_registry(
+        registry,
+        Arc::new(LocalInvocationServicesResolver::new(
+            Arc::new(LocalFilesystem::new()),
+            None,
+            Arc::new(LocalHostProcessPort::new()),
+            Some(Arc::new(InMemorySecretStore::new())),
+        )),
+    );
+    let filesystem = LocalFilesystem::new();
+    let governor = InMemoryResourceGovernor::new();
+    let package = test_package(WASM_MANIFEST, "test-wasm");
+
+    let result = adapter
+        .dispatch_json(RuntimeAdapterRequest {
+            package: &package,
+            descriptor: &descriptor,
+            filesystem: &filesystem,
+            governor: &governor,
+            runtime_policy: &policy,
+            capability_id: &descriptor.id,
+            scope: sample_scope(),
+            estimate: ResourceEstimate::default(),
+            mounts,
+            resource_reservation: None,
+            input: json!({}),
+        })
+        .await;
+
+    assert!(
+        matches!(
+            result,
+            Err(DispatchError::FirstParty { kind, .. }) if kind == expected_kind
+        ),
+        "expected first-party denial {expected_kind:?}, got {result:?}"
+    );
 }
 
 #[derive(Default)]

--- a/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
@@ -5699,23 +5699,24 @@ async fn builtin_http_runtime_policy_denial_stops_before_egress() {
 }
 
 #[tokio::test]
-async fn builtin_http_rejects_hosted_allowlist_plan_before_egress() {
+async fn builtin_http_uses_hosted_allowlist_plan_through_configured_egress() {
     let egress = Arc::new(RecordingRuntimeHttpEgress::with_body(
         br#"{"ok":true}"#.to_vec(),
     ));
     let runtime = runtime_with_http_egress_and_policy(Arc::clone(&egress), hosted_dev_policy());
 
-    let error = invoke_with_context(
+    let output = invoke_with_context(
         &runtime,
         HTTP_CAPABILITY_ID,
         json!({"url": "https://api.example.test/v1/items"}),
         execution_context_with_network([HTTP_CAPABILITY_ID], http_test_policy()),
     )
     .await
-    .unwrap_err();
+    .unwrap();
 
-    assert_eq!(error, RuntimeFailureKind::Network);
-    assert!(egress.requests().is_empty());
+    assert_eq!(output["status"], json!(200));
+    assert_eq!(output["body_text"], json!(r#"{"ok":true}"#));
+    assert_eq!(egress.requests().len(), 1);
 }
 
 #[tokio::test]
@@ -6178,22 +6179,24 @@ async fn builtin_http_awaits_async_egress_without_blocking_tokio_worker() {
 }
 
 #[tokio::test]
-async fn builtin_read_file_rejects_scoped_virtual_filesystem_plan_before_handler_access() {
+async fn builtin_read_file_reads_scoped_virtual_filesystem_through_mount_services() {
     let temp = tempfile::tempdir().unwrap();
-    std::fs::write(temp.path().join("README.md"), "must not be read\n").unwrap();
+    std::fs::write(temp.path().join("README.md"), "scoped read\n").unwrap();
     let (filesystem, mounts) = mounted_filesystem(temp.path(), MountPermissions::read_only());
     let runtime = runtime_with_filesystem_and_policy(filesystem, network_denied_policy());
 
-    let error = invoke_with_context(
+    let output = invoke_with_context(
         &runtime,
         READ_FILE_CAPABILITY_ID,
         json!({"path": "/workspace/README.md"}),
         execution_context_with_mounts([READ_FILE_CAPABILITY_ID], mounts),
     )
     .await
-    .unwrap_err();
+    .unwrap();
 
-    assert_eq!(error, RuntimeFailureKind::Authorization);
+    assert_eq!(output["content"], json!("     1│ scoped read"));
+    assert_eq!(output["path"], json!("/workspace/README.md"));
+    assert_eq!(output["total_lines"], json!(1));
 }
 
 #[tokio::test]

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/tests.rs
@@ -2919,13 +2919,43 @@ mod tests {
         ))
         .await
         .expect("local-dev services build");
-        let run_context = run_context("extension-search-loop-port").await;
-        enable_global_auto_approve_for_run(
+        assert_extension_search_capability_port_reads_system_catalog(
             &services,
-            &run_context,
-            &UserId::new("local-dev-extension-search-user").expect("user id"),
+            "extension-search-loop-port",
+            "local-dev-extension-search-user",
         )
         .await;
+    }
+
+    #[cfg(feature = "libsql")]
+    #[tokio::test]
+    async fn hosted_single_tenant_volume_capability_port_extension_search_reads_system_catalog() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let services = crate::build_reborn_services(
+            crate::hosted_single_tenant_volume_build_input(
+                "hosted-volume-extension-search-owner",
+                dir.path().join("hosted-volume"),
+            )
+            .expect("hosted volume input"),
+        )
+        .await
+        .expect("hosted volume services build");
+        assert_extension_search_capability_port_reads_system_catalog(
+            &services,
+            "hosted-volume-extension-search-loop-port",
+            "hosted-volume-extension-search-user",
+        )
+        .await;
+    }
+
+    async fn assert_extension_search_capability_port_reads_system_catalog(
+        services: &crate::RebornServices,
+        run_label: &str,
+        user_id: &str,
+    ) {
+        let run_context = run_context(run_label).await;
+        let user_id = UserId::new(user_id).expect("user id");
+        enable_global_auto_approve_for_run(services, &run_context, &user_id).await;
         let thread_scope = ThreadScope {
             tenant_id: run_context.scope.tenant_id.clone(),
             agent_id: run_context.scope.agent_id.clone().expect("agent id"),
@@ -2934,10 +2964,10 @@ mod tests {
             mission_id: None,
         };
         let wiring = capability_wiring(
-            &services,
+            services,
             Arc::new(InMemorySessionThreadService::default()),
             thread_scope,
-            UserId::new("local-dev-extension-search-user").expect("user id"),
+            user_id,
             Arc::new(
                 crate::local_dev_capability_policy::local_dev_capability_policy()
                     .expect("policy parses"),


### PR DESCRIPTION
## Summary
- allow the local-host service resolver to bind hosted-volume scoped/brokered plans after authorization
- accept hosted/enterprise allowlisted network and tenant/org broker secret modes that the policy resolver already emits
- keep raw host workspace, direct local network, inherited secrets, and local host process access local-only
- add resolver and first-party adapter regression coverage for typed denials before handler dispatch
- add hosted-volume capability-port regression coverage for builtin.extension_search reading the system extension catalog

## Change Type
- Bug fix
- Test coverage

## Linked Issue
- None.

## Why
Railway hosted-volume tool calls could get past approval, then fail at first-party runtime service resolution with authorization/filesystem denial because the resolver rejected valid non-local scoped/brokered service plans. The runtime boundary should be post-authorization service parity: hosted scoped-volume plans resolve only the scoped/brokered services they were authorized for, while local-only authority stays denied.

## Security Impact
This tightens the authority boundary. Hosted/enterprise plans can now use the brokered/scoped service modes emitted by runtime policy, while raw host filesystem, local host process execution, direct local network, inherited env secrets, and missing scoped mounts still fail closed with typed denial kinds before first-party handler invocation.

## Trust-Boundary Checklist
- Scoped virtual filesystem access is still mount-gated.
- Raw host filesystem backends remain local-only.
- LocalHost process execution remains local-only.
- Hosted/enterprise allowlisted network resolves only through the configured host egress service.
- Tenant/org brokered secrets resolve only through the configured secret store.
- Direct network and inherited env secrets remain denied outside local deployment.
- Resolver denial is covered before first-party handler dispatch.

## Blast Radius
- `ironclaw_host_runtime` invocation service resolution and tests.
- Hosted single-tenant volume capability-port tests in `ironclaw_reborn_composition` from the earlier commits in this PR.
- No schema, API, or Docker image changes.

## Rollback Plan
Revert this PR, or temporarily deploy the existing `hosted-single-tenant` profile instead of `hosted-single-tenant-volume` while investigating. The changes are isolated to runtime service resolution and tests.

## Review Follow-Through
- Addressed CodeRabbit allowlist network and tenant/org broker secret comments.
- Added hosted LocalHost process denial coverage.
- Added hosted raw host filesystem denial coverage.
- Extended first-party source scan to cover network and secret backend selection.
- Added post-authorization first-party adapter denial coverage for hosted unsupported filesystem, process, network, secret, and missing scoped mount cases.
- Gemini Code Assist left no actionable code comments.

## Tests
- `CARGO_TARGET_DIR=/Volumes/NVME/ironclaw-worktrees/hosted-single-tenant-volume/target cargo test -p ironclaw_host_runtime invocation_services --lib`
- `CARGO_TARGET_DIR=/Volumes/NVME/ironclaw-worktrees/hosted-single-tenant-volume/target cargo test -p ironclaw_host_runtime first_party_adapter_denies_hosted_unsupported_services_before_handler_dispatch --lib`
- Earlier in this PR: `cargo test -p ironclaw_reborn_composition hosted_single_tenant_volume_capability_port_extension_search_reads_system_catalog --features libsql,test-support --lib`
- Earlier in this PR: `cargo test -p ironclaw_reborn_composition local_dev_capability_port_extension_search_reads_system_catalog --lib`
