### PR TITLE
build(reborn): enable inmemory-turn-state in the ironclaw-reborn deploy build

### DIFF
--- a/Dockerfile.reborn
+++ b/Dockerfile.reborn
@@ -51,7 +51,7 @@ COPY --from=planner /app/recipe.json recipe.json
 RUN cargo chef cook \
     --profile dist \
     --package ironclaw_reborn_cli \
-    --features webui-v2-beta,slack-v2-host-beta,libsql,postgres \
+    --features webui-v2-beta,slack-v2-host-beta,libsql,postgres,inmemory-turn-state \
     --recipe-path recipe.json
 
 FROM deps AS builder
@@ -71,7 +71,7 @@ RUN mkdir -p src \
 RUN cargo build \
     --profile dist \
     --package ironclaw_reborn_cli \
-    --features webui-v2-beta,slack-v2-host-beta,libsql,postgres \
+    --features webui-v2-beta,slack-v2-host-beta,libsql,postgres,inmemory-turn-state \
     --bin ironclaw-reborn
 
 FROM debian:bookworm-slim AS runtime

--- a/crates/ironclaw_reborn_cli/Cargo.toml
+++ b/crates/ironclaw_reborn_cli/Cargo.toml
@@ -61,6 +61,15 @@ postgres = [
 libsql = [
     "ironclaw_reborn_composition/libsql",
 ]
+# Coordinate turn state in a single in-process `InMemoryTurnStateStore` authority
+# instead of the per-user `state.json` filesystem CAS store (the runtime-wedge
+# fix). Forwards to `ironclaw_reborn_composition/inmemory-turn-state`; see that
+# crate's feature doc for the durability trade-off (in-flight turns are volatile
+# across a hard crash, gate-blocked turns are persisted off the hot path and a
+# graceful shutdown flushes the full snapshot).
+inmemory-turn-state = [
+    "ironclaw_reborn_composition/inmemory-turn-state",
+]
 [dependencies]
 anyhow = "1"
 async-trait = { version = "0.1", optional = true }


### PR DESCRIPTION
## Summary

- The in-memory turn-state authority (the runtime-wedge fix, #5486) is a **compile-time** feature that shipped **dormant**: `ironclaw_reborn_composition` defines `inmemory-turn-state` but nothing enabled it, so the deployed `ironclaw-reborn` binary is still compiled with the per-user `state.json` filesystem CAS store — the livelocking path #5486 replaces.
- This wires the feature through so the deploy build actually uses the in-memory authority: a forwarding feature on `ironclaw_reborn_cli` + adding it to both `Dockerfile.reborn` `--features` lines.
- Build/feature change only — **no code changes**.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

(Activates an already-merged, feature-gated capability in the deploy build.)

## Linked Issue

Activates the capability merged in #5486. Companion to the runtime-wedge track (#5206, #5142, #5234). None closed by this PR.

## Validation

- [x] Full deploy feature set compiles: `cargo check -p ironclaw_reborn_cli --features webui-v2-beta,slack-v2-host-beta,libsql,postgres,inmemory-turn-state` (rustc 1.96, engine-excluded isolation build due to the environment's github.com egress policy). Confirms the forwarder resolves and the feature interactions (postgres + slack + webui + inmemory) compile.
- [ ] Full-workspace `fmt`/`clippy`/`test` — not run locally (workspace has a github.com git dependency `monty` via `ironclaw_engine` that the environment's egress policy blocks). No `.rs` changed, so fmt/clippy are unaffected; please run the standard gate in CI.
- Manual: verified `inmemory-turn-state` was previously enabled **nowhere** (defined only in the composition crate; absent from every `--features` line and from reborn_cli's forwarders), i.e. the merged fix was inert until this change.

## Security Impact

None. No change to permissions, network, secrets, file access, or sandbox policy. Turn-state coordination stays host-process-internal.

## Reborn Trust-Boundary Checklist

N/A — no code, policy, evidence, trust-bearing types, status/error variants, `serde(default)` fields, or bounds change. This only selects an already-merged store implementation at build time.

## Database Impact

None. No migration or schema change. The feature *removes* per-turn writes to the turn-state document on the hot path; the durable filesystem store and its migrations are untouched and remain available (used when the feature is off).

## Blast Radius

`Dockerfile.reborn` is the single reborn image, so this enables the in-memory turn-state authority for **every reborn deployment** (not only hosted-single-tenant-volume). Behavioral surface is exactly what #5486 introduced: turn coordination moves to one in-process `InMemoryTurnStateStore`. Durability trade-off (documented on the composition feature): in-flight turns are volatile across a **hard crash**; gate-blocked (approval/auth) turns are persisted off the hot path and recovered on restart; a **graceful** shutdown (SIGTERM) flushes the full snapshot so in-flight turns survive a planned deploy.

## Rollback Plan

Remove `inmemory-turn-state` from the `Dockerfile.reborn` `--features` lines (and/or drop the reborn_cli forwarder) and rebuild → the durable per-user filesystem turn-state store is restored. No schema/data change either way; reverting the commit is clean.

## Review Follow-Through

- Deliberately enables for all reborn deploys via the single image. If a narrower rollout is wanted (only the hosted-single-tenant-volume build), that would need a separate image/build target — flag if desired.
- Optimization follow-up (blocked-subset/delta persist to make the durable write O(active) instead of O(total state)) is tracked separately and does not block this.

---

**Review track**: C (runtime)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQzj2447pq2BUfgY3BUSJb)_