### PR TITLE
feat(reborn): introduce private installs of tools (#5459 part 2)

### DIFF
--- a/crates/ironclaw_extensions/src/installations.rs
+++ b/crates/ironclaw_extensions/src/installations.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use ironclaw_host_api::{ExtensionId, HostPortCatalog, SecretHandle};
+use ironclaw_host_api::{ExtensionId, HostPortCatalog, SecretHandle, UserId};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use thiserror::Error;
 use tokio::sync::RwLock;
@@ -315,6 +315,53 @@ impl ExtensionHealthSnapshot {
     }
 }
 
+/// Who an installation belongs to (#5459 P1 — shared vs private installs).
+///
+/// `Tenant` = installed for the whole tenant (the historical behavior, and
+/// what an admin install produces): every user sees and can dispatch the
+/// extension's capabilities. `User` = private to the installing user: only
+/// they see it, only they get grants minted for it.
+///
+/// Legacy persisted records predate this field and deserialize as `Tenant`
+/// via `#[serde(default)]` — no migration required, no behavior change for
+/// existing installs.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum InstallationOwner {
+    #[default]
+    Tenant,
+    User {
+        user_id: UserId,
+    },
+}
+
+impl InstallationOwner {
+    pub fn user(user_id: UserId) -> Self {
+        Self::User { user_id }
+    }
+
+    pub fn is_tenant(&self) -> bool {
+        matches!(self, Self::Tenant)
+    }
+
+    /// The owning user, if the installation is user-private.
+    pub fn as_user(&self) -> Option<&UserId> {
+        match self {
+            Self::User { user_id } => Some(user_id),
+            Self::Tenant => None,
+        }
+    }
+
+    /// Whether `caller` may see/use this installation: tenant-wide entries
+    /// are visible to everyone, user-private entries only to their owner.
+    pub fn visible_to(&self, caller: &UserId) -> bool {
+        match self {
+            Self::Tenant => true,
+            Self::User { user_id } => user_id == caller,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct ExtensionInstallation {
     installation_id: ExtensionInstallationId,
@@ -324,6 +371,13 @@ pub struct ExtensionInstallation {
     credential_bindings: Vec<ExtensionCredentialBinding>,
     health: ExtensionHealthSnapshot,
     updated_at: DateTime<Utc>,
+    // Tenant-owned rows serialize WITHOUT the field so they keep the exact
+    // pre-#5459 byte shape: a rollback to an older binary (whose wire struct
+    // uses `deny_unknown_fields`) still loads a state.json that contains no
+    // private installs. Only user-private rows carry the field — the one
+    // shape an older binary genuinely cannot represent.
+    #[serde(default, skip_serializing_if = "InstallationOwner::is_tenant")]
+    owner: InstallationOwner,
 }
 
 impl ExtensionInstallation {
@@ -334,6 +388,7 @@ impl ExtensionInstallation {
         manifest_ref: ExtensionManifestRef,
         credential_bindings: Vec<ExtensionCredentialBinding>,
         updated_at: DateTime<Utc>,
+        owner: InstallationOwner,
     ) -> Result<Self, ExtensionInstallationError> {
         if manifest_ref.extension_id() != &extension_id {
             return Err(ExtensionInstallationError::ManifestExtensionMismatch {
@@ -350,6 +405,7 @@ impl ExtensionInstallation {
             credential_bindings,
             health: ExtensionHealthSnapshot::new(ExtensionHealthStatus::Healthy, None, updated_at),
             updated_at,
+            owner,
         })
     }
 
@@ -381,6 +437,10 @@ impl ExtensionInstallation {
         self.updated_at
     }
 
+    pub fn owner(&self) -> &InstallationOwner {
+        &self.owner
+    }
+
     fn set_activation_state(&mut self, state: ExtensionActivationState) {
         self.activation_state = state;
         self.updated_at = Utc::now();
@@ -407,6 +467,10 @@ impl<'de> Deserialize<'de> for ExtensionInstallation {
             credential_bindings: Vec<ExtensionCredentialBinding>,
             health: ExtensionHealthSnapshot,
             updated_at: DateTime<Utc>,
+            // Legacy records predate the owner field; they were all
+            // tenant-visible, so absent == Tenant is behavior-preserving.
+            #[serde(default)]
+            owner: InstallationOwner,
         }
         let wire = Wire::deserialize(deserializer)?;
         if wire.manifest_ref.extension_id() != &wire.extension_id {
@@ -426,6 +490,7 @@ impl<'de> Deserialize<'de> for ExtensionInstallation {
             credential_bindings: wire.credential_bindings,
             health: wire.health,
             updated_at: wire.updated_at,
+            owner: wire.owner,
         })
     }
 }
@@ -846,8 +911,44 @@ mod tests {
             ),
             Vec::new(),
             Utc::now(),
+            InstallationOwner::Tenant,
         )
         .expect("installation")
+    }
+
+    /// #5459 P1: legacy persisted rows predate the `owner` field and were all
+    /// tenant-visible; a record without it MUST deserialize as `Tenant` (no
+    /// migration). The inverse also holds: a TENANT-owned record serializes
+    /// WITHOUT the field, keeping the exact pre-#5459 byte shape so a rollback
+    /// to an older binary (`deny_unknown_fields` wire struct) still loads a
+    /// state.json holding no private installs. A user-owned record must
+    /// round-trip its owner.
+    #[test]
+    fn installation_owner_defaults_to_tenant_for_legacy_rows_and_round_trips() {
+        let current = installation("fixture", Some("hash-1"));
+        let json = serde_json::to_value(&current).expect("serialize installation");
+        assert!(
+            json.get("owner").is_none(),
+            "tenant-owned rows must keep the pre-#5459 shape (rollback compat): {json}"
+        );
+        let legacy: ExtensionInstallation =
+            serde_json::from_value(json).expect("legacy row without owner deserializes");
+        assert_eq!(legacy.owner(), &InstallationOwner::Tenant);
+
+        let alice = ironclaw_host_api::UserId::new("alice").expect("user id");
+        let private = ExtensionInstallation::new(
+            ExtensionInstallationId::new("fixture".to_string()).expect("installation id"),
+            ExtensionId::new("fixture".to_string()).expect("extension id"),
+            ExtensionActivationState::Installed,
+            ExtensionManifestRef::new(ExtensionId::new("fixture".to_string()).unwrap(), None),
+            Vec::new(),
+            Utc::now(),
+            InstallationOwner::user(alice.clone()),
+        )
+        .expect("installation");
+        let json = serde_json::to_string(&private).expect("serialize");
+        let restored: ExtensionInstallation = serde_json::from_str(&json).expect("round-trip");
+        assert_eq!(restored.owner().as_user(), Some(&alice));
     }
 
     fn manifest_toml(extension_id: &str) -> String {

--- a/crates/ironclaw_extensions/src/installations.rs
+++ b/crates/ironclaw_extensions/src/installations.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::fmt;
 use std::sync::Arc;
 
@@ -315,49 +315,117 @@ impl ExtensionHealthSnapshot {
     }
 }
 
-/// Who an installation belongs to (#5459 P1 — shared vs private installs).
+/// Who an installation belongs to (#5459 P1 — shared vs member installs,
+/// membership model per the 2026-07-08 pivot in
+/// `docs/plans/2026-07-01-private-tool-installs.md`).
 ///
 /// `Tenant` = installed for the whole tenant (the historical behavior, and
-/// what an admin install produces): every user sees and can dispatch the
-/// extension's capabilities. `User` = private to the installing user: only
-/// they see it, only they get grants minted for it.
+/// what an operator install produces): every user sees and can dispatch the
+/// extension's capabilities. `Users` = held by a set of members: any number
+/// of users can independently install the same tool; only members see it,
+/// only members get grants minted for it.
 ///
 /// Legacy persisted records predate this field and deserialize as `Tenant`
 /// via `#[serde(default)]` — no migration required, no behavior change for
-/// existing installs.
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(tag = "kind", rename_all = "snake_case")]
+/// existing installs. Rows written by the slot iteration of this feature
+/// (`{"kind": "user", "user_id": …}`) deserialize as a singleton member set.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub enum InstallationOwner {
     #[default]
     Tenant,
-    User {
-        user_id: UserId,
+    Users {
+        user_ids: BTreeSet<UserId>,
     },
 }
 
 impl InstallationOwner {
+    /// Singleton member set — what a single member's install produces.
     pub fn user(user_id: UserId) -> Self {
-        Self::User { user_id }
+        Self::Users {
+            user_ids: BTreeSet::from([user_id]),
+        }
+    }
+
+    /// Member set; rejects an empty set (an installation must belong to the
+    /// tenant or to at least one member — an empty set would be a row nobody
+    /// can see, operate, or remove).
+    pub fn users(user_ids: BTreeSet<UserId>) -> Result<Self, ExtensionInstallationError> {
+        if user_ids.is_empty() {
+            return Err(ExtensionInstallationError::EmptyOwnerMembers);
+        }
+        Ok(Self::Users { user_ids })
     }
 
     pub fn is_tenant(&self) -> bool {
         matches!(self, Self::Tenant)
     }
 
-    /// The owning user, if the installation is user-private.
-    pub fn as_user(&self) -> Option<&UserId> {
+    /// The member set, if the installation is member-held.
+    pub fn members(&self) -> Option<&BTreeSet<UserId>> {
         match self {
-            Self::User { user_id } => Some(user_id),
+            Self::Users { user_ids } => Some(user_ids),
             Self::Tenant => None,
         }
     }
 
     /// Whether `caller` may see/use this installation: tenant-wide entries
-    /// are visible to everyone, user-private entries only to their owner.
+    /// are visible to everyone, member-held entries only to their members.
     pub fn visible_to(&self, caller: &UserId) -> bool {
         match self {
             Self::Tenant => true,
-            Self::User { user_id } => user_id == caller,
+            Self::Users { user_ids } => user_ids.contains(caller),
+        }
+    }
+}
+
+impl Serialize for InstallationOwner {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        InstallationOwnerWire::from(self.clone()).serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for InstallationOwner {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        InstallationOwnerWire::deserialize(deserializer)?
+            .try_into()
+            .map_err(serde::de::Error::custom)
+    }
+}
+
+/// Wire shape of [`InstallationOwner`]. `user` is the read-only legacy kind
+/// written by the slot iteration of #5459 P1 (a single owning user); it folds
+/// into a singleton member set on load and is never written back.
+#[derive(Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum InstallationOwnerWire {
+    Tenant,
+    User { user_id: UserId },
+    Users { user_ids: BTreeSet<UserId> },
+}
+
+impl From<InstallationOwner> for InstallationOwnerWire {
+    fn from(owner: InstallationOwner) -> Self {
+        match owner {
+            InstallationOwner::Tenant => Self::Tenant,
+            InstallationOwner::Users { user_ids } => Self::Users { user_ids },
+        }
+    }
+}
+
+impl TryFrom<InstallationOwnerWire> for InstallationOwner {
+    type Error = ExtensionInstallationError;
+
+    fn try_from(wire: InstallationOwnerWire) -> Result<Self, Self::Error> {
+        match wire {
+            InstallationOwnerWire::Tenant => Ok(Self::Tenant),
+            InstallationOwnerWire::User { user_id } => Ok(Self::user(user_id)),
+            InstallationOwnerWire::Users { user_ids } => Self::users(user_ids),
         }
     }
 }
@@ -439,6 +507,15 @@ impl ExtensionInstallation {
 
     pub fn owner(&self) -> &InstallationOwner {
         &self.owner
+    }
+
+    /// Same installation with a replaced owner (membership join/leave and
+    /// operator eviction-to-tenant are single row rewrites); refreshes
+    /// `updated_at` like every other row mutation.
+    pub fn with_owner(mut self, owner: InstallationOwner) -> Self {
+        self.owner = owner;
+        self.updated_at = Utc::now();
+        self
     }
 
     fn set_activation_state(&mut self, state: ExtensionActivationState) {
@@ -947,8 +1024,42 @@ mod tests {
         )
         .expect("installation");
         let json = serde_json::to_string(&private).expect("serialize");
+        assert!(
+            json.contains(r#""kind":"users""#),
+            "member-held rows serialize the set shape: {json}"
+        );
         let restored: ExtensionInstallation = serde_json::from_str(&json).expect("round-trip");
-        assert_eq!(restored.owner().as_user(), Some(&alice));
+        assert!(restored.owner().visible_to(&alice));
+        assert_eq!(
+            restored.owner().members().map(BTreeSet::len),
+            Some(1),
+            "singleton member set round-trips"
+        );
+    }
+
+    /// Membership pivot (2026-07-08): rows written by the slot iteration
+    /// carry `{"kind": "user", "user_id": …}` — they MUST keep loading, as a
+    /// singleton member set; an empty member set is rejected on the wire and
+    /// at construction (a row nobody could see, operate, or remove).
+    #[test]
+    fn slot_iteration_user_owner_rows_load_as_singleton_member_set() {
+        let alice = ironclaw_host_api::UserId::new("alice").expect("user id");
+        let bob = ironclaw_host_api::UserId::new("bob").expect("user id");
+        let legacy: InstallationOwner =
+            serde_json::from_str(r#"{"kind":"user","user_id":"alice"}"#)
+                .expect("slot-iteration owner row loads");
+        assert!(legacy.visible_to(&alice));
+        assert!(!legacy.visible_to(&bob));
+        assert_eq!(legacy, InstallationOwner::user(alice.clone()));
+
+        let set: InstallationOwner =
+            serde_json::from_str(r#"{"kind":"users","user_ids":["alice","bob"]}"#)
+                .expect("member set loads");
+        assert!(set.visible_to(&alice) && set.visible_to(&bob));
+
+        serde_json::from_str::<InstallationOwner>(r#"{"kind":"users","user_ids":[]}"#)
+            .expect_err("empty member set is rejected on the wire");
+        InstallationOwner::users(BTreeSet::new()).expect_err("empty member set is unconstructable");
     }
 
     fn manifest_toml(extension_id: &str) -> String {
@@ -984,6 +1095,8 @@ pub enum ExtensionInstallationError {
     Manifest(#[from] ManifestV2Error),
     #[error("invalid {field}: {reason}")]
     InvalidValue { field: &'static str, reason: String },
+    #[error("installation owner member set must not be empty")]
+    EmptyOwnerMembers,
     #[error("installation references unknown extension manifest {extension_id}")]
     UnknownManifest { extension_id: ExtensionId },
     #[error(

--- a/crates/ironclaw_extensions/src/lib.rs
+++ b/crates/ironclaw_extensions/src/lib.rs
@@ -436,7 +436,7 @@ pub use installations::{
     ExtensionHealthMessage, ExtensionHealthSnapshot, ExtensionHealthStatus, ExtensionInstallation,
     ExtensionInstallationError, ExtensionInstallationId, ExtensionInstallationStore,
     ExtensionManifestRecord, ExtensionManifestRef, InMemoryExtensionInstallationStore,
-    ManifestHash,
+    InstallationOwner, ManifestHash,
 };
 pub use lifecycle::{
     ExtensionLifecycleEvent, ExtensionLifecycleEventSink, ExtensionLifecycleService,

--- a/crates/ironclaw_extensions/tests/installations_contract.rs
+++ b/crates/ironclaw_extensions/tests/installations_contract.rs
@@ -3,8 +3,8 @@ use ironclaw_extensions::{
     ExtensionActivationState, ExtensionHealthMessage, ExtensionHealthSnapshot,
     ExtensionHealthStatus, ExtensionInstallation, ExtensionInstallationError,
     ExtensionInstallationId, ExtensionInstallationStore, ExtensionManifestRecord,
-    ExtensionManifestRef, InMemoryExtensionInstallationStore, MANIFEST_SCHEMA_VERSION,
-    ManifestHash, ManifestSource, ManifestV2Error,
+    ExtensionManifestRef, InMemoryExtensionInstallationStore, InstallationOwner,
+    MANIFEST_SCHEMA_VERSION, ManifestHash, ManifestSource, ManifestV2Error,
 };
 use ironclaw_host_api::{ExtensionId, HostPortCatalog};
 
@@ -65,6 +65,7 @@ fn installation(hash: &str) -> ExtensionInstallation {
         ExtensionManifestRef::new(extension_id("acme-tools"), Some(manifest_hash(hash))),
         vec![],
         Utc::now(),
+        InstallationOwner::Tenant,
     )
     .unwrap()
 }
@@ -77,6 +78,7 @@ fn installation_with_manifest_hash(hash: Option<&str>) -> ExtensionInstallation 
         ExtensionManifestRef::new(extension_id("acme-tools"), hash.map(manifest_hash)),
         vec![],
         Utc::now(),
+        InstallationOwner::Tenant,
     )
     .unwrap()
 }
@@ -117,6 +119,7 @@ async fn upsert_installation_rejects_unknown_manifest() {
                 ),
                 vec![],
                 Utc::now(),
+                InstallationOwner::Tenant,
             )
             .unwrap(),
         )
@@ -355,6 +358,7 @@ fn new_installation_uses_updated_at_for_initial_health_timestamp() {
         ),
         vec![],
         updated_at,
+        InstallationOwner::Tenant,
     )
     .unwrap();
 
@@ -389,6 +393,7 @@ async fn enabled_installations_sort_by_updated_at_desc_then_id() {
                     ),
                     vec![],
                     updated_at,
+                    InstallationOwner::Tenant,
                 )
                 .unwrap(),
             )

--- a/crates/ironclaw_product_adapter_registry/tests/registry_contract.rs
+++ b/crates/ironclaw_product_adapter_registry/tests/registry_contract.rs
@@ -6,7 +6,7 @@ use ironclaw_extensions::{
     ExtensionHealthMessage, ExtensionHealthSnapshot, ExtensionHealthStatus, ExtensionInstallation,
     ExtensionInstallationError, ExtensionInstallationId, ExtensionInstallationStore,
     ExtensionManifestRecord, ExtensionManifestRef, InMemoryExtensionInstallationStore,
-    MANIFEST_SCHEMA_VERSION, ManifestSource,
+    InstallationOwner, MANIFEST_SCHEMA_VERSION, ManifestSource,
 };
 use ironclaw_host_api::{ExtensionId, HostPortCatalog, SecretHandle};
 use ironclaw_product_adapter_registry::{
@@ -82,6 +82,7 @@ fn installation(state: ExtensionActivationState) -> ExtensionInstallation {
             SecretHandle::new("secret_telegram_bot_token").unwrap(),
         )],
         Utc::now(),
+        InstallationOwner::Tenant,
     )
     .unwrap()
 }
@@ -163,6 +164,7 @@ prompt_doc_ref = "prompts/do.md"
         ExtensionManifestRef::new(plain_id, Some(manifest_hash("sha256:plain"))),
         vec![],
         Utc::now(),
+        InstallationOwner::Tenant,
     )
     .unwrap();
 
@@ -195,6 +197,7 @@ async fn credential_binding_must_reference_declared_manifest_handle() {
             SecretHandle::new("secret_slack_bot_token").unwrap(),
         )],
         Utc::now(),
+        InstallationOwner::Tenant,
     )
     .unwrap();
 
@@ -289,6 +292,7 @@ fn duplicate_credential_bindings_rejected_at_construction() {
             ),
         ],
         Utc::now(),
+        InstallationOwner::Tenant,
     )
     .unwrap_err();
     assert!(
@@ -441,6 +445,7 @@ handle = "outbound_token"
             ),
         ],
         Utc::now(),
+        InstallationOwner::Tenant,
     )
     .unwrap();
 

--- a/crates/ironclaw_product_workflow/src/lib.rs
+++ b/crates/ironclaw_product_workflow/src/lib.rs
@@ -125,12 +125,12 @@ pub use lifecycle::{
     ChannelConnectionRequirement, LifecycleBlockerRef, LifecycleCommandKind,
     LifecycleExtensionCredentialRequirement, LifecycleExtensionCredentialSetup,
     LifecycleExtensionOnboarding, LifecycleExtensionRuntimeKind, LifecycleExtensionSource,
-    LifecycleExtensionSummary, LifecycleExtensionSurfaceKind, LifecycleInstalledExtensionSummary,
-    LifecyclePackageId, LifecyclePackageKind, LifecyclePackageRef, LifecyclePhase,
-    LifecycleProductAction, LifecycleProductContext, LifecycleProductFacade,
-    LifecycleProductPayload, LifecycleProductResponse, LifecycleProductSurfaceContext,
-    LifecycleReadinessBlocker, LifecycleSearchExtensionSummary, LifecycleSkillSource,
-    LifecycleSkillSummary, UnsupportedLifecycleProductFacade,
+    LifecycleExtensionSummary, LifecycleExtensionSurfaceKind, LifecycleInstallScope,
+    LifecycleInstalledExtensionSummary, LifecyclePackageId, LifecyclePackageKind,
+    LifecyclePackageRef, LifecyclePhase, LifecycleProductAction, LifecycleProductContext,
+    LifecycleProductFacade, LifecycleProductPayload, LifecycleProductResponse,
+    LifecycleProductSurfaceContext, LifecycleReadinessBlocker, LifecycleSearchExtensionSummary,
+    LifecycleSkillSource, LifecycleSkillSummary, UnsupportedLifecycleProductFacade,
 };
 // Product hosts use this outbound orchestration seam to wire outbound policy
 // decisions to adapter rendering without reaching into module internals.

--- a/crates/ironclaw_product_workflow/src/lifecycle.rs
+++ b/crates/ironclaw_product_workflow/src/lifecycle.rs
@@ -378,10 +378,26 @@ pub struct LifecycleSearchExtensionSummary {
     pub installation_phase: Option<LifecyclePhase>,
 }
 
+/// Whether an installed extension is tenant-shared or private to the caller
+/// (#5459 P1). Serialized on the wire; `#[serde(default)]`-friendly via
+/// `Option` on the summary so pre-#5459 payloads keep deserializing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LifecycleInstallScope {
+    /// Installed for the whole tenant (admin install) — visible to every user.
+    Shared,
+    /// Installed privately by the caller — visible only to them.
+    Private,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LifecycleInstalledExtensionSummary {
     pub summary: LifecycleExtensionSummary,
     pub phase: LifecyclePhase,
+    /// `None` only when the caller has no visible installation (projection of
+    /// an uninstalled package); list responses always carry `Some`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub install_scope: Option<LifecycleInstallScope>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/ironclaw_product_workflow/src/reborn_services.rs
+++ b/crates/ironclaw_product_workflow/src/reborn_services.rs
@@ -179,8 +179,18 @@ pub struct RebornOperatorToolInfo {
     pub effects: Arc<[EffectKind]>,
 }
 
+#[async_trait]
 pub trait RebornOperatorToolCatalog: Send + Sync {
-    fn list_operator_tools(&self) -> Vec<RebornOperatorToolInfo>;
+    /// Tools visible to `caller` in the operator/settings surface (#5459 P1).
+    ///
+    /// The settings/tools routes are authenticated-caller routes (not
+    /// operator-gated), so a member reads this catalog. It MUST therefore be
+    /// filtered by installation owner exactly like the model capability
+    /// surface: tenant-shared tools for everyone, user-private tools only for
+    /// their owner. An unfiltered catalog would disclose another user's
+    /// private install (its capability id, description, effects) — the leak
+    /// this parameter closes.
+    async fn list_operator_tools(&self, caller: &UserId) -> Vec<RebornOperatorToolInfo>;
 }
 
 #[derive(Clone)]
@@ -1086,13 +1096,18 @@ async fn auto_approve_config_entry(
     })
 }
 
-fn find_operator_tool(
+async fn find_operator_tool(
     config: &RebornOperatorApprovalConfig,
     raw_capability_id: &str,
+    caller: &UserId,
 ) -> Result<RebornOperatorToolInfo, RebornServicesError> {
+    // Look up within the CALLER-filtered catalog so a foreign user-private
+    // tool reads as an unknown key (same masking as list), never disclosing
+    // that it exists or letting a member set a permission on it (#5459 P1).
     config
         .tool_catalog
-        .list_operator_tools()
+        .list_operator_tools(caller)
+        .await
         .into_iter()
         .find(|tool| tool.capability_id.as_str() == raw_capability_id)
         .ok_or_else(|| operator_config_unknown_key_error("key"))
@@ -3398,13 +3413,15 @@ impl RebornServicesApi for RebornServices {
         &self,
         caller: WebUiAuthenticatedCaller,
     ) -> Result<RebornOperatorConfigListResponse, RebornServicesError> {
-        let _ = caller;
         let Some(config) = &self.operator_approval_config else {
             return Ok(operator_config_not_wired_response());
         };
         let scope = caller_resource_scope(&caller);
         let mut entries = vec![auto_approve_config_entry(config, &scope).await?];
-        let tools = config.tool_catalog.list_operator_tools();
+        let tools = config
+            .tool_catalog
+            .list_operator_tools(&scope.user_id)
+            .await;
         let tool_context = operator_tool_permission_context(config, &scope, &tools).await?;
         entries.extend(
             try_join_all(
@@ -3439,7 +3456,7 @@ impl RebornServicesApi for RebornServices {
         let entry = if key == AUTO_APPROVE_CONFIG_KEY {
             auto_approve_config_entry(config, &scope).await?
         } else if let Some(capability_id) = key.strip_prefix(TOOL_CONFIG_PREFIX) {
-            let tool = find_operator_tool(config, capability_id)?;
+            let tool = find_operator_tool(config, capability_id, &scope.user_id).await?;
             tool_config_entry(config, &scope, &tool).await?
         } else {
             return Err(operator_config_unknown_key_error("key"));
@@ -3476,7 +3493,7 @@ impl RebornServicesApi for RebornServices {
                 .map_err(operator_config_store_error)?;
             auto_approve_config_entry(config, &scope).await?
         } else if let Some(capability_id) = key.strip_prefix(TOOL_CONFIG_PREFIX) {
-            let tool = find_operator_tool(config, capability_id)?;
+            let tool = find_operator_tool(config, capability_id, &scope.user_id).await?;
             if tool_permission_locked(&tool) {
                 return Err(operator_config_invalid_value("state"));
             }

--- a/crates/ironclaw_product_workflow/src/reborn_services/extension_onboarding.rs
+++ b/crates/ironclaw_product_workflow/src/reborn_services/extension_onboarding.rs
@@ -497,6 +497,7 @@ mod tests {
                 onboarding,
             },
             phase,
+            install_scope: None,
         }
     }
 

--- a/crates/ironclaw_product_workflow/src/reborn_services/extensions.rs
+++ b/crates/ironclaw_product_workflow/src/reborn_services/extensions.rs
@@ -353,6 +353,7 @@ fn extension_info(
     };
     let onboarding =
         extension_onboarding::for_installed_with_credential_status(&installed, readiness);
+    let install_scope = installed.install_scope;
     let summary = installed.summary;
     let has_external_channel_surface = has_external_channel_surface(&summary);
     let kind = extension_kind(&summary).to_string();
@@ -389,6 +390,7 @@ fn extension_info(
         version: Some(summary.version),
         onboarding_state,
         onboarding: onboarding.onboarding,
+        install_scope,
     }
 }
 
@@ -818,6 +820,7 @@ mod tests {
             extension: LifecycleInstalledExtensionSummary {
                 summary: summary_with_onboarding(),
                 phase: LifecyclePhase::Active,
+                install_scope: None,
             },
         };
         let credentials = Arc::new(RecordingCredentials::default());
@@ -862,6 +865,7 @@ mod tests {
             extension: LifecycleInstalledExtensionSummary {
                 summary: summary_with_onboarding(),
                 phase: LifecyclePhase::Active,
+                install_scope: None,
             },
         };
         let credentials = UnavailableCredentials;
@@ -891,6 +895,7 @@ mod tests {
             extension: LifecycleInstalledExtensionSummary {
                 summary: summary_without_browser_setup_credentials(),
                 phase: LifecyclePhase::Active,
+                install_scope: None,
             },
         };
         let credentials = Arc::new(RecordingCredentials::default());
@@ -925,6 +930,7 @@ mod tests {
                 .map(|index| LifecycleInstalledExtensionSummary {
                     summary: summary_with_onboarding_for(&format!("fixture-{index}")),
                     phase: LifecyclePhase::Active,
+                    install_scope: None,
                 })
                 .collect(),
         };
@@ -1008,6 +1014,7 @@ mod tests {
             extension: LifecycleInstalledExtensionSummary {
                 summary,
                 phase: LifecyclePhase::Active,
+                install_scope: None,
             },
         };
 
@@ -1027,6 +1034,7 @@ mod tests {
                 extension: LifecycleInstalledExtensionSummary {
                     summary: unconnected_summary,
                     phase: LifecyclePhase::Active,
+                    install_scope: None,
                 },
             }),
             None,
@@ -1076,6 +1084,7 @@ mod tests {
             installed: LifecycleInstalledExtensionSummary {
                 summary: installed_summary,
                 phase: LifecyclePhase::Active,
+                install_scope: None,
             },
             registry: vec![
                 search_extension_summary(registry_installed_summary),
@@ -1371,6 +1380,7 @@ mod tests {
                     extensions: vec![LifecycleInstalledExtensionSummary {
                         summary: summary_with_onboarding(),
                         phase: LifecyclePhase::Installed,
+                        install_scope: None,
                     }],
                     count: 1,
                 }),
@@ -1447,6 +1457,7 @@ mod tests {
                             extensions: vec![LifecycleInstalledExtensionSummary {
                                 summary,
                                 phase: LifecyclePhase::Installed,
+                                install_scope: None,
                             }],
                             count: 1,
                         }),

--- a/crates/ironclaw_product_workflow/src/reborn_services/types.rs
+++ b/crates/ironclaw_product_workflow/src/reborn_services/types.rs
@@ -11,7 +11,8 @@ use serde::ser::SerializeStruct;
 use serde::{Deserialize, Deserializer, Serialize, de};
 
 use crate::{
-    LifecyclePackageRef, LifecyclePhase, LifecycleProductPayload, LifecycleReadinessBlocker,
+    LifecycleInstallScope, LifecyclePackageRef, LifecyclePhase, LifecycleProductPayload,
+    LifecycleReadinessBlocker,
 };
 
 const OUTBOUND_DELIVERY_TARGET_ID_MAX_BYTES: usize = 512;
@@ -1169,6 +1170,10 @@ pub struct RebornExtensionInfo {
     pub onboarding_state: Option<RebornExtensionOnboardingState>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub onboarding: Option<RebornExtensionOnboardingPayload>,
+    /// Whether this install is tenant-shared or private to the caller
+    /// (#5459 P1); `None` on pre-#5459 payloads.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub install_scope: Option<LifecycleInstallScope>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/ironclaw_product_workflow/tests/reborn_services_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/reborn_services_contract.rs
@@ -908,6 +908,7 @@ impl RecordingLifecycleFacade {
             extensions: vec![LifecycleInstalledExtensionSummary {
                 summary,
                 phase: LifecyclePhase::Configured,
+                install_scope: None,
             }],
             count: 1,
         })
@@ -5114,6 +5115,7 @@ async fn list_extensions_projects_onboarding_payload_through_reborn_services() {
                 Some(onboarding_fixture()),
             ),
             phase: LifecyclePhase::Installed,
+            install_scope: None,
         },
     }));
 
@@ -8400,8 +8402,14 @@ struct StaticOperatorToolCatalogForTest {
     tools: Vec<RebornOperatorToolInfo>,
 }
 
+#[async_trait]
 impl RebornOperatorToolCatalog for StaticOperatorToolCatalogForTest {
-    fn list_operator_tools(&self) -> Vec<RebornOperatorToolInfo> {
+    async fn list_operator_tools(
+        &self,
+        _caller: &ironclaw_host_api::UserId,
+    ) -> Vec<RebornOperatorToolInfo> {
+        // Ownership filtering is exercised by the composition-tier catalog
+        // test; this static catalog is caller-agnostic on purpose.
         self.tools.clone()
     }
 }

--- a/crates/ironclaw_reborn_composition/src/communication_context.rs
+++ b/crates/ironclaw_reborn_composition/src/communication_context.rs
@@ -452,6 +452,7 @@ mod tests {
                 onboarding: None,
             },
             phase: LifecyclePhase::Active,
+            install_scope: None,
         }
     }
 
@@ -472,6 +473,7 @@ mod tests {
                 onboarding: None,
             },
             phase: LifecyclePhase::Active,
+            install_scope: None,
         }
     }
 

--- a/crates/ironclaw_reborn_composition/src/extension_host/extension_installation_store.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/extension_installation_store.rs
@@ -289,7 +289,7 @@ mod tests {
     use chrono::Utc;
     use ironclaw_extensions::{
         ExtensionActivationState, ExtensionInstallationId, ExtensionManifestRecord,
-        ExtensionManifestRef, MANIFEST_SCHEMA_VERSION,
+        ExtensionManifestRef, InstallationOwner, MANIFEST_SCHEMA_VERSION,
     };
     use ironclaw_filesystem::{
         BackendCapabilities, CasExpectation, DirEntry, Entry, FileStat, FilesystemOperation,
@@ -394,6 +394,7 @@ prompt_doc_ref = "prompts/gmail/echo.md"
                     manifest_ref,
                     Vec::new(),
                     Utc::now(),
+                    InstallationOwner::Tenant,
                 )
                 .expect("valid installation"),
             )

--- a/crates/ironclaw_reborn_composition/src/extension_host/extension_lifecycle.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/extension_lifecycle.rs
@@ -13,13 +13,13 @@ use ironclaw_extensions::{
     CapabilityVisibility, ExtensionActivationState, ExtensionError, ExtensionInstallation,
     ExtensionInstallationError, ExtensionInstallationId, ExtensionInstallationStore,
     ExtensionLifecycleService, ExtensionManifestRecord, ExtensionManifestRef, ExtensionPackage,
-    ManifestHash, ManifestSource,
+    InstallationOwner, ManifestHash, ManifestSource,
 };
 use ironclaw_filesystem::RootFilesystem;
 use ironclaw_host_api::{
     CapabilityDescriptor, CapabilityId, EffectKind, ExtensionId, NetworkTargetPattern,
     PermissionMode, ResourceScope, RuntimeCredentialAuthRequirement, RuntimeCredentialRequirement,
-    RuntimeHttpEgress, VirtualPath, sha256_digest_token,
+    RuntimeHttpEgress, UserId, VirtualPath, sha256_digest_token,
 };
 use ironclaw_product_adapter_registry::PRODUCT_ADAPTER_HOST_API_ID;
 use ironclaw_product_workflow::{
@@ -68,6 +68,7 @@ impl ExtensionCredentialCleanup for RebornProductAuthServices {
 mod active_publication;
 #[cfg(test)]
 mod hosted_mcp_test_support;
+mod install_policy;
 
 use crate::extension_host::available_extensions::{
     AvailableExtensionCatalog, AvailableExtensionPackage, imported_extension_package,
@@ -86,6 +87,10 @@ use crate::extension_host::mcp_discovery::{
 pub(crate) use active_publication::ActiveExtensionPublisher;
 #[cfg(test)]
 use active_publication::extension_trust_policy_input;
+use install_policy::{
+    EvictedPrivateInstall, OccupiedSlotDecision, decide_occupied_slot, derive_owner,
+    ensure_caller_may_operate, install_scope_for_owner,
+};
 
 const RETIRED_SLACK_USER_EXTENSION_ID: &str = "slack_user";
 
@@ -113,6 +118,13 @@ pub(crate) struct RebornLocalExtensionManagementPort {
     /// per-request cap into N x 64 MiB of pressure before any lifecycle lock
     /// applies (#5499 review finding #3).
     import_decode_semaphore: Arc<Semaphore>,
+    /// The tenant operator identity (#5459 P1). In local-dev this is the base
+    /// owner user (`IRONCLAW_REBORN_WEBUI_USER_ID` semantics); installs by this
+    /// user derive [`InstallationOwner::Tenant`] (shared), installs by anyone
+    /// else derive [`InstallationOwner::User`] (private). Resolved ONCE here —
+    /// when P0 role wiring lands, this becomes a role-derived resolver instead
+    /// of an identity comparison; callers do not re-derive admin-ness.
+    tenant_operator_user_id: UserId,
 }
 
 /// Concurrent `import_bundle` decodes allowed before further uploads wait.
@@ -130,6 +142,10 @@ pub(crate) struct ActiveExtensionCapability {
     pub(crate) runtime_credentials: Vec<RuntimeCredentialRequirement>,
     /// Manifest-declared network egress allowlist, independent of credentials.
     pub(crate) network_targets: Vec<NetworkTargetPattern>,
+    /// Who the providing extension's installation belongs to (#5459 P1).
+    /// Tenant-owned capabilities are grant-minted for every user; user-owned
+    /// ones only for their owner (filtered in `LocalDevExtensionSurface`).
+    pub(crate) owner: InstallationOwner,
 }
 
 #[derive(Clone)]
@@ -142,7 +158,7 @@ pub(crate) enum ExtensionActivationMode {
 }
 
 impl ActiveExtensionCapability {
-    fn from_descriptor(descriptor: &CapabilityDescriptor) -> Self {
+    fn from_descriptor(descriptor: &CapabilityDescriptor, owner: InstallationOwner) -> Self {
         Self {
             id: descriptor.id.clone(),
             provider: descriptor.provider.clone(),
@@ -150,6 +166,7 @@ impl ActiveExtensionCapability {
             default_permission: descriptor.default_permission,
             runtime_credentials: descriptor.runtime_credentials.clone(),
             network_targets: descriptor.network_targets.clone(),
+            owner,
         }
     }
 }
@@ -340,6 +357,7 @@ impl RebornLocalExtensionManagementPort {
         lifecycle_service: Arc<Mutex<ExtensionLifecycleService>>,
         active_extensions: ActiveExtensionPublisher,
         credential_cleanup: Option<Arc<dyn ExtensionCredentialCleanup>>,
+        tenant_operator_user_id: UserId,
     ) -> Self {
         Self {
             filesystem,
@@ -350,6 +368,7 @@ impl RebornLocalExtensionManagementPort {
             operation_lock: Arc::new(Mutex::new(())),
             credential_cleanup,
             import_decode_semaphore: Arc::new(Semaphore::new(MAX_CONCURRENT_IMPORT_DECODES)),
+            tenant_operator_user_id,
         }
     }
 
@@ -377,16 +396,38 @@ impl RebornLocalExtensionManagementPort {
         &self.active_extensions
     }
 
+    /// The wired tenant-operator identity (#5459 P1). Used by tenant-wide
+    /// host activations (e.g. Slack host-beta channel setup) that operate a
+    /// shared install and therefore act as the operator rather than any
+    /// individual member.
+    #[cfg(feature = "slack-v2-host-beta")]
+    pub(crate) fn tenant_operator_user_id(&self) -> &UserId {
+        &self.tenant_operator_user_id
+    }
+
+    /// Test-support view of the wired tenant-operator identity (#5459 P1), so
+    /// tests can act "as the operator" without re-deriving the id the runtime
+    /// or fixture was built with. Mirrors the production owner wiring in
+    /// `build_local_runtime`. Tests only — zero bytes in production builds.
+    #[cfg(test)]
+    pub(crate) fn tenant_operator_user_id_for_test(&self) -> &UserId {
+        &self.tenant_operator_user_id
+    }
+
     pub(crate) async fn search(
         &self,
         query: &str,
         credential_gate: Option<&RuntimeExtensionActivationCredentialGate>,
+        caller: &UserId,
     ) -> Result<LifecycleProductResponse, ProductWorkflowError> {
         let catalog = self.catalog.read().await;
         let extensions = catalog.search(query);
         let mut summaries = Vec::new();
         for extension in extensions {
-            summaries.push(self.search_summary(extension, credential_gate).await?);
+            summaries.push(
+                self.search_summary(extension, credential_gate, caller)
+                    .await?,
+            );
         }
         drop(catalog);
         let count = summaries.len();
@@ -414,8 +455,9 @@ impl RebornLocalExtensionManagementPort {
 
     pub(crate) async fn list_installed(
         &self,
+        caller: &UserId,
     ) -> Result<LifecycleProductResponse, ProductWorkflowError> {
-        let summaries = self.installed_summaries().await?;
+        let summaries = self.installed_summaries(caller).await?;
         let count = summaries.len();
         Ok(response_with_payload(
             None,
@@ -430,21 +472,34 @@ impl RebornLocalExtensionManagementPort {
     pub(crate) async fn project(
         &self,
         package_ref: LifecyclePackageRef,
+        caller: &UserId,
     ) -> Result<LifecycleProductResponse, ProductWorkflowError> {
         let (_, installation_id) = extension_ids_from_package_ref(&package_ref)?;
-        let phase = self
+        let installation = self
             .installation_store
             .get_installation(&installation_id)
             .await
             .map_err(map_extension_installation_error)?
+            // A foreign user-private install projects as not-installed for
+            // this caller — same masking as search/list (#5459 P1).
+            .filter(|installation| installation.owner().visible_to(caller));
+        let phase = installation
+            .as_ref()
             .map(|installation| phase_for_activation_state(installation.activation_state()))
             .unwrap_or(LifecyclePhase::Discovered);
+        let install_scope = installation
+            .as_ref()
+            .and_then(|installation| install_scope_for_owner(installation.owner()));
         let summary = self.catalog.read().await.resolve(&package_ref)?.summary();
         Ok(response_with_payload(
             Some(package_ref),
             phase,
             LifecycleProductPayload::ExtensionList {
-                extensions: vec![LifecycleInstalledExtensionSummary { summary, phase }],
+                extensions: vec![LifecycleInstalledExtensionSummary {
+                    summary,
+                    phase,
+                    install_scope,
+                }],
                 count: 1,
             },
         ))
@@ -453,36 +508,77 @@ impl RebornLocalExtensionManagementPort {
     pub(crate) async fn active_model_visible_capabilities(
         &self,
     ) -> Result<Vec<ActiveExtensionCapability>, ProductWorkflowError> {
-        let enabled_extension_ids = self
+        // #5459 P1: carry each enabled installation's owner onto its
+        // capabilities so the per-request grant minting in the local-dev
+        // capability surface can filter user-private extensions to their
+        // owner. The registry itself stays global; owner is joined here.
+        let owner_by_extension = self
             .installation_store
             .list_enabled_installations()
             .await
             .map_err(map_extension_installation_error)?
             .into_iter()
-            .map(|installation| installation.extension_id().clone())
-            .collect::<BTreeSet<_>>();
+            .map(|installation| {
+                (
+                    installation.extension_id().clone(),
+                    installation.owner().clone(),
+                )
+            })
+            .collect::<std::collections::BTreeMap<_, _>>();
         let registry = self.active_extensions.snapshot();
         Ok(registry
             .capabilities()
-            .filter(|descriptor| enabled_extension_ids.contains(&descriptor.provider))
-            .filter(|descriptor| {
-                registry
+            .filter_map(|descriptor| {
+                let owner = owner_by_extension.get(&descriptor.provider)?;
+                let model_visible = registry
                     .capability_visibility(&descriptor.id)
                     .unwrap_or(CapabilityVisibility::Model)
-                    == CapabilityVisibility::Model
+                    == CapabilityVisibility::Model;
+                model_visible
+                    .then(|| ActiveExtensionCapability::from_descriptor(descriptor, owner.clone()))
             })
-            .map(ActiveExtensionCapability::from_descriptor)
+            .collect())
+    }
+
+    /// Owner of every installation (all activation states), keyed by extension
+    /// id (#5459 P1). The operator/settings tool catalog joins this to the
+    /// global extension registry so it can hide another user's private tool —
+    /// the registry snapshot alone carries no owner. Uses `list_installations`
+    /// (not `_enabled_`) because the catalog reflects installed tools
+    /// regardless of activation state.
+    pub(crate) async fn installation_owners(
+        &self,
+    ) -> Result<std::collections::BTreeMap<ExtensionId, InstallationOwner>, ProductWorkflowError>
+    {
+        Ok(self
+            .installation_store
+            .list_installations()
+            .await
+            .map_err(map_extension_installation_error)?
+            .into_iter()
+            .map(|installation| {
+                (
+                    installation.extension_id().clone(),
+                    installation.owner().clone(),
+                )
+            })
             .collect())
     }
 
     pub(crate) async fn activation_credential_requirements(
         &self,
         package_ref: &LifecyclePackageRef,
+        caller: &UserId,
     ) -> Result<Vec<RuntimeCredentialAuthRequirement>, ProductWorkflowError> {
         let (extension_id, installation_id) = extension_ids_from_package_ref(package_ref)?;
         let _operation_guard = self.operation_lock.lock().await;
-        self.load_installation(&extension_id, &installation_id)
+        let installation = self
+            .load_installation(&extension_id, &installation_id)
             .await?;
+        // Ownership masks before any credential preflight: a non-owner must
+        // get the "is not installed" denial, never a requirement shape that
+        // confirms a private credentialed install exists (#5525 review).
+        ensure_caller_may_operate(&installation, caller)?;
         let package = self.lifecycle_package(&extension_id).await?;
         let requirements = package_runtime_credential_auth_requirements(&package);
         Ok(requirements)
@@ -490,6 +586,7 @@ impl RebornLocalExtensionManagementPort {
 
     async fn installed_summaries(
         &self,
+        caller: &UserId,
     ) -> Result<Vec<LifecycleInstalledExtensionSummary>, ProductWorkflowError> {
         let installations = self
             .installation_store
@@ -498,6 +595,12 @@ impl RebornLocalExtensionManagementPort {
             .map_err(map_extension_installation_error)?;
         let mut summaries = Vec::with_capacity(installations.len());
         for installation in installations {
+            // #5459 P1: a caller's list is tenant-shared entries plus their
+            // OWN private entries; other users' private installs are invisible
+            // (the operator included — private installs are not enumerable).
+            if !installation.owner().visible_to(caller) {
+                continue;
+            }
             let Ok(package_ref) = LifecyclePackageRef::new(
                 LifecyclePackageKind::Extension,
                 installation.extension_id().as_str(),
@@ -514,6 +617,7 @@ impl RebornLocalExtensionManagementPort {
             summaries.push(LifecycleInstalledExtensionSummary {
                 summary: available.summary(),
                 phase: phase_for_activation_state(installation.activation_state()),
+                install_scope: install_scope_for_owner(installation.owner()),
             });
         }
         Ok(summaries)
@@ -523,10 +627,17 @@ impl RebornLocalExtensionManagementPort {
         &self,
         extension: &AvailableExtensionPackage,
         credential_gate: Option<&RuntimeExtensionActivationCredentialGate>,
+        caller: &UserId,
     ) -> Result<LifecycleSearchExtensionSummary, ProductWorkflowError> {
         let mut summary = extension.summary();
         suppress_search_credential_onboarding(&mut summary);
-        let Some(installation) = self.search_installation(&extension.package.id).await? else {
+        let installation = self
+            .search_installation(&extension.package.id)
+            .await?
+            // A foreign user-private install reads as not-installed for this
+            // caller (#5459 P1) — same masking as list/project.
+            .filter(|installation| installation.owner().visible_to(caller));
+        let Some(installation) = installation else {
             return Ok(LifecycleSearchExtensionSummary {
                 summary,
                 installation_phase: None,
@@ -642,16 +753,76 @@ impl RebornLocalExtensionManagementPort {
     pub(crate) async fn install(
         &self,
         package_ref: LifecyclePackageRef,
+        caller: &UserId,
     ) -> Result<LifecycleProductResponse, ProductWorkflowError> {
         // Read guard is held for the whole method because `available` borrows
-        // from the catalog (used by install_available_locked/visible_caps
+        // from the catalog (used by prepare_install/materialize/visible_caps
         // below). Acquired BEFORE `operation_lock`; `import_bundle` takes the
         // write guard before `operation_lock` too, so the lock order is
         // consistent and the two cannot deadlock.
+        let owner = derive_owner(caller, &self.tenant_operator_user_id);
         let catalog = self.catalog.read().await;
         let available = catalog.resolve(&package_ref)?;
+        let plan = prepare_install(available, owner.clone())?;
         let _operation_guard = self.operation_lock.lock().await;
-        self.install_available_locked(available).await?;
+        let evicted = self
+            .ensure_slot_available(
+                &available.package.id,
+                plan.installation.installation_id(),
+                &owner,
+            )
+            .await?;
+        if let Err(error) = self.register_lifecycle_package(&available.package).await {
+            return Err(self
+                .fail_install_restoring_evicted(
+                    "extension install registration failed",
+                    error,
+                    evicted.as_ref(),
+                )
+                .await);
+        }
+
+        if let Err(error) =
+            materialize_available_extension(self.filesystem.as_ref(), available).await
+        {
+            if let Err(rollback_error) =
+                self.rollback_lifecycle_install(&available.package.id).await
+            {
+                return Err(compensation_failure(
+                    "extension install materialization failed and lifecycle rollback failed",
+                    error,
+                    rollback_error,
+                ));
+            }
+            return Err(self
+                .fail_install_restoring_evicted(
+                    "extension install materialization failed",
+                    error,
+                    evicted.as_ref(),
+                )
+                .await);
+        }
+        if let Err(error) = self.persist_install_plan(plan).await {
+            let _ = self
+                .delete_materialized_extension_files(&available.package.id)
+                .await;
+            if let Err(rollback_error) =
+                self.rollback_lifecycle_install(&available.package.id).await
+            {
+                return Err(compensation_failure(
+                    "extension install persistence failed and lifecycle rollback failed",
+                    error,
+                    rollback_error,
+                ));
+            }
+            return Err(self
+                .fail_install_restoring_evicted(
+                    "extension install persistence failed",
+                    error,
+                    evicted.as_ref(),
+                )
+                .await);
+        }
 
         Ok(response_with_payload(
             Some(package_ref.clone()),
@@ -669,54 +840,14 @@ impl RebornLocalExtensionManagementPort {
         ))
     }
 
-    async fn install_available_locked(
-        &self,
-        available: &AvailableExtensionPackage,
-    ) -> Result<(), ProductWorkflowError> {
-        let plan = prepare_install(available)?;
-        self.ensure_not_installed(&available.package.id, plan.installation.installation_id())
-            .await?;
-        self.register_lifecycle_package(&available.package).await?;
-
-        if let Err(error) =
-            materialize_available_extension(self.filesystem.as_ref(), available).await
-        {
-            if let Err(rollback_error) =
-                self.rollback_lifecycle_install(&available.package.id).await
-            {
-                return Err(compensation_failure(
-                    "extension install materialization failed and lifecycle rollback failed",
-                    error,
-                    rollback_error,
-                ));
-            }
-            return Err(error);
-        }
-        if let Err(error) = self.persist_install_plan(plan).await {
-            let _ = self
-                .delete_materialized_extension_files(&available.package.id)
-                .await;
-            if let Err(rollback_error) =
-                self.rollback_lifecycle_install(&available.package.id).await
-            {
-                return Err(compensation_failure(
-                    "extension install persistence failed and lifecycle rollback failed",
-                    error,
-                    rollback_error,
-                ));
-            }
-            return Err(error);
-        }
-        Ok(())
-    }
-
     pub(crate) async fn activate(
         &self,
         package_ref: LifecyclePackageRef,
         mode: ExtensionActivationMode,
+        caller: &UserId,
     ) -> Result<LifecycleProductResponse, ProductWorkflowError> {
         let credential_gate = UnavailableExtensionActivationCredentialGate;
-        self.activate_inner(package_ref, mode, &credential_gate)
+        self.activate_inner(package_ref, mode, &credential_gate, caller)
             .await
     }
 
@@ -725,8 +856,9 @@ impl RebornLocalExtensionManagementPort {
         package_ref: LifecyclePackageRef,
         mode: ExtensionActivationMode,
         credential_gate: impl ExtensionActivationCredentialGate,
+        caller: &UserId,
     ) -> Result<LifecycleProductResponse, ProductWorkflowError> {
-        self.activate_inner(package_ref, mode, &credential_gate)
+        self.activate_inner(package_ref, mode, &credential_gate, caller)
             .await
     }
 
@@ -738,7 +870,8 @@ impl RebornLocalExtensionManagementPort {
     ) -> Result<LifecycleProductResponse, ProductWorkflowError> {
         let credential_gate =
             crate::extension_host::extension_activation_credentials::PrecheckedExtensionActivationCredentialGate;
-        self.activate_inner(package_ref, mode, &credential_gate)
+        let caller = self.tenant_operator_user_id.clone();
+        self.activate_inner(package_ref, mode, &credential_gate, &caller)
             .await
     }
 
@@ -747,6 +880,7 @@ impl RebornLocalExtensionManagementPort {
         package_ref: LifecyclePackageRef,
         mode: ExtensionActivationMode,
         credential_gate: &dyn ExtensionActivationCredentialGate,
+        caller: &UserId,
     ) -> Result<LifecycleProductResponse, ProductWorkflowError> {
         let (extension_id, installation_id) = extension_ids_from_package_ref(&package_ref)?;
 
@@ -755,6 +889,7 @@ impl RebornLocalExtensionManagementPort {
             let installation = self
                 .load_installation(&extension_id, &installation_id)
                 .await?;
+            ensure_caller_may_operate(&installation, caller)?;
             let package = self.lifecycle_package(&extension_id).await?;
             credential_gate.ensure_credentials(&package).await?;
             match mode {
@@ -805,6 +940,13 @@ impl RebornLocalExtensionManagementPort {
         let installation = self
             .load_installation(&extension_id, &installation_id)
             .await
+            .map_err(|_| hosted_mcp_changed_during_discovery_error())?;
+        // #5459 P1: the slot may have changed hands while the lock was dropped
+        // for discovery (eviction+reinstall / remove+reinstall reuse the same
+        // installation id), so re-check ownership before committing — phase 1's
+        // check is stale. A foreign row must not be flipped to Enabled under
+        // this caller's action.
+        ensure_caller_may_operate(&installation, caller)
             .map_err(|_| hosted_mcp_changed_during_discovery_error())?;
         let current_package = self
             .lifecycle_package(&extension_id)
@@ -909,20 +1051,39 @@ impl RebornLocalExtensionManagementPort {
     pub(crate) async fn remove(
         &self,
         package_ref: LifecyclePackageRef,
-        scope: &ResourceScope,
+        scope: Option<&ResourceScope>,
+        caller: &UserId,
     ) -> Result<LifecycleProductResponse, ProductWorkflowError> {
         // Capture the removed extension's credential providers and id BEFORE
         // taking the operation lock: `activation_credential_requirements` takes
         // the same lock, and the manifest is gone once removal succeeds.
         let removed_extension_id = package_ref.id.as_str().to_string();
-        let removed_providers = self.removed_extension_providers(&package_ref).await;
+        let removed_providers = self.removed_extension_providers(&package_ref, caller).await;
         let response = {
             let _operation_guard = self.operation_lock.lock().await;
-            self.remove_locked(package_ref).await
+            self.remove_locked(package_ref, caller).await
         };
         if response.is_ok() {
-            self.revoke_exclusive_credentials(scope, &removed_extension_id, &removed_providers)
-                .await;
+            match scope {
+                Some(scope) => {
+                    self.revoke_exclusive_credentials(
+                        scope,
+                        &removed_extension_id,
+                        &removed_providers,
+                        caller,
+                    )
+                    .await;
+                }
+                // Command-path removals (#5525) have no caller resource scope
+                // to target credential accounts with; revocation is best-effort
+                // by contract, so skip it rather than reject the removal.
+                None => {
+                    tracing::debug!(
+                        extension_id = %removed_extension_id,
+                        "extension removed without a caller resource scope; skipping credential cleanup"
+                    );
+                }
+            }
         }
         response
     }
@@ -933,8 +1094,12 @@ impl RebornLocalExtensionManagementPort {
     async fn removed_extension_providers(
         &self,
         package_ref: &LifecyclePackageRef,
+        caller: &UserId,
     ) -> Vec<AuthProviderId> {
-        match self.activation_credential_requirements(package_ref).await {
+        match self
+            .activation_credential_requirements(package_ref, caller)
+            .await
+        {
             Ok(requirements) => {
                 let mut providers: Vec<AuthProviderId> = Vec::new();
                 for requirement in requirements {
@@ -976,6 +1141,7 @@ impl RebornLocalExtensionManagementPort {
         scope: &ResourceScope,
         removed_extension_id: &str,
         removed_providers: &[AuthProviderId],
+        caller: &UserId,
     ) {
         let Some(cleanup) = self.credential_cleanup.as_ref() else {
             return;
@@ -983,7 +1149,7 @@ impl RebornLocalExtensionManagementPort {
         if removed_providers.is_empty() {
             return;
         }
-        let Some(providers_still_in_use) = self.providers_still_in_use().await else {
+        let Some(providers_still_in_use) = self.providers_still_in_use(caller).await else {
             return;
         };
         let extension_id = match ExtensionId::new(removed_extension_id) {
@@ -1018,8 +1184,13 @@ impl RebornLocalExtensionManagementPort {
     /// removal. Returns `None` when the set cannot be resolved so the caller
     /// fails safe and skips revocation rather than risk deleting a shared
     /// credential.
-    async fn providers_still_in_use(&self) -> Option<BTreeSet<AuthProviderId>> {
-        let response = match self.list_installed().await {
+    ///
+    /// Enumeration is caller-masked (#5459 P1): another user's private install
+    /// is invisible here, and that is the right universe — the revocation is
+    /// scoped to the remover's own credential accounts, which a foreign
+    /// private install cannot be consuming.
+    async fn providers_still_in_use(&self, caller: &UserId) -> Option<BTreeSet<AuthProviderId>> {
+        let response = match self.list_installed(caller).await {
             Ok(response) => response,
             Err(error) => {
                 tracing::debug!(
@@ -1036,7 +1207,7 @@ impl RebornLocalExtensionManagementPort {
         let mut providers = BTreeSet::new();
         for installed in extensions {
             match self
-                .activation_credential_requirements(&installed.summary.package_ref)
+                .activation_credential_requirements(&installed.summary.package_ref, caller)
                 .await
             {
                 Ok(requirements) => {
@@ -1070,11 +1241,21 @@ impl RebornLocalExtensionManagementPort {
     async fn remove_locked(
         &self,
         package_ref: LifecyclePackageRef,
+        caller: &UserId,
     ) -> Result<LifecycleProductResponse, ProductWorkflowError> {
         let (extension_id, installation_id) = extension_ids_from_package_ref(&package_ref)?;
         let installation = self
             .load_installation(&extension_id, &installation_id)
             .await?;
+        ensure_caller_may_operate(&installation, caller)?;
+        if installation.owner().is_tenant() && caller != &self.tenant_operator_user_id {
+            return Err(ProductWorkflowError::InvalidBindingRequest {
+                reason: format!(
+                    "extension {} is a shared tool; only the tenant admin can remove it",
+                    extension_id.as_str()
+                ),
+            });
+        }
         let manifest = self
             .installation_store
             .get_manifest(&extension_id)
@@ -1263,6 +1444,10 @@ impl RebornLocalExtensionManagementPort {
         Ok(())
     }
 
+    /// Fail-closed slot check for the catalog import path (#5499): reject a
+    /// zip-imported bundle whose id already has an installation row or manifest.
+    /// The per-user owner/slot rules in [`Self::ensure_slot_available`] apply at
+    /// install time; catalog import only needs the id to be free.
     async fn ensure_not_installed(
         &self,
         extension_id: &ExtensionId,
@@ -1291,6 +1476,161 @@ impl RebornLocalExtensionManagementPort {
             });
         }
         Ok(())
+    }
+
+    /// #5459 P1 slot rules — one installation slot per extension id per tenant,
+    /// with a typed owner deciding who may claim an occupied slot:
+    ///
+    /// - vacant → anyone installs (owner already derived by the caller)
+    /// - `Tenant`-owned → nobody re-installs over it (the update flow is a
+    ///   separate concern); members see "already available as a shared tool"
+    /// - `User`-owned → the owner sees "already installed"; OTHER users get a
+    ///   generic "unavailable" (never leaking who holds the slot); a TENANT
+    ///   install EVICTS the private install (admin-wins: a user must not be
+    ///   able to squat an id against the whole tenant, and "two users want it
+    ///   privately → admin installs it shared" self-heals through this rule)
+    ///
+    /// Eviction supersedes, never destroys: it unpublishes/deregisters the
+    /// private install so the tenant install can take the slot, but touches no
+    /// secret-store rows and no credential accounts — the evicted user's
+    /// personal credentials keep resolving caller-first at dispatch.
+    async fn ensure_slot_available(
+        &self,
+        extension_id: &ExtensionId,
+        installation_id: &ExtensionInstallationId,
+        claimant: &InstallationOwner,
+    ) -> Result<Option<EvictedPrivateInstall>, ProductWorkflowError> {
+        let existing = self
+            .installation_store
+            .get_installation(installation_id)
+            .await
+            .map_err(map_extension_installation_error)?;
+        let Some(existing) = existing else {
+            // No installation record; an orphaned manifest row still counts as
+            // an occupied slot (pre-#5459 behavior, kept fail-closed).
+            if self
+                .installation_store
+                .get_manifest(extension_id)
+                .await
+                .map_err(map_extension_installation_error)?
+                .is_some()
+            {
+                return Err(ProductWorkflowError::InvalidBindingRequest {
+                    reason: format!("extension {} is already installed", extension_id.as_str()),
+                });
+            }
+            return Ok(None);
+        };
+        match decide_occupied_slot(extension_id, existing.owner(), claimant)? {
+            OccupiedSlotDecision::EvictPrivateInstall => self
+                .evict_private_installation(extension_id, &existing)
+                .await
+                .map(Some),
+        }
+    }
+
+    /// Admin-wins eviction (#5459 P1): deregister/unpublish a user-private
+    /// installation so a tenant install can take the slot. The subsequent
+    /// install path overwrites the manifest + installation records via its
+    /// normal upsert (same installation id).
+    ///
+    /// Returns the pre-eviction snapshot so a tenant install that FAILS after
+    /// this point can put the victim back exactly as it was
+    /// ([`Self::restore_evicted_private_install`]) — a failed shared install
+    /// must not interfere with the user's private tool (#5525 review).
+    ///
+    /// Retry-safe by construction: if a prior tenant install partially
+    /// succeeded and crashed before compensation could run, the lifecycle
+    /// package may already be gone. Rather than dead-end at
+    /// `lifecycle_package()` — which would leave the id un-installable/
+    /// -removable tenant-wide until restart — eviction tolerates the absent
+    /// package as already-done, so the admin's retry re-runs eviction and
+    /// reclaims the slot. Grant minting gates on the enabled-installation
+    /// owner join, so the private capability is already denied the moment the
+    /// row flips to Disabled here, independent of the active-registry publish
+    /// state.
+    async fn evict_private_installation(
+        &self,
+        extension_id: &ExtensionId,
+        existing: &ExtensionInstallation,
+    ) -> Result<EvictedPrivateInstall, ProductWorkflowError> {
+        tracing::warn!(
+            extension_id = %extension_id.as_str(),
+            "tenant install is evicting a user-private installation (admin-wins slot rule)"
+        );
+        let was_enabled = existing.activation_state() == ExtensionActivationState::Enabled;
+        let manifest = self
+            .installation_store
+            .get_manifest(extension_id)
+            .await
+            .map_err(map_extension_installation_error)?;
+        let lifecycle_package = self.lifecycle_package(extension_id).await.ok();
+        self.installation_store
+            .set_activation_state(
+                existing.installation_id(),
+                ExtensionActivationState::Disabled,
+            )
+            .await
+            .map_err(map_extension_installation_error)?;
+        if let Some(lifecycle_package) = &lifecycle_package {
+            self.remove_lifecycle_package(extension_id).await?;
+            if was_enabled {
+                self.active_extensions.unpublish(lifecycle_package)?;
+            }
+        }
+        Ok(EvictedPrivateInstall {
+            manifest,
+            installation: existing.clone(),
+            lifecycle_package,
+        })
+    }
+
+    /// Inverse of [`Self::evict_private_installation`] for the FAILED
+    /// tenant-install path: restore the victim's manifest/installation rows,
+    /// re-register its lifecycle package, and re-publish its capability
+    /// surface to the captured pre-eviction state. Runs AFTER the tenant
+    /// package rollback so the lifecycle slot is free again.
+    async fn restore_evicted_private_install(
+        &self,
+        evicted: &EvictedPrivateInstall,
+    ) -> Result<(), ProductWorkflowError> {
+        let previous_state = evicted.installation.activation_state();
+        match &evicted.manifest {
+            Some(manifest) => {
+                self.restore_installation_records(manifest.clone(), evicted.installation.clone())
+                    .await?;
+            }
+            None => self.restore_installation(&evicted.installation).await?,
+        }
+        if let Some(package) = &evicted.lifecycle_package {
+            self.restore_lifecycle_package(package, previous_state)
+                .await?;
+            self.restore_active_publication(package, previous_state)?;
+        }
+        Ok(())
+    }
+
+    /// Shared failure exit for the install path: after the tenant-side
+    /// rollback has run, put any evicted private install back. Returns the
+    /// error to propagate — the original install error, or a
+    /// [`compensation_failure`] when the victim restore itself failed.
+    async fn fail_install_restoring_evicted(
+        &self,
+        context: &str,
+        error: ProductWorkflowError,
+        evicted: Option<&EvictedPrivateInstall>,
+    ) -> ProductWorkflowError {
+        let Some(evicted) = evicted else {
+            return error;
+        };
+        match self.restore_evicted_private_install(evicted).await {
+            Ok(()) => error,
+            Err(restore_error) => compensation_failure(
+                &format!("{context} and evicted private install restore failed"),
+                error,
+                restore_error,
+            ),
+        }
     }
 
     async fn load_installation(
@@ -1493,6 +1833,7 @@ struct ExtensionInstallPlan {
 
 fn prepare_install(
     available: &AvailableExtensionPackage,
+    owner: InstallationOwner,
 ) -> Result<ExtensionInstallPlan, ProductWorkflowError> {
     let manifest_hash = available_manifest_hash(available)?;
     let host_ports = ironclaw_host_runtime::default_host_port_catalog().map_err(|error| {
@@ -1527,6 +1868,7 @@ fn prepare_install(
         ExtensionManifestRef::new(available.package.id.clone(), Some(manifest_hash)),
         Vec::new(),
         chrono::Utc::now(),
+        owner,
     )
     .map_err(map_extension_installation_error)?;
     Ok(ExtensionInstallPlan {
@@ -1573,6 +1915,9 @@ fn prepare_manifest_migration(
         ExtensionManifestRef::new(existing.extension_id().clone(), Some(manifest_hash)),
         existing.credential_bindings().to_vec(),
         chrono::Utc::now(),
+        // Manifest migration preserves ownership — it changes the manifest
+        // hash, never who the installation belongs to.
+        existing.owner().clone(),
     )
     .map_err(map_extension_installation_error)?;
     Ok(ExtensionInstallPlan {
@@ -1733,6 +2078,10 @@ fn extension_ids_from_package_ref(
     Ok((extension_id, installation_id))
 }
 
+/// Project an installation owner into the wire-facing install scope (#5459
+/// P1): tenant-owned → `shared`, user-owned → `private`. Always `Some` for an
+/// existing installation; callers pass `None` when the caller has no visible
+/// installation at all.
 fn phase_for_activation_state(state: ExtensionActivationState) -> LifecyclePhase {
     match state {
         ExtensionActivationState::Enabled => LifecyclePhase::Active,
@@ -1916,6 +2265,8 @@ mod tests {
         LifecycleReadinessBlocker,
     };
     use ironclaw_trust::{HostTrustPolicy, InvalidationBus, TrustPolicy};
+
+    mod private_install_tests;
 
     #[test]
     fn installed_external_channel_search_result_gets_activation_guidance() {
@@ -2687,7 +3038,7 @@ output_schema_ref = "schemas/run.output.json"
         let slack_ref =
             LifecyclePackageRef::new(LifecyclePackageKind::Extension, "slack").expect("slack ref");
 
-        port.install(slack_ref.clone())
+        port.install(slack_ref.clone(), &lifecycle_owner())
             .await
             .expect("install Slack tools extension");
 
@@ -2707,7 +3058,10 @@ output_schema_ref = "schemas/run.output.json"
             "installing the Slack tools extension installs only itself, with no hidden companion"
         );
 
-        let list = port.list_installed().await.expect("list installed");
+        let list = port
+            .list_installed(&lifecycle_owner())
+            .await
+            .expect("list installed");
         let Some(LifecycleProductPayload::ExtensionList { extensions, count }) = list.payload
         else {
             panic!("expected extension list payload");
@@ -2715,7 +3069,10 @@ output_schema_ref = "schemas/run.output.json"
         assert_eq!(count, 1);
         assert_eq!(extensions[0].summary.package_ref.id.as_str(), "slack");
 
-        let search = port.search("slack", None).await.expect("search slack");
+        let search = port
+            .search("slack", None, &lifecycle_owner())
+            .await
+            .expect("search slack");
         let Some(LifecycleProductPayload::ExtensionSearch { extensions, .. }) = search.payload
         else {
             panic!("expected extension search payload");
@@ -2764,12 +3121,12 @@ output_schema_ref = "schemas/run.output.json"
         let slack_ref =
             LifecyclePackageRef::new(LifecyclePackageKind::Extension, "slack").expect("slack ref");
 
-        port.install(slack_ref.clone())
+        port.install(slack_ref.clone(), &lifecycle_owner())
             .await
             .expect("install public Slack extension");
 
         let requirements = port
-            .activation_credential_requirements(&slack_ref)
+            .activation_credential_requirements(&slack_ref, &lifecycle_owner())
             .await
             .expect("Slack activation requirements");
         assert_eq!(requirements.len(), 1);
@@ -2820,7 +3177,7 @@ output_schema_ref = "schemas/run.output.json"
         let slack_ref =
             LifecyclePackageRef::new(LifecyclePackageKind::Extension, "slack").expect("slack ref");
 
-        port.install(slack_ref.clone())
+        port.install(slack_ref.clone(), &lifecycle_owner())
             .await
             .expect("install public Slack extension");
         port.activate_with_prechecked_credentials_for_test(
@@ -2829,9 +3186,13 @@ output_schema_ref = "schemas/run.output.json"
         )
         .await
         .expect("activate Slack and internal user tools");
-        port.remove(slack_ref, &hosted_mcp_scope("extension-remove-test"))
-            .await
-            .expect("remove public Slack");
+        port.remove(
+            slack_ref,
+            Some(&hosted_mcp_scope("extension-remove-test")),
+            &lifecycle_owner(),
+        )
+        .await
+        .expect("remove public Slack");
 
         let installed_ids = installation_store
             .list_installations()
@@ -2871,7 +3232,7 @@ output_schema_ref = "schemas/run.output.json"
             .expect("seed builtin package");
         let package_ref = LifecyclePackageRef::new(LifecyclePackageKind::Extension, "fixture")
             .expect("valid ref");
-        port.install(package_ref.clone())
+        port.install(package_ref.clone(), &lifecycle_owner())
             .await
             .expect("install fixture extension");
         port.activate_with_prechecked_credentials_for_test(
@@ -2966,7 +3327,7 @@ output_schema_ref = "schemas/run.output.json"
             LifecyclePackageRef::new(LifecyclePackageKind::Extension, "notion").expect("valid ref");
         let egress = Arc::new(HostedMcpDiscoveryEgress::default());
 
-        port.install(package_ref.clone())
+        port.install(package_ref.clone(), &lifecycle_owner())
             .await
             .expect("install Notion MCP");
         port.activate_with_prechecked_credentials_for_test(
@@ -3024,7 +3385,7 @@ output_schema_ref = "schemas/run.output.json"
         let package_ref =
             LifecyclePackageRef::new(LifecyclePackageKind::Extension, "notion").expect("valid ref");
 
-        port.install(package_ref.clone())
+        port.install(package_ref.clone(), &lifecycle_owner())
             .await
             .expect("install Notion MCP");
         let activate = port
@@ -3064,7 +3425,7 @@ output_schema_ref = "schemas/run.output.json"
         };
         let calls = Arc::clone(&credential_gate.calls);
 
-        port.install(package_ref.clone())
+        port.install(package_ref.clone(), &lifecycle_owner())
             .await
             .expect("install Notion MCP");
         let error = port
@@ -3075,6 +3436,7 @@ output_schema_ref = "schemas/run.output.json"
                     runtime_http_egress: Arc::new(HostedMcpDiscoveryEgress::default()),
                 },
                 credential_gate,
+                &lifecycle_owner(),
             )
             .await
             .expect_err("post-discovery credential recheck should fail activation");
@@ -3111,7 +3473,7 @@ output_schema_ref = "schemas/run.output.json"
         let (egress, tools_list_started, release_tools_list) =
             BlockingToolsListHostedMcpEgress::new();
 
-        port.install(package_ref.clone())
+        port.install(package_ref.clone(), &lifecycle_owner())
             .await
             .expect("install Notion MCP");
         let activation = tokio::spawn({
@@ -3132,9 +3494,13 @@ output_schema_ref = "schemas/run.output.json"
             .await
             .expect("tools/list request should start");
 
-        port.remove(package_ref, &hosted_mcp_scope("extension-remove-test"))
-            .await
-            .expect("remove can proceed while discovery is in flight");
+        port.remove(
+            package_ref,
+            Some(&hosted_mcp_scope("extension-remove-test")),
+            &lifecycle_owner(),
+        )
+        .await
+        .expect("remove can proceed while discovery is in flight");
         release_tools_list
             .send(())
             .expect("release blocked tools/list response");
@@ -3167,7 +3533,7 @@ output_schema_ref = "schemas/run.output.json"
             TrustClass::Sandbox
         );
 
-        port.install(package_ref.clone())
+        port.install(package_ref.clone(), &lifecycle_owner())
             .await
             .expect("install fixture extension");
         port.activate_with_prechecked_credentials_for_test(
@@ -3192,9 +3558,13 @@ output_schema_ref = "schemas/run.output.json"
             vec![EffectKind::Network, EffectKind::ExternalWrite]
         );
 
-        port.remove(package_ref, &hosted_mcp_scope("extension-remove-test"))
-            .await
-            .expect("remove fixture extension");
+        port.remove(
+            package_ref,
+            Some(&hosted_mcp_scope("extension-remove-test")),
+            &lifecycle_owner(),
+        )
+        .await
+        .expect("remove fixture extension");
         let removed_decision = trust_policy
             .evaluate(&trust_input)
             .expect("removed extension trust");
@@ -3220,11 +3590,15 @@ output_schema_ref = "schemas/run.output.json"
         let package_ref = LifecyclePackageRef::new(LifecyclePackageKind::Extension, "fixture")
             .expect("valid ref");
 
-        port.install(package_ref.clone())
+        port.install(package_ref.clone(), &lifecycle_owner())
             .await
             .expect("install extension");
         let error = port
-            .activate(package_ref, ExtensionActivationMode::Static)
+            .activate(
+                package_ref,
+                ExtensionActivationMode::Static,
+                &lifecycle_owner(),
+            )
             .await
             .expect_err("activation-state persistence failure is reported");
 
@@ -3260,11 +3634,15 @@ output_schema_ref = "schemas/run.output.json"
         let package_ref = LifecyclePackageRef::new(LifecyclePackageKind::Extension, "fixture")
             .expect("valid ref");
 
-        port.install(package_ref.clone())
+        port.install(package_ref.clone(), &lifecycle_owner())
             .await
             .expect("install extension");
         let error = port
-            .activate(package_ref, ExtensionActivationMode::Static)
+            .activate(
+                package_ref,
+                ExtensionActivationMode::Static,
+                &lifecycle_owner(),
+            )
             .await
             .expect_err("publish failure is reported");
 
@@ -3300,7 +3678,7 @@ output_schema_ref = "schemas/run.output.json"
         let extension_id = ExtensionId::new("fixture").expect("valid extension id");
         let installation_id = ExtensionInstallationId::new("fixture").expect("valid installation");
 
-        port.install(package_ref.clone())
+        port.install(package_ref.clone(), &lifecycle_owner())
             .await
             .expect("install extension");
         installation_store
@@ -3341,7 +3719,7 @@ output_schema_ref = "schemas/run.output.json"
             );
 
         let error = port
-            .search("fixture", None)
+            .search("fixture", None, &lifecycle_owner())
             .await
             .expect_err("search reports installation-store read failure");
 
@@ -3361,7 +3739,7 @@ output_schema_ref = "schemas/run.output.json"
             );
 
         let error = port
-            .search("fixture", None)
+            .search("fixture", None, &lifecycle_owner())
             .await
             .expect_err("search reports mismatched installation row");
 
@@ -3381,7 +3759,7 @@ output_schema_ref = "schemas/run.output.json"
         let package_ref = LifecyclePackageRef::new(LifecyclePackageKind::Extension, "fixture")
             .expect("valid ref");
 
-        port.install(package_ref.clone())
+        port.install(package_ref.clone(), &lifecycle_owner())
             .await
             .expect("install fixture extension");
         port.activate_with_prechecked_credentials_for_test(
@@ -3419,7 +3797,7 @@ output_schema_ref = "schemas/run.output.json"
             );
         let package_ref = LifecyclePackageRef::new(LifecyclePackageKind::Extension, "fixture")
             .expect("valid ref");
-        port.install(package_ref.clone())
+        port.install(package_ref.clone(), &lifecycle_owner())
             .await
             .expect("install fixture extension");
         port.activate_with_prechecked_credentials_for_test(
@@ -3499,6 +3877,7 @@ output_schema_ref = "schemas/run.output.json"
                     ),
                     Vec::new(),
                     chrono::Utc::now(),
+                    InstallationOwner::Tenant,
                 )
                 .expect("retired slack_user installation"),
             )
@@ -3559,7 +3938,7 @@ output_schema_ref = "schemas/run.output.json"
             );
         let package_ref = LifecyclePackageRef::new(LifecyclePackageKind::Extension, "fixture")
             .expect("valid ref");
-        port.install(package_ref.clone())
+        port.install(package_ref.clone(), &lifecycle_owner())
             .await
             .expect("install fixture extension");
         port.activate_with_prechecked_credentials_for_test(
@@ -3609,7 +3988,7 @@ output_schema_ref = "schemas/run.output.json"
             );
         let package_ref = LifecyclePackageRef::new(LifecyclePackageKind::Extension, "fixture")
             .expect("valid ref");
-        port.install(package_ref.clone())
+        port.install(package_ref.clone(), &lifecycle_owner())
             .await
             .expect("install fixture extension");
         port.activate_with_prechecked_credentials_for_test(
@@ -3989,7 +4368,9 @@ output_schema_ref = "schemas/run.output.json"
         let error = facade
             .execute(
                 lifecycle_surface_context(),
-                LifecycleProductAction::ExtensionActivate { package_ref },
+                LifecycleProductAction::ExtensionActivate {
+                    package_ref: package_ref.clone(),
+                },
             )
             .await
             .expect_err("missing product-auth account blocks activation");
@@ -4003,6 +4384,40 @@ output_schema_ref = "schemas/run.output.json"
                 .snapshot()
                 .get_extension(&ExtensionId::new("github").unwrap())
                 .is_none()
+        );
+
+        // #5525 review: ownership masks BEFORE the credential preflight — a
+        // non-owner activating a private credentialed install must get the
+        // masked "is not installed" denial, never an auth-required response
+        // that leaks the extension's existence and credential requirements.
+        facade
+            .execute(
+                lifecycle_surface_context(),
+                LifecycleProductAction::ExtensionRemove {
+                    package_ref: package_ref.clone(),
+                },
+            )
+            .await
+            .expect("operator clears the shared slot");
+        facade
+            .execute(
+                lifecycle_surface_context_for_user("alice"),
+                LifecycleProductAction::ExtensionInstall {
+                    package_ref: package_ref.clone(),
+                },
+            )
+            .await
+            .expect("alice installs the credentialed extension privately");
+        let error = facade
+            .execute(
+                lifecycle_surface_context_for_user("bob"),
+                LifecycleProductAction::ExtensionActivate { package_ref },
+            )
+            .await
+            .expect_err("foreign private credentialed install must be inoperable");
+        assert!(
+            error.to_string().contains("is not installed"),
+            "ownership must mask before the credential preflight: {error}"
         );
     }
 
@@ -4358,12 +4773,17 @@ output_schema_ref = "schemas/run.output.json"
                 test_extension_trust_policy(),
             ),
             None,
+            lifecycle_owner(),
         );
         let package_ref = LifecyclePackageRef::new(LifecyclePackageKind::Extension, "fixture")
             .expect("valid ref");
 
         let error = port
-            .activate(package_ref, ExtensionActivationMode::Static)
+            .activate(
+                package_ref,
+                ExtensionActivationMode::Static,
+                &lifecycle_owner(),
+            )
             .await
             .expect_err("activation requires an installation record");
 
@@ -4488,7 +4908,7 @@ output_schema_ref = "schemas/run.output.json"
         let package_ref = LifecyclePackageRef::new(LifecyclePackageKind::Extension, "fixture")
             .expect("valid ref");
 
-        port.install(package_ref.clone())
+        port.install(package_ref.clone(), &lifecycle_owner())
             .await
             .expect("install extension");
         port.activate_with_prechecked_credentials_for_test(
@@ -4509,7 +4929,11 @@ output_schema_ref = "schemas/run.output.json"
         );
 
         let error = port
-            .remove(package_ref, &hosted_mcp_scope("extension-remove-test"))
+            .remove(
+                package_ref,
+                Some(&hosted_mcp_scope("extension-remove-test")),
+                &lifecycle_owner(),
+            )
             .await
             .expect_err("delete installation failure is reported");
 
@@ -4551,7 +4975,7 @@ output_schema_ref = "schemas/run.output.json"
         let package_ref = LifecyclePackageRef::new(LifecyclePackageKind::Extension, "fixture")
             .expect("valid ref");
 
-        port.install(package_ref.clone())
+        port.install(package_ref.clone(), &lifecycle_owner())
             .await
             .expect("install extension");
         port.activate_with_prechecked_credentials_for_test(
@@ -4564,7 +4988,11 @@ output_schema_ref = "schemas/run.output.json"
         let trust_input = extension_trust_policy_input(&package).expect("trust input");
 
         let error = port
-            .remove(package_ref, &hosted_mcp_scope("extension-remove-test"))
+            .remove(
+                package_ref,
+                Some(&hosted_mcp_scope("extension-remove-test")),
+                &lifecycle_owner(),
+            )
             .await
             .expect_err("delete manifest failure is reported");
 
@@ -4590,7 +5018,7 @@ output_schema_ref = "schemas/run.output.json"
         let package_ref = LifecyclePackageRef::new(LifecyclePackageKind::Extension, "fixture")
             .expect("valid ref");
 
-        port.install(package_ref.clone())
+        port.install(package_ref.clone(), &lifecycle_owner())
             .await
             .expect("install extension");
         port.activate_with_prechecked_credentials_for_test(
@@ -4603,7 +5031,11 @@ output_schema_ref = "schemas/run.output.json"
         let trust_input = extension_trust_policy_input(&package).expect("trust input");
 
         let error = port
-            .remove(package_ref, &hosted_mcp_scope("extension-remove-test"))
+            .remove(
+                package_ref,
+                Some(&hosted_mcp_scope("extension-remove-test")),
+                &lifecycle_owner(),
+            )
             .await
             .expect_err("delete files failure is reported");
 
@@ -4919,6 +5351,7 @@ output_schema_ref = "schemas/run.output.json"
                 Arc::clone(&trust_policy),
             ),
             None,
+            lifecycle_owner(),
         ));
         (
             dir,
@@ -5000,6 +5433,7 @@ output_schema_ref = "schemas/run.output.json"
                 test_extension_trust_policy(),
             ),
             credential_cleanup,
+            lifecycle_owner(),
         ));
         let facade =
             crate::extension_host::lifecycle::RebornLocalLifecycleFacade::new(skill_management)
@@ -5117,6 +5551,7 @@ output_schema_ref = "schemas/run.output.json"
                 Arc::clone(&trust_policy),
             ),
             None,
+            lifecycle_owner(),
         );
         (dir, port, active_registry, failing_store, trust_policy)
     }
@@ -5164,6 +5599,7 @@ output_schema_ref = "schemas/run.output.json"
                 Arc::clone(&trust_policy),
             ),
             None,
+            lifecycle_owner(),
         );
         (dir, port, active_registry, installation_store, trust_policy)
     }
@@ -5221,46 +5657,37 @@ output_schema_ref = "schemas/run.output.json"
         fail_set_activation_enabled: bool,
         fail_get_installation: bool,
         mismatched_get_installation: bool,
+        /// #5459 P1: fail the NEXT `upsert_installation` once, then clear —
+        /// simulates a mid-install persist failure so the retry can heal.
+        fail_next_upsert_installation: std::sync::atomic::AtomicBool,
     }
 
     impl DeleteInstallationFailingStore {
         fn fail_manifest_delete() -> Self {
             Self {
-                inner: InMemoryExtensionInstallationStore::default(),
                 fail_manifest_delete: true,
-                fail_set_activation_enabled: false,
-                fail_get_installation: false,
-                mismatched_get_installation: false,
+                ..Self::default()
             }
         }
 
         fn fail_set_activation_enabled() -> Self {
             Self {
-                inner: InMemoryExtensionInstallationStore::default(),
-                fail_manifest_delete: false,
                 fail_set_activation_enabled: true,
-                fail_get_installation: false,
-                mismatched_get_installation: false,
+                ..Self::default()
             }
         }
 
         fn fail_get_installation() -> Self {
             Self {
-                inner: InMemoryExtensionInstallationStore::default(),
-                fail_manifest_delete: false,
-                fail_set_activation_enabled: false,
                 fail_get_installation: true,
-                mismatched_get_installation: false,
+                ..Self::default()
             }
         }
 
         fn mismatched_get_installation() -> Self {
             Self {
-                inner: InMemoryExtensionInstallationStore::default(),
-                fail_manifest_delete: false,
-                fail_set_activation_enabled: false,
-                fail_get_installation: false,
                 mismatched_get_installation: true,
+                ..Self::default()
             }
         }
     }
@@ -5327,6 +5754,7 @@ output_schema_ref = "schemas/run.output.json"
                     ExtensionManifestRef::new(extension_id, None),
                     Vec::new(),
                     chrono::Utc::now(),
+                    InstallationOwner::Tenant,
                 )
                 .expect("mismatched installation fixture");
                 return Ok(Some(installation));
@@ -5338,6 +5766,14 @@ output_schema_ref = "schemas/run.output.json"
             &self,
             installation: ExtensionInstallation,
         ) -> Result<(), ExtensionInstallationError> {
+            if self
+                .fail_next_upsert_installation
+                .swap(false, std::sync::atomic::Ordering::SeqCst)
+            {
+                return Err(ExtensionInstallationError::InvalidInstallation {
+                    reason: "upsert installation failed".to_string(),
+                });
+            }
             self.inner.upsert_installation(installation).await
         }
 
@@ -5756,12 +6192,25 @@ output_schema_ref = "schemas/run.output.json"
     }
 
     fn lifecycle_surface_context() -> LifecycleProductContext {
+        lifecycle_surface_context_for_user("lifecycle-owner")
+    }
+
+    /// Surface context for an arbitrary member user (#5459 P1 tests). The
+    /// fixture wires `lifecycle-owner` as the tenant operator, so any other
+    /// user id here acts as a plain member whose installs derive `User(..)`.
+    fn lifecycle_surface_context_for_user(user: &str) -> LifecycleProductContext {
         LifecycleProductContext::Surface(LifecycleProductSurfaceContext {
             tenant_id: TenantId::new("lifecycle-tenant").expect("valid tenant"),
-            user_id: UserId::new("lifecycle-owner").expect("valid user"),
+            user_id: UserId::new(user).expect("valid user"),
             agent_id: None,
             project_id: None,
         })
+    }
+
+    /// The fixture's tenant-operator identity — matches the operator user id
+    /// wired into every test `RebornLocalExtensionManagementPort`.
+    fn lifecycle_owner() -> UserId {
+        UserId::new("lifecycle-owner").expect("valid user")
     }
 
     fn test_extension_trust_policy() -> Arc<HostTrustPolicy> {
@@ -6039,6 +6488,7 @@ output_schema_ref = "schemas/search.output.json"
             ),
             Vec::new(),
             chrono::Utc::now(),
+            InstallationOwner::Tenant,
         )
         .expect("fixture installation")
     }

--- a/crates/ironclaw_reborn_composition/src/extension_host/extension_lifecycle.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/extension_lifecycle.rs
@@ -88,7 +88,7 @@ pub(crate) use active_publication::ActiveExtensionPublisher;
 #[cfg(test)]
 use active_publication::extension_trust_policy_input;
 use install_policy::{
-    EvictedPrivateInstall, OccupiedSlotDecision, decide_occupied_slot, derive_owner,
+    InstallDecision, RemoveDecision, decide_install_on_existing, decide_remove, derive_owner,
     ensure_caller_may_operate, install_scope_for_owner,
 };
 
@@ -121,9 +121,10 @@ pub(crate) struct RebornLocalExtensionManagementPort {
     /// The tenant operator identity (#5459 P1). In local-dev this is the base
     /// owner user (`IRONCLAW_REBORN_WEBUI_USER_ID` semantics); installs by this
     /// user derive [`InstallationOwner::Tenant`] (shared), installs by anyone
-    /// else derive [`InstallationOwner::User`] (private). Resolved ONCE here —
-    /// when P0 role wiring lands, this becomes a role-derived resolver instead
-    /// of an identity comparison; callers do not re-derive admin-ness.
+    /// else make (or join) the member set [`InstallationOwner::Users`].
+    /// Resolved ONCE here — when P0 role wiring lands, this becomes a
+    /// role-derived resolver instead of an identity comparison; callers do
+    /// not re-derive admin-ness.
     tenant_operator_user_id: UserId,
 }
 
@@ -760,68 +761,38 @@ impl RebornLocalExtensionManagementPort {
         // below). Acquired BEFORE `operation_lock`; `import_bundle` takes the
         // write guard before `operation_lock` too, so the lock order is
         // consistent and the two cannot deadlock.
-        let owner = derive_owner(caller, &self.tenant_operator_user_id);
         let catalog = self.catalog.read().await;
         let available = catalog.resolve(&package_ref)?;
-        let plan = prepare_install(available, owner.clone())?;
         let _operation_guard = self.operation_lock.lock().await;
-        let evicted = self
-            .ensure_slot_available(
-                &available.package.id,
-                plan.installation.installation_id(),
-                &owner,
-            )
-            .await?;
-        if let Err(error) = self.register_lifecycle_package(&available.package).await {
-            return Err(self
-                .fail_install_restoring_evicted(
-                    "extension install registration failed",
-                    error,
-                    evicted.as_ref(),
-                )
-                .await);
-        }
-
-        if let Err(error) =
-            materialize_available_extension(self.filesystem.as_ref(), available).await
-        {
-            if let Err(rollback_error) =
-                self.rollback_lifecycle_install(&available.package.id).await
-            {
-                return Err(compensation_failure(
-                    "extension install materialization failed and lifecycle rollback failed",
-                    error,
-                    rollback_error,
-                ));
+        let installation_id =
+            ExtensionInstallationId::new(available.package.id.as_str().to_string())
+                .map_err(map_extension_installation_error)?;
+        let existing = self
+            .installation_store
+            .get_installation(&installation_id)
+            .await
+            .map_err(map_extension_installation_error)?;
+        match existing {
+            // The id is already installed: membership decides whether the
+            // caller JOINS the member set or the operator EVICTS it to
+            // `Tenant` — either way a single row rewrite; the bundle is
+            // already registered, materialized, and (if enabled) published,
+            // so there is nothing to compensate.
+            Some(existing) => {
+                let InstallDecision::UpdateOwner(new_owner) = decide_install_on_existing(
+                    &available.package.id,
+                    existing.owner(),
+                    caller,
+                    &self.tenant_operator_user_id,
+                )?;
+                self.installation_store
+                    .upsert_installation(existing.with_owner(new_owner))
+                    .await
+                    .map_err(map_extension_installation_error)?;
             }
-            return Err(self
-                .fail_install_restoring_evicted(
-                    "extension install materialization failed",
-                    error,
-                    evicted.as_ref(),
-                )
-                .await);
-        }
-        if let Err(error) = self.persist_install_plan(plan).await {
-            let _ = self
-                .delete_materialized_extension_files(&available.package.id)
-                .await;
-            if let Err(rollback_error) =
-                self.rollback_lifecycle_install(&available.package.id).await
-            {
-                return Err(compensation_failure(
-                    "extension install persistence failed and lifecycle rollback failed",
-                    error,
-                    rollback_error,
-                ));
+            None => {
+                self.install_fresh_locked(available, caller).await?;
             }
-            return Err(self
-                .fail_install_restoring_evicted(
-                    "extension install persistence failed",
-                    error,
-                    evicted.as_ref(),
-                )
-                .await);
         }
 
         Ok(response_with_payload(
@@ -838,6 +809,67 @@ impl RebornLocalExtensionManagementPort {
                 ),
             },
         ))
+    }
+
+    /// First install of an id: register the lifecycle package, materialize
+    /// the bundle, and persist the installation plan, unwinding on failure.
+    /// Callers hold `operation_lock` and have verified no installation row
+    /// exists.
+    async fn install_fresh_locked(
+        &self,
+        available: &AvailableExtensionPackage,
+        caller: &UserId,
+    ) -> Result<(), ProductWorkflowError> {
+        // An orphaned manifest row without an installation still counts as
+        // occupied (pre-#5459 behavior, kept fail-closed).
+        if self
+            .installation_store
+            .get_manifest(&available.package.id)
+            .await
+            .map_err(map_extension_installation_error)?
+            .is_some()
+        {
+            return Err(ProductWorkflowError::InvalidBindingRequest {
+                reason: format!(
+                    "extension {} is already installed",
+                    available.package.id.as_str()
+                ),
+            });
+        }
+        let owner = derive_owner(caller, &self.tenant_operator_user_id);
+        let plan = prepare_install(available, owner)?;
+        self.register_lifecycle_package(&available.package).await?;
+
+        if let Err(error) =
+            materialize_available_extension(self.filesystem.as_ref(), available).await
+        {
+            if let Err(rollback_error) =
+                self.rollback_lifecycle_install(&available.package.id).await
+            {
+                return Err(compensation_failure(
+                    "extension install materialization failed and lifecycle rollback failed",
+                    error,
+                    rollback_error,
+                ));
+            }
+            return Err(error);
+        }
+        if let Err(error) = self.persist_install_plan(plan).await {
+            let _ = self
+                .delete_materialized_extension_files(&available.package.id)
+                .await;
+            if let Err(rollback_error) =
+                self.rollback_lifecycle_install(&available.package.id).await
+            {
+                return Err(compensation_failure(
+                    "extension install persistence failed and lifecycle rollback failed",
+                    error,
+                    rollback_error,
+                ));
+            }
+            return Err(error);
+        }
+        Ok(())
     }
 
     pub(crate) async fn activate(
@@ -1256,6 +1288,23 @@ impl RebornLocalExtensionManagementPort {
                 ),
             });
         }
+        // Membership remove (#5459 P1 pivot): while other members still hold
+        // the tool, the caller just LEAVES the member set — a single row
+        // rewrite, no teardown. Only the last holder's remove (or the
+        // operator removing a tenant-shared tool) tears the install down.
+        if let RemoveDecision::LeaveMembers(remaining) =
+            decide_remove(installation.owner(), caller)?
+        {
+            self.installation_store
+                .upsert_installation(installation.with_owner(remaining))
+                .await
+                .map_err(map_extension_installation_error)?;
+            return Ok(response_with_payload(
+                Some(package_ref),
+                LifecyclePhase::Removed,
+                LifecycleProductPayload::ExtensionRemove { removed: true },
+            ));
+        }
         let manifest = self
             .installation_store
             .get_manifest(&extension_id)
@@ -1444,10 +1493,11 @@ impl RebornLocalExtensionManagementPort {
         Ok(())
     }
 
-    /// Fail-closed slot check for the catalog import path (#5499): reject a
-    /// zip-imported bundle whose id already has an installation row or manifest.
-    /// The per-user owner/slot rules in [`Self::ensure_slot_available`] apply at
-    /// install time; catalog import only needs the id to be free.
+    /// Fail-closed id check for the catalog import path (#5499): reject a
+    /// zip-imported bundle whose id already has an installation row or manifest
+    /// — a bundle cannot be swapped under live installs. The membership rules
+    /// in [`install_policy::decide_install_on_existing`] apply at install
+    /// time; catalog import only needs the id to be free.
     async fn ensure_not_installed(
         &self,
         extension_id: &ExtensionId,
@@ -1476,161 +1526,6 @@ impl RebornLocalExtensionManagementPort {
             });
         }
         Ok(())
-    }
-
-    /// #5459 P1 slot rules — one installation slot per extension id per tenant,
-    /// with a typed owner deciding who may claim an occupied slot:
-    ///
-    /// - vacant → anyone installs (owner already derived by the caller)
-    /// - `Tenant`-owned → nobody re-installs over it (the update flow is a
-    ///   separate concern); members see "already available as a shared tool"
-    /// - `User`-owned → the owner sees "already installed"; OTHER users get a
-    ///   generic "unavailable" (never leaking who holds the slot); a TENANT
-    ///   install EVICTS the private install (admin-wins: a user must not be
-    ///   able to squat an id against the whole tenant, and "two users want it
-    ///   privately → admin installs it shared" self-heals through this rule)
-    ///
-    /// Eviction supersedes, never destroys: it unpublishes/deregisters the
-    /// private install so the tenant install can take the slot, but touches no
-    /// secret-store rows and no credential accounts — the evicted user's
-    /// personal credentials keep resolving caller-first at dispatch.
-    async fn ensure_slot_available(
-        &self,
-        extension_id: &ExtensionId,
-        installation_id: &ExtensionInstallationId,
-        claimant: &InstallationOwner,
-    ) -> Result<Option<EvictedPrivateInstall>, ProductWorkflowError> {
-        let existing = self
-            .installation_store
-            .get_installation(installation_id)
-            .await
-            .map_err(map_extension_installation_error)?;
-        let Some(existing) = existing else {
-            // No installation record; an orphaned manifest row still counts as
-            // an occupied slot (pre-#5459 behavior, kept fail-closed).
-            if self
-                .installation_store
-                .get_manifest(extension_id)
-                .await
-                .map_err(map_extension_installation_error)?
-                .is_some()
-            {
-                return Err(ProductWorkflowError::InvalidBindingRequest {
-                    reason: format!("extension {} is already installed", extension_id.as_str()),
-                });
-            }
-            return Ok(None);
-        };
-        match decide_occupied_slot(extension_id, existing.owner(), claimant)? {
-            OccupiedSlotDecision::EvictPrivateInstall => self
-                .evict_private_installation(extension_id, &existing)
-                .await
-                .map(Some),
-        }
-    }
-
-    /// Admin-wins eviction (#5459 P1): deregister/unpublish a user-private
-    /// installation so a tenant install can take the slot. The subsequent
-    /// install path overwrites the manifest + installation records via its
-    /// normal upsert (same installation id).
-    ///
-    /// Returns the pre-eviction snapshot so a tenant install that FAILS after
-    /// this point can put the victim back exactly as it was
-    /// ([`Self::restore_evicted_private_install`]) — a failed shared install
-    /// must not interfere with the user's private tool (#5525 review).
-    ///
-    /// Retry-safe by construction: if a prior tenant install partially
-    /// succeeded and crashed before compensation could run, the lifecycle
-    /// package may already be gone. Rather than dead-end at
-    /// `lifecycle_package()` — which would leave the id un-installable/
-    /// -removable tenant-wide until restart — eviction tolerates the absent
-    /// package as already-done, so the admin's retry re-runs eviction and
-    /// reclaims the slot. Grant minting gates on the enabled-installation
-    /// owner join, so the private capability is already denied the moment the
-    /// row flips to Disabled here, independent of the active-registry publish
-    /// state.
-    async fn evict_private_installation(
-        &self,
-        extension_id: &ExtensionId,
-        existing: &ExtensionInstallation,
-    ) -> Result<EvictedPrivateInstall, ProductWorkflowError> {
-        tracing::warn!(
-            extension_id = %extension_id.as_str(),
-            "tenant install is evicting a user-private installation (admin-wins slot rule)"
-        );
-        let was_enabled = existing.activation_state() == ExtensionActivationState::Enabled;
-        let manifest = self
-            .installation_store
-            .get_manifest(extension_id)
-            .await
-            .map_err(map_extension_installation_error)?;
-        let lifecycle_package = self.lifecycle_package(extension_id).await.ok();
-        self.installation_store
-            .set_activation_state(
-                existing.installation_id(),
-                ExtensionActivationState::Disabled,
-            )
-            .await
-            .map_err(map_extension_installation_error)?;
-        if let Some(lifecycle_package) = &lifecycle_package {
-            self.remove_lifecycle_package(extension_id).await?;
-            if was_enabled {
-                self.active_extensions.unpublish(lifecycle_package)?;
-            }
-        }
-        Ok(EvictedPrivateInstall {
-            manifest,
-            installation: existing.clone(),
-            lifecycle_package,
-        })
-    }
-
-    /// Inverse of [`Self::evict_private_installation`] for the FAILED
-    /// tenant-install path: restore the victim's manifest/installation rows,
-    /// re-register its lifecycle package, and re-publish its capability
-    /// surface to the captured pre-eviction state. Runs AFTER the tenant
-    /// package rollback so the lifecycle slot is free again.
-    async fn restore_evicted_private_install(
-        &self,
-        evicted: &EvictedPrivateInstall,
-    ) -> Result<(), ProductWorkflowError> {
-        let previous_state = evicted.installation.activation_state();
-        match &evicted.manifest {
-            Some(manifest) => {
-                self.restore_installation_records(manifest.clone(), evicted.installation.clone())
-                    .await?;
-            }
-            None => self.restore_installation(&evicted.installation).await?,
-        }
-        if let Some(package) = &evicted.lifecycle_package {
-            self.restore_lifecycle_package(package, previous_state)
-                .await?;
-            self.restore_active_publication(package, previous_state)?;
-        }
-        Ok(())
-    }
-
-    /// Shared failure exit for the install path: after the tenant-side
-    /// rollback has run, put any evicted private install back. Returns the
-    /// error to propagate — the original install error, or a
-    /// [`compensation_failure`] when the victim restore itself failed.
-    async fn fail_install_restoring_evicted(
-        &self,
-        context: &str,
-        error: ProductWorkflowError,
-        evicted: Option<&EvictedPrivateInstall>,
-    ) -> ProductWorkflowError {
-        let Some(evicted) = evicted else {
-            return error;
-        };
-        match self.restore_evicted_private_install(evicted).await {
-            Ok(()) => error,
-            Err(restore_error) => compensation_failure(
-                &format!("{context} and evicted private install restore failed"),
-                error,
-                restore_error,
-            ),
-        }
     }
 
     async fn load_installation(

--- a/crates/ironclaw_reborn_composition/src/extension_host/extension_lifecycle/install_policy.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/extension_lifecycle/install_policy.rs
@@ -1,0 +1,219 @@
+//! Private-install ownership and slot policy (#5459 P1, #5525 review).
+//!
+//! Pure decisions only — every store read/write, package registration, and
+//! publish/unpublish stays in the parent module. Extracted so the ownership
+//! rules (who owns a new install, who may operate an existing one, who may
+//! take an occupied slot, and what an eviction must capture for restore) are
+//! reviewable and testable in one place instead of interleaved with the
+//! lifecycle I/O.
+
+use ironclaw_extensions::{
+    ExtensionInstallation, ExtensionManifestRecord, ExtensionPackage, InstallationOwner,
+};
+use ironclaw_host_api::{ExtensionId, UserId};
+use ironclaw_product_workflow::{LifecycleInstallScope, ProductWorkflowError};
+
+/// Derive who a NEW install belongs to (#5459 P1): the tenant operator
+/// installs for the whole tenant; anyone else installs privately.
+pub(super) fn derive_owner(caller: &UserId, tenant_operator: &UserId) -> InstallationOwner {
+    if caller == tenant_operator {
+        InstallationOwner::Tenant
+    } else {
+        InstallationOwner::user(caller.clone())
+    }
+}
+
+/// Fail-closed visibility check for lifecycle mutations on an existing
+/// installation: a user-private install is operable ONLY by its owner —
+/// every non-owner, the tenant operator included, gets the masked denial.
+/// The admin's sole power over a foreign private slot is the explicit
+/// shared-install eviction granted by [`decide_occupied_slot`], never direct
+/// activate/remove by id. The error is deliberately the same "is not
+/// installed" shape a missing installation produces, so a foreign caller
+/// cannot distinguish (or enumerate) other users' private installs.
+pub(super) fn ensure_caller_may_operate(
+    installation: &ExtensionInstallation,
+    caller: &UserId,
+) -> Result<(), ProductWorkflowError> {
+    match installation.owner() {
+        InstallationOwner::Tenant => Ok(()),
+        InstallationOwner::User { user_id } if user_id == caller => Ok(()),
+        InstallationOwner::User { .. } => Err(ProductWorkflowError::InvalidBindingRequest {
+            reason: format!(
+                "extension {} is not installed",
+                installation.extension_id().as_str()
+            ),
+        }),
+    }
+}
+
+/// The one takeover an occupied slot permits.
+pub(super) enum OccupiedSlotDecision {
+    /// Admin-wins (#5459 P1): a tenant claim seizes the slot by evicting the
+    /// existing user-private install.
+    EvictPrivateInstall,
+}
+
+/// Slot rules for an extension id whose installation row already exists.
+///
+/// Every rejection wording is part of the masking contract: a foreign member
+/// probing another user's private slot learns only that the id is
+/// "unavailable" — never that a private install exists or whose it is.
+pub(super) fn decide_occupied_slot(
+    extension_id: &ExtensionId,
+    existing_owner: &InstallationOwner,
+    claimant: &InstallationOwner,
+) -> Result<OccupiedSlotDecision, ProductWorkflowError> {
+    match (existing_owner, claimant) {
+        (InstallationOwner::Tenant, InstallationOwner::User { .. }) => {
+            Err(ProductWorkflowError::InvalidBindingRequest {
+                reason: format!(
+                    "extension {} is already available as a shared tool",
+                    extension_id.as_str()
+                ),
+            })
+        }
+        (InstallationOwner::Tenant, InstallationOwner::Tenant) => {
+            Err(ProductWorkflowError::InvalidBindingRequest {
+                reason: format!("extension {} is already installed", extension_id.as_str()),
+            })
+        }
+        (InstallationOwner::User { user_id }, InstallationOwner::User { user_id: caller }) => {
+            if user_id == caller {
+                Err(ProductWorkflowError::InvalidBindingRequest {
+                    reason: format!("extension {} is already installed", extension_id.as_str()),
+                })
+            } else {
+                // Generic wording: a foreign caller must not learn that a
+                // private install exists, let alone whose it is.
+                Err(ProductWorkflowError::InvalidBindingRequest {
+                    reason: format!("extension id {} is unavailable", extension_id.as_str()),
+                })
+            }
+        }
+        (InstallationOwner::User { .. }, InstallationOwner::Tenant) => {
+            Ok(OccupiedSlotDecision::EvictPrivateInstall)
+        }
+    }
+}
+
+/// Pre-eviction snapshot of a user-private install, captured by
+/// `evict_private_installation` so a tenant install that fails after eviction
+/// can restore the victim untouched (#5525 review: non-interference on failed
+/// shared installs).
+pub(super) struct EvictedPrivateInstall {
+    /// Manifest row as of eviction; `None` when a prior partial attempt
+    /// already dropped it.
+    pub(super) manifest: Option<ExtensionManifestRecord>,
+    /// The victim's installation row (owner + activation state).
+    pub(super) installation: ExtensionInstallation,
+    /// The victim's registered lifecycle package; `None` on the retry path
+    /// where a prior attempt already deregistered it.
+    pub(super) lifecycle_package: Option<ExtensionPackage>,
+}
+
+/// Settings/list projection of an installation owner (#5459 P1).
+pub(super) fn install_scope_for_owner(owner: &InstallationOwner) -> Option<LifecycleInstallScope> {
+    Some(match owner {
+        InstallationOwner::Tenant => LifecycleInstallScope::Shared,
+        InstallationOwner::User { .. } => LifecycleInstallScope::Private,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use ironclaw_extensions::{
+        ExtensionActivationState, ExtensionInstallationId, ExtensionManifestRef,
+    };
+
+    fn user(id: &str) -> UserId {
+        UserId::new(id).expect("valid user")
+    }
+
+    fn installation(owner: InstallationOwner) -> ExtensionInstallation {
+        let ext_id = ExtensionId::new("fixture").expect("extension id");
+        ExtensionInstallation::new(
+            ExtensionInstallationId::new("fixture").expect("installation id"),
+            ext_id.clone(),
+            ExtensionActivationState::Enabled,
+            ExtensionManifestRef::new(ext_id, None),
+            Vec::new(),
+            Utc::now(),
+            owner,
+        )
+        .expect("installation")
+    }
+
+    #[test]
+    fn derive_owner_maps_operator_to_tenant_and_members_to_private() {
+        let operator = user("operator");
+        assert!(derive_owner(&operator, &operator).is_tenant());
+        assert_eq!(
+            derive_owner(&user("alice"), &operator)
+                .as_user()
+                .map(UserId::as_str),
+            Some("alice")
+        );
+    }
+
+    #[test]
+    fn ensure_caller_may_operate_masks_every_non_owner_including_operator() {
+        let tenant_owned = installation(InstallationOwner::Tenant);
+        let private = installation(InstallationOwner::user(user("alice")));
+
+        ensure_caller_may_operate(&tenant_owned, &user("bob")).expect("tenant tools are shared");
+        ensure_caller_may_operate(&private, &user("alice")).expect("the owner operates her tool");
+        for non_owner in ["bob", "operator"] {
+            let error = ensure_caller_may_operate(&private, &user(non_owner))
+                .expect_err("non-owners must be denied");
+            let rendered = error.to_string();
+            assert!(
+                rendered.contains("is not installed") && !rendered.contains("alice"),
+                "denial must mask the private install: {rendered}"
+            );
+        }
+    }
+
+    #[test]
+    fn decide_occupied_slot_permits_only_tenant_over_private() {
+        let extension_id = ExtensionId::new("fixture").expect("extension id");
+        let tenant = InstallationOwner::Tenant;
+        let alice = InstallationOwner::user(user("alice"));
+        let bob = InstallationOwner::user(user("bob"));
+
+        assert!(matches!(
+            decide_occupied_slot(&extension_id, &alice, &tenant),
+            Ok(OccupiedSlotDecision::EvictPrivateInstall)
+        ));
+        for (existing, claimant, expected) in [
+            (&tenant, &alice, "already available as a shared tool"),
+            (&tenant, &tenant, "already installed"),
+            (&alice, &alice, "already installed"),
+            (&alice, &bob, "is unavailable"),
+        ] {
+            let error = decide_occupied_slot(&extension_id, existing, claimant)
+                .err()
+                .expect("occupied slot rejects this claim");
+            let rendered = error.to_string();
+            assert!(rendered.contains(expected), "unexpected: {rendered}");
+            assert!(
+                !rendered.contains("alice"),
+                "slot error must not leak the private owner: {rendered}"
+            );
+        }
+    }
+
+    #[test]
+    fn install_scope_projects_owner_kind() {
+        assert_eq!(
+            install_scope_for_owner(&InstallationOwner::Tenant),
+            Some(LifecycleInstallScope::Shared)
+        );
+        assert_eq!(
+            install_scope_for_owner(&InstallationOwner::user(user("alice"))),
+            Some(LifecycleInstallScope::Private)
+        );
+    }
+}

--- a/crates/ironclaw_reborn_composition/src/extension_host/extension_lifecycle/install_policy.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/extension_lifecycle/install_policy.rs
@@ -1,20 +1,27 @@
-//! Private-install ownership and slot policy (#5459 P1, #5525 review).
+//! Membership install policy (#5459 P1, 2026-07-08 pivot).
 //!
 //! Pure decisions only — every store read/write, package registration, and
 //! publish/unpublish stays in the parent module. Extracted so the ownership
-//! rules (who owns a new install, who may operate an existing one, who may
-//! take an occupied slot, and what an eviction must capture for restore) are
-//! reviewable and testable in one place instead of interleaved with the
-//! lifecycle I/O.
+//! rules (who holds a new install, who may operate an existing one, and what
+//! a repeated install of the same id does) are reviewable and testable in
+//! one place instead of interleaved with the lifecycle I/O.
+//!
+//! Contract (`docs/plans/2026-07-01-private-tool-installs.md`): a tenant
+//! (operator) install makes a tool available to everyone; a member install
+//! makes it available to that member — and any number of members can
+//! independently install the same tool by joining the one installation
+//! row's member set. An operator install of a member-held id EVICTS every
+//! member's private installation by replacing the member set with `Tenant`
+//! in a single row write.
 
-use ironclaw_extensions::{
-    ExtensionInstallation, ExtensionManifestRecord, ExtensionPackage, InstallationOwner,
-};
-use ironclaw_host_api::{ExtensionId, UserId};
+use std::collections::BTreeSet;
+
+use ironclaw_extensions::{ExtensionInstallation, InstallationOwner};
+use ironclaw_host_api::UserId;
 use ironclaw_product_workflow::{LifecycleInstallScope, ProductWorkflowError};
 
 /// Derive who a NEW install belongs to (#5459 P1): the tenant operator
-/// installs for the whole tenant; anyone else installs privately.
+/// installs for the whole tenant; anyone else installs for themselves.
 pub(super) fn derive_owner(caller: &UserId, tenant_operator: &UserId) -> InstallationOwner {
     if caller == tenant_operator {
         InstallationOwner::Tenant
@@ -24,99 +31,123 @@ pub(super) fn derive_owner(caller: &UserId, tenant_operator: &UserId) -> Install
 }
 
 /// Fail-closed visibility check for lifecycle mutations on an existing
-/// installation: a user-private install is operable ONLY by its owner —
-/// every non-owner, the tenant operator included, gets the masked denial.
-/// The admin's sole power over a foreign private slot is the explicit
-/// shared-install eviction granted by [`decide_occupied_slot`], never direct
-/// activate/remove by id. The error is deliberately the same "is not
-/// installed" shape a missing installation produces, so a foreign caller
-/// cannot distinguish (or enumerate) other users' private installs.
+/// installation: a member-held install is operable ONLY by its members —
+/// every non-member, the tenant operator included, gets the masked denial.
+/// The error is deliberately the same "is not installed" shape a missing
+/// installation produces, so a non-member cannot distinguish (or enumerate)
+/// tools other users hold.
 pub(super) fn ensure_caller_may_operate(
     installation: &ExtensionInstallation,
     caller: &UserId,
 ) -> Result<(), ProductWorkflowError> {
-    match installation.owner() {
-        InstallationOwner::Tenant => Ok(()),
-        InstallationOwner::User { user_id } if user_id == caller => Ok(()),
-        InstallationOwner::User { .. } => Err(ProductWorkflowError::InvalidBindingRequest {
-            reason: format!(
-                "extension {} is not installed",
-                installation.extension_id().as_str()
-            ),
-        }),
+    if installation.owner().visible_to(caller) {
+        return Ok(());
     }
+    Err(ProductWorkflowError::InvalidBindingRequest {
+        reason: format!(
+            "extension {} is not installed",
+            installation.extension_id().as_str()
+        ),
+    })
 }
 
-/// The one takeover an occupied slot permits.
-pub(super) enum OccupiedSlotDecision {
-    /// Admin-wins (#5459 P1): a tenant claim seizes the slot by evicting the
-    /// existing user-private install.
-    EvictPrivateInstall,
+/// What an install of an id whose installation row already exists does.
+pub(super) enum InstallDecision {
+    /// The caller gains the tool via a single row rewrite (member JOIN, or
+    /// operator EVICT-to-tenant); the bundle is already registered,
+    /// materialized, and — if enabled — published, so there is nothing to
+    /// compensate.
+    UpdateOwner(InstallationOwner),
 }
 
-/// Slot rules for an extension id whose installation row already exists.
-///
-/// Every rejection wording is part of the masking contract: a foreign member
-/// probing another user's private slot learns only that the id is
-/// "unavailable" — never that a private install exists or whose it is.
-pub(super) fn decide_occupied_slot(
-    extension_id: &ExtensionId,
+/// Membership rules for an extension id whose installation row already
+/// exists. `Err` is always "already installed": under membership the
+/// outcome of installing never depends on whether OTHER users hold the
+/// tool, so there is no ownership state left to mask on this path.
+pub(super) fn decide_install_on_existing(
+    extension_id: &ironclaw_host_api::ExtensionId,
     existing_owner: &InstallationOwner,
-    claimant: &InstallationOwner,
-) -> Result<OccupiedSlotDecision, ProductWorkflowError> {
-    match (existing_owner, claimant) {
-        (InstallationOwner::Tenant, InstallationOwner::User { .. }) => {
-            Err(ProductWorkflowError::InvalidBindingRequest {
-                reason: format!(
-                    "extension {} is already available as a shared tool",
-                    extension_id.as_str()
-                ),
-            })
-        }
-        (InstallationOwner::Tenant, InstallationOwner::Tenant) => {
-            Err(ProductWorkflowError::InvalidBindingRequest {
-                reason: format!("extension {} is already installed", extension_id.as_str()),
-            })
-        }
-        (InstallationOwner::User { user_id }, InstallationOwner::User { user_id: caller }) => {
-            if user_id == caller {
-                Err(ProductWorkflowError::InvalidBindingRequest {
-                    reason: format!("extension {} is already installed", extension_id.as_str()),
-                })
+    caller: &UserId,
+    tenant_operator: &UserId,
+) -> Result<InstallDecision, ProductWorkflowError> {
+    let already_installed = || ProductWorkflowError::InvalidBindingRequest {
+        reason: format!("extension {} is already installed", extension_id.as_str()),
+    };
+    match existing_owner {
+        // A tenant-shared tool is already available to every caller.
+        InstallationOwner::Tenant => Err(already_installed()),
+        InstallationOwner::Users { user_ids } => {
+            if caller == tenant_operator {
+                // Operator install evicts every member's private
+                // installation; the tenant row takes the id and everyone
+                // (the evicted members included) reaches the tool through
+                // the shared install.
+                Ok(InstallDecision::UpdateOwner(InstallationOwner::Tenant))
+            } else if user_ids.contains(caller) {
+                Err(already_installed())
             } else {
-                // Generic wording: a foreign caller must not learn that a
-                // private install exists, let alone whose it is.
-                Err(ProductWorkflowError::InvalidBindingRequest {
-                    reason: format!("extension id {} is unavailable", extension_id.as_str()),
-                })
+                // JOIN: the caller becomes a member alongside the others.
+                let mut user_ids = user_ids.clone();
+                user_ids.insert(caller.clone());
+                Ok(InstallDecision::UpdateOwner(
+                    InstallationOwner::users(user_ids).map_err(|error| {
+                        ProductWorkflowError::InvalidBindingRequest {
+                            reason: format!("installation owner update failed: {error}"),
+                        }
+                    })?,
+                ))
             }
         }
-        (InstallationOwner::User { .. }, InstallationOwner::Tenant) => {
-            Ok(OccupiedSlotDecision::EvictPrivateInstall)
+    }
+}
+
+/// What a member's remove does to the installation row.
+pub(super) enum RemoveDecision {
+    /// Other members still hold the tool: the caller leaves the member set
+    /// in a single row rewrite; no teardown.
+    LeaveMembers(InstallationOwner),
+    /// The caller is the last holder (sole member, or the operator removing
+    /// a tenant-shared tool): full teardown.
+    TearDown,
+}
+
+/// Membership rules for removing an installation the caller may operate
+/// (callers must pass [`ensure_caller_may_operate`] first; tenant rows are
+/// additionally operator-only to remove, enforced by the parent module).
+pub(super) fn decide_remove(
+    existing_owner: &InstallationOwner,
+    caller: &UserId,
+) -> Result<RemoveDecision, ProductWorkflowError> {
+    match existing_owner {
+        InstallationOwner::Tenant => Ok(RemoveDecision::TearDown),
+        InstallationOwner::Users { user_ids } => {
+            let remaining: BTreeSet<UserId> = user_ids
+                .iter()
+                .filter(|member| *member != caller)
+                .cloned()
+                .collect();
+            if remaining.is_empty() {
+                Ok(RemoveDecision::TearDown)
+            } else {
+                Ok(RemoveDecision::LeaveMembers(
+                    InstallationOwner::users(remaining).map_err(|error| {
+                        ProductWorkflowError::InvalidBindingRequest {
+                            reason: format!("installation owner update failed: {error}"),
+                        }
+                    })?,
+                ))
+            }
         }
     }
 }
 
-/// Pre-eviction snapshot of a user-private install, captured by
-/// `evict_private_installation` so a tenant install that fails after eviction
-/// can restore the victim untouched (#5525 review: non-interference on failed
-/// shared installs).
-pub(super) struct EvictedPrivateInstall {
-    /// Manifest row as of eviction; `None` when a prior partial attempt
-    /// already dropped it.
-    pub(super) manifest: Option<ExtensionManifestRecord>,
-    /// The victim's installation row (owner + activation state).
-    pub(super) installation: ExtensionInstallation,
-    /// The victim's registered lifecycle package; `None` on the retry path
-    /// where a prior attempt already deregistered it.
-    pub(super) lifecycle_package: Option<ExtensionPackage>,
-}
-
-/// Settings/list projection of an installation owner (#5459 P1).
+/// Settings/list projection of an installation owner (#5459 P1). Rows are
+/// caller-filtered before projection, so a member-held row shown to a
+/// viewer is by construction one they hold — "mine".
 pub(super) fn install_scope_for_owner(owner: &InstallationOwner) -> Option<LifecycleInstallScope> {
     Some(match owner {
         InstallationOwner::Tenant => LifecycleInstallScope::Shared,
-        InstallationOwner::User { .. } => LifecycleInstallScope::Private,
+        InstallationOwner::Users { .. } => LifecycleInstallScope::Private,
     })
 }
 
@@ -127,9 +158,14 @@ mod tests {
     use ironclaw_extensions::{
         ExtensionActivationState, ExtensionInstallationId, ExtensionManifestRef,
     };
+    use ironclaw_host_api::ExtensionId;
 
     fn user(id: &str) -> UserId {
         UserId::new(id).expect("valid user")
+    }
+
+    fn members(ids: &[&str]) -> InstallationOwner {
+        InstallationOwner::users(ids.iter().map(|id| user(id)).collect()).expect("member set")
     }
 
     fn installation(owner: InstallationOwner) -> ExtensionInstallation {
@@ -147,62 +183,97 @@ mod tests {
     }
 
     #[test]
-    fn derive_owner_maps_operator_to_tenant_and_members_to_private() {
+    fn derive_owner_maps_operator_to_tenant_and_members_to_singleton() {
         let operator = user("operator");
         assert!(derive_owner(&operator, &operator).is_tenant());
-        assert_eq!(
-            derive_owner(&user("alice"), &operator)
-                .as_user()
-                .map(UserId::as_str),
-            Some("alice")
-        );
+        let alice = user("alice");
+        assert!(derive_owner(&alice, &operator).visible_to(&alice));
+        assert!(!derive_owner(&alice, &operator).is_tenant());
     }
 
     #[test]
-    fn ensure_caller_may_operate_masks_every_non_owner_including_operator() {
+    fn ensure_caller_may_operate_masks_every_non_member_including_operator() {
         let tenant_owned = installation(InstallationOwner::Tenant);
-        let private = installation(InstallationOwner::user(user("alice")));
+        let held = installation(members(&["alice", "bob"]));
 
-        ensure_caller_may_operate(&tenant_owned, &user("bob")).expect("tenant tools are shared");
-        ensure_caller_may_operate(&private, &user("alice")).expect("the owner operates her tool");
-        for non_owner in ["bob", "operator"] {
-            let error = ensure_caller_may_operate(&private, &user(non_owner))
-                .expect_err("non-owners must be denied");
+        ensure_caller_may_operate(&tenant_owned, &user("carol")).expect("tenant tools are shared");
+        for member in ["alice", "bob"] {
+            ensure_caller_may_operate(&held, &user(member)).expect("members operate their tool");
+        }
+        for non_member in ["carol", "operator"] {
+            let error = ensure_caller_may_operate(&held, &user(non_member))
+                .expect_err("non-members must be denied");
             let rendered = error.to_string();
             assert!(
-                rendered.contains("is not installed") && !rendered.contains("alice"),
-                "denial must mask the private install: {rendered}"
+                rendered.contains("is not installed")
+                    && !rendered.contains("alice")
+                    && !rendered.contains("bob"),
+                "denial must mask the membership: {rendered}"
             );
         }
     }
 
     #[test]
-    fn decide_occupied_slot_permits_only_tenant_over_private() {
+    fn decide_install_joins_members_and_evicts_to_tenant_for_operator() {
         let extension_id = ExtensionId::new("fixture").expect("extension id");
-        let tenant = InstallationOwner::Tenant;
-        let alice = InstallationOwner::user(user("alice"));
-        let bob = InstallationOwner::user(user("bob"));
+        let operator = user("operator");
+
+        // Member joins an existing member set.
+        let Ok(InstallDecision::UpdateOwner(joined)) = decide_install_on_existing(
+            &extension_id,
+            &members(&["alice"]),
+            &user("bob"),
+            &operator,
+        ) else {
+            panic!("a second member must join");
+        };
+        assert!(joined.visible_to(&user("alice")) && joined.visible_to(&user("bob")));
+
+        // Operator evicts the whole member set to Tenant.
+        let Ok(InstallDecision::UpdateOwner(evicted)) = decide_install_on_existing(
+            &extension_id,
+            &members(&["alice", "bob"]),
+            &operator,
+            &operator,
+        ) else {
+            panic!("operator install must evict to tenant");
+        };
+        assert!(evicted.is_tenant());
+
+        // Real duplicates are "already installed" — and never leak members.
+        for (existing, caller) in [
+            (InstallationOwner::Tenant, user("alice")),
+            (InstallationOwner::Tenant, operator.clone()),
+            (members(&["alice"]), user("alice")),
+        ] {
+            let error = decide_install_on_existing(&extension_id, &existing, &caller, &operator)
+                .err()
+                .expect("duplicate install rejected");
+            let rendered = error.to_string();
+            assert!(
+                rendered.contains("already installed") && !rendered.contains("alice"),
+                "unexpected: {rendered}"
+            );
+        }
+    }
+
+    #[test]
+    fn decide_remove_leaves_members_until_the_last_holder() {
+        let Ok(RemoveDecision::LeaveMembers(remaining)) =
+            decide_remove(&members(&["alice", "bob"]), &user("alice"))
+        else {
+            panic!("a member with co-holders leaves the set");
+        };
+        assert!(!remaining.visible_to(&user("alice")) && remaining.visible_to(&user("bob")));
 
         assert!(matches!(
-            decide_occupied_slot(&extension_id, &alice, &tenant),
-            Ok(OccupiedSlotDecision::EvictPrivateInstall)
+            decide_remove(&members(&["bob"]), &user("bob")),
+            Ok(RemoveDecision::TearDown)
         ));
-        for (existing, claimant, expected) in [
-            (&tenant, &alice, "already available as a shared tool"),
-            (&tenant, &tenant, "already installed"),
-            (&alice, &alice, "already installed"),
-            (&alice, &bob, "is unavailable"),
-        ] {
-            let error = decide_occupied_slot(&extension_id, existing, claimant)
-                .err()
-                .expect("occupied slot rejects this claim");
-            let rendered = error.to_string();
-            assert!(rendered.contains(expected), "unexpected: {rendered}");
-            assert!(
-                !rendered.contains("alice"),
-                "slot error must not leak the private owner: {rendered}"
-            );
-        }
+        assert!(matches!(
+            decide_remove(&InstallationOwner::Tenant, &user("operator")),
+            Ok(RemoveDecision::TearDown)
+        ));
     }
 
     #[test]
@@ -212,7 +283,7 @@ mod tests {
             Some(LifecycleInstallScope::Shared)
         );
         assert_eq!(
-            install_scope_for_owner(&InstallationOwner::user(user("alice"))),
+            install_scope_for_owner(&members(&["alice"])),
             Some(LifecycleInstallScope::Private)
         );
     }

--- a/crates/ironclaw_reborn_composition/src/extension_host/extension_lifecycle/tests/private_install_tests.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/extension_lifecycle/tests/private_install_tests.rs
@@ -1,102 +1,129 @@
-//! Private-install ownership behavior tests (#5459 P1, #5525 review),
+//! Membership-model ownership tests (#5459 P1, 2026-07-08 pivot),
 //! driven through the lifecycle facade/port like every production caller.
 //! Split out of the parent test module, whose shared fixtures it reuses
 //! via `super::*`.
+//!
+//! Contract under test (docs/plans/2026-07-01-private-tool-installs.md):
+//! a tenant (operator) install makes a tool available to everyone; a
+//! member install makes it available to that member — and any number of
+//! members can independently install the same tool (they join the one
+//! installation row's member set). An operator install evicts every
+//! member's private installation by replacing the member set with
+//! `Tenant` in a single row write.
 
 use super::*;
 use ironclaw_product_workflow::LifecycleInstallScope;
 
-/// #5459 P1 slot rules, driven through the facade (the caller surface the
-/// WebUI and agent-tool paths both enter):
-/// - a member's install is PRIVATE: invisible in others' lists, and
-///   activate/remove/install by others fail without leaking that (or
-///   whose) a private install exists
-/// - a member cannot remove a TENANT-shared tool
-/// - a tenant (operator) install EVICTS the private install (admin-wins),
-///   after which everyone sees the shared tool
+/// Membership install rules through the facade: members install
+/// independently (second member JOINS, not "unavailable"), each sees a
+/// private entry, non-members stay masked, and a duplicate install by
+/// the same member is rejected as already installed.
 #[tokio::test]
-async fn private_install_slot_rules_and_admin_eviction() {
+async fn members_install_the_same_tool_independently() {
     let (_dir, _root, facade, _registry, installation_store) = extension_lifecycle_fixture();
     let fixture_ref =
         LifecyclePackageRef::new(LifecyclePackageKind::Extension, "fixture").expect("fixture ref");
     let installation_id = ExtensionInstallationId::new("fixture").expect("fixture installation id");
+    let alice = UserId::new("alice").expect("user");
+    let bob = UserId::new("bob").expect("user");
+    let carol = UserId::new("carol").expect("user");
 
-    // alice (member) installs → owner is User(alice) in the store.
-    let response = facade
-        .execute(
-            lifecycle_surface_context_for_user("alice"),
+    let install = |user: &str| {
+        facade.execute(
+            lifecycle_surface_context_for_user(user),
             LifecycleProductAction::ExtensionInstall {
                 package_ref: fixture_ref.clone(),
             },
         )
-        .await
-        .expect("alice installs privately");
+    };
+    let list = |user: &str| {
+        facade.execute(
+            lifecycle_surface_context_for_user(user),
+            LifecycleProductAction::ExtensionList,
+        )
+    };
+
+    // alice installs → visible to alice only.
+    let response = install("alice").await.expect("alice installs for herself");
     assert_eq!(response.phase, LifecyclePhase::Installed);
-    let installation = installation_store
-        .get_installation(&installation_id)
-        .await
-        .expect("store read")
-        .expect("installation row");
-    assert_eq!(
-        installation.owner().as_user().map(UserId::as_str),
-        Some("alice"),
-        "member install must be user-owned"
-    );
-
-    // bob's list is empty; alice's list shows a PRIVATE entry.
-    let bob_list = facade
-        .execute(
-            lifecycle_surface_context_for_user("bob"),
-            LifecycleProductAction::ExtensionList,
-        )
-        .await
-        .expect("bob lists");
-    let Some(LifecycleProductPayload::ExtensionList { count: 0, .. }) = bob_list.payload.as_ref()
-    else {
-        panic!("alice's private install must be invisible to bob: {bob_list:?}");
+    let owner_row = || async {
+        installation_store
+            .get_installation(&installation_id)
+            .await
+            .expect("store read")
+            .expect("installation row")
     };
-    let alice_list = facade
-        .execute(
-            lifecycle_surface_context_for_user("alice"),
-            LifecycleProductAction::ExtensionList,
-        )
-        .await
-        .expect("alice lists");
-    let Some(LifecycleProductPayload::ExtensionList {
-        extensions,
-        count: 1,
-    }) = alice_list.payload.as_ref()
-    else {
-        panic!("alice must see her own install: {alice_list:?}");
-    };
-    assert_eq!(
-        extensions[0].install_scope,
-        Some(LifecycleInstallScope::Private)
-    );
-
-    // bob cannot claim the slot — and the error must not leak the owner.
-    let error = facade
-        .execute(
-            lifecycle_surface_context_for_user("bob"),
-            LifecycleProductAction::ExtensionInstall {
-                package_ref: fixture_ref.clone(),
-            },
-        )
-        .await
-        .expect_err("bob cannot claim an id held by another user's private install");
-    let rendered = error.to_string();
-    assert!(rendered.contains("unavailable"), "unexpected: {rendered}");
+    let installation = owner_row().await;
     assert!(
-        !rendered.contains("alice"),
-        "slot error must not leak the private owner: {rendered}"
+        !installation.owner().is_tenant(),
+        "member install is not tenant-wide"
+    );
+    assert!(installation.owner().visible_to(&alice));
+    assert!(!installation.owner().visible_to(&bob));
+
+    // bob installs the SAME tool → joins; both members now hold it.
+    let response = install("bob")
+        .await
+        .expect("bob installs the same tool for himself (membership, not a slot)");
+    assert_eq!(response.phase, LifecyclePhase::Installed);
+    let installation = owner_row().await;
+    assert!(!installation.owner().is_tenant());
+    assert!(
+        installation.owner().visible_to(&alice),
+        "alice keeps the tool"
+    );
+    assert!(installation.owner().visible_to(&bob), "bob gains the tool");
+    assert!(!installation.owner().visible_to(&carol), "carol does not");
+
+    // Each member sees their own PRIVATE entry; carol sees nothing.
+    for member in ["alice", "bob"] {
+        let member_list = list(member).await.expect("member lists");
+        let Some(LifecycleProductPayload::ExtensionList {
+            extensions,
+            count: 1,
+        }) = member_list.payload.as_ref()
+        else {
+            panic!("{member} must see the tool they installed: {member_list:?}");
+        };
+        assert_eq!(
+            extensions[0].install_scope,
+            Some(LifecycleInstallScope::Private)
+        );
+    }
+    let carol_list = list("carol").await.expect("carol lists");
+    let Some(LifecycleProductPayload::ExtensionList { count: 0, .. }) = carol_list.payload.as_ref()
+    else {
+        panic!("members' installs must be invisible to non-members: {carol_list:?}");
+    };
+
+    // Duplicate install by a member who already holds it is a real error…
+    let error = install("alice")
+        .await
+        .expect_err("alice already holds the tool");
+    assert!(
+        error.to_string().contains("already installed"),
+        "unexpected: {error}"
     );
 
-    // bob cannot activate or remove it — reads as not installed. The
-    // tenant operator gets the same masking: a private tool is invisible
-    // and non-dispatchable to every non-owner, admin included — the
-    // admin's only special power is the shared-install eviction below.
+    // …while activate works for both members (the bundle publishes once;
+    // the second activate is an idempotent re-publish).
+    for member in ["alice", "bob"] {
+        let response = facade
+            .execute(
+                lifecycle_surface_context_for_user(member),
+                LifecycleProductAction::ExtensionActivate {
+                    package_ref: fixture_ref.clone(),
+                },
+            )
+            .await
+            .expect("member activates the tool they hold");
+        assert_eq!(response.phase, LifecyclePhase::Active);
+    }
+
+    // Non-members (carol AND the operator) stay masked on activate/remove:
+    // same "is not installed" a missing row produces, no owner leak.
     for context in [
-        lifecycle_surface_context_for_user("bob"),
+        lifecycle_surface_context_for_user("carol"),
         lifecycle_surface_context(),
     ] {
         for action in [
@@ -110,16 +137,45 @@ async fn private_install_slot_rules_and_admin_eviction() {
             let error = facade
                 .execute(context.clone(), action)
                 .await
-                .expect_err("foreign private install must be inoperable");
+                .expect_err("a tool the caller does not hold must be inoperable");
+            let rendered = error.to_string();
             assert!(
-                error.to_string().contains("is not installed"),
-                "unexpected: {error}"
+                rendered.contains("is not installed"),
+                "unexpected: {rendered}"
+            );
+            assert!(
+                !rendered.contains("alice") && !rendered.contains("bob"),
+                "masking must not leak member identities: {rendered}"
             );
         }
     }
+}
 
-    // alice activates her private install.
-    let response = facade
+/// Remove = leave the member set: the other member keeps the tool; the
+/// LAST member's remove triggers the full teardown, after which the id
+/// is free for a fresh install.
+#[tokio::test]
+async fn member_remove_leaves_others_and_last_member_remove_tears_down() {
+    let (_dir, _root, facade, _registry, installation_store) = extension_lifecycle_fixture();
+    let fixture_ref =
+        LifecyclePackageRef::new(LifecyclePackageKind::Extension, "fixture").expect("fixture ref");
+    let installation_id = ExtensionInstallationId::new("fixture").expect("fixture installation id");
+    let extension_id = ExtensionId::new("fixture").expect("extension id");
+    let alice = UserId::new("alice").expect("user");
+    let bob = UserId::new("bob").expect("user");
+
+    for member in ["alice", "bob"] {
+        facade
+            .execute(
+                lifecycle_surface_context_for_user(member),
+                LifecycleProductAction::ExtensionInstall {
+                    package_ref: fixture_ref.clone(),
+                },
+            )
+            .await
+            .expect("member installs");
+    }
+    facade
         .execute(
             lifecycle_surface_context_for_user("alice"),
             LifecycleProductAction::ExtensionActivate {
@@ -127,10 +183,121 @@ async fn private_install_slot_rules_and_admin_eviction() {
             },
         )
         .await
-        .expect("alice activates her private install");
-    assert_eq!(response.phase, LifecyclePhase::Active);
+        .expect("alice activates");
 
-    // The operator installs the same id → evicts alice's private install.
+    // alice removes → she leaves the set; bob keeps the (still enabled) tool.
+    let response = facade
+        .execute(
+            lifecycle_surface_context_for_user("alice"),
+            LifecycleProductAction::ExtensionRemove {
+                package_ref: fixture_ref.clone(),
+            },
+        )
+        .await
+        .expect("alice removes the tool for herself");
+    assert_eq!(response.phase, LifecyclePhase::Removed);
+    let installation = installation_store
+        .get_installation(&installation_id)
+        .await
+        .expect("store read")
+        .expect("row survives while another member holds the tool");
+    assert!(!installation.owner().visible_to(&alice), "alice left");
+    assert!(installation.owner().visible_to(&bob), "bob keeps it");
+    let alice_list = facade
+        .execute(
+            lifecycle_surface_context_for_user("alice"),
+            LifecycleProductAction::ExtensionList,
+        )
+        .await
+        .expect("alice lists");
+    let Some(LifecycleProductPayload::ExtensionList { count: 0, .. }) = alice_list.payload.as_ref()
+    else {
+        panic!("alice no longer sees the tool: {alice_list:?}");
+    };
+    let bob_list = facade
+        .execute(
+            lifecycle_surface_context_for_user("bob"),
+            LifecycleProductAction::ExtensionList,
+        )
+        .await
+        .expect("bob lists");
+    let Some(LifecycleProductPayload::ExtensionList { count: 1, .. }) = bob_list.payload.as_ref()
+    else {
+        panic!("bob must still see the tool: {bob_list:?}");
+    };
+
+    // bob (last member) removes → full teardown: row and manifest gone…
+    facade
+        .execute(
+            lifecycle_surface_context_for_user("bob"),
+            LifecycleProductAction::ExtensionRemove {
+                package_ref: fixture_ref.clone(),
+            },
+        )
+        .await
+        .expect("last member removes → teardown");
+    assert!(
+        installation_store
+            .get_installation(&installation_id)
+            .await
+            .expect("store read")
+            .is_none(),
+        "last member's remove must delete the installation row"
+    );
+    assert!(
+        installation_store
+            .get_manifest(&extension_id)
+            .await
+            .expect("store read")
+            .is_none(),
+        "last member's remove must delete the manifest"
+    );
+
+    // …and the id is free again for a fresh install.
+    facade
+        .execute(
+            lifecycle_surface_context_for_user("carol"),
+            LifecycleProductAction::ExtensionInstall {
+                package_ref: fixture_ref,
+            },
+        )
+        .await
+        .expect("id is installable again after teardown");
+}
+
+/// The operator installing a member-held tool EVICTS every member's
+/// private installation — one row write replacing the member set with
+/// `Tenant` — after which everyone sees the shared tool and only the
+/// operator can remove it.
+#[tokio::test]
+async fn operator_install_evicts_member_installs_to_tenant_shared() {
+    let (_dir, _root, facade, _registry, installation_store) = extension_lifecycle_fixture();
+    let fixture_ref =
+        LifecyclePackageRef::new(LifecyclePackageKind::Extension, "fixture").expect("fixture ref");
+    let installation_id = ExtensionInstallationId::new("fixture").expect("fixture installation id");
+
+    for member in ["alice", "bob"] {
+        facade
+            .execute(
+                lifecycle_surface_context_for_user(member),
+                LifecycleProductAction::ExtensionInstall {
+                    package_ref: fixture_ref.clone(),
+                },
+            )
+            .await
+            .expect("member installs");
+    }
+    facade
+        .execute(
+            lifecycle_surface_context_for_user("alice"),
+            LifecycleProductAction::ExtensionActivate {
+                package_ref: fixture_ref.clone(),
+            },
+        )
+        .await
+        .expect("alice activates");
+
+    // Operator installs → evicts both members' private installs to Tenant.
     let response = facade
         .execute(
             lifecycle_surface_context(),
@@ -139,7 +306,7 @@ async fn private_install_slot_rules_and_admin_eviction() {
             },
         )
         .await
-        .expect("tenant install evicts the private install");
+        .expect("operator install evicts member installs and takes the id");
     assert_eq!(response.phase, LifecyclePhase::Installed);
     let installation = installation_store
         .get_installation(&installation_id)
@@ -148,30 +315,52 @@ async fn private_install_slot_rules_and_admin_eviction() {
         .expect("installation row");
     assert!(
         installation.owner().is_tenant(),
-        "tenant install must own the slot after eviction"
+        "operator install must own the id tenant-wide after eviction"
+    );
+    assert_eq!(
+        installation.activation_state(),
+        ExtensionActivationState::Enabled,
+        "eviction must not disable the already-activated tool"
     );
 
-    // Everyone now sees the SHARED entry — bob included.
-    let bob_list = facade
+    // Everyone — evicted members and never-installed users alike — now
+    // sees the SHARED entry.
+    for user in ["alice", "bob", "carol"] {
+        let user_list = facade
+            .execute(
+                lifecycle_surface_context_for_user(user),
+                LifecycleProductAction::ExtensionList,
+            )
+            .await
+            .expect("list");
+        let Some(LifecycleProductPayload::ExtensionList {
+            extensions,
+            count: 1,
+        }) = user_list.payload.as_ref()
+        else {
+            panic!("shared install must be visible to {user}: {user_list:?}");
+        };
+        assert_eq!(
+            extensions[0].install_scope,
+            Some(LifecycleInstallScope::Shared)
+        );
+    }
+
+    // Operator re-install is a real duplicate; members cannot remove the
+    // shared tool; the operator can.
+    let error = facade
         .execute(
-            lifecycle_surface_context_for_user("bob"),
-            LifecycleProductAction::ExtensionList,
+            lifecycle_surface_context(),
+            LifecycleProductAction::ExtensionInstall {
+                package_ref: fixture_ref.clone(),
+            },
         )
         .await
-        .expect("bob lists after eviction");
-    let Some(LifecycleProductPayload::ExtensionList {
-        extensions,
-        count: 1,
-    }) = bob_list.payload.as_ref()
-    else {
-        panic!("shared install must be visible to bob: {bob_list:?}");
-    };
-    assert_eq!(
-        extensions[0].install_scope,
-        Some(LifecycleInstallScope::Shared)
+        .expect_err("shared tool is already installed");
+    assert!(
+        error.to_string().contains("already installed"),
+        "unexpected: {error}"
     );
-
-    // Members (alice included) cannot remove the shared tool; the operator can.
     for member in ["alice", "bob"] {
         let error = facade
             .execute(
@@ -198,19 +387,53 @@ async fn private_install_slot_rules_and_admin_eviction() {
         .expect("operator removes the shared tool");
 }
 
+/// A member installing a tool the operator already shares gets the real
+/// "already installed" error — the tool is already available to them.
+#[tokio::test]
+async fn member_install_of_a_shared_tool_reports_already_installed() {
+    let (_dir, _root, facade, _registry, _store) = extension_lifecycle_fixture();
+    let fixture_ref =
+        LifecyclePackageRef::new(LifecyclePackageKind::Extension, "fixture").expect("fixture ref");
+
+    facade
+        .execute(
+            lifecycle_surface_context(),
+            LifecycleProductAction::ExtensionInstall {
+                package_ref: fixture_ref.clone(),
+            },
+        )
+        .await
+        .expect("operator installs shared");
+    let error = facade
+        .execute(
+            lifecycle_surface_context_for_user("alice"),
+            LifecycleProductAction::ExtensionInstall {
+                package_ref: fixture_ref,
+            },
+        )
+        .await
+        .expect_err("the shared tool is already available to alice");
+    assert!(
+        error.to_string().contains("already installed"),
+        "unexpected: {error}"
+    );
+}
+
 /// #5525 review: `LifecycleProductCommandService` dispatches every
 /// `/extension_*` command as `LifecycleProductContext::Command`, so the
 /// facade must derive the caller from the verified command auth claim
-/// instead of rejecting non-surface contexts outright — and the private
-/// ownership masking must hold on the command path too.
+/// instead of rejecting non-surface contexts outright — and the
+/// membership masking must hold on the command path too.
 #[tokio::test]
 async fn extension_lifecycle_commands_derive_caller_from_command_auth_claim() {
     let (_dir, _root, facade, _registry, installation_store) = extension_lifecycle_fixture();
     let fixture_ref =
         LifecyclePackageRef::new(LifecyclePackageKind::Extension, "fixture").expect("fixture ref");
     let installation_id = ExtensionInstallationId::new("fixture").expect("fixture installation id");
+    let alice = UserId::new("alice").expect("user");
+    let bob = UserId::new("bob").expect("user");
 
-    // alice installs through the command path → owner derives from the claim.
+    // alice installs through the command path → membership derives from the claim.
     let response = facade
         .execute(
             lifecycle_command_context_for_user("alice"),
@@ -226,11 +449,11 @@ async fn extension_lifecycle_commands_derive_caller_from_command_auth_claim() {
         .await
         .expect("store read")
         .expect("installation row");
-    assert_eq!(
-        installation.owner().as_user().map(UserId::as_str),
-        Some("alice"),
-        "command install must be owned by the claim subject"
+    assert!(
+        installation.owner().visible_to(&alice) && !installation.owner().is_tenant(),
+        "command install must be held by the claim subject"
     );
+    assert!(!installation.owner().visible_to(&bob));
 
     // alice's command list sees it; bob's command list stays masked.
     let alice_list = facade
@@ -253,10 +476,10 @@ async fn extension_lifecycle_commands_derive_caller_from_command_auth_claim() {
         .expect("bob lists via command");
     let Some(LifecycleProductPayload::ExtensionList { count: 0, .. }) = bob_list.payload.as_ref()
     else {
-        panic!("alice's private install must stay invisible on the command path: {bob_list:?}");
+        panic!("alice's install must stay invisible on the command path: {bob_list:?}");
     };
 
-    // Owner masking holds for command-path mutations by a non-owner.
+    // Membership masking holds for command-path mutations by a non-member.
     let error = facade
         .execute(
             lifecycle_command_context_for_user("bob"),
@@ -265,14 +488,24 @@ async fn extension_lifecycle_commands_derive_caller_from_command_auth_claim() {
             },
         )
         .await
-        .expect_err("foreign private install must be inoperable via command");
+        .expect_err("a tool bob does not hold must be inoperable via command");
     assert!(
         error.to_string().contains("is not installed"),
         "unexpected: {error}"
     );
 
-    // alice activates and removes her install through the command path.
-    let response = facade
+    // bob JOINS through the command path, then alice activates and removes
+    // hers; bob keeps the tool.
+    facade
+        .execute(
+            lifecycle_command_context_for_user("bob"),
+            LifecycleProductAction::ExtensionInstall {
+                package_ref: fixture_ref.clone(),
+            },
+        )
+        .await
+        .expect("bob joins via command");
+    facade
         .execute(
             lifecycle_command_context_for_user("alice"),
             LifecycleProductAction::ExtensionActivate {
@@ -281,7 +514,6 @@ async fn extension_lifecycle_commands_derive_caller_from_command_auth_claim() {
         )
         .await
         .expect("alice activates via command");
-    assert_eq!(response.phase, LifecyclePhase::Active);
     facade
         .execute(
             lifecycle_command_context_for_user("alice"),
@@ -291,11 +523,17 @@ async fn extension_lifecycle_commands_derive_caller_from_command_auth_claim() {
         )
         .await
         .expect("alice removes via command");
+    let installation = installation_store
+        .get_installation(&installation_id)
+        .await
+        .expect("store read")
+        .expect("bob still holds the tool");
+    assert!(installation.owner().visible_to(&bob));
 }
 
 /// #5459 P1: the owner join in `active_model_visible_capabilities` — a
-/// privately installed+activated extension's capabilities carry the
-/// owning user, which is what the grant-minting filter keys on.
+/// member-installed+activated extension's capabilities carry the member
+/// set, which is what the grant-minting filter keys on.
 #[tokio::test]
 async fn active_capabilities_carry_installation_owner() {
     let (_dir, _root, port, _registry, _store) =
@@ -304,11 +542,12 @@ async fn active_capabilities_carry_installation_owner() {
             ExtensionLifecycleService::new(ExtensionRegistry::new()),
         );
     let alice = UserId::new("alice").expect("valid user");
+    let bob = UserId::new("bob").expect("valid user");
     let package_ref =
         LifecyclePackageRef::new(LifecyclePackageKind::Extension, "fixture").expect("fixture ref");
     port.install(package_ref.clone(), &alice)
         .await
-        .expect("alice installs privately");
+        .expect("alice installs for herself");
     port.activate(package_ref, ExtensionActivationMode::Static, &alice)
         .await
         .expect("alice activates");
@@ -319,139 +558,25 @@ async fn active_capabilities_carry_installation_owner() {
         .expect("active capabilities");
     assert!(!capabilities.is_empty(), "fixture capability published");
     for capability in &capabilities {
-        assert_eq!(
-            capability.owner.as_user().map(UserId::as_str),
-            Some("alice"),
-            "capability must carry the private owner for grant filtering"
+        assert!(
+            capability.owner.visible_to(&alice) && !capability.owner.visible_to(&bob),
+            "capability must carry the member set for grant filtering"
         );
     }
 
     // The operator/settings tool catalog joins THIS owner map to hide a
-    // foreign user's private tool (#5459 P1 leak fix). Pin that the map
-    // reports the private owner keyed by extension id.
+    // tool from users who don't hold it (#5459 P1 leak fix). Pin that the
+    // map reports the membership keyed by extension id.
     let owners = port
         .installation_owners()
         .await
         .expect("installation owners");
-    assert_eq!(
-        owners
-            .get(&ExtensionId::new("fixture").unwrap())
-            .and_then(InstallationOwner::as_user)
-            .map(UserId::as_str),
-        Some("alice"),
-        "installation_owners must report the private owner the catalog filters on"
-    );
-}
-
-/// #5459 P1 (should-fix): a tenant install that fails AFTER eviction has
-/// deregistered the private package must not brick the id tenant-wide.
-/// Eviction is retry-safe, so the admin's retry heals the slot to Tenant.
-#[tokio::test]
-async fn admin_install_retry_heals_after_eviction_then_persist_failure() {
-    let dir = tempfile::tempdir().expect("tempdir");
-    let storage_root = dir.path().join("local-dev");
-    std::fs::create_dir_all(storage_root.join("system/extensions")).expect("storage root");
-    let mut filesystem = LocalFilesystem::new();
-    filesystem
-        .mount_local(
-            VirtualPath::new("/projects").expect("valid virtual path"),
-            HostPath::from_path_buf(storage_root.clone()),
-        )
-        .expect("mount storage root");
-    filesystem
-        .mount_local(
-            VirtualPath::new("/system/extensions").expect("valid virtual path"),
-            HostPath::from_path_buf(storage_root.join("system/extensions")),
-        )
-        .expect("mount system extensions");
-    let root_filesystem: Arc<dyn RootFilesystem> = Arc::new(filesystem);
-    let active_registry = Arc::new(SharedExtensionRegistry::new(ExtensionRegistry::new()));
-    // Concrete Arc so the test can arm the one-shot persist failure AFTER
-    // alice's install; the port sees it as `dyn ExtensionInstallationStore`.
-    let store = Arc::new(DeleteInstallationFailingStore::default());
-    let store_dyn: Arc<dyn ExtensionInstallationStore> = store.clone();
-    let port = RebornLocalExtensionManagementPort::new(
-        root_filesystem,
-        AvailableExtensionCatalog::from_packages(vec![fixture_extension_package()]),
-        store_dyn,
-        Arc::new(Mutex::new(ExtensionLifecycleService::new(
-            ExtensionRegistry::new(),
-        ))),
-        test_active_extension_publisher(
-            Arc::clone(&active_registry),
-            test_extension_trust_policy(),
-        ),
-        None,
-        lifecycle_owner(),
-    );
-
-    let alice = UserId::new("alice").expect("user");
-    let package_ref =
-        LifecyclePackageRef::new(LifecyclePackageKind::Extension, "fixture").expect("fixture ref");
-
-    // alice privately installs + activates (Enabled, package published).
-    port.install(package_ref.clone(), &alice)
-        .await
-        .expect("alice installs privately");
-    port.activate(package_ref.clone(), ExtensionActivationMode::Static, &alice)
-        .await
-        .expect("alice activates");
-
-    // Admin install fails at persist (upsert_installation), AFTER eviction
-    // has already deregistered alice's package.
-    store
-        .fail_next_upsert_installation
-        .store(true, std::sync::atomic::Ordering::SeqCst);
-    port.install(package_ref.clone(), &lifecycle_owner())
-        .await
-        .expect_err("persist failure aborts the tenant install");
-
-    // #5525 review (non-interference): the FAILED shared install must
-    // leave alice's private install exactly as it was — owner alice, row
-    // still Enabled, and her capability still published — not disabled/
-    // unpublished until an admin retry shows up.
-    let fixture_id = ExtensionId::new("fixture").expect("extension id");
-    let owners = port.installation_owners().await.expect("owners");
-    assert_eq!(
-        owners
-            .get(&fixture_id)
-            .and_then(InstallationOwner::as_user)
-            .map(UserId::as_str),
-        Some("alice"),
-        "failed tenant install must restore alice's private ownership"
-    );
-    let installation = store
-        .get_installation(&ExtensionInstallationId::new("fixture").expect("installation id"))
-        .await
-        .expect("store read")
-        .expect("installation row survives the failed tenant install");
-    assert_eq!(
-        installation.activation_state(),
-        ExtensionActivationState::Enabled,
-        "failed tenant install must re-enable the evicted private install"
-    );
+    let owner = owners
+        .get(&ExtensionId::new("fixture").unwrap())
+        .expect("fixture owner present");
     assert!(
-        active_registry
-            .snapshot()
-            .get_extension(&fixture_id)
-            .is_some(),
-        "failed tenant install must re-publish the evicted private capability"
-    );
-
-    // Retry: eviction re-runs against the restored private install and the
-    // slot heals to a tenant-owned install rather than dead-ending on
-    // 'not installed'.
-    port.install(package_ref, &lifecycle_owner())
-        .await
-        .expect("admin retry heals the slot after a failed eviction install");
-
-    let owners = port.installation_owners().await.expect("owners");
-    assert!(
-        owners
-            .get(&ExtensionId::new("fixture").unwrap())
-            .expect("fixture installed")
-            .is_tenant(),
-        "the slot must heal to a tenant install, not stay bricked"
+        owner.visible_to(&alice) && !owner.visible_to(&bob) && !owner.is_tenant(),
+        "installation_owners must report the membership the catalog filters on"
     );
 }
 

--- a/crates/ironclaw_reborn_composition/src/extension_host/extension_lifecycle/tests/private_install_tests.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/extension_lifecycle/tests/private_install_tests.rs
@@ -1,0 +1,501 @@
+//! Private-install ownership behavior tests (#5459 P1, #5525 review),
+//! driven through the lifecycle facade/port like every production caller.
+//! Split out of the parent test module, whose shared fixtures it reuses
+//! via `super::*`.
+
+use super::*;
+use ironclaw_product_workflow::LifecycleInstallScope;
+
+/// #5459 P1 slot rules, driven through the facade (the caller surface the
+/// WebUI and agent-tool paths both enter):
+/// - a member's install is PRIVATE: invisible in others' lists, and
+///   activate/remove/install by others fail without leaking that (or
+///   whose) a private install exists
+/// - a member cannot remove a TENANT-shared tool
+/// - a tenant (operator) install EVICTS the private install (admin-wins),
+///   after which everyone sees the shared tool
+#[tokio::test]
+async fn private_install_slot_rules_and_admin_eviction() {
+    let (_dir, _root, facade, _registry, installation_store) = extension_lifecycle_fixture();
+    let fixture_ref =
+        LifecyclePackageRef::new(LifecyclePackageKind::Extension, "fixture").expect("fixture ref");
+    let installation_id = ExtensionInstallationId::new("fixture").expect("fixture installation id");
+
+    // alice (member) installs → owner is User(alice) in the store.
+    let response = facade
+        .execute(
+            lifecycle_surface_context_for_user("alice"),
+            LifecycleProductAction::ExtensionInstall {
+                package_ref: fixture_ref.clone(),
+            },
+        )
+        .await
+        .expect("alice installs privately");
+    assert_eq!(response.phase, LifecyclePhase::Installed);
+    let installation = installation_store
+        .get_installation(&installation_id)
+        .await
+        .expect("store read")
+        .expect("installation row");
+    assert_eq!(
+        installation.owner().as_user().map(UserId::as_str),
+        Some("alice"),
+        "member install must be user-owned"
+    );
+
+    // bob's list is empty; alice's list shows a PRIVATE entry.
+    let bob_list = facade
+        .execute(
+            lifecycle_surface_context_for_user("bob"),
+            LifecycleProductAction::ExtensionList,
+        )
+        .await
+        .expect("bob lists");
+    let Some(LifecycleProductPayload::ExtensionList { count: 0, .. }) = bob_list.payload.as_ref()
+    else {
+        panic!("alice's private install must be invisible to bob: {bob_list:?}");
+    };
+    let alice_list = facade
+        .execute(
+            lifecycle_surface_context_for_user("alice"),
+            LifecycleProductAction::ExtensionList,
+        )
+        .await
+        .expect("alice lists");
+    let Some(LifecycleProductPayload::ExtensionList {
+        extensions,
+        count: 1,
+    }) = alice_list.payload.as_ref()
+    else {
+        panic!("alice must see her own install: {alice_list:?}");
+    };
+    assert_eq!(
+        extensions[0].install_scope,
+        Some(LifecycleInstallScope::Private)
+    );
+
+    // bob cannot claim the slot — and the error must not leak the owner.
+    let error = facade
+        .execute(
+            lifecycle_surface_context_for_user("bob"),
+            LifecycleProductAction::ExtensionInstall {
+                package_ref: fixture_ref.clone(),
+            },
+        )
+        .await
+        .expect_err("bob cannot claim an id held by another user's private install");
+    let rendered = error.to_string();
+    assert!(rendered.contains("unavailable"), "unexpected: {rendered}");
+    assert!(
+        !rendered.contains("alice"),
+        "slot error must not leak the private owner: {rendered}"
+    );
+
+    // bob cannot activate or remove it — reads as not installed. The
+    // tenant operator gets the same masking: a private tool is invisible
+    // and non-dispatchable to every non-owner, admin included — the
+    // admin's only special power is the shared-install eviction below.
+    for context in [
+        lifecycle_surface_context_for_user("bob"),
+        lifecycle_surface_context(),
+    ] {
+        for action in [
+            LifecycleProductAction::ExtensionActivate {
+                package_ref: fixture_ref.clone(),
+            },
+            LifecycleProductAction::ExtensionRemove {
+                package_ref: fixture_ref.clone(),
+            },
+        ] {
+            let error = facade
+                .execute(context.clone(), action)
+                .await
+                .expect_err("foreign private install must be inoperable");
+            assert!(
+                error.to_string().contains("is not installed"),
+                "unexpected: {error}"
+            );
+        }
+    }
+
+    // alice activates her private install.
+    let response = facade
+        .execute(
+            lifecycle_surface_context_for_user("alice"),
+            LifecycleProductAction::ExtensionActivate {
+                package_ref: fixture_ref.clone(),
+            },
+        )
+        .await
+        .expect("alice activates her private install");
+    assert_eq!(response.phase, LifecyclePhase::Active);
+
+    // The operator installs the same id → evicts alice's private install.
+    let response = facade
+        .execute(
+            lifecycle_surface_context(),
+            LifecycleProductAction::ExtensionInstall {
+                package_ref: fixture_ref.clone(),
+            },
+        )
+        .await
+        .expect("tenant install evicts the private install");
+    assert_eq!(response.phase, LifecyclePhase::Installed);
+    let installation = installation_store
+        .get_installation(&installation_id)
+        .await
+        .expect("store read")
+        .expect("installation row");
+    assert!(
+        installation.owner().is_tenant(),
+        "tenant install must own the slot after eviction"
+    );
+
+    // Everyone now sees the SHARED entry — bob included.
+    let bob_list = facade
+        .execute(
+            lifecycle_surface_context_for_user("bob"),
+            LifecycleProductAction::ExtensionList,
+        )
+        .await
+        .expect("bob lists after eviction");
+    let Some(LifecycleProductPayload::ExtensionList {
+        extensions,
+        count: 1,
+    }) = bob_list.payload.as_ref()
+    else {
+        panic!("shared install must be visible to bob: {bob_list:?}");
+    };
+    assert_eq!(
+        extensions[0].install_scope,
+        Some(LifecycleInstallScope::Shared)
+    );
+
+    // Members (alice included) cannot remove the shared tool; the operator can.
+    for member in ["alice", "bob"] {
+        let error = facade
+            .execute(
+                lifecycle_surface_context_for_user(member),
+                LifecycleProductAction::ExtensionRemove {
+                    package_ref: fixture_ref.clone(),
+                },
+            )
+            .await
+            .expect_err("members cannot remove a shared tool");
+        assert!(
+            error.to_string().contains("only the tenant admin"),
+            "unexpected: {error}"
+        );
+    }
+    facade
+        .execute(
+            lifecycle_surface_context(),
+            LifecycleProductAction::ExtensionRemove {
+                package_ref: fixture_ref,
+            },
+        )
+        .await
+        .expect("operator removes the shared tool");
+}
+
+/// #5525 review: `LifecycleProductCommandService` dispatches every
+/// `/extension_*` command as `LifecycleProductContext::Command`, so the
+/// facade must derive the caller from the verified command auth claim
+/// instead of rejecting non-surface contexts outright — and the private
+/// ownership masking must hold on the command path too.
+#[tokio::test]
+async fn extension_lifecycle_commands_derive_caller_from_command_auth_claim() {
+    let (_dir, _root, facade, _registry, installation_store) = extension_lifecycle_fixture();
+    let fixture_ref =
+        LifecyclePackageRef::new(LifecyclePackageKind::Extension, "fixture").expect("fixture ref");
+    let installation_id = ExtensionInstallationId::new("fixture").expect("fixture installation id");
+
+    // alice installs through the command path → owner derives from the claim.
+    let response = facade
+        .execute(
+            lifecycle_command_context_for_user("alice"),
+            LifecycleProductAction::ExtensionInstall {
+                package_ref: fixture_ref.clone(),
+            },
+        )
+        .await
+        .expect("command install derives caller from auth claim");
+    assert_eq!(response.phase, LifecyclePhase::Installed);
+    let installation = installation_store
+        .get_installation(&installation_id)
+        .await
+        .expect("store read")
+        .expect("installation row");
+    assert_eq!(
+        installation.owner().as_user().map(UserId::as_str),
+        Some("alice"),
+        "command install must be owned by the claim subject"
+    );
+
+    // alice's command list sees it; bob's command list stays masked.
+    let alice_list = facade
+        .execute(
+            lifecycle_command_context_for_user("alice"),
+            LifecycleProductAction::ExtensionList,
+        )
+        .await
+        .expect("alice lists via command");
+    let Some(LifecycleProductPayload::ExtensionList { count: 1, .. }) = alice_list.payload.as_ref()
+    else {
+        panic!("alice must see her install via command: {alice_list:?}");
+    };
+    let bob_list = facade
+        .execute(
+            lifecycle_command_context_for_user("bob"),
+            LifecycleProductAction::ExtensionList,
+        )
+        .await
+        .expect("bob lists via command");
+    let Some(LifecycleProductPayload::ExtensionList { count: 0, .. }) = bob_list.payload.as_ref()
+    else {
+        panic!("alice's private install must stay invisible on the command path: {bob_list:?}");
+    };
+
+    // Owner masking holds for command-path mutations by a non-owner.
+    let error = facade
+        .execute(
+            lifecycle_command_context_for_user("bob"),
+            LifecycleProductAction::ExtensionActivate {
+                package_ref: fixture_ref.clone(),
+            },
+        )
+        .await
+        .expect_err("foreign private install must be inoperable via command");
+    assert!(
+        error.to_string().contains("is not installed"),
+        "unexpected: {error}"
+    );
+
+    // alice activates and removes her install through the command path.
+    let response = facade
+        .execute(
+            lifecycle_command_context_for_user("alice"),
+            LifecycleProductAction::ExtensionActivate {
+                package_ref: fixture_ref.clone(),
+            },
+        )
+        .await
+        .expect("alice activates via command");
+    assert_eq!(response.phase, LifecyclePhase::Active);
+    facade
+        .execute(
+            lifecycle_command_context_for_user("alice"),
+            LifecycleProductAction::ExtensionRemove {
+                package_ref: fixture_ref,
+            },
+        )
+        .await
+        .expect("alice removes via command");
+}
+
+/// #5459 P1: the owner join in `active_model_visible_capabilities` — a
+/// privately installed+activated extension's capabilities carry the
+/// owning user, which is what the grant-minting filter keys on.
+#[tokio::test]
+async fn active_capabilities_carry_installation_owner() {
+    let (_dir, _root, port, _registry, _store) =
+        extension_management_port_fixture_with_catalog_and_service(
+            AvailableExtensionCatalog::from_packages(vec![fixture_extension_package()]),
+            ExtensionLifecycleService::new(ExtensionRegistry::new()),
+        );
+    let alice = UserId::new("alice").expect("valid user");
+    let package_ref =
+        LifecyclePackageRef::new(LifecyclePackageKind::Extension, "fixture").expect("fixture ref");
+    port.install(package_ref.clone(), &alice)
+        .await
+        .expect("alice installs privately");
+    port.activate(package_ref, ExtensionActivationMode::Static, &alice)
+        .await
+        .expect("alice activates");
+
+    let capabilities = port
+        .active_model_visible_capabilities()
+        .await
+        .expect("active capabilities");
+    assert!(!capabilities.is_empty(), "fixture capability published");
+    for capability in &capabilities {
+        assert_eq!(
+            capability.owner.as_user().map(UserId::as_str),
+            Some("alice"),
+            "capability must carry the private owner for grant filtering"
+        );
+    }
+
+    // The operator/settings tool catalog joins THIS owner map to hide a
+    // foreign user's private tool (#5459 P1 leak fix). Pin that the map
+    // reports the private owner keyed by extension id.
+    let owners = port
+        .installation_owners()
+        .await
+        .expect("installation owners");
+    assert_eq!(
+        owners
+            .get(&ExtensionId::new("fixture").unwrap())
+            .and_then(InstallationOwner::as_user)
+            .map(UserId::as_str),
+        Some("alice"),
+        "installation_owners must report the private owner the catalog filters on"
+    );
+}
+
+/// #5459 P1 (should-fix): a tenant install that fails AFTER eviction has
+/// deregistered the private package must not brick the id tenant-wide.
+/// Eviction is retry-safe, so the admin's retry heals the slot to Tenant.
+#[tokio::test]
+async fn admin_install_retry_heals_after_eviction_then_persist_failure() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let storage_root = dir.path().join("local-dev");
+    std::fs::create_dir_all(storage_root.join("system/extensions")).expect("storage root");
+    let mut filesystem = LocalFilesystem::new();
+    filesystem
+        .mount_local(
+            VirtualPath::new("/projects").expect("valid virtual path"),
+            HostPath::from_path_buf(storage_root.clone()),
+        )
+        .expect("mount storage root");
+    filesystem
+        .mount_local(
+            VirtualPath::new("/system/extensions").expect("valid virtual path"),
+            HostPath::from_path_buf(storage_root.join("system/extensions")),
+        )
+        .expect("mount system extensions");
+    let root_filesystem: Arc<dyn RootFilesystem> = Arc::new(filesystem);
+    let active_registry = Arc::new(SharedExtensionRegistry::new(ExtensionRegistry::new()));
+    // Concrete Arc so the test can arm the one-shot persist failure AFTER
+    // alice's install; the port sees it as `dyn ExtensionInstallationStore`.
+    let store = Arc::new(DeleteInstallationFailingStore::default());
+    let store_dyn: Arc<dyn ExtensionInstallationStore> = store.clone();
+    let port = RebornLocalExtensionManagementPort::new(
+        root_filesystem,
+        AvailableExtensionCatalog::from_packages(vec![fixture_extension_package()]),
+        store_dyn,
+        Arc::new(Mutex::new(ExtensionLifecycleService::new(
+            ExtensionRegistry::new(),
+        ))),
+        test_active_extension_publisher(
+            Arc::clone(&active_registry),
+            test_extension_trust_policy(),
+        ),
+        None,
+        lifecycle_owner(),
+    );
+
+    let alice = UserId::new("alice").expect("user");
+    let package_ref =
+        LifecyclePackageRef::new(LifecyclePackageKind::Extension, "fixture").expect("fixture ref");
+
+    // alice privately installs + activates (Enabled, package published).
+    port.install(package_ref.clone(), &alice)
+        .await
+        .expect("alice installs privately");
+    port.activate(package_ref.clone(), ExtensionActivationMode::Static, &alice)
+        .await
+        .expect("alice activates");
+
+    // Admin install fails at persist (upsert_installation), AFTER eviction
+    // has already deregistered alice's package.
+    store
+        .fail_next_upsert_installation
+        .store(true, std::sync::atomic::Ordering::SeqCst);
+    port.install(package_ref.clone(), &lifecycle_owner())
+        .await
+        .expect_err("persist failure aborts the tenant install");
+
+    // #5525 review (non-interference): the FAILED shared install must
+    // leave alice's private install exactly as it was — owner alice, row
+    // still Enabled, and her capability still published — not disabled/
+    // unpublished until an admin retry shows up.
+    let fixture_id = ExtensionId::new("fixture").expect("extension id");
+    let owners = port.installation_owners().await.expect("owners");
+    assert_eq!(
+        owners
+            .get(&fixture_id)
+            .and_then(InstallationOwner::as_user)
+            .map(UserId::as_str),
+        Some("alice"),
+        "failed tenant install must restore alice's private ownership"
+    );
+    let installation = store
+        .get_installation(&ExtensionInstallationId::new("fixture").expect("installation id"))
+        .await
+        .expect("store read")
+        .expect("installation row survives the failed tenant install");
+    assert_eq!(
+        installation.activation_state(),
+        ExtensionActivationState::Enabled,
+        "failed tenant install must re-enable the evicted private install"
+    );
+    assert!(
+        active_registry
+            .snapshot()
+            .get_extension(&fixture_id)
+            .is_some(),
+        "failed tenant install must re-publish the evicted private capability"
+    );
+
+    // Retry: eviction re-runs against the restored private install and the
+    // slot heals to a tenant-owned install rather than dead-ending on
+    // 'not installed'.
+    port.install(package_ref, &lifecycle_owner())
+        .await
+        .expect("admin retry heals the slot after a failed eviction install");
+
+    let owners = port.installation_owners().await.expect("owners");
+    assert!(
+        owners
+            .get(&ExtensionId::new("fixture").unwrap())
+            .expect("fixture installed")
+            .is_tenant(),
+        "the slot must heal to a tenant install, not stay bricked"
+    );
+}
+
+/// Command-path context whose verified auth claim subject is `user` —
+/// mirrors `LifecycleProductCommandService` dispatching `/extension_*`
+/// commands as `LifecycleProductContext::Command`.
+fn lifecycle_command_context_for_user(user: &str) -> LifecycleProductContext {
+    use ironclaw_product_adapters::{
+        AdapterInstallationId, AuthRequirement, ExternalActorRef, ExternalConversationRef,
+        ExternalEventId, ProductAdapterId, ProductTriggerReason, ProtocolAuthEvidence,
+    };
+    use ironclaw_product_workflow::{
+        ActionFingerprintKey, ProductActionId, ProductCommandContext, SourceBindingKey,
+    };
+
+    let adapter_id = ProductAdapterId::new("test_adapter").expect("valid adapter");
+    let installation_id = AdapterInstallationId::new("install_alpha").expect("valid installation");
+    let actor = ExternalActorRef::new("test", user, Option::<String>::None).expect("valid actor");
+    let conversation =
+        ExternalConversationRef::new(None, "conv1", None, None).expect("valid conversation");
+    let auth_claim = ProtocolAuthEvidence::test_verified(
+        AuthRequirement::SharedSecretHeader {
+            header_name: "X-Secret".into(),
+        },
+        user,
+    )
+    .claim()
+    .cloned()
+    .expect("verified claim");
+    LifecycleProductContext::Command(Box::new(ProductCommandContext {
+        action_id: ProductActionId::new(),
+        fingerprint: ActionFingerprintKey::new(
+            adapter_id.clone(),
+            installation_id.clone(),
+            actor.clone(),
+            SourceBindingKey::new("space:0:;conversation:5:conv1;topic:0:;").expect("binding key"),
+            ExternalEventId::new("evt:lifecycle-command").expect("valid event"),
+        ),
+        adapter_id,
+        installation_id,
+        external_actor_ref: actor,
+        external_conversation_ref: conversation,
+        auth_claim,
+        trigger: ProductTriggerReason::BotCommand,
+        received_at: chrono::Utc::now(),
+    }))
+}

--- a/crates/ironclaw_reborn_composition/src/extension_host/extension_lifecycle_capabilities.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/extension_lifecycle_capabilities.rs
@@ -162,13 +162,19 @@ impl FirstPartyCapabilityHandler for ExtensionLifecycleToolHandler {
                     Arc::clone(&self.credential_accounts),
                 );
                 self.extension_management
-                    .search(&input.query, Some(&credential_gate))
+                    .search(&input.query, Some(&credential_gate), &request.scope.user_id)
                     .await
             }
             EXTENSION_INSTALL_CAPABILITY_ID => {
                 let input: ExtensionIdInput = parse_input(request.input)?;
+                // The dispatch scope carries the ACTING user, so a chat-driven
+                // install derives the same owner the WebUI path would (#5459
+                // P1): operator → tenant-shared, member → private.
                 self.extension_management
-                    .install(extension_package_ref(input.extension_id)?)
+                    .install(
+                        extension_package_ref(input.extension_id)?,
+                        &request.scope.user_id,
+                    )
                     .await
             }
             EXTENSION_ACTIVATE_CAPABILITY_ID => {
@@ -176,7 +182,7 @@ impl FirstPartyCapabilityHandler for ExtensionLifecycleToolHandler {
                 let package_ref = extension_package_ref(input.extension_id)?;
                 let requirements = self
                     .extension_management
-                    .activation_credential_requirements(&package_ref)
+                    .activation_credential_requirements(&package_ref, &request.scope.user_id)
                     .await
                     .map_err(lifecycle_error)?;
                 let credential_gate = RuntimeExtensionActivationCredentialGate::new(
@@ -198,7 +204,12 @@ impl FirstPartyCapabilityHandler for ExtensionLifecycleToolHandler {
                     request.services.runtime_http_egress.clone(),
                 );
                 self.extension_management
-                    .activate_with_credential_gate(package_ref, mode, credential_gate)
+                    .activate_with_credential_gate(
+                        package_ref,
+                        mode,
+                        credential_gate,
+                        &request.scope.user_id,
+                    )
                     .await
             }
             EXTENSION_REMOVE_CAPABILITY_ID => {
@@ -207,7 +218,11 @@ impl FirstPartyCapabilityHandler for ExtensionLifecycleToolHandler {
                 // convergence point shared with the WebUI facade), so the scope
                 // is threaded through rather than cleaned up here.
                 self.extension_management
-                    .remove(extension_package_ref(input.extension_id)?, &request.scope)
+                    .remove(
+                        extension_package_ref(input.extension_id)?,
+                        Some(&request.scope),
+                        &request.scope.user_id,
+                    )
                     .await
             }
             _ => {
@@ -834,6 +849,27 @@ mod tests {
 
         let active = active_extension_capability_ids(&extension_management).await;
         assert!(!active.iter().any(|id| id == "github.search_issues"));
+
+        // #5525 review: a foreign caller probing the same private credentialed
+        // install must NOT receive the auth gate — that response confirms the
+        // install exists and leaks its credential requirement shape. Ownership
+        // masks before the credential preflight, so the non-owner sees the
+        // same failure a missing installation would produce.
+        let outcome = crate::approval_test_support::invoke_with_local_dev_approval(
+            &services,
+            EXTENSION_ACTIVATE_CAPABILITY_ID,
+            execution_context_for_user(
+                "extension-tool-foreign-user",
+                [EXTENSION_ACTIVATE_CAPABILITY_ID],
+            ),
+            serde_json::json!({"extension_id": "github"}),
+            trust_decision(),
+        )
+        .await;
+        let RuntimeCapabilityOutcome::Failed(failure) = outcome else {
+            panic!("foreign caller must get the masked failure, not an auth gate: {outcome:?}");
+        };
+        assert_eq!(failure.kind, RuntimeFailureKind::InvalidInput);
     }
 
     #[tokio::test]
@@ -1352,9 +1388,16 @@ mod tests {
     fn execution_context<'a>(
         capability_ids: impl IntoIterator<Item = &'a str>,
     ) -> ExecutionContext {
+        execution_context_for_user("extension-tool-test-user", capability_ids)
+    }
+
+    fn execution_context_for_user<'a>(
+        user: &str,
+        capability_ids: impl IntoIterator<Item = &'a str>,
+    ) -> ExecutionContext {
         let caller = ExtensionId::new("extension-tool-test-caller").expect("valid extension id");
         ExecutionContext::local_default(
-            UserId::new("extension-tool-test-user").expect("valid user id"),
+            UserId::new(user).expect("valid user id"),
             caller.clone(),
             RuntimeKind::FirstParty,
             TrustClass::FirstParty,

--- a/crates/ironclaw_reborn_composition/src/extension_host/lifecycle.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/lifecycle.rs
@@ -335,6 +335,7 @@ impl RebornLocalLifecycleFacade {
                 let Some(extension_management) = &self.extension_management else {
                     return unsupported_projection(None);
                 };
+                let caller = lifecycle_caller(&context)?;
                 let credential_gate = if matches!(&context, LifecycleProductContext::Surface(_)) {
                     if let Some(credential_accounts) = &self.credential_accounts {
                         Some(RuntimeExtensionActivationCredentialGate::new(
@@ -348,30 +349,34 @@ impl RebornLocalLifecycleFacade {
                     None
                 };
                 extension_management
-                    .search(&query, credential_gate.as_ref())
+                    .search(&query, credential_gate.as_ref(), &caller)
                     .await
             }
             LifecycleProductAction::ExtensionList => {
                 let Some(extension_management) = &self.extension_management else {
                     return unsupported_projection(None);
                 };
-                extension_management.list_installed().await
+                let caller = lifecycle_caller(&context)?;
+                extension_management.list_installed(&caller).await
             }
             LifecycleProductAction::ExtensionInstall { package_ref } => {
                 let Some(extension_management) = &self.extension_management else {
                     return unsupported_projection(Some(package_ref));
                 };
-                extension_management.install(package_ref).await
+                let caller = lifecycle_caller(&context)?;
+                extension_management.install(package_ref, &caller).await
             }
             LifecycleProductAction::ExtensionActivate { package_ref } => {
                 let Some(extension_management) = &self.extension_management else {
                     return unsupported_projection(Some(package_ref));
                 };
+                let caller = lifecycle_caller(&context)?;
                 let credential_gate = self
                     .extension_activation_credential_gate(
                         &context,
                         extension_management,
                         &package_ref,
+                        &caller,
                     )
                     .await?;
                 if extension_management
@@ -395,10 +400,19 @@ impl RebornLocalLifecycleFacade {
                     return match credential_gate {
                         Some(credential_gate) => {
                             extension_management
-                                .activate_with_credential_gate(package_ref, mode, credential_gate)
+                                .activate_with_credential_gate(
+                                    package_ref,
+                                    mode,
+                                    credential_gate,
+                                    &caller,
+                                )
                                 .await
                         }
-                        None => extension_management.activate(package_ref, mode).await,
+                        None => {
+                            extension_management
+                                .activate(package_ref, mode, &caller)
+                                .await
+                        }
                     };
                 }
                 let mode =
@@ -406,10 +420,19 @@ impl RebornLocalLifecycleFacade {
                 match credential_gate {
                     Some(credential_gate) => {
                         extension_management
-                            .activate_with_credential_gate(package_ref, mode, credential_gate)
+                            .activate_with_credential_gate(
+                                package_ref,
+                                mode,
+                                credential_gate,
+                                &caller,
+                            )
                             .await
                     }
-                    None => extension_management.activate(package_ref, mode).await,
+                    None => {
+                        extension_management
+                            .activate(package_ref, mode, &caller)
+                            .await
+                    }
                 }
             }
             LifecycleProductAction::ExtensionRemove { package_ref } => {
@@ -418,9 +441,16 @@ impl RebornLocalLifecycleFacade {
                 };
                 // Thread the caller scope so the port can revoke the removed
                 // extension's exclusive credential (the convergence point shared
-                // with the agent capability path).
-                let scope = lifecycle_resource_scope(&context)?;
-                extension_management.remove(package_ref, &scope).await
+                // with the agent capability path). A command-context auth claim
+                // carries no tenant/agent scope to build one from, so
+                // command-path removals (#5525) skip the best-effort revocation
+                // instead of being rejected outright — the caller still comes
+                // from the verified claim via `lifecycle_caller`.
+                let scope = lifecycle_resource_scope(&context).ok();
+                let caller = lifecycle_caller(&context)?;
+                extension_management
+                    .remove(package_ref, scope.as_ref(), &caller)
+                    .await
             }
             LifecycleProductAction::ExtensionAuth { package_ref }
             | LifecycleProductAction::ExtensionConfigure { package_ref, .. } => {
@@ -434,9 +464,13 @@ impl RebornLocalLifecycleFacade {
         context: &LifecycleProductContext,
         extension_management: &RebornLocalExtensionManagementPort,
         package_ref: &LifecyclePackageRef,
+        caller: &UserId,
     ) -> Result<Option<RuntimeExtensionActivationCredentialGate>, ProductWorkflowError> {
+        // The requirements preflight checks ownership first, so a non-owner
+        // exits here with the masked "is not installed" denial before any
+        // credential or hosted-MCP probing can leak the install's existence.
         let requirements = extension_management
-            .activation_credential_requirements(package_ref)
+            .activation_credential_requirements(package_ref, caller)
             .await?;
         if requirements.is_empty() {
             return Ok(None);
@@ -480,14 +514,15 @@ impl LifecycleProductFacade for RebornLocalLifecycleFacade {
 
     async fn project_package(
         &self,
-        _context: LifecycleProductContext,
+        context: LifecycleProductContext,
         package_ref: LifecyclePackageRef,
     ) -> Result<LifecycleProductResponse, ProductWorkflowError> {
         if package_ref.kind == LifecyclePackageKind::Extension {
             let Some(extension_management) = &self.extension_management else {
                 return unsupported_projection(Some(package_ref));
             };
-            return extension_management.project(package_ref).await;
+            let caller = lifecycle_caller(&context)?;
+            return extension_management.project(package_ref, &caller).await;
         }
         unsupported_projection(Some(package_ref))
     }
@@ -527,6 +562,23 @@ fn lifecycle_resource_scope(
         thread_id: None,
         invocation_id: InvocationId::new(),
     })
+}
+
+/// Owner-attributing caller identity for extension lifecycle actions.
+///
+/// Surface callers carry a typed [`UserId`]; command callers derive it from
+/// the verified auth claim minted by host authentication — commands must stay
+/// owner-attributed, not fall back to an ownerless path.
+fn lifecycle_caller(context: &LifecycleProductContext) -> Result<UserId, ProductWorkflowError> {
+    match context {
+        LifecycleProductContext::Surface(context) => Ok(context.user_id.clone()),
+        LifecycleProductContext::Command(context) => UserId::new(context.auth_claim.subject())
+            .map_err(|error| ProductWorkflowError::InvalidBindingRequest {
+                reason: format!(
+                    "command auth subject is not a valid lifecycle caller identity: {error}"
+                ),
+            }),
+    }
 }
 
 fn map_lifecycle_credential_stage_error(error: CredentialStageError) -> ProductWorkflowError {

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -1668,6 +1668,9 @@ async fn build_local_runtime(input: RebornBuildInput) -> Result<RebornServices, 
         extension_lifecycle_service,
         active_extensions,
         Some(Arc::clone(&product_auth) as Arc<dyn ExtensionCredentialCleanup>),
+        // #5459 P1: the base owner is the tenant operator in local-dev —
+        // their installs are tenant-shared, everyone else's are private.
+        nearai_mcp_owner_scope.user_id.clone(),
     ));
     let nearai_mcp_bootstrap_outcome = crate::llm_admin::nearai_mcp::bootstrap_nearai_mcp(
         nearai_mcp_bootstrap_config,
@@ -5805,7 +5808,10 @@ mod tests {
                 .expect("valid ref");
 
         extension_management
-            .install(gmail_ref.clone())
+            .install(
+                gmail_ref.clone(),
+                extension_management.tenant_operator_user_id_for_test(),
+            )
             .await
             .expect("install Gmail");
         extension_management
@@ -5816,7 +5822,10 @@ mod tests {
             .await
             .expect("activate Gmail");
         extension_management
-            .install(calendar_ref.clone())
+            .install(
+                calendar_ref.clone(),
+                extension_management.tenant_operator_user_id_for_test(),
+            )
             .await
             .expect("install Google Calendar");
         extension_management
@@ -5943,7 +5952,10 @@ mod tests {
         assert!(capability_ids.contains(&"notion.notion-get-self"));
 
         extension_management
-            .install(notion_ref.clone())
+            .install(
+                notion_ref.clone(),
+                extension_management.tenant_operator_user_id_for_test(),
+            )
             .await
             .expect("install Notion MCP");
         extension_management
@@ -5999,7 +6011,10 @@ mod tests {
                 .expect("valid ref");
 
         extension_management
-            .install(web_access_ref.clone())
+            .install(
+                web_access_ref.clone(),
+                extension_management.tenant_operator_user_id_for_test(),
+            )
             .await
             .expect("install Web Access");
         extension_management
@@ -6431,7 +6446,10 @@ mod tests {
             LifecyclePackageRef::new(LifecyclePackageKind::Extension, "nearai").expect("valid ref");
 
         let projection = extension_management
-            .project(nearai_ref)
+            .project(
+                nearai_ref,
+                extension_management.tenant_operator_user_id_for_test(),
+            )
             .await
             .expect("NEAR AI MCP projected");
         assert_eq!(projection.phase, LifecyclePhase::Active);
@@ -6546,7 +6564,10 @@ mod tests {
             LifecyclePackageRef::new(LifecyclePackageKind::Extension, "nearai").expect("valid ref");
 
         let projection = extension_management
-            .project(nearai_ref)
+            .project(
+                nearai_ref,
+                extension_management.tenant_operator_user_id_for_test(),
+            )
             .await
             .expect("NEAR AI MCP projected");
         assert_eq!(projection.phase, LifecyclePhase::Discovered);
@@ -6683,11 +6704,14 @@ mod tests {
         extension_management
             .remove(
                 nearai_ref.clone(),
-                &ironclaw_host_api::ResourceScope::local_default(
-                    ironclaw_host_api::UserId::new("factory-remove-test").expect("valid user"),
-                    ironclaw_host_api::InvocationId::new(),
-                )
-                .expect("valid scope"),
+                Some(
+                    &ironclaw_host_api::ResourceScope::local_default(
+                        ironclaw_host_api::UserId::new("factory-remove-test").expect("valid user"),
+                        ironclaw_host_api::InvocationId::new(),
+                    )
+                    .expect("valid scope"),
+                ),
+                extension_management.tenant_operator_user_id_for_test(),
             )
             .await
             .expect("disable NEAR AI MCP extension");
@@ -6711,7 +6735,10 @@ mod tests {
             crate::llm_admin::nearai_mcp::NearAiMcpBootstrapOutcome::Activated
         );
         let projection = extension_management
-            .project(nearai_ref)
+            .project(
+                nearai_ref,
+                extension_management.tenant_operator_user_id_for_test(),
+            )
             .await
             .expect("NEAR AI MCP projected");
         assert_eq!(projection.phase, LifecyclePhase::Active);

--- a/crates/ironclaw_reborn_composition/src/llm_admin/nearai_mcp.rs
+++ b/crates/ironclaw_reborn_composition/src/llm_admin/nearai_mcp.rs
@@ -226,7 +226,7 @@ pub(crate) async fn bootstrap_nearai_mcp(
             }
         })?;
     let phase = extension_management
-        .project(package_ref.clone())
+        .project(package_ref.clone(), &owner_scope.user_id)
         .await
         .map_err(|error| RebornBuildError::InvalidConfig {
             reason: format!("NEAR AI MCP extension projection failed: {error}"),
@@ -322,9 +322,13 @@ pub(crate) async fn bootstrap_nearai_mcp(
         }
     }
 
+    // Bootstrap acts as the base owner (the tenant operator), so the install
+    // derives a tenant-shared owner — the NEAR AI MCP extension is for the
+    // whole tenant, matching pre-#5459 behavior.
+    let bootstrap_caller = resource_scope.user_id.clone();
     if phase == LifecyclePhase::Discovered {
         extension_management
-            .install(package_ref.clone())
+            .install(package_ref.clone(), &bootstrap_caller)
             .await
             .map_err(|error| RebornBuildError::InvalidConfig {
                 reason: format!("NEAR AI MCP extension install failed: {error}"),
@@ -340,6 +344,7 @@ pub(crate) async fn bootstrap_nearai_mcp(
                         resource_scope,
                         product_auth.runtime_credential_account_selection_service(),
                     ),
+                    &bootstrap_caller,
                 )
                 .await
                 .map_err(|error| RebornBuildError::InvalidConfig {

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -5967,7 +5967,10 @@ output_schema_ref = "schemas/write.output.json"
         let nearai_ref =
             LifecyclePackageRef::new(LifecyclePackageKind::Extension, "nearai").expect("valid ref");
         let projection = extension_management
-            .project(nearai_ref)
+            .project(
+                nearai_ref,
+                extension_management.tenant_operator_user_id_for_test(),
+            )
             .await
             .expect("NEAR AI MCP projected");
         assert_eq!(projection.phase, LifecyclePhase::Active);
@@ -6072,7 +6075,10 @@ output_schema_ref = "schemas/write.output.json"
         let nearai_ref =
             LifecyclePackageRef::new(LifecyclePackageKind::Extension, "nearai").expect("valid ref");
         let projection = extension_management
-            .project(nearai_ref)
+            .project(
+                nearai_ref,
+                extension_management.tenant_operator_user_id_for_test(),
+            )
             .await
             .expect("NEAR AI MCP projected");
         assert_eq!(projection.phase, LifecyclePhase::Active);
@@ -7601,7 +7607,10 @@ output_schema_ref = "schemas/write.output.json"
         let notion_ref = LifecyclePackageRef::new(LifecyclePackageKind::Extension, "notion")
             .expect("valid notion ref");
         extension_management
-            .install(notion_ref.clone())
+            .install(
+                notion_ref.clone(),
+                extension_management.tenant_operator_user_id_for_test(),
+            )
             .await
             .expect("install Notion MCP");
         extension_management
@@ -10417,9 +10426,12 @@ output_schema_ref = "schemas/write.output.json"
                 let package_ref =
                     LifecyclePackageRef::new(LifecyclePackageKind::Extension, "github")
                         .expect("valid github ref");
+                // #5459 P1: act as the runtime owner (the tenant operator) so
+                // the install is tenant-shared and visible to the run's
+                // surface user — a non-operator install would now be private.
                 let ctx = LifecycleProductContext::Surface(LifecycleProductSurfaceContext {
                     tenant_id: TenantId::new("tenant-multi-tool-surface").expect("tenant id"),
-                    user_id: UserId::new("user-multi-tool-surface").expect("user id"),
+                    user_id: UserId::new("runtime-multi-tool-surface-owner").expect("user id"),
                     agent_id: None,
                     project_id: None,
                 });

--- a/crates/ironclaw_reborn_composition/src/runtime/approval.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/approval.rs
@@ -75,8 +75,12 @@ impl LocalDevApprovalLeaseTermsProvider {
                 tracing::error!(%error, "local-dev extension approval lease terms are unavailable");
                 lease_terms_unavailable()
             })?;
+        // Lease terms resolve for the user whose run raised the gate; the
+        // owner filter in `grants` then behaves exactly like dispatch did
+        // (#5459 P1): their own private capability resolves, anyone else's
+        // yields no grant and the lease stays unavailable.
         let Some(grant) = surface
-            .grants(extension_id)
+            .grants(extension_id, &gate.resource_scope().user_id)
             .into_iter()
             .find(|grant| grant.capability == *capability)
         else {
@@ -247,6 +251,7 @@ mod tests {
                 default_permission: PermissionMode::Allow,
                 runtime_credentials: Vec::new(),
                 network_targets: Vec::new(),
+                owner: ironclaw_extensions::InstallationOwner::Tenant,
             }]),
         );
         let terms_provider = LocalDevApprovalLeaseTermsProvider::new(
@@ -318,6 +323,7 @@ mod tests {
                     required: true,
                 }],
                 network_targets: Vec::new(),
+                owner: ironclaw_extensions::InstallationOwner::Tenant,
             }]),
         );
         let terms_provider = LocalDevApprovalLeaseTermsProvider::new(
@@ -370,6 +376,7 @@ mod tests {
                 default_permission: PermissionMode::Allow,
                 runtime_credentials: Vec::new(),
                 network_targets: Vec::new(),
+                owner: ironclaw_extensions::InstallationOwner::Tenant,
             }]),
         );
         let terms_provider = LocalDevApprovalLeaseTermsProvider::new(
@@ -409,6 +416,7 @@ mod tests {
                 default_permission: PermissionMode::Ask,
                 runtime_credentials: Vec::new(),
                 network_targets: Vec::new(),
+                owner: ironclaw_extensions::InstallationOwner::Tenant,
             }]),
         );
         let terms_provider = LocalDevApprovalLeaseTermsProvider::new(
@@ -477,6 +485,7 @@ mod tests {
                 default_permission: PermissionMode::Deny,
                 runtime_credentials: Vec::new(),
                 network_targets: Vec::new(),
+                owner: ironclaw_extensions::InstallationOwner::Tenant,
             }]),
         );
         let terms_provider = LocalDevApprovalLeaseTermsProvider::new(

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev.rs
@@ -961,6 +961,14 @@ fn local_dev_visible_capability_request(
     inputs: LocalDevVisibleCapabilityInputs<'_>,
 ) -> Result<HostVisibleCapabilityRequest, AgentLoopHostError> {
     let extension_id = loop_driver_execution_extension_id(run_context)?;
+    // Resolved BEFORE grant minting: extension grants are filtered per caller
+    // (#5459 P1 — user-private installs mint grants only for their owner).
+    let user_id = run_context
+        .scope
+        .explicit_owner_user_id()
+        .cloned()
+        .or_else(|| run_context.actor().map(|actor| actor.user_id.clone()))
+        .unwrap_or_else(|| fallback_user_id.clone());
     let mut grants = inputs.policy.builtin_grants(
         &extension_id,
         inputs.workspace_mounts,
@@ -970,13 +978,7 @@ fn local_dev_visible_capability_request(
     );
     grants
         .grants
-        .extend(inputs.extension_surface.grants(&extension_id));
-    let user_id = run_context
-        .scope
-        .explicit_owner_user_id()
-        .cloned()
-        .or_else(|| run_context.actor().map(|actor| actor.user_id.clone()))
-        .unwrap_or_else(|| fallback_user_id.clone());
+        .extend(inputs.extension_surface.grants(&extension_id, &user_id));
     let mut context = ExecutionContext::local_default(
         user_id,
         extension_id,
@@ -1011,7 +1013,7 @@ fn local_dev_visible_capability_request(
             evaluated_at: Utc::now(),
         },
     );
-    provider_trust.extend(inputs.extension_surface.provider_trust());
+    provider_trust.extend(inputs.extension_surface.provider_trust(&context.user_id));
 
     Ok(HostVisibleCapabilityRequest::new(
         context,

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/extension_surface.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/extension_surface.rs
@@ -81,9 +81,20 @@ impl LocalDevExtensionSurface {
         })
     }
 
-    pub(in crate::runtime) fn grants(&self, grantee: &ExtensionId) -> Vec<CapabilityGrant> {
+    /// Mint capability grants for one request (#5459 P1: filtered to the
+    /// CALLER — tenant-owned capabilities grant to everyone, user-private ones
+    /// only to their owner). This is the single choke point: dispatch
+    /// authorization reuses the grants minted here, so a capability filtered
+    /// out is both invisible in the surface AND denied at dispatch — grant
+    /// absence fails closed with no separate preflight.
+    pub(in crate::runtime) fn grants(
+        &self,
+        grantee: &ExtensionId,
+        caller: &ironclaw_host_api::UserId,
+    ) -> Vec<CapabilityGrant> {
         self.active_capabilities
             .iter()
+            .filter(|capability| capability.owner.visible_to(caller))
             .map(|capability| CapabilityGrant {
                 id: CapabilityGrantId::new(),
                 capability: capability.id.clone(),
@@ -103,9 +114,18 @@ impl LocalDevExtensionSurface {
             .find(|capability| capability.id == *capability_id)
     }
 
-    pub(super) fn provider_trust(&self) -> BTreeMap<ExtensionId, TrustDecision> {
+    /// Provider trust for the same request; filtered by the same owner rule as
+    /// [`Self::grants`] so a user-private extension's provider is not even
+    /// advertised to other users' surfaces.
+    pub(super) fn provider_trust(
+        &self,
+        caller: &ironclaw_host_api::UserId,
+    ) -> BTreeMap<ExtensionId, TrustDecision> {
         let mut effects_by_provider: BTreeMap<ExtensionId, Vec<EffectKind>> = BTreeMap::new();
         for capability in &self.active_capabilities {
+            if !capability.owner.visible_to(caller) {
+                continue;
+            }
             let effects = effects_by_provider
                 .entry(capability.provider.clone())
                 .or_default();
@@ -215,7 +235,68 @@ fn extension_network_policy(capability: &ActiveExtensionCapability) -> NetworkPo
 mod tests {
     use super::*;
     use ironclaw_first_party_extensions::google_api_network_policy;
-    use ironclaw_host_api::{CapabilityId, PermissionMode};
+    use ironclaw_host_api::{CapabilityId, PermissionMode, UserId};
+
+    /// #5459 P1: the grant-minting choke point — a user-private extension's
+    /// capabilities mint grants (and advertise provider trust) ONLY for their
+    /// owner; tenant-owned ones mint for everyone. Grant absence is what makes
+    /// a private tool both invisible in the surface and denied at dispatch,
+    /// so this filter IS the enforcement.
+    #[test]
+    fn grants_and_provider_trust_filter_user_private_capabilities_to_their_owner() {
+        let alice = UserId::new("alice").unwrap();
+        let bob = UserId::new("bob").unwrap();
+        let grantee = ExtensionId::new("caller").unwrap();
+        let capability = |id: &str, provider: &str, owner| ActiveExtensionCapability {
+            id: CapabilityId::new(id).unwrap(),
+            provider: ExtensionId::new(provider).unwrap(),
+            effects: vec![EffectKind::DispatchCapability],
+            default_permission: PermissionMode::Allow,
+            runtime_credentials: Vec::new(),
+            network_targets: Vec::new(),
+            owner,
+        };
+        let surface = LocalDevExtensionSurface::from_active_capabilities(vec![
+            capability(
+                "market-data.snp500",
+                "market-data",
+                ironclaw_extensions::InstallationOwner::user(alice.clone()),
+            ),
+            capability(
+                "hacker-news.top_stories",
+                "hacker-news",
+                ironclaw_extensions::InstallationOwner::Tenant,
+            ),
+        ]);
+
+        let alice_capabilities: Vec<_> = surface
+            .grants(&grantee, &alice)
+            .into_iter()
+            .map(|grant| grant.capability.as_str().to_string())
+            .collect();
+        assert!(alice_capabilities.contains(&"market-data.snp500".to_string()));
+        assert!(alice_capabilities.contains(&"hacker-news.top_stories".to_string()));
+
+        let bob_capabilities: Vec<_> = surface
+            .grants(&grantee, &bob)
+            .into_iter()
+            .map(|grant| grant.capability.as_str().to_string())
+            .collect();
+        assert!(
+            !bob_capabilities.contains(&"market-data.snp500".to_string()),
+            "alice's private capability must not mint a grant for bob"
+        );
+        assert!(bob_capabilities.contains(&"hacker-news.top_stories".to_string()));
+
+        let alice_trust = surface.provider_trust(&alice);
+        assert!(alice_trust.contains_key(&ExtensionId::new("market-data").unwrap()));
+        let bob_trust = surface.provider_trust(&bob);
+        assert!(
+            !bob_trust.contains_key(&ExtensionId::new("market-data").unwrap()),
+            "alice's private provider must not be advertised to bob"
+        );
+        assert!(bob_trust.contains_key(&ExtensionId::new("hacker-news").unwrap()));
+    }
 
     #[test]
     fn web_access_search_gets_exa_mcp_network_target_without_credentials() {
@@ -226,6 +307,7 @@ mod tests {
             default_permission: PermissionMode::Allow,
             runtime_credentials: Vec::new(),
             network_targets: Vec::new(),
+            owner: ironclaw_extensions::InstallationOwner::Tenant,
         };
 
         let policy = extension_network_policy(&capability);
@@ -251,6 +333,7 @@ mod tests {
             default_permission: PermissionMode::Allow,
             runtime_credentials: Vec::new(),
             network_targets: Vec::new(),
+            owner: ironclaw_extensions::InstallationOwner::Tenant,
         };
 
         let policy = extension_network_policy(&capability);
@@ -282,6 +365,7 @@ mod tests {
             default_permission: PermissionMode::Allow,
             runtime_credentials: Vec::new(),
             network_targets: Vec::new(),
+            owner: ironclaw_extensions::InstallationOwner::Tenant,
         };
 
         let policy = extension_network_policy(&capability);
@@ -310,6 +394,7 @@ mod tests {
                 host_pattern: "news.ycombinator.com".to_string(),
                 port: None,
             }],
+            owner: ironclaw_extensions::InstallationOwner::Tenant,
         };
 
         let policy = extension_network_policy(&capability);
@@ -351,6 +436,7 @@ mod tests {
                 required: true,
             }],
             network_targets: Vec::new(),
+            owner: ironclaw_extensions::InstallationOwner::Tenant,
         };
 
         let policy = extension_network_policy(&capability);
@@ -373,6 +459,7 @@ mod tests {
             default_permission: PermissionMode::Allow,
             runtime_credentials: Vec::new(),
             network_targets: Vec::new(),
+            owner: ironclaw_extensions::InstallationOwner::Tenant,
         };
 
         let policy = extension_network_policy(&capability);
@@ -394,6 +481,7 @@ mod tests {
             default_permission: PermissionMode::Allow,
             runtime_credentials: Vec::new(),
             network_targets: Vec::new(),
+            owner: ironclaw_extensions::InstallationOwner::Tenant,
         };
 
         let policy = extension_network_policy(&capability);

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/extension_surface.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/extension_surface.rs
@@ -237,15 +237,17 @@ mod tests {
     use ironclaw_first_party_extensions::google_api_network_policy;
     use ironclaw_host_api::{CapabilityId, PermissionMode, UserId};
 
-    /// #5459 P1: the grant-minting choke point — a user-private extension's
-    /// capabilities mint grants (and advertise provider trust) ONLY for their
-    /// owner; tenant-owned ones mint for everyone. Grant absence is what makes
-    /// a private tool both invisible in the surface and denied at dispatch,
-    /// so this filter IS the enforcement.
+    /// #5459 P1: the grant-minting choke point — a member-held extension's
+    /// capabilities mint grants (and advertise provider trust) ONLY for its
+    /// members (every member of the set, not just one); tenant-owned ones
+    /// mint for everyone. Grant absence is what makes an un-held tool both
+    /// invisible in the surface and denied at dispatch, so this filter IS
+    /// the enforcement.
     #[test]
-    fn grants_and_provider_trust_filter_user_private_capabilities_to_their_owner() {
+    fn grants_and_provider_trust_filter_member_held_capabilities_to_their_members() {
         let alice = UserId::new("alice").unwrap();
         let bob = UserId::new("bob").unwrap();
+        let carol = UserId::new("carol").unwrap();
         let grantee = ExtensionId::new("caller").unwrap();
         let capability = |id: &str, provider: &str, owner| ActiveExtensionCapability {
             id: CapabilityId::new(id).unwrap(),
@@ -260,7 +262,10 @@ mod tests {
             capability(
                 "market-data.snp500",
                 "market-data",
-                ironclaw_extensions::InstallationOwner::user(alice.clone()),
+                ironclaw_extensions::InstallationOwner::users(
+                    [alice.clone(), bob.clone()].into_iter().collect(),
+                )
+                .expect("member set"),
             ),
             capability(
                 "hacker-news.top_stories",
@@ -269,33 +274,40 @@ mod tests {
             ),
         ]);
 
-        let alice_capabilities: Vec<_> = surface
-            .grants(&grantee, &alice)
-            .into_iter()
-            .map(|grant| grant.capability.as_str().to_string())
-            .collect();
-        assert!(alice_capabilities.contains(&"market-data.snp500".to_string()));
-        assert!(alice_capabilities.contains(&"hacker-news.top_stories".to_string()));
+        for member in [&alice, &bob] {
+            let member_capabilities: Vec<_> = surface
+                .grants(&grantee, member)
+                .into_iter()
+                .map(|grant| grant.capability.as_str().to_string())
+                .collect();
+            assert!(
+                member_capabilities.contains(&"market-data.snp500".to_string()),
+                "every member of the set gets the grant"
+            );
+            assert!(member_capabilities.contains(&"hacker-news.top_stories".to_string()));
+        }
 
-        let bob_capabilities: Vec<_> = surface
-            .grants(&grantee, &bob)
+        let carol_capabilities: Vec<_> = surface
+            .grants(&grantee, &carol)
             .into_iter()
             .map(|grant| grant.capability.as_str().to_string())
             .collect();
         assert!(
-            !bob_capabilities.contains(&"market-data.snp500".to_string()),
-            "alice's private capability must not mint a grant for bob"
+            !carol_capabilities.contains(&"market-data.snp500".to_string()),
+            "a member-held capability must not mint a grant for a non-member"
         );
-        assert!(bob_capabilities.contains(&"hacker-news.top_stories".to_string()));
+        assert!(carol_capabilities.contains(&"hacker-news.top_stories".to_string()));
 
-        let alice_trust = surface.provider_trust(&alice);
-        assert!(alice_trust.contains_key(&ExtensionId::new("market-data").unwrap()));
-        let bob_trust = surface.provider_trust(&bob);
+        for member in [&alice, &bob] {
+            let member_trust = surface.provider_trust(member);
+            assert!(member_trust.contains_key(&ExtensionId::new("market-data").unwrap()));
+        }
+        let carol_trust = surface.provider_trust(&carol);
         assert!(
-            !bob_trust.contains_key(&ExtensionId::new("market-data").unwrap()),
-            "alice's private provider must not be advertised to bob"
+            !carol_trust.contains_key(&ExtensionId::new("market-data").unwrap()),
+            "a member-held provider must not be advertised to a non-member"
         );
-        assert!(bob_trust.contains_key(&ExtensionId::new("hacker-news").unwrap()));
+        assert!(carol_trust.contains_key(&ExtensionId::new("hacker-news").unwrap()));
     }
 
     #[test]

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/tests.rs
@@ -286,10 +286,14 @@ mod tests {
         )
     }
 
-    fn lifecycle_context(label: &str) -> LifecycleProductContext {
+    /// #5459 P1: lifecycle context acting AS the runtime's tenant operator, so
+    /// test installs are tenant-shared and visible to every surface user —
+    /// what these runtime-surface tests always meant. A `lifecycle_context`
+    /// user would now produce a PRIVATE install invisible to the run's user.
+    fn operator_lifecycle_context(label: &str, operator: &UserId) -> LifecycleProductContext {
         LifecycleProductContext::Surface(LifecycleProductSurfaceContext {
             tenant_id: TenantId::new(format!("tenant-{label}")).expect("tenant id"),
-            user_id: UserId::new(format!("user-{label}")).expect("user id"),
+            user_id: operator.clone(),
             agent_id: None,
             project_id: None,
         })
@@ -523,6 +527,13 @@ mod tests {
             .as_ref()
             .expect("extension management")
             .clone();
+        // #5459 P1: install AS the runtime's tenant operator so the extensions
+        // are tenant-shared (what these surface tests always meant) — a
+        // non-operator context would now produce a private install invisible
+        // to the run's surface user.
+        let operator = extension_management
+            .tenant_operator_user_id_for_test()
+            .clone();
         let facade = crate::extension_host::lifecycle::RebornLocalLifecycleFacade::new(
             local_runtime.skill_management.clone(),
         )
@@ -532,9 +543,17 @@ mod tests {
             let package_ref =
                 LifecyclePackageRef::new(LifecyclePackageKind::Extension, extension_id)
                     .expect("valid extension ref");
+            let operator_context = |label: &str| {
+                LifecycleProductContext::Surface(LifecycleProductSurfaceContext {
+                    tenant_id: TenantId::new(format!("tenant-{label}")).expect("tenant id"),
+                    user_id: operator.clone(),
+                    agent_id: None,
+                    project_id: None,
+                })
+            };
             facade
                 .execute(
-                    lifecycle_context(extension_id),
+                    operator_context(extension_id),
                     LifecycleProductAction::ExtensionInstall {
                         package_ref: package_ref.clone(),
                     },
@@ -544,7 +563,7 @@ mod tests {
             if matches!(extension_state, GsuiteExtensionState::Activated) {
                 facade
                     .execute(
-                        lifecycle_context(extension_id),
+                        operator_context(extension_id),
                         LifecycleProductAction::ExtensionActivate { package_ref },
                     )
                     .await
@@ -3047,6 +3066,9 @@ mod tests {
                 .as_ref()
                 .expect("extension management")
                 .clone();
+            let operator = extension_management
+                .tenant_operator_user_id_for_test()
+                .clone();
             let facade = crate::extension_host::lifecycle::RebornLocalLifecycleFacade::new(
                 local_runtime.skill_management.clone(),
             )
@@ -3056,7 +3078,7 @@ mod tests {
                 .expect("valid github ref");
             facade
                 .execute(
-                    lifecycle_context("github-install"),
+                    operator_lifecycle_context("github-install", &operator),
                     LifecycleProductAction::ExtensionInstall {
                         package_ref: package_ref.clone(),
                     },
@@ -3065,7 +3087,7 @@ mod tests {
                 .expect("install github extension");
             facade
                 .execute(
-                    lifecycle_context("github-activate"),
+                    operator_lifecycle_context("github-activate", &operator),
                     LifecycleProductAction::ExtensionActivate { package_ref },
                 )
                 .await
@@ -3151,6 +3173,9 @@ mod tests {
             .as_ref()
             .expect("extension management")
             .clone();
+        let operator = extension_management
+            .tenant_operator_user_id_for_test()
+            .clone();
         let facade = crate::extension_host::lifecycle::RebornLocalLifecycleFacade::new(
             local_runtime.skill_management.clone(),
         )
@@ -3160,7 +3185,7 @@ mod tests {
             .expect("valid github ref");
         facade
             .execute(
-                lifecycle_context("github-live-install"),
+                operator_lifecycle_context("github-live-install", &operator),
                 LifecycleProductAction::ExtensionInstall {
                     package_ref: package_ref.clone(),
                 },
@@ -3169,7 +3194,7 @@ mod tests {
             .expect("install github extension");
         facade
             .execute(
-                lifecycle_context("github-live-activate"),
+                operator_lifecycle_context("github-live-activate", &operator),
                 LifecycleProductAction::ExtensionActivate { package_ref },
             )
             .await
@@ -3343,6 +3368,9 @@ mod tests {
             .as_ref()
             .expect("extension management")
             .clone();
+        let operator = extension_management
+            .tenant_operator_user_id_for_test()
+            .clone();
         let facade = crate::extension_host::lifecycle::RebornLocalLifecycleFacade::new(
             local_runtime.skill_management.clone(),
         )
@@ -3352,7 +3380,7 @@ mod tests {
             .expect("valid github ref");
         facade
             .execute(
-                lifecycle_context("mid-response-install"),
+                operator_lifecycle_context("mid-response-install", &operator),
                 LifecycleProductAction::ExtensionInstall {
                     package_ref: package_ref.clone(),
                 },
@@ -3361,7 +3389,7 @@ mod tests {
             .expect("install github extension");
         facade
             .execute(
-                lifecycle_context("mid-response-activate"),
+                operator_lifecycle_context("mid-response-activate", &operator),
                 LifecycleProductAction::ExtensionActivate { package_ref },
             )
             .await

--- a/crates/ironclaw_reborn_composition/src/slack/slack_host_beta/runtime_setup.rs
+++ b/crates/ironclaw_reborn_composition/src/slack/slack_host_beta/runtime_setup.rs
@@ -221,9 +221,12 @@ impl SlackChannelSetupActivation for DynamicSlackChannelSetupActivation {
     ) -> Result<(), SlackChannelSetupActivationError> {
         let package_ref = LifecyclePackageRef::new(LifecyclePackageKind::Extension, "slack_bot")
             .map_err(slack_setup_activation_error)?;
+        // Slack is a tenant-shared channel; host setup activates it as the
+        // tenant operator so it operates the shared install (#5459 P1).
+        let caller = self.extension_management.tenant_operator_user_id().clone();
         let projection = self
             .extension_management
-            .project(package_ref.clone())
+            .project(package_ref.clone(), &caller)
             .await
             .map_err(slack_setup_activation_error)?;
         if projection.phase == LifecyclePhase::Discovered {
@@ -236,7 +239,7 @@ impl SlackChannelSetupActivation for DynamicSlackChannelSetupActivation {
         // activate path (WebUI activateExtension after the connect flow),
         // which routes through activate_with_credential_gate.
         self.extension_management
-            .activate(package_ref, ExtensionActivationMode::Static)
+            .activate(package_ref, ExtensionActivationMode::Static, &caller)
             .await
             .map_err(slack_setup_activation_error)?;
         Ok(())

--- a/crates/ironclaw_reborn_composition/src/webui.rs
+++ b/crates/ironclaw_reborn_composition/src/webui.rs
@@ -4,8 +4,10 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use chrono::Utc;
 
 use async_trait::async_trait;
-use ironclaw_extensions::SharedExtensionRegistry;
-use ironclaw_host_api::{EffectKind, InvocationId, ResourceScope};
+use ironclaw_extensions::{InstallationOwner, SharedExtensionRegistry};
+use ironclaw_host_api::{
+    EffectKind, ExtensionId, InvocationId, ResourceScope, RuntimeKind, UserId,
+};
 use ironclaw_product_adapters::ProjectionStream;
 use ironclaw_product_workflow::{
     ChannelConnectionFacade, ConnectableChannelsProductFacade, OperatorStatusService,
@@ -20,6 +22,7 @@ use ironclaw_product_workflow::{
 
 use ironclaw_triggers::TriggerRepository;
 
+use crate::extension_host::extension_lifecycle::RebornLocalExtensionManagementPort;
 use crate::{
     RebornAutomationProductFacade, RebornBuildError, RebornProductAuthServices, RebornReadiness,
     RebornReadinessDiagnostic, RebornReadinessDiagnosticStatus, RebornRuntime,
@@ -46,26 +49,84 @@ static SKILL_CONTENT_SAFETY: std::sync::LazyLock<ironclaw_safety::Sanitizer> =
 struct ActiveRegistryOperatorToolCatalog {
     registry: Arc<SharedExtensionRegistry>,
     synthetic_tools: Arc<[RebornOperatorToolInfo]>,
+    /// Source of the installation owner-by-extension map (#5459 P1). Present
+    /// for the local-dev runtime; `None` for assemblies without extension
+    /// management, where every registry tool is treated as tenant-shared
+    /// (there is no per-user install path to leak).
+    owner_source: Option<Arc<RebornLocalExtensionManagementPort>>,
 }
 
 impl ActiveRegistryOperatorToolCatalog {
     fn new(
         registry: Arc<SharedExtensionRegistry>,
         synthetic_tools: Vec<RebornOperatorToolInfo>,
+        owner_source: Option<Arc<RebornLocalExtensionManagementPort>>,
     ) -> Self {
         Self {
             registry,
             synthetic_tools: Arc::from(synthetic_tools),
+            owner_source,
         }
     }
 }
 
+/// Owner data available to one `list_operator_tools` read.
+enum OwnerVisibility {
+    /// No extension management wired: no per-user install path exists, so
+    /// every registry tool is tenant-shared (pre-#5459 behavior).
+    AllShared,
+    /// Owner-aware assembly with a healthy owner map.
+    Owners(std::collections::BTreeMap<ExtensionId, InstallationOwner>),
+    /// Owner-aware assembly whose owner map could not be read. Install-backed
+    /// tools must fail CLOSED — an empty map is indistinguishable from
+    /// "no private owners" (#5525 review).
+    Unavailable,
+}
+
+#[async_trait]
 impl RebornOperatorToolCatalog for ActiveRegistryOperatorToolCatalog {
-    fn list_operator_tools(&self) -> Vec<RebornOperatorToolInfo> {
-        let mut tools = self
-            .registry
-            .snapshot()
+    async fn list_operator_tools(&self, caller: &UserId) -> Vec<RebornOperatorToolInfo> {
+        // #5459 P1: the settings/tools catalog is read by any authenticated
+        // member, so it MUST hide another user's private tool. The global
+        // registry carries no owner, so join the installation owner map and
+        // keep an install-backed capability only when its provider's owner row
+        // says it is tenant-shared or owned by `caller`. Host-authored
+        // builtins (`FirstParty`/`System` runtime — kinds the manifest wire
+        // format cannot even declare) have no install path and stay visible.
+        let owner_by_extension = match &self.owner_source {
+            Some(port) => match port.installation_owners().await {
+                Ok(owners) => OwnerVisibility::Owners(owners),
+                Err(error) => {
+                    tracing::warn!(
+                        %error,
+                        "settings tool catalog could not read installation owners; \
+                         hiding install-backed registry tools for this read"
+                    );
+                    OwnerVisibility::Unavailable
+                }
+            },
+            None => OwnerVisibility::AllShared,
+        };
+        let snapshot = self.registry.snapshot();
+        let mut tools = snapshot
             .capabilities()
+            .filter(|descriptor| match &owner_by_extension {
+                OwnerVisibility::AllShared => true,
+                _ if matches!(
+                    descriptor.runtime,
+                    RuntimeKind::FirstParty | RuntimeKind::System
+                ) =>
+                {
+                    true
+                }
+                // Fail closed on a missing owner row: a published
+                // install-backed capability without one is anomalous and could
+                // be private (#5525 review).
+                OwnerVisibility::Owners(owners) => owners
+                    .get(&descriptor.provider)
+                    .is_some_and(|owner| owner.visible_to(caller)),
+                OwnerVisibility::Unavailable => false,
+            })
             .map(|descriptor| RebornOperatorToolInfo {
                 capability_id: descriptor.id.clone(),
                 provider: descriptor.provider.clone(),
@@ -249,6 +310,7 @@ pub(crate) fn build_webui_services_with_connectable_channels(
             Arc::new(ActiveRegistryOperatorToolCatalog::new(
                 tool_registry,
                 synthetic_operator_tools,
+                local_runtime.extension_management.clone(),
             )),
         );
         let mut lifecycle_facade =
@@ -971,35 +1033,47 @@ fn status_check(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use async_trait::async_trait;
     use ironclaw_extensions::{
-        ExtensionManifest, ExtensionPackage, ExtensionRegistry, ManifestSource,
+        ExtensionActivationState, ExtensionHealthSnapshot, ExtensionInstallation,
+        ExtensionInstallationError, ExtensionInstallationId, ExtensionInstallationStore,
+        ExtensionManifest, ExtensionManifestRecord, ExtensionPackage, ExtensionRegistry,
+        InMemoryExtensionInstallationStore, ManifestSource,
     };
     use ironclaw_filesystem::LocalFilesystem;
     use ironclaw_host_api::{
-        HostPath, HostPortCatalog, MountAlias, MountGrant, MountPermissions, MountView, TenantId,
-        UserId, VirtualPath,
+        ExtensionId, HostPath, HostPortCatalog, MountAlias, MountGrant, MountPermissions,
+        MountView, TenantId, UserId, VirtualPath,
     };
     use std::{path::Path, time::Duration};
 
-    #[test]
-    fn operator_tool_catalog_reads_shared_registry_updates() {
+    #[tokio::test]
+    async fn operator_tool_catalog_reads_shared_registry_updates() {
         let registry = Arc::new(SharedExtensionRegistry::new(ExtensionRegistry::new()));
         let synthetic_provider =
             outbound_delivery_synthetic_provider().expect("synthetic provider id");
+        // No owner source: every registry tool is tenant-visible (the
+        // assembly-without-extension-management case).
         let catalog = ActiveRegistryOperatorToolCatalog::new(
             Arc::clone(&registry),
             vec![
                 outbound_delivery_target_set_operator_tool_info(synthetic_provider.clone())
                     .expect("synthetic tool info"),
             ],
+            None,
         );
+        let caller = UserId::new("caller").expect("caller id");
 
         assert!(
-            catalog.list_operator_tools().iter().any(|tool| {
-                tool.capability_id.as_str()
-                    == crate::outbound::OUTBOUND_DELIVERY_TARGET_SET_CAPABILITY_ID
-                    && tool.provider == synthetic_provider
-            }),
+            catalog
+                .list_operator_tools(&caller)
+                .await
+                .iter()
+                .any(|tool| {
+                    tool.capability_id.as_str()
+                        == crate::outbound::OUTBOUND_DELIVERY_TARGET_SET_CAPABILITY_ID
+                        && tool.provider == synthetic_provider
+                }),
             "synthetic outbound delivery capability must use the Settings > Tools provider key"
         );
 
@@ -1007,7 +1081,7 @@ mod tests {
             .insert(test_extension_package("dynamic-tools", "echo"))
             .expect("insert dynamic extension");
 
-        let tools = catalog.list_operator_tools();
+        let tools = catalog.list_operator_tools(&caller).await;
 
         assert!(
             tools
@@ -1015,6 +1089,270 @@ mod tests {
                 .any(|tool| tool.capability_id.as_str() == "dynamic-tools.echo"),
             "catalog must read the shared registry at list time so lifecycle updates are visible"
         );
+    }
+
+    /// #5459 P1 leak fix: the settings/tools catalog is read by any
+    /// authenticated member, so it MUST hide another user's private tool. With
+    /// an owner source wired, `list_operator_tools(bob)` excludes alice's
+    /// private capability while `list_operator_tools(alice)` includes it; a
+    /// tenant-shared tool is visible to both. This is the caller-level pin for
+    /// the confirmed enumeration/metadata-disclosure blocker.
+    #[tokio::test]
+    async fn operator_tool_catalog_hides_foreign_private_tools() {
+        use crate::extension_host::available_extensions::AvailableExtensionCatalog;
+        use ironclaw_extensions::{ExtensionLifecycleService, ExtensionManifestRef};
+        use tokio::sync::Mutex;
+
+        fn manifest_record(ext: &str, capability: &str) -> ExtensionManifestRecord {
+            let toml = format!(
+                "schema_version = \"reborn.extension_manifest.v2\"\n\
+                 id = \"{ext}\"\nname = \"{ext}\"\nversion = \"0.1.0\"\n\
+                 description = \"test\"\ntrust = \"third_party\"\n\n\
+                 [runtime]\nkind = \"wasm\"\nmodule = \"wasm/{ext}.wasm\"\n\n\
+                 [[capabilities]]\nid = \"{ext}.{capability}\"\ndescription = \"{capability}\"\n\
+                 effects = [\"network\"]\ndefault_permission = \"ask\"\nvisibility = \"model\"\n\
+                 input_schema_ref = \"schemas/{capability}.input.json\"\n\
+                 output_schema_ref = \"schemas/{capability}.output.json\"\n"
+            );
+            ExtensionManifestRecord::from_toml(
+                toml,
+                ManifestSource::HostBundled,
+                &HostPortCatalog::empty(),
+                None,
+            )
+            .expect("manifest record")
+        }
+
+        let operator = UserId::new("operator").expect("operator id");
+        let alice = UserId::new("alice").expect("alice id");
+        let bob = UserId::new("bob").expect("bob id");
+
+        // Store: alice privately owns `market-data`; `hacker-news` is tenant-shared.
+        // Wrapped so the test can inject an owner-read failure (#5525 review).
+        let store = Arc::new(OwnerReadFailingStore::default());
+        for (ext, capability, owner) in [
+            (
+                "market-data",
+                "snp500",
+                InstallationOwner::user(alice.clone()),
+            ),
+            ("hacker-news", "top_stories", InstallationOwner::Tenant),
+        ] {
+            let ext_id = ExtensionId::new(ext).expect("ext id");
+            store
+                .upsert_manifest_and_installation(
+                    manifest_record(ext, capability),
+                    ExtensionInstallation::new(
+                        ExtensionInstallationId::new(ext).expect("installation id"),
+                        ext_id.clone(),
+                        ExtensionActivationState::Enabled,
+                        ExtensionManifestRef::new(ext_id, None),
+                        Vec::new(),
+                        Utc::now(),
+                        owner,
+                    )
+                    .expect("installation"),
+                )
+                .await
+                .expect("upsert manifest + installation");
+        }
+        let installation_store: Arc<dyn ExtensionInstallationStore> = store.clone();
+
+        // Registry the catalog reads: both extensions' capabilities are
+        // published, plus one anomalous capability with NO installation row.
+        let registry = Arc::new(SharedExtensionRegistry::new(ExtensionRegistry::new()));
+        registry
+            .insert(test_extension_package("market-data", "snp500"))
+            .expect("insert market-data");
+        registry
+            .insert(test_extension_package("hacker-news", "top_stories"))
+            .expect("insert hacker-news");
+        registry
+            .insert(test_extension_package("orphan-tool", "probe"))
+            .expect("insert orphan-tool");
+
+        let trust_policy = Arc::new(
+            ironclaw_trust::HostTrustPolicy::new(vec![
+                Box::new(ironclaw_trust::AdminConfig::new()),
+            ])
+            .expect("trust policy"),
+        );
+        let port = Arc::new(RebornLocalExtensionManagementPort::new(
+            Arc::new(LocalFilesystem::new()),
+            AvailableExtensionCatalog::from_packages(Vec::new()),
+            installation_store,
+            Arc::new(Mutex::new(ExtensionLifecycleService::new(
+                ExtensionRegistry::new(),
+            ))),
+            crate::extension_host::extension_lifecycle::ActiveExtensionPublisher::new(
+                Arc::clone(&registry),
+                trust_policy,
+                Arc::new(ironclaw_trust::InvalidationBus::new()),
+            ),
+            None,
+            operator,
+        ));
+
+        let catalog = ActiveRegistryOperatorToolCatalog::new(registry, Vec::new(), Some(port));
+
+        let ids_for = |tools: Vec<RebornOperatorToolInfo>| {
+            tools
+                .into_iter()
+                .map(|t| t.capability_id.as_str().to_string())
+                .collect::<Vec<_>>()
+        };
+        let bob_ids = ids_for(catalog.list_operator_tools(&bob).await);
+        assert!(
+            bob_ids.contains(&"hacker-news.top_stories".to_string()),
+            "tenant-shared tool must be visible to every member: {bob_ids:?}"
+        );
+        assert!(
+            !bob_ids.contains(&"market-data.snp500".to_string()),
+            "alice's PRIVATE tool must not appear in bob's settings/tools catalog: {bob_ids:?}"
+        );
+        assert!(
+            !bob_ids.contains(&"orphan-tool.probe".to_string()),
+            "an installable capability without an owner row must fail closed: {bob_ids:?}"
+        );
+
+        let alice_ids = ids_for(catalog.list_operator_tools(&alice).await);
+        assert!(
+            alice_ids.contains(&"market-data.snp500".to_string())
+                && alice_ids.contains(&"hacker-news.top_stories".to_string()),
+            "the owner sees her own private tool plus shared tools: {alice_ids:?}"
+        );
+        assert!(
+            !alice_ids.contains(&"orphan-tool.probe".to_string()),
+            "the owner-row fail-closed default applies to every caller: {alice_ids:?}"
+        );
+
+        // #5525 review: when the owner map cannot be read at all, the
+        // owner-aware assembly must hide every install-backed registry tool
+        // (fail closed) instead of treating the empty map as all-shared.
+        store
+            .fail_list_installations
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        let degraded_ids = ids_for(catalog.list_operator_tools(&bob).await);
+        assert!(
+            degraded_ids.is_empty(),
+            "unreadable owner data must hide install-backed registry tools: {degraded_ids:?}"
+        );
+
+        // The next healthy read recovers the shared surface.
+        let recovered_ids = ids_for(catalog.list_operator_tools(&bob).await);
+        assert!(
+            recovered_ids.contains(&"hacker-news.top_stories".to_string())
+                && !recovered_ids.contains(&"market-data.snp500".to_string()),
+            "a healthy re-read restores shared visibility only: {recovered_ids:?}"
+        );
+    }
+
+    /// Store wrapper that fails `list_installations` once when armed —
+    /// injects the owner-read failure the settings catalog must fail closed
+    /// on (#5525 review).
+    #[derive(Default)]
+    struct OwnerReadFailingStore {
+        inner: InMemoryExtensionInstallationStore,
+        fail_list_installations: std::sync::atomic::AtomicBool,
+    }
+
+    #[async_trait]
+    impl ExtensionInstallationStore for OwnerReadFailingStore {
+        async fn list_manifests(
+            &self,
+        ) -> Result<Vec<ExtensionManifestRecord>, ExtensionInstallationError> {
+            self.inner.list_manifests().await
+        }
+
+        async fn get_manifest(
+            &self,
+            extension_id: &ExtensionId,
+        ) -> Result<Option<ExtensionManifestRecord>, ExtensionInstallationError> {
+            self.inner.get_manifest(extension_id).await
+        }
+
+        async fn upsert_manifest(
+            &self,
+            manifest: ExtensionManifestRecord,
+        ) -> Result<(), ExtensionInstallationError> {
+            self.inner.upsert_manifest(manifest).await
+        }
+
+        async fn upsert_manifest_and_installation(
+            &self,
+            manifest: ExtensionManifestRecord,
+            installation: ExtensionInstallation,
+        ) -> Result<(), ExtensionInstallationError> {
+            self.inner
+                .upsert_manifest_and_installation(manifest, installation)
+                .await
+        }
+
+        async fn list_installations(
+            &self,
+        ) -> Result<Vec<ExtensionInstallation>, ExtensionInstallationError> {
+            if self
+                .fail_list_installations
+                .swap(false, std::sync::atomic::Ordering::SeqCst)
+            {
+                return Err(ExtensionInstallationError::InvalidInstallation {
+                    reason: "injected owner read failure".to_string(),
+                });
+            }
+            self.inner.list_installations().await
+        }
+
+        async fn list_enabled_installations(
+            &self,
+        ) -> Result<Vec<ExtensionInstallation>, ExtensionInstallationError> {
+            self.inner.list_enabled_installations().await
+        }
+
+        async fn get_installation(
+            &self,
+            installation_id: &ExtensionInstallationId,
+        ) -> Result<Option<ExtensionInstallation>, ExtensionInstallationError> {
+            self.inner.get_installation(installation_id).await
+        }
+
+        async fn upsert_installation(
+            &self,
+            installation: ExtensionInstallation,
+        ) -> Result<(), ExtensionInstallationError> {
+            self.inner.upsert_installation(installation).await
+        }
+
+        async fn set_activation_state(
+            &self,
+            installation_id: &ExtensionInstallationId,
+            state: ExtensionActivationState,
+        ) -> Result<(), ExtensionInstallationError> {
+            self.inner
+                .set_activation_state(installation_id, state)
+                .await
+        }
+
+        async fn delete_installation(
+            &self,
+            installation_id: &ExtensionInstallationId,
+        ) -> Result<(), ExtensionInstallationError> {
+            self.inner.delete_installation(installation_id).await
+        }
+
+        async fn delete_manifest(
+            &self,
+            extension_id: &ExtensionId,
+        ) -> Result<(), ExtensionInstallationError> {
+            self.inner.delete_manifest(extension_id).await
+        }
+
+        async fn update_health(
+            &self,
+            installation_id: &ExtensionInstallationId,
+            health: ExtensionHealthSnapshot,
+        ) -> Result<(), ExtensionInstallationError> {
+            self.inner.update_health(installation_id, health).await
+        }
     }
 
     #[tokio::test]

--- a/crates/ironclaw_reborn_migration/src/convert/extensions.rs
+++ b/crates/ironclaw_reborn_migration/src/convert/extensions.rs
@@ -26,9 +26,9 @@ use ironclaw::tools::wasm::{StoredWasmTool, ToolStatus, WasmToolStore};
 use ironclaw_extensions::{
     ExtensionActivationState, ExtensionCredentialBinding, ExtensionCredentialHandle,
     ExtensionInstallation, ExtensionInstallationId, ExtensionManifestRecord, ExtensionManifestRef,
-    HostApiContractRegistry, MANIFEST_SCHEMA_VERSION, ManifestSource,
+    HostApiContractRegistry, InstallationOwner, MANIFEST_SCHEMA_VERSION, ManifestSource,
 };
-use ironclaw_host_api::{ExtensionId, HostPortCatalog, SecretHandle};
+use ironclaw_host_api::{ExtensionId, HostPortCatalog, SecretHandle, UserId};
 use ironclaw_host_runtime::{default_host_api_contract_registry, default_host_port_catalog};
 
 use crate::error::MigrationError;
@@ -240,6 +240,21 @@ async fn convert_installation(
         }
     };
     let manifest_ref = ExtensionManifestRef::new(extension_id.clone(), None);
+    // v1 installs were per-user; carry that owner across so migrated tools stay
+    // private to their v1 owner under the #5459 P1 ownership model.
+    let owner = match UserId::new(input.owner) {
+        Ok(user_id) => InstallationOwner::user(user_id),
+        Err(e) => {
+            report.record_loss(
+                Domain::Extension,
+                &source_id,
+                "owner",
+                LossReason::Unparseable,
+                format!("invalid owner user id: {e}"),
+            );
+            return Ok(());
+        }
+    };
     let installation = match ExtensionInstallation::new(
         installation_id,
         extension_id,
@@ -247,6 +262,7 @@ async fn convert_installation(
         manifest_ref,
         input.bindings,
         input.updated_at,
+        owner,
     ) {
         Ok(installation) => installation,
         Err(e) => {

--- a/crates/ironclaw_webui_v2/frontend/src/i18n/en.ts
+++ b/crates/ironclaw_webui_v2/frontend/src/i18n/en.ts
@@ -1286,6 +1286,8 @@ registerPack("en", {
   "extensions.connect": "Connect",
   "extensions.configureName": "Configure {name}",
   "extensions.allInstalled": "All installed extensions",
+  "extensions.scope.shared": "shared",
+  "extensions.scope.private": "mine",
   "mcp.installed": "Installed MCP servers",
   "extensions.oneCapability": "1 capability",
   "extensions.pluralCapabilities": "{count} capabilities",

--- a/crates/ironclaw_webui_v2/frontend/src/pages/extensions/components/extension-card.tsx
+++ b/crates/ironclaw_webui_v2/frontend/src/pages/extensions/components/extension-card.tsx
@@ -226,6 +226,9 @@ export function ExtensionCard({ ext, onActivate, onConfigure, onRemove, isBusy }
 
       <div className={META}>
         <span>{kindLabel}</span>
+        {ext.install_scope && (
+          <span>· {t(`extensions.scope.${ext.install_scope}`) || ext.install_scope}</span>
+        )}
         {ext.version && (<span>· v{ext.version}</span>)}
       </div>
 

--- a/docs/plans/2026-07-01-private-tool-installs.md
+++ b/docs/plans/2026-07-01-private-tool-installs.md
@@ -5,39 +5,72 @@
 test-tool fixtures to exercise a privately installed "network + key"
 tool end-to-end).
 
-**Goal:** a regular user can install a WASM tool that only they see and
-can dispatch; an admin install stays tenant-wide (today's behavior,
-now explicit). Sibling PRs: #5499 (env-seeded tenant-shared
-credentials), #5513 (admin UI for the same credential rows).
+**Goal:** the tenant (operator) install makes a tool available to
+everyone; anyone else who installs a catalog tool gets it for
+themselves — and **any number of users can independently install the
+same tool**. A member's install is invisible and non-dispatchable to
+everyone who hasn't installed it. Sibling PRs: #5499 (env-seeded
+tenant-shared credentials), #5513 (admin UI for the same credential
+rows).
+
+## 2026-07-08 pivot: membership, not slots
+
+The first iteration of this plan (locked 2026-07-01, reviewed in
+#5525) modeled ownership as **one install slot per extension id per
+tenant** with admin-wins eviction. Manual testing killed it: with a
+tool privately installed by one member, every other user's install
+attempt failed with a masked "extension id unavailable" — surfaced in
+the WebUI as a bare "Validation" banner on a tool that *looked*
+installable (foreign private installs are deliberately invisible).
+Decision (Emil, 2026-07-08): that complexity buys nothing the product
+wants. The model is now **membership**:
+
+- One installation **row** per id (unchanged — the store keys by
+  `installation_id == extension_id`), but the owner is either `Tenant`
+  or a **set of member user ids**.
+- A member installing a tool that others already hold **joins the
+  member set**; the bundle is registered/materialized only once, by
+  the first installer.
+- **Admin-wins eviction survives as a semantic, not as machinery**
+  (Emil, 2026-07-08): an operator install still evicts every member's
+  private installation — but with one row per id, that eviction IS the
+  single write that replaces the member set with `Tenant`. The
+  snapshot/restore/compensation machinery of the slot iteration is
+  deleted, and with it the "unavailable" denial: a member's install of
+  a catalog tool now only fails for real reasons (already theirs, or
+  already tenant-shared).
+
+serrrfirat's #5525 review findings were fixes *within* the slot
+iteration, not a request for slots; the ones about masking, caller
+derivation, credential-preflight ordering, fail-closed owner
+visibility, and policy extraction carry over to the membership model
+unchanged. The eviction-compensation finding is moot (no eviction).
 
 ## Verified mechanism (recon receipts)
 
 - **Identity**: `ExtensionId` = manifest.toml `id`
-  (`available_extensions.rs:1579`); `ExtensionInstallationId::new(extension_id)`
-  — the installation id IS the extension id (`extension_lifecycle.rs:1133`),
-  so there is exactly one install slot per id per tenant.
-  `ensure_not_installed` (`extension_lifecycle.rs:~882`) already rejects
-  duplicates on both axes.
+  (`available_extensions.rs`); `ExtensionInstallationId::new(extension_id)`
+  — the installation id IS the extension id, so there is exactly one
+  installation **row** per id per tenant. That row now carries the
+  member set; it does not limit how many users hold the tool.
 - **Registry**: one global process-wide snapshot; `publish` upserts by
   `ExtensionId`; duplicate `CapabilityId` insert fails closed
-  (`ironclaw_extensions/src/registry.rs:73-79`). Capability ids are
-  validated `<extension_id>.<name>`-prefixed (`v2.rs:884-896`), so
-  renaming an id at install time would mean rewriting the bundle.
-  ⇒ same-id coexistence (shared + private) is NOT cheap; do slots, not
-  shadowing.
-- **Visibility/dispatch today = blanket per-request grant minting**, not
-  authorizer policy: `local_dev_visible_capability_request`
-  (`runtime/local_dev.rs:878-942`) mints a grant for EVERY active
-  capability to `Principal::Extension(loop_driver)` via
-  `extension_surface.grants(&extension_id)`
-  (`runtime/local_dev/extension_surface.rs:82-93`). The caller's
-  `user_id` is computed in the same function (`:894-899`) and unused for
-  filtering. ⇒ one choke point: filter grant minting by installation
-  owner. Grant absence = invisible in the surface AND denied at
-  dispatch — fail closed for free.
+  (`ironclaw_extensions/src/registry.rs`). Capability ids are
+  validated `<extension_id>.<name>`-prefixed. ⇒ the bundle is
+  published **once**; per-user visibility is enforced at grant
+  minting, not by duplicate registration. This is exactly why
+  membership is cheap where same-id *separate installs* were not.
+- **Visibility/dispatch = per-caller grant minting**:
+  `local_dev_visible_capability_request` mints grants via
+  `extension_surface.grants(&extension_id)` filtered by
+  `owner.visible_to(caller)`
+  (`runtime/local_dev/extension_surface.rs`). Grant absence =
+  invisible in the surface AND denied at dispatch — fail closed for
+  free. Membership only changes what `visible_to` checks (set
+  membership instead of single-owner equality).
 - **Persistence**: installations live in ONE snapshot file
-  `/tenants/<t>/system/extensions/.installations/state.json`
-  (`extension_installation_store.rs:12`). Owner becomes a field on the
+  (`.installations/state.json` under the tenant's extension root,
+  `extension_installation_store.rs`). Owner stays a field on the
   record, not a new store.
 - **Reserved first-party ids** (`github`, `notion`, `web-access`,
   `slack`, nearai, gsuite) are the SYSTEM tier of the id namespace;
@@ -46,147 +79,150 @@ credentials), #5513 (admin UI for the same credential rows).
 ## Locked decisions
 
 1. **Typed owner, no name prefixes.**
-   `InstallationOwner { Tenant, User(UserId) }` on `ExtensionInstallation`,
-   `#[serde(default)]` = `Tenant` so existing `state.json` rows
-   deserialize unchanged (no migration). The skills-style `shared-`
-   prefix does NOT transfer to tools: capability-id prefix validation
-   forces bundle rewrites, tool names are model-facing API (prefix churn
-   breaks routines on scope change), and a prefix wouldn't solve
-   user↔user collisions anyway (registry is global; skills never had
-   that problem because skill trees are per-user).
-2. **Slot rules — admin-wins eviction** (Emil, 2026-07-01):
+   `InstallationOwner { Tenant, Users { user_ids: BTreeSet<UserId> } }`
+   on `ExtensionInstallation`, `#[serde(default)]` = `Tenant` so
+   pre-#5459 `state.json` rows deserialize unchanged (no migration).
+   Rows written by the slot iteration (`{kind: "user", user_id}`)
+   deserialize as a singleton member set — dev homes created on this
+   branch keep loading. New writes serialize the set shape.
+2. **Install rules — join, don't gate** (Emil, 2026-07-08):
 
-   | Slot state | User installs same id | Admin installs same id |
+   | Row state | Member installs same id | Operator installs same id |
    |---|---|---|
-   | free | ✓ owned by `User(them)` | ✓ owned by `Tenant` |
-   | `Tenant`-owned | ✗ "already available as a shared tool" | ✗ already installed |
-   | `User(x)`-owned | ✗ generic "extension id unavailable" (don't leak the owner) | ✓ **evicts the private install**; tenant record takes the slot |
+   | no row | ✓ row created, `Users{them}` | ✓ `Tenant` |
+   | `Tenant` | ✗ "already installed" (it is already available to them) | ✗ "already installed" |
+   | `Users(S)`, caller ∈ S | ✗ "already installed" | — |
+   | `Users(S)`, caller ∉ S | ✓ **joins**: row becomes `Users(S ∪ {caller})` | ✓ **evicts every member's private installation**; the tenant row takes the id (members regain the tool through the shared install) |
 
-   Rationale: anti-squatting — a user can never reserve an id against
-   the org (imagine a private `gmail` blocking the admin) — and
-   self-healing escalation: two users want the same tool privately →
-   admin installs it shared → everyone gets it.
-3. **Supersede, don't destroy.** Eviction rewrites installation state
-   only (natural: the store keys by installation_id == extension_id, so
-   the tenant record overwrites the slot). The evicted user's wasm
-   artifacts and private credentials are NOT deleted. Credential
-   cleanup is a separate explicit route
-   (`product_auth_serve/lifecycle.rs`) — never wired into
-   install/remove/evict.
-4. **Credential continuity across eviction.** Secrets are keyed
-   `(owner scope, handle)`, decoupled from installations. After
-   eviction the resolver (`secret_owner_scope`, caller-first →
-   tenant-shared → AuthRequired) still finds the user's personal key
-   under the same handle — their key keeps winning for their calls.
-   Extension-id-keyed credential grants (OAuth `granted_extensions`)
-   keep matching because admin-wins preserves the id string.
-5. **UI: one list, badges.** Entries badged `shared` / `mine`; the
-   badge flip (mine → shared) is the MVP-sufficient eviction notice.
-6. **Admin signal** = `operator_webui_config` capability (env-owner
-   today; role-derived admin when P0 role wiring lands — resolve in one
-   place, don't re-derive per layer).
+   Join and evict-to-tenant are row-only updates: the package is
+   already registered, materialized, and (if enabled) published, so
+   there is nothing to compensate — eviction is one write replacing
+   the member set with `Tenant`, not a disable/deregister/republish
+   dance. Anti-squatting still holds: the operator can always take any
+   id tenant-wide, and nobody loses access when they do.
+3. **Remove = leave the set.** A member removing a tool they hold is
+   removed from the member set (row-only update; others keep the
+   tool). The **last** member leaving triggers the full teardown
+   (disable, deregister, unpublish, delete rows/files) — same
+   compensated path as today. `Tenant` rows stay operator-only to
+   remove. Non-members get the masked "is not installed" denial.
+4. **Masking stays, the install-path denial goes.** Non-members still
+   cannot see, activate, remove, or probe a tool they don't hold
+   (`ensure_caller_may_operate`, list filtering, credential-preflight
+   ordering — all unchanged from the #5525 review fixes). But install
+   by a non-member now *succeeds*, so the anti-enumeration property is
+   strictly stronger: the outcome of "install X" no longer depends on
+   whether someone else holds X.
+5. **Credential continuity, including across eviction.** Secrets are
+   keyed `(owner scope, handle)`, decoupled from installations. Each
+   member's dispatch resolves caller-first → tenant-shared →
+   AuthRequired (`secret_owner_scope`), so two members of the same
+   tool use their own keys (or the tenant-shared one) — and after an
+   operator install evicts their private installations, the resolver
+   still finds each user's personal key under the same handle, so
+   their key keeps winning for their calls. Extension-id-keyed
+   credential grants (OAuth `granted_extensions`) keep matching
+   because eviction preserves the id string. Unchanged from the slot
+   iteration.
+6. **UI: one list, badges.** Entries badged `shared` / `mine`
+   (`install_scope`: `Tenant` → shared, member set containing the
+   caller → mine). A tool held by others but not the caller appears
+   simply as installable — indistinguishable from a fresh tool, by
+   design.
+7. **Admin signal** = `operator_webui_config` capability (env-owner
+   today; role-derived admin when P0 role wiring lands — resolve in
+   one place, don't re-derive per layer).
 
 ## Implementation steps (test-first per step)
 
 1. `crates/ironclaw_extensions/src/installations.rs` —
-   `InstallationOwner` enum + field on `ExtensionInstallation`
-   (`#[serde(default)]` = Tenant). Tests: legacy JSON row (no field)
-   deserializes as Tenant; round-trip with `User(uid)`.
-2. `crates/ironclaw_reborn_composition/src/extension_lifecycle.rs` —
-   install derives owner from the caller (admin → Tenant, else
-   User); slot rules incl. admin-wins eviction; `installed_summaries`
-   filtered to tenant-owned + caller-owned. Tests through the lifecycle
-   facade: each row of the slot table; eviction preserves the evicted
-   user's secret rows.
-3. `active_model_visible_capabilities()`
-   (`RebornLocalExtensionManagementPort`) — carry owner per capability
-   (join from the installation record) into `ActiveExtensionCapability`.
-4. `runtime/local_dev/extension_surface.rs` — `grants()` /
-   `provider_trust()` take the caller's `user_id` (already computed at
-   the call site, `local_dev.rs:894-899`) and filter
-   `owner == Tenant || owner == User(caller)`.
-5. WebUI (`ironclaw_webui_v2` + `_static`) — `shared`/`mine` badge on
-   extension cards; install-button behavior per slot rules; thread the
-   admin flag one hop down into the lifecycle context (same shape as
-   the #5513 operator endpoint).
-6. Integration tests (through the caller, per
-   `tests/support/reborn/CLAUDE.md`): bob cannot SEE or DISPATCH
-   alice's private tool (fail-closed check on both the surface and
-   dispatch paths); admin install evicts alice's private install and
-   alice's personal credential still resolves; market-data fixture
-   installed privately still gates on missing key and runs with the
-   tenant-shared key.
+   `InstallationOwner::Users { user_ids }`; `user(uid)` constructor
+   builds a singleton set (keeps migration + fixture call sites);
+   `visible_to` = tenant or membership; join/leave helpers. Tests:
+   legacy no-field row → Tenant; slot-iteration `{kind:"user"}` row →
+   singleton set; set round-trip; tenant rows still serialize without
+   the field (rollback shape).
+2. `extension_host/extension_lifecycle/install_policy.rs` — replace
+   `decide_occupied_slot`/eviction-snapshot types with a pure
+   `decide_install(existing_owner, claimant)` →
+   `Fresh | Join | EvictToTenant | AlreadyInstalled`;
+   `ensure_caller_may_operate` checks membership. Delete
+   `EvictedPrivateInstall`.
+3. `extension_host/extension_lifecycle.rs` — install branches: fresh
+   (register + materialize + persist, existing compensation), join /
+   evict-to-tenant (row-only upsert). Remove branches: leave-set
+   (row-only) vs last-member full teardown. Delete
+   `ensure_slot_available` / `evict_private_installation` /
+   `restore_evicted_private_install` / `fail_install_restoring_evicted`.
+   `import_bundle`'s `ensure_not_installed` stays (a bundle cannot be
+   swapped under live installs).
+4. Projections — `installation_owners()` map, settings-tools catalog
+   filter, `install_scope_for_owner`, grants/provider-trust filtering:
+   all reduce to `visible_to`/membership; signatures unchanged.
+5. WebUI — badges unchanged; install-button shows for any catalog
+   tool the caller doesn't hold.
+6. Facade-level tests (`tests/private_install_tests.rs`): two members
+   independently install the same tool and both dispatch it;
+   non-member masked on activate/remove and list; member remove
+   leaves the other member intact; last-member remove tears down;
+   operator install evicts both members' private installs and both
+   keep access through the shared tool (with their own credentials
+   still resolving); command-path caller derivation (kept from #5525).
 
-## Adversarial review (2026-07-01, run wmg0t4d3w) — confirmed + resolved
+## Adversarial review (2026-07-01 slot iteration) — what carries over
 
-- **[blocker] settings/tools catalog leaked private tools** — the
-  `GET /api/webchat/v2/settings/tools` catalog
-  (`ActiveRegistryOperatorToolCatalog`) read the global registry with no
-  owner filter, so any member saw another user's private capability id +
-  metadata (dispatch stayed denied — grants are per-caller — but the
-  existence/metadata leaked). FIXED: `RebornOperatorToolCatalog::list_operator_tools`
-  is now `async` + caller-aware; the composition catalog joins
-  `installation_owners()` and drops foreign-private tools; `find_operator_tool`
-  masks them on the get/set-key paths too. Pinned by
-  `operator_tool_catalog_hides_foreign_private_tools` (webui.rs) +
-  `installation_owners` assert in `active_capabilities_carry_installation_owner`.
-- **[should-fix] eviction bricked the id on partial failure** — a tenant
-  install that failed after eviction deregistered the private package left
-  the id un-installable tenant-wide until restart. FIXED: eviction is now
-  retry-safe (tolerates an already-absent lifecycle package), so the admin's
-  retry heals the slot. Pinned by
-  `admin_install_retry_heals_after_eviction_then_persist_failure`.
-- **[minor] activate TOCTOU across hosted-MCP discovery** — ownership was
-  checked only in phase 1; the slot could change hands during the discovery
-  network call. FIXED: `activate_inner` re-runs `ensure_caller_may_operate`
-  after re-acquiring the lock, mapping a change to
-  `hosted_mcp_changed_during_discovery_error`.
-
-Two accepted tradeoffs (documented, not code-fixed — see below).
+- **[blocker] settings/tools catalog leaked private tools** — FIXED
+  and carried over: `RebornOperatorToolCatalog::list_operator_tools`
+  is caller-aware; the composition catalog joins
+  `installation_owners()` and drops foreign-private tools, failing
+  closed on unreadable owner data. Pinned by
+  `operator_tool_catalog_hides_foreign_private_tools` (webui.rs).
+- **[minor] activate TOCTOU across hosted-MCP discovery** — FIXED and
+  carried over: `activate_inner` re-runs `ensure_caller_may_operate`
+  after re-acquiring the lock.
+- **[should-fix] eviction bricked the id on partial failure** —
+  obsolete: eviction no longer exists; join/convert are single row
+  writes.
 
 ## Non-goals / phase 2
 
-- **Multi-user private installs of the same id** (alice AND bob both
-  privately holding `market-data`): requires owner-scoped registry keys
-  + caller-first-then-tenant dispatch resolution (the
-  `secret_owner_scope` precedence, applied to the registry). Only if
-  demanded; the admin-escalation path covers the common case.
+- **Per-user bundle versions** (alice and bob holding *different*
+  builds of the same id): the catalog holds one bundle per id;
+  membership shares it. Owner-scoped catalog/registry keys stay out
+  of scope.
 - **Per-user suppression** of a tenant-wide tool ("hide this shared
   tool for me").
 - **User-uploaded private tools ("bring your own").** `import` (zip →
   catalog) stays admin-only, and the `AvailableExtensionCatalog` is a
-  single tenant-global catalog, so a member can only privately *install*
-  a tool an admin already imported (or a bundled/first-party one) — they
+  single tenant-global catalog, so a member can only *install* a tool
+  an admin already imported (or a bundled/first-party one) — they
   cannot introduce a brand-new WASM tool that only they see. True BYO
   private tools would require owner-scoping the import + catalog-browse
-  layer (one level below P1's install-scope), plus keeping arbitrary-WASM
-  upload behind a deliberate capability gate. Deferred.
-- **Restore-on-admin-remove** (evicted private install coming back when
-  the admin removes the shared tool) — nice-to-have; MVP leaves the
-  user to reinstall.
+  layer, plus keeping arbitrary-WASM upload behind a deliberate
+  capability gate. Deferred.
 - **Skills** — same shared-vs-private axis, different mechanics; owned
   by the P4 plan (`shared-` prefix IS right there, per-user trees).
 
 ## Accepted tradeoffs (operator awareness / release notes)
 
-- **Rollback is a full outage once any private install exists.** Tenant
+- **Rollback is a full outage once any member install exists.** Tenant
   rows serialize byte-identical to pre-#5459 (owner field skipped when
-  `Tenant`), so a rollback loads a state.json holding only shared tools.
-  But a user-private row carries `owner: {kind: user, …}`, which an older
-  binary's `deny_unknown_fields` wire struct rejects — and the store fails
-  the WHOLE state.json load, so `serve` refuses to start until the file is
-  hand-edited. One member clicking "install" turns a rollback into an
-  outage. Flag in release notes; the real fix is a forward-compatible
-  older binary (out of scope here).
-- **SSO users (incl. real admins) always install private on this branch.**
-  The tenant-operator identity is the env-bearer `IRONCLAW_REBORN_WEBUI_USER_ID`;
-  SSO logins mint UUID user ids that never equal it, so every SSO user
-  derives `User(..)`: private installs only, cannot install/administer
-  shared tools, and — one behavior regression — cannot remove a
-  tenant-shared tool (new "only the tenant admin can remove" check) that
-  a browser user could remove pre-#5459. Matches decision 6 (env-owner
-  today, role-derived admin at P0); a private-install squat on a
-  first-party id is un-evictable from an SSO browser until P0 lands.
+  `Tenant`), so a rollback loads a state.json holding only shared
+  tools. But a member row carries `owner: {kind: users, …}`, which an
+  older binary's `deny_unknown_fields` wire struct rejects — and the
+  store fails the WHOLE state.json load, so `serve` refuses to start
+  until the file is hand-edited. One member clicking "install" turns a
+  rollback into an outage. Flag in release notes; the real fix is a
+  forward-compatible older binary (out of scope here).
+- **SSO users (incl. real admins) always install for themselves on
+  this branch.** The tenant-operator identity is the env-bearer
+  (`IRONCLAW_REBORN_WEBUI_USER_ID`); SSO logins mint UUID user ids
+  that never equal it, so every SSO user installs as a member —
+  cannot install shared tools tenant-wide and cannot remove a
+  tenant-shared tool (operator-only check). Under membership this is
+  no longer a functional wall (they can always get the tool for
+  themselves); the remaining gap is administrative and closes when P0
+  role wiring lands (decision 7).
 
 ## Known upstream issue (not this plan's problem)
 

--- a/docs/plans/2026-07-01-private-tool-installs.md
+++ b/docs/plans/2026-07-01-private-tool-installs.md
@@ -1,0 +1,195 @@
+# Per-user (private) tool installs — #5459 P1
+
+**Branch:** `zetyquickly/issue-5459-private-installs` (based on
+`zetyquickly/issue-5459` — needs the credential resolver + the three
+test-tool fixtures to exercise a privately installed "network + key"
+tool end-to-end).
+
+**Goal:** a regular user can install a WASM tool that only they see and
+can dispatch; an admin install stays tenant-wide (today's behavior,
+now explicit). Sibling PRs: #5499 (env-seeded tenant-shared
+credentials), #5513 (admin UI for the same credential rows).
+
+## Verified mechanism (recon receipts)
+
+- **Identity**: `ExtensionId` = manifest.toml `id`
+  (`available_extensions.rs:1579`); `ExtensionInstallationId::new(extension_id)`
+  — the installation id IS the extension id (`extension_lifecycle.rs:1133`),
+  so there is exactly one install slot per id per tenant.
+  `ensure_not_installed` (`extension_lifecycle.rs:~882`) already rejects
+  duplicates on both axes.
+- **Registry**: one global process-wide snapshot; `publish` upserts by
+  `ExtensionId`; duplicate `CapabilityId` insert fails closed
+  (`ironclaw_extensions/src/registry.rs:73-79`). Capability ids are
+  validated `<extension_id>.<name>`-prefixed (`v2.rs:884-896`), so
+  renaming an id at install time would mean rewriting the bundle.
+  ⇒ same-id coexistence (shared + private) is NOT cheap; do slots, not
+  shadowing.
+- **Visibility/dispatch today = blanket per-request grant minting**, not
+  authorizer policy: `local_dev_visible_capability_request`
+  (`runtime/local_dev.rs:878-942`) mints a grant for EVERY active
+  capability to `Principal::Extension(loop_driver)` via
+  `extension_surface.grants(&extension_id)`
+  (`runtime/local_dev/extension_surface.rs:82-93`). The caller's
+  `user_id` is computed in the same function (`:894-899`) and unused for
+  filtering. ⇒ one choke point: filter grant minting by installation
+  owner. Grant absence = invisible in the surface AND denied at
+  dispatch — fail closed for free.
+- **Persistence**: installations live in ONE snapshot file
+  `/tenants/<t>/system/extensions/.installations/state.json`
+  (`extension_installation_store.rs:12`). Owner becomes a field on the
+  record, not a new store.
+- **Reserved first-party ids** (`github`, `notion`, `web-access`,
+  `slack`, nearai, gsuite) are the SYSTEM tier of the id namespace;
+  import-path enforcement landed with the #5499 hardening commit.
+
+## Locked decisions
+
+1. **Typed owner, no name prefixes.**
+   `InstallationOwner { Tenant, User(UserId) }` on `ExtensionInstallation`,
+   `#[serde(default)]` = `Tenant` so existing `state.json` rows
+   deserialize unchanged (no migration). The skills-style `shared-`
+   prefix does NOT transfer to tools: capability-id prefix validation
+   forces bundle rewrites, tool names are model-facing API (prefix churn
+   breaks routines on scope change), and a prefix wouldn't solve
+   user↔user collisions anyway (registry is global; skills never had
+   that problem because skill trees are per-user).
+2. **Slot rules — admin-wins eviction** (Emil, 2026-07-01):
+
+   | Slot state | User installs same id | Admin installs same id |
+   |---|---|---|
+   | free | ✓ owned by `User(them)` | ✓ owned by `Tenant` |
+   | `Tenant`-owned | ✗ "already available as a shared tool" | ✗ already installed |
+   | `User(x)`-owned | ✗ generic "extension id unavailable" (don't leak the owner) | ✓ **evicts the private install**; tenant record takes the slot |
+
+   Rationale: anti-squatting — a user can never reserve an id against
+   the org (imagine a private `gmail` blocking the admin) — and
+   self-healing escalation: two users want the same tool privately →
+   admin installs it shared → everyone gets it.
+3. **Supersede, don't destroy.** Eviction rewrites installation state
+   only (natural: the store keys by installation_id == extension_id, so
+   the tenant record overwrites the slot). The evicted user's wasm
+   artifacts and private credentials are NOT deleted. Credential
+   cleanup is a separate explicit route
+   (`product_auth_serve/lifecycle.rs`) — never wired into
+   install/remove/evict.
+4. **Credential continuity across eviction.** Secrets are keyed
+   `(owner scope, handle)`, decoupled from installations. After
+   eviction the resolver (`secret_owner_scope`, caller-first →
+   tenant-shared → AuthRequired) still finds the user's personal key
+   under the same handle — their key keeps winning for their calls.
+   Extension-id-keyed credential grants (OAuth `granted_extensions`)
+   keep matching because admin-wins preserves the id string.
+5. **UI: one list, badges.** Entries badged `shared` / `mine`; the
+   badge flip (mine → shared) is the MVP-sufficient eviction notice.
+6. **Admin signal** = `operator_webui_config` capability (env-owner
+   today; role-derived admin when P0 role wiring lands — resolve in one
+   place, don't re-derive per layer).
+
+## Implementation steps (test-first per step)
+
+1. `crates/ironclaw_extensions/src/installations.rs` —
+   `InstallationOwner` enum + field on `ExtensionInstallation`
+   (`#[serde(default)]` = Tenant). Tests: legacy JSON row (no field)
+   deserializes as Tenant; round-trip with `User(uid)`.
+2. `crates/ironclaw_reborn_composition/src/extension_lifecycle.rs` —
+   install derives owner from the caller (admin → Tenant, else
+   User); slot rules incl. admin-wins eviction; `installed_summaries`
+   filtered to tenant-owned + caller-owned. Tests through the lifecycle
+   facade: each row of the slot table; eviction preserves the evicted
+   user's secret rows.
+3. `active_model_visible_capabilities()`
+   (`RebornLocalExtensionManagementPort`) — carry owner per capability
+   (join from the installation record) into `ActiveExtensionCapability`.
+4. `runtime/local_dev/extension_surface.rs` — `grants()` /
+   `provider_trust()` take the caller's `user_id` (already computed at
+   the call site, `local_dev.rs:894-899`) and filter
+   `owner == Tenant || owner == User(caller)`.
+5. WebUI (`ironclaw_webui_v2` + `_static`) — `shared`/`mine` badge on
+   extension cards; install-button behavior per slot rules; thread the
+   admin flag one hop down into the lifecycle context (same shape as
+   the #5513 operator endpoint).
+6. Integration tests (through the caller, per
+   `tests/support/reborn/CLAUDE.md`): bob cannot SEE or DISPATCH
+   alice's private tool (fail-closed check on both the surface and
+   dispatch paths); admin install evicts alice's private install and
+   alice's personal credential still resolves; market-data fixture
+   installed privately still gates on missing key and runs with the
+   tenant-shared key.
+
+## Adversarial review (2026-07-01, run wmg0t4d3w) — confirmed + resolved
+
+- **[blocker] settings/tools catalog leaked private tools** — the
+  `GET /api/webchat/v2/settings/tools` catalog
+  (`ActiveRegistryOperatorToolCatalog`) read the global registry with no
+  owner filter, so any member saw another user's private capability id +
+  metadata (dispatch stayed denied — grants are per-caller — but the
+  existence/metadata leaked). FIXED: `RebornOperatorToolCatalog::list_operator_tools`
+  is now `async` + caller-aware; the composition catalog joins
+  `installation_owners()` and drops foreign-private tools; `find_operator_tool`
+  masks them on the get/set-key paths too. Pinned by
+  `operator_tool_catalog_hides_foreign_private_tools` (webui.rs) +
+  `installation_owners` assert in `active_capabilities_carry_installation_owner`.
+- **[should-fix] eviction bricked the id on partial failure** — a tenant
+  install that failed after eviction deregistered the private package left
+  the id un-installable tenant-wide until restart. FIXED: eviction is now
+  retry-safe (tolerates an already-absent lifecycle package), so the admin's
+  retry heals the slot. Pinned by
+  `admin_install_retry_heals_after_eviction_then_persist_failure`.
+- **[minor] activate TOCTOU across hosted-MCP discovery** — ownership was
+  checked only in phase 1; the slot could change hands during the discovery
+  network call. FIXED: `activate_inner` re-runs `ensure_caller_may_operate`
+  after re-acquiring the lock, mapping a change to
+  `hosted_mcp_changed_during_discovery_error`.
+
+Two accepted tradeoffs (documented, not code-fixed — see below).
+
+## Non-goals / phase 2
+
+- **Multi-user private installs of the same id** (alice AND bob both
+  privately holding `market-data`): requires owner-scoped registry keys
+  + caller-first-then-tenant dispatch resolution (the
+  `secret_owner_scope` precedence, applied to the registry). Only if
+  demanded; the admin-escalation path covers the common case.
+- **Per-user suppression** of a tenant-wide tool ("hide this shared
+  tool for me").
+- **User-uploaded private tools ("bring your own").** `import` (zip →
+  catalog) stays admin-only, and the `AvailableExtensionCatalog` is a
+  single tenant-global catalog, so a member can only privately *install*
+  a tool an admin already imported (or a bundled/first-party one) — they
+  cannot introduce a brand-new WASM tool that only they see. True BYO
+  private tools would require owner-scoping the import + catalog-browse
+  layer (one level below P1's install-scope), plus keeping arbitrary-WASM
+  upload behind a deliberate capability gate. Deferred.
+- **Restore-on-admin-remove** (evicted private install coming back when
+  the admin removes the shared tool) — nice-to-have; MVP leaves the
+  user to reinstall.
+- **Skills** — same shared-vs-private axis, different mechanics; owned
+  by the P4 plan (`shared-` prefix IS right there, per-user trees).
+
+## Accepted tradeoffs (operator awareness / release notes)
+
+- **Rollback is a full outage once any private install exists.** Tenant
+  rows serialize byte-identical to pre-#5459 (owner field skipped when
+  `Tenant`), so a rollback loads a state.json holding only shared tools.
+  But a user-private row carries `owner: {kind: user, …}`, which an older
+  binary's `deny_unknown_fields` wire struct rejects — and the store fails
+  the WHOLE state.json load, so `serve` refuses to start until the file is
+  hand-edited. One member clicking "install" turns a rollback into an
+  outage. Flag in release notes; the real fix is a forward-compatible
+  older binary (out of scope here).
+- **SSO users (incl. real admins) always install private on this branch.**
+  The tenant-operator identity is the env-bearer `IRONCLAW_REBORN_WEBUI_USER_ID`;
+  SSO logins mint UUID user ids that never equal it, so every SSO user
+  derives `User(..)`: private installs only, cannot install/administer
+  shared tools, and — one behavior regression — cannot remove a
+  tenant-shared tool (new "only the tenant admin can remove" check) that
+  a browser user could remove pre-#5459. Matches decision 6 (env-owner
+  today, role-derived admin at P0); a private-install squat on a
+  first-party id is un-evictable from an SSO browser until P0 lands.
+
+## Known upstream issue (not this plan's problem)
+
+`projection::tests::live_progress_stream::skill_learned_bubble_delivers_when_sse_resumes_from_advanced_durable_cursor`
+fails deterministically at the branch's merge-base (inherited from
+main). Do not chase it here.

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -72,6 +72,13 @@ EMULATE_GITHUB_READY_TOKEN = EMULATE_GITHUB_BEARER
 EMULATE_STARTUP_ATTEMPTS = 120
 EMULATE_STARTUP_POLL_SECONDS = 0.5
 
+# test-tools/*.zip are git-ignored build artifacts (test-tools/README.md);
+# rebuild whenever a tool's manifest/schema/prompt/wasm-src changes so an
+# uploaded fixture always matches checked-in source.
+TEST_TOOLS_DIR = ROOT / "test-tools"
+BUILD_TEST_TOOLS_SCRIPT = ROOT / "scripts" / "build-test-tools.sh"
+TEST_TOOL_NAMES = ("ascii-renderer", "hacker-news", "market-data")
+
 
 def _latest_mtime(path: Path) -> float:
     """Return the newest mtime under a file or directory."""
@@ -198,6 +205,55 @@ def _emulate_unavailable(reason: str) -> None:
     if os.environ.get("CI") == "true":
         pytest.fail(reason)
     pytest.skip(reason)
+
+
+def _wasip2_target_missing() -> bool:
+    try:
+        installed = subprocess.run(
+            ["rustup", "target", "list", "--installed"],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=15,
+        ).stdout
+    except (OSError, subprocess.CalledProcessError):
+        return True
+    return "wasm32-wasip2" not in installed.split()
+
+
+def _test_tool_zip_stale(tool: str) -> bool:
+    zip_path = TEST_TOOLS_DIR / f"{tool}.zip"
+    if not zip_path.exists():
+        return True
+    # wasm-src/target/ is a build cache, not a source input; _latest_mtime
+    # already skips directories literally named "target".
+    return _latest_mtime(TEST_TOOLS_DIR / tool) > zip_path.stat().st_mtime
+
+
+@pytest.fixture(scope="session")
+def test_tool_zips() -> dict[str, Path]:
+    """Build (or reuse) the test-tools/*.zip fixture bundles.
+
+    Mirrors the `ironclaw_binary` staleness pattern: rebuild only the tools
+    whose manifest/schema/prompt/wasm-src changed since their zip was last
+    built, via `scripts/build-test-tools.sh`.
+    """
+    stale = [tool for tool in TEST_TOOL_NAMES if _test_tool_zip_stale(tool)]
+    if stale:
+        if _wasip2_target_missing():
+            _emulate_unavailable(
+                "wasm32-wasip2 target not installed "
+                "(run: rustup target add wasm32-wasip2) "
+                f"-- required to build test-tools/: {', '.join(stale)}"
+            )
+        print(f"Building test-tools/ fixtures (stale: {', '.join(stale)})...")
+        subprocess.run(
+            ["bash", str(BUILD_TEST_TOOLS_SCRIPT), *stale],
+            cwd=ROOT,
+            check=True,
+            timeout=300,
+        )
+    return {tool: TEST_TOOLS_DIR / f"{tool}.zip" for tool in TEST_TOOL_NAMES}
 
 
 def _forward_coverage_env(env: dict[str, str]) -> None:

--- a/tests/e2e/mock_llm.py
+++ b/tests/e2e/mock_llm.py
@@ -177,6 +177,33 @@ TOOL_CALL_PATTERNS = [
         lambda _: {"operation": "now"},
     ),
     (re.compile(r"echo (.+)", re.IGNORECASE), "echo", lambda m: {"message": m.group(1)}),
+    # Private tool installs (#5459 P1) — the three test-tools/ fixture bundles
+    # (test-tools/README.md). The provider-visible tool name sanitizes the
+    # dotted capability id's "." to "__" (`encode_provider_tool_name` in
+    # ironclaw_reborn::tool_disclosure); the model gateway's provider_tool_name
+    # validator rejects a raw "." outright ("only ASCII letters, digits, '_',
+    # and '-' are allowed"), so the mock LLM must emit the encoded form, not
+    # the dotted capability id.
+    # The combined pattern is checked first so it doesn't get shadowed by the
+    # single-tool "ascii renderer to draw a" pattern below.
+    (
+        re.compile(r"ascii renderer and market data", re.IGNORECASE),
+        "ascii-renderer__draw",
+        lambda _: [
+            {"tool_name": "ascii-renderer__draw", "arguments": {"subject": "robot"}},
+            {"tool_name": "market-data__snp500", "arguments": {}},
+        ],
+    ),
+    (
+        re.compile(r"ascii renderer to draw a (?P<subject>cat|dog|robot)", re.IGNORECASE),
+        "ascii-renderer__draw",
+        lambda m: {"subject": m.group("subject").lower()},
+    ),
+    (
+        re.compile(r"hacker news tool", re.IGNORECASE),
+        "hacker-news__top_stories",
+        lambda _: {},
+    ),
     # Reborn v2 download chips: one assistant turn writes a CSV and a PDF into
     # the project workspace. Reborn exposes this first-party tool by capability
     # id; the provider-facing tool name sanitizes dots as "__". After both

--- a/tests/e2e/reborn_coverage_tests.txt
+++ b/tests/e2e/reborn_coverage_tests.txt
@@ -28,3 +28,4 @@ tests/e2e/scenarios/test_reborn_responses_api.py::test_reborn_models_api_v1_alia
 tests/e2e/scenarios/test_reborn_responses_api.py::test_reborn_models_requires_auth
 tests/e2e/scenarios/test_reborn_webui_v2_legacy_responses_api.py
 tests/e2e/scenarios/test_admin_api.py
+tests/e2e/scenarios/test_reborn_private_tool_installs.py

--- a/tests/e2e/reborn_webui_harness.py
+++ b/tests/e2e/reborn_webui_harness.py
@@ -8,6 +8,7 @@ scenarios exercise the real Reborn binary without duplicating process plumbing.
 """
 
 import asyncio
+import json
 import os
 import signal
 import socket
@@ -25,6 +26,12 @@ YOLO_PROFILE = "local-dev-yolo"
 DEFAULT_MODEL = "mock-model"
 VISION_MODEL = "gpt-4o"
 ACCEPTED_SEND_OUTCOMES = {"submitted", "already_submitted"}
+
+# Shared tenant secret for the test-tools/market-data fixture (test-tools/README.md).
+# `IRONCLAW_REBORN_DEV_SECRET__<handle>` is read once at `serve` boot, so it must
+# be present in the process env before start — see
+# reborn_v2_private_installs_yolo_server below.
+MARKET_DATA_DEV_SECRET = "e2e-market-data-shared-key"
 
 
 def find_free_port() -> int:
@@ -226,6 +233,32 @@ async def reborn_v2_yolo_server(ironclaw_reborn_binary, mock_llm_server, tmp_pat
         home_dir=home_dir,
         profile=YOLO_PROFILE,
         log_prefix="reborn-v2-yolo",
+    )
+    await enable_reborn_global_auto_approve(base_url)
+    try:
+        yield base_url
+    finally:
+        await close_reborn_server(proc)
+
+
+@pytest.fixture(scope="module")
+async def reborn_v2_private_installs_yolo_server(
+    ironclaw_reborn_binary, mock_llm_server, tmp_path_factory
+):
+    """Yolo-profile server with the market-data tenant-shared dev secret seeded.
+
+    Used by the private-tool-installs scenario (#5459 P1): auto-approve so
+    installed third-party WASM capabilities dispatch without an approval
+    gate, plus the market-data fixture's shared API key present at boot.
+    """
+    home_dir = tmp_path_factory.mktemp("ironclaw-reborn-v2-private-installs-home")
+    proc, base_url = await start_reborn_webui_v2_server(
+        ironclaw_reborn_binary=ironclaw_reborn_binary,
+        mock_llm_server=mock_llm_server,
+        home_dir=home_dir,
+        profile=YOLO_PROFILE,
+        log_prefix="reborn-v2-private-installs-yolo",
+        extra_env={"IRONCLAW_REBORN_DEV_SECRET__market_data_api_key": MARKET_DATA_DEV_SECRET},
     )
     await enable_reborn_global_auto_approve(base_url)
     try:
@@ -444,6 +477,52 @@ async def wait_for_assistant_message(
 
     raise AssertionError(
         f"Timed out waiting for a finalized assistant message in thread {thread_id}. "
+        f"Last timeline: {last_timeline}"
+    )
+
+
+def capability_preview_payload(message: dict) -> dict | None:
+    """Parse a `capability_display_preview` timeline message's JSON content.
+
+    Returns `None` for any other message kind.
+    """
+    if message.get("kind") != "capability_display_preview":
+        return None
+    content = message.get("content")
+    assert isinstance(content, str), f"preview content must be a string: {message!r}"
+    try:
+        return json.loads(content)
+    except json.JSONDecodeError as error:
+        raise AssertionError(f"preview content is not valid JSON: {content!r}") from error
+
+
+async def wait_for_capability_preview(
+    client: httpx.AsyncClient,
+    base_url: str,
+    thread_id: str,
+    capability_id: str,
+    *,
+    output_fragment: str | None = None,
+    timeout: float = 45.0,
+) -> dict:
+    """Poll the timeline until a `capability_display_preview` for `capability_id`
+    appears (optionally containing `output_fragment` in its output)."""
+    last_timeline: dict = {}
+    deadline = asyncio.get_running_loop().time() + timeout
+    while asyncio.get_running_loop().time() < deadline:
+        last_timeline = await fetch_timeline(client, base_url, thread_id)
+        for message in last_timeline.get("messages", []):
+            preview = capability_preview_payload(message)
+            if not preview or preview.get("capability_id") != capability_id:
+                continue
+            output = preview.get("output_preview") or preview.get("output_summary") or ""
+            if output_fragment and output_fragment.lower() not in output.lower():
+                continue
+            return preview
+        await asyncio.sleep(0.25)
+
+    raise AssertionError(
+        f"Timed out waiting for {capability_id!r} preview in thread {thread_id}. "
         f"Last timeline: {last_timeline}"
     )
 

--- a/tests/e2e/scenarios/test_reborn_private_tool_installs.py
+++ b/tests/e2e/scenarios/test_reborn_private_tool_installs.py
@@ -1,0 +1,205 @@
+"""Private tool installs E2E (#5459 P1): import, install/activate, per-user
+membership visibility, and real tool dispatch — driven through the real
+``ironclaw-reborn serve`` binary.
+
+Pure httpx/API surface, like ``test_admin_api.py`` and
+``test_reborn_webui_v2_extensions_api.py``: the acceptance criteria here are
+server-side (capability dispatch, list visibility), not DOM rendering, so no
+Playwright ``page`` fixture is used.
+
+Scenario:
+
+1. Operator imports the three ``test-tools/`` fixture bundles
+   (``test-tools/README.md``).
+2. Operator installs + activates ``ascii-renderer`` tenant-wide (available to
+   everyone).
+3. Operator creates two member users, alice and bob, through the admin API.
+4. Alice privately installs + activates ``hacker-news``.
+5. Alice prompts for ``ascii-renderer`` (shared) and ``hacker-news`` (her
+   private install); both dispatch.
+6. Bob privately installs + activates ``market-data``.
+7. ``hacker-news`` (alice's private install) is absent from bob's extension
+   list — membership-scoped visibility, checked without prompting.
+8. Bob prompts for ``ascii-renderer`` (shared) and ``market-data`` (his
+   private install) in one turn; both dispatch.
+"""
+
+import uuid
+
+import httpx
+
+from reborn_webui_harness import (
+    create_thread,
+    reborn_bearer_headers,
+    reborn_v2_private_installs_yolo_server,  # noqa: F401 - imported fixture
+    send_message,
+    wait_for_capability_preview,
+)
+
+EXTENSIONS_BASE = "/api/webchat/v2/extensions"
+ADMIN_BASE = "/api/webchat/v2/admin"
+
+
+def _package_ref(tool_id: str) -> dict:
+    return {"kind": "extension", "id": tool_id}
+
+
+def _extension_ids(extensions: list[dict]) -> set[str]:
+    return {
+        extension["package_ref"]["id"]
+        for extension in extensions
+        if extension.get("package_ref", {}).get("id")
+    }
+
+
+async def _import_tool(client: httpx.AsyncClient, base_url: str, zip_path) -> None:
+    response = await client.post(
+        f"{base_url}{EXTENSIONS_BASE}/import",
+        content=zip_path.read_bytes(),
+        timeout=15,
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["success"] is True
+
+
+async def _install_and_activate(
+    client: httpx.AsyncClient, base_url: str, tool_id: str
+) -> None:
+    install = await client.post(
+        f"{base_url}{EXTENSIONS_BASE}/install",
+        json={"package_ref": _package_ref(tool_id)},
+        timeout=15,
+    )
+    assert install.status_code == 200, install.text
+    assert install.json()["success"] is True
+
+    activate = await client.post(
+        f"{base_url}{EXTENSIONS_BASE}/{tool_id}/activate",
+        timeout=15,
+    )
+    assert activate.status_code == 200, activate.text
+    assert activate.json()["success"] is True
+
+
+async def _create_member_user(
+    operator_client: httpx.AsyncClient, base_url: str, *, display_name: str
+) -> dict:
+    email = f"{display_name.lower()}-{uuid.uuid4().hex[:8]}@example.com"
+    response = await operator_client.post(
+        f"{base_url}{ADMIN_BASE}/users",
+        json={"display_name": display_name, "email": email, "role": "member"},
+        timeout=15,
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    return {"user_id": body["user"]["user_id"], "token": body["api_token"]}
+
+
+def _user_client(base_url: str, token: str) -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        base_url=base_url,
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=15,
+    )
+
+
+async def test_private_tool_installs_full_path(
+    reborn_v2_private_installs_yolo_server, test_tool_zips
+):
+    base_url = reborn_v2_private_installs_yolo_server
+
+    async with httpx.AsyncClient(
+        base_url=base_url, headers=reborn_bearer_headers(), timeout=15
+    ) as operator:
+        # 1. Operator imports the three test-tools/ fixture bundles.
+        for tool_id in ("ascii-renderer", "hacker-news", "market-data"):
+            await _import_tool(operator, base_url, test_tool_zips[tool_id])
+
+        # 2. Operator installs + activates ascii-renderer tenant-wide.
+        await _install_and_activate(operator, base_url, "ascii-renderer")
+
+        # 3. Operator creates alice and bob.
+        alice = await _create_member_user(operator, base_url, display_name="Alice")
+        bob = await _create_member_user(operator, base_url, display_name="Bob")
+
+    try:
+        async with _user_client(base_url, alice["token"]) as alice_client:
+            # 4. Alice privately installs + activates hacker-news.
+            await _install_and_activate(alice_client, base_url, "hacker-news")
+
+            # 5. Alice's ascii-renderer (shared) and hacker-news (her private
+            #    install) prompts both dispatch.
+            thread_id = await create_thread(alice_client, base_url)
+            await send_message(
+                alice_client,
+                base_url,
+                thread_id,
+                "let's use the ascii renderer to draw a cat",
+            )
+            ascii_preview = await wait_for_capability_preview(
+                alice_client,
+                base_url,
+                thread_id,
+                "ascii-renderer.draw",
+                output_fragment="cat",
+            )
+            assert ascii_preview["status"] == "completed", ascii_preview
+
+            await send_message(
+                alice_client, base_url, thread_id, "let's use the hacker news tool"
+            )
+            hn_preview = await wait_for_capability_preview(
+                alice_client,
+                base_url,
+                thread_id,
+                "hacker-news.top_stories",
+                output_fragment="canned fixture data",
+            )
+            assert hn_preview["status"] == "completed", hn_preview
+
+        async with _user_client(base_url, bob["token"]) as bob_client:
+            # 6. Bob privately installs + activates market-data.
+            await _install_and_activate(bob_client, base_url, "market-data")
+
+            # 7. Alice's private hacker-news install is invisible to bob —
+            #    a pure visibility check, no prompting needed.
+            bob_extensions = await bob_client.get(f"{base_url}{EXTENSIONS_BASE}", timeout=15)
+            assert bob_extensions.status_code == 200, bob_extensions.text
+            bob_ids = _extension_ids(bob_extensions.json()["extensions"])
+            assert "hacker-news" not in bob_ids
+            # The shared ascii-renderer and his own market-data ARE visible.
+            assert "ascii-renderer" in bob_ids
+            assert "market-data" in bob_ids
+
+            # 8. Bob's combined prompt dispatches both the shared
+            #    ascii-renderer and his private market-data install in the
+            #    same turn.
+            thread_id = await create_thread(bob_client, base_url)
+            await send_message(
+                bob_client,
+                base_url,
+                thread_id,
+                "let's use ascii renderer and market data",
+            )
+            ascii_preview = await wait_for_capability_preview(
+                bob_client,
+                base_url,
+                thread_id,
+                "ascii-renderer.draw",
+                output_fragment="robot",
+            )
+            market_preview = await wait_for_capability_preview(
+                bob_client,
+                base_url,
+                thread_id,
+                "market-data.snp500",
+                output_fragment="SPX",
+            )
+            assert ascii_preview["status"] == "completed", ascii_preview
+            assert market_preview["status"] == "completed", market_preview
+    finally:
+        async with httpx.AsyncClient(
+            base_url=base_url, headers=reborn_bearer_headers(), timeout=15
+        ) as operator:
+            await operator.delete(f"{base_url}{ADMIN_BASE}/users/{alice['user_id']}")
+            await operator.delete(f"{base_url}{ADMIN_BASE}/users/{bob['user_id']}")

--- a/tests/e2e/scenarios/test_reborn_webui_v2_legacy_tool_execution.py
+++ b/tests/e2e/scenarios/test_reborn_webui_v2_legacy_tool_execution.py
@@ -11,6 +11,7 @@ from playwright.async_api import expect
 from helpers import REBORN_V2_AUTH_TOKEN, SEL_V2
 from reborn_webui_harness import (
     USER_ID,
+    capability_preview_payload as _preview_payload,
     create_thread,
     fetch_timeline,
     reborn_bearer_headers,
@@ -20,55 +21,12 @@ from reborn_webui_harness import (
     reborn_v2_yolo_server,  # noqa: F401 - imported fixture
     send_message,
     wait_for_assistant_message,
+    wait_for_capability_preview as _wait_for_capability_preview,
 )
 
 
 EMPTY_REPLY_THREAD_ID = "thread-legacy-empty-reply"
 EMPTY_REPLY_RUN_ID = "22222222-3333-4444-5555-666666666666"
-
-
-def _preview_payload(message: dict) -> dict | None:
-    if message.get("kind") != "capability_display_preview":
-        return None
-    content = message.get("content")
-    assert isinstance(content, str), f"preview content must be a string: {message!r}"
-    try:
-        return json.loads(content)
-    except json.JSONDecodeError as error:
-        raise AssertionError(f"preview content is not valid JSON: {content!r}") from error
-
-
-async def _wait_for_capability_preview(
-    client: httpx.AsyncClient,
-    base_url: str,
-    thread_id: str,
-    capability_id: str,
-    *,
-    output_fragment: str | None = None,
-    timeout: float = 45.0,
-) -> dict:
-    last_timeline = {}
-    deadline = asyncio.get_running_loop().time() + timeout
-    while asyncio.get_running_loop().time() < deadline:
-        last_timeline = await fetch_timeline(client, base_url, thread_id)
-        for message in last_timeline.get("messages", []):
-            preview = _preview_payload(message)
-            if not preview or preview.get("capability_id") != capability_id:
-                continue
-            output = (
-                preview.get("output_preview")
-                or preview.get("output_summary")
-                or ""
-            )
-            if output_fragment and output_fragment.lower() not in output.lower():
-                continue
-            return preview
-        await asyncio.sleep(0.25)
-
-    raise AssertionError(
-        f"Timed out waiting for {capability_id!r} preview in thread {thread_id}. "
-        f"Last timeline: {last_timeline}"
-    )
 
 
 async def _install_fake_event_source(page):

--- a/tests/integration/webui_v2_product_api.rs
+++ b/tests/integration/webui_v2_product_api.rs
@@ -152,8 +152,14 @@ async fn thread_history_cold_get_after_in_memory_reopen() {
 /// via a production impl (no enabler needed).
 struct TestOperatorToolCatalog;
 
+#[async_trait::async_trait]
 impl RebornOperatorToolCatalog for TestOperatorToolCatalog {
-    fn list_operator_tools(&self) -> Vec<RebornOperatorToolInfo> {
+    // Caller-agnostic double; owner filtering is exercised by the
+    // composition-tier catalog test (#5459 P1).
+    async fn list_operator_tools(
+        &self,
+        _caller: &ironclaw_host_api::UserId,
+    ) -> Vec<RebornOperatorToolInfo> {
         vec![RebornOperatorToolInfo {
             capability_id: CapabilityId::new("builtin.http").expect("capability id"),
             provider: ExtensionId::new("builtin").expect("extension id"),


### PR DESCRIPTION
this PR allows private installation of a tool by SSO (non-admin) users.

if the admin imports the tool with a ZIP file, or there's any other "Available Extension" in **Extensions → Registry**, any private user can install and activate the tool for themselves — and it won't interfere with other users in the tenant, nor with the admin user.

## how ownership works

- **admin** (env-bearer operator) installs → **shared**: available to everyone in the tenant. this is the historical behavior, now explicit.
- a regular **SSO user** installs → **private**: only they see it and only they get it in their model surface. it is invisible and non-dispatchable to every other user (the admin included).
- **no per-tool install slots.** any number of users can install the same tool independently — each just joins the tool's member set on the one installation row. the bundle is registered/materialized once; per-user visibility is enforced at grant minting.
- if the **admin installs** an id that users already hold privately, the shared install **evicts** every private install and takes the tool tenant-wide — a user can't squat a name against the org, and nobody loses the tool (they reach it through the shared install). eviction is a single row rewrite (member set → tenant); the evicted users' own credentials/secrets are left untouched.
- **remove = leave the set**: a member removing a tool others still hold just drops out; the last holder's remove tears the install down. shared tools stay admin-only to remove.

enforcement is a single choke point: the owner is stamped on the installation and carried onto the tool's capabilities, and grants are minted per-caller — so a tool is both hidden from the surface and denied at dispatch for anyone who isn't a member (fail-closed). the Settings → Tools list is filtered the same way. cards show a `shared` / `mine` tag.

## not in this PR (deferred / known)

- users still can't **import** their own ZIP — import stays admin-only (arbitrary WASM upload is a deliberate boundary). a user privately installs from the admin-curated Registry.
- SSO users can install for themselves only; they can't create shared installs or remove a shared tool until the admin-role wiring lands (currently "admin" == the env-bearer operator).
- shared **credential accounts** (e.g. the NEAR AI token) are not shared to all users yet — only raw secret-handle keys (like the market-data fixture's) resolve tenant-shared. separate follow-up.

> **note:** an earlier revision of this PR used a one-slot-per-tool model (a private install blocked others from installing the same id). that was reworked to the membership model above — see 8911eddde and the pinned comment.

part of #5459.

🤖 Generated with [Claude Code](https://claude.com/claude-code)