### PR TITLE
Use default setters in reborn CLI config fixtures

### DIFF
--- a/crates/ironclaw_reborn_cli/src/commands/serve.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/serve.rs
@@ -911,10 +911,7 @@ mod tests {
     #[test]
     fn webui_default_agent_uses_config_override() {
         let runtime_identity = RebornRuntimeIdentity::reborn_cli();
-        let identity = IdentitySection {
-            default_agent: Some("configured-agent".to_string()),
-            ..IdentitySection::default()
-        };
+        let identity = IdentitySection::default().set_default_agent("configured-agent");
 
         assert_eq!(
             resolve_webui_default_agent(Some(&identity), &runtime_identity),
@@ -935,10 +932,7 @@ mod tests {
 
     #[test]
     fn webui_runtime_owner_accepts_matching_config_owner() {
-        let identity = IdentitySection {
-            default_owner: Some("local-user".to_string()),
-            ..IdentitySection::default()
-        };
+        let identity = IdentitySection::default().set_default_owner("local-user");
 
         assert_eq!(
             resolve_webui_runtime_owner(Some(&identity), "local-user").unwrap(),
@@ -952,10 +946,7 @@ mod tests {
         // the bug class that silently made every thread invisible: the facade
         // writes under `owners/local-user` while the loop host reads under
         // `owners/reborn-cli`. Fail loud at startup instead.
-        let identity = IdentitySection {
-            default_owner: Some("reborn-cli".to_string()),
-            ..IdentitySection::default()
-        };
+        let identity = IdentitySection::default().set_default_owner("reborn-cli");
 
         let error = resolve_webui_runtime_owner(Some(&identity), "local-user")
             .expect_err("divergent owner must be rejected");

--- a/crates/ironclaw_reborn_cli/src/commands/serve_slack.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/serve_slack.rs
@@ -266,10 +266,7 @@ mod tests {
     fn slack_host_beta_runtime_config_is_disabled_unless_explicitly_enabled() {
         let _lock = env_lock();
         let _enabled = EnvGuard::remove(SLACK_ENABLED_ENV_VAR);
-        let section = ironclaw_reborn_config::SlackSection {
-            enabled: None,
-            ..Default::default()
-        };
+        let section = ironclaw_reborn_config::SlackSection::default();
 
         let resolved = resolve_slack_config_for_serve(
             Some(&section),
@@ -289,11 +286,9 @@ mod tests {
     fn slack_host_beta_runtime_config_rejects_legacy_fields_when_disabled() {
         let _lock = env_lock();
         let _enabled = EnvGuard::remove(SLACK_ENABLED_ENV_VAR);
-        let section = ironclaw_reborn_config::SlackSection {
-            enabled: Some(false),
-            installation_id: Some("install-alpha".to_string()),
-            ..Default::default()
-        };
+        let section = ironclaw_reborn_config::SlackSection::default()
+            .set_enabled(false)
+            .set_installation_id("install-alpha");
 
         let err = resolve_slack_config_for_serve(
             Some(&section),
@@ -313,10 +308,7 @@ mod tests {
     fn slack_host_beta_runtime_config_uses_webui_scope_when_enabled() {
         let _lock = env_lock();
         let _enabled = EnvGuard::remove(SLACK_ENABLED_ENV_VAR);
-        let section = ironclaw_reborn_config::SlackSection {
-            enabled: Some(true),
-            ..Default::default()
-        };
+        let section = ironclaw_reborn_config::SlackSection::default().set_enabled(true);
         let project_id = project_id("project");
 
         let resolved = resolve_slack_config_for_serve(
@@ -373,10 +365,7 @@ mod tests {
     fn slack_host_beta_runtime_config_env_enables_disabled_webui_section() {
         let _lock = env_lock();
         let _enabled = EnvGuard::set(SLACK_ENABLED_ENV_VAR, "1");
-        let section = ironclaw_reborn_config::SlackSection {
-            enabled: Some(false),
-            ..Default::default()
-        };
+        let section = ironclaw_reborn_config::SlackSection::default().set_enabled(false);
 
         let resolved = resolve_slack_config_for_serve(
             Some(&section),
@@ -397,10 +386,7 @@ mod tests {
     fn slack_host_beta_runtime_config_env_disable_is_webui_kill_switch() {
         let _lock = env_lock();
         let _enabled = EnvGuard::set(SLACK_ENABLED_ENV_VAR, "0");
-        let section = ironclaw_reborn_config::SlackSection {
-            enabled: Some(true),
-            ..Default::default()
-        };
+        let section = ironclaw_reborn_config::SlackSection::default().set_enabled(true);
 
         let resolved = resolve_slack_config_for_serve(
             Some(&section),
@@ -420,11 +406,9 @@ mod tests {
     fn slack_host_beta_runtime_config_env_disable_is_legacy_kill_switch() {
         let _lock = env_lock();
         let _enabled = EnvGuard::set(SLACK_ENABLED_ENV_VAR, "false");
-        let section = ironclaw_reborn_config::SlackSection {
-            enabled: Some(true),
-            installation_id: Some("install-alpha".to_string()),
-            ..Default::default()
-        };
+        let section = ironclaw_reborn_config::SlackSection::default()
+            .set_enabled(true)
+            .set_installation_id("install-alpha");
 
         let resolved = resolve_slack_config_for_serve(
             Some(&section),
@@ -547,21 +531,20 @@ mod tests {
         const BOT_ENV: &str = "IRONCLAW_TEST_SLACK_LEGACY_BOT_TOKEN";
         let _signing = EnvGuard::set(SIGNING_ENV, "legacy-signing-secret");
         let _bot = EnvGuard::set(BOT_ENV, "xoxb-legacy");
-        let section = ironclaw_reborn_config::SlackSection {
-            enabled: Some(true),
-            installation_id: Some("install-alpha".to_string()),
-            team_id: Some("T123".to_string()),
-            api_app_id: Some("A123".to_string()),
-            slack_user_id: Some("U123".to_string()),
-            user_id: Some("user:operator".to_string()),
-            shared_subject_user_id: Some("user:shared-slack".to_string()),
-            channel_routes: vec![ironclaw_reborn_config::SlackChannelRouteSection {
+        let section = ironclaw_reborn_config::SlackSection::default()
+            .set_enabled(true)
+            .set_installation_id("install-alpha")
+            .set_team_id("T123")
+            .set_api_app_id("A123")
+            .set_slack_user_id("U123")
+            .set_user_id("user:operator")
+            .set_shared_subject_user_id("user:shared-slack")
+            .set_channel_routes(vec![ironclaw_reborn_config::SlackChannelRouteSection {
                 channel_id: Some("CENG".to_string()),
                 subject_user_id: Some("user:eng-team-agent".to_string()),
-            }],
-            signing_secret_env: Some(SIGNING_ENV.to_string()),
-            bot_token_env: Some(BOT_ENV.to_string()),
-        };
+            }])
+            .set_signing_secret_env(SIGNING_ENV)
+            .set_bot_token_env(BOT_ENV);
 
         let resolved = resolve_slack_config_for_serve(
             Some(&section),
@@ -602,10 +585,7 @@ mod tests {
     fn slack_config_rejects_enabled_section_without_feature() {
         let _lock = env_lock();
         let _enabled = EnvGuard::remove(SLACK_ENABLED_ENV_VAR);
-        let section = ironclaw_reborn_config::SlackSection {
-            enabled: Some(true),
-            ..Default::default()
-        };
+        let section = ironclaw_reborn_config::SlackSection::default().set_enabled(true);
 
         let err = reject_enabled_slack_without_feature(Some(&section))
             .expect_err("enabled Slack should require feature");
@@ -636,10 +616,7 @@ mod tests {
     fn slack_enabled_env_false_kills_enabled_section_without_feature() {
         let _lock = env_lock();
         let _enabled = EnvGuard::set(SLACK_ENABLED_ENV_VAR, "false");
-        let section = ironclaw_reborn_config::SlackSection {
-            enabled: Some(true),
-            ..Default::default()
-        };
+        let section = ironclaw_reborn_config::SlackSection::default().set_enabled(true);
 
         reject_enabled_slack_without_feature(Some(&section))
             .expect("env-disabled Slack should be a no-op without the host-beta feature");

--- a/crates/ironclaw_reborn_cli/src/runtime/trigger_poller.rs
+++ b/crates/ironclaw_reborn_cli/src/runtime/trigger_poller.rs
@@ -216,14 +216,13 @@ mod tests {
         let _enabled = EnvGuard::clear("IRONCLAW_TRIGGER_POLLER_ENABLED");
         let _interval = EnvGuard::clear("IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS");
 
-        let section = TriggerPollerConfigSection {
-            enabled: Some(true),
-            poll_interval_secs: Some(15),
-            fires_per_tick: Some(50),
-            max_concurrent_fires_per_trigger: Some(1),
-            startup_jitter_max_secs: Some(3),
-            tick_jitter_max_secs: Some(7),
-        };
+        let section = TriggerPollerConfigSection::default()
+            .set_enabled(true)
+            .set_poll_interval_secs(15)
+            .set_fires_per_tick(50)
+            .set_max_concurrent_fires_per_trigger(1)
+            .set_startup_jitter_max_secs(3)
+            .set_tick_jitter_max_secs(7);
         let config = make_config_with_trigger_poller(section);
 
         let settings = trigger_poller_settings(Some(&config), RuntimeInputCaller::Run)
@@ -239,11 +238,9 @@ mod tests {
 
     #[test]
     fn trigger_poller_settings_max_concurrent_fires_greater_than_1_is_error() {
-        let section = TriggerPollerConfigSection {
-            enabled: Some(true),
-            max_concurrent_fires_per_trigger: Some(2),
-            ..Default::default()
-        };
+        let section = TriggerPollerConfigSection::default()
+            .set_enabled(true)
+            .set_max_concurrent_fires_per_trigger(2);
         let config = make_config_with_trigger_poller(section);
 
         let err = trigger_poller_settings(Some(&config), RuntimeInputCaller::Run)
@@ -257,11 +254,9 @@ mod tests {
 
     #[test]
     fn trigger_poller_settings_config_poll_interval_zero_is_error() {
-        let section = TriggerPollerConfigSection {
-            enabled: Some(true),
-            poll_interval_secs: Some(0),
-            ..Default::default()
-        };
+        let section = TriggerPollerConfigSection::default()
+            .set_enabled(true)
+            .set_poll_interval_secs(0);
         let config = make_config_with_trigger_poller(section);
 
         let err = trigger_poller_settings(Some(&config), RuntimeInputCaller::Run)
@@ -280,10 +275,7 @@ mod tests {
         let _interval = EnvGuard::clear("IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS");
         let _enabled = EnvGuard::set("IRONCLAW_TRIGGER_POLLER_ENABLED", "true");
 
-        let section = TriggerPollerConfigSection {
-            enabled: Some(false),
-            ..Default::default()
-        };
+        let section = TriggerPollerConfigSection::default().set_enabled(false);
         let config = make_config_with_trigger_poller(section);
 
         let settings = trigger_poller_settings(Some(&config), RuntimeInputCaller::Run)
@@ -301,10 +293,7 @@ mod tests {
         let _interval = EnvGuard::clear("IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS");
         let _enabled = EnvGuard::set("IRONCLAW_TRIGGER_POLLER_ENABLED", "false");
 
-        let section = TriggerPollerConfigSection {
-            enabled: Some(true),
-            ..Default::default()
-        };
+        let section = TriggerPollerConfigSection::default().set_enabled(true);
         let config = make_config_with_trigger_poller(section);
 
         let settings = trigger_poller_settings(Some(&config), RuntimeInputCaller::Run)
@@ -321,11 +310,9 @@ mod tests {
         let _enabled = EnvGuard::clear("IRONCLAW_TRIGGER_POLLER_ENABLED");
         let _interval = EnvGuard::set("IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS", "45");
 
-        let section = TriggerPollerConfigSection {
-            enabled: Some(true),
-            poll_interval_secs: Some(15),
-            ..Default::default()
-        };
+        let section = TriggerPollerConfigSection::default()
+            .set_enabled(true)
+            .set_poll_interval_secs(15);
         let config = make_config_with_trigger_poller(section);
 
         let settings = trigger_poller_settings(Some(&config), RuntimeInputCaller::Run)
@@ -387,11 +374,9 @@ mod tests {
 
     #[test]
     fn trigger_poller_settings_config_fires_per_tick_zero_is_error() {
-        let section = TriggerPollerConfigSection {
-            enabled: Some(true),
-            fires_per_tick: Some(0),
-            ..Default::default()
-        };
+        let section = TriggerPollerConfigSection::default()
+            .set_enabled(true)
+            .set_fires_per_tick(0);
         let config = make_config_with_trigger_poller(section);
 
         let err = trigger_poller_settings(Some(&config), RuntimeInputCaller::Run)
@@ -407,11 +392,9 @@ mod tests {
     fn trigger_poller_settings_config_poll_interval_above_cap_is_error() {
         // 86_400 secs = 1 day = far above the 3600s cap. Models the
         // common typo class of writing a millisecond value (e.g. 86_400_000).
-        let section = TriggerPollerConfigSection {
-            enabled: Some(true),
-            poll_interval_secs: Some(86_400),
-            ..Default::default()
-        };
+        let section = TriggerPollerConfigSection::default()
+            .set_enabled(true)
+            .set_poll_interval_secs(86_400);
         let config = make_config_with_trigger_poller(section);
 
         let err = trigger_poller_settings(Some(&config), RuntimeInputCaller::Run)
@@ -426,11 +409,9 @@ mod tests {
 
     #[test]
     fn trigger_poller_settings_config_fires_per_tick_above_cap_is_error() {
-        let section = TriggerPollerConfigSection {
-            enabled: Some(true),
-            fires_per_tick: Some(10_000),
-            ..Default::default()
-        };
+        let section = TriggerPollerConfigSection::default()
+            .set_enabled(true)
+            .set_fires_per_tick(10_000);
         let config = make_config_with_trigger_poller(section);
 
         let err = trigger_poller_settings(Some(&config), RuntimeInputCaller::Run)
@@ -445,11 +426,9 @@ mod tests {
 
     #[test]
     fn trigger_poller_settings_config_startup_jitter_above_cap_is_error() {
-        let section = TriggerPollerConfigSection {
-            enabled: Some(true),
-            startup_jitter_max_secs: Some(3601),
-            ..Default::default()
-        };
+        let section = TriggerPollerConfigSection::default()
+            .set_enabled(true)
+            .set_startup_jitter_max_secs(3601);
         let config = make_config_with_trigger_poller(section);
 
         let err = trigger_poller_settings(Some(&config), RuntimeInputCaller::Run)
@@ -463,11 +442,9 @@ mod tests {
 
     #[test]
     fn trigger_poller_settings_config_tick_jitter_above_cap_is_error() {
-        let section = TriggerPollerConfigSection {
-            enabled: Some(true),
-            tick_jitter_max_secs: Some(3601),
-            ..Default::default()
-        };
+        let section = TriggerPollerConfigSection::default()
+            .set_enabled(true)
+            .set_tick_jitter_max_secs(3601);
         let config = make_config_with_trigger_poller(section);
 
         let err = trigger_poller_settings(Some(&config), RuntimeInputCaller::Run)
@@ -518,11 +495,9 @@ mod tests {
         let _lock = lock_runtime_env();
         let _enabled = EnvGuard::clear("IRONCLAW_TRIGGER_POLLER_ENABLED");
         let _interval = EnvGuard::clear("IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS");
-        let section = TriggerPollerConfigSection {
-            enabled: Some(true),
-            poll_interval_secs: Some(3600),
-            ..Default::default()
-        };
+        let section = TriggerPollerConfigSection::default()
+            .set_enabled(true)
+            .set_poll_interval_secs(3600);
         let config = make_config_with_trigger_poller(section);
 
         let settings = trigger_poller_settings(Some(&config), RuntimeInputCaller::Run)
@@ -535,11 +510,9 @@ mod tests {
         let _lock = lock_runtime_env();
         let _enabled = EnvGuard::clear("IRONCLAW_TRIGGER_POLLER_ENABLED");
         let _interval = EnvGuard::clear("IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS");
-        let section = TriggerPollerConfigSection {
-            enabled: Some(true),
-            fires_per_tick: Some(1000),
-            ..Default::default()
-        };
+        let section = TriggerPollerConfigSection::default()
+            .set_enabled(true)
+            .set_fires_per_tick(1000);
         let config = make_config_with_trigger_poller(section);
 
         let settings = trigger_poller_settings(Some(&config), RuntimeInputCaller::Run)
@@ -552,12 +525,10 @@ mod tests {
         let _lock = lock_runtime_env();
         let _enabled = EnvGuard::clear("IRONCLAW_TRIGGER_POLLER_ENABLED");
         let _interval = EnvGuard::clear("IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS");
-        let section = TriggerPollerConfigSection {
-            enabled: Some(true),
-            startup_jitter_max_secs: Some(3600),
-            tick_jitter_max_secs: Some(3600),
-            ..Default::default()
-        };
+        let section = TriggerPollerConfigSection::default()
+            .set_enabled(true)
+            .set_startup_jitter_max_secs(3600)
+            .set_tick_jitter_max_secs(3600);
         let config = make_config_with_trigger_poller(section);
 
         let settings = trigger_poller_settings(Some(&config), RuntimeInputCaller::Run)
@@ -570,11 +541,9 @@ mod tests {
     fn trigger_poller_settings_max_concurrent_fires_zero_is_error() {
         // 0 has distinct semantic meaning in some systems (unlimited
         // concurrency); confirm the V1 guard rejects it explicitly.
-        let section = TriggerPollerConfigSection {
-            enabled: Some(true),
-            max_concurrent_fires_per_trigger: Some(0),
-            ..Default::default()
-        };
+        let section = TriggerPollerConfigSection::default()
+            .set_enabled(true)
+            .set_max_concurrent_fires_per_trigger(0);
         let config = make_config_with_trigger_poller(section);
 
         let err = trigger_poller_settings(Some(&config), RuntimeInputCaller::Run)
@@ -605,10 +574,7 @@ mod tests {
         let _enabled = EnvGuard::set("IRONCLAW_TRIGGER_POLLER_ENABLED", "0");
         let _interval = EnvGuard::clear("IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS");
 
-        let section = TriggerPollerConfigSection {
-            enabled: Some(true),
-            ..Default::default()
-        };
+        let section = TriggerPollerConfigSection::default().set_enabled(true);
         let config = make_config_with_trigger_poller(section);
 
         let settings = trigger_poller_settings(Some(&config), RuntimeInputCaller::Run)
@@ -653,10 +619,7 @@ mod tests {
         let _enabled = EnvGuard::set("IRONCLAW_TRIGGER_POLLER_ENABLED", "");
         let _interval = EnvGuard::clear("IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS");
 
-        let section = TriggerPollerConfigSection {
-            enabled: Some(true),
-            ..Default::default()
-        };
+        let section = TriggerPollerConfigSection::default().set_enabled(true);
         let config = make_config_with_trigger_poller(section);
 
         let err = trigger_poller_settings(Some(&config), RuntimeInputCaller::Run).expect_err(


### PR DESCRIPTION
## Summary
- convert sparse CLI IdentitySection, SlackSection, and TriggerPollerConfigSection fixtures to ::default().set_*() chains
- keep the dynamic trace policy literal unchanged because it carries optional values directly from CLI options

## Stack
- Depends on #5799 (agent/default-builders-reborn-config), which depends on #5791

## Validation
- cargo fmt --check
- cargo test -p ironclaw_reborn_cli