### PR TITLE
[codex] Fix WebUI frontend generated ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,10 +65,6 @@ trace_*.json
 # root they land in ./attachments/. These are user uploads, never source.
 /attachments/
 
-# Generated WebUI v2 bundle. Cargo builds and embeds this from OUT_DIR when
-# `webui-v2-beta` is enabled; the reviewable source lives under static/js/.
-/crates/ironclaw_webui_v2_static/static/dist/
-
 # Python cache
 __pycache__/
 *.pyc

--- a/crates/ironclaw_webui_v2/.gitignore
+++ b/crates/ironclaw_webui_v2/.gitignore
@@ -1,0 +1,1 @@
+/static/dist/

--- a/crates/ironclaw_webui_v2/frontend/.gitignore
+++ b/crates/ironclaw_webui_v2/frontend/.gitignore
@@ -1,1 +1,2 @@
-node_modules/
+/dist/
+/node_modules/


### PR DESCRIPTION
## Summary

- Fix the stale WebUI generated-bundle ignore path to the live `ironclaw_webui_v2` crate.
- Add the future Vite `frontend/dist/` output to `.gitignore`.
- Add the scoped frontend cleanup implementation plan, now limited to DevX/build cleanup only.

## Verification

- `git check-ignore -v crates/ironclaw_webui_v2/static/dist/app.js crates/ironclaw_webui_v2/frontend/dist/index.html`
- Stack tip verified with `git diff --check`, `pnpm typecheck`, `pnpm test`, `pnpm build`, `cargo test -p ironclaw_webui_v2 --features webui-v2-beta`, and `cargo test -p ironclaw_reborn_composition --features webui-v2-beta --test webui_v2_serve`.