### PR TITLE
test(reborn): LoopFailureKind fault-coverage matrix (100% error types + main comparison)

### DIFF
--- a/crates/ironclaw_agent_loop/src/executor/tests.rs
+++ b/crates/ironclaw_agent_loop/src/executor/tests.rs
@@ -52,6 +52,7 @@ mod support;
 use support::*;
 
 mod cancellation;
+mod failure_matrix;
 
 #[tokio::test]
 async fn reply_only_completes_with_final_checkpoint() {

--- a/crates/ironclaw_agent_loop/src/executor/tests/failure_matrix.rs
+++ b/crates/ironclaw_agent_loop/src/executor/tests/failure_matrix.rs
@@ -3,11 +3,12 @@ use super::{
     CanonicalAgentLoopExecutor, CapabilityFailureKind, CapabilityOutcome, CapabilityResultMessage,
     CheckpointKind, DefaultCompactionStrategy, FixedReplyAdmissionPolicy, GateOutcome, HostStage,
     LoopCheckpointKind, LoopCompactionError, LoopExecutionState, LoopExit, LoopFailureKind,
-    LoopGateRef, LoopResultRef, LoopRunInfoPort, LoopSafeSummary, MockHost,
-    active_task_preserving_compaction_index, calls_response, empty_gate_state,
-    family_with_compaction_strategy, family_with_gate_outcome, family_with_iteration_limit,
-    family_with_reply_admission, final_staged_state, reply_response, reply_response_with_text,
+    LoopGateRef, LoopResultRef, LoopSafeSummary, MockHost, active_task_preserving_compaction_index,
+    calls_response, empty_gate_state, family_with_compaction_strategy, family_with_gate_outcome,
+    family_with_iteration_limit, family_with_reply_admission, final_staged_state, reply_response,
+    reply_response_with_text,
 };
+use ironclaw_turns::run_profile::LoopRunInfoPort;
 
 #[derive(Clone, Copy)]
 struct MatrixRow {
@@ -205,12 +206,32 @@ const ROWS: &[MatrixRow] = &[
     },
 ];
 
-#[tokio::test]
-async fn executor_layer_failure_matrix() {
-    for row in ROWS {
-        let observed = run_setup(row.setup).await;
-        assert_expected_terminal(row, &observed);
-    }
+macro_rules! matrix_row_test {
+    ($name:ident, $row_index:expr) => {
+        #[tokio::test]
+        async fn $name() {
+            run_matrix_row(&ROWS[$row_index]).await;
+        }
+    };
+}
+
+matrix_row_test!(matrix_model_error_exhausting_retries, 0);
+matrix_row_test!(matrix_capability_protocol_error_permanent, 1);
+matrix_row_test!(matrix_capability_invalid_input_recovers, 2);
+matrix_row_test!(matrix_capability_invalid_output_recovers, 3);
+matrix_row_test!(matrix_iteration_limit, 4);
+matrix_row_test!(matrix_invalid_model_output, 5);
+matrix_row_test!(matrix_driver_bug_approval_skip_diverges, 6);
+matrix_row_test!(matrix_no_progress_detected, 7);
+matrix_row_test!(matrix_policy_denied_outcome_diverges, 8);
+matrix_row_test!(matrix_capability_policy_denied_recovers, 9);
+matrix_row_test!(matrix_compaction_unavailable, 10);
+matrix_row_test!(matrix_transcript_write_failed, 11);
+matrix_row_test!(matrix_checkpoint_rejected, 12);
+
+async fn run_matrix_row(row: &MatrixRow) {
+    let observed = run_setup(row.setup).await;
+    assert_expected_terminal(row, &observed);
 }
 
 async fn run_setup(setup: FailureSetup) -> ObservedTerminal {

--- a/crates/ironclaw_agent_loop/src/executor/tests/failure_matrix.rs
+++ b/crates/ironclaw_agent_loop/src/executor/tests/failure_matrix.rs
@@ -1,0 +1,495 @@
+use super::{
+    AgentLoopExecutor, AgentLoopExecutorError, AgentLoopHostError, AgentLoopHostErrorKind,
+    CanonicalAgentLoopExecutor, CapabilityFailureKind, CapabilityOutcome, CapabilityResultMessage,
+    CheckpointKind, DefaultCompactionStrategy, FixedReplyAdmissionPolicy, GateOutcome, HostStage,
+    LoopCheckpointKind, LoopCompactionError, LoopExecutionState, LoopExit, LoopFailureKind,
+    LoopGateRef, LoopResultRef, LoopRunInfoPort, LoopSafeSummary, MockHost,
+    active_task_preserving_compaction_index, calls_response, empty_gate_state,
+    family_with_compaction_strategy, family_with_gate_outcome, family_with_iteration_limit,
+    family_with_reply_admission, final_staged_state, reply_response, reply_response_with_text,
+};
+
+#[derive(Clone, Copy)]
+struct MatrixRow {
+    label: &'static str,
+    setup: FailureSetup,
+    expected_kind: ExpectedTerminal,
+    expects_explanation: bool,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum FailureSetup {
+    ModelError,
+    CapabilityProtocolError,
+    IterationLimit,
+    InvalidModelOutput,
+    DriverBugApprovalSkip,
+    NoProgressDetected,
+    PolicyDenied,
+    CompactionUnavailable,
+    TranscriptWriteFailed,
+    CheckpointRejected,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum ExpectedTerminal {
+    Failed {
+        kind: LoopFailureKind,
+        safe_summary: Option<&'static str>,
+    },
+    Error {
+        error: ExpectedError,
+    },
+    CompletedDivergence {
+        planned_kind: LoopFailureKind,
+    },
+}
+
+#[derive(Debug, Clone, Copy)]
+enum ExpectedError {
+    HostUnavailable { stage: HostStage },
+    CheckpointFailed { stage: CheckpointKind },
+}
+
+#[derive(Debug)]
+struct ObservedTerminal {
+    terminal: Terminal,
+    final_assistant_refs: Option<Vec<ironclaw_turns::LoopMessageRef>>,
+    finalized_assistant_messages: Vec<String>,
+    model_request_count: usize,
+}
+
+#[derive(Debug)]
+enum Terminal {
+    Exit(LoopExit),
+    Error(AgentLoopExecutorError),
+}
+
+const ROWS: &[MatrixRow] = &[
+    MatrixRow {
+        label: "ModelError <- with_model_errors exhausting retries",
+        setup: FailureSetup::ModelError,
+        expected_kind: ExpectedTerminal::Failed {
+            kind: LoopFailureKind::ModelError,
+            safe_summary: Some("model_unavailable"),
+        },
+        expects_explanation: false,
+    },
+    MatrixRow {
+        label: "CapabilityProtocolError <- batch outcome Failed(Permanent)",
+        setup: FailureSetup::CapabilityProtocolError,
+        expected_kind: ExpectedTerminal::Failed {
+            kind: LoopFailureKind::CapabilityProtocolError,
+            safe_summary: Some("capability_permanent"),
+        },
+        expects_explanation: true,
+    },
+    MatrixRow {
+        label: "IterationLimit <- family_with_iteration_limit(0)",
+        setup: FailureSetup::IterationLimit,
+        expected_kind: ExpectedTerminal::Failed {
+            kind: LoopFailureKind::IterationLimit,
+            safe_summary: None,
+        },
+        expects_explanation: true,
+    },
+    MatrixRow {
+        label: "InvalidModelOutput <- RejectAlways reply admission",
+        setup: FailureSetup::InvalidModelOutput,
+        expected_kind: ExpectedTerminal::Failed {
+            kind: LoopFailureKind::InvalidModelOutput,
+            safe_summary: None,
+        },
+        expects_explanation: true,
+    },
+    MatrixRow {
+        label: "DriverBug <- Approval gate SkipAndContinue",
+        setup: FailureSetup::DriverBugApprovalSkip,
+        // matrix-divergence: GateOutcome::validate_for_gate_kind marks
+        // Approval+SkipAndContinue as DriverBug, but GateStage does not enforce
+        // that validator today; the planned executor skips the gate and can
+        // continue to a normal completion.
+        expected_kind: ExpectedTerminal::CompletedDivergence {
+            planned_kind: LoopFailureKind::DriverBug,
+        },
+        expects_explanation: false,
+    },
+    MatrixRow {
+        label: "NoProgressDetected <- repeated identical no-change calls",
+        setup: FailureSetup::NoProgressDetected,
+        expected_kind: ExpectedTerminal::Failed {
+            kind: LoopFailureKind::NoProgressDetected,
+            safe_summary: None,
+        },
+        // matrix-divergence: NoProgressDetected is listed as explainable, but
+        // the StopKind::NoProgressDetected exit path writes the failed exit
+        // directly instead of calling attach_failure_explanation.
+        expects_explanation: false,
+    },
+    MatrixRow {
+        label: "PolicyDenied <- scripted Denied capability outcome",
+        setup: FailureSetup::PolicyDenied,
+        // matrix-divergence: DefaultRecoveryStrategy turns policy-denied
+        // capability outcomes into model-visible tool-error results; with a
+        // follow-up model reply the planned executor completes instead of
+        // surfacing LoopFailureKind::PolicyDenied.
+        expected_kind: ExpectedTerminal::CompletedDivergence {
+            planned_kind: LoopFailureKind::PolicyDenied,
+        },
+        expects_explanation: false,
+    },
+    MatrixRow {
+        label: "CompactionUnavailable <- compaction port returns Err",
+        setup: FailureSetup::CompactionUnavailable,
+        expected_kind: ExpectedTerminal::Failed {
+            kind: LoopFailureKind::CompactionUnavailable,
+            safe_summary: Some("compaction_security_rejected"),
+        },
+        expects_explanation: true,
+    },
+    MatrixRow {
+        label: "TranscriptWriteFailed <- fail_transcript_with",
+        setup: FailureSetup::TranscriptWriteFailed,
+        // matrix-divergence: TranscriptWriteFailed enum origin is legacy
+        // text_loop_driver; planned executor maps assistant transcript finalize
+        // failure to HostUnavailable { stage: Transcript } before any LoopExit.
+        expected_kind: ExpectedTerminal::Error {
+            error: ExpectedError::HostUnavailable {
+                stage: HostStage::Transcript,
+            },
+        },
+        expects_explanation: false,
+    },
+    MatrixRow {
+        label: "CheckpointRejected <- fail_checkpoint(BeforeModel)",
+        setup: FailureSetup::CheckpointRejected,
+        // matrix-divergence: CheckpointRejected enum origin is legacy
+        // text_loop_driver; planned executor maps host checkpoint rejection to
+        // AgentLoopExecutorError::CheckpointFailed rather than LoopExit::Failed.
+        expected_kind: ExpectedTerminal::Error {
+            error: ExpectedError::CheckpointFailed {
+                stage: CheckpointKind::BeforeModel,
+            },
+        },
+        expects_explanation: false,
+    },
+];
+
+#[tokio::test]
+async fn executor_layer_failure_matrix() {
+    for row in ROWS {
+        let observed = run_setup(row.setup).await;
+        assert_expected_terminal(row, &observed);
+    }
+}
+
+async fn run_setup(setup: FailureSetup) -> ObservedTerminal {
+    match setup {
+        FailureSetup::ModelError => {
+            let host = MockHost::new(Vec::new()).with_model_errors(vec![
+                AgentLoopHostError::new(AgentLoopHostErrorKind::Unavailable, "model unavailable"),
+                AgentLoopHostError::new(AgentLoopHostErrorKind::Unavailable, "model unavailable"),
+                AgentLoopHostError::new(AgentLoopHostErrorKind::Unavailable, "model unavailable"),
+            ]);
+            run_local(crate::families::default(), host, None).await
+        }
+        FailureSetup::CapabilityProtocolError => {
+            let host = MockHost::new(vec![
+                calls_response(),
+                reply_response_with_text("explanation"),
+            ])
+            .with_batch_outcomes(vec![batch_outcome(CapabilityOutcome::Failed(
+                ironclaw_turns::run_profile::CapabilityFailure {
+                    error_kind: CapabilityFailureKind::Permanent,
+                    safe_summary: "permanent protocol failure".to_string(),
+                    detail: None,
+                },
+            ))]);
+            run_local(crate::families::default(), host, None).await
+        }
+        FailureSetup::IterationLimit => {
+            let host = MockHost::new(vec![reply_response_with_text("iteration explanation")]);
+            run_local(family_with_iteration_limit(0), host, None).await
+        }
+        FailureSetup::InvalidModelOutput => {
+            let host = MockHost::new(vec![
+                reply_response(),
+                reply_response(),
+                reply_response(),
+                reply_response_with_text("invalid model output explanation"),
+            ]);
+            run_local(
+                family_with_reply_admission(FixedReplyAdmissionPolicy::RejectAlways),
+                host,
+                None,
+            )
+            .await
+        }
+        FailureSetup::DriverBugApprovalSkip => {
+            let host = MockHost::new(vec![
+                calls_response(),
+                reply_response_with_text("completed"),
+            ])
+            .with_batch_outcomes(vec![batch_outcome_stopped(
+                CapabilityOutcome::ApprovalRequired {
+                    gate_ref: LoopGateRef::new("gate:approval-skip").expect("valid"),
+                    safe_summary: "approval required".to_string(),
+                    approval_resume: None,
+                },
+            )]);
+            run_local(
+                family_with_gate_outcome(GateOutcome::SkipAndContinue {
+                    gate: empty_gate_state(),
+                }),
+                host,
+                None,
+            )
+            .await
+        }
+        FailureSetup::NoProgressDetected => {
+            let host = MockHost::new(vec![calls_response(), calls_response(), calls_response()])
+                .with_batch_outcomes(vec![
+                    batch_outcome(no_change_result("result:no-progress-1")),
+                    batch_outcome(no_change_result("result:no-progress-2")),
+                    batch_outcome(no_change_result("result:no-progress-3")),
+                ]);
+            run_local(crate::families::default(), host, None).await
+        }
+        FailureSetup::PolicyDenied => {
+            let host = MockHost::new(vec![
+                calls_response(),
+                reply_response_with_text("completed"),
+            ])
+            .with_batch_outcomes(vec![batch_outcome(CapabilityOutcome::Denied(
+                ironclaw_turns::run_profile::CapabilityDenied {
+                    reason_kind:
+                        ironclaw_turns::run_profile::CapabilityDeniedReasonKind::EmptySurface,
+                    safe_summary: "provider call denied".to_string(),
+                },
+            ))]);
+            run_local(crate::families::default(), host, None).await
+        }
+        FailureSetup::CompactionUnavailable => {
+            let host = MockHost::new(vec![reply_response_with_text("compaction explanation")])
+                .with_prompt_compaction_index(active_task_preserving_compaction_index())
+                .with_compaction_outcome(Err(LoopCompactionError::SecurityRejected {
+                    safe_summary: LoopSafeSummary::new("security rejected").expect("safe"),
+                }));
+            let mut state = LoopExecutionState::initial_for_run(host.run_context());
+            state.compaction_state.force_compact_on_next_iteration = true;
+            run_local(
+                family_with_compaction_strategy(DefaultCompactionStrategy {
+                    deadline_ms: 100,
+                    ..Default::default()
+                }),
+                host,
+                Some(state),
+            )
+            .await
+        }
+        FailureSetup::TranscriptWriteFailed => {
+            let host = MockHost::new(vec![reply_response_with_text("reply should not finalize")])
+                .fail_transcript_with(AgentLoopHostErrorKind::TranscriptWriteFailed);
+            run_local(crate::families::default(), host, None).await
+        }
+        FailureSetup::CheckpointRejected => {
+            let host = MockHost::new(vec![reply_response_with_text("unused")])
+                .fail_checkpoint(LoopCheckpointKind::BeforeModel);
+            run_local(crate::families::default(), host, None).await
+        }
+    }
+}
+
+async fn run_local(
+    family: crate::family::LoopFamily,
+    host: MockHost,
+    initial_state: Option<LoopExecutionState>,
+) -> ObservedTerminal {
+    let executor = CanonicalAgentLoopExecutor;
+    let state =
+        initial_state.unwrap_or_else(|| LoopExecutionState::initial_for_run(host.run_context()));
+    let terminal = match executor.execute_family(&family, &host, state).await {
+        Ok(exit) => Terminal::Exit(exit),
+        Err(error) => Terminal::Error(error),
+    };
+    let final_assistant_refs = match &terminal {
+        Terminal::Exit(LoopExit::Completed(_)) | Terminal::Exit(LoopExit::Failed(_)) => {
+            Some(final_staged_state(&host).assistant_refs)
+        }
+        Terminal::Exit(_) | Terminal::Error(_) => None,
+    };
+    ObservedTerminal {
+        terminal,
+        final_assistant_refs,
+        finalized_assistant_messages: host.finalized_assistant_messages(),
+        model_request_count: host.model_requests().len(),
+    }
+}
+
+fn assert_expected_terminal(row: &MatrixRow, observed: &ObservedTerminal) {
+    match (&row.expected_kind, &observed.terminal) {
+        (
+            ExpectedTerminal::Failed { kind, safe_summary },
+            Terminal::Exit(LoopExit::Failed(failed)),
+        ) => {
+            assert_eq!(
+                failed.reason_kind, *kind,
+                "{}: failed exit reason kind",
+                row.label
+            );
+            assert_eq!(
+                failed.reason_kind.as_str(),
+                kind.as_str(),
+                "{}: sanitized failure category",
+                row.label
+            );
+            assert_eq!(
+                failed
+                    .safe_summary
+                    .as_ref()
+                    .map(|summary| summary.category()),
+                *safe_summary,
+                "{}: safe summary category",
+                row.label
+            );
+            assert_explanation_refs(row, &failed.explanation_message_refs);
+            let final_refs = observed
+                .final_assistant_refs
+                .as_ref()
+                .expect("failed exits should have a final checkpoint state");
+            assert_eq!(
+                final_refs, &failed.explanation_message_refs,
+                "{}: no fabricated final assistant reply",
+                row.label
+            );
+        }
+        (ExpectedTerminal::Error { error }, Terminal::Error(actual)) => {
+            assert_expected_error(row, *error, actual);
+            assert!(
+                !row.expects_explanation,
+                "{}: executor errors cannot carry explanation refs",
+                row.label
+            );
+            match error {
+                ExpectedError::HostUnavailable {
+                    stage: HostStage::Transcript,
+                } => {
+                    assert_eq!(
+                        observed.model_request_count, 1,
+                        "{}: transcript row should reach exactly one model reply attempt",
+                        row.label
+                    );
+                    assert!(
+                        observed.finalized_assistant_messages.is_empty(),
+                        "{}: no assistant message should be finalized after transcript write failure",
+                        row.label
+                    );
+                }
+                ExpectedError::CheckpointFailed { .. } => {
+                    assert_eq!(
+                        observed.model_request_count, 0,
+                        "{}: checkpoint failure before model should not fabricate a reply",
+                        row.label
+                    );
+                }
+                ExpectedError::HostUnavailable { .. } => {}
+            }
+        }
+        (
+            ExpectedTerminal::CompletedDivergence { planned_kind },
+            Terminal::Exit(LoopExit::Completed(completed)),
+        ) => {
+            assert!(
+                !row.expects_explanation,
+                "{}: completed divergence rows do not carry failure explanations",
+                row.label
+            );
+            assert_eq!(
+                completed.reply_message_refs.len(),
+                1,
+                "{}: matrix-divergence for planned {:?} currently completes with one real reply",
+                row.label,
+                planned_kind
+            );
+            assert!(
+                completed.final_checkpoint_id.is_some(),
+                "{}: completed divergence row should still checkpoint final state",
+                row.label
+            );
+        }
+        _ => panic!(
+            "{}: expected {:?}, observed {:?}",
+            row.label, row.expected_kind, observed.terminal
+        ),
+    }
+}
+
+fn assert_expected_error(
+    row: &MatrixRow,
+    expected: ExpectedError,
+    actual: &AgentLoopExecutorError,
+) {
+    match expected {
+        ExpectedError::HostUnavailable { stage } => {
+            assert_eq!(
+                actual,
+                &AgentLoopExecutorError::HostUnavailable { stage },
+                "{}: executor error",
+                row.label
+            );
+        }
+        ExpectedError::CheckpointFailed { stage } => {
+            assert_eq!(
+                actual,
+                &AgentLoopExecutorError::CheckpointFailed { stage },
+                "{}: executor error",
+                row.label
+            );
+        }
+    }
+}
+
+fn assert_explanation_refs(row: &MatrixRow, refs: &[ironclaw_turns::LoopMessageRef]) {
+    if row.expects_explanation {
+        assert!(
+            !refs.is_empty(),
+            "{}: expected a persisted failure explanation message ref",
+            row.label
+        );
+    } else {
+        assert!(
+            refs.is_empty(),
+            "{}: expected no failure explanation message refs",
+            row.label
+        );
+    }
+}
+
+fn batch_outcome(
+    outcome: CapabilityOutcome,
+) -> ironclaw_turns::run_profile::CapabilityBatchOutcome {
+    ironclaw_turns::run_profile::CapabilityBatchOutcome {
+        outcomes: vec![outcome],
+        stopped_on_suspension: false,
+    }
+}
+
+fn batch_outcome_stopped(
+    outcome: CapabilityOutcome,
+) -> ironclaw_turns::run_profile::CapabilityBatchOutcome {
+    ironclaw_turns::run_profile::CapabilityBatchOutcome {
+        outcomes: vec![outcome],
+        stopped_on_suspension: true,
+    }
+}
+
+fn no_change_result(result_ref: &str) -> CapabilityOutcome {
+    CapabilityOutcome::Completed(CapabilityResultMessage {
+        result_ref: LoopResultRef::new(result_ref).expect("valid"),
+        safe_summary: "completed without progress".to_string(),
+        progress: ironclaw_turns::run_profile::CapabilityProgress::NoChange,
+        terminate_hint: false,
+        byte_len: 0,
+        output_digest: None,
+    })
+}

--- a/crates/ironclaw_agent_loop/src/executor/tests/failure_matrix.rs
+++ b/crates/ironclaw_agent_loop/src/executor/tests/failure_matrix.rs
@@ -21,11 +21,14 @@ struct MatrixRow {
 enum FailureSetup {
     ModelError,
     CapabilityProtocolError,
+    CapabilityInvalidInputRecoverable,
+    CapabilityInvalidOutputRecoverable,
     IterationLimit,
     InvalidModelOutput,
     DriverBugApprovalSkip,
     NoProgressDetected,
     PolicyDenied,
+    CapabilityPolicyDeniedRecoverable,
     CompactionUnavailable,
     TranscriptWriteFailed,
     CheckpointRejected,
@@ -85,6 +88,24 @@ const ROWS: &[MatrixRow] = &[
         expects_explanation: true,
     },
     MatrixRow {
+        label: "ModelError <- capability Failed(InvalidInput)",
+        setup: FailureSetup::CapabilityInvalidInputRecoverable,
+        // stack #5389 makes this recoverable; matrix asserts recovery.
+        expected_kind: ExpectedTerminal::CompletedDivergence {
+            planned_kind: LoopFailureKind::ModelError,
+        },
+        expects_explanation: false,
+    },
+    MatrixRow {
+        label: "CapabilityProtocolError <- capability Failed(InvalidOutput)",
+        setup: FailureSetup::CapabilityInvalidOutputRecoverable,
+        // stack #5389 makes this recoverable; matrix asserts recovery.
+        expected_kind: ExpectedTerminal::CompletedDivergence {
+            planned_kind: LoopFailureKind::CapabilityProtocolError,
+        },
+        expects_explanation: false,
+    },
+    MatrixRow {
         label: "IterationLimit <- family_with_iteration_limit(0)",
         setup: FailureSetup::IterationLimit,
         expected_kind: ExpectedTerminal::Failed {
@@ -133,6 +154,15 @@ const ROWS: &[MatrixRow] = &[
         // capability outcomes into model-visible tool-error results; with a
         // follow-up model reply the planned executor completes instead of
         // surfacing LoopFailureKind::PolicyDenied.
+        expected_kind: ExpectedTerminal::CompletedDivergence {
+            planned_kind: LoopFailureKind::PolicyDenied,
+        },
+        expects_explanation: false,
+    },
+    MatrixRow {
+        label: "PolicyDenied <- capability Failed(PolicyDenied)",
+        setup: FailureSetup::CapabilityPolicyDeniedRecoverable,
+        // stack #5389 makes this recoverable; matrix asserts recovery.
         expected_kind: ExpectedTerminal::CompletedDivergence {
             planned_kind: LoopFailureKind::PolicyDenied,
         },
@@ -207,6 +237,28 @@ async fn run_setup(setup: FailureSetup) -> ObservedTerminal {
             ))]);
             run_local(crate::families::default(), host, None).await
         }
+        FailureSetup::CapabilityInvalidInputRecoverable => {
+            let host = MockHost::new(vec![
+                calls_response(),
+                reply_response_with_text("completed after invalid input"),
+            ])
+            .with_batch_outcomes(vec![batch_outcome(failed_capability(
+                CapabilityFailureKind::InvalidInput,
+                "invalid input supplied by model",
+            ))]);
+            run_local(crate::families::default(), host, None).await
+        }
+        FailureSetup::CapabilityInvalidOutputRecoverable => {
+            let host = MockHost::new(vec![
+                calls_response(),
+                reply_response_with_text("completed after invalid output"),
+            ])
+            .with_batch_outcomes(vec![batch_outcome(failed_capability(
+                CapabilityFailureKind::InvalidOutput,
+                "invalid tool output",
+            ))]);
+            run_local(crate::families::default(), host, None).await
+        }
         FailureSetup::IterationLimit => {
             let host = MockHost::new(vec![reply_response_with_text("iteration explanation")]);
             run_local(family_with_iteration_limit(0), host, None).await
@@ -266,6 +318,17 @@ async fn run_setup(setup: FailureSetup) -> ObservedTerminal {
                         ironclaw_turns::run_profile::CapabilityDeniedReasonKind::EmptySurface,
                     safe_summary: "provider call denied".to_string(),
                 },
+            ))]);
+            run_local(crate::families::default(), host, None).await
+        }
+        FailureSetup::CapabilityPolicyDeniedRecoverable => {
+            let host = MockHost::new(vec![
+                calls_response(),
+                reply_response_with_text("completed after policy denial"),
+            ])
+            .with_batch_outcomes(vec![batch_outcome(failed_capability(
+                CapabilityFailureKind::PolicyDenied,
+                "capability policy denied",
             ))]);
             run_local(crate::families::default(), host, None).await
         }
@@ -472,6 +535,14 @@ fn batch_outcome(
         outcomes: vec![outcome],
         stopped_on_suspension: false,
     }
+}
+
+fn failed_capability(error_kind: CapabilityFailureKind, safe_summary: &str) -> CapabilityOutcome {
+    CapabilityOutcome::Failed(ironclaw_turns::run_profile::CapabilityFailure {
+        error_kind,
+        safe_summary: safe_summary.to_string(),
+        detail: None,
+    })
 }
 
 fn batch_outcome_stopped(

--- a/crates/ironclaw_agent_loop/src/executor/tests/support.rs
+++ b/crates/ironclaw_agent_loop/src/executor/tests/support.rs
@@ -63,6 +63,7 @@ pub(super) struct MockHost {
     provider_registration_activity_remap: Arc<Mutex<Option<ironclaw_turns::CapabilityActivityId>>>,
     staged_payloads: Arc<Mutex<Vec<StageCheckpointPayloadRequest>>>,
     appended_result_refs: Arc<Mutex<Vec<AppendCapabilityResultRef>>>,
+    finalized_assistant_messages: Arc<Mutex<Vec<String>>>,
     events: Arc<Mutex<Vec<String>>>,
     prompt_surface_version: Option<CapabilitySurfaceVersion>,
     visible_surface_version: CapabilitySurfaceVersion,
@@ -81,6 +82,7 @@ pub(super) struct MockHost {
     fail_visible_capabilities: bool,
     fail_prompt_bundle: bool,
     fail_batch_with: Arc<Mutex<Option<AgentLoopHostErrorKind>>>,
+    fail_transcript_with: Arc<Mutex<Option<AgentLoopHostErrorKind>>>,
     extra_capability_descriptors: Vec<CapabilityDescriptorView>,
 }
 
@@ -105,6 +107,7 @@ impl MockHost {
             provider_registration_activity_remap: Arc::new(Mutex::new(None)),
             staged_payloads: Arc::new(Mutex::new(Vec::new())),
             appended_result_refs: Arc::new(Mutex::new(Vec::new())),
+            finalized_assistant_messages: Arc::new(Mutex::new(Vec::new())),
             events: Arc::new(Mutex::new(Vec::new())),
             prompt_surface_version: Some(surface_version()),
             visible_surface_version: surface_version(),
@@ -123,6 +126,7 @@ impl MockHost {
             fail_visible_capabilities: false,
             fail_prompt_bundle: false,
             fail_batch_with: Arc::new(Mutex::new(None)),
+            fail_transcript_with: Arc::new(Mutex::new(None)),
             extra_capability_descriptors: Vec::new(),
         }
     }
@@ -201,6 +205,11 @@ impl MockHost {
         self
     }
 
+    pub(super) fn fail_transcript_with(self, kind: AgentLoopHostErrorKind) -> Self {
+        *self.fail_transcript_with.lock().expect("lock") = Some(kind);
+        self
+    }
+
     pub(super) fn with_provider_registration_errors(self, errors: Vec<AgentLoopHostError>) -> Self {
         *self.provider_registration_errors.lock().expect("lock") = errors.into();
         self
@@ -255,6 +264,13 @@ impl MockHost {
 
     pub(super) fn appended_result_refs(&self) -> Vec<AppendCapabilityResultRef> {
         self.appended_result_refs.lock().expect("lock").clone()
+    }
+
+    pub(super) fn finalized_assistant_messages(&self) -> Vec<String> {
+        self.finalized_assistant_messages
+            .lock()
+            .expect("lock")
+            .clone()
     }
 
     pub(super) fn events(&self) -> Vec<String> {
@@ -758,8 +774,15 @@ impl ironclaw_turns::run_profile::LoopCapabilityPort for MockHost {
 impl ironclaw_turns::run_profile::LoopTranscriptPort for MockHost {
     async fn finalize_assistant_message(
         &self,
-        _request: FinalizeAssistantMessage,
+        request: FinalizeAssistantMessage,
     ) -> Result<LoopMessageRef, AgentLoopHostError> {
+        if let Some(kind) = *self.fail_transcript_with.lock().expect("lock") {
+            return Err(AgentLoopHostError::new(kind, "scripted transcript failure"));
+        }
+        self.finalized_assistant_messages
+            .lock()
+            .expect("lock")
+            .push(request.reply.content);
         Ok(LoopMessageRef::new("msg:assistant").expect("valid"))
     }
 
@@ -767,6 +790,9 @@ impl ironclaw_turns::run_profile::LoopTranscriptPort for MockHost {
         &self,
         request: AppendCapabilityResultRef,
     ) -> Result<LoopMessageRef, AgentLoopHostError> {
+        if let Some(kind) = *self.fail_transcript_with.lock().expect("lock") {
+            return Err(AgentLoopHostError::new(kind, "scripted transcript failure"));
+        }
         if self.fail_append_result_ref {
             return Err(AgentLoopHostError::new(
                 AgentLoopHostErrorKind::TranscriptWriteFailed,

--- a/crates/ironclaw_agent_loop/src/test_support/mod.rs
+++ b/crates/ironclaw_agent_loop/src/test_support/mod.rs
@@ -60,6 +60,7 @@ pub struct MockAgentLoopDriverHost {
     staged_iterations: Mutex<VecDeque<u32>>,
     fail_prompt_with: Mutex<Option<AgentLoopHostErrorKind>>,
     fail_model_with: Mutex<Option<AgentLoopHostErrorKind>>,
+    fail_transcript_with: Mutex<Option<AgentLoopHostErrorKind>>,
     compaction_result: Mutex<Result<LoopCompactionOutcome, LoopCompactionError>>,
     progress_events: Mutex<Vec<LoopProgressEvent>>,
     prompt_requests: Mutex<Vec<LoopPromptBundleRequest>>,
@@ -134,6 +135,7 @@ pub struct MockAgentLoopDriverHostBuilder {
     prompt_compaction_indexes: VecDeque<Vec<LoopContextCompactionMetadata>>,
     fail_prompt_with: Option<AgentLoopHostErrorKind>,
     fail_model_with: Option<AgentLoopHostErrorKind>,
+    fail_transcript_with: Option<AgentLoopHostErrorKind>,
     compaction_result: Result<LoopCompactionOutcome, LoopCompactionError>,
     cancellation: Option<LoopCancellationSignal>,
     cancel_after_capability_batch: Option<LoopCancellationSignal>,
@@ -152,6 +154,7 @@ impl MockAgentLoopDriverHostBuilder {
             prompt_compaction_indexes: VecDeque::new(),
             fail_prompt_with: None,
             fail_model_with: None,
+            fail_transcript_with: None,
             compaction_result: Err(LoopCompactionError::InputTooLarge),
             cancellation: None,
             cancel_after_capability_batch: None,
@@ -203,6 +206,12 @@ impl MockAgentLoopDriverHostBuilder {
         self
     }
 
+    /// Forces every transcript write to fail with the selected host error kind.
+    pub fn fail_transcript_with(mut self, kind: AgentLoopHostErrorKind) -> Self {
+        self.fail_transcript_with = Some(kind);
+        self
+    }
+
     /// Sets the response returned by the host compaction port.
     pub fn compaction_result(
         mut self,
@@ -247,6 +256,7 @@ impl MockAgentLoopDriverHostBuilder {
                 staged_iterations: Mutex::new(VecDeque::new()),
                 fail_prompt_with: Mutex::new(self.fail_prompt_with),
                 fail_model_with: Mutex::new(self.fail_model_with),
+                fail_transcript_with: Mutex::new(self.fail_transcript_with),
                 compaction_result: Mutex::new(self.compaction_result),
                 progress_events: Mutex::new(Vec::new()),
                 prompt_requests: Mutex::new(Vec::new()),
@@ -858,8 +868,11 @@ impl ironclaw_turns::run_profile::LoopTranscriptPort for MockAgentLoopDriverHost
         &self,
         request: FinalizeAssistantMessage,
     ) -> Result<LoopMessageRef, AgentLoopHostError> {
-        lock_or_panic(&self.finalized_assistant_messages).push(request.reply.content);
         self.record_call(MockHostCall::FinalizeAssistantMessage);
+        if let Some(kind) = *lock_or_panic(&self.fail_transcript_with) {
+            return Err(AgentLoopHostError::new(kind, "scripted transcript failure"));
+        }
+        lock_or_panic(&self.finalized_assistant_messages).push(request.reply.content);
         Ok(loop_message_ref("msg:assistant"))
     }
 
@@ -871,6 +884,9 @@ impl ironclaw_turns::run_profile::LoopTranscriptPort for MockAgentLoopDriverHost
             result_ref: request.result_ref.clone(),
             provider_call: Box::new(request.provider_call.clone()),
         });
+        if let Some(kind) = *lock_or_panic(&self.fail_transcript_with) {
+            return Err(AgentLoopHostError::new(kind, "scripted transcript failure"));
+        }
         Ok(loop_message_ref("msg:tool-result"))
     }
 }

--- a/crates/ironclaw_reborn/src/planned_driver.rs
+++ b/crates/ironclaw_reborn/src/planned_driver.rs
@@ -549,7 +549,8 @@ mod tests {
         assert_eq!(
             result,
             Err(AgentLoopDriverError::Failed {
-                reason_kind: "interrupted_unexpectedly".to_string()
+                reason_kind: "interrupted_unexpectedly".to_string(),
+                detail: None,
             })
         );
         assert_eq!(

--- a/crates/ironclaw_reborn/src/planned_driver.rs
+++ b/crates/ironclaw_reborn/src/planned_driver.rs
@@ -525,6 +525,44 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn run_inflight_model_cancelled_maps_to_interrupted_unexpectedly_without_cancel_signal() {
+        let registry = build_loop_family_registry().expect("registry");
+        let driver = PlannedDriver::default_from_registry(&registry).expect("driver");
+        let context = run_context_for_driver(&driver);
+        let (host, _checkpoints) = MockAgentLoopDriverHost::builder()
+            .run_context(context.clone())
+            .fail_model_with(AgentLoopHostErrorKind::Cancelled)
+            .build();
+
+        let result = driver
+            .run(
+                AgentLoopDriverRunRequest {
+                    turn_id: context.turn_id,
+                    run_id: context.run_id,
+                    resolved_run_profile: context.resolved_run_profile.clone(),
+                },
+                &host,
+            )
+            .await;
+
+        assert_eq!(
+            result,
+            Err(AgentLoopDriverError::Failed {
+                reason_kind: "interrupted_unexpectedly".to_string()
+            })
+        );
+        assert_eq!(
+            host.observe_cancellation(),
+            None,
+            "scripted in-flight model cancellation must not depend on cooperative cancellation"
+        );
+        assert!(
+            host.call_log().contains(&MockHostCall::StreamModel),
+            "the driver must reach the in-flight model call before mapping cancellation"
+        );
+    }
+
     #[test]
     fn executor_model_credential_diagnostics_map_to_credentials_category() {
         let mapped = map_executor_error(AgentLoopExecutorError::HostUnavailableWithDiagnostics {
@@ -892,6 +930,7 @@ mod tests {
         match result.expect("resume should return a terminal failed loop exit") {
             LoopExit::Failed(failed) => {
                 assert_eq!(failed.reason_kind, LoopFailureKind::CheckpointUnavailable);
+                assert_eq!(failed.reason_kind.as_str(), "checkpoint_unavailable");
                 assert!(
                     failed.exit_id.as_str().ends_with("-checkpoint-unavailable"),
                     "checkpoint resume failures should use a checkpoint-specific exit id"

--- a/crates/ironclaw_turns/src/loop_exit/tests/mod.rs
+++ b/crates/ironclaw_turns/src/loop_exit/tests/mod.rs
@@ -1011,6 +1011,11 @@ fn blocked_variants_map_to_correct_blocked_reason() {
 
 #[test]
 fn all_failure_kinds_produce_stable_sanitized_category_strings() {
+    // matrix: docs/plans/2026-07-03-loop-failure-matrix.md — this table must
+    // stay exhaustive over LoopFailureKind. `ContextBuildFailed` and
+    // `InterruptedUnexpectedly` currently have no production constructor
+    // (category-string lock only); the rest are exercised at their real
+    // origins by the executor failure matrix in `ironclaw_agent_loop`.
     let variants: &[(LoopFailureKind, &str)] = &[
         (LoopFailureKind::ModelError, "model_error"),
         (LoopFailureKind::ContextBuildFailed, "context_build_failed"),
@@ -1022,6 +1027,10 @@ fn all_failure_kinds_produce_stable_sanitized_category_strings() {
         (LoopFailureKind::InvalidModelOutput, "invalid_model_output"),
         (LoopFailureKind::CheckpointRejected, "checkpoint_rejected"),
         (
+            LoopFailureKind::CheckpointUnavailable,
+            "checkpoint_unavailable",
+        ),
+        (
             LoopFailureKind::TranscriptWriteFailed,
             "transcript_write_failed",
         ),
@@ -1032,7 +1041,38 @@ fn all_failure_kinds_produce_stable_sanitized_category_strings() {
         ),
         (LoopFailureKind::NoProgressDetected, "no_progress_detected"),
         (LoopFailureKind::PolicyDenied, "policy_denied"),
+        (
+            LoopFailureKind::CompactionUnavailable,
+            "compaction_unavailable",
+        ),
     ];
+
+    // Exhaustiveness guard: adding a LoopFailureKind variant breaks this match
+    // (same-crate, so #[non_exhaustive] does not apply). When it fires, add a
+    // table row above AND extend this match with the new variant's expected
+    // category, keeping both in lockstep.
+    let expected_by_guard = |kind: LoopFailureKind| match kind {
+        LoopFailureKind::ModelError => "model_error",
+        LoopFailureKind::ContextBuildFailed => "context_build_failed",
+        LoopFailureKind::CapabilityProtocolError => "capability_protocol_error",
+        LoopFailureKind::IterationLimit => "iteration_limit",
+        LoopFailureKind::InvalidModelOutput => "invalid_model_output",
+        LoopFailureKind::CheckpointRejected => "checkpoint_rejected",
+        LoopFailureKind::CheckpointUnavailable => "checkpoint_unavailable",
+        LoopFailureKind::TranscriptWriteFailed => "transcript_write_failed",
+        LoopFailureKind::DriverBug => "driver_bug",
+        LoopFailureKind::InterruptedUnexpectedly => "interrupted_unexpectedly",
+        LoopFailureKind::NoProgressDetected => "no_progress_detected",
+        LoopFailureKind::PolicyDenied => "policy_denied",
+        LoopFailureKind::CompactionUnavailable => "compaction_unavailable",
+    };
+    for (kind, expected_category) in variants {
+        assert_eq!(
+            expected_by_guard(*kind),
+            *expected_category,
+            "guard/table category drift for {kind:?}"
+        );
+    }
 
     for (kind, expected_category) in variants {
         let decision = LoopExit::failed(*kind, exit_id("exit:failure-variant")).validate(

--- a/docs/plans/2026-07-03-loop-failure-matrix.md
+++ b/docs/plans/2026-07-03-loop-failure-matrix.md
@@ -1,0 +1,124 @@
+# LoopFailureKind fault matrix — coverage, injection seams, and branch-vs-main delta
+
+**Status:** synthesized from 4 parallel research passes (taxonomy/origins, coverage audit,
+main delta, injection seams) · **Date:** 2026-07-03
+**Scope:** every `LoopFailureKind` variant (`crates/ironclaw_turns/src/loop_exit.rs` ~440),
+the Part-1 "no-borking failures" contract, and what `origin/main` (f92c658c9) does instead.
+
+## 0. Contract properties (per failing run)
+
+- **P1** sanitized failure category surfaces (`TurnRunState.failure` / `sanitized_reason` / projection)
+- **P2** correct `retryable` (resume checkpoint preserved ⇒ retryable; else refused)
+- **P3** no fabricated final assistant reply
+- **P4** `retry_run` resumes to completion when retryable; refused (`RunNotRetryable`) when not
+
+## 1. Structural facts the matrix hinges on
+
+1. **Retryability is variant-agnostic.** No production code branches retry on the variant.
+   `retryable` = "does a `BeforeModel`/`BeforeBlock` checkpoint exist for the run"
+   (`memory.rs::fail_claimed_record` → `latest_resumable_loop_checkpoint`). The applier's
+   `resume_checkpoint_id` is always `None` in production (test-only setter), so the store
+   fallback scan is THE mechanism. The only `BeforeModel` writer is `prompt.rs:535`
+   (once per iteration, before each model call).
+2. **Two assertion vocabularies.** Executor tier asserts `LoopExit::Failed(f).reason_kind`
+   (the enum); binary/driver tier asserts the sanitized **string** after
+   `map_executor_error`/`map_host_error` (lossy: several host kinds collapse to
+   `model_error`/`driver_bug`). Each matrix row declares its layer.
+3. **Two variants have no production constructor** (`ContextBuildFailed`,
+   `InterruptedUnexpectedly` at the enum level) — enum + name-table entries only.
+   `interrupted_unexpectedly` *as a string* is reachable via `map_executor_error` on an
+   in-flight `Cancelled` host error. Honest coverage = wire/category-table locks +
+   documented unreachability; do NOT fabricate the enum in tests.
+4. **Legacy-only origins.** `TranscriptWriteFailed` and `CheckpointRejected` originate in
+   the legacy `text_loop_driver` (`CheckpointRejected` also via host run-not-active
+   mapping / `fail_checkpoint` → `map_executor_error`).
+5. **Explainable set (in-loop model explanation attached, branch only):**
+   `CapabilityProtocolError, IterationLimit, PolicyDenied, NoProgressDetected,
+   CompactionUnavailable, InvalidModelOutput` (`failure_explanation.rs:232-237`).
+
+## 2. Branch vs main (per-run user experience)
+
+Identical on both: the 13-variant taxonomy, `as_str()` categories, `sanitized_reason` on
+events, `RecoveryRequired` modeling. Main also has a **lazy, category-generic** explanation
+blurb at projection time (`FailureExplanationProvider`, input = category + fallback only).
+
+Branch-only (#4841): **in-loop run-context-aware explanation** persisted as a real
+transcript message (6 explainable kinds; bounded 10s model call, before Final checkpoint);
+`LoopFailed.explanation_message_refs` + `safe_summary`; and the **entire retry path**
+(`RebornServices::retry_run` → webui_v2 `WEBUI_V2_ROUTE_RETRY_RUN` → coordinator
+`retry_turn` → resume from latest resumable checkpoint). Main has **no retry-from-failed
+at all** — every failure is terminal for the user.
+
+## 3. The matrix
+
+Layers: **E** = executor (`ironclaw_agent_loop` tests, MockHost), **B** = binary/driver
+(`tests/support/reborn` harness or planned_driver tests). "≡" = covered by the shared
+variant-agnostic mechanism (checkpoint-presence retry contracts + store/runner tests).
+
+| Variant | Origin (stage) | Trigger seam | Layer | P1 today | P3 today | Explained (branch) | Main behavior | Gap → action |
+|---|---|---|---|---|---|---|---|---|
+| ModelError | model stage; recovery Abort | `with_model_errors([...])` | E+B | tables + e2e | e2e + executor | no | category only, terminal | none (reference row) |
+| ContextBuildFailed | **no producer (dead)** | — | — | tables only | NONE | no | same (dead) | unreachable-row: category-table lock + doc; no fabricated test |
+| CapabilityProtocolError | capability stage; recovery | `fail_batch_with(protocol kind)` | E | tables | 8× executor | **yes** | category only, terminal | matrix row (consolidate) |
+| IterationLimit | budget stage | `family_with_iteration_limit(n)` | E | tables + unit | executor | **yes** | category only, terminal | matrix row |
+| InvalidModelOutput | stop strategy | rejected-reply threshold / `RejectAlways` | E | tables | executor | **yes** | category only, terminal | matrix row |
+| CheckpointRejected | checkpoint stage err / legacy | `fail_checkpoint(kind)` → `checkpoint_rejected` string | E(kind)+B(string) | tables | NONE | no | category only, terminal | **new row + P3 assert** |
+| CheckpointUnavailable | PlannedDriver resume decode | corrupt/missing resume payload | **B only** | comp table only | NONE | no | category only, terminal | **new row + add to turns table** |
+| TranscriptWriteFailed | legacy driver map_host_error | **new knob:** `fail_transcript_with` (S) | E | tables | NONE | no | category only, terminal | **new seam + row + P3 assert** |
+| DriverBug | invariant guards (6+ origins) | canonical: `family_with_gate_outcome(SkipAndContinue)` on Approval gate | E | tables + evidence tests | via mapping | no | category only, terminal | matrix row (one canonical origin) |
+| InterruptedUnexpectedly | enum: no producer; string via in-flight Cancelled | `with_model_errors([kind: Cancelled])` → `map_executor_error` | B(string) | tables + violation path | NONE | no | same mapping exists | **string-level row**; enum documented dead |
+| NoProgressDetected | stop strategy repetition | repeated identical calls/errors | E | tables + projection | executor + safety_nets | **yes** | category only, terminal | matrix row |
+| PolicyDenied | capability denials; gate abort | `with_batch_outcomes(Denied)` | E | tables + unit | executor | **yes** | category only, terminal | matrix row |
+| CompactionUnavailable | prompt/compaction stage | `set_compaction_outcome(Err)` | E | comp table only | executor happy-path | **yes** | category only, terminal | **add to turns table** + matrix row |
+
+P2/P4 (all variants): ≡ shared — `retry_failed_turn_store_contract.rs` (both directions,
+incl. explicit-nonresumable refusal) + `turn_runner` retryable-mapping tests + the ModelError
+E2E (`reborn_failure_retry_resume_e2e.rs`). The matrix adds **one more binary-level P4 row**
+(capability-stage failure → retry resumes) so P4 isn't proven only through the model stage.
+
+## 4. Known one-off gaps to close alongside the matrix
+
+- `all_failure_kinds_produce_stable_sanitized_category_strings`
+  (`loop_exit/tests/mod.rs:1006`) omits `CheckpointUnavailable` + `CompactionUnavailable`
+  and has **no exhaustiveness guard** — add both + an exhaustive-match guard so a new
+  variant fails compilation, mirroring the parity-guarded composition table.
+- Legacy `text_loop_driver` private name map omits `CompactionUnavailable` (drift risk).
+- Prefer scripted-outcome injection over enum construction everywhere: the mapping logic
+  (`executor/mapping.rs`, `capability_failure_kind`, recovery) is itself under test.
+- Cancellation: cooperative cancel (`request_cancellation`) yields `LoopExit::Cancelled`
+  (not a failure) — matrix must use in-flight `Cancelled` errors, never the cancel knobs.
+
+## 5a. Divergences found by the executor matrix (asserted as actual behavior)
+
+The table-driven test (`executor/tests/failure_matrix.rs`) asserts what the code
+DOES; these divergences from the expected rows are documented, not silently fixed:
+
+1. **Approval gate + `SkipAndContinue` completes instead of `DriverBug`.**
+   `GateOutcome::validate_for_gate_kind` declares it invalid, but `GateStage`
+   never enforces it — the run completes (the gated call is skipped, not
+   executed). Enforcement would be a behavior change; flagged for owner review.
+2. **`NoProgressDetected` is in the explainable set but gets no explanation.**
+   The `StopKind::NoProgressDetected` failure path never calls
+   `attach_failure_explanation`, contradicting Part-1's own explainable-set
+   intent. Candidate fix on the failed branch only — NOTE: the no-progress path
+   is PinchBench-load-bearing (final-answer nudge), so any change must leave the
+   nudge untouched and be benchmarked.
+3. **A single `Denied` capability outcome recovers and completes** (denial is
+   fed back to the model as a tool error; the model adapts). Terminal
+   `PolicyDenied` requires repeated denials (no-progress) or a gate abort. This
+   is the no-borking contract working as designed — kept as a matrix row
+   asserting recovery, which is itself a strong vs-main datapoint.
+4. **`TranscriptWriteFailed` / `CheckpointRejected` never surface as
+   `LoopExit::Failed` in the planned executor** — they surface as executor
+   host-stage errors (`HostUnavailable{Transcript}` / `CheckpointFailed`) which
+   the runner maps to retryable host-stage failures. The enum origins are
+   legacy-`text_loop_driver`-only, confirming §1.4.
+
+## 5. Definition of 100% coverage (acceptance)
+
+Every variant has exactly one of:
+(a) a real-origin injection row asserting P1+P3 at its declared layer (+ shared P2/P4), or
+(b) an unreachable-variant row: category-table lock + `#[non_exhaustive]`-safe exhaustive
+    guard + doc note that no production constructor exists (ContextBuildFailed;
+    InterruptedUnexpectedly at enum level — string covered by (a) at binary layer).
+Plus: the turns-crate category table made exhaustive+guarded, and one non-model P4 E2E.

--- a/docs/plans/2026-07-03-loop-failure-matrix.md
+++ b/docs/plans/2026-07-03-loop-failure-matrix.md
@@ -114,6 +114,13 @@ DOES; these divergences from the expected rows are documented, not silently fixe
    the runner maps to retryable host-stage failures. The enum origins are
    legacy-`text_loop_driver`-only, confirming §1.4.
 
+5. **`interrupted_unexpectedly` is lost at the runner boundary.** The planned
+   driver's `map_executor_error` maps an in-flight `Cancelled` host error to
+   `interrupted_unexpectedly`, but runner sanitization projects the run failure
+   as `driver_failed` — the category is overwritten before it reaches the user
+   (binary-level divergence test locks both sides). Candidate follow-up:
+   preserve the driver-mapped category through runner sanitization.
+
 ## 5. Definition of 100% coverage (acceptance)
 
 Every variant has exactly one of:

--- a/docs/plans/2026-07-03-loop-failure-matrix.md
+++ b/docs/plans/2026-07-03-loop-failure-matrix.md
@@ -49,6 +49,14 @@ transcript message (6 explainable kinds; bounded 10s model call, before Final ch
 `retry_turn` → resume from latest resumable checkpoint). Main has **no retry-from-failed
 at all** — every failure is terminal for the user.
 
+Stack note: this branch now sits on top of #5389 and #5390. #5389 changes
+model-fixable capability failures into model-visible tool errors that continue
+the loop instead of terminating it; the matrix asserts those recovered outcomes
+directly. #5390 adds the `FailureLane` / `RetryDisposition` classifiers keyed on
+the sanitized category string plus the run's `retryable` signal; this matrix PR
+does not own that classifier, but proves real failure paths emit the inputs that
+feed it.
+
 ## 3. The matrix
 
 Layers: **E** = executor (`ironclaw_agent_loop` tests, MockHost), **B** = binary/driver
@@ -71,18 +79,23 @@ variant-agnostic mechanism (checkpoint-presence retry contracts + store/runner t
 | PolicyDenied | capability denials; gate abort | `with_batch_outcomes(Denied)` | E | tables + unit | executor | **yes** | category only, terminal | matrix row |
 | CompactionUnavailable | prompt/compaction stage | `set_compaction_outcome(Err)` | E | comp table only | executor happy-path | **yes** | category only, terminal | **add to turns table** + matrix row |
 
+Additional #5389 recovery rows live in the executor matrix: capability
+`Failed(InvalidInput)` (planned terminal kind `ModelError`), `Failed(InvalidOutput)`
+(planned `CapabilityProtocolError`), and `Failed(PolicyDenied)` (planned
+`PolicyDenied`) now complete after the model receives a tool-error result.
+
 P2/P4 (all variants): ≡ shared — `retry_failed_turn_store_contract.rs` (both directions,
 incl. explicit-nonresumable refusal) + `turn_runner` retryable-mapping tests + the ModelError
 E2E (`reborn_failure_retry_resume_e2e.rs`). The matrix adds **one more binary-level P4 row**
 (capability-stage failure → retry resumes) so P4 isn't proven only through the model stage.
 
-## 4. Known one-off gaps to close alongside the matrix
+## 4. Known one-off gaps/status
 
-- `all_failure_kinds_produce_stable_sanitized_category_strings`
-  (`loop_exit/tests/mod.rs:1006`) omits `CheckpointUnavailable` + `CompactionUnavailable`
-  and has **no exhaustiveness guard** — add both + an exhaustive-match guard so a new
-  variant fails compilation, mirroring the parity-guarded composition table.
-- Legacy `text_loop_driver` private name map omits `CompactionUnavailable` (drift risk).
+- RESOLVED in the matrix: `all_failure_kinds_produce_stable_sanitized_category_strings`
+  now includes `CheckpointUnavailable` + `CompactionUnavailable` and has an
+  exhaustive-match guard so a new `LoopFailureKind` variant fails compilation.
+- STILL OPEN: legacy `text_loop_driver` private name map omits
+  `CompactionUnavailable` (drift risk).
 - Prefer scripted-outcome injection over enum construction everywhere: the mapping logic
   (`executor/mapping.rs`, `capability_failure_kind`, recovery) is itself under test.
 - Cancellation: cooperative cancel (`request_cancellation`) yields `LoopExit::Cancelled`
@@ -91,37 +104,60 @@ E2E (`reborn_failure_retry_resume_e2e.rs`). The matrix adds **one more binary-le
 ## 5a. Divergences found by the executor matrix (asserted as actual behavior)
 
 The table-driven test (`executor/tests/failure_matrix.rs`) asserts what the code
-DOES; these divergences from the expected rows are documented, not silently fixed:
+DOES; these divergences from the original expected rows are documented, not
+silently fixed:
 
-1. **Approval gate + `SkipAndContinue` completes instead of `DriverBug`.**
+1. **STILL OPEN — Approval gate + `SkipAndContinue` completes instead of
+   `DriverBug`.**
    `GateOutcome::validate_for_gate_kind` declares it invalid, but `GateStage`
    never enforces it — the run completes (the gated call is skipped, not
    executed). Enforcement would be a behavior change; flagged for owner review.
-2. **`NoProgressDetected` is in the explainable set but gets no explanation.**
+2. **STILL OPEN — `NoProgressDetected` is in the explainable set but gets no
+   explanation.**
    The `StopKind::NoProgressDetected` failure path never calls
    `attach_failure_explanation`, contradicting Part-1's own explainable-set
    intent. Candidate fix on the failed branch only — NOTE: the no-progress path
    is PinchBench-load-bearing (final-answer nudge), so any change must leave the
    nudge untouched and be benchmarked.
-3. **A single `Denied` capability outcome recovers and completes** (denial is
-   fed back to the model as a tool error; the model adapts). Terminal
-   `PolicyDenied` requires repeated denials (no-progress) or a gate abort. This
-   is the no-borking contract working as designed — kept as a matrix row
-   asserting recovery, which is itself a strong vs-main datapoint.
-4. **`TranscriptWriteFailed` / `CheckpointRejected` never surface as
+3. **RESOLVED BY STACK #5389 — model-fixable capability failures recover and
+   complete.** A single `Denied` outcome is fed back to the model as a tool
+   error, and the stack now does the same for capability
+   `Failed(InvalidInput)`, `Failed(InvalidOutput)`, and
+   `Failed(PolicyDenied)`. Terminal `ModelError` / `CapabilityProtocolError` /
+   `PolicyDenied` still exist for true run-ending paths or exhausted recovery,
+   but these model-fixable rows are intentionally recovered. The matrix labels
+   those rows "stack #5389 makes this recoverable; matrix asserts recovery".
+4. **STILL OPEN / legacy-only — `TranscriptWriteFailed` / `CheckpointRejected`
+   never surface as
    `LoopExit::Failed` in the planned executor** — they surface as executor
    host-stage errors (`HostUnavailable{Transcript}` / `CheckpointFailed`) which
    the runner maps to retryable host-stage failures. The enum origins are
    legacy-`text_loop_driver`-only, confirming §1.4.
 
-5. **`interrupted_unexpectedly` is lost at the runner boundary.** The planned
+5. **STILL OPEN — `interrupted_unexpectedly` is lost at the runner boundary.**
+   The planned
    driver's `map_executor_error` maps an in-flight `Cancelled` host error to
    `interrupted_unexpectedly`, but runner sanitization projects the run failure
    as `driver_failed` — the category is overwritten before it reaches the user
    (binary-level divergence test locks both sides). Candidate follow-up:
    preserve the driver-mapped category through runner sanitization.
 
-## 5. Definition of 100% coverage (acceptance)
+## 6. Relationship to #5390 FailureLane
+
+#5390 owns the pure classifier unit tests: `failure_lane(category, retryable)`
+and `retry_disposition(category, retryable)` are tested exhaustively against the
+canonical category list in `ironclaw_reborn_composition`.
+
+This matrix is complementary. It drives real executor/binary paths and proves
+the emitted sanitized categories and retryable checkpoint signal are the inputs
+the classifier expects. The actual `failure_lane()` / `retry_disposition()`
+calls live in the binary E2E test because `ironclaw_agent_loop` has no dependency
+on `ironclaw_reborn_composition`, and adding that dependency would be outside
+this test/doc-only change. Executor-tier rows still assert their real terminal
+or recovered loop outcome; binary rows assert the classifier alignment for the
+observed `(category, retryable)` pair.
+
+## 7. Definition of 100% coverage (acceptance)
 
 Every variant has exactly one of:
 (a) a real-origin injection row asserting P1+P3 at its declared layer (+ shared P2/P4), or

--- a/tests/reborn_failure_retry_resume_e2e.rs
+++ b/tests/reborn_failure_retry_resume_e2e.rs
@@ -12,12 +12,16 @@
 mod reborn_support;
 mod support;
 
+use ironclaw_host_api::CapabilityId;
 use ironclaw_loop_support::{HostManagedModelErrorKind, HostManagedModelResponse};
 use ironclaw_turns::{TurnStatus, run_profile::LoopHostMilestoneKind};
 use reborn_support::{
     harness::{RebornBinaryE2EHarness, RecordingTestCapabilityPort},
-    model_replay::{RebornModelReplayStep, RebornTraceReplayModelGateway},
+    model_replay::{
+        RebornModelReplayStep, RebornScriptedProviderToolCall, RebornTraceReplayModelGateway,
+    },
 };
+use serde_json::json;
 
 /// First model call fails (provider rejects the request); the run must end as a
 /// sanitized, retryable `Failed`. Retrying resumes from the `BeforeModel`
@@ -105,6 +109,155 @@ async fn reborn_model_failure_is_retryable_and_retry_resumes_to_completion() {
 
     // Both scripted steps were consumed: the failing call and the recovered
     // retry call.
+    assert_eq!(harness.remaining_model_responses(), 0);
+
+    harness.shutdown().await;
+}
+
+/// A host-managed model call can surface `Cancelled` without any cooperative
+/// cancel signal. `planned_driver` maps that executor error to
+/// `interrupted_unexpectedly`; the binary runner currently projects the
+/// non-allowlisted driver failure as the generic driver category.
+#[tokio::test]
+async fn reborn_inflight_model_cancelled_projects_driver_failed_divergence() {
+    let model_gateway =
+        RebornTraceReplayModelGateway::with_scripted_steps([RebornModelReplayStep::ModelError {
+            kind: HostManagedModelErrorKind::Cancelled,
+            message: "model provider cancelled the in-flight request".to_string(),
+        }]);
+    let mut harness = RebornBinaryE2EHarness::with_model_gateway(
+        "room-model-cancelled-divergence",
+        model_gateway,
+        RecordingTestCapabilityPort::echo(),
+    )
+    .await
+    .expect("harness");
+    harness.start();
+
+    let submitted = harness
+        .submit_text(
+            "event-model-cancelled-divergence",
+            "Answer after a cancelled model call",
+        )
+        .await
+        .expect("submit text");
+    let failed = harness
+        .wait_for_status(submitted.run_id, TurnStatus::Failed)
+        .await
+        .expect("failed run");
+    // matrix-divergence: `map_executor_error` produces
+    // "interrupted_unexpectedly", but `TurnRunnerWorker::sanitized_driver_failure`
+    // only preserves allowlisted driver reason kinds and currently projects the
+    // binary run category as "driver_failed".
+    assert_eq!(
+        failed
+            .failure
+            .as_ref()
+            .expect("failure category")
+            .category(),
+        "driver_failed"
+    );
+    assert!(
+        failed.checkpoint_id.is_some(),
+        "a model-stage cancellation before a trustworthy LoopExit still preserves the BeforeModel checkpoint"
+    );
+    assert!(
+        !harness.milestones().iter().any(|milestone| matches!(
+            milestone.kind,
+            LoopHostMilestoneKind::AssistantReplyFinalized { .. }
+        )),
+        "a cancelled model call must not fabricate a final assistant reply"
+    );
+    assert_eq!(harness.remaining_model_responses(), 0);
+
+    harness.shutdown().await;
+}
+
+/// The first run reaches the capability stage and the capability host returns a
+/// permanent invocation error. The runner must still fail the run with a
+/// retryable capability-stage category, preserve the checkpoint, and allow a
+/// retry to resume to a final answer.
+#[tokio::test]
+async fn reborn_capability_failure_is_retryable_and_retry_resumes_to_completion() {
+    let model_gateway = RebornTraceReplayModelGateway::with_scripted_steps([
+        RebornModelReplayStep::ProviderToolCalls {
+            calls: vec![RebornScriptedProviderToolCall::new(
+                CapabilityId::new("test.echo").expect("valid capability id"),
+                "call-capability-fails",
+                json!({"message": "please use the test capability"}),
+            )],
+            expected_tool_results: Vec::new(),
+        },
+        RebornModelReplayStep::Response {
+            response: HostManagedModelResponse::assistant_reply(
+                "Recovered after capability failure.",
+            ),
+            expected_tool_results: Vec::new(),
+        },
+    ]);
+    let mut harness = RebornBinaryE2EHarness::with_model_gateway(
+        "room-capability-failure-retry-resume",
+        model_gateway,
+        RecordingTestCapabilityPort::invocation_error(),
+    )
+    .await
+    .expect("harness");
+    harness.start();
+
+    let submitted = harness
+        .submit_text(
+            "event-capability-failure-retry-resume",
+            "Use the test capability and then answer",
+        )
+        .await
+        .expect("submit text");
+    let failed = harness
+        .wait_for_status(submitted.run_id, TurnStatus::Failed)
+        .await
+        .expect("failed run");
+    assert_eq!(
+        failed
+            .failure
+            .as_ref()
+            .expect("failure category")
+            .category(),
+        "host_stage_unavailable_capability"
+    );
+    assert!(
+        failed.checkpoint_id.is_some(),
+        "a retryable capability-stage failure must preserve a resume checkpoint"
+    );
+    assert_eq!(
+        harness.capability_invocations().len(),
+        1,
+        "the failed first run must reach exactly one capability invocation"
+    );
+    assert!(
+        !harness.milestones().iter().any(|milestone| matches!(
+            milestone.kind,
+            LoopHostMilestoneKind::AssistantReplyFinalized { .. }
+        )),
+        "a failed capability invocation must not fabricate a final assistant reply"
+    );
+
+    let retry = harness
+        .retry_turn(submitted.run_id)
+        .await
+        .expect("retry the failed run");
+    assert_ne!(
+        retry.run_id, submitted.run_id,
+        "retry must spawn a distinct run"
+    );
+    assert_eq!(retry.status, TurnStatus::Queued);
+
+    harness
+        .wait_for_status(retry.run_id, TurnStatus::Completed)
+        .await
+        .expect("retry run completes");
+    harness
+        .assert_final_reply("Recovered after capability failure.")
+        .await
+        .expect("recovered reply persisted to the thread");
     assert_eq!(harness.remaining_model_responses(), 0);
 
     harness.shutdown().await;

--- a/tests/reborn_failure_retry_resume_e2e.rs
+++ b/tests/reborn_failure_retry_resume_e2e.rs
@@ -14,7 +14,8 @@ mod support;
 
 use ironclaw_host_api::CapabilityId;
 use ironclaw_loop_support::{HostManagedModelErrorKind, HostManagedModelResponse};
-use ironclaw_turns::{TurnStatus, run_profile::LoopHostMilestoneKind};
+use ironclaw_reborn_composition::{FailureLane, RetryDisposition, failure_lane, retry_disposition};
+use ironclaw_turns::{TurnRunState, TurnStatus, run_profile::LoopHostMilestoneKind};
 use reborn_support::{
     harness::{RebornBinaryE2EHarness, RecordingTestCapabilityPort},
     model_replay::{
@@ -60,13 +61,11 @@ async fn reborn_model_failure_is_retryable_and_retry_resumes_to_completion() {
         .wait_for_status(submitted.run_id, TurnStatus::Failed)
         .await
         .expect("failed run");
-    assert_eq!(
-        failed
-            .failure
-            .as_ref()
-            .expect("failure category")
-            .category(),
-        "host_stage_unavailable_model"
+    assert_failure_lane_alignment(
+        &failed,
+        "host_stage_unavailable_model",
+        FailureLane::Retriable,
+        RetryDisposition::Auto,
     );
 
     // 2) The failed run is retryable: it preserved a resumable checkpoint. This
@@ -149,13 +148,11 @@ async fn reborn_inflight_model_cancelled_projects_driver_failed_divergence() {
     // "interrupted_unexpectedly", but `TurnRunnerWorker::sanitized_driver_failure`
     // only preserves allowlisted driver reason kinds and currently projects the
     // binary run category as "driver_failed".
-    assert_eq!(
-        failed
-            .failure
-            .as_ref()
-            .expect("failure category")
-            .category(),
-        "driver_failed"
+    assert_failure_lane_alignment(
+        &failed,
+        "driver_failed",
+        FailureLane::Retriable,
+        RetryDisposition::UserInitiated,
     );
     assert!(
         failed.checkpoint_id.is_some(),
@@ -215,13 +212,11 @@ async fn reborn_capability_failure_is_retryable_and_retry_resumes_to_completion(
         .wait_for_status(submitted.run_id, TurnStatus::Failed)
         .await
         .expect("failed run");
-    assert_eq!(
-        failed
-            .failure
-            .as_ref()
-            .expect("failure category")
-            .category(),
-        "host_stage_unavailable_capability"
+    assert_failure_lane_alignment(
+        &failed,
+        "host_stage_unavailable_capability",
+        FailureLane::Retriable,
+        RetryDisposition::Auto,
     );
     assert!(
         failed.checkpoint_id.is_some(),
@@ -261,4 +256,32 @@ async fn reborn_capability_failure_is_retryable_and_retry_resumes_to_completion(
     assert_eq!(harness.remaining_model_responses(), 0);
 
     harness.shutdown().await;
+}
+
+fn assert_failure_lane_alignment(
+    state: &TurnRunState,
+    expected_category: &str,
+    expected_lane: FailureLane,
+    expected_disposition: RetryDisposition,
+) {
+    let failure = state.failure.as_ref().expect("failure category");
+    let category = failure.category();
+    let retryable = state.checkpoint_id.is_some();
+
+    assert_eq!(category, expected_category, "sanitized failure category");
+    assert_eq!(
+        failure_lane(category, retryable),
+        expected_lane,
+        "{category}: FailureLane must match the emitted category + retryable signal"
+    );
+    let disposition = retry_disposition(category, retryable);
+    assert_eq!(
+        disposition, expected_disposition,
+        "{category}: RetryDisposition must match the emitted category + retryable signal"
+    );
+    assert_eq!(
+        disposition.failure_lane(),
+        expected_lane,
+        "{category}: RetryDisposition must imply the same FailureLane"
+    );
 }

--- a/tests/support/reborn/harness.rs
+++ b/tests/support/reborn/harness.rs
@@ -3355,11 +3355,16 @@ enum CapabilityMode {
     Echo,
     ApprovalThenEcho,
     SpawnAuthThenApprovalThenEcho,
+    InvocationError,
 }
 
 impl RecordingTestCapabilityPort {
     pub fn echo() -> Self {
         Self::new(CapabilityMode::Echo, false, false)
+    }
+
+    pub fn invocation_error() -> Self {
+        Self::new(CapabilityMode::InvocationError, false, false)
     }
 
     pub fn echo_with_spawn_subagent() -> Self {
@@ -3521,6 +3526,12 @@ impl LoopCapabilityPort for RecordingTestCapabilityPort {
         request: CapabilityInvocation,
     ) -> Result<CapabilityOutcome, AgentLoopHostError> {
         self.invocations.lock().unwrap().push(request);
+        if matches!(self.mode, CapabilityMode::InvocationError) {
+            return Err(AgentLoopHostError::new(
+                AgentLoopHostErrorKind::InvalidInvocation,
+                "scripted capability invocation failure",
+            ));
+        }
         if matches!(self.mode, CapabilityMode::ApprovalThenEcho)
             && self.approval_calls.fetch_add(1, Ordering::SeqCst) == 0
         {


### PR DESCRIPTION
**Stacked on #5403** (top of the recoverability stack: main ← #4841 ← #5389 ← #5390 ← #5403). A pure **test + docs** PR — no production changes — giving the "no run-borking errors" work a per-error-type coverage net and a documented behavior comparison vs `main`.

## What & why

We had no test proving recovery/retry/explanation for **each** `LoopFailureKind`. This adds one, built from a 4-way parallel audit (taxonomy, coverage, main-delta, injection seams) synthesized in `docs/plans/2026-07-03-loop-failure-matrix.md`.

### 1. Exhaustive category table (`ironclaw_turns`)
`all_failure_kinds_produce_stable_sanitized_category_strings` now covers **13/13** variants (adds the previously-missing `CheckpointUnavailable` + `CompactionUnavailable`) with a same-crate exhaustive-match guard, so a new variant **fails compilation** until it's added.

### 2. Table-driven executor matrix (`ironclaw_agent_loop`, new `executor/tests/failure_matrix.rs`)
Drives every executor-reachable variant **at its real origin** via `MockHost` seams (+ a new `fail_transcript_with` knob), asserting per row: reason_kind + sanitized category (P1), no fabricated final reply (P3), and `explanation_message_refs` presence per the explainable set. Includes **recovery rows for #5389's now-model-fixable capability failures** (InvalidInput / InvalidOutput / PolicyDenied) that complete via a model-visible tool error instead of terminating.

### 3. Binary/driver rows + FailureLane alignment (`tests/reborn_failure_retry_resume_e2e.rs`)
- `CheckpointUnavailable` at the resume-decode path; in-flight `Cancelled` → `interrupted_unexpectedly` mapping.
- **Non-model P4 retry E2E**: a capability-stage failure is retryable (checkpoint preserved) and `retry_run` resumes to completion — so retry is no longer proven only through the model stage.
- **#5390 `FailureLane` / `RetryDisposition` alignment**: each real failure path's `(category, retryable)` is asserted to map to the expected bucket — proving the real paths feed #5390's classifier correctly. Complements #5390's classifier unit tests (which test the functions directly); does not duplicate them.

## vs `main` (doc §2)
`main` shows only a category + a lazy *generic* blurb and every failure is terminal for the user. The stack adds run-context explanations persisted to the transcript, the `retry_run` path, and #5390's recoverable/run-ending classification. The matrix asserts these as CI facts (e.g. "a single policy denial recovers and completes").

## Findings surfaced (doc §5a) — documented, not silently fixed
Resolved by the stack: model-fixable capability failures now recover. **Still open** (candidate follow-ups, flagged for owners): Approval-gate `SkipAndContinue` completes instead of `DriverBug`; `NoProgressDetected` never attaches its explanation (must not disturb the PinchBench-load-bearing nudge); `TranscriptWriteFailed`/`CheckpointRejected` are legacy-driver-only enum origins; `interrupted_unexpectedly` is overwritten to `driver_failed` at the runner boundary.

## Validation (bounded, on the stack)
`cargo test ironclaw_turns all_failure_kinds` · `cargo test ironclaw_agent_loop failure_matrix` · `cargo test --test reborn_failure_retry_resume_e2e` (19 passed) · `clippy -D warnings` · `fmt --check` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)