### PR TITLE
ci(reborn): count crate-tier tests in coverage + unify allowlist (#5477, #5332)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,7 +12,9 @@
 # - PRs automatically get coverage comments showing changes in coverage
 # - Visit https://codecov.io/gh/nearai/ironclaw for detailed coverage reports
 # - Coverage reports are generated for three configurations:
-#   1. all-features: Full feature set
+#   1. all-features: postgres+libsql+html-to-markdown+bedrock+import (NOT
+#      literal --all-features — excludes deliberately-deferred forward-gate
+#      features like `pr7-ready`/`pr3180-ready`, see Cargo.toml; #5332)
 #   2. default: Default features
 #   3. libsql-only: Minimal libSQL-only configuration
 # - E2E coverage tracks end-to-end test coverage separately
@@ -56,7 +58,14 @@ jobs:
       matrix:
         include:
           - name: all-features
-            flags: "--all-features"
+            # Explicit feature list, NOT literal --all-features: the workspace
+            # carries deliberately-deferred forward gates (`pr7-ready`,
+            # `pr3180-ready` — see Cargo.toml) whose whole purpose is staying
+            # off until their follow-up PRs land. `--all-features` auto-enables
+            # them, silently un-ignoring tests that pin not-yet-implemented
+            # behavior (#5332). Mirrors the same fix already applied to
+            # test.yml and platform-and-compat.yml's own "all-features" leg.
+            flags: "--no-default-features --features postgres,libsql,html-to-markdown,bedrock,import"
             has_postgres: true
           - name: default
             flags: ""

--- a/.github/workflows/reborn-coverage.yml
+++ b/.github/workflows/reborn-coverage.yml
@@ -1,22 +1,32 @@
-# Reborn integration-tier coverage
+# Reborn coverage
 #
-# Runs cargo-llvm-cov over the Reborn in-process integration-tier test binaries
-# (tests/reborn_integration_*.rs + tests/reborn_group_*/) and reports a
-# Reborn-crate-scoped line-coverage percentage in the PR's job summary.
+# Runs cargo-llvm-cov over two tiers of Reborn tests and reports a
+# Reborn-crate-scoped line-coverage percentage in the PR's job summary:
+#   - Int-tier: the in-process integration test binaries
+#     (tests/reborn_integration_*.rs + tests/reborn_group_*/).
+#   - Crate-tier: each Reborn-family crate's own `tests/` suite (e.g.
+#     ironclaw_webui_v2, ironclaw_reborn_event_store), the same suites
+#     .github/workflows/reborn-tests.yml's crate-tests job gates PRs on.
+#     Without this tier, crates with real contract-test coverage but no
+#     int-tier suite of their own reported 0%.
 #
 # This is the measurable signal behind the Reborn backend's "100% int-tier
 # coverage" goal (task T0-COV): it yields a per-PR percentage and a per-crate
-# hole list. It is INFORMATIONAL only — it
-# does not gate the PR on a coverage threshold.
+# hole list. It is INFORMATIONAL only — it does not gate the PR on a coverage
+# threshold.
 #
 # Scope notes:
-# - Features: default (postgres + libsql + html-to-markdown + tui), matching
-#   how scripts/ci/run-reborn-root-partition.sh runs these same suites. No live
-#   Postgres is needed; the suites skip Postgres backends when DATABASE_URL is
-#   unset (backend_matrix stays libsql-only per the roadmap).
-# - The % is filtered to the Reborn crate families (crates/ironclaw_reborn*,
-#   ironclaw_product*, ironclaw_architecture, the v2 channel adapters,
-#   ironclaw_webui_v2*) via scripts/ci/reborn-coverage-summary.sh.
+# - Int-tier features: default (postgres + libsql + html-to-markdown + tui),
+#   matching how scripts/ci/run-reborn-root-partition.sh runs these same
+#   suites. No live Postgres is needed; the suites skip Postgres backends
+#   when DATABASE_URL is unset (backend_matrix stays libsql-only per the
+#   roadmap).
+# - Crate-tier features: resolved per package by
+#   scripts/ci/package-feature-flags.sh, the same source
+#   .github/workflows/reborn-tests.yml's crate-tests job uses.
+# - The package list for the crate tier, and the % filter over the combined
+#   export, both derive from scripts/ci/reborn-crate-family-regex.sh — the
+#   single owner of the Reborn crate-family predicate (#5477).
 
 name: Reborn Coverage
 
@@ -79,6 +89,18 @@ jobs:
         with:
           components: llvm-tools-preview
 
+      # The crate-tier pass always includes webui-v2-beta packages (ironclaw_reborn_cli,
+      # ironclaw_reborn_composition, ironclaw_webui_v2, ironclaw_webui_v2_static are
+      # permanent Reborn-family members), whose build.rs shells out to npm — unlike
+      # reborn-tests.yml's per-shard matrix, this single job always needs it, so
+      # installing it unconditionally is simpler than replicating that job's
+      # per-package detection.
+      - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: crates/ironclaw_webui_v2_static/frontend/package-lock.json
+
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: reborn-coverage
@@ -91,7 +113,7 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@62b0f2dec647a8e604c6a0fda0e38530180dce20 # cargo-llvm-cov
 
-      - name: Generate Reborn integration-tier coverage
+      - name: Generate Reborn coverage (int-tier + crate-tier)
         run: |
           set -euo pipefail
           # Process substitution hides the discovery script's exit code, so
@@ -104,14 +126,52 @@ jobs:
           echo "Running coverage over Reborn int-tier binaries:"
           printf '  %s %s\n' "${test_args[@]}"
 
+          mapfile -t crate_packages < <(scripts/ci/reborn-crate-family-packages.sh)
+          if [ "${#crate_packages[@]}" -eq 0 ]; then
+            echo "No Reborn crate-family packages discovered" >&2
+            exit 1
+          fi
+          echo "Running coverage over Reborn crate-tier package test suites:"
+          printf '  %s\n' "${crate_packages[@]}"
+
           cargo llvm-cov clean --workspace
-          # Combined run+report in ONE invocation: --workspace scopes the report
-          # to every member crate (incl. the linked-but-not-root Reborn crates),
-          # which the standalone `report` subcommand cannot do. The named root
-          # `--test` targets still run only in the root package. Default features,
-          # matching scripts/ci/run-reborn-root-partition.sh.
-          cargo llvm-cov --workspace "${test_args[@]}" \
-            --json --output-path reborn-llvm-cov.json -- --nocapture
+
+          # Int-tier: root/group [[test]] binaries. --workspace instruments every
+          # member crate (incl. the linked-but-not-root Reborn crates) so a crate
+          # untouched by this pass still shows up in the report at 0%, rather than
+          # being absent. Default features, matching
+          # scripts/ci/run-reborn-root-partition.sh. --no-report defers reporting
+          # until the crate-tier passes below are folded in too.
+          cargo llvm-cov --no-report --workspace "${test_args[@]}" -- --nocapture
+
+          # Crate-tier (Tier B): each Reborn-family crate's own test suite
+          # (--all-targets: unit tests, tests/, examples, benches — same target
+          # selection as reborn-tests.yml's crate-tests job), merged into the
+          # same coverage session via --no-report. Per-package feature selection
+          # and the per-package timeout also mirror that job, so the same tests
+          # that gate the PR are the ones counted here, and a hung crate suite
+          # is caught per-package instead of by the blanket job timeout.
+          for package in "${crate_packages[@]}"; do
+            feature_flags="$(scripts/ci/package-feature-flags.sh "${package}")"
+            echo "::group::cargo llvm-cov --package ${package} ${feature_flags}"
+            # shellcheck disable=SC2086 # feature_flags intentionally expands to zero or more Cargo args.
+            timeout --signal=INT --kill-after=30s 28m \
+              cargo llvm-cov --no-report --package "${package}" ${feature_flags} --all-targets -- --nocapture
+            echo "::endgroup::"
+          done
+
+          # Standalone `report`: aggregates the profile data every --no-report run
+          # above produced. Unlike the run/test subcommands, `report` has no
+          # --workspace flag (confirmed: `cargo llvm-cov report --workspace`
+          # errors as unsupported) — it only includes crates named via explicit
+          # --package flags, so list every Reborn-family package again. Only the
+          # Reborn family is needed here (not the full workspace): non-family
+          # crates are filtered out by reborn-coverage-summary.sh regardless.
+          report_package_args=()
+          for package in "${crate_packages[@]}"; do
+            report_package_args+=(--package "${package}")
+          done
+          cargo llvm-cov report --json --output-path reborn-llvm-cov.json "${report_package_args[@]}"
 
       - name: Render Reborn coverage summary
         run: |

--- a/.github/workflows/reborn-tests.yml
+++ b/.github/workflows/reborn-tests.yml
@@ -104,24 +104,12 @@ jobs:
         run: |
           # Reborn/product crate families that are always tested, including
           # crates the shipped binary does not link (channel adapters, webui_v2).
+          # scripts/ci/reborn-crate-family-packages.sh is the single owner of
+          # this predicate, shared with scripts/ci/reborn-coverage-summary.sh
+          # so the tested set and the reported set can't drift apart (#5477).
           allowlist_packages="$(
-            cargo metadata --no-deps --format-version 1 \
-              | jq -c '
-                  [
-                    .packages[]
-                    | select(
-                        (.name | startswith("ironclaw_reborn"))
-                        or (.name | startswith("ironclaw_product"))
-                        or (.name == "ironclaw_architecture")
-                        or (.name == "ironclaw_slack_v2_adapter")
-                        or (.name == "ironclaw_telegram_v2_adapter")
-                        or (.name == "ironclaw_wasm_product_adapters")
-                        or (.name | startswith("ironclaw_webui_v2"))
-                      )
-                    | .name
-                  ]
-                  | unique
-                '
+            scripts/ci/reborn-crate-family-packages.sh \
+              | jq -R -s -c 'split("\n") | map(select(length > 0))'
           )"
 
           # The full ironclaw_reborn_cli dependency closure: every workspace

--- a/scripts/ci/reborn-coverage-comment.sh
+++ b/scripts/ci/reborn-coverage-comment.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 #
-# Upsert a single sticky PR comment carrying the Reborn integration-tier
-# coverage summary, so the %/hole-list lives in the PR conversation instead of
-# being buried in the Actions job summary.
+# Upsert a single sticky PR comment carrying the Reborn coverage summary
+# (int-tier + crate-tier), so the %/hole-list lives in the PR conversation
+# instead of being buried in the Actions job summary.
 #
 # This is VISIBILITY ONLY — it never gates. The workflow step that runs it is
 # `continue-on-error: true`, so any failure here (notably: fork PRs get a
@@ -49,7 +49,7 @@ if [ "${#zero_crates[@]}" -gt 0 ]; then
   # Crate names are constrained to [a-z0-9_]+, so a plain ", " join is safe.
   crate_list="$(printf '%s, ' "${zero_crates[@]}")"
   crate_list="${crate_list%, }"
-  callout="⚠️ ${#zero_crates[@]} Reborn crate(s) have 0 int-tier coverage (target: 0) — ${crate_list}"
+  callout="⚠️ ${#zero_crates[@]} Reborn crate(s) have 0 test coverage (target: 0) — ${crate_list}"
 fi
 
 if [ -n "${callout}" ]; then

--- a/scripts/ci/reborn-coverage-summary.sh
+++ b/scripts/ci/reborn-coverage-summary.sh
@@ -3,10 +3,11 @@
 # Render a Reborn-scoped coverage summary from a cargo-llvm-cov JSON export.
 #
 # cargo-llvm-cov instruments the whole workspace build, so a run over the
-# Reborn integration-tier test binaries produces coverage for every linked
-# crate. This script filters that export down to the Reborn crate families and
-# computes an aggregate line-coverage percentage plus a per-crate breakdown
-# (the "hole list" — which Reborn crates are least covered).
+# Reborn test suites (int-tier binaries + per-crate suites) produces coverage
+# for every linked crate. This script filters that export down to the Reborn
+# crate families and computes an aggregate line-coverage percentage plus a
+# per-crate breakdown (the "hole list" — which Reborn crates are least
+# covered).
 #
 # Usage:
 #   reborn-coverage-summary.sh <llvm-cov-json-export>
@@ -18,9 +19,10 @@
 #     aggregation as the report — this script is the single owner of that
 #     computation so reborn-coverage-comment.sh never has to recompute it.
 #
-# The Reborn crate families mirror the package allowlist in
-# .github/workflows/reborn-tests.yml: ironclaw_reborn*, ironclaw_product*,
-# ironclaw_architecture, the v2 channel adapters, and ironclaw_webui_v2*.
+# The Reborn crate families are the single predicate in
+# reborn-crate-family-regex.sh, shared with the package allowlist in
+# .github/workflows/reborn-tests.yml so the tested set and the reported set
+# can't drift apart (#5477).
 
 set -euo pipefail
 
@@ -40,11 +42,11 @@ fi
 # Matches the absolute filenames llvm-cov emits, e.g.
 # /work/ironclaw/crates/ironclaw_reborn/src/runtime.rs
 #
-# Mirrors the Reborn crate allowlist in .github/workflows/reborn-tests.yml:
-# prefix-match for the reborn_*/product_*/webui_v2_* families, exact-match
-# (no trailing name chars before the "/") for the four single crates. The
-# trailing "/" anchors the crate-name boundary in all cases.
-reborn_regex='/crates/(ironclaw_(reborn|product|webui_v2)[a-z0-9_]*|ironclaw_architecture|ironclaw_slack_v2_adapter|ironclaw_telegram_v2_adapter|ironclaw_wasm_product_adapters)/'
+# The trailing "/" anchors the crate-name boundary for both the prefix-match
+# families (reborn_*/product_*/webui_v2_*) and the exact-match single crates
+# emitted by reborn-crate-family-regex.sh.
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+reborn_regex="/crates/($("${script_dir}/reborn-crate-family-regex.sh"))/"
 
 jq -r --arg re "${reborn_regex}" --arg mode "${mode}" '
   # Round to 2 decimal places.
@@ -80,7 +82,7 @@ jq -r --arg re "${reborn_regex}" --arg mode "${mode}" '
   | if $mode == "zero-crates"
     then ( $byCrate[] | select(.count > 0 and .covered == 0) | .crate )
     else
-      "## Reborn integration-tier coverage",
+      "## Reborn coverage",
       "",
       (if $total > 0
        then "**Line coverage (Reborn crates): \($pct | round2)%** — \($hit) / \($total) lines"

--- a/scripts/ci/reborn-crate-family-packages.sh
+++ b/scripts/ci/reborn-crate-family-packages.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# Print, one per line, the workspace package names that belong to the Reborn
+# crate family (per reborn-crate-family-regex.sh), sorted and deduped.
+#
+# This is the single discovery mechanism for "which Reborn-family crates have
+# their own test suite to count" — consumed by:
+#   - .github/workflows/reborn-tests.yml (package-matrix job's allowlist,
+#     unioned there with the separate `cargo tree` dependency-closure list)
+#   - .github/workflows/reborn-coverage.yml (Tier-B crate-tests coverage pass)
+# Deliberately narrower than reborn-tests.yml's closure union: crates outside
+# the Reborn family are filtered out of the coverage %/hole-list by
+# reborn-coverage-summary.sh anyway, so running their test suites here would
+# spend CI time with no visible effect on the report.
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "${script_dir}/../.."
+
+family_regex="$("${script_dir}/reborn-crate-family-regex.sh")"
+
+cargo metadata --no-deps --format-version 1 \
+  | jq -r --arg re "${family_regex}" '
+      [ .packages[] | select(.name | test("^(" + $re + ")$")) | .name ]
+      | unique
+      | .[]
+    '

--- a/scripts/ci/reborn-crate-family-regex.sh
+++ b/scripts/ci/reborn-crate-family-regex.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#
+# Single source of truth for the Reborn crate-family predicate: which
+# workspace crates count as "Reborn" for CI test discovery
+# (.github/workflows/reborn-tests.yml package-matrix) and coverage reporting
+# (scripts/ci/reborn-coverage-summary.sh, reborn-crate-family-packages.sh).
+# Both consumers previously hand-maintained their own copy of this set (a jq
+# startswith/== chain vs a regex), which could silently drift apart (#5477).
+# This is now the one place the crate-family membership is written down.
+#
+# Prints ONE line: a POSIX ERE alternation body (no anchors, no wrapping
+# capture group) that matches a Reborn-family package name exactly, e.g.
+# "ironclaw_reborn_composition" or "ironclaw_architecture". Callers add
+# whatever anchoring their context needs — e.g. `^(...)$` for jq's test(),
+# or `/crates/(...)/ ` to match an llvm-cov export's file path.
+
+set -euo pipefail
+
+printf '%s\n' 'ironclaw_reborn[a-z0-9_]*|ironclaw_product[a-z0-9_]*|ironclaw_webui_v2[a-z0-9_]*|ironclaw_architecture|ironclaw_slack_v2_adapter|ironclaw_telegram_v2_adapter|ironclaw_wasm_product_adapters'

--- a/scripts/ci/test-reborn-coverage.sh
+++ b/scripts/ci/test-reborn-coverage.sh
@@ -1,17 +1,19 @@
 #!/usr/bin/env bash
 #
-# Regression tests for the three Reborn coverage CI helpers:
+# Regression tests for the Reborn coverage CI helpers:
 #   - reborn-coverage-summary.sh        (report + --zero-crates modes)
 #   - reborn-coverage-comment.sh        (sticky PR comment upsert via `gh api`)
 #   - reborn-coverage-int-tier-tests.sh (int-tier suite discovery)
+#   - reborn-crate-family-regex.sh      (Reborn crate-family predicate, #5477)
+#   - reborn-crate-family-packages.sh   (crate-family package discovery)
 #
 # Mirrors test-classify-test-scope.sh: self-contained, locates the
 # scripts-under-test relative to this file's own directory, builds its own
 # fixtures in a mktemp dir, and reports PASS/FAIL per case. Unlike that
 # precedent (which exits on the first failure), this suite runs every case
 # and prints a final summary, exiting non-zero only if something failed —
-# with three scripts and ~20 cases, seeing the full picture in one run beats
-# stopping at the first mismatch.
+# with five scripts and dozens of cases, seeing the full picture in one run
+# beats stopping at the first mismatch.
 #
 # reborn-coverage-comment.sh shells out to `gh api`. It is exercised here
 # against a fake `gh` (a fixture script placed first on PATH) that emulates
@@ -31,6 +33,8 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 summary_sh="${script_dir}/reborn-coverage-summary.sh"
 comment_sh="${script_dir}/reborn-coverage-comment.sh"
 int_tier_sh="${script_dir}/reborn-coverage-int-tier-tests.sh"
+family_regex_sh="${script_dir}/reborn-crate-family-regex.sh"
+family_packages_sh="${script_dir}/reborn-crate-family-packages.sh"
 
 tmp_root="$(mktemp -d)"
 trap 'rm -rf "${tmp_root}"' EXIT
@@ -466,9 +470,9 @@ assert_exit_code "C3: comment script exits 0 (zero-covered crate present)" 0 "${
 if [ -f "${c3_log}" ]; then
   c3_body="$(sed -n '/^BODY_START$/,/^BODY_END$/p' "${c3_log}" | sed '1d;$d')"
   assert_contains "C3: body contains the 0-coverage callout" "${c3_body}" \
-    "⚠️ 1 Reborn crate(s) have 0 int-tier coverage"
+    "⚠️ 1 Reborn crate(s) have 0 test coverage"
   assert_line_before "C3: callout is prepended before the coverage header" "${c3_body}" \
-    "⚠️ 1 Reborn crate(s) have 0 int-tier coverage" "## Reborn integration-tier coverage"
+    "⚠️ 1 Reborn crate(s) have 0 test coverage" "## Reborn coverage"
 else
   report_fail "C3: fake gh did not record a mutation"
 fi
@@ -603,6 +607,61 @@ assert_exit_code "D4: multiple suites exits 0" 0 "${CAP_RC}"
 assert_eq "D4: multiple suites sorted+deduped in expected order" \
   "$(printf -- '--test\nreborn_group_beta\n--test\nreborn_group_omega\n--test\nreborn_integration_alpha\n--test\nreborn_integration_zeta')" \
   "${CAP_OUT}"
+
+# ---------------------------------------------------------------------------
+# E. reborn-crate-family-regex.sh / reborn-crate-family-packages.sh (#5477)
+# ---------------------------------------------------------------------------
+#
+# reborn-crate-family-regex.sh is pure static data (no cargo dependency), so
+# it's exercised directly with bash's own ERE engine. reborn-crate-family-packages.sh
+# runs `cargo metadata` and therefore, unlike every other script in this
+# suite, is run against the real repo rather than a synthetic fixture tree —
+# package discovery inherently needs a real Cargo.toml/Cargo.lock.
+
+capture "${family_regex_sh}"
+assert_exit_code "E1: family regex script exits 0" 0 "${CAP_RC}"
+family_regex="${CAP_OUT}"
+
+assert_family_match() {
+  local name="$1"
+  if [[ "${name}" =~ ^(${family_regex})$ ]]; then
+    report_pass "E1: '${name}' matches the Reborn family regex"
+  else
+    report_fail "E1: '${name}' matches the Reborn family regex"
+  fi
+}
+
+assert_family_no_match() {
+  local name="$1"
+  if [[ "${name}" =~ ^(${family_regex})$ ]]; then
+    report_fail "E1: '${name}' does NOT match the Reborn family regex"
+  else
+    report_pass "E1: '${name}' does NOT match the Reborn family regex"
+  fi
+}
+
+# Prefix-family members (bare name and a suffixed variant each).
+assert_family_match "ironclaw_reborn"
+assert_family_match "ironclaw_reborn_composition"
+assert_family_match "ironclaw_product_workflow"
+assert_family_match "ironclaw_webui_v2"
+assert_family_match "ironclaw_webui_v2_static"
+# Exact-match single crates.
+assert_family_match "ironclaw_architecture"
+assert_family_match "ironclaw_slack_v2_adapter"
+assert_family_match "ironclaw_telegram_v2_adapter"
+assert_family_match "ironclaw_wasm_product_adapters"
+# Non-family crates, including the same lookalike boundary case A6 pins
+# against reborn-coverage-summary.sh's assembled path regex.
+assert_family_no_match "ironclaw_engine"
+assert_family_no_match "ironclaw_architecture_extra"
+assert_family_no_match "ironclaw_telegram_v2_adapters"
+
+capture "${family_packages_sh}"
+assert_exit_code "E2: family packages script exits 0" 0 "${CAP_RC}"
+assert_contains "E2: package list includes exact-match ironclaw_architecture" "${CAP_OUT}" "ironclaw_architecture"
+assert_contains "E2: package list includes prefix-family ironclaw_webui_v2" "${CAP_OUT}" "ironclaw_webui_v2"
+assert_not_contains "E2: package list excludes non-family ironclaw_engine" "${CAP_OUT}" "ironclaw_engine"
 
 # ---------------------------------------------------------------------------
 # Summary


### PR DESCRIPTION
## What

The Reborn coverage job (T0-COV, #5430) counts ONLY the int-tier test binaries — the substantial per-crate contract suites (`crates/*/tests/`: webui_v2 e2e/serve/streaming, event-store, budget, approval-CAS) are invisible to it. The shipped 14.61% baseline therefore understates real coverage. Three fixes, one PR:

### 1. Count Tier-B crate tests (`.github/workflows/reborn-coverage.yml`)
- Split the single `cargo llvm-cov --workspace <int-tier> --json` invocation into: int-tier `--no-report` pass (scope unchanged) → per-package `--no-report --package <pkg> --all-targets` loop over the 21 Reborn-family crates (features via existing `scripts/ci/package-feature-flags.sh`, per-package 28m timeout mirroring `reborn-tests.yml`) → final `cargo llvm-cov report --json` with explicit `--package` flags.
- Note: a bare `report` produces an EMPTY export (`report` has no `--workspace` mode) — hence the explicit package flags; caught during local verification.
- Added unconditional `setup-node` (webui-v2-beta `build.rs` shells to npm; this job always includes those packages).

### 2. Unify the crate-family allowlist — closes #5477
- New `scripts/ci/reborn-crate-family-regex.sh` (single ERE, one source of truth) + `scripts/ci/reborn-crate-family-packages.sh` (`cargo metadata` filtered by it).
- `reborn-tests.yml`'s 20-line inline jq OR-chain and `reborn-coverage-summary.sh`'s hardcoded path regex now both derive from these. Verified equivalence: old predicate vs new script over real `cargo metadata` → identical 21 packages.

### 3. Stop `--all-features` un-ignoring deferred gates — closes #5332
- `coverage.yml` all-features leg → `--no-default-features --features postgres,libsql,html-to-markdown,bedrock,import` (verbatim from test.yml / platform-and-compat.yml's existing pattern). `pr7-ready`/`pr3180-ready` can no longer be auto-enabled.

## Verification

- Tier-B proof: `cargo llvm-cov --package ironclaw_webui_v2 --features webui-v2-beta --tests --summary-only` → **91.19% lines** (2,791 hit; 0% in the shipped job).
- Foreground end-to-end of the exact workflow mechanics: int-tier run (reborn_integration_greeting, 22 passed) + crate-tier run (ironclaw_reborn_config, 10 passed) merged into one export; refactored summary rendered both (`ironclaw_reborn_config 87.85%` alongside int-tier-only crates).
- `actionlint` clean (3 workflows), `shellcheck` clean (5 scripts), `test-reborn-coverage.sh` 79/79 (17 new cases).

## Expected effect

Reported Reborn line coverage jumps substantially once crate suites count (webui_v2 alone 0→~91%; event_store/budget/approval-CAS become visible). Job stays informational — never gates PRs.

## Watch items (first live runs)

- CI wall-clock: crate-tier loop = ~21 sequential package builds with differing feature sets in one job; measure against the 180-min backstop.
- Resolver feature-set thrash between loop iterations may cause partial rebuilds of shared deps.
- Real proof is the first CI run's summary — confirm the Tier-B-inclusive percentage renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)