### PR TITLE
docs: reference main, not staging, as the PR/integration branch

### DIFF
--- a/.claude/rules/database.md
+++ b/.claude/rules/database.md
@@ -46,7 +46,7 @@ See `src/db/CLAUDE.md` for full schema, dialect differences, and libSQL limitati
 5. Add migration if needed:
    - PostgreSQL: new `migrations/VN__description.sql`
    - libSQL: add entry to `INCREMENTAL_MIGRATIONS` in `libsql_migrations.rs`
-   - **Version numbering**: always number after the highest version on `staging`/`main` — those migrations may already be in production. Check with `git ls-tree origin/staging migrations/` and staging's `INCREMENTAL_MIGRATIONS`. Never reuse or insert before an existing version.
+   - **Version numbering**: always number after the highest version on `main` — those migrations may already be in production. Check with `git ls-tree origin/main migrations/` and main's `INCREMENTAL_MIGRATIONS`. Never reuse or insert before an existing version.
 6. Test feature isolation:
    ```bash
    cargo check                                          # postgres (default)

--- a/docs/internal/trace-commons-storage.md
+++ b/docs/internal/trace-commons-storage.md
@@ -93,9 +93,7 @@ Current guidance after the server split:
   storage migrations.
 - Before creating any future Ironclaw migration, refresh refs with
   `git fetch origin` and re-check:
-  - `git ls-tree --name-only origin/staging:migrations`
   - `git ls-tree --name-only origin/main:migrations`
-  - `git show origin/staging:src/db/libsql_migrations.rs | rg '"[a-z_]+",|\\([[:space:]]*[0-9]+,'`
   - `git show origin/main:src/db/libsql_migrations.rs | rg '"[a-z_]+",|\\([[:space:]]*[0-9]+,'`
 - Do not add `IF NOT EXISTS` to Ironclaw PostgreSQL migration DDL unless the
   repo's refinery policy changes. PostgreSQL migrations should be one-shot and


### PR DESCRIPTION
We open PRs against `main` now, but a couple of active guidance docs still named `staging` as the authoritative integration branch. Fixes the drift.

## Changed
- **`.claude/rules/database.md`** — migration version numbering now checks `main`: "number after the highest version on `main` … `git ls-tree origin/main migrations/` and main's `INCREMENTAL_MIGRATIONS`" (was `staging`).
- **`docs/internal/trace-commons-storage.md`** — the "before creating any future migration" checklist dropped its `origin/staging` re-check commands, keeping the `origin/main` ones.

## Deliberately left alone
- Dated plan/postmortem snapshots (`docs/plans/*`, `docs/superpowers/plans/*`) and the "Historical local state" note in `trace-commons-storage.md` — these record what was true when written; editing them would falsify the historical record.
- The many unrelated uses of the word "staging" (staging area, key/secret staging, dev/staging/prod environments) — not branch references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)