### PR TITLE
test(reborn): PR-C2 Tier-2 coverage — skill/durable/errors (C-SKILL, C-DURABLE, C-ERRORS)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -370,6 +370,10 @@ name = "reborn_group_multiuser"
 path = "tests/reborn_group_multiuser/main.rs"
 
 [[test]]
+name = "reborn_group_skills"
+path = "tests/reborn_group_skills/main.rs"
+
+[[test]]
 name = "reborn_integration_oauth_refresh"
 required-features = ["libsql"]
 

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -2458,7 +2458,7 @@ pub(crate) const LOCAL_DEV_DB_FILENAME: &str = "reborn-local-dev.db";
 /// Open (or create) the local-dev libSQL database file at `root` — just the
 /// connection, no migrations/mount. One owner for the `libsql::Builder::new_local`
 /// sequence: [`build_default_local_dev_database_roots`] (production) and the
-/// E-DURABLE test-support trigger-repository reopen
+/// C-DURABLE test-support trigger-repository reopen
 /// (`open_local_dev_trigger_repository_for_test`) both call this rather than
 /// each opening their own connection to the same file.
 #[cfg(feature = "libsql")]
@@ -2582,7 +2582,7 @@ pub(crate) async fn open_local_dev_extension_installation_store_for_test(
     Ok(Arc::new(store))
 }
 
-/// Test-only (E-DURABLE/C-DURABLE seam): open a FRESH, independent
+/// Test-only (C-DURABLE seam): open a FRESH, independent
 /// [`ironclaw_run_state::ApprovalRequestStore`] at an existing local-dev
 /// `storage_root`, paralleling [`open_local_dev_extension_installation_store_for_test`]
 /// (same on-disk root; a sibling capability store). Reuses
@@ -2600,7 +2600,7 @@ pub(crate) async fn open_local_dev_approval_request_store_for_test(
     Ok(Arc::new(FilesystemApprovalRequestStore::new(scoped)))
 }
 
-/// Test-only (E-DURABLE/C-DURABLE seam): open a FRESH, independent
+/// Test-only (C-DURABLE seam): open a FRESH, independent
 /// [`ironclaw_triggers::TriggerRepository`] at an existing local-dev
 /// `storage_root`, paralleling [`open_local_dev_extension_installation_store_for_test`].
 /// Reuses [`open_local_dev_libsql_database`] (the same libSQL-open sequence

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -2455,6 +2455,27 @@ async fn build_local_dev_root_filesystem(
 /// any on-disk path assertion all derive from this constant.
 pub(crate) const LOCAL_DEV_DB_FILENAME: &str = "reborn-local-dev.db";
 
+/// Open (or create) the local-dev libSQL database file at `root` — just the
+/// connection, no migrations/mount. One owner for the `libsql::Builder::new_local`
+/// sequence: [`build_default_local_dev_database_roots`] (production) and the
+/// E-DURABLE test-support trigger-repository reopen
+/// (`open_local_dev_trigger_repository_for_test`) both call this rather than
+/// each opening their own connection to the same file.
+#[cfg(feature = "libsql")]
+async fn open_local_dev_libsql_database(
+    root: &Path,
+) -> Result<Arc<libsql::Database>, RebornBuildError> {
+    let db_path = root.join(LOCAL_DEV_DB_FILENAME);
+    Ok(Arc::new(
+        libsql::Builder::new_local(&db_path)
+            .build()
+            .await
+            .map_err(|error| RebornBuildError::InvalidConfig {
+                reason: format!("local-dev libSQL database could not be opened: {error}"),
+            })?,
+    ))
+}
+
 // `pub(crate)` so the `test_support` accessor
 // (`build_default_local_dev_database_roots_for_test`) can call this
 // without duplicating the 4-step libSQL setup sequence (Builder →
@@ -2466,15 +2487,7 @@ pub(crate) async fn build_default_local_dev_database_roots(
 ) -> Result<LocalDevDurableBackend, RebornBuildError> {
     #[cfg(feature = "libsql")]
     {
-        let db_path = root.join(LOCAL_DEV_DB_FILENAME);
-        let db = Arc::new(
-            libsql::Builder::new_local(&db_path)
-                .build()
-                .await
-                .map_err(|error| RebornBuildError::InvalidConfig {
-                    reason: format!("local-dev libSQL database could not be opened: {error}"),
-                })?,
-        );
+        let db = open_local_dev_libsql_database(root).await?;
         let database = Arc::new(LibSqlRootFilesystem::new(Arc::clone(&db)));
         database.run_migrations().await?;
         mount_local_dev_database_roots(composite, database)?;
@@ -2567,6 +2580,46 @@ pub(crate) async fn open_local_dev_extension_installation_store_for_test(
             reason: format!("extension installation state could not be reopened: {error}"),
         })?;
     Ok(Arc::new(store))
+}
+
+/// Test-only (E-DURABLE/C-DURABLE seam): open a FRESH, independent
+/// [`ironclaw_run_state::ApprovalRequestStore`] at an existing local-dev
+/// `storage_root`, paralleling [`open_local_dev_extension_installation_store_for_test`]
+/// (same on-disk root; a sibling capability store). Reuses
+/// [`mount_default_local_dev_database_roots`] + the production [`crate::wrap_scoped`]
+/// so the reopen mounts + scopes the SAME way `build_local_runtime` does when it
+/// first builds `approval_requests` — the reopen path never drifts from
+/// production. Tests only; zero bytes in production builds.
+#[cfg(all(feature = "test-support", feature = "libsql"))]
+pub(crate) async fn open_local_dev_approval_request_store_for_test(
+    storage_root: &Path,
+) -> Result<Arc<dyn ironclaw_run_state::ApprovalRequestStore>, RebornBuildError> {
+    let mut composite = CompositeRootFilesystem::new();
+    mount_default_local_dev_database_roots(storage_root, &mut composite).await?;
+    let scoped = crate::wrap_scoped(Arc::new(composite));
+    Ok(Arc::new(FilesystemApprovalRequestStore::new(scoped)))
+}
+
+/// Test-only (E-DURABLE/C-DURABLE seam): open a FRESH, independent
+/// [`ironclaw_triggers::TriggerRepository`] at an existing local-dev
+/// `storage_root`, paralleling [`open_local_dev_extension_installation_store_for_test`].
+/// Reuses [`open_local_dev_libsql_database`] (the same libSQL-open sequence
+/// production uses) + the real [`ironclaw_triggers::LibSqlTriggerRepository`], so
+/// the reopen path never hand-mirrors [`local_dev_trigger_repository`]. Tests
+/// only; zero bytes in production builds.
+#[cfg(all(feature = "test-support", feature = "libsql"))]
+pub(crate) async fn open_local_dev_trigger_repository_for_test(
+    storage_root: &Path,
+) -> Result<Arc<dyn TriggerRepository>, RebornBuildError> {
+    let db = open_local_dev_libsql_database(storage_root).await?;
+    let repository = ironclaw_triggers::LibSqlTriggerRepository::new(db);
+    repository
+        .run_migrations()
+        .await
+        .map_err(|error| RebornBuildError::InvalidConfig {
+            reason: format!("local-dev trigger repository migrations failed on reopen: {error}"),
+        })?;
+    Ok(Arc::new(repository))
 }
 
 fn mount_local_dev_memory_root<F>(

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -2604,22 +2604,17 @@ pub(crate) async fn open_local_dev_approval_request_store_for_test(
 /// [`ironclaw_triggers::TriggerRepository`] at an existing local-dev
 /// `storage_root`, paralleling [`open_local_dev_extension_installation_store_for_test`].
 /// Reuses [`open_local_dev_libsql_database`] (the same libSQL-open sequence
-/// production uses) + the real [`ironclaw_triggers::LibSqlTriggerRepository`], so
-/// the reopen path never hand-mirrors [`local_dev_trigger_repository`]. Tests
-/// only; zero bytes in production builds.
+/// production uses) AND delegates to [`local_dev_trigger_repository`] for
+/// repository construction + migrations, so the reopen path shares the SAME
+/// construction code as production local-dev wiring — never a second place to
+/// update if trigger repository setup changes. Tests only; zero bytes in
+/// production builds.
 #[cfg(all(feature = "test-support", feature = "libsql"))]
 pub(crate) async fn open_local_dev_trigger_repository_for_test(
     storage_root: &Path,
 ) -> Result<Arc<dyn TriggerRepository>, RebornBuildError> {
     let db = open_local_dev_libsql_database(storage_root).await?;
-    let repository = ironclaw_triggers::LibSqlTriggerRepository::new(db);
-    repository
-        .run_migrations()
-        .await
-        .map_err(|error| RebornBuildError::InvalidConfig {
-            reason: format!("local-dev trigger repository migrations failed on reopen: {error}"),
-        })?;
-    Ok(Arc::new(repository))
+    local_dev_trigger_repository(&LocalDevDurableBackend::LibSql(db)).await
 }
 
 fn mount_local_dev_memory_root<F>(

--- a/crates/ironclaw_reborn_composition/src/test_support/durable.rs
+++ b/crates/ironclaw_reborn_composition/src/test_support/durable.rs
@@ -1,10 +1,10 @@
 //! Durable-store test support for capability-produced state that outlives a
-//! process restart (E-DURABLE seam): extension installs, approval requests,
-//! and triggers. All three reopen at the SAME on-disk local-dev
-//! `storage_root` — the capability harness's always-real filesystem,
-//! independent of the integration harness's own `StorageMode` (which governs
-//! only the SEPARATE thread/turn composite; see `assert_reply_persists_after_reopen`
-//! for that one).
+//! process restart: extension installs (E-DURABLE seam), and approval
+//! requests + triggers (C-DURABLE seam). All three reopen at the SAME
+//! on-disk local-dev `storage_root` — the capability harness's always-real
+//! filesystem, independent of the integration harness's own `StorageMode`
+//! (which governs only the SEPARATE thread/turn composite; see
+//! `assert_reply_persists_after_reopen` for that one).
 
 /// Test-support entry point (E-DURABLE seam): reopen a fresh, independent
 /// extension-installation store at an existing local-dev `storage_root`. Lets

--- a/crates/ironclaw_reborn_composition/src/test_support/durable.rs
+++ b/crates/ironclaw_reborn_composition/src/test_support/durable.rs
@@ -1,4 +1,10 @@
-//! Extension-installation durable-store test support (E-DURABLE seam).
+//! Durable-store test support for capability-produced state that outlives a
+//! process restart (E-DURABLE seam): extension installs, approval requests,
+//! and triggers. All three reopen at the SAME on-disk local-dev
+//! `storage_root` — the capability harness's always-real filesystem,
+//! independent of the integration harness's own `StorageMode` (which governs
+//! only the SEPARATE thread/turn composite; see `assert_reply_persists_after_reopen`
+//! for that one).
 
 /// Test-support entry point (E-DURABLE seam): reopen a fresh, independent
 /// extension-installation store at an existing local-dev `storage_root`. Lets
@@ -14,4 +20,26 @@ pub async fn open_local_dev_extension_installation_store_for_test(
     crate::RebornBuildError,
 > {
     crate::factory::open_local_dev_extension_installation_store_for_test(storage_root).await
+}
+
+/// Test-support entry point (C-DURABLE): reopen a fresh, independent
+/// `ApprovalRequestStore` at an existing local-dev `storage_root`. Mirrors
+/// [`open_local_dev_extension_installation_store_for_test`] for approval-gate
+/// records instead of extension installs. Tests only.
+#[cfg(all(feature = "test-support", feature = "libsql"))]
+pub async fn open_local_dev_approval_request_store_for_test(
+    storage_root: &std::path::Path,
+) -> Result<std::sync::Arc<dyn ironclaw_run_state::ApprovalRequestStore>, crate::RebornBuildError> {
+    crate::factory::open_local_dev_approval_request_store_for_test(storage_root).await
+}
+
+/// Test-support entry point (C-DURABLE): reopen a fresh, independent
+/// `TriggerRepository` at an existing local-dev `storage_root`. Mirrors
+/// [`open_local_dev_extension_installation_store_for_test`] for triggers
+/// instead of extension installs. Tests only.
+#[cfg(all(feature = "test-support", feature = "libsql"))]
+pub async fn open_local_dev_trigger_repository_for_test(
+    storage_root: &std::path::Path,
+) -> Result<std::sync::Arc<dyn ironclaw_triggers::TriggerRepository>, crate::RebornBuildError> {
+    crate::factory::open_local_dev_trigger_repository_for_test(storage_root).await
 }

--- a/crates/ironclaw_reborn_composition/src/test_support/mod.rs
+++ b/crates/ironclaw_reborn_composition/src/test_support/mod.rs
@@ -22,8 +22,8 @@
 //!    without duplicating the wiring logic.
 //! 4. [`project_create`] — `project_create` synthetic-capability test support
 //!    (E-PROJ seam).
-//! 5. [`durable`] — extension-installation durable-store test support
-//!    (E-DURABLE seam).
+//! 5. [`durable`] — extension-installation, approval-request, and trigger
+//!    durable-store test support (E-DURABLE / C-DURABLE seam).
 //! 6. [`skill_activation`] — `skill_activate` synthetic-capability test
 //!    support (E-SKILL seam).
 //! 7. [`user_profile`] — `HostUserProfileSource` test support (E-PROFILE
@@ -42,6 +42,10 @@ pub use budget_gateway::{
 };
 #[cfg(feature = "test-support")]
 pub use durable::open_local_dev_extension_installation_store_for_test;
+#[cfg(all(feature = "test-support", feature = "libsql"))]
+pub use durable::{
+    open_local_dev_approval_request_store_for_test, open_local_dev_trigger_repository_for_test,
+};
 pub use local_dev_boot::LOCAL_DEV_DB_FILENAME;
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 pub use local_dev_boot::build_local_dev_secret_store_for_test;

--- a/tests/reborn_group_approvals/main.rs
+++ b/tests/reborn_group_approvals/main.rs
@@ -43,6 +43,7 @@ mod reborn_support;
 #[path = "../support/mod.rs"]
 mod support;
 
+mod scenario_approval_request_persists_after_reopen;
 mod scenario_approve_always_persists_cross_thread;
 mod scenario_concurrent_dual_gate_resume;
 mod scenario_failure_category_demasked;
@@ -73,6 +74,14 @@ async fn approvals_group_e2e() {
     report.record(
         "failure_category_demasked",
         scenario_failure_category_demasked::run(&g).await,
+    );
+    // C-DURABLE: independent of the auto-approve toggle (its own gate, resolved
+    // before returning) — the approval-request store is always on-disk
+    // regardless of the group's `StorageMode` (a separate capability-harness
+    // filesystem), so this needs no `StorageMode::LibSql` variant.
+    report.record(
+        "approval_request_persists_after_reopen",
+        scenario_approval_request_persists_after_reopen::run(&g).await,
     );
     // Dependent: must run last (flips the (tenant, user) auto-approve toggle ON).
     scenario_approve_always_persists_cross_thread::run(&g)

--- a/tests/reborn_group_approvals/main.rs
+++ b/tests/reborn_group_approvals/main.rs
@@ -1,6 +1,6 @@
 //! Group integration tests for the Reborn approval flow — the real gate path.
 //!
-//! One sequential `#[tokio::test]` drives five scenarios over a shared
+//! One sequential `#[tokio::test]` drives six scenarios over a shared
 //! [`RebornIntegrationGroup::live_approvals`] group (one approval-request store,
 //! one capability-lease store, one `(tenant, user)` auto-approve toggle, all
 //! shared across threads). See `tests/support/reborn/CLAUDE.md` §"Group tests".
@@ -30,7 +30,11 @@
 //!    `"driver_protocol_violation"` sentinel. Independent of the auto-approve
 //!    toggle (no gate involved); ordered alongside the other independent
 //!    scenarios, before the toggle is flipped.
-//! 5. `approve_always_persists_cross_thread` (HEADLINE) — thread A flips
+//! 5. `approval_request_persists_after_reopen` (C-DURABLE) — reopens a FRESH
+//!    `ApprovalRequestStore` at the same on-disk root and confirms the
+//!    `Pending` request survives, independent of the auto-approve toggle
+//!    (its own gate, resolved before returning).
+//! 6. `approve_always_persists_cross_thread` (HEADLINE) — thread A flips
 //!    auto-approve ON; a DIFFERENT thread B then writes with NO gate. Proves the
 //!    setting persists across thread boundaries. MUST run last (it flips the
 //!    toggle ON for the whole group), so the gate scenarios above are the control

--- a/tests/reborn_group_approvals/scenario_approval_request_persists_after_reopen.rs
+++ b/tests/reborn_group_approvals/scenario_approval_request_persists_after_reopen.rs
@@ -1,0 +1,65 @@
+//! C-DURABLE: a pending approval request survives an independent reopen of
+//! the approval-request store at the SAME on-disk local-dev `storage_root` —
+//! proving capability-produced approval state persists to disk, not just to
+//! in-memory state. Parallels `assert_reply_persists_after_reopen` (thread
+//! history) and `reborn_integration_durable.rs` (extension installs) for the
+//! approval-request store.
+//!
+//! Raises a real `BlockedApproval` gate (auto-approve is disabled for the
+//! group), reopens a FRESH `ApprovalRequestStore` at the capability harness's
+//! `storage_root_for_test()`, and asserts the `Pending` record is there —
+//! independent of the live `Arc` the running group holds. Then resolves the
+//! gate through the normal path so the scenario leaves no run permanently
+//! blocked.
+
+use super::reborn_support::group::{HarnessResult, RebornIntegrationGroup};
+use super::reborn_support::reply::RebornScriptedReply;
+use ironclaw_run_state::ApprovalStatus;
+use ironclaw_turns::TurnStatus;
+use serde_json::json;
+
+pub async fn run(g: &RebornIntegrationGroup) -> HarnessResult<()> {
+    let h = g
+        .thread("conv-approval-durable")
+        .script([
+            RebornScriptedReply::tool_call(
+                "builtin.write_file",
+                json!({"path": "/workspace/durable.txt", "content": "durable write"}),
+            ),
+            RebornScriptedReply::text("file written after approval"),
+        ])
+        .build()
+        .await?;
+    let (run_id, gate_ref) = h
+        .submit_turn_until_blocked("write the durability file")
+        .await?;
+
+    let capability_harness = g
+        .capability_harness()
+        .ok_or("live_approvals always uses HostRuntime")?;
+    let (request_id, scope) = capability_harness.approval_request_scope_for_test(&gate_ref)?;
+
+    // Reopen a FRESH, independent store at the same on-disk root — not the live
+    // `Arc` the running group holds — and confirm the pending request is there.
+    let reopened =
+        ironclaw_reborn_composition::test_support::open_local_dev_approval_request_store_for_test(
+            &capability_harness.storage_root_for_test(),
+        )
+        .await?;
+    let record = reopened
+        .get(&scope, request_id)
+        .await?
+        .ok_or("approval request not found after independent reopen")?;
+    if record.status != ApprovalStatus::Pending {
+        return Err(format!(
+            "expected Pending status after reopen, got {:?}",
+            record.status
+        )
+        .into());
+    }
+
+    // Resolve normally so this scenario leaves no run permanently blocked.
+    h.approve_gate(run_id, &gate_ref).await?;
+    h.wait_for_status(run_id, TurnStatus::Completed).await?;
+    Ok(())
+}

--- a/tests/reborn_group_approvals/scenario_approval_request_persists_after_reopen.rs
+++ b/tests/reborn_group_approvals/scenario_approval_request_persists_after_reopen.rs
@@ -57,6 +57,9 @@ pub async fn run(g: &RebornIntegrationGroup) -> HarnessResult<()> {
         )
         .into());
     }
+    // Drop the independent connection before resuming through the live store to
+    // avoid two open libsql connections spanning a subsequent write.
+    drop(reopened);
 
     // Resolve normally so this scenario leaves no run permanently blocked.
     h.approve_gate(run_id, &gate_ref).await?;

--- a/tests/reborn_group_skills/main.rs
+++ b/tests/reborn_group_skills/main.rs
@@ -1,0 +1,32 @@
+//! Group integration tests for the skill-management verbs at int tier (C-SKILL).
+//!
+//! `skill_list`/`skill_install`/`skill_remove` were previously covered ONLY at
+//! the QA/trace tier (`with_host_runtime_skill_management_capabilities`,
+//! `reborn_qa_smoke_scenarios_e2e.rs`), which swaps the whole model gateway and
+//! skips the real `ironclaw_llm` decorator chain. This group dispatches the
+//! same three verbs through the real turn → capability path, reusing the SAME
+//! `HostRuntimeCapabilityHarness::skill_management_tools()` preset the
+//! trace-tier harness already wires (`group_constructors.rs`), so the two
+//! tiers never drift on capability ids / mounts / policy.
+
+#[allow(dead_code)]
+#[path = "../support/reborn/mod.rs"]
+mod reborn_support;
+#[allow(dead_code)]
+#[path = "../support/mod.rs"]
+mod support;
+
+mod scenario_install_list_remove;
+
+use reborn_support::group::RebornIntegrationGroup;
+
+#[tokio::test]
+async fn skills_group_e2e() {
+    let g = RebornIntegrationGroup::skill_management_tools()
+        .await
+        .expect("skill-management group builds");
+
+    scenario_install_list_remove::run(&g)
+        .await
+        .expect("install_list_remove");
+}

--- a/tests/reborn_group_skills/scenario_install_list_remove.rs
+++ b/tests/reborn_group_skills/scenario_install_list_remove.rs
@@ -1,0 +1,95 @@
+//! HEADLINE: the full skill-management verb lifecycle at int tier.
+//!
+//! Three threads over the SAME shared `HostRuntimeCapabilityHarness` skill
+//! filesystem (mirrors `reborn_group_triggers`'s shared-repo shape):
+//! thread A lists (empty of the test skill), thread B installs then lists
+//! (present), thread C removes then lists (absent again). Split into three
+//! threads — not one multi-step turn — because `tool_result_output(cap)`
+//! returns only the MOST RECENT result for `cap` in a thread's slice, and
+//! `skill_list` is dispatched three times total; one thread per checkpoint
+//! keeps each `tool_result_output` call unambiguous (see the same gotcha
+//! documented in `reborn_group_triggers/scenario_verbs_lifecycle.rs`).
+
+use super::reborn_support::group::{HarnessResult, RebornIntegrationGroup};
+use super::reborn_support::reply::RebornScriptedReply;
+use serde_json::json;
+
+const SKILL_NAME: &str = "t0-skills-review";
+const SKILL_CONTENT: &str = "---\nname: t0-skills-review\ndescription: Read-only mini review.\n---\nInspect status and report findings without editing.\n";
+
+fn skill_names(list_output: &serde_json::Value) -> HarnessResult<Vec<String>> {
+    Ok(list_output["skills"]
+        .as_array()
+        .ok_or("skill_list output missing skills array")?
+        .iter()
+        .filter_map(|skill| skill["name"].as_str().map(str::to_string))
+        .collect())
+}
+
+pub async fn run(g: &RebornIntegrationGroup) -> HarnessResult<()> {
+    // ── Thread A: list before install — the test skill is absent ────────────
+    let lister_before = g
+        .thread("skills-list-before")
+        .script([
+            RebornScriptedReply::tool_call("builtin.skill_list", json!({})),
+            RebornScriptedReply::text("listed"),
+        ])
+        .build()
+        .await?;
+    lister_before.submit_turn("list my skills").await?;
+    let before = lister_before
+        .tool_result_output("builtin.skill_list")
+        .await?;
+    if skill_names(&before)?.contains(&SKILL_NAME.to_string()) {
+        return Err(format!("test skill present before install: {before}").into());
+    }
+
+    // ── Thread B: install, then list — the test skill is present ────────────
+    let installer = g
+        .thread("skills-install")
+        .script([
+            RebornScriptedReply::tool_call(
+                "builtin.skill_install",
+                json!({"name": SKILL_NAME, "content": SKILL_CONTENT}),
+            ),
+            RebornScriptedReply::tool_call("builtin.skill_list", json!({})),
+            RebornScriptedReply::text("installed"),
+        ])
+        .build()
+        .await?;
+    installer.submit_turn("install a review skill").await?;
+    let installed = installer
+        .tool_result_output("builtin.skill_install")
+        .await?;
+    if installed["installed"] != json!(true) || installed["name"] != json!(SKILL_NAME) {
+        return Err(format!("install must report success for the named skill: {installed}").into());
+    }
+    let after_install = installer.tool_result_output("builtin.skill_list").await?;
+    if !skill_names(&after_install)?.contains(&SKILL_NAME.to_string()) {
+        return Err(format!("installed skill absent from list: {after_install}").into());
+    }
+
+    // ── Thread C: remove, then list — the test skill is absent again ────────
+    let remover = g
+        .thread("skills-remove")
+        .script([
+            RebornScriptedReply::tool_call("builtin.skill_remove", json!({"name": SKILL_NAME})),
+            RebornScriptedReply::tool_call("builtin.skill_list", json!({})),
+            RebornScriptedReply::text("removed"),
+        ])
+        .build()
+        .await?;
+    remover.submit_turn("remove the review skill").await?;
+    let removed = remover.tool_result_output("builtin.skill_remove").await?;
+    if removed["removed"] != json!(true) || removed["name"] != json!(SKILL_NAME) {
+        return Err(format!("remove must report success for the named skill: {removed}").into());
+    }
+    // Non-vacuity guard: the removed skill is gone (not present merely because
+    // nothing else ever lists it after install either).
+    let after_remove = remover.tool_result_output("builtin.skill_list").await?;
+    if skill_names(&after_remove)?.contains(&SKILL_NAME.to_string()) {
+        return Err(format!("removed skill still present in list: {after_remove}").into());
+    }
+
+    Ok(())
+}

--- a/tests/reborn_group_triggers/main.rs
+++ b/tests/reborn_group_triggers/main.rs
@@ -23,6 +23,7 @@ mod reborn_support;
 #[path = "../support/mod.rs"]
 mod support;
 
+mod scenario_trigger_persists_after_reopen;
 mod scenario_verbs_lifecycle;
 
 use reborn_support::group::{RebornIntegrationGroup, ScenarioReport};
@@ -37,6 +38,13 @@ async fn triggers_group_e2e() {
     // HEADLINE: create a one-shot Once trigger + list it in thread A, then
     // pause → resume → remove it by id in thread B over the shared repo.
     report.record("verbs_lifecycle", scenario_verbs_lifecycle::run(&g).await);
+    // C-DURABLE: independent of `verbs_lifecycle` (its own trigger name/id) —
+    // the trigger repository is always on-disk regardless of the group's
+    // `StorageMode` (a separate capability-harness filesystem).
+    report.record(
+        "trigger_persists_after_reopen",
+        scenario_trigger_persists_after_reopen::run(&g).await,
+    );
 
     // TODO(triggered-turn follow-ups): coverage intentionally left OUT of this
     // binary because it needs a harness seam that does not exist yet — a way to

--- a/tests/reborn_group_triggers/scenario_trigger_persists_after_reopen.rs
+++ b/tests/reborn_group_triggers/scenario_trigger_persists_after_reopen.rs
@@ -1,0 +1,74 @@
+//! C-DURABLE: a created trigger survives an independent reopen of the trigger
+//! repository at the SAME on-disk local-dev `storage_root` — proving
+//! capability-produced trigger state persists to disk, not just to in-memory
+//! state. Parallels `assert_reply_persists_after_reopen` (thread history) and
+//! `reborn_integration_durable.rs` (extension installs) for the trigger
+//! repository.
+//!
+//! Creates a one-shot `Once` trigger through a real turn, reads the
+//! server-minted `trigger_id`, then reopens a FRESH `TriggerRepository` at the
+//! capability harness's `storage_root_for_test()` and confirms the trigger is
+//! there by id — independent of the live `Arc` the group holds.
+
+use super::reborn_support::group::{HarnessResult, RebornIntegrationGroup};
+use super::reborn_support::reply::RebornScriptedReply;
+use ironclaw_triggers::TriggerId;
+use serde_json::json;
+
+const ONCE_AT: &str = "2999-06-01T00:00:00";
+const TRIGGER_NAME: &str = "c-durable-trigger-reopen";
+
+pub async fn run(g: &RebornIntegrationGroup) -> HarnessResult<()> {
+    let h = g
+        .thread("trigger-durable")
+        .script([
+            RebornScriptedReply::tool_call(
+                "builtin.trigger_create",
+                json!({
+                    "name": TRIGGER_NAME,
+                    "prompt": "remind me once (durability check)",
+                    "schedule": {"kind": "once", "at": ONCE_AT, "timezone": "UTC"},
+                }),
+            ),
+            RebornScriptedReply::text("created"),
+        ])
+        .build()
+        .await?;
+    h.submit_turn("create a durable one-shot reminder").await?;
+
+    let created = h.tool_result_output("builtin.trigger_create").await?;
+    let trigger_id = created["trigger"]["trigger_id"]
+        .as_str()
+        .ok_or("trigger_create output missing trigger_id")?
+        .to_string();
+
+    let capability_harness = g
+        .capability_harness()
+        .ok_or("triggers group always uses HostRuntime")?;
+    // Same run-scope tenant every group's `build_base` resolves (the fixed
+    // itest scope) — read off the group's own product-workflow scope rather
+    // than a separately hardcoded literal, so this can never drift from the
+    // tenant `trigger_create` actually stored under.
+    let tenant_id = g.shared.product_harness.scope.tenant_id.clone();
+
+    // Reopen a FRESH, independent repository at the same on-disk root — not the
+    // live `Arc` the running group holds — and confirm the trigger is there.
+    let reopened =
+        ironclaw_reborn_composition::test_support::open_local_dev_trigger_repository_for_test(
+            &capability_harness.storage_root_for_test(),
+        )
+        .await?;
+    let record = reopened
+        .get_trigger(tenant_id, TriggerId::parse(&trigger_id)?)
+        .await?
+        .ok_or_else(|| format!("trigger {trigger_id} not found after independent reopen"))?;
+    if record.name != TRIGGER_NAME {
+        return Err(format!(
+            "reopened trigger name mismatch: expected {TRIGGER_NAME:?}, got {:?}",
+            record.name
+        )
+        .into());
+    }
+
+    Ok(())
+}

--- a/tests/reborn_integration_cancel.rs
+++ b/tests/reborn_integration_cancel.rs
@@ -1,4 +1,5 @@
-//! Reborn integration test — mid-turn cancellation (E-GATEWAY seam).
+//! Reborn integration test — mid-turn cancellation + related failure paths
+//! (E-GATEWAY seam, C-ERRORS).
 //!
 //! Proves the cancel path end-to-end at the int tier: the model call parks at
 //! the vendor-SDK seam, the test cancels the in-flight run, releases the park,
@@ -7,6 +8,11 @@
 //! by the loop-driver host's own default `TurnStateRunCancellationFactory`
 //! (`group.rs` leaves the optional `cancellation_factory` as `None`), not a
 //! wired coordinator fan-out.
+//!
+//! The three tests below extend the same seam with C-ERRORS' other two rows:
+//! a leaked-permit regression guard on the cancel path (precedent: PR #5206's
+//! RAII `ReservationGuard` bugs), thread-busy rejection, and a non-retryable
+//! provider-`Err` reaching a categorized `TurnStatus::Failed`.
 
 #[allow(dead_code)]
 #[path = "support/reborn/mod.rs"]
@@ -16,6 +22,7 @@ mod support;
 
 use std::time::Duration;
 
+use ironclaw_product_adapters::ProductInboundAck;
 use ironclaw_turns::TurnStatus;
 use reborn_support::builder::RebornIntegrationHarness;
 use reborn_support::reply::RebornScriptedReply;
@@ -49,4 +56,121 @@ async fn cancels_a_parked_mid_turn_run() {
         .wait_for_status(run_id, TurnStatus::Cancelled)
         .await
         .expect("parked run reaches Cancelled after cancel");
+}
+
+/// Regression guard: cancelling a parked run must release whatever
+/// per-actor/tenant admission slot or run-concurrency permit it held. If
+/// cancellation leaked one (precedent: PR #5206's leaked WASM
+/// permit/reservation bugs), a second turn on the SAME thread right after
+/// would either hang past `wait_for_status`'s internal deadline or come back
+/// `RejectedBusy` instead of completing.
+#[tokio::test]
+async fn cancelled_run_does_not_block_a_second_turn_on_the_same_thread() {
+    let gate = ParkingModelGate::new();
+    let harness = RebornIntegrationHarness::test_default()
+        .park_model(gate.clone())
+        .script([
+            RebornScriptedReply::text("should never be finalized"),
+            RebornScriptedReply::text("second turn done"),
+        ])
+        .build()
+        .await
+        .expect("harness builds");
+
+    let run_id = harness
+        .submit_turn_async("do a long thing")
+        .await
+        .expect("first turn submitted");
+    tokio::time::timeout(Duration::from_secs(10), gate.wait_until_parked())
+        .await
+        .expect("model call parks before the timeout");
+    harness.cancel_run(run_id).await.expect("cancel accepted");
+    gate.release();
+    harness
+        .wait_for_status(run_id, TurnStatus::Cancelled)
+        .await
+        .expect("parked run reaches Cancelled after cancel");
+
+    // The gate's channels are already consumed after the first park+release
+    // cycle, so this second call passes through the same `ParkingLlm` instantly
+    // (see `ParkingModelGate`'s "second call does not block" guarantee).
+    harness
+        .submit_turn("do another thing")
+        .await
+        .expect("second turn on the same thread completes after the first was cancelled");
+    harness
+        .assert_reply_contains("second turn done")
+        .await
+        .expect("second turn's reply persisted");
+}
+
+/// A second submit on a thread whose first run is still active (parked, not
+/// yet cancelled) must be rejected — `InboundTurnOutcome::RejectedBusy`
+/// (`ironclaw_product_workflow::inbound_turn`) — not silently queued or
+/// accepted. Releases the park afterward so the first run still completes and
+/// the harness doesn't leak a parked task past the test.
+#[tokio::test]
+async fn busy_reject_when_thread_already_has_an_active_run() {
+    let gate = ParkingModelGate::new();
+    let harness = RebornIntegrationHarness::test_default()
+        .park_model(gate.clone())
+        .script([RebornScriptedReply::text("first turn done")])
+        .build()
+        .await
+        .expect("harness builds");
+
+    let run_id = harness
+        .submit_turn_async("do a long thing")
+        .await
+        .expect("first turn submitted");
+    tokio::time::timeout(Duration::from_secs(10), gate.wait_until_parked())
+        .await
+        .expect("model call parks before the timeout");
+
+    let ack = harness
+        .submit_turn_ack("interrupt with something else")
+        .await
+        .expect("the busy-reject submit itself does not error");
+    assert!(
+        matches!(ack, ProductInboundAck::RejectedBusy { .. }),
+        "expected RejectedBusy while the thread has an active run, got {ack:?}"
+    );
+
+    gate.release();
+    harness
+        .wait_for_status(run_id, TurnStatus::Completed)
+        .await
+        .expect("first turn still completes after the rejected second submit");
+}
+
+/// A raw provider `Err` that the real `ironclaw_llm` decorator chain classifies
+/// as non-retryable (`LlmError::ContextLengthExceeded`, excluded from
+/// `ironclaw_llm::retry::is_retryable`) must reach the model a `TurnStatus::Failed`
+/// run categorized `"model_error"` (`LoopFailureKind::ModelError`), not silently
+/// retry forever or surface as a different failure category.
+#[tokio::test]
+async fn mid_turn_provider_error_reaches_failed_with_model_error_category() {
+    let harness = RebornIntegrationHarness::test_default()
+        .fail_model()
+        .build()
+        .await
+        .expect("harness builds");
+
+    let run_id = harness
+        .submit_turn_async("do something")
+        .await
+        .expect("turn submitted");
+    let state = harness
+        .wait_for_status(run_id, TurnStatus::Failed)
+        .await
+        .expect("run reaches Failed after a non-retryable provider error");
+    let failure = state
+        .failure
+        .as_ref()
+        .expect("a Failed run must carry a failure detail");
+    assert_eq!(
+        failure.category(),
+        "model_error",
+        "expected LoopFailureKind::ModelError, got {failure:?}"
+    );
 }

--- a/tests/reborn_integration_cancel.rs
+++ b/tests/reborn_integration_cancel.rs
@@ -9,8 +9,8 @@
 //! (`group.rs` leaves the optional `cancellation_factory` as `None`), not a
 //! wired coordinator fan-out.
 //!
-//! The three tests below extend the same seam with C-ERRORS' other two rows:
-//! a leaked-permit regression guard on the cancel path (precedent: PR #5206's
+//! The tests below extend the same seam with C-ERRORS coverage: a
+//! leaked-permit regression guard on the cancel path (precedent: PR #5206's
 //! RAII `ReservationGuard` bugs), thread-busy rejection, and a non-retryable
 //! provider-`Err` reaching a categorized `TurnStatus::Failed`.
 

--- a/tests/reborn_integration_skill_activate.rs
+++ b/tests/reborn_integration_skill_activate.rs
@@ -19,15 +19,20 @@
 //! the capability wrap or the `into_group` `skill_context_source` wiring
 //! regresses, the sentinel never reaches a captured request and the assert fails.
 //!
-//! The second test below drives the OTHER half of E-SKILL: criteria-based
-//! (keyword) auto-activation, with no `skill_activate` tool call scripted at
-//! all. `seed_system_skill_for_test`'s SKILL.md already carries
-//! `activation.keywords: ["greet"]`, and the harness wires
-//! `regex_skill_activation_enabled=true` unconditionally
-//! (`harness.rs`'s `skill_activation_tools`) — so a message containing "greet"
-//! reaches `SkillActivationMode::ActivationCriteria`
-//! (`ironclaw_first_party_extension_ports::activation::select_skill_activations`)
-//! with zero new production wiring.
+//! The second test below pins the OTHER half of E-SKILL: criteria-based
+//! (keyword) auto-activation stays OFF on the coordinator path. No
+//! `skill_activate` tool call is scripted, and `seed_system_skill_for_test`'s
+//! SKILL.md already carries `activation.keywords: ["greet"]` with
+//! `regex_skill_activation_enabled=true` wired unconditionally (`harness.rs`'s
+//! `skill_activation_tools`) — but `SkillActivationMode::ActivationCriteria`
+//! selection (`ironclaw_first_party_extension_ports::activation::select_skill_activations`)
+//! never runs on this path: it only fires when `take_message_for_run` returns
+//! `Some`, populated by `record_user_message`, whose sole production caller is
+//! the legacy `RebornRuntime::submit_user_turn` — the coordinator stack never
+//! records the message. So a keyword-matching message alone must NOT inject
+//! the skill prompt; the explicit `builtin.skill_activate` capability path
+//! (proven above) remains the supported mechanism (product decision, see
+//! closed issue #5530).
 
 #[allow(dead_code)]
 #[path = "support/reborn/mod.rs"]
@@ -110,13 +115,21 @@ async fn skill_criteria_auto_activation_stays_off_on_coordinator_path() {
         .await
         .expect("turn completes");
 
+    // Specific error check (not generic `is_err()`): `assert_model_request_contains`
+    // has a second, unrelated `Err` path (JSON serialization failure of the
+    // captured request) — asserting the exact "not found" message text rules
+    // that out, so an infra-level failure can't masquerade as proof the
+    // sentinel was absent.
+    let err = harness
+        .assert_model_request_contains("GREET_SKILL_PROMPT_SENTINEL")
+        .await
+        .expect_err(
+            "criteria auto-activation is intentionally OFF on the coordinator path — \
+             a keyword-matching message alone must not inject the skill prompt (#5530)",
+        );
     assert!(
-        harness
-            .assert_model_request_contains("GREET_SKILL_PROMPT_SENTINEL")
-            .await
-            .is_err(),
-        "criteria auto-activation is intentionally OFF on the coordinator path — \
-         a keyword-matching message alone must not inject the skill prompt (#5530)"
+        err.to_string().starts_with("no model request contained"),
+        "expected the intended \"not found\" assertion failure, got a different harness error: {err}"
     );
 
     // And the explicit capability was never dispatched either.

--- a/tests/reborn_integration_skill_activate.rs
+++ b/tests/reborn_integration_skill_activate.rs
@@ -78,35 +78,19 @@ async fn skill_activate_dispatches_and_injects_skill_context() {
         .expect("activated skill instructions must inject into a model request");
 }
 
-// ESCALATED (not fixed here — architectural, touches the shared agent-loop
-// ingress path): `SkillActivationMode::ActivationCriteria` is unreachable from
-// the modern Reborn turn-submission path today. `SelectableSkillContextSource::
-// load_skill_context_candidates` (activation.rs:789-808, the `HostSkillContextSource`
-// the loop calls) only runs fresh criteria selection when
-// `take_message_for_run(scope, accepted_message_ref)` returns `Some` — populated
-// exclusively by `record_user_message`/`record_message` (activation.rs:256-274).
-// `record_user_message`'s ONLY production caller is the legacy
-// `RebornRuntime::submit_user_turn` (`ironclaw_reborn_composition::runtime`, line
-// ~1924) — a different, older runtime, NOT the `TurnCoordinator`/agent-loop stack
-// `product_workflow::accept_inbound` drives (confirmed: production `skill_context_source`
-// wiring in `build_reborn_runtime` → `local_dev_filesystem_skill_context_source`,
-// runtime.rs:2925-3417, hands the raw `SelectableSkillContextSource` to the loop
-// driver with no message-recording decorator — same shape this test harness
-// wires). Net effect: on every real Reborn turn, `take_message_for_run` returns
-// `None`, `load_skill_context_candidates` falls back to `active_plan_candidates`
-// (only an already-EXPLICITLY-activated plan), and keyword/regex criteria
-// selection never fires — even though `auto_activate` defaults `true` and
-// `regex_skill_activation_enabled=true` is already wired.
-// TODO(reborn-skill-criteria-gap): wire `record_user_message` into the modern
-// turn-submission/loop-driver-host ingress path (mirroring what
-// `RebornRuntime::submit_user_turn` already does for the legacy path) — needs
-// its own PR; the right hook point (loop_driver_host pre-loop setup vs. a new
-// BeforeInbound-style hook) needs its own design pass. Pinned RED here so this
-// regresses loudly instead of silently if anyone assumes the criteria path
-// already works.
-#[ignore = "TODO(reborn-skill-criteria-gap): record_user_message never called on the modern Reborn submit_turn path — see comment above"]
+// INTENTIONAL: `SkillActivationMode::ActivationCriteria` (keyword/regex
+// auto-activation) does NOT fire on the modern `TurnCoordinator`/agent-loop
+// path — auto-activation is disabled on purpose (product decision, see closed
+// issue #5530). The explicit `builtin.skill_activate` capability path is the
+// supported mechanism and is what this binary covers. Mechanically: criteria
+// selection only runs when `take_message_for_run` returns `Some`, populated by
+// `record_user_message`, whose sole production caller is the legacy
+// `RebornRuntime::submit_user_turn` — the coordinator stack never records the
+// message, so criteria selection stays inert there by design. This test pins
+// that intentional OFF state: a keyword-matching message alone must NOT inject
+// the skill.
 #[tokio::test]
-async fn skill_auto_activates_via_criteria_without_explicit_capability_call() {
+async fn skill_criteria_auto_activation_stays_off_on_coordinator_path() {
     let group = RebornIntegrationGroup::skill_activation_tools()
         .await
         .expect("skill-activation group builds");
@@ -118,25 +102,29 @@ async fn skill_auto_activates_via_criteria_without_explicit_capability_call() {
         .expect("thread builds");
 
     // The message CONTAINS the seeded skill's activation keyword ("greet") and
-    // no `skill_activate` tool call is scripted — the only way the sentinel can
-    // reach the model is criteria-based auto-activation.
+    // no `skill_activate` tool call is scripted — if criteria auto-activation
+    // ever silently turned on for the coordinator path, the sentinel would
+    // reach the model and this test would go RED.
     harness
         .submit_turn("please greet the visitor")
         .await
         .expect("turn completes");
 
-    harness
-        .assert_model_request_contains("GREET_SKILL_PROMPT_SENTINEL")
-        .await
-        .expect("keyword-matching skill must auto-inject without an explicit activate call");
+    assert!(
+        harness
+            .assert_model_request_contains("GREET_SKILL_PROMPT_SENTINEL")
+            .await
+            .is_err(),
+        "criteria auto-activation is intentionally OFF on the coordinator path — \
+         a keyword-matching message alone must not inject the skill prompt (#5530)"
+    );
 
-    // Prove this really is the criteria path, not a hidden explicit call: the
-    // synthetic capability was never dispatched.
+    // And the explicit capability was never dispatched either.
     assert!(
         harness
             .assert_tool_invoked("builtin.skill_activate")
             .await
             .is_err(),
-        "builtin.skill_activate must NOT have been invoked on the criteria-only path"
+        "builtin.skill_activate must NOT have been invoked without an explicit call"
     );
 }

--- a/tests/reborn_integration_skill_activate.rs
+++ b/tests/reborn_integration_skill_activate.rs
@@ -18,6 +18,16 @@
 //! explicit `skill_activate` call — not from keyword auto-activation. If either
 //! the capability wrap or the `into_group` `skill_context_source` wiring
 //! regresses, the sentinel never reaches a captured request and the assert fails.
+//!
+//! The second test below drives the OTHER half of E-SKILL: criteria-based
+//! (keyword) auto-activation, with no `skill_activate` tool call scripted at
+//! all. `seed_system_skill_for_test`'s SKILL.md already carries
+//! `activation.keywords: ["greet"]`, and the harness wires
+//! `regex_skill_activation_enabled=true` unconditionally
+//! (`harness.rs`'s `skill_activation_tools`) — so a message containing "greet"
+//! reaches `SkillActivationMode::ActivationCriteria`
+//! (`ironclaw_first_party_extension_ports::activation::select_skill_activations`)
+//! with zero new production wiring.
 
 #[allow(dead_code)]
 #[path = "support/reborn/mod.rs"]
@@ -66,4 +76,67 @@ async fn skill_activate_dispatches_and_injects_skill_context() {
         .assert_model_request_contains("GREET_SKILL_PROMPT_SENTINEL")
         .await
         .expect("activated skill instructions must inject into a model request");
+}
+
+// ESCALATED (not fixed here — architectural, touches the shared agent-loop
+// ingress path): `SkillActivationMode::ActivationCriteria` is unreachable from
+// the modern Reborn turn-submission path today. `SelectableSkillContextSource::
+// load_skill_context_candidates` (activation.rs:789-808, the `HostSkillContextSource`
+// the loop calls) only runs fresh criteria selection when
+// `take_message_for_run(scope, accepted_message_ref)` returns `Some` — populated
+// exclusively by `record_user_message`/`record_message` (activation.rs:256-274).
+// `record_user_message`'s ONLY production caller is the legacy
+// `RebornRuntime::submit_user_turn` (`ironclaw_reborn_composition::runtime`, line
+// ~1924) — a different, older runtime, NOT the `TurnCoordinator`/agent-loop stack
+// `product_workflow::accept_inbound` drives (confirmed: production `skill_context_source`
+// wiring in `build_reborn_runtime` → `local_dev_filesystem_skill_context_source`,
+// runtime.rs:2925-3417, hands the raw `SelectableSkillContextSource` to the loop
+// driver with no message-recording decorator — same shape this test harness
+// wires). Net effect: on every real Reborn turn, `take_message_for_run` returns
+// `None`, `load_skill_context_candidates` falls back to `active_plan_candidates`
+// (only an already-EXPLICITLY-activated plan), and keyword/regex criteria
+// selection never fires — even though `auto_activate` defaults `true` and
+// `regex_skill_activation_enabled=true` is already wired.
+// TODO(reborn-skill-criteria-gap): wire `record_user_message` into the modern
+// turn-submission/loop-driver-host ingress path (mirroring what
+// `RebornRuntime::submit_user_turn` already does for the legacy path) — needs
+// its own PR; the right hook point (loop_driver_host pre-loop setup vs. a new
+// BeforeInbound-style hook) needs its own design pass. Pinned RED here so this
+// regresses loudly instead of silently if anyone assumes the criteria path
+// already works.
+#[ignore = "TODO(reborn-skill-criteria-gap): record_user_message never called on the modern Reborn submit_turn path — see comment above"]
+#[tokio::test]
+async fn skill_auto_activates_via_criteria_without_explicit_capability_call() {
+    let group = RebornIntegrationGroup::skill_activation_tools()
+        .await
+        .expect("skill-activation group builds");
+    let harness = group
+        .thread("conv-skill-criteria")
+        .script([RebornScriptedReply::text("done")])
+        .build()
+        .await
+        .expect("thread builds");
+
+    // The message CONTAINS the seeded skill's activation keyword ("greet") and
+    // no `skill_activate` tool call is scripted — the only way the sentinel can
+    // reach the model is criteria-based auto-activation.
+    harness
+        .submit_turn("please greet the visitor")
+        .await
+        .expect("turn completes");
+
+    harness
+        .assert_model_request_contains("GREET_SKILL_PROMPT_SENTINEL")
+        .await
+        .expect("keyword-matching skill must auto-inject without an explicit activate call");
+
+    // Prove this really is the criteria path, not a hidden explicit call: the
+    // synthetic capability was never dispatched.
+    assert!(
+        harness
+            .assert_tool_invoked("builtin.skill_activate")
+            .await
+            .is_err(),
+        "builtin.skill_activate must NOT have been invoked on the criteria-only path"
+    );
 }

--- a/tests/support/reborn/CLAUDE.md
+++ b/tests/support/reborn/CLAUDE.md
@@ -90,6 +90,12 @@ conversation; `submit_turn`/`assert_reply_contains` take just the text.
   harness struct to widen); it delegates the MCP wiring to the `pub(super)` factories
   in `harness_mcp.rs`. `harness.rs` remains large (a further `harness_auth.rs`
   split is tracked in the coverage roadmap).
+- `group_constructors.rs` — the per-capability `RebornIntegrationGroup` /
+  `RebornIntegrationGroupBuilder` preset constructors (`live_approvals`,
+  `builtin_tools`, `extension_lifecycle`, `skill_management_tools`, etc.), a
+  private child module of `group.rs` (same `harness_mcp.rs` split precedent)
+  so it can reach `group.rs`'s shared assembly internals at module-private
+  visibility. See [Group tests](#group-tests) below.
 - `process.rs` — `RecordingProcessPort`, the inert process port: records every
   `CommandExecutionRequest.command` and returns exit 0 / empty output without
   spawning any OS process. Injected by default when `with_builtin_http_tools()` is
@@ -376,6 +382,7 @@ pub async fn run(g: &RebornIntegrationGroup) -> HarnessResult<()> {
 | `RebornIntegrationGroup::builtin_tools()` | core built-in (http/echo/time/json/shell) | enabled |
 | `RebornIntegrationGroup::extension_lifecycle()` | extension_search/install/activate/remove | enabled |
 | `RebornIntegrationGroup::triggers()` | trigger_create/list/pause/resume/remove | enabled |
+| `RebornIntegrationGroup::skill_management_tools()` | skill_list/skill_install/skill_remove | enabled |
 | `RebornIntegrationGroup::builder().storage(LibSql).live_approvals()` | same + LibSql storage | disabled |
 
 ### Distinct actors per thread (E-MULTIUSER)

--- a/tests/support/reborn/builder.rs
+++ b/tests/support/reborn/builder.rs
@@ -111,6 +111,10 @@ pub struct RebornIntegrationHarnessBuilder {
     /// E-GATEWAY: when set, the model call parks until released, enabling a
     /// mid-turn cancel test. Threaded into the degenerate one-thread group.
     park_gate: Option<ParkingModelGate>,
+    /// E-GATEWAY (C-ERRORS): when `true`, the model call always fails with a
+    /// fixed non-retryable `LlmError`. Threaded into the degenerate one-thread
+    /// group. See [`RebornThreadBuilder::fail_model`].
+    fail_model: bool,
 }
 
 impl RebornIntegrationHarnessBuilder {
@@ -145,6 +149,14 @@ impl RebornIntegrationHarnessBuilder {
     /// [`RebornThreadBuilder::park_model`].
     pub fn park_model(mut self, gate: ParkingModelGate) -> Self {
         self.park_gate = Some(gate);
+        self
+    }
+
+    /// Fail this harness's model call unconditionally with a fixed, non-retryable
+    /// `LlmError` (E-GATEWAY seam, C-ERRORS). See
+    /// [`RebornThreadBuilder::fail_model`](super::group::RebornThreadBuilder::fail_model).
+    pub fn fail_model(mut self) -> Self {
+        self.fail_model = true;
         self
     }
 
@@ -298,6 +310,7 @@ impl RebornIntegrationHarnessBuilder {
             .thread(self.conversation_id)
             .script(self.replies)
             .park_model_opt(self.park_gate)
+            .fail_model_opt(self.fail_model)
             .build()
             .await
     }
@@ -389,6 +402,7 @@ impl RebornIntegrationHarness {
             safety_context: None,
             shell_mode: ShellMode::default(),
             park_gate: None,
+            fail_model: false,
         }
     }
 
@@ -403,6 +417,20 @@ impl RebornIntegrationHarness {
     /// — the caller drives the wait (`wait_for_status`). Used by approval/auth flows
     /// where the turn blocks on a gate rather than completing.
     pub async fn submit_turn_async(&self, text: &str) -> HarnessResult<TurnRunId> {
+        match self.submit_turn_ack(text).await? {
+            ProductInboundAck::Accepted {
+                submitted_run_id, ..
+            } => Ok(submitted_run_id),
+            other => Err(format!("expected accepted inbound ack, got {other:?}").into()),
+        }
+    }
+
+    /// Submit a user turn and return the raw `ProductInboundAck` — `Accepted` OR
+    /// `RejectedBusy` (thread already has an active run). Most callers want
+    /// `submit_turn_async`, which narrows to `Accepted` and errors on any other
+    /// ack; this is the seam for C-ERRORS' busy-reject test, which needs to
+    /// observe `RejectedBusy` without that narrowing turning it into an `Err`.
+    pub async fn submit_turn_ack(&self, text: &str) -> HarnessResult<ProductInboundAck> {
         let event_id = format!("evt-{}", self.event_seq.fetch_add(1, Ordering::Relaxed));
         let envelope = self.ingress.verified_text_envelope_with_trigger(
             &event_id,
@@ -411,13 +439,7 @@ impl RebornIntegrationHarness {
             text,
             ProductTriggerReason::DirectChat,
         )?;
-        let ack = self.workflow.accept_inbound(envelope).await?;
-        match ack {
-            ProductInboundAck::Accepted {
-                submitted_run_id, ..
-            } => Ok(submitted_run_id),
-            other => Err(format!("expected accepted inbound ack, got {other:?}").into()),
-        }
+        Ok(self.workflow.accept_inbound(envelope).await?)
     }
 
     /// Submit a user turn and wait until it blocks on an approval gate, returning

--- a/tests/support/reborn/group.rs
+++ b/tests/support/reborn/group.rs
@@ -302,9 +302,8 @@ impl RebornIntegrationGroup {
             group: self,
             conversation_id: conversation_id.into(),
             replies: Vec::new(),
-            park_gate: None,
             actor_id: None,
-            fail_model: false,
+            model_mode: ThreadModelMode::Normal,
         }
     }
 
@@ -382,7 +381,7 @@ impl GroupBaseData {
     /// dispatch shares the run's `(tenant, user)` with the turn-store /
     /// evidence scope resolved from the SAME `canonical_binding` (see the
     /// `canonical_binding` field docs above).
-    fn canonical_subject_user(&self) -> HarnessResult<UserId> {
+    pub(crate) fn canonical_subject_user(&self) -> HarnessResult<UserId> {
         Ok(self
             .canonical_binding
             .subject_user_id
@@ -651,17 +650,28 @@ pub struct RebornThreadBuilder<'g> {
     group: &'g RebornIntegrationGroup,
     conversation_id: String,
     replies: Vec<RebornScriptedReply>,
-    /// When set, this thread's model call parks until the gate is released
-    /// (E-GATEWAY seam), enabling a mid-turn cancel test. `None` = normal
-    /// scripted playback. Mutually exclusive with `fail_model` by usage
-    /// contract (not enforced by the type — no test sets both); `park_gate`
-    /// wins if it ever were.
-    park_gate: Option<ParkingModelGate>,
     actor_id: Option<String>,
-    /// When `true`, this thread's model call always fails with a fixed
-    /// non-retryable `LlmError` (E-GATEWAY seam, C-ERRORS) instead of playing
-    /// back `replies`. See [`super::scripted_provider::ErrLlm`].
-    fail_model: bool,
+    model_mode: ThreadModelMode,
+}
+
+/// A thread's model-call behavior: exactly one of normal scripted playback,
+/// parked-until-released, or unconditional failure. One enum instead of an
+/// `Option<ParkingModelGate>` + `bool` pair (mirrors `ShellMode` in
+/// `builder.rs`) so the three modes are mutually exclusive BY CONSTRUCTION —
+/// no tuple-priority rule needed at the dispatch site, and no state can
+/// silently ask for "parked AND failing" at once.
+#[derive(Default)]
+enum ThreadModelMode {
+    /// Normal scripted playback (the default).
+    #[default]
+    Normal,
+    /// This thread's model call parks until the gate is released (E-GATEWAY
+    /// seam), enabling a mid-turn cancel test.
+    Parked(ParkingModelGate),
+    /// This thread's model call always fails with a fixed non-retryable
+    /// `LlmError` (E-GATEWAY seam, C-ERRORS) instead of playing back
+    /// `replies`. See [`super::scripted_provider::ErrLlm`].
+    Failing,
 }
 
 impl<'g> RebornThreadBuilder<'g> {
@@ -680,9 +690,13 @@ impl<'g> RebornThreadBuilder<'g> {
     }
 
     /// Internal: set the optional park gate (used by the flat builder to thread
-    /// its own `park_gate` through the degenerate one-thread group).
+    /// its own park gate through the degenerate one-thread group). A `Some`
+    /// gate always wins, matching the old tuple-priority contract, even if
+    /// `fail_model_opt` is called first.
     pub(crate) fn park_model_opt(mut self, gate: Option<ParkingModelGate>) -> Self {
-        self.park_gate = gate;
+        if let Some(gate) = gate {
+            self.model_mode = ThreadModelMode::Parked(gate);
+        }
         self
     }
 
@@ -712,9 +726,13 @@ impl<'g> RebornThreadBuilder<'g> {
     }
 
     /// Internal: set the fail-model flag (used by the flat builder to thread
-    /// its own knob through the degenerate one-thread group).
+    /// its own knob through the degenerate one-thread group). Never downgrades
+    /// an already-`Parked` mode, matching the old tuple-priority contract
+    /// (`park_model` always wins over `fail_model`).
     pub(crate) fn fail_model_opt(mut self, fail: bool) -> Self {
-        self.fail_model = fail;
+        if fail && !matches!(self.model_mode, ThreadModelMode::Parked(_)) {
+            self.model_mode = ThreadModelMode::Failing;
+        }
         self
     }
 
@@ -781,13 +799,16 @@ impl<'g> RebornThreadBuilder<'g> {
         // (`assert_system_prompt_contains`, `assert_model_request_contains`)
         // regardless of whether this thread is parked.
         let scripted_llm: Arc<TraceLlm> = Arc::new(scripted_trace_llm(self.replies));
-        // C-ERRORS: `fail_model` swaps in `ErrLlm` at the same vendor-SDK seam,
-        // ahead of `park_gate` in priority (never both set by any test — see the
-        // field doc on `RebornThreadBuilder::park_gate`).
-        let raw: Arc<dyn LlmProvider> = match (self.park_gate, self.fail_model) {
-            (Some(gate), _) => Arc::new(parking_trace_llm(gate, scripted_llm.clone())),
-            (None, true) => Arc::new(ErrLlm),
-            (None, false) => scripted_llm.clone(),
+        // C-ERRORS: `Failing` swaps in `ErrLlm` at the same vendor-SDK seam;
+        // `Parked` swaps in the parking wrapper. `ThreadModelMode` makes the
+        // three modes mutually exclusive by construction — no priority rule
+        // needed here.
+        let raw: Arc<dyn LlmProvider> = match self.model_mode {
+            ThreadModelMode::Parked(gate) => {
+                Arc::new(parking_trace_llm(gate, scripted_llm.clone()))
+            }
+            ThreadModelMode::Failing => Arc::new(ErrLlm),
+            ThreadModelMode::Normal => scripted_llm.clone(),
         };
         let session = create_session_manager(SessionConfig {
             session_path: shared

--- a/tests/support/reborn/group.rs
+++ b/tests/support/reborn/group.rs
@@ -126,7 +126,7 @@ use super::product_workflow::RebornProductWorkflowHarness;
 use super::reply::RebornScriptedReply;
 use super::scope_gateway::ScopeRegistryGateway;
 use super::scripted_provider::{
-    ParkingModelGate, SCRIPTED_MODEL_NAME, parking_trace_llm, scripted_trace_llm,
+    ErrLlm, ParkingModelGate, SCRIPTED_MODEL_NAME, parking_trace_llm, scripted_trace_llm,
 };
 use super::session_thread::RebornThreadHarness;
 use super::test_adapter::{RebornTestIngress, RebornTestProductAdapter};
@@ -267,73 +267,20 @@ impl GroupCapability {
 /// [`extension_lifecycle`](Self::extension_lifecycle), or
 /// [`triggers`](Self::triggers), or via
 /// [`builder`](Self::builder) for custom storage mode.
+///
+/// The per-capability preset constructors themselves (`live_approvals`,
+/// `builtin_tools`, `extension_lifecycle`, `live_auth_gate`,
+/// `project_lifecycle`, `profile_tools`, `triggers`, `skill_activation_tools`,
+/// `skill_management_tools`, and their `RebornIntegrationGroupBuilder`
+/// counterparts) live in the sibling `group_constructors.rs` — a thin catalog
+/// of "which capability" selections layered over the one-shared-runtime
+/// assembly mechanics (`build_base`/`into_group`) this file owns. Mirrors the
+/// `harness_mcp.rs` split.
 pub struct RebornIntegrationGroup {
     pub(crate) shared: Arc<GroupSharedStorage>,
 }
 
 impl RebornIntegrationGroup {
-    /// Group with real file-tool approval stores (write_file/read_file at
-    /// `PermissionMode::Ask`). Auto-approve is disabled for the group scope at
-    /// construction so gated tool calls raise real `BlockedApproval` gates.
-    /// Resolve with `approve_gate`/`deny_gate` per thread; re-enable with
-    /// `enable_auto_approve` for the no-gate arm.
-    pub async fn live_approvals() -> HarnessResult<Self> {
-        Self::builder().live_approvals().await
-    }
-
-    /// Group with core built-in tools (memory/http/echo/time/json/shell).
-    /// Auto-approve is enabled for all capability ids in the group scope.
-    pub async fn builtin_tools() -> HarnessResult<Self> {
-        Self::builder().builtin_tools().await
-    }
-
-    /// Group with extension-lifecycle tools
-    /// (extension_search/install/activate/remove). Auto-approve is enabled;
-    /// registry credentials are seeded.
-    pub async fn extension_lifecycle() -> HarnessResult<Self> {
-        Self::builder().extension_lifecycle().await
-    }
-
-    /// Group whose GitHub extension's credential account resolves to
-    /// `AuthRequired`, so a scripted `github.*` tool call raises a real
-    /// `TurnStatus::BlockedAuth` gate (E-AUTHGATE seam). Drive with
-    /// `submit_turn_until_auth_blocked`.
-    pub async fn live_auth_gate() -> HarnessResult<Self> {
-        Self::builder().live_auth_gate().await
-    }
-
-    /// Group with the local-dev synthetic `project_create` capability wired
-    /// (E-PROJ seam). Auto-approve is enabled.
-    pub async fn project_lifecycle() -> HarnessResult<Self> {
-        Self::builder().project_lifecycle().await
-    }
-
-    /// Group whose ONLY capability is `builtin.profile_set` (E-PROFILE seam).
-    /// Auto-approve is enabled. Use `user_profile_source_for_test()` to read
-    /// a written profile back through the same adapter the group's planned
-    /// runtime resolves user profiles from.
-    pub async fn profile_tools() -> HarnessResult<Self> {
-        Self::builder().profile_tools().await
-    }
-
-    /// Group with trigger-management tools
-    /// (trigger_create/list/pause/resume/remove). Auto-approve is enabled for
-    /// all capability ids in the group scope so the `Ask`-mode verbs dispatch
-    /// through the real capability path instead of raising approval gates.
-    pub async fn triggers() -> HarnessResult<Self> {
-        Self::builder().triggers().await
-    }
-
-    /// Group whose ONLY capability is `builtin.skill_activate` (E-SKILL seam).
-    /// A system-scoped `greet` skill is seeded for the run; a scripted
-    /// `builtin.skill_activate` call for `greet` dispatches the synthetic
-    /// capability and injects the skill's instructions into the model
-    /// request through the runtime's `skill_context_source`. Auto-approve is
-    /// enabled.
-    pub async fn skill_activation_tools() -> HarnessResult<Self> {
-        Self::builder().skill_activation_tools().await
-    }
-
     /// Builder for advanced configuration (e.g. `StorageMode::LibSql`).
     /// Defaults to `StorageMode::InMemory`.
     pub fn builder() -> RebornIntegrationGroupBuilder {
@@ -357,6 +304,7 @@ impl RebornIntegrationGroup {
             replies: Vec::new(),
             park_gate: None,
             actor_id: None,
+            fail_model: false,
         }
     }
 
@@ -402,7 +350,12 @@ impl RebornIntegrationGroup {
 /// Replaces the 4-tuple `(RebornProductWorkflowHarness, Arc<CompositeRootFilesystem>,
 /// Option<PathBuf>, Arc<TempDir>)` so each constructor can name fields rather than
 /// position-destructure a tuple.
-struct GroupBaseData {
+///
+/// `pub(crate)` (not private): the per-capability preset constructors in the
+/// sibling `group_constructors.rs` take/return this type as the opaque handoff
+/// between `build_base` and `into_group` — they never read its fields except
+/// `canonical_binding` (also `pub(crate)`).
+pub(crate) struct GroupBaseData {
     product_harness: RebornProductWorkflowHarness,
     composite: Arc<CompositeRootFilesystem>,
     libsql_db_path: Option<PathBuf>,
@@ -415,7 +368,11 @@ struct GroupBaseData {
     /// `TurnScope`) has no `thread_id` field — so this canonical binding is a
     /// valid stand-in for the whole group (see `ensure_thread_scope_matches_turn_scope`,
     /// which checks only tenant/agent/project, never thread_id).
-    canonical_binding: ResolvedBinding,
+    ///
+    /// `pub(crate)`: `group_constructors.rs`'s `live_approvals`/
+    /// `skill_activation_tools` read the resolved tenant/subject user off this
+    /// field directly (see field docs above).
+    pub(crate) canonical_binding: ResolvedBinding,
 }
 
 impl GroupBaseData {
@@ -466,7 +423,10 @@ impl RebornIntegrationGroupBuilder {
     /// workflow harness over the fixed itest scope, the per-group `TempDir`, and
     /// the thread/turn composite. Returns [`GroupBaseData`] so each constructor
     /// names the fields it needs — the fixed test-scope strings live HERE only.
-    async fn build_base(&self) -> HarnessResult<GroupBaseData> {
+    ///
+    /// `pub(crate)`: called by the per-capability preset constructors in the
+    /// sibling `group_constructors.rs`.
+    pub(crate) async fn build_base(&self) -> HarnessResult<GroupBaseData> {
         apply_hermetic_env();
         let scope = test_product_scope(
             "tenant-itest",
@@ -522,7 +482,10 @@ impl RebornIntegrationGroupBuilder {
     /// `ThreadCheckpointLoopExitEvidencePort` (the de-mask fix, design §4) and
     /// `.with_approval_gate_evidence` when the capability backend exposes a
     /// local-dev approval store.
-    async fn into_group(
+    ///
+    /// `pub(crate)`: called by the per-capability preset constructors in the
+    /// sibling `group_constructors.rs`.
+    pub(crate) async fn into_group(
         self,
         base: GroupBaseData,
         capability: GroupCapability,
@@ -667,140 +630,6 @@ impl RebornIntegrationGroupBuilder {
             }),
         })
     }
-
-    /// Build a `RebornIntegrationGroup` for an already-selected `GroupCapability`.
-    /// Shared tail of the constructors whose capability is independent of the
-    /// resolved base (`builtin_tools`/`extension_lifecycle`) and the degenerate
-    /// single-shot path (`RebornIntegrationHarnessBuilder::build`).
-    /// `live_approvals` resolves its capability from `base` first, so it calls
-    /// `build_base` + `into_group` directly instead.
-    pub(crate) async fn build_with_capability(
-        self,
-        capability: GroupCapability,
-    ) -> HarnessResult<RebornIntegrationGroup> {
-        let base = self.build_base().await?;
-        self.into_group(base, capability).await
-    }
-
-    /// Build a live-approvals group. See [`RebornIntegrationGroup::live_approvals`].
-    pub async fn live_approvals(self) -> HarnessResult<RebornIntegrationGroup> {
-        let base = self.build_base().await?;
-        // Execute first-party tools under the run's CANONICAL binding subject
-        // user (the hashed `UserId` the actor `host-user` resolves to), not the
-        // constructor's fixed test user, so capability dispatch, approval
-        // persistence, auto-approve keying, and gate-evidence lookup all share the
-        // run's `(tenant, user)` — matching production. Reuse the SAME canonical
-        // binding `build_base` already resolved for the shared turn-store /
-        // evidence scope, so the approval user and the turn-store scope are
-        // derived from one probe and cannot drift.
-        let subject_user = base.canonical_subject_user()?;
-        let host_runtime = HostRuntimeCapabilityHarness::file_tools_requiring_approval()
-            .await?
-            .with_user_id(subject_user);
-        let capability = GroupCapability::HostRuntime(Arc::new(host_runtime));
-        let group = self.into_group(base, capability).await?;
-        // Disable auto-approve once at build time so every thread in this group
-        // faces real approval gates. The dispatch-time check is keyed on the
-        // capability harness's executor user (NOT the binding owner), so target
-        // `auto_approve_scope()` — `(run tenant, capability user)`.
-        // `live_approvals` always constructs `GroupCapability::HostRuntime`, so
-        // both `auto_approve_scope()` and `capability_harness()` are guaranteed
-        // `Some` — use `expect` rather than a redundant `if let`.
-        let scope = group
-            .shared
-            .auto_approve_scope()
-            .expect("live_approvals always uses HostRuntime; scope is always Some");
-        let arc = group
-            .capability_harness()
-            .expect("live_approvals always uses HostRuntime");
-        arc.disable_global_auto_approve(scope).await?;
-        Ok(group)
-    }
-
-    /// Build a core built-in tools group. See [`RebornIntegrationGroup::builtin_tools`].
-    pub async fn builtin_tools(self) -> HarnessResult<RebornIntegrationGroup> {
-        let host_runtime = HostRuntimeCapabilityHarness::core_builtin_tools().await?;
-        let capability = GroupCapability::HostRuntime(Arc::new(host_runtime));
-        self.build_with_capability(capability).await
-    }
-
-    /// Build an extension-lifecycle group. See [`RebornIntegrationGroup::extension_lifecycle`].
-    pub async fn extension_lifecycle(self) -> HarnessResult<RebornIntegrationGroup> {
-        let host_runtime = HostRuntimeCapabilityHarness::extension_lifecycle_tools().await?;
-        let capability = GroupCapability::HostRuntime(Arc::new(host_runtime));
-        self.build_with_capability(capability).await
-    }
-
-    /// Build an auth-gate group. See [`RebornIntegrationGroup::live_auth_gate`].
-    ///
-    /// No auto-approve disable and no approval-gate evidence: auth gates are
-    /// self-evidencing via the BeforeBlock checkpoint (loop_exit_applier.rs). Do
-    /// NOT add approval-gate evidence here — that store is only for approval gates.
-    pub async fn live_auth_gate(self) -> HarnessResult<RebornIntegrationGroup> {
-        let base = self.build_base().await?;
-        let host_runtime = HostRuntimeCapabilityHarness::github_issue_tools_auth_required().await?;
-        let capability = GroupCapability::HostRuntime(Arc::new(host_runtime));
-        self.into_group(base, capability).await
-    }
-
-    /// Build a project-lifecycle group. See [`RebornIntegrationGroup::project_lifecycle`].
-    pub async fn project_lifecycle(self) -> HarnessResult<RebornIntegrationGroup> {
-        let base = self.build_base().await?;
-        let host_runtime = HostRuntimeCapabilityHarness::project_tools().await?;
-        let capability = GroupCapability::HostRuntime(Arc::new(host_runtime));
-        self.into_group(base, capability).await
-    }
-
-    /// Build a profile-tools group. See [`RebornIntegrationGroup::profile_tools`].
-    pub async fn profile_tools(self) -> HarnessResult<RebornIntegrationGroup> {
-        let base = self.build_base().await?;
-        // Execute `builtin.profile_set` under the run's CANONICAL binding
-        // subject user (the hashed `UserId` the actor `host-user` resolves
-        // to), not the constructor's fixed test user, so capability dispatch
-        // and the loop's `resolve_user_profile` read-back share the SAME
-        // `(tenant, user)` — matching production and mirroring
-        // `live_approvals`'s alignment above. Without this, a second thread's
-        // loop resolves the profile under the canonical binding subject user
-        // while the write dispatched under the fixed constructor user, so the
-        // read-back never sees it.
-        let subject_user = base.canonical_subject_user()?;
-        let host_runtime = HostRuntimeCapabilityHarness::profile_tools()
-            .await?
-            .with_user_id(subject_user);
-        let capability = GroupCapability::HostRuntime(Arc::new(host_runtime));
-        self.into_group(base, capability).await
-    }
-
-    /// Build a trigger-management group. See [`RebornIntegrationGroup::triggers`].
-    pub async fn triggers(self) -> HarnessResult<RebornIntegrationGroup> {
-        let host_runtime = HostRuntimeCapabilityHarness::trigger_management_tools().await?;
-        let capability = GroupCapability::HostRuntime(Arc::new(host_runtime));
-        self.build_with_capability(capability).await
-    }
-
-    /// Build a skill-activation group. See
-    /// [`RebornIntegrationGroup::skill_activation_tools`]. Seeds a `greet` system
-    /// skill BEFORE `into_group` so the runtime's `skill_context_source` (and the
-    /// `skill_activate` capability's `activate_skills_for_run`) resolve it at
-    /// activation time. A system skill is used so resolution is independent of the
-    /// run's scope owner — the seam only needs the skill to exist.
-    pub async fn skill_activation_tools(self) -> HarnessResult<RebornIntegrationGroup> {
-        let base = self.build_base().await?;
-        // Pass the group's ACTUAL run-scope tenant (resolved by `build_base`
-        // above) rather than a separately hardcoded literal, so the E-SKILL
-        // skill context source is built for the same tenant the turn runs
-        // under — see `HostRuntimeCapabilityHarness::skill_activation_tools`.
-        let host_runtime =
-            HostRuntimeCapabilityHarness::skill_activation_tools(&base.canonical_binding.tenant_id)
-                .await?;
-        host_runtime.seed_system_skill_for_test(
-            "greet",
-            "greets the user warmly",
-            "GREET_SKILL_PROMPT_SENTINEL",
-        )?;
-        let capability = GroupCapability::HostRuntime(Arc::new(host_runtime));
-        self.into_group(base, capability).await
-    }
 }
 
 // ---------------------------------------------------------------------------
@@ -824,9 +653,15 @@ pub struct RebornThreadBuilder<'g> {
     replies: Vec<RebornScriptedReply>,
     /// When set, this thread's model call parks until the gate is released
     /// (E-GATEWAY seam), enabling a mid-turn cancel test. `None` = normal
-    /// scripted playback.
+    /// scripted playback. Mutually exclusive with `fail_model` by usage
+    /// contract (not enforced by the type — no test sets both); `park_gate`
+    /// wins if it ever were.
     park_gate: Option<ParkingModelGate>,
     actor_id: Option<String>,
+    /// When `true`, this thread's model call always fails with a fixed
+    /// non-retryable `LlmError` (E-GATEWAY seam, C-ERRORS) instead of playing
+    /// back `replies`. See [`super::scripted_provider::ErrLlm`].
+    fail_model: bool,
 }
 
 impl<'g> RebornThreadBuilder<'g> {
@@ -866,6 +701,20 @@ impl<'g> RebornThreadBuilder<'g> {
     /// behavior byte-identical.
     pub fn with_actor_id(mut self, actor_id: impl Into<String>) -> Self {
         self.actor_id = Some(actor_id.into());
+        self
+    }
+
+    /// Fail this thread's model call unconditionally with a fixed, non-retryable
+    /// `LlmError` (E-GATEWAY seam, C-ERRORS — provider-`Err` failure category).
+    /// Sits at the same vendor-SDK seam as `park_model`/scripted playback.
+    pub fn fail_model(self) -> Self {
+        self.fail_model_opt(true)
+    }
+
+    /// Internal: set the fail-model flag (used by the flat builder to thread
+    /// its own knob through the degenerate one-thread group).
+    pub(crate) fn fail_model_opt(mut self, fail: bool) -> Self {
+        self.fail_model = fail;
         self
     }
 
@@ -932,9 +781,13 @@ impl<'g> RebornThreadBuilder<'g> {
         // (`assert_system_prompt_contains`, `assert_model_request_contains`)
         // regardless of whether this thread is parked.
         let scripted_llm: Arc<TraceLlm> = Arc::new(scripted_trace_llm(self.replies));
-        let raw: Arc<dyn LlmProvider> = match self.park_gate {
-            Some(gate) => Arc::new(parking_trace_llm(gate, scripted_llm.clone())),
-            None => scripted_llm.clone(),
+        // C-ERRORS: `fail_model` swaps in `ErrLlm` at the same vendor-SDK seam,
+        // ahead of `park_gate` in priority (never both set by any test — see the
+        // field doc on `RebornThreadBuilder::park_gate`).
+        let raw: Arc<dyn LlmProvider> = match (self.park_gate, self.fail_model) {
+            (Some(gate), _) => Arc::new(parking_trace_llm(gate, scripted_llm.clone())),
+            (None, true) => Arc::new(ErrLlm),
+            (None, false) => scripted_llm.clone(),
         };
         let session = create_session_manager(SessionConfig {
             session_path: shared

--- a/tests/support/reborn/group.rs
+++ b/tests/support/reborn/group.rs
@@ -132,6 +132,14 @@ use super::session_thread::RebornThreadHarness;
 use super::test_adapter::{RebornTestIngress, RebornTestProductAdapter};
 use crate::support::trace_llm::TraceLlm;
 
+/// Per-capability preset constructors layered on `build_base`/`into_group`
+/// below. A private child module (not `pub mod` from `mod.rs`) so its only
+/// caller — the constructor catalog — can reach `GroupBaseData` and the
+/// assembly methods via plain module-private visibility instead of widening
+/// them to `pub(crate)` for the whole test-support crate.
+#[path = "group_constructors.rs"]
+mod group_constructors;
+
 /// Convenience alias matching `builder.rs` and `harness.rs`.
 pub type HarnessResult<T> = Result<T, Box<dyn std::error::Error + Send + Sync>>;
 
@@ -272,9 +280,11 @@ impl GroupCapability {
 /// `builtin_tools`, `extension_lifecycle`, `live_auth_gate`,
 /// `project_lifecycle`, `profile_tools`, `triggers`, `skill_activation_tools`,
 /// `skill_management_tools`, and their `RebornIntegrationGroupBuilder`
-/// counterparts) live in the sibling `group_constructors.rs` — a thin catalog
-/// of "which capability" selections layered over the one-shared-runtime
-/// assembly mechanics (`build_base`/`into_group`) this file owns. Mirrors the
+/// counterparts) live in the child `group_constructors` module (file:
+/// `group_constructors.rs`, kept private to `group` — see the `mod
+/// group_constructors` declaration below) — a thin catalog of "which
+/// capability" selections layered over the one-shared-runtime assembly
+/// mechanics (`build_base`/`into_group`) this file owns. Mirrors the
 /// `harness_mcp.rs` split.
 pub struct RebornIntegrationGroup {
     pub(crate) shared: Arc<GroupSharedStorage>,
@@ -350,11 +360,14 @@ impl RebornIntegrationGroup {
 /// Option<PathBuf>, Arc<TempDir>)` so each constructor can name fields rather than
 /// position-destructure a tuple.
 ///
-/// `pub(crate)` (not private): the per-capability preset constructors in the
-/// sibling `group_constructors.rs` take/return this type as the opaque handoff
-/// between `build_base` and `into_group` — they never read its fields except
-/// `canonical_binding` (also `pub(crate)`).
-pub(crate) struct GroupBaseData {
+/// Private (not `pub(crate)`): `group_constructors.rs` is a private child
+/// module of `group` (see the `mod group_constructors` declaration above), so
+/// module-private visibility already reaches it without widening these
+/// internals to the whole test-support crate. The per-capability preset
+/// constructors there take/return this type as the opaque handoff between
+/// `build_base` and `into_group` — they never read its fields except
+/// `canonical_binding`.
+struct GroupBaseData {
     product_harness: RebornProductWorkflowHarness,
     composite: Arc<CompositeRootFilesystem>,
     libsql_db_path: Option<PathBuf>,
@@ -368,10 +381,11 @@ pub(crate) struct GroupBaseData {
     /// valid stand-in for the whole group (see `ensure_thread_scope_matches_turn_scope`,
     /// which checks only tenant/agent/project, never thread_id).
     ///
-    /// `pub(crate)`: `group_constructors.rs`'s `live_approvals`/
-    /// `skill_activation_tools` read the resolved tenant/subject user off this
-    /// field directly (see field docs above).
-    pub(crate) canonical_binding: ResolvedBinding,
+    /// `group_constructors.rs`'s `live_approvals`/`skill_activation_tools`
+    /// read the resolved tenant/subject user off this field directly (see
+    /// field docs above); reachable at module-private visibility since that
+    /// file is a child module of `group`.
+    canonical_binding: ResolvedBinding,
 }
 
 impl GroupBaseData {
@@ -381,7 +395,7 @@ impl GroupBaseData {
     /// dispatch shares the run's `(tenant, user)` with the turn-store /
     /// evidence scope resolved from the SAME `canonical_binding` (see the
     /// `canonical_binding` field docs above).
-    pub(crate) fn canonical_subject_user(&self) -> HarnessResult<UserId> {
+    fn canonical_subject_user(&self) -> HarnessResult<UserId> {
         Ok(self
             .canonical_binding
             .subject_user_id
@@ -423,9 +437,9 @@ impl RebornIntegrationGroupBuilder {
     /// the thread/turn composite. Returns [`GroupBaseData`] so each constructor
     /// names the fields it needs — the fixed test-scope strings live HERE only.
     ///
-    /// `pub(crate)`: called by the per-capability preset constructors in the
-    /// sibling `group_constructors.rs`.
-    pub(crate) async fn build_base(&self) -> HarnessResult<GroupBaseData> {
+    /// Module-private: called by the per-capability preset constructors in
+    /// the child `group_constructors` module.
+    async fn build_base(&self) -> HarnessResult<GroupBaseData> {
         apply_hermetic_env();
         let scope = test_product_scope(
             "tenant-itest",
@@ -482,9 +496,9 @@ impl RebornIntegrationGroupBuilder {
     /// `.with_approval_gate_evidence` when the capability backend exposes a
     /// local-dev approval store.
     ///
-    /// `pub(crate)`: called by the per-capability preset constructors in the
-    /// sibling `group_constructors.rs`.
-    pub(crate) async fn into_group(
+    /// Module-private: called by the per-capability preset constructors in
+    /// the child `group_constructors` module.
+    async fn into_group(
         self,
         base: GroupBaseData,
         capability: GroupCapability,

--- a/tests/support/reborn/group_constructors.rs
+++ b/tests/support/reborn/group_constructors.rs
@@ -1,0 +1,244 @@
+//! Per-capability preset constructors for [`RebornIntegrationGroup`] /
+//! [`RebornIntegrationGroupBuilder`].
+//!
+//! `group.rs` owns the one-shared-runtime assembly mechanics
+//! (`RebornIntegrationGroupBuilder::build_base` / `into_group`); this sibling
+//! file is a thin catalog of "which capability" selections layered on top of
+//! that mechanics — one method per `HostRuntimeCapabilityHarness` preset.
+//! Split out (design precedent: `harness_mcp.rs`) once `group.rs` crossed the
+//! 1000-line ceiling with PR-E2's E-SKILL/E-DURABLE/E-GATEWAY additions; new
+//! capability presets belong HERE, not back in `group.rs`.
+
+// Shared by all group test binaries; symbols read as dead when a binary does
+// not exercise every preset (mirrors the same attribute on `group.rs`/`builder.rs`).
+#![allow(dead_code)]
+
+use std::sync::Arc;
+
+use super::group::{
+    GroupCapability, HarnessResult, RebornIntegrationGroup, RebornIntegrationGroupBuilder,
+};
+use super::harness::HostRuntimeCapabilityHarness;
+
+impl RebornIntegrationGroup {
+    /// Group with real file-tool approval stores (write_file/read_file at
+    /// `PermissionMode::Ask`). Auto-approve is disabled for the group scope at
+    /// construction so gated tool calls raise real `BlockedApproval` gates.
+    /// Resolve with `approve_gate`/`deny_gate` per thread; re-enable with
+    /// `enable_auto_approve` for the no-gate arm.
+    pub async fn live_approvals() -> HarnessResult<Self> {
+        Self::builder().live_approvals().await
+    }
+
+    /// Group with core built-in tools (memory/http/echo/time/json/shell).
+    /// Auto-approve is enabled for all capability ids in the group scope.
+    pub async fn builtin_tools() -> HarnessResult<Self> {
+        Self::builder().builtin_tools().await
+    }
+
+    /// Group with extension-lifecycle tools
+    /// (extension_search/install/activate/remove). Auto-approve is enabled;
+    /// registry credentials are seeded.
+    pub async fn extension_lifecycle() -> HarnessResult<Self> {
+        Self::builder().extension_lifecycle().await
+    }
+
+    /// Group whose GitHub extension's credential account resolves to
+    /// `AuthRequired`, so a scripted `github.*` tool call raises a real
+    /// `TurnStatus::BlockedAuth` gate (E-AUTHGATE seam). Drive with
+    /// `submit_turn_until_auth_blocked`.
+    pub async fn live_auth_gate() -> HarnessResult<Self> {
+        Self::builder().live_auth_gate().await
+    }
+
+    /// Group with the local-dev synthetic `project_create` capability wired
+    /// (E-PROJ seam). Auto-approve is enabled.
+    pub async fn project_lifecycle() -> HarnessResult<Self> {
+        Self::builder().project_lifecycle().await
+    }
+
+    /// Group whose ONLY capability is `builtin.profile_set` (E-PROFILE seam).
+    /// Auto-approve is enabled. Use `user_profile_source_for_test()` to read
+    /// a written profile back through the same adapter the group's planned
+    /// runtime resolves user profiles from.
+    pub async fn profile_tools() -> HarnessResult<Self> {
+        Self::builder().profile_tools().await
+    }
+
+    /// Group with trigger-management tools
+    /// (trigger_create/list/pause/resume/remove). Auto-approve is enabled for
+    /// all capability ids in the group scope so the `Ask`-mode verbs dispatch
+    /// through the real capability path instead of raising approval gates.
+    pub async fn triggers() -> HarnessResult<Self> {
+        Self::builder().triggers().await
+    }
+
+    /// Group whose ONLY capability is `builtin.skill_activate` (E-SKILL seam).
+    /// A system-scoped `greet` skill is seeded for the run; a scripted
+    /// `builtin.skill_activate` call for `greet` dispatches the synthetic
+    /// capability and injects the skill's instructions into the model
+    /// request through the runtime's `skill_context_source`. Auto-approve is
+    /// enabled.
+    pub async fn skill_activation_tools() -> HarnessResult<Self> {
+        Self::builder().skill_activation_tools().await
+    }
+
+    /// Group with the skill-management verbs (`skill_list`/`skill_install`/
+    /// `skill_remove`) at int tier (C-SKILL). Previously covered ONLY at the
+    /// QA/trace tier (`with_host_runtime_skill_management_capabilities`,
+    /// `harness.rs`); this reuses the SAME
+    /// `HostRuntimeCapabilityHarness::skill_management_tools()` preset over
+    /// the real turn → capability path. Auto-approve is enabled.
+    pub async fn skill_management_tools() -> HarnessResult<Self> {
+        Self::builder().skill_management_tools().await
+    }
+}
+
+impl RebornIntegrationGroupBuilder {
+    /// Build a `RebornIntegrationGroup` for an already-selected `GroupCapability`.
+    /// Shared tail of the constructors whose capability is independent of the
+    /// resolved base (`builtin_tools`/`extension_lifecycle`) and the degenerate
+    /// single-shot path (`RebornIntegrationHarnessBuilder::build`).
+    /// `live_approvals` resolves its capability from `base` first, so it calls
+    /// `build_base` + `into_group` directly instead.
+    pub(crate) async fn build_with_capability(
+        self,
+        capability: GroupCapability,
+    ) -> HarnessResult<RebornIntegrationGroup> {
+        let base = self.build_base().await?;
+        self.into_group(base, capability).await
+    }
+
+    /// Build a live-approvals group. See [`RebornIntegrationGroup::live_approvals`].
+    pub async fn live_approvals(self) -> HarnessResult<RebornIntegrationGroup> {
+        let base = self.build_base().await?;
+        // Execute first-party tools under the run's CANONICAL binding subject
+        // user (the hashed `UserId` the actor `host-user` resolves to), not the
+        // constructor's fixed test user, so capability dispatch, approval
+        // persistence, auto-approve keying, and gate-evidence lookup all share the
+        // run's `(tenant, user)` — matching production. Reuse the SAME canonical
+        // binding `build_base` already resolved for the shared turn-store /
+        // evidence scope, so the approval user and the turn-store scope are
+        // derived from one probe and cannot drift.
+        let subject_user = base.canonical_subject_user()?;
+        let host_runtime = HostRuntimeCapabilityHarness::file_tools_requiring_approval()
+            .await?
+            .with_user_id(subject_user);
+        let capability = GroupCapability::HostRuntime(Arc::new(host_runtime));
+        let group = self.into_group(base, capability).await?;
+        // Disable auto-approve once at build time so every thread in this group
+        // faces real approval gates. The dispatch-time check is keyed on the
+        // capability harness's executor user (NOT the binding owner), so target
+        // `auto_approve_scope()` — `(run tenant, capability user)`.
+        // `live_approvals` always constructs `GroupCapability::HostRuntime`, so
+        // both `auto_approve_scope()` and `capability_harness()` are guaranteed
+        // `Some` — use `expect` rather than a redundant `if let`.
+        let scope = group
+            .shared
+            .auto_approve_scope()
+            .expect("live_approvals always uses HostRuntime; scope is always Some");
+        let arc = group
+            .capability_harness()
+            .expect("live_approvals always uses HostRuntime");
+        arc.disable_global_auto_approve(scope).await?;
+        Ok(group)
+    }
+
+    /// Build a core built-in tools group. See [`RebornIntegrationGroup::builtin_tools`].
+    pub async fn builtin_tools(self) -> HarnessResult<RebornIntegrationGroup> {
+        let host_runtime = HostRuntimeCapabilityHarness::core_builtin_tools().await?;
+        let capability = GroupCapability::HostRuntime(Arc::new(host_runtime));
+        self.build_with_capability(capability).await
+    }
+
+    /// Build an extension-lifecycle group. See [`RebornIntegrationGroup::extension_lifecycle`].
+    pub async fn extension_lifecycle(self) -> HarnessResult<RebornIntegrationGroup> {
+        let host_runtime = HostRuntimeCapabilityHarness::extension_lifecycle_tools().await?;
+        let capability = GroupCapability::HostRuntime(Arc::new(host_runtime));
+        self.build_with_capability(capability).await
+    }
+
+    /// Build an auth-gate group. See [`RebornIntegrationGroup::live_auth_gate`].
+    ///
+    /// No auto-approve disable and no approval-gate evidence: auth gates are
+    /// self-evidencing via the BeforeBlock checkpoint (loop_exit_applier.rs). Do
+    /// NOT add approval-gate evidence here — that store is only for approval gates.
+    pub async fn live_auth_gate(self) -> HarnessResult<RebornIntegrationGroup> {
+        let base = self.build_base().await?;
+        let host_runtime = HostRuntimeCapabilityHarness::github_issue_tools_auth_required().await?;
+        let capability = GroupCapability::HostRuntime(Arc::new(host_runtime));
+        self.into_group(base, capability).await
+    }
+
+    /// Build a project-lifecycle group. See [`RebornIntegrationGroup::project_lifecycle`].
+    pub async fn project_lifecycle(self) -> HarnessResult<RebornIntegrationGroup> {
+        let base = self.build_base().await?;
+        let host_runtime = HostRuntimeCapabilityHarness::project_tools().await?;
+        let capability = GroupCapability::HostRuntime(Arc::new(host_runtime));
+        self.into_group(base, capability).await
+    }
+
+    /// Build a profile-tools group. See [`RebornIntegrationGroup::profile_tools`].
+    pub async fn profile_tools(self) -> HarnessResult<RebornIntegrationGroup> {
+        let base = self.build_base().await?;
+        // Execute `builtin.profile_set` under the run's CANONICAL binding
+        // subject user (the hashed `UserId` the actor `host-user` resolves
+        // to), not the constructor's fixed test user, so capability dispatch
+        // and the loop's `resolve_user_profile` read-back share the SAME
+        // `(tenant, user)` — matching production and mirroring
+        // `live_approvals`'s alignment above. Without this, a second thread's
+        // loop resolves the profile under the canonical binding subject user
+        // while the write dispatched under the fixed constructor user, so the
+        // read-back never sees it.
+        let subject_user = base.canonical_subject_user()?;
+        let host_runtime = HostRuntimeCapabilityHarness::profile_tools()
+            .await?
+            .with_user_id(subject_user);
+        let capability = GroupCapability::HostRuntime(Arc::new(host_runtime));
+        self.into_group(base, capability).await
+    }
+
+    /// Build a trigger-management group. See [`RebornIntegrationGroup::triggers`].
+    pub async fn triggers(self) -> HarnessResult<RebornIntegrationGroup> {
+        let host_runtime = HostRuntimeCapabilityHarness::trigger_management_tools().await?;
+        let capability = GroupCapability::HostRuntime(Arc::new(host_runtime));
+        self.build_with_capability(capability).await
+    }
+
+    /// Build a skill-activation group. See
+    /// [`RebornIntegrationGroup::skill_activation_tools`]. Seeds a `greet` system
+    /// skill BEFORE `into_group` so the runtime's `skill_context_source` (and the
+    /// `skill_activate` capability's `activate_skills_for_run`) resolve it at
+    /// activation time. A system skill is used so resolution is independent of the
+    /// run's scope owner — the seam only needs the skill to exist.
+    pub async fn skill_activation_tools(self) -> HarnessResult<RebornIntegrationGroup> {
+        let base = self.build_base().await?;
+        // Pass the group's ACTUAL run-scope tenant (resolved by `build_base`
+        // above) rather than a separately hardcoded literal, so the E-SKILL
+        // skill context source is built for the same tenant the turn runs
+        // under — see `HostRuntimeCapabilityHarness::skill_activation_tools`.
+        let host_runtime =
+            HostRuntimeCapabilityHarness::skill_activation_tools(&base.canonical_binding.tenant_id)
+                .await?;
+        host_runtime.seed_system_skill_for_test(
+            "greet",
+            "greets the user warmly",
+            "GREET_SKILL_PROMPT_SENTINEL",
+        )?;
+        let capability = GroupCapability::HostRuntime(Arc::new(host_runtime));
+        self.into_group(base, capability).await
+    }
+
+    /// Build a skill-management group. See
+    /// [`RebornIntegrationGroup::skill_management_tools`]. Reuses the SAME
+    /// `HostRuntimeCapabilityHarness::skill_management_tools()` preset the
+    /// QA/trace-tier harness already wires (`harness.rs`'s
+    /// `with_host_runtime_skill_management_capabilities`), so the int-tier
+    /// group and the trace-tier smoke test never drift on capability ids /
+    /// mounts / policy.
+    pub async fn skill_management_tools(self) -> HarnessResult<RebornIntegrationGroup> {
+        let host_runtime = HostRuntimeCapabilityHarness::skill_management_tools().await?;
+        let capability = GroupCapability::HostRuntime(Arc::new(host_runtime));
+        self.build_with_capability(capability).await
+    }
+}

--- a/tests/support/reborn/group_constructors.rs
+++ b/tests/support/reborn/group_constructors.rs
@@ -2,12 +2,17 @@
 //! [`RebornIntegrationGroupBuilder`].
 //!
 //! `group.rs` owns the one-shared-runtime assembly mechanics
-//! (`RebornIntegrationGroupBuilder::build_base` / `into_group`); this sibling
-//! file is a thin catalog of "which capability" selections layered on top of
-//! that mechanics — one method per `HostRuntimeCapabilityHarness` preset.
-//! Split out (design precedent: `harness_mcp.rs`) once `group.rs` crossed the
-//! 1000-line ceiling with PR-E2's E-SKILL/E-DURABLE/E-GATEWAY additions; new
-//! capability presets belong HERE, not back in `group.rs`.
+//! (`RebornIntegrationGroupBuilder::build_base` / `into_group`); this file is
+//! a private child module of `group` (declared `#[path = "group_constructors.rs"]
+//! mod group_constructors;` in `group.rs`, NOT `pub mod` from `mod.rs`) that
+//! catalogs "which capability" selections layered on top of that mechanics —
+//! one method per `HostRuntimeCapabilityHarness` preset. Keeping it a child
+//! module (rather than a top-level sibling) lets it reach `build_base`/
+//! `into_group`/`GroupBaseData` at plain module-private visibility instead of
+//! widening them to `pub(crate)` for the whole test-support crate. Split out
+//! (design precedent: `harness_mcp.rs`) once `group.rs` crossed the 1000-line
+//! ceiling with PR-E2's E-SKILL/E-DURABLE/E-GATEWAY additions; new capability
+//! presets belong HERE, not back in `group.rs`.
 
 // Shared by all group test binaries; symbols read as dead when a binary does
 // not exercise every preset (mirrors the same attribute on `group.rs`/`builder.rs`).
@@ -15,10 +20,10 @@
 
 use std::sync::Arc;
 
-use super::group::{
+use super::super::harness::HostRuntimeCapabilityHarness;
+use super::{
     GroupCapability, HarnessResult, RebornIntegrationGroup, RebornIntegrationGroupBuilder,
 };
-use super::harness::HostRuntimeCapabilityHarness;
 
 impl RebornIntegrationGroup {
     /// Group with real file-tool approval stores (write_file/read_file at

--- a/tests/support/reborn/group_constructors.rs
+++ b/tests/support/reborn/group_constructors.rs
@@ -99,8 +99,10 @@ impl RebornIntegrationGroupBuilder {
     /// Shared tail of the constructors whose capability is independent of the
     /// resolved base (`builtin_tools`/`extension_lifecycle`) and the degenerate
     /// single-shot path (`RebornIntegrationHarnessBuilder::build`).
-    /// `live_approvals` resolves its capability from `base` first, so it calls
-    /// `build_base` + `into_group` directly instead.
+    /// `live_approvals` and `profile_tools` both resolve their capability's
+    /// executor user FROM `base` (`canonical_subject_user()`), so they call
+    /// `build_base` + `into_group` directly instead, reusing the SAME `base`
+    /// for both the user lookup and the group assembly.
     pub(crate) async fn build_with_capability(
         self,
         capability: GroupCapability,
@@ -164,18 +166,16 @@ impl RebornIntegrationGroupBuilder {
     /// self-evidencing via the BeforeBlock checkpoint (loop_exit_applier.rs). Do
     /// NOT add approval-gate evidence here — that store is only for approval gates.
     pub async fn live_auth_gate(self) -> HarnessResult<RebornIntegrationGroup> {
-        let base = self.build_base().await?;
         let host_runtime = HostRuntimeCapabilityHarness::github_issue_tools_auth_required().await?;
         let capability = GroupCapability::HostRuntime(Arc::new(host_runtime));
-        self.into_group(base, capability).await
+        self.build_with_capability(capability).await
     }
 
     /// Build a project-lifecycle group. See [`RebornIntegrationGroup::project_lifecycle`].
     pub async fn project_lifecycle(self) -> HarnessResult<RebornIntegrationGroup> {
-        let base = self.build_base().await?;
         let host_runtime = HostRuntimeCapabilityHarness::project_tools().await?;
         let capability = GroupCapability::HostRuntime(Arc::new(host_runtime));
-        self.into_group(base, capability).await
+        self.build_with_capability(capability).await
     }
 
     /// Build a profile-tools group. See [`RebornIntegrationGroup::profile_tools`].
@@ -189,7 +189,10 @@ impl RebornIntegrationGroupBuilder {
         // `live_approvals`'s alignment above. Without this, a second thread's
         // loop resolves the profile under the canonical binding subject user
         // while the write dispatched under the fixed constructor user, so the
-        // read-back never sees it.
+        // read-back never sees it. This is ALSO why `profile_tools` cannot go
+        // through `build_with_capability` (see its doc comment): the
+        // capability depends on `base`, so `base` must be resolved first and
+        // reused here, exactly like `live_approvals`.
         let subject_user = base.canonical_subject_user()?;
         let host_runtime = HostRuntimeCapabilityHarness::profile_tools()
             .await?

--- a/tests/support/reborn/harness.rs
+++ b/tests/support/reborn/harness.rs
@@ -1940,7 +1940,11 @@ impl HostRuntimeCapabilityHarness {
         Ok(harness)
     }
 
-    async fn skill_management_tools() -> HarnessResult<Self> {
+    /// `pub(crate)`: also used by `RebornIntegrationGroupBuilder::skill_management_tools`
+    /// (`group_constructors.rs`, C-SKILL) to wire the SAME preset onto the
+    /// int-tier group, so the QA/trace-tier smoke test and the int-tier group
+    /// never drift on capability ids / mounts / policy.
+    pub(crate) async fn skill_management_tools() -> HarnessResult<Self> {
         let mut harness = Self::new_with_options(
             "reborn-e2e-skill-management-tools",
             vec![
@@ -2894,6 +2898,28 @@ impl HostRuntimeCapabilityHarness {
     /// Tests only.
     pub(crate) fn storage_root_for_test(&self) -> PathBuf {
         self.root.path().join("local-dev")
+    }
+
+    /// C-DURABLE: resolve `gate_ref` (a `"gate:approval-<id>"` local-dev
+    /// approval gate) to the `(ApprovalRequestId, ResourceScope)` pair a fresh,
+    /// independently-reopened `ApprovalRequestStore::get`/`read_versioned` call
+    /// needs. Reuses the SAME private lookup `approve_local_dev_gate`/
+    /// `deny_local_dev_gate` already use (`approval_request_id_from_gate_ref` +
+    /// `pending_approval_scopes`) so a durability test's scope construction can
+    /// never drift from the live approve/deny path. Tests only.
+    pub(crate) fn approval_request_scope_for_test(
+        &self,
+        gate_ref: &GateRef,
+    ) -> HarnessResult<(ApprovalRequestId, ResourceScope)> {
+        let request_id = approval_request_id_from_gate_ref(gate_ref)?;
+        let scope = self
+            .pending_approval_scopes
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .get(&request_id)
+            .cloned()
+            .ok_or("approval gate was not recorded by the host runtime harness")?;
+        Ok((request_id, scope))
     }
 
     /// E-SKILL: seed a system-scoped skill on this harness's on-disk skill

--- a/tests/support/reborn/mod.rs
+++ b/tests/support/reborn/mod.rs
@@ -8,6 +8,7 @@ pub mod extension_surface;
 pub mod filesystem;
 pub mod github;
 pub mod group;
+pub mod group_constructors;
 pub mod harness;
 pub mod harness_mcp;
 pub mod harness_web_access;

--- a/tests/support/reborn/mod.rs
+++ b/tests/support/reborn/mod.rs
@@ -8,7 +8,6 @@ pub mod extension_surface;
 pub mod filesystem;
 pub mod github;
 pub mod group;
-pub mod group_constructors;
 pub mod harness;
 pub mod harness_mcp;
 pub mod harness_web_access;

--- a/tests/support/reborn/scripted_provider.rs
+++ b/tests/support/reborn/scripted_provider.rs
@@ -171,6 +171,45 @@ impl LlmProvider for ParkingLlm {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Fixed-error model provider (E-GATEWAY seam) — provider-`Err` failure
+// category coverage (C-ERRORS).
+// ---------------------------------------------------------------------------
+
+/// A raw `LlmProvider` that always fails with a fixed, NON-retryable
+/// `LlmError::ContextLengthExceeded`. Deliberately NOT the `LlmError::RequestFailed`
+/// a naturally-exhausted `TraceLlm` returns (see `next_step` above) — `RequestFailed`
+/// IS retryable (`ironclaw_llm::retry::is_retryable`), so scripting it would drive
+/// several seconds of real exponential backoff (1s/2s/4s) before the run finally
+/// failed. `ContextLengthExceeded` is excluded from `is_retryable`, so the run
+/// fails on the first model call — fast and deterministic. Sits at the same
+/// vendor-SDK seam `scripted_trace_llm`/`ParkingLlm` fill; the real `ironclaw_llm`
+/// decorator chain still runs on top, so this proves the chain's non-retryable-error
+/// mapping through to a terminal `TurnStatus::Failed`, not just the seam itself.
+pub struct ErrLlm;
+
+#[async_trait]
+impl LlmProvider for ErrLlm {
+    fn model_name(&self) -> &str {
+        SCRIPTED_MODEL_NAME
+    }
+
+    fn cost_per_token(&self) -> (Decimal, Decimal) {
+        (Decimal::ZERO, Decimal::ZERO)
+    }
+
+    async fn complete(&self, _request: CompletionRequest) -> Result<CompletionResponse, LlmError> {
+        Err(LlmError::ContextLengthExceeded { used: 1, limit: 1 })
+    }
+
+    async fn complete_with_tools(
+        &self,
+        _request: ToolCompletionRequest,
+    ) -> Result<ToolCompletionResponse, LlmError> {
+        Err(LlmError::ContextLengthExceeded { used: 1, limit: 1 })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::time::Duration;


### PR DESCRIPTION
Tier-2 coverage over the three seams PR-E2 (#5514) merged. Roadmap rows C-SKILL / C-DURABLE / C-ERRORS (`docs/reborn/reborn-backend-coverage-roadmap.md`).

## C-SKILL
- `tests/reborn_group_skills/` (new bin): skill list-before-empty → install+present → remove+absent, via a new `RebornIntegrationGroup::skill_management_tools()` constructor over the existing harness preset.
- `tests/reborn_integration_skill_activate.rs`: explicit `skill_activate` dispatch + prompt-injection assert (skill content reaches the model-visible request via the `TraceLlm` seam), plus a pin that criteria-based auto-activation stays **intentionally OFF** on the coordinator path (product decision, closed #5530) — goes RED if it ever silently turns on.
- Mutation: flipped production `dispatch_install`'s `installed` field → RED with the exact expected message; reverted.

## C-DURABLE
- Two reopen scenarios: a real approval gate and a real trigger survive a fresh store opened at the same on-disk root (`scenario_approval_request_persists_after_reopen`, `scenario_trigger_persists_after_reopen`), via two pure-composition test-support factories (`#[cfg(test-support, libsql)]`, zero new business logic).
- Deduped the `libsql::Builder::new_local` open sequence into one shared helper (`open_local_dev_libsql_database`) — production `build_default_local_dev_database_roots` now uses it too (was about to become a third inline copy).
- Mutation: factories pointed at a wrong subdirectory → RED with real connection/lookup failures; reverted.

## C-ERRORS
Extended `reborn_integration_cancel.rs` — all green, no product bugs found:
- cancelled run does not block a second turn on the same thread (leaked-permit regression guard, #5206 precedent)
- busy-reject: second submit on an active thread returns `RejectedBusy` (new `submit_turn_ack()` extract-then-narrow helper)
- mid-turn non-retryable provider `Err` reaches `TurnStatus::Failed` with category `model_error` (new minimal `ErrLlm` + `fail_model` knob mirroring `park_gate`'s shape)
- Mutations: category flip, ack-polarity flip, reply flip — all RED for the right reason; reverted.

## Structural
`group.rs` was already over the 1000-line ceiling (1007) — split FIRST: 9 per-capability preset constructors extracted into `group_constructors.rs` (mirrors the `harness_mcp.rs` precedent), core mechanics stay in `group.rs`.

## Verification
- clippy `--all --benches --tests --examples --all-features`: zero new warnings; fmt clean.
- Green: `reborn_group_{approvals,extensions,memory,triggers,skills}`, `reborn_integration_{cancel,durable,skill_activate,backend_matrix}`.
- Pre-existing parallel-execution flake in `ironclaw_reborn_composition`'s own lib suite reproduces identically on base `e79842282` — not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)