### PR TITLE
Fix /canary PR target validation

### DIFF
--- a/.github/workflows/live-canary-command.yml
+++ b/.github/workflows/live-canary-command.yml
@@ -113,6 +113,7 @@ jobs:
           CASES: ${{ steps.parse.outputs.cases }}
           GH_TOKEN: ${{ github.token }}
           HEAD_SHA: ${{ steps.parse.outputs.head_sha }}
+          PR: ${{ github.event.issue.number }}
           REPO: ${{ github.repository }}
           TRIGGER_CONTEXT: ${{ steps.parse.outputs.trigger_context }}
         run: |
@@ -123,6 +124,7 @@ jobs:
             -f lane=reborn-webui-v2-live-qa \
             -f cases="$CASES" \
             -f target_ref="$HEAD_SHA" \
+            -f target_pr="$PR" \
             -f trigger_context="$TRIGGER_CONTEXT"
 
       - name: Post started comment

--- a/.github/workflows/live-canary.yml
+++ b/.github/workflows/live-canary.yml
@@ -51,6 +51,11 @@ on:
         type: string
         required: false
         default: ""
+      target_pr:
+        description: "Optional pull request number for validating target_ref before running Reborn WebUI v2 live QA with secrets."
+        type: string
+        required: false
+        default: ""
       trigger_context:
         description: "Optional run label supplied by ChatOps dispatchers."
         type: string
@@ -59,6 +64,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   group: live-canary-${{ github.event_name }}-${{ inputs.lane || github.event.schedule }}
@@ -604,15 +610,46 @@ jobs:
               echo "Running requested cases in this shard: ${joined}"
             fi
           fi
-      - name: Reject unsafe Reborn WebUI v2 live QA target refs
+      - name: Validate Reborn WebUI v2 live QA target ref
+        id: validate_reborn_webui_v2_target
         if: steps.resolve_reborn_webui_v2_cases.outputs.skip_shard != '1' && github.event_name == 'workflow_dispatch' && inputs.target_ref != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          TARGET_PR: ${{ inputs.target_pr }}
+          TARGET_REF: ${{ inputs.target_ref }}
         run: |
-          echo "::error::target_ref is disabled for reborn-webui-v2-live-qa because this lane runs with live secrets."
-          exit 1
+          set -euo pipefail
+          if ! [[ "${TARGET_REF}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::target_ref must be a full commit SHA for reborn-webui-v2-live-qa."
+            exit 1
+          fi
+          if ! [[ "${TARGET_PR}" =~ ^[0-9]+$ ]]; then
+            echo "::error::target_pr is required when target_ref is supplied for reborn-webui-v2-live-qa."
+            exit 1
+          fi
+          pr_json="$(gh pr view "${TARGET_PR}" --repo "${REPO}" --json isCrossRepository,headRefOid)"
+          is_cross_repository="$(jq -r '.isCrossRepository' <<< "${pr_json}")"
+          head_sha="$(jq -r '.headRefOid' <<< "${pr_json}")"
+          if [[ "${is_cross_repository}" == "true" ]]; then
+            echo "::error::Refusing to run reborn-webui-v2-live-qa with live secrets on a forked PR."
+            exit 1
+          fi
+          if [[ "${head_sha}" != "${TARGET_REF}" ]]; then
+            echo "::error::target_ref does not match PR #${TARGET_PR} head SHA."
+            exit 1
+          fi
+          echo "checkout_ref=${TARGET_REF}" >> "${GITHUB_OUTPUT}"
+      - name: Resolve default Reborn WebUI v2 live QA checkout ref
+        id: default_reborn_webui_v2_target
+        if: steps.resolve_reborn_webui_v2_cases.outputs.skip_shard != '1' && (github.event_name != 'workflow_dispatch' || inputs.target_ref == '')
+        run: |
+          echo "checkout_ref=${GITHUB_SHA}" >> "${GITHUB_OUTPUT}"
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         if: steps.resolve_reborn_webui_v2_cases.outputs.skip_shard != '1'
         with:
           persist-credentials: false
+          ref: ${{ steps.validate_reborn_webui_v2_target.outputs.checkout_ref || steps.default_reborn_webui_v2_target.outputs.checkout_ref }}
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         if: steps.resolve_reborn_webui_v2_cases.outputs.skip_shard != '1'
         with:

--- a/.github/workflows/live-canary.yml
+++ b/.github/workflows/live-canary.yml
@@ -64,7 +64,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
 
 concurrency:
   group: live-canary-${{ github.event_name }}-${{ inputs.lane || github.event.schedule }}
@@ -507,6 +506,9 @@ jobs:
       (github.event_name == 'workflow_dispatch' && (inputs.lane == 'all' || inputs.lane == 'reborn-webui-v2-live-qa'))
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    permissions:
+      contents: read
+      pull-requests: read
     strategy:
       fail-fast: false
       matrix:

--- a/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
+++ b/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
@@ -1609,10 +1609,17 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
             "Unknown Reborn WebUI v2 live QA case",
             match.group("body"),
         )
-        self.assertIn(
-            "target_ref is disabled for reborn-webui-v2-live-qa",
-            match.group("body"),
+        self.assertIn("target_pr is required when target_ref is supplied", match.group("body"))
+        self.assertIn("Refusing to run reborn-webui-v2-live-qa with live secrets on a forked PR", match.group("body"))
+        self.assertIn("target_ref does not match PR #${TARGET_PR} head SHA", match.group("body"))
+        self.assertIn("ref: ${{ steps.validate_reborn_webui_v2_target.outputs.checkout_ref", match.group("body"))
+
+        command_workflow_path = (
+            Path(__file__).resolve().parents[2] / ".github/workflows/live-canary-command.yml"
         )
+        command_workflow = command_workflow_path.read_text(encoding="utf-8")
+        self.assertIn('-f target_ref="$HEAD_SHA"', command_workflow)
+        self.assertIn('-f target_pr="$PR"', command_workflow)
 
     def test_case_manifest_distinguishes_targeted_from_placeholder_gates(self):
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary
- allow Reborn WebUI v2 live QA to checkout a PR head only after validating `target_ref` against a same-repo PR number
- pass `target_pr` from the `/canary` ChatOps workflow into `live-canary.yml`
- update the live QA workflow guard test so `/canary all` does not regress back to rejecting every PR target

## Why
The `/canary all` run failed before checkout because `live-canary.yml` rejected any non-empty `target_ref`, even though `live-canary-command.yml` intentionally dispatches the PR head SHA. The scrub step then failed because checkout never happened.

## Verification
- `python3 -m pytest scripts/reborn_webui_v2_live_qa/test_run_live_qa.py -q`
