### PR TITLE
[codex] Add SQL clients to Reborn image

### DIFF
--- a/Dockerfile.reborn
+++ b/Dockerfile.reborn
@@ -77,7 +77,10 @@ RUN cargo build \
 FROM debian:bookworm-slim AS runtime
 
 RUN apt-get -o Acquire::Retries=3 update \
-    && apt-get -o Acquire::Retries=3 install -y --no-install-recommends ca-certificates \
+    && apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
+        ca-certificates \
+        postgresql-client \
+        sqlite3 \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /app/target/dist/ironclaw-reborn /usr/local/bin/ironclaw-reborn

--- a/docs/reborn/deploy-reborn-cli-docker.md
+++ b/docs/reborn/deploy-reborn-cli-docker.md
@@ -146,6 +146,10 @@ that Reborn home on the mounted volume and does not require
 `IRONCLAW_REBORN_POSTGRES_URL`. The container workdir is `/workspace` so the
 workspace root stays separate from Reborn's state and skill roots.
 
+The image includes `sqlite3` and `psql` for terminal inspection from Railway
+shells. Use `sqlite3` for mounted-volume libSQL/SQLite state and `psql` for
+`IRONCLAW_REBORN_POSTGRES_URL` deployments.
+
 To seed a custom config instead of the bundled default, mount it under
 `/opt/ironclaw/` and set `IRONCLAW_REBORN_DEFAULT_CONFIG` to that path. On first
 start, the entrypoint copies that file into `$IRONCLAW_REBORN_HOME/config.toml`;

--- a/tests/dockerfile_runtime_home.rs
+++ b/tests/dockerfile_runtime_home.rs
@@ -170,6 +170,20 @@ fn reborn_dockerfile_uses_feature_matched_cache_and_loopback_default() {
 }
 
 #[test]
+fn reborn_runtime_image_includes_sql_debug_clients() {
+    let dockerfile = read_repo_file("Dockerfile.reborn");
+
+    assert!(
+        dockerfile.contains("postgresql-client"),
+        "runtime image must include psql for Railway hosted Postgres inspection"
+    );
+    assert!(
+        dockerfile.contains("sqlite3"),
+        "runtime image must include sqlite3 for volume-backed libSQL/SQLite inspection"
+    );
+}
+
+#[test]
 fn reborn_hosted_single_tenant_seed_config_contains_postgres_storage() {
     let config = read_repo_file("docker/reborn/config.hosted-single-tenant.toml");
 


### PR DESCRIPTION
## Summary
- Install sqlite3 in the Reborn runtime image for Railway shell inspection of volume-backed SQLite/libSQL state.
- Install postgresql-client so hosted Postgres deployments have psql available in the same shell.
- Document the available SQL clients and add a Dockerfile invariant test.

## Validation
- cargo test --test dockerfile_runtime_home