### PR TITLE
fix(reborn): post-run skill bubble dropped on SSE resume (shared live cursor)

### DIFF
--- a/crates/ironclaw_reborn_composition/src/projection.rs
+++ b/crates/ironclaw_reborn_composition/src/projection.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
 
 use async_trait::async_trait;
 use futures::{StreamExt, stream};
@@ -81,6 +82,13 @@ pub(crate) struct RebornProjectionServices {
     display_previews: Arc<dyn CapabilityDisplayPreviewSource>,
     webui_reply_target_binding_ref: ReplyTargetBindingRef,
     auth_challenges: Option<Arc<dyn AuthChallengeProvider>>,
+    /// Monotonic live-progress sequence shared by every publisher minted from
+    /// these services. Live cursors are `LIVE_PROGRESS_CURSOR_BASE + sequence`;
+    /// resetting per-publisher (the old bug) let a post-run publisher re-issue a
+    /// cursor at/below one already consumed on an open SSE stream, so the resume
+    /// drain filtered the bubble out. Sharing keeps cursors strictly increasing
+    /// across publisher instances for the lifetime of the services.
+    live_sequence: Arc<AtomicU64>,
 }
 
 impl RebornProjectionServices {
@@ -169,6 +177,7 @@ impl RebornProjectionServices {
         Arc::new(LiveProjectionPublisher::new(
             Arc::clone(&self.live_updates),
             actor_user_id,
+            Arc::clone(&self.live_sequence),
         ))
     }
 
@@ -203,6 +212,7 @@ pub(crate) fn build_reborn_projection_services(
         display_previews: Arc::new(NoopCapabilityDisplayPreviewSource),
         webui_reply_target_binding_ref,
         auth_challenges: None,
+        live_sequence: Arc::new(AtomicU64::new(0)),
     }
 }
 

--- a/crates/ironclaw_reborn_composition/src/projection/live_progress.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/live_progress.rs
@@ -49,7 +49,10 @@ pub(super) struct LiveSkillActivationObserver {
 pub(crate) struct LiveProjectionPublisher {
     update_source: Arc<InMemoryProjectionUpdateSource>,
     actor_user_id: UserId,
-    next_sequence: AtomicU64,
+    /// Shared across every publisher minted from the same services so live
+    /// cursors stay strictly increasing across instances (see the field doc on
+    /// `RebornProjectionServices::live_sequence`).
+    next_sequence: Arc<AtomicU64>,
 }
 
 impl std::fmt::Debug for LiveProjectionPublisher {
@@ -80,11 +83,12 @@ impl LiveProjectionPublisher {
     pub(super) fn new(
         update_source: Arc<InMemoryProjectionUpdateSource>,
         actor_user_id: UserId,
+        next_sequence: Arc<AtomicU64>,
     ) -> Self {
         Self {
             update_source,
             actor_user_id,
-            next_sequence: AtomicU64::new(0),
+            next_sequence,
         }
     }
 


### PR DESCRIPTION
## Problem

`projection::tests::live_progress_stream::skill_learned_bubble_delivers_when_sse_resumes_from_advanced_durable_cursor` is **red on `main`** (introduced by #5061). It's a faithful repro of a production bug: after a run completes, the skill-learning sink publishes a "learned a new skill" bubble, but clients on an already-open SSE stream never receive it.

## Root cause

`LiveProjectionPublisher::new` initializes `next_sequence` to `0`, and `RebornProjectionServices::live_projection_publisher()` mints a **fresh** publisher on every call. Live cursors are `LIVE_PROGRESS_CURSOR_BASE + sequence`, so a post-run publisher restarts at sequence 1 and re-issues a cursor at/below one already consumed on the open stream. `drain(after_cursor = …)` treats it as already-seen and filters the bubble out.

## Fix

Move the monotonic live-progress sequence into a shared `Arc<AtomicU64>` owned by `RebornProjectionServices` and clone it into every publisher. Live cursors now stay strictly increasing across publisher instances for the lifetime of the services, so post-run publishes always land past the resume cursor.

## Verification

`ironclaw_reborn_composition --lib` (features `root-llm-provider webui-v2-beta libsql test-support`): 1034 passed, 0 failed — including all 5 `live_progress_stream` tests (the named repro now passes). Clippy clean.

Standalone bug fix against `main`; unrelated to the reborn error-recoverability PR stack (#4841/#5389/#5390/#5403) but unblocks those branches' inherited red test once they rebase on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)