### PR TITLE
ci(bench): disable sccache-dist for /benchmark (dist compile was slower)

### DIFF
--- a/.github/workflows/nearai-bench.yml
+++ b/.github/workflows/nearai-bench.yml
@@ -240,17 +240,6 @@ jobs:
       # Empty when unspecified → the reusable workflow defaults to ironclaw.
       framework: ${{ needs.parse.outputs.framework }}
       trigger-comment-id: ${{ github.event.comment.id }}
-      # Route the harness compile through our OVH sccache-dist build server so a
-      # new PR SHA only recompiles changed crates. Non-secret half (scheduler URL
-      # + SSH host/user/port) — same vars sccache-dist-smoke.yml uses. Empty →
-      # the reusable's setup step no-ops to local compilation.
-      # GATED ON `trusted`: fork PRs run untrusted code at compile time, which
-      # could read these from ~/.config/sccache/config — so forks get '' and
-      # build locally. Only same-repo PRs get the build server.
-      sccache-scheduler-url: ${{ needs.parse.outputs.trusted == 'true' && vars.SCCACHE_DIST_SCHEDULER_URL || '' }}
-      sccache-cache-ssh-host: ${{ needs.parse.outputs.trusted == 'true' && vars.SCCACHE_CACHE_SSH_HOST || '' }}
-      sccache-cache-ssh-user: ${{ needs.parse.outputs.trusted == 'true' && vars.SCCACHE_CACHE_SSH_USER || '' }}
-      sccache-cache-ssh-port: ${{ needs.parse.outputs.trusted == 'true' && vars.SCCACHE_CACHE_SSH_PORT || '' }}
     # Scope inherited secrets to only what the reusable workflow needs.
     # Replaces `secrets: inherit`, which gave the called workflow access
     # to every secret available here.
@@ -260,9 +249,3 @@ jobs:
       # workflow reads this for LLM_BACKEND=nearai. Optional there, so legacy
       # ironclaw runs (OpenRouter) are unaffected if it's unset.
       NEARAI_API_KEY: ${{ secrets.NEARAI_API_KEY }}
-      # sccache-dist secret half — forwarded ONLY for trusted same-repo PRs
-      # (see the with: block above). Fork PRs get '' → local compile, no leak.
-      SCCACHE_DIST_AUTH_TOKEN: ${{ needs.parse.outputs.trusted == 'true' && secrets.SCCACHE_DIST_AUTH_TOKEN || '' }}
-      SCCACHE_CACHE_SSH_PRIVATE_KEY: ${{ needs.parse.outputs.trusted == 'true' && secrets.SCCACHE_CACHE_SSH_PRIVATE_KEY || '' }}
-      SCCACHE_CACHE_SSH_KNOWN_HOSTS: ${{ needs.parse.outputs.trusted == 'true' && secrets.SCCACHE_CACHE_SSH_KNOWN_HOSTS || '' }}
-      SCCACHE_REDIS_PASSWORD: ${{ needs.parse.outputs.trusted == 'true' && secrets.SCCACHE_REDIS_PASSWORD || '' }}


### PR DESCRIPTION
## Why
Activating sccache-**dist** (#5752) made `/benchmark` builds **slower**, not faster: a validation run sat >30 min still compiling (baseline build ≈15 min). The setup configures distributed compilation against a single OVH scheduler (`ns3211718.ip-146-59-71.eu`); shipping ironclaw's hundreds of crates to one remote worker is far slower than local `cargo build`, and the setup only *warns* on a slow scheduler — it doesn't back off.

## What
Stop forwarding the `SCCACHE_*` vars/secrets from `nearai-bench.yml` → the benchmarks reusable's setup step no-ops back to **local compilation** (the known-good ~15-min build). The `trusted` gate + output stay (harmless, ready if we revisit).

Keeps the wins that actually helped: the reborn hard-timeout (benchmarks#225) bounds the eval, and `CARGO_PROFILE_DEV_DEBUG=0` (benchmarks#224) trims the local build.

## Follow-up (with @Firat)
If we want a build-server win, the right config is **cache-only** — sccache with the shared Redis object cache but **no `[dist]`** (local compile on miss, remote cache on hit) — and only after confirming the cache/tunnel latency is actually a net win on ironclaw's crate graph. Distributed compilation to a single box is the wrong tool here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)