### PR TITLE
refactor(reborn_identity): de-slop — dead types, boundary rule, CONTRACT, error-path tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -284,6 +284,7 @@ When modifying a module with a spec, read the spec first. Code follows spec; spe
 | `src/tools/` | `src/tools/README.md` |
 | `src/workspace/` | `src/workspace/README.md` |
 | `crates/ironclaw_reborn_webui_ingress/` | `crates/ironclaw_reborn_webui_ingress/CLAUDE.md` |
+| `crates/ironclaw_reborn_identity/` | `crates/ironclaw_reborn_identity/CONTRACT.md` |
 | `tests/support/reborn/` | `tests/support/reborn/CLAUDE.md` |
 | `tests/e2e/` | `tests/e2e/CLAUDE.md` |
 

--- a/crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs
+++ b/crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs
@@ -120,6 +120,27 @@ fn reborn_crate_dependency_boundaries_hold() {
             .collect::<Vec<_>>(),
     );
 
+    // Canonical Reborn identity layer: it maps external identities to a stable
+    // `UserId` at the bottom of the stack, so among internal ironclaw crates it
+    // may depend ONLY on `ironclaw_host_api` (identity/scope newtypes) and
+    // `ironclaw_filesystem` (the durable substrate it persists behind). Enforced
+    // as an allowlist so it can never reach UPSTREAM (into
+    // `ironclaw_reborn_composition` / `ironclaw_product_workflow`) or onto the v1
+    // legacy enclave — the "never reach upstream" property the crate guarantees.
+    let reborn_identity_allowed = [
+        "ironclaw_reborn_identity",
+        "ironclaw_host_api",
+        "ironclaw_filesystem",
+    ];
+    assert_no_normal_workspace_deps(
+        &dependencies,
+        "ironclaw_reborn_identity",
+        workspace_ironclaw_crates(&dependencies)
+            .into_iter()
+            .filter(|name| !reborn_identity_allowed.contains(name))
+            .collect::<Vec<_>>(),
+    );
+
     for rule in boundary_rules() {
         assert_no_normal_workspace_deps(&dependencies, rule.crate_name, rule.forbidden);
     }

--- a/crates/ironclaw_reborn_identity/CONTRACT.md
+++ b/crates/ironclaw_reborn_identity/CONTRACT.md
@@ -1,0 +1,118 @@
+# `ironclaw_reborn_identity` — Contract
+
+The canonical Reborn identity layer. It maps every external identity — WebUI
+OAuth logins (`google`, `github`, …) and external channel/product actors
+(`telegram`, `slack`, triggers, …) — to a stable Reborn [`UserId`] **before**
+any runtime state (conversation binding, thread ownership) is touched. Identity
+provisioning lives here, not in WebUI ingress and not in `ironclaw_conversations`
+(which consumes an already-resolved `UserId`).
+
+## Position in the stack
+
+Bottom-of-stack, downstream-facing. Among internal `ironclaw_*` crates it
+depends **only** on `ironclaw_host_api` (identity/scope newtypes, `ScopedPath`)
+and `ironclaw_filesystem` (the durable substrate). It must never reach upstream
+(`ironclaw_reborn_composition`, `ironclaw_product_workflow`) or onto the v1
+legacy enclave. This is machine-enforced: `reborn_crate_dependency_boundaries_hold`
+in `crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs` allows
+exactly those two edges. The only external consumer is
+`ironclaw_reborn_composition`, which re-exports a curated subset via its facade.
+
+## Canonical key
+
+An external identity is keyed by
+`(tenant_id, surface_kind, provider_kind, provider_instance_id, external_subject_id)`.
+Two tenants, two adapter installations, or two surfaces cannot collide on the
+same subject id. Key parts cross the boundary as validated newtypes
+(`ProviderKind`, `ProviderInstanceId`, `ExternalSubjectId`: non-empty, no control
+chars) and are persisted **separately path-segmented** (each base64url-encoded
+into its own path segment, never flattened) so a delimiter-like id cannot collide
+with a key boundary. A `None` provider instance maps to the `_` sentinel — a
+value no base64 encoding produces.
+
+## Resolver surface (`RebornIdentityResolver`)
+
+- `resolve_or_create` — mint-capable. Resolves the identity, links by verified
+  email, or creates a new user. **`SurfaceKind::ChannelActor` is rejected**
+  (`ChannelActorNotMintable`): channel actors are never mint-capable and must
+  fail closed, not auto-provision.
+- `lookup` — link-only; returns the bound user or `None`, never creates.
+- `bind` — links an external identity to an **already-existing** user (upsert,
+  last-writer-wins). The caller must have authenticated the user first.
+- `adopt_migrated_identity` — seeds a pre-existing identity carried from a legacy
+  store, preserving its `user_id` and (for a verified email) the verified-email
+  index. Never mints. Idempotent — existing identity/index records win.
+
+## Invariants (and where each is enforced)
+
+1. **Verified-email linking is gated to OAuth + verified + non-empty.**
+   `verified_email_key` (`filesystem_store.rs`) is the single source of truth:
+   it returns `Some(lowercased email)` only on `SurfaceKind::Oauth` with
+   `email_verified` and a non-empty address, feeding **both** `resolve_or_create`
+   and `adopt_migrated_identity`. The surface gate is a **security** boundary: the
+   verified-email index carries no surface dimension, so restricting linking to
+   the allowlist-gated browser-SSO surface stops a channel actor that asserts a
+   verified email from reading or overwriting an OAuth user's index (cross-surface
+   account collapse). The empty-email guard stops `Some("")` from indexing on the
+   `_` sentinel.
+2. **Tenant scoping is by path**, not by the store's fixed host-caller
+   `ResourceScope`. `tenant_id` is the first encoded path segment of every
+   identity and verified-email record; the mount is `/tenant-shared`. Isolation
+   rests on path construction.
+3. **Index-before-identity write ordering** in `resolve_or_create`: the
+   verified-email index is written (`CasExpectation::Absent`) before the identity
+   record, so "a verified identity record exists" always implies "its index
+   exists", and the read-only fast path never returns an identity whose index is
+   missing. **This ordering guarantee is scoped to `resolve_or_create`** —
+   `adopt_migrated_identity` writes identity-then-index (safe for its
+   same-identity fast path; see the migration race note below).
+4. **Channel actors never mint** — enforced at the top of `resolve_or_create`;
+   `bind`/`adopt_migrated_identity` take an explicit authenticated `user_id`.
+
+## Concurrency model
+
+Relational guarantees are reconstructed on the filesystem's compare-and-swap
+primitive:
+
+- A per-identity-key **process-local async lock** serializes concurrent
+  first-contacts for one identity within a process. Serializing on the identity
+  key (not the email) is deliberate: it also catches two first-logins for the
+  same key presenting divergent verified emails, which an email-scoped lock would
+  let run concurrently.
+- `CasExpectation::Absent` on every create is the **cross-process** backstop: the
+  per-key lock does not serialize across runtime replicas, so a racing creator
+  gets `VersionMismatch` and reconciles by re-reading. The verified-email index
+  CAS is the cross-process arbiter for cross-provider linking on a shared email.
+
+### Accepted, bounded leak
+
+On a **lost** cold first-contact race, `resolve_or_create` may leave an
+unreferenced ("orphan") user row — never an orphan index. It occurs only on a
+lost race (the returning-login fast path never mints), the record is tiny, and
+there is no steady-state growth. Minting the user first is deliberate: writing it
+last would, in the divergent-email cross-process race, leave a verified-email
+index pointing at an id with no user record (a phantom) — strictly worse. GC of
+unreferenced user rows is out of scope for this crate.
+
+## Trust assumptions (load-bearing, external to this crate)
+
+- **Upstream admission gate.** The security of verified-email linking rests on an
+  upstream allowlist (the email-domain allowlist) that this crate cannot see.
+  This crate **trusts** that any `SurfaceKind::Oauth` + `email_verified: true`
+  identity handed to it was already admission-gated.
+- **`RebornIdentityError` carries storage paths.** `Backend(_)` wraps
+  `FilesystemError`, whose Display includes the `ScopedPath` (base64 of tenant /
+  subject / email). It is below the channel boundary; consumers that surface it
+  toward a user must map/scrub it per `.claude/rules/error-handling.md` (no paths
+  in user-facing errors).
+
+## Known gaps (tracked as issues, not yet closed)
+
+Filed from the de-slop review:
+
+- **#5614** — cross-process divergent-email logins can split a principal.
+- **#5615** — `bind()` has no OAuth-surface guard (defense-in-depth).
+- **#5616** — `adopt_migrated_identity` never writes `StoredUser` and reverses the
+  index/identity write order.
+- **#5617** — the login seam is tested only with fakes on both sides.
+- **#5618** — decide the `ExternalIdentityKey` + `lookup`/`bind` public surface.

--- a/crates/ironclaw_reborn_identity/src/filesystem_store.rs
+++ b/crates/ironclaw_reborn_identity/src/filesystem_store.rs
@@ -7,7 +7,7 @@
 //! centralized in the filesystem layer rather than this crate holding a raw
 //! database handle. The relational guarantees the canonical key needs are
 //! reconstructed on top of the filesystem's compare-and-swap primitive, the
-//! same way [`FilesystemSlackHostState`](../../ironclaw_reborn_composition) does:
+//! same way `FilesystemSlackHostState` (in `ironclaw_reborn_composition`) does:
 //!
 //! - **Keyed lookup** — one record per `(tenant, surface, provider, instance,
 //!   subject)`, addressed by a scoped path (key parts are opaque, separately

--- a/crates/ironclaw_reborn_identity/src/filesystem_store.rs
+++ b/crates/ironclaw_reborn_identity/src/filesystem_store.rs
@@ -150,7 +150,7 @@ where
     async fn identity_user(
         &self,
         tenant: &str,
-        surface: &str,
+        surface: SurfaceKind,
         provider: &str,
         instance: &str,
         subject: &str,
@@ -213,7 +213,7 @@ where
         }
 
         let tenant = identity.tenant_id.as_str();
-        let surface = identity.surface_kind.as_str();
+        let surface = identity.surface_kind;
         let provider = identity.provider_kind.as_str();
         // No installation (browser OAuth) maps to "" so the key stays total.
         let instance = identity
@@ -358,7 +358,7 @@ where
             .unwrap_or("");
         self.identity_user(
             key.tenant_id.as_str(),
-            key.surface_kind.as_str(),
+            key.surface_kind,
             key.provider_kind.as_str(),
             instance,
             key.external_subject_id.as_str(),
@@ -378,7 +378,7 @@ where
             .unwrap_or("");
         let path = identity_path(
             key.tenant_id.as_str(),
-            key.surface_kind.as_str(),
+            key.surface_kind,
             key.provider_kind.as_str(),
             instance,
             key.external_subject_id.as_str(),
@@ -421,7 +421,7 @@ where
         user_id: &UserId,
     ) -> Result<(), RebornIdentityError> {
         let tenant = identity.tenant_id.as_str();
-        let surface = identity.surface_kind.as_str();
+        let surface = identity.surface_kind;
         let provider = identity.provider_kind.as_str();
         let instance = identity
             .provider_instance_id

--- a/crates/ironclaw_reborn_identity/src/filesystem_store/paths.rs
+++ b/crates/ironclaw_reborn_identity/src/filesystem_store/paths.rs
@@ -9,25 +9,29 @@
 use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 use ironclaw_host_api::ScopedPath;
 
-use crate::RebornIdentityError;
+use crate::{RebornIdentityError, SurfaceKind};
 
 const IDENTITY_ROOT: &str = "/tenant-shared/reborn-identity";
 
 /// Path of the identity record for one
 /// `(tenant, surface, provider, instance, subject)` key.
+///
+/// `surface` is the typed [`SurfaceKind`] rather than a `&str`: it is a closed,
+/// trusted enum, so it crosses the boundary as a type (no transposition or
+/// arbitrary-string risk) and is rendered via its stable `as_str()`. Unlike the
+/// other key parts it needs no `segment()` encoding — the enum can never produce
+/// a delimiter-like value.
 pub(super) fn identity_path(
     tenant: &str,
-    surface: &str,
+    surface: SurfaceKind,
     provider: &str,
     instance: &str,
     subject: &str,
 ) -> Result<ScopedPath, RebornIdentityError> {
-    // `surface` is interpolated raw, unlike the other key parts: it is the
-    // closed, trusted `SurfaceKind::as_str()` enum ("oauth"/"channel_actor"),
-    // never an adapter-supplied opaque id, so it needs no `segment()` encoding.
     scoped_path(&format!(
-        "{IDENTITY_ROOT}/external/{}/{surface}/{}/{}/{}.json",
+        "{IDENTITY_ROOT}/external/{}/{}/{}/{}/{}.json",
         segment(tenant),
+        surface.as_str(),
         segment(provider),
         segment(instance),
         segment(subject),

--- a/crates/ironclaw_reborn_identity/src/filesystem_store/paths.rs
+++ b/crates/ironclaw_reborn_identity/src/filesystem_store/paths.rs
@@ -22,6 +22,9 @@ pub(super) fn identity_path(
     instance: &str,
     subject: &str,
 ) -> Result<ScopedPath, RebornIdentityError> {
+    // `surface` is interpolated raw, unlike the other key parts: it is the
+    // closed, trusted `SurfaceKind::as_str()` enum ("oauth"/"channel_actor"),
+    // never an adapter-supplied opaque id, so it needs no `segment()` encoding.
     scoped_path(&format!(
         "{IDENTITY_ROOT}/external/{}/{surface}/{}/{}/{}.json",
         segment(tenant),

--- a/crates/ironclaw_reborn_identity/src/filesystem_store/tests.rs
+++ b/crates/ironclaw_reborn_identity/src/filesystem_store/tests.rs
@@ -666,3 +666,123 @@ async fn empty_verified_email_does_not_index_or_link() {
         "an empty verified email must not create a verified-email index"
     );
 }
+
+#[tokio::test]
+async fn resolve_or_create_keys_on_provider_instance() {
+    // The resolve path normalizes a `None` instance to "" and keys on
+    // provider_instance_id exactly like bind/lookup: the same subject with no
+    // instance, with `inst-1`, and with `inst-2` must be three distinct users.
+    // Emails are omitted so verified-email linking cannot mask the instance axis.
+    let store = store();
+    let t = tenant("t");
+    let base = || ResolveExternalIdentity {
+        tenant_id: t.clone(),
+        surface_kind: SurfaceKind::Oauth,
+        provider_kind: ProviderKind::new("google").expect("provider"),
+        provider_instance_id: None,
+        external_subject_id: ExternalSubjectId::new("sub-1").expect("subject"),
+        email: None,
+        email_verified: false,
+        display_name: None,
+    };
+    let no_instance = store.resolve_or_create(base()).await.expect("resolve none");
+    let inst_1 = store
+        .resolve_or_create(ResolveExternalIdentity {
+            provider_instance_id: Some(ProviderInstanceId::new("inst-1").expect("instance")),
+            ..base()
+        })
+        .await
+        .expect("resolve inst-1");
+    let inst_2 = store
+        .resolve_or_create(ResolveExternalIdentity {
+            provider_instance_id: Some(ProviderInstanceId::new("inst-2").expect("instance")),
+            ..base()
+        })
+        .await
+        .expect("resolve inst-2");
+    assert_ne!(no_instance.as_str(), inst_1.as_str());
+    assert_ne!(inst_1.as_str(), inst_2.as_str());
+    assert_ne!(
+        no_instance.as_str(),
+        inst_2.as_str(),
+        "the provider instance is part of the resolve identity key"
+    );
+}
+
+#[tokio::test]
+async fn corrupt_persisted_user_id_surfaces_invalid_user_id() {
+    // A persisted identity record whose `user_id` fails `UserId` validation on
+    // read-back must surface `InvalidUserId` (backend inconsistency), never be
+    // silently dropped. Drives both the `lookup` fast path and `resolve_or_create`.
+    let store = store();
+    let t = tenant("t");
+    let path = identity_path(t.as_str(), "oauth", "google", "", "g-corrupt").expect("path");
+    store
+        .write_record(
+            &path,
+            &StoredExternalIdentity {
+                user_id: String::new(), // empty — rejected by UserId::new on read-back
+                email: None,
+                email_verified: false,
+                created_at: "2026-01-01T00:00:00Z".to_string(),
+            },
+            CasExpectation::Absent,
+        )
+        .await
+        .expect("seed corrupt record");
+
+    let via_lookup = store
+        .lookup(ExternalIdentityKey {
+            tenant_id: t.clone(),
+            surface_kind: SurfaceKind::Oauth,
+            provider_kind: ProviderKind::new("google").expect("provider"),
+            provider_instance_id: None,
+            external_subject_id: ExternalSubjectId::new("g-corrupt").expect("subject"),
+        })
+        .await;
+    assert!(
+        matches!(via_lookup, Err(RebornIdentityError::InvalidUserId(_))),
+        "lookup of a corrupt persisted user id must surface InvalidUserId, got {via_lookup:?}"
+    );
+
+    let via_resolve = store
+        .resolve_or_create(oauth(&t, "google", "g-corrupt", Some("a@x.com"), true))
+        .await;
+    assert!(
+        matches!(via_resolve, Err(RebornIdentityError::InvalidUserId(_))),
+        "resolve over a corrupt persisted user id must surface InvalidUserId, got {via_resolve:?}"
+    );
+}
+
+#[tokio::test]
+async fn corrupt_json_body_surfaces_backend_error() {
+    // A stored body that is not valid JSON for the record type must surface
+    // `Backend` (deserialize failure), not panic and not be swallowed.
+    let store = store();
+    let t = tenant("t");
+    let path = identity_path(t.as_str(), "oauth", "google", "", "g-badjson").expect("path");
+    store
+        .filesystem
+        .put(
+            &store.scope,
+            &path,
+            Entry::bytes(b"{ this is not json".to_vec()).with_content_type(ContentType::json()),
+            CasExpectation::Absent,
+        )
+        .await
+        .expect("seed raw bytes");
+
+    let result = store
+        .lookup(ExternalIdentityKey {
+            tenant_id: t.clone(),
+            surface_kind: SurfaceKind::Oauth,
+            provider_kind: ProviderKind::new("google").expect("provider"),
+            provider_instance_id: None,
+            external_subject_id: ExternalSubjectId::new("g-badjson").expect("subject"),
+        })
+        .await;
+    assert!(
+        matches!(result, Err(RebornIdentityError::Backend(_))),
+        "a corrupt JSON body must surface a Backend error, got {result:?}"
+    );
+}

--- a/crates/ironclaw_reborn_identity/src/filesystem_store/tests.rs
+++ b/crates/ironclaw_reborn_identity/src/filesystem_store/tests.rs
@@ -716,7 +716,8 @@ async fn corrupt_persisted_user_id_surfaces_invalid_user_id() {
     // silently dropped. Drives both the `lookup` fast path and `resolve_or_create`.
     let store = store();
     let t = tenant("t");
-    let path = identity_path(t.as_str(), "oauth", "google", "", "g-corrupt").expect("path");
+    let path =
+        identity_path(t.as_str(), SurfaceKind::Oauth, "google", "", "g-corrupt").expect("path");
     store
         .write_record(
             &path,
@@ -760,7 +761,8 @@ async fn corrupt_json_body_surfaces_backend_error() {
     // `Backend` (deserialize failure), not panic and not be swallowed.
     let store = store();
     let t = tenant("t");
-    let path = identity_path(t.as_str(), "oauth", "google", "", "g-badjson").expect("path");
+    let path =
+        identity_path(t.as_str(), SurfaceKind::Oauth, "google", "", "g-badjson").expect("path");
     store
         .filesystem
         .put(

--- a/crates/ironclaw_reborn_identity/src/lib.rs
+++ b/crates/ironclaw_reborn_identity/src/lib.rs
@@ -100,23 +100,6 @@ pub struct ExternalIdentityKey {
     pub external_subject_id: ExternalSubjectId,
 }
 
-/// A persisted canonical user.
-///
-/// `status` and `role` are intentionally absent: the store has no typed
-/// semantics for them yet, so the `users` table carries them as columns
-/// with DB-level defaults (`active` / `member`) rather than threading
-/// stringly-typed values through this record (see `.claude/rules/types.md`
-/// — fixed small sets must be enums, not strings). Reintroduce them as
-/// `UserStatus` / `UserRole` enums when a caller actually reads them.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct UserRecord {
-    pub id: UserId,
-    pub email: Option<String>,
-    pub display_name: Option<String>,
-    pub created_at: String,
-    pub updated_at: String,
-}
-
 /// Failure modes of the canonical identity layer.
 #[derive(Debug, thiserror::Error)]
 pub enum RebornIdentityError {
@@ -192,42 +175,4 @@ pub trait RebornIdentityResolver: Send + Sync {
         identity: ResolveExternalIdentity,
         user_id: &UserId,
     ) -> Result<(), RebornIdentityError>;
-}
-
-#[async_trait]
-impl<T> RebornIdentityResolver for std::sync::Arc<T>
-where
-    T: RebornIdentityResolver + ?Sized,
-{
-    async fn resolve_or_create(
-        &self,
-        identity: ResolveExternalIdentity,
-    ) -> Result<UserId, RebornIdentityError> {
-        self.as_ref().resolve_or_create(identity).await
-    }
-
-    async fn lookup(
-        &self,
-        key: ExternalIdentityKey,
-    ) -> Result<Option<UserId>, RebornIdentityError> {
-        self.as_ref().lookup(key).await
-    }
-
-    async fn bind(
-        &self,
-        key: ExternalIdentityKey,
-        user_id: &UserId,
-    ) -> Result<(), RebornIdentityError> {
-        self.as_ref().bind(key, user_id).await
-    }
-
-    async fn adopt_migrated_identity(
-        &self,
-        identity: ResolveExternalIdentity,
-        user_id: &UserId,
-    ) -> Result<(), RebornIdentityError> {
-        self.as_ref()
-            .adopt_migrated_identity(identity, user_id)
-            .await
-    }
 }


### PR DESCRIPTION
One iteration of the Reborn de-slop loop (`/deslop-reborn`, PR #5612) over `crates/ironclaw_reborn_identity` — the canonical Reborn identity layer. Reviewed from four angles (thermo-nuclear quality · paranoid architect · interface/contract/invariants · test-coverage/wiring); every "dead/over-exposed" lead was grep-verified before acting.

## What changed (findings grouped by angle)

**Quality**
- **Delete dead `pub struct UserRecord`** (`lib.rs`). Grep-confirmed zero references anywhere; its doc described a v1 `users` table (columns/defaults) that this filesystem-backed store does not have; and its name collided with the live v1 `crate::db::UserRecord`. Deleting it removes the dead type, the stale doc, and the collision.
- **Delete the unused blanket `impl RebornIdentityResolver for Arc<T>`** (`lib.rs`, −37 lines). No caller needs `Arc<Concrete>: Resolver` — every consumer uses `Arc<dyn Resolver>`. This was the one lead grep couldn't settle, so it was ratified by the build: `cargo check --workspace --all-targets` is green with it gone.

**Architecture & security**
- **Add the missing dependency-boundary rule** for `ironclaw_reborn_identity` in `ironclaw_architecture` (allowlist: `ironclaw_host_api` + `ironclaw_filesystem`). The crate had no rule, so nothing stopped a future edge upstream (into composition/product_workflow) or onto the v1 legacy enclave — the "never reach upstream" property it's supposed to guarantee. `cargo test -p ironclaw_architecture` now enforces it.

**Interface, contract & invariants**
- **Author `CONTRACT.md`** — the crate concentrates unusually subtle, security-load-bearing invariants (per-key async lock vs. cross-process CAS arbitration, the deliberate index-before-identity write ordering, an *accepted* orphan-user leak on lost races, the cross-surface-collapse defense in `verified_email_key`, and the upstream email-allowlist trust assumption) that lived only as scattered inline prose. Now captured in one place, and the crate is listed in CLAUDE.md's Module Specs.
- Fix a broken intra-doc link (`filesystem_store.rs`) and note that `surface` is a trusted enum interpolated raw while every other key part is `segment()`-encoded (`paths.rs`) — both were friction points during review, so the fix is a clarifying comment.

**Coverage**
- Add the un-asserted error-path tests: `Backend` on a corrupt JSON body, `InvalidUserId` on a corrupt persisted user id (drives `to_user_id` on both the lookup and resolve paths), and `resolve_or_create` provider-instance keying (previously covered only for bind/lookup). 25 → 28 tests.

## Deferred — filed as issues (out of scope for a single-crate quality PR)
- **#5614** — cross-process divergent-email logins can split a principal (correctness/race; the existing regression test only proves the single-process case).
- **#5615** — `bind()` has no OAuth-surface guard (defense-in-depth).
- **#5616** — `adopt_migrated_identity` never writes `StoredUser` (phantom user) and reverses the index/identity write order.
- **#5617** — the login seam (OAuth route → `WebuiUserDirectory` → resolver) is tested only with fakes on both sides.
- **#5618** — decide the `ExternalIdentityKey` + `lookup`/`bind` public surface (wire to Slack or drop).

## Gates
`cargo fmt --all --check` · `cargo test -p ironclaw_reborn_identity` (28 pass) · `cargo test -p ironclaw_architecture` · `cargo check --workspace --all-targets` · `cargo clippy --workspace --all-targets` — all green. Integration/live/Reborn-e2e tiers **CI-deferred** (need Postgres/Docker/LLM keys, unavailable in this environment).

Depends conceptually on the loop command in #5612 but is independent to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)