### PR TITLE
ci: ignore unreachable wasmtime wasi advisory

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -21,12 +21,15 @@ ignore = [
     "RUSTSEC-2026-0097",
     # wasmtime: WASI path_open(TRUNCATE) bypasses FilePerms::WRITE host restriction
     # (https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-2r75-cxrj-cmph).
+    # wasmtime-wasi: WASI hard links and renames bypass destination FilePerms
+    # (https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-4ch3-9j33-3pmj).
     # The IronClaw WASM sandbox does not grant guest modules WASI filesystem
     # capabilities backed by host-controlled FilePerms — guests communicate via
     # explicit host functions (see crates/ironclaw_engine and src/tools/wasm/host.rs),
-    # so the TRUNCATE bypass is not reachable from our guest surface. Remove once
-    # wasmtime is upgraded to a patched release.
+    # so these FilePerms bypasses are not reachable from our guest surface. Remove
+    # once wasmtime is upgraded to a patched release.
     "RUSTSEC-2026-0149",
+    "RUSTSEC-2026-0188",
 ]
 
 [licenses]


### PR DESCRIPTION
## Summary
- add a temporary cargo-deny ignore for `RUSTSEC-2026-0188`
- document why the Wasmtime WASI FilePerms bypass is not reachable from IronClaw's guest surface
- keep the actual Wasmtime upgrade separate because the patched line requires a newer Rust toolchain than `main` currently declares

## Root Cause
The `cargo-deny` job in the merge queue failed because RustSec added `RUSTSEC-2026-0188` for `wasmtime-wasi 44.0.3`. The advisory recommends upgrading to `45.0.3` or newer, but `wasmtime 45.0.3` declares `rust-version = 1.93.0` while `main` still declares Rust `1.92`.

IronClaw's WASM sandbox does not expose WASI filesystem capabilities backed by host-controlled `FilePerms`; guest modules communicate through explicit host functions. This matches the existing rationale for the adjacent Wasmtime FilePerms advisory ignore.

## Validation
- `cargo deny check advisories`
- `cargo deny check`
