### PR TITLE
fix(reborn): provider-backed OAuth token refresh on local-dev/hosted-single-tenant profiles

### DIFF
--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -1184,10 +1184,20 @@ async fn build_local_runtime(input: RebornBuildInput) -> Result<RebornServices, 
                     .client
                     .clone()
                     .unwrap_or_else(|| Arc::new(UnavailableAuthProviderClient));
+                // Wrap the credential-account service in
+                // `ProviderBackedCredentialAccountService` (via `with_provider_client`) so the
+                // runtime token-refresh path (`refresh_account`) routes through the OAuth
+                // provider client. `from_shared_with_provider` stores the provider client in a
+                // separate field but does NOT wrap the account service, so without this the
+                // durable `FilesystemAuthProductServices::refresh_account` stub returns
+                // `BackendUnavailable` — Google OAuth access tokens are never refreshed and every
+                // capability call reauths once the 1h access token expires. The sibling branch
+                // routes through `compose_product_auth_services`, which applies the same wrap.
                 let services = RebornProductAuthServicePorts::from_shared_with_provider(
                     Arc::clone(&durable_services),
-                    provider_client,
+                    provider_client.clone(),
                 )
+                .with_provider_client(provider_client)
                 .into_services(
                     auth_continuation_dispatcher(turn_coordinator.clone()),
                     Arc::clone(&secret_store),

--- a/crates/ironclaw_reborn_composition/tests/product_auth_refresh_composition.rs
+++ b/crates/ironclaw_reborn_composition/tests/product_auth_refresh_composition.rs
@@ -1,3 +1,13 @@
+//! Gated to the durable storage features: the fix and the bug both live in
+//! `build_local_runtime`'s `#[cfg(any(feature = "libsql", feature = "postgres"))]`
+//! branch. Without those features the in-memory branch runs instead, whose
+//! unwrapped `InMemoryAuthProductServices::refresh_account` *also* returns
+//! `CredentialMissing` for an unknown account — so the assertion below would pass
+//! pre- and post-fix and guard nothing. Skipping (not falsely passing) under the
+//! in-memory feature set keeps this an honest regression guard. CI runs the crate
+//! with `--features libsql,postgres`.
+#![cfg(any(feature = "libsql", feature = "postgres"))]
+
 //! Regression (issue #5378): the local-dev / hosted-single-tenant product-auth
 //! composition must wrap the credential-account service in
 //! `ProviderBackedCredentialAccountService` so the runtime token-refresh path is

--- a/crates/ironclaw_reborn_composition/tests/product_auth_refresh_composition.rs
+++ b/crates/ironclaw_reborn_composition/tests/product_auth_refresh_composition.rs
@@ -1,0 +1,77 @@
+//! Regression (issue #5378): the local-dev / hosted-single-tenant product-auth
+//! composition must wrap the credential-account service in
+//! `ProviderBackedCredentialAccountService` so the runtime token-refresh path is
+//! provider-backed.
+//!
+//! Before the fix, `build_local_runtime`'s durable (libsql/postgres) branch
+//! composed product-auth via `from_shared_with_provider(..).into_services(..)`
+//! WITHOUT `.with_provider_client(..)`, leaving `credential_account_service` as
+//! the raw `FilesystemAuthProductServices` whose `refresh_account` is an
+//! unconditional stub returning `BackendUnavailable`. That swallowed every
+//! Google OAuth token refresh (the inline refresher treats `BackendUnavailable`
+//! as transient and returns the existing, now-expired token), so every
+//! capability call forced a re-auth once the 1h access token expired. The
+//! sibling `build_backend_production` path routes through
+//! `compose_product_auth_services`, which applies the wrap — hence the bug was
+//! profile-specific.
+//!
+//! Discriminator that needs no live OAuth provider: the provider-backed wrapper
+//! performs an account lookup first and returns `CredentialMissing` for an
+//! unknown account, whereas the raw stub ignores the request and returns
+//! `BackendUnavailable` unconditionally. Asserting `CredentialMissing` therefore
+//! proves the account service was wrapped, regardless of which storage backend
+//! (libsql durable vs. in-memory) the build compiled in.
+
+use ironclaw_auth::{
+    AuthProductError, AuthProductScope, AuthProviderId, AuthSurface, CredentialAccountId,
+    CredentialRefreshRequest,
+};
+use ironclaw_host_api::{InvocationId, ResourceScope, UserId};
+use ironclaw_reborn_composition::{RebornBuildInput, build_reborn_services};
+
+#[tokio::test]
+async fn local_dev_product_auth_refresh_is_provider_backed_not_stub() {
+    let dir = tempfile::tempdir().unwrap();
+    let services = build_reborn_services(RebornBuildInput::local_dev(
+        "refresh-composition-owner",
+        dir.path().to_path_buf(),
+    ))
+    .await
+    .expect("local-dev runtime should build");
+
+    let product_auth = services
+        .product_auth
+        .expect("local-dev composition must expose product-auth services");
+    let account_service = product_auth.credential_account_service();
+
+    let scope = AuthProductScope::new(
+        ResourceScope::local_default(
+            UserId::new("refresh-composition-owner").unwrap(),
+            InvocationId::new(),
+        )
+        .unwrap(),
+        AuthSurface::Api,
+    );
+    let request = CredentialRefreshRequest::new(
+        scope,
+        AuthProviderId::new("google").unwrap(),
+        CredentialAccountId::new(),
+    );
+
+    let error = account_service
+        .refresh_account(request)
+        .await
+        .expect_err("refreshing a non-existent account must error");
+
+    // Provider-backed wrapper looks the account up first -> CredentialMissing.
+    // The raw FilesystemAuthProductServices stub (the regression) ignores the
+    // request and returns BackendUnavailable unconditionally.
+    assert!(
+        matches!(error, AuthProductError::CredentialMissing),
+        "expected CredentialMissing (the provider-backed wrapper performs an \
+         account lookup first), but got {error:?}. local-dev product-auth refresh \
+         fell back to the raw FilesystemAuthProductServices stub — the credential \
+         account service was not wrapped in ProviderBackedCredentialAccountService. \
+         Regression: issue #5378."
+    );
+}

--- a/crates/ironclaw_reborn_composition/tests/product_auth_refresh_composition.rs
+++ b/crates/ironclaw_reborn_composition/tests/product_auth_refresh_composition.rs
@@ -29,8 +29,8 @@
 //! performs an account lookup first and returns `CredentialMissing` for an
 //! unknown account, whereas the raw stub ignores the request and returns
 //! `BackendUnavailable` unconditionally. Asserting `CredentialMissing` therefore
-//! proves the account service was wrapped, regardless of which storage backend
-//! (libsql durable vs. in-memory) the build compiled in.
+//! proves the durable account service was wrapped, regardless of whether the
+//! durable backend is libsql or postgres.
 
 use ironclaw_auth::{
     AuthProductError, AuthProductScope, AuthProviderId, AuthSurface, CredentialAccountId,


### PR DESCRIPTION
Fixes #5378.

## Problem

On the `hosted-single-tenant` (Railway hosted deploy) and `local-dev` / `local-dev-yolo` profiles, every Google OAuth-backed capability (Gmail, Calendar, Drive) forced a re-authentication roughly **once an hour** — the Google access-token TTL. The on-demand refresh that should mint a new access token before the old one expires never succeeded.

This was a regression, not a Google-side issue. The original 1h-reauth bug was fixed by #5087; #5081 then moved the Railway deploy from the `production` profile onto `hosted-single-tenant`, which routes through a composition path that did not wire the OAuth client into the refresh service.

## Root cause

`build_local_runtime`'s durable (libsql/postgres) product-auth branch composed services via:

```rust
RebornProductAuthServicePorts::from_shared_with_provider(durable_services, provider_client)
    .into_services(..)
```

`from_shared_with_provider` stores the provider client in a separate field but does **not** wrap `credential_account_service` in `ProviderBackedCredentialAccountService`. So the account service stayed the raw `FilesystemAuthProductServices`, whose `refresh_account` is an unconditional stub returning `BackendUnavailable`.

The inline runtime refresher treats `BackendUnavailable` as a *transient* error and returns the existing (now-expired) token without refreshing. Credential staging then rejects it (`secret expired`) and the turn ends in `BlockedAuth` — the re-auth prompt.

Login kept working because the OAuth callback/exchange runs through the separately-wired gate registry, which is composed independently of the refresh client.

## Fix

Add the missing `.with_provider_client(..)` to the durable branch so `refresh_account` routes through `ProviderBackedCredentialAccountService` into the OAuth provider client:

```rust
RebornProductAuthServicePorts::from_shared_with_provider(durable_services, provider_client.clone())
    .with_provider_client(provider_client) // wrap -> provider-backed refresh
    .into_services(..)
```

This mirrors what the sibling paths already do: `build_backend_production` routes its ports through `compose_product_auth_services` (which applies the same wrap), and the local-dev **in-memory** branch already wrapped. The durable branch was the lone outlier.

### Why not change `from_shared_with_provider` to always wrap

The issue floated making the constructor itself wrap as a "root fix." That would **double-wrap** in production: `compose_product_auth_services` already calls `with_provider_client` on the ports it receives from `from_shared_with_provider`. The targeted wrap at the one un-wrapped call site is the correct, symmetric change and keeps the constructor's single responsibility intact.

## Regression test

`tests/product_auth_refresh_composition.rs` drives the full local-dev composition through `build_reborn_services` and asserts that `refresh_account` for an unknown account returns `CredentialMissing` (the provider-backed wrapper performs an account lookup first) rather than the stub's `BackendUnavailable`. The test fails on the pre-fix code and passes after.

## Verification

- New regression test passes; fails when the fix is reverted.
- `cargo fmt`, `cargo clippy -p ironclaw_reborn_composition --tests --features libsql` clean.
- Full composition lib suite (897 tests) passes.
- Regression test is gated to `#[cfg(any(feature = "libsql", feature = "postgres"))]` (the same cfg as the branch it covers), so it runs against the fixed durable path under CI's `--features libsql,postgres` and is skipped — not falsely green — under the in-memory feature set.
- Optional follow-up: a local `ironclaw-reborn serve` (local-dev-yolo, libsql) end-to-end spot-check, forcing an inline refresh via a temporary margin bump, can confirm the refresh reaches Google's token endpoint in a live run. Not required for correctness — the fix is symmetric with the already-working `production` path and the regression test covers the wiring — but a quick sanity check before merge.
