### PR TITLE
fix(ci): gate skills io/Read import to unix (Clippy Windows follow-up to #5325)

### DIFF
--- a/crates/ironclaw_skills/src/registry.rs
+++ b/crates/ironclaw_skills/src/registry.rs
@@ -14,6 +14,11 @@
 //! Uses async I/O throughout to avoid blocking the tokio runtime.
 
 use std::collections::HashSet;
+// `io`/`Read` are used only by the `#[cfg(unix)]` permission-check helpers
+// (`identity_matches`, `read_file_bytes_limited`); gate the import to match so
+// the non-unix build doesn't see them as unused (`std::io::ErrorKind` elsewhere
+// uses the full path and needs no import).
+#[cfg(unix)]
 use std::io::{self, Read};
 use std::path::{Path, PathBuf};
 


### PR DESCRIPTION
## Why
Follow-up to #5325. That PR gated `read_file_bytes_limited` `#[cfg(unix)]` to clear a Windows dead-code error — which worked, but **moved** the failure: `use std::io::{self, Read};` is now unused on Windows, because those imports are used *only* by the unix-gated helpers (`identity_matches`, `read_file_bytes_limited`). So `Clippy Windows` still failed on main, now with:

```
error: unused imports: `Read` and `self`
  --> crates/ironclaw_skills/src/registry.rs:17:15
```

(`Clippy Windows` runs **push-to-main only**, so this only surfaced after #5325 merged — same blind spot the original fixes addressed.)

## Fix
Gate the import to match its callers:
```rust
#[cfg(unix)]
use std::io::{self, Read};
```
`std::io::ErrorKind` elsewhere in the file uses the full path, so it needs no import — Windows compiles clean, unix is unchanged.

## Verification
`cargo clippy -p ironclaw_skills --tests -- -D warnings` clean on unix. The Windows side is sound by construction (both `io`/`Read` users are `#[cfg(unix)]`, so gating the import leaves nothing unused on non-unix) — but, like #5325, it's only finally confirmable on the push-to-main `Clippy Windows` leg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)