### PR TITLE
[codex] Add sccache dist smoke workflow

### DIFF
--- a/.github/workflows/sccache-dist-smoke.yml
+++ b/.github/workflows/sccache-dist-smoke.yml
@@ -1,0 +1,66 @@
+name: sccache Dist Smoke
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    name: Verify distributed sccache
+    runs-on: ubuntu-latest
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_DIST_SCHEDULER_URL: ${{ vars.SCCACHE_DIST_SCHEDULER_URL }}
+      SCCACHE_DIST_AUTH_TOKEN: ${{ secrets.SCCACHE_DIST_AUTH_TOKEN }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Check required sccache settings
+        shell: bash
+        run: |
+          missing=0
+          for name in SCCACHE_DIST_SCHEDULER_URL SCCACHE_DIST_AUTH_TOKEN; do
+            if [[ -z "${!name:-}" ]]; then
+              echo "::error title=Missing sccache setting::$name is required"
+              missing=1
+            fi
+          done
+          exit "$missing"
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: Install sccache
+        uses: mozilla-actions/sccache-action@1583d6b38d7be47f593cb472781bbb21cab4321e # v0.0.10
+        with:
+          version: v0.16.0
+
+      - name: Configure distributed sccache
+        shell: bash
+        run: |
+          mkdir -p "$HOME/.config/sccache"
+          cat > "$HOME/.config/sccache/config" <<EOF
+          [dist]
+          scheduler_url = "${SCCACHE_DIST_SCHEDULER_URL}"
+          toolchains = []
+          toolchain_cache_size = 5368709120
+
+          [dist.auth]
+          type = "token"
+          token = "${SCCACHE_DIST_AUTH_TOKEN}"
+          EOF
+          chmod 600 "$HOME/.config/sccache/config"
+          sccache --stop-server || true
+
+      - name: Show distributed status
+        run: sccache --dist-status
+
+      - name: Build a small Rust crate through sccache
+        run: cargo check -p ironclaw_reborn_config
+
+      - name: Show sccache stats
+        if: always()
+        run: sccache --show-stats

--- a/docs/internal/sccache-dist-ovh-ci.md
+++ b/docs/internal/sccache-dist-ovh-ci.md
@@ -1,0 +1,75 @@
+# OVH sccache-dist CI builder
+
+This repo uses an OVH dedicated server as a distributed `sccache` scheduler plus
+one Linux build server.
+
+## Server
+
+- Host: `146.59.71.184`
+- SSH user: `ubuntu`
+- OS: Ubuntu 24.04 LTS
+- Hardware observed at setup: 24 logical CPUs, 62 GiB RAM, NVMe RAID root
+- Scheduler: `https://ns3211718.ip-146-59-71.eu`
+- Builder: `146.59.71.184:10501`
+
+## Services
+
+On the server:
+
+```sh
+sudo systemctl status sccache-dist-scheduler.service
+sudo systemctl status sccache-dist-server.service
+sccache --dist-status
+```
+
+Config files:
+
+```text
+/etc/sccache-dist/scheduler.conf
+/etc/sccache-dist/server.conf
+/etc/sccache-dist/client.env
+```
+
+The client token is stored in `/etc/sccache-dist/client.env` and in the GitHub
+secret `SCCACHE_DIST_AUTH_TOKEN`.
+
+## GitHub Settings
+
+Repository variable:
+
+```text
+SCCACHE_DIST_SCHEDULER_URL=https://ns3211718.ip-146-59-71.eu
+```
+
+Repository secret:
+
+```text
+SCCACHE_DIST_AUTH_TOKEN=<token from /etc/sccache-dist/client.env>
+```
+
+## Smoke Test
+
+Run the manual workflow:
+
+```text
+sccache Dist Smoke
+```
+
+Expected status:
+
+```json
+{"SchedulerStatus":["https://ns3211718.ip-146-59-71.eu/",{"num_servers":1,"num_cpus":24,"in_progress":0}]}
+```
+
+## Rollout
+
+After the smoke workflow succeeds, add the same `Install sccache` and
+`Configure distributed sccache` steps to Linux Rust jobs, starting with:
+
+1. `Tests (Reborn)` package-crate matrix
+2. `Tests (Reborn)` root partition tests
+3. `Code Style` Linux clippy jobs
+4. Legacy heavy integration jobs
+
+Keep `Swatinem/rust-cache` during the first rollout so dependency downloads and
+non-cacheable target artifacts stay warm.


### PR DESCRIPTION
## Summary

- add a manual `sccache Dist Smoke` workflow for the OVH distributed build server
- document the OVH scheduler/builder host, systemd services, GitHub variable/secret, firewall state, and rollout order

## Validation

- Parsed `.github/workflows/sccache-dist-smoke.yml` locally with Ruby YAML loader
- Set GitHub repo variable `SCCACHE_DIST_SCHEDULER_URL=https://ns3211718.ip-146-59-71.eu`
- Verified GitHub repo secret `SCCACHE_DIST_AUTH_TOKEN` exists
- Installed Caddy on the OVH server and obtained a valid Let's Encrypt cert for `ns3211718.ip-146-59-71.eu`
- Verified public scheduler port `10600` is blocked by UFW, while `443` and builder port `10501` are reachable
- Verified OVH scheduler status over HTTPS:

```json
{"SchedulerStatus":["https://ns3211718.ip-146-59-71.eu/",{"num_servers":1,"num_cpus":24,"in_progress":0}]}
```

## Notes

The scheduler is now accessed through HTTPS. The builder port `10501` remains public because GitHub-hosted runners need to connect to the advertised builder address after scheduler assignment.
