### PR TITLE
fix(webui-v2): hide unsupported inference config fields

### DIFF
--- a/crates/ironclaw_webui_v2/static/js/i18n/ar.js
+++ b/crates/ironclaw_webui_v2/static/js/i18n/ar.js
@@ -368,18 +368,6 @@ registerPack("ar", {
   "llm.missingBaseUrl": "عنوان URL الأساسي مفقود",
   "llm.addApiKey": "أضف مفتاح واجهة برمجة التطبيقات",
 
-  // Settings — inference groups
-  "settings.group.embeddings": "التضمينات",
-  "settings.group.sampling": "أخذ العينات",
-  "settings.field.embeddingsEnabled": "تمكين التضمينات",
-  "settings.field.embeddingsEnabledDesc": "بحث دلالي عبر ذاكرة مساحة العمل",
-  "settings.field.embeddingsProvider": "المزوّد",
-  "settings.field.embeddingsProviderDesc": "مزوّد نموذج التضمينات",
-  "settings.field.embeddingsModel": "النموذج",
-  "settings.field.embeddingsModelDesc": "معرّف نموذج التضمينات",
-  "settings.field.temperature": "الحرارة",
-  "settings.field.temperatureDesc": "حرارة أخذ العينات الافتراضية (0.0–2.0)",
-
   // Settings — agent groups
   "settings.group.core": "الأساسيات",
   "settings.group.heartbeat": "النبض",

--- a/crates/ironclaw_webui_v2/static/js/i18n/de.js
+++ b/crates/ironclaw_webui_v2/static/js/i18n/de.js
@@ -368,18 +368,6 @@ registerPack("de", {
   "llm.missingBaseUrl": "Fehlende Basis-URL",
   "llm.addApiKey": "API-Schlüssel hinzufügen",
 
-  // Settings — inference groups
-  "settings.group.embeddings": "Einbettungen",
-  "settings.group.sampling": "Sampling",
-  "settings.field.embeddingsEnabled": "Embeddings aktivieren",
-  "settings.field.embeddingsEnabledDesc": "Semantische Suche über Workspace‑Memory",
-  "settings.field.embeddingsProvider": "Anbieter",
-  "settings.field.embeddingsProviderDesc": "Embedding‑Modell‑Provider",
-  "settings.field.embeddingsModel": "Modell",
-  "settings.field.embeddingsModelDesc": "Embedding‑Modell‑Identifier",
-  "settings.field.temperature": "Temperatur",
-  "settings.field.temperatureDesc": "Standard‑Sampling‑Temperatur (0.0–2.0)",
-
   // Settings — agent groups
   "settings.group.core": "Kern",
   "settings.group.heartbeat": "Heartbeat",

--- a/crates/ironclaw_webui_v2/static/js/i18n/en.js
+++ b/crates/ironclaw_webui_v2/static/js/i18n/en.js
@@ -377,19 +377,6 @@ registerPack("en", {
   "llm.missingBaseUrl": "Missing base URL",
   "llm.addApiKey": "Add API key",
 
-  // Settings — inference groups
-  "settings.group.embeddings": "Embeddings",
-  "settings.group.sampling": "Sampling",
-  "settings.field.embeddingsEnabled": "Enable embeddings",
-  "settings.field.embeddingsEnabledDesc":
-    "Semantic search over workspace memory",
-  "settings.field.embeddingsProvider": "Provider",
-  "settings.field.embeddingsProviderDesc": "Embedding model provider",
-  "settings.field.embeddingsModel": "Model",
-  "settings.field.embeddingsModelDesc": "Embedding model identifier",
-  "settings.field.temperature": "Temperature",
-  "settings.field.temperatureDesc": "Default sampling temperature (0.0–2.0)",
-
   // Settings — agent groups
   "settings.group.core": "Core",
   "settings.group.heartbeat": "Heartbeat",

--- a/crates/ironclaw_webui_v2/static/js/i18n/es.js
+++ b/crates/ironclaw_webui_v2/static/js/i18n/es.js
@@ -368,18 +368,6 @@ registerPack("es", {
   "llm.missingBaseUrl": "Falta URL base",
   "llm.addApiKey": "Agregar clave API",
 
-  // Settings — inference groups
-  "settings.group.embeddings": "Incrustaciones",
-  "settings.group.sampling": "Muestreo",
-  "settings.field.embeddingsEnabled": "Habilitar embeddings",
-  "settings.field.embeddingsEnabledDesc": "Búsqueda semántica sobre la memoria del workspace",
-  "settings.field.embeddingsProvider": "Proveedor",
-  "settings.field.embeddingsProviderDesc": "Proveedor del modelo de embeddings",
-  "settings.field.embeddingsModel": "Modelo",
-  "settings.field.embeddingsModelDesc": "Identificador del modelo de embeddings",
-  "settings.field.temperature": "Temperatura",
-  "settings.field.temperatureDesc": "Temperatura de muestreo por defecto (0.0–2.0)",
-
   // Settings — agent groups
   "settings.group.core": "Núcleo",
   "settings.group.heartbeat": "Heartbeat",

--- a/crates/ironclaw_webui_v2/static/js/i18n/fr.js
+++ b/crates/ironclaw_webui_v2/static/js/i18n/fr.js
@@ -368,18 +368,6 @@ registerPack("fr", {
   "llm.missingBaseUrl": "URL de base manquante",
   "llm.addApiKey": "Ajouter une clé API",
 
-  // Settings — inference groups
-  "settings.group.embeddings": "Intégrations",
-  "settings.group.sampling": "Échantillonnage",
-  "settings.field.embeddingsEnabled": "Activer les embeddings",
-  "settings.field.embeddingsEnabledDesc": "Recherche sémantique sur la mémoire du workspace",
-  "settings.field.embeddingsProvider": "Fournisseur",
-  "settings.field.embeddingsProviderDesc": "Fournisseur du modèle d’embeddings",
-  "settings.field.embeddingsModel": "Modèle",
-  "settings.field.embeddingsModelDesc": "Identifiant du modèle d’embeddings",
-  "settings.field.temperature": "Température",
-  "settings.field.temperatureDesc": "Température d’échantillonnage par défaut (0.0–2.0)",
-
   // Settings — agent groups
   "settings.group.core": "Cœur",
   "settings.group.heartbeat": "Battement de cœur",

--- a/crates/ironclaw_webui_v2/static/js/i18n/hi.js
+++ b/crates/ironclaw_webui_v2/static/js/i18n/hi.js
@@ -368,18 +368,6 @@ registerPack("hi", {
   "llm.missingBaseUrl": "गुम आधार यूआरएल",
   "llm.addApiKey": "एपीआई कुंजी जोड़ें",
 
-  // Settings — inference groups
-  "settings.group.embeddings": "एंबेडिंग्स",
-  "settings.group.sampling": "सैंपलिंग",
-  "settings.field.embeddingsEnabled": "Embeddings सक्षम करें",
-  "settings.field.embeddingsEnabledDesc": "वर्कस्पेस मेमोरी पर semantic search",
-  "settings.field.embeddingsProvider": "प्रदाता",
-  "settings.field.embeddingsProviderDesc": "Embedding मॉडल provider",
-  "settings.field.embeddingsModel": "मॉडल",
-  "settings.field.embeddingsModelDesc": "Embedding मॉडल identifier",
-  "settings.field.temperature": "तापमान",
-  "settings.field.temperatureDesc": "डिफ़ॉल्ट sampling temperature (0.0–2.0)",
-
   // Settings — agent groups
   "settings.group.core": "कोर",
   "settings.group.heartbeat": "दिल की धड़कन",

--- a/crates/ironclaw_webui_v2/static/js/i18n/ja.js
+++ b/crates/ironclaw_webui_v2/static/js/i18n/ja.js
@@ -368,18 +368,6 @@ registerPack("ja", {
   "llm.missingBaseUrl": "ベース URL がありません",
   "llm.addApiKey": "API キーを追加",
 
-  // Settings — inference groups
-  "settings.group.embeddings": "埋め込み",
-  "settings.group.sampling": "サンプリング",
-  "settings.field.embeddingsEnabled": "埋め込みを有効化",
-  "settings.field.embeddingsEnabledDesc": "ワークスペースメモリのセマンティック検索",
-  "settings.field.embeddingsProvider": "プロバイダー",
-  "settings.field.embeddingsProviderDesc": "埋め込みモデルのプロバイダー",
-  "settings.field.embeddingsModel": "モデル",
-  "settings.field.embeddingsModelDesc": "埋め込みモデル識別子",
-  "settings.field.temperature": "温度",
-  "settings.field.temperatureDesc": "デフォルトのサンプリング温度 (0.0–2.0)",
-
   // Settings — agent groups
   "settings.group.core": "コア",
   "settings.group.heartbeat": "ハートビート",

--- a/crates/ironclaw_webui_v2/static/js/i18n/ko.js
+++ b/crates/ironclaw_webui_v2/static/js/i18n/ko.js
@@ -368,18 +368,6 @@ registerPack("ko", {
   "llm.missingBaseUrl": "기본 URL 누락",
   "llm.addApiKey": "API 키 추가",
 
-  // Settings — inference groups
-  "settings.group.embeddings": "임베딩",
-  "settings.group.sampling": "샘플링",
-  "settings.field.embeddingsEnabled": "임베딩 활성화",
-  "settings.field.embeddingsEnabledDesc": "워크스페이스 메모리의 시맨틱 검색",
-  "settings.field.embeddingsProvider": "제공자",
-  "settings.field.embeddingsProviderDesc": "임베딩 모델 제공자",
-  "settings.field.embeddingsModel": "모델",
-  "settings.field.embeddingsModelDesc": "임베딩 모델 식별자",
-  "settings.field.temperature": "온도",
-  "settings.field.temperatureDesc": "기본 샘플링 온도 (0.0–2.0)",
-
   // Settings — agent groups
   "settings.group.core": "핵심",
   "settings.group.heartbeat": "하트비트",

--- a/crates/ironclaw_webui_v2/static/js/i18n/pt-BR.js
+++ b/crates/ironclaw_webui_v2/static/js/i18n/pt-BR.js
@@ -368,18 +368,6 @@ registerPack("pt-BR", {
   "llm.missingBaseUrl": "URL base ausente",
   "llm.addApiKey": "Adicionar chave de API",
 
-  // Settings — inference groups
-  "settings.group.embeddings": "Embeddings",
-  "settings.group.sampling": "Amostragem",
-  "settings.field.embeddingsEnabled": "Ativar embeddings",
-  "settings.field.embeddingsEnabledDesc": "Busca semântica na memória do workspace",
-  "settings.field.embeddingsProvider": "Provedor",
-  "settings.field.embeddingsProviderDesc": "Provedor do modelo de embeddings",
-  "settings.field.embeddingsModel": "Modelo",
-  "settings.field.embeddingsModelDesc": "Identificador do modelo de embeddings",
-  "settings.field.temperature": "Temperatura",
-  "settings.field.temperatureDesc": "Temperatura padrão de amostragem (0.0–2.0)",
-
   // Settings — agent groups
   "settings.group.core": "Núcleo",
   "settings.group.heartbeat": "Heartbeat",

--- a/crates/ironclaw_webui_v2/static/js/i18n/uk.js
+++ b/crates/ironclaw_webui_v2/static/js/i18n/uk.js
@@ -368,18 +368,6 @@ registerPack("uk", {
   "llm.missingBaseUrl": "Відсутня базова URL-адреса",
   "llm.addApiKey": "Додати ключ API",
 
-  // Settings — inference groups
-  "settings.group.embeddings": "Ембедінги",
-  "settings.group.sampling": "Семплінг",
-  "settings.field.embeddingsEnabled": "Увімкнути ембедінги",
-  "settings.field.embeddingsEnabledDesc": "Семантичний пошук по пам’яті робочого простору",
-  "settings.field.embeddingsProvider": "Провайдер",
-  "settings.field.embeddingsProviderDesc": "Провайдер моделі ембедінгів",
-  "settings.field.embeddingsModel": "Модель",
-  "settings.field.embeddingsModelDesc": "Ідентифікатор моделі ембедінгів",
-  "settings.field.temperature": "Температура",
-  "settings.field.temperatureDesc": "Температура семплінгу за замовчуванням (0.0–2.0)",
-
   // Settings — agent groups
   "settings.group.core": "Основне",
   "settings.group.heartbeat": "Heartbeat",

--- a/crates/ironclaw_webui_v2/static/js/i18n/zh-CN.js
+++ b/crates/ironclaw_webui_v2/static/js/i18n/zh-CN.js
@@ -368,18 +368,6 @@ registerPack("zh-CN", {
   "llm.missingBaseUrl": "缺少基础 URL",
   "llm.addApiKey": "添加 API 密钥",
 
-  // Settings — inference groups
-  "settings.group.embeddings": "向量嵌入",
-  "settings.group.sampling": "采样",
-  "settings.field.embeddingsEnabled": "启用嵌入",
-  "settings.field.embeddingsEnabledDesc": "工作区记忆的语义搜索",
-  "settings.field.embeddingsProvider": "提供商",
-  "settings.field.embeddingsProviderDesc": "嵌入模型提供商",
-  "settings.field.embeddingsModel": "模型",
-  "settings.field.embeddingsModelDesc": "嵌入模型标识",
-  "settings.field.temperature": "温度",
-  "settings.field.temperatureDesc": "默认采样温度 (0.0–2.0)",
-
   // Settings — agent groups
   "settings.group.core": "核心",
   "settings.group.heartbeat": "心跳",

--- a/crates/ironclaw_webui_v2/static/js/pages/settings/components/inference-tab.test.mjs
+++ b/crates/ironclaw_webui_v2/static/js/pages/settings/components/inference-tab.test.mjs
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import vm from "node:vm";
+
+import { INFERENCE_FIELDS } from "../lib/settings-schema.js";
+import { filterSettingsSections, matchesSearch } from "../lib/settings-search.js";
+
+function sourceForTest(path, exportNames) {
+  const source = readFileSync(new URL(path, import.meta.url), "utf8");
+  const lines = [];
+  let skippingImport = false;
+  for (const line of source.split("\n")) {
+    if (!skippingImport && line.startsWith("import ")) {
+      skippingImport = !line.trimEnd().endsWith(";");
+      continue;
+    }
+    if (skippingImport) {
+      skippingImport = !line.trimEnd().endsWith(";");
+      continue;
+    }
+    lines.push(line.replace(/^export function /, "function "));
+  }
+  return `${lines.join("\n")}\nglobalThis.__testExports = { ${exportNames.join(", ")} };`;
+}
+
+function html(strings, ...values) {
+  return { strings: Array.from(strings), values };
+}
+
+function visit(node, fn) {
+  if (Array.isArray(node)) {
+    for (const item of node) visit(item, fn);
+    return;
+  }
+  if (!node || typeof node !== "object") return;
+  fn(node);
+  if (Array.isArray(node.values)) {
+    for (const value of node.values) visit(value, fn);
+  }
+}
+
+function findComponentNodes(root, component) {
+  const found = [];
+  visit(root, (node) => {
+    if (Array.isArray(node.values) && node.values.includes(component)) {
+      found.push(node);
+    }
+  });
+  return found;
+}
+
+function component(name) {
+  return function TestComponent() {
+    return name;
+  };
+}
+
+function renderInferenceModule() {
+  const context = {
+    Badge: component("Badge"),
+    Card: component("Card"),
+    ProviderManagement: component("ProviderManagement"),
+    SettingsGroup: component("SettingsGroup"),
+    SettingsSearchEmpty: component("SettingsSearchEmpty"),
+    globalThis: {},
+    html,
+    INFERENCE_FIELDS,
+    filterSettingsSections,
+    matchesSearch,
+    useLlmProviders: () => ({
+      activeProviderId: "openai",
+      selectedModel: "gpt-4.1",
+      providers: [{ id: "openai", default_model: "gpt-4.1" }],
+      hasActiveProvider: true,
+    }),
+    useT: () => (key) => key,
+  };
+
+  vm.runInNewContext(sourceForTest("./inference-tab.js", ["InferenceTab"]), context);
+  return { context, exports: context.globalThis.__testExports };
+}
+
+test("Inference tab omits unsupported operator-config fields", () => {
+  const { context, exports } = renderInferenceModule();
+  const rendered = exports.InferenceTab({
+    settings: {},
+    gatewayStatus: null,
+    onSave: () => {},
+    savedKeys: {},
+    isLoading: false,
+    searchQuery: "",
+  });
+
+  assert.equal(
+    findComponentNodes(rendered, context.SettingsGroup).length,
+    0,
+    "unsupported settings like temperature must not render editable controls"
+  );
+  assert.equal(
+    findComponentNodes(rendered, context.ProviderManagement).length,
+    1,
+    "LLM provider management should remain visible"
+  );
+});

--- a/crates/ironclaw_webui_v2/static/js/pages/settings/components/inference-tab.test.mjs
+++ b/crates/ironclaw_webui_v2/static/js/pages/settings/components/inference-tab.test.mjs
@@ -1,28 +1,9 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
 import test from "node:test";
-import vm from "node:vm";
 
 import { INFERENCE_FIELDS } from "../lib/settings-schema.js";
 import { filterSettingsSections, matchesSearch } from "../lib/settings-search.js";
-
-function sourceForTest(path, exportNames) {
-  const source = readFileSync(new URL(path, import.meta.url), "utf8");
-  const lines = [];
-  let skippingImport = false;
-  for (const line of source.split("\n")) {
-    if (!skippingImport && line.startsWith("import ")) {
-      skippingImport = !line.trimEnd().endsWith(";");
-      continue;
-    }
-    if (skippingImport) {
-      skippingImport = !line.trimEnd().endsWith(";");
-      continue;
-    }
-    lines.push(line.replace(/^export function /, "function "));
-  }
-  return `${lines.join("\n")}\nglobalThis.__testExports = { ${exportNames.join(", ")} };`;
-}
+import { runVmModuleForTest } from "../../../test-support/vm-module-harness.test.mjs";
 
 function html(strings, ...values) {
   return { strings: Array.from(strings), values };
@@ -63,7 +44,6 @@ function renderInferenceModule() {
     ProviderManagement: component("ProviderManagement"),
     SettingsGroup: component("SettingsGroup"),
     SettingsSearchEmpty: component("SettingsSearchEmpty"),
-    globalThis: {},
     html,
     INFERENCE_FIELDS,
     filterSettingsSections,
@@ -77,8 +57,13 @@ function renderInferenceModule() {
     useT: () => (key) => key,
   };
 
-  vm.runInNewContext(sourceForTest("./inference-tab.js", ["InferenceTab"]), context);
-  return { context, exports: context.globalThis.__testExports };
+  const exports = runVmModuleForTest(
+    "./inference-tab.js",
+    ["InferenceTab"],
+    context,
+    import.meta.url
+  );
+  return { context, exports };
 }
 
 test("Inference tab omits unsupported operator-config fields", () => {

--- a/crates/ironclaw_webui_v2/static/js/pages/settings/components/provider-components.test.mjs
+++ b/crates/ironclaw_webui_v2/static/js/pages/settings/components/provider-components.test.mjs
@@ -1,33 +1,14 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
 import test from "node:test";
-import vm from "node:vm";
 
 import { groupProvidersByStatus } from "../lib/llm-providers.js";
+import { runVmModuleForTest } from "../../../test-support/vm-module-harness.test.mjs";
 
 const PROVIDER_GROUP_LABELS = [
   "llm.groupActive",
   "llm.groupReady",
   "llm.groupSetup",
 ];
-
-function sourceForTest(path, exportNames) {
-  const source = readFileSync(new URL(path, import.meta.url), "utf8");
-  const lines = [];
-  let skippingImport = false;
-  for (const line of source.split("\n")) {
-    if (!skippingImport && line.startsWith("import ")) {
-      skippingImport = !line.trimEnd().endsWith(";");
-      continue;
-    }
-    if (skippingImport) {
-      skippingImport = !line.trimEnd().endsWith(";");
-      continue;
-    }
-    lines.push(line.replace(/^export function /, "function "));
-  }
-  return `${lines.join("\n")}\nglobalThis.__testExports = { ${exportNames.join(", ")} };`;
-}
 
 function html(strings, ...values) {
   return { strings: Array.from(strings), values };
@@ -168,7 +149,6 @@ function renderProviderManagement({ providers, activeProviderId = "nearai", sear
     ProviderDialog: "ProviderDialog",
     ProviderLoginStatus: "ProviderLoginStatus",
     SettingsSearchEmpty: "SettingsSearchEmpty",
-    globalThis: {},
     groupProvidersByStatus,
     html,
     useProviderManagementActions: useProviderManagementActionsStub({
@@ -185,11 +165,13 @@ function renderProviderManagement({ providers, activeProviderId = "nearai", sear
     useT: () => (key) => key,
   };
 
-  vm.runInNewContext(
-    sourceForTest("./provider-management.js", ["ProviderManagement"]),
-    context
+  const exports = runVmModuleForTest(
+    "./provider-management.js",
+    ["ProviderManagement"],
+    context,
+    import.meta.url
   );
-  const rendered = context.globalThis.__testExports.ProviderManagement({
+  const rendered = exports.ProviderManagement({
     settings: {},
     gatewayStatus: {},
     searchQuery,
@@ -201,15 +183,16 @@ function renderProviderManagement({ providers, activeProviderId = "nearai", sear
 }
 
 function evalIsLocalDevOrigin({ hostname }) {
-  const context = { globalThis: {} };
+  const context = {};
   if (hostname !== undefined) {
     context.window = { location: { hostname } };
   }
-  vm.runInNewContext(
-    sourceForTest("../hooks/useProviderLogin.js", ["isLocalDevOrigin"]),
-    context
-  );
-  return context.globalThis.__testExports.isLocalDevOrigin();
+  return runVmModuleForTest(
+    "../hooks/useProviderLogin.js",
+    ["isLocalDevOrigin"],
+    context,
+    import.meta.url
+  ).isLocalDevOrigin();
 }
 
 function groupLabels(rendered) {
@@ -276,7 +259,6 @@ function createProviderCardHarness() {
     Icon: "Icon",
     React: createReactStateStub(state),
     adapterLabel: (adapter) => adapter,
-    globalThis: {},
     html,
     isProviderConfigured: (provider) => provider.configured !== false,
     providerAcceptsApiKey: (provider) => provider.accepts_api_key !== false,
@@ -286,15 +268,17 @@ function createProviderCardHarness() {
     useT: () => (key) => key,
   };
 
-  vm.runInNewContext(
-    sourceForTest("./provider-card.js", ["ProviderCard"]),
-    context
+  const exports = runVmModuleForTest(
+    "./provider-card.js",
+    ["ProviderCard"],
+    context,
+    import.meta.url
   );
 
   return {
     state,
     render: (props) =>
-      context.globalThis.__testExports.ProviderCard({
+      exports.ProviderCard({
         activeProviderId: "nearai",
         selectedModel: "active-model",
         builtinOverrides: {},
@@ -327,20 +311,21 @@ function createNearAiSetupMenuHarness() {
         if (state.listeners?.[type] === handler) delete state.listeners[type];
       },
     },
-    globalThis: {},
     html,
   };
 
-  vm.runInNewContext(
-    sourceForTest("../../onboarding/onboarding-page.js", ["NearAiSetupMenu"]),
-    context
+  const exports = runVmModuleForTest(
+    "../../onboarding/onboarding-page.js",
+    ["NearAiSetupMenu"],
+    context,
+    import.meta.url
   );
 
   return {
     calls,
     state,
     render: (props = {}) =>
-      context.globalThis.__testExports.NearAiSetupMenu({
+      exports.NearAiSetupMenu({
         provider: builtinProvider("nearai", { adapter: "nearai" }),
         isBusy: false,
         login: {
@@ -709,10 +694,11 @@ function runProviderLogin({ hostname, activeProviderId = null, popupClosed = fal
       crypto: { randomUUID: () => "uuid" },
     },
   };
-  context.globalThis = context;
-  vm.runInNewContext(
-    sourceForTest("../hooks/useProviderLogin.js", ["useProviderLogin"]),
-    context
+  const exports = runVmModuleForTest(
+    "../hooks/useProviderLogin.js",
+    ["useProviderLogin"],
+    context,
+    import.meta.url
   );
   // useState order in the hook: nearaiBusy(0), nearaiError(1), codexBusy(2),
   // codexError(3), codexCode(4).
@@ -721,7 +707,7 @@ function runProviderLogin({ hostname, activeProviderId = null, popupClosed = fal
   const CODEX_BUSY_SLOT = 2;
   const CODEX_ERROR_SLOT = 3;
   return {
-    hook: context.globalThis.__testExports.useProviderLogin({}),
+    hook: exports.useProviderLogin({}),
     httpCalls,
     openedUrls,
     popups,

--- a/crates/ironclaw_webui_v2/static/js/pages/settings/components/skill-install-panel.test.mjs
+++ b/crates/ironclaw_webui_v2/static/js/pages/settings/components/skill-install-panel.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
 import test from "node:test";
-import vm from "node:vm";
+
+import { runVmModuleForTest } from "../../../test-support/vm-module-harness.test.mjs";
 
 const COPY = {
   "skills.content": "SKILL.md content",
@@ -18,24 +18,6 @@ const COPY = {
   "skills.namePlaceholder": "skill-name",
   "skills.nameRequired": "Skill name is required.",
 };
-
-function skillInstallPanelSourceForTest() {
-  const source = readFileSync(new URL("./skill-install-panel.js", import.meta.url), "utf8");
-  const lines = [];
-  let skippingImport = false;
-  for (const line of source.split("\n")) {
-    if (!skippingImport && line.startsWith("import ")) {
-      skippingImport = !line.trimEnd().endsWith(";");
-      continue;
-    }
-    if (skippingImport) {
-      skippingImport = !line.trimEnd().endsWith(";");
-      continue;
-    }
-    lines.push(line.replace(/^export function /, "function "));
-  }
-  return `${lines.join("\n")}\nglobalThis.__testExports = { SkillInstallPanel };`;
-}
 
 function html(strings, ...values) {
   return { strings: Array.from(strings), values };
@@ -113,7 +95,6 @@ function createHarness({ onInstall = async () => ({ success: true }) } = {}) {
 
   const installs = [];
   const context = {
-    globalThis: {},
     Boolean,
     Button,
     Card,
@@ -131,7 +112,12 @@ function createHarness({ onInstall = async () => ({ success: true }) } = {}) {
       return value;
     },
   };
-  vm.runInNewContext(skillInstallPanelSourceForTest(), context);
+  const exports = runVmModuleForTest(
+    "./skill-install-panel.js",
+    ["SkillInstallPanel"],
+    context,
+    import.meta.url
+  );
   const allComponents = new Set([Button, Card, FormField, Icon, Input, Textarea]);
 
   return {
@@ -145,7 +131,7 @@ function createHarness({ onInstall = async () => ({ success: true }) } = {}) {
     },
     render({ isInstalling = false } = {}) {
       cursor = 0;
-      return context.globalThis.__testExports.SkillInstallPanel({
+      return exports.SkillInstallPanel({
         isInstalling,
         onInstall: async (payload) => {
           installs.push(payload);

--- a/crates/ironclaw_webui_v2/static/js/pages/settings/components/tools-tab.test.mjs
+++ b/crates/ironclaw_webui_v2/static/js/pages/settings/components/tools-tab.test.mjs
@@ -1,25 +1,7 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
 import test from "node:test";
-import vm from "node:vm";
 
-function sourceForTest(path, exportNames) {
-  const source = readFileSync(new URL(path, import.meta.url), "utf8");
-  const lines = [];
-  let skippingImport = false;
-  for (const line of source.split("\n")) {
-    if (!skippingImport && line.startsWith("import ")) {
-      skippingImport = !line.trimEnd().endsWith(";");
-      continue;
-    }
-    if (skippingImport) {
-      skippingImport = !line.trimEnd().endsWith(";");
-      continue;
-    }
-    lines.push(line.replace(/^export function /, "function "));
-  }
-  return `${lines.join("\n")}\nglobalThis.__testExports = { ${exportNames.join(", ")} };`;
-}
+import { runVmModuleForTest } from "../../../test-support/vm-module-harness.test.mjs";
 
 function html(strings, ...values) {
   return { strings: Array.from(strings), values };
@@ -98,7 +80,6 @@ function renderToolsModule({ tools = [], translations = {} } = {}) {
     Badge: "Badge",
     Card: "Card",
     Icon: "Icon",
-    globalThis: {},
     html,
     matchesSearch: (query, values) =>
       !query || values.some((value) => String(value || "").includes(query)),
@@ -110,11 +91,13 @@ function renderToolsModule({ tools = [], translations = {} } = {}) {
       savedTools: {},
     }),
   };
-  vm.runInNewContext(
-    sourceForTest("./tools-tab.js", ["ToolsTab", "AutoApproveCard", "Switch", "ToolRow"]),
-    context
+  const exports = runVmModuleForTest(
+    "./tools-tab.js",
+    ["ToolsTab", "AutoApproveCard", "Switch", "ToolRow"],
+    context,
+    import.meta.url
   );
-  return { exports: context.globalThis.__testExports, saved };
+  return { exports, saved };
 }
 
 test("Tools tab renders global auto-approve control and saves the operator key", () => {

--- a/crates/ironclaw_webui_v2/static/js/pages/settings/lib/settings-schema.js
+++ b/crates/ironclaw_webui_v2/static/js/pages/settings/lib/settings-schema.js
@@ -10,22 +10,9 @@ export const SETTINGS_TABS = [
   { id: "language", labelKey: "settings.language", icon: "globe" },
 ];
 
-export const INFERENCE_FIELDS = [
-  {
-    groupKey: "settings.group.embeddings",
-    fields: [
-      { key: "embeddings.enabled", labelKey: "settings.field.embeddingsEnabled", descKey: "settings.field.embeddingsEnabledDesc", type: "boolean" },
-      { key: "embeddings.provider", labelKey: "settings.field.embeddingsProvider", descKey: "settings.field.embeddingsProviderDesc", type: "select", options: ["openai", "nearai"] },
-      { key: "embeddings.model", labelKey: "settings.field.embeddingsModel", descKey: "settings.field.embeddingsModelDesc", type: "text" },
-    ],
-  },
-  {
-    groupKey: "settings.group.sampling",
-    fields: [
-      { key: "temperature", labelKey: "settings.field.temperature", descKey: "settings.field.temperatureDesc", type: "float", min: 0, max: 2, step: 0.1 },
-    ],
-  },
-];
+// Inference settings use dedicated LLM endpoints. Keep this schema empty until
+// any operator-config-backed keys are accepted by the Reborn config API.
+export const INFERENCE_FIELDS = [];
 
 export const AGENT_FIELDS = [
   {

--- a/crates/ironclaw_webui_v2/static/js/pages/settings/lib/settings-schema.js
+++ b/crates/ironclaw_webui_v2/static/js/pages/settings/lib/settings-schema.js
@@ -101,7 +101,6 @@ export const NETWORKING_FIELDS = [
 ];
 
 export const RESTART_REQUIRED_KEYS = new Set([
-  "embeddings.enabled", "embeddings.provider", "embeddings.model",
   "tunnel.provider", "tunnel.public_url",
   "gateway.rate_limit", "gateway.max_connections",
 ]);

--- a/crates/ironclaw_webui_v2/static/js/pages/settings/lib/settings-schema.test.mjs
+++ b/crates/ironclaw_webui_v2/static/js/pages/settings/lib/settings-schema.test.mjs
@@ -6,3 +6,14 @@ import { RESTART_REQUIRED_KEYS } from "./settings-schema.js";
 test("approval settings apply live without a restart banner", () => {
   assert.equal(RESTART_REQUIRED_KEYS.has("agent.auto_approve_tools"), false);
 });
+
+test("unsupported inference settings do not trigger a restart banner", () => {
+  for (const key of [
+    "embeddings.enabled",
+    "embeddings.provider",
+    "embeddings.model",
+    "llm.temperature",
+  ]) {
+    assert.equal(RESTART_REQUIRED_KEYS.has(key), false, `${key} should not require restart`);
+  }
+});

--- a/crates/ironclaw_webui_v2/static/js/pages/settings/vm-module-harness.test.mjs
+++ b/crates/ironclaw_webui_v2/static/js/pages/settings/vm-module-harness.test.mjs
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import vm from "node:vm";
+
+import { sourceTextForVmTest } from "../../test-support/vm-module-harness.test.mjs";
+
+function evaluate(source, exportNames) {
+  const context = { globalThis: {} };
+  vm.runInNewContext(sourceTextForVmTest(source, exportNames), context);
+  return context.globalThis.__testExports;
+}
+
+test("VM harness keeps code after semicolonless multiline imports", () => {
+  const exports = evaluate(
+    `
+import {
+  alpha,
+  beta,
+} from "./deps.js"
+const value = "still here";
+export function readValue() {
+  return value;
+}
+`,
+    ["readValue"]
+  );
+
+  assert.equal(exports.readValue(), "still here");
+});
+
+test("VM harness captures exported declarations and named export aliases", () => {
+  const exports = evaluate(
+    `
+const base = 41;
+export const answer = base + 1;
+function readAnswer() {
+  return answer;
+}
+export { readAnswer as getAnswer };
+`,
+    ["answer", "getAnswer"]
+  );
+
+  assert.equal(exports.answer, 42);
+  assert.equal(exports.getAnswer(), 42);
+});

--- a/crates/ironclaw_webui_v2/static/js/test-support/vm-module-harness.test.mjs
+++ b/crates/ironclaw_webui_v2/static/js/test-support/vm-module-harness.test.mjs
@@ -1,0 +1,49 @@
+import { readFileSync } from "node:fs";
+import vm from "node:vm";
+import { fileURLToPath } from "node:url";
+
+const STATIC_IMPORT_RE =
+  /(^|\n)[ \t]*import(?:\s+[\s\S]*?\s+from\s*)?\s*["'][^"'\n]+["'](?:\s+(?:assert|with)\s*\{[\s\S]*?\})?\s*;?[ \t]*(?=\n|$)/g;
+const NAMED_EXPORT_DECLARATION_RE =
+  /^(\s*)export\s+(?=(?:async\s+)?function\b|class\b|(?:const|let|var)\b)/gm;
+const NAMED_EXPORT_LIST_RE = /^(\s*)export\s*\{([\s\S]*?)\}\s*;?[ \t]*$/gm;
+
+export function sourceForVmTest(path, exportNames, metaUrl) {
+  return sourceTextForVmTest(
+    readFileSync(new URL(path, metaUrl), "utf8"),
+    exportNames
+  );
+}
+
+export function sourceTextForVmTest(source, exportNames) {
+  const exportAliases = new Map();
+  const transformed = source
+    .replace(STATIC_IMPORT_RE, "$1")
+    .replace(NAMED_EXPORT_LIST_RE, (_match, _indent, specifiers) => {
+      for (const specifier of specifiers.split(",")) {
+        const trimmed = specifier.trim();
+        if (!trimmed) continue;
+        const [localName, exportedName = localName] = trimmed.split(/\s+as\s+/);
+        exportAliases.set(exportedName.trim(), localName.trim());
+      }
+      return "";
+    })
+    .replace(NAMED_EXPORT_DECLARATION_RE, "$1");
+  const testExports = exportNames
+    .map((name) => {
+      const localName = exportAliases.get(name) || name;
+      return localName === name ? name : `${JSON.stringify(name)}: ${localName}`;
+    })
+    .join(", ");
+  return `${transformed.trimEnd()}\nglobalThis.__testExports = { ${testExports} };\n`;
+}
+
+export function runVmModuleForTest(path, exportNames, context, metaUrl) {
+  const moduleUrl = new URL(path, metaUrl);
+  // Capture exports on a detached object; the sandbox globals stay explicit.
+  context.globalThis = {};
+  vm.runInNewContext(sourceForVmTest(path, exportNames, metaUrl), context, {
+    filename: fileURLToPath(moduleUrl),
+  });
+  return context.globalThis.__testExports;
+}


### PR DESCRIPTION
## Summary
* Hides unsupported operator-config-backed Inference settings fields from WebUI v2.
* Keeps the existing LLM provider/model management UI visible on Settings → Inference.
* Adds a focused regression test to ensure unsupported editable controls like `temperature` are not rendered.

<img width="684" height="744" alt="iShot_2026-07-06_21 44 05" src="https://github.com/user-attachments/assets/ae7d9288-32bd-4628-b112-e1f779b749e0" />


## Linked Issue

Closes #5696

## Validation

* `node --test crates/ironclaw_webui_v2/static/js/pages/settings/**/*.test.mjs`
* `IRONCLAW_WEBUI_V2_DIST_DIR=/tmp/ironclaw-webui-v2-issue-5696 npm run build`

## Security Impact

No security-sensitive behavior changes. This only removes unsupported editable frontend controls.

## Database Impact

No schema or migration changes.

## Blast Radius

Limited to WebUI v2 Settings → Inference rendering and its frontend regression test.

## Rollback Plan

Revert this PR to restore the previous Inference settings schema.

---

Review track: A