### PR TITLE
fix(reborn): deterministic pairing-code TTL clock — kill slack_pairing_redeem expired-code flake

### DIFF
--- a/crates/ironclaw_reborn_composition/src/slack_host_state.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_host_state.rs
@@ -77,6 +77,12 @@ const CHANNEL_ROUTE_REPLACE_LOCK_RENEW_INTERVAL: Duration = Duration::from_secs(
 #[cfg(test)]
 const CHANNEL_ROUTE_REPLACE_LOCK_RENEW_INTERVAL: Duration = Duration::from_millis(100);
 
+/// Time source for pairing-challenge TTL comparisons. Production always
+/// gets the default (`Utc::now`); tests can inject a controllable clock via
+/// [`FilesystemSlackHostState::with_clock`] so expiry is deterministic
+/// instead of racing real wall-clock time against a millisecond TTL.
+type PairingClock = Arc<dyn Fn() -> DateTime<Utc> + Send + Sync>;
+
 pub(crate) struct FilesystemSlackHostState<F>
 where
     F: RootFilesystem + 'static,
@@ -84,6 +90,7 @@ where
     filesystem: Arc<ScopedFilesystem<F>>,
     scope: ResourceScope,
     pairing_ttl: Duration,
+    clock: PairingClock,
     locks: Arc<Mutex<HashMap<String, Weak<tokio::sync::Mutex<()>>>>>,
 }
 
@@ -96,6 +103,7 @@ where
             filesystem: Arc::clone(&self.filesystem),
             scope: self.scope.clone(),
             pairing_ttl: self.pairing_ttl,
+            clock: Arc::clone(&self.clock),
             locks: Arc::clone(&self.locks),
         }
     }
@@ -137,6 +145,7 @@ where
                 invocation_id: InvocationId::new(),
             },
             pairing_ttl: DEFAULT_PAIRING_TTL,
+            clock: Arc::new(Utc::now),
             locks: Arc::new(Mutex::new(HashMap::new())),
         }
     }
@@ -147,6 +156,23 @@ where
     pub(crate) fn with_pairing_ttl(mut self, pairing_ttl: Duration) -> Self {
         self.pairing_ttl = pairing_ttl;
         self
+    }
+
+    // Same visibility rationale as `with_pairing_ttl` above: lets pairing-TTL
+    // tests advance a deterministic clock instead of racing real wall-clock
+    // time against a millisecond TTL under `tokio::time::pause` (which never
+    // advances `chrono::Utc::now`, the wall clock `active_pairing_challenge`
+    // reads). Production never calls this, so it always gets `Utc::now`.
+    #[cfg(any(test, feature = "test-support"))]
+    pub(crate) fn with_clock(mut self, clock: PairingClock) -> Self {
+        self.clock = clock;
+        self
+    }
+
+    /// Current time as seen by pairing-TTL comparisons — `Utc::now()` in
+    /// production, an injected deterministic clock under test.
+    fn now(&self) -> DateTime<Utc> {
+        (self.clock)()
     }
 
     fn lock_for(&self, key: String) -> Arc<tokio::sync::Mutex<()>> {
@@ -1278,7 +1304,7 @@ where
             return Ok(issued);
         }
         if let Some((actor_record, _)) = existing_actor.as_ref()
-            && actor_record.expires_at <= Utc::now()
+            && actor_record.expires_at <= self.now()
         {
             self.cleanup_actor_pairing_code_record(actor_record).await?;
         }
@@ -1332,7 +1358,7 @@ where
             return Err(SlackPersonalBindingPairingError::ChallengeNotFound);
         };
 
-        active_pairing_challenge(&record)
+        active_pairing_challenge(&record, self.now())
     }
 
     async fn consume_challenge(
@@ -1349,7 +1375,7 @@ where
         else {
             return Err(SlackPersonalBindingPairingError::ChallengeNotFound);
         };
-        let challenge = active_pairing_challenge(&record)?;
+        let challenge = active_pairing_challenge(&record, self.now())?;
         let actor_path = Self::pairing_actor_path_for(
             &challenge.installation_id,
             challenge.slack_user_id.as_str(),
@@ -1570,7 +1596,7 @@ where
         actor_path: &ScopedPath,
         existing_actor_version: Option<RecordVersion>,
     ) -> Result<IssuedSlackPersonalBindingPairingChallenge, SlackPersonalBindingPairingError> {
-        let expires_at = Utc::now()
+        let expires_at = self.now()
             + chrono::Duration::from_std(self.pairing_ttl).map_err(|_| {
                 SlackPersonalBindingPairingError::Backend(
                     "Slack pairing TTL could not be represented".into(),
@@ -1644,7 +1670,7 @@ where
     {
         if actor_record.installation_id != requested.installation_id.as_str()
             || actor_record.slack_user_id != requested.slack_user_id.as_str()
-            || actor_record.expires_at <= Utc::now()
+            || actor_record.expires_at <= self.now()
         {
             return Ok(None);
         }
@@ -1657,7 +1683,7 @@ where
         else {
             return Ok(None);
         };
-        let challenge = match active_pairing_challenge(&code_record) {
+        let challenge = match active_pairing_challenge(&code_record, self.now()) {
             Ok(challenge) => challenge,
             Err(SlackPersonalBindingPairingError::ChallengeNotFound) => return Ok(None),
             Err(error) => return Err(error),
@@ -2043,8 +2069,9 @@ fn stored_channel_route(
 
 fn active_pairing_challenge(
     record: &StoredSlackPairingChallenge,
+    now: DateTime<Utc>,
 ) -> Result<SlackPersonalBindingPairingChallenge, SlackPersonalBindingPairingError> {
-    if record.status != StoredSlackPairingStatus::Pending || record.expires_at <= Utc::now() {
+    if record.status != StoredSlackPairingStatus::Pending || record.expires_at <= now {
         return Err(SlackPersonalBindingPairingError::ChallengeNotFound);
     }
     Ok(SlackPersonalBindingPairingChallenge {

--- a/crates/ironclaw_reborn_composition/src/test_support/mod.rs
+++ b/crates/ironclaw_reborn_composition/src/test_support/mod.rs
@@ -105,7 +105,9 @@ pub use skill_activation::{
 };
 #[cfg(all(feature = "test-support", feature = "slack-v2-host-beta"))]
 pub use slack_host_state::{
-    SlackHostStateTestParts, slack_host_state_for_test, slack_host_state_for_test_with_pairing_ttl,
+    SlackHostStateTestParts, SlackPairingTestClock, slack_host_state_for_test,
+    slack_host_state_for_test_with_pairing_ttl,
+    slack_host_state_for_test_with_pairing_ttl_and_clock,
 };
 #[cfg(feature = "test-support")]
 pub use trace_capture::trace_capture_turn_event_sink_for_test;

--- a/crates/ironclaw_reborn_composition/src/test_support/slack_host_state.rs
+++ b/crates/ironclaw_reborn_composition/src/test_support/slack_host_state.rs
@@ -75,3 +75,81 @@ where
         lookup: store,
     }
 }
+
+/// A manually-advanceable clock for pairing-TTL tests. The production TTL
+/// check (`slack_host_state::active_pairing_challenge`, read through
+/// `FilesystemSlackHostState::now`) compares against real
+/// `chrono::Utc::now()`, which `tokio::time::pause`'s virtual clock never
+/// advances — this clock lets a test push `now()` past expiry directly
+/// instead of racing a sleep against real time.
+#[cfg(all(feature = "test-support", feature = "slack-v2-host-beta"))]
+#[derive(Clone)]
+pub struct SlackPairingTestClock {
+    now: std::sync::Arc<std::sync::Mutex<chrono::DateTime<chrono::Utc>>>,
+}
+
+#[cfg(all(feature = "test-support", feature = "slack-v2-host-beta"))]
+impl Default for SlackPairingTestClock {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(all(feature = "test-support", feature = "slack-v2-host-beta"))]
+impl SlackPairingTestClock {
+    pub fn new() -> Self {
+        Self {
+            now: std::sync::Arc::new(std::sync::Mutex::new(chrono::Utc::now())),
+        }
+    }
+
+    /// Advances the clock by `delta`, deterministically pushing any TTL
+    /// comparison read through this clock past expiry.
+    pub fn advance(&self, delta: std::time::Duration) {
+        let mut guard = Self::lock(&self.now);
+        *guard += chrono::Duration::from_std(delta).unwrap_or_else(|_| chrono::Duration::zero());
+    }
+
+    fn lock(
+        mutex: &std::sync::Mutex<chrono::DateTime<chrono::Utc>>,
+    ) -> std::sync::MutexGuard<'_, chrono::DateTime<chrono::Utc>> {
+        mutex
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    fn as_now_fn(&self) -> std::sync::Arc<dyn Fn() -> chrono::DateTime<chrono::Utc> + Send + Sync> {
+        let now = std::sync::Arc::clone(&self.now);
+        std::sync::Arc::new(move || *Self::lock(&now))
+    }
+}
+
+/// Same as [`slack_host_state_for_test_with_pairing_ttl`] but also injects a
+/// [`SlackPairingTestClock`] in place of the real wall clock, for
+/// deterministic expiry tests.
+#[cfg(all(feature = "test-support", feature = "slack-v2-host-beta"))]
+pub fn slack_host_state_for_test_with_pairing_ttl_and_clock<F>(
+    filesystem: std::sync::Arc<ironclaw_filesystem::ScopedFilesystem<F>>,
+    tenant_id: ironclaw_host_api::TenantId,
+    user_id: ironclaw_host_api::UserId,
+    agent_id: ironclaw_host_api::AgentId,
+    project_id: Option<ironclaw_host_api::ProjectId>,
+    pairing_ttl: std::time::Duration,
+    clock: &SlackPairingTestClock,
+) -> SlackHostStateTestParts
+where
+    F: ironclaw_filesystem::RootFilesystem + 'static,
+{
+    let store = std::sync::Arc::new(
+        crate::slack_host_state::FilesystemSlackHostState::new(
+            filesystem, tenant_id, user_id, agent_id, project_id,
+        )
+        .with_pairing_ttl(pairing_ttl)
+        .with_clock(clock.as_now_fn()),
+    );
+    SlackHostStateTestParts {
+        challenges: store.clone(),
+        bindings: store.clone(),
+        lookup: store,
+    }
+}

--- a/tests/integration/slack_pairing_redeem.rs
+++ b/tests/integration/slack_pairing_redeem.rs
@@ -22,8 +22,9 @@ use ironclaw_reborn_composition::{
     SlackPersonalBindingPairingService, SlackPersonalBindingPrincipal,
     slack_serve::SlackUserId,
     test_support::{
-        SlackHostStateTestParts, slack_host_state_for_test,
+        SlackHostStateTestParts, SlackPairingTestClock, slack_host_state_for_test,
         slack_host_state_for_test_with_pairing_ttl,
+        slack_host_state_for_test_with_pairing_ttl_and_clock,
     },
 };
 use ironclaw_slack_v2_adapter::{SLACK_USER_ACTOR_KIND, SLACK_V2_ADAPTER_ID};
@@ -81,6 +82,39 @@ async fn open_slack_pairing_store(
         }
         None => slack_host_state_for_test(scoped, tenant, user, agent, project),
     }
+}
+
+/// Same as [`open_slack_pairing_store`] but with a caller-controlled
+/// pairing-code TTL and clock, for deterministic expiry tests — see
+/// [`SlackPairingTestClock`] for why this replaces sleeping.
+async fn open_slack_pairing_store_with_clock(
+    db_path: &std::path::Path,
+    pairing_ttl: Duration,
+    clock: &SlackPairingTestClock,
+) -> SlackHostStateTestParts {
+    let db = Arc::new(
+        libsql::Builder::new_local(db_path)
+            .build()
+            .await
+            .expect("build libsql database"),
+    );
+    let root = Arc::new(LibSqlRootFilesystem::new(db));
+    root.run_migrations().await.expect("run libsql migrations");
+    let scoped = Arc::new(ScopedFilesystem::with_fixed_view(
+        root,
+        tenant_shared_mount_view(),
+    ));
+    let tenant = tenant_id();
+    let (user, agent, project) = host_ids();
+    slack_host_state_for_test_with_pairing_ttl_and_clock(
+        scoped,
+        tenant,
+        user,
+        agent,
+        project,
+        pairing_ttl,
+        clock,
+    )
 }
 
 fn pairing_service(store: &SlackHostStateTestParts) -> SlackPersonalBindingPairingService {
@@ -192,18 +226,24 @@ async fn slack_pairing_redeem_rejects_unknown_code() {
     );
 }
 
-#[tokio::test(start_paused = true)]
+#[tokio::test]
 async fn slack_pairing_redeem_rejects_expired_code() {
     let root = tempfile::tempdir().expect("tempdir");
     let db_path = root.path().join("slack-host-state.db");
-    let store = open_slack_pairing_store(&db_path, Some(Duration::from_millis(1))).await;
+    let clock = SlackPairingTestClock::new();
+    let store =
+        open_slack_pairing_store_with_clock(&db_path, Duration::from_millis(1), &clock).await;
     let service = pairing_service(&store);
 
     let issued = service
         .issue_challenge(installation_id(), slack_user_id())
         .await
         .expect("issue_challenge must succeed");
-    tokio::time::sleep(Duration::from_millis(25)).await;
+    // Advance the injected clock past the TTL directly — deterministic,
+    // unlike racing a virtual `sleep` under `tokio::time::pause` against the
+    // real wall clock the store's TTL check reads (see
+    // `SlackPairingTestClock`).
+    clock.advance(Duration::from_millis(5));
 
     let result = service
         .redeem_challenge(


### PR DESCRIPTION
## Root cause

`slack_pairing_redeem_rejects_expired_code` (`tests/integration/slack_pairing_redeem.rs`) used `#[tokio::test(start_paused = true)]` plus a virtual `tokio::time::sleep(25ms)` to push a 1ms-TTL pairing code past expiry. The production TTL check (`FilesystemSlackHostState::active_pairing_challenge` in `crates/ironclaw_reborn_composition/src/slack_host_state.rs`) compares `record.expires_at` against `chrono::Utc::now()` — the real wall clock — which a paused tokio runtime's virtual clock never advances. Whether expiry was actually observed depended on how much *real* wall-clock time the intervening SQLite write happened to consume versus the 1ms TTL: two independent clock domains racing each other.

## Fix

Threaded an injectable clock (`Arc<dyn Fn() -> DateTime<Utc> + Send + Sync>`) through `FilesystemSlackHostState`, mirroring the existing crate-local `with_pairing_ttl` test-support builder pattern already used in this file (and the `TriggerManagementClock` pattern in `ironclaw_host_runtime`). Production construction (`FilesystemSlackHostState::new`) always defaults to `Utc::now` — zero production behavior change. All TTL comparisons that share the pairing-challenge `expires_at` field (mint, redeem, and the actor-level reissue dedup checks) now read through `self.now()` instead of a bare `Utc::now()`, so a test-injected clock consistently governs both the write side and the read side of the same TTL.

Test-support exposes a new `SlackPairingTestClock` (manually-advanceable, `Arc<Mutex<DateTime<Utc>>>`-backed) and `slack_host_state_for_test_with_pairing_ttl_and_clock`. The fixed test drops `start_paused` and the virtual sleep entirely, advancing the injected clock past the TTL directly instead.

## Determinism evidence

- **Pre-fix**: instrumenting the virtual sleep showed it consumed ~22µs of *real* wall-clock time (nowhere near the 1ms TTL), so the code was frequently still "unexpired" by the real-clock TTL check at redeem time. A 10-run loop against the original test measured **8/10 failures** on this machine.
- **Post-fix**: 10/10 passes, run repeatedly, including a dedicated 10x loop on `slack_pairing_redeem_rejects_expired_code` alone.

## Other verification

- `cargo test --features libsql --test reborn_integration_slack_pairing_redeem` — 3/3 pass
- `cargo test -p ironclaw_reborn_composition --lib --features test-support,libsql,slack-v2-host-beta` — 1435/1435 pass (includes the crate-tier `filesystem_slack_host_state_rejects_expired_pairing_code`, which already used a real, non-paused sleep and was never part of this flake)
- `cargo fmt --all -- --check` — clean
- `cargo clippy --all --tests --all-features -- -D warnings` — clean

Fixes #5787

🤖 Generated with [Claude Code](https://claude.com/claude-code)