### PR TITLE
Honor staged credential obligations for WASM egress

### DIFF
--- a/crates/ironclaw_host_runtime/src/services/builder.rs
+++ b/crates/ironclaw_host_runtime/src/services/builder.rs
@@ -980,18 +980,9 @@ where
                 descriptor.runtime == RuntimeKind::Wasm
                     && !descriptor.runtime_credentials.is_empty()
             });
-            let mut provider = SharedHostWasmRuntimeCredentials::new((*self.registry).clone());
-            if let (Some(secret_store), Some(account_resolver)) = (
-                self.secret_store.clone(),
-                self.runtime_credential_account_resolver.clone(),
-            ) {
-                provider = provider.with_product_auth_restaging(
-                    secret_store,
-                    Arc::clone(&self.secret_injection_store),
-                    account_resolver,
-                );
-            }
-            let provider = Arc::new(provider);
+            let provider = Arc::new(SharedHostWasmRuntimeCredentials::new(
+                (*self.registry).clone(),
+            ));
             self = self
                 .with_manifest_wasm_runtime_credentials(provider, has_current_manifest_credentials);
         }

--- a/crates/ironclaw_host_runtime/src/wasm_credentials.rs
+++ b/crates/ironclaw_host_runtime/src/wasm_credentials.rs
@@ -1,32 +1,25 @@
 use std::{
     collections::BTreeMap,
     fmt,
-    future::Future,
-    sync::{Arc, LazyLock, Mutex, mpsc},
+    sync::{Arc, Mutex},
 };
 
 use ironclaw_extensions::{ExtensionRegistry, SharedExtensionRegistry};
 use ironclaw_host_api::{
-    CapabilityId, CredentialStageError, ExtensionId, NetworkTargetPattern,
-    RuntimeCredentialInjection, RuntimeCredentialRequirementSource, RuntimeCredentialSource,
-    RuntimeCredentialTarget, RuntimeKind, SecretHandle,
+    CapabilityId, ExtensionId, NetworkTargetPattern, RuntimeCredentialInjection,
+    RuntimeCredentialRequirementSource, RuntimeCredentialSource, RuntimeCredentialTarget,
+    RuntimeKind, SecretHandle,
 };
 use ironclaw_network::{network_target_for_url, target_matches_pattern};
-use ironclaw_secrets::SecretStore;
 use ironclaw_wasm::{WasmHostError, WasmRuntimeCredentialProvider, WasmRuntimeCredentialRequest};
-use tokio::runtime::Handle;
-
-use crate::{
-    RuntimeCredentialAccountRequest, RuntimeCredentialAccountResolver,
-    obligations::RuntimeSecretInjectionStore,
-};
 
 /// Host-derived WASM credential provider built from validated extension manifests.
 ///
-/// This provider emits only host-approved staged-obligation injection plans. It
-/// never exposes raw secret material to WASM and never grants new authority; the
-/// matching staged secret material must already exist in the host egress handoff
-/// store for the scoped capability invocation.
+/// This provider emits manifest-derived staged-obligation injection plans. It
+/// never exposes raw secret material to WASM and never resolves product-auth
+/// accounts from the manifest by itself. Matching staged secret material must
+/// already exist in the host egress handoff store for the scoped capability
+/// invocation, which keeps `Decision.obligations` as the authority boundary.
 #[derive(Debug, Clone, Default)]
 pub(crate) struct HostWasmRuntimeCredentials {
     credentials: Vec<HostWasmRuntimeCredential>,
@@ -70,7 +63,6 @@ impl HostWasmRuntimeCredentials {
 pub(crate) struct SharedHostWasmRuntimeCredentials {
     registry: SharedExtensionRegistry,
     cache: Arc<Mutex<SharedCredentialCache>>,
-    restager: Option<RuntimeCredentialRestager>,
 }
 
 impl SharedHostWasmRuntimeCredentials {
@@ -78,22 +70,7 @@ impl SharedHostWasmRuntimeCredentials {
         Self {
             registry,
             cache: Arc::new(Mutex::new(SharedCredentialCache::default())),
-            restager: None,
         }
-    }
-
-    pub(crate) fn with_product_auth_restaging(
-        mut self,
-        secret_store: Arc<dyn SecretStore>,
-        secret_injections: Arc<RuntimeSecretInjectionStore>,
-        account_resolver: Arc<dyn RuntimeCredentialAccountResolver>,
-    ) -> Self {
-        self.restager = Some(RuntimeCredentialRestager {
-            secret_store,
-            secret_injections,
-            account_resolver,
-        });
-        self
     }
 }
 
@@ -103,7 +80,6 @@ impl fmt::Debug for SharedHostWasmRuntimeCredentials {
             .debug_struct("SharedHostWasmRuntimeCredentials")
             .field("registry", &self.registry)
             .field("cache", &self.cache)
-            .field("restager", &self.restager.as_ref().map(|_| "<configured>"))
             .finish()
     }
 }
@@ -112,79 +88,6 @@ impl fmt::Debug for SharedHostWasmRuntimeCredentials {
 struct SharedCredentialCache {
     registry_version: Option<u64>,
     credentials: HostWasmRuntimeCredentials,
-}
-
-#[derive(Clone)]
-struct RuntimeCredentialRestager {
-    secret_store: Arc<dyn SecretStore>,
-    secret_injections: Arc<RuntimeSecretInjectionStore>,
-    account_resolver: Arc<dyn RuntimeCredentialAccountResolver>,
-}
-
-impl fmt::Debug for RuntimeCredentialRestager {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter
-            .debug_struct("RuntimeCredentialRestager")
-            .field("secret_store", &"[REDACTED]")
-            .field("secret_injections", &self.secret_injections)
-            .field("account_resolver", &"<resolver>")
-            .finish()
-    }
-}
-
-impl RuntimeCredentialRestager {
-    fn stage_for_request(
-        &self,
-        request: WasmRuntimeCredentialRequest,
-        credential: HostWasmRuntimeCredential,
-    ) -> Result<(), CredentialStageError> {
-        let restager = self.clone();
-        block_on_credential_restage(async move {
-            restager
-                .stage_for_request_async(&request, &credential)
-                .await
-        })
-    }
-
-    async fn stage_for_request_async(
-        &self,
-        request: &WasmRuntimeCredentialRequest,
-        credential: &HostWasmRuntimeCredential,
-    ) -> Result<(), CredentialStageError> {
-        let RuntimeCredentialRequirementSource::ProductAuthAccount { provider, setup } =
-            &credential.source
-        else {
-            return Ok(());
-        };
-        let access_secret = self
-            .account_resolver
-            .resolve_access_secret(RuntimeCredentialAccountRequest {
-                scope: &request.scope,
-                provider,
-                setup,
-                provider_scopes: &credential.provider_scopes,
-                requester_extension: &credential.requester_extension,
-            })
-            .await?;
-        let lease = self
-            .secret_store
-            .lease_once(&access_secret.scope, &access_secret.handle)
-            .await
-            .map_err(crate::services::stage_secret_error)?;
-        let material = self
-            .secret_store
-            .consume(&access_secret.scope, lease.id)
-            .await
-            .map_err(crate::services::stage_secret_error)?;
-        self.secret_injections
-            .insert(
-                &request.scope,
-                &request.capability_id,
-                &credential.handle,
-                material,
-            )
-            .map_err(|_| CredentialStageError::Backend)
-    }
 }
 
 impl WasmRuntimeCredentialProvider for SharedHostWasmRuntimeCredentials {
@@ -205,7 +108,7 @@ impl WasmRuntimeCredentialProvider for SharedHostWasmRuntimeCredentials {
             }
             cache.credentials.clone()
         };
-        credentials.credential_injections_with_restager(request, self.restager.as_ref())
+        credentials.credential_injections(request)
     }
 }
 
@@ -214,15 +117,14 @@ impl WasmRuntimeCredentialProvider for HostWasmRuntimeCredentials {
         &self,
         request: &WasmRuntimeCredentialRequest,
     ) -> Result<Vec<RuntimeCredentialInjection>, WasmHostError> {
-        self.credential_injections_with_restager(request, None)
+        self.credential_injections_for_request(request)
     }
 }
 
 impl HostWasmRuntimeCredentials {
-    fn credential_injections_with_restager(
+    fn credential_injections_for_request(
         &self,
         request: &WasmRuntimeCredentialRequest,
-        restager: Option<&RuntimeCredentialRestager>,
     ) -> Result<Vec<RuntimeCredentialInjection>, WasmHostError> {
         let Ok(target) = network_target_for_url(&request.url) else {
             return Ok(Vec::new());
@@ -236,20 +138,6 @@ impl HostWasmRuntimeCredentials {
             .filter(|credential| target_matches_pattern(&target, &credential.audience));
         let mut injections = Vec::new();
         for credential in matching_credentials {
-            if let Some(restager) = restager {
-                restager
-                    .stage_for_request(request.clone(), credential.clone())
-                    .map_err(|error| {
-                        tracing::warn!(
-                            capability_id = %credential.capability_id,
-                            requester_extension = %credential.requester_extension,
-                            handle = %credential.handle,
-                            ?error,
-                            "failed to restage WASM runtime credential"
-                        );
-                        WasmHostError::Unavailable("credential_unavailable".to_string())
-                    })?;
-            }
             injections.push(RuntimeCredentialInjection {
                 handle: credential.handle.clone(),
                 source: RuntimeCredentialSource::StagedObligation {
@@ -288,67 +176,6 @@ pub(crate) fn wasm_runtime_credentials_from_registry(
             .collect(),
     )
 }
-
-fn block_on_credential_restage<F, T>(future: F) -> Result<T, CredentialStageError>
-where
-    F: Future<Output = Result<T, CredentialStageError>> + Send + 'static,
-    T: Send + 'static,
-{
-    // Credential restaging is driven from inside the synchronous WASM guest
-    // call, which the host runtime now runs on the blocking thread pool via
-    // `spawn_blocking`. `block_in_place` is the wrong tool from there (it
-    // targets tokio worker threads and, on a worker, would park it for the
-    // whole restage). Always route the on-runtime case through the dedicated
-    // single-thread restage runtime so the synchronous thread only blocks on a
-    // channel recv, never a turn worker.
-    match Handle::try_current() {
-        Ok(_) => run_credential_restage_on_worker(future),
-        Err(_) => run_credential_restage_future(future),
-    }
-}
-
-fn run_credential_restage_on_worker<F, T>(future: F) -> Result<T, CredentialStageError>
-where
-    F: Future<Output = Result<T, CredentialStageError>> + Send + 'static,
-    T: Send + 'static,
-{
-    let runtime = WASM_CREDENTIAL_RESTAGE_RUNTIME
-        .as_ref()
-        .map_err(|error| *error)?;
-    let (sender, receiver) = mpsc::sync_channel(1);
-    // Spawn on the worker runtime and recover the result via the join handle on
-    // a watchdog task, so a panicking restage future maps to
-    // `CredentialStageError::Backend` rather than dropping the sender and
-    // surfacing a misleading "recv on closed channel" error — consistent with
-    // the watchdog/panic-mapping pattern used by `run_runtime_http_egress_on_worker`.
-    let restage = runtime.spawn(future);
-    runtime.spawn(async move {
-        let result = restage.await.unwrap_or(Err(CredentialStageError::Backend));
-        let _ = sender.send(result);
-    });
-    receiver.recv().map_err(|_| CredentialStageError::Backend)?
-}
-
-fn run_credential_restage_future<F, T>(future: F) -> Result<T, CredentialStageError>
-where
-    F: Future<Output = Result<T, CredentialStageError>>,
-{
-    let runtime = WASM_CREDENTIAL_RESTAGE_RUNTIME
-        .as_ref()
-        .map_err(|error| *error)?;
-    runtime.block_on(future)
-}
-
-static WASM_CREDENTIAL_RESTAGE_RUNTIME: LazyLock<
-    Result<tokio::runtime::Runtime, CredentialStageError>,
-> = LazyLock::new(|| {
-    tokio::runtime::Builder::new_multi_thread()
-        .worker_threads(1)
-        .thread_name("wasm-credential-restage")
-        .enable_all()
-        .build()
-        .map_err(|_| CredentialStageError::Backend)
-});
 
 #[cfg(test)]
 mod tests {
@@ -633,21 +460,5 @@ runtime_credentials = [
             thread_id: None,
             invocation_id: InvocationId::new(),
         }
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn block_on_credential_restage_maps_panicking_future_to_backend_on_worker_runtime() {
-        // The multi-thread runtime means Handle::try_current() succeeds, so
-        // block_on_credential_restage routes through run_credential_restage_on_worker.
-        // That function spawns the future on the dedicated restage runtime and wraps
-        // a panicking / join-failed join handle with `.unwrap_or(Err(CredentialStageError::Backend))`,
-        // so a panic must surface as Backend rather than poisoning the process.
-        let result = block_on_credential_restage(async {
-            panic!("simulated restage panic");
-            #[allow(unreachable_code)]
-            Ok::<(), CredentialStageError>(())
-        });
-
-        assert_eq!(result, Err(CredentialStageError::Backend));
     }
 }

--- a/crates/ironclaw_host_runtime/tests/github_wasm_runtime_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/github_wasm_runtime_contract.rs
@@ -2000,13 +2000,53 @@ fn registry_with_github_package() -> ExtensionRegistry {
     )
 }
 
+const GITHUB_RUNTIME_AUTH_CREDENTIAL: &str =
+    r#"target = { type = "header", name = "authorization", prefix = "Bearer " } }"#;
+const OPTIONAL_GITHUB_RUNTIME_AUTH_CREDENTIAL: &str = r#"target = { type = "header", name = "authorization", prefix = "Bearer " }, required = false }"#;
+
 fn registry_with_optional_github_runtime_credentials() -> ExtensionRegistry {
     let manifest = std::fs::read_to_string(github_asset_root().join("manifest.toml")).unwrap();
-    let manifest = manifest.replace(
-        r#"target = { type = "header", name = "authorization", prefix = "Bearer " } }"#,
-        r#"target = { type = "header", name = "authorization", prefix = "Bearer " }, required = false }"#,
+    let replacement_count = manifest.matches(GITHUB_RUNTIME_AUTH_CREDENTIAL).count();
+    assert!(
+        replacement_count > 0,
+        "GitHub manifest auth credential shape changed; update optional credential test fixture"
     );
-    registry_from_github_manifest(&manifest)
+    let manifest = manifest.replace(
+        GITHUB_RUNTIME_AUTH_CREDENTIAL,
+        OPTIONAL_GITHUB_RUNTIME_AUTH_CREDENTIAL,
+    );
+    assert_eq!(
+        manifest
+            .matches(OPTIONAL_GITHUB_RUNTIME_AUTH_CREDENTIAL)
+            .count(),
+        replacement_count,
+        "optional GitHub credential rewrite should preserve the runtime credential count"
+    );
+
+    let registry = registry_from_github_manifest(&manifest);
+    let github_runtime_token = SecretHandle::new("github_runtime_token").unwrap();
+    let mut optional_github_runtime_credentials = 0;
+    let mut required_github_runtime_credentials = 0;
+    for credential in registry
+        .capabilities()
+        .flat_map(|descriptor| descriptor.runtime_credentials.iter())
+        .filter(|credential| credential.handle == github_runtime_token)
+    {
+        if credential.required {
+            required_github_runtime_credentials += 1;
+        } else {
+            optional_github_runtime_credentials += 1;
+        }
+    }
+    assert_eq!(
+        optional_github_runtime_credentials, replacement_count,
+        "optional credential fixture must rewrite every GitHub runtime token credential"
+    );
+    assert_eq!(
+        required_github_runtime_credentials, 0,
+        "optional credential fixture must not leave required GitHub runtime token credentials"
+    );
+    registry
 }
 
 fn registry_from_github_manifest(manifest: &str) -> ExtensionRegistry {

--- a/crates/ironclaw_host_runtime/tests/github_wasm_runtime_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/github_wasm_runtime_contract.rs
@@ -1,4 +1,7 @@
-use std::sync::Arc;
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
 
 use async_trait::async_trait;
 use chrono::Utc;
@@ -213,7 +216,7 @@ async fn host_runtime_services_routes_structured_github_wasm_search_through_runt
 }
 
 #[tokio::test]
-async fn host_runtime_services_restages_github_product_auth_for_multi_request_wasm_capability() {
+async fn wasm_github_product_auth_resolves_once_for_multi_request_dispatch() {
     let capability_id = CapabilityId::new("github.create_branch").unwrap();
     let scope = sample_scope(InvocationId::new());
     let source_sha = "abc123def4567890abc123def4567890abc123de";
@@ -224,6 +227,7 @@ async fn host_runtime_services_restages_github_product_auth_for_multi_request_wa
     let secret_store = Arc::new(InMemorySecretStore::new());
     let slot_handle = SecretHandle::new("github_runtime_token").unwrap();
     let account_access_secret = SecretHandle::new("github_manual_access").unwrap();
+    let resolver_calls = Arc::new(AtomicUsize::new(0));
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_github_package()),
         Arc::new(filesystem_with_github_package()),
@@ -244,7 +248,8 @@ async fn host_runtime_services_restages_github_product_auth_for_multi_request_wa
         CapabilitySurfaceVersion::new("surface-v1").unwrap(),
     )
     .with_secret_store(Arc::clone(&secret_store))
-    .with_runtime_credential_account_resolver(Arc::new(FixedRuntimeCredentialAccountResolver {
+    .with_runtime_credential_account_resolver(Arc::new(CountingRuntimeCredentialAccountResolver {
+        calls: Arc::clone(&resolver_calls),
         result: Ok(account_access_secret.clone()),
     }))
     .with_trust_policy(Arc::new(github_first_party_trust_policy()))
@@ -304,6 +309,160 @@ async fn host_runtime_services_restages_github_product_auth_for_multi_request_wa
     assert_eq!(
         create_body,
         json!({"ref": "refs/heads/feature/matrix", "sha": source_sha})
+    );
+    assert_eq!(
+        resolver_calls.load(Ordering::SeqCst),
+        1,
+        "authorized multi-request WASM dispatch must resolve product auth only during obligation staging"
+    );
+}
+
+#[tokio::test]
+async fn host_runtime_services_does_not_inject_optional_github_product_auth_without_obligation() {
+    let capability_id = CapabilityId::new("github.search_issues").unwrap();
+    let scope = sample_scope(InvocationId::new());
+    let expected_url =
+        "https://api.github.com/search/issues?q=repo%3Anearai%2Fironclaw%20is%3Aissue&per_page=1";
+    let policy = github_policy();
+    let network = RecordingNetworkHttpEgress::with_body(
+        br#"{"total_count":0,"incomplete_results":false,"items":[]}"#.to_vec(),
+    );
+    let secret_store = Arc::new(InMemorySecretStore::new());
+    let account_access_secret = SecretHandle::new("github_manual_access").unwrap();
+    let resolver_calls = Arc::new(AtomicUsize::new(0));
+    let services = HostRuntimeServices::new(
+        Arc::new(registry_with_optional_github_runtime_credentials()),
+        Arc::new(filesystem_with_github_package()),
+        Arc::new(governor_with_default_limit(sample_account())),
+        Arc::new(ObligatingAuthorizer::new(vec![
+            Obligation::ApplyNetworkPolicy {
+                policy: policy.clone(),
+            },
+        ])),
+        ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_secret_store(Arc::clone(&secret_store))
+    .with_runtime_credential_account_resolver(Arc::new(CountingRuntimeCredentialAccountResolver {
+        calls: Arc::clone(&resolver_calls),
+        result: Ok(account_access_secret.clone()),
+    }))
+    .with_trust_policy(Arc::new(github_first_party_trust_policy()))
+    .try_with_host_http_egress(network.clone())
+    .unwrap()
+    .try_with_wasm_runtime(WitToolRuntimeConfig::default(), WitToolHost::deny_all())
+    .unwrap();
+    secret_store
+        .put(
+            scope.clone(),
+            account_access_secret,
+            SecretMaterial::from("ghp_should_not_be_used"),
+            None,
+        )
+        .await
+        .unwrap();
+
+    let outcome = services
+        .host_runtime_for_local_testing()
+        .invoke_capability(wasm_runtime_request_for_scope(
+            capability_id.clone(),
+            scope,
+            json!({"repo": "nearai/ironclaw", "type": "issue", "limit": 1}),
+        ))
+        .await
+        .unwrap();
+
+    match outcome {
+        RuntimeCapabilityOutcome::Completed(completed) => {
+            assert_eq!(completed.capability_id, capability_id);
+            assert_eq!(
+                completed.output,
+                json!({"total_count":0,"incomplete_results":false,"items":[]})
+            );
+        }
+        other => panic!("expected completed outcome, got {other:?}"),
+    }
+    let requests = network.requests();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].method, NetworkMethod::Get);
+    assert_eq!(requests[0].url, expected_url);
+    assert_eq!(requests[0].body, Vec::<u8>::new());
+    assert_eq!(requests[0].policy, policy);
+    assert_no_authorization_header(&requests[0]);
+    assert_eq!(
+        resolver_calls.load(Ordering::SeqCst),
+        0,
+        "omitted credential obligations must not consult product-auth accounts"
+    );
+}
+
+#[tokio::test]
+async fn wasm_github_required_product_auth_without_obligation_fails_before_network() {
+    let capability_id = CapabilityId::new("github.search_issues").unwrap();
+    let scope = sample_scope(InvocationId::new());
+    let policy = github_policy();
+    let network = RecordingNetworkHttpEgress::with_body(
+        br#"{"total_count":0,"incomplete_results":false,"items":[]}"#.to_vec(),
+    );
+    let secret_store = Arc::new(InMemorySecretStore::new());
+    let account_access_secret = SecretHandle::new("github_manual_access").unwrap();
+    let resolver_calls = Arc::new(AtomicUsize::new(0));
+    let services = HostRuntimeServices::new(
+        Arc::new(registry_with_github_package()),
+        Arc::new(filesystem_with_github_package()),
+        Arc::new(governor_with_default_limit(sample_account())),
+        Arc::new(ObligatingAuthorizer::new(vec![
+            Obligation::ApplyNetworkPolicy { policy },
+        ])),
+        ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_secret_store(Arc::clone(&secret_store))
+    .with_runtime_credential_account_resolver(Arc::new(CountingRuntimeCredentialAccountResolver {
+        calls: Arc::clone(&resolver_calls),
+        result: Ok(account_access_secret.clone()),
+    }))
+    .with_trust_policy(Arc::new(github_first_party_trust_policy()))
+    .try_with_host_http_egress(network.clone())
+    .unwrap()
+    .try_with_wasm_runtime(WitToolRuntimeConfig::default(), WitToolHost::deny_all())
+    .unwrap();
+    secret_store
+        .put(
+            scope.clone(),
+            account_access_secret,
+            SecretMaterial::from("ghp_should_not_be_used"),
+            None,
+        )
+        .await
+        .unwrap();
+
+    let outcome = services
+        .host_runtime_for_local_testing()
+        .invoke_capability(wasm_runtime_request_for_scope(
+            capability_id.clone(),
+            scope,
+            json!({"repo": "nearai/ironclaw", "type": "issue", "limit": 1}),
+        ))
+        .await
+        .unwrap();
+
+    match outcome {
+        RuntimeCapabilityOutcome::AuthRequired(gate) => {
+            assert_eq!(gate.capability_id, capability_id);
+            assert!(gate.required_secrets.is_empty());
+            assert!(gate.credential_requirements.is_empty());
+        }
+        other => panic!("expected auth-required outcome, got {other:?}"),
+    }
+    assert!(
+        network.requests().is_empty(),
+        "required credential without staged obligation must block before HTTP dispatch"
+    );
+    assert_eq!(
+        resolver_calls.load(Ordering::SeqCst),
+        0,
+        "omitted credential obligations must not consult product-auth accounts"
     );
 }
 
@@ -1784,6 +1943,30 @@ impl RuntimeCredentialAccountResolver for FixedRuntimeCredentialAccountResolver 
 }
 
 #[derive(Debug)]
+struct CountingRuntimeCredentialAccountResolver {
+    calls: Arc<AtomicUsize>,
+    result: Result<SecretHandle, CredentialStageError>,
+}
+
+#[async_trait]
+impl RuntimeCredentialAccountResolver for CountingRuntimeCredentialAccountResolver {
+    async fn resolve_access_secret(
+        &self,
+        request: RuntimeCredentialAccountRequest<'_>,
+    ) -> Result<RuntimeCredentialAccessSecret, CredentialStageError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        assert_eq!(request.provider.as_str(), "github");
+        assert_eq!(request.requester_extension.as_str(), "github");
+        self.result
+            .clone()
+            .map(|handle| RuntimeCredentialAccessSecret {
+                scope: request.scope.clone(),
+                handle,
+            })
+    }
+}
+
+#[derive(Debug)]
 struct FixedGoogleRuntimeCredentialAccountResolver {
     expected_requester_extension: ExtensionId,
     expected_scopes: Vec<String>,
@@ -1812,8 +1995,23 @@ impl RuntimeCredentialAccountResolver for FixedGoogleRuntimeCredentialAccountRes
 }
 
 fn registry_with_github_package() -> ExtensionRegistry {
-    let manifest = ExtensionManifest::parse_with_host_api_contracts(
+    registry_from_github_manifest(
         &std::fs::read_to_string(github_asset_root().join("manifest.toml")).unwrap(),
+    )
+}
+
+fn registry_with_optional_github_runtime_credentials() -> ExtensionRegistry {
+    let manifest = std::fs::read_to_string(github_asset_root().join("manifest.toml")).unwrap();
+    let manifest = manifest.replace(
+        r#"target = { type = "header", name = "authorization", prefix = "Bearer " } }"#,
+        r#"target = { type = "header", name = "authorization", prefix = "Bearer " }, required = false }"#,
+    );
+    registry_from_github_manifest(&manifest)
+}
+
+fn registry_from_github_manifest(manifest: &str) -> ExtensionRegistry {
+    let manifest = ExtensionManifest::parse_with_host_api_contracts(
+        manifest,
         ManifestSource::HostBundled,
         &default_host_port_catalog().unwrap(),
         &default_host_api_contract_registry().unwrap(),
@@ -1975,6 +2173,17 @@ fn assert_google_bearer_header(request: &NetworkHttpRequest, expected_token: &st
             "authorization".to_string(),
             format!("Bearer {expected_token}"),
         ))
+    );
+}
+
+fn assert_no_authorization_header(request: &NetworkHttpRequest) {
+    assert!(
+        request
+            .headers
+            .iter()
+            .all(|(name, _)| name != "authorization"),
+        "request must not include an authorization header: {:?}",
+        request.headers
     );
 }
 


### PR DESCRIPTION
## Summary
- Remove WASM product-auth restaging from the manifest credential provider so WASM HTTP egress relies on material staged by `Decision.obligations`.
- Stop wiring the WASM credential provider to the product-auth resolver/secret store in host runtime service construction.
- Add GitHub WASM contract coverage for optional omitted obligations, required omitted obligations, and authorized multi-request reuse resolving product auth exactly once.

Closes #5512

## Local test/security loop
- `cargo fmt --all -- --check`
- `scripts/ci/delta_lint.sh`
- `python3.11 scripts/check_no_panics.py --base $(git merge-base origin/main HEAD) --head HEAD`
- `cargo test -p ironclaw_host_runtime --test github_wasm_runtime_contract -- --nocapture`
- `cargo test -p ironclaw_host_runtime wasm_credentials -- --nocapture`
- `cargo test -p ironclaw_host_runtime --test runtime_http_egress_contract host_http_egress_skips_optional_missing_staged_secret -- --nocapture`
- `cargo test -p ironclaw_host_runtime --test runtime_http_egress_contract host_http_egress_requires_available_required_credentials_before_network -- --nocapture`
- `cargo test -p ironclaw_host_runtime --test builtin_obligation_handler_contract inject_credential_account_once_resolves_and_stages_secret -- --nocapture`

## Follow-up verification
- `cargo fmt --all -- --check`
- `cargo test -p ironclaw_host_runtime --test github_wasm_runtime_contract host_runtime_services_does_not_inject_optional_github_product_auth_without_obligation -- --nocapture`
- `cargo test -p ironclaw_host_runtime --test github_wasm_runtime_contract -- --nocapture`
- `git diff --check`
- `scripts/ci/delta_lint.sh`
- `python3.11 scripts/check_no_panics.py --base $(git merge-base origin/main HEAD) --head HEAD`

## Pre-PR review loop
- `code-review-multi` local lanes: security, bugs, performance, conventions clean.
- Tests lane raised three coverage gaps; fixed with zero-resolver-call assertions for omitted obligations and one-resolver-call assertion for authorized multi-request dispatch.
- Final tests-lane rerun returned clean (`[]`).
- Thermo review: accepted the deletion-oriented design; tightened provider comment so it does not overstate authorization performed by the provider itself.

## Loop effectiveness follow-up
Current status after CI and first bot reviews:
- CI first-pass outcome: passed; required checks and preview are green, with expected skips only.
- CI failures caused by this PR: none observed.
- Maintainer/CodeRabbit blocker findings: maintainer review still required; Gemini had no comments; CodeRabbit posted 1 actionable test-helper robustness comment, fixed in follow-up commit `aa1b6934f`.
- Follow-up fix commits after PR open: 1.
- Escaped issue type, if any: test fixture robustness / brittle string replacement guard missed by local review loop; fixed by making the fixture fail loudly when the manifest rewrite stops matching and by checking the parsed runtime credential shape.

Use this PR as one data point for the readiness loop scorecard: the loop is doing good work if CI only fails for unrelated/flaky reasons, post-open reviews do not find blocker-class issues, and follow-up commits stay near zero.