### PR TITLE
test(reborn): coverage-enabler batch — bridged tool disclosure, webui-v2/identity unlock, trace-capture (0% crates onto the int-tier lane)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3960,6 +3960,7 @@ dependencies = [
  "ironclaw_tui",
  "ironclaw_turns",
  "ironclaw_wasm",
+ "ironclaw_webui_v2",
  "json5",
  "jsonschema",
  "jsonwebtoken",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -292,7 +292,15 @@ ironclaw_secrets = { path = "crates/ironclaw_secrets", version = "0.1.0" }
 ironclaw_product_adapters = { path = "crates/ironclaw_product_adapters", version = "0.1.0", features = ["test-support"] }
 ironclaw_product_workflow = { path = "crates/ironclaw_product_workflow", version = "0.1.0", features = ["test-support"] }
 ironclaw_reborn = { path = "crates/ironclaw_reborn", version = "0.1.0", features = ["root-llm-provider"] }
-ironclaw_reborn_composition = { path = "crates/ironclaw_reborn_composition", version = "0.1.0", features = ["test-support", "libsql"] }
+# `webui-v2-beta` puts `ironclaw_webui_v2` + `ironclaw_reborn_identity` on the
+# int-tier coverage lane (identity_resolution_smoke / webui_v2_router_smoke);
+# feature unification compiles them into every int-tier build, behaviorally
+# inert for suites that never call them.
+ironclaw_reborn_composition = { path = "crates/ironclaw_reborn_composition", version = "0.1.0", features = ["test-support", "libsql", "webui-v2-beta"] }
+# Direct dev-dep: composition deliberately does NOT re-export the bare
+# `webui_v2_router`/`WebUiV2State` (facade-only rule), and the router smoke
+# drives the bare router, not the `webui_v2_app` wrapper.
+ironclaw_webui_v2 = { path = "crates/ironclaw_webui_v2", version = "0.1.0", features = ["webui-v2-beta"] }
 ironclaw_reborn_config = { path = "crates/ironclaw_reborn_config", version = "0.1.0" }
 ironclaw_reborn_openai_compat = { path = "crates/ironclaw_reborn_openai_compat", version = "0.1.0", features = ["openai-compat-beta"] }
 ironclaw_run_state = { path = "crates/ironclaw_run_state", version = "0.1.0" }
@@ -443,6 +451,10 @@ name = "reborn_integration_http_matcher"
 path = "tests/integration/http_matcher.rs"
 
 [[test]]
+name = "reborn_integration_identity_resolution_smoke"
+path = "tests/integration/identity_resolution_smoke.rs"
+
+[[test]]
 name = "reborn_integration_mcp"
 path = "tests/integration/mcp.rs"
 
@@ -501,6 +513,10 @@ path = "tests/integration/triggered_submit.rs"
 [[test]]
 name = "reborn_integration_web_access"
 path = "tests/integration/web_access.rs"
+
+[[test]]
+name = "reborn_integration_webui_v2_router_smoke"
+path = "tests/integration/webui_v2_router_smoke.rs"
 
 [[test]]
 name = "e2e_thread_scheduling"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -487,6 +487,10 @@ name = "reborn_integration_tool_call"
 path = "tests/integration/tool_call.rs"
 
 [[test]]
+name = "reborn_integration_tool_disclosure"
+path = "tests/integration/tool_disclosure.rs"
+
+[[test]]
 name = "reborn_integration_tracecap"
 path = "tests/integration/tracecap.rs"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -503,6 +503,10 @@ name = "reborn_integration_tool_disclosure"
 path = "tests/integration/tool_disclosure.rs"
 
 [[test]]
+name = "reborn_integration_trace_capture"
+path = "tests/integration/trace_capture.rs"
+
+[[test]]
 name = "reborn_integration_tracecap"
 path = "tests/integration/tracecap.rs"
 

--- a/crates/ironclaw_reborn_composition/src/test_support/mod.rs
+++ b/crates/ironclaw_reborn_composition/src/test_support/mod.rs
@@ -31,6 +31,9 @@
 //! 8. [`trigger_materializer`] — `materialize_trigger_prompt_for_test`, the
 //!    single production-owned trusted-trigger prompt materializer entry
 //!    point for the integration-test harness (E-TRIGGERED-SUBMIT seam).
+//! 9. [`trace_capture`] — `trace_capture_turn_event_sink_for_test`, the
+//!    production `TraceCaptureTurnEventSink` factory for the integration-test
+//!    harness (C-TRACECAP seam).
 
 mod budget_gateway;
 mod durable;
@@ -39,6 +42,7 @@ mod oauth_product_auth;
 mod outbound_delivery;
 mod project_create;
 mod skill_activation;
+mod trace_capture;
 mod trigger_materializer;
 mod user_profile;
 
@@ -76,6 +80,8 @@ pub use skill_activation::{
     SKILL_ACTIVATE_CAPABILITY_ID, SkillActivationTestSource,
     build_local_dev_skill_context_source_for_test, wrap_skill_activation_capability_for_test,
 };
+#[cfg(feature = "test-support")]
+pub use trace_capture::trace_capture_turn_event_sink_for_test;
 #[cfg(feature = "test-support")]
 pub use trigger_materializer::materialize_trigger_prompt_for_test;
 #[cfg(feature = "test-support")]

--- a/crates/ironclaw_reborn_composition/src/test_support/trace_capture.rs
+++ b/crates/ironclaw_reborn_composition/src/test_support/trace_capture.rs
@@ -1,0 +1,27 @@
+//! Trace-capture `TurnEventSink` test support (C-TRACECAP seam).
+
+/// Build the SAME `TraceCaptureTurnEventSink` production fans into
+/// `DefaultPlannedRuntimeParts.turn_event_sink` inside `build_reborn_runtime`
+/// (`runtime.rs`, "Autonomous Trace Commons capture"), seeded with the
+/// runtime owner's tenant-scoped trace scope key — the identical
+/// `trace_scope_key(tenant, owner)` recipe, so the test path never drifts
+/// from production wiring. Capture stays policy-gated per scope (inert until
+/// the scope enrolls), exactly as in production.
+#[cfg(feature = "test-support")]
+pub fn trace_capture_turn_event_sink_for_test(
+    thread_service: std::sync::Arc<dyn ironclaw_threads::SessionThreadService>,
+    tenant_id: &str,
+    actor_user_id: &str,
+) -> std::sync::Arc<dyn ironclaw_turns::TurnEventSink> {
+    let scope = ironclaw_reborn_traces::contribution::trace_scope_key(tenant_id, actor_user_id);
+    let observed_scopes: crate::observability::trace_capture::ObservedTraceScopes =
+        std::sync::Arc::new(std::sync::Mutex::new(std::collections::BTreeSet::from([
+            scope,
+        ])));
+    std::sync::Arc::new(
+        crate::observability::trace_capture::TraceCaptureTurnEventSink::new(
+            thread_service,
+            observed_scopes,
+        ),
+    )
+}

--- a/crates/ironclaw_reborn_composition/src/test_support/trace_capture.rs
+++ b/crates/ironclaw_reborn_composition/src/test_support/trace_capture.rs
@@ -7,21 +7,27 @@
 /// `trace_scope_key(tenant, owner)` recipe, so the test path never drifts
 /// from production wiring. Capture stays policy-gated per scope (inert until
 /// the scope enrolls), exactly as in production.
+///
+/// Returns the sink alongside the EXACT scope key it was seeded with, so the
+/// caller has a single source of truth instead of recomputing
+/// `trace_scope_key(tenant_id, actor_user_id)` a second time (which risks the
+/// two call sites drifting if either recipe ever changes independently).
 #[cfg(feature = "test-support")]
 pub fn trace_capture_turn_event_sink_for_test(
     thread_service: std::sync::Arc<dyn ironclaw_threads::SessionThreadService>,
     tenant_id: &str,
     actor_user_id: &str,
-) -> std::sync::Arc<dyn ironclaw_turns::TurnEventSink> {
+) -> (std::sync::Arc<dyn ironclaw_turns::TurnEventSink>, String) {
     let scope = ironclaw_reborn_traces::contribution::trace_scope_key(tenant_id, actor_user_id);
     let observed_scopes: crate::observability::trace_capture::ObservedTraceScopes =
         std::sync::Arc::new(std::sync::Mutex::new(std::collections::BTreeSet::from([
-            scope,
+            scope.clone(),
         ])));
-    std::sync::Arc::new(
+    let sink = std::sync::Arc::new(
         crate::observability::trace_capture::TraceCaptureTurnEventSink::new(
             thread_service,
             observed_scopes,
         ),
-    )
+    );
+    (sink, scope)
 }

--- a/tests/integration/identity_resolution_smoke.rs
+++ b/tests/integration/identity_resolution_smoke.rs
@@ -1,0 +1,75 @@
+//! `ironclaw_reborn_identity` on the int-tier coverage lane (enabler (a)).
+//!
+//! First scenario crossing an enumerated `--test` binary into the canonical
+//! identity crate: the crate's own 790-line inline suite never runs under the
+//! coverage-lane invocation (which passes only suite names, never `--lib`).
+//!
+//! Reaches the crate through the composition facade only —
+//! `open_reborn_identity_resolver` (the existing `test-support` +
+//! `webui-v2-beta` gated factory mirroring production's
+//! `RebornRuntime::open_reborn_identity_resolver`) plus the re-exported
+//! resolver vocabulary. Composition deliberately keeps the concrete
+//! `FilesystemRebornIdentityStore` private ("keep lower substrate handles
+//! private"), so this suite takes no direct `ironclaw_reborn_identity`
+//! dependency. The factory's in-memory host filesystem replaces the plan's
+//! "tempdir" wording — same store code path, no on-disk state.
+//!
+//! Flat suite, no harness mounts: identity resolution is a standalone store
+//! round trip, not an agent turn (`RebornIntegrationHarness` models the
+//! latter).
+
+use ironclaw_reborn_composition::host_api::TenantId;
+use ironclaw_reborn_composition::{
+    ExternalSubjectId, ProviderKind, ResolveExternalIdentity, SurfaceKind,
+    open_reborn_identity_resolver,
+};
+
+fn oauth_identity(tenant: &TenantId, subject: &str) -> ResolveExternalIdentity {
+    ResolveExternalIdentity {
+        tenant_id: tenant.clone(),
+        surface_kind: SurfaceKind::Oauth,
+        provider_kind: ProviderKind::new("google").expect("provider"),
+        provider_instance_id: None,
+        external_subject_id: ExternalSubjectId::new(subject).expect("subject"),
+        email: Some("alice@example.com".to_string()),
+        email_verified: true,
+        display_name: Some("Alice".to_string()),
+    }
+}
+
+/// First contact mints a user; re-resolving the SAME external identity
+/// returns the SAME canonical `UserId` (the store's lookup-before-create
+/// path), while a DIFFERENT subject mints a different user — so the
+/// stability assertion discriminates on the identity key, not on a
+/// constant return.
+#[tokio::test]
+async fn oauth_identity_resolves_to_stable_user_id() {
+    let tenant = TenantId::new("tenant-identity-smoke").expect("tenant");
+    let resolver = open_reborn_identity_resolver(&tenant);
+
+    let minted = resolver
+        .resolve_or_create(oauth_identity(&tenant, "google-sub-1"))
+        .await
+        .expect("first contact mints a user");
+    let resolved = resolver
+        .resolve_or_create(oauth_identity(&tenant, "google-sub-1"))
+        .await
+        .expect("re-resolution succeeds");
+    assert_eq!(
+        minted, resolved,
+        "same external identity resolves to the same canonical user id"
+    );
+
+    let other = resolver
+        .resolve_or_create(ResolveExternalIdentity {
+            email: Some("bob@example.com".to_string()),
+            display_name: Some("Bob".to_string()),
+            ..oauth_identity(&tenant, "google-sub-2")
+        })
+        .await
+        .expect("distinct subject mints its own user");
+    assert_ne!(
+        minted, other,
+        "a different external subject must not collapse onto the first user"
+    );
+}

--- a/tests/integration/support/assertions.rs
+++ b/tests/integration/support/assertions.rs
@@ -266,8 +266,10 @@ impl RebornIntegrationHarness {
     /// `TraceLlm::captured_tool_definitions`) contains a definition named
     /// `name`, across every request this thread has sent so far (C-TOOLDISCLOSURE).
     /// This is the channel `ToolDisclosureMode::Bridged` rewrites: bridged runs
-    /// replace the flat per-capability tool list with the 3 bridge meta tools
-    /// (`tool_search`/`tool_describe`/`tool_call`).
+    /// replace the flat per-capability tool list with the bridge meta tools.
+    /// Only `tool_search` is ever ADVERTISED to the model; `tool_describe`/
+    /// `tool_call` are retained internally for describe-first routing and
+    /// never appear in the captured tool definitions.
     pub async fn assert_model_tools_contains(&self, name: &str) -> HarnessResult<()> {
         let definitions = self.scripted_llm.captured_tool_definitions();
         if definitions
@@ -289,13 +291,25 @@ impl RebornIntegrationHarness {
     /// argument contains a definition named `name`. Paired with the positive
     /// assertion to prove disclosure mode *replaces* the tool surface rather
     /// than merely adding to it.
+    ///
+    /// Errors (rather than vacuously passing) when ZERO tool definitions were
+    /// captured across every request: an empty tool surface trivially
+    /// "excludes" anything, which would let a broken wiring (e.g. no request
+    /// captured at all) pass silently. Callers must first prove SOME tool
+    /// list was captured — every existing caller already does, via a paired
+    /// `assert_model_tools_contains` on the same harness.
     pub async fn assert_model_tools_excludes(&self, name: &str) -> HarnessResult<()> {
         let definitions = self.scripted_llm.captured_tool_definitions();
-        if definitions
-            .iter()
-            .flatten()
-            .any(|definition| definition.name == name)
-        {
+        let mut all_definitions = definitions.iter().flatten().peekable();
+        if all_definitions.peek().is_none() {
+            return Err(format!(
+                "vacuous exclusion: zero tool definitions captured across {} request(s); \
+                 cannot prove {name:?} was excluded from a tool surface that was never sent",
+                definitions.len()
+            )
+            .into());
+        }
+        if all_definitions.any(|definition| definition.name == name) {
             return Err(format!("captured tool definition unexpectedly named {name:?}").into());
         }
         Ok(())

--- a/tests/integration/support/assertions.rs
+++ b/tests/integration/support/assertions.rs
@@ -261,6 +261,46 @@ impl RebornIntegrationHarness {
         .into())
     }
 
+    /// Assert some captured `tools` argument (the provider tool-calling schema
+    /// shipped alongside the messages, NOT system-prompt text — see
+    /// `TraceLlm::captured_tool_definitions`) contains a definition named
+    /// `name`, across every request this thread has sent so far (C-TOOLDISCLOSURE).
+    /// This is the channel `ToolDisclosureMode::Bridged` rewrites: bridged runs
+    /// replace the flat per-capability tool list with the 3 bridge meta tools
+    /// (`tool_search`/`tool_describe`/`tool_call`).
+    pub async fn assert_model_tools_contains(&self, name: &str) -> HarnessResult<()> {
+        let definitions = self.scripted_llm.captured_tool_definitions();
+        if definitions
+            .iter()
+            .flatten()
+            .any(|definition| definition.name == name)
+        {
+            return Ok(());
+        }
+        let seen: Vec<String> = definitions
+            .iter()
+            .flatten()
+            .map(|definition| definition.name.clone())
+            .collect();
+        Err(format!("no captured tool definition named {name:?}; saw {seen:?}").into())
+    }
+
+    /// Inverse of [`assert_model_tools_contains`]: assert NO captured `tools`
+    /// argument contains a definition named `name`. Paired with the positive
+    /// assertion to prove disclosure mode *replaces* the tool surface rather
+    /// than merely adding to it.
+    pub async fn assert_model_tools_excludes(&self, name: &str) -> HarnessResult<()> {
+        let definitions = self.scripted_llm.captured_tool_definitions();
+        if definitions
+            .iter()
+            .flatten()
+            .any(|definition| definition.name == name)
+        {
+            return Err(format!("captured tool definition unexpectedly named {name:?}").into());
+        }
+        Ok(())
+    }
+
     /// Collects the persisted `safe_summary` field of every `ToolResultReference`
     /// message on this thread's FULL history (not baseline-sliced — safe only
     /// for single-turn harnesses today). Shared collector for

--- a/tests/integration/support/builder.rs
+++ b/tests/integration/support/builder.rs
@@ -220,8 +220,12 @@ impl RebornIntegrationHarnessBuilder {
     /// Force `ToolDisclosureMode::Bridged` for this harness's underlying group
     /// (enabler (b), `REBORN_TOOL_DISCLOSURE=Bridged`), so the bridged decorator
     /// (`ToolDisclosureCapabilityDecorator`) replaces the flat per-capability
-    /// tool list with the 3 bridge meta tools in the `tools` argument shipped
-    /// to the model. Deferral is ALSO threshold-gated (`select_active_set`,
+    /// tool list with the bridge meta tools in the `tools` argument shipped
+    /// to the model. Only `tool_search` is ever ADVERTISED to the model;
+    /// `tool_describe`/`tool_call` are retained internally for describe-first
+    /// routing and never appear on the model-visible tool surface (see
+    /// `tool_disclosure.rs`'s `bridged_mode_defers_wide_catalog_to_bridge_meta_tools`).
+    /// Deferral is ALSO threshold-gated (`select_active_set`,
     /// `DisclosureCaps::default().max_tools = 32`): backends under the cap
     /// (e.g. `BuiltinHttpTools`, 13 tools) stay flat even in Bridged mode —
     /// pair with `.with_github_issue_tools()` (48 tools) to observe deferral.
@@ -231,6 +235,17 @@ impl RebornIntegrationHarnessBuilder {
     /// `ToolDisclosureMode::from_env`, `apply_hermetic_env`).
     pub fn with_tool_disclosure_bridged(mut self) -> Self {
         self.tool_disclosure = Some(ToolDisclosureMode::Bridged);
+        self
+    }
+
+    /// Force `ToolDisclosureMode::Off` for this harness's underlying group,
+    /// bypassing `REBORN_TOOL_DISCLOSURE`/`from_env()`. Use this to pin a
+    /// negative-control test's mode explicitly rather than relying on the
+    /// ambient env default — see
+    /// `RebornIntegrationGroupBuilder::with_tool_disclosure_off` for why the
+    /// env-resolution path alone is not control-safe.
+    pub fn with_tool_disclosure_off(mut self) -> Self {
+        self.tool_disclosure = Some(ToolDisclosureMode::Off);
         self
     }
 
@@ -392,8 +407,14 @@ impl RebornIntegrationHarnessBuilder {
         if self.turn_event_sink {
             group_builder = group_builder.with_turn_event_sink();
         }
-        if self.tool_disclosure == Some(ToolDisclosureMode::Bridged) {
-            group_builder = group_builder.with_tool_disclosure_bridged();
+        match self.tool_disclosure {
+            Some(ToolDisclosureMode::Bridged) => {
+                group_builder = group_builder.with_tool_disclosure_bridged();
+            }
+            Some(ToolDisclosureMode::Off) => {
+                group_builder = group_builder.with_tool_disclosure_off();
+            }
+            None => {}
         }
         if self.budget_accounting {
             group_builder = group_builder.budget_accounting();
@@ -1418,6 +1439,11 @@ pub(crate) fn apply_hermetic_env() {
             std::env::remove_var("LLM_RESPONSE_CACHE_ENABLED");
             std::env::remove_var("RESPONSE_CACHE_ENABLED");
             std::env::remove_var("NEARAI_SESSION_TOKEN");
+            // No integration test should inherit the ambient tool-disclosure
+            // knob: `ToolDisclosureMode::from_env()` resolution is opt-in per
+            // test via `.with_tool_disclosure_bridged()`/`.with_tool_disclosure_off()`,
+            // never ambient (see `tool_disclosure.rs`'s negative control).
+            std::env::remove_var(ironclaw_reborn::runtime::REBORN_TOOL_DISCLOSURE_ENV);
         }
     });
 }

--- a/tests/integration/support/builder.rs
+++ b/tests/integration/support/builder.rs
@@ -39,6 +39,7 @@ use ironclaw_product_workflow::{
     DefaultProductWorkflow, ProductConversationRouteKind, ResolveBindingRequest, ResolvedBinding,
 };
 use ironclaw_reborn::loop_driver_host::HookDispatcherBuilderFactory;
+use ironclaw_reborn::runtime::ToolDisclosureMode;
 use ironclaw_threads::ThreadScope;
 use ironclaw_turns::run_profile::{CommunicationContextProvider, InstructionSafetyContext};
 use ironclaw_turns::{
@@ -114,6 +115,12 @@ pub struct RebornIntegrationHarnessBuilder {
     fail_model: bool,
     /// C-TRACECAP seam: install an in-memory `TurnEventSink` when `true`.
     turn_event_sink: bool,
+    /// Force `ToolDisclosureMode::Bridged` into the underlying group's ONE
+    /// planned runtime, bypassing `REBORN_TOOL_DISCLOSURE`/`from_env()`
+    /// (test-only knob; see `RebornIntegrationGroupBuilder::tool_disclosure`).
+    /// `None` (default) resolves via `ToolDisclosureMode::from_env()`, matching
+    /// today's behavior byte-for-byte.
+    tool_disclosure: Option<ToolDisclosureMode>,
     /// C-BUDGET: when `true`, wire the production budget accountant into the
     /// degenerate one-thread group (see `RebornIntegrationGroupBuilder::budget_accounting`).
     budget_accounting: bool,
@@ -207,6 +214,23 @@ impl RebornIntegrationHarnessBuilder {
     /// [`RebornIntegrationHarness::recorded_turn_events`].
     pub fn with_turn_event_sink(mut self) -> Self {
         self.turn_event_sink = true;
+        self
+    }
+
+    /// Force `ToolDisclosureMode::Bridged` for this harness's underlying group
+    /// (enabler (b), `REBORN_TOOL_DISCLOSURE=Bridged`), so the bridged decorator
+    /// (`ToolDisclosureCapabilityDecorator`) replaces the flat per-capability
+    /// tool list with the 3 bridge meta tools in the `tools` argument shipped
+    /// to the model. Deferral is ALSO threshold-gated (`select_active_set`,
+    /// `DisclosureCaps::default().max_tools = 32`): backends under the cap
+    /// (e.g. `BuiltinHttpTools`, 13 tools) stay flat even in Bridged mode —
+    /// pair with `.with_github_issue_tools()` (48 tools) to observe deferral.
+    /// Read back with `assert_model_tools_contains`/
+    /// `assert_model_tools_excludes`. Never mutates the process env — avoids
+    /// the `#[tokio::test]` concurrent-test race a raw env var would hit (see
+    /// `ToolDisclosureMode::from_env`, `apply_hermetic_env`).
+    pub fn with_tool_disclosure_bridged(mut self) -> Self {
+        self.tool_disclosure = Some(ToolDisclosureMode::Bridged);
         self
     }
 
@@ -368,6 +392,9 @@ impl RebornIntegrationHarnessBuilder {
         if self.turn_event_sink {
             group_builder = group_builder.with_turn_event_sink();
         }
+        if self.tool_disclosure == Some(ToolDisclosureMode::Bridged) {
+            group_builder = group_builder.with_tool_disclosure_bridged();
+        }
         if self.budget_accounting {
             group_builder = group_builder.budget_accounting();
         }
@@ -474,6 +501,7 @@ impl RebornIntegrationHarness {
             park_gate: None,
             fail_model: false,
             turn_event_sink: false,
+            tool_disclosure: None,
             budget_accounting: false,
             communication_context_provider: None,
             hook_dispatcher_builder_factory: None,

--- a/tests/integration/support/group.rs
+++ b/tests/integration/support/group.rs
@@ -61,8 +61,9 @@ use ironclaw_host_runtime::TurnRunSchedulerHandle;
 use ironclaw_llm::testing::provider_chain_over;
 use ironclaw_llm::{LlmProvider, SessionConfig, create_session_manager};
 use ironclaw_loop_support::{
-    HostManagedModelGateway, HostUserProfileSource, JsonSpawnSubagentInputCodec, ModelCostTable,
-    SubagentSpawnLimits, ZeroCostTable,
+    CapabilityAllowSet, CapabilitySurfaceProfileResolver, HostManagedModelGateway,
+    HostUserProfileSource, JsonSpawnSubagentInputCodec, ModelCostTable, SubagentSpawnLimits,
+    ZeroCostTable,
 };
 use ironclaw_product_adapters::ProductTriggerReason;
 use ironclaw_product_workflow::{
@@ -76,7 +77,7 @@ use ironclaw_reborn::loop_exit_applier::{
 use ironclaw_reborn::model_gateway::{LlmModelProfilePolicy, LlmProviderModelGateway};
 use ironclaw_reborn::runtime::{
     DefaultPlannedRuntimeConfig, DefaultPlannedRuntimeParts, RuntimeTurnStateStore,
-    build_default_planned_runtime,
+    ToolDisclosureMode, build_default_planned_runtime,
 };
 use ironclaw_reborn::subagent::{
     flavors::StaticSubagentDefinitionResolver, gate_resolution::BoundedSubagentGateResolutionStore,
@@ -106,7 +107,7 @@ use super::builder::{
 use super::harness::{
     EmptyIdentityContextSource, HarnessCapabilityMode, HarnessCapabilityRecorder,
     HarnessTurnBackend, HostRuntimeCapabilityHarness, RecordingTestCapabilityPort,
-    test_product_scope,
+    StaticCapabilitySurfaceProfileResolver, test_product_scope,
 };
 use super::product_workflow::RebornProductWorkflowHarness;
 use super::reply::RebornScriptedReply;
@@ -127,7 +128,7 @@ use crate::support::trace_llm::TraceLlm;
 mod group_constructors;
 
 /// Optional-runtime-wiring setters (`storage`, `safety_context`,
-/// `with_turn_event_sink`, `budget_accounting`,
+/// `with_turn_event_sink`, `with_tool_disclosure_bridged`, `budget_accounting`,
 /// `communication_context_provider`, `hook_dispatcher_builder_factory`) on
 /// [`RebornIntegrationGroupBuilder`]. A private child module (not `pub mod`
 /// from `mod.rs`), same precedent as `group_constructors` above — it reaches
@@ -320,6 +321,7 @@ impl RebornIntegrationGroup {
             storage: StorageMode::InMemory,
             safety_context: None,
             turn_event_sink: None,
+            tool_disclosure: None,
             budget: false,
             communication_context_provider: None,
             hook_dispatcher_builder_factory: None,
@@ -469,6 +471,10 @@ pub struct RebornIntegrationGroupBuilder {
     safety_context: Option<InstructionSafetyContext>,
     /// C-TRACECAP seam: `Some` once `.with_turn_event_sink()` has been called.
     turn_event_sink: Option<Arc<InMemoryTurnEventSink>>,
+    /// Enabler (b): `Some(ToolDisclosureMode::Bridged)` once
+    /// `.with_tool_disclosure_bridged()` has been called; `None` resolves via
+    /// `ToolDisclosureMode::from_env()` in `into_group` (today's behavior).
+    tool_disclosure: Option<ToolDisclosureMode>,
     /// C-BUDGET: when `true`, `into_group` wires the production
     /// `build_default_budget_accountant` (in-memory governor + gate store +
     /// zero-cost table + compiled-default seeding) into the group's ONE planned
@@ -586,6 +592,24 @@ impl RebornIntegrationGroupBuilder {
             capability_recorder,
         ) = capability.mode().into_parts(milestone_sink.clone())?;
 
+        // Enabler (b): production resolves `CapabilityAllowSet::All` for a
+        // top-level user turn, making `CapabilitySurfaceProfileFilter` a no-op
+        // — so the disclosure decorator's synthetic bridge ids
+        // (`ironclaw.tool_search` etc., never in any granted set) survive to
+        // the model. The harness default (allowlist of exactly the granted
+        // capability ids) is NARROWER than production there and would strip
+        // the deferred bridge surface down to zero tools. Mirror production
+        // for bridged groups only; every non-bridged group keeps the strict
+        // allowlist.
+        let capability_surface_resolver: Arc<dyn CapabilitySurfaceProfileResolver> =
+            if self.tool_disclosure == Some(ToolDisclosureMode::Bridged) {
+                Arc::new(StaticCapabilitySurfaceProfileResolver {
+                    allow_set: CapabilityAllowSet::All,
+                })
+            } else {
+                capability_surface_resolver
+            };
+
         // --- loop-exit evidence (group-level, built once) -----------------
         // `.with_checkpoint_state_store` is the de-mask fix: without it a
         // genuinely-`Failed` run is reported as the masking
@@ -665,6 +689,13 @@ impl RebornIntegrationGroupBuilder {
             loop_exit_evidence,
             config: DefaultPlannedRuntimeConfig {
                 poll_interval: Duration::from_millis(10),
+                // Enabler (b): explicit builder opt-in wins; otherwise resolve
+                // via `from_env()` exactly like `DefaultPlannedRuntimeConfig`'s
+                // own `Default` impl — never mutate the process env from a
+                // test (see `ToolDisclosureMode::from_env` doc, `apply_hermetic_env`).
+                tool_disclosure: self
+                    .tool_disclosure
+                    .unwrap_or_else(ToolDisclosureMode::from_env),
                 ..DefaultPlannedRuntimeConfig::default()
             },
             model_route_resolver: None,

--- a/tests/integration/support/group.rs
+++ b/tests/integration/support/group.rs
@@ -128,8 +128,9 @@ use crate::support::trace_llm::TraceLlm;
 mod group_constructors;
 
 /// Optional-runtime-wiring setters (`storage`, `safety_context`,
-/// `with_turn_event_sink`, `with_tool_disclosure_bridged`, `budget_accounting`,
-/// `communication_context_provider`, `hook_dispatcher_builder_factory`) on
+/// `with_turn_event_sink`, `with_trace_capture`, `with_tool_disclosure_bridged`,
+/// `budget_accounting`, `communication_context_provider`,
+/// `hook_dispatcher_builder_factory`) on
 /// [`RebornIntegrationGroupBuilder`]. A private child module (not `pub mod`
 /// from `mod.rs`), same precedent as `group_constructors` above — it reaches
 /// the builder's private fields at plain module-private visibility instead
@@ -201,6 +202,11 @@ pub(crate) struct GroupSharedStorage {
     /// opted in (C-TRACECAP seam); `None` otherwise. Concrete type (not `Arc<dyn
     /// TurnEventSink>`) so a test can read `.events()` back directly.
     pub(crate) turn_event_sink: Option<Arc<InMemoryTurnEventSink>>,
+    /// Enabler (c): the `trace_scope_key(tenant, owner)` the production
+    /// trace-capture sink was seeded with when `.with_trace_capture()` opted
+    /// in; `None` otherwise. Recorded at wiring time so a test asserts against
+    /// EXACTLY the scope the sink observes, not a re-derived equivalent.
+    pub(crate) trace_capture_scope: Option<String>,
     /// C-BUDGET: the in-memory `ResourceGovernor` behind the group's
     /// `model_budget_accountant`. Retained so a test can read back the account
     /// the accountant seeds on a turn's first model call — proof the
@@ -321,11 +327,20 @@ impl RebornIntegrationGroup {
             storage: StorageMode::InMemory,
             safety_context: None,
             turn_event_sink: None,
+            trace_capture: false,
             tool_disclosure: None,
             budget: false,
             communication_context_provider: None,
             hook_dispatcher_builder_factory: None,
         }
+    }
+
+    /// Enabler (c): the trace scope key the production trace-capture sink was
+    /// seeded with; `Some` only after `.with_trace_capture()`. Pair with
+    /// `ironclaw_reborn_traces::contribution::queued_trace_envelope_paths_for_scope`
+    /// to assert an enrolled turn queued a contribution envelope.
+    pub fn trace_capture_scope(&self) -> Option<&str> {
+        self.shared.trace_capture_scope.as_deref()
     }
 
     /// Create a per-thread *workflow* builder for `conversation_id`, over the
@@ -471,6 +486,12 @@ pub struct RebornIntegrationGroupBuilder {
     safety_context: Option<InstructionSafetyContext>,
     /// C-TRACECAP seam: `Some` once `.with_turn_event_sink()` has been called.
     turn_event_sink: Option<Arc<InMemoryTurnEventSink>>,
+    /// Enabler (c): `true` once `.with_trace_capture()` has been called —
+    /// `into_group` wires the PRODUCTION `TraceCaptureTurnEventSink` (via
+    /// composition's `trace_capture_turn_event_sink_for_test`) into the
+    /// group's one planned runtime, fan-out-composed with the in-memory sink
+    /// when both are opted in.
+    trace_capture: bool,
     /// Enabler (b): `Some(ToolDisclosureMode::Bridged)` once
     /// `.with_tool_disclosure_bridged()` has been called; `None` resolves via
     /// `ToolDisclosureMode::from_env()` in `into_group` (today's behavior).
@@ -631,6 +652,43 @@ impl RebornIntegrationGroupBuilder {
         }
         let loop_exit_evidence: Arc<dyn LoopExitEvidencePort> = Arc::new(evidence);
 
+        // --- trace capture (enabler (c), C-TRACECAP) ------------------------
+        // The PRODUCTION TraceCaptureTurnEventSink over the group's thread
+        // service, seeded with the runtime owner's trace scope — the same
+        // recipe `build_reborn_runtime` uses. Policy-gated per scope, so it
+        // is inert until the test enrolls the scope.
+        let trace_capture = if self.trace_capture {
+            let subject_user = base.canonical_subject_user()?;
+            let scope = ironclaw_reborn_traces::contribution::trace_scope_key(
+                base.canonical_binding.tenant_id.as_str(),
+                subject_user.as_str(),
+            );
+            let sink =
+                ironclaw_reborn_composition::test_support::trace_capture_turn_event_sink_for_test(
+                    group_thread_harness.service.clone() as Arc<dyn SessionThreadService>,
+                    base.canonical_binding.tenant_id.as_str(),
+                    subject_user.as_str(),
+                );
+            Some((sink, scope))
+        } else {
+            None
+        };
+        // The planned runtime has ONE turn-event-sink slot; compose the two
+        // opt-in sinks through the fan-out only when both are present so
+        // single-sink groups keep today's wiring byte-for-byte.
+        let mut turn_event_sinks: Vec<Arc<dyn TurnEventSink>> = Vec::new();
+        if let Some(sink) = self.turn_event_sink.clone() {
+            turn_event_sinks.push(sink as Arc<dyn TurnEventSink>);
+        }
+        if let Some((sink, _)) = &trace_capture {
+            turn_event_sinks.push(Arc::clone(sink));
+        }
+        let composed_turn_event_sink: Option<Arc<dyn TurnEventSink>> = match turn_event_sinks.len()
+        {
+            0 | 1 => turn_event_sinks.pop(),
+            _ => Some(Arc::new(FanOutTurnEventSink(turn_event_sinks))),
+        };
+
         // --- the group's ONE planned runtime -------------------------------
         let turn_state_for_runtime: Arc<dyn RuntimeTurnStateStore> = turn_store.clone();
         let model_gateway: Arc<dyn HostManagedModelGateway> =
@@ -733,10 +791,7 @@ impl RebornIntegrationGroupBuilder {
             // only when `communication_context_provider()` was set).
             communication_context_provider: self.communication_context_provider,
             hook_security_audit_sink: None,
-            turn_event_sink: self
-                .turn_event_sink
-                .clone()
-                .map(|sink| sink as Arc<dyn TurnEventSink>),
+            turn_event_sink: composed_turn_event_sink,
             attachment_read_port: capability_recorder
                 .attachment_test_support()
                 .map(|support| support.read_port),
@@ -757,10 +812,32 @@ impl RebornIntegrationGroupBuilder {
                 capability_recorder,
                 user_profile_source,
                 turn_event_sink: self.turn_event_sink,
+                trace_capture_scope: trace_capture.map(|(_, scope)| scope),
                 budget_governor,
                 budget_account,
             }),
         })
+    }
+}
+
+/// Fan-out `TurnEventSink`: the planned runtime exposes ONE sink slot
+/// (`DefaultPlannedRuntimeParts.turn_event_sink`), so `.with_turn_event_sink()`
+/// (in-memory recorder) and `.with_trace_capture()` (production trace sink)
+/// compose through this when both are opted in. Test-local because
+/// production's equivalent (`CompositeTurnEventSink`) is `pub(crate)` inside
+/// composition.
+struct FanOutTurnEventSink(Vec<Arc<dyn TurnEventSink>>);
+
+#[async_trait::async_trait]
+impl TurnEventSink for FanOutTurnEventSink {
+    async fn publish(
+        &self,
+        event: ironclaw_turns::TurnLifecycleEvent,
+    ) -> Result<(), ironclaw_turns::TurnError> {
+        for sink in &self.0 {
+            sink.publish(event.clone()).await?;
+        }
+        Ok(())
     }
 }
 

--- a/tests/integration/support/group.rs
+++ b/tests/integration/support/group.rs
@@ -656,14 +656,14 @@ impl RebornIntegrationGroupBuilder {
         // The PRODUCTION TraceCaptureTurnEventSink over the group's thread
         // service, seeded with the runtime owner's trace scope — the same
         // recipe `build_reborn_runtime` uses. Policy-gated per scope, so it
-        // is inert until the test enrolls the scope.
+        // is inert until the test enrolls the scope. The factory returns the
+        // scope it seeded the sink with directly — this is the ONE source of
+        // truth for that scope; do not recompute `trace_scope_key` here too
+        // (a second, independent computation could silently drift from what
+        // the sink actually observes if either recipe changes).
         let trace_capture = if self.trace_capture {
             let subject_user = base.canonical_subject_user()?;
-            let scope = ironclaw_reborn_traces::contribution::trace_scope_key(
-                base.canonical_binding.tenant_id.as_str(),
-                subject_user.as_str(),
-            );
-            let sink =
+            let (sink, scope) =
                 ironclaw_reborn_composition::test_support::trace_capture_turn_event_sink_for_test(
                     group_thread_harness.service.clone() as Arc<dyn SessionThreadService>,
                     base.canonical_binding.tenant_id.as_str(),
@@ -830,14 +830,24 @@ struct FanOutTurnEventSink(Vec<Arc<dyn TurnEventSink>>);
 
 #[async_trait::async_trait]
 impl TurnEventSink for FanOutTurnEventSink {
+    /// Publishes to every sink unconditionally — a failing sink must not
+    /// short-circuit the others (e.g. the in-memory recorder must still see
+    /// the event even if the trace-capture sink errors, and vice versa).
+    /// Returns the FIRST error only after every sink has been attempted.
     async fn publish(
         &self,
         event: ironclaw_turns::TurnLifecycleEvent,
     ) -> Result<(), ironclaw_turns::TurnError> {
+        let mut first_error = None;
         for sink in &self.0 {
-            sink.publish(event.clone()).await?;
+            if let Err(error) = sink.publish(event.clone()).await {
+                first_error.get_or_insert(error);
+            }
         }
-        Ok(())
+        match first_error {
+            Some(error) => Err(error),
+            None => Ok(()),
+        }
     }
 }
 

--- a/tests/integration/support/group_constructors.rs
+++ b/tests/integration/support/group_constructors.rs
@@ -167,6 +167,15 @@ impl RebornIntegrationGroup {
         Self::builder().skill_management_tools().await
     }
 
+    /// Group with the five `builtin.trace_commons.*` capabilities (enabler
+    /// (c): the C-TRACECAP enrollment surface). Reuses the SAME
+    /// `profiles::trace_commons::trace_commons_tools()` preset the QA/trace
+    /// tier uses, over the real turn -> capability path. Auto-approve is
+    /// enabled by the profile so scripted onboard/status calls are not gated.
+    pub async fn trace_commons_tools() -> HarnessResult<Self> {
+        Self::builder().trace_commons_tools().await
+    }
+
     /// Group with the attachment read port + inbound lander wired (C-ATTACH
     /// seam), no first-party capability dispatch. Use
     /// [`RebornThreadBuilder::with_model_override`] to route a thread through a
@@ -404,6 +413,15 @@ impl RebornIntegrationGroupBuilder {
     /// [`RebornIntegrationGroup::skill_management_tools`].
     pub async fn skill_management_tools(self) -> HarnessResult<RebornIntegrationGroup> {
         let host_runtime = super::super::harness::profiles::skill::skill_management_tools().await?;
+        let capability = GroupCapability::HostRuntime(Arc::new(host_runtime));
+        self.build_with_capability(capability).await
+    }
+
+    /// Build a trace-commons group. See
+    /// [`RebornIntegrationGroup::trace_commons_tools`].
+    pub async fn trace_commons_tools(self) -> HarnessResult<RebornIntegrationGroup> {
+        let host_runtime =
+            super::super::harness::profiles::trace_commons::trace_commons_tools().await?;
         let capability = GroupCapability::HostRuntime(Arc::new(host_runtime));
         self.build_with_capability(capability).await
     }

--- a/tests/integration/support/group_options.rs
+++ b/tests/integration/support/group_options.rs
@@ -1,7 +1,7 @@
 //! Runtime-wiring setters for [`RebornIntegrationGroupBuilder`] — `storage`,
-//! `safety_context`, `with_turn_event_sink`, `with_tool_disclosure_bridged`,
-//! `budget_accounting`, `communication_context_provider`,
-//! `hook_dispatcher_builder_factory`.
+//! `safety_context`, `with_turn_event_sink`, `with_trace_capture`,
+//! `with_tool_disclosure_bridged`, `budget_accounting`,
+//! `communication_context_provider`, `hook_dispatcher_builder_factory`.
 //! Private child module of `group.rs` (owns the struct + `build_base`/
 //! `into_group`), so it reaches the builder's private fields at module-
 //! private visibility instead of widening them to `pub(crate)`. New builder
@@ -50,6 +50,20 @@ impl RebornIntegrationGroupBuilder {
     /// siblings' events. No raw sink accessor, deliberately.
     pub fn with_turn_event_sink(mut self) -> Self {
         self.turn_event_sink = Some(Arc::new(InMemoryTurnEventSink::default()));
+        self
+    }
+
+    /// Wire the PRODUCTION `TraceCaptureTurnEventSink` into the group's ONE
+    /// planned runtime (enabler (c), C-TRACECAP), via composition's
+    /// `trace_capture_turn_event_sink_for_test` — the same sink + scope-seed
+    /// recipe `build_reborn_runtime` composes. Read the seeded scope back with
+    /// `RebornIntegrationGroup::trace_capture_scope()`. Composes with
+    /// `.with_turn_event_sink()` through the group's fan-out. NOTE: capture
+    /// resolves policy/queue paths through `IRONCLAW_BASE_DIR` (a process-wide
+    /// `LazyLock`) — the consuming test binary must point it at a tempdir as
+    /// its FIRST action (see `tests/integration/trace_capture.rs`).
+    pub fn with_trace_capture(mut self) -> Self {
+        self.trace_capture = true;
         self
     }
 

--- a/tests/integration/support/group_options.rs
+++ b/tests/integration/support/group_options.rs
@@ -1,6 +1,6 @@
 //! Runtime-wiring setters for [`RebornIntegrationGroupBuilder`] — `storage`,
 //! `safety_context`, `with_turn_event_sink`, `with_trace_capture`,
-//! `with_tool_disclosure_bridged`, `budget_accounting`,
+//! `with_tool_disclosure_bridged`, `with_tool_disclosure_off`, `budget_accounting`,
 //! `communication_context_provider`, `hook_dispatcher_builder_factory`.
 //! Private child module of `group.rs` (owns the struct + `build_base`/
 //! `into_group`), so it reaches the builder's private fields at module-
@@ -74,6 +74,21 @@ impl RebornIntegrationGroupBuilder {
     /// (resolves via `from_env()`, matching today's behavior).
     pub fn with_tool_disclosure_bridged(mut self) -> Self {
         self.tool_disclosure = Some(ToolDisclosureMode::Bridged);
+        self
+    }
+
+    /// Force `ToolDisclosureMode::Off` into the group's ONE planned runtime
+    /// config, regardless of `REBORN_TOOL_DISCLOSURE`. Used by the disclosure
+    /// mode's negative-control test to pin Off-mode behavior explicitly:
+    /// leaving it on the `from_env()` default-resolution path would let an
+    /// ambient `REBORN_TOOL_DISCLOSURE=Bridged` (e.g. from a developer's
+    /// shell or a differently-configured CI runner) silently flip the control
+    /// into the very mode it's meant to disprove. `apply_hermetic_env()` also
+    /// scrubs the var for defense in depth, but this explicit opt-in is what
+    /// actually makes the control's assertion mode-specific rather than
+    /// env-dependent.
+    pub fn with_tool_disclosure_off(mut self) -> Self {
+        self.tool_disclosure = Some(ToolDisclosureMode::Off);
         self
     }
 

--- a/tests/integration/support/group_options.rs
+++ b/tests/integration/support/group_options.rs
@@ -1,6 +1,7 @@
 //! Runtime-wiring setters for [`RebornIntegrationGroupBuilder`] — `storage`,
-//! `safety_context`, `with_turn_event_sink`, `budget_accounting`,
-//! `communication_context_provider`, `hook_dispatcher_builder_factory`.
+//! `safety_context`, `with_turn_event_sink`, `with_tool_disclosure_bridged`,
+//! `budget_accounting`, `communication_context_provider`,
+//! `hook_dispatcher_builder_factory`.
 //! Private child module of `group.rs` (owns the struct + `build_base`/
 //! `into_group`), so it reaches the builder's private fields at module-
 //! private visibility instead of widening them to `pub(crate)`. New builder
@@ -14,6 +15,7 @@
 use std::sync::Arc;
 
 use ironclaw_reborn::loop_driver_host::HookDispatcherBuilderFactory;
+use ironclaw_reborn::runtime::ToolDisclosureMode;
 use ironclaw_turns::InMemoryTurnEventSink;
 use ironclaw_turns::run_profile::{CommunicationContextProvider, InstructionSafetyContext};
 
@@ -48,6 +50,16 @@ impl RebornIntegrationGroupBuilder {
     /// siblings' events. No raw sink accessor, deliberately.
     pub fn with_turn_event_sink(mut self) -> Self {
         self.turn_event_sink = Some(Arc::new(InMemoryTurnEventSink::default()));
+        self
+    }
+
+    /// Force `ToolDisclosureMode::Bridged` into the group's ONE planned
+    /// runtime config (enabler (b)), regardless of `REBORN_TOOL_DISCLOSURE` —
+    /// avoids the shared-process env-var race `apply_hermetic_env()` already
+    /// guards against (see `ToolDisclosureMode::from_env`). Defaults `None`
+    /// (resolves via `from_env()`, matching today's behavior).
+    pub fn with_tool_disclosure_bridged(mut self) -> Self {
+        self.tool_disclosure = Some(ToolDisclosureMode::Bridged);
         self
     }
 

--- a/tests/integration/tool_disclosure.rs
+++ b/tests/integration/tool_disclosure.rs
@@ -100,9 +100,19 @@ async fn bridged_mode_defers_wide_catalog_to_bridge_meta_tools() {
 /// `.with_tool_disclosure_bridged()` surfaces the flat 48-tool list (today's
 /// default, `ToolDisclosureMode::Off`) — proves the bridged assertion above
 /// discriminates on the disclosure mode, not on the backend.
+///
+/// Pins Off-mode explicitly via `.with_tool_disclosure_off()` rather than
+/// leaving this on the `from_env()` default-resolution path: without an
+/// explicit pin, an ambient `REBORN_TOOL_DISCLOSURE=Bridged` in the process
+/// env would silently flip this control into Bridged mode too, and the
+/// assertions below would then be discriminating on nothing.
+/// `apply_hermetic_env()` also scrubs the var, but the explicit builder call
+/// is what makes this test's mode independent of the ambient env by
+/// construction, not just by today's harness hygiene.
 #[tokio::test]
 async fn default_mode_surfaces_the_flat_wide_tool_list() {
     let harness = RebornIntegrationHarness::test_default()
+        .with_tool_disclosure_off()
         .with_github_issue_tools()
         .script([RebornScriptedReply::text("done")])
         .build()

--- a/tests/integration/tool_disclosure.rs
+++ b/tests/integration/tool_disclosure.rs
@@ -1,0 +1,149 @@
+//! `REBORN_TOOL_DISCLOSURE=Bridged` int-tier coverage (enabler (b), #5149).
+//!
+//! Proves `.with_tool_disclosure_bridged()` reaches production's
+//! `ToolDisclosureCapabilityDecorator` wiring
+//! (`ironclaw_reborn::runtime::build_default_planned_runtime_inner`, gated on
+//! `DefaultPlannedRuntimeConfig::tool_disclosure.is_bridged()`) — the same
+//! lower-level factory this harness's group assembly already calls.
+//!
+//! Two load-bearing mechanics, both empirically verified (NOT what the
+//! original plan text said — divergences noted):
+//!
+//! 1. **Channel**: bridged mode rewrites the `tools` argument shipped to the
+//!    model — captured via `TraceLlm::captured_tool_definitions()`, the same
+//!    request field real providers' native tool-calling schema travels
+//!    through. It is NOT system-prompt text: tool definitions are a separate
+//!    request field from the `System`-role message
+//!    `assert_system_prompt_contains` reads.
+//! 2. **Threshold gate**: `Bridged` mode alone does NOT defer — deferral is
+//!    additionally gated on the catalog exceeding `DisclosureCaps::default()`
+//!    (`max_tools: 32` / ~12k estimated schema tokens; `select_active_set`,
+//!    `crates/ironclaw_reborn/src/tool_disclosure.rs`). The
+//!    `GithubIssueTools` backend surfaces all 48 `github.*` manifest
+//!    capabilities (`github_support::capability_ids()`), none of which is
+//!    Core-tier (`CORE_TOOL_NAMES` suffix-match misses every github id), so
+//!    the deferred active set is exactly the `tool_search` bridge. The
+//!    13-capability `BuiltinHttpTools` backend stays UNDER the cap, so
+//!    bridged mode is wired-but-inert there — pinned below as the threshold
+//!    control.
+//!
+//! Harness note: bridged groups resolve `CapabilityAllowSet::All` (see
+//! `into_group`) — production's top-level resolution — because the harness's
+//! default granted-ids allowlist would strip the synthetic `ironclaw.*`
+//! bridge ids at `CapabilitySurfaceProfileFilter` and ship ZERO tools.
+
+#[allow(dead_code)]
+#[path = "support/mod.rs"]
+mod reborn_support;
+#[allow(dead_code)]
+#[path = "../support/mod.rs"]
+mod support;
+
+use reborn_support::builder::RebornIntegrationHarness;
+use reborn_support::reply::RebornScriptedReply;
+
+/// Bridge meta-tool names (`tool_disclosure.rs`'s `TOOL_SEARCH_NAME`/
+/// `TOOL_DESCRIBE_NAME`/`TOOL_CALL_NAME`), hardcoded as literals: the
+/// constants are `pub(crate)` inside `ironclaw_reborn` and not part of the
+/// crate's public surface for a test-tree import. Only `tool_search` is
+/// ADVERTISED (`advertised_bridge_tool_definitions`); `tool_describe`/
+/// `tool_call` are retained internally for describe-first routing and must
+/// NOT appear on the model surface.
+const TOOL_SEARCH_NAME: &str = "tool_search";
+const TOOL_DESCRIBE_NAME: &str = "tool_describe";
+const TOOL_CALL_NAME: &str = "tool_call";
+
+/// Representative flat github tool in provider wire form — dotted capability
+/// ids are `__`-encoded on the tool surface (`encode_provider_tool_name`;
+/// see `tests/snapshots/golden_payload__tool_call.snap`'s `tool_surface`).
+const FLAT_GITHUB_TOOL_NAME: &str = "github__get_repo";
+
+/// Flat first-party tool (wire form) for the below-caps threshold control.
+const FLAT_HTTP_TOOL_NAME: &str = "builtin__http";
+
+/// Bridged mode + a catalog over `DisclosureCaps::default().max_tools` (48
+/// github capabilities > 32): `select_active_set` defers, so the model sees
+/// the `tool_search` bridge (the only ADVERTISED bridge — discovery is
+/// tool_search → capability_info → direct call) and NOT the flat `github__*`
+/// list, nor the internal-only `tool_describe`/`tool_call` bridges.
+#[tokio::test]
+async fn bridged_mode_defers_wide_catalog_to_bridge_meta_tools() {
+    let harness = RebornIntegrationHarness::test_default()
+        .with_tool_disclosure_bridged()
+        .with_github_issue_tools()
+        .script([RebornScriptedReply::text("done")])
+        .build()
+        .await
+        .expect("bridged-disclosure harness builds");
+
+    harness.submit_turn("hello").await.expect("turn completes");
+
+    harness
+        .assert_model_tools_contains(TOOL_SEARCH_NAME)
+        .await
+        .expect("deferral advertises the tool_search bridge");
+    harness
+        .assert_model_tools_excludes(FLAT_GITHUB_TOOL_NAME)
+        .await
+        .expect("deferral replaces the flat tool list, not adds to it");
+    for internal_bridge in [TOOL_DESCRIBE_NAME, TOOL_CALL_NAME] {
+        harness
+            .assert_model_tools_excludes(internal_bridge)
+            .await
+            .unwrap_or_else(|error| {
+                panic!("bridge {internal_bridge:?} is internal-only, never advertised: {error}")
+            });
+    }
+}
+
+/// Negative control: the SAME wide catalog without
+/// `.with_tool_disclosure_bridged()` surfaces the flat 48-tool list (today's
+/// default, `ToolDisclosureMode::Off`) — proves the bridged assertion above
+/// discriminates on the disclosure mode, not on the backend.
+#[tokio::test]
+async fn default_mode_surfaces_the_flat_wide_tool_list() {
+    let harness = RebornIntegrationHarness::test_default()
+        .with_github_issue_tools()
+        .script([RebornScriptedReply::text("done")])
+        .build()
+        .await
+        .expect("default-disclosure harness builds");
+
+    harness.submit_turn("hello").await.expect("turn completes");
+
+    harness
+        .assert_model_tools_contains(FLAT_GITHUB_TOOL_NAME)
+        .await
+        .expect("default mode keeps the flat tool list");
+    harness
+        .assert_model_tools_excludes(TOOL_SEARCH_NAME)
+        .await
+        .expect("default mode never surfaces the bridge meta tools");
+}
+
+/// Threshold control: bridged mode with a catalog UNDER
+/// `DisclosureCaps::default()` (the 13-capability `BuiltinHttpTools` surface)
+/// does NOT defer — the flat list survives and no bridge meta tool appears.
+/// Pins that deferral is `mode AND caps-exceeded`, not mode alone: a harness
+/// (or production surface) below the cap is wired-but-inert in Bridged mode.
+#[tokio::test]
+async fn bridged_mode_below_caps_keeps_the_flat_list() {
+    let harness = RebornIntegrationHarness::test_default()
+        .with_tool_disclosure_bridged()
+        .with_builtin_http_tools()
+        .script([RebornScriptedReply::text("done")])
+        .build()
+        .await
+        .expect("below-caps bridged harness builds");
+
+    harness.submit_turn("hello").await.expect("turn completes");
+
+    harness
+        .assert_model_tools_contains(FLAT_HTTP_TOOL_NAME)
+        .await
+        .expect("below the disclosure caps the flat list is unchanged");
+    harness
+        .assert_model_tools_excludes(TOOL_SEARCH_NAME)
+        .await
+        .expect("no bridge meta tools below the disclosure caps");
+}

--- a/tests/integration/trace_capture.rs
+++ b/tests/integration/trace_capture.rs
@@ -1,0 +1,172 @@
+//! C-TRACECAP enabler (c): production trace-capture sink on the int-tier lane.
+//!
+//! Wires the REAL `TraceCaptureTurnEventSink` (via composition's
+//! `test_support::trace_capture_turn_event_sink_for_test`, mirroring
+//! `build_reborn_runtime`'s recipe) into the group's ONE planned runtime with
+//! `.with_trace_capture()`, and proves the capture path end-to-end: policy
+//! read → transcript capture → redact → score → queue
+//! (`ironclaw_reborn_traces::contribution`, previously 0% on the lane).
+//!
+//! Enrollment divergence from the plan (verified infeasible as written): a
+//! scripted `builtin.trace_commons.onboard` with `confirmed=true` can NEVER
+//! enroll against a canned recording-egress body — the onboarding client
+//! cross-checks the server-echoed `device_key_id` against a locally generated
+//! ephemeral key (`onboarding/mod.rs:241`), which only a live echo-mock
+//! issuer can satisfy (see `trace_commons_dispatch_e2e.rs`). The scenario
+//! therefore (1) scripts onboard with `confirmed=false` through real
+//! capability dispatch — the consent gate, which doubles as the
+//! inert-until-enrolled control — and (2) enrolls by writing the SAME policy
+//! state onboard writes (`write_trace_policy_for_scope`, the plan's original
+//! fallback). Live-issuer onboarding stays a named follow-on with the other
+//! network paths.
+//!
+//! This binary owns `IRONCLAW_BASE_DIR`: trace policy/queue paths resolve
+//! through `ironclaw_common`'s process-wide `LazyLock`, so the tempdir env
+//! var is set as the FIRST action, before any read (same pattern as
+//! `crates/ironclaw_host_runtime/tests/trace_commons_dispatch_e2e.rs`).
+//! Keep this suite a single sequenced `#[tokio::test]`: enrollment state is
+//! process-global (per scope), so concurrent tests in this binary would race.
+
+#[allow(dead_code)]
+#[path = "support/mod.rs"]
+mod reborn_support;
+#[allow(dead_code)]
+#[path = "../support/mod.rs"]
+mod support;
+
+use std::time::Duration;
+
+use ironclaw_reborn_traces::contribution::{
+    StandingTraceContributionPolicy, queued_trace_envelope_paths_for_scope,
+    write_trace_policy_for_scope,
+};
+use reborn_support::group::RebornIntegrationGroup;
+use reborn_support::reply::RebornScriptedReply;
+use tempfile::TempDir;
+
+const ONBOARD_CAPABILITY_ID: &str = "builtin.trace_commons.onboard";
+
+static BASE_DIR: std::sync::OnceLock<TempDir> = std::sync::OnceLock::new();
+
+/// Point `IRONCLAW_BASE_DIR` at a process-lifetime tempdir before any code
+/// reads it through `ironclaw_common`'s `LazyLock`. Must be the first call
+/// in every test in this binary.
+fn setup_base_dir() -> &'static TempDir {
+    BASE_DIR.get_or_init(|| {
+        let dir = tempfile::tempdir().expect("tempdir for IRONCLAW_BASE_DIR");
+        // SAFETY: executed exactly once inside `OnceLock::get_or_init`, before
+        // any base-dir read — no concurrent reader during this write.
+        unsafe {
+            std::env::set_var("IRONCLAW_BASE_DIR", dir.path());
+        }
+        dir
+    })
+}
+
+/// The enrolled-state policy the onboard flow writes
+/// (`onboarding/mod.rs::write_policy_at_dir`), minus the device-key/issuer
+/// fields only a live handshake can produce. `min_submission_score: 0.0` keeps
+/// a short scripted turn Submit-eligible (the 0.35 default would Hold-and-drop
+/// it as low-value); flush still fails fast before any network because the
+/// default `IRONCLAW_TRACE_SUBMIT_TOKEN` env is unset, so the queued envelope
+/// is retained for the assertion.
+fn enrolled_policy() -> StandingTraceContributionPolicy {
+    StandingTraceContributionPolicy {
+        enabled: true,
+        ingestion_endpoint: Some("https://traces.invalid/v1/ingest".to_string()),
+        include_message_text: true,
+        include_tool_payloads: true,
+        min_submission_score: 0.0,
+        ..StandingTraceContributionPolicy::default()
+    }
+}
+
+/// Poll for the spawned capture task (`capture_turn_trace` runs off the sink's
+/// `publish` via `tokio::spawn`) to queue the envelope.
+async fn wait_for_queued_envelopes(scope: &str) -> Vec<std::path::PathBuf> {
+    for _ in 0..100 {
+        let paths = queued_trace_envelope_paths_for_scope(Some(scope)).expect("read queue");
+        if !paths.is_empty() {
+            return paths;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    panic!("no trace envelope queued for enrolled scope {scope:?} within 10s");
+}
+
+#[tokio::test]
+async fn completed_turn_queues_trace_contribution_for_enrolled_scope() {
+    setup_base_dir();
+
+    let group = RebornIntegrationGroup::builder()
+        .with_trace_capture()
+        .trace_commons_tools()
+        .await
+        .expect("trace-commons group builds");
+    let scope = group
+        .trace_capture_scope()
+        .expect("with_trace_capture records the runtime owner scope")
+        .to_string();
+
+    // Turn 1 — NOT enrolled. Drives the real `builtin.trace_commons.onboard`
+    // capability dispatch at the consent gate (`confirmed=false` returns
+    // consent_required without enrolling), and doubles as the
+    // inert-until-enrolled control: the sink runs (policy read per turn) but
+    // must queue nothing.
+    let first = group
+        .thread("conv-trace-capture-consent")
+        .script([
+            RebornScriptedReply::tool_call(
+                ONBOARD_CAPABILITY_ID,
+                serde_json::json!({
+                    "invite_url": "https://tc.example.test/onboard#REBORN-INT-CODE",
+                    "confirmed": false
+                }),
+            ),
+            RebornScriptedReply::text("not enrolled"),
+        ])
+        .build()
+        .await
+        .expect("first thread builds");
+    first
+        .submit_turn("contribute my traces?")
+        .await
+        .expect("consent-gate turn completes");
+    first
+        .assert_tool_invoked(ONBOARD_CAPABILITY_ID)
+        .await
+        .expect("onboard capability dispatched through the group runtime");
+    // Grace period for the (spawned) capture task: a regression that captures
+    // without enrollment would queue within this window.
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    assert_eq!(
+        queued_trace_envelope_paths_for_scope(Some(&scope)).expect("read queue"),
+        Vec::<std::path::PathBuf>::new(),
+        "capture must stay inert for a non-enrolled scope"
+    );
+
+    // Enroll the scope: the same standing-policy state a completed onboard
+    // handshake persists.
+    write_trace_policy_for_scope(Some(&scope), &enrolled_policy()).expect("enroll scope");
+
+    // Turn 2 — enrolled. A plain completed turn must now flow policy read →
+    // capture → redact → score → queue.
+    let second = group
+        .thread("conv-trace-capture-enrolled")
+        .script([RebornScriptedReply::text("done")])
+        .build()
+        .await
+        .expect("second thread builds");
+    second
+        .submit_turn("hello after enrollment")
+        .await
+        .expect("enrolled turn completes");
+
+    let queued = wait_for_queued_envelopes(&scope).await;
+    assert_eq!(
+        queued.len(),
+        1,
+        "exactly the enrolled turn's envelope is queued (a late capture from \
+         the pre-enrollment turn would make this 2): {queued:?}"
+    );
+}

--- a/tests/integration/trace_capture.rs
+++ b/tests/integration/trace_capture.rs
@@ -37,7 +37,7 @@ mod support;
 use std::time::Duration;
 
 use ironclaw_reborn_traces::contribution::{
-    StandingTraceContributionPolicy, queued_trace_envelope_paths_for_scope,
+    StandingTraceContributionPolicy, queued_trace_envelope_paths_for_scope, trace_scope_key,
     write_trace_policy_for_scope,
 };
 use reborn_support::group::RebornIntegrationGroup;
@@ -45,6 +45,10 @@ use reborn_support::reply::RebornScriptedReply;
 use tempfile::TempDir;
 
 const ONBOARD_CAPABILITY_ID: &str = "builtin.trace_commons.onboard";
+
+/// Distinct actor for the inert (never-enrolled) consent-gate control thread —
+/// see the scope-isolation note on `completed_turn_queues_trace_contribution_for_enrolled_scope`.
+const CONSENT_CONTROL_ACTOR_ID: &str = "host-user-trace-consent-control";
 
 static BASE_DIR: std::sync::OnceLock<TempDir> = std::sync::OnceLock::new();
 
@@ -54,8 +58,13 @@ static BASE_DIR: std::sync::OnceLock<TempDir> = std::sync::OnceLock::new();
 fn setup_base_dir() -> &'static TempDir {
     BASE_DIR.get_or_init(|| {
         let dir = tempfile::tempdir().expect("tempdir for IRONCLAW_BASE_DIR");
-        // SAFETY: executed exactly once inside `OnceLock::get_or_init`, before
-        // any base-dir read — no concurrent reader during this write.
+        // Serialize against every other env-mutating test in this binary (same
+        // guard `apply_hermetic_env` takes) before touching the process env.
+        let _env_guard = ironclaw_common::env_helpers::lock_env();
+        // SAFETY: the `lock_env()` guard above serializes against all other
+        // env-mutating tests in this binary; `OnceLock::get_or_init` additionally
+        // guarantees this closure body runs exactly once, before any base-dir
+        // read (this fn is called as the first action of every test here).
         unsafe {
             std::env::set_var("IRONCLAW_BASE_DIR", dir.path());
         }
@@ -113,8 +122,22 @@ async fn completed_turn_queues_trace_contribution_for_enrolled_scope() {
     // consent_required without enrolling), and doubles as the
     // inert-until-enrolled control: the sink runs (policy read per turn) but
     // must queue nothing.
+    //
+    // Scope isolation (regression guard for a prior race): this thread runs
+    // under a DISTINCT actor (`CONSENT_CONTROL_ACTOR_ID`), so its capture
+    // scope (`control_scope` below) is entirely disjoint from `scope` — the
+    // canonical scope the SECOND thread enrolls and captures under. The
+    // sink's per-event capture task is detached (`tokio::spawn`), so without
+    // this isolation a slow scheduler could delay the first turn's capture
+    // task until AFTER `write_trace_policy_for_scope(&scope, ...)` below
+    // enrolls it, making the task observe the now-enrolled policy and queue
+    // an envelope into `scope` — inflating the final count to 2. With a
+    // disjoint scope, the control's own scope is NEVER enrolled by this test,
+    // so its capture stays inert regardless of task-scheduling timing; no
+    // sleep is required to make this deterministic.
     let first = group
         .thread("conv-trace-capture-consent")
+        .with_actor_id(CONSENT_CONTROL_ACTOR_ID)
         .script([
             RebornScriptedReply::tool_call(
                 ONBOARD_CAPABILITY_ID,
@@ -128,6 +151,20 @@ async fn completed_turn_queues_trace_contribution_for_enrolled_scope() {
         .build()
         .await
         .expect("first thread builds");
+    let control_scope = trace_scope_key(
+        first.binding.tenant_id.as_str(),
+        first
+            .binding
+            .subject_user_id
+            .as_ref()
+            .expect("resolved binding has a subject user id")
+            .as_str(),
+    );
+    assert_ne!(
+        control_scope, scope,
+        "the control actor must resolve a DIFFERENT trace scope than the \
+         canonical enrolled scope, or scope isolation below proves nothing"
+    );
     first
         .submit_turn("contribute my traces?")
         .await
@@ -136,14 +173,6 @@ async fn completed_turn_queues_trace_contribution_for_enrolled_scope() {
         .assert_tool_invoked(ONBOARD_CAPABILITY_ID)
         .await
         .expect("onboard capability dispatched through the group runtime");
-    // Grace period for the (spawned) capture task: a regression that captures
-    // without enrollment would queue within this window.
-    tokio::time::sleep(Duration::from_millis(300)).await;
-    assert_eq!(
-        queued_trace_envelope_paths_for_scope(Some(&scope)).expect("read queue"),
-        Vec::<std::path::PathBuf>::new(),
-        "capture must stay inert for a non-enrolled scope"
-    );
 
     // Enroll the scope: the same standing-policy state a completed onboard
     // handshake persists.
@@ -166,7 +195,15 @@ async fn completed_turn_queues_trace_contribution_for_enrolled_scope() {
     assert_eq!(
         queued.len(),
         1,
-        "exactly the enrolled turn's envelope is queued (a late capture from \
-         the pre-enrollment turn would make this 2): {queued:?}"
+        "exactly the enrolled turn's envelope is queued (a same-scope late \
+         capture from the pre-enrollment turn would make this 2): {queued:?}"
+    );
+    // The disjoint control scope must stay empty throughout — by now the test
+    // has already waited (up to 10s) for the enrolled envelope above, so any
+    // detached capture task the control turn spawned has long since run.
+    assert_eq!(
+        queued_trace_envelope_paths_for_scope(Some(&control_scope)).expect("read control queue"),
+        Vec::<std::path::PathBuf>::new(),
+        "the never-enrolled control scope must never accumulate a queued envelope"
     );
 }

--- a/tests/integration/webui_v2_router_smoke.rs
+++ b/tests/integration/webui_v2_router_smoke.rs
@@ -1,0 +1,332 @@
+//! `ironclaw_webui_v2` on the int-tier coverage lane (enabler (a)).
+//!
+//! First scenario crossing an enumerated `--test` binary into the WebChat v2
+//! route surface: the crate's own 5,801-line contract suite
+//! (`crates/ironclaw_webui_v2/tests/webui_v2_handlers_contract.rs`) never
+//! runs under the coverage-lane invocation, which passes only the root-tree
+//! suite names.
+//!
+//! Drives the BARE crate router (`webui_v2_router()` over a minimal fake
+//! `RebornServicesApi`), not composition's `webui_v2_app` wrapper — the
+//! wrapper needs the heavier `build_reborn_runtime` tier (named follow-on).
+//! Composition deliberately does not re-export the bare router/state
+//! (facade-only rule), so this suite carries the root DEV-dependency on
+//! `ironclaw_webui_v2` itself — production binaries are unaffected.
+//!
+//! `MinimalWebuiServices` duplicates the role of the contract suite's
+//! `StubServices`; extraction of a shared in-crate `test_support` module was
+//! reviewed and deferred (production-crate touch outside this batch's
+//! budget). The 24 required methods the scenario never calls return the
+//! shared rejecting error (`rejecting_reborn_services_error`, the public
+//! fakes helper — `RebornServicesError::service_unavailable` is
+//! `pub(super)`) so an unexpected dispatch fails loudly.
+//!
+//! Flat suite, no harness mounts: this models an HTTP wire contract, not an
+//! agent turn.
+
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use axum::Router;
+use axum::body::{Body, to_bytes};
+use axum::http::{Method, Request, StatusCode};
+use ironclaw_host_api::{AgentId, ProjectId, TenantId, ThreadId, UserId};
+use ironclaw_product_workflow::{
+    LifecyclePackageRef, RebornCancelRunResponse, RebornCreateThreadResponse,
+    RebornDeleteThreadRequest, RebornDeleteThreadResponse, RebornExtensionActionResponse,
+    RebornExtensionListResponse, RebornExtensionRegistryResponse, RebornGetRunStateRequest,
+    RebornGetRunStateResponse, RebornListAutomationsResponse, RebornListThreadsResponse,
+    RebornOutboundDeliveryTargetListResponse, RebornOutboundPreferencesResponse,
+    RebornResolveGateResponse, RebornServicesApi, RebornServicesError,
+    RebornSetOutboundPreferencesRequest, RebornSetupExtensionResponse, RebornSkillActionResponse,
+    RebornSkillContentResponse, RebornSkillListResponse, RebornSkillSearchResponse,
+    RebornStreamEventsRequest, RebornStreamEventsResponse, RebornSubmitTurnResponse,
+    RebornTimelineRequest, RebornTimelineResponse, WebUiAuthenticatedCaller, WebUiCancelRunRequest,
+    WebUiCreateThreadRequest, WebUiListAutomationsRequest, WebUiListThreadsRequest,
+    WebUiResolveGateRequest, WebUiSendMessageRequest, WebUiSetupExtensionRequest,
+    rejecting_reborn_services_error,
+};
+use ironclaw_threads::{SessionThreadRecord, ThreadScope};
+use ironclaw_webui_v2::{
+    DEFAULT_SSE_MAX_CONCURRENT_PER_CALLER, WebUiV2Capabilities, WebUiV2State, webui_v2_router,
+};
+use serde_json::Value;
+use tower::ServiceExt;
+
+/// Minimal `RebornServicesApi` fake: only `create_thread` is real (records
+/// the request, returns a canned thread); the other 24 required methods
+/// reject with the shared error helper.
+#[derive(Default)]
+struct MinimalWebuiServices {
+    create_thread_calls: Mutex<Vec<WebUiCreateThreadRequest>>,
+}
+
+#[async_trait]
+impl RebornServicesApi for MinimalWebuiServices {
+    async fn create_thread(
+        &self,
+        _caller: WebUiAuthenticatedCaller,
+        request: WebUiCreateThreadRequest,
+    ) -> Result<RebornCreateThreadResponse, RebornServicesError> {
+        self.create_thread_calls.lock().expect("lock").push(request);
+        Ok(RebornCreateThreadResponse {
+            thread: SessionThreadRecord {
+                thread_id: ThreadId::new("thread:webui-v2-smoke").expect("thread id"),
+                scope: ThreadScope {
+                    tenant_id: TenantId::new("tenant-smoke").expect("tenant"),
+                    agent_id: AgentId::new("agent-smoke").expect("agent"),
+                    project_id: None,
+                    owner_user_id: Some(UserId::new("user-smoke").expect("user")),
+                    mission_id: None,
+                },
+                created_by_actor_id: "user-smoke".to_string(),
+                title: None,
+                metadata_json: None,
+                goal: None,
+                created_at: None,
+                updated_at: None,
+            },
+        })
+    }
+
+    async fn submit_turn(
+        &self,
+        _caller: WebUiAuthenticatedCaller,
+        _request: WebUiSendMessageRequest,
+    ) -> Result<RebornSubmitTurnResponse, RebornServicesError> {
+        Err(rejecting_reborn_services_error())
+    }
+
+    async fn delete_thread(
+        &self,
+        _caller: WebUiAuthenticatedCaller,
+        _request: RebornDeleteThreadRequest,
+    ) -> Result<RebornDeleteThreadResponse, RebornServicesError> {
+        Err(rejecting_reborn_services_error())
+    }
+
+    async fn get_timeline(
+        &self,
+        _caller: WebUiAuthenticatedCaller,
+        _request: RebornTimelineRequest,
+    ) -> Result<RebornTimelineResponse, RebornServicesError> {
+        Err(rejecting_reborn_services_error())
+    }
+
+    async fn stream_events(
+        &self,
+        _caller: WebUiAuthenticatedCaller,
+        _request: RebornStreamEventsRequest,
+    ) -> Result<RebornStreamEventsResponse, RebornServicesError> {
+        Err(rejecting_reborn_services_error())
+    }
+
+    async fn cancel_run(
+        &self,
+        _caller: WebUiAuthenticatedCaller,
+        _request: WebUiCancelRunRequest,
+    ) -> Result<RebornCancelRunResponse, RebornServicesError> {
+        Err(rejecting_reborn_services_error())
+    }
+
+    async fn resolve_gate(
+        &self,
+        _caller: WebUiAuthenticatedCaller,
+        _request: WebUiResolveGateRequest,
+    ) -> Result<RebornResolveGateResponse, RebornServicesError> {
+        Err(rejecting_reborn_services_error())
+    }
+
+    async fn get_run_state(
+        &self,
+        _caller: WebUiAuthenticatedCaller,
+        _request: RebornGetRunStateRequest,
+    ) -> Result<RebornGetRunStateResponse, RebornServicesError> {
+        Err(rejecting_reborn_services_error())
+    }
+
+    async fn list_threads(
+        &self,
+        _caller: WebUiAuthenticatedCaller,
+        _request: WebUiListThreadsRequest,
+    ) -> Result<RebornListThreadsResponse, RebornServicesError> {
+        Err(rejecting_reborn_services_error())
+    }
+
+    async fn list_automations(
+        &self,
+        _caller: WebUiAuthenticatedCaller,
+        _request: WebUiListAutomationsRequest,
+    ) -> Result<RebornListAutomationsResponse, RebornServicesError> {
+        Err(rejecting_reborn_services_error())
+    }
+
+    async fn get_outbound_preferences(
+        &self,
+        _caller: WebUiAuthenticatedCaller,
+    ) -> Result<RebornOutboundPreferencesResponse, RebornServicesError> {
+        Err(rejecting_reborn_services_error())
+    }
+
+    async fn set_outbound_preferences(
+        &self,
+        _caller: WebUiAuthenticatedCaller,
+        _request: RebornSetOutboundPreferencesRequest,
+    ) -> Result<RebornOutboundPreferencesResponse, RebornServicesError> {
+        Err(rejecting_reborn_services_error())
+    }
+
+    async fn list_outbound_delivery_targets(
+        &self,
+        _caller: WebUiAuthenticatedCaller,
+    ) -> Result<RebornOutboundDeliveryTargetListResponse, RebornServicesError> {
+        Err(rejecting_reborn_services_error())
+    }
+
+    async fn list_extensions(
+        &self,
+        _caller: WebUiAuthenticatedCaller,
+    ) -> Result<RebornExtensionListResponse, RebornServicesError> {
+        Err(rejecting_reborn_services_error())
+    }
+
+    async fn list_skills(
+        &self,
+        _caller: WebUiAuthenticatedCaller,
+    ) -> Result<RebornSkillListResponse, RebornServicesError> {
+        Err(rejecting_reborn_services_error())
+    }
+
+    async fn search_skills(
+        &self,
+        _caller: WebUiAuthenticatedCaller,
+        _query: String,
+    ) -> Result<RebornSkillSearchResponse, RebornServicesError> {
+        Err(rejecting_reborn_services_error())
+    }
+
+    async fn install_skill(
+        &self,
+        _caller: WebUiAuthenticatedCaller,
+        _name: String,
+        _content: Option<String>,
+    ) -> Result<RebornSkillActionResponse, RebornServicesError> {
+        Err(rejecting_reborn_services_error())
+    }
+
+    async fn read_skill_content(
+        &self,
+        _caller: WebUiAuthenticatedCaller,
+        _name: String,
+    ) -> Result<RebornSkillContentResponse, RebornServicesError> {
+        Err(rejecting_reborn_services_error())
+    }
+
+    async fn update_skill(
+        &self,
+        _caller: WebUiAuthenticatedCaller,
+        _name: String,
+        _content: String,
+    ) -> Result<RebornSkillActionResponse, RebornServicesError> {
+        Err(rejecting_reborn_services_error())
+    }
+
+    async fn remove_skill(
+        &self,
+        _caller: WebUiAuthenticatedCaller,
+        _name: String,
+    ) -> Result<RebornSkillActionResponse, RebornServicesError> {
+        Err(rejecting_reborn_services_error())
+    }
+
+    async fn list_extension_registry(
+        &self,
+        _caller: WebUiAuthenticatedCaller,
+    ) -> Result<RebornExtensionRegistryResponse, RebornServicesError> {
+        Err(rejecting_reborn_services_error())
+    }
+
+    async fn install_extension(
+        &self,
+        _caller: WebUiAuthenticatedCaller,
+        _package_ref: LifecyclePackageRef,
+    ) -> Result<RebornExtensionActionResponse, RebornServicesError> {
+        Err(rejecting_reborn_services_error())
+    }
+
+    async fn activate_extension(
+        &self,
+        _caller: WebUiAuthenticatedCaller,
+        _package_ref: LifecyclePackageRef,
+    ) -> Result<RebornExtensionActionResponse, RebornServicesError> {
+        Err(rejecting_reborn_services_error())
+    }
+
+    async fn remove_extension(
+        &self,
+        _caller: WebUiAuthenticatedCaller,
+        _package_ref: LifecyclePackageRef,
+    ) -> Result<RebornExtensionActionResponse, RebornServicesError> {
+        Err(rejecting_reborn_services_error())
+    }
+
+    async fn setup_extension(
+        &self,
+        _caller: WebUiAuthenticatedCaller,
+        _package_ref: LifecyclePackageRef,
+        _request: WebUiSetupExtensionRequest,
+    ) -> Result<RebornSetupExtensionResponse, RebornServicesError> {
+        Err(rejecting_reborn_services_error())
+    }
+}
+
+/// Router exactly as the crate's contract suite builds it: real
+/// `webui_v2_router`, auth bypassed by injecting the authenticated-caller
+/// `Extension` directly (production composition's bearer middleware
+/// constructs it).
+fn smoke_router(services: Arc<MinimalWebuiServices>) -> Router {
+    webui_v2_router(WebUiV2State::new(
+        services,
+        DEFAULT_SSE_MAX_CONCURRENT_PER_CALLER,
+    ))
+    .layer(axum::Extension(WebUiAuthenticatedCaller::new(
+        TenantId::new("tenant-smoke").expect("tenant"),
+        UserId::new("user-smoke").expect("user"),
+        Some(AgentId::new("agent-smoke").expect("agent")),
+        Some(ProjectId::new("project-smoke").expect("project")),
+    )))
+    .layer(axum::Extension(WebUiV2Capabilities::default()))
+}
+
+#[tokio::test]
+async fn create_thread_round_trips_through_router() {
+    let services = Arc::new(MinimalWebuiServices::default());
+    let router = smoke_router(Arc::clone(&services));
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/api/webchat/v2/threads")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"client_action_id":"smoke-act-1"}"#))
+                .expect("request"),
+        )
+        .await
+        .expect("oneshot");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let bytes = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("body");
+    let body: Value = serde_json::from_slice(&bytes).expect("json body");
+    assert!(
+        body["thread"]["thread_id"].is_string(),
+        "response carries the created thread id: {body}"
+    );
+    assert_eq!(
+        services.create_thread_calls.lock().expect("lock").len(),
+        1,
+        "facade create_thread dispatched exactly once"
+    );
+}


### PR DESCRIPTION
Three coverage enablers, one commit each, ordered by certainty; commit 3 is independently droppable (verified via revert dry-run).

## Reviewer checkpoint (production-crate touch — the ONE in this PR)

Commit 3 adds exactly two `crates/` changes, both in `ironclaw_reborn_composition`:
- `src/test_support/trace_capture.rs` — NEW, 27 lines, `#[cfg(feature = "test-support")]`-gated thin factory over the existing `pub(crate) TraceCaptureTurnEventSink::new` (scope-seed recipe verbatim-identical to `build_reborn_runtime`'s wiring; diffed side-by-side in review). Zero bytes in production binaries; same pattern as the 9 existing `test_support/` files.
- `src/test_support/mod.rs` — +6 lines (module + re-export).
Nothing else under `crates/` or `src/`. If this is vetoed, revert commit 3 alone and the PR stands as (b)+(a).

## Commits

1. **(b) `REBORN_TOOL_DISCLOSURE=Bridged` int-tier coverage** — typed builder field (no env mutation; hermetic-safe), three scenarios on the real 48-capability GitHub manifest surface: bridged deferral (only `tool_search` advertised; flat list absent), Off-mode control, and a below-caps control pinning the wired-but-inert threshold trap (`DisclosureCaps::default().max_tools = 32`). Asserts on the captured `tools` request field, not prompt text. Bridged groups must resolve `CapabilityAllowSet::All` — the narrowed-allowlist interaction is a latent production hazard, filed as #5647.
2. **(a) webui-v2/identity unlock** — `webui-v2-beta` on composition's root dev-dep features + a direct dev-dep on `ironclaw_webui_v2` (composition's facade deliberately doesn't re-export the bare router). Router smoke over a test-local minimal `RebornServicesApi` fake (accepted debt vs webui_v2's own StubServices — documented in the header; production impl `RebornServices` is the W5-WEBUI-API lane's job) + identity resolver smoke via the pre-existing `open_reborn_identity_resolver` test-support factory. Coverage credit: `ironclaw_webui_v2` 0 → 228 covered lines, `ironclaw_reborn_identity` 0 → 156.
3. **(c) trace-capture enabler (C-TRACECAP)** — production `TraceCaptureTurnEventSink` into the existing `turn_event_sink` seam via the test-support factory above. Scenario: real `builtin.trace_commons.onboard` dispatch with `confirmed=false` (consent gate + inert-until-enrolled control) → enroll via pre-existing `write_trace_policy_for_scope` → completed turn queues exactly one envelope, asserted through the public `queued_trace_envelope_paths_for_scope` API. The plan's scripted-onboard route is provably infeasible (client cross-checks the server-echoed `device_key_id` against a local ephemeral key — `onboarding/mod.rs` step 6); divergence documented. `IRONCLAW_BASE_DIR` pinned to a tempdir first-thing (OnceLock). Coverage credit: `ironclaw_reborn_traces` `contribution.rs` 0 → 1,289 covered lines.

## Verification

Full-workspace clippy zero warnings; fmt clean; suites: tool_disclosure 9/9, trace_capture 7/7, tracecap 9/9 (regression), tool_call 12/12, both smokes green. Post-impl thermo-nuclear review: APPROVE ×3 (one non-blocking follow-up suggestion: rename `tracecap.rs` → e.g. `turn_event_sink_smoke.rs` to de-collide with `trace_capture.rs`).

Feature-unification note: the dev-dep features compile `ironclaw_webui_v2`/`ironclaw_reborn_identity` into every int-tier build (behaviorally inert for other suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)