### PR TITLE
ci(reborn): dedicated low-contention job for Reborn group tests (T0-CI)

### DIFF
--- a/.github/workflows/reborn-tests.yml
+++ b/.github/workflows/reborn-tests.yml
@@ -327,6 +327,80 @@ jobs:
       - name: Run Reborn root tests
         run: scripts/ci/run-reborn-root-partition.sh
 
+  reborn-group-tests:
+    name: Reborn group tests
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.has_reborn_tests == 'true'
+    runs-on: ubuntu-latest
+    # Group tests run sequentially in ONE job (build once, reuse artifacts), so
+    # the budget must cover N suites at REBORN_GROUP_TEST_TIMEOUT each plus setup
+    # — otherwise GitHub hard-kills the job before a hung suite reaches its own
+    # per-test timeout and reports which one hung. 3 suites x 28m + setup < 110m.
+    # If group suites grow past ~4, migrate to a package-matrix-style discovery
+    # job (one suite per matrix runner) instead of bumping this number.
+    timeout-minutes: 110
+    env:
+      ANTHROPIC_API_KEY: ""
+      LLM_BACKEND: ""
+      LLM_USE_CODEX_AUTH: "false"
+      OLLAMA_BASE_URL: ""
+      OPENAI_API_KEY: ""
+      REBORN_GROUP_TEST_TIMEOUT: 28m
+      CARGO_INCREMENTAL: "0"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+          persist-credentials: false
+
+      - name: Free disk space
+        run: |
+          df -h /
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/.ghcup /usr/local/share/boost /opt/hostedtoolcache/CodeQL || true
+          docker system prune -af || true
+          df -h /
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: Install mold and clang
+        run: |
+          scripts/ci/install-ci-apt-packages.sh clang mold
+          test -x /usr/bin/mold
+
+      - name: Verify mold linker is active
+        run: |
+          clang_output="$(
+            printf 'int main(void) { return 0; }\n' \
+              | clang --ld-path=/usr/bin/mold -Wl,--version -x c - -o /tmp/clang-mold-check 2>&1
+          )"
+          printf '%s\n' "$clang_output"
+          grep -qi mold <<< "$clang_output"
+
+          printf 'fn main() { println!("mold-link-ok"); }\n' > /tmp/mold-link-check.rs
+          rustc /tmp/mold-link-check.rs \
+            -C linker=clang \
+            -C link-arg=--ld-path=/usr/bin/mold \
+            -o /tmp/mold-link-check
+          test "$(/tmp/mold-link-check)" = "mold-link-ok"
+
+      - name: Restore Rust cache
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          # REUSE the root partitions' cache key: the group `[[test]]` binaries
+          # are part of the same root package build as the reborn_*.rs root tests,
+          # so they hit the already-warm target rather than a cold cache. Minting a
+          # new key would add another ~1 GB entry to the ~10 GB repo cache LRU and
+          # evict the root/crate states instead of sharing them.
+          shared-key: reborn-tests-root
+          # Keep saves to protected-branch and merge_group runs so the ~10 GB
+          # repo cache LRU is seeded by shared states, not arbitrary PR branches.
+          save-if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'merge_group' }}
+
+      - name: Run Reborn group tests
+        run: scripts/ci/run-reborn-group-tests.sh
+
   webui-v2-js-tests:
     name: Reborn WebUI v2 JS tests
     needs: changes
@@ -406,6 +480,7 @@ jobs:
       - package-matrix
       - crate-tests
       - root-reborn-parity-tests
+      - reborn-group-tests
       - webui-v2-js-tests
       - qa-recorded-fixtures
     steps:
@@ -438,6 +513,11 @@ jobs:
 
           if [[ "${{ needs.root-reborn-parity-tests.result }}" != "success" ]]; then
             echo "One or more Reborn root tests failed: ${{ needs.root-reborn-parity-tests.result }}"
+            exit 1
+          fi
+
+          if [[ "${{ needs.reborn-group-tests.result }}" != "success" ]]; then
+            echo "One or more Reborn group tests failed: ${{ needs.reborn-group-tests.result }}"
             exit 1
           fi
 

--- a/scripts/ci/classify-test-scope.sh
+++ b/scripts/ci/classify-test-scope.sh
@@ -66,7 +66,7 @@ is_shared_test_path() {
 is_reborn_test_path() {
   local path="$1"
   case "$path" in
-    docs/reborn/*|scripts/reborn-e2e-rust.sh|scripts/ci/run-reborn-root-partition.sh|tests/reborn_*|tests/support/reborn/*|tests/fixtures/llm_traces/reborn_qa/*|tests/e2e/scenarios/test_reborn_*)
+    docs/reborn/*|scripts/reborn-e2e-rust.sh|scripts/ci/run-reborn-root-partition.sh|scripts/ci/run-reborn-group-tests.sh|tests/reborn_*|tests/support/reborn/*|tests/fixtures/llm_traces/reborn_qa/*|tests/e2e/scenarios/test_reborn_*)
       return 0
       ;;
     crates/ironclaw_architecture/*)

--- a/scripts/ci/run-reborn-group-tests.sh
+++ b/scripts/ci/run-reborn-group-tests.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Reborn shared-persistence "group" suites are subdirectory `[[test]]` binaries
+# (tests/reborn_group_*/main.rs). Unlike the single-file reborn_*.rs root tests,
+# each spins up one runtime and drives several tenants' shared libsql-backed
+# stores across threads, so they run in a dedicated low-contention job instead
+# of the modulo-partitioned root runner. `--features libsql` is explicit so the
+# group binaries exercise the libsql-backed shared store independently of any
+# future change to the default feature set.
+
+test_timeout="${REBORN_GROUP_TEST_TIMEOUT:-28m}"
+
+# The `[[test]]` `name` field equals the directory basename, so emit the
+# directory path and let the `s#^tests/##` rewrite turn it into the Cargo test
+# name (e.g. tests/reborn_group_memory -> reborn_group_memory). The `sh -c`
+# predicate skips a half-scaffolded group dir (no main.rs yet) — returning false
+# from `-exec` just filters that dir, it does NOT make `find` exit non-zero, so
+# no `|| true` is needed; genuine `find` failures stay visible under `set -e`.
+# `sh -c` (not a bare `{}/main.rs`) avoids POSIX implementation-defined `{}`
+# substring substitution so discovery is portable across GNU/BSD find.
+mapfile -t test_names < <(
+  find tests -mindepth 1 -maxdepth 1 -type d -name 'reborn_group_*' \
+    -exec sh -c 'test -f "$1/main.rs"' _ {} ';' -print \
+    | sed -E 's#^tests/##' \
+    | LC_ALL=C sort
+)
+
+if [ "${#test_names[@]}" -eq 0 ]; then
+  echo "No Reborn group tests discovered" >&2
+  exit 1
+fi
+
+for test_name in "${test_names[@]}"; do
+  echo "::group::cargo test --test ${test_name} --features libsql"
+  timeout --signal=INT --kill-after=30s "${test_timeout}" \
+    cargo test --test "${test_name}" --features libsql -- --nocapture
+  echo "::endgroup::"
+done

--- a/scripts/ci/test-classify-test-scope.sh
+++ b/scripts/ci/test-classify-test-scope.sh
@@ -97,6 +97,14 @@ has_legacy_tests=false
 has_reborn_tests=true"
 
 assert_scope \
+  "reborn group test runner script" \
+  "scripts/ci/run-reborn-group-tests.sh" \
+  "docs_only=false
+has_core_code=true
+has_legacy_tests=false
+has_reborn_tests=true"
+
+assert_scope \
   "reborn root tests and support" \
   "tests/reborn_qa_smoke_scenarios_e2e.rs
 tests/support/reborn/harness.rs


### PR DESCRIPTION
## What & why (T0-CI)

`scripts/ci/run-reborn-root-partition.sh` discovers Reborn root-test targets with
`find tests -maxdepth 1 -type f -name 'reborn_*.rs'`. The `-type f` predicate never
matches the **subdirectory `[[test]]` binaries** `tests/reborn_group_*/main.rs`, so the
cross-thread shared-persistence group suites added in #5402 **never ran in CI**.

## Approach — a dedicated low-contention job (not the modulo partition)

The `reborn_group_*` suites each spin up **one** runtime and drive several tenants' shared
libsql-backed stores **across threads**. They are sensitive to CPU contention — exactly the
condition #5465 collapsed the group harness to a single runtime to avoid. Folding them into
the modulo-partitioned root runner (where they'd share a runner with the parity tests) risks
reintroducing that contention. So instead of spraying them into the partition, they run as a
**dedicated job**:

- **New `scripts/ci/run-reborn-group-tests.sh`** discovers `tests/reborn_group_*/` dirs that
  contain a `main.rs` (via a portable `sh -c` predicate — no implementation-defined `{}`
  substitution, and no `|| true`, so genuine `find` errors stay visible) and runs each as
  `cargo test --test <dir> --features libsql` under the same
  `timeout --signal=INT --kill-after=30s` wrapper as the root runner. `--features libsql` is
  explicit so the group binaries exercise the libsql-backed shared store independently of the
  default feature set.
- **New `reborn-group-tests` job** in `reborn-tests.yml` mirrors `root-reborn-parity-tests`
  and **reuses its `reborn-tests-root` cache key** — the group `[[test]]` binaries are part
  of the same root-package build, so they hit the already-warm target rather than a cold
  cache or a second ~1 GB LRU entry. `timeout-minutes: 110` covers N suites run sequentially
  at the per-test timeout plus setup, so a hung suite reaches its own `timeout` and reports
  *which* one hung before GitHub hard-kills the job. Wired into the `Tests (Reborn)` aggregate
  gate (`needs:` + result check).
- **`scripts/ci/classify-test-scope.sh`** (and its self-test) now treats
  `run-reborn-group-tests.sh` as a Reborn-test path, so a PR touching only the new runner
  still triggers the suite that validates it.
- **`run-reborn-root-partition.sh` is reverted** to single-file `reborn_*.rs` discovery with
  no `--features libsql` on the loop — byte-identical to `main`, so root-package tests keep a
  single CI owner.

## Coverage gap closed — `reborn_group_*` binaries in CI

| binary | before | after |
|---|---|---|
| `reborn_group_approvals` | not run | `Reborn group tests` job |
| `reborn_group_extensions` | not run | `Reborn group tests` job |
| `reborn_group_memory` | not run | `Reborn group tests` job |

## Verification

- **CI (this branch):** the new `Reborn group tests` job is **green** — it ran all three
  binaries (approvals 23, extensions 22, memory 22; 0 failed) in **5m36s**, on par with the
  root partitions (~6m) thanks to the shared warm cache.
- **Local:** `cargo test --test reborn_group_approvals --test reborn_group_extensions --test
  reborn_group_memory --features libsql` — all green.
- `shellcheck` clean on both scripts + the classifier self-test; `actionlint` clean on the
  workflow; `classify-test-scope.sh` self-test passes with the new assertion.

## Prior flake — resolved by rebase

An earlier revision surfaced a pre-existing harness flake in the group binaries
(`SanitizedFailure { category: "driver_protocol_violation" }` at `group.rs`), caused by the
old N-runtime group harness masking real failure categories under CPU contention. **#5465**
(collapse group harness to one runtime + `with_checkpoint_state_store` de-mask) merged to
`main`; this branch is **rebased onto it**, so the flake is gone — the green CI run above is
over the fixed harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)