### PR TITLE
test(reborn): wiring-parity guard — harness runtime shape vs production local-dev (#5637)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -499,6 +499,10 @@ name = "reborn_integration_web_access"
 path = "tests/integration/web_access.rs"
 
 [[test]]
+name = "reborn_integration_wiring_parity"
+path = "tests/integration/wiring_parity.rs"
+
+[[test]]
 name = "e2e_thread_scheduling"
 required-features = ["libsql", "integration"]
 

--- a/tests/integration/support/builder.rs
+++ b/tests/integration/support/builder.rs
@@ -52,6 +52,7 @@ use super::capability_backend::{MOCK_MCP_PROVIDER_ID, RebornCapabilityBackend, S
 use super::group::{GroupCapability, GroupSharedStorage, RebornIntegrationGroup};
 use super::harness::{HarnessCapabilityRecorder, HarnessTurnBackend, RecordedCapabilityResult};
 use super::http_matcher::ScriptedHttpResponse;
+use super::planned_runtime_parts_shape::DefaultPlannedRuntimePartsShape;
 use super::process::ScriptedProcessResult;
 use super::reply::RebornScriptedReply;
 use super::scripted_provider::ParkingModelGate;
@@ -478,6 +479,14 @@ impl RebornIntegrationHarness {
             communication_context_provider: None,
             hook_dispatcher_builder_factory: None,
         }
+    }
+
+    /// W5-WIRING-PARITY: the Some/None shape of the `DefaultPlannedRuntimeParts`
+    /// literal this (degenerate one-thread group's) planned runtime was
+    /// actually built from, captured at `into_group` construction time. See
+    /// `tests/integration/wiring_parity.rs`.
+    pub fn planned_runtime_parts_shape(&self) -> DefaultPlannedRuntimePartsShape {
+        self._shared.planned_runtime_parts_shape
     }
 
     /// Submit a user turn and wait for it to complete.

--- a/tests/integration/support/extension_surface.rs
+++ b/tests/integration/support/extension_surface.rs
@@ -1,4 +1,20 @@
 //! Static Reborn extension capability surface used by binary-E2E tests.
+//!
+//! **Not production truth.** `EXTENSION_LIFECYCLE_CAPABILITY_IDS` and
+//! `BUNDLED_EXTENSION_CAPABILITY_IDS` below are hand-transcribed test-support
+//! literals — they duplicate (fully or partially) values that live in a
+//! production crate, but are not themselves parsed or imported from one.
+//! `tests/integration/wiring_parity.rs`'s capability-id subset check no
+//! longer unions either constant into its production-surface RHS; see that
+//! file's module doc for why (W5-WIRING-PARITY finding 1). They remain here
+//! for the unrelated QA-smoke scripted-scenario assertions
+//! (`tests/reborn_qa_smoke_scenarios_e2e.rs`) that still use them as fixed
+//! literals to script a harness's own declared surface, not to verify it
+//! against production.
+//!
+//! `bundled_extension_manifest_capability_ids` below IS production truth —
+//! it parses the real `manifest.toml` assets bundled extensions ship with,
+//! the same way `github::capability_ids()` parses github's.
 
 pub const EXTENSION_SEARCH_CAPABILITY_ID: &str = "builtin.extension_search";
 pub const EXTENSION_INSTALL_CAPABILITY_ID: &str = "builtin.extension_install";
@@ -159,3 +175,61 @@ pub const BUNDLED_EXTENSION_CAPABILITY_IDS: &[&str] = &[
     "notion.notion-get-user",
     "notion.notion-get-self",
 ];
+
+/// Bundled first-party extension asset directories under
+/// `crates/ironclaw_first_party_extensions/assets/`, parsed by
+/// [`bundled_extension_manifest_capability_ids`]. Excludes `github` (parsed
+/// separately by `github::capability_ids()`, which this list intentionally
+/// does not duplicate) and `slack` (not yet a modeled bundled extension in
+/// this harness).
+const BUNDLED_EXTENSION_MANIFEST_ASSET_DIRS: &[&str] = &[
+    "web-access",
+    "gmail",
+    "google-calendar",
+    "google-docs",
+    "google-sheets",
+    "google-drive",
+    "google-slides",
+    "nearai-mcp",
+    "notion-mcp",
+];
+
+/// Real capability ids declared by every non-github bundled first-party
+/// extension's production `manifest.toml` asset — parsed the same way
+/// `github::capability_ids()` parses github's
+/// (`ExtensionManifest::parse_with_host_api_contracts` over the actual
+/// shipped asset file), so this is production truth, not a second
+/// hand-transcribed test-only id list like `BUNDLED_EXTENSION_CAPABILITY_IDS`
+/// above.
+pub fn bundled_extension_manifest_capability_ids()
+-> Result<Vec<ironclaw_host_api::CapabilityId>, Box<dyn std::error::Error + Send + Sync>> {
+    let mut registry = ironclaw_extensions::ExtensionRegistry::new();
+    for dir_name in BUNDLED_EXTENSION_MANIFEST_ASSET_DIRS {
+        let asset_root = repo_root()
+            .join("crates/ironclaw_first_party_extensions/assets")
+            .join(dir_name);
+        let manifest = ironclaw_extensions::ExtensionManifest::parse_with_host_api_contracts(
+            &std::fs::read_to_string(asset_root.join("manifest.toml"))?,
+            ironclaw_extensions::ManifestSource::HostBundled,
+            &ironclaw_host_runtime::default_host_port_catalog()?,
+            &ironclaw_host_runtime::default_host_api_contract_registry()?,
+        )?;
+        // The manifest's OWN `id` (not the asset directory name) must match
+        // the `ExtensionPackage` root's last segment — they differ for
+        // `nearai-mcp`/`notion-mcp` (manifest id `nearai`/`notion`).
+        let extension_id = manifest.id.as_str().to_string();
+        let package = ironclaw_extensions::ExtensionPackage::from_manifest(
+            manifest,
+            ironclaw_host_api::VirtualPath::new(format!("/system/extensions/{extension_id}"))?,
+        )?;
+        registry.insert(package)?;
+    }
+    Ok(registry
+        .capabilities()
+        .map(|descriptor| descriptor.id.clone())
+        .collect())
+}
+
+fn repo_root() -> &'static std::path::Path {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+}

--- a/tests/integration/support/group.rs
+++ b/tests/integration/support/group.rs
@@ -108,6 +108,9 @@ use super::harness::{
     HarnessTurnBackend, HostRuntimeCapabilityHarness, RecordingTestCapabilityPort,
     test_product_scope,
 };
+use super::planned_runtime_parts_shape::{
+    DefaultPlannedRuntimePartsShape, harness_planned_runtime_parts_shape,
+};
 use super::product_workflow::RebornProductWorkflowHarness;
 use super::reply::RebornScriptedReply;
 use super::scope_gateway::ScopeRegistryGateway;
@@ -210,6 +213,12 @@ pub(crate) struct GroupSharedStorage {
     /// reads the SAME account the loop's accountant seeds. `None` unless
     /// budget accounting is wired.
     pub(crate) budget_account: Option<ResourceAccount>,
+    /// W5-WIRING-PARITY: the Some/None shape of the `DefaultPlannedRuntimeParts`
+    /// literal this group's ONE planned runtime was actually built from,
+    /// captured at construction (before `build_default_planned_runtime`
+    /// consumes the struct by value) so a parity test can read back the
+    /// harness's REAL wiring shape, not a re-derived approximation.
+    pub(crate) planned_runtime_parts_shape: DefaultPlannedRuntimePartsShape,
 }
 
 impl GroupSharedStorage {
@@ -365,6 +374,14 @@ impl RebornIntegrationGroup {
             GroupCapability::HostRuntime(arc) => Some(arc),
             GroupCapability::Recording => None,
         }
+    }
+
+    /// W5-WIRING-PARITY: the Some/None shape of the `DefaultPlannedRuntimeParts`
+    /// literal this group's ONE planned runtime was actually built from
+    /// (`into_group`), captured at construction time before the struct was
+    /// consumed. See `tests/integration/wiring_parity.rs`.
+    pub fn planned_runtime_parts_shape(&self) -> DefaultPlannedRuntimePartsShape {
+        self.shared.planned_runtime_parts_shape
     }
 
     /// C-MULTIUSER: grant global always-allow (auto-approve) for a SPECIFIC run
@@ -644,7 +661,12 @@ impl RebornIntegrationGroupBuilder {
             (None, None, None)
         };
 
-        let composition = build_default_planned_runtime(DefaultPlannedRuntimeParts {
+        // W5-WIRING-PARITY: bind the literal to a local before consuming it so
+        // `harness_planned_runtime_parts_shape` can read the REAL Some/None
+        // shape this group's runtime is built from — the only place this
+        // struct value exists before `build_default_planned_runtime` takes it
+        // by value.
+        let parts = DefaultPlannedRuntimeParts {
             turn_state: turn_state_for_runtime,
             thread_service: group_thread_harness.service.clone() as Arc<dyn SessionThreadService>,
             thread_scope: group_thread_scope,
@@ -710,7 +732,9 @@ impl RebornIntegrationGroupBuilder {
                 .attachment_test_support()
                 .map(|support| support.read_port),
             scheduler_wake_wiring: None,
-        })?;
+        };
+        let planned_runtime_parts_shape = harness_planned_runtime_parts_shape(&parts);
+        let composition = build_default_planned_runtime(parts)?;
 
         Ok(RebornIntegrationGroup {
             shared: Arc::new(GroupSharedStorage {
@@ -728,6 +752,7 @@ impl RebornIntegrationGroupBuilder {
                 turn_event_sink: self.turn_event_sink,
                 budget_governor,
                 budget_account,
+                planned_runtime_parts_shape,
             }),
         })
     }

--- a/tests/integration/support/group.rs
+++ b/tests/integration/support/group.rs
@@ -723,6 +723,8 @@ impl RebornIntegrationGroupBuilder {
             // C-COMMCTX: delivery-preference / connected-channel provider (Some
             // only when `communication_context_provider()` was set).
             communication_context_provider: self.communication_context_provider,
+            // No RecordingSecurityAuditSink double exists yet (nearai/ironclaw#5640);
+            // wiring_parity.rs's ALLOWED_DIVERGENCES tracks this field by name, not line.
             hook_security_audit_sink: None,
             turn_event_sink: self
                 .turn_event_sink

--- a/tests/integration/support/harness/profiles/core_builtin.rs
+++ b/tests/integration/support/harness/profiles/core_builtin.rs
@@ -141,6 +141,30 @@ pub(crate) async fn core_builtin_tools_default() -> HarnessResult<HostRuntimeCap
     core_builtin_tools(CoreBuiltinOptions::default()).await
 }
 
+/// Real capability ids `core_builtin_tools_from_runtime` registers on the
+/// built harness — a single source shared with the wiring-parity
+/// capability-id subset check (`tests/integration/wiring_parity.rs`) instead
+/// of a second hand-transcribed copy of this list.
+pub(crate) fn core_builtin_tools_capability_ids() -> HarnessResult<Vec<CapabilityId>> {
+    Ok(vec![
+        CapabilityId::new(TIME_CAPABILITY_ID)?,
+        CapabilityId::new(JSON_CAPABILITY_ID)?,
+        CapabilityId::new(HTTP_CAPABILITY_ID)?,
+        CapabilityId::new(HTTP_SAVE_CAPABILITY_ID)?,
+        CapabilityId::new(MEMORY_SEARCH_CAPABILITY_ID)?,
+        CapabilityId::new(MEMORY_WRITE_CAPABILITY_ID)?,
+        CapabilityId::new(MEMORY_READ_CAPABILITY_ID)?,
+        CapabilityId::new(MEMORY_TREE_CAPABILITY_ID)?,
+        CapabilityId::new(PROFILE_SET_CAPABILITY_ID)?,
+        CapabilityId::new(READ_FILE_CAPABILITY_ID)?,
+        CapabilityId::new(APPLY_PATCH_CAPABILITY_ID)?,
+        // `builtin.shell` on the surface so scripted shell calls route
+        // through the process port (recording by default, live via
+        // `.with_live_shell()`).
+        CapabilityId::new(SHELL_CAPABILITY_ID)?,
+    ])
+}
+
 fn core_builtin_tools_from_runtime(
     root: Arc<tempfile::TempDir>,
     workspace_root: PathBuf,
@@ -174,23 +198,7 @@ fn core_builtin_tools_from_runtime(
             .cloned()
             .map(|capability_id| (capability_id, memory_mounts.clone()))
             .collect(),
-        capability_ids: vec![
-            CapabilityId::new(TIME_CAPABILITY_ID)?,
-            CapabilityId::new(JSON_CAPABILITY_ID)?,
-            CapabilityId::new(HTTP_CAPABILITY_ID)?,
-            CapabilityId::new(HTTP_SAVE_CAPABILITY_ID)?,
-            CapabilityId::new(MEMORY_SEARCH_CAPABILITY_ID)?,
-            CapabilityId::new(MEMORY_WRITE_CAPABILITY_ID)?,
-            CapabilityId::new(MEMORY_READ_CAPABILITY_ID)?,
-            CapabilityId::new(MEMORY_TREE_CAPABILITY_ID)?,
-            CapabilityId::new(PROFILE_SET_CAPABILITY_ID)?,
-            CapabilityId::new(READ_FILE_CAPABILITY_ID)?,
-            CapabilityId::new(APPLY_PATCH_CAPABILITY_ID)?,
-            // `builtin.shell` on the surface so scripted shell calls route
-            // through the process port (recording by default, live via
-            // `.with_live_shell()`).
-            CapabilityId::new(SHELL_CAPABILITY_ID)?,
-        ],
+        capability_ids: core_builtin_tools_capability_ids()?,
         runtime_kind: RuntimeKind::FirstParty,
         effect_kinds: vec![
             EffectKind::DispatchCapability,

--- a/tests/integration/support/harness/profiles/qa_smoke.rs
+++ b/tests/integration/support/harness/profiles/qa_smoke.rs
@@ -28,6 +28,40 @@ use super::super::{
     memory_mounts, qa_smoke_mounts,
 };
 
+/// Real capability ids `qa_smoke_tools` registers on the built harness — a
+/// single source shared with the wiring-parity capability-id subset check
+/// (`tests/integration/wiring_parity.rs`) instead of a second
+/// hand-transcribed copy of this list.
+pub(crate) fn qa_smoke_tools_capability_ids() -> HarnessResult<Vec<CapabilityId>> {
+    Ok(vec![
+        CapabilityId::new(ECHO_CAPABILITY_ID)?,
+        CapabilityId::new(TIME_CAPABILITY_ID)?,
+        CapabilityId::new(JSON_CAPABILITY_ID)?,
+        CapabilityId::new(HTTP_CAPABILITY_ID)?,
+        CapabilityId::new(HTTP_SAVE_CAPABILITY_ID)?,
+        CapabilityId::new(MEMORY_SEARCH_CAPABILITY_ID)?,
+        CapabilityId::new(MEMORY_WRITE_CAPABILITY_ID)?,
+        CapabilityId::new(MEMORY_READ_CAPABILITY_ID)?,
+        CapabilityId::new(MEMORY_TREE_CAPABILITY_ID)?,
+        CapabilityId::new(READ_FILE_CAPABILITY_ID)?,
+        CapabilityId::new(WRITE_FILE_CAPABILITY_ID)?,
+        CapabilityId::new(LIST_DIR_CAPABILITY_ID)?,
+        CapabilityId::new(GLOB_CAPABILITY_ID)?,
+        CapabilityId::new(GREP_CAPABILITY_ID)?,
+        CapabilityId::new(APPLY_PATCH_CAPABILITY_ID)?,
+        CapabilityId::new(SHELL_CAPABILITY_ID)?,
+        CapabilityId::new(SPAWN_SUBAGENT_CAPABILITY_ID)?,
+        CapabilityId::new(SKILL_LIST_CAPABILITY_ID)?,
+        CapabilityId::new(SKILL_INSTALL_CAPABILITY_ID)?,
+        CapabilityId::new(SKILL_REMOVE_CAPABILITY_ID)?,
+        CapabilityId::new(TRIGGER_CREATE_CAPABILITY_ID)?,
+        CapabilityId::new(TRIGGER_LIST_CAPABILITY_ID)?,
+        CapabilityId::new(TRIGGER_PAUSE_CAPABILITY_ID)?,
+        CapabilityId::new(TRIGGER_RESUME_CAPABILITY_ID)?,
+        CapabilityId::new(TRIGGER_REMOVE_CAPABILITY_ID)?,
+    ])
+}
+
 pub(crate) async fn qa_smoke_tools() -> HarnessResult<HostRuntimeCapabilityHarness> {
     let (root, storage_root, workspace_root) = host_runtime_storage_roots()?;
     std::fs::create_dir_all(storage_root.join("skills"))?;
@@ -63,33 +97,7 @@ pub(crate) async fn qa_smoke_tools() -> HarnessResult<HostRuntimeCapabilityHarne
             .cloned()
             .map(|capability_id| (capability_id, memory_mounts.clone()))
             .collect(),
-        capability_ids: vec![
-            CapabilityId::new(ECHO_CAPABILITY_ID)?,
-            CapabilityId::new(TIME_CAPABILITY_ID)?,
-            CapabilityId::new(JSON_CAPABILITY_ID)?,
-            CapabilityId::new(HTTP_CAPABILITY_ID)?,
-            CapabilityId::new(HTTP_SAVE_CAPABILITY_ID)?,
-            CapabilityId::new(MEMORY_SEARCH_CAPABILITY_ID)?,
-            CapabilityId::new(MEMORY_WRITE_CAPABILITY_ID)?,
-            CapabilityId::new(MEMORY_READ_CAPABILITY_ID)?,
-            CapabilityId::new(MEMORY_TREE_CAPABILITY_ID)?,
-            CapabilityId::new(READ_FILE_CAPABILITY_ID)?,
-            CapabilityId::new(WRITE_FILE_CAPABILITY_ID)?,
-            CapabilityId::new(LIST_DIR_CAPABILITY_ID)?,
-            CapabilityId::new(GLOB_CAPABILITY_ID)?,
-            CapabilityId::new(GREP_CAPABILITY_ID)?,
-            CapabilityId::new(APPLY_PATCH_CAPABILITY_ID)?,
-            CapabilityId::new(SHELL_CAPABILITY_ID)?,
-            CapabilityId::new(SPAWN_SUBAGENT_CAPABILITY_ID)?,
-            CapabilityId::new(SKILL_LIST_CAPABILITY_ID)?,
-            CapabilityId::new(SKILL_INSTALL_CAPABILITY_ID)?,
-            CapabilityId::new(SKILL_REMOVE_CAPABILITY_ID)?,
-            CapabilityId::new(TRIGGER_CREATE_CAPABILITY_ID)?,
-            CapabilityId::new(TRIGGER_LIST_CAPABILITY_ID)?,
-            CapabilityId::new(TRIGGER_PAUSE_CAPABILITY_ID)?,
-            CapabilityId::new(TRIGGER_RESUME_CAPABILITY_ID)?,
-            CapabilityId::new(TRIGGER_REMOVE_CAPABILITY_ID)?,
-        ],
+        capability_ids: qa_smoke_tools_capability_ids()?,
         runtime_kind: RuntimeKind::FirstParty,
         effect_kinds: vec![
             EffectKind::DispatchCapability,

--- a/tests/integration/support/harness/profiles/web_access.rs
+++ b/tests/integration/support/harness/profiles/web_access.rs
@@ -16,6 +16,17 @@ use super::super::{
     host_runtime_storage_roots, workspace_mounts,
 };
 
+/// Real capability ids `web_access_tools` registers on the built harness —
+/// a single source shared with the wiring-parity capability-id subset check
+/// (`tests/integration/wiring_parity.rs`) instead of a second
+/// hand-transcribed copy of this list.
+pub(crate) fn web_access_tools_capability_ids() -> HarnessResult<Vec<CapabilityId>> {
+    Ok(vec![
+        CapabilityId::new(WEB_SEARCH_CAPABILITY_ID)?,
+        CapabilityId::new(WEB_GET_CONTENT_CAPABILITY_ID)?,
+    ])
+}
+
 /// C-WEBACCESS: wires the real first-party web-access capabilities through production's
 /// `WebAccessExecutor`; no credential-injecting authorizer needed (declares zero `runtime_credentials`).
 ///
@@ -44,10 +55,7 @@ pub(crate) async fn web_access_tools() -> HarnessResult<HostRuntimeCapabilityHar
         workspace_root,
         mounts,
         capability_mount_overrides: Vec::new(),
-        capability_ids: vec![
-            CapabilityId::new(WEB_SEARCH_CAPABILITY_ID)?,
-            CapabilityId::new(WEB_GET_CONTENT_CAPABILITY_ID)?,
-        ],
+        capability_ids: web_access_tools_capability_ids()?,
         runtime_kind: RuntimeKind::FirstParty,
         effect_kinds: vec![EffectKind::DispatchCapability, EffectKind::Network],
         network_policy: harness_web_access::exa_mcp_test_network_policy(),

--- a/tests/integration/support/mod.rs
+++ b/tests/integration/support/mod.rs
@@ -16,6 +16,7 @@ pub mod hooks;
 pub mod http_matcher;
 pub mod oauth_flow;
 pub mod outbound_preferences;
+pub mod planned_runtime_parts_shape;
 pub mod process;
 pub mod product_workflow;
 pub mod project_service_fault;

--- a/tests/integration/support/planned_runtime_parts_shape.rs
+++ b/tests/integration/support/planned_runtime_parts_shape.rs
@@ -1,0 +1,103 @@
+//! W5-WIRING-PARITY: test-tree-only Some/None shape extraction for
+//! `DefaultPlannedRuntimeParts`.
+//!
+//! Lives in the shared support tree (not `tests/integration/wiring_parity.rs`
+//! itself) because the exhaustive destructure must run at the harness's OWN
+//! construction site (`group.rs`'s `into_group`, right after the struct
+//! literal is bound to `parts` and before `build_default_planned_runtime`
+//! consumes it by value) — that is the only place the full, real value
+//! exists. `wiring_parity.rs` only reads the already-computed shape back off
+//! `GroupSharedStorage`/`RebornIntegrationHarness`.
+//!
+//! Zero production-crate changes: `DefaultPlannedRuntimeParts` is already
+//! `pub` with `pub` fields and no `#[non_exhaustive]`
+//! (`crates/ironclaw_reborn/src/runtime.rs:260-326`), so this file only reads
+//! it from test-tree code.
+
+use ironclaw_loop_support::HostManagedModelGateway;
+use ironclaw_reborn::runtime::DefaultPlannedRuntimeParts;
+
+/// Some/None shape of `DefaultPlannedRuntimeParts`'s 13 `Option`-typed
+/// fields. Field VALUES are out of scope by design (see
+/// `tests/integration/wiring_parity.rs`'s module doc) — only whether each
+/// optional wiring seam is populated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DefaultPlannedRuntimePartsShape {
+    pub model_route_resolver: bool,
+    pub cancellation_factory: bool,
+    pub skill_context_source: bool,
+    pub attachment_read_port: bool,
+    pub input_queue: bool,
+    pub model_policy_guard: bool,
+    pub model_budget_accountant: bool,
+    pub safety_context: bool,
+    pub hook_security_audit_sink: bool,
+    pub turn_event_sink: bool,
+    pub hook_dispatcher_builder_factory: bool,
+    pub communication_context_provider: bool,
+    pub scheduler_wake_wiring: bool,
+}
+
+/// Exhaustive, no-`..` destructure of `parts` into its Option-field shape.
+///
+/// Every one of the 32 fields is named explicitly here (the 19 required
+/// fields bound to `_`), so this function FAILS TO COMPILE the moment a
+/// field is added to or removed from `DefaultPlannedRuntimeParts` — the
+/// tripwire `wiring_parity.rs` relies on. Match ergonomics on `&parts` bind
+/// every field by reference, so nothing is moved out of the caller's value.
+pub fn harness_planned_runtime_parts_shape<G>(
+    parts: &DefaultPlannedRuntimeParts<G>,
+) -> DefaultPlannedRuntimePartsShape
+where
+    G: HostManagedModelGateway + ?Sized + Send + Sync + 'static,
+{
+    let DefaultPlannedRuntimeParts {
+        turn_state: _,
+        thread_service: _,
+        thread_scope: _,
+        model_gateway: _,
+        checkpoint_state_store: _,
+        loop_checkpoint_store: _,
+        milestone_sink: _,
+        capability_factory: _,
+        capability_surface_resolver: _,
+        capability_result_writer: _,
+        subagent_goal_store: _,
+        subagent_gate_store: _,
+        subagent_definition_resolver: _,
+        subagent_spawn_input_codec: _,
+        subagent_spawn_limits: _,
+        loop_exit_evidence: _,
+        config: _,
+        model_route_resolver,
+        cancellation_factory,
+        skill_context_source,
+        attachment_read_port,
+        input_queue,
+        identity_context_source: _,
+        user_profile_source: _,
+        model_policy_guard,
+        model_budget_accountant,
+        safety_context,
+        hook_security_audit_sink,
+        turn_event_sink,
+        hook_dispatcher_builder_factory,
+        communication_context_provider,
+        scheduler_wake_wiring,
+    } = parts;
+    DefaultPlannedRuntimePartsShape {
+        model_route_resolver: model_route_resolver.is_some(),
+        cancellation_factory: cancellation_factory.is_some(),
+        skill_context_source: skill_context_source.is_some(),
+        attachment_read_port: attachment_read_port.is_some(),
+        input_queue: input_queue.is_some(),
+        model_policy_guard: model_policy_guard.is_some(),
+        model_budget_accountant: model_budget_accountant.is_some(),
+        safety_context: safety_context.is_some(),
+        hook_security_audit_sink: hook_security_audit_sink.is_some(),
+        turn_event_sink: turn_event_sink.is_some(),
+        hook_dispatcher_builder_factory: hook_dispatcher_builder_factory.is_some(),
+        communication_context_provider: communication_context_provider.is_some(),
+        scheduler_wake_wiring: scheduler_wake_wiring.is_some(),
+    }
+}

--- a/tests/integration/wiring_parity.rs
+++ b/tests/integration/wiring_parity.rs
@@ -1,0 +1,484 @@
+//! W5-WIRING-PARITY (issue #5637): the harness's `DefaultPlannedRuntimeParts`
+//! construction (`support/group.rs`'s `into_group`) stays field-Some/None-
+//! identical to production's local-dev construction
+//! (`ironclaw_reborn_composition::runtime::build_reborn_runtime`), modulo a
+//! named allowlist of deliberate test-double substitutions — so a new
+//! port/field lands loud instead of silently drifting. Zero production-crate
+//! edits: the mechanism is entirely test-side.
+//!
+//! **Scope, by design**: this compares Some/None SHAPE only, never field
+//! VALUES; only the local-dev/local-dev-yolo production profile (never
+//! `Production`/`HostedSingleTenant*`); never `DefaultPlannedRuntimeConfig`'s
+//! inner fields. Known accepted gap: it also cannot detect a silent
+//! value-preserving rewiring of an *existing* field in production — only
+//! added/removed fields and harness regressions on already-tracked fields.
+//!
+//! A companion, unrelated check lives in the same file: every
+//! `harness/profiles/*.rs` domain's `capability_ids` is a subset of
+//! production's real capability surface (`builtin_first_party_package()` +
+//! the extension/github id lists), modulo a skip-list of deliberately
+//! synthetic local-dev-only ids.
+
+#[allow(dead_code)]
+#[path = "support/mod.rs"]
+mod reborn_support;
+#[allow(dead_code)]
+#[path = "../support/mod.rs"]
+mod support;
+
+use std::collections::HashSet;
+
+use reborn_support::builder::RebornIntegrationHarness;
+use reborn_support::group::RebornIntegrationGroup;
+use reborn_support::planned_runtime_parts_shape::DefaultPlannedRuntimePartsShape;
+
+// ---------------------------------------------------------------------------
+// Part 1: DefaultPlannedRuntimeParts Some/None shape parity
+// ---------------------------------------------------------------------------
+
+/// Hand-derived from `crates/ironclaw_reborn_composition/src/runtime.rs`
+/// lines 3365-3459 (`build_reborn_runtime`, `LocalDev`/`LocalDevYolo`
+/// profile, `local_runtime: Some(..)`). NOT computed from running code —
+/// RE-DERIVE by re-reading that literal whenever it changes. (Verified
+/// against this range 2026-07-04.) The smoke build below at least proves the
+/// referenced literal still exists and the profile still builds.
+const EXPECTED_PRODUCTION_SHAPE: DefaultPlannedRuntimePartsShape =
+    DefaultPlannedRuntimePartsShape {
+        model_route_resolver: false,            // :3406 hardcoded None
+        cancellation_factory: false,            // :3407 hardcoded None
+        skill_context_source: true, // :2917-2929 local_dev_filesystem_skill_context_source
+        attachment_read_port: true, // :3372-3376 local_runtime.map(ProjectScopedAttachmentReader)
+        input_queue: false,         // hardcoded None
+        model_policy_guard: false,  // hardcoded None
+        model_budget_accountant: false, // :3027-3073 None absent a resolved LLM cost table
+        safety_context: false,      // hardcoded None
+        hook_security_audit_sink: true, // :3452 always Some(TracingSecurityAuditSink)
+        turn_event_sink: true,      // :3453 always Some(turn_event_sink)
+        hook_dispatcher_builder_factory: false, // :3230-3258 None, HooksActivationConfig defaults OFF
+        communication_context_provider: true,   // :3337-3357 Some whenever local_runtime present
+        scheduler_wake_wiring: false, // :2847-2857 None outside Production/MigrationDryRun
+    };
+
+/// Deliberate test-double substitutions: `(field, reason)`. Every other field
+/// must match `EXPECTED_PRODUCTION_SHAPE` exactly, or the parity assertion
+/// fails naming the field. Re-derived by reading both `group.rs`'s
+/// `into_group` (harness) and `runtime.rs`'s `build_reborn_runtime`
+/// (production) literals in full.
+const ALLOWED_DIVERGENCES: &[(&str, &str)] = &[
+    (
+        "skill_context_source",
+        "harness: None outside skill_activation_tools() groups (recorder.rs:56-63); \
+         production: always Some via local_dev_filesystem_skill_context_source (runtime.rs:2917-2929)",
+    ),
+    (
+        "attachment_read_port",
+        "harness: None outside attachment_tools() groups (recorder.rs:67-74); \
+         production: always Some via local_runtime.map(ProjectScopedAttachmentReader) (runtime.rs:3372-3376)",
+    ),
+    (
+        "turn_event_sink",
+        "harness: None unless .with_turn_event_sink() was called (group.rs); \
+         production: always Some, no config gate (runtime.rs:3453)",
+    ),
+    (
+        "communication_context_provider",
+        "harness: None unless .communication_context_provider() was called (group.rs); \
+         production: always Some whenever local_runtime is present (runtime.rs:3337-3357)",
+    ),
+    (
+        "hook_security_audit_sink",
+        "harness: always None (group.rs:704) — no RecordingSecurityAuditSink double exists \
+         yet (standing gap, tracked by nearai/ironclaw#5640, not a substitution); \
+         production: always Some(TracingSecurityAuditSink) (runtime.rs:3452)",
+    ),
+];
+
+/// Overwrite `field` on `shape` with `from`'s value for that SAME field — an
+/// exhaustive match on real struct-field assignments (not a string
+/// comparison), so a field rename/removal makes the corresponding arm fail to
+/// compile instead of letting a stale allowlist entry silently survive.
+fn mask(
+    mut shape: DefaultPlannedRuntimePartsShape,
+    field: &str,
+    from: DefaultPlannedRuntimePartsShape,
+) -> DefaultPlannedRuntimePartsShape {
+    match field {
+        "model_route_resolver" => shape.model_route_resolver = from.model_route_resolver,
+        "cancellation_factory" => shape.cancellation_factory = from.cancellation_factory,
+        "skill_context_source" => shape.skill_context_source = from.skill_context_source,
+        "attachment_read_port" => shape.attachment_read_port = from.attachment_read_port,
+        "input_queue" => shape.input_queue = from.input_queue,
+        "model_policy_guard" => shape.model_policy_guard = from.model_policy_guard,
+        "model_budget_accountant" => shape.model_budget_accountant = from.model_budget_accountant,
+        "safety_context" => shape.safety_context = from.safety_context,
+        "hook_security_audit_sink" => {
+            shape.hook_security_audit_sink = from.hook_security_audit_sink
+        }
+        "turn_event_sink" => shape.turn_event_sink = from.turn_event_sink,
+        "hook_dispatcher_builder_factory" => {
+            shape.hook_dispatcher_builder_factory = from.hook_dispatcher_builder_factory
+        }
+        "communication_context_provider" => {
+            shape.communication_context_provider = from.communication_context_provider
+        }
+        "scheduler_wake_wiring" => shape.scheduler_wake_wiring = from.scheduler_wake_wiring,
+        other => panic!(
+            "ALLOWED_DIVERGENCES references unknown field {other:?} — update this match and \
+             DefaultPlannedRuntimePartsShape together"
+        ),
+    }
+    shape
+}
+
+/// Apply every `ALLOWED_DIVERGENCES` row to `harness_shape`, then assert the
+/// masked result matches `EXPECTED_PRODUCTION_SHAPE` exactly. Any un-allowed
+/// field that still differs fails `assert_eq!` with a real `Debug` diff
+/// naming the field.
+fn assert_planned_runtime_parts_shape_parity(
+    harness_shape: DefaultPlannedRuntimePartsShape,
+    context: &str,
+) {
+    let mut masked = harness_shape;
+    for (field, _reason) in ALLOWED_DIVERGENCES {
+        masked = mask(masked, field, EXPECTED_PRODUCTION_SHAPE);
+    }
+    assert_eq!(
+        masked, EXPECTED_PRODUCTION_SHAPE,
+        "{context}: DefaultPlannedRuntimeParts Some/None shape diverges from production's \
+         local-dev build outside ALLOWED_DIVERGENCES — either wire the field to match \
+         production, or add a named allowlist row with a reason"
+    );
+}
+
+#[tokio::test]
+async fn test_default_planned_runtime_parts_shape_matches_production() {
+    let harness = RebornIntegrationHarness::test_default()
+        .build()
+        .await
+        .expect("test_default() harness builds");
+    assert_planned_runtime_parts_shape_parity(
+        harness.planned_runtime_parts_shape(),
+        "RebornIntegrationHarness::test_default()",
+    );
+}
+
+#[tokio::test]
+async fn builtin_tools_planned_runtime_parts_shape_matches_production() {
+    let group = RebornIntegrationGroup::builtin_tools()
+        .await
+        .expect("builtin_tools() group builds");
+    assert_planned_runtime_parts_shape_parity(
+        group.planned_runtime_parts_shape(),
+        "RebornIntegrationGroup::builtin_tools()",
+    );
+}
+
+/// Smoke build backing `EXPECTED_PRODUCTION_SHAPE`'s doc comment: proves the
+/// referenced `LocalDev` literal still exists and the profile still builds.
+/// Mirrors `crates/ironclaw_reborn_composition/tests/runtime.rs:132-146`. The
+/// constant's `bool` values still come from the hand-read above, NOT from
+/// introspecting this built `RebornRuntime` (there is no production-side
+/// accessor to do so without a production-crate change — the known accepted
+/// gap noted in the module doc).
+#[tokio::test]
+async fn local_dev_profile_still_builds() {
+    let root = tempfile::tempdir().expect("tempdir");
+    let policy = ironclaw_reborn_composition::local_dev_runtime_policy()
+        .expect("local-dev runtime policy resolves");
+    let input = ironclaw_reborn_composition::RebornBuildInput::local_dev(
+        "wiring-parity-smoke-owner",
+        root.path().join("local-dev"),
+    )
+    .with_runtime_policy(policy);
+    let runtime = ironclaw_reborn_composition::build_reborn_runtime(
+        ironclaw_reborn_composition::RebornRuntimeInput::from_services(input),
+    )
+    .await
+    .expect(
+        "local-dev profile builds — EXPECTED_PRODUCTION_SHAPE's referenced literal still exists",
+    );
+    runtime.shutdown().await.expect("shutdown");
+}
+
+// ---------------------------------------------------------------------------
+// Part 2: capability-id subset (companion check, unrelated to the shape
+// mechanism above — shares this file only because both assert something
+// about the harness's construction code never drifting from production).
+// ---------------------------------------------------------------------------
+
+/// Ids deliberately excluded from the subset check: local-dev-only synthetic
+/// capabilities (never part of `builtin_first_party_package()` or the
+/// extension/github id lists) or a fully dynamic runtime parameter with no
+/// static id to check. `(domain, reason)` — same naming discipline as
+/// `ALLOWED_DIVERGENCES`.
+const SYNTHETIC_CAPABILITY_SKIP_LIST: &[(&str, &str)] = &[
+    (
+        "mock_mcp",
+        "mock_mcp_tools(mcp_url, provider_id, capability_id) takes capability_id as a runtime \
+         string parameter (harness/profiles/mock_mcp.rs:70) — no static id to check",
+    ),
+    (
+        "project",
+        "PROJECT_CREATE_CAPABILITY_ID (harness/profiles/project.rs) is a local-dev synthetic \
+         capability (E-PROJ, ironclaw_reborn_composition::test_support), not part of \
+         builtin_first_party_package()",
+    ),
+    (
+        "outbound",
+        "OUTBOUND_DELIVERY_TARGETS_LIST/TARGET_SET_CAPABILITY_ID (harness/profiles/outbound.rs) \
+         are local-dev synthetic capabilities (C-SYNTH outbound, \
+         ironclaw_reborn_composition::test_support), not part of builtin_first_party_package()",
+    ),
+    (
+        "skill",
+        "skill_activation_tools_profile()'s SKILL_ACTIVATE_CAPABILITY_ID \
+         (harness/profiles/skill.rs) is a local-dev synthetic capability (E-SKILL, \
+         ironclaw_reborn_composition::test_support), not part of builtin_first_party_package(); \
+         skill_management_tools_profile()'s ids in the same file ARE checked below",
+    ),
+];
+
+/// The production capability surface: `builtin_first_party_package()`'s
+/// declared capabilities, unioned with the extension-lifecycle/bundled-
+/// extension id lists and the github extension's real manifest-derived ids
+/// (`github_support::capability_ids()` — parses the actual production asset
+/// at `crates/ironclaw_first_party_extensions/assets/github/manifest.toml`,
+/// so it is itself production truth, not a second test-only source).
+fn production_capability_surface() -> HashSet<String> {
+    let mut surface: HashSet<String> = ironclaw_host_runtime::builtin_first_party_package()
+        .expect("builtin first-party package parses")
+        .manifest
+        .capabilities
+        .iter()
+        .map(|capability| capability.id.as_str().to_string())
+        .collect();
+    surface.extend(
+        reborn_support::extension_surface::EXTENSION_LIFECYCLE_CAPABILITY_IDS
+            .iter()
+            .map(|id| id.to_string()),
+    );
+    surface.extend(
+        reborn_support::extension_surface::BUNDLED_EXTENSION_CAPABILITY_IDS
+            .iter()
+            .map(|id| id.to_string()),
+    );
+    surface.extend(
+        reborn_support::github::capability_ids()
+            .expect("github extension manifest parses")
+            .iter()
+            .map(|id| id.as_str().to_string()),
+    );
+    surface
+}
+
+/// One row per `harness/profiles/*.rs` domain (16 files total — see the
+/// module doc). The `Vec<&str>` is hand-transcribed from each file's
+/// `capability_ids` literal(s), built from the SAME named production
+/// constants those files import (not re-typed string literals), so a renamed
+/// constant fails this file to compile rather than silently drifting. Files
+/// on `SYNTHETIC_CAPABILITY_SKIP_LIST` contribute an empty (trivially
+/// passing) list, documented via that table instead of here.
+fn profile_capability_ids_by_domain() -> Vec<(&'static str, Vec<&'static str>)> {
+    use ironclaw_first_party_extensions::{
+        WEB_GET_CONTENT_CAPABILITY_ID, WEB_SEARCH_CAPABILITY_ID,
+    };
+    use ironclaw_host_runtime::{
+        APPLY_PATCH_CAPABILITY_ID, ECHO_CAPABILITY_ID, GLOB_CAPABILITY_ID, GREP_CAPABILITY_ID,
+        HTTP_CAPABILITY_ID, HTTP_SAVE_CAPABILITY_ID, JSON_CAPABILITY_ID, LIST_DIR_CAPABILITY_ID,
+        MEMORY_READ_CAPABILITY_ID, MEMORY_SEARCH_CAPABILITY_ID, MEMORY_TREE_CAPABILITY_ID,
+        MEMORY_WRITE_CAPABILITY_ID, PROFILE_SET_CAPABILITY_ID, READ_FILE_CAPABILITY_ID,
+        SHELL_CAPABILITY_ID, SKILL_INSTALL_CAPABILITY_ID, SKILL_LIST_CAPABILITY_ID,
+        SKILL_REMOVE_CAPABILITY_ID, SPAWN_SUBAGENT_CAPABILITY_ID, TIME_CAPABILITY_ID,
+        TRACE_COMMONS_CREDITS_CAPABILITY_ID, TRACE_COMMONS_ONBOARD_CAPABILITY_ID,
+        TRACE_COMMONS_PROFILE_SET_CAPABILITY_ID, TRACE_COMMONS_PROFILE_TOKEN_CAPABILITY_ID,
+        TRACE_COMMONS_STATUS_CAPABILITY_ID, TRIGGER_CREATE_CAPABILITY_ID,
+        TRIGGER_LIST_CAPABILITY_ID, TRIGGER_PAUSE_CAPABILITY_ID, TRIGGER_REMOVE_CAPABILITY_ID,
+        TRIGGER_RESUME_CAPABILITY_ID, WRITE_FILE_CAPABILITY_ID,
+    };
+
+    vec![
+        // attachment_tools_profile(): no first-party capability dispatch at all
+        // (harness/profiles/attachment.rs) — trivially empty.
+        ("attachment", vec![]),
+        // coding_read_tools_profile() (harness/profiles/coding_read.rs:15-18).
+        (
+            "coding_read",
+            vec![
+                LIST_DIR_CAPABILITY_ID,
+                GLOB_CAPABILITY_ID,
+                GREP_CAPABILITY_ID,
+            ],
+        ),
+        // core_builtin_tools_from_runtime() (harness/profiles/core_builtin.rs:177-193).
+        (
+            "core_builtin",
+            vec![
+                TIME_CAPABILITY_ID,
+                JSON_CAPABILITY_ID,
+                HTTP_CAPABILITY_ID,
+                HTTP_SAVE_CAPABILITY_ID,
+                MEMORY_SEARCH_CAPABILITY_ID,
+                MEMORY_WRITE_CAPABILITY_ID,
+                MEMORY_READ_CAPABILITY_ID,
+                MEMORY_TREE_CAPABILITY_ID,
+                PROFILE_SET_CAPABILITY_ID,
+                READ_FILE_CAPABILITY_ID,
+                APPLY_PATCH_CAPABILITY_ID,
+                SHELL_CAPABILITY_ID,
+            ],
+        ),
+        // extension_lifecycle_tools_profile() (harness/profiles/extension.rs:21-22)
+        // unions exactly these two production id lists — trivially a subset of
+        // the surface (which unions the SAME two lists); listed for the 16/16
+        // count, not because it exercises anything new.
+        (
+            "extension",
+            [
+                reborn_support::extension_surface::EXTENSION_LIFECYCLE_CAPABILITY_IDS,
+                reborn_support::extension_surface::BUNDLED_EXTENSION_CAPABILITY_IDS,
+            ]
+            .concat(),
+        ),
+        // file_tools_profile()/file_tools_requiring_approval_profile()/write_only_profile()
+        // (harness/profiles/file.rs) — union of all three constructors' ids.
+        (
+            "file",
+            vec![WRITE_FILE_CAPABILITY_ID, READ_FILE_CAPABILITY_ID],
+        ),
+        // file_and_github_auth_tools_profile() (harness/profiles/github.rs:62-66).
+        // github_issue_tools()/github_issue_tools_auth_required() use
+        // github_support::capability_ids() instead, which is itself
+        // production-manifest-derived (see production_capability_surface()) and
+        // so isn't re-checked here.
+        (
+            "github",
+            vec![
+                WRITE_FILE_CAPABILITY_ID,
+                READ_FILE_CAPABILITY_ID,
+                "github.get_repo",
+            ],
+        ),
+        // mock_mcp: SYNTHETIC_CAPABILITY_SKIP_LIST.
+        ("mock_mcp", vec![]),
+        // outbound_target_tools_profile(): SYNTHETIC_CAPABILITY_SKIP_LIST.
+        ("outbound", vec![]),
+        // process_tools_profile() (harness/profiles/process.rs:14-17).
+        (
+            "process",
+            vec![
+                ECHO_CAPABILITY_ID,
+                SHELL_CAPABILITY_ID,
+                SPAWN_SUBAGENT_CAPABILITY_ID,
+            ],
+        ),
+        // profile_tools_profile() (harness/profiles/profile.rs:18).
+        ("profile", vec![PROFILE_SET_CAPABILITY_ID]),
+        // project_tools_profile()/project_tools_with_fault_injection_profile():
+        // SYNTHETIC_CAPABILITY_SKIP_LIST.
+        ("project", vec![]),
+        // qa_smoke_tools() (harness/profiles/qa_smoke.rs:66-91).
+        (
+            "qa_smoke",
+            vec![
+                ECHO_CAPABILITY_ID,
+                TIME_CAPABILITY_ID,
+                JSON_CAPABILITY_ID,
+                HTTP_CAPABILITY_ID,
+                HTTP_SAVE_CAPABILITY_ID,
+                MEMORY_SEARCH_CAPABILITY_ID,
+                MEMORY_WRITE_CAPABILITY_ID,
+                MEMORY_READ_CAPABILITY_ID,
+                MEMORY_TREE_CAPABILITY_ID,
+                READ_FILE_CAPABILITY_ID,
+                WRITE_FILE_CAPABILITY_ID,
+                LIST_DIR_CAPABILITY_ID,
+                GLOB_CAPABILITY_ID,
+                GREP_CAPABILITY_ID,
+                APPLY_PATCH_CAPABILITY_ID,
+                SHELL_CAPABILITY_ID,
+                SPAWN_SUBAGENT_CAPABILITY_ID,
+                SKILL_LIST_CAPABILITY_ID,
+                SKILL_INSTALL_CAPABILITY_ID,
+                SKILL_REMOVE_CAPABILITY_ID,
+                TRIGGER_CREATE_CAPABILITY_ID,
+                TRIGGER_LIST_CAPABILITY_ID,
+                TRIGGER_PAUSE_CAPABILITY_ID,
+                TRIGGER_RESUME_CAPABILITY_ID,
+                TRIGGER_REMOVE_CAPABILITY_ID,
+            ],
+        ),
+        // skill_management_tools_profile() only (harness/profiles/skill.rs:17-20);
+        // skill_activation_tools_profile()'s id is on
+        // SYNTHETIC_CAPABILITY_SKIP_LIST.
+        (
+            "skill",
+            vec![
+                SKILL_LIST_CAPABILITY_ID,
+                SKILL_INSTALL_CAPABILITY_ID,
+                SKILL_REMOVE_CAPABILITY_ID,
+            ],
+        ),
+        // trace_commons_tools_profile() (harness/profiles/trace_commons.rs:15-20).
+        (
+            "trace_commons",
+            vec![
+                TRACE_COMMONS_ONBOARD_CAPABILITY_ID,
+                TRACE_COMMONS_STATUS_CAPABILITY_ID,
+                TRACE_COMMONS_CREDITS_CAPABILITY_ID,
+                TRACE_COMMONS_PROFILE_TOKEN_CAPABILITY_ID,
+                TRACE_COMMONS_PROFILE_SET_CAPABILITY_ID,
+            ],
+        ),
+        // trigger_management_tools_profile() (harness/profiles/trigger.rs:14-19).
+        (
+            "trigger",
+            vec![
+                TRIGGER_CREATE_CAPABILITY_ID,
+                TRIGGER_LIST_CAPABILITY_ID,
+                TRIGGER_PAUSE_CAPABILITY_ID,
+                TRIGGER_RESUME_CAPABILITY_ID,
+                TRIGGER_REMOVE_CAPABILITY_ID,
+            ],
+        ),
+        // web_access_tools() (harness/profiles/web_access.rs:47-50).
+        (
+            "web_access",
+            vec![WEB_SEARCH_CAPABILITY_ID, WEB_GET_CONTENT_CAPABILITY_ID],
+        ),
+    ]
+}
+
+/// Plain `#[test]`, not `#[tokio::test]`: pure data (production constants +
+/// hand-transcribed literals), no runtime built.
+#[test]
+fn harness_profile_capability_ids_are_a_production_subset() {
+    let surface = production_capability_surface();
+    let rows = profile_capability_ids_by_domain();
+    assert_eq!(
+        rows.len(),
+        16,
+        "expected exactly the 16 harness/profiles/*.rs domains named in the module doc"
+    );
+    for (domain, ids) in &rows {
+        for id in ids {
+            assert!(
+                surface.contains(*id),
+                "harness/profiles/{domain}.rs capability id {id:?} is not in the production \
+                 capability surface (builtin_first_party_package() + extension/github id \
+                 lists) — either it's a real drift, or it belongs on \
+                 SYNTHETIC_CAPABILITY_SKIP_LIST with a reason"
+            );
+        }
+    }
+    // Every skip-listed domain must still be accounted for above (as an
+    // empty/partial row), so a skip-list entry can't silently stop being
+    // checked for the ids it DOES declare (e.g. `skill`).
+    let checked_domains: HashSet<&str> = rows.iter().map(|(domain, _)| *domain).collect();
+    for (domain, _reason) in SYNTHETIC_CAPABILITY_SKIP_LIST {
+        assert!(
+            checked_domains.contains(domain),
+            "SYNTHETIC_CAPABILITY_SKIP_LIST references unknown domain {domain:?} — it must also \
+             appear (with its non-synthetic ids, if any) in profile_capability_ids_by_domain()"
+        );
+    }
+}

--- a/tests/integration/wiring_parity.rs
+++ b/tests/integration/wiring_parity.rs
@@ -14,10 +14,14 @@
 //! added/removed fields and harness regressions on already-tracked fields.
 //!
 //! A companion, unrelated check lives in the same file: every
-//! `harness/profiles/*.rs` domain's `capability_ids` is a subset of
-//! production's real capability surface (`builtin_first_party_package()` +
-//! the extension/github id lists), modulo a skip-list of deliberately
-//! synthetic local-dev-only ids.
+//! `harness/profiles/*.rs` domain's `capability_ids` — read from that
+//! domain's REAL `ToolsProfile`/harness constructor, never a hand-copied
+//! table — is a subset of production's real capability surface
+//! (`builtin_first_party_package()` + the github/bundled-extension
+//! manifest-derived id sets), modulo a skip-list of deliberately synthetic
+//! local-dev-only ids. See `production_capability_surface()`'s doc for one
+//! known, deliberately-excluded gap (the extension-lifecycle ids) that is
+//! visibility-blocked rather than papered over.
 
 #[allow(dead_code)]
 #[path = "support/mod.rs"]
@@ -28,8 +32,11 @@ mod support;
 
 use std::collections::HashSet;
 
+use ironclaw_host_api::CapabilityId;
 use reborn_support::builder::RebornIntegrationHarness;
 use reborn_support::group::RebornIntegrationGroup;
+use reborn_support::harness::HarnessResult;
+use reborn_support::harness::options::ToolsProfile;
 use reborn_support::planned_runtime_parts_shape::DefaultPlannedRuntimePartsShape;
 
 // ---------------------------------------------------------------------------
@@ -42,18 +49,38 @@ use reborn_support::planned_runtime_parts_shape::DefaultPlannedRuntimePartsShape
 /// RE-DERIVE by re-reading that literal whenever it changes. (Verified
 /// against this range 2026-07-04.) The smoke build below at least proves the
 /// referenced literal still exists and the profile still builds.
+///
+/// **`model_budget_accountant` scope**: this constant (and the harness sides
+/// it's compared against) models the NO-LLM local-dev build / the harness's
+/// no-real-LLM scripted `TraceLlm` path — both leave `llm_cost_table` `None`,
+/// so `model_budget_accountant` is `None` too. A production deployment with
+/// a resolved LLM policy and a real model cost table is a different,
+/// wider scope where that field is `Some` — see the field-level comment
+/// below for the exact code path.
 const EXPECTED_PRODUCTION_SHAPE: DefaultPlannedRuntimePartsShape =
     DefaultPlannedRuntimePartsShape {
-        model_route_resolver: false,            // :3406 hardcoded None
-        cancellation_factory: false,            // :3407 hardcoded None
-        skill_context_source: true, // :2917-2929 local_dev_filesystem_skill_context_source
-        attachment_read_port: true, // :3372-3376 local_runtime.map(ProjectScopedAttachmentReader)
-        input_queue: false,         // hardcoded None
-        model_policy_guard: false,  // hardcoded None
-        model_budget_accountant: false, // :3027-3073 None absent a resolved LLM cost table
-        safety_context: false,      // hardcoded None
-        hook_security_audit_sink: true, // :3452 always Some(TracingSecurityAuditSink)
-        turn_event_sink: true,      // :3453 always Some(turn_event_sink)
+        model_route_resolver: false, // :3406 hardcoded None
+        cancellation_factory: false, // :3407 hardcoded None
+        skill_context_source: true,  // :2917-2929 local_dev_filesystem_skill_context_source
+        attachment_read_port: true,  // :3372-3376 local_runtime.map(ProjectScopedAttachmentReader)
+        input_queue: false,          // hardcoded None
+        model_policy_guard: false,   // hardcoded None
+        // :3027-3073 — scope: this constant models the NO-LLM local-dev
+        // shape. When `model_gateway_override` is set (the harness's
+        // scripted `TraceLlm` path, and any test build), `llm_cost_table` is
+        // forced `None` unconditionally by the override arm (runtime.rs
+        // ~2973-2977) regardless of profile, so the harness's scripted-LLM
+        // shape matches this `false` too — it's genuinely like-for-like, not
+        // an LLM-vs-no-LLM mismatch papered over. A REAL production
+        // deployment with a resolved LLM policy (no override) and a known
+        // model cost table sets `model_budget_accountant: Some(..)` instead
+        // (the `(_, Some(cost_table)) => Some(accountant)` arm) — this
+        // constant does NOT hold for that case; it only pins the
+        // local-dev/harness scope this file compares.
+        model_budget_accountant: false,
+        safety_context: false,                  // hardcoded None
+        hook_security_audit_sink: true,         // :3452 always Some(TracingSecurityAuditSink)
+        turn_event_sink: true,                  // :3453 always Some(turn_event_sink)
         hook_dispatcher_builder_factory: false, // :3230-3258 None, HooksActivationConfig defaults OFF
         communication_context_provider: true,   // :3337-3357 Some whenever local_runtime present
         scheduler_wake_wiring: false, // :2847-2857 None outside Production/MigrationDryRun
@@ -87,8 +114,9 @@ const ALLOWED_DIVERGENCES: &[(&str, &str)] = &[
     ),
     (
         "hook_security_audit_sink",
-        "harness: always None (group.rs:704) — no RecordingSecurityAuditSink double exists \
-         yet (standing gap, tracked by nearai/ironclaw#5640, not a substitution); \
+        "harness: always None (group.rs's into_group, hook_security_audit_sink field) — no \
+         RecordingSecurityAuditSink double exists yet (standing gap, tracked by \
+         nearai/ironclaw#5640, not a substitution); \
          production: always Some(TracingSecurityAuditSink) (runtime.rs:3452)",
     ),
 ];
@@ -239,11 +267,29 @@ const SYNTHETIC_CAPABILITY_SKIP_LIST: &[(&str, &str)] = &[
 ];
 
 /// The production capability surface: `builtin_first_party_package()`'s
-/// declared capabilities, unioned with the extension-lifecycle/bundled-
-/// extension id lists and the github extension's real manifest-derived ids
-/// (`github_support::capability_ids()` — parses the actual production asset
-/// at `crates/ironclaw_first_party_extensions/assets/github/manifest.toml`,
-/// so it is itself production truth, not a second test-only source).
+/// declared capabilities, unioned with two independently production-derived
+/// sources — the github extension's real manifest-derived ids
+/// (`github_support::capability_ids()`) and every OTHER bundled extension's
+/// real manifest-derived ids
+/// (`extension_surface::bundled_extension_manifest_capability_ids()`) — both
+/// parse the actual `manifest.toml` assets under
+/// `crates/ironclaw_first_party_extensions/assets/`, so they are themselves
+/// production truth, not a second test-only source.
+///
+/// **Deliberately NOT unioned**: `extension_surface::EXTENSION_LIFECYCLE_CAPABILITY_IDS`
+/// (the four `builtin.extension_search`/`_install`/`_activate`/`_remove` ids).
+/// Their real values are defined in a production crate
+/// (`ironclaw_reborn_composition::extension_lifecycle_capabilities::EXTENSION_LIFECYCLE_CAPABILITY_IDS`),
+/// but as a `pub(crate)` constant with no public accessor — visibility-blocked
+/// from this test crate short of a `crates/` change, which is out of scope
+/// here. Unioning the test-support copy of this list back in would recreate
+/// exactly the tautology this restructure removes (RHS built from the same
+/// hand-transcribed list LHS grants from). STOP/report, not paper over: see
+/// `profile_capability_ids_by_domain()`'s "extension" row, which excludes
+/// these 4 ids from the check it runs for the same reason, and the PR that
+/// introduced this restructure (W5-WIRING-PARITY finding 1) for the tracked
+/// follow-up (export the list, or add a public accessor, from
+/// `ironclaw_reborn_composition`).
 fn production_capability_surface() -> HashSet<String> {
     let mut surface: HashSet<String> = ironclaw_host_runtime::builtin_first_party_package()
         .expect("builtin first-party package parses")
@@ -253,18 +299,14 @@ fn production_capability_surface() -> HashSet<String> {
         .map(|capability| capability.id.as_str().to_string())
         .collect();
     surface.extend(
-        reborn_support::extension_surface::EXTENSION_LIFECYCLE_CAPABILITY_IDS
-            .iter()
-            .map(|id| id.to_string()),
-    );
-    surface.extend(
-        reborn_support::extension_surface::BUNDLED_EXTENSION_CAPABILITY_IDS
-            .iter()
-            .map(|id| id.to_string()),
-    );
-    surface.extend(
         reborn_support::github::capability_ids()
             .expect("github extension manifest parses")
+            .iter()
+            .map(|id| id.as_str().to_string()),
+    );
+    surface.extend(
+        reborn_support::extension_surface::bundled_extension_manifest_capability_ids()
+            .expect("bundled extension manifests parse")
             .iter()
             .map(|id| id.as_str().to_string()),
     );
@@ -272,188 +314,155 @@ fn production_capability_surface() -> HashSet<String> {
 }
 
 /// One row per `harness/profiles/*.rs` domain (16 files total — see the
-/// module doc). The `Vec<&str>` is hand-transcribed from each file's
-/// `capability_ids` literal(s), built from the SAME named production
-/// constants those files import (not re-typed string literals), so a renamed
-/// constant fails this file to compile rather than silently drifting. Files
-/// on `SYNTHETIC_CAPABILITY_SKIP_LIST` contribute an empty (trivially
-/// passing) list, documented via that table instead of here.
-fn profile_capability_ids_by_domain() -> Vec<(&'static str, Vec<&'static str>)> {
-    use ironclaw_first_party_extensions::{
-        WEB_GET_CONTENT_CAPABILITY_ID, WEB_SEARCH_CAPABILITY_ID,
-    };
-    use ironclaw_host_runtime::{
-        APPLY_PATCH_CAPABILITY_ID, ECHO_CAPABILITY_ID, GLOB_CAPABILITY_ID, GREP_CAPABILITY_ID,
-        HTTP_CAPABILITY_ID, HTTP_SAVE_CAPABILITY_ID, JSON_CAPABILITY_ID, LIST_DIR_CAPABILITY_ID,
-        MEMORY_READ_CAPABILITY_ID, MEMORY_SEARCH_CAPABILITY_ID, MEMORY_TREE_CAPABILITY_ID,
-        MEMORY_WRITE_CAPABILITY_ID, PROFILE_SET_CAPABILITY_ID, READ_FILE_CAPABILITY_ID,
-        SHELL_CAPABILITY_ID, SKILL_INSTALL_CAPABILITY_ID, SKILL_LIST_CAPABILITY_ID,
-        SKILL_REMOVE_CAPABILITY_ID, SPAWN_SUBAGENT_CAPABILITY_ID, TIME_CAPABILITY_ID,
-        TRACE_COMMONS_CREDITS_CAPABILITY_ID, TRACE_COMMONS_ONBOARD_CAPABILITY_ID,
-        TRACE_COMMONS_PROFILE_SET_CAPABILITY_ID, TRACE_COMMONS_PROFILE_TOKEN_CAPABILITY_ID,
-        TRACE_COMMONS_STATUS_CAPABILITY_ID, TRIGGER_CREATE_CAPABILITY_ID,
-        TRIGGER_LIST_CAPABILITY_ID, TRIGGER_PAUSE_CAPABILITY_ID, TRIGGER_REMOVE_CAPABILITY_ID,
-        TRIGGER_RESUME_CAPABILITY_ID, WRITE_FILE_CAPABILITY_ID,
-    };
+/// module doc). Each `Vec<String>` is read from the domain's REAL
+/// constructor — a `ToolsProfile`'s `capability_ids` field for the domains
+/// that have one, or a small pure accessor added alongside the bespoke
+/// harness-literal constructors that don't
+/// (`core_builtin_tools_capability_ids()`, `qa_smoke_tools_capability_ids()`,
+/// `web_access_tools_capability_ids()` — each shared with, not duplicated
+/// from, the literal the harness builder itself uses) — never a
+/// hand-transcribed second copy. A renamed/removed production capability
+/// constant fails this file to compile (the profile constructors import the
+/// same named constants) rather than silently drifting. Domains on
+/// `SYNTHETIC_CAPABILITY_SKIP_LIST` contribute an empty (trivially passing)
+/// list, documented via that table instead of here.
+fn profile_capability_ids_by_domain() -> HarnessResult<Vec<(&'static str, Vec<String>)>> {
+    use reborn_support::harness::profiles;
 
-    vec![
+    fn ids_of(profile: ToolsProfile) -> Vec<String> {
+        profile
+            .capability_ids
+            .into_iter()
+            .map(CapabilityId::into_string)
+            .collect()
+    }
+
+    Ok(vec![
         // attachment_tools_profile(): no first-party capability dispatch at all
         // (harness/profiles/attachment.rs) — trivially empty.
-        ("attachment", vec![]),
-        // coding_read_tools_profile() (harness/profiles/coding_read.rs:15-18).
+        (
+            "attachment",
+            ids_of(profiles::attachment::attachment_tools_profile()?),
+        ),
+        // coding_read_tools_profile() (harness/profiles/coding_read.rs).
         (
             "coding_read",
-            vec![
-                LIST_DIR_CAPABILITY_ID,
-                GLOB_CAPABILITY_ID,
-                GREP_CAPABILITY_ID,
-            ],
+            ids_of(profiles::coding_read::coding_read_tools_profile()?),
         ),
-        // core_builtin_tools_from_runtime() (harness/profiles/core_builtin.rs:177-193).
+        // core_builtin_tools_capability_ids() — the SAME accessor
+        // core_builtin_tools_from_runtime() calls to build its harness
+        // (harness/profiles/core_builtin.rs).
         (
             "core_builtin",
-            vec![
-                TIME_CAPABILITY_ID,
-                JSON_CAPABILITY_ID,
-                HTTP_CAPABILITY_ID,
-                HTTP_SAVE_CAPABILITY_ID,
-                MEMORY_SEARCH_CAPABILITY_ID,
-                MEMORY_WRITE_CAPABILITY_ID,
-                MEMORY_READ_CAPABILITY_ID,
-                MEMORY_TREE_CAPABILITY_ID,
-                PROFILE_SET_CAPABILITY_ID,
-                READ_FILE_CAPABILITY_ID,
-                APPLY_PATCH_CAPABILITY_ID,
-                SHELL_CAPABILITY_ID,
-            ],
+            profiles::core_builtin::core_builtin_tools_capability_ids()?
+                .into_iter()
+                .map(CapabilityId::into_string)
+                .collect(),
         ),
-        // extension_lifecycle_tools_profile() (harness/profiles/extension.rs:21-22)
-        // unions exactly these two production id lists — trivially a subset of
-        // the surface (which unions the SAME two lists); listed for the 16/16
-        // count, not because it exercises anything new.
-        (
-            "extension",
-            [
-                reborn_support::extension_surface::EXTENSION_LIFECYCLE_CAPABILITY_IDS,
-                reborn_support::extension_surface::BUNDLED_EXTENSION_CAPABILITY_IDS,
-            ]
-            .concat(),
-        ),
-        // file_tools_profile()/file_tools_requiring_approval_profile()/write_only_profile()
-        // (harness/profiles/file.rs) — union of all three constructors' ids.
+        // extension_lifecycle_tools_profile() (harness/profiles/extension.rs)
+        // unions EXTENSION_LIFECYCLE_CAPABILITY_IDS (4 ids) then
+        // BUNDLED_EXTENSION_CAPABILITY_IDS, in that order. The leading 4 are
+        // skipped here: their real production values are visibility-blocked
+        // (see `production_capability_surface()`'s doc) — checking them
+        // against a surface that (correctly) no longer contains them would
+        // fail for a reason unrelated to real drift. The remaining ~130
+        // bundled-extension ids ARE checked, against the manifest-derived
+        // (not hand-transcribed) surface.
+        ("extension", {
+            let capability_ids =
+                profiles::extension::extension_lifecycle_tools_profile()?.capability_ids;
+            capability_ids
+                .into_iter()
+                .skip(reborn_support::extension_surface::EXTENSION_LIFECYCLE_CAPABILITY_IDS.len())
+                .map(CapabilityId::into_string)
+                .collect()
+        }),
+        // Union of all three file-domain constructors' ids
+        // (harness/profiles/file.rs).
         (
             "file",
-            vec![WRITE_FILE_CAPABILITY_ID, READ_FILE_CAPABILITY_ID],
+            [
+                profiles::file::file_tools_profile()?.capability_ids,
+                profiles::file::file_tools_requiring_approval_profile()?.capability_ids,
+                profiles::file::write_only_profile()?.capability_ids,
+            ]
+            .into_iter()
+            .flatten()
+            .map(CapabilityId::into_string)
+            .collect(),
         ),
-        // file_and_github_auth_tools_profile() (harness/profiles/github.rs:62-66).
+        // file_and_github_auth_tools_profile() (harness/profiles/github.rs).
         // github_issue_tools()/github_issue_tools_auth_required() use
         // github_support::capability_ids() instead, which is itself
-        // production-manifest-derived (see production_capability_surface()) and
-        // so isn't re-checked here.
+        // production-manifest-derived (see production_capability_surface())
+        // and so isn't re-checked here.
         (
             "github",
-            vec![
-                WRITE_FILE_CAPABILITY_ID,
-                READ_FILE_CAPABILITY_ID,
-                "github.get_repo",
-            ],
+            ids_of(profiles::github::file_and_github_auth_tools_profile()?),
         ),
         // mock_mcp: SYNTHETIC_CAPABILITY_SKIP_LIST.
         ("mock_mcp", vec![]),
         // outbound_target_tools_profile(): SYNTHETIC_CAPABILITY_SKIP_LIST.
         ("outbound", vec![]),
-        // process_tools_profile() (harness/profiles/process.rs:14-17).
+        // process_tools_profile() (harness/profiles/process.rs).
         (
             "process",
-            vec![
-                ECHO_CAPABILITY_ID,
-                SHELL_CAPABILITY_ID,
-                SPAWN_SUBAGENT_CAPABILITY_ID,
-            ],
+            ids_of(profiles::process::process_tools_profile()?),
         ),
-        // profile_tools_profile() (harness/profiles/profile.rs:18).
-        ("profile", vec![PROFILE_SET_CAPABILITY_ID]),
+        // profile_tools_profile() (harness/profiles/profile.rs).
+        (
+            "profile",
+            ids_of(profiles::profile::profile_tools_profile()?),
+        ),
         // project_tools_profile()/project_tools_with_fault_injection_profile():
         // SYNTHETIC_CAPABILITY_SKIP_LIST.
         ("project", vec![]),
-        // qa_smoke_tools() (harness/profiles/qa_smoke.rs:66-91).
+        // qa_smoke_tools_capability_ids() — the SAME accessor qa_smoke_tools()
+        // calls to build its harness (harness/profiles/qa_smoke.rs).
         (
             "qa_smoke",
-            vec![
-                ECHO_CAPABILITY_ID,
-                TIME_CAPABILITY_ID,
-                JSON_CAPABILITY_ID,
-                HTTP_CAPABILITY_ID,
-                HTTP_SAVE_CAPABILITY_ID,
-                MEMORY_SEARCH_CAPABILITY_ID,
-                MEMORY_WRITE_CAPABILITY_ID,
-                MEMORY_READ_CAPABILITY_ID,
-                MEMORY_TREE_CAPABILITY_ID,
-                READ_FILE_CAPABILITY_ID,
-                WRITE_FILE_CAPABILITY_ID,
-                LIST_DIR_CAPABILITY_ID,
-                GLOB_CAPABILITY_ID,
-                GREP_CAPABILITY_ID,
-                APPLY_PATCH_CAPABILITY_ID,
-                SHELL_CAPABILITY_ID,
-                SPAWN_SUBAGENT_CAPABILITY_ID,
-                SKILL_LIST_CAPABILITY_ID,
-                SKILL_INSTALL_CAPABILITY_ID,
-                SKILL_REMOVE_CAPABILITY_ID,
-                TRIGGER_CREATE_CAPABILITY_ID,
-                TRIGGER_LIST_CAPABILITY_ID,
-                TRIGGER_PAUSE_CAPABILITY_ID,
-                TRIGGER_RESUME_CAPABILITY_ID,
-                TRIGGER_REMOVE_CAPABILITY_ID,
-            ],
+            profiles::qa_smoke::qa_smoke_tools_capability_ids()?
+                .into_iter()
+                .map(CapabilityId::into_string)
+                .collect(),
         ),
-        // skill_management_tools_profile() only (harness/profiles/skill.rs:17-20);
+        // skill_management_tools_profile() only (harness/profiles/skill.rs);
         // skill_activation_tools_profile()'s id is on
         // SYNTHETIC_CAPABILITY_SKIP_LIST.
         (
             "skill",
-            vec![
-                SKILL_LIST_CAPABILITY_ID,
-                SKILL_INSTALL_CAPABILITY_ID,
-                SKILL_REMOVE_CAPABILITY_ID,
-            ],
+            ids_of(profiles::skill::skill_management_tools_profile()?),
         ),
-        // trace_commons_tools_profile() (harness/profiles/trace_commons.rs:15-20).
+        // trace_commons_tools_profile() (harness/profiles/trace_commons.rs).
         (
             "trace_commons",
-            vec![
-                TRACE_COMMONS_ONBOARD_CAPABILITY_ID,
-                TRACE_COMMONS_STATUS_CAPABILITY_ID,
-                TRACE_COMMONS_CREDITS_CAPABILITY_ID,
-                TRACE_COMMONS_PROFILE_TOKEN_CAPABILITY_ID,
-                TRACE_COMMONS_PROFILE_SET_CAPABILITY_ID,
-            ],
+            ids_of(profiles::trace_commons::trace_commons_tools_profile()?),
         ),
-        // trigger_management_tools_profile() (harness/profiles/trigger.rs:14-19).
+        // trigger_management_tools_profile() (harness/profiles/trigger.rs).
         (
             "trigger",
-            vec![
-                TRIGGER_CREATE_CAPABILITY_ID,
-                TRIGGER_LIST_CAPABILITY_ID,
-                TRIGGER_PAUSE_CAPABILITY_ID,
-                TRIGGER_RESUME_CAPABILITY_ID,
-                TRIGGER_REMOVE_CAPABILITY_ID,
-            ],
+            ids_of(profiles::trigger::trigger_management_tools_profile()?),
         ),
-        // web_access_tools() (harness/profiles/web_access.rs:47-50).
+        // web_access_tools_capability_ids() — the SAME accessor
+        // web_access_tools() calls to build its harness
+        // (harness/profiles/web_access.rs).
         (
             "web_access",
-            vec![WEB_SEARCH_CAPABILITY_ID, WEB_GET_CONTENT_CAPABILITY_ID],
+            profiles::web_access::web_access_tools_capability_ids()?
+                .into_iter()
+                .map(CapabilityId::into_string)
+                .collect(),
         ),
-    ]
+    ])
 }
 
-/// Plain `#[test]`, not `#[tokio::test]`: pure data (production constants +
-/// hand-transcribed literals), no runtime built.
+/// Plain `#[test]`, not `#[tokio::test]`: every `profile_capability_ids_by_domain()`
+/// row is built from a pure, sync constructor (no I/O beyond reading the
+/// github manifest asset off disk), so no async runtime is needed.
 #[test]
 fn harness_profile_capability_ids_are_a_production_subset() {
     let surface = production_capability_surface();
-    let rows = profile_capability_ids_by_domain();
+    let rows = profile_capability_ids_by_domain().expect("profile constructors build");
     assert_eq!(
         rows.len(),
         16,
@@ -462,10 +471,10 @@ fn harness_profile_capability_ids_are_a_production_subset() {
     for (domain, ids) in &rows {
         for id in ids {
             assert!(
-                surface.contains(*id),
+                surface.contains(id),
                 "harness/profiles/{domain}.rs capability id {id:?} is not in the production \
-                 capability surface (builtin_first_party_package() + extension/github id \
-                 lists) — either it's a real drift, or it belongs on \
+                 capability surface (builtin_first_party_package() + manifest-derived \
+                 extension id lists) — either it's a real drift, or it belongs on \
                  SYNTHETIC_CAPABILITY_SKIP_LIST with a reason"
             );
         }
@@ -481,4 +490,57 @@ fn harness_profile_capability_ids_are_a_production_subset() {
              appear (with its non-synthetic ids, if any) in profile_capability_ids_by_domain()"
         );
     }
+}
+
+/// Falsification for the restructured subset check (W5-WIRING-PARITY finding
+/// 1): temporarily narrow a COPY of the production surface so it's MISSING
+/// an id the "profile" domain genuinely grants (per its real
+/// `profile_tools_profile()` constructor, asserted below, not assumed), then
+/// confirm the check would fail on that row — proving the new shape (real
+/// constructor LHS vs. manifest-derived RHS) still catches drift instead of
+/// two hand-lists trivially agreeing with each other. This is a permanent
+/// regression test, not a one-off manual check: a future accidental
+/// reversion of `production_capability_surface()` back to a tautological
+/// harness-support-list union would show up as this test failing (the
+/// narrowed surface would then already be missing real ids for unrelated
+/// reasons, or the removed id would resurface via a re-added hand list).
+#[test]
+fn harness_profile_capability_ids_subset_falsifies_on_narrowed_surface() {
+    let mut surface = production_capability_surface();
+    let removed = ironclaw_host_runtime::PROFILE_SET_CAPABILITY_ID;
+    assert!(
+        surface.remove(removed),
+        "expected {removed:?} to be present in the real production surface before narrowing it"
+    );
+    let rows = profile_capability_ids_by_domain().expect("profile constructors build");
+    let profile_domain_ids = rows
+        .iter()
+        .find(|(domain, _)| *domain == "profile")
+        .map(|(_, ids)| ids.clone())
+        .expect("\"profile\" row present");
+    assert!(
+        profile_domain_ids.iter().any(|id| id == removed),
+        "\"profile\" row must actually grant {removed:?} for this falsification to be meaningful"
+    );
+    assert!(
+        !surface.contains(removed),
+        "narrowed surface must not contain {removed:?}"
+    );
+    // `PROFILE_SET_CAPABILITY_ID` is granted by more than one domain
+    // (`profile`, and `core_builtin`/`qa_smoke`'s bespoke literals), so
+    // narrowing the surface by this one id can legitimately fail more than
+    // one row — assert `profile` is AMONG the domains the check catches,
+    // rather than assuming it's the only or first one.
+    let failing_domains: Vec<&str> = rows
+        .iter()
+        .filter(|(_, ids)| ids.iter().any(|id| !surface.contains(id)))
+        .map(|(domain, _)| *domain)
+        .collect();
+    assert!(
+        failing_domains.contains(&"profile"),
+        "narrowing the production surface by {removed:?} (which the \"profile\" domain actually \
+         grants) should have made the subset check fail on the \"profile\" row — it didn't \
+         (failing domains: {failing_domains:?}), so the restructured check is not actually \
+         verifying anything"
+    );
 }

--- a/tests/integration/wiring_parity.rs
+++ b/tests/integration/wiring_parity.rs
@@ -360,21 +360,24 @@ fn profile_capability_ids_by_domain() -> HarnessResult<Vec<(&'static str, Vec<St
                 .collect(),
         ),
         // extension_lifecycle_tools_profile() (harness/profiles/extension.rs)
-        // unions EXTENSION_LIFECYCLE_CAPABILITY_IDS (4 ids) then
-        // BUNDLED_EXTENSION_CAPABILITY_IDS, in that order. The leading 4 are
-        // skipped here: their real production values are visibility-blocked
-        // (see `production_capability_surface()`'s doc) — checking them
-        // against a surface that (correctly) no longer contains them would
-        // fail for a reason unrelated to real drift. The remaining ~130
-        // bundled-extension ids ARE checked, against the manifest-derived
+        // grants EXTENSION_LIFECYCLE_CAPABILITY_IDS (4 ids) plus
+        // BUNDLED_EXTENSION_CAPABILITY_IDS. The 4 lifecycle ids are filtered
+        // out BY NAME (order-independent): their real production values are
+        // visibility-blocked (see `production_capability_surface()`'s doc) —
+        // checking them against a surface that (correctly) no longer contains
+        // them would fail for a reason unrelated to real drift. The remaining
+        // ~130 bundled-extension ids ARE checked, against the manifest-derived
         // (not hand-transcribed) surface.
         ("extension", {
             let capability_ids =
                 profiles::extension::extension_lifecycle_tools_profile()?.capability_ids;
             capability_ids
                 .into_iter()
-                .skip(reborn_support::extension_surface::EXTENSION_LIFECYCLE_CAPABILITY_IDS.len())
                 .map(CapabilityId::into_string)
+                .filter(|id| {
+                    !reborn_support::extension_surface::EXTENSION_LIFECYCLE_CAPABILITY_IDS
+                        .contains(&id.as_str())
+                })
                 .collect()
         }),
         // Union of all three file-domain constructors' ids


### PR DESCRIPTION
Closes #5637 (W5-WIRING-PARITY).

## What

A wiring-drift tripwire for the integration harness, test-tree only (zero `src/`/`crates/` changes):

- **Shape tripwire** — `tests/integration/support/planned_runtime_parts_shape.rs`: exhaustive no-`..` destructure over `DefaultPlannedRuntimeParts` (32 fields, 13 `Option`). Production adding/removing a field breaks this compile the day it lands, forcing a conscious wire-or-allowlist decision instead of a silent `None`.
- **Parity assertion** — `tests/integration/wiring_parity.rs`: the harness-built shape (both `test_default()` and `builtin_tools()` configs) compared against `EXPECTED_PRODUCTION_SHAPE`, hand-derived from `build_reborn_runtime`'s literal with a pinned re-derive instruction. `ALLOWED_DIVERGENCES` documents the 5 deliberate substitutions, one row per double/seam; `mask()` validates every row against the real field set and panics on unknown names, so renames can't leave stale entries inert.
- **Companion subset check** — every `harness/profiles/<domain>` capability-id list ⊆ the production registry surface (`builtin_first_party_package()` ∪ extension ∪ github id sets), with an evidence-backed skip-list for synthetic ids. Ids reference production constants, so renames fail compile.

## Falsification evidence (all fired red, then reverted)

1. Allowlist row removed → parity diff names exactly that field.
2. Destructure field removed → `E0027` compile error (tripwire proof).
3. Bogus allowlist field name → unknown-name panic.
4. Bogus capability id injected → subset check names domain + id.

## Known accepted gap

A silent production rewiring of an *existing* field isn't auto-detected (the expected shape is a hand-derived constant); #5641 tracks the machine-derived variant, which needs a production-crate test-support accessor and was deliberately excluded here. #5640 tracks the `hook_security_audit_sink` double gap behind one allowlist row.

## Verification

`reborn_integration_wiring_parity` 10/10; `cargo check --tests` clean; clippy zero warnings (full workspace, all features); suite-boundary guard OK; `git diff origin/main --name-only | grep -E '^(src|crates)/'` empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)