### PR TITLE
fix(reborn): distinguish transient model-provider network errors (stop silent empty turns)

### DIFF
--- a/crates/ironclaw_reborn/src/failure_categories.rs
+++ b/crates/ironclaw_reborn/src/failure_categories.rs
@@ -9,3 +9,12 @@ pub const MODEL_CREDENTIALS_UNAVAILABLE_CATEGORY: &str = "model_credentials_unav
 pub(crate) const MODEL_CREDITS_EXHAUSTED_REASON_KIND:
     ironclaw_turns::run_profile::AgentLoopHostErrorReasonKind =
     ironclaw_turns::run_profile::AgentLoopHostErrorReasonKind::ModelCreditsExhausted;
+
+/// Failure category identifier for a transient model-provider network failure
+/// (dropped connection, undecodable response body, timeout, upstream 5xx).
+/// Exposed for cross-crate consumers that project this category to a user-facing message.
+pub const MODEL_TRANSIENT_NETWORK_CATEGORY: &str = "model_transient_network";
+
+pub(crate) const MODEL_TRANSIENT_NETWORK_REASON_KIND:
+    ironclaw_turns::run_profile::AgentLoopHostErrorReasonKind =
+    ironclaw_turns::run_profile::AgentLoopHostErrorReasonKind::ModelTransientNetwork;

--- a/crates/ironclaw_reborn/src/model_failure_mapping.rs
+++ b/crates/ironclaw_reborn/src/model_failure_mapping.rs
@@ -2,7 +2,8 @@ use ironclaw_turns::run_profile::{AgentLoopHostErrorKind, AgentLoopHostErrorReas
 
 use crate::failure_categories::{
     MODEL_CREDENTIALS_UNAVAILABLE_CATEGORY, MODEL_CREDITS_EXHAUSTED_CATEGORY,
-    MODEL_CREDITS_EXHAUSTED_REASON_KIND,
+    MODEL_CREDITS_EXHAUSTED_REASON_KIND, MODEL_TRANSIENT_NETWORK_CATEGORY,
+    MODEL_TRANSIENT_NETWORK_REASON_KIND,
 };
 
 pub(crate) fn model_stage_failure_category(
@@ -16,6 +17,10 @@ pub(crate) fn model_stage_failure_category(
 
     if reason_kind == Some(MODEL_CREDITS_EXHAUSTED_REASON_KIND) {
         return Some(MODEL_CREDITS_EXHAUSTED_CATEGORY);
+    }
+
+    if reason_kind == Some(MODEL_TRANSIENT_NETWORK_REASON_KIND) {
+        return Some(MODEL_TRANSIENT_NETWORK_CATEGORY);
     }
 
     (kind == AgentLoopHostErrorKind::CredentialUnavailable)

--- a/crates/ironclaw_reborn/src/model_gateway.rs
+++ b/crates/ironclaw_reborn/src/model_gateway.rs
@@ -51,7 +51,7 @@ use ironclaw_turns::{
 use tracing::debug;
 
 use crate::{
-    failure_categories::MODEL_CREDITS_EXHAUSTED_REASON_KIND,
+    failure_categories::{MODEL_CREDITS_EXHAUSTED_REASON_KIND, MODEL_TRANSIENT_NETWORK_REASON_KIND},
     model_routes::{
         ModelRoute, ModelRouteError, ModelRouteErrorKind, ModelRouteProviderKey,
         ModelRouteResolver, ModelSelectionMode, ModelSlot, ResolvedModelRouteSnapshot,
@@ -1976,6 +1976,17 @@ fn map_provider_error(error: LlmError) -> HostManagedModelError {
         )
         .with_reason_kind(MODEL_CREDITS_EXHAUSTED_REASON_KIND);
     }
+    if is_transient_network_error(&error) {
+        // A dropped connection / undecodable body / timeout / upstream 5xx after
+        // retries exhaust. Still a safe "unavailable" turn, but tagged with a
+        // distinct reason_kind so a retryable blip is distinguishable from a hard
+        // outage in model_failed events (instead of an anonymous empty turn).
+        return HostManagedModelError::safe(
+            HostManagedModelErrorKind::Unavailable,
+            "transient network error reaching the model provider",
+        )
+        .with_reason_kind(MODEL_TRANSIENT_NETWORK_REASON_KIND);
+    }
     match error {
         LlmError::ContextLengthExceeded { .. } => HostManagedModelError::safe(
             HostManagedModelErrorKind::BudgetExceeded,
@@ -2014,6 +2025,30 @@ fn is_credit_exhaustion_error(error: &LlmError) -> bool {
         || lower.contains("out of credits")
 }
 
+/// Whether `error` is a transient network/transport failure reaching the
+/// provider (dropped connection, undecodable body, timeout, upstream 5xx), as
+/// opposed to a terminal config/policy error. Mirrors `is_credit_exhaustion_error`:
+/// used to tag the mapped host error with a distinct `reason_kind` so a
+/// retryable blip is distinguishable from a hard outage downstream.
+fn is_transient_network_error(error: &LlmError) -> bool {
+    match error {
+        // reqwest transport error: dropped connection, TLS/DNS, body decode.
+        LlmError::Http(_) => true,
+        // Upstream gateway 5xx — transient by definition.
+        LlmError::BadGateway { .. } => true,
+        LlmError::RequestFailed { reason, .. } => {
+            let lower = reason.to_ascii_lowercase();
+            lower.contains("error sending request")
+                || lower.contains("error decoding response body")
+                || lower.contains("connection")
+                || lower.contains("timed out")
+                || lower.contains("timeout")
+                || lower.contains("reset by peer")
+        }
+        _ => false,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2023,6 +2058,34 @@ mod tests {
             provider: "test_provider".to_string(),
             reason: reason.to_string(),
         }
+    }
+
+    #[test]
+    fn is_transient_network_error_matches_transport_failures() {
+        for phrase in [
+            "HttpError: error sending request for url (https://openrouter.ai/api/v1/chat/completions)",
+            "HttpError: error decoding response body for url (https://openrouter.ai/...)",
+            "connection reset by peer",
+            "request timed out after 60s",
+        ] {
+            assert!(
+                is_transient_network_error(&request_failed(phrase)),
+                "should be transient: {phrase}"
+            );
+        }
+    }
+
+    #[test]
+    fn is_transient_network_error_ignores_terminal_errors() {
+        // Credit exhaustion (handled earlier) and hard config errors are not
+        // transient, so they keep their own mapping.
+        assert!(!is_transient_network_error(&request_failed(
+            "HTTP 402 payment required"
+        )));
+        assert!(!is_transient_network_error(&LlmError::ModelNotAvailable {
+            provider: "p".to_string(),
+            model: "m".to_string(),
+        }));
     }
 
     #[test]

--- a/crates/ironclaw_turns/src/run_profile/host.rs
+++ b/crates/ironclaw_turns/src/run_profile/host.rs
@@ -768,12 +768,18 @@ impl AgentLoopHostErrorKind {
 #[serde(rename_all = "snake_case")]
 pub enum AgentLoopHostErrorReasonKind {
     ModelCreditsExhausted,
+    /// A transient network failure reaching the model provider (dropped
+    /// connection, undecodable response body, timeout, upstream 5xx). Distinct
+    /// from a terminal "unavailable" so consumers can tell a retryable blip
+    /// from a hard outage instead of seeing an anonymous empty turn.
+    ModelTransientNetwork,
 }
 
 impl AgentLoopHostErrorReasonKind {
     pub fn as_str(self) -> &'static str {
         match self {
             Self::ModelCreditsExhausted => "model_credits_exhausted",
+            Self::ModelTransientNetwork => "model_transient_network",
         }
     }
 }


### PR DESCRIPTION
## Problem
When a model-completion call fails at the **network layer** (dropped connection, undecodable response body, timeout, upstream 5xx) after retries exhaust, `map_provider_error` (model_gateway.rs) routes it through the `_` catch-all:
```rust
_ => HostManagedModelError::safe(Unavailable, "model service is unavailable")
```
No `reason_kind`. Downstream this reads as an **anonymous empty turn** — indistinguishable from a legitimate empty response — so a transient blip silently scores as a failed task with no signal to the harness/observer. (Observed on a bench run: an empty-response task had 143 debug-log entries and **zero** identifying the network failure that killed it.)

## Fix — mirror the existing credit-exhaustion handling end to end
- New `AgentLoopHostErrorReasonKind::ModelTransientNetwork` (+ `as_str`).
- New `MODEL_TRANSIENT_NETWORK_{CATEGORY,REASON_KIND}` constants.
- `is_transient_network_error()` detector (mirrors `is_credit_exhaustion_error`): reqwest transport errors, upstream 5xx (`BadGateway`), and `RequestFailed` whose reason indicates a transport failure (sending/decoding/connection/timeout/reset).
- A branch in `map_provider_error`, before the catch-all, tagging the mapped error with the new reason_kind + a specific safe summary.
- Project the reason_kind to `MODEL_TRANSIENT_NETWORK_CATEGORY` in `model_stage_failure_category` (mirrors the credits mapping — also keeps the const used when `root-llm-provider` is off).

**Control flow is unchanged** — still a safe `Unavailable` turn; the failure is now *identifiable* in `model_failed` events (via reason_kind), so a retryable network blip is distinguishable from a hard outage instead of vanishing into a silent empty turn.

## Safety / scope
Additive only. The reason-kind enum's only `match` (`as_str`) is updated; all other usages are `Some(...)` comparisons, so nothing is made non-exhaustive.

## Verification
- `cargo check -p ironclaw_reborn` **clean both with and without** `--features root-llm-provider` (the feature gates the file that uses the const — mapping it in `model_failure_mapping` keeps it live either way, no dead-code).
- New detector tests pass: `is_transient_network_error_matches_transport_failures`, `is_transient_network_error_ignores_terminal_errors` (2 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)