### PR TITLE
fix(extensions): wasm-channel OAuth setup should return auth_url, not fail on missing secret

### DIFF
--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -8135,6 +8135,16 @@ impl ExtensionManager {
                 if secret_def.optional {
                     continue;
                 }
+                // OAuth-resolvable secrets are satisfied by the OAuth `auth_url`
+                // flow initiated below (the WasmChannel branch), not by a
+                // directly submitted/stored value. A missing one must fall
+                // through to that flow rather than hard-failing here — otherwise
+                // configuring an OAuth channel with empty secrets (the expected
+                // first step) returns ValidationFailed instead of an auth_url.
+                // Mirrors the WasmTool path's `is_auto_resolved_oauth_field`.
+                if self.secret_supports_oauth(user_id, &secret_def.name).await {
+                    continue;
+                }
                 let submitted = secrets
                     .get(&secret_def.name)
                     .is_some_and(|v| !v.trim().is_empty());


### PR DESCRIPTION
## Problem

`ExtensionManager::configure()` hard-fails a **WasmChannel** setup when a required secret is missing, with no OAuth-awareness:

```
Required secret 'google_oauth_token' is missing for extension 'gmail_channel'
```

But an OAuth channel's *first* setup call legitimately submits **empty secrets** and expects an `auth_url` back to start the browser flow. The required-secret gate (`src/extensions/manager.rs`, the `channel_secret_defs` loop) returns **before** `configure()` reaches the WasmChannel OAuth-initiation branch (`auth(...).auth_url()` at ~`manager.rs:8272`), so OAuth-backed channels could never be configured.

Surfaced by the failing e2e test `test_v2_auth_oauth_matrix.py::test_wasm_channel_oauth_roundtrip`.

## Fix

In the channel required-secret loop, `continue` past any secret where `secret_supports_oauth(user_id, name)` is true, so a missing OAuth-resolvable secret falls through to the `auth_url` path. This mirrors the **WasmTool** path, which already filters OAuth-resolvable secrets via `is_auto_resolved_oauth_field` — the channel gate was the lone inconsistency.

```rust
for secret_def in &channel_secret_defs {
    if secret_def.optional { continue; }
    if self.secret_supports_oauth(user_id, &secret_def.name).await { continue; } // <-- added
    // ... existing submitted/stored required-secret check ...
}
```

## Verification & review note

- Compiles clean (`cargo check --bin ironclaw`).
- Traced the `configure()` flow: with the gate skipped for OAuth secrets, execution reaches the WasmChannel `auth_url` branch and returns `ConfigureResult { auth_url: Some(..), .. }` — exactly what the e2e test asserts.
- **I could not run the e2e suite locally (no Playwright env)**, so please validate against the full harness. This is sensitive onboarding/auth code (see `CLAUDE.md` → Extension/Auth Invariants).
- Regression coverage is the existing `test_wasm_channel_oauth_roundtrip` (currently failing; this fix makes it pass). A focused Rust integration test driving `configure()` for a channel with a missing OAuth secret would be a good add — the existing OAuth `configure()` tests are tool-only, and a faithful channel-OAuth harness needs wiring I couldn't verify locally.

Found during a post-#5281 audit of the chronic `main` CI red (diagnosed as overwhelmingly stale tests + CI-config gaps; this is the one clear product bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)