### PR TITLE
perf(filesystem): enable WAL + tune PRAGMAs on libSQL backend

### DIFF
--- a/crates/ironclaw_filesystem/src/libsql.rs
+++ b/crates/ironclaw_filesystem/src/libsql.rs
@@ -28,6 +28,49 @@ const LIBSQL_CONNECT_ATTEMPTS: u32 = 3;
 #[cfg(feature = "libsql")]
 const LIBSQL_CONNECT_INITIAL_BACKOFF: Duration = Duration::from_millis(50);
 
+/// Per-connection PRAGMAs applied to every libSQL connection.
+///
+/// libSQL/SQLite is a single-writer engine: there is no true "parallel
+/// write" mode for a local file. Concurrent writers always serialise on
+/// the database write lock. The throughput lever is therefore making each
+/// write cheap and keeping readers from blocking the writer — which is
+/// exactly what these PRAGMAs do, alongside `journal_mode=WAL` (set once at
+/// migration time, see `run_migrations`).
+///
+/// - `busy_timeout=5000`: unchanged from the prior policy. A writer that
+///   finds the write lock held waits up to 5s rather than failing fast.
+/// - `synchronous=NORMAL`: in WAL mode this is crash-safe for the
+///   *application* (committed transactions survive a process crash); only an
+///   OS/power loss can roll back the most-recent commits, and the database
+///   stays consistent regardless. It removes one fsync per commit, which is
+///   the dominant cost of the serial-write path under load. This is the
+///   standard high-throughput SQLite setting. Use `FULL` only if per-commit
+///   power-loss durability is required (it is not for turn/loop state).
+/// - `temp_store=MEMORY`: keep transient indexes/sorters off disk.
+/// - `cache_size=-16000`: ~16 MiB page cache per connection (negative =
+///   KiB), so hot pages (the turn-state and resource-snapshot rows that are
+///   read-modify-written every turn) stay resident instead of being
+///   re-read from the OS page cache on each op.
+/// - `mmap_size`: memory-map up to 256 MiB for reads, cutting read syscall
+///   overhead on the many read-before-write checks (`exact_entry`,
+///   `has_child_entry`, snapshot loads) that surround each write.
+/// - `wal_autocheckpoint=1000`: bound WAL growth (checkpoint every ~1000
+///   pages / ~4 MiB) so the WAL does not grow without limit under a burst
+///   of writes.
+///
+/// `journal_mode` is deliberately NOT set here: it is a persistent,
+/// database-level property (stored in the file header) and changing it
+/// inside or alongside ordinary work is wasteful and cannot run inside a
+/// transaction. It is set exactly once in `run_migrations`.
+#[cfg(feature = "libsql")]
+const LIBSQL_CONNECTION_PRAGMAS: &str = "\
+    PRAGMA busy_timeout = 5000;\
+    PRAGMA synchronous = NORMAL;\
+    PRAGMA temp_store = MEMORY;\
+    PRAGMA cache_size = -16000;\
+    PRAGMA mmap_size = 268435456;\
+    PRAGMA wal_autocheckpoint = 1000;";
+
 #[cfg(feature = "libsql")]
 impl LibSqlRootFilesystem {
     pub fn new(db: Arc<libsql::Database>) -> Self {
@@ -36,6 +79,29 @@ impl LibSqlRootFilesystem {
 
     pub async fn run_migrations(&self) -> Result<(), FilesystemError> {
         let conn = self.connect().await?;
+        // Switch the database to WAL journaling once, here, before any
+        // transaction is opened. WAL is persisted in the database header, so
+        // a single successful run sticks for the life of the file and for
+        // every future connection; re-running migrations on an
+        // already-WAL database is a cheap no-op.
+        //
+        // This is the single biggest lever on concurrent-write latency: the
+        // default `DELETE` rollback journal takes an EXCLUSIVE lock over the
+        // whole file for every commit and blocks readers for the duration,
+        // so the many read-before-write checks on the turn/loop path
+        // serialise behind each writer. WAL lets readers run concurrently
+        // with the (still single) writer and turns each commit into an
+        // append to the WAL instead of a rollback-journal create/fsync/
+        // delete cycle.
+        //
+        // `journal_mode` cannot be changed inside a transaction, so it must
+        // run before the `BEGIN IMMEDIATE` below. Use `query` to drain the
+        // single row the pragma returns (the resulting mode).
+        conn.query("PRAGMA journal_mode = WAL", ())
+            .await
+            .map_err(|error| {
+                infrastructure_libsql_error(FilesystemOperation::CreateDirAll, error)
+            })?;
         // Wrap every step in a single SQLite transaction so a mid-migration
         // crash can't leave concurrent readers observing a half-migrated
         // schema (e.g. `is_dir` column present but `version` missing). SQLite
@@ -87,7 +153,11 @@ where
     for attempt in 0..LIBSQL_CONNECT_ATTEMPTS {
         match open() {
             Ok(conn) => {
-                conn.query("PRAGMA busy_timeout = 5000", ())
+                // Apply the per-connection PRAGMAs in a single round-trip.
+                // `execute_batch` runs each statement and discards the rows
+                // PRAGMAs like `busy_timeout` return, which is exactly what
+                // we want — we only care about the side effect.
+                conn.execute_batch(LIBSQL_CONNECTION_PRAGMAS)
                     .await
                     .map_err(|error| {
                         infrastructure_libsql_error(FilesystemOperation::Stat, error)
@@ -1995,5 +2065,49 @@ mod tests {
         let row = rows.next().await.unwrap().unwrap();
         let timeout: i64 = row.get(0).unwrap();
         assert_eq!(timeout, 5000);
+    }
+
+    /// `run_migrations` must switch the database into WAL journaling, which
+    /// is the property that lets readers run concurrently with the single
+    /// writer instead of serialising behind a whole-file EXCLUSIVE lock.
+    /// WAL is persisted in the file header, so this also asserts that a
+    /// *fresh* connection opened after migration observes the mode — i.e.
+    /// the setting stuck rather than applying only to the migration
+    /// connection.
+    #[tokio::test]
+    async fn migrations_enable_wal_journal_mode() {
+        let (fs, _dir) = fresh_backend().await;
+        let conn = fs.connect().await.unwrap();
+        let mut rows = conn.query("PRAGMA journal_mode", ()).await.unwrap();
+        let row = rows.next().await.unwrap().unwrap();
+        let mode: String = row.get(0).unwrap();
+        assert_eq!(
+            mode.to_ascii_lowercase(),
+            "wal",
+            "migrations must leave the database in WAL journaling mode"
+        );
+    }
+
+    /// Every connection handed out by `connect` must carry the
+    /// throughput-tuning PRAGMAs, not just `busy_timeout`. `synchronous`
+    /// and `temp_store` are the two with stable, asserted numeric encodings
+    /// (`NORMAL` = 1, `MEMORY` = 2); checking them confirms the whole batch
+    /// was applied to the connection rather than silently skipped.
+    #[tokio::test]
+    async fn connect_applies_performance_pragmas() {
+        let (fs, _dir) = fresh_backend().await;
+        let conn = fs.connect().await.unwrap();
+
+        let mut rows = conn.query("PRAGMA synchronous", ()).await.unwrap();
+        let synchronous: i64 = rows.next().await.unwrap().unwrap().get(0).unwrap();
+        assert_eq!(synchronous, 1, "synchronous must be NORMAL (1)");
+
+        let mut rows = conn.query("PRAGMA temp_store", ()).await.unwrap();
+        let temp_store: i64 = rows.next().await.unwrap().unwrap().get(0).unwrap();
+        assert_eq!(temp_store, 2, "temp_store must be MEMORY (2)");
+
+        let mut rows = conn.query("PRAGMA busy_timeout", ()).await.unwrap();
+        let busy_timeout: i64 = rows.next().await.unwrap().unwrap().get(0).unwrap();
+        assert_eq!(busy_timeout, 5000, "busy_timeout must remain 5000");
     }
 }


### PR DESCRIPTION
## Summary

- The libSQL `RootFilesystem` backend (the Reborn CLI filesystem, used across the Reborn stack and by `ironclaw_stress`) ran in the default `DELETE` rollback-journal mode with only `busy_timeout=5000` set — the slowest possible config for the concurrent-write path each turn hammers.
- Enable `journal_mode=WAL` once at migration time (persisted in the file header) so readers run concurrently with the single writer and each commit becomes a WAL append instead of an exclusive-lock + rollback-journal create/fsync/delete cycle.
- Apply `synchronous=NORMAL`, `temp_store=MEMORY`, `cache_size=-16000` (~16 MiB), `mmap_size` 256 MiB, and `wal_autocheckpoint=1000` to every connection in one `execute_batch` round-trip. `busy_timeout` stays 5000.
- libSQL/SQLite has **no true parallel-write mode** for a local file — writers always serialize on one lock. This change attacks the two levers that matter: make each write cheap, and stop readers from blocking the writer.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

(Performance fix; closest box.)

## Linked Issue

None.

## Validation

Measured before/after with `ironclaw_stress` on this machine (4-core Linux, `chat-turn`, 30 ops/task, 200 users), pre-WAL vs this change:

| Concurrency | p95 (before → after) | throughput ops/s (before → after) | failures |
|---|---|---|---|
| 1  | 168.9ms → 94.3ms | 12.9 → 11.2 | 0 / 0 |
| 4  | 1091.8ms → 217.8ms | 12.8 → 27.7 | 0 / 0 |
| 8  | 1285.5ms → 176.5ms | 9.4 → 33.6 | 0 / 0 |
| 16 | 1139.5ms → 199.6ms | 6.9 → 27.7 | 0 / 0 |
| 32 | 1311.7ms → 276.4ms | 5.7 → 19.5 | **2 → 0** |

Without WAL, p95 jumps to ~1.1–1.3s the moment concurrency exceeds 1 and throughput *declines* as concurrency rises (writers serialize destructively, with lock-timeout failures at c32). With WAL, p95 holds at 175–280ms and throughput rises to a ~33 ops/s plateau — a **3.4–4.0× throughput gain and 5–7× p95 reduction** in the contended range.

- [ ] `cargo fmt --all -- --check` — not run (see note)
- [ ] `cargo clippy ... -D warnings` — not run (see note)
- [x] `cargo build` — `ironclaw_filesystem` + `ironclaw_stress` build clean (rustc 1.96)
- [x] Relevant tests pass: new `migrations_enable_wal_journal_mode` and `connect_applies_performance_pragmas`, plus the rest of the libSQL suite (37 passed). One pre-existing contract test (`libsql_root_filesystem_migration_failure_surfaces_infrastructure_variant`) fails **identically with and without this change** because it injects failure via `chmod 0o444`, which the root build user ignores — environmental, not a regression.
- [ ] `cargo test --features integration` — not run
- [x] Manual testing: before/after stress sweep above.

> Note: full-workspace `cargo fmt`/`clippy`/`test` could not run in the authoring environment — the workspace has a github.com git dependency (`monty`, via `ironclaw_engine`) and git-over-HTTPS to github.com is denied by the environment's egress policy, so cargo cannot resolve the full workspace. The change was built and tested against `ironclaw_filesystem` in isolation. Please run the standard quality gate in CI.

## Security Impact

`synchronous=NORMAL` (vs `FULL`) trades per-commit power-loss durability for throughput: committed transactions survive an application/process crash, and the database stays consistent; only an OS-level crash or power loss can roll back the most-recent commits. This is the standard high-throughput SQLite setting and is appropriate for turn/loop state. No change to permissions, network, secrets, file access, or sandbox policy.

## Reborn Trust-Boundary Checklist

N/A — storage-engine tuning only; no policy/trust types, prompt inputs, hashes, status/error variants, serde fields, buffers, or trust-boundary naming changed.

## Database Impact

libSQL only. `journal_mode=WAL` is persisted in the database file header and applied once at migration; re-running migrations on an already-WAL file is a no-op. No schema or migration-shape change. Existing on-disk databases are upgraded to WAL on the next `run_migrations`. PostgreSQL backend is unaffected.

## Blast Radius

Touches only `crates/ironclaw_filesystem/src/libsql.rs` (connection setup + migrations). Every consumer of `LibSqlRootFilesystem` (host_runtime, reborn_composition, event_store, product_workflow_storage, secrets, openai_compat_storage, …) inherits the new pragmas via `run_migrations`. WAL requires a local filesystem with shared-memory support — fine for `~/.ironclaw` and the per-project sandbox; it would not suit a networked filesystem (none in scope).

## Rollback Plan

Revert this commit. WAL is persisted in the file header, so already-migrated databases stay in WAL after a code rollback; a reverted build simply stops setting it on new files and continues to read/write WAL databases correctly (WAL is backward-compatible). To force a file back to rollback journaling, run `PRAGMA journal_mode=DELETE` once.

## Review Follow-Through

This is step 1 (the contained, backend-wide win). The remaining throughput wall at high concurrency is app-level CAS contention on the monolithic `/turns/state.json` and `/resources/snapshot.json` snapshots (each concurrent turn read-modify-writes one JSON doc with up to 32 retries). Sharding those per scope, coalescing the ~5 per-turn `/threads` writes into one transaction, batching runner-lease heartbeats, and a dedicated writer connection are the natural follow-ups — each gated on its own stress measurement.

## Database Impact (both backends)

libSQL only; PostgreSQL path untouched. See Database Impact above.

---

**Review track**: C (runtime/DB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQzj2447pq2BUfgY3BUSJb)_