### PR TITLE
[codex] Address sccache dist smoke review comments

### DIFF
--- a/.github/workflows/sccache-dist-smoke.yml
+++ b/.github/workflows/sccache-dist-smoke.yml
@@ -10,6 +10,7 @@ jobs:
   smoke:
     name: Verify distributed sccache
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     env:
       RUSTC_WRAPPER: sccache
       SCCACHE_DIST_SCHEDULER_URL: ${{ vars.SCCACHE_DIST_SCHEDULER_URL }}
@@ -21,6 +22,7 @@ jobs:
       - name: Check required sccache settings
         shell: bash
         run: |
+          set -euo pipefail
           missing=0
           for name in SCCACHE_DIST_SCHEDULER_URL SCCACHE_DIST_AUTH_TOKEN; do
             if [[ -z "${!name:-}" ]]; then
@@ -28,6 +30,10 @@ jobs:
               missing=1
             fi
           done
+          if [[ -n "${SCCACHE_DIST_SCHEDULER_URL:-}" && "${SCCACHE_DIST_SCHEDULER_URL}" != https://* ]]; then
+            echo "::error title=Insecure scheduler URL::SCCACHE_DIST_SCHEDULER_URL must use https://"
+            missing=1
+          fi
           exit "$missing"
 
       - name: Install Rust
@@ -41,6 +47,7 @@ jobs:
       - name: Configure distributed sccache
         shell: bash
         run: |
+          set -euo pipefail
           mkdir -p "$HOME/.config/sccache"
           cat > "$HOME/.config/sccache/config" <<EOF
           [dist]

--- a/docs/internal/sccache-dist-ovh-ci.md
+++ b/docs/internal/sccache-dist-ovh-ci.md
@@ -5,12 +5,12 @@ one Linux build server.
 
 ## Server
 
-- Host: `146.59.71.184`
-- SSH user: `ubuntu`
+- Host: `<private runbook>`
+- SSH user: `<private runbook>`
 - OS: Ubuntu 24.04 LTS
 - Hardware observed at setup: 24 logical CPUs, 62 GiB RAM, NVMe RAID root
-- Scheduler: `https://ns3211718.ip-146-59-71.eu`
-- Builder: `146.59.71.184:10501`
+- Scheduler: `SCCACHE_DIST_SCHEDULER_URL` GitHub repository variable
+- Builder: `<private runbook>`
 
 ## Services
 
@@ -38,7 +38,7 @@ secret `SCCACHE_DIST_AUTH_TOKEN`.
 Repository variable:
 
 ```text
-SCCACHE_DIST_SCHEDULER_URL=https://ns3211718.ip-146-59-71.eu
+SCCACHE_DIST_SCHEDULER_URL=https://<scheduler-host>
 ```
 
 Repository secret:
@@ -58,7 +58,7 @@ sccache Dist Smoke
 Expected status:
 
 ```json
-{"SchedulerStatus":["https://ns3211718.ip-146-59-71.eu/",{"num_servers":1,"num_cpus":24,"in_progress":0}]}
+{"SchedulerStatus":["https://<scheduler-host>/",{"num_servers":1,"num_cpus":24,"in_progress":0}]}
 ```
 
 ## Rollout


### PR DESCRIPTION
## Summary

- add a 20-minute timeout to the manual sccache smoke job
- fail the smoke job if the scheduler URL is not HTTPS before writing the auth token into config
- enable `set -euo pipefail` in the bash script blocks
- redact live OVH host/user/endpoint values from the public docs

## Validation

- Parsed `.github/workflows/sccache-dist-smoke.yml` locally with Ruby YAML loader
- Confirmed no live OVH IP/hostname remains in the smoke workflow or public doc
- Confirmed the existing merged smoke run completed successfully before these hardening changes: https://github.com/nearai/ironclaw/actions/runs/28660556192

## Review feedback addressed

Follow-up for CodeRabbit review on #5596:
- timeout missing
- token over plaintext HTTP risk
- strict bash options
- redact live infrastructure details
