### PR TITLE
[HST Postgres 2/4] Add row-store turn state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5465,6 +5465,7 @@ dependencies = [
  "blake3",
  "chrono",
  "chrono-tz",
+ "futures-util",
  "hex",
  "ironclaw_filesystem",
  "ironclaw_host_api",

--- a/crates/ironclaw_turns/Cargo.toml
+++ b/crates/ironclaw_turns/Cargo.toml
@@ -19,6 +19,7 @@ async-trait = "0.1"
 blake3 = "1"
 chrono = { version = "0.4", features = ["serde"] }
 chrono-tz = "0.10"
+futures-util = "0.3"
 ironclaw_filesystem = { path = "../ironclaw_filesystem", version = "0.1.0" }
 ironclaw_host_api = { path = "../ironclaw_host_api", version = "0.1.0" }
 ironclaw_observability = { path = "../ironclaw_observability" }

--- a/crates/ironclaw_turns/src/filesystem_store.rs
+++ b/crates/ironclaw_turns/src/filesystem_store.rs
@@ -69,11 +69,14 @@ use crate::{
 mod io;
 mod profile_resolver;
 mod projection;
+mod row_store;
 mod runner_lease;
 
 use io::{deserialize_snapshot, fs_error, snapshot_entry, snapshot_path};
 use profile_resolver::PreResolvedRunProfileResolver;
 use runner_lease::{RunnerLeaseMemory, RunnerLeaseOverlay, RunnerLeaseRecord, RunnerLeaseStore};
+
+pub use row_store::FilesystemTurnStateRowStore;
 
 #[cfg(test)]
 mod tests;
@@ -623,6 +626,51 @@ where
     }
 }
 
+/// Concrete filesystem turn-state store selected by composition.
+///
+/// Keeping this as a concrete enum, rather than a bundle of trait objects,
+/// lets production wiring retain component type checks while allowing
+/// Postgres-backed deployments to use the row/append layout and libSQL-backed
+/// deployments to keep the existing blob layout.
+pub enum FilesystemTurnStateStoreKind<F>
+where
+    F: RootFilesystem,
+{
+    // arch-exempt: large_file, boxed enum variant clippy fix in existing store facade, plan #5662
+    Blob(Box<FilesystemTurnStateStore<F>>),
+    Row(Box<FilesystemTurnStateRowStore<F>>),
+}
+
+impl<F> FilesystemTurnStateStoreKind<F>
+where
+    F: RootFilesystem,
+{
+    pub fn blob(filesystem: Arc<ScopedFilesystem<F>>) -> Self {
+        Self::Blob(Box::new(FilesystemTurnStateStore::new(filesystem)))
+    }
+
+    pub fn row(filesystem: Arc<ScopedFilesystem<F>>) -> Self
+    where
+        F: 'static,
+    {
+        Self::Row(Box::new(FilesystemTurnStateRowStore::new(filesystem)))
+    }
+
+    pub fn with_limits(self, limits: InMemoryTurnStateStoreLimits) -> Self {
+        match self {
+            Self::Blob(store) => Self::Blob(Box::new((*store).with_limits(limits))),
+            Self::Row(store) => Self::Row(Box::new((*store).with_limits(limits))),
+        }
+    }
+
+    pub async fn persistence_snapshot(&self) -> Result<TurnPersistenceSnapshot, TurnError> {
+        match self {
+            Self::Blob(store) => store.persistence_snapshot().await,
+            Self::Row(store) => store.persistence_snapshot().await,
+        }
+    }
+}
+
 /// Map a [`CasUpdateError`] into a [`TurnError`].
 fn map_cas_error(error: CasUpdateError<TurnError>) -> TurnError {
     match error {
@@ -637,6 +685,305 @@ fn map_cas_error(error: CasUpdateError<TurnError>) -> TurnError {
             reason: "turn state filesystem backend must support versioned CAS".to_string(),
         },
         CasUpdateError::Backend(fs) => fs_error(fs),
+    }
+}
+
+#[async_trait]
+impl<F> TurnStateStore for FilesystemTurnStateStoreKind<F>
+where
+    F: RootFilesystem,
+{
+    async fn submit_turn(
+        &self,
+        request: SubmitTurnRequest,
+        admission_policy: &dyn TurnAdmissionPolicy,
+        run_profile_resolver: &dyn RunProfileResolver,
+    ) -> Result<SubmitTurnResponse, TurnError> {
+        match self {
+            Self::Blob(store) => {
+                store
+                    .submit_turn(request, admission_policy, run_profile_resolver)
+                    .await
+            }
+            Self::Row(store) => {
+                store
+                    .submit_turn(request, admission_policy, run_profile_resolver)
+                    .await
+            }
+        }
+    }
+
+    async fn resume_turn(
+        &self,
+        request: ResumeTurnRequest,
+    ) -> Result<ResumeTurnResponse, TurnError> {
+        match self {
+            Self::Blob(store) => store.resume_turn(request).await,
+            Self::Row(store) => store.resume_turn(request).await,
+        }
+    }
+
+    async fn request_cancel(
+        &self,
+        request: CancelRunRequest,
+    ) -> Result<CancelRunResponse, TurnError> {
+        match self {
+            Self::Blob(store) => store.request_cancel(request).await,
+            Self::Row(store) => store.request_cancel(request).await,
+        }
+    }
+
+    async fn get_run_state(&self, request: GetRunStateRequest) -> Result<TurnRunState, TurnError> {
+        match self {
+            Self::Blob(store) => store.get_run_state(request).await,
+            Self::Row(store) => store.get_run_state(request).await,
+        }
+    }
+}
+
+#[async_trait]
+impl<F> TurnSpawnTreeStateStore for FilesystemTurnStateStoreKind<F>
+where
+    F: RootFilesystem,
+{
+    async fn submit_child_turn(
+        &self,
+        request: SubmitChildRunRequest,
+        admission_policy: &dyn TurnAdmissionPolicy,
+        run_profile_resolver: &dyn RunProfileResolver,
+    ) -> Result<SubmitTurnResponse, TurnError> {
+        match self {
+            Self::Blob(store) => {
+                store
+                    .submit_child_turn(request, admission_policy, run_profile_resolver)
+                    .await
+            }
+            Self::Row(store) => {
+                store
+                    .submit_child_turn(request, admission_policy, run_profile_resolver)
+                    .await
+            }
+        }
+    }
+
+    async fn children_of(
+        &self,
+        scope: &TurnScope,
+        run_id: TurnRunId,
+    ) -> Result<Vec<TurnRunRecord>, TurnError> {
+        match self {
+            Self::Blob(store) => store.children_of(scope, run_id).await,
+            Self::Row(store) => store.children_of(scope, run_id).await,
+        }
+    }
+
+    async fn get_run_record(
+        &self,
+        scope: &TurnScope,
+        run_id: TurnRunId,
+    ) -> Result<Option<TurnRunRecord>, TurnError> {
+        match self {
+            Self::Blob(store) => store.get_run_record(scope, run_id).await,
+            Self::Row(store) => store.get_run_record(scope, run_id).await,
+        }
+    }
+
+    async fn reserve_tree_descendants(
+        &self,
+        scope: &TurnScope,
+        root_run_id: TurnRunId,
+        delta: u32,
+        cap: u32,
+    ) -> Result<SpawnTreeReservation, TurnError> {
+        match self {
+            Self::Blob(store) => {
+                store
+                    .reserve_tree_descendants(scope, root_run_id, delta, cap)
+                    .await
+            }
+            Self::Row(store) => {
+                store
+                    .reserve_tree_descendants(scope, root_run_id, delta, cap)
+                    .await
+            }
+        }
+    }
+
+    async fn release_tree_descendants(
+        &self,
+        scope: &TurnScope,
+        root_run_id: TurnRunId,
+        delta: u32,
+    ) -> Result<(), TurnError> {
+        match self {
+            Self::Blob(store) => {
+                store
+                    .release_tree_descendants(scope, root_run_id, delta)
+                    .await
+            }
+            Self::Row(store) => {
+                store
+                    .release_tree_descendants(scope, root_run_id, delta)
+                    .await
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl<F> TurnEventProjectionSource for FilesystemTurnStateStoreKind<F>
+where
+    F: RootFilesystem,
+{
+    async fn read_turn_events_after(
+        &self,
+        scope: &TurnScope,
+        owner_user_id: Option<&UserId>,
+        after: Option<EventCursor>,
+        limit: usize,
+    ) -> Result<TurnEventPage, TurnError> {
+        match self {
+            Self::Blob(store) => {
+                store
+                    .read_turn_events_after(scope, owner_user_id, after, limit)
+                    .await
+            }
+            Self::Row(store) => {
+                store
+                    .read_turn_events_after(scope, owner_user_id, after, limit)
+                    .await
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl<F> LoopCheckpointStore for FilesystemTurnStateStoreKind<F>
+where
+    F: RootFilesystem,
+{
+    async fn put_loop_checkpoint(
+        &self,
+        request: PutLoopCheckpointRequest,
+    ) -> Result<LoopCheckpointRecord, TurnError> {
+        match self {
+            Self::Blob(store) => store.put_loop_checkpoint(request).await,
+            Self::Row(store) => store.put_loop_checkpoint(request).await,
+        }
+    }
+
+    async fn get_loop_checkpoint(
+        &self,
+        request: GetLoopCheckpointRequest,
+    ) -> Result<Option<LoopCheckpointRecord>, TurnError> {
+        match self {
+            Self::Blob(store) => store.get_loop_checkpoint(request).await,
+            Self::Row(store) => store.get_loop_checkpoint(request).await,
+        }
+    }
+}
+
+#[async_trait]
+impl<F> TurnRunTransitionPort for FilesystemTurnStateStoreKind<F>
+where
+    F: RootFilesystem,
+{
+    async fn claim_next_run(
+        &self,
+        request: ClaimRunRequest,
+    ) -> Result<Option<ClaimedTurnRun>, TurnError> {
+        match self {
+            Self::Blob(store) => store.claim_next_run(request).await,
+            Self::Row(store) => store.claim_next_run(request).await,
+        }
+    }
+
+    async fn heartbeat(&self, request: HeartbeatRequest) -> Result<EventCursor, TurnError> {
+        match self {
+            Self::Blob(store) => store.heartbeat(request).await,
+            Self::Row(store) => store.heartbeat(request).await,
+        }
+    }
+
+    async fn recover_expired_leases(
+        &self,
+        request: RecoverExpiredLeasesRequest,
+    ) -> Result<RecoverExpiredLeasesResponse, TurnError> {
+        match self {
+            Self::Blob(store) => store.recover_expired_leases(request).await,
+            Self::Row(store) => store.recover_expired_leases(request).await,
+        }
+    }
+
+    async fn record_model_route_snapshot(
+        &self,
+        request: RecordModelRouteSnapshotRequest,
+    ) -> Result<TurnRunState, TurnError> {
+        match self {
+            Self::Blob(store) => store.record_model_route_snapshot(request).await,
+            Self::Row(store) => store.record_model_route_snapshot(request).await,
+        }
+    }
+
+    async fn block_run(&self, request: BlockRunRequest) -> Result<TurnRunState, TurnError> {
+        match self {
+            Self::Blob(store) => store.block_run(request).await,
+            Self::Row(store) => store.block_run(request).await,
+        }
+    }
+
+    async fn complete_run(&self, request: CompleteRunRequest) -> Result<TurnRunState, TurnError> {
+        match self {
+            Self::Blob(store) => store.complete_run(request).await,
+            Self::Row(store) => store.complete_run(request).await,
+        }
+    }
+
+    async fn cancel_run(
+        &self,
+        request: CancelRunCompletionRequest,
+    ) -> Result<TurnRunState, TurnError> {
+        match self {
+            Self::Blob(store) => store.cancel_run(request).await,
+            Self::Row(store) => store.cancel_run(request).await,
+        }
+    }
+
+    async fn fail_run(&self, request: FailRunRequest) -> Result<TurnRunState, TurnError> {
+        match self {
+            Self::Blob(store) => store.fail_run(request).await,
+            Self::Row(store) => store.fail_run(request).await,
+        }
+    }
+
+    async fn record_runner_failure(
+        &self,
+        request: RecordRunnerFailureRequest,
+    ) -> Result<TurnRunState, TurnError> {
+        match self {
+            Self::Blob(store) => store.record_runner_failure(request).await,
+            Self::Row(store) => store.record_runner_failure(request).await,
+        }
+    }
+
+    async fn relinquish_run(
+        &self,
+        request: RelinquishRunRequest,
+    ) -> Result<TurnRunState, TurnError> {
+        match self {
+            Self::Blob(store) => store.relinquish_run(request).await,
+            Self::Row(store) => store.relinquish_run(request).await,
+        }
+    }
+
+    async fn apply_validated_loop_exit(
+        &self,
+        request: ApplyValidatedLoopExitRequest,
+    ) -> Result<TurnRunState, TurnError> {
+        match self {
+            Self::Blob(store) => store.apply_validated_loop_exit(request).await,
+            Self::Row(store) => store.apply_validated_loop_exit(request).await,
+        }
     }
 }
 

--- a/crates/ironclaw_turns/src/filesystem_store/projection.rs
+++ b/crates/ironclaw_turns/src/filesystem_store/projection.rs
@@ -1,4 +1,7 @@
-use crate::{TurnPersistenceSnapshot, TurnRunId, TurnRunRecord, TurnScope};
+use crate::{
+    GetLoopCheckpointRequest, GetRunStateRequest, LoopCheckpointRecord, TurnActor, TurnError,
+    TurnPersistenceSnapshot, TurnRunId, TurnRunRecord, TurnRunState, TurnScope,
+};
 
 /// Project the children of a run directly from a snapshot without building
 /// an `InMemoryTurnStateStore`. Mirrors `InMemoryTurnStateStore::children_of`
@@ -43,5 +46,71 @@ pub(super) fn run_record(
         .runs
         .iter()
         .find(|record| record.run_id == run_id && record.scope == *scope)
+        .cloned()
+}
+
+pub(super) fn run_state_parts(
+    snapshot: &TurnPersistenceSnapshot,
+    request: &GetRunStateRequest,
+) -> Result<Option<(TurnRunRecord, TurnActor)>, TurnError> {
+    let Some(run) = snapshot
+        .runs
+        .iter()
+        .find(|record| record.run_id == request.run_id && record.scope == request.scope)
+        .cloned()
+    else {
+        return Ok(None);
+    };
+    let actor = snapshot
+        .turns
+        .iter()
+        .find(|record| record.turn_id == run.turn_id)
+        .map(|record| record.actor.clone())
+        .ok_or_else(|| TurnError::Unavailable {
+            reason: "turn run references missing turn record".to_string(),
+        })?;
+    Ok(Some((run, actor)))
+}
+
+pub(super) fn run_state_from_record(run: TurnRunRecord, actor: TurnActor) -> TurnRunState {
+    TurnRunState {
+        scope: run.scope,
+        actor: Some(actor),
+        turn_id: run.turn_id,
+        run_id: run.run_id,
+        status: run.status,
+        accepted_message_ref: run.accepted_message_ref,
+        source_binding_ref: run.source_binding_ref,
+        reply_target_binding_ref: run.reply_target_binding_ref,
+        resolved_run_profile_id: run.profile.id,
+        resolved_run_profile_version: run.profile.version,
+        resolved_model_route: run.resolved_model_route,
+        received_at: run.received_at,
+        checkpoint_id: run.checkpoint_id,
+        gate_ref: run.gate_ref,
+        blocked_activity_id: run.blocked_activity_id,
+        credential_requirements: run.credential_requirements,
+        failure: run.failure,
+        event_cursor: run.event_cursor,
+        product_context: run.product_context,
+        resume_disposition: run.resume_disposition,
+    }
+}
+
+/// Project a loop checkpoint directly from a snapshot without rebuilding an
+/// `InMemoryTurnStateStore`. Mirrors `InMemoryTurnStateStore::get_loop_checkpoint`.
+pub(super) fn loop_checkpoint(
+    snapshot: &TurnPersistenceSnapshot,
+    request: &GetLoopCheckpointRequest,
+) -> Option<LoopCheckpointRecord> {
+    snapshot
+        .loop_checkpoints
+        .iter()
+        .find(|record| {
+            record.scope == request.scope
+                && record.turn_id == request.turn_id
+                && record.run_id == request.run_id
+                && record.checkpoint_id == request.checkpoint_id
+        })
         .cloned()
 }

--- a/crates/ironclaw_turns/src/filesystem_store/projection.rs
+++ b/crates/ironclaw_turns/src/filesystem_store/projection.rs
@@ -1,6 +1,5 @@
 use crate::{
-    GetLoopCheckpointRequest, GetRunStateRequest, LoopCheckpointRecord, TurnActor, TurnError,
-    TurnPersistenceSnapshot, TurnRunId, TurnRunRecord, TurnRunState, TurnScope,
+    TurnActor, TurnPersistenceSnapshot, TurnRunId, TurnRunRecord, TurnRunState, TurnScope,
 };
 
 /// Project the children of a run directly from a snapshot without building
@@ -49,29 +48,6 @@ pub(super) fn run_record(
         .cloned()
 }
 
-pub(super) fn run_state_parts(
-    snapshot: &TurnPersistenceSnapshot,
-    request: &GetRunStateRequest,
-) -> Result<Option<(TurnRunRecord, TurnActor)>, TurnError> {
-    let Some(run) = snapshot
-        .runs
-        .iter()
-        .find(|record| record.run_id == request.run_id && record.scope == request.scope)
-        .cloned()
-    else {
-        return Ok(None);
-    };
-    let actor = snapshot
-        .turns
-        .iter()
-        .find(|record| record.turn_id == run.turn_id)
-        .map(|record| record.actor.clone())
-        .ok_or_else(|| TurnError::Unavailable {
-            reason: "turn run references missing turn record".to_string(),
-        })?;
-    Ok(Some((run, actor)))
-}
-
 pub(super) fn run_state_from_record(run: TurnRunRecord, actor: TurnActor) -> TurnRunState {
     TurnRunState {
         scope: run.scope,
@@ -95,22 +71,4 @@ pub(super) fn run_state_from_record(run: TurnRunRecord, actor: TurnActor) -> Tur
         product_context: run.product_context,
         resume_disposition: run.resume_disposition,
     }
-}
-
-/// Project a loop checkpoint directly from a snapshot without rebuilding an
-/// `InMemoryTurnStateStore`. Mirrors `InMemoryTurnStateStore::get_loop_checkpoint`.
-pub(super) fn loop_checkpoint(
-    snapshot: &TurnPersistenceSnapshot,
-    request: &GetLoopCheckpointRequest,
-) -> Option<LoopCheckpointRecord> {
-    snapshot
-        .loop_checkpoints
-        .iter()
-        .find(|record| {
-            record.scope == request.scope
-                && record.turn_id == request.turn_id
-                && record.run_id == request.run_id
-                && record.checkpoint_id == request.checkpoint_id
-        })
-        .cloned()
 }

--- a/crates/ironclaw_turns/src/filesystem_store/row_store.rs
+++ b/crates/ironclaw_turns/src/filesystem_store/row_store.rs
@@ -1,0 +1,820 @@
+use std::{
+    collections::HashMap,
+    sync::{Arc, OnceLock},
+    time::Duration,
+};
+
+use ironclaw_filesystem::{
+    FILESYSTEM_APPLY_TIMEOUT, FileType, FilesystemError, RecordVersion, RootFilesystem,
+    ScopedFilesystem,
+};
+use ironclaw_host_api::{ResourceScope, UserId};
+use serde::de::DeserializeOwned;
+use tokio::sync::{Mutex as AsyncMutex, RwLock};
+use tracing::{Instrument, field};
+
+use crate::{
+    AllowAllTurnAdmissionLimitProvider, CancelRunRequest, EventCursor, GetRunStateRequest,
+    InMemoryTurnStateStore, InMemoryTurnStateStoreLimits, TurnAdmissionLimitProvider, TurnError,
+    TurnEventPage, TurnPersistenceSnapshot, TurnRecord, TurnRunId, TurnRunRecord, TurnRunState,
+    TurnScope, TurnStatus,
+    events::project_turn_events,
+    runner::{ClaimedTurnRun, HeartbeatRequest, RelinquishRunRequest, TurnRunTransitionPort},
+};
+
+use super::{
+    io as legacy_blob_io, projection,
+    runner_lease::{RunnerLeaseMemory, RunnerLeaseOverlay, RunnerLeaseRecord, RunnerLeaseStore},
+};
+
+mod delta;
+mod io;
+mod journal;
+mod traits;
+
+use delta::{
+    RowPersistError, RowSnapshotState, RowStoreMeta, SnapshotDelta, event_record_key,
+    keyed_records, preserve_loop_checkpoints, row_store_durable_delta,
+    row_store_hot_cache_snapshot, snapshot_delta,
+};
+use io::{deserialize_row, fs_error, meta_path, row_dir, row_path};
+use journal::{DeltaAck, DeltaJournal, materialize_delta_log};
+
+const TURN_ROWS: &str = "turns";
+const RUN_ROWS: &str = "runs";
+const ACTIVE_LOCK_ROWS: &str = "active-locks";
+const CHECKPOINT_ROWS: &str = "checkpoints";
+const LOOP_CHECKPOINT_ROWS: &str = "loop-checkpoints";
+const IDEMPOTENCY_ROWS: &str = "idempotency";
+const EVENT_ROWS: &str = "events";
+const ADMISSION_RESERVATION_ROWS: &str = "admission-reservations";
+const SPAWN_TREE_RESERVATION_ROWS: &str = "spawn-tree-reservations";
+static LEGACY_MIGRATION_GATE: OnceLock<Arc<AsyncMutex<()>>> = OnceLock::new();
+
+/// Filesystem-backed turn-state store using typed append-log deltas.
+///
+/// This is intentionally separate from [`super::FilesystemTurnStateStore`].
+/// When the row projection is empty, first load imports a legacy
+/// `/turns/state.json` blob by appending a full-snapshot row delta and then
+/// replaying the normal delta journal. Once any row data exists, rows are
+/// authoritative and the legacy blob is left untouched as rollback evidence.
+/// Transitions still delegate to [`InMemoryTurnStateStore`]; only the durable
+/// representation changes from whole-snapshot CAS to a typed append log plus a
+/// process-local hot snapshot cache.
+pub struct FilesystemTurnStateRowStore<F>
+where
+    F: RootFilesystem,
+{
+    filesystem: Arc<ScopedFilesystem<F>>,
+    limits: InMemoryTurnStateStoreLimits,
+    admission_limit_provider: Arc<dyn TurnAdmissionLimitProvider>,
+    snapshot_state: AsyncMutex<Option<RowSnapshotState>>,
+    commit_gate: AsyncMutex<()>,
+    runner_leases: RunnerLeaseMemory,
+    delta_journal: DeltaJournal,
+    apply_timeout: Duration,
+}
+
+struct RunStateTransitionTarget {
+    run_id: TurnRunId,
+    runner_id: crate::TurnRunnerId,
+    lease_token: crate::TurnLeaseToken,
+    retired_status: TurnStatus,
+}
+
+impl<F> FilesystemTurnStateRowStore<F>
+where
+    F: RootFilesystem,
+{
+    pub fn new(filesystem: Arc<ScopedFilesystem<F>>) -> Self
+    where
+        F: 'static,
+    {
+        Self {
+            filesystem: Arc::clone(&filesystem),
+            limits: InMemoryTurnStateStoreLimits::default(),
+            admission_limit_provider: Arc::new(AllowAllTurnAdmissionLimitProvider),
+            snapshot_state: AsyncMutex::new(None),
+            commit_gate: AsyncMutex::new(()),
+            runner_leases: Arc::new(RwLock::new(HashMap::new())),
+            delta_journal: DeltaJournal::new(filesystem),
+            apply_timeout: FILESYSTEM_APPLY_TIMEOUT,
+        }
+    }
+
+    pub fn with_limits(mut self, limits: InMemoryTurnStateStoreLimits) -> Self {
+        self.limits = limits;
+        self
+    }
+
+    pub fn with_admission_limit_provider(
+        mut self,
+        admission_limit_provider: Arc<dyn TurnAdmissionLimitProvider>,
+    ) -> Self {
+        self.admission_limit_provider = admission_limit_provider;
+        self
+    }
+
+    pub async fn persistence_snapshot(&self) -> Result<TurnPersistenceSnapshot, TurnError> {
+        let (snapshot, _) = self
+            .read_snapshot_with_runner_lease_overlay(RunnerLeaseOverlay::All)
+            .await?;
+        Ok(snapshot)
+    }
+
+    async fn read_snapshot(
+        &self,
+    ) -> Result<(TurnPersistenceSnapshot, Option<RecordVersion>), TurnError> {
+        let mut guard = self.snapshot_state.lock().await;
+        if guard.is_none() {
+            *guard = Some(self.load_snapshot_from_rows().await?);
+        }
+        let snapshot = guard
+            .as_ref()
+            .map(|state| state.snapshot.clone())
+            .unwrap_or_default();
+        Ok((snapshot, None))
+    }
+
+    async fn read_snapshot_with_runner_lease_overlay(
+        &self,
+        overlay: RunnerLeaseOverlay,
+    ) -> Result<(TurnPersistenceSnapshot, Option<RecordVersion>), TurnError> {
+        let snapshot = self.read_snapshot().await?;
+        self.runner_lease_store().overlay(snapshot, overlay).await
+    }
+
+    async fn with_cached_snapshot<T, R>(&self, read: R) -> Result<T, TurnError>
+    where
+        R: FnOnce(&TurnPersistenceSnapshot) -> T,
+    {
+        let mut guard = self.snapshot_state.lock().await;
+        if guard.is_none() {
+            *guard = Some(self.load_snapshot_from_rows().await?);
+        }
+        let snapshot = &guard
+            .as_ref()
+            .expect("row snapshot cache is initialized above")
+            .snapshot;
+        Ok(read(snapshot))
+    }
+
+    async fn clear_snapshot_cache(&self) {
+        *self.snapshot_state.lock().await = None;
+    }
+
+    async fn load_snapshot_from_rows(&self) -> Result<RowSnapshotState, TurnError> {
+        materialize_delta_log(self.filesystem.as_ref(), None).await?;
+        let snapshot = self.read_materialized_row_snapshot().await?;
+        let snapshot = self.migrate_legacy_blob_if_needed(snapshot).await?;
+        let snapshot = row_store_hot_cache_snapshot(snapshot, self.limits);
+        let store = self.build_in_memory_store(snapshot)?;
+        let snapshot = store.persistence_snapshot();
+        RowSnapshotState::new(snapshot, Arc::new(store))
+    }
+
+    async fn read_materialized_row_snapshot(&self) -> Result<TurnPersistenceSnapshot, TurnError> {
+        let meta = self.read_meta().await?;
+        let turns = self.read_row_collection(TURN_ROWS).await?;
+        let runs = self.read_row_collection(RUN_ROWS).await?;
+        let active_locks = self.read_row_collection(ACTIVE_LOCK_ROWS).await?;
+        let checkpoints = self.read_row_collection(CHECKPOINT_ROWS).await?;
+        let loop_checkpoints = self.read_row_collection(LOOP_CHECKPOINT_ROWS).await?;
+        let idempotency_records = self.read_row_collection(IDEMPOTENCY_ROWS).await?;
+        let events = self.read_row_collection(EVENT_ROWS).await?;
+        let admission_reservations = self.read_row_collection(ADMISSION_RESERVATION_ROWS).await?;
+        let spawn_tree_reservations = self
+            .read_row_collection(SPAWN_TREE_RESERVATION_ROWS)
+            .await?;
+
+        Ok(TurnPersistenceSnapshot {
+            turns,
+            runs,
+            active_locks,
+            checkpoints,
+            loop_checkpoints,
+            idempotency_records,
+            events,
+            event_retention_floor: meta.event_retention_floor,
+            admission_reservations,
+            spawn_tree_reservations,
+        })
+    }
+
+    async fn migrate_legacy_blob_if_needed(
+        &self,
+        materialized: TurnPersistenceSnapshot,
+    ) -> Result<TurnPersistenceSnapshot, TurnError> {
+        if materialized != TurnPersistenceSnapshot::default() {
+            return Ok(materialized);
+        }
+
+        let gate = legacy_migration_gate();
+        let _migration_guard = gate.lock().await;
+        materialize_delta_log(self.filesystem.as_ref(), None).await?;
+        let current = self.read_materialized_row_snapshot().await?;
+        if current != TurnPersistenceSnapshot::default() {
+            return Ok(current);
+        }
+
+        let Some(legacy) = self.read_legacy_blob_snapshot().await? else {
+            return Ok(current);
+        };
+        if legacy == TurnPersistenceSnapshot::default() {
+            return Ok(current);
+        }
+
+        let delta = snapshot_delta(&TurnPersistenceSnapshot::default(), &legacy)
+            .map_err(RowPersistError::into_turn)?;
+        if delta.is_empty() {
+            return Ok(current);
+        }
+
+        tracing::info!(
+            turns = legacy.turns.len(),
+            runs = legacy.runs.len(),
+            events = legacy.events.len(),
+            active_locks = legacy.active_locks.len(),
+            checkpoints = legacy.checkpoints.len(),
+            loop_checkpoints = legacy.loop_checkpoints.len(),
+            idempotency_records = legacy.idempotency_records.len(),
+            "migrating legacy turn-state blob into row store"
+        );
+        let ack = self
+            .enqueue_delta(delta)
+            .map_err(RowPersistError::into_turn)?;
+        self.await_delta_ack(ack)
+            .await
+            .map_err(RowPersistError::into_turn)?;
+        materialize_delta_log(self.filesystem.as_ref(), None).await?;
+        let migrated = self.read_materialized_row_snapshot().await?;
+        tracing::info!(
+            turns = migrated.turns.len(),
+            runs = migrated.runs.len(),
+            events = migrated.events.len(),
+            active_locks = migrated.active_locks.len(),
+            checkpoints = migrated.checkpoints.len(),
+            loop_checkpoints = migrated.loop_checkpoints.len(),
+            idempotency_records = migrated.idempotency_records.len(),
+            "legacy turn-state blob migration completed"
+        );
+        Ok(migrated)
+    }
+
+    async fn read_legacy_blob_snapshot(
+        &self,
+    ) -> Result<Option<TurnPersistenceSnapshot>, TurnError> {
+        let path = legacy_blob_io::snapshot_path()?;
+        match self.filesystem.get(&ResourceScope::system(), &path).await {
+            Ok(Some(versioned)) => {
+                legacy_blob_io::deserialize_snapshot(&versioned.entry.body).map(Some)
+            }
+            Ok(None) => Ok(None),
+            Err(FilesystemError::NotFound { .. }) => Ok(None),
+            Err(error) => Err(fs_error(error)),
+        }
+    }
+
+    async fn read_meta(&self) -> Result<RowStoreMeta, TurnError> {
+        let path = meta_path()?;
+        match self.filesystem.get(&ResourceScope::system(), &path).await {
+            Ok(Some(versioned)) => deserialize_row(&versioned.entry.body, "turn-state row meta"),
+            Ok(None) => Ok(RowStoreMeta::default()),
+            Err(error) => Err(fs_error(error)),
+        }
+    }
+
+    async fn read_row_collection<T>(&self, collection: &'static str) -> Result<Vec<T>, TurnError>
+    where
+        T: DeserializeOwned,
+    {
+        let dir = row_dir(collection)?;
+        let entries = match self
+            .filesystem
+            .list_dir(&ResourceScope::system(), &dir)
+            .await
+        {
+            Ok(entries) => entries,
+            Err(FilesystemError::NotFound { .. }) => Vec::new(),
+            Err(error) => return Err(fs_error(error)),
+        };
+        let mut records = Vec::with_capacity(entries.len());
+        for entry in entries
+            .into_iter()
+            .filter(|entry| entry.file_type == FileType::File)
+            .filter(|entry| entry.name.ends_with(".json"))
+        {
+            let key = entry.name.trim_end_matches(".json").to_string();
+            let path = row_path(collection, &key)?;
+            let Some(versioned) = self
+                .filesystem
+                .get(&ResourceScope::system(), &path)
+                .await
+                .map_err(fs_error)?
+            else {
+                continue;
+            };
+            records.push(deserialize_row(&versioned.entry.body, collection)?);
+        }
+        Ok(records)
+    }
+
+    async fn read_row_by_key<T>(
+        &self,
+        collection: &'static str,
+        key: &str,
+    ) -> Result<Option<T>, TurnError>
+    where
+        T: DeserializeOwned,
+    {
+        let path = row_path(collection, key)?;
+        let Some(versioned) = self
+            .filesystem
+            .get(&ResourceScope::system(), &path)
+            .await
+            .map_err(fs_error)?
+        else {
+            return Ok(None);
+        };
+        deserialize_row(&versioned.entry.body, collection).map(Some)
+    }
+
+    async fn read_run_state_from_durable_rows(
+        &self,
+        request: &GetRunStateRequest,
+    ) -> Result<Option<TurnRunState>, TurnError> {
+        materialize_delta_log(self.filesystem.as_ref(), None).await?;
+        let run = self
+            .read_row_by_key::<TurnRunRecord>(RUN_ROWS, &request.run_id.to_string())
+            .await?;
+
+        let Some(run) = run.filter(|record| record.scope == request.scope) else {
+            return Ok(None);
+        };
+        let turn_key = run.turn_id.to_string();
+        let turn = self
+            .read_row_by_key::<TurnRecord>(TURN_ROWS, &turn_key)
+            .await?
+            .ok_or_else(|| TurnError::Unavailable {
+                reason: "turn run references missing durable turn row".to_string(),
+            })?;
+        let run = self.runner_lease_store().overlay_run_record(run).await?;
+        Ok(Some(projection::run_state_from_record(run, turn.actor)))
+    }
+
+    async fn read_turn_events_from_durable_rows(
+        &self,
+        scope: &TurnScope,
+        owner_user_id: Option<&UserId>,
+        after: Option<EventCursor>,
+        limit: usize,
+    ) -> Result<TurnEventPage, TurnError> {
+        materialize_delta_log(self.filesystem.as_ref(), None).await?;
+        let events = keyed_records(
+            &self.read_row_collection(EVENT_ROWS).await?,
+            &event_record_key,
+        )
+        .map_err(RowPersistError::into_turn)?;
+        let retention_floor = self.read_meta().await?.event_retention_floor;
+        let mut events = events.into_values().collect::<Vec<_>>();
+        events.sort_by_key(|event| event.cursor);
+        Ok(project_turn_events(
+            &events,
+            scope,
+            owner_user_id,
+            after,
+            limit,
+            retention_floor,
+        ))
+    }
+
+    async fn seed_runner_lease_from_cached_run(&self, run_id: TurnRunId) -> Result<(), TurnError> {
+        let run = self
+            .with_cached_snapshot(|snapshot| {
+                snapshot
+                    .runs
+                    .iter()
+                    .find(|record| record.run_id == run_id)
+                    .cloned()
+            })
+            .await?
+            .ok_or(TurnError::ScopeNotFound)?;
+        self.runner_lease_store().seed_from_run_record(run).await
+    }
+
+    async fn cleanup_runner_lease_after_state(&self, result: &Result<TurnRunState, TurnError>) {
+        self.runner_lease_store().cleanup_after_state(result).await;
+    }
+
+    async fn heartbeat_runner_lease(
+        &self,
+        request: HeartbeatRequest,
+    ) -> Result<EventCursor, TurnError> {
+        let lease_store = self.runner_lease_store();
+        match lease_store.heartbeat(request.clone()).await {
+            Err(TurnError::ScopeNotFound) => {
+                self.seed_missing_runner_lease_from_snapshot(request.run_id)
+                    .await?;
+                self.runner_lease_store().heartbeat(request).await
+            }
+            result => result,
+        }
+    }
+
+    async fn seed_missing_runner_lease_from_snapshot(
+        &self,
+        run_id: TurnRunId,
+    ) -> Result<(), TurnError> {
+        let (snapshot, _version) = self.read_snapshot().await?;
+        self.runner_lease_store()
+            .seed_from_snapshot_if_missing(&snapshot, run_id)
+            .await
+    }
+
+    async fn prepare_cancel_requested_runner_lease(
+        &self,
+        request: &CancelRunRequest,
+    ) -> Result<Option<RunnerLeaseRecord>, TurnError> {
+        let (snapshot, _version) = self.read_snapshot().await?;
+        let Some(run) = snapshot
+            .runs
+            .iter()
+            .find(|record| record.run_id == request.run_id && record.scope == request.scope)
+        else {
+            return Ok(None);
+        };
+        if !matches!(
+            run.status,
+            TurnStatus::Running | TurnStatus::CancelRequested
+        ) {
+            return Ok(None);
+        }
+        self.runner_lease_store()
+            .mark_cancel_requested_from_snapshot(&snapshot, request.run_id)
+            .await
+    }
+
+    async fn prepare_runner_lease_retirement(
+        &self,
+        run_id: TurnRunId,
+        runner_id: crate::TurnRunnerId,
+        lease_token: crate::TurnLeaseToken,
+        retired_status: TurnStatus,
+    ) -> Result<Option<RunnerLeaseRecord>, TurnError> {
+        let (snapshot, _version) = self.read_snapshot().await?;
+        self.runner_lease_store()
+            .retire_runner_lease_from_snapshot(
+                &snapshot,
+                run_id,
+                runner_id,
+                lease_token,
+                retired_status,
+            )
+            .await
+    }
+
+    async fn restore_runner_lease_after_failed_transition(
+        &self,
+        previous: Option<RunnerLeaseRecord>,
+        current_status: TurnStatus,
+    ) {
+        let Some(previous) = previous else {
+            return;
+        };
+        self.runner_lease_store()
+            .restore_if_current_status(previous, current_status)
+            .await;
+    }
+
+    fn runner_lease_store(&self) -> RunnerLeaseStore {
+        RunnerLeaseStore::new(
+            Arc::clone(&self.runner_leases),
+            self.limits.runner_lease_ttl,
+            self.apply_timeout,
+        )
+    }
+
+    fn build_in_memory_store(
+        &self,
+        snapshot: TurnPersistenceSnapshot,
+    ) -> Result<InMemoryTurnStateStore, TurnError> {
+        InMemoryTurnStateStore::from_persistence_snapshot_with_admission_limit_provider(
+            snapshot,
+            self.limits,
+            self.admission_limit_provider.clone(),
+        )
+    }
+
+    async fn apply<T, A, Fut>(
+        &self,
+        overlay: RunnerLeaseOverlay,
+        mut apply: A,
+    ) -> Result<T, TurnError>
+    where
+        A: FnMut(Arc<InMemoryTurnStateStore>) -> Fut + Send,
+        Fut: std::future::Future<Output = Result<T, TurnError>> + Send,
+        T: Send,
+    {
+        let critical = async {
+            let _commit_guard = self.commit_gate.lock().await;
+            let mut guard = self.snapshot_state.lock().await;
+            if guard.is_none() {
+                *guard = Some(self.load_snapshot_from_rows().await?);
+            }
+            let baseline = guard
+                .as_ref()
+                .map(|state| state.snapshot.clone())
+                .unwrap_or_default();
+            let (overlaid_snapshot, _) = self
+                .runner_lease_store()
+                .overlay((baseline.clone(), None), overlay)
+                .await?;
+            let store = Arc::new(self.build_in_memory_store(overlaid_snapshot)?);
+            let outcome = apply(Arc::clone(&store)).await;
+            let mut new_snapshot = store.persistence_snapshot();
+            preserve_loop_checkpoints(&baseline, &mut new_snapshot);
+            let value = match outcome {
+                Ok(value) => value,
+                Err(error) => {
+                    *guard = None;
+                    return Err(error);
+                }
+            };
+            if new_snapshot == baseline {
+                return Ok((None, value));
+            }
+
+            let delta = match snapshot_delta(&baseline, &new_snapshot) {
+                Ok(delta) => delta,
+                Err(RowPersistError::Turn(error)) => {
+                    *guard = None;
+                    return Err(error);
+                }
+            };
+            let persist_delta = row_store_durable_delta(delta.clone());
+            let ack = match self.enqueue_delta(persist_delta) {
+                Ok(ack) => ack,
+                Err(RowPersistError::Turn(error)) => {
+                    *guard = None;
+                    return Err(error);
+                }
+            };
+            *guard = Some(RowSnapshotState::new(new_snapshot, store)?);
+            Ok((ack, value))
+        };
+
+        let (ack, value) = match tokio::time::timeout(self.apply_timeout, critical).await {
+            Ok(result) => result?,
+            Err(_) => {
+                self.clear_snapshot_cache().await;
+                return Err(TurnError::Unavailable {
+                    reason: "turn state row-store apply timed out".to_string(),
+                });
+            }
+        };
+        if let Err(error) = self.await_delta_ack(ack).await {
+            self.clear_snapshot_cache().await;
+            return Err(error.into_turn());
+        }
+        Ok(value)
+    }
+
+    fn enqueue_delta(&self, delta: SnapshotDelta) -> Result<Option<DeltaAck>, RowPersistError> {
+        self.delta_journal
+            .enqueue(delta)
+            .map_err(RowPersistError::Turn)
+    }
+
+    async fn await_delta_ack(&self, ack: Option<DeltaAck>) -> Result<(), RowPersistError> {
+        DeltaJournal::await_ack(ack)
+            .await
+            .map_err(RowPersistError::Turn)
+    }
+
+    async fn apply_cached_delta(&self, delta: SnapshotDelta) -> Result<(), TurnError> {
+        if delta.is_empty() {
+            return Ok(());
+        }
+        let mut guard = self.snapshot_state.lock().await;
+        if let Some(state) = guard.as_mut() {
+            state.apply_delta(delta)?;
+        }
+        Ok(())
+    }
+
+    async fn apply_with_targeted_delta<T, A, Fut, D>(
+        &self,
+        overlay: RunnerLeaseOverlay,
+        mut apply: A,
+        build_delta: D,
+    ) -> Result<T, TurnError>
+    where
+        A: FnMut(Arc<InMemoryTurnStateStore>) -> Fut + Send,
+        Fut: std::future::Future<Output = Result<T, TurnError>> + Send,
+        D: FnOnce(
+                &TurnPersistenceSnapshot,
+                EventCursor,
+                &InMemoryTurnStateStore,
+                &T,
+            ) -> Result<SnapshotDelta, TurnError>
+            + Send,
+        T: Send,
+    {
+        let critical = async {
+            let _commit_guard = self.commit_gate.lock().await;
+            let mut guard = self.snapshot_state.lock().await;
+            if guard.is_none() {
+                *guard = Some(self.load_snapshot_from_rows().await?);
+            }
+            let state = guard
+                .as_ref()
+                .expect("row snapshot cache is initialized above");
+            let baseline = state.snapshot.clone();
+            let latest_event_cursor = state.latest_event_cursor();
+            let (overlaid_snapshot, _) = self
+                .runner_lease_store()
+                .overlay((baseline.clone(), None), overlay)
+                .await?;
+            let store = Arc::new(self.build_in_memory_store(overlaid_snapshot)?);
+            let outcome = apply(Arc::clone(&store)).await;
+            let value = match outcome {
+                Ok(value) => value,
+                Err(error) => {
+                    *guard = None;
+                    return Err(error);
+                }
+            };
+            let delta = build_delta(&baseline, latest_event_cursor, store.as_ref(), &value)?;
+            let persist_delta = row_store_durable_delta(delta.clone());
+            let ack = match self.enqueue_delta(persist_delta) {
+                Ok(ack) => ack,
+                Err(RowPersistError::Turn(error)) => {
+                    *guard = None;
+                    return Err(error);
+                }
+            };
+            if let Some(state) = guard.as_mut() {
+                if let Err(error) = state.apply_delta(delta) {
+                    *guard = None;
+                    return Err(error);
+                }
+                state.store = store;
+            } else {
+                let mut snapshot = store.persistence_snapshot();
+                snapshot = row_store_hot_cache_snapshot(snapshot, self.limits);
+                *guard = Some(RowSnapshotState::new(snapshot, store)?);
+            }
+            Ok((ack, value))
+        };
+
+        let (ack, value) = match tokio::time::timeout(self.apply_timeout, critical).await {
+            Ok(result) => result?,
+            Err(_) => {
+                self.clear_snapshot_cache().await;
+                return Err(TurnError::Unavailable {
+                    reason: "turn state row-store targeted apply timed out".to_string(),
+                });
+            }
+        };
+        if let Err(error) = self.await_delta_ack(ack).await {
+            self.clear_snapshot_cache().await;
+            return Err(error.into_turn());
+        }
+        Ok(value)
+    }
+
+    async fn apply_run_state_transition<A, Fut>(
+        &self,
+        operation: &'static str,
+        run_id: TurnRunId,
+        runner_id: crate::TurnRunnerId,
+        lease_token: crate::TurnLeaseToken,
+        retired_status: TurnStatus,
+        apply: A,
+    ) -> Result<TurnRunState, TurnError>
+    where
+        A: FnMut(Arc<InMemoryTurnStateStore>) -> Fut + Send,
+        Fut: std::future::Future<Output = Result<TurnRunState, TurnError>> + Send,
+    {
+        let span = turn_state_write_span(operation, None, Some(&run_id));
+        async move {
+            let previous = self
+                .prepare_runner_lease_retirement(run_id, runner_id, lease_token, retired_status)
+                .await?;
+            let result = self.apply(RunnerLeaseOverlay::Run(run_id), apply).await;
+            if result.is_err() {
+                self.restore_runner_lease_after_failed_transition(previous, retired_status)
+                    .await;
+            }
+            self.cleanup_runner_lease_after_state(&result).await;
+            result
+        }
+        .instrument(span)
+        .await
+    }
+
+    async fn apply_run_state_transition_with_targeted_delta<A, Fut, D>(
+        &self,
+        operation: &'static str,
+        target: RunStateTransitionTarget,
+        apply: A,
+        build_delta: D,
+    ) -> Result<TurnRunState, TurnError>
+    where
+        A: FnMut(Arc<InMemoryTurnStateStore>) -> Fut + Send,
+        Fut: std::future::Future<Output = Result<TurnRunState, TurnError>> + Send,
+        D: FnOnce(
+                &TurnPersistenceSnapshot,
+                EventCursor,
+                &InMemoryTurnStateStore,
+                &TurnRunState,
+            ) -> Result<SnapshotDelta, TurnError>
+            + Send,
+    {
+        let RunStateTransitionTarget {
+            run_id,
+            runner_id,
+            lease_token,
+            retired_status,
+        } = target;
+        let span = turn_state_write_span(operation, None, Some(&run_id));
+        async move {
+            let previous = self
+                .prepare_runner_lease_retirement(run_id, runner_id, lease_token, retired_status)
+                .await?;
+            let result = self
+                .apply_with_targeted_delta(RunnerLeaseOverlay::Run(run_id), apply, build_delta)
+                .await;
+            if result.is_err() {
+                self.restore_runner_lease_after_failed_transition(previous, retired_status)
+                    .await;
+            }
+            self.cleanup_runner_lease_after_state(&result).await;
+            result
+        }
+        .instrument(span)
+        .await
+    }
+
+    async fn compensate_failed_claim(&self, claimed: &ClaimedTurnRun) {
+        let run_id = claimed.state.run_id;
+        let result = self
+            .apply(RunnerLeaseOverlay::Run(run_id), |store| async move {
+                let outcome = store
+                    .relinquish_run(RelinquishRunRequest {
+                        run_id,
+                        runner_id: claimed.runner_id,
+                        lease_token: claimed.lease_token,
+                    })
+                    .await;
+                outcome.map(|_| ())
+            })
+            .instrument(turn_state_write_span(
+                "compensate_failed_claim",
+                Some(&claimed.state.scope),
+                Some(&run_id),
+            ))
+            .await;
+        if let Err(error) = result {
+            tracing::debug!(
+                run_id = %run_id,
+                error = %error,
+                "failed to compensate turn claim after memory runner lease seed failed"
+            );
+        }
+    }
+}
+
+fn turn_state_write_span(
+    operation: &'static str,
+    scope: Option<&TurnScope>,
+    run_id: Option<&TurnRunId>,
+) -> tracing::Span {
+    let span = tracing::trace_span!(
+        target: "ironclaw_latency",
+        "turn_state_write",
+        turn_state_op = operation,
+        tenant_id = field::Empty,
+        thread_id = field::Empty,
+        owner_user_id = field::Empty,
+        run_id = field::Empty,
+    );
+
+    if let Some(scope) = scope {
+        span.record("tenant_id", field::display(&scope.tenant_id));
+        span.record("thread_id", field::display(&scope.thread_id));
+        if let Some(owner_user_id) = scope.explicit_owner_user_id() {
+            span.record("owner_user_id", field::display(owner_user_id));
+        }
+    }
+
+    if let Some(run_id) = run_id {
+        span.record("run_id", field::display(&run_id));
+    }
+
+    span
+}
+
+fn legacy_migration_gate() -> Arc<AsyncMutex<()>> {
+    Arc::clone(LEGACY_MIGRATION_GATE.get_or_init(|| Arc::new(AsyncMutex::new(()))))
+}

--- a/crates/ironclaw_turns/src/filesystem_store/row_store.rs
+++ b/crates/ironclaw_turns/src/filesystem_store/row_store.rs
@@ -1,23 +1,21 @@
-use std::{
-    collections::HashMap,
-    sync::{Arc, OnceLock},
-    time::Duration,
-};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
+use futures_util::stream::{self, StreamExt, TryStreamExt};
 use ironclaw_filesystem::{
-    FILESYSTEM_APPLY_TIMEOUT, FileType, FilesystemError, RecordVersion, RootFilesystem,
-    ScopedFilesystem,
+    CasExpectation, ContentType, Entry, FILESYSTEM_APPLY_TIMEOUT, FileType, FilesystemError,
+    RecordVersion, RootFilesystem, ScopedFilesystem, SeqNo,
 };
-use ironclaw_host_api::{ResourceScope, UserId};
+use ironclaw_host_api::{ResourceScope, ScopedPath, UserId};
 use serde::de::DeserializeOwned;
 use tokio::sync::{Mutex as AsyncMutex, RwLock};
 use tracing::{Instrument, field};
 
 use crate::{
-    AllowAllTurnAdmissionLimitProvider, CancelRunRequest, EventCursor, GetRunStateRequest,
-    InMemoryTurnStateStore, InMemoryTurnStateStoreLimits, TurnAdmissionLimitProvider, TurnError,
-    TurnEventPage, TurnPersistenceSnapshot, TurnRecord, TurnRunId, TurnRunRecord, TurnRunState,
-    TurnScope, TurnStatus,
+    AllowAllTurnAdmissionLimitProvider, CancelRunRequest, EventCursor, GetLoopCheckpointRequest,
+    GetRunStateRequest, InMemoryTurnStateStore, InMemoryTurnStateStoreLimits, LoopCheckpointRecord,
+    TurnActiveLockRecord, TurnAdmissionLimitProvider, TurnError, TurnEventPage,
+    TurnPersistenceSnapshot, TurnRecord, TurnRunId, TurnRunRecord, TurnRunState, TurnScope,
+    TurnStatus,
     events::project_turn_events,
     runner::{ClaimedTurnRun, HeartbeatRequest, RelinquishRunRequest, TurnRunTransitionPort},
 };
@@ -33,11 +31,14 @@ mod journal;
 mod traits;
 
 use delta::{
-    RowPersistError, RowSnapshotState, RowStoreMeta, SnapshotDelta, event_record_key,
-    keyed_records, preserve_loop_checkpoints, row_store_durable_delta,
-    row_store_hot_cache_snapshot, snapshot_delta,
+    RowPersistError, RowSnapshotState, RowStoreMeta, SnapshotDelta, active_lock_record_key,
+    event_record_key, keyed_records, preserve_loop_checkpoints, row_store_durable_delta,
+    row_store_hot_cache_snapshot, run_record_key, snapshot_delta,
 };
-use io::{deserialize_row, fs_error, meta_path, row_dir, row_path};
+use io::{
+    delta_log_path, deserialize_materialized_row, deserialize_row, fs_error, materialized_row_seq,
+    meta_path, row_dir, row_path, serialize_materialized_row,
+};
 use journal::{DeltaAck, DeltaJournal, materialize_delta_log};
 
 const TURN_ROWS: &str = "turns";
@@ -49,7 +50,7 @@ const IDEMPOTENCY_ROWS: &str = "idempotency";
 const EVENT_ROWS: &str = "events";
 const ADMISSION_RESERVATION_ROWS: &str = "admission-reservations";
 const SPAWN_TREE_RESERVATION_ROWS: &str = "spawn-tree-reservations";
-static LEGACY_MIGRATION_GATE: OnceLock<Arc<AsyncMutex<()>>> = OnceLock::new();
+const ROW_COLLECTION_READ_CONCURRENCY: usize = 32;
 
 /// Filesystem-backed turn-state store using typed append-log deltas.
 ///
@@ -70,9 +71,57 @@ where
     admission_limit_provider: Arc<dyn TurnAdmissionLimitProvider>,
     snapshot_state: AsyncMutex<Option<RowSnapshotState>>,
     commit_gate: AsyncMutex<()>,
+    legacy_migration_gate: Arc<AsyncMutex<()>>,
+    materialize_gate: Arc<AsyncMutex<()>>,
     runner_leases: RunnerLeaseMemory,
     delta_journal: DeltaJournal,
     apply_timeout: Duration,
+}
+
+enum ActiveLockReservation {
+    Created {
+        key: String,
+        run: Option<RunRowReservation>,
+    },
+    Updated {
+        key: String,
+        previous: Box<TurnActiveLockRecord>,
+        previous_seq: SeqNo,
+        version: RecordVersion,
+    },
+}
+
+enum RunRowReservation {
+    Created {
+        turn_key: Option<String>,
+        run_key: Option<String>,
+    },
+    UpdatedRun {
+        key: String,
+        previous: Box<TurnRunRecord>,
+        previous_seq: SeqNo,
+        version: RecordVersion,
+    },
+}
+
+impl ActiveLockReservation {
+    fn key(&self) -> &str {
+        match self {
+            Self::Created { key, .. } | Self::Updated { key, .. } => key,
+        }
+    }
+}
+
+struct PendingRowCommit<T> {
+    value: T,
+    ack: Option<DeltaAck>,
+    active_lock_reservations: Vec<ActiveLockReservation>,
+    run_row_reservations: Vec<RunRowReservation>,
+}
+
+enum RowApplyOutcome<T> {
+    Ready(T),
+    Pending(PendingRowCommit<T>),
 }
 
 struct RunStateTransitionTarget {
@@ -90,14 +139,17 @@ where
     where
         F: 'static,
     {
+        let materialize_gate = Arc::new(AsyncMutex::new(()));
         Self {
             filesystem: Arc::clone(&filesystem),
             limits: InMemoryTurnStateStoreLimits::default(),
             admission_limit_provider: Arc::new(AllowAllTurnAdmissionLimitProvider),
             snapshot_state: AsyncMutex::new(None),
             commit_gate: AsyncMutex::new(()),
+            legacy_migration_gate: Arc::new(AsyncMutex::new(())),
+            materialize_gate: Arc::clone(&materialize_gate),
             runner_leases: Arc::new(RwLock::new(HashMap::new())),
-            delta_journal: DeltaJournal::new(filesystem),
+            delta_journal: DeltaJournal::new(filesystem, materialize_gate),
             apply_timeout: FILESYSTEM_APPLY_TIMEOUT,
         }
     }
@@ -112,6 +164,11 @@ where
         admission_limit_provider: Arc<dyn TurnAdmissionLimitProvider>,
     ) -> Self {
         self.admission_limit_provider = admission_limit_provider;
+        self
+    }
+
+    pub fn with_apply_timeout(mut self, apply_timeout: Duration) -> Self {
+        self.apply_timeout = apply_timeout;
         self
     }
 
@@ -154,7 +211,9 @@ where
         }
         let snapshot = &guard
             .as_ref()
-            .expect("row snapshot cache is initialized above")
+            .ok_or_else(|| TurnError::Unavailable {
+                reason: "row snapshot cache was not initialized".to_string(),
+            })?
             .snapshot;
         Ok(read(snapshot))
     }
@@ -163,14 +222,45 @@ where
         *self.snapshot_state.lock().await = None;
     }
 
+    async fn ensure_snapshot_cache_for_mutation(
+        &self,
+        guard: &mut Option<RowSnapshotState>,
+    ) -> Result<(), TurnError> {
+        if guard.is_none() {
+            *guard = Some(self.load_snapshot_from_rows().await?);
+        }
+        Ok(())
+    }
+
+    async fn refresh_snapshot_cache_after_stale_mutation_error(
+        &self,
+        guard: &mut Option<RowSnapshotState>,
+        error: &TurnError,
+    ) -> Result<bool, TurnError> {
+        if !matches!(error, TurnError::ThreadBusy(_)) {
+            return Ok(false);
+        }
+        let head_seq = self.delta_log_head_seq().await?;
+        if guard
+            .as_ref()
+            .is_none_or(|state| state.journal_seq < head_seq)
+        {
+            *guard = Some(self.load_snapshot_from_rows().await?);
+            return Ok(true);
+        }
+        Ok(false)
+    }
+
     async fn load_snapshot_from_rows(&self) -> Result<RowSnapshotState, TurnError> {
-        materialize_delta_log(self.filesystem.as_ref(), None).await?;
+        materialize_delta_log(self.filesystem.as_ref(), &self.materialize_gate, None).await?;
         let snapshot = self.read_materialized_row_snapshot().await?;
+        let snapshot = self.remove_orphan_active_locks(snapshot).await?;
         let snapshot = self.migrate_legacy_blob_if_needed(snapshot).await?;
         let snapshot = row_store_hot_cache_snapshot(snapshot, self.limits);
         let store = self.build_in_memory_store(snapshot)?;
         let snapshot = store.persistence_snapshot();
-        RowSnapshotState::new(snapshot, Arc::new(store))
+        let journal_seq = self.read_meta().await?.journal_seq;
+        RowSnapshotState::new(snapshot, Arc::new(store), journal_seq)
     }
 
     async fn read_materialized_row_snapshot(&self) -> Result<TurnPersistenceSnapshot, TurnError> {
@@ -201,6 +291,32 @@ where
         })
     }
 
+    async fn remove_orphan_active_locks(
+        &self,
+        mut snapshot: TurnPersistenceSnapshot,
+    ) -> Result<TurnPersistenceSnapshot, TurnError> {
+        let mut retained = Vec::with_capacity(snapshot.active_locks.len());
+        for lock in snapshot.active_locks {
+            if snapshot.runs.iter().any(|run| run.run_id == lock.run_id) {
+                retained.push(lock);
+                continue;
+            }
+            let key = active_lock_record_key(&lock)?;
+            let path = row_path(ACTIVE_LOCK_ROWS, &key)?;
+            self.filesystem
+                .delete(&ResourceScope::system(), &path)
+                .await
+                .map_err(fs_error)?;
+            tracing::warn!(
+                active_lock_key = %key,
+                run_id = %lock.run_id,
+                "removed orphan turn-state active-lock row without a durable run row",
+            );
+        }
+        snapshot.active_locks = retained;
+        Ok(snapshot)
+    }
+
     async fn migrate_legacy_blob_if_needed(
         &self,
         materialized: TurnPersistenceSnapshot,
@@ -208,12 +324,17 @@ where
         if materialized != TurnPersistenceSnapshot::default() {
             return Ok(materialized);
         }
+        if self.read_meta().await?.journal_seq > SeqNo::ZERO {
+            return Ok(materialized);
+        }
 
-        let gate = legacy_migration_gate();
-        let _migration_guard = gate.lock().await;
-        materialize_delta_log(self.filesystem.as_ref(), None).await?;
+        let _migration_guard = self.legacy_migration_gate.lock().await;
+        materialize_delta_log(self.filesystem.as_ref(), &self.materialize_gate, None).await?;
         let current = self.read_materialized_row_snapshot().await?;
         if current != TurnPersistenceSnapshot::default() {
+            return Ok(current);
+        }
+        if self.read_meta().await?.journal_seq > SeqNo::ZERO {
             return Ok(current);
         }
 
@@ -246,7 +367,7 @@ where
         self.await_delta_ack(ack)
             .await
             .map_err(RowPersistError::into_turn)?;
-        materialize_delta_log(self.filesystem.as_ref(), None).await?;
+        materialize_delta_log(self.filesystem.as_ref(), &self.materialize_gate, None).await?;
         let migrated = self.read_materialized_row_snapshot().await?;
         tracing::info!(
             turns = migrated.turns.len(),
@@ -284,6 +405,20 @@ where
         }
     }
 
+    async fn delta_log_head_seq(&self) -> Result<SeqNo, TurnError> {
+        let path = delta_log_path()?;
+        let head = self
+            .filesystem
+            .head_seq(&ResourceScope::system(), &path, SeqNo::ZERO)
+            .await
+            .map_err(fs_error)?;
+        Ok(head.unwrap_or(SeqNo::ZERO))
+    }
+
+    async fn next_delta_log_seq(&self) -> Result<SeqNo, TurnError> {
+        Ok(self.delta_log_head_seq().await?.next())
+    }
+
     async fn read_row_collection<T>(&self, collection: &'static str) -> Result<Vec<T>, TurnError>
     where
         T: DeserializeOwned,
@@ -298,25 +433,31 @@ where
             Err(FilesystemError::NotFound { .. }) => Vec::new(),
             Err(error) => return Err(fs_error(error)),
         };
-        let mut records = Vec::with_capacity(entries.len());
-        for entry in entries
+        let paths = entries
             .into_iter()
             .filter(|entry| entry.file_type == FileType::File)
             .filter(|entry| entry.name.ends_with(".json"))
-        {
-            let key = entry.name.trim_end_matches(".json").to_string();
-            let path = row_path(collection, &key)?;
-            let Some(versioned) = self
-                .filesystem
-                .get(&ResourceScope::system(), &path)
-                .await
-                .map_err(fs_error)?
-            else {
-                continue;
-            };
-            records.push(deserialize_row(&versioned.entry.body, collection)?);
-        }
-        Ok(records)
+            .map(|entry| {
+                let key = entry.name.trim_end_matches(".json").to_string();
+                row_path(collection, &key)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let records = stream::iter(paths)
+            .map(|path| async move {
+                let Some(versioned) = self
+                    .filesystem
+                    .get(&ResourceScope::system(), &path)
+                    .await
+                    .map_err(fs_error)?
+                else {
+                    return Ok(None);
+                };
+                deserialize_materialized_row(&versioned.entry.body, collection)
+            })
+            .buffer_unordered(ROW_COLLECTION_READ_CONCURRENCY)
+            .try_collect::<Vec<_>>()
+            .await?;
+        Ok(records.into_iter().flatten().collect())
     }
 
     async fn read_row_by_key<T>(
@@ -336,14 +477,16 @@ where
         else {
             return Ok(None);
         };
-        deserialize_row(&versioned.entry.body, collection).map(Some)
+        deserialize_materialized_row(&versioned.entry.body, collection)
     }
 
     async fn read_run_state_from_durable_rows(
         &self,
         request: &GetRunStateRequest,
     ) -> Result<Option<TurnRunState>, TurnError> {
-        materialize_delta_log(self.filesystem.as_ref(), None).await?;
+        materialize_delta_log(self.filesystem.as_ref(), &self.materialize_gate, None).await?;
+        self.ensure_legacy_blob_migrated_for_direct_row_read()
+            .await?;
         let run = self
             .read_row_by_key::<TurnRunRecord>(RUN_ROWS, &request.run_id.to_string())
             .await?;
@@ -369,7 +512,9 @@ where
         after: Option<EventCursor>,
         limit: usize,
     ) -> Result<TurnEventPage, TurnError> {
-        materialize_delta_log(self.filesystem.as_ref(), None).await?;
+        materialize_delta_log(self.filesystem.as_ref(), &self.materialize_gate, None).await?;
+        self.ensure_legacy_blob_migrated_for_direct_row_read()
+            .await?;
         let events = keyed_records(
             &self.read_row_collection(EVENT_ROWS).await?,
             &event_record_key,
@@ -386,6 +531,39 @@ where
             limit,
             retention_floor,
         ))
+    }
+
+    async fn read_loop_checkpoint_from_durable_rows(
+        &self,
+        request: &GetLoopCheckpointRequest,
+    ) -> Result<Option<LoopCheckpointRecord>, TurnError> {
+        materialize_delta_log(self.filesystem.as_ref(), &self.materialize_gate, None).await?;
+        self.ensure_legacy_blob_migrated_for_direct_row_read()
+            .await?;
+        let key = request.checkpoint_id.as_uuid().to_string();
+        let checkpoint = self
+            .read_row_by_key::<LoopCheckpointRecord>(LOOP_CHECKPOINT_ROWS, &key)
+            .await?;
+        Ok(checkpoint.filter(|record| {
+            record.scope == request.scope
+                && record.turn_id == request.turn_id
+                && record.run_id == request.run_id
+                && record.checkpoint_id == request.checkpoint_id
+        }))
+    }
+
+    async fn ensure_legacy_blob_migrated_for_direct_row_read(&self) -> Result<(), TurnError> {
+        if self.read_meta().await?.journal_seq > SeqNo::ZERO {
+            return Ok(());
+        }
+        if self.read_legacy_blob_snapshot().await?.is_none() {
+            return Ok(());
+        }
+        let mut guard = self.snapshot_state.lock().await;
+        if guard.is_none() {
+            *guard = Some(self.load_snapshot_from_rows().await?);
+        }
+        Ok(())
     }
 
     async fn seed_runner_lease_from_cached_run(&self, run_id: TurnRunId) -> Result<(), TurnError> {
@@ -518,52 +696,97 @@ where
         let critical = async {
             let _commit_guard = self.commit_gate.lock().await;
             let mut guard = self.snapshot_state.lock().await;
-            if guard.is_none() {
-                *guard = Some(self.load_snapshot_from_rows().await?);
-            }
-            let baseline = guard
-                .as_ref()
-                .map(|state| state.snapshot.clone())
-                .unwrap_or_default();
-            let (overlaid_snapshot, _) = self
-                .runner_lease_store()
-                .overlay((baseline.clone(), None), overlay)
-                .await?;
-            let store = Arc::new(self.build_in_memory_store(overlaid_snapshot)?);
-            let outcome = apply(Arc::clone(&store)).await;
-            let mut new_snapshot = store.persistence_snapshot();
-            preserve_loop_checkpoints(&baseline, &mut new_snapshot);
-            let value = match outcome {
-                Ok(value) => value,
-                Err(error) => {
-                    *guard = None;
-                    return Err(error);
+            let mut refreshed_after_stale_error = false;
+            loop {
+                self.ensure_snapshot_cache_for_mutation(&mut guard).await?;
+                let baseline = guard
+                    .as_ref()
+                    .map(|state| state.snapshot.clone())
+                    .unwrap_or_default();
+                let (overlaid_snapshot, _) = self
+                    .runner_lease_store()
+                    .overlay((baseline.clone(), None), overlay)
+                    .await?;
+                let store = Arc::new(self.build_in_memory_store(overlaid_snapshot)?);
+                let outcome = apply(Arc::clone(&store)).await;
+                let mut new_snapshot = store.persistence_snapshot();
+                preserve_loop_checkpoints(&baseline, &mut new_snapshot);
+                let value = match outcome {
+                    Ok(value) => value,
+                    Err(error) => {
+                        if !refreshed_after_stale_error
+                            && self
+                                .refresh_snapshot_cache_after_stale_mutation_error(
+                                    &mut guard, &error,
+                                )
+                                .await?
+                        {
+                            refreshed_after_stale_error = true;
+                            continue;
+                        }
+                        *guard = None;
+                        return Err(error);
+                    }
+                };
+                if new_snapshot == baseline {
+                    return Ok(RowApplyOutcome::Ready(value));
                 }
-            };
-            if new_snapshot == baseline {
-                return Ok((None, value));
-            }
 
-            let delta = match snapshot_delta(&baseline, &new_snapshot) {
-                Ok(delta) => delta,
-                Err(RowPersistError::Turn(error)) => {
-                    *guard = None;
-                    return Err(error);
-                }
-            };
-            let persist_delta = row_store_durable_delta(delta.clone());
-            let ack = match self.enqueue_delta(persist_delta) {
-                Ok(ack) => ack,
-                Err(RowPersistError::Turn(error)) => {
-                    *guard = None;
-                    return Err(error);
-                }
-            };
-            *guard = Some(RowSnapshotState::new(new_snapshot, store)?);
-            Ok((ack, value))
+                let delta = match snapshot_delta(&baseline, &new_snapshot) {
+                    Ok(delta) => delta,
+                    Err(RowPersistError::Turn(error)) => {
+                        *guard = None;
+                        return Err(error);
+                    }
+                };
+                let persist_delta = row_store_durable_delta(delta.clone());
+                let reservation_seq = self.next_delta_log_seq().await?;
+                let next_state = RowSnapshotState::new(new_snapshot, store, reservation_seq)?;
+                let run_row_reservations = match self
+                    .reserve_run_row_updates(&baseline, &persist_delta, reservation_seq)
+                    .await
+                {
+                    Ok(reservations) => reservations,
+                    Err(error) => {
+                        *guard = None;
+                        return Err(error.into_turn());
+                    }
+                };
+                let active_lock_reservations = match self
+                    .reserve_active_lock_writes(&baseline, &persist_delta, reservation_seq)
+                    .await
+                {
+                    Ok(reservations) => reservations,
+                    Err(error) => {
+                        self.rollback_run_row_reservations(run_row_reservations)
+                            .await;
+                        *guard = None;
+                        return Err(error.into_turn());
+                    }
+                };
+                let ack = match self.enqueue_delta(persist_delta) {
+                    Ok(ack) => ack,
+                    Err(RowPersistError::Turn(error)) => {
+                        self.rollback_row_reservations(
+                            active_lock_reservations,
+                            run_row_reservations,
+                        )
+                        .await;
+                        *guard = None;
+                        return Err(error);
+                    }
+                };
+                *guard = Some(next_state);
+                return Ok(RowApplyOutcome::Pending(PendingRowCommit {
+                    value,
+                    ack,
+                    active_lock_reservations,
+                    run_row_reservations,
+                }));
+            }
         };
 
-        let (ack, value) = match tokio::time::timeout(self.apply_timeout, critical).await {
+        let outcome = match tokio::time::timeout(self.apply_timeout, critical).await {
             Ok(result) => result?,
             Err(_) => {
                 self.clear_snapshot_cache().await;
@@ -572,11 +795,13 @@ where
                 });
             }
         };
-        if let Err(error) = self.await_delta_ack(ack).await {
-            self.clear_snapshot_cache().await;
-            return Err(error.into_turn());
+        match outcome {
+            RowApplyOutcome::Ready(value) => Ok(value),
+            RowApplyOutcome::Pending(pending) => {
+                self.await_pending_commit(pending, "turn state row-store append ack timed out")
+                    .await
+            }
         }
-        Ok(value)
     }
 
     fn enqueue_delta(&self, delta: SnapshotDelta) -> Result<Option<DeltaAck>, RowPersistError> {
@@ -591,13 +816,687 @@ where
             .map_err(RowPersistError::Turn)
     }
 
+    async fn await_pending_commit<T>(
+        &self,
+        pending: PendingRowCommit<T>,
+        timeout_reason: &'static str,
+    ) -> Result<T, TurnError> {
+        match tokio::time::timeout(self.apply_timeout, self.await_delta_ack(pending.ack)).await {
+            Ok(Ok(())) => Ok(pending.value),
+            Ok(Err(error)) => {
+                self.rollback_row_reservations(
+                    pending.active_lock_reservations,
+                    pending.run_row_reservations,
+                )
+                .await;
+                self.clear_snapshot_cache().await;
+                Err(error.into_turn())
+            }
+            Err(_) => {
+                self.clear_snapshot_cache().await;
+                Err(TurnError::Unavailable {
+                    reason: timeout_reason.to_string(),
+                })
+            }
+        }
+    }
+
+    async fn reserve_active_lock_writes(
+        &self,
+        baseline: &TurnPersistenceSnapshot,
+        delta: &SnapshotDelta,
+        reservation_seq: SeqNo,
+    ) -> Result<Vec<ActiveLockReservation>, RowPersistError> {
+        let mut reservations = Vec::new();
+        for record in &delta.active_locks_upsert {
+            let key = active_lock_record_key(record)?;
+            let path = row_path(ACTIVE_LOCK_ROWS, &key)?;
+
+            let Some(previous) = baseline_committed_active_lock(baseline, record) else {
+                let mut run_reservation = self
+                    .reserve_run_row_for_active_lock(record, delta, reservation_seq)
+                    .await?;
+                let mut reserved = false;
+                for attempt in 0..3 {
+                    let entry = active_lock_entry(record, reservation_seq)?;
+                    match self
+                        .filesystem
+                        .put(
+                            &ResourceScope::system(),
+                            &path,
+                            entry,
+                            CasExpectation::Absent,
+                        )
+                        .await
+                    {
+                        Ok(_version) => {
+                            reservations.push(ActiveLockReservation::Created {
+                                key,
+                                run: run_reservation.take(),
+                            });
+                            reserved = true;
+                            break;
+                        }
+                        Err(FilesystemError::VersionMismatch { .. }) => {
+                            let current =
+                                match self.filesystem.get(&ResourceScope::system(), &path).await {
+                                    Ok(current) => current,
+                                    Err(error) => {
+                                        self.rollback_run_row_reservation(run_reservation.take())
+                                            .await;
+                                        self.rollback_active_lock_reservations(reservations).await;
+                                        return Err(RowPersistError::Turn(fs_error(error)));
+                                    }
+                                };
+                            if let Some(current) = current {
+                                let current_record: Option<TurnActiveLockRecord> =
+                                    deserialize_materialized_row(
+                                        &current.entry.body,
+                                        ACTIVE_LOCK_ROWS,
+                                    )?;
+                                if current_record.is_none() {
+                                    let current_seq = materialized_row_seq(
+                                        &current.entry.body,
+                                        ACTIVE_LOCK_ROWS,
+                                    )?;
+                                    let entry = active_lock_entry(
+                                        record,
+                                        current_seq.max(reservation_seq),
+                                    )?;
+                                    match self
+                                        .filesystem
+                                        .put(
+                                            &ResourceScope::system(),
+                                            &path,
+                                            entry,
+                                            CasExpectation::Version(current.version),
+                                        )
+                                        .await
+                                    {
+                                        Ok(_version) => {
+                                            reservations.push(ActiveLockReservation::Created {
+                                                key,
+                                                run: run_reservation.take(),
+                                            });
+                                            reserved = true;
+                                            break;
+                                        }
+                                        Err(FilesystemError::VersionMismatch { .. }) => continue,
+                                        Err(error) => {
+                                            self.rollback_run_row_reservation(
+                                                run_reservation.take(),
+                                            )
+                                            .await;
+                                            self.rollback_active_lock_reservations(reservations)
+                                                .await;
+                                            return Err(RowPersistError::Turn(fs_error(error)));
+                                        }
+                                    }
+                                }
+                            }
+                            if self
+                                .delete_orphan_active_lock_if_present(&key, &path)
+                                .await?
+                            {
+                                continue;
+                            }
+                            if attempt == 0 {
+                                materialize_delta_log(
+                                    self.filesystem.as_ref(),
+                                    &self.materialize_gate,
+                                    None,
+                                )
+                                .await?;
+                                continue;
+                            }
+                            self.rollback_run_row_reservation(run_reservation.take())
+                                .await;
+                            self.rollback_active_lock_reservations(reservations).await;
+                            return Err(RowPersistError::Turn(TurnError::Conflict {
+                                reason: "turn scope already has a durable active lock".to_string(),
+                            }));
+                        }
+                        Err(error) => {
+                            self.rollback_run_row_reservation(run_reservation.take())
+                                .await;
+                            self.rollback_active_lock_reservations(reservations).await;
+                            return Err(RowPersistError::Turn(fs_error(error)));
+                        }
+                    }
+                }
+                if !reserved {
+                    self.rollback_run_row_reservation(run_reservation.take())
+                        .await;
+                    self.rollback_active_lock_reservations(reservations).await;
+                    return Err(RowPersistError::Turn(TurnError::Conflict {
+                        reason: "turn scope already has a durable active lock".to_string(),
+                    }));
+                }
+                continue;
+            };
+
+            if previous == record {
+                continue;
+            }
+
+            for attempt in 0..2 {
+                let current = match self.filesystem.get(&ResourceScope::system(), &path).await {
+                    Ok(Some(current)) => current,
+                    Ok(None) if attempt == 0 => {
+                        materialize_delta_log(
+                            self.filesystem.as_ref(),
+                            &self.materialize_gate,
+                            None,
+                        )
+                        .await?;
+                        continue;
+                    }
+                    Ok(None) => {
+                        self.rollback_active_lock_reservations(reservations).await;
+                        return Err(RowPersistError::Turn(TurnError::Conflict {
+                            reason: "durable active lock disappeared before update".to_string(),
+                        }));
+                    }
+                    Err(error) => {
+                        self.rollback_active_lock_reservations(reservations).await;
+                        return Err(RowPersistError::Turn(fs_error(error)));
+                    }
+                };
+                let current_record: TurnActiveLockRecord =
+                    deserialize_materialized_row(&current.entry.body, ACTIVE_LOCK_ROWS)?
+                        .ok_or_else(|| {
+                            RowPersistError::Turn(TurnError::Conflict {
+                                reason: "durable active lock row was deleted before update"
+                                    .to_string(),
+                            })
+                        })?;
+                let previous_seq = materialized_row_seq(&current.entry.body, ACTIVE_LOCK_ROWS)?;
+                if &current_record != previous {
+                    if attempt == 0 {
+                        materialize_delta_log(
+                            self.filesystem.as_ref(),
+                            &self.materialize_gate,
+                            None,
+                        )
+                        .await?;
+                        continue;
+                    }
+                    self.rollback_active_lock_reservations(reservations).await;
+                    return Err(RowPersistError::Turn(TurnError::Conflict {
+                        reason: "durable active lock changed before update".to_string(),
+                    }));
+                }
+                let entry = active_lock_entry(record, reservation_seq)?;
+                match self
+                    .filesystem
+                    .put(
+                        &ResourceScope::system(),
+                        &path,
+                        entry,
+                        CasExpectation::Version(current.version),
+                    )
+                    .await
+                {
+                    Ok(version) => {
+                        reservations.push(ActiveLockReservation::Updated {
+                            key,
+                            previous: Box::new(previous.clone()),
+                            previous_seq,
+                            version,
+                        });
+                        break;
+                    }
+                    Err(FilesystemError::VersionMismatch { .. }) if attempt == 0 => {
+                        materialize_delta_log(
+                            self.filesystem.as_ref(),
+                            &self.materialize_gate,
+                            None,
+                        )
+                        .await?;
+                    }
+                    Err(FilesystemError::VersionMismatch { .. }) => {
+                        self.rollback_active_lock_reservations(reservations).await;
+                        return Err(RowPersistError::Turn(TurnError::Conflict {
+                            reason: "durable active lock changed before update".to_string(),
+                        }));
+                    }
+                    Err(error) => {
+                        self.rollback_active_lock_reservations(reservations).await;
+                        return Err(RowPersistError::Turn(fs_error(error)));
+                    }
+                }
+            }
+        }
+        Ok(reservations)
+    }
+
+    async fn reserve_run_row_for_active_lock(
+        &self,
+        record: &TurnActiveLockRecord,
+        delta: &SnapshotDelta,
+        reservation_seq: SeqNo,
+    ) -> Result<Option<RunRowReservation>, RowPersistError> {
+        let run = delta
+            .runs_upsert
+            .iter()
+            .find(|run| run.run_id == record.run_id)
+            .ok_or_else(|| {
+                RowPersistError::Turn(TurnError::Unavailable {
+                    reason: "turn-state active-lock create missing matching run row".to_string(),
+                })
+            })?;
+        let turn = delta
+            .turns_upsert
+            .iter()
+            .find(|turn| turn.turn_id == run.turn_id)
+            .ok_or_else(|| {
+                RowPersistError::Turn(TurnError::Unavailable {
+                    reason: "turn-state active-lock create missing matching turn row".to_string(),
+                })
+            })?;
+        let turn_key = match self
+            .reserve_json_row(TURN_ROWS, &turn.turn_id.to_string(), turn, reservation_seq)
+            .await
+        {
+            Ok(key) => key,
+            Err(error) => return Err(error),
+        };
+        let run_key = match self
+            .reserve_json_row(RUN_ROWS, &run_record_key(run)?, run, reservation_seq)
+            .await
+        {
+            Ok(key) => key,
+            Err(error) => {
+                self.rollback_run_row_reservation(Some(RunRowReservation::Created {
+                    turn_key,
+                    run_key: None,
+                }))
+                .await;
+                return Err(error);
+            }
+        };
+        if turn_key.is_none() && run_key.is_none() {
+            Ok(None)
+        } else {
+            Ok(Some(RunRowReservation::Created { turn_key, run_key }))
+        }
+    }
+
+    async fn reserve_run_row_updates(
+        &self,
+        baseline: &TurnPersistenceSnapshot,
+        delta: &SnapshotDelta,
+        reservation_seq: SeqNo,
+    ) -> Result<Vec<RunRowReservation>, RowPersistError> {
+        let mut reservations = Vec::new();
+        for run in &delta.runs_upsert {
+            if baseline
+                .runs
+                .iter()
+                .any(|previous| previous.run_id == run.run_id)
+                && let Some(reservation) = self
+                    .reserve_run_row_update(run, baseline, reservation_seq)
+                    .await?
+            {
+                reservations.push(reservation);
+            }
+        }
+        Ok(reservations)
+    }
+
+    async fn reserve_run_row_update(
+        &self,
+        run: &TurnRunRecord,
+        baseline: &TurnPersistenceSnapshot,
+        reservation_seq: SeqNo,
+    ) -> Result<Option<RunRowReservation>, RowPersistError> {
+        let previous = baseline
+            .runs
+            .iter()
+            .find(|previous| previous.run_id == run.run_id)
+            .ok_or_else(|| {
+                RowPersistError::Turn(TurnError::Unavailable {
+                    reason: "turn-state run-row update missing baseline run row".to_string(),
+                })
+            })?;
+        if previous == run {
+            return Ok(None);
+        }
+
+        let key = run_record_key(run)?;
+        let path = row_path(RUN_ROWS, &key)?;
+        for attempt in 0..2 {
+            let current = match self.filesystem.get(&ResourceScope::system(), &path).await {
+                Ok(Some(current)) => current,
+                Ok(None) if attempt == 0 => {
+                    materialize_delta_log(self.filesystem.as_ref(), &self.materialize_gate, None)
+                        .await?;
+                    continue;
+                }
+                Ok(None) => {
+                    return Err(RowPersistError::Turn(TurnError::Conflict {
+                        reason: "durable run row disappeared before reservation".to_string(),
+                    }));
+                }
+                Err(error) => return Err(RowPersistError::Turn(fs_error(error))),
+            };
+            let current_record: TurnRunRecord =
+                deserialize_materialized_row(&current.entry.body, RUN_ROWS)?.ok_or_else(|| {
+                    RowPersistError::Turn(TurnError::Conflict {
+                        reason: "durable run row was deleted before reservation".to_string(),
+                    })
+                })?;
+            let previous_seq = materialized_row_seq(&current.entry.body, RUN_ROWS)?;
+            if &current_record != previous {
+                if attempt == 0 {
+                    materialize_delta_log(self.filesystem.as_ref(), &self.materialize_gate, None)
+                        .await?;
+                    continue;
+                }
+                return Err(RowPersistError::Turn(TurnError::Conflict {
+                    reason: "durable run row changed before reservation".to_string(),
+                }));
+            }
+            let entry = row_entry(RUN_ROWS, run, reservation_seq)?;
+            match self
+                .filesystem
+                .put(
+                    &ResourceScope::system(),
+                    &path,
+                    entry,
+                    CasExpectation::Version(current.version),
+                )
+                .await
+            {
+                Ok(version) => {
+                    return Ok(Some(RunRowReservation::UpdatedRun {
+                        key,
+                        previous: Box::new(previous.clone()),
+                        previous_seq,
+                        version,
+                    }));
+                }
+                Err(FilesystemError::VersionMismatch { .. }) if attempt == 0 => {
+                    materialize_delta_log(self.filesystem.as_ref(), &self.materialize_gate, None)
+                        .await?;
+                }
+                Err(FilesystemError::VersionMismatch { .. }) => {
+                    return Err(RowPersistError::Turn(TurnError::Conflict {
+                        reason: "durable run row changed before reservation".to_string(),
+                    }));
+                }
+                Err(error) => return Err(RowPersistError::Turn(fs_error(error))),
+            }
+        }
+        Err(RowPersistError::Turn(TurnError::Conflict {
+            reason: "durable run row changed before active-lock update".to_string(),
+        }))
+    }
+
+    async fn reserve_json_row<T>(
+        &self,
+        collection: &'static str,
+        key: &str,
+        record: &T,
+        reservation_seq: SeqNo,
+    ) -> Result<Option<String>, RowPersistError>
+    where
+        T: serde::Serialize + DeserializeOwned + PartialEq,
+    {
+        let path = row_path(collection, key)?;
+        let entry = row_entry(collection, record, reservation_seq)?;
+        match self
+            .filesystem
+            .put(
+                &ResourceScope::system(),
+                &path,
+                entry,
+                CasExpectation::Absent,
+            )
+            .await
+        {
+            Ok(_version) => Ok(Some(key.to_string())),
+            Err(FilesystemError::VersionMismatch { .. }) => {
+                let current = self
+                    .filesystem
+                    .get(&ResourceScope::system(), &path)
+                    .await
+                    .map_err(fs_error)?
+                    .ok_or_else(|| {
+                        RowPersistError::Turn(TurnError::Conflict {
+                            reason: format!(
+                                "durable {collection} row changed before active-lock reservation"
+                            ),
+                        })
+                    })?;
+                let current_record: Option<T> =
+                    deserialize_materialized_row(&current.entry.body, collection)?;
+                match current_record {
+                    Some(current_record) if current_record == *record => Ok(None),
+                    None => {
+                        let current_seq = materialized_row_seq(&current.entry.body, collection)?;
+                        let entry =
+                            row_entry(collection, record, current_seq.max(reservation_seq))?;
+                        match self
+                            .filesystem
+                            .put(
+                                &ResourceScope::system(),
+                                &path,
+                                entry,
+                                CasExpectation::Version(current.version),
+                            )
+                            .await
+                        {
+                            Ok(_version) => Ok(Some(key.to_string())),
+                            Err(FilesystemError::VersionMismatch { .. }) => {
+                                Err(RowPersistError::Turn(TurnError::Conflict {
+                                    reason: format!(
+                                        "durable {collection} row changed before active-lock reservation"
+                                    ),
+                                }))
+                            }
+                            Err(error) => Err(RowPersistError::Turn(fs_error(error))),
+                        }
+                    }
+                    Some(_) => Err(RowPersistError::Turn(TurnError::Conflict {
+                        reason: format!(
+                            "durable {collection} row changed before active-lock reservation"
+                        ),
+                    })),
+                }
+            }
+            Err(error) => Err(RowPersistError::Turn(fs_error(error))),
+        }
+    }
+
+    async fn delete_orphan_active_lock_if_present(
+        &self,
+        key: &str,
+        path: &ScopedPath,
+    ) -> Result<bool, RowPersistError> {
+        let current = match self.filesystem.get(&ResourceScope::system(), path).await {
+            Ok(Some(current)) => current,
+            Ok(None) => return Ok(false),
+            Err(error) => return Err(RowPersistError::Turn(fs_error(error))),
+        };
+        let current_record: TurnActiveLockRecord = deserialize_materialized_row(
+            &current.entry.body,
+            ACTIVE_LOCK_ROWS,
+        )?
+        .ok_or_else(|| {
+            RowPersistError::Turn(TurnError::Conflict {
+                reason: "durable active lock row was deleted before reservation".to_string(),
+            })
+        })?;
+        let run_path = row_path(RUN_ROWS, &current_record.run_id.to_string())?;
+        match self
+            .filesystem
+            .get(&ResourceScope::system(), &run_path)
+            .await
+        {
+            Ok(Some(_)) => Ok(false),
+            Ok(None) => {
+                self.filesystem
+                    .delete(&ResourceScope::system(), path)
+                    .await
+                    .map_err(fs_error)?;
+                tracing::warn!(
+                    active_lock_key = %key,
+                    run_id = %current_record.run_id,
+                    "removed orphan turn-state active-lock row while reserving a new lock",
+                );
+                Ok(true)
+            }
+            Err(error) => Err(RowPersistError::Turn(fs_error(error))),
+        }
+    }
+
+    async fn rollback_run_row_reservation(&self, reservation: Option<RunRowReservation>) {
+        let Some(reservation) = reservation else {
+            return;
+        };
+        match reservation {
+            RunRowReservation::Created { turn_key, run_key } => {
+                for (collection, key) in [(RUN_ROWS, run_key), (TURN_ROWS, turn_key)] {
+                    let Some(key) = key else {
+                        continue;
+                    };
+                    let Ok(path) = row_path(collection, &key) else {
+                        continue;
+                    };
+                    if let Err(error) = self
+                        .filesystem
+                        .delete(&ResourceScope::system(), &path)
+                        .await
+                    {
+                        tracing::warn!(
+                            error = %error,
+                            collection,
+                            row_key = %key,
+                            "failed to roll back row reservation after active-lock reservation failure",
+                        );
+                    }
+                }
+            }
+            RunRowReservation::UpdatedRun {
+                key,
+                previous,
+                previous_seq,
+                version,
+            } => {
+                let Ok(path) = row_path(RUN_ROWS, &key) else {
+                    return;
+                };
+                let entry = match row_entry(RUN_ROWS, previous.as_ref(), previous_seq) {
+                    Ok(entry) => entry,
+                    Err(error) => {
+                        let error = error.into_turn();
+                        tracing::warn!(
+                            error = %error,
+                            row_key = %key,
+                            "failed to serialize run-row rollback after active-lock reservation failure",
+                        );
+                        return;
+                    }
+                };
+                if let Err(error) = self
+                    .filesystem
+                    .put(
+                        &ResourceScope::system(),
+                        &path,
+                        entry,
+                        CasExpectation::Version(version),
+                    )
+                    .await
+                {
+                    tracing::warn!(
+                        error = %error,
+                        row_key = %key,
+                        "failed to roll back run-row reservation after active-lock reservation failure",
+                    );
+                }
+            }
+        }
+    }
+
+    async fn rollback_run_row_reservations(&self, reservations: Vec<RunRowReservation>) {
+        for reservation in reservations {
+            self.rollback_run_row_reservation(Some(reservation)).await;
+        }
+    }
+
+    async fn rollback_row_reservations(
+        &self,
+        active_lock_reservations: Vec<ActiveLockReservation>,
+        run_row_reservations: Vec<RunRowReservation>,
+    ) {
+        self.rollback_active_lock_reservations(active_lock_reservations)
+            .await;
+        self.rollback_run_row_reservations(run_row_reservations)
+            .await;
+    }
+
+    async fn rollback_active_lock_reservations(&self, reservations: Vec<ActiveLockReservation>) {
+        for reservation in reservations {
+            let key = reservation.key().to_string();
+            let Ok(path) = row_path(ACTIVE_LOCK_ROWS, &key) else {
+                continue;
+            };
+            let result = match reservation {
+                ActiveLockReservation::Created { run, .. } => {
+                    let result = self
+                        .filesystem
+                        .delete(&ResourceScope::system(), &path)
+                        .await;
+                    self.rollback_run_row_reservation(run).await;
+                    result
+                }
+                ActiveLockReservation::Updated {
+                    previous,
+                    previous_seq,
+                    version,
+                    ..
+                } => {
+                    let entry = match active_lock_entry(previous.as_ref(), previous_seq) {
+                        Ok(entry) => entry,
+                        Err(error) => {
+                            let error = error.into_turn();
+                            tracing::warn!(
+                                error = %error,
+                                active_lock_key = %key,
+                                "failed to serialize active-lock rollback after turn-state append failure",
+                            );
+                            continue;
+                        }
+                    };
+                    self.filesystem
+                        .put(
+                            &ResourceScope::system(),
+                            &path,
+                            entry,
+                            CasExpectation::Version(version),
+                        )
+                        .await
+                        .map(|_| ())
+                }
+            };
+            if let Err(error) = result {
+                tracing::warn!(
+                    error = %error,
+                    active_lock_key = %key,
+                    "failed to roll back active-lock reservation after turn-state append failure",
+                );
+            }
+        }
+    }
+
     async fn apply_cached_delta(&self, delta: SnapshotDelta) -> Result<(), TurnError> {
         if delta.is_empty() {
             return Ok(());
         }
         let mut guard = self.snapshot_state.lock().await;
         if let Some(state) = guard.as_mut() {
-            state.apply_delta(delta)?;
+            state.apply_delta(delta, state.journal_seq)?;
         }
         Ok(())
     }
@@ -623,51 +1522,116 @@ where
         let critical = async {
             let _commit_guard = self.commit_gate.lock().await;
             let mut guard = self.snapshot_state.lock().await;
-            if guard.is_none() {
-                *guard = Some(self.load_snapshot_from_rows().await?);
+            let mut build_delta = Some(build_delta);
+            let mut refreshed_after_stale_error = false;
+            loop {
+                self.ensure_snapshot_cache_for_mutation(&mut guard).await?;
+                let state = guard.as_ref().ok_or_else(|| TurnError::Unavailable {
+                    reason: "row snapshot cache was not initialized".to_string(),
+                })?;
+                let baseline = state.snapshot.clone();
+                let latest_event_cursor = state.latest_event_cursor();
+                let (overlaid_snapshot, _) = self
+                    .runner_lease_store()
+                    .overlay((baseline.clone(), None), overlay)
+                    .await?;
+                let store = Arc::new(self.build_in_memory_store(overlaid_snapshot)?);
+                let outcome = apply(Arc::clone(&store)).await;
+                let value = match outcome {
+                    Ok(value) => value,
+                    Err(error) => {
+                        if !refreshed_after_stale_error
+                            && self
+                                .refresh_snapshot_cache_after_stale_mutation_error(
+                                    &mut guard, &error,
+                                )
+                                .await?
+                        {
+                            refreshed_after_stale_error = true;
+                            continue;
+                        }
+                        *guard = None;
+                        return Err(error);
+                    }
+                };
+                let build_delta = build_delta.take().ok_or_else(|| TurnError::Unavailable {
+                    reason: "turn state row-store targeted delta builder was reused".to_string(),
+                })?;
+                let delta = build_delta(&baseline, latest_event_cursor, store.as_ref(), &value)?;
+                let persist_delta = row_store_durable_delta(delta.clone());
+                let reservation_seq = self.next_delta_log_seq().await?;
+                let run_row_reservations = match self
+                    .reserve_run_row_updates(&baseline, &persist_delta, reservation_seq)
+                    .await
+                {
+                    Ok(reservations) => reservations,
+                    Err(error) => {
+                        *guard = None;
+                        return Err(error.into_turn());
+                    }
+                };
+                let active_lock_reservations = match self
+                    .reserve_active_lock_writes(&baseline, &persist_delta, reservation_seq)
+                    .await
+                {
+                    Ok(reservations) => reservations,
+                    Err(error) => {
+                        self.rollback_run_row_reservations(run_row_reservations)
+                            .await;
+                        *guard = None;
+                        return Err(error.into_turn());
+                    }
+                };
+                if let Some(state) = guard.as_mut() {
+                    if let Err(error) = state.apply_delta(delta, reservation_seq) {
+                        self.rollback_row_reservations(
+                            active_lock_reservations,
+                            run_row_reservations,
+                        )
+                        .await;
+                        *guard = None;
+                        return Err(error);
+                    }
+                    state.store = store;
+                } else {
+                    let mut snapshot = store.persistence_snapshot();
+                    snapshot = row_store_hot_cache_snapshot(snapshot, self.limits);
+                    let next_state = match RowSnapshotState::new(snapshot, store, reservation_seq) {
+                        Ok(state) => state,
+                        Err(error) => {
+                            self.rollback_row_reservations(
+                                active_lock_reservations,
+                                run_row_reservations,
+                            )
+                            .await;
+                            *guard = None;
+                            return Err(error);
+                        }
+                    };
+                    *guard = Some(next_state);
+                }
+                let ack = match self.enqueue_delta(persist_delta) {
+                    Ok(ack) => ack,
+                    Err(RowPersistError::Turn(error)) => {
+                        self.rollback_row_reservations(
+                            active_lock_reservations,
+                            run_row_reservations,
+                        )
+                        .await;
+                        *guard = None;
+                        return Err(error);
+                    }
+                };
+                return Ok(PendingRowCommit {
+                    value,
+                    ack,
+                    active_lock_reservations,
+                    run_row_reservations,
+                });
             }
-            let state = guard
-                .as_ref()
-                .expect("row snapshot cache is initialized above");
-            let baseline = state.snapshot.clone();
-            let latest_event_cursor = state.latest_event_cursor();
-            let (overlaid_snapshot, _) = self
-                .runner_lease_store()
-                .overlay((baseline.clone(), None), overlay)
-                .await?;
-            let store = Arc::new(self.build_in_memory_store(overlaid_snapshot)?);
-            let outcome = apply(Arc::clone(&store)).await;
-            let value = match outcome {
-                Ok(value) => value,
-                Err(error) => {
-                    *guard = None;
-                    return Err(error);
-                }
-            };
-            let delta = build_delta(&baseline, latest_event_cursor, store.as_ref(), &value)?;
-            let persist_delta = row_store_durable_delta(delta.clone());
-            let ack = match self.enqueue_delta(persist_delta) {
-                Ok(ack) => ack,
-                Err(RowPersistError::Turn(error)) => {
-                    *guard = None;
-                    return Err(error);
-                }
-            };
-            if let Some(state) = guard.as_mut() {
-                if let Err(error) = state.apply_delta(delta) {
-                    *guard = None;
-                    return Err(error);
-                }
-                state.store = store;
-            } else {
-                let mut snapshot = store.persistence_snapshot();
-                snapshot = row_store_hot_cache_snapshot(snapshot, self.limits);
-                *guard = Some(RowSnapshotState::new(snapshot, store)?);
-            }
-            Ok((ack, value))
         };
 
-        let (ack, value) = match tokio::time::timeout(self.apply_timeout, critical).await {
+        let pending = match tokio::time::timeout(self.apply_timeout, critical).await {
             Ok(result) => result?,
             Err(_) => {
                 self.clear_snapshot_cache().await;
@@ -676,11 +1640,11 @@ where
                 });
             }
         };
-        if let Err(error) = self.await_delta_ack(ack).await {
-            self.clear_snapshot_cache().await;
-            return Err(error.into_turn());
-        }
-        Ok(value)
+        self.await_pending_commit(
+            pending,
+            "turn state row-store targeted append ack timed out",
+        )
+        .await
     }
 
     async fn apply_run_state_transition<A, Fut>(
@@ -815,6 +1779,36 @@ fn turn_state_write_span(
     span
 }
 
-fn legacy_migration_gate() -> Arc<AsyncMutex<()>> {
-    Arc::clone(LEGACY_MIGRATION_GATE.get_or_init(|| Arc::new(AsyncMutex::new(()))))
+fn active_lock_entry(
+    record: &TurnActiveLockRecord,
+    journal_seq: SeqNo,
+) -> Result<Entry, RowPersistError> {
+    row_entry(ACTIVE_LOCK_ROWS, record, journal_seq)
+}
+
+fn row_entry<T>(
+    collection: &'static str,
+    record: &T,
+    journal_seq: SeqNo,
+) -> Result<Entry, RowPersistError>
+where
+    T: serde::Serialize,
+{
+    let body = serialize_materialized_row(journal_seq, Some(record), collection)?;
+    Ok(Entry::bytes(body).with_content_type(ContentType::json()))
+}
+
+fn baseline_committed_active_lock<'a>(
+    baseline: &'a TurnPersistenceSnapshot,
+    record: &TurnActiveLockRecord,
+) -> Option<&'a TurnActiveLockRecord> {
+    let existing = baseline
+        .active_locks
+        .iter()
+        .find(|existing| existing.key == record.key && existing.run_id == record.run_id)?;
+    baseline
+        .runs
+        .iter()
+        .any(|run| run.run_id == record.run_id)
+        .then_some(existing)
 }

--- a/crates/ironclaw_turns/src/filesystem_store/row_store/delta.rs
+++ b/crates/ironclaw_turns/src/filesystem_store/row_store/delta.rs
@@ -38,6 +38,7 @@ fn zero_seq_no() -> SeqNo {
 pub(super) struct RowSnapshotState {
     pub(super) snapshot: TurnPersistenceSnapshot,
     pub(super) store: Arc<InMemoryTurnStateStore>,
+    pub(super) journal_seq: SeqNo,
     latest_event_cursor: EventCursor,
     indexes: RowSnapshotIndexes,
 }
@@ -46,12 +47,14 @@ impl RowSnapshotState {
     pub(super) fn new(
         snapshot: TurnPersistenceSnapshot,
         store: Arc<InMemoryTurnStateStore>,
+        journal_seq: SeqNo,
     ) -> Result<Self, TurnError> {
         let latest_event_cursor = latest_event_cursor(&snapshot);
         let indexes = RowSnapshotIndexes::from_snapshot(&snapshot)?;
         Ok(Self {
             snapshot,
             store,
+            journal_seq,
             latest_event_cursor,
             indexes,
         })
@@ -61,9 +64,14 @@ impl RowSnapshotState {
         self.latest_event_cursor
     }
 
-    pub(super) fn apply_delta(&mut self, delta: SnapshotDelta) -> Result<(), TurnError> {
+    pub(super) fn apply_delta(
+        &mut self,
+        delta: SnapshotDelta,
+        journal_seq: SeqNo,
+    ) -> Result<(), TurnError> {
         let latest_event_cursor = latest_event_cursor_after_delta(self.latest_event_cursor, &delta);
         apply_delta_indexed(&mut self.snapshot, &mut self.indexes, delta)?;
+        self.journal_seq = self.journal_seq.max(journal_seq);
         self.latest_event_cursor = latest_event_cursor;
         Ok(())
     }

--- a/crates/ironclaw_turns/src/filesystem_store/row_store/delta.rs
+++ b/crates/ironclaw_turns/src/filesystem_store/row_store/delta.rs
@@ -1,0 +1,822 @@
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
+
+use chrono::Utc;
+use ironclaw_filesystem::SeqNo;
+use serde::Serialize;
+
+use crate::{
+    EventCursor, InMemoryTurnStateStore, InMemoryTurnStateStoreLimits, LoopCheckpointRecord,
+    PutLoopCheckpointRequest, SpawnTreeReservation, SubmitTurnResponse, TurnActiveLockRecord,
+    TurnAdmissionReservationRecord, TurnCheckpointId, TurnCheckpointRecord, TurnError,
+    TurnIdempotencyRecord, TurnLifecycleEvent, TurnPersistenceSnapshot, TurnRecord, TurnRunId,
+    TurnRunRecord, TurnRunState, TurnScope, runner::ClaimedTurnRun,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, serde::Deserialize)]
+pub(super) struct RowStoreMeta {
+    pub(super) event_retention_floor: EventCursor,
+    #[serde(default = "zero_seq_no")]
+    pub(super) journal_seq: SeqNo,
+}
+
+impl Default for RowStoreMeta {
+    fn default() -> Self {
+        Self {
+            event_retention_floor: EventCursor::default(),
+            journal_seq: SeqNo::ZERO,
+        }
+    }
+}
+
+fn zero_seq_no() -> SeqNo {
+    SeqNo::ZERO
+}
+
+pub(super) struct RowSnapshotState {
+    pub(super) snapshot: TurnPersistenceSnapshot,
+    pub(super) store: Arc<InMemoryTurnStateStore>,
+    latest_event_cursor: EventCursor,
+    indexes: RowSnapshotIndexes,
+}
+
+impl RowSnapshotState {
+    pub(super) fn new(
+        snapshot: TurnPersistenceSnapshot,
+        store: Arc<InMemoryTurnStateStore>,
+    ) -> Result<Self, TurnError> {
+        let latest_event_cursor = latest_event_cursor(&snapshot);
+        let indexes = RowSnapshotIndexes::from_snapshot(&snapshot)?;
+        Ok(Self {
+            snapshot,
+            store,
+            latest_event_cursor,
+            indexes,
+        })
+    }
+
+    pub(super) fn latest_event_cursor(&self) -> EventCursor {
+        self.latest_event_cursor
+    }
+
+    pub(super) fn apply_delta(&mut self, delta: SnapshotDelta) -> Result<(), TurnError> {
+        let latest_event_cursor = latest_event_cursor_after_delta(self.latest_event_cursor, &delta);
+        apply_delta_indexed(&mut self.snapshot, &mut self.indexes, delta)?;
+        self.latest_event_cursor = latest_event_cursor;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Default)]
+struct RowSnapshotIndexes {
+    turns: HashMap<String, usize>,
+    runs: HashMap<String, usize>,
+    active_locks: HashMap<String, usize>,
+    checkpoints: HashMap<String, usize>,
+    loop_checkpoints: HashMap<String, usize>,
+    idempotency_records: HashMap<String, usize>,
+    events: HashMap<String, usize>,
+    admission_reservations: HashMap<String, usize>,
+    spawn_tree_reservations: HashMap<String, usize>,
+}
+
+impl RowSnapshotIndexes {
+    fn from_snapshot(snapshot: &TurnPersistenceSnapshot) -> Result<Self, TurnError> {
+        Ok(Self {
+            turns: indexed_records(&snapshot.turns, &turn_record_key)?,
+            runs: indexed_records(&snapshot.runs, &run_record_key)?,
+            active_locks: indexed_records(&snapshot.active_locks, &active_lock_record_key)?,
+            checkpoints: indexed_records(&snapshot.checkpoints, &checkpoint_record_key)?,
+            loop_checkpoints: indexed_records(
+                &snapshot.loop_checkpoints,
+                &loop_checkpoint_record_key,
+            )?,
+            idempotency_records: indexed_records(
+                &snapshot.idempotency_records,
+                &idempotency_record_key,
+            )?,
+            events: indexed_records(&snapshot.events, &event_record_key)?,
+            admission_reservations: indexed_records(
+                &snapshot.admission_reservations,
+                &admission_reservation_record_key,
+            )?,
+            spawn_tree_reservations: indexed_records(
+                &snapshot.spawn_tree_reservations,
+                &spawn_tree_reservation_record_key,
+            )?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, serde::Deserialize)]
+pub(super) struct SnapshotDelta {
+    pub(super) turns_upsert: Vec<TurnRecord>,
+    pub(super) turns_delete: Vec<String>,
+    pub(super) runs_upsert: Vec<TurnRunRecord>,
+    pub(super) runs_delete: Vec<String>,
+    pub(super) active_locks_upsert: Vec<TurnActiveLockRecord>,
+    pub(super) active_locks_delete: Vec<String>,
+    pub(super) checkpoints_upsert: Vec<TurnCheckpointRecord>,
+    pub(super) checkpoints_delete: Vec<String>,
+    pub(super) loop_checkpoints_upsert: Vec<LoopCheckpointRecord>,
+    pub(super) loop_checkpoints_delete: Vec<String>,
+    pub(super) idempotency_upsert: Vec<TurnIdempotencyRecord>,
+    pub(super) idempotency_delete: Vec<String>,
+    pub(super) events_upsert: Vec<TurnLifecycleEvent>,
+    pub(super) events_delete: Vec<String>,
+    pub(super) admission_reservations_upsert: Vec<TurnAdmissionReservationRecord>,
+    pub(super) admission_reservations_delete: Vec<String>,
+    pub(super) spawn_tree_reservations_upsert: Vec<SpawnTreeReservation>,
+    pub(super) spawn_tree_reservations_delete: Vec<String>,
+    pub(super) event_retention_floor: Option<EventCursor>,
+}
+
+impl SnapshotDelta {
+    pub(super) fn is_empty(&self) -> bool {
+        self.turns_upsert.is_empty()
+            && self.turns_delete.is_empty()
+            && self.runs_upsert.is_empty()
+            && self.runs_delete.is_empty()
+            && self.active_locks_upsert.is_empty()
+            && self.active_locks_delete.is_empty()
+            && self.checkpoints_upsert.is_empty()
+            && self.checkpoints_delete.is_empty()
+            && self.loop_checkpoints_upsert.is_empty()
+            && self.loop_checkpoints_delete.is_empty()
+            && self.idempotency_upsert.is_empty()
+            && self.idempotency_delete.is_empty()
+            && self.events_upsert.is_empty()
+            && self.events_delete.is_empty()
+            && self.admission_reservations_upsert.is_empty()
+            && self.admission_reservations_delete.is_empty()
+            && self.spawn_tree_reservations_upsert.is_empty()
+            && self.spawn_tree_reservations_delete.is_empty()
+            && self.event_retention_floor.is_none()
+    }
+}
+
+pub(super) enum RowPersistError {
+    Turn(TurnError),
+}
+
+impl RowPersistError {
+    pub(super) fn into_turn(self) -> TurnError {
+        match self {
+            Self::Turn(error) => error,
+        }
+    }
+}
+
+impl From<TurnError> for RowPersistError {
+    fn from(error: TurnError) -> Self {
+        Self::Turn(error)
+    }
+}
+
+#[derive(Serialize)]
+struct SpawnTreeReservationKeyForPath<'a> {
+    scope: &'a TurnScope,
+    root_run_id: TurnRunId,
+}
+
+pub(super) fn turn_record_key(record: &TurnRecord) -> Result<String, TurnError> {
+    Ok(record.turn_id.to_string())
+}
+
+pub(super) fn run_record_key(record: &TurnRunRecord) -> Result<String, TurnError> {
+    Ok(record.run_id.to_string())
+}
+
+pub(super) fn active_lock_record_key(record: &TurnActiveLockRecord) -> Result<String, TurnError> {
+    hash_key(&record.key)
+}
+
+pub(super) fn checkpoint_record_key(record: &TurnCheckpointRecord) -> Result<String, TurnError> {
+    Ok(record.checkpoint_id.as_uuid().to_string())
+}
+
+pub(super) fn loop_checkpoint_record_key(
+    record: &LoopCheckpointRecord,
+) -> Result<String, TurnError> {
+    Ok(record.checkpoint_id.as_uuid().to_string())
+}
+
+pub(super) fn idempotency_record_key(record: &TurnIdempotencyRecord) -> Result<String, TurnError> {
+    hash_key(record)
+}
+
+pub(super) fn event_record_key(record: &TurnLifecycleEvent) -> Result<String, TurnError> {
+    Ok(format!("{:020}", record.cursor.0))
+}
+
+pub(super) fn admission_reservation_record_key(
+    record: &TurnAdmissionReservationRecord,
+) -> Result<String, TurnError> {
+    Ok(record.run_id.to_string())
+}
+
+pub(super) fn spawn_tree_reservation_record_key(
+    record: &SpawnTreeReservation,
+) -> Result<String, TurnError> {
+    hash_key(&SpawnTreeReservationKeyForPath {
+        scope: &record.scope,
+        root_run_id: record.root_run_id,
+    })
+}
+
+pub(super) fn snapshot_delta(
+    old: &TurnPersistenceSnapshot,
+    new: &TurnPersistenceSnapshot,
+) -> Result<SnapshotDelta, RowPersistError> {
+    let (turns_upsert, turns_delete) = delta_collection(&old.turns, &new.turns, |record| {
+        Ok(record.turn_id.to_string())
+    })?;
+    let (runs_upsert, runs_delete) =
+        delta_collection(&old.runs, &new.runs, |record| Ok(record.run_id.to_string()))?;
+    let (active_locks_upsert, active_locks_delete) =
+        delta_collection(&old.active_locks, &new.active_locks, |record| {
+            hash_key(&record.key)
+        })?;
+    let (checkpoints_upsert, checkpoints_delete) =
+        delta_collection(&old.checkpoints, &new.checkpoints, |record| {
+            Ok(record.checkpoint_id.as_uuid().to_string())
+        })?;
+    let (loop_checkpoints_upsert, loop_checkpoints_delete) =
+        delta_collection(&old.loop_checkpoints, &new.loop_checkpoints, |record| {
+            Ok(record.checkpoint_id.as_uuid().to_string())
+        })?;
+    let (idempotency_upsert, idempotency_delete) =
+        delta_collection(&old.idempotency_records, &new.idempotency_records, hash_key)?;
+    let (events_upsert, events_delete) = delta_collection(&old.events, &new.events, |record| {
+        Ok(format!("{:020}", record.cursor.0))
+    })?;
+    let (admission_reservations_upsert, admission_reservations_delete) = delta_collection(
+        &old.admission_reservations,
+        &new.admission_reservations,
+        |record| Ok(record.run_id.to_string()),
+    )?;
+    let (spawn_tree_reservations_upsert, spawn_tree_reservations_delete) = delta_collection(
+        &old.spawn_tree_reservations,
+        &new.spawn_tree_reservations,
+        |record| {
+            hash_key(&SpawnTreeReservationKeyForPath {
+                scope: &record.scope,
+                root_run_id: record.root_run_id,
+            })
+        },
+    )?;
+
+    Ok(SnapshotDelta {
+        turns_upsert,
+        turns_delete,
+        runs_upsert,
+        runs_delete,
+        active_locks_upsert,
+        active_locks_delete,
+        checkpoints_upsert,
+        checkpoints_delete,
+        loop_checkpoints_upsert,
+        loop_checkpoints_delete,
+        idempotency_upsert,
+        idempotency_delete,
+        events_upsert,
+        events_delete,
+        admission_reservations_upsert,
+        admission_reservations_delete,
+        spawn_tree_reservations_upsert,
+        spawn_tree_reservations_delete,
+        event_retention_floor: (old.event_retention_floor != new.event_retention_floor)
+            .then_some(new.event_retention_floor),
+    })
+}
+
+fn apply_delta_indexed(
+    snapshot: &mut TurnPersistenceSnapshot,
+    indexes: &mut RowSnapshotIndexes,
+    delta: SnapshotDelta,
+) -> Result<(), TurnError> {
+    if !delta.turns_upsert.is_empty() || !delta.turns_delete.is_empty() {
+        apply_delta_collection_indexed(
+            &mut snapshot.turns,
+            &mut indexes.turns,
+            delta.turns_upsert,
+            delta.turns_delete,
+            turn_record_key,
+        )?;
+    }
+    if !delta.runs_upsert.is_empty() || !delta.runs_delete.is_empty() {
+        apply_delta_collection_indexed(
+            &mut snapshot.runs,
+            &mut indexes.runs,
+            delta.runs_upsert,
+            delta.runs_delete,
+            run_record_key,
+        )?;
+    }
+    if !delta.active_locks_upsert.is_empty() || !delta.active_locks_delete.is_empty() {
+        apply_delta_collection_indexed(
+            &mut snapshot.active_locks,
+            &mut indexes.active_locks,
+            delta.active_locks_upsert,
+            delta.active_locks_delete,
+            active_lock_record_key,
+        )?;
+    }
+    if !delta.checkpoints_upsert.is_empty() || !delta.checkpoints_delete.is_empty() {
+        apply_delta_collection_indexed(
+            &mut snapshot.checkpoints,
+            &mut indexes.checkpoints,
+            delta.checkpoints_upsert,
+            delta.checkpoints_delete,
+            checkpoint_record_key,
+        )?;
+    }
+    if !delta.loop_checkpoints_upsert.is_empty() || !delta.loop_checkpoints_delete.is_empty() {
+        apply_delta_collection_indexed(
+            &mut snapshot.loop_checkpoints,
+            &mut indexes.loop_checkpoints,
+            delta.loop_checkpoints_upsert,
+            delta.loop_checkpoints_delete,
+            loop_checkpoint_record_key,
+        )?;
+    }
+    if !delta.idempotency_upsert.is_empty() || !delta.idempotency_delete.is_empty() {
+        apply_delta_collection_indexed(
+            &mut snapshot.idempotency_records,
+            &mut indexes.idempotency_records,
+            delta.idempotency_upsert,
+            delta.idempotency_delete,
+            idempotency_record_key,
+        )?;
+    }
+    if !delta.events_upsert.is_empty() || !delta.events_delete.is_empty() {
+        apply_delta_collection_indexed(
+            &mut snapshot.events,
+            &mut indexes.events,
+            delta.events_upsert,
+            delta.events_delete,
+            event_record_key,
+        )?;
+    }
+    if !delta.admission_reservations_upsert.is_empty()
+        || !delta.admission_reservations_delete.is_empty()
+    {
+        apply_delta_collection_indexed(
+            &mut snapshot.admission_reservations,
+            &mut indexes.admission_reservations,
+            delta.admission_reservations_upsert,
+            delta.admission_reservations_delete,
+            admission_reservation_record_key,
+        )?;
+    }
+    if !delta.spawn_tree_reservations_upsert.is_empty()
+        || !delta.spawn_tree_reservations_delete.is_empty()
+    {
+        apply_delta_collection_indexed(
+            &mut snapshot.spawn_tree_reservations,
+            &mut indexes.spawn_tree_reservations,
+            delta.spawn_tree_reservations_upsert,
+            delta.spawn_tree_reservations_delete,
+            spawn_tree_reservation_record_key,
+        )?;
+    }
+    if let Some(event_retention_floor) = delta.event_retention_floor {
+        snapshot.event_retention_floor = event_retention_floor;
+    }
+    Ok(())
+}
+
+fn delta_collection<T, K>(
+    old: &[T],
+    new: &[T],
+    key_fn: K,
+) -> Result<(Vec<T>, Vec<String>), RowPersistError>
+where
+    T: Clone + PartialEq,
+    K: Fn(&T) -> Result<String, TurnError>,
+{
+    let old_map = keyed_records(old, &key_fn)?;
+    let new_map = keyed_records(new, &key_fn)?;
+    let upsert = new_map
+        .iter()
+        .filter(|(key, record)| old_map.get(*key) != Some(*record))
+        .map(|(_key, record)| record.clone())
+        .collect();
+    let new_keys = new_map.keys().cloned().collect::<HashSet<_>>();
+    let delete = old_map
+        .keys()
+        .filter(|key| !new_keys.contains(*key))
+        .cloned()
+        .collect();
+    Ok((upsert, delete))
+}
+
+fn apply_delta_collection_indexed<T, K>(
+    records: &mut Vec<T>,
+    index: &mut HashMap<String, usize>,
+    upsert: Vec<T>,
+    delete: Vec<String>,
+    key_fn: K,
+) -> Result<(), TurnError>
+where
+    K: Fn(&T) -> Result<String, TurnError>,
+{
+    if !delete.is_empty() {
+        let deleted = delete.into_iter().collect::<HashSet<_>>();
+        let mut retained = Vec::with_capacity(records.len());
+        for record in records.drain(..) {
+            if !deleted.contains(&key_fn(&record)?) {
+                retained.push(record);
+            }
+        }
+        *records = retained;
+        *index = indexed_records(records, &key_fn)?;
+    }
+
+    for record in upsert {
+        let key = key_fn(&record)?;
+        if let Some(record_index) = index.get(&key).copied() {
+            if record_index >= records.len() {
+                return Err(TurnError::Unavailable {
+                    reason: "row-store snapshot index is out of bounds".to_string(),
+                });
+            }
+            records[record_index] = record;
+        } else {
+            let record_index = records.len();
+            records.push(record);
+            index.insert(key, record_index);
+        }
+    }
+    Ok(())
+}
+
+fn indexed_records<T, K>(records: &[T], key_fn: &K) -> Result<HashMap<String, usize>, TurnError>
+where
+    K: Fn(&T) -> Result<String, TurnError>,
+{
+    let mut index = HashMap::with_capacity(records.len());
+    for (record_index, record) in records.iter().enumerate() {
+        index.insert(key_fn(record)?, record_index);
+    }
+    Ok(index)
+}
+
+pub(super) fn keyed_records<T, K>(
+    records: &[T],
+    key_fn: &K,
+) -> Result<HashMap<String, T>, RowPersistError>
+where
+    T: Clone,
+    K: Fn(&T) -> Result<String, TurnError>,
+{
+    records
+        .iter()
+        .map(|record| Ok((key_fn(record)?, record.clone())))
+        .collect()
+}
+
+pub(super) fn submit_turn_targeted_delta(
+    snapshot: &TurnPersistenceSnapshot,
+    latest_event_cursor: EventCursor,
+    store: &InMemoryTurnStateStore,
+    response: &SubmitTurnResponse,
+) -> Result<SnapshotDelta, TurnError> {
+    let SubmitTurnResponse::Accepted {
+        turn_id, run_id, ..
+    } = response;
+    let turn = store
+        .turn_record(*turn_id)
+        .ok_or_else(|| TurnError::Unavailable {
+            reason: "accepted turn missing from row-store hot state".to_string(),
+        })?;
+    let run = store
+        .run_record(*run_id)
+        .ok_or_else(|| TurnError::Unavailable {
+            reason: "accepted run missing from row-store hot state".to_string(),
+        })?;
+    let mut delta = SnapshotDelta {
+        turns_upsert: vec![turn.clone()],
+        runs_upsert: vec![run],
+        ..SnapshotDelta::default()
+    };
+    if let Some(lock) = store.active_lock_record(&turn.scope) {
+        delta.active_locks_upsert.push(lock);
+    }
+    if let Some(reservation) = store.admission_reservation(*run_id) {
+        delta.admission_reservations_upsert.push(reservation);
+    }
+    delta.idempotency_upsert.extend(
+        store
+            .idempotency_records_after(turn.created_at)
+            .into_iter()
+            .filter(|record| {
+                record.operation == crate::TurnIdempotencyOperationKind::Submit
+                    && record.run_id == Some(*run_id)
+            }),
+    );
+    add_event_delta(snapshot, latest_event_cursor, store, &mut delta)?;
+    Ok(delta)
+}
+
+pub(super) fn full_snapshot_delta(
+    snapshot: &TurnPersistenceSnapshot,
+    store: &InMemoryTurnStateStore,
+) -> Result<SnapshotDelta, TurnError> {
+    let mut new_snapshot = store.persistence_snapshot();
+    preserve_loop_checkpoints(snapshot, &mut new_snapshot);
+    snapshot_delta(snapshot, &new_snapshot).map_err(|error| match error {
+        RowPersistError::Turn(error) => error,
+    })
+}
+
+pub(super) fn row_store_durable_delta(mut delta: SnapshotDelta) -> SnapshotDelta {
+    // Tier-2 rows are the durable run record. Row-store cache limits may evict
+    // old terminal runs/events from memory, but persistence must not encode
+    // those cache evictions as data deletion.
+    delta.turns_delete.clear();
+    delta.runs_delete.clear();
+    delta.events_delete.clear();
+    delta.event_retention_floor = None;
+    delta
+}
+
+pub(super) fn row_store_hot_cache_snapshot(
+    mut snapshot: TurnPersistenceSnapshot,
+    limits: InMemoryTurnStateStoreLimits,
+) -> TurnPersistenceSnapshot {
+    let mut terminal_runs = snapshot
+        .runs
+        .iter()
+        .filter(|record| record.status.is_terminal())
+        .map(|record| (record.event_cursor, record.run_id))
+        .collect::<Vec<_>>();
+    terminal_runs.sort_by_key(|(cursor, _)| *cursor);
+    let evicted_terminal_run_ids = terminal_runs
+        .len()
+        .saturating_sub(limits.max_terminal_records);
+    let evicted_terminal_run_ids = terminal_runs
+        .into_iter()
+        .take(evicted_terminal_run_ids)
+        .map(|(_, run_id)| run_id)
+        .collect::<HashSet<_>>();
+
+    if !evicted_terminal_run_ids.is_empty() {
+        snapshot
+            .runs
+            .retain(|record| !evicted_terminal_run_ids.contains(&record.run_id));
+        let retained_run_ids = snapshot
+            .runs
+            .iter()
+            .map(|record| record.run_id)
+            .collect::<HashSet<_>>();
+        let retained_turn_ids = snapshot
+            .runs
+            .iter()
+            .map(|record| record.turn_id)
+            .collect::<HashSet<_>>();
+        let active_spawn_roots = snapshot
+            .runs
+            .iter()
+            .filter(|record| !record.status.is_terminal())
+            .filter_map(|record| record.spawn_tree_root_run_id)
+            .collect::<HashSet<_>>();
+
+        snapshot
+            .turns
+            .retain(|record| retained_turn_ids.contains(&record.turn_id));
+        snapshot
+            .active_locks
+            .retain(|record| retained_run_ids.contains(&record.run_id));
+        snapshot
+            .checkpoints
+            .retain(|record| retained_run_ids.contains(&record.run_id));
+        snapshot
+            .loop_checkpoints
+            .retain(|record| retained_run_ids.contains(&record.run_id));
+        snapshot
+            .admission_reservations
+            .retain(|record| retained_run_ids.contains(&record.run_id));
+        snapshot.spawn_tree_reservations.retain(|record| {
+            retained_run_ids.contains(&record.root_run_id)
+                || active_spawn_roots.contains(&record.root_run_id)
+        });
+    }
+
+    snapshot.events.sort_by_key(|event| event.cursor);
+    if snapshot.events.len() > limits.max_events {
+        let excess = snapshot.events.len() - limits.max_events;
+        if let Some(last_pruned) = snapshot.events.get(excess.saturating_sub(1)) {
+            snapshot.event_retention_floor = snapshot.event_retention_floor.max(last_pruned.cursor);
+        }
+        snapshot.events.drain(0..excess);
+    }
+
+    let max_idempotency_records = limits.max_idempotency_records.saturating_mul(3);
+    snapshot
+        .idempotency_records
+        .sort_by_key(|record| record.created_at);
+    if snapshot.idempotency_records.len() > max_idempotency_records {
+        let excess = snapshot.idempotency_records.len() - max_idempotency_records;
+        snapshot.idempotency_records.drain(0..excess);
+    }
+
+    snapshot
+}
+
+pub(super) fn preserve_loop_checkpoints(
+    baseline: &TurnPersistenceSnapshot,
+    new_snapshot: &mut TurnPersistenceSnapshot,
+) {
+    new_snapshot.loop_checkpoints = baseline.loop_checkpoints.clone();
+}
+
+pub(super) fn loop_checkpoint_record_from_request(
+    request: PutLoopCheckpointRequest,
+) -> LoopCheckpointRecord {
+    LoopCheckpointRecord {
+        checkpoint_id: TurnCheckpointId::new(),
+        scope: request.scope,
+        turn_id: request.turn_id,
+        run_id: request.run_id,
+        state_ref: request.state_ref,
+        schema_id: request.schema_id,
+        schema_version: request.schema_version,
+        kind: request.kind,
+        gate_ref: request.gate_ref,
+        created_at: Utc::now(),
+    }
+}
+
+pub(super) fn claimed_run_targeted_delta(
+    snapshot: &TurnPersistenceSnapshot,
+    latest_event_cursor: EventCursor,
+    store: &InMemoryTurnStateStore,
+    claimed: &Option<ClaimedTurnRun>,
+) -> Result<SnapshotDelta, TurnError> {
+    let Some(claimed) = claimed else {
+        return Ok(SnapshotDelta::default());
+    };
+    run_state_targeted_delta(
+        snapshot,
+        latest_event_cursor,
+        store,
+        claimed.state.run_id,
+        &claimed.state.scope,
+    )
+}
+
+pub(super) fn run_state_targeted_delta(
+    snapshot: &TurnPersistenceSnapshot,
+    latest_event_cursor: EventCursor,
+    store: &InMemoryTurnStateStore,
+    run_id: TurnRunId,
+    scope: &TurnScope,
+) -> Result<SnapshotDelta, TurnError> {
+    let mut delta = SnapshotDelta::default();
+    match store.run_record(run_id) {
+        Some(run) => {
+            delta.runs_upsert.push(run);
+        }
+        None => {
+            delta.runs_delete.push(run_id.to_string());
+            if let Some(old_run) = snapshot.runs.iter().find(|record| record.run_id == run_id)
+                && store.turn_record(old_run.turn_id).is_none()
+            {
+                delta.turns_delete.push(old_run.turn_id.to_string());
+            }
+        }
+    }
+
+    if let Some(lock) = store.active_lock_record(scope) {
+        delta.active_locks_upsert.push(lock);
+    } else if let Some(old_lock) = snapshot
+        .active_locks
+        .iter()
+        .find(|record| record.key.scope == *scope)
+    {
+        delta.active_locks_delete.push(hash_key(&old_lock.key)?);
+    }
+
+    if let Some(reservation) = store.admission_reservation(run_id) {
+        delta.admission_reservations_upsert.push(reservation);
+    } else if snapshot
+        .admission_reservations
+        .iter()
+        .any(|record| record.run_id == run_id)
+    {
+        delta.admission_reservations_delete.push(run_id.to_string());
+    }
+
+    add_event_delta(snapshot, latest_event_cursor, store, &mut delta)?;
+    Ok(delta)
+}
+
+pub(super) fn run_state_with_idempotency_targeted_delta(
+    snapshot: &TurnPersistenceSnapshot,
+    latest_event_cursor: EventCursor,
+    store: &InMemoryTurnStateStore,
+    run_id: TurnRunId,
+    scope: &TurnScope,
+    operation: crate::TurnIdempotencyOperationKind,
+) -> Result<SnapshotDelta, TurnError> {
+    let mut delta = run_state_targeted_delta(snapshot, latest_event_cursor, store, run_id, scope)?;
+    add_run_idempotency_delta(snapshot, store, &mut delta, run_id, operation);
+    Ok(delta)
+}
+
+pub(super) fn blocked_run_targeted_delta(
+    snapshot: &TurnPersistenceSnapshot,
+    latest_event_cursor: EventCursor,
+    store: &InMemoryTurnStateStore,
+    state: &TurnRunState,
+) -> Result<SnapshotDelta, TurnError> {
+    let mut delta = run_state_targeted_delta(
+        snapshot,
+        latest_event_cursor,
+        store,
+        state.run_id,
+        &state.scope,
+    )?;
+    if let Some(checkpoint_id) = state.checkpoint_id {
+        let checkpoint =
+            store
+                .checkpoint_record(checkpoint_id)
+                .ok_or_else(|| TurnError::Unavailable {
+                    reason: "blocked run checkpoint missing from row-store hot state".to_string(),
+                })?;
+        delta.checkpoints_upsert.push(checkpoint);
+    }
+    Ok(delta)
+}
+
+fn add_run_idempotency_delta(
+    snapshot: &TurnPersistenceSnapshot,
+    store: &InMemoryTurnStateStore,
+    delta: &mut SnapshotDelta,
+    run_id: TurnRunId,
+    operation: crate::TurnIdempotencyOperationKind,
+) {
+    delta.idempotency_upsert.extend(
+        store
+            .idempotency_records_for_run_operation(run_id, operation)
+            .into_iter()
+            .filter(|record| !snapshot.idempotency_records.contains(record)),
+    );
+}
+
+fn latest_event_cursor(snapshot: &TurnPersistenceSnapshot) -> EventCursor {
+    snapshot
+        .events
+        .iter()
+        .map(|event| event.cursor)
+        .max()
+        .unwrap_or(snapshot.event_retention_floor)
+        .max(snapshot.event_retention_floor)
+}
+
+fn latest_event_cursor_after_delta(current: EventCursor, delta: &SnapshotDelta) -> EventCursor {
+    let event_cursor = delta
+        .events_upsert
+        .iter()
+        .map(|event| event.cursor)
+        .max()
+        .unwrap_or(current);
+    let retention_floor = delta.event_retention_floor.unwrap_or(current);
+    current.max(event_cursor).max(retention_floor)
+}
+
+fn add_event_delta(
+    snapshot: &TurnPersistenceSnapshot,
+    latest_event_cursor: EventCursor,
+    store: &InMemoryTurnStateStore,
+    delta: &mut SnapshotDelta,
+) -> Result<(), TurnError> {
+    delta
+        .events_upsert
+        .extend(store.events_after(latest_event_cursor));
+    let event_retention_floor = store.event_retention_floor();
+    if event_retention_floor != snapshot.event_retention_floor {
+        delta.event_retention_floor = Some(event_retention_floor);
+        for event in snapshot
+            .events
+            .iter()
+            .filter(|event| event.cursor <= event_retention_floor)
+        {
+            delta.events_delete.push(format!("{:020}", event.cursor.0));
+        }
+    }
+    Ok(())
+}
+
+fn hash_key<T>(record: &T) -> Result<String, TurnError>
+where
+    T: Serialize,
+{
+    let bytes = serde_jcs::to_vec(record).map_err(|error| TurnError::Unavailable {
+        reason: format!("turn-state row key serialization failed: {error}"),
+    })?;
+    Ok(hex::encode(blake3::hash(&bytes).as_bytes()))
+}

--- a/crates/ironclaw_turns/src/filesystem_store/row_store/io.rs
+++ b/crates/ironclaw_turns/src/filesystem_store/row_store/io.rs
@@ -1,0 +1,48 @@
+use ironclaw_filesystem::FilesystemError;
+use ironclaw_host_api::ScopedPath;
+use serde::de::DeserializeOwned;
+
+use crate::TurnError;
+
+const ROW_ROOT: &str = "/turns/rows/v1";
+const META_DIR: &str = "meta";
+const META_FILE: &str = "state.json";
+const DELTA_LOG: &str = "deltas/log";
+
+pub(super) fn row_dir(collection: &str) -> Result<ScopedPath, TurnError> {
+    scoped_row_path(format!("{ROW_ROOT}/{collection}"))
+}
+
+pub(super) fn row_path(collection: &str, key: &str) -> Result<ScopedPath, TurnError> {
+    scoped_row_path(format!("{ROW_ROOT}/{collection}/{key}.json"))
+}
+
+pub(super) fn meta_path() -> Result<ScopedPath, TurnError> {
+    scoped_row_path(format!("{ROW_ROOT}/{META_DIR}/{META_FILE}"))
+}
+
+pub(super) fn delta_log_path() -> Result<ScopedPath, TurnError> {
+    scoped_row_path(format!("{ROW_ROOT}/{DELTA_LOG}"))
+}
+
+fn scoped_row_path(path: String) -> Result<ScopedPath, TurnError> {
+    ScopedPath::new(path).map_err(|error| TurnError::Unavailable {
+        reason: format!("invalid turn-state row path: {error}"),
+    })
+}
+
+pub(super) fn deserialize_row<T>(bytes: &[u8], collection: &'static str) -> Result<T, TurnError>
+where
+    T: DeserializeOwned,
+{
+    serde_json::from_slice(bytes).map_err(|error| TurnError::Unavailable {
+        reason: format!("turn-state {collection} row deserialization failed: {error}"),
+    })
+}
+
+pub(super) fn fs_error(error: FilesystemError) -> TurnError {
+    tracing::debug!(%error, "turn state row-store filesystem operation failed");
+    TurnError::Unavailable {
+        reason: "turn state row-store persistence temporarily unavailable".to_string(),
+    }
+}

--- a/crates/ironclaw_turns/src/filesystem_store/row_store/io.rs
+++ b/crates/ironclaw_turns/src/filesystem_store/row_store/io.rs
@@ -1,6 +1,6 @@
-use ironclaw_filesystem::FilesystemError;
+use ironclaw_filesystem::{FilesystemError, SeqNo};
 use ironclaw_host_api::ScopedPath;
-use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
 use crate::TurnError;
 
@@ -38,6 +38,69 @@ where
     serde_json::from_slice(bytes).map_err(|error| TurnError::Unavailable {
         reason: format!("turn-state {collection} row deserialization failed: {error}"),
     })
+}
+
+#[derive(Serialize)]
+struct MaterializedRowRef<'a, T> {
+    journal_seq: SeqNo,
+    value: Option<&'a T>,
+}
+
+#[derive(Deserialize)]
+struct MaterializedRow<T> {
+    journal_seq: SeqNo,
+    value: Option<T>,
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum StoredRow<T> {
+    Materialized(MaterializedRow<T>),
+    Raw(T),
+}
+
+pub(super) fn serialize_materialized_row<T>(
+    journal_seq: SeqNo,
+    value: Option<&T>,
+    collection: &'static str,
+) -> Result<Vec<u8>, TurnError>
+where
+    T: Serialize,
+{
+    serde_json::to_vec(&MaterializedRowRef { journal_seq, value }).map_err(|error| {
+        TurnError::Unavailable {
+            reason: format!("turn-state {collection} row serialization failed: {error}"),
+        }
+    })
+}
+
+pub(super) fn deserialize_materialized_row<T>(
+    bytes: &[u8],
+    collection: &'static str,
+) -> Result<Option<T>, TurnError>
+where
+    T: DeserializeOwned,
+{
+    match serde_json::from_slice::<StoredRow<T>>(bytes).map_err(|error| TurnError::Unavailable {
+        reason: format!("turn-state {collection} row deserialization failed: {error}"),
+    })? {
+        StoredRow::Materialized(row) => Ok(row.value),
+        StoredRow::Raw(row) => Ok(Some(row)),
+    }
+}
+
+pub(super) fn materialized_row_seq(
+    bytes: &[u8],
+    collection: &'static str,
+) -> Result<SeqNo, TurnError> {
+    match serde_json::from_slice::<StoredRow<serde_json::Value>>(bytes).map_err(|error| {
+        TurnError::Unavailable {
+            reason: format!("turn-state {collection} row deserialization failed: {error}"),
+        }
+    })? {
+        StoredRow::Materialized(row) => Ok(row.journal_seq),
+        StoredRow::Raw(_) => Ok(SeqNo::ZERO),
+    }
 }
 
 pub(super) fn fs_error(error: FilesystemError) -> TurnError {

--- a/crates/ironclaw_turns/src/filesystem_store/row_store/journal.rs
+++ b/crates/ironclaw_turns/src/filesystem_store/row_store/journal.rs
@@ -1,11 +1,7 @@
-use std::{
-    sync::{Arc, OnceLock},
-    time::Duration,
-};
+use std::{sync::Arc, time::Duration};
 
 use ironclaw_filesystem::{
-    CasExpectation, ContentType, Entry, EventRecord, FilesystemError, RootFilesystem,
-    ScopedFilesystem, SeqNo,
+    CasExpectation, ContentType, Entry, FilesystemError, RootFilesystem, ScopedFilesystem, SeqNo,
 };
 use ironclaw_host_api::ResourceScope;
 use tokio::sync::{Mutex as AsyncMutex, mpsc, oneshot};
@@ -21,12 +17,15 @@ use super::{
         loop_checkpoint_record_key, run_record_key, spawn_tree_reservation_record_key,
         turn_record_key,
     },
-    io::{delta_log_path, deserialize_row, fs_error, meta_path, row_path},
+    io::{
+        delta_log_path, deserialize_row, fs_error, materialized_row_seq, meta_path, row_path,
+        serialize_materialized_row,
+    },
 };
 
 const DELTA_JOURNAL_MAX_BATCH: usize = 256;
 const DELTA_JOURNAL_MATERIALIZE_IDLE_DELAY: Duration = Duration::from_millis(25);
-static MATERIALIZE_GATE: OnceLock<Arc<AsyncMutex<()>>> = OnceLock::new();
+const MATERIALIZED_ROW_CAS_RETRIES: usize = 16;
 
 pub(super) type DeltaAck = oneshot::Receiver<Result<(), TurnError>>;
 
@@ -40,7 +39,10 @@ struct DeltaJournalRequest {
 }
 
 impl DeltaJournal {
-    pub(super) fn new<F>(filesystem: Arc<ScopedFilesystem<F>>) -> Self
+    pub(super) fn new<F>(
+        filesystem: Arc<ScopedFilesystem<F>>,
+        materialize_gate: Arc<AsyncMutex<()>>,
+    ) -> Self
     where
         F: RootFilesystem + 'static,
     {
@@ -48,6 +50,7 @@ impl DeltaJournal {
         let (materialize_sender, materialize_receiver) = mpsc::unbounded_channel();
         tokio::spawn(run_delta_journal_materializer(
             Arc::clone(&filesystem),
+            materialize_gate,
             materialize_receiver,
         ));
         tokio::spawn(run_delta_journal_flusher(
@@ -118,6 +121,7 @@ async fn run_delta_journal_flusher<F>(
 
 async fn run_delta_journal_materializer<F>(
     filesystem: Arc<ScopedFilesystem<F>>,
+    materialize_gate: Arc<AsyncMutex<()>>,
     mut receiver: mpsc::UnboundedReceiver<SeqNo>,
 ) where
     F: RootFilesystem,
@@ -134,7 +138,9 @@ async fn run_delta_journal_materializer<F>(
                 break;
             }
         }
-        if let Err(error) = materialize_delta_batch(filesystem.as_ref(), &target_seq).await {
+        if let Err(error) =
+            materialize_delta_batch(filesystem.as_ref(), &materialize_gate, &target_seq).await
+        {
             tracing::warn!(
                 error = %error,
                 target_seq = target_seq.get(),
@@ -183,23 +189,24 @@ where
 
 async fn materialize_delta_batch<F>(
     filesystem: &ScopedFilesystem<F>,
+    materialize_gate: &Arc<AsyncMutex<()>>,
     target_seq: &SeqNo,
 ) -> Result<(), TurnError>
 where
     F: RootFilesystem,
 {
-    materialize_delta_log(filesystem, Some(*target_seq)).await
+    materialize_delta_log(filesystem, materialize_gate, Some(*target_seq)).await
 }
 
 pub(super) async fn materialize_delta_log<F>(
     filesystem: &ScopedFilesystem<F>,
+    materialize_gate: &Arc<AsyncMutex<()>>,
     target_seq: Option<SeqNo>,
 ) -> Result<(), TurnError>
 where
     F: RootFilesystem,
 {
-    let gate = materialize_gate();
-    let _guard = gate.lock().await;
+    let _guard = materialize_gate.lock().await;
     materialize_delta_log_unlocked(filesystem, target_seq).await
 }
 
@@ -235,135 +242,152 @@ where
         }
         Err(error) => return Err(fs_error(error)),
     };
+    let mut updated = false;
     for record in records {
         if target_seq.is_some_and(|target_seq| record.seq > target_seq) {
             break;
         }
-        materialize_delta_record(filesystem, &mut meta, record).await?;
+        let delta: SnapshotDelta =
+            serde_json::from_slice(&record.payload).map_err(|error| TurnError::Unavailable {
+                reason: format!("turn-state delta deserialization failed: {error}"),
+            })?;
+        materialize_delta(filesystem, record.seq, &delta).await?;
+        if let Some(floor) = delta.event_retention_floor {
+            meta.event_retention_floor = meta.event_retention_floor.max(floor);
+        }
+        meta.journal_seq = record.seq;
+        updated = true;
+    }
+    if updated {
+        write_meta(filesystem, &meta).await?;
     }
     Ok(())
 }
 
-fn materialize_gate() -> Arc<AsyncMutex<()>> {
-    Arc::clone(MATERIALIZE_GATE.get_or_init(|| Arc::new(AsyncMutex::new(()))))
-}
-
-async fn materialize_delta_record<F>(
-    filesystem: &ScopedFilesystem<F>,
-    meta: &mut RowStoreMeta,
-    record: EventRecord,
-) -> Result<(), TurnError>
-where
-    F: RootFilesystem,
-{
-    let delta: SnapshotDelta =
-        serde_json::from_slice(&record.payload).map_err(|error| TurnError::Unavailable {
-            reason: format!("turn-state delta deserialization failed: {error}"),
-        })?;
-    materialize_delta(filesystem, &delta).await?;
-    if let Some(floor) = delta.event_retention_floor {
-        meta.event_retention_floor = meta.event_retention_floor.max(floor);
-    }
-    meta.journal_seq = record.seq;
-    write_meta(filesystem, meta).await
-}
-
 async fn materialize_delta<F>(
     filesystem: &ScopedFilesystem<F>,
+    journal_seq: SeqNo,
     delta: &SnapshotDelta,
 ) -> Result<(), TurnError>
 where
     F: RootFilesystem,
 {
     for record in &delta.turns_upsert {
-        put_row(filesystem, TURN_ROWS, &turn_record_key(record)?, record).await?;
+        put_row(
+            filesystem,
+            TURN_ROWS,
+            &turn_record_key(record)?,
+            journal_seq,
+            record,
+        )
+        .await?;
     }
     for key in &delta.turns_delete {
-        delete_row(filesystem, TURN_ROWS, key).await?;
+        delete_row(filesystem, TURN_ROWS, key, journal_seq).await?;
     }
     for record in &delta.runs_upsert {
-        put_row(filesystem, RUN_ROWS, &run_record_key(record)?, record).await?;
+        put_row(
+            filesystem,
+            RUN_ROWS,
+            &run_record_key(record)?,
+            journal_seq,
+            record,
+        )
+        .await?;
     }
     for key in &delta.runs_delete {
-        delete_row(filesystem, RUN_ROWS, key).await?;
+        delete_row(filesystem, RUN_ROWS, key, journal_seq).await?;
     }
     for record in &delta.active_locks_upsert {
         put_row(
             filesystem,
             ACTIVE_LOCK_ROWS,
             &active_lock_record_key(record)?,
+            journal_seq,
             record,
         )
         .await?;
     }
     for key in &delta.active_locks_delete {
-        delete_row(filesystem, ACTIVE_LOCK_ROWS, key).await?;
+        delete_row(filesystem, ACTIVE_LOCK_ROWS, key, journal_seq).await?;
     }
     for record in &delta.checkpoints_upsert {
         put_row(
             filesystem,
             CHECKPOINT_ROWS,
             &checkpoint_record_key(record)?,
+            journal_seq,
             record,
         )
         .await?;
     }
     for key in &delta.checkpoints_delete {
-        delete_row(filesystem, CHECKPOINT_ROWS, key).await?;
+        delete_row(filesystem, CHECKPOINT_ROWS, key, journal_seq).await?;
     }
     for record in &delta.loop_checkpoints_upsert {
         put_row(
             filesystem,
             LOOP_CHECKPOINT_ROWS,
             &loop_checkpoint_record_key(record)?,
+            journal_seq,
             record,
         )
         .await?;
     }
     for key in &delta.loop_checkpoints_delete {
-        delete_row(filesystem, LOOP_CHECKPOINT_ROWS, key).await?;
+        delete_row(filesystem, LOOP_CHECKPOINT_ROWS, key, journal_seq).await?;
     }
     for record in &delta.idempotency_upsert {
         put_row(
             filesystem,
             IDEMPOTENCY_ROWS,
             &idempotency_record_key(record)?,
+            journal_seq,
             record,
         )
         .await?;
     }
     for key in &delta.idempotency_delete {
-        delete_row(filesystem, IDEMPOTENCY_ROWS, key).await?;
+        delete_row(filesystem, IDEMPOTENCY_ROWS, key, journal_seq).await?;
     }
     for record in &delta.events_upsert {
-        put_row(filesystem, EVENT_ROWS, &event_record_key(record)?, record).await?;
+        put_row(
+            filesystem,
+            EVENT_ROWS,
+            &event_record_key(record)?,
+            journal_seq,
+            record,
+        )
+        .await?;
     }
     for key in &delta.events_delete {
-        delete_row(filesystem, EVENT_ROWS, key).await?;
+        delete_row(filesystem, EVENT_ROWS, key, journal_seq).await?;
     }
     for record in &delta.admission_reservations_upsert {
         put_row(
             filesystem,
             ADMISSION_RESERVATION_ROWS,
             &admission_reservation_record_key(record)?,
+            journal_seq,
             record,
         )
         .await?;
     }
     for key in &delta.admission_reservations_delete {
-        delete_row(filesystem, ADMISSION_RESERVATION_ROWS, key).await?;
+        delete_row(filesystem, ADMISSION_RESERVATION_ROWS, key, journal_seq).await?;
     }
     for record in &delta.spawn_tree_reservations_upsert {
         put_row(
             filesystem,
             SPAWN_TREE_RESERVATION_ROWS,
             &spawn_tree_reservation_record_key(record)?,
+            journal_seq,
             record,
         )
         .await?;
     }
     for key in &delta.spawn_tree_reservations_delete {
-        delete_row(filesystem, SPAWN_TREE_RESERVATION_ROWS, key).await?;
+        delete_row(filesystem, SPAWN_TREE_RESERVATION_ROWS, key, journal_seq).await?;
     }
     Ok(())
 }
@@ -372,43 +396,74 @@ async fn put_row<F, T>(
     filesystem: &ScopedFilesystem<F>,
     collection: &'static str,
     key: &str,
+    journal_seq: SeqNo,
     record: &T,
 ) -> Result<(), TurnError>
 where
     F: RootFilesystem,
     T: serde::Serialize,
 {
-    let body = serde_json::to_vec(record).map_err(|error| TurnError::Unavailable {
-        reason: format!("turn-state {collection} row serialization failed: {error}"),
-    })?;
-    let entry = Entry::bytes(body).with_content_type(ContentType::json());
-    filesystem
-        .put(
-            &ResourceScope::system(),
-            &row_path(collection, key)?,
-            entry,
-            CasExpectation::Any,
-        )
-        .await
-        .map_err(fs_error)?;
-    Ok(())
+    let body = serialize_materialized_row(journal_seq, Some(record), collection)?;
+    write_materialized_row(filesystem, collection, key, journal_seq, body).await
 }
 
 async fn delete_row<F>(
     filesystem: &ScopedFilesystem<F>,
     collection: &'static str,
     key: &str,
+    journal_seq: SeqNo,
 ) -> Result<(), TurnError>
 where
     F: RootFilesystem,
 {
-    match filesystem
-        .delete(&ResourceScope::system(), &row_path(collection, key)?)
-        .await
-    {
-        Ok(()) | Err(FilesystemError::NotFound { .. }) => Ok(()),
-        Err(error) => Err(fs_error(error)),
+    let body = serialize_materialized_row::<serde_json::Value>(journal_seq, None, collection)?;
+    write_materialized_row(filesystem, collection, key, journal_seq, body).await
+}
+
+async fn write_materialized_row<F>(
+    filesystem: &ScopedFilesystem<F>,
+    collection: &'static str,
+    key: &str,
+    journal_seq: SeqNo,
+    body: Vec<u8>,
+) -> Result<(), TurnError>
+where
+    F: RootFilesystem,
+{
+    let path = row_path(collection, key)?;
+    for attempt in 0..MATERIALIZED_ROW_CAS_RETRIES {
+        let current = match filesystem.get(&ResourceScope::system(), &path).await {
+            Ok(current) => current,
+            Err(FilesystemError::NotFound { .. }) => None,
+            Err(error) => return Err(fs_error(error)),
+        };
+        let cas = match current {
+            Some(versioned) => {
+                let current_seq = materialized_row_seq(&versioned.entry.body, collection)?;
+                if current_seq > journal_seq {
+                    return Ok(());
+                }
+                CasExpectation::Version(versioned.version)
+            }
+            None => CasExpectation::Absent,
+        };
+        let entry = Entry::bytes(body.clone()).with_content_type(ContentType::json());
+        match filesystem
+            .put(&ResourceScope::system(), &path, entry, cas)
+            .await
+        {
+            Ok(_version) => return Ok(()),
+            Err(FilesystemError::VersionMismatch { .. })
+                if attempt + 1 < MATERIALIZED_ROW_CAS_RETRIES =>
+            {
+                tokio::task::yield_now().await;
+            }
+            Err(error) => return Err(fs_error(error)),
+        }
     }
+    Err(TurnError::Unavailable {
+        reason: format!("turn-state {collection} row CAS retry budget exhausted"),
+    })
 }
 
 async fn read_meta<F>(filesystem: &ScopedFilesystem<F>) -> Result<RowStoreMeta, TurnError>
@@ -432,24 +487,162 @@ async fn write_meta<F>(
 where
     F: RootFilesystem,
 {
-    let body = serde_json::to_vec(meta).map_err(|error| TurnError::Unavailable {
-        reason: format!("turn-state row meta serialization failed: {error}"),
-    })?;
-    let entry = Entry::bytes(body).with_content_type(ContentType::json());
-    filesystem
-        .put(
-            &ResourceScope::system(),
-            &meta_path()?,
-            entry,
-            CasExpectation::Any,
-        )
-        .await
-        .map_err(fs_error)?;
-    Ok(())
+    let path = meta_path()?;
+    for attempt in 0..MATERIALIZED_ROW_CAS_RETRIES {
+        let current = match filesystem.get(&ResourceScope::system(), &path).await {
+            Ok(current) => current,
+            Err(FilesystemError::NotFound { .. }) => None,
+            Err(error) => return Err(fs_error(error)),
+        };
+        let (next, cas) = match current {
+            Some(versioned) => {
+                let current_meta: RowStoreMeta =
+                    deserialize_row(&versioned.entry.body, "turn-state row meta")?;
+                if current_meta.journal_seq >= meta.journal_seq
+                    && current_meta.event_retention_floor >= meta.event_retention_floor
+                {
+                    return Ok(());
+                }
+                let mut next = meta.clone();
+                next.journal_seq = next.journal_seq.max(current_meta.journal_seq);
+                next.event_retention_floor = next
+                    .event_retention_floor
+                    .max(current_meta.event_retention_floor);
+                (next, CasExpectation::Version(versioned.version))
+            }
+            None => (meta.clone(), CasExpectation::Absent),
+        };
+        let body = serde_json::to_vec(&next).map_err(|error| TurnError::Unavailable {
+            reason: format!("turn-state row meta serialization failed: {error}"),
+        })?;
+        let entry = Entry::bytes(body).with_content_type(ContentType::json());
+        match filesystem
+            .put(&ResourceScope::system(), &path, entry, cas)
+            .await
+        {
+            Ok(_version) => return Ok(()),
+            Err(FilesystemError::VersionMismatch { .. })
+                if attempt + 1 < MATERIALIZED_ROW_CAS_RETRIES =>
+            {
+                tokio::task::yield_now().await;
+            }
+            Err(error) => return Err(fs_error(error)),
+        }
+    }
+    Err(TurnError::Unavailable {
+        reason: "turn-state row meta CAS retry budget exhausted".to_string(),
+    })
 }
 
 fn delta_journal_stopped() -> TurnError {
     TurnError::Unavailable {
         reason: "turn-state delta journal stopped".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use ironclaw_filesystem::{InMemoryBackend, ScopedFilesystem};
+    use ironclaw_host_api::{MountAlias, MountGrant, MountPermissions, MountView, VirtualPath};
+    use serde::{Deserialize, Serialize};
+
+    use super::super::io::{deserialize_materialized_row, row_path};
+    use super::*;
+
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    struct TestRow {
+        value: String,
+    }
+
+    fn scoped_filesystem() -> ScopedFilesystem<InMemoryBackend> {
+        let mounts = MountView::new(vec![MountGrant::new(
+            MountAlias::new("/turns").expect("create turns mount alias"),
+            VirtualPath::new("/turns").expect("create turns virtual path"),
+            MountPermissions::read_write_list_delete(),
+        )])
+        .expect("create turns mount view");
+        ScopedFilesystem::with_fixed_view(Arc::new(InMemoryBackend::new()), mounts)
+    }
+
+    async fn read_test_row(
+        filesystem: &ScopedFilesystem<InMemoryBackend>,
+        key: &str,
+    ) -> Option<TestRow> {
+        let path = row_path("test-rows", key).expect("create row path");
+        let versioned = filesystem
+            .get(&ResourceScope::system(), &path)
+            .await
+            .expect("read test row")?;
+        deserialize_materialized_row(&versioned.entry.body, "test-rows")
+            .expect("deserialize test row")
+    }
+
+    #[tokio::test]
+    async fn materialized_row_write_skips_older_journal_sequence() {
+        let filesystem = scoped_filesystem();
+        put_row(
+            &filesystem,
+            "test-rows",
+            "row",
+            SeqNo::from_backend(2),
+            &TestRow {
+                value: "newer".to_string(),
+            },
+        )
+        .await
+        .expect("write newer row");
+
+        put_row(
+            &filesystem,
+            "test-rows",
+            "row",
+            SeqNo::from_backend(1),
+            &TestRow {
+                value: "older".to_string(),
+            },
+        )
+        .await
+        .expect("skip older row");
+
+        assert_eq!(
+            read_test_row(&filesystem, "row").await,
+            Some(TestRow {
+                value: "newer".to_string(),
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn materialized_row_delete_skips_older_journal_sequence() {
+        let filesystem = scoped_filesystem();
+        put_row(
+            &filesystem,
+            "test-rows",
+            "row",
+            SeqNo::from_backend(2),
+            &TestRow {
+                value: "newer".to_string(),
+            },
+        )
+        .await
+        .expect("write newer row");
+
+        delete_row(&filesystem, "test-rows", "row", SeqNo::from_backend(1))
+            .await
+            .expect("skip older tombstone");
+
+        assert_eq!(
+            read_test_row(&filesystem, "row").await,
+            Some(TestRow {
+                value: "newer".to_string(),
+            })
+        );
+
+        delete_row(&filesystem, "test-rows", "row", SeqNo::from_backend(3))
+            .await
+            .expect("write newer tombstone");
+        assert_eq!(read_test_row(&filesystem, "row").await, None);
     }
 }

--- a/crates/ironclaw_turns/src/filesystem_store/row_store/journal.rs
+++ b/crates/ironclaw_turns/src/filesystem_store/row_store/journal.rs
@@ -1,0 +1,455 @@
+use std::{
+    sync::{Arc, OnceLock},
+    time::Duration,
+};
+
+use ironclaw_filesystem::{
+    CasExpectation, ContentType, Entry, EventRecord, FilesystemError, RootFilesystem,
+    ScopedFilesystem, SeqNo,
+};
+use ironclaw_host_api::ResourceScope;
+use tokio::sync::{Mutex as AsyncMutex, mpsc, oneshot};
+
+use crate::TurnError;
+
+use super::{
+    ACTIVE_LOCK_ROWS, ADMISSION_RESERVATION_ROWS, CHECKPOINT_ROWS, EVENT_ROWS, IDEMPOTENCY_ROWS,
+    LOOP_CHECKPOINT_ROWS, RUN_ROWS, SPAWN_TREE_RESERVATION_ROWS, TURN_ROWS,
+    delta::{
+        RowStoreMeta, SnapshotDelta, active_lock_record_key, admission_reservation_record_key,
+        checkpoint_record_key, event_record_key, idempotency_record_key,
+        loop_checkpoint_record_key, run_record_key, spawn_tree_reservation_record_key,
+        turn_record_key,
+    },
+    io::{delta_log_path, deserialize_row, fs_error, meta_path, row_path},
+};
+
+const DELTA_JOURNAL_MAX_BATCH: usize = 256;
+const DELTA_JOURNAL_MATERIALIZE_IDLE_DELAY: Duration = Duration::from_millis(25);
+static MATERIALIZE_GATE: OnceLock<Arc<AsyncMutex<()>>> = OnceLock::new();
+
+pub(super) type DeltaAck = oneshot::Receiver<Result<(), TurnError>>;
+
+pub(super) struct DeltaJournal {
+    sender: mpsc::UnboundedSender<DeltaJournalRequest>,
+}
+
+struct DeltaJournalRequest {
+    delta: SnapshotDelta,
+    ack: oneshot::Sender<Result<(), TurnError>>,
+}
+
+impl DeltaJournal {
+    pub(super) fn new<F>(filesystem: Arc<ScopedFilesystem<F>>) -> Self
+    where
+        F: RootFilesystem + 'static,
+    {
+        let (sender, receiver) = mpsc::unbounded_channel();
+        let (materialize_sender, materialize_receiver) = mpsc::unbounded_channel();
+        tokio::spawn(run_delta_journal_materializer(
+            Arc::clone(&filesystem),
+            materialize_receiver,
+        ));
+        tokio::spawn(run_delta_journal_flusher(
+            filesystem,
+            receiver,
+            materialize_sender,
+        ));
+        Self { sender }
+    }
+
+    pub(super) fn enqueue(&self, delta: SnapshotDelta) -> Result<Option<DeltaAck>, TurnError> {
+        if delta.is_empty() {
+            return Ok(None);
+        }
+        let (ack, receiver) = oneshot::channel();
+        self.sender
+            .send(DeltaJournalRequest { delta, ack })
+            .map_err(|_| delta_journal_stopped())?;
+        Ok(Some(receiver))
+    }
+
+    pub(super) async fn await_ack(ack: Option<DeltaAck>) -> Result<(), TurnError> {
+        let Some(ack) = ack else {
+            return Ok(());
+        };
+        ack.await.map_err(|_| delta_journal_stopped())?
+    }
+}
+
+async fn run_delta_journal_flusher<F>(
+    filesystem: Arc<ScopedFilesystem<F>>,
+    mut receiver: mpsc::UnboundedReceiver<DeltaJournalRequest>,
+    materialize_sender: mpsc::UnboundedSender<SeqNo>,
+) where
+    F: RootFilesystem,
+{
+    while let Some(first) = receiver.recv().await {
+        let mut requests = Vec::with_capacity(DELTA_JOURNAL_MAX_BATCH);
+        requests.push(first);
+        tokio::task::yield_now().await;
+        while requests.len() < DELTA_JOURNAL_MAX_BATCH {
+            match receiver.try_recv() {
+                Ok(request) => requests.push(request),
+                Err(mpsc::error::TryRecvError::Empty | mpsc::error::TryRecvError::Disconnected) => {
+                    break;
+                }
+            }
+        }
+        let result = append_delta_journal_batch(filesystem.as_ref(), &requests).await;
+        match result {
+            Ok(seqs) => {
+                let target_seq = seqs.iter().copied().max();
+                for request in requests {
+                    let _ = request.ack.send(Ok(()));
+                }
+                if let Some(target_seq) = target_seq {
+                    let _ = materialize_sender.send(target_seq);
+                }
+            }
+            Err(error) => {
+                for request in requests {
+                    let _ = request.ack.send(Err(error.clone()));
+                }
+            }
+        }
+    }
+}
+
+async fn run_delta_journal_materializer<F>(
+    filesystem: Arc<ScopedFilesystem<F>>,
+    mut receiver: mpsc::UnboundedReceiver<SeqNo>,
+) where
+    F: RootFilesystem,
+{
+    while let Some(mut target_seq) = receiver.recv().await {
+        loop {
+            tokio::time::sleep(DELTA_JOURNAL_MATERIALIZE_IDLE_DELAY).await;
+            let mut saw_new_target = false;
+            while let Ok(next_seq) = receiver.try_recv() {
+                target_seq = target_seq.max(next_seq);
+                saw_new_target = true;
+            }
+            if !saw_new_target {
+                break;
+            }
+        }
+        if let Err(error) = materialize_delta_batch(filesystem.as_ref(), &target_seq).await {
+            tracing::warn!(
+                error = %error,
+                target_seq = target_seq.get(),
+                "turn-state row materialization failed after durable delta append",
+            );
+        }
+    }
+}
+
+async fn append_delta_journal_batch<F>(
+    filesystem: &ScopedFilesystem<F>,
+    requests: &[DeltaJournalRequest],
+) -> Result<Vec<SeqNo>, TurnError>
+where
+    F: RootFilesystem,
+{
+    let path = delta_log_path()?;
+    let mut payloads = Vec::with_capacity(requests.len());
+    for request in requests {
+        payloads.push(serde_json::to_vec(&request.delta).map_err(|error| {
+            TurnError::Unavailable {
+                reason: format!("turn-state delta serialization failed: {error}"),
+            }
+        })?);
+    }
+    let seqs = if let [payload] = payloads.as_slice() {
+        vec![
+            filesystem
+                .append(&ResourceScope::system(), &path, payload.clone())
+                .await
+                .map_err(fs_error)?,
+        ]
+    } else {
+        filesystem
+            .append_batch(&ResourceScope::system(), &path, payloads)
+            .await
+            .map_err(fs_error)?
+    };
+    if seqs.len() != requests.len() {
+        return Err(TurnError::Unavailable {
+            reason: "turn-state delta batch append returned an unexpected ack count".to_string(),
+        });
+    }
+    Ok(seqs)
+}
+
+async fn materialize_delta_batch<F>(
+    filesystem: &ScopedFilesystem<F>,
+    target_seq: &SeqNo,
+) -> Result<(), TurnError>
+where
+    F: RootFilesystem,
+{
+    materialize_delta_log(filesystem, Some(*target_seq)).await
+}
+
+pub(super) async fn materialize_delta_log<F>(
+    filesystem: &ScopedFilesystem<F>,
+    target_seq: Option<SeqNo>,
+) -> Result<(), TurnError>
+where
+    F: RootFilesystem,
+{
+    let gate = materialize_gate();
+    let _guard = gate.lock().await;
+    materialize_delta_log_unlocked(filesystem, target_seq).await
+}
+
+async fn materialize_delta_log_unlocked<F>(
+    filesystem: &ScopedFilesystem<F>,
+    target_seq: Option<SeqNo>,
+) -> Result<(), TurnError>
+where
+    F: RootFilesystem,
+{
+    let mut meta = read_meta(filesystem).await?;
+    if let Some(target_seq) = target_seq
+        && target_seq <= meta.journal_seq
+    {
+        return Ok(());
+    }
+    let path = delta_log_path()?;
+    let max_records = target_seq
+        .map(|target_seq| target_seq.get().saturating_sub(meta.journal_seq.get()) as usize)
+        .unwrap_or(usize::MAX);
+    let records = match filesystem
+        .tail_bounded(
+            &ResourceScope::system(),
+            &path,
+            meta.journal_seq,
+            max_records,
+        )
+        .await
+    {
+        Ok(records) => records,
+        Err(FilesystemError::NotFound { .. }) | Err(FilesystemError::Unsupported { .. }) => {
+            Vec::new()
+        }
+        Err(error) => return Err(fs_error(error)),
+    };
+    for record in records {
+        if target_seq.is_some_and(|target_seq| record.seq > target_seq) {
+            break;
+        }
+        materialize_delta_record(filesystem, &mut meta, record).await?;
+    }
+    Ok(())
+}
+
+fn materialize_gate() -> Arc<AsyncMutex<()>> {
+    Arc::clone(MATERIALIZE_GATE.get_or_init(|| Arc::new(AsyncMutex::new(()))))
+}
+
+async fn materialize_delta_record<F>(
+    filesystem: &ScopedFilesystem<F>,
+    meta: &mut RowStoreMeta,
+    record: EventRecord,
+) -> Result<(), TurnError>
+where
+    F: RootFilesystem,
+{
+    let delta: SnapshotDelta =
+        serde_json::from_slice(&record.payload).map_err(|error| TurnError::Unavailable {
+            reason: format!("turn-state delta deserialization failed: {error}"),
+        })?;
+    materialize_delta(filesystem, &delta).await?;
+    if let Some(floor) = delta.event_retention_floor {
+        meta.event_retention_floor = meta.event_retention_floor.max(floor);
+    }
+    meta.journal_seq = record.seq;
+    write_meta(filesystem, meta).await
+}
+
+async fn materialize_delta<F>(
+    filesystem: &ScopedFilesystem<F>,
+    delta: &SnapshotDelta,
+) -> Result<(), TurnError>
+where
+    F: RootFilesystem,
+{
+    for record in &delta.turns_upsert {
+        put_row(filesystem, TURN_ROWS, &turn_record_key(record)?, record).await?;
+    }
+    for key in &delta.turns_delete {
+        delete_row(filesystem, TURN_ROWS, key).await?;
+    }
+    for record in &delta.runs_upsert {
+        put_row(filesystem, RUN_ROWS, &run_record_key(record)?, record).await?;
+    }
+    for key in &delta.runs_delete {
+        delete_row(filesystem, RUN_ROWS, key).await?;
+    }
+    for record in &delta.active_locks_upsert {
+        put_row(
+            filesystem,
+            ACTIVE_LOCK_ROWS,
+            &active_lock_record_key(record)?,
+            record,
+        )
+        .await?;
+    }
+    for key in &delta.active_locks_delete {
+        delete_row(filesystem, ACTIVE_LOCK_ROWS, key).await?;
+    }
+    for record in &delta.checkpoints_upsert {
+        put_row(
+            filesystem,
+            CHECKPOINT_ROWS,
+            &checkpoint_record_key(record)?,
+            record,
+        )
+        .await?;
+    }
+    for key in &delta.checkpoints_delete {
+        delete_row(filesystem, CHECKPOINT_ROWS, key).await?;
+    }
+    for record in &delta.loop_checkpoints_upsert {
+        put_row(
+            filesystem,
+            LOOP_CHECKPOINT_ROWS,
+            &loop_checkpoint_record_key(record)?,
+            record,
+        )
+        .await?;
+    }
+    for key in &delta.loop_checkpoints_delete {
+        delete_row(filesystem, LOOP_CHECKPOINT_ROWS, key).await?;
+    }
+    for record in &delta.idempotency_upsert {
+        put_row(
+            filesystem,
+            IDEMPOTENCY_ROWS,
+            &idempotency_record_key(record)?,
+            record,
+        )
+        .await?;
+    }
+    for key in &delta.idempotency_delete {
+        delete_row(filesystem, IDEMPOTENCY_ROWS, key).await?;
+    }
+    for record in &delta.events_upsert {
+        put_row(filesystem, EVENT_ROWS, &event_record_key(record)?, record).await?;
+    }
+    for key in &delta.events_delete {
+        delete_row(filesystem, EVENT_ROWS, key).await?;
+    }
+    for record in &delta.admission_reservations_upsert {
+        put_row(
+            filesystem,
+            ADMISSION_RESERVATION_ROWS,
+            &admission_reservation_record_key(record)?,
+            record,
+        )
+        .await?;
+    }
+    for key in &delta.admission_reservations_delete {
+        delete_row(filesystem, ADMISSION_RESERVATION_ROWS, key).await?;
+    }
+    for record in &delta.spawn_tree_reservations_upsert {
+        put_row(
+            filesystem,
+            SPAWN_TREE_RESERVATION_ROWS,
+            &spawn_tree_reservation_record_key(record)?,
+            record,
+        )
+        .await?;
+    }
+    for key in &delta.spawn_tree_reservations_delete {
+        delete_row(filesystem, SPAWN_TREE_RESERVATION_ROWS, key).await?;
+    }
+    Ok(())
+}
+
+async fn put_row<F, T>(
+    filesystem: &ScopedFilesystem<F>,
+    collection: &'static str,
+    key: &str,
+    record: &T,
+) -> Result<(), TurnError>
+where
+    F: RootFilesystem,
+    T: serde::Serialize,
+{
+    let body = serde_json::to_vec(record).map_err(|error| TurnError::Unavailable {
+        reason: format!("turn-state {collection} row serialization failed: {error}"),
+    })?;
+    let entry = Entry::bytes(body).with_content_type(ContentType::json());
+    filesystem
+        .put(
+            &ResourceScope::system(),
+            &row_path(collection, key)?,
+            entry,
+            CasExpectation::Any,
+        )
+        .await
+        .map_err(fs_error)?;
+    Ok(())
+}
+
+async fn delete_row<F>(
+    filesystem: &ScopedFilesystem<F>,
+    collection: &'static str,
+    key: &str,
+) -> Result<(), TurnError>
+where
+    F: RootFilesystem,
+{
+    match filesystem
+        .delete(&ResourceScope::system(), &row_path(collection, key)?)
+        .await
+    {
+        Ok(()) | Err(FilesystemError::NotFound { .. }) => Ok(()),
+        Err(error) => Err(fs_error(error)),
+    }
+}
+
+async fn read_meta<F>(filesystem: &ScopedFilesystem<F>) -> Result<RowStoreMeta, TurnError>
+where
+    F: RootFilesystem,
+{
+    match filesystem
+        .get(&ResourceScope::system(), &meta_path()?)
+        .await
+    {
+        Ok(Some(versioned)) => deserialize_row(&versioned.entry.body, "turn-state row meta"),
+        Ok(None) | Err(FilesystemError::NotFound { .. }) => Ok(RowStoreMeta::default()),
+        Err(error) => Err(fs_error(error)),
+    }
+}
+
+async fn write_meta<F>(
+    filesystem: &ScopedFilesystem<F>,
+    meta: &RowStoreMeta,
+) -> Result<(), TurnError>
+where
+    F: RootFilesystem,
+{
+    let body = serde_json::to_vec(meta).map_err(|error| TurnError::Unavailable {
+        reason: format!("turn-state row meta serialization failed: {error}"),
+    })?;
+    let entry = Entry::bytes(body).with_content_type(ContentType::json());
+    filesystem
+        .put(
+            &ResourceScope::system(),
+            &meta_path()?,
+            entry,
+            CasExpectation::Any,
+        )
+        .await
+        .map_err(fs_error)?;
+    Ok(())
+}
+
+fn delta_journal_stopped() -> TurnError {
+    TurnError::Unavailable {
+        reason: "turn-state delta journal stopped".to_string(),
+    }
+}

--- a/crates/ironclaw_turns/src/filesystem_store/row_store/traits.rs
+++ b/crates/ironclaw_turns/src/filesystem_store/row_store/traits.rs
@@ -23,7 +23,7 @@ use super::super::{
     profile_resolver::PreResolvedRunProfileResolver, projection, runner_lease::RunnerLeaseOverlay,
 };
 use super::{
-    FilesystemTurnStateRowStore, RunStateTransitionTarget,
+    FilesystemTurnStateRowStore, PendingRowCommit, RunStateTransitionTarget,
     delta::{
         RowPersistError, SnapshotDelta, blocked_run_targeted_delta, claimed_run_targeted_delta,
         full_snapshot_delta, loop_checkpoint_record_from_request, row_store_durable_delta,
@@ -178,17 +178,9 @@ where
     }
 
     async fn get_run_state(&self, request: GetRunStateRequest) -> Result<TurnRunState, TurnError> {
-        let Some((run, actor)) = self
-            .with_cached_snapshot(|snapshot| projection::run_state_parts(snapshot, &request))
-            .await??
-        else {
-            return self
-                .read_run_state_from_durable_rows(&request)
-                .await?
-                .ok_or(TurnError::ScopeNotFound);
-        };
-        let run = self.runner_lease_store().overlay_run_record(run).await?;
-        Ok(projection::run_state_from_record(run, actor))
+        self.read_run_state_from_durable_rows(&request)
+            .await?
+            .ok_or(TurnError::ScopeNotFound)
     }
 }
 
@@ -334,11 +326,16 @@ where
                 self.apply_cached_delta(delta).await?;
                 ack
             };
-            if let Err(error) = self.await_delta_ack(ack).await {
-                self.clear_snapshot_cache().await;
-                return Err(error.into_turn());
-            }
-            Ok(record)
+            self.await_pending_commit(
+                PendingRowCommit {
+                    value: record,
+                    ack,
+                    active_lock_reservations: Vec::new(),
+                    run_row_reservations: Vec::new(),
+                },
+                "timed out waiting for loop checkpoint row-store append",
+            )
+            .await
         }
         .instrument(span)
         .await
@@ -348,8 +345,7 @@ where
         &self,
         request: GetLoopCheckpointRequest,
     ) -> Result<Option<LoopCheckpointRecord>, TurnError> {
-        self.with_cached_snapshot(|snapshot| projection::loop_checkpoint(snapshot, &request))
-            .await
+        self.read_loop_checkpoint_from_durable_rows(&request).await
     }
 }
 

--- a/crates/ironclaw_turns/src/filesystem_store/row_store/traits.rs
+++ b/crates/ironclaw_turns/src/filesystem_store/row_store/traits.rs
@@ -1,0 +1,625 @@
+use async_trait::async_trait;
+use ironclaw_filesystem::RootFilesystem;
+use ironclaw_host_api::UserId;
+use tracing::Instrument;
+
+use crate::{
+    CancelRunRequest, CancelRunResponse, EventCursor, GetLoopCheckpointRequest, GetRunStateRequest,
+    LoopCheckpointRecord, LoopCheckpointStore, PutLoopCheckpointRequest, ResumeTurnRequest,
+    ResumeTurnResponse, RunProfileResolver, SpawnTreeReservation, SubmitChildRunRequest,
+    SubmitTurnRequest, SubmitTurnResponse, TurnAdmissionPolicy, TurnError, TurnEventPage,
+    TurnEventProjectionSource, TurnRunId, TurnRunRecord, TurnRunState, TurnScope,
+    TurnSpawnTreeStateStore, TurnStateStore, TurnStatus,
+    runner::{
+        ApplyValidatedLoopExitRequest, BlockRunRequest, CancelRunCompletionRequest,
+        ClaimRunRequest, ClaimedTurnRun, CompleteRunRequest, FailRunRequest, HeartbeatRequest,
+        RecordModelRouteSnapshotRequest, RecordRunnerFailureRequest, RecoverExpiredLeasesRequest,
+        RecoverExpiredLeasesResponse, RelinquishRunRequest, TurnRunTransitionPort,
+        TurnRunnerOutcome,
+    },
+};
+
+use super::super::{
+    profile_resolver::PreResolvedRunProfileResolver, projection, runner_lease::RunnerLeaseOverlay,
+};
+use super::{
+    FilesystemTurnStateRowStore, RunStateTransitionTarget,
+    delta::{
+        RowPersistError, SnapshotDelta, blocked_run_targeted_delta, claimed_run_targeted_delta,
+        full_snapshot_delta, loop_checkpoint_record_from_request, row_store_durable_delta,
+        run_state_targeted_delta, run_state_with_idempotency_targeted_delta,
+        submit_turn_targeted_delta,
+    },
+    turn_state_write_span,
+};
+
+#[async_trait]
+impl<F> TurnStateStore for FilesystemTurnStateRowStore<F>
+where
+    F: RootFilesystem,
+{
+    async fn submit_turn(
+        &self,
+        request: SubmitTurnRequest,
+        admission_policy: &dyn TurnAdmissionPolicy,
+        run_profile_resolver: &dyn RunProfileResolver,
+    ) -> Result<SubmitTurnResponse, TurnError> {
+        let profile_resolution = run_profile_resolver
+            .resolve_run_profile(crate::RunProfileResolutionRequest {
+                requested_run_profile: request.requested_run_profile.clone(),
+                ..crate::RunProfileResolutionRequest::interactive_default()
+            })
+            .await;
+        let pre_resolved = PreResolvedRunProfileResolver::new(profile_resolution);
+        let max_idempotency_records = self.limits.max_idempotency_records;
+        self.apply_with_targeted_delta(
+            RunnerLeaseOverlay::None,
+            |store| {
+                let request = request.clone();
+                let pre_resolved = pre_resolved.clone();
+                async move {
+                    store
+                        .submit_turn(request, admission_policy, &pre_resolved)
+                        .await
+                }
+            },
+            move |snapshot, latest_event_cursor, store, response| {
+                if snapshot.idempotency_records.len() >= max_idempotency_records {
+                    return full_snapshot_delta(snapshot, store);
+                }
+                submit_turn_targeted_delta(snapshot, latest_event_cursor, store, response)
+            },
+        )
+        .instrument(turn_state_write_span(
+            "submit_turn",
+            Some(&request.scope),
+            request.requested_run_id.as_ref(),
+        ))
+        .await
+    }
+
+    async fn resume_turn(
+        &self,
+        request: ResumeTurnRequest,
+    ) -> Result<ResumeTurnResponse, TurnError> {
+        let max_idempotency_records = self.limits.max_idempotency_records;
+        let scope = request.scope.clone();
+        let run_id = request.run_id;
+        self.apply_with_targeted_delta(
+            RunnerLeaseOverlay::None,
+            |store| {
+                let request = request.clone();
+                async move { store.resume_turn(request).await }
+            },
+            move |snapshot, latest_event_cursor, store, response| {
+                if snapshot.idempotency_records.len() >= max_idempotency_records {
+                    return full_snapshot_delta(snapshot, store);
+                }
+                run_state_with_idempotency_targeted_delta(
+                    snapshot,
+                    latest_event_cursor,
+                    store,
+                    response.run_id,
+                    &scope,
+                    crate::TurnIdempotencyOperationKind::Resume,
+                )
+            },
+        )
+        .instrument(turn_state_write_span(
+            "resume_turn",
+            Some(&request.scope),
+            Some(&run_id),
+        ))
+        .await
+    }
+
+    async fn request_cancel(
+        &self,
+        request: CancelRunRequest,
+    ) -> Result<CancelRunResponse, TurnError> {
+        let span = turn_state_write_span(
+            "request_cancel",
+            Some(&request.scope),
+            Some(&request.run_id),
+        );
+        async move {
+            let previous = self.prepare_cancel_requested_runner_lease(&request).await?;
+            let max_idempotency_records = self.limits.max_idempotency_records;
+            let max_terminal_records = self.limits.max_terminal_records;
+            let scope = request.scope.clone();
+            let result = self
+                .apply_with_targeted_delta(
+                    RunnerLeaseOverlay::Run(request.run_id),
+                    |store| {
+                        let request = request.clone();
+                        async move { store.request_cancel(request).await }
+                    },
+                    move |snapshot, latest_event_cursor, store, response| {
+                        if snapshot.idempotency_records.len() >= max_idempotency_records {
+                            return full_snapshot_delta(snapshot, store);
+                        }
+                        let terminal_records = snapshot
+                            .runs
+                            .iter()
+                            .filter(|record| record.status.is_terminal())
+                            .count();
+                        if response.status.is_terminal() && terminal_records >= max_terminal_records
+                        {
+                            return full_snapshot_delta(snapshot, store);
+                        }
+                        run_state_with_idempotency_targeted_delta(
+                            snapshot,
+                            latest_event_cursor,
+                            store,
+                            response.run_id,
+                            &scope,
+                            crate::TurnIdempotencyOperationKind::Cancel,
+                        )
+                    },
+                )
+                .await;
+            if result.is_err() {
+                self.restore_runner_lease_after_failed_transition(
+                    previous,
+                    TurnStatus::CancelRequested,
+                )
+                .await;
+            }
+            let response = result?;
+            if response.status.is_terminal() {
+                self.runner_lease_store()
+                    .delete_best_effort(response.run_id)
+                    .await;
+            }
+            Ok(response)
+        }
+        .instrument(span)
+        .await
+    }
+
+    async fn get_run_state(&self, request: GetRunStateRequest) -> Result<TurnRunState, TurnError> {
+        let Some((run, actor)) = self
+            .with_cached_snapshot(|snapshot| projection::run_state_parts(snapshot, &request))
+            .await??
+        else {
+            return self
+                .read_run_state_from_durable_rows(&request)
+                .await?
+                .ok_or(TurnError::ScopeNotFound);
+        };
+        let run = self.runner_lease_store().overlay_run_record(run).await?;
+        Ok(projection::run_state_from_record(run, actor))
+    }
+}
+
+#[async_trait]
+impl<F> TurnSpawnTreeStateStore for FilesystemTurnStateRowStore<F>
+where
+    F: RootFilesystem,
+{
+    async fn submit_child_turn(
+        &self,
+        request: SubmitChildRunRequest,
+        admission_policy: &dyn TurnAdmissionPolicy,
+        run_profile_resolver: &dyn RunProfileResolver,
+    ) -> Result<SubmitTurnResponse, TurnError> {
+        let profile_resolution = run_profile_resolver
+            .resolve_run_profile(crate::RunProfileResolutionRequest {
+                requested_run_profile: request.requested_run_profile.clone(),
+                ..crate::RunProfileResolutionRequest::interactive_default()
+            })
+            .await;
+        let pre_resolved = PreResolvedRunProfileResolver::new(profile_resolution);
+        self.apply(RunnerLeaseOverlay::None, |store| {
+            let request = request.clone();
+            let pre_resolved = pre_resolved.clone();
+            async move {
+                store
+                    .submit_child_turn(request, admission_policy, &pre_resolved)
+                    .await
+            }
+        })
+        .instrument(turn_state_write_span(
+            "submit_child_turn",
+            Some(&request.child_scope),
+            request.requested_run_id.as_ref(),
+        ))
+        .await
+    }
+
+    async fn children_of(
+        &self,
+        scope: &TurnScope,
+        run_id: TurnRunId,
+    ) -> Result<Vec<TurnRunRecord>, TurnError> {
+        let (snapshot, _) = self.read_snapshot().await?;
+        Ok(projection::children_of(&snapshot, scope, run_id))
+    }
+
+    async fn get_run_record(
+        &self,
+        scope: &TurnScope,
+        run_id: TurnRunId,
+    ) -> Result<Option<TurnRunRecord>, TurnError> {
+        let (snapshot, _) = self
+            .read_snapshot_with_runner_lease_overlay(RunnerLeaseOverlay::Run(run_id))
+            .await?;
+        Ok(projection::run_record(&snapshot, scope, run_id))
+    }
+
+    async fn reserve_tree_descendants(
+        &self,
+        scope: &TurnScope,
+        root_run_id: TurnRunId,
+        delta: u32,
+        cap: u32,
+    ) -> Result<SpawnTreeReservation, TurnError> {
+        self.apply(RunnerLeaseOverlay::None, |store| async move {
+            store
+                .reserve_tree_descendants(scope, root_run_id, delta, cap)
+                .await
+        })
+        .instrument(turn_state_write_span(
+            "reserve_tree_descendants",
+            Some(scope),
+            Some(&root_run_id),
+        ))
+        .await
+    }
+
+    async fn release_tree_descendants(
+        &self,
+        scope: &TurnScope,
+        root_run_id: TurnRunId,
+        delta: u32,
+    ) -> Result<(), TurnError> {
+        self.apply(RunnerLeaseOverlay::None, |store| async move {
+            store
+                .release_tree_descendants(scope, root_run_id, delta)
+                .await
+        })
+        .instrument(turn_state_write_span(
+            "release_tree_descendants",
+            Some(scope),
+            Some(&root_run_id),
+        ))
+        .await
+    }
+}
+
+#[async_trait]
+impl<F> TurnEventProjectionSource for FilesystemTurnStateRowStore<F>
+where
+    F: RootFilesystem,
+{
+    async fn read_turn_events_after(
+        &self,
+        scope: &TurnScope,
+        owner_user_id: Option<&UserId>,
+        after: Option<EventCursor>,
+        limit: usize,
+    ) -> Result<TurnEventPage, TurnError> {
+        self.read_turn_events_from_durable_rows(scope, owner_user_id, after, limit)
+            .await
+    }
+}
+
+#[async_trait]
+impl<F> LoopCheckpointStore for FilesystemTurnStateRowStore<F>
+where
+    F: RootFilesystem,
+{
+    async fn put_loop_checkpoint(
+        &self,
+        request: PutLoopCheckpointRequest,
+    ) -> Result<LoopCheckpointRecord, TurnError> {
+        let span = turn_state_write_span(
+            "put_loop_checkpoint",
+            Some(&request.scope),
+            Some(&request.run_id),
+        );
+        async move {
+            let record = loop_checkpoint_record_from_request(request);
+            let delta = SnapshotDelta {
+                loop_checkpoints_upsert: vec![record.clone()],
+                ..SnapshotDelta::default()
+            };
+            let ack = {
+                let _commit_guard = self.commit_gate.lock().await;
+                let ack = self
+                    .enqueue_delta(row_store_durable_delta(delta.clone()))
+                    .map_err(|error| match error {
+                        RowPersistError::Turn(error) => error,
+                    })?;
+                self.apply_cached_delta(delta).await?;
+                ack
+            };
+            if let Err(error) = self.await_delta_ack(ack).await {
+                self.clear_snapshot_cache().await;
+                return Err(error.into_turn());
+            }
+            Ok(record)
+        }
+        .instrument(span)
+        .await
+    }
+
+    async fn get_loop_checkpoint(
+        &self,
+        request: GetLoopCheckpointRequest,
+    ) -> Result<Option<LoopCheckpointRecord>, TurnError> {
+        self.with_cached_snapshot(|snapshot| projection::loop_checkpoint(snapshot, &request))
+            .await
+    }
+}
+
+#[async_trait]
+impl<F> TurnRunTransitionPort for FilesystemTurnStateRowStore<F>
+where
+    F: RootFilesystem,
+{
+    async fn claim_next_run(
+        &self,
+        request: ClaimRunRequest,
+    ) -> Result<Option<ClaimedTurnRun>, TurnError> {
+        let span = turn_state_write_span("claim_next_run", request.scope_filter.as_ref(), None);
+        async move {
+            let claimed = self
+                .apply_with_targeted_delta(
+                    RunnerLeaseOverlay::None,
+                    |store| {
+                        let request = request.clone();
+                        async move { store.claim_next_run(request).await }
+                    },
+                    claimed_run_targeted_delta,
+                )
+                .await?;
+            if let Some(claimed) = &claimed
+                && let Err(error) = self
+                    .seed_runner_lease_from_cached_run(claimed.state.run_id)
+                    .await
+            {
+                self.compensate_failed_claim(claimed).await;
+                return Err(error);
+            }
+            Ok(claimed)
+        }
+        .instrument(span)
+        .await
+    }
+
+    async fn heartbeat(&self, request: HeartbeatRequest) -> Result<EventCursor, TurnError> {
+        self.heartbeat_runner_lease(request).await
+    }
+
+    async fn recover_expired_leases(
+        &self,
+        request: RecoverExpiredLeasesRequest,
+    ) -> Result<RecoverExpiredLeasesResponse, TurnError> {
+        let result = self
+            .apply(RunnerLeaseOverlay::All, |store| {
+                let request = request.clone();
+                async move { store.recover_expired_leases(request).await }
+            })
+            .instrument(turn_state_write_span(
+                "recover_expired_leases",
+                request.scope_filter.as_ref(),
+                None,
+            ))
+            .await;
+        if let Ok(response) = &result {
+            for state in &response.recovered {
+                self.runner_lease_store()
+                    .delete_best_effort(state.run_id)
+                    .await;
+            }
+        }
+        result
+    }
+
+    async fn record_model_route_snapshot(
+        &self,
+        request: RecordModelRouteSnapshotRequest,
+    ) -> Result<TurnRunState, TurnError> {
+        self.apply(RunnerLeaseOverlay::Run(request.run_id), |store| {
+            let request = request.clone();
+            async move { store.record_model_route_snapshot(request).await }
+        })
+        .instrument(turn_state_write_span(
+            "record_model_route_snapshot",
+            None,
+            Some(&request.run_id),
+        ))
+        .await
+    }
+
+    async fn block_run(&self, request: BlockRunRequest) -> Result<TurnRunState, TurnError> {
+        self.apply_run_state_transition_with_targeted_delta(
+            "block_run",
+            RunStateTransitionTarget {
+                run_id: request.run_id,
+                runner_id: request.runner_id,
+                lease_token: request.lease_token,
+                retired_status: request.reason.status(),
+            },
+            |store| {
+                let request = request.clone();
+                async move { store.block_run(request).await }
+            },
+            blocked_run_targeted_delta,
+        )
+        .await
+    }
+
+    async fn complete_run(&self, request: CompleteRunRequest) -> Result<TurnRunState, TurnError> {
+        let span = turn_state_write_span("complete_run", None, Some(&request.run_id));
+        async move {
+            let previous = self
+                .prepare_runner_lease_retirement(
+                    request.run_id,
+                    request.runner_id,
+                    request.lease_token,
+                    TurnStatus::Completed,
+                )
+                .await?;
+            let max_terminal_records = self.limits.max_terminal_records;
+            let result = self
+                .apply_with_targeted_delta(
+                    RunnerLeaseOverlay::Run(request.run_id),
+                    |store| {
+                        let request = request.clone();
+                        async move { store.complete_run(request).await }
+                    },
+                    move |snapshot, latest_event_cursor, store, state| {
+                        let terminal_records = snapshot
+                            .runs
+                            .iter()
+                            .filter(|record| record.status.is_terminal())
+                            .count();
+                        if terminal_records >= max_terminal_records {
+                            return full_snapshot_delta(snapshot, store);
+                        }
+                        run_state_targeted_delta(
+                            snapshot,
+                            latest_event_cursor,
+                            store,
+                            state.run_id,
+                            &state.scope,
+                        )
+                    },
+                )
+                .await;
+            if result.is_err() {
+                self.restore_runner_lease_after_failed_transition(previous, TurnStatus::Completed)
+                    .await;
+            }
+            self.cleanup_runner_lease_after_state(&result).await;
+            result
+        }
+        .instrument(span)
+        .await
+    }
+
+    async fn cancel_run(
+        &self,
+        request: CancelRunCompletionRequest,
+    ) -> Result<TurnRunState, TurnError> {
+        let max_terminal_records = self.limits.max_terminal_records;
+        self.apply_run_state_transition_with_targeted_delta(
+            "cancel_run",
+            RunStateTransitionTarget {
+                run_id: request.run_id,
+                runner_id: request.runner_id,
+                lease_token: request.lease_token,
+                retired_status: TurnStatus::Cancelled,
+            },
+            |store| {
+                let request = request.clone();
+                async move { store.cancel_run(request).await }
+            },
+            move |snapshot, latest_event_cursor, store, state| {
+                let terminal_records = snapshot
+                    .runs
+                    .iter()
+                    .filter(|record| record.status.is_terminal())
+                    .count();
+                if terminal_records >= max_terminal_records {
+                    return full_snapshot_delta(snapshot, store);
+                }
+                run_state_targeted_delta(
+                    snapshot,
+                    latest_event_cursor,
+                    store,
+                    state.run_id,
+                    &state.scope,
+                )
+            },
+        )
+        .await
+    }
+
+    async fn fail_run(&self, request: FailRunRequest) -> Result<TurnRunState, TurnError> {
+        self.apply_run_state_transition(
+            "fail_run",
+            request.run_id,
+            request.runner_id,
+            request.lease_token,
+            TurnStatus::Failed,
+            |store| {
+                let request = request.clone();
+                async move { store.fail_run(request).await }
+            },
+        )
+        .await
+    }
+
+    async fn record_runner_failure(
+        &self,
+        request: RecordRunnerFailureRequest,
+    ) -> Result<TurnRunState, TurnError> {
+        self.apply_run_state_transition(
+            "record_runner_failure",
+            request.run_id,
+            request.runner_id,
+            request.lease_token,
+            TurnStatus::Failed,
+            |store| {
+                let request = request.clone();
+                async move { store.record_runner_failure(request).await }
+            },
+        )
+        .await
+    }
+
+    async fn relinquish_run(
+        &self,
+        request: RelinquishRunRequest,
+    ) -> Result<TurnRunState, TurnError> {
+        self.apply_run_state_transition(
+            "relinquish_run",
+            request.run_id,
+            request.runner_id,
+            request.lease_token,
+            TurnStatus::Queued,
+            |store| {
+                let request = request.clone();
+                async move { store.relinquish_run(request).await }
+            },
+        )
+        .await
+    }
+
+    async fn apply_validated_loop_exit(
+        &self,
+        request: ApplyValidatedLoopExitRequest,
+    ) -> Result<TurnRunState, TurnError> {
+        self.apply_run_state_transition(
+            "apply_validated_loop_exit",
+            request.run_id,
+            request.runner_id,
+            request.lease_token,
+            retired_status_for_loop_exit(&request.mapping),
+            |store| {
+                let request = request.clone();
+                async move { store.apply_validated_loop_exit(request).await }
+            },
+        )
+        .await
+    }
+}
+
+fn retired_status_for_loop_exit(mapping: &crate::LoopExitMapping) -> TurnStatus {
+    match mapping {
+        crate::LoopExitMapping::RunnerOutcome(TurnRunnerOutcome::Completed) => {
+            TurnStatus::Completed
+        }
+        crate::LoopExitMapping::RunnerOutcome(TurnRunnerOutcome::Cancelled) => {
+            TurnStatus::Cancelled
+        }
+        crate::LoopExitMapping::RunnerOutcome(TurnRunnerOutcome::Blocked { reason, .. }) => {
+            reason.status()
+        }
+        crate::LoopExitMapping::RunnerOutcome(TurnRunnerOutcome::Failed { .. })
+        | crate::LoopExitMapping::RecoveryRequired { .. } => TurnStatus::Failed,
+    }
+}

--- a/crates/ironclaw_turns/src/filesystem_store/runner_lease.rs
+++ b/crates/ironclaw_turns/src/filesystem_store/runner_lease.rs
@@ -68,6 +68,17 @@ impl RunnerLeaseStore {
         }
     }
 
+    pub(super) async fn overlay_run_record(
+        &self,
+        run: TurnRunRecord,
+    ) -> Result<TurnRunRecord, TurnError> {
+        self.with_timeout(
+            self.overlay_run_record_inner(run),
+            "overlay run record lease",
+        )
+        .await
+    }
+
     pub(super) async fn seed_from_snapshot(
         &self,
         snapshot: &TurnPersistenceSnapshot,
@@ -76,6 +87,14 @@ impl RunnerLeaseStore {
         self.with_timeout(
             self.seed_from_snapshot_inner(snapshot, run_id),
             "seed runner lease",
+        )
+        .await
+    }
+
+    pub(super) async fn seed_from_run_record(&self, run: TurnRunRecord) -> Result<(), TurnError> {
+        self.with_timeout(
+            self.seed_from_run_record_inner(run),
+            "seed runner lease from run record",
         )
         .await
     }
@@ -249,6 +268,20 @@ impl RunnerLeaseStore {
         Ok((snapshot, version))
     }
 
+    async fn overlay_run_record_inner(
+        &self,
+        mut run: TurnRunRecord,
+    ) -> Result<TurnRunRecord, TurnError> {
+        if !run_can_use_external_lease(&run) {
+            return Ok(run);
+        }
+        let leases = self.leases.read().await;
+        if let Some(lease) = leases.get(&run.run_id) {
+            apply_runner_lease_overlay(&mut run, lease);
+        }
+        Ok(run)
+    }
+
     async fn seed_from_snapshot_inner(
         &self,
         snapshot: &TurnPersistenceSnapshot,
@@ -258,6 +291,16 @@ impl RunnerLeaseStore {
             return Err(TurnError::ScopeNotFound);
         };
         let Some(record) = runner_lease_from_run(run) else {
+            return Err(TurnError::InvalidTransition {
+                from: run.status,
+                to: TurnStatus::Running,
+            });
+        };
+        self.upsert(record).await
+    }
+
+    async fn seed_from_run_record_inner(&self, run: TurnRunRecord) -> Result<(), TurnError> {
+        let Some(record) = runner_lease_from_run(&run) else {
             return Err(TurnError::InvalidTransition {
                 from: run.status,
                 to: TurnStatus::Running,
@@ -506,6 +549,48 @@ mod tests {
             .cloned()
             .expect("existing lease");
         assert_eq!(stored, existing);
+    }
+
+    #[tokio::test]
+    async fn seed_from_run_record_uses_exact_persisted_lease_metadata() {
+        let run_id = TurnRunId::new();
+        let runner_id = TurnRunnerId::new();
+        let lease_token = TurnLeaseToken::new();
+        let now = Utc::now();
+        let lease_expires_at = now + chrono::Duration::minutes(2);
+        let last_heartbeat_at = now + chrono::Duration::seconds(7);
+        let event_cursor = EventCursor(7);
+        let run = turn_run_record(
+            run_id,
+            runner_id,
+            lease_token,
+            TurnStatus::Running,
+            lease_expires_at,
+            last_heartbeat_at,
+            event_cursor,
+        );
+        let store = RunnerLeaseStore::new(
+            Arc::new(RwLock::new(HashMap::new())),
+            chrono::Duration::minutes(1),
+            Duration::from_secs(1),
+        );
+
+        store.seed_from_run_record(run).await.unwrap();
+
+        let stored = store
+            .leases
+            .read()
+            .await
+            .get(&run_id)
+            .cloned()
+            .expect("seeded lease");
+        assert_eq!(stored.run_id, run_id);
+        assert_eq!(stored.runner_id, runner_id);
+        assert_eq!(stored.lease_token, lease_token);
+        assert_eq!(stored.lease_expires_at, lease_expires_at);
+        assert_eq!(stored.last_heartbeat_at, last_heartbeat_at);
+        assert_eq!(stored.status, TurnStatus::Running);
+        assert_eq!(stored.event_cursor, event_cursor);
     }
 
     fn turn_run_record(

--- a/crates/ironclaw_turns/src/lib.rs
+++ b/crates/ironclaw_turns/src/lib.rs
@@ -58,7 +58,10 @@ pub use external_tool_catalog::{
     ExternalToolCatalog, ExternalToolCatalogError, ExternalToolSpec, ExternalToolSpecError,
     InMemoryExternalToolCatalog, PendingExternalCall,
 };
-pub use filesystem_store::{FilesystemTurnStateBlockPersistence, FilesystemTurnStateStore};
+pub use filesystem_store::{
+    FilesystemTurnStateBlockPersistence, FilesystemTurnStateRowStore, FilesystemTurnStateStore,
+    FilesystemTurnStateStoreKind,
+};
 pub use ids::{
     AcceptedMessageRef, CapabilityActivityId, GateRef, IdempotencyKey, LoopDiagnosticRef,
     LoopExitId, LoopGateRef, LoopMessageRef, LoopResultRef, LoopUsageSummaryRef,

--- a/crates/ironclaw_turns/src/memory/mod.rs
+++ b/crates/ironclaw_turns/src/memory/mod.rs
@@ -2015,6 +2015,10 @@ impl Inner {
         let mut records = HashMap::new();
         let mut queued_runs = VecDeque::new();
         let mut terminal_runs = VecDeque::new();
+        let mut active_locks = HashMap::new();
+        for lock in snapshot.active_locks {
+            active_locks.insert(lock.key.clone(), lock);
+        }
         for run in snapshot.runs {
             cursor = cursor.max(run.event_cursor.0);
             let actor = turns
@@ -2023,7 +2027,10 @@ impl Inner {
                 .ok_or_else(|| TurnError::Unavailable {
                     reason: "turn run references missing turn record".to_string(),
                 })?;
-            if run.status == TurnStatus::Queued {
+            let has_non_queued_active_lock = active_locks
+                .values()
+                .any(|lock| lock.run_id == run.run_id && lock.status != TurnStatus::Queued);
+            if run.status == TurnStatus::Queued && !has_non_queued_active_lock {
                 queued_runs.push_back(run.run_id);
             }
             if run.status.is_terminal() {
@@ -2061,11 +2068,6 @@ impl Inner {
                     resume_disposition: run.resume_disposition,
                 },
             );
-        }
-
-        let mut active_locks = HashMap::new();
-        for lock in snapshot.active_locks {
-            active_locks.insert(lock.key.clone(), lock);
         }
 
         let mut submit_idempotency = HashMap::new();

--- a/crates/ironclaw_turns/src/memory/mod.rs
+++ b/crates/ironclaw_turns/src/memory/mod.rs
@@ -1,3 +1,4 @@
+// arch-exempt: large_file, in-memory turn state decomposition, plan #5662
 use async_trait::async_trait;
 use std::{
     collections::{HashMap, HashSet, VecDeque},
@@ -427,6 +428,166 @@ impl InMemoryTurnStateStore {
         match self.inner.lock() {
             Ok(inner) => inner.events.clone(),
             Err(poisoned) => poisoned.into_inner().events.clone(),
+        }
+    }
+
+    pub(crate) fn events_after(&self, cursor: EventCursor) -> Vec<TurnLifecycleEvent> {
+        match self.inner.lock() {
+            Ok(inner) => inner
+                .events
+                .iter()
+                .filter(|event| event.cursor > cursor)
+                .cloned()
+                .collect(),
+            Err(poisoned) => poisoned
+                .into_inner()
+                .events
+                .iter()
+                .filter(|event| event.cursor > cursor)
+                .cloned()
+                .collect(),
+        }
+    }
+
+    pub(crate) fn event_retention_floor(&self) -> EventCursor {
+        match self.inner.lock() {
+            Ok(inner) => inner.event_retention_floor,
+            Err(poisoned) => poisoned.into_inner().event_retention_floor,
+        }
+    }
+
+    pub(crate) fn turn_record(&self, turn_id: crate::TurnId) -> Option<TurnRecord> {
+        match self.inner.lock() {
+            Ok(inner) => inner.turns.get(&turn_id).cloned(),
+            Err(poisoned) => poisoned.into_inner().turns.get(&turn_id).cloned(),
+        }
+    }
+
+    pub(crate) fn run_record(&self, run_id: TurnRunId) -> Option<TurnRunRecord> {
+        match self.inner.lock() {
+            Ok(inner) => inner
+                .records
+                .get(&run_id)
+                .map(RunRecord::persistence_record),
+            Err(poisoned) => poisoned
+                .into_inner()
+                .records
+                .get(&run_id)
+                .map(RunRecord::persistence_record),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn overlay_runner_lease_record(
+        &self,
+        overlaid: TurnRunRecord,
+    ) -> Result<(), TurnError> {
+        let mut inner = self.lock_inner()?;
+        let Some(record) = inner.records.get_mut(&overlaid.run_id) else {
+            return Err(TurnError::ScopeNotFound);
+        };
+        if !matches!(
+            record.status.get(),
+            TurnStatus::Running | TurnStatus::CancelRequested
+        ) || record.runner_id != overlaid.runner_id
+            || record.lease_token != overlaid.lease_token
+            || record.runner_id.is_none()
+            || record.lease_token.is_none()
+        {
+            return Ok(());
+        }
+        if let (Some(current), Some(incoming)) =
+            (record.last_heartbeat_at, overlaid.last_heartbeat_at)
+            && incoming < current
+        {
+            return Ok(());
+        }
+        record.last_heartbeat_at = overlaid.last_heartbeat_at;
+        record.lease_expires_at = overlaid.lease_expires_at;
+        Ok(())
+    }
+
+    pub(crate) fn active_lock_record(&self, scope: &TurnScope) -> Option<TurnActiveLockRecord> {
+        let key = TurnActiveLockKey::from(scope);
+        match self.inner.lock() {
+            Ok(inner) => inner.active_locks.get(&key).cloned(),
+            Err(poisoned) => poisoned.into_inner().active_locks.get(&key).cloned(),
+        }
+    }
+
+    pub(crate) fn admission_reservation(
+        &self,
+        run_id: TurnRunId,
+    ) -> Option<TurnAdmissionReservationRecord> {
+        match self.inner.lock() {
+            Ok(inner) => inner.admission_reservations.get(&run_id).cloned(),
+            Err(poisoned) => poisoned
+                .into_inner()
+                .admission_reservations
+                .get(&run_id)
+                .cloned(),
+        }
+    }
+
+    pub(crate) fn checkpoint_record(
+        &self,
+        checkpoint_id: TurnCheckpointId,
+    ) -> Option<TurnCheckpointRecord> {
+        match self.inner.lock() {
+            Ok(inner) => inner
+                .checkpoints
+                .iter()
+                .find(|record| record.checkpoint_id == checkpoint_id)
+                .cloned(),
+            Err(poisoned) => poisoned
+                .into_inner()
+                .checkpoints
+                .iter()
+                .find(|record| record.checkpoint_id == checkpoint_id)
+                .cloned(),
+        }
+    }
+
+    pub(crate) fn idempotency_records_after(
+        &self,
+        created_at: crate::TurnTimestamp,
+    ) -> Vec<TurnIdempotencyRecord> {
+        match self.inner.lock() {
+            Ok(inner) => inner
+                .idempotency_records
+                .values()
+                .filter(|record| record.created_at >= created_at)
+                .cloned()
+                .collect(),
+            Err(poisoned) => poisoned
+                .into_inner()
+                .idempotency_records
+                .values()
+                .filter(|record| record.created_at >= created_at)
+                .cloned()
+                .collect(),
+        }
+    }
+
+    pub(crate) fn idempotency_records_for_run_operation(
+        &self,
+        run_id: TurnRunId,
+        operation: TurnIdempotencyOperationKind,
+    ) -> Vec<TurnIdempotencyRecord> {
+        match self.inner.lock() {
+            Ok(inner) => inner
+                .idempotency_records
+                .values()
+                .filter(|record| record.run_id == Some(run_id) && record.operation == operation)
+                .cloned()
+                .collect(),
+            Err(poisoned) => poisoned
+                .into_inner()
+                .idempotency_records
+                .values()
+                .filter(|record| record.run_id == Some(run_id) && record.operation == operation)
+                .cloned()
+                .collect(),
         }
     }
 
@@ -3052,7 +3213,16 @@ impl Inner {
                     .keys()
                     .any(|reservation| reservation.root_run_id == run_id)
             {
-                self.records.remove(&run_id);
+                if let Some(record) = self.records.remove(&run_id) {
+                    let turn_id = record.turn_id;
+                    if !self
+                        .records
+                        .values()
+                        .any(|record| record.turn_id == turn_id)
+                    {
+                        self.turns.remove(&turn_id);
+                    }
+                }
                 self.admission_reservations.remove(&run_id);
             }
         }
@@ -3340,4 +3510,187 @@ where
         order.pop_front();
     }
     removed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        AllowAllTurnAdmissionPolicy, ResolvedRunProfile, RunProfileId, RunProfileVersion,
+        TurnLeaseToken, TurnRunnerId,
+    };
+    use async_trait::async_trait;
+    use ironclaw_host_api::{AgentId, ProjectId, ThreadId};
+
+    struct TestRunProfileResolver;
+
+    #[async_trait]
+    impl RunProfileResolver for TestRunProfileResolver {
+        async fn resolve_run_profile(
+            &self,
+            _request: RunProfileResolutionRequest,
+        ) -> Result<ResolvedRunProfile, RunProfileResolutionError> {
+            Ok(ResolvedRunProfile::legacy_compatibility(
+                RunProfileId::default_profile(),
+                RunProfileVersion::new(1),
+                false,
+            ))
+        }
+    }
+
+    #[tokio::test]
+    async fn terminal_pruning_removes_orphaned_turn_records() {
+        let limits = InMemoryTurnStateStoreLimits {
+            max_terminal_records: 1,
+            ..InMemoryTurnStateStoreLimits::default()
+        };
+        let store = InMemoryTurnStateStore::with_limits(limits);
+        let policy = AllowAllTurnAdmissionPolicy;
+        let resolver = TestRunProfileResolver;
+        let scope = TurnScope::new(
+            TenantId::new("tenant-turn-prune").unwrap(),
+            Some(AgentId::new("agent-turn-prune").unwrap()),
+            Some(ProjectId::new("project-turn-prune").unwrap()),
+            ThreadId::new("thread-turn-prune").unwrap(),
+        );
+
+        for index in 0..2 {
+            let response = store
+                .submit_turn(
+                    SubmitTurnRequest {
+                        scope: scope.clone(),
+                        actor: TurnActor::new(UserId::new(format!("user-{index}")).unwrap()),
+                        accepted_message_ref: AcceptedMessageRef::new(format!("accepted-{index}"))
+                            .unwrap(),
+                        source_binding_ref: SourceBindingRef::new(format!("source-{index}"))
+                            .unwrap(),
+                        reply_target_binding_ref: ReplyTargetBindingRef::new(format!(
+                            "reply-{index}"
+                        ))
+                        .unwrap(),
+                        idempotency_key: IdempotencyKey::new(format!("submit-{index}")).unwrap(),
+                        requested_run_profile: None,
+                        requested_run_id: None,
+                        received_at: Utc::now(),
+                        parent_run_id: None,
+                        subagent_depth: 0,
+                        spawn_tree_root_run_id: None,
+                        product_context: None,
+                    },
+                    &policy,
+                    &resolver,
+                )
+                .await
+                .unwrap();
+            let SubmitTurnResponse::Accepted { run_id, .. } = response;
+            let runner_id = TurnRunnerId::new();
+            let lease_token = TurnLeaseToken::new();
+            let claimed = store
+                .claim_next_run(ClaimRunRequest {
+                    runner_id,
+                    lease_token,
+                    scope_filter: Some(scope.clone()),
+                })
+                .await
+                .unwrap()
+                .expect("submitted run should be claimable");
+            assert_eq!(claimed.state.run_id, run_id);
+            store
+                .complete_run(CompleteRunRequest {
+                    run_id,
+                    runner_id,
+                    lease_token,
+                })
+                .await
+                .unwrap();
+        }
+
+        let snapshot = store.persistence_snapshot();
+        assert_eq!(
+            snapshot.runs.len(),
+            1,
+            "terminal run retention cap should prune old terminal runs"
+        );
+        assert_eq!(
+            snapshot.turns.len(),
+            1,
+            "pruning a terminal run must also prune its orphaned turn record"
+        );
+        assert_eq!(
+            snapshot.turns[0].turn_id, snapshot.runs[0].turn_id,
+            "remaining turn record should belong to the retained run"
+        );
+    }
+
+    #[tokio::test]
+    async fn overlay_runner_lease_record_ignores_stale_heartbeat() {
+        let store = InMemoryTurnStateStore::default();
+        let policy = AllowAllTurnAdmissionPolicy;
+        let resolver = TestRunProfileResolver;
+        let scope = TurnScope::new(
+            TenantId::new("tenant-lease-overlay").unwrap(),
+            Some(AgentId::new("agent-lease-overlay").unwrap()),
+            Some(ProjectId::new("project-lease-overlay").unwrap()),
+            ThreadId::new("thread-lease-overlay").unwrap(),
+        );
+        let response = store
+            .submit_turn(
+                SubmitTurnRequest {
+                    scope: scope.clone(),
+                    actor: TurnActor::new(UserId::new("user-lease-overlay").unwrap()),
+                    accepted_message_ref: AcceptedMessageRef::new("accepted-lease-overlay")
+                        .unwrap(),
+                    source_binding_ref: SourceBindingRef::new("source-lease-overlay").unwrap(),
+                    reply_target_binding_ref: ReplyTargetBindingRef::new("reply-lease-overlay")
+                        .unwrap(),
+                    idempotency_key: IdempotencyKey::new("submit-lease-overlay").unwrap(),
+                    requested_run_profile: None,
+                    requested_run_id: None,
+                    received_at: Utc::now(),
+                    parent_run_id: None,
+                    subagent_depth: 0,
+                    spawn_tree_root_run_id: None,
+                    product_context: None,
+                },
+                &policy,
+                &resolver,
+            )
+            .await
+            .unwrap();
+        let SubmitTurnResponse::Accepted { run_id, .. } = response;
+        store
+            .claim_next_run(ClaimRunRequest {
+                runner_id: TurnRunnerId::new(),
+                lease_token: TurnLeaseToken::new(),
+                scope_filter: Some(scope),
+            })
+            .await
+            .unwrap()
+            .expect("submitted run should be claimable");
+        let original = store.run_record(run_id).expect("claimed run record");
+        let original_heartbeat = original
+            .last_heartbeat_at
+            .expect("claimed run has heartbeat timestamp");
+        let original_expiry = original
+            .lease_expires_at
+            .expect("claimed run has lease expiry");
+
+        let mut stale = original.clone();
+        stale.last_heartbeat_at = Some(original_heartbeat - ChronoDuration::seconds(1));
+        stale.lease_expires_at = Some(original_expiry - ChronoDuration::seconds(1));
+        store.overlay_runner_lease_record(stale).unwrap();
+        let after_stale = store.run_record(run_id).expect("claimed run record");
+        assert_eq!(after_stale.last_heartbeat_at, Some(original_heartbeat));
+        assert_eq!(after_stale.lease_expires_at, Some(original_expiry));
+
+        let mut newer = original.clone();
+        let newer_heartbeat = original_heartbeat + ChronoDuration::seconds(1);
+        let newer_expiry = original_expiry + ChronoDuration::seconds(1);
+        newer.last_heartbeat_at = Some(newer_heartbeat);
+        newer.lease_expires_at = Some(newer_expiry);
+        store.overlay_runner_lease_record(newer).unwrap();
+        let after_newer = store.run_record(run_id).expect("claimed run record");
+        assert_eq!(after_newer.last_heartbeat_at, Some(newer_heartbeat));
+        assert_eq!(after_newer.lease_expires_at, Some(newer_expiry));
+    }
 }

--- a/crates/ironclaw_turns/tests/filesystem_turn_state_contract.rs
+++ b/crates/ironclaw_turns/tests/filesystem_turn_state_contract.rs
@@ -1,3 +1,4 @@
+// arch-exempt: large_file, filesystem turn-state contract suite decomposition, plan #5662
 //! Contract tests for [`FilesystemTurnStateStore`] against a
 //! [`ScopedFilesystem`] over a CAS-capable filesystem backend. The persistent
 //! shape is a lower-churn `/turns/state.json` snapshot; active runner leases
@@ -5,7 +6,7 @@
 
 use std::{
     sync::{
-        Arc,
+        Arc, Condvar, Mutex as StdMutex,
         atomic::{AtomicBool, AtomicUsize, Ordering},
     },
     time::Duration,
@@ -17,22 +18,28 @@ use ironclaw_filesystem::{
     BackendCapabilities, BackendId, BackendKind, CasExpectation, CompositeRootFilesystem,
     ContentKind, DirEntry, Entry, FileStat, FilesystemError, FilesystemOperation, InMemoryBackend,
     IndexPolicy, LocalFilesystem, MountDescriptor, RecordVersion, RootFilesystem, ScopedFilesystem,
-    StorageClass, VersionedEntry,
+    SeqNo, StorageClass, VersionedEntry,
 };
 use ironclaw_host_api::{
     AgentId, HostPath, MountAlias, MountGrant, MountPermissions, MountView, ProjectId, ScopedPath,
     TenantId, ThreadId, UserId, VirtualPath,
 };
 use ironclaw_turns::{
-    AcceptedMessageRef, AllowAllTurnAdmissionPolicy, FilesystemTurnStateStore, GetRunStateRequest,
-    IdempotencyKey, InMemoryRunProfileResolver, ProductTurnContext, ReplyTargetBindingRef,
-    RunOriginAdapter, RunProfileRequest, SanitizedCancelReason, SourceBindingRef,
-    SubmitChildRunRequest, SubmitTurnRequest, SubmitTurnResponse, TurnActor, TurnError,
-    TurnLeaseToken, TurnOriginKind, TurnOwner, TurnPersistenceSnapshot, TurnRunId, TurnRunnerId,
-    TurnScope, TurnSpawnTreeStateStore, TurnStateStore, TurnStatus,
+    AcceptedMessageRef, AdmissionRejection, AllowAllTurnAdmissionPolicy, BlockedReason,
+    CheckpointSchemaId, FilesystemTurnStateRowStore, FilesystemTurnStateStore, GateRef,
+    GetLoopCheckpointRequest, GetRunStateRequest, IdempotencyKey, InMemoryRunProfileResolver,
+    InMemoryTurnStateStoreLimits, LoopCheckpointStore, ProductTurnContext,
+    PutLoopCheckpointRequest, ReplyTargetBindingRef, ResumeTurnPrecondition, ResumeTurnRequest,
+    RunOriginAdapter, RunProfileRequest, RunProfileVersion, SanitizedCancelReason,
+    SanitizedFailure, SourceBindingRef, SubmitChildRunRequest, SubmitTurnRequest,
+    SubmitTurnResponse, TurnActor, TurnAdmissionPolicy, TurnCheckpointId, TurnError, TurnEventKind,
+    TurnEventProjectionSource, TurnId, TurnLeaseToken, TurnOriginKind, TurnOwner,
+    TurnPersistenceSnapshot, TurnRunId, TurnRunnerId, TurnScope, TurnSpawnTreeStateStore,
+    TurnStateStore, TurnStatus,
+    run_profile::{LoopCheckpointKind, LoopCheckpointStateRef},
     runner::{
-        ClaimRunRequest, CompleteRunRequest, HeartbeatRequest, RecoverExpiredLeasesRequest,
-        TurnRunTransitionPort,
+        BlockRunRequest, ClaimRunRequest, CompleteRunRequest, FailRunRequest, HeartbeatRequest,
+        RecoverExpiredLeasesRequest, TurnRunTransitionPort,
     },
 };
 
@@ -131,6 +138,35 @@ impl RootFilesystem for CountingFilesystem {
     async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
         self.inner.delete(path).await
     }
+
+    async fn append(&self, path: &VirtualPath, payload: Vec<u8>) -> Result<SeqNo, FilesystemError> {
+        self.inner.append(path, payload).await
+    }
+
+    async fn append_batch(
+        &self,
+        path: &VirtualPath,
+        payloads: Vec<Vec<u8>>,
+    ) -> Result<Vec<SeqNo>, FilesystemError> {
+        self.inner.append_batch(path, payloads).await
+    }
+
+    async fn tail(
+        &self,
+        path: &VirtualPath,
+        from: SeqNo,
+    ) -> Result<Vec<ironclaw_filesystem::EventRecord>, FilesystemError> {
+        self.inner.tail(path, from).await
+    }
+
+    async fn tail_bounded(
+        &self,
+        path: &VirtualPath,
+        from: SeqNo,
+        max_records: usize,
+    ) -> Result<Vec<ironclaw_filesystem::EventRecord>, FilesystemError> {
+        self.inner.tail_bounded(path, from, max_records).await
+    }
 }
 
 /// Wrap a [`RootFilesystem`] in a [`ScopedFilesystem`] that exposes the
@@ -164,6 +200,53 @@ where
     scoped_turns_fs_at(backend, "test-tenant", "test-user")
 }
 
+async fn retry_get_run_state<F>(
+    store: &FilesystemTurnStateRowStore<F>,
+    scope: TurnScope,
+    run_id: TurnRunId,
+) -> ironclaw_turns::TurnRunState
+where
+    F: RootFilesystem,
+{
+    let mut last_error = None;
+    for _ in 0..8 {
+        match store
+            .get_run_state(GetRunStateRequest {
+                scope: scope.clone(),
+                run_id,
+            })
+            .await
+        {
+            Ok(state) => return state,
+            Err(error) => {
+                last_error = Some(error);
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        }
+    }
+    panic!("run state replay did not recover after materialization retry: {last_error:?}");
+}
+
+async fn retry_read_turn_events<F>(
+    store: &FilesystemTurnStateRowStore<F>,
+    scope: &TurnScope,
+) -> ironclaw_turns::TurnEventPage
+where
+    F: RootFilesystem,
+{
+    let mut last_error = None;
+    for _ in 0..8 {
+        match store.read_turn_events_after(scope, None, None, 100).await {
+            Ok(events) => return events,
+            Err(error) => {
+                last_error = Some(error);
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        }
+    }
+    panic!("event replay did not recover after materialization retry: {last_error:?}");
+}
+
 fn snapshot_virtual_path() -> VirtualPath {
     VirtualPath::new("/engine/tenants/test-tenant/users/test-user/turns/state.json").unwrap()
 }
@@ -171,6 +254,18 @@ fn snapshot_virtual_path() -> VirtualPath {
 fn runner_lease_virtual_path(run_id: TurnRunId) -> VirtualPath {
     VirtualPath::new(format!(
         "/engine/tenants/test-tenant/users/test-user/turns/runner-leases/{run_id}.json"
+    ))
+    .unwrap()
+}
+
+fn row_delta_log_virtual_path() -> VirtualPath {
+    VirtualPath::new("/engine/tenants/test-tenant/users/test-user/turns/rows/v1/deltas/log")
+        .unwrap()
+}
+
+fn row_run_virtual_path(run_id: TurnRunId) -> VirtualPath {
+    VirtualPath::new(format!(
+        "/engine/tenants/test-tenant/users/test-user/turns/rows/v1/runs/{run_id}.json"
     ))
     .unwrap()
 }
@@ -239,6 +334,49 @@ impl<F> BlockingPutFilesystem<F> {
     }
 }
 
+struct BlockingAppendFilesystem<F> {
+    inner: F,
+    block_next_append: AtomicBool,
+    append_blocked: AtomicBool,
+    append_started: tokio::sync::Notify,
+    release_append: tokio::sync::Notify,
+}
+
+impl<F> BlockingAppendFilesystem<F> {
+    fn new(inner: F) -> Self {
+        Self {
+            inner,
+            block_next_append: AtomicBool::new(false),
+            append_blocked: AtomicBool::new(false),
+            append_started: tokio::sync::Notify::new(),
+            release_append: tokio::sync::Notify::new(),
+        }
+    }
+
+    fn block_next_append(&self) {
+        self.block_next_append.store(true, Ordering::SeqCst);
+    }
+
+    async fn wait_for_blocked_append(&self) {
+        while !self.append_blocked.load(Ordering::SeqCst) {
+            self.append_started.notified().await;
+        }
+    }
+
+    fn release_blocked_append(&self) {
+        self.release_append.notify_one();
+    }
+
+    async fn maybe_block_append(&self) {
+        if self.block_next_append.swap(false, Ordering::SeqCst) {
+            self.append_blocked.store(true, Ordering::SeqCst);
+            self.append_started.notify_one();
+            self.release_append.notified().await;
+            self.append_blocked.store(false, Ordering::SeqCst);
+        }
+    }
+}
+
 struct BlockingSnapshotPutFilesystem<F> {
     inner: F,
     block_snapshot_puts: AtomicBool,
@@ -289,6 +427,61 @@ impl<F> RejectSnapshotGetFilesystem<F> {
 
     fn reject_snapshot_gets(&self) {
         self.reject_snapshot_gets.store(true, Ordering::SeqCst);
+    }
+}
+
+struct BlockingAdmissionPolicy {
+    state: StdMutex<BlockingAdmissionState>,
+    entered: Condvar,
+    released: Condvar,
+}
+
+struct BlockingAdmissionState {
+    entered: bool,
+    released: bool,
+}
+
+impl BlockingAdmissionPolicy {
+    fn new() -> Self {
+        Self {
+            state: StdMutex::new(BlockingAdmissionState {
+                entered: false,
+                released: false,
+            }),
+            entered: Condvar::new(),
+            released: Condvar::new(),
+        }
+    }
+
+    fn wait_until_entered(&self) {
+        let mut state = self.state.lock().expect("blocking admission mutex");
+        while !state.entered {
+            state = self
+                .entered
+                .wait(state)
+                .expect("blocking admission condvar");
+        }
+    }
+
+    fn release(&self) {
+        let mut state = self.state.lock().expect("blocking admission mutex");
+        state.released = true;
+        self.released.notify_all();
+    }
+}
+
+impl TurnAdmissionPolicy for BlockingAdmissionPolicy {
+    fn check_submit(&self, _request: &SubmitTurnRequest) -> Result<(), AdmissionRejection> {
+        let mut state = self.state.lock().expect("blocking admission mutex");
+        state.entered = true;
+        self.entered.notify_all();
+        while !state.released {
+            state = self
+                .released
+                .wait(state)
+                .expect("blocking admission condvar");
+        }
+        Ok(())
     }
 }
 
@@ -371,6 +564,16 @@ struct RejectingPutFilesystem<F> {
     put_calls: AtomicUsize,
 }
 
+struct RejectingAppendFilesystem<F> {
+    inner: F,
+    append_calls: AtomicUsize,
+}
+
+struct FailOncePutFilesystem<F> {
+    inner: F,
+    fail_next_put: AtomicBool,
+}
+
 impl<F> RejectingPutFilesystem<F> {
     fn new(inner: F) -> Self {
         Self {
@@ -381,6 +584,28 @@ impl<F> RejectingPutFilesystem<F> {
 
     fn put_calls(&self) -> usize {
         self.put_calls.load(Ordering::SeqCst)
+    }
+}
+
+impl<F> RejectingAppendFilesystem<F> {
+    fn new(inner: F) -> Self {
+        Self {
+            inner,
+            append_calls: AtomicUsize::new(0),
+        }
+    }
+
+    fn append_calls(&self) -> usize {
+        self.append_calls.load(Ordering::SeqCst)
+    }
+}
+
+impl<F> FailOncePutFilesystem<F> {
+    fn new(inner: F) -> Self {
+        Self {
+            inner,
+            fail_next_put: AtomicBool::new(true),
+        }
     }
 }
 
@@ -420,6 +645,181 @@ where
 
     async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
         self.inner.delete(path).await
+    }
+
+    async fn append(&self, path: &VirtualPath, payload: Vec<u8>) -> Result<SeqNo, FilesystemError> {
+        self.inner.append(path, payload).await
+    }
+
+    async fn append_batch(
+        &self,
+        path: &VirtualPath,
+        payloads: Vec<Vec<u8>>,
+    ) -> Result<Vec<SeqNo>, FilesystemError> {
+        self.inner.append_batch(path, payloads).await
+    }
+
+    async fn tail(
+        &self,
+        path: &VirtualPath,
+        from: SeqNo,
+    ) -> Result<Vec<ironclaw_filesystem::EventRecord>, FilesystemError> {
+        self.inner.tail(path, from).await
+    }
+
+    async fn tail_bounded(
+        &self,
+        path: &VirtualPath,
+        from: SeqNo,
+        max_records: usize,
+    ) -> Result<Vec<ironclaw_filesystem::EventRecord>, FilesystemError> {
+        self.inner.tail_bounded(path, from, max_records).await
+    }
+}
+
+#[async_trait]
+impl<F> RootFilesystem for RejectingAppendFilesystem<F>
+where
+    F: RootFilesystem,
+{
+    fn capabilities(&self) -> BackendCapabilities {
+        self.inner.capabilities()
+    }
+
+    async fn put(
+        &self,
+        path: &VirtualPath,
+        entry: Entry,
+        cas: CasExpectation,
+    ) -> Result<RecordVersion, FilesystemError> {
+        self.inner.put(path, entry, cas).await
+    }
+
+    async fn get(&self, path: &VirtualPath) -> Result<Option<VersionedEntry>, FilesystemError> {
+        self.inner.get(path).await
+    }
+
+    async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
+        self.inner.list_dir(path).await
+    }
+
+    async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
+        self.inner.stat(path).await
+    }
+
+    async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
+        self.inner.delete(path).await
+    }
+
+    async fn append(
+        &self,
+        path: &VirtualPath,
+        _payload: Vec<u8>,
+    ) -> Result<SeqNo, FilesystemError> {
+        self.append_calls.fetch_add(1, Ordering::SeqCst);
+        Err(FilesystemError::PermissionDenied {
+            path: ScopedPath::new(path.as_str().to_string()).expect("scoped path"),
+            operation: FilesystemOperation::Append,
+        })
+    }
+
+    async fn append_batch(
+        &self,
+        path: &VirtualPath,
+        _payloads: Vec<Vec<u8>>,
+    ) -> Result<Vec<SeqNo>, FilesystemError> {
+        self.append_calls.fetch_add(1, Ordering::SeqCst);
+        Err(FilesystemError::PermissionDenied {
+            path: ScopedPath::new(path.as_str().to_string()).expect("scoped path"),
+            operation: FilesystemOperation::Append,
+        })
+    }
+
+    async fn tail(
+        &self,
+        path: &VirtualPath,
+        from: SeqNo,
+    ) -> Result<Vec<ironclaw_filesystem::EventRecord>, FilesystemError> {
+        self.inner.tail(path, from).await
+    }
+
+    async fn tail_bounded(
+        &self,
+        path: &VirtualPath,
+        from: SeqNo,
+        max_records: usize,
+    ) -> Result<Vec<ironclaw_filesystem::EventRecord>, FilesystemError> {
+        self.inner.tail_bounded(path, from, max_records).await
+    }
+}
+
+#[async_trait]
+impl<F> RootFilesystem for FailOncePutFilesystem<F>
+where
+    F: RootFilesystem,
+{
+    fn capabilities(&self) -> BackendCapabilities {
+        self.inner.capabilities()
+    }
+
+    async fn put(
+        &self,
+        path: &VirtualPath,
+        entry: Entry,
+        cas: CasExpectation,
+    ) -> Result<RecordVersion, FilesystemError> {
+        if self.fail_next_put.swap(false, Ordering::SeqCst) {
+            return Err(FilesystemError::PermissionDenied {
+                path: ScopedPath::new(path.as_str().to_string()).expect("scoped path"),
+                operation: FilesystemOperation::WriteFile,
+            });
+        }
+        self.inner.put(path, entry, cas).await
+    }
+
+    async fn get(&self, path: &VirtualPath) -> Result<Option<VersionedEntry>, FilesystemError> {
+        self.inner.get(path).await
+    }
+
+    async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
+        self.inner.list_dir(path).await
+    }
+
+    async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
+        self.inner.stat(path).await
+    }
+
+    async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
+        self.inner.delete(path).await
+    }
+
+    async fn append(&self, path: &VirtualPath, payload: Vec<u8>) -> Result<SeqNo, FilesystemError> {
+        self.inner.append(path, payload).await
+    }
+
+    async fn append_batch(
+        &self,
+        path: &VirtualPath,
+        payloads: Vec<Vec<u8>>,
+    ) -> Result<Vec<SeqNo>, FilesystemError> {
+        self.inner.append_batch(path, payloads).await
+    }
+
+    async fn tail(
+        &self,
+        path: &VirtualPath,
+        from: SeqNo,
+    ) -> Result<Vec<ironclaw_filesystem::EventRecord>, FilesystemError> {
+        self.inner.tail(path, from).await
+    }
+
+    async fn tail_bounded(
+        &self,
+        path: &VirtualPath,
+        from: SeqNo,
+        max_records: usize,
+    ) -> Result<Vec<ironclaw_filesystem::EventRecord>, FilesystemError> {
+        self.inner.tail_bounded(path, from, max_records).await
     }
 }
 
@@ -501,6 +901,105 @@ where
 
     async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
         self.inner.stat(path).await
+    }
+
+    async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
+        self.inner.delete(path).await
+    }
+
+    async fn append(&self, path: &VirtualPath, payload: Vec<u8>) -> Result<SeqNo, FilesystemError> {
+        self.inner.append(path, payload).await
+    }
+
+    async fn append_batch(
+        &self,
+        path: &VirtualPath,
+        payloads: Vec<Vec<u8>>,
+    ) -> Result<Vec<SeqNo>, FilesystemError> {
+        self.inner.append_batch(path, payloads).await
+    }
+
+    async fn tail(
+        &self,
+        path: &VirtualPath,
+        from: SeqNo,
+    ) -> Result<Vec<ironclaw_filesystem::EventRecord>, FilesystemError> {
+        self.inner.tail(path, from).await
+    }
+
+    async fn tail_bounded(
+        &self,
+        path: &VirtualPath,
+        from: SeqNo,
+        max_records: usize,
+    ) -> Result<Vec<ironclaw_filesystem::EventRecord>, FilesystemError> {
+        self.inner.tail_bounded(path, from, max_records).await
+    }
+}
+
+#[async_trait]
+impl<F> RootFilesystem for BlockingAppendFilesystem<F>
+where
+    F: RootFilesystem,
+{
+    fn capabilities(&self) -> BackendCapabilities {
+        self.inner.capabilities()
+    }
+
+    async fn put(
+        &self,
+        path: &VirtualPath,
+        entry: Entry,
+        cas: CasExpectation,
+    ) -> Result<RecordVersion, FilesystemError> {
+        self.inner.put(path, entry, cas).await
+    }
+
+    async fn get(&self, path: &VirtualPath) -> Result<Option<VersionedEntry>, FilesystemError> {
+        self.inner.get(path).await
+    }
+
+    async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
+        self.inner.list_dir(path).await
+    }
+
+    async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
+        self.inner.stat(path).await
+    }
+
+    async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
+        self.inner.delete(path).await
+    }
+
+    async fn append(&self, path: &VirtualPath, payload: Vec<u8>) -> Result<SeqNo, FilesystemError> {
+        self.maybe_block_append().await;
+        self.inner.append(path, payload).await
+    }
+
+    async fn append_batch(
+        &self,
+        path: &VirtualPath,
+        payloads: Vec<Vec<u8>>,
+    ) -> Result<Vec<SeqNo>, FilesystemError> {
+        self.maybe_block_append().await;
+        self.inner.append_batch(path, payloads).await
+    }
+
+    async fn tail(
+        &self,
+        path: &VirtualPath,
+        from: SeqNo,
+    ) -> Result<Vec<ironclaw_filesystem::EventRecord>, FilesystemError> {
+        self.inner.tail(path, from).await
+    }
+
+    async fn tail_bounded(
+        &self,
+        path: &VirtualPath,
+        from: SeqNo,
+        max_records: usize,
+    ) -> Result<Vec<ironclaw_filesystem::EventRecord>, FilesystemError> {
+        self.inner.tail_bounded(path, from, max_records).await
     }
 }
 
@@ -694,6 +1193,11 @@ fn accepted_run_id(response: &SubmitTurnResponse) -> TurnRunId {
     *run_id
 }
 
+fn accepted_turn_id(response: &SubmitTurnResponse) -> TurnId {
+    let SubmitTurnResponse::Accepted { turn_id, .. } = response;
+    *turn_id
+}
+
 #[tokio::test]
 async fn filesystem_turn_state_store_does_not_write_unchanged_idle_runner_snapshot() {
     let backend = Arc::new(engine_filesystem());
@@ -726,6 +1230,911 @@ async fn filesystem_turn_state_store_does_not_write_unchanged_idle_runner_snapsh
     assert!(
         matches!(err, FilesystemError::NotFound { .. }),
         "idle no-op runner polling must not create or rewrite the snapshot: {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn filesystem_turn_state_row_store_persists_rows_without_state_blob() {
+    let backend = Arc::new(engine_filesystem());
+    let scoped = scoped_turns_fs(Arc::clone(&backend));
+    let store = FilesystemTurnStateRowStore::new(Arc::clone(&scoped));
+    let resolver = InMemoryRunProfileResolver::default();
+
+    let request = submit_request_for(turn_scope("thread-fs-row-persist"), "idem-fs-row-persist");
+    let response = store
+        .submit_turn(request.clone(), &AllowAllTurnAdmissionPolicy, &resolver)
+        .await
+        .unwrap();
+    let run_id = accepted_run_id(&response);
+    let runner_id = TurnRunnerId::new();
+    let lease_token = TurnLeaseToken::new();
+    let claimed = store
+        .claim_next_run(ClaimRunRequest {
+            runner_id,
+            lease_token,
+            scope_filter: None,
+        })
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(claimed.state.status, TurnStatus::Running);
+    let checkpoint_id = TurnCheckpointId::new();
+    let gate_ref = GateRef::new("gate-fs-row-block").unwrap();
+    let blocked = store
+        .block_run(BlockRunRequest {
+            run_id,
+            runner_id,
+            lease_token,
+            checkpoint_id,
+            state_ref: LoopCheckpointStateRef::new("checkpoint:fs-row-block").unwrap(),
+            reason: BlockedReason::Approval {
+                gate_ref: gate_ref.clone(),
+            },
+        })
+        .await
+        .unwrap();
+    assert_eq!(blocked.status, TurnStatus::BlockedApproval);
+    assert_eq!(blocked.checkpoint_id, Some(checkpoint_id));
+
+    let reopened_blocked = FilesystemTurnStateRowStore::new(Arc::clone(&scoped));
+    let blocked_state = reopened_blocked
+        .get_run_state(GetRunStateRequest {
+            scope: request.scope.clone(),
+            run_id,
+        })
+        .await
+        .unwrap();
+    assert_eq!(blocked_state.status, TurnStatus::BlockedApproval);
+    let blocked_snapshot = reopened_blocked.persistence_snapshot().await.unwrap();
+    assert!(
+        blocked_snapshot
+            .checkpoints
+            .iter()
+            .any(|record| record.checkpoint_id == checkpoint_id),
+        "row store must persist block-created checkpoints as row deltas"
+    );
+
+    reopened_blocked
+        .resume_turn(ResumeTurnRequest {
+            scope: request.scope.clone(),
+            actor: turn_actor(),
+            run_id,
+            gate_resolution_ref: gate_ref,
+            source_binding_ref: SourceBindingRef::new("source-resume").unwrap(),
+            reply_target_binding_ref: ReplyTargetBindingRef::new("reply-resume").unwrap(),
+            idempotency_key: IdempotencyKey::new("idem-fs-row-resume").unwrap(),
+            precondition: ResumeTurnPrecondition::BlockedApprovalGate,
+            resume_disposition: None,
+        })
+        .await
+        .unwrap();
+    let resume_snapshot = reopened_blocked.persistence_snapshot().await.unwrap();
+    assert!(
+        resume_snapshot
+            .idempotency_records
+            .iter()
+            .any(|record| record.operation == ironclaw_turns::TurnIdempotencyOperationKind::Resume),
+        "row store must persist resume idempotency as a targeted delta"
+    );
+    let (runner_id, lease_token) = {
+        let runner_id = TurnRunnerId::new();
+        let lease_token = TurnLeaseToken::new();
+        reopened_blocked
+            .claim_next_run(ClaimRunRequest {
+                runner_id,
+                lease_token,
+                scope_filter: None,
+            })
+            .await
+            .unwrap()
+            .unwrap();
+        (runner_id, lease_token)
+    };
+    reopened_blocked
+        .complete_run(CompleteRunRequest {
+            run_id,
+            runner_id,
+            lease_token,
+        })
+        .await
+        .unwrap();
+
+    assert!(
+        backend
+            .get(&snapshot_virtual_path())
+            .await
+            .unwrap()
+            .is_none(),
+        "row store must not write the blob-shaped state.json snapshot"
+    );
+    assert!(
+        !backend
+            .tail(&row_delta_log_virtual_path(), SeqNo::ZERO)
+            .await
+            .unwrap()
+            .is_empty(),
+        "row store should persist typed transition deltas in the append log"
+    );
+
+    let reopened = FilesystemTurnStateRowStore::new(scoped);
+    let state = reopened
+        .get_run_state(GetRunStateRequest {
+            scope: request.scope,
+            run_id,
+        })
+        .await
+        .unwrap();
+    assert_eq!(state.status, TurnStatus::Completed);
+}
+
+#[tokio::test]
+async fn filesystem_turn_state_row_store_migrates_legacy_state_blob() {
+    let backend = Arc::new(engine_filesystem());
+    let scoped = scoped_turns_fs(Arc::clone(&backend));
+    let legacy_store = FilesystemTurnStateStore::new(Arc::clone(&scoped));
+    let resolver = InMemoryRunProfileResolver::default();
+    let scope = turn_scope("thread-fs-row-migrate-legacy");
+    let run_id = TurnRunId::new();
+    let mut request = submit_request_for(scope.clone(), "idem-fs-row-migrate-legacy");
+    request.requested_run_id = Some(run_id);
+
+    legacy_store
+        .submit_turn(request, &AllowAllTurnAdmissionPolicy, &resolver)
+        .await
+        .unwrap();
+    let legacy_snapshot = legacy_store.persistence_snapshot().await.unwrap();
+    assert!(
+        legacy_snapshot
+            .runs
+            .iter()
+            .any(|record| record.run_id == run_id),
+        "legacy blob fixture must contain the submitted run"
+    );
+    assert!(
+        backend
+            .get(&snapshot_virtual_path())
+            .await
+            .unwrap()
+            .is_some(),
+        "legacy store must write the blob-shaped state snapshot"
+    );
+
+    let row_store = FilesystemTurnStateRowStore::new(Arc::clone(&scoped));
+    let state = row_store
+        .get_run_state(GetRunStateRequest {
+            scope: scope.clone(),
+            run_id,
+        })
+        .await
+        .unwrap();
+    assert_eq!(state.status, TurnStatus::Queued);
+    assert!(
+        backend
+            .get(&row_run_virtual_path(run_id))
+            .await
+            .unwrap()
+            .is_some(),
+        "legacy snapshot migration must materialize a durable run row"
+    );
+    assert!(
+        !backend
+            .tail(&row_delta_log_virtual_path(), SeqNo::ZERO)
+            .await
+            .unwrap()
+            .is_empty(),
+        "legacy snapshot migration must enter through the delta journal"
+    );
+    assert!(
+        backend
+            .get(&snapshot_virtual_path())
+            .await
+            .unwrap()
+            .is_some(),
+        "migration keeps the legacy blob as rollback evidence"
+    );
+
+    let reopened = FilesystemTurnStateRowStore::new(scoped);
+    let reopened_state = reopened
+        .get_run_state(GetRunStateRequest {
+            scope: scope.clone(),
+            run_id,
+        })
+        .await
+        .unwrap();
+    assert_eq!(reopened_state.status, TurnStatus::Queued);
+    let events = reopened
+        .read_turn_events_after(&scope, None, None, 100)
+        .await
+        .unwrap();
+    assert!(
+        events
+            .entries
+            .iter()
+            .any(|event| event.run_id == run_id && event.kind == TurnEventKind::Submitted),
+        "migrated event rows must remain queryable after reopening the row store"
+    );
+}
+
+#[tokio::test]
+async fn filesystem_turn_state_row_store_does_not_remigrate_stale_blob_after_rows_exist() {
+    let backend = Arc::new(engine_filesystem());
+    let scoped = scoped_turns_fs(Arc::clone(&backend));
+    let row_store = FilesystemTurnStateRowStore::new(Arc::clone(&scoped));
+    let resolver = InMemoryRunProfileResolver::default();
+    let row_scope = turn_scope("thread-fs-row-existing-wins");
+    let row_run_id = TurnRunId::new();
+    let mut row_request = submit_request_for(row_scope.clone(), "idem-fs-row-existing-wins");
+    row_request.requested_run_id = Some(row_run_id);
+
+    row_store
+        .submit_turn(row_request, &AllowAllTurnAdmissionPolicy, &resolver)
+        .await
+        .unwrap();
+    let head_after_row_write = backend
+        .head_seq(&row_delta_log_virtual_path(), SeqNo::ZERO)
+        .await
+        .unwrap();
+
+    let stale_scope = turn_scope("thread-fs-row-stale-legacy");
+    let stale_run_id = TurnRunId::new();
+    let mut stale_request = submit_request_for(stale_scope.clone(), "idem-fs-row-stale-legacy");
+    stale_request.requested_run_id = Some(stale_run_id);
+    let legacy_store = FilesystemTurnStateStore::new(Arc::clone(&scoped));
+    legacy_store
+        .submit_turn(stale_request, &AllowAllTurnAdmissionPolicy, &resolver)
+        .await
+        .unwrap();
+    assert!(
+        backend
+            .get(&snapshot_virtual_path())
+            .await
+            .unwrap()
+            .is_some(),
+        "stale legacy fixture must write a blob next to existing rows"
+    );
+
+    let reopened = FilesystemTurnStateRowStore::new(scoped);
+    let state = reopened
+        .get_run_state(GetRunStateRequest {
+            scope: row_scope,
+            run_id: row_run_id,
+        })
+        .await
+        .unwrap();
+    assert_eq!(state.status, TurnStatus::Queued);
+    let stale = reopened
+        .get_run_state(GetRunStateRequest {
+            scope: stale_scope,
+            run_id: stale_run_id,
+        })
+        .await;
+    assert!(
+        matches!(stale, Err(TurnError::ScopeNotFound)),
+        "row data must remain authoritative once the row store has materialized rows"
+    );
+    let head_after_reopen = backend
+        .head_seq(&row_delta_log_virtual_path(), SeqNo::ZERO)
+        .await
+        .unwrap();
+    assert_eq!(
+        head_after_reopen, head_after_row_write,
+        "opening a row store with existing rows must not append a stale blob migration"
+    );
+}
+
+#[tokio::test]
+async fn filesystem_turn_state_row_store_concurrent_submits_preserve_all_runs() {
+    let backend = Arc::new(engine_filesystem());
+    let scoped = scoped_turns_fs(Arc::clone(&backend));
+    let store = Arc::new(FilesystemTurnStateRowStore::new(Arc::clone(&scoped)));
+    let resolver = Arc::new(InMemoryRunProfileResolver::default());
+    let workers = 32;
+    let barrier = Arc::new(tokio::sync::Barrier::new(workers));
+    let mut handles = Vec::new();
+
+    for idx in 0..workers {
+        let store = Arc::clone(&store);
+        let resolver = Arc::clone(&resolver);
+        let barrier = Arc::clone(&barrier);
+        handles.push(tokio::spawn(async move {
+            let scope = turn_scope(&format!("thread-fs-row-concurrent-{idx}"));
+            let request =
+                submit_request_for(scope.clone(), &format!("idem-fs-row-concurrent-{idx}"));
+            barrier.wait().await;
+            let response = store
+                .submit_turn(request, &AllowAllTurnAdmissionPolicy, resolver.as_ref())
+                .await
+                .unwrap();
+            (scope, accepted_run_id(&response))
+        }));
+    }
+
+    let mut accepted = Vec::new();
+    for handle in handles {
+        accepted.push(handle.await.expect("submit task joins"));
+    }
+    assert_eq!(accepted.len(), workers);
+
+    let reopened = FilesystemTurnStateRowStore::new(Arc::clone(&scoped));
+    for (scope, run_id) in accepted {
+        let state = reopened
+            .get_run_state(GetRunStateRequest { scope, run_id })
+            .await
+            .unwrap();
+        assert_eq!(state.run_id, run_id);
+        assert_eq!(state.status, TurnStatus::Queued);
+    }
+}
+
+#[tokio::test]
+async fn filesystem_turn_state_row_store_publish_is_optimistic_but_waits_for_append_ack() {
+    let backend = Arc::new(BlockingAppendFilesystem::new(engine_filesystem()));
+    let scoped = scoped_turns_fs(Arc::clone(&backend));
+    let store = Arc::new(FilesystemTurnStateRowStore::new(Arc::clone(&scoped)));
+    let scope = turn_scope("thread-fs-row-blocked-materialize");
+    let run_id = TurnRunId::new();
+    let mut request = submit_request_for(scope.clone(), "idem-fs-row-blocked-materialize");
+    request.requested_run_id = Some(run_id);
+    let second_scope = turn_scope("thread-fs-row-blocked-materialize-second");
+    let second_run_id = TurnRunId::new();
+    let mut second_request = submit_request_for(
+        second_scope.clone(),
+        "idem-fs-row-blocked-materialize-second",
+    );
+    second_request.requested_run_id = Some(second_run_id);
+
+    backend.block_next_append();
+    let submit_store = Arc::clone(&store);
+    let submit = tokio::spawn(async move {
+        let resolver = InMemoryRunProfileResolver::default();
+        let admission = AllowAllTurnAdmissionPolicy;
+        submit_store
+            .submit_turn(request, &admission, &resolver)
+            .await
+    });
+    backend.wait_for_blocked_append().await;
+
+    let visible = store
+        .get_run_state(GetRunStateRequest {
+            scope: scope.clone(),
+            run_id,
+        })
+        .await
+        .unwrap();
+    assert_eq!(visible.status, TurnStatus::Queued);
+    assert!(
+        !submit.is_finished(),
+        "writer must still wait for the durable append ack before returning"
+    );
+
+    let second_store = Arc::clone(&store);
+    let second_submit = tokio::spawn(async move {
+        let resolver = InMemoryRunProfileResolver::default();
+        let admission = AllowAllTurnAdmissionPolicy;
+        second_store
+            .submit_turn(second_request, &admission, &resolver)
+            .await
+    });
+    let second_visible = tokio::time::timeout(
+        Duration::from_secs(1),
+        retry_get_run_state(&store, second_scope.clone(), second_run_id),
+    )
+    .await
+    .expect("commit gate must be released before the first durable append ack");
+    assert_eq!(second_visible.status, TurnStatus::Queued);
+    assert!(
+        !second_submit.is_finished(),
+        "second writer also waits for the single flusher's durable append ack"
+    );
+
+    backend.release_blocked_append();
+    let response = submit.await.expect("submit task joins").unwrap();
+    assert_eq!(accepted_run_id(&response), run_id);
+    let second_response = second_submit
+        .await
+        .expect("second submit task joins")
+        .unwrap();
+    assert_eq!(accepted_run_id(&second_response), second_run_id);
+
+    let state = store
+        .get_run_state(GetRunStateRequest { scope, run_id })
+        .await
+        .unwrap();
+    assert_eq!(state.status, TurnStatus::Queued);
+}
+
+#[tokio::test]
+async fn filesystem_turn_state_row_store_loop_checkpoint_releases_gate_before_append_ack() {
+    let backend = Arc::new(BlockingAppendFilesystem::new(engine_filesystem()));
+    let scoped = scoped_turns_fs(Arc::clone(&backend));
+    let store = Arc::new(FilesystemTurnStateRowStore::new(Arc::clone(&scoped)));
+    let resolver = InMemoryRunProfileResolver::default();
+    let parent_scope = turn_scope("thread-fs-row-checkpoint-blocked-append");
+    let parent_response = store
+        .submit_turn(
+            submit_request_for(
+                parent_scope.clone(),
+                "idem-fs-row-checkpoint-blocked-append",
+            ),
+            &AllowAllTurnAdmissionPolicy,
+            &resolver,
+        )
+        .await
+        .unwrap();
+    let parent_run_id = accepted_run_id(&parent_response);
+    let parent_turn_id = accepted_turn_id(&parent_response);
+
+    backend.block_next_append();
+    let checkpoint_store = Arc::clone(&store);
+    let checkpoint_scope = parent_scope.clone();
+    let checkpoint = tokio::spawn(async move {
+        checkpoint_store
+            .put_loop_checkpoint(PutLoopCheckpointRequest {
+                scope: checkpoint_scope,
+                turn_id: parent_turn_id,
+                run_id: parent_run_id,
+                state_ref: LoopCheckpointStateRef::new("checkpoint:blocked-append").unwrap(),
+                schema_id: CheckpointSchemaId::new("interactive_checkpoint_v1").unwrap(),
+                schema_version: RunProfileVersion::new(1),
+                kind: LoopCheckpointKind::BeforeModel,
+                gate_ref: None,
+            })
+            .await
+    });
+    backend.wait_for_blocked_append().await;
+    assert!(
+        !checkpoint.is_finished(),
+        "checkpoint writer must still wait for the durable append ack"
+    );
+
+    let second_scope = turn_scope("thread-fs-row-checkpoint-blocked-append-second");
+    let second_run_id = TurnRunId::new();
+    let mut second_request = submit_request_for(
+        second_scope.clone(),
+        "idem-fs-row-checkpoint-blocked-append-second",
+    );
+    second_request.requested_run_id = Some(second_run_id);
+    let second_store = Arc::clone(&store);
+    let second_submit = tokio::spawn(async move {
+        let resolver = InMemoryRunProfileResolver::default();
+        let admission = AllowAllTurnAdmissionPolicy;
+        second_store
+            .submit_turn(second_request, &admission, &resolver)
+            .await
+    });
+    let second_visible = tokio::time::timeout(
+        Duration::from_secs(1),
+        retry_get_run_state(&store, second_scope.clone(), second_run_id),
+    )
+    .await
+    .expect("loop checkpoint must release the commit gate before append ack");
+    assert_eq!(second_visible.status, TurnStatus::Queued);
+    assert!(
+        !second_submit.is_finished(),
+        "later writer still waits for the flusher's durable append ack"
+    );
+
+    backend.release_blocked_append();
+    let checkpoint = checkpoint
+        .await
+        .expect("checkpoint task joins")
+        .expect("checkpoint write succeeds");
+    let second_response = second_submit
+        .await
+        .expect("second submit task joins")
+        .unwrap();
+    assert_eq!(accepted_run_id(&second_response), second_run_id);
+
+    let loaded = store
+        .get_loop_checkpoint(GetLoopCheckpointRequest {
+            scope: parent_scope,
+            turn_id: parent_turn_id,
+            run_id: parent_run_id,
+            checkpoint_id: checkpoint.checkpoint_id,
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        loaded.as_ref().map(|record| record.checkpoint_id),
+        Some(checkpoint.checkpoint_id)
+    );
+}
+
+#[tokio::test]
+async fn filesystem_turn_state_row_store_append_failure_clears_hot_cache() {
+    let backend = Arc::new(RejectingAppendFilesystem::new(engine_filesystem()));
+    let scoped = scoped_turns_fs(Arc::clone(&backend));
+    let store = FilesystemTurnStateRowStore::new(Arc::clone(&scoped));
+    let scope = turn_scope("thread-fs-row-reject-append");
+    let run_id = TurnRunId::new();
+    let mut request = submit_request_for(scope.clone(), "idem-fs-row-reject-append");
+    request.requested_run_id = Some(run_id);
+    let resolver = InMemoryRunProfileResolver::default();
+
+    let error = store
+        .submit_turn(request, &AllowAllTurnAdmissionPolicy, &resolver)
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(error, TurnError::Unavailable { .. }),
+        "durable delta append failure should fail the writer, got {error:?}"
+    );
+    assert_eq!(backend.append_calls(), 1);
+
+    let hidden = store
+        .get_run_state(GetRunStateRequest { scope, run_id })
+        .await;
+    assert!(
+        matches!(hidden, Err(TurnError::ScopeNotFound)),
+        "failed durable append should not publish hot cache state: {hidden:?}"
+    );
+}
+
+#[tokio::test]
+async fn filesystem_turn_state_row_store_materializes_unadvanced_prior_delta_before_cursor() {
+    let backend = Arc::new(FailOncePutFilesystem::new(engine_filesystem()));
+    let scoped = scoped_turns_fs(Arc::clone(&backend));
+    let store = FilesystemTurnStateRowStore::new(Arc::clone(&scoped));
+    let resolver = InMemoryRunProfileResolver::default();
+    let first_scope = turn_scope("thread-fs-row-recover-prior-1");
+    let first_run_id = TurnRunId::new();
+    let mut first_request = submit_request_for(first_scope.clone(), "idem-fs-row-recover-prior-1");
+    first_request.requested_run_id = Some(first_run_id);
+
+    store
+        .submit_turn(first_request, &AllowAllTurnAdmissionPolicy, &resolver)
+        .await
+        .unwrap();
+
+    let second_scope = turn_scope("thread-fs-row-recover-prior-2");
+    let second_run_id = TurnRunId::new();
+    let mut second_request =
+        submit_request_for(second_scope.clone(), "idem-fs-row-recover-prior-2");
+    second_request.requested_run_id = Some(second_run_id);
+    store
+        .submit_turn(second_request, &AllowAllTurnAdmissionPolicy, &resolver)
+        .await
+        .unwrap();
+
+    let reopened = FilesystemTurnStateRowStore::new(scoped);
+    let first = retry_get_run_state(&reopened, first_scope, first_run_id).await;
+    assert_eq!(first.status, TurnStatus::Queued);
+    let second = retry_get_run_state(&reopened, second_scope, second_run_id).await;
+    assert_eq!(second.status, TurnStatus::Queued);
+}
+
+#[tokio::test]
+async fn filesystem_turn_state_row_store_event_projection_replays_unmaterialized_journal() {
+    let backend = Arc::new(FailOncePutFilesystem::new(engine_filesystem()));
+    let scoped = scoped_turns_fs(Arc::clone(&backend));
+    let store = FilesystemTurnStateRowStore::new(Arc::clone(&scoped));
+    let resolver = InMemoryRunProfileResolver::default();
+    let scope = turn_scope("thread-fs-row-event-replay");
+    let run_id = TurnRunId::new();
+    let mut request = submit_request_for(scope.clone(), "idem-fs-row-event-replay");
+    request.requested_run_id = Some(run_id);
+
+    store
+        .submit_turn(request, &AllowAllTurnAdmissionPolicy, &resolver)
+        .await
+        .unwrap();
+
+    let reopened = FilesystemTurnStateRowStore::new(scoped);
+    let events = retry_read_turn_events(&reopened, &scope).await;
+    assert!(
+        events
+            .entries
+            .iter()
+            .any(|event| event.run_id == run_id && event.kind == TurnEventKind::Submitted),
+        "event projection must replay durable delta journal tails before reading event rows"
+    );
+}
+
+#[tokio::test]
+async fn filesystem_turn_state_row_store_loop_checkpoint_survives_concurrent_full_snapshot_apply() {
+    let backend = Arc::new(engine_filesystem());
+    let scoped = scoped_turns_fs(Arc::clone(&backend));
+    let store = Arc::new(FilesystemTurnStateRowStore::new(Arc::clone(&scoped)));
+    let resolver = InMemoryRunProfileResolver::default();
+    let parent_scope = turn_scope("thread-fs-row-checkpoint-race-parent");
+    let parent_response = store
+        .submit_turn(
+            submit_request_for(parent_scope.clone(), "idem-fs-row-checkpoint-race-parent"),
+            &AllowAllTurnAdmissionPolicy,
+            &resolver,
+        )
+        .await
+        .unwrap();
+    let parent_run_id = accepted_run_id(&parent_response);
+    let parent_turn_id = accepted_turn_id(&parent_response);
+
+    let admission = Arc::new(BlockingAdmissionPolicy::new());
+    let child_store = Arc::clone(&store);
+    let child_admission = Arc::clone(&admission);
+    let child_parent_scope = parent_scope.clone();
+    let child_scope = turn_scope("thread-fs-row-checkpoint-race-child");
+    let child = std::thread::spawn(move || {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        runtime.block_on(async move {
+            let resolver = InMemoryRunProfileResolver::default();
+            child_store
+                .submit_child_turn(
+                    child_run_request(
+                        child_parent_scope,
+                        parent_run_id,
+                        child_scope,
+                        "idem-fs-row-checkpoint-race-child",
+                        1,
+                    ),
+                    child_admission.as_ref(),
+                    &resolver,
+                )
+                .await
+        })
+    });
+    let wait_admission = Arc::clone(&admission);
+    tokio::task::spawn_blocking(move || wait_admission.wait_until_entered())
+        .await
+        .unwrap();
+
+    let checkpoint_store = Arc::clone(&store);
+    let checkpoint_scope = parent_scope.clone();
+    let checkpoint = tokio::spawn(async move {
+        checkpoint_store
+            .put_loop_checkpoint(PutLoopCheckpointRequest {
+                scope: checkpoint_scope,
+                turn_id: parent_turn_id,
+                run_id: parent_run_id,
+                state_ref: LoopCheckpointStateRef::new("checkpoint:row-race").unwrap(),
+                schema_id: CheckpointSchemaId::new("interactive_checkpoint_v1").unwrap(),
+                schema_version: RunProfileVersion::new(1),
+                kind: LoopCheckpointKind::BeforeModel,
+                gate_ref: None,
+            })
+            .await
+    });
+    tokio::task::yield_now().await;
+
+    admission.release();
+    tokio::task::spawn_blocking(move || child.join().expect("child submit thread joins"))
+        .await
+        .unwrap()
+        .unwrap();
+    let checkpoint = checkpoint
+        .await
+        .expect("checkpoint task joins")
+        .expect("checkpoint write succeeds");
+    let loaded = store
+        .get_loop_checkpoint(GetLoopCheckpointRequest {
+            scope: parent_scope,
+            turn_id: parent_turn_id,
+            run_id: parent_run_id,
+            checkpoint_id: checkpoint.checkpoint_id,
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        loaded.as_ref().map(|record| record.checkpoint_id),
+        Some(checkpoint.checkpoint_id),
+        "full-snapshot row-store publication must not overwrite a concurrent loop checkpoint"
+    );
+}
+
+#[tokio::test]
+async fn filesystem_turn_state_row_store_evicted_terminal_run_remains_queryable() {
+    let backend = Arc::new(engine_filesystem());
+    let scoped = scoped_turns_fs(Arc::clone(&backend));
+    let limits = InMemoryTurnStateStoreLimits {
+        max_events: 2,
+        max_terminal_records: 1,
+        max_idempotency_records: 1,
+        ..InMemoryTurnStateStoreLimits::default()
+    };
+    let store = FilesystemTurnStateRowStore::new(Arc::clone(&scoped)).with_limits(limits);
+    let resolver = InMemoryRunProfileResolver::default();
+
+    let first_scope = turn_scope("thread-fs-row-evicted-terminal-1");
+    let first_request = submit_request_for(first_scope.clone(), "idem-fs-row-evicted-1");
+    let first_response = store
+        .submit_turn(first_request, &AllowAllTurnAdmissionPolicy, &resolver)
+        .await
+        .unwrap();
+    let first_run_id = accepted_run_id(&first_response);
+    let first_runner_id = TurnRunnerId::new();
+    let first_lease_token = TurnLeaseToken::new();
+    store
+        .claim_next_run(ClaimRunRequest {
+            runner_id: first_runner_id,
+            lease_token: first_lease_token,
+            scope_filter: None,
+        })
+        .await
+        .unwrap()
+        .unwrap();
+    store
+        .fail_run(FailRunRequest {
+            run_id: first_run_id,
+            runner_id: first_runner_id,
+            lease_token: first_lease_token,
+            failure: SanitizedFailure::new("test_failure").unwrap(),
+        })
+        .await
+        .unwrap();
+
+    let second_scope = turn_scope("thread-fs-row-evicted-terminal-2");
+    let second_request = submit_request_for(second_scope, "idem-fs-row-evicted-2");
+    let second_response = store
+        .submit_turn(second_request, &AllowAllTurnAdmissionPolicy, &resolver)
+        .await
+        .unwrap();
+    let second_run_id = accepted_run_id(&second_response);
+    let second_runner_id = TurnRunnerId::new();
+    let second_lease_token = TurnLeaseToken::new();
+    store
+        .claim_next_run(ClaimRunRequest {
+            runner_id: second_runner_id,
+            lease_token: second_lease_token,
+            scope_filter: None,
+        })
+        .await
+        .unwrap()
+        .unwrap();
+    store
+        .complete_run(CompleteRunRequest {
+            run_id: second_run_id,
+            runner_id: second_runner_id,
+            lease_token: second_lease_token,
+        })
+        .await
+        .unwrap();
+
+    let hot_snapshot = store.persistence_snapshot().await.unwrap();
+    assert!(
+        !hot_snapshot
+            .runs
+            .iter()
+            .any(|record| record.run_id == first_run_id),
+        "terminal cache limit should evict the old failed run from the hot snapshot"
+    );
+    assert!(
+        hot_snapshot.events.len() <= limits.max_events,
+        "event cache limit should bound the hot snapshot without deleting durable events"
+    );
+
+    let failed = store
+        .get_run_state(GetRunStateRequest {
+            scope: first_scope.clone(),
+            run_id: first_run_id,
+        })
+        .await
+        .unwrap();
+    assert_eq!(failed.status, TurnStatus::Failed);
+    assert_eq!(
+        failed.failure.as_ref().map(SanitizedFailure::category),
+        Some("test_failure")
+    );
+
+    let first_events = store
+        .read_turn_events_after(&first_scope, None, None, 100)
+        .await
+        .unwrap();
+    assert_eq!(first_events.rebase_required, None);
+    assert!(
+        first_events
+            .entries
+            .iter()
+            .any(|event| event.run_id == first_run_id && event.kind == TurnEventKind::Failed),
+        "events are Tier 2 run-record rows and must survive cache event eviction"
+    );
+
+    let reopened = FilesystemTurnStateRowStore::new(scoped).with_limits(limits);
+    let reopened_hot_snapshot = reopened.persistence_snapshot().await.unwrap();
+    assert!(
+        !reopened_hot_snapshot
+            .runs
+            .iter()
+            .any(|record| record.run_id == first_run_id),
+        "startup should apply the same terminal cache window instead of hydrating all history"
+    );
+    let reopened_failed = reopened
+        .get_run_state(GetRunStateRequest {
+            scope: first_scope.clone(),
+            run_id: first_run_id,
+        })
+        .await
+        .unwrap();
+    assert_eq!(reopened_failed.status, TurnStatus::Failed);
+    assert_eq!(
+        reopened_failed
+            .failure
+            .as_ref()
+            .map(SanitizedFailure::category),
+        Some("test_failure")
+    );
+    let reopened_events = reopened
+        .read_turn_events_after(&first_scope, None, None, 100)
+        .await
+        .unwrap();
+    assert_eq!(reopened_events.rebase_required, None);
+    assert!(
+        reopened_events
+            .entries
+            .iter()
+            .any(|event| event.run_id == first_run_id && event.kind == TurnEventKind::Failed),
+        "durable event rows should remain queryable after restart"
+    );
+}
+
+#[tokio::test]
+async fn filesystem_turn_state_row_store_heartbeat_does_not_rewrite_run_row() {
+    let backend = Arc::new(engine_filesystem());
+    let scoped = scoped_turns_fs(Arc::clone(&backend));
+    let store = FilesystemTurnStateRowStore::new(scoped);
+    let resolver = InMemoryRunProfileResolver::default();
+
+    let request = submit_request_for(
+        turn_scope("thread-fs-row-heartbeat-memory"),
+        "idem-fs-row-heartbeat-memory",
+    );
+    let response = store
+        .submit_turn(request, &AllowAllTurnAdmissionPolicy, &resolver)
+        .await
+        .unwrap();
+    let run_id = accepted_run_id(&response);
+    let runner_id = TurnRunnerId::new();
+    let lease_token = TurnLeaseToken::new();
+    store
+        .claim_next_run(ClaimRunRequest {
+            runner_id,
+            lease_token,
+            scope_filter: None,
+        })
+        .await
+        .unwrap()
+        .unwrap();
+    let head_after_claim = backend
+        .head_seq(&row_delta_log_virtual_path(), SeqNo::ZERO)
+        .await
+        .unwrap();
+    let first_snapshot = store.persistence_snapshot().await.unwrap();
+    let first_heartbeat_at = first_snapshot
+        .runs
+        .iter()
+        .find(|record| record.run_id == run_id)
+        .and_then(|record| record.last_heartbeat_at)
+        .expect("claimed heartbeat timestamp");
+
+    tokio::time::sleep(Duration::from_millis(5)).await;
+    store
+        .heartbeat(HeartbeatRequest {
+            run_id,
+            runner_id,
+            lease_token,
+        })
+        .await
+        .unwrap();
+
+    let head_after_heartbeat = backend
+        .head_seq(&row_delta_log_virtual_path(), SeqNo::ZERO)
+        .await
+        .unwrap();
+    assert_eq!(
+        head_after_heartbeat, head_after_claim,
+        "heartbeat must refresh the runner lease without appending a durable delta"
+    );
+    let heartbeat_snapshot = store.persistence_snapshot().await.unwrap();
+    let heartbeat_at = heartbeat_snapshot
+        .runs
+        .iter()
+        .find(|record| record.run_id == run_id)
+        .and_then(|record| record.last_heartbeat_at)
+        .expect("heartbeat timestamp");
+    assert!(
+        heartbeat_at > first_heartbeat_at,
+        "row-store read model should expose the refreshed memory lease timestamp"
     );
 }
 

--- a/crates/ironclaw_turns/tests/filesystem_turn_state_contract.rs
+++ b/crates/ironclaw_turns/tests/filesystem_turn_state_contract.rs
@@ -768,7 +768,9 @@ where
         entry: Entry,
         cas: CasExpectation,
     ) -> Result<RecordVersion, FilesystemError> {
-        if self.fail_next_put.swap(false, Ordering::SeqCst) {
+        if path.as_str().ends_with("/turns/rows/v1/meta/state.json")
+            && self.fail_next_put.swap(false, Ordering::SeqCst)
+        {
             return Err(FilesystemError::PermissionDenied {
                 path: ScopedPath::new(path.as_str().to_string()).expect("scoped path"),
                 operation: FilesystemOperation::WriteFile,
@@ -1368,6 +1370,353 @@ async fn filesystem_turn_state_row_store_persists_rows_without_state_blob() {
 }
 
 #[tokio::test]
+async fn filesystem_turn_state_row_store_rejects_stale_cross_store_active_lock_create() {
+    let backend = Arc::new(engine_filesystem());
+    let scoped = scoped_turns_fs(Arc::clone(&backend));
+    let first_store = FilesystemTurnStateRowStore::new(Arc::clone(&scoped));
+    let second_store = FilesystemTurnStateRowStore::new(Arc::clone(&scoped));
+    let resolver = InMemoryRunProfileResolver::default();
+    let policy = AllowAllTurnAdmissionPolicy;
+    let scope = turn_scope("thread-fs-row-stale-active-lock");
+
+    first_store.persistence_snapshot().await.unwrap();
+    second_store.persistence_snapshot().await.unwrap();
+
+    let first = first_store.submit_turn(
+        submit_request_for(scope.clone(), "idem-row-stale-active-lock-a"),
+        &policy,
+        &resolver,
+    );
+    let second = second_store.submit_turn(
+        submit_request_for(scope, "idem-row-stale-active-lock-b"),
+        &policy,
+        &resolver,
+    );
+    let (first, second) = tokio::join!(first, second);
+    let successes = [first.as_ref(), second.as_ref()]
+        .into_iter()
+        .filter(|result| result.is_ok())
+        .count();
+    let conflicts = [first, second]
+        .into_iter()
+        .filter(|result| matches!(result, Err(TurnError::Conflict { .. })))
+        .count();
+
+    assert_eq!(successes, 1);
+    assert_eq!(conflicts, 1);
+}
+
+#[tokio::test]
+async fn filesystem_turn_state_row_store_rejects_stale_cross_store_claim() {
+    let backend = Arc::new(engine_filesystem());
+    let scoped = scoped_turns_fs(Arc::clone(&backend));
+    let first_store = FilesystemTurnStateRowStore::new(Arc::clone(&scoped));
+    let second_store = FilesystemTurnStateRowStore::new(Arc::clone(&scoped));
+    let resolver = InMemoryRunProfileResolver::default();
+    let policy = AllowAllTurnAdmissionPolicy;
+    let scope = turn_scope("thread-fs-row-stale-claim");
+
+    let submitted = first_store
+        .submit_turn(
+            submit_request_for(scope, "idem-row-stale-claim"),
+            &policy,
+            &resolver,
+        )
+        .await
+        .unwrap();
+    let run_id = accepted_run_id(&submitted);
+
+    first_store.persistence_snapshot().await.unwrap();
+    second_store.persistence_snapshot().await.unwrap();
+
+    let first = first_store.claim_next_run(ClaimRunRequest {
+        runner_id: TurnRunnerId::new(),
+        lease_token: TurnLeaseToken::new(),
+        scope_filter: None,
+    });
+    let second = second_store.claim_next_run(ClaimRunRequest {
+        runner_id: TurnRunnerId::new(),
+        lease_token: TurnLeaseToken::new(),
+        scope_filter: None,
+    });
+    let (first, second) = tokio::join!(first, second);
+    let successes = [&first, &second]
+        .into_iter()
+        .filter(|result| matches!(result, Ok(Some(claimed)) if claimed.state.run_id == run_id))
+        .count();
+    let conflicts = [first, second]
+        .into_iter()
+        .filter(|result| matches!(result, Err(TurnError::Conflict { .. })))
+        .count();
+
+    assert_eq!(successes, 1);
+    assert_eq!(conflicts, 1);
+}
+
+#[tokio::test]
+async fn filesystem_turn_state_row_store_rejects_preappend_cross_store_claim() {
+    let backend = Arc::new(BlockingAppendFilesystem::new(engine_filesystem()));
+    let scoped = scoped_turns_fs(Arc::clone(&backend));
+    let first_store = Arc::new(FilesystemTurnStateRowStore::new(Arc::clone(&scoped)));
+    let resolver = InMemoryRunProfileResolver::default();
+    let policy = AllowAllTurnAdmissionPolicy;
+    let scope = turn_scope("thread-fs-row-preappend-claim");
+
+    let submitted = first_store
+        .submit_turn(
+            submit_request_for(scope.clone(), "idem-row-preappend-claim"),
+            &policy,
+            &resolver,
+        )
+        .await
+        .unwrap();
+    let run_id = accepted_run_id(&submitted);
+
+    backend.block_next_append();
+    let first_claim = {
+        let first_store = Arc::clone(&first_store);
+        tokio::spawn(async move {
+            first_store
+                .claim_next_run(ClaimRunRequest {
+                    runner_id: TurnRunnerId::new(),
+                    lease_token: TurnLeaseToken::new(),
+                    scope_filter: None,
+                })
+                .await
+        })
+    };
+    backend.wait_for_blocked_append().await;
+
+    let second_store = FilesystemTurnStateRowStore::new(Arc::clone(&scoped));
+    let preappend_snapshot = second_store.persistence_snapshot().await.unwrap();
+    assert!(
+        preappend_snapshot
+            .runs
+            .iter()
+            .any(|record| record.run_id == run_id && record.status == TurnStatus::Running)
+    );
+    assert!(
+        preappend_snapshot
+            .active_locks
+            .iter()
+            .any(|record| record.run_id == run_id && record.status == TurnStatus::Running)
+    );
+    let second = second_store
+        .claim_next_run(ClaimRunRequest {
+            runner_id: TurnRunnerId::new(),
+            lease_token: TurnLeaseToken::new(),
+            scope_filter: None,
+        })
+        .await;
+    assert!(
+        matches!(second, Ok(None) | Err(TurnError::Conflict { .. })),
+        "fresh store must not double-claim a run while another claim's append is blocked"
+    );
+
+    backend.release_blocked_append();
+    let first = first_claim
+        .await
+        .expect("first claim task joins")
+        .unwrap()
+        .expect("first claim succeeds");
+    assert_eq!(first.state.run_id, run_id);
+    assert_eq!(first.state.status, TurnStatus::Running);
+}
+
+#[tokio::test]
+async fn filesystem_turn_state_row_store_refreshes_stale_active_lock_cache_before_submit() {
+    let backend = Arc::new(engine_filesystem());
+    let scoped = scoped_turns_fs(Arc::clone(&backend));
+    let first_store = FilesystemTurnStateRowStore::new(Arc::clone(&scoped));
+    let second_store = FilesystemTurnStateRowStore::new(Arc::clone(&scoped));
+    let resolver = InMemoryRunProfileResolver::default();
+    let policy = AllowAllTurnAdmissionPolicy;
+    let scope = turn_scope("thread-fs-row-stale-active-lock-cache");
+    let first_run_id = TurnRunId::new();
+    let second_run_id = TurnRunId::new();
+    let mut first_request = submit_request_for(scope.clone(), "idem-row-stale-cache-a");
+    first_request.requested_run_id = Some(first_run_id);
+
+    first_store
+        .submit_turn(first_request, &policy, &resolver)
+        .await
+        .unwrap();
+    second_store.persistence_snapshot().await.unwrap();
+
+    let runner_id = TurnRunnerId::new();
+    let lease_token = TurnLeaseToken::new();
+    first_store
+        .claim_next_run(ClaimRunRequest {
+            runner_id,
+            lease_token,
+            scope_filter: None,
+        })
+        .await
+        .unwrap()
+        .unwrap();
+    first_store
+        .complete_run(CompleteRunRequest {
+            run_id: first_run_id,
+            runner_id,
+            lease_token,
+        })
+        .await
+        .unwrap();
+
+    let mut second_request = submit_request_for(scope, "idem-row-stale-cache-b");
+    second_request.requested_run_id = Some(second_run_id);
+    let submitted = second_store
+        .submit_turn(second_request, &policy, &resolver)
+        .await
+        .unwrap();
+
+    assert_eq!(accepted_run_id(&submitted), second_run_id);
+}
+
+#[tokio::test]
+async fn filesystem_turn_state_row_store_get_run_state_refreshes_stale_cached_run() {
+    let backend = Arc::new(engine_filesystem());
+    let scoped = scoped_turns_fs(Arc::clone(&backend));
+    let first_store = FilesystemTurnStateRowStore::new(Arc::clone(&scoped));
+    let second_store = FilesystemTurnStateRowStore::new(Arc::clone(&scoped));
+    let resolver = InMemoryRunProfileResolver::default();
+    let policy = AllowAllTurnAdmissionPolicy;
+    let scope = turn_scope("thread-fs-row-stale-get-run-state");
+
+    let submitted = first_store
+        .submit_turn(
+            submit_request_for(scope.clone(), "idem-row-stale-get-run-state"),
+            &policy,
+            &resolver,
+        )
+        .await
+        .unwrap();
+    let run_id = accepted_run_id(&submitted);
+    let runner_id = TurnRunnerId::new();
+    let lease_token = TurnLeaseToken::new();
+
+    let cached = second_store
+        .get_run_state(GetRunStateRequest {
+            scope: scope.clone(),
+            run_id,
+        })
+        .await
+        .unwrap();
+    assert_eq!(cached.status, TurnStatus::Queued);
+
+    first_store
+        .claim_next_run(ClaimRunRequest {
+            runner_id,
+            lease_token,
+            scope_filter: None,
+        })
+        .await
+        .unwrap()
+        .expect("run claimed");
+
+    let refreshed = second_store
+        .get_run_state(GetRunStateRequest { scope, run_id })
+        .await
+        .unwrap();
+    assert_eq!(refreshed.status, TurnStatus::Running);
+}
+
+#[tokio::test]
+async fn filesystem_turn_state_row_store_rejects_uncommitted_active_lock_reservation() {
+    let backend = Arc::new(BlockingAppendFilesystem::new(engine_filesystem()));
+    let scoped = scoped_turns_fs(Arc::clone(&backend));
+    let first_store = Arc::new(FilesystemTurnStateRowStore::new(Arc::clone(&scoped)));
+    let second_store = FilesystemTurnStateRowStore::new(Arc::clone(&scoped));
+    let resolver = InMemoryRunProfileResolver::default();
+    let policy = AllowAllTurnAdmissionPolicy;
+    let scope = turn_scope("thread-fs-row-uncommitted-active-lock");
+    let first_run_id = TurnRunId::new();
+    let second_run_id = TurnRunId::new();
+    let mut first_request = submit_request_for(scope.clone(), "idem-row-uncommitted-active-lock-a");
+    first_request.requested_run_id = Some(first_run_id);
+
+    backend.block_next_append();
+    let first_submit = {
+        let first_store = Arc::clone(&first_store);
+        tokio::spawn(async move {
+            let resolver = InMemoryRunProfileResolver::default();
+            let policy = AllowAllTurnAdmissionPolicy;
+            first_store
+                .submit_turn(first_request, &policy, &resolver)
+                .await
+        })
+    };
+    backend.wait_for_blocked_append().await;
+
+    let snapshot = second_store.persistence_snapshot().await.unwrap();
+    assert_eq!(snapshot.turns.len(), 1);
+    assert_eq!(snapshot.runs.len(), 1);
+    assert_eq!(snapshot.active_locks.len(), 1);
+
+    let mut second_request =
+        submit_request_for(scope.clone(), "idem-row-uncommitted-active-lock-b");
+    second_request.requested_run_id = Some(second_run_id);
+    let second = second_store
+        .submit_turn(second_request, &policy, &resolver)
+        .await;
+    assert!(
+        matches!(
+            second,
+            Err(TurnError::Conflict { .. }) | Err(TurnError::ThreadBusy(_))
+        ),
+        "fresh store must not accept a same-thread run when it only sees another writer's pre-append active-lock reservation"
+    );
+
+    backend.release_blocked_append();
+    let first = first_submit
+        .await
+        .expect("first submit task joins")
+        .unwrap();
+    assert_eq!(accepted_run_id(&first), first_run_id);
+}
+
+#[tokio::test]
+async fn filesystem_turn_state_row_store_recovers_preappend_active_lock_reservation() {
+    let backend = Arc::new(BlockingAppendFilesystem::new(engine_filesystem()));
+    let scoped = scoped_turns_fs(Arc::clone(&backend));
+    let first_store = Arc::new(FilesystemTurnStateRowStore::new(Arc::clone(&scoped)));
+    let scope = turn_scope("thread-fs-row-recover-preappend-active-lock");
+    let run_id = TurnRunId::new();
+    let mut request = submit_request_for(scope, "idem-row-recover-preappend-active-lock");
+    request.requested_run_id = Some(run_id);
+
+    backend.block_next_append();
+    let first_submit = {
+        let first_store = Arc::clone(&first_store);
+        tokio::spawn(async move {
+            let resolver = InMemoryRunProfileResolver::default();
+            let policy = AllowAllTurnAdmissionPolicy;
+            first_store.submit_turn(request, &policy, &resolver).await
+        })
+    };
+    backend.wait_for_blocked_append().await;
+    first_submit.abort();
+
+    let recovered_store = FilesystemTurnStateRowStore::new(Arc::clone(&scoped));
+    let snapshot = recovered_store.persistence_snapshot().await.unwrap();
+    assert_eq!(snapshot.turns.len(), 1);
+    assert_eq!(snapshot.runs.len(), 1);
+    assert_eq!(snapshot.active_locks.len(), 1);
+
+    let claimed = recovered_store
+        .claim_next_run(ClaimRunRequest {
+            runner_id: TurnRunnerId::new(),
+            lease_token: TurnLeaseToken::new(),
+            scope_filter: None,
+        })
+        .await
+        .unwrap()
+        .expect("pre-append reservation recovers as queued run");
+    assert_eq!(claimed.state.run_id, run_id);
+    assert_eq!(claimed.state.status, TurnStatus::Running);
+}
+
+#[tokio::test]
 async fn filesystem_turn_state_row_store_migrates_legacy_state_blob() {
     let backend = Arc::new(engine_filesystem());
     let scoped = scoped_turns_fs(Arc::clone(&backend));
@@ -1730,6 +2079,119 @@ async fn filesystem_turn_state_row_store_loop_checkpoint_releases_gate_before_ap
             scope: parent_scope,
             turn_id: parent_turn_id,
             run_id: parent_run_id,
+            checkpoint_id: checkpoint.checkpoint_id,
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        loaded.as_ref().map(|record| record.checkpoint_id),
+        Some(checkpoint.checkpoint_id)
+    );
+}
+
+#[tokio::test]
+async fn filesystem_turn_state_row_store_loop_checkpoint_times_out_without_losing_unknown_commit() {
+    let backend = Arc::new(BlockingAppendFilesystem::new(engine_filesystem()));
+    let scoped = scoped_turns_fs(Arc::clone(&backend));
+    let store = Arc::new(
+        FilesystemTurnStateRowStore::new(Arc::clone(&scoped))
+            .with_apply_timeout(Duration::from_millis(100)),
+    );
+    let resolver = InMemoryRunProfileResolver::default();
+    let parent_scope = turn_scope("thread-fs-row-checkpoint-timeout");
+    let parent_response = store
+        .submit_turn(
+            submit_request_for(parent_scope.clone(), "idem-fs-row-checkpoint-timeout"),
+            &AllowAllTurnAdmissionPolicy,
+            &resolver,
+        )
+        .await
+        .unwrap();
+    let parent_run_id = accepted_run_id(&parent_response);
+    let parent_turn_id = accepted_turn_id(&parent_response);
+
+    backend.block_next_append();
+    let checkpoint_store = Arc::clone(&store);
+    let checkpoint_scope = parent_scope.clone();
+    let checkpoint = tokio::spawn(async move {
+        checkpoint_store
+            .put_loop_checkpoint(PutLoopCheckpointRequest {
+                scope: checkpoint_scope,
+                turn_id: parent_turn_id,
+                run_id: parent_run_id,
+                state_ref: LoopCheckpointStateRef::new("checkpoint:timeout").unwrap(),
+                schema_id: CheckpointSchemaId::new("interactive_checkpoint_v1").unwrap(),
+                schema_version: RunProfileVersion::new(1),
+                kind: LoopCheckpointKind::BeforeModel,
+                gate_ref: None,
+            })
+            .await
+    });
+    backend.wait_for_blocked_append().await;
+
+    let result = tokio::time::timeout(Duration::from_secs(1), checkpoint)
+        .await
+        .expect("checkpoint write must hit the bounded row-store append timeout")
+        .expect("checkpoint task joins");
+    assert!(
+        matches!(result, Err(TurnError::Unavailable { reason }) if reason == "timed out waiting for loop checkpoint row-store append")
+    );
+
+    backend.release_blocked_append();
+    for _ in 0..8 {
+        let reopened = FilesystemTurnStateRowStore::new(Arc::clone(&scoped));
+        let snapshot = reopened.persistence_snapshot().await.unwrap();
+        if snapshot
+            .loop_checkpoints
+            .iter()
+            .any(|record| record.run_id == parent_run_id)
+        {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    panic!("timed-out checkpoint append should still materialize after the blocked append commits");
+}
+
+#[tokio::test]
+async fn filesystem_turn_state_row_store_get_loop_checkpoint_refreshes_stale_cached_rows() {
+    let backend = Arc::new(engine_filesystem());
+    let scoped = scoped_turns_fs(Arc::clone(&backend));
+    let writer = FilesystemTurnStateRowStore::new(Arc::clone(&scoped));
+    let reader = FilesystemTurnStateRowStore::new(Arc::clone(&scoped));
+    let resolver = InMemoryRunProfileResolver::default();
+    let scope = turn_scope("thread-fs-row-checkpoint-stale-cache");
+    let response = writer
+        .submit_turn(
+            submit_request_for(scope.clone(), "idem-fs-row-checkpoint-stale-cache"),
+            &AllowAllTurnAdmissionPolicy,
+            &resolver,
+        )
+        .await
+        .unwrap();
+    let run_id = accepted_run_id(&response);
+    let turn_id = accepted_turn_id(&response);
+
+    let _stale_snapshot = reader.persistence_snapshot().await.unwrap();
+    let checkpoint = writer
+        .put_loop_checkpoint(PutLoopCheckpointRequest {
+            scope: scope.clone(),
+            turn_id,
+            run_id,
+            state_ref: LoopCheckpointStateRef::new("checkpoint:stale-cache").unwrap(),
+            schema_id: CheckpointSchemaId::new("interactive_checkpoint_v1").unwrap(),
+            schema_version: RunProfileVersion::new(1),
+            kind: LoopCheckpointKind::BeforeModel,
+            gate_ref: None,
+        })
+        .await
+        .unwrap();
+
+    let loaded = reader
+        .get_loop_checkpoint(GetLoopCheckpointRequest {
+            scope,
+            turn_id,
+            run_id,
             checkpoint_id: checkpoint.checkpoint_id,
         })
         .await

--- a/crates/ironclaw_turns/tests/loop_checkpoint_store_contract.rs
+++ b/crates/ironclaw_turns/tests/loop_checkpoint_store_contract.rs
@@ -9,10 +9,10 @@ use ironclaw_host_api::{
     VirtualPath,
 };
 use ironclaw_turns::{
-    CheckpointSchemaId, FilesystemTurnStateStore, GetLoopCheckpointRequest,
-    InMemoryLoopCheckpointStore, InMemoryTurnStateStore, LoopCheckpointStateRef,
-    LoopCheckpointStore, PutLoopCheckpointRequest, RunProfileVersion, TurnId, TurnRunId, TurnScope,
-    run_profile::LoopCheckpointKind,
+    CheckpointSchemaId, FilesystemTurnStateRowStore, FilesystemTurnStateStore,
+    GetLoopCheckpointRequest, InMemoryLoopCheckpointStore, InMemoryTurnStateStore,
+    LoopCheckpointStateRef, LoopCheckpointStore, PutLoopCheckpointRequest, RunProfileVersion,
+    TurnId, TurnRunId, TurnScope, run_profile::LoopCheckpointKind,
 };
 
 fn test_scope(thread: &str) -> TurnScope {
@@ -166,6 +166,10 @@ where
     Arc::new(ScopedFilesystem::with_fixed_view(Arc::new(root), mounts))
 }
 
+fn snapshot_virtual_path() -> VirtualPath {
+    VirtualPath::new("/engine/tenants/test-tenant/users/test-user/turns/state.json").unwrap()
+}
+
 #[tokio::test]
 async fn filesystem_turn_state_loop_checkpoint_roundtrip_and_snapshot() {
     let backend = Arc::new(engine_filesystem());
@@ -188,6 +192,30 @@ async fn filesystem_turn_state_loop_checkpoint_roundtrip_and_snapshot() {
     // rehydrate the same loop-checkpoint set without any backend-specific
     // migration step.
     let reopened = FilesystemTurnStateStore::new(scoped);
+    let reopened_snapshot = reopened.persistence_snapshot().await.unwrap();
+    assert_eq!(reopened_snapshot.loop_checkpoints.len(), 2);
+}
+
+#[tokio::test]
+async fn filesystem_turn_state_row_store_loop_checkpoint_roundtrip_and_snapshot() {
+    let backend = Arc::new(engine_filesystem());
+    let scoped = scoped_turns_fs(Arc::clone(&backend));
+    let store = FilesystemTurnStateRowStore::new(Arc::clone(&scoped));
+    assert_loop_checkpoint_store_roundtrip(&store).await;
+    assert_loop_checkpoint_store_cross_scope_and_run_miss(&store).await;
+
+    let snapshot = store.persistence_snapshot().await.unwrap();
+    assert_eq!(snapshot.loop_checkpoints.len(), 2);
+    assert!(
+        backend
+            .get(&snapshot_virtual_path())
+            .await
+            .unwrap()
+            .is_none(),
+        "row store loop checkpoints must not write the blob-shaped state.json snapshot"
+    );
+
+    let reopened = FilesystemTurnStateRowStore::new(scoped);
     let reopened_snapshot = reopened.persistence_snapshot().await.unwrap();
     assert_eq!(reopened_snapshot.loop_checkpoints.len(), 2);
 }

--- a/docs/reborn/contracts/migration-compatibility.md
+++ b/docs/reborn/contracts/migration-compatibility.md
@@ -203,6 +203,10 @@ Cutover requirements:
 - one config-driven production composition root for `HostRuntimeServices` and adjacent shipped reference/userland services;
 - caller-level tests across `CapabilityHost -> Dispatcher -> Adapter -> Process/Event/Memory` paths;
 - explicit migration/backfill path for reused legacy schemas;
+- RootFilesystem physical-layout migrations that replace a hot production blob
+  with rows, such as turn state `/turns/state.json` to `/turns/rows/v1`, are the
+  final stack step before production exposure; the stack must not go live until
+  the migration has run idempotently and row readback is verified;
 - rollback notes for any bridge that can affect production state;
 - no accidental dual source of truth between legacy `src/` services and Reborn repositories.
 

--- a/docs/reborn/contracts/turn-persistence.md
+++ b/docs/reborn/contracts/turn-persistence.md
@@ -39,6 +39,32 @@ The initial PostgreSQL/libSQL adapter slice stores each logical record family in
 
 Legacy `turn_checkpoints` rows created before scoped checkpoint metadata may carry empty indexed `scope_key` values after migration. Those rows remain readable through the serialized payload; any future targeted `turn_checkpoints` read path must first add a scoped backfill plan or explicitly reject unbackfilled legacy rows instead of treating empty scope as a real owner.
 
+The RootFilesystem-backed row store uses `/turns/rows/v1` as its durable shape.
+Each logical family has its own keyed row collection under that root, with
+`/turns/rows/v1/meta/state.json` carrying the last fully materialized
+delta-journal sequence (`journal_seq`) and the event retention floor. Writers
+update the hot in-process row cache, enqueue a `SnapshotDelta`, and return only
+after the delta is durably appended. Row materialization is allowed to lag
+behind the foreground ack: the background materializer coalesces journal tails
+into row updates and advances `journal_seq`, while restart and durable read
+paths replay any journal tail newer than `journal_seq` before trusting row
+projections. Materialization writers are serialized within the runtime so an
+older projector cannot overwrite rows after a newer projector has advanced the
+projection. This keeps the journal as the crash-recovery source of truth while
+avoiding full-snapshot rewrites on hot writes. Tier-2 run-record rows (`turns`,
+`turn_runs`, and lifecycle events) remain durable even when terminal runs are
+evicted from hot in-memory indexes; cache limits are eviction thresholds, not
+deletion thresholds for the durable run record.
+
+Legacy `/turns/state.json` blobs migrate into `/turns/rows/v1` through the same
+delta journal. On first row-store load, if materialized rows and replayed
+journal state are still empty, the store reads the legacy blob, appends one
+full-snapshot `SnapshotDelta`, waits for the durable append ack, and then
+materializes rows. The legacy blob is not deleted. Once any row data exists,
+rows are authoritative and later stale blobs are ignored. Hosted rollout must
+run this migration as the final stack step with no live turn writers, then
+verify the row projection before enabling row-store-only production traffic.
+
 ---
 
 ## 3. Active-lock rules


### PR DESCRIPTION
## Stack

2/4 for hosted-single-tenant Postgres latency parity.

Base: `codex/hst-postgres-01-rootfs` (#5688)
Next: `codex/hst-postgres-03-runtime-stores`

## What changes

- Adds the RootFilesystem-backed row-store turn state implementation.
- Persists turn-state deltas through a grouped append journal and materialized keyed rows.
- Adds terminal-run hot-cache eviction while keeping terminal runs queryable from rows.
- Adds the migration gate from legacy `turns/state.json` blob into row records.
- Documents the migration compatibility requirement.

## Hosted-volume safety

This PR adds the row store and migration coverage, but does not by itself wire the hosted profile to use it. The compatibility gate that matters for live hosted-volume instances is covered by the legacy blob migration contract test.

## Verification

- `cargo check -p ironclaw_turns`
- `cargo test -p ironclaw_turns --test filesystem_turn_state_contract`
