### PR TITLE
test(reborn): error/deny-path coverage for http/shell/mcp tools (T0-ERRPATHS)

### DIFF
--- a/tests/reborn_integration_http_matcher.rs
+++ b/tests/reborn_integration_http_matcher.rs
@@ -168,15 +168,10 @@ async fn http_5xx_status_surfaces_as_completed_result_with_status() {
 /// Asserts the `denied` category surfaced (not merely that the run completed).
 #[tokio::test]
 async fn http_network_policy_denied_surfaces_recoverable_denied() {
-    use ironclaw_host_api::RuntimeHttpEgressError;
     let h = RebornIntegrationHarness::test_default()
-        .with_keyed_http_responses([ScriptedHttpResponse::egress_error(
+        .with_keyed_http_responses([ScriptedHttpResponse::network_error(
             ERR_URL,
-            RuntimeHttpEgressError::Network {
-                reason: "policy_denied".to_string(),
-                request_bytes: 0,
-                response_bytes: 0,
-            },
+            "policy_denied",
         )])
         .script([
             RebornScriptedReply::tool_call("builtin.http", json!({"url": ERR_URL})),
@@ -199,17 +194,11 @@ async fn http_network_policy_denied_surfaces_recoverable_denied() {
 /// `Failed{OutputTooLarge}` capability outcome; the run recovers to completion.
 #[tokio::test]
 async fn http_oversize_response_surfaces_recoverable_failed() {
-    use ironclaw_host_api::{
-        RUNTIME_HTTP_REASON_RESPONSE_BODY_LIMIT_EXCEEDED, RuntimeHttpEgressError,
-    };
+    use ironclaw_host_api::RUNTIME_HTTP_REASON_RESPONSE_BODY_LIMIT_EXCEEDED;
     let h = RebornIntegrationHarness::test_default()
-        .with_keyed_http_responses([ScriptedHttpResponse::egress_error(
+        .with_keyed_http_responses([ScriptedHttpResponse::response_error(
             ERR_URL,
-            RuntimeHttpEgressError::Response {
-                reason: RUNTIME_HTTP_REASON_RESPONSE_BODY_LIMIT_EXCEEDED.to_string(),
-                request_bytes: 0,
-                response_bytes: 0,
-            },
+            RUNTIME_HTTP_REASON_RESPONSE_BODY_LIMIT_EXCEEDED,
         )])
         .script([
             RebornScriptedReply::tool_call("builtin.http", json!({"url": ERR_URL})),
@@ -225,4 +214,52 @@ async fn http_oversize_response_surfaces_recoverable_failed() {
     h.assert_reply_contains("done")
         .await
         .expect("run recovered and finalized (not terminal driver_unavailable)");
+}
+
+/// Guards `assert_tool_error_summary_contains` against a vacuous pass, mirroring
+/// the sibling negative guards (`shell_assertions_fail_when_no_shell_call_ran`,
+/// `assert_mcp_tool_called_fails_when_no_mcp_call_ran`). Two ways it must return
+/// `Err`: (a) a completed turn that persisted NO tool-error reference at all, and
+/// (b) a real `Denied` turn probed with a needle that isn't in the summary.
+#[tokio::test]
+async fn tool_error_summary_assertion_fails_without_matching_tool_error() {
+    // (a) Plain text turn — no tool call, so no `ToolResultReference` is persisted.
+    let clean = RebornIntegrationHarness::test_default()
+        .script([RebornScriptedReply::text("no tool")])
+        .build()
+        .await
+        .expect("harness builds");
+    clean
+        .submit_turn("just talk")
+        .await
+        .expect("turn completes");
+    assert!(
+        clean
+            .assert_tool_error_summary_contains("capability denied with policy_denied")
+            .await
+            .is_err(),
+        "assertion must reject a turn that persisted no tool-error reference"
+    );
+
+    // (b) Real `Denied` turn, but probed with a needle that isn't in the summary.
+    let denied = RebornIntegrationHarness::test_default()
+        .with_keyed_http_responses([ScriptedHttpResponse::network_error(
+            ERR_URL,
+            "policy_denied",
+        )])
+        .script([
+            RebornScriptedReply::tool_call("builtin.http", json!({"url": ERR_URL})),
+            RebornScriptedReply::text("done"),
+        ])
+        .build()
+        .await
+        .expect("harness builds");
+    denied.submit_turn("fetch").await.expect("turn completes");
+    assert!(
+        denied
+            .assert_tool_error_summary_contains("capability failed with backend")
+            .await
+            .is_err(),
+        "assertion must reject a needle that is absent from the persisted summary"
+    );
 }

--- a/tests/reborn_integration_http_matcher.rs
+++ b/tests/reborn_integration_http_matcher.rs
@@ -16,6 +16,7 @@ mod reborn_support;
 #[allow(dead_code)]
 mod support;
 
+use reborn_support::assertions::ToolErrorClass;
 use reborn_support::builder::RebornIntegrationHarness;
 use reborn_support::http_matcher::ScriptedHttpResponse;
 use reborn_support::reply::RebornScriptedReply;
@@ -181,7 +182,7 @@ async fn http_network_policy_denied_surfaces_recoverable_denied() {
         .await
         .expect("harness builds");
     h.submit_turn("fetch").await.expect("turn completes");
-    h.assert_tool_error_summary_contains("capability denied with policy_denied")
+    h.assert_tool_error(ToolErrorClass::Denied, "policy_denied")
         .await
         .expect("policy-denied surfaced as a model-visible Denied tool error");
     h.assert_reply_contains("done")
@@ -208,7 +209,7 @@ async fn http_oversize_response_surfaces_recoverable_failed() {
         .await
         .expect("harness builds");
     h.submit_turn("fetch").await.expect("turn completes");
-    h.assert_tool_error_summary_contains("capability failed with output_too_large")
+    h.assert_tool_error(ToolErrorClass::Failed, "output_too_large")
         .await
         .expect("oversize response surfaced as a model-visible Failed tool error");
     h.assert_reply_contains("done")
@@ -216,13 +217,15 @@ async fn http_oversize_response_surfaces_recoverable_failed() {
         .expect("run recovered and finalized (not terminal driver_unavailable)");
 }
 
-/// Guards `assert_tool_error_summary_contains` against a vacuous pass, mirroring
-/// the sibling negative guards (`shell_assertions_fail_when_no_shell_call_ran`,
-/// `assert_mcp_tool_called_fails_when_no_mcp_call_ran`). Two ways it must return
-/// `Err`: (a) a completed turn that persisted NO tool-error reference at all, and
-/// (b) a real `Denied` turn probed with a needle that isn't in the summary.
+/// Guards `assert_tool_error` against a vacuous pass, mirroring the sibling
+/// negative guards (`shell_assertions_fail_when_no_shell_call_ran`,
+/// `assert_mcp_tool_called_fails_when_no_mcp_call_ran`). Three ways it must
+/// return `Err`: (a) a completed turn that persisted NO tool-error reference at
+/// all, (b) a real `Denied` turn probed with the wrong reason, and (c) that same
+/// `Denied` turn probed with the WRONG CLASS but the right reason token —
+/// proving the class discriminates structurally, not just the reason.
 #[tokio::test]
-async fn tool_error_summary_assertion_fails_without_matching_tool_error() {
+async fn tool_error_assertion_fails_without_matching_tool_error() {
     // (a) Plain text turn — no tool call, so no `ToolResultReference` is persisted.
     let clean = RebornIntegrationHarness::test_default()
         .script([RebornScriptedReply::text("no tool")])
@@ -235,13 +238,13 @@ async fn tool_error_summary_assertion_fails_without_matching_tool_error() {
         .expect("turn completes");
     assert!(
         clean
-            .assert_tool_error_summary_contains("capability denied with policy_denied")
+            .assert_tool_error(ToolErrorClass::Denied, "policy_denied")
             .await
             .is_err(),
         "assertion must reject a turn that persisted no tool-error reference"
     );
 
-    // (b) Real `Denied` turn, but probed with a needle that isn't in the summary.
+    // A real `Denied{policy_denied}` turn for cases (b) and (c).
     let denied = RebornIntegrationHarness::test_default()
         .with_keyed_http_responses([ScriptedHttpResponse::network_error(
             ERR_URL,
@@ -255,11 +258,21 @@ async fn tool_error_summary_assertion_fails_without_matching_tool_error() {
         .await
         .expect("harness builds");
     denied.submit_turn("fetch").await.expect("turn completes");
+    // (b) Right class, wrong reason.
     assert!(
         denied
-            .assert_tool_error_summary_contains("capability failed with backend")
+            .assert_tool_error(ToolErrorClass::Denied, "backend")
             .await
             .is_err(),
-        "assertion must reject a needle that is absent from the persisted summary"
+        "assertion must reject a reason that is absent from the persisted summary"
+    );
+    // (c) Wrong class, right reason token — the crux of the class-discrimination
+    // fix: `policy_denied` is present, but the outcome is `Denied`, not `Failed`.
+    assert!(
+        denied
+            .assert_tool_error(ToolErrorClass::Failed, "policy_denied")
+            .await
+            .is_err(),
+        "assertion must discriminate the outcome class, not just the reason token"
     );
 }

--- a/tests/reborn_integration_http_matcher.rs
+++ b/tests/reborn_integration_http_matcher.rs
@@ -133,3 +133,96 @@ async fn capability_keyed_response_matches_and_mismatch_falls_through_to_second_
         "wrong-capability entry must not match a builtin.http call"
     );
 }
+
+const ERR_URL: &str = "https://api.example.test/v1/err";
+
+/// Error path — HTTP 5xx status. A scripted `500` is NOT an egress error: the
+/// `builtin.http` tool surfaces it as a *successful* (Completed) tool result
+/// carrying `"status":500`, so the run completes and the model can react. Proves
+/// a server-error status is model-visible, not a terminal driver failure.
+#[tokio::test]
+async fn http_5xx_status_surfaces_as_completed_result_with_status() {
+    let h = RebornIntegrationHarness::test_default()
+        .with_keyed_http_responses([
+            ScriptedHttpResponse::for_url(ERR_URL, br#"{"error":"boom"}"#).with_status(500),
+        ])
+        .script([
+            RebornScriptedReply::tool_call("builtin.http", json!({"url": ERR_URL})),
+            RebornScriptedReply::text("done"),
+        ])
+        .build()
+        .await
+        .expect("harness builds");
+    h.submit_turn("fetch").await.expect("turn completes");
+    h.assert_tool_result_contains("\"status\":500")
+        .await
+        .expect("5xx status surfaced in the model-visible tool result");
+    h.assert_reply_contains("done")
+        .await
+        .expect("run recovered and finalized");
+}
+
+/// Error path — network-policy-denied egress. The scripted egress `Err` maps
+/// (`policy_denied` reason) to a model-visible `Denied` capability outcome, so
+/// the run continues to completion rather than dying with `driver_unavailable`.
+/// Asserts the `denied` category surfaced (not merely that the run completed).
+#[tokio::test]
+async fn http_network_policy_denied_surfaces_recoverable_denied() {
+    use ironclaw_host_api::RuntimeHttpEgressError;
+    let h = RebornIntegrationHarness::test_default()
+        .with_keyed_http_responses([ScriptedHttpResponse::egress_error(
+            ERR_URL,
+            RuntimeHttpEgressError::Network {
+                reason: "policy_denied".to_string(),
+                request_bytes: 0,
+                response_bytes: 0,
+            },
+        )])
+        .script([
+            RebornScriptedReply::tool_call("builtin.http", json!({"url": ERR_URL})),
+            RebornScriptedReply::text("done"),
+        ])
+        .build()
+        .await
+        .expect("harness builds");
+    h.submit_turn("fetch").await.expect("turn completes");
+    h.assert_tool_error_summary_contains("policy_denied")
+        .await
+        .expect("policy-denied surfaced as a model-visible Denied tool error");
+    h.assert_reply_contains("done")
+        .await
+        .expect("run recovered and finalized (not terminal driver_unavailable)");
+}
+
+/// Error path — oversize response body. The scripted egress
+/// `response_body_limit_exceeded` error maps to a model-visible
+/// `Failed{OutputTooLarge}` capability outcome; the run recovers to completion.
+#[tokio::test]
+async fn http_oversize_response_surfaces_recoverable_failed() {
+    use ironclaw_host_api::{
+        RUNTIME_HTTP_REASON_RESPONSE_BODY_LIMIT_EXCEEDED, RuntimeHttpEgressError,
+    };
+    let h = RebornIntegrationHarness::test_default()
+        .with_keyed_http_responses([ScriptedHttpResponse::egress_error(
+            ERR_URL,
+            RuntimeHttpEgressError::Response {
+                reason: RUNTIME_HTTP_REASON_RESPONSE_BODY_LIMIT_EXCEEDED.to_string(),
+                request_bytes: 0,
+                response_bytes: 0,
+            },
+        )])
+        .script([
+            RebornScriptedReply::tool_call("builtin.http", json!({"url": ERR_URL})),
+            RebornScriptedReply::text("done"),
+        ])
+        .build()
+        .await
+        .expect("harness builds");
+    h.submit_turn("fetch").await.expect("turn completes");
+    h.assert_tool_error_summary_contains("output_too_large")
+        .await
+        .expect("oversize response surfaced as a model-visible Failed tool error");
+    h.assert_reply_contains("done")
+        .await
+        .expect("run recovered and finalized (not terminal driver_unavailable)");
+}

--- a/tests/reborn_integration_http_matcher.rs
+++ b/tests/reborn_integration_http_matcher.rs
@@ -186,7 +186,7 @@ async fn http_network_policy_denied_surfaces_recoverable_denied() {
         .await
         .expect("harness builds");
     h.submit_turn("fetch").await.expect("turn completes");
-    h.assert_tool_error_summary_contains("policy_denied")
+    h.assert_tool_error_summary_contains("capability denied with policy_denied")
         .await
         .expect("policy-denied surfaced as a model-visible Denied tool error");
     h.assert_reply_contains("done")
@@ -219,7 +219,7 @@ async fn http_oversize_response_surfaces_recoverable_failed() {
         .await
         .expect("harness builds");
     h.submit_turn("fetch").await.expect("turn completes");
-    h.assert_tool_error_summary_contains("output_too_large")
+    h.assert_tool_error_summary_contains("capability failed with output_too_large")
         .await
         .expect("oversize response surfaced as a model-visible Failed tool error");
     h.assert_reply_contains("done")

--- a/tests/reborn_integration_mcp.rs
+++ b/tests/reborn_integration_mcp.rs
@@ -12,6 +12,7 @@ mod reborn_support;
 #[allow(dead_code)]
 mod support;
 
+use reborn_support::assertions::ToolErrorClass;
 use reborn_support::builder::RebornIntegrationHarness;
 use reborn_support::reply::RebornScriptedReply;
 use support::mock_mcp_server::{MockMcpServer, MockToolResponse, start_mock_mcp_server};
@@ -129,7 +130,7 @@ async fn mcp_tool_call_error_surfaces_recoverable_failed() {
     h.assert_mcp_tool_called("search")
         .await
         .expect("MCP tool was invoked before the error");
-    h.assert_tool_error_summary_contains("capability failed with backend")
+    h.assert_tool_error(ToolErrorClass::Failed, "backend")
         .await
         .expect("JSON-RPC error surfaced as a model-visible Failed tool error");
     h.assert_reply_contains("done")
@@ -165,7 +166,7 @@ async fn mcp_server_5xx_surfaces_recoverable_failed() {
     h.assert_mcp_tool_called("search")
         .await
         .expect("MCP tool call reached the server before the 5xx");
-    h.assert_tool_error_summary_contains("capability failed with backend")
+    h.assert_tool_error(ToolErrorClass::Failed, "backend")
         .await
         .expect("server 5xx surfaced as a model-visible Failed tool error");
     h.assert_reply_contains("done")

--- a/tests/reborn_integration_mcp.rs
+++ b/tests/reborn_integration_mcp.rs
@@ -14,7 +14,38 @@ mod support;
 
 use reborn_support::builder::RebornIntegrationHarness;
 use reborn_support::reply::RebornScriptedReply;
-use support::mock_mcp_server::{MockToolResponse, start_mock_mcp_server};
+use support::mock_mcp_server::{MockMcpServer, MockToolResponse, start_mock_mcp_server};
+
+/// Asserts the mock MCP server actually received a `tools/call` request naming
+/// `expected_tool` with a `query` argument equal to `expected_query`. Mirrors
+/// the inline server-side check in `mcp_tool_call_reaches_mock_server`, so
+/// error-path tests also prove the loopback HTTP boundary was reached, not
+/// just that the harness's own capability-invocation recorder fired.
+fn assert_recorded_tools_call(server: &MockMcpServer, expected_tool: &str, expected_query: &str) {
+    let recorded = server.recorded_requests();
+    let tools_call = recorded
+        .iter()
+        .find(|r| r.method == "tools/call")
+        .unwrap_or_else(|| panic!("no tools/call recorded; saw: {:?}", recorded));
+
+    assert_eq!(
+        tools_call
+            .params
+            .as_ref()
+            .and_then(|p| p.get("name"))
+            .and_then(|n| n.as_str()),
+        Some(expected_tool)
+    );
+    assert_eq!(
+        tools_call
+            .params
+            .as_ref()
+            .and_then(|p| p.get("arguments"))
+            .and_then(|a| a.get("query"))
+            .and_then(|q| q.as_str()),
+        Some(expected_query)
+    );
+}
 
 /// Core slice-6 scenario: a scripted MCP tool call round-trips through the real
 /// MCP runtime to the loopback mock server, and the invocation is recorded.
@@ -130,10 +161,11 @@ async fn mcp_tool_call_error_surfaces_recoverable_failed() {
         .expect("harness builds");
 
     h.submit_turn("search").await.expect("turn completes");
+    assert_recorded_tools_call(&server, "search", "x");
     h.assert_mcp_tool_called("search")
         .await
         .expect("MCP tool was invoked before the error");
-    h.assert_tool_error_summary_contains("backend")
+    h.assert_tool_error_summary_contains("capability failed with backend")
         .await
         .expect("JSON-RPC error surfaced as a model-visible Failed tool error");
     h.assert_reply_contains("done")
@@ -165,10 +197,11 @@ async fn mcp_server_5xx_surfaces_recoverable_failed() {
         .expect("harness builds");
 
     h.submit_turn("search").await.expect("turn completes");
+    assert_recorded_tools_call(&server, "search", "x");
     h.assert_mcp_tool_called("search")
         .await
         .expect("MCP tool call reached the server before the 5xx");
-    h.assert_tool_error_summary_contains("backend")
+    h.assert_tool_error_summary_contains("capability failed with backend")
         .await
         .expect("server 5xx surfaced as a model-visible Failed tool error");
     h.assert_reply_contains("done")

--- a/tests/reborn_integration_mcp.rs
+++ b/tests/reborn_integration_mcp.rs
@@ -104,3 +104,82 @@ async fn assert_mcp_tool_called_fails_when_no_mcp_call_ran() {
     h.submit_turn("just talk").await.expect("turn completes");
     assert!(h.assert_mcp_tool_called("search").await.is_err());
 }
+
+/// Error path — MCP `tools/call` returns a JSON-RPC `error` object. The client
+/// surfaces this as `Failed{Backend}` (a recoverable, model-visible tool
+/// error), so the run continues to completion rather than dying with
+/// `driver_unavailable`. Distinct wire path from the 5xx case below: this trips
+/// the client's JSON-RPC error-field guard, not its HTTP status gate.
+#[tokio::test]
+async fn mcp_tool_call_error_surfaces_recoverable_failed() {
+    let server = start_mock_mcp_server(vec![MockToolResponse {
+        name: "search".to_string(),
+        content: serde_json::json!({"results": []}),
+    }])
+    .await;
+    server.set_tool_call_error(-32602, "unknown tool");
+
+    let h = RebornIntegrationHarness::test_default()
+        .script([
+            RebornScriptedReply::tool_call("mock-mcp.search", serde_json::json!({"query": "x"})),
+            RebornScriptedReply::text("done"),
+        ])
+        .with_mock_mcp(server.mcp_url())
+        .build()
+        .await
+        .expect("harness builds");
+
+    h.submit_turn("search").await.expect("turn completes");
+    h.assert_mcp_tool_called("search")
+        .await
+        .expect("MCP tool was invoked before the error");
+    h.assert_tool_error_summary_contains("backend")
+        .await
+        .expect("JSON-RPC error surfaced as a model-visible Failed tool error");
+    h.assert_reply_contains("done")
+        .await
+        .expect("run recovered and finalized (not terminal driver_unavailable)");
+}
+
+/// Error path — MCP server returns HTTP 5xx on the tool call. The client
+/// surfaces this as `Failed{Backend}` (recoverable, model-visible), and the run
+/// completes. Distinct wire path from the JSON-RPC-error case above: this trips
+/// the client's HTTP status gate, not its JSON-RPC error-field guard.
+#[tokio::test]
+async fn mcp_server_5xx_surfaces_recoverable_failed() {
+    let server = start_mock_mcp_server(vec![MockToolResponse {
+        name: "search".to_string(),
+        content: serde_json::json!({"results": []}),
+    }])
+    .await;
+    server.force_http_status(500);
+
+    let h = RebornIntegrationHarness::test_default()
+        .script([
+            RebornScriptedReply::tool_call("mock-mcp.search", serde_json::json!({"query": "x"})),
+            RebornScriptedReply::text("done"),
+        ])
+        .with_mock_mcp(server.mcp_url())
+        .build()
+        .await
+        .expect("harness builds");
+
+    h.submit_turn("search").await.expect("turn completes");
+    h.assert_mcp_tool_called("search")
+        .await
+        .expect("MCP tool call reached the server before the 5xx");
+    h.assert_tool_error_summary_contains("backend")
+        .await
+        .expect("server 5xx surfaced as a model-visible Failed tool error");
+    h.assert_reply_contains("done")
+        .await
+        .expect("run recovered and finalized (not terminal driver_unavailable)");
+}
+
+// MCP "auth mismatch" (HTTP 401/403) is deliberately NOT covered here: unlike
+// the two cases above, a 401/403 maps to `McpClientError::AuthRequired` — an
+// auth *gate* (park-and-resume), not a model-visible `Failed`/`Denied` tool
+// error. Exercising a credentialed-backend 401 through to a raised auth gate
+// requires a capability-backend credential stub that this tier does not yet
+// have; it is the same "live-401 re-auth arm" already deferred in
+// `reborn_integration_auth_failure.rs`. Track with that follow-up.

--- a/tests/reborn_integration_mcp.rs
+++ b/tests/reborn_integration_mcp.rs
@@ -79,47 +79,11 @@ async fn mcp_tool_call_reaches_mock_server() {
     h.assert_mcp_tool_called("search")
         .await
         .expect("MCP tool was invoked");
-    // Confirm the mock server actually received an HTTP request — this proves
-    // the MCP runtime made a real HTTP call to the loopback server, not just
-    // that the capability recorder fired before the egress (the M4 gap).
-    let recorded = server.recorded_requests();
-    assert!(
-        !recorded.is_empty(),
-        "mock MCP server received no HTTP request; MCP egress did not reach the server"
-    );
-    let tools_call = recorded
-        .iter()
-        .find(|r| r.method == "tools/call")
-        .unwrap_or_else(|| {
-            panic!(
-                "mock MCP server received requests but none was tools/call; saw: {:?}",
-                recorded
-                    .iter()
-                    .map(|r| r.method.as_str())
-                    .collect::<Vec<_>>()
-            )
-        });
-    assert_eq!(
-        tools_call
-            .params
-            .as_ref()
-            .and_then(|p| p.get("name"))
-            .and_then(|n| n.as_str()),
-        Some("search"),
-        "tools/call params did not name the expected tool 'search'; params: {:?}",
-        tools_call.params
-    );
-    assert_eq!(
-        tools_call
-            .params
-            .as_ref()
-            .and_then(|p| p.get("arguments"))
-            .and_then(|a| a.get("query"))
-            .and_then(|q| q.as_str()),
-        Some("needle-xyz-42"),
-        "tools/call did not carry the scripted arguments intact; params: {:?}",
-        tools_call.params
-    );
+    // Confirm the mock server actually received the `tools/call` over HTTP with
+    // the scripted arguments intact — proves the MCP runtime made a real HTTP
+    // call to the loopback server, not just that the capability recorder fired
+    // before the egress (the M4 gap).
+    assert_recorded_tools_call(&server, "search", "needle-xyz-42");
 }
 
 /// Guards `assert_mcp_tool_called` against vacuous pass: when no MCP tool ran

--- a/tests/reborn_integration_process_port.rs
+++ b/tests/reborn_integration_process_port.rs
@@ -11,6 +11,7 @@ mod reborn_support;
 #[allow(dead_code)]
 mod support;
 
+use reborn_support::assertions::ToolErrorClass;
 use reborn_support::builder::RebornIntegrationHarness;
 use reborn_support::reply::RebornScriptedReply;
 use serde_json::json;
@@ -100,7 +101,7 @@ async fn shell_timeout_surfaces_recoverable_failed() {
         .await
         .expect("harness builds");
     h.submit_turn("run shell").await.expect("turn completes");
-    h.assert_tool_error_summary_contains("capability failed with resource")
+    h.assert_tool_error(ToolErrorClass::Failed, "resource")
         .await
         .expect("timeout surfaced as a model-visible Failed{Resource} tool error");
     h.assert_reply_contains("done")

--- a/tests/reborn_integration_process_port.rs
+++ b/tests/reborn_integration_process_port.rs
@@ -100,7 +100,7 @@ async fn shell_timeout_surfaces_recoverable_failed() {
         .await
         .expect("harness builds");
     h.submit_turn("run shell").await.expect("turn completes");
-    h.assert_tool_error_summary_contains("resource")
+    h.assert_tool_error_summary_contains("capability failed with resource")
         .await
         .expect("timeout surfaced as a model-visible Failed{Resource} tool error");
     h.assert_reply_contains("done")

--- a/tests/reborn_integration_process_port.rs
+++ b/tests/reborn_integration_process_port.rs
@@ -56,6 +56,58 @@ async fn shell_assertions_fail_when_no_shell_call_ran() {
     assert!(h.assert_shell_ran_through_inert_port().await.is_err());
 }
 
+/// Error path — non-zero exit. A scripted `exit_code = 1` is NOT a tool error:
+/// `builtin.shell` surfaces it as a *Completed* result carrying `"exit_code":1`
+/// / `"success":false`, so the run completes and the model can react.
+#[tokio::test]
+async fn shell_non_zero_exit_surfaces_as_completed_result() {
+    let h = RebornIntegrationHarness::test_default()
+        .with_shell_exit_code(1)
+        .script([
+            RebornScriptedReply::tool_call("builtin.shell", json!({"command": "echo boom"})),
+            RebornScriptedReply::text("done"),
+        ])
+        .build()
+        .await
+        .expect("harness builds");
+    h.submit_turn("run shell").await.expect("turn completes");
+    h.assert_tool_result_contains("\"exit_code\":1")
+        .await
+        .expect("non-zero exit surfaced in the model-visible tool result");
+    h.assert_tool_result_contains("\"success\":false")
+        .await
+        .expect("success flag reflects the non-zero exit");
+    h.assert_shell_command_recorded("echo boom")
+        .await
+        .expect("command dispatched through the inert port");
+    h.assert_reply_contains("done")
+        .await
+        .expect("run recovered and finalized");
+}
+
+/// Error path — command timeout. A scripted `RuntimeProcessError::Timeout` maps
+/// to a recoverable, model-visible `Failed{Resource}` capability error, so the
+/// run continues to completion rather than dying with `driver_unavailable`.
+#[tokio::test]
+async fn shell_timeout_surfaces_recoverable_failed() {
+    let h = RebornIntegrationHarness::test_default()
+        .with_shell_timeout()
+        .script([
+            RebornScriptedReply::tool_call("builtin.shell", json!({"command": "sleep 999"})),
+            RebornScriptedReply::text("done"),
+        ])
+        .build()
+        .await
+        .expect("harness builds");
+    h.submit_turn("run shell").await.expect("turn completes");
+    h.assert_tool_error_summary_contains("resource")
+        .await
+        .expect("timeout surfaced as a model-visible Failed{Resource} tool error");
+    h.assert_reply_contains("done")
+        .await
+        .expect("run recovered and finalized (not terminal driver_unavailable)");
+}
+
 // `.with_live_shell()` test omitted: a live `echo` is hermetic but offers no
 // assertion the recording-port test above doesn't already cover — the scripted
 // model reply is fixed regardless of actual shell output, so there is nothing

--- a/tests/support/mock_mcp_server.rs
+++ b/tests/support/mock_mcp_server.rs
@@ -80,6 +80,21 @@ impl MockMcpServer {
         self.state.recorded_requests.lock().unwrap().clone()
     }
 
+    /// Force every subsequent otherwise-successful `/mcp` response to carry this
+    /// HTTP status (sticky), keeping the normal JSON-RPC body. Use for the MCP
+    /// server-5xx error-path case.
+    pub fn force_http_status(&self, status: u16) {
+        *self.state.force_status.lock().unwrap() = Some(status);
+    }
+
+    /// Force every subsequent `tools/call` to return a top-level JSON-RPC error
+    /// object with this code/message (sticky). The response still carries a
+    /// valid `result`, so the client's error-detection guard is the only thing
+    /// keeping it from parsing as Completed. Use for the MCP tool-call-error case.
+    pub fn set_tool_call_error(&self, code: i64, message: impl Into<String>) {
+        *self.state.force_tool_call_error.lock().unwrap() = Some((code, message.into()));
+    }
+
     pub fn clear_recorded_requests(&self) {
         self.state.recorded_requests.lock().unwrap().clear();
     }
@@ -123,6 +138,17 @@ struct MockState {
     /// `Mcp-Session-Id` per handshake so multi-user isolation tests can
     /// observe that each activation binds its own session.
     session_counter: std::sync::Mutex<u64>,
+    /// Sticky HTTP status override for error-path tests: when set, every
+    /// otherwise-successful `/mcp` response is returned with this status
+    /// (keeping the normal JSON-RPC success body, so a client that wrongly
+    /// accepts a non-2xx status would parse it as Completed). Drives the
+    /// server-5xx MCP error case.
+    force_status: std::sync::Mutex<Option<u16>>,
+    /// Sticky `tools/call` JSON-RPC error override: when set, `tools/call`
+    /// returns a top-level `error` object (alongside a valid `result`, so the
+    /// client's error-detection guard is the only thing preventing a spurious
+    /// Completed). Drives the tool-call-error MCP case.
+    force_tool_call_error: std::sync::Mutex<Option<(i64, String)>>,
 }
 
 #[derive(Clone, Serialize)]
@@ -178,6 +204,8 @@ pub async fn start_mock_mcp_server(tool_responses: Vec<MockToolResponse>) -> Moc
         tool_response_idx: std::sync::Mutex::new(HashMap::new()),
         recorded_requests: std::sync::Mutex::new(Vec::new()),
         session_counter: std::sync::Mutex::new(0),
+        force_status: std::sync::Mutex::new(None),
+        force_tool_call_error: std::sync::Mutex::new(None),
     });
 
     let app = Router::new()
@@ -256,6 +284,8 @@ pub async fn start_mock_mcp_server_with_specs(specs: Vec<MockToolSpec>) -> MockM
         tool_response_idx: std::sync::Mutex::new(HashMap::new()),
         recorded_requests: std::sync::Mutex::new(Vec::new()),
         session_counter: std::sync::Mutex::new(0),
+        force_status: std::sync::Mutex::new(None),
+        force_tool_call_error: std::sync::Mutex::new(None),
     });
 
     let app = Router::new()
@@ -487,18 +517,33 @@ async fn handle_mcp(
                 result
             };
 
-            serde_json::json!({
-                "jsonrpc": "2.0",
-                "id": req.id,
-                "result": {
-                    "content": [
-                        {
-                            "type": "text",
-                            "text": serde_json::to_string(&content).unwrap_or_default()
-                        }
-                    ]
-                }
-            })
+            let success_result = serde_json::json!({
+                "content": [
+                    {
+                        "type": "text",
+                        "text": serde_json::to_string(&content).unwrap_or_default()
+                    }
+                ]
+            });
+            // Sticky tool-call error override: emit a top-level JSON-RPC `error`
+            // object AND a valid `result`. A conformant client returns on the
+            // `error` field; the `result` is present so that removing that guard
+            // (the mutation) would flip the outcome to Completed — making the
+            // error-path test able to detect the mutant.
+            if let Some((code, message)) = state.force_tool_call_error.lock().unwrap().clone() {
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": req.id,
+                    "error": {"code": code, "message": message},
+                    "result": success_result
+                })
+            } else {
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": req.id,
+                    "result": success_result
+                })
+            }
         }
         _ => serde_json::json!({
             "jsonrpc": "2.0",
@@ -507,14 +552,31 @@ async fn handle_mcp(
         }),
     };
 
+    // Sticky HTTP status override (server-5xx case): keep the normal JSON-RPC
+    // body but return it with the forced status. Scoped to `tools/call` so the
+    // `initialize`/`tools/list` handshake still succeeds and the error is
+    // observed at the tool invocation, not activation. A conformant client
+    // rejects a non-2xx status before parsing; a client that wrongly accepts it
+    // would parse the valid body as Completed — so the mutation is detectable.
+    let status = if req.method == "tools/call" {
+        state
+            .force_status
+            .lock()
+            .unwrap()
+            .and_then(|code| StatusCode::from_u16(code).ok())
+            .unwrap_or(StatusCode::OK)
+    } else {
+        StatusCode::OK
+    };
+
     if let Some(session_id) = response_session_id {
         (
-            StatusCode::OK,
+            status,
             [("mcp-session-id", session_id.as_str())],
             Json(response),
         )
             .into_response()
     } else {
-        Json(response).into_response()
+        (status, Json(response)).into_response()
     }
 }

--- a/tests/support/mock_mcp_server.rs
+++ b/tests/support/mock_mcp_server.rs
@@ -80,10 +80,13 @@ impl MockMcpServer {
         self.state.recorded_requests.lock().unwrap().clone()
     }
 
-    /// Force every subsequent otherwise-successful `/mcp` response to carry this
-    /// HTTP status (sticky), keeping the normal JSON-RPC body. Use for the MCP
+    /// Force every subsequent otherwise-successful `tools/call` response to
+    /// carry this HTTP status (sticky), keeping the normal JSON-RPC body. The
+    /// `initialize`/`tools/list` handshake is unaffected. Use for the MCP
     /// server-5xx error-path case.
     pub fn force_http_status(&self, status: u16) {
+        let status = StatusCode::from_u16(status)
+            .unwrap_or_else(|_| panic!("invalid HTTP status code for force_http_status: {status}"));
         *self.state.force_status.lock().unwrap() = Some(status);
     }
 
@@ -139,11 +142,12 @@ struct MockState {
     /// observe that each activation binds its own session.
     session_counter: std::sync::Mutex<u64>,
     /// Sticky HTTP status override for error-path tests: when set, every
-    /// otherwise-successful `/mcp` response is returned with this status
+    /// otherwise-successful `tools/call` response is returned with this status
     /// (keeping the normal JSON-RPC success body, so a client that wrongly
     /// accepts a non-2xx status would parse it as Completed). Drives the
-    /// server-5xx MCP error case.
-    force_status: std::sync::Mutex<Option<u16>>,
+    /// server-5xx MCP error case. Scoped to `tools/call` only — the
+    /// `initialize`/`tools/list` handshake is unaffected.
+    force_status: std::sync::Mutex<Option<StatusCode>>,
     /// Sticky `tools/call` JSON-RPC error override: when set, `tools/call`
     /// returns a top-level `error` object (alongside a valid `result`, so the
     /// client's error-detection guard is the only thing preventing a spurious
@@ -521,7 +525,8 @@ async fn handle_mcp(
                 "content": [
                     {
                         "type": "text",
-                        "text": serde_json::to_string(&content).unwrap_or_default()
+                        "text": serde_json::to_string(&content)
+                            .expect("serializing serde_json::Value for mock MCP content should not fail")
                     }
                 ]
             });
@@ -559,12 +564,7 @@ async fn handle_mcp(
     // rejects a non-2xx status before parsing; a client that wrongly accepts it
     // would parse the valid body as Completed — so the mutation is detectable.
     let status = if req.method == "tools/call" {
-        state
-            .force_status
-            .lock()
-            .unwrap()
-            .and_then(|code| StatusCode::from_u16(code).ok())
-            .unwrap_or(StatusCode::OK)
+        state.force_status.lock().unwrap().unwrap_or(StatusCode::OK)
     } else {
         StatusCode::OK
     };

--- a/tests/support/reborn/CLAUDE.md
+++ b/tests/support/reborn/CLAUDE.md
@@ -100,7 +100,8 @@ conversation; `submit_turn`/`assert_reply_contains` take just the text.
   `.with_keyed_http_responses([..])`).
 - `assertions.rs` — the richer egress + tool-result assertions
   (`assert_egress_count` / `assert_egress_url_order` / `assert_egress_method_order`
-  / `assert_egress_body_contains` / `assert_tool_result_contains`).
+  / `assert_egress_body_contains` / `assert_tool_result_contains` /
+  `assert_tool_error_summary_contains`).
 - Tests live as flat `tests/reborn_*.rs` (Cargo requires top-level test files).
 
 Module paths: each `tests/reborn_*.rs` declares both `#[path = "support/reborn/mod.rs"] mod reborn_support;` and `mod support;`, then `use reborn_support::builder::RebornIntegrationHarness;` / `use reborn_support::reply::RebornScriptedReply;`. Inside the support tree, siblings reference each other via `super::` and `trace_llm` via `crate::support::trace_llm` (there is no `crate::support::reborn` path). Copy the includes from `tests/reborn_integration_greeting.rs`.
@@ -148,7 +149,8 @@ Richer assertions in `assertions.rs` (all check the `[baseline..]` delta per thr
 - `assert_egress_url_order(&[substrings])` — URLs in call order, each containing the matching substring; also checks count.
 - `assert_egress_method_order(&[methods])` — HTTP methods in call order (case-insensitive).
 - `assert_egress_body_contains(url_substr, body_substr)` — body of the captured egress request whose URL contains the substring.
-- `assert_tool_result_contains(needle)` — a recorded capability result's output contains the text (proves the scripted body surfaced back to the model).
+- `assert_tool_result_contains(needle)` — a recorded capability result's output contains the text (proves the scripted body surfaced back to the model on the *Completed* path; reads the in-process recorder).
+- `assert_tool_error_summary_contains(needle)` — a persisted `ToolResultReference` transcript message's `safe_summary` contains the text. Distinct from `assert_tool_result_contains`: this reads the *Failed*/*Denied* capability-error path (persisted via `append_tool_result_reference`), not the in-process recorder, so it's the assertion for `egress_error`-scripted responses and other capability failures/denials. `needle` must include the `"capability failed with "` / `"capability denied with "` prefix to discriminate outcome class, not just a bare failure-kind token (see doc comment). Scans full thread history (not baseline-sliced) — safe only for single-turn harnesses today; a multi-turn/group reuse must add baseline scoping first.
 
 ### Keyed HTTP responses
 
@@ -158,9 +160,11 @@ needs a different scripted body, install keyed responses via
 
 `ScriptedHttpResponse` — first-match-wins in scripted order:
 
-- `ScriptedHttpResponse::for_url(url_substr, body)` — matches any request whose URL contains the substring.
+- `ScriptedHttpResponse::for_url(url_substr, body)` — matches any request whose URL contains the substring; defaults to a `200` body.
 - `.with_method(method)` — narrow to a specific HTTP method (lowercase, e.g. `"post"`).
 - `.with_capability(capability_id)` — narrow to a specific capability id (e.g. `"builtin.http"`).
+- `.with_status(status)` — override the status of a `for_url` body response (e.g. `404`, `500`). Still a successful egress call — `builtin.http` surfaces it as a Completed tool result carrying that status. Panics if called on an `egress_error` response (mutually exclusive outcomes).
+- `ScriptedHttpResponse::egress_error(url_substr, error)` — scripts a runtime egress failure (`Err(RuntimeHttpEgressError)` from `execute`) instead of a body, driving `builtin.http`'s error-mapping paths (e.g. `policy_denied` → `Denied`, `response_body_limit_exceeded` → `Failed{OutputTooLarge}`).
 
 Requests that match no scripted response fall back to the recording egress default body. The keyed matcher is the canonical HTTP-scripting API; new per-URL response needs fold into `ScriptedHttpResponse` rather than adding a parallel matcher.
 

--- a/tests/support/reborn/CLAUDE.md
+++ b/tests/support/reborn/CLAUDE.md
@@ -101,7 +101,7 @@ conversation; `submit_turn`/`assert_reply_contains` take just the text.
 - `assertions.rs` — the richer egress + tool-result assertions
   (`assert_egress_count` / `assert_egress_url_order` / `assert_egress_method_order`
   / `assert_egress_body_contains` / `assert_tool_result_contains` /
-  `assert_tool_error_summary_contains`).
+  `assert_tool_error`).
 - Tests live as flat `tests/reborn_*.rs` (Cargo requires top-level test files).
 
 Module paths: each `tests/reborn_*.rs` declares both `#[path = "support/reborn/mod.rs"] mod reborn_support;` and `mod support;`, then `use reborn_support::builder::RebornIntegrationHarness;` / `use reborn_support::reply::RebornScriptedReply;`. Inside the support tree, siblings reference each other via `super::` and `trace_llm` via `crate::support::trace_llm` (there is no `crate::support::reborn` path). Copy the includes from `tests/reborn_integration_greeting.rs`.
@@ -150,7 +150,7 @@ Richer assertions in `assertions.rs` (all check the `[baseline..]` delta per thr
 - `assert_egress_method_order(&[methods])` — HTTP methods in call order (case-insensitive).
 - `assert_egress_body_contains(url_substr, body_substr)` — body of the captured egress request whose URL contains the substring.
 - `assert_tool_result_contains(needle)` — a recorded capability result's output contains the text (proves the scripted body surfaced back to the model on the *Completed* path; reads the in-process recorder).
-- `assert_tool_error_summary_contains(needle)` — a persisted `ToolResultReference` transcript message's `safe_summary` contains the text. Distinct from `assert_tool_result_contains`: this reads the *Failed*/*Denied* capability-error path (persisted via `append_tool_result_reference`), not the in-process recorder, so it's the assertion for `egress_error`-scripted responses and other capability failures/denials. `needle` must include the `"capability failed with "` / `"capability denied with "` prefix to discriminate outcome class, not just a bare failure-kind token (see doc comment). Scans full thread history (not baseline-sliced) — safe only for single-turn harnesses today; a multi-turn/group reuse must add baseline scoping first.
+- `assert_tool_error(class, reason)` — a persisted `ToolResultReference` envelope's parsed `safe_summary` field is of outcome `class` (`ToolErrorClass::{Failed, Denied}`) and carries `reason`. Distinct from `assert_tool_result_contains`: this reads the *Failed*/*Denied* capability-error path (persisted via `append_tool_result_reference`), not the in-process recorder, so it's the assertion for `egress_error`-scripted responses and other capability failures/denials. `class` is a typed arg (not a needle prefix) so it discriminates Failed-vs-Denied structurally — a `Failed{PolicyDenied}` and a `Denied{policy_denied}` render the same `reason` token but different classes. Parses the `safe_summary` field (not a raw-JSON substring). Scans full thread history (not baseline-sliced) — safe only for single-turn harnesses today; a multi-turn/group reuse must add baseline scoping first.
 
 ### Keyed HTTP responses
 

--- a/tests/support/reborn/CLAUDE.md
+++ b/tests/support/reborn/CLAUDE.md
@@ -164,7 +164,9 @@ needs a different scripted body, install keyed responses via
 - `.with_method(method)` — narrow to a specific HTTP method (lowercase, e.g. `"post"`).
 - `.with_capability(capability_id)` — narrow to a specific capability id (e.g. `"builtin.http"`).
 - `.with_status(status)` — override the status of a `for_url` body response (e.g. `404`, `500`). Still a successful egress call — `builtin.http` surfaces it as a Completed tool result carrying that status. Panics if called on an `egress_error` response (mutually exclusive outcomes).
-- `ScriptedHttpResponse::egress_error(url_substr, error)` — scripts a runtime egress failure (`Err(RuntimeHttpEgressError)` from `execute`) instead of a body, driving `builtin.http`'s error-mapping paths (e.g. `policy_denied` → `Denied`, `response_body_limit_exceeded` → `Failed{OutputTooLarge}`).
+- `ScriptedHttpResponse::egress_error(url_substr, error)` — scripts a runtime egress failure (`Err(RuntimeHttpEgressError)` from `execute`) instead of a body, driving `builtin.http`'s error-mapping paths (e.g. `policy_denied` → `Denied`, `response_body_limit_exceeded` → `Failed{OutputTooLarge}`). Prefer the two named wrappers below so test bodies select the scenario by name instead of hand-building the nested error struct:
+  - `ScriptedHttpResponse::network_error(url_substr, reason)` — a `RuntimeHttpEgressError::Network` with `reason` (e.g. `"policy_denied"` → `Denied`).
+  - `ScriptedHttpResponse::response_error(url_substr, reason)` — a `RuntimeHttpEgressError::Response` with `reason` (e.g. `RUNTIME_HTTP_REASON_RESPONSE_BODY_LIMIT_EXCEEDED` → `Failed{OutputTooLarge}`).
 
 Requests that match no scripted response fall back to the recording egress default body. The keyed matcher is the canonical HTTP-scripting API; new per-URL response needs fold into `ScriptedHttpResponse` rather than adding a parallel matcher.
 

--- a/tests/support/reborn/assertions.rs
+++ b/tests/support/reborn/assertions.rs
@@ -112,6 +112,46 @@ impl RebornIntegrationHarness {
         .into())
     }
 
+    /// Assert a model-visible tool ERROR carrying `needle` was persisted for
+    /// this thread. Unlike [`assert_tool_result_contains`] (which reads the
+    /// in-process recorder, populated only on the *Completed* write path), a
+    /// `Failed`/`Denied` capability outcome is persisted through a different
+    /// pipeline — `append_capability_result_ref` →
+    /// `append_tool_result_reference` — as a `MessageKind::ToolResultReference`
+    /// message whose `content` is the JSON-serialized `ToolResultReferenceEnvelope`.
+    /// That envelope's `safe_summary` reads `"capability failed with <kind>: …"`
+    /// / `"capability denied with <reason>: …"` (and, for `Failed`, a
+    /// `model_observation` naming the same failure kind), so `needle` such as
+    /// `"policy_denied"`, `"output_too_large"`, `"resource"`, or `"backend"`
+    /// discriminates the surfaced category. Reaching this state at all (rather
+    /// than a terminal `driver_unavailable`) also proves the failure was a
+    /// recoverable, model-visible tool error.
+    pub async fn assert_tool_error_summary_contains(&self, needle: &str) -> HarnessResult<()> {
+        let history = self
+            .thread_harness
+            .history(self.binding.thread_id.clone())
+            .await?;
+        let matched = history.iter().any(|message| {
+            message.kind == ironclaw_threads::MessageKind::ToolResultReference
+                && message
+                    .content
+                    .as_deref()
+                    .is_some_and(|content| content.contains(needle))
+        });
+        if matched {
+            return Ok(());
+        }
+        let seen: Vec<String> = history
+            .iter()
+            .filter(|message| message.kind == ironclaw_threads::MessageKind::ToolResultReference)
+            .filter_map(|message| message.content.clone())
+            .collect();
+        Err(format!(
+            "no persisted tool-result-reference message containing {needle:?}; saw {seen:?}"
+        )
+        .into())
+    }
+
     /// Assert some recorded capability result (tool output) — i.e. a surfaced
     /// HTTP response — serializes to text containing `needle`. Proves the keyed
     /// scripted body actually surfaced back to the model as a tool result.

--- a/tests/support/reborn/assertions.rs
+++ b/tests/support/reborn/assertions.rs
@@ -121,11 +121,30 @@ impl RebornIntegrationHarness {
     /// message whose `content` is the JSON-serialized `ToolResultReferenceEnvelope`.
     /// That envelope's `safe_summary` reads `"capability failed with <kind>: …"`
     /// / `"capability denied with <reason>: …"` (and, for `Failed`, a
-    /// `model_observation` naming the same failure kind), so `needle` such as
-    /// `"policy_denied"`, `"output_too_large"`, `"resource"`, or `"backend"`
-    /// discriminates the surfaced category. Reaching this state at all (rather
-    /// than a terminal `driver_unavailable`) also proves the failure was a
-    /// recoverable, model-visible tool error.
+    /// `model_observation` naming the same failure kind). Reaching this state at
+    /// all (rather than a terminal `driver_unavailable`) also proves the failure
+    /// was a recoverable, model-visible tool error.
+    ///
+    /// **`needle` must include the `"capability failed with "` / `"capability
+    /// denied with "` prefix** (not just the bare failure-kind/reason token) to
+    /// discriminate the outcome *class*, not just the reason — e.g.
+    /// `"capability denied with policy_denied"`, not `"policy_denied"` alone.
+    /// The bare-token form is ambiguous: `CapabilityFailureKind::PolicyDenied`
+    /// (a `Failed` outcome) and the `policy_denied` `Denied` reason both render
+    /// the token `"policy_denied"`, so a regression that turns a `Denied` into a
+    /// `Failed{PolicyDenied}` (or vice versa) would still match a bare-token
+    /// needle and pass vacuously.
+    ///
+    /// **Scans the full thread history, not baseline-sliced** (unlike the
+    /// sibling `assert_egress_*`/`assert_tool_result_contains`, which slice
+    /// `[baseline..]` off the shared in-process recorder). Every current caller
+    /// is a single-turn, single-tool-call harness, so there is at most one
+    /// `ToolResultReference` message and no earlier-thread bleed-through is
+    /// reachable. A future multi-turn or group-thread reuse of this assertion
+    /// MUST add baseline scoping first (thread a `baseline_history_len` through
+    /// harness construction, mirroring `baseline_egress_count` etc.) — do not
+    /// assume this helper is safe to reuse as-is once a thread has more than one
+    /// turn.
     pub async fn assert_tool_error_summary_contains(&self, needle: &str) -> HarnessResult<()> {
         let history = self
             .thread_harness

--- a/tests/support/reborn/assertions.rs
+++ b/tests/support/reborn/assertions.rs
@@ -25,6 +25,31 @@ use super::builder::RebornIntegrationHarness;
 
 type HarnessResult<T> = Result<T, Box<dyn std::error::Error + Send + Sync>>;
 
+/// The two model-visible tool-error outcome classes a capability can surface
+/// (`CapabilityOutcome::Failed` vs `Denied`). A `Failed` and a `Denied` outcome
+/// can render the SAME reason token (e.g. `policy_denied` is both
+/// `CapabilityFailureKind::PolicyDenied` and the `Denied` reason), so
+/// [`assert_tool_error`](RebornIntegrationHarness::assert_tool_error) takes the
+/// class as a typed argument rather than trusting a needle prefix — the class is
+/// then discriminated structurally, not by convention.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolErrorClass {
+    Failed,
+    Denied,
+}
+
+impl ToolErrorClass {
+    /// The `safe_summary` prefix the executor writes for this class — see
+    /// `capability_{failed,denied}_summary` in
+    /// `crates/ironclaw_agent_loop/src/executor/capabilities.rs`.
+    fn summary_prefix(self) -> &'static str {
+        match self {
+            Self::Failed => "capability failed with ",
+            Self::Denied => "capability denied with ",
+        }
+    }
+}
+
 impl RebornIntegrationHarness {
     /// Assert exactly `expected` Tier-2 HTTP egress requests were captured.
     pub async fn assert_egress_count(&self, expected: usize) -> HarnessResult<()> {
@@ -112,28 +137,25 @@ impl RebornIntegrationHarness {
         .into())
     }
 
-    /// Assert a model-visible tool ERROR carrying `needle` was persisted for
-    /// this thread. Unlike [`assert_tool_result_contains`] (which reads the
-    /// in-process recorder, populated only on the *Completed* write path), a
-    /// `Failed`/`Denied` capability outcome is persisted through a different
-    /// pipeline — `append_capability_result_ref` →
+    /// Assert a model-visible tool error of `class` carrying `reason` was
+    /// persisted for this thread. Unlike [`assert_tool_result_contains`] (which
+    /// reads the in-process recorder, populated only on the *Completed* write
+    /// path), a `Failed`/`Denied` capability outcome is persisted through a
+    /// different pipeline — `append_capability_result_ref` →
     /// `append_tool_result_reference` — as a `MessageKind::ToolResultReference`
     /// message whose `content` is the JSON-serialized `ToolResultReferenceEnvelope`.
-    /// That envelope's `safe_summary` reads `"capability failed with <kind>: …"`
-    /// / `"capability denied with <reason>: …"` (and, for `Failed`, a
-    /// `model_observation` naming the same failure kind). Reaching this state at
-    /// all (rather than a terminal `driver_unavailable`) also proves the failure
-    /// was a recoverable, model-visible tool error.
+    /// Reaching this state at all (rather than a terminal `driver_unavailable`)
+    /// also proves the failure was a recoverable, model-visible tool error.
     ///
-    /// **`needle` must include the `"capability failed with "` / `"capability
-    /// denied with "` prefix** (not just the bare failure-kind/reason token) to
-    /// discriminate the outcome *class*, not just the reason — e.g.
-    /// `"capability denied with policy_denied"`, not `"policy_denied"` alone.
-    /// The bare-token form is ambiguous: `CapabilityFailureKind::PolicyDenied`
-    /// (a `Failed` outcome) and the `policy_denied` `Denied` reason both render
-    /// the token `"policy_denied"`, so a regression that turns a `Denied` into a
-    /// `Failed{PolicyDenied}` (or vice versa) would still match a bare-token
-    /// needle and pass vacuously.
+    /// This parses the envelope and checks its **`safe_summary` field** — NOT a
+    /// raw-JSON substring — so `reason` cannot match incidentally inside
+    /// `model_observation`/`result_ref`, and JSON escaping can't skew the match.
+    /// The summary reads `"capability <failed|denied> with <token>: …"`; the
+    /// assertion requires the summary to start with [`class`](ToolErrorClass)'s
+    /// prefix AND contain `reason`. `class` therefore discriminates
+    /// Failed-vs-Denied structurally: a regression that flips one into the other
+    /// fails even when both classes render the same `reason` token (e.g.
+    /// `policy_denied`).
     ///
     /// **Scans the full thread history, not baseline-sliced** (unlike the
     /// sibling `assert_egress_*`/`assert_tool_result_contains`, which slice
@@ -145,28 +167,33 @@ impl RebornIntegrationHarness {
     /// harness construction, mirroring `baseline_egress_count` etc.) — do not
     /// assume this helper is safe to reuse as-is once a thread has more than one
     /// turn.
-    pub async fn assert_tool_error_summary_contains(&self, needle: &str) -> HarnessResult<()> {
+    pub async fn assert_tool_error(
+        &self,
+        class: ToolErrorClass,
+        reason: &str,
+    ) -> HarnessResult<()> {
         let history = self
             .thread_harness
             .history(self.binding.thread_id.clone())
             .await?;
-        let matched = history.iter().any(|message| {
-            message.kind == ironclaw_threads::MessageKind::ToolResultReference
-                && message
-                    .content
-                    .as_deref()
-                    .is_some_and(|content| content.contains(needle))
-        });
-        if matched {
-            return Ok(());
-        }
-        let seen: Vec<String> = history
+        let summaries: Vec<String> = history
             .iter()
             .filter(|message| message.kind == ironclaw_threads::MessageKind::ToolResultReference)
-            .filter_map(|message| message.content.clone())
+            .filter_map(|message| message.content.as_deref())
+            .filter_map(|content| {
+                serde_json::from_str::<ironclaw_threads::ToolResultReferenceEnvelope>(content).ok()
+            })
+            .map(|envelope| envelope.safe_summary.as_str().to_string())
             .collect();
+        let prefix = class.summary_prefix();
+        if summaries
+            .iter()
+            .any(|summary| summary.starts_with(prefix) && summary.contains(reason))
+        {
+            return Ok(());
+        }
         Err(format!(
-            "no persisted tool-result-reference message containing {needle:?}; saw {seen:?}"
+            "no persisted tool-error summary of class {class:?} with reason {reason:?}; saw {summaries:?}"
         )
         .into())
     }

--- a/tests/support/reborn/builder.rs
+++ b/tests/support/reborn/builder.rs
@@ -115,12 +115,26 @@ pub struct RebornIntegrationHarnessBuilder {
     capability: RebornCapabilityBackend,
     keyed_http_responses: Vec<ScriptedHttpResponse>,
     storage: StorageMode,
-    /// Slice 5: when `true`, the `BuiltinHttpTools` backend uses the real
-    /// `LocalHostProcessPort` instead of the inert `RecordingProcessPort`.
-    live_shell: bool,
-    /// Sticky scripted result for the inert recording process port (error-path
-    /// coverage): a non-zero exit code or a `run_command` error.
-    scripted_process: Option<ScriptedProcessResult>,
+    /// How the `BuiltinHttpTools` backend wires `builtin.shell`. One enum instead
+    /// of a `bool` + `Option` so the modes are mutually exclusive by
+    /// construction — the last shell-selecting builder method wins, and a live
+    /// runtime can never carry a stale scripted result.
+    shell_mode: ShellMode,
+}
+
+/// Which process port the built `BuiltinHttpTools` runtime installs for
+/// `builtin.shell`. These are mutually exclusive; the builder holds exactly one.
+#[derive(Debug, Clone, Default)]
+enum ShellMode {
+    /// Slice 5 default: the inert `RecordingProcessPort` records the command and
+    /// spawns no OS process.
+    #[default]
+    Inert,
+    /// The real `LocalHostProcessPort` runs a (hermetic) command for real.
+    Live,
+    /// The inert recording port returns a scripted result (error-path coverage):
+    /// a non-zero exit code or a `run_command` error.
+    Scripted(ScriptedProcessResult),
 }
 
 impl RebornIntegrationHarnessBuilder {
@@ -158,7 +172,7 @@ impl RebornIntegrationHarnessBuilder {
     /// Implies [`with_builtin_http_tools`](Self::with_builtin_http_tools).
     pub fn with_live_shell(mut self) -> Self {
         self.capability = RebornCapabilityBackend::BuiltinHttpTools;
-        self.live_shell = true;
+        self.shell_mode = ShellMode::Live;
         self
     }
 
@@ -168,8 +182,7 @@ impl RebornIntegrationHarnessBuilder {
     /// [`with_builtin_http_tools`](Self::with_builtin_http_tools).
     pub fn with_shell_exit_code(mut self, exit_code: i64) -> Self {
         self.capability = RebornCapabilityBackend::BuiltinHttpTools;
-        self.scripted_process = Some(ScriptedProcessResult::ExitCode(exit_code));
-        self.live_shell = false;
+        self.shell_mode = ShellMode::Scripted(ScriptedProcessResult::ExitCode(exit_code));
         self
     }
 
@@ -179,8 +192,7 @@ impl RebornIntegrationHarnessBuilder {
     /// [`with_builtin_http_tools`](Self::with_builtin_http_tools).
     pub fn with_shell_timeout(mut self) -> Self {
         self.capability = RebornCapabilityBackend::BuiltinHttpTools;
-        self.scripted_process = Some(ScriptedProcessResult::Timeout);
-        self.live_shell = false;
+        self.shell_mode = ShellMode::Scripted(ScriptedProcessResult::Timeout);
         self
     }
 
@@ -220,7 +232,7 @@ impl RebornIntegrationHarnessBuilder {
     /// the scripted provider, and start the planned runtime.
     ///
     /// Routes through an internal, degenerate one-thread `RebornIntegrationGroup`
-    /// (matching this builder's capability/storage/live_shell/keyed_http_responses
+    /// (matching this builder's capability/storage/shell_mode/keyed_http_responses
     /// selections) so there is exactly ONE assembly path for both groups and
     /// single-shot harnesses (design §3: no de-facto fork). Behavior is
     /// byte-identical to the old inline build — existing tests are unaffected
@@ -236,14 +248,18 @@ impl RebornIntegrationHarnessBuilder {
             RebornCapabilityBackend::Echo => GroupCapability::Recording,
             RebornCapabilityBackend::BuiltinHttpTools => {
                 // Slice 5: `.with_live_shell()` opts into the real LocalHostProcessPort;
-                // the default recording path uses the inert RecordingProcessPort.
-                let host_runtime = if self.live_shell {
-                    HostRuntimeCapabilityHarness::core_builtin_tools_with_live_shell().await?
-                } else {
-                    HostRuntimeCapabilityHarness::core_builtin_tools().await?
+                // `Inert`/`Scripted` both use the inert RecordingProcessPort (the
+                // latter with a canned result installed below).
+                let host_runtime = match self.shell_mode {
+                    ShellMode::Live => {
+                        HostRuntimeCapabilityHarness::core_builtin_tools_with_live_shell().await?
+                    }
+                    ShellMode::Inert | ShellMode::Scripted(_) => {
+                        HostRuntimeCapabilityHarness::core_builtin_tools().await?
+                    }
                 };
                 host_runtime.install_http_responses(self.keyed_http_responses)?;
-                if let Some(scripted_process) = self.scripted_process {
+                if let ShellMode::Scripted(scripted_process) = self.shell_mode {
                     host_runtime.install_process_script(scripted_process)?;
                 }
                 GroupCapability::HostRuntime(Arc::new(host_runtime))
@@ -320,8 +336,7 @@ impl RebornIntegrationHarness {
             capability: RebornCapabilityBackend::Echo,
             keyed_http_responses: Vec::new(),
             storage: StorageMode::default(),
-            live_shell: false,
-            scripted_process: None,
+            shell_mode: ShellMode::default(),
         }
     }
 

--- a/tests/support/reborn/builder.rs
+++ b/tests/support/reborn/builder.rs
@@ -52,6 +52,7 @@ use super::harness::{
     RecordedCapabilityResult,
 };
 use super::http_matcher::ScriptedHttpResponse;
+use super::process::ScriptedProcessResult;
 use super::reply::RebornScriptedReply;
 use super::session_thread::RebornThreadHarness;
 use super::test_adapter::RebornTestIngress;
@@ -117,6 +118,9 @@ pub struct RebornIntegrationHarnessBuilder {
     /// Slice 5: when `true`, the `BuiltinHttpTools` backend uses the real
     /// `LocalHostProcessPort` instead of the inert `RecordingProcessPort`.
     live_shell: bool,
+    /// Sticky scripted result for the inert recording process port (error-path
+    /// coverage): a non-zero exit code or a `run_command` error.
+    scripted_process: Option<ScriptedProcessResult>,
 }
 
 impl RebornIntegrationHarnessBuilder {
@@ -155,6 +159,26 @@ impl RebornIntegrationHarnessBuilder {
     pub fn with_live_shell(mut self) -> Self {
         self.capability = RebornCapabilityBackend::BuiltinHttpTools;
         self.live_shell = true;
+        self
+    }
+
+    /// Script the inert recording process port so `builtin.shell` returns a
+    /// non-zero exit code (error-path coverage). The tool still surfaces a
+    /// *Completed* result carrying `exit_code`/`success: false`. Implies
+    /// [`with_builtin_http_tools`](Self::with_builtin_http_tools).
+    pub fn with_shell_exit_code(mut self, exit_code: i64) -> Self {
+        self.capability = RebornCapabilityBackend::BuiltinHttpTools;
+        self.scripted_process = Some(ScriptedProcessResult::ExitCode(exit_code));
+        self
+    }
+
+    /// Script the inert recording process port so `builtin.shell` returns a
+    /// timeout error (`RuntimeProcessError::Timeout`), which the tool maps to a
+    /// recoverable model-visible `Failed{Resource}` capability error. Implies
+    /// [`with_builtin_http_tools`](Self::with_builtin_http_tools).
+    pub fn with_shell_timeout(mut self) -> Self {
+        self.capability = RebornCapabilityBackend::BuiltinHttpTools;
+        self.scripted_process = Some(ScriptedProcessResult::Timeout);
         self
     }
 
@@ -217,6 +241,9 @@ impl RebornIntegrationHarnessBuilder {
                     HostRuntimeCapabilityHarness::core_builtin_tools().await?
                 };
                 host_runtime.install_http_responses(self.keyed_http_responses)?;
+                if let Some(scripted_process) = self.scripted_process {
+                    host_runtime.install_process_script(scripted_process)?;
+                }
                 GroupCapability::HostRuntime(Arc::new(host_runtime))
             }
             RebornCapabilityBackend::MockMcp { mcp_url } => {
@@ -292,6 +319,7 @@ impl RebornIntegrationHarness {
             keyed_http_responses: Vec::new(),
             storage: StorageMode::default(),
             live_shell: false,
+            scripted_process: None,
         }
     }
 

--- a/tests/support/reborn/builder.rs
+++ b/tests/support/reborn/builder.rs
@@ -169,6 +169,7 @@ impl RebornIntegrationHarnessBuilder {
     pub fn with_shell_exit_code(mut self, exit_code: i64) -> Self {
         self.capability = RebornCapabilityBackend::BuiltinHttpTools;
         self.scripted_process = Some(ScriptedProcessResult::ExitCode(exit_code));
+        self.live_shell = false;
         self
     }
 
@@ -179,6 +180,7 @@ impl RebornIntegrationHarnessBuilder {
     pub fn with_shell_timeout(mut self) -> Self {
         self.capability = RebornCapabilityBackend::BuiltinHttpTools;
         self.scripted_process = Some(ScriptedProcessResult::Timeout);
+        self.live_shell = false;
         self
     }
 

--- a/tests/support/reborn/harness.rs
+++ b/tests/support/reborn/harness.rs
@@ -2396,6 +2396,20 @@ impl HostRuntimeCapabilityHarness {
         Ok(())
     }
 
+    /// Install a sticky scripted `builtin.shell` process result on the inert
+    /// recording process port (mirrors `install_http_responses`). Errors if the
+    /// harness has no recording port (e.g. the `.with_live_shell()` path).
+    pub(crate) fn install_process_script(
+        &self,
+        result: super::process::ScriptedProcessResult,
+    ) -> HarnessResult<()> {
+        self.process_port
+            .as_ref()
+            .ok_or("host runtime harness has no recording process port to script")?
+            .set_scripted(result);
+        Ok(())
+    }
+
     fn network_http_requests(&self) -> Vec<NetworkHttpRequest> {
         self.network_egress
             .as_ref()
@@ -3389,21 +3403,35 @@ impl RuntimeHttpEgress for RecordingRuntimeHttpEgress {
         request: RuntimeHttpEgressRequest,
     ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {
         let request_bytes = request.body.len() as u64;
-        // Resolve the keyed body BEFORE recording the request: pushing moves the
-        // request into the log and (via its `Drop`) zeroizes its URL/headers.
-        let keyed_body = {
+        // Resolve the keyed outcome BEFORE recording the request: pushing moves
+        // the request into the log and (via its `Drop`) zeroizes its URL/headers.
+        let keyed_outcome = {
             let scripted = self.scripted.lock().unwrap();
             scripted
                 .iter()
                 .find(|response| response.matches(&request))
-                .map(|response| response.body_bytes())
+                .map(|response| response.outcome())
         };
         self.requests.lock().unwrap().push(request);
-        let body = keyed_body
-            .or_else(|| self.response_bodies.lock().unwrap().pop_front())
-            .unwrap_or_else(|| self.default_body.clone());
+        // A scripted egress error short-circuits with `Err`, driving the tool's
+        // error mapping. A body outcome (or the FIFO/default fallback) returns
+        // `Ok` with the scripted status/body.
+        let (status, body) = match keyed_outcome {
+            Some(super::http_matcher::ScriptedHttpOutcome::Error(error)) => return Err(error),
+            Some(super::http_matcher::ScriptedHttpOutcome::Body { status, bytes }) => {
+                (status, bytes)
+            }
+            None => (
+                200,
+                self.response_bodies
+                    .lock()
+                    .unwrap()
+                    .pop_front()
+                    .unwrap_or_else(|| self.default_body.clone()),
+            ),
+        };
         Ok(RuntimeHttpEgressResponse {
-            status: 200,
+            status,
             headers: vec![("content-type".to_string(), "application/json".to_string())],
             body: body.clone(),
             saved_body: None,

--- a/tests/support/reborn/harness.rs
+++ b/tests/support/reborn/harness.rs
@@ -3403,8 +3403,11 @@ impl RuntimeHttpEgress for RecordingRuntimeHttpEgress {
         request: RuntimeHttpEgressRequest,
     ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {
         let request_bytes = request.body.len() as u64;
-        // Resolve the keyed outcome BEFORE recording the request: pushing moves
-        // the request into the log and (via its `Drop`) zeroizes its URL/headers.
+        // Resolve the keyed outcome BEFORE recording the request: `push(request)`
+        // moves `request` by value into the log, so any code reading its fields
+        // (the `.matches()` lookup) must run first. (`RuntimeHttpEgressRequest`
+        // does implement `Drop`/`ZeroizeOnDrop` to scrub its URL/headers, but that
+        // fires later when the logged entry is actually dropped, not on push.)
         let keyed_outcome = {
             let scripted = self.scripted.lock().unwrap();
             scripted

--- a/tests/support/reborn/http_matcher.rs
+++ b/tests/support/reborn/http_matcher.rs
@@ -19,7 +19,22 @@
 // under `-D warnings`. Module-level allow matches the sibling support modules.
 #![allow(dead_code)]
 
-use ironclaw_host_api::RuntimeHttpEgressRequest;
+use ironclaw_host_api::{RuntimeHttpEgressError, RuntimeHttpEgressRequest};
+
+/// What a matched [`ScriptedHttpResponse`] yields at the runtime HTTP egress
+/// boundary: either a successful response (status + body) or a scripted egress
+/// error. The error arm lets tests exercise the runtime error paths
+/// (`policy_denied`, `response_body_limit_exceeded`, …) that the real
+/// `HostHttpEgressService` produces but the recording egress otherwise cannot —
+/// the egress *is* the vendor/network seam this tier fakes, so scripting an
+/// error here is the same seam as scripting a body.
+#[derive(Debug, Clone)]
+pub enum ScriptedHttpOutcome {
+    /// A successful egress response with the given HTTP status and body.
+    Body { status: u16, bytes: Vec<u8> },
+    /// A scripted egress error (`Err(RuntimeHttpEgressError)` from `execute`).
+    Error(RuntimeHttpEgressError),
+}
 
 /// One scripted HTTP response keyed by request attributes. Matching is
 /// first-match-wins in scripted order. A response with only a URL substring
@@ -37,19 +52,50 @@ pub struct ScriptedHttpResponse {
     method: Option<String>,
     /// Optional: the request's capability id must equal this exactly.
     capability_id: Option<String>,
-    /// Scripted response body returned when this response matches.
-    body: Vec<u8>,
+    /// Scripted outcome returned when this response matches.
+    outcome: ScriptedHttpOutcome,
 }
 
 impl ScriptedHttpResponse {
-    /// Script `body` for any request whose URL contains `url_substr`.
+    /// Script a `200` response with `body` for any request whose URL contains
+    /// `url_substr`. Use [`with_status`] to script a non-2xx status (which the
+    /// `builtin.http` tool surfaces as a *successful* tool result carrying the
+    /// status), or [`egress_error`] for a runtime egress error.
+    ///
+    /// [`with_status`]: ScriptedHttpResponse::with_status
+    /// [`egress_error`]: ScriptedHttpResponse::egress_error
     pub fn for_url(url_substr: impl Into<String>, body: impl Into<Vec<u8>>) -> Self {
         Self {
             url_contains: url_substr.into(),
             method: None,
             capability_id: None,
-            body: body.into(),
+            outcome: ScriptedHttpOutcome::Body {
+                status: 200,
+                bytes: body.into(),
+            },
         }
+    }
+
+    /// Script a runtime egress error for any request whose URL contains
+    /// `url_substr`. The `execute` boundary returns `Err(error)`, driving the
+    /// `builtin.http` tool's error mapping (e.g. `policy_denied` → `Denied`,
+    /// `response_body_limit_exceeded` → `Failed{OutputTooLarge}`).
+    pub fn egress_error(url_substr: impl Into<String>, error: RuntimeHttpEgressError) -> Self {
+        Self {
+            url_contains: url_substr.into(),
+            method: None,
+            capability_id: None,
+            outcome: ScriptedHttpOutcome::Error(error),
+        }
+    }
+
+    /// Override the HTTP status of a body response (default `200`). No-op on an
+    /// [`egress_error`](ScriptedHttpResponse::egress_error) response.
+    pub fn with_status(mut self, status: u16) -> Self {
+        if let ScriptedHttpOutcome::Body { status: s, .. } = &mut self.outcome {
+            *s = status;
+        }
+        self
     }
 
     /// Narrow the key to a specific HTTP method (lowercase, e.g. `"post"`).
@@ -82,8 +128,8 @@ impl ScriptedHttpResponse {
         true
     }
 
-    /// The scripted body to return on a match.
-    pub(crate) fn body_bytes(&self) -> Vec<u8> {
-        self.body.clone()
+    /// The scripted outcome to return on a match.
+    pub(crate) fn outcome(&self) -> ScriptedHttpOutcome {
+        self.outcome.clone()
     }
 }

--- a/tests/support/reborn/http_matcher.rs
+++ b/tests/support/reborn/http_matcher.rs
@@ -9,6 +9,13 @@
 //! egress returns the body of the FIRST scripted response whose key matches the
 //! request, falling back to the FIFO queue, then the default body.
 //!
+//! A matched response is not always a `200` body: `.with_status(u16)` scripts a
+//! non-2xx status (still a successful egress call — `builtin.http` surfaces it
+//! as a Completed tool result carrying that status), and
+//! `ScriptedHttpResponse::egress_error(url, RuntimeHttpEgressError)` scripts a
+//! runtime egress failure (`Err` from `execute`, mapping to a
+//! `Failed`/`Denied` capability outcome). See [`ScriptedHttpOutcome`].
+//!
 //! Concrete by design (spec §3.7): the `Recording*` structs are deliberately not
 //! a premature generic `Recording<P>` — this is written in the extractable
 //! scripted-responses + captured-calls shape so a future rule-of-three lift is
@@ -89,11 +96,19 @@ impl ScriptedHttpResponse {
         }
     }
 
-    /// Override the HTTP status of a body response (default `200`). No-op on an
-    /// [`egress_error`](ScriptedHttpResponse::egress_error) response.
+    /// Override the HTTP status of a body response (default `200`). Panics on
+    /// an [`egress_error`](ScriptedHttpResponse::egress_error) response — the
+    /// two are mutually exclusive scripted outcomes, and silently no-op'ing
+    /// would leave the test exercising the egress-error path instead of the
+    /// status the author intended.
     pub fn with_status(mut self, status: u16) -> Self {
-        if let ScriptedHttpOutcome::Body { status: s, .. } = &mut self.outcome {
-            *s = status;
+        match &mut self.outcome {
+            ScriptedHttpOutcome::Body { status: s, .. } => *s = status,
+            ScriptedHttpOutcome::Error(_) => {
+                panic!(
+                    "with_status() has no effect on an egress_error() response; these are mutually exclusive outcomes"
+                )
+            }
         }
         self
     }

--- a/tests/support/reborn/http_matcher.rs
+++ b/tests/support/reborn/http_matcher.rs
@@ -96,6 +96,38 @@ impl ScriptedHttpResponse {
         }
     }
 
+    /// Script a network-layer egress failure (`RuntimeHttpEgressError::Network`)
+    /// with the given `reason` — e.g. `"policy_denied"`, which the tool's error
+    /// mapping surfaces as a `Denied` capability outcome. Thin named wrapper over
+    /// [`egress_error`](Self::egress_error) so test bodies select the scenario by
+    /// name instead of hand-building the nested error struct.
+    pub fn network_error(url_substr: impl Into<String>, reason: impl Into<String>) -> Self {
+        Self::egress_error(
+            url_substr,
+            RuntimeHttpEgressError::Network {
+                reason: reason.into(),
+                request_bytes: 0,
+                response_bytes: 0,
+            },
+        )
+    }
+
+    /// Script a response-layer egress failure (`RuntimeHttpEgressError::Response`)
+    /// with the given `reason` — e.g. `RUNTIME_HTTP_REASON_RESPONSE_BODY_LIMIT_EXCEEDED`,
+    /// which the tool's error mapping surfaces as `Failed{OutputTooLarge}`. Thin
+    /// named wrapper over [`egress_error`](Self::egress_error) so test bodies
+    /// select the scenario by name instead of hand-building the nested error struct.
+    pub fn response_error(url_substr: impl Into<String>, reason: impl Into<String>) -> Self {
+        Self::egress_error(
+            url_substr,
+            RuntimeHttpEgressError::Response {
+                reason: reason.into(),
+                request_bytes: 0,
+                response_bytes: 0,
+            },
+        )
+    }
+
     /// Override the HTTP status of a body response (default `200`). Panics on
     /// an [`egress_error`](ScriptedHttpResponse::egress_error) response — the
     /// two are mutually exclusive scripted outcomes, and silently no-op'ing

--- a/tests/support/reborn/process.rs
+++ b/tests/support/reborn/process.rs
@@ -87,7 +87,10 @@ impl RuntimeProcessPort for RecordingProcessPort {
             None => 0,
             Some(ScriptedProcessResult::ExitCode(code)) => code,
             Some(ScriptedProcessResult::Timeout) => {
-                return Err(RuntimeProcessError::Timeout(Duration::from_secs(1)));
+                let timeout_secs = request.timeout_secs.unwrap_or(1);
+                return Err(RuntimeProcessError::Timeout(Duration::from_secs(
+                    timeout_secs,
+                )));
             }
         };
         Ok(CommandExecutionOutput {

--- a/tests/support/reborn/process.rs
+++ b/tests/support/reborn/process.rs
@@ -18,12 +18,31 @@ use ironclaw_host_runtime::{
     CommandExecutionOutput, CommandExecutionRequest, RuntimeProcessError, RuntimeProcessPort,
 };
 
-/// Inert process port: records every `CommandExecutionRequest` and returns a
-/// benign success (`exit_code = 0`, empty stdout/stderr) without spawning any
-/// OS process.
+/// A scripted `run_command` result for the recording process port. Sticky:
+/// once set, EVERY `run_command` call returns it (after recording the command),
+/// so a retryable failure surfaces consistently across the loop's retry budget
+/// instead of being consumed once from a FIFO queue.
+#[derive(Debug, Clone)]
+pub enum ScriptedProcessResult {
+    /// Return a benign success with this exit code (non-zero drives the tool's
+    /// `success: false` / `exit_code` model-visible output — still a Completed
+    /// tool result, not an error).
+    ExitCode(i64),
+    /// Return `Err(RuntimeProcessError::Timeout(..))` — the tool maps this to a
+    /// recoverable `Failed{Resource}` capability error.
+    Timeout,
+}
+
+/// Inert process port: records every `CommandExecutionRequest` and, by default,
+/// returns a benign success (`exit_code = 0`, empty stdout/stderr) without
+/// spawning any OS process. A scripted result (via [`set_scripted`]) overrides
+/// the default for every subsequent call.
+///
+/// [`set_scripted`]: RecordingProcessPort::set_scripted
 #[derive(Debug, Clone, Default)]
 pub struct RecordingProcessPort {
     commands: Arc<Mutex<Vec<String>>>,
+    scripted: Arc<Mutex<Option<ScriptedProcessResult>>>,
 }
 
 impl RecordingProcessPort {
@@ -38,6 +57,15 @@ impl RecordingProcessPort {
             .expect("recording process port lock poisoned")
             .clone()
     }
+
+    /// Install a sticky scripted result returned by every subsequent
+    /// `run_command` call (the command is still recorded first).
+    pub fn set_scripted(&self, result: ScriptedProcessResult) {
+        *self
+            .scripted
+            .lock()
+            .expect("recording process port lock poisoned") = Some(result);
+    }
 }
 
 #[async_trait]
@@ -50,10 +78,22 @@ impl RuntimeProcessPort for RecordingProcessPort {
             .lock()
             .expect("recording process port lock poisoned")
             .push(request.command.clone());
+        let scripted = self
+            .scripted
+            .lock()
+            .expect("recording process port lock poisoned")
+            .clone();
+        let exit_code = match scripted {
+            None => 0,
+            Some(ScriptedProcessResult::ExitCode(code)) => code,
+            Some(ScriptedProcessResult::Timeout) => {
+                return Err(RuntimeProcessError::Timeout(Duration::from_secs(1)));
+            }
+        };
         Ok(CommandExecutionOutput {
             output: String::new(),
             saved_output: None,
-            exit_code: 0,
+            exit_code,
             sandboxed: false,
             duration: Duration::from_millis(0),
         })


### PR DESCRIPTION
## What

Closes the **T0-ERRPATHS** row of the reborn backend coverage roadmap: error/deny-path coverage for the already happy-path-covered `builtin.http`, `builtin.shell`, and MCP tools. Extends the existing in-process integration tests (`reborn_integration_http_matcher` / `process_port` / `mcp`) — no redundant new bins (per `testing.md` consolidate-don't-proliferate).

Each new case asserts the failure surfaces as a **model-visible recoverable tool error (Failed/Denied)** — the run reaches `Completed`, not a terminal `driver_unavailable`/`HostUnavailable` — and asserts the **correct category**, cross-checked against `.claude/rules/agent-loop-capabilities.md` (the `Err` vs `Ok(Failed)` distinction).

## Cases (7, all mutation-verified)

| Tool | Case | Outcome asserted |
|---|---|---|
| http | 5xx status | Completed carrying `"status":500` |
| http | network-policy denied | `Denied` (`policy_denied`) |
| http | oversize response body | `Failed{OutputTooLarge}` |
| shell | non-zero exit | Completed carrying `exit_code`/`success:false` |
| shell | timeout | `Failed{Resource}` |
| mcp | tool-call JSON-RPC error | `Failed{Backend}` (error-field guard) |
| mcp | server 5xx | `Failed{Backend}` (HTTP status gate) |

**MCP 401 auth-mismatch is deliberately omitted**: a 401 raises an `AuthRequired` *gate* (park-and-resume), not a `Failed`/`Denied` tool error, and the credentialed-backend-401 arm is already deferred in `reborn_integration_auth_failure.rs` pending a capability-backend credential stub.

## Minimal harness scripting seams (mirror existing patterns)

- `ScriptedHttpResponse`: `body` field → `ScriptedHttpOutcome` enum (`Body{status,bytes}` | `Error(RuntimeHttpEgressError)`); `with_status`, `egress_error`. `RecordingRuntimeHttpEgress` honors the outcome. Existing keyed-matcher API/tests unchanged.
- `RecordingProcessPort`: sticky `ScriptedProcessResult` (`ExitCode`|`Timeout`); builder `with_shell_exit_code` / `with_shell_timeout`; `install_process_script` mirrors `install_http_responses`.
- mock MCP server: sticky `force_http_status` / `set_tool_call_error` post-start setters (no `MockToolResponse` struct change → no call-site churn).
- `assert_tool_error_summary_contains` reads the persisted `ToolResultReference` transcript, since `Failed`/`Denied` outcomes flow through `append_capability_result_ref`, not the `Completed`-only in-process recorder.

## Verification

- All 7 new cases green; existing tests in the 3 bins unchanged/green.
- **Mutation-verified**: each case's error-mapping code was deliberately broken (swallow/mis-map) → test RED → reverted.
- `cargo clippy --all --benches --tests --examples --all-features` clean; `cargo fmt` clean; touched bins run with `--features libsql`.
- Postgres parity out of scope. Rebased onto current `main`.

> Note: `harness.rs` is already >4000 lines (tracked for decomposition in `tests/support/reborn/CLAUDE.md`); additions here are minimal (~+30 lines, mirroring `install_http_responses`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)