### PR TITLE
Label turn state filesystem write traces

### DIFF
--- a/crates/ironclaw_filesystem/src/scoped.rs
+++ b/crates/ironclaw_filesystem/src/scoped.rs
@@ -58,6 +58,7 @@ enum PathClass {
     Memory,
     Artifacts,
     Turns,
+    Resources,
     Other,
 }
 
@@ -68,6 +69,7 @@ impl PathClass {
             Self::Memory => "memory",
             Self::Artifacts => "artifacts",
             Self::Turns => "turns",
+            Self::Resources => "resources",
             Self::Other => "other",
         }
     }
@@ -79,7 +81,17 @@ fn scoped_path_class(path: &ScopedPath) -> PathClass {
         Some("memory") => PathClass::Memory,
         Some("artifacts") => PathClass::Artifacts,
         Some("turns") => PathClass::Turns,
+        Some("resources") => PathClass::Resources,
         _ => PathClass::Other,
+    }
+}
+
+fn scoped_path_detail(path: &ScopedPath) -> &'static str {
+    match path.as_str() {
+        "/turns/state.json" => "turn_state_snapshot",
+        "/resources/snapshot.json" => "resource_governor_snapshot",
+        "/resources/budget-gates.json" => "budget_gate_snapshot",
+        _ => "unknown",
     }
 }
 
@@ -113,12 +125,14 @@ fn trace_fs_latency<T>(
     bytes: Option<usize>,
 ) {
     let path_class = scoped_path_class(path);
+    let path_detail = scoped_path_detail(path);
     match result {
         Ok(_) => ironclaw_observability::live_latency_trace_ok!(
             "filesystem",
             operation,
             started_at,
             path_class = path_class.as_str(),
+            path_detail,
             bytes = bytes.unwrap_or(0),
             "filesystem operation completed",
         ),
@@ -128,6 +142,7 @@ fn trace_fs_latency<T>(
             started_at,
             filesystem_error_kind(error),
             path_class = path_class.as_str(),
+            path_detail,
             bytes = bytes.unwrap_or(0),
             "filesystem operation failed",
         ),

--- a/crates/ironclaw_filesystem/src/scoped/tests.rs
+++ b/crates/ironclaw_filesystem/src/scoped/tests.rs
@@ -46,6 +46,7 @@ fn scoped_path_class_buckets_known_segments_and_redacts_unknowns() {
         ("/memory/profile.json", PathClass::Memory),
         ("/artifacts/run/output.json", PathClass::Artifacts),
         ("/turns/state.json", PathClass::Turns),
+        ("/resources/snapshot.json", PathClass::Resources),
         ("/users/alice/private.txt", PathClass::Other),
         ("/tenants/acme/users/alice/secrets", PathClass::Other),
     ];
@@ -53,6 +54,21 @@ fn scoped_path_class_buckets_known_segments_and_redacts_unknowns() {
     for (raw, expected) in cases {
         let path = ScopedPath::new(raw).unwrap();
         assert_eq!(scoped_path_class(&path), expected);
+    }
+}
+
+#[test]
+fn scoped_path_detail_labels_known_snapshots_without_exposing_paths() {
+    let cases = [
+        ("/turns/state.json", "turn_state_snapshot"),
+        ("/resources/snapshot.json", "resource_governor_snapshot"),
+        ("/resources/budget-gates.json", "budget_gate_snapshot"),
+        ("/resources/other.json", "unknown"),
+    ];
+
+    for (raw, expected) in cases {
+        let path = ScopedPath::new(raw).unwrap();
+        assert_eq!(scoped_path_detail(&path), expected);
     }
 }
 

--- a/crates/ironclaw_turns/src/filesystem_store.rs
+++ b/crates/ironclaw_turns/src/filesystem_store.rs
@@ -576,19 +576,21 @@ where
         Fut: std::future::Future<Output = (Result<TurnRunState, TurnError>, InMemoryTurnStateStore)>
             + Send,
     {
-        let previous = self
-            .prepare_runner_lease_retirement(run_id, runner_id, lease_token, retired_status)
-            .await?;
-        let result = self
-            .apply(RunnerLeaseOverlay::Run(run_id), apply)
-            .instrument(turn_state_write_span(operation, None, Some(&run_id)))
-            .await;
-        if result.is_err() {
-            self.restore_runner_lease_after_failed_transition(previous, retired_status)
-                .await;
+        let span = turn_state_write_span(operation, None, Some(&run_id));
+        async move {
+            let previous = self
+                .prepare_runner_lease_retirement(run_id, runner_id, lease_token, retired_status)
+                .await?;
+            let result = self.apply(RunnerLeaseOverlay::Run(run_id), apply).await;
+            if result.is_err() {
+                self.restore_runner_lease_after_failed_transition(previous, retired_status)
+                    .await;
+            }
+            self.cleanup_runner_lease_after_state(&result).await;
+            result
         }
-        self.cleanup_runner_lease_after_state(&result).await;
-        result
+        .instrument(span)
+        .await
     }
 
     async fn compensate_failed_claim(&self, claimed: &ClaimedTurnRun) {
@@ -700,38 +702,42 @@ where
         &self,
         request: CancelRunRequest,
     ) -> Result<CancelRunResponse, TurnError> {
-        let previous = self.prepare_cancel_requested_runner_lease(&request).await?;
-        let result = self
-            .apply(RunnerLeaseOverlay::Run(request.run_id), |store| {
-                let request = request.clone();
-                async move {
-                    let outcome = store.request_cancel(request).await;
-                    (outcome, store)
-                }
-            })
-            .instrument(turn_state_write_span(
-                "request_cancel",
-                Some(&request.scope),
-                Some(&request.run_id),
-            ))
-            .await;
-        if result.is_err() {
-            self.restore_runner_lease_after_failed_transition(
-                previous,
-                TurnStatus::CancelRequested,
-            )
-            .await;
-        }
-        let response = result?;
-        match response.status {
-            status if status.is_terminal() => {
-                self.runner_lease_store()
-                    .delete_best_effort(response.run_id)
-                    .await;
+        let span = turn_state_write_span(
+            "request_cancel",
+            Some(&request.scope),
+            Some(&request.run_id),
+        );
+        async move {
+            let previous = self.prepare_cancel_requested_runner_lease(&request).await?;
+            let result = self
+                .apply(RunnerLeaseOverlay::Run(request.run_id), |store| {
+                    let request = request.clone();
+                    async move {
+                        let outcome = store.request_cancel(request).await;
+                        (outcome, store)
+                    }
+                })
+                .await;
+            if result.is_err() {
+                self.restore_runner_lease_after_failed_transition(
+                    previous,
+                    TurnStatus::CancelRequested,
+                )
+                .await;
             }
-            _ => {}
+            let response = result?;
+            match response.status {
+                status if status.is_terminal() => {
+                    self.runner_lease_store()
+                        .delete_best_effort(response.run_id)
+                        .await;
+                }
+                _ => {}
+            }
+            Ok(response)
         }
-        Ok(response)
+        .instrument(span)
+        .await
     }
 
     async fn get_run_state(&self, request: GetRunStateRequest) -> Result<TurnRunState, TurnError> {
@@ -913,29 +919,29 @@ where
         &self,
         request: ClaimRunRequest,
     ) -> Result<Option<ClaimedTurnRun>, TurnError> {
-        let claimed = self
-            .apply(RunnerLeaseOverlay::None, |store| {
-                let request = request.clone();
-                async move {
-                    let outcome = store.claim_next_run(request).await;
-                    (outcome, store)
-                }
-            })
-            .instrument(turn_state_write_span(
-                "claim_next_run",
-                request.scope_filter.as_ref(),
-                None,
-            ))
-            .await?;
-        if let Some(claimed) = &claimed
-            && let Err(error) = self
-                .seed_runner_lease_from_snapshot_inner(claimed.state.run_id)
-                .await
-        {
-            self.compensate_failed_claim(claimed).await;
-            return Err(error);
+        let span = turn_state_write_span("claim_next_run", request.scope_filter.as_ref(), None);
+        async move {
+            let claimed = self
+                .apply(RunnerLeaseOverlay::None, |store| {
+                    let request = request.clone();
+                    async move {
+                        let outcome = store.claim_next_run(request).await;
+                        (outcome, store)
+                    }
+                })
+                .await?;
+            if let Some(claimed) = &claimed
+                && let Err(error) = self
+                    .seed_runner_lease_from_snapshot_inner(claimed.state.run_id)
+                    .await
+            {
+                self.compensate_failed_claim(claimed).await;
+                return Err(error);
+            }
+            Ok(claimed)
         }
-        Ok(claimed)
+        .instrument(span)
+        .await
     }
 
     async fn heartbeat(&self, request: HeartbeatRequest) -> Result<EventCursor, TurnError> {

--- a/crates/ironclaw_turns/src/filesystem_store.rs
+++ b/crates/ironclaw_turns/src/filesystem_store.rs
@@ -45,6 +45,7 @@ use ironclaw_filesystem::{
 };
 use ironclaw_host_api::{ResourceScope, UserId};
 use tokio::sync::RwLock;
+use tracing::{Instrument, field};
 
 use crate::{
     AllowAllTurnAdmissionLimitProvider, CancelRunRequest, CancelRunResponse, EventCursor,
@@ -78,6 +79,36 @@ use runner_lease::{RunnerLeaseMemory, RunnerLeaseOverlay, RunnerLeaseRecord, Run
 mod tests;
 
 const SNAPSHOT_READ_CACHE_TTL: Duration = Duration::from_millis(500);
+
+fn turn_state_write_span(
+    operation: &'static str,
+    scope: Option<&TurnScope>,
+    run_id: Option<&TurnRunId>,
+) -> tracing::Span {
+    let span = tracing::trace_span!(
+        target: "ironclaw_latency",
+        "turn_state_write",
+        turn_state_op = operation,
+        tenant_id = field::Empty,
+        thread_id = field::Empty,
+        owner_user_id = field::Empty,
+        run_id = field::Empty,
+    );
+
+    if let Some(scope) = scope {
+        span.record("tenant_id", field::display(&scope.tenant_id));
+        span.record("thread_id", field::display(&scope.thread_id));
+        if let Some(owner_user_id) = scope.explicit_owner_user_id() {
+            span.record("owner_user_id", field::display(owner_user_id));
+        }
+    }
+
+    if let Some(run_id) = run_id {
+        span.record("run_id", field::display(run_id));
+    }
+
+    span
+}
 
 #[derive(Clone)]
 struct CachedSnapshot {
@@ -533,6 +564,7 @@ where
 
     async fn apply_run_state_transition<A, Fut>(
         &self,
+        operation: &'static str,
         run_id: TurnRunId,
         runner_id: crate::TurnRunnerId,
         lease_token: crate::TurnLeaseToken,
@@ -547,7 +579,10 @@ where
         let previous = self
             .prepare_runner_lease_retirement(run_id, runner_id, lease_token, retired_status)
             .await?;
-        let result = self.apply(RunnerLeaseOverlay::Run(run_id), apply).await;
+        let result = self
+            .apply(RunnerLeaseOverlay::Run(run_id), apply)
+            .instrument(turn_state_write_span(operation, None, Some(&run_id)))
+            .await;
         if result.is_err() {
             self.restore_runner_lease_after_failed_transition(previous, retired_status)
                 .await;
@@ -569,6 +604,11 @@ where
                     .await;
                 (outcome.map(|_| ()), store)
             })
+            .instrument(turn_state_write_span(
+                "compensate_failed_claim",
+                Some(&claimed.state.scope),
+                Some(&run_id),
+            ))
             .await;
         if let Err(error) = result {
             tracing::debug!(
@@ -629,6 +669,11 @@ where
                 (outcome, store)
             }
         })
+        .instrument(turn_state_write_span(
+            "submit_turn",
+            Some(&request.scope),
+            request.requested_run_id.as_ref(),
+        ))
         .await
     }
 
@@ -643,6 +688,11 @@ where
                 (outcome, store)
             }
         })
+        .instrument(turn_state_write_span(
+            "resume_turn",
+            Some(&request.scope),
+            Some(&request.run_id),
+        ))
         .await
     }
 
@@ -659,6 +709,11 @@ where
                     (outcome, store)
                 }
             })
+            .instrument(turn_state_write_span(
+                "request_cancel",
+                Some(&request.scope),
+                Some(&request.run_id),
+            ))
             .await;
         if result.is_err() {
             self.restore_runner_lease_after_failed_transition(
@@ -717,6 +772,11 @@ where
                 (outcome, store)
             }
         })
+        .instrument(turn_state_write_span(
+            "submit_child_turn",
+            Some(&request.child_scope),
+            request.requested_run_id.as_ref(),
+        ))
         .await
     }
 
@@ -756,6 +816,11 @@ where
                 .await;
             (outcome, store)
         })
+        .instrument(turn_state_write_span(
+            "reserve_tree_descendants",
+            Some(scope),
+            Some(&root_run_id),
+        ))
         .await
     }
 
@@ -771,6 +836,11 @@ where
                 .await;
             (outcome, store)
         })
+        .instrument(turn_state_write_span(
+            "release_tree_descendants",
+            Some(scope),
+            Some(&root_run_id),
+        ))
         .await
     }
 }
@@ -815,6 +885,11 @@ where
                 (outcome, store)
             }
         })
+        .instrument(turn_state_write_span(
+            "put_loop_checkpoint",
+            Some(&request.scope),
+            Some(&request.run_id),
+        ))
         .await
     }
 
@@ -846,6 +921,11 @@ where
                     (outcome, store)
                 }
             })
+            .instrument(turn_state_write_span(
+                "claim_next_run",
+                request.scope_filter.as_ref(),
+                None,
+            ))
             .await?;
         if let Some(claimed) = &claimed
             && let Err(error) = self
@@ -874,6 +954,11 @@ where
                     (outcome, store)
                 }
             })
+            .instrument(turn_state_write_span(
+                "recover_expired_leases",
+                request.scope_filter.as_ref(),
+                None,
+            ))
             .await;
         if let Ok(response) = &result {
             for state in &response.recovered {
@@ -897,11 +982,17 @@ where
                 (outcome, store)
             }
         })
+        .instrument(turn_state_write_span(
+            "record_model_route_snapshot",
+            None,
+            Some(&request.run_id),
+        ))
         .await
     }
 
     async fn block_run(&self, request: BlockRunRequest) -> Result<TurnRunState, TurnError> {
         self.apply_run_state_transition(
+            "block_run",
             request.run_id,
             request.runner_id,
             request.lease_token,
@@ -919,6 +1010,7 @@ where
 
     async fn complete_run(&self, request: CompleteRunRequest) -> Result<TurnRunState, TurnError> {
         self.apply_run_state_transition(
+            "complete_run",
             request.run_id,
             request.runner_id,
             request.lease_token,
@@ -939,6 +1031,7 @@ where
         request: CancelRunCompletionRequest,
     ) -> Result<TurnRunState, TurnError> {
         self.apply_run_state_transition(
+            "cancel_run",
             request.run_id,
             request.runner_id,
             request.lease_token,
@@ -956,6 +1049,7 @@ where
 
     async fn fail_run(&self, request: FailRunRequest) -> Result<TurnRunState, TurnError> {
         self.apply_run_state_transition(
+            "fail_run",
             request.run_id,
             request.runner_id,
             request.lease_token,
@@ -976,6 +1070,7 @@ where
         request: RecordRunnerFailureRequest,
     ) -> Result<TurnRunState, TurnError> {
         self.apply_run_state_transition(
+            "record_runner_failure",
             request.run_id,
             request.runner_id,
             request.lease_token,
@@ -996,6 +1091,7 @@ where
         request: RelinquishRunRequest,
     ) -> Result<TurnRunState, TurnError> {
         self.apply_run_state_transition(
+            "relinquish_run",
             request.run_id,
             request.runner_id,
             request.lease_token,
@@ -1016,6 +1112,7 @@ where
         request: ApplyValidatedLoopExitRequest,
     ) -> Result<TurnRunState, TurnError> {
         self.apply_run_state_transition(
+            "apply_validated_loop_exit",
             request.run_id,
             request.runner_id,
             request.lease_token,


### PR DESCRIPTION
## Summary
- classify `/resources` filesystem latency rows separately from `other`
- add redacted `path_detail` labels for turn state, resource governor, and budget gate snapshots
- add `turn_state_write` trace spans around durable turn-state mutation paths so `/turns/state.json` CAS/version-mismatch rows inherit the logical writer operation

## Behavior
Observability-only. No persistence format, scheduling, retry, or storage behavior changes.

## Test plan
- `cargo fmt --check`
- `cargo check -p ironclaw_filesystem -p ironclaw_turns`
- `cargo test -p ironclaw_filesystem scoped_path`
- `cargo test -p ironclaw_turns filesystem_store::tests`
- `git diff --check`