### PR TITLE
ci: benchmark bucketed Reborn crate tests

### DIFF
--- a/.github/workflows/reborn-tests.yml
+++ b/.github/workflows/reborn-tests.yml
@@ -89,6 +89,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       packages: ${{ steps.packages.outputs.packages }}
+      buckets: ${{ steps.packages.outputs.buckets }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -160,15 +161,20 @@ jobs:
           fi
 
           echo "packages=${packages}" >> "$GITHUB_OUTPUT"
+          buckets="$(scripts/ci/reborn-crate-test-buckets.sh "${packages}")"
+          echo "buckets=${buckets}" >> "$GITHUB_OUTPUT"
+
           echo "Testing Reborn package crates:"
           printf '%s\n' "${packages}" | jq -r '.[] | "- " + .'
+          echo "Testing Reborn package buckets:"
+          printf '%s\n' "${buckets}" | jq -r '.[] | "- \(.name): \(.packages | join(", "))"'
 
   crate-tests:
-    name: Test ${{ matrix.package }}
+    name: Test Reborn crate bucket (${{ matrix.bucket.name }})
     needs: [changes, package-matrix]
     if: needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.has_reborn_tests == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     env:
       ANTHROPIC_API_KEY: ""
       LLM_BACKEND: ""
@@ -178,7 +184,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        package: ${{ fromJSON(needs.package-matrix.outputs.packages) }}
+        bucket: ${{ fromJSON(needs.package-matrix.outputs.buckets) }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -196,21 +202,32 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
-      - name: Resolve crate feature flags
-        id: crate-feature-flags
+      - name: Resolve bucket settings
+        id: bucket-settings
         env:
-          PACKAGE: ${{ matrix.package }}
+          BUCKET_PACKAGES: ${{ toJSON(matrix.bucket.packages) }}
         run: |
-          feature_flags="$(scripts/ci/package-feature-flags.sh "$PACKAGE")"
-          echo "feature_flags=${feature_flags}" >> "$GITHUB_OUTPUT"
-          if [[ "${feature_flags}" == *"webui-v2-beta"* ]]; then
-            echo "needs_webui_node=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "needs_webui_node=false" >> "$GITHUB_OUTPUT"
-          fi
+          needs_webui_node=false
+          sccache_dist_enabled=true
+
+          while IFS= read -r package; do
+            feature_flags="$(scripts/ci/package-feature-flags.sh "$package")"
+            if [[ "${feature_flags}" == *"webui-v2-beta"* ]]; then
+              needs_webui_node=true
+            fi
+
+            case "${package}" in
+              ironclaw_first_party_extension_ports|ironclaw_host_runtime|ironclaw_loop_support|ironclaw_product_workflow|ironclaw_reborn|ironclaw_reborn_cli|ironclaw_reborn_composition|ironclaw_reborn_webui_ingress|ironclaw_wasm|ironclaw_wasm_product_adapters|ironclaw_wasm_sandbox_core)
+                sccache_dist_enabled=false
+                ;;
+            esac
+          done < <(printf '%s\n' "${BUCKET_PACKAGES}" | jq -r '.[]')
+
+          echo "needs_webui_node=${needs_webui_node}" >> "${GITHUB_OUTPUT}"
+          echo "sccache_dist_enabled=${sccache_dist_enabled}" >> "${GITHUB_OUTPUT}"
 
       - name: Install Node.js for WebUI bundle builds
-        if: ${{ steps.crate-feature-flags.outputs.needs_webui_node == 'true' }}
+        if: ${{ steps.bucket-settings.outputs.needs_webui_node == 'true' }}
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
         with:
           node-version: "22"
@@ -238,26 +255,11 @@ jobs:
           # repo cache LRU is seeded by shared states, not arbitrary PR branches.
           save-if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'merge_group' }}
 
-      - name: Resolve distributed sccache eligibility
-        id: sccache-dist-eligibility
-        env:
-          PACKAGE: ${{ matrix.package }}
-        run: |
-          case "${PACKAGE}" in
-            ironclaw_first_party_extension_ports|ironclaw_host_runtime|ironclaw_loop_support|ironclaw_product_workflow|ironclaw_reborn|ironclaw_reborn_cli|ironclaw_reborn_composition|ironclaw_reborn_webui_ingress|ironclaw_wasm|ironclaw_wasm_product_adapters|ironclaw_wasm_sandbox_core)
-              echo "enabled=false" >> "${GITHUB_OUTPUT}"
-              echo "::notice title=Distributed sccache skipped::${PACKAGE} compiles wasmtime-wasi proc macros that read registry source files unavailable on the remote builder."
-              ;;
-            *)
-              echo "enabled=true" >> "${GITHUB_OUTPUT}"
-              ;;
-          esac
-
       - name: Setup OVH sccache
         uses: ./.github/actions/setup-sccache-dist
         with:
-          scheduler-url: ${{ steps.sccache-dist-eligibility.outputs.enabled == 'true' && vars.SCCACHE_DIST_SCHEDULER_URL || '' }}
-          auth-token: ${{ steps.sccache-dist-eligibility.outputs.enabled == 'true' && secrets.SCCACHE_DIST_AUTH_TOKEN || '' }}
+          scheduler-url: ${{ steps.bucket-settings.outputs.sccache_dist_enabled == 'true' && vars.SCCACHE_DIST_SCHEDULER_URL || '' }}
+          auth-token: ${{ steps.bucket-settings.outputs.sccache_dist_enabled == 'true' && secrets.SCCACHE_DIST_AUTH_TOKEN || '' }}
           cache-ssh-host: ${{ vars.SCCACHE_CACHE_SSH_HOST }}
           cache-ssh-user: ${{ vars.SCCACHE_CACHE_SSH_USER }}
           cache-ssh-port: ${{ vars.SCCACHE_CACHE_SSH_PORT }}
@@ -267,18 +269,26 @@ jobs:
 
       - name: Run crate tests
         env:
-          PACKAGE: ${{ matrix.package }}
+          BUCKET_NAME: ${{ matrix.bucket.name }}
+          BUCKET_PACKAGES: ${{ toJSON(matrix.bucket.packages) }}
         run: |
-          feature_flags="${{ steps.crate-feature-flags.outputs.feature_flags }}"
+          echo "Running Reborn crate bucket: ${BUCKET_NAME}"
+          printf '%s\n' "${BUCKET_PACKAGES}" | jq -r '.[] | "- " + .'
 
-          if [ "$PACKAGE" = "ironclaw_reborn_composition" ]; then
-            echo "Disabling incremental compilation for ironclaw_reborn_composition to keep runner disk usage bounded."
-            export CARGO_INCREMENTAL=0
-          fi
+          while IFS= read -r package; do
+            feature_flags="$(scripts/ci/package-feature-flags.sh "$package")"
+            echo "::group::cargo test -p ${package} ${feature_flags}"
 
-          # shellcheck disable=SC2086 # feature_flags intentionally expands to zero or more Cargo args.
-          timeout --signal=INT --kill-after=30s 28m \
-            cargo test -p "$PACKAGE" ${feature_flags} --all-targets -- --nocapture
+            if [ "$package" = "ironclaw_reborn_composition" ]; then
+              echo "Disabling incremental compilation for ironclaw_reborn_composition to keep runner disk usage bounded."
+              export CARGO_INCREMENTAL=0
+            fi
+
+            # shellcheck disable=SC2086 # feature_flags intentionally expands to zero or more Cargo args.
+            timeout --signal=INT --kill-after=30s 28m \
+              cargo test -p "$package" ${feature_flags} --all-targets -- --nocapture
+            echo "::endgroup::"
+          done < <(printf '%s\n' "${BUCKET_PACKAGES}" | jq -r '.[]')
 
   root-reborn-parity-tests:
     name: Reborn root tests (${{ matrix.partition }})

--- a/scripts/ci/reborn-crate-test-buckets.sh
+++ b/scripts/ci/reborn-crate-test-buckets.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: $0 <packages-json-array>" >&2
+  exit 2
+fi
+
+packages_json="$1"
+
+if ! jq -e 'type == "array" and all(.[]?; type == "string")' >/dev/null 2>&1 <<< "${packages_json}"; then
+  echo "error: input must be a JSON array of package-name strings" >&2
+  exit 1
+fi
+
+jq -c -n --argjson packages "${packages_json}" '
+  def bucket_order: [
+    "host-runtime",
+    "agent-runtime",
+    "reborn-core",
+    "composition-core",
+    "product-workflow",
+    "webui-ingress",
+    "wasm-sandbox",
+    "llm-mcp",
+    "events-conversations",
+    "auth-security",
+    "memory-skills",
+    "adapters-misc"
+  ];
+
+  def bucket_map:
+    {
+      ironclaw_host_runtime: "host-runtime",
+
+      ironclaw_agent_loop: "agent-runtime",
+      ironclaw_approvals: "agent-runtime",
+      ironclaw_capabilities: "agent-runtime",
+      ironclaw_dispatcher: "agent-runtime",
+      ironclaw_host_api: "agent-runtime",
+      ironclaw_loop_support: "agent-runtime",
+
+      ironclaw_reborn: "reborn-core",
+      ironclaw_reborn_cli: "reborn-core",
+      ironclaw_reborn_config: "reborn-core",
+      ironclaw_reborn_event_store: "reborn-core",
+      ironclaw_reborn_identity: "reborn-core",
+      ironclaw_reborn_openai_compat: "reborn-core",
+
+      ironclaw_reborn_composition: "composition-core",
+
+      ironclaw_product_adapter_registry: "product-workflow",
+      ironclaw_product_adapters: "product-workflow",
+      ironclaw_product_context: "product-workflow",
+      ironclaw_product_workflow: "product-workflow",
+
+      ironclaw_attachments: "webui-ingress",
+      ironclaw_projects: "webui-ingress",
+      ironclaw_reborn_webui_ingress: "webui-ingress",
+      ironclaw_resources: "webui-ingress",
+      ironclaw_webui_v2: "webui-ingress",
+
+      ironclaw_first_party_extension_ports: "wasm-sandbox",
+      ironclaw_first_party_extensions: "wasm-sandbox",
+      ironclaw_wasm: "wasm-sandbox",
+      ironclaw_wasm_limiter: "wasm-sandbox",
+      ironclaw_wasm_product_adapters: "wasm-sandbox",
+      ironclaw_wasm_sandbox_core: "wasm-sandbox",
+
+      ironclaw_filesystem: "llm-mcp",
+      ironclaw_llm: "llm-mcp",
+      ironclaw_mcp: "llm-mcp",
+      ironclaw_network: "llm-mcp",
+      ironclaw_outbound: "llm-mcp",
+      ironclaw_process_sandbox: "llm-mcp",
+      ironclaw_processes: "llm-mcp",
+
+      ironclaw_conversations: "events-conversations",
+      ironclaw_event_projections: "events-conversations",
+      ironclaw_event_streams: "events-conversations",
+      ironclaw_events: "events-conversations",
+      ironclaw_prompt_envelope: "events-conversations",
+      ironclaw_run_state: "events-conversations",
+      ironclaw_threads: "events-conversations",
+      ironclaw_turns: "events-conversations",
+
+      ironclaw_auth: "auth-security",
+      ironclaw_authorization: "auth-security",
+      ironclaw_hooks: "auth-security",
+      ironclaw_runtime_policy: "auth-security",
+      ironclaw_safety: "auth-security",
+      ironclaw_secrets: "auth-security",
+      ironclaw_trust: "auth-security",
+
+      ironclaw_extractors: "memory-skills",
+      ironclaw_memory: "memory-skills",
+      ironclaw_memory_native: "memory-skills",
+      ironclaw_observability: "memory-skills",
+      ironclaw_scripts: "memory-skills",
+      ironclaw_skill_learning: "memory-skills",
+      ironclaw_skills: "memory-skills",
+
+      ironclaw_architecture: "adapters-misc",
+      ironclaw_common: "adapters-misc",
+      ironclaw_extensions: "adapters-misc",
+      ironclaw_reborn_traces: "adapters-misc",
+      ironclaw_slack_v2_adapter: "adapters-misc",
+      ironclaw_telegram_v2_adapter: "adapters-misc"
+    };
+
+  bucket_map as $bucket_map
+  | [
+    bucket_order[]? as $bucket
+    | {
+        name: $bucket,
+        packages: [
+          $packages[]?
+          | select(($bucket_map[.] // "adapters-misc") == $bucket)
+        ]
+      }
+    | select(.packages | length > 0)
+  ]
+'


### PR DESCRIPTION
## Summary

Benchmark replacing the current one-job-per-Reborn-crate matrix with 12 named crate buckets.

The current workflow discovers 65 Reborn/package-closure crates and runs each package in its own GitHub Actions job. This PR keeps the same package discovery and package-specific feature flags, but runs package tests sequentially inside dependency/family buckets so each bucket pays checkout, Rust install, cache restore, mold install, and target-dir setup once.

## Why

Recent unbucketed Reborn Tests baselines:

- main push run `28711221235`: 15:42:00Z -> 15:51:31Z, about 9m31s.
- PR run `28711504758`: 15:52:23Z -> 16:00:41Z, about 8m18s.
- PR run `28711578881`: 15:55:11Z -> 16:04:55Z, about 9m44s.
- PR run `28708503905`: 13:59:22Z -> 14:08:18Z, about 8m56s.

This benchmark reduces runner fan-out from 65 crate-test jobs to 12 bucket jobs. Wall clock is roughly flat against recent baselines, but runner-slot pressure and aggregate crate-test runner time drop sharply.

## Scope

- Add `scripts/ci/reborn-crate-test-buckets.sh` to map the discovered package list into 12 buckets.
- Change `crate-tests` from `matrix.package` to `matrix.bucket`.
- Preserve existing package coverage by deriving buckets from the same discovered package JSON.
- Preserve per-package feature behavior by calling `scripts/ci/package-feature-flags.sh` for every package in the bucket.
- Preserve the existing Node install behavior for buckets containing webui-enabled packages.
- Preserve the existing distributed sccache safety rule: if a bucket contains any package that was previously ineligible for distributed sccache, the whole bucket disables the distributed scheduler while still keeping the cache setup path.

## Benchmark Result

Final 12-bucket run: `28713081810`, head `1c77234`.

- `Tests (Reborn)` wall clock: 16:51:44Z -> 17:00:53Z, about 9m09s.
- Baseline range from recent unbucketed runs: about 8m18s to 9m44s.
- Wall-clock verdict: flat; not a 50% wall-clock win.
- Crate-test job count: 65 -> 12, about 82% fewer crate-test jobs.
- Aggregate crate-test runner time: 9,167s -> 3,647s, about 60% lower.
- Max crate-test job duration: 484s -> 500s, effectively flat/slightly worse for the heaviest crate bucket, but no bucket exceeds the old full Reborn Tests wall-clock range.

Longest bucket jobs on final run:

- `composition-core`: 500s
- `host-runtime`: 449s
- `webui-ingress`: 390s
- `reborn-core`: 339s
- `adapters-misc`: 323s

## Success Criteria Check

- `Tests (Reborn)` wall clock improves materially versus the current ~8-10m baseline: **not proven**; result is within baseline variance.
- No individual bucket becomes a new long pole worse than the old Reborn Tests roll-up: **passed**.
- Total Reborn crate-test job count drops from ~65 to 12, reducing runner-slot pressure: **passed**.

## Local Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/reborn-tests.yml"); puts "ok reborn-tests"'`
- `/tmp/actionlint .github/workflows/reborn-tests.yml`
- `git diff --check`
- `bash -n scripts/ci/reborn-crate-test-buckets.sh scripts/ci/package-feature-flags.sh`
- Generated buckets locally from the workflow's package-discovery commands and verified 65 input packages map to 65 bucketed packages with no diff.
- Verified invalid helper input fails with a clear error message.

## CI Validation

All PR checks passed on `1c77234`.

Note: `Platform & Compat` initially hit an unrelated hooks/libSQL concurrency failure and passed on rerun. `Reborn Coverage` attempt 1 hung and passed on rerun; coverage is independent of this bucket change.

## Benchmark Notes

- Initial 10-bucket attempt was cancelled: `runtime-host` became the long pole and exceeded the old Reborn roll-up window by itself.
- The final 12-bucket attempt splits `host-runtime` and `agent-runtime`, and splits `composition-core` from `product-workflow`.