### PR TITLE
fix(deps): replace unmaintained serde_yml with serde_norway

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4129,7 +4129,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "serde_yml",
+ "serde_norway",
  "sha2 0.11.0",
  "subtle",
  "tar",
@@ -5508,7 +5508,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
- "serde_yml",
+ "serde_norway",
  "sha2 0.11.0",
  "tempfile",
  "thiserror 2.0.18",
@@ -6260,16 +6260,6 @@ dependencies = [
  "tracing",
  "uuid",
  "zerocopy 0.7.35",
-]
-
-[[package]]
-name = "libyml"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
-dependencies = [
- "anyhow",
- "version_check",
 ]
 
 [[package]]
@@ -8905,6 +8895,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_norway"
+version = "0.9.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e408f29489b5fd500fab51ff1484fc859bb655f32c671f307dcd733b72e8168c"
+dependencies = [
+ "indexmap 2.14.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml-norway",
+]
+
+[[package]]
 name = "serde_path_to_error"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8977,21 +8980,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "serde_yml"
-version = "0.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
-dependencies = [
- "indexmap 2.14.0",
- "itoa",
- "libyml",
- "memchr",
- "ryu",
- "serde",
- "version_check",
 ]
 
 [[package]]
@@ -10482,6 +10470,12 @@ dependencies = [
  "crypto-common 0.1.7",
  "subtle",
 ]
+
+[[package]]
+name = "unsafe-libyaml-norway"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39abd59bf32521c7f2301b52d05a6a2c975b6003521cbd0c6dc1582f0a22104"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,7 +158,7 @@ regex = "1"
 aho-corasick = "1"
 
 # YAML parsing for SKILL.md frontmatter
-serde_yml = "0.0.12"
+serde_norway = "0.9"
 
 # Filesystem paths
 dirs = "6"

--- a/crates/ironclaw_skills/Cargo.toml
+++ b/crates/ironclaw_skills/Cargo.toml
@@ -27,7 +27,7 @@ libc = "0.2"
 regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde_yml = "0.0.12"
+serde_norway = "0.9"
 sha2 = "0.11"
 thiserror = "2"
 tokio = { version = "1", features = ["sync", "process", "fs"] }

--- a/crates/ironclaw_skills/src/parser.rs
+++ b/crates/ironclaw_skills/src/parser.rs
@@ -187,8 +187,8 @@ fn parse_skill_md_impl(content: &str, validate_name: bool) -> Result<ParsedSkill
     let yaml_str = &after_first_line[..yaml_end];
 
     // Parse YAML frontmatter
-    let mut manifest: SkillManifest =
-        serde_yml::from_str(yaml_str).map_err(|e| SkillParseError::InvalidYaml(e.to_string()))?;
+    let mut manifest: SkillManifest = serde_norway::from_str(yaml_str)
+        .map_err(|e| SkillParseError::InvalidYaml(e.to_string()))?;
 
     // Detect the legacy `metadata.openclaw.requires` shape and warn loudly.
     // The new flat `requires:` field replaces it; serde silently drops the
@@ -248,7 +248,7 @@ fn parse_skill_md_impl(content: &str, validate_name: bool) -> Result<ParsedSkill
 /// `SkillManifest`, so without this check a skill author can think their
 /// gating/dependency requirements are honored when they are completely inert.
 pub(crate) fn has_legacy_metadata_openclaw_requires(yaml_str: &str) -> bool {
-    let raw: serde_yml::Value = match serde_yml::from_str(yaml_str) {
+    let raw: serde_norway::Value = match serde_norway::from_str(yaml_str) {
         Ok(v) => v,
         Err(_) => return false,
     };

--- a/crates/ironclaw_skills/src/registry.rs
+++ b/crates/ironclaw_skills/src/registry.rs
@@ -65,7 +65,7 @@ fn parse_error_for_install(error_label: &str, error: SkillParseError) -> SkillRe
 /// Rewrite the `name` field in raw YAML frontmatter while preserving every
 /// other key and value in the original mapping.
 ///
-/// We deliberately operate on `serde_yml::Value` instead of the typed
+/// We deliberately operate on `serde_norway::Value` instead of the typed
 /// `SkillManifest`: re-serializing through the typed struct silently drops
 /// any unknown frontmatter fields published upstream (custom metadata, future
 /// fields, vendor extensions). The recovery path must be lossless except for
@@ -75,8 +75,8 @@ fn rewrite_frontmatter_name(
     new_name: &str,
     error_label: &str,
 ) -> Result<String, SkillRegistryError> {
-    let mut value: serde_yml::Value =
-        serde_yml::from_str(frontmatter).map_err(|e| SkillRegistryError::ParseError {
+    let mut value: serde_norway::Value =
+        serde_norway::from_str(frontmatter).map_err(|e| SkillRegistryError::ParseError {
             name: error_label.to_string(),
             reason: format!("Failed to parse SKILL.md frontmatter for rewrite: {}", e),
         })?;
@@ -89,11 +89,11 @@ fn rewrite_frontmatter_name(
         })?;
 
     mapping.insert(
-        serde_yml::Value::String("name".to_string()),
-        serde_yml::Value::String(new_name.to_string()),
+        serde_norway::Value::String("name".to_string()),
+        serde_norway::Value::String(new_name.to_string()),
     );
 
-    let yaml = serde_yml::to_string(&value).map_err(|e| SkillRegistryError::ParseError {
+    let yaml = serde_norway::to_string(&value).map_err(|e| SkillRegistryError::ParseError {
         name: error_label.to_string(),
         reason: format!("Failed to rewrite normalized SKILL.md: {}", e),
     })?;

--- a/crates/ironclaw_skills/src/types.rs
+++ b/crates/ironclaw_skills/src/types.rs
@@ -494,7 +494,7 @@ activation:
   patterns: ["(?i)\\b(write|draft)\\b.*\\b(email|letter)\\b"]
   max_context_tokens: 2000
 "#;
-        let manifest: SkillManifest = serde_yml::from_str(yaml).expect("parse failed");
+        let manifest: SkillManifest = serde_norway::from_str(yaml).expect("parse failed");
         assert_eq!(manifest.name, "writing-assistant");
         assert_eq!(manifest.activation.keywords.len(), 3);
     }
@@ -509,7 +509,7 @@ requires:
   config: ["/etc/vale.ini"]
   skills: ["commitment-triage", "commitment-digest"]
 "#;
-        let manifest: SkillManifest = serde_yml::from_str(yaml).expect("parse failed");
+        let manifest: SkillManifest = serde_norway::from_str(yaml).expect("parse failed");
         assert_eq!(manifest.requires.bins, vec!["vale"]);
         assert_eq!(manifest.requires.env, vec!["VALE_CONFIG"]);
         assert_eq!(manifest.requires.config, vec!["/etc/vale.ini"]);
@@ -564,7 +564,7 @@ credentials:
       scopes: ["https://www.googleapis.com/auth/gmail.modify"]
       test_url: "https://www.googleapis.com/oauth2/v1/userinfo"
 "#;
-        let manifest: SkillManifest = serde_yml::from_str(yaml).expect("parse failed");
+        let manifest: SkillManifest = serde_norway::from_str(yaml).expect("parse failed");
         assert_eq!(manifest.credentials.len(), 1);
         let cred = &manifest.credentials[0];
         assert_eq!(cred.name, "google_oauth_token");
@@ -597,7 +597,7 @@ credentials:
       prefix: "Token"
     hosts: ["api.custom.com"]
 "#;
-        let manifest: SkillManifest = serde_yml::from_str(yaml).expect("parse failed");
+        let manifest: SkillManifest = serde_norway::from_str(yaml).expect("parse failed");
         let cred = &manifest.credentials[0];
         match &cred.location {
             SkillCredentialLocation::Header { name, prefix } => {
@@ -620,7 +620,7 @@ credentials:
       name: access_token
     hosts: ["api.legacy.com"]
 "#;
-        let manifest: SkillManifest = serde_yml::from_str(yaml).expect("parse failed");
+        let manifest: SkillManifest = serde_norway::from_str(yaml).expect("parse failed");
         let cred = &manifest.credentials[0];
         match &cred.location {
             SkillCredentialLocation::QueryParam { name } => {
@@ -642,7 +642,7 @@ credentials:
       username: admin
     hosts: ["api.example.com"]
 "#;
-        let manifest: SkillManifest = serde_yml::from_str(yaml).expect("parse failed");
+        let manifest: SkillManifest = serde_norway::from_str(yaml).expect("parse failed");
         let cred = &manifest.credentials[0];
         match &cred.location {
             SkillCredentialLocation::BasicAuth { username } => {
@@ -672,7 +672,7 @@ credentials:
         extra_params:
           grant_type: refresh_token
 "#;
-        let manifest: SkillManifest = serde_yml::from_str(yaml).expect("parse failed");
+        let manifest: SkillManifest = serde_norway::from_str(yaml).expect("parse failed");
         let oauth = manifest.credentials[0].oauth.as_ref().unwrap();
         match &oauth.refresh {
             ProviderRefreshStrategy::Custom {
@@ -702,7 +702,7 @@ credentials:
       refresh:
         strategy: reauthorize_only
 "#;
-        let manifest: SkillManifest = serde_yml::from_str(yaml).expect("parse failed");
+        let manifest: SkillManifest = serde_norway::from_str(yaml).expect("parse failed");
         let oauth = manifest.credentials[0].oauth.as_ref().unwrap();
         assert!(matches!(
             oauth.refresh,
@@ -716,7 +716,7 @@ credentials:
 name: simple-skill
 description: No credentials needed
 "#;
-        let manifest: SkillManifest = serde_yml::from_str(yaml).expect("parse failed");
+        let manifest: SkillManifest = serde_norway::from_str(yaml).expect("parse failed");
         assert!(manifest.credentials.is_empty());
     }
 
@@ -761,7 +761,7 @@ credentials:
         access_type: offline
         prompt: consent
 "#;
-        let manifest: SkillManifest = serde_yml::from_str(yaml).expect("parse failed");
+        let manifest: SkillManifest = serde_norway::from_str(yaml).expect("parse failed");
         let oauth = manifest.credentials[0].oauth.as_ref().unwrap();
         assert!(oauth.use_pkce);
         assert_eq!(oauth.extra_params.get("access_type").unwrap(), "offline");

--- a/deny.toml
+++ b/deny.toml
@@ -3,11 +3,9 @@ unmaintained = "workspace"
 yanked = "deny"
 ignore = [
     # Pre-existing advisories — tracked for upgrade in separate PRs
-    # serde_yml unsound/unmaintained — direct dep, upgrade tracked separately
-    "RUSTSEC-2025-0068",
     # tokio-tar PAX header parsing — sandbox containers only
     "RUSTSEC-2025-0111",
-    # rustls-webpki advisories — 0.102.8 remains pinned by a libsql 0.6.0 transitive dep
+    # rustls-webpki advisories — 0.102.8 remains pinned by a libsql 0.9.30 transitive dep
     # (via rustls 0.22 → hyper-rustls 0.25); keep ignored until that pin is gone.
     # RUSTSEC-2026-0104: panic on empty `onlySomeReasons` BIT STRING during CRL parsing.
     # We do not use CRLs, and the advisory explicitly notes apps that don't parse CRLs

--- a/src/bridge/store_adapter.rs
+++ b/src/bridge/store_adapter.rs
@@ -1302,7 +1302,7 @@ fn deserialize_knowledge_doc(content: &str) -> Option<MemoryDoc> {
     let body = after_first_line.get(body_start..)?.trim_start_matches('\n');
 
     // Parse YAML frontmatter
-    let yaml: serde_json::Value = serde_yml::from_str(yaml_str).ok()?;
+    let yaml: serde_json::Value = serde_norway::from_str(yaml_str).ok()?;
 
     let id_str = yaml.get("id")?.as_str()?;
     let id = uuid::Uuid::parse_str(id_str).ok()?;

--- a/tests/skill_credential_injection.rs
+++ b/tests/skill_credential_injection.rs
@@ -112,7 +112,7 @@ credentials:
       test_url: "https://www.googleapis.com/oauth2/v1/userinfo"
     setup_instructions: "Enable Gmail API in Google Cloud Console"
 "#;
-    let manifest: SkillManifest = serde_yml::from_str(yaml).expect("parse failed");
+    let manifest: SkillManifest = serde_norway::from_str(yaml).expect("parse failed");
 
     assert_eq!(manifest.name, "gmail");
     assert_eq!(manifest.credentials.len(), 1);
@@ -175,7 +175,7 @@ credentials:
         extra_params:
           grant_type: refresh_token
 "#;
-    let manifest: SkillManifest = serde_yml::from_str(yaml).expect("parse failed");
+    let manifest: SkillManifest = serde_norway::from_str(yaml).expect("parse failed");
     assert_eq!(manifest.credentials.len(), 2);
 
     // GitHub: reauthorize_only
@@ -233,7 +233,7 @@ credentials:
       name: access_token
     hosts: ["api.example.com"]
 "#;
-    let manifest: SkillManifest = serde_yml::from_str(yaml).expect("parse failed");
+    let manifest: SkillManifest = serde_norway::from_str(yaml).expect("parse failed");
     assert_eq!(manifest.credentials.len(), 4);
 
     assert!(matches!(
@@ -619,7 +619,7 @@ credentials:
         strategy: reauthorize_only
     setup_instructions: "Create a PAT at https://github.com/settings/tokens"
 "#;
-    let manifest: SkillManifest = serde_yml::from_str(yaml).expect("parse failed");
+    let manifest: SkillManifest = serde_norway::from_str(yaml).expect("parse failed");
 
     // Step 2: Validate
     for spec in &manifest.credentials {


### PR DESCRIPTION
Resolves Dependabot alerts **#4** (libyml, high) and **#5** (serde_yml, medium) — both RUSTSEC *unmaintained* advisories with no upstream patch. Dependabot PR #4498 tried bumping serde_yml 0.0.12 → 0.0.13 and failed 25 CI checks; that is a dead-end bump of an abandoned crate. This replaces it outright with the maintained fork **serde_norway** (drop-in serde_yaml API), which removes both `serde_yml` and its `libyml` dependency from the tree.

## Changes
- Root `Cargo.toml` + `crates/ironclaw_skills/Cargo.toml`: `serde_yml = "0.0.12"` → `serde_norway = "0.9"`.
- `.rs` call sites re-pointed `serde_yml::` → `serde_norway::` (skills parser/registry/types, store_adapter knowledge-doc frontmatter, credential-injection test). API is 1:1 — `from_str`/`to_string`/`Value`/`Value::String`.
- `deny.toml`: removed the now-dead `RUSTSEC-2025-0068` (serde_yml) ignore; refreshed the stale rustls-webpki comment (libsql 0.6.0 → 0.9.30).
- `Cargo.lock`: **surgical** — only serde_yml/libyml removed, serde_norway/unsafe-libyaml-norway added, two dependents re-pointed. No incidental transitive churn (`--locked` build passes).

## Verification
- `cargo build --all-features --locked` ✓
- `cargo clippy --all-features --all-targets --locked` — zero warnings
- `cargo test -p ironclaw_skills --locked` — 218 passed / 0 failed; `skill_credential_injection` 15/0; `bridge::store_adapter` 51/0
- `cargo tree -i serde_yml` / `cargo tree -i libyml` — both gone
- YAML round-trip output byte-compatible with existing fixtures (no snapshot changes needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)