### PR TITLE
docs(oauth): mark ironclaw_oauth v1-only, delete-with-v1

### DIFF
--- a/crates/ironclaw_oauth/CLAUDE.md
+++ b/crates/ironclaw_oauth/CLAUDE.md
@@ -1,6 +1,6 @@
 # ironclaw_oauth guardrails
 
-> **v1-only today.** Sole consumer is the root `ironclaw` crate. Reborn auth (`ironclaw_auth` + composition's oauth modules) has its own OAuth handling and does not use this crate; it retires — or gets adopted deliberately — with the v1 cleanup.
+> **Deprecated — delete with v1.** Sole consumer is the root `ironclaw` v1 crate. Reborn auth (`ironclaw_auth` + composition's oauth modules) has its own OAuth handling on durable gateway routes and does not use this crate. Do **not** add new consumers or port it to Reborn; delete this crate when the v1 `src/` surface is removed.
 
 - Owns the loopback OAuth callback listener (port 9876), branded landing pages, and `OAUTH_CALLBACK_HOST` binding rules. That is the entire scope.
 - Do **not** add provider-specific OAuth (Anthropic, Gemini, GitHub Copilot, OpenAI Codex, NEAR AI, MCP) — those flows live with the consumer that owns the credential and depend on this crate for the transport.

--- a/crates/ironclaw_oauth/src/lib.rs
+++ b/crates/ironclaw_oauth/src/lib.rs
@@ -1,12 +1,28 @@
-//! Shared OAuth callback infrastructure used by every IronClaw OAuth flow
-//! (NEAR AI session login, WASM tool auth, MCP server auth, registry-provider
-//! OAuth backends).
+//! Loopback OAuth callback transport for the **v1 (legacy) stack only**.
 //!
-//! This crate owns the loopback callback listener, the branded landing pages,
-//! and the host-binding rules that keep the callback safe on remote hosts.
-//! It is deliberately small and free of LLM/auth-provider concerns — the
-//! provider-specific OAuth flows live in their owning crates and depend on
-//! this crate for the transport.
+//! This crate owns the fixed-port (`127.0.0.1:9876`) loopback callback
+//! listener, the branded landing pages, and the host-binding rules that keep
+//! the callback safe on remote hosts. It is deliberately small and free of
+//! LLM/auth-provider concerns — the provider-specific v1 OAuth flows (NEAR AI
+//! session login, WASM tool auth, MCP server auth, registry-provider backends)
+//! live in their owning v1 modules and depend on this crate for the transport.
+//!
+//! ## Not used by Reborn
+//!
+//! The Reborn stack does **not** use this crate. Its hosted, multi-tenant model
+//! receives OAuth callbacks on durable gateway HTTP routes
+//! (`/api/reborn/product-auth/oauth/callback/{flow_id}`, see
+//! `ironclaw_reborn_composition::product_auth_serve`) with persisted flow state,
+//! which is fundamentally incompatible with a single-flow, in-process,
+//! fixed-port loopback listener. The sole consumer is the root `ironclaw` v1
+//! binary.
+//!
+//! ## DELETE WITH V1
+//!
+//! This crate is part of the deprecated v1 surface (see "Where to Build —
+//! Reborn-First" in the root `CLAUDE.md`). When the legacy `src/` stack is
+//! removed, delete this crate outright — do **not** port it to Reborn, which
+//! already has its own callback transport, and do **not** add new consumers.
 
 use std::collections::HashMap;
 use std::time::Duration;


### PR DESCRIPTION
## Summary

`ironclaw_oauth`'s crate-level doc comment claimed it is *"Shared OAuth callback infrastructure used by **every** IronClaw OAuth flow."* That is stale — the Reborn stack does **not** use this crate.

`ironclaw_oauth` is only a **v1 loopback callback transport**: a fixed-port (`127.0.0.1:9876`) `TcpListener` that blocks a single in-process flow and serves a branded landing page. Reborn instead receives OAuth callbacks on **durable gateway HTTP routes** (`/api/reborn/product-auth/oauth/callback/{flow_id}`, in `ironclaw_reborn_composition::product_auth_serve`) with persisted, multi-tenant flow state — fundamentally incompatible with a single-flow fixed-port loopback listener. `ironclaw_llm` doesn't depend on it either; the sole consumer is the root v1 `ironclaw` binary.

## Changes (docs only)

- **`src/lib.rs`** — rewrite the header: scope it to the v1 stack, add a *"Not used by Reborn"* section explaining the callback-model mismatch, and a **`## DELETE WITH V1`** note (remove the crate when `src/` goes; don't port to Reborn; no new consumers).
- **`CLAUDE.md`** — sharpen the existing guardrail from *"retires — or gets adopted deliberately"* to an unambiguous **delete-with-v1** stance.

No code changes. Complements the `src/`-is-deprecated guidance already in the root `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)