### PR TITLE
Stabilize QA6 and QA8 live canary assertions

### DIFF
--- a/scripts/reborn_webui_v2_live_qa/google_api_helpers.py
+++ b/scripts/reborn_webui_v2_live_qa/google_api_helpers.py
@@ -234,20 +234,38 @@ async def _wait_for_google_sheet_marker(
 ) -> dict[str, object]:
     deadline = time.monotonic() + timeout
     last_check: dict[str, object] | None = None
+    last_error: Exception | None = None
     while time.monotonic() < deadline:
-        last_check = await _google_sheet_contains_marker(
-            access_token=access_token,
-            spreadsheet_id=spreadsheet_id,
-            marker=marker,
-            range_name=range_name,
-        )
+        try:
+            last_check = await _google_sheet_contains_marker(
+                access_token=access_token,
+                spreadsheet_id=spreadsheet_id,
+                marker=marker,
+                range_name=range_name,
+            )
+            last_error = None
+        except AssertionError:
+            raise
+        except Exception as exc:
+            last_error = exc
+            last_check = None
+            await asyncio.sleep(2.0)
+            continue
         if last_check.get("found"):
             return last_check
         await asyncio.sleep(2.0)
+    last_error_text = ""
+    if last_error is not None:
+        exc_text = str(last_error)
+        last_error_text = (
+            f" last_error={type(last_error).__name__}: {exc_text}"
+            if exc_text
+            else f" last_error={type(last_error).__name__}"
+        )
     raise AssertionError(
         "Google Sheet marker was not observed before timeout. "
         f"spreadsheet_id_present={bool(spreadsheet_id)} marker={marker!r} "
-        f"last_check={last_check!r}"
+        f"last_check={last_check!r}{last_error_text}"
     )
 
 

--- a/scripts/reborn_webui_v2_live_qa/google_api_helpers.py
+++ b/scripts/reborn_webui_v2_live_qa/google_api_helpers.py
@@ -9,6 +9,18 @@ import urllib.parse
 
 from scripts.reborn_webui_v2_live_qa.env_helpers import _first_env_value
 
+try:
+    import httpx as _httpx
+except ModuleNotFoundError:
+    _httpx = None
+
+
+class _NoHttpxHTTPError(Exception):
+    pass
+
+
+_HTTPX_HTTP_ERROR = _httpx.HTTPError if _httpx is not None else _NoHttpxHTTPError
+
 _SPREADSHEET_ID_PATTERNS = (
     re.compile(r"https://docs\.google\.com/spreadsheets/d/([A-Za-z0-9_-]+)", re.IGNORECASE),
     re.compile(r"\bspreadsheet(?:\s+id)?\s*[:=]\s*([A-Za-z0-9_-]{20,})", re.IGNORECASE),
@@ -246,7 +258,7 @@ async def _wait_for_google_sheet_marker(
             last_error = None
         except AssertionError:
             raise
-        except Exception as exc:
+        except _HTTPX_HTTP_ERROR as exc:
             last_error = exc
             last_check = None
             await asyncio.sleep(2.0)

--- a/scripts/reborn_webui_v2_live_qa/run_live_qa.py
+++ b/scripts/reborn_webui_v2_live_qa/run_live_qa.py
@@ -2876,10 +2876,11 @@ async def case_qa_6e_gmail_to_sheet_delivery(ctx: LiveQaContext) -> ProbeResult:
                 "Drive lookup by exact sheet name did not find one"
             )
             return result
-        sheet_check = await _google_sheet_contains_marker(
+        sheet_check = await _wait_for_google_sheet_marker(
             access_token=access_token,
             spreadsheet_id=spreadsheet_id,
             marker=marker,
+            timeout=90.0,
         )
         result.details["google_token"] = token_meta
         result.details["spreadsheet_id"] = spreadsheet_id
@@ -2893,7 +2894,10 @@ async def case_qa_6e_gmail_to_sheet_delivery(ctx: LiveQaContext) -> ProbeResult:
         result.success = False
         result.latency_ms = int((time.monotonic() - started) * 1000)
         result.details["spreadsheet_id"] = spreadsheet_id
-        result.details["error"] = str(exc)
+        exc_text = str(exc)
+        result.details["error"] = (
+            f"{type(exc).__name__}: {exc_text}" if exc_text else type(exc).__name__
+        )
         return result
 
 
@@ -3644,7 +3648,7 @@ async def case_qa_8c_hn_keyword_slack_routine(ctx: LiveQaContext) -> ProbeResult
         case_name="qa_8c_hn_keyword_slack_routine",
         routine_name=routine_name,
         marker=None,
-        required_text=["routine"],
+        required_text=["routine|trigger|automation|cron|schedule|created|monitor"],
         prompt=_qa_sheet_prompt("qa_8c_hn_keyword_slack_routine"),
     )
 

--- a/scripts/reborn_webui_v2_live_qa/run_live_qa.py
+++ b/scripts/reborn_webui_v2_live_qa/run_live_qa.py
@@ -2885,9 +2885,6 @@ async def case_qa_6e_gmail_to_sheet_delivery(ctx: LiveQaContext) -> ProbeResult:
         result.details["google_token"] = token_meta
         result.details["spreadsheet_id"] = spreadsheet_id
         result.details["sheet_marker_check"] = sheet_check
-        if not sheet_check.get("found"):
-            result.success = False
-            result.details["error"] = "Google Sheet did not contain the QA marker row"
         result.latency_ms = int((time.monotonic() - started) * 1000)
         return result
     except Exception as exc:

--- a/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
+++ b/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
@@ -1586,16 +1586,20 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
         self.assertEqual(result.details["error"], "TimeoutError")
 
     def test_wait_for_google_sheet_marker_retries_transient_read_errors(self):
+        class FakeHttpxReadError(Exception):
+            pass
+
         attempts = 0
 
         async def fake_google_sheet_contains_marker(**_kwargs):
             nonlocal attempts
             attempts += 1
             if attempts == 1:
-                raise TimeoutError()
+                raise FakeHttpxReadError("read timed out")
             return {"found": True, "row_count": 2}
 
         with (
+            patch.object(google_api_helpers, "_HTTPX_HTTP_ERROR", FakeHttpxReadError),
             patch.object(
                 google_api_helpers,
                 "_google_sheet_contains_marker",
@@ -1616,10 +1620,14 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
         self.assertEqual(attempts, 2)
 
     def test_wait_for_google_sheet_marker_reports_empty_exception_type(self):
+        class FakeHttpxReadError(Exception):
+            pass
+
         async def fake_google_sheet_contains_marker(**_kwargs):
-            raise TimeoutError()
+            raise FakeHttpxReadError("")
 
         with (
+            patch.object(google_api_helpers, "_HTTPX_HTTP_ERROR", FakeHttpxReadError),
             patch.object(
                 google_api_helpers,
                 "_google_sheet_contains_marker",
@@ -1627,7 +1635,7 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
             ),
             patch.object(google_api_helpers.asyncio, "sleep", return_value=None),
         ):
-            with self.assertRaisesRegex(AssertionError, "last_error=TimeoutError"):
+            with self.assertRaisesRegex(AssertionError, "last_error=FakeHttpxReadError"):
                 asyncio.run(
                     google_api_helpers._wait_for_google_sheet_marker(
                         access_token="access-token",
@@ -1654,6 +1662,34 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
             patch.object(google_api_helpers.asyncio, "sleep", return_value=None),
         ):
             with self.assertRaisesRegex(AssertionError, "HTTP 403"):
+                asyncio.run(
+                    google_api_helpers._wait_for_google_sheet_marker(
+                        access_token="access-token",
+                        spreadsheet_id="spreadsheet-id",
+                        marker="marker",
+                        timeout=1.0,
+                    )
+                )
+
+        self.assertEqual(attempts, 1)
+
+    def test_wait_for_google_sheet_marker_propagates_unexpected_errors(self):
+        attempts = 0
+
+        async def fake_google_sheet_contains_marker(**_kwargs):
+            nonlocal attempts
+            attempts += 1
+            raise ValueError("bad sheet payload")
+
+        with (
+            patch.object(
+                google_api_helpers,
+                "_google_sheet_contains_marker",
+                side_effect=fake_google_sheet_contains_marker,
+            ),
+            patch.object(google_api_helpers.asyncio, "sleep", return_value=None),
+        ):
+            with self.assertRaisesRegex(ValueError, "bad sheet payload"):
                 asyncio.run(
                     google_api_helpers._wait_for_google_sheet_marker(
                         access_token="access-token",

--- a/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
+++ b/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
@@ -23,11 +23,13 @@ from pathlib import Path
 from unittest.mock import patch
 
 if __package__:
+    from . import google_api_helpers
     from . import run_live_qa
     from . import semantic_judge
     from . import text_match
 else:
     import run_live_qa
+    from scripts.reborn_webui_v2_live_qa import google_api_helpers
     import semantic_judge
     import text_match
 
@@ -1292,6 +1294,38 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
             ["news.ycombinator.com|hacker news|hn|discussion|id="],
         )
 
+    def test_hn_routine_accepts_schedule_monitor_confirmation(self):
+        captured: dict[str, object] = {}
+
+        async def fake_live_chat_case(_ctx, **kwargs):
+            captured.update(kwargs)
+            return run_live_qa.ProbeResult(
+                provider="test",
+                mode=f"live:{kwargs['case_name']}",
+                success=True,
+                latency_ms=1,
+                details={
+                    "text_excerpt": (
+                        "Done! Here's what was created: HN Monitor. "
+                        "Schedule: Every hour at :00."
+                    )
+                },
+            )
+
+        with (
+            patch.object(run_live_qa, "_live_chat_case", side_effect=fake_live_chat_case),
+            patch.object(run_live_qa, "_trigger_record_count", side_effect=[0, 1]),
+        ):
+            result = asyncio.run(
+                run_live_qa.case_qa_8c_hn_keyword_slack_routine(self._dummy_ctx())
+            )
+
+        self.assertTrue(result.success)
+        self.assertEqual(
+            captured["required_text"],
+            ["routine|trigger|automation|cron|schedule|created|monitor"],
+        )
+
     def test_live_google_side_effect_cases_install_required_extensions(self):
         captured: dict[str, dict[str, object]] = {}
         spreadsheet_id = "1AbCdEfGhIjKlMnOpQrStUvWxYz_1234567890"
@@ -1330,6 +1364,9 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
         async def fake_google_sheet_contains_marker(**_kwargs):
             return {"found": True}
 
+        async def fake_wait_for_google_sheet_marker(**_kwargs):
+            return {"found": True}
+
         with (
             patch.object(
                 run_live_qa,
@@ -1365,6 +1402,11 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
                 run_live_qa,
                 "_google_sheet_contains_marker",
                 side_effect=fake_google_sheet_contains_marker,
+            ),
+            patch.object(
+                run_live_qa,
+                "_wait_for_google_sheet_marker",
+                side_effect=fake_wait_for_google_sheet_marker,
             ),
         ):
             ctx = self._dummy_ctx()
@@ -1458,9 +1500,10 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
             captured_lookup.update(kwargs)
             return spreadsheet_id
 
-        async def fake_google_sheet_contains_marker(**kwargs):
+        async def fake_wait_for_google_sheet_marker(**kwargs):
             self.assertEqual(kwargs["spreadsheet_id"], spreadsheet_id)
             self.assertEqual(kwargs["marker"], captured_lookup["name"])
+            self.assertEqual(kwargs["timeout"], 90.0)
             return {"found": True}
 
         with (
@@ -1481,8 +1524,8 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
             ),
             patch.object(
                 run_live_qa,
-                "_google_sheet_contains_marker",
-                side_effect=fake_google_sheet_contains_marker,
+                "_wait_for_google_sheet_marker",
+                side_effect=fake_wait_for_google_sheet_marker,
             ),
         ):
             result = asyncio.run(
@@ -1496,6 +1539,131 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
             captured_lookup["mime_type"],
             "application/vnd.google-apps.spreadsheet",
         )
+
+    def test_gmail_to_sheet_delivery_records_empty_verifier_exception_type(self):
+        async def fake_live_chat_with_extensions_case(_ctx, **kwargs):
+            marker = kwargs["marker"]
+            return run_live_qa.ProbeResult(
+                provider="test",
+                mode="live:qa_6e_gmail_to_sheet_delivery",
+                success=True,
+                latency_ms=1,
+                details={
+                    "marker": marker,
+                    "text_excerpt": (
+                        "Google Sheet "
+                        "https://docs.google.com/spreadsheets/d/"
+                        "1AbCdEfGhIjKlMnOpQrStUvWxYz_1234567890/edit"
+                    ),
+                },
+            )
+
+        async def fake_wait_for_google_sheet_marker(**_kwargs):
+            raise TimeoutError()
+
+        with (
+            patch.object(
+                run_live_qa,
+                "_live_chat_with_extensions_case",
+                side_effect=fake_live_chat_with_extensions_case,
+            ),
+            patch.object(
+                run_live_qa,
+                "_google_runtime_access_token",
+                return_value=("fresh-access-token", {"source": "test"}),
+            ),
+            patch.object(
+                run_live_qa,
+                "_wait_for_google_sheet_marker",
+                side_effect=fake_wait_for_google_sheet_marker,
+            ),
+        ):
+            result = asyncio.run(
+                run_live_qa.case_qa_6e_gmail_to_sheet_delivery(self._dummy_ctx())
+            )
+
+        self.assertFalse(result.success)
+        self.assertEqual(result.details["error"], "TimeoutError")
+
+    def test_wait_for_google_sheet_marker_retries_transient_read_errors(self):
+        attempts = 0
+
+        async def fake_google_sheet_contains_marker(**_kwargs):
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                raise TimeoutError()
+            return {"found": True, "row_count": 2}
+
+        with (
+            patch.object(
+                google_api_helpers,
+                "_google_sheet_contains_marker",
+                side_effect=fake_google_sheet_contains_marker,
+            ),
+            patch.object(google_api_helpers.asyncio, "sleep", return_value=None),
+        ):
+            result = asyncio.run(
+                google_api_helpers._wait_for_google_sheet_marker(
+                    access_token="access-token",
+                    spreadsheet_id="spreadsheet-id",
+                    marker="marker",
+                    timeout=1.0,
+                )
+            )
+
+        self.assertEqual(result, {"found": True, "row_count": 2})
+        self.assertEqual(attempts, 2)
+
+    def test_wait_for_google_sheet_marker_reports_empty_exception_type(self):
+        async def fake_google_sheet_contains_marker(**_kwargs):
+            raise TimeoutError()
+
+        with (
+            patch.object(
+                google_api_helpers,
+                "_google_sheet_contains_marker",
+                side_effect=fake_google_sheet_contains_marker,
+            ),
+            patch.object(google_api_helpers.asyncio, "sleep", return_value=None),
+        ):
+            with self.assertRaisesRegex(AssertionError, "last_error=TimeoutError"):
+                asyncio.run(
+                    google_api_helpers._wait_for_google_sheet_marker(
+                        access_token="access-token",
+                        spreadsheet_id="spreadsheet-id",
+                        marker="marker",
+                        timeout=0.001,
+                    )
+                )
+
+    def test_wait_for_google_sheet_marker_does_not_retry_explicit_api_failures(self):
+        attempts = 0
+
+        async def fake_google_sheet_contains_marker(**_kwargs):
+            nonlocal attempts
+            attempts += 1
+            raise AssertionError("Google Sheets read returned HTTP 403: forbidden")
+
+        with (
+            patch.object(
+                google_api_helpers,
+                "_google_sheet_contains_marker",
+                side_effect=fake_google_sheet_contains_marker,
+            ),
+            patch.object(google_api_helpers.asyncio, "sleep", return_value=None),
+        ):
+            with self.assertRaisesRegex(AssertionError, "HTTP 403"):
+                asyncio.run(
+                    google_api_helpers._wait_for_google_sheet_marker(
+                        access_token="access-token",
+                        spreadsheet_id="spreadsheet-id",
+                        marker="marker",
+                        timeout=1.0,
+                    )
+                )
+
+        self.assertEqual(attempts, 1)
 
     def test_slack_side_effect_setup_prompts_avoid_connect_action_trigger(self):
         captured_prompts: dict[str, str] = {}


### PR DESCRIPTION
## Summary
- Retry QA6E Google Sheets marker verification for transient Sheets client/read failures.
- Preserve exception type in QA6E verifier errors so empty exception messages remain diagnosable.
- Relax QA8C routine confirmation matching while still requiring trigger record creation.

## Change Type
- [x] Test / QA harness
- [ ] Product behavior
- [ ] Documentation

## Linked Issue
None.

## Validation
- `python3 -m py_compile scripts/reborn_webui_v2_live_qa/run_live_qa.py scripts/reborn_webui_v2_live_qa/test_run_live_qa.py scripts/reborn_webui_v2_live_qa/google_api_helpers.py`
- `python3 scripts/reborn_webui_v2_live_qa/test_run_live_qa.py`

## Security Impact
No production auth, secret handling, or runtime security behavior changed. Live QA artifacts continue to use existing redaction/scrubbing paths.

## Blast Radius
Limited to Reborn WebUI v2 live canary harness assertions and the Google Sheets verification helper used by live QA scripts.

## Rollback Plan
Revert this PR to restore the previous one-shot Sheets marker check and stricter QA8C text assertion.

## Review Track
QA harness stabilization.
