### PR TITLE
fix(deps): bump rand 0.8.5 → 0.8.6 in wechat channel

### DIFF
--- a/channels-src/wechat/Cargo.lock
+++ b/channels-src/wechat/Cargo.lock
@@ -257,9 +257,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",


### PR DESCRIPTION
Clears Dependabot **#15** (GHSA-cq8v-f236-94qc — rand unsound with a custom logger using `rand::rng()`).

`channels-src/wechat` has its own lockfile separate from the root workspace, so the root cargo update never reaches it. Low severity (Stacked Borrows UB only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)