### PR TITLE
perf(turns): persist compact recovery snapshot on flush/block

### DIFF
--- a/crates/ironclaw_turns/src/memory/mod.rs
+++ b/crates/ironclaw_turns/src/memory/mod.rs
@@ -1844,6 +1844,15 @@ impl TurnRunTransitionPort for InMemoryTurnStateStore {
     }
 }
 
+/// Selects which slice of state [`Inner::build_snapshot`] captures.
+enum SnapshotScope {
+    /// Full runtime read-model: every run, turn, and the retained event log.
+    Full,
+    /// Compact durable-recovery slice: non-terminal runs + their referential
+    /// closure, audit events dropped.
+    Recovery,
+}
+
 impl Inner {
     fn from_persistence_snapshot(
         snapshot: TurnPersistenceSnapshot,
@@ -2106,105 +2115,81 @@ impl Inner {
         }
     }
 
+    /// The full runtime read-model snapshot: every run, turn, checkpoint,
+    /// reservation, and the retained audit event log. This is the projection /
+    /// rehydration surface consumed elsewhere; it is *not* what durable writes
+    /// persist (see [`recovery_snapshot`](Self::recovery_snapshot)).
     fn persistence_snapshot(&self) -> TurnPersistenceSnapshot {
-        let mut turns = self.turns.values().cloned().collect::<Vec<_>>();
-        turns.sort_by_key(|record| record.created_at);
-        let mut runs = self
-            .records
-            .values()
-            .map(RunRecord::persistence_record)
-            .collect::<Vec<_>>();
-        runs.sort_by_key(|record| record.event_cursor);
-        let mut active_locks = self.active_locks.values().cloned().collect::<Vec<_>>();
-        active_locks.sort_by_key(|record| record.acquired_at);
-        let mut checkpoints = self.checkpoints.clone();
-        checkpoints.sort_by(|a, b| {
-            a.created_at
-                .cmp(&b.created_at)
-                .then_with(|| a.sequence.cmp(&b.sequence))
-        });
-        let mut loop_checkpoints = self.loop_checkpoints.values().cloned().collect::<Vec<_>>();
-        loop_checkpoints.sort_by(|a, b| {
-            a.created_at
-                .cmp(&b.created_at)
-                .then_with(|| a.checkpoint_id.as_uuid().cmp(&b.checkpoint_id.as_uuid()))
-        });
-        let mut idempotency_records = self
-            .idempotency_records
-            .values()
-            .cloned()
-            .collect::<Vec<_>>();
-        idempotency_records.sort_by_key(|record| record.created_at);
-        let mut admission_reservations = self
-            .admission_reservations
-            .values()
-            .cloned()
-            .collect::<Vec<_>>();
-        admission_reservations.sort_by_key(|reservation| reservation.run_id.to_string());
-        let mut spawn_tree_reservations = self
-            .tree_reservations
-            .iter()
-            .filter_map(|(key, descendant_count)| {
-                let root = self.records.get(&key.root_run_id)?;
-                Some(SpawnTreeReservation {
-                    scope: root.scope.clone(),
-                    root_run_id: key.root_run_id,
-                    descendant_count: *descendant_count,
-                })
-            })
-            .collect::<Vec<_>>();
-        spawn_tree_reservations.sort_by_key(|reservation| reservation.root_run_id.to_string());
-        TurnPersistenceSnapshot {
-            turns,
-            runs,
-            active_locks,
-            checkpoints,
-            loop_checkpoints,
-            idempotency_records,
-            events: self.events.clone(),
-            event_retention_floor: self.event_retention_floor,
-            admission_reservations,
-            spawn_tree_reservations,
-        }
+        self.build_snapshot(SnapshotScope::Full)
     }
 
-    /// A compact snapshot for durable recovery: only the runs a restart must
+    /// The compact snapshot durable writes persist: only the runs a restart must
     /// coordinate — the **non-terminal** ones (blocked + queued + running) — plus
-    /// exactly the records they reference. Terminal runs need no coordination
-    /// recovery (a completed/failed run must not rehydrate as live) and lifecycle
-    /// `events` exist only for audit/projection, so both are omitted. This makes
-    /// the durable write O(active runs) instead of O(total accumulated state),
-    /// and structurally prevents a finished run from being resurrected.
+    /// their referential closure, with the audit event log dropped. Terminal runs
+    /// need no coordination recovery (a completed/failed run must not rehydrate as
+    /// live) and events exist only for audit/projection, so both are omitted. The
+    /// durable write is then O(active runs) instead of O(total accumulated state),
+    /// and a finished run cannot be structurally resurrected.
     ///
-    /// The filter is closed under references: `from_persistence_snapshot` rejects
-    /// a run whose turn is absent, and blocked runs must keep their thread lock,
-    /// checkpoints, and admission/spawn reservations — so every kept run keeps its
-    /// turn, active lock, checkpoints, and reservations. Idempotency records are
-    /// kept whole (bounded by the store cap, no run-ref requirement) so recent
-    /// submit/resume/cancel dedup survives a restart. Concurrency counters and any
-    /// missing admission reservations are re-derived from the kept runs on load.
+    /// The retained closure satisfies what `from_persistence_snapshot` requires:
+    /// a run's turn must be present, and a blocked run keeps its thread lock,
+    /// checkpoint, and admission/spawn reservations. Idempotency records are kept
+    /// whole (store-capped, no run-ref requirement) so recent submit/resume/cancel
+    /// dedup survives a restart. Concurrency counters and any missing admission
+    /// reservations are re-derived from the kept runs on load.
     fn recovery_snapshot(&self) -> TurnPersistenceSnapshot {
-        let kept: Vec<&RunRecord> = self
+        self.build_snapshot(SnapshotScope::Recovery)
+    }
+
+    /// Shared snapshot assembler for [`persistence_snapshot`] and
+    /// [`recovery_snapshot`]. The two differ only in `scope`: which runs are
+    /// captured (all, or non-terminal + referential closure) and whether the
+    /// audit event log is included. Keeping the collect/sort logic in one place
+    /// means a field added to `TurnPersistenceSnapshot` is handled once; the
+    /// filtered scope never clones the records it will drop.
+    ///
+    /// [`persistence_snapshot`]: Self::persistence_snapshot
+    /// [`recovery_snapshot`]: Self::recovery_snapshot
+    fn build_snapshot(&self, scope: SnapshotScope) -> TurnPersistenceSnapshot {
+        let recovery = matches!(scope, SnapshotScope::Recovery);
+        let selected: Vec<&RunRecord> = self
             .records
             .values()
-            .filter(|record| !record.status.get().is_terminal())
-            .collect();
-        let kept_run_ids: HashSet<TurnRunId> = kept.iter().map(|record| record.run_id).collect();
-        let kept_turn_ids: HashSet<crate::TurnId> =
-            kept.iter().map(|record| record.turn_id).collect();
-        let kept_checkpoint_ids: HashSet<TurnCheckpointId> = kept
-            .iter()
-            .filter_map(|record| record.checkpoint_id)
-            .collect();
-        // Tree roots that still have a non-terminal run (root kept, or a kept
-        // descendant points at it) — keep those spawn-tree reservations so
-        // subagent capacity stays accurate across restart.
-        let live_tree_roots: HashSet<TurnRunId> = kept
-            .iter()
-            .map(|record| record.spawn_tree_root_run_id.unwrap_or(record.run_id))
+            .filter(|record| !recovery || !record.status.get().is_terminal())
             .collect();
 
-        let mut runs = kept
+        // Referential-closure keys drive the `recovery` filters below; the `Full`
+        // scope keeps everything, so they stay empty and every filter short-circuits.
+        let kept_run_ids: HashSet<TurnRunId> = if recovery {
+            selected.iter().map(|record| record.run_id).collect()
+        } else {
+            HashSet::new()
+        };
+        let kept_turn_ids: HashSet<crate::TurnId> = if recovery {
+            selected.iter().map(|record| record.turn_id).collect()
+        } else {
+            HashSet::new()
+        };
+        let kept_checkpoint_ids: HashSet<TurnCheckpointId> = if recovery {
+            selected
+                .iter()
+                .filter_map(|record| record.checkpoint_id)
+                .collect()
+        } else {
+            HashSet::new()
+        };
+        // Tree roots still backing a non-terminal run keep their subagent-capacity
+        // reservation across restart.
+        let live_tree_roots: HashSet<TurnRunId> = if recovery {
+            selected
+                .iter()
+                .map(|record| record.spawn_tree_root_run_id.unwrap_or(record.run_id))
+                .collect()
+        } else {
+            HashSet::new()
+        };
+
+        let mut runs = selected
             .iter()
             .map(|record| record.persistence_record())
             .collect::<Vec<_>>();
@@ -2212,21 +2197,23 @@ impl Inner {
         let mut turns = self
             .turns
             .values()
-            .filter(|turn| kept_turn_ids.contains(&turn.turn_id))
+            .filter(|turn| !recovery || kept_turn_ids.contains(&turn.turn_id))
             .cloned()
             .collect::<Vec<_>>();
         turns.sort_by_key(|record| record.created_at);
         let mut active_locks = self
             .active_locks
             .values()
-            .filter(|lock| kept_run_ids.contains(&lock.run_id))
+            .filter(|lock| !recovery || kept_run_ids.contains(&lock.run_id))
             .cloned()
             .collect::<Vec<_>>();
         active_locks.sort_by_key(|record| record.acquired_at);
         let mut checkpoints = self
             .checkpoints
             .iter()
-            .filter(|checkpoint| kept_checkpoint_ids.contains(&checkpoint.checkpoint_id))
+            .filter(|checkpoint| {
+                !recovery || kept_checkpoint_ids.contains(&checkpoint.checkpoint_id)
+            })
             .cloned()
             .collect::<Vec<_>>();
         checkpoints.sort_by(|a, b| {
@@ -2237,7 +2224,9 @@ impl Inner {
         let mut loop_checkpoints = self
             .loop_checkpoints
             .values()
-            .filter(|checkpoint| kept_checkpoint_ids.contains(&checkpoint.checkpoint_id))
+            .filter(|checkpoint| {
+                !recovery || kept_checkpoint_ids.contains(&checkpoint.checkpoint_id)
+            })
             .cloned()
             .collect::<Vec<_>>();
         loop_checkpoints.sort_by(|a, b| {
@@ -2245,6 +2234,8 @@ impl Inner {
                 .cmp(&b.created_at)
                 .then_with(|| a.checkpoint_id.as_uuid().cmp(&b.checkpoint_id.as_uuid()))
         });
+        // Idempotency records are kept whole in both scopes (store-capped, no
+        // run-ref requirement) so recent submit/resume/cancel dedup survives.
         let mut idempotency_records = self
             .idempotency_records
             .values()
@@ -2254,14 +2245,14 @@ impl Inner {
         let mut admission_reservations = self
             .admission_reservations
             .values()
-            .filter(|reservation| kept_run_ids.contains(&reservation.run_id))
+            .filter(|reservation| !recovery || kept_run_ids.contains(&reservation.run_id))
             .cloned()
             .collect::<Vec<_>>();
         admission_reservations.sort_by_key(|reservation| reservation.run_id.to_string());
         let mut spawn_tree_reservations = self
             .tree_reservations
             .iter()
-            .filter(|(key, _)| live_tree_roots.contains(&key.root_run_id))
+            .filter(|(key, _)| !recovery || live_tree_roots.contains(&key.root_run_id))
             .filter_map(|(key, descendant_count)| {
                 let root = self.records.get(&key.root_run_id)?;
                 Some(SpawnTreeReservation {
@@ -2279,9 +2270,13 @@ impl Inner {
             checkpoints,
             loop_checkpoints,
             idempotency_records,
-            // Dropped: audit-only lifecycle events are the unbounded bloat, and
-            // recovery reconstructs the cursor from the kept runs' event cursors.
-            events: Vec::new(),
+            // Recovery drops the audit-only event log (the unbounded bloat) and
+            // rebuilds the cursor from the kept runs' cursors + the retention floor.
+            events: if recovery {
+                Vec::new()
+            } else {
+                self.events.clone()
+            },
             event_retention_floor: self.event_retention_floor,
             admission_reservations,
             spawn_tree_reservations,

--- a/crates/ironclaw_turns/src/memory/mod.rs
+++ b/crates/ironclaw_turns/src/memory/mod.rs
@@ -2155,7 +2155,19 @@ impl Inner {
         let selected: Vec<&RunRecord> = self
             .records
             .values()
-            .filter(|record| !recovery || !record.status.get().is_terminal())
+            .filter(|record| {
+                !recovery
+                    || !record.status.get().is_terminal()
+                    // A *terminal* run that still roots a live spawn-tree
+                    // reservation must be retained: its reservation is kept
+                    // below, and `reserve_/release_tree_descendants` resolve the
+                    // root through `records` — dropping it would strand the
+                    // release with `ScopeNotFound` on the next restart.
+                    || self
+                        .tree_reservations
+                        .keys()
+                        .any(|key| key.root_run_id == record.run_id)
+            })
             .collect();
 
         // Referential-closure keys drive the `recovery` filters below; the `Full`
@@ -2170,16 +2182,8 @@ impl Inner {
         } else {
             HashSet::new()
         };
-        let kept_checkpoint_ids: HashSet<TurnCheckpointId> = if recovery {
-            selected
-                .iter()
-                .filter_map(|record| record.checkpoint_id)
-                .collect()
-        } else {
-            HashSet::new()
-        };
-        // Tree roots still backing a non-terminal run keep their subagent-capacity
-        // reservation across restart.
+        // Tree roots whose record survives keep their subagent-capacity
+        // reservation across restart (every reservation root is retained above).
         let live_tree_roots: HashSet<TurnRunId> = if recovery {
             selected
                 .iter()
@@ -2208,12 +2212,14 @@ impl Inner {
             .cloned()
             .collect::<Vec<_>>();
         active_locks.sort_by_key(|record| record.acquired_at);
+        // Retain *every* checkpoint of a kept run, not just its latest
+        // (`record.checkpoint_id`): a run that blocked, resumed, and blocked
+        // again keeps historical gate checkpoints that `approval_run_for_actor_and_gate`
+        // scans to resolve a run by an earlier gate.
         let mut checkpoints = self
             .checkpoints
             .iter()
-            .filter(|checkpoint| {
-                !recovery || kept_checkpoint_ids.contains(&checkpoint.checkpoint_id)
-            })
+            .filter(|checkpoint| !recovery || kept_run_ids.contains(&checkpoint.run_id))
             .cloned()
             .collect::<Vec<_>>();
         checkpoints.sort_by(|a, b| {
@@ -2224,9 +2230,7 @@ impl Inner {
         let mut loop_checkpoints = self
             .loop_checkpoints
             .values()
-            .filter(|checkpoint| {
-                !recovery || kept_checkpoint_ids.contains(&checkpoint.checkpoint_id)
-            })
+            .filter(|checkpoint| !recovery || kept_run_ids.contains(&checkpoint.run_id))
             .cloned()
             .collect::<Vec<_>>();
         loop_checkpoints.sort_by(|a, b| {

--- a/crates/ironclaw_turns/src/memory/mod.rs
+++ b/crates/ironclaw_turns/src/memory/mod.rs
@@ -527,9 +527,10 @@ impl InMemoryTurnStateStore {
             Err(poisoned) => poisoned.into_inner(),
         };
         let seq = self.persist_seq.fetch_add(1, Ordering::SeqCst);
-        // Durable writes persist the *compact recovery* snapshot (non-terminal
-        // runs + their referenced records, no audit events) — O(active runs), not
-        // O(total state). The full `persistence_snapshot()` stays the runtime
+        // Durable writes persist the *compact recovery* snapshot (live runs +
+        // their referenced records, plus terminal spawn-tree roots still anchoring
+        // a live reservation, no audit events) — O(active runs), not O(total
+        // state). The full `persistence_snapshot()` stays the runtime
         // read-model/projection surface.
         (seq, inner.recovery_snapshot())
     }
@@ -2123,13 +2124,15 @@ impl Inner {
         self.build_snapshot(SnapshotScope::Full)
     }
 
-    /// The compact snapshot durable writes persist: only the runs a restart must
+    /// The compact snapshot durable writes persist: the runs a restart must
     /// coordinate — the **non-terminal** ones (blocked + queued + running) — plus
-    /// their referential closure, with the audit event log dropped. Terminal runs
-    /// need no coordination recovery (a completed/failed run must not rehydrate as
-    /// live) and events exist only for audit/projection, so both are omitted. The
-    /// durable write is then O(active runs) instead of O(total accumulated state),
-    /// and a finished run cannot be structurally resurrected.
+    /// their referential closure, plus any *terminal* spawn-tree root still needed
+    /// to release a live descendant reservation, with the audit event log dropped.
+    /// Ordinary terminal runs need no coordination recovery (a completed/failed
+    /// run must not rehydrate as live) and events exist only for audit/projection,
+    /// so both are omitted. The durable write is then O(active runs) instead of
+    /// O(total accumulated state), and a finished run cannot be structurally
+    /// resurrected.
     ///
     /// The retained closure satisfies what `from_persistence_snapshot` requires:
     /// a run's turn must be present, and a blocked run keeps its thread lock,
@@ -2267,6 +2270,22 @@ impl Inner {
             })
             .collect::<Vec<_>>();
         spawn_tree_reservations.sort_by_key(|reservation| reservation.root_run_id.to_string());
+        // Recovery clears the audit event log, so every event up to the highest
+        // issued cursor becomes unavailable. Advance the retention floor to that
+        // high-water mark (over both the dropped events and every run's cursor) so
+        // a consumer with a stale cursor is told to rebase rather than silently
+        // reading an empty range — fail loud, no silent retention gap.
+        let event_retention_floor = if recovery {
+            self.events
+                .iter()
+                .map(|event| event.cursor)
+                .chain(self.records.values().map(|record| record.event_cursor))
+                .fold(self.event_retention_floor, |floor, cursor| {
+                    floor.max(cursor)
+                })
+        } else {
+            self.event_retention_floor
+        };
         TurnPersistenceSnapshot {
             turns,
             runs,
@@ -2274,14 +2293,15 @@ impl Inner {
             checkpoints,
             loop_checkpoints,
             idempotency_records,
-            // Recovery drops the audit-only event log (the unbounded bloat) and
-            // rebuilds the cursor from the kept runs' cursors + the retention floor.
+            // Recovery drops the audit-only event log (the unbounded bloat); the
+            // retention floor above marks everything up to the high-water mark as
+            // evicted so consumers rebase instead of replaying a missing range.
             events: if recovery {
                 Vec::new()
             } else {
                 self.events.clone()
             },
-            event_retention_floor: self.event_retention_floor,
+            event_retention_floor,
             admission_reservations,
             spawn_tree_reservations,
         }

--- a/crates/ironclaw_turns/src/memory/mod.rs
+++ b/crates/ironclaw_turns/src/memory/mod.rs
@@ -527,7 +527,11 @@ impl InMemoryTurnStateStore {
             Err(poisoned) => poisoned.into_inner(),
         };
         let seq = self.persist_seq.fetch_add(1, Ordering::SeqCst);
-        (seq, inner.persistence_snapshot())
+        // Durable writes persist the *compact recovery* snapshot (non-terminal
+        // runs + their referenced records, no audit events) — O(active runs), not
+        // O(total state). The full `persistence_snapshot()` stays the runtime
+        // read-model/projection surface.
+        (seq, inner.recovery_snapshot())
     }
 
     /// Persist the snapshot through the durable block sink, if one is attached.
@@ -2158,6 +2162,126 @@ impl Inner {
             loop_checkpoints,
             idempotency_records,
             events: self.events.clone(),
+            event_retention_floor: self.event_retention_floor,
+            admission_reservations,
+            spawn_tree_reservations,
+        }
+    }
+
+    /// A compact snapshot for durable recovery: only the runs a restart must
+    /// coordinate — the **non-terminal** ones (blocked + queued + running) — plus
+    /// exactly the records they reference. Terminal runs need no coordination
+    /// recovery (a completed/failed run must not rehydrate as live) and lifecycle
+    /// `events` exist only for audit/projection, so both are omitted. This makes
+    /// the durable write O(active runs) instead of O(total accumulated state),
+    /// and structurally prevents a finished run from being resurrected.
+    ///
+    /// The filter is closed under references: `from_persistence_snapshot` rejects
+    /// a run whose turn is absent, and blocked runs must keep their thread lock,
+    /// checkpoints, and admission/spawn reservations — so every kept run keeps its
+    /// turn, active lock, checkpoints, and reservations. Idempotency records are
+    /// kept whole (bounded by the store cap, no run-ref requirement) so recent
+    /// submit/resume/cancel dedup survives a restart. Concurrency counters and any
+    /// missing admission reservations are re-derived from the kept runs on load.
+    fn recovery_snapshot(&self) -> TurnPersistenceSnapshot {
+        let kept: Vec<&RunRecord> = self
+            .records
+            .values()
+            .filter(|record| !record.status.get().is_terminal())
+            .collect();
+        let kept_run_ids: HashSet<TurnRunId> = kept.iter().map(|record| record.run_id).collect();
+        let kept_turn_ids: HashSet<crate::TurnId> =
+            kept.iter().map(|record| record.turn_id).collect();
+        let kept_checkpoint_ids: HashSet<TurnCheckpointId> = kept
+            .iter()
+            .filter_map(|record| record.checkpoint_id)
+            .collect();
+        // Tree roots that still have a non-terminal run (root kept, or a kept
+        // descendant points at it) — keep those spawn-tree reservations so
+        // subagent capacity stays accurate across restart.
+        let live_tree_roots: HashSet<TurnRunId> = kept
+            .iter()
+            .map(|record| record.spawn_tree_root_run_id.unwrap_or(record.run_id))
+            .collect();
+
+        let mut runs = kept
+            .iter()
+            .map(|record| record.persistence_record())
+            .collect::<Vec<_>>();
+        runs.sort_by_key(|record| record.event_cursor);
+        let mut turns = self
+            .turns
+            .values()
+            .filter(|turn| kept_turn_ids.contains(&turn.turn_id))
+            .cloned()
+            .collect::<Vec<_>>();
+        turns.sort_by_key(|record| record.created_at);
+        let mut active_locks = self
+            .active_locks
+            .values()
+            .filter(|lock| kept_run_ids.contains(&lock.run_id))
+            .cloned()
+            .collect::<Vec<_>>();
+        active_locks.sort_by_key(|record| record.acquired_at);
+        let mut checkpoints = self
+            .checkpoints
+            .iter()
+            .filter(|checkpoint| kept_checkpoint_ids.contains(&checkpoint.checkpoint_id))
+            .cloned()
+            .collect::<Vec<_>>();
+        checkpoints.sort_by(|a, b| {
+            a.created_at
+                .cmp(&b.created_at)
+                .then_with(|| a.sequence.cmp(&b.sequence))
+        });
+        let mut loop_checkpoints = self
+            .loop_checkpoints
+            .values()
+            .filter(|checkpoint| kept_checkpoint_ids.contains(&checkpoint.checkpoint_id))
+            .cloned()
+            .collect::<Vec<_>>();
+        loop_checkpoints.sort_by(|a, b| {
+            a.created_at
+                .cmp(&b.created_at)
+                .then_with(|| a.checkpoint_id.as_uuid().cmp(&b.checkpoint_id.as_uuid()))
+        });
+        let mut idempotency_records = self
+            .idempotency_records
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
+        idempotency_records.sort_by_key(|record| record.created_at);
+        let mut admission_reservations = self
+            .admission_reservations
+            .values()
+            .filter(|reservation| kept_run_ids.contains(&reservation.run_id))
+            .cloned()
+            .collect::<Vec<_>>();
+        admission_reservations.sort_by_key(|reservation| reservation.run_id.to_string());
+        let mut spawn_tree_reservations = self
+            .tree_reservations
+            .iter()
+            .filter(|(key, _)| live_tree_roots.contains(&key.root_run_id))
+            .filter_map(|(key, descendant_count)| {
+                let root = self.records.get(&key.root_run_id)?;
+                Some(SpawnTreeReservation {
+                    scope: root.scope.clone(),
+                    root_run_id: key.root_run_id,
+                    descendant_count: *descendant_count,
+                })
+            })
+            .collect::<Vec<_>>();
+        spawn_tree_reservations.sort_by_key(|reservation| reservation.root_run_id.to_string());
+        TurnPersistenceSnapshot {
+            turns,
+            runs,
+            active_locks,
+            checkpoints,
+            loop_checkpoints,
+            idempotency_records,
+            // Dropped: audit-only lifecycle events are the unbounded bloat, and
+            // recovery reconstructs the cursor from the kept runs' event cursors.
+            events: Vec::new(),
             event_retention_floor: self.event_retention_floor,
             admission_reservations,
             spawn_tree_reservations,

--- a/crates/ironclaw_turns/tests/turn_coordinator_contract.rs
+++ b/crates/ironclaw_turns/tests/turn_coordinator_contract.rs
@@ -1048,10 +1048,10 @@ async fn blocked_run_persists_to_sink_and_rehydrates_across_restart() {
     );
 
     // A resumed run completes from `Running`, not from a blocked state. The
-    // durable snapshot must still converge to the terminal state so a restart
-    // does not rehydrate an already-finished run as a live `Queued`/`Running`
-    // run — persist-on-block tracks the gate-touched run through its terminal
-    // transition to guarantee this.
+    // compact recovery snapshot must converge by *dropping* the now-terminal run
+    // so a restart does not rehydrate an already-finished run as a live
+    // `Queued`/`Running` run — persist-on-block tracks the gate-touched run
+    // through its terminal transition to trigger that write.
     let resumed_runner_id = TurnRunnerId::new();
     let resumed_lease_token = TurnLeaseToken::new();
     store
@@ -1075,30 +1075,32 @@ async fn blocked_run_persists_to_sink_and_rehydrates_across_restart() {
     assert_eq!(
         after_complete.len(),
         4,
-        "completing a gate-resumed run must persist its terminal state"
+        "completing a gate-resumed run must persist the recovery-set change"
     );
     let terminal_snapshot = after_complete.last().unwrap().clone();
-    let terminal_run = terminal_snapshot
-        .runs
-        .iter()
-        .find(|record| record.run_id == run_id)
-        .expect("resumed run present in terminal snapshot");
-    assert_eq!(terminal_run.status, TurnStatus::Completed);
+    assert!(
+        terminal_snapshot
+            .runs
+            .iter()
+            .all(|record| record.run_id != run_id),
+        "a completed run must be absent from the compact recovery snapshot"
+    );
 
-    // Rehydrate from the terminal snapshot — the run must come back Completed,
-    // not Queued/Running, so recovery does not re-run a finished turn.
+    // Rehydrate from that snapshot — the finished run must not come back at all,
+    // so recovery cannot re-run it.
     let restored_terminal = InMemoryTurnStateStore::from_persistence_snapshot(
         terminal_snapshot,
         InMemoryTurnStateStoreLimits::default(),
     )
     .unwrap();
-    let restored_terminal_run = restored_terminal
-        .persistence_snapshot()
-        .runs
-        .into_iter()
-        .find(|record| record.run_id == run_id)
-        .expect("completed run survives rehydration");
-    assert_eq!(restored_terminal_run.status, TurnStatus::Completed);
+    assert!(
+        restored_terminal
+            .persistence_snapshot()
+            .runs
+            .iter()
+            .all(|record| record.run_id != run_id),
+        "a completed run must not be resurrected on rehydration"
+    );
 }
 
 /// A run recovered *from a restart snapshot* while blocked must still receive a
@@ -1196,21 +1198,18 @@ async fn rehydrated_blocked_run_persists_terminal_state_after_resume() {
         .await
         .unwrap();
 
-    // Completing the recovered run must have persisted its terminal state, so a
-    // subsequent restart rehydrates it as Completed, not live.
+    // Completing the recovered run must persist the recovery-set change, dropping
+    // the now-terminal run so a subsequent restart cannot rehydrate it as live.
     let terminal_snapshot = restored_sink
         .snapshots()
         .pop()
         .expect("terminal persist after recovery resume/complete");
-    let terminal_run = terminal_snapshot
-        .runs
-        .iter()
-        .find(|record| record.run_id == run_id)
-        .expect("recovered run present in terminal snapshot");
-    assert_eq!(
-        terminal_run.status,
-        TurnStatus::Completed,
-        "recovered gate-blocked run must persist its terminal state, not stay Queued/Running"
+    assert!(
+        terminal_snapshot
+            .runs
+            .iter()
+            .all(|record| record.run_id != run_id),
+        "a recovered gate-blocked run that completes must be dropped from the recovery snapshot, not left as live"
     );
 }
 
@@ -1322,15 +1321,12 @@ async fn rehydrated_resumed_run_persists_terminal_state() {
         .snapshots()
         .pop()
         .expect("terminal persist after recovered resumed run completes");
-    assert_eq!(
+    assert!(
         terminal_snapshot
             .runs
             .iter()
-            .find(|record| record.run_id == run_id)
-            .expect("recovered resumed run present in terminal snapshot")
-            .status,
-        TurnStatus::Completed,
-        "a resumed gate-touched run recovered from a restart must still persist its terminal state"
+            .all(|record| record.run_id != run_id),
+        "a resumed gate-touched run recovered from a restart must be dropped from the recovery snapshot once it completes"
     );
 }
 
@@ -1397,6 +1393,143 @@ async fn flush_persists_in_flight_non_blocked_run() {
             .iter()
             .any(|record| record.run_id == run_id),
         "in-flight run survives flush + rehydration"
+    );
+}
+
+/// The durable snapshot written on flush/persist is the **compact recovery
+/// snapshot**, not the full runtime read-model: it keeps only non-terminal runs
+/// (and their referential closure) and drops the replayable event log, which the
+/// runtime rebuilds from its own source-of-truth on restart. This is the core of
+/// the blocked-subset/delta recovery design — a completed run carries no
+/// in-flight coordination state worth recovering, so persisting it only bloats
+/// every write and risks resurrecting a finished turn. Referential integrity
+/// must still hold: every kept run's turn survives so rehydration succeeds.
+#[tokio::test]
+async fn flush_recovery_snapshot_keeps_active_runs_drops_terminal_and_events() {
+    let sink = Arc::new(RecordingBlockPersistence::default());
+    let store = Arc::new(InMemoryTurnStateStore::default().with_block_persistence(sink.clone()));
+    let coordinator = DefaultTurnCoordinator::new(store.clone());
+
+    // Run A: completed → terminal, must be dropped from the recovery snapshot.
+    let done_run = accepted_run_id(
+        &coordinator
+            .submit_turn(submit_request("thread-done", "idem-done"))
+            .await
+            .unwrap(),
+    );
+    complete_queued_run(&store, done_run, "thread-done").await;
+
+    // Run B: claimed and left Running (in-flight, never blocked) → kept.
+    let running_run = accepted_run_id(
+        &coordinator
+            .submit_turn(submit_request("thread-running", "idem-running"))
+            .await
+            .unwrap(),
+    );
+    let running_runner = TurnRunnerId::new();
+    let running_lease = TurnLeaseToken::new();
+    store
+        .claim_next_run(ClaimRunRequest {
+            runner_id: running_runner,
+            lease_token: running_lease,
+            scope_filter: Some(scope("thread-running")),
+        })
+        .await
+        .unwrap()
+        .unwrap();
+
+    // Run C: claimed then gate-blocked (Approval) → kept.
+    let blocked_run = accepted_run_id(
+        &coordinator
+            .submit_turn(submit_request("thread-blocked", "idem-blocked"))
+            .await
+            .unwrap(),
+    );
+    let blocked_runner = TurnRunnerId::new();
+    let blocked_lease = TurnLeaseToken::new();
+    store
+        .claim_next_run(ClaimRunRequest {
+            runner_id: blocked_runner,
+            lease_token: blocked_lease,
+            scope_filter: Some(scope("thread-blocked")),
+        })
+        .await
+        .unwrap()
+        .unwrap();
+    store
+        .block_run(BlockRunRequest {
+            run_id: blocked_run,
+            runner_id: blocked_runner,
+            lease_token: blocked_lease,
+            checkpoint_id: TurnCheckpointId::new(),
+            state_ref: block_state_ref(),
+            reason: BlockedReason::Approval {
+                gate_ref: GateRef::new("recovery-gate").unwrap(),
+            },
+        })
+        .await
+        .unwrap();
+
+    store.flush().await;
+    let snapshot = sink
+        .snapshots()
+        .pop()
+        .expect("flush must persist a snapshot");
+
+    // Terminal run dropped; active runs kept with their live status.
+    assert!(
+        snapshot.runs.iter().all(|record| record.run_id != done_run),
+        "a completed run carries no in-flight state and must be dropped from the recovery snapshot"
+    );
+    assert_eq!(
+        snapshot
+            .runs
+            .iter()
+            .find(|record| record.run_id == running_run)
+            .expect("in-flight running run kept")
+            .status,
+        TurnStatus::Running,
+    );
+    assert_eq!(
+        snapshot
+            .runs
+            .iter()
+            .find(|record| record.run_id == blocked_run)
+            .expect("gate-blocked run kept")
+            .status,
+        TurnStatus::BlockedApproval,
+    );
+
+    // The replayable event log is not part of the recovery snapshot.
+    assert!(
+        snapshot.events.is_empty(),
+        "recovery snapshot must drop the replayable event log, got {} events",
+        snapshot.events.len()
+    );
+
+    // Referential integrity: kept runs' turns survive, so rehydration succeeds
+    // and recovers exactly the two active runs (never the terminal one).
+    let restored = InMemoryTurnStateStore::from_persistence_snapshot(
+        snapshot,
+        InMemoryTurnStateStoreLimits::default(),
+    )
+    .expect("compact recovery snapshot must rehydrate (referential closure intact)");
+    let restored_runs = restored.persistence_snapshot().runs;
+    assert!(
+        restored_runs
+            .iter()
+            .any(|record| record.run_id == running_run),
+        "in-flight running run survives rehydration"
+    );
+    assert!(
+        restored_runs
+            .iter()
+            .any(|record| record.run_id == blocked_run),
+        "gate-blocked run survives rehydration"
+    );
+    assert!(
+        restored_runs.iter().all(|record| record.run_id != done_run),
+        "terminal run is never resurrected on rehydration"
     );
 }
 

--- a/crates/ironclaw_turns/tests/turn_coordinator_contract.rs
+++ b/crates/ironclaw_turns/tests/turn_coordinator_contract.rs
@@ -1533,6 +1533,181 @@ async fn flush_recovery_snapshot_keeps_active_runs_drops_terminal_and_events() {
     );
 }
 
+/// Regression: a run that blocked on one gate, resumed, then blocked on another
+/// accumulates *two* historical checkpoints while `record.checkpoint_id` tracks
+/// only the latest. The recovery snapshot must retain every checkpoint of a kept
+/// run — `approval_run_for_actor_and_gate` scans historical checkpoints to
+/// resolve a run by an *earlier* gate, so keeping only the latest would make that
+/// lookup fail after a restart.
+#[tokio::test]
+async fn recovery_snapshot_retains_historical_gate_checkpoints_of_active_runs() {
+    let sink = Arc::new(RecordingBlockPersistence::default());
+    let store = Arc::new(InMemoryTurnStateStore::default().with_block_persistence(sink.clone()));
+    let coordinator = DefaultTurnCoordinator::new(store.clone());
+    let thread = "thread-multi-gate";
+    let run_id = accepted_run_id(
+        &coordinator
+            .submit_turn(submit_request(thread, "idem-multi-gate"))
+            .await
+            .unwrap(),
+    );
+    let gate_a = GateRef::new("multi-gate-a").unwrap();
+    let gate_b = GateRef::new("multi-gate-b").unwrap();
+
+    // Block on gate A.
+    let runner_a = TurnRunnerId::new();
+    let lease_a = TurnLeaseToken::new();
+    store
+        .claim_next_run(ClaimRunRequest {
+            runner_id: runner_a,
+            lease_token: lease_a,
+            scope_filter: Some(scope(thread)),
+        })
+        .await
+        .unwrap()
+        .unwrap();
+    store
+        .block_run(BlockRunRequest {
+            run_id,
+            runner_id: runner_a,
+            lease_token: lease_a,
+            checkpoint_id: TurnCheckpointId::new(),
+            state_ref: block_state_ref(),
+            reason: BlockedReason::Approval {
+                gate_ref: gate_a.clone(),
+            },
+        })
+        .await
+        .unwrap();
+
+    // Resume gate A, then claim and block again on gate B — now two checkpoints.
+    store
+        .resume_turn(ResumeTurnRequest {
+            scope: scope(thread),
+            actor: actor(),
+            run_id,
+            gate_resolution_ref: gate_a.clone(),
+            source_binding_ref: SourceBindingRef::new("src-multi").unwrap(),
+            reply_target_binding_ref: ReplyTargetBindingRef::new("reply-multi").unwrap(),
+            idempotency_key: IdempotencyKey::new("idem-multi-resume").unwrap(),
+            precondition: ironclaw_turns::ResumeTurnPrecondition::BlockedApprovalGate,
+            resume_disposition: None,
+        })
+        .await
+        .unwrap();
+    let runner_b = TurnRunnerId::new();
+    let lease_b = TurnLeaseToken::new();
+    store
+        .claim_next_run(ClaimRunRequest {
+            runner_id: runner_b,
+            lease_token: lease_b,
+            scope_filter: Some(scope(thread)),
+        })
+        .await
+        .unwrap()
+        .unwrap();
+    store
+        .block_run(BlockRunRequest {
+            run_id,
+            runner_id: runner_b,
+            lease_token: lease_b,
+            checkpoint_id: TurnCheckpointId::new(),
+            state_ref: block_state_ref(),
+            reason: BlockedReason::Approval {
+                gate_ref: gate_b.clone(),
+            },
+        })
+        .await
+        .unwrap();
+
+    // Recover across a restart.
+    store.flush().await;
+    let snapshot = sink
+        .snapshots()
+        .pop()
+        .expect("flush must persist a snapshot");
+    let restored = InMemoryTurnStateStore::from_persistence_snapshot(
+        snapshot,
+        InMemoryTurnStateStoreLimits::default(),
+    )
+    .unwrap();
+
+    // The earlier (gate-A) checkpoint survived, so the run is still resolvable by
+    // its first gate — not only its latest.
+    assert_eq!(
+        restored
+            .approval_run_for_actor_and_gate(&scope(thread), &actor(), &gate_a)
+            .unwrap(),
+        Some(run_id),
+        "historical gate-A checkpoint must survive recovery so the approval lookup resolves the run"
+    );
+}
+
+/// Regression: a *terminal* spawn-tree root that still backs a live descendant
+/// reservation must be retained in the recovery snapshot.
+/// `reserve_/release_tree_descendants` resolve the root through `records`, so
+/// dropping the terminal root would strand the release with `ScopeNotFound` after
+/// a restart and leak the reserved subagent capacity.
+#[tokio::test]
+async fn recovery_snapshot_keeps_terminal_spawn_tree_root_with_live_reservation() {
+    let sink = Arc::new(RecordingBlockPersistence::default());
+    let store = Arc::new(InMemoryTurnStateStore::default().with_block_persistence(sink.clone()));
+    let coordinator = DefaultTurnCoordinator::new(store.clone());
+    let parent_scope = scope("thread-tree-recover");
+    let parent_run_id = accepted_run_id(
+        &coordinator
+            .submit_turn(submit_request("thread-tree-recover", "idem-tree-recover"))
+            .await
+            .unwrap(),
+    );
+    store
+        .reserve_tree_descendants(&parent_scope, parent_run_id, 1, 3)
+        .await
+        .unwrap();
+    complete_queued_run(&store, parent_run_id, "thread-tree-recover").await;
+    // The root is now terminal but still roots a live descendant reservation.
+
+    store.flush().await;
+    let snapshot = sink
+        .snapshots()
+        .pop()
+        .expect("flush must persist a snapshot");
+    assert!(
+        snapshot
+            .spawn_tree_reservations
+            .iter()
+            .any(|reservation| reservation.root_run_id == parent_run_id),
+        "a live reservation must survive recovery"
+    );
+    assert!(
+        snapshot
+            .runs
+            .iter()
+            .any(|record| record.run_id == parent_run_id),
+        "the terminal root backing a live reservation must be retained so its release can resolve it"
+    );
+
+    let restored = Arc::new(
+        InMemoryTurnStateStore::from_persistence_snapshot(
+            snapshot,
+            InMemoryTurnStateStoreLimits::default(),
+        )
+        .unwrap(),
+    );
+    assert!(
+        restored
+            .get_run_record(&parent_scope, parent_run_id)
+            .await
+            .unwrap()
+            .is_some(),
+        "root record survives rehydration"
+    );
+    restored
+        .release_tree_descendants(&parent_scope, parent_run_id, 1)
+        .await
+        .expect("release must resolve the retained terminal root, not fail ScopeNotFound");
+}
+
 #[tokio::test]
 async fn default_turn_coordinator_publishes_lifecycle_events_to_sink() {
     let store = Arc::new(InMemoryTurnStateStore::default());

--- a/crates/ironclaw_turns/tests/turn_coordinator_contract.rs
+++ b/crates/ironclaw_turns/tests/turn_coordinator_contract.rs
@@ -1708,6 +1708,73 @@ async fn recovery_snapshot_keeps_terminal_spawn_tree_root_with_live_reservation(
         .expect("release must resolve the retained terminal root, not fail ScopeNotFound");
 }
 
+/// Regression: recovery drops the audit event log, so it must advance the
+/// retention floor to the high-water cursor. Otherwise a consumer holding a
+/// stale cursor below the floor would silently read an empty range after a
+/// restart instead of being told to rebase past the evicted events.
+#[tokio::test]
+async fn recovery_snapshot_advances_retention_floor_past_dropped_events() {
+    let sink = Arc::new(RecordingBlockPersistence::default());
+    let store = Arc::new(InMemoryTurnStateStore::default().with_block_persistence(sink.clone()));
+    let coordinator = DefaultTurnCoordinator::new(store.clone());
+    let thread = "thread-floor";
+    let run_id = accepted_run_id(
+        &coordinator
+            .submit_turn(submit_request(thread, "idem-floor"))
+            .await
+            .unwrap(),
+    );
+    // Claim + block advances the run's event cursor above the initial floor (0).
+    let runner = TurnRunnerId::new();
+    let lease = TurnLeaseToken::new();
+    store
+        .claim_next_run(ClaimRunRequest {
+            runner_id: runner,
+            lease_token: lease,
+            scope_filter: Some(scope(thread)),
+        })
+        .await
+        .unwrap()
+        .unwrap();
+    store
+        .block_run(BlockRunRequest {
+            run_id,
+            runner_id: runner,
+            lease_token: lease,
+            checkpoint_id: TurnCheckpointId::new(),
+            state_ref: block_state_ref(),
+            reason: BlockedReason::Approval {
+                gate_ref: GateRef::new("floor-gate").unwrap(),
+            },
+        })
+        .await
+        .unwrap();
+
+    store.flush().await;
+    let snapshot = sink
+        .snapshots()
+        .pop()
+        .expect("flush must persist a snapshot");
+    assert!(
+        snapshot.events.is_empty(),
+        "recovery drops the audit event log"
+    );
+    // The blocked run's own events were dropped with the log, so the floor must
+    // now cover its cursor — a consumer below it must rebase, not read empty.
+    let kept_cursor = snapshot
+        .runs
+        .iter()
+        .find(|record| record.run_id == run_id)
+        .expect("blocked run kept")
+        .event_cursor;
+    assert!(
+        snapshot.event_retention_floor >= kept_cursor,
+        "clearing the event log must advance the retention floor past dropped events ({:?} < {:?})",
+        snapshot.event_retention_floor,
+        kept_cursor,
+    );
+}
+
 #[tokio::test]
 async fn default_turn_coordinator_publishes_lifecycle_events_to_sink() {
     let store = Arc::new(InMemoryTurnStateStore::default());


### PR DESCRIPTION
## Summary

- Durable turn-state writes (persist-on-block and graceful `flush`) now persist a **compact recovery snapshot** instead of the full runtime read-model. The shared write path (`snapshot_with_seq`) routes through `build_snapshot(SnapshotScope::Recovery)`.
- Recovery keeps only the runs a restart must coordinate — **non-terminal** runs (blocked/queued/running) plus their referential closure (turns, active locks, checkpoints, admission + spawn-tree reservations, idempotency records) — and **drops the audit event log**. The durable payload is O(active runs), not O(total accumulated state), and a terminal run can no longer be structurally resurrected.
- `persistence_snapshot()` is unchanged and remains the full projection / rehydration read-model; both shapes are now assembled by one parameterized `build_snapshot(SnapshotScope)` so the collect/sort logic and field set live in exactly one place.
- Review-driven correctness fixes: retain terminal spawn-tree roots that still back a live reservation, and retain **all** historical checkpoints of active runs (not just each run's latest) so `approval_run_for_actor_and_gate` still resolves a run by an earlier gate after restart.

## Change Type

- [x] Bug fix <!-- the two review-driven recovery-filter fixes -->
- [ ] New feature
- [x] Refactor <!-- single scoped snapshot builder -->
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

(Primarily performance — realizes an O(active-runs) durable write — plus two correctness fixes found in review.)

## Linked Issue

None. Optimization + correctness follow-up to the in-memory turn-state authority (#5486, merged) and its graceful-flush durability. Independent of the enablement PR (#5492), which wires the `inmemory-turn-state` feature into the shipped binary — this changes only what gets written, not whether the path is active.

## Validation

Built and tested against the affected crate in isolation (rustc 1.96). The full workspace has a github.com git dependency (`monty`, via `ironclaw_engine`) that the environment's egress policy denies, so cargo cannot resolve the whole workspace here — please run the standard gate in CI.

- [x] `cargo fmt` on the changed crate — clean
- [x] `cargo clippy -p ironclaw_turns --all-targets` — clean
- [x] `cargo build -p ironclaw_turns`
- [x] Relevant tests pass: full `ironclaw_turns` suite (incl. `turn_coordinator_contract`) green. New/updated tests:
  - `flush_recovery_snapshot_keeps_active_runs_drops_terminal_and_events` — terminal run dropped, running + blocked kept with live status, event log empty, rehydration recovers exactly the active runs.
  - `recovery_snapshot_retains_historical_gate_checkpoints_of_active_runs` — block→resume→block on a second gate, then assert `approval_run_for_actor_and_gate` resolves the run by gate A after rehydration (verified red before the fix).
  - `recovery_snapshot_keeps_terminal_spawn_tree_root_with_live_reservation` — terminal root + live reservation survives; `release_tree_descendants` resolves after rehydration instead of `ScopeNotFound` (verified red before the fix).
  - Three existing terminal-convergence tests flipped from "terminal run present" to "terminal run absent" assertions.
- [ ] `cargo test --features integration` — not run (workspace resolution blocked as above); no DB/schema change in this PR.
- [x] Coding agent review run before requesting review (thermo-nuclear code-quality pass + addressed CodeRabbit/Gemini findings).

## Security Impact

None. No change to permissions, network, secrets, file access, tool execution, or sandbox policy. This only narrows which in-memory coordination state is serialized to the existing durable block sink.

## Reborn Trust-Boundary Checklist

- [x] Public policy/evidence/trust-bearing types: none added or changed.
- [x] Untrusted content enters prompts only through an envelope/escaping primitive: N/A — turn state stores refs/metadata only, no prompt/assistant content (crate invariant).
- [x] Hashes: none added.
- [x] New/changed status/exit/policy/runtime/error variants: none. `SnapshotScope` is a private in-crate enum, never serialized.
- [x] Security/durability `serde(default)` fields: none added. Recovery reuses the existing `TurnPersistenceSnapshot` wire type; `from_persistence_snapshot` still enforces every run's turn is present.
- [x] Queues/maps/buffers/counters bounds: unchanged; recovery strictly *reduces* what is persisted. Idempotency records remain store-capped.
- [x] Driver/operator-visible errors: unchanged.
- [x] Sandbox/native/host names: unchanged.

## Database Impact

None. No migration, no schema change. Reuses the existing `TurnStateBlockPersistence` sink and `TurnPersistenceSnapshot` type; both PostgreSQL and libSQL are unaffected (turn-state durability is the filesystem block sink behind the in-memory authority).

## Blast Radius

`ironclaw_turns` in-memory store only — the durable snapshot builder (`build_snapshot`/`recovery_snapshot`) and the `snapshot_with_seq` write path. `persistence_snapshot()` output is byte-identical (the `Full` scope short-circuits every recovery filter), so the projection/rehydration read-model surface is unchanged. Risk is confined to what a restart recovers; covered by the contract suite above.

## Rollback Plan

Revert this PR — `snapshot_with_seq` returns to persisting the full `persistence_snapshot()`. Safe in both directions: the compact snapshot is a strict subset of the full snapshot and rehydrates through the same `from_persistence_snapshot` path, so a snapshot written by either version loads under the other. No data migration involved (turn state holds coordination metadata only).

## Review Follow-Through

- Two correctness findings raised in review (terminal spawn-tree root; historical gate checkpoints) are fixed and regression-tested through their real callers; both threads resolved.
- Not addressed here (matches `persistence_snapshot` behavior, out of scope): a spawn-tree reservation whose root record is entirely absent from `records` is still dropped by the existing `filter_map(...get()?)` construction — a pre-existing invariant-violation path, not introduced by this change.

---

**Review track**: C (runtime / durable state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)