### PR TITLE
test(reborn): C-TRACECAP + C-ATTACH — turn-event sink and attachment read-port coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4062,6 +4062,7 @@ dependencies = [
  "iana-time-zone",
  "insta",
  "ironclaw_approvals",
+ "ironclaw_attachments",
  "ironclaw_auth",
  "ironclaw_authorization",
  "ironclaw_common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -268,6 +268,8 @@ insta = { version = "1.46.3", features = ["yaml"] }
 ironclaw_llm = { path = "crates/ironclaw_llm", version = "0.1.0", features = ["testing"] }
 ironclaw_auth = { path = "crates/ironclaw_auth", version = "0.1.0" }
 ironclaw_approvals = { path = "crates/ironclaw_approvals", version = "0.1.0" }
+# C-ATTACH: `InboundAttachment` for `submit_turn_with_image_attachment`.
+ironclaw_attachments = { path = "crates/ironclaw_attachments", version = "0.1.0" }
 ironclaw_authorization = { path = "crates/ironclaw_authorization", version = "0.1.0" }
 ironclaw_extensions = { path = "crates/ironclaw_extensions", version = "0.1.0" }
 ironclaw_filesystem = { path = "crates/ironclaw_filesystem", version = "0.1.0" }

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -585,6 +585,49 @@ impl RebornServices {
         let local_runtime = self.local_runtime.as_ref()?;
         Some(Arc::clone(&local_runtime.project_service))
     }
+
+    /// Test-support access to the attachment read port + inbound lander backing
+    /// the C-ATTACH seam. The read port is built over `local_runtime.workspace_filesystem`,
+    /// exactly like production's `attachment_read_port` (`runtime.rs` ~line 3328) —
+    /// that handle is intentionally read-only (it backs setup-marker reads), which
+    /// is fine for reading. The lander is built over a SEPARATE read-write view
+    /// constructed from `local_runtime.extension_filesystem` + `local_runtime.workspace_mounts`,
+    /// mirroring `RebornRuntimeComposition::webui_workspace_filesystem` (`runtime.rs`
+    /// ~line 1499) exactly — landing through the read-only `workspace_filesystem`
+    /// handle fails closed with `PermissionDenied`. Bundled into one accessor
+    /// (rather than two, mirroring `local_dev_profile_filesystem_for_test` /
+    /// `local_dev_project_service_for_test` above) because the two are always
+    /// populated together. Returns `None` for production-profile compositions
+    /// without a local-dev runtime.
+    #[cfg(feature = "test-support")]
+    pub fn local_dev_attachment_test_support_for_test(&self) -> Option<AttachmentTestSupport> {
+        let local_runtime = self.local_runtime.as_ref()?;
+        let read_write_workspace_filesystem = Arc::new(ScopedFilesystem::with_fixed_view(
+            Arc::clone(&local_runtime.extension_filesystem),
+            local_runtime.workspace_mounts.clone(),
+        ));
+        Some(AttachmentTestSupport {
+            read_port: Arc::new(
+                crate::attachment_landing::ProjectScopedAttachmentReader::new(Arc::clone(
+                    &local_runtime.workspace_filesystem,
+                )),
+            ),
+            lander: Arc::new(
+                crate::attachment_landing::ProjectScopedAttachmentLander::new(
+                    read_write_workspace_filesystem,
+                ),
+            ),
+        })
+    }
+}
+
+/// Bundle returned by [`RebornServices::local_dev_attachment_test_support_for_test`]
+/// (C-ATTACH seam). Test-support only — zero bytes shipped in production builds.
+#[cfg(feature = "test-support")]
+#[derive(Clone)]
+pub struct AttachmentTestSupport {
+    pub read_port: Arc<dyn ironclaw_loop_support::LoopAttachmentReadPort>,
+    pub lander: Arc<dyn ironclaw_product_workflow::InboundAttachmentLander>,
 }
 
 #[cfg(feature = "test-support")]

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -522,6 +522,29 @@ impl RebornServices {
         Arc::clone(&self.secret_store)
     }
 
+    /// Read-write project-scoped workspace filesystem, built over
+    /// `local_runtime.extension_filesystem` + `local_runtime.workspace_mounts`.
+    /// `None` when no local runtime is composed.
+    ///
+    /// This deliberately does NOT reuse `local_runtime.workspace_filesystem`:
+    /// that handle is intentionally read-only (it backs setup-marker reads —
+    /// see `local_dev_setup_marker_workspace_filesystem_is_read_only`), so
+    /// writing through it fails closed with `PermissionDenied`.
+    ///
+    /// Single owner of this recipe — both `RebornRuntime::webui_workspace_filesystem`
+    /// (production attachment landing) and `local_dev_attachment_test_support_for_test`
+    /// (C-ATTACH test seam) call this rather than each rebuilding the view, so the
+    /// two can never drift apart.
+    pub(crate) fn read_write_workspace_filesystem(
+        &self,
+    ) -> Option<Arc<ScopedFilesystem<LocalDevRootFilesystem>>> {
+        let local_runtime = self.local_runtime.as_ref()?;
+        Some(Arc::new(ScopedFilesystem::with_fixed_view(
+            Arc::clone(&local_runtime.extension_filesystem),
+            local_runtime.workspace_mounts.clone(),
+        )))
+    }
+
     #[cfg(feature = "test-support")]
     pub fn local_dev_approval_test_parts(&self) -> Option<RebornLocalDevApprovalTestParts> {
         let local_runtime = self.local_runtime.as_ref()?;
@@ -590,22 +613,18 @@ impl RebornServices {
     /// the C-ATTACH seam. The read port is built over `local_runtime.workspace_filesystem`,
     /// exactly like production's `attachment_read_port` (`runtime.rs` ~line 3328) —
     /// that handle is intentionally read-only (it backs setup-marker reads), which
-    /// is fine for reading. The lander is built over a SEPARATE read-write view
-    /// constructed from `local_runtime.extension_filesystem` + `local_runtime.workspace_mounts`,
-    /// mirroring `RebornRuntimeComposition::webui_workspace_filesystem` (`runtime.rs`
-    /// ~line 1499) exactly — landing through the read-only `workspace_filesystem`
-    /// handle fails closed with `PermissionDenied`. Bundled into one accessor
-    /// (rather than two, mirroring `local_dev_profile_filesystem_for_test` /
-    /// `local_dev_project_service_for_test` above) because the two are always
-    /// populated together. Returns `None` for production-profile compositions
-    /// without a local-dev runtime.
+    /// is fine for reading. The lander is built over the SAME read-write view
+    /// `RebornRuntime::webui_workspace_filesystem` uses in production, via the
+    /// shared [`Self::read_write_workspace_filesystem`] helper — landing through
+    /// the read-only `workspace_filesystem` handle fails closed with
+    /// `PermissionDenied`. Bundled into one accessor (rather than two, mirroring
+    /// `local_dev_profile_filesystem_for_test` / `local_dev_project_service_for_test`
+    /// above) because the two are always populated together. Returns `None` for
+    /// production-profile compositions without a local-dev runtime.
     #[cfg(feature = "test-support")]
     pub fn local_dev_attachment_test_support_for_test(&self) -> Option<AttachmentTestSupport> {
         let local_runtime = self.local_runtime.as_ref()?;
-        let read_write_workspace_filesystem = Arc::new(ScopedFilesystem::with_fixed_view(
-            Arc::clone(&local_runtime.extension_filesystem),
-            local_runtime.workspace_mounts.clone(),
-        ));
+        let read_write_workspace_filesystem = self.read_write_workspace_filesystem()?;
         Some(AttachmentTestSupport {
             read_port: Arc::new(
                 crate::attachment_landing::ProjectScopedAttachmentReader::new(Arc::clone(

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -182,6 +182,8 @@ pub use extension_lifecycle_command::{
     execute_reborn_extension_lifecycle_command, render_reborn_extension_lifecycle_response,
 };
 #[cfg(feature = "test-support")]
+pub use factory::AttachmentTestSupport;
+#[cfg(feature = "test-support")]
 pub use factory::RebornLocalDevApprovalTestParts;
 pub use factory::{RebornServices, build_reborn_services, builtin_first_party_trust_policy};
 pub use failure_summary::reborn_failure_summary_for_category;

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -8592,6 +8592,100 @@ output_schema_ref = "schemas/write.output.json"
         runtime.shutdown().await.expect("runtime shutdown");
     }
 
+    /// Caller-level regression for the production attachment-landing path:
+    /// drives `RebornRuntime::webui_workspace_filesystem()` — the exact method
+    /// `build_webui_services`/`build_openai_compat_route_mount` call — through
+    /// a real `ProjectScopedAttachmentLander`, then reads the landed bytes back
+    /// through the same `ProjectScopedAttachmentReader` production wires
+    /// `attachment_read_port` with. The C-ATTACH integration tests exercise the
+    /// shared `RebornServices::read_write_workspace_filesystem` recipe via the
+    /// `local_dev_attachment_test_support_for_test` seam, but never call through
+    /// this `RebornRuntime` wrapper itself; this closes that gap so a future
+    /// regression in the wrapper (not just the shared recipe) fails a test
+    /// instead of only breaking WebUI/OpenAI-compatible attachment landing in
+    /// production.
+    #[tokio::test]
+    async fn webui_workspace_filesystem_lands_attachment_with_read_write_mount() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let gateway = Arc::new(RecordingGateway {
+            reply: "attachment mount ok".to_string(),
+            requests: Arc::new(StdMutex::new(Vec::new())),
+        });
+        let input = RebornRuntimeInput::from_services(
+            RebornBuildInput::local_dev(
+                "runtime-attachment-mount-owner",
+                root.path().join("local-dev"),
+            )
+            .with_runtime_policy(local_dev_runtime_policy()),
+        )
+        .with_identity(RebornRuntimeIdentity {
+            tenant_id: "runtime-attachment-mount-tenant".to_string(),
+            agent_id: "runtime-attachment-mount-agent".to_string(),
+            source_binding_id: "runtime-attachment-mount-source".to_string(),
+            reply_target_binding_id: "runtime-attachment-mount-reply".to_string(),
+        })
+        .with_poll_settings(PollSettings {
+            interval: Duration::from_millis(10),
+            max_total: Duration::from_secs(3),
+        })
+        .with_model_gateway_override(gateway);
+
+        let runtime = build_reborn_runtime(input).await.expect("runtime builds");
+        let read_write_filesystem = runtime
+            .webui_workspace_filesystem()
+            .expect("local-dev runtime composes a read-write webui workspace filesystem");
+        let local_runtime = runtime
+            .services()
+            .local_runtime
+            .as_ref()
+            .expect("local-dev runtime substrate");
+        // Mirrors production's `attachment_read_port` wiring (read-only
+        // `workspace_filesystem`), so the read side is the same authority a
+        // vision-capable model's multimodal part would resolve through.
+        let read_port = crate::attachment_landing::ProjectScopedAttachmentReader::new(Arc::clone(
+            &local_runtime.workspace_filesystem,
+        ));
+        let lander =
+            crate::attachment_landing::ProjectScopedAttachmentLander::new(read_write_filesystem);
+
+        let thread_scope = ThreadScope {
+            tenant_id: TenantId::new("runtime-attachment-mount-tenant").unwrap(),
+            agent_id: AgentId::new("runtime-attachment-mount-agent").unwrap(),
+            project_id: None,
+            owner_user_id: Some(UserId::new("runtime-attachment-mount-owner").unwrap()),
+            mission_id: None,
+        };
+        let refs = ironclaw_product_workflow::InboundAttachmentLander::land(
+            &lander,
+            &thread_scope,
+            "msg-attachment-mount",
+            vec![ironclaw_attachments::InboundAttachment {
+                id: "att-0".to_string(),
+                mime_type: "image/png".to_string(),
+                filename: Some("mount-check.png".to_string()),
+                bytes: b"attachment-mount-bytes".to_vec(),
+            }],
+        )
+        .await
+        .expect("landing through the production webui workspace filesystem succeeds");
+        let storage_key = refs[0]
+            .storage_key
+            .as_deref()
+            .expect("landed attachment carries a storage_key");
+
+        let read_back = ironclaw_loop_support::LoopAttachmentReadPort::read_attachment_bytes(
+            &read_port,
+            &thread_scope.to_resource_scope(),
+            storage_key,
+        )
+        .await
+        .expect("reading the landed attachment back through the read port succeeds");
+
+        assert_eq!(read_back, b"attachment-mount-bytes".to_vec());
+
+        runtime.shutdown().await.expect("runtime shutdown");
+    }
+
     #[tokio::test]
     async fn local_dev_webui_bundle_uses_local_lifecycle_facade_for_setup_extension() {
         let root = tempfile::tempdir().expect("tempdir");

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -1544,20 +1544,15 @@ impl RebornRuntime {
     /// This deliberately does NOT reuse `rt.workspace_filesystem`: that handle
     /// is intentionally read-only (it backs setup-marker reads — see
     /// `local_dev_setup_marker_workspace_filesystem_is_read_only`), so writing
-    /// an attachment through it fails closed with `PermissionDenied`. Build a
-    /// read-write view over the same root using the read-write `workspace_mounts`
-    /// the agent's `file_write`/`file_read` tools resolve through, so a landed
-    /// attachment is addressable at its recorded `storage_key`.
+    /// an attachment through it fails closed with `PermissionDenied`. Delegates
+    /// to `RebornServices::read_write_workspace_filesystem` — the single owner
+    /// of this recipe, shared with the `local_dev_attachment_test_support_for_test`
+    /// C-ATTACH test seam so the two views can never drift apart.
     pub(crate) fn webui_workspace_filesystem(
         &self,
     ) -> Option<Arc<ironclaw_filesystem::ScopedFilesystem<crate::factory::LocalDevRootFilesystem>>>
     {
-        self.services.local_runtime.as_ref().map(|rt| {
-            Arc::new(ironclaw_filesystem::ScopedFilesystem::with_fixed_view(
-                Arc::clone(&rt.extension_filesystem),
-                rt.workspace_mounts.clone(),
-            ))
-        })
+        self.services.read_write_workspace_filesystem()
     }
 
     /// Read-only scoped filesystem spanning every mount the standalone WebUI

--- a/tests/reborn_integration_attach.rs
+++ b/tests/reborn_integration_attach.rs
@@ -23,6 +23,7 @@ mod reborn_support;
 #[allow(dead_code)]
 mod support;
 
+use reborn_support::builder::RebornIntegrationHarness;
 use reborn_support::group::RebornIntegrationGroup;
 use reborn_support::reply::RebornScriptedReply;
 
@@ -88,11 +89,43 @@ async fn non_vision_model_does_not_receive_a_multimodal_image_part() {
         .await
         .expect("turn completes");
 
+    let err = harness
+        .assert_model_saw_image_attachment(PNG_MIME, PNG_BYTES)
+        .await
+        .unwrap_err();
     assert!(
-        harness
-            .assert_model_saw_image_attachment(PNG_MIME, PNG_BYTES)
-            .await
-            .is_err(),
-        "a non-vision-pattern model id must not receive a multimodal image part"
+        err.to_string()
+            .contains("no captured image data: URL matching"),
+        "expected error about missing image data URL, got: {err}"
+    );
+}
+
+/// Negative control: a plain harness (not built via
+/// `RebornIntegrationGroup::attachment_tools()`) has no `InboundAttachmentLander`
+/// wired, so `submit_turn_with_image_attachment`'s explicit no-lander guard must
+/// fire before any turn is submitted. Proves that fail-fast path stays load-bearing
+/// — without this, a regression that removed or weakened the guard would not be
+/// caught, since every other test in this file only exercises harnesses with a
+/// lander wired.
+#[tokio::test]
+async fn submit_with_image_attachment_fails_fast_without_a_lander() {
+    let harness = RebornIntegrationHarness::test_default()
+        .script([RebornScriptedReply::text("unused")])
+        .build()
+        .await
+        .expect("harness builds");
+
+    let err = harness
+        .submit_turn_with_image_attachment(
+            "what's in this image?",
+            "diagram.png",
+            PNG_MIME,
+            PNG_BYTES.to_vec(),
+        )
+        .await
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("no attachment lander wired"),
+        "expected the no-lander fail-fast error, got: {err}"
     );
 }

--- a/tests/reborn_integration_attach.rs
+++ b/tests/reborn_integration_attach.rs
@@ -1,0 +1,98 @@
+//! C-ATTACH: `attachment_read_port` int-tier coverage (rev-3 Tier-2, A1 audit).
+//!
+//! Production wires `attachment_read_port` from the local-dev workspace
+//! filesystem (`ProjectScopedAttachmentReader` over `local_runtime.workspace_filesystem`,
+//! `crates/ironclaw_reborn_composition/src/runtime.rs:3328-3334`) so the loop
+//! model port can read landed attachment bytes back and the gateway
+//! (`crates/ironclaw_reborn/src/model_gateway.rs::convert_messages`) builds a
+//! `ContentPart::ImageUrl` multimodal part for a vision-capable model. That seam
+//! was never exercised by any Reborn test: `DefaultPlannedRuntimeParts.attachment_read_port`
+//! was `None` everywhere, so every image attachment silently degraded to the
+//! textual `<attachments>` pointer regardless of the model's vision capability.
+//!
+//! This test wires the read port + the real `InboundAttachmentLander` (same
+//! production `ProjectScopedAttachmentLander`) via `RebornIntegrationGroup::attachment_tools()`,
+//! lands an image through the real `submit_inbound_with_attachments` production
+//! entry point, routes the thread through a vision-pattern model id
+//! (`.with_model_override`), and asserts the model-visible request actually
+//! carried the image as a `data:` URL content part.
+
+#[allow(dead_code)]
+#[path = "support/reborn/mod.rs"]
+mod reborn_support;
+#[allow(dead_code)]
+mod support;
+
+use reborn_support::group::RebornIntegrationGroup;
+use reborn_support::reply::RebornScriptedReply;
+
+/// A vision-capable model id per `ironclaw_llm::vision_models::VISION_PATTERNS`.
+const VISION_MODEL: &str = "claude-3-5-sonnet-20241022";
+const PNG_MIME: &str = "image/png";
+const PNG_BYTES: &[u8] = &[0x89, b'P', b'N', b'G', 1, 2, 3, 4];
+
+#[tokio::test]
+async fn landed_image_attachment_reaches_the_model_as_a_multimodal_part() {
+    let group = RebornIntegrationGroup::attachment_tools()
+        .await
+        .expect("attachment-tools group builds");
+    let harness = group
+        .thread("conv-attach")
+        .with_model_override(VISION_MODEL)
+        .script([RebornScriptedReply::text("I see a diagram")])
+        .build()
+        .await
+        .expect("thread builds");
+
+    harness
+        .submit_turn_with_image_attachment(
+            "what's in this image?",
+            "diagram.png",
+            PNG_MIME,
+            PNG_BYTES.to_vec(),
+        )
+        .await
+        .expect("turn completes");
+
+    harness
+        .assert_model_saw_image_attachment(PNG_MIME, PNG_BYTES)
+        .await
+        .expect("landed image bytes reached the model intact as a multimodal content part");
+}
+
+/// Negative control: without `.with_model_override(<vision id>)` the thread
+/// keeps the harness's default scripted model id, which is not a vision-pattern
+/// match. `convert_messages` then drops the image part (text-only fallback), so
+/// no multimodal content part should reach the model even though the
+/// attachment landed and the read port is wired. Proves the model-override knob
+/// (not just the read port) is load-bearing for this assertion.
+#[tokio::test]
+async fn non_vision_model_does_not_receive_a_multimodal_image_part() {
+    let group = RebornIntegrationGroup::attachment_tools()
+        .await
+        .expect("attachment-tools group builds");
+    let harness = group
+        .thread("conv-attach-no-vision")
+        .script([RebornScriptedReply::text("got it")])
+        .build()
+        .await
+        .expect("thread builds");
+
+    harness
+        .submit_turn_with_image_attachment(
+            "what's in this image?",
+            "diagram.png",
+            PNG_MIME,
+            PNG_BYTES.to_vec(),
+        )
+        .await
+        .expect("turn completes");
+
+    assert!(
+        harness
+            .assert_model_saw_image_attachment(PNG_MIME, PNG_BYTES)
+            .await
+            .is_err(),
+        "a non-vision-pattern model id must not receive a multimodal image part"
+    );
+}

--- a/tests/reborn_integration_tracecap.rs
+++ b/tests/reborn_integration_tracecap.rs
@@ -25,6 +25,7 @@ mod support;
 
 use ironclaw_turns::TurnEventKind;
 use reborn_support::builder::RebornIntegrationHarness;
+use reborn_support::group::RebornIntegrationGroup;
 use reborn_support::reply::RebornScriptedReply;
 
 #[tokio::test]
@@ -64,11 +65,62 @@ async fn no_events_recorded_without_opting_in() {
         .await
         .expect("turn completes");
 
+    let err = harness
+        .assert_turn_event_recorded(TurnEventKind::Completed)
+        .await
+        .unwrap_err();
     assert!(
-        harness
-            .assert_turn_event_recorded(TurnEventKind::Completed)
-            .await
-            .is_err(),
-        "no sink was installed, so no turn event should have been recorded"
+        err.to_string().contains("no recorded turn event of kind"),
+        "expected error about missing turn event, got: {err}"
+    );
+}
+
+/// Regression: the sink is shared across every thread in a `.with_turn_event_sink()`
+/// group (it has no per-thread channel), so `assert_turn_event_recorded` must slice
+/// `[baseline_turn_event_count..]` to see only THIS thread's events. Drives a first
+/// thread to Completed, then builds a second thread AFTER that (so its baseline
+/// already includes the first thread's event) and never submits a turn on it. If
+/// the baseline slice were missing, the second thread's assertion would incorrectly
+/// pass on the first thread's Completed event.
+#[tokio::test]
+async fn group_thread_does_not_see_a_sibling_threads_turn_event() {
+    let group = RebornIntegrationGroup::builder()
+        .with_turn_event_sink()
+        .builtin_tools()
+        .await
+        .expect("builtin-tools group builds");
+
+    let first = group
+        .thread("conv-tracecap-first")
+        .script([RebornScriptedReply::text("done")])
+        .build()
+        .await
+        .expect("first thread builds");
+    first
+        .submit_turn("do something")
+        .await
+        .expect("first turn completes");
+    first
+        .assert_turn_event_recorded(TurnEventKind::Completed)
+        .await
+        .expect("first thread recorded its own Completed event");
+
+    // Built after `first` completed, so the shared sink already holds `first`'s
+    // Completed event ahead of this thread's baseline.
+    let second = group
+        .thread("conv-tracecap-second")
+        .script([RebornScriptedReply::text("unused")])
+        .build()
+        .await
+        .expect("second thread builds");
+
+    let err = second
+        .assert_turn_event_recorded(TurnEventKind::Completed)
+        .await
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("no recorded turn event of kind"),
+        "second thread never submitted a turn, so it must not see the first \
+         thread's Completed event; got: {err}"
     );
 }

--- a/tests/reborn_integration_tracecap.rs
+++ b/tests/reborn_integration_tracecap.rs
@@ -1,0 +1,74 @@
+//! C-TRACECAP: `turn_event_sink` int-tier coverage (rev-3 Tier-2, A1 audit).
+//!
+//! Production wires a best-effort turn-lifecycle sink via
+//! `lifecycle_bus.subscribe_best_effort(sink)` in
+//! `build_default_planned_runtime_inner` (`crates/ironclaw_reborn/src/runtime.rs:613-619`),
+//! fed in real deployments by `CompositeTurnEventSink` over
+//! `[TraceCaptureTurnEventSink, ..]` (`crates/ironclaw_reborn_composition/src/runtime.rs:3229-3290`)
+//! — the entry point to the 0%-covered `ironclaw_reborn_traces` crate. That
+//! seam was never exercised by any Reborn test: `DefaultPlannedRuntimeParts.turn_event_sink`
+//! was `None` in every harness/group construction.
+//!
+//! This test wires `ironclaw_turns::InMemoryTurnEventSink` — a real, already-shipped
+//! production `TurnEventSink` impl with zero callers anywhere in the codebase
+//! today — into the harness's planned runtime via `.with_turn_event_sink()`, and
+//! proves `subscribe_best_effort` actually publishes to it for a real completed
+//! turn. Distinct from T0-SYSPROMPT's `TraceLlm` captured model requests (a
+//! different seam: what the model saw, not what the turn coordinator published)
+//! and from `reborn_recorded_trace_parity.rs` (recorded-response replay).
+
+#[allow(dead_code)]
+#[path = "support/reborn/mod.rs"]
+mod reborn_support;
+#[allow(dead_code)]
+mod support;
+
+use ironclaw_turns::TurnEventKind;
+use reborn_support::builder::RebornIntegrationHarness;
+use reborn_support::reply::RebornScriptedReply;
+
+#[tokio::test]
+async fn turn_event_sink_receives_completed_event_for_a_finished_turn() {
+    let harness = RebornIntegrationHarness::test_default()
+        .with_turn_event_sink()
+        .script([RebornScriptedReply::text("done")])
+        .build()
+        .await
+        .expect("harness builds");
+
+    harness
+        .submit_turn("do something")
+        .await
+        .expect("turn completes");
+
+    harness
+        .assert_turn_event_recorded(TurnEventKind::Completed)
+        .await
+        .expect("turn-lifecycle sink recorded the Completed event for the finished turn");
+}
+
+/// Negative control: a harness that never calls `.with_turn_event_sink()` has no
+/// sink installed, so `DefaultPlannedRuntimeParts.turn_event_sink` stays `None`
+/// (matching every pre-existing reborn test) and no events are recorded. Proves
+/// the assertion is discriminating on real wiring, not a tautology.
+#[tokio::test]
+async fn no_events_recorded_without_opting_in() {
+    let harness = RebornIntegrationHarness::test_default()
+        .script([RebornScriptedReply::text("done")])
+        .build()
+        .await
+        .expect("harness builds");
+
+    harness
+        .submit_turn("do something")
+        .await
+        .expect("turn completes");
+
+    assert!(
+        harness
+            .assert_turn_event_recorded(TurnEventKind::Completed)
+            .await
+            .is_err(),
+        "no sink was installed, so no turn event should have been recorded"
+    );
+}

--- a/tests/support/reborn/CLAUDE.md
+++ b/tests/support/reborn/CLAUDE.md
@@ -236,8 +236,11 @@ Commons capture and skill learning hang off in production. Off by default
 (`turn_event_sink: None`, matching every pre-existing test).
 
 - `assert_turn_event_recorded(kind)` — at least one recorded `TurnLifecycleEvent`
-  of that `TurnEventKind` (e.g. `Completed`). The sink is group-shared, not
-  baseline-sliced; match on `run_id` if a group thread needs scoping.
+  of that `TurnEventKind` (e.g. `Completed`). The sink is group-shared, but the
+  harness records `baseline_turn_event_count` at construction and
+  `recorded_turn_events` slices `[baseline..]` (R2), so each thread only sees
+  events its own turns published — a sibling thread's earlier event can't make
+  this assertion pass.
 
 ### Attachments (multimodal)
 

--- a/tests/support/reborn/CLAUDE.md
+++ b/tests/support/reborn/CLAUDE.md
@@ -414,7 +414,7 @@ pub async fn run(g: &RebornIntegrationGroup) -> HarnessResult<()> {
 | `RebornIntegrationGroup::extension_lifecycle()` | extension_search/install/activate/remove | enabled |
 | `RebornIntegrationGroup::triggers()` | trigger_create/list/pause/resume/remove | enabled |
 | `RebornIntegrationGroup::skill_management_tools()` | skill_list/skill_install/skill_remove | enabled |
-| `RebornIntegrationGroup::attachment_tools()` | attachment lander + read port (no tool dispatch) | enabled |
+| `RebornIntegrationGroup::attachment_tools()` | attachment lander + read port (no tool dispatch) | n/a (no capability dispatch) |
 | `RebornIntegrationGroup::builder().storage(LibSql).live_approvals()` | same + LibSql storage | disabled |
 
 ### Distinct actors per thread (E-MULTIUSER)

--- a/tests/support/reborn/CLAUDE.md
+++ b/tests/support/reborn/CLAUDE.md
@@ -227,6 +227,37 @@ followed by a trailing `RebornScriptedReply::text(..)` turn.
 
 - `assert_network_egress_header_contains(url_substr, header_name, value_substr)` — see the "Richer assertions" list below; this is the assertion for this capability.
 
+### Turn lifecycle events
+
+`.with_turn_event_sink()` (harness or group builder) installs an in-memory
+`ironclaw_turns::InMemoryTurnEventSink` into the ONE planned runtime via the
+production `lifecycle_bus.subscribe_best_effort` seam — the entry point Trace
+Commons capture and skill learning hang off in production. Off by default
+(`turn_event_sink: None`, matching every pre-existing test).
+
+- `assert_turn_event_recorded(kind)` — at least one recorded `TurnLifecycleEvent`
+  of that `TurnEventKind` (e.g. `Completed`). The sink is group-shared, not
+  baseline-sliced; match on `run_id` if a group thread needs scoping.
+
+### Attachments (multimodal)
+
+`RebornIntegrationGroup::attachment_tools()` wires the real production
+attachment pair over the local-dev workspace filesystem:
+`ProjectScopedAttachmentLander` (lands inbound bytes) +
+`ProjectScopedAttachmentReader` (the `attachment_read_port` the loop model port
+reads bytes back through). Route the thread at a vision-capable model id with
+`.with_model_override(model_id)` (see `ironclaw_llm::vision_models`) — the
+scripted default id is not a vision pattern, so image parts are dropped for it.
+
+- `submit_turn_with_image_attachment(text, filename, mime, bytes)` — lands the
+  image through the real `submit_inbound_with_attachments` entry point and waits
+  for completion. Errors if the harness has no lander (i.e. not an
+  `attachment_tools()` group).
+- `assert_model_saw_image_attachment(mime, bytes)` — a captured model request
+  carried a `ContentPart::ImageUrl` part whose `data:` URL is exactly
+  `data:<mime>;base64,<encode(bytes)>` — byte-fidelity through lander →
+  filesystem → read port, not just the textual `<attachments>` pointer.
+
 ### OAuth / product-auth
 
 Available from crate `ironclaw_reborn_composition::test_support`, gated on
@@ -383,6 +414,7 @@ pub async fn run(g: &RebornIntegrationGroup) -> HarnessResult<()> {
 | `RebornIntegrationGroup::extension_lifecycle()` | extension_search/install/activate/remove | enabled |
 | `RebornIntegrationGroup::triggers()` | trigger_create/list/pause/resume/remove | enabled |
 | `RebornIntegrationGroup::skill_management_tools()` | skill_list/skill_install/skill_remove | enabled |
+| `RebornIntegrationGroup::attachment_tools()` | attachment lander + read port (no tool dispatch) | enabled |
 | `RebornIntegrationGroup::builder().storage(LibSql).live_approvals()` | same + LibSql storage | disabled |
 
 ### Distinct actors per thread (E-MULTIUSER)

--- a/tests/support/reborn/assertions.rs
+++ b/tests/support/reborn/assertions.rs
@@ -317,9 +317,16 @@ impl RebornIntegrationHarness {
         if urls.iter().any(|url| url == &expected) {
             return Ok(());
         }
+        // Redacted: the full base64-encoded attachment bytes must never land in
+        // CI logs on assertion failure (a future test using a sensitive/screenshot
+        // fixture would otherwise leak its contents). Report mime type, byte
+        // length, and a short digest instead — enough to distinguish "wrong bytes"
+        // from "no image part at all" without reproducing the content.
+        let seen: Vec<String> = urls.iter().map(|url| redact_data_url(url)).collect();
         Err(format!(
-            "no captured image data: URL equal to {expected:?}; saw {} image part(s): {urls:?}",
-            urls.len()
+            "no captured image data: URL matching {}; saw {} image part(s): {seen:?}",
+            redact_data_url(&expected),
+            seen.len()
         )
         .into())
     }
@@ -533,5 +540,38 @@ impl RebornIntegrationHarness {
             "no recorded capability result for {capability_id:?}; saw results for {seen:?}"
         )
         .into())
+    }
+}
+
+/// Redact a `data:<mime>;base64,<bytes>` URL for safe inclusion in an assertion
+/// failure message — never prints the base64 payload itself (which is the raw
+/// attachment content) or even a prefix of it. Reports the mime type, decoded
+/// byte length, and a short SHA-256 prefix, which is enough to tell "wrong
+/// bytes" apart from "no image part at all" without reconstructing the content.
+fn redact_data_url(url: &str) -> String {
+    use base64::Engine;
+    use sha2::{Digest, Sha256};
+    let Some(rest) = url.strip_prefix("data:") else {
+        return "<non-data: URL>".to_string();
+    };
+    let Some((mime, b64)) = rest.split_once(";base64,") else {
+        return format!(
+            "data:{}...<unparseable, redacted>",
+            &rest.chars().take(40).collect::<String>()
+        );
+    };
+    match base64::engine::general_purpose::STANDARD.decode(b64) {
+        Ok(bytes) => {
+            let digest_hex: String = Sha256::digest(&bytes)
+                .iter()
+                .take(4)
+                .map(|byte| format!("{byte:02x}"))
+                .collect();
+            format!(
+                "data:{mime};base64=<redacted, {} byte(s), sha256={digest_hex}>",
+                bytes.len(),
+            )
+        }
+        Err(_) => format!("data:{mime};base64=<redacted, undecodable>"),
     }
 }

--- a/tests/support/reborn/assertions.rs
+++ b/tests/support/reborn/assertions.rs
@@ -557,7 +557,7 @@ fn redact_data_url(url: &str) -> String {
     let Some((mime, b64)) = rest.split_once(";base64,") else {
         return format!(
             "data:{}...<unparseable, redacted>",
-            &rest.chars().take(40).collect::<String>()
+            rest.chars().take(40).collect::<String>()
         );
     };
     match base64::engine::general_purpose::STANDARD.decode(b64) {

--- a/tests/support/reborn/assertions.rs
+++ b/tests/support/reborn/assertions.rs
@@ -282,6 +282,48 @@ impl RebornIntegrationHarness {
             .collect()
     }
 
+    /// Assert the in-memory `TurnEventSink` installed via `.with_turn_event_sink()`
+    /// (C-TRACECAP) recorded at least one event of `kind`. Proves
+    /// `subscribe_best_effort` actually fired the sink for a real turn, not just
+    /// that the harness wired the field.
+    pub async fn assert_turn_event_recorded(
+        &self,
+        kind: ironclaw_turns::TurnEventKind,
+    ) -> HarnessResult<()> {
+        let events = self.recorded_turn_events();
+        if events.iter().any(|event| event.kind == kind) {
+            return Ok(());
+        }
+        let seen: Vec<_> = events.iter().map(|event| &event.kind).collect();
+        Err(format!("no recorded turn event of kind {kind:?}; saw {seen:?}").into())
+    }
+
+    /// Assert a captured model request carried a multimodal `data:` image part
+    /// holding exactly `bytes` under `mime_type` (C-ATTACH) — proves the landed
+    /// attachment round-tripped intact (lander → project filesystem →
+    /// `attachment_read_port` → base64) and reached the model as
+    /// `ContentPart::ImageUrl`, not just the textual `<attachments>` pointer.
+    pub async fn assert_model_saw_image_attachment(
+        &self,
+        mime_type: &str,
+        bytes: &[u8],
+    ) -> HarnessResult<()> {
+        use base64::Engine;
+        let urls = self.captured_image_data_urls();
+        let expected = format!(
+            "data:{mime_type};base64,{}",
+            base64::engine::general_purpose::STANDARD.encode(bytes)
+        );
+        if urls.iter().any(|url| url == &expected) {
+            return Ok(());
+        }
+        Err(format!(
+            "no captured image data: URL equal to {expected:?}; saw {} image part(s): {urls:?}",
+            urls.len()
+        )
+        .into())
+    }
+
     /// Assert a model-visible tool error of `class` carrying `reason` was
     /// persisted for this thread. Unlike [`assert_tool_result_contains`] (which
     /// reads the in-process recorder, populated only on the *Completed* write

--- a/tests/support/reborn/builder.rs
+++ b/tests/support/reborn/builder.rs
@@ -115,6 +115,8 @@ pub struct RebornIntegrationHarnessBuilder {
     /// fixed non-retryable `LlmError`. Threaded into the degenerate one-thread
     /// group. See [`RebornThreadBuilder::fail_model`].
     fail_model: bool,
+    /// C-TRACECAP seam: install an in-memory `TurnEventSink` when `true`.
+    turn_event_sink: bool,
 }
 
 impl RebornIntegrationHarnessBuilder {
@@ -159,6 +161,15 @@ impl RebornIntegrationHarnessBuilder {
         self.fail_model = true;
         self
     }
+
+    /// Install an in-memory `TurnEventSink` into the underlying group's planned
+    /// runtime (C-TRACECAP). Read the recorded events back with
+    /// [`RebornIntegrationHarness::recorded_turn_events`].
+    pub fn with_turn_event_sink(mut self) -> Self {
+        self.turn_event_sink = true;
+        self
+    }
+
 
     /// Use the real first-party tool runtime so scripted tool calls execute through
     /// `RuntimeHttpEgress`, captured at the recording egress (no network). Required
@@ -303,6 +314,9 @@ impl RebornIntegrationHarnessBuilder {
         if let Some(ctx) = self.safety_context {
             group_builder = group_builder.safety_context(ctx);
         }
+        if self.turn_event_sink {
+            group_builder = group_builder.with_turn_event_sink();
+        }
         let group: RebornIntegrationGroup = group_builder
             .build_with_capability(group_capability)
             .await?;
@@ -403,6 +417,7 @@ impl RebornIntegrationHarness {
             shell_mode: ShellMode::default(),
             park_gate: None,
             fail_model: false,
+            turn_event_sink: false,
         }
     }
 
@@ -417,7 +432,68 @@ impl RebornIntegrationHarness {
     /// — the caller drives the wait (`wait_for_status`). Used by approval/auth flows
     /// where the turn blocks on a gate rather than completing.
     pub async fn submit_turn_async(&self, text: &str) -> HarnessResult<TurnRunId> {
-        match self.submit_turn_ack(text).await? {
+        Self::run_id_from_ack(self.submit_turn_ack(text).await?)
+    }
+
+    /// Submit a user turn carrying one inline image attachment, and wait for it
+    /// to complete (C-ATTACH). Lands `bytes` through the harness's real
+    /// `InboundAttachmentLander` (production `ProjectScopedAttachmentLander` over
+    /// the local-dev workspace filesystem — wired only by `.attachment_tools()`
+    /// groups) via `DefaultProductWorkflow::submit_inbound_with_attachments`, the
+    /// same production entry point a synchronous host surface (e.g. the
+    /// OpenAI-compatible API) uses for inline image bytes. Errors clearly if the
+    /// harness has no lander wired.
+    pub async fn submit_turn_with_image_attachment(
+        &self,
+        text: &str,
+        filename: &str,
+        mime_type: &str,
+        bytes: Vec<u8>,
+    ) -> HarnessResult<TurnRunId> {
+        if self.capability_recorder.attachment_test_support().is_none() {
+            return Err(
+                "no attachment lander wired — build the harness via RebornIntegrationGroup::attachment_tools()"
+                    .into(),
+            );
+        }
+        let (event_id, envelope) = self.build_user_envelope(text)?;
+        let attachment = ironclaw_attachments::InboundAttachment {
+            id: format!("{event_id}-att-0"),
+            mime_type: mime_type.to_string(),
+            filename: Some(filename.to_string()),
+            bytes,
+        };
+        let ack = self
+            .workflow
+            .submit_inbound_with_attachments(envelope, vec![attachment])
+            .await?;
+        let run_id = Self::run_id_from_ack(ack)?;
+        self.wait_for_status(run_id, TurnStatus::Completed).await?;
+        Ok(run_id)
+    }
+
+    /// Build the synthetic inbound envelope `submit_turn_ack` and
+    /// `submit_turn_with_image_attachment` both submit, plus the `event_id` it
+    /// was minted from (attachment ids derive from it).
+    fn build_user_envelope(
+        &self,
+        text: &str,
+    ) -> HarnessResult<(String, ironclaw_product_adapters::ProductInboundEnvelope)> {
+        let event_id = format!("evt-{}", self.event_seq.fetch_add(1, Ordering::Relaxed));
+        let envelope = self.ingress.verified_text_envelope_with_trigger(
+            &event_id,
+            &self.actor_id,
+            &self.conversation_id,
+            text,
+            ProductTriggerReason::DirectChat,
+        )?;
+        Ok((event_id, envelope))
+    }
+
+    /// Extract the submitted run id from an `Accepted` ack, or a descriptive
+    /// error for any other outcome. Shared by every `submit_turn*` entry point.
+    fn run_id_from_ack(ack: ProductInboundAck) -> HarnessResult<TurnRunId> {
+        match ack {
             ProductInboundAck::Accepted {
                 submitted_run_id, ..
             } => Ok(submitted_run_id),
@@ -659,6 +735,37 @@ impl RebornIntegrationHarness {
             .flatten()
             .filter(|message| matches!(message.role, Role::System))
             .map(|message| message.content)
+            .collect()
+    }
+
+    /// Turn-lifecycle events recorded by the in-memory `TurnEventSink`
+    /// installed via `.with_turn_event_sink()` (C-TRACECAP). Empty when the
+    /// harness did not opt in — reads the group-shared sink, so a group
+    /// thread sees every thread's events (the sink has no per-thread baseline;
+    /// callers that need thread scoping should match on `TurnLifecycleEvent::run_id`).
+    pub(super) fn recorded_turn_events(&self) -> Vec<ironclaw_turns::TurnLifecycleEvent> {
+        self._shared
+            .turn_event_sink
+            .as_ref()
+            .map(|sink| sink.events())
+            .unwrap_or_default()
+    }
+
+    /// Every `data:` URL from a `ContentPart::ImageUrl` part across all captured
+    /// model requests (C-ATTACH). Empty when no multimodal image part reached
+    /// the model — either no image was attached, the model id wasn't
+    /// vision-capable (see `RebornThreadBuilder::with_model_override`), or the
+    /// attachment read port failed to land/read the bytes.
+    pub(super) fn captured_image_data_urls(&self) -> Vec<String> {
+        self.scripted_llm
+            .captured_requests()
+            .into_iter()
+            .flatten()
+            .flat_map(|message| message.content_parts)
+            .filter_map(|part| match part {
+                ironclaw_llm::ContentPart::ImageUrl { image_url } => Some(image_url.url),
+                ironclaw_llm::ContentPart::Text { .. } => None,
+            })
             .collect()
     }
 

--- a/tests/support/reborn/builder.rs
+++ b/tests/support/reborn/builder.rs
@@ -396,6 +396,16 @@ pub struct RebornIntegrationHarness {
     pub(crate) baseline_process_count: usize,
     /// Network-egress-request count at harness construction. See `baseline_invocation_count`.
     pub(crate) baseline_network_count: usize,
+    /// Turn-lifecycle-event count on the group-shared `InMemoryTurnEventSink` at
+    /// harness construction, if `.with_turn_event_sink()` opted in. The sink has
+    /// no per-thread channel — every thread in a group publishes to the same
+    /// `Arc<InMemoryTurnEventSink>` — so without this baseline a group thread's
+    /// `assert_turn_event_recorded` could pass on an EARLIER thread's event
+    /// (e.g. a prior thread's `Completed`) even if this thread's own turn never
+    /// published anything, silently defeating the assertion. `recorded_turn_events`
+    /// slices `[baseline_turn_event_count..]` the same way the other
+    /// `baseline_*_count` fields scope their recorders to this thread only (R2).
+    pub(crate) baseline_turn_event_count: usize,
 }
 
 impl RebornIntegrationHarness {
@@ -739,15 +749,18 @@ impl RebornIntegrationHarness {
     }
 
     /// Turn-lifecycle events recorded by the in-memory `TurnEventSink`
-    /// installed via `.with_turn_event_sink()` (C-TRACECAP). Empty when the
-    /// harness did not opt in — reads the group-shared sink, so a group
-    /// thread sees every thread's events (the sink has no per-thread baseline;
-    /// callers that need thread scoping should match on `TurnLifecycleEvent::run_id`).
+    /// installed via `.with_turn_event_sink()` (C-TRACECAP), for this thread
+    /// only. Empty when the harness did not opt in. Reads the group-shared
+    /// sink but slices `[baseline_turn_event_count..]` (R2) so a group thread
+    /// never sees an earlier sibling thread's events.
     pub(super) fn recorded_turn_events(&self) -> Vec<ironclaw_turns::TurnLifecycleEvent> {
         self._shared
             .turn_event_sink
             .as_ref()
-            .map(|sink| sink.events())
+            .map(|sink| {
+                let all = sink.events();
+                all[self.baseline_turn_event_count.min(all.len())..].to_vec()
+            })
             .unwrap_or_default()
     }
 

--- a/tests/support/reborn/builder.rs
+++ b/tests/support/reborn/builder.rs
@@ -170,7 +170,6 @@ impl RebornIntegrationHarnessBuilder {
         self
     }
 
-
     /// Use the real first-party tool runtime so scripted tool calls execute through
     /// `RuntimeHttpEgress`, captured at the recording egress (no network). Required
     /// for tool-calling tests; a text-only turn needs only the default echo backend.

--- a/tests/support/reborn/group.rs
+++ b/tests/support/reborn/group.rs
@@ -357,13 +357,6 @@ impl RebornIntegrationGroup {
     pub(crate) fn user_profile_source_for_test(&self) -> &Arc<dyn HostUserProfileSource> {
         &self.shared.user_profile_source
     }
-
-    /// The in-memory turn-lifecycle sink installed via
-    /// `.with_turn_event_sink()` (C-TRACECAP seam), if this group opted in.
-    /// `None` when the group did not call `.with_turn_event_sink()`.
-    pub(crate) fn turn_event_sink_for_test(&self) -> Option<&Arc<InMemoryTurnEventSink>> {
-        self.shared.turn_event_sink.as_ref()
-    }
 }
 
 // ---------------------------------------------------------------------------
@@ -455,8 +448,10 @@ impl RebornIntegrationGroupBuilder {
     /// seam production wires via `subscribe_best_effort` in `build_default_planned_runtime_inner`,
     /// `crates/ironclaw_reborn/src/runtime.rs:613-619`) into the group's ONE planned
     /// runtime (C-TRACECAP). Read the recorded events back with
-    /// [`RebornIntegrationGroup::turn_event_sink_for_test`] or, for a single-shot
-    /// harness, [`RebornIntegrationHarness::recorded_turn_events`].
+    /// [`RebornIntegrationHarness::recorded_turn_events`] — the ONLY read path;
+    /// it slices `[baseline_turn_event_count..]` so a group thread never sees a
+    /// sibling thread's events. Deliberately no raw group-level sink accessor:
+    /// one would bypass that slicing and reintroduce cross-thread bleed.
     pub fn with_turn_event_sink(mut self) -> Self {
         self.turn_event_sink = Some(Arc::new(InMemoryTurnEventSink::default()));
         self

--- a/tests/support/reborn/group.rs
+++ b/tests/support/reborn/group.rs
@@ -908,6 +908,11 @@ impl<'g> RebornThreadBuilder<'g> {
         let baseline_result_count = capability_recorder.capability_results().len();
         let baseline_process_count = capability_recorder.recorded_process_commands().len();
         let baseline_network_count = capability_recorder.network_http_requests().len();
+        let baseline_turn_event_count = shared
+            .turn_event_sink
+            .as_ref()
+            .map(|sink| sink.events().len())
+            .unwrap_or(0);
 
         // --- per-thread workflow over the SHARED coordinator --------------------
         let binding_service: Arc<dyn ConversationBindingService> =
@@ -962,6 +967,7 @@ impl<'g> RebornThreadBuilder<'g> {
             baseline_result_count,
             baseline_process_count,
             baseline_network_count,
+            baseline_turn_event_count,
         })
     }
 }

--- a/tests/support/reborn/group.rs
+++ b/tests/support/reborn/group.rs
@@ -108,8 +108,8 @@ use ironclaw_turns::run_profile::{
     InMemoryLoopHostMilestoneSink, InstructionSafetyContext, ModelProfileId,
 };
 use ironclaw_turns::{
-    FilesystemTurnStateStore, InMemoryCheckpointStateStore, LoopCheckpointStore, TurnCoordinator,
-    TurnScope, TurnStateStore,
+    FilesystemTurnStateStore, InMemoryCheckpointStateStore, InMemoryTurnEventSink,
+    LoopCheckpointStore, TurnCoordinator, TurnEventSink, TurnScope, TurnStateStore,
 };
 
 use super::builder::{
@@ -203,6 +203,13 @@ pub(crate) struct GroupSharedStorage {
     /// that breaks the `into_group` wiring (not just `build_user_profile_source_for_test`
     /// itself) is caught.
     pub(crate) user_profile_source: Arc<dyn HostUserProfileSource>,
+    /// In-memory turn-lifecycle event sink wired into the group's ONE planned
+    /// runtime when `.with_turn_event_sink()` opted in (C-TRACECAP seam).
+    /// `None` for every group that did not opt in (`turn_event_sink` stays
+    /// `None` in `DefaultPlannedRuntimeParts`, matching prior behavior).
+    /// Kept as the concrete `InMemoryTurnEventSink` (not `Arc<dyn TurnEventSink>`)
+    /// so a test can read `.events()` back directly.
+    pub(crate) turn_event_sink: Option<Arc<InMemoryTurnEventSink>>,
 }
 
 impl GroupSharedStorage {
@@ -279,7 +286,7 @@ impl GroupCapability {
 /// The per-capability preset constructors themselves (`live_approvals`,
 /// `builtin_tools`, `extension_lifecycle`, `live_auth_gate`,
 /// `project_lifecycle`, `profile_tools`, `triggers`, `skill_activation_tools`,
-/// `skill_management_tools`, and their `RebornIntegrationGroupBuilder`
+/// `skill_management_tools`, `attachment_tools`, and their `RebornIntegrationGroupBuilder`
 /// counterparts) live in the child `group_constructors` module (file:
 /// `group_constructors.rs`, kept private to `group` — see the `mod
 /// group_constructors` declaration below) — a thin catalog of "which
@@ -297,6 +304,7 @@ impl RebornIntegrationGroup {
         RebornIntegrationGroupBuilder {
             storage: StorageMode::InMemory,
             safety_context: None,
+            turn_event_sink: None,
         }
     }
 
@@ -314,6 +322,7 @@ impl RebornIntegrationGroup {
             replies: Vec::new(),
             actor_id: None,
             model_mode: ThreadModelMode::Normal,
+            model_override: None,
         }
     }
 
@@ -347,6 +356,13 @@ impl RebornIntegrationGroup {
     /// field docs on `GroupSharedStorage::user_profile_source`.
     pub(crate) fn user_profile_source_for_test(&self) -> &Arc<dyn HostUserProfileSource> {
         &self.shared.user_profile_source
+    }
+
+    /// The in-memory turn-lifecycle sink installed via
+    /// `.with_turn_event_sink()` (C-TRACECAP seam), if this group opted in.
+    /// `None` when the group did not call `.with_turn_event_sink()`.
+    pub(crate) fn turn_event_sink_for_test(&self) -> Option<&Arc<InMemoryTurnEventSink>> {
+        self.shared.turn_event_sink.as_ref()
     }
 }
 
@@ -410,6 +426,8 @@ impl GroupBaseData {
 pub struct RebornIntegrationGroupBuilder {
     storage: StorageMode,
     safety_context: Option<InstructionSafetyContext>,
+    /// C-TRACECAP seam: `Some` once `.with_turn_event_sink()` has been called.
+    turn_event_sink: Option<Arc<InMemoryTurnEventSink>>,
 }
 
 impl RebornIntegrationGroupBuilder {
@@ -429,6 +447,18 @@ impl RebornIntegrationGroupBuilder {
     /// C-SAFETY). Defaults to `None` (no banner, matching today's behavior).
     pub fn safety_context(mut self, ctx: InstructionSafetyContext) -> Self {
         self.safety_context = Some(ctx);
+        self
+    }
+
+    /// Install an in-memory `TurnEventSink` (`ironclaw_turns::InMemoryTurnEventSink`,
+    /// a real, already-shipped production type with zero callers today — this is the
+    /// seam production wires via `subscribe_best_effort` in `build_default_planned_runtime_inner`,
+    /// `crates/ironclaw_reborn/src/runtime.rs:613-619`) into the group's ONE planned
+    /// runtime (C-TRACECAP). Read the recorded events back with
+    /// [`RebornIntegrationGroup::turn_event_sink_for_test`] or, for a single-shot
+    /// harness, [`RebornIntegrationHarness::recorded_turn_events`].
+    pub fn with_turn_event_sink(mut self) -> Self {
+        self.turn_event_sink = Some(Arc::new(InMemoryTurnEventSink::default()));
         self
     }
 
@@ -622,8 +652,13 @@ impl RebornIntegrationGroupBuilder {
             hook_dispatcher_builder_factory: None,
             communication_context_provider: None,
             hook_security_audit_sink: None,
-            turn_event_sink: None,
-            attachment_read_port: None,
+            turn_event_sink: self
+                .turn_event_sink
+                .clone()
+                .map(|sink| sink as Arc<dyn TurnEventSink>),
+            attachment_read_port: capability_recorder
+                .attachment_test_support()
+                .map(|support| support.read_port),
             scheduler_wake_wiring: None,
         })?;
 
@@ -640,6 +675,7 @@ impl RebornIntegrationGroupBuilder {
                 turn_store,
                 capability_recorder,
                 user_profile_source,
+                turn_event_sink: self.turn_event_sink,
             }),
         })
     }
@@ -666,6 +702,12 @@ pub struct RebornThreadBuilder<'g> {
     replies: Vec<RebornScriptedReply>,
     actor_id: Option<String>,
     model_mode: ThreadModelMode,
+    /// C-ATTACH seam: overrides `LlmModelProfileRoute.model_override` (the same
+    /// production model-pin field, `model_gateway.rs:160-162`). `None` keeps the
+    /// prior behavior (scripted model id, not a vision pattern, so image parts
+    /// are dropped); `Some` routes through a vision-capable id so `convert_messages`
+    /// builds `ContentPart::ImageUrl` parts.
+    model_override: Option<String>,
 }
 
 /// A thread's model-call behavior: exactly one of normal scripted playback,
@@ -747,6 +789,14 @@ impl<'g> RebornThreadBuilder<'g> {
         if fail && !matches!(self.model_mode, ThreadModelMode::Parked(_)) {
             self.model_mode = ThreadModelMode::Failing;
         }
+        self
+    }
+
+    /// Route this thread at a specific provider model id (see
+    /// `ironclaw_llm::vision_models::VISION_PATTERNS` for vision-capable ids) —
+    /// C-ATTACH seam.
+    pub fn with_model_override(mut self, model: impl Into<String>) -> Self {
+        self.model_override = Some(model.into());
         self
     }
 
@@ -836,7 +886,8 @@ impl<'g> RebornThreadBuilder<'g> {
         let provider = provider_chain_over(raw, &llm_config, session).await?;
         let model_profile_id = ModelProfileId::new(INTERACTIVE_MODEL_PROFILE)
             .map_err(|reason| format!("invalid model profile id: {reason}"))?;
-        let policy = LlmModelProfilePolicy::new().allow_model_profile(model_profile_id, None);
+        let policy = LlmModelProfilePolicy::new()
+            .allow_model_profile(model_profile_id, self.model_override.clone());
         let thread_gateway: Arc<dyn HostManagedModelGateway> =
             Arc::new(LlmProviderModelGateway::new(provider, policy));
 
@@ -861,11 +912,18 @@ impl<'g> RebornThreadBuilder<'g> {
         // --- per-thread workflow over the SHARED coordinator --------------------
         let binding_service: Arc<dyn ConversationBindingService> =
             Arc::new(shared.product_harness.binding_service()?);
-        let inbound: Arc<dyn InboundTurnService> = Arc::new(DefaultInboundTurnService::new(
+        let mut inbound_service = DefaultInboundTurnService::new(
             Arc::clone(&binding_service),
             thread_harness.service_instance()?,
             Arc::clone(&shared.coordinator),
-        ));
+        );
+        // C-ATTACH: wire the real lander when the backend has one (`attachment_tools()`)
+        // so `submit_inbound_with_attachments` lands through it instead of
+        // failing closed. `None` for every other group (unchanged behavior).
+        if let Some(support) = capability_recorder.attachment_test_support() {
+            inbound_service = inbound_service.with_inbound_attachments(support.lander);
+        }
+        let inbound: Arc<dyn InboundTurnService> = Arc::new(inbound_service);
         let ledger: Arc<dyn IdempotencyLedger> =
             Arc::new(shared.product_harness.idempotency_ledger());
         let workflow = DefaultProductWorkflow::new(inbound, ledger, binding_service);

--- a/tests/support/reborn/group_constructors.rs
+++ b/tests/support/reborn/group_constructors.rs
@@ -97,6 +97,16 @@ impl RebornIntegrationGroup {
     pub async fn skill_management_tools() -> HarnessResult<Self> {
         Self::builder().skill_management_tools().await
     }
+
+    /// Group with the attachment read port + inbound lander wired (C-ATTACH
+    /// seam), no first-party capability dispatch. Use
+    /// [`RebornThreadBuilder::with_model_override`] to route a thread through a
+    /// vision-capable model id and
+    /// [`RebornIntegrationHarness::submit_turn_with_image_attachment`] to land
+    /// an image and submit it in one turn.
+    pub async fn attachment_tools() -> HarnessResult<Self> {
+        Self::builder().attachment_tools().await
+    }
 }
 
 impl RebornIntegrationGroupBuilder {
@@ -246,6 +256,13 @@ impl RebornIntegrationGroupBuilder {
     /// mounts / policy.
     pub async fn skill_management_tools(self) -> HarnessResult<RebornIntegrationGroup> {
         let host_runtime = HostRuntimeCapabilityHarness::skill_management_tools().await?;
+        let capability = GroupCapability::HostRuntime(Arc::new(host_runtime));
+        self.build_with_capability(capability).await
+    }
+
+    /// Build an attachment-tools group. See [`RebornIntegrationGroup::attachment_tools`].
+    pub async fn attachment_tools(self) -> HarnessResult<RebornIntegrationGroup> {
+        let host_runtime = HostRuntimeCapabilityHarness::attachment_tools().await?;
         let capability = GroupCapability::HostRuntime(Arc::new(host_runtime));
         self.build_with_capability(capability).await
     }

--- a/tests/support/reborn/harness.rs
+++ b/tests/support/reborn/harness.rs
@@ -304,6 +304,18 @@ impl HarnessCapabilityRecorder {
         }
     }
 
+    /// C-ATTACH: the attachment read port + inbound lander for this backend, if
+    /// any. `None` for the Echo backend and for HostRuntime harnesses without a
+    /// local-dev workspace filesystem.
+    pub(crate) fn attachment_test_support(
+        &self,
+    ) -> Option<ironclaw_reborn_composition::AttachmentTestSupport> {
+        match self {
+            Self::Recording(_) => None,
+            Self::HostRuntime(harness) => harness.attachment_test_support_for_test(),
+        }
+    }
+
     pub(crate) fn runtime_http_requests(&self) -> Vec<RuntimeHttpEgressRequest> {
         match self {
             Self::Recording(_) => Vec::new(),
@@ -1615,6 +1627,12 @@ pub(crate) struct HostRuntimeCapabilityHarness {
     /// `into_group`. Held as the opaque test-support handle so this crate never
     /// names the crate-private source type.
     skill_activation_source: Option<SkillActivationTestSource>,
+    /// Attachment read port + inbound lander backing the C-ATTACH seam. `Some`
+    /// only for `new_with_options`-built harnesses (which flow through
+    /// `RebornServices`, and thus have a local-dev workspace filesystem to build
+    /// both over); `None` for the lower-level constructors and the Echo backend.
+    /// Read back via `attachment_test_support_for_test`.
+    attachment_test_support: Option<ironclaw_reborn_composition::AttachmentTestSupport>,
 }
 
 struct HostRuntimeHarnessOptions {
@@ -1844,6 +1862,7 @@ impl HostRuntimeCapabilityHarness {
             profile_filesystem: None,
             project_service: None,
             skill_activation_source: None,
+            attachment_test_support: None,
         })
     }
 
@@ -1938,6 +1957,33 @@ impl HostRuntimeCapabilityHarness {
             .enable_global_auto_approve_for_product_and_harness_users()
             .await?;
         Ok(harness)
+    }
+
+    /// Group with NO first-party capability dispatch — the test drives the
+    /// C-ATTACH seam purely through the attachment read port + inbound lander,
+    /// never a tool call. Uses `new_with_options` (mirrors `profile_tools()`),
+    /// so `attachment_test_support` is populated from
+    /// `services.local_dev_attachment_test_support_for_test()`. No mounts needed:
+    /// attachment landing/reading goes through `local_runtime.workspace_filesystem`
+    /// directly, not the capability-dispatch `MountView` (mirrors
+    /// `trigger_management_tools()`'s `MountView::default()`, which also has no
+    /// filesystem capability to gate).
+    pub(crate) async fn attachment_tools() -> HarnessResult<Self> {
+        Self::new_with_options(
+            "reborn-e2e-attachment-tools",
+            Vec::new(),
+            vec![EffectKind::ReadFilesystem, EffectKind::WriteFilesystem],
+            Vec::new(),
+            ExtensionId::new(BUILTIN_FIRST_PARTY_PROVIDER)?,
+            UserId::new("reborn-e2e-attachment-tools-user")?,
+            HostRuntimeHarnessOptions::new(
+                MountView::default(),
+                Some(ironclaw_reborn_composition::local_dev_yolo_runtime_policy(
+                    true,
+                )?),
+            ),
+        )
+        .await
     }
 
     /// `pub(crate)`: also used by `RebornIntegrationGroupBuilder::skill_management_tools`
@@ -2221,8 +2267,9 @@ impl HostRuntimeCapabilityHarness {
         }
         let approval_parts = services.local_dev_approval_test_parts();
         let auto_approve_settings = services.local_dev_auto_approve_settings_for_test();
-        // Capture the profile filesystem + project service before
-        // `services.host_runtime` is moved out below (E-PROFILE / E-PROJ seams).
+        // Capture the profile filesystem + project service + attachment support
+        // before `services.host_runtime` is moved out below (E-PROFILE / E-PROJ /
+        // C-ATTACH seams).
         let profile_filesystem = services.local_dev_profile_filesystem_for_test();
         let project_service = services.local_dev_project_service_for_test();
         // E-SKILL: build the local-dev skill context source only when this
@@ -2243,6 +2290,7 @@ impl HostRuntimeCapabilityHarness {
         } else {
             None
         };
+        let attachment_test_support = services.local_dev_attachment_test_support_for_test();
         let pending_approval_scopes = Arc::new(Mutex::new(HashMap::new()));
         let runtime = services
             .host_runtime
@@ -2277,6 +2325,7 @@ impl HostRuntimeCapabilityHarness {
             profile_filesystem,
             project_service,
             skill_activation_source,
+            attachment_test_support,
         })
     }
 
@@ -2424,6 +2473,7 @@ impl HostRuntimeCapabilityHarness {
             profile_filesystem: None,
             project_service: None,
             skill_activation_source: None,
+            attachment_test_support: None,
         })
     }
 
@@ -2519,6 +2569,7 @@ impl HostRuntimeCapabilityHarness {
             profile_filesystem: None,
             project_service: None,
             skill_activation_source: None,
+            attachment_test_support: None,
         })
     }
 
@@ -2593,6 +2644,7 @@ impl HostRuntimeCapabilityHarness {
             profile_filesystem: None,
             project_service: None,
             skill_activation_source: None,
+            attachment_test_support: None,
         })
     }
 
@@ -2653,6 +2705,7 @@ impl HostRuntimeCapabilityHarness {
             profile_filesystem: None,
             project_service: None,
             skill_activation_source: None,
+            attachment_test_support: None,
         })
     }
 
@@ -2951,6 +3004,16 @@ impl HostRuntimeCapabilityHarness {
         );
         std::fs::write(dir.join("SKILL.md"), body)?;
         Ok(())
+    }
+
+    /// C-ATTACH: the attachment read port + inbound lander over this harness's
+    /// local-dev workspace filesystem, for wiring `DefaultPlannedRuntimeParts.attachment_read_port`
+    /// and `DefaultInboundTurnService::with_inbound_attachments` — mirrors
+    /// `profile_filesystem_for_test`'s role for E-PROFILE.
+    pub(crate) fn attachment_test_support_for_test(
+        &self,
+    ) -> Option<ironclaw_reborn_composition::AttachmentTestSupport> {
+        self.attachment_test_support.clone()
     }
 
     /// E-PROJ: wrap `port` with the local-dev synthetic capabilities this harness


### PR DESCRIPTION
Rev-3 Tier-2 rows from the A1 wiring-drift audit (`docs/reborn/reborn-backend-coverage-roadmap.md`): wire two `DefaultPlannedRuntimeParts` fields the harness left `None` while production populates them, each with driving coverage.

## C-TRACECAP — `turn_event_sink`
- `.with_turn_event_sink()` on the harness/group builders installs the production `ironclaw_turns::InMemoryTurnEventSink`, exercising `lifecycle_bus.subscribe_best_effort` (`ironclaw_reborn/src/runtime.rs:555-561`) for the first time in ANY test — the entry point to the previously 0%-covered `ironclaw_reborn_traces` crate. (Distinct from `TraceLlm` captured model requests and from recorded-trace replay parity.)
- Cases: completed turn → `assert_turn_event_recorded(TurnEventKind::Completed)`; negative control — no opt-in → no events (pins the default and proves non-tautology).
- Mutation: severed the wire (`turn_event_sink: None`) → RED: `no recorded turn event of kind Completed; saw []`. Reverted.

## C-ATTACH — `attachment_read_port`
- Wires the real production pair: `ProjectScopedAttachmentReader` over the read-only workspace filesystem (mirror of serve wiring, composition `runtime.rs:3328`) + `ProjectScopedAttachmentLander` (mirror of the webui workspace wiring). `submit_turn_with_image_attachment` drives the production `DefaultProductWorkflow::submit_inbound_with_attachments` entry point; model routing reuses the production `LlmModelProfileRoute.model_override` field.
- Cases: landed PNG reaches the model as a `ContentPart::ImageUrl` with **byte-exact** `data:image/png;base64,<...>` payload (fidelity through lander → filesystem → read port → gateway); negative control — non-vision model id drops the image part (proves the vision gate is load-bearing).
- Mutations: severed the read port → RED (`saw 0 image part(s)`); severed the lander → submit fails closed. Both reverted.

## Notes
- Composition-crate edits are test-support-gated accessors mirroring the existing `local_dev_profile_filesystem_for_test` precedent — no production behavior change.
- No product bugs found.
- `builder.rs` crossed the 1000-line guardrail (963→1062): waived in-lane — a mid-flight reorg would conflict with the parallel coverage lanes; the harness-support split is tracked roadmap debt (PR-C2 already did the `group.rs` half).

## Verification
- clippy `--all --benches --tests --examples --all-features`: zero warnings from this change; fmt clean.
- Green under `--features libsql`: both new bins (`reborn_integration_tracecap`, `reborn_integration_attach`) + `reborn_group_{approvals,memory,extensions,triggers}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)