### PR TITLE
test: stop running legacy support unit tests inside Reborn test binaries

### DIFF
--- a/tests/support/live_mission_helpers.rs
+++ b/tests/support/live_mission_helpers.rs
@@ -150,36 +150,3 @@ impl Drop for ApprovalAutoResponder {
         self.handle.abort();
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn looks_like_routine_notification_accepts_marker() {
-        assert!(looks_like_routine_notification(
-            "**[bitcoin_price_checker]** Some output\nbody body body"
-        ));
-    }
-
-    #[test]
-    fn looks_like_routine_notification_rejects_foreground_reply() {
-        // Foreground replies have no marker.
-        assert!(!looks_like_routine_notification(
-            "## Bitcoin Price Checker Routine Created ✅\nSchedule: */5 * * * *"
-        ));
-    }
-
-    #[test]
-    fn looks_like_routine_notification_rejects_empty_marker() {
-        assert!(!looks_like_routine_notification("**[]** empty name"));
-    }
-
-    #[test]
-    fn tool_is_matches_bare_and_parenthesised() {
-        assert!(tool_is("mission_fire", "mission_fire"));
-        assert!(tool_is("mission_fire(abc)", "mission_fire"));
-        assert!(!tool_is("mission_fired", "mission_fire"));
-        assert!(!tool_is("other_mission_fire", "mission_fire"));
-    }
-}

--- a/tests/support/trace_runner.rs
+++ b/tests/support/trace_runner.rs
@@ -203,7 +203,7 @@ async fn run_one(
     (result, start.elapsed())
 }
 
-fn evaluate_expectation(
+pub(crate) fn evaluate_expectation(
     index: usize,
     op: &TraceOperation,
     result: &Result<ToolOutput, ToolError>,
@@ -249,7 +249,7 @@ fn evaluate_expectation(
 }
 
 /// Walk the assertion DSL and return `Some(reason)` on mismatch.
-fn check_success_assertions(
+pub(crate) fn check_success_assertions(
     output: &serde_json::Value,
     assertions: &serde_json::Value,
 ) -> Option<String> {
@@ -305,7 +305,10 @@ fn check_success_assertions(
 
 /// Resolve a dot-separated path in a JSON value. `a.b.c` walks objects;
 /// numeric segments index arrays.
-fn json_path<'a>(value: &'a serde_json::Value, path: &str) -> Option<&'a serde_json::Value> {
+pub(crate) fn json_path<'a>(
+    value: &'a serde_json::Value,
+    path: &str,
+) -> Option<&'a serde_json::Value> {
     let mut cur = value;
     for seg in path.split('.') {
         cur = match cur {
@@ -318,103 +321,4 @@ fn json_path<'a>(value: &'a serde_json::Value, path: &str) -> Option<&'a serde_j
         };
     }
     Some(cur)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn json_path_walks_nested_objects() {
-        let v = serde_json::json!({"a": {"b": {"c": 42}}});
-        assert_eq!(json_path(&v, "a.b.c"), Some(&serde_json::Value::from(42)));
-        assert_eq!(json_path(&v, "a.b.missing"), None);
-    }
-
-    #[test]
-    fn json_path_indexes_arrays() {
-        let v = serde_json::json!({"items": ["x", "y", "z"]});
-        assert_eq!(
-            json_path(&v, "items.1"),
-            Some(&serde_json::Value::from("y"))
-        );
-        assert_eq!(json_path(&v, "items.99"), None);
-    }
-
-    #[test]
-    fn check_assertions_eq_matches() {
-        let out = serde_json::json!({"foo": 1});
-        let asserts = serde_json::json!({"eq": {"foo": 1}});
-        assert!(check_success_assertions(&out, &asserts).is_none());
-    }
-
-    #[test]
-    fn check_assertions_eq_reports_mismatch() {
-        let out = serde_json::json!({"foo": 1});
-        let asserts = serde_json::json!({"eq": {"foo": 2}});
-        let reason = check_success_assertions(&out, &asserts).expect("should fail");
-        assert!(reason.contains("eq mismatch"));
-    }
-
-    #[test]
-    fn check_assertions_contains_text() {
-        let out = serde_json::json!("hello world");
-        let asserts = serde_json::json!({"contains_text": "world"});
-        assert!(check_success_assertions(&out, &asserts).is_none());
-
-        let asserts_bad = serde_json::json!({"contains_text": "nope"});
-        assert!(check_success_assertions(&out, &asserts_bad).is_some());
-    }
-
-    #[test]
-    fn check_assertions_fields_paths() {
-        let out = serde_json::json!({"data": {"items": [{"id": 7}]}});
-        let asserts = serde_json::json!({
-            "fields": {
-                "data.items.0.id": 7,
-            }
-        });
-        assert!(check_success_assertions(&out, &asserts).is_none());
-    }
-
-    #[test]
-    fn failure_expectation_rejects_empty_error_contains() {
-        let op = TraceOperation {
-            tool_name: "missing".into(),
-            params: serde_json::Value::Null,
-            expected: TraceExpectation::Failure {
-                error_contains: " ".into(),
-            },
-        };
-        let failure = evaluate_expectation(0, &op, &Err(ToolError::ExecutionFailed("boom".into())))
-            .expect("empty error_contains must be rejected");
-        assert!(failure.reason.contains("non-empty error_contains"));
-    }
-
-    #[test]
-    fn trace_roundtrips_json() {
-        let trace = Trace {
-            name: "demo".into(),
-            operations: vec![
-                TraceOperation {
-                    tool_name: "echo".into(),
-                    params: serde_json::json!({"message": "hi"}),
-                    expected: TraceExpectation::Success {
-                        assertions: serde_json::json!({"contains_text": "hi"}),
-                    },
-                },
-                TraceOperation {
-                    tool_name: "missing".into(),
-                    params: serde_json::Value::Null,
-                    expected: TraceExpectation::Failure {
-                        error_contains: "not found".into(),
-                    },
-                },
-            ],
-        };
-        let j = serde_json::to_value(&trace).unwrap();
-        let back: Trace = serde_json::from_value(j).unwrap();
-        assert_eq!(back.name, "demo");
-        assert_eq!(back.operations.len(), 2);
-    }
 }

--- a/tests/support_unit_tests.rs
+++ b/tests/support_unit_tests.rs
@@ -2945,3 +2945,147 @@ mod test_rig_tests {
         rig.shutdown();
     }
 }
+
+// ---------------------------------------------------------------------------
+// live_mission_helpers
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "libsql")]
+mod live_mission_helpers_tests {
+    use crate::support::live_mission_helpers::{looks_like_routine_notification, tool_is};
+
+    #[test]
+    fn looks_like_routine_notification_accepts_marker() {
+        assert!(looks_like_routine_notification(
+            "**[bitcoin_price_checker]** Some output\nbody body body"
+        ));
+    }
+
+    #[test]
+    fn looks_like_routine_notification_rejects_foreground_reply() {
+        // Foreground replies have no marker.
+        assert!(!looks_like_routine_notification(
+            "## Bitcoin Price Checker Routine Created ✅\nSchedule: */5 * * * *"
+        ));
+    }
+
+    #[test]
+    fn looks_like_routine_notification_rejects_empty_marker() {
+        assert!(!looks_like_routine_notification("**[]** empty name"));
+    }
+
+    #[test]
+    fn tool_is_matches_bare_and_parenthesised() {
+        assert!(tool_is("mission_fire", "mission_fire"));
+        assert!(tool_is("mission_fire(abc)", "mission_fire"));
+        assert!(!tool_is("mission_fired", "mission_fire"));
+        assert!(!tool_is("other_mission_fire", "mission_fire"));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// trace_runner
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "libsql")]
+mod trace_runner_tests {
+    use crate::support::trace_runner::{
+        Trace, TraceExpectation, TraceOperation, check_success_assertions, evaluate_expectation,
+        json_path,
+    };
+    use ironclaw::tools::ToolError;
+
+    #[test]
+    fn json_path_walks_nested_objects() {
+        let v = serde_json::json!({"a": {"b": {"c": 42}}});
+        assert_eq!(json_path(&v, "a.b.c"), Some(&serde_json::Value::from(42)));
+        assert_eq!(json_path(&v, "a.b.missing"), None);
+    }
+
+    #[test]
+    fn json_path_indexes_arrays() {
+        let v = serde_json::json!({"items": ["x", "y", "z"]});
+        assert_eq!(
+            json_path(&v, "items.1"),
+            Some(&serde_json::Value::from("y"))
+        );
+        assert_eq!(json_path(&v, "items.99"), None);
+    }
+
+    #[test]
+    fn check_assertions_eq_matches() {
+        let out = serde_json::json!({"foo": 1});
+        let asserts = serde_json::json!({"eq": {"foo": 1}});
+        assert!(check_success_assertions(&out, &asserts).is_none());
+    }
+
+    #[test]
+    fn check_assertions_eq_reports_mismatch() {
+        let out = serde_json::json!({"foo": 1});
+        let asserts = serde_json::json!({"eq": {"foo": 2}});
+        let reason = check_success_assertions(&out, &asserts).expect("should fail");
+        assert!(reason.contains("eq mismatch"));
+    }
+
+    #[test]
+    fn check_assertions_contains_text() {
+        let out = serde_json::json!("hello world");
+        let asserts = serde_json::json!({"contains_text": "world"});
+        assert!(check_success_assertions(&out, &asserts).is_none());
+
+        let asserts_bad = serde_json::json!({"contains_text": "nope"});
+        assert!(check_success_assertions(&out, &asserts_bad).is_some());
+    }
+
+    #[test]
+    fn check_assertions_fields_paths() {
+        let out = serde_json::json!({"data": {"items": [{"id": 7}]}});
+        let asserts = serde_json::json!({
+            "fields": {
+                "data.items.0.id": 7,
+            }
+        });
+        assert!(check_success_assertions(&out, &asserts).is_none());
+    }
+
+    #[test]
+    fn failure_expectation_rejects_empty_error_contains() {
+        let op = TraceOperation {
+            tool_name: "missing".into(),
+            params: serde_json::Value::Null,
+            expected: TraceExpectation::Failure {
+                error_contains: " ".into(),
+            },
+        };
+        let failure = evaluate_expectation(0, &op, &Err(ToolError::ExecutionFailed("boom".into())))
+            .expect("empty error_contains must be rejected");
+        assert!(failure.reason.contains("non-empty error_contains"));
+    }
+
+    #[test]
+    fn trace_roundtrips_json() {
+        let trace = Trace {
+            name: "demo".into(),
+            operations: vec![
+                TraceOperation {
+                    tool_name: "echo".into(),
+                    params: serde_json::json!({"message": "hi"}),
+                    expected: TraceExpectation::Success {
+                        assertions: serde_json::json!({"contains_text": "hi"}),
+                    },
+                },
+                TraceOperation {
+                    tool_name: "missing".into(),
+                    params: serde_json::Value::Null,
+                    expected: TraceExpectation::Failure {
+                        error_contains: "not found".into(),
+                    },
+                },
+            ],
+        };
+        let j = serde_json::to_value(&trace).unwrap();
+        let back: Trace = serde_json::from_value(j).unwrap();
+        assert_eq!(back.name, "demo");
+        assert_eq!(back.operations.len(), 2);
+    }
+}


### PR DESCRIPTION
## Problem

CI's Reborn partition was executing non-Reborn tests: `support::live_mission_helpers::tests` (4) and `support::trace_runner::tests` (8) ran inside each of the 3 `reborn_group_*` binaries — 36 redundant executions per run. Root cause: every Reborn binary declares `mod support;` (needed only for `trace_llm` types), which drags in the whole legacy support tree, and these two files still carried inline `#[cfg(test)] mod tests` blocks that were never migrated when `support_unit_tests.rs` was created to hold support-module tests "exactly once".

## Fix (mechanical, no test logic changed)

- Move both inline test blocks into `tests/support_unit_tests.rs`, `#[cfg(feature = "libsql")]`-gated (matching the file's existing `test_rig_tests` precedent — both source modules are libsql-gated in `support/mod.rs`).
- Widen the three private `trace_runner` helpers the tests exercise (`evaluate_expectation`, `check_success_assertions`, `json_path`) to `pub(crate)`.

## Verification

- `cargo test --features libsql --test support_unit_tests -- live_mission_helpers trace_runner` → 12 passed (run exactly once).
- `cargo test --features libsql --test reborn_group_memory` → green; zero `support::live_mission_helpers`/`support::trace_runner` tests in the output (was 12).
- `cargo clippy --tests --features libsql` clean on touched targets; `cargo fmt` clean.

Follow-up candidate (not this PR): a thin shim so Reborn binaries compile only `trace_llm` instead of the whole legacy support tree — compile-time cleanup, requires touching the documented boilerplate contract in `tests/support/reborn/CLAUDE.md` across 47 binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)