### PR TITLE
Use read scope setters in reborn event store tests

### DIFF
--- a/crates/ironclaw_reborn_event_store/tests/durable_event_store_contract.rs
+++ b/crates/ironclaw_reborn_event_store/tests/durable_event_store_contract.rs
@@ -103,10 +103,8 @@ async fn libsql_replay_advances_next_cursor_past_trailing_filtered_records() {
         .await
         .expect("append trailing project b");
 
-    let project_a = ReadScope {
-        project_id: scope_a.project_id.clone(),
-        ..ReadScope::default()
-    };
+    let project_a = ReadScope::default()
+        .set_project_id(scope_a.project_id.clone().expect("fixture has project id"));
     let replay = stores
         .events
         .read_after_cursor(&stream, &project_a, None, 10)
@@ -238,10 +236,8 @@ async fn jsonl_runtime_log_survives_rebuild_and_preserves_filtered_cursor_semant
     .await
     .expect("jsonl stores after restart");
 
-    let project_a = ReadScope {
-        project_id: scope_a.project_id.clone(),
-        ..ReadScope::default()
-    };
+    let project_a = ReadScope::default()
+        .set_project_id(scope_a.project_id.clone().expect("fixture has project id"));
     let first = stores
         .events
         .read_after_cursor(&stream, &project_a, None, 1)
@@ -264,10 +260,8 @@ async fn jsonl_runtime_log_survives_rebuild_and_preserves_filtered_cursor_semant
     );
     assert_eq!(second.next_cursor, EventCursor::new(3));
 
-    let project_b = ReadScope {
-        project_id: scope_b.project_id.clone(),
-        ..ReadScope::default()
-    };
+    let project_b = ReadScope::default()
+        .set_project_id(scope_b.project_id.clone().expect("fixture has project id"));
     let replay_b = stores
         .events
         .read_after_cursor(&stream, &project_b, None, 10)
@@ -393,10 +387,8 @@ async fn jsonl_audit_log_survives_rebuild_and_filters_scope() {
     )
     .await
     .expect("jsonl stores after restart");
-    let project_a = ReadScope {
-        project_id: scope_a.project_id.clone(),
-        ..ReadScope::default()
-    };
+    let project_a = ReadScope::default()
+        .set_project_id(scope_a.project_id.clone().expect("fixture has project id"));
     let replay = stores
         .audit
         .read_after_cursor(&stream, &project_a, None, 10)
@@ -479,10 +471,8 @@ async fn libsql_runtime_and_audit_logs_survive_rebuild_with_filtered_cursor_sema
     .await
     .expect("libsql stores after restart");
 
-    let project_a = ReadScope {
-        project_id: scope_a.project_id.clone(),
-        ..ReadScope::default()
-    };
+    let project_a = ReadScope::default()
+        .set_project_id(scope_a.project_id.clone().expect("fixture has project id"));
     let first = stores
         .events
         .read_after_cursor(&stream, &project_a, None, 1)
@@ -561,10 +551,8 @@ async fn postgres_replay_advances_next_cursor_past_trailing_filtered_records() {
         .await
         .expect("append trailing project b");
 
-    let project_a = ReadScope {
-        project_id: scope_a.project_id.clone(),
-        ..ReadScope::default()
-    };
+    let project_a = ReadScope::default()
+        .set_project_id(scope_a.project_id.clone().expect("fixture has project id"));
     let replay = stores
         .events
         .read_after_cursor(&stream, &project_a, None, 10)
@@ -656,10 +644,8 @@ async fn postgres_runtime_and_audit_logs_survive_rebuild_with_filtered_cursor_se
     .await
     .expect("postgres stores after reconnect");
 
-    let project_a = ReadScope {
-        project_id: scope_a.project_id.clone(),
-        ..ReadScope::default()
-    };
+    let project_a = ReadScope::default()
+        .set_project_id(scope_a.project_id.clone().expect("fixture has project id"));
     let replay = stores
         .events
         .read_after_cursor(&stream, &project_a, None, 10)
@@ -786,10 +772,8 @@ async fn jsonl_replay_advances_next_cursor_past_trailing_filtered_records() {
         .await
         .expect("append b1");
 
-    let project_a = ReadScope {
-        project_id: scope_a.project_id.clone(),
-        ..ReadScope::default()
-    };
+    let project_a = ReadScope::default()
+        .set_project_id(scope_a.project_id.clone().expect("fixture has project id"));
     let replay = stores
         .events
         .read_after_cursor(&stream, &project_a, None, 10)

--- a/crates/ironclaw_reborn_event_store/tests/filesystem_event_log_contract.rs
+++ b/crates/ironclaw_reborn_event_store/tests/filesystem_event_log_contract.rs
@@ -256,10 +256,8 @@ async fn filesystem_event_log_replay_filters_by_read_scope() {
     .await
     .expect("append a2");
 
-    let project_a = ReadScope {
-        project_id: scope_a.project_id.clone(),
-        ..ReadScope::default()
-    };
+    let project_a = ReadScope::default()
+        .set_project_id(scope_a.project_id.clone().expect("fixture has project id"));
     let replay = log
         .read_after_cursor(&stream, &project_a, None, 10)
         .await
@@ -295,10 +293,8 @@ async fn filesystem_event_log_replay_advances_past_trailing_filtered_records() {
     .await
     .expect("append b");
 
-    let project_a = ReadScope {
-        project_id: scope_a.project_id.clone(),
-        ..ReadScope::default()
-    };
+    let project_a = ReadScope::default()
+        .set_project_id(scope_a.project_id.clone().expect("fixture has project id"));
     let replay = log
         .read_after_cursor(&stream, &project_a, None, 10)
         .await
@@ -407,10 +403,8 @@ async fn filesystem_audit_log_round_trips_and_filters() {
         .await
         .expect("append audit b");
 
-    let project_a = ReadScope {
-        project_id: scope_a.project_id.clone(),
-        ..ReadScope::default()
-    };
+    let project_a = ReadScope::default()
+        .set_project_id(scope_a.project_id.clone().expect("fixture has project id"));
     let replay = log
         .read_after_cursor(&stream, &project_a, None, 10)
         .await


### PR DESCRIPTION
## Summary

- Convert Reborn event-store contract tests to use `ReadScope::default().set_project_id(...)` for sparse project filters.
- Remove repeated `ReadScope { project_id: ..., ..ReadScope::default() }` boilerplate.

## Why

The event-store contract tests repeatedly build one-field `ReadScope` filters. The setter style keeps the test intent focused on the filter value and avoids future field churn.

## Validation

- `cargo fmt --check`
- `cargo test -p ironclaw_reborn_event_store`

## Stack

Stacked on #5793 (`agent/default-builders-events`), which adds the `ReadScope` setters.