### PR TITLE
[HST Postgres 1/4] RootFilesystem latency substrate

### DIFF
--- a/crates/ironclaw_filesystem/src/backend.rs
+++ b/crates/ironclaw_filesystem/src/backend.rs
@@ -18,7 +18,10 @@
 use async_trait::async_trait;
 use ironclaw_host_api::VirtualPath;
 
-use crate::{CasExpectation, Entry, FilesystemError, RecordVersion, SeqNo, VersionedEntry};
+use crate::{
+    CasExpectation, Entry, FilesystemError, FilesystemOperation, RecordVersion, SeqNo,
+    VersionedEntry,
+};
 
 /// Multi-key transactional handle returned by [`RootFilesystem::begin`].
 ///
@@ -40,6 +43,13 @@ pub trait StorageTxn: Send {
 
     async fn delete(&mut self, path: &VirtualPath) -> Result<(), FilesystemError>;
 
+    async fn reserve_sequence(&mut self, path: &VirtualPath) -> Result<SeqNo, FilesystemError> {
+        Err(FilesystemError::Unsupported {
+            path: path.clone(),
+            operation: FilesystemOperation::ReserveSeq,
+        })
+    }
+
     async fn commit(self: Box<Self>) -> Result<(), FilesystemError>;
 
     async fn rollback(self: Box<Self>);
@@ -58,5 +68,64 @@ pub struct EventRecord {
 impl EventRecord {
     pub fn new(seq: SeqNo, payload: Vec<u8>) -> Self {
         Self { seq, payload }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct DummyTxn;
+
+    #[async_trait]
+    impl StorageTxn for DummyTxn {
+        async fn put(
+            &mut self,
+            path: &VirtualPath,
+            _entry: Entry,
+            _cas: CasExpectation,
+        ) -> Result<RecordVersion, FilesystemError> {
+            Err(FilesystemError::Unsupported {
+                path: path.clone(),
+                operation: FilesystemOperation::WriteFile,
+            })
+        }
+
+        async fn get(
+            &mut self,
+            path: &VirtualPath,
+        ) -> Result<Option<VersionedEntry>, FilesystemError> {
+            Err(FilesystemError::Unsupported {
+                path: path.clone(),
+                operation: FilesystemOperation::ReadFile,
+            })
+        }
+
+        async fn delete(&mut self, path: &VirtualPath) -> Result<(), FilesystemError> {
+            Err(FilesystemError::Unsupported {
+                path: path.clone(),
+                operation: FilesystemOperation::Delete,
+            })
+        }
+
+        async fn commit(self: Box<Self>) -> Result<(), FilesystemError> {
+            Ok(())
+        }
+
+        async fn rollback(self: Box<Self>) {}
+    }
+
+    #[tokio::test]
+    async fn storage_txn_reserve_sequence_fails_closed_by_default() {
+        let path = VirtualPath::new("/events/log").unwrap();
+        let mut txn = DummyTxn;
+
+        let err = txn.reserve_sequence(&path).await.unwrap_err();
+
+        assert!(matches!(
+            err,
+            FilesystemError::Unsupported { path: actual, operation: FilesystemOperation::ReserveSeq }
+                if actual == path
+        ));
     }
 }

--- a/crates/ironclaw_filesystem/src/libsql.rs
+++ b/crates/ironclaw_filesystem/src/libsql.rs
@@ -141,9 +141,21 @@ impl LibSqlRootFilesystem {
 }
 
 #[cfg(feature = "libsql")]
-async fn connect_with_retry<F>(mut open: F) -> Result<libsql::Connection, FilesystemError>
+async fn connect_with_retry<F>(open: F) -> Result<libsql::Connection, FilesystemError>
 where
     F: FnMut() -> Result<libsql::Connection, libsql::Error>,
+{
+    connect_with_retry_and_pragmas(open, |_| LIBSQL_CONNECTION_PRAGMAS).await
+}
+
+#[cfg(feature = "libsql")]
+async fn connect_with_retry_and_pragmas<F, P>(
+    mut open: F,
+    mut pragmas_for_attempt: P,
+) -> Result<libsql::Connection, FilesystemError>
+where
+    F: FnMut() -> Result<libsql::Connection, libsql::Error>,
+    P: FnMut(u32) -> &'static str,
 {
     // Match the legacy libSQL backend's connection policy: every
     // operation gets its own connection, concurrent writers wait on
@@ -157,7 +169,7 @@ where
                 // `execute_batch` runs each statement and discards the rows
                 // PRAGMAs like `busy_timeout` return, which is exactly what
                 // we want — we only care about the side effect.
-                match conn.execute_batch(LIBSQL_CONNECTION_PRAGMAS).await {
+                match conn.execute_batch(pragmas_for_attempt(attempt)).await {
                     Ok(_) => return Ok(conn),
                     Err(error) => {
                         last_error = Some(error);
@@ -2136,6 +2148,39 @@ mod tests {
         .unwrap();
 
         assert_eq!(attempts, LIBSQL_CONNECT_ATTEMPTS);
+        let mut rows = conn.query("PRAGMA busy_timeout", ()).await.unwrap();
+        let row = rows.next().await.unwrap().unwrap();
+        let timeout: i64 = row.get(0).unwrap();
+        assert_eq!(timeout, 5000);
+    }
+
+    #[tokio::test]
+    async fn connect_retries_transient_pragma_failures_before_succeeding() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("connect-retry-pragma-test.db");
+        let db = libsql::Builder::new_local(db_path).build().await.unwrap();
+        let mut opens = 0;
+        let mut initializers = 0;
+
+        let conn = connect_with_retry_and_pragmas(
+            || {
+                opens += 1;
+                db.connect()
+            },
+            |_| {
+                initializers += 1;
+                if initializers == 1 {
+                    "THIS IS NOT SQL"
+                } else {
+                    LIBSQL_CONNECTION_PRAGMAS
+                }
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(opens, 2);
+        assert_eq!(initializers, 2);
         let mut rows = conn.query("PRAGMA busy_timeout", ()).await.unwrap();
         let row = rows.next().await.unwrap().unwrap();
         let timeout: i64 = row.get(0).unwrap();

--- a/crates/ironclaw_filesystem/src/libsql.rs
+++ b/crates/ironclaw_filesystem/src/libsql.rs
@@ -147,7 +147,7 @@ where
 {
     // Match the legacy libSQL backend's connection policy: every
     // operation gets its own connection, concurrent writers wait on
-    // SQLite locks, and transient file-open races get a short retry
+    // SQLite locks, and transient file-open/setup races get a short retry
     // budget before surfacing as infrastructure errors.
     let mut last_error = None;
     for attempt in 0..LIBSQL_CONNECT_ATTEMPTS {
@@ -157,12 +157,15 @@ where
                 // `execute_batch` runs each statement and discards the rows
                 // PRAGMAs like `busy_timeout` return, which is exactly what
                 // we want — we only care about the side effect.
-                conn.execute_batch(LIBSQL_CONNECTION_PRAGMAS)
-                    .await
-                    .map_err(|error| {
-                        infrastructure_libsql_error(FilesystemOperation::Stat, error)
-                    })?;
-                return Ok(conn);
+                match conn.execute_batch(LIBSQL_CONNECTION_PRAGMAS).await {
+                    Ok(_) => return Ok(conn),
+                    Err(error) => {
+                        last_error = Some(error);
+                        if attempt + 1 < LIBSQL_CONNECT_ATTEMPTS {
+                            tokio::time::sleep(connect_backoff(attempt)).await;
+                        }
+                    }
+                }
             }
             Err(error) => {
                 last_error = Some(error);
@@ -176,11 +179,13 @@ where
     let reason = match last_error {
         Some(error) => {
             format!(
-                "failed to create libSQL connection after {LIBSQL_CONNECT_ATTEMPTS} attempts: {error}"
+                "failed to create or initialize libSQL connection after {LIBSQL_CONNECT_ATTEMPTS} attempts: {error}"
             )
         }
         None => {
-            format!("failed to create libSQL connection after {LIBSQL_CONNECT_ATTEMPTS} attempts")
+            format!(
+                "failed to create or initialize libSQL connection after {LIBSQL_CONNECT_ATTEMPTS} attempts"
+            )
         }
     };
     Err(crate::db::infrastructure_error(

--- a/crates/ironclaw_filesystem/src/postgres.rs
+++ b/crates/ironclaw_filesystem/src/postgres.rs
@@ -1683,13 +1683,16 @@ fn postgres_shared_projection_index_name(spec: &IndexSpec) -> String {
         IndexKind::Fts => "fts",
         IndexKind::Vector { .. } => "vector",
     };
-    let keys = spec
-        .keys
-        .iter()
-        .map(|key| key.as_str())
-        .collect::<Vec<_>>()
-        .join("_");
+    let mut keys = postgres_projection_index_component(kind);
+    for key in &spec.keys {
+        keys.push_str(&postgres_projection_index_component(key.as_str()));
+    }
     sql_index_name(&format!("/shared/{kind}/{keys}"), spec.name.as_str())
+}
+
+#[cfg(feature = "postgres")]
+fn postgres_projection_index_component(value: &str) -> String {
+    format!("{}:{value}", value.len())
 }
 
 /// Translate a [`Filter`] tree into a postgres WHERE-clause fragment.
@@ -2093,6 +2096,28 @@ mod tests {
         assert_ne!(
             postgres_shared_projection_index_name(&exact_bucket),
             postgres_shared_projection_index_name(&exact_tenant)
+        );
+    }
+
+    #[test]
+    fn shared_projection_index_name_uses_injective_key_encoding() {
+        let split_keys = IndexSpec::new(
+            crate::IndexName::new("bucket_exact").unwrap(),
+            vec![
+                crate::IndexKey::new("a").unwrap(),
+                crate::IndexKey::new("b").unwrap(),
+            ],
+            IndexKind::Exact,
+        );
+        let joined_key = IndexSpec::new(
+            crate::IndexName::new("bucket_exact").unwrap(),
+            vec![crate::IndexKey::new("a_b").unwrap()],
+            IndexKind::Exact,
+        );
+
+        assert_ne!(
+            postgres_shared_projection_index_name(&split_keys),
+            postgres_shared_projection_index_name(&joined_key)
         );
     }
 

--- a/crates/ironclaw_filesystem/src/postgres.rs
+++ b/crates/ironclaw_filesystem/src/postgres.rs
@@ -1,4 +1,6 @@
 use std::{collections::BTreeMap, error::Error, time::Duration};
+#[cfg(feature = "postgres")]
+use std::{collections::HashSet, sync::OnceLock};
 
 use async_trait::async_trait;
 use ironclaw_host_api::VirtualPath;
@@ -33,6 +35,11 @@ const POSTGRES_MIGRATION_CONNECT_DEFAULT_MAX_WAIT: Duration = Duration::from_sec
 const POSTGRES_MIGRATION_CONNECT_INITIAL_BACKOFF: Duration = Duration::from_millis(250);
 #[cfg(feature = "postgres")]
 const POSTGRES_MIGRATION_CONNECT_MAX_BACKOFF: Duration = Duration::from_secs(10);
+#[cfg(feature = "postgres")]
+const POSTGRES_ROOT_FILESYSTEM_MIGRATION_ADVISORY_LOCK: i64 = 824_917_203;
+#[cfg(feature = "postgres")]
+static POSTGRES_ROOT_FILESYSTEM_MIGRATED_SCHEMAS: OnceLock<tokio::sync::Mutex<HashSet<String>>> =
+    OnceLock::new();
 
 #[cfg(feature = "postgres")]
 impl PostgresRootFilesystem {
@@ -41,11 +48,36 @@ impl PostgresRootFilesystem {
     }
 
     pub async fn run_migrations(&self) -> Result<(), FilesystemError> {
-        let client = self.migration_client_with_retry().await?;
-        client
+        let mut client = self.migration_client_with_retry().await?;
+        let migration_key = postgres_root_filesystem_migration_key(&client).await?;
+        let registry = POSTGRES_ROOT_FILESYSTEM_MIGRATED_SCHEMAS
+            .get_or_init(|| tokio::sync::Mutex::new(HashSet::new()));
+        let mut migrated_schemas = registry.lock().await;
+        if migrated_schemas.contains(&migration_key) {
+            return Ok(());
+        }
+        let transaction = client
+            .transaction()
+            .await
+            .map_err(|error| infrastructure_pg_error(FilesystemOperation::CreateDirAll, error))?;
+        transaction
+            .execute(
+                "SELECT pg_advisory_xact_lock($1)",
+                &[&POSTGRES_ROOT_FILESYSTEM_MIGRATION_ADVISORY_LOCK],
+            )
+            .await
+            .map_err(|error| infrastructure_pg_error(FilesystemOperation::CreateDirAll, error))?;
+        transaction
             .batch_execute(POSTGRES_ROOT_FILESYSTEM_SCHEMA)
             .await
-            .map_err(|error| infrastructure_pg_error(FilesystemOperation::CreateDirAll, error))
+            .map_err(|error| infrastructure_pg_error(FilesystemOperation::CreateDirAll, error))?;
+        drop_legacy_projection_indexes(&transaction).await?;
+        transaction
+            .commit()
+            .await
+            .map_err(|error| infrastructure_pg_error(FilesystemOperation::CreateDirAll, error))?;
+        migrated_schemas.insert(migration_key);
+        Ok(())
     }
 
     async fn migration_client_with_retry(
@@ -94,6 +126,61 @@ impl PostgresRootFilesystem {
             }
         })
     }
+}
+
+#[cfg(feature = "postgres")]
+async fn drop_legacy_projection_indexes(
+    transaction: &tokio_postgres::Transaction<'_>,
+) -> Result<(), FilesystemError> {
+    let rows = transaction
+        .query(
+            "SELECT indexname \
+             FROM pg_indexes \
+             WHERE schemaname = current_schema() \
+               AND tablename = 'root_filesystem_entries' \
+               AND indexname LIKE 'idx_rfs_%' \
+               AND indexname NOT LIKE 'idx_rfs_shared_%' \
+               AND indexdef LIKE '%btree (((indexed ->>%'",
+            &[],
+        )
+        .await
+        .map_err(|error| infrastructure_pg_error(FilesystemOperation::CreateDirAll, error))?;
+    for row in rows {
+        let index_name: String = row.get(0);
+        let quoted = quote_postgres_identifier(&index_name);
+        transaction
+            .batch_execute(&format!("DROP INDEX IF EXISTS {quoted}"))
+            .await
+            .map_err(|error| infrastructure_pg_error(FilesystemOperation::CreateDirAll, error))?;
+    }
+    Ok(())
+}
+
+#[cfg(feature = "postgres")]
+fn quote_postgres_identifier(identifier: &str) -> String {
+    format!("\"{}\"", identifier.replace('"', "\"\""))
+}
+
+#[cfg(feature = "postgres")]
+async fn postgres_root_filesystem_migration_key(
+    client: &deadpool_postgres::Object,
+) -> Result<String, FilesystemError> {
+    let row = client
+        .query_one(
+            "SELECT \
+                current_database(), \
+                current_schema(), \
+                COALESCE(inet_server_addr()::text, 'local'), \
+                COALESCE(inet_server_port()::text, 'local')",
+            &[],
+        )
+        .await
+        .map_err(|error| infrastructure_pg_error(FilesystemOperation::Connect, error))?;
+    let database: String = row.get(0);
+    let schema: String = row.get(1);
+    let host: String = row.get(2);
+    let port: String = row.get(3);
+    Ok(format!("{host}:{port}/{database}/{schema}"))
 }
 
 #[cfg(feature = "postgres")]
@@ -248,14 +335,17 @@ impl RootFilesystem for PostgresRootFilesystem {
         let index_name = sql_index_name(path.as_str(), spec.name.as_str());
         match &spec.kind {
             IndexKind::Exact | IndexKind::Prefix => {
+                let index_name = postgres_shared_projection_index_name(spec);
                 let expressions: Vec<String> = spec
                     .keys
                     .iter()
                     .map(|k| format!("((indexed->>'{}'))", k.as_str()))
                     .collect();
+                let mut columns = expressions;
+                columns.push("path".to_string());
                 let ddl = format!(
                     "CREATE INDEX IF NOT EXISTS {index_name} ON root_filesystem_entries ({})",
-                    expressions.join(", ")
+                    columns.join(", ")
                 );
                 client.batch_execute(&ddl).await.map_err(|error| {
                     db_error(path.clone(), FilesystemOperation::EnsureIndex, error)
@@ -373,8 +463,12 @@ impl RootFilesystem for PostgresRootFilesystem {
         let client = self.client().await?;
         let params_ref: Vec<&(dyn tokio_postgres::types::ToSql + Sync)> =
             params.iter().map(|p| p.as_ref() as _).collect();
+        let statement = client
+            .prepare_cached(sql.as_str())
+            .await
+            .map_err(|error| db_error(path.clone(), FilesystemOperation::Query, error))?;
         let rows = client
-            .query(sql.as_str(), &params_ref[..])
+            .query(&statement, &params_ref[..])
             .await
             .map_err(|error| db_error(path.clone(), FilesystemOperation::Query, error))?;
         rows.into_iter()
@@ -564,27 +658,7 @@ impl RootFilesystem for PostgresRootFilesystem {
 
     async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
         let client = self.client().await?;
-        if let Some((len, file_type, modified)) =
-            self.exact_entry_with_client(&client, path).await?
-        {
-            return Ok(FileStat {
-                path: path.clone(),
-                file_type,
-                len,
-                modified,
-                sensitive: false,
-            });
-        }
-        if self.has_child_entry_with_client(&client, path).await? {
-            return Ok(FileStat {
-                path: path.clone(),
-                file_type: FileType::Directory,
-                len: 0,
-                modified: None,
-                sensitive: false,
-            });
-        }
-        Err(not_found(path.clone(), FilesystemOperation::Stat))
+        postgres_stat_with_client(&client, path).await
     }
 
     async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
@@ -750,22 +824,7 @@ impl RootFilesystem for PostgresRootFilesystem {
 
     async fn reserve_sequence(&self, path: &VirtualPath) -> Result<SeqNo, FilesystemError> {
         let client = self.client().await?;
-        let row = cached_query_one(
-            &client,
-            r#"
-                INSERT INTO root_filesystem_sequences (path, next_seq, updated_at)
-                VALUES ($1, 2, NOW())
-                ON CONFLICT (path) DO UPDATE SET
-                    next_seq = root_filesystem_sequences.next_seq + 1,
-                    updated_at = NOW()
-                RETURNING next_seq - 1 AS reserved
-                "#,
-            &[&path.as_str()],
-        )
-        .await
-        .map_err(|error| db_error(path.clone(), FilesystemOperation::ReserveSeq, error))?;
-        let reserved: i64 = row.get("reserved");
-        seq_no_from_i64(path, reserved, FilesystemOperation::ReserveSeq)
+        postgres_reserve_sequence_with_client(&client, path).await
     }
 
     async fn create_dir_all(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
@@ -1052,6 +1111,11 @@ impl StorageTxn for PostgresStorageTxn {
         postgres_delete_with_client(self.client()?, path).await
     }
 
+    async fn reserve_sequence(&mut self, path: &VirtualPath) -> Result<SeqNo, FilesystemError> {
+        self.check_path(path)?;
+        postgres_reserve_sequence_with_client(self.client()?, path).await
+    }
+
     async fn commit(mut self: Box<Self>) -> Result<(), FilesystemError> {
         let client = self.client.take().ok_or_else(|| FilesystemError::Backend {
             path: self.prefix.clone(),
@@ -1083,6 +1147,29 @@ impl StorageTxn for PostgresStorageTxn {
 }
 
 #[cfg(feature = "postgres")]
+async fn postgres_reserve_sequence_with_client(
+    client: &deadpool_postgres::Object,
+    path: &VirtualPath,
+) -> Result<SeqNo, FilesystemError> {
+    let row = cached_query_one(
+        client,
+        r#"
+            INSERT INTO root_filesystem_sequences (path, next_seq, updated_at)
+            VALUES ($1, 2, NOW())
+            ON CONFLICT (path) DO UPDATE SET
+                next_seq = root_filesystem_sequences.next_seq + 1,
+                updated_at = NOW()
+            RETURNING next_seq - 1 AS reserved
+            "#,
+        &[&path.as_str()],
+    )
+    .await
+    .map_err(|error| db_error(path.clone(), FilesystemOperation::ReserveSeq, error))?;
+    let reserved: i64 = row.get("reserved");
+    seq_no_from_i64(path, reserved, FilesystemOperation::ReserveSeq)
+}
+
+#[cfg(feature = "postgres")]
 impl Drop for PostgresStorageTxn {
     fn drop(&mut self) {
         if !self.active {
@@ -1105,10 +1192,12 @@ impl Drop for PostgresStorageTxn {
 /// what keeps the small hosted pool from starving the heartbeat/webui and
 /// wedging the runner lease.
 ///
-/// Only use these with *static* SQL — dynamic SQL would grow the cache
-/// unbounded, so the filter `query` and index DDL paths stay on the uncached
-/// `tokio_postgres` calls. The error type stays `tokio_postgres::Error` so
-/// existing `db_error` mapping at call sites is unchanged.
+/// Prefer these with static or low-cardinality query-shape SQL. Filesystem
+/// `query` SQL is generated from the filter shape and indexed key names while
+/// paths and values stay bound parameters, so it uses `prepare_cached` directly
+/// at the call site. Index DDL remains uncached. The error type stays
+/// `tokio_postgres::Error` so existing `db_error` mapping at call sites is
+/// unchanged.
 #[cfg(feature = "postgres")]
 async fn cached_query_opt(
     client: &deadpool_postgres::Object,
@@ -1415,6 +1504,74 @@ async fn postgres_get_with_client(
 }
 
 #[cfg(feature = "postgres")]
+async fn postgres_stat_with_client(
+    client: &deadpool_postgres::Object,
+    path: &VirtualPath,
+) -> Result<FileStat, FilesystemError> {
+    let (prefix_lower, prefix_upper) = descendant_path_range(path);
+    let row = cached_query_opt(
+        client,
+        r#"
+            WITH exact AS (
+                SELECT OCTET_LENGTH(contents)::bigint AS len,
+                       is_dir,
+                       EXTRACT(EPOCH FROM updated_at)::bigint AS updated_at_epoch
+                FROM root_filesystem_entries
+                WHERE path = $1
+            ),
+            child AS (
+                SELECT 1
+                FROM root_filesystem_entries
+                WHERE path >= $2 AND path < $3
+                LIMIT 1
+            )
+            SELECT len, is_dir, updated_at_epoch, TRUE AS exact_match
+            FROM exact
+            UNION ALL
+            SELECT NULL::bigint AS len, TRUE AS is_dir, NULL::bigint AS updated_at_epoch,
+                   FALSE AS exact_match
+            FROM child
+            WHERE NOT EXISTS (SELECT 1 FROM exact)
+            LIMIT 1
+            "#,
+        &[&path.as_str(), &prefix_lower, &prefix_upper],
+    )
+    .await
+    .map_err(|error| db_error(path.clone(), FilesystemOperation::Stat, error))?;
+    let Some(row) = row else {
+        return Err(not_found(path.clone(), FilesystemOperation::Stat));
+    };
+    let exact_match: bool = row.get("exact_match");
+    if !exact_match {
+        return Ok(FileStat {
+            path: path.clone(),
+            file_type: FileType::Directory,
+            len: 0,
+            modified: None,
+            sensitive: false,
+        });
+    }
+    let len: Option<i64> = row.get("len");
+    let is_dir: bool = row.get("is_dir");
+    let updated_at_epoch: Option<i64> = row.get("updated_at_epoch");
+    Ok(FileStat {
+        path: path.clone(),
+        file_type: if is_dir {
+            FileType::Directory
+        } else {
+            FileType::File
+        },
+        len: if is_dir {
+            0
+        } else {
+            len.unwrap_or_default().max(0) as u64
+        },
+        modified: updated_at_epoch.and_then(system_time_from_unix_seconds),
+        sensitive: false,
+    })
+}
+
+#[cfg(feature = "postgres")]
 async fn postgres_delete_with_client(
     client: &deadpool_postgres::Object,
     path: &VirtualPath,
@@ -1516,6 +1673,23 @@ fn descendant_path_range(path: &VirtualPath) -> (String, String) {
     // exclusive upper bound "{prefix}0" works because '/' sorts before '0'
     // in the normalized virtual path alphabet used by these storage paths.
     (format!("{prefix}/"), format!("{prefix}0"))
+}
+
+#[cfg(feature = "postgres")]
+fn postgres_shared_projection_index_name(spec: &IndexSpec) -> String {
+    let kind = match &spec.kind {
+        IndexKind::Exact => "exact",
+        IndexKind::Prefix => "prefix",
+        IndexKind::Fts => "fts",
+        IndexKind::Vector { .. } => "vector",
+    };
+    let keys = spec
+        .keys
+        .iter()
+        .map(|key| key.as_str())
+        .collect::<Vec<_>>()
+        .join("_");
+    sql_index_name(&format!("/shared/{kind}/{keys}"), spec.name.as_str())
 }
 
 /// Translate a [`Filter`] tree into a postgres WHERE-clause fragment.
@@ -1878,5 +2052,56 @@ mod tests {
         assert!("/secrets/a/b/child" >= lower && "/secrets/a/b/child" < upper);
         assert!("/secrets/a/b" < lower); // the path itself is excluded
         assert!("/secrets/a/bb" >= upper); // prefix-sharing sibling excluded
+    }
+
+    #[test]
+    fn shared_projection_index_name_ignores_prefix_specific_declarations() {
+        let spec = IndexSpec::new(
+            crate::IndexName::new("bucket_exact").unwrap(),
+            vec![crate::IndexKey::new("bucket").unwrap()],
+            IndexKind::Exact,
+        );
+        let first = postgres_shared_projection_index_name(&spec);
+        let second = postgres_shared_projection_index_name(&spec);
+        assert_eq!(first, second);
+        assert!(first.contains("shared"));
+        assert!(first.contains("bucket_exact"));
+        assert!(first.len() <= 62);
+    }
+
+    #[test]
+    fn shared_projection_index_name_separates_kind_and_keys() {
+        let exact_bucket = IndexSpec::new(
+            crate::IndexName::new("bucket_exact").unwrap(),
+            vec![crate::IndexKey::new("bucket").unwrap()],
+            IndexKind::Exact,
+        );
+        let prefix_bucket = IndexSpec::new(
+            crate::IndexName::new("bucket_exact").unwrap(),
+            vec![crate::IndexKey::new("bucket").unwrap()],
+            IndexKind::Prefix,
+        );
+        let exact_tenant = IndexSpec::new(
+            crate::IndexName::new("bucket_exact").unwrap(),
+            vec![crate::IndexKey::new("tenant_id").unwrap()],
+            IndexKind::Exact,
+        );
+        assert_ne!(
+            postgres_shared_projection_index_name(&exact_bucket),
+            postgres_shared_projection_index_name(&prefix_bucket)
+        );
+        assert_ne!(
+            postgres_shared_projection_index_name(&exact_bucket),
+            postgres_shared_projection_index_name(&exact_tenant)
+        );
+    }
+
+    #[test]
+    fn quote_postgres_identifier_doubles_embedded_quotes() {
+        assert_eq!(quote_postgres_identifier("idx_simple"), "\"idx_simple\"");
+        assert_eq!(
+            quote_postgres_identifier("idx_\"quoted\""),
+            "\"idx_\"\"quoted\"\"\""
+        );
     }
 }

--- a/crates/ironclaw_filesystem/src/scoped.rs
+++ b/crates/ironclaw_filesystem/src/scoped.rs
@@ -703,6 +703,12 @@ impl StorageTxn for ScopedStorageTxn {
         self.inner.delete(path).await
     }
 
+    async fn reserve_sequence(&mut self, path: &VirtualPath) -> Result<SeqNo, FilesystemError> {
+        self.check(FilesystemOperation::ReserveSeq)?;
+        self.check_path(path)?;
+        self.inner.reserve_sequence(path).await
+    }
+
     async fn commit(self: Box<Self>) -> Result<(), FilesystemError> {
         self.inner.commit().await
     }

--- a/crates/ironclaw_reborn_event_store/src/lib.rs
+++ b/crates/ironclaw_reborn_event_store/src/lib.rs
@@ -291,6 +291,19 @@ pub async fn build_reborn_event_stores(
 /// `/events`. Production composition reuses this on top of a libSQL /
 /// PostgreSQL `RootFilesystem` so the backend choice is a property of the
 /// filesystem rather than of the durable-log impl.
+///
+/// The caller must run any backend schema migrations before calling this
+/// helper. Config-based builders perform their own migration step.
+#[cfg(any(feature = "libsql", feature = "postgres"))]
+pub fn build_reborn_event_stores_from_root_filesystem<F>(
+    root: Arc<F>,
+) -> Result<RebornEventStores, RebornEventStoreError>
+where
+    F: RootFilesystem + Send + Sync + 'static,
+{
+    wrap_root_filesystem_as_event_stores(root)
+}
+
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 fn wrap_root_filesystem_as_event_stores<F>(
     root: Arc<F>,


### PR DESCRIPTION
## Stack

1/4 for hosted-single-tenant Postgres latency parity.

Base: `main`
Next: `codex/hst-postgres-02-turn-state` (#5689)

This first PR is intentionally the reviewer entry point for the whole stack. The code here is only the RootFilesystem substrate slice, but the journey, experiments, and final gains are summarized here so reviewers do not have to start from the large final harness PR.

## Stack Map

- #5688: RootFilesystem latency substrate. No hosted-volume behavior switch.
- #5689: filesystem row-store turn state plus `/turns/state.json` -> `/turns/rows/v1` migration gate. Still no profile switch by itself.
- #5690: production runtime store wiring. This is the first PR that changes live hosted-volume runtime behavior.
- #5691: latency/stress harness and benchmark evidence. Merge last so evidence matches the reviewed runtime stack.

## What This PR Changes

- Optimizes the Postgres `RootFilesystem` substrate used by later stores:
  - serializes root filesystem migrations with an advisory lock and process-local migrated-schema cache
  - moves projection indexes to shared names and includes `path` in exact/prefix indexes
  - uses prepared statements for RootFilesystem query paths
  - exposes transaction-level sequence reservation for append-heavy stores
- Adds a small libSQL connection-init retry fix for transient setup races.
- Adds an event-store helper for wrapping an already-migrated `RootFilesystem`.

## Hosted-Volume Safety

No hosted profile wiring changes here. This PR should not switch `hosted-single-tenant-volume` to any new store layout by itself.

Live-data safety gates across the stack:

- Turn state: #5689 imports legacy `/turns/state.json` only when row state is empty, appends the import through the row journal, and treats existing rows as authoritative afterward.
- Resource governor: #5690 loads existing `/resources/snapshot.json` before replaying the new journal.
- Threads: #5690 derives thread index rows from source thread records on first list; index rows are not source of truth.
- Secrets: `main` already has the per-record filesystem secret layout; #5690 keeps that path and removes direct DB-store bypasses rather than introducing a snapshot-to-row secret migration boundary.

## Starting Point

The production-shaped hosted-volume reference the stack had to beat:

- c32 mixed flow: op p95 154.4ms, resource-governor p95 52.2ms
- c100 mixed flow: op p95 388.1ms, resource-governor p95 213.3ms
- resource-only c100: p95 158.9ms, throughput 859.5 ops/sec

Other important baselines discovered during the cycles:

- Hosted substrate build before migration memoization: libSQL p95 31.87ms, Postgres pool-1 p95 68.77ms, pool-2 p95 52.97ms.
- Blob turn-state size growth: `chat-turn` turn-store p95 climbed by quartile from 32.7ms -> 60.9ms -> 78.8ms -> 114.4ms as `/turns/state.json` grew.
- Locked turn lifecycle blob signal: libSQL c4 p95 about 5.6-8.4s, Postgres blob/early row path in seconds under c4/c8/c100 pressure.
- High-concurrency row turn-state before group/index work: Postgres-only c100 turn lifecycle p95 29.96s, then 15.04s, then 10.56s across early row cycles.
- Thread list before index rows: libSQL cold 11.31s/warm 10.75s; Postgres cold 1.35s/warm 1.23s for 1000 threads.
- Full-flow c100 after row turn-state but before governor fix: op p95 467.7ms, resource-governor p95 271.0ms, turn-store p95 85.5ms.

## Ending Point

Final recorded push-gate numbers after the stack:

- Postgres c100 mixed-user-session, pool32, filesystem-row: op p95 105.7ms, p99 173.7ms, throughput 2,246.6 ops/sec.
- Attribution for that final c100 run: thread-store writes p95 56.0ms, turn-store p95 43.0ms, resource-governor p95 6.2ms, context reads p95 5.1ms.
- Postgres c100 reserve-reconcile: p95 8.8ms, p99 15.7ms, throughput 18,134.4 ops/sec.
- Postgres c100 turn-lifecycle-churn: p95 76.0ms, p99 132.7ms, throughput 5,966.9 ops/sec.
- Clean libSQL vs Postgres c4 turn lifecycle after row-store alignment: libSQL p95 30.9ms, Postgres pool-2 p95 27.6ms.
- Indexed thread list latest: libSQL op p95 5.9ms, Postgres op p95 6.0ms; warm reads are about 185us and 211us respectively.
- Postgres c100 secret consume latest: p95 19.3ms, p99 21.7ms, throughput 10,656.2 ops/sec.

## Gains

| Area | Before | After | Gain |
| --- | ---: | ---: | ---: |
| c100 mixed flow op p95 | 388.1ms hosted-volume reference | 105.7ms | 3.7x lower p95 |
| c100 mixed flow governor p95 | 213.3ms hosted-volume reference | 6.2ms attribution | 34.4x lower p95 |
| resource-only c100 p95 | 158.9ms | 8.8ms | 18.1x lower p95 |
| resource-only throughput | 859.5 ops/sec | 18,134.4 ops/sec | 21.1x higher throughput |
| c100 turn lifecycle p95 | about 10.56s after initial row indexing cycle, 29.96s before lifecycle delta work | 76.0ms | 139x to 394x lower p95 depending baseline |
| libSQL c4 turn lifecycle | about 7.8s when still on blob path | 30.9ms | about 253x lower p95 |
| Postgres c4 turn lifecycle | about 35ms after row alignment | 27.6ms | holds parity |
| libSQL 1000-thread cold list | 11.31s | 5.7ms | about 1984x lower cold-list time |
| Postgres 1000-thread cold list | 1.35s | 5.8ms | about 233x lower cold-list time |
| Postgres c100 secret consume | temporary/direct-store path removed; unified FS store latest | 19.3ms p95 | unified path still clears c100 gate |

## Experiment Ledger

The detailed journey is summarized here in PR text; the raw scratch log is intentionally not committed to the repo.

- Cycle 0, Harness Bootstrap: built the first RootFilesystem latency harness; found Postgres append/tail slower than libSQL and acceptance gaps in turns/triggers/resources/secrets.
- Cycle 1, Invalid Pool-Sizing Detour: detected that raising Postgres pool size made scores look better but violated the hosted pool constraint; reverted the detour.
- Cycle 2, Encode Pool-Cap Scoring: made the scorer compare one libSQL baseline against fixed Postgres pool sizes so pool inflation could not hide regressions.
- Cycle 3, LFD Goal Scaffold: wrote the loss/constraint scaffold and made acceptance gaps explicit.
- Cycle 4, Hosted Substrate Build Workload: measured real hosted runtime construction; Postgres pool-2 p95 was 52.97ms vs libSQL 31.87ms.
- Cycle 5, Postgres Migration Memoization: memoized repeated root migrations; hosted substrate dropped to Postgres pool-1 p95 18.05ms and pool-2 p95 20.89ms.
- Cycle 6, Trigger Coverage: stabilized trigger setup and added durable trigger latency coverage; trigger rows passed and Postgres was faster in focused runs.
- Cycle 7, Control-Plane Snapshot Coverage: added approval/secret/resource snapshot coverage; exposed secret lease consume CAS retry storms.
- Cycle 8, Temporary Postgres Secret Rows: proved per-secret/per-lease row shape removed secret retry storms, but this direct store was later deleted in favor of RootFilesystem rows.
- Cycle 9, Temporary Postgres Resource Rows: proved row-shaped governor state could beat libSQL on control-plane paths, but still bypassed RootFilesystem.
- Cycle 10, Production Resource Wiring Detour: wired native Postgres resource governor as a diagnostic production path; later replaced by the filesystem governor.
- Cycle 11, Shared Postgres Query Indexes: replaced per-prefix projection indexes with shared indexes and prepared query paths; removed stable query hard failures.
- Cycle 12, LibSQL Trigger PRAGMA Drain: fixed transient libSQL trigger baseline failures by retrying connection PRAGMA setup.
- Cycle 13, Single-Query Postgres Stat: collapsed Postgres `stat` to one cached query; control-plane probe stayed faster than libSQL.
- Cycle 14, Resource Migration Memoization: memoized resource migrations; improved substrate path but did not yet hit full latency target.
- Cycle 15, Root Migration Front-Guard: added composition-level migration front guard; hosted substrate moved to about 10.9-11.8ms p50/p95 vs libSQL about 13.6-15.2ms.
- Cycle 16, Stress E2E Pool Deadlock: switched to `ironclaw_stress`; found and fixed nested Postgres pool checkout deadlock via transaction-local sequence reservation.
- Cycle 17, Governor Worker Serialization: widened the temporary Postgres resource governor worker path; c16 pool-2 op p95 improved 104.0ms -> 86.0ms.
- Cycle 18, Holdout LibSQL Connection Flake: retried libSQL PRAGMA setup and got holdout scoring clean; E2E c16 Postgres passed with p95 76.7ms on pool-2.
- Cycle 19, Turn-State Attribution: instrumented full turn flow and proved blob CAS cost grows with state size; retention caps helped but could not solve the design.
- Cycle 20, Filesystem Turn-State Row Layout: introduced typed row/append turn state behind RootFilesystem; validated shape but first row versions were still too slow.
- Cycle 21, Turn Lifecycle Harness Signal: added locked `turn_lifecycle_blob` workload so blob contention became visible in the scorer.
- Cycle 22, Postgres Row Turn-State Wiring: wired Postgres to row turn state and made the dev scorer pass, while c32/c100 still showed same-user serialization.
- Cycle 23, High-Concurrency Resource Pressure: measured c32/c100 full flow and identified resource governor as the top full-flow bottleneck.
- Cycle 24, Diagnostic Backend Filter: added diagnostic-only backend filtering so Postgres c100 rows could be measured even when libSQL crashed first.
- Cycle 25, WebUI Session Path: added real Axum `/api/webchat/v2/session` workload; c1/c4 passed, c100 showed middleware/read-path pressure.
- Cycle 26, Loop Checkpoint Targeted Deltas: made loop checkpoint writes targeted row deltas; c100 turn lifecycle improved but still sat in seconds.
- Cycle 27, Lifecycle Targeted Deltas: made block/resume/cancel/request-cancel targeted; Postgres c100 turn lifecycle improved 29.96s -> 15.04s.
- Cycle 28, Resource Shared-Row Contention: optimized temporary native governor unlimited path; captured hosted-volume reference c32/c100 numbers used as baseline.
- Cycle 29, Checkpoint Readback Projection: removed full snapshot rebuild from checkpoint reads; c100 turn lifecycle improved 14.72s -> 13.23s.
- Cycle 30, Run-State Readback Projection: projected a single run directly; c100 turn lifecycle improved 13.23s -> 12.50s.
- Cycle 31, Event Tail Tracking: cached latest lifecycle event cursor; mostly flat, so we stopped tuning that lever.
- Cycle 32, In-Place Delta Apply: replaced vector rebuilds with in-place row updates; c100 improved 12.43s -> 10.56s.
- Cycle 33, Pool Sweep and Single-Run Lease Prep: confirmed pool size was not the main lever and prepared targeted lease overlay work.
- Cycle 34, Direct Loop Checkpoint Row Deltas: continued checkpoint delta cleanup; held semantics while reducing row-store churn.
- Cycle 35, Claim Lease Seeding: removed more full-snapshot clone/rebuild from lease paths; c100 improved to about 10.20s.
- Cycle 36, Single-Run Overlay: applied runner lease overlay directly to one run; c100 improved 10.20s -> 8.67s.
- Cycle 37, Sparse Delta Experiment: tried sparse JSON delta encoding; rejected it because p95 did not improve.
- Cycle 38, Group-Commit Delta Journal: added the single flusher and `append_batch`; c100 turn lifecycle improved 8.67s -> 3.52s.
- Cycle 39, Indexed Row Snapshot Apply: added row-keyed hot indexes; c100 turn lifecycle improved 3.52s -> 790ms and dev c4 Postgres reached about 35ms.
- Cycle 40, RootFilesystem Journaled Governor: replaced direct Postgres governor with in-process authority plus RootFilesystem delta journal; c100 governor p95 dropped 271.0ms -> 31.1ms.
- Cycle 41, Post-Governor Attribution: after governor fix, top groups moved to thread-store writes and turn-store rather than governor.
- Cycle 42, LibSQL Turn-State Cliff Diagnostic: diagnosed 7.8s libSQL c4 as the harness still using blob turn state; fixed libSQL to row store and got c4 p95 30.9ms.
- Cycle 43, Two-Tier Turn-State Lifecycle: made terminal run eviction a hot-cache policy, not durable row deletion; c100 full mixed flow p95 118.3ms.
- Cycle 44, Thread Index Rows: added derivable per-thread index rows and warm cache; 1000-thread list fell from seconds to about 23ms, then later to about 6ms.
- Cycle 45, Remove Direct Postgres Secret Store: deleted the temporary direct DB secret store and kept secrets on unified per-record RootFilesystem layout; c100 Postgres secret consume stayed around 20ms p95.
- Cycle 46, Thermo Cleanup: split oversized modules and reran gates; mixed-flow c100 improved to 102.3ms p95 in that run, thread list to about 5ms.
- Cycle 47, Review Fixes: fixed real review findings in checkpoint concurrency, stale thread-index delete, partial bootstrap, and no-op index touch; reran benchmarks and found a turn-lifecycle regression.
- Cycle 48, Governor/Turn Lock Boundary: released governor and turn commit gates before durable ack waits while preserving enqueue ordering; final c100 mixed p95 105.7ms, governor p95 6.2ms, turn-lifecycle p95 76.0ms.
- Cycle 49, Turn Blob-to-Row Migration Gate: added the legacy `/turns/state.json` import gate and stale-blob no-remigrate tests so the stack has a live hosted-volume migration path before go-live.

## Verification For This PR

- `cargo check -p ironclaw_filesystem --features libsql,postgres`
- `cargo check -p ironclaw_reborn_event_store --features libsql,postgres`

Stack-wide verification is listed in the dependent PRs and summarized above.
