### PR TITLE
[codex] Add Reborn WebUI legacy E2E harness

### DIFF
--- a/tests/e2e/helpers.py
+++ b/tests/e2e/helpers.py
@@ -236,8 +236,44 @@ SEL_V2 = {
     "msg_user":       "[data-testid='msg-user']",       # user message bubble
     "msg_assistant":  "[data-testid='msg-assistant']",  # assistant message bubble
     "msg_system":     "[data-testid='msg-system']",     # system notice bubble
+    "message_list_scroll": "[data-testid='message-list-scroll']",
+    "message_list_content": "[data-testid='message-list-content']",
+    "message_list_load_older": "[data-testid='message-list-load-older']",
+    "auth_gate":      "[data-testid='auth-gate']",
+    "auth_gate_for":  "[data-testid='auth-gate'][data-auth-challenge='{kind}']",
+    "auth_token_input": "[data-testid='auth-token-input']",
+    "auth_oauth_open": "[data-testid='auth-oauth-open']",
+    "channel_connect_card": "[data-testid='channel-connect-card']",
+    "channel_connect_card_for": (
+        "[data-testid='channel-connect-card'][data-channel='{channel}']"
+        "[data-strategy='{strategy}']"
+    ),
+    "channel_connect_dismiss": "[data-testid='channel-connect-dismiss']",
+    "slack_pairing_section": "[data-testid='slack-pairing-section']",
+    "slack_pairing_code_input": "[data-testid='slack-pairing-code-input']",
+    "slack_pairing_submit": "[data-testid='slack-pairing-submit']",
+    "slack_pairing_success": "[data-testid='slack-pairing-success']",
+    "slack_pairing_error": "[data-testid='slack-pairing-error']",
     "approval_card":  "[data-testid='approval-card']",  # approval gate card
     "busy_gate_notice": "[data-testid='busy-gate-notice']",  # gate busy notice
+    "activity_run":   "[data-testid='activity-run']",
+    "activity_run_toggle": "[data-testid='activity-run-toggle']",
+    "activity_run_items": "[data-testid='activity-run-items']",
+    "tool_activity_card": "[data-testid='tool-activity-card']",
+    "tool_activity_card_for": "[data-testid='tool-activity-card'][data-tool-name='{name}']",
+    "tool_activity_toggle": "[data-testid='tool-activity-toggle']",
+    "tool_activity_detail": "[data-testid='tool-activity-detail']",
+    "projects_grid": "[data-testid='projects-grid']",
+    "projects_search_input": "[data-testid='projects-search-input']",
+    "project_card": "[data-testid='project-card']",
+    "project_card_for": "[data-testid='project-card'][data-project-id='{id}']",
+    "project_open_workspace": "[data-testid='project-open-workspace']",
+    "project_workspace": "[data-testid='project-workspace']",
+    "project_workspace_for": "[data-testid='project-workspace'][data-project-id='{id}']",
+    "project_workspace_title": "[data-testid='project-workspace-title']",
+    "project_filesystem_entry_for": (
+        "[data-testid='project-filesystem-entry'][data-entry-path='{path}']"
+    ),
     # Download chip for an agent-produced workspace file; `{path}` selects one.
     # Clicking a chip opens the shared attachment preview modal, whose footer
     # carries the Download action.

--- a/tests/e2e/mock_llm.py
+++ b/tests/e2e/mock_llm.py
@@ -33,13 +33,18 @@ CANNED_RESPONSES = [
     (re.compile(r"link test", re.IGNORECASE),
      "See [the pull request](https://example.com/pr/1) for details."),
     # Reborn v2 download chips: after the agent writes a CSV and a PDF (the
-    # write_file dispatch lives in TOOL_CALL_PATTERNS), it replies referencing
-    # their /workspace paths so the WebUI renders downloadable file chips. Fires
-    # after the tool calls run (match_tool_call dedups the already-run writes).
+    # builtin__write_file dispatch lives in TOOL_CALL_PATTERNS), it replies
+    # referencing their /workspace paths so the WebUI renders downloadable file
+    # chips. Fires after the tool calls run (match_tool_call dedups the
+    # already-run writes).
     (
         re.compile(r"produce a downloadable csv and pdf", re.IGNORECASE),
         "Done — I saved /workspace/report.csv and /workspace/report.pdf. "
         "Both are ready to download.",
+    ),
+    (
+        re.compile(r"reborn write approval file (?P<label>[a-z0-9_-]+)", re.IGNORECASE),
+        "Done - saved the approval test file.",
     ),
     (re.compile(r"\bhello\b|\bhi\b|\bhey\b", re.IGNORECASE), "Hello! How can I help you today?"),
     (re.compile(r"2\s*\+\s*2|two plus two", re.IGNORECASE), "The answer is 4."),
@@ -134,6 +139,17 @@ NOTION_SEARCH_LIFECYCLE_TRIGGER = re.compile(
 )
 
 TOOL_CALL_PATTERNS = [
+    # Reborn parallel tool-call port: the Reborn provider-visible builtin tool
+    # names are namespaced/sanitized, while the legacy engine keeps using the
+    # unqualified trigger below.
+    (
+        re.compile(r"reborn parallel echo and time", re.IGNORECASE),
+        "builtin__echo",
+        lambda _: [
+            {"tool_name": "builtin__echo", "arguments": {"message": "parallel-test"}},
+            {"tool_name": "builtin__time", "arguments": {"operation": "now"}},
+        ],
+    ),
     # Parallel tool calls: return both echo and time in one response
     (
         re.compile(r"parallel echo and time", re.IGNORECASE),
@@ -143,24 +159,36 @@ TOOL_CALL_PATTERNS = [
             {"tool_name": "time", "arguments": {"operation": "now"}},
         ],
     ),
+    (
+        re.compile(r"reborn builtin echo (.+)", re.IGNORECASE),
+        "builtin__echo",
+        lambda m: {"message": m.group(1)},
+    ),
+    (
+        re.compile(r"reborn builtin time", re.IGNORECASE),
+        "builtin__time",
+        lambda _: {"operation": "now"},
+    ),
     (re.compile(r"echo (.+)", re.IGNORECASE), "echo", lambda m: {"message": m.group(1)}),
     # Reborn v2 download chips: one assistant turn writes a CSV and a PDF into
-    # the project workspace. After both results land, match_tool_call dedups
-    # write_file and the conversation falls through to the CANNED_RESPONSES
-    # reply that references the two paths.
+    # the project workspace. Reborn exposes this first-party tool by capability
+    # id; the provider-facing tool name sanitizes dots as "__". After both
+    # results land, match_tool_call dedups builtin__write_file and the
+    # conversation falls through to the CANNED_RESPONSES reply that
+    # references the two paths.
     (
         re.compile(r"produce a downloadable csv and pdf", re.IGNORECASE),
-        "write_file",
+        "builtin__write_file",
         lambda _: [
             {
-                "tool_name": "write_file",
+                "tool_name": "builtin__write_file",
                 "arguments": {
                     "path": "/workspace/report.csv",
                     "content": "name,score\nalice,90\nbob,85\n",
                 },
             },
             {
-                "tool_name": "write_file",
+                "tool_name": "builtin__write_file",
                 "arguments": {
                     "path": "/workspace/report.pdf",
                     "content": (
@@ -170,6 +198,14 @@ TOOL_CALL_PATTERNS = [
                 },
             },
         ],
+    ),
+    (
+        re.compile(r"reborn write approval file (?P<label>[a-z0-9_-]+)", re.IGNORECASE),
+        "builtin__write_file",
+        lambda m: {
+            "path": f"/workspace/reborn-approval-{m.group('label')}.txt",
+            "content": f"approved {m.group('label')}\n",
+        },
     ),
     (
         re.compile(
@@ -952,11 +988,28 @@ def _active_skill_names(messages: list[dict]) -> set[str]:
     return names
 
 
+def _typed_user_content_for_skill_detection(messages: list[dict]) -> str:
+    """Return user-authored text without generated attachment context.
+
+    Reborn appends a model-visible ``<attachments>`` block to user messages so
+    tools can reason about uploaded files and their /workspace storage paths.
+    Those paths are not user-typed slash skills, so the mock's missing-skill
+    heuristic must ignore that generated block.
+    """
+    return re.sub(
+        r"\n+<attachments>.*?</attachments>\s*$",
+        "",
+        _last_user_content(messages),
+        flags=re.DOTALL,
+    )
+
+
 def _missing_explicit_skills(messages: list[dict]) -> list[str]:
     active = _active_skill_names(messages)
     missing = []
     seen = set()
-    for match in re.finditer(r'(^|[\s"\(])/(?P<name>[A-Za-z0-9._-]+)', _last_user_content(messages)):
+    content = _typed_user_content_for_skill_detection(messages)
+    for match in re.finditer(r'(^|[\s"\(])/(?P<name>[A-Za-z0-9._-]+)', content):
         name = match.group("name").lower()
         if name in active or name in seen:
             continue
@@ -1294,6 +1347,21 @@ def _normalize_tool_calls(tool_name: str, value: object) -> list[dict]:
             "dict (single tool call) or list[dict] (multi-call)."
         )
     return [{"tool_name": tool_name, "arguments": value}]
+
+
+def _advertised_tool_names(tools: object) -> set[str]:
+    names: set[str] = set()
+    if not isinstance(tools, list):
+        return names
+    for tool in tools:
+        if not isinstance(tool, dict):
+            continue
+        function = tool.get("function")
+        if isinstance(function, dict) and isinstance(function.get("name"), str):
+            names.add(function["name"])
+        elif isinstance(tool.get("name"), str):
+            names.add(tool["name"])
+    return names
 
 
 def match_tool_call(messages: list[dict], has_tools: bool) -> list[dict] | None:
@@ -1689,16 +1757,33 @@ async def _send_sse(resp: web.StreamResponse, data: dict):
     await resp.write(f"data: {json.dumps(data)}\n\n".encode())
 
 
-def match_special_response(messages: list[dict], has_tools: bool) -> dict | None:
+def _preferred_tool_name(available_tool_names: set[str], legacy: str) -> str:
+    reborn_name = {
+        "echo": "builtin__echo",
+        "time": "builtin__time",
+    }.get(legacy)
+    if reborn_name and reborn_name in available_tool_names:
+        return reborn_name
+    return legacy
+
+
+def match_special_response(
+    messages: list[dict],
+    has_tools: bool,
+    available_tool_names: set[str] | None = None,
+) -> dict | None:
     """Deterministic issue-specific responses for agent-loop recovery tests."""
     last_user = _last_user_content(messages)
+    available_tool_names = available_tool_names or set()
+    echo_tool = _preferred_tool_name(available_tool_names, "echo")
+    time_tool = _preferred_tool_name(available_tool_names, "time")
 
     if _conversation_has_user_trigger(messages, LOOP_FOREVER_TRIGGER):
         if has_tools:
             return {
                 "type": "tool_call",
                 "tool_call": {
-                    "tool_name": "echo",
+                    "tool_name": echo_tool,
                     "arguments": {"message": "loop-iteration"},
                 },
             }
@@ -1712,7 +1797,7 @@ def match_special_response(messages: list[dict], has_tools: bool) -> dict | None
             return {
                 "type": "truncated_tool_call",
                 "tool_call": {
-                    "tool_name": "time",
+                    "tool_name": time_tool,
                     "arguments": {},
                 },
                 "content": "Attempting a tool call but the response was truncated.",
@@ -1726,7 +1811,7 @@ def match_special_response(messages: list[dict], has_tools: bool) -> dict | None
         return {
             "type": "tool_call",
             "tool_call": {
-                "tool_name": "time",
+                "tool_name": time_tool,
                 "arguments": {"operation": "broken-operation"},
             },
         }
@@ -1743,12 +1828,18 @@ def match_special_response(messages: list[dict], has_tools: bool) -> dict | None
         if n == 0 and has_tools:
             return {
                 "type": "tool_call",
-                "tool_call": {"tool_name": "echo", "arguments": {"message": "step-one"}},
+                "tool_call": {
+                    "tool_name": echo_tool,
+                    "arguments": {"message": "step-one"},
+                },
             }
         if n == 1 and has_tools:
             return {
                 "type": "tool_call",
-                "tool_call": {"tool_name": "time", "arguments": {"operation": "now"}},
+                "tool_call": {
+                    "tool_name": time_tool,
+                    "arguments": {"operation": "now"},
+                },
             }
         return {
             "type": "text",
@@ -2014,7 +2105,9 @@ async def chat_completions(request: web.Request) -> web.StreamResponse:
     _last_chat_request = body
     messages = body.get("messages", [])
     stream = body.get("stream", False)
-    has_tools = bool(body.get("tools"))
+    tools = body.get("tools")
+    has_tools = bool(tools)
+    available_tool_names = _advertised_tool_names(tools)
     cid = f"mock-{uuid.uuid4().hex[:8]}"
 
     slow_response_delay = _conversation_slow_response_delay(messages)
@@ -2036,7 +2129,7 @@ async def chat_completions(request: web.Request) -> web.StreamResponse:
 
     # Special chat-loop recovery cases that intentionally override the normal
     # tool-result summary path (for example, the looping case).
-    special = match_special_response(messages, has_tools)
+    special = match_special_response(messages, has_tools, available_tool_names)
     if special and _conversation_has_user_trigger(messages, LOOP_FOREVER_TRIGGER):
         return await _dispatch_special_response(request, cid, stream, special)
     # Multi-step chain: must bypass tool-result-summary to issue second tool call

--- a/tests/e2e/reborn_webui_harness.py
+++ b/tests/e2e/reborn_webui_harness.py
@@ -1,0 +1,459 @@
+"""Shared Reborn WebUI v2 Playwright harness.
+
+The legacy Playwright suite has mature shared fixtures in ``conftest.py`` for
+the ``ironclaw`` gateway. Reborn WebUI v2 is a different product surface: it
+boots ``ironclaw-reborn serve``, serves the React SPA under ``/v2/``, and uses
+``/api/webchat/v2/*`` endpoints. Keep that setup here so migrated scenarios
+exercise the real Reborn binary without duplicating process plumbing.
+"""
+
+import asyncio
+import os
+import signal
+import socket
+import uuid
+from pathlib import Path
+
+import httpx
+import pytest
+from playwright.async_api import async_playwright
+
+from helpers import REBORN_V2_AUTH_TOKEN, SEL_V2, wait_for_ready
+
+USER_ID = "reborn-v2-e2e-user"
+DEFAULT_PROFILE = "local-dev"
+YOLO_PROFILE = "local-dev-yolo"
+DEFAULT_MODEL = "mock-model"
+VISION_MODEL = "gpt-4o"
+
+
+def find_free_port() -> int:
+    """Ask the OS for an available loopback port as a startup hint."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def read_log(path: Path, limit: int = 8192) -> str:
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")[-limit:]
+    except OSError:
+        return ""
+
+
+def forward_coverage_env(env: dict[str, str]) -> None:
+    for key, value in os.environ.items():
+        if key.startswith(("CARGO_LLVM_COV", "LLVM_")) or key in {
+            "CARGO_ENCODED_RUSTFLAGS",
+            "CARGO_INCREMENTAL",
+        }:
+            env[key] = value
+
+
+async def stop_process(proc, *, sig=signal.SIGINT, timeout: float = 10) -> None:
+    """Signal a subprocess and wait for exit without re-reading stdio pipes."""
+    if proc.returncode is not None:
+        return
+    try:
+        proc.send_signal(sig)
+    except ProcessLookupError:
+        return
+    try:
+        await asyncio.wait_for(proc.wait(), timeout=timeout)
+    except asyncio.TimeoutError:
+        proc.kill()
+        await asyncio.wait_for(proc.wait(), timeout=5)
+
+
+def write_config_toml(
+    path: Path,
+    mock_llm_server: str,
+    profile: str = DEFAULT_PROFILE,
+    model: str = DEFAULT_MODEL,
+) -> None:
+    """Seed a sparse Reborn config that selects the mock OpenAI-compatible LLM."""
+    path.write_text(
+        f"""api_version = "ironclaw.runtime/v1"
+
+[boot]
+profile = "{profile}"
+
+[identity]
+default_owner = "{USER_ID}"
+tenant = "reborn-v2-e2e"
+default_agent = "reborn-v2-e2e-agent"
+
+[webui]
+env_token_var = "IRONCLAW_REBORN_WEBUI_TOKEN"
+env_user_id_var = "IRONCLAW_REBORN_WEBUI_USER_ID"
+
+[llm.default]
+provider_id = "openai"
+model = "{model}"
+api_key_env = "MOCK_LLM_API_KEY"
+base_url = "{mock_llm_server}/v1"
+""",
+        encoding="utf-8",
+    )
+
+
+async def start_reborn_webui_v2_server(
+    *,
+    ironclaw_reborn_binary: str,
+    mock_llm_server: str,
+    home_dir: Path,
+    profile: str = DEFAULT_PROFILE,
+    model: str = DEFAULT_MODEL,
+    log_prefix: str = "reborn-v2",
+    extra_env: dict[str, str] | None = None,
+) -> tuple[object, str]:
+    """Start ``ironclaw-reborn serve`` and return ``(process, base_url)``."""
+    reborn_home = home_dir / "reborn-home"
+    reborn_home.mkdir(parents=True, exist_ok=True)
+    write_config_toml(
+        reborn_home / "config.toml",
+        mock_llm_server,
+        profile=profile,
+        model=model,
+    )
+
+    proc = None
+    last_stderr = ""
+    last_port = None
+
+    for attempt in range(1, 4):
+        port = find_free_port()
+        last_port = port
+        stdout_path = home_dir / f"{log_prefix}-attempt-{attempt}.stdout.log"
+        stderr_path = home_dir / f"{log_prefix}-attempt-{attempt}.stderr.log"
+
+        env = {
+            "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            "HOME": str(home_dir),
+            "IRONCLAW_REBORN_HOME": str(reborn_home),
+            "IRONCLAW_REBORN_PROFILE": profile,
+            "IRONCLAW_REBORN_WEBUI_TOKEN": REBORN_V2_AUTH_TOKEN,
+            "IRONCLAW_REBORN_WEBUI_USER_ID": USER_ID,
+            "MOCK_LLM_API_KEY": "mock-api-key",
+            "NO_PROXY": "127.0.0.1,localhost,::1",
+            "no_proxy": "127.0.0.1,localhost,::1",
+            "RUST_LOG": "ironclaw=warn,ironclaw_reborn=warn",
+            "RUST_BACKTRACE": "1",
+        }
+        if extra_env:
+            env.update(extra_env)
+        forward_coverage_env(env)
+
+        args = [
+            ironclaw_reborn_binary,
+            "serve",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(port),
+        ]
+        if profile == YOLO_PROFILE:
+            args.insert(2, "--confirm-host-access")
+
+        with stdout_path.open("wb") as out, stderr_path.open("wb") as err:
+            proc = await asyncio.create_subprocess_exec(
+                *args,
+                stdin=asyncio.subprocess.DEVNULL,
+                stdout=out,
+                stderr=err,
+                env=env,
+            )
+        base_url = f"http://127.0.0.1:{port}"
+
+        try:
+            await wait_for_ready(f"{base_url}/api/health", timeout=60)
+            return proc, base_url
+        except TimeoutError:
+            if proc.returncode is None:
+                await stop_process(proc, timeout=2)
+            last_stderr = read_log(stderr_path)
+            proc = None
+
+    pytest.fail(
+        f"Reborn WebUI v2 server failed to start after 3 attempts.\n"
+        f"Last attempted port: {last_port}\n"
+        f"stderr:\n{last_stderr}"
+    )
+
+
+async def close_reborn_server(proc) -> None:
+    if proc is not None and proc.returncode is None:
+        await stop_process(proc, sig=signal.SIGINT, timeout=10)
+        if proc.returncode is None:
+            await stop_process(proc, sig=signal.SIGTERM, timeout=5)
+
+
+async def enable_reborn_global_auto_approve(base_url: str) -> None:
+    """Enable the Tools settings global auto-approve switch for this test user."""
+    async with httpx.AsyncClient(headers=reborn_bearer_headers()) as client:
+        response = await client.post(
+            f"{base_url}/api/webchat/v2/settings/tools",
+            json={"enabled": True},
+            timeout=15,
+        )
+        response.raise_for_status()
+
+
+@pytest.fixture(scope="module")
+async def reborn_v2_server(ironclaw_reborn_binary, mock_llm_server, tmp_path_factory):
+    """Start ``ironclaw-reborn serve`` with the default local-dev profile."""
+    home_dir = tmp_path_factory.mktemp("ironclaw-reborn-v2-home")
+    proc, base_url = await start_reborn_webui_v2_server(
+        ironclaw_reborn_binary=ironclaw_reborn_binary,
+        mock_llm_server=mock_llm_server,
+        home_dir=home_dir,
+        profile=DEFAULT_PROFILE,
+    )
+    try:
+        yield base_url
+    finally:
+        await close_reborn_server(proc)
+
+
+@pytest.fixture(scope="module")
+async def reborn_v2_yolo_server(ironclaw_reborn_binary, mock_llm_server, tmp_path_factory):
+    """Start ``ironclaw-reborn serve`` with auto-approval local-dev-yolo profile."""
+    home_dir = tmp_path_factory.mktemp("ironclaw-reborn-v2-yolo-home")
+    proc, base_url = await start_reborn_webui_v2_server(
+        ironclaw_reborn_binary=ironclaw_reborn_binary,
+        mock_llm_server=mock_llm_server,
+        home_dir=home_dir,
+        profile=YOLO_PROFILE,
+        log_prefix="reborn-v2-yolo",
+    )
+    await enable_reborn_global_auto_approve(base_url)
+    try:
+        yield base_url
+    finally:
+        await close_reborn_server(proc)
+
+
+@pytest.fixture
+async def reborn_v2_restartable_server(
+    ironclaw_reborn_binary, mock_llm_server, tmp_path_factory
+):
+    """Start/stop Reborn against one persistent home directory."""
+    home_dir = tmp_path_factory.mktemp("ironclaw-reborn-v2-restartable-home")
+    state = {"proc": None, "base_url": None}
+
+    async def start() -> str:
+        proc, base_url = await start_reborn_webui_v2_server(
+            ironclaw_reborn_binary=ironclaw_reborn_binary,
+            mock_llm_server=mock_llm_server,
+            home_dir=home_dir,
+            profile=DEFAULT_PROFILE,
+            log_prefix="reborn-v2-restartable",
+        )
+        state["proc"] = proc
+        state["base_url"] = base_url
+        return base_url
+
+    async def stop() -> None:
+        await close_reborn_server(state["proc"])
+        state["proc"] = None
+
+    await start()
+    try:
+        yield state, start, stop
+    finally:
+        await stop()
+
+
+@pytest.fixture(scope="module")
+async def reborn_v2_loop_limited_yolo_server(
+    ironclaw_reborn_binary, mock_llm_server, tmp_path_factory
+):
+    """Start Reborn yolo mode with a low planned-profile loop budget."""
+    home_dir = tmp_path_factory.mktemp("ironclaw-reborn-v2-loop-limited-home")
+    proc, base_url = await start_reborn_webui_v2_server(
+        ironclaw_reborn_binary=ironclaw_reborn_binary,
+        mock_llm_server=mock_llm_server,
+        home_dir=home_dir,
+        profile=YOLO_PROFILE,
+        log_prefix="reborn-v2-loop-limited-yolo",
+        extra_env={
+            "IRONCLAW_REBORN_PLANNED_DEFAULT_ITERATION_LIMIT": "1",
+        },
+    )
+    await enable_reborn_global_auto_approve(base_url)
+    try:
+        yield base_url
+    finally:
+        await close_reborn_server(proc)
+
+
+@pytest.fixture(scope="module")
+async def reborn_v2_vision_server(ironclaw_reborn_binary, mock_llm_server, tmp_path_factory):
+    """Start Reborn with a vision-classified model id backed by the mock LLM."""
+    home_dir = tmp_path_factory.mktemp("ironclaw-reborn-v2-vision-home")
+    proc, base_url = await start_reborn_webui_v2_server(
+        ironclaw_reborn_binary=ironclaw_reborn_binary,
+        mock_llm_server=mock_llm_server,
+        home_dir=home_dir,
+        profile=DEFAULT_PROFILE,
+        model=VISION_MODEL,
+        log_prefix="reborn-v2-vision",
+    )
+    try:
+        yield base_url
+    finally:
+        await close_reborn_server(proc)
+
+
+@pytest.fixture(scope="module")
+async def reborn_v2_browser():
+    """Chromium instance for Reborn v2 tests, independent of the legacy gateway."""
+    from playwright.async_api import Error as PlaywrightError
+
+    headless = os.environ.get("HEADED", "").strip() not in ("1", "true")
+    async with async_playwright() as p:
+        browser = None
+        for attempt in range(3):
+            try:
+                browser = await p.chromium.launch(headless=headless, timeout=60000)
+                break
+            except PlaywrightError:
+                if attempt == 2:
+                    raise
+                await asyncio.sleep(1)
+        yield browser
+        await browser.close()
+
+
+@pytest.fixture
+async def reborn_v2_page(reborn_v2_server, reborn_v2_browser):
+    """Fresh authenticated page on the Reborn v2 SPA."""
+    context = await reborn_v2_browser.new_context(viewport={"width": 1280, "height": 720})
+    page = await context.new_page()
+    await open_reborn_v2_page(page, reborn_v2_server)
+    yield page
+    await context.close()
+
+
+@pytest.fixture
+async def reborn_v2_yolo_page(reborn_v2_yolo_server, reborn_v2_browser):
+    """Fresh authenticated yolo-profile page with downloads enabled."""
+    context = await reborn_v2_browser.new_context(
+        viewport={"width": 1280, "height": 720}, accept_downloads=True
+    )
+    page = await context.new_page()
+    await open_reborn_v2_page(page, reborn_v2_yolo_server)
+    yield page
+    await context.close()
+
+
+@pytest.fixture
+async def reborn_v2_vision_page(reborn_v2_vision_server, reborn_v2_browser):
+    """Fresh authenticated page backed by a vision-classified mock model."""
+    context = await reborn_v2_browser.new_context(viewport={"width": 1280, "height": 720})
+    page = await context.new_page()
+    await open_reborn_v2_page(page, reborn_v2_vision_server)
+    yield page
+    await context.close()
+
+
+async def open_reborn_v2_page(page, base_url: str, path: str = "/v2/") -> None:
+    separator = "&" if "?" in path else "?"
+    await page.goto(f"{base_url}{path}{separator}token={REBORN_V2_AUTH_TOKEN}")
+    await page.wait_for_selector(SEL_V2["chat_composer"], timeout=15000)
+
+
+def reborn_bearer_headers() -> dict[str, str]:
+    return {"Authorization": f"Bearer {REBORN_V2_AUTH_TOKEN}"}
+
+
+def client_action_id() -> str:
+    """Idempotency key accepted by ``webui_inbound::parse_client_action_id``."""
+    return str(uuid.uuid4())
+
+
+async def create_thread(client: httpx.AsyncClient, base_url: str) -> str:
+    response = await client.post(
+        f"{base_url}/api/webchat/v2/threads",
+        json={"client_action_id": client_action_id()},
+        timeout=15,
+    )
+    response.raise_for_status()
+    return response.json()["thread"]["thread_id"]
+
+
+async def send_message(
+    client: httpx.AsyncClient, base_url: str, thread_id: str, content: str
+) -> None:
+    response = await client.post(
+        f"{base_url}/api/webchat/v2/threads/{thread_id}/messages",
+        json={"client_action_id": client_action_id(), "content": content},
+        timeout=30,
+    )
+    assert response.status_code in (200, 202), response.text
+
+
+async def fetch_timeline(client: httpx.AsyncClient, base_url: str, thread_id: str) -> dict:
+    response = await client.get(
+        f"{base_url}/api/webchat/v2/threads/{thread_id}/timeline",
+        timeout=15,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+async def wait_for_assistant_message(
+    client: httpx.AsyncClient,
+    base_url: str,
+    thread_id: str,
+    *,
+    timeout: float = 45.0,
+) -> dict:
+    """Poll the timeline until a finalized assistant message appears."""
+    last_timeline: dict = {}
+    for _ in range(int(timeout * 2)):
+        last_timeline = await fetch_timeline(client, base_url, thread_id)
+        finalized = [
+            message
+            for message in last_timeline.get("messages", [])
+            if message.get("kind") == "assistant"
+            and message.get("status") == "finalized"
+            and (message.get("content") or "").strip()
+        ]
+        if finalized:
+            return finalized[-1]
+        await asyncio.sleep(0.5)
+
+    raise AssertionError(
+        f"Timed out waiting for a finalized assistant message in thread {thread_id}. "
+        f"Last timeline: {last_timeline}"
+    )
+
+
+def finalized_assistant_count(timeline: dict) -> int:
+    return sum(
+        1
+        for message in timeline.get("messages", [])
+        if message.get("kind") == "assistant"
+        and message.get("status") == "finalized"
+        and (message.get("content") or "").strip()
+    )
+
+
+async def send_and_settle(
+    client: httpx.AsyncClient,
+    base_url: str,
+    thread_id: str,
+    content: str,
+    expected: int,
+) -> None:
+    """Send a text turn and wait until ``expected`` assistant replies finalize."""
+    await send_message(client, base_url, thread_id, content)
+    for _ in range(90):
+        timeline = await fetch_timeline(client, base_url, thread_id)
+        if finalized_assistant_count(timeline) >= expected:
+            return
+        await asyncio.sleep(0.5)
+    raise AssertionError(
+        f"Thread {thread_id} did not reach {expected} finalized assistant replies"
+    )


### PR DESCRIPTION
## Summary
- Adds the shared Reborn WebUI E2E harness used by the split legacy browser coverage ports.
- Extends the mock LLM/test helpers needed by the Reborn WebUI scenarios.

## Validation
- `tests/e2e/.venv/bin/python -m py_compile tests/e2e/helpers.py tests/e2e/mock_llm.py tests/e2e/reborn_webui_harness.py`

Stack base for the follow-up Reborn runtime, OpenAI-compatible Responses API, and WebUI v2 browser coverage PRs.