### PR TITLE
ci(openwiki): fix provider config + apply openwiki#33 workaround so generation succeeds

### DIFF
--- a/.github/workflows/openwiki-update.yml
+++ b/.github/workflows/openwiki-update.yml
@@ -60,10 +60,30 @@ jobs:
       - name: Install OpenWiki
         run: npm install --global openwiki
 
-      # openwiki reads files as raw bytes and attaches binaries as media/document
-      # content blocks that the LLM API rejects. It has no ignore config, so strip
-      # non-text assets from this ephemeral checkout (the real repo is untouched;
-      # binaries carry no documentation value).
+      # openwiki bug (langchain-ai/openwiki#33): the bundled deepagents read-tool maps
+      # any unmapped/extensionless file (Makefile, Dockerfile, LICENSE, *.lock, ...) to
+      # application/octet-stream and sends it as a base64 `document` block, which the
+      # Anthropic Messages API rejects (only application/pdf allowed) -> 400 mid-run.
+      # Workaround from the issue: fall back to text/plain instead of octet-stream.
+      - name: Patch deepagents MIME fallback (openwiki#33 workaround)
+        run: |
+          B="$(npm root -g)/openwiki/node_modules/deepagents/dist"
+          patched=0
+          for f in "$B"/*.js "$B"/*.cjs; do
+            [ -f "$f" ] || continue
+            if grep -q 'toLocaleLowerCase()] || "application/octet-stream"' "$f"; then
+              sed -i 's#toLocaleLowerCase()\] || "application/octet-stream"#toLocaleLowerCase()] || "text/plain"#g' "$f"
+              patched=$((patched+1))
+            fi
+          done
+          echo "patched ${patched} deepagents bundle file(s): octet-stream -> text/plain"
+          if [ "${patched}" -eq 0 ]; then
+            echo "::warning::openwiki#33 patch matched nothing — deepagents bundle layout may have changed; run may 400 on extensionless files"
+          fi
+
+      # Real binaries (.png/.pdf/.xlsx/...) are ALSO sent as document blocks and only
+      # application/pdf is accepted, so strip them from this ephemeral checkout too
+      # (the real repo is untouched; binaries carry no documentation value).
       - name: Strip binary assets openwiki must not attach
         run: |
           find . -type f \( \

--- a/.github/workflows/openwiki-update.yml
+++ b/.github/workflows/openwiki-update.yml
@@ -13,18 +13,20 @@ name: OpenWiki Update
 #     the required-check workflows actually trigger on it — a GITHUB_TOKEN-opened PR
 #     does not trigger other workflows, so a human reviewer would see no checks and
 #     the ruleset would block the merge.
-#   - OPENWIKI_PROVIDER + OPENWIKI_MODEL_ID come from openwiki's own src/constants.ts,
-#     not the raw Anthropic API ids. Provider must be set explicitly ("anthropic") or
-#     openwiki defaults to OpenRouter. Anthropic model ids: claude-haiku-4-5 (default),
-#     claude-sonnet-5, claude-opus-4.8. Override per-run via the model_id dispatch input.
+#   - Uses openwiki's OpenAI provider pointed at NEAR AI's OpenAI-compatible endpoint
+#     (base https://cloud-api.near.ai/v1) with the existing LIVE_OPENAI_COMPATIBLE_API_KEY
+#     repo secret — same key/host/model the live-canary workflow uses. This avoids the
+#     Anthropic path, whose strict document-content-block validation openwiki trips on
+#     (400 invalid_request_error). Provider MUST be set or openwiki defaults to OpenRouter.
+#     Override the model per-run via the model_id dispatch input.
 
 on:
   workflow_dispatch:
     inputs:
       model_id:
-        description: "OPENWIKI_MODEL_ID (openwiki Anthropic ids: claude-haiku-4-5, claude-sonnet-5, claude-opus-4.8)"
+        description: "OPENWIKI_MODEL_ID (NEAR AI model, e.g. Qwen/Qwen3.5-122B-A10B or deepseek-ai/DeepSeek-V4-Flash)"
         required: false
-        default: "claude-haiku-4-5"
+        default: ""
   schedule:
     - cron: "0 8 * * 1"   # Mondays 08:00 UTC (weekly)
 
@@ -60,12 +62,12 @@ jobs:
       - name: Regenerate wiki
         run: openwiki --update --print
         env:
-          # openwiki needs OPENWIKI_PROVIDER explicitly; without it it defaults to
-          # OpenRouter and demands OPENROUTER_API_KEY. Provider ids + model ids come
-          # from openwiki's src/constants.ts (NOT the raw Anthropic API ids).
-          OPENWIKI_PROVIDER: anthropic
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          OPENWIKI_MODEL_ID: ${{ github.event.inputs.model_id || 'claude-haiku-4-5' }}
+          # openwiki's OpenAI provider -> NEAR AI OpenAI-compatible endpoint.
+          # base URL + model default to the same values live-canary.yml uses.
+          OPENWIKI_PROVIDER: openai
+          OPENAI_API_KEY: ${{ secrets.LIVE_OPENAI_COMPATIBLE_API_KEY }}
+          OPENAI_BASE_URL: ${{ vars.LIVE_OPENAI_COMPATIBLE_BASE_URL || 'https://cloud-api.near.ai/v1' }}
+          OPENWIKI_MODEL_ID: ${{ github.event.inputs.model_id || vars.LIVE_OPENAI_COMPATIBLE_MODEL || 'Qwen/Qwen3.5-122B-A10B' }}
 
       - name: Open review PR
         id: cpr

--- a/.github/workflows/openwiki-update.yml
+++ b/.github/workflows/openwiki-update.yml
@@ -13,20 +13,21 @@ name: OpenWiki Update
 #     the required-check workflows actually trigger on it — a GITHUB_TOKEN-opened PR
 #     does not trigger other workflows, so a human reviewer would see no checks and
 #     the ruleset would block the merge.
-#   - Uses openwiki's OpenAI provider pointed at NEAR AI's OpenAI-compatible endpoint
-#     (base https://cloud-api.near.ai/v1) with the existing LIVE_OPENAI_COMPATIBLE_API_KEY
-#     repo secret — same key/host/model the live-canary workflow uses. This avoids the
-#     Anthropic path, whose strict document-content-block validation openwiki trips on
-#     (400 invalid_request_error). Provider MUST be set or openwiki defaults to OpenRouter.
-#     Override the model per-run via the model_id dispatch input.
+#   - Provider set explicitly to "anthropic" (openwiki defaults to OpenRouter otherwise);
+#     model ids are openwiki's own (src/constants.ts): claude-haiku-4-5 (default),
+#     claude-sonnet-5, claude-opus-4.8. Override per-run via the model_id dispatch input.
+#   - openwiki's read_file tool wraps binary files as media/document content blocks, which
+#     Anthropic rejects (e.g. tests/fixtures/hello.pdf -> a non-PDF document block, 400).
+#     openwiki has no hard ignore config, so the "Strip binary assets" step below removes
+#     them from the EPHEMERAL checkout (the real repo is untouched) so they can't be read.
 
 on:
   workflow_dispatch:
     inputs:
       model_id:
-        description: "OPENWIKI_MODEL_ID (NEAR AI model, e.g. Qwen/Qwen3.5-122B-A10B or deepseek-ai/DeepSeek-V4-Flash)"
+        description: "OPENWIKI_MODEL_ID (openwiki Anthropic ids: claude-haiku-4-5, claude-sonnet-5, claude-opus-4.8)"
         required: false
-        default: ""
+        default: "claude-haiku-4-5"
   schedule:
     - cron: "0 8 * * 1"   # Mondays 08:00 UTC (weekly)
 
@@ -59,15 +60,27 @@ jobs:
       - name: Install OpenWiki
         run: npm install --global openwiki
 
+      # openwiki reads files as raw bytes and attaches binaries as media/document
+      # content blocks that the LLM API rejects. It has no ignore config, so strip
+      # non-text assets from this ephemeral checkout (the real repo is untouched;
+      # binaries carry no documentation value).
+      - name: Strip binary assets openwiki must not attach
+        run: |
+          find . -type f \( \
+            -name '*.pdf' -o -name '*.png' -o -name '*.jpg' -o -name '*.jpeg' \
+            -o -name '*.gif' -o -name '*.webp' -o -name '*.ico' -o -name '*.svg' \
+            -o -name '*.wasm' -o -name '*.woff' -o -name '*.woff2' -o -name '*.ttf' \
+            -o -name '*.otf' -o -name '*.gz' -o -name '*.zip' -o -name '*.zst' \
+            -o -name '*.mp4' -o -name '*.mov' -o -name '*.pdf' \) \
+            -not -path './.git/*' -delete
+          echo "stripped binary assets from ephemeral checkout"
+
       - name: Regenerate wiki
         run: openwiki --update --print
         env:
-          # openwiki's OpenAI provider -> NEAR AI OpenAI-compatible endpoint.
-          # base URL + model default to the same values live-canary.yml uses.
-          OPENWIKI_PROVIDER: openai
-          OPENAI_API_KEY: ${{ secrets.LIVE_OPENAI_COMPATIBLE_API_KEY }}
-          OPENAI_BASE_URL: ${{ vars.LIVE_OPENAI_COMPATIBLE_BASE_URL || 'https://cloud-api.near.ai/v1' }}
-          OPENWIKI_MODEL_ID: ${{ github.event.inputs.model_id || vars.LIVE_OPENAI_COMPATIBLE_MODEL || 'Qwen/Qwen3.5-122B-A10B' }}
+          OPENWIKI_PROVIDER: anthropic
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENWIKI_MODEL_ID: ${{ github.event.inputs.model_id || 'claude-haiku-4-5' }}
 
       - name: Open review PR
         id: cpr

--- a/.github/workflows/openwiki-update.yml
+++ b/.github/workflows/openwiki-update.yml
@@ -13,12 +13,18 @@ name: OpenWiki Update
 #     the required-check workflows actually trigger on it — a GITHUB_TOKEN-opened PR
 #     does not trigger other workflows, so a human reviewer would see no checks and
 #     the ruleset would block the merge.
-#   - OPENWIKI_MODEL_ID must match OpenWiki's Anthropic model resolution; if the
-#     run errors on the model, adjust the string (e.g. an "anthropic/"/"anthropic:"
-#     prefix, or claude-haiku-4-5-20251001 for a cheaper pass).
+#   - OPENWIKI_PROVIDER + OPENWIKI_MODEL_ID come from openwiki's own src/constants.ts,
+#     not the raw Anthropic API ids. Provider must be set explicitly ("anthropic") or
+#     openwiki defaults to OpenRouter. Anthropic model ids: claude-haiku-4-5 (default),
+#     claude-sonnet-5, claude-opus-4.8. Override per-run via the model_id dispatch input.
 
 on:
   workflow_dispatch:
+    inputs:
+      model_id:
+        description: "OPENWIKI_MODEL_ID (openwiki Anthropic ids: claude-haiku-4-5, claude-sonnet-5, claude-opus-4.8)"
+        required: false
+        default: "claude-haiku-4-5"
   schedule:
     - cron: "0 8 * * 1"   # Mondays 08:00 UTC (weekly)
 
@@ -54,8 +60,12 @@ jobs:
       - name: Regenerate wiki
         run: openwiki --update --print
         env:
+          # openwiki needs OPENWIKI_PROVIDER explicitly; without it it defaults to
+          # OpenRouter and demands OPENROUTER_API_KEY. Provider ids + model ids come
+          # from openwiki's src/constants.ts (NOT the raw Anthropic API ids).
+          OPENWIKI_PROVIDER: anthropic
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          OPENWIKI_MODEL_ID: claude-sonnet-4-6
+          OPENWIKI_MODEL_ID: ${{ github.event.inputs.model_id || 'claude-haiku-4-5' }}
 
       - name: Open review PR
         id: cpr


### PR DESCRIPTION
## What this fixes

The OpenWiki workflow merged in #5532 never actually generated — it failed on the first file read. This makes it work, and it just produced the first wiki: #5535 (+3,062 lines).

## The bug (langchain-ai/openwiki#33)

openwiki's bundled `deepagents` read-tool maps any **unmapped/extensionless** file (`Makefile`, `Dockerfile`, `LICENSE`, `*.lock`, …) to `application/octet-stream` and sends it as a base64 `document` content block. The Anthropic Messages API only accepts `application/pdf` for base64 documents, so the agent 400s on the first such file. (NEAR AI's OpenAI-compatible endpoint rejects the same shape.)

## The fix

Three additions to `.github/workflows/openwiki-update.yml`:
1. **Set `OPENWIKI_PROVIDER: anthropic`** — without it openwiki defaults to OpenRouter (and demanded a key we don't have). Correct model id `claude-haiku-4-5` (openwiki's own id, via `src/constants.ts`), overridable by a `model_id` dispatch input.
2. **Patch step (openwiki#33 workaround)** — rewrite the installed deepagents MIME fallback from `octet-stream` → `text/plain` so extensionless text files are inlined as text, not attached as documents.
3. **Strip binary assets** from the ephemeral checkout (genuine `.png/.pdf/...` are also sent as document blocks and only `application/pdf` is accepted). The real repo is untouched.

Provider stays **Anthropic** (it was never the problem — auth and generation both work once #33 is patched). Publishing is unchanged: a human-reviewed PR via the GH App, no auto-merge (SOC 2).

## Validation

Dispatched from this branch end-to-end: patch ✓, strip ✓, `Regenerate wiki` ✓ (ran to completion, not the prior 5-second crash), and it opened #5535.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
