### PR TITLE
[codex] fix exa mcp sse initialize parsing

### DIFF
--- a/crates/ironclaw_first_party_extensions/src/web_access.rs
+++ b/crates/ironclaw_first_party_extensions/src/web_access.rs
@@ -1346,13 +1346,17 @@ mod tests {
 
         fn ok_json(body: Value) -> RuntimeHttpEgressResponse {
             let bytes = serde_json::to_vec(&body).unwrap();
+            Self::ok_body(bytes, 20)
+        }
+
+        fn ok_body(body: Vec<u8>, response_bytes: u64) -> RuntimeHttpEgressResponse {
             RuntimeHttpEgressResponse {
                 status: 200,
                 headers: Vec::new(),
-                body: bytes,
+                body,
                 saved_body: None,
                 request_bytes: 10,
-                response_bytes: 20,
+                response_bytes,
                 redaction_applied: false,
             }
         }
@@ -1360,15 +1364,8 @@ mod tests {
         fn ok_sse_json(body: Value) -> RuntimeHttpEgressResponse {
             let body = format!("event: message\ndata: {body}\n");
             let bytes = body.into_bytes();
-            RuntimeHttpEgressResponse {
-                status: 200,
-                headers: Vec::new(),
-                response_bytes: bytes.len() as u64,
-                body: bytes,
-                saved_body: None,
-                request_bytes: 10,
-                redaction_applied: false,
-            }
+            let response_bytes = bytes.len() as u64;
+            Self::ok_body(bytes, response_bytes)
         }
 
         fn ok_sse_data_lines(lines: &[&str]) -> RuntimeHttpEgressResponse {
@@ -1380,15 +1377,8 @@ mod tests {
             }
             body.push('\n');
             let bytes = body.into_bytes();
-            RuntimeHttpEgressResponse {
-                status: 200,
-                headers: Vec::new(),
-                response_bytes: bytes.len() as u64,
-                body: bytes,
-                saved_body: None,
-                request_bytes: 10,
-                redaction_applied: false,
-            }
+            let response_bytes = bytes.len() as u64;
+            Self::ok_body(bytes, response_bytes)
         }
 
         fn accepted() -> RuntimeHttpEgressResponse {
@@ -1918,18 +1908,15 @@ data: }
         );
     }
 
-    #[tokio::test]
-    async fn get_content_accepts_sse_mcp_initialize_response() {
+    async fn assert_get_content_accepts_initialize_response(
+        initialize_response: RuntimeHttpEgressResponse,
+    ) {
         let executor = WebAccessExecutor::default();
         let capability = capability_id(WEB_GET_CONTENT_CAPABILITY_ID);
         let scope = scope();
         let input = json!({"url":"https://example.com", "max_characters": 1000});
         let egress = Arc::new(RecordingEgress::with_responses(vec![
-            Ok(RecordingEgress::ok_sse_json(json!({
-                "jsonrpc": "2.0",
-                "id": 1,
-                "result": {"protocolVersion": "2024-11-05", "capabilities": {}}
-            }))),
+            Ok(initialize_response),
             Ok(RecordingEgress::accepted()),
             Ok(RecordingEgress::ok_json(json!({
                 "result": {"content": [{"type": "text", "text": "# Example Domain\nURL: https://example.com\n\nExample body"}]}
@@ -1953,39 +1940,27 @@ data: }
     }
 
     #[tokio::test]
+    async fn get_content_accepts_sse_mcp_initialize_response() {
+        let initialize_response = RecordingEgress::ok_sse_json(json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {"protocolVersion": "2024-11-05", "capabilities": {}}
+        }));
+
+        assert_get_content_accepts_initialize_response(initialize_response).await;
+    }
+
+    #[tokio::test]
     async fn get_content_accepts_split_data_sse_mcp_initialize_response() {
-        let executor = WebAccessExecutor::default();
-        let capability = capability_id(WEB_GET_CONTENT_CAPABILITY_ID);
-        let scope = scope();
-        let input = json!({"url":"https://example.com", "max_characters": 1000});
-        let egress = Arc::new(RecordingEgress::with_responses(vec![
-            Ok(RecordingEgress::ok_sse_data_lines(&[
-                "{",
-                r#""jsonrpc": "2.0","#,
-                r#""id": 1,"#,
-                r#""result": {"protocolVersion": "2024-11-05", "capabilities": {}}"#,
-                "}",
-            ])),
-            Ok(RecordingEgress::accepted()),
-            Ok(RecordingEgress::ok_json(json!({
-                "result": {"content": [{"type": "text", "text": "# Example Domain\nURL: https://example.com\n\nExample body"}]}
-            }))),
-        ]));
+        let initialize_response = RecordingEgress::ok_sse_data_lines(&[
+            "{",
+            r#""jsonrpc": "2.0","#,
+            r#""id": 1,"#,
+            r#""result": {"protocolVersion": "2024-11-05", "capabilities": {}}"#,
+            "}",
+        ]);
 
-        let result = executor
-            .dispatch(request(
-                &capability,
-                &scope,
-                &input,
-                Some(egress.clone() as Arc<dyn RuntimeHttpEgress>),
-            ))
-            .await
-            .unwrap();
-
-        assert_eq!(result.output["provider_used"], "exa_mcp");
-        assert_eq!(result.output["url"], "https://example.com");
-        assert_eq!(result.output["content"], "Example body");
-        assert_eq!(egress.request_bodies().len(), 3);
+        assert_get_content_accepts_initialize_response(initialize_response).await;
     }
 
     #[tokio::test]

--- a/crates/ironclaw_first_party_extensions/src/web_access.rs
+++ b/crates/ironclaw_first_party_extensions/src/web_access.rs
@@ -552,10 +552,28 @@ fn mcp_initialize_params() -> Value {
 }
 
 fn is_valid_mcp_initialize_response(body: &[u8]) -> bool {
-    let Ok(value) = serde_json::from_slice::<Value>(body) else {
+    let Some(value) = mcp_json_value_from_body(body) else {
         return false;
     };
     value.get("error").is_none() && value.get("result").is_some_and(Value::is_object)
+}
+
+fn mcp_json_value_from_body(body: &[u8]) -> Option<Value> {
+    if let Ok(value) = serde_json::from_slice::<Value>(body) {
+        return Some(value);
+    }
+
+    let body = std::str::from_utf8(body).ok()?;
+    for line in body.lines().filter_map(|line| line.strip_prefix("data:")) {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        if let Ok(value) = serde_json::from_str::<Value>(line) {
+            return Some(value);
+        }
+    }
+    None
 }
 
 async fn call_exa_mcp_search(
@@ -1318,6 +1336,20 @@ mod tests {
             }
         }
 
+        fn ok_sse_json(body: Value) -> RuntimeHttpEgressResponse {
+            let body = format!("event: message\ndata: {body}\n");
+            let bytes = body.into_bytes();
+            RuntimeHttpEgressResponse {
+                status: 200,
+                headers: Vec::new(),
+                response_bytes: bytes.len() as u64,
+                body: bytes,
+                saved_body: None,
+                request_bytes: 10,
+                redaction_applied: false,
+            }
+        }
+
         fn accepted() -> RuntimeHttpEgressResponse {
             RuntimeHttpEgressResponse {
                 status: 202,
@@ -1386,6 +1418,14 @@ data: {"result":{"content":[{"type":"text","text":"Title: Example\nURL: https://
             extract_mcp_text(body).as_deref(),
             Some("Title: Example\nURL: https://example.com\nText: Body")
         );
+    }
+
+    #[test]
+    fn validates_sse_mcp_initialize_response() {
+        let body = br#"event: message
+data: {"result":{"protocolVersion":"2024-11-05","capabilities":{}},"jsonrpc":"2.0","id":1}
+"#;
+        assert!(is_valid_mcp_initialize_response(body));
     }
 
     #[test]
@@ -1819,6 +1859,40 @@ data: {"result":{"content":[{"type":"text","text":"Title: Example\nURL: https://
             request_bodies[2]["params"]["arguments"]["maxCharacters"],
             1000
         );
+    }
+
+    #[tokio::test]
+    async fn get_content_accepts_sse_mcp_initialize_response() {
+        let executor = WebAccessExecutor::default();
+        let capability = capability_id(WEB_GET_CONTENT_CAPABILITY_ID);
+        let scope = scope();
+        let input = json!({"url":"https://example.com", "max_characters": 1000});
+        let egress = Arc::new(RecordingEgress::with_responses(vec![
+            Ok(RecordingEgress::ok_sse_json(json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": {"protocolVersion": "2024-11-05", "capabilities": {}}
+            }))),
+            Ok(RecordingEgress::accepted()),
+            Ok(RecordingEgress::ok_json(json!({
+                "result": {"content": [{"type": "text", "text": "# Example Domain\nURL: https://example.com\n\nExample body"}]}
+            }))),
+        ]));
+
+        let result = executor
+            .dispatch(request(
+                &capability,
+                &scope,
+                &input,
+                Some(egress.clone() as Arc<dyn RuntimeHttpEgress>),
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(result.output["provider_used"], "exa_mcp");
+        assert_eq!(result.output["url"], "https://example.com");
+        assert_eq!(result.output["content"], "Example body");
+        assert_eq!(egress.request_bodies().len(), 3);
     }
 
     #[tokio::test]

--- a/crates/ironclaw_first_party_extensions/src/web_access.rs
+++ b/crates/ironclaw_first_party_extensions/src/web_access.rs
@@ -1,3 +1,4 @@
+// arch-exempt: large_file, web-access Exa SSE regression coverage stays with this tool harness, plan #5573
 use std::{
     collections::{HashMap, HashSet, VecDeque},
     net::IpAddr,
@@ -564,16 +565,36 @@ fn mcp_json_value_from_body(body: &[u8]) -> Option<Value> {
     }
 
     let body = std::str::from_utf8(body).ok()?;
-    for line in body.lines().filter_map(|line| line.strip_prefix("data:")) {
-        let line = line.trim();
+    let mut event_data = String::new();
+    for line in body.lines() {
         if line.is_empty() {
+            if let Some(value) = mcp_json_value_from_sse_event(&event_data) {
+                return Some(value);
+            }
+            event_data.clear();
             continue;
         }
-        if let Ok(value) = serde_json::from_str::<Value>(line) {
-            return Some(value);
+
+        let Some(data) = line.strip_prefix("data:") else {
+            continue;
+        };
+        let data = data.trim_start();
+        if data.is_empty() {
+            continue;
         }
+        if !event_data.is_empty() {
+            event_data.push('\n');
+        }
+        event_data.push_str(data);
     }
-    None
+    mcp_json_value_from_sse_event(&event_data)
+}
+
+fn mcp_json_value_from_sse_event(data: &str) -> Option<Value> {
+    if data.trim().is_empty() {
+        return None;
+    }
+    serde_json::from_str::<Value>(data).ok()
 }
 
 async fn call_exa_mcp_search(
@@ -1350,6 +1371,26 @@ mod tests {
             }
         }
 
+        fn ok_sse_data_lines(lines: &[&str]) -> RuntimeHttpEgressResponse {
+            let mut body = String::from("event: message\n");
+            for line in lines {
+                body.push_str("data: ");
+                body.push_str(line);
+                body.push('\n');
+            }
+            body.push('\n');
+            let bytes = body.into_bytes();
+            RuntimeHttpEgressResponse {
+                status: 200,
+                headers: Vec::new(),
+                response_bytes: bytes.len() as u64,
+                body: bytes,
+                saved_body: None,
+                request_bytes: 10,
+                redaction_applied: false,
+            }
+        }
+
         fn accepted() -> RuntimeHttpEgressResponse {
             RuntimeHttpEgressResponse {
                 status: 202,
@@ -1424,6 +1465,22 @@ data: {"result":{"content":[{"type":"text","text":"Title: Example\nURL: https://
     fn validates_sse_mcp_initialize_response() {
         let body = br#"event: message
 data: {"result":{"protocolVersion":"2024-11-05","capabilities":{}},"jsonrpc":"2.0","id":1}
+"#;
+        assert!(is_valid_mcp_initialize_response(body));
+    }
+
+    #[test]
+    fn validates_split_data_sse_mcp_initialize_response() {
+        let body = br#"event: message
+data: {
+data:   "result": {
+data:     "protocolVersion": "2024-11-05",
+data:     "capabilities": {}
+data:   },
+data:   "jsonrpc": "2.0",
+data:   "id": 1
+data: }
+
 "#;
         assert!(is_valid_mcp_initialize_response(body));
     }
@@ -1873,6 +1930,42 @@ data: {"result":{"protocolVersion":"2024-11-05","capabilities":{}},"jsonrpc":"2.
                 "id": 1,
                 "result": {"protocolVersion": "2024-11-05", "capabilities": {}}
             }))),
+            Ok(RecordingEgress::accepted()),
+            Ok(RecordingEgress::ok_json(json!({
+                "result": {"content": [{"type": "text", "text": "# Example Domain\nURL: https://example.com\n\nExample body"}]}
+            }))),
+        ]));
+
+        let result = executor
+            .dispatch(request(
+                &capability,
+                &scope,
+                &input,
+                Some(egress.clone() as Arc<dyn RuntimeHttpEgress>),
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(result.output["provider_used"], "exa_mcp");
+        assert_eq!(result.output["url"], "https://example.com");
+        assert_eq!(result.output["content"], "Example body");
+        assert_eq!(egress.request_bodies().len(), 3);
+    }
+
+    #[tokio::test]
+    async fn get_content_accepts_split_data_sse_mcp_initialize_response() {
+        let executor = WebAccessExecutor::default();
+        let capability = capability_id(WEB_GET_CONTENT_CAPABILITY_ID);
+        let scope = scope();
+        let input = json!({"url":"https://example.com", "max_characters": 1000});
+        let egress = Arc::new(RecordingEgress::with_responses(vec![
+            Ok(RecordingEgress::ok_sse_data_lines(&[
+                "{",
+                r#""jsonrpc": "2.0","#,
+                r#""id": 1,"#,
+                r#""result": {"protocolVersion": "2024-11-05", "capabilities": {}}"#,
+                "}",
+            ])),
             Ok(RecordingEgress::accepted()),
             Ok(RecordingEgress::ok_json(json!({
                 "result": {"content": [{"type": "text", "text": "# Example Domain\nURL: https://example.com\n\nExample body"}]}


### PR DESCRIPTION
## Summary
- accept raw JSON and SSE-wrapped JSON-RPC bodies when validating Exa MCP initialize responses
- reconstruct multi-line SSE `data:` events before parsing the JSON-RPC payload
- add helper-level and `get_content` caller-level regression coverage

## Change Type
Bug fix

## Linked Issue
None. Regression from #5534; fix tracked in #5573.

## Root Cause
PR #5534 tightened MCP initialize validation to parse only raw JSON. Exa currently returns initialize as Server-Sent Events with the JSON-RPC payload in `data:` lines, so `exa_websearch` and `get_content` failed before reaching `tools/call` with `OutputDecode`.

## Security Impact
Low. This only broadens MCP initialize parsing to valid SSE framing from the existing Exa endpoint. The initialize response still has to validate as JSON-RPC with a result object, and existing network egress/body limits remain unchanged.

## Database Impact
None.

## Blast Radius
Limited to first-party `web-access.search` and `web-access.get_content` Exa MCP initialize parsing.

## Rollback Plan
Revert this PR. That restores the previous strict raw-JSON initialize parser, but it also reintroduces the Exa SSE `OutputDecode` regression.

## Review Follow-Through
- Addressed the CodeRabbit inline comment by buffering a full SSE event across consecutive `data:` lines before JSON parsing.
- Added split-`data:` helper coverage and caller-level `get_content` regression coverage.
- Added the required large-file safety exemption tied to #5573 because the regression tests belong in the existing web-access harness.

## Review track
Correctness / first-party web-access regression fix.

## Validation
- `cargo fmt --check`
- `CARGO_TARGET_DIR=/Users/firatsertgoz/.codex/worktrees/e801/ironclaw/target cargo test -p ironclaw_first_party_extensions split_data_sse_mcp_initialize_response`
- `CARGO_TARGET_DIR=/Users/firatsertgoz/.codex/worktrees/e801/ironclaw/target cargo test -p ironclaw_first_party_extensions web_access::tests`
- `CARGO_TARGET_DIR=/Users/firatsertgoz/.codex/worktrees/e801/ironclaw/target cargo clippy -p ironclaw_first_party_extensions --all-targets --all-features -- -D warnings`
- `bash scripts/pre-commit-safety.sh`
- `git diff --check`