### PR TITLE
ci: use canonical Reborn live QA harness for PR canaries

### DIFF
--- a/.github/workflows/live-canary.yml
+++ b/.github/workflows/live-canary.yml
@@ -652,6 +652,32 @@ jobs:
         with:
           persist-credentials: false
           ref: ${{ steps.validate_reborn_webui_v2_target.outputs.checkout_ref || steps.default_reborn_webui_v2_target.outputs.checkout_ref }}
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        if: >
+          steps.resolve_reborn_webui_v2_cases.outputs.skip_shard != '1' &&
+          github.event_name == 'workflow_dispatch' &&
+          inputs.target_ref != ''
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.repository.default_branch }}
+          path: .canonical-live-qa-harness
+      - name: Restore canonical Reborn WebUI v2 live QA harness
+        if: >
+          steps.resolve_reborn_webui_v2_cases.outputs.skip_shard != '1' &&
+          github.event_name == 'workflow_dispatch' &&
+          inputs.target_ref != ''
+        run: |
+          set -euo pipefail
+          harness_ref="$(git -C .canonical-live-qa-harness rev-parse HEAD)"
+          rm -rf scripts/reborn_webui_v2_live_qa scripts/live-canary
+          cp -a .canonical-live-qa-harness/scripts/reborn_webui_v2_live_qa scripts/
+          cp -a .canonical-live-qa-harness/scripts/live-canary scripts/
+          cp .canonical-live-qa-harness/tests/e2e/pyproject.toml tests/e2e/pyproject.toml
+          mkdir -p tests/e2e/ironclaw_e2e.egg-info
+          cp .canonical-live-qa-harness/tests/e2e/ironclaw_e2e.egg-info/PKG-INFO tests/e2e/ironclaw_e2e.egg-info/PKG-INFO
+          cp .canonical-live-qa-harness/tests/e2e/ironclaw_e2e.egg-info/requires.txt tests/e2e/ironclaw_e2e.egg-info/requires.txt
+          rm -rf .canonical-live-qa-harness
+          echo "REBORN_WEBUI_V2_LIVE_QA_HARNESS_REF=${harness_ref}" >> "${GITHUB_ENV}"
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         if: steps.resolve_reborn_webui_v2_cases.outputs.skip_shard != '1'
         with:

--- a/scripts/live-canary/run.sh
+++ b/scripts/live-canary/run.sh
@@ -106,6 +106,7 @@ write_env_summary() {
     echo "playwright_install=${PLAYWRIGHT_INSTALL}"
     echo "python_bin=${PYTHON_BIN}"
     echo "cases=${CASES:-<default>}"
+    echo "reborn_webui_v2_live_qa_harness_ref=${REBORN_WEBUI_V2_LIVE_QA_HARNESS_REF:-<checkout>}"
     echo "skip_build=${SKIP_BUILD:-0}"
     echo "skip_python_bootstrap=${SKIP_PYTHON_BOOTSTRAP:-0}"
   } > "${ENV_FILE}"

--- a/scripts/live-canary/test_run_dispatch.py
+++ b/scripts/live-canary/test_run_dispatch.py
@@ -46,11 +46,12 @@ class RunShDispatchTests(unittest.TestCase):
                 check=True,
             )
 
-    def test_reborn_all_cases_dispatches_all_cases_flag(self):
+    def test_reborn_all_cases_dispatches_non_telegram_qa_flag(self):
         result = self.run_dispatch(cases="all")
 
         self.assertIn("scripts/reborn_webui_v2_live_qa/run_live_qa.py", result.stdout)
-        self.assertIn("--all-cases", result.stdout)
+        self.assertIn("--non-telegram-qa-cases", result.stdout)
+        self.assertNotIn("--all-cases", result.stdout)
         self.assertNotIn("--case all", result.stdout)
 
     def test_reborn_specific_cases_dispatch_as_repeated_case_flags(self):


### PR DESCRIPTION
## Summary
- restore the Reborn WebUI v2 live QA harness from the canonical workflow commit when `/canary` targets a PR SHA
- keep the PR branch checkout for product code/builds, but avoid stale PR copies of `scripts/reborn_webui_v2_live_qa` and `scripts/live-canary`
- record `reborn_webui_v2_live_qa_harness_ref` in `env-summary.txt` so artifacts show which harness version ran
- update the live-canary dispatch test to expect the current non-Telegram full QA flag

## Why
The 2026-06-30 12:20 Istanbul `/canary PR #5373` run failed QA 3B and QA 6C even though the assistant completed the requested work. Artifacts showed the tested PR SHA `a7bc712...` used stale strict harness checks (`["status"]` and `["ABC", "spreadsheet"]`) while the canonical harness already accepted the successful variants (`HTTP 200`, `up`, `sheet`, `near.ai`, etc.).

This makes `/canary` use current canonical QA assertions while still testing the target PR product code.

## Verification
- `bash -n scripts/live-canary/run.sh`
- `python3 -m pytest scripts/live-canary/test_run_dispatch.py scripts/live-canary/test_emit_results_json.py -q`
- `python3 -m pytest scripts/reborn_webui_v2_live_qa/test_run_live_qa.py -q`