### PR TITLE
test: validate /benchmark build against current ironclaw main (throwaway)

### DIFF
--- a/BENCHMARK_VALIDATION.md
+++ b/BENCHMARK_VALIDATION.md
@@ -1,0 +1,4 @@
+# Benchmark build validation (temporary)
+
+Throwaway PR to validate that `/benchmark` builds against current ironclaw
+main after benchmarks#196 (toml_parser lock bump). Safe to close/delete.


### PR DESCRIPTION
Throwaway PR to validate that `/benchmark` builds the benchmarks harness against **current** ironclaw main after [benchmarks#196](https://github.com/nearai/benchmarks/pull/196) (toml_parser lock bump).

Context: PRs based on ironclaw main from **before 2026-06-25 12:14 UTC** fail `/benchmark` with `E0599: no method named enable_global_auto_approve_for_test` (the method landed at `163d594b`). This PR is off current main, which has it — so it should build clean. **Not for merge; will close after validation.**