### PR TITLE
fix(reborn): skip response leak-sanitization for OAuth token exchange

### DIFF
--- a/crates/ironclaw_host_api/src/http.rs
+++ b/crates/ironclaw_host_api/src/http.rs
@@ -414,6 +414,24 @@ pub trait RuntimeHttpEgress: Send + Sync {
         &self,
         request: RuntimeHttpEgressRequest,
     ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError>;
+
+    /// Egress for an internal credential exchange (e.g. an OAuth token
+    /// endpoint). The response legitimately carries credential material that
+    /// the host auth system consumes directly — parsed and re-stored as a
+    /// secret handle — and never surfaces to the model. Response
+    /// leak-sanitization is therefore skipped: it would otherwise redact or
+    /// hard-block the very token this call exists to retrieve.
+    ///
+    /// The default forwards to [`RuntimeHttpEgress::execute`], which is correct
+    /// for implementations that never sanitize responses (e.g. test fakes).
+    /// The production host egress service overrides this to run the transport
+    /// pipeline without the response sanitizer.
+    async fn execute_credential_exchange(
+        &self,
+        request: RuntimeHttpEgressRequest,
+    ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {
+        self.execute(request).await
+    }
 }
 
 #[async_trait]
@@ -426,6 +444,13 @@ where
         request: RuntimeHttpEgressRequest,
     ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {
         self.as_ref().execute(request).await
+    }
+
+    async fn execute_credential_exchange(
+        &self,
+        request: RuntimeHttpEgressRequest,
+    ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {
+        self.as_ref().execute_credential_exchange(request).await
     }
 }
 

--- a/crates/ironclaw_host_runtime/src/egress/mod.rs
+++ b/crates/ironclaw_host_runtime/src/egress/mod.rs
@@ -186,6 +186,27 @@ where
             }
         }
     }
+
+    async fn execute_credential_exchange(
+        &self,
+        request: RuntimeHttpEgressRequest,
+    ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {
+        let scope = request.scope.clone();
+        let capability_id = request.capability_id.clone();
+        let result = pipeline::execute_credential_exchange(self, request).await;
+        match result {
+            Ok(response) => Ok(response),
+            Err(error) => {
+                if error.should_discard_staged_policy() {
+                    self.discard_staged_policy(&scope, &capability_id);
+                }
+                if error.should_discard_staged_secret_injections() {
+                    self.discard_staged_secret_injections(&scope, &capability_id);
+                }
+                Err(error.into_inner())
+            }
+        }
+    }
 }
 
 #[async_trait]

--- a/crates/ironclaw_host_runtime/src/egress/pipeline.rs
+++ b/crates/ironclaw_host_runtime/src/egress/pipeline.rs
@@ -19,7 +19,7 @@ where
     N: NetworkHttpEgress + Send + Sync,
     S: SecretStore + Send + Sync,
 {
-    execute_inner(service, request, false).await
+    execute_inner(service, request, false, false).await
 }
 
 pub(super) async fn execute_for_model_visible_output<N, S>(
@@ -30,13 +30,29 @@ where
     N: NetworkHttpEgress + Send + Sync,
     S: SecretStore + Send + Sync,
 {
-    execute_inner(service, request, true).await
+    execute_inner(service, request, true, false).await
+}
+
+/// Transport for an internal credential exchange (OAuth token endpoint).
+/// Identical to [`execute`] except response leak-sanitization is skipped, so
+/// the credential in the response body reaches the host auth caller intact.
+/// Request-side leak validation and credential injection still apply.
+pub(super) async fn execute_credential_exchange<N, S>(
+    service: &HostHttpEgressService<N, S>,
+    request: RuntimeHttpEgressRequest,
+) -> Result<RuntimeHttpEgressResponse, PipelineError>
+where
+    N: NetworkHttpEgress + Send + Sync,
+    S: SecretStore + Send + Sync,
+{
+    execute_inner(service, request, false, true).await
 }
 
 async fn execute_inner<N, S>(
     service: &HostHttpEgressService<N, S>,
     mut request: RuntimeHttpEgressRequest,
     allow_partial_response_body: bool,
+    skip_response_sanitization: bool,
 ) -> Result<RuntimeHttpEgressResponse, PipelineError>
 where
     N: NetworkHttpEgress + Send + Sync,
@@ -62,12 +78,21 @@ where
         dispatch_network(service, request, network_policy).await?
     };
     let credentials_injected = !redaction_values.is_empty();
-    let (response, response_redacted) = super::sanitize::sanitize_runtime_response(
-        response,
-        &redaction_values,
-        service.leak_detector(),
-    )
-    .map_err(PipelineError::post_transport)?;
+    let (response, response_redacted) = if skip_response_sanitization {
+        // Credential-exchange responses (OAuth token endpoints) are consumed by
+        // the host auth system and never surfaced to the model, so the response
+        // sanitizer is bypassed — it would otherwise redact or hard-block the
+        // token this call exists to fetch. Safe here because such requests
+        // carry no injected credentials to redact (redaction_values is empty).
+        (response, false)
+    } else {
+        super::sanitize::sanitize_runtime_response(
+            response,
+            &redaction_values,
+            service.leak_detector(),
+        )
+        .map_err(PipelineError::post_transport)?
+    };
     let (response, saved_body) = http_body::apply_body_disposition(
         response,
         save_body_to,

--- a/crates/ironclaw_reborn_composition/src/oauth_provider_client.rs
+++ b/crates/ironclaw_reborn_composition/src/oauth_provider_client.rs
@@ -244,7 +244,7 @@ impl HostOAuthProviderClient {
         })?;
         let response = self
             .egress
-            .execute(RuntimeHttpEgressRequest {
+            .execute_credential_exchange(RuntimeHttpEgressRequest {
                 runtime: self.runtime,
                 scope,
                 capability_id: self.capability_id.clone(),


### PR DESCRIPTION
## What

Adds `RuntimeHttpEgress::execute_credential_exchange` — an egress path for internal credential exchanges (OAuth token endpoints) that **skips response leak-sanitization** — and routes `HostOAuthProviderClient`'s token exchange + refresh through it.

## Why

The host egress pipeline runs every response through the leak detector (`sanitize_runtime_response`). An OAuth token-endpoint response *legitimately* contains credential material (access/refresh tokens), so the detector **hard-blocks** it (`response_leak_blocked`) and the token never reaches the caller.

Observed live: a Slack `oauth.v2.access` response was blocked, so the callback returned `backend_unavailable` and no credential was stored. Google works only by luck — its token response doesn't happen to match a leak pattern. This is latent breakage for **any** provider whose token response trips the scanner, not a Slack-specific issue.

## Why this is safe

The credential-exchange response is consumed by the host auth system (parsed and re-stored as a secret handle via the secret store) and is **never surfaced to the model or a channel**. These requests also carry **no injected credentials** (`credential_injections` is empty), so there are no injected values to redact. Request-side leak validation and credential injection are unchanged; only response sanitization is skipped, and only on this dedicated path.

## Scope

- `ironclaw_host_api`: trait method (default forwards to `execute`, correct for non-sanitizing test fakes) + `Arc<T>` forwarding.
- `ironclaw_host_runtime`: `pipeline::execute_credential_exchange` (`execute_inner` gains a `skip_response_sanitization` flag; existing callers pass `false`) + `HostHttpEgressService` override.
- `ironclaw_reborn_composition`: `HostOAuthProviderClient::execute_token_request` calls the new method (covers code exchange **and** refresh).

## Testing

`cargo check`/`clippy` clean; egress + provider tests pass. This unblocks the Slack personal OAuth feature (separate PR, which depends on this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)