### PR TITLE
Link failed Reborn QA cases to artifacts

### DIFF
--- a/scripts/live-canary/notify_slack.py
+++ b/scripts/live-canary/notify_slack.py
@@ -75,6 +75,7 @@ class RebornQaCaseReport:
     latency_ms: int | float | None = None
     message: str = ""
     tool_calls: list["RebornQaToolCall"] = field(default_factory=list)
+    debug_paths: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -351,6 +352,7 @@ def parse_reborn_qa_case_reports(lane_dir: Path, report: LaneReport) -> None:
                 manifest_by_case[case_data["case"]] = case_data
 
     cases: list[RebornQaCaseReport] = []
+    artifact_path_prefix = "/".join(lane_dir.parts[-3:])
     for entry in results:
         if not isinstance(entry, dict):
             continue
@@ -379,6 +381,14 @@ def parse_reborn_qa_case_reports(lane_dir: Path, report: LaneReport) -> None:
         )
         latency = entry.get("latency_ms")
         tool_calls = parse_reborn_trace_tool_calls(lane_dir / "traces" / f"{case}.json")
+        debug_paths = []
+        if not entry.get("success"):
+            debug_paths = [
+                f"{artifact_path_prefix}/results.json",
+                f"{artifact_path_prefix}/test-output.log",
+                f"{artifact_path_prefix}/traces/{case}.json",
+                f"{artifact_path_prefix}/traces/index.json",
+            ]
         cases.append(
             RebornQaCaseReport(
                 rows=row_tuple,
@@ -388,6 +398,7 @@ def parse_reborn_qa_case_reports(lane_dir: Path, report: LaneReport) -> None:
                 latency_ms=latency if isinstance(latency, (int, float)) else None,
                 message=_reborn_failure_message(entry),
                 tool_calls=tool_calls,
+                debug_paths=debug_paths,
             )
         )
     report.reborn_qa_cases = cases
@@ -608,7 +619,10 @@ def _format_reborn_tool_summary(cases: list[RebornQaCaseReport]) -> list[str]:
     return lines
 
 
-def _format_reborn_failure_lines(cases: list[RebornQaCaseReport]) -> list[str]:
+def _format_reborn_failure_lines(
+    cases: list[RebornQaCaseReport],
+    run_url: str | None,
+) -> list[str]:
     lines: list[str] = []
     for case in cases:
         if case.success:
@@ -616,10 +630,20 @@ def _format_reborn_failure_lines(cases: list[RebornQaCaseReport]) -> list[str]:
         rows = _qa_case_rows(case)
         message = case.message or "failed"
         lines.append(f"*Failure `{rows}`:* {message}")
+        if case.debug_paths:
+            paths = ", ".join(f"`{path}`" for path in case.debug_paths)
+            if run_url:
+                lines.append(f"*Debug `{rows}`:* <{run_url}|GitHub run artifacts> → {paths}")
+            else:
+                lines.append(f"*Debug `{rows}`:* artifacts → {paths}")
     return lines
 
 
-def _format_reborn_qa_group(group: str, cases: list[RebornQaCaseReport]) -> list[dict]:
+def _format_reborn_qa_group(
+    group: str,
+    cases: list[RebornQaCaseReport],
+    run_url: str | None = None,
+) -> list[dict]:
     passed = sum(1 for case in cases if case.success)
     failed = len(cases) - passed
     status = ":white_check_mark:" if failed == 0 else ":x:"
@@ -636,7 +660,7 @@ def _format_reborn_qa_group(group: str, cases: list[RebornQaCaseReport]) -> list
         f"{status} *QA {group}* — {passed}/{len(cases)} passed{duration}",
         f"*Cases:* {_trim_slack_text('; '.join(case_summaries), 900)}",
     ]
-    lines.extend(_format_reborn_failure_lines(cases))
+    lines.extend(_format_reborn_failure_lines(cases, run_url))
     lines.extend(_format_reborn_tool_summary(cases))
     blocks: list[dict] = []
     current: list[str] = []
@@ -669,13 +693,16 @@ def _format_reborn_qa_group(group: str, cases: list[RebornQaCaseReport]) -> list
     return blocks
 
 
-def _format_reborn_qa_groups(cases: list[RebornQaCaseReport]) -> list[dict]:
+def _format_reborn_qa_groups(
+    cases: list[RebornQaCaseReport],
+    run_url: str | None = None,
+) -> list[dict]:
     grouped: dict[str, list[RebornQaCaseReport]] = {}
     for case in cases:
         grouped.setdefault(_qa_group_key(case), []).append(case)
     blocks: list[dict] = []
     for group in sorted(grouped, key=_qa_group_sort_key):
-        blocks.extend(_format_reborn_qa_group(group, grouped[group]))
+        blocks.extend(_format_reborn_qa_group(group, grouped[group], run_url))
     return blocks
 
 
@@ -728,7 +755,7 @@ def slack_payload(
         blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": "\n".join(lines)}})
         if renders_reborn_qa_groups:
             remaining = max(0, SLACK_MAX_BLOCKS - len(blocks))
-            blocks.extend(_format_reborn_qa_groups(r.reborn_qa_cases)[:remaining])
+            blocks.extend(_format_reborn_qa_groups(r.reborn_qa_cases, run_url)[:remaining])
 
     # Cross-lane "Summary by Category" block — only emitted when there
     # are >=2 failures (with 1 the per-lane block is already enough).

--- a/scripts/live-canary/test_notify_slack.py
+++ b/scripts/live-canary/test_notify_slack.py
@@ -272,6 +272,16 @@ class RebornQaSlackReportTests(unittest.TestCase):
             report.reborn_qa_cases[1].message,
             "requires live Google runtime access",
         )
+        self.assertEqual(
+            report.reborn_qa_cases[1].debug_paths,
+            [
+                "reborn-webui-v2-live-qa/reborn-webui-v2/20260628T000000Z/results.json",
+                "reborn-webui-v2-live-qa/reborn-webui-v2/20260628T000000Z/test-output.log",
+                "reborn-webui-v2-live-qa/reborn-webui-v2/20260628T000000Z/traces/qa_2d_calendar_prep_live_chat.json",
+                "reborn-webui-v2-live-qa/reborn-webui-v2/20260628T000000Z/traces/index.json",
+            ],
+        )
+        self.assertEqual(report.reborn_qa_cases[0].debug_paths, [])
 
     def test_slack_payload_renders_each_reborn_qa_row(self):
         report = notify.LaneReport(
@@ -304,6 +314,12 @@ class RebornQaSlackReportTests(unittest.TestCase):
                     success=False,
                     latency_ms=0,
                     message="requires live Google runtime access",
+                    debug_paths=[
+                        "reborn-webui-v2-live-qa/reborn-webui-v2/20260628T000000Z/results.json",
+                        "reborn-webui-v2-live-qa/reborn-webui-v2/20260628T000000Z/test-output.log",
+                        "reborn-webui-v2-live-qa/reborn-webui-v2/20260628T000000Z/traces/qa_2d_calendar_prep_live_chat.json",
+                        "reborn-webui-v2-live-qa/reborn-webui-v2/20260628T000000Z/traces/index.json",
+                    ],
                     tool_calls=[
                         notify.RebornQaToolCall(
                             name="google-calendar.list_events",
@@ -326,7 +342,11 @@ class RebornQaSlackReportTests(unittest.TestCase):
             ],
         )
 
-        payload = notify.slack_payload([report], None, "abcdef0123456789")
+        payload = notify.slack_payload(
+            [report],
+            "https://github.com/nearai/ironclaw/actions/runs/123",
+            "abcdef0123456789",
+        )
         section_texts = [
             block["text"]["text"]
             for block in payload["blocks"]
@@ -354,10 +374,19 @@ class RebornQaSlackReportTests(unittest.TestCase):
             qa_text,
         )
         self.assertIn(
+            "*Debug `2D`:* <https://github.com/nearai/ironclaw/actions/runs/123|GitHub run artifacts> → "
+            "`reborn-webui-v2-live-qa/reborn-webui-v2/20260628T000000Z/results.json`, "
+            "`reborn-webui-v2-live-qa/reborn-webui-v2/20260628T000000Z/test-output.log`, "
+            "`reborn-webui-v2-live-qa/reborn-webui-v2/20260628T000000Z/traces/qa_2d_calendar_prep_live_chat.json`, "
+            "`reborn-webui-v2-live-qa/reborn-webui-v2/20260628T000000Z/traces/index.json`",
+            qa_text,
+        )
+        self.assertIn(
             "*Failure `2E`:* assistant returned success but routine scope "
             "'reborn-qa-2e-calendar-prep-email' did not add a trigger_record",
             qa_text,
         )
+        self.assertNotIn("*Debug `2A`", qa_text)
         self.assertIn("*Tools:* 2 calls across 2 tools", qa_text)
         self.assertNotIn("in#1234567890", qa_text)
         self.assertNotIn("out#9876543210", qa_text)


### PR DESCRIPTION
## Summary
- add failure-only debug artifact paths to Reborn WebUI v2 QA Slack case reports
- include the GitHub run artifact link plus exact `results.json`, `test-output.log`, case trace, and trace index paths for failed cases
- keep passing case Slack output unchanged

## Verification
- `python3 -m pytest scripts/live-canary/test_notify_slack.py -q`
- `python3 -m pytest scripts/reborn_webui_v2_live_qa/test_run_live_qa.py -q`
