### PR TITLE
fix(deps): RUSTSEC-2026-0204 crossbeam-epoch bump — unbreaks cargo-deny on every PR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2093,9 +2093,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -14,9 +14,6 @@ ignore = [
     "RUSTSEC-2026-0098",
     "RUSTSEC-2026-0099",
     "RUSTSEC-2026-0104",
-    # rand unsoundness with custom logger calling rand::rng() during reseed — we don't use this pattern;
-    # revisit/remove by 2026-06-30, or when transitive deps (tower, nanoid, phf_generator) release rand ≥0.9.3 compat
-    "RUSTSEC-2026-0097",
 ]
 
 [licenses]


### PR DESCRIPTION
## What

Every open PR's `cargo-deny` check is red. Root cause (reproduced locally, not PR-specific): **RUSTSEC-2026-0204** — invalid pointer dereference in `crossbeam-epoch` 0.9.18's `fmt::Pointer` impl. Transitive dep (via `termimad`/`crossbeam-deque` trees), so per the remediation playbook this is a lockfile bump, not a manifest change: `cargo update -p crossbeam-epoch` → **0.9.20** (patch, advisory's stated fix version).

Also drops the stale `RUSTSEC-2026-0097` ignore — cargo-deny warns `advisory-not-detected` (the rand pattern left the dependency tree), and the ignore's own comment said revisit by 2026-06-30.

## Verification

`cargo deny check` local: `advisories ok, bans ok, licenses ok, sources ok` (was `advisories FAILED`).

Merge-first candidate: unblocks the cargo-deny check on all open PRs once they merge/rebase past it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)