### PR TITLE
[codex] Fix Web Access Exa content fetch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4526,6 +4526,7 @@ dependencies = [
  "tokio",
  "tracing",
  "unicode-normalization",
+ "url",
 ]
 
 [[package]]

--- a/crates/ironclaw_first_party_extensions/Cargo.toml
+++ b/crates/ironclaw_first_party_extensions/Cargo.toml
@@ -31,6 +31,7 @@ thiserror = "2"
 tokio = { version = "1", features = ["rt", "sync"] }
 tracing = "0.1"
 unicode-normalization = "0.1"
+url = "2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/ironclaw_first_party_extensions/assets/web-access/manifest.toml
+++ b/crates/ironclaw_first_party_extensions/assets/web-access/manifest.toml
@@ -21,8 +21,8 @@ prompt_doc_ref = "prompts/web-access/search.md"
 
 [[capabilities]]
 id = "web-access.get_content"
-description = "Retrieve full content saved from a previous web search response."
-effects = ["dispatch_capability"]
+description = "Retrieve full web page content through Exa MCP, or read content cached from a previous web search response."
+effects = ["dispatch_capability", "network"]
 default_permission = "allow"
 visibility = "model"
 input_schema_ref = "schemas/web-access/get_content.input.v1.json"

--- a/crates/ironclaw_first_party_extensions/assets/web-access/prompts/web-access/get_content.md
+++ b/crates/ironclaw_first_party_extensions/assets/web-access/prompts/web-access/get_content.md
@@ -1,1 +1,3 @@
-Retrieve full stored source content from a previous web-access.search response when snippets are not enough.
+Retrieve full source content when snippets are not enough.
+
+Prefer passing `url` or `urls` from a prior web-access.search result; this fetches current page content through Exa MCP. Use `response_id` only when you need the cached content already returned by web-access.search.

--- a/crates/ironclaw_first_party_extensions/assets/web-access/schemas/web-access/get_content.input.v1.json
+++ b/crates/ironclaw_first_party_extensions/assets/web-access/schemas/web-access/get_content.input.v1.json
@@ -16,6 +16,7 @@
     },
     "urls": {
       "type": "array",
+      "minItems": 1,
       "maxItems": 10,
       "items": {
         "type": "string",

--- a/crates/ironclaw_first_party_extensions/assets/web-access/schemas/web-access/get_content.input.v1.json
+++ b/crates/ironclaw_first_party_extensions/assets/web-access/schemas/web-access/get_content.input.v1.json
@@ -3,7 +3,7 @@
   "properties": {
     "response_id": {
       "type": "string",
-      "description": "The response_id from web-access.search"
+      "description": "Optional response_id from web-access.search for cached lookup"
     },
     "query": {
       "type": "string",
@@ -11,14 +11,100 @@
     },
     "url": {
       "type": "string",
-      "description": "Optional source URL selector"
+      "maxLength": 2048,
+      "description": "Source URL to fetch through Exa, or cached source URL selector when response_id is provided"
+    },
+    "urls": {
+      "type": "array",
+      "maxItems": 10,
+      "items": {
+        "type": "string",
+        "maxLength": 2048
+      },
+      "description": "Source URLs to fetch through Exa. Use either url or urls, not both."
     },
     "url_index": {
       "type": "integer",
       "minimum": 0,
-      "description": "Optional source index selector. Defaults to 0."
+      "description": "Optional cached source index selector. Defaults to 0. Requires response_id."
+    },
+    "max_characters": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 50000,
+      "description": "Maximum characters to fetch per URL. Defaults to 50000."
+    },
+    "maxCharacters": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 50000,
+      "description": "Alias for max_characters"
     }
   },
-  "required": ["response_id"],
+  "oneOf": [
+    {
+      "required": ["response_id"],
+      "not": {
+        "anyOf": [
+          {
+            "required": ["urls"]
+          },
+          {
+            "required": ["max_characters"]
+          },
+          {
+            "required": ["maxCharacters"]
+          },
+          {
+            "required": ["url", "url_index"]
+          }
+        ]
+      }
+    },
+    {
+      "required": ["url"],
+      "not": {
+        "anyOf": [
+          {
+            "required": ["response_id"]
+          },
+          {
+            "required": ["urls"]
+          },
+          {
+            "required": ["query"]
+          },
+          {
+            "required": ["url_index"]
+          },
+          {
+            "required": ["max_characters", "maxCharacters"]
+          }
+        ]
+      }
+    },
+    {
+      "required": ["urls"],
+      "not": {
+        "anyOf": [
+          {
+            "required": ["response_id"]
+          },
+          {
+            "required": ["url"]
+          },
+          {
+            "required": ["query"]
+          },
+          {
+            "required": ["url_index"]
+          },
+          {
+            "required": ["max_characters", "maxCharacters"]
+          }
+        ]
+      }
+    }
+  ],
   "additionalProperties": false
 }

--- a/crates/ironclaw_first_party_extensions/assets/web-access/schemas/web-access/get_content.output.v1.json
+++ b/crates/ironclaw_first_party_extensions/assets/web-access/schemas/web-access/get_content.output.v1.json
@@ -7,6 +7,10 @@
     "query": {
       "type": "string"
     },
+    "provider_used": {
+      "type": "string",
+      "enum": ["cache", "exa_mcp"]
+    },
     "title": {
       "type": "string"
     },
@@ -15,8 +19,28 @@
     },
     "content": {
       "type": "string"
+    },
+    "contents": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          }
+        },
+        "required": ["title", "url", "content"],
+        "additionalProperties": false
+      }
     }
   },
-  "required": ["response_id", "query", "title", "url", "content"],
+  "required": ["provider_used", "title", "url", "content", "contents"],
   "additionalProperties": false
 }

--- a/crates/ironclaw_first_party_extensions/src/web_access.rs
+++ b/crates/ironclaw_first_party_extensions/src/web_access.rs
@@ -725,7 +725,7 @@ fn parse_fetch_results(
         .collect::<HashSet<_>>();
     if lines
         .iter()
-        .any(|line| fetch_error_url(line).is_some_and(|url| requested.contains(url)))
+        .any(|line| fetch_error_mentions_requested(line, &requested))
     {
         return Err(operation_error());
     }
@@ -742,9 +742,14 @@ fn parse_fetch_results(
     let mut results = Vec::new();
     for (position, start) in starts.iter().enumerate() {
         let end = starts.get(position + 1).copied().unwrap_or(lines.len());
-        let title = lines[*start].trim_start_matches("# ").trim().to_string();
+        let title = lines[*start]
+            .strip_prefix("# ")
+            .unwrap_or(lines[*start])
+            .trim()
+            .to_string();
         let url = lines[*start + 1]
-            .trim_start_matches("URL: ")
+            .strip_prefix("URL: ")
+            .unwrap_or(lines[*start + 1])
             .trim()
             .to_string();
         let content = lines[*start + 2..end].join("\n").trim().to_string();
@@ -775,10 +780,17 @@ fn parse_fetch_results(
     }])
 }
 
-fn fetch_error_url(line: &str) -> Option<&str> {
-    line.strip_prefix("Error fetching ")
-        .and_then(|remainder| remainder.rsplit_once(':').map(|(url, _)| url.trim()))
-        .filter(|url| !url.is_empty())
+fn fetch_error_mentions_requested(line: &str, requested: &HashSet<&str>) -> bool {
+    let Some(remainder) = line.strip_prefix("Error fetching ") else {
+        return false;
+    };
+    let remainder = remainder.trim();
+    requested.iter().any(|url| {
+        remainder == *url
+            || remainder
+                .strip_prefix(*url)
+                .is_some_and(|suffix| suffix.trim_start().starts_with(':'))
+    })
 }
 
 fn line_value(block: &str, prefix: &str) -> Option<String> {
@@ -1250,6 +1262,17 @@ data: {"result":{"content":[{"type":"text","text":"Title: Example\nURL: https://
                 "https://example.com".to_string(),
                 "https://bad.example".to_string(),
             ],
+        )
+        .unwrap_err();
+
+        assert_eq!(error.kind(), RuntimeDispatchErrorKind::OperationFailed);
+    }
+
+    #[test]
+    fn parse_exa_fetch_result_blocks_rejects_bare_requested_url_failures() {
+        let error = parse_fetch_results(
+            "Error fetching https://bad.example",
+            &["https://bad.example".to_string()],
         )
         .unwrap_err();
 

--- a/crates/ironclaw_first_party_extensions/src/web_access.rs
+++ b/crates/ironclaw_first_party_extensions/src/web_access.rs
@@ -1,5 +1,6 @@
 use std::{
-    collections::{HashMap, VecDeque},
+    collections::{HashMap, HashSet, VecDeque},
+    net::IpAddr,
     sync::{Arc, Mutex},
 };
 
@@ -10,6 +11,7 @@ use ironclaw_host_api::{
     RuntimeHttpEgressError, RuntimeHttpEgressReasonCode, RuntimeHttpEgressRequest, RuntimeKind,
 };
 use serde_json::{Value, json};
+use url::{Host, Url};
 
 pub const WEB_ACCESS_EXTENSION_ID: &str = "web-access";
 pub const WEB_SEARCH_CAPABILITY_ID: &str = "web-access.search";
@@ -717,12 +719,23 @@ fn parse_fetch_results(
     requested_urls: &[String],
 ) -> Result<Vec<SearchResult>, WebAccessDispatchError> {
     let lines = text.lines().collect::<Vec<_>>();
+    let requested = requested_urls
+        .iter()
+        .map(String::as_str)
+        .collect::<HashSet<_>>();
+    if lines
+        .iter()
+        .any(|line| fetch_error_url(line).is_some_and(|url| requested.contains(url)))
+    {
+        return Err(operation_error());
+    }
     let starts = lines
         .iter()
         .enumerate()
         .filter_map(|(index, line)| {
             let next = lines.get(index + 1)?;
-            (line.starts_with("# ") && next.starts_with("URL: ")).then_some(index)
+            let url = next.strip_prefix("URL: ")?.trim();
+            (line.starts_with("# ") && requested.contains(url)).then_some(index)
         })
         .collect::<Vec<_>>();
 
@@ -760,6 +773,12 @@ fn parse_fetch_results(
         url: first_url.clone(),
         content: text.trim().to_string(),
     }])
+}
+
+fn fetch_error_url(line: &str) -> Option<&str> {
+    line.strip_prefix("Error fetching ")
+        .and_then(|remainder| remainder.rsplit_once(':').map(|(url, _)| url.trim()))
+        .filter(|url| !url.is_empty())
 }
 
 fn line_value(block: &str, prefix: &str) -> Option<String> {
@@ -866,13 +885,64 @@ fn reject_keys(input: &Value, keys: &[&str]) -> Result<(), WebAccessDispatchErro
 
 fn validated_fetch_url(value: &str) -> Result<String, WebAccessDispatchError> {
     let url = bounded_trimmed_string(value, MAX_URL_CHARS)?;
-    if !(url.starts_with("https://") || url.starts_with("http://")) {
+    let parsed = Url::parse(&url).map_err(|_| input_error())?;
+    if !matches!(parsed.scheme(), "https" | "http") {
+        return Err(input_error());
+    }
+    if !parsed.username().is_empty() || parsed.password().is_some() {
         return Err(input_error());
     }
     if url.chars().any(|ch| ch.is_control() || ch.is_whitespace()) {
         return Err(input_error());
     }
+    let host = parsed.host().ok_or_else(input_error)?;
+    if disallowed_fetch_host(host) {
+        return Err(input_error());
+    }
     Ok(url)
+}
+
+fn disallowed_fetch_host(host: Host<&str>) -> bool {
+    match host {
+        Host::Domain(host) => {
+            let host = host.trim_end_matches('.').to_ascii_lowercase();
+            host == "localhost"
+                || host.ends_with(".localhost")
+                || host
+                    .parse::<IpAddr>()
+                    .map(fetch_ip_is_not_public)
+                    .unwrap_or(false)
+        }
+        Host::Ipv4(ip) => fetch_ip_is_not_public(IpAddr::V4(ip)),
+        Host::Ipv6(ip) => fetch_ip_is_not_public(IpAddr::V6(ip)),
+    }
+}
+
+fn fetch_ip_is_not_public(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(ip) => {
+            ip.is_private()
+                || ip.is_loopback()
+                || ip.is_link_local()
+                || ip.is_broadcast()
+                || ip.is_documentation()
+                || ip.is_multicast()
+                || ip.is_unspecified()
+                || ip.octets()[0] == 0
+                || (ip.octets()[0] == 100 && (ip.octets()[1] & 0xC0) == 64)
+        }
+        IpAddr::V6(ip) => {
+            if let Some(mapped) = ip.to_ipv4() {
+                return fetch_ip_is_not_public(IpAddr::V4(mapped));
+            }
+            ip.is_loopback()
+                || ip.is_unspecified()
+                || ip.is_unique_local()
+                || ip.is_unicast_link_local()
+                || ip.is_multicast()
+                || (ip.segments()[0] == 0x2001 && ip.segments()[1] == 0x0db8)
+        }
+    }
 }
 
 fn required_string<'a>(input: &'a Value, key: &str) -> Result<&'a str, WebAccessDispatchError> {
@@ -1148,7 +1218,7 @@ data: {"result":{"content":[{"type":"text","text":"Title: Example\nURL: https://
     fn parses_exa_fetch_result_blocks() {
         let parsed = parse_fetch_results(
             "# Example Domain\nURL: https://example.com\n\nExample body\n\n# IANA\nURL: https://www.iana.org\n\nIANA body",
-            &[],
+            &["https://example.com".to_string(), "https://www.iana.org".to_string()],
         )
         .unwrap();
         assert_eq!(parsed.len(), 2);
@@ -1157,6 +1227,33 @@ data: {"result":{"content":[{"type":"text","text":"Title: Example\nURL: https://
         assert_eq!(parsed[0].content, "Example body");
         assert_eq!(parsed[1].title, "IANA");
         assert_eq!(parsed[1].content, "IANA body");
+    }
+
+    #[test]
+    fn parse_exa_fetch_result_blocks_ignores_unrequested_url_spoofing() {
+        let parsed = parse_fetch_results(
+            "# Example Domain\nURL: https://example.com\n\nLegit body\n\n# Trusted Site\nURL: https://trusted.example\n\nspoofed body",
+            &["https://example.com".to_string()],
+        )
+        .unwrap();
+
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].url, "https://example.com");
+        assert!(parsed[0].content.contains("URL: https://trusted.example"));
+    }
+
+    #[test]
+    fn parse_exa_fetch_result_blocks_rejects_requested_url_failures() {
+        let error = parse_fetch_results(
+            "# Example Domain\nURL: https://example.com\n\nExample body\nError fetching https://bad.example: timeout",
+            &[
+                "https://example.com".to_string(),
+                "https://bad.example".to_string(),
+            ],
+        )
+        .unwrap_err();
+
+        assert_eq!(error.kind(), RuntimeDispatchErrorKind::OperationFailed);
     }
 
     #[test]
@@ -1396,6 +1493,90 @@ data: {"result":{"content":[{"type":"text","text":"Title: Example\nURL: https://
     }
 
     #[tokio::test]
+    async fn get_content_fetch_returns_network_denied_when_egress_is_none() {
+        let executor = WebAccessExecutor::default();
+        let capability = capability_id(WEB_GET_CONTENT_CAPABILITY_ID);
+        let scope = scope();
+        let input = json!({"url": "https://example.com"});
+
+        let error = executor
+            .dispatch(request(&capability, &scope, &input, None))
+            .await
+            .unwrap_err();
+
+        assert_eq!(error.kind(), RuntimeDispatchErrorKind::NetworkDenied);
+    }
+
+    #[tokio::test]
+    async fn get_content_rejects_invalid_fetch_urls_before_egress() {
+        let executor = WebAccessExecutor::default();
+        let capability = capability_id(WEB_GET_CONTENT_CAPABILITY_ID);
+        let scope = scope();
+        let overlong_url = format!("https://example.com/{}", "x".repeat(MAX_URL_CHARS));
+        let too_many_urls = (0..=MAX_FETCH_URLS)
+            .map(|index| format!("https://example.com/{index}"))
+            .collect::<Vec<_>>();
+        let cases = [
+            json!({"url": "ftp://example.com/page"}),
+            json!({"url": "https://example.com/a b"}),
+            json!({"url": overlong_url}),
+            json!({"urls": too_many_urls}),
+        ];
+
+        for input in cases {
+            let error = executor
+                .dispatch(request(&capability, &scope, &input, None))
+                .await
+                .unwrap_err();
+
+            assert_eq!(error.kind(), RuntimeDispatchErrorKind::InputEncode);
+            assert!(error.usage().is_none());
+        }
+    }
+
+    #[tokio::test]
+    async fn get_content_rejects_local_or_private_fetch_urls_before_egress() {
+        let executor = WebAccessExecutor::default();
+        let capability = capability_id(WEB_GET_CONTENT_CAPABILITY_ID);
+        let scope = scope();
+
+        for url in [
+            "http://localhost/page",
+            "https://service.localhost/page",
+            "http://127.0.0.1/page",
+            "http://10.0.0.1/page",
+            "http://169.254.169.254/latest/meta-data",
+            "http://[::1]/page",
+            "http://[::ffff:10.0.0.1]/page",
+        ] {
+            let input = json!({"url": url});
+            let error = executor
+                .dispatch(request(&capability, &scope, &input, None))
+                .await
+                .unwrap_err();
+
+            assert_eq!(error.kind(), RuntimeDispatchErrorKind::InputEncode, "{url}");
+            assert!(error.usage().is_none(), "{url}");
+        }
+    }
+
+    #[tokio::test]
+    async fn get_content_rejects_fetch_urls_with_userinfo_before_egress() {
+        let executor = WebAccessExecutor::default();
+        let capability = capability_id(WEB_GET_CONTENT_CAPABILITY_ID);
+        let scope = scope();
+        let input = json!({"url": "https://user:secret@example.com/page"});
+
+        let error = executor
+            .dispatch(request(&capability, &scope, &input, None))
+            .await
+            .unwrap_err();
+
+        assert_eq!(error.kind(), RuntimeDispatchErrorKind::InputEncode);
+        assert!(error.usage().is_none());
+    }
+
+    #[tokio::test]
     async fn get_content_fetches_url_with_exa_web_fetch_tool() {
         let executor = WebAccessExecutor::default();
         let capability = capability_id(WEB_GET_CONTENT_CAPABILITY_ID);
@@ -1429,6 +1610,42 @@ data: {"result":{"content":[{"type":"text","text":"Title: Example\nURL: https://
         assert_eq!(
             request_bodies[2]["params"]["arguments"]["maxCharacters"],
             1000
+        );
+    }
+
+    #[tokio::test]
+    async fn get_content_fetches_multiple_urls_with_exa_web_fetch_tool() {
+        let executor = WebAccessExecutor::default();
+        let capability = capability_id(WEB_GET_CONTENT_CAPABILITY_ID);
+        let scope = scope();
+        let input = json!({"urls":["https://example.com", "https://www.iana.org"]});
+        let egress = Arc::new(RecordingEgress::for_mcp_search(json!({
+            "result": {"content": [{"type": "text", "text": "# Example Domain\nURL: https://example.com\n\nExample body\n\n# IANA\nURL: https://www.iana.org\n\nIANA body"}]}
+        })));
+
+        let result = executor
+            .dispatch(request(
+                &capability,
+                &scope,
+                &input,
+                Some(egress.clone() as Arc<dyn RuntimeHttpEgress>),
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(result.output["provider_used"], "exa_mcp");
+        assert_eq!(result.output["contents"].as_array().unwrap().len(), 2);
+        assert_eq!(result.output["contents"][0]["url"], "https://example.com");
+        assert_eq!(result.output["contents"][1]["content"], "IANA body");
+        let request_bodies = egress.request_bodies();
+        assert_eq!(request_bodies[2]["params"]["name"], "web_fetch_exa");
+        assert_eq!(
+            request_bodies[2]["params"]["arguments"]["urls"],
+            json!(["https://example.com", "https://www.iana.org"])
+        );
+        assert_eq!(
+            request_bodies[2]["params"]["arguments"]["maxCharacters"],
+            DEFAULT_FETCH_MAX_CHARACTERS
         );
     }
 

--- a/crates/ironclaw_first_party_extensions/src/web_access.rs
+++ b/crates/ironclaw_first_party_extensions/src/web_access.rs
@@ -24,11 +24,15 @@ const MAX_QUERIES: usize = 10;
 const MAX_QUERY_CHARS: usize = 500;
 const MAX_DOMAIN_FILTERS: usize = 20;
 const MAX_DOMAIN_CHARS: usize = 200;
+const MAX_FETCH_URLS: usize = 10;
+const MAX_URL_CHARS: usize = 2_048;
 const MAX_STORED_RESPONSES: usize = 100;
 /// 50 MiB total content budget across all cached responses.
 const MAX_STORED_CONTENT_BYTES: u64 = 50 * 1024 * 1024;
 const DEFAULT_CONTEXT_CHARS: u64 = 3_000;
 const INCLUDE_CONTENT_CONTEXT_CHARS: u64 = 50_000;
+const DEFAULT_FETCH_MAX_CHARACTERS: u64 = 50_000;
+const MAX_FETCH_MAX_CHARACTERS: u64 = 50_000;
 const DEFAULT_TIMEOUT_MS: u32 = 60_000;
 const RESPONSE_BODY_LIMIT: u64 = 2 * 1024 * 1024;
 
@@ -126,7 +130,7 @@ impl WebAccessExecutor {
     ) -> Result<WebAccessDispatchResult, WebAccessDispatchError> {
         match request.capability_id.as_str() {
             WEB_SEARCH_CAPABILITY_ID => self.search(request).await,
-            WEB_GET_CONTENT_CAPABILITY_ID => self.get_content(request),
+            WEB_GET_CONTENT_CAPABILITY_ID => self.get_content(request).await,
             _ => Err(WebAccessDispatchError::new(
                 RuntimeDispatchErrorKind::UndeclaredCapability,
             )),
@@ -147,7 +151,23 @@ impl WebAccessExecutor {
         }
     }
 
-    fn get_content(
+    async fn get_content(
+        &self,
+        request: WebAccessDispatchRequest<'_>,
+    ) -> Result<WebAccessDispatchResult, WebAccessDispatchError> {
+        if request.input.get("response_id").is_some() {
+            reject_keys(request.input, &["urls", "max_characters", "maxCharacters"])?;
+            return self.get_cached_content(request);
+        }
+        reject_keys(request.input, &["query", "url_index"])?;
+        let urls = fetch_url_list(request.input)?;
+        if urls.is_empty() {
+            return Err(input_error());
+        }
+        self.fetch_content(request, urls).await
+    }
+
+    fn get_cached_content(
         &self,
         request: WebAccessDispatchRequest<'_>,
     ) -> Result<WebAccessDispatchResult, WebAccessDispatchError> {
@@ -171,6 +191,9 @@ impl WebAccessExecutor {
         } else {
             stored.queries.first().ok_or_else(operation_error)?
         };
+        if url_selector.is_some() && url_index.is_some() {
+            return Err(input_error());
+        }
         let selected = if let Some(url) = url_selector {
             selected_query
                 .results
@@ -190,11 +213,68 @@ impl WebAccessExecutor {
             output: json!({
                 "response_id": response_id,
                 "query": selected_query.query,
+                "provider_used": "cache",
                 "title": selected.title,
                 "url": selected.url,
                 "content": selected.content,
+                "contents": [{
+                    "title": selected.title,
+                    "url": selected.url,
+                    "content": selected.content,
+                }],
             }),
             usage: ResourceUsage::default(),
+        })
+    }
+
+    async fn fetch_content(
+        &self,
+        request: WebAccessDispatchRequest<'_>,
+        urls: Vec<String>,
+    ) -> Result<WebAccessDispatchResult, WebAccessDispatchError> {
+        let max_characters = fetch_max_characters(request.input)?;
+        let egress = request
+            .runtime_http_egress
+            .as_ref()
+            .ok_or_else(|| WebAccessDispatchError::new(RuntimeDispatchErrorKind::NetworkDenied))?
+            .clone();
+        let response_text = call_exa_mcp_fetch(
+            egress,
+            request.capability_id,
+            request.scope,
+            &urls,
+            max_characters,
+        )
+        .await
+        .map_err(|e| {
+            let total_bytes = e.total_bytes();
+            map_egress_error(e.inner).with_accumulated_bytes(total_bytes)
+        })?;
+        let results = parse_fetch_results(&response_text.body, &urls)?;
+        let Some(first) = results.first() else {
+            return Err(operation_error());
+        };
+        let output = json!({
+            "provider_used": "exa_mcp",
+            "title": first.title,
+            "url": first.url,
+            "content": first.content,
+            "contents": results.iter().map(|result| json!({
+                "title": result.title,
+                "url": result.url,
+                "content": result.content,
+            })).collect::<Vec<_>>(),
+        });
+        let output_bytes = serde_json::to_vec(&output)
+            .map(|bytes| bytes.len() as u64)
+            .unwrap_or(0);
+        Ok(WebAccessDispatchResult {
+            output,
+            usage: ResourceUsage {
+                output_bytes,
+                network_egress_bytes: response_text.request_bytes,
+                ..ResourceUsage::default()
+            },
         })
     }
 
@@ -226,7 +306,7 @@ impl WebAccessExecutor {
         let mut stored_queries = Vec::new();
         for query in queries {
             let enriched_query = build_mcp_query(&query, recency_filter.as_deref(), &domain_filter);
-            let response_text = call_exa_mcp(
+            let response_text = call_exa_mcp_search(
                 Arc::clone(&egress),
                 request.capability_id,
                 request.scope,
@@ -395,13 +475,54 @@ fn mcp_initialize_params() -> Value {
     })
 }
 
-async fn call_exa_mcp(
+async fn call_exa_mcp_search(
     egress: Arc<dyn RuntimeHttpEgress>,
     capability_id: &CapabilityId,
     scope: &ResourceScope,
     query: &str,
     num_results: u64,
     include_content: bool,
+) -> Result<EgressText, EgressCallError> {
+    let arguments = json!({
+        "query": query,
+        "numResults": num_results,
+        "livecrawl": "fallback",
+        "type": "auto",
+        "contextMaxCharacters": if include_content {
+            INCLUDE_CONTENT_CONTEXT_CHARS
+        } else {
+            DEFAULT_CONTEXT_CHARS
+        },
+    });
+    call_exa_mcp_tool(egress, capability_id, scope, "web_search_exa", arguments).await
+}
+
+async fn call_exa_mcp_fetch(
+    egress: Arc<dyn RuntimeHttpEgress>,
+    capability_id: &CapabilityId,
+    scope: &ResourceScope,
+    urls: &[String],
+    max_characters: u64,
+) -> Result<EgressText, EgressCallError> {
+    call_exa_mcp_tool(
+        egress,
+        capability_id,
+        scope,
+        "web_fetch_exa",
+        json!({
+            "urls": urls,
+            "maxCharacters": max_characters,
+        }),
+    )
+    .await
+}
+
+async fn call_exa_mcp_tool(
+    egress: Arc<dyn RuntimeHttpEgress>,
+    capability_id: &CapabilityId,
+    scope: &ResourceScope,
+    tool_name: &str,
+    arguments: Value,
 ) -> Result<EgressText, EgressCallError> {
     let mut prior_bytes = 0_u64;
 
@@ -472,18 +593,8 @@ async fn call_exa_mcp(
 
     // 3. tools/call with session ID.
     let call_params = json!({
-        "name": "web_search_exa",
-        "arguments": {
-            "query": query,
-            "numResults": num_results,
-            "livecrawl": "fallback",
-            "type": "auto",
-            "contextMaxCharacters": if include_content {
-                INCLUDE_CONTENT_CONTEXT_CHARS
-            } else {
-                DEFAULT_CONTEXT_CHARS
-            },
-        }
+        "name": tool_name,
+        "arguments": arguments,
     });
     let call_body = json_rpc_body(Some(2), "tools/call", Some(call_params))
         .map_err(|e| EgressCallError::new(e).with_prior(prior_bytes))?;
@@ -601,6 +712,56 @@ fn parse_mcp_block(block: &str) -> Option<SearchResult> {
     })
 }
 
+fn parse_fetch_results(
+    text: &str,
+    requested_urls: &[String],
+) -> Result<Vec<SearchResult>, WebAccessDispatchError> {
+    let lines = text.lines().collect::<Vec<_>>();
+    let starts = lines
+        .iter()
+        .enumerate()
+        .filter_map(|(index, line)| {
+            let next = lines.get(index + 1)?;
+            (line.starts_with("# ") && next.starts_with("URL: ")).then_some(index)
+        })
+        .collect::<Vec<_>>();
+
+    let mut results = Vec::new();
+    for (position, start) in starts.iter().enumerate() {
+        let end = starts.get(position + 1).copied().unwrap_or(lines.len());
+        let title = lines[*start].trim_start_matches("# ").trim().to_string();
+        let url = lines[*start + 1]
+            .trim_start_matches("URL: ")
+            .trim()
+            .to_string();
+        let content = lines[*start + 2..end].join("\n").trim().to_string();
+        results.push(SearchResult {
+            title,
+            url,
+            content,
+        });
+    }
+
+    if !results.is_empty() {
+        return Ok(results);
+    }
+
+    let Some(first_url) = requested_urls.first() else {
+        return Err(input_error());
+    };
+    let title = text
+        .lines()
+        .find_map(|line| line.strip_prefix("# ").map(str::trim))
+        .filter(|value| !value.is_empty())
+        .unwrap_or(first_url)
+        .to_string();
+    Ok(vec![SearchResult {
+        title,
+        url: first_url.clone(),
+        content: text.trim().to_string(),
+    }])
+}
+
 fn line_value(block: &str, prefix: &str) -> Option<String> {
     block.lines().find_map(|line| {
         line.strip_prefix(prefix)
@@ -665,6 +826,53 @@ fn query_list(input: &Value) -> Result<Vec<String>, WebAccessDispatchError> {
         return Err(input_error());
     }
     Ok(queries)
+}
+
+fn fetch_url_list(input: &Value) -> Result<Vec<String>, WebAccessDispatchError> {
+    let single_url = optional_string(input, "url")?
+        .map(|url| validated_fetch_url(&url))
+        .transpose()?;
+    let urls = bounded_string_array(input, "urls", MAX_FETCH_URLS, MAX_URL_CHARS)?
+        .into_iter()
+        .map(|url| validated_fetch_url(&url))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    match (single_url, urls.is_empty()) {
+        (Some(_), false) => Err(input_error()),
+        (Some(url), true) => Ok(vec![url]),
+        (None, false) => Ok(urls),
+        (None, true) => Ok(Vec::new()),
+    }
+}
+
+fn fetch_max_characters(input: &Value) -> Result<u64, WebAccessDispatchError> {
+    let snake_case = optional_u64(input, "max_characters")?;
+    let camel_case = optional_u64(input, "maxCharacters")?;
+    match (snake_case, camel_case) {
+        (Some(_), Some(_)) => Err(input_error()),
+        (Some(0), None) | (None, Some(0)) => Err(input_error()),
+        (Some(value), None) | (None, Some(value)) if value <= MAX_FETCH_MAX_CHARACTERS => Ok(value),
+        (Some(_), None) | (None, Some(_)) => Err(input_error()),
+        (None, None) => Ok(DEFAULT_FETCH_MAX_CHARACTERS),
+    }
+}
+
+fn reject_keys(input: &Value, keys: &[&str]) -> Result<(), WebAccessDispatchError> {
+    if keys.iter().any(|key| input.get(*key).is_some()) {
+        return Err(input_error());
+    }
+    Ok(())
+}
+
+fn validated_fetch_url(value: &str) -> Result<String, WebAccessDispatchError> {
+    let url = bounded_trimmed_string(value, MAX_URL_CHARS)?;
+    if !(url.starts_with("https://") || url.starts_with("http://")) {
+        return Err(input_error());
+    }
+    if url.chars().any(|ch| ch.is_control() || ch.is_whitespace()) {
+        return Err(input_error());
+    }
+    Ok(url)
 }
 
 fn required_string<'a>(input: &'a Value, key: &str) -> Result<&'a str, WebAccessDispatchError> {
@@ -826,6 +1034,7 @@ mod tests {
 
     struct RecordingEgress {
         responses: StdMutex<VecDeque<Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError>>>,
+        requests: StdMutex<Vec<Value>>,
     }
 
     impl RecordingEgress {
@@ -874,7 +1083,12 @@ mod tests {
                     .into_iter()
                     .collect(),
                 ),
+                requests: StdMutex::new(Vec::new()),
             }
+        }
+
+        fn request_bodies(&self) -> Vec<Value> {
+            self.requests.lock().unwrap().clone()
         }
     }
 
@@ -882,8 +1096,12 @@ mod tests {
     impl RuntimeHttpEgress for RecordingEgress {
         async fn execute(
             &self,
-            _request: RuntimeHttpEgressRequest,
+            request: RuntimeHttpEgressRequest,
         ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {
+            self.requests.lock().unwrap().push(
+                serde_json::from_slice(&request.body)
+                    .unwrap_or_else(|_| json!({"invalid_request_body": true})),
+            );
             self.responses
                 .lock()
                 .unwrap()
@@ -924,6 +1142,21 @@ data: {"result":{"content":[{"type":"text","text":"Title: Example\nURL: https://
         assert_eq!(parsed[0].title, "One");
         assert_eq!(parsed[0].content, "First body");
         assert_eq!(parsed[1].url, "https://two.test");
+    }
+
+    #[test]
+    fn parses_exa_fetch_result_blocks() {
+        let parsed = parse_fetch_results(
+            "# Example Domain\nURL: https://example.com\n\nExample body\n\n# IANA\nURL: https://www.iana.org\n\nIANA body",
+            &[],
+        )
+        .unwrap();
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(parsed[0].title, "Example Domain");
+        assert_eq!(parsed[0].url, "https://example.com");
+        assert_eq!(parsed[0].content, "Example body");
+        assert_eq!(parsed[1].title, "IANA");
+        assert_eq!(parsed[1].content, "IANA body");
     }
 
     #[test]
@@ -985,8 +1218,8 @@ data: {"result":{"content":[{"type":"text","text":"Title: Example\nURL: https://
         assert!(build_mcp_query("rust", Some("year"), &[]).ends_with("past year"));
     }
 
-    #[test]
-    fn get_content_rejects_missing_response_id() {
+    #[tokio::test]
+    async fn get_content_rejects_missing_response_id() {
         let executor = WebAccessExecutor::default();
         let capability = capability_id(WEB_GET_CONTENT_CAPABILITY_ID);
         let scope = scope();
@@ -994,13 +1227,14 @@ data: {"result":{"content":[{"type":"text","text":"Title: Example\nURL: https://
 
         let error = executor
             .get_content(request(&capability, &scope, &input, None))
+            .await
             .unwrap_err();
 
         assert_eq!(error.kind(), RuntimeDispatchErrorKind::InputEncode);
     }
 
-    #[test]
-    fn get_content_returns_unknown_response_id_error() {
+    #[tokio::test]
+    async fn get_content_returns_unknown_response_id_error() {
         let executor = WebAccessExecutor::default();
         let capability = capability_id(WEB_GET_CONTENT_CAPABILITY_ID);
         let scope = scope();
@@ -1008,13 +1242,14 @@ data: {"result":{"content":[{"type":"text","text":"Title: Example\nURL: https://
 
         let error = executor
             .get_content(request(&capability, &scope, &input, None))
+            .await
             .unwrap_err();
 
         assert_eq!(error.kind(), RuntimeDispatchErrorKind::OperationFailed);
     }
 
-    #[test]
-    fn get_content_rejects_unknown_query_selector() {
+    #[tokio::test]
+    async fn get_content_rejects_unknown_query_selector() {
         let (executor, response_id) = seed_executor();
         let capability = capability_id(WEB_GET_CONTENT_CAPABILITY_ID);
         let scope = scope();
@@ -1022,13 +1257,14 @@ data: {"result":{"content":[{"type":"text","text":"Title: Example\nURL: https://
 
         let error = executor
             .get_content(request(&capability, &scope, &input, None))
+            .await
             .unwrap_err();
 
         assert_eq!(error.kind(), RuntimeDispatchErrorKind::OperationFailed);
     }
 
-    #[test]
-    fn get_content_returns_result_by_url_index() {
+    #[tokio::test]
+    async fn get_content_returns_result_by_url_index() {
         let (executor, response_id) = seed_executor();
         let capability = capability_id(WEB_GET_CONTENT_CAPABILITY_ID);
         let scope = scope();
@@ -1036,14 +1272,16 @@ data: {"result":{"content":[{"type":"text","text":"Title: Example\nURL: https://
 
         let result = executor
             .get_content(request(&capability, &scope, &input, None))
+            .await
             .unwrap();
 
         assert_eq!(result.output["url"], "https://two.test");
         assert_eq!(result.output["content"], "second body");
+        assert_eq!(result.output["provider_used"], "cache");
     }
 
-    #[test]
-    fn get_content_returns_result_by_url_selector() {
+    #[tokio::test]
+    async fn get_content_returns_result_by_url_selector() {
         let (executor, response_id) = seed_executor();
         let capability = capability_id(WEB_GET_CONTENT_CAPABILITY_ID);
         let scope = scope();
@@ -1051,13 +1289,14 @@ data: {"result":{"content":[{"type":"text","text":"Title: Example\nURL: https://
 
         let result = executor
             .get_content(request(&capability, &scope, &input, None))
+            .await
             .unwrap();
 
         assert_eq!(result.output["title"], "First");
     }
 
-    #[test]
-    fn get_content_rejects_out_of_bounds_url_index() {
+    #[tokio::test]
+    async fn get_content_rejects_out_of_bounds_url_index() {
         let (executor, response_id) = seed_executor();
         let capability = capability_id(WEB_GET_CONTENT_CAPABILITY_ID);
         let scope = scope();
@@ -1065,9 +1304,132 @@ data: {"result":{"content":[{"type":"text","text":"Title: Example\nURL: https://
 
         let error = executor
             .get_content(request(&capability, &scope, &input, None))
+            .await
             .unwrap_err();
 
         assert_eq!(error.kind(), RuntimeDispatchErrorKind::OperationFailed);
+    }
+
+    #[tokio::test]
+    async fn get_content_rejects_multiple_cached_result_selectors() {
+        let (executor, response_id) = seed_executor();
+        let capability = capability_id(WEB_GET_CONTENT_CAPABILITY_ID);
+        let scope = scope();
+        let input = json!({"response_id": response_id, "url": "https://one.test", "url_index": 0});
+
+        let error = executor
+            .get_content(request(&capability, &scope, &input, None))
+            .await
+            .unwrap_err();
+
+        assert_eq!(error.kind(), RuntimeDispatchErrorKind::InputEncode);
+    }
+
+    #[tokio::test]
+    async fn get_content_rejects_cached_request_with_fetch_only_fields() {
+        let executor = WebAccessExecutor::default();
+        let capability = capability_id(WEB_GET_CONTENT_CAPABILITY_ID);
+        let scope = scope();
+        let input = json!({"response_id": "cached", "urls": ["https://example.com"]});
+
+        let error = executor
+            .get_content(request(&capability, &scope, &input, None))
+            .await
+            .unwrap_err();
+
+        assert_eq!(error.kind(), RuntimeDispatchErrorKind::InputEncode);
+    }
+
+    #[tokio::test]
+    async fn get_content_rejects_fetch_request_with_cached_selector_fields() {
+        let executor = WebAccessExecutor::default();
+        let capability = capability_id(WEB_GET_CONTENT_CAPABILITY_ID);
+        let scope = scope();
+        let input = json!({"url": "https://example.com", "url_index": 0});
+
+        let error = executor
+            .get_content(request(&capability, &scope, &input, None))
+            .await
+            .unwrap_err();
+
+        assert_eq!(error.kind(), RuntimeDispatchErrorKind::InputEncode);
+    }
+
+    #[tokio::test]
+    async fn get_content_rejects_duplicate_fetch_max_character_aliases() {
+        let executor = WebAccessExecutor::default();
+        let capability = capability_id(WEB_GET_CONTENT_CAPABILITY_ID);
+        let scope = scope();
+        let input =
+            json!({"url": "https://example.com", "max_characters": 1000, "maxCharacters": 1000});
+
+        let error = executor
+            .get_content(request(&capability, &scope, &input, None))
+            .await
+            .unwrap_err();
+
+        assert_eq!(error.kind(), RuntimeDispatchErrorKind::InputEncode);
+    }
+
+    #[tokio::test]
+    async fn get_content_rejects_out_of_range_fetch_max_characters() {
+        let executor = WebAccessExecutor::default();
+        let capability = capability_id(WEB_GET_CONTENT_CAPABILITY_ID);
+        let scope = scope();
+        let input = json!({"url": "https://example.com", "max_characters": 0});
+
+        let error = executor
+            .get_content(request(&capability, &scope, &input, None))
+            .await
+            .unwrap_err();
+
+        assert_eq!(error.kind(), RuntimeDispatchErrorKind::InputEncode);
+
+        let input =
+            json!({"url": "https://example.com", "max_characters": MAX_FETCH_MAX_CHARACTERS + 1});
+        let error = executor
+            .get_content(request(&capability, &scope, &input, None))
+            .await
+            .unwrap_err();
+
+        assert_eq!(error.kind(), RuntimeDispatchErrorKind::InputEncode);
+    }
+
+    #[tokio::test]
+    async fn get_content_fetches_url_with_exa_web_fetch_tool() {
+        let executor = WebAccessExecutor::default();
+        let capability = capability_id(WEB_GET_CONTENT_CAPABILITY_ID);
+        let scope = scope();
+        let input = json!({"url":"https://example.com", "max_characters": 1000});
+        let egress = Arc::new(RecordingEgress::for_mcp_search(json!({
+            "result": {"content": [{"type": "text", "text": "# Example Domain\nURL: https://example.com\n\nExample body"}]}
+        })));
+
+        let result = executor
+            .dispatch(request(
+                &capability,
+                &scope,
+                &input,
+                Some(egress.clone() as Arc<dyn RuntimeHttpEgress>),
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(result.output["provider_used"], "exa_mcp");
+        assert_eq!(result.output["title"], "Example Domain");
+        assert_eq!(result.output["url"], "https://example.com");
+        assert_eq!(result.output["content"], "Example body");
+        let request_bodies = egress.request_bodies();
+        assert_eq!(request_bodies[2]["method"], "tools/call");
+        assert_eq!(request_bodies[2]["params"]["name"], "web_fetch_exa");
+        assert_eq!(
+            request_bodies[2]["params"]["arguments"]["urls"][0],
+            "https://example.com"
+        );
+        assert_eq!(
+            request_bodies[2]["params"]["arguments"]["maxCharacters"],
+            1000
+        );
     }
 
     #[test]

--- a/crates/ironclaw_product_workflow/src/reborn_services/extension_onboarding.rs
+++ b/crates/ironclaw_product_workflow/src/reborn_services/extension_onboarding.rs
@@ -299,7 +299,7 @@ mod tests {
             Vec::new(),
             LifecycleExtensionRuntimeKind::FirstParty,
             Some(LifecycleExtensionOnboarding {
-                instructions: "Web Access does not need credentials. Activate it to make web search and saved-result retrieval tools available.".to_string(),
+                instructions: "Web Access does not need credentials. Activate it to make web search and page-content retrieval tools available.".to_string(),
                 credential_instructions: Some("No credentials are required for Web Access.".to_string()),
                 setup_url: None,
                 credential_next_step: Some("Activate Web Access to publish its tools.".to_string()),
@@ -316,7 +316,7 @@ mod tests {
         assert_eq!(
             onboarding.instructions.as_deref(),
             Some(
-                "Web Access does not need credentials. Activate it to make web search and saved-result retrieval tools available."
+                "Web Access does not need credentials. Activate it to make web search and page-content retrieval tools available."
             )
         );
     }

--- a/crates/ironclaw_reborn_composition/src/available_extensions.rs
+++ b/crates/ironclaw_reborn_composition/src/available_extensions.rs
@@ -186,7 +186,7 @@ fn onboarding(package_ref: &LifecyclePackageRef) -> Option<LifecycleExtensionOnb
             "After authorization completes, activate Notion to publish its MCP tools.",
         )),
         "web-access" => Some(onboarding_message(
-            "Web Access does not need credentials. Activate it to make web search and saved-result retrieval tools available.",
+            "Web Access does not need credentials. Activate it to make web search and page-content retrieval tools available.",
             Some("No credentials are required for Web Access."),
             None,
             "Activate Web Access to publish its tools.",

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/extension_surface.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/extension_surface.rs
@@ -9,8 +9,8 @@ use ironclaw_trust::{AuthorityCeiling, EffectiveTrustClass, TrustDecision, Trust
 
 use crate::extension_lifecycle::{ActiveExtensionCapability, RebornLocalExtensionManagementPort};
 use ironclaw_first_party_extensions::{
-    EXA_MCP_HOST, NETWORK_EGRESS_LIMIT, WEB_ACCESS_EXTENSION_ID, WEB_SEARCH_CAPABILITY_ID,
-    gsuite_network_policy_for,
+    EXA_MCP_HOST, NETWORK_EGRESS_LIMIT, WEB_ACCESS_EXTENSION_ID, WEB_GET_CONTENT_CAPABILITY_ID,
+    WEB_SEARCH_CAPABILITY_ID, gsuite_network_policy_for,
 };
 use ironclaw_product_workflow::ProductWorkflowError;
 
@@ -165,9 +165,12 @@ fn extension_network_policy(capability: &ActiveExtensionCapability) -> NetworkPo
             targets.push(credential.audience.clone());
         }
     }
-    let is_web_access_search = capability.provider.as_str() == WEB_ACCESS_EXTENSION_ID
-        && capability.id.as_str() == WEB_SEARCH_CAPABILITY_ID;
-    if is_web_access_search
+    let is_web_access_exa_mcp = capability.provider.as_str() == WEB_ACCESS_EXTENSION_ID
+        && matches!(
+            capability.id.as_str(),
+            WEB_SEARCH_CAPABILITY_ID | WEB_GET_CONTENT_CAPABILITY_ID
+        );
+    if is_web_access_exa_mcp
         && !targets
             .iter()
             .any(|target| target.host_pattern == EXA_MCP_HOST)
@@ -181,7 +184,7 @@ fn extension_network_policy(capability: &ActiveExtensionCapability) -> NetworkPo
     NetworkPolicy {
         allowed_targets: targets,
         deny_private_ip_ranges: true,
-        max_egress_bytes: is_web_access_search.then_some(NETWORK_EGRESS_LIMIT),
+        max_egress_bytes: is_web_access_exa_mcp.then_some(NETWORK_EGRESS_LIMIT),
     }
 }
 
@@ -195,6 +198,30 @@ mod tests {
     fn web_access_search_gets_exa_mcp_network_target_without_credentials() {
         let capability = ActiveExtensionCapability {
             id: CapabilityId::new(WEB_SEARCH_CAPABILITY_ID).unwrap(),
+            provider: ExtensionId::new(WEB_ACCESS_EXTENSION_ID).unwrap(),
+            effects: vec![EffectKind::DispatchCapability, EffectKind::Network],
+            default_permission: PermissionMode::Allow,
+            runtime_credentials: Vec::new(),
+        };
+
+        let policy = extension_network_policy(&capability);
+
+        assert_eq!(
+            policy.allowed_targets,
+            vec![NetworkTargetPattern {
+                scheme: Some(NetworkScheme::Https),
+                host_pattern: EXA_MCP_HOST.to_string(),
+                port: None,
+            }]
+        );
+        assert!(policy.deny_private_ip_ranges);
+        assert_eq!(policy.max_egress_bytes, Some(NETWORK_EGRESS_LIMIT));
+    }
+
+    #[test]
+    fn web_access_get_content_gets_exa_mcp_network_target_without_credentials() {
+        let capability = ActiveExtensionCapability {
+            id: CapabilityId::new(WEB_GET_CONTENT_CAPABILITY_ID).unwrap(),
             provider: ExtensionId::new(WEB_ACCESS_EXTENSION_ID).unwrap(),
             effects: vec![EffectKind::DispatchCapability, EffectKind::Network],
             default_permission: PermissionMode::Allow,

--- a/crates/ironclaw_reborn_composition/src/web_access.rs
+++ b/crates/ironclaw_reborn_composition/src/web_access.rs
@@ -60,3 +60,123 @@ fn web_access_error(error: WebAccessDispatchError) -> FirstPartyCapabilityError 
         mapped
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ironclaw_host_api::{
+        InvocationId, ResourceScope, RuntimeHttpEgress, RuntimeHttpEgressError,
+        RuntimeHttpEgressRequest, RuntimeHttpEgressResponse, UserId,
+    };
+    use serde_json::{Value, json};
+    use std::{
+        collections::VecDeque,
+        sync::{Arc, Mutex},
+    };
+
+    struct RecordingEgress {
+        responses: Mutex<VecDeque<RuntimeHttpEgressResponse>>,
+        requests: Mutex<Vec<RuntimeHttpEgressRequest>>,
+    }
+
+    impl RecordingEgress {
+        fn for_mcp_fetch() -> Self {
+            Self {
+                responses: Mutex::new(
+                    [
+                        Self::json_response(json!({
+                            "jsonrpc": "2.0",
+                            "id": 1,
+                            "result": {"protocolVersion": "2024-11-05", "capabilities": {}}
+                        })),
+                        RuntimeHttpEgressResponse {
+                            status: 202,
+                            headers: Vec::new(),
+                            body: Vec::new(),
+                            saved_body: None,
+                            request_bytes: 5,
+                            response_bytes: 0,
+                            redaction_applied: false,
+                        },
+                        Self::json_response(json!({
+                            "result": {"content": [{"type": "text", "text": "# Example Domain\nURL: https://example.com\n\nExample body"}]}
+                        })),
+                    ]
+                    .into_iter()
+                    .collect(),
+                ),
+                requests: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn json_response(body: Value) -> RuntimeHttpEgressResponse {
+            let body = serde_json::to_vec(&body).unwrap();
+            RuntimeHttpEgressResponse {
+                status: 200,
+                headers: Vec::new(),
+                body,
+                saved_body: None,
+                request_bytes: 10,
+                response_bytes: 20,
+                redaction_applied: false,
+            }
+        }
+
+        fn requests(&self) -> Vec<RuntimeHttpEgressRequest> {
+            self.requests.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl RuntimeHttpEgress for RecordingEgress {
+        async fn execute(
+            &self,
+            request: RuntimeHttpEgressRequest,
+        ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {
+            self.requests.lock().unwrap().push(request);
+            Ok(self
+                .responses
+                .lock()
+                .unwrap()
+                .pop_front()
+                .expect("RecordingEgress: no more responses queued"))
+        }
+    }
+
+    fn scope() -> ResourceScope {
+        ResourceScope::local_default(UserId::new("test-user").unwrap(), InvocationId::new())
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn bundled_web_access_get_content_handler_forwards_runtime_egress() {
+        let mut registry = FirstPartyCapabilityRegistry::default();
+        register_bundled_web_access_first_party_handlers(&mut registry).unwrap();
+        let capability_id = CapabilityId::new(WEB_GET_CONTENT_CAPABILITY_ID).unwrap();
+        let egress = Arc::new(RecordingEgress::for_mcp_fetch());
+        let egress_port: Arc<dyn RuntimeHttpEgress> = egress.clone();
+        let handler = registry.get(&capability_id).expect("handler registered");
+
+        let result = handler
+            .dispatch(FirstPartyCapabilityRequest::request_for_test(
+                capability_id.clone(),
+                scope(),
+                json!({"url": "https://example.com"}),
+                Some(egress_port),
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(result.output["provider_used"], "exa_mcp");
+        assert_eq!(result.output["url"], "https://example.com");
+        let requests = egress.requests();
+        assert_eq!(requests.len(), 3);
+        assert!(
+            requests
+                .iter()
+                .all(|request| request.capability_id == capability_id)
+        );
+        let tools_call = serde_json::from_slice::<Value>(&requests[2].body).unwrap();
+        assert_eq!(tools_call["params"]["name"], "web_fetch_exa");
+    }
+}


### PR DESCRIPTION
## Summary
- Update Web Access `get_content` to fetch direct URLs through Exa `web_fetch_exa` while preserving cached `response_id` lookup.
- Tighten input/output schemas so cached lookup and live fetch modes are explicit and non-ambiguous.
- Grant the local-dev Reborn capability surface Exa MCP network policy for `get_content` and refresh onboarding copy.

## Root Cause
Exa hosted MCP currently exposes `web_search_exa` and `web_fetch_exa`. IronClaw exposed `web-access.get_content` as a cache-only capability, so URL-based content fetches reached the wrong contract and lacked network policy.

## Validation
- `cargo test -p ironclaw_first_party_extensions web_access`
- `cargo test -p ironclaw_reborn_composition --lib web_access_get_content_gets_exa_mcp_network_target_without_credentials`
- `cargo test -p ironclaw_product_workflow --lib web_access_projects_activation_message_without_credentials`
- `cargo fmt --all --check`
- `jq empty crates/ironclaw_first_party_extensions/assets/web-access/schemas/web-access/get_content.input.v1.json crates/ironclaw_first_party_extensions/assets/web-access/schemas/web-access/get_content.output.v1.json`
- `git diff --check`

Note: Host disk was nearly full during validation, so target artifacts were cleaned and narrow tests were run in isolation.