### PR TITLE
feat(filesystem): advertise BatchPut on Postgres + raise pool size (2/5)

### DIFF
--- a/crates/ironclaw_filesystem/src/postgres.rs
+++ b/crates/ironclaw_filesystem/src/postgres.rs
@@ -161,6 +161,14 @@ impl RootFilesystem for PostgresRootFilesystem {
             .with(Capability::Events)
             .with(Capability::IndexFts)
             .with(Capability::IndexVector)
+            // `put_batch` is served by the trait default impl, which is
+            // atomic on this backend: Postgres advertises MultiKey (below),
+            // so the default routes the whole batch through one `begin`/
+            // `StorageTxn` BEGIN…COMMIT — and `PostgresStorageTxn`'s `Drop`
+            // guard rolls back a txn abandoned by async-cancel/panic, which a
+            // hand-rolled override would have to re-implement. Advertising
+            // BatchPut lets atomic-batching callers gate on this bit.
+            .with(Capability::BatchPut)
             .with_txn(TxnCapability::MultiKey)
     }
 

--- a/crates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
+++ b/crates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
@@ -1783,14 +1783,17 @@ mod postgres_tests {
 
     #[tokio::test]
     async fn postgres_put_batch_multi_all_or_nothing() {
-        // Postgres advertises TxnCapability::MultiKey, so the default
-        // put_batch impl drives a real multi-key transaction: a mix of
-        // Absent (insert) and Version (CAS update) legs all land together,
-        // and a single stale leg rolls the whole batch back.
+        // Postgres advertises TxnCapability::MultiKey + Capability::BatchPut, so
+        // put_batch is served by the trait default impl, which routes the whole
+        // batch through one `begin`/`StorageTxn` BEGIN…COMMIT over the common
+        // prefix: a mix of Absent (insert) and Version (CAS update) legs all land
+        // together over a real Postgres transaction, and a single stale leg rolls
+        // the whole batch back, leaving nothing written.
         let Some((fs, prefix)) = postgres_root().await else {
             return;
         };
         assert_eq!(fs.capabilities().txn(), TxnCapability::MultiKey);
+        assert!(fs.capabilities().has(Capability::BatchPut));
 
         // Pre-create two paths so we can exercise Version CAS legs.
         let c = vpath(&prefix, "C");
@@ -2486,5 +2489,17 @@ mod postgres_tests {
             return;
         };
         assert!(fs.capabilities().has(Capability::Events));
+    }
+
+    #[tokio::test]
+    async fn postgres_capabilities_advertise_batch_put() {
+        let Some((fs, _prefix)) = postgres_root().await else {
+            return;
+        };
+        // Postgres must advertise the BatchPut bit so atomic-batching callers
+        // can gate on it; put_batch is served atomically by the trait default
+        // over the MultiKey txn capability also advertised here.
+        assert!(fs.capabilities().has(Capability::BatchPut));
+        assert_eq!(fs.capabilities().txn(), TxnCapability::MultiKey);
     }
 }

--- a/crates/ironclaw_reborn_cli/tests/smoke.rs
+++ b/crates/ironclaw_reborn_cli/tests/smoke.rs
@@ -194,7 +194,7 @@ fn docker_reborn_production_config_uses_postgres_storage() {
         storage.secret_master_key_env.as_deref(),
         Some("IRONCLAW_REBORN_SECRET_MASTER_KEY")
     );
-    assert_eq!(storage.pool_max_size, Some(2));
+    assert_eq!(storage.pool_max_size, Some(16));
 
     let policy = parsed
         .policy

--- a/crates/ironclaw_reborn_event_store/src/lib.rs
+++ b/crates/ironclaw_reborn_event_store/src/lib.rs
@@ -53,8 +53,21 @@ mod filesystem_store;
 pub use coalescing_sink::{CoalescingEventSink, EventBatchConfig};
 pub use filesystem_store::{FilesystemDurableAuditLog, FilesystemDurableEventLog};
 
+/// Default ceiling for the shared Postgres pool used by the filesystem,
+/// triggers, event store, and keepalive subsystems.
+///
+/// Bumped from 2 to 16 to give `put_batch`'s held `BEGIN…COMMIT` headroom
+/// across the shared pool's consumers. `put_batch` (served by the
+/// `RootFilesystem` trait default on the Postgres MultiKey backend) holds one
+/// pooled connection for the span of its transaction; at a ceiling of 2, a
+/// single in-flight batch left only one connection for every other subsystem
+/// sharing this pool, which could starve the heartbeat/webui paths and wedge
+/// the runner lease (the #5081-class stall). 16 is a safer floor for concurrent
+/// holders while staying modest against a server's `max_connections`. Tune per
+/// deployment via the `IRONCLAW_REBORN_POSTGRES_POOL_MAX_SIZE` env override,
+/// which takes precedence over this default.
 #[cfg(feature = "postgres")]
-pub const DEFAULT_POSTGRES_POOL_MAX_SIZE: usize = 2;
+pub const DEFAULT_POSTGRES_POOL_MAX_SIZE: usize = 16;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct PostgresPoolTlsOptions {

--- a/docker/reborn/config.hosted-single-tenant.toml
+++ b/docker/reborn/config.hosted-single-tenant.toml
@@ -20,14 +20,16 @@ backend = "postgres"
 url_env = "IRONCLAW_REBORN_POSTGRES_URL"
 secret_master_key_env = "IRONCLAW_REBORN_SECRET_MASTER_KEY"
 # All Postgres-backed subsystems (turns, threads, messages, events, secrets)
-# share this single pool, and each filesystem op checks out a connection. A
+# share this single pool, and each filesystem op checks out a connection;
+# put_batch additionally holds a connection for the span of its BEGIN…COMMIT. A
 # size of 1-2 starves the heartbeat/webui under a single turn, so the runner
-# lease expires and the turn wedges. Size for runtime concurrency while staying
-# under the upstream pooler cap: the reference deployment fronts Postgres with
-# the Supabase Supavisor session pooler (default pool size ~15), so 10 leaves
-# headroom for migrations and any admin sessions. Override at runtime without a
-# redeploy via IRONCLAW_REBORN_POSTGRES_POOL_MAX_SIZE (env wins over this file).
-pool_max_size = 10
+# lease expires and the turn wedges. 16 matches DEFAULT_POSTGRES_POOL_MAX_SIZE
+# for batch headroom. NOTE: the reference deployment fronts Postgres with the
+# Supabase Supavisor session pooler (default pool size ~15); confirm 16 stays
+# within the upstream pooler cap (and the server max_connections) before rollout,
+# and lower this value if the pooler ceiling is ~15. Override at runtime without
+# a redeploy via IRONCLAW_REBORN_POSTGRES_POOL_MAX_SIZE (env wins over this file).
+pool_max_size = 16
 # Remote Postgres defaults to TLS. For trusted private-network deployments
 # where the provider cannot complete TLS, set both DATABASE_SSLMODE=disable
 # and IRONCLAW_REBORN_ALLOW_REMOTE_POSTGRES_CLEAR_TEXT=true.

--- a/docker/reborn/config.production.toml
+++ b/docker/reborn/config.production.toml
@@ -31,7 +31,11 @@ regex_activation_enabled = true
 backend = "postgres"
 url_env = "IRONCLAW_REBORN_POSTGRES_URL"
 secret_master_key_env = "IRONCLAW_REBORN_SECRET_MASTER_KEY"
-pool_max_size = 2
+# Matches DEFAULT_POSTGRES_POOL_MAX_SIZE: all Postgres-backed subsystems share
+# this pool and put_batch holds a connection for its BEGIN…COMMIT, so a size of
+# 2 starved every other consumer. Override at runtime without a redeploy via
+# IRONCLAW_REBORN_POSTGRES_POOL_MAX_SIZE (env wins over this file).
+pool_max_size = 16
 # Remote Postgres defaults to TLS. For trusted private-network deployments
 # where the provider cannot complete TLS, set both DATABASE_SSLMODE=disable
 # and IRONCLAW_REBORN_ALLOW_REMOTE_POSTGRES_CLEAR_TEXT=true.

--- a/tests/dockerfile_runtime_home.rs
+++ b/tests/dockerfile_runtime_home.rs
@@ -177,7 +177,7 @@ fn reborn_hosted_single_tenant_seed_config_contains_postgres_storage() {
         "hosted seed config must include Postgres storage"
     );
     assert!(
-        config.contains("pool_max_size = 10"),
+        config.contains("pool_max_size = 16"),
         "hosted seed config must size the shared Postgres pool for runtime concurrency"
     );
     assert!(


### PR DESCRIPTION
**Stack 2/5** · base `feat/ns-pr1-putbatch-trait`

Postgres is `TxnCapability::MultiKey`, so the PR-1 default `put_batch` (begin/`StorageTxn` BEGIN…COMMIT, Drop-safe) already serves atomic batches. This PR:
- Advertises `Capability::BatchPut` on Postgres.
- Fixes pool sizing where it actually takes effect: `DEFAULT_POSTGRES_POOL_MAX_SIZE` 2→16 **and** `config.production.toml` / `config.hosted-single-tenant.toml` → 16 (config overrides the default).

No hand-rolled native override — code-review found it duplicated the default and **lacked the Drop rollback guard** (txn leak on cancel/panic), so it was deleted.

⚠️ **Pool size 16 needs sign-off** vs the DB server / Supavisor session-pooler (~15) ceiling on hosted. Adjust the hosted value if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
