### PR TITLE
Make missing outbound delivery targets recoverable

### DIFF
--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/outbound_delivery.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/outbound_delivery.rs
@@ -207,10 +207,23 @@ impl LocalDevSyntheticCapabilityHandler for OutboundDeliveryTargetSetHandler {
                 .await
                 .map_err(|error| approval_lease_error("consume_approval_lease", error))?;
         }
-        let response =
-            set_outbound_delivery_target_for_model(self.facade.as_ref(), caller, target_input)
-                .await
-                .map_err(|error| outbound_delivery_host_error("set_target", error))?;
+        let response = match set_outbound_delivery_target_for_model(
+            self.facade.as_ref(),
+            caller,
+            target_input,
+        )
+        .await
+        {
+            Ok(response) => response,
+            Err(error) if error.code == RebornServicesErrorCode::NotFound => {
+                return Ok(CapabilityOutcome::Failed(CapabilityFailure {
+                    error_kind: CapabilityFailureKind::InvalidInput,
+                    safe_summary: "outbound delivery target is not available".to_string(),
+                    detail: None,
+                }));
+            }
+            Err(error) => return Err(outbound_delivery_host_error("set_target", error)),
+        };
         let output = serde_json::to_value(response).map_err(|error| {
             AgentLoopHostError::new(
                 AgentLoopHostErrorKind::Internal,

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/outbound_delivery.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/outbound_delivery.rs
@@ -201,12 +201,6 @@ impl LocalDevSyntheticCapabilityHandler for OutboundDeliveryTargetSetHandler {
 
         let target_summary = target_input.target_id().as_str().to_string();
         let caller = caller_for_run(&invocation, &self.fallback_user_id);
-        if let Some(approved_lease) = approved_lease {
-            self.capability_leases
-                .consume(&approved_lease.scope, approved_lease.lease_id)
-                .await
-                .map_err(|error| approval_lease_error("consume_approval_lease", error))?;
-        }
         let response = match set_outbound_delivery_target_for_model(
             self.facade.as_ref(),
             caller,
@@ -224,6 +218,12 @@ impl LocalDevSyntheticCapabilityHandler for OutboundDeliveryTargetSetHandler {
             }
             Err(error) => return Err(outbound_delivery_host_error("set_target", error)),
         };
+        if let Some(approved_lease) = approved_lease {
+            self.capability_leases
+                .consume(&approved_lease.scope, approved_lease.lease_id)
+                .await
+                .map_err(|error| approval_lease_error("consume_approval_lease", error))?;
+        }
         let output = serde_json::to_value(response).map_err(|error| {
             AgentLoopHostError::new(
                 AgentLoopHostErrorKind::Internal,

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/tests.rs
@@ -2164,6 +2164,40 @@ mod tests {
             run_context.scope.tenant_id.clone(),
             actor_user_id.clone(),
         );
+        let missing_target_id =
+            RebornOutboundDeliveryTargetId::new("slack:missing-dm").expect("target id");
+        let missing_set_candidate = port
+            .register_provider_tool_call(RegisterProviderToolCallRequest::new(
+                provider_tool_call_with_name(
+                    "builtin__outbound_delivery_target_set",
+                    serde_json::json!({ "target_id": missing_target_id.as_str() }),
+                ),
+            ))
+            .await
+            .expect("missing-target set call stages");
+        let missing_set_outcome = port
+            .invoke_capability(invocation_for_candidate(&missing_set_candidate))
+            .await
+            .expect("missing-target set call returns a capability outcome");
+        match missing_set_outcome {
+            CapabilityOutcome::Failed(failure) => {
+                assert_eq!(failure.error_kind, CapabilityFailureKind::InvalidInput);
+                assert_eq!(
+                    failure.safe_summary,
+                    "outbound delivery target is not available"
+                );
+            }
+            outcome => panic!("missing target should fail non-terminally, got {outcome:?}"),
+        }
+        assert!(
+            local_runtime
+                .outbound_preferences
+                .load_communication_preference(owner_preference_key.clone())
+                .await
+                .expect("owner preference read after missing-target set")
+                .is_none()
+        );
+
         let set_candidate = port
             .register_provider_tool_call(RegisterProviderToolCallRequest::new(
                 provider_tool_call_with_name(

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/tests.rs
@@ -1840,6 +1840,118 @@ mod tests {
             .await
             .expect("disable global auto-approve"); // safety: test-only gating precondition
         }
+        let set_capability_id =
+            CapabilityId::new(OUTBOUND_DELIVERY_TARGET_SET_CAPABILITY_ID).expect("capability id");
+
+        let missing_target_id =
+            RebornOutboundDeliveryTargetId::new("slack:missing-approved-dm").expect("target id");
+        let missing_set_candidate = port
+            .register_provider_tool_call(RegisterProviderToolCallRequest::new(
+                provider_tool_call_with_name(
+                    "builtin__outbound_delivery_target_set",
+                    serde_json::json!({ "target_id": missing_target_id.as_str() }),
+                ),
+            ))
+            .await
+            .expect("missing-target set call stages");
+        let missing_set_activity_id = missing_set_candidate.activity_id;
+        let missing_set_surface_version = missing_set_candidate.surface_version.clone();
+        let missing_set_capability_id_from_candidate = missing_set_candidate.capability_id.clone();
+        let missing_blocked_outcome = port
+            .invoke_capability(invocation_for_candidate(&missing_set_candidate))
+            .await
+            .expect("missing-target set call reaches approval gate");
+        let missing_approval_resume = match missing_blocked_outcome {
+            CapabilityOutcome::ApprovalRequired {
+                gate_ref,
+                approval_resume: Some(resume),
+                ..
+            } => {
+                assert!(gate_ref.as_str().starts_with("gate:approval-"));
+                resume
+            }
+            outcome => panic!("missing-target set should require approval, got {outcome:?}"),
+        };
+        let missing_invocation_id =
+            InvocationId::parse(missing_approval_resume.resume_token.as_str())
+                .expect("missing-target resume token carries invocation id");
+        let mut missing_approval_scope = run_context.scope.to_resource_scope();
+        missing_approval_scope.user_id = owner_user_id.clone();
+        missing_approval_scope.invocation_id = missing_invocation_id;
+        let missing_approval = local_runtime
+            .capability_policy
+            .lease_approval_for(
+                crate::local_dev_capability_policy::LocalDevApprovalPolicyAction::Dispatch {
+                    capability: &set_capability_id,
+                },
+                &local_runtime.workspace_mounts,
+                &local_runtime.skill_mounts,
+                &local_runtime.memory_mounts,
+                &local_runtime.system_extensions_lifecycle_mounts,
+            )
+            .expect("missing-target outbound delivery approval lease terms");
+        ApprovalResolver::new(
+            local_runtime.approval_requests.as_ref(),
+            local_runtime.capability_leases.as_ref(),
+        )
+        .approve_dispatch(
+            &missing_approval_scope,
+            missing_approval_resume.approval_request_id,
+            missing_approval,
+        )
+        .await
+        .expect("missing-target approval issues dispatch lease");
+        let missing_lease_id = local_runtime
+            .capability_leases
+            .leases_for_scope(&missing_approval_scope)
+            .await
+            .into_iter()
+            .find(|lease| lease.grant.capability == set_capability_id)
+            .expect("missing-target approval lease exists")
+            .grant
+            .id;
+
+        let missing_set_outcome = port
+            .invoke_capability(CapabilityInvocation {
+                activity_id: missing_set_activity_id,
+                surface_version: missing_set_surface_version,
+                capability_id: missing_set_capability_id_from_candidate,
+                input_ref: CapabilityInputRef::new("input:missing-target-approval-resume")
+                    .expect("missing-target input ref"),
+                approval_resume: Some(missing_approval_resume),
+                auth_resume: None,
+            })
+            .await
+            .expect("approved missing-target set call returns a capability outcome");
+        match missing_set_outcome {
+            CapabilityOutcome::Failed(failure) => {
+                assert_eq!(failure.error_kind, CapabilityFailureKind::InvalidInput);
+                assert_eq!(
+                    failure.safe_summary,
+                    "outbound delivery target is not available"
+                );
+            }
+            outcome => {
+                panic!("approved missing target should fail non-terminally, got {outcome:?}")
+            }
+        }
+        assert!(
+            local_runtime
+                .outbound_preferences
+                .load_communication_preference(owner_preference_key.clone())
+                .await
+                .expect("owner preference read after approved missing-target set")
+                .is_none()
+        );
+        let missing_leases = local_runtime
+            .capability_leases
+            .leases_for_scope(&missing_approval_scope)
+            .await;
+        let missing_lease = missing_leases
+            .iter()
+            .find(|lease| lease.grant.id == missing_lease_id)
+            .expect("missing-target approval lease remains");
+        assert_eq!(missing_lease.status, CapabilityLeaseStatus::Claimed);
 
         let set_candidate = port
             .register_provider_tool_call(RegisterProviderToolCallRequest::new(
@@ -1886,8 +1998,6 @@ mod tests {
                 .is_none()
         );
 
-        let set_capability_id =
-            CapabilityId::new(OUTBOUND_DELIVERY_TARGET_SET_CAPABILITY_ID).expect("capability id");
         let invocation_id = InvocationId::parse(approval_resume.resume_token.as_str())
             .expect("resume token carries invocation id");
         let mut approval_scope = run_context.scope.to_resource_scope();


### PR DESCRIPTION
## Summary
- Return a model-visible `CapabilityOutcome::Failed` when `builtin.outbound_delivery_target_set` is given a target id that no connected provider can resolve.
- Keep genuine backend/auth/service failures on the existing host-error path.
- Add caller-level local-dev coverage proving the missing-target case is non-terminal and does not persist an outbound preference.

## Verification
- `cargo fmt --package ironclaw_reborn_composition`
- `RUSTC=$(rustup which --toolchain 1.96.0-aarch64-apple-darwin rustc) $(rustup which --toolchain 1.96.0-aarch64-apple-darwin cargo) test -p ironclaw_reborn_composition local_dev_yolo_outbound_delivery_target_set_bypasses_approval_gate -- --nocapture`

Note: plain `cargo test ...` initially used Homebrew Rust 1.93 and failed before compilation because the workspace requires Rust 1.96; reran successfully with the installed rustup 1.96 toolchain.
