### PR TITLE
fix(reborn): [PRODUCTION CHANGE] #5572 — forward checkpoint stage/load through HookedLoopCheckpointPort; activate hooks integration coverage

### DIFF
--- a/crates/ironclaw_hooks/src/middleware/checkpoint_port.rs
+++ b/crates/ironclaw_hooks/src/middleware/checkpoint_port.rs
@@ -161,6 +161,12 @@ mod tests {
         ) -> Result<LoopCheckpointStateRef, AgentLoopHostError> {
             *self.stage_calls.lock().expect("not poisoned") += 1;
             let _ = request;
+            if self.fail {
+                return Err(AgentLoopHostError::new(
+                    ironclaw_turns::run_profile::AgentLoopHostErrorKind::Invalid,
+                    "stub stage failure",
+                ));
+            }
             LoopCheckpointStateRef::new("checkpoint:stub-staged").map_err(|reason| {
                 AgentLoopHostError::new(
                     ironclaw_turns::run_profile::AgentLoopHostErrorKind::Internal,
@@ -175,6 +181,12 @@ mod tests {
         ) -> Result<ironclaw_turns::run_profile::LoadedCheckpointPayload, AgentLoopHostError>
         {
             *self.load_calls.lock().expect("not poisoned") += 1;
+            if self.fail {
+                return Err(AgentLoopHostError::new(
+                    ironclaw_turns::run_profile::AgentLoopHostErrorKind::Invalid,
+                    "stub load failure",
+                ));
+            }
             Ok(ironclaw_turns::run_profile::LoadedCheckpointPayload {
                 kind: LoopCheckpointKind::BeforeModel,
                 schema_id: request.expected_schema_id,
@@ -277,6 +289,47 @@ mod tests {
             })
             .await
             .expect("forwarded load call succeeds");
+        assert_eq!(inner.load_call_count(), 1);
+    }
+
+    /// Mirrors the happy-path forwarding test above but with a failing inner
+    /// port: both pass-throughs must propagate the inner error unchanged
+    /// rather than swallowing it or falling through to a default.
+    #[tokio::test]
+    async fn stage_and_load_checkpoint_payload_forward_inner_error() {
+        let inner = Arc::new(StubCheckpointPort::failing());
+        let dispatcher = Arc::new(HookDispatcher::new(HookRegistry::new()));
+        let wrapped = HookedLoopCheckpointPort::new(inner.clone(), dispatcher, tenant());
+
+        let stage_err = wrapped
+            .stage_checkpoint_payload(ironclaw_turns::run_profile::StageCheckpointPayloadRequest {
+                kind: LoopCheckpointKind::BeforeModel,
+                schema_id: "test-schema".to_string(),
+                payload: b"payload".to_vec(),
+            })
+            .await
+            .expect_err("inner stage error must propagate");
+        assert_eq!(
+            stage_err.kind,
+            ironclaw_turns::run_profile::AgentLoopHostErrorKind::Invalid
+        );
+        assert_eq!(inner.stage_call_count(), 1);
+
+        let load_err = wrapped
+            .load_checkpoint_payload(ironclaw_turns::run_profile::LoadCheckpointPayloadRequest {
+                checkpoint_id: TurnCheckpointId::new(),
+                expected_schema_id: ironclaw_turns::run_profile::CheckpointSchemaId::new(
+                    "test-schema",
+                )
+                .expect("ok"),
+                expected_schema_version: ironclaw_turns::RunProfileVersion::new(1),
+            })
+            .await
+            .expect_err("inner load error must propagate");
+        assert_eq!(
+            load_err.kind,
+            ironclaw_turns::run_profile::AgentLoopHostErrorKind::Invalid
+        );
         assert_eq!(inner.load_call_count(), 1);
     }
 

--- a/crates/ironclaw_hooks/src/middleware/checkpoint_port.rs
+++ b/crates/ironclaw_hooks/src/middleware/checkpoint_port.rs
@@ -4,20 +4,28 @@
 //! Checkpoints are durable facts — observers only see that a checkpoint was
 //! written, never its state contents. Observation runs after the inner port
 //! returns success; errors from the inner port forward unchanged and skip
-//! observer dispatch.
+//! observer dispatch. `stage_checkpoint_payload` and `load_checkpoint_payload`
+//! are transparent pass-throughs to `inner` — they carry redacted payload
+//! bytes the executor stages/loads around every `checkpoint` call, not a
+//! completion fact, so they aren't observation points.
 
 use std::sync::Arc;
 
 use async_trait::async_trait;
 use ironclaw_host_api::TenantId;
 use ironclaw_turns::TurnCheckpointId;
-use ironclaw_turns::run_profile::{AgentLoopHostError, LoopCheckpointPort, LoopCheckpointRequest};
+use ironclaw_turns::run_profile::{
+    AgentLoopHostError, LoadCheckpointPayloadRequest, LoadedCheckpointPayload, LoopCheckpointPort,
+    LoopCheckpointRequest, LoopCheckpointStateRef, StageCheckpointPayloadRequest,
+};
 
 use crate::dispatch::HookDispatcher;
 use crate::registry::HookPointSpec;
 
-/// Wraps an inner `LoopCheckpointPort`, forwards `checkpoint` unchanged, and
-/// dispatches `after_checkpoint` observer hooks after a successful write.
+/// Wraps an inner `LoopCheckpointPort`. Only `checkpoint` (the durable
+/// metadata write) is an interception point that dispatches `after_checkpoint`
+/// observer hooks; every other method is a transparent pass-through to
+/// `inner` so the wrapper never changes checkpoint availability.
 pub struct HookedLoopCheckpointPort {
     inner: Arc<dyn LoopCheckpointPort>,
     dispatcher: Arc<HookDispatcher>,
@@ -56,6 +64,20 @@ impl LoopCheckpointPort for HookedLoopCheckpointPort {
         );
         Ok(checkpoint_id)
     }
+
+    async fn stage_checkpoint_payload(
+        &self,
+        request: StageCheckpointPayloadRequest,
+    ) -> Result<LoopCheckpointStateRef, AgentLoopHostError> {
+        self.inner.stage_checkpoint_payload(request).await
+    }
+
+    async fn load_checkpoint_payload(
+        &self,
+        request: LoadCheckpointPayloadRequest,
+    ) -> Result<LoadedCheckpointPayload, AgentLoopHostError> {
+        self.inner.load_checkpoint_payload(request).await
+    }
 }
 
 #[cfg(test)]
@@ -80,6 +102,8 @@ mod tests {
 
     struct StubCheckpointPort {
         calls: Mutex<u32>,
+        stage_calls: Mutex<u32>,
+        load_calls: Mutex<u32>,
         fail: bool,
     }
 
@@ -87,6 +111,8 @@ mod tests {
         fn new() -> Self {
             Self {
                 calls: Mutex::new(0),
+                stage_calls: Mutex::new(0),
+                load_calls: Mutex::new(0),
                 fail: false,
             }
         }
@@ -94,12 +120,22 @@ mod tests {
         fn failing() -> Self {
             Self {
                 calls: Mutex::new(0),
+                stage_calls: Mutex::new(0),
+                load_calls: Mutex::new(0),
                 fail: true,
             }
         }
 
         fn call_count(&self) -> u32 {
             *self.calls.lock().expect("not poisoned")
+        }
+
+        fn stage_call_count(&self) -> u32 {
+            *self.stage_calls.lock().expect("not poisoned")
+        }
+
+        fn load_call_count(&self) -> u32 {
+            *self.load_calls.lock().expect("not poisoned")
         }
     }
 
@@ -117,6 +153,35 @@ mod tests {
                 ));
             }
             Ok(TurnCheckpointId::new())
+        }
+
+        async fn stage_checkpoint_payload(
+            &self,
+            request: ironclaw_turns::run_profile::StageCheckpointPayloadRequest,
+        ) -> Result<LoopCheckpointStateRef, AgentLoopHostError> {
+            *self.stage_calls.lock().expect("not poisoned") += 1;
+            let _ = request;
+            LoopCheckpointStateRef::new("checkpoint:stub-staged").map_err(|reason| {
+                AgentLoopHostError::new(
+                    ironclaw_turns::run_profile::AgentLoopHostErrorKind::Internal,
+                    reason,
+                )
+            })
+        }
+
+        async fn load_checkpoint_payload(
+            &self,
+            request: ironclaw_turns::run_profile::LoadCheckpointPayloadRequest,
+        ) -> Result<ironclaw_turns::run_profile::LoadedCheckpointPayload, AgentLoopHostError>
+        {
+            *self.load_calls.lock().expect("not poisoned") += 1;
+            Ok(ironclaw_turns::run_profile::LoadedCheckpointPayload {
+                kind: LoopCheckpointKind::BeforeModel,
+                schema_id: request.expected_schema_id,
+                schema_version: request.expected_schema_version,
+                payload: ironclaw_turns::RedactedCheckpointPayload::new(Vec::new())
+                    .expect("empty payload is within the size limit"),
+            })
         }
     }
 
@@ -179,6 +244,40 @@ mod tests {
 
         wrapped.checkpoint(request()).await.expect("ok");
         assert_eq!(inner.call_count(), 1);
+    }
+
+    /// A coordinator turn stages a checkpoint payload before writing the
+    /// checkpoint itself; if the wrapper falls through to the trait's
+    /// fail-closed default instead of forwarding to `inner`, every
+    /// hooks-enabled turn dies here before any hook fires.
+    #[tokio::test]
+    async fn stage_and_load_checkpoint_payload_forward_to_inner() {
+        let inner = Arc::new(StubCheckpointPort::new());
+        let dispatcher = Arc::new(HookDispatcher::new(HookRegistry::new()));
+        let wrapped = HookedLoopCheckpointPort::new(inner.clone(), dispatcher, tenant());
+
+        wrapped
+            .stage_checkpoint_payload(ironclaw_turns::run_profile::StageCheckpointPayloadRequest {
+                kind: LoopCheckpointKind::BeforeModel,
+                schema_id: "test-schema".to_string(),
+                payload: b"payload".to_vec(),
+            })
+            .await
+            .expect("forwarded stage call succeeds");
+        assert_eq!(inner.stage_call_count(), 1);
+
+        wrapped
+            .load_checkpoint_payload(ironclaw_turns::run_profile::LoadCheckpointPayloadRequest {
+                checkpoint_id: TurnCheckpointId::new(),
+                expected_schema_id: ironclaw_turns::run_profile::CheckpointSchemaId::new(
+                    "test-schema",
+                )
+                .expect("ok"),
+                expected_schema_version: ironclaw_turns::RunProfileVersion::new(1),
+            })
+            .await
+            .expect("forwarded load call succeeds");
+        assert_eq!(inner.load_call_count(), 1);
     }
 
     #[tokio::test]

--- a/tests/integration/hooks.rs
+++ b/tests/integration/hooks.rs
@@ -2,30 +2,11 @@
 //! fire hooks at the expected lifecycle points on a real coordinator-path turn,
 //! and a hook deny should block the capability without wedging the run.
 //!
-//! # BLOCKED by a production bug (both scenarios are `#[ignore]`d RED regressions)
-//!
-//! Wiring ANY hook dispatcher into a full coordinator-path turn fails EVERY
-//! turn with `driver_unavailable`:
-//! `HostUnavailableWithDiagnostics { stage: Checkpoint, kind: Unavailable,
-//! safe_summary: "stage_checkpoint_payload not implemented" }`.
-//!
-//! Root cause: `ironclaw_hooks::middleware::checkpoint_port::
-//! HookedLoopCheckpointPort` overrides only `LoopCheckpointPort::checkpoint`;
-//! it does NOT forward `stage_checkpoint_payload`/`load_checkpoint_payload` to
-//! its inner port, so those fall through to the trait's fail-closed defaults.
-//! A planned run stages a checkpoint payload before the first model call, so
-//! with a hook dispatcher active the turn dies there before any hook fires.
-//! Hooks are off by default in production, so this latent bug has never been
-//! exercised — this is the first full-turn-with-hooks path.
-//!
-//! TODO(reborn-hooks-checkpoint-forward): forward both methods through
-//! `HookedLoopCheckpointPort` to `self.inner` (mirroring `checkpoint()`), then
-//! remove the `#[ignore]`s below. Cross-crate fix in `ironclaw_hooks`, out of
-//! scope for this tests-only lane.
-//!
-//! The E-HOOK-INFRA enabler (recording hook doubles, the
-//! `hook_dispatcher_builder_factory` group-builder seam, `with_hook_factory`)
-//! DOES land and is correct — these scenarios go green once the wrapper bug is fixed.
+//! These drive a full coordinator-path turn with an active hook dispatcher —
+//! the first tests to do so — so they also pin that `HookedLoopCheckpointPort`
+//! stays transparent for `stage_checkpoint_payload`/`load_checkpoint_payload`,
+//! not just `checkpoint`. A planned run stages a checkpoint payload before
+//! every model call, so any gap there fails every hooks-enabled turn.
 
 #[allow(dead_code)]
 #[path = "support/mod.rs"]
@@ -44,17 +25,10 @@ use serde_json::json;
 
 const HTTP_TOOL_URL: &str = "https://api.example.test/v1/items";
 
-/// The AfterModel observer fires on the model call and the BeforeCapability gate
-/// hook fires before the dispatched capability — both recorded through the real
-/// turn wire. The passing gate hook does not block the capability, so the http
-/// tool still runs.
-///
-/// `#[ignore]`d RED regression — currently fails at the checkpoint stage (see the
-/// module-level bug note). Un-ignore once `HookedLoopCheckpointPort` forwards
-/// `stage_checkpoint_payload`.
-#[ignore = "blocked: HookedLoopCheckpointPort omits stage_checkpoint_payload forwarding; \
-            hooked coordinator turn dies driver_unavailable at checkpoint_before_model \
-            (TODO reborn-hooks-checkpoint-forward)"]
+/// The BeforeCapability gate hook fires before the dispatched capability, and
+/// the AfterModel observer fires once for the turn — both recorded through
+/// the real turn wire. The passing gate hook does not block the capability,
+/// so the http tool still runs.
 #[tokio::test]
 async fn hooks_fire_at_lifecycle_points_on_coordinator_turn() {
     let log = RecordingHookLog::new();
@@ -73,29 +47,21 @@ async fn hooks_fire_at_lifecycle_points_on_coordinator_turn() {
     h.assert_tool_invoked("builtin.http")
         .await
         .expect("http tool ran through the real capability path");
-    // Both lifecycle points fired in order: AfterModel dispatches once per
-    // `finalize_assistant_message` call, and the script's two assistant turns
-    // sandwich the BeforeCapability gate hook right before dispatch.
+    // AfterModel fires only once per turn, at `finalize_assistant_message`
+    // for the terminal text reply — the tool-call reply that precedes it
+    // finalizes through the capability path, not the transcript port, so it
+    // does not fire AfterModel on its own.
     assert_eq!(
         log.fires(),
-        vec![
-            "observer:AfterModel",
-            "before_capability:builtin.http",
-            "observer:AfterModel",
-        ],
-        "hook fires must occur in lifecycle order: AfterModel (tool-call reply) -> \
-         BeforeCapability (builtin.http dispatch) -> AfterModel (final text reply)"
+        vec!["before_capability:builtin.http", "observer:AfterModel",],
+        "hook fires must occur in lifecycle order: BeforeCapability (builtin.http dispatch) \
+         -> AfterModel (final text reply)"
     );
 }
 
 /// A BeforeCapability hook deny should block the capability (it never reaches the
 /// wire) yet the run should still complete — the hook error path must NOT wedge
 /// the run.
-///
-/// `#[ignore]`d RED regression — same checkpoint bug as above blocks it.
-#[ignore = "blocked: HookedLoopCheckpointPort omits stage_checkpoint_payload forwarding; \
-            hooked coordinator turn dies driver_unavailable at checkpoint_before_model \
-            (TODO reborn-hooks-checkpoint-forward)"]
 #[tokio::test]
 async fn hook_deny_blocks_capability_without_wedging_run() {
     let log = RecordingHookLog::new();


### PR DESCRIPTION
## Root cause

`HookedLoopCheckpointPort` (`crates/ironclaw_hooks/src/middleware/checkpoint_port.rs`) overrode only `LoopCheckpointPort::checkpoint`. `stage_checkpoint_payload` and `load_checkpoint_payload` were left unimplemented, so calls fell through to the trait's fail-closed default implementations in `crates/ironclaw_turns/src/run_profile/host.rs`, which return `Err(AgentLoopHostErrorKind::Unavailable, "... not implemented")`.

A planned coordinator turn stages a checkpoint payload before every model call. With any hook dispatcher wired in, every turn died `driver_unavailable{stage: Checkpoint}` at `checkpoint_before_model` before a single hook could fire — hooks were effectively unusable end-to-end, though hooks are off by default in production so this was never exercised.

## Fix shape

Added transparent forwarding of both methods to `self.inner`, mirroring the existing `checkpoint()` method's structure. This matches the established pattern in the same `middleware/` directory: `HookedLoopCapabilityPort` and `HookedLoopTranscriptPort` already forward *every* method of their wrapped trait — including ones with fail-closed defaults — so decorators here are meant to be transparent pass-throughs except at their one intentional interception point. `HookedLoopCheckpointPort` was the sole outlier. Verified `LoopModelPort`/`LoopPromptPort` have only one method each (already forwarded), so this closes the entire "unforwarded method" bug class in the crate, not just the two methods named in the issue.

Added a unit regression test (`stage_and_load_checkpoint_payload_forward_to_inner`) and mutation-verified it: reverting the forward turns it red with the exact `driver_unavailable`/`Unavailable` error from the issue.

## Scenarios activated

Un-ignored both `#[ignore]`d RED regressions in `tests/integration/hooks.rs`:
- `hooks_fire_at_lifecycle_points_on_coordinator_turn` — now pins that `BeforeCapability` gates a real capability dispatch and `AfterModel` fires once, through a real coordinator-path turn with hooks wired in.
- `hook_deny_blocks_capability_without_wedging_run` — pins that a hook deny blocks the capability (zero egress) without wedging the run, and that the deny reason propagates to the persisted tool-error summary.

One scenario's fire-order assertion had rotted (it was written before it could ever execute) — repaired from an assumed 3-fire sequence to the real 2-fire sequence, since `AfterModel` fires exactly once per turn at `finalize_assistant_message`, not per model call. This is pre-existing, intentional behavior from an earlier fix, independently confirmed by the sibling test `after_model_fires_exactly_once_at_durable_boundary` in `crates/ironclaw_reborn/tests/hooks_integration.rs`.

## Verification

- `cargo test --test reborn_integration_hooks` — 8/8 pass (both previously-ignored scenarios green)
- `cargo test -p ironclaw_hooks` — 295/295 unit + 7 integration pass
- `cargo test -p ironclaw_hooks --test predicate_state_libsql_contract --features libsql,contract-tests` — 20/20 pass (no flake this run)
- `cargo test -p ironclaw_reborn --test hooks_integration` — 49/49 pass (3 pre-existing unrelated `#[ignore]`s, carried forward from #3634)
- `cargo fmt --check` — clean
- `cargo clippy --all --tests --all-features` — zero warnings

Closes #5572

🤖 Generated with [Claude Code](https://claude.com/claude-code)