### PR TITLE
test(reborn): C-MULTIUSER turn/run-state isolation across distinct actors

### DIFF
--- a/tests/integration/group_multiuser/main.rs
+++ b/tests/integration/group_multiuser/main.rs
@@ -17,6 +17,7 @@ mod support;
 
 mod scenario_auto_approve_isolation_across_actors;
 mod scenario_memory_isolation_across_actors;
+mod scenario_turn_state_isolation_across_actors;
 mod scenario_two_actors_own_threads;
 
 use reborn_support::group::{RebornIntegrationGroup, ScenarioReport};
@@ -54,6 +55,15 @@ async fn multiuser_group_e2e() {
     report.record(
         "auto_approve_isolation_across_actors",
         scenario_auto_approve_isolation_across_actors::run(&approvals_group).await,
+    );
+
+    // Scenario 4 (C-MULTIUSER): per-actor turn/run-state isolation — see
+    // scenario_turn_state_isolation_across_actors for the seam. Reuses the
+    // plain `builtin_tools` group (no gate needed): the store's own
+    // scope-equality gate is what's under test.
+    report.record(
+        "turn_state_isolation_across_actors",
+        scenario_turn_state_isolation_across_actors::run(&g).await,
     );
 
     report.assert_all_passed();

--- a/tests/integration/group_multiuser/scenario_turn_state_isolation_across_actors.rs
+++ b/tests/integration/group_multiuser/scenario_turn_state_isolation_across_actors.rs
@@ -1,0 +1,125 @@
+//! C-MULTIUSER scenario: per-actor TURN/RUN-STATE isolation on the shared
+//! `FilesystemTurnStateStore`. Unlike the thread/memory/approval stores, the
+//! group's turn_store is built with a construction-time-fixed mount view
+//! (`owner_turn_state_filesystem` in `ironclaw_reborn_composition::factory`,
+//! mirroring production's `HostedSingleTenant`/local-dev composition), so ALL
+//! actors' run records physically share ONE snapshot file. The only thing
+//! keeping one actor's run
+//! state from another's eyes is the store's own logical gate:
+//! `record.scope == request.scope` in `ironclaw_turns::memory`'s
+//! `get_run_state`/`resume_turn_once`/`request_cancel_once`. No existing
+//! scenario drives that gate directly — `scenario_two_actors_own_threads` and
+//! `group_journeys::scenario_multi_actor_gate_isolation` prove run-ids are
+//! distinct and gate refs don't cross, but never call `get_run_state` with a
+//! MISMATCHED actor's scope against another actor's real `run_id`.
+
+use super::reborn_support::group::{HarnessResult, RebornIntegrationGroup};
+use super::reborn_support::reply::RebornScriptedReply;
+use ironclaw_turns::{GetRunStateRequest, TurnError, TurnRunId, TurnScope, TurnStateStore};
+
+pub async fn run(g: &RebornIntegrationGroup) -> HarnessResult<()> {
+    // ── Actor A (default actor): complete a turn over the shared turn_store ──
+    let a = g
+        .thread("conv-turnstate-iso-a")
+        .script([RebornScriptedReply::text("reply-for-actor-a")])
+        .build()
+        .await?;
+    let run_a = a
+        .submit_turn("hello from actor a")
+        .await
+        .map_err(|e| format!("[A submit] {e}"))?;
+
+    // ── Actor B (DISTINCT actor, SAME shared turn_store) ──────────────────────
+    let b = g
+        .thread("conv-turnstate-iso-b")
+        .with_actor_id("reborn-actor-b")
+        .script([RebornScriptedReply::text("reply-for-actor-b")])
+        .build()
+        .await?;
+    // Non-vacuity: if `with_actor_id` regressed to a no-op, both scopes would
+    // be identical and the negative pins below would trivially "pass".
+    if a.binding.subject_user_id == b.binding.subject_user_id {
+        return Err("with_actor_id seam no-op: both actors resolved the same owner".into());
+    }
+    let run_b = b
+        .submit_turn("hello from actor b")
+        .await
+        .map_err(|e| format!("[B submit] {e}"))?;
+
+    // Positive pins: each actor reads back its OWN run under its OWN scope,
+    // and gets genuinely ITS record back (not just any `Ok(_)`).
+    assert_own_run_state_readable(a.turn_store.as_ref(), a.turn_scope.clone(), run_a, "A").await?;
+    assert_own_run_state_readable(b.turn_store.as_ref(), b.turn_scope.clone(), run_b, "B").await?;
+
+    // Negative pins, SYMMETRIC both ways: the store's scope-equality gate must
+    // reject a request for the OTHER actor's run_id under the reader's OWN
+    // scope — the one mechanism actually enforcing isolation given the shared
+    // physical snapshot file (see module doc).
+    assert_cannot_read_other_run_state(
+        a.turn_store.as_ref(),
+        a.turn_scope.clone(),
+        run_b,
+        "A",
+        "B",
+    )
+    .await?;
+    assert_cannot_read_other_run_state(
+        b.turn_store.as_ref(),
+        b.turn_scope.clone(),
+        run_a,
+        "B",
+        "A",
+    )
+    .await?;
+
+    Ok(())
+}
+
+async fn assert_own_run_state_readable(
+    turn_store: &impl TurnStateStore,
+    scope: TurnScope,
+    run_id: TurnRunId,
+    actor_name: &str,
+) -> HarnessResult<()> {
+    let state = turn_store
+        .get_run_state(GetRunStateRequest { scope, run_id })
+        .await
+        .map_err(|e| format!("[{actor_name} own get_run_state] {e}"))?;
+    if state.run_id != run_id {
+        return Err(format!(
+            "[{actor_name} own get_run_state] returned run_id {} instead of {run_id}",
+            state.run_id
+        )
+        .into());
+    }
+    Ok(())
+}
+
+async fn assert_cannot_read_other_run_state(
+    turn_store: &impl TurnStateStore,
+    reader_scope: TurnScope,
+    other_run_id: TurnRunId,
+    reader_name: &str,
+    other_name: &str,
+) -> HarnessResult<()> {
+    let result = turn_store
+        .get_run_state(GetRunStateRequest {
+            scope: reader_scope,
+            run_id: other_run_id,
+        })
+        .await;
+    match result {
+        Err(TurnError::ScopeNotFound) => Ok(()),
+        Err(other) => Err(format!(
+            "isolation guard fired for the wrong reason: actor {reader_name} reading actor \
+             {other_name}'s run_id under its own scope returned {other:?}, expected \
+             TurnError::ScopeNotFound"
+        )
+        .into()),
+        Ok(leaked) => Err(format!(
+            "isolation failure: actor {reader_name} read actor {other_name}'s run state \
+             ({leaked:?}) under its OWN scope"
+        )
+        .into()),
+    }
+}


### PR DESCRIPTION
## What

Closes the last uncovered edge of the Reborn multi-user isolation matrix (#5479): **per-actor turn/run-state isolation** on the shared `FilesystemTurnStateStore`.

Adds one integration scenario to the existing `group_multiuser` binary (one `mod` + one `report.record(...)` — no new harness, no new group builder).

## Why this edge was uncovered

The group's `turn_store` is built with a construction-time-fixed mount view (`owner_turn_state_filesystem`, mirroring production's `HostedSingleTenant`/local-dev composition), so **all actors' run records physically share one snapshot file**. Isolation therefore rests entirely on the store's own **logical** scope-equality gate — `record.scope == request.scope` in `ironclaw_turns::memory`'s `get_run_state`/`resume_turn_once`/`request_cancel_once`. Every prior multi-user scenario proves run-ids are distinct or that gate refs don't cross; none called `get_run_state` with a *mismatched* actor's scope against another actor's real `run_id`.

## Isolation edges the scenario covers

- **Positive pins:** each actor reads back its OWN run under its OWN scope and gets genuinely its record (`run_id` asserted, not a vacuous `Ok`).
- **Negative pins (symmetric both ways):** reading the OTHER actor's `run_id` under the reader's own scope returns `TurnError::ScopeNotFound`, not the leaked record — proving the gate fails closed in both directions.
- **Non-vacuity pin:** the two actors resolve genuinely distinct owners (guards against a `with_actor_id` no-op silently degrading to the same-owner case).

## Production scoping site (real isolation, not a test shim)

The gate under test is production code: `crates/ironclaw_turns/src/memory/mod.rs:1072` (`.filter(|record| record.scope == request.scope)`), reached via the production `FilesystemTurnStateStore` (wired at `crates/ironclaw_reborn_composition/src/factory.rs:2098`) on the real submit/resume/cancel/get_run_state path — production callers include `runtime.rs` `wait_for_terminal`, `ironclaw_conversations::inbound`, `reborn_services`, and `slack_delivery`. The harness reads the exact store instance the running loop persists to.

## Verification

- `cargo test --test reborn_group_multiuser --features integration` — 7 passed, 0 failed.
- **Mutation-verified RED:** removing the `.filter(|record| record.scope == request.scope)` clause in `get_run_state` flips the negative pin to a cross-actor read (actor A reads actor B's record); reverted via `git checkout`.
- `cargo fmt` clean; `cargo clippy --all --tests --all-features` — 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)