### PR TITLE
Use default setters for event read scopes

### DIFF
--- a/crates/ironclaw_events/src/cursor.rs
+++ b/crates/ironclaw_events/src/cursor.rs
@@ -115,6 +115,26 @@ impl ReadScope {
         Self::default()
     }
 
+    pub fn set_project_id(mut self, project_id: ProjectId) -> Self {
+        self.project_id = Some(project_id);
+        self
+    }
+
+    pub fn set_mission_id(mut self, mission_id: MissionId) -> Self {
+        self.mission_id = Some(mission_id);
+        self
+    }
+
+    pub fn set_thread_id(mut self, thread_id: ThreadId) -> Self {
+        self.thread_id = Some(thread_id);
+        self
+    }
+
+    pub fn set_process_id(mut self, process_id: ProcessId) -> Self {
+        self.process_id = Some(process_id);
+        self
+    }
+
     /// True iff every `Some` field in the filter has a matching value in the
     /// supplied [`ResourceScope`]. `process_id` is checked against the
     /// caller-supplied `process_id` because runtime events carry it on the

--- a/crates/ironclaw_events/src/cursor.rs
+++ b/crates/ironclaw_events/src/cursor.rs
@@ -115,23 +115,23 @@ impl ReadScope {
         Self::default()
     }
 
-    pub fn set_project_id(mut self, project_id: ProjectId) -> Self {
-        self.project_id = Some(project_id);
+    pub fn set_project_id(mut self, project_id: impl Into<Option<ProjectId>>) -> Self {
+        self.project_id = project_id.into();
         self
     }
 
-    pub fn set_mission_id(mut self, mission_id: MissionId) -> Self {
-        self.mission_id = Some(mission_id);
+    pub fn set_mission_id(mut self, mission_id: impl Into<Option<MissionId>>) -> Self {
+        self.mission_id = mission_id.into();
         self
     }
 
-    pub fn set_thread_id(mut self, thread_id: ThreadId) -> Self {
-        self.thread_id = Some(thread_id);
+    pub fn set_thread_id(mut self, thread_id: impl Into<Option<ThreadId>>) -> Self {
+        self.thread_id = thread_id.into();
         self
     }
 
-    pub fn set_process_id(mut self, process_id: ProcessId) -> Self {
-        self.process_id = Some(process_id);
+    pub fn set_process_id(mut self, process_id: impl Into<Option<ProcessId>>) -> Self {
+        self.process_id = process_id.into();
         self
     }
 

--- a/crates/ironclaw_events/tests/durable_log_contract.rs
+++ b/crates/ironclaw_events/tests/durable_log_contract.rs
@@ -981,10 +981,7 @@ async fn read_scope_filter_isolates_project_within_same_stream() {
 
     let stream = EventStreamKey::new(tenant_id, user_id, Some(agent_id));
 
-    let project_a_filter = ReadScope {
-        project_id: Some(project_a.clone()),
-        ..ReadScope::default()
-    };
+    let project_a_filter = ReadScope::default().set_project_id(project_a.clone());
     let project_a_replay = log
         .read_after_cursor(&stream, &project_a_filter, None, 10)
         .await
@@ -998,10 +995,7 @@ async fn read_scope_filter_isolates_project_within_same_stream() {
     // cursor reflects the position they've already considered.
     assert_eq!(project_a_replay.next_cursor, EventCursor::new(3));
 
-    let project_b_filter = ReadScope {
-        project_id: Some(project_b.clone()),
-        ..ReadScope::default()
-    };
+    let project_b_filter = ReadScope::default().set_project_id(project_b.clone());
     let project_b_replay = log
         .read_after_cursor(&stream, &project_b_filter, None, 10)
         .await
@@ -1148,10 +1142,12 @@ async fn read_scope_filter_excludes_records_with_none_field_when_filter_is_some(
     .expect("without project");
 
     let stream = EventStreamKey::from_scope(&scope_with_project);
-    let filter = ReadScope {
-        project_id: scope_with_project.project_id.clone(),
-        ..ReadScope::default()
-    };
+    let filter = ReadScope::default().set_project_id(
+        scope_with_project
+            .project_id
+            .clone()
+            .expect("fixture has project id"),
+    );
     let replay = log
         .read_after_cursor(&stream, &filter, None, 10)
         .await

--- a/crates/ironclaw_events/tests/durable_log_contract.rs
+++ b/crates/ironclaw_events/tests/durable_log_contract.rs
@@ -1142,12 +1142,7 @@ async fn read_scope_filter_excludes_records_with_none_field_when_filter_is_some(
     .expect("without project");
 
     let stream = EventStreamKey::from_scope(&scope_with_project);
-    let filter = ReadScope::default().set_project_id(
-        scope_with_project
-            .project_id
-            .clone()
-            .expect("fixture has project id"),
-    );
+    let filter = ReadScope::default().set_project_id(scope_with_project.project_id.clone());
     let replay = log
         .read_after_cursor(&stream, &filter, None, 10)
         .await


### PR DESCRIPTION
## Summary

- Add fluent setters for `ReadScope::default().set_*` filters.
- Convert the owning `ironclaw_events` durable log tests away from sparse `ReadScope { ..default }` literals.

## Why

`ReadScope` is an optional-field filter used across event replay tests. Setters make single-field filters easier to scan and keep future fields from adding test churn.

## Validation

- `cargo fmt --check`
- `cargo test -p ironclaw_events`

## Stack

Stacked on #5791 (`agent/default-backed-builders`) for the default-backed builder rule.