### PR TITLE
test(reborn): re-enable spawn_subagent surface + un-ignore spawn e2e tests (T0-SPAWN)

### DIFF
--- a/crates/ironclaw_reborn/src/runtime.rs
+++ b/crates/ironclaw_reborn/src/runtime.rs
@@ -599,14 +599,14 @@ where
         parts.subagent_spawn_limits,
         flavors::builtin_flavor_catalog(),
     )?);
-    // TEMP(disable-spawn-subagents): explicit composition decision to remove the
-    // spawn_subagent capability from the model-facing surface across all
-    // profiles. Applied as the OUTERMOST decorator so it strips the capability
+    // Strip any capability in DISABLED_CAPABILITY_IDS from the model-facing
+    // surface, applied as the OUTERMOST decorator so it strips a capability
     // whether it was surfaced by `spawn_decorator` (the rich flavor-aware tool)
     // or by the host-runtime first-party manifest (the bare authorization stub).
     // This is a deny list — it takes effect regardless of the resolved profile
     // allow-set (which is `All` for top-level runs, making a profile allow-set
-    // narrowing a no-op). Empty `DISABLED_CAPABILITY_IDS` to re-enable.
+    // narrowing a no-op). The list is currently empty, so no capability is
+    // stripped and the decorator is skipped entirely.
     let disabled = DISABLED_CAPABILITY_IDS
         .iter()
         .map(|id| CapabilityId::new(*id))
@@ -708,11 +708,12 @@ where
 /// Outermost decorator that strips a caller-supplied deny list from every loop
 /// capability surface (tool definitions, visible descriptors, and invocation),
 /// regardless of the resolved profile allow-set.
-/// Capabilities temporarily removed from the model-facing surface as an
-/// explicit composition decision. Applied via an outermost
-/// [`CapabilitySurfaceDenyFilter`]. Empty this slice to re-enable everything.
-const DISABLED_CAPABILITY_IDS: &[&str] =
-    &[ironclaw_loop_support::DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID];
+/// Capability ids removed from the model-facing surface as an explicit
+/// composition decision, applied via an outermost
+/// [`CapabilitySurfaceDenyFilter`]. Currently empty — add an id here to deny a
+/// capability across every surface path (tool definitions, visible descriptors,
+/// validate, register, invoke) regardless of the resolved profile allow-set.
+const DISABLED_CAPABILITY_IDS: &[&str] = &[];
 
 struct DisabledCapabilitiesDecorator {
     denied_capability_ids: Vec<CapabilityId>,

--- a/tests/reborn_qa_smoke_scenarios_e2e.rs
+++ b/tests/reborn_qa_smoke_scenarios_e2e.rs
@@ -305,7 +305,6 @@ async fn qa_trigger_automation_smokes_create_view_and_cleanup() {
 }
 
 #[tokio::test]
-#[ignore = "TEMP(disable-spawn-subagents): spawn_subagent temporarily disabled via capability deny filter; re-enable by emptying DISABLED_CAPABILITY_IDS"]
 async fn qa_subagent_capability_smoke_uses_child_run() {
     let spawn_subagent = cap(DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID);
     let model_gateway = RebornTraceReplayModelGateway::with_scripted_steps([

--- a/tests/reborn_subagent_spawn_e2e.rs
+++ b/tests/reborn_subagent_spawn_e2e.rs
@@ -20,7 +20,6 @@ use reborn_support::{
 };
 
 #[tokio::test]
-#[ignore = "TEMP(disable-spawn-subagents): spawn_subagent temporarily disabled via capability deny filter; re-enable by emptying DISABLED_CAPABILITY_IDS"]
 async fn blocking_spawn_parks_parent_then_resumes_with_child_result() {
     let model_gateway = RebornTraceReplayModelGateway::with_scripted_steps([
         RebornModelReplayStep::ProviderToolCalls {
@@ -85,7 +84,6 @@ async fn blocking_spawn_parks_parent_then_resumes_with_child_result() {
 }
 
 #[tokio::test]
-#[ignore = "TEMP(disable-spawn-subagents): spawn_subagent temporarily disabled via capability deny filter; re-enable by emptying DISABLED_CAPABILITY_IDS"]
 async fn legacy_explicit_blocking_spawn_still_parks_parent_and_resumes() {
     let model_gateway = RebornTraceReplayModelGateway::with_scripted_steps([
         RebornModelReplayStep::ProviderToolCalls {
@@ -144,7 +142,6 @@ async fn legacy_explicit_blocking_spawn_still_parks_parent_and_resumes() {
 }
 
 #[tokio::test]
-#[ignore = "TEMP(disable-spawn-subagents): spawn_subagent temporarily disabled via capability deny filter; re-enable by emptying DISABLED_CAPABILITY_IDS"]
 async fn background_spawn_is_rejected_before_child_run_or_auth_invocation() {
     let model_gateway = RebornTraceReplayModelGateway::with_scripted_steps([
         RebornModelReplayStep::ProviderToolCalls {
@@ -198,7 +195,6 @@ async fn background_spawn_is_rejected_before_child_run_or_auth_invocation() {
 }
 
 #[tokio::test]
-#[ignore = "TEMP(disable-spawn-subagents): spawn_subagent temporarily disabled via capability deny filter; re-enable by emptying DISABLED_CAPABILITY_IDS"]
 async fn blocking_spawn_waits_while_child_is_blocked_on_approval_then_resumes() {
     let model_gateway = RebornTraceReplayModelGateway::with_scripted_steps([
         RebornModelReplayStep::ProviderToolCalls {
@@ -308,7 +304,6 @@ async fn blocking_spawn_waits_while_child_is_blocked_on_approval_then_resumes() 
 }
 
 #[tokio::test]
-#[ignore = "TEMP(disable-spawn-subagents): spawn_subagent temporarily disabled via capability deny filter; re-enable by emptying DISABLED_CAPABILITY_IDS"]
 async fn parallel_blocking_spawn_resumes_once_after_last_child() {
     let model_gateway = RebornTraceReplayModelGateway::with_scripted_steps([
         RebornModelReplayStep::ProviderToolCalls {

--- a/tests/reborn_trace_first_party_tool_coverage.rs
+++ b/tests/reborn_trace_first_party_tool_coverage.rs
@@ -154,15 +154,15 @@ async fn reborn_trace_process_first_party_tools_parity() {
             .any(|message| message.content.contains(shell.as_str())),
         "shell must be advertised on the Reborn model-facing first-party surface"
     );
-    // TEMP(disable-spawn-subagents): spawn_subagent is temporarily disabled via
-    // the outermost capability deny filter in the default planned runtime, so it
-    // must NOT appear on the model-facing surface.
+    // Subagent spawning is a special loop path covered by
+    // tests/reborn_subagent_spawn_e2e.rs; this first-party tool trace only
+    // verifies it remains advertised on the model-facing surface.
     assert!(
-        !requests[0]
+        requests[0]
             .messages
             .iter()
             .any(|message| message.content.contains(spawn_subagent.as_str())),
-        "spawn_subagent must NOT be advertised while temporarily disabled"
+        "spawn_subagent must be advertised on the Reborn model-facing first-party surface"
     );
     assert_eq!(tool_result_count(&requests[1]), 1);
     assert_milestone_order(
@@ -176,7 +176,6 @@ async fn reborn_trace_process_first_party_tools_parity() {
 }
 
 #[tokio::test]
-#[ignore = "TEMP(disable-spawn-subagents): spawn_subagent temporarily disabled via capability deny filter; re-enable by emptying DISABLED_CAPABILITY_IDS"]
 async fn reborn_trace_spawn_subagent_is_surface_text_and_structured_tool() {
     let spawn_subagent =
         CapabilityId::new(SPAWN_SUBAGENT_CAPABILITY_ID).expect("valid capability id");


### PR DESCRIPTION
## T0-SPAWN — clear the `spawn_subagent` rollout toggle

Roadmap: `docs/reborn/reborn-backend-coverage-roadmap.md` (Tier 0, T0-SPAWN).

### Investigation gate (verdict: TEST/ROLLOUT TOGGLE — not a product kill-switch)
Before changing anything, confirmed the disable is a temporary toggle:
- Introducing commit `42307a764` is titled **"refactor(reborn): temporarily disable spawn_subagent capability (#5175)"** and states *"Revert is a one-line change"* / *"re-enable = empty the list."*
- All ignore reasons read `TEMP(disable-spawn-subagents): spawn_subagent temporarily disabled via capability deny filter; re-enable by emptying DISABLED_CAPABILITY_IDS`.
- The full spawn machinery (`SubagentSpawnCapabilityDecorator`, first-party manifest, handler) was left intact; #5175 only hid the model-facing surface behind an outermost `CapabilitySurfaceDenyFilter`.

### Change
- `crates/ironclaw_reborn/src/runtime.rs`: empty `DISABLED_CAPABILITY_IDS` to `&[]`. The application-site guard `if !disabled.is_empty()` short-circuits, so the deny-filter decorator is skipped entirely; the reusable machinery is kept for future use. Refreshed the two now-stale "temporarily disabled" comments.
- Dropped `#[ignore]` on the **5** `reborn_subagent_spawn_e2e` tests.
- Dropped `#[ignore]` on the spawn trace-surface test and the subagent qa-smoke test (same toggle ignore reason — leaving them ignored after emptying the list would make their reason self-contradicting).
- Un-flipped `reborn_trace_process_first_party_tools_parity` back to asserting spawn **MUST** be advertised (#5175 had flipped it to "must NOT").

### Verification
- 5 `reborn_subagent_spawn_e2e` tests **green** under `--features libsql` and `--all-features`.
- **Mutation-proof:** re-adding spawn to `DISABLED_CAPABILITY_IDS` turns all 5 RED with `SanitizedFailure { category: "driver_unavailable" }` — the deny filter strips the spawn capability so the scripted spawn call can't dispatch and the parent never reaches `BlockedDependentRun`. Reverting restores green. The tests genuinely exercise the surface.
- `codegraph_impact` on `DISABLED_CAPABILITY_IDS`: consumed only within `runtime.rs` — no non-test caller relied on spawn being disabled.
- Broad reborn binaries green (`--features libsql`): group_{approvals,extensions,memory}, integration_{greeting,tool_call}, minimal_dispatch, response_order, recorded_trace, trace_{core_builtin,error_path,first_party_tool_coverage}, qa_smoke.
- `cargo build --tests --all-features` exit 0; `cargo clippy --all --tests --all-features -- -D warnings` clean.
- Post-impl review (thermo-nuclear + approach/local-patterns/maintainability lenses): **CLEAN**, no findings.

### Dependency note for the roadmap
**C-SPAWN's int-tier coverage (Wave 3) passes only after this const-clear merges** — the `CapabilitySurfaceDenyFilter` applies at the int tier too, so spawn must be reachable there before C-SPAWN's tests can go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)