### PR TITLE
Add OVH sccache to Reborn gateway smoke

### DIFF
--- a/.github/workflows/reborn-e2e.yml
+++ b/.github/workflows/reborn-e2e.yml
@@ -95,6 +95,16 @@ jobs:
           key: reborn-e2e-gateway-smoke
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
+      - name: Setup OVH sccache cache
+        uses: ./.github/actions/setup-sccache-dist
+        with:
+          cache-ssh-host: ${{ vars.SCCACHE_CACHE_SSH_HOST }}
+          cache-ssh-user: ${{ vars.SCCACHE_CACHE_SSH_USER }}
+          cache-ssh-port: ${{ vars.SCCACHE_CACHE_SSH_PORT }}
+          cache-ssh-private-key: ${{ secrets.SCCACHE_CACHE_SSH_PRIVATE_KEY }}
+          cache-ssh-known-hosts: ${{ secrets.SCCACHE_CACHE_SSH_KNOWN_HOSTS }}
+          redis-password: ${{ secrets.SCCACHE_REDIS_PASSWORD }}
+
       - name: Build ironclaw with libSQL
         run: cargo build --no-default-features --features libsql
 


### PR DESCRIPTION
## Summary
- add OVH Redis sccache setup to `Reborn E2E / Reborn gateway smoke`
- keep the setup cache-only, not distributed compile, to avoid the Wasmtime/Wiggle distributed sccache failures seen in earlier CI

## Benchmark result
Baseline from latest comparable main run:
- Reborn gateway smoke: 488s

This PR benchmark run:
- Reborn gateway smoke: 277s
- delta: 211s faster (~43%)
- sccache stats: 80 Rust hits, 1 Rust miss, 0 dist compiles, 0 dist errors, Redis backend

I also tested the other requested candidates and did not keep them because they were worse:
- Replay snapshot gate: 595s vs 497s baseline, slower
- WASM WIT Compatibility: 1063s vs 1020s/1049s baselines, slightly slower
- Benchmark Compilation: exceeded its 793s baseline and was cancelled to stop wasting CI

## Validation
- ruby YAML parse for touched workflows and setup action
- setup action embedded shell parses with bash -n
- git diff --check
