### PR TITLE
fix(reborn): keep terminal shortcut clear of chat composer

### DIFF
--- a/crates/ironclaw_webui_v2/static/js/pages/chat/components/message-list.js
+++ b/crates/ironclaw_webui_v2/static/js/pages/chat/components/message-list.js
@@ -8,16 +8,18 @@ import { groupMessages } from "../lib/message-groups.js";
 
 export const BOTTOM_FOLLOW_THRESHOLD_PX = 100;
 const TOP_LOAD_THRESHOLD_PX = 100;
-const FLOATING_CONTROL_OFFSET_PX = 128;
+// Keep transcript-floating controls above the composer. The spacer mirrors the
+// offset plus the icon control size so the final message can scroll above them.
+const FLOATING_CONTROL_BOTTOM_OFFSET_PX = 128;
 const FLOATING_CONTROL_SIZE_PX = 36;
-const FLOATING_CONTROL_OFFSET_CLASS = `bottom-[${FLOATING_CONTROL_OFFSET_PX}px]`;
-const FLOATING_CONTROL_SPACER_CLASS = `h-[${
-  FLOATING_CONTROL_OFFSET_PX + FLOATING_CONTROL_SIZE_PX
-}px]`;
+const FLOATING_CONTROL_SPACER_HEIGHT_PX =
+  FLOATING_CONTROL_BOTTOM_OFFSET_PX + FLOATING_CONTROL_SIZE_PX;
+const FLOATING_CONTROL_STYLE = { bottom: FLOATING_CONTROL_BOTTOM_OFFSET_PX };
+const FLOATING_CONTROL_SPACER_STYLE = { height: FLOATING_CONTROL_SPACER_HEIGHT_PX };
 const FLOATING_LOGS_BUTTON_CLASS =
-  `group absolute ${FLOATING_CONTROL_OFFSET_CLASS} right-5 inline-flex size-9 items-center justify-center gap-0 overflow-hidden rounded-full border border-[color-mix(in_srgb,var(--v2-accent)_28%,var(--v2-panel-border))] bg-[color-mix(in_srgb,var(--v2-surface)_88%,var(--v2-accent)_12%)] text-xs font-semibold text-[var(--v2-text-base)] shadow-[0_14px_34px_-18px_rgba(0,0,0,0.95),0_0_0_1px_rgba(255,255,255,0.04)] backdrop-blur-md transition-all hover:border-[color-mix(in_srgb,var(--v2-accent)_50%,var(--v2-panel-border))] hover:bg-[color-mix(in_srgb,var(--v2-surface-muted)_82%,var(--v2-accent)_18%)] hover:text-[var(--v2-text-strong)] focus:outline-none focus:ring-2 focus:ring-[color-mix(in_srgb,var(--v2-accent)_42%,transparent)]`;
+  "group absolute right-5 inline-flex size-9 items-center justify-center gap-0 overflow-hidden rounded-full border border-[color-mix(in_srgb,var(--v2-accent)_28%,var(--v2-panel-border))] bg-[color-mix(in_srgb,var(--v2-surface)_88%,var(--v2-accent)_12%)] text-xs font-semibold text-[var(--v2-text-base)] shadow-[0_14px_34px_-18px_rgba(0,0,0,0.95),0_0_0_1px_rgba(255,255,255,0.04)] backdrop-blur-md transition-all hover:border-[color-mix(in_srgb,var(--v2-accent)_50%,var(--v2-panel-border))] hover:bg-[color-mix(in_srgb,var(--v2-surface-muted)_82%,var(--v2-accent)_18%)] hover:text-[var(--v2-text-strong)] focus:outline-none focus:ring-2 focus:ring-[color-mix(in_srgb,var(--v2-accent)_42%,transparent)]";
 const JUMP_TO_BOTTOM_BUTTON_CLASS =
-  `absolute ${FLOATING_CONTROL_OFFSET_CLASS} left-1/2 inline-flex -translate-x-1/2 items-center gap-1.5 rounded-full border border-[var(--v2-panel-border)] bg-[var(--v2-surface)] px-3 py-1.5 text-xs font-medium text-[var(--v2-text-strong)] shadow-[0_10px_30px_-12px_rgba(0,0,0,0.7)] hover:border-[color-mix(in_srgb,var(--v2-accent)_40%,var(--v2-panel-border))]`;
+  "absolute left-1/2 inline-flex -translate-x-1/2 items-center gap-1.5 rounded-full border border-[var(--v2-panel-border)] bg-[var(--v2-surface)] px-3 py-1.5 text-xs font-medium text-[var(--v2-text-strong)] shadow-[0_10px_30px_-12px_rgba(0,0,0,0.7)] hover:border-[color-mix(in_srgb,var(--v2-accent)_40%,var(--v2-panel-border))]";
 
 export function distanceFromBottom(el) {
   if (!el) return Number.POSITIVE_INFINITY;
@@ -222,7 +224,7 @@ export function MessageList({
   const grouped = React.useMemo(() => groupMessages(messages), [messages]);
 
   return html`
-    <div className="relative flex min-h-0 min-w-0 flex-1 overflow-hidden">
+    <div className="relative flex min-h-0 min-w-0 flex-1">
     <div
       ref=${containerRef}
       onScroll=${onScroll}
@@ -265,7 +267,11 @@ export function MessageList({
         )}
         ${children}
         ${logsPath &&
-        html`<div aria-hidden="true" className=${`${FLOATING_CONTROL_SPACER_CLASS} shrink-0`} />`}
+        html`<div
+          aria-hidden="true"
+          className="shrink-0"
+          style=${FLOATING_CONTROL_SPACER_STYLE}
+        />`}
       </div>
     </div>
     ${logsPath &&
@@ -275,6 +281,7 @@ export function MessageList({
         aria-label=${t("nav.logs")}
         title=${t("nav.logs")}
         className=${FLOATING_LOGS_BUTTON_CLASS}
+        style=${FLOATING_CONTROL_STYLE}
       >
         <${Icon} name="logs" className="size-5" />
       <//>
@@ -286,6 +293,7 @@ export function MessageList({
         onClick=${jumpToBottom}
         aria-label=${t("chat.jumpToLatest")}
         className=${JUMP_TO_BOTTOM_BUTTON_CLASS}
+        style=${FLOATING_CONTROL_STYLE}
       >
         <${Icon} name="arrowDown" className="h-3.5 w-3.5" />
         ${t("chat.jumpToLatest")}

--- a/crates/ironclaw_webui_v2/static/js/pages/chat/components/message-list.js
+++ b/crates/ironclaw_webui_v2/static/js/pages/chat/components/message-list.js
@@ -9,7 +9,7 @@ import { groupMessages } from "../lib/message-groups.js";
 export const BOTTOM_FOLLOW_THRESHOLD_PX = 100;
 const TOP_LOAD_THRESHOLD_PX = 100;
 const FLOATING_LOGS_BUTTON_CLASS =
-  "group absolute bottom-5 right-5 inline-flex size-9 items-center justify-center gap-0 overflow-hidden rounded-full border border-[color-mix(in_srgb,var(--v2-accent)_28%,var(--v2-panel-border))] bg-[color-mix(in_srgb,var(--v2-surface)_88%,var(--v2-accent)_12%)] text-xs font-semibold text-[var(--v2-text-base)] shadow-[0_14px_34px_-18px_rgba(0,0,0,0.95),0_0_0_1px_rgba(255,255,255,0.04)] backdrop-blur-md transition-all hover:border-[color-mix(in_srgb,var(--v2-accent)_50%,var(--v2-panel-border))] hover:bg-[color-mix(in_srgb,var(--v2-surface-muted)_82%,var(--v2-accent)_18%)] hover:text-[var(--v2-text-strong)] focus:outline-none focus:ring-2 focus:ring-[color-mix(in_srgb,var(--v2-accent)_42%,transparent)]";
+  "group absolute bottom-32 right-5 inline-flex size-9 items-center justify-center gap-0 overflow-hidden rounded-full border border-[color-mix(in_srgb,var(--v2-accent)_28%,var(--v2-panel-border))] bg-[color-mix(in_srgb,var(--v2-surface)_88%,var(--v2-accent)_12%)] text-xs font-semibold text-[var(--v2-text-base)] shadow-[0_14px_34px_-18px_rgba(0,0,0,0.95),0_0_0_1px_rgba(255,255,255,0.04)] backdrop-blur-md transition-all hover:border-[color-mix(in_srgb,var(--v2-accent)_50%,var(--v2-panel-border))] hover:bg-[color-mix(in_srgb,var(--v2-surface-muted)_82%,var(--v2-accent)_18%)] hover:text-[var(--v2-text-strong)] focus:outline-none focus:ring-2 focus:ring-[color-mix(in_srgb,var(--v2-accent)_42%,transparent)]";
 
 export function distanceFromBottom(el) {
   if (!el) return Number.POSITIVE_INFINITY;
@@ -214,7 +214,7 @@ export function MessageList({
   const grouped = React.useMemo(() => groupMessages(messages), [messages]);
 
   return html`
-    <div className="relative flex min-h-0 min-w-0 flex-1">
+    <div className="relative flex min-h-0 min-w-0 flex-1 overflow-hidden">
     <div
       ref=${containerRef}
       onScroll=${onScroll}
@@ -256,7 +256,7 @@ export function MessageList({
               />`
         )}
         ${children}
-        ${logsPath && html`<div aria-hidden="true" className="h-14 shrink-0" />`}
+        ${logsPath && html`<div aria-hidden="true" className="h-40 shrink-0" />`}
       </div>
     </div>
     ${logsPath &&

--- a/crates/ironclaw_webui_v2/static/js/pages/chat/components/message-list.js
+++ b/crates/ironclaw_webui_v2/static/js/pages/chat/components/message-list.js
@@ -8,8 +8,16 @@ import { groupMessages } from "../lib/message-groups.js";
 
 export const BOTTOM_FOLLOW_THRESHOLD_PX = 100;
 const TOP_LOAD_THRESHOLD_PX = 100;
+const FLOATING_CONTROL_OFFSET_PX = 128;
+const FLOATING_CONTROL_SIZE_PX = 36;
+const FLOATING_CONTROL_OFFSET_CLASS = `bottom-[${FLOATING_CONTROL_OFFSET_PX}px]`;
+const FLOATING_CONTROL_SPACER_CLASS = `h-[${
+  FLOATING_CONTROL_OFFSET_PX + FLOATING_CONTROL_SIZE_PX
+}px]`;
 const FLOATING_LOGS_BUTTON_CLASS =
-  "group absolute bottom-32 right-5 inline-flex size-9 items-center justify-center gap-0 overflow-hidden rounded-full border border-[color-mix(in_srgb,var(--v2-accent)_28%,var(--v2-panel-border))] bg-[color-mix(in_srgb,var(--v2-surface)_88%,var(--v2-accent)_12%)] text-xs font-semibold text-[var(--v2-text-base)] shadow-[0_14px_34px_-18px_rgba(0,0,0,0.95),0_0_0_1px_rgba(255,255,255,0.04)] backdrop-blur-md transition-all hover:border-[color-mix(in_srgb,var(--v2-accent)_50%,var(--v2-panel-border))] hover:bg-[color-mix(in_srgb,var(--v2-surface-muted)_82%,var(--v2-accent)_18%)] hover:text-[var(--v2-text-strong)] focus:outline-none focus:ring-2 focus:ring-[color-mix(in_srgb,var(--v2-accent)_42%,transparent)]";
+  `group absolute ${FLOATING_CONTROL_OFFSET_CLASS} right-5 inline-flex size-9 items-center justify-center gap-0 overflow-hidden rounded-full border border-[color-mix(in_srgb,var(--v2-accent)_28%,var(--v2-panel-border))] bg-[color-mix(in_srgb,var(--v2-surface)_88%,var(--v2-accent)_12%)] text-xs font-semibold text-[var(--v2-text-base)] shadow-[0_14px_34px_-18px_rgba(0,0,0,0.95),0_0_0_1px_rgba(255,255,255,0.04)] backdrop-blur-md transition-all hover:border-[color-mix(in_srgb,var(--v2-accent)_50%,var(--v2-panel-border))] hover:bg-[color-mix(in_srgb,var(--v2-surface-muted)_82%,var(--v2-accent)_18%)] hover:text-[var(--v2-text-strong)] focus:outline-none focus:ring-2 focus:ring-[color-mix(in_srgb,var(--v2-accent)_42%,transparent)]`;
+const JUMP_TO_BOTTOM_BUTTON_CLASS =
+  `absolute ${FLOATING_CONTROL_OFFSET_CLASS} left-1/2 inline-flex -translate-x-1/2 items-center gap-1.5 rounded-full border border-[var(--v2-panel-border)] bg-[var(--v2-surface)] px-3 py-1.5 text-xs font-medium text-[var(--v2-text-strong)] shadow-[0_10px_30px_-12px_rgba(0,0,0,0.7)] hover:border-[color-mix(in_srgb,var(--v2-accent)_40%,var(--v2-panel-border))]`;
 
 export function distanceFromBottom(el) {
   if (!el) return Number.POSITIVE_INFINITY;
@@ -256,7 +264,8 @@ export function MessageList({
               />`
         )}
         ${children}
-        ${logsPath && html`<div aria-hidden="true" className="h-40 shrink-0" />`}
+        ${logsPath &&
+        html`<div aria-hidden="true" className=${`${FLOATING_CONTROL_SPACER_CLASS} shrink-0`} />`}
       </div>
     </div>
     ${logsPath &&
@@ -276,7 +285,7 @@ export function MessageList({
         type="button"
         onClick=${jumpToBottom}
         aria-label=${t("chat.jumpToLatest")}
-        className="absolute bottom-4 left-1/2 inline-flex -translate-x-1/2 items-center gap-1.5 rounded-full border border-[var(--v2-panel-border)] bg-[var(--v2-surface)] px-3 py-1.5 text-xs font-medium text-[var(--v2-text-strong)] shadow-[0_10px_30px_-12px_rgba(0,0,0,0.7)] hover:border-[color-mix(in_srgb,var(--v2-accent)_40%,var(--v2-panel-border))]"
+        className=${JUMP_TO_BOTTOM_BUTTON_CLASS}
       >
         <${Icon} name="arrowDown" className="h-3.5 w-3.5" />
         ${t("chat.jumpToLatest")}

--- a/crates/ironclaw_webui_v2/static/js/pages/chat/components/message-list.js
+++ b/crates/ironclaw_webui_v2/static/js/pages/chat/components/message-list.js
@@ -10,6 +10,7 @@ export const BOTTOM_FOLLOW_THRESHOLD_PX = 100;
 const TOP_LOAD_THRESHOLD_PX = 100;
 // Keep transcript-floating controls above the composer. The spacer mirrors the
 // offset plus the icon control size so the final message can scroll above them.
+// FLOATING_CONTROL_SIZE_PX must stay in sync with the logs button's `size-9`.
 const FLOATING_CONTROL_BOTTOM_OFFSET_PX = 128;
 const FLOATING_CONTROL_SIZE_PX = 36;
 const FLOATING_CONTROL_SPACER_HEIGHT_PX =

--- a/crates/ironclaw_webui_v2/static/js/pages/chat/components/message-list.test.mjs
+++ b/crates/ironclaw_webui_v2/static/js/pages/chat/components/message-list.test.mjs
@@ -34,6 +34,11 @@ function messageListSourceForTest() {
   return `${lines.join("\n")}
 globalThis.__testExports = {
   BOTTOM_FOLLOW_THRESHOLD_PX,
+  FLOATING_CONTROL_BOTTOM_OFFSET_PX,
+  FLOATING_CONTROL_SIZE_PX,
+  FLOATING_CONTROL_SPACER_HEIGHT_PX,
+  FLOATING_CONTROL_STYLE,
+  FLOATING_CONTROL_SPACER_STYLE,
   distanceFromBottom,
   isNearBottom,
   scrollToBottom,
@@ -169,6 +174,14 @@ test("MessageList observes content growth from streamed markdown layout", () => 
 });
 
 test("MessageList renders a floating thread logs shortcut", () => {
+  const {
+    FLOATING_CONTROL_BOTTOM_OFFSET_PX,
+    FLOATING_CONTROL_SIZE_PX,
+    FLOATING_CONTROL_SPACER_HEIGHT_PX,
+    FLOATING_CONTROL_STYLE,
+    FLOATING_CONTROL_SPACER_STYLE,
+  } = loadHelpers();
+
   assert.match(
     messageListSource,
     /import \{ Link \} from "react-router";/,
@@ -191,32 +204,41 @@ test("MessageList renders a floating thread logs shortcut", () => {
   );
   assert.match(
     messageListSource,
-    /<div className="relative flex min-h-0 min-w-0 flex-1 overflow-hidden">/,
-    "floating logs control should be clipped to the transcript area, not the composer",
+    /<div className="relative flex min-h-0 min-w-0 flex-1">/,
+    "message-list should keep the transcript area as the floating-control anchor",
+  );
+  assert.doesNotMatch(
+    messageListSource,
+    /bottom-\[\$\{|h-\[\$\{|bottom-\[128px\]|h-\[164px\]/,
+    "floating controls should not rely on Tailwind generated arbitrary classes",
+  );
+  assert.equal(FLOATING_CONTROL_BOTTOM_OFFSET_PX, 128);
+  assert.equal(FLOATING_CONTROL_SIZE_PX, 36);
+  assert.equal(
+    FLOATING_CONTROL_SPACER_HEIGHT_PX,
+    FLOATING_CONTROL_BOTTOM_OFFSET_PX + FLOATING_CONTROL_SIZE_PX,
+    "spacer height should track the floating control offset plus control size",
+  );
+  assert.equal(FLOATING_CONTROL_STYLE.bottom, 128);
+  assert.equal(FLOATING_CONTROL_SPACER_STYLE.height, 164);
+  assert.match(
+    messageListSource,
+    /className="shrink-0"[\s\S]*style=\$\{FLOATING_CONTROL_SPACER_STYLE\}/,
+    "floating logs control should reserve style-driven end-of-content space to clear the composer",
   );
   assert.match(
     messageListSource,
-    /const FLOATING_CONTROL_OFFSET_PX = 128;[\s\S]*const FLOATING_CONTROL_SIZE_PX = 36;[\s\S]*const FLOATING_CONTROL_OFFSET_CLASS = `bottom-\[\$\{FLOATING_CONTROL_OFFSET_PX\}px\]`;[\s\S]*FLOATING_CONTROL_OFFSET_PX \+ FLOATING_CONTROL_SIZE_PX/,
-    "floating controls should share one numeric offset and spacer relationship",
-  );
-  assert.match(
-    messageListSource,
-    /className=\$\{`\$\{FLOATING_CONTROL_SPACER_CLASS\} shrink-0`\}/,
-    "floating logs control should reserve enough end-of-content space to clear the composer",
-  );
-  assert.match(
-    messageListSource,
-    /const FLOATING_LOGS_BUTTON_CLASS =[\s\S]*group absolute \$\{FLOATING_CONTROL_OFFSET_CLASS\} right-5[\s\S]*border-\[color-mix\(in_srgb,var\(--v2-accent\)_28%,var\(--v2-panel-border\)\)\][\s\S]*bg-\[color-mix\(in_srgb,var\(--v2-surface\)_88%,var\(--v2-accent\)_12%\)\]/,
+    /const FLOATING_LOGS_BUTTON_CLASS =[\s\S]*group absolute right-5[\s\S]*border-\[color-mix\(in_srgb,var\(--v2-accent\)_28%,var\(--v2-panel-border\)\)\][\s\S]*bg-\[color-mix\(in_srgb,var\(--v2-surface\)_88%,var\(--v2-accent\)_12%\)\]/,
     "floating logs button classes should live in a module-level constant",
   );
   assert.match(
     messageListSource,
-    /const JUMP_TO_BOTTOM_BUTTON_CLASS =[\s\S]*absolute \$\{FLOATING_CONTROL_OFFSET_CLASS\} left-1\/2[\s\S]*className=\$\{JUMP_TO_BOTTOM_BUTTON_CLASS\}/,
-    "jump-to-latest should use the same composer-safe offset as the floating logs control",
+    /<\$\{Link\}\s+to=\$\{logsPath\}[\s\S]*className=\$\{FLOATING_LOGS_BUTTON_CLASS\}[\s\S]*style=\$\{FLOATING_CONTROL_STYLE\}[\s\S]*<\$\{Icon\} name="logs"/,
+    "thread logs shortcut should render as a visible bottom-right icon button",
   );
   assert.match(
     messageListSource,
-    /<\$\{Link\}\s+to=\$\{logsPath\}[\s\S]*className=\$\{FLOATING_LOGS_BUTTON_CLASS\}[\s\S]*<\$\{Icon\} name="logs"/,
-    "thread logs shortcut should render as a visible bottom-right icon button",
+    /const JUMP_TO_BOTTOM_BUTTON_CLASS =[\s\S]*absolute left-1\/2[\s\S]*className=\$\{JUMP_TO_BOTTOM_BUTTON_CLASS\}[\s\S]*style=\$\{FLOATING_CONTROL_STYLE\}/,
+    "jump-to-latest should use the same composer-safe offset as the floating logs control",
   );
 });

--- a/crates/ironclaw_webui_v2/static/js/pages/chat/components/message-list.test.mjs
+++ b/crates/ironclaw_webui_v2/static/js/pages/chat/components/message-list.test.mjs
@@ -191,12 +191,17 @@ test("MessageList renders a floating thread logs shortcut", () => {
   );
   assert.match(
     messageListSource,
-    /\$\{logsPath && html`<div aria-hidden="true" className="h-14 shrink-0" \/>`\}/,
-    "floating logs control should reserve space with an end-of-content spacer",
+    /<div className="relative flex min-h-0 min-w-0 flex-1 overflow-hidden">/,
+    "floating logs control should be clipped to the transcript area, not the composer",
   );
   assert.match(
     messageListSource,
-    /const FLOATING_LOGS_BUTTON_CLASS =[\s\S]*group absolute bottom-5 right-5[\s\S]*border-\[color-mix\(in_srgb,var\(--v2-accent\)_28%,var\(--v2-panel-border\)\)\][\s\S]*bg-\[color-mix\(in_srgb,var\(--v2-surface\)_88%,var\(--v2-accent\)_12%\)\]/,
+    /\$\{logsPath && html`<div aria-hidden="true" className="h-40 shrink-0" \/>`\}/,
+    "floating logs control should reserve enough end-of-content space to clear the composer",
+  );
+  assert.match(
+    messageListSource,
+    /const FLOATING_LOGS_BUTTON_CLASS =[\s\S]*group absolute bottom-32 right-5[\s\S]*border-\[color-mix\(in_srgb,var\(--v2-accent\)_28%,var\(--v2-panel-border\)\)\][\s\S]*bg-\[color-mix\(in_srgb,var\(--v2-surface\)_88%,var\(--v2-accent\)_12%\)\]/,
     "floating logs button classes should live in a module-level constant",
   );
   assert.match(

--- a/crates/ironclaw_webui_v2/static/js/pages/chat/components/message-list.test.mjs
+++ b/crates/ironclaw_webui_v2/static/js/pages/chat/components/message-list.test.mjs
@@ -196,13 +196,23 @@ test("MessageList renders a floating thread logs shortcut", () => {
   );
   assert.match(
     messageListSource,
-    /\$\{logsPath && html`<div aria-hidden="true" className="h-40 shrink-0" \/>`\}/,
+    /const FLOATING_CONTROL_OFFSET_PX = 128;[\s\S]*const FLOATING_CONTROL_SIZE_PX = 36;[\s\S]*const FLOATING_CONTROL_OFFSET_CLASS = `bottom-\[\$\{FLOATING_CONTROL_OFFSET_PX\}px\]`;[\s\S]*FLOATING_CONTROL_OFFSET_PX \+ FLOATING_CONTROL_SIZE_PX/,
+    "floating controls should share one numeric offset and spacer relationship",
+  );
+  assert.match(
+    messageListSource,
+    /className=\$\{`\$\{FLOATING_CONTROL_SPACER_CLASS\} shrink-0`\}/,
     "floating logs control should reserve enough end-of-content space to clear the composer",
   );
   assert.match(
     messageListSource,
-    /const FLOATING_LOGS_BUTTON_CLASS =[\s\S]*group absolute bottom-32 right-5[\s\S]*border-\[color-mix\(in_srgb,var\(--v2-accent\)_28%,var\(--v2-panel-border\)\)\][\s\S]*bg-\[color-mix\(in_srgb,var\(--v2-surface\)_88%,var\(--v2-accent\)_12%\)\]/,
+    /const FLOATING_LOGS_BUTTON_CLASS =[\s\S]*group absolute \$\{FLOATING_CONTROL_OFFSET_CLASS\} right-5[\s\S]*border-\[color-mix\(in_srgb,var\(--v2-accent\)_28%,var\(--v2-panel-border\)\)\][\s\S]*bg-\[color-mix\(in_srgb,var\(--v2-surface\)_88%,var\(--v2-accent\)_12%\)\]/,
     "floating logs button classes should live in a module-level constant",
+  );
+  assert.match(
+    messageListSource,
+    /const JUMP_TO_BOTTOM_BUTTON_CLASS =[\s\S]*absolute \$\{FLOATING_CONTROL_OFFSET_CLASS\} left-1\/2[\s\S]*className=\$\{JUMP_TO_BOTTOM_BUTTON_CLASS\}/,
+    "jump-to-latest should use the same composer-safe offset as the floating logs control",
   );
   assert.match(
     messageListSource,


### PR DESCRIPTION
## Summary
* Moves the floating terminal/logs shortcut higher in the WebChat v2 transcript area so it no longer overlaps the chat composer or send controls.
* Clips the floating shortcut to the message-list region instead of allowing it to spill over the composer.
* Expands the transcript end spacer so the final chat content remains scrollable above the floating shortcut.
* Adds a MessageList regression test that locks the composer-clearance behavior.

<img width="468" height="604" alt="iShot_2026-07-03_17 33 58" src="https://github.com/user-attachments/assets/515dcdf0-5d38-4eb0-9ff2-bb7c32094daa" />


## Linked Issue

Closes #5555

## Validation

* `node --test crates/ironclaw_webui_v2/static/js/pages/chat/components/message-list.test.mjs`
* `node --check crates/ironclaw_webui_v2/static/js/pages/chat/components/message-list.js`
* `cargo test -p ironclaw_webui_v2 --features webui-v2-beta static_assets -- --nocapture`
* `git diff --check`

## Security Impact

No. This is a WebChat v2 layout-only change and does not alter auth, routing, secrets, or runtime behavior.

## Database Impact

No schema or migration changes.

## Blast Radius

Limited to the WebChat v2 chat message list floating terminal/logs shortcut and its component regression test.

## Rollback Plan

Revert this PR to restore the previous floating shortcut positioning.

---

Review track: A