### PR TITLE
Accept QA7 routine wording variants

### DIFF
--- a/scripts/reborn_webui_v2_live_qa/run_live_qa.py
+++ b/scripts/reborn_webui_v2_live_qa/run_live_qa.py
@@ -1011,7 +1011,7 @@ async def _wait_for_assistant_reply(
                 last_text = text
             normalized = text.lower()
             marker_matches = not marker or marker in text
-            if marker_matches and all(piece.lower() in normalized for piece in required_text):
+            if marker_matches and _required_text_matches(normalized, required_text):
                 return text[-2000:]
         await asyncio.sleep(0.5)
     main_text = ""
@@ -1023,6 +1023,13 @@ async def _wait_for_assistant_reply(
         "assistant reply did not contain required text before timeout. "
         f"marker={marker!r} required_text={required_text!r} "
         f"last_assistant={last_text[-500:]!r} main_excerpt={main_text[-1000:]!r}"
+    )
+
+
+def _required_text_matches(normalized_text: str, required_text: list[str]) -> bool:
+    return all(
+        any(option.strip().lower() in normalized_text for option in piece.split("|"))
+        for piece in required_text
     )
 
 
@@ -3161,7 +3168,7 @@ async def case_qa_7c_slack_bug_logger_routine(ctx: LiveQaContext) -> ProbeResult
             case_name="qa_7c_slack_bug_logger_routine",
             routine_name=routine_name,
             marker=None,
-            required_text=["trigger", "bug"],
+            required_text=["trigger|routine|automation|cron|schedule|fires|watches", "bug"],
             prompt=_qa_sheet_prompt("qa_7c_slack_bug_logger_routine"),
             extensions=[
                 {

--- a/scripts/reborn_webui_v2_live_qa/run_live_qa.py
+++ b/scripts/reborn_webui_v2_live_qa/run_live_qa.py
@@ -1026,11 +1026,12 @@ async def _wait_for_assistant_reply(
     )
 
 
-def _required_text_matches(normalized_text: str, required_text: list[str]) -> bool:
+def _required_text_matches(text: str, required_text: list[str]) -> bool:
+    normalized_text = text.lower()
     return all(
-        any(option.strip().lower() in normalized_text for option in piece.split("|"))
+        any(option.strip().lower() in normalized_text for option in piece.split('|') if option.strip())
         for piece in required_text
-    )
+)
 
 
 async def _approve_visible_tool_gate(page: object) -> None:

--- a/scripts/reborn_webui_v2_live_qa/run_live_qa.py
+++ b/scripts/reborn_webui_v2_live_qa/run_live_qa.py
@@ -1029,9 +1029,18 @@ async def _wait_for_assistant_reply(
 def _required_text_matches(text: str, required_text: list[str]) -> bool:
     normalized_text = text.lower()
     return all(
-        any(option.strip().lower() in normalized_text for option in piece.split('|') if option.strip())
+        any(_required_option_matches(normalized_text, option) for option in piece.split("|"))
         for piece in required_text
-)
+    )
+
+
+def _required_option_matches(normalized_text: str, option: str) -> bool:
+    normalized_option = option.strip().lower()
+    if not normalized_option:
+        return False
+    if re.fullmatch(r"\w+", normalized_option):
+        return re.search(rf"\b{re.escape(normalized_option)}\b", normalized_text) is not None
+    return normalized_option in normalized_text
 
 
 async def _approve_visible_tool_gate(page: object) -> None:

--- a/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
+++ b/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
@@ -373,6 +373,20 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
         self.assertEqual(captured["timeout"], 180.0)
         self.assertTrue(result.details["fixture_ready"])
 
+    def test_required_text_accepts_explicit_alternatives(self):
+        self.assertTrue(
+            run_live_qa._required_text_matches(
+                "fires every 5 minutes and watches slack for bug messages",
+                ["trigger|routine|automation|cron|schedule|fires|watches", "bug"],
+            )
+        )
+        self.assertFalse(
+            run_live_qa._required_text_matches(
+                "records bug messages in a sheet",
+                ["trigger|routine|automation|cron|schedule|fires|watches", "bug"],
+            )
+        )
+
     def test_slack_delivery_target_dm_detection(self):
         self.assertTrue(run_live_qa._slack_delivery_target_is_dm("D12345"))
         self.assertFalse(run_live_qa._slack_delivery_target_is_dm("C12345"))
@@ -676,7 +690,10 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
         self.assertEqual(captured_routine["case_name"], "qa_7c_slack_bug_logger_routine")
         self.assertIsNone(captured_routine["marker"])
         self.assertEqual(captured_routine["routine_name"], "reborn-qa-7c-slack-bug-sheet")
-        self.assertEqual(captured_routine["required_text"], ["trigger", "bug"])
+        self.assertEqual(
+            captured_routine["required_text"],
+            ["trigger|routine|automation|cron|schedule|fires|watches", "bug"],
+        )
         self.assertEqual(
             captured_routine["prompt"],
             run_live_qa._qa_sheet_prompt("qa_7c_slack_bug_logger_routine"),

--- a/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
+++ b/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
@@ -386,6 +386,24 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
                 ["trigger|routine|automation|cron|schedule|fires|watches", "bug"],
             )
         )
+        self.assertFalse(
+            run_live_qa._required_text_matches(
+                "fires every 5 minutes and watches slack for debug messages",
+                ["trigger|routine|automation|cron|schedule|fires|watches", "bug"],
+            )
+        )
+        self.assertFalse(
+            run_live_qa._required_text_matches(
+                "fires every 5 minutes and watches slack for bugfix messages",
+                ["trigger|routine|automation|cron|schedule|fires|watches", "bug"],
+            )
+        )
+        self.assertTrue(
+            run_live_qa._required_text_matches(
+                "fires every 5 minutes and watches slack for bug: messages",
+                ["trigger|routine|automation|cron|schedule|fires|watches", "bug"],
+            )
+        )
 
     def test_slack_delivery_target_dm_detection(self):
         self.assertTrue(run_live_qa._slack_delivery_target_is_dm("D12345"))


### PR DESCRIPTION
## Summary
- allow Reborn WebUI v2 live QA text gates to express explicit wording alternatives with `|`
- update QA 7C to accept routine/automation/cron/schedule/fires/watches wording while still requiring `bug`
- keep the trigger-record creation check unchanged, so the case still fails if no routine is persisted

## Why
QA 7C can legitimately report the created automation as "fires every 5 minutes" or "watches Slack" instead of literally saying "trigger". The latest `/canary all` failure showed the routine was described successfully but rejected by an overly literal text gate.

## Verification
- `python3 -m pytest scripts/reborn_webui_v2_live_qa/test_run_live_qa.py -q`
