### PR TITLE
fix(ironclaw_llm): repair provider-corrupted tool-call argument JSON

### DIFF
--- a/crates/ironclaw_llm/src/lib.rs
+++ b/crates/ironclaw_llm/src/lib.rs
@@ -42,6 +42,7 @@ pub mod runtime;
 pub mod session;
 pub mod smart_routing;
 mod token_refreshing;
+mod tool_repair;
 // arch-exempt: scaffolding, Phase A helpers awaiting first per-provider caller, plan #4522
 // Remove the allow once any production call site references these items.
 #[allow(dead_code)]

--- a/crates/ironclaw_llm/src/nearai_chat.rs
+++ b/crates/ironclaw_llm/src/nearai_chat.rs
@@ -27,6 +27,8 @@ use crate::provider::{
 
 #[path = "nearai_tool_message_flattening.rs"]
 mod nearai_tool_message_flattening;
+use crate::tool_args::parse_tool_call_args_lossy;
+use crate::tool_repair::repair_tool_args;
 use crate::tool_schema::{ToolSchemaPolicy, shape_tool_schema};
 use crate::{costs, session::SessionManager};
 
@@ -654,19 +656,25 @@ impl LlmProvider for NearAiChatProvider {
         emit_reasoning_trace(reasoning_fallback.as_deref());
         let provider_reasoning = reasoning_fallback.clone();
 
+        let raw_finish_reason = choice.finish_reason.as_deref();
+        let allow_argument_completion = raw_finish_reason != Some("length");
+
         let tool_calls: Vec<ToolCall> = message_tool_calls
             .unwrap_or_default()
             .into_iter()
             .map(|tc| {
-                let arguments = serde_json::from_str(&tc.function.arguments)
-                    .unwrap_or(serde_json::Value::Object(Default::default()));
+                let arguments = parse_tool_call_arguments(
+                    &tc.function.name,
+                    &tc.function.arguments,
+                    allow_argument_completion,
+                );
                 ToolCall {
                     id: tc.id,
                     name: tc.function.name,
-                    arguments,
+                    arguments: arguments.0,
                     reasoning: None,
                     signature: None,
-                    arguments_parse_error: None,
+                    arguments_parse_error: arguments.1,
                 }
             })
             .collect();
@@ -683,7 +691,7 @@ impl LlmProvider for NearAiChatProvider {
             message_content
         };
 
-        let finish_reason = match choice.finish_reason.as_deref() {
+        let finish_reason = match raw_finish_reason {
             Some("stop") => FinishReason::Stop,
             Some("length") => FinishReason::Length,
             Some("tool_calls") => FinishReason::ToolUse,
@@ -1177,6 +1185,29 @@ fn saturate_u32(val: u64) -> u32 {
 fn emit_reasoning_trace(reasoning: Option<&str>) {
     if let Some(rc) = reasoning.filter(|s| !s.is_empty()) {
         tracing::trace!(target: "ironclaw_llm::reasoning", "{rc}");
+    }
+}
+
+fn parse_tool_call_arguments(
+    tool_name: &str,
+    raw_arguments: &str,
+    allow_completion: bool,
+) -> (serde_json::Value, Option<String>) {
+    match serde_json::from_str(raw_arguments) {
+        Ok(arguments) => (arguments, None),
+        Err(parse_error) => {
+            if let Some(arguments) = repair_tool_args(raw_arguments, allow_completion) {
+                tracing::debug!(
+                    tool_name = %tool_name,
+                    raw_len = raw_arguments.len(),
+                    error = %parse_error,
+                    "repaired malformed NEAR AI tool-call arguments JSON"
+                );
+                (arguments, None)
+            } else {
+                parse_tool_call_args_lossy(raw_arguments)
+            }
+        }
     }
 }
 
@@ -1915,6 +1946,24 @@ mod tests {
         let (default_in, default_out) = costs::default_cost();
         assert_eq!(input, default_in);
         assert_eq!(output, default_out);
+    }
+
+    #[test]
+    fn length_truncated_tool_arguments_fall_back_to_empty_object_with_error() {
+        let (arguments, parse_error) =
+            parse_tool_call_arguments("write_file", r#"{"path":"/tmp/a","content":"hel"#, false);
+        assert_eq!(arguments, serde_json::Value::Object(Default::default()));
+        assert!(parse_error.as_deref().is_some_and(|reason| {
+            reason.starts_with("failed to parse tool-call arguments JSON: ")
+        }));
+    }
+
+    #[test]
+    fn non_truncated_leaked_tag_tool_arguments_are_repaired_without_error() {
+        let (arguments, parse_error) =
+            parse_tool_call_arguments("shell", r#"{"command":"cat"}</parameter>"#, true);
+        assert_eq!(arguments["command"], "cat");
+        assert!(parse_error.is_none());
     }
 
     /// Regression: reasoning fallbacks must NOT leak into tool-call responses.

--- a/crates/ironclaw_llm/src/reasoning.rs
+++ b/crates/ironclaw_llm/src/reasoning.rs
@@ -9,6 +9,8 @@ use ironclaw_common::provider_transcript::strip_provider_transcript_artifact_lin
 
 use crate::error::LlmError;
 
+use crate::tool_args::parse_tool_call_args_lossy;
+use crate::tool_repair::repair_tool_args;
 use crate::{
     ChatMessage, CompletionRequest, FinishReason, LlmProvider, Role, ToolCall,
     ToolCompletionRequest, ToolDefinition,
@@ -1709,8 +1711,23 @@ pub fn recover_tool_calls_from_content(
                 // so find the last "]" on this logical line.
                 if let Some(bracket_end) = args_start.rfind(']') {
                     let args_str = &args_start[..bracket_end];
-                    let arguments = serde_json::from_str::<serde_json::Value>(args_str)
-                        .unwrap_or(serde_json::Value::Object(Default::default()));
+                    let (arguments, arguments_parse_error) =
+                        match serde_json::from_str::<serde_json::Value>(args_str) {
+                            Ok(arguments) => (arguments, None),
+                            Err(parse_error) => {
+                                if let Some(arguments) = repair_tool_args(args_str, false) {
+                                    tracing::debug!(
+                                        tool_name = %name,
+                                        raw_len = args_str.len(),
+                                        error = %parse_error,
+                                        "repaired recovered tool-call arguments JSON"
+                                    );
+                                    (arguments, None)
+                                } else {
+                                    parse_tool_call_args_lossy(args_str)
+                                }
+                            }
+                        };
                     calls.push(ToolCall {
                         id: super::provider::generate_tool_call_id(
                             calls.len(),
@@ -1720,7 +1737,7 @@ pub fn recover_tool_calls_from_content(
                         arguments,
                         reasoning: None,
                         signature: None,
-                        arguments_parse_error: None,
+                        arguments_parse_error,
                     });
                     remaining = &args_start[bracket_end + 1..];
                     continue;
@@ -3246,6 +3263,39 @@ That's my plan."#;
         assert_eq!(calls[0].name, "http");
         assert_eq!(calls[0].arguments["method"], "GET");
         assert_eq!(calls[0].arguments["url"], "https://example.com");
+        assert!(calls[0].arguments_parse_error.is_none());
+    }
+
+    #[test]
+    fn test_recover_bracket_format_repairs_trailing_tool_arg_tag() {
+        let tools = make_tools(&["shell"]);
+        let content = "Let me run that. [Called tool `shell` with arguments: {\"command\":\"cat\",\"content\":\"hello\"}</parameter>]";
+        let calls = recover_tool_calls_from_content(content, &tools);
+
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "shell");
+        assert_eq!(calls[0].arguments["command"], "cat");
+        assert_eq!(calls[0].arguments["content"], "hello");
+        assert!(calls[0].arguments_parse_error.is_none());
+    }
+
+    #[test]
+    fn test_recover_bracket_format_unrepairable_args_preserves_parse_error() {
+        let tools = make_tools(&["shell"]);
+        let content = "Let me run that. [Called tool `shell` with arguments: {not json}]";
+        let calls = recover_tool_calls_from_content(content, &tools);
+
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "shell");
+        assert_eq!(
+            calls[0].arguments,
+            serde_json::Value::Object(Default::default())
+        );
+        assert!(
+            calls[0].arguments_parse_error.as_deref().is_some_and(
+                |reason| reason.starts_with("failed to parse tool-call arguments JSON: ")
+            )
+        );
     }
 
     #[test]

--- a/crates/ironclaw_llm/src/rig_adapter.rs
+++ b/crates/ironclaw_llm/src/rig_adapter.rs
@@ -33,6 +33,8 @@ use crate::provider::{
     ToolDefinition as IronToolDefinition, strip_unsupported_completion_params,
     strip_unsupported_tool_params,
 };
+use crate::tool_args::parse_tool_call_args_lossy;
+use crate::tool_repair::repair_tool_args;
 use crate::tool_schema::{ToolSchemaPolicy, shape_tool_schema};
 #[cfg(test)]
 use crate::tool_schema::{normalize_schema_strict, serialize_json_capped};
@@ -681,6 +683,7 @@ fn rig_reasoning_to_iron(reasoning: &rig::message::Reasoning) -> Option<IronReas
 fn extract_response(
     choice: &OneOrMany<AssistantContent>,
     _usage: &RigUsage,
+    allow_argument_completion: bool,
 ) -> (
     Option<String>,
     Vec<IronToolCall>,
@@ -701,17 +704,22 @@ fn extract_response(
             }
             AssistantContent::Text(_) => {}
             AssistantContent::ToolCall(tc) => {
+                let arguments = repair_rig_tool_arguments(
+                    &tc.function.name,
+                    &tc.function.arguments,
+                    allow_argument_completion,
+                );
                 tool_calls.push(IronToolCall {
                     id: tc.id.clone(),
                     name: tc.function.name.clone(),
-                    arguments: tc.function.arguments.clone(),
+                    arguments: arguments.0,
                     reasoning: None,
                     // Capture Gemini `thought_signature` (and any other
                     // per-tool-call signatures) so the next turn can echo
                     // them. Without this, Gemini 2.5+ rejects the next
                     // request with HTTP 400. See #3225.
                     signature: tc.signature.clone(),
-                    arguments_parse_error: None,
+                    arguments_parse_error: arguments.1,
                 });
             }
             AssistantContent::Reasoning(r) if !r.content.is_empty() => {
@@ -759,6 +767,32 @@ fn extract_response(
     (text, tool_calls, finish, reasoning, typed_reasoning)
 }
 
+fn repair_rig_tool_arguments(
+    tool_name: &str,
+    arguments: &serde_json::Value,
+    allow_completion: bool,
+) -> (serde_json::Value, Option<String>) {
+    let Some(raw) = arguments.as_str() else {
+        return (arguments.clone(), None);
+    };
+
+    match serde_json::from_str::<serde_json::Value>(raw) {
+        Ok(parsed) => (parsed, None),
+        Err(parse_error) => {
+            let Some(repaired) = repair_tool_args(raw, allow_completion) else {
+                return parse_tool_call_args_lossy(raw);
+            };
+            tracing::debug!(
+                tool_name = %tool_name,
+                raw_len = raw.len(),
+                error = %parse_error,
+                "repaired malformed rig tool-call arguments JSON"
+            );
+            (repaired, None)
+        }
+    }
+}
+
 /// Saturate u64 to u32 for token counts.
 fn saturate_u32(val: u64) -> u32 {
     val.min(u32::MAX as u64) as u32
@@ -791,6 +825,38 @@ fn extract_cache_creation<T: Serialize>(raw: &T) -> u32 {
         .and_then(|v| v.get("usage")?.get("cache_creation_input_tokens")?.as_u64())
         .map(|n| n.min(u32::MAX as u64) as u32)
         .unwrap_or(0)
+}
+
+fn raw_response_finish_reason<T: Serialize>(raw: &T) -> Option<FinishReason> {
+    let value = serde_json::to_value(raw).ok()?;
+    find_finish_reason(&value).map(map_raw_finish_reason)
+}
+
+fn find_finish_reason(value: &serde_json::Value) -> Option<&str> {
+    if let Some(reason) = value
+        .get("finish_reason")
+        .and_then(serde_json::Value::as_str)
+    {
+        return Some(reason);
+    }
+    if let Some(reason) = value.get("stop_reason").and_then(serde_json::Value::as_str) {
+        return Some(reason);
+    }
+    value
+        .get("choices")
+        .and_then(serde_json::Value::as_array)?
+        .iter()
+        .find_map(find_finish_reason)
+}
+
+fn map_raw_finish_reason(reason: &str) -> FinishReason {
+    match reason.to_ascii_lowercase().as_str() {
+        "length" | "max_tokens" | "max_output_tokens" => FinishReason::Length,
+        "tool_calls" | "tool_use" => FinishReason::ToolUse,
+        "content_filter" | "safety" => FinishReason::ContentFilter,
+        "stop" | "end_turn" => FinishReason::Stop,
+        _ => FinishReason::Unknown,
+    }
 }
 
 /// Merge default additional parameters into the rig-core request.
@@ -967,8 +1033,10 @@ where
             .await
             .map_err(|e| map_rig_error(&self.model_name, e))?;
 
+        let allow_argument_completion =
+            raw_response_finish_reason(&response.raw_response) != Some(FinishReason::Length);
         let (text, _tool_calls, finish, _reasoning, _reasoning_details) =
-            extract_response(&response.choice, &response.usage);
+            extract_response(&response.choice, &response.usage, allow_argument_completion);
 
         let resp = CompletionResponse {
             content: text.unwrap_or_default(),
@@ -1029,8 +1097,10 @@ where
             .await
             .map_err(|e| map_rig_error(&self.model_name, e))?;
 
+        let allow_argument_completion =
+            raw_response_finish_reason(&response.raw_response) != Some(FinishReason::Length);
         let (text, mut tool_calls, finish, reasoning, reasoning_details) =
-            extract_response(&response.choice, &response.usage);
+            extract_response(&response.choice, &response.usage, allow_argument_completion);
 
         // Normalize tool call names: some proxies prepend "proxy_" prefixes.
         for tc in &mut tool_calls {
@@ -2200,7 +2270,7 @@ mod tests {
         let content = OneOrMany::one(AssistantContent::text("Hello world"));
         let usage = RigUsage::new();
         let (text, calls, finish, _reasoning, _reasoning_details) =
-            extract_response(&content, &usage);
+            extract_response(&content, &usage, true);
         assert_eq!(text, Some("Hello world".to_string()));
         assert!(calls.is_empty());
         assert_eq!(finish, FinishReason::Stop);
@@ -2212,7 +2282,7 @@ mod tests {
         let content = OneOrMany::one(tc);
         let usage = RigUsage::new();
         let (text, calls, finish, _reasoning, _reasoning_details) =
-            extract_response(&content, &usage);
+            extract_response(&content, &usage, true);
         assert!(text.is_none());
         assert_eq!(calls.len(), 1);
         assert_eq!(calls[0].name, "search");
@@ -3030,6 +3100,82 @@ mod tests {
         }
     }
 
+    #[test]
+    fn extract_response_repairs_malformed_string_tool_arguments() {
+        let rig_response = OneOrMany::one(AssistantContent::ToolCall(rig::message::ToolCall::new(
+            "call_abc123".to_string(),
+            ToolFunction::new(
+                "shell".to_string(),
+                serde_json::Value::String(
+                    r#"{"command":"cat","content":"hello"}</parameter>"#.to_string(),
+                ),
+            ),
+        )));
+        let usage = RigUsage::new();
+        let (_text, tool_calls, finish, _reasoning, _reasoning_details) =
+            extract_response(&rig_response, &usage, true);
+
+        assert_eq!(finish, FinishReason::ToolUse);
+        assert_eq!(tool_calls.len(), 1);
+        assert_eq!(tool_calls[0].arguments["command"], "cat");
+        assert_eq!(tool_calls[0].arguments["content"], "hello");
+        assert!(tool_calls[0].arguments_parse_error.is_none());
+    }
+
+    #[test]
+    fn extract_response_promotes_valid_string_and_preserves_object_tool_arguments() {
+        let rig_response = OneOrMany::many(vec![
+            AssistantContent::ToolCall(rig::message::ToolCall::new(
+                "call_string".to_string(),
+                ToolFunction::new(
+                    "shell".to_string(),
+                    serde_json::Value::String(r#"{"command":"pwd"}"#.to_string()),
+                ),
+            )),
+            AssistantContent::ToolCall(rig::message::ToolCall::new(
+                "call_object".to_string(),
+                ToolFunction::new("shell".to_string(), serde_json::json!({"command": "ls"})),
+            )),
+        ])
+        .unwrap();
+        let usage = RigUsage::new();
+        let (_text, tool_calls, finish, _reasoning, _reasoning_details) =
+            extract_response(&rig_response, &usage, true);
+
+        assert_eq!(finish, FinishReason::ToolUse);
+        assert_eq!(tool_calls.len(), 2);
+        assert_eq!(tool_calls[0].arguments["command"], "pwd");
+        assert!(tool_calls[0].arguments_parse_error.is_none());
+        assert_eq!(tool_calls[1].arguments["command"], "ls");
+        assert!(tool_calls[1].arguments_parse_error.is_none());
+    }
+
+    #[test]
+    fn extract_response_does_not_complete_length_truncated_tool_arguments() {
+        let rig_response = OneOrMany::one(AssistantContent::ToolCall(rig::message::ToolCall::new(
+            "call_abc123".to_string(),
+            ToolFunction::new(
+                "write_file".to_string(),
+                serde_json::Value::String(r#"{"path":"/tmp/a","content":"hel"#.to_string()),
+            ),
+        )));
+        let usage = RigUsage::new();
+        let (_text, tool_calls, finish, _reasoning, _reasoning_details) =
+            extract_response(&rig_response, &usage, false);
+
+        assert_eq!(finish, FinishReason::ToolUse);
+        assert_eq!(tool_calls.len(), 1);
+        assert_eq!(
+            tool_calls[0].arguments,
+            serde_json::Value::Object(Default::default())
+        );
+        assert!(
+            tool_calls[0].arguments_parse_error.as_deref().is_some_and(
+                |reason| reason.starts_with("failed to parse tool-call arguments JSON: ")
+            )
+        );
+    }
+
     /// Regression for #3201 / #3225 (the high-severity gap in PR #3326):
     /// the dedicated rig-core DeepSeek/Gemini/OpenRouter clients only fix the
     /// reasoning round-trip *inside* rig-core. IronClaw's RigAdapter sits
@@ -3067,7 +3213,7 @@ mod tests {
         .unwrap();
         let usage = RigUsage::new();
         let (text, tool_calls, finish, reasoning, reasoning_details) =
-            extract_response(&rig_response, &usage);
+            extract_response(&rig_response, &usage, true);
 
         assert_eq!(finish, FinishReason::ToolUse);
         assert_eq!(text, None);
@@ -3175,7 +3321,7 @@ mod tests {
 
         let usage = RigUsage::new();
         let (text, tool_calls, _finish, reasoning, reasoning_details) =
-            extract_response(&rig_response, &usage);
+            extract_response(&rig_response, &usage, true);
 
         assert_eq!(text, None);
         assert_eq!(reasoning.as_deref(), Some("safe summary"));

--- a/crates/ironclaw_llm/src/tool_repair.rs
+++ b/crates/ironclaw_llm/src/tool_repair.rs
@@ -1,0 +1,311 @@
+//! Deterministic repair for malformed provider tool-call argument JSON.
+
+use serde_json::Value;
+
+const MAX_REPAIR_BYTES: usize = 64 * 1024;
+
+/// Repair provider-emitted tool-call argument JSON when a minimal deterministic
+/// fix makes it parse.
+///
+/// Inspired by the LAB Meta-Harness `toolcall_json_repair` mechanism: Lee et
+/// al., "Meta-Harness: End-to-End Optimization of Model Harnesses",
+/// arXiv:2603.28052 (MIT).
+pub(crate) fn repair_tool_args(args: &str, allow_completion: bool) -> Option<Value> {
+    if args.len() > MAX_REPAIR_BYTES || args.trim().is_empty() || parses_json(args) {
+        return None;
+    }
+
+    let stripped = strip_trailing_leaked_tags(args);
+    if stripped != args
+        && let Ok(value) = serde_json::from_str::<Value>(&stripped)
+    {
+        return Some(value);
+    }
+
+    if !allow_completion {
+        return None;
+    }
+
+    if stripped != args
+        && let Some(value) = complete_truncated_json(&stripped)
+            .filter(|completed| completed != args)
+            .and_then(|completed| serde_json::from_str::<Value>(&completed).ok())
+    {
+        return Some(value);
+    }
+
+    complete_truncated_json(args)
+        .filter(|completed| completed != args)
+        .and_then(|completed| serde_json::from_str::<Value>(&completed).ok())
+}
+
+fn parses_json(input: &str) -> bool {
+    serde_json::from_str::<serde::de::IgnoredAny>(input).is_ok()
+}
+
+fn strip_trailing_leaked_tags(input: &str) -> String {
+    let trimmed_end = trim_end_index(input);
+    if !may_end_with_xmlish_tag(&input[..trimmed_end]) {
+        return input.to_owned();
+    }
+
+    let mut candidate = input.to_owned();
+
+    loop {
+        let trimmed_end = trim_end_index(&candidate);
+        let Some(start) = trailing_xmlish_tag_start(&candidate[..trimmed_end]) else {
+            break;
+        };
+        candidate.truncate(start);
+    }
+
+    candidate
+}
+
+fn may_end_with_xmlish_tag(input: &str) -> bool {
+    match input.char_indices().next_back() {
+        Some((_, '>')) => true,
+        Some((_, ch)) => is_tag_name_continue(ch),
+        None => false,
+    }
+}
+
+fn trim_end_index(input: &str) -> usize {
+    input
+        .char_indices()
+        .rev()
+        .find(|(_, ch)| !ch.is_whitespace())
+        .map(|(idx, ch)| idx + ch.len_utf8())
+        .unwrap_or(0)
+}
+
+fn trailing_xmlish_tag_start(input: &str) -> Option<usize> {
+    if input.is_empty() {
+        return None;
+    }
+
+    let tag_body_end = match input.char_indices().next_back() {
+        Some((idx, '>')) => idx,
+        Some((idx, ch)) => idx + ch.len_utf8(),
+        None => return None,
+    };
+    let name_end = trim_end_index(&input[..tag_body_end]);
+    let start = input[..name_end].rfind('<')?;
+    let mut chars = input[start + '<'.len_utf8()..name_end].chars().peekable();
+
+    if chars.next_if_eq(&'/').is_none() || chars.peek().is_none() {
+        return None;
+    }
+
+    let first = chars.next()?;
+    if !is_tag_name_start(first) {
+        return None;
+    }
+    if !chars.all(is_tag_name_continue) {
+        return None;
+    }
+
+    Some(start)
+}
+
+fn is_tag_name_start(ch: char) -> bool {
+    ch.is_ascii_alphabetic() || ch == '_' || ch == '\u{2581}'
+}
+
+fn is_tag_name_continue(ch: char) -> bool {
+    ch.is_ascii_alphanumeric() || matches!(ch, '_' | '\u{2581}' | '.' | '-')
+}
+
+fn complete_truncated_json(input: &str) -> Option<String> {
+    let mut stack = Vec::new();
+    let mut in_string = false;
+    let mut escaped = false;
+
+    for ch in input.chars() {
+        if in_string {
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == '"' {
+                in_string = false;
+            }
+            continue;
+        }
+
+        match ch {
+            '"' => in_string = true,
+            '{' => stack.push('}'),
+            '[' => stack.push(']'),
+            '}' | ']' => {
+                // Bind before the check so this stays a plain arm body rather
+                // than a match guard (keeps clippy::collapsible_match quiet and
+                // the stack side effect explicit).
+                let matched = stack.pop() == Some(ch);
+                if !matched {
+                    return None;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    if stack.is_empty() && !in_string && !escaped {
+        return None;
+    }
+
+    let mut candidate = input.to_owned();
+    if in_string {
+        if let Some(start) = incomplete_escape_start(&candidate) {
+            candidate.truncate(start);
+        }
+        candidate.push('"');
+    }
+    for closer in stack.iter().rev() {
+        candidate.push(*closer);
+    }
+
+    Some(candidate)
+}
+
+fn incomplete_escape_start(input: &str) -> Option<usize> {
+    let slash = input.rfind('\\')?;
+    if !is_active_escape(input, slash) {
+        return None;
+    }
+
+    let tail = &input[slash + '\\'.len_utf8()..];
+    if tail.is_empty() {
+        return Some(slash);
+    }
+
+    let digits = tail.strip_prefix('u')?;
+    let digit_count = digits.chars().count();
+    if digit_count < 4 && digits.chars().all(|ch| ch.is_ascii_hexdigit()) {
+        Some(slash)
+    } else {
+        None
+    }
+}
+
+fn is_active_escape(input: &str, slash: usize) -> bool {
+    input[..slash]
+        .chars()
+        .rev()
+        .take_while(|ch| *ch == '\\')
+        .count()
+        % 2
+        == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::Value;
+
+    fn repaired_value(input: &str) -> Value {
+        repair_tool_args(input, true).expect("input should repair")
+    }
+
+    #[test]
+    fn valid_json_returns_none() {
+        assert_eq!(repair_tool_args(r#"{"command":"ls"}"#, true), None);
+    }
+
+    #[test]
+    fn strips_trailing_parameter_tag() {
+        let value = repaired_value(r#"{"command":"ls"}</parameter>"#);
+        assert_eq!(value["command"], "ls");
+    }
+
+    #[test]
+    fn completes_object_truncated_mid_string() {
+        let value = repaired_value(r#"{"command":"cat","content":"hello"#);
+        assert_eq!(value["command"], "cat");
+        assert_eq!(value["content"], "hello");
+    }
+
+    #[test]
+    fn strips_deepseek_sentencepiece_tool_call_tag() {
+        let value = repaired_value("{\"content\":\"ok\"}</tool\u{2581}call>");
+        assert_eq!(value["content"], "ok");
+    }
+
+    #[test]
+    fn balances_nested_array_truncation() {
+        let value = repaired_value(r#"{"items":[{"content":"one"},{"content":"two"#);
+        assert_eq!(value["items"][0]["content"], "one");
+        assert_eq!(value["items"][1]["content"], "two");
+    }
+
+    #[test]
+    fn drops_dangling_escape_before_closing_open_string() {
+        let value = repaired_value(r#"{"content":"abc\"#);
+        assert_eq!(value["content"], "abc");
+    }
+
+    #[test]
+    fn drops_incomplete_unicode_escape_before_closing_open_string() {
+        let value = repaired_value(r#"{"command":"cat","content":"ab\u003"#);
+        assert_eq!(value["command"], "cat");
+        assert_eq!(value["content"], "ab");
+    }
+
+    #[test]
+    fn strips_then_completes_trailing_tag_inside_open_string() {
+        let value = repaired_value(r#"{"command":"cat","content":"hell</parameter>"#);
+        assert_eq!(value["command"], "cat");
+        assert_eq!(value["content"], "hell");
+    }
+
+    #[test]
+    fn strips_two_stacked_trailing_tags() {
+        let value = repaired_value(r#"{"k":"v"}</parameter></tool_call>"#);
+        assert_eq!(value["k"], "v");
+    }
+
+    #[test]
+    fn does_not_strip_incomplete_opening_tag_content() {
+        assert_eq!(repair_tool_args(r#"{"content":"see <b"#, false), None);
+
+        let value = repaired_value(r#"{"content":"see <b"#);
+        assert_eq!(value["content"], "see <b");
+    }
+
+    #[test]
+    fn empty_or_whitespace_returns_none() {
+        assert_eq!(repair_tool_args("", true), None);
+        assert_eq!(repair_tool_args(" \n\t", true), None);
+    }
+
+    #[test]
+    fn mismatched_bracket_returns_none() {
+        assert_eq!(repair_tool_args(r#"{"foo":[}"#, true), None);
+    }
+
+    #[test]
+    fn completion_disallowed_does_not_complete_truncated_json() {
+        assert_eq!(
+            repair_tool_args(r#"{"path":"/tmp/a","content":"hel"#, false),
+            None
+        );
+    }
+
+    #[test]
+    fn completion_disallowed_still_strips_complete_trailing_tag() {
+        let value = repair_tool_args(r#"{"command":"cat"}</parameter>"#, false)
+            .expect("stripping should repair complete JSON");
+        assert_eq!(value["command"], "cat");
+    }
+
+    #[test]
+    fn oversized_input_returns_none() {
+        let input = format!("{}x", " ".repeat(MAX_REPAIR_BYTES));
+        assert_eq!(repair_tool_args(&input, true), None);
+    }
+
+    #[test]
+    fn unrepairable_garbage_returns_none() {
+        assert_eq!(repair_tool_args("not json", true), None);
+    }
+}


### PR DESCRIPTION
## Problem

When an OpenAI-compatible provider (OpenRouter, NEAR AI Cloud) bleeds a model's native XML tool-call format through the OpenAI-compat translation, the tool call's `arguments` string arrives truncated or with a leaked trailing tag — e.g. `</parameter>`, or DeepSeek's `</tool▁call>` with the U+2581 SentencePiece underscore. `serde_json` then rejects it, and today the code either:

- falls back to an empty `{}` object, so the tool runs with **no arguments** (silently wrong), or
- the provider rejects the re-sent history with `HTTP 400 process_messages_failed: Invalid JSON in tool call arguments`, sinking the whole turn.

## Change

Add `crates/ironclaw_llm/src/tool_repair.rs::repair_tool_args` — a deterministic, **zero-regression** repair that only runs when the raw string already fails to parse:

1. **Strip leaked trailing XML-ish tags** — always safe (the arguments were complete; a tag just leaked onto the end).
2. **Complete truncated JSON** (balance an open string + the `{`/`[` stack) — but only when the response was **not** length-truncated.

Truncation-completion is gated on a non-length finish reason (threaded from the rig `raw_response`, the NEAR AI `finish_reason`, and defaulted off in the prose-recovery path), so a genuinely cut-off side-effecting tool call is never executed with partial arguments. A 64 KiB input cap bounds the work, and the function returns the already-validated `Value` to remove a redundant re-parse at each call site.

Wired into `rig_adapter.rs`, `nearai_chat.rs`, and `reasoning.rs` (`recover_tool_calls_from_content`). The rig path also now promotes already-valid string-encoded arguments to a parsed object (previously they passed through as a `Value::String`, so downstream `args["field"]` indexing silently returned `Null`).

## Tests

19 new unit/integration tests: strip / complete / strip-then-complete, stacked tags, DeepSeek U+2581, incomplete `\u` escape, dangling escape, oversized input, empty/whitespace, mismatched brackets, gated completion (length-truncated → empty fallback vs non-truncated leaked-tag → repaired), and rig string-promotion / object pass-through.

- `cargo test -p ironclaw_llm` → 915 passed
- `cargo clippy -p ironclaw_llm --lib --tests` → clean
- `cargo fmt --check` → clean

Technique adapted from the Meta-Harness LAB harness (Lee et al., "Meta-Harness: End-to-End Optimization of Model Harnesses", [arXiv:2603.28052](https://arxiv.org/abs/2603.28052)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
