### PR TITLE
Preserve model-visible capability output observations

### DIFF
--- a/crates/ironclaw_agent_loop/src/executor/capabilities.rs
+++ b/crates/ironclaw_agent_loop/src/executor/capabilities.rs
@@ -433,6 +433,7 @@ impl ExecutorStage<CapabilityInput> for CapabilityStage {
                             terminate_hint: false,
                             byte_len,
                             output_digest: None,
+                            model_observation: None,
                         };
                         append_completed_capability_result(
                             ctx.host,
@@ -724,6 +725,7 @@ impl CapabilityStage {
                     terminate_hint: false,
                     byte_len,
                     output_digest: None,
+                    model_observation: None,
                 };
                 AwaitDependentRunGateStage
                     .process(
@@ -1236,6 +1238,7 @@ async fn append_spawned_child_result(
         terminate_hint: false,
         byte_len,
         output_digest: None,
+        model_observation: None,
     };
     append_completed_capability_result(host, state, call, result, capability_batch).await
 }
@@ -1375,6 +1378,7 @@ mod tests {
             terminate_hint: false,
             byte_len: 0,
             output_digest: None,
+            model_observation: None,
         })
     }
 

--- a/crates/ironclaw_agent_loop/src/executor/capability_helpers.rs
+++ b/crates/ironclaw_agent_loop/src/executor/capability_helpers.rs
@@ -231,7 +231,7 @@ pub(super) async fn append_capability_result_ref(
         result_ref: result.result_ref.clone(),
         safe_summary: result.safe_summary.clone(),
         provider_call: provider_tool_call_reference(call),
-        model_observation: None,
+        model_observation: result.model_observation.clone(),
     })
     .await
     .map_err(capability_host_error)?;
@@ -599,6 +599,7 @@ mod tests {
             terminate_hint: false,
             byte_len: 1000,
             output_digest: None,
+            model_observation: None,
         };
         let result_a2 = CapabilityResultMessage {
             result_ref: ironclaw_turns::LoopResultRef::new("result:a2".to_string()).unwrap(),
@@ -607,6 +608,7 @@ mod tests {
             terminate_hint: false,
             byte_len: 500,
             output_digest: None,
+            model_observation: None,
         };
         let result_b = CapabilityResultMessage {
             result_ref: ironclaw_turns::LoopResultRef::new("result:b".to_string()).unwrap(),
@@ -615,6 +617,7 @@ mod tests {
             terminate_hint: false,
             byte_len: 2000,
             output_digest: None,
+            model_observation: None,
         };
         push_completed_result(&mut state, &cap_a, result_a1);
         push_completed_result(&mut state, &cap_a, result_a2);

--- a/crates/ironclaw_agent_loop/src/executor/tests.rs
+++ b/crates/ironclaw_agent_loop/src/executor/tests.rs
@@ -10,9 +10,10 @@ use ironclaw_turns::{
         LoopCancelReasonKind, LoopCheckpointKind, LoopCompactionError, LoopCompactionOutcome,
         LoopCompactionResponse, LoopContextCompactionKind, LoopInput, LoopInputAckToken,
         LoopInputBatch, LoopInputCursor, LoopInterruptKind, LoopProcessRef, LoopProgressEvent,
-        LoopRunInfoPort, LoopSafeSummary, LoopSummaryArtifactId, ObservationTrust,
-        ParentLoopOutput, ProcessHandleSummary, ProviderToolCallReplay, SameCallRetryConstraint,
-        ToolObservationDetail, ToolObservationStatus, VisibleCapabilityRequest,
+        LoopRunInfoPort, LoopSafeSummary, LoopSummaryArtifactId, ModelVisibleToolObservation,
+        ObservationTrust, ParentLoopOutput, ProcessHandleSummary, ProviderToolCallReplay,
+        SameCallRetryConstraint, ToolObservationDetail, ToolObservationStatus,
+        VisibleCapabilityRequest,
     },
 };
 
@@ -1225,6 +1226,7 @@ async fn reply_admission_rejects_candidate_before_finalizing_and_continues() {
                 terminate_hint: false,
                 byte_len: 0,
                 output_digest: None,
+                model_observation: None,
             })],
             stopped_on_suspension: false,
         }]);
@@ -1296,6 +1298,7 @@ async fn reply_admission_rendered_flag_stays_false_when_context_suppresses_contr
                 terminate_hint: false,
                 byte_len: 0,
                 output_digest: None,
+                model_observation: None,
             })],
             stopped_on_suspension: false,
         }]);
@@ -1466,6 +1469,7 @@ async fn capability_stage_returns_after_batch_summary() {
                 terminate_hint: false,
                 byte_len: 0,
                 output_digest: None,
+                model_observation: None,
             })],
             stopped_on_suspension: false,
         },
@@ -1829,6 +1833,7 @@ async fn stopped_on_suspension_completed_outcome_still_appends_result() {
                 terminate_hint: true,
                 byte_len: 0,
                 output_digest: None,
+                model_observation: None,
             })],
             stopped_on_suspension: true,
         },
@@ -1920,6 +1925,7 @@ async fn terminate_hint_after_batch_completes_without_extra_model_call() {
                 terminate_hint: true,
                 byte_len: 0,
                 output_digest: None,
+                model_observation: None,
             })],
             stopped_on_suspension: false,
         },
@@ -2058,6 +2064,7 @@ async fn approval_resume_metadata_is_replayed_after_before_block_checkpoint() {
                 terminate_hint: true,
                 byte_len: 0,
                 output_digest: None,
+                model_observation: None,
             })],
             stopped_on_suspension: false,
         },
@@ -2289,6 +2296,7 @@ async fn parallel_batch_records_completed_results_before_blocking_on_suspension(
                     terminate_hint: false,
                     byte_len: 0,
                     output_digest: None,
+                    model_observation: None,
                 }),
             ],
             stopped_on_suspension: false,
@@ -2349,6 +2357,7 @@ async fn capability_batch_rejects_outcome_count_exceeding_invocation_count() {
                     terminate_hint: false,
                     byte_len: 0,
                     output_digest: None,
+                    model_observation: None,
                 }),
                 CapabilityOutcome::Completed(CapabilityResultMessage {
                     result_ref: LoopResultRef::new("result:second").expect("valid"),
@@ -2357,6 +2366,7 @@ async fn capability_batch_rejects_outcome_count_exceeding_invocation_count() {
                     terminate_hint: false,
                     byte_len: 0,
                     output_digest: None,
+                    model_observation: None,
                 }),
             ],
             stopped_on_suspension: true,
@@ -2580,6 +2590,7 @@ async fn terminate_hint_counts_only_visible_invoked_calls() {
                 terminate_hint: true,
                 byte_len: 0,
                 output_digest: None,
+                model_observation: None,
             })],
             stopped_on_suspension: false,
         },
@@ -2671,6 +2682,7 @@ async fn retry_uses_single_call_invocation() {
                     terminate_hint: true,
                     byte_len: 0,
                     output_digest: None,
+                    model_observation: None,
                 },
             )]);
         let executor = CanonicalAgentLoopExecutor;
@@ -2707,6 +2719,7 @@ async fn policy_denied_capability_error_honors_retry_recovery() {
                 terminate_hint: true,
                 byte_len: 0,
                 output_digest: None,
+                model_observation: None,
             },
         )]);
     let executor = CanonicalAgentLoopExecutor;
@@ -2832,6 +2845,7 @@ async fn completed_provider_call_appends_provider_replay_metadata() {
                 terminate_hint: true,
                 byte_len: 0,
                 output_digest: None,
+                model_observation: None,
             })],
             stopped_on_suspension: false,
         },
@@ -2879,6 +2893,7 @@ async fn denied_provider_call_appends_failure_tool_result_for_replay() {
                     terminate_hint: true,
                     byte_len: 0,
                     output_digest: None,
+                    model_observation: None,
                 }),
                 CapabilityOutcome::Denied(ironclaw_turns::run_profile::CapabilityDenied {
                     reason_kind:
@@ -2996,6 +3011,45 @@ async fn invalid_provider_tool_failure_appends_structured_model_observation() {
             path: "file_path".to_string()
         }]
     );
+}
+
+#[tokio::test]
+async fn completed_provider_tool_result_appends_model_visible_output_observation() {
+    let observation = ModelVisibleToolObservation {
+        schema_version: ironclaw_turns::run_profile::MODEL_VISIBLE_TOOL_OBSERVATION_SCHEMA_VERSION,
+        status: ToolObservationStatus::Success,
+        summary: "Tool completed.".to_string(),
+        detail: ToolObservationDetail::Output {
+            content: serde_json::json!({"path": "notes.md", "content": "remembered"}),
+        },
+        artifacts: Vec::new(),
+        recovery: None,
+        trust: ObservationTrust::UntrustedToolOutput,
+    };
+    let host = MockHost::new(vec![provider_calls_response(), reply_response()])
+        .with_batch_outcomes(vec![ironclaw_turns::run_profile::CapabilityBatchOutcome {
+            outcomes: vec![CapabilityOutcome::Completed(CapabilityResultMessage {
+                result_ref: LoopResultRef::new("result:memory-read").expect("valid result ref"),
+                safe_summary: "capability completed".to_string(),
+                progress: ironclaw_turns::run_profile::CapabilityProgress::MadeProgress,
+                terminate_hint: false,
+                byte_len: 64,
+                output_digest: None,
+                model_observation: Some(observation.clone()),
+            })],
+            stopped_on_suspension: false,
+        }]);
+    let executor = CanonicalAgentLoopExecutor;
+    let state = LoopExecutionState::initial_for_run(host.run_context());
+
+    executor
+        .execute_family(&crate::families::default(), &host, state)
+        .await
+        .expect("execute");
+
+    let appended = host.appended_result_refs();
+    assert_eq!(appended.len(), 1);
+    assert_eq!(appended[0].model_observation, Some(observation));
 }
 
 #[tokio::test]
@@ -3119,6 +3173,7 @@ async fn completed_output_digest_is_recorded_into_seen_capability_output_digests
                 terminate_hint: true,
                 byte_len: 0,
                 output_digest: Some(digest),
+                model_observation: None,
             })],
             stopped_on_suspension: false,
         },
@@ -3425,6 +3480,7 @@ async fn executor_post_capability_trips_policy_and_sets_flags_in_final_state() {
                 // Exceeds the default 32 000-byte cap for unknown capability ids.
                 byte_len: 33_001,
                 output_digest: None,
+                model_observation: None,
             })],
             stopped_on_suspension: false,
         },
@@ -3488,6 +3544,7 @@ async fn executor_post_capability_does_not_trip_under_threshold() {
                 terminate_hint: true,
                 byte_len: 100, // well under the 32 000-byte default cap
                 output_digest: None,
+                model_observation: None,
             })],
             stopped_on_suspension: false,
         },
@@ -3535,6 +3592,7 @@ async fn executor_skip_model_turn_bypasses_model_stage() {
                 terminate_hint: false, // loop must continue so SkipModel fires
                 byte_len: 33_001,
                 output_digest: None,
+                model_observation: None,
             })],
             stopped_on_suspension: false,
         },
@@ -3647,6 +3705,7 @@ async fn executor_batch_accumulates_per_capability_bytes_and_trips() {
                     terminate_hint: true, // exit after batch so we can inspect state
                     byte_len: 20_000,
                     output_digest: None,
+                    model_observation: None,
                 }),
                 CapabilityOutcome::Completed(CapabilityResultMessage {
                     result_ref: LoopResultRef::new("result:second").expect("valid"),
@@ -3655,6 +3714,7 @@ async fn executor_batch_accumulates_per_capability_bytes_and_trips() {
                     terminate_hint: true,
                     byte_len: 20_000,
                     output_digest: None,
+                    model_observation: None,
                 }),
             ],
             stopped_on_suspension: false,
@@ -3877,6 +3937,7 @@ async fn executor_emits_compaction_started_with_capability_result_overflow_initi
                 terminate_hint: false, // loop must continue so SkipModel iteration fires
                 byte_len: 33_001,      // exceeds the 32 000-byte default cap
                 output_digest: None,
+                model_observation: None,
             })],
             stopped_on_suspension: false,
         }])
@@ -4324,6 +4385,7 @@ async fn parallel_batch_records_completed_results_before_external_tool_block() {
                     terminate_hint: false,
                     byte_len: 0,
                     output_digest: None,
+                    model_observation: None,
                 }),
                 CapabilityOutcome::ExternalToolPending {
                     gate_ref: external_gate_ref.clone(),
@@ -4381,6 +4443,7 @@ async fn resume_after_external_tool_gate_redispatches_without_model_turn() {
                     terminate_hint: true,
                     byte_len: 0,
                     output_digest: None,
+                    model_observation: None,
                 },
             )],
             stopped_on_suspension: false,
@@ -4457,6 +4520,7 @@ async fn resume_after_auth_gate_redispatches_original_call_without_model_turn() 
                     terminate_hint: true,
                     byte_len: 0,
                     output_digest: None,
+                    model_observation: None,
                 },
             )],
             stopped_on_suspension: false,
@@ -4628,6 +4692,7 @@ async fn auth_resume_provider_registration_failure_fails_before_invocation() {
                         terminate_hint: true,
                         byte_len: 0,
                         output_digest: None,
+                        model_observation: None,
                     },
                 )],
                 stopped_on_suspension: false,
@@ -4698,6 +4763,7 @@ async fn auth_resume_provider_activity_remap_fails_before_invocation() {
                     terminate_hint: true,
                     byte_len: 0,
                     output_digest: None,
+                    model_observation: None,
                 },
             )],
             stopped_on_suspension: false,
@@ -5190,6 +5256,7 @@ async fn auth_resume_after_approval_carries_resume_token_and_approval_request_id
                     terminate_hint: true,
                     byte_len: 0,
                     output_digest: None,
+                    model_observation: None,
                 },
             )],
             stopped_on_suspension: false,
@@ -5432,6 +5499,7 @@ async fn auth_resume_after_approval_carries_original_correlation_id() {
                     terminate_hint: true,
                     byte_len: 0,
                     output_digest: None,
+                    model_observation: None,
                 },
             )],
             stopped_on_suspension: false,
@@ -5567,6 +5635,7 @@ async fn auth_resume_slot_consumed_on_first_batch_match_not_reused_for_second_ca
                         terminate_hint: false,
                         byte_len: 0,
                         output_digest: None,
+                        model_observation: None,
                     },
                 ),
                 CapabilityOutcome::Completed(
@@ -5577,6 +5646,7 @@ async fn auth_resume_slot_consumed_on_first_batch_match_not_reused_for_second_ca
                         terminate_hint: false,
                         byte_len: 0,
                         output_digest: None,
+                        model_observation: None,
                     },
                 ),
             ],
@@ -6412,6 +6482,7 @@ async fn capability_stage_denied_auth_resume_only_fails_matching_call_remaining_
                 terminate_hint: false,
                 byte_len: 0,
                 output_digest: None,
+                model_observation: None,
             })],
             stopped_on_suspension: false,
         }]);
@@ -6610,6 +6681,7 @@ async fn capability_stage_denied_auth_resume_only_fails_matching_activity_when_c
                 terminate_hint: false,
                 byte_len: 0,
                 output_digest: None,
+                model_observation: None,
             })],
             stopped_on_suspension: false,
         },
@@ -6763,6 +6835,7 @@ async fn capability_stage_denied_auth_resume_one_denied_two_remaining_all_dispat
                     terminate_hint: false,
                     byte_len: 0,
                     output_digest: None,
+                    model_observation: None,
                 }),
                 CapabilityOutcome::Completed(CapabilityResultMessage {
                     result_ref: z_result_ref.clone(),
@@ -6771,6 +6844,7 @@ async fn capability_stage_denied_auth_resume_one_denied_two_remaining_all_dispat
                     terminate_hint: false,
                     byte_len: 0,
                     output_digest: None,
+                    model_observation: None,
                 }),
             ],
             stopped_on_suspension: false,
@@ -7006,6 +7080,7 @@ async fn capability_stage_denied_approval_resume_only_fails_matching_call_remain
                 terminate_hint: false,
                 byte_len: 0,
                 output_digest: None,
+                model_observation: None,
             })],
             stopped_on_suspension: false,
         }]);
@@ -7222,6 +7297,7 @@ async fn capability_stage_denied_approval_resume_no_matching_call_dispatches_unr
                 terminate_hint: false,
                 byte_len: 0,
                 output_digest: None,
+                model_observation: None,
             })],
             stopped_on_suspension: false,
         }]);

--- a/crates/ironclaw_agent_loop/src/executor/tests/cancellation.rs
+++ b/crates/ironclaw_agent_loop/src/executor/tests/cancellation.rs
@@ -640,6 +640,7 @@ async fn cancellation_after_capability_batch_preserves_completed_result() {
                 terminate_hint: true,
                 byte_len: 0,
                 output_digest: None,
+                model_observation: None,
             })],
             stopped_on_suspension: false,
         }])

--- a/crates/ironclaw_agent_loop/src/test_support/mod.rs
+++ b/crates/ironclaw_agent_loop/src/test_support/mod.rs
@@ -29,9 +29,9 @@ use ironclaw_turns::{
         LoopInputBatch, LoopInputCursor, LoopInputCursorToken, LoopModelMessage, LoopModelRequest,
         LoopModelResponse, LoopProgressEvent, LoopPromptBundle, LoopPromptBundleRef,
         LoopPromptBundleRequest, LoopRunContext, LoopRunInfoPort, ModelProfileId, ModelStreamChunk,
-        ParentLoopOutput, ProviderToolCallReference, RedactedRunProfileProvenance,
-        ResolvedRunProfile, ResourceBudgetPolicy, ResourceBudgetTier, RunClassId,
-        RunProfileFingerprint, RuntimeProfileConstraints, SchedulingClass,
+        ModelVisibleToolObservation, ParentLoopOutput, ProviderToolCallReference,
+        RedactedRunProfileProvenance, ResolvedRunProfile, ResourceBudgetPolicy, ResourceBudgetTier,
+        RunClassId, RunProfileFingerprint, RuntimeProfileConstraints, SchedulingClass,
         StageCheckpointPayloadRequest, SteeringPolicy, VisibleCapabilityRequest,
         VisibleCapabilitySurface,
     },
@@ -465,6 +465,8 @@ pub enum ScriptedCapabilityOutcome {
         terminate_hint: bool,
         /// Optional digest over completed output.
         output_digest: Option<ContentDigest>,
+        /// Optional model-visible observation for completed output.
+        model_observation: Option<ModelVisibleToolObservation>,
     },
     /// Approval gate.
     ApprovalRequired {
@@ -514,6 +516,7 @@ impl ScriptedCapabilityOutcome {
             progress: CapabilityProgress::MadeProgress,
             terminate_hint: false,
             output_digest: None,
+            model_observation: None,
         }
     }
 
@@ -527,6 +530,7 @@ impl ScriptedCapabilityOutcome {
             progress: CapabilityProgress::MadeProgress,
             terminate_hint: false,
             output_digest: Some(output_digest),
+            model_observation: None,
         }
     }
 
@@ -537,6 +541,7 @@ impl ScriptedCapabilityOutcome {
             progress: CapabilityProgress::NoChange,
             terminate_hint: false,
             output_digest: None,
+            model_observation: None,
         }
     }
 
@@ -547,6 +552,7 @@ impl ScriptedCapabilityOutcome {
             progress: CapabilityProgress::Blocked,
             terminate_hint: false,
             output_digest: None,
+            model_observation: None,
         }
     }
 
@@ -557,6 +563,7 @@ impl ScriptedCapabilityOutcome {
             progress: CapabilityProgress::MadeProgress,
             terminate_hint: true,
             output_digest: None,
+            model_observation: None,
         }
     }
 
@@ -1077,6 +1084,7 @@ fn scripted_capability_outcome(
             progress,
             terminate_hint,
             output_digest,
+            model_observation,
         } => Ok(CapabilityOutcome::Completed(CapabilityResultMessage {
             result_ref: LoopResultRef::new(result_ref)
                 .unwrap_or_else(|error| panic!("test result ref should be valid: {error}")),
@@ -1085,6 +1093,7 @@ fn scripted_capability_outcome(
             terminate_hint,
             byte_len: 0,
             output_digest,
+            model_observation,
         })),
         ScriptedCapabilityOutcome::ApprovalRequired { gate_ref } => {
             Ok(CapabilityOutcome::ApprovalRequired {

--- a/crates/ironclaw_hooks/src/middleware/capability_port.rs
+++ b/crates/ironclaw_hooks/src/middleware/capability_port.rs
@@ -710,6 +710,7 @@ mod tests {
                 terminate_hint: false,
                 byte_len: 0,
                 output_digest: None,
+                model_observation: None,
             }))
         }
 

--- a/crates/ironclaw_hooks/src/middleware/tests/capability_port.rs
+++ b/crates/ironclaw_hooks/src/middleware/tests/capability_port.rs
@@ -79,6 +79,7 @@ impl LoopCapabilityPort for AlwaysCompletedPort {
             terminate_hint: false,
             byte_len: 0,
             output_digest: None,
+            model_observation: None,
         }))
     }
 

--- a/crates/ironclaw_loop_support/src/capability_port.rs
+++ b/crates/ironclaw_loop_support/src/capability_port.rs
@@ -27,9 +27,10 @@ use ironclaw_turns::{
         CapabilityInputIssueCode, CapabilityInputRef, CapabilityInvocation, CapabilityOutcome,
         CapabilityResultMessage, CapabilityResumeToken, ConcurrencyHint, ContentDigest,
         LoopCapabilityPort, LoopHostMilestone, LoopHostMilestoneKind, LoopHostMilestoneSink,
-        LoopProcessRef, LoopRunContext, LoopSafeSummary, ProcessHandleSummary, ProviderToolCall,
-        ProviderToolCallCapabilityIds, ProviderToolCallReplay, ProviderToolDefinition,
-        RegisterProviderToolCallRequest, VisibleCapabilityRequest, VisibleCapabilitySurface,
+        LoopProcessRef, LoopRunContext, LoopSafeSummary, ModelVisibleToolObservation,
+        ProcessHandleSummary, ProviderToolCall, ProviderToolCallCapabilityIds,
+        ProviderToolCallReplay, ProviderToolDefinition, RegisterProviderToolCallRequest,
+        VisibleCapabilityRequest, VisibleCapabilitySurface,
     },
 };
 use serde_json::Value;
@@ -1212,6 +1213,7 @@ impl HostRuntimeLoopCapabilityPort {
             }
             Err(error) => return Err(error),
         };
+        let model_observation = model_visible_output_observation(output.clone());
         let write_result = self
             .result_writer
             .write_capability_result(CapabilityResultWrite {
@@ -1230,6 +1232,7 @@ impl HostRuntimeLoopCapabilityPort {
             terminate_hint: false,
             byte_len: write_result.byte_len,
             output_digest: write_result.output_digest,
+            model_observation,
         }))
     }
 
@@ -2369,6 +2372,7 @@ async fn runtime_outcome_to_loop(
     ensure_runtime_outcome_matches(conversion.requested_capability_id, &conversion.outcome)?;
     Ok(match conversion.outcome {
         RuntimeCapabilityOutcome::Completed(completed) => {
+            let model_observation = model_visible_output_observation(completed.output.clone());
             let write_result = result_writer
                 .write_capability_result(CapabilityResultWrite {
                     run_context,
@@ -2386,6 +2390,7 @@ async fn runtime_outcome_to_loop(
                 terminate_hint: false,
                 byte_len: write_result.byte_len,
                 output_digest: write_result.output_digest,
+                model_observation,
             })
         }
         RuntimeCapabilityOutcome::ApprovalRequired(gate) => {
@@ -2488,6 +2493,21 @@ fn runtime_terminal_milestone(
         | RuntimeCapabilityOutcome::ResourceBlocked(_)
         | RuntimeCapabilityOutcome::SpawnedProcess(_) => None,
     })
+}
+
+fn model_visible_output_observation(
+    output: serde_json::Value,
+) -> Option<ModelVisibleToolObservation> {
+    match ModelVisibleToolObservation::success_output(output) {
+        Ok(observation) => Some(observation),
+        Err(error) => {
+            tracing::debug!(
+                reason = %error,
+                "dropping completed capability model-visible output observation"
+            );
+            None
+        }
+    }
 }
 
 fn runtime_failure_to_loop(
@@ -2779,6 +2799,10 @@ fn host_runtime_error(error: HostRuntimeError) -> AgentLoopHostError {
 mod tests {
     use super::*;
     mod runtime_lifecycle_tests;
+
+    use ironclaw_turns::run_profile::{
+        ObservationTrust, ToolObservationDetail, ToolObservationStatus,
+    };
 
     use std::{
         collections::VecDeque,
@@ -4249,6 +4273,43 @@ mod tests {
             &serde_json::json!({"message": "hello"}),
             "observer should receive the resolved tool-call arguments"
         );
+    }
+
+    #[tokio::test]
+    async fn invoke_capability_returns_bounded_model_visible_output_observation() {
+        let capability_id = CapabilityId::new("demo.echo").expect("valid capability id");
+        let provider_id = ExtensionId::new("demo").expect("valid provider id");
+        let port = runtime_capability_port(
+            &capability_id,
+            &provider_id,
+            Arc::new(RecordingHostRuntime::new(vec![visible_capability(
+                capability_id,
+                provider_id,
+            )])),
+            dummy_result_writer(),
+            dummy_milestone_sink(),
+            "thread-model-visible-output",
+        )
+        .await;
+
+        let outcome = invoke_visible_runtime_capability(&port)
+            .await
+            .expect("capability succeeds");
+        let CapabilityOutcome::Completed(result) = outcome else {
+            panic!("expected completed outcome");
+        };
+        let observation = result
+            .model_observation
+            .expect("completed output must be model-visible");
+        assert_eq!(observation.status, ToolObservationStatus::Success);
+        assert_eq!(observation.summary, "Tool completed.");
+        assert_eq!(observation.trust, ObservationTrust::UntrustedToolOutput);
+        match observation.detail {
+            ToolObservationDetail::Output { content } => {
+                assert_eq!(content, serde_json::json!({"ok": true}));
+            }
+            detail => panic!("expected output detail, got {detail:?}"),
+        }
     }
 
     #[tokio::test]
@@ -8099,6 +8160,7 @@ mod tests {
                 result_ref,
                 byte_len: 0,
                 output_digest: Some(output_digest),
+                model_observation: None,
             })
         }
     }

--- a/crates/ironclaw_loop_support/src/capability_surface_filter.rs
+++ b/crates/ironclaw_loop_support/src/capability_surface_filter.rs
@@ -839,6 +839,7 @@ mod tests {
             terminate_hint: false,
             byte_len: 0,
             output_digest: None,
+            model_observation: None,
         })
     }
 

--- a/crates/ironclaw_loop_support/src/subagent_spawn_port/tests.rs
+++ b/crates/ironclaw_loop_support/src/subagent_spawn_port/tests.rs
@@ -248,6 +248,7 @@ impl LoopCapabilityPort for SurfacePrimedSpawnAuthPort {
             terminate_hint: false,
             byte_len: 0,
             output_digest: None,
+            model_observation: None,
         }))
     }
 
@@ -370,6 +371,7 @@ impl LoopCapabilityPort for AuthPassPort {
             terminate_hint: false,
             byte_len: 0,
             output_digest: None,
+            model_observation: None,
         }))
     }
 
@@ -1223,6 +1225,7 @@ fn completed_outcome(label: &str) -> CapabilityOutcome {
         terminate_hint: false,
         byte_len: 0,
         output_digest: None,
+        model_observation: None,
     })
 }
 

--- a/crates/ironclaw_product_workflow/tests/support/planned_agent_loop.rs
+++ b/crates/ironclaw_product_workflow/tests/support/planned_agent_loop.rs
@@ -841,6 +841,7 @@ impl LoopCapabilityPort for RecordingCapabilityPort {
             terminate_hint: self.capability.terminate_hint,
             byte_len: 0,
             output_digest: None,
+            model_observation: None,
         }))
     }
 

--- a/crates/ironclaw_reborn/src/subagent/flavors.rs
+++ b/crates/ironclaw_reborn/src/subagent/flavors.rs
@@ -537,6 +537,7 @@ mod tests {
                     terminate_hint: false,
                     byte_len: 0,
                     output_digest: None,
+                    model_observation: None,
                 }))
             }
 

--- a/crates/ironclaw_reborn/tests/hooks_integration.rs
+++ b/crates/ironclaw_reborn/tests/hooks_integration.rs
@@ -219,6 +219,7 @@ impl LoopCapabilityPort for RecordingCapabilityPort {
             terminate_hint: false,
             byte_len: 0,
             output_digest: None,
+            model_observation: None,
         }))
     }
 
@@ -292,6 +293,7 @@ impl LoopCapabilityPort for ProviderAwareCapabilityPort {
             terminate_hint: false,
             byte_len: 0,
             output_digest: None,
+            model_observation: None,
         }))
     }
 

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/external_tool_capability.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/external_tool_capability.rs
@@ -31,9 +31,9 @@ use ironclaw_turns::run_profile::{
     AgentLoopHostError, AgentLoopHostErrorKind, CapabilityBatchInvocation, CapabilityBatchOutcome,
     CapabilityCallCandidate, CapabilityInvocation, CapabilityOutcome, CapabilityProgress,
     CapabilityResultMessage, CapabilitySurfaceVersion, ConcurrencyHint, LoopCapabilityPort,
-    LoopRunContext, ProviderToolCall, ProviderToolCallCapabilityIds, ProviderToolCallReplay,
-    ProviderToolDefinition, RegisterProviderToolCallRequest, VisibleCapabilityRequest,
-    VisibleCapabilitySurface,
+    LoopRunContext, ModelVisibleToolObservation, ProviderToolCall, ProviderToolCallCapabilityIds,
+    ProviderToolCallReplay, ProviderToolDefinition, RegisterProviderToolCallRequest,
+    VisibleCapabilityRequest, VisibleCapabilitySurface,
 };
 use ironclaw_turns::{ExternalToolCatalog, PendingExternalCall};
 use ironclaw_turns::{LoopGateRef, TurnRunId};
@@ -201,6 +201,8 @@ impl ExternalToolCapabilityPort {
             .await
             .map_err(catalog_error)?
         {
+            let model_observation =
+                ModelVisibleToolObservation::success_output(output.clone()).ok();
             let write = self
                 .result_writer
                 .write_capability_result(CapabilityResultWrite {
@@ -225,6 +227,7 @@ impl ExternalToolCapabilityPort {
                 terminate_hint: false,
                 byte_len: write.byte_len,
                 output_digest: write.output_digest,
+                model_observation,
             }));
         }
         // No output yet → park and return control to the API client.

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/outbound_delivery.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/outbound_delivery.rs
@@ -19,6 +19,7 @@ use ironclaw_turns::{
         AgentLoopHostError, AgentLoopHostErrorKind, CapabilityApprovalResume, CapabilityFailure,
         CapabilityFailureKind, CapabilityInputRef, CapabilityOutcome, CapabilityProgress,
         CapabilityResultMessage, CapabilityResumeToken, ConcurrencyHint, LoopRunContext,
+        ModelVisibleToolObservation,
     },
 };
 
@@ -417,6 +418,7 @@ async fn write_completed_result(
     output: serde_json::Value,
     safe_summary: String,
 ) -> Result<CapabilityOutcome, AgentLoopHostError> {
+    let model_observation = ModelVisibleToolObservation::success_output(output.clone()).ok();
     let write_result = invocation
         .result_writer
         .write_capability_result(CapabilityResultWrite {
@@ -435,6 +437,7 @@ async fn write_completed_result(
         terminate_hint: false,
         byte_len: write_result.byte_len,
         output_digest: write_result.output_digest,
+        model_observation,
     }))
 }
 

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/project_create.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/project_create.rs
@@ -9,7 +9,7 @@ use ironclaw_product_workflow::{
 use ironclaw_turns::run_profile::{
     AgentLoopHostError, AgentLoopHostErrorKind, CapabilityFailure, CapabilityFailureKind,
     CapabilityOutcome, CapabilityProgress, CapabilityResultMessage, ConcurrencyHint,
-    LoopRunContext,
+    LoopRunContext, ModelVisibleToolObservation,
 };
 
 use crate::runtime::local_dev::synthetic_capability::{
@@ -97,6 +97,7 @@ impl LocalDevSyntheticCapabilityHandler for ProjectCreateHandler {
         // name and id from the result `output`; the summary stays a fixed,
         // delimiter-free string.
         let safe_summary = "created project".to_string();
+        let model_observation = ModelVisibleToolObservation::success_output(output.clone()).ok();
         let write_result = invocation
             .result_writer
             .write_capability_result(CapabilityResultWrite {
@@ -115,6 +116,7 @@ impl LocalDevSyntheticCapabilityHandler for ProjectCreateHandler {
             terminate_hint: false,
             byte_len: write_result.byte_len,
             output_digest: write_result.output_digest,
+            model_observation,
         }))
     }
 }

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/skill_activation.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/skill_activation.rs
@@ -5,7 +5,7 @@ use ironclaw_host_api::InvocationId;
 use ironclaw_loop_support::CapabilityResultWrite;
 use ironclaw_turns::run_profile::{
     AgentLoopHostError, AgentLoopHostErrorKind, CapabilityFailure, CapabilityFailureKind,
-    CapabilityOutcome, CapabilityResultMessage, ConcurrencyHint,
+    CapabilityOutcome, CapabilityResultMessage, ConcurrencyHint, ModelVisibleToolObservation,
 };
 
 use crate::runtime::{
@@ -95,6 +95,7 @@ impl LocalDevSyntheticCapabilityHandler for SkillActivationHandler {
             "activated": activated,
             "count": activated.len(),
         });
+        let model_observation = ModelVisibleToolObservation::success_output(output.clone()).ok();
         let write_result = invocation
             .result_writer
             .write_capability_result(CapabilityResultWrite {
@@ -113,6 +114,7 @@ impl LocalDevSyntheticCapabilityHandler for SkillActivationHandler {
             terminate_hint: false,
             byte_len: write_result.byte_len,
             output_digest: write_result.output_digest,
+            model_observation,
         }))
     }
 }

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/synthetic_capability.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/synthetic_capability.rs
@@ -654,6 +654,7 @@ mod tests {
                     terminate_hint: false,
                     byte_len: 0,
                     output_digest: None,
+                    model_observation: None,
                 },
             ))
         }

--- a/crates/ironclaw_threads/src/tool_result_reference.rs
+++ b/crates/ironclaw_threads/src/tool_result_reference.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 // ASCII letters, digits, `_`, `-`, or `.`.
 const MAX_TOOL_RESULT_REF_BYTES: usize = 256;
 const MAX_TOOL_RESULT_SUMMARY_BYTES: usize = 512;
-const MAX_MODEL_OBSERVATION_BYTES: usize = 4096;
+const MAX_MODEL_OBSERVATION_BYTES: usize = 16 * 1024;
 const MODEL_VISIBLE_TOOL_OBSERVATION_SCHEMA_VERSION: u64 = 1;
 const MODEL_OBSERVATION_SUMMARY_MAX_BYTES: usize = 512;
 const MODEL_OBSERVATION_ARTIFACTS_MAX: usize = 16;
@@ -505,6 +505,14 @@ fn validate_model_observation_detail(value: &serde_json::Value) -> Result<(), St
                 128,
             )
         }
+        "output" => {
+            validate_object_keys(object, &["kind", "content"], "model observation detail")?;
+            validate_model_observation_value(required_field(
+                object,
+                "content",
+                "model observation detail",
+            )?)
+        }
         other => Err(format!(
             "model observation detail kind `{other}` is unsupported"
         )),
@@ -939,6 +947,34 @@ mod tests {
         .expect("nested formatting whitespace is valid");
 
         assert!(envelope.model_observation.is_some());
+    }
+
+    #[test]
+    fn model_observation_accepts_success_output_detail() {
+        let observation = serde_json::json!({
+            "schema_version": 1,
+            "status": "success",
+            "summary": "Tool completed.",
+            "detail": {
+                "kind": "output",
+                "content": {
+                    "path": "MEMORY.md",
+                    "content": "remembered"
+                }
+            },
+            "trust": "untrusted_tool_output"
+        });
+        let envelope = ToolResultReferenceEnvelope::with_model_observation(
+            "result:memory-read",
+            ToolResultSafeSummary::new("capability completed").expect("summary"),
+            observation.clone(),
+        )
+        .expect("output observation is valid");
+
+        assert_eq!(
+            envelope.model_visible_content_or_safe_summary(),
+            serde_json::to_string(&observation).expect("serialize")
+        );
     }
 
     #[test]

--- a/crates/ironclaw_turns/src/run_profile/host.rs
+++ b/crates/ironclaw_turns/src/run_profile/host.rs
@@ -1741,6 +1741,11 @@ pub struct CapabilityResultMessage {
     /// compatibility and for synthetic results that do not stage real output.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub output_digest: Option<ContentDigest>,
+    /// Bounded, model-visible view of the staged output. The full result stays
+    /// behind `result_ref`; this optional observation lets the next model turn
+    /// consume ordinary tool output without dereferencing host storage.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_observation: Option<ModelVisibleToolObservation>,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/ironclaw_turns/src/run_profile/model_observation.rs
+++ b/crates/ironclaw_turns/src/run_profile/model_observation.rs
@@ -7,6 +7,7 @@ const MODEL_OBSERVATION_ARTIFACTS_MAX: usize = 16;
 const MODEL_OBSERVATION_REPAIRS_MAX: usize = 16;
 const MODEL_OBSERVATION_INPUT_ISSUES_MAX: usize = 16;
 const MODEL_OBSERVATION_TEXT_MAX_BYTES: usize = 512;
+const MODEL_OBSERVATION_MAX_BYTES: usize = 16 * 1024;
 pub const MODEL_VISIBLE_TOOL_OBSERVATION_SCHEMA_VERSION: u32 = 1;
 
 #[non_exhaustive]
@@ -31,6 +32,22 @@ pub struct ModelVisibleToolObservation {
 }
 
 impl ModelVisibleToolObservation {
+    /// Builds the canonical bounded observation for successful capability JSON
+    /// output. The full result remains staged behind the result ref.
+    pub fn success_output(output: serde_json::Value) -> Result<Self, String> {
+        let observation = Self {
+            schema_version: MODEL_VISIBLE_TOOL_OBSERVATION_SCHEMA_VERSION,
+            status: ToolObservationStatus::Success,
+            summary: "Tool completed.".to_string(),
+            detail: ToolObservationDetail::Output { content: output },
+            artifacts: Vec::new(),
+            recovery: None,
+            trust: ObservationTrust::UntrustedToolOutput,
+        };
+        observation.validate()?;
+        Ok(observation)
+    }
+
     pub fn validate(&self) -> Result<(), String> {
         if self.schema_version != MODEL_VISIBLE_TOOL_OBSERVATION_SCHEMA_VERSION {
             return Err(format!(
@@ -38,6 +55,7 @@ impl ModelVisibleToolObservation {
                 self.schema_version
             ));
         }
+        validate_observation_len(self)?;
         validate_non_empty_text(&self.summary, "model observation summary")?;
         validate_text_len(
             &self.summary,
@@ -75,6 +93,7 @@ pub enum ToolObservationStatus {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum ToolObservationDetail {
+    Output { content: serde_json::Value },
     InvalidInput { issues: Vec<CapabilityInputIssue> },
     GenericFailure { failure_kind: CapabilityFailureKind },
 }
@@ -82,6 +101,7 @@ pub enum ToolObservationDetail {
 impl ToolObservationDetail {
     fn validate(&self) -> Result<(), String> {
         match self {
+            Self::Output { .. } => Ok(()),
             Self::InvalidInput { issues } => {
                 validate_len(
                     issues.len(),
@@ -256,6 +276,17 @@ fn validate_len(len: usize, max: usize, label: &'static str) -> Result<(), Strin
     Ok(())
 }
 
+fn validate_observation_len(value: &ModelVisibleToolObservation) -> Result<(), String> {
+    let serialized = serde_json::to_vec(value)
+        .map_err(|_| "model observation could not be serialized".to_string())?;
+    if serialized.len() > MODEL_OBSERVATION_MAX_BYTES {
+        return Err(format!(
+            "model observation exceeds {MODEL_OBSERVATION_MAX_BYTES} bytes"
+        ));
+    }
+    Ok(())
+}
+
 fn validate_optional_text(value: Option<&str>, label: &'static str) -> Result<(), String> {
     if let Some(value) = value {
         validate_text_len(value, label, MODEL_OBSERVATION_TEXT_MAX_BYTES)?;
@@ -332,5 +363,27 @@ mod tests {
             serde_json::json!("provide_required_field")
         );
         assert_eq!(value["trust"], "untrusted_tool_output");
+    }
+
+    #[test]
+    fn model_visible_tool_observation_accepts_bounded_output() {
+        let observation = ModelVisibleToolObservation::success_output(
+            serde_json::json!({"path": "notes.md", "content": "answer"}),
+        )
+        .expect("bounded output is valid");
+
+        let value = serde_json::to_value(&observation).expect("serialize");
+        assert_eq!(value["status"], "success");
+        assert_eq!(value["detail"]["kind"], "output");
+        assert_eq!(value["detail"]["content"]["content"], "answer");
+    }
+
+    #[test]
+    fn model_visible_tool_observation_rejects_oversized_output() {
+        let error = ModelVisibleToolObservation::success_output(serde_json::json!({
+            "content": "x".repeat(MODEL_OBSERVATION_MAX_BYTES)
+        }))
+        .expect_err("oversized output must be rejected");
+        assert!(error.contains("model observation exceeds"));
     }
 }

--- a/tests/support/reborn/harness.rs
+++ b/tests/support/reborn/harness.rs
@@ -3716,6 +3716,7 @@ impl RecordingTestCapabilityPort {
             terminate_hint: false,
             byte_len: 0,
             output_digest: None,
+            model_observation: None,
         })
     }
 }


### PR DESCRIPTION
## Summary
- add a bounded success-output observation shape for completed capability JSON results
- carry model-visible observations from capability completion through executor result refs into transcript storage
- teach transcript validation/replay to accept success output observations and reuse the canonical constructor in runtime/direct synthetic paths

## Tests
- cargo fmt
- git diff --check
- CARGO_TARGET_DIR=/tmp/ironclaw-thermo-target cargo test -p ironclaw_turns model_visible_tool_observation_ --lib
- CARGO_TARGET_DIR=/tmp/ironclaw-thermo-target cargo test -p ironclaw_threads model_observation --lib
- CARGO_TARGET_DIR=/tmp/ironclaw-thermo-target cargo test -p ironclaw_agent_loop completed_provider_tool_result_appends_model_visible_output_observation --lib

## Notes
- Broader cargo check for ironclaw_reborn_composition was attempted with -j 1 but the local disk filled before reaching the target crate.
