### PR TITLE
fix(reborn): preserve model outage failure category

### DIFF
--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -3148,6 +3148,9 @@ pub async fn build_reborn_runtime(
         Arc::clone(&loop_checkpoint_store) as Arc<dyn ironclaw_turns::LoopCheckpointStore>,
         await_dependent_run_evidence,
         thread_scope.clone(),
+    )
+    .with_checkpoint_state_store(
+        Arc::clone(&checkpoint_state_store) as Arc<dyn ironclaw_turns::CheckpointStateStore>
     );
     if let Some(local_runtime) = local_runtime {
         loop_exit_evidence = loop_exit_evidence.with_approval_gate_evidence(Arc::new(
@@ -4857,6 +4860,11 @@ output_schema_ref = "schemas/write.output.json"
     }
 
     #[derive(Debug, Default)]
+    struct ModelOutageGateway {
+        calls: AtomicUsize,
+    }
+
+    #[derive(Debug, Default)]
     struct FailingSkillContextSource {
         calls: AtomicUsize,
     }
@@ -4924,6 +4932,20 @@ output_schema_ref = "schemas/write.output.json"
                 .push(request);
             Ok(HostManagedModelResponse::assistant_reply(
                 self.reply.clone(),
+            ))
+        }
+    }
+
+    #[async_trait]
+    impl HostManagedModelGateway for ModelOutageGateway {
+        async fn stream_model(
+            &self,
+            _request: HostManagedModelRequest,
+        ) -> Result<HostManagedModelResponse, HostManagedModelError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Err(HostManagedModelError::safe(
+                HostManagedModelErrorKind::Unavailable,
+                "model service is unavailable",
             ))
         }
     }
@@ -6956,6 +6978,50 @@ output_schema_ref = "schemas/write.output.json"
         assert_eq!(reply.status, TurnStatus::Completed);
         assert_eq!(reply.text.as_deref(), Some("recorded runtime reply"));
         assert_eq!(recorded_request_count(&requests), 1);
+
+        runtime.shutdown().await.expect("runtime shutdown");
+    }
+
+    #[tokio::test]
+    async fn send_user_message_preserves_model_unavailable_after_retry_budget() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let gateway = Arc::new(ModelOutageGateway::default());
+        let input = RebornRuntimeInput::from_services(
+            RebornBuildInput::local_dev(
+                "runtime-model-outage-owner",
+                root.path().join("local-dev"),
+            )
+            .with_runtime_policy(local_dev_runtime_policy()),
+        )
+        .with_identity(RebornRuntimeIdentity {
+            tenant_id: "runtime-model-outage-tenant".to_string(),
+            agent_id: "runtime-model-outage-agent".to_string(),
+            source_binding_id: "runtime-model-outage-source".to_string(),
+            reply_target_binding_id: "runtime-model-outage-reply".to_string(),
+        })
+        .with_poll_settings(PollSettings {
+            interval: Duration::from_millis(10),
+            max_total: RUNTIME_POLL_TIMEOUT,
+        })
+        .with_model_gateway_override(gateway.clone());
+
+        let runtime = build_reborn_runtime(input).await.expect("runtime builds");
+        let conversation = runtime.new_conversation().await.expect("conversation");
+        let reply = tokio::time::timeout(
+            RUNTIME_SEND_TIMEOUT,
+            runtime.send_user_message(&conversation, "please write a long report"),
+        )
+        .await
+        .expect("runtime send should finish")
+        .expect("runtime send should succeed");
+
+        assert_eq!(reply.status, TurnStatus::Failed);
+        assert_eq!(reply.failure_category.as_deref(), Some("model_unavailable"));
+        assert_eq!(reply.text, None);
+        assert!(
+            gateway.calls.load(Ordering::SeqCst) >= 3,
+            "model outage should be retried before the run fails"
+        );
 
         runtime.shutdown().await.expect("runtime shutdown");
     }

--- a/crates/ironclaw_reborn_composition/tests/runtime.rs
+++ b/crates/ironclaw_reborn_composition/tests/runtime.rs
@@ -184,15 +184,12 @@ async fn stub_gateway_send_cancels_recovery_required_and_releases_conversation()
     .unwrap()
     .unwrap();
 
-    // With no LLM gateway configured the stubbed driver path reports a
-    // protocol violation, which maps to a terminal Failed turn instead of the
-    // pre-PR RecoveryRequired path that cancelled via the standalone-runtime
-    // cancel guard.
+    // With no LLM gateway configured the stubbed driver path exhausts the
+    // model retry budget and verifies the final checkpoint evidence, which
+    // maps to a terminal model_unavailable failure instead of the pre-PR
+    // RecoveryRequired path that cancelled via the standalone-runtime guard.
     assert_eq!(reply.status, TurnStatus::Failed);
-    assert_eq!(
-        reply.failure_category.as_deref(),
-        Some("driver_protocol_violation")
-    );
+    assert_eq!(reply.failure_category.as_deref(), Some("model_unavailable"));
     assert_eq!(reply.text, None);
 
     let second_reply = tokio::time::timeout(
@@ -206,7 +203,7 @@ async fn stub_gateway_send_cancels_recovery_required_and_releases_conversation()
     assert_eq!(second_reply.status, TurnStatus::Failed);
     assert_eq!(
         second_reply.failure_category.as_deref(),
-        Some("driver_protocol_violation")
+        Some("model_unavailable")
     );
     assert_eq!(second_reply.text, None);
 
@@ -515,7 +512,7 @@ async fn build_reborn_runtime_wires_per_user_cap_from_turn_runner_settings() {
     let runtime = build_reborn_runtime(input).await.unwrap();
 
     // Submit two sequential turns on two conversations. With the stub gateway
-    // each turn completes (as Failed / driver_protocol_violation) before the
+    // each turn completes (as Failed / model_unavailable) before the
     // next is submitted, so the per-user slot is always free and neither
     // submission should be rejected. If the cap was accidentally set to 0 (a
     // misconfiguration the wiring layer could introduce) the store would block


### PR DESCRIPTION
## Summary

- Wire the Reborn composition loop-exit evidence verifier to the same checkpoint state store used by the runner.
- Add a caller-level runtime regression proving an exhausted model outage retry budget surfaces `model_unavailable` instead of falling back to a protocol violation.
- This fixes the product-facing invalid/protocol-failure result for provider outage timeouts like the issue reproduced in this thread.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

None.

## Root cause

The agent loop wrote a final checkpoint containing the model failure kind, but the Reborn composition runtime built `ThreadCheckpointLoopExitEvidencePort` without a `CheckpointStateStore`. That made failure evidence verification fail closed, so the turn-exit validator replaced the real model outage with the generic driver-protocol failure seen by the product UI.

## Validation

- [x] `cargo fmt --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings` not run; scoped runtime fix was covered with targeted tests below.
- [ ] `cargo build` not run separately; targeted tests compiled touched crates.
- [x] Relevant tests pass:
  - `cargo test -p ironclaw_reborn_composition send_user_message_preserves_model_unavailable_after_retry_budget`
  - `cargo test -p ironclaw_reborn loop_exit_applier_accepts_thread_checkpoint_failure_evidence`
  - `cargo test -p ironclaw_reborn thread_checkpoint_evidence_verifies_failure_from_final_checkpoint_state`
- [ ] `cargo test --features integration` not run; no database-backed behavior changed.
- [ ] Manual testing: not run; regression is covered by caller-level runtime test.
- [ ] `review-pr` or `pr-shepherd --fix` not run; IronLoop, Gemini, and CodeRabbit reviews were checked.

Note: the focused composition test still emits existing unrelated warning noise in this crate.

## Security Impact

None. This does not change permissions, network calls, secrets, file access, tool execution, sandbox policy, or trust minting. It only wires an existing checkpoint-state evidence source into the existing loop-exit verifier so runtime failure classification can preserve the already-recorded model outage category.

## Reborn Trust-Boundary Checklist

- [x] Public policy/evidence/trust-bearing types: no new types; composition now passes the existing `CheckpointStateStore` into the existing `ThreadCheckpointLoopExitEvidencePort`.
- [x] Untrusted content enters prompts only through an envelope/escaping primitive: no prompt construction changes.
- [x] Hashes declare purpose; trust/binding/authenticity uses SHA-256/BLAKE3 or separate authenticity check: no hash or authenticity changes.
- [x] New/changed status, exit, policy, runtime, or error variants: no variants changed; downstream failure-category semantics verified by targeted tests.
- [x] Security/durability `serde(default)` fields fail closed or have migration tests: no serialization fields changed.
- [x] Queues/maps/buffers/counters have bounds and overflow-safe arithmetic: no queue, map, buffer, or counter behavior changed.
- [x] Driver/operator-visible errors have stable class semantics (`Transient`, `Permanent`, `Misconfigured`, `PolicyDenied` or equivalent): stable `model_unavailable` classification is preserved and tested.
- [x] Sandbox/native/host names accurately describe trust boundary: no sandbox/native/host naming changes.

## Database Impact

None. No migrations, schemas, PostgreSQL behavior, or libSQL behavior changed.

## Blast Radius

Touches Reborn runtime composition failure classification for terminal model-provider outages. Successful model turns and the model retry policy are unchanged. The expected behavior change is that exhausted model outages now surface `model_unavailable` instead of degrading to a driver-protocol failure.

## Rollback Plan

Revert this PR. Rollback restores the previous composition wiring and therefore the previous failure-classification behavior. No data migration or cleanup is required.

## Review Follow-Through

Gemini reported no actionable comments. CodeRabbit reported no code comments and only flagged missing PR-template sections; this update fills the required sections. Reviewer judgment is still requested on whether Track C runtime approval coverage is sufficient for this narrow composition wiring fix.

---

**Review track**: C (runtime composition / failure classification)