### PR TITLE
Experiment with OVH Reborn nextest archive

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -34,3 +34,7 @@ slow-timeout = { period = "300s", terminate-after = 2 }
 [[profile.ci.overrides]]
 filter = "test(=live_tests::zizmor_scan) | test(=live_tests::zizmor_scan_v2) | test(~e2e_thread_scheduling) | test(~heavy_integration)"
 slow-timeout = { period = "300s", terminate-after = 2 }
+
+[[profile.ci.overrides]]
+filter = "binary(/reborn_.*/) | binary(=support_unit_tests)"
+slow-timeout = { period = "300s", terminate-after = 6 }

--- a/.github/workflows/reborn-tests.yml
+++ b/.github/workflows/reborn-tests.yml
@@ -385,6 +385,7 @@ jobs:
           mkdir -p target/nextest-archive
           printf 'Archiving Reborn test target: %s\n' "${test_names[@]}"
           cargo nextest archive \
+            --no-default-features \
             --features libsql \
             "${archive_args[@]}" \
             --archive-file target/nextest-archive/reborn-nextest.tar.zst

--- a/.github/workflows/reborn-tests.yml
+++ b/.github/workflows/reborn-tests.yml
@@ -280,10 +280,128 @@ jobs:
           timeout --signal=INT --kill-after=30s 28m \
             cargo test -p "$PACKAGE" ${feature_flags} --all-targets -- --nocapture
 
+  reborn-nextest-archive:
+    name: Build Reborn nextest archive
+    needs: changes
+    if: >
+      needs.changes.outputs.docs_only != 'true' &&
+      needs.changes.outputs.has_reborn_tests == 'true' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: [self-hosted, Linux, X64, ovh, trusted-pr]
+    timeout-minutes: 45
+    env:
+      ANTHROPIC_API_KEY: ""
+      LLM_BACKEND: ""
+      LLM_USE_CODEX_AUTH: "false"
+      OLLAMA_BASE_URL: ""
+      OPENAI_API_KEY: ""
+      CARGO_INCREMENTAL: "0"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+          persist-credentials: false
+
+      - name: Free disk space
+        run: |
+          df -h /
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/.ghcup /usr/local/share/boost /opt/hostedtoolcache/CodeQL || true
+          docker system prune -af || true
+          df -h /
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: Install mold and clang
+        run: |
+          scripts/ci/install-ci-apt-packages.sh clang mold
+          test -x /usr/bin/mold
+
+      - name: Verify mold linker is active
+        run: |
+          clang_output="$(
+            printf 'int main(void) { return 0; }\n' \
+              | clang --ld-path=/usr/bin/mold -Wl,--version -x c - -o /tmp/clang-mold-check 2>&1
+          )"
+          printf '%s\n' "$clang_output"
+          grep -qi mold <<< "$clang_output"
+
+          printf 'fn main() { println!("mold-link-ok"); }\n' > /tmp/mold-link-check.rs
+          rustc /tmp/mold-link-check.rs \
+            -C linker=clang \
+            -C link-arg=--ld-path=/usr/bin/mold \
+            -o /tmp/mold-link-check
+          test "$(/tmp/mold-link-check)" = "mold-link-ok"
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@62b0f2dec647a8e604c6a0fda0e38530180dce20 # v2
+        with:
+          tool: cargo-nextest
+
+      - name: Restore Rust cache
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: reborn-tests-root
+          save-if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'merge_group' }}
+
+      - name: Setup OVH sccache cache
+        uses: ./.github/actions/setup-sccache-dist
+        with:
+          cache-ssh-host: ${{ vars.SCCACHE_CACHE_SSH_HOST }}
+          cache-ssh-user: ${{ vars.SCCACHE_CACHE_SSH_USER }}
+          cache-ssh-port: ${{ vars.SCCACHE_CACHE_SSH_PORT }}
+          cache-ssh-private-key: ${{ secrets.SCCACHE_CACHE_SSH_PRIVATE_KEY }}
+          cache-ssh-known-hosts: ${{ secrets.SCCACHE_CACHE_SSH_KNOWN_HOSTS }}
+          redis-password: ${{ secrets.SCCACHE_REDIS_PASSWORD }}
+
+      - name: Build Reborn nextest archive
+        env:
+          NEXTEST_PROFILE: ci
+        run: |
+          mapfile -t test_names < <(
+            {
+              find tests -maxdepth 1 -type f -name 'reborn_*.rs' -print
+              if [ -f tests/support_unit_tests.rs ]; then
+                printf '%s\n' tests/support_unit_tests.rs
+              fi
+              find tests -mindepth 1 -maxdepth 1 -type d -name 'reborn_group_*' \
+                -exec sh -c 'test -f "$1/main.rs"' _ {} ';' -print
+            } \
+              | sed -E 's#^tests/##; s#\.rs$##' \
+              | LC_ALL=C sort
+          )
+
+          if [ "${#test_names[@]}" -eq 0 ]; then
+            echo "No Reborn nextest archive targets discovered" >&2
+            exit 1
+          fi
+
+          archive_args=()
+          for test_name in "${test_names[@]}"; do
+            archive_args+=(--test "${test_name}")
+          done
+
+          mkdir -p target/nextest-archive
+          printf 'Archiving Reborn test target: %s\n' "${test_names[@]}"
+          cargo nextest archive \
+            --features libsql \
+            "${archive_args[@]}" \
+            --archive-file target/nextest-archive/reborn-nextest.tar.zst
+          ls -lh target/nextest-archive/reborn-nextest.tar.zst
+
+      - name: Upload Reborn nextest archive
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: reborn-nextest-archive
+          path: target/nextest-archive/reborn-nextest.tar.zst
+          if-no-files-found: error
+          retention-days: 1
+
   root-reborn-parity-tests:
     name: Reborn root tests (${{ matrix.partition }})
-    needs: changes
-    if: needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.has_reborn_tests == 'true'
+    needs: [changes, reborn-nextest-archive]
+    if: always() && needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.has_reborn_tests == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     env:
@@ -301,6 +419,12 @@ jobs:
       matrix:
         partition: [0, 1, 2, 3]
     steps:
+      - name: Fail if trusted Reborn archive build failed
+        if: needs.reborn-nextest-archive.result != 'success' && needs.reborn-nextest-archive.result != 'skipped'
+        run: |
+          echo "Reborn nextest archive build did not succeed: ${{ needs.reborn-nextest-archive.result }}"
+          exit 1
+
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -308,6 +432,7 @@ jobs:
           persist-credentials: false
 
       - name: Free disk space
+        if: needs.reborn-nextest-archive.result == 'skipped'
         run: |
           df -h /
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/.ghcup /usr/local/share/boost /opt/hostedtoolcache/CodeQL || true
@@ -315,14 +440,17 @@ jobs:
           df -h /
 
       - name: Install Rust
+        if: needs.reborn-nextest-archive.result == 'skipped'
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Install mold and clang
+        if: needs.reborn-nextest-archive.result == 'skipped'
         run: |
           scripts/ci/install-ci-apt-packages.sh clang mold
           test -x /usr/bin/mold
 
       - name: Verify mold linker is active
+        if: needs.reborn-nextest-archive.result == 'skipped'
         run: |
           clang_output="$(
             printf 'int main(void) { return 0; }\n' \
@@ -339,6 +467,7 @@ jobs:
           test "$(/tmp/mold-link-check)" = "mold-link-ok"
 
       - name: Restore Rust cache
+        if: needs.reborn-nextest-archive.result == 'skipped'
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           # All 4 root partitions compile the *same* root-package build (they
@@ -352,6 +481,7 @@ jobs:
           save-if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'merge_group' }}
 
       - name: Setup OVH sccache cache
+        if: needs.reborn-nextest-archive.result == 'skipped'
         uses: ./.github/actions/setup-sccache-dist
         with:
           cache-ssh-host: ${{ vars.SCCACHE_CACHE_SSH_HOST }}
@@ -362,12 +492,38 @@ jobs:
           redis-password: ${{ secrets.SCCACHE_REDIS_PASSWORD }}
 
       - name: Run Reborn root tests
+        if: needs.reborn-nextest-archive.result == 'skipped'
         run: scripts/ci/run-reborn-root-partition.sh
+
+      - name: Install cargo-nextest
+        if: needs.reborn-nextest-archive.result == 'success'
+        uses: taiki-e/install-action@62b0f2dec647a8e604c6a0fda0e38530180dce20 # v2
+        with:
+          tool: cargo-nextest
+
+      - name: Download Reborn nextest archive
+        if: needs.reborn-nextest-archive.result == 'success'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: reborn-nextest-archive
+          path: target/nextest-archive
+
+      - name: Run Reborn root tests from archive
+        if: needs.reborn-nextest-archive.result == 'success'
+        env:
+          NEXTEST_PROFILE: ci
+        run: |
+          partition="$((REBORN_ROOT_TEST_PARTITION + 1))/${REBORN_ROOT_TEST_PARTITIONS}"
+          cargo-nextest nextest run \
+            --archive-file target/nextest-archive/reborn-nextest.tar.zst \
+            --workspace-remap "$GITHUB_WORKSPACE" \
+            --partition "slice:${partition}" \
+            -E '(binary(/reborn_.*/) - binary(/reborn_group_.*/)) + binary(=support_unit_tests)'
 
   reborn-group-tests:
     name: Reborn group tests
-    needs: changes
-    if: needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.has_reborn_tests == 'true'
+    needs: [changes, reborn-nextest-archive]
+    if: always() && needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.has_reborn_tests == 'true'
     runs-on: ubuntu-latest
     # Group tests run sequentially in ONE job (build once, reuse artifacts), so
     # the budget must cover N suites at REBORN_GROUP_TEST_TIMEOUT each plus setup
@@ -385,6 +541,12 @@ jobs:
       REBORN_GROUP_TEST_TIMEOUT: 28m
       CARGO_INCREMENTAL: "0"
     steps:
+      - name: Fail if trusted Reborn archive build failed
+        if: needs.reborn-nextest-archive.result != 'success' && needs.reborn-nextest-archive.result != 'skipped'
+        run: |
+          echo "Reborn nextest archive build did not succeed: ${{ needs.reborn-nextest-archive.result }}"
+          exit 1
+
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -392,6 +554,7 @@ jobs:
           persist-credentials: false
 
       - name: Free disk space
+        if: needs.reborn-nextest-archive.result == 'skipped'
         run: |
           df -h /
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/.ghcup /usr/local/share/boost /opt/hostedtoolcache/CodeQL || true
@@ -399,14 +562,17 @@ jobs:
           df -h /
 
       - name: Install Rust
+        if: needs.reborn-nextest-archive.result == 'skipped'
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Install mold and clang
+        if: needs.reborn-nextest-archive.result == 'skipped'
         run: |
           scripts/ci/install-ci-apt-packages.sh clang mold
           test -x /usr/bin/mold
 
       - name: Verify mold linker is active
+        if: needs.reborn-nextest-archive.result == 'skipped'
         run: |
           clang_output="$(
             printf 'int main(void) { return 0; }\n' \
@@ -423,6 +589,7 @@ jobs:
           test "$(/tmp/mold-link-check)" = "mold-link-ok"
 
       - name: Restore Rust cache
+        if: needs.reborn-nextest-archive.result == 'skipped'
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           # REUSE the root partitions' cache key: the group `[[test]]` binaries
@@ -436,6 +603,7 @@ jobs:
           save-if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'merge_group' }}
 
       - name: Setup OVH sccache cache
+        if: needs.reborn-nextest-archive.result == 'skipped'
         uses: ./.github/actions/setup-sccache-dist
         with:
           cache-ssh-host: ${{ vars.SCCACHE_CACHE_SSH_HOST }}
@@ -446,7 +614,33 @@ jobs:
           redis-password: ${{ secrets.SCCACHE_REDIS_PASSWORD }}
 
       - name: Run Reborn group tests
+        if: needs.reborn-nextest-archive.result == 'skipped'
         run: scripts/ci/run-reborn-group-tests.sh
+
+      - name: Install cargo-nextest
+        if: needs.reborn-nextest-archive.result == 'success'
+        uses: taiki-e/install-action@62b0f2dec647a8e604c6a0fda0e38530180dce20 # v2
+        with:
+          tool: cargo-nextest
+
+      - name: Download Reborn nextest archive
+        if: needs.reborn-nextest-archive.result == 'success'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: reborn-nextest-archive
+          path: target/nextest-archive
+
+      - name: Run Reborn group tests from archive
+        if: needs.reborn-nextest-archive.result == 'success'
+        env:
+          NEXTEST_PROFILE: ci
+        run: |
+          timeout --signal=INT --kill-after=30s "${REBORN_GROUP_TEST_TIMEOUT}" \
+            cargo-nextest nextest run \
+              --archive-file target/nextest-archive/reborn-nextest.tar.zst \
+              --workspace-remap "$GITHUB_WORKSPACE" \
+              --test-threads 1 \
+              -E 'binary(/reborn_group_.*/)'
 
   webui-v2-js-tests:
     name: Reborn WebUI v2 JS tests
@@ -536,6 +730,7 @@ jobs:
       - changes
       - package-matrix
       - crate-tests
+      - reborn-nextest-archive
       - root-reborn-parity-tests
       - reborn-group-tests
       - webui-v2-js-tests
@@ -565,6 +760,11 @@ jobs:
 
           if [[ "${{ needs.crate-tests.result }}" != "success" ]]; then
             echo "One or more Reborn binary crate tests failed: ${{ needs.crate-tests.result }}"
+            exit 1
+          fi
+
+          if [[ "${{ needs.reborn-nextest-archive.result }}" != "success" && "${{ needs.reborn-nextest-archive.result }}" != "skipped" ]]; then
+            echo "Reborn nextest archive build failed: ${{ needs.reborn-nextest-archive.result }}"
             exit 1
           fi
 

--- a/.github/workflows/reborn-tests.yml
+++ b/.github/workflows/reborn-tests.yml
@@ -385,7 +385,6 @@ jobs:
           mkdir -p target/nextest-archive
           printf 'Archiving Reborn test target: %s\n' "${test_names[@]}"
           cargo nextest archive \
-            --no-default-features \
             --features libsql \
             "${archive_args[@]}" \
             --archive-file target/nextest-archive/reborn-nextest.tar.zst

--- a/.github/workflows/reborn-tests.yml
+++ b/.github/workflows/reborn-tests.yml
@@ -513,12 +513,43 @@ jobs:
         env:
           NEXTEST_PROFILE: ci
         run: |
-          partition="$((REBORN_ROOT_TEST_PARTITION + 1))/${REBORN_ROOT_TEST_PARTITIONS}"
+          mapfile -t test_names < <(
+            {
+              find tests -maxdepth 1 -type f -name 'reborn_*.rs' -print
+              if [ -f tests/support_unit_tests.rs ]; then
+                printf '%s\n' tests/support_unit_tests.rs
+              fi
+            } \
+              | sed -E 's#^tests/##; s#\.rs$##' \
+              | LC_ALL=C sort
+          )
+
+          selected_filters=()
+          for index in "${!test_names[@]}"; do
+            if (( index % REBORN_ROOT_TEST_PARTITIONS != REBORN_ROOT_TEST_PARTITION )); then
+              continue
+            fi
+            selected_filters+=("binary(=${test_names[$index]})")
+          done
+
+          if [ "${#selected_filters[@]}" -eq 0 ]; then
+            echo "No Reborn root tests assigned to partition ${REBORN_ROOT_TEST_PARTITION} of ${REBORN_ROOT_TEST_PARTITIONS}; passing by design"
+            exit 0
+          fi
+
+          filter=""
+          for expression in "${selected_filters[@]}"; do
+            if [ -n "${filter}" ]; then
+              filter="${filter} | "
+            fi
+            filter="${filter}${expression}"
+          done
+
           cargo-nextest nextest run \
             --archive-file target/nextest-archive/reborn-nextest.tar.zst \
             --workspace-remap "$GITHUB_WORKSPACE" \
-            --partition "slice:${partition}" \
-            -E '(binary(/reborn_.*/) - binary(/reborn_group_.*/)) + binary(=support_unit_tests)'
+            --test-threads 1 \
+            -E "${filter}"
 
   reborn-group-tests:
     name: Reborn group tests

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 pub mod assertions;
 pub mod cleanup;
 #[cfg(feature = "libsql")]
@@ -16,3 +18,10 @@ pub mod test_rig;
 pub mod trace_llm;
 #[cfg(feature = "libsql")]
 pub mod trace_runner;
+
+pub fn repo_root() -> PathBuf {
+    std::env::var_os("GITHUB_WORKSPACE")
+        .or_else(|| std::env::var_os("CARGO_MANIFEST_DIR"))
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(env!("CARGO_MANIFEST_DIR")))
+}

--- a/tests/support/reborn/github.rs
+++ b/tests/support/reborn/github.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use ironclaw_extensions::{ExtensionManifest, ExtensionPackage, ExtensionRegistry, ManifestSource};
 use ironclaw_host_api::{
@@ -72,6 +72,6 @@ pub fn asset_root() -> PathBuf {
     repo_root().join("crates/ironclaw_first_party_extensions/assets/github")
 }
 
-fn repo_root() -> &'static Path {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
+fn repo_root() -> PathBuf {
+    super::repo_root()
 }

--- a/tests/support/reborn/golden.rs
+++ b/tests/support/reborn/golden.rs
@@ -121,7 +121,7 @@ impl RebornIntegrationHarness {
             &self.scripted_llm.captured_tool_definitions(),
         ));
         let mut settings = insta::Settings::clone_current();
-        settings.set_snapshot_path(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/snapshots"));
+        settings.set_snapshot_path(super::repo_root().join("tests/snapshots"));
         settings.set_prepend_module_to_snapshot(false);
         settings.set_omit_expression(true);
         settings.bind(|| {

--- a/tests/support/reborn/harness_web_access.rs
+++ b/tests/support/reborn/harness_web_access.rs
@@ -37,10 +37,7 @@
 
 #![allow(dead_code)] // Test-only scaffolding; not every consumer exercises every helper.
 
-use std::{
-    path::{Path, PathBuf},
-    sync::Arc,
-};
+use std::{path::PathBuf, sync::Arc};
 
 use ironclaw_authorization::GrantAuthorizer;
 use ironclaw_extensions::{ExtensionManifest, ExtensionPackage, ExtensionRegistry, ManifestSource};
@@ -92,8 +89,8 @@ pub(super) fn asset_root() -> PathBuf {
     repo_root().join("crates/ironclaw_first_party_extensions/assets/web-access")
 }
 
-fn repo_root() -> &'static Path {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
+fn repo_root() -> PathBuf {
+    super::repo_root()
 }
 
 /// Trust policy admitting the test-only `web-access` provider as first-party,

--- a/tests/support/reborn/mod.rs
+++ b/tests/support/reborn/mod.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 pub mod approval;
 pub mod assertions;
 pub mod builder;
@@ -30,3 +32,10 @@ pub mod scripted_provider;
 pub mod session_thread;
 pub mod test_adapter;
 pub mod triggered_submit;
+
+pub fn repo_root() -> PathBuf {
+    std::env::var_os("GITHUB_WORKSPACE")
+        .or_else(|| std::env::var_os("CARGO_MANIFEST_DIR"))
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(env!("CARGO_MANIFEST_DIR")))
+}

--- a/tests/support/reborn/qa_trace.rs
+++ b/tests/support/reborn/qa_trace.rs
@@ -186,7 +186,7 @@ fn network_response_from_http_exchange_response(
 }
 
 pub fn qa_fixture_path(fixture_name: &str) -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+    super::repo_root()
         .join("tests/fixtures/llm_traces/reborn_qa")
         .join(format!("{fixture_name}.json"))
 }

--- a/tests/support/replay_outcome.rs
+++ b/tests/support/replay_outcome.rs
@@ -298,7 +298,10 @@ async fn capture_engine_threads() -> Vec<ThreadSummary> {
 macro_rules! assert_replay_snapshot {
     ($name:expr, $outcome:expr) => {{
         let mut settings = ::insta::Settings::clone_current();
-        settings.set_snapshot_path(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/snapshots"));
+        let repo_root = ::std::env::var_os("GITHUB_WORKSPACE")
+            .or_else(|| ::std::env::var_os("CARGO_MANIFEST_DIR"))
+            .unwrap_or_else(|| ::std::ffi::OsString::from(env!("CARGO_MANIFEST_DIR")));
+        settings.set_snapshot_path(::std::path::PathBuf::from(repo_root).join("tests/snapshots"));
         settings.set_prepend_module_to_snapshot(false);
         settings.set_sort_maps(true);
         settings.set_omit_expression(true);

--- a/tests/support/test_rig.rs
+++ b/tests/support/test_rig.rs
@@ -1650,10 +1650,9 @@ impl TestRig {
 /// `filename` is relative to `tests/fixtures/llm_traces/recorded/`.
 #[cfg(feature = "libsql")]
 pub async fn run_recorded_trace(filename: &str) {
-    let path = format!(
-        "{}/tests/fixtures/llm_traces/recorded/{filename}",
-        env!("CARGO_MANIFEST_DIR")
-    );
+    let path = super::repo_root()
+        .join("tests/fixtures/llm_traces/recorded")
+        .join(filename);
     let trace = LlmTrace::from_file(&path)
         .unwrap_or_else(|e| panic!("failed to load trace {filename}: {e}"));
     let rig = TestRigBuilder::new()
@@ -1668,10 +1667,9 @@ pub async fn run_recorded_trace(filename: &str) {
 /// Like [`run_recorded_trace`] but routes through the engine v2 pipeline.
 #[cfg(feature = "libsql")]
 pub async fn run_recorded_trace_v2(filename: &str) {
-    let path = format!(
-        "{}/tests/fixtures/llm_traces/recorded/{filename}",
-        env!("CARGO_MANIFEST_DIR")
-    );
+    let path = super::repo_root()
+        .join("tests/fixtures/llm_traces/recorded")
+        .join(filename);
     let trace = LlmTrace::from_file(&path)
         .unwrap_or_else(|e| panic!("failed to load trace {filename}: {e}"));
     let rig = TestRigBuilder::new()

--- a/tests/support_unit_tests.rs
+++ b/tests/support_unit_tests.rs
@@ -2861,10 +2861,8 @@ mod trace_llm_tests {
 
     #[tokio::test]
     async fn from_json_file() {
-        let fixture_path = concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/tests/fixtures/llm_traces/simple_text.json"
-        );
+        let fixture_path =
+            crate::support::repo_root().join("tests/fixtures/llm_traces/simple_text.json");
         let llm = TraceLlm::from_file(fixture_path).unwrap();
 
         assert_eq!(llm.model_name(), "test-model");


### PR DESCRIPTION
## Summary

This is an experiment for using the OVH trusted self-hosted runner as a Reborn nextest archive producer:

- builds one Reborn `cargo nextest` archive on the trusted OVH runner
- uploads the archive as a short-lived artifact
- makes GitHub-hosted Reborn root/group jobs download and run tests from that archive
- keeps the old compile-on-GitHub path when the archive job is skipped, e.g. untrusted fork PRs
- fixes test support paths so archived binaries resolve fixtures/manifests from the runtime checkout via `GITHUB_WORKSPACE`

## Benchmark result

Latest green archive run: https://github.com/nearai/ironclaw/actions/runs/28684600515

Target job timings:

| Job | Time |
| --- | ---: |
| Build Reborn nextest archive | 395s |
| Reborn group tests | 212s |
| Reborn root tests (0) | 304s |
| Reborn root tests (1) | 136s |
| Reborn root tests (2) | 279s |
| Reborn root tests (3) | 278s |

Baseline latest `main` run: https://github.com/nearai/ironclaw/actions/runs/28681653394

| Job | Time |
| --- | ---: |
| Reborn group tests | 326s |
| Reborn root tests (0) | 397s |
| Reborn root tests (1) | 426s |
| Reborn root tests (2) | 487s |
| Reborn root tests (3) | 414s |

Full workflow active time was worse in this experiment: 711s here vs 603s on the baseline main run. Root/group consumers are faster individually, but the archive producer adds a gate that more than cancels out the savings.

I also tested `--no-default-features --features libsql` in https://github.com/nearai/ironclaw/actions/runs/28685265502. It passed but was slower: archive 399s, group 383s, active workflow 793s. That commit was reverted.

## Recommendation

Do not merge this as-is for speed. It is useful evidence, but the current PR CI already benefits enough from parallel warmed cache builds that a single archive producer is not a net win. The next better lever is likely archive-per-heavy-suite only, or reducing duplicated compilation in coverage where the archive gate can replace a more expensive serial rebuild.

## Validation

- `cargo fmt --check`
- `git diff --check`
- workflow YAML parse
- embedded workflow bash snippets parse
- Reborn workflow green on branch: https://github.com/nearai/ironclaw/actions/runs/28684600515
