### PR TITLE
[codex] Update Reborn nightly tests for pairing flow

### DIFF
--- a/tests/e2e/scenarios/test_reborn_webui_v2_legacy_extensions.py
+++ b/tests/e2e/scenarios/test_reborn_webui_v2_legacy_extensions.py
@@ -735,7 +735,7 @@ async def test_reborn_legacy_extensions_install_auth_url_requires_https(
         await harness["context"].close()
 
 
-async def test_reborn_legacy_install_setup_required_channel_opens_configure_modal(
+async def test_reborn_legacy_install_setup_required_channel_opens_pairing_modal(
     reborn_v2_server, reborn_v2_browser
 ):
     setup_channel = {
@@ -785,9 +785,12 @@ async def test_reborn_legacy_install_setup_required_channel_opens_configure_moda
         await expect(
             page.get_by_role("heading", name="Configure Slack Channel")
         ).to_be_visible(timeout=5000)
-        await expect(page.get_by_text("Enter the Slack channel token.")).to_be_visible()
-        await expect(page.get_by_text("Slack bot token")).to_be_visible()
-        await expect(page.locator('input[type="password"]')).to_have_count(1)
+        modal = page.get_by_label("Configure Slack Channel")
+        await expect(page.get_by_text("Enter the code from the channel")).to_be_visible()
+        await expect(modal.get_by_label("Enter pairing code…")).to_be_visible()
+        await expect(modal.get_by_role("button", name="Connect")).to_be_disabled()
+        await expect(page.get_by_text("Slack bot token")).to_have_count(0)
+        await expect(page.locator('input[type="password"]')).to_have_count(0)
         assert harness["setup_submit_requests"] == []
     finally:
         await harness["context"].close()
@@ -1196,7 +1199,7 @@ async def test_reborn_legacy_activate_auth_url_accepts_uppercase_https(
         await harness["context"].close()
 
 
-async def test_reborn_legacy_channel_config_label_depends_on_authentication(
+async def test_reborn_legacy_channel_connect_label_depends_on_authentication(
     reborn_v2_server, reborn_v2_browser
 ):
     harness = await _open_mocked_extensions_page(
@@ -1225,10 +1228,10 @@ async def test_reborn_legacy_channel_config_label_depends_on_authentication(
         await expect(unauthenticated).to_be_visible(timeout=5000)
         await _open_card_menu(unauthenticated)
         await expect(
-            page.get_by_role("menuitem", name="Configure", exact=True)
+            page.get_by_role("menuitem", name="Connect", exact=True)
         ).to_have_count(1)
         await expect(
-            page.get_by_role("menuitem", name="Reconfigure", exact=True)
+            page.get_by_role("menuitem", name="Reconnect", exact=True)
         ).to_have_count(0)
 
         await page.mouse.click(8, 8)
@@ -1236,16 +1239,16 @@ async def test_reborn_legacy_channel_config_label_depends_on_authentication(
         await expect(authenticated).to_be_visible(timeout=5000)
         await _open_card_menu(authenticated)
         await expect(
-            page.get_by_role("menuitem", name="Reconfigure", exact=True)
+            page.get_by_role("menuitem", name="Reconnect", exact=True)
         ).to_have_count(1)
         await expect(
-            page.get_by_role("menuitem", name="Configure", exact=True)
+            page.get_by_role("menuitem", name="Connect", exact=True)
         ).to_have_count(0)
     finally:
         await harness["context"].close()
 
 
-async def test_reborn_legacy_channel_setup_required_has_single_configure_action(
+async def test_reborn_legacy_channel_setup_required_has_single_connect_action(
     reborn_v2_server, reborn_v2_browser
 ):
     harness = await _open_mocked_extensions_page(
@@ -1265,7 +1268,7 @@ async def test_reborn_legacy_channel_setup_required_has_single_configure_action(
         card = _card_by_title(page, "Label Channel")
         await expect(card).to_be_visible(timeout=5000)
 
-        await expect(card.get_by_role("button", name="Configure")).to_have_count(1)
+        await expect(card.get_by_role("button", name="Connect")).to_have_count(1)
         await _open_card_menu(card)
         await expect(page.get_by_role("menuitem", name="Setup", exact=True)).to_have_count(
             0
@@ -1273,11 +1276,12 @@ async def test_reborn_legacy_channel_setup_required_has_single_configure_action(
         await expect(
             page.get_by_role("menuitem", name="Configure", exact=True)
         ).to_have_count(0)
+        await expect(page.get_by_role("menuitem", name="Connect", exact=True)).to_have_count(0)
     finally:
         await harness["context"].close()
 
 
-async def test_reborn_legacy_channel_reconfigure_opens_modal_without_activate(
+async def test_reborn_legacy_channel_reconnect_opens_pairing_modal_without_activate(
     reborn_v2_server, reborn_v2_browser
 ):
     harness = await _open_mocked_extensions_page(
@@ -1318,11 +1322,13 @@ async def test_reborn_legacy_channel_reconfigure_opens_modal_without_activate(
         await expect(card).to_be_visible(timeout=5000)
 
         await _open_card_menu(card)
-        await page.get_by_role("menuitem", name="Reconfigure", exact=True).click()
+        await page.get_by_role("menuitem", name="Reconnect", exact=True).click()
         await expect(page.get_by_role("heading", name="Configure Label Channel")).to_be_visible(
             timeout=5000
         )
-        await expect(page.get_by_text("Bot token")).to_be_visible()
+        await expect(page.get_by_text("Enter the code from the channel")).to_be_visible()
+        await expect(page.get_by_label("Enter pairing code…")).to_be_visible()
+        await expect(page.get_by_text("Bot token")).to_have_count(0)
         assert harness["activate_requests"] == []
     finally:
         await harness["context"].close()
@@ -2043,7 +2049,7 @@ async def test_reborn_legacy_configure_modal_enter_key_submits(
         await harness["context"].close()
 
 
-async def test_reborn_legacy_telegram_token_configure_preserves_token_characters(
+async def test_reborn_legacy_telegram_pairing_code_preserves_token_characters(
     reborn_v2_server, reborn_v2_browser
 ):
     token = "123456789:ABCdef_GHI-jkl_mnop-QRSTuvwxyz"
@@ -2072,32 +2078,41 @@ async def test_reborn_legacy_telegram_token_configure_preserves_token_characters
     )
     try:
         page = harness["page"]
+        redeem_requests: list[dict] = []
+
+        async def handle_redeem(route):
+            redeem_requests.append(json.loads(route.request.post_data or "{}"))
+            await route.fulfill(
+                status=200,
+                content_type="application/json",
+                body=json.dumps(
+                    {
+                        "provider": "telegram",
+                        "provider_user_id": "123456789",
+                    }
+                ),
+            )
+
+        await page.route("**/api/webchat/v2/extensions/pairing/redeem", handle_redeem)
+
         card = _card_by_title(page, "Telegram")
         await expect(card).to_be_visible(timeout=5000)
-        await card.get_by_role("button", name="Configure").click()
+        await card.get_by_role("button", name="Connect").click()
 
         await expect(
             page.get_by_role("heading", name="Configure Telegram")
         ).to_be_visible(timeout=5000)
-        await expect(page.get_by_text("Telegram Bot Token")).to_be_visible()
-        await page.locator('input[type="password"]').first.fill(token)
-        await page.get_by_role("button", name="Save").click()
+        modal = page.get_by_label("Configure Telegram")
+        await expect(page.get_by_text("Enter the code from the channel")).to_be_visible()
+        await modal.get_by_label("Enter pairing code…").fill(token)
+        await modal.get_by_role("button", name="Connect").click()
 
         await expect(
             page.get_by_role("heading", name="Configure Telegram")
         ).to_have_count(0)
-        assert harness["setup_submit_requests"] == [
-            {
-                "package_id": "telegram",
-                "body": {
-                    "action": "submit",
-                    "payload": {
-                        "secrets": {"telegram_bot_token": token},
-                        "fields": {},
-                    },
-                },
-            }
-        ]
+        assert redeem_requests == [{"channel": "telegram", "code": token}]
+        assert harness["activate_requests"] == ["telegram"]
+        assert harness["setup_submit_requests"] == []
     finally:
         await harness["context"].close()
 

--- a/tests/e2e/scenarios/test_reborn_webui_v2_legacy_pending_messages.py
+++ b/tests/e2e/scenarios/test_reborn_webui_v2_legacy_pending_messages.py
@@ -470,7 +470,7 @@ async def test_reborn_legacy_pending_attachment_message_survives_thread_reload(
         await harness["context"].close()
 
 
-async def test_reborn_legacy_sidebar_refresh_keeps_active_thread_outside_summary_window(
+async def test_reborn_legacy_sidebar_cache_keeps_active_thread_outside_summary_window(
     reborn_v2_server, reborn_v2_browser
 ):
     async def handle_successful_send(route, _payload, fulfill_json):
@@ -519,10 +519,6 @@ async def test_reborn_legacy_sidebar_refresh_keeps_active_thread_outside_summary
                 has_text="Summary refresh should keep this Reborn thread"
             )
         ).to_have_count(1, timeout=5000)
-        await _wait_for_request_count(
-            harness["thread_requests"],
-            before_refresh_requests,
-        )
 
         assert len(harness["send_requests"]) == 1
         assert (
@@ -533,9 +529,16 @@ async def test_reborn_legacy_sidebar_refresh_keeps_active_thread_outside_summary
         await expect(composer).to_be_visible(timeout=5000)
         await expect(
             page.locator(SEL_V2["sidebar"]).get_by_role("button").filter(
+                has_text="Summary refresh should keep this Reborn thread"
+            )
+        ).to_be_visible(timeout=5000)
+        await expect(
+            page.locator(SEL_V2["sidebar"]).get_by_role("button").filter(
                 has_text="Newest summary thread"
             )
         ).to_be_visible(timeout=5000)
+        await page.wait_for_timeout(250)
+        assert len(harness["thread_requests"]) == before_refresh_requests
     finally:
         await harness["context"].close()
 


### PR DESCRIPTION
## Summary
- update Reborn extension E2E expectations for channel pairing-code flows (`Connect` / `Reconnect`)
- update the pending-message sidebar test for the local thread-cache behavior after sends

## Why
The Reborn WebUI functionality changed so channel extensions pair through proof-code connection flows instead of credential configure forms. The sidebar send path also updates the thread list cache locally instead of refetching the full `/threads` list after every successful send. The nightly failures were stale test expectations for those behaviors.

## Validation
- `uv run --project tests/e2e pytest scenarios/test_reborn_webui_v2_legacy_extensions.py -q --timeout=120 --durations=10`
- `uv run --project tests/e2e pytest scenarios/test_reborn_webui_v2_legacy_pending_messages.py -q --timeout=120 --durations=10`
- combined touched coverage: `40 passed`
- `git diff --check`