### PR TITLE
build(deps): bump rand to 0.8.6 in /channels-src/wechat

### DIFF
--- a/channels-src/wechat/Cargo.lock
+++ b/channels-src/wechat/Cargo.lock
@@ -257,9 +257,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",

--- a/registry/channels/wechat.json
+++ b/registry/channels/wechat.json
@@ -2,7 +2,7 @@
   "name": "wechat",
   "display_name": "WeChat Channel",
   "kind": "channel",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "wit_version": "0.3.0",
   "description": "Talk to your agent through a WeChat iLink bot account",
   "keywords": [


### PR DESCRIPTION
Resolves Dependabot alert **#15** (low) for `rand` in `channels-src/wechat/`.

Supersedes Dependabot PR #3705, which made the `rand` 0.8.5 → 0.8.6 bump but failed the repo's **Version Bump Check** gate: any change under `channels-src/wechat/` must also bump the version in `registry/channels/wechat.json`. This PR does both.

- `channels-src/wechat/Cargo.lock`: `rand` 0.8.5 → 0.8.6 (sole copy).
- `registry/channels/wechat.json`: `version` 0.1.0 → 0.1.1.

Verified: `cargo build --target wasm32-wasip2 --release` in `channels-src/wechat` succeeds. Close #3705 once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)