### PR TITLE
feat(filesystem): add get_batch read primitive + shared composite dispatcher (5/5)

### DIFF
--- a/crates/ironclaw_filesystem/src/catalog.rs
+++ b/crates/ironclaw_filesystem/src/catalog.rs
@@ -126,6 +126,43 @@ impl CompositeRootFilesystem {
             .max_by_key(|mount| mount.descriptor.virtual_root.as_str().len())
             .ok_or_else(|| FilesystemError::MountNotFound { path: path.clone() })
     }
+
+    /// Resolve a multi-path batch to the single [`CompositeMount`] that owns
+    /// every path, or fail closed.
+    ///
+    /// A batch may not straddle mounts: every path must resolve to the same
+    /// mount as the first item, else the whole call fails `PathOutsideMount`.
+    /// Mount identity is compared by pointer on the resolved `CompositeMount`,
+    /// so one `matching_mount` resolve per path settles routing. Shared by
+    /// [`put_batch`](RootFilesystem::put_batch) and
+    /// [`get_batch`](RootFilesystem::get_batch) composite dispatch.
+    ///
+    /// An empty `items` slice returns [`FilesystemError::BackendInfrastructure`]
+    /// (`op`) — no path is in scope to resolve. Callers whose empty case is a
+    /// valid no-op (e.g. `get_batch`) must short-circuit *before* calling this.
+    fn resolve_single_mount_batch<'a, T>(
+        &'a self,
+        items: &[T],
+        path_of: impl Fn(&T) -> &VirtualPath,
+        op: FilesystemOperation,
+    ) -> Result<&'a CompositeMount, FilesystemError> {
+        let Some(first) = items.first() else {
+            return Err(FilesystemError::BackendInfrastructure {
+                operation: op,
+                reason: "empty batch".to_string(),
+            });
+        };
+        let first_mount = self.matching_mount(path_of(first))?;
+        for item in &items[1..] {
+            let mount = self.matching_mount(path_of(item))?;
+            if !std::ptr::eq(mount, first_mount) {
+                return Err(FilesystemError::PathOutsideMount {
+                    path: path_of(item).clone(),
+                });
+            }
+        }
+        Ok(first_mount)
+    }
 }
 
 impl Default for CompositeRootFilesystem {
@@ -267,27 +304,28 @@ impl RootFilesystem for CompositeRootFilesystem {
         self.matching_mount(path)?.backend.begin(path).await
     }
 
-    // A batch may not straddle mounts: every path must resolve to the same
-    // mount as the first leg, else the whole call fails `PathOutsideMount` and
-    // nothing is written. Identity is compared by pointer on the resolved
-    // `CompositeMount`, so a single resolve per path settles routing.
+    // A write batch may not straddle mounts (see `resolve_single_mount_batch`):
+    // every path must resolve to the same mount as the first leg, else the whole
+    // call fails `PathOutsideMount` and nothing is written.
     async fn put_batch(&self, puts: Vec<BatchPut>) -> Result<Vec<RecordVersion>, FilesystemError> {
-        if puts.is_empty() {
-            return Err(FilesystemError::BackendInfrastructure {
-                operation: FilesystemOperation::PutBatch,
-                reason: "empty put_batch".to_string(),
-            });
+        let mount =
+            self.resolve_single_mount_batch(&puts, |p| &p.path, FilesystemOperation::PutBatch)?;
+        mount.backend.put_batch(puts).await
+    }
+
+    // Read analogue of `put_batch`. Empty is a valid no-op (`Ok(vec![])`), so we
+    // short-circuit before resolving a mount; otherwise the same single-mount
+    // dispatcher routes every path to one backend `get_batch`.
+    async fn get_batch(
+        &self,
+        paths: Vec<VirtualPath>,
+    ) -> Result<Vec<Option<VersionedEntry>>, FilesystemError> {
+        if paths.is_empty() {
+            return Ok(Vec::new());
         }
-        let first_mount = self.matching_mount(&puts[0].path)?;
-        for put in &puts[1..] {
-            let mount = self.matching_mount(&put.path)?;
-            if !std::ptr::eq(mount, first_mount) {
-                return Err(FilesystemError::PathOutsideMount {
-                    path: put.path.clone(),
-                });
-            }
-        }
-        first_mount.backend.put_batch(puts).await
+        let mount =
+            self.resolve_single_mount_batch(&paths, |p| p, FilesystemOperation::ReadFile)?;
+        mount.backend.get_batch(paths).await
     }
 
     // ── Event plane ──
@@ -491,5 +529,80 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    #[tokio::test]
+    async fn get_batch_routes_to_owning_mount_in_order_with_none() {
+        // Through the composite dispatcher: seed a and c on the /secrets mount,
+        // skip b, and read [a,b,c] in one call. The shared single-mount
+        // dispatcher routes all three to the one backend, which returns
+        // [Some(a), None, Some(c)] in input order.
+        let mut composite = CompositeRootFilesystem::new();
+        let secrets = Arc::new(InMemoryBackend::new());
+        composite
+            .mount(descriptor("/secrets"), secrets.clone())
+            .unwrap();
+        secrets
+            .put(
+                &vp("/secrets/leases/a"),
+                Entry::bytes(vec![0xA]),
+                CasExpectation::Absent,
+            )
+            .await
+            .unwrap();
+        secrets
+            .put(
+                &vp("/secrets/leases/c"),
+                Entry::bytes(vec![0xC]),
+                CasExpectation::Absent,
+            )
+            .await
+            .unwrap();
+
+        let out = composite
+            .get_batch(vec![
+                vp("/secrets/leases/a"),
+                vp("/secrets/leases/b"),
+                vp("/secrets/leases/c"),
+            ])
+            .await
+            .unwrap();
+        assert_eq!(out.len(), 3);
+        assert_eq!(out[0].as_ref().unwrap().entry.body, vec![0xA]);
+        assert!(out[1].is_none());
+        assert_eq!(out[2].as_ref().unwrap().entry.body, vec![0xC]);
+    }
+
+    #[tokio::test]
+    async fn get_batch_empty_is_ok_noop() {
+        // The composite short-circuits an empty read batch to Ok(vec![]) before
+        // resolving any mount — unlike the empty put_batch, which is an error.
+        let composite = CompositeRootFilesystem::new();
+        let out = composite.get_batch(Vec::new()).await.unwrap();
+        assert!(out.is_empty());
+    }
+
+    #[tokio::test]
+    async fn get_batch_cross_mount_rejected() {
+        // A read batch may not straddle mounts: same single-mount dispatcher as
+        // put_batch, so a path on a second mount fails PathOutsideMount.
+        let mut composite = CompositeRootFilesystem::new();
+        let secrets = Arc::new(InMemoryBackend::new());
+        let memory = Arc::new(InMemoryBackend::new());
+        composite
+            .mount(descriptor("/secrets"), secrets.clone())
+            .unwrap();
+        composite
+            .mount(descriptor("/memory"), memory.clone())
+            .unwrap();
+
+        let err = composite
+            .get_batch(vec![vp("/secrets/leases/a"), vp("/memory/docs/b")])
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, FilesystemError::PathOutsideMount { .. }),
+            "cross-mount get_batch must be rejected, got {err:?}"
+        );
     }
 }

--- a/crates/ironclaw_filesystem/src/in_memory.rs
+++ b/crates/ironclaw_filesystem/src/in_memory.rs
@@ -161,6 +161,39 @@ impl RootFilesystem for InMemoryBackend {
         }))
     }
 
+    async fn get_batch(
+        &self,
+        paths: Vec<VirtualPath>,
+    ) -> Result<Vec<Option<VersionedEntry>>, FilesystemError> {
+        if paths.is_empty() {
+            return Ok(Vec::new());
+        }
+        if paths.len() > crate::MAX_BATCH_GETS {
+            return Err(FilesystemError::BackendInfrastructure {
+                operation: FilesystemOperation::ReadFile,
+                reason: format!(
+                    "get_batch has {} paths, exceeding MAX_BATCH_GETS ({})",
+                    paths.len(),
+                    crate::MAX_BATCH_GETS
+                ),
+            });
+        }
+        // Native fast path: acquire the single `Mutex<State>` once and look up
+        // every path under it, returning one slot per input path in input order
+        // (`None` = absent). No `.await` while the lock is held.
+        let state = self.state.lock().await;
+        Ok(paths
+            .into_iter()
+            .map(|path| {
+                state.entries.get(&path).map(|stored| VersionedEntry {
+                    path,
+                    entry: stored.entry.clone(),
+                    version: stored.version,
+                })
+            })
+            .collect())
+    }
+
     async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
         let mut state = self.state.lock().await;
         // PR #3659 reviewer fix: delete now matches the SQL backends'
@@ -1538,5 +1571,61 @@ mod tests {
         );
         assert!(fs.get(&vpath("/memory/a")).await.unwrap().is_none());
         assert!(fs.get(&vpath("/turns/b")).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn get_batch_returns_results_in_input_order_with_none_for_absent() {
+        // Seed a and c, skip b. get_batch([a,b,c]) must yield
+        // [Some(a), None, Some(c)] — one slot per input path, in input order.
+        let fs = InMemoryBackend::new();
+        let a = vpath("/secrets/leases/a");
+        let b = vpath("/secrets/leases/b");
+        let c = vpath("/secrets/leases/c");
+        fs.put(&a, Entry::bytes(vec![0xA]), CasExpectation::Absent)
+            .await
+            .unwrap();
+        fs.put(&c, Entry::bytes(vec![0xC]), CasExpectation::Absent)
+            .await
+            .unwrap();
+
+        let out = fs
+            .get_batch(vec![a.clone(), b.clone(), c.clone()])
+            .await
+            .unwrap();
+        assert_eq!(out.len(), 3);
+        assert_eq!(out[0].as_ref().unwrap().path, a);
+        assert_eq!(out[0].as_ref().unwrap().entry.body, vec![0xA]);
+        assert!(out[1].is_none());
+        assert_eq!(out[2].as_ref().unwrap().path, c);
+        assert_eq!(out[2].as_ref().unwrap().entry.body, vec![0xC]);
+    }
+
+    #[tokio::test]
+    async fn get_batch_empty_is_ok_noop() {
+        // Unlike put_batch, an empty read batch is a valid no-op (not an error).
+        let fs = InMemoryBackend::new();
+        let out = fs.get_batch(Vec::new()).await.unwrap();
+        assert!(out.is_empty());
+    }
+
+    #[tokio::test]
+    async fn get_batch_exceeding_cap_rejected() {
+        // A read batch larger than MAX_BATCH_GETS surfaces a typed
+        // BackendInfrastructure error rather than running a giant query.
+        let fs = InMemoryBackend::new();
+        let paths: Vec<VirtualPath> = (0..=crate::MAX_BATCH_GETS)
+            .map(|i| vpath(&format!("/secrets/leases/cap/L{i}")))
+            .collect();
+        assert!(paths.len() > crate::MAX_BATCH_GETS);
+        match fs.get_batch(paths).await.unwrap_err() {
+            FilesystemError::BackendInfrastructure {
+                operation: FilesystemOperation::ReadFile,
+                reason,
+            } => assert!(
+                reason.contains("MAX_BATCH_GETS"),
+                "expected cap reason, got {reason}"
+            ),
+            other => panic!("expected BackendInfrastructure cap error, got {other:?}"),
+        }
     }
 }

--- a/crates/ironclaw_filesystem/src/lib.rs
+++ b/crates/ironclaw_filesystem/src/lib.rs
@@ -46,7 +46,7 @@ pub use postgres::PostgresRootFilesystem;
 pub use record::{
     CasExpectation, ContentType, Entry, RecordKind, RecordVersion, SeqNo, VersionedEntry,
 };
-pub use root::{BatchPut, MAX_BATCH_PUTS, RootFilesystem};
+pub use root::{BatchPut, MAX_BATCH_GETS, MAX_BATCH_PUTS, RootFilesystem};
 pub use scoped::{MountViewResolver, ScopedBatchPut, ScopedFilesystem};
 pub use types::{
     BackendCapabilities, BackendId, BackendKind, Capability, ContentKind, DirEntry, FileStat,

--- a/crates/ironclaw_filesystem/src/libsql.rs
+++ b/crates/ironclaw_filesystem/src/libsql.rs
@@ -328,6 +328,27 @@ impl RootFilesystem for LibSqlRootFilesystem {
         libsql_get_on_conn(&conn, path).await
     }
 
+    async fn get_batch(
+        &self,
+        paths: Vec<VirtualPath>,
+    ) -> Result<Vec<Option<VersionedEntry>>, FilesystemError> {
+        if paths.is_empty() {
+            return Ok(Vec::new());
+        }
+        if paths.len() > crate::MAX_BATCH_GETS {
+            return Err(FilesystemError::BackendInfrastructure {
+                operation: FilesystemOperation::ReadFile,
+                reason: format!(
+                    "get_batch has {} paths, exceeding MAX_BATCH_GETS ({})",
+                    paths.len(),
+                    crate::MAX_BATCH_GETS
+                ),
+            });
+        }
+        let conn = self.connect().await?;
+        libsql_get_batch_on_conn(&conn, paths).await
+    }
+
     async fn ensure_index(
         &self,
         path: &VirtualPath,
@@ -1498,6 +1519,87 @@ async fn libsql_get_on_conn(
         entry,
         version: record_version_from_i64(path, version_raw)?,
     }))
+}
+
+/// Read every requested path via chunked `WHERE path IN (?,…)` queries and
+/// reassemble into one slot per input path, **in input order** (`None` =
+/// absent or a directory row). Reuses the same row→[`VersionedEntry`] decoding
+/// as [`libsql_get_on_conn`].
+#[cfg(feature = "libsql")]
+async fn libsql_get_batch_on_conn(
+    conn: &libsql::Connection,
+    paths: Vec<VirtualPath>,
+) -> Result<Vec<Option<VersionedEntry>>, FilesystemError> {
+    // SQLite caps bound parameters per statement (~999). Each path is one `IN`
+    // placeholder, so chunk well under that ceiling — mirrors the chunking in
+    // `append_batch`. Index decoded rows by path string and clone out of the
+    // map so the result is one slot per input path in input order, correct even
+    // when the input contains duplicate paths.
+    const PATHS_PER_STATEMENT: usize = 512;
+    // The batch query has no single path in scope; attribute any infrastructure
+    // error to the first requested path. `paths` is non-empty (caller's guard).
+    let probe = paths[0].clone();
+    let mut by_path: std::collections::HashMap<String, VersionedEntry> =
+        std::collections::HashMap::with_capacity(paths.len());
+    for chunk in paths.chunks(PATHS_PER_STATEMENT) {
+        let placeholders = std::iter::repeat_n("?", chunk.len())
+            .collect::<Vec<_>>()
+            .join(",");
+        let sql = format!(
+            "SELECT path, contents, is_dir, content_type, kind, indexed, version \
+             FROM root_filesystem_entries WHERE path IN ({placeholders})"
+        );
+        let params: Vec<libsql::Value> = chunk
+            .iter()
+            .map(|p| libsql::Value::Text(p.as_str().to_string()))
+            .collect();
+        let mut rows = conn.query(&sql, params).await.map_err(|error| {
+            libsql_db_error(probe.clone(), FilesystemOperation::ReadFile, error)
+        })?;
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|error| libsql_db_error(probe.clone(), FilesystemOperation::ReadFile, error))?
+        {
+            let is_dir: i64 = row.get(2).map_err(|error| {
+                libsql_db_error(probe.clone(), FilesystemOperation::ReadFile, error)
+            })?;
+            if is_dir != 0 {
+                continue;
+            }
+            let row_path_str: String = row.get(0).map_err(|error| {
+                libsql_db_error(probe.clone(), FilesystemOperation::ReadFile, error)
+            })?;
+            let row_path = VirtualPath::new(row_path_str.clone())?;
+            let body: Vec<u8> = row.get(1).map_err(|error| {
+                libsql_db_error(row_path.clone(), FilesystemOperation::ReadFile, error)
+            })?;
+            let content_type_raw: String = row.get(3).map_err(|error| {
+                libsql_db_error(row_path.clone(), FilesystemOperation::ReadFile, error)
+            })?;
+            let kind_raw: Option<String> = row.get(4).ok();
+            let indexed_raw: String = row.get(5).map_err(|error| {
+                libsql_db_error(row_path.clone(), FilesystemOperation::ReadFile, error)
+            })?;
+            let version_raw: i64 = row.get(6).map_err(|error| {
+                libsql_db_error(row_path.clone(), FilesystemOperation::ReadFile, error)
+            })?;
+            let entry = build_entry(&row_path, body, content_type_raw, kind_raw, indexed_raw)?;
+            let version = record_version_from_i64(&row_path, version_raw)?;
+            by_path.insert(
+                row_path_str,
+                VersionedEntry {
+                    path: row_path,
+                    entry,
+                    version,
+                },
+            );
+        }
+    }
+    Ok(paths
+        .into_iter()
+        .map(|path| by_path.get(path.as_str()).cloned())
+        .collect())
 }
 
 /// Delete the row (and any descendants) at `path` on the supplied (possibly

--- a/crates/ironclaw_filesystem/src/postgres.rs
+++ b/crates/ironclaw_filesystem/src/postgres.rs
@@ -187,6 +187,27 @@ impl RootFilesystem for PostgresRootFilesystem {
         postgres_get_with_client(&client, path).await
     }
 
+    async fn get_batch(
+        &self,
+        paths: Vec<VirtualPath>,
+    ) -> Result<Vec<Option<VersionedEntry>>, FilesystemError> {
+        if paths.is_empty() {
+            return Ok(Vec::new());
+        }
+        if paths.len() > crate::MAX_BATCH_GETS {
+            return Err(FilesystemError::BackendInfrastructure {
+                operation: FilesystemOperation::ReadFile,
+                reason: format!(
+                    "get_batch has {} paths, exceeding MAX_BATCH_GETS ({})",
+                    paths.len(),
+                    crate::MAX_BATCH_GETS
+                ),
+            });
+        }
+        let client = self.client().await?;
+        postgres_get_batch_with_client(&client, paths).await
+    }
+
     async fn ensure_index(
         &self,
         path: &VirtualPath,
@@ -1385,6 +1406,66 @@ async fn postgres_get_with_client(
         entry,
         version: record_version_from_i64(path, version_raw)?,
     }))
+}
+
+/// Read every requested path in one `WHERE path = ANY($1)` query and
+/// reassemble the rows into one slot per input path, **in input order**
+/// (`None` = absent or a directory row). Reuses the same row→[`VersionedEntry`]
+/// decoding the single-path [`postgres_get_with_client`] uses. Indexing by path
+/// string and cloning out of the map (rather than draining) keeps the result
+/// correct even when the input contains duplicate paths.
+#[cfg(feature = "postgres")]
+async fn postgres_get_batch_with_client(
+    client: &deadpool_postgres::Object,
+    paths: Vec<VirtualPath>,
+) -> Result<Vec<Option<VersionedEntry>>, FilesystemError> {
+    // Probe path for any infrastructure error: the batch query has no single
+    // path in scope, so attribute it to the first requested path. `paths` is
+    // guaranteed non-empty by the caller's guard.
+    let probe = paths[0].clone();
+    let path_strs: Vec<&str> = paths.iter().map(|p| p.as_str()).collect();
+    let rows = cached_query(
+        client,
+        r#"
+            SELECT path, contents, is_dir, content_type, kind, indexed, version
+            FROM root_filesystem_entries
+            WHERE path = ANY($1)
+            "#,
+        &[&path_strs],
+    )
+    .await
+    .map_err(|error| db_error(probe, FilesystemOperation::ReadFile, error))?;
+
+    let mut by_path: std::collections::HashMap<String, VersionedEntry> =
+        std::collections::HashMap::with_capacity(rows.len());
+    for row in &rows {
+        // A directory row is `None` to readers, mirroring `get`.
+        let is_dir: bool = row.get("is_dir");
+        if is_dir {
+            continue;
+        }
+        let row_path_str: String = row.get("path");
+        let row_path = VirtualPath::new(row_path_str.clone())?;
+        let body: Vec<u8> = row.get("contents");
+        let content_type_raw: String = row.get("content_type");
+        let kind_raw: Option<String> = row.get("kind");
+        let indexed_value: serde_json::Value = row.get("indexed");
+        let version_raw: i64 = row.get("version");
+        let entry = build_entry(&row_path, body, content_type_raw, kind_raw, indexed_value)?;
+        let version = record_version_from_i64(&row_path, version_raw)?;
+        by_path.insert(
+            row_path_str,
+            VersionedEntry {
+                path: row_path,
+                entry,
+                version,
+            },
+        );
+    }
+    Ok(paths
+        .into_iter()
+        .map(|path| by_path.get(path.as_str()).cloned())
+        .collect())
 }
 
 #[cfg(feature = "postgres")]

--- a/crates/ironclaw_filesystem/src/root.rs
+++ b/crates/ironclaw_filesystem/src/root.rs
@@ -22,6 +22,14 @@ pub struct BatchPut {
 /// `put_batch` overrides reuse this same cap rather than defining their own.
 pub const MAX_BATCH_PUTS: usize = 64;
 
+/// Universal upper bound on the number of paths in a single
+/// [`get_batch`](RootFilesystem::get_batch). Deliberately **not**
+/// [`MAX_BATCH_PUTS`]: a read batch has no transaction legs to bound, so the
+/// motivation is different — SQL `IN`-clause / `= ANY` payload size and the
+/// per-statement bound-parameter ceiling, not multi-key txn cost. A read batch
+/// is therefore allowed to be considerably larger than a write batch.
+pub const MAX_BATCH_GETS: usize = 256;
+
 /// Unified filesystem interface over canonical virtual paths.
 ///
 /// Both individual storage backends (local files, Postgres, libSQL, HSM,
@@ -249,6 +257,46 @@ pub trait RootFilesystem: Send + Sync {
                 Ok(versions)
             }
         }
+    }
+
+    /// Read several entries in one call.
+    ///
+    /// Returns one [`Option<VersionedEntry>`] per input path, **in input
+    /// order** (`None` = the path holds no entry). This is the read analogue
+    /// of [`put_batch`](Self::put_batch): a pure-latency collapse of N serial
+    /// [`get`](Self::get) round-trips into one. There is **no** atomicity and
+    /// **no** CAS — a read batch observes whatever each path holds when the
+    /// backend reads it; it carries no all-or-nothing promise.
+    ///
+    /// Availability contract:
+    /// - `paths.len() == 0` is a valid no-op and returns `Ok(vec![])` — unlike
+    ///   the empty `put_batch`, an empty read has nothing to fail on.
+    /// - `paths.len() > MAX_BATCH_GETS` returns
+    ///   [`FilesystemError::BackendInfrastructure`].
+    ///
+    /// The default impl reads sequentially through [`get`](Self::get), so
+    /// `get_batch` is **always available** on every backend. Native backends
+    /// override it with a single `WHERE path IN (…)` / `= ANY` query for the
+    /// latency win — they are merely faster, never required — so this primitive
+    /// intentionally needs no [`Capability`](crate::Capability) bit.
+    async fn get_batch(
+        &self,
+        paths: Vec<VirtualPath>,
+    ) -> Result<Vec<Option<VersionedEntry>>, FilesystemError> {
+        if paths.is_empty() {
+            return Ok(Vec::new());
+        }
+        if paths.len() > MAX_BATCH_GETS {
+            return Err(FilesystemError::BackendInfrastructure {
+                operation: FilesystemOperation::ReadFile,
+                reason: "batch exceeds MAX_BATCH_GETS".to_string(),
+            });
+        }
+        let mut out = Vec::with_capacity(paths.len());
+        for path in &paths {
+            out.push(self.get(path).await?);
+        }
+        Ok(out)
     }
 
     // ─── Event plane (append/tail) ────────────────────────────────────────

--- a/crates/ironclaw_filesystem/src/scoped.rs
+++ b/crates/ironclaw_filesystem/src/scoped.rs
@@ -161,6 +161,34 @@ where
         self.root.get(&virtual_path).await
     }
 
+    /// Read several entries in one call.
+    ///
+    /// Each [`ScopedPath`] is resolved and permission-checked (as a read)
+    /// against this scope's [`MountView`] before any backend dispatch; the
+    /// resolved [`VirtualPath`]s are then handed to
+    /// [`RootFilesystem::get_batch`], which returns one
+    /// [`Option<VersionedEntry>`] per path in input order (`None` = absent).
+    /// Pure latency: no atomicity, no CAS. The mount view is resolved once for
+    /// the whole batch; per-path authorization mirrors the per-leg loop in
+    /// [`put_batch`](Self::put_batch). See [`RootFilesystem::get_batch`] for the
+    /// always-available / empty-is-`Ok(vec![])` contract.
+    pub async fn get_batch(
+        &self,
+        scope: &ResourceScope,
+        paths: Vec<ScopedPath>,
+    ) -> Result<Vec<Option<VersionedEntry>>, FilesystemError> {
+        let view = self.mount_view(scope)?;
+        let mut resolved = Vec::with_capacity(paths.len());
+        for path in &paths {
+            resolved.push(resolve_with_permission_view(
+                &view,
+                path,
+                FilesystemOperation::ReadFile,
+            )?);
+        }
+        self.root.get_batch(resolved).await
+    }
+
     /// Filtered query over `prefix`.
     pub async fn query(
         &self,

--- a/crates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
+++ b/crates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
@@ -1586,6 +1586,40 @@ async fn libsql_put_batch_empty_rejected() {
 }
 
 #[cfg(feature = "libsql")]
+#[tokio::test]
+async fn libsql_get_batch_returns_results_in_input_order_with_none() {
+    // Native chunked `WHERE path IN (?,…)` path: seed a and c, skip b, and read
+    // [a,b,c] in one pass. The result is reassembled into one slot per input
+    // path in input order (`None` = absent).
+    let filesystem = libsql_root().await;
+    let a = VirtualPath::new("/secrets/leases/getbatch/a").unwrap();
+    let b = VirtualPath::new("/secrets/leases/getbatch/b").unwrap();
+    let c = VirtualPath::new("/secrets/leases/getbatch/c").unwrap();
+    filesystem
+        .put(&a, Entry::bytes(vec![0xA]), CasExpectation::Absent)
+        .await
+        .unwrap();
+    filesystem
+        .put(&c, Entry::bytes(vec![0xC]), CasExpectation::Absent)
+        .await
+        .unwrap();
+
+    let out = filesystem
+        .get_batch(vec![a.clone(), b.clone(), c.clone()])
+        .await
+        .unwrap();
+    assert_eq!(out.len(), 3);
+    assert_eq!(out[0].as_ref().unwrap().path, a);
+    assert_eq!(out[0].as_ref().unwrap().entry.body, vec![0xA]);
+    assert!(out[1].is_none());
+    assert_eq!(out[2].as_ref().unwrap().path, c);
+    assert_eq!(out[2].as_ref().unwrap().entry.body, vec![0xC]);
+
+    // Empty read batch is a valid no-op (unlike empty put_batch).
+    assert!(filesystem.get_batch(Vec::new()).await.unwrap().is_empty());
+}
+
+#[cfg(feature = "libsql")]
 async fn libsql_root() -> TestLibSqlRootFilesystem {
     let db_dir = tempfile::tempdir().unwrap();
     let db_path = db_dir.path().join("root-filesystem.db");
@@ -2081,6 +2115,39 @@ mod postgres_tests {
         };
         let path = vpath(&prefix, "missing");
         assert!(fs.get(&path).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn postgres_get_batch_returns_results_in_input_order_with_none() {
+        // Native `WHERE path = ANY($1)` path: seed a and c, skip b, and read
+        // [a,b,c] in one query. The result is reassembled into one slot per
+        // input path in input order (`None` = absent).
+        let Some((fs, prefix)) = postgres_root().await else {
+            return;
+        };
+        let a = vpath(&prefix, "a");
+        let b = vpath(&prefix, "b");
+        let c = vpath(&prefix, "c");
+        fs.put(&a, Entry::bytes(vec![0xA]), CasExpectation::Absent)
+            .await
+            .unwrap();
+        fs.put(&c, Entry::bytes(vec![0xC]), CasExpectation::Absent)
+            .await
+            .unwrap();
+
+        let out = fs
+            .get_batch(vec![a.clone(), b.clone(), c.clone()])
+            .await
+            .unwrap();
+        assert_eq!(out.len(), 3);
+        assert_eq!(out[0].as_ref().unwrap().path, a);
+        assert_eq!(out[0].as_ref().unwrap().entry.body, vec![0xA]);
+        assert!(out[1].is_none());
+        assert_eq!(out[2].as_ref().unwrap().path, c);
+        assert_eq!(out[2].as_ref().unwrap().entry.body, vec![0xC]);
+
+        // Empty read batch is a valid no-op (unlike empty put_batch).
+        assert!(fs.get_batch(Vec::new()).await.unwrap().is_empty());
     }
 
     #[tokio::test]

--- a/crates/ironclaw_filesystem/tests/filesystem_contract.rs
+++ b/crates/ironclaw_filesystem/tests/filesystem_contract.rs
@@ -503,6 +503,60 @@ async fn read_requires_read_permission_through_scoped_api() {
 }
 
 #[tokio::test]
+async fn get_batch_requires_read_permission_and_returns_in_order_with_none() {
+    let storage = tempdir().unwrap();
+    std::fs::create_dir_all(storage.path().join("project1")).unwrap();
+    std::fs::write(storage.path().join("project1/a.txt"), b"AA").unwrap();
+    std::fs::write(storage.path().join("project1/c.txt"), b"CC").unwrap();
+
+    // Denied: every leg is permission-checked as a read before any backend
+    // dispatch, so a write-only grant fails closed with PermissionDenied{ReadFile}.
+    let write_only = scoped_project_fs(
+        storage.path(),
+        MountPermissions {
+            read: false,
+            write: true,
+            delete: false,
+            list: true,
+            execute: false,
+        },
+    );
+    let err = write_only
+        .get_batch(
+            &ResourceScope::system(),
+            vec![ScopedPath::new("/workspace/a.txt").unwrap()],
+        )
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        FilesystemError::PermissionDenied {
+            operation: FilesystemOperation::ReadFile,
+            ..
+        }
+    ));
+
+    // Granted: read permission yields one slot per input path, in input order,
+    // None for the absent middle path.
+    let readable = scoped_project_fs(storage.path(), MountPermissions::read_only());
+    let out = readable
+        .get_batch(
+            &ResourceScope::system(),
+            vec![
+                ScopedPath::new("/workspace/a.txt").unwrap(),
+                ScopedPath::new("/workspace/missing.txt").unwrap(),
+                ScopedPath::new("/workspace/c.txt").unwrap(),
+            ],
+        )
+        .await
+        .unwrap();
+    assert_eq!(out.len(), 3);
+    assert_eq!(out[0].as_ref().unwrap().entry.body, b"AA".to_vec());
+    assert!(out[1].is_none());
+    assert_eq!(out[2].as_ref().unwrap().entry.body, b"CC".to_vec());
+}
+
+#[tokio::test]
 async fn stat_is_allowed_by_read_or_list_and_denied_without_both() {
     let storage = tempdir().unwrap();
     std::fs::create_dir_all(storage.path().join("project1")).unwrap();


### PR DESCRIPTION
**Stack 5/5** · base `feat/ns-pr4-inmemory`

Adds `get_batch` — the read analogue of `put_batch` — to collapse N serial `get()` round-trips into one. Pure latency, **no atomicity, no capability bit**.
- Default: sequential `get` (empty → `Ok(vec![])`, cap `MAX_BATCH_GETS=256`). Read permission via existing `ReadFile` (no new `FilesystemOperation` variant).
- Natives: Postgres `WHERE path = ANY($1)`, libSQL chunked `WHERE path IN (…)` — both reassembled into `Vec<Option<VersionedEntry>>` in **input order**, `None` for missing. In-memory single lock.
- **Consolidation:** extracts `resolve_single_mount_batch` (composite same-mount dispatcher) now shared by `put_batch` and `get_batch` — per thermo-nuclear review (the batch family stays separate; duplication killed at the composite layer).

Serves the governor's per-account pre-reads and the surface-auth read batching. `cargo test -p ironclaw_filesystem` (lib 100, contract 44/25/7) + workspace build green; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
