### PR TITLE
docs(ci): define build-time optimization target

### DIFF
--- a/docs/ci-build-time-lfd/LOG.md
+++ b/docs/ci-build-time-lfd/LOG.md
@@ -1,0 +1,29 @@
+# CI build-time LFD log
+
+## 2026-07-04
+
+Observed recent main workflow timings with `gh run list` and `gh run view`.
+
+Key finding: the first OVH nextest archive PR is a negative result for PR CI latency. It made test consumers faster but increased the overall Reborn workflow active time because the archive producer became a serial dependency.
+
+Current working hypothesis:
+
+- OVH should not be the single central builder for all PR tests.
+- OVH can still help as a trusted producer for workflows that already duplicate identical setup across shards, especially live canary and binary-based browser tests.
+- The highest-signal next move is build-once artifact fan-out for repeated binary/WASM setup, measured by workflow active time, not isolated job duration.
+
+Evidence captured:
+
+- Tests (Reborn) main run `28696684191`: active 597s.
+- Reborn E2E main run `28696684177`: active 487s.
+- Reborn Coverage main run `28696684175`: active 574s.
+- Tests (Legacy) main run `28228462994`: active 1888s.
+- Live Canary run `28694683262`: active 1403s, failed, but Reborn WebUI v2 QA shards still expose repeated setup cost.
+- OVH archive experiment:
+  - baseline `28681653394`: 603s
+  - full-feature archive `28684600515`: 711s
+  - libsql archive `28685265502`: 793s
+
+Next action for an implementation branch:
+
+Run `docs/ci-build-time-lfd/harness/score.sh` against baseline and candidate runs, then start with live canary or Reborn E2E binary artifact fan-out. Do not merge an optimization unless it beats the primary workflow set and does not regress the probe set.

--- a/docs/ci-build-time-lfd/eval/dev/workflows.txt
+++ b/docs/ci-build-time-lfd/eval/dev/workflows.txt
@@ -1,0 +1,4 @@
+reborn-tests.yml
+reborn-e2e.yml
+reborn-coverage.yml
+test.yml

--- a/docs/ci-build-time-lfd/eval/holdout/README.md
+++ b/docs/ci-build-time-lfd/eval/holdout/README.md
@@ -1,0 +1,18 @@
+# Holdout workflow set
+
+The holdout set is intentionally not encoded as fixed answer data in this directory. Use fresh run IDs from GitHub Actions when evaluating a candidate branch.
+
+Recommended holdout workflows:
+
+- `live-canary.yml`
+- `coverage.yml`
+- `reborn-playwright.yml`
+
+For live canary, pass explicit run IDs to the scorer because scheduled runs can be product-red while still carrying useful build-time timing.
+
+Example:
+
+```bash
+BASE_RUN_IDS=28694683262 CANDIDATE_RUN_IDS=<candidate-live-canary-run> \
+  docs/ci-build-time-lfd/harness/score.sh --repo nearai/ironclaw
+```

--- a/docs/ci-build-time-lfd/goal.md
+++ b/docs/ci-build-time-lfd/goal.md
@@ -1,0 +1,105 @@
+# CI build-time LFD target
+
+This is a loss-function design target for reducing IronClaw CI build time without reducing test coverage.
+
+## Current conclusion
+
+The OVH "build one nextest archive, then fan out" experiment is useful evidence, but it is not a PR-CI win in its current form. The consumer jobs got faster, but the new archive producer became a serial gate, so the workflow finished later overall.
+
+That does not make OVH useless. It means OVH should be treated as a trusted cache/build producer only where the downstream jobs already need a shared artifact or where the current jobs repeatedly do the same trusted build work. It should not replace already-wide GitHub parallelism unless the measured critical path improves.
+
+## Success target
+
+Reduce build-related CI critical-path time by at least 30 percent on the selected workflow set, with no reduction in tests, features, security guards, or checked behavior.
+
+Primary workflow set:
+
+- `reborn-tests.yml`
+- `reborn-e2e.yml`
+- `reborn-coverage.yml`
+- `test.yml`
+
+Probe workflow set:
+
+- `live-canary.yml`
+- `coverage.yml`
+- `reborn-playwright.yml`
+
+`live-canary.yml` is a probe because scheduled runs are often red for product reasons. It is still important because it shows repeated Rust/WASM setup across Reborn WebUI v2 live QA shards.
+
+## Observed baseline
+
+Collected on July 4, 2026 from recent `main` GitHub Actions runs.
+
+| Workflow | Run | Active time | Heavy jobs |
+| --- | --- | ---: | --- |
+| Tests (Reborn) | `28696684191` | 597s | `ironclaw_host_runtime` 557s, root partitions 381-462s, group tests 378s, `ironclaw_reborn_composition` 418s |
+| Reborn E2E | `28696684177` | 487s | gateway smoke 481s, architecture 319s, WebUI smoke 192s |
+| Reborn Coverage | `28696684175` | 574s | Reborn Coverage 571s |
+| Tests (Legacy) | `28228462994` | 1888s | all-features 1475s, libsql-only 1466s, default 1443s, Telegram integration 569-621s, Slack 593s |
+| Live Canary | `28694683262` | 1403s | Reborn WebUI v2 QA shards 1008-1354s; run failed, but still useful as a build-time probe |
+
+The earlier OVH archive experiment on `codex/ovh-nextest-archive` produced these measured results:
+
+- Baseline Reborn run `28681653394`: active time 603s.
+- Full-feature archive run `28684600515`: active time 711s.
+- `--no-default-features --features libsql` archive run `28685265502`: active time 793s.
+
+The archive path should stay unmerged unless a later variant beats the baseline on total workflow time, not just consumer-job time.
+
+## Loss function
+
+The scorer compares recent baseline runs against candidate-branch runs.
+
+Primary metric:
+
+```text
+speedup_percent = 100 * (baseline_active_seconds - candidate_active_seconds) / baseline_active_seconds
+```
+
+Aggregate score:
+
+```text
+score = speedup_percent - stability_penalty - guard_penalty
+```
+
+Hard void conditions:
+
+- Any required workflow becomes red for a reason not present in the baseline.
+- A test job, shard, or check is removed without an equivalent replacement.
+- Tests are skipped, ignored, filtered out, or made non-fatal.
+- Required feature sets are weakened.
+- Trigger/path filters are narrowed to avoid CI.
+- Secrets/live lanes are moved to untrusted runners.
+- The scoring harness is modified in the same PR as an optimization without reviewer approval.
+
+Soft penalties:
+
+- More than 10 percent slower on any probe workflow.
+- Reliance on a single warm-cache run without a second confirming run.
+- More total runner minutes with only small wall-clock improvement.
+- Higher live-secret exposure or broader self-hosted runner permissions.
+
+## Allowed implementation levers
+
+- Reuse the proven `reborn-playwright.yml` pattern: build once, upload a binary or exact test artifact, then fan out consumers.
+- Add artifact producers only where consumers already wait on the producer or duplicate identical compile work.
+- Improve Rust cache key sharing where feature sets and target dirs are genuinely compatible.
+- Use OVH Redis/sccache as a persistent cache backend where credentials are available and HTTPS/SSH boundaries remain locked down.
+- Use trusted OVH self-hosted runners only for maintainer/secret-safe jobs, never for fork PR code with secrets.
+- Add timing/stat reporting that makes cache hit rates and build phases visible.
+
+## First experiments to run
+
+1. Live canary Reborn WebUI v2 QA: build WASM channels and any reusable Rust binaries once, upload artifacts, and let QA shards consume them. This is the best OVH/trusted-producer candidate because each shard repeats setup before long live tests.
+2. Reborn E2E gateway/WebUI smoke: mirror the Reborn Playwright binary-artifact pattern if the Python fixtures can consume prebuilt `target/debug` binaries without changing test behavior.
+3. Reborn Coverage: measure mold plus OVH Redis cache impact for `cargo llvm-cov`, and only keep it if total active time improves across two runs.
+4. Legacy PR tests: identify duplicated WASM/channel builds and exact feature-compatible target cache sharing before attempting a central archive. Avoid serializing the three feature matrices unless the critical path improves.
+
+## Non-goals
+
+- Do not reduce the number of tests.
+- Do not remove live canary coverage.
+- Do not make red jobs informational.
+- Do not move unsafe fork PR work onto OVH.
+- Do not optimize only the visible dev workflows while slowing coverage/canary probes.

--- a/docs/ci-build-time-lfd/harness/lint.sh
+++ b/docs/ci-build-time-lfd/harness/lint.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+base_ref="${BASE_REF:-origin/main}"
+range="${base_ref}...HEAD"
+
+if ! git rev-parse --verify "$base_ref" >/dev/null 2>&1; then
+  echo "missing base ref $base_ref; run git fetch origin main or set BASE_REF" >&2
+  exit 2
+fi
+
+diff_tmp="$(mktemp)"
+name_status_tmp="$(mktemp)"
+trap 'rm -f "$diff_tmp" "$name_status_tmp"' EXIT
+
+git diff -U0 "$range" -- .github/workflows .github/actions scripts/ci scripts/live-canary tests Cargo.toml Cargo.lock > "$diff_tmp"
+git diff --name-status "$range" > "$name_status_tmp"
+
+failures=0
+
+fail_if_diff_matches() {
+  name="$1"
+  pattern="$2"
+  if grep -En "$pattern" "$diff_tmp"; then
+    echo "FAIL: $name" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+warn_if_diff_matches() {
+  name="$1"
+  pattern="$2"
+  if grep -En "$pattern" "$diff_tmp"; then
+    echo "WARN: $name" >&2
+  fi
+}
+
+fail_if_diff_matches "new continue-on-error in CI paths" '^\+.*continue-on-error:[[:space:]]*true'
+fail_if_diff_matches "new explicit test skip/ignore marker" '^\+.*(--skip|--ignored|#\[ignore\]|#\[cfg\(ignore)'
+fail_if_diff_matches "new cargo test exclusion flag" '^\+.*cargo (nextest run|test|llvm-cov).*--exclude[[:space:]]'
+fail_if_diff_matches "new pytest exclusion expression" '^\+.*pytest .* -k .*not '
+fail_if_diff_matches "new neutralized shell failure handling" '^\+.*\|\|[[:space:]]*true([[:space:]]|$)'
+
+deleted_tests="$(awk '$1 ~ /^D/ && $2 ~ /(^tests\/|\/tests\/|_test\.rs$|\.test\.(js|mjs|ts|tsx)$)/ { print }' "$name_status_tmp")"
+if [ -n "$deleted_tests" ]; then
+  printf '%s\n' "$deleted_tests"
+  echo "FAIL: test files were deleted" >&2
+  failures=$((failures + 1))
+fi
+
+warn_if_diff_matches "workflow trigger or path filters changed; reviewer must confirm no CI is avoided" '^[-+].*(pull_request:|merge_group:|push:|paths:|paths-ignore:)'
+warn_if_diff_matches "job guard changed; reviewer must confirm checks still run" '^[-+].*if:[[:space:]]'
+warn_if_diff_matches "timeout changed; reviewer must confirm this is not hiding work" '^[-+].*timeout-minutes:'
+warn_if_diff_matches "test command changed; compare test inventory before merging" '^[-+].*(cargo test|cargo nextest run|cargo llvm-cov|pytest |node --test)'
+
+if [ "$failures" -gt 0 ]; then
+  echo "CI build-time lint failed with $failures hard guard violation(s)." >&2
+  exit 1
+fi
+
+echo "CI build-time lint passed."

--- a/docs/ci-build-time-lfd/harness/probe.sh
+++ b/docs/ci-build-time-lfd/harness/probe.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo="${REPO:-nearai/ironclaw}"
+base_branch="${BASE_BRANCH:-main}"
+candidate_branch="${CANDIDATE_BRANCH:-}"
+candidate_args=()
+if [ -n "$candidate_branch" ]; then
+  candidate_args=(--candidate-branch "$candidate_branch")
+fi
+
+echo "# CI build-time probe"
+echo
+echo "Primary workflow set"
+WORKFLOWS="${DEV_WORKFLOWS:-reborn-tests.yml,reborn-e2e.yml,reborn-coverage.yml,test.yml}" \
+  "$script_dir/score.sh" --repo "$repo" --base-branch "$base_branch" "${candidate_args[@]}"
+
+echo
+echo "Probe workflow set"
+if [ -n "${PROBE_BASE_RUN_IDS:-}" ] || [ -n "${PROBE_CANDIDATE_RUN_IDS:-}" ]; then
+  BASE_RUN_IDS="${PROBE_BASE_RUN_IDS:-}" \
+  CANDIDATE_RUN_IDS="${PROBE_CANDIDATE_RUN_IDS:-}" \
+    "$script_dir/score.sh" --repo "$repo" --base-branch "$base_branch" "${candidate_args[@]}"
+else
+  echo "No probe run IDs supplied."
+  echo "Set PROBE_BASE_RUN_IDS and PROBE_CANDIDATE_RUN_IDS for live-canary/coverage/reborn-playwright holdout checks."
+fi

--- a/docs/ci-build-time-lfd/harness/score.sh
+++ b/docs/ci-build-time-lfd/harness/score.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+score.sh compares GitHub Actions active time for CI build-time experiments.
+
+Usage:
+  score.sh [--repo nearai/ironclaw] [--base-branch main] [--candidate-branch BRANCH]
+           [--workflows reborn-tests.yml,reborn-e2e.yml,reborn-coverage.yml,test.yml]
+
+Environment:
+  REPO                  GitHub repository, default nearai/ironclaw
+  BASE_BRANCH           Baseline branch, default main
+  CANDIDATE_BRANCH      Candidate branch. If omitted, prints baseline only.
+  WORKFLOWS             Comma-separated workflow files for automatic run lookup.
+  BASE_RUN_IDS          Comma-separated explicit baseline run IDs.
+  CANDIDATE_RUN_IDS     Comma-separated explicit candidate run IDs.
+
+Notes:
+  - Explicit run IDs override workflow lookup.
+  - Automatic lookup uses the latest successful completed run for each workflow.
+  - The score is based on workflow active time, not queue time.
+USAGE
+}
+
+repo="${REPO:-nearai/ironclaw}"
+base_branch="${BASE_BRANCH:-main}"
+candidate_branch="${CANDIDATE_BRANCH:-}"
+workflows="${WORKFLOWS:-reborn-tests.yml,reborn-e2e.yml,reborn-coverage.yml,test.yml}"
+base_run_ids="${BASE_RUN_IDS:-}"
+candidate_run_ids="${CANDIDATE_RUN_IDS:-}"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --repo)
+      repo="$2"
+      shift 2
+      ;;
+    --base-branch)
+      base_branch="$2"
+      shift 2
+      ;;
+    --candidate-branch)
+      candidate_branch="$2"
+      shift 2
+      ;;
+    --workflows)
+      workflows="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+need() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "missing required command: $1" >&2
+    exit 2
+  fi
+}
+
+need gh
+need jq
+need awk
+
+csv_to_lines() {
+  printf '%s\n' "$1" | tr ',' '\n' | sed '/^[[:space:]]*$/d'
+}
+
+latest_successful_run_id() {
+  branch="$1"
+  workflow="$2"
+  gh run list \
+    --repo "$repo" \
+    --workflow "$workflow" \
+    --branch "$branch" \
+    --limit 20 \
+    --json databaseId,status,conclusion \
+    --jq '.[] | select(.status == "completed" and .conclusion == "success") | .databaseId' \
+    | head -n 1
+}
+
+resolve_run_ids() {
+  explicit_ids="$1"
+  branch="$2"
+  if [ -n "$explicit_ids" ]; then
+    csv_to_lines "$explicit_ids"
+    return
+  fi
+
+  while IFS= read -r workflow; do
+    run_id="$(latest_successful_run_id "$branch" "$workflow")"
+    if [ -z "$run_id" ]; then
+      echo "no successful completed run found for workflow $workflow on branch $branch" >&2
+      exit 1
+    fi
+    printf '%s\n' "$run_id"
+  done < <(csv_to_lines "$workflows")
+}
+
+metrics_for_run() {
+  run_id="$1"
+  gh run view "$run_id" --repo "$repo" --json databaseId,url,conclusion,createdAt,updatedAt,jobs \
+    | jq -r '
+      def seconds_between($start; $end): (($end | fromdateiso8601) - ($start | fromdateiso8601));
+      def job_seconds:
+        [
+          .jobs[]
+          | select(.startedAt != null and .completedAt != null)
+          | seconds_between(.startedAt; .completedAt)
+        ];
+      {
+        id: .databaseId,
+        url: .url,
+        conclusion: (.conclusion // ""),
+        active_seconds: seconds_between(.createdAt; .updatedAt),
+        critical_job_seconds: ((job_seconds | max) // 0),
+        job_count: (.jobs | length),
+        failed_jobs: ([.jobs[] | select(.conclusion != "success" and .conclusion != "skipped") | .name] | length)
+      }
+      | [.id, .conclusion, .active_seconds, .critical_job_seconds, .job_count, .failed_jobs, .url]
+      | @tsv'
+}
+
+collect_metrics() {
+  label="$1"
+  output="$2"
+  shift 2
+  : > "$output"
+  for run_id in "$@"; do
+    metrics_for_run "$run_id" >> "$output"
+  done
+
+  echo
+  echo "## $label"
+  printf 'run_id\tconclusion\tactive_seconds\tcritical_job_seconds\tjob_count\tfailed_jobs\turl\n'
+  cat "$output"
+}
+
+sum_column() {
+  file="$1"
+  column="$2"
+  awk -v col="$column" '{ sum += $col } END { printf "%.0f", sum }' "$file"
+}
+
+failed_jobs_total() {
+  file="$1"
+  awk '{ sum += $6 } END { printf "%.0f", sum }' "$file"
+}
+
+base_ids_tmp="$(mktemp)"
+candidate_ids_tmp="$(mktemp)"
+base_metrics_tmp="$(mktemp)"
+candidate_metrics_tmp="$(mktemp)"
+trap 'rm -f "$base_ids_tmp" "$candidate_ids_tmp" "$base_metrics_tmp" "$candidate_metrics_tmp"' EXIT
+
+resolve_run_ids "$base_run_ids" "$base_branch" > "$base_ids_tmp"
+base_ids=()
+while IFS= read -r run_id || [ -n "$run_id" ]; do
+  base_ids+=("$run_id")
+done < "$base_ids_tmp"
+
+echo "# CI build-time score"
+echo
+echo "repo: $repo"
+echo "base_branch: $base_branch"
+echo "candidate_branch: ${candidate_branch:-<none>}"
+echo "workflows: $workflows"
+
+collect_metrics "Baseline" "$base_metrics_tmp" "${base_ids[@]}"
+base_active="$(sum_column "$base_metrics_tmp" 3)"
+base_failed="$(failed_jobs_total "$base_metrics_tmp")"
+
+if [ "$base_failed" -gt 0 ]; then
+  echo
+  echo "VOID: baseline contains failed jobs. Use successful baselines or explicit accepted probe run IDs." >&2
+  exit 1
+fi
+
+if [ -z "$candidate_branch" ] && [ -z "$candidate_run_ids" ]; then
+  echo
+  echo "baseline_active_seconds=$base_active"
+  echo "candidate not provided; baseline-only mode."
+  exit 0
+fi
+
+resolve_run_ids "$candidate_run_ids" "$candidate_branch" > "$candidate_ids_tmp"
+candidate_ids=()
+while IFS= read -r run_id || [ -n "$run_id" ]; do
+  candidate_ids+=("$run_id")
+done < "$candidate_ids_tmp"
+
+collect_metrics "Candidate" "$candidate_metrics_tmp" "${candidate_ids[@]}"
+candidate_active="$(sum_column "$candidate_metrics_tmp" 3)"
+candidate_failed="$(failed_jobs_total "$candidate_metrics_tmp")"
+
+if [ "$candidate_failed" -gt 0 ]; then
+  echo
+  echo "VOID: candidate contains failed jobs." >&2
+  exit 1
+fi
+
+improvement="$(
+  awk -v base="$base_active" -v candidate="$candidate_active" '
+    BEGIN {
+      if (base <= 0) {
+        print "0.00"
+      } else {
+        printf "%.2f", 100 * (base - candidate) / base
+      }
+    }'
+)"
+
+echo
+echo "baseline_active_seconds=$base_active"
+echo "candidate_active_seconds=$candidate_active"
+echo "speedup_percent=$improvement"
+
+awk -v improvement="$improvement" 'BEGIN {
+  if (improvement >= 30) {
+    print "result=PASS"
+  } else {
+    print "result=FAIL"
+  }
+}'

--- a/docs/ci-build-time-lfd/harness/status.sh
+++ b/docs/ci-build-time-lfd/harness/status.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo="${REPO:-nearai/ironclaw}"
+branch="$(git rev-parse --abbrev-ref HEAD)"
+workflows="${WORKFLOWS:-reborn-tests.yml,reborn-e2e.yml,reborn-coverage.yml,test.yml,live-canary.yml}"
+
+echo "# CI build-time LFD status"
+echo
+echo "branch: $branch"
+echo "repo: $repo"
+echo
+
+if command -v gh >/dev/null 2>&1; then
+  if pr_json="$(gh pr view --repo "$repo" --json number,url,headRefName,state 2>/dev/null)"; then
+    echo "PR: $(jq -r '.url + \" (\" + .state + \")\"' <<< "$pr_json")"
+  else
+    echo "PR: none for current branch"
+  fi
+else
+  echo "PR: gh not installed"
+fi
+
+echo
+echo "Recent workflow runs:"
+while IFS= read -r workflow; do
+  [ -n "$workflow" ] || continue
+  echo
+  echo "## $workflow"
+  gh run list --repo "$repo" --workflow "$workflow" --limit 3 \
+    --json databaseId,branch,status,conclusion,createdAt,updatedAt,url \
+    --jq '.[] | [.databaseId, .branch, .status, (.conclusion // ""), .createdAt, .updatedAt, .url] | @tsv'
+done < <(printf '%s' "$workflows" | tr ',' '\n')


### PR DESCRIPTION
## Summary
- documents the failed OVH nextest archive result as a negative benchmark
- defines the CI build-time loss target and anti-cheat constraints
- adds scorer/lint/probe/status scripts for comparing future candidate runs against baseline GitHub Actions runs

## Verification
- bash -n docs/ci-build-time-lfd/harness/score.sh docs/ci-build-time-lfd/harness/lint.sh docs/ci-build-time-lfd/harness/probe.sh docs/ci-build-time-lfd/harness/status.sh
- BASE_RUN_IDS=28696684191,28696684177,28696684175,28228462994 docs/ci-build-time-lfd/harness/score.sh --repo nearai/ironclaw
- BASE_REF=origin/main docs/ci-build-time-lfd/harness/lint.sh

## Notes
This PR does not change CI behavior. It creates the target and harness the next implementation PR should be measured against.