### PR TITLE
ci: include PR context in canary Slack reports

### DIFF
--- a/.github/workflows/live-canary-command.yml
+++ b/.github/workflows/live-canary-command.yml
@@ -87,12 +87,15 @@ jobs:
             exit 0
           fi
 
-          head_sha="$(gh pr view "$PR" --repo "$REPO" --json headRefOid --jq .headRefOid)"
+          pr_head="$(gh pr view "$PR" --repo "$REPO" --json headRefName,headRefOid)"
+          head_ref="$(printf '%s' "$pr_head" | jq -r .headRefName)"
+          head_sha="$(printf '%s' "$pr_head" | jq -r .headRefOid)"
           short_sha="${head_sha:0:10}"
           trigger_context="/canary PR #${PR} ${short_sha} comment ${COMMENT_ID} by @${COMMENT_AUTHOR}"
 
           {
             echo "cases=$cases"
+            echo "head_ref=$head_ref"
             echo "head_sha=$head_sha"
             echo "short_sha=$short_sha"
             echo "trigger_context=$trigger_context"
@@ -112,6 +115,7 @@ jobs:
         env:
           CASES: ${{ steps.parse.outputs.cases }}
           GH_TOKEN: ${{ github.token }}
+          HEAD_REF: ${{ steps.parse.outputs.head_ref }}
           HEAD_SHA: ${{ steps.parse.outputs.head_sha }}
           PR: ${{ github.event.issue.number }}
           REPO: ${{ github.repository }}
@@ -124,6 +128,7 @@ jobs:
             -f lane=reborn-webui-v2-live-qa \
             -f cases="$CASES" \
             -f target_ref="$HEAD_SHA" \
+            -f target_branch="$HEAD_REF" \
             -f target_pr="$PR" \
             -f trigger_context="$TRIGGER_CONTEXT"
 
@@ -132,6 +137,7 @@ jobs:
         env:
           CASES: ${{ steps.parse.outputs.cases }}
           GH_TOKEN: ${{ github.token }}
+          HEAD_REF: ${{ steps.parse.outputs.head_ref }}
           PR: ${{ github.event.issue.number }}
           REPO: ${{ github.repository }}
           SHORT_SHA: ${{ steps.parse.outputs.short_sha }}
@@ -159,4 +165,4 @@ jobs:
           fi
 
           gh pr comment "$PR" --repo "$REPO" --body \
-            "Started Reborn WebUI v2 live canary for \`${SHORT_SHA}\` with cases \`${CASES}\`: ${run_url}"
+            "Started Reborn WebUI v2 live canary for \`${HEAD_REF}\` at \`${SHORT_SHA}\` with cases \`${CASES}\`: ${run_url}"

--- a/.github/workflows/live-canary.yml
+++ b/.github/workflows/live-canary.yml
@@ -51,6 +51,11 @@ on:
         type: string
         required: false
         default: ""
+      target_branch:
+        description: "Optional branch name for the Reborn WebUI v2 live QA checkout. Used by /canary PR comments."
+        type: string
+        required: false
+        default: ""
       target_pr:
         description: "Optional pull request number for validating target_ref before running Reborn WebUI v2 live QA with secrets."
         type: string
@@ -1169,6 +1174,10 @@ jobs:
           CANARY_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GITHUB_SHA: ${{ github.sha }}
           GITHUB_REPOSITORY: ${{ github.repository }}
+          CANARY_TARGET_BRANCH: ${{ github.event_name == 'workflow_dispatch' && inputs.target_branch || '' }}
+          CANARY_TARGET_PR: ${{ github.event_name == 'workflow_dispatch' && inputs.target_pr || '' }}
+          CANARY_TARGET_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.target_ref || '' }}
+          CANARY_TRIGGER_CONTEXT: ${{ github.event_name == 'workflow_dispatch' && inputs.trigger_context || '' }}
           CANARY_CREATE_ISSUES: "0"
         run: |
           # The notifier is intentionally side-effect-light: it exits 0 even on

--- a/scripts/live-canary/notify_slack.py
+++ b/scripts/live-canary/notify_slack.py
@@ -110,6 +110,15 @@ class LaneReport:
     reborn_qa_cases: list[RebornQaCaseReport] = field(default_factory=list)
 
 
+@dataclass(frozen=True)
+class CanaryRunContext:
+    repository: str = ""
+    trigger_context: str = ""
+    target_pr: str = ""
+    target_branch: str = ""
+    target_ref: str = ""
+
+
 def read_tail(path: Path, n_bytes: int) -> str:
     if not path.exists():
         return ""
@@ -706,12 +715,34 @@ def _format_reborn_qa_groups(
     return blocks
 
 
+def _format_run_context(context: CanaryRunContext | None) -> str:
+    if context is None:
+        return ""
+    parts: list[str] = []
+    if context.target_pr:
+        if context.repository:
+            parts.append(
+                f"PR <https://github.com/{context.repository}/pull/"
+                f"{context.target_pr}|#{context.target_pr}>"
+            )
+        else:
+            parts.append(f"PR #{context.target_pr}")
+    if context.target_branch:
+        parts.append(f"branch `{_trim_slack_text(context.target_branch, 120)}`")
+    if context.target_ref:
+        parts.append(f"target `{_trim_slack_text(context.target_ref, 40)[:10]}`")
+    if context.trigger_context:
+        parts.append(_trim_slack_text(context.trigger_context, 160))
+    return " • ".join(parts)
+
+
 def slack_payload(
     reports: list[LaneReport],
     run_url: str | None,
     commit: str | None,
     *,
     category_summary: str = "",
+    run_context: CanaryRunContext | None = None,
 ) -> dict:
     emoji = {"pass": ":white_check_mark:", "fail": ":x:", "skip": ":heavy_minus_sign:"}
     red = sum(1 for r in reports if r.status == "fail")
@@ -720,6 +751,11 @@ def slack_payload(
     blocks: list[dict] = [
         {"type": "header", "text": {"type": "plain_text", "text": header}},
     ]
+    context_text = _format_run_context(run_context)
+    if context_text:
+        blocks.append(
+            {"type": "context", "elements": [{"type": "mrkdwn", "text": context_text}]}
+        )
     for r in reports:
         renders_reborn_qa_groups = bool(r.reborn_qa_cases)
         header_line = (
@@ -771,7 +807,9 @@ def slack_payload(
             }
         )
     ctx: list[str] = []
-    if commit:
+    if run_context and run_context.target_ref:
+        ctx.append(f"commit `{run_context.target_ref[:7]}`")
+    elif commit:
         ctx.append(f"commit `{commit[:7]}`")
     if run_url:
         ctx.append(f"<{run_url}|GitHub run>")
@@ -1077,8 +1115,19 @@ def main() -> int:
                 file=sys.stderr,
             )
 
+    run_context = CanaryRunContext(
+        repository=args.repo,
+        trigger_context=os.environ.get("CANARY_TRIGGER_CONTEXT", ""),
+        target_pr=os.environ.get("CANARY_TARGET_PR", ""),
+        target_branch=os.environ.get("CANARY_TARGET_BRANCH", ""),
+        target_ref=os.environ.get("CANARY_TARGET_REF", ""),
+    )
     payload = slack_payload(
-        reports, args.run_url, args.commit, category_summary=category_summary
+        reports,
+        args.run_url,
+        args.commit,
+        category_summary=category_summary,
+        run_context=run_context,
     )
 
     if args.dry_run or not args.slack_webhook:

--- a/scripts/live-canary/test_notify_slack.py
+++ b/scripts/live-canary/test_notify_slack.py
@@ -391,6 +391,50 @@ class RebornQaSlackReportTests(unittest.TestCase):
         self.assertNotIn("in#1234567890", qa_text)
         self.assertNotIn("out#9876543210", qa_text)
 
+    def test_slack_payload_includes_pr_branch_context_when_present(self):
+        report = notify.LaneReport(
+            lane="reborn-webui-v2-live-qa",
+            provider="reborn-webui-v2",
+            passed=1,
+            failed=0,
+            tests=1,
+            duration_s=1.2,
+            status="pass",
+        )
+
+        payload = notify.slack_payload(
+            [report],
+            "https://github.com/nearai/ironclaw/actions/runs/123",
+            "mainsha0123456789",
+            run_context=notify.CanaryRunContext(
+                repository="nearai/ironclaw",
+                trigger_context="/canary PR #42 abcdef0123 comment 987 by @maintainer",
+                target_pr="42",
+                target_branch="codex/canary-smoke",
+                target_ref="abcdef0123456789",
+            ),
+        )
+
+        context_texts = [
+            element["text"]
+            for block in payload["blocks"]
+            if block.get("type") == "context"
+            for element in block.get("elements", [])
+        ]
+        combined_context = "\n".join(context_texts)
+        self.assertIn(
+            "PR <https://github.com/nearai/ironclaw/pull/42|#42>",
+            combined_context,
+        )
+        self.assertIn("branch `codex/canary-smoke`", combined_context)
+        self.assertIn("target `abcdef0123`", combined_context)
+        self.assertIn(
+            "/canary PR #42 abcdef0123 comment 987 by @maintainer",
+            combined_context,
+        )
+        self.assertIn("commit `abcdef0`", combined_context)
+        self.assertNotIn("mainsha", combined_context)
+
     def test_reborn_rows_fit_with_scheduled_all_lane_report(self):
         case_rows = [
             f"{group}{suffix}"


### PR DESCRIPTION
## Summary
- pass PR head branch metadata from /canary comment dispatches into live-canary.yml
- include PR link, branch name, target SHA, and trigger context in Slack canary reports when present
- keep scheduled canary Slack messages unchanged when no PR context is supplied

## Verification
- python3 scripts/live-canary/test_notify_slack.py
- python3 YAML parse check for .github/workflows/live-canary.yml and .github/workflows/live-canary-command.yml
- git diff --check