### PR TITLE
[codex] Add structured Railway log output

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -376,6 +376,7 @@ SAFETY_INJECTION_CHECK_ENABLED=true
 # IRONCLAW_REBORN_HOME=/data/ironclaw-reborn
 # IRONCLAW_REBORN_PROFILE=local-dev
 # IRONCLAW_REBORN_LOG=info
+# IRONCLAW_REBORN_LOG_FORMAT=json
 # IRONCLAW_REBORN_POSTGRES_URL=postgres://user:password@db.example.com/ironclaw?sslmode=require
 # IRONCLAW_REBORN_SECRET_MASTER_KEY=replace-with-independent-secret-key-material
 # IRONCLAW_REBORN_SERVE_HOST=127.0.0.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4812,8 +4812,10 @@ dependencies = [
 name = "ironclaw_observability"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "serde_json",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -5044,6 +5046,7 @@ dependencies = [
  "clap_complete",
  "dotenvy",
  "hex",
+ "ironclaw_observability",
  "ironclaw_reborn_composition",
  "ironclaw_reborn_config",
  "ironclaw_reborn_traces",

--- a/crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs
+++ b/crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs
@@ -401,10 +401,11 @@ fn reborn_cli_binary_crate_stays_separate_from_v1_root() {
         [
             "ironclaw_reborn_composition",
             "ironclaw_reborn_config",
+            "ironclaw_observability",
             "ironclaw_reborn_traces",
             "ironclaw_reborn_webui_ingress",
         ],
-        "ironclaw_reborn_cli should enter Reborn through ironclaw_reborn_composition (assembled-runtime and provider-admin facade), ironclaw_reborn_config (boot-config contract), ironclaw_reborn_traces (contributor-side TraceCommons client extracted from the legacy monolith), and ironclaw_reborn_webui_ingress (host-owned WebUI serve lifecycle) only. Adding any other workspace crate here re-opens speculative public API access to internal Reborn types.",
+        "ironclaw_reborn_cli should enter Reborn through ironclaw_reborn_composition (assembled-runtime and provider-admin facade), ironclaw_reborn_config (boot-config contract), ironclaw_observability (shared structured stderr/log-layer implementation), ironclaw_reborn_traces (contributor-side TraceCommons client extracted from the legacy monolith), and ironclaw_reborn_webui_ingress (host-owned WebUI serve lifecycle) only. Adding any other workspace crate here re-opens speculative public API access to internal Reborn types.",
     );
     assert_workspace_deps_exactly(
         &dependencies_all_kinds,

--- a/crates/ironclaw_observability/Cargo.toml
+++ b/crates/ironclaw_observability/Cargo.toml
@@ -11,5 +11,7 @@ repository = "https://github.com/nearai/ironclaw"
 publish = false
 
 [dependencies]
+chrono = { version = "0.4", features = ["serde"] }
 serde_json = "1"
 tracing = "0.1"
+tracing-subscriber = "0.3"

--- a/crates/ironclaw_observability/src/lib.rs
+++ b/crates/ironclaw_observability/src/lib.rs
@@ -3,6 +3,9 @@
 
 use std::time::Instant;
 
+mod structured_logs;
+
+pub use structured_logs::StructuredJsonLogLayer;
 pub use tracing;
 
 #[inline]

--- a/crates/ironclaw_observability/src/structured_logs.rs
+++ b/crates/ironclaw_observability/src/structured_logs.rs
@@ -1,0 +1,416 @@
+use std::collections::BTreeMap;
+use std::io::{self, Write};
+
+use chrono::{SecondsFormat, Utc};
+use serde_json::{Map, Value};
+use tracing::field::{Field, Visit};
+use tracing::span::{Attributes, Record};
+use tracing::{Event, Id, Level, Subscriber};
+use tracing_subscriber::layer::Context;
+use tracing_subscriber::registry::LookupSpan;
+
+type LogLineWriter = fn(&str);
+
+#[derive(Clone)]
+pub struct StructuredJsonLogLayer {
+    metadata: StructuredLogMetadata,
+    write_line: LogLineWriter,
+}
+
+impl StructuredJsonLogLayer {
+    pub fn new(default_service: &str) -> Self {
+        Self {
+            metadata: StructuredLogMetadata::from_env(default_service),
+            write_line: write_stderr_line,
+        }
+    }
+
+    #[cfg(test)]
+    fn with_line_writer(default_service: &str, write_line: LogLineWriter) -> Self {
+        Self {
+            metadata: StructuredLogMetadata::from_env(default_service),
+            write_line,
+        }
+    }
+}
+
+impl<S> tracing_subscriber::Layer<S> for StructuredJsonLogLayer
+where
+    S: Subscriber + for<'lookup> LookupSpan<'lookup>,
+{
+    fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
+        let mut visitor = StructuredFieldsVisitor::default();
+        attrs.record(&mut visitor);
+        if let Some(span) = ctx.span(id) {
+            span.extensions_mut().insert(StructuredSpanFields {
+                promoted: visitor.promoted,
+                fields: visitor.fields,
+            });
+        }
+    }
+
+    fn on_record(&self, id: &Id, values: &Record<'_>, ctx: Context<'_, S>) {
+        let Some(span) = ctx.span(id) else {
+            return;
+        };
+        let mut visitor = StructuredFieldsVisitor::default();
+        values.record(&mut visitor);
+        let mut extensions = span.extensions_mut();
+        if let Some(existing) = extensions.get_mut::<StructuredSpanFields>() {
+            merge_json_map(&mut existing.promoted, visitor.promoted);
+            merge_json_map(&mut existing.fields, visitor.fields);
+        } else {
+            extensions.insert(StructuredSpanFields {
+                promoted: visitor.promoted,
+                fields: visitor.fields,
+            });
+        }
+    }
+
+    fn on_event(&self, event: &Event<'_>, ctx: Context<'_, S>) {
+        let mut promoted = BTreeMap::new();
+        let mut fields = BTreeMap::new();
+        for span in ctx
+            .event_scope(event)
+            .into_iter()
+            .flat_map(|scope| scope.from_root())
+        {
+            if let Some(span_fields) = span.extensions().get::<StructuredSpanFields>() {
+                merge_json_map(&mut promoted, span_fields.promoted.clone());
+                merge_json_map(&mut fields, span_fields.fields.clone());
+            }
+        }
+
+        let mut visitor = StructuredFieldsVisitor::default();
+        event.record(&mut visitor);
+        merge_json_map(&mut promoted, visitor.promoted);
+        merge_json_map(&mut fields, visitor.fields);
+
+        let line = structured_log_line(
+            &self.metadata,
+            event.metadata().level(),
+            event.metadata().target(),
+            visitor.message,
+            promoted,
+            fields,
+        );
+        if let Ok(line) = serde_json::to_string(&Value::Object(line)) {
+            (self.write_line)(&line);
+        }
+    }
+}
+
+fn write_stderr_line(line: &str) {
+    let _ = writeln!(io::stderr(), "{line}");
+}
+
+#[derive(Clone)]
+struct StructuredLogMetadata {
+    service: String,
+    environment: Option<String>,
+    deployment_id: Option<String>,
+    replica_id: Option<String>,
+    git_sha: Option<String>,
+}
+
+impl StructuredLogMetadata {
+    fn from_env(default_service: &str) -> Self {
+        Self {
+            service: first_env(&["RAILWAY_SERVICE_NAME", "IRONCLAW_SERVICE_NAME"])
+                .unwrap_or_else(|| default_service.to_string()),
+            environment: first_env(&[
+                "RAILWAY_ENVIRONMENT_NAME",
+                "IRONCLAW_ENV",
+                "APP_ENV",
+                "ENVIRONMENT",
+            ]),
+            deployment_id: first_env(&["RAILWAY_DEPLOYMENT_ID"]),
+            replica_id: first_env(&["RAILWAY_REPLICA_ID"]),
+            git_sha: first_env(&["RAILWAY_GIT_COMMIT_SHA", "GIT_SHA", "COMMIT_SHA"]),
+        }
+    }
+}
+
+fn first_env(keys: &[&str]) -> Option<String> {
+    keys.iter().find_map(|key| {
+        let value = std::env::var(key).ok()?;
+        (!value.trim().is_empty()).then_some(value)
+    })
+}
+
+#[derive(Clone)]
+struct StructuredSpanFields {
+    promoted: BTreeMap<String, Value>,
+    fields: BTreeMap<String, Value>,
+}
+
+#[derive(Default)]
+struct StructuredFieldsVisitor {
+    message: String,
+    promoted: BTreeMap<String, Value>,
+    fields: BTreeMap<String, Value>,
+}
+
+impl StructuredFieldsVisitor {
+    fn record_value(&mut self, field: &Field, value: Value) {
+        if field.name() == "message" {
+            self.message = json_value_to_log_string(value);
+        } else if let Some(name) = canonical_log_field(field.name()) {
+            self.promoted
+                .insert(name.to_string(), normalize_promoted_value(name, value));
+        } else {
+            self.fields.insert(field.name().to_string(), value);
+        }
+    }
+}
+
+impl Visit for StructuredFieldsVisitor {
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        self.record_value(field, Value::String(render_debug_value(value)));
+    }
+
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.record_value(field, Value::Number(value.into()));
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.record_value(field, Value::Number(value.into()));
+    }
+
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        self.record_value(field, Value::Bool(value));
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.record_value(field, Value::String(value.to_string()));
+    }
+
+    fn record_error(&mut self, field: &Field, value: &(dyn std::error::Error + 'static)) {
+        self.record_value(field, Value::String(value.to_string()));
+    }
+}
+
+fn canonical_log_field(name: &str) -> Option<&'static str> {
+    match name {
+        "thread_id" => Some("thread_id"),
+        "run_id" | "turn_run_id" | "submitted_run_id" => Some("run_id"),
+        "turn_id" | "submission_id" => Some("turn_id"),
+        "tool_name" | "capability_id" => Some("tool_name"),
+        "tool_call_id" | "invocation_id" | "capability_invocation_id" => Some("tool_call_id"),
+        "request_id" | "trace_id" => Some("request_id"),
+        "error_kind" => Some("error_kind"),
+        "duration_ms" => Some("duration_ms"),
+        _ => None,
+    }
+}
+
+fn normalize_promoted_value(name: &str, value: Value) -> Value {
+    if name == "duration_ms" {
+        match value {
+            Value::String(value) => value
+                .parse::<u64>()
+                .ok()
+                .map(|value| Value::Number(value.into()))
+                .unwrap_or(Value::String(value)),
+            value => value,
+        }
+    } else {
+        value
+    }
+}
+
+fn structured_log_line(
+    metadata: &StructuredLogMetadata,
+    level: &Level,
+    target: &str,
+    message: String,
+    mut promoted: BTreeMap<String, Value>,
+    fields: BTreeMap<String, Value>,
+) -> Map<String, Value> {
+    let mut line = Map::new();
+    line.insert(
+        "timestamp".to_string(),
+        Value::String(Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true)),
+    );
+    line.insert(
+        "level".to_string(),
+        Value::String(level.as_str().to_ascii_lowercase()),
+    );
+    line.insert("message".to_string(), Value::String(message));
+    line.insert(
+        "service".to_string(),
+        Value::String(metadata.service.clone()),
+    );
+    line.insert(
+        "environment".to_string(),
+        optional_json_string(&metadata.environment),
+    );
+    line.insert(
+        "deployment_id".to_string(),
+        optional_json_string(&metadata.deployment_id),
+    );
+    line.insert(
+        "replica_id".to_string(),
+        optional_json_string(&metadata.replica_id),
+    );
+    line.insert(
+        "git_sha".to_string(),
+        optional_json_string(&metadata.git_sha),
+    );
+    line.insert("target".to_string(), Value::String(target.to_string()));
+
+    for field in [
+        "thread_id",
+        "run_id",
+        "turn_id",
+        "tool_name",
+        "request_id",
+        "error_kind",
+        "duration_ms",
+        "tool_call_id",
+    ] {
+        line.insert(
+            field.to_string(),
+            promoted.remove(field).unwrap_or(Value::Null),
+        );
+    }
+
+    let mut extra_fields = fields;
+    merge_json_map(&mut extra_fields, promoted);
+    if !extra_fields.is_empty() {
+        line.insert(
+            "fields".to_string(),
+            Value::Object(extra_fields.into_iter().collect()),
+        );
+    }
+    line
+}
+
+fn optional_json_string(value: &Option<String>) -> Value {
+    value
+        .as_ref()
+        .map(|value| Value::String(value.clone()))
+        .unwrap_or(Value::Null)
+}
+
+fn merge_json_map(target: &mut BTreeMap<String, Value>, source: BTreeMap<String, Value>) {
+    for (key, value) in source {
+        target.insert(key, value);
+    }
+}
+
+fn json_value_to_log_string(value: Value) -> String {
+    match value {
+        Value::String(value) => value,
+        value => value.to_string(),
+    }
+}
+
+fn render_debug_value(value: &dyn std::fmt::Debug) -> String {
+    let rendered = format!("{value:?}");
+    rendered
+        .strip_prefix('"')
+        .and_then(|value| value.strip_suffix('"'))
+        .unwrap_or(rendered.as_str())
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{LazyLock, Mutex};
+    use tracing_subscriber::prelude::*;
+
+    static CAPTURED_LOG_LINES: LazyLock<Mutex<Vec<String>>> =
+        LazyLock::new(|| Mutex::new(Vec::new()));
+
+    fn capture_log_line(line: &str) {
+        CAPTURED_LOG_LINES
+            .lock()
+            .expect("capture log lock")
+            .push(line.to_string());
+    }
+
+    #[test]
+    fn structured_line_has_stable_fields() {
+        let metadata = StructuredLogMetadata {
+            service: "ironclaw".to_string(),
+            environment: Some("production".to_string()),
+            deployment_id: Some("dep_123".to_string()),
+            replica_id: Some("replica_1".to_string()),
+            git_sha: Some("abc123".to_string()),
+        };
+        let mut promoted = BTreeMap::new();
+        promoted.insert(
+            "thread_id".to_string(),
+            Value::String("thread-a".to_string()),
+        );
+        promoted.insert("duration_ms".to_string(), Value::Number(42.into()));
+
+        let line = structured_log_line(
+            &metadata,
+            &Level::INFO,
+            "ironclaw",
+            "started".to_string(),
+            promoted,
+            BTreeMap::new(),
+        );
+
+        assert_eq!(line["level"], "info");
+        assert_eq!(line["service"], "ironclaw");
+        assert_eq!(line["deployment_id"], "dep_123");
+        assert_eq!(line["thread_id"], "thread-a");
+        assert_eq!(line["duration_ms"], 42);
+        assert!(line.contains_key("request_id"));
+        assert!(line.contains_key("error_kind"));
+    }
+
+    #[test]
+    fn structured_json_layer_emits_single_line_json_with_span_and_event_fields() {
+        CAPTURED_LOG_LINES.lock().expect("capture log lock").clear();
+        let subscriber = tracing_subscriber::registry().with(
+            StructuredJsonLogLayer::with_line_writer("ironclaw-test", capture_log_line),
+        );
+
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::info_span!(
+                "turn",
+                thread_id = "thread-a",
+                run_id = "run-a",
+                duration_ms = "42",
+                span_extra = "from-span",
+            );
+            let _guard = span.enter();
+            tracing::info!(
+                target: "ironclaw::test",
+                turn_id = "turn-a",
+                tool_name = "shell",
+                request_id = "request-a",
+                event_extra = "from-event",
+                "tool completed"
+            );
+        });
+
+        let lines = CAPTURED_LOG_LINES.lock().expect("capture log lock");
+        assert_eq!(lines.len(), 1, "expected one captured log line: {lines:?}");
+        assert!(
+            !lines[0].contains('\n'),
+            "structured logs must stay single-line"
+        );
+        let line: Value =
+            serde_json::from_str(&lines[0]).expect("captured log line parses as JSON");
+
+        assert_eq!(line["level"], "info");
+        assert_eq!(line["message"], "tool completed");
+        assert_eq!(line["service"], "ironclaw-test");
+        assert_eq!(line["target"], "ironclaw::test");
+        assert_eq!(line["thread_id"], "thread-a");
+        assert_eq!(line["run_id"], "run-a");
+        assert_eq!(line["turn_id"], "turn-a");
+        assert_eq!(line["tool_name"], "shell");
+        assert_eq!(line["request_id"], "request-a");
+        assert_eq!(line["duration_ms"], 42);
+        assert_eq!(line["fields"]["span_extra"], "from-span");
+        assert_eq!(line["fields"]["event_extra"], "from-event");
+    }
+}

--- a/crates/ironclaw_reborn_cli/AGENTS.md
+++ b/crates/ironclaw_reborn_cli/AGENTS.md
@@ -15,7 +15,7 @@ This crate owns the standalone `ironclaw-reborn` command surface. Keep it small,
 - Keep commands side-effect free unless the command name and issue explicitly require mutation.
 - Use `IRONCLAW_REBORN_HOME` / `~/.ironclaw/reborn`; do not write current v1 state.
 - no v1 runtime imports: do not depend on root `ironclaw`, `src/agent`, channels, worker, DB, setup, service, sandbox, or `ironclaw_engine`.
-- Do not add workspace dependencies beyond `ironclaw_reborn_composition`, `ironclaw_reborn_config`, `ironclaw_reborn_traces`, and `ironclaw_reborn_webui_ingress` (host-owned WebUI serve lifecycle) without an architecture test update and explicit PR rationale. Provider registry/auth/model UX should enter through the Reborn composition provider-admin facade, not a separate CLI-only path.
+- Do not add workspace dependencies beyond `ironclaw_reborn_composition`, `ironclaw_reborn_config`, `ironclaw_observability` (shared log-layer implementation), `ironclaw_reborn_traces`, and `ironclaw_reborn_webui_ingress` (host-owned WebUI serve lifecycle) without an architecture test update and explicit PR rationale. Provider registry/auth/model UX should enter through the Reborn composition provider-admin facade, not a separate CLI-only path.
 
 ## Adding a command
 

--- a/crates/ironclaw_reborn_cli/Cargo.toml
+++ b/crates/ironclaw_reborn_cli/Cargo.toml
@@ -78,6 +78,7 @@ hex = "0.4.3"
 clap = { version = "4", features = ["derive", "env"] }
 clap_complete = "4.5.0"
 dotenvy = "0.15"
+ironclaw_observability = { path = "../ironclaw_observability", version = "0.1.0" }
 ironclaw_reborn_composition = { path = "../ironclaw_reborn_composition", version = "0.1.0" }
 ironclaw_reborn_config = { path = "../ironclaw_reborn_config", version = "0.1.0" }
 ironclaw_reborn_traces = { path = "../ironclaw_reborn_traces", version = "0.1.0" }

--- a/crates/ironclaw_reborn_cli/src/commands/serve.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/serve.rs
@@ -97,6 +97,7 @@ impl ServeCommand {
             .unwrap_or("reborn-cli");
         let tenant_id = TenantId::new(tenant_raw)
             .map_err(|err| anyhow!("[identity].tenant `{tenant_raw}` is invalid: {err}"))?;
+        let structured_json_logs = crate::runtime::structured_json_logs_enabled();
 
         // Resolve env-bearer authenticator from the env-var names the
         // operator declared in `[webui]`. Values themselves are env-only
@@ -323,7 +324,7 @@ impl ServeCommand {
         // is a foot-gun. Operators can silence by setting
         // `--host 0.0.0.0` explicitly (we don't have a "yes I mean
         // it" flag yet — this is purely an attention nudge).
-        if !host.is_loopback() {
+        if !host.is_loopback() && !structured_json_logs {
             eprintln!(
                 "WARNING: WebChat v2 listener will bind to non-loopback address {host}. \
                  The default env-bearer authenticator is intended for single-operator \
@@ -334,7 +335,7 @@ impl ServeCommand {
         // see the same signal.
         if !host.is_loopback() {
             tracing::warn!(
-                target = "ironclaw::reborn::cli::serve",
+                target: "ironclaw::reborn::cli::serve",
                 %host,
                 "binding WebChat v2 listener on a non-loopback interface",
             );
@@ -475,13 +476,23 @@ impl ServeCommand {
             )
             .await?;
 
-            print_serve_banner(
-                listen_addr,
-                env_token_var,
-                env_user_id_var,
-                &allowed_origins_raw,
-                &bundle.readiness,
-            );
+            if structured_json_logs {
+                log_serve_banner(
+                    listen_addr,
+                    env_token_var,
+                    env_user_id_var,
+                    &allowed_origins_raw,
+                    &bundle.readiness,
+                );
+            } else {
+                print_serve_banner(
+                    listen_addr,
+                    env_token_var,
+                    env_user_id_var,
+                    &allowed_origins_raw,
+                    &bundle.readiness,
+                );
+            }
 
             let mut serve_config = WebuiServeConfig::new(tenant_id, authenticator, allowed_origins)
                 .with_default_agent_id(default_agent_id.clone());
@@ -883,6 +894,25 @@ fn print_serve_banner(
     }
     eprintln!("  readiness : {readiness:?}");
     eprintln!();
+}
+
+fn log_serve_banner(
+    listen_addr: SocketAddr,
+    env_token_var: &str,
+    env_user_id_var: &str,
+    allowed_origins: &[String],
+    readiness: &RebornReadiness,
+) {
+    tracing::info!(
+        target: "ironclaw::reborn::cli::serve",
+        %listen_addr,
+        env_token_var,
+        env_user_id_var,
+        allowed_origins_count = allowed_origins.len(),
+        allowed_origins = ?allowed_origins,
+        readiness = ?readiness,
+        "WebChat v2 listener started",
+    );
 }
 
 #[cfg(test)]

--- a/crates/ironclaw_reborn_cli/src/runtime/mod.rs
+++ b/crates/ironclaw_reborn_cli/src/runtime/mod.rs
@@ -60,14 +60,24 @@ pub(crate) fn init_tracing() {
         "IRONCLAW_REBORN_OPERATOR_LOG",
         "info,ironclaw_reborn=debug,ironclaw_host_runtime=debug",
     );
-    let _ = tracing_subscriber::registry()
-        .with(
-            fmt::layer()
-                .with_writer(std::io::stderr)
-                .with_filter(stderr_filter),
-        )
-        .with(OperatorLogLayer.with_filter(operator_filter))
-        .try_init();
+    if structured_json_logs_enabled() {
+        let _ = tracing_subscriber::registry()
+            .with(
+                ironclaw_observability::StructuredJsonLogLayer::new("ironclaw-reborn")
+                    .with_filter(stderr_filter),
+            )
+            .with(OperatorLogLayer.with_filter(operator_filter))
+            .try_init();
+    } else {
+        let _ = tracing_subscriber::registry()
+            .with(
+                fmt::layer()
+                    .with_writer(std::io::stderr)
+                    .with_filter(stderr_filter),
+            )
+            .with(OperatorLogLayer.with_filter(operator_filter))
+            .try_init();
+    }
 }
 
 const REBORN_NOISY_LOG_TARGETS: &[(&str, &str)] = &[
@@ -82,6 +92,27 @@ const REBORN_NOISY_LOG_TARGETS: &[(&str, &str)] = &[
     ("tower_http", "warn"),
     ("ironclaw_llm", "info"),
 ];
+
+const REBORN_LOG_FORMAT_ENV: &str = "IRONCLAW_REBORN_LOG_FORMAT";
+
+pub(crate) fn structured_json_logs_enabled() -> bool {
+    log_format_env(REBORN_LOG_FORMAT_ENV)
+        .unwrap_or_else(|| railway_runtime_present() && !std::io::stderr().is_terminal())
+}
+
+fn log_format_env(key: &str) -> Option<bool> {
+    let value = std::env::var(key).ok()?;
+    match value.trim().to_ascii_lowercase().as_str() {
+        "json" | "structured" | "structured-json" | "railway" => Some(true),
+        "text" | "plain" | "pretty" | "human" => Some(false),
+        _ => None,
+    }
+}
+
+fn railway_runtime_present() -> bool {
+    std::env::var_os("RAILWAY_DEPLOYMENT_ID").is_some()
+        || std::env::var_os("RAILWAY_SERVICE_ID").is_some()
+}
 
 fn reborn_env_filter(env_key: &str, default_filter: &str) -> tracing_subscriber::EnvFilter {
     let default_filter = protect_reborn_log_filter(default_filter);
@@ -1192,6 +1223,7 @@ mod tests {
         RuntimeInputCaller, RuntimeInputOptions, apply_credential_refresh_override, block_on_cli,
         build_runtime_input, build_runtime_input_with_options, no_assistant_text_message,
         protect_reborn_log_filter, resolve_google_oauth_config, runner_settings,
+        structured_json_logs_enabled,
     };
     // Only the `#[cfg(feature = "libsql")]` hosted-volume test consumes this.
     #[cfg(feature = "libsql")]
@@ -1204,6 +1236,33 @@ mod tests {
             &std::path::PathBuf::from("/test/config.toml"),
         )
         .expect("must parse")
+    }
+
+    #[test]
+    fn structured_json_logs_enabled_respects_format_env() {
+        let _lock = lock_runtime_env();
+        let _deployment = EnvGuard::clear("RAILWAY_DEPLOYMENT_ID");
+        let _service = EnvGuard::clear("RAILWAY_SERVICE_ID");
+
+        {
+            let _format = EnvGuard::set("IRONCLAW_REBORN_LOG_FORMAT", "json");
+            assert!(structured_json_logs_enabled());
+        }
+
+        {
+            let _format = EnvGuard::set("IRONCLAW_REBORN_LOG_FORMAT", "structured-json");
+            assert!(structured_json_logs_enabled());
+        }
+
+        {
+            let _format = EnvGuard::set("IRONCLAW_REBORN_LOG_FORMAT", "text");
+            assert!(!structured_json_logs_enabled());
+        }
+
+        {
+            let _format = EnvGuard::set("IRONCLAW_REBORN_LOG_FORMAT", "definitely-not-json");
+            assert!(!structured_json_logs_enabled());
+        }
     }
 
     #[test]

--- a/crates/ironclaw_reborn_cli/tests/smoke.rs
+++ b/crates/ironclaw_reborn_cli/tests/smoke.rs
@@ -1490,6 +1490,93 @@ fn serve_with_env_auth_seeds_reborn_config_before_binding() {
     );
 }
 
+#[cfg(feature = "webui-v2-beta")]
+#[test]
+fn serve_emits_json_logs_when_ironclaw_reborn_log_format_json() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let reborn_home = temp.path().join("reborn-home");
+    let home = temp.path().join("home");
+    std::fs::create_dir_all(&home).expect("home dir");
+
+    let mut child = Command::new(reborn_bin())
+        .args(["serve", "--host", "127.0.0.1", "--port", "0"])
+        .env_clear()
+        .env("HOME", &home)
+        .env("IRONCLAW_REBORN_HOME", &reborn_home)
+        .env("IRONCLAW_REBORN_LOG_FORMAT", "json")
+        .env("IRONCLAW_REBORN_WEBUI_TOKEN", "test-token")
+        .env("IRONCLAW_REBORN_WEBUI_USER_ID", "test-user")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("ironclaw-reborn serve should start");
+    let stderr = child.stderr.take().expect("stderr should be piped");
+    let (stderr_tx, stderr_rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        for line in std::io::BufReader::new(stderr).lines() {
+            if stderr_tx.send(line).is_err() {
+                break;
+            }
+        }
+    });
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
+    let mut stderr_text = String::new();
+    let startup_log = loop {
+        if let Some(status) = child.try_wait().expect("serve child status") {
+            panic!("serve exited before binding with {status}; stderr: {stderr_text}");
+        }
+        if std::time::Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!("serve did not emit JSON listener startup log; stderr: {stderr_text}");
+        }
+        match stderr_rx.recv_timeout(std::time::Duration::from_millis(100)) {
+            Ok(Ok(line)) => {
+                if line.trim().is_empty() {
+                    continue;
+                }
+                stderr_text.push_str(&line);
+                stderr_text.push('\n');
+                let parsed: serde_json::Value =
+                    serde_json::from_str(&line).unwrap_or_else(|error| {
+                        panic!("stderr line must be JSON in structured mode: {error}; line: {line}")
+                    });
+                if parsed["message"] == "WebChat v2 listener started" {
+                    break parsed;
+                }
+            }
+            Ok(Err(error)) => panic!("failed to read serve stderr: {error}"),
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                panic!("serve stderr closed before startup log; stderr: {stderr_text}");
+            }
+        }
+    };
+
+    let _ = child.kill();
+    let _ = child.wait();
+    assert_eq!(startup_log["level"], "info");
+    assert_eq!(startup_log["service"], "ironclaw-reborn");
+    assert_eq!(startup_log["target"], "ironclaw::reborn::cli::serve");
+    assert_eq!(
+        startup_log["fields"]["env_token_var"],
+        "IRONCLAW_REBORN_WEBUI_TOKEN"
+    );
+    assert_eq!(
+        startup_log["fields"]["env_user_id_var"],
+        "IRONCLAW_REBORN_WEBUI_USER_ID"
+    );
+    assert!(
+        startup_log["fields"]["listen_addr"].as_str().is_some(),
+        "startup log should include listen_addr: {startup_log}"
+    );
+    assert!(
+        !stderr_text.contains("ironclaw-reborn: WebChat v2 listener"),
+        "structured mode must not mix the plain serve banner into stderr: {stderr_text}"
+    );
+}
+
 #[cfg(all(feature = "webui-v2-beta", feature = "slack-v2-host-beta"))]
 #[test]
 fn serve_env_slack_enabled_mounts_slack_events_route() {


### PR DESCRIPTION
## Summary

- add a shared structured JSON tracing layer in `ironclaw_observability`
- emit Railway-friendly single-line logs from the Reborn runtime logging path
- expose `IRONCLAW_REBORN_LOG_FORMAT=json` while still auto-enabling JSON in Railway-style non-TTY runtimes

## Impact

Reborn Railway logs now include stable top-level fields for cross-deployment filtering and export workflows, including service/environment/deployment metadata plus run and tool correlation fields.

## Validation

- `cargo fmt --check`
- `cargo test -p ironclaw_observability`
- `cargo check -p ironclaw_reborn_cli`
