### PR TITLE
[codex] Dedup WASM resource limiter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5748,6 +5748,7 @@ dependencies = [
 name = "ironclaw_wasm_sandbox_core"
 version = "0.1.0"
 dependencies = [
+ "ironclaw_wasm_limiter",
  "thiserror 2.0.18",
  "tracing",
  "wasmtime",

--- a/crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs
+++ b/crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs
@@ -987,9 +987,30 @@ fn wasm_sandbox_core_is_standalone_v1_parity_kernel() {
     let workspace_deps = workspace_dependency_names(package)
         .filter_map(|dependency| dependency["name"].as_str())
         .collect::<Vec<_>>();
+    let allowed_workspace_deps = ["ironclaw_wasm_limiter"];
+    let forbidden_workspace_deps = workspace_deps
+        .iter()
+        .copied()
+        .filter(|dependency| !allowed_workspace_deps.contains(dependency))
+        .collect::<Vec<_>>();
     assert!(
-        workspace_deps.is_empty(),
-        "WASM sandbox core should stay independent of IronClaw domain crates; got {workspace_deps:?}"
+        forbidden_workspace_deps.is_empty(),
+        "WASM sandbox core should stay independent of IronClaw product/runtime crates; \
+         only the low-level shared limiter workspace crate is allowed. Got forbidden deps: \
+         {forbidden_workspace_deps:?}; all workspace deps: {workspace_deps:?}"
+    );
+
+    let limiter_package = packages
+        .iter()
+        .find(|package| package["name"] == "ironclaw_wasm_limiter")
+        .expect("ironclaw_wasm_limiter must be a workspace package");
+    let limiter_workspace_deps = workspace_dependency_names(limiter_package)
+        .filter_map(|dependency| dependency["name"].as_str())
+        .collect::<Vec<_>>();
+    assert!(
+        limiter_workspace_deps.is_empty(),
+        "ironclaw_wasm_limiter is allowed only as low-level WASM accounting; \
+         got workspace deps: {limiter_workspace_deps:?}"
     );
 }
 

--- a/crates/ironclaw_wasm_limiter/src/lib.rs
+++ b/crates/ironclaw_wasm_limiter/src/lib.rs
@@ -31,6 +31,14 @@ impl WasmResourceLimiter {
             max_memories: 10,
         }
     }
+
+    pub fn memory_used(&self) -> u64 {
+        self.memory_used
+    }
+
+    pub fn memory_limit(&self) -> u64 {
+        self.memory_limit
+    }
 }
 
 impl ResourceLimiter for WasmResourceLimiter {

--- a/crates/ironclaw_wasm_sandbox_core/Cargo.toml
+++ b/crates/ironclaw_wasm_sandbox_core/Cargo.toml
@@ -6,6 +6,7 @@ rust-version.workspace = true
 publish = false
 
 [dependencies]
+ironclaw_wasm_limiter = { path = "../ironclaw_wasm_limiter" }
 thiserror = "2"
 tracing = "0.1"
 wasmtime = { version = "46.0.1", features = ["component-model"] }

--- a/crates/ironclaw_wasm_sandbox_core/src/lib.rs
+++ b/crates/ironclaw_wasm_sandbox_core/src/lib.rs
@@ -1,9 +1,10 @@
 use std::time::{Duration, Instant};
 
 use wasmtime::component::Linker;
-use wasmtime::{Config, Engine, ResourceLimiter, Store};
+use wasmtime::{Config, Engine, Store};
 use wasmtime_wasi::{ResourceTable, WasiCtx, WasiCtxBuilder, WasiCtxView, WasiView};
 
+pub use ironclaw_wasm_limiter::WasmResourceLimiter;
 pub use wasmtime_wasi::{WasiCtxView as MinimalWasiCtxView, WasiView as MinimalWasiView};
 
 /// Runtime-specific store data exposes the shared v1-style limiter to Wasmtime.
@@ -100,118 +101,6 @@ impl SandboxStoreCore {
 impl WasiView for SandboxStoreCore {
     fn ctx(&mut self) -> WasiCtxView<'_> {
         self.ctx()
-    }
-}
-
-/// Wasmtime ResourceLimiter implementation from the v1 WASM sandbox.
-///
-/// This intentionally mirrors the Reborn v1 behavior: memory checks track
-/// aggregate growth across component-model memories while still permitting
-/// multiple internal instances/memories.
-#[derive(Debug)]
-pub struct WasmResourceLimiter {
-    memory_limit: u64,
-    memory_used: u64,
-    pending_memory_growth: u64,
-    max_tables: u32,
-    max_instances: u32,
-    max_memories: u32,
-}
-
-impl WasmResourceLimiter {
-    pub fn new(memory_limit: u64) -> Self {
-        Self {
-            memory_limit,
-            memory_used: 0,
-            pending_memory_growth: 0,
-            max_tables: 10,
-            max_instances: 10,
-            max_memories: 10,
-        }
-    }
-
-    pub fn memory_used(&self) -> u64 {
-        self.memory_used
-    }
-
-    pub fn memory_limit(&self) -> u64 {
-        self.memory_limit
-    }
-}
-
-impl ResourceLimiter for WasmResourceLimiter {
-    fn memory_growing(
-        &mut self,
-        current: usize,
-        desired: usize,
-        _maximum: Option<usize>,
-    ) -> Result<bool, wasmtime::Error> {
-        self.pending_memory_growth = 0;
-
-        let current = current as u64;
-        let desired = desired as u64;
-        let growth = desired.saturating_sub(current);
-        let total_memory = self.memory_used.saturating_add(growth);
-        if total_memory > self.memory_limit {
-            tracing::warn!(
-                current,
-                desired,
-                growth,
-                used = self.memory_used,
-                total = total_memory,
-                limit = self.memory_limit,
-                "WASM memory growth denied"
-            );
-            return Ok(false);
-        }
-
-        self.memory_used = total_memory;
-        self.pending_memory_growth = growth;
-        tracing::trace!(
-            current,
-            desired,
-            growth,
-            used = self.memory_used,
-            limit = self.memory_limit,
-            "WASM memory growth allowed"
-        );
-        Ok(true)
-    }
-
-    fn memory_grow_failed(&mut self, error: wasmtime::Error) -> Result<(), wasmtime::Error> {
-        self.memory_used = self.memory_used.saturating_sub(self.pending_memory_growth);
-        self.pending_memory_growth = 0;
-        tracing::debug!(error = ?error, "WASM memory growth failed after approval");
-        Ok(())
-    }
-
-    fn table_growing(
-        &mut self,
-        current: usize,
-        desired: usize,
-        _maximum: Option<usize>,
-    ) -> Result<bool, wasmtime::Error> {
-        if desired > 10_000 {
-            tracing::warn!(
-                current = current,
-                desired = desired,
-                "WASM table growth denied: too large"
-            );
-            return Ok(false);
-        }
-        Ok(true)
-    }
-
-    fn instances(&self) -> usize {
-        self.max_instances as usize
-    }
-
-    fn tables(&self) -> usize {
-        self.max_tables as usize
-    }
-
-    fn memories(&self) -> usize {
-        self.max_memories as usize
     }
 }
 
@@ -313,6 +202,16 @@ mod tests {
         assert_eq!(limiter.instances(), 10);
         assert_eq!(limiter.tables(), 10);
         assert_eq!(limiter.memories(), 10);
+    }
+
+    #[test]
+    fn limiter_reexport_preserves_bookkeeping_accessors() {
+        let mut limiter = WasmResourceLimiter::new(128 * 1024);
+        assert_eq!(limiter.memory_limit(), 128 * 1024);
+        assert_eq!(limiter.memory_used(), 0);
+
+        assert!(limiter.memory_growing(0, 32 * 1024, None).unwrap());
+        assert_eq!(limiter.memory_used(), 32 * 1024);
     }
 
     /// Regression: the epoch ticker thread must observe `Weak::upgrade() ==


### PR DESCRIPTION
## Summary

- Reuse `ironclaw_wasm_limiter::WasmResourceLimiter` from `ironclaw_wasm_sandbox_core` instead of carrying a private duplicate implementation.
- Preserve the sandbox-core public limiter name via re-export, and preserve the previous bookkeeping accessors on the shared limiter.
- Keep the existing sandbox-core architecture guard conservative by allowing only this domain-free shared limiter crate as a workspace dependency.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p ironclaw_architecture`
- `cargo test -p ironclaw_wasm_limiter`
- `cargo test -p ironclaw_wasm_sandbox_core`
- `cargo test -p ironclaw_wasm`
- `cargo test -p ironclaw_wasm_product_adapters`

## Notes

TDD red check observed:

- `cargo test -p ironclaw_wasm_sandbox_core limiter_reexport_preserves_bookkeeping_accessors` failed before adding the accessors to the shared limiter.