### PR TITLE
feat(reborn): manifest-projected host-ingress route + fail-closed credential coherence

### DIFF
--- a/crates/ironclaw_product_adapter_registry/CLAUDE.md
+++ b/crates/ironclaw_product_adapter_registry/CLAUDE.md
@@ -23,6 +23,23 @@ Owns ProductAdapter host-api projection contracts for IronClaw Reborn.
   - validate every egress credential handle is declared in
     `required_credentials`,
   - keep `(host, credential_handle)` pairs distinct.
+- A section MAY declare `host_ingress` routes (`[[product_adapter.<sub>.host_ingress]]`),
+  each carrying a full host-owned `ironclaw_host_api::IngressRouteDescriptor`
+  (validated by host_api's own `Deserialize` — dotted route id, absolute path,
+  and every policy invariant incl. the fail-closed floor that a
+  `public_webhook` listener MUST require `webhook_signature`) plus the
+  `credential_handles` that verify it. This crate does NOT re-own ingress
+  route/policy vocabulary — it only projects the descriptor and enforces
+  **ingress credential coherence**, which is fail-closed:
+  - every `credential_handles` entry must be declared in `required_credentials`
+    (mirrors the egress rule, so ingress handles flow into the same declared
+    set installation bindings validate against),
+  - an auth-required route (`IngressAuthPolicy::Required`) must name at least
+    one verifying credential handle,
+  - route ids stay distinct within a section.
+  Mounting these routes (descriptor → axum route + verifier) is the serve
+  layer's job, NOT this crate's — this crate still must not route webhooks,
+  resolve secret material, or bind HTTP ingress.
 - ProductAdapter runtime projection must keep the cross-write invariant at
   read time: every surfaced installation must remain valid against its
   registered manifest and current ProductAdapter sections.
@@ -38,6 +55,11 @@ Owns ProductAdapter host-api projection contracts for IronClaw Reborn.
   mismatch, redacted health, and cross-write invariant maintenance.
 - Integration tests in `tests/manifest_ingestion.rs` cover manifest
   parsing, unknown-field rejection, inline-secret rejection, and egress
-  credential validation.
+  credential validation — plus host-ingress route projection over the wire,
+  the inherited host_api fail-closed floor (`public_webhook` without
+  `webhook_signature` rejected), and ingress credential coherence. The
+  ingress credential-coherence matrix (undeclared handle, auth-required route
+  missing a credential, duplicate route id, happy projection) has focused
+  unit coverage in `src/lib.rs` `mod tests`.
 - `cargo test -p ironclaw_architecture reborn_crate_dependency_boundaries_hold`
   pins crate dependency boundary.

--- a/crates/ironclaw_product_adapter_registry/src/lib.rs
+++ b/crates/ironclaw_product_adapter_registry/src/lib.rs
@@ -21,7 +21,9 @@ use ironclaw_extensions::{
     HostApiManifestContext, HostApiManifestContract, HostApiMultiplicity, HostApiRefV2,
     ManifestSectionPath, ManifestSource, ManifestV2Error,
 };
-use ironclaw_host_api::{ExtensionId, HostPortCatalog};
+use ironclaw_host_api::{
+    ExtensionId, HostPortCatalog, IngressAuthPolicy, IngressRouteDescriptor, IngressRouteId,
+};
 use ironclaw_product_adapters::{
     AuthRequirement, DeclaredEgressTarget, EgressCredentialHandle, ProductAdapterCapabilities,
     ProductAdapterId, ProductCapabilityFlag, ProductSurfaceKind,
@@ -68,6 +70,37 @@ pub fn product_adapter_sections(
     project_product_adapter_sections(record.raw_toml(), record.manifest())
 }
 
+/// A host-ingress route declared by a ProductAdapter manifest section, paired
+/// with the credential handles that verify it.
+///
+/// The route itself is the host-owned [`IngressRouteDescriptor`] vocabulary
+/// (`ironclaw_host_api` owns route/policy validation, including the fail-closed
+/// floor that a `PublicWebhook` listener must require `WebhookSignature`). That
+/// descriptor deliberately carries **no** credential binding — host_api is
+/// route/policy vocabulary only. The manifest layer is therefore where "which
+/// credential handle verifies this route" is declared, and this crate makes it
+/// credential-coherent against the section's `required_credentials`
+/// (see [`ProductAdapterHostApiSection::validate`]).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HostIngressRoute {
+    descriptor: IngressRouteDescriptor,
+    credential_handles: Vec<EgressCredentialHandle>,
+}
+
+impl HostIngressRoute {
+    /// The host-owned, already-validated ingress route/policy descriptor.
+    pub fn descriptor(&self) -> &IngressRouteDescriptor {
+        &self.descriptor
+    }
+
+    /// Credential handles that verify this route. Every handle is guaranteed to
+    /// be declared in the owning section's `required_credentials`, and an
+    /// auth-required route is guaranteed to name at least one.
+    pub fn credential_handles(&self) -> &[EgressCredentialHandle] {
+        &self.credential_handles
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProductAdapterHostApiSection {
     adapter_id: ProductAdapterId,
@@ -77,6 +110,7 @@ pub struct ProductAdapterHostApiSection {
     auth_requirement: AuthRequirement,
     declared_egress: Vec<DeclaredEgressTarget>,
     required_credentials: Vec<EgressCredentialHandle>,
+    host_ingress: Vec<HostIngressRoute>,
 }
 
 impl ProductAdapterHostApiSection {
@@ -114,6 +148,14 @@ impl ProductAdapterHostApiSection {
             .into_iter()
             .map(|c| c.handle)
             .collect();
+        let host_ingress = raw
+            .host_ingress
+            .into_iter()
+            .map(|route| HostIngressRoute {
+                descriptor: route.descriptor,
+                credential_handles: route.credential_handles,
+            })
+            .collect();
         let projected = Self {
             adapter_id,
             section,
@@ -122,6 +164,7 @@ impl ProductAdapterHostApiSection {
             auth_requirement,
             declared_egress: raw.egress,
             required_credentials,
+            host_ingress,
         };
         projected.validate()?;
         Ok(projected)
@@ -149,6 +192,14 @@ impl ProductAdapterHostApiSection {
         &self.required_credentials
     }
 
+    /// Host-ingress routes this ProductAdapter section declares. Each carries a
+    /// host-owned [`IngressRouteDescriptor`] and its verifying credential
+    /// handles; the serve layer projects these into mounted routes. Empty for
+    /// sections that declare no ingress (the common case today).
+    pub fn host_ingress(&self) -> &[HostIngressRoute] {
+        &self.host_ingress
+    }
+
     fn validate(&self) -> Result<(), RegistryError> {
         validate_auth_requirement(&self.auth_requirement)?;
         let mut required = BTreeSet::new();
@@ -170,6 +221,36 @@ impl ProductAdapterHostApiSection {
             }
             if !pairs.insert((target.host.clone(), target.credential_handle.clone())) {
                 return Err(RegistryError::DuplicateEgressTarget);
+            }
+        }
+        // Host-ingress credential coherence. Fail closed: an auth-required route
+        // must name at least one verifying credential handle, and every named
+        // handle must be declared in `required_credentials` (mirroring the
+        // egress rule above, so ingress handles flow into the same declared set
+        // installation bindings are validated against). Route ids stay distinct
+        // within a section so a mounted route can be addressed unambiguously.
+        let mut route_ids = BTreeSet::new();
+        for route in &self.host_ingress {
+            if !route_ids.insert(route.descriptor.route_id().as_str()) {
+                return Err(RegistryError::DuplicateIngressRoute {
+                    route_id: route.descriptor.route_id().clone(),
+                });
+            }
+            let auth_required = matches!(
+                route.descriptor.policy().auth(),
+                IngressAuthPolicy::Required { .. }
+            );
+            if auth_required && route.credential_handles.is_empty() {
+                return Err(RegistryError::IngressRouteMissingCredential {
+                    route_id: route.descriptor.route_id().clone(),
+                });
+            }
+            for handle in &route.credential_handles {
+                if !required.contains(handle) {
+                    return Err(RegistryError::UndeclaredIngressCredentialHandle {
+                        handle: handle.clone(),
+                    });
+                }
             }
         }
         Ok(())
@@ -344,6 +425,12 @@ pub enum RegistryError {
     DuplicateEgressTarget,
     #[error("egress references undeclared credential handle {handle}")]
     UndeclaredEgressCredentialHandle { handle: EgressCredentialHandle },
+    #[error("host-ingress route references undeclared credential handle {handle}")]
+    UndeclaredIngressCredentialHandle { handle: EgressCredentialHandle },
+    #[error("auth-required host-ingress route {route_id} declares no verifying credential handle")]
+    IngressRouteMissingCredential { route_id: IngressRouteId },
+    #[error("duplicate host-ingress route {route_id}")]
+    DuplicateIngressRoute { route_id: IngressRouteId },
     #[error("installation references unknown extension manifest {extension_id}")]
     UnknownManifest { extension_id: ExtensionId },
     #[error("installation binds undeclared credential handle {handle}")]
@@ -656,6 +743,22 @@ struct RawProductAdapterSection {
     required_credentials: Vec<RawProductAdapterCredential>,
     #[serde(default)]
     egress: Vec<DeclaredEgressTarget>,
+    #[serde(default)]
+    host_ingress: Vec<RawHostIngressRoute>,
+}
+
+/// Manifest shape for a declared host-ingress route: the full host-owned
+/// [`IngressRouteDescriptor`] (validated by `ironclaw_host_api`'s own
+/// `Deserialize` — `deny_unknown_fields`, dotted route id, absolute path, and
+/// all policy cross-field invariants) plus the credential handles that verify
+/// it. Credential coherence against `required_credentials` is enforced in
+/// [`ProductAdapterHostApiSection::validate`].
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawHostIngressRoute {
+    descriptor: IngressRouteDescriptor,
+    #[serde(default)]
+    credential_handles: Vec<EgressCredentialHandle>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -705,5 +808,151 @@ impl RawProductAdapterAuth {
         };
         validate_auth_requirement(&requirement)?;
         Ok(requirement)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Unit coverage for host-ingress credential coherence — the novel logic
+    //! this crate adds on top of host_api's already-validated ingress
+    //! descriptor. Descriptors are built in Rust (not TOML text) so these
+    //! cases are robust to serde renames; the wire path is covered end-to-end
+    //! in `tests/manifest_ingestion.rs`.
+    use super::*;
+    use ironclaw_host_api::{
+        AllowedEffectPath, AuditTraceClass, BodyLimitPolicy, CorsPolicy, IngressAuthScheme,
+        IngressPolicy, IngressPolicyParts, IngressScopeSource, ListenerClass, NetworkMethod,
+        RateLimitPolicy, RateLimitScope, StreamingMode, WebSocketOriginPolicy,
+    };
+    use serde::Serialize;
+    use std::num::{NonZeroU32, NonZeroU64};
+
+    /// A fail-closed public-webhook descriptor mirroring the values Slack's
+    /// `slack_events_policy()` uses, parameterized by route id.
+    fn webhook_descriptor(route_id: &str) -> IngressRouteDescriptor {
+        let policy = IngressPolicy::new(IngressPolicyParts {
+            listener_class: ListenerClass::PublicWebhook,
+            auth: IngressAuthPolicy::Required {
+                schemes: vec![IngressAuthScheme::WebhookSignature],
+            },
+            scope_source: IngressScopeSource::HostResolved,
+            body_limit: BodyLimitPolicy::Limited {
+                max_bytes: NonZeroU64::new(262_144).expect("nonzero"),
+            },
+            rate_limit: RateLimitPolicy::Limited {
+                scope: RateLimitScope::Global,
+                max_requests: NonZeroU32::new(600).expect("nonzero"),
+                window_seconds: NonZeroU32::new(60).expect("nonzero"),
+            },
+            cors: CorsPolicy::NotApplicable,
+            websocket_origin: WebSocketOriginPolicy::NotApplicable,
+            streaming: StreamingMode::None,
+            audit: AuditTraceClass::PublicCallback,
+            effect_path: AllowedEffectPath::ProductWorkflow,
+        })
+        .expect("policy validates");
+        IngressRouteDescriptor::new(
+            route_id,
+            NetworkMethod::Post,
+            "/webhooks/telegram/updates",
+            policy,
+        )
+        .expect("descriptor validates")
+    }
+
+    #[derive(Serialize)]
+    struct RouteFixture {
+        descriptor: IngressRouteDescriptor,
+        credential_handles: Vec<String>,
+    }
+
+    /// Build a ProductAdapter section `toml::Value` with a valid base and the
+    /// given host-ingress routes, then run it through the real projection.
+    fn project(routes: Vec<RouteFixture>) -> Result<ProductAdapterHostApiSection, RegistryError> {
+        let mut value: toml::Value = toml::from_str(
+            r#"
+surface_kind = "external_channel"
+[auth]
+kind = "shared_secret_header"
+header_name = "X-Telegram-Bot-Api-Secret-Token"
+[capabilities]
+flags = ["inbound_messages"]
+[[required_credentials]]
+handle = "telegram_bot_token"
+"#,
+        )
+        .expect("base section parses");
+        let host_ingress = toml::Value::try_from(routes).expect("routes serialize");
+        value
+            .as_table_mut()
+            .expect("section is a table")
+            .insert("host_ingress".to_string(), host_ingress);
+
+        let extension_id = ExtensionId::new("telegram-v2").expect("extension id");
+        let section = ManifestSectionPath::new("product_adapter.inbound").expect("section path");
+        ProductAdapterHostApiSection::from_value(&extension_id, section, value)
+    }
+
+    fn route(route_id: &str, credential_handles: &[&str]) -> RouteFixture {
+        RouteFixture {
+            descriptor: webhook_descriptor(route_id),
+            credential_handles: credential_handles.iter().map(|h| h.to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn host_ingress_route_projects_descriptor_and_handles() {
+        let section = project(vec![route("telegram.updates", &["telegram_bot_token"])])
+            .expect("valid section projects");
+        assert_eq!(section.host_ingress().len(), 1);
+        let projected = &section.host_ingress()[0];
+        assert_eq!(
+            projected.descriptor().route_id().as_str(),
+            "telegram.updates"
+        );
+        assert_eq!(
+            projected.descriptor().route_pattern().as_str(),
+            "/webhooks/telegram/updates"
+        );
+        assert_eq!(projected.credential_handles().len(), 1);
+        assert_eq!(
+            projected.credential_handles()[0].as_str(),
+            "telegram_bot_token"
+        );
+    }
+
+    #[test]
+    fn host_ingress_undeclared_credential_handle_rejected() {
+        let err = project(vec![route("telegram.updates", &["not_declared_token"])])
+            .expect_err("undeclared handle must reject");
+        assert!(
+            matches!(err, RegistryError::UndeclaredIngressCredentialHandle { .. }),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn host_ingress_auth_required_route_needs_credential() {
+        // Fail closed: an auth-required route with no verifying credential
+        // handle must reject, not mount a route nothing can authenticate.
+        let err = project(vec![route("telegram.updates", &[])])
+            .expect_err("auth-required route without a credential must reject");
+        assert!(
+            matches!(err, RegistryError::IngressRouteMissingCredential { .. }),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn host_ingress_duplicate_route_id_rejected() {
+        let err = project(vec![
+            route("telegram.updates", &["telegram_bot_token"]),
+            route("telegram.updates", &["telegram_bot_token"]),
+        ])
+        .expect_err("duplicate route id must reject");
+        assert!(
+            matches!(err, RegistryError::DuplicateIngressRoute { .. }),
+            "got {err:?}"
+        );
     }
 }

--- a/crates/ironclaw_product_adapter_registry/src/lib.rs
+++ b/crates/ironclaw_product_adapter_registry/src/lib.rs
@@ -94,8 +94,15 @@ impl HostIngressRoute {
     }
 
     /// Credential handles that verify this route. Every handle is guaranteed to
-    /// be declared in the owning section's `required_credentials`, and an
-    /// auth-required route is guaranteed to name at least one.
+    /// be declared in the owning section's `required_credentials`; an
+    /// auth-required route names at least one, and a public (no-auth) route
+    /// names none.
+    ///
+    /// The handle type is [`EgressCredentialHandle`] — the single credential-
+    /// handle newtype `ironclaw_product_adapters` owns. It is reused here rather
+    /// than mirrored into an ingress-specific type (per the type-placement
+    /// rule); its `Display` renders only the handle string, so no "egress"
+    /// wording leaks into ingress error messages.
     pub fn credential_handles(&self) -> &[EgressCredentialHandle] {
         &self.credential_handles
     }
@@ -223,27 +230,41 @@ impl ProductAdapterHostApiSection {
                 return Err(RegistryError::DuplicateEgressTarget);
             }
         }
-        // Host-ingress credential coherence. Fail closed: an auth-required route
-        // must name at least one verifying credential handle, and every named
-        // handle must be declared in `required_credentials` (mirroring the
-        // egress rule above, so ingress handles flow into the same declared set
-        // installation bindings are validated against). Route ids stay distinct
-        // within a section so a mounted route can be addressed unambiguously.
-        let mut route_ids = BTreeSet::new();
+        // Host-ingress credential coherence, fail closed. A route's declared
+        // verifying credentials must line up with whether it is actually
+        // authenticated, and every named handle must be declared in
+        // `required_credentials` (mirroring the egress rule above, so ingress
+        // handles flow into the same declared set installation bindings are
+        // validated against). Route ids stay distinct within a section so a
+        // mounted route can be addressed unambiguously.
+        let mut route_ids: BTreeSet<&IngressRouteId> = BTreeSet::new();
         for route in &self.host_ingress {
-            if !route_ids.insert(route.descriptor.route_id().as_str()) {
+            let route_id = route.descriptor.route_id();
+            if !route_ids.insert(route_id) {
                 return Err(RegistryError::DuplicateIngressRoute {
-                    route_id: route.descriptor.route_id().clone(),
+                    route_id: route_id.clone(),
                 });
             }
-            let auth_required = matches!(
-                route.descriptor.policy().auth(),
-                IngressAuthPolicy::Required { .. }
-            );
-            if auth_required && route.credential_handles.is_empty() {
-                return Err(RegistryError::IngressRouteMissingCredential {
-                    route_id: route.descriptor.route_id().clone(),
-                });
+            match route.descriptor.policy().auth() {
+                // An auth-required route with no verifying credential is a route
+                // nothing could authenticate — reject it.
+                IngressAuthPolicy::Required { .. } => {
+                    if route.credential_handles.is_empty() {
+                        return Err(RegistryError::IngressRouteMissingCredential {
+                            route_id: route_id.clone(),
+                        });
+                    }
+                }
+                // A public (no-auth) route is verified by nothing, so declaring a
+                // credential handle on it is incoherent and misleading — a reader
+                // would assume the route is authenticated by that credential.
+                IngressAuthPolicy::Public { .. } => {
+                    if !route.credential_handles.is_empty() {
+                        return Err(RegistryError::PublicIngressRouteHasCredential {
+                            route_id: route_id.clone(),
+                        });
+                    }
+                }
             }
             for handle in &route.credential_handles {
                 if !required.contains(handle) {
@@ -429,6 +450,10 @@ pub enum RegistryError {
     UndeclaredIngressCredentialHandle { handle: EgressCredentialHandle },
     #[error("auth-required host-ingress route {route_id} declares no verifying credential handle")]
     IngressRouteMissingCredential { route_id: IngressRouteId },
+    #[error(
+        "public host-ingress route {route_id} declares a verifying credential handle but is not authenticated"
+    )]
+    PublicIngressRouteHasCredential { route_id: IngressRouteId },
     #[error("duplicate host-ingress route {route_id}")]
     DuplicateIngressRoute { route_id: IngressRouteId },
     #[error("installation references unknown extension manifest {extension_id}")]
@@ -821,8 +846,8 @@ mod tests {
     use super::*;
     use ironclaw_host_api::{
         AllowedEffectPath, AuditTraceClass, BodyLimitPolicy, CorsPolicy, IngressAuthScheme,
-        IngressPolicy, IngressPolicyParts, IngressScopeSource, ListenerClass, NetworkMethod,
-        RateLimitPolicy, RateLimitScope, StreamingMode, WebSocketOriginPolicy,
+        IngressJustification, IngressPolicy, IngressPolicyParts, IngressScopeSource, ListenerClass,
+        NetworkMethod, RateLimitPolicy, RateLimitScope, StreamingMode, WebSocketOriginPolicy,
     };
     use serde::Serialize;
     use std::num::{NonZeroU32, NonZeroU64};
@@ -858,6 +883,35 @@ mod tests {
             policy,
         )
         .expect("descriptor validates")
+    }
+
+    /// A valid public (no-auth) route, mirroring the SSO login mount's policy
+    /// combination (LocalGateway + Public + PublicRoute + NoEffect).
+    fn public_descriptor(route_id: &str) -> IngressRouteDescriptor {
+        let policy = IngressPolicy::new(IngressPolicyParts {
+            listener_class: ListenerClass::LocalGateway,
+            auth: IngressAuthPolicy::Public {
+                justification: IngressJustification::new("ingress", "public test route")
+                    .expect("justification"),
+            },
+            scope_source: IngressScopeSource::PublicRoute,
+            body_limit: BodyLimitPolicy::Limited {
+                max_bytes: NonZeroU64::new(4096).expect("nonzero"),
+            },
+            rate_limit: RateLimitPolicy::Limited {
+                scope: RateLimitScope::PerIp,
+                max_requests: NonZeroU32::new(60).expect("nonzero"),
+                window_seconds: NonZeroU32::new(60).expect("nonzero"),
+            },
+            cors: CorsPolicy::SameOriginOnly,
+            websocket_origin: WebSocketOriginPolicy::NotApplicable,
+            streaming: StreamingMode::None,
+            audit: AuditTraceClass::PublicCallback,
+            effect_path: AllowedEffectPath::NoEffect,
+        })
+        .expect("public policy validates");
+        IngressRouteDescriptor::new(route_id, NetworkMethod::Post, "/public/callback", policy)
+            .expect("descriptor validates")
     }
 
     #[derive(Serialize)]
@@ -954,5 +1008,33 @@ handle = "telegram_bot_token"
             matches!(err, RegistryError::DuplicateIngressRoute { .. }),
             "got {err:?}"
         );
+    }
+
+    #[test]
+    fn host_ingress_public_route_must_not_declare_credentials() {
+        // Fail closed on the dual of the auth-required rule: a public (no-auth)
+        // route is verified by nothing, so declaring a credential handle on it
+        // is incoherent and would mislead a reader into assuming it is
+        // authenticated.
+        let err = project(vec![RouteFixture {
+            descriptor: public_descriptor("public.callback"),
+            credential_handles: vec!["telegram_bot_token".to_string()],
+        }])
+        .expect_err("public route with a credential handle must reject");
+        assert!(
+            matches!(err, RegistryError::PublicIngressRouteHasCredential { .. }),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn host_ingress_public_route_without_credentials_projects() {
+        // The complement: a public route that declares no credentials is valid.
+        let section = project(vec![RouteFixture {
+            descriptor: public_descriptor("public.callback"),
+            credential_handles: vec![],
+        }])
+        .expect("public route with no credentials projects");
+        assert_eq!(section.host_ingress().len(), 1);
     }
 }

--- a/crates/ironclaw_product_adapter_registry/tests/manifest_ingestion.rs
+++ b/crates/ironclaw_product_adapter_registry/tests/manifest_ingestion.rs
@@ -194,8 +194,16 @@ fn rejects_host_ingress_public_webhook_without_webhook_signature() {
     // weaken the descriptor's built-in verification requirement.
     let raw = manifest(&host_ingress_fragment("telegram_bot_token", "bearer_token"));
     let err = parse(&raw).unwrap_err();
+    // The invalid descriptor is rejected while deserializing the section, which
+    // may surface either as a stringified `Manifest` error (via the host-api
+    // contract validator) or as a typed `ManifestSectionParse` (via the final
+    // projection) depending on which projection runs first — accept both so the
+    // test pins the fail-closed behavior, not the error-routing path.
     assert!(
-        matches!(err, RegistryError::Manifest(_)),
+        matches!(
+            err,
+            RegistryError::Manifest(_) | RegistryError::ManifestSectionParse { .. }
+        ),
         "expected the host_api listener/auth invariant to reject, got {err:?}"
     );
 }

--- a/crates/ironclaw_product_adapter_registry/tests/manifest_ingestion.rs
+++ b/crates/ironclaw_product_adapter_registry/tests/manifest_ingestion.rs
@@ -149,6 +149,75 @@ fn rejects_auth_header_injection_shape() {
     ));
 }
 
+/// A valid public-webhook host-ingress route declaration in manifest wire form.
+/// `{cred}` lets a test swap the verifying credential handle; `{scheme}` lets a
+/// test swap the auth scheme to exercise host_api's fail-closed floor.
+fn host_ingress_fragment(cred: &str, scheme: &str) -> String {
+    format!(
+        r#"
+[[product_adapter.inbound.host_ingress]]
+credential_handles = ["{cred}"]
+descriptor = {{ route_id = "telegram.updates", method = "post", route_pattern = "/webhooks/telegram/updates", policy = {{ listener_class = "public_webhook", auth = {{ type = "required", schemes = ["{scheme}"] }}, scope_source = "host_resolved", body_limit = {{ type = "limited", max_bytes = 262144 }}, rate_limit = {{ type = "limited", scope = "global", max_requests = 600, window_seconds = 60 }}, cors = "not_applicable", websocket_origin = "not_applicable", streaming = "none", audit = "public_callback", effect_path = {{ type = "product_workflow" }} }} }}
+"#
+    )
+}
+
+#[test]
+fn parses_host_ingress_route_from_manifest() {
+    let record = parse(&manifest(&host_ingress_fragment(
+        "telegram_bot_token",
+        "webhook_signature",
+    )))
+    .unwrap();
+    let adapters = product_adapter_sections(&record).unwrap();
+    let routes = adapters[0].host_ingress();
+    assert_eq!(routes.len(), 1);
+    assert_eq!(
+        routes[0].descriptor().route_id().as_str(),
+        "telegram.updates"
+    );
+    assert_eq!(
+        routes[0].descriptor().route_pattern().as_str(),
+        "/webhooks/telegram/updates"
+    );
+    assert_eq!(
+        routes[0].credential_handles()[0].as_str(),
+        "telegram_bot_token"
+    );
+}
+
+#[test]
+fn rejects_host_ingress_public_webhook_without_webhook_signature() {
+    // host_api's own fail-closed floor: a `public_webhook` listener MUST
+    // require `webhook_signature`. Declaring `bearer_token` instead must be
+    // rejected while projecting the manifest — the manifest layer cannot
+    // weaken the descriptor's built-in verification requirement.
+    let raw = manifest(&host_ingress_fragment("telegram_bot_token", "bearer_token"));
+    let err = parse(&raw).unwrap_err();
+    assert!(
+        matches!(err, RegistryError::Manifest(_)),
+        "expected the host_api listener/auth invariant to reject, got {err:?}"
+    );
+}
+
+#[test]
+fn rejects_host_ingress_credential_handle_not_declared_as_required() {
+    // Ingress credential coherence over the wire: a route may only be verified
+    // by a credential the section declares in `required_credentials`.
+    let raw = manifest(&host_ingress_fragment(
+        "undeclared_token",
+        "webhook_signature",
+    ));
+    let err = parse(&raw).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            RegistryError::UndeclaredIngressCredentialHandle { .. } | RegistryError::Manifest(_)
+        ),
+        "got {err:?}"
+    );
+}
+
 #[test]
 fn rejects_real_derived_adapter_id_that_exceeds_limit() {
     let extension_id = "a".repeat(128);


### PR DESCRIPTION
## Summary

Re-derives the one still-valuable idea from the **superseded earliest-reborn ingress stack** — #5072 → #5093 → #5100 → #5107, which I reviewed and **closed as superseded** — fresh atop main's current `ironclaw_host_api::ingress` contract, as a **single small, registry-only change** instead of rebasing a ~250-commit-stale, 4-deep stack built on a `host_ingress_registry` crate main never adopted.

A ProductAdapter manifest section may now declare `[[product_adapter.<sub>.host_ingress]]` routes, each carrying a full host-owned `IngressRouteDescriptor` **plus** the `credential_handles` that verify it — the binding host_api's route/policy vocabulary deliberately lacks.

## Why this shape (and not the old stack)

The closed stack introduced a parallel `host_ingress_registry` crate + a new descriptor vocabulary. Main already has:
- `ironclaw_host_api::ingress` — the typed, `deny_unknown_fields`, fail-closed ingress policy vocabulary (incl. the floor that a `public_webhook` listener MUST require `webhook_signature`);
- `PublicRouteMount` + the descriptor-fold middleware in composition, which already mount an arbitrary number of descriptor-carrying routers with per-route body/rate/WS policy.

So the only genuinely-missing pieces were (1) letting a **manifest** declare an ingress route, and (2) **ingress credential coherence** — which PR #5107's review flagged as fail-open/`TODO`'d. This PR adds exactly those, reusing host_api's validation wholesale (no new vocabulary, no new crate).

## What it does

The registry does **not** re-own ingress route/policy vocabulary — it projects the descriptor (host_api validates it on deserialize) and enforces **ingress credential coherence, fail-closed**:
- every `credential_handles` entry must be declared in `required_credentials` (mirrors the egress rule, so ingress handles flow into the same declared set installation bindings validate against);
- an auth-required route (`IngressAuthPolicy::Required`) must name **≥1** verifying credential handle (no route nothing can authenticate);
- route ids stay distinct within a section.

Manifest shape:
```toml
[[product_adapter.inbound.host_ingress]]
credential_handles = ["telegram_bot_token"]
descriptor = { route_id = "telegram.updates", method = "post", route_pattern = "/webhooks/telegram/updates", policy = { listener_class = "public_webhook", auth = { type = "required", schemes = ["webhook_signature"] }, ... } }
```

## Scope / follow-up

Deliberately **registry-only** — one crate, no new dependency edges, no architecture-boundary changes. The serve-layer generic mount (project each declared route → axum route + reused `SharedSecretHeader`/`Hmac` verifier, then delete Slack's per-surface Rust literal) is the clear next PR: main's `PublicRouteMount` + descriptor-fold already generalize, so it's a small wiring change. A compact manifest schema (defaulting the verbose policy per listener_class via a host_api constructor lifted from `slack_events_policy()`) is a natural ergonomics follow-up.

## Tests

- **Unit** (`src/lib.rs mod tests`): ingress credential-coherence matrix — undeclared handle, auth-required route missing a credential, duplicate route id, happy projection (descriptors built in Rust, robust to serde renames).
- **Integration** (`tests/manifest_ingestion.rs`): wire-path projection, the inherited host_api fail-closed floor (`public_webhook` + `bearer_token` rejected), and coherence over the wire.
- `cargo fmt` + `cargo clippy --all-features --tests` clean; reverse-dependent `ironclaw_host_runtime` compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)