### PR TITLE
Fix live canary workflow expression

### DIFF
--- a/.github/workflows/live-canary.yml
+++ b/.github/workflows/live-canary.yml
@@ -402,7 +402,7 @@ jobs:
     name: Deterministic Replay
     if: >
       github.event_name == 'workflow_dispatch' &&
-      (inputs.lane == 'all' || inputs.lane == 'deterministic-replay'))
+      (inputs.lane == 'all' || inputs.lane == 'deterministic-replay')
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:


### PR DESCRIPTION
## Summary
- fix the `deterministic-replay` job `if:` expression left invalid by the scheduled-canary cleanup
- removes the extra closing parenthesis that caused GitHub to create failed zero-job workflow records and show the workflow as `.github/workflows/live-canary.yml` instead of `Live Canary`

## Testing
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/live-canary.yml"); puts "yaml ok"'`\n- `git diff --check`\n- targeted workflow assertions for the cron shape and deterministic-replay expression\n- `actionlint -ignore 'label "ironclaw-live" is unknown' .github/workflows/live-canary.yml`