### PR TITLE
Move runner lease heartbeats to memory store

### DIFF
--- a/crates/ironclaw_turns/src/filesystem_store.rs
+++ b/crates/ironclaw_turns/src/filesystem_store.rs
@@ -1,11 +1,12 @@
 //! Filesystem-backed [`TurnStateStore`] implementation.
 //!
 //! Persists the lower-churn [`TurnPersistenceSnapshot`] as a JSON blob under
-//! the `/turns` mount alias (alias-relative path: `/turns/state.json`) and
-//! high-churn runner lease heartbeats as per-run CAS records under
-//! `/turns/runner-leases`. Snapshot mutations read the snapshot, overlay
-//! current runner leases, delegate to an [`InMemoryTurnStateStore`] in a
-//! transient `apply` closure, and write the resulting snapshot back with
+//! the `/turns` mount alias (alias-relative path: `/turns/state.json`).
+//! High-churn runner lease heartbeats are memory-backed per
+//! [`FilesystemTurnStateStore`] instance and are overlaid onto the durable
+//! snapshot while the process is alive. Snapshot mutations read the snapshot,
+//! overlay current runner leases, delegate to an [`InMemoryTurnStateStore`] in
+//! a transient `apply` closure, and write the resulting snapshot back with
 //! optimistic CAS + bounded retry. Reads load the snapshot, overlay current
 //! runner leases, and project through the in-memory store without writing
 //! back.
@@ -22,7 +23,6 @@
 //!
 //! ```text
 //! /turns/state.json
-//! /turns/runner-leases/{run_id}.json
 //! ```
 //!
 //! Within-tenant scoping (agent/project/thread) is encoded inside the
@@ -33,6 +33,7 @@
 //! path itself.
 
 use std::{
+    collections::HashMap,
     sync::{Arc, Mutex},
     time::{Duration, Instant},
 };
@@ -70,7 +71,7 @@ use io::{
     put_with_cas, snapshot_entry, snapshot_path,
 };
 use profile_resolver::PreResolvedRunProfileResolver;
-use runner_lease::{RunnerLeaseOverlay, RunnerLeaseRecord, RunnerLeaseSidecar};
+use runner_lease::{RunnerLeaseMemory, RunnerLeaseOverlay, RunnerLeaseRecord, RunnerLeaseStore};
 
 #[cfg(test)]
 mod tests;
@@ -124,6 +125,7 @@ where
     limits: InMemoryTurnStateStoreLimits,
     admission_limit_provider: Arc<dyn TurnAdmissionLimitProvider>,
     snapshot_cache: Mutex<Option<CachedSnapshot>>,
+    runner_leases: RunnerLeaseMemory,
     apply_timeout: Duration,
 }
 
@@ -137,6 +139,7 @@ where
             limits: InMemoryTurnStateStoreLimits::default(),
             admission_limit_provider: Arc::new(AllowAllTurnAdmissionLimitProvider),
             snapshot_cache: Mutex::new(None),
+            runner_leases: Arc::new(Mutex::new(HashMap::new())),
             apply_timeout: FILESYSTEM_APPLY_TIMEOUT,
         }
     }
@@ -225,7 +228,7 @@ where
         snapshot: (TurnPersistenceSnapshot, Option<RecordVersion>),
         overlay: RunnerLeaseOverlay,
     ) -> Result<(TurnPersistenceSnapshot, Option<RecordVersion>), TurnError> {
-        self.runner_lease_sidecar().overlay(snapshot, overlay).await
+        self.runner_lease_store().overlay(snapshot, overlay).await
     }
 
     async fn seed_runner_lease_from_snapshot_inner(
@@ -233,7 +236,7 @@ where
         run_id: TurnRunId,
     ) -> Result<(), TurnError> {
         let (snapshot, _version) = self.read_snapshot_from_filesystem().await?;
-        self.runner_lease_sidecar()
+        self.runner_lease_store()
             .seed_from_snapshot(&snapshot, run_id)
             .await?;
         self.clear_snapshot_cache();
@@ -241,9 +244,7 @@ where
     }
 
     async fn cleanup_runner_lease_after_state(&self, result: &Result<TurnRunState, TurnError>) {
-        self.runner_lease_sidecar()
-            .cleanup_after_state(result)
-            .await;
+        self.runner_lease_store().cleanup_after_state(result).await;
         self.clear_snapshot_cache();
     }
 
@@ -251,12 +252,12 @@ where
         &self,
         request: HeartbeatRequest,
     ) -> Result<EventCursor, TurnError> {
-        let sidecar = self.runner_lease_sidecar();
-        let cursor = match sidecar.heartbeat(request.clone()).await {
+        let lease_store = self.runner_lease_store();
+        let cursor = match lease_store.heartbeat(request.clone()).await {
             Err(TurnError::ScopeNotFound) => {
                 self.seed_missing_runner_lease_from_snapshot(request.run_id)
                     .await?;
-                self.runner_lease_sidecar().heartbeat(request).await?
+                self.runner_lease_store().heartbeat(request).await?
             }
             result => result?,
         };
@@ -269,7 +270,7 @@ where
         run_id: TurnRunId,
     ) -> Result<(), TurnError> {
         let (snapshot, _version) = self.read_snapshot_from_filesystem().await?;
-        self.runner_lease_sidecar()
+        self.runner_lease_store()
             .seed_from_snapshot_if_missing(&snapshot, run_id)
             .await
     }
@@ -292,7 +293,7 @@ where
         ) {
             return Ok(None);
         }
-        self.runner_lease_sidecar()
+        self.runner_lease_store()
             .mark_cancel_requested_from_snapshot(&snapshot, request.run_id)
             .await
     }
@@ -305,7 +306,7 @@ where
         retired_status: TurnStatus,
     ) -> Result<Option<RunnerLeaseRecord>, TurnError> {
         let (snapshot, _version) = self.read_snapshot_from_filesystem().await?;
-        self.runner_lease_sidecar()
+        self.runner_lease_store()
             .retire_runner_lease_from_snapshot(
                 &snapshot,
                 run_id,
@@ -324,15 +325,15 @@ where
         let Some(previous) = previous else {
             return;
         };
-        self.runner_lease_sidecar()
+        self.runner_lease_store()
             .restore_if_current_status(previous, current_status)
             .await;
         self.clear_snapshot_cache();
     }
 
-    fn runner_lease_sidecar(&self) -> RunnerLeaseSidecar<F> {
-        RunnerLeaseSidecar::new(
-            Arc::clone(&self.filesystem),
+    fn runner_lease_store(&self) -> RunnerLeaseStore {
+        RunnerLeaseStore::new(
+            Arc::clone(&self.runner_leases),
             self.limits.runner_lease_ttl,
             self.apply_timeout,
         )
@@ -503,7 +504,7 @@ where
             tracing::debug!(
                 run_id = %run_id,
                 error = %error,
-                "failed to compensate turn claim after runner lease sidecar seed failed"
+                "failed to compensate turn claim after memory runner lease seed failed"
             );
         }
         self.clear_snapshot_cache();
@@ -582,7 +583,7 @@ where
         let response = result?;
         match response.status {
             status if status.is_terminal() => {
-                self.runner_lease_sidecar()
+                self.runner_lease_store()
                     .delete_best_effort(response.run_id)
                     .await;
             }
@@ -789,7 +790,7 @@ where
             .await;
         if let Ok(response) = &result {
             for state in &response.recovered {
-                self.runner_lease_sidecar()
+                self.runner_lease_store()
                     .delete_best_effort(state.run_id)
                     .await;
             }

--- a/crates/ironclaw_turns/src/filesystem_store.rs
+++ b/crates/ironclaw_turns/src/filesystem_store.rs
@@ -41,6 +41,7 @@ use std::{
 use async_trait::async_trait;
 use ironclaw_filesystem::{CasExpectation, RecordVersion, RootFilesystem, ScopedFilesystem};
 use ironclaw_host_api::{ResourceScope, ScopedPath, UserId};
+use tokio::sync::RwLock;
 
 use crate::{
     AllowAllTurnAdmissionLimitProvider, CancelRunRequest, CancelRunResponse, EventCursor,
@@ -139,7 +140,7 @@ where
             limits: InMemoryTurnStateStoreLimits::default(),
             admission_limit_provider: Arc::new(AllowAllTurnAdmissionLimitProvider),
             snapshot_cache: Mutex::new(None),
-            runner_leases: Arc::new(Mutex::new(HashMap::new())),
+            runner_leases: Arc::new(RwLock::new(HashMap::new())),
             apply_timeout: FILESYSTEM_APPLY_TIMEOUT,
         }
     }

--- a/crates/ironclaw_turns/src/filesystem_store/runner_lease.rs
+++ b/crates/ironclaw_turns/src/filesystem_store/runner_lease.rs
@@ -1,11 +1,7 @@
-use std::{
-    collections::HashMap,
-    future::Future,
-    sync::{Arc, Mutex},
-    time::Duration,
-};
+use std::{collections::HashMap, future::Future, sync::Arc, time::Duration};
 
 use ironclaw_filesystem::RecordVersion;
+use tokio::sync::RwLock;
 
 use crate::{
     EventCursor, TurnError, TurnPersistenceSnapshot, TurnRunId, TurnRunRecord, TurnRunState,
@@ -30,7 +26,7 @@ pub(super) enum RunnerLeaseOverlay {
     All,
 }
 
-pub(super) type RunnerLeaseMemory = Arc<Mutex<HashMap<TurnRunId, RunnerLeaseRecord>>>;
+pub(super) type RunnerLeaseMemory = Arc<RwLock<HashMap<TurnRunId, RunnerLeaseRecord>>>;
 
 pub(super) struct RunnerLeaseStore {
     leases: RunnerLeaseMemory,
@@ -218,15 +214,16 @@ impl RunnerLeaseStore {
         snapshot: (TurnPersistenceSnapshot, Option<RecordVersion>),
     ) -> Result<(TurnPersistenceSnapshot, Option<RecordVersion>), TurnError> {
         let (mut snapshot, version) = snapshot;
+        let leases = self.leases.read().await;
         for run in snapshot
             .runs
             .iter_mut()
             .filter(|record| run_can_use_external_lease(record))
         {
-            let Some(lease) = self.read(run.run_id)? else {
+            let Some(lease) = leases.get(&run.run_id) else {
                 continue;
             };
-            apply_runner_lease_overlay(run, &lease);
+            apply_runner_lease_overlay(run, lease);
         }
         Ok((snapshot, version))
     }
@@ -244,10 +241,11 @@ impl RunnerLeaseStore {
         else {
             return Ok((snapshot, version));
         };
-        let Some(lease) = self.read(run.run_id)? else {
+        let leases = self.leases.read().await;
+        let Some(lease) = leases.get(&run.run_id) else {
             return Ok((snapshot, version));
         };
-        apply_runner_lease_overlay(run, &lease);
+        apply_runner_lease_overlay(run, lease);
         Ok((snapshot, version))
     }
 
@@ -273,15 +271,18 @@ impl RunnerLeaseStore {
         snapshot: &TurnPersistenceSnapshot,
         run_id: TurnRunId,
     ) -> Result<(), TurnError> {
-        if self.read(run_id)?.is_some() {
+        let mut leases = self.leases.write().await;
+        if leases.contains_key(&run_id) {
             return Ok(());
         }
-        self.seed_from_snapshot_inner(snapshot, run_id).await
+        let record = runner_lease_from_snapshot(snapshot, run_id)?;
+        leases.insert(record.run_id, record);
+        Ok(())
     }
 
     async fn heartbeat_inner(&self, request: HeartbeatRequest) -> Result<EventCursor, TurnError> {
         let now = chrono::Utc::now();
-        let mut leases = self.lock_leases()?;
+        let mut leases = self.leases.write().await;
         let Some(existing) = leases.get_mut(&request.run_id) else {
             return Err(TurnError::ScopeNotFound);
         };
@@ -303,7 +304,7 @@ impl RunnerLeaseStore {
         previous: RunnerLeaseRecord,
         current_status: TurnStatus,
     ) -> Result<(), TurnError> {
-        let mut leases = self.lock_leases()?;
+        let mut leases = self.leases.write().await;
         let Some(current) = leases.get(&previous.run_id) else {
             return Ok(());
         };
@@ -326,17 +327,11 @@ impl RunnerLeaseStore {
     }
 
     async fn delete_best_effort_inner(&self, run_id: TurnRunId) {
-        if let Err(error) = self.delete(run_id) {
-            tracing::debug!(
-                run_id = %run_id,
-                error = %error,
-                "failed to delete memory-backed runner lease after run left runner-owned state"
-            );
-        }
+        self.delete(run_id).await;
     }
 
     async fn upsert(&self, record: RunnerLeaseRecord) -> Result<(), TurnError> {
-        self.lock_leases()?.insert(record.run_id, record);
+        self.leases.write().await.insert(record.run_id, record);
         Ok(())
     }
 
@@ -348,7 +343,7 @@ impl RunnerLeaseStore {
         status: TurnStatus,
     ) -> Result<Option<RunnerLeaseRecord>, TurnError> {
         let fallback = runner_lease_from_snapshot(snapshot, run_id)?;
-        let mut leases = self.lock_leases()?;
+        let mut leases = self.leases.write().await;
         let existing = leases.get(&run_id).cloned().unwrap_or(fallback);
         if let Some((runner_id, lease_token)) = expected_runner {
             ensure_active_runner_lease(&existing, runner_id, lease_token, chrono::Utc::now())?;
@@ -371,21 +366,8 @@ impl RunnerLeaseStore {
         Ok(Some(existing))
     }
 
-    fn read(&self, run_id: TurnRunId) -> Result<Option<RunnerLeaseRecord>, TurnError> {
-        Ok(self.lock_leases()?.get(&run_id).cloned())
-    }
-
-    fn delete(&self, run_id: TurnRunId) -> Result<(), TurnError> {
-        self.lock_leases()?.remove(&run_id);
-        Ok(())
-    }
-
-    fn lock_leases(
-        &self,
-    ) -> Result<std::sync::MutexGuard<'_, HashMap<TurnRunId, RunnerLeaseRecord>>, TurnError> {
-        self.leases.lock().map_err(|_| TurnError::Unavailable {
-            reason: "turn runner lease memory store poisoned".to_string(),
-        })
+    async fn delete(&self, run_id: TurnRunId) {
+        self.leases.write().await.remove(&run_id);
     }
 }
 
@@ -465,4 +447,116 @@ fn ensure_active_runner_lease(
         });
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        AcceptedMessageRef, ReplyTargetBindingRef, SourceBindingRef, TurnId, TurnLeaseToken,
+        TurnRunnerId, TurnScope,
+    };
+    use chrono::Utc;
+    use ironclaw_host_api::{AgentId, ProjectId, TenantId, ThreadId};
+
+    #[tokio::test]
+    async fn seed_from_snapshot_if_missing_does_not_overwrite_existing_lease() {
+        let run_id = TurnRunId::new();
+        let runner_id = TurnRunnerId::new();
+        let lease_token = TurnLeaseToken::new();
+        let now = Utc::now();
+        let snapshot = TurnPersistenceSnapshot {
+            runs: vec![turn_run_record(
+                run_id,
+                runner_id,
+                lease_token,
+                TurnStatus::Running,
+                now,
+                now,
+                EventCursor(1),
+            )],
+            ..TurnPersistenceSnapshot::default()
+        };
+        let existing = RunnerLeaseRecord {
+            run_id,
+            runner_id,
+            lease_token,
+            lease_expires_at: now + chrono::Duration::minutes(2),
+            last_heartbeat_at: now + chrono::Duration::seconds(5),
+            status: TurnStatus::CancelRequested,
+            event_cursor: EventCursor(2),
+        };
+        let store = RunnerLeaseStore::new(
+            Arc::new(RwLock::new(HashMap::new())),
+            chrono::Duration::minutes(1),
+            Duration::from_secs(1),
+        );
+        store.upsert(existing.clone()).await.unwrap();
+
+        store
+            .seed_from_snapshot_if_missing(&snapshot, run_id)
+            .await
+            .unwrap();
+
+        let stored = store
+            .leases
+            .read()
+            .await
+            .get(&run_id)
+            .cloned()
+            .expect("existing lease");
+        assert_eq!(stored, existing);
+    }
+
+    fn turn_run_record(
+        run_id: TurnRunId,
+        runner_id: TurnRunnerId,
+        lease_token: TurnLeaseToken,
+        status: TurnStatus,
+        lease_expires_at: crate::TurnTimestamp,
+        last_heartbeat_at: crate::TurnTimestamp,
+        event_cursor: EventCursor,
+    ) -> TurnRunRecord {
+        let profile: crate::TurnRunProfile = serde_json::from_value(serde_json::json!({
+            "id": "default",
+            "version": 1,
+            "allow_steering": false,
+            "auto_queue_followups": false,
+        }))
+        .expect("profile deserialization");
+        TurnRunRecord {
+            run_id,
+            turn_id: TurnId::new(),
+            scope: TurnScope::new(
+                TenantId::new("tenant-runner-lease-test").unwrap(),
+                Some(AgentId::new("agent-runner-lease-test").unwrap()),
+                Some(ProjectId::new("project-runner-lease-test").unwrap()),
+                ThreadId::new("thread-runner-lease-test").unwrap(),
+            ),
+            accepted_message_ref: AcceptedMessageRef::new("accepted-runner-lease-test").unwrap(),
+            source_binding_ref: SourceBindingRef::new("source-runner-lease-test").unwrap(),
+            reply_target_binding_ref: ReplyTargetBindingRef::new("reply-runner-lease-test")
+                .unwrap(),
+            status,
+            profile,
+            resolved_model_route: None,
+            checkpoint_id: None,
+            gate_ref: None,
+            blocked_activity_id: None,
+            credential_requirements: vec![],
+            failure: None,
+            event_cursor,
+            runner_id: Some(runner_id),
+            lease_token: Some(lease_token),
+            lease_expires_at: Some(lease_expires_at),
+            last_heartbeat_at: Some(last_heartbeat_at),
+            claim_count: 1,
+            received_at: last_heartbeat_at,
+            parent_run_id: None,
+            subagent_depth: 0,
+            spawn_tree_root_run_id: None,
+            product_context: None,
+            resume_disposition: None,
+        }
+    }
 }

--- a/crates/ironclaw_turns/src/filesystem_store/runner_lease.rs
+++ b/crates/ironclaw_turns/src/filesystem_store/runner_lease.rs
@@ -1,25 +1,18 @@
-use std::{future::Future, sync::Arc, time::Duration};
-
-use ironclaw_filesystem::{
-    CasExpectation, ContentType, Entry, FilesystemError, RecordKind, RecordVersion, RootFilesystem,
-    ScopedFilesystem,
+use std::{
+    collections::HashMap,
+    future::Future,
+    sync::{Arc, Mutex},
+    time::Duration,
 };
-use ironclaw_host_api::{ResourceScope, ScopedPath};
-use serde::{Deserialize, Serialize};
+
+use ironclaw_filesystem::RecordVersion;
 
 use crate::{
     EventCursor, TurnError, TurnPersistenceSnapshot, TurnRunId, TurnRunRecord, TurnRunState,
-    TurnStatus,
-    filesystem_store::io::{
-        FILESYSTEM_CAS_RETRIES, PutError, cas_retry_backoff, fs_error, put_with_cas,
-    },
-    runner::HeartbeatRequest,
+    TurnStatus, runner::HeartbeatRequest,
 };
 
-const TURNS_RUNNER_LEASE_PREFIX: &str = "/turns/runner-leases";
-const TURNS_RUNNER_LEASE_KIND: &str = "turn_runner_lease";
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct RunnerLeaseRecord {
     run_id: TurnRunId,
     runner_id: crate::TurnRunnerId,
@@ -37,26 +30,22 @@ pub(super) enum RunnerLeaseOverlay {
     All,
 }
 
-pub(super) struct RunnerLeaseSidecar<F>
-where
-    F: RootFilesystem,
-{
-    filesystem: Arc<ScopedFilesystem<F>>,
+pub(super) type RunnerLeaseMemory = Arc<Mutex<HashMap<TurnRunId, RunnerLeaseRecord>>>;
+
+pub(super) struct RunnerLeaseStore {
+    leases: RunnerLeaseMemory,
     runner_lease_ttl: chrono::Duration,
     apply_timeout: Duration,
 }
 
-impl<F> RunnerLeaseSidecar<F>
-where
-    F: RootFilesystem,
-{
+impl RunnerLeaseStore {
     pub(super) fn new(
-        filesystem: Arc<ScopedFilesystem<F>>,
+        leases: RunnerLeaseMemory,
         runner_lease_ttl: chrono::Duration,
         apply_timeout: Duration,
     ) -> Self {
         Self {
-            filesystem,
+            leases,
             runner_lease_ttl,
             apply_timeout,
         }
@@ -234,7 +223,7 @@ where
             .iter_mut()
             .filter(|record| run_can_use_external_lease(record))
         {
-            let Some((lease, _version)) = self.read(run.run_id).await? else {
+            let Some(lease) = self.read(run.run_id)? else {
                 continue;
             };
             apply_runner_lease_overlay(run, &lease);
@@ -255,7 +244,7 @@ where
         else {
             return Ok((snapshot, version));
         };
-        let Some((lease, _version)) = self.read(run.run_id).await? else {
+        let Some(lease) = self.read(run.run_id)? else {
             return Ok((snapshot, version));
         };
         apply_runner_lease_overlay(run, &lease);
@@ -284,37 +273,29 @@ where
         snapshot: &TurnPersistenceSnapshot,
         run_id: TurnRunId,
     ) -> Result<(), TurnError> {
-        if self.read(run_id).await?.is_some() {
+        if self.read(run_id)?.is_some() {
             return Ok(());
         }
         self.seed_from_snapshot_inner(snapshot, run_id).await
     }
 
     async fn heartbeat_inner(&self, request: HeartbeatRequest) -> Result<EventCursor, TurnError> {
-        for attempt in 0..FILESYSTEM_CAS_RETRIES {
-            let now = chrono::Utc::now();
-            let Some((existing, version)) = self.read(request.run_id).await? else {
-                return Err(TurnError::ScopeNotFound);
-            };
-            ensure_active_runner_lease(&existing, request.runner_id, request.lease_token, now)?;
-            if existing.status != TurnStatus::Running {
-                return Err(TurnError::InvalidTransition {
-                    from: existing.status,
-                    to: TurnStatus::Running,
-                });
-            }
-            let mut next = existing.clone();
-            next.lease_expires_at = next_lease_expiry(self.runner_lease_ttl, now);
-            next.last_heartbeat_at = now;
-            match self.write(&next, CasExpectation::Version(version)).await {
-                Ok(_) => return Ok(existing.event_cursor),
-                Err(PutError::VersionMismatch) => cas_retry_backoff(attempt).await,
-                Err(PutError::Other(error)) => return Err(error),
-            }
+        let now = chrono::Utc::now();
+        let mut leases = self.lock_leases()?;
+        let Some(existing) = leases.get_mut(&request.run_id) else {
+            return Err(TurnError::ScopeNotFound);
+        };
+        ensure_active_runner_lease(existing, request.runner_id, request.lease_token, now)?;
+        if existing.status != TurnStatus::Running {
+            return Err(TurnError::InvalidTransition {
+                from: existing.status,
+                to: TurnStatus::Running,
+            });
         }
-        Err(TurnError::Unavailable {
-            reason: "turn runner lease CAS retries exhausted".to_string(),
-        })
+        let event_cursor = existing.event_cursor;
+        existing.lease_expires_at = next_lease_expiry(self.runner_lease_ttl, now);
+        existing.last_heartbeat_at = now;
+        Ok(event_cursor)
     }
 
     async fn restore_if_current_status_inner(
@@ -322,28 +303,18 @@ where
         previous: RunnerLeaseRecord,
         current_status: TurnStatus,
     ) -> Result<(), TurnError> {
-        for attempt in 0..FILESYSTEM_CAS_RETRIES {
-            let Some((current, version)) = self.read(previous.run_id).await? else {
-                return Ok(());
-            };
-            if current.runner_id != previous.runner_id
-                || current.lease_token != previous.lease_token
-                || current.status != current_status
-            {
-                return Ok(());
-            }
-            match self
-                .write(&previous, CasExpectation::Version(version))
-                .await
-            {
-                Ok(_) => return Ok(()),
-                Err(PutError::VersionMismatch) => cas_retry_backoff(attempt).await,
-                Err(PutError::Other(error)) => return Err(error),
-            }
+        let mut leases = self.lock_leases()?;
+        let Some(current) = leases.get(&previous.run_id) else {
+            return Ok(());
+        };
+        if current.runner_id != previous.runner_id
+            || current.lease_token != previous.lease_token
+            || current.status != current_status
+        {
+            return Ok(());
         }
-        Err(TurnError::Unavailable {
-            reason: "turn runner lease CAS retries exhausted".to_string(),
-        })
+        leases.insert(previous.run_id, previous);
+        Ok(())
     }
 
     async fn cleanup_after_state_inner(&self, result: &Result<TurnRunState, TurnError>) {
@@ -355,33 +326,18 @@ where
     }
 
     async fn delete_best_effort_inner(&self, run_id: TurnRunId) {
-        match self.delete(run_id).await {
-            Ok(()) | Err(TurnError::ScopeNotFound) => {}
-            Err(error) => {
-                tracing::debug!(
-                    run_id = %run_id,
-                    error = %error,
-                    "failed to delete runner lease sidecar after run left runner-owned state"
-                );
-            }
+        if let Err(error) = self.delete(run_id) {
+            tracing::debug!(
+                run_id = %run_id,
+                error = %error,
+                "failed to delete memory-backed runner lease after run left runner-owned state"
+            );
         }
     }
 
     async fn upsert(&self, record: RunnerLeaseRecord) -> Result<(), TurnError> {
-        for attempt in 0..FILESYSTEM_CAS_RETRIES {
-            let cas = match self.read(record.run_id).await? {
-                Some((_existing, version)) => CasExpectation::Version(version),
-                None => CasExpectation::Absent,
-            };
-            match self.write(&record, cas).await {
-                Ok(_) => return Ok(()),
-                Err(PutError::VersionMismatch) => cas_retry_backoff(attempt).await,
-                Err(PutError::Other(error)) => return Err(error),
-            }
-        }
-        Err(TurnError::Unavailable {
-            reason: "turn runner lease CAS retries exhausted".to_string(),
-        })
+        self.lock_leases()?.insert(record.run_id, record);
+        Ok(())
     }
 
     async fn write_status_from_snapshot(
@@ -392,88 +348,45 @@ where
         status: TurnStatus,
     ) -> Result<Option<RunnerLeaseRecord>, TurnError> {
         let fallback = runner_lease_from_snapshot(snapshot, run_id)?;
-        for attempt in 0..FILESYSTEM_CAS_RETRIES {
-            let (existing, cas) = match self.read(run_id).await? {
-                Some((existing, version)) => (existing, CasExpectation::Version(version)),
-                None => (fallback.clone(), CasExpectation::Absent),
-            };
-            if let Some((runner_id, lease_token)) = expected_runner {
-                ensure_active_runner_lease(&existing, runner_id, lease_token, chrono::Utc::now())?;
-            }
-            if existing.status == status {
-                return Ok(None);
-            }
-            if !matches!(
-                existing.status,
-                TurnStatus::Running | TurnStatus::CancelRequested
-            ) {
-                return Err(TurnError::InvalidTransition {
-                    from: existing.status,
-                    to: status,
-                });
-            }
-            let mut next = existing.clone();
-            next.status = status;
-            match self.write(&next, cas).await {
-                Ok(_) => return Ok(Some(existing)),
-                Err(PutError::VersionMismatch) => cas_retry_backoff(attempt).await,
-                Err(PutError::Other(error)) => return Err(error),
-            }
+        let mut leases = self.lock_leases()?;
+        let existing = leases.get(&run_id).cloned().unwrap_or(fallback);
+        if let Some((runner_id, lease_token)) = expected_runner {
+            ensure_active_runner_lease(&existing, runner_id, lease_token, chrono::Utc::now())?;
         }
-        Err(TurnError::Unavailable {
-            reason: "turn runner lease CAS retries exhausted".to_string(),
+        if existing.status == status {
+            return Ok(None);
+        }
+        if !matches!(
+            existing.status,
+            TurnStatus::Running | TurnStatus::CancelRequested
+        ) {
+            return Err(TurnError::InvalidTransition {
+                from: existing.status,
+                to: status,
+            });
+        }
+        let mut next = existing.clone();
+        next.status = status;
+        leases.insert(run_id, next);
+        Ok(Some(existing))
+    }
+
+    fn read(&self, run_id: TurnRunId) -> Result<Option<RunnerLeaseRecord>, TurnError> {
+        Ok(self.lock_leases()?.get(&run_id).cloned())
+    }
+
+    fn delete(&self, run_id: TurnRunId) -> Result<(), TurnError> {
+        self.lock_leases()?.remove(&run_id);
+        Ok(())
+    }
+
+    fn lock_leases(
+        &self,
+    ) -> Result<std::sync::MutexGuard<'_, HashMap<TurnRunId, RunnerLeaseRecord>>, TurnError> {
+        self.leases.lock().map_err(|_| TurnError::Unavailable {
+            reason: "turn runner lease memory store poisoned".to_string(),
         })
     }
-
-    async fn read(
-        &self,
-        run_id: TurnRunId,
-    ) -> Result<Option<(RunnerLeaseRecord, RecordVersion)>, TurnError> {
-        let path = runner_lease_path(run_id)?;
-        match self.filesystem.get(&ResourceScope::system(), &path).await {
-            Ok(Some(versioned)) => {
-                let record = deserialize_runner_lease(&versioned.entry.body)?;
-                Ok(Some((record, versioned.version)))
-            }
-            Ok(None) => Ok(None),
-            Err(error) => Err(fs_error(error)),
-        }
-    }
-
-    async fn write(
-        &self,
-        record: &RunnerLeaseRecord,
-        cas: CasExpectation,
-    ) -> Result<RecordVersion, PutError> {
-        let path = runner_lease_path(record.run_id).map_err(PutError::Other)?;
-        put_with_cas(
-            self.filesystem.as_ref(),
-            &path,
-            runner_lease_entry(record).map_err(PutError::Other)?,
-            cas,
-        )
-        .await
-    }
-
-    async fn delete(&self, run_id: TurnRunId) -> Result<(), TurnError> {
-        let path = runner_lease_path(run_id)?;
-        match self
-            .filesystem
-            .delete(&ResourceScope::system(), &path)
-            .await
-        {
-            Ok(()) | Err(FilesystemError::NotFound { .. }) => Ok(()),
-            Err(error) => Err(fs_error(error)),
-        }
-    }
-}
-
-fn runner_lease_path(run_id: TurnRunId) -> Result<ScopedPath, TurnError> {
-    ScopedPath::new(format!("{TURNS_RUNNER_LEASE_PREFIX}/{run_id}.json")).map_err(|error| {
-        TurnError::Unavailable {
-            reason: format!("invalid turn runner lease path: {error}"),
-        }
-    })
 }
 
 fn next_lease_expiry(
@@ -552,23 +465,4 @@ fn ensure_active_runner_lease(
         });
     }
     Ok(())
-}
-
-fn runner_lease_entry(record: &RunnerLeaseRecord) -> Result<Entry, TurnError> {
-    let body = serde_json::to_vec(record).map_err(|error| TurnError::Unavailable {
-        reason: format!("turn runner lease serialization failed: {error}"),
-    })?;
-    let kind =
-        RecordKind::new(TURNS_RUNNER_LEASE_KIND).map_err(|error| TurnError::Unavailable {
-            reason: format!("invalid turn runner lease record kind: {error}"),
-        })?;
-    let mut entry = Entry::bytes(body).with_content_type(ContentType::json());
-    entry.kind = Some(kind);
-    Ok(entry)
-}
-
-fn deserialize_runner_lease(bytes: &[u8]) -> Result<RunnerLeaseRecord, TurnError> {
-    serde_json::from_slice(bytes).map_err(|error| TurnError::Unavailable {
-        reason: format!("turn runner lease deserialization failed: {error}"),
-    })
 }

--- a/crates/ironclaw_turns/tests/filesystem_turn_state_contract.rs
+++ b/crates/ironclaw_turns/tests/filesystem_turn_state_contract.rs
@@ -1,7 +1,7 @@
 //! Contract tests for [`FilesystemTurnStateStore`] against a
 //! [`ScopedFilesystem`] over a CAS-capable filesystem backend. The persistent
-//! shape is a lower-churn `/turns/state.json` snapshot plus per-run lease
-//! sidecars keyed by the [`MountView`] target.
+//! shape is a lower-churn `/turns/state.json` snapshot; active runner leases
+//! are memory-backed and fall back to the snapshot after restart.
 
 use std::{
     sync::{
@@ -366,25 +366,6 @@ impl<F> VersionMismatchFilesystem<F> {
     }
 }
 
-struct OneShotRunnerLeaseVersionMismatchFilesystem<F> {
-    inner: F,
-    reject_next_runner_lease_put: AtomicBool,
-}
-
-impl<F> OneShotRunnerLeaseVersionMismatchFilesystem<F> {
-    fn new(inner: F) -> Self {
-        Self {
-            inner,
-            reject_next_runner_lease_put: AtomicBool::new(false),
-        }
-    }
-
-    fn reject_next_runner_lease_put(&self) {
-        self.reject_next_runner_lease_put
-            .store(true, Ordering::SeqCst);
-    }
-}
-
 struct RejectingPutFilesystem<F> {
     inner: F,
     put_calls: AtomicUsize,
@@ -467,55 +448,6 @@ where
             expected,
             found: None,
         })
-    }
-
-    async fn get(&self, path: &VirtualPath) -> Result<Option<VersionedEntry>, FilesystemError> {
-        self.inner.get(path).await
-    }
-
-    async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
-        self.inner.list_dir(path).await
-    }
-
-    async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
-        self.inner.stat(path).await
-    }
-
-    async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
-        self.inner.delete(path).await
-    }
-}
-
-#[async_trait]
-impl<F> RootFilesystem for OneShotRunnerLeaseVersionMismatchFilesystem<F>
-where
-    F: RootFilesystem,
-{
-    fn capabilities(&self) -> BackendCapabilities {
-        self.inner.capabilities()
-    }
-
-    async fn put(
-        &self,
-        path: &VirtualPath,
-        entry: Entry,
-        cas: CasExpectation,
-    ) -> Result<RecordVersion, FilesystemError> {
-        if path.as_str().contains("/turns/runner-leases/")
-            && self
-                .reject_next_runner_lease_put
-                .swap(false, Ordering::SeqCst)
-        {
-            return Err(FilesystemError::VersionMismatch {
-                path: path.clone(),
-                expected: match cas {
-                    CasExpectation::Any | CasExpectation::Absent => None,
-                    CasExpectation::Version(version) => Some(version),
-                },
-                found: None,
-            });
-        }
-        self.inner.put(path, entry, cas).await
     }
 
     async fn get(&self, path: &VirtualPath) -> Result<Option<VersionedEntry>, FilesystemError> {
@@ -805,8 +737,8 @@ async fn filesystem_turn_state_store_heartbeat_updates_lease_without_rewriting_s
     let resolver = InMemoryRunProfileResolver::default();
 
     let request = submit_request_for(
-        turn_scope("thread-fs-heartbeat-sidecar"),
-        "idem-fs-heartbeat-sidecar",
+        turn_scope("thread-fs-heartbeat-memory"),
+        "idem-fs-heartbeat-memory",
     );
     let response = store
         .submit_turn(request.clone(), &AllowAllTurnAdmissionPolicy, &resolver)
@@ -872,24 +804,32 @@ async fn filesystem_turn_state_store_heartbeat_updates_lease_without_rewriting_s
             .last_heartbeat_at
             .expect("heartbeat timestamp")
             > first_heartbeat_at,
-        "heartbeat read model should expose the refreshed sidecar timestamp"
+        "heartbeat read model should expose the refreshed memory lease timestamp"
     );
     assert!(
         heartbeat_run.lease_expires_at.expect("lease expiry") > first_expiry,
-        "heartbeat read model should expose the refreshed sidecar expiry"
+        "heartbeat read model should expose the refreshed memory lease expiry"
+    );
+    assert!(
+        backend
+            .get(&runner_lease_virtual_path(run_id))
+            .await
+            .unwrap()
+            .is_none(),
+        "runner leases are memory-backed and must not materialize durable sidecar records"
     );
 }
 
 #[tokio::test]
-async fn filesystem_turn_state_store_heartbeat_backfills_missing_runner_lease_sidecar() {
+async fn filesystem_turn_state_store_heartbeat_seeds_memory_lease_from_snapshot_after_reopen() {
     let backend = Arc::new(engine_filesystem());
     let scoped = scoped_turns_fs(Arc::clone(&backend));
-    let store = FilesystemTurnStateStore::new(scoped);
+    let store = FilesystemTurnStateStore::new(Arc::clone(&scoped));
     let resolver = InMemoryRunProfileResolver::default();
 
     let request = submit_request_for(
-        turn_scope("thread-fs-heartbeat-sidecar-backfill"),
-        "idem-fs-heartbeat-sidecar-backfill",
+        turn_scope("thread-fs-heartbeat-memory-backfill"),
+        "idem-fs-heartbeat-memory-backfill",
     );
     let response = store
         .submit_turn(request.clone(), &AllowAllTurnAdmissionPolicy, &resolver)
@@ -915,21 +855,18 @@ async fn filesystem_turn_state_store_heartbeat_backfills_missing_runner_lease_si
         .and_then(|record| record.last_heartbeat_at)
         .expect("claimed heartbeat timestamp");
 
-    backend
-        .delete(&runner_lease_virtual_path(run_id))
-        .await
-        .unwrap();
+    let reopened = FilesystemTurnStateStore::new(scoped);
     tokio::time::sleep(Duration::from_millis(5)).await;
-    store
+    reopened
         .heartbeat(HeartbeatRequest {
             run_id,
             runner_id,
             lease_token,
         })
         .await
-        .expect("heartbeat should lazily seed a missing sidecar from state.json");
+        .expect("heartbeat should lazily seed a missing memory lease from state.json");
 
-    let heartbeat_snapshot = store.persistence_snapshot().await.unwrap();
+    let heartbeat_snapshot = reopened.persistence_snapshot().await.unwrap();
     let heartbeat_run = heartbeat_snapshot
         .runs
         .iter()
@@ -940,20 +877,20 @@ async fn filesystem_turn_state_store_heartbeat_backfills_missing_runner_lease_si
             .last_heartbeat_at
             .expect("heartbeat timestamp")
             > first_heartbeat_at,
-        "lazy sidecar backfill must still expose the refreshed heartbeat"
+        "lazy memory lease backfill must still expose the refreshed heartbeat"
     );
 }
 
 #[tokio::test]
-async fn filesystem_turn_state_store_recover_expired_leases_uses_runner_lease_sidecar() {
+async fn filesystem_turn_state_store_recover_expired_leases_uses_memory_runner_lease() {
     let backend = Arc::new(engine_filesystem());
     let scoped = scoped_turns_fs(Arc::clone(&backend));
     let store = FilesystemTurnStateStore::new(scoped);
     let resolver = InMemoryRunProfileResolver::default();
 
     let request = submit_request_for(
-        turn_scope("thread-fs-recover-sidecar"),
-        "idem-fs-recover-sidecar",
+        turn_scope("thread-fs-recover-memory-lease"),
+        "idem-fs-recover-memory-lease",
     );
     let response = store
         .submit_turn(request, &AllowAllTurnAdmissionPolicy, &resolver)
@@ -1006,7 +943,7 @@ async fn filesystem_turn_state_store_recover_expired_leases_uses_runner_lease_si
         .unwrap();
     assert!(
         not_yet_recovered.recovered.is_empty(),
-        "recovery must use sidecar expiry instead of stale state.json expiry"
+        "recovery must use memory lease expiry instead of stale state.json expiry"
     );
 
     let recovered = store
@@ -1022,15 +959,15 @@ async fn filesystem_turn_state_store_recover_expired_leases_uses_runner_lease_si
 }
 
 #[tokio::test]
-async fn filesystem_turn_state_store_complete_run_uses_runner_lease_sidecar() {
+async fn filesystem_turn_state_store_complete_run_uses_memory_runner_lease() {
     let backend = Arc::new(engine_filesystem());
     let scoped = scoped_turns_fs(Arc::clone(&backend));
     let store = FilesystemTurnStateStore::new(scoped);
     let resolver = InMemoryRunProfileResolver::default();
 
     let request = submit_request_for(
-        turn_scope("thread-fs-complete-sidecar"),
-        "idem-fs-complete-sidecar",
+        turn_scope("thread-fs-complete-memory-lease"),
+        "idem-fs-complete-memory-lease",
     );
     let response = store
         .submit_turn(request, &AllowAllTurnAdmissionPolicy, &resolver)
@@ -1068,22 +1005,20 @@ async fn filesystem_turn_state_store_complete_run_uses_runner_lease_sidecar() {
             lease_token,
         })
         .await
-        .expect("terminal transition must validate against sidecar lease metadata");
+        .expect("terminal transition must validate against memory lease metadata");
     assert_eq!(completed.status, TurnStatus::Completed);
 }
 
 #[tokio::test]
-async fn filesystem_turn_state_store_heartbeat_retries_runner_lease_sidecar_cas() {
-    let backend = Arc::new(OneShotRunnerLeaseVersionMismatchFilesystem::new(
-        engine_filesystem(),
-    ));
+async fn filesystem_turn_state_store_heartbeat_does_not_write_runner_lease_sidecar() {
+    let backend = Arc::new(engine_filesystem());
     let scoped = scoped_turns_fs(Arc::clone(&backend));
     let store = FilesystemTurnStateStore::new(scoped);
     let resolver = InMemoryRunProfileResolver::default();
 
     let request = submit_request_for(
-        turn_scope("thread-fs-heartbeat-sidecar-cas"),
-        "idem-fs-heartbeat-sidecar-cas",
+        turn_scope("thread-fs-heartbeat-memory-no-sidecar"),
+        "idem-fs-heartbeat-memory-no-sidecar",
     );
     let response = store
         .submit_turn(request, &AllowAllTurnAdmissionPolicy, &resolver)
@@ -1109,7 +1044,6 @@ async fn filesystem_turn_state_store_heartbeat_retries_runner_lease_sidecar_cas(
         .and_then(|record| record.last_heartbeat_at)
         .expect("claimed heartbeat timestamp");
 
-    backend.reject_next_runner_lease_put();
     tokio::time::sleep(Duration::from_millis(5)).await;
     store
         .heartbeat(HeartbeatRequest {
@@ -1118,7 +1052,7 @@ async fn filesystem_turn_state_store_heartbeat_retries_runner_lease_sidecar_cas(
             lease_token,
         })
         .await
-        .expect("heartbeat should retry sidecar CAS version mismatch");
+        .expect("heartbeat should update the memory-backed runner lease");
 
     let heartbeat_snapshot = store.persistence_snapshot().await.unwrap();
     let heartbeat_at = heartbeat_snapshot
@@ -1128,6 +1062,14 @@ async fn filesystem_turn_state_store_heartbeat_retries_runner_lease_sidecar_cas(
         .and_then(|record| record.last_heartbeat_at)
         .expect("heartbeat timestamp");
     assert!(heartbeat_at > first_heartbeat_at);
+    assert!(
+        backend
+            .get(&runner_lease_virtual_path(run_id))
+            .await
+            .unwrap()
+            .is_none(),
+        "memory-backed heartbeat must not write a durable runner lease sidecar"
+    );
 }
 
 #[tokio::test]
@@ -1140,8 +1082,8 @@ async fn filesystem_turn_state_store_heartbeat_does_not_read_snapshot() {
     let response = store
         .submit_turn(
             submit_request_for(
-                turn_scope("thread-fs-heartbeat-sidecar-only"),
-                "idem-fs-heartbeat-sidecar-only",
+                turn_scope("thread-fs-heartbeat-memory-only"),
+                "idem-fs-heartbeat-memory-only",
             ),
             &AllowAllTurnAdmissionPolicy,
             &resolver,
@@ -1170,19 +1112,19 @@ async fn filesystem_turn_state_store_heartbeat_does_not_read_snapshot() {
             lease_token,
         })
         .await
-        .expect("heartbeat must use only the runner lease sidecar");
+        .expect("heartbeat must use only the memory runner lease");
 }
 
 #[tokio::test]
-async fn filesystem_turn_state_store_cancel_requested_heartbeat_uses_sidecar_status() {
+async fn filesystem_turn_state_store_cancel_requested_heartbeat_uses_memory_lease_status() {
     let backend = Arc::new(RejectSnapshotGetFilesystem::new(engine_filesystem()));
     let scoped = scoped_turns_fs(Arc::clone(&backend));
     let store = FilesystemTurnStateStore::new(scoped);
     let resolver = InMemoryRunProfileResolver::default();
 
     let request = submit_request_for(
-        turn_scope("thread-fs-heartbeat-cancel-sidecar"),
-        "idem-fs-heartbeat-cancel-sidecar",
+        turn_scope("thread-fs-heartbeat-cancel-memory"),
+        "idem-fs-heartbeat-cancel-memory",
     );
     let response = store
         .submit_turn(request.clone(), &AllowAllTurnAdmissionPolicy, &resolver)


### PR DESCRIPTION
## Summary
- keep accepted/terminal turn state durable in /turns/state.json, but move high-churn runner lease heartbeat state into a per-FilesystemTurnStateStore memory map
- overlay memory runner leases onto snapshot reads/mutations so recovery, completion, cancellation, and read models still see current lease metadata while the process is alive
- lazily seed the memory lease from the durable snapshot after a store reopen, and assert heartbeats no longer rewrite state.json or materialize /turns/runner-leases sidecars

## Tradeoff
Live heartbeat extensions are now process-local. That matches the current single-process runner path and removes a hot durable write source, but a future multi-process runner model will need either a shared lease owner/store or a different coordination boundary before relying on cross-process heartbeats.

## Deployment note
This intentionally does not migrate old `/turns/runner-leases/*` heartbeat sidecars. In-flight runs across a restart may be recovered or failed from the older `/turns/state.json` lease timestamp. That is acceptable for the current internal single-instance deployment; fresh runs after deploy use the memory-backed lease path.

## Tests
- cargo fmt --check
- PATH=/Users/firatsertgoz/.rustup/toolchains/1.96.0-aarch64-apple-darwin/bin:$PATH CARGO_TARGET_DIR=/Volumes/NVME/ironclaw-target CARGO_INCREMENTAL=0 cargo clippy -p ironclaw_turns --tests -- -D warnings
- PATH=/Users/firatsertgoz/.rustup/toolchains/1.96.0-aarch64-apple-darwin/bin:$PATH CARGO_TARGET_DIR=/Volumes/NVME/ironclaw-target CARGO_INCREMENTAL=0 cargo test -p ironclaw_turns --test filesystem_turn_state_contract -- --nocapture
- PATH=/Users/firatsertgoz/.rustup/toolchains/1.96.0-aarch64-apple-darwin/bin:$PATH CARGO_TARGET_DIR=/Volumes/NVME/ironclaw-target CARGO_INCREMENTAL=0 cargo test -p ironclaw_turns
