### PR TITLE
feat(approvals): default "Always allow eligible tools" to on

### DIFF
--- a/crates/ironclaw_approvals/src/auto_approve.rs
+++ b/crates/ironclaw_approvals/src/auto_approve.rs
@@ -32,6 +32,11 @@ use serde::{Deserialize, Serialize};
 
 use crate::CapabilityPermissionStoreError as ToolPermissionStoreError;
 
+/// Default for the auto-approve toggle when a user has never set it. ON so new
+/// users aren't prompted per tool call. Single source of truth — the dispatch
+/// path and the settings API both resolve unset state through this.
+pub const AUTO_APPROVE_DEFAULT_ENABLED: bool = true;
+
 const SETTING_PREFIX: &str = "/approvals/auto-approve";
 const SETTING_CAS_RETRY_ATTEMPTS: usize = 3;
 
@@ -82,10 +87,13 @@ pub trait AutoApproveSettingStore: Send + Sync {
         key: &AutoApproveSettingKey,
     ) -> Result<Option<AutoApproveSettingRecord>, ToolPermissionStoreError>;
 
-    /// Convenience: the effective boolean, defaulting to `false` when unset.
+    /// Effective boolean; defaults to [`AUTO_APPROVE_DEFAULT_ENABLED`] when unset.
     async fn is_enabled(&self, scope: &ResourceScope) -> Result<bool, ToolPermissionStoreError> {
         let key = AutoApproveSettingKey::from_resource_scope(scope);
-        Ok(self.get(&key).await?.is_some_and(|record| record.enabled))
+        Ok(self
+            .get(&key)
+            .await?
+            .map_or(AUTO_APPROVE_DEFAULT_ENABLED, |record| record.enabled))
     }
 }
 
@@ -381,9 +389,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn in_memory_defaults_to_disabled() {
+    async fn in_memory_defaults_to_enabled_when_unset() {
         let store = InMemoryAutoApproveSettingStore::new();
-        assert!(!store.is_enabled(&scope("alice", None, None)).await.unwrap());
+        assert!(store.is_enabled(&scope("alice", None, None)).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn in_memory_explicit_disable_is_honored() {
+        let store = InMemoryAutoApproveSettingStore::new();
+        let scope = scope("alice", None, None);
+        store.set(input(scope.clone(), false)).await.unwrap();
+        assert!(!store.is_enabled(&scope).await.unwrap());
     }
 
     #[tokio::test]
@@ -424,6 +440,12 @@ mod tests {
         let store = InMemoryAutoApproveSettingStore::new();
         store
             .set(input(scope("alice", None, None), true))
+            .await
+            .unwrap();
+        // Explicit off for bob so the per-user isolation assertion doesn't ride
+        // on the unset default (which is now ON).
+        store
+            .set(input(scope("bob", None, None), false))
             .await
             .unwrap();
 

--- a/crates/ironclaw_approvals/src/lib.rs
+++ b/crates/ironclaw_approvals/src/lib.rs
@@ -20,8 +20,9 @@ use ironclaw_run_state::{ApprovalRecord, ApprovalRequestStore, ApprovalStatus, R
 use thiserror::Error;
 
 pub use auto_approve::{
-    AutoApproveSettingInput, AutoApproveSettingKey, AutoApproveSettingRecord,
-    AutoApproveSettingStore, FilesystemAutoApproveSettingStore, InMemoryAutoApproveSettingStore,
+    AUTO_APPROVE_DEFAULT_ENABLED, AutoApproveSettingInput, AutoApproveSettingKey,
+    AutoApproveSettingRecord, AutoApproveSettingStore, FilesystemAutoApproveSettingStore,
+    InMemoryAutoApproveSettingStore,
 };
 pub use capability_permission::{
     CapabilityPermissionOverride, CapabilityPermissionOverrideInput,

--- a/crates/ironclaw_product_workflow/src/reborn_services.rs
+++ b/crates/ironclaw_product_workflow/src/reborn_services.rs
@@ -82,11 +82,11 @@ pub use fs_browse::{
     RebornFsMountsResponse, RebornFsReadRequest, RebornFsStatRequest, RebornFsStatResponse,
 };
 use ironclaw_approvals::{
-    AutoApproveSettingInput, AutoApproveSettingKey, AutoApproveSettingStore,
-    PersistentApprovalAction, PersistentApprovalPolicyError, PersistentApprovalPolicyInput,
-    PersistentApprovalPolicyKey, PersistentApprovalPolicyStore, ToolPermissionOverride,
-    ToolPermissionOverrideInput, ToolPermissionOverrideKey, ToolPermissionOverrideStore,
-    ToolPermissionState, permission_mode_allows_persistent_approval,
+    AUTO_APPROVE_DEFAULT_ENABLED, AutoApproveSettingInput, AutoApproveSettingKey,
+    AutoApproveSettingStore, PersistentApprovalAction, PersistentApprovalPolicyError,
+    PersistentApprovalPolicyInput, PersistentApprovalPolicyKey, PersistentApprovalPolicyStore,
+    ToolPermissionOverride, ToolPermissionOverrideInput, ToolPermissionOverrideKey,
+    ToolPermissionOverrideStore, ToolPermissionState, permission_mode_allows_persistent_approval,
 };
 pub use llm_config::{
     CodexLoginStart, LlmActiveSelection, LlmConfigService, LlmConfigServiceError,
@@ -963,7 +963,9 @@ async fn auto_approve_config_entry(
         .get(&key)
         .await
         .map_err(operator_config_store_error)?;
-    let enabled = record.as_ref().is_some_and(|record| record.enabled);
+    let enabled = record
+        .as_ref()
+        .map_or(AUTO_APPROVE_DEFAULT_ENABLED, |record| record.enabled);
     Ok(RebornOperatorConfigEntry {
         key: AUTO_APPROVE_CONFIG_KEY.to_string(),
         value: serde_json::json!(enabled),

--- a/crates/ironclaw_product_workflow/tests/reborn_services_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/reborn_services_contract.rs
@@ -8161,11 +8161,11 @@ async fn operator_config_reads_and_writes_auto_approve_and_tool_permissions() {
         .expect("operator config");
     assert_eq!(
         operator_config_entry_value(&initial, "agent.auto_approve_tools"),
-        &json!(false)
+        &json!(true)
     );
     assert_eq!(
         operator_config_entry_value(&initial, "tool.tool.alpha")["state"],
-        "ask_each_time"
+        "always_allow"
     );
     assert_eq!(
         operator_config_entry_value(&initial, "tool.tool.alpha")["effective_source"],
@@ -8173,8 +8173,8 @@ async fn operator_config_reads_and_writes_auto_approve_and_tool_permissions() {
     );
     assert_eq!(
         operator_config_entry_value(&initial, "tool.tool.default_allow")["state"],
-        "ask_each_time",
-        "default-allow tools must still ask while global auto-approve is off"
+        "always_allow",
+        "follow-global tools auto-approve while global auto-approve defaults on"
     );
     assert_eq!(
         operator_config_entry_value(&initial, "tool.tool.default_allow")["effective_source"],
@@ -8382,10 +8382,14 @@ async fn operator_config_is_scoped_by_tenant_and_user() {
         .set_operator_config_key(
             alice_tenant_a.clone(),
             "agent.auto_approve_tools".to_string(),
-            RebornOperatorConfigSetRequest { value: json!(true) },
+            // Set the non-default (off) so isolation is provable: other
+            // users/tenants must still read the default (on), not this value.
+            RebornOperatorConfigSetRequest {
+                value: json!(false),
+            },
         )
         .await
-        .expect("alice enables auto approve in tenant alpha");
+        .expect("alice disables auto approve in tenant alpha");
     services
         .set_operator_config_key(
             alice_tenant_a.clone(),
@@ -8410,7 +8414,7 @@ async fn operator_config_is_scoped_by_tenant_and_user() {
         .expect("same tenant/user operator config");
     assert_eq!(
         operator_config_entry_value(&alice_alpha_other_project, "agent.auto_approve_tools"),
-        &json!(true),
+        &json!(false),
         "auto-approve settings are scoped by tenant/user, not agent/project"
     );
     assert_eq!(
@@ -8430,13 +8434,13 @@ async fn operator_config_is_scoped_by_tenant_and_user() {
             .expect("isolated operator config");
         assert_eq!(
             operator_config_entry_value(&config, "agent.auto_approve_tools"),
-            &json!(false),
+            &json!(true),
             "auto-approve must not leak across user or tenant"
         );
         assert_eq!(
             operator_config_entry_value(&config, "tool.tool.alpha")["state"],
-            "ask_each_time",
-            "tool override must not leak across user or tenant"
+            "always_allow",
+            "tool override must not leak across user or tenant (follows global default-on)"
         );
         assert_eq!(
             operator_config_entry_value(&config, "tool.tool.alpha")["effective_source"],

--- a/crates/ironclaw_reborn_composition/src/approval_test_support.rs
+++ b/crates/ironclaw_reborn_composition/src/approval_test_support.rs
@@ -1,5 +1,5 @@
-use ironclaw_approvals::ApprovalResolver;
-use ironclaw_host_api::{Action, CapabilityId, ExecutionContext, ResourceEstimate};
+use ironclaw_approvals::{ApprovalResolver, AutoApproveSettingInput, AutoApproveSettingStore};
+use ironclaw_host_api::{Action, CapabilityId, ExecutionContext, Principal, ResourceEstimate};
 use ironclaw_host_runtime::{
     RuntimeCapabilityOutcome, RuntimeCapabilityRequest, RuntimeCapabilityResumeRequest,
     RuntimeFailureKind,
@@ -9,11 +9,32 @@ use ironclaw_trust::TrustDecision;
 
 use crate::{
     RebornServices,
+    factory::RebornLocalRuntimeServices,
     local_dev_capability_policy::{
         LocalDevApprovalPolicyAction, LocalDevCapabilityPolicyError,
         local_dev_one_shot_lease_approval,
     },
 };
+
+/// Turn the global auto-approve switch off for `context`'s actor scope.
+/// Global auto-approve defaults ON, so any test exercising the per-tool approval
+/// gate must flip it off first. Shared by every `src` `#[cfg(test)]` site;
+/// integration-test and root-crate binaries keep their own copies (they cannot
+/// see this crate-internal helper).
+pub(crate) async fn disable_global_auto_approve(
+    local_runtime: &RebornLocalRuntimeServices,
+    context: &ExecutionContext,
+) {
+    local_runtime
+        .auto_approve_settings
+        .set(AutoApproveSettingInput {
+            scope: context.resource_scope.clone(),
+            enabled: false,
+            updated_by: Principal::User(context.resource_scope.user_id.clone()),
+        })
+        .await
+        .expect("disable global auto-approve"); // safety: test-only gating precondition
+}
 
 pub(crate) async fn invoke_json_with_local_dev_approval(
     services: &RebornServices,

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -4880,7 +4880,7 @@ mod tests {
             .await
             .expect("create Google account");
 
-        disable_global_auto_approve_for_context(local_runtime, &gmail_context).await;
+        disable_global_auto_approve(local_runtime, &gmail_context).await;
         let failure = invoke_json(
             &services,
             "gmail.send_message",
@@ -4901,7 +4901,7 @@ mod tests {
         assert_eq!(gmail_leases[0].status, CapabilityLeaseStatus::Revoked);
 
         let calendar_context = gsuite_context("google-calendar.create_event");
-        disable_global_auto_approve_for_context(local_runtime, &calendar_context).await;
+        disable_global_auto_approve(local_runtime, &calendar_context).await;
         let failure = invoke_json(
             &services,
             "google-calendar.create_event",
@@ -6193,24 +6193,7 @@ mod tests {
             .expect("enabling global auto-approve should succeed");
     }
 
-    /// Turn off the global auto-approve switch for `context`'s actor scope.
-    /// Global auto-approve now defaults ON, so a test that needs to exercise the
-    /// per-tool approval gate (and its resume/one-shot-lease path) must flip the
-    /// switch off explicitly as a precondition.
-    async fn disable_global_auto_approve_for_context(
-        local_runtime: &RebornLocalRuntimeServices,
-        context: &ExecutionContext,
-    ) {
-        local_runtime
-            .auto_approve_settings
-            .set(AutoApproveSettingInput {
-                updated_by: Principal::User(context.resource_scope.user_id.clone()),
-                scope: context.resource_scope.clone(),
-                enabled: false,
-            })
-            .await
-            .expect("disabling global auto-approve should succeed");
-    }
+    use crate::approval_test_support::disable_global_auto_approve;
 
     fn notion_mcp_context(capability_id: &str) -> ExecutionContext {
         let extension_id = ExtensionId::new("caller").expect("valid extension id");

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -4880,6 +4880,7 @@ mod tests {
             .await
             .expect("create Google account");
 
+        disable_global_auto_approve_for_context(local_runtime, &gmail_context).await;
         let failure = invoke_json(
             &services,
             "gmail.send_message",
@@ -4900,6 +4901,7 @@ mod tests {
         assert_eq!(gmail_leases[0].status, CapabilityLeaseStatus::Revoked);
 
         let calendar_context = gsuite_context("google-calendar.create_event");
+        disable_global_auto_approve_for_context(local_runtime, &calendar_context).await;
         let failure = invoke_json(
             &services,
             "google-calendar.create_event",
@@ -6189,6 +6191,25 @@ mod tests {
             })
             .await
             .expect("enabling global auto-approve should succeed");
+    }
+
+    /// Turn off the global auto-approve switch for `context`'s actor scope.
+    /// Global auto-approve now defaults ON, so a test that needs to exercise the
+    /// per-tool approval gate (and its resume/one-shot-lease path) must flip the
+    /// switch off explicitly as a precondition.
+    async fn disable_global_auto_approve_for_context(
+        local_runtime: &RebornLocalRuntimeServices,
+        context: &ExecutionContext,
+    ) {
+        local_runtime
+            .auto_approve_settings
+            .set(AutoApproveSettingInput {
+                updated_by: Principal::User(context.resource_scope.user_id.clone()),
+                scope: context.resource_scope.clone(),
+                enabled: false,
+            })
+            .await
+            .expect("disabling global auto-approve should succeed");
     }
 
     fn notion_mcp_context(capability_id: &str) -> ExecutionContext {

--- a/crates/ironclaw_reborn_composition/src/factory/local_dev_host_tests/approval_gates.rs
+++ b/crates/ironclaw_reborn_composition/src/factory/local_dev_host_tests/approval_gates.rs
@@ -27,20 +27,7 @@ use ironclaw_trust::{AuthorityCeiling, EffectiveTrustClass, TrustDecision, Trust
 use super::*;
 use crate::local_dev_capability_policy::local_dev_one_shot_lease_approval;
 
-async fn disable_global_auto_approve(
-    local_runtime: &RebornLocalRuntimeServices,
-    context: &ExecutionContext,
-) {
-    local_runtime
-        .auto_approve_settings
-        .set(AutoApproveSettingInput {
-            scope: context.resource_scope.clone(),
-            enabled: false,
-            updated_by: Principal::User(context.user_id.clone()),
-        })
-        .await
-        .expect("disable global auto-approve"); // safety: test-only gating precondition
-}
+use crate::approval_test_support::disable_global_auto_approve;
 
 #[tokio::test]
 async fn local_dev_ask_destructive_shell_invocation_blocks_then_resumes_with_one_shot_lease() {

--- a/crates/ironclaw_reborn_composition/src/factory/local_dev_host_tests/approval_gates.rs
+++ b/crates/ironclaw_reborn_composition/src/factory/local_dev_host_tests/approval_gates.rs
@@ -39,7 +39,7 @@ async fn disable_global_auto_approve(
             updated_by: Principal::User(context.user_id.clone()),
         })
         .await
-        .expect("disable global auto-approve");
+        .expect("disable global auto-approve"); // safety: test-only gating precondition
 }
 
 #[tokio::test]

--- a/crates/ironclaw_reborn_composition/src/factory/local_dev_host_tests/approval_gates.rs
+++ b/crates/ironclaw_reborn_composition/src/factory/local_dev_host_tests/approval_gates.rs
@@ -278,6 +278,52 @@ async fn local_dev_auto_approve_setting_update_skips_next_shell_gate() {
 }
 
 #[tokio::test]
+async fn local_dev_default_allow_echo_auto_approves_when_global_unset() {
+    // Caller-level proof of the PR's promise: a fresh user (auto-approve setting
+    // never written → defaults ON) has an eligible tool auto-approved at
+    // dispatch, with no approval gate. No disable call — the default must carry.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let services = build_reborn_services(
+        RebornBuildInput::local_dev("local-dev-echo-default-on", dir.path().join("local-dev"))
+            .with_runtime_policy(local_dev_policy()),
+    )
+    .await
+    .expect("local-dev services build");
+    let local_runtime = services
+        .local_runtime
+        .as_ref()
+        .expect("local-dev runtime substrate");
+    let host_runtime = services
+        .host_runtime
+        .as_ref()
+        .expect("local-dev host runtime");
+    let capability_id = CapabilityId::new(ECHO_CAPABILITY_ID).expect("echo capability");
+    let context =
+        echo_spawn_execution_context("local-dev-echo-default-on", "thread-echo-default-on");
+
+    let outcome = host_runtime
+        .invoke_capability(RuntimeCapabilityRequest::new(
+            context.clone(),
+            capability_id,
+            ResourceEstimate::default(),
+            serde_json::json!({"message": "auto approve echo"}),
+            trust_decision(echo_spawn_allowed_effects()),
+        ))
+        .await
+        .expect("echo invocation resolves");
+
+    assert!(
+        matches!(outcome, RuntimeCapabilityOutcome::Completed(_)),
+        "unset global auto-approve defaults ON, so eligible echo must auto-approve, got {outcome:?}"
+    );
+    assert_eq!(
+        pending_approval_count(local_runtime, &context).await,
+        0,
+        "default-on auto-approve must not create a pending approval"
+    );
+}
+
+#[tokio::test]
 async fn local_dev_default_allow_echo_asks_when_global_auto_approve_is_off() {
     let dir = tempfile::tempdir().expect("tempdir");
     let services = build_reborn_services(

--- a/crates/ironclaw_reborn_composition/src/factory/local_dev_host_tests/approval_gates.rs
+++ b/crates/ironclaw_reborn_composition/src/factory/local_dev_host_tests/approval_gates.rs
@@ -27,6 +27,21 @@ use ironclaw_trust::{AuthorityCeiling, EffectiveTrustClass, TrustDecision, Trust
 use super::*;
 use crate::local_dev_capability_policy::local_dev_one_shot_lease_approval;
 
+async fn disable_global_auto_approve(
+    local_runtime: &RebornLocalRuntimeServices,
+    context: &ExecutionContext,
+) {
+    local_runtime
+        .auto_approve_settings
+        .set(AutoApproveSettingInput {
+            scope: context.resource_scope.clone(),
+            enabled: false,
+            updated_by: Principal::User(context.user_id.clone()),
+        })
+        .await
+        .expect("disable global auto-approve");
+}
+
 #[tokio::test]
 async fn local_dev_ask_destructive_shell_invocation_blocks_then_resumes_with_one_shot_lease() {
     let dir = tempfile::tempdir().expect("tempdir");
@@ -48,6 +63,7 @@ async fn local_dev_ask_destructive_shell_invocation_blocks_then_resumes_with_one
     let estimate = ResourceEstimate::default();
     let input = serde_json::json!({"command": "echo approved"});
     let context = shell_execution_context("local-dev-approval-owner", "thread-local-dev-approval");
+    disable_global_auto_approve(local_runtime, &context).await;
 
     let blocked = host_runtime
         .invoke_capability(RuntimeCapabilityRequest::new(
@@ -122,6 +138,7 @@ async fn local_dev_approved_shell_uses_injected_tenant_sandbox_process_port() {
     let estimate = ResourceEstimate::default();
     let input = serde_json::json!({"command": "echo composed sandbox", "timeout": 9});
     let context = shell_execution_context("sandbox-port-owner", "sandbox-port-thread");
+    disable_global_auto_approve(local_runtime, &context).await;
 
     let blocked = host_runtime
         .invoke_capability(RuntimeCapabilityRequest::new(
@@ -192,6 +209,7 @@ async fn local_dev_yolo_shell_invocation_asks_when_global_auto_approve_is_off() 
         "local-dev-yolo-approval-owner",
         "thread-local-yolo-approval",
     );
+    disable_global_auto_approve(local_runtime, &context).await;
 
     let outcome = host_runtime
         .invoke_capability(RuntimeCapabilityRequest::new(
@@ -291,6 +309,7 @@ async fn local_dev_default_allow_echo_asks_when_global_auto_approve_is_off() {
         .expect("local-dev host runtime");
     let capability_id = CapabilityId::new(ECHO_CAPABILITY_ID).expect("echo capability");
     let context = echo_spawn_execution_context("local-dev-echo-default-ask", "thread-echo-ask");
+    disable_global_auto_approve(local_runtime, &context).await;
 
     let outcome = host_runtime
         .invoke_capability(RuntimeCapabilityRequest::new(
@@ -336,6 +355,7 @@ async fn local_dev_legacy_persistent_echo_grant_does_not_override_global_off() {
     let capability_id = CapabilityId::new(ECHO_CAPABILITY_ID).expect("echo capability");
     let context =
         echo_spawn_execution_context("local-dev-echo-legacy-grant", "thread-echo-legacy-grant");
+    disable_global_auto_approve(local_runtime, &context).await;
 
     local_runtime
         .persistent_approval_policies
@@ -631,6 +651,7 @@ async fn local_dev_denied_shell_approval_does_not_issue_resume_lease() {
     let estimate = ResourceEstimate::default();
     let input = serde_json::json!({"command": "echo denied"});
     let context = shell_execution_context("local-dev-deny-owner", "local-dev-deny-thread");
+    disable_global_auto_approve(local_runtime, &context).await;
 
     let blocked = host_runtime
         .invoke_capability(RuntimeCapabilityRequest::new(
@@ -861,6 +882,7 @@ async fn local_dev_minimal_policy_shell_invocation_asks_when_global_auto_approve
         .expect("local-dev host runtime"); // safety: test-only helper in #[cfg(test)] module.
     let capability_id = CapabilityId::new(SHELL_CAPABILITY_ID).expect("shell capability"); // safety: test-only helper in #[cfg(test)] module.
     let context = shell_execution_context("local-dev-minimal-owner", "thread-minimal-approval");
+    disable_global_auto_approve(local_runtime, &context).await;
 
     let outcome = host_runtime
         .invoke_capability(RuntimeCapabilityRequest::new(
@@ -903,6 +925,7 @@ async fn local_dev_minimal_with_enterprise_profile_still_gates_shell() {
         .expect("local-dev host runtime"); // safety: test-only helper in #[cfg(test)] module.
     let capability_id = CapabilityId::new(SHELL_CAPABILITY_ID).expect("shell capability"); // safety: test-only helper in #[cfg(test)] module.
     let context = shell_execution_context("ent-minimal-owner", "thread-ent-minimal");
+    disable_global_auto_approve(local_runtime, &context).await;
 
     let outcome = host_runtime
         .invoke_capability(RuntimeCapabilityRequest::new(
@@ -954,6 +977,7 @@ async fn local_dev_ask_destructive_spawn_capability_blocks_then_resumes() {
     let input = serde_json::json!({"command": "echo spawn-approved"});
     let context =
         shell_execution_context("local-dev-spawn-approval-owner", "thread-spawn-approval");
+    disable_global_auto_approve(local_runtime, &context).await;
 
     let blocked = host_runtime
         .spawn_capability(RuntimeCapabilityRequest::new(
@@ -1017,12 +1041,17 @@ async fn local_dev_ask_destructive_spawn_dispatch_only_capability_requires_appro
     )
     .await
     .expect("local-dev services build"); // safety: test-only helper in #[cfg(test)] module.
+    let local_runtime = services
+        .local_runtime
+        .as_ref()
+        .expect("local-dev runtime substrate"); // safety: test-only helper in #[cfg(test)] module.
     let host_runtime = services
         .host_runtime
         .as_ref()
         .expect("local-dev host runtime"); // safety: test-only helper in #[cfg(test)] module.
     let capability_id = CapabilityId::new(ECHO_CAPABILITY_ID).expect("echo capability"); // safety: test-only helper in #[cfg(test)] module.
     let context = echo_spawn_execution_context("local-dev-echo-spawn-owner", "thread-echo-spawn");
+    disable_global_auto_approve(local_runtime, &context).await;
 
     let outcome = host_runtime
         .spawn_capability(RuntimeCapabilityRequest::new(
@@ -1146,6 +1175,7 @@ async fn local_dev_one_shot_lease_regates_on_second_invocation() {
     let estimate = ResourceEstimate::default();
     let input = serde_json::json!({"command": "echo regate"});
     let context = shell_execution_context("local-dev-regate-owner", "thread-regate");
+    disable_global_auto_approve(local_runtime, &context).await;
 
     // First invocation — expect approval gate.
     let first_blocked = host_runtime

--- a/crates/ironclaw_reborn_composition/src/local_dev_authorization.rs
+++ b/crates/ironclaw_reborn_composition/src/local_dev_authorization.rs
@@ -606,10 +606,28 @@ mod tests {
         let policy = Arc::new(local_dev_capability_policy().expect("capability policy"));
         let authorizer = local_dev_authorizer(None, policy, settings);
 
+        // Global auto-approve now defaults ON, so explicitly disable it first to
+        // establish the gating baseline this test reads back across dispatches.
+        {
+            let scope = ironclaw_host_api::ResourceScope::local_default(
+                user_id.clone(),
+                ironclaw_host_api::InvocationId::new(),
+            )
+            .expect("local resource scope");
+            auto_approve
+                .set(AutoApproveSettingInput {
+                    scope,
+                    enabled: false,
+                    updated_by: Principal::User(user_id.clone()),
+                })
+                .await
+                .expect("auto-approve setting update");
+        }
+
         let before = local_dev_shell_decision_with_authorizer(authorizer.as_ref(), &user_id).await;
         assert!(
             matches!(before, ironclaw_host_api::Decision::RequireApproval { .. }),
-            "default local-dev shell dispatch should gate before a settings update, got {before:?}"
+            "local-dev shell dispatch should gate when global auto-approve is off, got {before:?}"
         );
 
         let scope = ironclaw_host_api::ResourceScope::local_default(

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/tests.rs
@@ -1720,6 +1720,24 @@ mod tests {
             run_context.scope.tenant_id.clone(),
             actor_user_id.clone(),
         );
+        // Global auto-approve now defaults ON, so disable it for the owner scope
+        // (the scope the set dispatch authorizes against) to exercise the
+        // gate -> approve -> resume path this test verifies.
+        {
+            let mut disable_scope = run_context.scope.to_resource_scope();
+            disable_scope.user_id = owner_user_id.clone();
+            ironclaw_approvals::AutoApproveSettingStore::set(
+                local_runtime.auto_approve_settings.as_ref(),
+                ironclaw_approvals::AutoApproveSettingInput {
+                    updated_by: ironclaw_host_api::Principal::User(owner_user_id.clone()),
+                    scope: disable_scope,
+                    enabled: false,
+                },
+            )
+            .await
+            .expect("disable global auto-approve"); // safety: test-only gating precondition
+        }
+
         let set_candidate = port
             .register_provider_tool_call(RegisterProviderToolCallRequest::new(
                 provider_tool_call_with_name(

--- a/crates/ironclaw_reborn_composition/src/runtime_profile_approval_policy.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime_profile_approval_policy.rs
@@ -113,6 +113,28 @@ mod tests {
     }
 
     #[test]
+    fn hard_floor_forces_approval_for_high_risk_effects_on_real_policy() {
+        // The production gate policy must hard-floor these even under the most
+        // permissive profile (yolo), so global auto-approve / always-allow can
+        // never bypass them.
+        let p = policy(RuntimeProfile::LocalYolo);
+        for effect in [
+            EffectKind::Financial,
+            EffectKind::ModifyApproval,
+            EffectKind::ModifyBudget,
+        ] {
+            assert!(
+                p.effects_force_approval(&[effect]),
+                "{effect:?} must be hard-floored by the production policy"
+            );
+        }
+        // Ordinary effects and the empty set are not floored.
+        assert!(!p.effects_force_approval(&[EffectKind::WriteFilesystem]));
+        assert!(!p.effects_force_approval(&[EffectKind::SpawnProcess]));
+        assert!(!p.effects_force_approval(&[]));
+    }
+
+    #[test]
     fn minimal_only_disables_gates_for_local_and_hosted_yolo_profiles() {
         for profile in [
             RuntimeProfile::LocalYolo,

--- a/crates/ironclaw_reborn_composition/tests/product_live_adapters.rs
+++ b/crates/ironclaw_reborn_composition/tests/product_live_adapters.rs
@@ -413,6 +413,12 @@ async fn local_dev_adapter_gates_builtin_echo_when_global_auto_approve_is_off() 
     .await
     .unwrap();
     let run_context = loop_run_context("builtin-echo").await;
+    disable_global_auto_approve_for_run(
+        &services,
+        &run_context,
+        UserId::new("user-builtin-echo").unwrap(),
+    )
+    .await;
     let io = Arc::new(ProductLiveCapabilityIo::default());
     let input_ref = io
         .stage_input(
@@ -500,6 +506,12 @@ async fn local_dev_adapter_invokes_builtin_shell_through_product_live_surface() 
     .await
     .unwrap();
     let run_context = loop_run_context("builtin-shell").await;
+    disable_global_auto_approve_for_run(
+        &services,
+        &run_context,
+        UserId::new("user-builtin-shell").unwrap(),
+    )
+    .await;
     let io = Arc::new(ProductLiveCapabilityIo::default());
     let input_ref = io
         .stage_input(
@@ -1541,6 +1553,28 @@ async fn enable_global_auto_approve_for_run(
         })
         .await
         .expect("enable global auto-approve for product-live dispatch");
+}
+
+// Global auto-approve now defaults ON, so a test that needs to exercise the
+// per-tool approval gate must flip it OFF for the dispatch scope explicitly.
+async fn disable_global_auto_approve_for_run(
+    services: &RebornServices,
+    run_context: &LoopRunContext,
+    user_id: UserId,
+) {
+    let store = services
+        .local_dev_auto_approve_settings_for_test()
+        .expect("local-dev exposes auto-approve settings for test");
+    let mut scope = run_context.scope.to_resource_scope();
+    scope.user_id = user_id;
+    store
+        .set(ironclaw_approvals::AutoApproveSettingInput {
+            updated_by: Principal::User(scope.user_id.clone()),
+            scope,
+            enabled: false,
+        })
+        .await
+        .expect("disable global auto-approve for product-live dispatch");
 }
 
 async fn loop_run_context(label: &str) -> LoopRunContext {

--- a/crates/ironclaw_webui_v2_static/static/js/pages/settings/components/tools-tab.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/settings/components/tools-tab.js
@@ -50,8 +50,9 @@ function Switch({ checked, disabled = false, label, onChange }) {
 function AutoApproveCard({ settings, onSave, savedKeys, isLoading }) {
   const t = useT();
   const label = t("settings.field.autoApproveEligibleTools");
-  const checked =
-    settings?.[AUTO_APPROVE_KEY] === true || settings?.[AUTO_APPROVE_KEY] === "true";
+  // Fallback default ON, mirroring backend AUTO_APPROVE_DEFAULT_ENABLED.
+  const raw = settings?.[AUTO_APPROVE_KEY];
+  const checked = raw !== false && raw !== "false";
 
   return html`
     <${Card} padding="md" className="flex items-center justify-between gap-6">

--- a/crates/ironclaw_webui_v2_static/static/js/pages/settings/components/tools-tab.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/settings/components/tools-tab.js
@@ -50,9 +50,9 @@ function Switch({ checked, disabled = false, label, onChange }) {
 function AutoApproveCard({ settings, onSave, savedKeys, isLoading }) {
   const t = useT();
   const label = t("settings.field.autoApproveEligibleTools");
-  // Fallback default ON, mirroring backend AUTO_APPROVE_DEFAULT_ENABLED.
+  // Absent → default ON (mirrors backend AUTO_APPROVE_DEFAULT_ENABLED).
   const raw = settings?.[AUTO_APPROVE_KEY];
-  const checked = raw !== false && raw !== "false";
+  const checked = raw == null ? true : raw === true || raw === "true";
 
   return html`
     <${Card} padding="md" className="flex items-center justify-between gap-6">

--- a/crates/ironclaw_webui_v2_static/static/js/pages/settings/components/tools-tab.test.mjs
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/settings/components/tools-tab.test.mjs
@@ -133,6 +133,24 @@ test("Tools tab renders global auto-approve control and saves the operator key",
   assert.deepEqual(saved, [{ key: "agent.auto_approve_tools", value: true }]);
 });
 
+test("Auto-approve toggle defaults ON when unset and reads present values strictly", () => {
+  const { exports } = renderToolsModule();
+  const checkedFor = (settings) => {
+    const rendered = exports.AutoApproveCard({ settings, savedKeys: {}, onSave: () => {} });
+    const node = findComponentNode(rendered, exports.Switch);
+    return componentProps(node, exports.Switch).checked;
+  };
+  // Absent → default ON.
+  assert.equal(checkedFor({}), true, "unset must default ON");
+  // Present values read strictly.
+  assert.equal(checkedFor({ "agent.auto_approve_tools": true }), true);
+  assert.equal(checkedFor({ "agent.auto_approve_tools": "true" }), true);
+  assert.equal(checkedFor({ "agent.auto_approve_tools": false }), false);
+  // Unexpected falsy must read OFF, not silently ON.
+  assert.equal(checkedFor({ "agent.auto_approve_tools": 0 }), false, "0 must read OFF");
+  assert.equal(checkedFor({ "agent.auto_approve_tools": "" }), false, "empty string must read OFF");
+});
+
 test("Tool permission select follows global unless a per-tool override exists", () => {
   const { exports } = renderToolsModule();
   const globalTool = exports.ToolRow({

--- a/crates/ironclaw_webui_v2_static/static/js/pages/settings/lib/settings-api.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/settings/lib/settings-api.js
@@ -61,7 +61,8 @@ export async function fetchSettingsExport() {
 export async function fetchSetting(key) {
   if (key === AUTO_APPROVE_KEY) {
     const data = await fetchSettingsExport();
-    return data.settings[AUTO_APPROVE_KEY] ?? false;
+    // Default ON when unset, mirroring backend AUTO_APPROVE_DEFAULT_ENABLED.
+    return data.settings[AUTO_APPROVE_KEY] ?? true;
   }
   const data = await apiFetch(`${OPERATOR_CONFIG_BASE}/${encodeURIComponent(key)}`);
   return data.entry?.value ?? null;

--- a/tests/support/reborn/harness.rs
+++ b/tests/support/reborn/harness.rs
@@ -1553,7 +1553,13 @@ impl HostRuntimeCapabilityHarness {
     }
 
     async fn file_tools_requiring_approval() -> HarnessResult<Self> {
-        Self::file_tools_with_runtime_policy(None).await
+        let harness = Self::file_tools_with_runtime_policy(None).await?;
+        // Global auto-approve now defaults ON, so disable it explicitly to keep
+        // this constructor's per-tool approval gate behavior.
+        harness
+            .disable_global_auto_approve_for_product_and_harness_users()
+            .await?;
+        Ok(harness)
     }
 
     async fn file_tools_with_runtime_policy(
@@ -1826,6 +1832,36 @@ impl HostRuntimeCapabilityHarness {
                 updated_by: Principal::User(scope.user_id.clone()),
                 scope,
                 enabled: true,
+            })
+            .await?;
+        Ok(())
+    }
+
+    /// Global auto-approve now defaults ON. A test that needs to exercise the
+    /// per-tool approval gate must flip it OFF for the product and harness-user
+    /// scopes the run authorizes against, as an explicit precondition.
+    pub async fn disable_global_auto_approve_for_product_and_harness_users(
+        &self,
+    ) -> HarnessResult<()> {
+        let product_scope = product_scope();
+        self.disable_global_auto_approve(product_scope.clone())
+            .await?;
+        let mut harness_user_scope = product_scope;
+        harness_user_scope.user_id = self.user_id.clone();
+        self.disable_global_auto_approve(harness_user_scope).await?;
+        Ok(())
+    }
+
+    async fn disable_global_auto_approve(&self, scope: ResourceScope) -> HarnessResult<()> {
+        let store = self
+            .auto_approve_settings
+            .as_ref()
+            .ok_or("host runtime harness missing local-dev auto-approve settings")?;
+        store
+            .set(AutoApproveSettingInput {
+                updated_by: Principal::User(scope.user_id.clone()),
+                scope,
+                enabled: false,
             })
             .await?;
         Ok(())


### PR DESCRIPTION
Closes #5364.

## What
The "Always allow eligible tools" toggle already existed but defaulted **off**, so new users/sessions hit a per-call approval prompt for every tool dispatch (e.g. 5+ gates for "connect to gmail"). This flips the default to **on**.

## How
Single source of truth: `AUTO_APPROVE_DEFAULT_ENABLED` in `ironclaw_approvals`, resolved consistently across the three layers that each previously hardcoded `unset -> false`:
- `is_enabled` — dispatch enforcement
- `auto_approve_config_entry` — settings-API value the UI reads
- `tools-tab.js` / `settings-api.js` — frontend fallback (mirrors the constant)

(An earlier iteration only changed one layer, so the toggle still displayed OFF — all three are now aligned.)

## Invariants preserved
- **Explicit user choice still honored**, including an explicit **off**.
- **Hard floor unchanged** — financial / budget / approval-modifying effects always require a gate, even with auto-approve on.

## Tests
- Renamed the default-assertion unit test to pin `unset -> enabled`; added one locking in "explicit off is honored".
- Updated the 11 local-dev gating tests to set auto-approve off explicitly (their precondition — previously inherited from the default) via a shared `disable_global_auto_approve` helper.
- All `approvals` + `approval_gates` + relevant JS tests pass; fmt/clippy clean.

## Verified on UI
Settings toggle shows ON by default; a fresh chat ran 3 tools (web_search, time) with no approval gate.