### PR TITLE
Use default setters in product workflow tests

### DIFF
--- a/crates/ironclaw_product_workflow/src/webui_inbound.rs
+++ b/crates/ironclaw_product_workflow/src/webui_inbound.rs
@@ -276,6 +276,28 @@ pub struct WebUiListThreadsRequest {
     pub needs_approval: bool,
 }
 
+impl WebUiListThreadsRequest {
+    pub fn set_limit(mut self, limit: u32) -> Self {
+        self.limit = Some(limit);
+        self
+    }
+
+    pub fn set_cursor(mut self, cursor: impl Into<String>) -> Self {
+        self.cursor = Some(cursor.into());
+        self
+    }
+
+    pub fn set_candidate_thread_id(mut self, candidate_thread_id: impl Into<String>) -> Self {
+        self.candidate_thread_id = Some(candidate_thread_id.into());
+        self
+    }
+
+    pub fn set_needs_approval(mut self, needs_approval: bool) -> Self {
+        self.needs_approval = needs_approval;
+        self
+    }
+}
+
 /// Browser query for WebUI automation listing.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct WebUiListAutomationsRequest {
@@ -288,6 +310,23 @@ pub struct WebUiListAutomationsRequest {
     /// existing callers that do not set this flag are unaffected.
     #[serde(default)]
     pub include_completed: bool,
+}
+
+impl WebUiListAutomationsRequest {
+    pub fn set_limit(mut self, limit: u32) -> Self {
+        self.limit = Some(limit);
+        self
+    }
+
+    pub fn set_run_limit(mut self, run_limit: u32) -> Self {
+        self.run_limit = Some(run_limit);
+        self
+    }
+
+    pub fn set_include_completed(mut self, include_completed: bool) -> Self {
+        self.include_completed = include_completed;
+        self
+    }
 }
 
 /// Browser body for WebUI extension-setup interaction.

--- a/crates/ironclaw_product_workflow/tests/planned_agent_loop_harness.rs
+++ b/crates/ironclaw_product_workflow/tests/planned_agent_loop_harness.rs
@@ -14,10 +14,9 @@ use support::planned_agent_loop::{
 
 #[tokio::test]
 async fn product_live_harness_runs_planned_loop_and_persists_reply() {
-    let harness = ProductLiveAgentLoopHarness::new(ProductLiveAgentLoopHarnessConfig {
-        assistant_reply: "hello from planned loop".to_string(),
-        ..ProductLiveAgentLoopHarnessConfig::default()
-    })
+    let harness = ProductLiveAgentLoopHarness::new(
+        ProductLiveAgentLoopHarnessConfig::default().set_assistant_reply("hello from planned loop"),
+    )
     .await;
     let envelope = harness.user_message("planned-harness-basic", "hello world");
 
@@ -52,12 +51,12 @@ async fn product_live_harness_runs_planned_loop_and_persists_reply() {
 
 #[tokio::test]
 async fn ported_product_live_fixture_uses_shared_harness_for_no_profile_reply() {
-    let harness = ProductLiveAgentLoopHarness::new(ProductLiveAgentLoopHarnessConfig {
-        assistant_reply: "planned product reply".to_string(),
-        user_id: "user:product-live".to_string(),
-        thread_id: "thread:product-live".to_string(),
-        ..ProductLiveAgentLoopHarnessConfig::default()
-    })
+    let harness = ProductLiveAgentLoopHarness::new(
+        ProductLiveAgentLoopHarnessConfig::default()
+            .set_assistant_reply("planned product reply")
+            .set_user_id("user:product-live")
+            .set_thread_id("thread:product-live"),
+    )
     .await;
     let envelope = harness.user_message("planned-product-live-ported", "hello world");
 
@@ -91,13 +90,13 @@ async fn ported_product_live_fixture_uses_shared_harness_for_no_profile_reply() 
 
 #[tokio::test]
 async fn ported_product_live_fixture_cancels_through_public_turn_path() {
-    let harness = ProductLiveAgentLoopHarness::new(ProductLiveAgentLoopHarnessConfig {
-        assistant_reply: "reply after cancel".to_string(),
-        user_id: "user:product-live".to_string(),
-        thread_id: "thread:product-live-cancel-live".to_string(),
-        pause_model_until_released: true,
-        ..ProductLiveAgentLoopHarnessConfig::default()
-    })
+    let harness = ProductLiveAgentLoopHarness::new(
+        ProductLiveAgentLoopHarnessConfig::default()
+            .set_assistant_reply("reply after cancel")
+            .set_user_id("user:product-live")
+            .set_thread_id("thread:product-live-cancel-live")
+            .set_pause_model_until_released(true),
+    )
     .await;
     let envelope = harness.user_message("planned-product-live-cancel-ported", "hello world");
 
@@ -137,20 +136,20 @@ async fn ported_product_live_fixture_cancels_through_public_turn_path() {
 
 #[tokio::test]
 async fn product_live_harness_invokes_capability_then_persists_final_reply() {
-    let harness = ProductLiveAgentLoopHarness::new(ProductLiveAgentLoopHarnessConfig {
-        assistant_reply: "unused fallback".to_string(),
-        model_responses: vec![
-            capability_call_response("harness.echo", "input:harness-echo-1"),
-            HostManagedModelResponse::assistant_reply("final reply after capability"),
-        ],
-        capability: Some(HarnessCapabilityConfig {
-            capability_id: "harness.echo".to_string(),
-            result_ref: "result:harness-echo-1".to_string(),
-            safe_summary: "echo completed".to_string(),
-            terminate_hint: false,
-        }),
-        ..ProductLiveAgentLoopHarnessConfig::default()
-    })
+    let harness = ProductLiveAgentLoopHarness::new(
+        ProductLiveAgentLoopHarnessConfig::default()
+            .set_assistant_reply("unused fallback")
+            .set_model_responses(vec![
+                capability_call_response("harness.echo", "input:harness-echo-1"),
+                HostManagedModelResponse::assistant_reply("final reply after capability"),
+            ])
+            .set_capability(HarnessCapabilityConfig {
+                capability_id: "harness.echo".to_string(),
+                result_ref: "result:harness-echo-1".to_string(),
+                safe_summary: "echo completed".to_string(),
+                terminate_hint: false,
+            }),
+    )
     .await;
     let envelope = harness.user_message("planned-harness-capability", "use echo");
 
@@ -185,14 +184,14 @@ async fn product_live_harness_invokes_capability_then_persists_final_reply() {
 
 #[tokio::test]
 async fn product_live_harness_invokes_builtin_echo_through_host_runtime() {
-    let harness = ProductLiveAgentLoopHarness::new(ProductLiveAgentLoopHarnessConfig {
-        assistant_reply: "final reply after builtin echo".to_string(),
-        host_runtime_capability: Some(HostRuntimeCapabilityConfig {
-            capability_id: ironclaw_host_runtime::ECHO_CAPABILITY_ID.to_string(),
-            input: serde_json::json!({ "message": "hello from builtin echo" }),
-        }),
-        ..ProductLiveAgentLoopHarnessConfig::default()
-    })
+    let harness = ProductLiveAgentLoopHarness::new(
+        ProductLiveAgentLoopHarnessConfig::default()
+            .set_assistant_reply("final reply after builtin echo")
+            .set_host_runtime_capability(HostRuntimeCapabilityConfig {
+                capability_id: ironclaw_host_runtime::ECHO_CAPABILITY_ID.to_string(),
+                input: serde_json::json!({ "message": "hello from builtin echo" }),
+            }),
+    )
     .await;
     let envelope = harness.user_message("planned-harness-builtin-echo", "use builtin echo");
 

--- a/crates/ironclaw_product_workflow/tests/reborn_services_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/reborn_services_contract.rs
@@ -5071,11 +5071,7 @@ async fn list_automation_dispatches_through_product_facade() {
     let listed = services
         .list_automations(
             caller(),
-            WebUiListAutomationsRequest {
-                limit: Some(10),
-                run_limit: None,
-                ..Default::default()
-            },
+            WebUiListAutomationsRequest::default().set_limit(10),
         )
         .await
         .expect("list automations");
@@ -5820,11 +5816,7 @@ async fn list_automations_rejects_missing_agent_id() {
     let err = services
         .list_automations(
             caller_without_agent(),
-            WebUiListAutomationsRequest {
-                limit: Some(10),
-                run_limit: None,
-                ..Default::default()
-            },
+            WebUiListAutomationsRequest::default().set_limit(10),
         )
         .await
         .expect_err("missing agent id should fail closed");
@@ -5846,11 +5838,7 @@ async fn list_automations_clamps_oversize_limit_before_product_facade() {
     services
         .list_automations(
             caller(),
-            WebUiListAutomationsRequest {
-                limit: Some(u32::MAX),
-                run_limit: None,
-                ..Default::default()
-            },
+            WebUiListAutomationsRequest::default().set_limit(u32::MAX),
         )
         .await
         .expect("list automations");
@@ -5876,11 +5864,7 @@ async fn list_automations_clamps_zero_limit_before_product_facade() {
     services
         .list_automations(
             caller(),
-            WebUiListAutomationsRequest {
-                limit: Some(0),
-                run_limit: None,
-                ..Default::default()
-            },
+            WebUiListAutomationsRequest::default().set_limit(0),
         )
         .await
         .expect("list automations");
@@ -5903,14 +5887,7 @@ async fn list_automations_uses_default_limit_when_omitted() {
     .with_automation_product_facade(automation_facade.clone());
 
     services
-        .list_automations(
-            caller(),
-            WebUiListAutomationsRequest {
-                limit: None,
-                run_limit: None,
-                ..Default::default()
-            },
-        )
+        .list_automations(caller(), WebUiListAutomationsRequest::default())
         .await
         .expect("list automations");
 
@@ -5935,11 +5912,7 @@ async fn list_automations_clamps_oversize_run_limit_before_product_facade() {
     services
         .list_automations(
             caller(),
-            WebUiListAutomationsRequest {
-                limit: None,
-                run_limit: Some(u32::MAX),
-                ..Default::default()
-            },
+            WebUiListAutomationsRequest::default().set_run_limit(u32::MAX),
         )
         .await
         .expect("list automations");
@@ -5965,11 +5938,7 @@ async fn list_automations_allows_zero_run_limit_before_product_facade() {
     services
         .list_automations(
             caller(),
-            WebUiListAutomationsRequest {
-                limit: None,
-                run_limit: Some(0),
-                ..Default::default()
-            },
+            WebUiListAutomationsRequest::default().set_run_limit(0),
         )
         .await
         .expect("list automations");
@@ -5994,10 +5963,7 @@ async fn list_automations_forwards_include_completed_true_to_product_facade() {
     services
         .list_automations(
             caller(),
-            WebUiListAutomationsRequest {
-                include_completed: true,
-                ..Default::default()
-            },
+            WebUiListAutomationsRequest::default().set_include_completed(true),
         )
         .await
         .expect("list automations");
@@ -6020,13 +5986,7 @@ async fn list_automations_forwards_include_completed_false_to_product_facade() {
     .with_automation_product_facade(automation_facade.clone());
 
     services
-        .list_automations(
-            caller(),
-            WebUiListAutomationsRequest {
-                include_completed: false,
-                ..Default::default()
-            },
-        )
+        .list_automations(caller(), WebUiListAutomationsRequest::default())
         .await
         .expect("list automations");
 
@@ -10220,10 +10180,7 @@ async fn list_threads_needs_approval_returns_only_automation_threads_with_pendin
     let response = services
         .list_threads(
             caller,
-            WebUiListThreadsRequest {
-                needs_approval: true,
-                ..WebUiListThreadsRequest::default()
-            },
+            WebUiListThreadsRequest::default().set_needs_approval(true),
         )
         .await
         .expect("list approval threads");
@@ -10267,10 +10224,7 @@ async fn list_threads_needs_approval_queries_pending_with_run_scope_shape() {
     let response = services
         .list_threads(
             caller,
-            WebUiListThreadsRequest {
-                needs_approval: true,
-                ..WebUiListThreadsRequest::default()
-            },
+            WebUiListThreadsRequest::default().set_needs_approval(true),
         )
         .await
         .expect("list approval threads");
@@ -10313,10 +10267,7 @@ async fn list_threads_needs_approval_uses_bounded_run_candidates() {
     let response = services
         .list_threads(
             caller,
-            WebUiListThreadsRequest {
-                needs_approval: true,
-                ..WebUiListThreadsRequest::default()
-            },
+            WebUiListThreadsRequest::default().set_needs_approval(true),
         )
         .await
         .expect("list approval threads");
@@ -10362,10 +10313,7 @@ async fn list_threads_needs_approval_finds_legacy_ownerless_automation_thread() 
     let response = services
         .list_threads(
             caller,
-            WebUiListThreadsRequest {
-                needs_approval: true,
-                ..WebUiListThreadsRequest::default()
-            },
+            WebUiListThreadsRequest::default().set_needs_approval(true),
         )
         .await
         .expect("list approval threads");
@@ -10421,10 +10369,7 @@ async fn list_threads_needs_approval_uses_automation_name_when_thread_title_miss
     let response = services
         .list_threads(
             caller,
-            WebUiListThreadsRequest {
-                needs_approval: true,
-                ..WebUiListThreadsRequest::default()
-            },
+            WebUiListThreadsRequest::default().set_needs_approval(true),
         )
         .await
         .expect("list approval threads");
@@ -10461,11 +10406,9 @@ async fn list_threads_needs_approval_checks_candidate_automation_thread() {
     let response = services
         .list_threads(
             caller,
-            WebUiListThreadsRequest {
-                needs_approval: true,
-                candidate_thread_id: Some(automation_pending_thread_id.as_str().to_string()),
-                ..WebUiListThreadsRequest::default()
-            },
+            WebUiListThreadsRequest::default()
+                .set_needs_approval(true)
+                .set_candidate_thread_id(automation_pending_thread_id.as_str()),
         )
         .await
         .expect("list approval threads");
@@ -10516,14 +10459,7 @@ async fn list_threads_breaks_out_when_cursor_does_not_advance_for_automation_thr
 
     let response = tokio::time::timeout(
         Duration::from_secs(1),
-        services.list_threads(
-            caller,
-            WebUiListThreadsRequest {
-                limit: Some(2),
-                cursor: None,
-                ..WebUiListThreadsRequest::default()
-            },
-        ),
+        services.list_threads(caller, WebUiListThreadsRequest::default().set_limit(2)),
     )
     .await
     .expect("list_threads should terminate when backend cursor stalls")
@@ -10577,14 +10513,7 @@ async fn list_threads_caps_filtered_pages_when_automation_threads_dominate() {
     );
 
     let response = services
-        .list_threads(
-            caller,
-            WebUiListThreadsRequest {
-                limit: Some(1),
-                cursor: None,
-                ..WebUiListThreadsRequest::default()
-            },
-        )
+        .list_threads(caller, WebUiListThreadsRequest::default().set_limit(1))
         .await
         .expect("list threads");
 
@@ -10668,11 +10597,7 @@ async fn list_threads_skips_hidden_automation_threads_when_filling_page() {
     let first_page = services
         .list_threads(
             caller.clone(),
-            WebUiListThreadsRequest {
-                limit: Some(1),
-                cursor: None,
-                ..WebUiListThreadsRequest::default()
-            },
+            WebUiListThreadsRequest::default().set_limit(1),
         )
         .await
         .expect("list first visible page");
@@ -10689,11 +10614,9 @@ async fn list_threads_skips_hidden_automation_threads_when_filling_page() {
     let second_page = services
         .list_threads(
             caller,
-            WebUiListThreadsRequest {
-                limit: Some(1),
-                cursor: first_page.next_cursor,
-                ..WebUiListThreadsRequest::default()
-            },
+            WebUiListThreadsRequest::default()
+                .set_limit(1)
+                .set_cursor(first_page.next_cursor.expect("first visible page cursor")),
         )
         .await
         .expect("list second visible page");

--- a/crates/ironclaw_product_workflow/tests/support/planned_agent_loop.rs
+++ b/crates/ironclaw_product_workflow/tests/support/planned_agent_loop.rs
@@ -118,6 +118,46 @@ impl Default for ProductLiveAgentLoopHarnessConfig {
     }
 }
 
+impl ProductLiveAgentLoopHarnessConfig {
+    pub fn set_assistant_reply(mut self, assistant_reply: impl Into<String>) -> Self {
+        self.assistant_reply = assistant_reply.into();
+        self
+    }
+
+    pub fn set_user_id(mut self, user_id: impl Into<String>) -> Self {
+        self.user_id = user_id.into();
+        self
+    }
+
+    pub fn set_thread_id(mut self, thread_id: impl Into<String>) -> Self {
+        self.thread_id = thread_id.into();
+        self
+    }
+
+    pub fn set_pause_model_until_released(mut self, pause_model_until_released: bool) -> Self {
+        self.pause_model_until_released = pause_model_until_released;
+        self
+    }
+
+    pub fn set_model_responses(mut self, model_responses: Vec<HostManagedModelResponse>) -> Self {
+        self.model_responses = model_responses;
+        self
+    }
+
+    pub fn set_capability(mut self, capability: HarnessCapabilityConfig) -> Self {
+        self.capability = Some(capability);
+        self
+    }
+
+    pub fn set_host_runtime_capability(
+        mut self,
+        host_runtime_capability: HostRuntimeCapabilityConfig,
+    ) -> Self {
+        self.host_runtime_capability = Some(host_runtime_capability);
+        self
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct HarnessCapabilityConfig {
     pub capability_id: String,


### PR DESCRIPTION
## Summary
- add default-backed setters for WebUI list request DTOs and the planned loop harness config
- convert sparse product workflow request/config fixtures to ::default().set_*() chains
- keep default-only request cases as ::default()

## Stack
- Depends on #5791 (agent/default-backed-builders)

## Validation
- cargo fmt --check
- cargo test -p ironclaw_product_workflow --test planned_agent_loop_harness
- cargo test -p ironclaw_product_workflow --test reborn_services_contract