### PR TITLE
Add /canary PR comment trigger

### DIFF
--- a/.github/workflows/live-canary-command.yml
+++ b/.github/workflows/live-canary-command.yml
@@ -1,0 +1,160 @@
+name: Live Canary Command
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  actions: write        # dispatch live-canary.yml
+  contents: read
+  issues: write         # comment on PR threads and react to trigger comments
+  pull-requests: write  # reactions on PR comments require PR write in this repo
+
+concurrency:
+  group: live-canary-command-${{ github.event.issue.number || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  dispatch:
+    name: Dispatch Live Canary
+    if: >-
+      github.event.issue.pull_request != null
+      && (
+        github.event.comment.body == '/canary'
+        || startsWith(github.event.comment.body, '/canary ')
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check commenter has write permission
+        id: auth
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.0.1
+        with:
+          script: |
+            let permission = 'none';
+            try {
+              const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username: context.payload.comment.user.login,
+              });
+              permission = data.permission;
+            } catch (err) {
+              if (err.status !== 404) throw err;
+            }
+
+            const ok = ['admin', 'write', 'maintain'].includes(permission);
+            core.setOutput('authorized', ok ? 'yes' : 'no');
+            if (!ok) {
+              core.notice(`Comment author @${context.payload.comment.user.login} is not authorized to trigger live canary (permission: ${permission}).`);
+            }
+
+      - name: Parse command and resolve pull request
+        id: parse
+        if: steps.auth.outputs.authorized == 'yes'
+        env:
+          BODY: ${{ github.event.comment.body }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          usage=$'Usage: `/canary [all|cases=<case-list>|<case-list>]`\n\nExamples:\n- `/canary`\n- `/canary all`\n- `/canary cases=2A,2D,5C`'
+          body_norm="$(printf '%s' "$BODY" | tr '\n\t' '  ' | tr -s ' ' | sed -E 's/^ +| +$//g')"
+          args="${body_norm#/canary}"
+          args="$(printf '%s' "$args" | sed -E 's/^ +| +$//g')"
+
+          cases="all"
+          if [ -n "$args" ] && [ "$args" != "all" ]; then
+            case "$args" in
+              cases=*) cases="${args#cases=}" ;;
+              case=*) cases="${args#case=}" ;;
+              *) cases="$args" ;;
+            esac
+          fi
+
+          if ! printf '%s' "$cases" | grep -Eq '^(all|[A-Za-z0-9_.:-]+(,[A-Za-z0-9_.:-]+)*)$'; then
+            gh pr comment "$PR" --repo "$REPO" --body "Could not parse \`/canary\` cases argument."$'\n\n'"$usage"
+            exit 0
+          fi
+
+          is_cross_repository="$(gh pr view "$PR" --repo "$REPO" --json isCrossRepository --jq .isCrossRepository)"
+          if [ "$is_cross_repository" = "true" ]; then
+            gh pr comment "$PR" --repo "$REPO" --body \
+              "Refusing to run live canary on a forked PR. The live canary uses production-like integration secrets, so \`/canary\` is limited to branches in this repository."
+            exit 0
+          fi
+
+          head_sha="$(gh pr view "$PR" --repo "$REPO" --json headRefOid --jq .headRefOid)"
+          short_sha="${head_sha:0:10}"
+          trigger_context="/canary PR #${PR} ${short_sha} comment ${COMMENT_ID} by @${COMMENT_AUTHOR}"
+
+          {
+            echo "cases=$cases"
+            echo "head_sha=$head_sha"
+            echo "short_sha=$short_sha"
+            echo "trigger_context=$trigger_context"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Acknowledge with rocket reaction
+        if: steps.parse.outputs.head_sha != ''
+        env:
+          COMMENT_ID: ${{ github.event.comment.id }}
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh api "/repos/${REPO}/issues/comments/${COMMENT_ID}/reactions" -F content=rocket
+
+      - name: Dispatch Reborn WebUI v2 live canary
+        if: steps.parse.outputs.head_sha != ''
+        env:
+          CASES: ${{ steps.parse.outputs.cases }}
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ steps.parse.outputs.head_sha }}
+          REPO: ${{ github.repository }}
+          TRIGGER_CONTEXT: ${{ steps.parse.outputs.trigger_context }}
+        run: |
+          set -euo pipefail
+          gh workflow run live-canary.yml \
+            --repo "$REPO" \
+            --ref main \
+            -f lane=reborn-webui-v2-live-qa \
+            -f cases="$CASES" \
+            -f target_ref="$HEAD_SHA" \
+            -f trigger_context="$TRIGGER_CONTEXT"
+
+      - name: Post started comment
+        if: steps.parse.outputs.head_sha != ''
+        env:
+          CASES: ${{ steps.parse.outputs.cases }}
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+          SHORT_SHA: ${{ steps.parse.outputs.short_sha }}
+          TRIGGER_CONTEXT: ${{ steps.parse.outputs.trigger_context }}
+        run: |
+          set -euo pipefail
+          run_url=""
+          for _ in $(seq 1 12); do
+            runs_json="$(gh run list \
+              --repo "$REPO" \
+              --workflow live-canary.yml \
+              --branch main \
+              --event workflow_dispatch \
+              --limit 20 \
+              --json displayTitle,url)"
+            run_url="$(printf '%s' "$runs_json" | jq -r --arg title "$TRIGGER_CONTEXT" '.[] | select(.displayTitle == $title) | .url' | head -n 1)"
+            if [ -n "$run_url" ]; then
+              break
+            fi
+            sleep 5
+          done
+
+          if [ -z "$run_url" ]; then
+            run_url="https://github.com/${REPO}/actions/workflows/live-canary.yml"
+          fi
+
+          gh pr comment "$PR" --repo "$REPO" --body \
+            "Started Reborn WebUI v2 live canary for \`${SHORT_SHA}\` with cases \`${CASES}\`: ${run_url}"

--- a/.github/workflows/live-canary.yml
+++ b/.github/workflows/live-canary.yml
@@ -1,4 +1,5 @@
 name: Live Canary
+run-name: ${{ inputs.trigger_context || github.workflow }}
 
 on:
   # Scheduled runs are intentionally limited to Reborn WebUI v2 live QA.
@@ -42,6 +43,16 @@ on:
         type: string
       previous_ref:
         description: "Previous release/tag for upgrade-canary"
+        type: string
+        required: false
+        default: ""
+      target_ref:
+        description: "Optional ref/SHA for the Reborn WebUI v2 live QA checkout. Used by /canary PR comments."
+        type: string
+        required: false
+        default: ""
+      trigger_context:
+        description: "Optional run label supplied by ChatOps dispatchers."
         type: string
         required: false
         default: ""
@@ -507,6 +518,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          ref: ${{ inputs.target_ref || github.ref }}
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:


### PR DESCRIPTION
## Summary
- add a maintainer-only `/canary` PR comment workflow
- dispatch the canonical `live-canary.yml` from `main` with `lane=reborn-webui-v2-live-qa`
- pass the commented PR head SHA through `target_ref` so the live canary tests the PR code even if the PR branch does not contain the latest canary workflow
- reject forked PRs because live canary uses production-like integration secrets

## Usage
- `/canary` runs the full promoted Reborn WebUI v2 live QA suite
- `/canary all` is equivalent
- `/canary cases=2A,2D,5C` runs a subset

## Testing
- `ruby -e 'require "yaml"; %w[.github/workflows/live-canary.yml .github/workflows/live-canary-command.yml].each { |f| YAML.load_file(f); puts "yaml ok #{f}" }'`\n- `git diff --check`\n- targeted assertions for `target_ref`, `/canary` dispatch inputs, same-repo guard, and Reborn lane selection\n- `actionlint -ignore 'label "ironclaw-live" is unknown' .github/workflows/live-canary.yml .github/workflows/live-canary-command.yml`