### PR TITLE
ci: comment canary results on triggering PR

### DIFF
--- a/.github/workflows/live-canary.yml
+++ b/.github/workflows/live-canary.yml
@@ -74,6 +74,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
 
 concurrency:
   group: live-canary-${{ github.event_name }}-${{ inputs.lane || github.event.schedule }}
@@ -1174,11 +1175,13 @@ jobs:
           CANARY_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GITHUB_SHA: ${{ github.sha }}
           GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ github.token }}
           CANARY_TARGET_BRANCH: ${{ github.event_name == 'workflow_dispatch' && inputs.target_branch || '' }}
           CANARY_TARGET_PR: ${{ github.event_name == 'workflow_dispatch' && inputs.target_pr || '' }}
           CANARY_TARGET_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.target_ref || '' }}
           CANARY_TRIGGER_CONTEXT: ${{ github.event_name == 'workflow_dispatch' && inputs.trigger_context || '' }}
           CANARY_CREATE_ISSUES: "0"
+          CANARY_POST_PR_COMMENT: ${{ github.event_name == 'workflow_dispatch' && inputs.target_pr != '' && '1' || '0' }}
         run: |
           # The notifier is intentionally side-effect-light: it exits 0 even on
           # failure so the canary run's overall status isn't masked by a flaky

--- a/.github/workflows/live-canary.yml
+++ b/.github/workflows/live-canary.yml
@@ -74,7 +74,6 @@ on:
 
 permissions:
   contents: read
-  issues: write
 
 concurrency:
   group: live-canary-${{ github.event_name }}-${{ inputs.lane || github.event.schedule }}
@@ -1146,6 +1145,10 @@ jobs:
     if: ${{ always() }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/scripts/live-canary/notify_slack.py
+++ b/scripts/live-canary/notify_slack.py
@@ -29,6 +29,7 @@ ANTHROPIC_URL = "https://api.anthropic.com/v1/messages"
 ANTHROPIC_VERSION = "2023-06-01"
 MAX_LOG_BYTES = 20_000
 SLACK_MAX_BLOCKS = 50
+GITHUB_COMMENT_BODY_LIMIT = 65_000
 
 HAIKU_SYSTEM = (
     "You analyze CI canary test logs. Given a lane's summary, JUnit digest, "
@@ -818,6 +819,186 @@ def slack_payload(
     return {"blocks": blocks}
 
 
+def _markdown_run_context_lines(
+    run_context: CanaryRunContext | None,
+    run_url: str | None,
+    commit: str | None,
+) -> list[str]:
+    lines: list[str] = []
+    if run_context and run_context.target_pr:
+        if run_context.repository:
+            lines.append(
+                f"- PR: [#{run_context.target_pr}]"
+                f"(https://github.com/{run_context.repository}/pull/"
+                f"{run_context.target_pr})"
+            )
+        else:
+            lines.append(f"- PR: #{run_context.target_pr}")
+    if run_context and run_context.target_branch:
+        lines.append(f"- Branch: `{_trim_slack_text(run_context.target_branch, 120)}`")
+    if run_context and run_context.target_ref:
+        lines.append(f"- Target: `{_trim_slack_text(run_context.target_ref, 40)[:10]}`")
+    if run_context and run_context.trigger_context:
+        lines.append(f"- Trigger: {_trim_slack_text(run_context.trigger_context, 200)}")
+    display_commit = (
+        run_context.target_ref
+        if run_context and run_context.target_ref
+        else commit
+    )
+    if display_commit:
+        lines.append(f"- Commit: `{display_commit[:7]}`")
+    if run_url:
+        lines.append(f"- Run: [GitHub Actions]({run_url})")
+    return lines
+
+
+def _markdown_reborn_case_lines(
+    cases: list[RebornQaCaseReport],
+    run_url: str | None,
+) -> list[str]:
+    lines: list[str] = []
+    grouped: dict[str, list[RebornQaCaseReport]] = {}
+    for case in cases:
+        grouped.setdefault(_qa_group_key(case), []).append(case)
+    for group in sorted(grouped, key=_qa_group_sort_key):
+        group_cases = grouped[group]
+        passed = sum(1 for case in group_cases if case.success)
+        lines.append(f"#### QA {group}: {passed}/{len(group_cases)} passed")
+        for case in group_cases:
+            status = ":white_check_mark:" if case.success else ":x:"
+            latency = (
+                f" ({case.latency_ms / 1000.0:.1f}s)"
+                if isinstance(case.latency_ms, (int, float))
+                else ""
+            )
+            lines.append(
+                f"- {status} `{_qa_case_rows(case)}` {case.feature}{latency}"
+            )
+            if not case.success and case.message:
+                lines.append(f"  - Failure: {case.message}")
+            if not case.success and case.debug_paths:
+                paths = ", ".join(f"`{path}`" for path in case.debug_paths)
+                if run_url:
+                    lines.append(
+                        f"  - Debug: [GitHub run artifacts]({run_url}) - {paths}"
+                    )
+                else:
+                    lines.append(f"  - Debug: {paths}")
+        lines.append("")
+    return lines
+
+
+def github_comment_body(
+    reports: list[LaneReport],
+    run_url: str | None,
+    commit: str | None,
+    *,
+    category_summary: str = "",
+    run_context: CanaryRunContext | None = None,
+) -> str:
+    red = sum(1 for r in reports if r.status == "fail")
+    green = sum(1 for r in reports if r.status == "pass")
+    lines = [
+        f"## Live canary result: {green} passed, {red} failed of {len(reports)} lanes",
+        "",
+    ]
+    context_lines = _markdown_run_context_lines(run_context, run_url, commit)
+    if context_lines:
+        lines.extend(context_lines)
+        lines.append("")
+
+    lines.extend(
+        [
+            "| Lane | Provider | Status | Passed | Failed | Duration |",
+            "| --- | --- | --- | ---: | ---: | ---: |",
+        ]
+    )
+    for r in reports:
+        status = {
+            "pass": ":white_check_mark:",
+            "fail": ":x:",
+            "skip": ":heavy_minus_sign:",
+        }.get(r.status, ":grey_question:")
+        lines.append(
+            f"| `{r.lane}` | `{r.provider}` | {status} {r.status} | "
+            f"{r.passed}/{r.tests} | {r.failed} | {r.duration_s:.0f}s |"
+        )
+
+    if category_summary:
+        lines.extend(["", "### Summary by Category", "", category_summary])
+
+    detail_lines: list[str] = []
+    for r in reports:
+        if r.reborn_qa_cases:
+            detail_lines.extend(
+                [
+                    "",
+                    f"### {r.lane} ({r.provider})",
+                    "",
+                ]
+            )
+            detail_lines.extend(_markdown_reborn_case_lines(r.reborn_qa_cases, run_url))
+        elif r.status == "fail":
+            detail_lines.extend(["", f"### {r.lane} ({r.provider})"])
+            if r.test_name:
+                detail_lines.append(f"- Test: `{r.test_name}`")
+            if r.error:
+                detail_lines.append(f"- Error: {r.error}")
+            if r.root_cause:
+                detail_lines.append(f"- Root Cause: {r.root_cause}")
+            if r.fix:
+                detail_lines.append(f"- Fix: {r.fix}")
+            if r.reason:
+                detail_lines.append(f"- Reason: {r.reason}")
+            if r.notable:
+                detail_lines.append(f"- Note: {r.notable}")
+    if detail_lines:
+        lines.extend(detail_lines)
+
+    lines.append("")
+    lines.append("_Auto-posted by `scripts/live-canary/notify_slack.py`._")
+    body = "\n".join(lines)
+    if len(body) <= GITHUB_COMMENT_BODY_LIMIT:
+        return body
+    suffix = "\n\n_Comment truncated because the canary report exceeded GitHub's body limit._"
+    return body[: GITHUB_COMMENT_BODY_LIMIT - len(suffix)].rstrip() + suffix
+
+
+def post_pr_comment(
+    reports: list[LaneReport],
+    *,
+    repo: str,
+    github_token: str,
+    run_context: CanaryRunContext,
+    run_url: str | None,
+    commit: str | None,
+    category_summary: str = "",
+) -> str:
+    if not run_context.target_pr:
+        return ""
+    headers = {
+        "Authorization": f"Bearer {github_token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    created = post_json(
+        f"https://api.github.com/repos/{repo}/issues/"
+        f"{run_context.target_pr}/comments",
+        {
+            "body": github_comment_body(
+                reports,
+                run_url,
+                commit,
+                category_summary=category_summary,
+                run_context=run_context,
+            )
+        },
+        headers,
+        timeout=15,
+    )
+    return str(created.get("html_url") or "")
+
+
 def categorize_failures(api_key: str, reports: list[LaneReport]) -> str:
     """Second-pass Haiku call: group failed lanes by shared root cause.
 
@@ -1048,6 +1229,15 @@ def main() -> int:
         ),
     )
     p.add_argument(
+        "--post-pr-comment",
+        action="store_true",
+        default=os.environ.get("CANARY_POST_PR_COMMENT") == "1",
+        help=(
+            "Post the final canary report as a PR comment when "
+            "CANARY_TARGET_PR is set."
+        ),
+    )
+    p.add_argument(
         "--create-issues",
         action="store_true",
         default=os.environ.get("CANARY_CREATE_ISSUES") == "1",
@@ -1130,7 +1320,7 @@ def main() -> int:
         run_context=run_context,
     )
 
-    if args.dry_run or not args.slack_webhook:
+    if args.dry_run:
         print(json.dumps(payload, indent=2))
         # Dry-run still surfaces what the issue creator WOULD do so a
         # local invocation can sanity-check title/body shapes.
@@ -1141,21 +1331,61 @@ def main() -> int:
                 f"{len(failed)} issue(s) on {args.repo}",
                 file=sys.stderr,
             )
+        if args.post_pr_comment and run_context.target_pr:
+            print(
+                github_comment_body(
+                    reports,
+                    args.run_url,
+                    args.commit,
+                    category_summary=category_summary,
+                    run_context=run_context,
+                )
+            )
         return 0
 
-    try:
-        post_json(args.slack_webhook, payload, {}, timeout=10)
+    if args.slack_webhook:
+        try:
+            post_json(args.slack_webhook, payload, {}, timeout=10)
+            print(
+                f"[notify_slack] posted Slack message for {len(reports)} lane(s)",
+                file=sys.stderr,
+            )
+        except Exception as e:
+            print(f"[notify_slack] slack post failed: {e} — sending fallback", file=sys.stderr)
+            try:
+                post_json(args.slack_webhook, fallback_payload(reports, args.run_url), {}, timeout=10)
+                print("[notify_slack] fallback posted", file=sys.stderr)
+            except Exception as e2:
+                print(f"[notify_slack] fallback also failed: {e2}", file=sys.stderr)
+    else:
+        print("[notify_slack] no SLACK_WEBHOOK_URL — skipping Slack post", file=sys.stderr)
+
+    if args.post_pr_comment and run_context.target_pr and args.github_token:
+        try:
+            comment_url = post_pr_comment(
+                reports,
+                repo=args.repo,
+                github_token=args.github_token,
+                run_context=run_context,
+                run_url=args.run_url,
+                commit=args.commit,
+                category_summary=category_summary,
+            )
+            print(
+                f"[notify_slack] posted PR canary comment: {comment_url or '?'}",
+                file=sys.stderr,
+            )
+        except Exception as e:
+            print(
+                f"[notify_slack] PR comment post failed: {type(e).__name__}: {e}",
+                file=sys.stderr,
+            )
+    elif args.post_pr_comment and run_context.target_pr:
         print(
-            f"[notify_slack] posted Slack message for {len(reports)} lane(s)",
+            "[notify_slack] --post-pr-comment set but no GITHUB_TOKEN / "
+            "GH_TOKEN / CANARY_ISSUES_TOKEN — skipping PR comment",
             file=sys.stderr,
         )
-    except Exception as e:
-        print(f"[notify_slack] slack post failed: {e} — sending fallback", file=sys.stderr)
-        try:
-            post_json(args.slack_webhook, fallback_payload(reports, args.run_url), {}, timeout=10)
-            print("[notify_slack] fallback posted", file=sys.stderr)
-        except Exception as e2:
-            print(f"[notify_slack] fallback also failed: {e2}", file=sys.stderr)
 
     # Issue creation runs AFTER Slack so a Slack-side failure doesn't
     # block the GitHub-side bookkeeping (and vice versa).

--- a/scripts/live-canary/notify_slack.py
+++ b/scripts/live-canary/notify_slack.py
@@ -742,15 +742,18 @@ def _github_md_text(value: object, limit: int | None = None) -> str:
     text = _trim_slack_text(value, limit) if limit else str(value or "").strip()
     return (
         text.replace("\\", "\\\\")
+        .replace("\n", " ")
         .replace("@", GITHUB_MD_MENTION_BREAK)
         .replace("|", "\\|")
         .replace("`", "\\`")
+        .replace("[", "\\[")
+        .replace("]", "\\]")
     )
 
 
 def _github_md_code(value: object, limit: int | None = None) -> str:
     text = _trim_slack_text(value, limit) if limit else str(value or "").strip()
-    return text.replace("`", "'").replace("\n", " ")
+    return text.replace("`", "'").replace("\n", " ").replace("|", "\\|")
 
 
 def slack_payload(
@@ -1002,7 +1005,7 @@ def post_pr_comment(
 ) -> str:
     if not run_context.target_pr:
         return ""
-    if not run_context.target_pr.isdecimal():
+    if not run_context.target_pr.isascii() or not run_context.target_pr.isdigit():
         raise ValueError("target_pr must be a decimal pull request number")
     headers = {
         "Authorization": f"Bearer {github_token}",

--- a/scripts/live-canary/notify_slack.py
+++ b/scripts/live-canary/notify_slack.py
@@ -30,6 +30,7 @@ ANTHROPIC_VERSION = "2023-06-01"
 MAX_LOG_BYTES = 20_000
 SLACK_MAX_BLOCKS = 50
 GITHUB_COMMENT_BODY_LIMIT = 65_000
+GITHUB_MD_MENTION_BREAK = "@\u200b"
 
 HAIKU_SYSTEM = (
     "You analyze CI canary test logs. Given a lane's summary, JUnit digest, "
@@ -737,6 +738,21 @@ def _format_run_context(context: CanaryRunContext | None) -> str:
     return " • ".join(parts)
 
 
+def _github_md_text(value: object, limit: int | None = None) -> str:
+    text = _trim_slack_text(value, limit) if limit else str(value or "").strip()
+    return (
+        text.replace("\\", "\\\\")
+        .replace("@", GITHUB_MD_MENTION_BREAK)
+        .replace("|", "\\|")
+        .replace("`", "\\`")
+    )
+
+
+def _github_md_code(value: object, limit: int | None = None) -> str:
+    text = _trim_slack_text(value, limit) if limit else str(value or "").strip()
+    return text.replace("`", "'").replace("\n", " ")
+
+
 def slack_payload(
     reports: list[LaneReport],
     run_url: str | None,
@@ -835,18 +851,18 @@ def _markdown_run_context_lines(
         else:
             lines.append(f"- PR: #{run_context.target_pr}")
     if run_context and run_context.target_branch:
-        lines.append(f"- Branch: `{_trim_slack_text(run_context.target_branch, 120)}`")
+        lines.append(f"- Branch: `{_github_md_code(run_context.target_branch, 120)}`")
     if run_context and run_context.target_ref:
-        lines.append(f"- Target: `{_trim_slack_text(run_context.target_ref, 40)[:10]}`")
+        lines.append(f"- Target: `{_github_md_code(run_context.target_ref[:10])}`")
     if run_context and run_context.trigger_context:
-        lines.append(f"- Trigger: {_trim_slack_text(run_context.trigger_context, 200)}")
+        lines.append(f"- Trigger: {_github_md_text(run_context.trigger_context, 200)}")
     display_commit = (
         run_context.target_ref
         if run_context and run_context.target_ref
         else commit
     )
     if display_commit:
-        lines.append(f"- Commit: `{display_commit[:7]}`")
+        lines.append(f"- Commit: `{_github_md_code(display_commit[:7])}`")
     if run_url:
         lines.append(f"- Run: [GitHub Actions]({run_url})")
     return lines
@@ -872,12 +888,13 @@ def _markdown_reborn_case_lines(
                 else ""
             )
             lines.append(
-                f"- {status} `{_qa_case_rows(case)}` {case.feature}{latency}"
+                f"- {status} `{_github_md_code(_qa_case_rows(case))}` "
+                f"{_github_md_text(case.feature)}{latency}"
             )
             if not case.success and case.message:
-                lines.append(f"  - Failure: {case.message}")
+                lines.append(f"  - Failure: {_github_md_text(case.message)}")
             if not case.success and case.debug_paths:
-                paths = ", ".join(f"`{path}`" for path in case.debug_paths)
+                paths = ", ".join(f"`{_github_md_code(path)}`" for path in case.debug_paths)
                 if run_url:
                     lines.append(
                         f"  - Debug: [GitHub run artifacts]({run_url}) - {paths}"
@@ -920,12 +937,13 @@ def github_comment_body(
             "skip": ":heavy_minus_sign:",
         }.get(r.status, ":grey_question:")
         lines.append(
-            f"| `{r.lane}` | `{r.provider}` | {status} {r.status} | "
+            f"| `{_github_md_code(r.lane)}` | `{_github_md_code(r.provider)}` | "
+            f"{status} {r.status} | "
             f"{r.passed}/{r.tests} | {r.failed} | {r.duration_s:.0f}s |"
         )
 
     if category_summary:
-        lines.extend(["", "### Summary by Category", "", category_summary])
+        lines.extend(["", "### Summary by Category", "", _github_md_text(category_summary)])
 
     detail_lines: list[str] = []
     for r in reports:
@@ -933,25 +951,33 @@ def github_comment_body(
             detail_lines.extend(
                 [
                     "",
-                    f"### {r.lane} ({r.provider})",
+                    f"### {_github_md_text(r.lane)} ({_github_md_text(r.provider)})",
                     "",
                 ]
             )
             detail_lines.extend(_markdown_reborn_case_lines(r.reborn_qa_cases, run_url))
         elif r.status == "fail":
-            detail_lines.extend(["", f"### {r.lane} ({r.provider})"])
+            detail_lines.extend(
+                ["", f"### {_github_md_text(r.lane)} ({_github_md_text(r.provider)})"]
+            )
             if r.test_name:
-                detail_lines.append(f"- Test: `{r.test_name}`")
+                detail_lines.append(f"- Test: `{_github_md_code(r.test_name)}`")
             if r.error:
-                detail_lines.append(f"- Error: {r.error}")
+                detail_lines.append(f"- Error: {_github_md_text(r.error)}")
             if r.root_cause:
-                detail_lines.append(f"- Root Cause: {r.root_cause}")
+                detail_lines.append(f"- Root Cause: {_github_md_text(r.root_cause)}")
             if r.fix:
-                detail_lines.append(f"- Fix: {r.fix}")
+                detail_lines.append(f"- Fix: {_github_md_text(r.fix)}")
             if r.reason:
-                detail_lines.append(f"- Reason: {r.reason}")
+                detail_lines.append(f"- Reason: {_github_md_text(r.reason)}")
             if r.notable:
-                detail_lines.append(f"- Note: {r.notable}")
+                detail_lines.append(f"- Note: {_github_md_text(r.notable)}")
+            if r.junit_failures:
+                detail_lines.append("- Failures:")
+                for name, msg in r.junit_failures[:10]:
+                    detail_lines.append(
+                        f"  - `{_github_md_code(name)}`: {_github_md_text(msg)}"
+                    )
     if detail_lines:
         lines.extend(detail_lines)
 
@@ -976,11 +1002,18 @@ def post_pr_comment(
 ) -> str:
     if not run_context.target_pr:
         return ""
+    if not run_context.target_pr.isdecimal():
+        raise ValueError("target_pr must be a decimal pull request number")
     headers = {
         "Authorization": f"Bearer {github_token}",
         "Accept": "application/vnd.github+json",
         "X-GitHub-Api-Version": "2022-11-28",
     }
+    get_json(
+        f"https://api.github.com/repos/{repo}/pulls/{run_context.target_pr}",
+        headers,
+        timeout=15,
+    )
     created = post_json(
         f"https://api.github.com/repos/{repo}/issues/"
         f"{run_context.target_pr}/comments",
@@ -1332,6 +1365,7 @@ def main() -> int:
                 file=sys.stderr,
             )
         if args.post_pr_comment and run_context.target_pr:
+            print("\n--- GitHub PR Comment Body (Dry Run) ---", file=sys.stderr)
             print(
                 github_comment_body(
                     reports,
@@ -1339,7 +1373,8 @@ def main() -> int:
                     args.commit,
                     category_summary=category_summary,
                     run_context=run_context,
-                )
+                ),
+                file=sys.stderr,
             )
         return 0
 

--- a/scripts/live-canary/test_notify_slack.py
+++ b/scripts/live-canary/test_notify_slack.py
@@ -497,46 +497,51 @@ class RebornQaSlackReportTests(unittest.TestCase):
     def test_github_comment_body_includes_junit_fallback_for_failed_lane(self):
         report = notify.LaneReport(
             lane="auth|lane",
-            provider="mock",
+            provider="mock|provider",
             passed=0,
             failed=1,
             tests=1,
             duration_s=0.5,
             status="fail",
-            junit_failures=[("test_name", "bad | value from @team")],
+            junit_failures=[("test|name", "bad | value from @team\n[link](http://evil)")],
         )
 
         body = notify.github_comment_body(
             [report],
             "https://github.com/nearai/ironclaw/actions/runs/123",
             "abcdef0123456789",
-            category_summary="failure from @team | table",
+            category_summary="failure from @team | table\n[link](http://evil)",
             run_context=notify.CanaryRunContext(
                 repository="nearai/ironclaw",
                 target_pr="42",
                 target_branch="branch`name",
                 target_ref="abcdef0123456789",
-                trigger_context="/canary @team | table",
+                trigger_context="/canary @team | table\n[link](http://evil)",
             ),
         )
 
         self.assertIn("- Branch: `branch'name`", body)
-        self.assertIn("/canary @\u200bteam \\| table", body)
-        self.assertIn("failure from @\u200bteam \\| table", body)
-        self.assertIn("### auth\\|lane (mock)", body)
+        self.assertIn("/canary @\u200bteam \\| table \\[link\\](http://evil)", body)
+        self.assertIn("failure from @\u200bteam \\| table \\[link\\](http://evil)", body)
+        self.assertIn("| `auth\\|lane` | `mock\\|provider` |", body)
+        self.assertIn("### auth\\|lane (mock\\|provider)", body)
         self.assertIn("- Failures:", body)
-        self.assertIn("  - `test_name`: bad \\| value from @\u200bteam", body)
+        self.assertIn(
+            "  - `test\\|name`: bad \\| value from @\u200bteam \\[link\\](http://evil)",
+            body,
+        )
 
     def test_post_pr_comment_validates_target_is_decimal_pull_request(self):
-        with self.assertRaisesRegex(ValueError, "decimal pull request number"):
-            notify.post_pr_comment(
-                [],
-                repo="nearai/ironclaw",
-                github_token="token",
-                run_context=notify.CanaryRunContext(target_pr="42abc"),
-                run_url=None,
-                commit=None,
-            )
+        for target_pr in ("42abc", "\u0664\u0662"):
+            with self.assertRaisesRegex(ValueError, "decimal pull request number"):
+                notify.post_pr_comment(
+                    [],
+                    repo="nearai/ironclaw",
+                    github_token="token",
+                    run_context=notify.CanaryRunContext(target_pr=target_pr),
+                    run_url=None,
+                    commit=None,
+                )
 
         with (
             mock.patch.object(notify, "get_json", return_value={"number": 42}) as get_json,
@@ -595,6 +600,45 @@ class RebornQaSlackReportTests(unittest.TestCase):
                 notify,
                 "post_pr_comment",
                 return_value="https://github.com/nearai/ironclaw/pull/42#issuecomment-1",
+            ) as post_pr_comment,
+        ):
+            rc = notify.main()
+
+        self.assertEqual(rc, 0)
+        post_json.assert_not_called()
+        post_pr_comment.assert_called_once()
+
+    def test_main_ignores_pr_comment_failure_without_slack_webhook(self):
+        report = notify.LaneReport(
+            lane="reborn-webui-v2-live-qa",
+            provider="reborn-webui-v2",
+            passed=1,
+            failed=0,
+            tests=1,
+            status="pass",
+        )
+        env = {
+            "CANARY_POST_PR_COMMENT": "1",
+            "CANARY_TARGET_PR": "42",
+            "CANARY_TARGET_BRANCH": "codex/canary-smoke",
+            "CANARY_TARGET_REF": "abcdef0123456789",
+            "GITHUB_REPOSITORY": "nearai/ironclaw",
+            "GITHUB_TOKEN": "token",
+        }
+        with (
+            mock.patch.dict(notify.os.environ, env, clear=True),
+            mock.patch.object(sys, "argv", ["notify_slack.py"]),
+            mock.patch.object(
+                notify,
+                "discover_lane_dirs",
+                return_value=[Path("reborn-webui-v2-live-qa/reborn-webui-v2/run")],
+            ),
+            mock.patch.object(notify, "collect_lane", return_value=report),
+            mock.patch.object(notify, "post_json") as post_json,
+            mock.patch.object(
+                notify,
+                "post_pr_comment",
+                side_effect=RuntimeError("github unavailable"),
             ) as post_pr_comment,
         ):
             rc = notify.main()

--- a/scripts/live-canary/test_notify_slack.py
+++ b/scripts/live-canary/test_notify_slack.py
@@ -435,6 +435,63 @@ class RebornQaSlackReportTests(unittest.TestCase):
         self.assertIn("commit `abcdef0`", combined_context)
         self.assertNotIn("mainsha", combined_context)
 
+    def test_github_comment_body_includes_pr_branch_and_case_results(self):
+        report = notify.LaneReport(
+            lane="reborn-webui-v2-live-qa",
+            provider="reborn-webui-v2",
+            passed=1,
+            failed=1,
+            tests=2,
+            duration_s=2.5,
+            status="fail",
+            reborn_qa_cases=[
+                notify.RebornQaCaseReport(
+                    rows=("2A",),
+                    case="qa_2a_gmail_connect",
+                    feature="Gmail connection flow",
+                    success=True,
+                    latency_ms=1200,
+                ),
+                notify.RebornQaCaseReport(
+                    rows=("2D",),
+                    case="qa_2d_calendar_prep_live_chat",
+                    feature="Calendar prep assistant",
+                    success=False,
+                    latency_ms=1300,
+                    message="requires live Google runtime access",
+                    debug_paths=[
+                        "reborn-webui-v2-live-qa/reborn-webui-v2/20260628T000000Z/results.json",
+                    ],
+                ),
+            ],
+        )
+
+        body = notify.github_comment_body(
+            [report],
+            "https://github.com/nearai/ironclaw/actions/runs/123",
+            "mainsha0123456789",
+            run_context=notify.CanaryRunContext(
+                repository="nearai/ironclaw",
+                trigger_context="/canary all PR #42 abcdef0123 comment 987 by @maintainer",
+                target_pr="42",
+                target_branch="codex/canary-smoke",
+                target_ref="abcdef0123456789",
+            ),
+        )
+
+        self.assertIn("## Live canary result: 0 passed, 1 failed of 1 lanes", body)
+        self.assertIn("- PR: [#42](https://github.com/nearai/ironclaw/pull/42)", body)
+        self.assertIn("- Branch: `codex/canary-smoke`", body)
+        self.assertIn("- Target: `abcdef0123`", body)
+        self.assertIn("- Commit: `abcdef0`", body)
+        self.assertNotIn("mainsha", body)
+        self.assertIn("| `reborn-webui-v2-live-qa` | `reborn-webui-v2` |", body)
+        self.assertIn("#### QA 2: 1/2 passed", body)
+        self.assertIn(":white_check_mark: `2A` Gmail connection flow", body)
+        self.assertIn(":x: `2D` Calendar prep assistant", body)
+        self.assertIn("Failure: requires live Google runtime access", body)
+        self.assertIn("[GitHub run artifacts]", body)
+
     def test_reborn_rows_fit_with_scheduled_all_lane_report(self):
         case_rows = [
             f"{group}{suffix}"

--- a/scripts/live-canary/test_notify_slack.py
+++ b/scripts/live-canary/test_notify_slack.py
@@ -24,6 +24,7 @@ import json
 import sys
 import tempfile
 import unittest
+from unittest import mock
 from pathlib import Path
 
 
@@ -484,6 +485,7 @@ class RebornQaSlackReportTests(unittest.TestCase):
         self.assertIn("- Branch: `codex/canary-smoke`", body)
         self.assertIn("- Target: `abcdef0123`", body)
         self.assertIn("- Commit: `abcdef0`", body)
+        self.assertIn("/canary all PR #42 abcdef0123 comment 987 by @\u200bmaintainer", body)
         self.assertNotIn("mainsha", body)
         self.assertIn("| `reborn-webui-v2-live-qa` | `reborn-webui-v2` |", body)
         self.assertIn("#### QA 2: 1/2 passed", body)
@@ -491,6 +493,115 @@ class RebornQaSlackReportTests(unittest.TestCase):
         self.assertIn(":x: `2D` Calendar prep assistant", body)
         self.assertIn("Failure: requires live Google runtime access", body)
         self.assertIn("[GitHub run artifacts]", body)
+
+    def test_github_comment_body_includes_junit_fallback_for_failed_lane(self):
+        report = notify.LaneReport(
+            lane="auth|lane",
+            provider="mock",
+            passed=0,
+            failed=1,
+            tests=1,
+            duration_s=0.5,
+            status="fail",
+            junit_failures=[("test_name", "bad | value from @team")],
+        )
+
+        body = notify.github_comment_body(
+            [report],
+            "https://github.com/nearai/ironclaw/actions/runs/123",
+            "abcdef0123456789",
+            category_summary="failure from @team | table",
+            run_context=notify.CanaryRunContext(
+                repository="nearai/ironclaw",
+                target_pr="42",
+                target_branch="branch`name",
+                target_ref="abcdef0123456789",
+                trigger_context="/canary @team | table",
+            ),
+        )
+
+        self.assertIn("- Branch: `branch'name`", body)
+        self.assertIn("/canary @\u200bteam \\| table", body)
+        self.assertIn("failure from @\u200bteam \\| table", body)
+        self.assertIn("### auth\\|lane (mock)", body)
+        self.assertIn("- Failures:", body)
+        self.assertIn("  - `test_name`: bad \\| value from @\u200bteam", body)
+
+    def test_post_pr_comment_validates_target_is_decimal_pull_request(self):
+        with self.assertRaisesRegex(ValueError, "decimal pull request number"):
+            notify.post_pr_comment(
+                [],
+                repo="nearai/ironclaw",
+                github_token="token",
+                run_context=notify.CanaryRunContext(target_pr="42abc"),
+                run_url=None,
+                commit=None,
+            )
+
+        with (
+            mock.patch.object(notify, "get_json", return_value={"number": 42}) as get_json,
+            mock.patch.object(
+                notify,
+                "post_json",
+                return_value={"html_url": "https://github.com/nearai/ironclaw/pull/42#issuecomment-1"},
+            ) as post_json,
+        ):
+            url = notify.post_pr_comment(
+                [],
+                repo="nearai/ironclaw",
+                github_token="token",
+                run_context=notify.CanaryRunContext(target_pr="42"),
+                run_url=None,
+                commit=None,
+            )
+
+        self.assertEqual(
+            url,
+            "https://github.com/nearai/ironclaw/pull/42#issuecomment-1",
+        )
+        get_json.assert_called_once()
+        self.assertIn("/pulls/42", get_json.call_args.args[0])
+        post_json.assert_called_once()
+        self.assertIn("/issues/42/comments", post_json.call_args.args[0])
+
+    def test_main_posts_pr_comment_without_slack_webhook(self):
+        report = notify.LaneReport(
+            lane="reborn-webui-v2-live-qa",
+            provider="reborn-webui-v2",
+            passed=1,
+            failed=0,
+            tests=1,
+            status="pass",
+        )
+        env = {
+            "CANARY_POST_PR_COMMENT": "1",
+            "CANARY_TARGET_PR": "42",
+            "CANARY_TARGET_BRANCH": "codex/canary-smoke",
+            "CANARY_TARGET_REF": "abcdef0123456789",
+            "GITHUB_REPOSITORY": "nearai/ironclaw",
+            "GITHUB_TOKEN": "token",
+        }
+        with (
+            mock.patch.dict(notify.os.environ, env, clear=True),
+            mock.patch.object(sys, "argv", ["notify_slack.py"]),
+            mock.patch.object(
+                notify,
+                "discover_lane_dirs",
+                return_value=[Path("reborn-webui-v2-live-qa/reborn-webui-v2/run")],
+            ),
+            mock.patch.object(notify, "collect_lane", return_value=report),
+            mock.patch.object(notify, "post_json") as post_json,
+            mock.patch.object(
+                notify,
+                "post_pr_comment",
+                return_value="https://github.com/nearai/ironclaw/pull/42#issuecomment-1",
+            ) as post_pr_comment,
+        ):
+            rc = notify.main()
+
+        self.assertEqual(rc, 0)
+        post_json.assert_not_called()
+        post_pr_comment.assert_called_once()
 
     def test_reborn_rows_fit_with_scheduled_all_lane_report(self):
         case_rows = [


### PR DESCRIPTION
## Summary
- render the final live canary report as GitHub Markdown in addition to Slack Block Kit
- post that report back to the PR that supplied target_pr for /canary runs
- keep the comment path non-blocking and independent from Slack webhook availability

## Verification
- python3 scripts/live-canary/test_notify_slack.py
- python3 YAML parse check for .github/workflows/live-canary.yml and .github/workflows/live-canary-command.yml
- git diff --check origin/main...HEAD