### PR TITLE
Fix thread list pagination when automation threads dominate

### DIFF
--- a/crates/ironclaw_product_workflow/src/reborn_services.rs
+++ b/crates/ironclaw_product_workflow/src/reborn_services.rs
@@ -44,9 +44,9 @@ use url::Url;
 use uuid::Uuid;
 
 use crate::{
-    ApprovalInteractionDecision, ApprovalInteractionService, AuthInteractionDecision,
-    AuthInteractionRejectionKind, AuthInteractionService, LifecyclePackageRef,
-    LifecycleProductFacade, ListPendingApprovalsRequest, ProductWorkflowError,
+    AUTOMATION_TRIGGER_THREAD_SOURCE_TAG, ApprovalInteractionDecision, ApprovalInteractionService,
+    AuthInteractionDecision, AuthInteractionRejectionKind, AuthInteractionService,
+    LifecyclePackageRef, LifecycleProductFacade, ListPendingApprovalsRequest, ProductWorkflowError,
     ResolveApprovalInteractionRequest, ResolveApprovalInteractionResponse,
     ResolveAuthInteractionRequest, ResolveAuthInteractionResponse,
     UnsupportedLifecycleProductFacade, WebUiAuthenticatedCaller, WebUiCancelRunRequest,
@@ -59,7 +59,7 @@ use crate::{
         DEFAULT_BINDING_REF_RAW_MAX_BYTES, bounded_reply_target_binding_ref,
         bounded_source_binding_ref,
     },
-    is_approval_gate_ref, is_auth_gate_ref, thread_metadata_is_automation_trigger,
+    is_approval_gate_ref, is_auth_gate_ref,
 };
 
 mod error;
@@ -4309,68 +4309,20 @@ impl RebornServices {
             .await
             .map_err(|_| notification_approval_timeout_error())?;
         }
-        let fetch_limit = visible_limit
-            .max(THREAD_LIST_FILTER_MIN_FETCH_SIZE)
-            .min(THREAD_LIST_MAX_PAGE_SIZE as usize);
-        let mut cursor = request.cursor;
-        let mut visible_threads = Vec::with_capacity(visible_limit);
-        let mut next_cursor = None;
-        let mut pages_fetched = 0usize;
-
-        while visible_threads.len() < visible_limit {
-            if pages_fetched >= THREAD_LIST_FILTER_MAX_PAGES {
-                tracing::warn!(
-                    cursor = ?cursor,
-                    pages_fetched,
-                    max_pages = THREAD_LIST_FILTER_MAX_PAGES,
-                    visible_threads = visible_threads.len(),
-                    visible_limit,
-                    "thread listing filter page budget exhausted while skipping automation threads"
-                );
-                next_cursor = None;
-                break;
-            }
-            pages_fetched += 1;
-            let response = self
-                .thread_service
-                .list_threads_for_scope(ironclaw_threads::ListThreadsForScopeRequest {
-                    scope: scope.clone(),
-                    limit: Some(fetch_limit as u32),
-                    cursor: cursor.clone(),
-                })
-                .await
-                .map_err(map_thread_error)?;
-            for thread in response.threads {
-                if is_automation_trigger_thread(&thread) {
-                    continue;
-                }
-                visible_threads.push(thread);
-            }
-            next_cursor = response.next_cursor;
-            let Some(next) = next_cursor.clone() else {
-                break;
-            };
-            if cursor.as_deref() == Some(next.as_str()) {
-                tracing::warn!(
-                    cursor = %next,
-                    "thread listing cursor did not advance while filtering automation threads"
-                );
-                next_cursor = None;
-                break;
-            }
-            cursor = Some(next);
-        }
-
-        if visible_threads.len() > visible_limit {
-            next_cursor = visible_threads
-                .get(visible_limit.saturating_sub(1))
-                .map(|thread| thread.thread_id.as_str().to_string());
-            visible_threads.truncate(visible_limit);
-        }
+        let response = self
+            .thread_service
+            .list_threads_for_scope(ironclaw_threads::ListThreadsForScopeRequest {
+                scope,
+                limit: Some(visible_limit as u32),
+                cursor: request.cursor,
+                excluded_metadata_sources: vec![AUTOMATION_TRIGGER_THREAD_SOURCE_TAG.to_string()],
+            })
+            .await
+            .map_err(map_thread_error)?;
 
         Ok(RebornListThreadsResponse {
-            threads: visible_threads,
-            next_cursor,
+            threads: response.threads,
+            next_cursor: response.next_cursor,
         })
     }
 
@@ -4653,23 +4605,6 @@ impl RebornServices {
 
 fn automation_unavailable() -> RebornServicesError {
     RebornServicesError::service_unavailable(true)
-}
-
-fn is_automation_trigger_thread(thread: &SessionThreadRecord) -> bool {
-    let Some(metadata) = thread.metadata_json.as_deref() else {
-        return false;
-    };
-    match thread_metadata_is_automation_trigger(metadata) {
-        Ok(is_automation_trigger) => is_automation_trigger,
-        Err(error) => {
-            tracing::debug!(
-                error = %error,
-                thread_id = %thread.thread_id,
-                "failed to parse thread metadata_json for automation filter"
-            );
-            false
-        }
-    }
 }
 
 fn outbound_preferences_unavailable() -> RebornServicesError {
@@ -5763,8 +5698,6 @@ const TIMELINE_MAX_SUMMARY_ARTIFACTS: usize = 200;
 
 const THREAD_LIST_DEFAULT_PAGE_SIZE: u32 = 50;
 const THREAD_LIST_MAX_PAGE_SIZE: u32 = 200;
-const THREAD_LIST_FILTER_MIN_FETCH_SIZE: usize = 50;
-const THREAD_LIST_FILTER_MAX_PAGES: usize = 20;
 const NOTIFICATION_APPROVAL_AUTOMATION_LIMIT: usize = 20;
 const NOTIFICATION_APPROVAL_RUN_LIMIT: usize = 20;
 const NOTIFICATION_APPROVAL_CANDIDATE_LIMIT: usize = 20;

--- a/crates/ironclaw_product_workflow/src/reborn_services.rs
+++ b/crates/ironclaw_product_workflow/src/reborn_services.rs
@@ -5857,7 +5857,7 @@ fn automation_trigger_metadata_source() -> ThreadMetadataSource {
     // Invariant: the automation source tag is a static non-empty ASCII label
     // below the thread metadata source bound.
     ThreadMetadataSource::new(AUTOMATION_TRIGGER_THREAD_SOURCE_TAG)
-        .expect("static automation trigger metadata source is non-empty and bounded")
+        .expect("static automation trigger metadata source is non-empty and bounded") // safety: static tag is a repository-owned constant validated by thread metadata source bounds.
 }
 
 fn map_timeline_probe_error(error: SessionThreadError) -> RebornServicesError {

--- a/crates/ironclaw_product_workflow/src/reborn_services.rs
+++ b/crates/ironclaw_product_workflow/src/reborn_services.rs
@@ -31,7 +31,7 @@ use ironclaw_threads::{
     AcceptInboundMessageRequest, AcceptedInboundMessageReplay, AttachmentRef, EnsureThreadRequest,
     MessageContent, MessageStatus, ReplayAcceptedInboundMessageRequest, SessionThreadError,
     SessionThreadRecord, SessionThreadService, ThreadHistory, ThreadHistoryRequest,
-    ThreadMessageId, ThreadScope,
+    ThreadMessageId, ThreadMetadataSource, ThreadScope,
 };
 use ironclaw_turns::{
     AcceptedMessageRef, GateRef, GetRunStateRequest, IdempotencyKey, ResumeTurnPrecondition,
@@ -4315,7 +4315,7 @@ impl RebornServices {
                 scope,
                 limit: Some(visible_limit as u32),
                 cursor: request.cursor,
-                excluded_metadata_sources: vec![AUTOMATION_TRIGGER_THREAD_SOURCE_TAG.to_string()],
+                excluded_metadata_sources: vec![automation_trigger_metadata_source()],
             })
             .await
             .map_err(map_thread_error)?;
@@ -5851,6 +5851,13 @@ fn blocked_authentication_unavailable() -> RebornServicesError {
 
 fn segment(name: &str, value: &str) -> String {
     format!("{name}:{}:{value};", value.len())
+}
+
+fn automation_trigger_metadata_source() -> ThreadMetadataSource {
+    // Invariant: the automation source tag is a static non-empty ASCII label
+    // below the thread metadata source bound.
+    ThreadMetadataSource::new(AUTOMATION_TRIGGER_THREAD_SOURCE_TAG)
+        .expect("static automation trigger metadata source is non-empty and bounded")
 }
 
 fn map_timeline_probe_error(error: SessionThreadError) -> RebornServicesError {

--- a/crates/ironclaw_product_workflow/tests/reborn_services_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/reborn_services_contract.rs
@@ -89,7 +89,7 @@ use ironclaw_threads::{
     LoadContextWindowRequest, MessageContent, MessageKind, MessageStatus, RedactMessageRequest,
     ReplayAcceptedInboundMessageRequest, SessionThreadError, SessionThreadRecord,
     SessionThreadService, SummaryArtifact, ThreadHistory, ThreadHistoryRequest, ThreadMessageId,
-    ThreadMessageRecord, ThreadScope, UpdateAssistantDraftRequest,
+    ThreadMessageRecord, ThreadMetadataSource, ThreadScope, UpdateAssistantDraftRequest,
     UpdateToolResultReferenceRequest,
 };
 use ironclaw_turns::{
@@ -157,6 +157,10 @@ fn run_id_string() -> String {
 
 fn automation_run_id() -> TurnRunId {
     TurnRunId::parse("11111111-1111-1111-1111-111111111111").expect("valid automation run id")
+}
+
+fn metadata_source(source: &str) -> ThreadMetadataSource {
+    ThreadMetadataSource::new(source).expect("valid metadata source")
 }
 
 fn fake_thread_history(owner: &WebUiAuthenticatedCaller, thread_id: &str) -> ThreadHistory {
@@ -10447,7 +10451,7 @@ async fn list_threads_requests_backend_filter_for_automation_trigger_threads() {
     assert_eq!(list_requests[0].cursor.as_deref(), Some("cursor-in"));
     assert_eq!(
         list_requests[0].excluded_metadata_sources,
-        vec![AUTOMATION_TRIGGER_THREAD_SOURCE_TAG.to_string()],
+        vec![metadata_source(AUTOMATION_TRIGGER_THREAD_SOURCE_TAG)],
         "the product facade must ask the backend to hide automation threads before pagination",
     );
 }

--- a/crates/ironclaw_product_workflow/tests/reborn_services_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/reborn_services_contract.rs
@@ -10104,6 +10104,86 @@ async fn list_threads_hides_automation_trigger_threads() {
 }
 
 #[tokio::test]
+async fn list_threads_keeps_created_threads_without_source_metadata_when_filtering_automation() {
+    let thread_service = Arc::new(InMemorySessionThreadService::default());
+    let services = RebornServices::new(
+        thread_service.clone(),
+        Arc::new(FakeTurnCoordinator::default()),
+    );
+    let caller = caller();
+    let visible_thread_id =
+        ThreadId::new("thread-created-without-source").expect("visible thread id");
+    let automation_thread_id =
+        ThreadId::new("thread-newer-automation-source").expect("automation thread id");
+
+    let created = services
+        .create_thread(
+            caller.clone(),
+            serde_json::from_value::<WebUiCreateThreadRequest>(json!({
+                "client_action_id": "create-without-source",
+                "requested_thread_id": visible_thread_id.as_str()
+            }))
+            .expect("create request"),
+        )
+        .await
+        .expect("create source-less thread");
+    assert_eq!(created.thread.thread_id, visible_thread_id);
+    let metadata = created
+        .thread
+        .metadata_json
+        .as_deref()
+        .and_then(|metadata| serde_json::from_str::<serde_json::Value>(metadata).ok())
+        .expect("created thread metadata is json");
+    assert_eq!(
+        metadata.get("source"),
+        None,
+        "ordinary WebUI create-thread metadata does not carry a source field",
+    );
+    if let Some(updated_at) = created.thread.updated_at {
+        wait_until_after(updated_at).await;
+    }
+
+    thread_service
+        .ensure_thread(EnsureThreadRequest {
+            scope: thread_scope_for(&caller),
+            thread_id: Some(automation_thread_id.clone()),
+            created_by_actor_id: "system".to_string(),
+            title: Some("Newer automation run".to_string()),
+            metadata_json: Some(automation_trigger_thread_metadata_json(
+                "trigger-created-source-less",
+            )),
+        })
+        .await
+        .expect("newer automation thread");
+
+    let response = services
+        .list_threads(
+            caller,
+            WebUiListThreadsRequest {
+                limit: Some(1),
+                ..WebUiListThreadsRequest::default()
+            },
+        )
+        .await
+        .expect("list visible threads");
+    let thread_ids = response
+        .threads
+        .iter()
+        .map(|thread| thread.thread_id.clone())
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        thread_ids,
+        vec![visible_thread_id],
+        "source-less WebUI-created threads must stay visible when automation threads are filtered before pagination",
+    );
+    assert!(
+        !thread_ids.contains(&automation_thread_id),
+        "newer automation thread would have filled the page if the backend exclusion were not active",
+    );
+}
+
+#[tokio::test]
 async fn list_threads_needs_approval_returns_only_automation_threads_with_pending_approval() {
     let thread_service = Arc::new(InMemorySessionThreadService::default());
     let caller = caller();

--- a/crates/ironclaw_product_workflow/tests/reborn_services_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/reborn_services_contract.rs
@@ -10401,94 +10401,26 @@ async fn list_threads_needs_approval_checks_candidate_automation_thread() {
 }
 
 #[tokio::test]
-async fn list_threads_breaks_out_when_cursor_does_not_advance_for_automation_threads() {
+async fn list_threads_requests_backend_filter_for_automation_trigger_threads() {
     let caller = caller();
     let scope = thread_scope_for(&caller);
-    let automation_thread = |thread_id: &str| SessionThreadRecord {
+    let visible_thread_id = ThreadId::new("thread-visible-filtered").expect("thread id");
+    let visible_thread = SessionThreadRecord {
         scope: scope.clone(),
-        thread_id: ThreadId::new(thread_id).expect("automation thread id"),
+        thread_id: visible_thread_id.clone(),
         created_by_actor_id: caller.user_id.as_str().to_string(),
-        title: Some(format!("Automation run {thread_id}")),
-        metadata_json: Some(automation_trigger_thread_metadata_json(
-            "trigger-scheduled-summary",
-        )),
+        title: Some("Visible chat".to_string()),
+        metadata_json: Some(json!({ "source": "webui" }).to_string()),
         goal: None,
         created_at: None,
         updated_at: None,
     };
-    let stalled_cursor = "cursor-stalled".to_string();
     let thread_service = Arc::new(ScriptedThreadService::list_pages(vec![
         ListThreadsForScopeResponse {
-            threads: vec![automation_thread("thread-automation-stall-1")],
-            next_cursor: Some(stalled_cursor.clone()),
-        },
-        ListThreadsForScopeResponse {
-            threads: vec![automation_thread("thread-automation-stall-2")],
-            next_cursor: Some(stalled_cursor.clone()),
+            threads: vec![visible_thread],
+            next_cursor: Some("cursor-visible".to_string()),
         },
     ]));
-    let services = RebornServices::new(
-        thread_service.clone(),
-        Arc::new(FakeTurnCoordinator::default()),
-    );
-
-    let response = tokio::time::timeout(
-        Duration::from_secs(1),
-        services.list_threads(
-            caller,
-            WebUiListThreadsRequest {
-                limit: Some(2),
-                cursor: None,
-                ..WebUiListThreadsRequest::default()
-            },
-        ),
-    )
-    .await
-    .expect("list_threads should terminate when backend cursor stalls")
-    .expect("list threads");
-
-    assert!(
-        response.threads.is_empty(),
-        "automation trigger threads must stay hidden even when every fetched page is filtered",
-    );
-    assert_eq!(
-        response.next_cursor, None,
-        "stalled cursor must be cleared so callers do not keep replaying the same filtered page",
-    );
-    let list_requests = thread_service.list_requests();
-    assert_eq!(
-        list_requests.len(),
-        2,
-        "facade should fetch the stalled page once and then break on the repeated cursor",
-    );
-    assert_eq!(list_requests[0].cursor, None);
-    assert_eq!(list_requests[1].cursor.as_deref(), Some("cursor-stalled"));
-}
-
-#[tokio::test]
-async fn list_threads_caps_filtered_pages_when_automation_threads_dominate() {
-    let caller = caller();
-    let scope = thread_scope_for(&caller);
-    let automation_thread = |index: usize| SessionThreadRecord {
-        scope: scope.clone(),
-        thread_id: ThreadId::new(format!("thread-automation-budget-{index:02}"))
-            .expect("automation thread id"),
-        created_by_actor_id: caller.user_id.as_str().to_string(),
-        title: Some(format!("Automation run {index}")),
-        metadata_json: Some(automation_trigger_thread_metadata_json(
-            "trigger-scheduled-summary",
-        )),
-        goal: None,
-        created_at: None,
-        updated_at: None,
-    };
-    let responses = (0..20)
-        .map(|index| ListThreadsForScopeResponse {
-            threads: vec![automation_thread(index)],
-            next_cursor: Some(format!("cursor-{index:02}")),
-        })
-        .collect::<Vec<_>>();
-    let thread_service = Arc::new(ScriptedThreadService::list_pages(responses));
     let services = RebornServices::new(
         thread_service.clone(),
         Arc::new(FakeTurnCoordinator::default()),
@@ -10498,33 +10430,25 @@ async fn list_threads_caps_filtered_pages_when_automation_threads_dominate() {
         .list_threads(
             caller,
             WebUiListThreadsRequest {
-                limit: Some(1),
-                cursor: None,
+                limit: Some(2),
+                cursor: Some("cursor-in".to_string()),
                 ..WebUiListThreadsRequest::default()
             },
         )
         .await
         .expect("list threads");
 
-    assert!(
-        response.threads.is_empty(),
-        "automation trigger threads must stay hidden when filter pages are exhausted",
-    );
-    assert_eq!(
-        response.next_cursor, None,
-        "filter page budget exhaustion must clear the cursor so callers do not keep scanning",
-    );
+    assert_eq!(response.threads.len(), 1);
+    assert_eq!(response.threads[0].thread_id, visible_thread_id);
+    assert_eq!(response.next_cursor.as_deref(), Some("cursor-visible"));
     let list_requests = thread_service.list_requests();
+    assert_eq!(list_requests.len(), 1);
+    assert_eq!(list_requests[0].limit, Some(2));
+    assert_eq!(list_requests[0].cursor.as_deref(), Some("cursor-in"));
     assert_eq!(
-        list_requests.len(),
-        20,
-        "facade must enforce a hard cap on filtered backend pages",
-    );
-    assert!(
-        list_requests
-            .iter()
-            .all(|request| request.limit == Some(50)),
-        "facade should use a fixed candidate page size instead of shrinking toward one"
+        list_requests[0].excluded_metadata_sources,
+        vec![AUTOMATION_TRIGGER_THREAD_SOURCE_TAG.to_string()],
+        "the product facade must ask the backend to hide automation threads before pagination",
     );
 }
 

--- a/crates/ironclaw_reborn_composition/src/slack_host_beta.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_host_beta.rs
@@ -3862,6 +3862,7 @@ mod tests {
                     scope: scope.clone(),
                     limit: Some(1),
                     cursor: None,
+                    excluded_metadata_sources: Vec::new(),
                 })
                 .await
                 .expect("list Slack-created threads");
@@ -3899,6 +3900,7 @@ mod tests {
                 scope: scope.clone(),
                 limit: Some(100),
                 cursor: None,
+                excluded_metadata_sources: Vec::new(),
             })
             .await
             .expect("list Slack-created threads");
@@ -3959,6 +3961,7 @@ mod tests {
                 scope,
                 limit: Some(1),
                 cursor: None,
+                excluded_metadata_sources: Vec::new(),
             })
             .await
             .expect("list Slack-created threads");

--- a/crates/ironclaw_reborn_composition/src/trigger_poller_trusted_submit.rs
+++ b/crates/ironclaw_reborn_composition/src/trigger_poller_trusted_submit.rs
@@ -566,6 +566,7 @@ mod tests {
                 scope,
                 limit: Some(10),
                 cursor: None,
+                excluded_metadata_sources: Vec::new(),
             })
             .await
             .expect("threads load");
@@ -1685,6 +1686,7 @@ mod tests {
                 scope: expected_scope.clone(),
                 limit: Some(10),
                 cursor: None,
+                excluded_metadata_sources: Vec::new(),
             })
             .await
             .expect("threads load");
@@ -1837,6 +1839,7 @@ mod tests {
                 },
                 limit: Some(10),
                 cursor: None,
+                excluded_metadata_sources: Vec::new(),
             })
             .await
             .expect("threads load");

--- a/crates/ironclaw_threads/src/contract.rs
+++ b/crates/ironclaw_threads/src/contract.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use chrono::{DateTime, Utc};
 use ironclaw_common::AttachmentRef;
 use ironclaw_host_api::{AgentId, MissionId, ProjectId, TenantId, ThreadId, UserId};
@@ -8,6 +10,7 @@ use crate::identifiers::{SummaryArtifactId, ThreadMessageId};
 use crate::tool_result_reference::{ProviderToolCallReferenceEnvelope, ToolResultSafeSummary};
 
 pub const GOAL_STATEMENT_MAX_CHARS: usize = 4000;
+const THREAD_METADATA_SOURCE_MAX_CHARS: usize = 128;
 
 /// Canonical scope carried by a Reborn session thread.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -434,6 +437,78 @@ pub struct FinalizedAssistantMessageByRunRequest {
     pub turn_run_id: String,
 }
 
+/// Typed metadata `source` selector used by thread list filters.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(try_from = "String")]
+pub struct ThreadMetadataSource(String);
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ThreadMetadataSourceError {
+    #[error("thread metadata source must not be empty")]
+    Empty,
+    #[error("thread metadata source exceeds {max} chars")]
+    TooLong { max: usize },
+    #[error("thread metadata source must not contain control characters")]
+    ControlCharacter,
+}
+
+impl ThreadMetadataSource {
+    pub fn new(raw: impl Into<String>) -> Result<Self, ThreadMetadataSourceError> {
+        let value = raw.into();
+        Self::validate(&value)?;
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn into_inner(self) -> String {
+        self.0
+    }
+
+    fn validate(value: &str) -> Result<(), ThreadMetadataSourceError> {
+        if value.trim().is_empty() {
+            return Err(ThreadMetadataSourceError::Empty);
+        }
+        if value.chars().count() > THREAD_METADATA_SOURCE_MAX_CHARS {
+            return Err(ThreadMetadataSourceError::TooLong {
+                max: THREAD_METADATA_SOURCE_MAX_CHARS,
+            });
+        }
+        if value.chars().any(char::is_control) {
+            return Err(ThreadMetadataSourceError::ControlCharacter);
+        }
+        Ok(())
+    }
+}
+
+impl TryFrom<String> for ThreadMetadataSource {
+    type Error = ThreadMetadataSourceError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl AsRef<str> for ThreadMetadataSource {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl fmt::Display for ThreadMetadataSource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl From<ThreadMetadataSource> for String {
+    fn from(value: ThreadMetadataSource) -> Self {
+        value.into_inner()
+    }
+}
+
 /// Browser-driven list-threads query scoped to a single caller.
 ///
 /// Pagination is opaque: `cursor` is whatever value the backend
@@ -445,7 +520,7 @@ pub struct ListThreadsForScopeRequest {
     pub scope: ThreadScope,
     pub limit: Option<u32>,
     pub cursor: Option<String>,
-    pub excluded_metadata_sources: Vec<String>,
+    pub excluded_metadata_sources: Vec<ThreadMetadataSource>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]

--- a/crates/ironclaw_threads/src/contract.rs
+++ b/crates/ironclaw_threads/src/contract.rs
@@ -445,6 +445,7 @@ pub struct ListThreadsForScopeRequest {
     pub scope: ThreadScope,
     pub limit: Option<u32>,
     pub cursor: Option<String>,
+    pub excluded_metadata_sources: Vec<String>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]

--- a/crates/ironclaw_threads/src/filesystem_service.rs
+++ b/crates/ironclaw_threads/src/filesystem_service.rs
@@ -51,6 +51,7 @@ use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
 use crate::identifiers::SummaryArtifactId;
+use crate::service::thread_metadata_source_is_excluded;
 use crate::summary_artifacts::find_overlapping_summary;
 use crate::title::derive_title_from_message;
 use crate::{
@@ -2402,7 +2403,13 @@ where
         let mut listed: Vec<(SessionThreadRecord, u64)> = Vec::with_capacity(reads.len());
         for (thread_id, result) in reads {
             match result {
-                Ok(Some((stored, _))) if stored.record.scope == request.scope => {
+                Ok(Some((stored, _)))
+                    if stored.record.scope == request.scope
+                        && !thread_metadata_source_is_excluded(
+                            &stored.record,
+                            &request.excluded_metadata_sources,
+                        ) =>
+                {
                     let next_sequence = stored.next_sequence;
                     listed.push((stored.record, next_sequence));
                 }

--- a/crates/ironclaw_threads/src/in_memory.rs
+++ b/crates/ironclaw_threads/src/in_memory.rs
@@ -10,6 +10,7 @@ use tokio::sync::Mutex;
 use uuid::Uuid;
 
 use crate::identifiers::SummaryArtifactId;
+use crate::service::thread_metadata_source_is_excluded;
 use crate::summary_artifacts::find_overlapping_summary;
 use crate::title::derive_thread_title;
 use crate::{
@@ -65,6 +66,100 @@ impl InboundIdempotencyKey {
             scope: request.scope.clone(),
             source_binding_id: request.source_binding_id.clone()?,
             external_event_id: request.external_event_id.clone()?,
+        })
+    }
+}
+
+impl InMemorySessionThreadService {
+    async fn list_threads_for_scope_inner(
+        &self,
+        scope: ThreadScope,
+        limit: Option<u32>,
+        cursor: Option<String>,
+        excluded_metadata_sources: &[String],
+    ) -> Result<ListThreadsForScopeResponse, SessionThreadError> {
+        // In-memory enumeration for local-dev. Production backends
+        // (filesystem / postgres) override with their own pagination
+        // strategy; this impl is fine because the store is bounded
+        // by tenant memory in the first place.
+        let limit = limit
+            .map(|n| (n as usize).clamp(1, LIST_THREADS_MAX_PAGE_SIZE))
+            .unwrap_or(LIST_THREADS_DEFAULT_PAGE_SIZE);
+
+        let state = self.state.lock().await;
+
+        // Scope filter is exact equality on the full `ThreadScope`
+        // tuple — tenant + agent + project + owner — so a caller
+        // cannot see threads owned by other users in the same
+        // (tenant, agent, project) triple. The trait contract
+        // documents this invariant.
+        //
+        // Filter before cloning: matching on the borrowed scope avoids
+        // cloning records owned by other tenants/projects only to throw
+        // them away. Metadata-source exclusions are also applied before
+        // pagination so hidden system-owned threads cannot bury visible
+        // chat threads behind cursor windows.
+        //
+        // Derive a sidebar-friendly title from the first user message
+        // when the record itself has none. Matches v1's libSQL list
+        // semantics: titles aren't stored, they're computed on read
+        // from the first user message in the transcript. The
+        // filesystem backend does the same thing via
+        // `list_thread_messages` + `derive_title_from_message`.
+        let mut matching: Vec<SessionThreadRecord> = state
+            .threads
+            .values()
+            .filter(|stored| stored.record.scope == scope)
+            .filter(|stored| {
+                !thread_metadata_source_is_excluded(&stored.record, excluded_metadata_sources)
+            })
+            .map(|stored| {
+                let mut record = stored.record.clone();
+                if record.title.is_none()
+                    && let Some(title) = derive_thread_title(&stored.messages)
+                {
+                    record.title = Some(title);
+                }
+                record
+            })
+            .collect();
+        // Newest activity first (`updated_at`, falling back to
+        // `created_at`); legacy records without timestamps sort last.
+        // Tie-break on thread_id ascending so the order is stable and
+        // opaque cursors stay resumable, matching the filesystem backend
+        // and the web sidebar's `byActivityDesc` comparator.
+        matching.sort_by(|a, b| {
+            let a_key = a.updated_at.or(a.created_at);
+            let b_key = b.updated_at.or(b.created_at);
+            std::cmp::Reverse(a_key)
+                .cmp(&std::cmp::Reverse(b_key))
+                .then_with(|| a.thread_id.as_str().cmp(b.thread_id.as_str()))
+        });
+
+        // Opaque cursor is the last thread_id of the previous page; find
+        // it in the activity-sorted list and resume after it. A cursor
+        // that no longer resolves ends the stream rather than restarting.
+        let start_index = match cursor.as_deref() {
+            Some(cursor) => matching
+                .iter()
+                .position(|record| record.thread_id.as_str() == cursor)
+                .map(|index| index + 1)
+                .unwrap_or(matching.len()),
+            None => 0,
+        };
+        let end_index = start_index.saturating_add(limit).min(matching.len());
+        let next_cursor = if end_index < matching.len() {
+            matching[start_index..end_index]
+                .last()
+                .map(|record| record.thread_id.as_str().to_string())
+        } else {
+            None
+        };
+        let page: Vec<SessionThreadRecord> = matching[start_index..end_index].to_vec();
+
+        Ok(ListThreadsForScopeResponse {
+            threads: page,
+            next_cursor,
         })
     }
 }
@@ -746,88 +841,13 @@ impl SessionThreadService for InMemorySessionThreadService {
         &self,
         request: ListThreadsForScopeRequest,
     ) -> Result<ListThreadsForScopeResponse, SessionThreadError> {
-        // In-memory enumeration for local-dev. Production backends
-        // (filesystem / postgres) override with their own pagination
-        // strategy; this impl is fine because the store is bounded
-        // by tenant memory in the first place.
-        let limit = request
-            .limit
-            .map(|n| (n as usize).clamp(1, LIST_THREADS_MAX_PAGE_SIZE))
-            .unwrap_or(LIST_THREADS_DEFAULT_PAGE_SIZE);
-
-        let state = self.state.lock().await;
-
-        // Scope filter is exact equality on the full `ThreadScope`
-        // tuple — tenant + agent + project + owner — so a caller
-        // cannot see threads owned by other users in the same
-        // (tenant, agent, project) triple. The trait contract
-        // documents this invariant.
-        //
-        // Filter before cloning: matching on the borrowed scope avoids
-        // cloning records owned by other tenants/projects only to throw
-        // them away. The store is bounded by tenant memory so a full
-        // scan is still acceptable here; a scope-indexed secondary
-        // map would help with very large stores but local-dev never
-        // gets close to that scale.
-        //
-        // Derive a sidebar-friendly title from the first user message
-        // when the record itself has none. Matches v1's libSQL list
-        // semantics: titles aren't stored, they're computed on read
-        // from the first user message in the transcript. The
-        // filesystem backend does the same thing via
-        // `list_thread_messages` + `derive_title_from_message`.
-        let mut matching: Vec<SessionThreadRecord> = state
-            .threads
-            .values()
-            .filter(|stored| stored.record.scope == request.scope)
-            .map(|stored| {
-                let mut record = stored.record.clone();
-                if record.title.is_none()
-                    && let Some(title) = derive_thread_title(&stored.messages)
-                {
-                    record.title = Some(title);
-                }
-                record
-            })
-            .collect();
-        // Newest activity first (`updated_at`, falling back to
-        // `created_at`); legacy records without timestamps sort last.
-        // Tie-break on thread_id ascending so the order is stable and
-        // opaque cursors stay resumable, matching the filesystem backend
-        // and the web sidebar's `byActivityDesc` comparator.
-        matching.sort_by(|a, b| {
-            let a_key = a.updated_at.or(a.created_at);
-            let b_key = b.updated_at.or(b.created_at);
-            std::cmp::Reverse(a_key)
-                .cmp(&std::cmp::Reverse(b_key))
-                .then_with(|| a.thread_id.as_str().cmp(b.thread_id.as_str()))
-        });
-
-        // Opaque cursor is the last thread_id of the previous page; find
-        // it in the activity-sorted list and resume after it. A cursor
-        // that no longer resolves ends the stream rather than restarting.
-        let start_index = match request.cursor.as_deref() {
-            Some(cursor) => matching
-                .iter()
-                .position(|record| record.thread_id.as_str() == cursor)
-                .map(|index| index + 1)
-                .unwrap_or(matching.len()),
-            None => 0,
-        };
-        let end_index = start_index.saturating_add(limit).min(matching.len());
-        let next_cursor = if end_index < matching.len() {
-            matching[start_index..end_index]
-                .last()
-                .map(|record| record.thread_id.as_str().to_string())
-        } else {
-            None
-        };
-        let page: Vec<SessionThreadRecord> = matching[start_index..end_index].to_vec();
-
-        Ok(ListThreadsForScopeResponse {
-            threads: page,
-            next_cursor,
-        })
+        self.list_threads_for_scope_inner(
+            request.scope,
+            request.limit,
+            request.cursor,
+            &request.excluded_metadata_sources,
+        )
+        .await
     }
 
     async fn read_thread_by_id(

--- a/crates/ironclaw_threads/src/in_memory.rs
+++ b/crates/ironclaw_threads/src/in_memory.rs
@@ -76,7 +76,7 @@ impl InMemorySessionThreadService {
         scope: ThreadScope,
         limit: Option<u32>,
         cursor: Option<String>,
-        excluded_metadata_sources: &[String],
+        excluded_metadata_sources: &[crate::ThreadMetadataSource],
     ) -> Result<ListThreadsForScopeResponse, SessionThreadError> {
         // In-memory enumeration for local-dev. Production backends
         // (filesystem / postgres) override with their own pagination

--- a/crates/ironclaw_threads/src/lib.rs
+++ b/crates/ironclaw_threads/src/lib.rs
@@ -43,8 +43,9 @@ pub use contract::{
     LoadContextWindowRequest, MessageContent, MessageKind, MessageStatus, RedactMessageRequest,
     ReplayAcceptedInboundMessageRequest, SessionThreadRecord, SummaryArtifact, SummaryKind,
     SummaryModelContextPolicy, ThreadGoal, ThreadHistory, ThreadHistoryRequest, ThreadMessageRange,
-    ThreadMessageRangeRequest, ThreadMessageRecord, ThreadScope, UpdateAssistantDraftRequest,
-    UpdateThreadGoalRequest, UpdateToolResultReferenceRequest,
+    ThreadMessageRangeRequest, ThreadMessageRecord, ThreadMetadataSource,
+    ThreadMetadataSourceError, ThreadScope, UpdateAssistantDraftRequest, UpdateThreadGoalRequest,
+    UpdateToolResultReferenceRequest,
 };
 pub use error::SessionThreadError;
 pub use identifiers::{SummaryArtifactId, ThreadMessageId};

--- a/crates/ironclaw_threads/src/service.rs
+++ b/crates/ironclaw_threads/src/service.rs
@@ -500,7 +500,7 @@ where
 
 pub(crate) fn thread_metadata_source_is_excluded(
     thread: &SessionThreadRecord,
-    excluded_sources: &[String],
+    excluded_sources: &[crate::ThreadMetadataSource],
 ) -> bool {
     if excluded_sources.is_empty() {
         return false;
@@ -508,11 +508,21 @@ pub(crate) fn thread_metadata_source_is_excluded(
     let Some(metadata) = thread.metadata_json.as_deref() else {
         return false;
     };
+    if !excluded_sources
+        .iter()
+        .any(|excluded| metadata.contains(excluded.as_str()))
+    {
+        return false;
+    }
     let Ok(value) = serde_json::from_str::<serde_json::Value>(metadata) else {
         return false;
     };
     value
         .get("source")
         .and_then(serde_json::Value::as_str)
-        .is_some_and(|source| excluded_sources.iter().any(|excluded| excluded == source))
+        .is_some_and(|source| {
+            excluded_sources
+                .iter()
+                .any(|excluded| excluded.as_str() == source)
+        })
 }

--- a/crates/ironclaw_threads/src/service.rs
+++ b/crates/ironclaw_threads/src/service.rs
@@ -497,3 +497,22 @@ where
         self.as_ref().list_threads_for_scope(request).await
     }
 }
+
+pub(crate) fn thread_metadata_source_is_excluded(
+    thread: &SessionThreadRecord,
+    excluded_sources: &[String],
+) -> bool {
+    if excluded_sources.is_empty() {
+        return false;
+    }
+    let Some(metadata) = thread.metadata_json.as_deref() else {
+        return false;
+    };
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(metadata) else {
+        return false;
+    };
+    value
+        .get("source")
+        .and_then(serde_json::Value::as_str)
+        .is_some_and(|source| excluded_sources.iter().any(|excluded| excluded == source))
+}

--- a/crates/ironclaw_threads/tests/filesystem_session_thread_contract.rs
+++ b/crates/ironclaw_threads/tests/filesystem_session_thread_contract.rs
@@ -36,7 +36,7 @@ use ironclaw_threads::{
     LoadContextMessagesRequest, LoadContextWindowRequest, MessageContent, MessageKind,
     MessageStatus, RedactMessageRequest, ReplayAcceptedInboundMessageRequest, SessionThreadError,
     SessionThreadService, SummaryKind, SummaryModelContextPolicy, ThreadHistoryRequest,
-    ThreadScope, ToolResultSafeSummary, UpdateAssistantDraftRequest,
+    ThreadMetadataSource, ThreadScope, ToolResultSafeSummary, UpdateAssistantDraftRequest,
 };
 use tokio::sync::{Barrier, Mutex, OwnedMutexGuard};
 
@@ -1465,19 +1465,48 @@ async fn filesystem_list_threads_filters_metadata_sources_before_pagination() {
     let service = FilesystemSessionThreadService::new(scoped);
     let scope_a = scope("filtered-list-fs");
 
-    let visible = service
+    let visible_older = service
         .ensure_thread(EnsureThreadRequest {
             scope: scope_a.clone(),
-            thread_id: Some(ThreadId::new("t-visible").unwrap()),
+            thread_id: Some(ThreadId::new("t-visible-older").unwrap()),
             created_by_actor_id: "actor-a".into(),
-            title: Some("Visible chat".into()),
+            title: Some("Older visible chat".into()),
             metadata_json: Some(serde_json::json!({ "source": "webui" }).to_string()),
         })
         .await
         .unwrap();
-    wait_until_after(visible.updated_at.expect("activity stamp")).await;
+    wait_until_after(visible_older.updated_at.expect("activity stamp")).await;
 
-    for id in ["t-auto-001", "t-auto-002", "t-auto-003"] {
+    let hidden_before_visible_newer = service
+        .ensure_thread(EnsureThreadRequest {
+            scope: scope_a.clone(),
+            thread_id: Some(ThreadId::new("t-auto-001").unwrap()),
+            created_by_actor_id: "actor-a".into(),
+            title: Some("t-auto-001".into()),
+            metadata_json: Some(serde_json::json!({ "source": "automation_trigger" }).to_string()),
+        })
+        .await
+        .unwrap();
+    wait_until_after(
+        hidden_before_visible_newer
+            .updated_at
+            .expect("activity stamp"),
+    )
+    .await;
+
+    let visible_newer = service
+        .ensure_thread(EnsureThreadRequest {
+            scope: scope_a.clone(),
+            thread_id: Some(ThreadId::new("t-visible-newer").unwrap()),
+            created_by_actor_id: "actor-a".into(),
+            title: Some("Newer visible chat".into()),
+            metadata_json: Some(serde_json::json!({ "source": "webui" }).to_string()),
+        })
+        .await
+        .unwrap();
+    wait_until_after(visible_newer.updated_at.expect("activity stamp")).await;
+
+    for id in ["t-auto-002", "t-auto-003"] {
         let record = service
             .ensure_thread(EnsureThreadRequest {
                 scope: scope_a.clone(),
@@ -1510,10 +1539,10 @@ async fn filesystem_list_threads_filters_metadata_sources_before_pagination() {
 
     let filtered = service
         .list_threads_for_scope(ListThreadsForScopeRequest {
-            scope: scope_a,
+            scope: scope_a.clone(),
             limit: Some(1),
             cursor: None,
-            excluded_metadata_sources: vec!["automation_trigger".to_string()],
+            excluded_metadata_sources: vec![metadata_source("automation_trigger")],
         })
         .await
         .unwrap();
@@ -1523,11 +1552,34 @@ async fn filesystem_list_threads_filters_metadata_sources_before_pagination() {
             .iter()
             .map(|record| record.thread_id.as_str())
             .collect::<Vec<_>>(),
-        ["t-visible"],
+        ["t-visible-newer"],
+    );
+    assert_eq!(
+        filtered.next_cursor.as_deref(),
+        Some("t-visible-newer"),
+        "cursor should be based on visible records, not hidden automation rows",
+    );
+
+    let second_page = service
+        .list_threads_for_scope(ListThreadsForScopeRequest {
+            scope: scope_a,
+            limit: Some(1),
+            cursor: filtered.next_cursor,
+            excluded_metadata_sources: vec![metadata_source("automation_trigger")],
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        second_page
+            .threads
+            .iter()
+            .map(|record| record.thread_id.as_str())
+            .collect::<Vec<_>>(),
+        ["t-visible-older"],
     );
     assert!(
-        filtered.next_cursor.is_none(),
-        "cursor should be based on visible records, not hidden automation rows",
+        second_page.next_cursor.is_none(),
+        "second page should exhaust visible records",
     );
 }
 
@@ -2160,6 +2212,10 @@ fn scope(label: &str) -> ThreadScope {
         owner_user_id: Some(UserId::new(format!("user-{label}")).unwrap()),
         mission_id: None,
     }
+}
+
+fn metadata_source(source: &str) -> ThreadMetadataSource {
+    ThreadMetadataSource::new(source).unwrap()
 }
 
 fn assert_unknown_thread(error: SessionThreadError, thread_id: &ThreadId) {

--- a/crates/ironclaw_threads/tests/filesystem_session_thread_contract.rs
+++ b/crates/ironclaw_threads/tests/filesystem_session_thread_contract.rs
@@ -1336,6 +1336,7 @@ async fn filesystem_list_threads_for_scope_is_scope_filtered_and_paginated() {
             scope: scope_a.clone(),
             limit: None,
             cursor: None,
+            excluded_metadata_sources: Vec::new(),
         })
         .await
         .unwrap();
@@ -1383,6 +1384,7 @@ async fn filesystem_list_threads_for_scope_is_scope_filtered_and_paginated() {
             scope: scope_a.clone(),
             limit: None,
             cursor: None,
+            excluded_metadata_sources: Vec::new(),
         })
         .await
         .unwrap();
@@ -1403,6 +1405,7 @@ async fn filesystem_list_threads_for_scope_is_scope_filtered_and_paginated() {
             scope: scope_a.clone(),
             limit: Some(2),
             cursor: None,
+            excluded_metadata_sources: Vec::new(),
         })
         .await
         .unwrap();
@@ -1420,6 +1423,7 @@ async fn filesystem_list_threads_for_scope_is_scope_filtered_and_paginated() {
             scope: scope_a.clone(),
             limit: Some(2),
             cursor: page_1.next_cursor.clone(),
+            excluded_metadata_sources: Vec::new(),
         })
         .await
         .unwrap();
@@ -1440,6 +1444,7 @@ async fn filesystem_list_threads_for_scope_is_scope_filtered_and_paginated() {
             scope: scope_b,
             limit: None,
             cursor: None,
+            excluded_metadata_sources: Vec::new(),
         })
         .await
         .unwrap();
@@ -1449,6 +1454,81 @@ async fn filesystem_list_threads_for_scope_is_scope_filtered_and_paginated() {
         .map(|record| record.thread_id.as_str())
         .collect();
     assert_eq!(ids_b, ["t-b-001"]);
+}
+
+#[tokio::test]
+async fn filesystem_list_threads_filters_metadata_sources_before_pagination() {
+    use ironclaw_threads::ListThreadsForScopeRequest;
+
+    let backend = Arc::new(InMemoryBackend::new());
+    let scoped = scoped_threads_fs_at(backend, "tenant-filtered-host", "alice");
+    let service = FilesystemSessionThreadService::new(scoped);
+    let scope_a = scope("filtered-list-fs");
+
+    let visible = service
+        .ensure_thread(EnsureThreadRequest {
+            scope: scope_a.clone(),
+            thread_id: Some(ThreadId::new("t-visible").unwrap()),
+            created_by_actor_id: "actor-a".into(),
+            title: Some("Visible chat".into()),
+            metadata_json: Some(serde_json::json!({ "source": "webui" }).to_string()),
+        })
+        .await
+        .unwrap();
+    wait_until_after(visible.updated_at.expect("activity stamp")).await;
+
+    for id in ["t-auto-001", "t-auto-002", "t-auto-003"] {
+        let record = service
+            .ensure_thread(EnsureThreadRequest {
+                scope: scope_a.clone(),
+                thread_id: Some(ThreadId::new(id).unwrap()),
+                created_by_actor_id: "actor-a".into(),
+                title: Some(id.into()),
+                metadata_json: Some(
+                    serde_json::json!({ "source": "automation_trigger" }).to_string(),
+                ),
+            })
+            .await
+            .unwrap();
+        wait_until_after(record.updated_at.expect("activity stamp")).await;
+    }
+
+    let unfiltered = service
+        .list_threads_for_scope(ListThreadsForScopeRequest {
+            scope: scope_a.clone(),
+            limit: Some(1),
+            cursor: None,
+            excluded_metadata_sources: Vec::new(),
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        unfiltered.threads[0].thread_id.as_str(),
+        "t-auto-003",
+        "newer automation threads should dominate the unfiltered activity list",
+    );
+
+    let filtered = service
+        .list_threads_for_scope(ListThreadsForScopeRequest {
+            scope: scope_a,
+            limit: Some(1),
+            cursor: None,
+            excluded_metadata_sources: vec!["automation_trigger".to_string()],
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        filtered
+            .threads
+            .iter()
+            .map(|record| record.thread_id.as_str())
+            .collect::<Vec<_>>(),
+        ["t-visible"],
+    );
+    assert!(
+        filtered.next_cursor.is_none(),
+        "cursor should be based on visible records, not hidden automation rows",
+    );
 }
 
 /// Regression: the "Recent" list must order by last interaction, not by
@@ -1490,6 +1570,7 @@ async fn filesystem_list_threads_orders_by_last_activity_not_creation() {
             scope: scope_a.clone(),
             limit: None,
             cursor: None,
+            excluded_metadata_sources: Vec::new(),
         })
         .await
         .unwrap();
@@ -1523,6 +1604,7 @@ async fn filesystem_list_threads_orders_by_last_activity_not_creation() {
             scope: scope_a.clone(),
             limit: None,
             cursor: None,
+            excluded_metadata_sources: Vec::new(),
         })
         .await
         .unwrap();
@@ -1595,6 +1677,7 @@ async fn filesystem_list_threads_orders_by_last_activity_not_creation() {
             scope: scope_a,
             limit: None,
             cursor: None,
+            excluded_metadata_sources: Vec::new(),
         })
         .await
         .unwrap();
@@ -1707,6 +1790,7 @@ async fn filesystem_list_threads_for_scope_derives_title_from_first_user_message
             scope,
             limit: None,
             cursor: None,
+            excluded_metadata_sources: Vec::new(),
         })
         .await
         .unwrap();
@@ -2655,6 +2739,7 @@ async fn filesystem_accept_rejects_duplicate_attachment_ids() {
             scope,
             limit: None,
             cursor: None,
+            excluded_metadata_sources: Vec::new(),
         })
         .await
         .unwrap();

--- a/crates/ironclaw_threads/tests/session_thread_contract.rs
+++ b/crates/ironclaw_threads/tests/session_thread_contract.rs
@@ -14,8 +14,8 @@ use ironclaw_threads::{
     MessageContent, MessageKind, MessageStatus, ProviderToolCallReferenceEnvelope,
     RedactMessageRequest, SessionThreadError, SessionThreadService, SummaryKind,
     SummaryModelContextPolicy, ThreadHistoryRequest, ThreadMessageId, ThreadMessageRangeRequest,
-    ThreadScope, ToolResultReferenceEnvelope, ToolResultSafeSummary, UpdateAssistantDraftRequest,
-    UpdateToolResultReferenceRequest,
+    ThreadMetadataSource, ThreadScope, ToolResultReferenceEnvelope, ToolResultSafeSummary,
+    UpdateAssistantDraftRequest, UpdateToolResultReferenceRequest,
 };
 
 fn scope(label: &str) -> ThreadScope {
@@ -30,6 +30,10 @@ fn scope(label: &str) -> ThreadScope {
 
 fn user_message(text: &str) -> MessageContent {
     MessageContent::text(text)
+}
+
+fn metadata_source(source: &str) -> ThreadMetadataSource {
+    ThreadMetadataSource::new(source).unwrap()
 }
 
 fn provider_call_reference() -> ProviderToolCallReferenceEnvelope {
@@ -2736,19 +2740,48 @@ async fn list_threads_for_scope_filters_metadata_sources_before_pagination() {
     let service = InMemorySessionThreadService::default();
     let scope_a = scope("filtered-list");
 
-    let visible = service
+    let visible_older = service
         .ensure_thread(EnsureThreadRequest {
             scope: scope_a.clone(),
-            thread_id: Some(ThreadId::new("t-visible").unwrap()),
+            thread_id: Some(ThreadId::new("t-visible-older").unwrap()),
             created_by_actor_id: "actor-a".into(),
-            title: Some("Visible chat".into()),
+            title: Some("Older visible chat".into()),
             metadata_json: Some(serde_json::json!({ "source": "webui" }).to_string()),
         })
         .await
         .unwrap();
-    wait_until_after(visible.updated_at.expect("activity stamp")).await;
+    wait_until_after(visible_older.updated_at.expect("activity stamp")).await;
 
-    for id in ["t-auto-001", "t-auto-002", "t-auto-003"] {
+    let hidden_before_visible_newer = service
+        .ensure_thread(EnsureThreadRequest {
+            scope: scope_a.clone(),
+            thread_id: Some(ThreadId::new("t-auto-001").unwrap()),
+            created_by_actor_id: "actor-a".into(),
+            title: Some("t-auto-001".into()),
+            metadata_json: Some(serde_json::json!({ "source": "automation_trigger" }).to_string()),
+        })
+        .await
+        .unwrap();
+    wait_until_after(
+        hidden_before_visible_newer
+            .updated_at
+            .expect("activity stamp"),
+    )
+    .await;
+
+    let visible_newer = service
+        .ensure_thread(EnsureThreadRequest {
+            scope: scope_a.clone(),
+            thread_id: Some(ThreadId::new("t-visible-newer").unwrap()),
+            created_by_actor_id: "actor-a".into(),
+            title: Some("Newer visible chat".into()),
+            metadata_json: Some(serde_json::json!({ "source": "webui" }).to_string()),
+        })
+        .await
+        .unwrap();
+    wait_until_after(visible_newer.updated_at.expect("activity stamp")).await;
+
+    for id in ["t-auto-002", "t-auto-003"] {
         let record = service
             .ensure_thread(EnsureThreadRequest {
                 scope: scope_a.clone(),
@@ -2781,10 +2814,10 @@ async fn list_threads_for_scope_filters_metadata_sources_before_pagination() {
 
     let filtered = service
         .list_threads_for_scope(ListThreadsForScopeRequest {
-            scope: scope_a,
+            scope: scope_a.clone(),
             limit: Some(1),
             cursor: None,
-            excluded_metadata_sources: vec!["automation_trigger".to_string()],
+            excluded_metadata_sources: vec![metadata_source("automation_trigger")],
         })
         .await
         .unwrap();
@@ -2794,11 +2827,34 @@ async fn list_threads_for_scope_filters_metadata_sources_before_pagination() {
             .iter()
             .map(|record| record.thread_id.as_str())
             .collect::<Vec<_>>(),
-        ["t-visible"],
+        ["t-visible-newer"],
+    );
+    assert_eq!(
+        filtered.next_cursor.as_deref(),
+        Some("t-visible-newer"),
+        "cursor should be based on visible records, not hidden automation rows",
+    );
+
+    let second_page = service
+        .list_threads_for_scope(ListThreadsForScopeRequest {
+            scope: scope_a,
+            limit: Some(1),
+            cursor: filtered.next_cursor,
+            excluded_metadata_sources: vec![metadata_source("automation_trigger")],
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        second_page
+            .threads
+            .iter()
+            .map(|record| record.thread_id.as_str())
+            .collect::<Vec<_>>(),
+        ["t-visible-older"],
     );
     assert!(
-        filtered.next_cursor.is_none(),
-        "cursor should be based on visible records, not hidden automation rows",
+        second_page.next_cursor.is_none(),
+        "second page should exhaust visible records",
     );
 }
 

--- a/crates/ironclaw_threads/tests/session_thread_contract.rs
+++ b/crates/ironclaw_threads/tests/session_thread_contract.rs
@@ -2619,6 +2619,7 @@ async fn list_threads_for_scope_is_scope_filtered_and_paginated() {
             scope: scope_a.clone(),
             limit: None,
             cursor: None,
+            excluded_metadata_sources: Vec::new(),
         })
         .await
         .unwrap();
@@ -2661,6 +2662,7 @@ async fn list_threads_for_scope_is_scope_filtered_and_paginated() {
             scope: scope_a.clone(),
             limit: None,
             cursor: None,
+            excluded_metadata_sources: Vec::new(),
         })
         .await
         .unwrap();
@@ -2681,6 +2683,7 @@ async fn list_threads_for_scope_is_scope_filtered_and_paginated() {
             scope: scope_a.clone(),
             limit: Some(2),
             cursor: None,
+            excluded_metadata_sources: Vec::new(),
         })
         .await
         .unwrap();
@@ -2698,6 +2701,7 @@ async fn list_threads_for_scope_is_scope_filtered_and_paginated() {
             scope: scope_a.clone(),
             limit: Some(2),
             cursor: page_1.next_cursor.clone(),
+            excluded_metadata_sources: Vec::new(),
         })
         .await
         .unwrap();
@@ -2715,6 +2719,7 @@ async fn list_threads_for_scope_is_scope_filtered_and_paginated() {
             scope: scope_b,
             limit: None,
             cursor: None,
+            excluded_metadata_sources: Vec::new(),
         })
         .await
         .unwrap();
@@ -2724,6 +2729,77 @@ async fn list_threads_for_scope_is_scope_filtered_and_paginated() {
         .map(|record| record.thread_id.as_str())
         .collect();
     assert_eq!(ids_b, ["t-b-001"]);
+}
+
+#[tokio::test]
+async fn list_threads_for_scope_filters_metadata_sources_before_pagination() {
+    let service = InMemorySessionThreadService::default();
+    let scope_a = scope("filtered-list");
+
+    let visible = service
+        .ensure_thread(EnsureThreadRequest {
+            scope: scope_a.clone(),
+            thread_id: Some(ThreadId::new("t-visible").unwrap()),
+            created_by_actor_id: "actor-a".into(),
+            title: Some("Visible chat".into()),
+            metadata_json: Some(serde_json::json!({ "source": "webui" }).to_string()),
+        })
+        .await
+        .unwrap();
+    wait_until_after(visible.updated_at.expect("activity stamp")).await;
+
+    for id in ["t-auto-001", "t-auto-002", "t-auto-003"] {
+        let record = service
+            .ensure_thread(EnsureThreadRequest {
+                scope: scope_a.clone(),
+                thread_id: Some(ThreadId::new(id).unwrap()),
+                created_by_actor_id: "actor-a".into(),
+                title: Some(id.into()),
+                metadata_json: Some(
+                    serde_json::json!({ "source": "automation_trigger" }).to_string(),
+                ),
+            })
+            .await
+            .unwrap();
+        wait_until_after(record.updated_at.expect("activity stamp")).await;
+    }
+
+    let unfiltered = service
+        .list_threads_for_scope(ListThreadsForScopeRequest {
+            scope: scope_a.clone(),
+            limit: Some(1),
+            cursor: None,
+            excluded_metadata_sources: Vec::new(),
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        unfiltered.threads[0].thread_id.as_str(),
+        "t-auto-003",
+        "newer automation threads should dominate the unfiltered activity list",
+    );
+
+    let filtered = service
+        .list_threads_for_scope(ListThreadsForScopeRequest {
+            scope: scope_a,
+            limit: Some(1),
+            cursor: None,
+            excluded_metadata_sources: vec!["automation_trigger".to_string()],
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        filtered
+            .threads
+            .iter()
+            .map(|record| record.thread_id.as_str())
+            .collect::<Vec<_>>(),
+        ["t-visible"],
+    );
+    assert!(
+        filtered.next_cursor.is_none(),
+        "cursor should be based on visible records, not hidden automation rows",
+    );
 }
 
 #[tokio::test]
@@ -2813,6 +2889,7 @@ async fn list_threads_for_scope_derives_title_from_first_user_message() {
             scope: scope.clone(),
             limit: None,
             cursor: None,
+            excluded_metadata_sources: Vec::new(),
         })
         .await
         .unwrap();
@@ -2871,6 +2948,7 @@ async fn list_threads_for_scope_title_stays_none_for_assistant_only_thread() {
             scope: scope.clone(),
             limit: None,
             cursor: None,
+            excluded_metadata_sources: Vec::new(),
         })
         .await
         .unwrap();
@@ -2920,6 +2998,7 @@ async fn list_threads_for_scope_truncates_long_first_user_message_to_60_chars() 
             scope: scope.clone(),
             limit: None,
             cursor: None,
+            excluded_metadata_sources: Vec::new(),
         })
         .await
         .unwrap();
@@ -2973,6 +3052,7 @@ async fn list_threads_for_scope_title_stays_none_when_user_message_is_whitespace
             scope: scope.clone(),
             limit: None,
             cursor: None,
+            excluded_metadata_sources: Vec::new(),
         })
         .await
         .unwrap();

--- a/crates/ironclaw_threads/tests/session_thread_contract.rs
+++ b/crates/ironclaw_threads/tests/session_thread_contract.rs
@@ -14,8 +14,8 @@ use ironclaw_threads::{
     MessageContent, MessageKind, MessageStatus, ProviderToolCallReferenceEnvelope,
     RedactMessageRequest, SessionThreadError, SessionThreadService, SummaryKind,
     SummaryModelContextPolicy, ThreadHistoryRequest, ThreadMessageId, ThreadMessageRangeRequest,
-    ThreadMetadataSource, ThreadScope, ToolResultReferenceEnvelope, ToolResultSafeSummary,
-    UpdateAssistantDraftRequest, UpdateToolResultReferenceRequest,
+    ThreadMetadataSource, ThreadMetadataSourceError, ThreadScope, ToolResultReferenceEnvelope,
+    ToolResultSafeSummary, UpdateAssistantDraftRequest, UpdateToolResultReferenceRequest,
 };
 
 fn scope(label: &str) -> ThreadScope {
@@ -34,6 +34,31 @@ fn user_message(text: &str) -> MessageContent {
 
 fn metadata_source(source: &str) -> ThreadMetadataSource {
     ThreadMetadataSource::new(source).unwrap()
+}
+
+#[test]
+fn thread_metadata_source_rejects_empty_too_long_and_control_values() {
+    assert_eq!(
+        ThreadMetadataSource::new(" \t").unwrap_err(),
+        ThreadMetadataSourceError::Empty
+    );
+    assert_eq!(
+        ThreadMetadataSource::new("a".repeat(129)).unwrap_err(),
+        ThreadMetadataSourceError::TooLong { max: 128 }
+    );
+    assert_eq!(
+        ThreadMetadataSource::new("automation\ntrigger").unwrap_err(),
+        ThreadMetadataSourceError::ControlCharacter
+    );
+
+    let serde_error =
+        serde_json::from_value::<ThreadMetadataSource>(serde_json::json!("automation\u{0000}"));
+    assert!(
+        serde_error
+            .expect_err("serde must reject invalid metadata source values")
+            .to_string()
+            .contains("control characters")
+    );
 }
 
 fn provider_call_reference() -> ProviderToolCallReferenceEnvelope {


### PR DESCRIPTION
## Summary
- add metadata-source exclusions to thread list requests
- apply automation-thread exclusion inside thread backends before pagination
- update WebUI thread listing to request backend-side automation filtering while keeping notification approval listing intact

## Tests
- cargo fmt --check
- git diff --check
- CARGO_TARGET_DIR=target-lite CARGO_PROFILE_TEST_DEBUG=0 CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=2 cargo test -p ironclaw_threads --test session_thread_contract list_threads_for_scope -- --nocapture
- CARGO_TARGET_DIR=target-lite CARGO_PROFILE_TEST_DEBUG=0 CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=2 cargo test -p ironclaw_threads --test filesystem_session_thread_contract filesystem_list_threads -- --nocapture
- CARGO_TARGET_DIR=target-lite CARGO_PROFILE_TEST_DEBUG=0 CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=2 cargo test -p ironclaw_product_workflow --test reborn_services_contract list_threads -- --nocapture