### PR TITLE
feat(reborn): recoverable-error fixes — batch 1 (on top of #4841)

### DIFF
--- a/crates/ironclaw_agent_loop/src/executor/mapping.rs
+++ b/crates/ironclaw_agent_loop/src/executor/mapping.rs
@@ -148,19 +148,32 @@ pub(super) fn capability_error_class(kind: &CapabilityFailureKind) -> Capability
         | CapabilityFailureKind::OperationFailed
         | CapabilityFailureKind::OutputTooLarge
         | CapabilityFailureKind::Process
-        | CapabilityFailureKind::Resource => CapabilityErrorClass::OperationFailed,
+        | CapabilityFailureKind::Resource
+        // Dispatcher/InvalidOutput/Unknown are dispositioned as model-visible
+        // (run-continuing) by the host_runtime layer
+        // (`capability_failure_disposition`). Map them to OperationFailed so the
+        // recovery strategy turns them into a model-visible ToolErrorResult
+        // instead of aborting the run — e.g. the model calling a nonexistent
+        // tool (UnknownCapability/UnknownProvider -> InvalidOutput) becomes a
+        // recoverable tool error the model can correct.
+        | CapabilityFailureKind::Dispatcher
+        | CapabilityFailureKind::InvalidOutput
+        | CapabilityFailureKind::Unknown(_) => CapabilityErrorClass::OperationFailed,
         CapabilityFailureKind::Authorization
         | CapabilityFailureKind::GateDeclined
         | CapabilityFailureKind::PolicyDenied => CapabilityErrorClass::PolicyDenied,
         CapabilityFailureKind::Internal => CapabilityErrorClass::Internal,
-        CapabilityFailureKind::Dispatcher => CapabilityErrorClass::Permanent,
-        CapabilityFailureKind::Cancelled => CapabilityErrorClass::Permanent,
-        CapabilityFailureKind::InvalidOutput
-        | CapabilityFailureKind::Permanent
-        | CapabilityFailureKind::Unknown(_) => CapabilityErrorClass::Permanent,
-        // CapabilityFailureKind is #[non_exhaustive]; treat unrecognised future variants as
-        // permanent failures so callers do not retry indefinitely on unknown error kinds.
-        &_ => CapabilityErrorClass::Permanent,
+        // Cancelled is intercepted upstream as cancellation; Permanent is an
+        // explicit non-retryable signal. Both stay terminal.
+        CapabilityFailureKind::Cancelled | CapabilityFailureKind::Permanent => {
+            CapabilityErrorClass::Permanent
+        }
+        // CapabilityFailureKind is #[non_exhaustive]. Treat unrecognised future
+        // variants as recoverable (OperationFailed) to match the host_runtime
+        // disposition layer's recoverable default: by design no capability
+        // failure should abort the run, so an unknown kind becomes a
+        // model-visible tool error rather than killing the run.
+        &_ => CapabilityErrorClass::OperationFailed,
     }
 }
 
@@ -253,6 +266,44 @@ mod tests {
         assert_eq!(
             capability_failure_kind(&CapabilityFailureKind::PolicyDenied),
             LoopFailureKind::PolicyDenied
+        );
+    }
+
+    #[test]
+    fn model_recoverable_capability_failures_are_operation_failed_not_permanent() {
+        // The host_runtime disposition layer treats Dispatcher, InvalidOutput,
+        // and Unknown as model-visible (run-continuing) errors. The recovery
+        // class mapping must agree: these become OperationFailed (a
+        // model-visible tool error) rather than Permanent (which aborts the
+        // run). E.g. the model calling a nonexistent tool becomes a recoverable
+        // tool error, not a run-ending protocol failure.
+        assert_eq!(
+            capability_error_class(&CapabilityFailureKind::Dispatcher),
+            CapabilityErrorClass::OperationFailed
+        );
+        assert_eq!(
+            capability_error_class(&CapabilityFailureKind::InvalidOutput),
+            CapabilityErrorClass::OperationFailed
+        );
+        let unknown = CapabilityFailureKind::unknown("some_future_kind".to_string())
+            .expect("valid unknown kind");
+        assert_eq!(
+            capability_error_class(&unknown),
+            CapabilityErrorClass::OperationFailed
+        );
+    }
+
+    #[test]
+    fn terminal_capability_failures_remain_permanent() {
+        // Cancelled is intercepted upstream as cancellation; Permanent is an
+        // explicit non-retryable signal. Both must stay terminal.
+        assert_eq!(
+            capability_error_class(&CapabilityFailureKind::Cancelled),
+            CapabilityErrorClass::Permanent
+        );
+        assert_eq!(
+            capability_error_class(&CapabilityFailureKind::Permanent),
+            CapabilityErrorClass::Permanent
         );
     }
 

--- a/crates/ironclaw_host_runtime/src/production.rs
+++ b/crates/ironclaw_host_runtime/src/production.rs
@@ -484,7 +484,16 @@ impl HostRuntime for DefaultHostRuntime {
             idempotency_key,
             trust_decision: _caller_trust_decision,
         } = request;
-        let input = host_runtime_spawn_input_for_capability(&capability_id, input)?;
+        let input = match host_runtime_spawn_input_for_capability(&capability_id, input)? {
+            SpawnInputPreparation::Ready(input) => input,
+            SpawnInputPreparation::ModelInputRejected(failure) => {
+                tracing::debug!(
+                    capability_id = %capability_id,
+                    "process sandbox spawn rejected malformed model plan as recoverable tool error"
+                );
+                return Ok(RuntimeCapabilityOutcome::Failed(failure));
+            }
+        };
         let scope = context.resource_scope.clone();
         let invocation_id = context.invocation_id;
         let idempotency_key = idempotency_key.map(|key| key.as_str().to_string());
@@ -808,7 +817,16 @@ impl HostRuntime for DefaultHostRuntime {
             idempotency_key,
             trust_decision: _caller_trust_decision,
         } = request;
-        let input = host_runtime_spawn_input_for_capability(&capability_id, input)?;
+        let input = match host_runtime_spawn_input_for_capability(&capability_id, input)? {
+            SpawnInputPreparation::Ready(input) => input,
+            SpawnInputPreparation::ModelInputRejected(failure) => {
+                tracing::debug!(
+                    capability_id = %capability_id,
+                    "process sandbox spawn resume rejected malformed model plan as recoverable tool error"
+                );
+                return Ok(RuntimeCapabilityOutcome::Failed(failure));
+            }
+        };
         let idempotency_key = idempotency_key.map(|key| key.as_str().to_string());
         if let Some(key) = idempotency_key.as_deref() {
             tracing::debug!(
@@ -1980,26 +1998,65 @@ fn persistent_approval_lookup_scopes(scope: &ResourceScope) -> Vec<PersistentApp
     }
 }
 
+/// Outcome of preparing model-supplied spawn input for a capability.
+///
+/// A malformed or invalid process-sandbox plan is a *model-fixable* condition:
+/// the model chose bad arguments and can correct them on a retry. It must
+/// surface as a recoverable, model-visible tool error
+/// ([`RuntimeFailureKind::InvalidInput`] → `ModelVisibleToolError`), never as a
+/// terminal [`HostRuntimeError`] that ends the whole run. Genuine host-side
+/// faults (serializing the validated host struct back to JSON) remain errors.
+enum SpawnInputPreparation {
+    /// Input is ready to dispatch to the capability host.
+    Ready(serde_json::Value),
+    /// Model supplied an unparseable/invalid plan — recoverable, model-visible.
+    ModelInputRejected(RuntimeCapabilityFailure),
+}
+
 fn host_runtime_spawn_input_for_capability(
     capability_id: &CapabilityId,
     input: serde_json::Value,
-) -> Result<serde_json::Value, HostRuntimeError> {
+) -> Result<SpawnInputPreparation, HostRuntimeError> {
     if capability_id.as_str() != PROCESS_SANDBOX_CAPABILITY_ID {
-        return Ok(input);
+        return Ok(SpawnInputPreparation::Ready(input));
     }
-    let plan = serde_json::from_value::<SandboxProcessPlan>(input).map_err(|_| {
-        HostRuntimeError::invalid_request(
-            "process sandbox capability input must be a SandboxProcessPlan",
-        )
-    })?;
-    let plan = ValidatedSandboxProcessPlan::new(plan).map_err(|_| {
-        HostRuntimeError::invalid_request(
-            "process sandbox capability input failed SandboxProcessPlan validation",
-        )
-    })?;
-    serde_json::to_value(plan.into_plan()).map_err(|_| {
+    let plan = match serde_json::from_value::<SandboxProcessPlan>(input) {
+        Ok(plan) => plan,
+        Err(_) => {
+            return Ok(SpawnInputPreparation::ModelInputRejected(
+                RuntimeCapabilityFailure::new(
+                    capability_id.clone(),
+                    RuntimeFailureKind::InvalidInput,
+                    Some(
+                        "process sandbox capability input must be a SandboxProcessPlan"
+                            .to_string(),
+                    ),
+                ),
+            ));
+        }
+    };
+    let plan = match ValidatedSandboxProcessPlan::new(plan) {
+        Ok(plan) => plan,
+        Err(_) => {
+            return Ok(SpawnInputPreparation::ModelInputRejected(
+                RuntimeCapabilityFailure::new(
+                    capability_id.clone(),
+                    RuntimeFailureKind::InvalidInput,
+                    Some(
+                        "process sandbox capability input failed SandboxProcessPlan validation"
+                            .to_string(),
+                    ),
+                ),
+            ));
+        }
+    };
+    // Serializing the *validated host struct* back to JSON is a host-side
+    // operation, not model input. A failure here is a genuine internal fault,
+    // so it stays a terminal error rather than a model-visible tool error.
+    let value = serde_json::to_value(plan.into_plan()).map_err(|_| {
         HostRuntimeError::invalid_request("validated process sandbox plan could not be serialized")
-    })
+    })?;
+    Ok(SpawnInputPreparation::Ready(value))
 }
 
 fn failure_from(
@@ -2469,7 +2526,81 @@ output_schema_ref = "schemas/test.output.json"
         let output = host_runtime_spawn_input_for_capability(&cap(), input.clone())
             .expect("non-sandbox capability input should pass through");
 
-        assert_eq!(output, input);
+        match output {
+            SpawnInputPreparation::Ready(value) => assert_eq!(value, input),
+            SpawnInputPreparation::ModelInputRejected(_) => {
+                panic!("non-sandbox input must pass through unchanged")
+            }
+        }
+    }
+
+    fn process_sandbox_cap() -> CapabilityId {
+        CapabilityId::new(PROCESS_SANDBOX_CAPABILITY_ID).expect("valid process sandbox capability")
+    }
+
+    #[test]
+    fn host_runtime_spawn_input_rejects_malformed_plan_as_recoverable_invalid_input() {
+        // The model supplied JSON that is not a `SandboxProcessPlan` at all.
+        // This is model-fixable: it must surface as a recoverable, model-visible
+        // tool error (`InvalidInput`), never a terminal `HostRuntimeError`.
+        let input = serde_json::json!({ "not_run": true });
+
+        let output = host_runtime_spawn_input_for_capability(&process_sandbox_cap(), input)
+            .expect("malformed model plan must not be a terminal host error");
+
+        match output {
+            SpawnInputPreparation::ModelInputRejected(failure) => {
+                assert_eq!(failure.kind, RuntimeFailureKind::InvalidInput);
+                assert_eq!(
+                    failure.disposition(),
+                    crate::CapabilityFailureDisposition::ModelVisibleToolError
+                );
+            }
+            SpawnInputPreparation::Ready(_) => {
+                panic!("malformed plan must be rejected as model-visible InvalidInput")
+            }
+        }
+    }
+
+    #[test]
+    fn host_runtime_spawn_input_rejects_invalid_plan_as_recoverable_invalid_input() {
+        // The model supplied a structurally-parseable plan that fails
+        // `ValidatedSandboxProcessPlan` validation (empty command). Still
+        // model-fixable → recoverable `InvalidInput`, not terminal.
+        let input = serde_json::json!({ "run": { "command": "" } });
+
+        let output = host_runtime_spawn_input_for_capability(&process_sandbox_cap(), input)
+            .expect("invalid model plan must not be a terminal host error");
+
+        match output {
+            SpawnInputPreparation::ModelInputRejected(failure) => {
+                assert_eq!(failure.kind, RuntimeFailureKind::InvalidInput);
+                assert_eq!(
+                    failure.disposition(),
+                    crate::CapabilityFailureDisposition::ModelVisibleToolError
+                );
+            }
+            SpawnInputPreparation::Ready(_) => {
+                panic!("invalid plan must be rejected as model-visible InvalidInput")
+            }
+        }
+    }
+
+    #[test]
+    fn host_runtime_spawn_input_accepts_valid_plan() {
+        let input = serde_json::json!({ "run": { "command": "echo", "args": ["ok"] } });
+
+        let output = host_runtime_spawn_input_for_capability(&process_sandbox_cap(), input)
+            .expect("valid plan preparation must not error");
+
+        match output {
+            SpawnInputPreparation::Ready(value) => {
+                assert!(value.is_object(), "validated plan serializes to an object");
+            }
+            SpawnInputPreparation::ModelInputRejected(_) => {
+                panic!("valid plan must be accepted")
+            }
+        }
     }
 
     #[test]

--- a/crates/ironclaw_host_runtime/src/production.rs
+++ b/crates/ironclaw_host_runtime/src/production.rs
@@ -2214,13 +2214,20 @@ impl From<DispatchFailureKind> for RuntimeFailureKind {
             DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::OperationFailed) => {
                 RuntimeFailureKind::OperationFailed
             }
+            // A method or capability the model named that does not exist is a
+            // model-fixable request error, not an infra fault: classify it as
+            // InvalidInput so it surfaces as an immediate model-visible tool
+            // error instead of burning the retry budget on a call that can
+            // never resolve by retrying.
+            DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::MethodMissing)
+            | DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::UndeclaredCapability) => {
+                RuntimeFailureKind::InvalidInput
+            }
             DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::Backend)
             | DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::Client)
             | DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::Executor)
             | DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::Guest)
             | DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::Manifest)
-            | DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::MethodMissing)
-            | DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::UndeclaredCapability)
             | DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::UnsupportedRunner) => {
                 RuntimeFailureKind::Backend
             }
@@ -2412,7 +2419,7 @@ output_schema_ref = "schemas/test.output.json"
             ),
             (
                 RuntimeDispatchErrorKind::MethodMissing,
-                RuntimeFailureKind::Backend,
+                RuntimeFailureKind::InvalidInput,
             ),
             (
                 RuntimeDispatchErrorKind::NetworkDenied,
@@ -2444,7 +2451,7 @@ output_schema_ref = "schemas/test.output.json"
             ),
             (
                 RuntimeDispatchErrorKind::UndeclaredCapability,
-                RuntimeFailureKind::Backend,
+                RuntimeFailureKind::InvalidInput,
             ),
             (
                 RuntimeDispatchErrorKind::UnsupportedRunner,

--- a/crates/ironclaw_host_runtime/src/production.rs
+++ b/crates/ironclaw_host_runtime/src/production.rs
@@ -2028,8 +2028,7 @@ fn host_runtime_spawn_input_for_capability(
                     capability_id.clone(),
                     RuntimeFailureKind::InvalidInput,
                     Some(
-                        "process sandbox capability input must be a SandboxProcessPlan"
-                            .to_string(),
+                        "process sandbox capability input must be a SandboxProcessPlan".to_string(),
                     ),
                 ),
             ));

--- a/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
@@ -3513,16 +3513,31 @@ async fn host_runtime_spawn_process_sandbox_rejects_invalid_plan_before_executor
     let mut request = process_sandbox_runtime_request_for_scope(scope);
     request.input = invalid_process_sandbox_input();
 
-    let error = runtime
+    // A malformed/invalid plan is model-fixable: it must surface as a
+    // recoverable, model-visible tool error (InvalidInput) so the run
+    // continues and the model can correct its arguments — never a terminal
+    // HostRuntimeError that kills the whole run.
+    let outcome = runtime
         .spawn_capability(request)
         .await
-        .expect_err("invalid sandbox plans must fail at the host runtime boundary");
+        .expect("invalid sandbox plans must not be a terminal host runtime error");
 
-    match error {
-        ironclaw_host_runtime::HostRuntimeError::InvalidRequest { reason } => {
-            assert!(reason.contains("SandboxProcessPlan"));
+    match outcome {
+        RuntimeCapabilityOutcome::Failed(failure) => {
+            assert_eq!(failure.kind, RuntimeFailureKind::InvalidInput);
+            assert_eq!(
+                failure.disposition(),
+                ironclaw_host_runtime::CapabilityFailureDisposition::ModelVisibleToolError,
+            );
+            assert!(
+                failure
+                    .message
+                    .as_deref()
+                    .unwrap_or_default()
+                    .contains("SandboxProcessPlan")
+            );
         }
-        other => panic!("expected invalid request, got {other:?}"),
+        other => panic!("expected recoverable InvalidInput failure, got {other:?}"),
     }
     assert!(
         sandbox_executor.requests().is_empty(),
@@ -3796,7 +3811,10 @@ async fn host_runtime_spawn_process_sandbox_resume_invalid_plan_fails_before_exe
     };
     let lease = approve_spawn_for_services(&services, &scope, approval_request_id, None).await;
 
-    let error = runtime
+    // Same recoverable contract on the resume path: a malformed/invalid plan
+    // is model-fixable, so it must surface as a recoverable InvalidInput tool
+    // error rather than a terminal host runtime error.
+    let outcome = runtime
         .resume_spawn_capability(RuntimeCapabilityResumeRequest::new(
             context,
             approval_request_id,
@@ -3806,13 +3824,24 @@ async fn host_runtime_spawn_process_sandbox_resume_invalid_plan_fails_before_exe
             process_sandbox_trust_decision(),
         ))
         .await
-        .expect_err("invalid sandbox resume input must fail at the host runtime boundary");
+        .expect("invalid sandbox resume input must not be a terminal host runtime error");
 
-    match error {
-        ironclaw_host_runtime::HostRuntimeError::InvalidRequest { reason } => {
-            assert!(reason.contains("SandboxProcessPlan"));
+    match outcome {
+        RuntimeCapabilityOutcome::Failed(failure) => {
+            assert_eq!(failure.kind, RuntimeFailureKind::InvalidInput);
+            assert_eq!(
+                failure.disposition(),
+                ironclaw_host_runtime::CapabilityFailureDisposition::ModelVisibleToolError,
+            );
+            assert!(
+                failure
+                    .message
+                    .as_deref()
+                    .unwrap_or_default()
+                    .contains("SandboxProcessPlan")
+            );
         }
-        other => panic!("expected invalid request, got {other:?}"),
+        other => panic!("expected recoverable InvalidInput failure, got {other:?}"),
     }
     assert!(
         sandbox_executor.requests().is_empty(),

--- a/crates/ironclaw_llm/src/anthropic_oauth.rs
+++ b/crates/ironclaw_llm/src/anthropic_oauth.rs
@@ -67,6 +67,17 @@ fn parse_oauth_access_token(json: &str) -> Option<String> {
     }
     Some(token.to_string())
 }
+/// Map an HTTP error status + response body to a context-length error when it
+/// indicates the prompt exceeded the model's context window.
+///
+/// Returns `Some(LlmError::ContextLengthExceeded { .. })` for HTTP 413 or for
+/// an HTTP 400 whose body matches a context-overflow pattern, and `None`
+/// otherwise. Delegates to the shared `crate::error::context_length_error`
+/// helper so detection stays consistent across direct-HTTP providers.
+fn context_length_error_for_status(status_code: u16, response_text: &str) -> Option<LlmError> {
+    crate::error::context_length_error(status_code, response_text)
+}
+
 const ANTHROPIC_API_URL: &str = "https://api.anthropic.com/v1/messages";
 /// OAuth beta requires 2023-06-01; the 2024-10-22 version is not valid with the beta flag.
 const ANTHROPIC_API_VERSION: &str = "2023-06-01";
@@ -254,6 +265,14 @@ impl AnthropicOAuthProvider {
                     provider: "anthropic_oauth".to_string(),
                     retry_after,
                 });
+            }
+            // A too-large prompt (HTTP 413, or a 400 whose body says the context
+            // window was exceeded) must map to ContextLengthExceeded so the
+            // loop's context-shrink recovery can compact and retry instead of
+            // borking on a generic RequestFailed.
+            if let Some(error) = context_length_error_for_status(status.as_u16(), &response_text) {
+                tracing::warn!("Anthropic OAuth: context length exceeded");
+                return Err(error);
             }
             let truncated = ironclaw_common::truncate_for_preview(&response_text, 512);
             return Err(LlmError::RequestFailed {
@@ -766,6 +785,44 @@ fn extract_response_content(response: &AnthropicResponse) -> ExtractedAnthropicR
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn context_overflow_413_maps_to_context_length_exceeded() {
+        // A raw HTTP 413 (payload too large) must become ContextLengthExceeded
+        // so the loop's context-shrink recovery fires.
+        match context_length_error_for_status(413, "Request Entity Too Large") {
+            Some(LlmError::ContextLengthExceeded { .. }) => {}
+            other => panic!("expected ContextLengthExceeded, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn context_overflow_400_body_maps_to_context_length_exceeded() {
+        let body = r#"{"type":"error","error":{"type":"invalid_request_error","message":"prompt is too long: 234872 tokens > 200000 maximum"}}"#;
+        match context_length_error_for_status(400, body) {
+            Some(LlmError::ContextLengthExceeded { used, limit }) => {
+                assert_eq!(used, 234872);
+                assert_eq!(limit, 200000);
+            }
+            other => panic!("expected ContextLengthExceeded, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unrelated_400_is_not_context_overflow() {
+        // A plain bad-request (e.g. invalid request shape) must NOT be
+        // classified as context overflow — the caller falls through to
+        // RequestFailed.
+        assert!(
+            context_length_error_for_status(400, r#"{"error":{"message":"invalid request body"}}"#)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn unrelated_5xx_is_not_context_overflow() {
+        assert!(context_length_error_for_status(503, "service unavailable").is_none());
+    }
 
     #[test]
     fn test_convert_messages_extracts_system() {

--- a/crates/ironclaw_llm/src/codex_chatgpt.rs
+++ b/crates/ironclaw_llm/src/codex_chatgpt.rs
@@ -525,6 +525,11 @@ impl CodexChatGptProvider {
                                 .await
                                 .unwrap_or(Ok(String::new()))
                                 .unwrap_or_default();
+                        if let Some(error) =
+                            crate::error::context_length_error(retry_status.as_u16(), &body_text)
+                        {
+                            return Err(error);
+                        }
                         return Err(LlmError::RequestFailed {
                             provider: "codex_chatgpt".to_string(),
                             reason: format!(
@@ -561,6 +566,11 @@ impl CodexChatGptProvider {
                                 .await
                                 .unwrap_or(Ok(String::new()))
                                 .unwrap_or_default();
+                        if let Some(error) =
+                            crate::error::context_length_error(retry_status.as_u16(), &body_text)
+                        {
+                            return Err(error);
+                        }
                         return Err(LlmError::RequestFailed {
                             provider: "codex_chatgpt".to_string(),
                             reason: format!(
@@ -591,6 +601,12 @@ impl CodexChatGptProvider {
                 .await
                 .unwrap_or(Ok(String::new()))
                 .unwrap_or_default();
+            // Context-overflow (HTTP 413, or a 400 whose body names a
+            // context-length error) must surface as ContextLengthExceeded so
+            // the loop's context-shrink recovery fires.
+            if let Some(error) = crate::error::context_length_error(status.as_u16(), &body_text) {
+                return Err(error);
+            }
             return Err(LlmError::RequestFailed {
                 provider: "codex_chatgpt".to_string(),
                 reason: format!("HTTP {status} from {url}: {body_text}",),
@@ -651,7 +667,10 @@ impl CodexChatGptProvider {
                         continue;
                     }
                     if data == "[DONE]" {
-                        return Ok(result);
+                        // `[DONE]` is the SSE terminator, but the Responses API
+                        // always emits `response.completed` before it. A `[DONE]`
+                        // without a preceding completion is a truncated stream.
+                        return Self::finalize_stream_result(result);
                     }
 
                     let parsed: Value = match serde_json::from_str(data) {
@@ -660,7 +679,7 @@ impl CodexChatGptProvider {
                     };
 
                     let event_type = Self::resolve_sse_event_type(event.event.as_str(), &parsed);
-                    if Self::handle_sse_event(&mut result, event_type.as_ref(), &parsed) {
+                    if Self::handle_sse_event(&mut result, event_type.as_ref(), &parsed)? {
                         return Ok(result);
                     }
                 }
@@ -670,7 +689,9 @@ impl CodexChatGptProvider {
                         reason: format!("Failed to read SSE stream: {e}"),
                     });
                 }
-                Ok(None) => return Ok(result),
+                // Stream ended without a terminal `response.completed`
+                // (mid-stream disconnect). Treat as truncated, not success.
+                Ok(None) => return Self::finalize_stream_result(result),
                 Err(_) => {
                     return Err(LlmError::RequestFailed {
                         provider: "codex_chatgpt".to_string(),
@@ -682,6 +703,26 @@ impl CodexChatGptProvider {
                 }
             }
         }
+    }
+
+    /// Convert a stream that ended without a terminal `response.completed`
+    /// event into a RETRYABLE error. A dropped connection must not masquerade
+    /// as a successful completion: `EmptyResponse` when nothing was produced,
+    /// `InvalidResponse` when partial content/tool calls were captured.
+    ///
+    /// `response.completed` is the only path that returns `Ok(result)`
+    /// directly, so reaching this finalizer always means the terminal event
+    /// was missing.
+    fn finalize_stream_result(result: ResponsesResult) -> Result<ResponsesResult, LlmError> {
+        if result.text.is_empty() && result.pending_tool_calls.is_empty() {
+            return Err(LlmError::EmptyResponse {
+                provider: "codex_chatgpt".to_string(),
+            });
+        }
+        Err(LlmError::InvalidResponse {
+            provider: "codex_chatgpt".to_string(),
+            reason: "stream ended before response.completed".to_string(),
+        })
     }
 
     /// Parse SSE events from the response text.
@@ -702,7 +743,7 @@ impl CodexChatGptProvider {
                     continue;
                 }
                 if data == "[DONE]" {
-                    return Ok(result);
+                    return Self::finalize_stream_result(result);
                 }
 
                 let parsed: Value = match serde_json::from_str(data) {
@@ -711,13 +752,13 @@ impl CodexChatGptProvider {
                 };
 
                 let event_type = Self::resolve_sse_event_type(current_event_type.as_str(), &parsed);
-                if Self::handle_sse_event(&mut result, event_type.as_ref(), &parsed) {
+                if Self::handle_sse_event(&mut result, event_type.as_ref(), &parsed)? {
                     return Ok(result);
                 }
             }
         }
 
-        Ok(result)
+        Self::finalize_stream_result(result)
     }
 
     fn resolve_sse_event_type<'a>(event_type: &'a str, parsed: &'a Value) -> Cow<'a, str> {
@@ -731,7 +772,19 @@ impl CodexChatGptProvider {
             .unwrap_or_else(|| Cow::Borrowed(event_type))
     }
 
-    fn handle_sse_event(result: &mut ResponsesResult, event_type: &str, parsed: &Value) -> bool {
+    /// Handle a single SSE event.
+    ///
+    /// Returns `Ok(true)` when a terminal `response.completed` event was seen
+    /// (the caller stops reading), `Ok(false)` to continue, and `Err(_)` when
+    /// the event signals an upstream failure (`error` / `response.failed`).
+    /// Context-overflow failures map to [`LlmError::ContextLengthExceeded`] so
+    /// the loop's context-shrink recovery fires; everything else maps to a
+    /// retryable error.
+    fn handle_sse_event(
+        result: &mut ResponsesResult,
+        event_type: &str,
+        parsed: &Value,
+    ) -> Result<bool, LlmError> {
         match event_type {
             "response.output_text.delta" => {
                 if let Some(delta) = parsed.get("delta").and_then(|d| d.as_str()) {
@@ -827,12 +880,53 @@ impl CodexChatGptProvider {
                     output_tokens = result.output_tokens,
                     "Codex ChatGPT: parsed completed response"
                 );
-                return true;
+                return Ok(true);
+            }
+            // Upstream signalled the response failed. Mirror
+            // `openai_codex_provider.rs`: prefer ContextLengthExceeded when the
+            // message names a context/413 error, else a retryable error.
+            "response.failed" => {
+                let reason = parsed
+                    .get("response")
+                    .and_then(|r| r.get("status_details"))
+                    .and_then(|d| d.get("error"))
+                    .and_then(|e| e.get("message"))
+                    .and_then(|m| m.as_str())
+                    .unwrap_or("Unknown error");
+                if crate::error::is_context_length_error_message(&reason.to_ascii_lowercase()) {
+                    let (used, limit) =
+                        crate::error::parse_context_token_counts(&reason.to_ascii_lowercase());
+                    return Err(LlmError::ContextLengthExceeded { used, limit });
+                }
+                return Err(LlmError::RequestFailed {
+                    provider: "codex_chatgpt".to_string(),
+                    reason: format!("Response failed: {reason}"),
+                });
+            }
+            // Standalone SSE error event.
+            "error" => {
+                let code = parsed
+                    .get("code")
+                    .and_then(|c| c.as_str())
+                    .unwrap_or("unknown");
+                let message = parsed
+                    .get("message")
+                    .and_then(|m| m.as_str())
+                    .unwrap_or("Unknown error");
+                if crate::error::is_context_length_error_message(&message.to_ascii_lowercase()) {
+                    let (used, limit) =
+                        crate::error::parse_context_token_counts(&message.to_ascii_lowercase());
+                    return Err(LlmError::ContextLengthExceeded { used, limit });
+                }
+                return Err(LlmError::RequestFailed {
+                    provider: "codex_chatgpt".to_string(),
+                    reason: format!("Error {code}: {message}"),
+                });
             }
             _ => {}
         }
 
-        false
+        Ok(false)
     }
 
     fn merge_completed_response_output(result: &mut ResponsesResult, response: &Value) {
@@ -1516,8 +1610,13 @@ data: {"response":{"usage":{"input_tokens":20,"output_tokens":15}}}
     }
 
     #[tokio::test]
-    async fn test_parse_sse_done_marker_stops_parsing() {
+    async fn test_parse_sse_done_marker_stops_parsing_after_completed() {
+        // `[DONE]` stops parsing and ignores later events, but only AFTER a
+        // terminal `response.completed`. With the completion present, the
+        // result is returned successfully and trailing events are dropped.
         let sse = r#"data: {"type":"response.output_text.delta","delta":"hello"}
+
+data: {"type":"response.completed","response":{"usage":{"input_tokens":1,"output_tokens":1}}}
 
 data: [DONE]
 
@@ -1531,6 +1630,9 @@ data: {"type":"response.output_text.delta","delta":" ignored"}
             Ok(Bytes::from_static(
                 b"data: {\"type\":\"response.output_text.delta\",\"delta\":\"hello\"}\n\n",
             )),
+            Ok(Bytes::from_static(
+                b"data: {\"type\":\"response.completed\",\"response\":{\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}}\n\n",
+            )),
             Ok(Bytes::from_static(b"data: [DONE]\n\n")),
             Ok(Bytes::from_static(
                 b"data: {\"type\":\"response.output_text.delta\",\"delta\":\" ignored\"}\n\n",
@@ -1540,6 +1642,122 @@ data: {"type":"response.output_text.delta","delta":" ignored"}
             .await
             .unwrap();
         assert_eq!(result.text, "hello");
+    }
+
+    /// `[DONE]` (or stream end) without a preceding `response.completed` is a
+    /// truncated stream — a mid-stream disconnect must surface as a retryable
+    /// error, not a successful partial result.
+    #[tokio::test]
+    async fn test_parse_sse_done_without_completed_is_truncated() {
+        let sse = r#"data: {"type":"response.output_text.delta","delta":"hello"}
+
+data: [DONE]
+
+"#;
+        let result = CodexChatGptProvider::parse_sse_response(sse);
+        assert!(
+            matches!(result, Err(LlmError::InvalidResponse { .. })),
+            "[DONE] without response.completed must be InvalidResponse, got {result:?}"
+        );
+
+        let stream = stream::iter(vec![
+            Ok(Bytes::from_static(
+                b"data: {\"type\":\"response.output_text.delta\",\"delta\":\"hello\"}\n\n",
+            )),
+            Ok(Bytes::from_static(b"data: [DONE]\n\n")),
+        ]);
+        let result = CodexChatGptProvider::parse_sse_stream(stream, Duration::from_secs(1)).await;
+        assert!(matches!(result, Err(LlmError::InvalidResponse { .. })));
+    }
+
+    /// A stream that ends (EOF) without any terminal event and without content
+    /// must surface as `EmptyResponse`.
+    #[tokio::test]
+    async fn test_parse_sse_stream_eof_empty_is_error() {
+        let stream = stream::iter(Vec::<Result<Bytes, String>>::new());
+        let result = CodexChatGptProvider::parse_sse_stream(stream, Duration::from_secs(1)).await;
+        assert!(
+            matches!(result, Err(LlmError::EmptyResponse { .. })),
+            "empty stream must be EmptyResponse, got {result:?}"
+        );
+    }
+
+    /// A stream that produced partial text then hit EOF (no `response.completed`)
+    /// must surface as a retryable `InvalidResponse`.
+    #[tokio::test]
+    async fn test_parse_sse_stream_eof_with_partial_text_is_error() {
+        let stream = stream::iter(vec![Ok(Bytes::from_static(
+            b"data: {\"type\":\"response.output_text.delta\",\"delta\":\"partial\"}\n\n",
+        ))]);
+        let result = CodexChatGptProvider::parse_sse_stream(stream, Duration::from_secs(1)).await;
+        match result {
+            Err(LlmError::InvalidResponse { reason, .. }) => {
+                assert!(reason.contains("response.completed"), "reason: {reason}");
+            }
+            other => panic!("expected InvalidResponse, got {other:?}"),
+        }
+    }
+
+    /// An SSE `error` event whose message is a context-overflow error maps to
+    /// `ContextLengthExceeded` so the loop's context-shrink recovery fires.
+    #[test]
+    fn test_parse_sse_error_event_context_length() {
+        let sse = r#"data: {"type":"error","code":"context_length_exceeded","message":"This model's maximum context length is 128000 tokens. However, your messages resulted in 150000 tokens."}
+
+"#;
+        match CodexChatGptProvider::parse_sse_response(sse) {
+            Err(LlmError::ContextLengthExceeded { used, limit }) => {
+                assert_eq!(used, 150000);
+                assert_eq!(limit, 128000);
+            }
+            other => panic!("expected ContextLengthExceeded, got {other:?}"),
+        }
+    }
+
+    /// An SSE `error` event that is NOT context-related maps to a retryable
+    /// `RequestFailed` (previously these were silently ignored).
+    #[test]
+    fn test_parse_sse_error_event_generic_maps_to_request_failed() {
+        let sse = r#"data: {"type":"error","code":"rate_limit_exceeded","message":"Too many requests"}
+
+"#;
+        match CodexChatGptProvider::parse_sse_response(sse) {
+            Err(LlmError::RequestFailed { reason, .. }) => {
+                assert!(reason.contains("rate_limit_exceeded"), "reason: {reason}");
+            }
+            other => panic!("expected RequestFailed, got {other:?}"),
+        }
+    }
+
+    /// A `response.failed` event maps to a retryable `RequestFailed` (was
+    /// previously ignored, letting the stream look truncated/empty).
+    #[test]
+    fn test_parse_sse_response_failed_event() {
+        let sse = r#"data: {"type":"response.failed","response":{"status":"failed","status_details":{"error":{"message":"Model overloaded"}}}}
+
+"#;
+        match CodexChatGptProvider::parse_sse_response(sse) {
+            Err(LlmError::RequestFailed { reason, .. }) => {
+                assert!(reason.contains("Model overloaded"), "reason: {reason}");
+            }
+            other => panic!("expected RequestFailed, got {other:?}"),
+        }
+    }
+
+    /// A `response.failed` event whose message is a context-overflow error maps
+    /// to `ContextLengthExceeded`.
+    #[test]
+    fn test_parse_sse_response_failed_context_length() {
+        let sse = r#"data: {"type":"response.failed","response":{"status":"failed","status_details":{"error":{"message":"prompt is too long: 200000 tokens > 128000 maximum"}}}}
+
+"#;
+        match CodexChatGptProvider::parse_sse_response(sse) {
+            Err(LlmError::ContextLengthExceeded { used, limit }) => {
+                assert_eq!(used, 200000);
+                assert_eq!(limit, 128000);
+            }
+            other => panic!("expected ContextLengthExceeded, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/crates/ironclaw_llm/src/github_copilot.rs
+++ b/crates/ironclaw_llm/src/github_copilot.rs
@@ -28,6 +28,17 @@ use crate::provider::{
     strip_unsupported_completion_params, strip_unsupported_tool_params,
 };
 
+/// Map an HTTP error status + response body to a context-length error when it
+/// indicates the prompt exceeded the model's context window.
+///
+/// Returns `Some(LlmError::ContextLengthExceeded { .. })` for HTTP 413 or for
+/// an HTTP 400 whose body matches a context-overflow pattern, and `None`
+/// otherwise. Delegates to the shared `crate::error::context_length_error`
+/// helper so detection stays consistent across direct-HTTP providers.
+fn context_length_error_for_status(status_code: u16, response_text: &str) -> Option<LlmError> {
+    crate::error::context_length_error(status_code, response_text)
+}
+
 /// GitHub Copilot provider with automatic token exchange.
 pub(crate) struct GithubCopilotProvider {
     client: Client,
@@ -179,6 +190,14 @@ impl GithubCopilotProvider {
                     provider: "github_copilot".to_string(),
                     retry_after,
                 });
+            }
+            // A too-large prompt (HTTP 413, or a 400 whose body says the context
+            // window was exceeded) must map to ContextLengthExceeded so the
+            // loop's context-shrink recovery can compact and retry instead of
+            // borking on a generic RequestFailed.
+            if let Some(error) = context_length_error_for_status(status.as_u16(), &response_text) {
+                tracing::warn!("Copilot: context length exceeded");
+                return Err(error);
             }
             let truncated = ironclaw_common::truncate_for_preview(&response_text, 512);
             return Err(LlmError::RequestFailed {
@@ -619,6 +638,40 @@ fn extract_choice_content(choice: &OpenAiChoice) -> (Option<String>, Vec<ToolCal
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn context_overflow_413_maps_to_context_length_exceeded() {
+        // A raw HTTP 413 (payload too large) must become ContextLengthExceeded
+        // so the loop's context-shrink recovery fires.
+        match context_length_error_for_status(413, "Request Entity Too Large") {
+            Some(LlmError::ContextLengthExceeded { .. }) => {}
+            other => panic!("expected ContextLengthExceeded, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn context_overflow_400_body_maps_to_context_length_exceeded() {
+        let body = r#"{"error":{"message":"This model's maximum context length is 128000 tokens. However, your messages resulted in 150000 tokens.","code":"context_length_exceeded"}}"#;
+        match context_length_error_for_status(400, body) {
+            Some(LlmError::ContextLengthExceeded { .. }) => {}
+            other => panic!("expected ContextLengthExceeded, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unrelated_400_is_not_context_overflow() {
+        // A plain bad-request (e.g. invalid tool schema) must NOT be classified
+        // as context overflow — the caller falls through to RequestFailed.
+        assert!(
+            context_length_error_for_status(400, r#"{"error":{"message":"invalid tool schema"}}"#)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn unrelated_5xx_is_not_context_overflow() {
+        assert!(context_length_error_for_status(500, "internal server error").is_none());
+    }
 
     #[test]
     fn test_convert_messages_basic() {

--- a/crates/ironclaw_llm/src/openai_codex_provider.rs
+++ b/crates/ironclaw_llm/src/openai_codex_provider.rs
@@ -226,6 +226,13 @@ impl OpenAiCodexProvider {
                     retry_after,
                 });
             }
+            // Context-overflow (HTTP 413, or a 400 whose body names a
+            // context-length error) must surface as ContextLengthExceeded so
+            // the loop's context-shrink recovery fires instead of a generic
+            // RequestFailed.
+            if let Some(error) = crate::error::context_length_error(status.as_u16(), &body_text) {
+                return Err(error);
+            }
             return Err(LlmError::RequestFailed {
                 provider: "openai_codex".to_string(),
                 reason: format!("HTTP {status}: {body_text}"),
@@ -579,6 +586,11 @@ fn parse_sse_response(body: &str) -> Result<ParsedResponse, LlmError> {
     let mut active_function_calls: std::collections::HashMap<String, FunctionCallState> =
         std::collections::HashMap::new();
     let mut response_status: Option<String> = None;
+    // Whether a terminal `response.completed` event was observed. A stream
+    // that ends without it (mid-stream disconnect) is truncated and must not
+    // be reported as a successful `Stop` — see the truncated-stream guard
+    // after the loop.
+    let mut saw_completed = false;
 
     for line in body.lines() {
         let line = line.trim();
@@ -741,6 +753,7 @@ fn parse_sse_response(body: &str) -> Result<ParsedResponse, LlmError> {
 
             // Response completed
             "response.completed" => {
+                saw_completed = true;
                 if let Some(response) = event.data.get("response") {
                     // Extract usage
                     if let Some(usage) = response.get("usage") {
@@ -770,6 +783,13 @@ fn parse_sse_response(body: &str) -> Result<ParsedResponse, LlmError> {
                     .and_then(|e| e.get("message"))
                     .and_then(|m| m.as_str())
                     .unwrap_or("Unknown error");
+                // Prefer ContextLengthExceeded for context-overflow failures
+                // so the loop's context-shrink recovery fires.
+                if crate::error::is_context_length_error_message(&reason.to_ascii_lowercase()) {
+                    let (used, limit) =
+                        crate::error::parse_context_token_counts(&reason.to_ascii_lowercase());
+                    return Err(LlmError::ContextLengthExceeded { used, limit });
+                }
                 return Err(LlmError::RequestFailed {
                     provider: "openai_codex".to_string(),
                     reason: format!("Response failed: {reason}"),
@@ -788,6 +808,14 @@ fn parse_sse_response(body: &str) -> Result<ParsedResponse, LlmError> {
                     .get("message")
                     .and_then(|m| m.as_str())
                     .unwrap_or("Unknown error");
+                // A context-overflow surfaced as an SSE error must become
+                // ContextLengthExceeded so the loop's context-shrink recovery
+                // fires instead of a generic failure.
+                if crate::error::is_context_length_error_message(&message.to_ascii_lowercase()) {
+                    let (used, limit) =
+                        crate::error::parse_context_token_counts(&message.to_ascii_lowercase());
+                    return Err(LlmError::ContextLengthExceeded { used, limit });
+                }
                 return Err(LlmError::RequestFailed {
                     provider: "openai_codex".to_string(),
                     reason: format!("Error {code}: {message}"),
@@ -815,6 +843,25 @@ fn parse_sse_response(body: &str) -> Result<ParsedResponse, LlmError> {
                 arguments_parse_error: None,
             });
         }
+    }
+
+    // Truncated-stream guard: the Responses API always emits a terminal
+    // `response.completed` (errors return early above). If the stream ended
+    // without one, the connection was dropped mid-response. Returning the
+    // partial content as a successful `Stop` would let a dropped connection
+    // masquerade as a normal completion, so surface a RETRYABLE error
+    // instead. `EmptyResponse` when nothing was produced; `InvalidResponse`
+    // when partial content/tool calls were captured.
+    if !saw_completed {
+        if text_content.is_empty() && tool_calls.is_empty() {
+            return Err(LlmError::EmptyResponse {
+                provider: "openai_codex".to_string(),
+            });
+        }
+        return Err(LlmError::InvalidResponse {
+            provider: "openai_codex".to_string(),
+            reason: "stream ended before response.completed".to_string(),
+        });
     }
 
     // Map status to finish reason (matching OpenClaw's mapStopReason)
@@ -1125,9 +1172,39 @@ data: {"type":"response.completed","response":{"status":"incomplete","usage":{"i
         assert_eq!(parsed.finish_reason, FinishReason::Length);
     }
 
+    /// `[DONE]` stops parsing (events after it are ignored), but on its own
+    /// it is NOT a completion signal — the Responses API always emits
+    /// `response.completed` before the SSE terminator. A `[DONE]` that arrives
+    /// without a preceding `response.completed` is a truncated stream and must
+    /// surface as a retryable error rather than a successful `Stop`.
     #[test]
-    fn test_parse_sse_done_marker() {
+    fn test_parse_sse_done_marker_without_completed_is_truncated() {
         let sse_body = r#"data: {"type":"response.output_text.delta","delta":"hello"}
+
+data: [DONE]
+
+data: {"type":"response.output_text.delta","delta":" ignored"}
+
+"#;
+        let result = parse_sse_response(sse_body);
+        assert!(
+            result.is_err(),
+            "[DONE] without response.completed is truncated"
+        );
+        assert!(matches!(
+            result.unwrap_err(),
+            LlmError::InvalidResponse { .. }
+        ));
+    }
+
+    /// `[DONE]` after a proper `response.completed` is the normal terminator:
+    /// parsing stops, later events are ignored, and the completed response is
+    /// returned successfully.
+    #[test]
+    fn test_parse_sse_completed_then_done_marker() {
+        let sse_body = r#"data: {"type":"response.output_text.delta","delta":"hello"}
+
+data: {"type":"response.completed","response":{"status":"completed","usage":{"input_tokens":1,"output_tokens":1}}}
 
 data: [DONE]
 
@@ -1138,6 +1215,105 @@ data: {"type":"response.output_text.delta","delta":" ignored"}
         assert!(result.is_ok());
         let parsed = result.unwrap();
         assert_eq!(parsed.text_content, "hello");
+    }
+
+    /// Regression: a stream that ends WITHOUT a terminal `response.completed`
+    /// event (mid-stream disconnect) must NOT be reported as a successful
+    /// `Stop`. Partial content that ends abruptly is a truncated stream and
+    /// must surface as a retryable `InvalidResponse` so the loop retries.
+    #[test]
+    fn test_parse_sse_truncated_stream_with_partial_text_is_error() {
+        let sse_body = r#"data: {"type":"response.output_item.added","item":{"type":"message","role":"assistant","id":"msg_1"}}
+
+data: {"type":"response.output_text.delta","delta":"partial answer that got cut"}
+
+"#;
+        let result = parse_sse_response(sse_body);
+        assert!(
+            result.is_err(),
+            "truncated stream must not be reported as success"
+        );
+        match result.unwrap_err() {
+            LlmError::InvalidResponse { reason, .. } => {
+                assert!(
+                    reason.contains("response.completed"),
+                    "reason should explain the missing terminal event: {reason}"
+                );
+            }
+            other => panic!("expected InvalidResponse, got {other:?}"),
+        }
+    }
+
+    /// Regression: a stream with no events at all (no content, no terminal
+    /// completion) must surface as `EmptyResponse` so the caller can retry.
+    #[test]
+    fn test_parse_sse_truncated_stream_empty_is_error() {
+        let sse_body = ":keepalive\n\n";
+        let result = parse_sse_response(sse_body);
+        assert!(
+            result.is_err(),
+            "empty truncated stream must not be reported as success"
+        );
+        assert!(matches!(
+            result.unwrap_err(),
+            LlmError::EmptyResponse { .. }
+        ));
+    }
+
+    /// A stream that produced tool calls but ended WITHOUT a terminal
+    /// `response.completed` is still truncated and must surface as a retryable
+    /// error, not a successful `ToolUse`.
+    #[test]
+    fn test_parse_sse_truncated_stream_with_tool_calls_is_error() {
+        let sse_body = r#"data: {"type":"response.output_item.added","item":{"type":"function_call","id":"fc_1","call_id":"call_abc","name":"search"}}
+
+data: {"type":"response.output_item.done","item":{"type":"function_call","id":"fc_1","call_id":"call_abc","name":"search","arguments":"{\"query\":\"test\"}"}}
+
+"#;
+        let result = parse_sse_response(sse_body);
+        assert!(
+            result.is_err(),
+            "truncated stream with tool calls must not be reported as success"
+        );
+        assert!(matches!(
+            result.unwrap_err(),
+            LlmError::InvalidResponse { .. }
+        ));
+    }
+
+    /// An SSE `error` event whose message is a context-overflow error must map
+    /// to `ContextLengthExceeded` (not generic `RequestFailed`) so the loop's
+    /// context-shrink recovery fires.
+    #[test]
+    fn test_parse_sse_error_context_length_maps_to_context_exceeded() {
+        let sse_body = r#"data: {"type":"error","code":"context_length_exceeded","message":"This model's maximum context length is 128000 tokens. However, your messages resulted in 150000 tokens."}
+
+"#;
+        let result = parse_sse_response(sse_body);
+        match result {
+            Err(LlmError::ContextLengthExceeded { used, limit }) => {
+                assert_eq!(used, 150000);
+                assert_eq!(limit, 128000);
+            }
+            other => panic!("expected ContextLengthExceeded, got {other:?}"),
+        }
+    }
+
+    /// A `response.failed` event whose error message is a context-overflow
+    /// error must also map to `ContextLengthExceeded`.
+    #[test]
+    fn test_parse_sse_failed_context_length_maps_to_context_exceeded() {
+        let sse_body = r#"data: {"type":"response.failed","response":{"status":"failed","status_details":{"error":{"message":"prompt is too long: 200000 tokens > 128000 maximum"}}}}
+
+"#;
+        let result = parse_sse_response(sse_body);
+        match result {
+            Err(LlmError::ContextLengthExceeded { used, limit }) => {
+                assert_eq!(used, 200000);
+                assert_eq!(limit, 128000);
+            }
+            other => panic!("expected ContextLengthExceeded, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/crates/ironclaw_llm/src/rig_adapter.rs
+++ b/crates/ironclaw_llm/src/rig_adapter.rs
@@ -1109,14 +1109,50 @@ fn map_rig_error(model_name: &str, e: impl std::fmt::Display) -> LlmError {
     let msg = e.to_string();
     let lower = msg.to_ascii_lowercase();
 
+    // Context-length is checked first so a 413/context error is never
+    // misread as an auth failure.
     if crate::error::is_context_length_error_message(&lower) {
         let (used, limit) = crate::error::parse_context_token_counts(&lower);
         return LlmError::ContextLengthExceeded { used, limit };
     }
+
+    // Auth failures (bad/expired key, 401/403) must not be treated as
+    // transient: AuthFailed is neither retried nor trips the circuit breaker,
+    // whereas the RequestFailed fallback below is both.
+    if is_auth_error_message(&lower) {
+        return LlmError::AuthFailed {
+            provider: model_name.to_string(),
+        };
+    }
+
     LlmError::RequestFailed {
         provider: model_name.to_string(),
         reason: msg,
     }
+}
+
+/// Detect authentication/authorization failures in a lowercased provider
+/// error message.
+///
+/// Mirrors the shape of [`crate::error::is_context_length_error_message`].
+/// Deliberately conservative: matches robust indicators (HTTP 401/403,
+/// explicit "invalid api key"/"unauthorized"/"authentication" phrasing) and
+/// avoids unrelated substrings such as a bare `"key"`.
+fn is_auth_error_message(lower: &str) -> bool {
+    const AUTH_PATTERNS: &[&str] = &[
+        "401",
+        "403",
+        "unauthorized",
+        "invalid api key",
+        "incorrect api key",
+        "invalid_api_key",
+        "authentication",
+        "permission denied",
+        "missing api key",
+        "no api key",
+    ];
+
+    AUTH_PATTERNS.iter().any(|pattern| lower.contains(pattern))
 }
 
 /// Normalize a tool call name returned by an OpenAI-compatible provider.
@@ -1143,6 +1179,64 @@ mod tests {
     use super::*;
     use rig::completion::CompletionError;
     use rig::streaming::StreamingCompletionResponse;
+
+    #[test]
+    fn map_rig_error_auth_401_unauthorized() {
+        let err = map_rig_error("openai", "HTTP error 401 Unauthorized: invalid api key");
+        assert!(
+            matches!(err, LlmError::AuthFailed { provider } if provider == "openai"),
+            "401/invalid api key should map to AuthFailed, got a different variant",
+        );
+    }
+
+    #[test]
+    fn map_rig_error_auth_invalid_api_key() {
+        let err = map_rig_error("anthropic", "Incorrect API key provided");
+        assert!(
+            matches!(err, LlmError::AuthFailed { provider } if provider == "anthropic"),
+            "invalid/incorrect api key should map to AuthFailed",
+        );
+    }
+
+    #[test]
+    fn map_rig_error_context_length_still_wins_over_auth() {
+        // A context-length error must never be misread as auth.
+        let err = map_rig_error(
+            "openai",
+            "This model's maximum context length is 128000 tokens.",
+        );
+        assert!(
+            matches!(err, LlmError::ContextLengthExceeded { .. }),
+            "context-length error should map to ContextLengthExceeded",
+        );
+    }
+
+    #[test]
+    fn map_rig_error_unrelated_still_request_failed() {
+        let err = map_rig_error("openai", "connection reset by peer");
+        assert!(
+            matches!(err, LlmError::RequestFailed { provider, .. } if provider == "openai"),
+            "unrelated transient error should remain RequestFailed",
+        );
+    }
+
+    #[test]
+    fn is_auth_error_message_conservative() {
+        // Positive indicators
+        assert!(is_auth_error_message("401 unauthorized"));
+        assert!(is_auth_error_message("403 forbidden"));
+        assert!(is_auth_error_message("invalid api key"));
+        assert!(is_auth_error_message("incorrect api key"));
+        assert!(is_auth_error_message("error code: invalid_api_key"));
+        assert!(is_auth_error_message("authentication failed"));
+        assert!(is_auth_error_message("permission denied"));
+        assert!(is_auth_error_message("missing api key"));
+        assert!(is_auth_error_message("no api key was provided"));
+        // Conservative: a bare "key" or unrelated message must not match.
+        assert!(!is_auth_error_message("could not find the key in the map"));
+        assert!(!is_auth_error_message("connection reset by peer"));
+        assert!(!is_auth_error_message("rate limit exceeded"));
+    }
 
     #[test]
     fn parse_models_response_openai_extracts_ids() {

--- a/crates/ironclaw_loop_support/src/capability_port.rs
+++ b/crates/ironclaw_loop_support/src/capability_port.rs
@@ -1668,33 +1668,31 @@ impl LoopCapabilityPort for HostRuntimeLoopCapabilityPort {
                 }
                 Err(error) => return Err(error.error),
             };
-            let runtime_input = match host_runtime_input_for_capability(
-                &request.capability_id,
-                input,
-            ) {
-                Ok(runtime_input) => runtime_input,
-                Err(error) if error.kind == AgentLoopHostErrorKind::InvalidInvocation => {
-                    // A malformed/invalid model-supplied process sandbox plan is a
-                    // model-fixable error, not a host fault: surface it as a
-                    // model-visible tool error so the agent can correct the
-                    // arguments instead of ending the run. `host_runtime_input_for_capability`
-                    // only returns `InvalidInvocation` for the sandbox-plan parse/validation
-                    // case; its host-internal serialization failure keeps its `Internal` Err.
-                    let result = Ok(CapabilityOutcome::Failed(CapabilityFailure {
-                        error_kind: CapabilityFailureKind::InvalidInput,
-                        safe_summary: error.safe_summary,
-                        detail: None,
-                    }));
-                    guard.commit();
-                    self.record_loop_completed(
-                        &idempotency_key,
-                        requested_invocation_id,
-                        result.clone(),
-                    )?;
-                    return result;
-                }
-                Err(error) => return Err(error),
-            };
+            let runtime_input =
+                match host_runtime_input_for_capability(&request.capability_id, input) {
+                    Ok(runtime_input) => runtime_input,
+                    Err(error) if error.kind == AgentLoopHostErrorKind::InvalidInvocation => {
+                        // A malformed/invalid model-supplied process sandbox plan is a
+                        // model-fixable error, not a host fault: surface it as a
+                        // model-visible tool error so the agent can correct the
+                        // arguments instead of ending the run. `host_runtime_input_for_capability`
+                        // only returns `InvalidInvocation` for the sandbox-plan parse/validation
+                        // case; its host-internal serialization failure keeps its `Internal` Err.
+                        let result = Ok(CapabilityOutcome::Failed(CapabilityFailure {
+                            error_kind: CapabilityFailureKind::InvalidInput,
+                            safe_summary: error.safe_summary,
+                            detail: None,
+                        }));
+                        guard.commit();
+                        self.record_loop_completed(
+                            &idempotency_key,
+                            requested_invocation_id,
+                            result.clone(),
+                        )?;
+                        return result;
+                    }
+                    Err(error) => return Err(error),
+                };
             (runtime_input, capability.estimate.clone())
         };
         let mut invocation_context =

--- a/crates/ironclaw_loop_support/src/capability_port.rs
+++ b/crates/ironclaw_loop_support/src/capability_port.rs
@@ -1668,10 +1668,34 @@ impl LoopCapabilityPort for HostRuntimeLoopCapabilityPort {
                 }
                 Err(error) => return Err(error.error),
             };
-            (
-                host_runtime_input_for_capability(&request.capability_id, input)?,
-                capability.estimate.clone(),
-            )
+            let runtime_input = match host_runtime_input_for_capability(
+                &request.capability_id,
+                input,
+            ) {
+                Ok(runtime_input) => runtime_input,
+                Err(error) if error.kind == AgentLoopHostErrorKind::InvalidInvocation => {
+                    // A malformed/invalid model-supplied process sandbox plan is a
+                    // model-fixable error, not a host fault: surface it as a
+                    // model-visible tool error so the agent can correct the
+                    // arguments instead of ending the run. `host_runtime_input_for_capability`
+                    // only returns `InvalidInvocation` for the sandbox-plan parse/validation
+                    // case; its host-internal serialization failure keeps its `Internal` Err.
+                    let result = Ok(CapabilityOutcome::Failed(CapabilityFailure {
+                        error_kind: CapabilityFailureKind::InvalidInput,
+                        safe_summary: error.safe_summary,
+                        detail: None,
+                    }));
+                    guard.commit();
+                    self.record_loop_completed(
+                        &idempotency_key,
+                        requested_invocation_id,
+                        result.clone(),
+                    )?;
+                    return result;
+                }
+                Err(error) => return Err(error),
+            };
+            (runtime_input, capability.estimate.clone())
         };
         let mut invocation_context =
             invocation_context_from_visible(VisibleInvocationContextRequest {
@@ -6633,7 +6657,7 @@ mod tests {
             .await
             .expect("visible capabilities load");
 
-        let error = port
+        let outcome = port
             .invoke_capability(CapabilityInvocation {
                 activity_id: ironclaw_turns::CapabilityActivityId::new(),
                 surface_version: surface.version,
@@ -6644,9 +6668,14 @@ mod tests {
                 auth_resume: None,
             })
             .await
-            .expect_err("invalid process sandbox plan must fail before runtime dispatch");
+            .expect("invalid process sandbox plan is a recoverable model-visible tool error");
 
-        assert_eq!(error.kind, AgentLoopHostErrorKind::InvalidInvocation);
+        match outcome {
+            CapabilityOutcome::Failed(failure) => {
+                assert_eq!(failure.error_kind, CapabilityFailureKind::InvalidInput);
+            }
+            other => panic!("expected Failed(InvalidInput), got {other:?}"),
+        }
         assert!(runtime.take_requests().is_empty());
         assert!(runtime.take_spawn_requests().is_empty());
     }
@@ -6691,7 +6720,7 @@ mod tests {
             .await
             .expect("visible capabilities load");
 
-        let error = port
+        let outcome = port
             .invoke_capability(CapabilityInvocation {
                 activity_id: ironclaw_turns::CapabilityActivityId::new(),
                 surface_version: surface.version,
@@ -6702,9 +6731,14 @@ mod tests {
                 auth_resume: None,
             })
             .await
-            .expect_err("malformed process sandbox plan must fail before runtime dispatch");
+            .expect("malformed process sandbox plan is a recoverable model-visible tool error");
 
-        assert_eq!(error.kind, AgentLoopHostErrorKind::InvalidInvocation);
+        match outcome {
+            CapabilityOutcome::Failed(failure) => {
+                assert_eq!(failure.error_kind, CapabilityFailureKind::InvalidInput);
+            }
+            other => panic!("expected Failed(InvalidInput), got {other:?}"),
+        }
         assert!(runtime.take_requests().is_empty());
         assert!(runtime.take_spawn_requests().is_empty());
     }

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/outbound_delivery.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/outbound_delivery.rs
@@ -16,9 +16,10 @@ use ironclaw_run_state::{ApprovalRequestStore, ApprovalStatus, RunStateError};
 use ironclaw_turns::{
     LoopGateRef,
     run_profile::{
-        AgentLoopHostError, AgentLoopHostErrorKind, CapabilityApprovalResume, CapabilityFailure,
-        CapabilityFailureKind, CapabilityInputRef, CapabilityOutcome, CapabilityProgress,
-        CapabilityResultMessage, CapabilityResumeToken, ConcurrencyHint, LoopRunContext,
+        AgentLoopHostError, AgentLoopHostErrorKind, CapabilityApprovalResume, CapabilityDenied,
+        CapabilityDeniedReasonKind, CapabilityFailure, CapabilityFailureKind, CapabilityInputRef,
+        CapabilityOutcome, CapabilityProgress, CapabilityResultMessage, CapabilityResumeToken,
+        ConcurrencyHint, LoopRunContext,
     },
 };
 
@@ -103,9 +104,20 @@ impl LocalDevSyntheticCapabilityHandler for OutboundDeliveryTargetsListHandler {
             parse_outbound_delivery_targets_list_input(&invocation.input).map_err(input_error)?;
         let caller = caller_for_run(&invocation, &self.fallback_user_id);
         let response =
-            list_outbound_delivery_targets_for_model(self.facade.as_ref(), caller, input)
+            match list_outbound_delivery_targets_for_model(self.facade.as_ref(), caller, input)
                 .await
-                .map_err(|error| outbound_delivery_host_error("list_targets", error))?;
+            {
+                Ok(response) => response,
+                // A model-recoverable service failure (invalid request, not
+                // found, denied, conflict, rate limit, transient unavailability)
+                // must surface as a model-visible tool error so the run continues
+                // and the model can adapt — NOT a terminal
+                // `Err(AgentLoopHostError)`, which `ironclaw_agent_loop`'s executor
+                // maps to a run-ending `HostUnavailable { stage: Capability }`.
+                // Only a genuine internal bug stays terminal. See
+                // `outbound_delivery_outcome`.
+                Err(error) => return outbound_delivery_outcome(error),
+            };
         let count = response.targets.len();
         let output = serde_json::to_value(response).map_err(|error| {
             AgentLoopHostError::new(
@@ -134,6 +146,17 @@ struct OutboundDeliveryTargetSetHandler {
 struct ApprovedDispatchLease {
     scope: ResourceScope,
     lease_id: CapabilityGrantId,
+}
+
+/// Outcome of verifying an approval resume before dispatch.
+///
+/// `Approved` carries the claimed lease to consume; `Denied` carries a
+/// model-visible denial so the run continues and the user can re-request
+/// approval, instead of a terminal `Err(AgentLoopHostError)` that would end the
+/// run (see .claude/rules/agent-loop-capabilities.md, Invariant 1).
+enum ApprovedResumeDecision {
+    Approved(ApprovedDispatchLease),
+    Denied(CapabilityDenied),
 }
 
 enum OutboundDeliveryApprovalSettingsDecision {
@@ -169,10 +192,22 @@ impl LocalDevSyntheticCapabilityHandler for OutboundDeliveryTargetSetHandler {
         let capability_id = outbound_delivery_target_set_capability_id()?;
         let approved_lease = if self.requires_approval {
             match invocation.request.approval_resume.clone() {
-                Some(resume) => Some(
-                    self.verify_approved_resume(&invocation, &resume, &input)
-                        .await?,
-                ),
+                Some(resume) => {
+                    // A lost / expired / not-yet-granted approval lease is
+                    // recoverable: the user can re-request approval. Route those
+                    // arms to `Ok(Denied)` so the run continues instead of a
+                    // terminal `Err(Unauthorized)`. Only genuine infra faults
+                    // (lease persistence / CAS) stay terminal.
+                    match self
+                        .verify_approved_resume(&invocation, &resume, &input)
+                        .await?
+                    {
+                        ApprovedResumeDecision::Approved(lease) => Some(lease),
+                        ApprovedResumeDecision::Denied(denied) => {
+                            return Ok(CapabilityOutcome::Denied(denied));
+                        }
+                    }
+                }
                 None => match self.settings_decision(&invocation, &capability_id).await? {
                     OutboundDeliveryApprovalSettingsDecision::Allow => None,
                     OutboundDeliveryApprovalSettingsDecision::Ask => {
@@ -199,30 +234,47 @@ impl LocalDevSyntheticCapabilityHandler for OutboundDeliveryTargetSetHandler {
             None
         };
 
-        let target_summary = target_input.target_id().as_str().to_string();
         let caller = caller_for_run(&invocation, &self.fallback_user_id);
         if let Some(approved_lease) = approved_lease {
-            self.capability_leases
+            // Lease consumption races (expired / exhausted between claim and
+            // consume) are recoverable — surface as `Denied` so the model can
+            // re-request approval rather than ending the run. Infra faults stay
+            // terminal. See `approval_lease_outcome`.
+            match self
+                .capability_leases
                 .consume(&approved_lease.scope, approved_lease.lease_id)
                 .await
-                .map_err(|error| approval_lease_error("consume_approval_lease", error))?;
+            {
+                Ok(_) => {}
+                Err(error) => match approval_lease_outcome("consume_approval_lease", error) {
+                    Ok(denied) => return Ok(CapabilityOutcome::Denied(denied)),
+                    Err(host_error) => return Err(host_error),
+                },
+            }
         }
         let response =
-            set_outbound_delivery_target_for_model(self.facade.as_ref(), caller, target_input)
+            match set_outbound_delivery_target_for_model(self.facade.as_ref(), caller, target_input)
                 .await
-                .map_err(|error| outbound_delivery_host_error("set_target", error))?;
+            {
+                Ok(response) => response,
+                // See `outbound_delivery_outcome`: recoverable service errors are
+                // model-visible failures, not terminal host errors.
+                Err(error) => return outbound_delivery_outcome(error),
+            };
         let output = serde_json::to_value(response).map_err(|error| {
             AgentLoopHostError::new(
                 AgentLoopHostErrorKind::Internal,
                 format!("outbound delivery target set output serialization failed: {error}"),
             )
         })?;
-        write_completed_result(
-            invocation,
-            output,
-            format!("set delivery target to {target_summary}"),
-        )
-        .await
+        // The safe summary must not interpolate the raw, model-controlled
+        // `target_id`: a delimiter (`/ < > [ ] { } ` + "`" + ` \`) trips
+        // `ToolResultSafeSummary` validation in `append_capability_result_ref`,
+        // which surfaces as a terminal `HostUnavailable` that kills the whole
+        // turn (see .claude/rules/agent-loop-capabilities.md, Invariant 2). The
+        // model still gets the target id from the result `output`; the summary
+        // stays a fixed, delimiter-free string.
+        write_completed_result(invocation, output, "set delivery target".to_string()).await
     }
 }
 
@@ -316,7 +368,7 @@ impl OutboundDeliveryTargetSetHandler {
         invocation: &LocalDevSyntheticCapabilityInvocation,
         resume: &CapabilityApprovalResume,
         input: &serde_json::Value,
-    ) -> Result<ApprovedDispatchLease, AgentLoopHostError> {
+    ) -> Result<ApprovedResumeDecision, AgentLoopHostError> {
         if resume.input != *input {
             return Err(AgentLoopHostError::new(
                 AgentLoopHostErrorKind::InvalidInvocation,
@@ -332,22 +384,26 @@ impl OutboundDeliveryTargetSetHandler {
             invocation_id,
         );
         let fingerprint = approval_fingerprint(&scope, &capability_id, &resume.estimate, input)?;
-        let approval_record = self
+        // A missing or not-yet-granted approval record is recoverable: the user
+        // can re-request approval. Surface `Denied` so the run continues rather
+        // than ending it with a terminal `Err(Unauthorized)`.
+        let approval_record = match self
             .approval_requests
             .get(&scope, resume.approval_request_id)
             .await
             .map_err(|error| approval_store_error("load_approval", error))?
-            .ok_or_else(|| {
-                AgentLoopHostError::new(
-                    AgentLoopHostErrorKind::Unauthorized,
-                    "outbound delivery target approval is unavailable",
-                )
-            })?;
+        {
+            Some(record) => record,
+            None => {
+                return Ok(ApprovedResumeDecision::Denied(approval_denied(
+                    "outbound delivery target approval is unavailable; re-request approval",
+                )?));
+            }
+        };
         if approval_record.status != ApprovalStatus::Approved {
-            return Err(AgentLoopHostError::new(
-                AgentLoopHostErrorKind::Unauthorized,
-                "outbound delivery target approval has not been granted",
-            ));
+            return Ok(ApprovedResumeDecision::Denied(approval_denied(
+                "outbound delivery target approval has not been granted; re-request approval",
+            )?));
         }
         if approval_record.request.correlation_id != resume.correlation_id {
             return Err(AgentLoopHostError::new(
@@ -371,7 +427,7 @@ impl OutboundDeliveryTargetSetHandler {
             ));
         }
 
-        let lease = self
+        let lease = match self
             .capability_leases
             .leases_for_scope(&scope)
             .await
@@ -381,21 +437,35 @@ impl OutboundDeliveryTargetSetHandler {
                     && lease.grant.capability == capability_id
                     && lease.grant.grantee == approval_record.request.requested_by
                     && lease.invocation_fingerprint.as_ref() == Some(&fingerprint)
-            })
-            .ok_or_else(|| {
-                AgentLoopHostError::new(
-                    AgentLoopHostErrorKind::Unauthorized,
-                    "outbound delivery target approval lease is unavailable",
-                )
-            })?;
-        self.capability_leases
+            }) {
+            Some(lease) => lease,
+            // The approval lease expired or was lost between approval and resume;
+            // recoverable by re-requesting approval, so deny instead of killing
+            // the run.
+            None => {
+                return Ok(ApprovedResumeDecision::Denied(approval_denied(
+                    "outbound delivery target approval lease is unavailable; re-request approval",
+                )?));
+            }
+        };
+        // A lease-state failure on claim (expired / exhausted / fingerprint
+        // mismatch) is recoverable: deny and let the model re-request approval.
+        // Only infra faults (persistence / CAS) stay terminal.
+        match self
+            .capability_leases
             .claim(&scope, lease.grant.id, &fingerprint)
             .await
-            .map_err(|error| approval_lease_error("claim_approval_lease", error))?;
-        Ok(ApprovedDispatchLease {
+        {
+            Ok(_) => {}
+            Err(error) => match approval_lease_outcome("claim_approval_lease", error) {
+                Ok(denied) => return Ok(ApprovedResumeDecision::Denied(denied)),
+                Err(host_error) => return Err(host_error),
+            },
+        }
+        Ok(ApprovedResumeDecision::Approved(ApprovedDispatchLease {
             scope,
             lease_id: lease.grant.id,
-        })
+        }))
     }
 }
 
@@ -572,30 +642,74 @@ fn input_error(error: OutboundDeliveryCapabilityInputError) -> AgentLoopHostErro
     AgentLoopHostError::new(AgentLoopHostErrorKind::InvalidInvocation, error.to_string())
 }
 
-fn outbound_delivery_host_error(
-    operation: &'static str,
+/// Disposition an outbound-delivery service failure into either a model-visible,
+/// recoverable capability outcome or a terminal host error.
+///
+/// As with `project_service_outcome` and `skill_activation_selection_outcome`,
+/// the two arms map onto the executor's two failure paths
+/// (`ironclaw_agent_loop::executor::mapping`): `CapabilityOutcome::Failed` /
+/// `Denied` is handed back to the model and the run continues (so the model can
+/// fix its request or tell the user), while `Err(AgentLoopHostError)` becomes a
+/// run-ending `HostUnavailable { stage: Capability }`. Only a genuine internal
+/// bug stays terminal — invalid input, not-found, denials, conflicts, rate
+/// limits, and transient unavailability are all surfaced to the model instead of
+/// killing the turn.
+///
+/// Safe summaries stay fixed and host-authored: `RebornServicesError` carries a
+/// free-form `field` that could contain a forbidden delimiter/marker and remap a
+/// recoverable arm into a terminal `HostUnavailable` (Invariant 2).
+fn outbound_delivery_outcome(
     error: RebornServicesError,
-) -> AgentLoopHostError {
-    let kind = match error.code {
+) -> Result<CapabilityOutcome, AgentLoopHostError> {
+    match error.code {
         RebornServicesErrorCode::InvalidRequest | RebornServicesErrorCode::NotFound => {
-            AgentLoopHostErrorKind::InvalidInvocation
+            Ok(CapabilityOutcome::Failed(CapabilityFailure {
+                error_kind: CapabilityFailureKind::InvalidInput,
+                safe_summary: "invalid outbound delivery request".to_string(),
+                detail: None,
+            }))
         }
         RebornServicesErrorCode::Unauthenticated | RebornServicesErrorCode::Forbidden => {
-            AgentLoopHostErrorKind::Unauthorized
+            Ok(CapabilityOutcome::Denied(approval_denied(
+                "not permitted to change the outbound delivery target",
+            )?))
         }
-        RebornServicesErrorCode::Conflict | RebornServicesErrorCode::RateLimited => {
-            AgentLoopHostErrorKind::Unavailable
-        }
-        RebornServicesErrorCode::Unavailable => AgentLoopHostErrorKind::Unavailable,
-        RebornServicesErrorCode::Internal => AgentLoopHostErrorKind::Internal,
-    };
-    ironclaw_loop_support::raw_agent_loop_host_error(
-        "local_dev_outbound_delivery",
-        operation,
-        kind,
-        "outbound delivery target operation failed",
-        error,
-    )
+        RebornServicesErrorCode::Conflict => Ok(CapabilityOutcome::Failed(CapabilityFailure {
+            error_kind: CapabilityFailureKind::OperationFailed,
+            safe_summary: "outbound delivery target operation conflicted".to_string(),
+            detail: None,
+        })),
+        RebornServicesErrorCode::RateLimited => Ok(CapabilityOutcome::Failed(CapabilityFailure {
+            error_kind: CapabilityFailureKind::Resource,
+            safe_summary: "outbound delivery target operation rate limited".to_string(),
+            detail: None,
+        })),
+        RebornServicesErrorCode::Unavailable => Ok(CapabilityOutcome::Failed(CapabilityFailure {
+            error_kind: CapabilityFailureKind::Unavailable,
+            safe_summary: "outbound delivery service temporarily unavailable".to_string(),
+            detail: None,
+        })),
+        RebornServicesErrorCode::Internal => Err(AgentLoopHostError::new(
+            AgentLoopHostErrorKind::Internal,
+            "outbound delivery target operation failed",
+        )),
+    }
+}
+
+/// Build a model-visible `CapabilityDenied` with a fixed, host-authored summary.
+/// The reason kind is a charset-safe identifier, so it never trips
+/// safe-summary/identifier validation.
+fn approval_denied(safe_summary: &str) -> Result<CapabilityDenied, AgentLoopHostError> {
+    Ok(CapabilityDenied {
+        reason_kind: CapabilityDeniedReasonKind::unknown("outbound_delivery_approval_required")
+            .map_err(|reason| {
+                AgentLoopHostError::new(
+                    AgentLoopHostErrorKind::Internal,
+                    format!("outbound delivery denial reason kind is invalid: {reason}"),
+                )
+            })?,
+        safe_summary: safe_summary.to_string(),
+    })
 }
 
 fn approval_store_error(operation: &'static str, error: RunStateError) -> AgentLoopHostError {
@@ -608,33 +722,231 @@ fn approval_store_error(operation: &'static str, error: RunStateError) -> AgentL
     )
 }
 
-fn approval_lease_error(
+/// Disposition a capability-lease failure into either a model-visible denial
+/// (recoverable — the user can re-request approval) or a terminal host error.
+///
+/// Lease-state arms (unknown / expired / exhausted / unclaimed-fingerprint /
+/// fingerprint-mismatch / inactive) describe a lost or stale approval lease,
+/// which the model can recover from by re-requesting approval — so they return
+/// `Ok(CapabilityDenied)`. Genuine infra faults (lease persistence, version
+/// mismatch, CAS exhaustion) stay terminal `Err(AgentLoopHostError)`.
+fn approval_lease_outcome(
     operation: &'static str,
     error: CapabilityLeaseError,
-) -> AgentLoopHostError {
-    let kind = match error {
+) -> Result<CapabilityDenied, AgentLoopHostError> {
+    match error {
         CapabilityLeaseError::UnknownLease { .. }
         | CapabilityLeaseError::ExpiredLease { .. }
         | CapabilityLeaseError::ExhaustedLease { .. }
         | CapabilityLeaseError::UnclaimedFingerprintLease { .. }
         | CapabilityLeaseError::FingerprintMismatch { .. }
-        | CapabilityLeaseError::InactiveLease { .. } => AgentLoopHostErrorKind::Unauthorized,
+        | CapabilityLeaseError::InactiveLease { .. } => approval_denied(
+            "outbound delivery target approval lease is no longer valid; re-request approval",
+        ),
         CapabilityLeaseError::Persistence { .. }
         | CapabilityLeaseError::VersionMismatch
-        | CapabilityLeaseError::CasExhausted => AgentLoopHostErrorKind::Unavailable,
-    };
-    ironclaw_loop_support::raw_agent_loop_host_error(
-        "local_dev_outbound_delivery",
-        operation,
-        kind,
-        "outbound delivery approval lease operation failed",
-        error,
-    )
+        | CapabilityLeaseError::CasExhausted => Err(ironclaw_loop_support::raw_agent_loop_host_error(
+            "local_dev_outbound_delivery",
+            operation,
+            AgentLoopHostErrorKind::Unavailable,
+            "outbound delivery approval lease operation failed",
+            error,
+        )),
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ironclaw_product_workflow::RebornServicesErrorKind;
+    use ironclaw_turns::run_profile::LoopSafeSummary;
+
+    fn service_error(code: RebornServicesErrorCode) -> RebornServicesError {
+        RebornServicesError {
+            code,
+            kind: RebornServicesErrorKind::Internal,
+            status_code: 500,
+            retryable: false,
+            // A free-form `field` carrying a forbidden delimiter is the exact
+            // shape that, if interpolated into a safe summary, would remap a
+            // recoverable arm into a terminal `HostUnavailable` (Invariant 2).
+            field: Some("slack/<channel>".to_string()),
+            validation_code: None,
+        }
+    }
+
+    fn lease_error_unknown() -> CapabilityLeaseError {
+        CapabilityLeaseError::ExpiredLease {
+            lease_id: CapabilityGrantId::new(),
+        }
+    }
+
+    #[test]
+    fn invalid_request_is_a_recoverable_tool_failure_not_terminal() {
+        let outcome =
+            outbound_delivery_outcome(service_error(RebornServicesErrorCode::InvalidRequest))
+                .expect("invalid request must be a model-visible failure, not terminal");
+
+        match outcome {
+            CapabilityOutcome::Failed(failure) => {
+                assert_eq!(failure.error_kind, CapabilityFailureKind::InvalidInput);
+                LoopSafeSummary::new(failure.safe_summary)
+                    .expect("safe summary must satisfy the loop validator");
+            }
+            other => panic!("expected CapabilityOutcome::Failed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn not_found_is_a_recoverable_tool_failure_not_terminal() {
+        let outcome = outbound_delivery_outcome(service_error(RebornServicesErrorCode::NotFound))
+            .expect("not found must be a model-visible failure, not terminal");
+
+        assert!(matches!(
+            outcome,
+            CapabilityOutcome::Failed(failure)
+                if failure.error_kind == CapabilityFailureKind::InvalidInput
+        ));
+    }
+
+    #[test]
+    fn unauthenticated_is_a_recoverable_denial_not_terminal() {
+        let outcome =
+            outbound_delivery_outcome(service_error(RebornServicesErrorCode::Unauthenticated))
+                .expect("unauthenticated must be a model-visible denial, not terminal");
+
+        match outcome {
+            CapabilityOutcome::Denied(denied) => {
+                LoopSafeSummary::new(denied.safe_summary)
+                    .expect("safe summary must satisfy the loop validator");
+            }
+            other => panic!("expected CapabilityOutcome::Denied, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn forbidden_is_a_recoverable_denial_not_terminal() {
+        let outcome = outbound_delivery_outcome(service_error(RebornServicesErrorCode::Forbidden))
+            .expect("forbidden must be a model-visible denial, not terminal");
+
+        assert!(matches!(outcome, CapabilityOutcome::Denied(_)));
+    }
+
+    #[test]
+    fn conflict_is_a_recoverable_tool_failure_not_terminal() {
+        let outcome = outbound_delivery_outcome(service_error(RebornServicesErrorCode::Conflict))
+            .expect("conflict must be a model-visible failure, not terminal");
+
+        assert!(matches!(
+            outcome,
+            CapabilityOutcome::Failed(failure)
+                if failure.error_kind == CapabilityFailureKind::OperationFailed
+        ));
+    }
+
+    #[test]
+    fn rate_limited_is_a_recoverable_tool_failure_not_terminal() {
+        let outcome = outbound_delivery_outcome(service_error(RebornServicesErrorCode::RateLimited))
+            .expect("rate limited must be a model-visible failure, not terminal");
+
+        assert!(matches!(
+            outcome,
+            CapabilityOutcome::Failed(failure)
+                if failure.error_kind == CapabilityFailureKind::Resource
+        ));
+    }
+
+    #[test]
+    fn unavailable_is_a_recoverable_tool_failure_not_terminal() {
+        let outcome = outbound_delivery_outcome(service_error(RebornServicesErrorCode::Unavailable))
+            .expect("transient unavailability must not kill the run");
+
+        assert!(matches!(
+            outcome,
+            CapabilityOutcome::Failed(failure)
+                if failure.error_kind == CapabilityFailureKind::Unavailable
+        ));
+    }
+
+    #[test]
+    fn internal_service_error_stays_terminal() {
+        let error = outbound_delivery_outcome(service_error(RebornServicesErrorCode::Internal))
+            .expect_err("internal bugs must stay terminal");
+
+        assert_eq!(error.kind, AgentLoopHostErrorKind::Internal);
+    }
+
+    #[test]
+    fn service_error_field_with_delimiter_does_not_reach_safe_summary() {
+        // A `field` carrying a `/ < >` delimiter must never poison the fixed,
+        // host-authored safe summary. Each recoverable outcome's summary must
+        // still pass the loop safe-summary validator that fires at
+        // `append_capability_result_ref` (the terminal-failure boundary).
+        for code in [
+            RebornServicesErrorCode::InvalidRequest,
+            RebornServicesErrorCode::NotFound,
+            RebornServicesErrorCode::Unauthenticated,
+            RebornServicesErrorCode::Forbidden,
+            RebornServicesErrorCode::Conflict,
+            RebornServicesErrorCode::RateLimited,
+            RebornServicesErrorCode::Unavailable,
+        ] {
+            let outcome = outbound_delivery_outcome(service_error(code))
+                .unwrap_or_else(|_| panic!("{code:?} must be recoverable"));
+            let summary = match outcome {
+                CapabilityOutcome::Failed(failure) => failure.safe_summary,
+                CapabilityOutcome::Denied(denied) => denied.safe_summary,
+                other => panic!("expected a recoverable outcome, got {other:?}"),
+            };
+            assert!(
+                !summary.contains("slack/<channel>"),
+                "summary must not interpolate the service error field: {summary}"
+            );
+            LoopSafeSummary::new(summary).unwrap_or_else(|reason| {
+                panic!("{code:?} summary must satisfy the loop validator: {reason}")
+            });
+        }
+    }
+
+    #[test]
+    fn set_delivery_target_summary_is_fixed_and_validator_safe() {
+        // The set-target completion summary is a fixed host-authored string and
+        // must not interpolate the model-controlled target id. A target id may
+        // legally contain a `/ < >` delimiter (it is rejected only for control
+        // chars), so interpolating it would trip the safe-summary validator and
+        // kill the run. Confirm the delimiter-bearing id parses and that the
+        // fixed summary validates.
+        let target = RebornOutboundDeliveryTargetId::new("slack/<channel>")
+            .expect("a delimiter-bearing target id is a valid target id");
+        assert!(target.as_str().contains('/'));
+        LoopSafeSummary::new("set delivery target")
+            .expect("the fixed set-target summary must satisfy the loop validator");
+        // The previous interpolated summary would have been rejected:
+        LoopSafeSummary::new(format!("set delivery target to {}", target.as_str()))
+            .expect_err("interpolating the delimiter-bearing target id must trip the validator");
+    }
+
+    #[test]
+    fn expired_lease_is_a_recoverable_denial_not_terminal() {
+        let denied = approval_lease_outcome("claim_approval_lease", lease_error_unknown())
+            .expect("an expired approval lease must be a model-visible denial, not terminal");
+
+        LoopSafeSummary::new(denied.safe_summary)
+            .expect("denial safe summary must satisfy the loop validator");
+    }
+
+    #[test]
+    fn lease_persistence_failure_stays_terminal() {
+        let error = approval_lease_outcome(
+            "claim_approval_lease",
+            CapabilityLeaseError::Persistence {
+                reason: "disk".to_string(),
+            },
+        )
+        .expect_err("genuine lease infra faults must stay terminal");
+
+        assert_eq!(error.kind, AgentLoopHostErrorKind::Unavailable);
+    }
 
     #[test]
     fn parse_outbound_delivery_targets_list_input_rejects_empty_channel() {

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/outbound_delivery.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/outbound_delivery.rs
@@ -252,15 +252,18 @@ impl LocalDevSyntheticCapabilityHandler for OutboundDeliveryTargetSetHandler {
                 },
             }
         }
-        let response =
-            match set_outbound_delivery_target_for_model(self.facade.as_ref(), caller, target_input)
-                .await
-            {
-                Ok(response) => response,
-                // See `outbound_delivery_outcome`: recoverable service errors are
-                // model-visible failures, not terminal host errors.
-                Err(error) => return outbound_delivery_outcome(error),
-            };
+        let response = match set_outbound_delivery_target_for_model(
+            self.facade.as_ref(),
+            caller,
+            target_input,
+        )
+        .await
+        {
+            Ok(response) => response,
+            // See `outbound_delivery_outcome`: recoverable service errors are
+            // model-visible failures, not terminal host errors.
+            Err(error) => return outbound_delivery_outcome(error),
+        };
         let output = serde_json::to_value(response).map_err(|error| {
             AgentLoopHostError::new(
                 AgentLoopHostErrorKind::Internal,
@@ -745,13 +748,15 @@ fn approval_lease_outcome(
         ),
         CapabilityLeaseError::Persistence { .. }
         | CapabilityLeaseError::VersionMismatch
-        | CapabilityLeaseError::CasExhausted => Err(ironclaw_loop_support::raw_agent_loop_host_error(
-            "local_dev_outbound_delivery",
-            operation,
-            AgentLoopHostErrorKind::Unavailable,
-            "outbound delivery approval lease operation failed",
-            error,
-        )),
+        | CapabilityLeaseError::CasExhausted => {
+            Err(ironclaw_loop_support::raw_agent_loop_host_error(
+                "local_dev_outbound_delivery",
+                operation,
+                AgentLoopHostErrorKind::Unavailable,
+                "outbound delivery approval lease operation failed",
+                error,
+            ))
+        }
     }
 }
 
@@ -846,8 +851,9 @@ mod tests {
 
     #[test]
     fn rate_limited_is_a_recoverable_tool_failure_not_terminal() {
-        let outcome = outbound_delivery_outcome(service_error(RebornServicesErrorCode::RateLimited))
-            .expect("rate limited must be a model-visible failure, not terminal");
+        let outcome =
+            outbound_delivery_outcome(service_error(RebornServicesErrorCode::RateLimited))
+                .expect("rate limited must be a model-visible failure, not terminal");
 
         assert!(matches!(
             outcome,
@@ -858,8 +864,9 @@ mod tests {
 
     #[test]
     fn unavailable_is_a_recoverable_tool_failure_not_terminal() {
-        let outcome = outbound_delivery_outcome(service_error(RebornServicesErrorCode::Unavailable))
-            .expect("transient unavailability must not kill the run");
+        let outcome =
+            outbound_delivery_outcome(service_error(RebornServicesErrorCode::Unavailable))
+                .expect("transient unavailability must not kill the run");
 
         assert!(matches!(
             outcome,

--- a/docs/plans/2026-06-28-reborn-error-recoverability-audit.md
+++ b/docs/plans/2026-06-28-reborn-error-recoverability-audit.md
@@ -1,0 +1,240 @@
+# Reborn Error Recoverability — Audit + Remediation Plan
+
+**Date:** 2026-06-28
+**Status:** discovery complete (core); two backend sweeps outstanding (see §6.4)
+**Builds on:** [`docs/plans/2026-06-12-reborn-no-borking-failures.md`](2026-06-12-reborn-no-borking-failures.md) and PR #4841 (`reborn: no run-borking failures`, OPEN).
+
+## Goal (decided with user)
+
+Every reborn run error must end in one of two user-visible outcomes:
+
+1. **Security-related → stop the run** (deliberate, clean halt).
+2. **Everything else → user-explainable OR retriable.**
+
+The "agent cannot cover / opaque dead-end" category must be **eliminated** by routing every failure into one of three terminal lanes.
+
+Two decisions locked in:
+
+- **Bucket 1 (SecurityStop) is minimal** — *only* injection/jailbreak detection and real secret/credential leaks halt a run. Authorization, policy, and egress denials are **not** stops; they stay recoverable or explainable.
+- **Hybrid retry** — infra/lease/transient faults auto-retry silently; model/provider faults surface to the user with a retry affordance.
+
+---
+
+## 1. The error spine (how every error is classified today)
+
+The agent-loop executor (`crates/ironclaw_agent_loop/src/executor.rs:99`) returns `Result<LoopExit, AgentLoopExecutorError>`.
+
+- `LoopExit::Completed` = success
+- `LoopExit::Blocked(LoopBlockedKind)` = **parked / resumable** (Approval / Auth / Resource / AwaitDependentRun / ExternalTool) — not a failure
+- `LoopExit::Cancelled` = cancel / interrupt
+- `LoopExit::Failed(LoopFailureKind)` = **graceful run-bork** (`crates/ironclaw_turns/src/loop_exit.rs:251,432`)
+- `AgentLoopExecutorError` = **hard run-bork** — no trustworthy exit (`HostUnavailable`, `HostUnavailableWithDiagnostics`, `PlannerContract`(=driver bug), `CheckpointFailed`, `Cancelled`)
+
+### Two decision layers govern a capability (tool) failure
+
+**Layer 1 — host_runtime disposition** (`crates/ironclaw_host_runtime/src/lib.rs:811` `capability_failure_disposition`). Only two outcomes exist:
+
+- `ModelVisibleToolError` — return a tool error to the model in the same loop
+- `RetrySameCall` — retry first; the loop recovery strategy owns the budget and post-exhaustion fallback
+
+**There is no "abort" disposition. By design, no runtime capability failure should ever end the run.** Default for any kind that is not retryable-infra and not `InvalidInput` is `ModelVisibleToolError`. Retryable-infra set = `Backend / Network / Transient / Unavailable / Internal`.
+
+**Layer 2 — recovery strategy class** (`crates/ironclaw_agent_loop/src/strategies/recovery.rs` `DefaultRecoveryStrategy`, max 2 retries/class; classification in `crates/ironclaw_agent_loop/src/executor/mapping.rs:131` `capability_error_class`):
+
+| `CapabilityFailureKind` | class | fate |
+|---|---|---|
+| Network, Transient | Transient | retry → **recoverable** |
+| Backend, Unavailable | Unavailable | retry → **recoverable** |
+| InvalidInput | InputInvalid | **recoverable** |
+| MissingRuntime, OperationFailed, OutputTooLarge, Process, Resource | OperationFailed | **recoverable** |
+| Authorization, GateDeclined, PolicyDenied | PolicyDenied | **recoverable** (denied) |
+| Internal | Internal | retry → **recoverable** |
+| **Dispatcher, Cancelled, InvalidOutput, Permanent, Unknown(_), + future** | Permanent | **ABORT → `LoopExit::Failed{CapabilityProtocolError}`** |
+
+### Model-call failures are *always* run-borking
+
+`model_error_class` (`mapping.rs:94`): transient/unavailable/internal/context-overflow → retry ×2 then Abort (`ModelError`); content-filtered → Abort; budget-approval → parked; cancelled → cancel; **Unauthorized / PolicyDenied / ScopeMismatch / StaleSurface / InvalidInvocation / Invalid / CheckpointRejected / TranscriptWriteFailed → None → hard bork** (`HostUnavailableWithDiagnostics{Model}`), invisible to the model. A model failure can never become a recoverable tool error.
+
+---
+
+## 2. Complete classification map
+
+**Recoverable (loop continues, agent adapts):** all tool/capability failures by design — bad args, policy/authorization denials, WASM fuel/trap/memory/timeout, MCP timeout/protocol/session-loss, process non-zero-exit/timeout/OOM, filesystem permission/size/path, network DNS/TLS/denied-domain, transient model errors (retried in-loop to `Completed`). The tool backends (`mcp`, `wasm*`, `processes`, `process_sandbox`, `filesystem`, `network`, `outbound`, `secrets`, `resources`) are **clean** — no `panic`/`unwrap`/`expect` on runtime input; every recoverable trigger is a structured `Result::Err` → `Failed` outcome.
+
+**Run-bork (graceful, `LoopExit::Failed`):** capability `Permanent` class or 8-retry ceiling → `CapabilityProtocolError`; all model errors after retry → `ModelError`; iteration limit (32) → `IterationLimit`; no-progress/stuck → `NoProgressDetected`; ≥3 rejected replies → `InvalidModelOutput`; compaction failure → `CompactionUnavailable`; `SpawnedProcess` unsupported → `CapabilityProtocolError`.
+
+**Run-bork (hard, `AgentLoopExecutorError`):** any host-port call fails; model class=None; planner/driver contract violations; checkpoint serialize/write; safe-summary validation reject; malformed sandbox-plan; the 4 `unreachable!` index-key constants (regression-only); Postgres `row.get` schema drift.
+
+**Parked / cancel (not failures):** gate outcomes (resume_turn); host cancel/interrupt.
+
+`ContextBuildFailed` is **dead** (verified — no construction site); prompt-build failures hard-bork as `HostUnavailable{Prompt}` instead.
+
+---
+
+## 3. PR #4841 coverage (OPEN, "Part 1")
+
+#4841 delivers the **explainable + retryable backbone** — in the two-bucket model, that *is* bucket 2 for the graceful-failure surface.
+
+- **Tier-1 model explanation** for model-reachable failures (CapabilityProtocolError, IterationLimit, PolicyDenied, NoProgressDetected, CompactionUnavailable, InvalidModelOutput) — one best-effort no-capability model call before failing.
+- **Tier-2 deterministic templates** — `FailureExplanationProvider` covers *every* `LoopFailureKind` + reborn failure category + `host_stage_unavailable:*` (exhaustive-match test).
+- **Failed exits carry evidence** (explanation refs, partial assistant refs, diagnostics, `safe_summary` category).
+- **Retry-from-failed** — `retry_turn` in both store backends, new run from last resumable checkpoint, idempotent, `webui_v2` retry endpoint, `retryable` flag on the wire.
+- **HostUnavailable → categorized retryable failure** (`host_stage_unavailable:<stage>`), no longer opaque.
+
+It does **not** touch `ironclaw_llm`, `ironclaw_processes`, `outbound_delivery`, `process_sandbox`, `ironclaw_safety`, or `turn_scheduler.rs`.
+
+### Per-case status
+
+| §4 cannot-cover case | #4841 |
+|---|---|
+| HostUnavailable infra, lease expiry, checkpoint/transcript, scope/surface, driver-bug, model PolicyDenied | **Covered (explainable; retryable if checkpoint)** |
+| model bad key / ModelNotAvailable | **Partial** — surfaced+retryable, but root mis-classification in `ironclaw_llm` remains |
+| safe-summary kill | **Partial** — explainable+retryable, not prevented |
+| resumed-checkpoint-gone, projection split-brain | **Partial — verify** |
+| Codex truncated-stream, detached bg-process | **Not covered** (`ironclaw_llm` / `ironclaw_processes` untouched) |
+| evidence stores unwired | **Softened, not fixed** |
+
+---
+
+## 4. The "retriable" gap
+
+#4841 is **not** fully retriable per the hybrid decision:
+
+1. **Auto half missing** — all retry is *user-initiated* (the endpoint / `retry_turn`). No silent auto re-drive; `turn_scheduler.rs` is untouched. Everything we marked Auto-retriable (infra `HostUnavailable`, checkpoint/transcript, lease loss, scope/surface) is only manually retryable.
+2. **Checkpoint-gated** — retryable *only* when a `BeforeModel`/`BeforeBlock` checkpoint exists (`crates/ironclaw_reborn/src/planned_driver.rs:393`). `BeforeSideEffect` and `Final` are not resumable. Failures before the first `BeforeModel` checkpoint (`crates/ironclaw_agent_loop/src/executor/canonical.rs:111`) — input drain, context/prompt build, surface build, compaction — are explainable but **not retriable at all**.
+3. **Codex truncation** — not even detected as a failure, so nothing to retry.
+
+### No-checkpoint user journey + the from-input gap
+
+The original input **is durable** — `SubmitTurnRequest.accepted_message_ref` (`crates/ironclaw_turns/src/request.rs:58`). So a from-scratch retry is feasible without asking the user to re-type. Two populations:
+
+- **(a) Pre-first-checkpoint failures** — nothing durable happened. A from-input re-drive (seed a new run from `accepted_message_ref` when no resumable checkpoint exists) is **safe and cheap** and makes essentially every early failure retryable via the same affordance. **This is a near-free win.**
+- **(b) Side-effect-only / final-only failures** — a side effect may have run; blind re-drive double-executes it. This is the genuine open decision: (i) make side-effect dispatch idempotent and add `BeforeSideEffect` to the resumable set; or (ii) explicit user-confirmed "resend (may repeat actions)"; or (iii) explainable-only.
+
+Today's no-retry journey is a dead end: explanation shown, `retryable: false`, no retry button (copy-mismatch risk: Tier-2 says "Retry the run" while the flag is false), user must manually re-send → new turn, lost continuity.
+
+---
+
+## 5. Residue after #4841 + Part-2 (still neither retriable nor explainable)
+
+1. **Pre-run failures** — boot/config (operator-explainable via logs only) and API-ingress/submission rejections (HTTP-explainable to the client; the agent never sees them; no run to retry).
+2. **SecurityStop** — explainable but deliberately not retriable (correct by the minimal-bucket-1 decision).
+3. **Explainable-but-futile** — driver bugs (generic sentence + telemetry; retry re-hits the bug), genuinely-permanent capability failures, and the §6 recoverable→bork defects (retry re-fails).
+4. **Out-of-run-loop surfaces** — proactive work (triggers, heartbeat, routines) and projection/SSE/UI-convergence have their own failure handling, not the run-retry/explain machinery.
+5. **Persistence floor** — a sustained store outage means even *recording* the explainable/retryable failure can't land.
+
+---
+
+## 6. The recoverable→bork defect hunt (the high-leverage fix)
+
+**Premise:** turn model-fixable failures into agent-recoverable tool errors so ~90% of failures keep the run alive. There are three shapes.
+
+### 6.1 Keystone — the table contradicts the disposition layer (verified)
+
+Layer 1 (host_runtime) dispositions `Dispatcher`, `InvalidOutput`, and `Unknown` as `ModelVisibleToolError` (intended recoverable). Layer 2 (`capability_error_class`, `mapping.rs:155-162`) maps the same three to `Permanent` → **Abort**. `RuntimeFailureKind` has **no `Permanent` variant** (`crates/ironclaw_host_runtime/src/lib.rs:698`), so the abort class is reached *only* through these three (plus `Cancelled`, which is legitimately a cancel).
+
+Notably, `DispatchFailureKind::UnknownCapability` / `UnknownProvider` → `RuntimeFailureKind::InvalidOutput` (`crates/ironclaw_host_runtime/src/production.rs:2113`), so **"model called a nonexistent tool" → InvalidOutput → Permanent → run dies**, when it should be a model-visible `Failed{InvalidInput}` ("no such tool, choose another").
+
+There's also an internal tell: `SameCallRetryConstraint` (`crates/ironclaw_agent_loop/src/executor/capability_helpers.rs:388`) marks `Dispatcher` = `Allowed` and `InvalidOutput` = `RequiresChangedInput` (i.e. retry/adapt makes sense) while the recovery class aborts — the two layers disagree.
+
+**Fix (single, high-leverage):** in `capability_error_class`, move `Dispatcher`, `InvalidOutput`, and `Unknown(_)` out of `Permanent` into a recoverable class (`OperationFailed` → `ToolErrorResult`), aligning Layer 2 with Layer 1's `ModelVisibleToolError` intent. Keep only genuinely-terminal sources (none from the runtime path) and `Cancelled` (handled as cancel) as abort. This converts the entire "nonexistent tool / malformed output / unknown failure" population from run-ending to recoverable in one change.
+
+### 6.2 Handler-level Err-instead-of-Ok(Failed) — Invariant 1 (confirmed)
+
+A handler `invoke` returning `Err(AgentLoopHostError)` is mapped by `capability_host_error` (`mapping.rs:117`) to terminal `HostUnavailable{Capability}` — every non-`Cancelled` kind kills the run. Per `.claude/rules/agent-loop-capabilities.md`, model-fixable conditions must be `Ok(CapabilityOutcome::Failed/Denied)`.
+
+**Confirmed defects:**
+
+| Site | Condition | Current | Fix |
+|---|---|---|---|
+| `crates/ironclaw_reborn_composition/src/runtime/local_dev/outbound_delivery.rs:108,213` (via `outbound_delivery_host_error`, :575) | model picks bad/nonexistent `target_id` (InvalidRequest/NotFound), forbidden, conflict, rate-limited, transient-unavailable | maps **all** `RebornServicesErrorCode` → `Err` → terminal | mirror `project_service_outcome`: InvalidRequest/NotFound→`Failed{InvalidInput}`; Unauthenticated/Forbidden→`Denied`; Conflict→`Failed{OperationFailed}`; RateLimited→`Failed{Resource}`; Unavailable→`Failed{Unavailable}`; only Internal→`Err` |
+| `outbound_delivery.rs:223` | model-supplied `target_id` interpolated into `safe_summary` | `format!("set delivery target to {target_id}")` — a delimiter in the id trips validation → terminal | fixed host-authored string; id travels in `output` |
+| `outbound_delivery.rs:208,340-351,392-394` (via `approval_lease_error`) | expired/lost approval lease, not-yet-approved gate | → `Unauthorized` `Err` (terminal) | route lease-state arms → `Ok(Denied)` (re-request); keep Persistence/CAS as `Err` |
+| `crates/ironclaw_host_runtime/src/production.rs:1990,1995` (`host_runtime_spawn_input_for_capability`) | malformed model-supplied `SandboxProcessPlan` | `HostRuntimeError::invalid_request` → `InvalidInvocation` → terminal | `Ok(CapabilityOutcome::Failed{InvalidInput})` (locked in by a test at `loop_support/.../capability_port.rs:6655` — update it) |
+
+The exemplars to copy: `skill_activation.rs` (`skill_activation_selection_outcome`) and `project_create.rs` (`project_service_outcome`) — recoverable codes → `Ok(Failed)`, only `Internal` → `Err`.
+
+### 6.3 Provider fidelity (model path) — accurate explainability
+
+| Site | Condition | Current | Fix |
+|---|---|---|---|
+| `crates/ironclaw_llm/src/rig_adapter.rs:1019` (`map_rig_error`) | 401/403 auth on a turn (OpenAI/Anthropic/Ollama/Tinfoil/openai_compatible) | only context-length special-cased; everything else → `RequestFailed` → generic `Unavailable` → retried then bork as "model unavailable" | detect auth → `AuthFailed`/credentials category so the user is told to fix the key |
+| `crates/ironclaw_llm/src/bedrock.rs:700` | AccessDenied / Throttling / ValidationException(overflow) | all → `RequestFailed` | map to AuthFailed / RateLimited / ContextLengthExceeded |
+| Codex (`openai_codex_provider.rs:830`, `codex_chatgpt.rs:673`) | truncated SSE stream / dropped `error`/`response.failed` events | silent partial success labeled `Stop` | detect incomplete stream → `InvalidResponse`/`Unavailable` (retryable); map SSE error events |
+| Codex/Bedrock/Copilot/Anthropic-OAuth | context overflow | no 413 detection → no `ShrinkContext` | detect 413/context-overflow → `ContextLengthExceeded` |
+
+### 6.4 Outstanding sweeps (not completed — finish these)
+
+Two parallel read-only sweeps were started and interrupted; finish them with the §6.1 rubric:
+
+- **host_runtime + dispatcher variant-by-variant**: audit `failure_kind_from` (`production.rs:2068`), `From<DispatchFailureKind>` (`production.rs:2113`), `RuntimeDispatchErrorKind` / `DispatchFailureKind` / `CapabilityInvocationError` variant lists. For each model-fixable variant, confirm it doesn't land in the abort set or in an infra-retry kind it shouldn't. (`MethodMissing`, `UndeclaredCapability`, `OutputDecode`, `InvalidResult`, `InputEncode` are the suspects.)
+- **tool backends + extensions**: `mcp`, `wasm*`, `processes`, `process_sandbox`, `filesystem`, `network`, `outbound`, `first_party_extensions`, `product_adapters`, `skills` — any model-fixable backend failure (unknown method, bad args, malformed output, denied target) that surfaces as a hard `Err` or lands in `InvalidOutput`/`Dispatcher`/`Unknown` (abort set).
+
+---
+
+## 7. Remediation plan — target architecture
+
+Collapse every terminal failure into three lanes via one classifier:
+
+| Lane | Retry policy | Membership |
+|---|---|---|
+| **SecurityStop** | None (clean halt) | *only* injection/jailbreak + real leak (safety layer / leak detector) |
+| **Retriable** | `AutoBounded` silent re-drive; exhaustion → Explainable | infra host-port faults, lease loss/runner death, checkpoint/transcript, projection, scope/surface |
+| **Explainable** | `UserInitiated` (retry affordance) or `None+restart` | model/provider faults, config/credentials, driver bugs, lost checkpoint |
+
+### Building blocks (dependency order)
+
+1. **`RunFailureReason` taxonomy** — wire-stable, user-facing, distinct from internal `LoopFailureKind`; carries `{lane, retry_policy, user_message, correlation_id}`. (#4841's `FailureExplanationProvider` + `safe_summary` category is most of this.)
+2. **One exhaustive-match classifier** at the run boundary (`crates/ironclaw_reborn/src/planned_driver.rs` + `turn_run_executor.rs`). Every failure passes through it; a new kind without classification fails to compile.
+3. **Re-bucket the `Permanent` class** (§6.1) — the highest-leverage single change.
+4. **Fix handler Err sites** (§6.2) + provider fidelity (§6.3).
+5. **Scheduler auto re-drive** for the Retriable lane (the missing "Auto" half) — consumes #4841's `retry_turn`, bounded, exhaustion → Explainable.
+6. **From-input retry** (§4 population a) — seed a new run from `accepted_message_ref` when no resumable checkpoint exists.
+7. **Defense-in-depth degradation** — safe-summary/validation failures fall back to a fixed summary (recoverable), never bork.
+8. **Reconcilers** — stuck-`Running` bg-process; lease reclaim → requeue.
+9. **Fail-fast composition** — required evidence stores; loud startup failure if unwired.
+
+### Sequencing
+
+1. **#6.1 table re-bucket** (small, high-leverage, makes most capability failures recoverable).
+2. **#6.2 handler fixes + #6.3 provider fidelity** (accurate recoverable/explainable).
+3. **Block 1+2 classifier keystone** (enforce the three-lane invariant).
+4. **Retriable lane**: #5 auto re-drive + #6 from-input retry + lease requeue + projection self-heal.
+5. **Prevention/security**: #7 degradation, #9 fail-fast, the SecurityStop set, the enforcement test.
+
+### Enforcement
+
+A test asserting: every `RunFailureReason` resolves to `SecurityStop` **only if** sourced from the safety/leak layer; everything else is `Retriable` or `Explainable` with a non-empty `user_message`. A new variant without classification fails to compile; a new `SecurityStop` outside the safety layer fails the test.
+
+---
+
+## 8. Open decisions
+
+1. **Population (b) side-effect retry** (§4) — idempotent dispatch + resumable `BeforeSideEffect`, vs user-confirmed resend, vs explainable-only.
+2. **Pre-run / ingress failures** (§5.1) — surface into the same user-facing taxonomy, or accept the HTTP/log boundary for those.
+
+---
+
+## Appendix — key code locations
+
+| Concern | Location |
+|---|---|
+| Disposition layer (no-abort intent) | `crates/ironclaw_host_runtime/src/lib.rs:811` (`capability_failure_disposition`), enum `:745`, `RuntimeFailureKind` `:698` |
+| Recovery classes | `crates/ironclaw_agent_loop/src/executor/mapping.rs:131` (`capability_error_class`), `:94` (`model_error_class`), `:166` |
+| Recovery strategy | `crates/ironclaw_agent_loop/src/strategies/recovery.rs` (`DefaultRecoveryStrategy`) |
+| Same-call retry hint | `crates/ironclaw_agent_loop/src/executor/capability_helpers.rs:388` |
+| Terminal mapper (Err→HostUnavailable) | `crates/ironclaw_agent_loop/src/executor/mapping.rs:117` (`capability_host_error`) |
+| LoopExit / LoopFailureKind | `crates/ironclaw_turns/src/loop_exit.rs:251,432` |
+| AgentLoopExecutorError | `crates/ironclaw_agent_loop/src/executor.rs:99` |
+| Runtime→loop kind map | `crates/ironclaw_loop_support/src/capability_port.rs:2570` (`runtime_failure_kind_to_loop`) |
+| Dispatch kind map | `crates/ironclaw_host_runtime/src/production.rs:2068` (`failure_kind_from`), `:2113` (`From<DispatchFailureKind>`) |
+| outbound_delivery defect | `crates/ironclaw_reborn_composition/src/runtime/local_dev/outbound_delivery.rs:108,213,223,575` |
+| sandbox-plan defect | `crates/ironclaw_host_runtime/src/production.rs:1990` |
+| Provider fidelity | `crates/ironclaw_llm/src/rig_adapter.rs:1019`, `bedrock.rs:700`, `openai_codex_provider.rs:830`, `codex_chatgpt.rs:673` |
+| Model-error path | `crates/ironclaw_agent_loop/src/executor/model.rs:125` |
+| Resumable checkpoint kinds | `crates/ironclaw_reborn/src/planned_driver.rs:393`; first checkpoint `canonical.rs:111` |
+| Durable turn input | `crates/ironclaw_turns/src/request.rs:58` (`accepted_message_ref`) |
+| Lease expiry | `crates/ironclaw_turns/src/memory.rs` (`recover_expired_leases`) |
+| Exemplar recoverable handlers | `crates/ironclaw_reborn_composition/src/runtime/local_dev/{skill_activation,project_create}.rs` |
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)


### PR DESCRIPTION
Stacked on #4841 (base = its branch, so this shows only the delta). Implements the §6 recoverable→bork fixes from `docs/plans/2026-06-28-reborn-error-recoverability-audit.md`: turns model-fixable capability failures into model-visible tool errors so the agent self-corrects instead of the run dying.

## Changes (each crate's lib tests green)
- **Keystone** (`ironclaw_agent_loop`): `capability_error_class` re-buckets `Dispatcher` / `InvalidOutput` / `Unknown(_)` / non-exhaustive default from `Permanent` (Abort) to `OperationFailed` (recoverable `ToolErrorResult`), aligning with the host_runtime disposition layer (which never intends a capability failure to abort). `Cancelled`/`Permanent` stay terminal. Makes "model called a nonexistent tool" (`UnknownCapability`/`UnknownProvider` → `InvalidOutput`) recoverable. 354 tests.
- **outbound_delivery** (`ironclaw_reborn_composition`): `outbound_delivery_outcome` routes recoverable `RebornServicesErrorCode` to `Ok(Failed/Denied)` (only `Internal` → `Err`); fixed the `safe_summary` that interpolated the model-supplied `target_id` (Invariant 2); expired / not-yet-approved approval-lease → `Ok(Denied)`. 26 tests.
- **sandbox-plan** (`ironclaw_host_runtime` + `ironclaw_loop_support`): a malformed model-supplied `SandboxProcessPlan` now yields a recoverable `Failed{InvalidInput}` instead of terminal `InvalidInvocation`/`HostUnavailable`. Fixed at the live gate (`host_runtime_input_for_capability`) and as host_runtime defense-in-depth. 297 + 337 tests.

Regression check: keystone introduced zero failures in dependents (agent_loop 354, host_runtime 297, loop_support 337, reborn 259 lib, 0 failed). Changed files `cargo fmt`/clippy clean.

## Pre-existing base breakages (on #4841 after its main automerge — not introduced here)
- `loop_support/tests/thread_loop_support_contract.rs`: `LoopModelRequest` initializer missing the new `inline_messages` field.
- `reborn_composition/src/openai_compat_serve/tests.rs:751`: `StaticTurnCoordinator` missing `retry_turn`.
- `reborn/tests/loop_driver_host`: 2 failing tests.

## Remaining (next batches)
Provider fidelity (`ironclaw_llm`), scheduler auto re-drive + from-input retry, the three-lane `RunFailureReason` classifier, and the host_runtime/dispatcher + tool-backend recoverable→bork sweeps.

Draft — verification scoped to touched crates + dependents (lib targets), not the full workspace gate (pre-existing base breakages would fail it regardless).

🤖 Generated with [Claude Code](https://claude.com/claude-code)