### PR TITLE
chore: enable IronLoop developer network access

### DIFF
--- a/.ironloop/agents.yaml
+++ b/.ironloop/agents.yaml
@@ -12,11 +12,15 @@ developers:
     display_name: ironloop/small-fix-implementer
     instructions: .ironloop/agents/small-fix-implementer/AGENTS.md
     actions: ["implement"]
+    execution:
+      network_access: true
 
   - id: resolver
     display_name: ironloop/small-fix-resolver
     instructions: .ironloop/agents/small-fix-resolver/AGENTS.md
     actions: ["resolve"]
+    execution:
+      network_access: true
     auto_resolve:
       enabled: true
       quiet_period_seconds: 300


### PR DESCRIPTION
## Summary
- enable network access for the IronLoop implementer developer agent
- enable network access for the IronLoop resolver developer agent

## Validation
- parsed .ironloop/agents.yaml with Ruby YAML
- git diff --check