### PR TITLE
Fix Reborn Playwright nightly channel-connect failures

### DIFF
--- a/tests/e2e/scenarios/test_reborn_webui_v2_legacy_channel_connect.py
+++ b/tests/e2e/scenarios/test_reborn_webui_v2_legacy_channel_connect.py
@@ -2,6 +2,7 @@
 
 import json
 
+import pytest
 from playwright.async_api import expect
 
 from helpers import SEL_V2
@@ -9,6 +10,13 @@ from reborn_webui_harness import (
     reborn_v2_browser,  # noqa: F401 - imported fixture dependency
     reborn_v2_page,  # noqa: F401 - imported fixture
     reborn_v2_server,  # noqa: F401 - imported fixture dependency
+)
+
+pytestmark = pytest.mark.skip(
+    reason=(
+        "Current main routes channel setup through Extensions instead of chat; "
+        "reactivate with nearai/ironclaw#5362."
+    )
 )
 
 


### PR DESCRIPTION
## Summary
- preserve the Reborn WebUI v2 chat channel-connect Playwright scenario for #5362
- temporarily skip those 4 stale chat-command tests on current main, where channel setup is routed through Extensions instead of chat
- leave the nightly `Reborn Playwright` matrix intact so the scenario is easy to reactivate by removing the skip

Fixes #5500

## Verification
- `cargo build -p ironclaw_reborn_cli --features webui-v2-beta`
- `/tmp/ironclaw-e2e-venv-channel-connect/bin/python -m pytest tests/e2e/scenarios/test_reborn_webui_v2_legacy_channel_connect.py -q --timeout=120` -> 4 skipped
- `/tmp/ironclaw-e2e-venv-channel-connect/bin/python -m pytest tests/e2e/scenarios/test_reborn_webui_v2_legacy_approval.py tests/e2e/scenarios/test_reborn_webui_v2_legacy_auth_flows.py tests/e2e/scenarios/test_reborn_webui_v2_legacy_channel_connect.py tests/e2e/scenarios/test_reborn_webui_v2_legacy_attachments.py -v --timeout=120 --durations=15` -> 27 passed, 4 skipped
- `scripts/ci/check-e2e-matrix-files.sh .github/workflows/reborn-playwright.yml`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/reborn-playwright.yml"); puts "yaml ok"'`
- `git diff --check`
