### PR TITLE
Enable distributed sccache in key CI workflows

### DIFF
--- a/.github/actions/setup-sccache-dist/action.yml
+++ b/.github/actions/setup-sccache-dist/action.yml
@@ -45,16 +45,16 @@ runs:
         fi
 
         mkdir -p "${HOME}/.config/sccache"
-        cat > "${HOME}/.config/sccache/config" <<EOF
-        [dist]
-        scheduler_url = "${SCCACHE_DIST_SCHEDULER_URL}"
-        toolchains = []
-        toolchain_cache_size = 5368709120
-
-        [dist.auth]
-        type = "token"
-        token = "${SCCACHE_DIST_AUTH_TOKEN}"
-        EOF
+        {
+          printf '%s\n' "[dist]"
+          printf 'scheduler_url = "%s"\n' "${SCCACHE_DIST_SCHEDULER_URL}"
+          printf '%s\n' "toolchains = []"
+          printf '%s\n' "toolchain_cache_size = 5368709120"
+          printf '%s\n' ""
+          printf '%s\n' "[dist.auth]"
+          printf '%s\n' 'type = "token"'
+          printf 'token = "%s"\n' "${SCCACHE_DIST_AUTH_TOKEN}"
+        } > "${HOME}/.config/sccache/config"
         chmod 600 "${HOME}/.config/sccache/config"
         echo "RUSTC_WRAPPER=sccache" >> "${GITHUB_ENV}"
         sccache --stop-server || true

--- a/.github/actions/setup-sccache-dist/action.yml
+++ b/.github/actions/setup-sccache-dist/action.yml
@@ -155,5 +155,7 @@ runs:
         echo "RUSTC_WRAPPER=sccache" >> "${GITHUB_ENV}"
         sccache --stop-server || true
         if [[ "${dist_enabled}" == "true" ]]; then
-          sccache --dist-status
+          if ! sccache --dist-status; then
+            echo "::warning title=sccache-dist scheduler probe failed::Distributed compilation may fall back or fail if the scheduler remains unavailable."
+          fi
         fi

--- a/.github/actions/setup-sccache-dist/action.yml
+++ b/.github/actions/setup-sccache-dist/action.yml
@@ -44,16 +44,23 @@ runs:
           exit 1
         fi
 
+        toml_basic_string() {
+          VALUE="$1" python3 -c 'import json, os; print(json.dumps(os.environ["VALUE"]))'
+        }
+
+        scheduler_url_toml="$(toml_basic_string "${SCCACHE_DIST_SCHEDULER_URL}")"
+        auth_token_toml="$(toml_basic_string "${SCCACHE_DIST_AUTH_TOKEN}")"
+
         mkdir -p "${HOME}/.config/sccache"
         {
           printf '%s\n' "[dist]"
-          printf 'scheduler_url = "%s"\n' "${SCCACHE_DIST_SCHEDULER_URL}"
+          printf 'scheduler_url = %s\n' "${scheduler_url_toml}"
           printf '%s\n' "toolchains = []"
           printf '%s\n' "toolchain_cache_size = 5368709120"
           printf '%s\n' ""
           printf '%s\n' "[dist.auth]"
           printf '%s\n' 'type = "token"'
-          printf 'token = "%s"\n' "${SCCACHE_DIST_AUTH_TOKEN}"
+          printf 'token = %s\n' "${auth_token_toml}"
         } > "${HOME}/.config/sccache/config"
         chmod 600 "${HOME}/.config/sccache/config"
         echo "RUSTC_WRAPPER=sccache" >> "${GITHUB_ENV}"

--- a/.github/actions/setup-sccache-dist/action.yml
+++ b/.github/actions/setup-sccache-dist/action.yml
@@ -1,7 +1,39 @@
-name: Setup distributed sccache
-description: Install sccache and configure the OVH distributed compiler backend when credentials are available.
+name: Setup OVH sccache
+description: Install sccache and configure the OVH Redis cache plus distributed compiler backend when credentials are available.
 
 inputs:
+  cache-ssh-host:
+    description: SSH host used to tunnel to the private OVH Redis sccache backend.
+    required: false
+    default: ""
+  cache-ssh-user:
+    description: SSH user used to tunnel to the private OVH Redis sccache backend.
+    required: false
+    default: "sccache-cache"
+  cache-ssh-port:
+    description: SSH port used to tunnel to the private OVH Redis sccache backend.
+    required: false
+    default: "22"
+  cache-ssh-private-key:
+    description: Private SSH key for the private OVH Redis sccache tunnel.
+    required: false
+    default: ""
+  cache-ssh-known-hosts:
+    description: Strict known_hosts content for the private OVH Redis sccache tunnel.
+    required: false
+    default: ""
+  redis-password:
+    description: Redis password for the private OVH sccache cache backend.
+    required: false
+    default: ""
+  redis-local-port:
+    description: Local port for the Redis SSH tunnel.
+    required: false
+    default: "6380"
+  redis-key-prefix:
+    description: Key prefix for entries written to the OVH Redis sccache cache.
+    required: false
+    default: "ironclaw/rust/v1"
   scheduler-url:
     description: HTTPS URL for the sccache-dist scheduler.
     required: false
@@ -14,32 +46,54 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Skip unavailable distributed sccache
-      if: ${{ inputs.auth-token == '' }}
+    - name: Skip unavailable OVH sccache
+      if: ${{ inputs.auth-token == '' && (inputs.redis-password == '' || inputs.cache-ssh-private-key == '' || inputs.cache-ssh-host == '' || inputs.cache-ssh-known-hosts == '') }}
       shell: bash
-      run: echo "::notice title=Distributed sccache skipped::SCCACHE_DIST_AUTH_TOKEN is unavailable; using local compilation."
+      run: echo "::notice title=OVH sccache skipped::SCCACHE_DIST_AUTH_TOKEN or OVH Redis cache credentials are unavailable; using local compilation."
 
     - name: Install sccache
-      if: ${{ inputs.auth-token != '' }}
+      if: ${{ inputs.auth-token != '' || (inputs.redis-password != '' && inputs.cache-ssh-private-key != '' && inputs.cache-ssh-host != '' && inputs.cache-ssh-known-hosts != '') }}
       uses: mozilla-actions/sccache-action@1583d6b38d7be47f593cb472781bbb21cab4321e # v0.0.10
       with:
         version: v0.16.0
 
-    - name: Configure distributed sccache
-      if: ${{ inputs.auth-token != '' }}
+    - name: Configure OVH sccache
+      if: ${{ inputs.auth-token != '' || (inputs.redis-password != '' && inputs.cache-ssh-private-key != '' && inputs.cache-ssh-host != '' && inputs.cache-ssh-known-hosts != '') }}
       shell: bash
       env:
+        SCCACHE_CACHE_SSH_HOST: ${{ inputs.cache-ssh-host }}
+        SCCACHE_CACHE_SSH_USER: ${{ inputs.cache-ssh-user }}
+        SCCACHE_CACHE_SSH_PORT: ${{ inputs.cache-ssh-port }}
+        SCCACHE_CACHE_SSH_PRIVATE_KEY: ${{ inputs.cache-ssh-private-key }}
+        SCCACHE_CACHE_SSH_KNOWN_HOSTS: ${{ inputs.cache-ssh-known-hosts }}
+        SCCACHE_REDIS_PASSWORD: ${{ inputs.redis-password }}
+        SCCACHE_REDIS_LOCAL_PORT: ${{ inputs.redis-local-port }}
+        SCCACHE_REDIS_KEY_PREFIX: ${{ inputs.redis-key-prefix }}
         SCCACHE_DIST_SCHEDULER_URL: ${{ inputs.scheduler-url }}
         SCCACHE_DIST_AUTH_TOKEN: ${{ inputs.auth-token }}
       run: |
         set -euo pipefail
 
-        if [[ -z "${SCCACHE_DIST_SCHEDULER_URL}" ]]; then
+        cache_enabled=false
+        if [[ -n "${SCCACHE_REDIS_PASSWORD}" || -n "${SCCACHE_CACHE_SSH_PRIVATE_KEY}" || -n "${SCCACHE_CACHE_SSH_HOST}" || -n "${SCCACHE_CACHE_SSH_KNOWN_HOSTS}" ]]; then
+          if [[ -z "${SCCACHE_REDIS_PASSWORD}" || -z "${SCCACHE_CACHE_SSH_PRIVATE_KEY}" || -z "${SCCACHE_CACHE_SSH_HOST}" || -z "${SCCACHE_CACHE_SSH_KNOWN_HOSTS}" ]]; then
+            echo "::error title=Incomplete OVH Redis cache settings::SCCACHE_REDIS_PASSWORD, cache SSH host, private key, and known_hosts must be provided together."
+            exit 1
+          fi
+          cache_enabled=true
+        fi
+
+        dist_enabled=false
+        if [[ -n "${SCCACHE_DIST_AUTH_TOKEN}" ]]; then
+          dist_enabled=true
+        fi
+
+        if [[ "${dist_enabled}" == "true" && -z "${SCCACHE_DIST_SCHEDULER_URL}" ]]; then
           echo "::error title=Missing scheduler URL::SCCACHE_DIST_SCHEDULER_URL is required when SCCACHE_DIST_AUTH_TOKEN is set."
           exit 1
         fi
 
-        if [[ "${SCCACHE_DIST_SCHEDULER_URL}" != https://* ]]; then
+        if [[ "${dist_enabled}" == "true" && "${SCCACHE_DIST_SCHEDULER_URL}" != https://* ]]; then
           echo "::error title=Insecure scheduler URL::SCCACHE_DIST_SCHEDULER_URL must use https://"
           exit 1
         fi
@@ -50,19 +104,56 @@ runs:
 
         scheduler_url_toml="$(toml_basic_string "${SCCACHE_DIST_SCHEDULER_URL}")"
         auth_token_toml="$(toml_basic_string "${SCCACHE_DIST_AUTH_TOKEN}")"
+        redis_password_toml="$(toml_basic_string "${SCCACHE_REDIS_PASSWORD}")"
+        redis_key_prefix_toml="$(toml_basic_string "${SCCACHE_REDIS_KEY_PREFIX}")"
+        redis_endpoint_toml="$(toml_basic_string "redis://127.0.0.1:${SCCACHE_REDIS_LOCAL_PORT}")"
+
+        if [[ "${cache_enabled}" == "true" ]]; then
+          mkdir -p "${HOME}/.ssh"
+          chmod 700 "${HOME}/.ssh"
+          ssh_key="${RUNNER_TEMP}/sccache-cache-ssh-key"
+          known_hosts="${RUNNER_TEMP}/sccache-cache-known-hosts"
+          printf '%s\n' "${SCCACHE_CACHE_SSH_PRIVATE_KEY}" | tr -d '\r' > "${ssh_key}"
+          printf '%s\n' "${SCCACHE_CACHE_SSH_KNOWN_HOSTS}" | tr -d '\r' > "${known_hosts}"
+          chmod 600 "${ssh_key}" "${known_hosts}"
+
+          ssh -f -N \
+            -o ExitOnForwardFailure=yes \
+            -o ServerAliveInterval=30 \
+            -o ServerAliveCountMax=3 \
+            -o StrictHostKeyChecking=yes \
+            -o UserKnownHostsFile="${known_hosts}" \
+            -i "${ssh_key}" \
+            -p "${SCCACHE_CACHE_SSH_PORT}" \
+            -L "127.0.0.1:${SCCACHE_REDIS_LOCAL_PORT}:127.0.0.1:6379" \
+            "${SCCACHE_CACHE_SSH_USER}@${SCCACHE_CACHE_SSH_HOST}"
+        fi
 
         mkdir -p "${HOME}/.config/sccache"
         {
-          printf '%s\n' "[dist]"
-          printf 'scheduler_url = %s\n' "${scheduler_url_toml}"
-          printf '%s\n' "toolchains = []"
-          printf '%s\n' "toolchain_cache_size = 5368709120"
-          printf '%s\n' ""
-          printf '%s\n' "[dist.auth]"
-          printf '%s\n' 'type = "token"'
-          printf 'token = %s\n' "${auth_token_toml}"
+          if [[ "${cache_enabled}" == "true" ]]; then
+            printf '%s\n' "[cache.redis]"
+            printf 'endpoint = %s\n' "${redis_endpoint_toml}"
+            printf 'password = %s\n' "${redis_password_toml}"
+            printf '%s\n' "expiration = 1209600"
+            printf 'key_prefix = %s\n' "${redis_key_prefix_toml}"
+            printf '%s\n' ""
+          fi
+
+          if [[ "${dist_enabled}" == "true" ]]; then
+            printf '%s\n' "[dist]"
+            printf 'scheduler_url = %s\n' "${scheduler_url_toml}"
+            printf '%s\n' "toolchains = []"
+            printf '%s\n' "toolchain_cache_size = 5368709120"
+            printf '%s\n' ""
+            printf '%s\n' "[dist.auth]"
+            printf '%s\n' 'type = "token"'
+            printf 'token = %s\n' "${auth_token_toml}"
+          fi
         } > "${HOME}/.config/sccache/config"
         chmod 600 "${HOME}/.config/sccache/config"
         echo "RUSTC_WRAPPER=sccache" >> "${GITHUB_ENV}"
         sccache --stop-server || true
-        sccache --dist-status
+        if [[ "${dist_enabled}" == "true" ]]; then
+          sccache --dist-status
+        fi

--- a/.github/actions/setup-sccache-dist/action.yml
+++ b/.github/actions/setup-sccache-dist/action.yml
@@ -1,0 +1,61 @@
+name: Setup distributed sccache
+description: Install sccache and configure the OVH distributed compiler backend when credentials are available.
+
+inputs:
+  scheduler-url:
+    description: HTTPS URL for the sccache-dist scheduler.
+    required: false
+    default: ""
+  auth-token:
+    description: Token for the sccache-dist scheduler.
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Skip unavailable distributed sccache
+      if: ${{ inputs.auth-token == '' }}
+      shell: bash
+      run: echo "::notice title=Distributed sccache skipped::SCCACHE_DIST_AUTH_TOKEN is unavailable; using local compilation."
+
+    - name: Install sccache
+      if: ${{ inputs.auth-token != '' }}
+      uses: mozilla-actions/sccache-action@1583d6b38d7be47f593cb472781bbb21cab4321e # v0.0.10
+      with:
+        version: v0.16.0
+
+    - name: Configure distributed sccache
+      if: ${{ inputs.auth-token != '' }}
+      shell: bash
+      env:
+        SCCACHE_DIST_SCHEDULER_URL: ${{ inputs.scheduler-url }}
+        SCCACHE_DIST_AUTH_TOKEN: ${{ inputs.auth-token }}
+      run: |
+        set -euo pipefail
+
+        if [[ -z "${SCCACHE_DIST_SCHEDULER_URL}" ]]; then
+          echo "::error title=Missing scheduler URL::SCCACHE_DIST_SCHEDULER_URL is required when SCCACHE_DIST_AUTH_TOKEN is set."
+          exit 1
+        fi
+
+        if [[ "${SCCACHE_DIST_SCHEDULER_URL}" != https://* ]]; then
+          echo "::error title=Insecure scheduler URL::SCCACHE_DIST_SCHEDULER_URL must use https://"
+          exit 1
+        fi
+
+        mkdir -p "${HOME}/.config/sccache"
+        cat > "${HOME}/.config/sccache/config" <<EOF
+        [dist]
+        scheduler_url = "${SCCACHE_DIST_SCHEDULER_URL}"
+        toolchains = []
+        toolchain_cache_size = 5368709120
+
+        [dist.auth]
+        type = "token"
+        token = "${SCCACHE_DIST_AUTH_TOKEN}"
+        EOF
+        chmod 600 "${HOME}/.config/sccache/config"
+        echo "RUSTC_WRAPPER=sccache" >> "${GITHUB_ENV}"
+        sccache --stop-server || true
+        sccache --dist-status

--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -191,6 +191,11 @@ jobs:
           # Keep saves to protected-branch and merge_group runs so the ~10 GB
           # repo cache LRU is seeded by shared states, not arbitrary PR branches.
           save-if: ${{ matrix.name == 'all-features' && ((github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'merge_group') }}
+      - name: Setup distributed sccache
+        uses: ./.github/actions/setup-sccache-dist
+        with:
+          scheduler-url: ${{ vars.SCCACHE_DIST_SCHEDULER_URL }}
+          auth-token: ${{ secrets.SCCACHE_DIST_AUTH_TOKEN }}
       - name: Check lints
         run: cargo clippy --all --tests --examples ${{ matrix.flags }} -- -D warnings
 
@@ -244,6 +249,11 @@ jobs:
           # Keep saves to protected-branch and merge_group runs so the ~10 GB
           # repo cache LRU is seeded by shared states, not arbitrary PR branches.
           save-if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'merge_group' }}
+      - name: Setup distributed sccache
+        uses: ./.github/actions/setup-sccache-dist
+        with:
+          scheduler-url: ${{ vars.SCCACHE_DIST_SCHEDULER_URL }}
+          auth-token: ${{ secrets.SCCACHE_DIST_AUTH_TOKEN }}
       - name: Test Reborn boot config crate
         run: cargo test -p ironclaw_reborn_config
       - name: Test Reborn CLI binary crate

--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -258,8 +258,9 @@ jobs:
       - name: Setup OVH sccache
         uses: ./.github/actions/setup-sccache-dist
         with:
-          scheduler-url: ${{ vars.SCCACHE_DIST_SCHEDULER_URL }}
-          auth-token: ${{ secrets.SCCACHE_DIST_AUTH_TOKEN }}
+          # Keep this Wasmtime-heavy smoke target cache-only. sccache-dist can
+          # corrupt generated Wasmtime/Wiggle inputs and produce bogus type
+          # resolution failures.
           cache-ssh-host: ${{ vars.SCCACHE_CACHE_SSH_HOST }}
           cache-ssh-user: ${{ vars.SCCACHE_CACHE_SSH_USER }}
           cache-ssh-port: ${{ vars.SCCACHE_CACHE_SSH_PORT }}

--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -191,11 +191,17 @@ jobs:
           # Keep saves to protected-branch and merge_group runs so the ~10 GB
           # repo cache LRU is seeded by shared states, not arbitrary PR branches.
           save-if: ${{ matrix.name == 'all-features' && ((github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'merge_group') }}
-      - name: Setup distributed sccache
+      - name: Setup OVH sccache
         uses: ./.github/actions/setup-sccache-dist
         with:
           scheduler-url: ${{ vars.SCCACHE_DIST_SCHEDULER_URL }}
           auth-token: ${{ secrets.SCCACHE_DIST_AUTH_TOKEN }}
+          cache-ssh-host: ${{ vars.SCCACHE_CACHE_SSH_HOST }}
+          cache-ssh-user: ${{ vars.SCCACHE_CACHE_SSH_USER }}
+          cache-ssh-port: ${{ vars.SCCACHE_CACHE_SSH_PORT }}
+          cache-ssh-private-key: ${{ secrets.SCCACHE_CACHE_SSH_PRIVATE_KEY }}
+          cache-ssh-known-hosts: ${{ secrets.SCCACHE_CACHE_SSH_KNOWN_HOSTS }}
+          redis-password: ${{ secrets.SCCACHE_REDIS_PASSWORD }}
       - name: Check lints
         run: cargo clippy --all --tests --examples ${{ matrix.flags }} -- -D warnings
 
@@ -249,11 +255,17 @@ jobs:
           # Keep saves to protected-branch and merge_group runs so the ~10 GB
           # repo cache LRU is seeded by shared states, not arbitrary PR branches.
           save-if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'merge_group' }}
-      - name: Setup distributed sccache
+      - name: Setup OVH sccache
         uses: ./.github/actions/setup-sccache-dist
         with:
           scheduler-url: ${{ vars.SCCACHE_DIST_SCHEDULER_URL }}
           auth-token: ${{ secrets.SCCACHE_DIST_AUTH_TOKEN }}
+          cache-ssh-host: ${{ vars.SCCACHE_CACHE_SSH_HOST }}
+          cache-ssh-user: ${{ vars.SCCACHE_CACHE_SSH_USER }}
+          cache-ssh-port: ${{ vars.SCCACHE_CACHE_SSH_PORT }}
+          cache-ssh-private-key: ${{ secrets.SCCACHE_CACHE_SSH_PRIVATE_KEY }}
+          cache-ssh-known-hosts: ${{ secrets.SCCACHE_CACHE_SSH_KNOWN_HOSTS }}
+          redis-password: ${{ secrets.SCCACHE_REDIS_PASSWORD }}
       - name: Test Reborn boot config crate
         run: cargo test -p ironclaw_reborn_config
       - name: Test Reborn CLI binary crate

--- a/.github/workflows/live-canary.yml
+++ b/.github/workflows/live-canary.yml
@@ -394,6 +394,11 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: live-canary-workflow-canary
+      - name: Setup distributed sccache
+        uses: ./.github/actions/setup-sccache-dist
+        with:
+          scheduler-url: ${{ vars.SCCACHE_DIST_SCHEDULER_URL }}
+          auth-token: ${{ secrets.SCCACHE_DIST_AUTH_TOKEN }}
       - name: Install cargo-component
         run: cargo install cargo-component --locked || true
       - name: Build WASM channels
@@ -431,6 +436,11 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: live-canary-deterministic-replay
+      - name: Setup distributed sccache
+        uses: ./.github/actions/setup-sccache-dist
+        with:
+          scheduler-url: ${{ vars.SCCACHE_DIST_SCHEDULER_URL }}
+          auth-token: ${{ secrets.SCCACHE_DIST_AUTH_TOKEN }}
       - name: Install cargo-component
         run: cargo install cargo-component --locked || true
       - name: Build WASM extensions
@@ -474,6 +484,11 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: live-canary-public-smoke
+      - name: Setup distributed sccache
+        uses: ./.github/actions/setup-sccache-dist
+        with:
+          scheduler-url: ${{ vars.SCCACHE_DIST_SCHEDULER_URL }}
+          auth-token: ${{ secrets.SCCACHE_DIST_AUTH_TOKEN }}
       - name: Install cargo-component
         run: cargo install cargo-component --locked || true
       - name: Build WASM extensions
@@ -692,6 +707,12 @@ jobs:
         if: steps.resolve_reborn_webui_v2_cases.outputs.skip_shard != '1'
         with:
           key: live-canary-reborn-webui-v2-live-qa
+      - name: Setup distributed sccache
+        if: steps.resolve_reborn_webui_v2_cases.outputs.skip_shard != '1'
+        uses: ./.github/actions/setup-sccache-dist
+        with:
+          scheduler-url: ${{ vars.SCCACHE_DIST_SCHEDULER_URL }}
+          auth-token: ${{ secrets.SCCACHE_DIST_AUTH_TOKEN }}
       - name: Install cargo-component
         if: steps.resolve_reborn_webui_v2_cases.outputs.skip_shard != '1'
         run: cargo install cargo-component --locked || true
@@ -792,6 +813,11 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: live-canary-persona-rotating
+      - name: Setup distributed sccache
+        uses: ./.github/actions/setup-sccache-dist
+        with:
+          scheduler-url: ${{ vars.SCCACHE_DIST_SCHEDULER_URL }}
+          auth-token: ${{ secrets.SCCACHE_DIST_AUTH_TOKEN }}
       - name: Install cargo-component
         run: cargo install cargo-component --locked || true
       - name: Build WASM extensions
@@ -900,6 +926,11 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: live-canary-provider-${{ matrix.provider }}
+      - name: Setup distributed sccache
+        uses: ./.github/actions/setup-sccache-dist
+        with:
+          scheduler-url: ${{ vars.SCCACHE_DIST_SCHEDULER_URL }}
+          auth-token: ${{ secrets.SCCACHE_DIST_AUTH_TOKEN }}
       - name: Install cargo-component
         run: cargo install cargo-component --locked || true
       - name: Build WASM extensions
@@ -964,6 +995,11 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: live-canary-release-public-full
+      - name: Setup distributed sccache
+        uses: ./.github/actions/setup-sccache-dist
+        with:
+          scheduler-url: ${{ vars.SCCACHE_DIST_SCHEDULER_URL }}
+          auth-token: ${{ secrets.SCCACHE_DIST_AUTH_TOKEN }}
       - name: Install cargo-component
         run: cargo install cargo-component --locked || true
       - name: Build WASM extensions
@@ -1006,6 +1042,11 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: live-canary-upgrade
+      - name: Setup distributed sccache
+        uses: ./.github/actions/setup-sccache-dist
+        with:
+          scheduler-url: ${{ vars.SCCACHE_DIST_SCHEDULER_URL }}
+          auth-token: ${{ secrets.SCCACHE_DIST_AUTH_TOKEN }}
       - name: Run upgrade canary lane
         env:
           LANE: upgrade-canary

--- a/.github/workflows/live-canary.yml
+++ b/.github/workflows/live-canary.yml
@@ -394,11 +394,17 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: live-canary-workflow-canary
-      - name: Setup distributed sccache
+      - name: Setup OVH sccache
         uses: ./.github/actions/setup-sccache-dist
         with:
           scheduler-url: ${{ vars.SCCACHE_DIST_SCHEDULER_URL }}
           auth-token: ${{ secrets.SCCACHE_DIST_AUTH_TOKEN }}
+          cache-ssh-host: ${{ vars.SCCACHE_CACHE_SSH_HOST }}
+          cache-ssh-user: ${{ vars.SCCACHE_CACHE_SSH_USER }}
+          cache-ssh-port: ${{ vars.SCCACHE_CACHE_SSH_PORT }}
+          cache-ssh-private-key: ${{ secrets.SCCACHE_CACHE_SSH_PRIVATE_KEY }}
+          cache-ssh-known-hosts: ${{ secrets.SCCACHE_CACHE_SSH_KNOWN_HOSTS }}
+          redis-password: ${{ secrets.SCCACHE_REDIS_PASSWORD }}
       - name: Install cargo-component
         run: cargo install cargo-component --locked || true
       - name: Build WASM channels
@@ -436,11 +442,17 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: live-canary-deterministic-replay
-      - name: Setup distributed sccache
+      - name: Setup OVH sccache
         uses: ./.github/actions/setup-sccache-dist
         with:
           scheduler-url: ${{ vars.SCCACHE_DIST_SCHEDULER_URL }}
           auth-token: ${{ secrets.SCCACHE_DIST_AUTH_TOKEN }}
+          cache-ssh-host: ${{ vars.SCCACHE_CACHE_SSH_HOST }}
+          cache-ssh-user: ${{ vars.SCCACHE_CACHE_SSH_USER }}
+          cache-ssh-port: ${{ vars.SCCACHE_CACHE_SSH_PORT }}
+          cache-ssh-private-key: ${{ secrets.SCCACHE_CACHE_SSH_PRIVATE_KEY }}
+          cache-ssh-known-hosts: ${{ secrets.SCCACHE_CACHE_SSH_KNOWN_HOSTS }}
+          redis-password: ${{ secrets.SCCACHE_REDIS_PASSWORD }}
       - name: Install cargo-component
         run: cargo install cargo-component --locked || true
       - name: Build WASM extensions
@@ -484,11 +496,17 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: live-canary-public-smoke
-      - name: Setup distributed sccache
+      - name: Setup OVH sccache
         uses: ./.github/actions/setup-sccache-dist
         with:
           scheduler-url: ${{ vars.SCCACHE_DIST_SCHEDULER_URL }}
           auth-token: ${{ secrets.SCCACHE_DIST_AUTH_TOKEN }}
+          cache-ssh-host: ${{ vars.SCCACHE_CACHE_SSH_HOST }}
+          cache-ssh-user: ${{ vars.SCCACHE_CACHE_SSH_USER }}
+          cache-ssh-port: ${{ vars.SCCACHE_CACHE_SSH_PORT }}
+          cache-ssh-private-key: ${{ secrets.SCCACHE_CACHE_SSH_PRIVATE_KEY }}
+          cache-ssh-known-hosts: ${{ secrets.SCCACHE_CACHE_SSH_KNOWN_HOSTS }}
+          redis-password: ${{ secrets.SCCACHE_REDIS_PASSWORD }}
       - name: Install cargo-component
         run: cargo install cargo-component --locked || true
       - name: Build WASM extensions
@@ -707,12 +725,18 @@ jobs:
         if: steps.resolve_reborn_webui_v2_cases.outputs.skip_shard != '1'
         with:
           key: live-canary-reborn-webui-v2-live-qa
-      - name: Setup distributed sccache
+      - name: Setup OVH sccache
         if: steps.resolve_reborn_webui_v2_cases.outputs.skip_shard != '1'
         uses: ./.github/actions/setup-sccache-dist
         with:
           scheduler-url: ${{ vars.SCCACHE_DIST_SCHEDULER_URL }}
           auth-token: ${{ secrets.SCCACHE_DIST_AUTH_TOKEN }}
+          cache-ssh-host: ${{ vars.SCCACHE_CACHE_SSH_HOST }}
+          cache-ssh-user: ${{ vars.SCCACHE_CACHE_SSH_USER }}
+          cache-ssh-port: ${{ vars.SCCACHE_CACHE_SSH_PORT }}
+          cache-ssh-private-key: ${{ secrets.SCCACHE_CACHE_SSH_PRIVATE_KEY }}
+          cache-ssh-known-hosts: ${{ secrets.SCCACHE_CACHE_SSH_KNOWN_HOSTS }}
+          redis-password: ${{ secrets.SCCACHE_REDIS_PASSWORD }}
       - name: Install cargo-component
         if: steps.resolve_reborn_webui_v2_cases.outputs.skip_shard != '1'
         run: cargo install cargo-component --locked || true
@@ -813,11 +837,17 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: live-canary-persona-rotating
-      - name: Setup distributed sccache
+      - name: Setup OVH sccache
         uses: ./.github/actions/setup-sccache-dist
         with:
           scheduler-url: ${{ vars.SCCACHE_DIST_SCHEDULER_URL }}
           auth-token: ${{ secrets.SCCACHE_DIST_AUTH_TOKEN }}
+          cache-ssh-host: ${{ vars.SCCACHE_CACHE_SSH_HOST }}
+          cache-ssh-user: ${{ vars.SCCACHE_CACHE_SSH_USER }}
+          cache-ssh-port: ${{ vars.SCCACHE_CACHE_SSH_PORT }}
+          cache-ssh-private-key: ${{ secrets.SCCACHE_CACHE_SSH_PRIVATE_KEY }}
+          cache-ssh-known-hosts: ${{ secrets.SCCACHE_CACHE_SSH_KNOWN_HOSTS }}
+          redis-password: ${{ secrets.SCCACHE_REDIS_PASSWORD }}
       - name: Install cargo-component
         run: cargo install cargo-component --locked || true
       - name: Build WASM extensions
@@ -926,11 +956,17 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: live-canary-provider-${{ matrix.provider }}
-      - name: Setup distributed sccache
+      - name: Setup OVH sccache
         uses: ./.github/actions/setup-sccache-dist
         with:
           scheduler-url: ${{ vars.SCCACHE_DIST_SCHEDULER_URL }}
           auth-token: ${{ secrets.SCCACHE_DIST_AUTH_TOKEN }}
+          cache-ssh-host: ${{ vars.SCCACHE_CACHE_SSH_HOST }}
+          cache-ssh-user: ${{ vars.SCCACHE_CACHE_SSH_USER }}
+          cache-ssh-port: ${{ vars.SCCACHE_CACHE_SSH_PORT }}
+          cache-ssh-private-key: ${{ secrets.SCCACHE_CACHE_SSH_PRIVATE_KEY }}
+          cache-ssh-known-hosts: ${{ secrets.SCCACHE_CACHE_SSH_KNOWN_HOSTS }}
+          redis-password: ${{ secrets.SCCACHE_REDIS_PASSWORD }}
       - name: Install cargo-component
         run: cargo install cargo-component --locked || true
       - name: Build WASM extensions
@@ -995,11 +1031,17 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: live-canary-release-public-full
-      - name: Setup distributed sccache
+      - name: Setup OVH sccache
         uses: ./.github/actions/setup-sccache-dist
         with:
           scheduler-url: ${{ vars.SCCACHE_DIST_SCHEDULER_URL }}
           auth-token: ${{ secrets.SCCACHE_DIST_AUTH_TOKEN }}
+          cache-ssh-host: ${{ vars.SCCACHE_CACHE_SSH_HOST }}
+          cache-ssh-user: ${{ vars.SCCACHE_CACHE_SSH_USER }}
+          cache-ssh-port: ${{ vars.SCCACHE_CACHE_SSH_PORT }}
+          cache-ssh-private-key: ${{ secrets.SCCACHE_CACHE_SSH_PRIVATE_KEY }}
+          cache-ssh-known-hosts: ${{ secrets.SCCACHE_CACHE_SSH_KNOWN_HOSTS }}
+          redis-password: ${{ secrets.SCCACHE_REDIS_PASSWORD }}
       - name: Install cargo-component
         run: cargo install cargo-component --locked || true
       - name: Build WASM extensions
@@ -1042,11 +1084,17 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: live-canary-upgrade
-      - name: Setup distributed sccache
+      - name: Setup OVH sccache
         uses: ./.github/actions/setup-sccache-dist
         with:
           scheduler-url: ${{ vars.SCCACHE_DIST_SCHEDULER_URL }}
           auth-token: ${{ secrets.SCCACHE_DIST_AUTH_TOKEN }}
+          cache-ssh-host: ${{ vars.SCCACHE_CACHE_SSH_HOST }}
+          cache-ssh-user: ${{ vars.SCCACHE_CACHE_SSH_USER }}
+          cache-ssh-port: ${{ vars.SCCACHE_CACHE_SSH_PORT }}
+          cache-ssh-private-key: ${{ secrets.SCCACHE_CACHE_SSH_PRIVATE_KEY }}
+          cache-ssh-known-hosts: ${{ secrets.SCCACHE_CACHE_SSH_KNOWN_HOSTS }}
+          redis-password: ${{ secrets.SCCACHE_REDIS_PASSWORD }}
       - name: Run upgrade canary lane
         env:
           LANE: upgrade-canary

--- a/.github/workflows/reborn-coverage.yml
+++ b/.github/workflows/reborn-coverage.yml
@@ -88,6 +88,12 @@ jobs:
           # (invisible to other PRs) that evicts the useful seed.
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
+      - name: Setup distributed sccache
+        uses: ./.github/actions/setup-sccache-dist
+        with:
+          scheduler-url: ${{ vars.SCCACHE_DIST_SCHEDULER_URL }}
+          auth-token: ${{ secrets.SCCACHE_DIST_AUTH_TOKEN }}
+
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@62b0f2dec647a8e604c6a0fda0e38530180dce20 # cargo-llvm-cov
 

--- a/.github/workflows/reborn-coverage.yml
+++ b/.github/workflows/reborn-coverage.yml
@@ -88,11 +88,17 @@ jobs:
           # (invisible to other PRs) that evicts the useful seed.
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
-      - name: Setup distributed sccache
+      - name: Setup OVH sccache
         uses: ./.github/actions/setup-sccache-dist
         with:
           scheduler-url: ${{ vars.SCCACHE_DIST_SCHEDULER_URL }}
           auth-token: ${{ secrets.SCCACHE_DIST_AUTH_TOKEN }}
+          cache-ssh-host: ${{ vars.SCCACHE_CACHE_SSH_HOST }}
+          cache-ssh-user: ${{ vars.SCCACHE_CACHE_SSH_USER }}
+          cache-ssh-port: ${{ vars.SCCACHE_CACHE_SSH_PORT }}
+          cache-ssh-private-key: ${{ secrets.SCCACHE_CACHE_SSH_PRIVATE_KEY }}
+          cache-ssh-known-hosts: ${{ secrets.SCCACHE_CACHE_SSH_KNOWN_HOSTS }}
+          redis-password: ${{ secrets.SCCACHE_REDIS_PASSWORD }}
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@62b0f2dec647a8e604c6a0fda0e38530180dce20 # cargo-llvm-cov

--- a/.github/workflows/reborn-tests.yml
+++ b/.github/workflows/reborn-tests.yml
@@ -253,12 +253,17 @@ jobs:
               ;;
           esac
 
-      - name: Setup distributed sccache
-        if: steps.sccache-dist-eligibility.outputs.enabled == 'true'
+      - name: Setup OVH sccache
         uses: ./.github/actions/setup-sccache-dist
         with:
-          scheduler-url: ${{ vars.SCCACHE_DIST_SCHEDULER_URL }}
-          auth-token: ${{ secrets.SCCACHE_DIST_AUTH_TOKEN }}
+          scheduler-url: ${{ steps.sccache-dist-eligibility.outputs.enabled == 'true' && vars.SCCACHE_DIST_SCHEDULER_URL || '' }}
+          auth-token: ${{ steps.sccache-dist-eligibility.outputs.enabled == 'true' && secrets.SCCACHE_DIST_AUTH_TOKEN || '' }}
+          cache-ssh-host: ${{ vars.SCCACHE_CACHE_SSH_HOST }}
+          cache-ssh-user: ${{ vars.SCCACHE_CACHE_SSH_USER }}
+          cache-ssh-port: ${{ vars.SCCACHE_CACHE_SSH_PORT }}
+          cache-ssh-private-key: ${{ secrets.SCCACHE_CACHE_SSH_PRIVATE_KEY }}
+          cache-ssh-known-hosts: ${{ secrets.SCCACHE_CACHE_SSH_KNOWN_HOSTS }}
+          redis-password: ${{ secrets.SCCACHE_REDIS_PASSWORD }}
 
       - name: Run crate tests
         env:
@@ -346,6 +351,16 @@ jobs:
           # repo cache LRU is seeded by shared states, not arbitrary PR branches.
           save-if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'merge_group' }}
 
+      - name: Setup OVH sccache cache
+        uses: ./.github/actions/setup-sccache-dist
+        with:
+          cache-ssh-host: ${{ vars.SCCACHE_CACHE_SSH_HOST }}
+          cache-ssh-user: ${{ vars.SCCACHE_CACHE_SSH_USER }}
+          cache-ssh-port: ${{ vars.SCCACHE_CACHE_SSH_PORT }}
+          cache-ssh-private-key: ${{ secrets.SCCACHE_CACHE_SSH_PRIVATE_KEY }}
+          cache-ssh-known-hosts: ${{ secrets.SCCACHE_CACHE_SSH_KNOWN_HOSTS }}
+          redis-password: ${{ secrets.SCCACHE_REDIS_PASSWORD }}
+
       - name: Run Reborn root tests
         run: scripts/ci/run-reborn-root-partition.sh
 
@@ -420,6 +435,16 @@ jobs:
           # repo cache LRU is seeded by shared states, not arbitrary PR branches.
           save-if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'merge_group' }}
 
+      - name: Setup OVH sccache cache
+        uses: ./.github/actions/setup-sccache-dist
+        with:
+          cache-ssh-host: ${{ vars.SCCACHE_CACHE_SSH_HOST }}
+          cache-ssh-user: ${{ vars.SCCACHE_CACHE_SSH_USER }}
+          cache-ssh-port: ${{ vars.SCCACHE_CACHE_SSH_PORT }}
+          cache-ssh-private-key: ${{ secrets.SCCACHE_CACHE_SSH_PRIVATE_KEY }}
+          cache-ssh-known-hosts: ${{ secrets.SCCACHE_CACHE_SSH_KNOWN_HOSTS }}
+          redis-password: ${{ secrets.SCCACHE_REDIS_PASSWORD }}
+
       - name: Run Reborn group tests
         run: scripts/ci/run-reborn-group-tests.sh
 
@@ -486,6 +511,16 @@ jobs:
         with:
           key: reborn-qa-recorded-fixtures
           save-if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'merge_group' }}
+
+      - name: Setup OVH sccache cache
+        uses: ./.github/actions/setup-sccache-dist
+        with:
+          cache-ssh-host: ${{ vars.SCCACHE_CACHE_SSH_HOST }}
+          cache-ssh-user: ${{ vars.SCCACHE_CACHE_SSH_USER }}
+          cache-ssh-port: ${{ vars.SCCACHE_CACHE_SSH_PORT }}
+          cache-ssh-private-key: ${{ secrets.SCCACHE_CACHE_SSH_PRIVATE_KEY }}
+          cache-ssh-known-hosts: ${{ secrets.SCCACHE_CACHE_SSH_KNOWN_HOSTS }}
+          redis-password: ${{ secrets.SCCACHE_REDIS_PASSWORD }}
 
       - name: Scrub Reborn QA fixtures
         run: scripts/ci/check-reborn-qa-fixtures.sh

--- a/.github/workflows/reborn-tests.yml
+++ b/.github/workflows/reborn-tests.yml
@@ -238,6 +238,12 @@ jobs:
           # repo cache LRU is seeded by shared states, not arbitrary PR branches.
           save-if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'merge_group' }}
 
+      - name: Setup distributed sccache
+        uses: ./.github/actions/setup-sccache-dist
+        with:
+          scheduler-url: ${{ vars.SCCACHE_DIST_SCHEDULER_URL }}
+          auth-token: ${{ secrets.SCCACHE_DIST_AUTH_TOKEN }}
+
       - name: Run crate tests
         env:
           PACKAGE: ${{ matrix.package }}
@@ -324,6 +330,12 @@ jobs:
           # repo cache LRU is seeded by shared states, not arbitrary PR branches.
           save-if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'merge_group' }}
 
+      - name: Setup distributed sccache
+        uses: ./.github/actions/setup-sccache-dist
+        with:
+          scheduler-url: ${{ vars.SCCACHE_DIST_SCHEDULER_URL }}
+          auth-token: ${{ secrets.SCCACHE_DIST_AUTH_TOKEN }}
+
       - name: Run Reborn root tests
         run: scripts/ci/run-reborn-root-partition.sh
 
@@ -398,6 +410,12 @@ jobs:
           # repo cache LRU is seeded by shared states, not arbitrary PR branches.
           save-if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'merge_group' }}
 
+      - name: Setup distributed sccache
+        uses: ./.github/actions/setup-sccache-dist
+        with:
+          scheduler-url: ${{ vars.SCCACHE_DIST_SCHEDULER_URL }}
+          auth-token: ${{ secrets.SCCACHE_DIST_AUTH_TOKEN }}
+
       - name: Run Reborn group tests
         run: scripts/ci/run-reborn-group-tests.sh
 
@@ -464,6 +482,12 @@ jobs:
         with:
           key: reborn-qa-recorded-fixtures
           save-if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'merge_group' }}
+
+      - name: Setup distributed sccache
+        uses: ./.github/actions/setup-sccache-dist
+        with:
+          scheduler-url: ${{ vars.SCCACHE_DIST_SCHEDULER_URL }}
+          auth-token: ${{ secrets.SCCACHE_DIST_AUTH_TOKEN }}
 
       - name: Scrub Reborn QA fixtures
         run: scripts/ci/check-reborn-qa-fixtures.sh

--- a/.github/workflows/reborn-tests.yml
+++ b/.github/workflows/reborn-tests.yml
@@ -244,7 +244,7 @@ jobs:
           PACKAGE: ${{ matrix.package }}
         run: |
           case "${PACKAGE}" in
-            ironclaw_first_party_extension_ports|ironclaw_host_runtime|ironclaw_reborn|ironclaw_reborn_composition|ironclaw_reborn_webui_ingress|ironclaw_wasm|ironclaw_wasm_product_adapters|ironclaw_wasm_sandbox_core)
+            ironclaw_first_party_extension_ports|ironclaw_host_runtime|ironclaw_loop_support|ironclaw_product_workflow|ironclaw_reborn|ironclaw_reborn_cli|ironclaw_reborn_composition|ironclaw_reborn_webui_ingress|ironclaw_wasm|ironclaw_wasm_product_adapters|ironclaw_wasm_sandbox_core)
               echo "enabled=false" >> "${GITHUB_OUTPUT}"
               echo "::notice title=Distributed sccache skipped::${PACKAGE} compiles wasmtime-wasi proc macros that read registry source files unavailable on the remote builder."
               ;;
@@ -346,12 +346,6 @@ jobs:
           # repo cache LRU is seeded by shared states, not arbitrary PR branches.
           save-if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'merge_group' }}
 
-      - name: Setup distributed sccache
-        uses: ./.github/actions/setup-sccache-dist
-        with:
-          scheduler-url: ${{ vars.SCCACHE_DIST_SCHEDULER_URL }}
-          auth-token: ${{ secrets.SCCACHE_DIST_AUTH_TOKEN }}
-
       - name: Run Reborn root tests
         run: scripts/ci/run-reborn-root-partition.sh
 
@@ -426,12 +420,6 @@ jobs:
           # repo cache LRU is seeded by shared states, not arbitrary PR branches.
           save-if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'merge_group' }}
 
-      - name: Setup distributed sccache
-        uses: ./.github/actions/setup-sccache-dist
-        with:
-          scheduler-url: ${{ vars.SCCACHE_DIST_SCHEDULER_URL }}
-          auth-token: ${{ secrets.SCCACHE_DIST_AUTH_TOKEN }}
-
       - name: Run Reborn group tests
         run: scripts/ci/run-reborn-group-tests.sh
 
@@ -498,12 +486,6 @@ jobs:
         with:
           key: reborn-qa-recorded-fixtures
           save-if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'merge_group' }}
-
-      - name: Setup distributed sccache
-        uses: ./.github/actions/setup-sccache-dist
-        with:
-          scheduler-url: ${{ vars.SCCACHE_DIST_SCHEDULER_URL }}
-          auth-token: ${{ secrets.SCCACHE_DIST_AUTH_TOKEN }}
 
       - name: Scrub Reborn QA fixtures
         run: scripts/ci/check-reborn-qa-fixtures.sh

--- a/.github/workflows/reborn-tests.yml
+++ b/.github/workflows/reborn-tests.yml
@@ -238,7 +238,23 @@ jobs:
           # repo cache LRU is seeded by shared states, not arbitrary PR branches.
           save-if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'merge_group' }}
 
+      - name: Resolve distributed sccache eligibility
+        id: sccache-dist-eligibility
+        env:
+          PACKAGE: ${{ matrix.package }}
+        run: |
+          case "${PACKAGE}" in
+            ironclaw_first_party_extension_ports|ironclaw_host_runtime|ironclaw_reborn|ironclaw_reborn_composition|ironclaw_reborn_webui_ingress|ironclaw_wasm|ironclaw_wasm_sandbox_core)
+              echo "enabled=false" >> "${GITHUB_OUTPUT}"
+              echo "::notice title=Distributed sccache skipped::${PACKAGE} compiles wasmtime-wasi proc macros that read registry source files unavailable on the remote builder."
+              ;;
+            *)
+              echo "enabled=true" >> "${GITHUB_OUTPUT}"
+              ;;
+          esac
+
       - name: Setup distributed sccache
+        if: steps.sccache-dist-eligibility.outputs.enabled == 'true'
         uses: ./.github/actions/setup-sccache-dist
         with:
           scheduler-url: ${{ vars.SCCACHE_DIST_SCHEDULER_URL }}

--- a/.github/workflows/reborn-tests.yml
+++ b/.github/workflows/reborn-tests.yml
@@ -244,7 +244,7 @@ jobs:
           PACKAGE: ${{ matrix.package }}
         run: |
           case "${PACKAGE}" in
-            ironclaw_first_party_extension_ports|ironclaw_host_runtime|ironclaw_reborn|ironclaw_reborn_composition|ironclaw_reborn_webui_ingress|ironclaw_wasm|ironclaw_wasm_sandbox_core)
+            ironclaw_first_party_extension_ports|ironclaw_host_runtime|ironclaw_reborn|ironclaw_reborn_composition|ironclaw_reborn_webui_ingress|ironclaw_wasm|ironclaw_wasm_product_adapters|ironclaw_wasm_sandbox_core)
               echo "enabled=false" >> "${GITHUB_OUTPUT}"
               echo "::notice title=Distributed sccache skipped::${PACKAGE} compiles wasmtime-wasi proc macros that read registry source files unavailable on the remote builder."
               ;;

--- a/.github/workflows/sccache-dist-smoke.yml
+++ b/.github/workflows/sccache-dist-smoke.yml
@@ -1,4 +1,4 @@
-name: sccache Dist Smoke
+name: sccache OVH Smoke
 
 on:
   workflow_dispatch:
@@ -8,62 +8,27 @@ permissions:
 
 jobs:
   smoke:
-    name: Verify distributed sccache
+    name: Verify OVH sccache
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    env:
-      RUSTC_WRAPPER: sccache
-      SCCACHE_DIST_SCHEDULER_URL: ${{ vars.SCCACHE_DIST_SCHEDULER_URL }}
-      SCCACHE_DIST_AUTH_TOKEN: ${{ secrets.SCCACHE_DIST_AUTH_TOKEN }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Check required sccache settings
-        shell: bash
-        run: |
-          set -euo pipefail
-          missing=0
-          for name in SCCACHE_DIST_SCHEDULER_URL SCCACHE_DIST_AUTH_TOKEN; do
-            if [[ -z "${!name:-}" ]]; then
-              echo "::error title=Missing sccache setting::$name is required"
-              missing=1
-            fi
-          done
-          if [[ -n "${SCCACHE_DIST_SCHEDULER_URL:-}" && "${SCCACHE_DIST_SCHEDULER_URL}" != https://* ]]; then
-            echo "::error title=Insecure scheduler URL::SCCACHE_DIST_SCHEDULER_URL must use https://"
-            missing=1
-          fi
-          exit "$missing"
-
       - name: Install Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
-      - name: Install sccache
-        uses: mozilla-actions/sccache-action@1583d6b38d7be47f593cb472781bbb21cab4321e # v0.0.10
+      - name: Setup OVH sccache
+        uses: ./.github/actions/setup-sccache-dist
         with:
-          version: v0.16.0
-
-      - name: Configure distributed sccache
-        shell: bash
-        run: |
-          set -euo pipefail
-          mkdir -p "$HOME/.config/sccache"
-          cat > "$HOME/.config/sccache/config" <<EOF
-          [dist]
-          scheduler_url = "${SCCACHE_DIST_SCHEDULER_URL}"
-          toolchains = []
-          toolchain_cache_size = 5368709120
-
-          [dist.auth]
-          type = "token"
-          token = "${SCCACHE_DIST_AUTH_TOKEN}"
-          EOF
-          chmod 600 "$HOME/.config/sccache/config"
-          sccache --stop-server || true
-
-      - name: Show distributed status
-        run: sccache --dist-status
+          scheduler-url: ${{ vars.SCCACHE_DIST_SCHEDULER_URL }}
+          auth-token: ${{ secrets.SCCACHE_DIST_AUTH_TOKEN }}
+          cache-ssh-host: ${{ vars.SCCACHE_CACHE_SSH_HOST }}
+          cache-ssh-user: ${{ vars.SCCACHE_CACHE_SSH_USER }}
+          cache-ssh-port: ${{ vars.SCCACHE_CACHE_SSH_PORT }}
+          cache-ssh-private-key: ${{ secrets.SCCACHE_CACHE_SSH_PRIVATE_KEY }}
+          cache-ssh-known-hosts: ${{ secrets.SCCACHE_CACHE_SSH_KNOWN_HOSTS }}
+          redis-password: ${{ secrets.SCCACHE_REDIS_PASSWORD }}
 
       - name: Build a small Rust crate through sccache
         run: cargo check -p ironclaw_reborn_config


### PR DESCRIPTION
## Summary
- add a reusable setup-sccache-dist composite action that installs sccache and configures the distributed backend only when the repo secret is available
- enforce HTTPS scheduler URLs before enabling RUSTC_WRAPPER
- enable distributed sccache for Reborn PR tests, Linux clippy/Reborn CLI smoke, Reborn coverage, and selected Ubuntu live-canary lanes

## Security notes
- this keeps jobs on GitHub-hosted runners; the OVH box is not registered as a self-hosted runner for PR code
- fork/untrusted contexts without SCCACHE_DIST_AUTH_TOKEN skip the distributed backend and compile locally
- the OVH token was rotated after host hardening
- host hardening verified: UFW default deny, SSH rate-limited, password/root login disabled, fail2ban active, scheduler 10600 externally closed, builder 10501 reachable for GitHub runners

## Verification
- ruby YAML parse for the new action and touched workflow files
- git diff --cached --check
- sccache dist status over HTTPS: num_servers=1, num_cpus=24
- external 10600 connection timed out; external 10501 connection succeeded

## Follow-up
- consider a GitHub Actions CIDR allowlist updater for 10501, or moving the build server behind a VPN/proxy if we want to eliminate the public builder port entirely
