### PR TITLE
fix(resources): keep unlimited governor fast path in memory

### DIFF
--- a/crates/ironclaw_resources/src/lib.rs
+++ b/crates/ironclaw_resources/src/lib.rs
@@ -1184,10 +1184,7 @@ where
             let local_state = local.state.clone();
             let local_initialized = local.initialized;
             let updated_state = self.store.update(move |snapshot| {
-                if local_initialized
-                    && !resource_state_has_finite_limits(&snapshot.state)
-                    && !resource_state_has_durable_activity(&snapshot.state)
-                {
+                if local_initialized && !resource_state_has_finite_limits(&snapshot.state) {
                     snapshot.state = local_state.clone();
                 }
                 set_limit_in_state(&mut snapshot.state, account.clone(), limits.clone(), now);
@@ -1234,12 +1231,14 @@ where
             return Ok(None);
         }
         self.store.inspect(|snapshot| {
-            if resource_state_has_finite_limits(&snapshot.state)
-                || resource_state_has_durable_activity(&snapshot.state)
-            {
+            if resource_state_has_finite_limits(&snapshot.state) {
                 Ok(None)
             } else {
-                Ok(Some(snapshot.state.clone()))
+                let mut state = snapshot.state.clone();
+                state.reserved_by_account.clear();
+                state.usage_by_account.clear();
+                state.reservations.clear();
+                Ok(Some(state))
             }
         })
     }
@@ -1451,12 +1450,6 @@ struct UnlimitedFastPathState {
 
 fn resource_state_has_finite_limits(state: &ResourceState) -> bool {
     state.limits.values().any(|limits| !limits.is_unlimited())
-}
-
-fn resource_state_has_durable_activity(state: &ResourceState) -> bool {
-    !state.reserved_by_account.is_empty()
-        || !state.usage_by_account.is_empty()
-        || !state.reservations.is_empty()
 }
 
 /// Snapshot of accumulated period-scoped spend + reserved.

--- a/crates/ironclaw_resources/src/lib.rs
+++ b/crates/ironclaw_resources/src/lib.rs
@@ -1183,14 +1183,26 @@ where
             let mut local = self.lock_unlimited_state()?;
             let local_state = local.state.clone();
             let local_initialized = local.initialized;
+            let setting_finite_limit = !limits.is_unlimited();
+            let local_account = account.clone();
+            let local_limits = limits.clone();
             let updated_state = self.store.update(move |snapshot| {
-                if local_initialized && !resource_state_has_finite_limits(&snapshot.state) {
-                    snapshot.state = local_state.clone();
+                if local_initialized
+                    && setting_finite_limit
+                    && !resource_state_has_finite_limits(&snapshot.state)
+                {
+                    merge_unlimited_fast_path_state(&mut snapshot.state, &local_state);
                 }
                 set_limit_in_state(&mut snapshot.state, account.clone(), limits.clone(), now);
                 Ok(snapshot.state.clone())
             })?;
-            local.state = updated_state;
+            if resource_state_has_finite_limits(&updated_state) {
+                local.state = updated_state;
+            } else if local_initialized {
+                set_limit_in_state(&mut local.state, local_account, local_limits, now);
+            } else {
+                local.state = sanitized_unlimited_fast_path_state(updated_state);
+            };
             local.initialized = true;
             return Ok(());
         }
@@ -1234,11 +1246,9 @@ where
             if resource_state_has_finite_limits(&snapshot.state) {
                 Ok(None)
             } else {
-                let mut state = snapshot.state.clone();
-                state.reserved_by_account.clear();
-                state.usage_by_account.clear();
-                state.reservations.clear();
-                Ok(Some(state))
+                Ok(Some(sanitized_unlimited_fast_path_state(
+                    snapshot.state.clone(),
+                )))
             }
         })
     }
@@ -1450,6 +1460,36 @@ struct UnlimitedFastPathState {
 
 fn resource_state_has_finite_limits(state: &ResourceState) -> bool {
     state.limits.values().any(|limits| !limits.is_unlimited())
+}
+
+fn sanitized_unlimited_fast_path_state(mut state: ResourceState) -> ResourceState {
+    state.reserved_by_account.clear();
+    state.usage_by_account.clear();
+    state.reservations.clear();
+    state
+}
+
+fn merge_unlimited_fast_path_state(target: &mut ResourceState, local: &ResourceState) {
+    for (account, tally) in &local.reserved_by_account {
+        target
+            .reserved_by_account
+            .entry(account.clone())
+            .or_default()
+            .add_assign(tally);
+    }
+    for (account, tally) in &local.usage_by_account {
+        target
+            .usage_by_account
+            .entry(account.clone())
+            .or_default()
+            .add_assign(tally);
+    }
+    for (id, record) in &local.reservations {
+        target.reservations.insert(*id, record.clone());
+    }
+    for (account, anchor) in &local.period_anchors {
+        target.period_anchors.insert(account.clone(), *anchor);
+    }
 }
 
 /// Snapshot of accumulated period-scoped spend + reserved.

--- a/crates/ironclaw_resources/tests/resource_governor_contract.rs
+++ b/crates/ironclaw_resources/tests/resource_governor_contract.rs
@@ -827,9 +827,15 @@ fn persistent_governor_unlimited_fast_path_ignores_legacy_durable_activity() {
     let dir = tempdir().unwrap();
     let path = dir.path().join("resource-governor.json");
     let scope = sample_scope("tenant1", "user1", Some("project1"));
+    let tenant_account = ResourceAccount::tenant(scope.tenant_id.clone());
+    let user_account = ResourceAccount::user(scope.tenant_id.clone(), scope.user_id.clone());
+    let unrelated_account = ResourceAccount::tenant(TenantId::new("tenant-unrelated").unwrap());
 
     let legacy_governor =
         PersistentResourceGovernor::new(JsonFileResourceGovernorStore::new(&path));
+    legacy_governor
+        .set_limit(tenant_account.clone(), ResourceLimits::default())
+        .unwrap();
     let legacy_reservation = legacy_governor
         .reserve(
             scope.clone(),
@@ -849,13 +855,42 @@ fn persistent_governor_unlimited_fast_path_ignores_legacy_durable_activity() {
             },
         )
         .unwrap();
+    let legacy_usage = legacy_governor.usage_for(&tenant_account).unwrap();
+    assert_eq!(
+        legacy_usage.usd,
+        dec!(0.20),
+        "test setup must leave durable usage for the fast path to ignore"
+    );
     let before_fast_path = fs::read_to_string(&path).unwrap();
+    let before_fast_path_json: serde_json::Value = serde_json::from_str(&before_fast_path).unwrap();
+    assert!(
+        before_fast_path_json["state"]["usage_by_account"]
+            .as_array()
+            .is_some_and(|entries| !entries.is_empty()),
+        "legacy fixture must contain durable usage so the test exercises accounting cleanup"
+    );
+    assert!(
+        before_fast_path_json["state"]["reservations"]
+            .as_array()
+            .is_some_and(|entries| !entries.is_empty()),
+        "legacy fixture must contain durable reservations so the test exercises accounting cleanup"
+    );
 
     let governor = PersistentResourceGovernor::new(JsonFileResourceGovernorStore::new(&path))
         .with_unlimited_fast_path();
+    governor
+        .set_limit(unrelated_account, ResourceLimits::default())
+        .unwrap();
+    assert_eq!(
+        governor.usage_for(&user_account).unwrap(),
+        ResourceTally::default(),
+        "unlimited set_limit must not seed local fast-path state with legacy durable usage"
+    );
+    let after_unlimited_limit = fs::read_to_string(&path).unwrap();
+
     let reservation = governor
         .reserve(
-            scope,
+            scope.clone(),
             ResourceEstimate {
                 usd: Some(dec!(0.10)),
                 concurrency_slots: Some(1),
@@ -885,8 +920,26 @@ fn persistent_governor_unlimited_fast_path_ignores_legacy_durable_activity() {
     );
     assert_eq!(
         fs::read_to_string(&path).unwrap(),
-        before_fast_path,
+        after_unlimited_limit,
         "legacy durable usage/reservations should not force unlimited fast-path writes"
+    );
+
+    governor
+        .set_limit(
+            tenant_account.clone(),
+            ResourceLimits {
+                max_usd: Some(dec!(10.00)),
+                ..ResourceLimits::default()
+            },
+        )
+        .unwrap();
+
+    let reloaded = PersistentResourceGovernor::new(JsonFileResourceGovernorStore::new(&path));
+    let snapshot = reloaded.account_snapshot(&tenant_account).unwrap().unwrap();
+    assert_eq!(
+        snapshot.ledger.spent.usd,
+        dec!(0.30),
+        "finite-limit transition should preserve legacy durable usage and merge fast-path usage"
     );
 }
 

--- a/crates/ironclaw_resources/tests/resource_governor_contract.rs
+++ b/crates/ironclaw_resources/tests/resource_governor_contract.rs
@@ -823,6 +823,74 @@ fn persistent_governor_unlimited_fast_path_avoids_durable_writes_until_finite_li
 }
 
 #[test]
+fn persistent_governor_unlimited_fast_path_ignores_legacy_durable_activity() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("resource-governor.json");
+    let scope = sample_scope("tenant1", "user1", Some("project1"));
+
+    let legacy_governor =
+        PersistentResourceGovernor::new(JsonFileResourceGovernorStore::new(&path));
+    let legacy_reservation = legacy_governor
+        .reserve(
+            scope.clone(),
+            ResourceEstimate {
+                usd: Some(dec!(0.20)),
+                concurrency_slots: Some(1),
+                ..ResourceEstimate::default()
+            },
+        )
+        .unwrap();
+    legacy_governor
+        .reconcile(
+            legacy_reservation.id,
+            ResourceUsage {
+                usd: dec!(0.20),
+                ..ResourceUsage::default()
+            },
+        )
+        .unwrap();
+    let before_fast_path = fs::read_to_string(&path).unwrap();
+
+    let governor = PersistentResourceGovernor::new(JsonFileResourceGovernorStore::new(&path))
+        .with_unlimited_fast_path();
+    let reservation = governor
+        .reserve(
+            scope,
+            ResourceEstimate {
+                usd: Some(dec!(0.10)),
+                concurrency_slots: Some(1),
+                ..ResourceEstimate::default()
+            },
+        )
+        .unwrap();
+    governor
+        .reconcile(
+            reservation.id,
+            ResourceUsage {
+                usd: dec!(0.10),
+                ..ResourceUsage::default()
+            },
+        )
+        .unwrap();
+
+    assert!(
+        matches!(
+            governor.release(reservation.id),
+            Err(ResourceError::ReservationClosed {
+                status: ReservationStatus::Reconciled,
+                ..
+            })
+        ),
+        "same-process lifecycle checks should still use local state"
+    );
+    assert_eq!(
+        fs::read_to_string(&path).unwrap(),
+        before_fast_path,
+        "legacy durable usage/reservations should not force unlimited fast-path writes"
+    );
+}
+
+#[test]
 fn persistent_governor_serializes_concurrent_reservations_across_handles() {
     let dir = tempdir().unwrap();
     let path = dir.path().join("resource-governor.json");


### PR DESCRIPTION
## Summary
- keep the resource governor unlimited fast path active when old durable snapshots contain only historical usage/reservation activity
- sanitize local unlimited-mode state so legacy durable accounting does not leak back into reserve/reconcile
- preserve and merge legacy durable accounting plus new fast-path accounting when a finite limit is later configured
- strengthen regression coverage for legacy durable activity, unlimited `set_limit`, no extra fast-path writes, and finite-limit transition

## Change Type
Bug fix / performance fix for the opt-in resource governor unlimited fast path.

## Linked Issue
None. This follows live latency diagnostics showing repeated 37MB `resource_governor_snapshot` writes.

## Why
Live latency traces showed repeated `filesystem/put resources:resource_governor_snapshot` writes around 37MB even with `IRONCLAW_RESOURCE_GOVERNOR_UNLIMITED_FAST_PATH=true`. The existing fast-path gate treated any durable activity in the old snapshot as a reason to fall back to the full persistent snapshot. On internal unlimited instances, that makes historical accounting keep the hot path on storage forever.

## Security Impact
No auth, secrets, sandboxing, network, or trust-boundary changes.

## DB / Storage Impact
No schema changes. This reduces durable resource-governor writes only when the explicit unlimited fast path is enabled and no finite limits are active. Finite limits still use durable storage.

## Blast Radius
Limited to `PersistentResourceGovernor` with `with_unlimited_fast_path()`. Default governor behavior without the env-gated fast path is unchanged.

## Rollback Plan
Disable `IRONCLAW_RESOURCE_GOVERNOR_UNLIMITED_FAST_PATH` or revert this PR. Either returns the governor to the durable snapshot path.

## Review Follow-Through
- Addressed Gemini feedback by merging local fast-path accounting into durable state when transitioning to finite limits.
- Addressed CodeRabbit feedback by sanitizing local unlimited state after unlimited `set_limit` and asserting the legacy fixture really contains durable activity.

## Trust-Boundary Checklist
- [x] No new inbound request path
- [x] No auth or permission changes
- [x] No secret handling changes
- [x] No external network behavior changes
- [x] No schema migration

## Validation
- `cargo fmt --check`
- `cargo test -p ironclaw_resources persistent_governor_unlimited_fast_path --test resource_governor_contract`
- `cargo test -p ironclaw_resources`
- `git diff --check`
- `bash scripts/pre-commit-safety.sh`