### PR TITLE
[codex] instrument first-party tool latency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4512,6 +4512,7 @@ dependencies = [
  "ironclaw_extractors",
  "ironclaw_filesystem",
  "ironclaw_host_api",
+ "ironclaw_observability",
  "ironclaw_safety",
  "ironclaw_skills",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4859,6 +4859,7 @@ dependencies = [
 name = "ironclaw_observability"
 version = "0.1.0"
 dependencies = [
+ "serde_json",
  "tracing",
 ]
 

--- a/crates/ironclaw_first_party_extensions/Cargo.toml
+++ b/crates/ironclaw_first_party_extensions/Cargo.toml
@@ -21,6 +21,7 @@ ironclaw_auth = { path = "../ironclaw_auth" }
 ironclaw_extractors = { path = "../ironclaw_extractors" }
 ironclaw_filesystem = { path = "../ironclaw_filesystem" }
 ironclaw_host_api = { path = "../ironclaw_host_api" }
+ironclaw_observability = { path = "../ironclaw_observability" }
 ironclaw_safety = { path = "../ironclaw_safety" }
 ironclaw_skills = { path = "../ironclaw_skills" }
 regex = "1"

--- a/crates/ironclaw_first_party_extensions/src/coding/mod.rs
+++ b/crates/ironclaw_first_party_extensions/src/coding/mod.rs
@@ -20,9 +20,15 @@ use std::sync::Arc;
 
 use ironclaw_filesystem::RootFilesystem;
 use ironclaw_host_api::{
-    CapabilityDisplayOutputPreview, MountView, ResourceScope, RuntimeDispatchErrorKind,
+    CapabilityDisplayOutputPreview, CapabilityId, MountView, ResourceScope,
+    RuntimeDispatchErrorKind,
 };
 use serde_json::Value;
+
+use crate::latency::{
+    FirstPartyToolLatencyFields, FirstPartyToolLatencyMetrics, json_bytes, started_at,
+    trace_tool_error, trace_tool_ok,
+};
 
 use state::SharedCodingEditLocks;
 
@@ -36,8 +42,22 @@ pub enum CodingCapabilityKind {
     ApplyPatch,
 }
 
+impl CodingCapabilityKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::ReadFile => "read_file",
+            Self::WriteFile => "write_file",
+            Self::ListDir => "list_dir",
+            Self::Glob => "glob",
+            Self::Grep => "grep",
+            Self::ApplyPatch => "apply_patch",
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct CodingCapabilityRequest<'a> {
+    pub(crate) capability_id: &'a CapabilityId,
     pub(crate) kind: CodingCapabilityKind,
     pub(crate) scope: &'a ResourceScope,
     pub(crate) mounts: Option<&'a MountView>,
@@ -72,6 +92,7 @@ impl CodingCapabilityOutput {
 
 impl<'a> CodingCapabilityRequest<'a> {
     pub fn new(
+        capability_id: &'a CapabilityId,
         kind: CodingCapabilityKind,
         scope: &'a ResourceScope,
         mounts: Option<&'a MountView>,
@@ -79,6 +100,7 @@ impl<'a> CodingCapabilityRequest<'a> {
         input: &'a Value,
     ) -> Self {
         Self {
+            capability_id,
             kind,
             scope,
             mounts,
@@ -140,7 +162,13 @@ async fn dispatch(
     request: &CodingCapabilityRequest<'_>,
     edit_locks: &SharedCodingEditLocks,
 ) -> Result<CodingCapabilityOutput, CodingCapabilityError> {
-    match request.kind {
+    let started_at = started_at();
+    let latency_fields = FirstPartyToolLatencyFields::from_input(
+        request.capability_id,
+        request.scope,
+        request.input,
+    );
+    let result = match request.kind {
         CodingCapabilityKind::ReadFile => file::read_file(request)
             .await
             .map(CodingCapabilityOutput::new),
@@ -155,6 +183,45 @@ async fn dispatch(
             .await
             .map(CodingCapabilityOutput::new),
         CodingCapabilityKind::ApplyPatch => file::apply_patch(request, edit_locks).await,
+    };
+    trace_coding_latency(request, latency_fields.as_ref(), started_at, &result);
+    result
+}
+
+fn trace_coding_latency(
+    request: &CodingCapabilityRequest<'_>,
+    fields: Option<&FirstPartyToolLatencyFields>,
+    started_at: Option<std::time::Instant>,
+    result: &Result<CodingCapabilityOutput, CodingCapabilityError>,
+) {
+    let output_bytes = result
+        .as_ref()
+        .ok()
+        .map(|output| json_bytes(&output.output))
+        .unwrap_or(0);
+
+    match result {
+        Ok(_) => trace_tool_ok(
+            "first_party_coding_tool",
+            request.kind.as_str(),
+            fields,
+            started_at,
+            FirstPartyToolLatencyMetrics {
+                output_bytes,
+                ..FirstPartyToolLatencyMetrics::default()
+            },
+        ),
+        Err(error) => trace_tool_error(
+            "first_party_coding_tool",
+            request.kind.as_str(),
+            fields,
+            started_at,
+            error.kind().as_str(),
+            FirstPartyToolLatencyMetrics {
+                output_bytes,
+                ..FirstPartyToolLatencyMetrics::default()
+            },
+        ),
     }
 }
 
@@ -191,8 +258,8 @@ mod tests {
 
     use ironclaw_filesystem::{LocalFilesystem, RootFilesystem};
     use ironclaw_host_api::{
-        HostPath, InvocationId, MountAlias, MountGrant, MountPermissions, MountView, ResourceScope,
-        RuntimeDispatchErrorKind, UserId, VirtualPath,
+        CapabilityId, HostPath, InvocationId, MountAlias, MountGrant, MountPermissions, MountView,
+        ResourceScope, RuntimeDispatchErrorKind, UserId, VirtualPath,
     };
     use serde_json::json;
 
@@ -243,12 +310,15 @@ mod tests {
         )
         .expect("resource scope");
         let state = super::CodingCapabilityState::default();
+        let write_capability_id = CapabilityId::new("builtin.write_file").expect("capability id");
+        let read_capability_id = CapabilityId::new("builtin.read_file").expect("capability id");
 
         let write_input = json!({
             "path": "workspace/demo/a.txt",
             "content": "hello"
         });
         let write_request = super::CodingCapabilityRequest::new(
+            &write_capability_id,
             super::CodingCapabilityKind::WriteFile,
             &scope,
             Some(&mounts),
@@ -295,6 +365,7 @@ mod tests {
 
         let read_input = json!({ "path": "workspace/demo/a.txt" });
         let read_request = super::CodingCapabilityRequest::new(
+            &read_capability_id,
             super::CodingCapabilityKind::ReadFile,
             &scope,
             Some(&mounts),
@@ -317,6 +388,7 @@ mod tests {
             "content": "blocked"
         });
         let url_like_request = super::CodingCapabilityRequest::new(
+            &write_capability_id,
             super::CodingCapabilityKind::WriteFile,
             &scope,
             Some(&mounts),
@@ -342,6 +414,7 @@ mod tests {
             "content": "blocked"
         });
         let reserved_workspace_file_request = super::CodingCapabilityRequest::new(
+            &write_capability_id,
             super::CodingCapabilityKind::WriteFile,
             &scope,
             Some(&mounts),

--- a/crates/ironclaw_first_party_extensions/src/gsuite/handlers.rs
+++ b/crates/ironclaw_first_party_extensions/src/gsuite/handlers.rs
@@ -33,6 +33,10 @@ use crate::gsuite::{
     },
     network::google_api_network_policy,
 };
+use crate::latency::{
+    FirstPartyToolLatencyFields, FirstPartyToolLatencyMetrics, json_bytes, started_at,
+    trace_tool_error, trace_tool_ok,
+};
 
 mod calendar_list_events;
 
@@ -62,6 +66,52 @@ pub struct GsuiteExecutor {
     credential_stager: Arc<dyn GsuiteCredentialStager>,
 }
 
+fn gsuite_latency_started_at() -> Option<std::time::Instant> {
+    started_at()
+}
+
+fn trace_gsuite_latency_ok(
+    operation: &'static str,
+    fields: Option<&FirstPartyToolLatencyFields>,
+    started_at: Option<std::time::Instant>,
+    network_egress_bytes: u64,
+    output_bytes: u64,
+) {
+    trace_tool_ok(
+        "gsuite_first_party_tool",
+        operation,
+        fields,
+        started_at,
+        FirstPartyToolLatencyMetrics {
+            network_egress_bytes,
+            output_bytes,
+            ..FirstPartyToolLatencyMetrics::default()
+        },
+    );
+}
+
+fn trace_gsuite_latency_error(
+    operation: &'static str,
+    fields: Option<&FirstPartyToolLatencyFields>,
+    started_at: Option<std::time::Instant>,
+    error_kind: &str,
+    network_egress_bytes: u64,
+    output_bytes: u64,
+) {
+    trace_tool_error(
+        "gsuite_first_party_tool",
+        operation,
+        fields,
+        started_at,
+        error_kind,
+        FirstPartyToolLatencyMetrics {
+            network_egress_bytes,
+            output_bytes,
+            ..FirstPartyToolLatencyMetrics::default()
+        },
+    );
+}
+
 impl GsuiteExecutor {
     pub fn new(
         accounts: Arc<dyn CredentialAccountService>,
@@ -78,6 +128,11 @@ impl GsuiteExecutor {
         &self,
         request: GsuiteDispatchRequest<'_>,
     ) -> Result<GsuiteDispatchResult, GsuiteDispatchError> {
+        let latency_fields = FirstPartyToolLatencyFields::from_input(
+            request.capability_id,
+            request.scope,
+            request.input,
+        );
         let started = Instant::now();
         let (package, capability) = find_gsuite_capability(request.capability_id.as_str())
             .ok_or_else(|| {
@@ -86,27 +141,122 @@ impl GsuiteExecutor {
         let extension = ExtensionId::new(package.extension_id)
             .map_err(|_| GsuiteDispatchError::new(RuntimeDispatchErrorKind::Backend))?;
         let scopes = required_provider_scopes(capability)?;
-        let credential = self
+        let resolve_credential_started_at = gsuite_latency_started_at();
+        let credential = match self
             .resolver
             .resolve(request.scope, &extension, &scopes)
             .await
-            .map_err(map_credential_error)?;
+        {
+            Ok(credential) => {
+                trace_gsuite_latency_ok(
+                    "resolve_credential",
+                    latency_fields.as_ref(),
+                    resolve_credential_started_at,
+                    0,
+                    0,
+                );
+                credential
+            }
+            Err(error) => {
+                let error = map_credential_error(error);
+                trace_gsuite_latency_error(
+                    "resolve_credential",
+                    latency_fields.as_ref(),
+                    resolve_credential_started_at,
+                    error.kind().as_str(),
+                    error
+                        .usage()
+                        .map(|usage| usage.network_egress_bytes)
+                        .unwrap_or(0),
+                    0,
+                );
+                return Err(error);
+            }
+        };
         // Stage after parsing so a parse failure doesn't leave a staged credential
         // behind in the injection store.
-        let execution = capability_execution(capability, request.input)?;
-        self.stage_credential(&request, &credential).await?;
+        let parse_execution_started_at = gsuite_latency_started_at();
+        let execution = match capability_execution(capability, request.input) {
+            Ok(execution) => {
+                trace_gsuite_latency_ok(
+                    "parse_execution",
+                    latency_fields.as_ref(),
+                    parse_execution_started_at,
+                    0,
+                    0,
+                );
+                execution
+            }
+            Err(error) => {
+                trace_gsuite_latency_error(
+                    "parse_execution",
+                    latency_fields.as_ref(),
+                    parse_execution_started_at,
+                    error.kind().as_str(),
+                    error
+                        .usage()
+                        .map(|usage| usage.network_egress_bytes)
+                        .unwrap_or(0),
+                    0,
+                );
+                return Err(error);
+            }
+        };
+        let stage_credential_started_at = gsuite_latency_started_at();
+        if let Err(error) = self.stage_credential(&request, &credential).await {
+            trace_gsuite_latency_error(
+                "stage_credential",
+                latency_fields.as_ref(),
+                stage_credential_started_at,
+                error.kind().as_str(),
+                error
+                    .usage()
+                    .map(|usage| usage.network_egress_bytes)
+                    .unwrap_or(0),
+                0,
+            );
+            return Err(error);
+        }
+        trace_gsuite_latency_ok(
+            "stage_credential",
+            latency_fields.as_ref(),
+            stage_credential_started_at,
+            0,
+            0,
+        );
+
+        let execute_primary_started_at = gsuite_latency_started_at();
         let (response, network_egress_bytes) = match execution
             .execute(&request, &credential, self.credential_stager.as_ref())
-            .await?
+            .await
         {
-            CapabilityExecutionOutcome::Response {
+            Ok(CapabilityExecutionOutcome::Response {
                 response,
                 network_egress_bytes,
-            } => (response, network_egress_bytes),
-            CapabilityExecutionOutcome::AuthExpired {
+            }) => {
+                trace_gsuite_latency_ok(
+                    "execute_primary",
+                    latency_fields.as_ref(),
+                    execute_primary_started_at,
+                    network_egress_bytes,
+                    response.response_bytes,
+                );
+                (response, network_egress_bytes)
+            }
+            Ok(CapabilityExecutionOutcome::AuthExpired {
                 network_egress_bytes,
-            } => {
-                self.resolver
+            }) => {
+                trace_gsuite_latency_error(
+                    "execute_primary",
+                    latency_fields.as_ref(),
+                    execute_primary_started_at,
+                    RuntimeDispatchErrorKind::Client.as_str(),
+                    network_egress_bytes,
+                    0,
+                );
+                let refresh_started_at = gsuite_latency_started_at();
+                if let Err(error) = self
+                    .resolver
                     .refresh(
                         request.scope,
                         &credential.account_scope,
@@ -114,10 +264,32 @@ impl GsuiteExecutor {
                         credential.account_id,
                     )
                     .await
-                    .map_err(|error| {
-                        add_network_usage(map_credential_error(error), network_egress_bytes)
-                    })?;
-                let refreshed = self
+                {
+                    let error =
+                        add_network_usage(map_credential_error(error), network_egress_bytes);
+                    trace_gsuite_latency_error(
+                        "refresh_credential",
+                        latency_fields.as_ref(),
+                        refresh_started_at,
+                        error.kind().as_str(),
+                        error
+                            .usage()
+                            .map(|usage| usage.network_egress_bytes)
+                            .unwrap_or(0),
+                        0,
+                    );
+                    return Err(error);
+                }
+                trace_gsuite_latency_ok(
+                    "refresh_credential",
+                    latency_fields.as_ref(),
+                    refresh_started_at,
+                    network_egress_bytes,
+                    0,
+                );
+
+                let resolve_refreshed_started_at = gsuite_latency_started_at();
+                let refreshed = match self
                     .resolver
                     .resolve_account(
                         request.scope,
@@ -127,31 +299,111 @@ impl GsuiteExecutor {
                         &scopes,
                     )
                     .await
-                    .map_err(|error| {
-                        add_network_usage(map_credential_error(error), network_egress_bytes)
-                    })?;
+                {
+                    Ok(refreshed) => {
+                        trace_gsuite_latency_ok(
+                            "resolve_refreshed_credential",
+                            latency_fields.as_ref(),
+                            resolve_refreshed_started_at,
+                            network_egress_bytes,
+                            0,
+                        );
+                        refreshed
+                    }
+                    Err(error) => {
+                        let error =
+                            add_network_usage(map_credential_error(error), network_egress_bytes);
+                        trace_gsuite_latency_error(
+                            "resolve_refreshed_credential",
+                            latency_fields.as_ref(),
+                            resolve_refreshed_started_at,
+                            error.kind().as_str(),
+                            error
+                                .usage()
+                                .map(|usage| usage.network_egress_bytes)
+                                .unwrap_or(0),
+                            0,
+                        );
+                        return Err(error);
+                    }
+                };
                 // Parse before staging for the same reason as the primary path:
                 // a parse failure should not leave a credential staged.
-                let retry_execution = capability_execution(capability, request.input)?;
-                self.stage_credential(&request, &refreshed)
-                    .await
-                    .map_err(|error| add_network_usage(error, network_egress_bytes))?;
+                let retry_parse_started_at = gsuite_latency_started_at();
+                let retry_execution = match capability_execution(capability, request.input) {
+                    Ok(retry_execution) => {
+                        trace_gsuite_latency_ok(
+                            "parse_retry_execution",
+                            latency_fields.as_ref(),
+                            retry_parse_started_at,
+                            network_egress_bytes,
+                            0,
+                        );
+                        retry_execution
+                    }
+                    Err(error) => {
+                        trace_gsuite_latency_error(
+                            "parse_retry_execution",
+                            latency_fields.as_ref(),
+                            retry_parse_started_at,
+                            error.kind().as_str(),
+                            error
+                                .usage()
+                                .map(|usage| usage.network_egress_bytes)
+                                .unwrap_or(0),
+                            0,
+                        );
+                        return Err(error);
+                    }
+                };
+                let retry_stage_started_at = gsuite_latency_started_at();
+                if let Err(error) = self.stage_credential(&request, &refreshed).await {
+                    let error = add_network_usage(error, network_egress_bytes);
+                    trace_gsuite_latency_error(
+                        "stage_retry_credential",
+                        latency_fields.as_ref(),
+                        retry_stage_started_at,
+                        error.kind().as_str(),
+                        error
+                            .usage()
+                            .map(|usage| usage.network_egress_bytes)
+                            .unwrap_or(0),
+                        0,
+                    );
+                    return Err(error);
+                }
+                trace_gsuite_latency_ok(
+                    "stage_retry_credential",
+                    latency_fields.as_ref(),
+                    retry_stage_started_at,
+                    network_egress_bytes,
+                    0,
+                );
+
+                let execute_retry_started_at = gsuite_latency_started_at();
                 match retry_execution
                     .execute(&request, &refreshed, self.credential_stager.as_ref())
                     .await
-                    .map_err(|error| add_network_usage(error, network_egress_bytes))?
                 {
-                    CapabilityExecutionOutcome::Response {
+                    Ok(CapabilityExecutionOutcome::Response {
                         response,
                         network_egress_bytes: retry_network_egress_bytes,
-                    } => (
-                        response,
-                        network_egress_bytes.saturating_add(retry_network_egress_bytes),
-                    ),
-                    CapabilityExecutionOutcome::AuthExpired {
+                    }) => {
+                        let total_network_egress_bytes =
+                            network_egress_bytes.saturating_add(retry_network_egress_bytes);
+                        trace_gsuite_latency_ok(
+                            "execute_retry",
+                            latency_fields.as_ref(),
+                            execute_retry_started_at,
+                            total_network_egress_bytes,
+                            response.response_bytes,
+                        );
+                        (response, total_network_egress_bytes)
+                    }
+                    Ok(CapabilityExecutionOutcome::AuthExpired {
                         network_egress_bytes: retry_network_egress_bytes,
-                    } => {
-                        return Err(GsuiteDispatchError::new(RuntimeDispatchErrorKind::Client)
+                    }) => {
+                        let error = GsuiteDispatchError::new(RuntimeDispatchErrorKind::Client)
                             .with_reason(GsuiteCredentialDispatchReason::AuthRequired {
                                 required_secrets: vec![refreshed.access_secret.clone()],
                             })
@@ -159,16 +411,63 @@ impl GsuiteExecutor {
                                 network_egress_bytes: network_egress_bytes
                                     .saturating_add(retry_network_egress_bytes),
                                 ..ResourceUsage::default()
-                            }));
+                            });
+                        trace_gsuite_latency_error(
+                            "execute_retry",
+                            latency_fields.as_ref(),
+                            execute_retry_started_at,
+                            error.kind().as_str(),
+                            error
+                                .usage()
+                                .map(|usage| usage.network_egress_bytes)
+                                .unwrap_or(0),
+                            0,
+                        );
+                        return Err(error);
+                    }
+                    Err(error) => {
+                        let error = add_network_usage(error, network_egress_bytes);
+                        trace_gsuite_latency_error(
+                            "execute_retry",
+                            latency_fields.as_ref(),
+                            execute_retry_started_at,
+                            error.kind().as_str(),
+                            error
+                                .usage()
+                                .map(|usage| usage.network_egress_bytes)
+                                .unwrap_or(0),
+                            0,
+                        );
+                        return Err(error);
                     }
                 }
             }
+            Err(error) => {
+                trace_gsuite_latency_error(
+                    "execute_primary",
+                    latency_fields.as_ref(),
+                    execute_primary_started_at,
+                    error.kind().as_str(),
+                    error
+                        .usage()
+                        .map(|usage| usage.network_egress_bytes)
+                        .unwrap_or(0),
+                    0,
+                );
+                return Err(error);
+            }
         };
+        let shape_output_started_at = gsuite_latency_started_at();
         let output = response_output(&response)?;
+        let output_bytes = json_bytes(&output);
+        trace_gsuite_latency_ok(
+            "shape_output",
+            latency_fields.as_ref(),
+            shape_output_started_at,
+            network_egress_bytes,
+            output_bytes,
+        );
         let wall_clock_ms = started.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
-        let output_bytes = serde_json::to_vec(&output)
-            .map(|body| body.len() as u64)
-            .unwrap_or(0);
         Ok(GsuiteDispatchResult {
             output,
             usage: ResourceUsage {

--- a/crates/ironclaw_first_party_extensions/src/gsuite/handlers.rs
+++ b/crates/ironclaw_first_party_extensions/src/gsuite/handlers.rs
@@ -72,7 +72,7 @@ fn gsuite_latency_started_at() -> Option<std::time::Instant> {
 
 fn trace_gsuite_latency_ok(
     operation: &'static str,
-    fields: Option<&FirstPartyToolLatencyFields>,
+    fields: Option<&FirstPartyToolLatencyFields<'_>>,
     started_at: Option<std::time::Instant>,
     network_egress_bytes: u64,
     output_bytes: u64,
@@ -92,7 +92,7 @@ fn trace_gsuite_latency_ok(
 
 fn trace_gsuite_latency_error(
     operation: &'static str,
-    fields: Option<&FirstPartyToolLatencyFields>,
+    fields: Option<&FirstPartyToolLatencyFields<'_>>,
     started_at: Option<std::time::Instant>,
     error_kind: &str,
     network_egress_bytes: u64,
@@ -134,13 +134,42 @@ impl GsuiteExecutor {
             request.input,
         );
         let started = Instant::now();
-        let (package, capability) = find_gsuite_capability(request.capability_id.as_str())
-            .ok_or_else(|| {
-                GsuiteDispatchError::new(RuntimeDispatchErrorKind::UndeclaredCapability)
-            })?;
-        let extension = ExtensionId::new(package.extension_id)
-            .map_err(|_| GsuiteDispatchError::new(RuntimeDispatchErrorKind::Backend))?;
-        let scopes = required_provider_scopes(capability)?;
+        let prepare_started_at = gsuite_latency_started_at();
+        let (capability, extension, scopes) = match (|| {
+            let (package, capability) = find_gsuite_capability(request.capability_id.as_str())
+                .ok_or_else(|| {
+                    GsuiteDispatchError::new(RuntimeDispatchErrorKind::UndeclaredCapability)
+                })?;
+            let extension = ExtensionId::new(package.extension_id)
+                .map_err(|_| GsuiteDispatchError::new(RuntimeDispatchErrorKind::Backend))?;
+            let scopes = required_provider_scopes(capability)?;
+            Ok::<_, GsuiteDispatchError>((capability, extension, scopes))
+        })() {
+            Ok(prepared) => {
+                trace_gsuite_latency_ok(
+                    "prepare_capability",
+                    latency_fields.as_ref(),
+                    prepare_started_at,
+                    0,
+                    0,
+                );
+                prepared
+            }
+            Err(error) => {
+                trace_gsuite_latency_error(
+                    "prepare_capability",
+                    latency_fields.as_ref(),
+                    prepare_started_at,
+                    error.kind().as_str(),
+                    error
+                        .usage()
+                        .map(|usage| usage.network_egress_bytes)
+                        .unwrap_or(0),
+                    0,
+                );
+                return Err(error);
+            }
+        };
         let resolve_credential_started_at = gsuite_latency_started_at();
         let credential = match self
             .resolver
@@ -458,7 +487,20 @@ impl GsuiteExecutor {
             }
         };
         let shape_output_started_at = gsuite_latency_started_at();
-        let output = response_output(&response)?;
+        let output = match response_output(&response) {
+            Ok(output) => output,
+            Err(error) => {
+                trace_gsuite_latency_error(
+                    "shape_output",
+                    latency_fields.as_ref(),
+                    shape_output_started_at,
+                    error.kind().as_str(),
+                    network_egress_bytes,
+                    0,
+                );
+                return Err(error);
+            }
+        };
         let output_bytes = json_bytes(&output);
         trace_gsuite_latency_ok(
             "shape_output",

--- a/crates/ironclaw_first_party_extensions/src/latency.rs
+++ b/crates/ironclaw_first_party_extensions/src/latency.rs
@@ -1,6 +1,7 @@
 use std::time::Instant;
 
 use ironclaw_host_api::{CapabilityId, ResourceScope};
+pub(crate) use ironclaw_observability::json_value_bytes as json_bytes;
 use serde_json::Value;
 
 pub(crate) struct FirstPartyToolLatencyFields<'a> {
@@ -43,26 +44,6 @@ impl<'a> FirstPartyToolLatencyFields<'a> {
 
 pub(crate) fn started_at() -> Option<Instant> {
     ironclaw_observability::live_latency_started_at()
-}
-
-pub(crate) fn json_bytes(value: &Value) -> u64 {
-    struct ByteCounter(u64);
-
-    impl std::io::Write for ByteCounter {
-        fn write(&mut self, buffer: &[u8]) -> std::io::Result<usize> {
-            self.0 = self.0.saturating_add(buffer.len() as u64);
-            Ok(buffer.len())
-        }
-
-        fn flush(&mut self) -> std::io::Result<()> {
-            Ok(())
-        }
-    }
-
-    let mut counter = ByteCounter(0);
-    serde_json::to_writer(&mut counter, value)
-        .map(|()| counter.0)
-        .unwrap_or(0)
 }
 
 pub(crate) fn trace_tool_ok(

--- a/crates/ironclaw_first_party_extensions/src/latency.rs
+++ b/crates/ironclaw_first_party_extensions/src/latency.rs
@@ -1,0 +1,149 @@
+use std::time::Instant;
+
+use ironclaw_host_api::{CapabilityId, ResourceScope};
+use serde_json::Value;
+
+pub(crate) struct FirstPartyToolLatencyFields {
+    capability_id: String,
+    tenant_id: String,
+    user_id: String,
+    agent_id: String,
+    project_id: String,
+    mission_id: String,
+    thread_id: String,
+    invocation_id: String,
+    input_bytes: u64,
+}
+
+#[derive(Default)]
+pub(crate) struct FirstPartyToolLatencyMetrics {
+    pub(crate) request_bytes: u64,
+    pub(crate) network_egress_bytes: u64,
+    pub(crate) output_bytes: u64,
+}
+
+impl FirstPartyToolLatencyFields {
+    pub(crate) fn from_input(
+        capability_id: &CapabilityId,
+        scope: &ResourceScope,
+        input: &Value,
+    ) -> Option<Self> {
+        Self::from_input_bytes(capability_id, scope, json_bytes(input))
+    }
+
+    pub(crate) fn from_input_bytes(
+        capability_id: &CapabilityId,
+        scope: &ResourceScope,
+        input_bytes: u64,
+    ) -> Option<Self> {
+        Self::from_input_bytes_name(capability_id.to_string(), scope, input_bytes)
+    }
+
+    pub(crate) fn from_input_bytes_name(
+        capability_id: impl Into<String>,
+        scope: &ResourceScope,
+        input_bytes: u64,
+    ) -> Option<Self> {
+        ironclaw_observability::live_latency_enabled().then(|| Self {
+            capability_id: capability_id.into(),
+            tenant_id: scope.tenant_id.as_str().to_string(),
+            user_id: scope.user_id.as_str().to_string(),
+            agent_id: scope
+                .agent_id
+                .as_ref()
+                .map(|id| id.as_str().to_string())
+                .unwrap_or_default(),
+            project_id: scope
+                .project_id
+                .as_ref()
+                .map(|id| id.as_str().to_string())
+                .unwrap_or_default(),
+            mission_id: scope
+                .mission_id
+                .as_ref()
+                .map(|id| id.as_str().to_string())
+                .unwrap_or_default(),
+            thread_id: scope
+                .thread_id
+                .as_ref()
+                .map(|id| id.as_str().to_string())
+                .unwrap_or_default(),
+            invocation_id: scope.invocation_id.to_string(),
+            input_bytes,
+        })
+    }
+}
+
+pub(crate) fn started_at() -> Option<Instant> {
+    ironclaw_observability::live_latency_started_at()
+}
+
+pub(crate) fn json_bytes(value: &Value) -> u64 {
+    serde_json::to_vec(value)
+        .map(|bytes| bytes.len() as u64)
+        .unwrap_or(0)
+}
+
+pub(crate) fn trace_tool_ok(
+    component: &'static str,
+    operation: &'static str,
+    fields: Option<&FirstPartyToolLatencyFields>,
+    started_at: Option<Instant>,
+    metrics: FirstPartyToolLatencyMetrics,
+) {
+    let Some(fields) = fields else {
+        return;
+    };
+
+    ironclaw_observability::live_latency_trace_ok!(
+        component,
+        operation,
+        started_at,
+        capability_id = fields.capability_id.as_str(),
+        tenant_id = fields.tenant_id.as_str(),
+        user_id = fields.user_id.as_str(),
+        agent_id = fields.agent_id.as_str(),
+        project_id = fields.project_id.as_str(),
+        mission_id = fields.mission_id.as_str(),
+        thread_id = fields.thread_id.as_str(),
+        invocation_id = fields.invocation_id.as_str(),
+        input_bytes = fields.input_bytes,
+        request_bytes = metrics.request_bytes,
+        network_egress_bytes = metrics.network_egress_bytes,
+        output_bytes = metrics.output_bytes,
+        "first-party tool operation completed",
+    );
+}
+
+pub(crate) fn trace_tool_error(
+    component: &'static str,
+    operation: &'static str,
+    fields: Option<&FirstPartyToolLatencyFields>,
+    started_at: Option<Instant>,
+    error_kind: &str,
+    metrics: FirstPartyToolLatencyMetrics,
+) {
+    let Some(fields) = fields else {
+        return;
+    };
+
+    ironclaw_observability::live_latency_trace_error!(
+        component,
+        operation,
+        started_at,
+        error_kind,
+        capability_id = fields.capability_id.as_str(),
+        tenant_id = fields.tenant_id.as_str(),
+        user_id = fields.user_id.as_str(),
+        agent_id = fields.agent_id.as_str(),
+        project_id = fields.project_id.as_str(),
+        mission_id = fields.mission_id.as_str(),
+        thread_id = fields.thread_id.as_str(),
+        invocation_id = fields.invocation_id.as_str(),
+        input_bytes = fields.input_bytes,
+        request_bytes = metrics.request_bytes,
+        network_egress_bytes = metrics.network_egress_bytes,
+        output_bytes = metrics.output_bytes,
+        "first-party tool operation failed",
+    );
+}

--- a/crates/ironclaw_first_party_extensions/src/latency.rs
+++ b/crates/ironclaw_first_party_extensions/src/latency.rs
@@ -3,15 +3,9 @@ use std::time::Instant;
 use ironclaw_host_api::{CapabilityId, ResourceScope};
 use serde_json::Value;
 
-pub(crate) struct FirstPartyToolLatencyFields {
-    capability_id: String,
-    tenant_id: String,
-    user_id: String,
-    agent_id: String,
-    project_id: String,
-    mission_id: String,
-    thread_id: String,
-    invocation_id: String,
+pub(crate) struct FirstPartyToolLatencyFields<'a> {
+    capability_id: &'a CapabilityId,
+    scope: &'a ResourceScope,
     input_bytes: u64,
 }
 
@@ -22,53 +16,26 @@ pub(crate) struct FirstPartyToolLatencyMetrics {
     pub(crate) output_bytes: u64,
 }
 
-impl FirstPartyToolLatencyFields {
+impl<'a> FirstPartyToolLatencyFields<'a> {
     pub(crate) fn from_input(
-        capability_id: &CapabilityId,
-        scope: &ResourceScope,
+        capability_id: &'a CapabilityId,
+        scope: &'a ResourceScope,
         input: &Value,
     ) -> Option<Self> {
+        if !ironclaw_observability::live_latency_enabled() {
+            return None;
+        }
         Self::from_input_bytes(capability_id, scope, json_bytes(input))
     }
 
     pub(crate) fn from_input_bytes(
-        capability_id: &CapabilityId,
-        scope: &ResourceScope,
+        capability_id: &'a CapabilityId,
+        scope: &'a ResourceScope,
         input_bytes: u64,
     ) -> Option<Self> {
-        Self::from_input_bytes_name(capability_id.to_string(), scope, input_bytes)
-    }
-
-    pub(crate) fn from_input_bytes_name(
-        capability_id: impl Into<String>,
-        scope: &ResourceScope,
-        input_bytes: u64,
-    ) -> Option<Self> {
-        ironclaw_observability::live_latency_enabled().then(|| Self {
-            capability_id: capability_id.into(),
-            tenant_id: scope.tenant_id.as_str().to_string(),
-            user_id: scope.user_id.as_str().to_string(),
-            agent_id: scope
-                .agent_id
-                .as_ref()
-                .map(|id| id.as_str().to_string())
-                .unwrap_or_default(),
-            project_id: scope
-                .project_id
-                .as_ref()
-                .map(|id| id.as_str().to_string())
-                .unwrap_or_default(),
-            mission_id: scope
-                .mission_id
-                .as_ref()
-                .map(|id| id.as_str().to_string())
-                .unwrap_or_default(),
-            thread_id: scope
-                .thread_id
-                .as_ref()
-                .map(|id| id.as_str().to_string())
-                .unwrap_or_default(),
-            invocation_id: scope.invocation_id.to_string(),
+        ironclaw_observability::live_latency_enabled().then_some(Self {
+            capability_id,
+            scope,
             input_bytes,
         })
     }
@@ -79,15 +46,29 @@ pub(crate) fn started_at() -> Option<Instant> {
 }
 
 pub(crate) fn json_bytes(value: &Value) -> u64 {
-    serde_json::to_vec(value)
-        .map(|bytes| bytes.len() as u64)
+    struct ByteCounter(u64);
+
+    impl std::io::Write for ByteCounter {
+        fn write(&mut self, buffer: &[u8]) -> std::io::Result<usize> {
+            self.0 = self.0.saturating_add(buffer.len() as u64);
+            Ok(buffer.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    let mut counter = ByteCounter(0);
+    serde_json::to_writer(&mut counter, value)
+        .map(|()| counter.0)
         .unwrap_or(0)
 }
 
 pub(crate) fn trace_tool_ok(
     component: &'static str,
     operation: &'static str,
-    fields: Option<&FirstPartyToolLatencyFields>,
+    fields: Option<&FirstPartyToolLatencyFields<'_>>,
     started_at: Option<Instant>,
     metrics: FirstPartyToolLatencyMetrics,
 ) {
@@ -99,14 +80,14 @@ pub(crate) fn trace_tool_ok(
         component,
         operation,
         started_at,
-        capability_id = fields.capability_id.as_str(),
-        tenant_id = fields.tenant_id.as_str(),
-        user_id = fields.user_id.as_str(),
-        agent_id = fields.agent_id.as_str(),
-        project_id = fields.project_id.as_str(),
-        mission_id = fields.mission_id.as_str(),
-        thread_id = fields.thread_id.as_str(),
-        invocation_id = fields.invocation_id.as_str(),
+        capability_id = %fields.capability_id,
+        tenant_id = %fields.scope.tenant_id,
+        user_id = %fields.scope.user_id,
+        agent_id = fields.scope.agent_id.as_ref().map(|id| id.as_str()).unwrap_or(""),
+        project_id = fields.scope.project_id.as_ref().map(|id| id.as_str()).unwrap_or(""),
+        mission_id = fields.scope.mission_id.as_ref().map(|id| id.as_str()).unwrap_or(""),
+        thread_id = fields.scope.thread_id.as_ref().map(|id| id.as_str()).unwrap_or(""),
+        invocation_id = %fields.scope.invocation_id,
         input_bytes = fields.input_bytes,
         request_bytes = metrics.request_bytes,
         network_egress_bytes = metrics.network_egress_bytes,
@@ -118,7 +99,7 @@ pub(crate) fn trace_tool_ok(
 pub(crate) fn trace_tool_error(
     component: &'static str,
     operation: &'static str,
-    fields: Option<&FirstPartyToolLatencyFields>,
+    fields: Option<&FirstPartyToolLatencyFields<'_>>,
     started_at: Option<Instant>,
     error_kind: &str,
     metrics: FirstPartyToolLatencyMetrics,
@@ -132,14 +113,14 @@ pub(crate) fn trace_tool_error(
         operation,
         started_at,
         error_kind,
-        capability_id = fields.capability_id.as_str(),
-        tenant_id = fields.tenant_id.as_str(),
-        user_id = fields.user_id.as_str(),
-        agent_id = fields.agent_id.as_str(),
-        project_id = fields.project_id.as_str(),
-        mission_id = fields.mission_id.as_str(),
-        thread_id = fields.thread_id.as_str(),
-        invocation_id = fields.invocation_id.as_str(),
+        capability_id = %fields.capability_id,
+        tenant_id = %fields.scope.tenant_id,
+        user_id = %fields.scope.user_id,
+        agent_id = fields.scope.agent_id.as_ref().map(|id| id.as_str()).unwrap_or(""),
+        project_id = fields.scope.project_id.as_ref().map(|id| id.as_str()).unwrap_or(""),
+        mission_id = fields.scope.mission_id.as_ref().map(|id| id.as_str()).unwrap_or(""),
+        thread_id = fields.scope.thread_id.as_ref().map(|id| id.as_str()).unwrap_or(""),
+        invocation_id = %fields.scope.invocation_id,
         input_bytes = fields.input_bytes,
         request_bytes = metrics.request_bytes,
         network_egress_bytes = metrics.network_egress_bytes,

--- a/crates/ironclaw_first_party_extensions/src/lib.rs
+++ b/crates/ironclaw_first_party_extensions/src/lib.rs
@@ -7,6 +7,7 @@
 
 pub mod coding;
 mod gsuite;
+mod latency;
 pub mod skills;
 pub mod web_access;
 

--- a/crates/ironclaw_first_party_extensions/src/web_access.rs
+++ b/crates/ironclaw_first_party_extensions/src/web_access.rs
@@ -13,6 +13,11 @@ use ironclaw_host_api::{
 use serde_json::{Value, json};
 use url::{Host, Url};
 
+use crate::latency::{
+    FirstPartyToolLatencyFields, FirstPartyToolLatencyMetrics, json_bytes, started_at,
+    trace_tool_error, trace_tool_ok,
+};
+
 pub const WEB_ACCESS_EXTENSION_ID: &str = "web-access";
 pub const WEB_SEARCH_CAPABILITY_ID: &str = "web-access.search";
 pub const WEB_GET_CONTENT_CAPABILITY_ID: &str = "web-access.get_content";
@@ -85,6 +90,52 @@ pub struct WebAccessDispatchRequest<'a> {
     pub runtime_http_egress: Option<Arc<dyn RuntimeHttpEgress>>,
 }
 
+fn web_access_latency_started_at() -> Option<std::time::Instant> {
+    started_at()
+}
+
+fn trace_web_access_latency_ok(
+    operation: &'static str,
+    fields: Option<&FirstPartyToolLatencyFields>,
+    started_at: Option<std::time::Instant>,
+    request_bytes: u64,
+    output_bytes: u64,
+) {
+    trace_tool_ok(
+        "web_access_first_party_tool",
+        operation,
+        fields,
+        started_at,
+        FirstPartyToolLatencyMetrics {
+            request_bytes,
+            output_bytes,
+            ..FirstPartyToolLatencyMetrics::default()
+        },
+    );
+}
+
+fn trace_web_access_latency_error(
+    operation: &'static str,
+    fields: Option<&FirstPartyToolLatencyFields>,
+    started_at: Option<std::time::Instant>,
+    error_kind: &str,
+    request_bytes: u64,
+    output_bytes: u64,
+) {
+    trace_tool_error(
+        "web_access_first_party_tool",
+        operation,
+        fields,
+        started_at,
+        error_kind,
+        FirstPartyToolLatencyMetrics {
+            request_bytes,
+            output_bytes,
+            ..FirstPartyToolLatencyMetrics::default()
+        },
+    );
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WebAccessDispatchResult {
     pub output: Value,
@@ -130,13 +181,40 @@ impl WebAccessExecutor {
         &self,
         request: WebAccessDispatchRequest<'_>,
     ) -> Result<WebAccessDispatchResult, WebAccessDispatchError> {
-        match request.capability_id.as_str() {
+        let latency_fields = FirstPartyToolLatencyFields::from_input(
+            request.capability_id,
+            request.scope,
+            request.input,
+        );
+        let started_at = web_access_latency_started_at();
+        let result = match request.capability_id.as_str() {
             WEB_SEARCH_CAPABILITY_ID => self.search(request).await,
             WEB_GET_CONTENT_CAPABILITY_ID => self.get_content(request).await,
             _ => Err(WebAccessDispatchError::new(
                 RuntimeDispatchErrorKind::UndeclaredCapability,
             )),
+        };
+        match &result {
+            Ok(result) => trace_web_access_latency_ok(
+                "dispatch",
+                latency_fields.as_ref(),
+                started_at,
+                result.usage.network_egress_bytes,
+                result.usage.output_bytes,
+            ),
+            Err(error) => trace_web_access_latency_error(
+                "dispatch",
+                latency_fields.as_ref(),
+                started_at,
+                error.kind().as_str(),
+                error
+                    .usage()
+                    .map(|usage| usage.network_egress_bytes)
+                    .unwrap_or(0),
+                error.usage().map(|usage| usage.output_bytes).unwrap_or(0),
+            ),
         }
+        result
     }
 
     async fn search(
@@ -267,9 +345,7 @@ impl WebAccessExecutor {
                 "content": result.content,
             })).collect::<Vec<_>>(),
         });
-        let output_bytes = serde_json::to_vec(&output)
-            .map(|bytes| bytes.len() as u64)
-            .unwrap_or(0);
+        let output_bytes = json_bytes(&output);
         Ok(WebAccessDispatchResult {
             output,
             usage: ResourceUsage {
@@ -351,9 +427,7 @@ impl WebAccessExecutor {
             "provider_used": "exa_mcp",
             "queries": output_queries,
         });
-        let output_bytes = serde_json::to_vec(&output)
-            .map(|bytes| bytes.len() as u64)
-            .unwrap_or(0);
+        let output_bytes = json_bytes(&output);
         Ok(WebAccessDispatchResult {
             output,
             usage: ResourceUsage {
@@ -526,6 +600,8 @@ async fn call_exa_mcp_tool(
     tool_name: &str,
     arguments: Value,
 ) -> Result<EgressText, EgressCallError> {
+    let latency_fields =
+        FirstPartyToolLatencyFields::from_input_bytes(capability_id, scope, json_bytes(&arguments));
     let mut prior_bytes = 0_u64;
 
     // 1. initialize — required before tools/call on compliant MCP servers.
@@ -545,9 +621,30 @@ async fn call_exa_mcp_tool(
         save_body_to: None,
         timeout_ms: Some(DEFAULT_TIMEOUT_MS),
     };
-    let init_resp = execute_runtime_http(init_req, Arc::clone(&egress))
-        .await
-        .map_err(|e| EgressCallError::new(e).with_prior(prior_bytes))?;
+    let init_started_at = web_access_latency_started_at();
+    let init_resp = match execute_runtime_http(init_req, Arc::clone(&egress)).await {
+        Ok(response) => {
+            trace_web_access_latency_ok(
+                "exa_initialize",
+                latency_fields.as_ref(),
+                init_started_at,
+                response.request_bytes,
+                response.response_bytes,
+            );
+            response
+        }
+        Err(error) => {
+            trace_web_access_latency_error(
+                "exa_initialize",
+                latency_fields.as_ref(),
+                init_started_at,
+                error.stable_runtime_reason(),
+                prior_bytes.saturating_add(error.request_bytes()),
+                error.response_bytes(),
+            );
+            return Err(EgressCallError::new(error).with_prior(prior_bytes));
+        }
+    };
     prior_bytes = prior_bytes.saturating_add(init_resp.request_bytes);
 
     // Extract Mcp-Session-Id for reuse in subsequent requests.
@@ -563,12 +660,20 @@ async fn call_exa_mcp_tool(
         .and_then(|v| v.get("error").cloned())
         .is_some()
     {
-        return Err(EgressCallError::new(RuntimeHttpEgressError::Response {
+        let error = RuntimeHttpEgressError::Response {
             reason: "invalid_mcp_response".to_string(),
             request_bytes: prior_bytes,
             response_bytes: init_resp.response_bytes,
-        })
-        .with_prior(0));
+        };
+        trace_web_access_latency_error(
+            "exa_initialize_parse",
+            latency_fields.as_ref(),
+            web_access_latency_started_at(),
+            error.stable_runtime_reason(),
+            error.request_bytes(),
+            error.response_bytes(),
+        );
+        return Err(EgressCallError::new(error).with_prior(0));
     }
 
     // 2. notifications/initialized — no id (notification, not a request).
@@ -588,9 +693,30 @@ async fn call_exa_mcp_tool(
         save_body_to: None,
         timeout_ms: Some(DEFAULT_TIMEOUT_MS),
     };
-    let notif_resp = execute_runtime_http(notif_req, Arc::clone(&egress))
-        .await
-        .map_err(|e| EgressCallError::new(e).with_prior(prior_bytes))?;
+    let notif_started_at = web_access_latency_started_at();
+    let notif_resp = match execute_runtime_http(notif_req, Arc::clone(&egress)).await {
+        Ok(response) => {
+            trace_web_access_latency_ok(
+                "exa_initialized",
+                latency_fields.as_ref(),
+                notif_started_at,
+                response.request_bytes,
+                response.response_bytes,
+            );
+            response
+        }
+        Err(error) => {
+            trace_web_access_latency_error(
+                "exa_initialized",
+                latency_fields.as_ref(),
+                notif_started_at,
+                error.stable_runtime_reason(),
+                prior_bytes.saturating_add(error.request_bytes()),
+                error.response_bytes(),
+            );
+            return Err(EgressCallError::new(error).with_prior(prior_bytes));
+        }
+    };
     prior_bytes = prior_bytes.saturating_add(notif_resp.request_bytes);
 
     // 3. tools/call with session ID.
@@ -614,26 +740,73 @@ async fn call_exa_mcp_tool(
         save_body_to: None,
         timeout_ms: Some(DEFAULT_TIMEOUT_MS),
     };
-    let call_resp = execute_runtime_http(call_req, egress)
-        .await
-        .map_err(|e| EgressCallError::new(e).with_prior(prior_bytes))?;
+    let call_started_at = web_access_latency_started_at();
+    let call_resp = match execute_runtime_http(call_req, egress).await {
+        Ok(response) => {
+            trace_web_access_latency_ok(
+                "exa_tool_call",
+                latency_fields.as_ref(),
+                call_started_at,
+                response.request_bytes,
+                response.response_bytes,
+            );
+            response
+        }
+        Err(error) => {
+            trace_web_access_latency_error(
+                "exa_tool_call",
+                latency_fields.as_ref(),
+                call_started_at,
+                error.stable_runtime_reason(),
+                prior_bytes.saturating_add(error.request_bytes()),
+                error.response_bytes(),
+            );
+            return Err(EgressCallError::new(error).with_prior(prior_bytes));
+        }
+    };
     let call_request_bytes = call_resp.request_bytes;
     prior_bytes = prior_bytes.saturating_add(call_request_bytes);
 
+    let parse_started_at = web_access_latency_started_at();
     let body = String::from_utf8(call_resp.body).map_err(|_| {
-        EgressCallError::new(RuntimeHttpEgressError::Response {
+        let error = RuntimeHttpEgressError::Response {
             reason: "invalid_utf8".to_string(),
             request_bytes: prior_bytes,
             response_bytes: call_resp.response_bytes,
-        })
+        };
+        trace_web_access_latency_error(
+            "exa_parse_tool_response",
+            latency_fields.as_ref(),
+            parse_started_at,
+            error.stable_runtime_reason(),
+            error.request_bytes(),
+            error.response_bytes(),
+        );
+        EgressCallError::new(error)
     })?;
     let text = extract_mcp_text(&body).ok_or_else(|| {
-        EgressCallError::new(RuntimeHttpEgressError::Response {
+        let error = RuntimeHttpEgressError::Response {
             reason: "invalid_mcp_response".to_string(),
             request_bytes: prior_bytes,
             response_bytes: call_resp.response_bytes,
-        })
+        };
+        trace_web_access_latency_error(
+            "exa_parse_tool_response",
+            latency_fields.as_ref(),
+            parse_started_at,
+            error.stable_runtime_reason(),
+            error.request_bytes(),
+            error.response_bytes(),
+        );
+        EgressCallError::new(error)
     })?;
+    trace_web_access_latency_ok(
+        "exa_parse_tool_response",
+        latency_fields.as_ref(),
+        parse_started_at,
+        prior_bytes,
+        text.len() as u64,
+    );
     Ok(EgressText {
         body: text,
         request_bytes: prior_bytes,

--- a/crates/ironclaw_first_party_extensions/src/web_access.rs
+++ b/crates/ironclaw_first_party_extensions/src/web_access.rs
@@ -96,7 +96,7 @@ fn web_access_latency_started_at() -> Option<std::time::Instant> {
 
 fn trace_web_access_latency_ok(
     operation: &'static str,
-    fields: Option<&FirstPartyToolLatencyFields>,
+    fields: Option<&FirstPartyToolLatencyFields<'_>>,
     started_at: Option<std::time::Instant>,
     request_bytes: u64,
     output_bytes: u64,
@@ -116,7 +116,7 @@ fn trace_web_access_latency_ok(
 
 fn trace_web_access_latency_error(
     operation: &'static str,
-    fields: Option<&FirstPartyToolLatencyFields>,
+    fields: Option<&FirstPartyToolLatencyFields<'_>>,
     started_at: Option<std::time::Instant>,
     error_kind: &str,
     request_bytes: u64,
@@ -600,8 +600,7 @@ async fn call_exa_mcp_tool(
     tool_name: &str,
     arguments: Value,
 ) -> Result<EgressText, EgressCallError> {
-    let latency_fields =
-        FirstPartyToolLatencyFields::from_input_bytes(capability_id, scope, json_bytes(&arguments));
+    let latency_fields = FirstPartyToolLatencyFields::from_input(capability_id, scope, &arguments);
     let mut prior_bytes = 0_u64;
 
     // 1. initialize — required before tools/call on compliant MCP servers.
@@ -655,6 +654,7 @@ async fn call_exa_mcp_tool(
         .map(|(_, v)| v.clone());
 
     // Check initialize response for MCP-level error.
+    let init_parse_started_at = web_access_latency_started_at();
     if serde_json::from_slice::<Value>(&init_resp.body)
         .ok()
         .and_then(|v| v.get("error").cloned())
@@ -668,7 +668,7 @@ async fn call_exa_mcp_tool(
         trace_web_access_latency_error(
             "exa_initialize_parse",
             latency_fields.as_ref(),
-            web_access_latency_started_at(),
+            init_parse_started_at,
             error.stable_runtime_reason(),
             error.request_bytes(),
             error.response_bytes(),

--- a/crates/ironclaw_first_party_extensions/src/web_access.rs
+++ b/crates/ironclaw_first_party_extensions/src/web_access.rs
@@ -551,6 +551,13 @@ fn mcp_initialize_params() -> Value {
     })
 }
 
+fn is_valid_mcp_initialize_response(body: &[u8]) -> bool {
+    let Ok(value) = serde_json::from_slice::<Value>(body) else {
+        return false;
+    };
+    value.get("error").is_none() && value.get("result").is_some_and(Value::is_object)
+}
+
 async fn call_exa_mcp_search(
     egress: Arc<dyn RuntimeHttpEgress>,
     capability_id: &CapabilityId,
@@ -653,13 +660,9 @@ async fn call_exa_mcp_tool(
         .find(|(name, _)| name.eq_ignore_ascii_case("mcp-session-id"))
         .map(|(_, v)| v.clone());
 
-    // Check initialize response for MCP-level error.
+    // Check initialize response before moving to initialized notification.
     let init_parse_started_at = web_access_latency_started_at();
-    if serde_json::from_slice::<Value>(&init_resp.body)
-        .ok()
-        .and_then(|v| v.get("error").cloned())
-        .is_some()
-    {
+    if !is_valid_mcp_initialize_response(&init_resp.body) {
         let error = RuntimeHttpEgressError::Response {
             reason: "invalid_mcp_response".to_string(),
             request_bytes: prior_bytes,
@@ -1293,6 +1296,15 @@ mod tests {
     }
 
     impl RecordingEgress {
+        fn with_responses(
+            responses: Vec<Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError>>,
+        ) -> Self {
+            Self {
+                responses: StdMutex::new(responses.into()),
+                requests: StdMutex::new(Vec::new()),
+            }
+        }
+
         fn ok_json(body: Value) -> RuntimeHttpEgressResponse {
             let bytes = serde_json::to_vec(&body).unwrap();
             RuntimeHttpEgressResponse {
@@ -1952,6 +1964,60 @@ data: {"result":{"content":[{"type":"text","text":"Title: Example\nURL: https://
             result.output["queries"][0]["results"][0]["url"],
             "https://tokio.rs"
         );
+    }
+
+    #[tokio::test]
+    async fn search_rejects_malformed_mcp_initialize_response() {
+        let executor = WebAccessExecutor::default();
+        let capability = capability_id(WEB_SEARCH_CAPABILITY_ID);
+        let scope = scope();
+        let input = json!({"query":"rust async"});
+        let egress = Arc::new(RecordingEgress::with_responses(vec![Ok(
+            RuntimeHttpEgressResponse {
+                status: 200,
+                headers: Vec::new(),
+                body: b"not json".to_vec(),
+                saved_body: None,
+                request_bytes: 10,
+                response_bytes: 8,
+                redaction_applied: false,
+            },
+        )]));
+
+        let error = executor
+            .dispatch(request(&capability, &scope, &input, Some(egress.clone())))
+            .await
+            .unwrap_err();
+
+        assert_eq!(error.kind(), RuntimeDispatchErrorKind::OutputDecode);
+        assert_eq!(
+            error.usage().unwrap().network_egress_bytes,
+            10,
+            "only the initialize request should be accounted"
+        );
+        assert_eq!(egress.request_bodies().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn search_rejects_mcp_initialize_response_without_result() {
+        let executor = WebAccessExecutor::default();
+        let capability = capability_id(WEB_SEARCH_CAPABILITY_ID);
+        let scope = scope();
+        let input = json!({"query":"rust async"});
+        let egress = Arc::new(RecordingEgress::with_responses(vec![Ok(
+            RecordingEgress::ok_json(json!({
+                "jsonrpc": "2.0",
+                "id": 1
+            })),
+        )]));
+
+        let error = executor
+            .dispatch(request(&capability, &scope, &input, Some(egress.clone())))
+            .await
+            .unwrap_err();
+
+        assert_eq!(error.kind(), RuntimeDispatchErrorKind::OutputDecode);
+        assert_eq!(egress.request_bodies().len(), 1);
     }
 
     #[tokio::test]

--- a/crates/ironclaw_host_api/src/runtime.rs
+++ b/crates/ironclaw_host_api/src/runtime.rs
@@ -30,6 +30,24 @@ pub enum RuntimeKind {
     System,
 }
 
+impl RuntimeKind {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Wasm => "wasm",
+            Self::Mcp => "mcp",
+            Self::Script => "script",
+            Self::FirstParty => "first_party",
+            Self::System => "system",
+        }
+    }
+}
+
+impl std::fmt::Display for RuntimeKind {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
 /// Effective trust ceiling for an invocation, produced by the host trust
 /// policy engine.
 ///

--- a/crates/ironclaw_host_runtime/src/egress/mod.rs
+++ b/crates/ironclaw_host_runtime/src/egress/mod.rs
@@ -258,6 +258,10 @@ impl PipelineError {
     fn into_inner(self) -> RuntimeHttpEgressError {
         self.error
     }
+
+    pub(super) fn stable_runtime_reason(&self) -> &'static str {
+        self.error.stable_runtime_reason()
+    }
 }
 
 pub(super) fn runtime_network_error(

--- a/crates/ironclaw_host_runtime/src/egress/pipeline.rs
+++ b/crates/ironclaw_host_runtime/src/egress/pipeline.rs
@@ -290,12 +290,18 @@ where
         &capability_id,
     ) {
         Ok(result) => {
+            let output_bytes = result
+                .1
+                .as_ref()
+                .map_or(result.0.body.len() as u64, |saved_body| {
+                    saved_body.bytes_written
+                });
             trace_http_egress_latency_ok(
                 "body_disposition",
                 latency_fields.as_ref(),
                 body_disposition_started_at,
                 0,
-                result.0.body.len() as u64,
+                output_bytes,
             );
             result
         }

--- a/crates/ironclaw_host_runtime/src/egress/pipeline.rs
+++ b/crates/ironclaw_host_runtime/src/egress/pipeline.rs
@@ -23,15 +23,19 @@ fn http_egress_latency_fields(
     request: &RuntimeHttpEgressRequest,
     allow_partial_response_body: bool,
 ) -> Option<HttpEgressLatencyFields> {
+    if !ironclaw_observability::live_latency_enabled() {
+        return None;
+    }
+
     RuntimeLatencyFields::from_scope(
         &request.capability_id,
         &request.scope,
-        format!("{:?}", request.runtime),
+        request.runtime.as_str(),
         0,
     )
     .map(|fields| {
         fields.with_http_details(
-            format!("{:?}", request.method),
+            request.method.to_string(),
             request.body.len() as u64,
             request.response_body_limit.unwrap_or(0),
             request.credential_injections.len(),

--- a/crates/ironclaw_host_runtime/src/egress/pipeline.rs
+++ b/crates/ironclaw_host_runtime/src/egress/pipeline.rs
@@ -6,10 +6,76 @@ use ironclaw_network::{NetworkHttpEgress, NetworkHttpRequest};
 use ironclaw_secrets::SecretStore;
 
 use super::{HostHttpEgressService, PipelineError, runtime_network_error, runtime_response};
-use crate::http_body::{
-    self, RESPONSE_BODY_STORE_UNAUTHORIZED_REASON, RESPONSE_BODY_STORE_UNAVAILABLE_REASON,
-    RuntimeHttpBodyStoreError,
+use crate::{
+    http_body::{
+        self, RESPONSE_BODY_STORE_UNAUTHORIZED_REASON, RESPONSE_BODY_STORE_UNAVAILABLE_REASON,
+        RuntimeHttpBodyStoreError,
+    },
+    latency::{
+        RuntimeLatencyFields, RuntimeLatencyMetrics, started_at as latency_started_at,
+        trace_runtime_error, trace_runtime_ok,
+    },
 };
+
+type HttpEgressLatencyFields = RuntimeLatencyFields;
+
+fn http_egress_latency_fields(
+    request: &RuntimeHttpEgressRequest,
+    allow_partial_response_body: bool,
+) -> Option<HttpEgressLatencyFields> {
+    RuntimeLatencyFields::from_scope(
+        &request.capability_id,
+        &request.scope,
+        format!("{:?}", request.runtime),
+        0,
+    )
+    .map(|fields| {
+        fields.with_http_details(
+            format!("{:?}", request.method),
+            request.body.len() as u64,
+            request.response_body_limit.unwrap_or(0),
+            request.credential_injections.len(),
+            request.save_body_to.is_some(),
+            allow_partial_response_body,
+        )
+    })
+}
+
+fn trace_http_egress_latency_ok(
+    operation: &'static str,
+    fields: Option<&HttpEgressLatencyFields>,
+    started_at: Option<std::time::Instant>,
+    request_bytes: u64,
+    response_bytes: u64,
+) {
+    trace_runtime_ok(
+        "runtime_http_egress",
+        operation,
+        fields,
+        started_at,
+        RuntimeLatencyMetrics {
+            request_bytes,
+            response_bytes,
+            ..RuntimeLatencyMetrics::default()
+        },
+    );
+}
+
+fn trace_http_egress_latency_error(
+    operation: &'static str,
+    fields: Option<&HttpEgressLatencyFields>,
+    started_at: Option<std::time::Instant>,
+    error_kind: &str,
+) {
+    trace_runtime_error(
+        "runtime_http_egress",
+        operation,
+        fields,
+        started_at,
+        error_kind,
+        RuntimeLatencyMetrics::default(),
+    );
+}
 
 pub(super) async fn execute<N, S>(
     service: &HostHttpEgressService<N, S>,
@@ -42,40 +108,203 @@ where
     N: NetworkHttpEgress + Send + Sync,
     S: SecretStore + Send + Sync,
 {
-    let network_policy = service.network_policy_for_request(&mut request)?;
-    service.validate_credential_sources_for_request(&request)?;
-    let save_body_to = authorize_body_store(service, &mut request)?;
-    super::sanitize::validate_runtime_request(&request, service.leak_detector())
-        .map_err(PipelineError::pre_transport)?;
+    let latency_fields = http_egress_latency_fields(&request, allow_partial_response_body);
+    let policy_started_at = latency_started_at();
+    let network_policy = match service.network_policy_for_request(&mut request) {
+        Ok(network_policy) => {
+            trace_http_egress_latency_ok(
+                "policy_lookup",
+                latency_fields.as_ref(),
+                policy_started_at,
+                0,
+                0,
+            );
+            network_policy
+        }
+        Err(error) => {
+            trace_http_egress_latency_error(
+                "policy_lookup",
+                latency_fields.as_ref(),
+                policy_started_at,
+                error.stable_runtime_reason(),
+            );
+            return Err(error);
+        }
+    };
+
+    let credential_validation_started_at = latency_started_at();
+    if let Err(error) = service.validate_credential_sources_for_request(&request) {
+        trace_http_egress_latency_error(
+            "credential_validation",
+            latency_fields.as_ref(),
+            credential_validation_started_at,
+            error.stable_runtime_reason(),
+        );
+        return Err(error);
+    }
+    trace_http_egress_latency_ok(
+        "credential_validation",
+        latency_fields.as_ref(),
+        credential_validation_started_at,
+        0,
+        0,
+    );
+
+    let body_store_started_at = latency_started_at();
+    let save_body_to = match authorize_body_store(service, &mut request) {
+        Ok(save_body_to) => {
+            trace_http_egress_latency_ok(
+                "body_store_authorize",
+                latency_fields.as_ref(),
+                body_store_started_at,
+                0,
+                0,
+            );
+            save_body_to
+        }
+        Err(error) => {
+            trace_http_egress_latency_error(
+                "body_store_authorize",
+                latency_fields.as_ref(),
+                body_store_started_at,
+                error.stable_runtime_reason(),
+            );
+            return Err(error);
+        }
+    };
+
+    let sanitize_request_started_at = latency_started_at();
+    if let Err(error) = super::sanitize::validate_runtime_request(&request, service.leak_detector())
+    {
+        trace_http_egress_latency_error(
+            "sanitize_request",
+            latency_fields.as_ref(),
+            sanitize_request_started_at,
+            error.stable_runtime_reason(),
+        );
+        return Err(PipelineError::pre_transport(error));
+    }
+    trace_http_egress_latency_ok(
+        "sanitize_request",
+        latency_fields.as_ref(),
+        sanitize_request_started_at,
+        0,
+        0,
+    );
+
     let scope = request.scope.clone();
     let capability_id = request.capability_id.clone();
-    let redaction_values = super::credential::apply_credential_injections(
+    let apply_credentials_started_at = latency_started_at();
+    let redaction_values = match super::credential::apply_credential_injections(
         service.secrets(),
         service.secret_injections(),
         &mut request,
-    )
-    .map_err(PipelineError::pre_transport_keep_staged_secrets)?;
-
-    let response = if allow_partial_response_body {
-        dispatch_network_for_model_visible_output(service, request, network_policy).await?
-    } else {
-        dispatch_network(service, request, network_policy).await?
+    ) {
+        Ok(redaction_values) => {
+            trace_http_egress_latency_ok(
+                "apply_credentials",
+                latency_fields.as_ref(),
+                apply_credentials_started_at,
+                0,
+                0,
+            );
+            redaction_values
+        }
+        Err(error) => {
+            trace_http_egress_latency_error(
+                "apply_credentials",
+                latency_fields.as_ref(),
+                apply_credentials_started_at,
+                error.stable_runtime_reason(),
+            );
+            return Err(PipelineError::pre_transport_keep_staged_secrets(error));
+        }
     };
+
+    let transport_started_at = latency_started_at();
+    let response = if allow_partial_response_body {
+        dispatch_network_for_model_visible_output(service, request, network_policy).await
+    } else {
+        dispatch_network(service, request, network_policy).await
+    };
+    let response = match response {
+        Ok(response) => {
+            trace_http_egress_latency_ok(
+                "network_transport",
+                latency_fields.as_ref(),
+                transport_started_at,
+                0,
+                response.body.len() as u64,
+            );
+            response
+        }
+        Err(error) => {
+            trace_http_egress_latency_error(
+                "network_transport",
+                latency_fields.as_ref(),
+                transport_started_at,
+                error.stable_runtime_reason(),
+            );
+            return Err(error);
+        }
+    };
+
     let credentials_injected = !redaction_values.is_empty();
-    let (response, response_redacted) = super::sanitize::sanitize_runtime_response(
+    let sanitize_response_started_at = latency_started_at();
+    let (response, response_redacted) = match super::sanitize::sanitize_runtime_response(
         response,
         &redaction_values,
         service.leak_detector(),
-    )
-    .map_err(PipelineError::post_transport)?;
-    let (response, saved_body) = http_body::apply_body_disposition(
+    ) {
+        Ok(result) => {
+            trace_http_egress_latency_ok(
+                "sanitize_response",
+                latency_fields.as_ref(),
+                sanitize_response_started_at,
+                0,
+                result.0.body.len() as u64,
+            );
+            result
+        }
+        Err(error) => {
+            trace_http_egress_latency_error(
+                "sanitize_response",
+                latency_fields.as_ref(),
+                sanitize_response_started_at,
+                error.stable_runtime_reason(),
+            );
+            return Err(PipelineError::post_transport(error));
+        }
+    };
+
+    let body_disposition_started_at = latency_started_at();
+    let (response, saved_body) = match http_body::apply_body_disposition(
         response,
         save_body_to,
         service.body_store(),
         &scope,
         &capability_id,
-    )
-    .map_err(PipelineError::post_transport)?;
+    ) {
+        Ok(result) => {
+            trace_http_egress_latency_ok(
+                "body_disposition",
+                latency_fields.as_ref(),
+                body_disposition_started_at,
+                0,
+                result.0.body.len() as u64,
+            );
+            result
+        }
+        Err(error) => {
+            trace_http_egress_latency_error(
+                "body_disposition",
+                latency_fields.as_ref(),
+                body_disposition_started_at,
+                error.stable_runtime_reason(),
+            );
+            return Err(PipelineError::post_transport(error));
+        }
+    };
     Ok(runtime_response(
         response,
         credentials_injected || response_redacted,

--- a/crates/ironclaw_host_runtime/src/first_party_tools/mod.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/mod.rs
@@ -545,6 +545,7 @@ impl FirstPartyCapabilityHandler for BuiltinFirstPartyTools {
                     ));
                 };
                 let request = CodingCapabilityRequest::new(
+                    &request.capability_id,
                     metadata.kind,
                     &request.scope,
                     request.mounts.as_ref(),

--- a/crates/ironclaw_host_runtime/src/latency.rs
+++ b/crates/ironclaw_host_runtime/src/latency.rs
@@ -1,0 +1,182 @@
+use std::time::Instant;
+
+use ironclaw_host_api::{CapabilityId, ResourceScope};
+
+pub(crate) struct RuntimeLatencyFields {
+    capability_id: String,
+    runtime: String,
+    tenant_id: String,
+    user_id: String,
+    agent_id: String,
+    project_id: String,
+    mission_id: String,
+    thread_id: String,
+    invocation_id: String,
+    input_bytes: u64,
+    method: String,
+    request_body_bytes: u64,
+    response_body_limit: u64,
+    credential_injection_count: usize,
+    saves_body: bool,
+    allow_partial_response_body: bool,
+}
+
+#[derive(Default)]
+pub(crate) struct RuntimeLatencyMetrics {
+    pub(crate) request_bytes: u64,
+    pub(crate) response_bytes: u64,
+    pub(crate) output_bytes: u64,
+    pub(crate) used_prepared_reservation: bool,
+}
+
+impl RuntimeLatencyFields {
+    pub(crate) fn from_scope(
+        capability_id: &CapabilityId,
+        scope: &ResourceScope,
+        runtime: impl Into<String>,
+        input_bytes: u64,
+    ) -> Option<Self> {
+        ironclaw_observability::live_latency_enabled().then(|| Self {
+            capability_id: capability_id.to_string(),
+            runtime: runtime.into(),
+            tenant_id: scope.tenant_id.as_str().to_string(),
+            user_id: scope.user_id.as_str().to_string(),
+            agent_id: scope
+                .agent_id
+                .as_ref()
+                .map(|id| id.as_str().to_string())
+                .unwrap_or_default(),
+            project_id: scope
+                .project_id
+                .as_ref()
+                .map(|id| id.as_str().to_string())
+                .unwrap_or_default(),
+            mission_id: scope
+                .mission_id
+                .as_ref()
+                .map(|id| id.as_str().to_string())
+                .unwrap_or_default(),
+            thread_id: scope
+                .thread_id
+                .as_ref()
+                .map(|id| id.as_str().to_string())
+                .unwrap_or_default(),
+            invocation_id: scope.invocation_id.to_string(),
+            input_bytes,
+            method: String::new(),
+            request_body_bytes: 0,
+            response_body_limit: 0,
+            credential_injection_count: 0,
+            saves_body: false,
+            allow_partial_response_body: false,
+        })
+    }
+
+    pub(crate) fn with_http_details(
+        mut self,
+        method: impl Into<String>,
+        request_body_bytes: u64,
+        response_body_limit: u64,
+        credential_injection_count: usize,
+        saves_body: bool,
+        allow_partial_response_body: bool,
+    ) -> Self {
+        self.method = method.into();
+        self.request_body_bytes = request_body_bytes;
+        self.response_body_limit = response_body_limit;
+        self.credential_injection_count = credential_injection_count;
+        self.saves_body = saves_body;
+        self.allow_partial_response_body = allow_partial_response_body;
+        self
+    }
+}
+
+pub(crate) fn json_bytes(value: &serde_json::Value) -> u64 {
+    serde_json::to_vec(value)
+        .map(|bytes| bytes.len() as u64)
+        .unwrap_or(0)
+}
+
+pub(crate) fn started_at() -> Option<Instant> {
+    ironclaw_observability::live_latency_started_at()
+}
+
+pub(crate) fn trace_runtime_ok(
+    component: &'static str,
+    operation: &'static str,
+    fields: Option<&RuntimeLatencyFields>,
+    started_at: Option<Instant>,
+    metrics: RuntimeLatencyMetrics,
+) {
+    let Some(fields) = fields else {
+        return;
+    };
+
+    ironclaw_observability::live_latency_trace_ok!(
+        component,
+        operation,
+        started_at,
+        capability_id = fields.capability_id.as_str(),
+        runtime = fields.runtime.as_str(),
+        tenant_id = fields.tenant_id.as_str(),
+        user_id = fields.user_id.as_str(),
+        agent_id = fields.agent_id.as_str(),
+        project_id = fields.project_id.as_str(),
+        mission_id = fields.mission_id.as_str(),
+        thread_id = fields.thread_id.as_str(),
+        invocation_id = fields.invocation_id.as_str(),
+        input_bytes = fields.input_bytes,
+        method = fields.method.as_str(),
+        request_body_bytes = fields.request_body_bytes,
+        response_body_limit = fields.response_body_limit,
+        credential_injection_count = fields.credential_injection_count,
+        saves_body = fields.saves_body,
+        allow_partial_response_body = fields.allow_partial_response_body,
+        request_bytes = metrics.request_bytes,
+        response_bytes = metrics.response_bytes,
+        output_bytes = metrics.output_bytes,
+        used_prepared_reservation = metrics.used_prepared_reservation,
+        "host runtime operation completed",
+    );
+}
+
+pub(crate) fn trace_runtime_error(
+    component: &'static str,
+    operation: &'static str,
+    fields: Option<&RuntimeLatencyFields>,
+    started_at: Option<Instant>,
+    error_kind: &str,
+    metrics: RuntimeLatencyMetrics,
+) {
+    let Some(fields) = fields else {
+        return;
+    };
+
+    ironclaw_observability::live_latency_trace_error!(
+        component,
+        operation,
+        started_at,
+        error_kind,
+        capability_id = fields.capability_id.as_str(),
+        runtime = fields.runtime.as_str(),
+        tenant_id = fields.tenant_id.as_str(),
+        user_id = fields.user_id.as_str(),
+        agent_id = fields.agent_id.as_str(),
+        project_id = fields.project_id.as_str(),
+        mission_id = fields.mission_id.as_str(),
+        thread_id = fields.thread_id.as_str(),
+        invocation_id = fields.invocation_id.as_str(),
+        input_bytes = fields.input_bytes,
+        method = fields.method.as_str(),
+        request_body_bytes = fields.request_body_bytes,
+        response_body_limit = fields.response_body_limit,
+        credential_injection_count = fields.credential_injection_count,
+        saves_body = fields.saves_body,
+        allow_partial_response_body = fields.allow_partial_response_body,
+        request_bytes = metrics.request_bytes,
+        response_bytes = metrics.response_bytes,
+        output_bytes = metrics.output_bytes,
+        used_prepared_reservation = metrics.used_prepared_reservation,
+        "host runtime operation failed",
+    );
+}

--- a/crates/ironclaw_host_runtime/src/latency.rs
+++ b/crates/ironclaw_host_runtime/src/latency.rs
@@ -30,13 +30,25 @@ pub(crate) struct RuntimeLatencyMetrics {
 }
 
 impl RuntimeLatencyFields {
+    pub(crate) fn from_json_input(
+        capability_id: &CapabilityId,
+        scope: &ResourceScope,
+        runtime: impl Into<String>,
+        input: &serde_json::Value,
+    ) -> Option<Self> {
+        if !ironclaw_observability::live_latency_enabled() {
+            return None;
+        }
+        Self::from_scope(capability_id, scope, runtime, json_bytes(input))
+    }
+
     pub(crate) fn from_scope(
         capability_id: &CapabilityId,
         scope: &ResourceScope,
         runtime: impl Into<String>,
         input_bytes: u64,
     ) -> Option<Self> {
-        ironclaw_observability::live_latency_enabled().then(|| Self {
+        ironclaw_observability::live_latency_enabled().then_some(Self {
             capability_id: capability_id.to_string(),
             runtime: runtime.into(),
             tenant_id: scope.tenant_id.as_str().to_string(),
@@ -92,8 +104,22 @@ impl RuntimeLatencyFields {
 }
 
 pub(crate) fn json_bytes(value: &serde_json::Value) -> u64 {
-    serde_json::to_vec(value)
-        .map(|bytes| bytes.len() as u64)
+    struct ByteCounter(u64);
+
+    impl std::io::Write for ByteCounter {
+        fn write(&mut self, buffer: &[u8]) -> std::io::Result<usize> {
+            self.0 = self.0.saturating_add(buffer.len() as u64);
+            Ok(buffer.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    let mut counter = ByteCounter(0);
+    serde_json::to_writer(&mut counter, value)
+        .map(|()| counter.0)
         .unwrap_or(0)
 }
 

--- a/crates/ironclaw_host_runtime/src/latency.rs
+++ b/crates/ironclaw_host_runtime/src/latency.rs
@@ -1,6 +1,7 @@
 use std::time::Instant;
 
 use ironclaw_host_api::{CapabilityId, ResourceScope};
+use ironclaw_observability::json_value_bytes;
 
 pub(crate) struct RuntimeLatencyFields {
     capability_id: String,
@@ -39,7 +40,7 @@ impl RuntimeLatencyFields {
         if !ironclaw_observability::live_latency_enabled() {
             return None;
         }
-        Self::from_scope(capability_id, scope, runtime, json_bytes(input))
+        Self::from_scope(capability_id, scope, runtime, json_value_bytes(input))
     }
 
     pub(crate) fn from_scope(
@@ -101,26 +102,6 @@ impl RuntimeLatencyFields {
         self.allow_partial_response_body = allow_partial_response_body;
         self
     }
-}
-
-pub(crate) fn json_bytes(value: &serde_json::Value) -> u64 {
-    struct ByteCounter(u64);
-
-    impl std::io::Write for ByteCounter {
-        fn write(&mut self, buffer: &[u8]) -> std::io::Result<usize> {
-            self.0 = self.0.saturating_add(buffer.len() as u64);
-            Ok(buffer.len())
-        }
-
-        fn flush(&mut self) -> std::io::Result<()> {
-            Ok(())
-        }
-    }
-
-    let mut counter = ByteCounter(0);
-    serde_json::to_writer(&mut counter, value)
-        .map(|()| counter.0)
-        .unwrap_or(0)
 }
 
 pub(crate) fn started_at() -> Option<Instant> {

--- a/crates/ironclaw_host_runtime/src/lib.rs
+++ b/crates/ironclaw_host_runtime/src/lib.rs
@@ -44,6 +44,7 @@ mod first_party;
 mod first_party_tools;
 mod http_body;
 mod invocation_services;
+mod latency;
 pub mod memory_context;
 mod obligations;
 mod planner;

--- a/crates/ironclaw_host_runtime/src/services/runtime_adapters.rs
+++ b/crates/ironclaw_host_runtime/src/services/runtime_adapters.rs
@@ -22,7 +22,7 @@ use super::{
 use crate::{
     FirstPartyCapabilityError,
     latency::{
-        RuntimeLatencyFields, RuntimeLatencyMetrics, json_bytes, started_at as latency_started_at,
+        RuntimeLatencyFields, RuntimeLatencyMetrics, started_at as latency_started_at,
         trace_runtime_error, trace_runtime_ok,
     },
 };
@@ -36,11 +36,11 @@ where
     F: RootFilesystem,
     G: ResourceGovernor,
 {
-    RuntimeLatencyFields::from_scope(
+    RuntimeLatencyFields::from_json_input(
         request.capability_id,
         &request.scope,
-        format!("{:?}", request.descriptor.runtime),
-        json_bytes(&request.input),
+        request.descriptor.runtime.as_str(),
+        &request.input,
     )
 }
 
@@ -444,6 +444,15 @@ where
             None => request
                 .governor
                 .reserve(request.scope.clone(), request.estimate.clone())
+                .inspect(|_| {
+                    trace_first_party_latency_ok(
+                        "reserve_resources",
+                        latency_fields.as_ref(),
+                        reserve_started_at,
+                        0,
+                        used_prepared_reservation,
+                    );
+                })
                 .map_err(|_| {
                     tracing::debug!("first-party runtime adapter resource reservation failed");
                     trace_first_party_latency_error(

--- a/crates/ironclaw_host_runtime/src/services/runtime_adapters.rs
+++ b/crates/ironclaw_host_runtime/src/services/runtime_adapters.rs
@@ -19,7 +19,70 @@ use super::{
     WasmRuntimeHttpAdapter, WasmRuntimePolicyDiscarder, WitToolHost, WitToolRuntime,
     WitToolRuntimeConfig, plan_capability, runtime_http_egress,
 };
-use crate::FirstPartyCapabilityError;
+use crate::{
+    FirstPartyCapabilityError,
+    latency::{
+        RuntimeLatencyFields, RuntimeLatencyMetrics, json_bytes, started_at as latency_started_at,
+        trace_runtime_error, trace_runtime_ok,
+    },
+};
+
+type FirstPartyLatencyFields = RuntimeLatencyFields;
+
+fn first_party_latency_fields<F, G>(
+    request: &RuntimeAdapterRequest<'_, F, G>,
+) -> Option<FirstPartyLatencyFields>
+where
+    F: RootFilesystem,
+    G: ResourceGovernor,
+{
+    RuntimeLatencyFields::from_scope(
+        request.capability_id,
+        &request.scope,
+        format!("{:?}", request.descriptor.runtime),
+        json_bytes(&request.input),
+    )
+}
+
+fn trace_first_party_latency_ok(
+    operation: &'static str,
+    fields: Option<&FirstPartyLatencyFields>,
+    started_at: Option<std::time::Instant>,
+    output_bytes: u64,
+    used_prepared_reservation: bool,
+) {
+    trace_runtime_ok(
+        "first_party_runtime_adapter",
+        operation,
+        fields,
+        started_at,
+        RuntimeLatencyMetrics {
+            output_bytes,
+            used_prepared_reservation,
+            ..RuntimeLatencyMetrics::default()
+        },
+    );
+}
+
+fn trace_first_party_latency_error(
+    operation: &'static str,
+    fields: Option<&FirstPartyLatencyFields>,
+    started_at: Option<std::time::Instant>,
+    error_kind: &str,
+    used_prepared_reservation: bool,
+) {
+    trace_runtime_error(
+        "first_party_runtime_adapter",
+        operation,
+        fields,
+        started_at,
+        error_kind,
+        RuntimeLatencyMetrics {
+            used_prepared_reservation,
+            ..RuntimeLatencyMetrics::default()
+        },
+    );
+}
 
 pub(super) struct ServiceResolvedRuntimeAdapter<T> {
     inner: Arc<T>,
@@ -232,7 +295,11 @@ where
         &self,
         request: RuntimeAdapterRequest<'_, F, G>,
     ) -> Result<RuntimeAdapterResult, DispatchError> {
+        let latency_fields = first_party_latency_fields(&request);
+        let dispatch_started_at = latency_started_at();
+        let used_prepared_reservation = request.resource_reservation.is_some();
         tracing::debug!("first-party runtime adapter dispatch started");
+        let lookup_started_at = latency_started_at();
         let Some(handler) = self.registry.get(request.capability_id) else {
             if let Some(reservation) = request.resource_reservation
                 && let Err(error) = request.governor.release(reservation.id)
@@ -244,28 +311,72 @@ where
                 );
             }
             tracing::debug!("first-party runtime adapter missing handler");
+            trace_first_party_latency_error(
+                "lookup_handler",
+                latency_fields.as_ref(),
+                lookup_started_at,
+                RuntimeDispatchErrorKind::UndeclaredCapability.as_str(),
+                used_prepared_reservation,
+            );
+            trace_first_party_latency_error(
+                "dispatch",
+                latency_fields.as_ref(),
+                dispatch_started_at,
+                RuntimeDispatchErrorKind::UndeclaredCapability.as_str(),
+                used_prepared_reservation,
+            );
             return Err(DispatchError::FirstParty {
                 kind: RuntimeDispatchErrorKind::UndeclaredCapability,
                 safe_summary: None,
                 detail: None,
             });
         };
+        trace_first_party_latency_ok(
+            "lookup_handler",
+            latency_fields.as_ref(),
+            lookup_started_at,
+            0,
+            used_prepared_reservation,
+        );
 
+        let plan_started_at = latency_started_at();
         let plan =
             plan_capability(request.descriptor, request.runtime_policy).map_err(|error| {
+                let kind = planner_error_kind(&error);
                 tracing::debug!(
-                    error_kind = %planner_error_kind(&error),
+                    error_kind = %kind,
                     "first-party runtime adapter policy planning failed"
                 );
                 if let Some(reservation) = &request.resource_reservation {
                     release_first_party_reservation(request.governor, reservation.id);
                 }
+                trace_first_party_latency_error(
+                    "plan_capability",
+                    latency_fields.as_ref(),
+                    plan_started_at,
+                    kind.as_str(),
+                    used_prepared_reservation,
+                );
+                trace_first_party_latency_error(
+                    "dispatch",
+                    latency_fields.as_ref(),
+                    dispatch_started_at,
+                    kind.as_str(),
+                    used_prepared_reservation,
+                );
                 DispatchError::FirstParty {
-                    kind: planner_error_kind(&error),
+                    kind,
                     safe_summary: None,
                     detail: None,
                 }
             })?;
+        trace_first_party_latency_ok(
+            "plan_capability",
+            latency_fields.as_ref(),
+            plan_started_at,
+            0,
+            used_prepared_reservation,
+        );
         tracing::debug!(
             filesystem_backend = ?plan.filesystem_backend,
             process_backend = ?plan.process_backend,
@@ -273,6 +384,7 @@ where
             secret_mode = ?plan.secret_mode,
             "first-party runtime adapter policy plan resolved"
         );
+        let resolve_started_at = latency_started_at();
         let services = self
             .invocation_services
             .resolve(InvocationServicesResolutionRequest {
@@ -288,22 +400,66 @@ where
                 if let Some(reservation) = &request.resource_reservation {
                     release_first_party_reservation(request.governor, reservation.id);
                 }
+                trace_first_party_latency_error(
+                    "resolve_services",
+                    latency_fields.as_ref(),
+                    resolve_started_at,
+                    error.kind().as_str(),
+                    used_prepared_reservation,
+                );
+                trace_first_party_latency_error(
+                    "dispatch",
+                    latency_fields.as_ref(),
+                    dispatch_started_at,
+                    error.kind().as_str(),
+                    used_prepared_reservation,
+                );
                 DispatchError::FirstParty {
                     kind: error.kind(),
                     safe_summary: None,
                     detail: None,
                 }
             })?;
+        trace_first_party_latency_ok(
+            "resolve_services",
+            latency_fields.as_ref(),
+            resolve_started_at,
+            0,
+            used_prepared_reservation,
+        );
         tracing::debug!("first-party runtime adapter services resolved");
 
-        let used_prepared_reservation = request.resource_reservation.is_some();
+        let reserve_started_at = latency_started_at();
         let reservation = match request.resource_reservation {
-            Some(reservation) => reservation,
+            Some(reservation) => {
+                trace_first_party_latency_ok(
+                    "reserve_resources",
+                    latency_fields.as_ref(),
+                    reserve_started_at,
+                    0,
+                    used_prepared_reservation,
+                );
+                reservation
+            }
             None => request
                 .governor
                 .reserve(request.scope.clone(), request.estimate.clone())
                 .map_err(|_| {
                     tracing::debug!("first-party runtime adapter resource reservation failed");
+                    trace_first_party_latency_error(
+                        "reserve_resources",
+                        latency_fields.as_ref(),
+                        reserve_started_at,
+                        RuntimeDispatchErrorKind::Resource.as_str(),
+                        used_prepared_reservation,
+                    );
+                    trace_first_party_latency_error(
+                        "dispatch",
+                        latency_fields.as_ref(),
+                        dispatch_started_at,
+                        RuntimeDispatchErrorKind::Resource.as_str(),
+                        used_prepared_reservation,
+                    );
                     DispatchError::FirstParty {
                         kind: RuntimeDispatchErrorKind::Resource,
                         safe_summary: None,
@@ -333,6 +489,7 @@ where
             reservation_id = %reservation_id,
             "first-party runtime adapter invoking handler"
         );
+        let handler_started_at = latency_started_at();
         let result = match AssertUnwindSafe(handler.dispatch(FirstPartyCapabilityRequest {
             capability_id: request.capability_id.clone(),
             scope: request.scope.clone(),
@@ -344,12 +501,32 @@ where
         .catch_unwind()
         .await
         {
-            Ok(Ok(result)) => result,
+            Ok(Ok(result)) => {
+                trace_first_party_latency_ok(
+                    "handler_dispatch",
+                    latency_fields.as_ref(),
+                    handler_started_at,
+                    0,
+                    used_prepared_reservation,
+                );
+                result
+            }
             Ok(Err(error)) => {
                 tracing::debug!(
                     reservation_id = %reservation_id,
                     is_auth_required = error.is_auth_required(),
                     "first-party runtime adapter handler failed"
+                );
+                let error_kind = error
+                    .kind()
+                    .map(RuntimeDispatchErrorKind::as_str)
+                    .unwrap_or("AuthRequired");
+                trace_first_party_latency_error(
+                    "handler_dispatch",
+                    latency_fields.as_ref(),
+                    handler_started_at,
+                    error_kind,
+                    used_prepared_reservation,
                 );
                 if let Err(acct_err) =
                     guard.account_failed(error.usage(), first_party_resource_error)
@@ -361,6 +538,13 @@ where
                          returning original handler error"
                     );
                 }
+                trace_first_party_latency_error(
+                    "dispatch",
+                    latency_fields.as_ref(),
+                    dispatch_started_at,
+                    error_kind,
+                    used_prepared_reservation,
+                );
                 return match error {
                     FirstPartyCapabilityError::AuthRequired {
                         required_secrets,
@@ -388,6 +572,20 @@ where
                     reservation_id = %reservation_id,
                     "first-party runtime adapter handler panicked"
                 );
+                trace_first_party_latency_error(
+                    "handler_dispatch",
+                    latency_fields.as_ref(),
+                    handler_started_at,
+                    RuntimeDispatchErrorKind::Backend.as_str(),
+                    used_prepared_reservation,
+                );
+                trace_first_party_latency_error(
+                    "dispatch",
+                    latency_fields.as_ref(),
+                    dispatch_started_at,
+                    RuntimeDispatchErrorKind::Backend.as_str(),
+                    used_prepared_reservation,
+                );
                 // Dropping `guard` releases the reservation.
                 return Err(DispatchError::FirstParty {
                     kind: RuntimeDispatchErrorKind::Backend,
@@ -397,12 +595,27 @@ where
             }
         };
 
+        let serialize_started_at = latency_started_at();
         let output_bytes = serde_json::to_vec(&result.output)
             .map(|bytes| bytes.len() as u64)
             .map_err(|_| {
                 tracing::debug!(
                     reservation_id = %reservation_id,
                     "first-party runtime adapter output serialization failed"
+                );
+                trace_first_party_latency_error(
+                    "serialize_output",
+                    latency_fields.as_ref(),
+                    serialize_started_at,
+                    RuntimeDispatchErrorKind::OutputDecode.as_str(),
+                    used_prepared_reservation,
+                );
+                trace_first_party_latency_error(
+                    "dispatch",
+                    latency_fields.as_ref(),
+                    dispatch_started_at,
+                    RuntimeDispatchErrorKind::OutputDecode.as_str(),
+                    used_prepared_reservation,
                 );
                 // Dropping `guard` releases the reservation.
                 DispatchError::FirstParty {
@@ -411,6 +624,13 @@ where
                     detail: None,
                 }
             })?;
+        trace_first_party_latency_ok(
+            "serialize_output",
+            latency_fields.as_ref(),
+            serialize_started_at,
+            output_bytes,
+            used_prepared_reservation,
+        );
         let mut usage = result.usage;
         usage.output_bytes = usage.output_bytes.max(output_bytes);
         // Happy path: reconcile inline so we preserve the existing
@@ -418,8 +638,18 @@ where
         // hands reservation ownership back from the guard; both reconcile
         // outcomes settle the reservation below.
         let reconcile_id = guard.disarm();
+        let reconcile_started_at = latency_started_at();
         let receipt = match request.governor.reconcile(reconcile_id, usage.clone()) {
-            Ok(receipt) => receipt,
+            Ok(receipt) => {
+                trace_first_party_latency_ok(
+                    "reconcile_resources",
+                    latency_fields.as_ref(),
+                    reconcile_started_at,
+                    output_bytes,
+                    used_prepared_reservation,
+                );
+                receipt
+            }
             Err(_) => {
                 tracing::debug!(
                     reservation_id = %reconcile_id,
@@ -432,6 +662,20 @@ where
                         "failed to release first-party resource reservation after reconcile failure"
                     );
                 }
+                trace_first_party_latency_error(
+                    "reconcile_resources",
+                    latency_fields.as_ref(),
+                    reconcile_started_at,
+                    RuntimeDispatchErrorKind::Resource.as_str(),
+                    used_prepared_reservation,
+                );
+                trace_first_party_latency_error(
+                    "dispatch",
+                    latency_fields.as_ref(),
+                    dispatch_started_at,
+                    RuntimeDispatchErrorKind::Resource.as_str(),
+                    used_prepared_reservation,
+                );
                 return Err(DispatchError::FirstParty {
                     kind: RuntimeDispatchErrorKind::Resource,
                     safe_summary: None,
@@ -443,6 +687,13 @@ where
             reservation_id = %reconcile_id,
             output_bytes,
             "first-party runtime adapter dispatch completed"
+        );
+        trace_first_party_latency_ok(
+            "dispatch",
+            latency_fields.as_ref(),
+            dispatch_started_at,
+            output_bytes,
+            used_prepared_reservation,
         );
 
         Ok(RuntimeAdapterResult {

--- a/crates/ironclaw_host_runtime/src/services/runtime_adapters.rs
+++ b/crates/ironclaw_host_runtime/src/services/runtime_adapters.rs
@@ -84,6 +84,30 @@ fn trace_first_party_latency_error(
     );
 }
 
+fn trace_first_party_stage_and_dispatch_error(
+    stage: &'static str,
+    fields: Option<&FirstPartyLatencyFields>,
+    stage_started_at: Option<std::time::Instant>,
+    dispatch_started_at: Option<std::time::Instant>,
+    error_kind: &str,
+    used_prepared_reservation: bool,
+) {
+    trace_first_party_latency_error(
+        stage,
+        fields,
+        stage_started_at,
+        error_kind,
+        used_prepared_reservation,
+    );
+    trace_first_party_latency_error(
+        "dispatch",
+        fields,
+        dispatch_started_at,
+        error_kind,
+        used_prepared_reservation,
+    );
+}
+
 pub(super) struct ServiceResolvedRuntimeAdapter<T> {
     inner: Arc<T>,
     invocation_services: Arc<dyn InvocationServicesResolver>,
@@ -311,16 +335,10 @@ where
                 );
             }
             tracing::debug!("first-party runtime adapter missing handler");
-            trace_first_party_latency_error(
+            trace_first_party_stage_and_dispatch_error(
                 "lookup_handler",
                 latency_fields.as_ref(),
                 lookup_started_at,
-                RuntimeDispatchErrorKind::UndeclaredCapability.as_str(),
-                used_prepared_reservation,
-            );
-            trace_first_party_latency_error(
-                "dispatch",
-                latency_fields.as_ref(),
                 dispatch_started_at,
                 RuntimeDispatchErrorKind::UndeclaredCapability.as_str(),
                 used_prepared_reservation,
@@ -350,16 +368,10 @@ where
                 if let Some(reservation) = &request.resource_reservation {
                     release_first_party_reservation(request.governor, reservation.id);
                 }
-                trace_first_party_latency_error(
+                trace_first_party_stage_and_dispatch_error(
                     "plan_capability",
                     latency_fields.as_ref(),
                     plan_started_at,
-                    kind.as_str(),
-                    used_prepared_reservation,
-                );
-                trace_first_party_latency_error(
-                    "dispatch",
-                    latency_fields.as_ref(),
                     dispatch_started_at,
                     kind.as_str(),
                     used_prepared_reservation,
@@ -400,16 +412,10 @@ where
                 if let Some(reservation) = &request.resource_reservation {
                     release_first_party_reservation(request.governor, reservation.id);
                 }
-                trace_first_party_latency_error(
+                trace_first_party_stage_and_dispatch_error(
                     "resolve_services",
                     latency_fields.as_ref(),
                     resolve_started_at,
-                    error.kind().as_str(),
-                    used_prepared_reservation,
-                );
-                trace_first_party_latency_error(
-                    "dispatch",
-                    latency_fields.as_ref(),
                     dispatch_started_at,
                     error.kind().as_str(),
                     used_prepared_reservation,
@@ -455,16 +461,10 @@ where
                 })
                 .map_err(|_| {
                     tracing::debug!("first-party runtime adapter resource reservation failed");
-                    trace_first_party_latency_error(
+                    trace_first_party_stage_and_dispatch_error(
                         "reserve_resources",
                         latency_fields.as_ref(),
                         reserve_started_at,
-                        RuntimeDispatchErrorKind::Resource.as_str(),
-                        used_prepared_reservation,
-                    );
-                    trace_first_party_latency_error(
-                        "dispatch",
-                        latency_fields.as_ref(),
                         dispatch_started_at,
                         RuntimeDispatchErrorKind::Resource.as_str(),
                         used_prepared_reservation,
@@ -529,11 +529,12 @@ where
                 let error_kind = error
                     .kind()
                     .map(RuntimeDispatchErrorKind::as_str)
-                    .unwrap_or("AuthRequired");
-                trace_first_party_latency_error(
+                    .unwrap_or("auth_required");
+                trace_first_party_stage_and_dispatch_error(
                     "handler_dispatch",
                     latency_fields.as_ref(),
                     handler_started_at,
+                    dispatch_started_at,
                     error_kind,
                     used_prepared_reservation,
                 );
@@ -547,13 +548,6 @@ where
                          returning original handler error"
                     );
                 }
-                trace_first_party_latency_error(
-                    "dispatch",
-                    latency_fields.as_ref(),
-                    dispatch_started_at,
-                    error_kind,
-                    used_prepared_reservation,
-                );
                 return match error {
                     FirstPartyCapabilityError::AuthRequired {
                         required_secrets,
@@ -581,16 +575,10 @@ where
                     reservation_id = %reservation_id,
                     "first-party runtime adapter handler panicked"
                 );
-                trace_first_party_latency_error(
+                trace_first_party_stage_and_dispatch_error(
                     "handler_dispatch",
                     latency_fields.as_ref(),
                     handler_started_at,
-                    RuntimeDispatchErrorKind::Backend.as_str(),
-                    used_prepared_reservation,
-                );
-                trace_first_party_latency_error(
-                    "dispatch",
-                    latency_fields.as_ref(),
                     dispatch_started_at,
                     RuntimeDispatchErrorKind::Backend.as_str(),
                     used_prepared_reservation,
@@ -612,16 +600,10 @@ where
                     reservation_id = %reservation_id,
                     "first-party runtime adapter output serialization failed"
                 );
-                trace_first_party_latency_error(
+                trace_first_party_stage_and_dispatch_error(
                     "serialize_output",
                     latency_fields.as_ref(),
                     serialize_started_at,
-                    RuntimeDispatchErrorKind::OutputDecode.as_str(),
-                    used_prepared_reservation,
-                );
-                trace_first_party_latency_error(
-                    "dispatch",
-                    latency_fields.as_ref(),
                     dispatch_started_at,
                     RuntimeDispatchErrorKind::OutputDecode.as_str(),
                     used_prepared_reservation,
@@ -671,16 +653,10 @@ where
                         "failed to release first-party resource reservation after reconcile failure"
                     );
                 }
-                trace_first_party_latency_error(
+                trace_first_party_stage_and_dispatch_error(
                     "reconcile_resources",
                     latency_fields.as_ref(),
                     reconcile_started_at,
-                    RuntimeDispatchErrorKind::Resource.as_str(),
-                    used_prepared_reservation,
-                );
-                trace_first_party_latency_error(
-                    "dispatch",
-                    latency_fields.as_ref(),
                     dispatch_started_at,
                     RuntimeDispatchErrorKind::Resource.as_str(),
                     used_prepared_reservation,

--- a/crates/ironclaw_observability/Cargo.toml
+++ b/crates/ironclaw_observability/Cargo.toml
@@ -11,4 +11,5 @@ repository = "https://github.com/nearai/ironclaw"
 publish = false
 
 [dependencies]
+serde_json = "1"
 tracing = "0.1"

--- a/crates/ironclaw_observability/src/lib.rs
+++ b/crates/ironclaw_observability/src/lib.rs
@@ -24,6 +24,30 @@ pub fn live_latency_started_at() -> Option<Instant> {
     live_latency_enabled().then(Instant::now)
 }
 
+#[inline]
+pub fn json_value_bytes(value: &serde_json::Value) -> u64 {
+    let mut counter = JsonByteCounter::default();
+    serde_json::to_writer(&mut counter, value)
+        .map(|()| counter.bytes)
+        .unwrap_or(0)
+}
+
+#[derive(Default)]
+struct JsonByteCounter {
+    bytes: u64,
+}
+
+impl std::io::Write for JsonByteCounter {
+    fn write(&mut self, buffer: &[u8]) -> std::io::Result<usize> {
+        self.bytes = self.bytes.saturating_add(buffer.len() as u64);
+        Ok(buffer.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
 #[macro_export]
 macro_rules! live_latency_trace {
     ($($fields:tt)*) => {
@@ -62,4 +86,38 @@ macro_rules! live_latency_trace_error {
             );
         }
     };
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write as _;
+
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn json_value_bytes_matches_serialized_value_length() {
+        let value = json!({
+            "message": "hello",
+            "count": 3,
+            "items": ["a", "b"]
+        });
+
+        assert_eq!(
+            json_value_bytes(&value),
+            serde_json::to_vec(&value).unwrap().len() as u64
+        );
+    }
+
+    #[test]
+    fn json_byte_counter_saturates_on_write() {
+        let mut counter = JsonByteCounter {
+            bytes: u64::MAX - 1,
+        };
+
+        counter.write_all(b"abc").unwrap();
+
+        assert_eq!(counter.bytes, u64::MAX);
+    }
 }


### PR DESCRIPTION
## Summary

- Add `ironclaw_latency` trace events around first-party runtime dispatch.
- Add phase-level HTTP egress latency tracing for runtime tool calls.
- Add metadata-only latency tracing for built-in coding, GSuite, and web access tools.
- Keep trace field capture/emission in focused latency helper modules instead of duplicating it across each tool path.

## Why

Live traces currently show storage and model-loop timing, but first-party/built-in tools still have large opaque sections. This adds span-style trace events around the first-party capability dispatch path and common tool phases so we can see whether time is being spent in runtime setup, egress policy/transport/body handling, or the tool handler itself.

## Change Type

- [x] Observability / instrumentation
- [ ] Bug fix
- [ ] Feature
- [ ] Docs-only

## Linked Issue

None.

## Security Impact

Trace-only metadata. This does not log raw tool input params, file contents, URLs, headers, response bodies, or secret handles. Auth, approval, policy, and egress behavior are unchanged.

## Reborn Checklist

- [x] Reborn runtime path considered
- [x] No model/tool routing behavior change
- [x] No approval/auth bypass
- [x] Targeted runtime tests run

## Database Impact

None. No schema, migration, or storage format changes.

## Blast Radius

Runtime observability for first-party dispatch, HTTP egress, coding, GSuite, and web access tools. Log volume increases only when `ironclaw_latency=trace` is enabled.

## Rollback Plan

Revert this PR, or remove `ironclaw_latency=trace` from `RUST_LOG` to stop emitting these traces. The change is instrumentation-only.

## Review Follow-Through

Addressed CodeRabbit feedback by adding trace coverage for GSuite pre-dispatch and output shaping failures, starting the Exa initialize parse timer before parsing, trace-gating JSON byte counts, avoiding temporary JSON buffers for byte counts, emitting successful fresh resource reservations, and using stable runtime/method labels instead of debug formatting.

## Review Track

Runtime / observability.

## Privacy / Production Impact

- Trace-only change; no intended behavior change.
- Logs metadata only: operation names, capability IDs, scope IDs, payload byte counts, outcome, and stable error buckets.
- Does not log raw tool input params, file contents, URLs, headers, response bodies, or secret handles.

## Validation

- `cargo fmt`
- `cargo check -p ironclaw_host_runtime -p ironclaw_first_party_extensions`
- `cargo test -p ironclaw_first_party_extensions`
- `cargo test -p ironclaw_host_runtime --test first_party_builtin_tools`
- `cargo clippy -p ironclaw_host_runtime -p ironclaw_first_party_extensions --all-targets -- -D warnings`
- `git diff --check`

## Enablement

Use the existing latency target:

```bash
RUST_LOG="info,ironclaw_latency=trace"
```

New components to filter for include `first_party_runtime_adapter`, `runtime_http_egress`, `first_party_coding_tool`, `gsuite_first_party_tool`, and `web_access_first_party_tool`.
