### PR TITLE
test(reborn): add memory_search/memory_tree int-tier scenarios (T0-MEMQ)

### DIFF
--- a/tests/reborn_group_memory/main.rs
+++ b/tests/reborn_group_memory/main.rs
@@ -6,9 +6,11 @@
 //!
 //! ## Why one sequential `#[tokio::test]`
 //!
-//! Scenario 1's writer must complete before the reader runs; a shared group
-//! instance cannot be split across Cargo test cases without fragile global
-//! state. One orchestrating function gives deterministic ordering for free.
+//! Each scenario's writer must complete before its reader/searcher/lister runs;
+//! a shared group instance cannot be split across Cargo test cases without
+//! fragile global state. One orchestrating function gives deterministic ordering
+//! for free. Each scenario seeds its own data, so they are independent and the
+//! ordering between scenarios does not matter.
 
 #[allow(dead_code)]
 #[path = "../support/reborn/mod.rs"]
@@ -17,6 +19,8 @@ mod reborn_support;
 #[path = "../support/mod.rs"]
 mod support;
 
+mod scenario_memory_search_finds_seeded;
+mod scenario_memory_tree_reflects_structure;
 mod scenario_write_then_read_cross_thread;
 
 use reborn_support::group::{RebornIntegrationGroup, ScenarioReport};
@@ -34,6 +38,20 @@ async fn memory_group_e2e() {
     report.record(
         "write_then_read_cross_thread",
         scenario_write_then_read_cross_thread::run(&g).await,
+    );
+
+    // Scenario 2: seed a document, then locate it via `memory_search` from a
+    // different conversation over the shared FTS-backed store.
+    report.record(
+        "memory_search_finds_seeded",
+        scenario_memory_search_finds_seeded::run(&g).await,
+    );
+
+    // Scenario 3: seed a nested document, then assert `memory_tree` reflects the
+    // directory structure when listed from a different conversation.
+    report.record(
+        "memory_tree_reflects_structure",
+        scenario_memory_tree_reflects_structure::run(&g).await,
     );
 
     report.assert_all_passed();

--- a/tests/reborn_group_memory/scenario_memory_search_finds_seeded.rs
+++ b/tests/reborn_group_memory/scenario_memory_search_finds_seeded.rs
@@ -1,0 +1,72 @@
+//! Scenario 2: seed a document in thread A, locate it via `memory_search` in
+//! thread B over the shared store.
+//!
+//! `memory_search` projects each written document into FTS chunk records inside
+//! the shared `RootFilesystem` (see `ironclaw_memory_native`'s repository chunk
+//! projection). Because the group's threads share one underlying filesystem, a
+//! search issued from a *different* conversation hits the chunks the writer
+//! committed — exercising both the write→reindex path and the search-surface
+//! path end to end at int tier.
+
+use super::reborn_support::group::{HarnessResult, RebornIntegrationGroup};
+use super::reborn_support::reply::RebornScriptedReply;
+use serde_json::json;
+
+pub async fn run(g: &RebornIntegrationGroup) -> HarnessResult<()> {
+    // ── Thread A: writer ────────────────────────────────────────────────────
+    // Seed a short, distinctive sentence so the FTS snippet returned by search
+    // contains the marker token verbatim.
+    let writer = g
+        .thread("conv-memory-search-writer")
+        .script([
+            RebornScriptedReply::tool_call(
+                "builtin.memory_write",
+                json!({
+                    "target": "memory",
+                    "content": "remember that the staging rollback codename is osprey-meridian-7",
+                    "append": false
+                }),
+            ),
+            RebornScriptedReply::text("seeded"),
+        ])
+        .build()
+        .await?;
+    writer.submit_turn("note the rollback codename").await?;
+    writer.assert_tool_invoked("builtin.memory_write").await?;
+
+    // ── Thread B: searcher (DIFFERENT conversation, SAME shared store) ──────
+    // A natural-language query whose terms overlap the seeded sentence. The
+    // matched chunk's `content` snippet surfaces the marker token, proving the
+    // search actually located the seeded document rather than returning empty.
+    let searcher = g
+        .thread("conv-memory-searcher")
+        .script([
+            RebornScriptedReply::tool_call(
+                "builtin.memory_search",
+                json!({"query": "staging rollback codename", "limit": 5}),
+            ),
+            RebornScriptedReply::text("found"),
+        ])
+        .build()
+        .await?;
+    searcher.submit_turn("what is the rollback codename").await?;
+    searcher.assert_tool_invoked("builtin.memory_search").await?;
+    // The hit's snippet includes the marker → search located the seeded doc.
+    searcher.assert_tool_result_contains("osprey-meridian-7").await?;
+
+    // Committed negative guard (non-vacuity): a marker that was never written
+    // must be ABSENT from the search result, so `assert_tool_result_contains`
+    // is proven to discriminate rather than pass unconditionally (e.g. if the
+    // search silently returned every document or an empty-but-stringified set).
+    if searcher
+        .assert_tool_result_contains("tungsten-mirage-88")
+        .await
+        .is_ok()
+    {
+        return Err(
+            "negative guard failed: search result must not contain an unwritten marker".into(),
+        );
+    }
+
+    Ok(())
+}

--- a/tests/reborn_group_memory/scenario_memory_search_finds_seeded.rs
+++ b/tests/reborn_group_memory/scenario_memory_search_finds_seeded.rs
@@ -49,10 +49,16 @@ pub async fn run(g: &RebornIntegrationGroup) -> HarnessResult<()> {
         ])
         .build()
         .await?;
-    searcher.submit_turn("what is the rollback codename").await?;
-    searcher.assert_tool_invoked("builtin.memory_search").await?;
+    searcher
+        .submit_turn("what is the rollback codename")
+        .await?;
+    searcher
+        .assert_tool_invoked("builtin.memory_search")
+        .await?;
     // The hit's snippet includes the marker → search located the seeded doc.
-    searcher.assert_tool_result_contains("osprey-meridian-7").await?;
+    searcher
+        .assert_tool_result_contains("osprey-meridian-7")
+        .await?;
 
     // Committed negative guard (non-vacuity): a marker that was never written
     // must be ABSENT from the search result, so `assert_tool_result_contains`

--- a/tests/reborn_group_memory/scenario_memory_tree_reflects_structure.rs
+++ b/tests/reborn_group_memory/scenario_memory_tree_reflects_structure.rs
@@ -39,10 +39,7 @@ pub async fn run(g: &RebornIntegrationGroup) -> HarnessResult<()> {
     let lister = g
         .thread("conv-memory-tree-lister")
         .script([
-            RebornScriptedReply::tool_call(
-                "builtin.memory_tree",
-                json!({"path": "", "depth": 3}),
-            ),
+            RebornScriptedReply::tool_call("builtin.memory_tree", json!({"path": "", "depth": 3})),
             RebornScriptedReply::text("listed"),
         ])
         .build()
@@ -58,9 +55,7 @@ pub async fn run(g: &RebornIntegrationGroup) -> HarnessResult<()> {
     // must be ABSENT, so the positive assertions discriminate rather than pass
     // unconditionally.
     if lister.assert_tool_result_contains("phantom/").await.is_ok() {
-        return Err(
-            "negative guard failed: tree must not contain an uncreated directory".into(),
-        );
+        return Err("negative guard failed: tree must not contain an uncreated directory".into());
     }
 
     Ok(())

--- a/tests/reborn_group_memory/scenario_memory_tree_reflects_structure.rs
+++ b/tests/reborn_group_memory/scenario_memory_tree_reflects_structure.rs
@@ -1,0 +1,67 @@
+//! Scenario 3: seed a nested document in thread A, then assert `memory_tree`
+//! reflects that directory structure when listed from thread B.
+//!
+//! `memory_tree` walks the shared workspace filesystem and returns a compact
+//! JSON array where directories render as `"<name>/"` (with children nested as
+//! `{"<name>/": [..]}`) and files render as plain strings. Seeding a path with
+//! intermediate directories and then listing the root proves the tree surface
+//! materializes the real structure end to end at int tier.
+
+use super::reborn_support::group::{HarnessResult, RebornIntegrationGroup};
+use super::reborn_support::reply::RebornScriptedReply;
+use serde_json::json;
+
+pub async fn run(g: &RebornIntegrationGroup) -> HarnessResult<()> {
+    // ── Thread A: writer ────────────────────────────────────────────────────
+    // Write to a nested path so the tree must materialize an intermediate
+    // directory (`atlas/`) and the leaf file (`runbook.md`).
+    let writer = g
+        .thread("conv-memory-tree-writer")
+        .script([
+            RebornScriptedReply::tool_call(
+                "builtin.memory_write",
+                json!({
+                    "target": "projects/atlas/runbook.md",
+                    "content": "atlas service rollback runbook",
+                    "append": false
+                }),
+            ),
+            RebornScriptedReply::text("seeded"),
+        ])
+        .build()
+        .await?;
+    writer.submit_turn("save the atlas runbook").await?;
+    writer.assert_tool_invoked("builtin.memory_write").await?;
+
+    // ── Thread B: lister (DIFFERENT conversation, SAME shared store) ────────
+    // List from the root with enough depth to reach the leaf
+    // (projects=1, atlas=2, runbook.md=3).
+    let lister = g
+        .thread("conv-memory-tree-lister")
+        .script([
+            RebornScriptedReply::tool_call(
+                "builtin.memory_tree",
+                json!({"path": "", "depth": 3}),
+            ),
+            RebornScriptedReply::text("listed"),
+        ])
+        .build()
+        .await?;
+    lister.submit_turn("show the memory tree").await?;
+    lister.assert_tool_invoked("builtin.memory_tree").await?;
+    // The serialized tree array must contain both the intermediate directory
+    // and the leaf file, proving the structure was reflected (not dropped).
+    lister.assert_tool_result_contains("atlas/").await?;
+    lister.assert_tool_result_contains("runbook.md").await?;
+
+    // Committed negative guard (non-vacuity): a directory that was never created
+    // must be ABSENT, so the positive assertions discriminate rather than pass
+    // unconditionally.
+    if lister.assert_tool_result_contains("phantom/").await.is_ok() {
+        return Err(
+            "negative guard failed: tree must not contain an uncreated directory".into(),
+        );
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## What

Closes **T0-MEMQ** from the Reborn backend coverage roadmap (`docs/reborn/reborn-backend-coverage-roadmap.md`, Tier 0). Adds two integration-tier scenarios to the `reborn_group_memory` group, covering the `builtin.memory_search` and `builtin.memory_tree` first-party tools — already registered by `builtin_tools()` but previously exercised only at trace/QA tier in-process int-tier.

## Scenarios added

- **`memory_search_finds_seeded`** (`tests/reborn_group_memory/scenario_memory_search_finds_seeded.rs`) — writer conversation seeds a distinctive sentence via `memory_write` (`target: "memory"`); a *different* conversation issues `memory_search` over the shared store and asserts the hit's snippet surfaces the marker (`osprey-meridian-7`). This exercises the write→reindex→FTS-chunk-projection→search path end to end. Cross-thread search works because the chunk records + FTS index live in the shared `RootFilesystem`.
- **`memory_tree_reflects_structure`** (`tests/reborn_group_memory/scenario_memory_tree_reflects_structure.rs`) — writer seeds a nested path (`projects/atlas/runbook.md`); a different conversation lists via `memory_tree` (root, depth 3) and asserts both the intermediate directory (`atlas/`) and the leaf (`runbook.md`) appear.

Both mirror the existing `scenario_write_then_read_cross_thread.rs` pattern (writer + `assert_tool_invoked`, then `assert_tool_result_contains` on the consumer) and each carries a committed **negative guard** (an unwritten marker / uncreated directory) so the positive assertion is proven to discriminate rather than pass vacuously.

## Mutation proof (protocol #4)

Code-under-test: `crates/ironclaw_host_runtime/src/first_party_tools/memory.rs`.

- Forced `search_response_to_value` to emit **empty** results → only `memory_search_finds_seeded` went RED: *"no recorded capability result containing osprey-meridian-7"*. Reverted.
- Forced `tree_response_to_value` to return an **empty array** → only `memory_tree_reflects_structure` went RED: *"no recorded capability result containing atlas/"*. Reverted.

Each mutation reddened exactly the intended scenario for the right reason; the other scenarios stayed green.

## Verification

- `cargo build --tests --all-features` — green
- `cargo clippy --all --tests --all-features -- -D warnings` — clean
- `reborn_group_memory` green under `--features libsql` and `--all-features` (5× consecutive under all-features, no flake)
- Post-impl review (thermo-nuclear / approach / local-patterns / maintainability lenses via Sonnet reviewer): clean, no defects.

## Notes / deferred

- No production code changed — pure test authoring. The two mutation edits above were temporary and reverted (the host_runtime file has no net diff).
- T0-MEMQ has no merged-dependency gate; branched from `main` (`efcacdc50`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)