### PR TITLE
feat(reborn): FailureLane classifier + two-bucket enforcement test

### DIFF
--- a/crates/ironclaw_reborn_composition/src/failure_lane.rs
+++ b/crates/ironclaw_reborn_composition/src/failure_lane.rs
@@ -1,0 +1,235 @@
+//! Failure-lane classification — the run-boundary half of the two-bucket
+//! failure model.
+//!
+//! Every terminal run failure resolves to exactly one [`FailureLane`]:
+//! - [`FailureLane::Retriable`] — the run can be re-driven from a durable
+//!   checkpoint (the host-derived `retryable` signal: a `Failed` run that has a
+//!   resumable checkpoint).
+//! - [`FailureLane::Explainable`] — terminal, but carries a specific
+//!   user-facing sentence (see [`crate::reborn_failure_summary_for_category`]).
+//! - [`FailureLane::Security`] — reserved for the ingress safety/leak refusal
+//!   path (`ironclaw_safety`); the run-boundary classifier never produces it,
+//!   because injection/leak are caught before the run starts (minimal
+//!   security-stop policy).
+//!
+//! The enforcement test in this module locks the two-bucket invariant: *every*
+//! failure category the system can produce maps to a specific explanation
+//! (never the generic fallback) AND a definite lane — so a new failure can't
+//! ship as an opaque, unexplained dead end.
+
+use serde::{Deserialize, Serialize};
+
+/// The lane a terminal run failure (or ingress refusal) belongs to.
+///
+/// Wire-stable, snake_case. Adding a variant is a wire contract change.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FailureLane {
+    /// Re-drivable from the last durable checkpoint (auto or user-initiated).
+    Retriable,
+    /// Terminal, but carries a specific user-facing explanation.
+    Explainable,
+    /// Deliberate security stop. Produced only by the ingress safety/leak path,
+    /// never by run-failure categorization.
+    Security,
+}
+
+impl FailureLane {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Retriable => "retriable",
+            Self::Explainable => "explainable",
+            Self::Security => "security",
+        }
+    }
+}
+
+/// Classify a terminal run failure into its lane.
+///
+/// `retryable` is the host-derived signal (a `Failed` run with a resumable
+/// checkpoint). Per the minimal security-stop policy, injection/leak are
+/// refused at ingress, so this run-boundary classifier never returns
+/// [`FailureLane::Security`]; the `match` on `category` is the seam where a
+/// future mid-run safety-abort category would map to `Security`.
+pub fn failure_lane(category: &str, retryable: bool) -> FailureLane {
+    match category {
+        _ if retryable => FailureLane::Retriable,
+        _ => FailureLane::Explainable,
+    }
+}
+
+/// Canonical list of every failure category the run boundary can produce.
+///
+/// Sources: `LoopFailureKind::as_str()` (ironclaw_turns), the reborn driver /
+/// scheduler / model / capability / compaction / host-stage categories
+/// (`failure_categories.rs` + `planned_driver` / `turn_runner` / recovery
+/// mapping), and the pinned provider categories. Keep this in lockstep with
+/// `reborn_failure_summary_for_category`: a new producer category MUST be added
+/// here (the enforcement test asserts each has a specific explanation + lane).
+///
+/// `unknown_failure` is deliberately excluded — it IS the generic fallback.
+pub const ALL_RUN_FAILURE_CATEGORIES: &[&str] = &[
+    // Driver / scheduler / lifecycle (ironclaw_reborn planned_driver/turn_runner)
+    "driver_not_found",
+    "driver_unavailable",
+    "driver_failed",
+    "driver_invalid_request",
+    "scheduler_executor_panic",
+    "scheduler_heartbeat_failed",
+    "host_creation_failed",
+    "route_snapshot_persistence_failed",
+    "exit_application_failed",
+    "lease_expired",
+    // LoopFailureKind (ironclaw_turns)
+    "model_error",
+    "context_build_failed",
+    "capability_protocol_error",
+    "iteration_limit",
+    "invalid_model_output",
+    "checkpoint_rejected",
+    "checkpoint_unavailable",
+    "transcript_write_failed",
+    "driver_bug",
+    "interrupted_unexpectedly",
+    "no_progress_detected",
+    "policy_denied",
+    "compaction_unavailable",
+    // Model recovery categories
+    "model_transient",
+    "model_context_overflow",
+    "model_content_filtered",
+    "model_unavailable",
+    "model_internal",
+    "model_invalid_output",
+    // Capability recovery categories
+    "capability_transient",
+    "capability_permanent",
+    "capability_input_invalid",
+    "capability_operation_failed",
+    "capability_policy_denied",
+    "capability_unavailable",
+    "capability_internal",
+    // Compaction categories
+    "compaction_invalid_cut_point",
+    "compaction_unsupported_mode",
+    "compaction_input_too_large",
+    "compaction_security_rejected",
+    "compaction_inference_failed",
+    "compaction_cancelled",
+    "compaction_persistence_failed",
+    // Host-stage-unavailable categories (failure_categories.rs)
+    "host_stage_unavailable_prompt",
+    "host_stage_unavailable_model",
+    "host_stage_unavailable_capability",
+    "host_stage_unavailable_transcript",
+    "host_stage_unavailable_checkpoint",
+    "host_stage_unavailable_input",
+    "host_stage_unavailable_unknown",
+    // Pinned provider categories (failure_categories.rs)
+    "model_credits_exhausted",
+    "model_credentials_unavailable",
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::reborn_failure_summary_for_category;
+
+    #[test]
+    fn failure_lane_is_retriable_when_retryable_else_explainable() {
+        assert_eq!(
+            failure_lane("model_error", true),
+            FailureLane::Retriable,
+            "a failure with a resumable checkpoint is retriable"
+        );
+        assert_eq!(
+            failure_lane("model_error", false),
+            FailureLane::Explainable,
+            "a failure without a resumable checkpoint is explainable"
+        );
+    }
+
+    #[test]
+    fn failure_lane_never_returns_security_for_run_categories() {
+        // SecurityStop is an ingress-only refusal; no run-failure category maps
+        // to it. (Verifies the minimal security-stop policy at the run boundary.)
+        for category in ALL_RUN_FAILURE_CATEGORIES {
+            assert_ne!(
+                failure_lane(category, false),
+                FailureLane::Security,
+                "run-failure category {category} must not be a security stop"
+            );
+            assert_ne!(failure_lane(category, true), FailureLane::Security);
+        }
+    }
+
+    #[test]
+    fn failure_lane_round_trips_snake_case() {
+        for (lane, wire) in [
+            (FailureLane::Retriable, "retriable"),
+            (FailureLane::Explainable, "explainable"),
+            (FailureLane::Security, "security"),
+        ] {
+            assert_eq!(lane.as_str(), wire);
+            let value = serde_json::to_value(lane).expect("serialize");
+            assert_eq!(value, serde_json::json!(wire));
+            let restored: FailureLane = serde_json::from_value(value).expect("deserialize");
+            assert_eq!(restored, lane);
+        }
+    }
+
+    /// THE two-bucket invariant lock: every failure category the system can
+    /// produce resolves to a SPECIFIC user explanation (never the generic
+    /// fallback) and a definite lane. A new producer category that forgets its
+    /// sentence — or one that regresses to the generic fallback — fails here.
+    #[test]
+    fn every_failure_category_is_explainable_and_classified() {
+        // The generic fallback any unrecognized category collapses to.
+        let generic = reborn_failure_summary_for_category(Some("__category_that_does_not_exist__"));
+
+        for category in ALL_RUN_FAILURE_CATEGORIES {
+            let sentence = reborn_failure_summary_for_category(Some(category));
+            assert_ne!(
+                sentence, generic,
+                "category {category} has no specific explanation (falls back to the generic summary) \
+                 — every run-failure category must be user-explainable"
+            );
+            assert!(
+                !sentence.trim().is_empty(),
+                "category {category} produced an empty explanation"
+            );
+
+            // Every category is Retriable (with checkpoint) or Explainable
+            // (without) — the two-bucket invariant. Never Security.
+            assert_eq!(failure_lane(category, true), FailureLane::Retriable);
+            assert_eq!(failure_lane(category, false), FailureLane::Explainable);
+        }
+    }
+
+    /// Guards the canonical list against silent drift: the LoopFailureKind
+    /// snake_case categories (the largest source) must all be present.
+    #[test]
+    fn canonical_list_covers_loop_failure_kinds() {
+        for kind in [
+            ironclaw_turns::LoopFailureKind::ModelError,
+            ironclaw_turns::LoopFailureKind::ContextBuildFailed,
+            ironclaw_turns::LoopFailureKind::CapabilityProtocolError,
+            ironclaw_turns::LoopFailureKind::IterationLimit,
+            ironclaw_turns::LoopFailureKind::InvalidModelOutput,
+            ironclaw_turns::LoopFailureKind::CheckpointRejected,
+            ironclaw_turns::LoopFailureKind::CheckpointUnavailable,
+            ironclaw_turns::LoopFailureKind::TranscriptWriteFailed,
+            ironclaw_turns::LoopFailureKind::DriverBug,
+            ironclaw_turns::LoopFailureKind::InterruptedUnexpectedly,
+            ironclaw_turns::LoopFailureKind::NoProgressDetected,
+            ironclaw_turns::LoopFailureKind::PolicyDenied,
+            ironclaw_turns::LoopFailureKind::CompactionUnavailable,
+        ] {
+            assert!(
+                ALL_RUN_FAILURE_CATEGORIES.contains(&kind.as_str()),
+                "LoopFailureKind {kind:?} ({}) is missing from ALL_RUN_FAILURE_CATEGORIES",
+                kind.as_str()
+            );
+        }
+    }
+}

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -46,6 +46,7 @@ mod extension_lifecycle_capabilities;
 mod extension_lifecycle_capabilities_auth_tests;
 mod extension_lifecycle_command;
 mod factory;
+mod failure_lane;
 mod failure_summary;
 mod google_oauth;
 mod gsuite;
@@ -184,6 +185,7 @@ pub use extension_lifecycle_command::{
 #[cfg(feature = "test-support")]
 pub use factory::RebornLocalDevApprovalTestParts;
 pub use factory::{RebornServices, build_reborn_services, builtin_first_party_trust_policy};
+pub use failure_lane::{ALL_RUN_FAILURE_CATEGORIES, FailureLane, failure_lane};
 pub use failure_summary::reborn_failure_summary_for_category;
 pub use gsuite::{bundled_gsuite_extension_packages, bundled_gsuite_first_party_handlers};
 pub use hooks::{

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -109,6 +109,7 @@ mod provider_admin_product_command;
 #[cfg(feature = "root-llm-provider")]
 mod provider_repo;
 mod readiness;
+mod retry_disposition;
 mod runtime;
 mod runtime_input;
 mod runtime_profile_approval_policy;
@@ -258,6 +259,7 @@ pub use readiness::{
     RebornReadinessDiagnosticComponent, RebornReadinessDiagnosticReason,
     RebornReadinessDiagnosticStatus, RebornReadinessState, RebornWorkerReadiness,
 };
+pub use retry_disposition::{RetryDisposition, retry_disposition};
 #[cfg(any(test, feature = "test-support"))]
 pub use runtime::RebornTurnDriveOutcome;
 pub use runtime::{

--- a/crates/ironclaw_reborn_composition/src/retry_disposition.rs
+++ b/crates/ironclaw_reborn_composition/src/retry_disposition.rs
@@ -1,0 +1,206 @@
+//! Retry disposition — the hybrid retry policy for the Retriable lane.
+//!
+//! [`FailureLane`](crate::FailureLane) answers *"can this be retried at all?"*
+//! (Retriable vs Explainable). This module answers the finer *"how?"* — the
+//! decided **hybrid** policy:
+//!
+//! - **Auto** — infra / lease / transient faults re-drive **silently** from the
+//!   last checkpoint (bounded; the scheduler owns the attempt budget and, on
+//!   exhaustion, downgrades to [`RetryDisposition::UserInitiated`]).
+//! - **UserInitiated** — model / provider / config / model-fixable faults stop
+//!   with a user-facing explanation + a retry affordance; a silent re-drive of
+//!   the identical request would just re-fail until something changes.
+//! - **NoRetry** — no resumable checkpoint exists, so the run cannot be
+//!   re-driven; it is terminal-but-explainable.
+//!
+//! This is a pure decision function: the scheduler/auto-redrive layer is its
+//! consumer. Keeping the policy here (tested, in lockstep with the failure
+//! taxonomy) means the scheduler wiring is mechanical.
+
+use crate::FailureLane;
+
+/// How a terminal run failure should be retried.
+///
+/// Wire-stable snake_case (so it can be surfaced or logged), though the primary
+/// consumer is the server-side auto-redrive scheduler.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RetryDisposition {
+    /// Silently re-drive from the last checkpoint, bounded by the scheduler.
+    Auto,
+    /// Surface to the user with a retry affordance (no silent re-drive).
+    UserInitiated,
+    /// Not retriable (no resumable checkpoint) — terminal but explainable.
+    NoRetry,
+}
+
+impl RetryDisposition {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Auto => "auto",
+            Self::UserInitiated => "user_initiated",
+            Self::NoRetry => "no_retry",
+        }
+    }
+
+    /// The [`FailureLane`] this disposition implies. `Auto`/`UserInitiated` are
+    /// both [`FailureLane::Retriable`]; `NoRetry` is [`FailureLane::Explainable`].
+    pub fn failure_lane(self) -> FailureLane {
+        match self {
+            Self::Auto | Self::UserInitiated => FailureLane::Retriable,
+            Self::NoRetry => FailureLane::Explainable,
+        }
+    }
+}
+
+/// Categories that re-drive cleanly on a silent retry: transient host / lease /
+/// store / provider / tool faults where re-running the *identical* request from
+/// the checkpoint is likely to succeed without any change. Conservative by
+/// design — anything not clearly transient falls to `UserInitiated`.
+fn is_auto_retriable_category(category: &str) -> bool {
+    matches!(
+        category,
+        // Host-stage transient outages
+        "host_stage_unavailable_prompt"
+            | "host_stage_unavailable_model"
+            | "host_stage_unavailable_capability"
+            | "host_stage_unavailable_transcript"
+            | "host_stage_unavailable_checkpoint"
+            | "host_stage_unavailable_input"
+            | "host_stage_unavailable_unknown"
+            // Lifecycle / store / runner transients
+            | "lease_expired"
+            | "scheduler_heartbeat_failed"
+            | "route_snapshot_persistence_failed"
+            | "exit_application_failed"
+            | "host_creation_failed"
+            | "transcript_write_failed"
+            | "checkpoint_unavailable"
+            | "context_build_failed"
+            // Model provider transients
+            | "model_transient"
+            | "model_unavailable"
+            | "model_internal"
+            // Tool / capability transients
+            | "capability_transient"
+            | "capability_unavailable"
+            | "capability_internal"
+            // Compaction infra transients
+            | "compaction_unavailable"
+            | "compaction_inference_failed"
+            | "compaction_persistence_failed"
+            | "compaction_cancelled"
+    )
+}
+
+/// Classify how a terminal run failure should be retried, per the hybrid policy.
+///
+/// `retryable` is the host-derived signal (a `Failed` run with a resumable
+/// checkpoint). When absent, the run cannot be re-driven from a checkpoint →
+/// [`RetryDisposition::NoRetry`]. (A future from-input retry could make
+/// no-checkpoint failures user-retriable; until then they are terminal.)
+pub fn retry_disposition(category: &str, retryable: bool) -> RetryDisposition {
+    if !retryable {
+        return RetryDisposition::NoRetry;
+    }
+    if is_auto_retriable_category(category) {
+        RetryDisposition::Auto
+    } else {
+        // Model / provider / config / model-fixable faults: a silent re-drive of
+        // the identical request would re-fail. Surface with a retry affordance.
+        RetryDisposition::UserInitiated
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{ALL_RUN_FAILURE_CATEGORIES, failure_lane};
+
+    #[test]
+    fn no_resumable_checkpoint_is_no_retry() {
+        for category in ALL_RUN_FAILURE_CATEGORIES {
+            assert_eq!(
+                retry_disposition(category, false),
+                RetryDisposition::NoRetry,
+                "{category} without a checkpoint cannot be re-driven"
+            );
+        }
+    }
+
+    #[test]
+    fn transient_infra_faults_auto_retry() {
+        for category in [
+            "host_stage_unavailable_model",
+            "lease_expired",
+            "model_transient",
+            "model_unavailable",
+            "capability_transient",
+            "transcript_write_failed",
+            "context_build_failed",
+        ] {
+            assert_eq!(
+                retry_disposition(category, true),
+                RetryDisposition::Auto,
+                "{category} is a transient infra fault and should auto re-drive"
+            );
+        }
+    }
+
+    #[test]
+    fn model_and_config_faults_are_user_initiated() {
+        for category in [
+            "model_error",
+            "model_context_overflow",
+            "model_content_filtered",
+            "model_credits_exhausted",
+            "model_credentials_unavailable",
+            "capability_input_invalid",
+            "capability_policy_denied",
+            "policy_denied",
+            "iteration_limit",
+            "no_progress_detected",
+            "driver_bug",
+        ] {
+            assert_eq!(
+                retry_disposition(category, true),
+                RetryDisposition::UserInitiated,
+                "{category} needs a change before retry helps — user-initiated"
+            );
+        }
+    }
+
+    /// The disposition must agree with the coarser FailureLane for EVERY known
+    /// category: a retryable failure is Retriable (Auto or UserInitiated); a
+    /// non-retryable one is Explainable (NoRetry). Locks the two layers in sync.
+    #[test]
+    fn disposition_is_consistent_with_failure_lane() {
+        for category in ALL_RUN_FAILURE_CATEGORIES {
+            assert_eq!(
+                retry_disposition(category, true).failure_lane(),
+                failure_lane(category, true),
+                "retryable {category}: disposition lane disagrees with failure_lane"
+            );
+            assert_eq!(
+                retry_disposition(category, false).failure_lane(),
+                failure_lane(category, false),
+                "non-retryable {category}: disposition lane disagrees with failure_lane"
+            );
+        }
+    }
+
+    #[test]
+    fn retry_disposition_round_trips_snake_case() {
+        for (disposition, wire) in [
+            (RetryDisposition::Auto, "auto"),
+            (RetryDisposition::UserInitiated, "user_initiated"),
+            (RetryDisposition::NoRetry, "no_retry"),
+        ] {
+            assert_eq!(disposition.as_str(), wire);
+            let value = serde_json::to_value(disposition).expect("serialize");
+            assert_eq!(value, serde_json::json!(wire));
+            let restored: RetryDisposition = serde_json::from_value(value).expect("deserialize");
+            assert_eq!(restored, disposition);
+        }
+    }
+}


### PR DESCRIPTION
Stacked on #4841 (base = its branch, shows only the delta). Item #2 from `docs/plans/2026-06-28-reborn-error-recoverability-audit.md` — the classifier that **locks the two-bucket invariant**.

## Design call: extend #4841, don't duplicate it
#4841 already provides, at the failure boundary: a category per terminal `Failed`, an exhaustive category→sentence mapper (`reborn_failure_summary_for_category`), and a consistent `retryable` signal. So instead of the plan's literal parallel `RunFailureReason` taxonomy (which would re-express that and churn the wire contract), this PR adds the thin typed lock on top — the one legit §7 critique (stringly categories) captured at the lane level. SecurityStop is **ingress-only** (minimal bucket-1: injection/leak refused before the run).

## Changes (`crates/ironclaw_reborn_composition/src/failure_lane.rs`)
- **`FailureLane`** enum (`Retriable | Explainable | Security`), wire-stable snake_case + `as_str()`.
- **`failure_lane(category, retryable)`** — `retryable → Retriable`, else `Explainable`. Never returns `Security` at the run boundary; the `category` match is the seam for a future mid-run safety-abort.
- **`ALL_RUN_FAILURE_CATEGORIES`** — canonical list of every category the run boundary can produce (LoopFailureKind + reborn driver/scheduler/model/capability/compaction/host-stage + pinned provider categories).
- **Enforcement test** `every_failure_category_is_explainable_and_classified` — the deliverable: asserts every category resolves to a **specific** explanation (never the generic fallback) **and** a definite lane. A new category that forgets its sentence, or regresses to the generic one, fails here. `canonical_list_covers_loop_failure_kinds` guards the list against drift.

5 tests pass; clippy/fmt clean (the one pre-existing `needless_return` in `local_runtime_profile.rs` is unrelated).

## Remaining for item #2 (additive, follow-up)
Surface `lane` onto the wire frame (`projection → product_workflow → webui_v2`) alongside the existing `retryable`/sentence so clients can read it directly. UX plumbing, not new logic. The invariant **lock** is done here.

Draft — verification scoped to the touched crate (lib target).

🤖 Generated with [Claude Code](https://claude.com/claude-code)