### PR TITLE
test: /benchmark CI probe (throwaway — confirms engine_v2 build fix)

### DIFF
--- a/docs/benchmark-ci-probe.md
+++ b/docs/benchmark-ci-probe.md
@@ -1,0 +1,3 @@
+# /benchmark CI probe
+
+Throwaway PR to confirm `/benchmark` builds against ironclaw main after benchmarks #219 (engine_v2 gate). Safe to close/delete.


### PR DESCRIPTION
Throwaway PR to verify `/benchmark` builds against ironclaw main after benchmarks #219 (gates `AgentConfig.engine_v2`). Will close once the build + run is confirmed. Do not merge.