### PR TITLE
ci(reborn): add cargo-llvm-cov integration-tier coverage job (T0-COV)

### DIFF
--- a/.github/workflows/reborn-coverage.yml
+++ b/.github/workflows/reborn-coverage.yml
@@ -4,9 +4,9 @@
 # (tests/reborn_integration_*.rs + tests/reborn_group_*/) and reports a
 # Reborn-crate-scoped line-coverage percentage in the PR's job summary.
 #
-# This is the measurable signal behind the "100% int-tier coverage" goal in
-# docs/reborn/reborn-backend-coverage-roadmap.md (task T0-COV): it yields a
-# per-PR percentage and a per-crate hole list. It is INFORMATIONAL only — it
+# This is the measurable signal behind the Reborn backend's "100% int-tier
+# coverage" goal (task T0-COV): it yields a per-PR percentage and a per-crate
+# hole list. It is INFORMATIONAL only — it
 # does not gate the PR on a coverage threshold.
 #
 # Scope notes:
@@ -33,7 +33,10 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: reborn-coverage-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  # PR number (not head_ref) for pull_request: two fork PRs can share a branch
+  # name (main/fix/…), and head_ref grouping + cancel-in-progress would let one
+  # cancel the other's run. number is null off-PR, so fall back to github.ref.
+  group: reborn-coverage-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/reborn-coverage.yml
+++ b/.github/workflows/reborn-coverage.yml
@@ -48,10 +48,11 @@ jobs:
   reborn-coverage:
     name: Reborn Coverage
     runs-on: ubuntu-latest
-    # No explicit timeout: a cold-cache instrumented build of the Reborn closure
-    # is heavy, so inherit GitHub's 360-minute default — matching the analogous
-    # full-workspace instrumented `coverage` job in coverage.yml, which also runs
-    # `cargo llvm-cov --workspace` without mold and without a tighter timeout.
+    # Generous backstop, not a tight bound: a cold-cache instrumented build of
+    # the Reborn closure is heavy (no mold), so this only catches a runaway/hung
+    # run — it sits well above any real build yet halves GitHub's 360-minute
+    # default, which would otherwise tie up a runner for hours.
+    timeout-minutes: 180
     env:
       # Reborn suites must not reach a live LLM (mirrors reborn-tests.yml).
       ANTHROPIC_API_KEY: ""

--- a/.github/workflows/reborn-coverage.yml
+++ b/.github/workflows/reborn-coverage.yml
@@ -1,0 +1,118 @@
+# Reborn integration-tier coverage
+#
+# Runs cargo-llvm-cov over the Reborn in-process integration-tier test binaries
+# (tests/reborn_integration_*.rs + tests/reborn_group_*/) and reports a
+# Reborn-crate-scoped line-coverage percentage in the PR's job summary.
+#
+# This is the measurable signal behind the "100% int-tier coverage" goal in
+# docs/reborn/reborn-backend-coverage-roadmap.md (task T0-COV): it yields a
+# per-PR percentage and a per-crate hole list. It is INFORMATIONAL only — it
+# does not gate the PR on a coverage threshold.
+#
+# Scope notes:
+# - Features: default (postgres + libsql + html-to-markdown + tui), matching
+#   how scripts/ci/run-reborn-root-partition.sh runs these same suites. No live
+#   Postgres is needed; the suites skip Postgres backends when DATABASE_URL is
+#   unset (backend_matrix stays libsql-only per the roadmap).
+# - The % is filtered to the Reborn crate families (crates/ironclaw_reborn*,
+#   ironclaw_product*, ironclaw_architecture, the v2 channel adapters,
+#   ironclaw_webui_v2*) via scripts/ci/reborn-coverage-summary.sh.
+
+name: Reborn Coverage
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: reborn-coverage-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+env:
+  # Tests must never touch the real OS keychain (see reborn-tests.yml).
+  IRONCLAW_DISABLE_OS_KEYCHAIN: "1"
+  CARGO_PROFILE_DEV_DEBUG: 0
+  CARGO_PROFILE_TEST_DEBUG: 0
+  # Keep instrumented build/runtime disk and time bounded.
+  CARGO_INCREMENTAL: "0"
+
+jobs:
+  reborn-coverage:
+    name: Reborn Coverage
+    runs-on: ubuntu-latest
+    # No explicit timeout: a cold-cache instrumented build of the Reborn closure
+    # is heavy, so inherit GitHub's 360-minute default — matching the analogous
+    # full-workspace instrumented `coverage` job in coverage.yml, which also runs
+    # `cargo llvm-cov --workspace` without mold and without a tighter timeout.
+    env:
+      # Reborn suites must not reach a live LLM (mirrors reborn-tests.yml).
+      ANTHROPIC_API_KEY: ""
+      LLM_BACKEND: ""
+      LLM_USE_CODEX_AUTH: "false"
+      OLLAMA_BASE_URL: ""
+      OPENAI_API_KEY: ""
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Free runner disk space
+        run: |
+          df -h /
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/.ghcup /usr/local/share/boost /opt/hostedtoolcache/CodeQL || true
+          docker system prune -af || true
+          df -h /
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          components: llvm-tools-preview
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          key: reborn-coverage
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@62b0f2dec647a8e604c6a0fda0e38530180dce20 # cargo-llvm-cov
+
+      - name: Generate Reborn integration-tier coverage
+        run: |
+          set -euo pipefail
+          # Process substitution hides the discovery script's exit code, so
+          # guard the array explicitly (mirrors run-reborn-root-partition.sh).
+          mapfile -t test_args < <(scripts/ci/reborn-coverage-int-tier-tests.sh)
+          if [ "${#test_args[@]}" -eq 0 ]; then
+            echo "No Reborn integration-tier test arguments discovered" >&2
+            exit 1
+          fi
+          echo "Running coverage over Reborn int-tier binaries:"
+          printf '  %s %s\n' "${test_args[@]}"
+
+          cargo llvm-cov clean --workspace
+          # Combined run+report in ONE invocation: --workspace scopes the report
+          # to every member crate (incl. the linked-but-not-root Reborn crates),
+          # which the standalone `report` subcommand cannot do. The named root
+          # `--test` targets still run only in the root package. Default features,
+          # matching scripts/ci/run-reborn-root-partition.sh.
+          cargo llvm-cov --workspace "${test_args[@]}" \
+            --json --output-path reborn-llvm-cov.json -- --nocapture
+
+      - name: Render Reborn coverage summary
+        run: |
+          set -euo pipefail
+          scripts/ci/reborn-coverage-summary.sh reborn-llvm-cov.json | tee -a "$GITHUB_STEP_SUMMARY"
+
+      # The JSON export is the full per-file detail behind the summary table —
+      # the "real hole list" — kept as an artifact for offline inspection.
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: reborn-coverage
+          path: reborn-llvm-cov.json
+          if-no-files-found: warn

--- a/.github/workflows/reborn-coverage.yml
+++ b/.github/workflows/reborn-coverage.yml
@@ -29,6 +29,8 @@ on:
 
 permissions:
   contents: read
+  # The sticky coverage comment upserts a PR comment via the issues API.
+  pull-requests: write
 
 concurrency:
   group: reborn-coverage-${{ github.event_name }}-${{ github.head_ref || github.ref }}
@@ -106,6 +108,18 @@ jobs:
         run: |
           set -euo pipefail
           scripts/ci/reborn-coverage-summary.sh reborn-llvm-cov.json | tee -a "$GITHUB_STEP_SUMMARY"
+
+      # Surface the same %/hole-list as a sticky PR comment so it lives in the
+      # conversation, not just the job summary. PR-only, and non-fatal by design:
+      # fork PRs get a read-only GITHUB_TOKEN and the comment API 403s, which must
+      # never red the check. This is visibility, never a gate.
+      - name: Post sticky coverage comment
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: scripts/ci/reborn-coverage-comment.sh reborn-llvm-cov.json
 
       # The JSON export is the full per-file detail behind the summary table —
       # the "real hole list" — kept as an artifact for offline inspection.

--- a/.github/workflows/reborn-coverage.yml
+++ b/.github/workflows/reborn-coverage.yml
@@ -78,6 +78,11 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: reborn-coverage
+          # Instrumented target dirs are multi-GB. Only save on main so the ~10 GB
+          # repo cache LRU holds ONE shared, main-seeded instrumented cache that
+          # every PR restores — instead of each PR writing a branch-scoped copy
+          # (invisible to other PRs) that evicts the useful seed.
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@62b0f2dec647a8e604c6a0fda0e38530180dce20 # cargo-llvm-cov

--- a/scripts/ci/reborn-coverage-comment.sh
+++ b/scripts/ci/reborn-coverage-comment.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+#
+# Upsert a single sticky PR comment carrying the Reborn integration-tier
+# coverage summary, so the %/hole-list lives in the PR conversation instead of
+# being buried in the Actions job summary.
+#
+# This is VISIBILITY ONLY — it never gates. The workflow step that runs it is
+# `continue-on-error: true`, so any failure here (notably: fork PRs get a
+# read-only GITHUB_TOKEN and the comment API 403s) must never red the check.
+#
+# The comment body reuses reborn-coverage-summary.sh (the %, table and hole list
+# are computed there, once — it is the single owner of the crate aggregation)
+# and prepends:
+#   1. a hidden marker line so re-runs edit the same comment in place, and
+#   2. a breadth callout counting Reborn crates with instrumented-but-uncovered
+#      lines, also sourced from that script (--zero-crates). The callout is
+#      informational too — the "target: 0" is the roadmap goal, not a check that
+#      can fail.
+#
+# Usage: reborn-coverage-comment.sh <llvm-cov-json-export>
+#
+# Requires env: GH_TOKEN (for gh), GITHUB_REPOSITORY, PR_NUMBER.
+
+set -euo pipefail
+
+json_path="${1:?usage: reborn-coverage-comment.sh <llvm-cov-json-export>}"
+
+if [ ! -f "${json_path}" ]; then
+  echo "coverage JSON not found: ${json_path}" >&2
+  exit 1
+fi
+
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY must be set}"
+: "${PR_NUMBER:?PR_NUMBER must be set}"
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+summary_sh="${script_dir}/reborn-coverage-summary.sh"
+
+marker='<!-- reborn-coverage-sticky -->'
+
+# Reuse the canonical summary renderer for the body and the breadth holes — no
+# duplicated %/table/aggregation jq lives here.
+summary_body="$("${summary_sh}" "${json_path}")"
+mapfile -t zero_crates < <("${summary_sh}" --zero-crates "${json_path}")
+
+callout=""
+if [ "${#zero_crates[@]}" -gt 0 ]; then
+  # Crate names are constrained to [a-z0-9_]+, so a plain ", " join is safe.
+  crate_list="$(printf '%s, ' "${zero_crates[@]}")"
+  crate_list="${crate_list%, }"
+  callout="⚠️ ${#zero_crates[@]} Reborn crate(s) have 0 int-tier coverage (target: 0) — ${crate_list}"
+fi
+
+if [ -n "${callout}" ]; then
+  body="$(printf '%s\n\n%s\n\n%s' "${marker}" "${callout}" "${summary_body}")"
+else
+  body="$(printf '%s\n\n%s' "${marker}" "${summary_body}")"
+fi
+
+# Upsert: find an existing sticky comment (marker is the first body line) and
+# PATCH it; otherwise POST a new one. Pure `gh api`, no extra action dependency.
+#
+# --paginate: the comment thread can exceed one page (30) on a busy PR, and the
+# sticky may have aged off page 1 — without it the lookup misses and we POST a
+# duplicate every run. The marker is passed via the environment (env.STICKY_*)
+# rather than interpolated into the jq program. Capture the ids first, then take
+# the first: piping `gh --paginate` straight into `head` would SIGPIPE gh mid-
+# stream and, under `pipefail`, fail the pipeline.
+existing_ids="$(STICKY_MARKER="${marker}" gh api --paginate \
+  "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+  --jq '.[] | select(.body | startswith(env.STICKY_MARKER)) | .id')"
+existing="$(printf '%s\n' "${existing_ids}" | head -n1)"
+
+if [ -n "${existing}" ]; then
+  gh api -X PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${existing}" -f body="${body}"
+else
+  gh api -X POST "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" -f body="${body}"
+fi

--- a/scripts/ci/reborn-coverage-comment.sh
+++ b/scripts/ci/reborn-coverage-comment.sh
@@ -32,6 +32,7 @@ fi
 
 : "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY must be set}"
 : "${PR_NUMBER:?PR_NUMBER must be set}"
+: "${GH_TOKEN:?GH_TOKEN must be set — gh api needs it (the workflow passes github.token)}"
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 summary_sh="${script_dir}/reborn-coverage-summary.sh"

--- a/scripts/ci/reborn-coverage-int-tier-tests.sh
+++ b/scripts/ci/reborn-coverage-int-tier-tests.sh
@@ -3,8 +3,7 @@
 # Print the cargo `--test <name>` arguments for the Reborn in-process
 # integration-tier test binaries, one per line.
 #
-# Integration-tier is defined (docs/reborn/reborn-backend-coverage-roadmap.md)
-# as the in-process suites:
+# Integration-tier (task T0-COV) is the set of in-process suites:
 #   - tests/reborn_integration_*.rs        (single-file root test binaries)
 #   - tests/reborn_group_*/                ([[test]] binaries; name == dir name)
 #

--- a/scripts/ci/reborn-coverage-int-tier-tests.sh
+++ b/scripts/ci/reborn-coverage-int-tier-tests.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#
+# Print the cargo `--test <name>` arguments for the Reborn in-process
+# integration-tier test binaries, one per line.
+#
+# Integration-tier is defined (docs/reborn/reborn-backend-coverage-roadmap.md)
+# as the in-process suites:
+#   - tests/reborn_integration_*.rs        (single-file root test binaries)
+#   - tests/reborn_group_*/                ([[test]] binaries; name == dir name)
+#
+# Discovery is dynamic so coverage automatically picks up new int-tier suites
+# as they land (mirrors scripts/ci/run-reborn-root-partition.sh).
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${repo_root}"
+
+mapfile -t names < <(
+  {
+    find tests -maxdepth 1 -type f -name 'reborn_integration_*.rs' \
+      | sed -E 's#^tests/##; s#\.rs$##'
+    find tests -maxdepth 1 -type d -name 'reborn_group_*' \
+      | sed -E 's#^tests/##'
+  } | LC_ALL=C sort -u
+)
+
+if [ "${#names[@]}" -eq 0 ]; then
+  echo "No Reborn integration-tier test binaries discovered" >&2
+  exit 1
+fi
+
+for name in "${names[@]}"; do
+  printf -- '--test\n%s\n' "${name}"
+done

--- a/scripts/ci/reborn-coverage-summary.sh
+++ b/scripts/ci/reborn-coverage-summary.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+#
+# Render a Reborn-scoped coverage summary from a cargo-llvm-cov JSON export.
+#
+# cargo-llvm-cov instruments the whole workspace build, so a run over the
+# Reborn integration-tier test binaries produces coverage for every linked
+# crate. This script filters that export down to the Reborn crate families and
+# computes an aggregate line-coverage percentage plus a per-crate breakdown
+# (the "hole list" — which Reborn crates are least covered).
+#
+# Usage: reborn-coverage-summary.sh <llvm-cov-json-export>
+#
+# Writes a GitHub-flavored Markdown report to stdout. The caller is responsible
+# for redirecting it into "$GITHUB_STEP_SUMMARY" (or anywhere else).
+#
+# The Reborn crate families mirror the package allowlist in
+# .github/workflows/reborn-tests.yml: ironclaw_reborn*, ironclaw_product*,
+# ironclaw_architecture, the v2 channel adapters, and ironclaw_webui_v2*.
+
+set -euo pipefail
+
+json_path="${1:?usage: reborn-coverage-summary.sh <llvm-cov-json-export>}"
+
+if [ ! -f "${json_path}" ]; then
+  echo "coverage JSON not found: ${json_path}" >&2
+  exit 1
+fi
+
+# Matches the absolute filenames llvm-cov emits, e.g.
+# /work/ironclaw/crates/ironclaw_reborn/src/runtime.rs
+#
+# Mirrors the Reborn crate allowlist in .github/workflows/reborn-tests.yml:
+# prefix-match for the reborn_*/product_*/webui_v2_* families, exact-match
+# (no trailing name chars before the "/") for the four single crates. The
+# trailing "/" anchors the crate-name boundary in all cases.
+reborn_regex='/crates/(ironclaw_(reborn|product|webui_v2)[a-z0-9_]*|ironclaw_architecture|ironclaw_slack_v2_adapter|ironclaw_telegram_v2_adapter|ironclaw_wasm_product_adapters)/'
+
+jq -r --arg re "${reborn_regex}" '
+  # Round to 2 decimal places.
+  def round2: . * 100 | round / 100;
+
+  # All instrumented files that belong to a Reborn crate family. The "?" and
+  # "// []" route an empty/missing "data" array (no coverage produced) through
+  # the $total == 0 branch below instead of crashing on a null iteration.
+  [ (.data[0]?.files // [])[]
+    | select(.filename | test($re))
+    | { crate: (.filename | capture("/crates/(?<c>ironclaw_[a-z0-9_]+)/").c),
+        covered: .summary.lines.covered,
+        count: .summary.lines.count }
+  ] as $files
+
+  | ($files | map(.count)   | add // 0) as $total
+  | ($files | map(.covered) | add // 0) as $hit
+  | (if $total > 0 then ($hit / $total * 100) else 0 end) as $pct
+
+  | ($files
+      | group_by(.crate)
+      | map({ crate: .[0].crate,
+              covered: (map(.covered) | add // 0),
+              count:   (map(.count)   | add // 0) })
+      | map(. + { pct: (if .count > 0 then (.covered / .count * 100) else 0 end) })
+      | sort_by(.pct)
+    ) as $byCrate
+
+  | "## Reborn integration-tier coverage",
+    "",
+    (if $total > 0
+     then "**Line coverage (Reborn crates): \($pct | round2)%** — \($hit) / \($total) lines"
+     else "**No Reborn crate coverage data found** (0 instrumented lines matched the Reborn crate filter)."
+     end),
+    "",
+    (if $total > 0
+     then ( "| Crate | Line % | Covered / Total |",
+            "|---|---:|---:|",
+            ( $byCrate[]
+              | "| `\(.crate)` | \(.pct | round2)% | \(.covered) / \(.count) |" ),
+            "",
+            "_Lowest-covered crates first. This signal is informational; it does not gate the PR._"
+          )
+     else empty
+     end)
+' "${json_path}"

--- a/scripts/ci/reborn-coverage-summary.sh
+++ b/scripts/ci/reborn-coverage-summary.sh
@@ -50,10 +50,12 @@ jq -r --arg re "${reborn_regex}" --arg mode "${mode}" '
   # Round to 2 decimal places.
   def round2: . * 100 | round / 100;
 
-  # All instrumented files that belong to a Reborn crate family. The "?" and
-  # "// []" route an empty/missing "data" array (no coverage produced) through
-  # the $total == 0 branch below instead of crashing on a null iteration.
-  [ (.data[0]?.files // [])[]
+  # All instrumented files that belong to a Reborn crate family. llvm-cov nests
+  # files under data[]; iterate every dataset (a single `cargo llvm-cov --json`
+  # emits one, but the export format permits several) so no coverage is dropped.
+  # The trailing "?"s swallow a missing/empty data or files, routing no-coverage
+  # runs through the $total == 0 branch below instead of erroring.
+  [ (.data[]?.files[]?)
     | select(.filename | test($re))
     | { crate: (.filename | capture("/crates/(?<c>ironclaw_[a-z0-9_]+)/").c),
         covered: .summary.lines.covered,

--- a/scripts/ci/reborn-coverage-summary.sh
+++ b/scripts/ci/reborn-coverage-summary.sh
@@ -8,10 +8,15 @@
 # computes an aggregate line-coverage percentage plus a per-crate breakdown
 # (the "hole list" — which Reborn crates are least covered).
 #
-# Usage: reborn-coverage-summary.sh <llvm-cov-json-export>
-#
-# Writes a GitHub-flavored Markdown report to stdout. The caller is responsible
-# for redirecting it into "$GITHUB_STEP_SUMMARY" (or anywhere else).
+# Usage:
+#   reborn-coverage-summary.sh <llvm-cov-json-export>
+#     Writes a GitHub-flavored Markdown report to stdout. The caller redirects
+#     it into "$GITHUB_STEP_SUMMARY" (or anywhere else).
+#   reborn-coverage-summary.sh --zero-crates <llvm-cov-json-export>
+#     Writes, one per line, the Reborn crates that have instrumented lines but
+#     zero of them covered (the "breadth" holes). Same crate filter and
+#     aggregation as the report — this script is the single owner of that
+#     computation so reborn-coverage-comment.sh never has to recompute it.
 #
 # The Reborn crate families mirror the package allowlist in
 # .github/workflows/reborn-tests.yml: ironclaw_reborn*, ironclaw_product*,
@@ -19,7 +24,13 @@
 
 set -euo pipefail
 
-json_path="${1:?usage: reborn-coverage-summary.sh <llvm-cov-json-export>}"
+mode="report"
+if [ "${1:-}" = "--zero-crates" ]; then
+  mode="zero-crates"
+  shift
+fi
+
+json_path="${1:?usage: reborn-coverage-summary.sh [--zero-crates] <llvm-cov-json-export>}"
 
 if [ ! -f "${json_path}" ]; then
   echo "coverage JSON not found: ${json_path}" >&2
@@ -35,7 +46,7 @@ fi
 # trailing "/" anchors the crate-name boundary in all cases.
 reborn_regex='/crates/(ironclaw_(reborn|product|webui_v2)[a-z0-9_]*|ironclaw_architecture|ironclaw_slack_v2_adapter|ironclaw_telegram_v2_adapter|ironclaw_wasm_product_adapters)/'
 
-jq -r --arg re "${reborn_regex}" '
+jq -r --arg re "${reborn_regex}" --arg mode "${mode}" '
   # Round to 2 decimal places.
   def round2: . * 100 | round / 100;
 
@@ -62,21 +73,31 @@ jq -r --arg re "${reborn_regex}" '
       | sort_by(.pct)
     ) as $byCrate
 
-  | "## Reborn integration-tier coverage",
-    "",
-    (if $total > 0
-     then "**Line coverage (Reborn crates): \($pct | round2)%** — \($hit) / \($total) lines"
-     else "**No Reborn crate coverage data found** (0 instrumented lines matched the Reborn crate filter)."
-     end),
-    "",
-    (if $total > 0
-     then ( "| Crate | Line % | Covered / Total |",
-            "|---|---:|---:|",
-            ( $byCrate[]
-              | "| `\(.crate)` | \(.pct | round2)% | \(.covered) / \(.count) |" ),
-            "",
-            "_Lowest-covered crates first. This signal is informational; it does not gate the PR._"
-          )
-     else empty
-     end)
+  # --zero-crates: just the breadth holes (crates instrumented but 0% covered),
+  # one crate name per line, sorted. The Markdown report is the default mode.
+  | if $mode == "zero-crates"
+    then ( $byCrate[] | select(.count > 0 and .covered == 0) | .crate )
+    else
+      "## Reborn integration-tier coverage",
+      "",
+      (if $total > 0
+       then "**Line coverage (Reborn crates): \($pct | round2)%** — \($hit) / \($total) lines"
+       else "**No Reborn crate coverage data found** (0 instrumented lines matched the Reborn crate filter)."
+       end),
+      "",
+      (if $total > 0
+       then ( "<details><summary>Per-crate breakdown (\($byCrate | length) crates, lowest-covered first)</summary>",
+              "",
+              "| Crate | Line % | Covered / Total |",
+              "|---|---:|---:|",
+              ( $byCrate[]
+                | "| `\(.crate)` | \(.pct | round2)% | \(.covered) / \(.count) |" ),
+              "",
+              "</details>",
+              "",
+              "_This signal is informational: coverage never gates the PR — not the percentage, not the per-crate holes, not the 0-coverage callout._"
+            )
+       else empty
+       end)
+    end
 ' "${json_path}"

--- a/scripts/ci/test-reborn-coverage.sh
+++ b/scripts/ci/test-reborn-coverage.sh
@@ -1,0 +1,499 @@
+#!/usr/bin/env bash
+#
+# Regression tests for the three Reborn coverage CI helpers:
+#   - reborn-coverage-summary.sh        (report + --zero-crates modes)
+#   - reborn-coverage-comment.sh        (sticky PR comment upsert via `gh api`)
+#   - reborn-coverage-int-tier-tests.sh (int-tier suite discovery)
+#
+# Mirrors test-classify-test-scope.sh: self-contained, locates the
+# scripts-under-test relative to this file's own directory, builds its own
+# fixtures in a mktemp dir, and reports PASS/FAIL per case. Unlike that
+# precedent (which exits on the first failure), this suite runs every case
+# and prints a final summary, exiting non-zero only if something failed —
+# with three scripts and ~20 cases, seeing the full picture in one run beats
+# stopping at the first mismatch.
+#
+# reborn-coverage-comment.sh shells out to `gh api`. It is exercised here
+# against a fake `gh` (a fixture script placed first on PATH) that emulates
+# `gh api --paginate <path> --jq '<filter>'` by running the given jq filter
+# over a canned comments JSON array, and records the verb/path/body of any
+# mutating call (-X POST / -X PATCH) to a log file this suite inspects.
+#
+# reborn-coverage-int-tier-tests.sh derives its repo root from its own path
+# (`$(dirname BASH_SOURCE)/../..`) and `cd`s there, so it cannot simply be
+# pointed at a fixture tree via an argument. Each case here copies the real
+# script into a temp tree's scripts/ci/ and builds a tests/ subtree next to
+# it, so the copy's own repo-root resolution lands on the temp tree.
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+summary_sh="${script_dir}/reborn-coverage-summary.sh"
+comment_sh="${script_dir}/reborn-coverage-comment.sh"
+int_tier_sh="${script_dir}/reborn-coverage-int-tier-tests.sh"
+
+tmp_root="$(mktemp -d)"
+trap 'rm -rf "${tmp_root}"' EXIT
+
+fixtures_dir="${tmp_root}/fixtures"
+mkdir -p "${fixtures_dir}"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+report_pass() {
+  PASS_COUNT=$((PASS_COUNT + 1))
+  printf 'PASS %s\n' "$1"
+}
+
+report_fail() {
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+  printf 'FAIL %s\n' "$1" >&2
+}
+
+assert_eq() {
+  local name="$1" expected="$2" actual="$3"
+  if [ "${actual}" = "${expected}" ]; then
+    report_pass "${name}"
+  else
+    report_fail "${name}"
+    printf 'Expected:\n%s\n' "${expected}" >&2
+    printf 'Actual:\n%s\n' "${actual}" >&2
+  fi
+}
+
+assert_exit_code() {
+  local name="$1" expected="$2" actual="$3"
+  if [ "${actual}" -eq "${expected}" ]; then
+    report_pass "${name}"
+  else
+    report_fail "${name}"
+    printf 'Expected exit code %s, got %s\n' "${expected}" "${actual}" >&2
+  fi
+}
+
+assert_contains() {
+  local name="$1" haystack="$2" needle="$3"
+  if [[ "${haystack}" == *"${needle}"* ]]; then
+    report_pass "${name}"
+  else
+    report_fail "${name}"
+    printf 'Expected to contain:\n%s\n' "${needle}" >&2
+    printf 'Actual:\n%s\n' "${haystack}" >&2
+  fi
+}
+
+assert_not_contains() {
+  local name="$1" haystack="$2" needle="$3"
+  if [[ "${haystack}" != *"${needle}"* ]]; then
+    report_pass "${name}"
+  else
+    report_fail "${name}"
+    printf 'Expected NOT to contain:\n%s\n' "${needle}" >&2
+    printf 'Actual:\n%s\n' "${haystack}" >&2
+  fi
+}
+
+# Asserts needle_a's first occurrence is on an earlier line than needle_b's
+# first occurrence within haystack (both must be present).
+assert_line_before() {
+  local name="$1" haystack="$2" needle_a="$3" needle_b="$4"
+  local line_a line_b
+  line_a="$(printf '%s\n' "${haystack}" | grep -n -F -- "${needle_a}" | head -n1 | cut -d: -f1)"
+  line_b="$(printf '%s\n' "${haystack}" | grep -n -F -- "${needle_b}" | head -n1 | cut -d: -f1)"
+  if [ -n "${line_a}" ] && [ -n "${line_b}" ] && [ "${line_a}" -lt "${line_b}" ]; then
+    report_pass "${name}"
+  else
+    report_fail "${name}"
+    printf 'line_a=%s line_b=%s\n' "${line_a:-<missing>}" "${line_b:-<missing>}" >&2
+  fi
+}
+
+# Runs "$@", capturing stdout/stderr/exit code into CAP_OUT/CAP_ERR/CAP_RC
+# without tripping this script's own `set -e` on a non-zero exit.
+CAP_OUT=""
+CAP_ERR=""
+CAP_RC=0
+capture() {
+  local err_file out rc
+  err_file="$(mktemp "${tmp_root}/capture.XXXXXX")"
+  set +e
+  out="$("$@" 2>"${err_file}")"
+  rc=$?
+  set -e
+  CAP_OUT="${out}"
+  CAP_ERR="$(cat "${err_file}")"
+  CAP_RC="${rc}"
+  rm -f "${err_file}"
+}
+
+# ---------------------------------------------------------------------------
+# A. reborn-coverage-summary.sh (default report mode)
+# ---------------------------------------------------------------------------
+
+cat > "${fixtures_dir}/a1_mixed.json" <<'JSON'
+{
+  "data": [
+    {
+      "files": [
+        { "filename": "/work/ironclaw/crates/ironclaw_reborn/src/runtime.rs", "summary": { "lines": { "covered": 80, "count": 100 } } },
+        { "filename": "/work/ironclaw/crates/ironclaw_product_workflow/src/lib.rs", "summary": { "lines": { "covered": 50, "count": 50 } } },
+        { "filename": "/work/ironclaw/crates/ironclaw_engine/src/lib.rs", "summary": { "lines": { "covered": 10, "count": 10 } } }
+      ]
+    }
+  ]
+}
+JSON
+
+capture "${summary_sh}" "${fixtures_dir}/a1_mixed.json"
+assert_exit_code "A1: summary exits 0 for mixed Reborn/non-Reborn fixture" 0 "${CAP_RC}"
+assert_not_contains "A1: non-Reborn crate excluded from output" "${CAP_OUT}" "ironclaw_engine"
+assert_contains "A1: aggregate matches hand-computed 86.67% (130/150)" "${CAP_OUT}" \
+  '**Line coverage (Reborn crates): 86.67%** — 130 / 150 lines'
+assert_contains "A1: table includes ironclaw_reborn row" "${CAP_OUT}" "| \`ironclaw_reborn\` | 80% | 80 / 100 |"
+assert_contains "A1: table includes ironclaw_product_workflow row" "${CAP_OUT}" \
+  "| \`ironclaw_product_workflow\` | 100% | 50 / 50 |"
+
+cat > "${fixtures_dir}/a2_non_reborn_only.json" <<'JSON'
+{
+  "data": [
+    { "files": [ { "filename": "/work/ironclaw/crates/ironclaw_engine/src/lib.rs", "summary": { "lines": { "covered": 10, "count": 10 } } } ] }
+  ]
+}
+JSON
+
+capture "${summary_sh}" "${fixtures_dir}/a2_non_reborn_only.json"
+assert_exit_code "A2: summary exits 0 when only non-Reborn crates present" 0 "${CAP_RC}"
+assert_contains "A2: prints no-data message when no Reborn files match" "${CAP_OUT}" \
+  "No Reborn crate coverage data found"
+
+printf '{"data":[]}' > "${fixtures_dir}/a3_empty_data.json"
+printf '{}' > "${fixtures_dir}/a3_absent_data.json"
+
+capture "${summary_sh}" "${fixtures_dir}/a3_empty_data.json"
+assert_exit_code 'A3: {"data":[]} exits 0' 0 "${CAP_RC}"
+assert_contains 'A3: {"data":[]} prints no-data message' "${CAP_OUT}" "No Reborn crate coverage data found"
+
+capture "${summary_sh}" "${fixtures_dir}/a3_absent_data.json"
+assert_exit_code 'A3: {} exits 0' 0 "${CAP_RC}"
+assert_contains 'A3: {} prints no-data message' "${CAP_OUT}" "No Reborn crate coverage data found"
+
+cat > "${fixtures_dir}/a4_multi_dataset.json" <<'JSON'
+{
+  "data": [
+    { "files": [ { "filename": "/work/ironclaw/crates/ironclaw_reborn/src/a.rs", "summary": { "lines": { "covered": 10, "count": 20 } } } ] },
+    { "files": [ { "filename": "/work/ironclaw/crates/ironclaw_reborn_cli/src/main.rs", "summary": { "lines": { "covered": 5, "count": 5 } } } ] }
+  ]
+}
+JSON
+
+capture "${summary_sh}" "${fixtures_dir}/a4_multi_dataset.json"
+assert_exit_code "A4: multi-dataset summary exits 0" 0 "${CAP_RC}"
+assert_contains "A4: aggregate counts files from BOTH data[] entries (15/25)" "${CAP_OUT}" \
+  '**Line coverage (Reborn crates): 60%** — 15 / 25 lines'
+assert_contains "A4: includes crate from data[0]" "${CAP_OUT}" "\`ironclaw_reborn\`"
+assert_contains "A4: includes crate from data[1]" "${CAP_OUT}" "\`ironclaw_reborn_cli\`"
+
+cat > "${fixtures_dir}/a5_zero_sorted.json" <<'JSON'
+{
+  "data": [
+    {
+      "files": [
+        { "filename": "/work/ironclaw/crates/ironclaw_reborn_zero/src/a.rs", "summary": { "lines": { "covered": 0, "count": 10 } } },
+        { "filename": "/work/ironclaw/crates/ironclaw_reborn_half/src/a.rs", "summary": { "lines": { "covered": 5, "count": 10 } } }
+      ]
+    }
+  ]
+}
+JSON
+
+capture "${summary_sh}" "${fixtures_dir}/a5_zero_sorted.json"
+assert_exit_code "A5: zero-covered-crate fixture summary exits 0" 0 "${CAP_RC}"
+assert_contains "A5: zero-covered crate row shows 0%" "${CAP_OUT}" "| \`ironclaw_reborn_zero\` | 0% | 0 / 10 |"
+assert_line_before "A5: zero-covered crate sorted to top (lowest-covered first)" "${CAP_OUT}" \
+  "\`ironclaw_reborn_zero\`" "\`ironclaw_reborn_half\`"
+
+# ---------------------------------------------------------------------------
+# B. reborn-coverage-summary.sh --zero-crates
+# ---------------------------------------------------------------------------
+
+cat > "${fixtures_dir}/b1_mixed_zero.json" <<'JSON'
+{
+  "data": [
+    {
+      "files": [
+        { "filename": "/work/ironclaw/crates/ironclaw_reborn_zero_a/src/a.rs", "summary": { "lines": { "covered": 0, "count": 5 } } },
+        { "filename": "/work/ironclaw/crates/ironclaw_reborn_zero_b/src/a.rs", "summary": { "lines": { "covered": 0, "count": 3 } } },
+        { "filename": "/work/ironclaw/crates/ironclaw_reborn_partial/src/a.rs", "summary": { "lines": { "covered": 4, "count": 10 } } },
+        { "filename": "/work/ironclaw/crates/ironclaw_reborn_full/src/a.rs", "summary": { "lines": { "covered": 10, "count": 10 } } }
+      ]
+    }
+  ]
+}
+JSON
+
+capture "${summary_sh}" --zero-crates "${fixtures_dir}/b1_mixed_zero.json"
+assert_exit_code "B1: --zero-crates exits 0" 0 "${CAP_RC}"
+assert_eq "B1: --zero-crates emits exactly the 2 zero-covered crate names" \
+  "$(printf 'ironclaw_reborn_zero_a\nironclaw_reborn_zero_b')" "${CAP_OUT}"
+
+cat > "${fixtures_dir}/b2_all_covered.json" <<'JSON'
+{
+  "data": [
+    { "files": [ { "filename": "/work/ironclaw/crates/ironclaw_reborn_full/src/a.rs", "summary": { "lines": { "covered": 10, "count": 10 } } } ] }
+  ]
+}
+JSON
+
+capture "${summary_sh}" --zero-crates "${fixtures_dir}/b2_all_covered.json"
+assert_exit_code "B2: all-covered fixture --zero-crates exits 0" 0 "${CAP_RC}"
+assert_eq "B2: all-covered fixture --zero-crates emits nothing" "" "${CAP_OUT}"
+
+capture "${summary_sh}" --zero-crates "${fixtures_dir}/a3_empty_data.json"
+assert_exit_code "B3: empty data --zero-crates exits 0" 0 "${CAP_RC}"
+assert_eq "B3: empty data --zero-crates emits nothing" "" "${CAP_OUT}"
+
+# ---------------------------------------------------------------------------
+# C. reborn-coverage-comment.sh (sticky PR comment upsert via a fake `gh`)
+# ---------------------------------------------------------------------------
+
+gh_bin_dir="${tmp_root}/bin"
+mkdir -p "${gh_bin_dir}"
+
+# Emulates `gh api [--paginate] <path> [--jq <filter>]` (read path: runs the
+# jq filter over the canned comments JSON, exercising env.STICKY_MARKER) and
+# `gh api -X POST|PATCH <path> -f body=<value>` (mutation path: records
+# verb + path + body to FAKE_GH_LOG instead of calling the network).
+cat > "${gh_bin_dir}/gh" <<'GHEOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${1:-}" != "api" ]; then
+  echo "fake gh: unsupported command: $*" >&2
+  exit 1
+fi
+shift
+
+: "${FAKE_GH_COMMENTS_JSON:?FAKE_GH_COMMENTS_JSON must be set}"
+: "${FAKE_GH_LOG:?FAKE_GH_LOG must be set}"
+
+method="GET"
+req_path=""
+jq_filter=""
+fields=()
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --paginate)
+      shift
+      ;;
+    -X)
+      method="$2"
+      shift 2
+      ;;
+    --jq)
+      jq_filter="$2"
+      shift 2
+      ;;
+    -f)
+      fields+=("$2")
+      shift 2
+      ;;
+    *)
+      req_path="$1"
+      shift
+      ;;
+  esac
+done
+
+if [ "${method}" = "GET" ]; then
+  if [ -n "${jq_filter}" ]; then
+    jq -r "${jq_filter}" "${FAKE_GH_COMMENTS_JSON}"
+  else
+    cat "${FAKE_GH_COMMENTS_JSON}"
+  fi
+  exit 0
+fi
+
+body_value=""
+for f in "${fields[@]}"; do
+  case "${f}" in
+    body=*)
+      body_value="${f#body=}"
+      ;;
+  esac
+done
+
+{
+  printf 'VERB=%s\n' "${method}"
+  printf 'API_PATH=%s\n' "${req_path}"
+  printf 'BODY_START\n'
+  printf '%s' "${body_value}"
+  printf '\nBODY_END\n'
+} > "${FAKE_GH_LOG}"
+
+echo '{}'
+GHEOF
+chmod +x "${gh_bin_dir}/gh"
+
+cat > "${fixtures_dir}/c_basic_coverage.json" <<'JSON'
+{
+  "data": [
+    { "files": [ { "filename": "/work/ironclaw/crates/ironclaw_reborn/src/a.rs", "summary": { "lines": { "covered": 8, "count": 10 } } } ] }
+  ]
+}
+JSON
+
+cat > "${fixtures_dir}/c_zero_coverage.json" <<'JSON'
+{
+  "data": [
+    { "files": [ { "filename": "/work/ironclaw/crates/ironclaw_reborn_zero/src/a.rs", "summary": { "lines": { "covered": 0, "count": 5 } } } ] }
+  ]
+}
+JSON
+
+cat > "${fixtures_dir}/c1_comments_empty.json" <<'JSON'
+[]
+JSON
+
+# The sticky comment (id 99) is deliberately NOT first in the list, pinning
+# that the lookup filters by marker rather than assuming position.
+cat > "${fixtures_dir}/c2_comments_with_sticky.json" <<'JSON'
+[
+  { "id": 1, "body": "Just a regular comment, unrelated to coverage." },
+  { "id": 99, "body": "<!-- reborn-coverage-sticky -->\n\nstale summary body" }
+]
+JSON
+
+gh_repo="acme/ironclaw-test"
+gh_pr="42"
+
+# C1: no existing sticky comment -> POST a new one.
+c1_log="${tmp_root}/c1-gh.log"
+capture env \
+  GH_TOKEN="fake-token" \
+  GITHUB_REPOSITORY="${gh_repo}" \
+  PR_NUMBER="${gh_pr}" \
+  PATH="${gh_bin_dir}:${PATH}" \
+  FAKE_GH_COMMENTS_JSON="${fixtures_dir}/c1_comments_empty.json" \
+  FAKE_GH_LOG="${c1_log}" \
+  "${comment_sh}" "${fixtures_dir}/c_basic_coverage.json"
+assert_exit_code "C1: comment script exits 0 (no existing sticky)" 0 "${CAP_RC}"
+
+if [ -f "${c1_log}" ]; then
+  c1_body="$(sed -n '/^BODY_START$/,/^BODY_END$/p' "${c1_log}" | sed '1d;$d')"
+  assert_contains "C1: no existing sticky issues a POST" "$(sed -n '1p' "${c1_log}")" "VERB=POST"
+  assert_contains "C1: POST targets the PR comments collection" "$(sed -n '2p' "${c1_log}")" \
+    "API_PATH=repos/${gh_repo}/issues/${gh_pr}/comments"
+  assert_contains "C1: POST body starts with the sticky marker" "${c1_body}" "<!-- reborn-coverage-sticky -->"
+  assert_contains "C1: POST body contains the Line coverage line" "${c1_body}" "Line coverage"
+else
+  report_fail "C1: fake gh did not record a mutation"
+fi
+
+# C2: existing sticky present (not first in the list) -> PATCH it, not a new POST.
+c2_log="${tmp_root}/c2-gh.log"
+capture env \
+  GH_TOKEN="fake-token" \
+  GITHUB_REPOSITORY="${gh_repo}" \
+  PR_NUMBER="${gh_pr}" \
+  PATH="${gh_bin_dir}:${PATH}" \
+  FAKE_GH_COMMENTS_JSON="${fixtures_dir}/c2_comments_with_sticky.json" \
+  FAKE_GH_LOG="${c2_log}" \
+  "${comment_sh}" "${fixtures_dir}/c_basic_coverage.json"
+assert_exit_code "C2: comment script exits 0 (existing sticky)" 0 "${CAP_RC}"
+
+if [ -f "${c2_log}" ]; then
+  assert_contains "C2: existing sticky (non-first in list) triggers a PATCH" "$(sed -n '1p' "${c2_log}")" "VERB=PATCH"
+  assert_contains "C2: PATCH targets the matched comment id (99), not a POST" "$(sed -n '2p' "${c2_log}")" \
+    "API_PATH=repos/${gh_repo}/issues/comments/99"
+else
+  report_fail "C2: fake gh did not record a mutation"
+fi
+
+# C3: zero-covered crates present -> callout line prepended before the header.
+c3_log="${tmp_root}/c3-gh.log"
+capture env \
+  GH_TOKEN="fake-token" \
+  GITHUB_REPOSITORY="${gh_repo}" \
+  PR_NUMBER="${gh_pr}" \
+  PATH="${gh_bin_dir}:${PATH}" \
+  FAKE_GH_COMMENTS_JSON="${fixtures_dir}/c1_comments_empty.json" \
+  FAKE_GH_LOG="${c3_log}" \
+  "${comment_sh}" "${fixtures_dir}/c_zero_coverage.json"
+assert_exit_code "C3: comment script exits 0 (zero-covered crate present)" 0 "${CAP_RC}"
+
+if [ -f "${c3_log}" ]; then
+  c3_body="$(sed -n '/^BODY_START$/,/^BODY_END$/p' "${c3_log}" | sed '1d;$d')"
+  assert_contains "C3: body contains the 0-coverage callout" "${c3_body}" \
+    "⚠️ 1 Reborn crate(s) have 0 int-tier coverage"
+  assert_line_before "C3: callout is prepended before the coverage header" "${c3_body}" \
+    "⚠️ 1 Reborn crate(s) have 0 int-tier coverage" "## Reborn integration-tier coverage"
+else
+  report_fail "C3: fake gh did not record a mutation"
+fi
+
+# ---------------------------------------------------------------------------
+# D. reborn-coverage-int-tier-tests.sh (int-tier suite discovery)
+# ---------------------------------------------------------------------------
+#
+# The script derives its repo root from its own path and `cd`s there, so
+# each case copies it into a fresh temp tree's scripts/ci/ and builds a
+# tests/ subtree alongside it, then invokes the copy.
+
+setup_int_tier_case() {
+  local case_dir="$1"
+  mkdir -p "${case_dir}/scripts/ci" "${case_dir}/tests"
+  cp "${int_tier_sh}" "${case_dir}/scripts/ci/reborn-coverage-int-tier-tests.sh"
+  chmod +x "${case_dir}/scripts/ci/reborn-coverage-int-tier-tests.sh"
+}
+
+# D1: empty tests/ -> non-zero exit + discovery error.
+d1="${tmp_root}/d1"
+setup_int_tier_case "${d1}"
+capture "${d1}/scripts/ci/reborn-coverage-int-tier-tests.sh"
+assert_exit_code "D1: empty tests/ exits non-zero" 1 "${CAP_RC}"
+assert_contains "D1: empty tests/ prints the discovery error" "${CAP_ERR}" \
+  "No Reborn integration-tier test binaries discovered"
+
+# D2: one tests/reborn_integration_foo.rs -> --test / reborn_integration_foo.
+d2="${tmp_root}/d2"
+setup_int_tier_case "${d2}"
+: > "${d2}/tests/reborn_integration_foo.rs"
+capture "${d2}/scripts/ci/reborn-coverage-int-tier-tests.sh"
+assert_exit_code "D2: single integration file exits 0" 0 "${CAP_RC}"
+assert_eq "D2: single integration file emits its --test pair" \
+  "$(printf -- '--test\nreborn_integration_foo')" "${CAP_OUT}"
+
+# D3: one tests/reborn_group_bar/ -> --test / reborn_group_bar.
+d3="${tmp_root}/d3"
+setup_int_tier_case "${d3}"
+mkdir -p "${d3}/tests/reborn_group_bar"
+capture "${d3}/scripts/ci/reborn-coverage-int-tier-tests.sh"
+assert_exit_code "D3: single group dir exits 0" 0 "${CAP_RC}"
+assert_eq "D3: single group dir emits its --test pair" \
+  "$(printf -- '--test\nreborn_group_bar')" "${CAP_OUT}"
+
+# D4: multiple files + dirs, created out of alphabetical order -> sorted,
+# deduped output. Group dirs ('g') sort before integration files ('i').
+d4="${tmp_root}/d4"
+setup_int_tier_case "${d4}"
+: > "${d4}/tests/reborn_integration_zeta.rs"
+: > "${d4}/tests/reborn_integration_alpha.rs"
+mkdir -p "${d4}/tests/reborn_group_omega" "${d4}/tests/reborn_group_beta"
+capture "${d4}/scripts/ci/reborn-coverage-int-tier-tests.sh"
+assert_exit_code "D4: multiple suites exits 0" 0 "${CAP_RC}"
+assert_eq "D4: multiple suites sorted+deduped in expected order" \
+  "$(printf -- '--test\nreborn_group_beta\n--test\nreborn_group_omega\n--test\nreborn_integration_alpha\n--test\nreborn_integration_zeta')" \
+  "${CAP_OUT}"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+printf '\n%s of %s cases passed\n' "${PASS_COUNT}" "$((PASS_COUNT + FAIL_COUNT))"
+if [ "${FAIL_COUNT}" -gt 0 ]; then
+  printf '%s case(s) FAILED\n' "${FAIL_COUNT}" >&2
+  exit 1
+fi
+exit 0

--- a/scripts/ci/test-reborn-coverage.sh
+++ b/scripts/ci/test-reborn-coverage.sh
@@ -99,8 +99,11 @@ assert_not_contains() {
 assert_line_before() {
   local name="$1" haystack="$2" needle_a="$3" needle_b="$4"
   local line_a line_b
-  line_a="$(printf '%s\n' "${haystack}" | grep -n -F -- "${needle_a}" | head -n1 | cut -d: -f1)"
-  line_b="$(printf '%s\n' "${haystack}" | grep -n -F -- "${needle_b}" | head -n1 | cut -d: -f1)"
+  # `|| true`: a missing needle makes grep exit 1, which under `set -o pipefail`
+  # would abort the whole suite on assignment instead of falling through to the
+  # empty-check below and reporting a normal FAIL (the harness runs every case).
+  line_a="$(printf '%s\n' "${haystack}" | grep -n -F -- "${needle_a}" | head -n1 | cut -d: -f1 || true)"
+  line_b="$(printf '%s\n' "${haystack}" | grep -n -F -- "${needle_b}" | head -n1 | cut -d: -f1 || true)"
   if [ -n "${line_a}" ] && [ -n "${line_b}" ] && [ "${line_a}" -lt "${line_b}" ]; then
     report_pass "${name}"
   else

--- a/scripts/ci/test-reborn-coverage.sh
+++ b/scripts/ci/test-reborn-coverage.sh
@@ -433,6 +433,31 @@ else
   report_fail "C3: fake gh did not record a mutation"
 fi
 
+# C4: GH_TOKEN unset -> fast-fail before any `gh` call. `env -u` (not a subshell
+# export/unset) keeps this the same shape as C1-C3 and shellcheck-clean.
+capture env -u GH_TOKEN \
+  GITHUB_REPOSITORY="${gh_repo}" \
+  PR_NUMBER="${gh_pr}" \
+  "${comment_sh}" "${fixtures_dir}/c_basic_coverage.json"
+assert_exit_code "C4: GH_TOKEN unset exits non-zero" 1 "${CAP_RC}"
+assert_contains "C4: GH_TOKEN unset reports the missing-var guard" "${CAP_ERR}" "GH_TOKEN must be set"
+
+# C5: PR_NUMBER unset -> guard fires before GH_TOKEN is even checked.
+capture env -u PR_NUMBER \
+  GH_TOKEN="fake-token" \
+  GITHUB_REPOSITORY="${gh_repo}" \
+  "${comment_sh}" "${fixtures_dir}/c_basic_coverage.json"
+assert_exit_code "C5: PR_NUMBER unset exits non-zero" 1 "${CAP_RC}"
+assert_contains "C5: PR_NUMBER unset reports the missing-var guard" "${CAP_ERR}" "PR_NUMBER must be set"
+
+# C6: GITHUB_REPOSITORY unset -> the first guard, fires immediately.
+capture env -u GITHUB_REPOSITORY \
+  GH_TOKEN="fake-token" \
+  PR_NUMBER="${gh_pr}" \
+  "${comment_sh}" "${fixtures_dir}/c_basic_coverage.json"
+assert_exit_code "C6: GITHUB_REPOSITORY unset exits non-zero" 1 "${CAP_RC}"
+assert_contains "C6: GITHUB_REPOSITORY unset reports the missing-var guard" "${CAP_ERR}" "GITHUB_REPOSITORY must be set"
+
 # ---------------------------------------------------------------------------
 # D. reborn-coverage-int-tier-tests.sh (int-tier suite discovery)
 # ---------------------------------------------------------------------------

--- a/scripts/ci/test-reborn-coverage.sh
+++ b/scripts/ci/test-reborn-coverage.sh
@@ -216,6 +216,43 @@ assert_contains "A5: zero-covered crate row shows 0%" "${CAP_OUT}" "| \`ironclaw
 assert_line_before "A5: zero-covered crate sorted to top (lowest-covered first)" "${CAP_OUT}" \
   "\`ironclaw_reborn_zero\`" "\`ironclaw_reborn_half\`"
 
+# A6: allowlist boundary — two exact-match single crates, one family-prefix
+# crate, and a lookalike (ironclaw_architecture_extra) that must be dropped:
+# it is not one of the four exact-match crates and does not start with a
+# reborn/product/webui_v2 family prefix.
+cat > "${fixtures_dir}/a6_allowlist_boundary.json" <<'JSON'
+{
+  "data": [
+    {
+      "files": [
+        { "filename": "/work/ironclaw/crates/ironclaw_architecture/src/a.rs", "summary": { "lines": { "covered": 5, "count": 10 } } },
+        { "filename": "/work/ironclaw/crates/ironclaw_slack_v2_adapter/src/a.rs", "summary": { "lines": { "covered": 3, "count": 10 } } },
+        { "filename": "/work/ironclaw/crates/ironclaw_reborn_config/src/a.rs", "summary": { "lines": { "covered": 8, "count": 10 } } },
+        { "filename": "/work/ironclaw/crates/ironclaw_architecture_extra/src/a.rs", "summary": { "lines": { "covered": 0, "count": 999 } } }
+      ]
+    }
+  ]
+}
+JSON
+
+capture "${summary_sh}" "${fixtures_dir}/a6_allowlist_boundary.json"
+assert_exit_code "A6: allowlist boundary fixture summary exits 0" 0 "${CAP_RC}"
+assert_contains "A6: table includes exact-match ironclaw_architecture row" "${CAP_OUT}" \
+  "| \`ironclaw_architecture\` | 50% | 5 / 10 |"
+assert_contains "A6: table includes exact-match ironclaw_slack_v2_adapter row" "${CAP_OUT}" \
+  "| \`ironclaw_slack_v2_adapter\` | 30% | 3 / 10 |"
+assert_contains "A6: table includes family-prefix ironclaw_reborn_config row" "${CAP_OUT}" \
+  "| \`ironclaw_reborn_config\` | 80% | 8 / 10 |"
+assert_not_contains "A6: lookalike ironclaw_architecture_extra excluded from table" "${CAP_OUT}" \
+  "ironclaw_architecture_extra"
+assert_contains "A6: aggregate drops lookalike's 999 lines (16/30, not 16/1029)" "${CAP_OUT}" \
+  '**Line coverage (Reborn crates): 53.33%** — 16 / 30 lines'
+
+# A7: missing coverage JSON -> non-zero exit + not-found error on stderr.
+capture "${summary_sh}" "${fixtures_dir}/does_not_exist.json"
+assert_exit_code "A7: summary exits non-zero for missing coverage JSON" 1 "${CAP_RC}"
+assert_contains "A7: summary reports missing coverage JSON" "${CAP_ERR}" "coverage JSON not found"
+
 # ---------------------------------------------------------------------------
 # B. reborn-coverage-summary.sh --zero-crates
 # ---------------------------------------------------------------------------
@@ -460,6 +497,26 @@ capture env -u GITHUB_REPOSITORY \
   "${comment_sh}" "${fixtures_dir}/c_basic_coverage.json"
 assert_exit_code "C6: GITHUB_REPOSITORY unset exits non-zero" 1 "${CAP_RC}"
 assert_contains "C6: GITHUB_REPOSITORY unset reports the missing-var guard" "${CAP_ERR}" "GITHUB_REPOSITORY must be set"
+
+# C7: missing coverage JSON -> the "if [ ! -f ]" guard at the top of
+# comment.sh fires before GH_TOKEN/GITHUB_REPOSITORY/PR_NUMBER are even
+# consulted, so no `gh` call — and therefore no mutation — is ever recorded.
+c7_log="${tmp_root}/c7-gh.log"
+capture env \
+  GH_TOKEN="fake-token" \
+  GITHUB_REPOSITORY="${gh_repo}" \
+  PR_NUMBER="${gh_pr}" \
+  PATH="${gh_bin_dir}:${PATH}" \
+  FAKE_GH_COMMENTS_JSON="${fixtures_dir}/c1_comments_empty.json" \
+  FAKE_GH_LOG="${c7_log}" \
+  "${comment_sh}" "${fixtures_dir}/does_not_exist.json"
+assert_exit_code "C7: comment script exits non-zero for missing coverage JSON" 1 "${CAP_RC}"
+assert_contains "C7: comment script reports missing coverage JSON" "${CAP_ERR}" "coverage JSON not found"
+if [ -f "${c7_log}" ]; then
+  report_fail "C7: fake gh did not record a mutation (guard fires before gh use)"
+else
+  report_pass "C7: fake gh did not record a mutation (guard fires before gh use)"
+fi
 
 # ---------------------------------------------------------------------------
 # D. reborn-coverage-int-tier-tests.sh (int-tier suite discovery)

--- a/scripts/ci/test-reborn-coverage.sh
+++ b/scripts/ci/test-reborn-coverage.sh
@@ -518,6 +518,38 @@ else
   report_pass "C7: fake gh did not record a mutation (guard fires before gh use)"
 fi
 
+# C8: existing-but-malformed coverage JSON aborts before any gh mutation.
+#
+# Distinct path from C7: this fixture file exists, so it passes comment.sh's
+# "[ -f ]" guard and proceeds to call reborn-coverage-summary.sh to render
+# the body — and that render fails on jq's parse error under `set -e`,
+# before any POST/PATCH is ever issued. Pins the "render-before-mutate"
+# ordering.
+cat > "${fixtures_dir}/c8_malformed.json" <<'JSON'
+{ this is not valid json
+JSON
+
+c8_log="${tmp_root}/c8-gh.log"
+capture env \
+  GH_TOKEN="fake-token" \
+  GITHUB_REPOSITORY="${gh_repo}" \
+  PR_NUMBER="${gh_pr}" \
+  PATH="${gh_bin_dir}:${PATH}" \
+  FAKE_GH_COMMENTS_JSON="${fixtures_dir}/c1_comments_empty.json" \
+  FAKE_GH_LOG="${c8_log}" \
+  "${comment_sh}" "${fixtures_dir}/c8_malformed.json"
+# Non-zero, not an exact code: jq's parse-error exit differs across versions.
+if [ "${CAP_RC}" -ne 0 ]; then
+  report_pass "C8: comment script exits non-zero on malformed coverage JSON"
+else
+  report_fail "C8: comment script exits non-zero on malformed coverage JSON (got 0)"
+fi
+if [ -f "${c8_log}" ]; then
+  report_fail "C8: fake gh did not record a mutation (render fails before gh use)"
+else
+  report_pass "C8: fake gh did not record a mutation (render fails before gh use)"
+fi
+
 # ---------------------------------------------------------------------------
 # D. reborn-coverage-int-tier-tests.sh (int-tier suite discovery)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Adds a per-PR, **informational** coverage signal for the Reborn backend (roadmap task **T0-COV**, `docs/reborn/reborn-backend-coverage-roadmap.md`). A new `Reborn Coverage` workflow runs `cargo-llvm-cov` over the in-process integration-tier test binaries and surfaces a **Reborn-crate-scoped line-coverage %** plus a **per-crate hole list** in the PR job summary.

This is what makes the roadmap's "100% int-tier coverage" goal measurable and yields the real hole list to drive the rest of the coverage workstreams.

## Measured baseline

Running the job's exact scope locally produced:

**Line coverage (Reborn crates): 13.99% — 8351 / 59713 lines**

Lowest-covered crates (the hole list): `ironclaw_reborn_config`, `ironclaw_reborn_identity`, `ironclaw_reborn_traces`, `ironclaw_webui_v2(_static)` at 0%; `ironclaw_reborn_composition` 18.9%; `ironclaw_reborn` 25.8%.

## How the % surfaces per-PR

The `Render Reborn coverage summary` step writes the markdown table to `$GITHUB_STEP_SUMMARY`, so the % and per-crate breakdown appear on the **workflow run's summary page** for every PR (the repo's existing job-summary convention; the full per-file JSON export is uploaded as the `reborn-coverage` artifact for offline inspection).

## Scope decisions

- **Test scope** = the in-process int-tier suites per the roadmap's definition: `tests/reborn_integration_*.rs` + `tests/reborn_group_*/`. Discovered dynamically (`scripts/ci/reborn-coverage-int-tier-tests.sh`) so new suites auto-enroll.
- **Features** = default (`postgres`+`libsql`+`html-to-markdown`+`tui`), matching how `scripts/ci/run-reborn-root-partition.sh` runs these same suites. No live Postgres needed (suites skip Postgres backends when `DATABASE_URL` is unset; `backend_matrix` stays libsql-only).
- **Combined `cargo llvm-cov --workspace --test … --json` one-shot** is deliberate: the standalone `report` subcommand cannot take `--workspace`, so a split `--no-report`/`report` would scope the report to only the root package's `src/` and report 0% for the linked Reborn crates. The `--workspace` combined form surfaces the member-crate files (verified: 0% → 13.99%).
- **Non-gating**: no coverage threshold, no PR fail — matches "do not gate on coverage yet".
- Reuses `coverage.yml`'s pinned action SHAs / install action; LLM-neutralizing env mirrors `reborn-tests.yml`; crate-scope regex mirrors the `reborn-tests.yml` package allowlist (prefix-match for `reborn_*`/`product_*`/`webui_v2_*`, exact-match for the four single crates).

## Verification

- `shellcheck` + `actionlint` clean; YAML validated.
- Local run: all 13 int-tier binaries pass; baseline % reproduced via `scripts/ci/reborn-coverage-summary.sh`.
- No `.rs` / `Cargo.toml` / `Cargo.lock` changes — `cargo build`/clippy state is identical to the green `main` base.
- Reviewed via thermo-nuclear + code-review (approach/local-patterns/maintainability) loops; findings addressed.


## Added since open

- **Sticky PR comment** (`scripts/ci/reborn-coverage-comment.sh`): upserts one marker'd comment so the %/hole-list lives in the conversation, not just the job summary. PR-only, `continue-on-error: true` — a fork's read-only token 403 can't red the check. Per-crate table folded into `<details>` to keep it compact.
- **Cache hygiene** (`save-if` gated to `main`): PRs restore a warm main-seeded instrumented cache instead of each PR writing a branch-scoped copy that churns the ~10 GB LRU.
- **Review fixes**: iterate all llvm-cov `data[]` datasets; `GH_TOKEN` fast-fail guard; `timeout-minutes: 180` runaway backstop.
- **Regression tests** (`scripts/ci/test-reborn-coverage.sh`, 43 cases): summary report/`--zero-crates`, comment POST/PATCH upsert via fake `gh`, int-tier discovery — mirrors the `test-classify-test-scope.sh` precedent.

## Change Type

CI / tooling (new workflow + shell helpers + tests). No production `.rs`, `Cargo.toml`, or `Cargo.lock` changes.

## Linked Issue

Roadmap task **T0-COV** (`docs/reborn/reborn-backend-coverage-roadmap.md`). No separate tracking issue.

## Validation

- `shellcheck` + `actionlint` clean; YAML validated.
- `scripts/ci/test-reborn-coverage.sh`: 43/43 pass (mutation-checked non-vacuous).
- Live: the `Reborn Coverage` job ran on this PR and posted the sticky comment (real ~13.9% run) — confirms the workflow, permissions, and upsert path end-to-end.
- No `.rs`/`Cargo.*` changes — `cargo build`/clippy state identical to the green `main` base.

## Security / Blast Radius

- Trigger is `pull_request` (not `pull_request_target`) — no privileged-context checkout of untrusted code. Minimal token scope: `contents: read` + `pull-requests: write` (issues-comment upsert).
- Fork PRs get a read-only token; the comment step is `continue-on-error` so its 403 is non-fatal. No secrets consumed (LLM env is neutralized).
- Purely informational: no gate, cannot block or alter any other check.

## Rollback Plan

Self-contained and additive. Revert the workflow + four `scripts/ci/reborn-coverage-*.sh` files (or disable via `.github/workflows/reborn-coverage.yml`) — nothing else depends on them, no state/migrations, no effect on other jobs. If the sticky comment misbehaves, deleting the comment step alone leaves the job-summary signal intact.

## Review track

Highest review-risk track (CI workflow change). Reviewed via thermo-nuclear + multi-agent code-review loops; valid findings fixed, non-issues documented in the triage comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
