### PR TITLE
chore: update IronLoop auto review config

### DIFF
--- a/.ironloop/agents.yaml
+++ b/.ironloop/agents.yaml
@@ -3,7 +3,9 @@ reviewers:
   - id: reviewer
     display_name: ironloop/common-reviewer
     instructions: .ironloop/agents/common-reviewer/AGENTS.md
-    auto_review: true
+    auto_review:
+      enabled: true
+      on_update: false
 
 developers:
   - id: implementer


### PR DESCRIPTION
## Summary
- update `.ironloop/agents.yaml` to use the current `auto_review.enabled` / `auto_review.on_update` structure
- keep auto review enabled for PR open/ready
- keep auto review disabled for every-push updates for now

## Validation
- parsed the config with IronLoop's current `parseAgentConfig`
- `git diff --check`
