### PR TITLE
Reject Slack DM IDs in shared-channel routes

### DIFF
--- a/crates/ironclaw_reborn_cli/src/commands/serve_slack.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/serve_slack.rs
@@ -177,6 +177,9 @@ fn parse_slack_channel_route_config(
     let subject_field = format!("channel_routes[{index}].subject_user_id");
     let channel_id = optional_slack_config_value(&channel_field, &route.channel_id)?
         .ok_or_else(|| anyhow!("[slack].{channel_field} must be set"))?;
+    if channel_id.starts_with('D') {
+        anyhow::bail!("[slack].{channel_field} must not be a Slack DM channel id");
+    }
     let subject_user_id =
         optional_slack_user_id_config_value(&subject_field, &route.subject_user_id)?
             .ok_or_else(|| anyhow!("[slack].{subject_field} must be set"))?;
@@ -595,6 +598,39 @@ mod tests {
             "legacy-signing-secret"
         );
         assert_eq!(legacy.bot_token.expose_secret(), "xoxb-legacy");
+    }
+
+    #[cfg(feature = "slack-v2-host-beta")]
+    #[test]
+    fn slack_host_beta_config_channel_route_rejects_dm_channel_id() {
+        let section = ironclaw_reborn_config::SlackSection {
+            enabled: Some(true),
+            installation_id: Some("install-alpha".to_string()),
+            team_id: Some("T123".to_string()),
+            api_app_id: Some("A123".to_string()),
+            channel_routes: vec![ironclaw_reborn_config::SlackChannelRouteSection {
+                channel_id: Some("D0HOST".to_string()),
+                subject_user_id: Some("user:eng-team-agent".to_string()),
+            }],
+            ..Default::default()
+        };
+
+        let error = resolve_slack_config_for_serve(
+            Some(&section),
+            &tenant_id("tenant"),
+            &agent_id("agent"),
+            None,
+            &user_id("web-user"),
+            std::path::Path::new("/tmp/reborn-config.toml"),
+        )
+        .expect_err("channel route must reject Slack DM channel IDs");
+
+        assert!(
+            error
+                .to_string()
+                .contains("[slack].channel_routes[0].channel_id"),
+            "message: {error}"
+        );
     }
 
     #[cfg(not(feature = "slack-v2-host-beta"))]

--- a/crates/ironclaw_reborn_composition/src/slack_channel_routes.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_channel_routes.rs
@@ -70,6 +70,9 @@ impl SlackChannelRouteKey {
         team_id: String,
         channel_id: String,
     ) -> Result<Self, SlackChannelRouteError> {
+        if channel_id.starts_with('D') {
+            return Err(SlackChannelRouteError::InvalidRoute);
+        }
         ProductConversationRouteKey::new(Some(team_id.clone()), channel_id.clone())
             .map_err(|_| SlackChannelRouteError::InvalidRoute)?;
         Ok(Self {
@@ -1265,6 +1268,38 @@ mod tests {
             .expect("response");
 
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        assert!(
+            store
+                .list_routes(
+                    &TenantId::new(TENANT).expect("tenant"),
+                    &AdapterInstallationId::new(INSTALLATION).expect("installation"),
+                    TEAM,
+                    0,
+                    DEFAULT_LIST_LIMIT,
+                )
+                .await
+                .expect("routes list")
+                .routes
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn route_admin_rejects_dm_channel_id_without_mutating_store() {
+        let store = Arc::new(InMemorySlackChannelRouteStore::new());
+        let mount = slack_channel_route_admin_route_mount(route_config(store.clone()));
+
+        let response = mount
+            .protected
+            .oneshot(request(
+                "PUT",
+                r#"{"channel_id":"D0HOST","subject_user_id":"user:eng-team-agent"}"#,
+                TENANT,
+            ))
+            .await
+            .expect("upsert responds");
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
         assert!(
             store
                 .list_routes(

--- a/crates/ironclaw_reborn_composition/src/slack_channel_routes/allowed/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_channel_routes/allowed/tests.rs
@@ -562,6 +562,34 @@ async fn allowed_channel_admin_rejects_invalid_channel_without_mutating_store() 
 }
 
 #[tokio::test]
+async fn allowed_channel_admin_rejects_dm_channel_without_mutating_store() {
+    let store = Arc::new(InMemorySlackChannelRouteStore::new());
+    let mount = slack_channel_route_admin_route_mount(route_config(store.clone()));
+
+    let response = mount
+        .protected
+        .oneshot(request("PUT", r#"{"channel_ids":["D0HOST"]}"#, TENANT))
+        .await
+        .expect("save responds");
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert!(
+        store
+            .list_routes(
+                &TenantId::new(TENANT).expect("tenant"),
+                &AdapterInstallationId::new(INSTALLATION).expect("installation"),
+                TEAM,
+                0,
+                DEFAULT_LIST_LIMIT,
+            )
+            .await
+            .expect("routes list")
+            .routes
+            .is_empty()
+    );
+}
+
+#[tokio::test]
 async fn allowed_channel_admin_rejects_more_than_max_allowed_channels_without_mutating_store() {
     let store = Arc::new(InMemorySlackChannelRouteStore::new());
     let mount = slack_channel_route_admin_route_mount(route_config(store.clone()));

--- a/crates/ironclaw_reborn_composition/src/slack_host_beta.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_host_beta.rs
@@ -889,6 +889,12 @@ fn slack_channel_route_key(
     team_id: &SlackTeamId,
     route: &SlackHostBetaChannelRoute,
 ) -> Result<ProductConversationRouteKey, SlackHostBetaBuildError> {
+    if route.channel_id.starts_with('D') {
+        return Err(invalid_config(
+            "channel_routes",
+            "Slack shared-channel routes must not use DM channel IDs".to_string(),
+        ));
+    }
     ProductConversationRouteKey::new(Some(team_id.as_str().to_string()), route.channel_id.clone())
         .map_err(|reason| invalid_config("channel_routes", reason.to_string()))
 }
@@ -3534,6 +3540,33 @@ mod tests {
 
         assert!(
             error.to_string().contains("duplicate channel_id 'C0HOST'"),
+            "message: {error}"
+        );
+    }
+
+    #[test]
+    fn slack_host_beta_config_rejects_dm_channel_route() {
+        let error = SlackHostBetaConfig::new(SlackHostBetaConfigInput {
+            tenant_id: TenantId::new(TENANT).expect("tenant"),
+            agent_id: AgentId::new(AGENT).expect("agent"),
+            project_id: Some(ProjectId::new(PROJECT).expect("project")),
+            installation_id: INSTALLATION.to_string(),
+            team_id: SlackTeamId::new(TEAM),
+            api_app_id: Some(API_APP.to_string()),
+            slack_user_id: Some(SLACK_USER.to_string()),
+            user_id: UserId::new(USER).expect("user"),
+            shared_subject_user_id: None,
+            channel_routes: vec![SlackHostBetaChannelRoute::new(
+                "D0HOST",
+                UserId::new("user:first-subject").expect("first subject"),
+            )],
+            signing_secret: SecretString::from(SECRET),
+            bot_token: SecretString::from("xoxb-host-token"),
+        })
+        .expect_err("DM channel routes must fail closed");
+
+        assert!(
+            error.to_string().contains("channel_routes"),
             "message: {error}"
         );
     }

--- a/crates/ironclaw_reborn_composition/src/slack_outbound_targets.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_outbound_targets.rs
@@ -319,6 +319,7 @@ impl SlackHostBetaOutboundTargetProvider {
             .as_str()
             .strip_prefix(&self.shared_target_id_prefix)
             .filter(|channel_id| !channel_id.is_empty())
+            .filter(|channel_id| !is_slack_dm_channel_id(channel_id))
     }
 
     fn user_id_for_personal_target_id(
@@ -369,6 +370,9 @@ impl SlackHostBetaOutboundTargetProvider {
             return None;
         }
         if rest.is_empty() {
+            if is_slack_dm_channel_id(conversation_id) {
+                return None;
+            }
             return Some(ParsedSlackReplyTarget::SharedChannel {
                 channel_id: conversation_id.to_string(),
             });
@@ -399,6 +403,9 @@ impl SlackHostBetaOutboundTargetProvider {
         &self,
         channel_id: &str,
     ) -> Result<Option<SlackConfiguredChannelRoute>, RebornServicesError> {
+        if is_slack_dm_channel_id(channel_id) {
+            return Ok(None);
+        }
         let key = match SlackChannelRouteKey::new(
             self.tenant_id.clone(),
             self.installation_id.clone(),
@@ -656,6 +663,16 @@ impl OutboundDeliveryTargetProvider for SlackHostBetaOutboundTargetProvider {
             // is suppressed (admin override takes precedence).
         }
         routes.sort_by(|left, right| left.channel_id.cmp(&right.channel_id));
+        routes.retain(|route| {
+            let keep = !is_slack_dm_channel_id(&route.channel_id);
+            if !keep {
+                tracing::warn!(
+                    channel_id = %route.channel_id,
+                    "Slack DM channel id was ignored in shared-channel outbound target routes"
+                );
+            }
+            keep
+        });
         let mut targets = routes
             .into_iter()
             .map(|route| self.entry_for_shared_channel_route(&route))
@@ -987,6 +1004,10 @@ fn slack_target_not_found_error() -> RebornServicesError {
         field: None,
         validation_code: None,
     }
+}
+
+fn is_slack_dm_channel_id(channel_id: &str) -> bool {
+    channel_id.starts_with('D')
 }
 
 fn slack_target_backend_error() -> RebornServicesError {
@@ -1352,6 +1373,64 @@ mod tests {
             target_ids
         );
         assert_eq!(listed.len(), 2, "exactly one shared + one DM target");
+    }
+
+    #[tokio::test]
+    async fn slack_list_outbound_delivery_targets_skips_dm_prefixed_shared_channel_routes() {
+        let routes = vec![
+            SlackConfiguredChannelRoute::new(
+                "D0HOST".to_string(),
+                UserId::new(USER).expect("user"),
+            ),
+            SlackConfiguredChannelRoute::new(
+                "C0HOST".to_string(),
+                UserId::new(USER).expect("user"),
+            ),
+        ];
+        let provider = SlackHostBetaOutboundTargetProvider::new(
+            provider_config(routes),
+            Arc::new(InMemorySlackChannelRouteStore::new()),
+            Arc::new(InMemorySlackPersonalDmTargetStore::new()),
+        );
+
+        let listed = provider
+            .list_outbound_delivery_targets(&caller())
+            .await
+            .expect("target list");
+
+        let target_ids: Vec<String> = listed
+            .iter()
+            .map(|entry| entry.summary.target_id.as_str().to_string())
+            .collect();
+        assert_eq!(
+            target_ids,
+            vec![format!("slack:shared-channel:{TEAM}:C0HOST")]
+        );
+    }
+
+    #[tokio::test]
+    async fn slack_shared_channel_target_id_rejects_dm_prefixed_channel_id() {
+        let provider = SlackHostBetaOutboundTargetProvider::new(
+            provider_config(vec![SlackConfiguredChannelRoute::new(
+                "D0HOST".to_string(),
+                UserId::new(USER).expect("user"),
+            )]),
+            Arc::new(InMemorySlackChannelRouteStore::new()),
+            Arc::new(InMemorySlackPersonalDmTargetStore::new()),
+        );
+        let target_id =
+            RebornOutboundDeliveryTargetId::new(format!("slack:shared-channel:{TEAM}:D0HOST"))
+                .expect("target id");
+
+        assert_eq!(provider.channel_id_for_target_id(&target_id), None);
+        let resolved = provider
+            .resolve_outbound_delivery_target(&caller(), &target_id)
+            .await
+            .expect("resolve succeeds");
+        assert!(
+            resolved.is_none(),
+            "D-prefixed IDs must not resolve through the shared-channel target path"
+        );
     }
 
     // ── shared_channel_routes cap guard ──────────────────────────────────────

--- a/crates/ironclaw_reborn_config/src/config_file.rs
+++ b/crates/ironclaw_reborn_config/src/config_file.rs
@@ -804,6 +804,14 @@ impl RebornConfigFile {
                         Cow::Owned(format!("slack.channel_routes[{index}].channel_id")),
                         channel_id,
                     )?;
+                    if channel_id.starts_with('D') {
+                        return Err(RebornConfigFileError::InvalidField {
+                            path: attributed_path.display().to_string(),
+                            field: format!("slack.channel_routes[{index}].channel_id"),
+                            reason: "Slack shared-channel routes must not use DM channel IDs"
+                                .to_string(),
+                        });
+                    }
                 }
                 if let Some(subject_user_id) = &route.subject_user_id {
                     check_non_empty_trimmed(
@@ -1458,6 +1466,27 @@ subject_user_id = "user:eng-team-agent"
         assert_eq!(
             slack.channel_routes[0].subject_user_id.as_deref(),
             Some("user:eng-team-agent")
+        );
+    }
+
+    #[test]
+    fn rejects_dm_prefixed_slack_channel_route_channel_id() {
+        let toml = r#"
+[slack]
+enabled = true
+
+[[slack.channel_routes]]
+channel_id = "D0HOST"
+subject_user_id = "user:eng-team-agent"
+"#;
+        let error = RebornConfigFile::parse_text(toml, &attributed())
+            .expect_err("DM-prefixed channel route IDs must fail validation");
+
+        assert!(
+            error
+                .to_string()
+                .contains("slack.channel_routes[0].channel_id"),
+            "message: {error}"
         );
     }
 


### PR DESCRIPTION
## Summary
- reject Slack DM channel IDs (`D...`) in shared-channel route config parsing
- reject DM-prefixed channel IDs through the Slack route admin APIs
- keep outbound delivery target resolution from treating DM IDs as shared-channel targets

## Testing
- `cargo test -p ironclaw_reborn_config rejects_dm_prefixed_slack_channel_route_channel_id -- --format terse`
- attempted `cargo test -p ironclaw_reborn_cli --features slack-v2-host-beta slack_host_beta_config_channel_route_rejects_dm_channel_id -- --format terse`, but local linking failed with `errno=28` / no space left on device before test execution
- attempted `cargo test -p ironclaw_reborn_composition dm_channel -- --format terse`, but local compilation failed with no space left on device before test execution

## Notes
This is intentionally split out from the live canary diagnostics PR so the canary PR remains harness-only.