### PR TITLE
fix(reborn-tests): resolve one-runtime owner-scope gap for multi-actor groups (E-MULTIUSER)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -366,6 +366,10 @@ name = "reborn_group_triggers"
 path = "tests/reborn_group_triggers/main.rs"
 
 [[test]]
+name = "reborn_group_multiuser"
+path = "tests/reborn_group_multiuser/main.rs"
+
+[[test]]
 name = "reborn_integration_oauth_refresh"
 required-features = ["libsql"]
 

--- a/tests/reborn_group_multiuser/main.rs
+++ b/tests/reborn_group_multiuser/main.rs
@@ -1,0 +1,37 @@
+//! Group integration test for FIX-5479 / E-MULTIUSER: a second, distinct
+//! actor submitting to its own thread over the group's ONE shared runtime.
+//!
+//! Before the fix, `RebornIntegrationGroupBuilder::into_group`'s shared
+//! runtime resolved every thread through a construction-time-fixed owner
+//! scope (the group's canonical/default actor), so any OTHER actor's turn
+//! failed deterministically with `driver_unavailable` / "unknown thread"
+//! (issue #5479). `with_actor_id` on `RebornThreadBuilder` is the seam that
+//! exercises a second owner over the shared runtime.
+
+#[allow(dead_code)]
+#[path = "../support/reborn/mod.rs"]
+mod reborn_support;
+#[allow(dead_code)]
+#[path = "../support/mod.rs"]
+mod support;
+
+mod scenario_two_actors_own_threads;
+
+use reborn_support::group::{RebornIntegrationGroup, ScenarioReport};
+
+#[tokio::test]
+async fn multiuser_group_e2e() {
+    let g = RebornIntegrationGroup::builtin_tools()
+        .await
+        .expect("group builds");
+    let mut report = ScenarioReport::new();
+
+    // Single scenario: two distinct actors, each completing a turn on their
+    // own thread over the SAME shared coordinator/scheduler/thread_service.
+    report.record(
+        "two_actors_own_threads",
+        scenario_two_actors_own_threads::run(&g).await,
+    );
+
+    report.assert_all_passed();
+}

--- a/tests/reborn_group_multiuser/scenario_two_actors_own_threads.rs
+++ b/tests/reborn_group_multiuser/scenario_two_actors_own_threads.rs
@@ -1,0 +1,72 @@
+//! Scenario: two distinct actors, each on their own thread, both complete a
+//! turn over the group's ONE shared runtime (Option P, #5465).
+//!
+//! FIX-5479 / E-MULTIUSER: the shared runtime resolves each turn's thread
+//! through a per-turn owner-scope rewrite (`ThreadScopeResolver::
+//! resolve_for_turn`, the same mechanism production already uses for
+//! multi-user WebChat) rather than a construction-time-fixed owner. Before
+//! the fix, any actor other than the group's canonical default actor failed
+//! deterministically with `driver_unavailable` / "unknown thread".
+
+use super::reborn_support::group::{HarnessResult, RebornIntegrationGroup};
+use super::reborn_support::reply::RebornScriptedReply;
+
+pub async fn run(g: &RebornIntegrationGroup) -> HarnessResult<()> {
+    // Thread A: the group's default actor (`HARNESS_ACTOR_ID`).
+    let a = g
+        .thread("conv-multiuser-a")
+        .script([RebornScriptedReply::text("reply-for-actor-a")])
+        .build()
+        .await?;
+    a.submit_turn("hello from actor a")
+        .await
+        .map_err(|e| format!("[step A submit] {e}"))?;
+    a.assert_reply_contains("reply-for-actor-a")
+        .await
+        .map_err(|e| format!("[step A assert] {e}"))?;
+
+    // Thread B: a DISTINCT actor over the SAME shared coordinator/scheduler/
+    // thread_service — this is exactly the path that previously raised
+    // `driver_unavailable` for any non-canonical owner.
+    let b = g
+        .thread("conv-multiuser-b")
+        .with_actor_id("reborn-actor-b")
+        .script([RebornScriptedReply::text("reply-for-actor-b")])
+        .build()
+        .await?;
+    // Non-vacuity pin: the seam must resolve a genuinely DISTINCT owner for
+    // thread B. If `with_actor_id` ever regressed to a no-op, both bindings
+    // would share the default actor's owner and this scenario would silently
+    // degrade to the already-covered one-actor/two-conversations case.
+    if a.binding.subject_user_id == b.binding.subject_user_id {
+        return Err("with_actor_id seam no-op: both threads resolved the same owner".into());
+    }
+
+    b.submit_turn("hello from actor b")
+        .await
+        .map_err(|e| format!("[step B submit] {e}"))?;
+    b.assert_reply_contains("reply-for-actor-b")
+        .await
+        .map_err(|e| format!("[step B assert] {e}"))?;
+
+    // Isolation negative guards (prove genuine owner separation, not just
+    // "didn't crash" — the banana-99 pattern):
+    // 1. Actor A's own thread must not surface actor B's reply.
+    if a.assert_reply_contains("reply-for-actor-b").await.is_ok() {
+        return Err("isolation failure: actor A's thread surfaced actor B's reply".into());
+    }
+    // 2. Actor B's thread must not be readable through actor A's owner scope
+    //    at all — B's records live under a separate `owners/<user>` subtree.
+    if a
+        .thread_harness
+        .history(b.binding.thread_id.clone())
+        .await
+        .is_ok()
+    {
+        return Err(
+            "isolation failure: actor B's thread is readable under actor A's owner scope".into(),
+        );
+    }
+
+    Ok(())
+}

--- a/tests/reborn_group_multiuser/scenario_two_actors_own_threads.rs
+++ b/tests/reborn_group_multiuser/scenario_two_actors_own_threads.rs
@@ -62,7 +62,8 @@ pub async fn run(g: &RebornIntegrationGroup) -> HarnessResult<()> {
 /// separation, not just "didn't crash" — the banana-99 pattern):
 /// `reader`'s own thread must not surface `other`'s reply, and `other`'s
 /// thread must not be readable through `reader`'s owner scope at all — each
-/// owner's records live under a separate `owners/<user>` subtree. One helper
+/// owner's records live under a separate `/tenants/<tenant>/users/<user>/threads`
+/// subtree. One helper
 /// called once per direction, so the symmetric check cannot silently de-sync.
 async fn assert_cannot_read_other_actor(
     reader: &RebornIntegrationHarness,

--- a/tests/reborn_group_multiuser/scenario_two_actors_own_threads.rs
+++ b/tests/reborn_group_multiuser/scenario_two_actors_own_threads.rs
@@ -8,6 +8,7 @@
 //! the fix, any actor other than the group's canonical default actor failed
 //! deterministically with `driver_unavailable` / "unknown thread".
 
+use super::reborn_support::builder::RebornIntegrationHarness;
 use super::reborn_support::group::{HarnessResult, RebornIntegrationGroup};
 use super::reborn_support::reply::RebornScriptedReply;
 
@@ -49,24 +50,44 @@ pub async fn run(g: &RebornIntegrationGroup) -> HarnessResult<()> {
         .await
         .map_err(|e| format!("[step B assert] {e}"))?;
 
-    // Isolation negative guards (prove genuine owner separation, not just
-    // "didn't crash" — the banana-99 pattern):
-    // 1. Actor A's own thread must not surface actor B's reply.
-    if a.assert_reply_contains("reply-for-actor-b").await.is_ok() {
-        return Err("isolation failure: actor A's thread surfaced actor B's reply".into());
+    // Isolation negative guards, SYMMETRIC both ways: neither actor's owner
+    // scope may surface the other's reply or read the other's thread history.
+    assert_cannot_read_other_actor(&a, "A", &b, "B", "reply-for-actor-b").await?;
+    assert_cannot_read_other_actor(&b, "B", &a, "A", "reply-for-actor-a").await?;
+
+    Ok(())
+}
+
+/// One direction of the owner-isolation negative guard (prove genuine owner
+/// separation, not just "didn't crash" — the banana-99 pattern):
+/// `reader`'s own thread must not surface `other`'s reply, and `other`'s
+/// thread must not be readable through `reader`'s owner scope at all — each
+/// owner's records live under a separate `owners/<user>` subtree. One helper
+/// called once per direction, so the symmetric check cannot silently de-sync.
+async fn assert_cannot_read_other_actor(
+    reader: &RebornIntegrationHarness,
+    reader_name: &str,
+    other: &RebornIntegrationHarness,
+    other_name: &str,
+    other_reply: &str,
+) -> HarnessResult<()> {
+    if reader.assert_reply_contains(other_reply).await.is_ok() {
+        return Err(format!(
+            "isolation failure: actor {reader_name}'s thread surfaced actor {other_name}'s reply"
+        )
+        .into());
     }
-    // 2. Actor B's thread must not be readable through actor A's owner scope
-    //    at all — B's records live under a separate `owners/<user>` subtree.
-    if a
+    if reader
         .thread_harness
-        .history(b.binding.thread_id.clone())
+        .history(other.binding.thread_id.clone())
         .await
         .is_ok()
     {
-        return Err(
-            "isolation failure: actor B's thread is readable under actor A's owner scope".into(),
-        );
+        return Err(format!(
+            "isolation failure: actor {other_name}'s thread is readable under actor \
+             {reader_name}'s owner scope"
+        )
+        .into());
     }
-
     Ok(())
 }

--- a/tests/support/reborn/CLAUDE.md
+++ b/tests/support/reborn/CLAUDE.md
@@ -378,6 +378,18 @@ pub async fn run(g: &RebornIntegrationGroup) -> HarnessResult<()> {
 | `RebornIntegrationGroup::triggers()` | trigger_create/list/pause/resume/remove | enabled |
 | `RebornIntegrationGroup::builder().storage(LibSql).live_approvals()` | same + LibSql storage | disabled |
 
+### Distinct actors per thread (E-MULTIUSER)
+
+`g.thread(conv).with_actor_id("some-actor")` resolves that thread's binding
+under a DISTINCT actor instead of the default `HARNESS_ACTOR_ID` — both at
+the build-time binding probe and at every `submit_turn` for that thread, so
+probe and submit always resolve the same binding/owner. The group's one
+shared runtime resolves each turn's thread by the run's own owner
+(production's `ThreadScopeResolver::resolve_for_turn` over the harness's
+per-op `/threads` mount), so two actors' threads coexist over one
+coordinator with their history isolated under separate `owners/<user>`
+subtrees. Driving test: `tests/reborn_group_multiuser/`.
+
 ### Key accessors on `RebornIntegrationGroup`
 
 - `turn_composite()` — the thread/turn `CompositeRootFilesystem`; use for

--- a/tests/support/reborn/CLAUDE.md
+++ b/tests/support/reborn/CLAUDE.md
@@ -387,8 +387,9 @@ probe and submit always resolve the same binding/owner. The group's one
 shared runtime resolves each turn's thread by the run's own owner
 (production's `ThreadScopeResolver::resolve_for_turn` over the harness's
 per-op `/threads` mount), so two actors' threads coexist over one
-coordinator with their history isolated under separate `owners/<user>`
-subtrees. Driving test: `tests/reborn_group_multiuser/`.
+coordinator with their history isolated under separate
+`/tenants/<tenant>/users/<user>/threads` subtrees. Driving test:
+`tests/reborn_group_multiuser/`.
 
 ### Key accessors on `RebornIntegrationGroup`
 

--- a/tests/support/reborn/builder.rs
+++ b/tests/support/reborn/builder.rs
@@ -309,11 +309,26 @@ pub struct RebornIntegrationHarness {
     pub(crate) ingress: RebornTestIngress,
     pub(crate) workflow: DefaultProductWorkflow,
     pub(crate) conversation_id: String,
-    /// External actor id every submit for this thread is made under. Defaults
-    /// to `HARNESS_ACTOR_ID`; a group thread built with `with_actor_id` (the
-    /// E-MULTIUSER seam) carries its distinct actor here so submit-time
-    /// envelopes resolve the SAME binding (and owner scope) as the build-time
-    /// probe.
+    /// External (raw, pre-resolution) actor id every submit for this thread is
+    /// made under. Defaults to `HARNESS_ACTOR_ID`; a group thread built with
+    /// `with_actor_id` (the E-MULTIUSER seam) carries its distinct actor here
+    /// so submit-time envelopes resolve the SAME binding (and owner scope) as
+    /// the build-time probe.
+    ///
+    /// NOT redundant with `binding.actor_user_id`: the binding's field is a
+    /// one-way SHA-256-derived opaque `UserId` (`user_id_for_binding` /
+    /// `scoped_id`, product_workflow.rs), while `verified_text_envelope_with_trigger`
+    /// (called by both the build-time probe and every submit) needs the raw,
+    /// pre-hash external actor-id string to compute the SAME `binding_path`
+    /// hash the probe persisted under. Substituting `binding.actor_user_id`
+    /// here would make submit resolve a *different*, unrelated binding (new
+    /// `actor_user_id`/`subject_user_id`, same `thread_id` since that hash is
+    /// actor-independent) instead of reusing this harness's own — silently
+    /// breaking every `submit_turn`/`submit_turn_async` call, not just the
+    /// multi-actor scenario. `binding.actor_user_id` IS the right source of
+    /// truth for `resume_run`'s `TurnActor` (an already-resolved identity, no
+    /// envelope round-trip involved) — that is a materially different use
+    /// case from this field's.
     pub(crate) actor_id: String,
     pub(crate) binding: ResolvedBinding,
     pub(crate) turn_scope: TurnScope,

--- a/tests/support/reborn/builder.rs
+++ b/tests/support/reborn/builder.rs
@@ -309,6 +309,12 @@ pub struct RebornIntegrationHarness {
     pub(crate) ingress: RebornTestIngress,
     pub(crate) workflow: DefaultProductWorkflow,
     pub(crate) conversation_id: String,
+    /// External actor id every submit for this thread is made under. Defaults
+    /// to `HARNESS_ACTOR_ID`; a group thread built with `with_actor_id` (the
+    /// E-MULTIUSER seam) carries its distinct actor here so submit-time
+    /// envelopes resolve the SAME binding (and owner scope) as the build-time
+    /// probe.
+    pub(crate) actor_id: String,
     pub(crate) binding: ResolvedBinding,
     pub(crate) turn_scope: TurnScope,
     pub(crate) turn_store: Arc<FilesystemTurnStateStore<HarnessTurnBackend>>,
@@ -385,7 +391,7 @@ impl RebornIntegrationHarness {
         let event_id = format!("evt-{}", self.event_seq.fetch_add(1, Ordering::Relaxed));
         let envelope = self.ingress.verified_text_envelope_with_trigger(
             &event_id,
-            HARNESS_ACTOR_ID,
+            &self.actor_id,
             &self.conversation_id,
             text,
             ProductTriggerReason::DirectChat,

--- a/tests/support/reborn/group.rs
+++ b/tests/support/reborn/group.rs
@@ -857,8 +857,13 @@ impl<'g> RebornThreadBuilder<'g> {
     /// thread's, so the run's `TurnActor` and per-turn owner-scope resolution
     /// (`ThreadScopeResolver::resolve_for_turn`, the same mechanism production
     /// uses for multi-user WebChat) isolate this thread's reads/writes under
-    /// its own `owners/<actor_id>` subtree. Unset (the default) keeps the
-    /// existing `HARNESS_ACTOR_ID` behavior byte-identical.
+    /// their own subtree. The owner axis of that subtree is the resolved
+    /// canonical `UserId` (`binding.subject_user_id` / `ThreadScope.owner_user_id`)
+    /// — NOT the external `actor_id` string passed here — the binding probe
+    /// maps this `actor_id` to that canonical user id once at build time, and
+    /// every subsequent op resolves its mount from the binding, not the raw
+    /// string. Unset (the default) keeps the existing `HARNESS_ACTOR_ID`
+    /// behavior byte-identical.
     pub fn with_actor_id(mut self, actor_id: impl Into<String>) -> Self {
         self.actor_id = Some(actor_id.into());
         self

--- a/tests/support/reborn/group.rs
+++ b/tests/support/reborn/group.rs
@@ -356,6 +356,7 @@ impl RebornIntegrationGroup {
             conversation_id: conversation_id.into(),
             replies: Vec::new(),
             park_gate: None,
+            actor_id: None,
         }
     }
 
@@ -825,6 +826,7 @@ pub struct RebornThreadBuilder<'g> {
     /// (E-GATEWAY seam), enabling a mid-turn cancel test. `None` = normal
     /// scripted playback.
     park_gate: Option<ParkingModelGate>,
+    actor_id: Option<String>,
 }
 
 impl<'g> RebornThreadBuilder<'g> {
@@ -849,6 +851,19 @@ impl<'g> RebornThreadBuilder<'g> {
         self
     }
 
+    /// Resolve this thread's binding under a DISTINCT actor instead of the
+    /// group's default `HARNESS_ACTOR_ID` (E-MULTIUSER seam). The resulting
+    /// binding's `subject_user_id`/`actor_user_id` differ from every other
+    /// thread's, so the run's `TurnActor` and per-turn owner-scope resolution
+    /// (`ThreadScopeResolver::resolve_for_turn`, the same mechanism production
+    /// uses for multi-user WebChat) isolate this thread's reads/writes under
+    /// its own `owners/<actor_id>` subtree. Unset (the default) keeps the
+    /// existing `HARNESS_ACTOR_ID` behavior byte-identical.
+    pub fn with_actor_id(mut self, actor_id: impl Into<String>) -> Self {
+        self.actor_id = Some(actor_id.into());
+        self
+    }
+
     /// Build the per-thread `RebornIntegrationHarness` over the group's shared
     /// storage and ONE shared planned runtime.
     ///
@@ -870,11 +885,12 @@ impl<'g> RebornThreadBuilder<'g> {
         // A fresh adapter + ingress each time (cheap, stateless). The binding
         // service is backed by `shared.product_harness`, which is shared; the
         // idempotency ledger is also shared (per-binding idempotency).
+        let actor_id = self.actor_id.as_deref().unwrap_or(HARNESS_ACTOR_ID);
         let adapter = RebornTestProductAdapter::new("reborn-itest", "itest-install")?;
         let ingress = RebornTestIngress::new(adapter);
         let probe = ingress.verified_text_envelope_with_trigger(
             "binding-probe",
-            HARNESS_ACTOR_ID,
+            actor_id,
             &self.conversation_id,
             "hi",
             ProductTriggerReason::DirectChat,
@@ -980,6 +996,7 @@ impl<'g> RebornThreadBuilder<'g> {
             ingress,
             workflow,
             conversation_id: self.conversation_id,
+            actor_id: actor_id.to_owned(),
             binding,
             turn_scope,
             turn_store: Arc::clone(&shared.turn_store),

--- a/tests/support/reborn/session_thread.rs
+++ b/tests/support/reborn/session_thread.rs
@@ -211,8 +211,11 @@ where
 /// through `ResourceScope::system()`) and owner-less thread scopes carry the
 /// `SYSTEM_RESERVED_ID` sentinel — control bytes, not path-safe — in the
 /// tenant and/or user segment. Map it to the harness's historical `_system`
-/// segment, mirroring production's `resource_scope_path_segment`
-/// (`invocation_mount_view`, ironclaw_reborn_composition).
+/// segment: this mirrors production's `resource_scope_path_segment`
+/// (`invocation_mount_view`, ironclaw_reborn_composition) only in SHAPE
+/// (sentinel-in, path-safe-segment-out) — production's actual segment value
+/// is `__system__`, not `_system`. Deliberately NOT switched to match, to
+/// avoid rewriting every existing harness fixture path; see `path_segment`.
 fn threads_mount_view(
     root_prefix: &str,
     scope: &ironclaw_host_api::ResourceScope,
@@ -228,8 +231,9 @@ fn threads_mount_view(
 }
 
 /// Path-safe segment for one scope axis: the `SYSTEM_RESERVED_ID` sentinel
-/// becomes the harness's historical `_system` segment; everything else is
-/// used verbatim (production's `resource_scope_path_segment` shape).
+/// becomes the harness's historical `_system` segment (NOT production's
+/// `__system__` value — see `threads_mount_view`); everything else is used
+/// verbatim, matching production's `resource_scope_path_segment` shape.
 fn path_segment(value: &str) -> &str {
     if value == ironclaw_host_api::SYSTEM_RESERVED_ID {
         "_system"

--- a/tests/support/reborn/session_thread.rs
+++ b/tests/support/reborn/session_thread.rs
@@ -237,3 +237,57 @@ fn path_segment(value: &str) -> &str {
         value
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use ironclaw_host_api::{AgentId, ResourceScope, SYSTEM_RESERVED_ID, TenantId};
+
+    use super::*;
+
+    /// Direct unit pin for `path_segment`'s sentinel mapping (review finding,
+    /// PR #5526): the `SYSTEM_RESERVED_ID` control-byte sentinel becomes the
+    /// path-safe `_system` segment; any ordinary id passes through unchanged.
+    #[test]
+    fn path_segment_maps_system_sentinel_to_system_segment() {
+        assert_eq!(path_segment(SYSTEM_RESERVED_ID), "_system");
+        assert_eq!(path_segment("tenant-real"), "tenant-real");
+    }
+
+    /// `ResourceScope::system()` (both tenant AND user are the sentinel, the
+    /// scope `find_idempotency_record` routes through) must mount under
+    /// `_system/_system`, not leak the raw control-byte sentinel into a
+    /// filesystem path.
+    #[test]
+    fn threads_mount_view_system_scope_mounts_under_system_segments() {
+        let view =
+            threads_mount_view("", &ResourceScope::system()).expect("system scope mount view");
+        assert_eq!(view.mounts.len(), 1);
+        assert_eq!(
+            view.mounts[0].target.as_str(),
+            "/tenants/_system/users/_system/threads"
+        );
+    }
+
+    /// An owner-less thread scope (`ThreadScope::to_resource_scope` with no
+    /// `owner_user_id` — system-scoped thread infrastructure with no owning
+    /// user) carries a REAL tenant but the sentinel only in the user segment.
+    /// Only the user axis should fall back to `_system`; the tenant axis must
+    /// resolve normally.
+    #[test]
+    fn threads_mount_view_owner_less_scope_mounts_only_user_segment_under_system() {
+        let owner_less = ThreadScope {
+            tenant_id: TenantId::new("tenant-owner-less").unwrap(),
+            agent_id: AgentId::new("agent-owner-less").unwrap(),
+            project_id: None,
+            owner_user_id: None,
+            mission_id: None,
+        }
+        .to_resource_scope();
+
+        let view = threads_mount_view("", &owner_less).expect("owner-less scope mount view");
+        assert_eq!(
+            view.mounts[0].target.as_str(),
+            "/tenants/tenant-owner-less/users/_system/threads"
+        );
+    }
+}

--- a/tests/support/reborn/session_thread.rs
+++ b/tests/support/reborn/session_thread.rs
@@ -59,8 +59,7 @@ where
 /// Shared methods: work for any `F: RootFilesystem`.
 impl<F: RootFilesystem> RebornThreadHarness<F> {
     pub fn reopened(&self) -> Result<Self, RebornThreadHarnessError> {
-        let scoped =
-            scoped_threads_fs_at(&self.root_prefix, Arc::clone(&self.backend), &self.scope)?;
+        let scoped = scoped_threads_fs_at(&self.root_prefix, Arc::clone(&self.backend))?;
         let service = Arc::new(FilesystemSessionThreadService::new(scoped));
         Ok(Self {
             scope: self.scope.clone(),
@@ -74,8 +73,7 @@ impl<F: RootFilesystem> RebornThreadHarness<F> {
     pub fn service_instance(
         &self,
     ) -> Result<FilesystemSessionThreadService<F>, RebornThreadHarnessError> {
-        let scoped =
-            scoped_threads_fs_at(&self.root_prefix, Arc::clone(&self.backend), &self.scope)?;
+        let scoped = scoped_threads_fs_at(&self.root_prefix, Arc::clone(&self.backend))?;
         Ok(FilesystemSessionThreadService::new(scoped))
     }
 
@@ -135,7 +133,7 @@ impl RebornThreadHarness<InMemoryBackend> {
         scope: ThreadScope,
         backend: Arc<InMemoryBackend>,
     ) -> Result<Self, RebornThreadHarnessError> {
-        let scoped = scoped_threads_fs_at("/engine", Arc::clone(&backend), &scope)?;
+        let scoped = scoped_threads_fs_at("/engine", Arc::clone(&backend))?;
         let service = Arc::new(FilesystemSessionThreadService::new(scoped));
         Ok(Self {
             scope,
@@ -163,7 +161,7 @@ impl RebornThreadHarness<CompositeRootFilesystem> {
         backend: Arc<CompositeRootFilesystem>,
         root: Arc<tempfile::TempDir>,
     ) -> Result<Self, RebornThreadHarnessError> {
-        let scoped = scoped_threads_fs_at("", Arc::clone(&backend), &scope)?;
+        let scoped = scoped_threads_fs_at("", Arc::clone(&backend))?;
         let service = Arc::new(FilesystemSessionThreadService::new(scoped));
         Ok(Self {
             scope,
@@ -175,7 +173,21 @@ impl RebornThreadHarness<CompositeRootFilesystem> {
     }
 }
 
-/// Build the scoped thread filesystem for `scope`.
+/// Build the scoped thread filesystem.
+///
+/// The `/threads` mount is resolved **per filesystem operation** from that
+/// operation's own `ResourceScope` (production's `invocation_mount_view`
+/// shape: `ScopedFilesystem::new` + resolver) — NOT fixed once at
+/// construction. `FilesystemSessionThreadService` derives each op's
+/// `ResourceScope` from the request's `ThreadScope` (owner included, via
+/// `ThreadScope::to_resource_scope`), so ONE service instance serves every
+/// owner's `/tenants/{t}/users/{owner}/threads` subtree. This is what lets a
+/// group's ONE shared runtime resolve a second actor's thread (issue #5479):
+/// the runtime's per-turn owner rewrite
+/// (`ThreadScopeResolver::resolve_for_turn`) now lands on the right physical
+/// root instead of a mount pinned to the group's canonical actor. For any
+/// single owner the resolved path is byte-identical to the previous fixed
+/// view, so single-actor tests are unaffected.
 ///
 /// `root_prefix` is prepended before `/tenants/...`:
 /// - Default `InMemoryBackend` tier: `"/engine"` → `/engine/tenants/{t}/users/{u}/threads`
@@ -183,23 +195,45 @@ impl RebornThreadHarness<CompositeRootFilesystem> {
 fn scoped_threads_fs_at<F>(
     root_prefix: &str,
     backend: Arc<F>,
-    scope: &ThreadScope,
 ) -> Result<Arc<ScopedFilesystem<F>>, ironclaw_host_api::HostApiError>
 where
     F: RootFilesystem,
 {
-    let user_id = scope
-        .owner_user_id
-        .as_ref()
-        .map_or("_system", |user_id| user_id.as_str());
-    let target = format!(
-        "{root_prefix}/tenants/{}/users/{}/threads",
-        scope.tenant_id, user_id
-    );
-    let mounts = MountView::new(vec![MountGrant::new(
-        MountAlias::new("/threads").expect("valid threads alias"),
-        VirtualPath::new(target).expect("valid threads target"),
+    let root_prefix = root_prefix.to_owned();
+    Ok(Arc::new(ScopedFilesystem::new(backend, move |scope| {
+        threads_mount_view(&root_prefix, scope)
+    })))
+}
+
+/// The single `/threads` mount grant for one operation's `ResourceScope`.
+///
+/// System-scoped operations (e.g. `find_idempotency_record`, which routes
+/// through `ResourceScope::system()`) and owner-less thread scopes carry the
+/// `SYSTEM_RESERVED_ID` sentinel — control bytes, not path-safe — in the
+/// tenant and/or user segment. Map it to the harness's historical `_system`
+/// segment, mirroring production's `resource_scope_path_segment`
+/// (`invocation_mount_view`, ironclaw_reborn_composition).
+fn threads_mount_view(
+    root_prefix: &str,
+    scope: &ironclaw_host_api::ResourceScope,
+) -> Result<MountView, ironclaw_host_api::HostApiError> {
+    let tenant_id = path_segment(scope.tenant_id.as_str());
+    let user_id = path_segment(scope.user_id.as_str());
+    let target = format!("{root_prefix}/tenants/{tenant_id}/users/{user_id}/threads");
+    MountView::new(vec![MountGrant::new(
+        MountAlias::new("/threads")?,
+        VirtualPath::new(target)?,
         MountPermissions::read_write_list_delete(),
-    )])?;
-    Ok(Arc::new(ScopedFilesystem::with_fixed_view(backend, mounts)))
+    )])
+}
+
+/// Path-safe segment for one scope axis: the `SYSTEM_RESERVED_ID` sentinel
+/// becomes the harness's historical `_system` segment; everything else is
+/// used verbatim (production's `resource_scope_path_segment` shape).
+fn path_segment(value: &str) -> &str {
+    if value == ironclaw_host_api::SYSTEM_RESERVED_ID {
+        "_system"
+    } else {
+        value
+    }
 }

--- a/tests/support/reborn/session_thread.rs
+++ b/tests/support/reborn/session_thread.rs
@@ -216,7 +216,7 @@ where
 /// (sentinel-in, path-safe-segment-out) — production's actual segment value
 /// is `__system__`, not `_system`. Deliberately NOT switched to match, to
 /// avoid rewriting every existing harness fixture path; see `path_segment`.
-fn threads_mount_view(
+pub(crate) fn threads_mount_view(
     root_prefix: &str,
     scope: &ironclaw_host_api::ResourceScope,
 ) -> Result<MountView, ironclaw_host_api::HostApiError> {
@@ -234,64 +234,10 @@ fn threads_mount_view(
 /// becomes the harness's historical `_system` segment (NOT production's
 /// `__system__` value — see `threads_mount_view`); everything else is used
 /// verbatim, matching production's `resource_scope_path_segment` shape.
-fn path_segment(value: &str) -> &str {
+pub(crate) fn path_segment(value: &str) -> &str {
     if value == ironclaw_host_api::SYSTEM_RESERVED_ID {
         "_system"
     } else {
         value
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use ironclaw_host_api::{AgentId, ResourceScope, SYSTEM_RESERVED_ID, TenantId};
-
-    use super::*;
-
-    /// Direct unit pin for `path_segment`'s sentinel mapping (review finding,
-    /// PR #5526): the `SYSTEM_RESERVED_ID` control-byte sentinel becomes the
-    /// path-safe `_system` segment; any ordinary id passes through unchanged.
-    #[test]
-    fn path_segment_maps_system_sentinel_to_system_segment() {
-        assert_eq!(path_segment(SYSTEM_RESERVED_ID), "_system");
-        assert_eq!(path_segment("tenant-real"), "tenant-real");
-    }
-
-    /// `ResourceScope::system()` (both tenant AND user are the sentinel, the
-    /// scope `find_idempotency_record` routes through) must mount under
-    /// `_system/_system`, not leak the raw control-byte sentinel into a
-    /// filesystem path.
-    #[test]
-    fn threads_mount_view_system_scope_mounts_under_system_segments() {
-        let view =
-            threads_mount_view("", &ResourceScope::system()).expect("system scope mount view");
-        assert_eq!(view.mounts.len(), 1);
-        assert_eq!(
-            view.mounts[0].target.as_str(),
-            "/tenants/_system/users/_system/threads"
-        );
-    }
-
-    /// An owner-less thread scope (`ThreadScope::to_resource_scope` with no
-    /// `owner_user_id` — system-scoped thread infrastructure with no owning
-    /// user) carries a REAL tenant but the sentinel only in the user segment.
-    /// Only the user axis should fall back to `_system`; the tenant axis must
-    /// resolve normally.
-    #[test]
-    fn threads_mount_view_owner_less_scope_mounts_only_user_segment_under_system() {
-        let owner_less = ThreadScope {
-            tenant_id: TenantId::new("tenant-owner-less").unwrap(),
-            agent_id: AgentId::new("agent-owner-less").unwrap(),
-            project_id: None,
-            owner_user_id: None,
-            mission_id: None,
-        }
-        .to_resource_scope();
-
-        let view = threads_mount_view("", &owner_less).expect("owner-less scope mount view");
-        assert_eq!(
-            view.mounts[0].target.as_str(),
-            "/tenants/tenant-owner-less/users/_system/threads"
-        );
     }
 }

--- a/tests/support_unit_tests.rs
+++ b/tests/support_unit_tests.rs
@@ -362,7 +362,7 @@ mod reborn_support_tests {
     };
 
     use async_trait::async_trait;
-    use ironclaw_filesystem::ScopedFilesystem;
+    use ironclaw_filesystem::{InMemoryBackend, ScopedFilesystem};
     use ironclaw_host_api::{
         AgentId, CapabilityId, InvocationId, MountAlias, MountGrant, MountPermissions, MountView,
         NetworkMethod, NetworkPolicy, NetworkTargetPattern, ProjectId, ResourceScope, TenantId,
@@ -1085,6 +1085,49 @@ mod reborn_support_tests {
             .assert_final_reply(ThreadId::new("thread-reopen").unwrap(), "assistant")
             .await
             .expect("reopened final reply");
+    }
+
+    #[tokio::test]
+    async fn filesystem_thread_harness_reopens_distinct_actor_scope() {
+        // Regression pin for E-MULTIUSER (#5479): before the fix, the
+        // `/threads` mount was resolved ONCE at construction
+        // (`ScopedFilesystem::with_fixed_view`), baking in whichever scope
+        // built the service first. Build a harness under a NON-default owner
+        // (distinct from every other test's shared "user-reborn-support"),
+        // write history, reopen a fresh service instance over the SAME
+        // backend under that SAME distinct owner, and confirm history is
+        // still readable — the reopened mount resolves the identical owner
+        // subtree. A sibling harness sharing the SAME backend but a
+        // DIFFERENT owner must not see it (proves subtree separation, not
+        // just "didn't crash" round-tripping).
+        let backend = Arc::new(InMemoryBackend::new());
+        let owner_a = RebornThreadHarness::filesystem_shared_backend(
+            thread_scope_with_owner("distinct-actor-reopen", "user-distinct-actor-a"),
+            Arc::clone(&backend),
+        )
+        .expect("owner-a thread harness");
+        let thread_id = write_thread_history(&owner_a).await;
+
+        let reopened_a = owner_a.reopened().expect("reopened owner-a harness");
+        let history = reopened_a
+            .history(thread_id.clone())
+            .await
+            .expect("reopened history under the same distinct owner");
+        assert_eq!(history.len(), 2);
+        reopened_a
+            .assert_final_reply(thread_id.clone(), "assistant")
+            .await
+            .expect("reopened final reply under the same distinct owner");
+
+        let owner_b = RebornThreadHarness::filesystem_shared_backend(
+            thread_scope_with_owner("distinct-actor-reopen", "user-distinct-actor-b"),
+            backend,
+        )
+        .expect("owner-b thread harness");
+        assert!(
+            owner_b.history(thread_id).await.is_err(),
+            "a distinct owner scope must not see owner-a's history after reopen"
+        );
     }
 
     #[tokio::test]
@@ -2168,11 +2211,17 @@ mod reborn_support_tests {
     }
 
     fn thread_scope(label: &str) -> ThreadScope {
+        thread_scope_with_owner(label, "user-reborn-support")
+    }
+
+    /// Like [`thread_scope`] but with a caller-chosen owner, so tests can pin
+    /// behavior for a non-default owner (E-MULTIUSER reopen coverage).
+    fn thread_scope_with_owner(label: &str, owner: &str) -> ThreadScope {
         ThreadScope {
             tenant_id: TenantId::new("tenant-reborn-support").unwrap(),
             agent_id: AgentId::new("agent-reborn-support").unwrap(),
             project_id: None,
-            owner_user_id: Some(UserId::new("user-reborn-support").unwrap()),
+            owner_user_id: Some(UserId::new(owner).unwrap()),
             mission_id: None,
         }
         .with_thread_label(label)

--- a/tests/support_unit_tests.rs
+++ b/tests/support_unit_tests.rs
@@ -2551,6 +2551,64 @@ mod reborn_support_tests {
 }
 
 // ---------------------------------------------------------------------------
+// reborn support: session_thread
+// ---------------------------------------------------------------------------
+
+mod session_thread_tests {
+    use ironclaw_host_api::{AgentId, ResourceScope, SYSTEM_RESERVED_ID, TenantId};
+    use ironclaw_threads::ThreadScope;
+
+    use crate::reborn_support::session_thread::{path_segment, threads_mount_view};
+
+    /// Direct unit pin for `path_segment`'s sentinel mapping: the
+    /// `SYSTEM_RESERVED_ID` control-byte sentinel becomes the path-safe
+    /// `_system` segment; any ordinary id passes through unchanged.
+    #[test]
+    fn path_segment_maps_system_sentinel_to_system_segment() {
+        assert_eq!(path_segment(SYSTEM_RESERVED_ID), "_system");
+        assert_eq!(path_segment("tenant-real"), "tenant-real");
+    }
+
+    /// `ResourceScope::system()` (both tenant AND user are the sentinel, the
+    /// scope `find_idempotency_record` routes through) must mount under
+    /// `_system/_system`, not leak the raw control-byte sentinel into a
+    /// filesystem path.
+    #[test]
+    fn threads_mount_view_system_scope_mounts_under_system_segments() {
+        let view =
+            threads_mount_view("", &ResourceScope::system()).expect("system scope mount view");
+        assert_eq!(view.mounts.len(), 1);
+        assert_eq!(
+            view.mounts[0].target.as_str(),
+            "/tenants/_system/users/_system/threads"
+        );
+    }
+
+    /// An owner-less thread scope (`ThreadScope::to_resource_scope` with no
+    /// `owner_user_id` — system-scoped thread infrastructure with no owning
+    /// user) carries a REAL tenant but the sentinel only in the user segment.
+    /// Only the user axis should fall back to `_system`; the tenant axis must
+    /// resolve normally.
+    #[test]
+    fn threads_mount_view_owner_less_scope_mounts_only_user_segment_under_system() {
+        let owner_less = ThreadScope {
+            tenant_id: TenantId::new("tenant-owner-less").unwrap(),
+            agent_id: AgentId::new("agent-owner-less").unwrap(),
+            project_id: None,
+            owner_user_id: None,
+            mission_id: None,
+        }
+        .to_resource_scope();
+
+        let view = threads_mount_view("", &owner_less).expect("owner-less scope mount view");
+        assert_eq!(
+            view.mounts[0].target.as_str(),
+            "/tenants/tenant-owner-less/users/_system/threads"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
 // trace_llm
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes #5479.

## Root cause — test-harness side; production is NOT buggy

The issue's "what's needed" items 1–2 already shipped in production (#5230): per-turn owner rewriting via `ThreadScopeResolver::resolve_for_turn` (`thread_scope.rs:41`, wired at `loop_driver_host.rs:1069` + `loop_exit_applier.rs:291`) and per-operation mount resolution (`invocation_mount_view`, composition `lib.rs:749`). Production serves multiple owners from one runtime today. Two harness defects made the group harness fail for a second actor:

1. **Frozen mount view** (`tests/support/reborn/session_thread.rs:183`): `scoped_threads_fs_at` used `ScopedFilesystem::with_fixed_view` — the `/threads` mount target was computed once at construction, baking the first owner into the shared runtime. Every actor's thread ops physically resolved through the canonical actor's subtree → the issue's `driver_unavailable`.
2. **Hardcoded submit identity** (`tests/support/reborn/builder.rs:403`): submit always used `HARNESS_ACTOR_ID`, so a thread probed as actor B submitted as actor A → `ScopeNotFound` one layer before the driver.

## Fix (test-support only — production untouched, verified via `git show --stat`)

- `session_thread.rs`: `/threads` mount now resolved **per operation** from that op's own `ResourceScope` (mirrors production's `invocation_mount_view`/`resource_scope_path_segment`, incl. the `SYSTEM_RESERVED_ID` sentinel needed by `ResourceScope::system()` idempotency reads). For any single owner the resolved path is byte-identical to before.
  - Mirror-not-reuse justification: the production helper is db-feature-gated; this tier must pass featureless.
- **E-MULTIUSER seam** (roadmap Tier-1): `RebornThreadBuilder::with_actor_id()`, threaded through both the build-time binding probe and every submit (new `actor_id` field on the harness). Default unset = byte-identical `HARNESS_ACTOR_ID` behavior.
- **Driving test**: new binary `tests/reborn_group_multiuser/` — two actors complete turns over ONE shared coordinator, with a non-vacuity pin (distinct `subject_user_id`s) and two negative isolation guards (A never surfaces B's reply; B's thread unreadable under A's owner scope).
- `tests/support/reborn/CLAUDE.md`: seam documented.

## RED→GREEN + mutation evidence

- RED 1 (seam incomplete): `ScopeNotFound` "turn run not found" — exposed defect 2.
- RED 2 (seam complete, mount fix absent): `SanitizedFailure { category: "driver_unavailable" }` — the issue's exact symptom.
- GREEN after the resolver fix.
- Mutation 1 (`with_actor_id` ignored): RED — "both threads resolved the same owner". Reverted.
- Mutation 2 (mount pinned to first-resolved scope — the pre-fix behavior class): RED with `driver_unavailable`. Reverted; bin re-verified green.

## Verification

- Full group suite (`cargo test --features libsql`, all 5 `reborn_group_*` bins): 3 full green runs (incl. post-rebase onto `3b222f9d4`/#5516), plus `reborn_integration_triggered_submit` — no flake.
- All 14 flat `reborn_integration_*` bins green (shared `session_thread.rs` plumbing touched).
- Clippy `--all --benches --tests --examples --all-features`: zero warnings from this diff; `cargo fmt` clean.

## Unlocks

C-MULTIUSER (full isolation matrix: memory / approvals / auto-approve non-leak) as the next, separate PR.

Note: `group.rs` (937 lines) and `builder.rs` (969) are approaching the 1000-line guardrail — the next seam PR should carry the planned `harness_auth.rs`-style split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)