### PR TITLE
perf(reborn): step-efficient tool guidance — script-first + smaller output cap

### DIFF
--- a/crates/ironclaw_first_party_extensions/src/coding/file.rs
+++ b/crates/ironclaw_first_party_extensions/src/coding/file.rs
@@ -149,7 +149,10 @@ fn read_file_continuation_notice(
     next_offset: usize,
 ) -> String {
     format!(
-        "[Showing lines {}-{} of {} ({} limit). Use offset={} to continue.]",
+        "[Showing lines {}-{} of {} ({} limit). This file is large: to analyze, summarize, or \
+         count over it, run ONE shell command or script (grep/awk/python) over the whole file and \
+         read only the computed result — do NOT page through it (offset={}) and reason over it in \
+         context, which is slow and costly.]",
         start_line + 1,
         last_line_shown,
         total_lines,

--- a/crates/ironclaw_host_runtime/src/first_party_tools/schemas.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/schemas.rs
@@ -149,7 +149,7 @@ pub(crate) fn resolve_builtin_input_schema_ref(reference: &str) -> Option<Value>
         "schemas/builtin/shell.input.v1.json" => json!({
             "type": "object",
             "properties": {
-                "command": { "type": "string", "description": "Shell command to execute" },
+                "command": { "type": "string", "description": "Shell command to execute. Prefer ONE command that does the whole job: combine steps with '&&' or pipes, or write and run a single script (awk/python) — do NOT issue one command per metric/day/line, and don't re-read files you already have." },
                 "workdir": { "type": "string", "description": "Optional scoped working directory" },
                 "timeout": { "type": "integer", "minimum": 1, "description": "Timeout in seconds" }
             },

--- a/crates/ironclaw_host_runtime/src/process_output.rs
+++ b/crates/ironclaw_host_runtime/src/process_output.rs
@@ -12,7 +12,13 @@ use uuid::Uuid;
 use crate::{RuntimeProcessError, sandbox_process::RebornSandboxScopeKey};
 
 /// Maximum model-facing process output preview before middle truncation.
-pub(crate) const COMMAND_MAX_OUTPUT_SIZE: usize = 64 * 1024;
+///
+/// Lowered 64KB -> 16KB: shell/command output is fresh (non-cached) prompt
+/// tokens re-sent on every subsequent turn, so oversized previews dominate cost
+/// on data/log tasks. 16KB keeps enough head+tail context for the model to act
+/// on (full output is still saved and referenceable) while cutting the per-turn
+/// cost of large results. Measured no accuracy regression on data tasks.
+pub(crate) const COMMAND_MAX_OUTPUT_SIZE: usize = 16 * 1024;
 const COMMAND_PREVIEW_HALF_SIZE: usize = COMMAND_MAX_OUTPUT_SIZE / 2;
 const COMMAND_MAX_SAVED_STREAM_SIZE: usize = 16 * 1024 * 1024;
 const COMMAND_OUTPUT_RETENTION: Duration = Duration::from_secs(24 * 60 * 60);

--- a/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
@@ -6488,7 +6488,9 @@ async fn read_file_enforces_byte_budget_on_long_lines_and_offers_continuation() 
     );
     let next = read["next_offset"].as_u64().unwrap();
     assert_eq!(next, shown + 1);
-    assert!(content.contains(&format!("Use offset={next} to continue")));
+    assert!(content.contains("run ONE shell command or script"));
+    assert!(content.contains("do NOT page through it"));
+    assert!(content.contains(&format!("offset={next}")));
 
     // Resuming from next_offset advances past the already-shown lines.
     let resumed = invoke_with_context(


### PR DESCRIPTION
## Problem

On data/log-analysis tasks in PinchBench (deepseek-v4-flash / OpenRouter), reborn does the analysis **in the model loop** instead of in code — it chunk-reads files and runs **one shell command per metric**, racking up **50–99 tool calls** on a single task. Because every tool call re-sends the whole growing transcript, those tasks dominate cost (80–99 calls ≈ 80× the fixed per-call context).

Examples (before this change):
- `log_apache_timeline`: **99 tool calls** — `grep -c 'Jun 09'`, `grep -c 'Jun 10'`, … one grep per day.
- `log_apache_error_summary`: **82 calls** — one metric per shell.
- `selector_fix`: **66 calls** — 26 single `apply_patch` + re-reading the same files ~18×.

## Changes (behavioral steering; tool mechanics unchanged except the output cap)

1. **`read_file` truncation notice** (`coding/file.rs`) — the old *"Use offset= to continue"* trained pagination. Reworded to steer large-file work to **one script/command over the whole file**, reading only the computed result.
2. **`shell` `command` description** (`first_party_tools/schemas.rs`) — was *"Shell command to execute"*. Now: prefer **one command/script** (`&&`/pipes), don't issue one command per metric/day/line, don't re-read files already held.
3. **`COMMAND_MAX_OUTPUT_SIZE` 64KB → 16KB** (`process_output.rs`) — shell output is fresh (non-cached) prompt tokens re-sent every turn; 16KB keeps enough head+tail context (full output still saved/referenceable) while cutting the per-turn cost of large results.

## Results — reborn before → after (PinchBench, deepseek-v4-flash / OpenRouter, fair cache accounting)

Worst tasks:

| task | tool calls | cost | score |
|---|---|---|---|
| log_apache_error_summary | 82 → **15** | $0.186 → **$0.025** | 1.00 → 1.00 |
| log_apache_timeline | 99 → **18** | $0.093 → **$0.025** | 1.00 → 1.00 |
| events | 50 → **7** | $0.074 → **$0.012** | 0.82 → **0.90** |
| log_hdfs_slow_ops | 20 → **13** | $0.110 → **$0.022** | 0.90 → 0.90 |
| selector_fix | 66 → **37** | $0.072 → **$0.039** | 0.79 → **0.82** |
| **total (6)** | — | **$0.608 → $0.161 (−73%)** | held / improved |

Full suite (147 tasks): **total cost −26%**, avg_score held/up (**0.875 → 0.898**), total tool calls down (deepseek stops looping on the data/log tasks). No accuracy regression.

## Also tried, excluded
Pruning the LocalDevYolo capability policy 35→14 tools — only ~2% in bridged mode (it only shrinks the tool_search catalog, not the per-call advertised tools) and it removes user-facing capabilities, so not worth it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)