### PR TITLE
[codex] Add Reborn Playwright workflow

### DIFF
--- a/.github/workflows/reborn-playwright.yml
+++ b/.github/workflows/reborn-playwright.yml
@@ -1,0 +1,172 @@
+name: Reborn Playwright
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "20 3 * * *" # Nightly standalone Reborn browser coverage at 03:20 UTC
+
+permissions:
+  contents: read
+
+concurrency:
+  group: reborn-playwright-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  matrix-config:
+    name: Configure Reborn Playwright matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Check referenced scenario files
+        run: scripts/ci/check-e2e-matrix-files.sh .github/workflows/reborn-playwright.yml
+
+      - id: set
+        run: |
+          MATRIX=$(cat <<'JSON'
+          [
+            {
+              "group": "webui-smoke-files",
+              "files": "tests/e2e/scenarios/test_reborn_webui_v2_smoke.py tests/e2e/scenarios/test_reborn_v2_file_download.py"
+            },
+            {
+              "group": "legacy-core-ui",
+              "files": "tests/e2e/scenarios/test_reborn_webui_v2_legacy_core.py tests/e2e/scenarios/test_reborn_webui_v2_legacy_rendering.py tests/e2e/scenarios/test_reborn_webui_v2_legacy_chat_actions.py tests/e2e/scenarios/test_reborn_webui_v2_legacy_dom_resource_limits.py"
+            },
+            {
+              "group": "legacy-auth-inputs",
+              "files": "tests/e2e/scenarios/test_reborn_webui_v2_legacy_approval.py tests/e2e/scenarios/test_reborn_webui_v2_legacy_auth_flows.py tests/e2e/scenarios/test_reborn_webui_v2_legacy_channel_connect.py tests/e2e/scenarios/test_reborn_webui_v2_legacy_attachments.py"
+            },
+            {
+              "group": "legacy-settings-extensions",
+              "files": "tests/e2e/scenarios/test_reborn_webui_v2_legacy_extensions.py tests/e2e/scenarios/test_reborn_webui_v2_legacy_settings_search.py tests/e2e/scenarios/test_reborn_webui_v2_legacy_skills.py tests/e2e/scenarios/test_reborn_webui_v2_legacy_tool_permissions.py tests/e2e/scenarios/test_reborn_webui_v2_legacy_projects.py",
+              "pytest_args": "-k 'not test_reborn_legacy_always_approve_survives_reborn_restart'"
+            },
+            {
+              "group": "legacy-runtime",
+              "files": "tests/e2e/scenarios/test_reborn_webui_v2_legacy_message_persistence.py tests/e2e/scenarios/test_reborn_webui_v2_legacy_pending_messages.py tests/e2e/scenarios/test_reborn_webui_v2_legacy_sse_history.py tests/e2e/scenarios/test_reborn_webui_v2_legacy_tool_execution.py"
+            }
+          ]
+          JSON
+          )
+          {
+            echo "matrix<<EOF"
+            echo "${MATRIX}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+  build:
+    name: Build Reborn Playwright binaries
+    needs: matrix-config
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: Install Node.js for WebUI bundle build
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: crates/ironclaw_webui_v2_static/frontend/package-lock.json
+
+      - name: Restore Rust cache
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          key: reborn-playwright
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+
+      - name: Build ironclaw-reborn with WebUI surface
+        run: cargo build -p ironclaw_reborn_cli --features webui-v2-beta
+
+      - name: Upload binaries
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: reborn-playwright-binaries
+          path: |
+            target/debug/ironclaw-reborn
+          retention-days: 1
+
+  test:
+    name: Reborn Playwright (${{ matrix.group }})
+    needs: [matrix-config, build]
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.matrix-config.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Download binaries
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: reborn-playwright-binaries
+          path: target/debug/
+
+      - name: Make binaries executable
+        run: |
+          chmod +x target/debug/ironclaw-reborn
+          touch target/debug/ironclaw-reborn
+
+      - name: Install Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: tests/e2e/pyproject.toml
+
+      - name: Install Node.js for emulate-backed scenarios
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
+        with:
+          node-version: "22"
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('tests/e2e/pyproject.toml') }}
+          restore-keys: ${{ runner.os }}-playwright-
+
+      - name: Install E2E dependencies
+        run: |
+          cd tests/e2e
+          pip install -e .
+          playwright install --with-deps chromium
+
+      - name: Run Reborn Playwright shard
+        run: pytest ${{ matrix.files }} ${{ matrix.pytest_args }} -v --timeout=120 --durations=25
+
+      - name: Upload screenshots on failure
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: reborn-playwright-screenshots-${{ matrix.group }}
+          path: tests/e2e/screenshots/
+          if-no-files-found: ignore
+
+  reborn-playwright:
+    name: Reborn Playwright
+    runs-on: ubuntu-latest
+    if: always()
+    needs: [test]
+    steps:
+      - name: Check Reborn Playwright shards
+        run: |
+          if [[ "${{ needs.test.result }}" != "success" ]]; then
+            echo "One or more Reborn Playwright shards failed"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

Adds a separate nightly `Reborn Playwright` workflow for standalone Reborn browser scenarios.

The workflow:
- runs nightly at 03:20 UTC and can also be started manually with `workflow_dispatch`
- builds the `ironclaw-reborn` WebUI binary once
- uploads that binary as a short-lived artifact
- runs standalone Reborn browser-backed scenario files across five named pytest shards with `--durations=25`
- excludes `test_reborn_legacy_always_approve_survives_reborn_restart`, which is a server restart persistence test rather than a browser timing test and timed out in the first measurement run

## Validation

- `scripts/ci/check-e2e-matrix-files.sh .github/workflows/reborn-playwright.yml`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/reborn-playwright.yml"); puts "yaml ok"'`
- pytest collect-only for every matrix shard:
  - `webui-smoke-files`: 14 tests
  - `legacy-core-ui`: 19 tests
  - `legacy-auth-inputs`: 31 tests
  - `legacy-settings-extensions`: 58 selected / 59 collected, 1 deselected
  - `legacy-runtime`: 31 tests
  - total selected: 153 tests

## Notes

Earlier measurement showed the Playwright shards are short, but the shared Rust build dominates wall time. This PR keeps the suite out of normal PR CI and makes it nightly/manual instead.
