### PR TITLE
ci(bench): forward sccache-dist creds to the benchmarks reusable

### DIFF
--- a/.github/workflows/nearai-bench.yml
+++ b/.github/workflows/nearai-bench.yml
@@ -227,6 +227,14 @@ jobs:
       # Empty when unspecified → the reusable workflow defaults to ironclaw.
       framework: ${{ needs.parse.outputs.framework }}
       trigger-comment-id: ${{ github.event.comment.id }}
+      # Route the harness compile through our OVH sccache-dist build server so a
+      # new PR SHA only recompiles changed crates. Non-secret half (scheduler URL
+      # + SSH host/user/port) — same vars sccache-dist-smoke.yml uses. Empty →
+      # the reusable's setup step no-ops to local compilation.
+      sccache-scheduler-url: ${{ vars.SCCACHE_DIST_SCHEDULER_URL }}
+      sccache-cache-ssh-host: ${{ vars.SCCACHE_CACHE_SSH_HOST }}
+      sccache-cache-ssh-user: ${{ vars.SCCACHE_CACHE_SSH_USER }}
+      sccache-cache-ssh-port: ${{ vars.SCCACHE_CACHE_SSH_PORT }}
     # Scope inherited secrets to only what the reusable workflow needs.
     # Replaces `secrets: inherit`, which gave the called workflow access
     # to every secret available here.
@@ -236,3 +244,8 @@ jobs:
       # workflow reads this for LLM_BACKEND=nearai. Optional there, so legacy
       # ironclaw runs (OpenRouter) are unaffected if it's unset.
       NEARAI_API_KEY: ${{ secrets.NEARAI_API_KEY }}
+      # sccache-dist secret half — forwarded to the reusable's setup step.
+      SCCACHE_DIST_AUTH_TOKEN: ${{ secrets.SCCACHE_DIST_AUTH_TOKEN }}
+      SCCACHE_CACHE_SSH_PRIVATE_KEY: ${{ secrets.SCCACHE_CACHE_SSH_PRIVATE_KEY }}
+      SCCACHE_CACHE_SSH_KNOWN_HOSTS: ${{ secrets.SCCACHE_CACHE_SSH_KNOWN_HOSTS }}
+      SCCACHE_REDIS_PASSWORD: ${{ secrets.SCCACHE_REDIS_PASSWORD }}

--- a/.github/workflows/nearai-bench.yml
+++ b/.github/workflows/nearai-bench.yml
@@ -57,6 +57,10 @@ jobs:
       framework: ${{ steps.parse.outputs.framework }}
       head_sha: ${{ steps.parse.outputs.head_sha }}
       authorized: ${{ steps.auth.outputs.authorized }}
+      # "true" only for same-repo PRs. Fork PRs run untrusted code at compile
+      # time (build scripts/proc macros), so we must NOT expose sccache creds to
+      # them — they'd be readable from ~/.config/sccache/config during cargo build.
+      trusted: ${{ steps.parse.outputs.trusted }}
     steps:
       - name: Check commenter has write permission
         id: auth
@@ -145,11 +149,20 @@ jobs:
             gh pr comment "$PR" --repo "$REPO" --body "Unknown suite \`${suite}\`. Available: ${available}"
             exit 0
           fi
-          sha=$(gh pr view "$PR" --repo "$REPO" --json headRefOid -q .headRefOid)
+          info=$(gh pr view "$PR" --repo "$REPO" --json headRefOid,isCrossRepository)
+          sha=$(printf '%s' "$info" | jq -r .headRefOid)
+          # Same-repo PR = trusted; fork PR (isCrossRepository) = untrusted, no
+          # sccache creds (see the `trusted` output rationale above).
+          if [ "$(printf '%s' "$info" | jq -r .isCrossRepository)" = "true" ]; then
+            trusted=false
+          else
+            trusted=true
+          fi
           echo "suite=$suite" >> "$GITHUB_OUTPUT"
           echo "model=$model" >> "$GITHUB_OUTPUT"
           echo "framework=$framework" >> "$GITHUB_OUTPUT"
           echo "head_sha=$sha" >> "$GITHUB_OUTPUT"
+          echo "trusted=$trusted" >> "$GITHUB_OUTPUT"
 
       - name: Acknowledge with 🚀 reaction
         if: steps.auth.outputs.authorized == 'yes' && steps.parse.outputs.suite != ''
@@ -231,10 +244,13 @@ jobs:
       # new PR SHA only recompiles changed crates. Non-secret half (scheduler URL
       # + SSH host/user/port) — same vars sccache-dist-smoke.yml uses. Empty →
       # the reusable's setup step no-ops to local compilation.
-      sccache-scheduler-url: ${{ vars.SCCACHE_DIST_SCHEDULER_URL }}
-      sccache-cache-ssh-host: ${{ vars.SCCACHE_CACHE_SSH_HOST }}
-      sccache-cache-ssh-user: ${{ vars.SCCACHE_CACHE_SSH_USER }}
-      sccache-cache-ssh-port: ${{ vars.SCCACHE_CACHE_SSH_PORT }}
+      # GATED ON `trusted`: fork PRs run untrusted code at compile time, which
+      # could read these from ~/.config/sccache/config — so forks get '' and
+      # build locally. Only same-repo PRs get the build server.
+      sccache-scheduler-url: ${{ needs.parse.outputs.trusted == 'true' && vars.SCCACHE_DIST_SCHEDULER_URL || '' }}
+      sccache-cache-ssh-host: ${{ needs.parse.outputs.trusted == 'true' && vars.SCCACHE_CACHE_SSH_HOST || '' }}
+      sccache-cache-ssh-user: ${{ needs.parse.outputs.trusted == 'true' && vars.SCCACHE_CACHE_SSH_USER || '' }}
+      sccache-cache-ssh-port: ${{ needs.parse.outputs.trusted == 'true' && vars.SCCACHE_CACHE_SSH_PORT || '' }}
     # Scope inherited secrets to only what the reusable workflow needs.
     # Replaces `secrets: inherit`, which gave the called workflow access
     # to every secret available here.
@@ -244,8 +260,9 @@ jobs:
       # workflow reads this for LLM_BACKEND=nearai. Optional there, so legacy
       # ironclaw runs (OpenRouter) are unaffected if it's unset.
       NEARAI_API_KEY: ${{ secrets.NEARAI_API_KEY }}
-      # sccache-dist secret half — forwarded to the reusable's setup step.
-      SCCACHE_DIST_AUTH_TOKEN: ${{ secrets.SCCACHE_DIST_AUTH_TOKEN }}
-      SCCACHE_CACHE_SSH_PRIVATE_KEY: ${{ secrets.SCCACHE_CACHE_SSH_PRIVATE_KEY }}
-      SCCACHE_CACHE_SSH_KNOWN_HOSTS: ${{ secrets.SCCACHE_CACHE_SSH_KNOWN_HOSTS }}
-      SCCACHE_REDIS_PASSWORD: ${{ secrets.SCCACHE_REDIS_PASSWORD }}
+      # sccache-dist secret half — forwarded ONLY for trusted same-repo PRs
+      # (see the with: block above). Fork PRs get '' → local compile, no leak.
+      SCCACHE_DIST_AUTH_TOKEN: ${{ needs.parse.outputs.trusted == 'true' && secrets.SCCACHE_DIST_AUTH_TOKEN || '' }}
+      SCCACHE_CACHE_SSH_PRIVATE_KEY: ${{ needs.parse.outputs.trusted == 'true' && secrets.SCCACHE_CACHE_SSH_PRIVATE_KEY || '' }}
+      SCCACHE_CACHE_SSH_KNOWN_HOSTS: ${{ needs.parse.outputs.trusted == 'true' && secrets.SCCACHE_CACHE_SSH_KNOWN_HOSTS || '' }}
+      SCCACHE_REDIS_PASSWORD: ${{ needs.parse.outputs.trusted == 'true' && secrets.SCCACHE_REDIS_PASSWORD || '' }}


### PR DESCRIPTION
## Why
`/benchmark` spends ~15 min compiling the harness twice (pinned-main, then the PR's `--ironclaw-rev`) — the biggest fixed cost of a run. Routing that compile through our OVH **sccache-dist** build server makes a new PR SHA recompile only changed crates.

## What
Forwards the `SCCACHE_*` **vars** (scheduler URL + SSH host/user/port) and **secrets** (auth token, SSH key/known-hosts, redis password) — the same ones `sccache-dist-smoke.yml` already uses — into the `nearai/benchmarks` reusable bench workflow.

## Depends on
**benchmarks#224 must merge first** — it adds the matching optional inputs/secrets to the reusable. Passing these to the current `@main` reusable (which doesn't define them yet) would error. Once #224 is on benchmarks `main`, this is safe to merge.

## Notes
- No behavior change until #224 lands; the reusable's setup step no-ops to local compilation if creds are absent.
- @Firat — confirms the scheduler can take bench traffic + that sharing the token into the benchmarks reusable is OK. Both repos are same-org public.

🤖 Generated with [Claude Code](https://claude.com/claude-code)