### PR TITLE
test: micro-pinchbench-13 on 16-core (do not merge)

### DIFF
--- a/.bench-smoke-16core.md
+++ b/.bench-smoke-16core.md
@@ -1,0 +1,1 @@
+Throwaway: time /benchmark micro-pinchbench-13 on the ubuntu-16core runner. Close without merging.


### PR DESCRIPTION
Throwaway to time /benchmark on the new ubuntu-16core runner. Close without merging.