### PR TITLE
Stabilize QA 2E assistant text gate

### DIFF
--- a/scripts/reborn_webui_v2_live_qa/run_live_qa.py
+++ b/scripts/reborn_webui_v2_live_qa/run_live_qa.py
@@ -1002,11 +1002,22 @@ async def _wait_for_assistant_reply(
     last_text = ""
     while time.monotonic() < deadline:
         await _approve_visible_tool_gate(page)
-        if await assistant.count() > 0:
+        assistant_blocks = page.locator("[data-testid='msg-assistant']")  # type: ignore[attr-defined]
+        if await assistant_blocks.count() > 0:
             try:
                 text = await assistant.inner_text(timeout=1000)
             except Exception:
                 text = ""
+            try:
+                block_texts = [
+                    block.strip()
+                    for block in await assistant_blocks.all_inner_texts()
+                    if block.strip()
+                ]
+            except Exception:
+                block_texts = []
+            if block_texts:
+                text = "\n".join(block_texts)
             if text:
                 last_text = text
             normalized = text.lower()
@@ -2042,7 +2053,7 @@ async def case_qa_2e_calendar_prep_email_routine(ctx: LiveQaContext) -> ProbeRes
         case_name="qa_2e_calendar_prep_email_routine",
         routine_name=routine_name,
         marker=None,
-        required_text=["routine", "email"],
+        required_text=["routine", "email|emails|gmail"],
         prompt=_qa_sheet_prompt("qa_2e_calendar_prep_email_routine"),
     )
 

--- a/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
+++ b/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
@@ -429,6 +429,53 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
             )
         )
 
+    def test_wait_for_assistant_reply_matches_combined_assistant_blocks(self):
+        class FakeApprove:
+            @property
+            def last(self):
+                return self
+
+            async def is_visible(self, **_kwargs):
+                return False
+
+        class FakeAssistantBlocks:
+            @property
+            def last(self):
+                return self
+
+            async def count(self):
+                return 2
+
+            async def inner_text(self, **_kwargs):
+                return "latest news on that company\nEmails a concise briefing"
+
+            async def all_inner_texts(self):
+                return [
+                    'The routine has been created successfully. Routine: "30-min meeting briefing"',
+                    "latest news on that company\nEmails a concise briefing",
+                ]
+
+        class FakePage:
+            def locator(self, selector):
+                if selector != "[data-testid='msg-assistant']":
+                    raise AssertionError(f"unexpected selector: {selector}")
+                return FakeAssistantBlocks()
+
+            def get_by_role(self, _role, **_kwargs):
+                return FakeApprove()
+
+        text = asyncio.run(
+            run_live_qa._wait_for_assistant_reply(
+                FakePage(),
+                marker=None,
+                required_text=["routine", "email|emails|gmail"],
+                timeout=1.0,
+            )
+        )
+
+        self.assertIn("routine", text.lower())
+        self.assertIn("emails", text.lower())
+
     def test_slack_delivery_target_dm_detection(self):
         self.assertTrue(run_live_qa._slack_delivery_target_is_dm("D12345"))
         self.assertFalse(run_live_qa._slack_delivery_target_is_dm("C12345"))


### PR DESCRIPTION
## Summary
- make the Reborn WebUIv2 live QA assistant wait helper match the combined assistant response blocks instead of only the final rendered block
- allow QA 2E's email assertion to accept email/emails/Gmail wording while keeping the existing word-aware matcher
- add a regression test for the 7:16 PM Istanbul QA 2E failure shape

## Why
The 2026-06-30 19:16 Istanbul scheduled canary showed QA 2E created the trigger successfully (`trigger_records_before: 0`, `trigger_records_after: 1` and `builtin.trigger_create` completed), but the harness failed because the last assistant block started mid-answer at "latest news... Emails..." and omitted the earlier "routine" text.

## Verification
- `python3 scripts/reborn_webui_v2_live_qa/test_run_live_qa.py`
