### PR TITLE
Use default setters in reborn composition fixtures

### DIFF
--- a/crates/ironclaw_reborn_composition/src/extension_lifecycle_capabilities.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_lifecycle_capabilities.rs
@@ -121,11 +121,9 @@ fn lifecycle_manifest(
         required_host_ports: Vec::new(),
         runtime_credentials: Vec::new(),
         resource_profile: Some(ResourceProfile {
-            default_estimate: ResourceEstimate {
-                wall_clock_ms: Some(100),
-                output_bytes: Some(16 * 1024),
-                ..ResourceEstimate::default()
-            },
+            default_estimate: ResourceEstimate::default()
+                .set_wall_clock_ms(100)
+                .set_output_bytes(16 * 1024),
             hard_ceiling: None,
         }),
     })
@@ -331,10 +329,8 @@ fn without_model_visible_connection_chrome(
 }
 
 fn resource_usage(started: Instant) -> ResourceUsage {
-    ResourceUsage {
-        wall_clock_ms: started.elapsed().as_millis().try_into().unwrap_or(u64::MAX),
-        ..ResourceUsage::default()
-    }
+    ResourceUsage::default()
+        .set_wall_clock_ms(started.elapsed().as_millis().try_into().unwrap_or(u64::MAX))
 }
 
 fn credential_stage_error(error: CredentialStageError) -> FirstPartyCapabilityError {

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -4664,8 +4664,8 @@ mod tests {
         CapabilityGrant, CapabilityGrantId, CapabilityId, CapabilitySet, EffectKind,
         ExecutionContext, ExtensionId, GrantConstraints, InvocationId, MountAlias, MountGrant,
         MountPermissions, NetworkPolicy, NetworkScheme, NetworkTargetPattern, Principal,
-        ResourceEstimate, ResourceScope, RuntimeKind, ScopedPath, SecretHandle, TenantId,
-        TrustClass, UserId, VirtualPath,
+        ResourceEstimate, ResourceScope, ResourceUsage, RuntimeKind, ScopedPath, SecretHandle,
+        TenantId, TrustClass, UserId, VirtualPath,
     };
     #[cfg(any(feature = "libsql", feature = "postgres"))]
     use ironclaw_host_api::{

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -4664,8 +4664,8 @@ mod tests {
         CapabilityGrant, CapabilityGrantId, CapabilityId, CapabilitySet, EffectKind,
         ExecutionContext, ExtensionId, GrantConstraints, InvocationId, MountAlias, MountGrant,
         MountPermissions, NetworkPolicy, NetworkScheme, NetworkTargetPattern, Principal,
-        ResourceEstimate, ResourceScope, ResourceUsage, RuntimeKind, ScopedPath, SecretHandle,
-        TenantId, TrustClass, UserId, VirtualPath,
+        ResourceEstimate, ResourceScope, RuntimeKind, ScopedPath, SecretHandle, TenantId,
+        TrustClass, UserId, VirtualPath,
     };
     #[cfg(any(feature = "libsql", feature = "postgres"))]
     use ironclaw_host_api::{
@@ -4768,23 +4768,11 @@ mod tests {
 
         let reservation = local_runtime
             .resource_governor
-            .reserve(
-                scope,
-                ResourceEstimate {
-                    usd: Some(dec!(0.10)),
-                    ..ResourceEstimate::default()
-                },
-            )
+            .reserve(scope, ResourceEstimate::default().set_usd(dec!(0.10)))
             .expect("reservation");
         local_runtime
             .resource_governor
-            .reconcile(
-                reservation.id,
-                ResourceUsage {
-                    usd: dec!(0.10),
-                    ..ResourceUsage::default()
-                },
-            )
+            .reconcile(reservation.id, ResourceUsage::default().set_usd(dec!(0.10)))
             .expect("reconcile");
 
         assert_eq!(

--- a/crates/ironclaw_reborn_composition/src/projection/tests/turn_stream.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/tests/turn_stream.rs
@@ -227,10 +227,7 @@ async fn webui_event_stream_offers_always_for_typed_approval_gate() {
                 requested_by: Principal::Extension(ExtensionId::new("builtin").unwrap()),
                 action: Box::new(Action::Dispatch {
                     capability: capability.clone(),
-                    estimated_resources: ResourceEstimate {
-                        network_egress_bytes: Some(4096),
-                        ..ResourceEstimate::default()
-                    },
+                    estimated_resources: ResourceEstimate::default().set_network_egress_bytes(4096),
                 }),
                 invocation_fingerprint: None,
                 reason: "raw path /Users/firatsertgoz/.ssh/id_rsa and token sk-secret".to_string(),
@@ -489,10 +486,7 @@ async fn webui_event_stream_projects_spawn_approval_context() {
                 requested_by: Principal::Extension(ExtensionId::new("builtin").unwrap()),
                 action: Box::new(Action::SpawnCapability {
                     capability: CapabilityId::new("script.shell").unwrap(),
-                    estimated_resources: ResourceEstimate {
-                        process_count: Some(2),
-                        ..ResourceEstimate::default()
-                    },
+                    estimated_resources: ResourceEstimate::default().set_process_count(2),
                 }),
                 invocation_fingerprint: None,
                 reason: "raw spawn reason".to_string(),

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -6780,15 +6780,12 @@ output_schema_ref = "schemas/write.output.json"
             reply: "trigger invalid config".to_string(),
             requests: Arc::new(StdMutex::new(Vec::new())),
         });
-        let trigger_poller = TriggerPollerSettings {
-            enabled: true,
-            worker: ironclaw_triggers::TriggerPollerWorkerConfig {
-                poll_interval: Duration::ZERO,
-                ..Default::default()
-            },
-            ..Default::default()
-        }
-        .with_tenant_scoped_authorizer_for_test();
+        let trigger_poller = TriggerPollerSettings::enabled()
+            .with_worker_config(
+                ironclaw_triggers::TriggerPollerWorkerConfig::default()
+                    .set_poll_interval(Duration::ZERO),
+            )
+            .with_tenant_scoped_authorizer_for_test();
 
         let input = RebornRuntimeInput::from_services(
             RebornBuildInput::local_dev(

--- a/crates/ironclaw_reborn_composition/src/runtime/tests/auth_interaction.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/tests/auth_interaction.rs
@@ -169,11 +169,11 @@ async fn build_runtime(
                 source_binding_id: format!("{owner}-source"),
                 reply_target_binding_id: format!("{owner}-reply"),
             })
-            .with_runner_settings(TurnRunnerSettings {
-                heartbeat_interval: Duration::from_secs(60),
-                poll_interval: Duration::from_secs(60),
-                ..TurnRunnerSettings::default()
-            })
+            .with_runner_settings(
+                TurnRunnerSettings::default()
+                    .set_heartbeat_interval(Duration::from_secs(60))
+                    .set_poll_interval(Duration::from_secs(60)),
+            )
             .with_model_gateway_override(Arc::new(UnusedModelGateway)),
     )
     .await

--- a/crates/ironclaw_reborn_composition/src/runtime_input.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime_input.rs
@@ -231,6 +231,31 @@ impl Default for TurnRunnerSettings {
     }
 }
 
+impl TurnRunnerSettings {
+    pub fn set_heartbeat_interval(mut self, heartbeat_interval: Duration) -> Self {
+        self.heartbeat_interval = heartbeat_interval;
+        self
+    }
+
+    pub fn set_poll_interval(mut self, poll_interval: Duration) -> Self {
+        self.poll_interval = poll_interval;
+        self
+    }
+
+    pub fn set_worker_count(mut self, worker_count: std::num::NonZeroUsize) -> Self {
+        self.worker_count = Some(worker_count);
+        self
+    }
+
+    pub fn set_max_concurrent_runs_per_user(
+        mut self,
+        max_concurrent_runs_per_user: std::num::NonZeroU32,
+    ) -> Self {
+        self.max_concurrent_runs_per_user = Some(max_concurrent_runs_per_user);
+        self
+    }
+}
+
 /// Completion polling policy for `RebornRuntime::send_user_message`.
 #[derive(Debug, Clone)]
 pub struct PollSettings {

--- a/crates/ironclaw_reborn_composition/src/runtime_input.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime_input.rs
@@ -242,16 +242,19 @@ impl TurnRunnerSettings {
         self
     }
 
-    pub fn set_worker_count(mut self, worker_count: std::num::NonZeroUsize) -> Self {
-        self.worker_count = Some(worker_count);
+    pub fn set_worker_count(
+        mut self,
+        worker_count: impl Into<Option<std::num::NonZeroUsize>>,
+    ) -> Self {
+        self.worker_count = worker_count.into();
         self
     }
 
     pub fn set_max_concurrent_runs_per_user(
         mut self,
-        max_concurrent_runs_per_user: std::num::NonZeroU32,
+        max_concurrent_runs_per_user: impl Into<Option<std::num::NonZeroU32>>,
     ) -> Self {
-        self.max_concurrent_runs_per_user = Some(max_concurrent_runs_per_user);
+        self.max_concurrent_runs_per_user = max_concurrent_runs_per_user.into();
         self
     }
 }

--- a/crates/ironclaw_reborn_composition/src/slack_host_beta.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_host_beta.rs
@@ -4729,10 +4729,10 @@ mod tests {
                 .with_model_gateway_override(Arc::new(StaticGateway))
                 .with_trigger_poller_settings(
                     crate::TriggerPollerSettings::enabled_with_tenant_scoped_authorizer_for_test()
-                        .with_worker_config(TriggerPollerWorkerConfig {
-                            poll_interval: std::time::Duration::from_millis(20),
-                            ..TriggerPollerWorkerConfig::default()
-                        }),
+                        .with_worker_config(
+                            TriggerPollerWorkerConfig::default()
+                                .set_poll_interval(std::time::Duration::from_millis(20)),
+                        ),
                 ),
         )
         .await

--- a/crates/ironclaw_reborn_composition/src/trigger_poller_trusted_submit.rs
+++ b/crates/ironclaw_reborn_composition/src/trigger_poller_trusted_submit.rs
@@ -1412,10 +1412,7 @@ mod tests {
             }),
         );
         let worker = TriggerPollerWorker::new(
-            TriggerPollerWorkerConfig {
-                fires_per_tick: 1,
-                ..TriggerPollerWorkerConfig::default()
-            },
+            TriggerPollerWorkerConfig::default().set_fires_per_tick(1),
             TriggerPollerWorkerDeps {
                 repository: repo,
                 source_provider: Arc::new(ScheduleTriggerSourceProvider),
@@ -1476,10 +1473,7 @@ mod tests {
             }),
         );
         let worker = TriggerPollerWorker::new(
-            TriggerPollerWorkerConfig {
-                fires_per_tick: 1,
-                ..TriggerPollerWorkerConfig::default()
-            },
+            TriggerPollerWorkerConfig::default().set_fires_per_tick(1),
             TriggerPollerWorkerDeps {
                 repository: repo,
                 source_provider: Arc::new(ScheduleTriggerSourceProvider),
@@ -1552,10 +1546,7 @@ mod tests {
             }),
         );
         let worker = TriggerPollerWorker::new(
-            TriggerPollerWorkerConfig {
-                fires_per_tick: 1,
-                ..TriggerPollerWorkerConfig::default()
-            },
+            TriggerPollerWorkerConfig::default().set_fires_per_tick(1),
             TriggerPollerWorkerDeps {
                 repository: repo,
                 source_provider: Arc::new(ScheduleTriggerSourceProvider),
@@ -1721,10 +1712,7 @@ mod tests {
             Arc::new(RecordingTurnCoordinator { run_id }),
         );
         let worker = TriggerPollerWorker::new(
-            TriggerPollerWorkerConfig {
-                fires_per_tick: 1,
-                ..TriggerPollerWorkerConfig::default()
-            },
+            TriggerPollerWorkerConfig::default().set_fires_per_tick(1),
             TriggerPollerWorkerDeps {
                 repository: repo.clone(),
                 source_provider: Arc::new(ScheduleTriggerSourceProvider),
@@ -2003,10 +1991,7 @@ mod tests {
             captured: captured.clone(),
         });
         let worker = TriggerPollerWorker::new(
-            TriggerPollerWorkerConfig {
-                fires_per_tick: 1,
-                ..TriggerPollerWorkerConfig::default()
-            },
+            TriggerPollerWorkerConfig::default().set_fires_per_tick(1),
             TriggerPollerWorkerDeps {
                 repository: repo,
                 source_provider: Arc::new(ScheduleTriggerSourceProvider),

--- a/crates/ironclaw_reborn_composition/tests/budget_approval_e2e.rs
+++ b/crates/ironclaw_reborn_composition/tests/budget_approval_e2e.rs
@@ -151,15 +151,13 @@ async fn build_runtime_with_pause_inducing_setup(
     governor
         .set_limit(
             user_account,
-            ResourceLimits {
-                max_usd: Some(dec!(10.00)),
-                period: BudgetPeriod::Rolling24h,
-                thresholds: BudgetThresholds {
+            ResourceLimits::default()
+                .set_max_usd(dec!(10.00))
+                .set_period(BudgetPeriod::Rolling24h)
+                .set_thresholds(BudgetThresholds {
                     warn_at: 0.2,
                     pause_at: 0.5,
-                },
-                ..ResourceLimits::default()
-            },
+                }),
         )
         .unwrap();
     (runtime, gateway)
@@ -218,12 +216,10 @@ async fn f3_approval_with_increased_limit_unblocks_retry() {
     // succeeds.
     let store = runtime.budget_gate_store().expect("gate store");
     let approver = ironclaw_host_api::UserId::new("f3-approver").unwrap();
-    let increased = ResourceLimits {
-        max_usd: Some(dec!(1_000.00)),
-        period: BudgetPeriod::Rolling24h,
-        thresholds: BudgetThresholds::DISABLED,
-        ..ResourceLimits::default()
-    };
+    let increased = ResourceLimits::default()
+        .set_max_usd(dec!(1_000.00))
+        .set_period(BudgetPeriod::Rolling24h)
+        .set_thresholds(BudgetThresholds::DISABLED);
     let resolved = store
         .resolve(
             &gate_scope,

--- a/crates/ironclaw_reborn_composition/tests/budget_e2e.rs
+++ b/crates/ironclaw_reborn_composition/tests/budget_e2e.rs
@@ -222,15 +222,13 @@ async fn f2_crossing_warn_threshold_emits_warned_event() {
     governor
         .set_limit(
             user_account.clone(),
-            ResourceLimits {
-                max_usd: Some(dec!(10.00)),
-                period: BudgetPeriod::Rolling24h,
-                thresholds: BudgetThresholds {
+            ResourceLimits::default()
+                .set_max_usd(dec!(10.00))
+                .set_period(BudgetPeriod::Rolling24h)
+                .set_thresholds(BudgetThresholds {
                     warn_at: 0.5,
                     pause_at: 0.95,
-                },
-                ..ResourceLimits::default()
-            },
+                }),
         )
         .unwrap();
 
@@ -296,10 +294,7 @@ async fn f6_hard_cap_denied_before_provider_call() {
     governor
         .set_limit(
             user_account.clone(),
-            ResourceLimits {
-                max_usd: Some(dec!(0.000001)),
-                ..ResourceLimits::default()
-            },
+            ResourceLimits::default().set_max_usd(dec!(0.000001)),
         )
         .unwrap();
     let sink = runtime.budget_event_sink().expect("sink");
@@ -358,12 +353,10 @@ async fn c1_provider_tokens_reconcile_to_actual_usd() {
     governor
         .set_limit(
             user_account,
-            ResourceLimits {
-                max_usd: Some(dec!(1_000.00)),
-                period: BudgetPeriod::Rolling24h,
-                thresholds: BudgetThresholds::DISABLED,
-                ..ResourceLimits::default()
-            },
+            ResourceLimits::default()
+                .set_max_usd(dec!(1_000.00))
+                .set_period(BudgetPeriod::Rolling24h)
+                .set_thresholds(BudgetThresholds::DISABLED),
         )
         .unwrap();
 
@@ -590,26 +583,22 @@ async fn d1_agent_deny_preserves_user_warn_event() {
     governor
         .set_limit(
             ResourceAccount::user(tenant.clone(), user_id.clone()),
-            ResourceLimits {
-                max_usd: Some(dec!(10.00)),
-                period: BudgetPeriod::Rolling24h,
-                thresholds: BudgetThresholds {
+            ResourceLimits::default()
+                .set_max_usd(dec!(10.00))
+                .set_period(BudgetPeriod::Rolling24h)
+                .set_thresholds(BudgetThresholds {
                     warn_at: 0.5,
                     pause_at: 0.95,
-                },
-                ..ResourceLimits::default()
-            },
+                }),
         )
         .unwrap();
     // Agent cap tight enough that the same estimate hard-denies.
     governor
         .set_limit(
             ResourceAccount::agent(tenant.clone(), user_id.clone(), None, agent_id.clone()),
-            ResourceLimits {
-                max_usd: Some(dec!(0.50)),
-                period: BudgetPeriod::Rolling24h,
-                ..ResourceLimits::default()
-            },
+            ResourceLimits::default()
+                .set_max_usd(dec!(0.50))
+                .set_period(BudgetPeriod::Rolling24h),
         )
         .unwrap();
     let sink = runtime.budget_event_sink().expect("sink");
@@ -755,12 +744,10 @@ async fn budget_test_gateway_scripted_replies_drive_per_turn_costs() {
     governor
         .set_limit(
             user_account,
-            ResourceLimits {
-                max_usd: Some(dec!(1_000.00)),
-                period: BudgetPeriod::Rolling24h,
-                thresholds: BudgetThresholds::DISABLED,
-                ..ResourceLimits::default()
-            },
+            ResourceLimits::default()
+                .set_max_usd(dec!(1_000.00))
+                .set_period(BudgetPeriod::Rolling24h)
+                .set_thresholds(BudgetThresholds::DISABLED),
         )
         .unwrap();
 

--- a/crates/ironclaw_reborn_composition/tests/runtime.rs
+++ b/crates/ironclaw_reborn_composition/tests/runtime.rs
@@ -507,7 +507,7 @@ async fn build_reborn_runtime_wires_per_user_cap_from_turn_runner_settings() {
     .with_runner_settings(
         TurnRunnerSettings::default()
             // Cap = 1 per user. Verifies this value flows from settings → store limits.
-            .set_max_concurrent_runs_per_user(NonZeroU32::new(1).unwrap())
+            .set_max_concurrent_runs_per_user(NonZeroU32::new(1))
             .set_heartbeat_interval(Duration::from_millis(25))
             .set_poll_interval(Duration::from_millis(10)),
     );
@@ -582,7 +582,7 @@ async fn multi_worker_runtime_does_not_raise_worker_stopped_while_workers_are_al
         TurnRunnerSettings::default()
             // Explicitly set 2 workers — ensures the guard uses .all() semantics
             // and does not fire when only a subset of workers have finished.
-            .set_worker_count(NonZeroUsize::new(2).unwrap())
+            .set_worker_count(NonZeroUsize::new(2))
             .set_heartbeat_interval(Duration::from_millis(25))
             .set_poll_interval(Duration::from_secs(60)),
     );

--- a/crates/ironclaw_reborn_composition/tests/runtime.rs
+++ b/crates/ironclaw_reborn_composition/tests/runtime.rs
@@ -19,10 +19,13 @@ use ironclaw_product_workflow::{
     ResolveApprovalInteractionRequest,
 };
 use ironclaw_reborn_composition::{
-    HooksActivationConfig, PollSettings, RebornBuildInput, RebornCompositionProfile,
-    RebornRuntimeError, RebornRuntimeIdentity, RebornRuntimeInput, RebornSkillSourceKind,
-    RebornTurnDriveOutcome, TurnRunnerSettings, build_reborn_runtime,
-    local_runtime_build_input_with_options,
+    HooksActivationConfig, PollSettings, RebornBuildInput, RebornRuntimeError,
+    RebornRuntimeIdentity, RebornRuntimeInput, RebornSkillSourceKind, RebornTurnDriveOutcome,
+    TurnRunnerSettings, build_reborn_runtime,
+};
+#[cfg(feature = "libsql")]
+use ironclaw_reborn_composition::{
+    RebornCompositionProfile, local_runtime_build_input_with_options,
 };
 use ironclaw_turns::run_profile::{
     LoopCapabilityPort, ProviderToolCall, RegisterProviderToolCallRequest,
@@ -140,11 +143,11 @@ async fn hosted_single_tenant_volume_builds_live_runtime() {
         source_binding_id: "runtime-hosted-volume-source".to_string(),
         reply_target_binding_id: "runtime-hosted-volume-reply".to_string(),
     })
-    .with_runner_settings(TurnRunnerSettings {
-        heartbeat_interval: Duration::from_secs(60),
-        poll_interval: Duration::from_secs(60),
-        ..TurnRunnerSettings::default()
-    });
+    .with_runner_settings(
+        TurnRunnerSettings::default()
+            .set_heartbeat_interval(Duration::from_secs(60))
+            .set_poll_interval(Duration::from_secs(60)),
+    );
 
     let runtime = build_reborn_runtime(input).await.unwrap();
     assert_eq!(runtime.default_run_profile_id(), "reborn-planned-default");
@@ -166,11 +169,11 @@ async fn stub_gateway_send_cancels_recovery_required_and_releases_conversation()
         source_binding_id: "runtime-test-source".to_string(),
         reply_target_binding_id: "runtime-test-reply".to_string(),
     })
-    .with_runner_settings(TurnRunnerSettings {
-        heartbeat_interval: Duration::from_secs(60),
-        poll_interval: Duration::from_secs(60),
-        ..TurnRunnerSettings::default()
-    });
+    .with_runner_settings(
+        TurnRunnerSettings::default()
+            .set_heartbeat_interval(Duration::from_secs(60))
+            .set_poll_interval(Duration::from_secs(60)),
+    );
 
     let runtime = build_reborn_runtime(input).await.unwrap();
     assert_eq!(runtime.default_run_profile_id(), "reborn-planned-default");
@@ -224,11 +227,11 @@ async fn send_user_message_with_cancellation_cancels_submitted_run() {
         source_binding_id: "runtime-cancel-source".to_string(),
         reply_target_binding_id: "runtime-cancel-reply".to_string(),
     })
-    .with_runner_settings(TurnRunnerSettings {
-        heartbeat_interval: Duration::from_secs(60),
-        poll_interval: Duration::from_secs(60),
-        ..TurnRunnerSettings::default()
-    })
+    .with_runner_settings(
+        TurnRunnerSettings::default()
+            .set_heartbeat_interval(Duration::from_secs(60))
+            .set_poll_interval(Duration::from_secs(60)),
+    )
     .with_poll_settings(PollSettings {
         interval: Duration::from_secs(60),
         max_total: Duration::from_secs(180),
@@ -381,11 +384,11 @@ async fn build_reborn_runtime_wires_third_party_hooks_when_enabled() {
         reply_target_binding_id: "runtime-hooks-reply".to_string(),
     })
     .with_hooks_config(HooksActivationConfig::enabled().with_third_party_enabled(true))
-    .with_runner_settings(TurnRunnerSettings {
-        heartbeat_interval: Duration::from_millis(25),
-        poll_interval: Duration::from_secs(60),
-        ..TurnRunnerSettings::default()
-    });
+    .with_runner_settings(
+        TurnRunnerSettings::default()
+            .set_heartbeat_interval(Duration::from_millis(25))
+            .set_poll_interval(Duration::from_secs(60)),
+    );
 
     // Build succeeds: the third-party discovery + projection + dispatcher factory
     // composed into the planned runtime without error.
@@ -501,13 +504,13 @@ async fn build_reborn_runtime_wires_per_user_cap_from_turn_runner_settings() {
         source_binding_id: "cap-wiring-source".to_string(),
         reply_target_binding_id: "cap-wiring-reply".to_string(),
     })
-    .with_runner_settings(TurnRunnerSettings {
-        // Cap = 1 per user. Verifies this value flows from settings → store limits.
-        max_concurrent_runs_per_user: NonZeroU32::new(1),
-        heartbeat_interval: Duration::from_millis(25),
-        poll_interval: Duration::from_millis(10),
-        ..TurnRunnerSettings::default()
-    });
+    .with_runner_settings(
+        TurnRunnerSettings::default()
+            // Cap = 1 per user. Verifies this value flows from settings → store limits.
+            .set_max_concurrent_runs_per_user(NonZeroU32::new(1).unwrap())
+            .set_heartbeat_interval(Duration::from_millis(25))
+            .set_poll_interval(Duration::from_millis(10)),
+    );
 
     let runtime = build_reborn_runtime(input).await.unwrap();
 
@@ -575,14 +578,14 @@ async fn multi_worker_runtime_does_not_raise_worker_stopped_while_workers_are_al
         source_binding_id: "multi-worker-guard-source".to_string(),
         reply_target_binding_id: "multi-worker-guard-reply".to_string(),
     })
-    .with_runner_settings(TurnRunnerSettings {
-        // Explicitly set 2 workers — ensures the guard uses .all() semantics
-        // and does not fire when only a subset of workers have finished.
-        worker_count: Some(NonZeroUsize::new(2).unwrap()),
-        heartbeat_interval: Duration::from_millis(25),
-        poll_interval: Duration::from_secs(60),
-        ..TurnRunnerSettings::default()
-    });
+    .with_runner_settings(
+        TurnRunnerSettings::default()
+            // Explicitly set 2 workers — ensures the guard uses .all() semantics
+            // and does not fire when only a subset of workers have finished.
+            .set_worker_count(NonZeroUsize::new(2).unwrap())
+            .set_heartbeat_interval(Duration::from_millis(25))
+            .set_poll_interval(Duration::from_secs(60)),
+    );
 
     let runtime = build_reborn_runtime(input).await.unwrap();
     let conversation = runtime.new_conversation().await.unwrap();
@@ -623,11 +626,11 @@ async fn local_dev_test_support_interaction_service_accessors_build_real_service
         source_binding_id: "test-support-accessors-source".to_string(),
         reply_target_binding_id: "test-support-accessors-reply".to_string(),
     })
-    .with_runner_settings(TurnRunnerSettings {
-        heartbeat_interval: Duration::from_secs(60),
-        poll_interval: Duration::from_secs(60),
-        ..TurnRunnerSettings::default()
-    });
+    .with_runner_settings(
+        TurnRunnerSettings::default()
+            .set_heartbeat_interval(Duration::from_secs(60))
+            .set_poll_interval(Duration::from_secs(60)),
+    );
 
     let runtime = build_reborn_runtime(input).await.unwrap();
     let turn_coordinator = runtime

--- a/crates/ironclaw_reborn_composition/tests/trigger_poller_e2e.rs
+++ b/crates/ironclaw_reborn_composition/tests/trigger_poller_e2e.rs
@@ -547,10 +547,7 @@ async fn trigger_poller_drives_trusted_ingress_for_due_scheduled_trigger() {
         &root,
         Arc::clone(&recording_gateway),
         TriggerPollerSettings::enabled_with_tenant_scoped_authorizer_for_test().with_worker_config(
-            TriggerPollerWorkerConfig {
-                poll_interval: Duration::from_millis(20),
-                ..Default::default()
-            },
+            TriggerPollerWorkerConfig::default().set_poll_interval(Duration::from_millis(20)),
         ),
     )
     .await;
@@ -711,10 +708,7 @@ async fn builtin_trigger_create_pairs_creator_and_poller_submits_turn() {
         &root,
         Arc::clone(&recording_gateway),
         TriggerPollerSettings::enabled_with_tenant_scoped_authorizer_for_test().with_worker_config(
-            TriggerPollerWorkerConfig {
-                poll_interval: Duration::from_millis(20),
-                ..Default::default()
-            },
+            TriggerPollerWorkerConfig::default().set_poll_interval(Duration::from_millis(20)),
         ),
     )
     .await;
@@ -834,10 +828,7 @@ async fn builtin_created_recurring_trigger_fires_again_after_first_run_settles()
         &root,
         Arc::clone(&recording_gateway),
         TriggerPollerSettings::enabled_with_tenant_scoped_authorizer_for_test().with_worker_config(
-            TriggerPollerWorkerConfig {
-                poll_interval: Duration::from_millis(20),
-                ..Default::default()
-            },
+            TriggerPollerWorkerConfig::default().set_poll_interval(Duration::from_millis(20)),
         ),
     )
     .await;
@@ -960,10 +951,7 @@ async fn trigger_poller_does_not_fire_trigger_with_future_next_run_at() {
         &root,
         Arc::clone(&recording_gateway),
         TriggerPollerSettings::enabled_with_tenant_scoped_authorizer_for_test().with_worker_config(
-            TriggerPollerWorkerConfig {
-                poll_interval: Duration::from_millis(20),
-                ..Default::default()
-            },
+            TriggerPollerWorkerConfig::default().set_poll_interval(Duration::from_millis(20)),
         ),
     )
     .await;
@@ -1080,10 +1068,7 @@ async fn trigger_poller_does_not_submit_turn_for_unpaired_actor() {
         &root,
         Arc::clone(&recording_gateway),
         TriggerPollerSettings::enabled_with_tenant_scoped_authorizer_for_test().with_worker_config(
-            TriggerPollerWorkerConfig {
-                poll_interval: Duration::from_millis(20),
-                ..Default::default()
-            },
+            TriggerPollerWorkerConfig::default().set_poll_interval(Duration::from_millis(20)),
         ),
     )
     .await;
@@ -1191,10 +1176,7 @@ async fn trigger_poller_fires_recurring_trigger_and_leaves_it_scheduled() {
         &root,
         Arc::clone(&recording_gateway),
         TriggerPollerSettings::enabled_with_tenant_scoped_authorizer_for_test().with_worker_config(
-            TriggerPollerWorkerConfig {
-                poll_interval: Duration::from_millis(20),
-                ..Default::default()
-            },
+            TriggerPollerWorkerConfig::default().set_poll_interval(Duration::from_millis(20)),
         ),
     )
     .await;
@@ -1396,10 +1378,7 @@ async fn scheduled_trigger_denies_mutators_with_tool_disclosure(
         &root,
         Arc::clone(&gateway),
         TriggerPollerSettings::enabled_with_tenant_scoped_authorizer_for_test().with_worker_config(
-            TriggerPollerWorkerConfig {
-                poll_interval: Duration::from_millis(20),
-                ..Default::default()
-            },
+            TriggerPollerWorkerConfig::default().set_poll_interval(Duration::from_millis(20)),
         ),
         tool_disclosure,
     )

--- a/crates/ironclaw_reborn_composition/tests/trigger_webui_timeline_e2e.rs
+++ b/crates/ironclaw_reborn_composition/tests/trigger_webui_timeline_e2e.rs
@@ -146,10 +146,10 @@ async fn build_timeline_runtime(root: &tempfile::TempDir) -> RebornRuntime {
         })
         .with_trigger_poller_settings(
             TriggerPollerSettings::enabled_with_tenant_scoped_authorizer_for_test()
-                .with_worker_config(TriggerPollerWorkerConfig {
-                    poll_interval: Duration::from_millis(20),
-                    ..Default::default()
-                }),
+                .with_worker_config(
+                    TriggerPollerWorkerConfig::default()
+                        .set_poll_interval(Duration::from_millis(20)),
+                ),
         )
         .with_model_gateway_override(Arc::new(StaticGateway) as Arc<dyn HostManagedModelGateway>);
 


### PR DESCRIPTION
## Summary
- add default-backed setters for TurnRunnerSettings
- convert sparse Reborn composition resource, budget, runner, and trigger poller fixtures to ::default().set_*() chains
- leave dynamic optional OAuth egress estimates and unrelated DTO defaults as literals

## Stack
- Depends on #5792 (agent/default-builders-triggers), which depends on #5791

## Validation
- cargo fmt --check
- cargo test -p ironclaw_reborn_composition --lib
- cargo test -p ironclaw_reborn_composition --test runtime
- cargo test -p ironclaw_reborn_composition --test budget_e2e
- cargo test -p ironclaw_reborn_composition --test budget_approval_e2e
- cargo test -p ironclaw_reborn_composition --test trigger_poller_e2e
- cargo test -p ironclaw_reborn_composition --test trigger_webui_timeline_e2e
- cargo test -p ironclaw_reborn_composition --lib factory::tests::resource_governor_unlimited_fast_path_records_shadow_accounting_when_disabled (compile/filter check after import cleanup; 0 matched tests)

## Note
- The lib-test command passes but emits existing dead-code warnings in factory.rs that are unrelated to this change.