### PR TITLE
[codex] Fix hosted volume runtime startup

### DIFF
--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -222,9 +222,8 @@ pub use llm_config_service::{LlmReloadTrigger, RebornLlmConfigService};
 pub use llm_key_store::{LlmKeyStore, LlmKeyStoreError};
 pub use local_runtime_profile::{
     RebornLocalRuntimeProfileError, RebornLocalRuntimeProfileOptions,
-    hosted_single_tenant_runtime_policy, hosted_single_tenant_volume_build_input,
-    hosted_single_tenant_volume_runtime_policy, local_dev_runtime_policy,
-    local_dev_yolo_runtime_policy, local_runtime_build_input,
+    hosted_single_tenant_runtime_policy, hosted_single_tenant_volume_runtime_policy,
+    local_dev_runtime_policy, local_dev_yolo_runtime_policy, local_runtime_build_input,
     local_runtime_build_input_with_options,
 };
 pub use nearai_mcp::{

--- a/crates/ironclaw_reborn_composition/src/local_runtime_profile.rs
+++ b/crates/ironclaw_reborn_composition/src/local_runtime_profile.rs
@@ -46,9 +46,8 @@ pub fn local_runtime_build_input_with_options(
     root: PathBuf,
     options: RebornLocalRuntimeProfileOptions,
 ) -> Result<RebornBuildInput, RebornLocalRuntimeProfileError> {
-    #[cfg(not(feature = "libsql"))]
     if profile == RebornCompositionProfile::HostedSingleTenantVolume {
-        return Err(RebornLocalRuntimeProfileError::MissingLibsqlFeature);
+        return hosted_single_tenant_volume_build_input(owner_id, root);
     }
 
     let policy = local_runtime_policy(profile, options)?;
@@ -56,6 +55,31 @@ pub fn local_runtime_build_input_with_options(
         RebornBuildInput::local_dev_with_profile(profile, owner_id, root)
             .with_runtime_policy(policy),
     )
+}
+
+/// Build the hosted single-tenant volume substrate input with the matching
+/// secure hosted runtime policy.
+pub(crate) fn hosted_single_tenant_volume_build_input(
+    owner_id: impl Into<String>,
+    root: PathBuf,
+) -> Result<RebornBuildInput, RebornLocalRuntimeProfileError> {
+    #[cfg(not(feature = "libsql"))]
+    {
+        let _ = owner_id;
+        let _ = root;
+        return Err(RebornLocalRuntimeProfileError::MissingLibsqlFeature);
+    }
+
+    #[cfg(feature = "libsql")]
+    let policy = hosted_single_tenant_volume_runtime_policy()
+        .map_err(RebornLocalRuntimeProfileError::Policy)?;
+    #[cfg(feature = "libsql")]
+    Ok(RebornBuildInput::local_dev_with_profile(
+        RebornCompositionProfile::HostedSingleTenantVolume,
+        owner_id,
+        root,
+    )
+    .with_runtime_policy(policy))
 }
 
 /// Resolved policy for the standalone local development runtime profile.
@@ -78,19 +102,6 @@ pub fn hosted_single_tenant_volume_runtime_policy() -> Result<ResolvedRuntimePol
         RuntimeProfile::SecureDefault,
     );
     ironclaw_runtime_policy::resolve(request)
-}
-
-/// Build the hosted single-tenant volume substrate input with the matching
-/// secure hosted runtime policy.
-pub fn hosted_single_tenant_volume_build_input(
-    owner_id: impl Into<String>,
-    root: PathBuf,
-) -> Result<RebornBuildInput, RebornLocalRuntimeProfileError> {
-    local_runtime_build_input(
-        RebornCompositionProfile::HostedSingleTenantVolume,
-        owner_id,
-        root,
-    )
 }
 
 /// Resolved policy for trusted single-user local development with inherited

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -2436,7 +2436,8 @@ impl RebornRuntime {
 ///
 /// **Currently supported profiles:** `RebornCompositionProfile::LocalDev`,
 /// `RebornCompositionProfile::LocalDevYolo`,
-/// `RebornCompositionProfile::HostedSingleTenant`, and
+/// `RebornCompositionProfile::HostedSingleTenant`,
+/// `RebornCompositionProfile::HostedSingleTenantVolume`, and
 /// `RebornCompositionProfile::Production` are wired end-to-end here. Production
 /// starts only after readiness diagnostics validate that live traffic can be
 /// exposed without a partial cutover.
@@ -2574,7 +2575,8 @@ pub async fn build_reborn_runtime(
     let runtime_parts = match profile {
         RebornCompositionProfile::LocalDev
         | RebornCompositionProfile::LocalDevYolo
-        | RebornCompositionProfile::HostedSingleTenant => {
+        | RebornCompositionProfile::HostedSingleTenant
+        | RebornCompositionProfile::HostedSingleTenantVolume => {
             let local_runtime =
                 services
                     .local_runtime

--- a/crates/ironclaw_reborn_composition/tests/facade_factory.rs
+++ b/crates/ironclaw_reborn_composition/tests/facade_factory.rs
@@ -719,9 +719,11 @@ async fn local_dev_builds_facades_without_production_claim() {
 #[tokio::test]
 async fn hosted_single_tenant_volume_hides_process_capabilities() {
     let dir = tempfile::tempdir().unwrap();
-    let input = ironclaw_reborn_composition::hosted_single_tenant_volume_build_input(
+    let input = ironclaw_reborn_composition::local_runtime_build_input_with_options(
+        RebornCompositionProfile::HostedSingleTenantVolume,
         "hosted-volume-owner",
         dir.path().to_path_buf(),
+        Default::default(),
     )
     .unwrap();
     let services = build_reborn_services(input).await.unwrap();

--- a/crates/ironclaw_reborn_composition/tests/profile_acceptance.rs
+++ b/crates/ironclaw_reborn_composition/tests/profile_acceptance.rs
@@ -1,4 +1,3 @@
-use ironclaw_reborn_composition::hosted_single_tenant_volume_build_input;
 // Only the `#[cfg(not(feature = "libsql"))]` no-libsql regression test below
 // consumes this error type; `webui-v2-beta` (hence CI) pulls in `libsql`.
 #[cfg(not(feature = "libsql"))]
@@ -446,9 +445,11 @@ fn hosted_single_tenant_volume_is_visible_as_preview_readiness() {
 #[tokio::test]
 async fn hosted_single_tenant_volume_factory_readiness_includes_preview_diagnostic() {
     let dir = tempfile::tempdir().unwrap();
-    let input = hosted_single_tenant_volume_build_input(
+    let input = local_runtime_build_input_with_options(
+        RebornCompositionProfile::HostedSingleTenantVolume,
         "readiness-contract-owner",
         dir.path().to_path_buf(),
+        Default::default(),
     )
     .unwrap();
     let services = build_reborn_services(input).await.unwrap();
@@ -469,13 +470,15 @@ async fn hosted_single_tenant_volume_factory_readiness_includes_preview_diagnost
 
 #[cfg(not(feature = "libsql"))]
 #[test]
-fn hosted_single_tenant_volume_build_input_errors_without_libsql_feature() {
+fn hosted_single_tenant_volume_input_errors_without_libsql_feature() {
     let dir = tempfile::tempdir().unwrap();
     // `RebornBuildInput` (the Ok type) is not `Debug`, so `unwrap_err()` won't
     // compile; match on the `Result` directly instead.
-    let result = hosted_single_tenant_volume_build_input(
+    let result = local_runtime_build_input_with_options(
+        RebornCompositionProfile::HostedSingleTenantVolume,
         "readiness-contract-owner",
         dir.path().to_path_buf(),
+        Default::default(),
     );
 
     assert!(matches!(

--- a/crates/ironclaw_reborn_composition/tests/runtime.rs
+++ b/crates/ironclaw_reborn_composition/tests/runtime.rs
@@ -5,9 +5,9 @@ use ironclaw_host_api::runtime_policy::{
     NetworkMode, ProcessBackendKind, RuntimeProfile, SecretMode,
 };
 use ironclaw_reborn_composition::{
-    HooksActivationConfig, PollSettings, RebornBuildInput, RebornRuntimeError,
-    RebornRuntimeIdentity, RebornRuntimeInput, RebornSkillSourceKind, TurnRunnerSettings,
-    build_reborn_runtime,
+    HooksActivationConfig, PollSettings, RebornBuildInput, RebornCompositionProfile,
+    RebornRuntimeError, RebornRuntimeIdentity, RebornRuntimeInput, RebornSkillSourceKind,
+    TurnRunnerSettings, build_reborn_runtime, local_runtime_build_input_with_options,
 };
 use ironclaw_turns::TurnStatus;
 use tokio_util::sync::CancellationToken;
@@ -92,6 +92,41 @@ async fn runtime_requires_resolved_runtime_policy_for_local_dev() {
         panic!("expected invalid argument, got {error:?}");
     };
     assert!(reason.contains("resolved runtime policy"));
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn hosted_single_tenant_volume_builds_live_runtime() {
+    // Regression for #5346: the runtime profile match was hardcoded after
+    // #5259 added this live local-substrate profile, so startup reached the
+    // "unsupported runtime profile checked above" unreachable arm.
+    let _guard = runtime_composition_test_guard().await;
+    let root = tempfile::tempdir().unwrap();
+    let input = RebornRuntimeInput::from_services(
+        local_runtime_build_input_with_options(
+            RebornCompositionProfile::HostedSingleTenantVolume,
+            "runtime-hosted-volume-owner",
+            root.path().join("hosted-volume"),
+            Default::default(),
+        )
+        .unwrap(),
+    )
+    .with_identity(RebornRuntimeIdentity {
+        tenant_id: "runtime-hosted-volume-tenant".to_string(),
+        agent_id: "runtime-hosted-volume-agent".to_string(),
+        source_binding_id: "runtime-hosted-volume-source".to_string(),
+        reply_target_binding_id: "runtime-hosted-volume-reply".to_string(),
+    })
+    .with_runner_settings(TurnRunnerSettings {
+        heartbeat_interval: Duration::from_secs(60),
+        poll_interval: Duration::from_secs(60),
+        ..TurnRunnerSettings::default()
+    });
+
+    let runtime = build_reborn_runtime(input).await.unwrap();
+    assert_eq!(runtime.default_run_profile_id(), "reborn-planned-default");
+
+    runtime.shutdown().await.unwrap();
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- Restore `HostedSingleTenantVolume` to the live local-runtime substrate arm.
- Update the runtime support comment to include the hosted-volume profile.
- Add a libSQL-gated caller-level regression test for hosted-volume runtime assembly.

## Root Cause
PR #5346 regressed the path added by PR #5259 by replacing the generic `uses_local_runtime_substrate()` match with a hardcoded list that omitted `HostedSingleTenantVolume`, causing startup to reach the `unsupported runtime profile checked above` unreachable arm.

## Validation
- `cargo fmt`
- `cargo test -p ironclaw_reborn_composition --features libsql --test runtime hosted_single_tenant_volume_builds_live_runtime`