### PR TITLE
test(reborn): explain green WebUI v2 live QA runs

### DIFF
--- a/scripts/reborn_webui_v2_live_qa/green_run_explanation.py
+++ b/scripts/reborn_webui_v2_live_qa/green_run_explanation.py
@@ -42,7 +42,7 @@ class _CaseExplanation:
     text_excerpt_present: bool
     literal_required_text_matched: bool
     semantic_judge_used: bool
-    semantic_judge_reason: object
+    semantic_judge_reason: str | None
     semantic_judge_summary: dict[str, object] | None
 
     def success_reasons(self) -> list[str]:
@@ -133,6 +133,7 @@ def _explain_case(result: ProbeResult) -> _CaseExplanation:
     details = result.details if isinstance(result.details, dict) else {}
     required_text = _required_text_from_details(details.get("required_text"))
     text_excerpt = str(details.get("text_excerpt") or "")
+    semantic_judge_reason = _semantic_judge_reason(details)
     return _CaseExplanation(
         name=str(details.get("case") or result.mode.rsplit(":", 1)[-1]),
         mode=result.mode,
@@ -140,20 +141,51 @@ def _explain_case(result: ProbeResult) -> _CaseExplanation:
         blocked=bool(details.get("blocked")),
         required_text=required_text,
         text_excerpt_present=bool(text_excerpt),
-        literal_required_text_matched=bool(required_text)
-        and required_text_matches(text_excerpt, required_text),
-        semantic_judge_used=bool(details.get("semantic_judge_used")),
-        semantic_judge_reason=details.get("semantic_judge_reason"),
+        literal_required_text_matched=_literal_required_text_matched(
+            required_text=required_text,
+            text_excerpt=text_excerpt,
+            semantic_judge_reason=semantic_judge_reason,
+        ),
+        semantic_judge_used=(
+            bool(details.get("semantic_judge_used"))
+            or semantic_judge_reason == "semantic_judge_completed"
+        ),
+        semantic_judge_reason=semantic_judge_reason or None,
         semantic_judge_summary=_semantic_judge_summary(details),
     )
 
 
 def _required_text_from_details(value: object) -> list[str]:
     if isinstance(value, list):
-        return [str(item) for item in value if str(item)]
+        required_text: list[str] = []
+        for item in value:
+            if item is None:
+                continue
+            text = str(item)
+            if text:
+                required_text.append(text)
+        return required_text
     if isinstance(value, str) and value:
         return [value]
     return []
+
+
+def _semantic_judge_reason(details: dict[str, object]) -> str:
+    reason = details.get("semantic_judge_reason")
+    return reason if isinstance(reason, str) else ""
+
+
+def _literal_required_text_matched(
+    *,
+    required_text: list[str],
+    text_excerpt: str,
+    semantic_judge_reason: str,
+) -> bool:
+    if semantic_judge_reason == "literal_required_text_matched":
+        return True
+    if semantic_judge_reason == "semantic_judge_completed":
+        return False
+    return bool(required_text) and required_text_matches(text_excerpt, required_text)
 
 
 def _semantic_judge_summary(details: dict[str, object]) -> dict[str, object] | None:

--- a/scripts/reborn_webui_v2_live_qa/green_run_explanation.py
+++ b/scripts/reborn_webui_v2_live_qa/green_run_explanation.py
@@ -1,0 +1,168 @@
+"""Explain why Reborn WebUI v2 live QA cases were green."""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+from scripts.live_canary.common import ProbeResult
+from scripts.reborn_webui_v2_live_qa.text_match import required_text_matches
+
+
+def write_green_run_explanation(output_dir: Path, results: list[ProbeResult]) -> Path:
+    path = output_dir / "green-run-explanation.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    cases: list[dict[str, object]] = []
+    summary = _GreenRunSummary()
+
+    for result in results:
+        case = _explain_case(result)
+        summary.add(case)
+        cases.append(case.to_json())
+
+    payload = {
+        "generated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "why_things_were_green": summary.message(),
+        **summary.to_json(),
+        "cases": cases,
+    }
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+@dataclass(frozen=True)
+class _CaseExplanation:
+    name: str
+    mode: str
+    success: bool
+    blocked: bool
+    required_text: list[str]
+    text_excerpt_present: bool
+    literal_required_text_matched: bool
+    semantic_judge_used: bool
+    semantic_judge_reason: object
+    semantic_judge_summary: dict[str, object] | None
+
+    def success_reasons(self) -> list[str]:
+        if not self.success:
+            return []
+        reasons: list[str] = []
+        if self.literal_required_text_matched:
+            reasons.append("literal_required_text_matched")
+        if self.semantic_judge_used:
+            reasons.append("semantic_judge_completed")
+        if not self.required_text:
+            reasons.append("case_success_from_non_text_assertions")
+        if not reasons:
+            reasons.append("case_success_reason_unclassified")
+        return reasons
+
+    def to_json(self) -> dict[str, object]:
+        return {
+            "case": self.name,
+            "mode": self.mode,
+            "success": self.success,
+            "blocked": self.blocked,
+            "required_text": self.required_text,
+            "text_excerpt_present": self.text_excerpt_present,
+            "literal_required_text_matched": self.literal_required_text_matched,
+            "semantic_judge_used": self.semantic_judge_used,
+            "semantic_judge_reason": self.semantic_judge_reason,
+            "semantic_judge_summary": self.semantic_judge_summary,
+            "success_reasons": self.success_reasons(),
+        }
+
+
+@dataclass
+class _GreenRunSummary:
+    total_cases: int = 0
+    successful_cases: int = 0
+    failed_cases: int = 0
+    successful_cases_matching_required_text_literally: int = 0
+    successful_cases_using_semantic_judge: int = 0
+
+    def add(self, case: _CaseExplanation) -> None:
+        self.total_cases += 1
+        if not case.success:
+            self.failed_cases += 1
+            return
+        self.successful_cases += 1
+        if case.literal_required_text_matched:
+            self.successful_cases_matching_required_text_literally += 1
+        if case.semantic_judge_used:
+            self.successful_cases_using_semantic_judge += 1
+
+    def message(self) -> str:
+        if self.failed_cases:
+            status = (
+                f"{self.successful_cases} of {self.total_cases} cases were green; "
+                f"{self.failed_cases} failed."
+            )
+        else:
+            status = f"All {self.total_cases} cases were green."
+        literal = (
+            f"{self.successful_cases_matching_required_text_literally} successful cases "
+            "matched their required text literally."
+        )
+        if self.successful_cases_using_semantic_judge:
+            judge = (
+                f"{self.successful_cases_using_semantic_judge} successful cases used "
+                "the semantic judge fallback."
+            )
+        else:
+            judge = "No successful cases used the semantic judge fallback."
+        return f"{status} {literal} {judge}"
+
+    def to_json(self) -> dict[str, int]:
+        return {
+            "total_cases": self.total_cases,
+            "successful_cases": self.successful_cases,
+            "failed_cases": self.failed_cases,
+            "successful_cases_matching_required_text_literally": (
+                self.successful_cases_matching_required_text_literally
+            ),
+            "successful_cases_using_semantic_judge": (
+                self.successful_cases_using_semantic_judge
+            ),
+        }
+
+
+def _explain_case(result: ProbeResult) -> _CaseExplanation:
+    details = result.details if isinstance(result.details, dict) else {}
+    required_text = _required_text_from_details(details.get("required_text"))
+    text_excerpt = str(details.get("text_excerpt") or "")
+    return _CaseExplanation(
+        name=str(details.get("case") or result.mode.rsplit(":", 1)[-1]),
+        mode=result.mode,
+        success=result.success,
+        blocked=bool(details.get("blocked")),
+        required_text=required_text,
+        text_excerpt_present=bool(text_excerpt),
+        literal_required_text_matched=bool(required_text)
+        and required_text_matches(text_excerpt, required_text),
+        semantic_judge_used=bool(details.get("semantic_judge_used")),
+        semantic_judge_reason=details.get("semantic_judge_reason"),
+        semantic_judge_summary=_semantic_judge_summary(details),
+    )
+
+
+def _required_text_from_details(value: object) -> list[str]:
+    if isinstance(value, list):
+        return [str(item) for item in value if str(item)]
+    if isinstance(value, str) and value:
+        return [value]
+    return []
+
+
+def _semantic_judge_summary(details: dict[str, object]) -> dict[str, object] | None:
+    semantic_judge = details.get("semantic_judge")
+    if not isinstance(semantic_judge, dict):
+        return None
+    return {
+        "completed": semantic_judge.get("completed"),
+        "confidence": semantic_judge.get("confidence"),
+        "reason": semantic_judge.get("reason"),
+        "enabled": semantic_judge.get("enabled"),
+    }

--- a/scripts/reborn_webui_v2_live_qa/run_live_qa.py
+++ b/scripts/reborn_webui_v2_live_qa/run_live_qa.py
@@ -93,6 +93,9 @@ from scripts.reborn_webui_v2_live_qa.root_filesystem import (  # noqa: E402
     _root_filesystem_json,
     _root_filesystem_secret_by_handle,
 )
+from scripts.reborn_webui_v2_live_qa.green_run_explanation import (  # noqa: E402
+    write_green_run_explanation,
+)
 from scripts.reborn_webui_v2_live_qa.semantic_judge import (  # noqa: E402
     _compact_json,
     _judge_assistant_reply_completion,
@@ -112,6 +115,9 @@ from scripts.reborn_webui_v2_live_qa.slack_helpers import (  # noqa: E402
     _slack_config_value,
     _slack_enabled,
     _slack_team_id_from_bot_token_env,
+)
+from scripts.reborn_webui_v2_live_qa.text_match import (  # noqa: E402
+    required_text_matches,
 )
 
 QA_SHEET_PROMPTS: dict[str, str] = {
@@ -1055,7 +1061,7 @@ async def _wait_for_assistant_reply(
                 last_text = text
             normalized = text.lower()
             marker_matches = not marker or marker in text
-            if marker_matches and _required_text_matches(normalized, required_text):
+            if marker_matches and required_text_matches(normalized, required_text):
                 return AssistantReplyWaitResult(
                     text_excerpt=text[-2000:],
                     semantic_judge_used=False,
@@ -1089,23 +1095,6 @@ async def _wait_for_assistant_reply(
         f"last_assistant={last_text[-500:]!r} main_excerpt={main_text[-1000:]!r} "
         f"semantic_judge={_compact_json(semantic_judge)}"
     )
-
-
-def _required_text_matches(text: str, required_text: list[str]) -> bool:
-    normalized_text = text.lower()
-    return all(
-        any(_required_option_matches(normalized_text, option) for option in piece.split("|"))
-        for piece in required_text
-    )
-
-
-def _required_option_matches(normalized_text: str, option: str) -> bool:
-    normalized_option = option.strip().lower()
-    if not normalized_option:
-        return False
-    if re.fullmatch(r"\w+", normalized_option):
-        return re.search(rf"\b{re.escape(normalized_option)}\b", normalized_text) is not None
-    return normalized_option in normalized_text
 
 
 async def _approve_visible_tool_gate(page: object) -> None:
@@ -3807,144 +3796,6 @@ def write_trace_index(output_dir: Path, traces: list[dict[str, object]]) -> Path
     }
     path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
     return path
-
-
-def write_green_run_explanation(output_dir: Path, results: list[ProbeResult]) -> Path:
-    path = output_dir / "green-run-explanation.json"
-    path.parent.mkdir(parents=True, exist_ok=True)
-    cases: list[dict[str, object]] = []
-    successful_cases = 0
-    failed_cases = 0
-    literal_required_text_matched_count = 0
-    semantic_judge_used_count = 0
-
-    for result in results:
-        details = result.details if isinstance(result.details, dict) else {}
-        case_name = str(details.get("case") or result.mode.rsplit(":", 1)[-1])
-        required_text = _required_text_from_details(details.get("required_text"))
-        text_excerpt = str(details.get("text_excerpt") or "")
-        literal_required_text_matched = bool(required_text) and _required_text_matches(
-            text_excerpt,
-            required_text,
-        )
-        semantic_judge_used = bool(details.get("semantic_judge_used"))
-
-        if result.success:
-            successful_cases += 1
-            if literal_required_text_matched:
-                literal_required_text_matched_count += 1
-            if semantic_judge_used:
-                semantic_judge_used_count += 1
-        else:
-            failed_cases += 1
-
-        cases.append(
-            {
-                "case": case_name,
-                "mode": result.mode,
-                "success": result.success,
-                "blocked": bool(details.get("blocked")),
-                "required_text": required_text,
-                "text_excerpt_present": bool(text_excerpt),
-                "literal_required_text_matched": literal_required_text_matched,
-                "semantic_judge_used": semantic_judge_used,
-                "semantic_judge_reason": details.get("semantic_judge_reason"),
-                "semantic_judge_summary": _semantic_judge_summary(details),
-                "success_reasons": _green_success_reasons(
-                    result=result,
-                    required_text=required_text,
-                    literal_required_text_matched=literal_required_text_matched,
-                    semantic_judge_used=semantic_judge_used,
-                ),
-            }
-        )
-
-    payload = {
-        "generated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
-        "why_things_were_green": _green_run_summary(
-            total_cases=len(results),
-            successful_cases=successful_cases,
-            failed_cases=failed_cases,
-            literal_required_text_matched_count=literal_required_text_matched_count,
-            semantic_judge_used_count=semantic_judge_used_count,
-        ),
-        "total_cases": len(results),
-        "successful_cases": successful_cases,
-        "failed_cases": failed_cases,
-        "successful_cases_matching_required_text_literally": (
-            literal_required_text_matched_count
-        ),
-        "successful_cases_using_semantic_judge": semantic_judge_used_count,
-        "cases": cases,
-    }
-    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    return path
-
-
-def _required_text_from_details(value: object) -> list[str]:
-    if isinstance(value, list):
-        return [str(item) for item in value if str(item)]
-    if isinstance(value, str) and value:
-        return [value]
-    return []
-
-
-def _semantic_judge_summary(details: dict[str, object]) -> dict[str, object] | None:
-    semantic_judge = details.get("semantic_judge")
-    if not isinstance(semantic_judge, dict):
-        return None
-    return {
-        "completed": semantic_judge.get("completed"),
-        "confidence": semantic_judge.get("confidence"),
-        "reason": semantic_judge.get("reason"),
-        "enabled": semantic_judge.get("enabled"),
-    }
-
-
-def _green_success_reasons(
-    *,
-    result: ProbeResult,
-    required_text: list[str],
-    literal_required_text_matched: bool,
-    semantic_judge_used: bool,
-) -> list[str]:
-    if not result.success:
-        return []
-    reasons: list[str] = []
-    if literal_required_text_matched:
-        reasons.append("literal_required_text_matched")
-    if semantic_judge_used:
-        reasons.append("semantic_judge_completed")
-    if not required_text:
-        reasons.append("case_success_from_non_text_assertions")
-    if not reasons:
-        reasons.append("case_success_from_non_text_assertions")
-    return reasons
-
-
-def _green_run_summary(
-    *,
-    total_cases: int,
-    successful_cases: int,
-    failed_cases: int,
-    literal_required_text_matched_count: int,
-    semantic_judge_used_count: int,
-) -> str:
-    if failed_cases:
-        status = f"{successful_cases} of {total_cases} cases were green; {failed_cases} failed."
-    else:
-        status = f"All {total_cases} cases were green."
-    literal = (
-        f"{literal_required_text_matched_count} successful cases matched their "
-        "required text literally."
-    )
-    if semantic_judge_used_count:
-        judge = (
-            f"{semantic_judge_used_count} successful cases used the semantic judge fallback."
-        )
-    else:
-        judge = "No successful cases used the semantic judge fallback."
-    return f"{status} {literal} {judge}"
 
 
 def write_preflight(output_dir: Path, prepared_home: PreparedRebornHome) -> Path:

--- a/scripts/reborn_webui_v2_live_qa/run_live_qa.py
+++ b/scripts/reborn_webui_v2_live_qa/run_live_qa.py
@@ -796,6 +796,14 @@ async def _with_page(output_dir: Path, case_name: str, action: Callable[[object]
             await browser.close()
 
 
+@dataclass(frozen=True)
+class AssistantReplyWaitResult:
+    text_excerpt: str
+    semantic_judge_used: bool
+    semantic_judge_reason: str
+    semantic_judge: dict[str, object] | None = None
+
+
 def _result(case_name: str, success: bool, started: float, details: dict[str, object]) -> ProbeResult:
     details = {"case": case_name, **details}
     if case_name in QA_SHEET_CASES:
@@ -812,6 +820,17 @@ def _result(case_name: str, success: bool, started: float, details: dict[str, ob
         latency_ms=int((time.monotonic() - started) * 1000),
         details=details,
     )
+
+
+def _record_assistant_reply_wait_result(
+    observed: dict[str, object],
+    reply: AssistantReplyWaitResult,
+) -> None:
+    observed["text_excerpt"] = reply.text_excerpt
+    observed["semantic_judge_used"] = reply.semantic_judge_used
+    observed["semantic_judge_reason"] = reply.semantic_judge_reason
+    if reply.semantic_judge is not None:
+        observed["semantic_judge"] = reply.semantic_judge
 
 
 async def _live_chat_case(
@@ -856,12 +875,15 @@ async def _live_chat_case(
                 prompt[:80],
                 timeout=15000,
             )
-        observed["text_excerpt"] = await _wait_for_assistant_reply(
-            page,
-            marker=marker,
-            required_text=required_text,
-            timeout=timeout,
-            semantic_goal=prompt,
+        _record_assistant_reply_wait_result(
+            observed,
+            await _wait_for_assistant_reply(
+                page,
+                marker=marker,
+                required_text=required_text,
+                timeout=timeout,
+                semantic_goal=prompt,
+            ),
         )
         if forbidden_text:
             text = str(observed["text_excerpt"]).lower()
@@ -968,12 +990,15 @@ async def _live_chat_with_extensions_case(
                 prompt[:80],
                 timeout=15000,
             )
-        observed["text_excerpt"] = await _wait_for_assistant_reply(
-            page,
-            marker=marker,
-            required_text=required_text,
-            timeout=timeout,
-            semantic_goal=prompt,
+        _record_assistant_reply_wait_result(
+            observed,
+            await _wait_for_assistant_reply(
+                page,
+                marker=marker,
+                required_text=required_text,
+                timeout=timeout,
+                semantic_goal=prompt,
+            ),
         )
 
     try:
@@ -1004,7 +1029,7 @@ async def _wait_for_assistant_reply(
     required_text: list[str],
     timeout: float,
     semantic_goal: str | None = None,
-) -> str:
+) -> AssistantReplyWaitResult:
     deadline = time.monotonic() + timeout
     assistant = page.locator("[data-testid='msg-assistant']").last  # type: ignore[attr-defined]
     last_text = ""
@@ -1031,7 +1056,11 @@ async def _wait_for_assistant_reply(
             normalized = text.lower()
             marker_matches = not marker or marker in text
             if marker_matches and _required_text_matches(normalized, required_text):
-                return text[-2000:]
+                return AssistantReplyWaitResult(
+                    text_excerpt=text[-2000:],
+                    semantic_judge_used=False,
+                    semantic_judge_reason="literal_required_text_matched",
+                )
         await asyncio.sleep(0.5)
     main_text = ""
     try:
@@ -1048,7 +1077,12 @@ async def _wait_for_assistant_reply(
             semantic_goal=semantic_goal,
         )
         if _semantic_judge_passed(semantic_judge):
-            return last_text[-2000:]
+            return AssistantReplyWaitResult(
+                text_excerpt=last_text[-2000:],
+                semantic_judge_used=True,
+                semantic_judge_reason="semantic_judge_completed",
+                semantic_judge=semantic_judge,
+            )
     raise AssertionError(
         "assistant reply did not contain required text before timeout. "
         f"marker={marker!r} required_text={required_text!r} "
@@ -3335,11 +3369,14 @@ async def case_qa_7a_slack_product_channel_connect(ctx: LiveQaContext) -> ProbeR
                 prompt[:80],
                 timeout=15000,
             )
-            observed["text_excerpt"] = await _wait_for_assistant_reply(
-                page,
-                marker=None,
-                required_text=["slack"],
-                timeout=180.0,
+            _record_assistant_reply_wait_result(
+                observed,
+                await _wait_for_assistant_reply(
+                    page,
+                    marker=None,
+                    required_text=["slack"],
+                    timeout=180.0,
+                ),
             )
             deadline = time.monotonic() + 180.0
             while time.monotonic() < deadline:
@@ -3772,6 +3809,144 @@ def write_trace_index(output_dir: Path, traces: list[dict[str, object]]) -> Path
     return path
 
 
+def write_green_run_explanation(output_dir: Path, results: list[ProbeResult]) -> Path:
+    path = output_dir / "green-run-explanation.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    cases: list[dict[str, object]] = []
+    successful_cases = 0
+    failed_cases = 0
+    literal_required_text_matched_count = 0
+    semantic_judge_used_count = 0
+
+    for result in results:
+        details = result.details if isinstance(result.details, dict) else {}
+        case_name = str(details.get("case") or result.mode.rsplit(":", 1)[-1])
+        required_text = _required_text_from_details(details.get("required_text"))
+        text_excerpt = str(details.get("text_excerpt") or "")
+        literal_required_text_matched = bool(required_text) and _required_text_matches(
+            text_excerpt,
+            required_text,
+        )
+        semantic_judge_used = bool(details.get("semantic_judge_used"))
+
+        if result.success:
+            successful_cases += 1
+            if literal_required_text_matched:
+                literal_required_text_matched_count += 1
+            if semantic_judge_used:
+                semantic_judge_used_count += 1
+        else:
+            failed_cases += 1
+
+        cases.append(
+            {
+                "case": case_name,
+                "mode": result.mode,
+                "success": result.success,
+                "blocked": bool(details.get("blocked")),
+                "required_text": required_text,
+                "text_excerpt_present": bool(text_excerpt),
+                "literal_required_text_matched": literal_required_text_matched,
+                "semantic_judge_used": semantic_judge_used,
+                "semantic_judge_reason": details.get("semantic_judge_reason"),
+                "semantic_judge_summary": _semantic_judge_summary(details),
+                "success_reasons": _green_success_reasons(
+                    result=result,
+                    required_text=required_text,
+                    literal_required_text_matched=literal_required_text_matched,
+                    semantic_judge_used=semantic_judge_used,
+                ),
+            }
+        )
+
+    payload = {
+        "generated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "why_things_were_green": _green_run_summary(
+            total_cases=len(results),
+            successful_cases=successful_cases,
+            failed_cases=failed_cases,
+            literal_required_text_matched_count=literal_required_text_matched_count,
+            semantic_judge_used_count=semantic_judge_used_count,
+        ),
+        "total_cases": len(results),
+        "successful_cases": successful_cases,
+        "failed_cases": failed_cases,
+        "successful_cases_matching_required_text_literally": (
+            literal_required_text_matched_count
+        ),
+        "successful_cases_using_semantic_judge": semantic_judge_used_count,
+        "cases": cases,
+    }
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def _required_text_from_details(value: object) -> list[str]:
+    if isinstance(value, list):
+        return [str(item) for item in value if str(item)]
+    if isinstance(value, str) and value:
+        return [value]
+    return []
+
+
+def _semantic_judge_summary(details: dict[str, object]) -> dict[str, object] | None:
+    semantic_judge = details.get("semantic_judge")
+    if not isinstance(semantic_judge, dict):
+        return None
+    return {
+        "completed": semantic_judge.get("completed"),
+        "confidence": semantic_judge.get("confidence"),
+        "reason": semantic_judge.get("reason"),
+        "enabled": semantic_judge.get("enabled"),
+    }
+
+
+def _green_success_reasons(
+    *,
+    result: ProbeResult,
+    required_text: list[str],
+    literal_required_text_matched: bool,
+    semantic_judge_used: bool,
+) -> list[str]:
+    if not result.success:
+        return []
+    reasons: list[str] = []
+    if literal_required_text_matched:
+        reasons.append("literal_required_text_matched")
+    if semantic_judge_used:
+        reasons.append("semantic_judge_completed")
+    if not required_text:
+        reasons.append("case_success_from_non_text_assertions")
+    if not reasons:
+        reasons.append("case_success_from_non_text_assertions")
+    return reasons
+
+
+def _green_run_summary(
+    *,
+    total_cases: int,
+    successful_cases: int,
+    failed_cases: int,
+    literal_required_text_matched_count: int,
+    semantic_judge_used_count: int,
+) -> str:
+    if failed_cases:
+        status = f"{successful_cases} of {total_cases} cases were green; {failed_cases} failed."
+    else:
+        status = f"All {total_cases} cases were green."
+    literal = (
+        f"{literal_required_text_matched_count} successful cases matched their "
+        "required text literally."
+    )
+    if semantic_judge_used_count:
+        judge = (
+            f"{semantic_judge_used_count} successful cases used the semantic judge fallback."
+        )
+    else:
+        judge = "No successful cases used the semantic judge fallback."
+    return f"{status} {literal} {judge}"
+
+
 def write_preflight(output_dir: Path, prepared_home: PreparedRebornHome) -> Path:
     payload = {
         "generated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
@@ -4041,8 +4216,13 @@ async def run_cases(args: argparse.Namespace) -> int:
             )
     results_path = write_results(args.output_dir, results, first_base_url)
     trace_index_path = write_trace_index(args.output_dir, trace_exports)
+    green_explanation_path = write_green_run_explanation(args.output_dir, results)
     print(f"[reborn-webui-v2-live-qa] results={results_path}", flush=True)
     print(f"[reborn-webui-v2-live-qa] trace_index={trace_index_path}", flush=True)
+    print(
+        f"[reborn-webui-v2-live-qa] green_run_explanation={green_explanation_path}",
+        flush=True,
+    )
     return 0 if all(result.success for result in results) else 1
 
 
@@ -4089,6 +4269,11 @@ def main() -> int:
             details={"error": str(exc)},
         )
         write_results(args.output_dir, [failed], "")
+        green_explanation_path = write_green_run_explanation(args.output_dir, [failed])
+        print(
+            f"[reborn-webui-v2-live-qa] green_run_explanation={green_explanation_path}",
+            flush=True,
+        )
         print(f"[reborn-webui-v2-live-qa] {exc}", file=sys.stderr, flush=True)
         return 1
 

--- a/scripts/reborn_webui_v2_live_qa/test_green_run_explanation.py
+++ b/scripts/reborn_webui_v2_live_qa/test_green_run_explanation.py
@@ -29,8 +29,8 @@ class GreenRunExplanationTests(unittest.TestCase):
                 latency_ms=1,
                 details={
                     "case": "literal_case",
-                    "required_text": ["routine"],
-                    "text_excerpt": "Routine created successfully.",
+                    "required_text": [None, "", "routine"],
+                    "text_excerpt": "Truncated excerpt without the matched word.",
                     "semantic_judge_used": False,
                     "semantic_judge_reason": "literal_required_text_matched",
                 },
@@ -44,7 +44,6 @@ class GreenRunExplanationTests(unittest.TestCase):
                     "case": "semantic_case",
                     "required_text": ["routine"],
                     "text_excerpt": "Schedule: every hour. Trigger ID: trigger-123.",
-                    "semantic_judge_used": True,
                     "semantic_judge_reason": "semantic_judge_completed",
                     "semantic_judge": {
                         "completed": True,
@@ -78,6 +77,9 @@ class GreenRunExplanationTests(unittest.TestCase):
         self.assertEqual(payload["successful_cases_using_semantic_judge"], 1)
         self.assertIn("All 3 cases were green", payload["why_things_were_green"])
         cases_by_name = {case["case"]: case for case in payload["cases"]}
+        self.assertEqual(cases_by_name["literal_case"]["required_text"], ["routine"])
+        self.assertTrue(cases_by_name["literal_case"]["literal_required_text_matched"])
+        self.assertTrue(cases_by_name["semantic_case"]["semantic_judge_used"])
         self.assertEqual(
             cases_by_name["literal_case"]["success_reasons"],
             ["literal_required_text_matched"],
@@ -122,6 +124,46 @@ class GreenRunExplanationTests(unittest.TestCase):
             payload["cases"][0]["success_reasons"],
             ["case_success_reason_unclassified"],
         )
+
+    def test_failed_case_updates_summary_and_message(self):
+        results = [
+            ProbeResult(
+                provider="test",
+                mode="live:passed_case",
+                success=True,
+                latency_ms=1,
+                details={
+                    "case": "passed_case",
+                    "required_text": ["routine"],
+                    "text_excerpt": "Routine created.",
+                },
+            ),
+            ProbeResult(
+                provider="test",
+                mode="live:failed_case",
+                success=False,
+                latency_ms=1,
+                details={
+                    "case": "failed_case",
+                    "error": "setup failed",
+                },
+            ),
+        ]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir)
+            path = write_green_run_explanation(output_dir, results)
+            payload = json.loads(path.read_text(encoding="utf-8"))
+
+        self.assertEqual(payload["total_cases"], 2)
+        self.assertEqual(payload["successful_cases"], 1)
+        self.assertEqual(payload["failed_cases"], 1)
+        self.assertIn(
+            "1 of 2 cases were green; 1 failed.",
+            payload["why_things_were_green"],
+        )
+        cases_by_name = {case["case"]: case for case in payload["cases"]}
+        self.assertEqual(cases_by_name["failed_case"]["success_reasons"], [])
 
 
 if __name__ == "__main__":

--- a/scripts/reborn_webui_v2_live_qa/test_green_run_explanation.py
+++ b/scripts/reborn_webui_v2_live_qa/test_green_run_explanation.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Unit tests for Reborn WebUI v2 live QA green-run explanations."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.live_canary.common import ProbeResult  # noqa: E402
+from scripts.reborn_webui_v2_live_qa.green_run_explanation import (  # noqa: E402
+    write_green_run_explanation,
+)
+
+
+class GreenRunExplanationTests(unittest.TestCase):
+    def test_write_green_run_explanation_records_success_reasons(self):
+        results = [
+            ProbeResult(
+                provider="test",
+                mode="live:literal_case",
+                success=True,
+                latency_ms=1,
+                details={
+                    "case": "literal_case",
+                    "required_text": ["routine"],
+                    "text_excerpt": "Routine created successfully.",
+                    "semantic_judge_used": False,
+                    "semantic_judge_reason": "literal_required_text_matched",
+                },
+            ),
+            ProbeResult(
+                provider="test",
+                mode="live:semantic_case",
+                success=True,
+                latency_ms=1,
+                details={
+                    "case": "semantic_case",
+                    "required_text": ["routine"],
+                    "text_excerpt": "Schedule: every hour. Trigger ID: trigger-123.",
+                    "semantic_judge_used": True,
+                    "semantic_judge_reason": "semantic_judge_completed",
+                    "semantic_judge": {
+                        "completed": True,
+                        "confidence": 0.91,
+                        "reason": "The response confirms the scheduled task.",
+                        "evidence": ["Trigger ID: trigger-123"],
+                    },
+                },
+            ),
+            ProbeResult(
+                provider="test",
+                mode="live:side_effect_case",
+                success=True,
+                latency_ms=1,
+                details={
+                    "case": "side_effect_case",
+                    "delivery_verified": True,
+                },
+            ),
+        ]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir)
+            path = write_green_run_explanation(output_dir, results)
+            payload = json.loads(path.read_text(encoding="utf-8"))
+
+        self.assertEqual(payload["total_cases"], 3)
+        self.assertEqual(payload["successful_cases"], 3)
+        self.assertEqual(payload["failed_cases"], 0)
+        self.assertEqual(payload["successful_cases_matching_required_text_literally"], 1)
+        self.assertEqual(payload["successful_cases_using_semantic_judge"], 1)
+        self.assertIn("All 3 cases were green", payload["why_things_were_green"])
+        cases_by_name = {case["case"]: case for case in payload["cases"]}
+        self.assertEqual(
+            cases_by_name["literal_case"]["success_reasons"],
+            ["literal_required_text_matched"],
+        )
+        self.assertEqual(
+            cases_by_name["semantic_case"]["success_reasons"],
+            ["semantic_judge_completed"],
+        )
+        self.assertEqual(
+            cases_by_name["side_effect_case"]["success_reasons"],
+            ["case_success_from_non_text_assertions"],
+        )
+        self.assertEqual(
+            cases_by_name["semantic_case"]["semantic_judge_summary"],
+            {
+                "completed": True,
+                "confidence": 0.91,
+                "reason": "The response confirms the scheduled task.",
+                "enabled": None,
+            },
+        )
+
+    def test_success_with_required_text_but_no_gate_is_unclassified(self):
+        result = ProbeResult(
+            provider="test",
+            mode="live:unexpected_case",
+            success=True,
+            latency_ms=1,
+            details={
+                "case": "unexpected_case",
+                "required_text": ["routine"],
+                "text_excerpt": "No matching text here.",
+            },
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir)
+            path = write_green_run_explanation(output_dir, [result])
+            payload = json.loads(path.read_text(encoding="utf-8"))
+
+        self.assertEqual(
+            payload["cases"][0]["success_reasons"],
+            ["case_success_reason_unclassified"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
+++ b/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
@@ -25,9 +25,11 @@ from unittest.mock import patch
 if __package__:
     from . import run_live_qa
     from . import semantic_judge
+    from . import text_match
 else:
     import run_live_qa
     import semantic_judge
+    import text_match
 
 
 class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
@@ -556,55 +558,55 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
 
     def test_required_text_accepts_explicit_alternatives(self):
         self.assertTrue(
-            run_live_qa._required_text_matches(
+            text_match.required_text_matches(
                 "fires every 5 minutes and watches slack for bug messages",
                 ["trigger|routine|automation|cron|schedule|fires|watches", "bug"],
             )
         )
         self.assertFalse(
-            run_live_qa._required_text_matches(
+            text_match.required_text_matches(
                 "records bug messages in a sheet",
                 ["trigger|routine|automation|cron|schedule|fires|watches", "bug"],
             )
         )
         self.assertFalse(
-            run_live_qa._required_text_matches(
+            text_match.required_text_matches(
                 "fires every 5 minutes and watches slack for debug messages",
                 ["trigger|routine|automation|cron|schedule|fires|watches", "bug"],
             )
         )
         self.assertFalse(
-            run_live_qa._required_text_matches(
+            text_match.required_text_matches(
                 "fires every 5 minutes and watches slack for bugfix messages",
                 ["trigger|routine|automation|cron|schedule|fires|watches", "bug"],
             )
         )
         self.assertTrue(
-            run_live_qa._required_text_matches(
+            text_match.required_text_matches(
                 "fires every 5 minutes and watches slack for bug: messages",
                 ["trigger|routine|automation|cron|schedule|fires|watches", "bug"],
             )
         )
         self.assertTrue(
-            run_live_qa._required_text_matches(
+            text_match.required_text_matches(
                 "https://near.ai responded with HTTP 200 - the endpoint is up and running fine.",
                 ["status|http|200|up|running|responded"],
             )
         )
         self.assertTrue(
-            run_live_qa._required_text_matches(
+            text_match.required_text_matches(
                 "Trigger created. Schedule: every 5 minutes. Action: fetch latest releases.",
                 ["routine|trigger|automation|cron|schedule|created"],
             )
         )
         self.assertTrue(
-            run_live_qa._required_text_matches(
+            text_match.required_text_matches(
                 "The email from firat.sertgoz@near.ai is already in the sheet.",
                 ["ABC|sheet|spreadsheet", "email|row|near.ai|near ai"],
             )
         )
         self.assertTrue(
-            run_live_qa._required_text_matches(
+            text_match.required_text_matches(
                 'Discussion thread "vibe coded eh" (id=47005839) mentions NEAR AI.',
                 ["news.ycombinator.com|hacker news|hn|discussion|id="],
             )
@@ -2504,86 +2506,6 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
             self.assertEqual(paths, [tool_index_path, message_path])
             self.assertNotIn(secret_path, paths)
             self.assertEqual(payload["entries"][1]["contents"]["content"], "hello live trace")
-
-    def test_write_green_run_explanation_records_success_reasons(self):
-        results = [
-            run_live_qa.ProbeResult(
-                provider="test",
-                mode="live:literal_case",
-                success=True,
-                latency_ms=1,
-                details={
-                    "case": "literal_case",
-                    "required_text": ["routine"],
-                    "text_excerpt": "Routine created successfully.",
-                    "semantic_judge_used": False,
-                    "semantic_judge_reason": "literal_required_text_matched",
-                },
-            ),
-            run_live_qa.ProbeResult(
-                provider="test",
-                mode="live:semantic_case",
-                success=True,
-                latency_ms=1,
-                details={
-                    "case": "semantic_case",
-                    "required_text": ["routine"],
-                    "text_excerpt": "Schedule: every hour. Trigger ID: trigger-123.",
-                    "semantic_judge_used": True,
-                    "semantic_judge_reason": "semantic_judge_completed",
-                    "semantic_judge": {
-                        "completed": True,
-                        "confidence": 0.91,
-                        "reason": "The response confirms the scheduled task.",
-                        "evidence": ["Trigger ID: trigger-123"],
-                    },
-                },
-            ),
-            run_live_qa.ProbeResult(
-                provider="test",
-                mode="live:side_effect_case",
-                success=True,
-                latency_ms=1,
-                details={
-                    "case": "side_effect_case",
-                    "delivery_verified": True,
-                },
-            ),
-        ]
-
-        with tempfile.TemporaryDirectory() as tmpdir:
-            output_dir = Path(tmpdir)
-            path = run_live_qa.write_green_run_explanation(output_dir, results)
-            payload = json.loads(path.read_text(encoding="utf-8"))
-
-        self.assertEqual(payload["total_cases"], 3)
-        self.assertEqual(payload["successful_cases"], 3)
-        self.assertEqual(payload["failed_cases"], 0)
-        self.assertEqual(payload["successful_cases_matching_required_text_literally"], 1)
-        self.assertEqual(payload["successful_cases_using_semantic_judge"], 1)
-        self.assertIn("All 3 cases were green", payload["why_things_were_green"])
-        cases_by_name = {case["case"]: case for case in payload["cases"]}
-        self.assertEqual(
-            cases_by_name["literal_case"]["success_reasons"],
-            ["literal_required_text_matched"],
-        )
-        self.assertEqual(
-            cases_by_name["semantic_case"]["success_reasons"],
-            ["semantic_judge_completed"],
-        )
-        self.assertEqual(
-            cases_by_name["side_effect_case"]["success_reasons"],
-            ["case_success_from_non_text_assertions"],
-        )
-        self.assertEqual(
-            cases_by_name["semantic_case"]["semantic_judge_summary"],
-            {
-                "completed": True,
-                "confidence": 0.91,
-                "reason": "The response confirms the scheduled task.",
-                "enabled": None,
-            },
-        )
 
     def test_run_cases_isolates_reborn_home_and_preflight_per_selected_case(self):
         async def fake_case(ctx: run_live_qa.LiveQaContext) -> run_live_qa.ProbeResult:

--- a/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
+++ b/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
@@ -645,7 +645,7 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
             def get_by_role(self, _role, **_kwargs):
                 return FakeApprove()
 
-        text = asyncio.run(
+        reply = asyncio.run(
             run_live_qa._wait_for_assistant_reply(
                 FakePage(),
                 marker=None,
@@ -654,8 +654,11 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
             )
         )
 
+        text = reply.text_excerpt
         self.assertIn("routine", text.lower())
         self.assertIn("emails", text.lower())
+        self.assertFalse(reply.semantic_judge_used)
+        self.assertEqual(reply.semantic_judge_reason, "literal_required_text_matched")
 
     def test_wait_for_assistant_reply_uses_semantic_judge_for_text_mismatch(self):
         response_text = (
@@ -685,7 +688,7 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
             ),
             patch.object(run_live_qa.asyncio, "sleep", side_effect=fake_sleep),
         ):
-            text = asyncio.run(
+            reply = asyncio.run(
                 run_live_qa._wait_for_assistant_reply(
                     self._fake_assistant_reply_page(response_text),
                     marker=None,
@@ -695,7 +698,11 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
                 )
             )
 
+        text = reply.text_excerpt
         self.assertIn("Trigger ID", text)
+        self.assertTrue(reply.semantic_judge_used)
+        self.assertEqual(reply.semantic_judge_reason, "semantic_judge_completed")
+        self.assertEqual(reply.semantic_judge["confidence"], 0.91)
         self.assertEqual(captured["required_text"], ["routine"])
         self.assertIn("hourly Hacker News", captured["semantic_goal"])
 
@@ -920,7 +927,11 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
             await action(FakePage())
 
         async def fake_wait_for_assistant_reply(_page, **_kwargs):
-            return "Slack is connected"
+            return run_live_qa.AssistantReplyWaitResult(
+                text_excerpt="Slack is connected",
+                semantic_judge_used=False,
+                semantic_judge_reason="literal_required_text_matched",
+            )
 
         async def fake_approve_visible_tool_gate(_page):
             return None
@@ -2494,6 +2505,86 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
             self.assertNotIn(secret_path, paths)
             self.assertEqual(payload["entries"][1]["contents"]["content"], "hello live trace")
 
+    def test_write_green_run_explanation_records_success_reasons(self):
+        results = [
+            run_live_qa.ProbeResult(
+                provider="test",
+                mode="live:literal_case",
+                success=True,
+                latency_ms=1,
+                details={
+                    "case": "literal_case",
+                    "required_text": ["routine"],
+                    "text_excerpt": "Routine created successfully.",
+                    "semantic_judge_used": False,
+                    "semantic_judge_reason": "literal_required_text_matched",
+                },
+            ),
+            run_live_qa.ProbeResult(
+                provider="test",
+                mode="live:semantic_case",
+                success=True,
+                latency_ms=1,
+                details={
+                    "case": "semantic_case",
+                    "required_text": ["routine"],
+                    "text_excerpt": "Schedule: every hour. Trigger ID: trigger-123.",
+                    "semantic_judge_used": True,
+                    "semantic_judge_reason": "semantic_judge_completed",
+                    "semantic_judge": {
+                        "completed": True,
+                        "confidence": 0.91,
+                        "reason": "The response confirms the scheduled task.",
+                        "evidence": ["Trigger ID: trigger-123"],
+                    },
+                },
+            ),
+            run_live_qa.ProbeResult(
+                provider="test",
+                mode="live:side_effect_case",
+                success=True,
+                latency_ms=1,
+                details={
+                    "case": "side_effect_case",
+                    "delivery_verified": True,
+                },
+            ),
+        ]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir)
+            path = run_live_qa.write_green_run_explanation(output_dir, results)
+            payload = json.loads(path.read_text(encoding="utf-8"))
+
+        self.assertEqual(payload["total_cases"], 3)
+        self.assertEqual(payload["successful_cases"], 3)
+        self.assertEqual(payload["failed_cases"], 0)
+        self.assertEqual(payload["successful_cases_matching_required_text_literally"], 1)
+        self.assertEqual(payload["successful_cases_using_semantic_judge"], 1)
+        self.assertIn("All 3 cases were green", payload["why_things_were_green"])
+        cases_by_name = {case["case"]: case for case in payload["cases"]}
+        self.assertEqual(
+            cases_by_name["literal_case"]["success_reasons"],
+            ["literal_required_text_matched"],
+        )
+        self.assertEqual(
+            cases_by_name["semantic_case"]["success_reasons"],
+            ["semantic_judge_completed"],
+        )
+        self.assertEqual(
+            cases_by_name["side_effect_case"]["success_reasons"],
+            ["case_success_from_non_text_assertions"],
+        )
+        self.assertEqual(
+            cases_by_name["semantic_case"]["semantic_judge_summary"],
+            {
+                "completed": True,
+                "confidence": 0.91,
+                "reason": "The response confirms the scheduled task.",
+                "enabled": None,
+            },
+        )
+
     def test_run_cases_isolates_reborn_home_and_preflight_per_selected_case(self):
         async def fake_case(ctx: run_live_qa.LiveQaContext) -> run_live_qa.ProbeResult:
             return run_live_qa.ProbeResult(
@@ -2567,6 +2658,11 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
             self.assertTrue((output_dir / "traces" / "case_a.json").exists())
             self.assertTrue((output_dir / "traces" / "case_b.json").exists())
             self.assertTrue((output_dir / "traces" / "index.json").exists())
+            self.assertTrue((output_dir / "green-run-explanation.json").exists())
+            green_explanation = json.loads(
+                (output_dir / "green-run-explanation.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(green_explanation["successful_cases"], 2)
 
 
 if __name__ == "__main__":

--- a/scripts/reborn_webui_v2_live_qa/text_match.py
+++ b/scripts/reborn_webui_v2_live_qa/text_match.py
@@ -1,0 +1,22 @@
+"""Required-text matching for Reborn WebUI v2 live QA responses."""
+
+from __future__ import annotations
+
+import re
+
+
+def required_text_matches(text: str, required_text: list[str]) -> bool:
+    normalized_text = text.lower()
+    return all(
+        any(_required_option_matches(normalized_text, option) for option in piece.split("|"))
+        for piece in required_text
+    )
+
+
+def _required_option_matches(normalized_text: str, option: str) -> bool:
+    normalized_option = option.strip().lower()
+    if not normalized_option:
+        return False
+    if re.fullmatch(r"\w+", normalized_option):
+        return re.search(rf"\b{re.escape(normalized_option)}\b", normalized_text) is not None
+    return normalized_option in normalized_text


### PR DESCRIPTION
## Summary

- Record whether Reborn WebUI v2 live QA assistant text checks passed by literal required-text matching or semantic judge fallback.
- Add `green-run-explanation.json` to the live QA output directory with per-case pass reasons and aggregate fallback counts.
- Isolate green-run reporting in `green_run_explanation.py` and centralize required-text matching in `text_match.py`.
- Address Gemini and CodeRabbit review feedback for `None` required-text entries, truncated-excerpt classification, and failed-case coverage.

## Change Type

- [ ] Bug fix
- [x] New feature
- [x] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

None.

## Validation

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [ ] `cargo build`
- [x] Relevant tests pass:
  - `python3 -m py_compile scripts/reborn_webui_v2_live_qa/green_run_explanation.py scripts/reborn_webui_v2_live_qa/test_green_run_explanation.py scripts/reborn_webui_v2_live_qa/run_live_qa.py scripts/reborn_webui_v2_live_qa/test_run_live_qa.py scripts/reborn_webui_v2_live_qa/text_match.py scripts/reborn_webui_v2_live_qa/semantic_judge.py`
  - `python3 scripts/reborn_webui_v2_live_qa/test_green_run_explanation.py`
  - `python3 scripts/reborn_webui_v2_live_qa/test_run_live_qa.py`
  - `git diff --check`
- [ ] `cargo test --features integration` if database-backed or integration behavior changed
- [ ] Manual testing: not run; artifact shape is covered by unit tests
- [x] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review: thermo-nuclear review plus Gemini/CodeRabbit review-address pass run

## Security Impact

None. This only changes live QA artifact metadata and Python test helpers. It does not add secrets, network calls, permissions, file access beyond existing artifact writes, tool execution, or sandbox policy.

## Reborn Trust-Boundary Checklist

N/A. This PR changes Reborn WebUI v2 live QA scripts and artifact reporting, not runtime trust-bearing types, prompt ingestion, policy, status variants, queues, DB durability, or sandbox/native boundaries.

## Database Impact

None. No migrations, schema changes, or PostgreSQL/libSQL behavior changes.

## Blast Radius

Scoped to `scripts/reborn_webui_v2_live_qa/`. The main risk is inaccurate live-canary artifact classification; targeted tests cover literal, semantic, non-text, unclassified, and failed-case paths.

## Rollback Plan

Revert this PR. The live QA lane will continue writing `results.json` and traces without `green-run-explanation.json` or semantic-judge audit classification.

## Review Follow-Through

Gemini and CodeRabbit feedback addressed where still valid. The Gemini request to remove the non-text success branch was intentionally not applied after the refactor because it now distinguishes non-text assertion passes from unclassified text-gated passes.

---

**Review track**: A (docs/tests/chore)