### PR TITLE
ci(fix): scope E2E coverage to standalone Reborn

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,6 +28,8 @@
 
 name: Code Coverage
 on:
+  pull_request:
+    branches: [main]
   push:
     branches: [main]
 
@@ -170,12 +172,6 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@62b0f2dec647a8e604c6a0fda0e38530180dce20 # cargo-llvm-cov
 
-      - name: Install cargo-component
-        uses: ./.github/actions/install-cargo-component
-
-      - name: Build WASM channels
-        run: ./scripts/build-wasm-extensions.sh --channels
-
       - name: Set up coverage instrumentation
         run: |
           # show-env outputs shell-quoted values (KEY='value') but GITHUB_ENV
@@ -186,25 +182,26 @@ jobs:
       - name: Clean coverage workspace
         run: cargo llvm-cov clean --workspace
 
-      - name: Build instrumented binary
-        run: cargo build --no-default-features --features libsql
+      - name: Install Node.js for WebUI bundle build
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: crates/ironclaw_webui_v2/frontend/package-lock.json
 
       # Pre-build the reborn binary under the same llvm-cov env so the E2E
-      # session fixture finds it cached instead of doing a cold instrumented
-      # build inside a 120s pytest timeout (which SIGKILLs and errors every
-      # webui-v2 smoke test). Mirrors reborn-e2e.yml.
-      - name: Build instrumented ironclaw-reborn (WebChat v2)
-        run: cargo build -p ironclaw_reborn_cli --features webui-v2-beta
+      # fixtures find it cached instead of doing a cold instrumented build
+      # inside a pytest timeout. openai-compat-beta is a strict superset of
+      # webui-v2-beta, so one binary covers both Reborn WebChat v2 and the
+      # OpenAI-compatible Responses API scenarios selected below.
+      - name: Build instrumented ironclaw-reborn
+        run: cargo build -p ironclaw_reborn_cli --features openai-compat-beta
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
           cache: pip
           cache-dependency-path: tests/e2e/pyproject.toml
-
-      - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
-        with:
-          node-version: "22"
 
       # Cache the Playwright browser binaries (chromium ~150MB) keyed on the e2e
       # deps file; on a hit `playwright install` skips the download and only runs
@@ -221,9 +218,14 @@ jobs:
           pip install -e .
           playwright install --with-deps chromium
 
-      - name: Run E2E tests
+      - name: Run Reborn E2E coverage tests
         run: |
-          pytest tests/e2e/ -v --timeout=120
+          mapfile -t reborn_e2e_tests < <(
+            sed -e 's/#.*//' -e '/^[[:space:]]*$/d' tests/e2e/reborn_coverage_tests.txt
+          )
+          printf 'Selected Reborn E2E coverage tests:\n'
+          printf '  %s\n' "${reborn_e2e_tests[@]}"
+          pytest "${reborn_e2e_tests[@]}" -v --timeout=120
         env:
           RUST_LOG: ironclaw=info
           RUST_BACKTRACE: "1"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,8 +28,6 @@
 
 name: Code Coverage
 on:
-  pull_request:
-    branches: [main]
   push:
     branches: [main]
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -133,6 +133,7 @@ jobs:
         run: cargo llvm-cov ${{ matrix.flags }} --workspace --lcov --output-path lcov.info
 
       - name: Upload to Codecov
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: lcov.info
@@ -223,6 +224,10 @@ jobs:
           mapfile -t reborn_e2e_tests < <(
             sed -e 's/#.*//' -e '/^[[:space:]]*$/d' tests/e2e/reborn_coverage_tests.txt
           )
+          if ((${#reborn_e2e_tests[@]} == 0)); then
+            echo "No Reborn coverage tests selected"
+            exit 1
+          fi
           printf 'Selected Reborn E2E coverage tests:\n'
           printf '  %s\n' "${reborn_e2e_tests[@]}"
           pytest "${reborn_e2e_tests[@]}" -v --timeout=120
@@ -247,7 +252,7 @@ jobs:
         run: cargo llvm-cov report --lcov --output-path e2e-coverage.info
 
       - name: Upload to Codecov
-        if: always()
+        if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: e2e-coverage.info

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -131,7 +131,6 @@ jobs:
         run: cargo llvm-cov ${{ matrix.flags }} --workspace --lcov --output-path lcov.info
 
       - name: Upload to Codecov
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: lcov.info
@@ -250,7 +249,7 @@ jobs:
         run: cargo llvm-cov report --lcov --output-path e2e-coverage.info
 
       - name: Upload to Codecov
-        if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        if: always()
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: e2e-coverage.info

--- a/tests/e2e/CLAUDE.md
+++ b/tests/e2e/CLAUDE.md
@@ -78,6 +78,21 @@ from `tests/e2e/` for the full, current set.
 | `test_v2_activity_shell.py` | v2 activity shell rendering |
 | `test_v2_*_flow.py` / `test_v2_engine_*.py` | v2 auth/OAuth matrix (GitHub PAT, GSuite, Notion MCP) and v2-engine approval/auth/tool-lifecycle/error-handling |
 
+### Reborn E2E coverage gate
+
+The Code Coverage workflow does **not** run the entire historical Python E2E
+tree. It reads `tests/e2e/reborn_coverage_tests.txt`, which is limited to
+scenarios that start the standalone `ironclaw-reborn serve` binary and exercise
+the Reborn WebChat v2 or OpenAI-compatible API surface. The manifest may use
+pytest node IDs to include only the Reborn binary/API checks from a broader
+scenario file.
+
+Do not add legacy `ironclaw` gateway tests to that manifest, even if they run
+with `ENGINE_V2=true`. Those are compatibility/runtime E2E tests. Direct
+Emulate provider-contract tests are also excluded from the Reborn coverage gate
+because they primarily validate the fixture provider, while current hosted
+full-path Emulate tests still start the legacy gateway binary.
+
 **Provider-contract / full-path (Emulate-backed):**
 
 | File | What it tests |

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -61,6 +61,17 @@ Then Playwright drives a headless Chromium browser against the gateway, making D
 | `test_emulate_reborn_provider_contracts.py` | Emulate provider contracts for Reborn-backed Google Gmail/Calendar/Drive reads and writes, Slack channel/thread/DM delivery plus reactions/user lookup, and GitHub repo/issue/PR/search/branch/git-object/release/fork/action-route surfaces |
 | `test_reborn_emulate_full_path.py` | Full-path Reborn + Emulate coverage: install/auth a first-party extension, drive a scripted model tool call, and assert provider-side Emulate state |
 
+## Reborn coverage gate
+
+The GitHub Actions Code Coverage workflow uses
+`tests/e2e/reborn_coverage_tests.txt` instead of running every scenario in this
+directory. That manifest is intentionally limited to tests that boot
+`ironclaw-reborn serve` and cover the Reborn WebChat v2 or OpenAI-compatible
+API surface. Legacy gateway tests and `ENGINE_V2=true` compatibility tests stay
+in the E2E suite, but they are not part of the Reborn coverage gate. Manifest
+entries may be pytest node IDs when only part of a broader scenario file belongs
+in this gate.
+
 ## Adding new scenarios
 
 1. Create `tests/e2e/scenarios/test_<name>.py`

--- a/tests/e2e/reborn_coverage_tests.txt
+++ b/tests/e2e/reborn_coverage_tests.txt
@@ -1,0 +1,28 @@
+# Reborn E2E coverage gate.
+#
+# Keep this list limited to tests that exercise the standalone
+# `ironclaw-reborn serve` binary and its Reborn WebChat v2 / OpenAI-compatible
+# API surface. Do not add legacy `ironclaw` gateway tests, even when they run
+# with ENGINE_V2=true; those belong in compatibility/runtime E2E jobs, not this
+# Reborn coverage gate.
+#
+# Direct Emulate provider-contract tests are useful QA, but they mostly validate
+# the provider fixture layer. Full-path hosted OAuth tests currently start the
+# legacy gateway binary, so they are intentionally excluded here too.
+#
+# Pytest node IDs are allowed. Use them when a scenario file contains broader
+# provider-fixture or model-tool-choice coverage that should stay in the normal
+# E2E suite but not in this Reborn binary coverage gate.
+tests/e2e/scenarios/test_reborn_webui_v2_smoke.py
+tests/e2e/scenarios/test_reborn_v2_file_download.py
+tests/e2e/scenarios/test_reborn_responses_api.py::test_reborn_responses_lookup_and_cancel_missing_id_match_not_found_shape
+tests/e2e/scenarios/test_reborn_responses_api.py::test_reborn_openai_compat_route_mounts_require_bearer_served
+tests/e2e/scenarios/test_reborn_responses_api.py::test_reborn_openai_compat_route_mounts_authenticated_aliases_served
+tests/e2e/scenarios/test_reborn_responses_api.py::test_reborn_chat_completions_non_streaming_served
+tests/e2e/scenarios/test_reborn_responses_api.py::test_reborn_chat_completions_idempotency_replay_and_conflict_served
+tests/e2e/scenarios/test_reborn_responses_api.py::test_reborn_chat_completions_streaming_raw_sse_served
+tests/e2e/scenarios/test_reborn_responses_api.py::test_reborn_chat_completions_auth_and_validation_served
+tests/e2e/scenarios/test_reborn_responses_api.py::test_reborn_models_v1_lists_configured_mock_model
+tests/e2e/scenarios/test_reborn_responses_api.py::test_reborn_models_api_v1_alias_matches_v1_models
+tests/e2e/scenarios/test_reborn_responses_api.py::test_reborn_models_requires_auth
+tests/e2e/scenarios/test_reborn_webui_v2_legacy_responses_api.py

--- a/tests/e2e/scenarios/test_reborn_responses_api.py
+++ b/tests/e2e/scenarios/test_reborn_responses_api.py
@@ -11,7 +11,7 @@ from typing import Any
 import httpx
 import pytest
 
-from helpers import REBORN_V2_AUTH_TOKEN, sse_stream, wait_for_ready
+from helpers import REBORN_V2_AUTH_TOKEN, wait_for_ready
 
 USER_ID = "reborn-responses-e2e-user"
 PROFILE = "local-dev"
@@ -389,28 +389,28 @@ async def test_reborn_chat_completions_idempotency_replay_and_conflict_served(
 async def test_reborn_chat_completions_streaming_raw_sse_served(
     reborn_responses_server,
 ):
-    async with sse_stream(
-        reborn_responses_server,
-        path="/v1/chat/completions",
-        method="POST",
-        token=REBORN_V2_AUTH_TOKEN,
-        headers={"Content-Type": "application/json"},
-        json={
-            "model": "mock-model",
-            "messages": [{"role": "user", "content": "Say hi"}],
-            "stream": True,
-        },
-    ) as response:
-        assert response.status == 200
-        raw = ""
-        while True:
-            line = (await response.content.readline()).decode(
-                "utf-8",
-                errors="replace",
-            ).rstrip("\r\n")
-            raw += line + "\n"
-            if line == "data: [DONE]":
-                break
+    async with httpx.AsyncClient(timeout=45) as client:
+        stream = client.stream(
+            "POST",
+            f"{reborn_responses_server}/v1/chat/completions",
+            headers={
+                "Accept": "text/event-stream",
+                "Authorization": f"Bearer {REBORN_V2_AUTH_TOKEN}",
+                "Content-Type": "application/json",
+            },
+            json={
+                "model": "mock-model",
+                "messages": [{"role": "user", "content": "Say hi"}],
+                "stream": True,
+            },
+        )
+        async with stream as response:
+            assert response.status_code == 200
+            raw = ""
+            async for line in response.aiter_lines():
+                raw += line + "\n"
+                if line == "data: [DONE]":
+                    break
 
     assert "chat.completion.chunk" in raw
     assert "data: [DONE]" in raw
@@ -431,7 +431,10 @@ async def test_reborn_chat_completions_auth_and_validation_served(
         )
     invalid = await reborn_responses_client.post(
         "/v1/chat/completions",
-        json={"model": "mock-model", "messages": []},
+        json={
+            "model": "mock-model",
+            "messages": [],
+        },
     )
 
     assert unauthenticated.status_code == 401


### PR DESCRIPTION
## Summary

- Scope the Code Coverage E2E job to an explicit Reborn-only manifest.
- Build only the standalone `ironclaw-reborn` binary with `openai-compat-beta` for E2E coverage.
- Document that legacy gateway and `ENGINE_V2=true` compatibility tests are not part of the Reborn coverage gate.
- Keep the Code Coverage workflow main-only while adding a fail-fast guard for an empty Reborn coverage manifest.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [x] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

None.

## Validation

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [ ] `cargo build`
- [x] Relevant tests pass: manifest collection with pytest: `33 tests collected`
- [ ] `cargo test --features integration` if database-backed or integration behavior changed
- [x] Manual testing: parsed `.github/workflows/coverage.yml` with Python YAML, verified the workflow trigger is `push` to `main` only, and parsed the workflow bash snippet with `bash -n`
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

## Security Impact

This keeps the Code Coverage workflow on `push` to `main` only. No PR-triggered OIDC Codecov upload path remains in this PR. No runtime permissions, secrets, auth, sandboxing, or product code paths are changed.

## Reborn Trust-Boundary Checklist

N/A: CI workflow and E2E manifest/docs only; no Reborn runtime, trust-bearing type, prompt ingress, policy, sandbox, DB, or host-boundary behavior is changed.

## Database Impact

None.

## Blast Radius

Touches the Code Coverage GitHub Actions workflow and E2E coverage manifest/docs. Possible breakage is limited to main-branch CI coverage job selection, instrumented Reborn E2E coverage execution, and Codecov upload behavior.

## Rollback Plan

Revert this PR to restore the previous Code Coverage workflow behavior. If only the manifest guard causes trouble, revert the empty-array check in the `Run Reborn E2E coverage tests` step.

## Review Follow-Through

Addressed review feedback by adding an explicit empty-manifest guard before invoking pytest and by keeping Code Coverage main-only. Per maintainer feedback, the temporary Codecov upload conditions were reverted. The Reborn coverage manifest intentionally excludes broader provider-fixture/model-tool-choice scenarios from this specific coverage gate.

---

**Review track**: C (CI)