### PR TITLE
test(e2e): black-box smoke for ironclaw-reborn serve — restart + kill-9 durability

### DIFF
--- a/.github/workflows/reborn-e2e.yml
+++ b/.github/workflows/reborn-e2e.yml
@@ -293,6 +293,64 @@ jobs:
           path: tests/e2e/screenshots/
           if-no-files-found: ignore
 
+  blackbox-smoke:
+    name: Reborn black-box smoke
+    needs: changes
+    if: needs.changes.outputs.has_e2e_scope == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+          persist-credentials: false
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: Enable pnpm for setup-node cache
+        run: corepack enable pnpm
+
+      - name: Install Node.js for WebUI bundle build
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+          cache-dependency-path: crates/ironclaw_webui_v2/frontend/pnpm-lock.yaml
+
+      - name: Enable pnpm
+        run: corepack enable pnpm
+
+      - name: Install WebUI frontend dependencies
+        run: |
+          cd crates/ironclaw_webui_v2/frontend
+          pnpm install --frozen-lockfile
+
+      - name: Restore Rust cache
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          key: reborn-e2e-blackbox-smoke
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+
+      - name: Build ironclaw-reborn with WebChat v2 surface
+        run: cargo build -p ironclaw_reborn_cli --features webui-v2-beta --bin ironclaw-reborn
+
+      - name: Install Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: tests/e2e/pyproject.toml
+
+      - name: Install E2E dependencies
+        run: |
+          cd tests/e2e
+          pip install -e .
+
+      - name: Run Reborn black-box smoke
+        run: pytest tests/e2e/scenarios/test_reborn_blackbox_smoke.py -v --timeout=120
+
   reborn-e2e:
     name: Reborn E2E
     runs-on: ubuntu-latest
@@ -302,6 +360,7 @@ jobs:
       - rust-reborn
       - gateway-smoke
       - webui-v2-smoke
+      - blackbox-smoke
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -333,5 +392,9 @@ jobs:
           fi
           if ! job_result_ok "webui-v2-smoke" "${{ needs.webui-v2-smoke.result }}" false "allow"; then
             echo "Reborn WebUI v2 smoke failed"
+            exit 1
+          fi
+          if ! job_result_ok "blackbox-smoke" "${{ needs.blackbox-smoke.result }}" false "allow"; then
+            echo "Reborn black-box smoke failed"
             exit 1
           fi

--- a/tests/e2e/reborn_webui_harness.py
+++ b/tests/e2e/reborn_webui_harness.py
@@ -196,6 +196,16 @@ async def close_reborn_server(proc) -> None:
             await stop_process(proc, sig=signal.SIGTERM, timeout=5)
 
 
+async def kill_reborn_server(proc) -> None:
+    """Hard-kill (SIGKILL) the reborn process, skipping graceful shutdown entirely.
+
+    Used by durability scenarios that need to prove on-disk state survives an
+    unclean process death, as opposed to `close_reborn_server`'s SIGINT/SIGTERM path.
+    """
+    if proc is not None and proc.returncode is None:
+        await stop_process(proc, sig=signal.SIGKILL, timeout=5)
+
+
 async def enable_reborn_global_auto_approve(base_url: str) -> None:
     """Enable the Tools settings global auto-approve switch for this test user."""
     async with httpx.AsyncClient(headers=reborn_bearer_headers()) as client:
@@ -271,7 +281,13 @@ async def reborn_v2_private_installs_yolo_server(
 async def reborn_v2_restartable_server(
     ironclaw_reborn_binary, mock_llm_server, tmp_path_factory
 ):
-    """Start/stop Reborn against one persistent home directory."""
+    """Start/stop Reborn against one persistent home directory.
+
+    `stop(hard=True)` SIGKILLs the process instead of shutting it down
+    gracefully, for durability scenarios that need to prove on-disk state
+    survives an unclean death — the caller can read the killed PID off
+    `state["proc"].pid` beforehand for a post-kill leak check.
+    """
     home_dir = tmp_path_factory.mktemp("ironclaw-reborn-v2-restartable-home")
     state = {"proc": None, "base_url": None}
 
@@ -287,8 +303,11 @@ async def reborn_v2_restartable_server(
         state["base_url"] = base_url
         return base_url
 
-    async def stop() -> None:
-        await close_reborn_server(state["proc"])
+    async def stop(*, hard: bool = False) -> None:
+        if hard:
+            await kill_reborn_server(state["proc"])
+        else:
+            await close_reborn_server(state["proc"])
         state["proc"] = None
 
     await start()

--- a/tests/e2e/scenarios/test_reborn_blackbox_smoke.py
+++ b/tests/e2e/scenarios/test_reborn_blackbox_smoke.py
@@ -1,0 +1,193 @@
+"""True black-box smoke suite for `ironclaw-reborn serve`.
+
+The in-process Reborn integration harness (`tests/integration/`) is the
+coverage workhorse for Reborn behavior, but it cannot prove three things: real
+process startup, real HTTP end-to-end, and process-death durability (its
+`new_at_path()` reopen approximates a restart; it cannot cover kill -9 /
+partial-write / lock-file behavior). This suite is the thin black-box layer on
+top of the real `ironclaw-reborn` binary — SMALL and permanent, five
+scenarios, not a second workhorse. Resist scope growth here; deeper
+functional/UI coverage belongs in `test_reborn_webui_v2_smoke.py` and its
+siblings, not this file.
+
+Pure HTTP via `httpx` — no Playwright/browser fixture, since nothing here
+needs to render the SPA. All process/config plumbing (config TOML, bearer
+env, mock-LLM wiring, start/stop/restart) is reused from
+`reborn_webui_harness.py`; see that module for the shared implementation.
+
+Run directly:
+
+    cd tests/e2e && source .venv/bin/activate
+    pytest scenarios/test_reborn_blackbox_smoke.py -v
+
+Wired into CI as the `blackbox-smoke` job in `.github/workflows/reborn-e2e.yml`.
+"""
+
+import os
+import shutil
+import subprocess
+
+import httpx
+
+from reborn_webui_harness import (
+    create_thread,
+    fetch_timeline,
+    finalized_assistant_count,
+    reborn_bearer_headers,
+    reborn_v2_restartable_server,  # noqa: F401 - imported fixture
+    reborn_v2_server,  # noqa: F401 - imported fixture
+    reborn_v2_yolo_server,  # noqa: F401 - imported fixture
+    send_message,
+    wait_for_assistant_message,
+    wait_for_capability_preview,
+)
+
+
+def _descendant_pids(pid: int) -> list[int]:
+    """Snapshot the full subtree of live descendant PIDs under `pid`.
+
+    Must be called while `pid` is still alive: once the parent dies its children
+    are reparented (to init or a subreaper), so `pgrep -P <pid>` no longer lists
+    them. A post-mortem `pgrep -P <pid>` would therefore always come back empty
+    and pass vacuously — the leak check has to capture the tree first, then probe
+    each captured PID directly after the kill.
+    """
+    descendants: list[int] = []
+    frontier = [pid]
+    while frontier:
+        parent = frontier.pop()
+        result = subprocess.run(
+            ["pgrep", "-P", str(parent)], capture_output=True, text=True
+        )
+        for token in result.stdout.split():
+            child = int(token)
+            descendants.append(child)
+            frontier.append(child)
+    return descendants
+
+
+def _pid_alive(pid: int) -> bool:
+    """True if `pid` still names a live process (signal 0 probe, no signal sent)."""
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Exists but owned by another user — still counts as alive.
+        return True
+    return True
+
+
+async def test_reborn_blackbox_boot_health_and_chat_roundtrip(reborn_v2_server):
+    """`serve` boots, `/api/health` responds, and a scripted chat turn round-trips."""
+    async with httpx.AsyncClient() as anon:
+        health = await anon.get(f"{reborn_v2_server}/api/health", timeout=15)
+        assert health.status_code == 200, health.text
+
+    async with httpx.AsyncClient(headers=reborn_bearer_headers()) as client:
+        thread_id = await create_thread(client, reborn_v2_server)
+        await send_message(client, reborn_v2_server, thread_id, "what is 2 + 2?")
+        reply = await wait_for_assistant_message(client, reborn_v2_server, thread_id)
+
+    assert reply["content"] == "The answer is 4.", reply
+
+
+async def test_reborn_blackbox_tool_call_turn_executes_and_replies(reborn_v2_yolo_server):
+    """A tool-call turn executes the tool and then finalizes a reply.
+
+    Uses the auto-approve `yolo` profile so the turn isn't blocked on an
+    approval gate — gate behavior itself is covered by the tool-permissions
+    and approval scenario files, not this black-box smoke.
+    """
+    marker = "blackbox-smoke-echo-8821"
+    async with httpx.AsyncClient(headers=reborn_bearer_headers()) as client:
+        thread_id = await create_thread(client, reborn_v2_yolo_server)
+        await send_message(
+            client, reborn_v2_yolo_server, thread_id, f"reborn builtin echo {marker}"
+        )
+        preview = await wait_for_capability_preview(
+            client,
+            reborn_v2_yolo_server,
+            thread_id,
+            "builtin.echo",
+            output_fragment=marker,
+        )
+        await wait_for_assistant_message(client, reborn_v2_yolo_server, thread_id)
+
+    assert preview["status"] == "completed", preview
+    assert marker in (preview.get("output_preview") or ""), preview
+
+
+async def test_reborn_blackbox_graceful_restart_preserves_thread_history(
+    reborn_v2_restartable_server,
+):
+    """SIGINT -> start: prior thread/turn history survives a graceful restart."""
+    state, start_server, stop_server = reborn_v2_restartable_server
+
+    async with httpx.AsyncClient(headers=reborn_bearer_headers()) as client:
+        thread_id = await create_thread(client, state["base_url"])
+        await send_message(client, state["base_url"], thread_id, "what is 2 + 2?")
+        await wait_for_assistant_message(client, state["base_url"], thread_id)
+
+    await stop_server()
+    restarted_url = await start_server()
+
+    async with httpx.AsyncClient(headers=reborn_bearer_headers()) as client:
+        timeline = await fetch_timeline(client, restarted_url, thread_id)
+
+    assert finalized_assistant_count(timeline) > 0, timeline
+
+
+async def test_reborn_blackbox_kill9_durability(reborn_v2_restartable_server):
+    """SIGKILL after a completed turn: data survives, server comes back healthy.
+
+    This is the scenario the in-process integration harness cannot cover —
+    its restart approximation (`new_at_path()` reopen) never actually kills a
+    process. Only a real black-box test can prove the on-disk libsql store
+    tolerates an unclean death with no wedge or corruption.
+    """
+    state, start_server, stop_server = reborn_v2_restartable_server
+
+    async with httpx.AsyncClient(headers=reborn_bearer_headers()) as client:
+        thread_id = await create_thread(client, state["base_url"])
+        await send_message(client, state["base_url"], thread_id, "what is 2 + 2?")
+        await wait_for_assistant_message(client, state["base_url"], thread_id)
+
+    pid = state["proc"].pid
+    # Snapshot the child process tree *before* the kill: after the parent dies
+    # its children reparent away, so they can only be checked by the PIDs we
+    # captured while it was alive (see `_descendant_pids`).
+    descendants = _descendant_pids(pid) if shutil.which("pgrep") is not None else []
+    await stop_server(hard=True)
+
+    still_alive = [child for child in descendants if _pid_alive(child)]
+    assert not still_alive, (
+        f"kill -9 of pid {pid} left descendant processes running: {still_alive}"
+    )
+
+    restarted_url = await start_server()
+
+    async with httpx.AsyncClient() as anon:
+        health = await anon.get(f"{restarted_url}/api/health", timeout=15)
+        assert health.status_code == 200, health.text
+
+    async with httpx.AsyncClient(headers=reborn_bearer_headers()) as client:
+        timeline = await fetch_timeline(client, restarted_url, thread_id)
+
+    assert finalized_assistant_count(timeline) > 0, timeline
+
+
+async def test_reborn_blackbox_auth_boundary(reborn_v2_server):
+    """A v2 route rejects a missing bearer with 401 and accepts a valid one with 200.
+
+    Minimal boundary check only — the full bearer/`?token=` shim matrix is
+    already covered by `test_reborn_v2_bearer_auth_and_token_shim_scope` in
+    `test_reborn_webui_v2_smoke.py`.
+    """
+    async with httpx.AsyncClient() as anon:
+        unauth = await anon.get(f"{reborn_v2_server}/api/webchat/v2/session", timeout=15)
+    assert unauth.status_code == 401, unauth.text
+
+    async with httpx.AsyncClient(headers=reborn_bearer_headers()) as client:
+        authed = await client.get(f"{reborn_v2_server}/api/webchat/v2/session", timeout=15)
+    assert authed.status_code == 200, authed.text


### PR DESCRIPTION
## What

Thin, permanent black-box smoke layer for the real `ironclaw-reborn serve` binary — the process-level scenarios the in-process integration harness cannot prove (real startup, real HTTP end-to-end, process-death durability). Deliberately small (~5 scenarios); not a second coverage workhorse.

## Scenarios (`tests/e2e/scenarios/test_reborn_blackbox_smoke.py`, HTTP-only via httpx, no browser)

| # | Scenario | Asserts |
|---|---|---|
| a | boot + health + chat round-trip | scripted mock-LLM reply content matches exactly |
| b | tool-call turn | model tool call executes → final reply lands |
| c | graceful restart (SIGINT → start) | prior thread/turn history visible after restart |
| d | **kill -9 durability** | SIGKILL → restart → thread + reply persisted (libsql on disk), server healthy, **no leaked child processes** (pgrep check) |
| e | bearer-auth boundary | no token → 401; token → 200 |

## Fixture work (reuse, not re-build)

- Extended the existing `reborn_v2_restartable_server` fixture (`tests/e2e/reborn_webui_harness.py`) with `kill_reborn_server()` (SIGKILL) via a `hard: bool = False` param on the existing `stop()` closure — 3-tuple return shape unchanged, zero edits needed in the existing consumer.
- Promoted `_wait_for_capability_preview`/`_preview_payload` from `test_reborn_webui_v2_legacy_tool_execution.py` into shared harness helpers (behavior-preserving dedupe; now used by two files).

## CI

New `blackbox-smoke` job in `.github/workflows/reborn-e2e.yml` (mirrors `webui-v2-smoke` build, no Playwright), wired into the `reborn-e2e` aggregate gate.

## Mutation evidence (scenario d)

Made `start()` allocate a fresh unlinked home dir per call → kill-9 test went RED for the right reason (timeline 404: persisted thread gone, not a timeout). Reverted; hunk diff back to 0 lines.

## Verification

- All 5 scenarios pass locally (multiple runs, 8–34s).
- Touched files' existing suites re-run post-refactor: tool_execution 9/9, tool_permissions 6/6.
- No leaked `ironclaw-reborn` processes after any run.
- Pre-existing, unrelated: `test_reborn_legacy_always_approve_survives_reborn_restart` fails in this local env identically with the branch stashed — not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)