### PR TITLE
fix(deps): migrate serde_yml → serde_yaml_ng (drop unsound libyml)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4076,7 +4076,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "serde_yml",
+ "serde_yaml_ng",
  "sha2 0.10.9",
  "subtle",
  "tar",
@@ -5447,7 +5447,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "serde_yml",
+ "serde_yaml_ng",
  "sha2 0.10.9",
  "tempfile",
  "thiserror 2.0.18",
@@ -6142,16 +6142,6 @@ dependencies = [
  "tracing",
  "uuid",
  "zerocopy 0.7.35",
-]
-
-[[package]]
-name = "libyml"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
-dependencies = [
- "anyhow",
- "version_check",
 ]
 
 [[package]]
@@ -8779,18 +8769,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yml"
-version = "0.0.12"
+name = "serde_yaml_ng"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
  "indexmap 2.14.0",
  "itoa",
- "libyml",
- "memchr",
  "ryu",
  "serde",
- "version_check",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -10255,6 +10243,12 @@ dependencies = [
  "crypto-common 0.1.7",
  "subtle",
 ]
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,7 +155,7 @@ regex = "1"
 aho-corasick = "1"
 
 # YAML parsing for SKILL.md frontmatter
-serde_yml = "0.0.12"
+serde_yaml_ng = "0.10.0"
 
 # Filesystem paths
 dirs = "6"

--- a/crates/ironclaw_skills/Cargo.toml
+++ b/crates/ironclaw_skills/Cargo.toml
@@ -26,7 +26,7 @@ libc = "0.2"
 regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde_yml = "0.0.12"
+serde_yaml_ng = "0.10.0"
 sha2 = "0.10"
 thiserror = "2"
 tokio = { version = "1", features = ["sync", "process", "fs"] }

--- a/crates/ironclaw_skills/src/parser.rs
+++ b/crates/ironclaw_skills/src/parser.rs
@@ -187,8 +187,8 @@ fn parse_skill_md_impl(content: &str, validate_name: bool) -> Result<ParsedSkill
     let yaml_str = &after_first_line[..yaml_end];
 
     // Parse YAML frontmatter
-    let mut manifest: SkillManifest =
-        serde_yml::from_str(yaml_str).map_err(|e| SkillParseError::InvalidYaml(e.to_string()))?;
+    let mut manifest: SkillManifest = serde_yaml_ng::from_str(yaml_str)
+        .map_err(|e| SkillParseError::InvalidYaml(e.to_string()))?;
 
     // Detect the legacy `metadata.openclaw.requires` shape and warn loudly.
     // The new flat `requires:` field replaces it; serde silently drops the
@@ -248,7 +248,7 @@ fn parse_skill_md_impl(content: &str, validate_name: bool) -> Result<ParsedSkill
 /// `SkillManifest`, so without this check a skill author can think their
 /// gating/dependency requirements are honored when they are completely inert.
 pub(crate) fn has_legacy_metadata_openclaw_requires(yaml_str: &str) -> bool {
-    let raw: serde_yml::Value = match serde_yml::from_str(yaml_str) {
+    let raw: serde_yaml_ng::Value = match serde_yaml_ng::from_str(yaml_str) {
         Ok(v) => v,
         Err(_) => return false,
     };

--- a/crates/ironclaw_skills/src/registry.rs
+++ b/crates/ironclaw_skills/src/registry.rs
@@ -65,7 +65,7 @@ fn parse_error_for_install(error_label: &str, error: SkillParseError) -> SkillRe
 /// Rewrite the `name` field in raw YAML frontmatter while preserving every
 /// other key and value in the original mapping.
 ///
-/// We deliberately operate on `serde_yml::Value` instead of the typed
+/// We deliberately operate on `serde_yaml_ng::Value` instead of the typed
 /// `SkillManifest`: re-serializing through the typed struct silently drops
 /// any unknown frontmatter fields published upstream (custom metadata, future
 /// fields, vendor extensions). The recovery path must be lossless except for
@@ -75,8 +75,8 @@ fn rewrite_frontmatter_name(
     new_name: &str,
     error_label: &str,
 ) -> Result<String, SkillRegistryError> {
-    let mut value: serde_yml::Value =
-        serde_yml::from_str(frontmatter).map_err(|e| SkillRegistryError::ParseError {
+    let mut value: serde_yaml_ng::Value =
+        serde_yaml_ng::from_str(frontmatter).map_err(|e| SkillRegistryError::ParseError {
             name: error_label.to_string(),
             reason: format!("Failed to parse SKILL.md frontmatter for rewrite: {}", e),
         })?;
@@ -89,11 +89,11 @@ fn rewrite_frontmatter_name(
         })?;
 
     mapping.insert(
-        serde_yml::Value::String("name".to_string()),
-        serde_yml::Value::String(new_name.to_string()),
+        serde_yaml_ng::Value::String("name".to_string()),
+        serde_yaml_ng::Value::String(new_name.to_string()),
     );
 
-    let yaml = serde_yml::to_string(&value).map_err(|e| SkillRegistryError::ParseError {
+    let yaml = serde_yaml_ng::to_string(&value).map_err(|e| SkillRegistryError::ParseError {
         name: error_label.to_string(),
         reason: format!("Failed to rewrite normalized SKILL.md: {}", e),
     })?;
@@ -2639,5 +2639,29 @@ mod tests {
                 i
             );
         }
+    }
+
+    #[test]
+    fn rewrite_frontmatter_name_is_lossless_and_no_doc_end_marker() {
+        // Verifies that rewrite_frontmatter_name:
+        //   1. updates the name field to the new value,
+        //   2. preserves unknown/custom fields (lossless),
+        //   3. does NOT emit a YAML document-end `...` marker.
+        let frontmatter = "name: old-name\nversion: \"1.0\"\ncustom_field: keepme\n";
+        let result = rewrite_frontmatter_name(frontmatter, "new-name", "test-skill")
+            .expect("rewrite should succeed");
+
+        assert!(
+            result.contains("name: new-name"),
+            "rewritten frontmatter should contain updated name; got: {result:?}"
+        );
+        assert!(
+            result.contains("custom_field: keepme"),
+            "rewritten frontmatter must preserve unknown keys (lossless); got: {result:?}"
+        );
+        assert!(
+            !result.contains("..."),
+            "rewritten frontmatter must not contain a YAML document-end marker; got: {result:?}"
+        );
     }
 }

--- a/crates/ironclaw_skills/src/types.rs
+++ b/crates/ironclaw_skills/src/types.rs
@@ -494,7 +494,7 @@ activation:
   patterns: ["(?i)\\b(write|draft)\\b.*\\b(email|letter)\\b"]
   max_context_tokens: 2000
 "#;
-        let manifest: SkillManifest = serde_yml::from_str(yaml).expect("parse failed");
+        let manifest: SkillManifest = serde_yaml_ng::from_str(yaml).expect("parse failed");
         assert_eq!(manifest.name, "writing-assistant");
         assert_eq!(manifest.activation.keywords.len(), 3);
     }
@@ -509,7 +509,7 @@ requires:
   config: ["/etc/vale.ini"]
   skills: ["commitment-triage", "commitment-digest"]
 "#;
-        let manifest: SkillManifest = serde_yml::from_str(yaml).expect("parse failed");
+        let manifest: SkillManifest = serde_yaml_ng::from_str(yaml).expect("parse failed");
         assert_eq!(manifest.requires.bins, vec!["vale"]);
         assert_eq!(manifest.requires.env, vec!["VALE_CONFIG"]);
         assert_eq!(manifest.requires.config, vec!["/etc/vale.ini"]);
@@ -564,7 +564,7 @@ credentials:
       scopes: ["https://www.googleapis.com/auth/gmail.modify"]
       test_url: "https://www.googleapis.com/oauth2/v1/userinfo"
 "#;
-        let manifest: SkillManifest = serde_yml::from_str(yaml).expect("parse failed");
+        let manifest: SkillManifest = serde_yaml_ng::from_str(yaml).expect("parse failed");
         assert_eq!(manifest.credentials.len(), 1);
         let cred = &manifest.credentials[0];
         assert_eq!(cred.name, "google_oauth_token");
@@ -597,7 +597,7 @@ credentials:
       prefix: "Token"
     hosts: ["api.custom.com"]
 "#;
-        let manifest: SkillManifest = serde_yml::from_str(yaml).expect("parse failed");
+        let manifest: SkillManifest = serde_yaml_ng::from_str(yaml).expect("parse failed");
         let cred = &manifest.credentials[0];
         match &cred.location {
             SkillCredentialLocation::Header { name, prefix } => {
@@ -620,7 +620,7 @@ credentials:
       name: access_token
     hosts: ["api.legacy.com"]
 "#;
-        let manifest: SkillManifest = serde_yml::from_str(yaml).expect("parse failed");
+        let manifest: SkillManifest = serde_yaml_ng::from_str(yaml).expect("parse failed");
         let cred = &manifest.credentials[0];
         match &cred.location {
             SkillCredentialLocation::QueryParam { name } => {
@@ -642,7 +642,7 @@ credentials:
       username: admin
     hosts: ["api.example.com"]
 "#;
-        let manifest: SkillManifest = serde_yml::from_str(yaml).expect("parse failed");
+        let manifest: SkillManifest = serde_yaml_ng::from_str(yaml).expect("parse failed");
         let cred = &manifest.credentials[0];
         match &cred.location {
             SkillCredentialLocation::BasicAuth { username } => {
@@ -672,7 +672,7 @@ credentials:
         extra_params:
           grant_type: refresh_token
 "#;
-        let manifest: SkillManifest = serde_yml::from_str(yaml).expect("parse failed");
+        let manifest: SkillManifest = serde_yaml_ng::from_str(yaml).expect("parse failed");
         let oauth = manifest.credentials[0].oauth.as_ref().unwrap();
         match &oauth.refresh {
             ProviderRefreshStrategy::Custom {
@@ -702,7 +702,7 @@ credentials:
       refresh:
         strategy: reauthorize_only
 "#;
-        let manifest: SkillManifest = serde_yml::from_str(yaml).expect("parse failed");
+        let manifest: SkillManifest = serde_yaml_ng::from_str(yaml).expect("parse failed");
         let oauth = manifest.credentials[0].oauth.as_ref().unwrap();
         assert!(matches!(
             oauth.refresh,
@@ -716,7 +716,7 @@ credentials:
 name: simple-skill
 description: No credentials needed
 "#;
-        let manifest: SkillManifest = serde_yml::from_str(yaml).expect("parse failed");
+        let manifest: SkillManifest = serde_yaml_ng::from_str(yaml).expect("parse failed");
         assert!(manifest.credentials.is_empty());
     }
 
@@ -761,7 +761,7 @@ credentials:
         access_type: offline
         prompt: consent
 "#;
-        let manifest: SkillManifest = serde_yml::from_str(yaml).expect("parse failed");
+        let manifest: SkillManifest = serde_yaml_ng::from_str(yaml).expect("parse failed");
         let oauth = manifest.credentials[0].oauth.as_ref().unwrap();
         assert!(oauth.use_pkce);
         assert_eq!(oauth.extra_params.get("access_type").unwrap(), "offline");

--- a/src/bridge/store_adapter.rs
+++ b/src/bridge/store_adapter.rs
@@ -1302,7 +1302,7 @@ fn deserialize_knowledge_doc(content: &str) -> Option<MemoryDoc> {
     let body = after_first_line.get(body_start..)?.trim_start_matches('\n');
 
     // Parse YAML frontmatter
-    let yaml: serde_json::Value = serde_yml::from_str(yaml_str).ok()?;
+    let yaml: serde_json::Value = serde_yaml_ng::from_str(yaml_str).ok()?;
 
     let id_str = yaml.get("id")?.as_str()?;
     let id = uuid::Uuid::parse_str(id_str).ok()?;


### PR DESCRIPTION
Clears two Dependabot alerts with **no patched release** available:
- **#5** `serde_yml` — unsound + unmaintained
- **#4** `libyml` — GHSA-gfxp-f68g-8x78, unsound `yaml_string_extend` (the C-binding backing serde_yml)

### Approach
`serde_yaml_ng` is the maintained continuation of serde_yaml's API lineage (NOT `serde_yaml`, which is also unmaintained). The call-site API is 1:1 — `from_str`, `to_string`, `Value`, `as_mapping_mut`, `Mapping::insert`. `libyml` leaves the tree entirely since serde_yml was its only consumer (serde_yaml_ng uses pure-Rust `unsafe-libyaml`).

YAML frontmatter parsing receives **untrusted input** (workspace memory docs via `deserialize_knowledge_doc`, external SKILL.md files), so the soundness fix is security-relevant.

- 219/219 `ironclaw_skills` tests pass, clippy clean
- `libyml` + `serde_yml` confirmed gone from `Cargo.lock`
- Added round-trip test locking `rewrite_frontmatter_name`'s lossless output shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)