### PR TITLE
[codex] fix reborn google oauth decode and preview host login

### DIFF
--- a/crates/ironclaw_reborn_cli/src/commands/serve_sso.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/serve_sso.rs
@@ -230,6 +230,14 @@ fn oauth_providers_from_env() -> anyhow::Result<Vec<Arc<dyn OAuthProvider>>> {
                  hosted domain; set it to also require a specific hd claim",
             );
         }
+        // Redacted startup diagnostic. The `client_id` is public (it
+        // appears in the authorization URL), but the secret is never
+        // logged — only its length, which lets an operator spot an empty,
+        // truncated, or wrong-length secret without a live login. A code
+        // exchange that fails only at the token endpoint while
+        // authorization succeeds almost always means the secret does not
+        // match this client id.
+        log_provider_config("google", &client_id, client_secret.len());
         let provider = GoogleProvider::new(GoogleOAuthConfig {
             client_id,
             client_secret: SecretString::from(client_secret),
@@ -248,6 +256,7 @@ fn oauth_providers_from_env() -> anyhow::Result<Vec<Arc<dyn OAuthProvider>>> {
                      IRONCLAW_REBORN_WEBUI_GITHUB_CLIENT_SECRET is missing"
                 )
             })?;
+        log_provider_config("github", &client_id, client_secret.len());
         let provider = GitHubProvider::new(GitHubOAuthConfig {
             client_id,
             client_secret: SecretString::from(client_secret),
@@ -260,9 +269,51 @@ fn oauth_providers_from_env() -> anyhow::Result<Vec<Arc<dyn OAuthProvider>>> {
     Ok(providers)
 }
 
-/// Read an env var, returning `None` when it is unset or blank.
+/// Log a redacted view of a configured OAuth provider at startup. The
+/// secret value is never logged — only its length — so a misconfigured
+/// (empty / truncated / wrong) secret is diagnosable from boot logs
+/// without leaking it or needing to capture a live login attempt.
+fn log_provider_config(provider: &str, client_id: &str, client_secret_len: usize) {
+    tracing::info!(
+        target = "ironclaw::reborn::cli::serve",
+        provider,
+        client_id,
+        client_secret_len,
+        "configured WebUI SSO OAuth provider",
+    );
+}
+
+/// Read an env var, returning `None` when it is unset or blank and the
+/// **trimmed** value otherwise.
+///
+/// Trimming is the fix for a silent OAuth failure: an
+/// `IRONCLAW_REBORN_WEBUI_*_CLIENT_SECRET` pasted into a deployment
+/// dashboard with a trailing newline / surrounding space used to be
+/// forwarded to the provider verbatim. The `client_secret` is the one
+/// credential a provider checks *only* at the token endpoint (never at
+/// authorization), so the broken value sailed through the login redirect
+/// and Google rejected the code exchange with `invalid_client` —
+/// surfacing to the user as `login_error=exchange_failed` ("Could not
+/// complete sign-in with the provider"). Surrounding whitespace is never
+/// a meaningful part of any of these values (URLs, client ids/secrets,
+/// domains), so it is always stripped, and stripping is logged so the
+/// operator can spot a malformed secret without it reaching the provider.
 fn non_empty_env(name: &str) -> Option<String> {
-    env::var(name).ok().filter(|raw| !raw.trim().is_empty())
+    let raw = env::var(name).ok()?;
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if trimmed.len() != raw.len() {
+        tracing::warn!(
+            target = "ironclaw::reborn::cli::serve",
+            var = name,
+            "environment variable had surrounding whitespace that was trimmed — check the \
+             deployment secret for a trailing newline; an untrimmed OAuth client secret is \
+             rejected by the provider at code exchange (invalid_client)",
+        );
+    }
+    Some(trimmed.to_string())
 }
 
 /// Operator override for the OAuth provider HTTP per-call timeout, in
@@ -569,5 +620,76 @@ mod tests {
             webui_oauth_base_url_from_env(addr("127.0.0.1:3000")).expect("base url"),
             "http://127.0.0.1:3000"
         );
+    }
+
+    /// Regression for the live preview failure: Google login reached the
+    /// callback (authorization + client_id + redirect_uri were valid) but
+    /// the token exchange was rejected with `invalid_client`, because the
+    /// `client_secret` is the one credential checked only at the token
+    /// endpoint. A secret pasted into the deployment dashboard with a
+    /// trailing newline / surrounding space was previously forwarded to
+    /// Google verbatim — `non_empty_env` filtered on `.trim()` but returned
+    /// the RAW value. It must now return the trimmed value so the secret
+    /// sent at exchange matches what Google stored.
+    #[test]
+    fn non_empty_env_trims_surrounding_whitespace() {
+        let _guard = WEBUI_BASE_URL_ENV_LOCK.lock().expect("env lock");
+        clear_sso_env();
+        // SAFETY: serialized by WEBUI_BASE_URL_ENV_LOCK; cleared before/after.
+        unsafe {
+            std::env::set_var(
+                "IRONCLAW_REBORN_WEBUI_GOOGLE_CLIENT_SECRET",
+                "  GOCSPX-trailing-newline\n",
+            );
+        }
+        assert_eq!(
+            non_empty_env("IRONCLAW_REBORN_WEBUI_GOOGLE_CLIENT_SECRET").as_deref(),
+            Some("GOCSPX-trailing-newline"),
+            "surrounding whitespace (a trailing newline from a pasted secret) must be trimmed",
+        );
+
+        // Whitespace-only stays None — it is not a configured value.
+        // SAFETY: serialized by WEBUI_BASE_URL_ENV_LOCK.
+        unsafe {
+            std::env::set_var("IRONCLAW_REBORN_WEBUI_GOOGLE_CLIENT_SECRET", "   \n\t");
+        }
+        assert_eq!(
+            non_empty_env("IRONCLAW_REBORN_WEBUI_GOOGLE_CLIENT_SECRET"),
+            None,
+            "a whitespace-only value is treated as unset",
+        );
+
+        clear_sso_env();
+    }
+
+    /// Caller-level coverage: credentials with surrounding whitespace must
+    /// still configure the provider through `sso_startup_config_from_env`
+    /// (the same path `serve.rs` uses), proving the trim happens before the
+    /// secret reaches `GoogleProvider` rather than the padded value being
+    /// rejected or forwarded.
+    #[test]
+    fn whitespace_padded_oauth_credentials_still_configure_provider() {
+        let _guard = WEBUI_BASE_URL_ENV_LOCK.lock().expect("env lock");
+        clear_sso_env();
+        // SAFETY: serialized by WEBUI_BASE_URL_ENV_LOCK; cleared before/after.
+        unsafe {
+            std::env::set_var("IRONCLAW_REBORN_WEBUI_GOOGLE_CLIENT_ID", "  client-id\n");
+            std::env::set_var(
+                "IRONCLAW_REBORN_WEBUI_GOOGLE_CLIENT_SECRET",
+                " client-secret \n",
+            );
+            std::env::set_var("IRONCLAW_REBORN_WEBUI_ALLOWED_EMAIL_DOMAINS", "example.com");
+        }
+
+        let resolved = sso_startup_config_from_env(addr("127.0.0.1:3000"))
+            .expect("padded-but-non-empty credentials must start")
+            .expect("providers configured → Some(config)");
+        assert_eq!(
+            resolved.providers.len(),
+            1,
+            "the Google provider should be configured from the trimmed credentials",
+        );
+
+        clear_sso_env();
     }
 }

--- a/crates/ironclaw_reborn_webui_ingress/CLAUDE.md
+++ b/crates/ironclaw_reborn_webui_ingress/CLAUDE.md
@@ -57,7 +57,8 @@ secrets, never speaks to Google, never reads a `SessionStore` row.
 Routes mounted by `webui_v2_auth_router`:
 
 - `GET  /auth/providers` — list configured provider names.
-- `GET  /auth/login/{provider}` — mint a pending flow (CSRF state +
+- `GET  /auth/login/{provider}` — redirect non-canonical hosts to
+  the configured `base_url`, then mint a pending flow (CSRF state +
   PKCE verifier + sanitized `redirect_after`) and redirect the
   browser to the provider's authorization URL.
 - `GET  /auth/callback/{provider}` — single-use state lookup,
@@ -115,6 +116,11 @@ pub trait OAuthProvider: Send + Sync + 'static {
   5-min TTL), and single-use on `take`. A replayed callback cannot
   re-use a state token; cross-provider replay (state minted for
   Google arriving on the GitHub callback) fails closed.
+- **Canonical login host** is the configured `base_url`. Login
+  requests received on any other `Host` redirect to that base URL
+  before a pending-flow entry is created, so preview/custom domains
+  cannot mint state that the registered provider callback host will
+  never see.
 - **Session exchange tickets** are process-local, bounded (1024
   entries + 60-sec TTL), and single-use on `take`. The OAuth
   callback puts only the ticket in the redirect `Location`; the SPA

--- a/crates/ironclaw_reborn_webui_ingress/src/auth/google.rs
+++ b/crates/ironclaw_reborn_webui_ingress/src/auth/google.rs
@@ -38,6 +38,10 @@ const GOOGLE_ISSUER: &str = "https://accounts.google.com";
 /// cross-border path can override it via `GoogleOAuthConfig::http_timeout`
 /// (the reborn CLI exposes `IRONCLAW_REBORN_WEBUI_OAUTH_HTTP_TIMEOUT_SECS`).
 const GOOGLE_HTTP_TIMEOUT: Duration = Duration::from_secs(20);
+/// `jsonwebtoken::Validation` applied a small expiration leeway before the
+/// manual parse path. Keep that tolerance so normal clock skew does not turn a
+/// freshly-issued Google callback into a false profile-fetch failure.
+const ID_TOKEN_EXPIRY_LEEWAY_SECS: i64 = 60;
 
 /// Google OIDC provider.
 pub struct GoogleProvider {
@@ -235,14 +239,20 @@ impl OAuthProvider for GoogleProvider {
                 // it lands in an error string that gets logged — same
                 // log-injection guard as the GitHub provider.
                 let safe_error = sanitize_error_code(&error_code);
+                tracing::warn!(
+                    target = "ironclaw::reborn::webui_ingress::auth",
+                    %status,
+                    error_code = %safe_error,
+                    "Google token endpoint rejected OAuth code exchange",
+                );
                 return Err(OAuthError::CodeExchange(format!(
                     "Google token endpoint returned {status} ({safe_error})"
                 )));
             }
-            tracing::debug!(
+            tracing::warn!(
+                target = "ironclaw::reborn::webui_ingress::auth",
                 %status,
-                body = %String::from_utf8_lossy(&body),
-                "google token endpoint returned non-success response"
+                "Google token endpoint returned a non-success response without a JSON error code",
             );
             return Err(OAuthError::CodeExchange(format!(
                 "Google token endpoint returned {status}"
@@ -267,7 +277,7 @@ impl OAuthProvider for GoogleProvider {
             .duration_since(UNIX_EPOCH)
             .map_err(|err| OAuthError::ProfileFetch(format!("decode id_token: {err}")))?
             .as_secs() as i64;
-        if claims.exp <= now {
+        if claims.exp.saturating_add(ID_TOKEN_EXPIRY_LEEWAY_SECS) <= now {
             return Err(OAuthError::ProfileFetch(format!(
                 "decode id_token: token expired at {}",
                 claims.exp
@@ -660,5 +670,27 @@ mod tests {
             matches!(&err, OAuthError::ProfileFetch(_)),
             "expected ProfileFetch for expired token, got {err:?}",
         );
+    }
+
+    #[tokio::test]
+    async fn exchange_code_allows_small_id_token_clock_skew() {
+        let client_id: &'static str = "client-id-123";
+        let id_token = make_id_token(client_id, None, chrono::Utc::now().timestamp() - 30);
+        let addr = spawn_mock_token_endpoint(id_token).await;
+        let endpoint = format!("http://{addr}/token");
+
+        let provider =
+            GoogleProvider::with_endpoints(cfg(None), "https://example.invalid/auth", endpoint)
+                .expect("build provider");
+        let profile = provider
+            .exchange_code(
+                "fake-auth-code",
+                "https://example.com/auth/callback/google",
+                "fake-verifier",
+            )
+            .await
+            .expect("small clock skew should be accepted");
+
+        assert_eq!(profile.provider_user_id, "google-sub-123");
     }
 }

--- a/crates/ironclaw_reborn_webui_ingress/src/auth/google.rs
+++ b/crates/ironclaw_reborn_webui_ingress/src/auth/google.rs
@@ -18,6 +18,7 @@ use std::time::Duration;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
+use jsonwebtoken::Algorithm;
 use secrecy::{ExposeSecret, SecretString};
 use serde::Deserialize;
 
@@ -120,12 +121,59 @@ struct GoogleTokenErrorResponse {
 #[derive(Deserialize)]
 struct GoogleIdTokenClaims {
     sub: String,
+    aud: GoogleIdTokenAudience,
+    iss: String,
     email: Option<String>,
     email_verified: Option<bool>,
     name: Option<String>,
     exp: i64,
     /// Google Workspace hosted domain claim (e.g. `company.com`).
     hd: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum GoogleIdTokenAudience {
+    Single(String),
+    Multiple(Vec<String>),
+}
+
+impl GoogleIdTokenAudience {
+    fn contains(&self, client_id: &str) -> bool {
+        match self {
+            Self::Single(audience) => audience == client_id,
+            Self::Multiple(audiences) => audiences.iter().any(|audience| audience == client_id),
+        }
+    }
+}
+
+fn decode_google_id_token(
+    id_token: &str,
+    client_id: &str,
+) -> Result<GoogleIdTokenClaims, OAuthError> {
+    let token_data = jsonwebtoken::dangerous::insecure_decode::<GoogleIdTokenClaims>(id_token)
+        .map_err(|err| OAuthError::ProfileFetch(format!("decode id_token: {err}")))?;
+
+    if token_data.header.alg != Algorithm::RS256 {
+        return Err(OAuthError::ProfileFetch(format!(
+            "decode id_token: unexpected algorithm {:?}",
+            token_data.header.alg
+        )));
+    }
+
+    let claims = token_data.claims;
+    if !claims.aud.contains(client_id) {
+        return Err(OAuthError::ProfileFetch(
+            "decode id_token: invalid audience".to_string(),
+        ));
+    }
+    if claims.iss != GOOGLE_ISSUER && claims.iss != "accounts.google.com" {
+        return Err(OAuthError::ProfileFetch(
+            "decode id_token: invalid issuer".to_string(),
+        ));
+    }
+
+    Ok(claims)
 }
 
 #[async_trait]
@@ -211,24 +259,10 @@ impl OAuthProvider for GoogleProvider {
         })?;
 
         // Skip signature verification — token was received over TLS
-        // directly from Google. Validate `aud` (prevents another
-        // Google client substituting tokens), `iss` (defense in
-        // depth against a forged TLS termination), and `exp` so
-        // expired tokens still fail closed.
-        let mut validation = jsonwebtoken::Validation::default();
-        #[allow(deprecated)]
-        validation.insecure_disable_signature_validation();
-        validation.set_audience(&[&self.client_id]);
-        validation.set_issuer(&[GOOGLE_ISSUER, "accounts.google.com"]);
-        validation.validate_exp = true;
-
-        let token_data = jsonwebtoken::decode::<GoogleIdTokenClaims>(
-            &id_token,
-            &jsonwebtoken::DecodingKey::from_secret(&[]),
-            &validation,
-        )
-        .map_err(|err| OAuthError::ProfileFetch(format!("decode id_token: {err}")))?;
-        let claims = token_data.claims;
+        // directly from Google. We still validate `alg`, `aud`, `iss`,
+        // and `exp` explicitly so the dependency's crypto backend does
+        // not need a fake RSA key just to parse Google's RS256 token.
+        let claims = decode_google_id_token(&id_token, &self.client_id)?;
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .map_err(|err| OAuthError::ProfileFetch(format!("decode id_token: {err}")))?
@@ -278,7 +312,9 @@ mod tests {
     use super::*;
     use axum::Json;
     use axum::routing::post;
-    use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
+    use base64::Engine as _;
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    use jsonwebtoken::Header;
     use serde::Serialize;
     use std::net::SocketAddr;
 
@@ -342,11 +378,18 @@ mod tests {
     }
 
     fn make_id_token(client_id: &'static str, hd: Option<&'static str>, exp: i64) -> String {
-        // Sign with HS256 + a dummy secret — `GoogleProvider` disables
-        // signature verification, so any well-formed JWT decodes
-        // successfully as long as the claims pass audience+issuer
-        // validation.
+        make_id_token_with_algorithm(client_id, hd, exp, Algorithm::RS256)
+    }
+
+    fn make_id_token_with_algorithm(
+        client_id: &'static str,
+        hd: Option<&'static str>,
+        exp: i64,
+        alg: Algorithm,
+    ) -> String {
         let now = chrono::Utc::now().timestamp();
+        let mut header = Header::new(alg);
+        header.kid = Some("test-key-id".to_string());
         let claims = MockIdTokenClaims {
             sub: "google-sub-123",
             email: "alice@example.com",
@@ -358,12 +401,9 @@ mod tests {
             exp,
             hd,
         };
-        encode(
-            &Header::new(Algorithm::HS256),
-            &claims,
-            &EncodingKey::from_secret(b"unused-test-secret"),
-        )
-        .expect("encode JWT")
+        let header = URL_SAFE_NO_PAD.encode(serde_json::to_vec(&header).expect("encode header"));
+        let claims = URL_SAFE_NO_PAD.encode(serde_json::to_vec(&claims).expect("encode claims"));
+        format!("{header}.{claims}.signature")
     }
 
     async fn spawn_mock_token_endpoint(id_token: String) -> SocketAddr {
@@ -447,6 +487,35 @@ mod tests {
         assert!(
             matches!(err, OAuthError::Denied(_)),
             "expected Denied, got {err:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn exchange_code_rejects_non_google_id_token_algorithm() {
+        let client_id: &'static str = "client-id-123";
+        let id_token = make_id_token_with_algorithm(
+            client_id,
+            None,
+            chrono::Utc::now().timestamp() + 600,
+            Algorithm::HS256,
+        );
+        let addr = spawn_mock_token_endpoint(id_token).await;
+        let endpoint = format!("http://{addr}/token");
+
+        let provider =
+            GoogleProvider::with_endpoints(cfg(None), "https://example.invalid/auth", endpoint)
+                .expect("build provider");
+        let err = provider
+            .exchange_code(
+                "fake-auth-code",
+                "https://example.com/auth/callback/google",
+                "fake-verifier",
+            )
+            .await
+            .expect_err("non-Google alg must reject");
+        assert!(
+            matches!(&err, OAuthError::ProfileFetch(msg) if msg.contains("unexpected algorithm")),
+            "expected ProfileFetch for unexpected alg, got {err:?}",
         );
     }
 

--- a/crates/ironclaw_reborn_webui_ingress/src/auth/routes.rs
+++ b/crates/ironclaw_reborn_webui_ingress/src/auth/routes.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 
 use axum::Json;
 use axum::extract::{Path, Query, State};
-use axum::http::{StatusCode, header};
+use axum::http::{HeaderMap, StatusCode, header};
 use axum::response::{IntoResponse, Redirect, Response};
 use axum::routing::{get, post};
 use chrono::Duration as ChronoDuration;
@@ -334,6 +334,7 @@ struct LoginParams {
 /// authorization URL.
 async fn login_handler(
     State(state): State<RouterStateHandle>,
+    headers: HeaderMap,
     Path(raw_provider): Path<String>,
     Query(params): Query<LoginParams>,
 ) -> Response {
@@ -356,6 +357,22 @@ async fn login_handler(
     };
 
     let redirect_after = sanitize_redirect(params.redirect_after);
+    if let Some(location) = canonical_login_location(
+        &state.base_url,
+        &headers,
+        provider.name(),
+        redirect_after.as_deref(),
+    ) {
+        tracing::warn!(
+            target = "ironclaw::reborn::webui_ingress::auth",
+            provider = %provider_name,
+            base_url = %state.base_url,
+            request_host = ?request_host(&headers),
+            "OAuth login requested on a non-canonical host; redirecting before state creation",
+        );
+        return Redirect::temporary(&location).into_response();
+    }
+
     let (csrf_state, flow) = state
         .pending
         .insert(provider.name().clone(), redirect_after);
@@ -621,6 +638,55 @@ fn error_code_for(err: &OAuthError) -> &'static str {
     }
 }
 
+fn request_host(headers: &HeaderMap) -> Option<&str> {
+    headers.get(header::HOST)?.to_str().ok()
+}
+
+fn canonical_login_location(
+    base_url: &str,
+    headers: &HeaderMap,
+    provider_name: &OAuthProviderName,
+    redirect_after: Option<&str>,
+) -> Option<String> {
+    let request_host = request_host(headers)?;
+    let base = url::Url::parse(base_url).ok()?;
+    if request_host_matches_base(request_host, &base) {
+        return None;
+    }
+
+    let mut url = base;
+    url.set_path(&format!("/auth/login/{provider_name}"));
+    url.set_query(None);
+    if let Some(redirect_after) = redirect_after {
+        url.query_pairs_mut()
+            .append_pair("redirect_after", redirect_after);
+    }
+    Some(url.to_string())
+}
+
+fn request_host_matches_base(request_host: &str, base: &url::Url) -> bool {
+    let Ok(authority) = request_host.trim().parse::<axum::http::uri::Authority>() else {
+        return true;
+    };
+    let Some(base_host) = base.host_str() else {
+        return true;
+    };
+    if !authority.host().eq_ignore_ascii_case(base_host) {
+        return false;
+    }
+
+    let request_port = authority.port_u16().or_else(|| default_port(base.scheme()));
+    request_port == base.port_or_known_default()
+}
+
+fn default_port(scheme: &str) -> Option<u16> {
+    match scheme {
+        "http" => Some(80),
+        "https" => Some(443),
+        _ => None,
+    }
+}
+
 fn log_oauth_error(provider_name: &OAuthProviderName, err: &OAuthError) {
     // Provider error bodies and JWT decode details are operator-only
     // — never echoed back to the client. Logged at `warn!` so they
@@ -629,7 +695,16 @@ fn log_oauth_error(provider_name: &OAuthProviderName, err: &OAuthError) {
     tracing::warn!(
         target = "ironclaw::reborn::webui_ingress::auth",
         provider = %provider_name,
+        error_kind = error_kind_for(err),
         error = %err,
         "OAuth flow failed",
     );
+}
+
+fn error_kind_for(err: &OAuthError) -> &'static str {
+    match err {
+        OAuthError::CodeExchange(_) => "code_exchange",
+        OAuthError::ProfileFetch(_) => "profile_fetch",
+        OAuthError::Denied(_) => "denied",
+    }
 }

--- a/crates/ironclaw_reborn_webui_ingress/tests/google_oauth_routes.rs
+++ b/crates/ironclaw_reborn_webui_ingress/tests/google_oauth_routes.rs
@@ -250,6 +250,63 @@ async fn login_redirects_to_provider_with_state_and_callback_url() {
 }
 
 #[tokio::test]
+async fn login_from_non_canonical_host_redirects_before_state_creation() {
+    let store: Arc<dyn SessionStore> = Arc::new(InMemorySessionStore::new());
+    let provider = StubProvider::google_with_profile(alice_profile());
+    let router = build_router(vec![provider as Arc<dyn OAuthProvider>], store);
+
+    let resp = router
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/auth/login/google?redirect_after=%2Fv2")
+                .header(header::HOST, "preview.example")
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("oneshot");
+    assert_eq!(resp.status(), StatusCode::TEMPORARY_REDIRECT);
+    let location = resp
+        .headers()
+        .get(header::LOCATION)
+        .expect("Location header")
+        .to_str()
+        .expect("utf-8");
+    assert_eq!(
+        location,
+        "https://gateway.example/auth/login/google?redirect_after=%2Fv2"
+    );
+}
+
+#[tokio::test]
+async fn canonical_login_redirect_does_not_echo_unsafe_redirect_after() {
+    let store: Arc<dyn SessionStore> = Arc::new(InMemorySessionStore::new());
+    let provider = StubProvider::google_with_profile(alice_profile());
+    let router = build_router(vec![provider as Arc<dyn OAuthProvider>], store);
+
+    let resp = router
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/auth/login/google?redirect_after=%2F%2Fevil.example%2Fv2")
+                .header(header::HOST, "preview.example")
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("oneshot");
+    assert_eq!(resp.status(), StatusCode::TEMPORARY_REDIRECT);
+    let location = resp
+        .headers()
+        .get(header::LOCATION)
+        .expect("Location header")
+        .to_str()
+        .expect("utf-8");
+    assert_eq!(location, "https://gateway.example/auth/login/google");
+}
+
+#[tokio::test]
 async fn login_unknown_provider_returns_404() {
     let store: Arc<dyn SessionStore> = Arc::new(InMemorySessionStore::new());
     let router = build_router(Vec::new(), store);

--- a/docs/reborn/deploy-reborn-cli-docker.md
+++ b/docs/reborn/deploy-reborn-cli-docker.md
@@ -152,7 +152,9 @@ start, the entrypoint copies that file into `$IRONCLAW_REBORN_HOME/config.toml`;
 later starts preserve the existing home config.
 
 For public WebUI Google login, use the Reborn WebUI SSO variables and an HTTPS
-base URL that matches the deployed Railway domain:
+base URL that matches the deployed Railway domain users will open. If Railway
+exposes more than one domain for the same service, choose one canonical domain
+for `IRONCLAW_REBORN_WEBUI_BASE_URL` and register that same domain in Google:
 
 ```bash
 IRONCLAW_REBORN_WEBUI_BASE_URL=https://<railway-domain>


### PR DESCRIPTION
## Summary

- Fix Reborn WebUI Google SSO `id_token` decoding for real Google `RS256` tokens after the `jsonwebtoken` 10.x bump.
- Canonicalize `/auth/login/{provider}` to `IRONCLAW_REBORN_WEBUI_BASE_URL` before creating pending OAuth state, so Railway preview/custom domains cannot send the browser to a callback host that cannot see the minted state.
- Add redacted Google token-endpoint diagnostics and restore the previous 60-second ID-token expiration leeway.
- Update caller-level Google OAuth route tests, provider token tests, and deployment/docs guidance.

## Root Cause

Initial failure: Google returns `RS256` ID tokens. The provider disabled signature verification but still called `jsonwebtoken::decode` with `DecodingKey::from_secret(&[])`. With `jsonwebtoken` 10.4.0 plus the `aws_lc_rs` crypto backend, `decode` still builds a verifier from the token header before skipping signature validation, so `RS256` tokens paired with an HMAC empty key fail with `InvalidKeyFormat`.

Second failure found in preview: the Railway PR web URL was `https://ironclaw-ironclaw-pr-5388.up.railway.app`, but the OAuth callback configured in the generated Google authorization URL was `https://ironclaw-ci-preview.up.railway.app/auth/callback/google`. A live fake-code flow that started on the PR web host redirected to the callback host and returned `/v2?login_error=invalid_state`, proving the pending state was minted on a host/process the callback could not read. The login route now redirects to the configured canonical base URL before state creation.

The dependency break was exposed by #5271, which bumped `jsonwebtoken` to 10.4.0. The fragile empty-key pattern originated in the original WebUI v2 Google SSO implementation.

## Validation

- `cargo fmt --check`
- `cargo test -p ironclaw_reborn_webui_ingress --all-features --test google_oauth_routes -- --nocapture`
- `cargo test -p ironclaw_reborn_webui_ingress --all-features --lib exchange_code_ -- --nocapture`
- `CARGO_TARGET_DIR=target/codex-clippy-1.95 RUSTC=/Users/firatsertgoz/.rustup/toolchains/1.95.0-aarch64-apple-darwin/bin/rustc /Users/firatsertgoz/.rustup/toolchains/1.95.0-aarch64-apple-darwin/bin/cargo-clippy clippy -p ironclaw_reborn_webui_ingress --all-features --tests -- -D warnings`
