### PR TITLE
Use default setters in host runtime resource fixtures

### DIFF
--- a/crates/ironclaw_host_runtime/src/first_party.rs
+++ b/crates/ironclaw_host_runtime/src/first_party.rs
@@ -388,10 +388,7 @@ mod tests {
     #[test]
     fn first_party_capability_error_with_usage_preserves_required_secrets() {
         let handle = SecretHandle::new("google-access-token").unwrap();
-        let usage = ResourceUsage {
-            network_egress_bytes: 42,
-            ..ResourceUsage::default()
-        };
+        let usage = ResourceUsage::default().set_network_egress_bytes(42);
         let error = FirstPartyCapabilityError::auth_required_with(vec![handle.clone()])
             .with_usage(usage.clone());
 
@@ -416,12 +413,8 @@ mod tests {
     #[test]
     fn first_party_capability_error_with_usage_on_dispatch_variant() {
         use ironclaw_host_api::RuntimeDispatchErrorKind;
-        let error = FirstPartyCapabilityError::new(RuntimeDispatchErrorKind::Backend).with_usage(
-            ResourceUsage {
-                network_egress_bytes: 10,
-                ..ResourceUsage::default()
-            },
-        );
+        let error = FirstPartyCapabilityError::new(RuntimeDispatchErrorKind::Backend)
+            .with_usage(ResourceUsage::default().set_network_egress_bytes(10));
         assert_eq!(error.kind(), Some(RuntimeDispatchErrorKind::Backend));
         assert_eq!(error.required_secrets(), None);
         assert!(!error.is_auth_required());

--- a/crates/ironclaw_host_runtime/src/first_party_tools/http.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/http.rs
@@ -87,12 +87,10 @@ fn http_manifest(
 
 fn http_resource_profile() -> ResourceProfile {
     ResourceProfile {
-        default_estimate: ResourceEstimate {
-            wall_clock_ms: Some(DEFAULT_HTTP_TIMEOUT_MS.into()),
-            output_bytes: Some(DEFAULT_INLINE_RESPONSE_BODY_LIMIT),
-            network_egress_bytes: Some(DEFAULT_NETWORK_EGRESS_BYTES),
-            ..ResourceEstimate::default()
-        },
+        default_estimate: ResourceEstimate::default()
+            .set_wall_clock_ms(DEFAULT_HTTP_TIMEOUT_MS.into())
+            .set_output_bytes(DEFAULT_INLINE_RESPONSE_BODY_LIMIT)
+            .set_network_egress_bytes(DEFAULT_NETWORK_EGRESS_BYTES),
         hard_ceiling: Some(ResourceCeiling {
             max_usd: None,
             max_input_tokens: None,

--- a/crates/ironclaw_host_runtime/src/first_party_tools/memory.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/memory.rs
@@ -108,10 +108,7 @@ pub(super) async fn dispatch(
     let wall_clock_ms = start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
     Ok(FirstPartyCapabilityResult::new(
         output,
-        ResourceUsage {
-            wall_clock_ms,
-            ..ResourceUsage::default()
-        },
+        ResourceUsage::default().set_wall_clock_ms(wall_clock_ms),
     ))
 }
 

--- a/crates/ironclaw_host_runtime/src/first_party_tools/mod.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/mod.rs
@@ -499,22 +499,20 @@ impl FirstPartyCapabilityHandler for BuiltinFirstPartyTools {
                 let wall_clock_ms = duration.as_millis().try_into().unwrap_or(u64::MAX);
                 let output_bytes = bounded_output_bytes(&output, FIRST_PARTY_MAX_OUTPUT_BYTES)
                     .map_err(|error| {
-                        error.with_usage(ResourceUsage {
-                            wall_clock_ms,
-                            network_egress_bytes,
-                            process_count: 1,
-                            ..ResourceUsage::default()
-                        })
+                        error.with_usage(
+                            ResourceUsage::default()
+                                .set_wall_clock_ms(wall_clock_ms)
+                                .set_network_egress_bytes(network_egress_bytes)
+                                .set_process_count(1),
+                        )
                     })?;
                 return Ok(FirstPartyCapabilityResult::new(
                     output,
-                    ResourceUsage {
-                        wall_clock_ms,
-                        output_bytes,
-                        network_egress_bytes,
-                        process_count: 1,
-                        ..ResourceUsage::default()
-                    },
+                    ResourceUsage::default()
+                        .set_wall_clock_ms(wall_clock_ms)
+                        .set_output_bytes(output_bytes)
+                        .set_network_egress_bytes(network_egress_bytes)
+                        .set_process_count(1),
                 ));
             }
             SPAWN_SUBAGENT_CAPABILITY_ID => (spawn_subagent::dispatch(), None),
@@ -567,21 +565,19 @@ impl FirstPartyCapabilityHandler for BuiltinFirstPartyTools {
         };
         let output_bytes = bounded_output_bytes(&output, output_limit_bytes).map_err(|error| {
             if network_egress_bytes > 0 {
-                error.with_usage(ResourceUsage {
-                    wall_clock_ms,
-                    network_egress_bytes,
-                    ..ResourceUsage::default()
-                })
+                error.with_usage(
+                    ResourceUsage::default()
+                        .set_wall_clock_ms(wall_clock_ms)
+                        .set_network_egress_bytes(network_egress_bytes),
+                )
             } else {
                 error
             }
         })?;
-        let usage = ResourceUsage {
-            wall_clock_ms,
-            output_bytes,
-            network_egress_bytes,
-            ..ResourceUsage::default()
-        };
+        let usage = ResourceUsage::default()
+            .set_wall_clock_ms(wall_clock_ms)
+            .set_output_bytes(output_bytes)
+            .set_network_egress_bytes(network_egress_bytes);
         Ok(FirstPartyCapabilityResult::new(output, usage).with_display_preview(display_preview))
     }
 }
@@ -674,11 +670,9 @@ fn normalize_optional_null_sentinels(request: &mut FirstPartyCapabilityRequest) 
 
 fn resource_profile() -> Option<ResourceProfile> {
     Some(ResourceProfile {
-        default_estimate: ResourceEstimate {
-            wall_clock_ms: Some(FIRST_PARTY_DEFAULT_WALL_CLOCK_MS),
-            output_bytes: Some(FIRST_PARTY_DEFAULT_OUTPUT_BYTES),
-            ..ResourceEstimate::default()
-        },
+        default_estimate: ResourceEstimate::default()
+            .set_wall_clock_ms(FIRST_PARTY_DEFAULT_WALL_CLOCK_MS)
+            .set_output_bytes(FIRST_PARTY_DEFAULT_OUTPUT_BYTES),
         hard_ceiling: Some(ResourceCeiling {
             max_usd: None,
             max_input_tokens: None,

--- a/crates/ironclaw_host_runtime/src/first_party_tools/shell.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/shell.rs
@@ -41,12 +41,10 @@ pub(super) fn manifest() -> Result<CapabilityManifest, ExtensionError> {
         ],
         PermissionMode::Ask,
         Some(ResourceProfile {
-            default_estimate: ResourceEstimate {
-                wall_clock_ms: Some(DEFAULT_SHELL_WALL_CLOCK_MS),
-                output_bytes: Some(DEFAULT_SHELL_OUTPUT_BYTES),
-                process_count: Some(1),
-                ..ResourceEstimate::default()
-            },
+            default_estimate: ResourceEstimate::default()
+                .set_wall_clock_ms(DEFAULT_SHELL_WALL_CLOCK_MS)
+                .set_output_bytes(DEFAULT_SHELL_OUTPUT_BYTES)
+                .set_process_count(1),
             hard_ceiling: Some(ResourceCeiling {
                 max_usd: None,
                 max_input_tokens: None,

--- a/crates/ironclaw_host_runtime/src/first_party_tools/trigger_management.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/trigger_management.rs
@@ -786,11 +786,9 @@ fn trigger_error_kind(error: &TriggerError) -> &'static str {
 }
 
 fn elapsed_usage_with_bytes(started: Instant, output_bytes: u64) -> ResourceUsage {
-    ResourceUsage {
-        wall_clock_ms: started.elapsed().as_millis().try_into().unwrap_or(u64::MAX),
-        output_bytes,
-        ..ResourceUsage::default()
-    }
+    ResourceUsage::default()
+        .set_wall_clock_ms(started.elapsed().as_millis().try_into().unwrap_or(u64::MAX))
+        .set_output_bytes(output_bytes)
 }
 
 #[cfg(test)]

--- a/crates/ironclaw_host_runtime/src/services/tests/first_party_runtime_adapter.rs
+++ b/crates/ironclaw_host_runtime/src/services/tests/first_party_runtime_adapter.rs
@@ -553,10 +553,7 @@ async fn first_party_adapter_releases_reservation_when_dispatch_future_is_cancel
         SecretMode::ScrubbedEnv,
     );
     // Non-zero estimate so the held reservation is observable in the tally.
-    let estimate = ResourceEstimate {
-        output_bytes: Some(128),
-        ..ResourceEstimate::default()
-    };
+    let estimate = ResourceEstimate::default().set_output_bytes(128);
 
     let dispatch = adapter.dispatch_json(RuntimeAdapterRequest {
         package: &package,
@@ -622,10 +619,7 @@ impl crate::FirstPartyCapabilityHandler for DispatchFailingWithUsageHandler {
         &self,
         _request: crate::FirstPartyCapabilityRequest,
     ) -> Result<crate::FirstPartyCapabilityResult, crate::FirstPartyCapabilityError> {
-        let usage = ironclaw_host_api::ResourceUsage {
-            output_bytes: 64,
-            ..ironclaw_host_api::ResourceUsage::default()
-        };
+        let usage = ironclaw_host_api::ResourceUsage::default().set_output_bytes(64);
         Err(
             crate::FirstPartyCapabilityError::new(RuntimeDispatchErrorKind::OperationFailed)
                 .with_usage(usage),

--- a/crates/ironclaw_host_runtime/tests/builtin_obligation_handler_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/builtin_obligation_handler_contract.rs
@@ -144,11 +144,9 @@ async fn builtin_obligation_handler_allows_resource_ceiling_when_estimate_is_wit
     let handler = BuiltinObligationHandler::new();
     let context = execution_context(CapabilitySet::default());
     let capability_id = capability_id();
-    let estimate = ResourceEstimate {
-        usd: Some(1.into()),
-        input_tokens: Some(100),
-        ..ResourceEstimate::default()
-    };
+    let estimate = ResourceEstimate::default()
+        .set_usd(1.into())
+        .set_input_tokens(100);
     let obligations = vec![Obligation::EnforceResourceCeiling {
         ceiling: ResourceCeiling {
             max_usd: Some(2.into()),
@@ -177,10 +175,7 @@ async fn builtin_obligation_handler_rejects_resource_ceiling_above_host_estimate
     let handler = BuiltinObligationHandler::new();
     let context = execution_context(CapabilitySet::default());
     let capability_id = capability_id();
-    let estimate = ResourceEstimate {
-        usd: Some(3.into()),
-        ..ResourceEstimate::default()
-    };
+    let estimate = ResourceEstimate::default().set_usd(3.into());
     let obligations = vec![Obligation::EnforceResourceCeiling {
         ceiling: ResourceCeiling {
             max_usd: Some(2.into()),
@@ -255,10 +250,7 @@ async fn builtin_obligation_handler_rejects_wall_clock_ceiling_until_runtime_han
     let handler = BuiltinObligationHandler::new();
     let context = execution_context(CapabilitySet::default());
     let capability_id = capability_id();
-    let estimate = ResourceEstimate {
-        wall_clock_ms: Some(500),
-        ..ResourceEstimate::default()
-    };
+    let estimate = ResourceEstimate::default().set_wall_clock_ms(500);
     let obligations = vec![Obligation::EnforceResourceCeiling {
         ceiling: ResourceCeiling {
             max_usd: None,
@@ -294,10 +286,7 @@ async fn builtin_obligation_handler_rejects_sandbox_network_ceiling_until_runtim
     let handler = BuiltinObligationHandler::new();
     let context = execution_context(CapabilitySet::default());
     let capability_id = capability_id();
-    let estimate = ResourceEstimate {
-        network_egress_bytes: Some(512),
-        ..ResourceEstimate::default()
-    };
+    let estimate = ResourceEstimate::default().set_network_egress_bytes(512);
     let obligations = vec![Obligation::EnforceResourceCeiling {
         ceiling: ResourceCeiling {
             max_usd: None,
@@ -336,10 +325,7 @@ async fn builtin_obligation_handler_rejects_sandbox_process_ceiling_until_runtim
     let handler = BuiltinObligationHandler::new();
     let context = execution_context(CapabilitySet::default());
     let capability_id = capability_id();
-    let estimate = ResourceEstimate {
-        process_count: Some(1),
-        ..ResourceEstimate::default()
-    };
+    let estimate = ResourceEstimate::default().set_process_count(1);
     let obligations = vec![Obligation::EnforceResourceCeiling {
         ceiling: ResourceCeiling {
             max_usd: None,
@@ -455,10 +441,7 @@ async fn builtin_obligation_handler_enforces_resource_ceiling_after_dispatch_usa
     let handler = BuiltinObligationHandler::new();
     let context = execution_context(CapabilitySet::default());
     let capability_id = capability_id();
-    let estimate = ResourceEstimate {
-        output_tokens: Some(10),
-        ..ResourceEstimate::default()
-    };
+    let estimate = ResourceEstimate::default().set_output_tokens(10);
     let obligations = vec![Obligation::EnforceResourceCeiling {
         ceiling: ResourceCeiling {
             max_usd: None,
@@ -773,10 +756,7 @@ async fn builtin_obligation_handler_satisfy_preserves_staged_handoffs_when_relea
     let context = execution_context(CapabilitySet::default());
     let account = ResourceAccount::tenant(context.resource_scope.tenant_id.clone());
     let capability_id = capability_id();
-    let estimate = ResourceEstimate {
-        concurrency_slots: Some(1),
-        ..ResourceEstimate::default()
-    };
+    let estimate = ResourceEstimate::default().set_concurrency_slots(1);
     let handle = SecretHandle::new("api_token").unwrap();
     secret_store
         .put(
@@ -911,10 +891,7 @@ async fn builtin_obligation_handler_reserves_requested_resources_and_releases_on
     let context = execution_context(CapabilitySet::default());
     let account = ResourceAccount::tenant(context.resource_scope.tenant_id.clone());
     let capability_id = capability_id();
-    let estimate = ResourceEstimate {
-        concurrency_slots: Some(1),
-        ..ResourceEstimate::default()
-    };
+    let estimate = ResourceEstimate::default().set_concurrency_slots(1);
     let reservation_id = ResourceReservationId::new();
     let obligations = vec![Obligation::ReserveResources { reservation_id }];
 
@@ -1021,10 +998,7 @@ async fn default_host_runtime_dispatches_when_resource_ceiling_is_satisfied() {
         .invoke_capability(RuntimeCapabilityRequest::new(
             execution_context(CapabilitySet::default()),
             capability_id(),
-            ResourceEstimate {
-                usd: Some(1.into()),
-                ..ResourceEstimate::default()
-            },
+            ResourceEstimate::default().set_usd(1.into()),
             json!({"message": "obligated"}),
             trust_decision(),
         ))

--- a/crates/ironclaw_host_runtime/tests/extension_v2_lifecycle_e2e.rs
+++ b/crates/ironclaw_host_runtime/tests/extension_v2_lifecycle_e2e.rs
@@ -72,21 +72,17 @@ async fn extension_v2_lifecycle_discovers_installs_publishes_and_dispatches_host
     let governor = Arc::new(InMemoryResourceGovernor::new());
     let scope = sample_scope();
     let account = ResourceAccount::tenant(scope.tenant_id.clone());
-    let estimate = ResourceEstimate {
-        concurrency_slots: Some(1),
-        process_count: Some(1),
-        output_bytes: Some(10_000),
-        ..ResourceEstimate::default()
-    };
+    let estimate = ResourceEstimate::default()
+        .set_concurrency_slots(1)
+        .set_process_count(1)
+        .set_output_bytes(10_000);
     governor
         .set_limit(
             account.clone(),
-            ResourceLimits {
-                max_concurrency_slots: Some(1),
-                max_process_count: Some(1),
-                max_output_bytes: Some(10_000),
-                ..ResourceLimits::default()
-            },
+            ResourceLimits::default()
+                .set_max_concurrency_slots(1)
+                .set_max_process_count(1)
+                .set_max_output_bytes(10_000),
         )
         .unwrap();
     let adapter = Arc::new(RecordingAdapter::new(
@@ -492,14 +488,12 @@ impl RuntimeAdapter<LocalFilesystem, InMemoryResourceGovernor> for RecordingAdap
         });
 
         let output_bytes = serde_json::to_vec(&self.output).unwrap().len() as u64;
-        let usage = ResourceUsage {
-            output_bytes,
-            process_count: u32::from(matches!(
+        let usage = ResourceUsage::default()
+            .set_output_bytes(output_bytes)
+            .set_process_count(u32::from(matches!(
                 self.runtime,
                 RuntimeKind::Script | RuntimeKind::Mcp
-            )),
-            ..ResourceUsage::default()
-        };
+            )));
         let reservation = match request.resource_reservation {
             Some(reservation) => reservation,
             None => request

--- a/crates/ironclaw_host_runtime/tests/first_party_runtime_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_runtime_contract.rs
@@ -63,10 +63,7 @@ async fn host_runtime_invokes_first_party_handler_through_capability_host() {
     });
     let scope = context.resource_scope.clone();
     let invocation_id = context.invocation_id;
-    let estimate = ResourceEstimate {
-        output_bytes: Some(1024),
-        ..ResourceEstimate::default()
-    };
+    let estimate = ResourceEstimate::default().set_output_bytes(1024);
     let input = json!({"message":"status"});
 
     let outcome = runtime
@@ -151,11 +148,9 @@ async fn first_party_handler_uses_staged_secret_through_production_host_egress()
         .invoke_capability(RuntimeCapabilityRequest::new(
             context,
             capability_id(),
-            ResourceEstimate {
-                network_egress_bytes: Some(100),
-                output_bytes: Some(1024),
-                ..ResourceEstimate::default()
-            },
+            ResourceEstimate::default()
+                .set_network_egress_bytes(100)
+                .set_output_bytes(1024),
             json!({"url":"https://api.example.test/v1/native"}),
             trust_decision(),
         ))
@@ -412,10 +407,9 @@ async fn host_runtime_health_reports_missing_first_party_backend_for_empty_regis
 
 #[tokio::test]
 async fn first_party_handler_error_reconciles_reported_usage_after_side_effect() {
-    let handler = Arc::new(FailingFirstPartyHandler::new(ResourceUsage {
-        network_egress_bytes: 77,
-        ..ResourceUsage::default()
-    }));
+    let handler = Arc::new(FailingFirstPartyHandler::new(
+        ResourceUsage::default().set_network_egress_bytes(77),
+    ));
     let first_party =
         FirstPartyCapabilityRegistry::new().with_handler(capability_id(), Arc::clone(&handler));
     let governor = Arc::new(InMemoryResourceGovernor::new());
@@ -439,10 +433,7 @@ async fn first_party_handler_error_reconciles_reported_usage_after_side_effect()
         .invoke_capability(RuntimeCapabilityRequest::new(
             context,
             capability_id(),
-            ResourceEstimate {
-                network_egress_bytes: Some(100),
-                ..ResourceEstimate::default()
-            },
+            ResourceEstimate::default().set_network_egress_bytes(100),
             json!({"message":"status"}),
             trust_decision(),
         ))
@@ -488,10 +479,7 @@ async fn first_party_handler_panic_fails_closed_and_releases_reservation() {
     let outcome = AssertUnwindSafe(runtime.invoke_capability(RuntimeCapabilityRequest::new(
         context,
         capability_id(),
-        ResourceEstimate {
-            network_egress_bytes: Some(100),
-            ..ResourceEstimate::default()
-        },
+        ResourceEstimate::default().set_network_egress_bytes(100),
         json!({"message":"status"}),
         trust_decision(),
     )))
@@ -771,11 +759,9 @@ impl FirstPartyCapabilityHandler for HttpFirstPartyHandler {
             })?;
         Ok(FirstPartyCapabilityResult::new(
             json!({"status": response.status}),
-            ResourceUsage {
-                network_egress_bytes: response.request_bytes,
-                output_bytes: 14,
-                ..ResourceUsage::default()
-            },
+            ResourceUsage::default()
+                .set_network_egress_bytes(response.request_bytes)
+                .set_output_bytes(14),
         ))
     }
 }
@@ -828,11 +814,9 @@ async fn invoke_http_fixture(
         .invoke_capability(RuntimeCapabilityRequest::new(
             context,
             capability_id(),
-            ResourceEstimate {
-                network_egress_bytes: Some(100),
-                output_bytes: Some(1024),
-                ..ResourceEstimate::default()
-            },
+            ResourceEstimate::default()
+                .set_network_egress_bytes(100)
+                .set_output_bytes(1024),
             input,
             trust_decision(),
         ))

--- a/crates/ironclaw_host_runtime/tests/github_wasm_runtime_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/github_wasm_runtime_contract.rs
@@ -2148,24 +2148,20 @@ fn governor_with_default_limit(account: ResourceAccount) -> InMemoryResourceGove
     governor
         .set_limit(
             account,
-            ResourceLimits {
-                max_concurrency_slots: Some(10),
-                max_network_egress_bytes: Some(10_000),
-                max_output_bytes: Some(100_000),
-                ..ResourceLimits::default()
-            },
+            ResourceLimits::default()
+                .set_max_concurrency_slots(10)
+                .set_max_network_egress_bytes(10_000)
+                .set_max_output_bytes(100_000),
         )
         .unwrap();
     governor
 }
 
 fn wasm_http_estimate() -> ResourceEstimate {
-    ResourceEstimate {
-        concurrency_slots: Some(1),
-        network_egress_bytes: Some(10),
-        output_bytes: Some(10_000),
-        ..ResourceEstimate::default()
-    }
+    ResourceEstimate::default()
+        .set_concurrency_slots(1)
+        .set_network_egress_bytes(10)
+        .set_output_bytes(10_000)
 }
 
 fn sample_account() -> ResourceAccount {

--- a/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
@@ -339,20 +339,11 @@ async fn with_filesystem_resource_governor_persists_reservations_across_handles(
     governor
         .set_limit(
             account.clone(),
-            ResourceLimits {
-                max_concurrency_slots: Some(1),
-                ..ResourceLimits::default()
-            },
+            ResourceLimits::default().set_max_concurrency_slots(1),
         )
         .unwrap();
     let reservation = governor
-        .reserve(
-            scope,
-            ResourceEstimate {
-                concurrency_slots: Some(1),
-                ..ResourceEstimate::default()
-            },
-        )
+        .reserve(scope, ResourceEstimate::default().set_concurrency_slots(1))
         .unwrap();
     governor.release(reservation.id).unwrap();
 }
@@ -392,17 +383,11 @@ async fn with_filesystem_resource_governor_closes_process_reservations_on_cancel
     let scope = sample_scope(InvocationId::new());
     let account = ResourceAccount::tenant(scope.tenant_id.clone());
     let reservation_id = ResourceReservationId::new();
-    let estimate = ResourceEstimate {
-        concurrency_slots: Some(1),
-        ..ResourceEstimate::default()
-    };
+    let estimate = ResourceEstimate::default().set_concurrency_slots(1);
     governor
         .set_limit(
             account.clone(),
-            ResourceLimits {
-                max_concurrency_slots: Some(1),
-                ..ResourceLimits::default()
-            },
+            ResourceLimits::default().set_max_concurrency_slots(1),
         )
         .unwrap();
     governor
@@ -4165,12 +4150,10 @@ async fn host_runtime_services_projects_resource_network_secret_obligation_audit
         .invoke_capability(RuntimeCapabilityRequest::new(
             execution_context_with_dispatch_grant_for_scope(script_capability_id(), scope.clone()),
             script_capability_id(),
-            ResourceEstimate {
-                concurrency_slots: Some(1),
-                network_egress_bytes: Some(10),
-                output_bytes: Some(100),
-                ..ResourceEstimate::default()
-            },
+            ResourceEstimate::default()
+                .set_concurrency_slots(1)
+                .set_network_egress_bytes(10)
+                .set_output_bytes(100),
             payload.clone(),
             trust_decision_with_dispatch_authority(),
         ))
@@ -4244,11 +4227,9 @@ async fn host_runtime_services_enforces_output_limit_and_reconciles_resource_usa
     governor
         .set_limit(
             account.clone(),
-            ResourceLimits {
-                max_concurrency_slots: Some(1),
-                max_output_bytes: Some(10_000),
-                ..ResourceLimits::default()
-            },
+            ResourceLimits::default()
+                .set_max_concurrency_slots(1)
+                .set_max_output_bytes(10_000),
         )
         .unwrap();
     let run_state = Arc::new(InMemoryRunStateStore::new());
@@ -4283,11 +4264,9 @@ async fn host_runtime_services_enforces_output_limit_and_reconciles_resource_usa
         .invoke_capability(RuntimeCapabilityRequest::new(
             execution_context_with_dispatch_grant_for_scope(script_capability_id(), scope.clone()),
             script_capability_id(),
-            ResourceEstimate {
-                concurrency_slots: Some(1),
-                output_bytes: Some(1024),
-                ..ResourceEstimate::default()
-            },
+            ResourceEstimate::default()
+                .set_concurrency_slots(1)
+                .set_output_bytes(1024),
             input,
             trust_decision_with_dispatch_authority(),
         ))
@@ -4318,10 +4297,7 @@ async fn host_runtime_services_releases_reservation_when_dispatch_preflight_fail
     governor
         .set_limit(
             account.clone(),
-            ResourceLimits {
-                max_concurrency_slots: Some(1),
-                ..ResourceLimits::default()
-            },
+            ResourceLimits::default().set_max_concurrency_slots(1),
         )
         .unwrap();
     let run_state = Arc::new(InMemoryRunStateStore::new());
@@ -4347,10 +4323,7 @@ async fn host_runtime_services_releases_reservation_when_dispatch_preflight_fail
         .invoke_capability(RuntimeCapabilityRequest::new(
             execution_context_with_dispatch_grant_for_scope(script_capability_id(), scope.clone()),
             script_capability_id(),
-            ResourceEstimate {
-                concurrency_slots: Some(1),
-                ..ResourceEstimate::default()
-            },
+            ResourceEstimate::default().set_concurrency_slots(1),
             json!({"message": "missing runtime after reservation"}),
             trust_decision_with_dispatch_authority(),
         ))
@@ -5121,11 +5094,9 @@ async fn process_obligation_lifecycle_cleans_record_started_before_wrapper_exist
     );
     let invocation_id = InvocationId::new();
     let scope = sample_scope(invocation_id);
-    let estimate = ResourceEstimate {
-        process_count: Some(1),
-        concurrency_slots: Some(1),
-        ..ResourceEstimate::default()
-    };
+    let estimate = ResourceEstimate::default()
+        .set_process_count(1)
+        .set_concurrency_slots(1);
     governor
         .reserve_with_id(scope.clone(), estimate.clone(), reservation_id)
         .unwrap();
@@ -5284,11 +5255,9 @@ async fn process_obligation_lifecycle_does_not_clean_handoffs_twice_after_backgr
     let invocation_id = InvocationId::new();
     let scope = sample_scope(invocation_id);
     let process_id = ProcessId::new();
-    let estimate = ResourceEstimate {
-        process_count: Some(1),
-        concurrency_slots: Some(1),
-        ..ResourceEstimate::default()
-    };
+    let estimate = ResourceEstimate::default()
+        .set_process_count(1)
+        .set_concurrency_slots(1);
     governor
         .reserve_with_id(scope.clone(), estimate.clone(), reservation_id)
         .unwrap();

--- a/crates/ironclaw_host_runtime/tests/reborn_e2e_gate.rs
+++ b/crates/ironclaw_host_runtime/tests/reborn_e2e_gate.rs
@@ -116,10 +116,7 @@ async fn reborn_e2e_gate_invokes_script_through_host_runtime_with_status_events_
         .invoke_capability(RuntimeCapabilityRequest::new(
             context,
             script_capability_id(),
-            ResourceEstimate {
-                output_bytes: Some(4096),
-                ..ResourceEstimate::default()
-            },
+            ResourceEstimate::default().set_output_bytes(4096),
             input.clone(),
             trust_decision_with_dispatch_authority(),
         ))

--- a/crates/ironclaw_host_runtime/tests/reborn_invoke_vertical_slice.rs
+++ b/crates/ironclaw_host_runtime/tests/reborn_invoke_vertical_slice.rs
@@ -60,10 +60,7 @@ async fn default_host_runtime_invokes_through_runtime_dispatcher_with_resources_
     });
     let scope = context.resource_scope.clone();
     let invocation_id = context.invocation_id;
-    let estimate = ResourceEstimate {
-        output_bytes: Some(4_096),
-        ..ResourceEstimate::default()
-    };
+    let estimate = ResourceEstimate::default().set_output_bytes(4_096);
     let input = json!({"message":"through host runtime"});
 
     let outcome = runtime
@@ -217,10 +214,8 @@ impl RuntimeAdapter<LocalFilesystem, InMemoryResourceGovernor> for RecordingRunt
             input: request.input.clone(),
         });
         let output = self.output.clone();
-        let usage = ResourceUsage {
-            output_bytes: serde_json::to_vec(&output).unwrap().len() as u64,
-            ..ResourceUsage::default()
-        };
+        let usage = ResourceUsage::default()
+            .set_output_bytes(serde_json::to_vec(&output).unwrap().len() as u64);
         let reservation = match request.resource_reservation {
             Some(reservation) => reservation,
             None => request

--- a/crates/ironclaw_host_runtime/tests/support/host_runtime_harness.rs
+++ b/crates/ironclaw_host_runtime/tests/support/host_runtime_harness.rs
@@ -1092,11 +1092,9 @@ where
     let scope = sample_scope(invocation_id);
     let context =
         execution_context_with_dispatch_grant_for_scope(script_capability_id(), scope.clone());
-    let estimate = ResourceEstimate {
-        process_count: Some(1),
-        concurrency_slots: Some(1),
-        ..ResourceEstimate::default()
-    };
+    let estimate = ResourceEstimate::default()
+        .set_process_count(1)
+        .set_concurrency_slots(1);
     secret_store
         .put(
             scope.clone(),
@@ -1999,11 +1997,9 @@ pub(crate) fn process_sandbox_runtime_request_for_scope(
 }
 
 pub(crate) fn process_sandbox_estimate() -> ResourceEstimate {
-    ResourceEstimate {
-        process_count: Some(1),
-        concurrency_slots: Some(1),
-        ..ResourceEstimate::default()
-    }
+    ResourceEstimate::default()
+        .set_process_count(1)
+        .set_concurrency_slots(1)
 }
 
 pub(crate) fn process_sandbox_input() -> serde_json::Value {
@@ -2158,12 +2154,10 @@ pub(crate) fn governor_with_default_limit(account: ResourceAccount) -> InMemoryR
     governor
         .set_limit(
             account,
-            ResourceLimits {
-                max_concurrency_slots: Some(10),
-                max_network_egress_bytes: Some(10_000),
-                max_output_bytes: Some(100_000),
-                ..ResourceLimits::default()
-            },
+            ResourceLimits::default()
+                .set_max_concurrency_slots(10)
+                .set_max_network_egress_bytes(10_000)
+                .set_max_output_bytes(100_000),
         )
         .unwrap();
     governor
@@ -2193,12 +2187,10 @@ pub(crate) fn wasm_runtime_request_for_scope(
 }
 
 pub(crate) fn wasm_http_estimate() -> ResourceEstimate {
-    ResourceEstimate {
-        concurrency_slots: Some(1),
-        network_egress_bytes: Some(10),
-        output_bytes: Some(10_000),
-        ..ResourceEstimate::default()
-    }
+    ResourceEstimate::default()
+        .set_concurrency_slots(1)
+        .set_network_egress_bytes(10)
+        .set_output_bytes(10_000)
 }
 
 pub(crate) fn sample_account() -> ResourceAccount {


### PR DESCRIPTION
## Summary
- convert sparse ResourceEstimate, ResourceUsage, and ResourceLimits literals in ironclaw_host_runtime to ::default().set_*() chains
- simplify shared host runtime harness helpers and resource-oriented contract fixtures
- leave the dynamic optional network estimate and unrelated Docker option defaults as literals

## Stack
- Depends on #5791 (agent/default-backed-builders)

## Validation
- cargo fmt --check
- cargo test -p ironclaw_host_runtime --test builtin_obligation_handler_contract
- cargo test -p ironclaw_host_runtime --test first_party_runtime_contract
- cargo test -p ironclaw_host_runtime --test host_runtime_services_contract
- cargo test -p ironclaw_host_runtime --test extension_v2_lifecycle_e2e
- cargo test -p ironclaw_host_runtime --test github_wasm_runtime_contract
- cargo test -p ironclaw_host_runtime --test reborn_invoke_vertical_slice
- cargo test -p ironclaw_host_runtime --test reborn_e2e_gate

## Note
- cargo test -p ironclaw_host_runtime compiled and ran 295 unit tests, but the package run cannot pass in this environment because three existing sandbox_process unit tests unwrap a missing /var/run/docker.sock.