### PR TITLE
[codex] Skip durable resource writes when limits are unlimited

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ the current branch.
 | `IRONCLAW_REBORN_PROFILE` | Boot profile selector. Supported values: `local-dev`, `local-dev-yolo`, `hosted-single-tenant`, `hosted-single-tenant-volume`, `production`, `migration-dry-run`. |
 | `IRONCLAW_REBORN_POSTGRES_URL` | Production PostgreSQL storage URL when `[storage].backend = "postgres"` and `[storage].url_env` names this variable. Keep it out of `config.toml`; remote providers must use TLS. |
 | `IRONCLAW_REBORN_POSTGRES_POOL_MAX_SIZE` | Optional override for the Reborn PostgreSQL client pool size. Use this when a managed provider enforces a small session-pool cap. |
+| `IRONCLAW_RESOURCE_GOVERNOR_UNLIMITED_FAST_PATH` | Optional `true`/`1`/`yes`/`on` toggle that skips durable resource-governor reserve/reconcile/release writes when no finite limits are configured. Defaults to false so production keeps durable accounting unless this is explicitly enabled. |
 | `IRONCLAW_FILESYSTEM_POSTGRES_MIGRATION_CONNECT_MAX_WAIT_SECS` | Optional startup wait window for Postgres filesystem migration connection retries. Defaults to 300 seconds. |
 | `IRONCLAW_REBORN_SECRET_MASTER_KEY` | Production Reborn secret master key when `[storage].secret_master_key_env` names this variable. Keep it independent from the database URL and out of `config.toml`. |
 | `IRONCLAW_REBORN_LOG` | Tracing filter for the Reborn binary, for example `debug,ironclaw_reborn=trace`. |

--- a/crates/ironclaw_reborn_composition/src/error.rs
+++ b/crates/ironclaw_reborn_composition/src/error.rs
@@ -57,6 +57,9 @@ impl From<ironclaw_host_runtime::ProductionWiringReport> for RebornBuildError {
 impl From<crate::RebornCompositionError> for RebornBuildError {
     fn from(error: crate::RebornCompositionError) -> Self {
         match error {
+            crate::RebornCompositionError::InvalidConfig { reason } => {
+                Self::InvalidConfig { reason }
+            }
             crate::RebornCompositionError::MissingSecretMasterKey => Self::MissingSecretMasterKey,
             crate::RebornCompositionError::Mount(error) => Self::Mount(error),
             crate::RebornCompositionError::Filesystem(error) => Self::Filesystem(error),

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -1,6 +1,6 @@
 // arch-exempt: large_file, needs Reborn composition helper extraction, plan #4469
 #[cfg(test)]
-use std::sync::Mutex;
+use std::cell::RefCell;
 use std::{
     collections::VecDeque,
     path::{Path, PathBuf},
@@ -241,10 +241,10 @@ type LocalDevResourceGovernor =
 type LocalDevResourceGovernor = InMemoryResourceGovernor;
 
 #[cfg(test)]
-static RESOURCE_GOVERNOR_UNLIMITED_FAST_PATH_ENV_OVERRIDE: Mutex<Option<String>> = Mutex::new(None);
-
-#[cfg(test)]
-static RESOURCE_GOVERNOR_UNLIMITED_FAST_PATH_ENV_TEST_LOCK: Mutex<()> = Mutex::new(());
+thread_local! {
+    static RESOURCE_GOVERNOR_UNLIMITED_FAST_PATH_ENV_OVERRIDE: RefCell<Option<String>> =
+        const { RefCell::new(None) };
+}
 
 #[cfg(any(feature = "libsql", feature = "postgres", test))]
 const RESOURCE_GOVERNOR_UNLIMITED_FAST_PATH_ENV: &str =
@@ -1749,12 +1749,8 @@ fn resource_governor_unlimited_fast_path_enabled_from_env() -> Result<bool, Stri
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 fn resource_governor_unlimited_fast_path_env_value() -> Result<Option<String>, String> {
     #[cfg(test)]
-    if let Some(value) = RESOURCE_GOVERNOR_UNLIMITED_FAST_PATH_ENV_OVERRIDE
-        .lock()
-        .map_err(|_| {
-            format!("{RESOURCE_GOVERNOR_UNLIMITED_FAST_PATH_ENV} test override lock poisoned")
-        })?
-        .clone()
+    if let Some(value) =
+        RESOURCE_GOVERNOR_UNLIMITED_FAST_PATH_ENV_OVERRIDE.with(|value| value.borrow().clone())
     {
         return Ok(Some(value));
     }
@@ -1772,12 +1768,8 @@ fn resource_governor_unlimited_fast_path_env_value() -> Result<Option<String>, S
 fn set_resource_governor_unlimited_fast_path_env_override_for_test(
     value: impl Into<String>,
 ) -> Result<ResourceGovernorFastPathEnvOverrideGuard, String> {
-    let mut override_value = RESOURCE_GOVERNOR_UNLIMITED_FAST_PATH_ENV_OVERRIDE
-        .lock()
-        .map_err(|_| {
-            format!("{RESOURCE_GOVERNOR_UNLIMITED_FAST_PATH_ENV} test override lock poisoned")
-        })?;
-    *override_value = Some(value.into());
+    RESOURCE_GOVERNOR_UNLIMITED_FAST_PATH_ENV_OVERRIDE
+        .with(|override_value| *override_value.borrow_mut() = Some(value.into()));
     Ok(ResourceGovernorFastPathEnvOverrideGuard)
 }
 
@@ -1787,9 +1779,8 @@ struct ResourceGovernorFastPathEnvOverrideGuard;
 #[cfg(test)]
 impl Drop for ResourceGovernorFastPathEnvOverrideGuard {
     fn drop(&mut self) {
-        if let Ok(mut override_value) = RESOURCE_GOVERNOR_UNLIMITED_FAST_PATH_ENV_OVERRIDE.lock() {
-            *override_value = None;
-        }
+        RESOURCE_GOVERNOR_UNLIMITED_FAST_PATH_ENV_OVERRIDE
+            .with(|override_value| *override_value.borrow_mut() = None);
     }
 }
 
@@ -4258,9 +4249,6 @@ mod tests {
     #[cfg(any(feature = "libsql", feature = "postgres"))]
     #[test]
     fn build_reborn_services_rejects_invalid_resource_governor_fast_path_env() {
-        let _serial = RESOURCE_GOVERNOR_UNLIMITED_FAST_PATH_ENV_TEST_LOCK
-            .lock()
-            .expect("resource governor env test lock");
         let _override = set_resource_governor_unlimited_fast_path_env_override_for_test("maybe")
             .expect("resource governor env override");
         let dir = tempfile::tempdir().expect("tempdir");
@@ -4283,9 +4271,6 @@ mod tests {
     #[cfg(any(feature = "libsql", feature = "postgres"))]
     #[test]
     fn build_reborn_services_applies_resource_governor_fast_path_env() {
-        let _serial = RESOURCE_GOVERNOR_UNLIMITED_FAST_PATH_ENV_TEST_LOCK
-            .lock()
-            .expect("resource governor env test lock");
         let _override = set_resource_governor_unlimited_fast_path_env_override_for_test("true")
             .expect("resource governor env override");
         let dir = tempfile::tempdir().expect("tempdir");

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -1760,6 +1760,7 @@ fn build_local_dev_store_graph(
         PersistentResourceGovernor::new(FilesystemResourceGovernorStore::new(Arc::clone(
             &scoped_filesystem,
         )))
+        .with_unlimited_fast_path()
         .with_event_sink(Arc::clone(&budget_event_sink)),
     );
     let skill_mounts =
@@ -3524,7 +3525,8 @@ where
     )
     .await?;
     let resource_store = FilesystemResourceGovernorStore::new(Arc::clone(&scoped_filesystem));
-    let governor = Arc::new(PersistentResourceGovernor::new(resource_store));
+    let governor =
+        Arc::new(PersistentResourceGovernor::new(resource_store).with_unlimited_fast_path());
     let capability_leases = Arc::new(FilesystemCapabilityLeaseStore::new(Arc::clone(
         &scoped_filesystem,
     )));
@@ -3788,6 +3790,7 @@ where
         PersistentResourceGovernor::new(FilesystemResourceGovernorStore::new(Arc::clone(
             &stores.scoped_filesystem,
         )))
+        .with_unlimited_fast_path()
         .with_event_sink(Arc::clone(&budget_event_sink)),
     );
     let production_resource_governor: Arc<dyn ResourceGovernor> = resource_governor.clone();

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -1,4 +1,6 @@
 // arch-exempt: large_file, needs Reborn composition helper extraction, plan #4469
+#[cfg(test)]
+use std::sync::Mutex;
 use std::{
     collections::VecDeque,
     path::{Path, PathBuf},
@@ -89,12 +91,13 @@ use ironclaw_product_workflow::{
     LifecycleProductSurfaceContext, ProductAuthTurnGateResumeDispatcher, ProjectService,
 };
 use ironclaw_projects::ProjectRepository;
-use ironclaw_resources::InMemoryResourceGovernor;
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 use ironclaw_resources::{
     BroadcastBudgetEventSink, BudgetGateStore, FilesystemBudgetGateStore,
-    FilesystemResourceGovernorStore, PersistentResourceGovernor, ResourceGovernor,
-    ResourceGovernorStore,
+    FilesystemResourceGovernorStore, ResourceGovernor,
+};
+use ironclaw_resources::{
+    InMemoryResourceGovernor, PersistentResourceGovernor, ResourceGovernorStore,
 };
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 use ironclaw_run_state::{FilesystemApprovalRequestStore, FilesystemRunStateStore};
@@ -237,7 +240,13 @@ type LocalDevResourceGovernor =
 #[cfg(not(any(feature = "libsql", feature = "postgres")))]
 type LocalDevResourceGovernor = InMemoryResourceGovernor;
 
-#[cfg(any(feature = "libsql", feature = "postgres"))]
+#[cfg(test)]
+static RESOURCE_GOVERNOR_UNLIMITED_FAST_PATH_ENV_OVERRIDE: Mutex<Option<String>> = Mutex::new(None);
+
+#[cfg(test)]
+static RESOURCE_GOVERNOR_UNLIMITED_FAST_PATH_ENV_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+#[cfg(any(feature = "libsql", feature = "postgres", test))]
 const RESOURCE_GOVERNOR_UNLIMITED_FAST_PATH_ENV: &str =
     "IRONCLAW_RESOURCE_GOVERNOR_UNLIMITED_FAST_PATH";
 
@@ -1704,7 +1713,7 @@ fn local_dev_extension_installation_state_path(
     })
 }
 
-#[cfg(any(feature = "libsql", feature = "postgres"))]
+#[cfg_attr(not(any(feature = "libsql", feature = "postgres")), allow(dead_code))]
 fn apply_resource_governor_unlimited_fast_path<S>(
     governor: PersistentResourceGovernor<S>,
 ) -> Result<PersistentResourceGovernor<S>, String>
@@ -1718,17 +1727,68 @@ where
     }
 }
 
-#[cfg(any(feature = "libsql", feature = "postgres"))]
+#[cfg_attr(not(any(feature = "libsql", feature = "postgres")), allow(dead_code))]
 fn resource_governor_unlimited_fast_path_enabled_from_env() -> Result<bool, String> {
-    match std::env::var(RESOURCE_GOVERNOR_UNLIMITED_FAST_PATH_ENV) {
-        Ok(value) => parse_bool_env_value(&value).ok_or_else(|| {
+    #[cfg(not(any(feature = "libsql", feature = "postgres")))]
+    {
+        return Ok(false);
+    }
+
+    #[cfg(any(feature = "libsql", feature = "postgres"))]
+    match resource_governor_unlimited_fast_path_env_value() {
+        Ok(Some(value)) => parse_bool_env_value(&value).ok_or_else(|| {
             format!(
                 "{RESOURCE_GOVERNOR_UNLIMITED_FAST_PATH_ENV} must be one of true, false, 1, 0, yes, no, on, or off"
             )
         }),
-        Err(std::env::VarError::NotPresent) => Ok(false),
-        Err(std::env::VarError::NotUnicode(_)) => {
-            Err(format!("{RESOURCE_GOVERNOR_UNLIMITED_FAST_PATH_ENV} must be valid UTF-8"))
+        Ok(None) => Ok(false),
+        Err(reason) => Err(reason),
+    }
+}
+
+#[cfg(any(feature = "libsql", feature = "postgres"))]
+fn resource_governor_unlimited_fast_path_env_value() -> Result<Option<String>, String> {
+    #[cfg(test)]
+    if let Some(value) = RESOURCE_GOVERNOR_UNLIMITED_FAST_PATH_ENV_OVERRIDE
+        .lock()
+        .map_err(|_| {
+            format!("{RESOURCE_GOVERNOR_UNLIMITED_FAST_PATH_ENV} test override lock poisoned")
+        })?
+        .clone()
+    {
+        return Ok(Some(value));
+    }
+
+    match std::env::var(RESOURCE_GOVERNOR_UNLIMITED_FAST_PATH_ENV) {
+        Ok(value) => Ok(Some(value)),
+        Err(std::env::VarError::NotPresent) => Ok(None),
+        Err(std::env::VarError::NotUnicode(_)) => Err(format!(
+            "{RESOURCE_GOVERNOR_UNLIMITED_FAST_PATH_ENV} must be valid UTF-8"
+        )),
+    }
+}
+
+#[cfg(test)]
+fn set_resource_governor_unlimited_fast_path_env_override_for_test(
+    value: impl Into<String>,
+) -> Result<ResourceGovernorFastPathEnvOverrideGuard, String> {
+    let mut override_value = RESOURCE_GOVERNOR_UNLIMITED_FAST_PATH_ENV_OVERRIDE
+        .lock()
+        .map_err(|_| {
+            format!("{RESOURCE_GOVERNOR_UNLIMITED_FAST_PATH_ENV} test override lock poisoned")
+        })?;
+    *override_value = Some(value.into());
+    Ok(ResourceGovernorFastPathEnvOverrideGuard)
+}
+
+#[cfg(test)]
+struct ResourceGovernorFastPathEnvOverrideGuard;
+
+#[cfg(test)]
+impl Drop for ResourceGovernorFastPathEnvOverrideGuard {
+    fn drop(&mut self) {
+        if let Ok(mut override_value) = RESOURCE_GOVERNOR_UNLIMITED_FAST_PATH_ENV_OVERRIDE.lock() {
+            *override_value = None;
         }
     }
 }
@@ -4149,8 +4209,8 @@ mod tests {
         CapabilityGrant, CapabilityGrantId, CapabilityId, CapabilitySet, EffectKind,
         ExecutionContext, ExtensionId, GrantConstraints, InvocationId, MountAlias, MountGrant,
         MountPermissions, NetworkPolicy, NetworkScheme, NetworkTargetPattern, Principal,
-        ResourceEstimate, ResourceScope, RuntimeKind, ScopedPath, SecretHandle, TenantId,
-        TrustClass, UserId, VirtualPath,
+        ResourceEstimate, ResourceScope, ResourceUsage, RuntimeKind, ScopedPath, SecretHandle,
+        TenantId, TrustClass, UserId, VirtualPath,
     };
     #[cfg(any(feature = "libsql", feature = "postgres"))]
     use ironclaw_host_api::{
@@ -4164,6 +4224,8 @@ mod tests {
     };
     use ironclaw_product_workflow::{LifecyclePackageKind, LifecyclePackageRef, LifecyclePhase};
     use ironclaw_trust::{AuthorityCeiling, EffectiveTrustClass, TrustDecision, TrustProvenance};
+    #[cfg(any(feature = "libsql", feature = "postgres"))]
+    use rust_decimal_macros::dec;
     #[cfg(feature = "libsql")]
     use secrecy::ExposeSecret;
 
@@ -4191,6 +4253,94 @@ mod tests {
     #[test]
     fn resource_governor_fast_path_env_parser_rejects_unknown_values() {
         assert_eq!(parse_bool_env_value("maybe"), None);
+    }
+
+    #[cfg(any(feature = "libsql", feature = "postgres"))]
+    #[test]
+    fn build_reborn_services_rejects_invalid_resource_governor_fast_path_env() {
+        let _serial = RESOURCE_GOVERNOR_UNLIMITED_FAST_PATH_ENV_TEST_LOCK
+            .lock()
+            .expect("resource governor env test lock");
+        let _override = set_resource_governor_unlimited_fast_path_env_override_for_test("maybe")
+            .expect("resource governor env override");
+        let dir = tempfile::tempdir().expect("tempdir");
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime");
+
+        let result = runtime.block_on(build_reborn_services(RebornBuildInput::local_dev(
+            "resource-governor-invalid-env-owner",
+            dir.path().join("local-dev"),
+        )));
+
+        let Err(RebornBuildError::InvalidConfig { reason }) = result else {
+            panic!("expected invalid config for resource governor fast-path env");
+        };
+        assert!(reason.contains(RESOURCE_GOVERNOR_UNLIMITED_FAST_PATH_ENV));
+    }
+
+    #[cfg(any(feature = "libsql", feature = "postgres"))]
+    #[test]
+    fn build_reborn_services_applies_resource_governor_fast_path_env() {
+        let _serial = RESOURCE_GOVERNOR_UNLIMITED_FAST_PATH_ENV_TEST_LOCK
+            .lock()
+            .expect("resource governor env test lock");
+        let _override = set_resource_governor_unlimited_fast_path_env_override_for_test("true")
+            .expect("resource governor env override");
+        let dir = tempfile::tempdir().expect("tempdir");
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime");
+
+        let services = runtime
+            .block_on(build_reborn_services(RebornBuildInput::local_dev(
+                "resource-governor-enabled-env-owner",
+                dir.path().join("local-dev"),
+            )))
+            .expect("local-dev services build");
+        let local_runtime = services.local_runtime.as_ref().expect("local runtime");
+        let scope = ResourceScope {
+            tenant_id: TenantId::new("resource-governor-tenant").expect("tenant"),
+            user_id: UserId::new("resource-governor-user").expect("user"),
+            agent_id: None,
+            project_id: None,
+            mission_id: None,
+            thread_id: None,
+            invocation_id: InvocationId::new(),
+        };
+        let account = ironclaw_resources::ResourceAccount::tenant(scope.tenant_id.clone());
+
+        let reservation = local_runtime
+            .resource_governor
+            .reserve(
+                scope,
+                ResourceEstimate {
+                    usd: Some(dec!(0.10)),
+                    ..ResourceEstimate::default()
+                },
+            )
+            .expect("reservation");
+        local_runtime
+            .resource_governor
+            .reconcile(
+                reservation.id,
+                ResourceUsage {
+                    usd: dec!(0.10),
+                    ..ResourceUsage::default()
+                },
+            )
+            .expect("reconcile");
+
+        assert_eq!(
+            local_runtime
+                .resource_governor
+                .usage_for(&account)
+                .expect("usage")
+                .usd,
+            dec!(0.10)
+        );
     }
 
     #[test]

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -94,6 +94,7 @@ use ironclaw_resources::InMemoryResourceGovernor;
 use ironclaw_resources::{
     BroadcastBudgetEventSink, BudgetGateStore, FilesystemBudgetGateStore,
     FilesystemResourceGovernorStore, PersistentResourceGovernor, ResourceGovernor,
+    ResourceGovernorStore,
 };
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 use ironclaw_run_state::{FilesystemApprovalRequestStore, FilesystemRunStateStore};
@@ -235,6 +236,10 @@ type LocalDevResourceGovernor =
     PersistentResourceGovernor<FilesystemResourceGovernorStore<LocalDevRootFilesystem>>;
 #[cfg(not(any(feature = "libsql", feature = "postgres")))]
 type LocalDevResourceGovernor = InMemoryResourceGovernor;
+
+#[cfg(any(feature = "libsql", feature = "postgres"))]
+const RESOURCE_GOVERNOR_UNLIMITED_FAST_PATH_ENV: &str =
+    "IRONCLAW_RESOURCE_GOVERNOR_UNLIMITED_FAST_PATH";
 
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 type LocalDevRunStateStore = FilesystemRunStateStore<LocalDevRootFilesystem>;
@@ -1700,6 +1705,44 @@ fn local_dev_extension_installation_state_path(
 }
 
 #[cfg(any(feature = "libsql", feature = "postgres"))]
+fn apply_resource_governor_unlimited_fast_path<S>(
+    governor: PersistentResourceGovernor<S>,
+) -> Result<PersistentResourceGovernor<S>, String>
+where
+    S: ResourceGovernorStore,
+{
+    if resource_governor_unlimited_fast_path_enabled_from_env()? {
+        Ok(governor.with_unlimited_fast_path())
+    } else {
+        Ok(governor)
+    }
+}
+
+#[cfg(any(feature = "libsql", feature = "postgres"))]
+fn resource_governor_unlimited_fast_path_enabled_from_env() -> Result<bool, String> {
+    match std::env::var(RESOURCE_GOVERNOR_UNLIMITED_FAST_PATH_ENV) {
+        Ok(value) => parse_bool_env_value(&value).ok_or_else(|| {
+            format!(
+                "{RESOURCE_GOVERNOR_UNLIMITED_FAST_PATH_ENV} must be one of true, false, 1, 0, yes, no, on, or off"
+            )
+        }),
+        Err(std::env::VarError::NotPresent) => Ok(false),
+        Err(std::env::VarError::NotUnicode(_)) => {
+            Err(format!("{RESOURCE_GOVERNOR_UNLIMITED_FAST_PATH_ENV} must be valid UTF-8"))
+        }
+    }
+}
+
+#[cfg(any(feature = "libsql", feature = "postgres"))]
+fn parse_bool_env_value(value: &str) -> Option<bool> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "" | "0" | "false" | "no" | "off" => Some(false),
+        "1" | "true" | "yes" | "on" => Some(true),
+        _ => None,
+    }
+}
+
+#[cfg(any(feature = "libsql", feature = "postgres"))]
 fn build_local_dev_store_graph(
     input: RebornLocalDevStoreGraphInput,
 ) -> Result<RebornLocalDevStoreGraph, RebornBuildError> {
@@ -1756,13 +1799,13 @@ fn build_local_dev_store_graph(
     let budget_gate_store: Arc<dyn BudgetGateStore> = Arc::new(FilesystemBudgetGateStore::new(
         Arc::clone(&scoped_filesystem),
     ));
-    let resource_governor: Arc<LocalDevResourceGovernor> = Arc::new(
-        PersistentResourceGovernor::new(FilesystemResourceGovernorStore::new(Arc::clone(
-            &scoped_filesystem,
-        )))
-        .with_unlimited_fast_path()
-        .with_event_sink(Arc::clone(&budget_event_sink)),
-    );
+    let resource_governor =
+        apply_resource_governor_unlimited_fast_path(PersistentResourceGovernor::new(
+            FilesystemResourceGovernorStore::new(Arc::clone(&scoped_filesystem)),
+        ))
+        .map_err(|reason| RebornBuildError::InvalidConfig { reason })?
+        .with_event_sink(Arc::clone(&budget_event_sink));
+    let resource_governor: Arc<LocalDevResourceGovernor> = Arc::new(resource_governor);
     let skill_mounts =
         skill_management_mount_view().map_err(|error| RebornBuildError::InvalidConfig {
             reason: error.to_string(),
@@ -3525,8 +3568,11 @@ where
     )
     .await?;
     let resource_store = FilesystemResourceGovernorStore::new(Arc::clone(&scoped_filesystem));
-    let governor =
-        Arc::new(PersistentResourceGovernor::new(resource_store).with_unlimited_fast_path());
+    let governor = apply_resource_governor_unlimited_fast_path(PersistentResourceGovernor::new(
+        resource_store,
+    ))
+    .map_err(|reason| crate::RebornCompositionError::InvalidConfig { reason })?;
+    let governor = Arc::new(governor);
     let capability_leases = Arc::new(FilesystemCapabilityLeaseStore::new(Arc::clone(
         &scoped_filesystem,
     )));
@@ -3786,13 +3832,13 @@ where
     let thread_service: Arc<dyn SessionThreadService> = Arc::new(
         FilesystemSessionThreadService::new(Arc::clone(&stores.scoped_filesystem)),
     );
-    let resource_governor = Arc::new(
-        PersistentResourceGovernor::new(FilesystemResourceGovernorStore::new(Arc::clone(
-            &stores.scoped_filesystem,
-        )))
-        .with_unlimited_fast_path()
-        .with_event_sink(Arc::clone(&budget_event_sink)),
-    );
+    let resource_governor =
+        apply_resource_governor_unlimited_fast_path(PersistentResourceGovernor::new(
+            FilesystemResourceGovernorStore::new(Arc::clone(&stores.scoped_filesystem)),
+        ))
+        .map_err(|reason| RebornBuildError::InvalidConfig { reason })?
+        .with_event_sink(Arc::clone(&budget_event_sink));
+    let resource_governor = Arc::new(resource_governor);
     let production_resource_governor: Arc<dyn ResourceGovernor> = resource_governor.clone();
     let budget_gate_store: Arc<dyn BudgetGateStore> = Arc::new(FilesystemBudgetGateStore::new(
         Arc::clone(&stores.scoped_filesystem),
@@ -4129,6 +4175,23 @@ mod tests {
         },
         runtime::SKILL_ACTIVATE_CAPABILITY_ID,
     };
+
+    #[cfg(any(feature = "libsql", feature = "postgres"))]
+    #[test]
+    fn resource_governor_fast_path_env_parser_accepts_documented_values() {
+        for value in ["true", "TRUE", "1", "yes", "on", "  true  "] {
+            assert_eq!(parse_bool_env_value(value), Some(true), "value={value}");
+        }
+        for value in ["", "false", "FALSE", "0", "no", "off", "  off  "] {
+            assert_eq!(parse_bool_env_value(value), Some(false), "value={value}");
+        }
+    }
+
+    #[cfg(any(feature = "libsql", feature = "postgres"))]
+    #[test]
+    fn resource_governor_fast_path_env_parser_rejects_unknown_values() {
+        assert_eq!(parse_bool_env_value("maybe"), None);
+    }
 
     #[test]
     fn extension_installation_state_path_stays_legacy_for_local_dev() {

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -882,6 +882,8 @@ where
 
 #[derive(Debug, Error)]
 pub enum RebornCompositionError {
+    #[error("invalid reborn production configuration: {reason}")]
+    InvalidConfig { reason: String },
     #[error(
         "reborn production composition requires a configured or keychain-resolvable secret master key"
     )]

--- a/crates/ironclaw_resources/src/cas_snapshot.rs
+++ b/crates/ironclaw_resources/src/cas_snapshot.rs
@@ -130,6 +130,44 @@ where
         self.update_with_scope::<S, T, E, U>(self.scope.clone(), update)
     }
 
+    /// Read the underlying snapshot through the store's default scope without
+    /// writing it back.
+    pub(crate) fn inspect<S, T, E, U>(&self, inspect: U) -> Result<T, E>
+    where
+        S: Snapshot,
+        T: Send + 'static,
+        E: StorageError,
+        U: FnOnce(&S) -> Result<T, E> + Send + 'static,
+    {
+        self.inspect_with_scope::<S, T, E, U>(self.scope.clone(), inspect)
+    }
+
+    /// Read the underlying snapshot through a caller-supplied scope without
+    /// writing it back.
+    pub(crate) fn inspect_with_scope<S, T, E, U>(
+        &self,
+        scope: ResourceScope,
+        inspect: U,
+    ) -> Result<T, E>
+    where
+        S: Snapshot,
+        T: Send + 'static,
+        E: StorageError,
+        U: FnOnce(&S) -> Result<T, E> + Send + 'static,
+    {
+        let filesystem = Arc::clone(&self.filesystem);
+        let path_str = self.path_str;
+        let worker_cell = Arc::clone(&self.worker);
+        let worker_name = self.worker_thread_name;
+        run_on_worker(&worker_cell, worker_name, move || async move {
+            let path = ScopedPath::new(path_str.to_string()).map_err(|error| {
+                E::storage(format!("invalid snapshot path {path_str}: {error}"))
+            })?;
+            let snapshot = read_snapshot::<F, S, E>(&filesystem, &scope, &path).await?;
+            inspect(&snapshot)
+        })
+    }
+
     /// Run a read-modify-write transaction against the underlying
     /// snapshot using a caller-supplied [`ResourceScope`].
     ///
@@ -187,11 +225,10 @@ where
     U: FnOnce(&mut S) -> Result<T, E>,
 {
     let (mut snapshot, expectation) = match filesystem.get(scope, path).await {
-        Ok(Some(versioned)) => {
-            let snapshot: S = serde_json::from_slice(&versioned.entry.body)
-                .map_err(|error| E::storage(format!("decode snapshot: {error}")))?;
-            (snapshot, CasExpectation::Version(versioned.version))
-        }
+        Ok(Some(versioned)) => (
+            decode_snapshot::<S, E>(&versioned.entry.body)?,
+            CasExpectation::Version(versioned.version),
+        ),
         Ok(None) => (S::fresh(), CasExpectation::Absent),
         Err(error) => return Err(E::storage_from(error)),
     };
@@ -206,6 +243,31 @@ where
         ))),
         Err(PutError::Other(err)) => Err(err),
     }
+}
+
+async fn read_snapshot<F, S, E>(
+    filesystem: &ScopedFilesystem<F>,
+    scope: &ResourceScope,
+    path: &ScopedPath,
+) -> Result<S, E>
+where
+    F: RootFilesystem,
+    S: Snapshot,
+    E: StorageError,
+{
+    match filesystem.get(scope, path).await {
+        Ok(Some(versioned)) => decode_snapshot::<S, E>(&versioned.entry.body),
+        Ok(None) => Ok(S::fresh()),
+        Err(error) => Err(E::storage_from(error)),
+    }
+}
+
+fn decode_snapshot<S, E>(body: &[u8]) -> Result<S, E>
+where
+    S: Snapshot,
+    E: StorageError,
+{
+    serde_json::from_slice(body).map_err(|error| E::storage(format!("decode snapshot: {error}")))
 }
 
 enum PutError<E> {

--- a/crates/ironclaw_resources/src/filesystem_store.rs
+++ b/crates/ironclaw_resources/src/filesystem_store.rs
@@ -100,6 +100,15 @@ where
         self.store
             .update::<ResourceGovernorSnapshot, T, ResourceError, _>(update)
     }
+
+    fn inspect<T, U>(&self, inspect: U) -> Result<T, ResourceError>
+    where
+        T: Send + 'static,
+        U: FnOnce(&ResourceGovernorSnapshot) -> Result<T, ResourceError> + Send + 'static,
+    {
+        self.store
+            .inspect::<ResourceGovernorSnapshot, T, ResourceError, _>(inspect)
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/ironclaw_resources/src/lib.rs
+++ b/crates/ironclaw_resources/src/lib.rs
@@ -804,6 +804,14 @@ pub trait ResourceGovernorStore: Send + Sync + 'static {
     where
         T: Send + 'static,
         F: FnOnce(&mut ResourceGovernorSnapshot) -> Result<T, ResourceError> + Send + 'static;
+
+    fn inspect<T, F>(&self, inspect: F) -> Result<T, ResourceError>
+    where
+        T: Send + 'static,
+        F: FnOnce(&ResourceGovernorSnapshot) -> Result<T, ResourceError> + Send + 'static,
+    {
+        self.update(move |snapshot| inspect(snapshot))
+    }
 }
 
 /// File-backed resource-governor store using a stable sidecar lock file around
@@ -842,6 +850,33 @@ impl ResourceGovernorStore for JsonFileResourceGovernorStore {
         lock_file.lock_exclusive().map_err(storage_error)?;
 
         let result = update_file_snapshot(&self.path, update);
+        let unlock_result = lock_file.unlock().map_err(storage_error);
+        match (result, unlock_result) {
+            (Ok(value), Ok(())) => Ok(value),
+            (Err(error), _) => Err(error),
+            (Ok(_), Err(error)) => Err(error),
+        }
+    }
+
+    fn inspect<T, F>(&self, inspect: F) -> Result<T, ResourceError>
+    where
+        T: Send + 'static,
+        F: FnOnce(&ResourceGovernorSnapshot) -> Result<T, ResourceError> + Send + 'static,
+    {
+        let lock_path = lock_path_for(&self.path);
+        if let Some(parent) = lock_path.parent() {
+            std::fs::create_dir_all(parent).map_err(storage_error)?;
+        }
+        let lock_file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(lock_path)
+            .map_err(storage_error)?;
+        lock_file.lock_shared().map_err(storage_error)?;
+
+        let result = read_file_snapshot(&self.path).and_then(|snapshot| inspect(&snapshot));
         let unlock_result = lock_file.unlock().map_err(storage_error);
         match (result, unlock_result) {
             (Ok(value), Ok(())) => Ok(value),
@@ -1065,6 +1100,8 @@ where
 {
     store: S,
     clock: Arc<dyn Clock>,
+    unlimited_fast_path: bool,
+    unlimited_state: Mutex<ResourceState>,
     /// Optional sink that receives `BudgetEvent`s as reservations,
     /// reconciliations, warnings, and denials happen. Wired by
     /// composition; defaults to [`NoOpBudgetEventSink`] so the
@@ -1081,6 +1118,8 @@ where
         Self {
             store,
             clock: Arc::new(SystemClock),
+            unlimited_fast_path: false,
+            unlimited_state: Mutex::new(ResourceState::default()),
             event_sink: Arc::new(NoOpBudgetEventSink),
         }
     }
@@ -1092,8 +1131,23 @@ where
         Self {
             store,
             clock,
+            unlimited_fast_path: false,
+            unlimited_state: Mutex::new(ResourceState::default()),
             event_sink: Arc::new(NoOpBudgetEventSink),
         }
+    }
+
+    /// Keep unlimited/no-quota reservation bookkeeping process-local.
+    ///
+    /// When no finite resource limits are configured, the persistent governor
+    /// does not need durable snapshot writes to enforce limits. This opt-in
+    /// path preserves same-process reservation lifecycle checks while avoiding
+    /// synchronous writes on reserve/reconcile/release. As soon as any finite
+    /// limit is present in the durable snapshot, new reservations use the
+    /// durable path again.
+    pub fn with_unlimited_fast_path(mut self) -> Self {
+        self.unlimited_fast_path = true;
+        self
     }
 
     /// Plug in an audit/SSE sink. Every `reserve`, `reconcile`,
@@ -1122,6 +1176,15 @@ where
     pub fn reserved_for(&self, account: &ResourceAccount) -> Result<ResourceTally, ResourceError> {
         let account = account.clone();
         let now = self.clock.now();
+        if self.can_use_unlimited_fast_path()? {
+            let mut state = self.lock_unlimited_state();
+            advance_period_if_rolled_over(&mut state, &account, now);
+            return Ok(state
+                .reserved_by_account
+                .get(&account)
+                .cloned()
+                .unwrap_or_default());
+        }
         self.store.update(move |snapshot| {
             advance_period_if_rolled_over(&mut snapshot.state, &account, now);
             Ok(snapshot
@@ -1136,6 +1199,15 @@ where
     pub fn usage_for(&self, account: &ResourceAccount) -> Result<ResourceTally, ResourceError> {
         let account = account.clone();
         let now = self.clock.now();
+        if self.can_use_unlimited_fast_path()? {
+            let mut state = self.lock_unlimited_state();
+            advance_period_if_rolled_over(&mut state, &account, now);
+            return Ok(state
+                .usage_by_account
+                .get(&account)
+                .cloned()
+                .unwrap_or_default());
+        }
         self.store.update(move |snapshot| {
             advance_period_if_rolled_over(&mut snapshot.state, &account, now);
             Ok(snapshot
@@ -1145,6 +1217,26 @@ where
                 .cloned()
                 .unwrap_or_default())
         })
+    }
+
+    fn has_finite_limits(&self) -> Result<bool, ResourceError> {
+        self.store.inspect(|snapshot| {
+            Ok(snapshot
+                .state
+                .limits
+                .values()
+                .any(|limits| !limits.is_unlimited()))
+        })
+    }
+
+    fn can_use_unlimited_fast_path(&self) -> Result<bool, ResourceError> {
+        Ok(self.unlimited_fast_path && !self.has_finite_limits()?)
+    }
+
+    fn lock_unlimited_state(&self) -> MutexGuard<'_, ResourceState> {
+        self.unlimited_state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
     }
 }
 
@@ -1181,6 +1273,17 @@ where
         reservation_id: ResourceReservationId,
     ) -> Result<ReservationOutcome, ResourceError> {
         let now = self.clock.now();
+        if self.can_use_unlimited_fast_path()? {
+            let result = reserve_with_outcome_in_state(
+                &mut self.lock_unlimited_state(),
+                scope,
+                estimate,
+                reservation_id,
+                now,
+            );
+            emit_reserve_events(self.event_sink.as_ref(), &result, now);
+            return result;
+        }
         let result = self.store.update(move |snapshot| {
             reserve_with_outcome_in_state(&mut snapshot.state, scope, estimate, reservation_id, now)
         });
@@ -1194,6 +1297,26 @@ where
         actual: ResourceUsage,
     ) -> Result<ResourceReceipt, ResourceError> {
         let now = self.clock.now();
+        if self.unlimited_fast_path {
+            let result = reconcile_in_state(
+                &mut self.lock_unlimited_state(),
+                reservation_id,
+                actual.clone(),
+                now,
+            );
+            match result {
+                Ok(receipt) => {
+                    self.event_sink.emit(BudgetEvent::Reconciled {
+                        account: most_specific_account(&receipt.scope),
+                        receipt: receipt.clone(),
+                        at: now,
+                    });
+                    return Ok(receipt);
+                }
+                Err(ResourceError::UnknownReservation { .. }) => {}
+                Err(error) => return Err(error),
+            }
+        }
         let result = self.store.update(move |snapshot| {
             reconcile_in_state(&mut snapshot.state, reservation_id, actual, now)
         });
@@ -1212,6 +1335,21 @@ where
         reservation_id: ResourceReservationId,
     ) -> Result<ResourceReceipt, ResourceError> {
         let now = self.clock.now();
+        if self.unlimited_fast_path {
+            let result = release_in_state(&mut self.lock_unlimited_state(), reservation_id, now);
+            match result {
+                Ok(receipt) => {
+                    self.event_sink.emit(BudgetEvent::Released {
+                        account: most_specific_account(&receipt.scope),
+                        receipt: receipt.clone(),
+                        at: now,
+                    });
+                    return Ok(receipt);
+                }
+                Err(ResourceError::UnknownReservation { .. }) => {}
+                Err(error) => return Err(error),
+            }
+        }
         let result = self
             .store
             .update(move |snapshot| release_in_state(&mut snapshot.state, reservation_id, now));
@@ -1231,6 +1369,13 @@ where
     ) -> Result<Option<AccountSnapshot>, ResourceError> {
         let account = account.clone();
         let now = self.clock.now();
+        if self.can_use_unlimited_fast_path()? {
+            return Ok(account_snapshot_in_state(
+                &mut self.lock_unlimited_state(),
+                &account,
+                now,
+            ));
+        }
         self.store.update(move |snapshot| {
             Ok(account_snapshot_in_state(
                 &mut snapshot.state,

--- a/crates/ironclaw_resources/src/lib.rs
+++ b/crates/ironclaw_resources/src/lib.rs
@@ -808,10 +808,7 @@ pub trait ResourceGovernorStore: Send + Sync + 'static {
     fn inspect<T, F>(&self, inspect: F) -> Result<T, ResourceError>
     where
         T: Send + 'static,
-        F: FnOnce(&ResourceGovernorSnapshot) -> Result<T, ResourceError> + Send + 'static,
-    {
-        self.update(move |snapshot| inspect(snapshot))
-    }
+        F: FnOnce(&ResourceGovernorSnapshot) -> Result<T, ResourceError> + Send + 'static;
 }
 
 /// File-backed resource-governor store using a stable sidecar lock file around
@@ -1101,7 +1098,7 @@ where
     store: S,
     clock: Arc<dyn Clock>,
     unlimited_fast_path: bool,
-    unlimited_state: Mutex<ResourceState>,
+    unlimited_state: Mutex<UnlimitedFastPathState>,
     /// Optional sink that receives `BudgetEvent`s as reservations,
     /// reconciliations, warnings, and denials happen. Wired by
     /// composition; defaults to [`NoOpBudgetEventSink`] so the
@@ -1119,7 +1116,7 @@ where
             store,
             clock: Arc::new(SystemClock),
             unlimited_fast_path: false,
-            unlimited_state: Mutex::new(ResourceState::default()),
+            unlimited_state: Mutex::new(UnlimitedFastPathState::default()),
             event_sink: Arc::new(NoOpBudgetEventSink),
         }
     }
@@ -1132,7 +1129,7 @@ where
             store,
             clock,
             unlimited_fast_path: false,
-            unlimited_state: Mutex::new(ResourceState::default()),
+            unlimited_state: Mutex::new(UnlimitedFastPathState::default()),
             event_sink: Arc::new(NoOpBudgetEventSink),
         }
     }
@@ -1167,6 +1164,24 @@ where
         limits: ResourceLimits,
     ) -> Result<(), ResourceError> {
         let now = self.clock.now();
+        if self.unlimited_fast_path {
+            let mut local = self.lock_unlimited_state()?;
+            let local_state = local.state.clone();
+            let local_initialized = local.initialized;
+            let updated_state = self.store.update(move |snapshot| {
+                if local_initialized
+                    && !resource_state_has_finite_limits(&snapshot.state)
+                    && !resource_state_has_durable_activity(&snapshot.state)
+                {
+                    snapshot.state = local_state;
+                }
+                set_limit_in_state(&mut snapshot.state, account, limits, now);
+                Ok(snapshot.state.clone())
+            })?;
+            local.state = updated_state;
+            local.initialized = true;
+            return Ok(());
+        }
         self.store.update(move |snapshot| {
             set_limit_in_state(&mut snapshot.state, account, limits, now);
             Ok(())
@@ -1199,18 +1214,19 @@ where
         })
     }
 
-    fn has_finite_limits(&self) -> Result<bool, ResourceError> {
+    fn unlimited_fast_path_seed(&self) -> Result<Option<ResourceState>, ResourceError> {
+        if !self.unlimited_fast_path {
+            return Ok(None);
+        }
         self.store.inspect(|snapshot| {
-            Ok(snapshot
-                .state
-                .limits
-                .values()
-                .any(|limits| !limits.is_unlimited()))
+            if resource_state_has_finite_limits(&snapshot.state)
+                || resource_state_has_durable_activity(&snapshot.state)
+            {
+                Ok(None)
+            } else {
+                Ok(Some(snapshot.state.clone()))
+            }
         })
-    }
-
-    fn can_use_unlimited_fast_path(&self) -> Result<bool, ResourceError> {
-        Ok(self.unlimited_fast_path && !self.has_finite_limits()?)
     }
 
     fn update_active_state<T, F>(&self, update: F) -> Result<T, ResourceError>
@@ -1218,9 +1234,13 @@ where
         T: Send + 'static,
         F: FnOnce(&mut ResourceState) -> Result<T, ResourceError> + Send + 'static,
     {
-        if self.can_use_unlimited_fast_path()? {
-            let mut state = self.lock_unlimited_state();
-            return update(&mut state);
+        if let Some(seed) = self.unlimited_fast_path_seed()? {
+            let mut local = self.lock_unlimited_state()?;
+            if !local.initialized {
+                local.state = seed;
+                local.initialized = true;
+            }
+            return update(&mut local.state);
         }
         self.store
             .update(move |snapshot| update(&mut snapshot.state))
@@ -1236,9 +1256,13 @@ where
         L: FnOnce(&mut ResourceState) -> Result<T, ResourceError>,
         D: FnOnce(&mut ResourceGovernorSnapshot) -> Result<T, ResourceError> + Send + 'static,
     {
-        if self.unlimited_fast_path {
-            let mut state = self.lock_unlimited_state();
-            match local_close(&mut state) {
+        if let Some(seed) = self.unlimited_fast_path_seed()? {
+            let mut local = self.lock_unlimited_state()?;
+            if !local.initialized {
+                local.state = seed;
+                local.initialized = true;
+            }
+            match local_close(&mut local.state) {
                 Ok(value) => return Ok(value),
                 Err(ResourceError::UnknownReservation { .. }) => {}
                 Err(error) => return Err(error),
@@ -1247,10 +1271,14 @@ where
         self.store.update(durable_close)
     }
 
-    fn lock_unlimited_state(&self) -> MutexGuard<'_, ResourceState> {
+    fn lock_unlimited_state(
+        &self,
+    ) -> Result<MutexGuard<'_, UnlimitedFastPathState>, ResourceError> {
         self.unlimited_state
             .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .map_err(|_| ResourceError::Storage {
+                reason: "resource governor unlimited fast-path state lock poisoned".to_string(),
+            })
     }
 }
 
@@ -1380,6 +1408,22 @@ struct ResourceState {
     /// `ResourceLimits::period` on each mutation; v1 snapshots that lack
     /// this field migrate transparently.
     period_anchors: HashMap<ResourceAccount, DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq)]
+struct UnlimitedFastPathState {
+    state: ResourceState,
+    initialized: bool,
+}
+
+fn resource_state_has_finite_limits(state: &ResourceState) -> bool {
+    state.limits.values().any(|limits| !limits.is_unlimited())
+}
+
+fn resource_state_has_durable_activity(state: &ResourceState) -> bool {
+    !state.reserved_by_account.is_empty()
+        || !state.usage_by_account.is_empty()
+        || !state.reservations.is_empty()
 }
 
 /// Snapshot of accumulated period-scoped spend + reserved.

--- a/crates/ironclaw_resources/src/lib.rs
+++ b/crates/ironclaw_resources/src/lib.rs
@@ -1176,19 +1176,9 @@ where
     pub fn reserved_for(&self, account: &ResourceAccount) -> Result<ResourceTally, ResourceError> {
         let account = account.clone();
         let now = self.clock.now();
-        if self.can_use_unlimited_fast_path()? {
-            let mut state = self.lock_unlimited_state();
-            advance_period_if_rolled_over(&mut state, &account, now);
-            return Ok(state
-                .reserved_by_account
-                .get(&account)
-                .cloned()
-                .unwrap_or_default());
-        }
-        self.store.update(move |snapshot| {
-            advance_period_if_rolled_over(&mut snapshot.state, &account, now);
-            Ok(snapshot
-                .state
+        self.update_active_state(move |state| {
+            advance_period_if_rolled_over(state, &account, now);
+            Ok(state
                 .reserved_by_account
                 .get(&account)
                 .cloned()
@@ -1199,19 +1189,9 @@ where
     pub fn usage_for(&self, account: &ResourceAccount) -> Result<ResourceTally, ResourceError> {
         let account = account.clone();
         let now = self.clock.now();
-        if self.can_use_unlimited_fast_path()? {
-            let mut state = self.lock_unlimited_state();
-            advance_period_if_rolled_over(&mut state, &account, now);
-            return Ok(state
-                .usage_by_account
-                .get(&account)
-                .cloned()
-                .unwrap_or_default());
-        }
-        self.store.update(move |snapshot| {
-            advance_period_if_rolled_over(&mut snapshot.state, &account, now);
-            Ok(snapshot
-                .state
+        self.update_active_state(move |state| {
+            advance_period_if_rolled_over(state, &account, now);
+            Ok(state
                 .usage_by_account
                 .get(&account)
                 .cloned()
@@ -1231,6 +1211,40 @@ where
 
     fn can_use_unlimited_fast_path(&self) -> Result<bool, ResourceError> {
         Ok(self.unlimited_fast_path && !self.has_finite_limits()?)
+    }
+
+    fn update_active_state<T, F>(&self, update: F) -> Result<T, ResourceError>
+    where
+        T: Send + 'static,
+        F: FnOnce(&mut ResourceState) -> Result<T, ResourceError> + Send + 'static,
+    {
+        if self.can_use_unlimited_fast_path()? {
+            let mut state = self.lock_unlimited_state();
+            return update(&mut state);
+        }
+        self.store
+            .update(move |snapshot| update(&mut snapshot.state))
+    }
+
+    fn close_fast_path_or_durable<T, L, D>(
+        &self,
+        local_close: L,
+        durable_close: D,
+    ) -> Result<T, ResourceError>
+    where
+        T: Send + 'static,
+        L: FnOnce(&mut ResourceState) -> Result<T, ResourceError>,
+        D: FnOnce(&mut ResourceGovernorSnapshot) -> Result<T, ResourceError> + Send + 'static,
+    {
+        if self.unlimited_fast_path {
+            let mut state = self.lock_unlimited_state();
+            match local_close(&mut state) {
+                Ok(value) => return Ok(value),
+                Err(ResourceError::UnknownReservation { .. }) => {}
+                Err(error) => return Err(error),
+            }
+        }
+        self.store.update(durable_close)
     }
 
     fn lock_unlimited_state(&self) -> MutexGuard<'_, ResourceState> {
@@ -1273,19 +1287,8 @@ where
         reservation_id: ResourceReservationId,
     ) -> Result<ReservationOutcome, ResourceError> {
         let now = self.clock.now();
-        if self.can_use_unlimited_fast_path()? {
-            let result = reserve_with_outcome_in_state(
-                &mut self.lock_unlimited_state(),
-                scope,
-                estimate,
-                reservation_id,
-                now,
-            );
-            emit_reserve_events(self.event_sink.as_ref(), &result, now);
-            return result;
-        }
-        let result = self.store.update(move |snapshot| {
-            reserve_with_outcome_in_state(&mut snapshot.state, scope, estimate, reservation_id, now)
+        let result = self.update_active_state(move |state| {
+            reserve_with_outcome_in_state(state, scope, estimate, reservation_id, now)
         });
         emit_reserve_events(self.event_sink.as_ref(), &result, now);
         result
@@ -1297,29 +1300,11 @@ where
         actual: ResourceUsage,
     ) -> Result<ResourceReceipt, ResourceError> {
         let now = self.clock.now();
-        if self.unlimited_fast_path {
-            let result = reconcile_in_state(
-                &mut self.lock_unlimited_state(),
-                reservation_id,
-                actual.clone(),
-                now,
-            );
-            match result {
-                Ok(receipt) => {
-                    self.event_sink.emit(BudgetEvent::Reconciled {
-                        account: most_specific_account(&receipt.scope),
-                        receipt: receipt.clone(),
-                        at: now,
-                    });
-                    return Ok(receipt);
-                }
-                Err(ResourceError::UnknownReservation { .. }) => {}
-                Err(error) => return Err(error),
-            }
-        }
-        let result = self.store.update(move |snapshot| {
-            reconcile_in_state(&mut snapshot.state, reservation_id, actual, now)
-        });
+        let local_actual = actual.clone();
+        let result = self.close_fast_path_or_durable(
+            move |state| reconcile_in_state(state, reservation_id, local_actual, now),
+            move |snapshot| reconcile_in_state(&mut snapshot.state, reservation_id, actual, now),
+        );
         if let Ok(receipt) = &result {
             self.event_sink.emit(BudgetEvent::Reconciled {
                 account: most_specific_account(&receipt.scope),
@@ -1335,24 +1320,10 @@ where
         reservation_id: ResourceReservationId,
     ) -> Result<ResourceReceipt, ResourceError> {
         let now = self.clock.now();
-        if self.unlimited_fast_path {
-            let result = release_in_state(&mut self.lock_unlimited_state(), reservation_id, now);
-            match result {
-                Ok(receipt) => {
-                    self.event_sink.emit(BudgetEvent::Released {
-                        account: most_specific_account(&receipt.scope),
-                        receipt: receipt.clone(),
-                        at: now,
-                    });
-                    return Ok(receipt);
-                }
-                Err(ResourceError::UnknownReservation { .. }) => {}
-                Err(error) => return Err(error),
-            }
-        }
-        let result = self
-            .store
-            .update(move |snapshot| release_in_state(&mut snapshot.state, reservation_id, now));
+        let result = self.close_fast_path_or_durable(
+            move |state| release_in_state(state, reservation_id, now),
+            move |snapshot| release_in_state(&mut snapshot.state, reservation_id, now),
+        );
         if let Ok(receipt) = &result {
             self.event_sink.emit(BudgetEvent::Released {
                 account: most_specific_account(&receipt.scope),
@@ -1369,20 +1340,7 @@ where
     ) -> Result<Option<AccountSnapshot>, ResourceError> {
         let account = account.clone();
         let now = self.clock.now();
-        if self.can_use_unlimited_fast_path()? {
-            return Ok(account_snapshot_in_state(
-                &mut self.lock_unlimited_state(),
-                &account,
-                now,
-            ));
-        }
-        self.store.update(move |snapshot| {
-            Ok(account_snapshot_in_state(
-                &mut snapshot.state,
-                &account,
-                now,
-            ))
-        })
+        self.update_active_state(move |state| Ok(account_snapshot_in_state(state, &account, now)))
     }
 }
 

--- a/crates/ironclaw_resources/tests/resource_governor_contract.rs
+++ b/crates/ironclaw_resources/tests/resource_governor_contract.rs
@@ -23,6 +23,16 @@ impl ResourceGovernorStore for AlwaysFailingStore {
             reason: "forced durable write failure".to_string(),
         })
     }
+
+    fn inspect<T, F>(&self, _inspect: F) -> Result<T, ResourceError>
+    where
+        T: Send + 'static,
+        F: FnOnce(&ResourceGovernorSnapshot) -> Result<T, ResourceError> + Send + 'static,
+    {
+        Err(ResourceError::Storage {
+            reason: "forced durable read failure".to_string(),
+        })
+    }
 }
 
 #[test]
@@ -770,18 +780,9 @@ fn persistent_governor_unlimited_fast_path_avoids_durable_writes_until_finite_li
         "reconcile on the unlimited fast path should not create the durable snapshot"
     );
 
-    governor
-        .set_limit(
-            account,
-            ResourceLimits {
-                max_concurrency_slots: Some(1),
-                ..ResourceLimits::default()
-            },
-        )
-        .unwrap();
-    let _durable = governor
+    let active = governor
         .reserve(
-            scope,
+            scope.clone(),
             ResourceEstimate {
                 concurrency_slots: Some(1),
                 ..ResourceEstimate::default()
@@ -789,9 +790,36 @@ fn persistent_governor_unlimited_fast_path_avoids_durable_writes_until_finite_li
         )
         .unwrap();
     assert!(
-        path.exists(),
-        "finite limits should force the durable governor path"
+        !path.exists(),
+        "active unlimited fast-path reservations should stay process-local before finite limits"
     );
+
+    governor
+        .set_limit(
+            account.clone(),
+            ResourceLimits {
+                max_concurrency_slots: Some(1),
+                ..ResourceLimits::default()
+            },
+        )
+        .unwrap();
+    let denied = governor
+        .reserve(
+            scope,
+            ResourceEstimate {
+                concurrency_slots: Some(1),
+                ..ResourceEstimate::default()
+            },
+        )
+        .unwrap_err();
+    assert!(matches!(
+        denied,
+        ResourceError::LimitExceeded {
+            denial,
+            ..
+        } if denial.dimension == ResourceDimension::ConcurrencySlots
+    ));
+    governor.release(active.id).unwrap();
 }
 
 #[test]

--- a/crates/ironclaw_resources/tests/resource_governor_contract.rs
+++ b/crates/ironclaw_resources/tests/resource_governor_contract.rs
@@ -723,6 +723,78 @@ fn persistent_governor_reloads_active_holds_and_usage_from_store() {
 }
 
 #[test]
+fn persistent_governor_unlimited_fast_path_avoids_durable_writes_until_finite_limit() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("resource-governor.json");
+    let scope = sample_scope("tenant1", "user1", Some("project1"));
+    let account = ResourceAccount::tenant(scope.tenant_id.clone());
+
+    let governor = PersistentResourceGovernor::new(JsonFileResourceGovernorStore::new(&path))
+        .with_unlimited_fast_path();
+    let reservation = governor
+        .reserve(
+            scope.clone(),
+            ResourceEstimate {
+                usd: Some(dec!(0.20)),
+                concurrency_slots: Some(1),
+                ..ResourceEstimate::default()
+            },
+        )
+        .unwrap();
+    assert!(
+        !path.exists(),
+        "unlimited fast path should not create the durable governor snapshot"
+    );
+
+    governor
+        .reconcile(
+            reservation.id,
+            ResourceUsage {
+                usd: dec!(0.20),
+                ..ResourceUsage::default()
+            },
+        )
+        .unwrap();
+    assert!(
+        matches!(
+            governor.release(reservation.id),
+            Err(ResourceError::ReservationClosed {
+                status: ReservationStatus::Reconciled,
+                ..
+            })
+        ),
+        "same-process lifecycle checks are still enforced"
+    );
+    assert!(
+        !path.exists(),
+        "reconcile on the unlimited fast path should not create the durable snapshot"
+    );
+
+    governor
+        .set_limit(
+            account,
+            ResourceLimits {
+                max_concurrency_slots: Some(1),
+                ..ResourceLimits::default()
+            },
+        )
+        .unwrap();
+    let _durable = governor
+        .reserve(
+            scope,
+            ResourceEstimate {
+                concurrency_slots: Some(1),
+                ..ResourceEstimate::default()
+            },
+        )
+        .unwrap();
+    assert!(
+        path.exists(),
+        "finite limits should force the durable governor path"
+    );
+}
+
+#[test]
 fn persistent_governor_serializes_concurrent_reservations_across_handles() {
     let dir = tempdir().unwrap();
     let path = dir.path().join("resource-governor.json");

--- a/tools/ironclaw_stress/README.md
+++ b/tools/ironclaw_stress/README.md
@@ -184,7 +184,9 @@ fields:
 
 ### bottleneck-finder
 
-The broad scan for libsql and general local bottleneck discovery:
+The broad scan for libsql and general local bottleneck discovery. User-turn
+cases use separate user threads by default; hot-thread serialization is kept as
+an explicit preset so it does not distort capacity results.
 
 ```bash
 cargo run -p ironclaw_stress --release -- \
@@ -198,7 +200,6 @@ Cases include:
 
 - `resource-contention`
 - `chat-baseline`
-- `hot-thread`
 - `large-context`
 - `tool-heavy`
 - `tool-wait`
@@ -244,12 +245,17 @@ cargo run -p ironclaw_stress --release -- \
 cargo run -p ironclaw_stress --release -- \
   --backend libsql \
   --preset chat-baseline \
+  --users 128 \
   --ramp-concurrency 64 \
   --max-p95-ms 500 \
   --max-failure-rate 0.01 \
   --human-read \
   --bottleneck-report
 ```
+
+For user-turn capacity runs, keep `--users >= --concurrency`. With the default
+`--active-thread-count 0`, the harness partitions users/threads across workers
+so concurrent workers do not target the same thread.
 
 ### Test hot-thread behavior
 

--- a/tools/ironclaw_stress/src/main.rs
+++ b/tools/ironclaw_stress/src/main.rs
@@ -1754,7 +1754,9 @@ where
     let view = resource_mount_view(run_id)?;
     let scoped = Arc::new(ScopedFilesystem::with_fixed_view(root, view));
     let store = FilesystemResourceGovernorStore::new(scoped);
-    Ok(Arc::new(PersistentResourceGovernor::new(store)))
+    Ok(Arc::new(
+        PersistentResourceGovernor::new(store).with_unlimited_fast_path(),
+    ))
 }
 
 fn resource_mount_view(run_id: &str) -> Result<MountView, String> {

--- a/tools/ironclaw_stress/src/main.rs
+++ b/tools/ironclaw_stress/src/main.rs
@@ -903,6 +903,13 @@ fn validate_args(args: &Args) -> Result<(), String> {
     if args.sweep_users.contains(&0) {
         return Err("--sweep-users values must be greater than 0".to_string());
     }
+    let max_concurrency = args
+        .sweep_concurrency
+        .iter()
+        .copied()
+        .max()
+        .unwrap_or(args.concurrency)
+        .max(args.ramp_concurrency.unwrap_or(args.concurrency));
     let min_user_count = args.sweep_users.iter().copied().min().unwrap_or(args.users);
     let max_active_thread_count = args
         .sweep_active_thread_count
@@ -916,6 +923,20 @@ fn validate_args(args: &Args) -> Result<(), String> {
     if max_active_thread_count > min_user_count {
         return Err(
             "--active-thread-count and --sweep-active-thread-count values must be less than or equal to every --sweep-users value"
+                .to_string(),
+        );
+    }
+    if args.scenario.is_user_turn()
+        && args
+            .sweep_active_thread_count
+            .iter()
+            .copied()
+            .chain(std::iter::once(args.active_thread_count))
+            .any(|active_thread_count| active_thread_count == 0)
+        && max_concurrency > min_user_count
+    {
+        return Err(
+            "user-turn scenarios with --active-thread-count 0 require --users to be greater than or equal to --concurrency"
                 .to_string(),
         );
     }

--- a/tools/ironclaw_stress/src/main.rs
+++ b/tools/ironclaw_stress/src/main.rs
@@ -908,8 +908,10 @@ fn validate_args(args: &Args) -> Result<(), String> {
         .iter()
         .copied()
         .max()
-        .unwrap_or(args.concurrency)
-        .max(args.ramp_concurrency.unwrap_or(args.concurrency));
+        .unwrap_or(args.concurrency);
+    let max_concurrency = args
+        .ramp_concurrency
+        .map_or(max_concurrency, |ramp_max| max_concurrency.max(ramp_max));
     let min_user_count = args.sweep_users.iter().copied().min().unwrap_or(args.users);
     let max_active_thread_count = args
         .sweep_active_thread_count

--- a/tools/ironclaw_stress/src/suite.rs
+++ b/tools/ironclaw_stress/src/suite.rs
@@ -188,12 +188,6 @@ pub(crate) fn build_cases(suite: StressSuite) -> Vec<SuiteCase> {
                 scenario: Scenario::ChatTurn,
             },
             SuiteCase {
-                label: "hot-thread",
-                probe: "same-thread-serialization",
-                preset: Some(StressPreset::HotThread),
-                scenario: Scenario::ChatTurn,
-            },
-            SuiteCase {
                 label: "large-context",
                 probe: "context-read-amplification",
                 preset: Some(StressPreset::LargeContext),
@@ -244,12 +238,6 @@ pub(crate) fn build_cases(suite: StressSuite) -> Vec<SuiteCase> {
                 scenario: Scenario::ChatTurn,
             },
             SuiteCase {
-                label: "postgres-hot-thread-pool",
-                probe: "postgres-hot-thread-pool",
-                preset: Some(StressPreset::HotThread),
-                scenario: Scenario::ChatTurn,
-            },
-            SuiteCase {
                 label: "postgres-context-pool",
                 probe: "postgres-context-read-pool",
                 preset: Some(StressPreset::LargeContext),
@@ -296,10 +284,6 @@ fn apply_case(base_args: &Args, case: &SuiteCase, case_args: &mut Args, run_id: 
     }
 
     match case.label {
-        "hot-thread" => {
-            case_args.active_thread_count = 1;
-            case_args.span_log_failures = true;
-        }
         "large-context" => {
             case_args.prefill_threads = base_args.users.clamp(1, 100);
             case_args.prefill_turns_per_thread = base_args
@@ -333,11 +317,6 @@ fn apply_case(base_args: &Args, case: &SuiteCase, case_args: &mut Args, run_id: 
         }
         "postgres-chat-pool" => {
             apply_postgres_pool_pressure_defaults(base_args, case_args);
-        }
-        "postgres-hot-thread-pool" => {
-            apply_postgres_pool_pressure_defaults(base_args, case_args);
-            case_args.active_thread_count = 1;
-            case_args.span_log_failures = true;
         }
         "postgres-context-pool" => {
             apply_postgres_pool_pressure_defaults(base_args, case_args);

--- a/tools/ironclaw_stress/src/synthetic.rs
+++ b/tools/ironclaw_stress/src/synthetic.rs
@@ -82,10 +82,15 @@ impl SyntheticIds {
         worker_index: usize,
         operation_index: usize,
     ) -> Result<UserTurnContext, String> {
-        let (_, user_index, global_index) =
-            self.synthetic_indexes(args, worker_index, operation_index);
-        let thread_user_index = self.thread_user_index(args, user_index, global_index);
-        self.user_turn_context_for_indexes(user_index, thread_user_index)
+        let actor_user_index = partitioned_worker_index(
+            self.users.len(),
+            args.concurrency,
+            worker_index,
+            operation_index,
+        );
+        let thread_user_index =
+            self.thread_user_index(args, actor_user_index, worker_index, operation_index);
+        self.user_turn_context_for_indexes(actor_user_index, thread_user_index)
     }
 
     pub(crate) fn user_turn_context_for_user_index(
@@ -141,11 +146,22 @@ impl SyntheticIds {
         })
     }
 
-    fn thread_user_index(&self, args: &Args, user_index: usize, global_index: usize) -> usize {
+    fn thread_user_index(
+        &self,
+        args: &Args,
+        user_index: usize,
+        worker_index: usize,
+        operation_index: usize,
+    ) -> usize {
         if args.active_thread_count == 0 {
             user_index
         } else {
-            global_index % args.active_thread_count
+            partitioned_worker_index(
+                args.active_thread_count,
+                args.concurrency,
+                worker_index,
+                operation_index,
+            )
         }
     }
 
@@ -162,4 +178,24 @@ impl SyntheticIds {
         let tenant_index = user_index % self.tenants.len();
         (tenant_index, user_index, global_index)
     }
+}
+
+fn partitioned_worker_index(
+    pool_size: usize,
+    worker_count: usize,
+    worker_index: usize,
+    operation_index: usize,
+) -> usize {
+    let worker_count = worker_count.max(1);
+    if pool_size < worker_count {
+        return worker_index % pool_size;
+    }
+
+    let base_len = pool_size / worker_count;
+    let remainder = pool_size % worker_count;
+    let partition_len = base_len + usize::from(worker_index < remainder);
+    let partition_start = worker_index
+        .saturating_mul(base_len)
+        .saturating_add(worker_index.min(remainder));
+    partition_start + operation_index % partition_len
 }

--- a/tools/ironclaw_stress/src/tests.rs
+++ b/tools/ironclaw_stress/src/tests.rs
@@ -432,6 +432,18 @@ fn sweep_concurrency_rejects_zero_values() {
 }
 
 #[test]
+fn sweep_concurrency_validation_uses_sweep_max_not_base_concurrency() {
+    let mut args = test_args();
+    args.scenario = Scenario::MixedUserSession;
+    args.concurrency = 8;
+    args.sweep_concurrency = vec![2, 4];
+    args.users = 4;
+    args.active_thread_count = 0;
+
+    validate_args(&args).expect("sweep cases only require enough users for the sweep max");
+}
+
+#[test]
 fn active_thread_count_rejects_values_above_users() {
     let mut args = test_args();
     args.active_thread_count = args.users + 1;

--- a/tools/ironclaw_stress/src/tests.rs
+++ b/tools/ironclaw_stress/src/tests.rs
@@ -87,6 +87,56 @@ fn fixed_operation_mode_spreads_concurrent_workers_across_threads() {
 }
 
 #[test]
+fn user_turn_workers_keep_disjoint_thread_partitions() {
+    let mut args = test_args();
+    args.users = 10;
+    args.concurrency = 4;
+    args.operations = 100;
+    args.active_thread_count = 0;
+    let ids = SyntheticIds::new(&args).expect("synthetic ids build");
+
+    let mut seen_by_worker = Vec::new();
+    for worker_index in 0..args.concurrency {
+        let thread_ids = (0..args.operations)
+            .map(|operation_index| {
+                ids.user_turn_context(&args, worker_index, operation_index)
+                    .expect("context")
+                    .thread_id
+            })
+            .collect::<std::collections::BTreeSet<_>>();
+        seen_by_worker.push(thread_ids);
+    }
+
+    for worker_index in 0..seen_by_worker.len() {
+        for other_worker_index in worker_index + 1..seen_by_worker.len() {
+            assert!(
+                seen_by_worker[worker_index].is_disjoint(&seen_by_worker[other_worker_index]),
+                "workers {worker_index} and {other_worker_index} should not share target threads"
+            );
+        }
+    }
+    let all_threads = seen_by_worker
+        .iter()
+        .flat_map(|thread_ids| thread_ids.iter().cloned())
+        .collect::<std::collections::BTreeSet<_>>();
+    assert_eq!(all_threads.len(), args.users);
+}
+
+#[test]
+fn user_turn_default_rejects_more_workers_than_users() {
+    let mut args = test_args();
+    args.scenario = Scenario::ChatTurn;
+    args.users = 2;
+    args.concurrency = 3;
+    args.active_thread_count = 0;
+
+    let error =
+        validate_args(&args).expect_err("default user-turn mode should require enough users");
+
+    assert!(error.contains("--users to be greater than or equal to --concurrency"));
+}
+
+#[test]
 fn chat_turn_rejects_multi_process_runs() {
     let mut args = test_args();
     args.scenario = Scenario::ChatTurn;
@@ -157,7 +207,7 @@ fn bottleneck_finder_suite_includes_core_pressure_cases() {
 
     assert!(labels.contains("resource-contention"));
     assert!(labels.contains("chat-baseline"));
-    assert!(labels.contains("hot-thread"));
+    assert!(!labels.contains("hot-thread"));
     assert!(labels.contains("large-context"));
     assert!(labels.contains("tool-heavy"));
     assert!(labels.contains("tool-wait"));
@@ -176,7 +226,7 @@ fn postgres_pool_pressure_suite_includes_remote_pool_cases() {
         .collect::<std::collections::BTreeSet<_>>();
 
     assert!(labels.contains("postgres-chat-pool"));
-    assert!(labels.contains("postgres-hot-thread-pool"));
+    assert!(!labels.contains("postgres-hot-thread-pool"));
     assert!(labels.contains("postgres-context-pool"));
     assert!(labels.contains("postgres-tool-pool"));
 }


### PR DESCRIPTION
## Summary

- add a read-only resource-governor snapshot inspection path
- add an opt-in unlimited-limits fast path for `PersistentResourceGovernor`
- gate the Reborn product path behind `IRONCLAW_RESOURCE_GOVERNOR_UNLIMITED_FAST_PATH`
- keep `ironclaw_stress` on the fast path so stress runs can isolate unlimited-governor overhead
- make default capacity stress runs use distinct per-user threads instead of a hot-thread contention workload

## Why

Unlimited resource-governor reserve/reconcile/release does not need to persist a snapshot on every operation when there are no finite limits to enforce. The new fast path keeps same-process reservation lifecycle checks, but avoids durable mutation for unlimited-limit reserve/reconcile/release. If any finite limit exists, the governor falls back to the durable CAS path.

Production defaults remain conservative: the Reborn composition only enables this path when `IRONCLAW_RESOURCE_GOVERNOR_UNLIMITED_FAST_PATH=true` (also accepts `1`, `yes`, `on`). Invalid values fail startup.

## Benchmarks

Rerun on 2026-06-30 against current `origin/main` (`b597ecf33`) and this PR (`2b677ddab`). Both use local libSQL, release builds, one process, `--concurrency 8`, `--operations 200`, `--users 200`, `--tenants 1`, `--progress-interval-seconds 0`, `--human-read`, and `--bottleneck-report`.

### Resource Governor Only

Command shape:

```bash
cargo run -p ironclaw_stress --release -- \
  --backend libsql \
  --scenario reserve-reconcile \
  --concurrency 8 \
  --operations 200 \
  --users 200 \
  --tenants 1 \
  --progress-interval-seconds 0 \
  --human-read \
  --bottleneck-report
```

| Branch | Throughput | Success | Failure rate | op p95 | op p99 | DB growth |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| `origin/main` | 30.6 ops/s | 1600/1600 | 0.0% | 456.9ms | 581.0ms | +7.8 MiB |
| this PR | 42.5 ops/s | 1600/1600 | 0.0% | 290.7ms | 309.9ms | +7.8 MiB |

### Realistic Distinct-Thread User Session

Command shape:

```bash
cargo run -p ironclaw_stress --release -- \
  --backend libsql \
  --scenario mixed-user-session \
  --active-thread-count 0 \
  --concurrency 8 \
  --operations 200 \
  --users 200 \
  --tenants 1 \
  --progress-interval-seconds 0 \
  --human-read \
  --bottleneck-report
```

`--active-thread-count 0` means each synthetic user has their own active thread pool. This avoids the previous hot-thread benchmark where all workers intentionally raced one thread and produced expected `turn_thread_busy` failures.

| Branch | Throughput | Success | Failure rate | op p95 | op p99 | thread writes p95 | turn store p95 | governor p95 | DB growth |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| `origin/main` | 9.5 ops/s | 1600/1600 | 0.0% | 1.57s | 2.27s | 761.2ms | 407.9ms | 769.5ms | +33.6 MiB |
| this PR | 12.7 ops/s | 1600/1600 | 0.0% | 1.32s | 1.78s | 668.1ms | 313.9ms | 542.4ms | +33.6 MiB |

The old PR body included a `--active-thread-count 1` table. That measured deliberate same-thread contention, not distinct-user capacity, so it has been removed from the capacity comparison.

## Interpretation

This PR improves the unlimited-governor path, but it does not remove the main libSQL write bottlenecks from realistic chat-like workloads. In `mixed-user-session`, the remaining high-latency groups are still thread-store writes and turn-store writes. DB file growth is therefore expected and should not be read as proof that the governor is still doing durable reserve/reconcile writes.

The practical result is a clean no-failure workload with roughly:

- +39% throughput on the isolated reserve/reconcile stress case
- +33% throughput on the distinct-thread mixed user session
- lower governor attribution p95 in the mixed workload: 769.5ms -> 542.4ms

## Validation

Functional checks run on this branch:

- `cargo check -p ironclaw_reborn_composition --features libsql --lib`
- `cargo test -p ironclaw_resources --test resource_governor_contract`
- `cargo test -p ironclaw_stress`
- `cargo clippy -p ironclaw_resources -p ironclaw_stress --tests -- -D warnings`

Fresh benchmark result files used for this body:

- `/tmp/ironclaw-bench-results/main-reserve.json`
- `/tmp/ironclaw-bench-results/pr-reserve.json`
- `/tmp/ironclaw-bench-results/main-mixed.json`
- `/tmp/ironclaw-bench-results/pr-mixed.json`
