### PR TITLE
test(reborn): add extension_activate int-tier scenario (T0-EXTACT)

### DIFF
--- a/tests/reborn_group_extensions/main.rs
+++ b/tests/reborn_group_extensions/main.rs
@@ -19,9 +19,9 @@ mod support;
 
 // Declared in execution order (install → remove → activate) to match the run
 // sequence in `extensions_group_e2e` below.
+mod scenario_activate_then_active_cross_thread;
 mod scenario_install_then_visible_cross_thread;
 mod scenario_remove_then_absent_cross_thread;
-mod scenario_activate_then_active_cross_thread;
 
 use reborn_support::group::{RebornIntegrationGroup, ScenarioReport};
 

--- a/tests/reborn_group_extensions/main.rs
+++ b/tests/reborn_group_extensions/main.rs
@@ -19,9 +19,9 @@ mod support;
 
 // Declared in execution order (install → remove → activate) to match the run
 // sequence in `extensions_group_e2e` below.
-mod scenario_activate_then_active_cross_thread;
 mod scenario_install_then_visible_cross_thread;
 mod scenario_remove_then_absent_cross_thread;
+mod scenario_activate_then_active_cross_thread;
 
 use reborn_support::group::{RebornIntegrationGroup, ScenarioReport};
 

--- a/tests/reborn_group_extensions/main.rs
+++ b/tests/reborn_group_extensions/main.rs
@@ -17,11 +17,13 @@ mod reborn_support;
 #[path = "../support/mod.rs"]
 mod support;
 
-// Declared in execution order (install → remove → activate) to match the run
-// sequence in `extensions_group_e2e` below.
+// Scenario modules, declared alphabetically because rustfmt reorders `mod`
+// declarations. The execution order — install → remove → activate — is set by
+// the `report.record(...)` call sequence in `extensions_group_e2e` below, not
+// by declaration order.
+mod scenario_activate_then_active_cross_thread;
 mod scenario_install_then_visible_cross_thread;
 mod scenario_remove_then_absent_cross_thread;
-mod scenario_activate_then_active_cross_thread;
 
 use reborn_support::group::{RebornIntegrationGroup, ScenarioReport};
 

--- a/tests/reborn_group_extensions/main.rs
+++ b/tests/reborn_group_extensions/main.rs
@@ -17,8 +17,11 @@ mod reborn_support;
 #[path = "../support/mod.rs"]
 mod support;
 
+// Declared in execution order (install → remove → activate) to match the run
+// sequence in `extensions_group_e2e` below.
 mod scenario_install_then_visible_cross_thread;
 mod scenario_remove_then_absent_cross_thread;
+mod scenario_activate_then_active_cross_thread;
 
 use reborn_support::group::{RebornIntegrationGroup, ScenarioReport};
 
@@ -45,6 +48,16 @@ async fn extensions_group_e2e() {
     report.record(
         "remove_then_absent_cross_thread",
         scenario_remove_then_absent_cross_thread::run(&g).await,
+    );
+
+    // Scenario 3: install in thread A → activate in thread B → search in thread C
+    // confirms the extension reports `installation_phase:active` over the shared
+    // store. Closes the `extension_activate` int-tier gap. Independent of
+    // Scenarios 1 & 2: it uses "web-access" (the only credential-free bundled
+    // extension), untouched by "github"/"notion", so it is self-contained.
+    report.record(
+        "activate_then_active_cross_thread",
+        scenario_activate_then_active_cross_thread::run(&g).await,
     );
 
     report.assert_all_passed();

--- a/tests/reborn_group_extensions/scenario_activate_then_active_cross_thread.rs
+++ b/tests/reborn_group_extensions/scenario_activate_then_active_cross_thread.rs
@@ -105,7 +105,9 @@ pub async fn run(g: &RebornIntegrationGroup) -> HarnessResult<()> {
         ])
         .build()
         .await?;
-    viewer.submit_turn("search web-access after activation").await?;
+    viewer
+        .submit_turn("search web-access after activation")
+        .await?;
     viewer
         .assert_tool_invoked("builtin.extension_search")
         .await?;

--- a/tests/reborn_group_extensions/scenario_activate_then_active_cross_thread.rs
+++ b/tests/reborn_group_extensions/scenario_activate_then_active_cross_thread.rs
@@ -1,0 +1,153 @@
+//! Scenario 3 (HEADLINE): install an extension in thread A, ACTIVATE it in
+//! thread B (a DIFFERENT conversation), and confirm thread C (yet another
+//! conversation) observes the extension as ACTIVE — not merely installed — over
+//! the shared store. This closes the `extension_activate` int-tier gap: install,
+//! search, and remove already have cross-thread coverage; activation did not.
+//!
+//! Uses "web-access" (NOT "github"/"notion") for two reasons. First, it is the
+//! only bundled extension that activates WITHOUT credentials / without raising an
+//! auth gate, so activation reaches a SUCCESS result (`activated:true`) in this
+//! harness rather than blocking on a credential gate. "github" et al. require
+//! credentials and would return an auth gate (confirmed by the unit test
+//! `local_dev_extension_activate_returns_auth_gate_for_missing_extension_credentials`
+//! in `extension_lifecycle_capabilities.rs`). Second, it is untouched by Scenario
+//! 1 ("github") and Scenario 2 ("notion"), so a fresh install→activate cycle here
+//! observes a real lifecycle transition over the shared store rather than an
+//! already-installed/activated no-op.
+//!
+//! Key behaviours asserted (from `extension_lifecycle.rs::commit_activation` and
+//! `search_installation_phase`): a successful activate yields `"activated":true`
+//! plus a `visible_capability_ids` array of the now-published capability ids; and
+//! `extension_search` renders an ACTIVE extension as `"installation_phase":"active"`
+//! versus `"installed"` for an installed-but-not-yet-activated one.
+//!
+//! Because all three conversations use different conversation IDs but the same
+//! `Arc<HostRuntimeCapabilityHarness>`, asserting that thread C sees
+//! `installation_phase:active` proves cross-thread ACTIVATION persistence: an
+//! activate in thread B is durably visible to thread C, and the extension's
+//! capability surface (e.g. `web-access.search`) has come online.
+
+use super::reborn_support::group::{HarnessResult, RebornIntegrationGroup};
+use super::reborn_support::reply::RebornScriptedReply;
+use serde_json::json;
+
+pub async fn run(g: &RebornIntegrationGroup) -> HarnessResult<()> {
+    // ── Thread A: installer ─────────────────────────────────────────────────
+    // Install "web-access" so there is an installed-but-inactive extension to
+    // activate. The install persists to the shared HostRuntimeCapabilityHarness
+    // filesystem so the activator thread sees it immediately.
+    let installer = g
+        .thread("ext-activate-phase-install")
+        .script([
+            RebornScriptedReply::tool_call(
+                "builtin.extension_install",
+                json!({"extension_id": "web-access"}),
+            ),
+            RebornScriptedReply::text("installed"),
+        ])
+        .build()
+        .await?;
+    installer.submit_turn("install web-access").await?;
+    installer
+        .assert_tool_invoked("builtin.extension_install")
+        .await?;
+    // Confirm the install succeeded: output carries `"installed":true`.
+    installer
+        .assert_tool_result_contains("\"installed\":true")
+        .await?;
+
+    // ── Thread B: activator (DIFFERENT conversation, SAME shared store) ──────
+    // A distinct conversation_id → distinct binding/thread scope, but the same
+    // `HostRuntimeCapabilityHarness`, so the activator can see and activate the
+    // installation Thread A just wrote. "web-access" needs no credentials, so
+    // activation reaches a SUCCESS result instead of an auth gate.
+    let activator = g
+        .thread("ext-activate-phase-activate")
+        .script([
+            RebornScriptedReply::tool_call(
+                "builtin.extension_activate",
+                json!({"extension_id": "web-access"}),
+            ),
+            RebornScriptedReply::text("activated"),
+        ])
+        .build()
+        .await?;
+    activator.submit_turn("activate web-access").await?;
+    activator
+        .assert_tool_invoked("builtin.extension_activate")
+        .await?;
+    // Direct effect: activation succeeded → output carries `"activated":true`.
+    // Assert the VALUE, not just the key, so an `activated:false` / auth-gate
+    // outcome cannot satisfy this.
+    activator
+        .assert_tool_result_contains("\"activated\":true")
+        .await?;
+    // Capability surfaces: the activate payload's `visible_capability_ids` array
+    // carries the now-published capability ids. `web-access.search` coming online
+    // is the observable proof that activation published the extension's tool
+    // surface (mere install does NOT publish capabilities).
+    activator
+        .assert_tool_result_contains(r#""web-access.search""#)
+        .await?;
+
+    // ── Thread C: viewer (DIFFERENT conversation, SAME shared store) ─────────
+    // A third distinct conversation_id over the Arc-cloned store. Searching for
+    // "web-access" must now report it as ACTIVE — observing Thread B's activation
+    // across threads.
+    let viewer = g
+        .thread("ext-activate-phase-viewer")
+        .script([
+            RebornScriptedReply::tool_call(
+                "builtin.extension_search",
+                json!({"query": "web-access"}),
+            ),
+            RebornScriptedReply::text("searched"),
+        ])
+        .build()
+        .await?;
+    viewer.submit_turn("search web-access after activation").await?;
+    viewer
+        .assert_tool_invoked("builtin.extension_search")
+        .await?;
+    // Cross-thread activation persistence: the search result carries
+    // `installation_phase:"active"` only because Thread B's activation enabled the
+    // installation in the shared store. Assert the VALUE so a still-`installed`
+    // phase cannot satisfy this.
+    viewer
+        .assert_tool_result_contains(r#""installation_phase":"active""#)
+        .await?;
+
+    // Discriminating guard: an extension that was installed but NOT activated
+    // renders `installation_phase:"installed"`. Its ABSENCE here proves the phase
+    // genuinely advanced past install — a no-op activate (leaving the extension
+    // inactive) would surface `"installed"` and trip this guard.
+    if viewer
+        .assert_tool_result_contains(r#""installation_phase":"installed""#)
+        .await
+        .is_ok()
+    {
+        return Err(
+            "web-access still shows installation_phase:installed after a cross-thread activate; \
+             builtin.extension_activate did not advance the lifecycle through the shared store"
+                .into(),
+        );
+    }
+
+    // Non-vacuity guard: "web-access" must still appear in the catalog search
+    // result, proving the search actually ran and returned a catalog entry. The
+    // presence of `installation_phase:active` is therefore meaningful — not a
+    // symptom of an empty or errored result.
+    if viewer
+        .assert_tool_result_contains("\"web-access\"")
+        .await
+        .is_err()
+    {
+        return Err(
+            "non-vacuity guard failed: web-access catalog entry must appear in search results \
+             after activation; the active-phase assertion would otherwise be vacuous"
+                .into(),
+        );
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## What

Closes the **T0-EXTACT** coverage gap from the reborn backend coverage roadmap: `reborn_group_extensions` covered `extension_search`/`install`/`remove` at the integration tier cross-thread, but **`extension_activate` had no int-tier coverage**. The tools were already wired in the `extension_lifecycle()` group harness; this PR is pure authoring.

## Scenario added

`tests/reborn_group_extensions/scenario_activate_then_active_cross_thread.rs` (registered as Scenario 3 in `main.rs`), mirroring the two existing cross-thread lifecycle scenarios:

- **Thread A** installs the `web-access` bundled extension → asserts `"installed":true`.
- **Thread B** (different conversation, same Arc-shared `HostRuntimeCapabilityHarness`) activates it → asserts `"activated":true` **and** that the activate payload's `visible_capability_ids` publishes `web-access.search` (the capability surface coming online).
- **Thread C** (third conversation) searches `web-access` → asserts `"installation_phase":"active"`, proving the activation persisted cross-thread.

Guards: a discriminating guard (absence of `installation_phase:"installed"`) catches a no-op activation, and a non-vacuity guard requires the `web-access` catalog entry to appear so the active-phase assertion is meaningful.

### Why `web-access`

It is the only bundled extension that activates **without** raising a credential auth gate (confirmed by `local_dev_extension_activate_returns_auth_gate_for_missing_extension_credentials`), so activation reaches a SUCCESS result rather than blocking on credentials. It is also untouched by the existing `github`/`notion` scenarios, so the install→activate cycle is a genuine fresh transition over the shared store.

## Mutation proof

Forcing `commit_activation` (`extension_lifecycle.rs`) to persist `ExtensionActivationState::Installed` instead of `Enabled` (activation no-op) turns **only this scenario** RED with:

```
activate_then_active_cross_thread: no recorded capability result containing
"\"installation_phase\":\"active\""; saw results for ["builtin.extension_search"]
```

The sibling install/remove scenarios stay green. Reverted before commit.

## Verification

- `cargo clippy --all --tests --all-features -- -D warnings` — clean
- `reborn_group_extensions` green: 3/3 under `--features libsql`, 5/5 under `--all-features`
- One intermittent failure observed matched the **known pre-existing harness flake** (panic at `tests/support/reborn/group.rs:498`, `driver_protocol_violation`, surfaced by T0-CI) — NOT this scenario's assertion (which produces the distinct `installation_phase:"active"` message seen during mutation testing). `group.rs` was not touched.

## Notes / deferred

- Post-impl review (thermo-nuclear + code-review lenses, Sonnet) returned only LOW findings; applied module-order + escaping consistency + doc trim. Kept the `web-access.search` capability-surface assertion because the task explicitly requires asserting "its capability surfaces"; its comment notes it is a distinct (publication) invariant from cross-thread persistence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)