### PR TITLE
ci(fix): fix main Docker build prompt inputs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,8 @@ target/
 .env
 .env.*
 *.md
+!prompts/**/*.md
+!src/workspace/seeds/**/*.md
 !skills/**/*.md
 !crates/**/*.md
 !CLAUDE.md

--- a/.github/workflows/platform-and-compat.yml
+++ b/.github/workflows/platform-and-compat.yml
@@ -318,7 +318,12 @@ jobs:
     if: >
       needs.changes.outputs.docs_only != 'true' &&
       needs.changes.outputs.has_legacy_tests == 'true' &&
-      (github.event_name == 'push' || (github.event_name == 'workflow_call' && inputs.include_docker))
+      (
+        github.event_name == 'push' ||
+        github.event_name == 'pull_request' ||
+        github.event_name == 'merge_group' ||
+        (github.event_name == 'workflow_call' && inputs.include_docker)
+      )
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/platform-and-compat.yml
+++ b/.github/workflows/platform-and-compat.yml
@@ -318,12 +318,7 @@ jobs:
     if: >
       needs.changes.outputs.docs_only != 'true' &&
       needs.changes.outputs.has_legacy_tests == 'true' &&
-      (
-        github.event_name == 'push' ||
-        github.event_name == 'pull_request' ||
-        github.event_name == 'merge_group' ||
-        (github.event_name == 'workflow_call' && inputs.include_docker)
-      )
+      (github.event_name == 'push' || (github.event_name == 'workflow_call' && inputs.include_docker))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ COPY build.rs build.rs
 COPY src/ src/
 COPY tests/ tests/
 COPY migrations/ migrations/
+COPY prompts/ prompts/
 COPY registry/ registry/
 COPY channels-src/ channels-src/
 COPY tools-src/ tools-src/
@@ -60,6 +61,7 @@ COPY build.rs build.rs
 COPY src/ src/
 COPY tests/ tests/
 COPY migrations/ migrations/
+COPY prompts/ prompts/
 COPY registry/ registry/
 COPY channels-src/ channels-src/
 COPY tools-src/ tools-src/

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,6 @@ COPY build.rs build.rs
 COPY src/ src/
 COPY tests/ tests/
 COPY migrations/ migrations/
-COPY prompts/ prompts/
 COPY registry/ registry/
 COPY channels-src/ channels-src/
 COPY tools-src/ tools-src/


### PR DESCRIPTION
## Summary

- copy the root `prompts/` directory into the legacy Docker builder stage so compile-time `include_str!` prompt inputs are present
- allowlist the specific markdown inputs needed by Docker builds in `.dockerignore`
- keep the cargo-chef planner stage and Platform & Compat workflow gating unchanged

## Root Cause

The main-branch Docker build compiled the legacy `ironclaw` binary inside an image that copied `src/` but not root `prompts/`. Two `include_str!` paths (`prompts/session_summary.md` and `prompts/memory_reasoning_synthesis.md`) therefore existed in normal checkouts but not inside the Docker builder context. `.dockerignore` also ignored markdown by default, so the prompt and workspace seed markdown inputs need explicit allowlists.

## Change Type

Bug fix.

## Linked Issue

Fixes the Docker Build failure from https://github.com/nearai/ironclaw/actions/runs/28688841760/job/85086298143.

## Security Impact

No auth, secrets, listener, sandbox, or egress behavior changes. The Docker context allowlist is limited to repo-tracked prompt/seed markdown needed by compile-time embeds.

## Database Impact

N/A. No schema or persistence changes.

## Blast Radius

Docker build context and legacy image compilation only. Runtime behavior is unchanged except that the image can now compile with embedded prompt assets.

## Rollback Plan

Revert this PR to restore the previous Docker context. The risk is that the main Docker Build check will fail again until an equivalent prompt-copy fix is reapplied.

## Validation

- `docker build --target runtime -t ironclaw-test:ci .`
- `docker build -f Dockerfile.reborn -t ironclaw-reborn-test:ci .`
- PR `Docker Build` check passed before restoring the temporary workflow enablement
- inline Docker context check copying `prompts/session_summary.md`, `prompts/memory_reasoning_synthesis.md`, and `src/workspace/seeds/README.md`
