### PR TITLE
fix(webui): avoid thread list refetch on send

### DIFF
--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/hooks/useChat.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/hooks/useChat.js
@@ -5,9 +5,9 @@ import {
   sendMessage,
   submitManualToken,
 } from "../../../lib/api.js";
-import { queryClient } from "../../../lib/query-client.js";
 import { React } from "../../../lib/html.js";
 import { useChatEvents } from "../lib/useChatEvents.js";
+import { touchThreadInCache, upsertThreadInCache } from "../lib/thread-cache.js";
 import {
   addPending,
   recordAcceptedMessageRef,
@@ -54,14 +54,6 @@ function approvalGatePendingSendError() {
   );
   error.safeErrorCode = APPROVAL_GATE_PENDING_SEND_ERROR;
   return error;
-}
-
-function threadNeedsSidebarRefresh(threadId) {
-  const cached = queryClient.getQueryData?.(["threads"]);
-  const threads = cached?.threads;
-  if (!Array.isArray(threads)) return true;
-  const thread = threads.find((item) => item.thread_id === threadId || item.id === threadId);
-  return !thread?.title;
 }
 
 function busyNoticeKey(threadId, gate) {
@@ -440,7 +432,7 @@ export function useChat(threadId) {
 
       if (!sendThreadId) {
         const created = await createThreadRequest();
-        queryClient.invalidateQueries({ queryKey: ["threads"] });
+        upsertThreadInCache(created?.thread);
         sendThreadId = created?.thread?.thread_id;
         if (!sendThreadId) {
           throw new Error("createThread returned no thread_id");
@@ -510,11 +502,12 @@ export function useChat(threadId) {
           content,
           attachments: wireAttachments,
         });
-        // Refresh the sidebar only while the cached entry is missing
-        // or title-less. Once the first-message title has appeared,
-        // repeated sends do not need to refetch the whole thread list.
-        if (threadNeedsSidebarRefresh(sendThreadId)) {
-          queryClient.invalidateQueries({ queryKey: ["threads"] });
+        if (response?.outcome !== "rejected_busy") {
+          touchThreadInCache({
+            threadId: response?.thread_id || sendThreadId,
+            messageContent: content,
+            updatedAt: pendingRecord.timestamp,
+          });
         }
         let runSettledBeforeResponse = false;
         if (response?.run_id && shouldTrackLocalRun) {

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/hooks/useChat.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/hooks/useChat.js
@@ -505,7 +505,7 @@ export function useChat(threadId) {
         if (response?.outcome !== "rejected_busy") {
           touchThreadInCache({
             threadId: response?.thread_id || sendThreadId,
-            messageContent: content,
+            messageContent: renderContent,
             updatedAt: pendingRecord.timestamp,
           });
         }

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/hooks/useThreads.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/hooks/useThreads.js
@@ -6,13 +6,14 @@ import {
   listThreads,
 } from "../../../lib/api.js";
 import { queryClient } from "../../../lib/query-client.js";
+import { upsertThreadInCache } from "../lib/thread-cache.js";
 
 export function useThreads() {
-  // No polling: the sidebar refreshes via `queryClient.invalidateQueries`
-  // after a local `createThread` succeeds, and the v2 deployment has no
-  // out-of-band thread producers (no Telegram channel, no background
-  // routine) in this binary. The fork's 5s poll was inherited from a v1
-  // multi-channel context that doesn't apply here.
+  // No polling: the sidebar is kept current by local cache writes after
+  // create/send and by invalidating after delete. The v2 deployment has no
+  // out-of-band thread producers (no Telegram channel, no background routine)
+  // in this binary. The fork's 5s poll was inherited from a v1 multi-channel
+  // context that doesn't apply here.
   const query = useQuery({
     queryKey: ["threads"],
     queryFn: () => listThreads({}),
@@ -35,7 +36,7 @@ export function useThreads() {
     const createPromise = (async () => {
       try {
         const data = await createThreadRequest(projectId ? { projectId } : undefined);
-        queryClient.invalidateQueries({ queryKey: ["threads"] });
+        upsertThreadInCache(data?.thread);
         // RebornCreateThreadResponse → { thread: SessionThreadRecord }.
         // SessionThreadRecord uses `thread_id`, not `id`.
         const threadId = data?.thread?.thread_id;

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/hooks/useThreads.test.mjs
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/hooks/useThreads.test.mjs
@@ -62,7 +62,7 @@ function makeDeferredCreate() {
   };
 }
 
-function instantiate(createThreadRequest) {
+function instantiate(createThreadRequest, overrides = {}) {
   const context = {
     console,
     useQuery: () => ({ data: { threads: [] }, isLoading: false }),
@@ -71,7 +71,9 @@ function instantiate(createThreadRequest) {
     deleteThreadRequest: async () => {},
     listThreads: async () => ({ threads: [] }),
     queryClient: { invalidateQueries: () => {} },
+    upsertThreadInCache: () => {},
     globalThis: {},
+    ...overrides,
   };
   vm.runInNewContext(useThreadsSourceForTest(), context);
   return context.globalThis.__testExports.useThreads();
@@ -111,4 +113,22 @@ test("handleCreateThread still collapses concurrent creates within one project",
   // Both callers observe the single in-flight create's result.
   assert.equal(await first, "thread-project-a");
   assert.equal(await second, "thread-project-a");
+});
+
+test("handleCreateThread upserts the created thread without refetching the list", async () => {
+  const upserted = [];
+  const hook = instantiate(
+    async () => ({ thread: { thread_id: "thread-created", title: "Created" } }),
+    {
+      queryClient: {
+        invalidateQueries: () => {
+          throw new Error("create should not refetch the full thread list");
+        },
+      },
+      upsertThreadInCache: (thread) => upserted.push(thread),
+    },
+  );
+
+  assert.equal(await hook.createThread(), "thread-created");
+  assert.deepEqual(upserted, [{ thread_id: "thread-created", title: "Created" }]);
 });

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/thread-cache.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/thread-cache.js
@@ -1,0 +1,100 @@
+import { queryClient } from "../../../lib/query-client.js";
+
+const THREADS_QUERY_KEY = ["threads"];
+const TITLE_MAX_CHARS = 60;
+
+export function deriveSidebarTitle(message) {
+  const firstLine = String(message || "")
+    .split(/\r?\n/)
+    .find((line) => line.trim());
+  if (!firstLine) return null;
+  const trimmed = firstLine.trim();
+  const chars = Array.from(trimmed);
+  if (chars.length <= TITLE_MAX_CHARS) return trimmed;
+  return `${chars.slice(0, TITLE_MAX_CHARS - 3).join("")}...`;
+}
+
+function threadIdFor(record) {
+  return record?.thread_id || record?.id || null;
+}
+
+function threadListData(data) {
+  return data && typeof data === "object"
+    ? data
+    : { threads: [], next_cursor: null };
+}
+
+function withNormalizedThreadId(record) {
+  const threadId = threadIdFor(record);
+  if (!threadId) return null;
+  return { ...record, thread_id: threadId };
+}
+
+export function upsertThreadList(data, thread) {
+  const record = withNormalizedThreadId(thread);
+  if (!record) return data;
+
+  const current = threadListData(data);
+  const threads = Array.isArray(current.threads) ? current.threads : [];
+  let found = false;
+  const nextThreads = threads.map((existing) => {
+    if (threadIdFor(existing) !== record.thread_id) return existing;
+    found = true;
+    return { ...existing, ...record, thread_id: record.thread_id };
+  });
+  if (!found) nextThreads.unshift(record);
+
+  return {
+    ...current,
+    threads: nextThreads,
+    next_cursor: current.next_cursor ?? null,
+  };
+}
+
+export function touchThreadList(data, { threadId, messageContent, updatedAt }) {
+  if (!threadId) return data;
+
+  const current = threadListData(data);
+  const threads = Array.isArray(current.threads) ? current.threads : [];
+  const derivedTitle = deriveSidebarTitle(messageContent);
+  const timestamp = updatedAt || new Date().toISOString();
+  let found = false;
+
+  const nextThreads = threads.map((existing) => {
+    if (threadIdFor(existing) !== threadId) return existing;
+    found = true;
+    return {
+      ...existing,
+      thread_id: threadId,
+      title: existing.title || derivedTitle || null,
+      updated_at: timestamp,
+    };
+  });
+
+  if (!found) {
+    nextThreads.unshift({
+      thread_id: threadId,
+      title: derivedTitle,
+      created_at: timestamp,
+      updated_at: timestamp,
+    });
+  }
+
+  return {
+    ...current,
+    threads: nextThreads,
+    next_cursor: current.next_cursor ?? null,
+  };
+}
+
+export function upsertThreadInCache(thread) {
+  queryClient.setQueryData?.(THREADS_QUERY_KEY, (data) =>
+    upsertThreadList(data, thread),
+  );
+}
+
+export function touchThreadInCache(update) {
+  queryClient.setQueryData?.(THREADS_QUERY_KEY, (data) =>
+    touchThreadList(data, update),
+  );
+}

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/thread-cache.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/thread-cache.js
@@ -36,17 +36,22 @@ export function upsertThreadList(data, thread) {
 
   const current = threadListData(data);
   const threads = Array.isArray(current.threads) ? current.threads : [];
-  let found = false;
-  const nextThreads = threads.map((existing) => {
-    if (threadIdFor(existing) !== record.thread_id) return existing;
-    found = true;
-    return { ...existing, ...record, thread_id: record.thread_id };
-  });
-  if (!found) nextThreads.unshift(record);
+  let promoted = null;
+  const remaining = [];
+
+  for (const existing of threads) {
+    if (threadIdFor(existing) !== record.thread_id) {
+      remaining.push(existing);
+      continue;
+    }
+    if (!promoted) {
+      promoted = { ...existing, ...record, thread_id: record.thread_id };
+    }
+  }
 
   return {
     ...current,
-    threads: nextThreads,
+    threads: [promoted || record, ...remaining],
     next_cursor: current.next_cursor ?? null,
   };
 }
@@ -58,31 +63,36 @@ export function touchThreadList(data, { threadId, messageContent, updatedAt }) {
   const threads = Array.isArray(current.threads) ? current.threads : [];
   const derivedTitle = deriveSidebarTitle(messageContent);
   const timestamp = updatedAt || new Date().toISOString();
-  let found = false;
+  let promoted = null;
+  const remaining = [];
 
-  const nextThreads = threads.map((existing) => {
-    if (threadIdFor(existing) !== threadId) return existing;
-    found = true;
-    return {
-      ...existing,
-      thread_id: threadId,
-      title: existing.title || derivedTitle || null,
-      updated_at: timestamp,
-    };
-  });
+  for (const existing of threads) {
+    if (threadIdFor(existing) !== threadId) {
+      remaining.push(existing);
+      continue;
+    }
+    if (!promoted) {
+      promoted = {
+        ...existing,
+        thread_id: threadId,
+        title: existing.title || derivedTitle || null,
+        updated_at: timestamp,
+      };
+    }
+  }
 
-  if (!found) {
-    nextThreads.unshift({
+  if (!promoted) {
+    promoted = {
       thread_id: threadId,
       title: derivedTitle,
       created_at: timestamp,
       updated_at: timestamp,
-    });
+    };
   }
 
   return {
     ...current,
-    threads: nextThreads,
+    threads: [promoted, ...remaining],
     next_cursor: current.next_cursor ?? null,
   };
 }

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/thread-cache.test.mjs
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/thread-cache.test.mjs
@@ -1,0 +1,129 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import vm from "node:vm";
+
+function threadCacheSourceForTest() {
+  const source = readFileSync(
+    new URL("./thread-cache.js", import.meta.url),
+    "utf8",
+  );
+  const lines = [];
+  for (const line of source.split("\n")) {
+    if (line.startsWith("import ")) continue;
+    lines.push(line.replace(/^export function /, "function "));
+  }
+  return `${lines.join("\n")}
+globalThis.__testExports = {
+  deriveSidebarTitle,
+  touchThreadList,
+  upsertThreadList,
+};`;
+}
+
+function loadThreadCache() {
+  const context = { Array, Date, String, globalThis: {} };
+  vm.runInNewContext(threadCacheSourceForTest(), context);
+  return context.globalThis.__testExports;
+}
+
+function normalize(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+test("deriveSidebarTitle uses the first non-empty line", () => {
+  const { deriveSidebarTitle } = loadThreadCache();
+
+  assert.equal(
+    deriveSidebarTitle("\n\n  hello thread  \nsecond line"),
+    "hello thread",
+  );
+  assert.equal(deriveSidebarTitle("   "), null);
+});
+
+test("deriveSidebarTitle truncates long titles", () => {
+  const { deriveSidebarTitle } = loadThreadCache();
+  const title = deriveSidebarTitle("a".repeat(70));
+
+  assert.equal(title.length, 60);
+  assert.equal(title, `${"a".repeat(57)}...`);
+});
+
+test("upsertThreadList inserts a created thread and preserves pagination metadata", () => {
+  const { upsertThreadList } = loadThreadCache();
+  const data = { threads: [{ thread_id: "thread-old" }], next_cursor: "cursor-1" };
+
+  assert.deepEqual(
+    normalize(upsertThreadList(data, { thread_id: "thread-new", title: "New" })),
+    {
+      threads: [
+        { thread_id: "thread-new", title: "New" },
+        { thread_id: "thread-old" },
+      ],
+      next_cursor: "cursor-1",
+    },
+  );
+});
+
+test("upsertThreadList merges an existing thread record", () => {
+  const { upsertThreadList } = loadThreadCache();
+  const data = {
+    threads: [{ thread_id: "thread-1", title: null, created_at: "before" }],
+    next_cursor: null,
+  };
+
+  assert.deepEqual(
+    normalize(upsertThreadList(data, { thread_id: "thread-1", title: "Updated" })),
+    {
+      threads: [{ thread_id: "thread-1", title: "Updated", created_at: "before" }],
+      next_cursor: null,
+    },
+  );
+});
+
+test("touchThreadList updates activity without overwriting an existing title", () => {
+  const { touchThreadList } = loadThreadCache();
+  const data = {
+    threads: [{ thread_id: "thread-1", title: "Existing", updated_at: "before" }],
+    next_cursor: "cursor-1",
+  };
+
+  assert.deepEqual(
+    normalize(
+      touchThreadList(data, {
+        threadId: "thread-1",
+        messageContent: "new first message",
+        updatedAt: "after",
+      }),
+    ),
+    {
+      threads: [{ thread_id: "thread-1", title: "Existing", updated_at: "after" }],
+      next_cursor: "cursor-1",
+    },
+  );
+});
+
+test("touchThreadList creates a minimal missing thread record", () => {
+  const { touchThreadList } = loadThreadCache();
+
+  assert.deepEqual(
+    normalize(
+      touchThreadList(undefined, {
+        threadId: "thread-new",
+        messageContent: "hello world",
+        updatedAt: "now",
+      }),
+    ),
+    {
+      threads: [
+        {
+          thread_id: "thread-new",
+          title: "hello world",
+          created_at: "now",
+          updated_at: "now",
+        },
+      ],
+      next_cursor: null,
+    },
+  );
+});

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/thread-cache.test.mjs
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/thread-cache.test.mjs
@@ -68,14 +68,22 @@ test("upsertThreadList inserts a created thread and preserves pagination metadat
 test("upsertThreadList merges an existing thread record", () => {
   const { upsertThreadList } = loadThreadCache();
   const data = {
-    threads: [{ thread_id: "thread-1", title: null, created_at: "before" }],
+    threads: [
+      { thread_id: "thread-newer", title: "Newer" },
+      { thread_id: "thread-1", title: null, created_at: "before" },
+      { thread_id: "thread-older", title: "Older" },
+    ],
     next_cursor: null,
   };
 
   assert.deepEqual(
     normalize(upsertThreadList(data, { thread_id: "thread-1", title: "Updated" })),
     {
-      threads: [{ thread_id: "thread-1", title: "Updated", created_at: "before" }],
+      threads: [
+        { thread_id: "thread-1", title: "Updated", created_at: "before" },
+        { thread_id: "thread-newer", title: "Newer" },
+        { thread_id: "thread-older", title: "Older" },
+      ],
       next_cursor: null,
     },
   );
@@ -84,7 +92,11 @@ test("upsertThreadList merges an existing thread record", () => {
 test("touchThreadList updates activity without overwriting an existing title", () => {
   const { touchThreadList } = loadThreadCache();
   const data = {
-    threads: [{ thread_id: "thread-1", title: "Existing", updated_at: "before" }],
+    threads: [
+      { thread_id: "thread-newer", title: "Newer", updated_at: "newer" },
+      { thread_id: "thread-1", title: "Existing", updated_at: "before" },
+      { thread_id: "thread-older", title: "Older", updated_at: "older" },
+    ],
     next_cursor: "cursor-1",
   };
 
@@ -97,7 +109,11 @@ test("touchThreadList updates activity without overwriting an existing title", (
       }),
     ),
     {
-      threads: [{ thread_id: "thread-1", title: "Existing", updated_at: "after" }],
+      threads: [
+        { thread_id: "thread-1", title: "Existing", updated_at: "after" },
+        { thread_id: "thread-newer", title: "Newer", updated_at: "newer" },
+        { thread_id: "thread-older", title: "Older", updated_at: "older" },
+      ],
       next_cursor: "cursor-1",
     },
   );

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/useChat-send.test.mjs
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/useChat-send.test.mjs
@@ -370,10 +370,12 @@ test("useChat.send: touches sidebar cache without refetching thread list", async
   runUseChatSource(context);
 
   const chat = context.globalThis.__testExports.useChat(threadId);
-  await chat.send("hello from the existing thread");
+  await chat.send("raw wire content", {
+    displayContent: "visible sidebar title",
+  });
 
   assert.equal(touched.threadId, threadId);
-  assert.equal(touched.messageContent, "hello from the existing thread");
+  assert.equal(touched.messageContent, "visible sidebar title");
   assert.match(touched.updatedAt, /^\d{4}-\d{2}-\d{2}T/);
 });
 

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/useChat-send.test.mjs
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/useChat-send.test.mjs
@@ -59,6 +59,8 @@ function runUseChatSource(context) {
     resetToolActivityState,
     timelineMessageIdFromAcceptedRef,
   });
+  if (!("touchThreadInCache" in context)) context.touchThreadInCache = () => {};
+  if (!("upsertThreadInCache" in context)) context.upsertThreadInCache = () => {};
   vm.runInNewContext(useChatSourceForTest(), context);
 }
 
@@ -351,6 +353,28 @@ test("useChat.send: stamps render attachments on the optimistic message", async 
       preview_url: "data:image/png;base64,cG5n",
     },
   ]);
+});
+
+test("useChat.send: touches sidebar cache without refetching thread list", async () => {
+  const threadId = "thread-1";
+  const { context } = createSendCaptureContext();
+  let touched = null;
+
+  context.queryClient.invalidateQueries = () => {
+    throw new Error("send should not refetch the full thread list");
+  };
+  context.touchThreadInCache = (update) => {
+    touched = update;
+  };
+
+  runUseChatSource(context);
+
+  const chat = context.globalThis.__testExports.useChat(threadId);
+  await chat.send("hello from the existing thread");
+
+  assert.equal(touched.threadId, threadId);
+  assert.equal(touched.messageContent, "hello from the existing thread");
+  assert.match(touched.updatedAt, /^\d{4}-\d{2}-\d{2}T/);
 });
 
 test("useChat.send: target-thread send does not append into active thread", async () => {
@@ -1896,6 +1920,7 @@ test("useChat.cancelRun completion does not clear a newer run", async () => {
 test("useChat.send: ordinary Slack chat prompts submit to the model", async () => {
   let createThreadCalled = false;
   let sentContent = null;
+  let upsertedThread = null;
 
   const context = {
     AbortController,
@@ -1916,7 +1941,9 @@ test("useChat.send: ordinary Slack chat prompts submit to the model", async () =
     globalThis: {},
     queryClient: {
       fetchQuery: async ({ queryFn }) => queryFn(),
-      invalidateQueries: () => {},
+      invalidateQueries: () => {
+        throw new Error("first send should not refetch the full thread list");
+      },
     },
     recordAcceptedMessageRef,
     removePending,
@@ -1933,6 +1960,9 @@ test("useChat.send: ordinary Slack chat prompts submit to the model", async () =
     setInterval,
     setTimeout,
     submitManualToken: async () => {},
+    upsertThreadInCache: (thread) => {
+      upsertedThread = thread;
+    },
     useChatEvents: () => () => {},
     useHistory: () => ({
       messages: [],
@@ -1955,6 +1985,7 @@ test("useChat.send: ordinary Slack chat prompts submit to the model", async () =
   assert.equal(sentContent, "setup a Slack regex for chat routing");
   assert.equal(response.channel_connect_action, undefined);
   assert.equal(response.thread_id, "thread-created");
+  assert.deepEqual(upsertedThread, { thread_id: "thread-created" });
 });
 
 test("useChat.send: rejected_busy appends system notice, marks optimistic failed, clears isProcessing", async () => {


### PR DESCRIPTION
## Summary
- update the v2 chat sidebar cache locally after thread create/send instead of invalidating the full threads query
- keep delete invalidation unchanged so removals still reconcile with server state
- add focused cache-helper and hook tests covering create/send without full list refetch

## Why
Instances with many inactive threads can lag when the frontend refetches `/api/webchat/v2/threads` after send/create. This is a surgical frontend mitigation so we can test whether avoiding that hot list path removes the observed user-facing lag while the backend list implementation remains unchanged.

## Validation
- `node --test crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/thread-cache.test.mjs`
- `node --test crates/ironclaw_webui_v2_static/static/js/pages/chat/hooks/useThreads.test.mjs`
- `node --test crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/useChat-send.test.mjs`

## Notes
This does not change backend storage or thread listing semantics. The longer-term fix is still to stop `list_threads_for_scope` from tree-scanning the whole thread filesystem.