### PR TITLE
[codex] test llm loop failures

### DIFF
--- a/crates/ironclaw_agent_loop/src/test_support/mod.rs
+++ b/crates/ironclaw_agent_loop/src/test_support/mod.rs
@@ -428,7 +428,7 @@ pub enum ScriptedModelResponse {
         /// Host error kind to return.
         kind: AgentLoopHostErrorKind,
         /// Safe summary exposed to loop recovery.
-        safe_summary: String,
+        safe_summary: &'static str,
     },
 }
 

--- a/crates/ironclaw_agent_loop/src/test_support/mod.rs
+++ b/crates/ironclaw_agent_loop/src/test_support/mod.rs
@@ -423,6 +423,13 @@ pub enum ScriptedModelResponse {
         /// Host error kind to return.
         kind: AgentLoopHostErrorKind,
     },
+    /// Return a sanitized host error with an explicit safe summary.
+    ErrorWithSummary {
+        /// Host error kind to return.
+        kind: AgentLoopHostErrorKind,
+        /// Safe summary exposed to loop recovery.
+        safe_summary: String,
+    },
 }
 
 /// Scripted capability call candidate.
@@ -1032,6 +1039,9 @@ fn scripted_model_response(
         ),
         ScriptedModelResponse::Error { kind } => {
             return Err(AgentLoopHostError::new(kind, "scripted model failure"));
+        }
+        ScriptedModelResponse::ErrorWithSummary { kind, safe_summary } => {
+            return Err(AgentLoopHostError::new(kind, safe_summary));
         }
     };
     Ok(LoopModelResponse {

--- a/crates/ironclaw_agent_loop/tests/safety_nets.rs
+++ b/crates/ironclaw_agent_loop/tests/safety_nets.rs
@@ -424,6 +424,49 @@ async fn chaos_repeated_model_service_drops_report_model_error() {
 }
 
 #[tokio::test]
+async fn invalid_model_output_is_retried_before_accepting_next_valid_reply() {
+    let script = ScenarioScript {
+        model_responses: VecDeque::from([
+            ScriptedModelResponse::ErrorWithSummary {
+                kind: AgentLoopHostErrorKind::Unavailable,
+                safe_summary: "model output was structurally invalid".to_string(),
+            },
+            ScriptedModelResponse::Reply {
+                text: "recovered after invalid model output".to_string(),
+            },
+        ]),
+        capability_outcomes: VecDeque::new(),
+        single_call_retry_outcomes: VecDeque::new(),
+        pending_inputs: VecDeque::new(),
+    };
+    let (host, _) = MockAgentLoopDriverHost::builder().script(script).build();
+    let state = LoopExecutionState::initial_for_run(host.run_context());
+
+    let exit = CanonicalAgentLoopExecutor
+        .execute_family(&families::default(), &host, state)
+        .await
+        .expect("loop execution should recover from retryable invalid model output");
+
+    match exit {
+        LoopExit::Completed(completed) => {
+            assert_eq!(completed.reply_message_refs.len(), 1);
+            assert!(completed.final_checkpoint_id.is_some());
+        }
+        other => panic!("expected completion after retrying invalid model output, got {other:?}"),
+    }
+    assert_eq!(host.model_call_count(), 2);
+    assert_eq!(
+        host.finalized_assistant_messages(),
+        vec!["recovered after invalid model output"]
+    );
+    assert_eq!(
+        host.prompt_requests().len(),
+        2,
+        "model recovery must rebuild the prompt before retrying"
+    );
+}
+
+#[tokio::test]
 async fn recovery_budget_exhaustion_uses_single_call_retry() {
     let script = ScenarioScript::same_failure_repeated("demo.echo", "transient", 1)
         .with_single_call_retry_outcomes(vec![

--- a/crates/ironclaw_agent_loop/tests/safety_nets.rs
+++ b/crates/ironclaw_agent_loop/tests/safety_nets.rs
@@ -429,7 +429,7 @@ async fn invalid_model_output_is_retried_before_accepting_next_valid_reply() {
         model_responses: VecDeque::from([
             ScriptedModelResponse::ErrorWithSummary {
                 kind: AgentLoopHostErrorKind::Unavailable,
-                safe_summary: "model output was structurally invalid".to_string(),
+                safe_summary: "model output was structurally invalid",
             },
             ScriptedModelResponse::Reply {
                 text: "recovered after invalid model output".to_string(),

--- a/crates/ironclaw_loop_support/tests/thread_loop_support_contract.rs
+++ b/crates/ironclaw_loop_support/tests/thread_loop_support_contract.rs
@@ -3276,6 +3276,49 @@ async fn model_port_rejects_malformed_tool_result_reference_content() {
 }
 
 #[tokio::test]
+async fn model_port_rejects_missing_explicit_tool_result_reference_before_gateway_call() {
+    let fixture = ThreadFixture::new().await;
+    let missing_tool_result_ref =
+        LoopMessageRef::new("msg:33333333-3333-3333-3333-333333333333").unwrap();
+    let thread_service = Arc::new(StaticContextThreadService::new(ContextMessage {
+        message_id: Some(ThreadMessageId::parse("44444444-4444-4444-4444-444444444444").unwrap()),
+        summary_id: None,
+        sequence: 1,
+        kind: MessageKind::User,
+        tool_result_provider_call: None,
+        content: "newer user message still exists".to_string(),
+        image_attachments: Vec::new(),
+    }));
+    let gateway = Arc::new(RecordingGateway::reply("model says hi"));
+    let model_port = ThreadBackedLoopModelPort::new(
+        thread_service,
+        fixture.thread_scope.clone(),
+        fixture.run_context.clone(),
+        gateway.clone(),
+        16,
+    );
+    let messages = vec![LoopModelMessage {
+        role: "tool_result_reference".to_string(),
+        content_ref: missing_tool_result_ref,
+    }];
+    issue_prompt_grant(&fixture.run_context, &messages);
+
+    let error = model_port
+        .stream_model(LoopModelRequest {
+            messages,
+            surface_version: None,
+            model_preference: None,
+            capability_view: None,
+        })
+        .await
+        .expect_err("missing tool result reference should fail before model call");
+
+    assert_eq!(error.kind, AgentLoopHostErrorKind::InvalidInvocation);
+    assert_eq!(error.safe_summary, "model message reference is unavailable");
+    assert!(gateway.calls.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
 async fn model_port_emits_model_milestones_without_prompt_or_output_payloads() {
     let fixture = ThreadFixture::new_with_user_content(
         "RAW_PROMPT_TEXT_SENTINEL sk-prompt-secret /host/path tool_input",


### PR DESCRIPTION
## Summary

Adds focused regression coverage for LLM-side loop failure modes:

- verifies retry behavior when the model returns structurally invalid output before recovering with a valid reply
- adds a test fixture variant for model errors with explicit safe summaries
- verifies missing explicit tool-result references fail before the model gateway is called

## Validation

- `cargo fmt`
- `cargo test -p ironclaw_agent_loop --test safety_nets`
- `cargo test -p ironclaw_loop_support --test thread_loop_support_contract`