### PR TITLE
Use default setters in dispatcher resource tests

### DIFF
--- a/crates/ironclaw_dispatcher/tests/event_dispatch_contract.rs
+++ b/crates/ironclaw_dispatcher/tests/event_dispatch_contract.rs
@@ -30,11 +30,9 @@ async fn dispatcher_emits_events_for_wasm_and_script_success() {
         .dispatch_json(CapabilityDispatchRequest {
             capability_id: CapabilityId::new("echo-wasm.say").unwrap(),
             scope: sample_scope(),
-            estimate: ResourceEstimate {
-                concurrency_slots: Some(1),
-                output_bytes: Some(10_000),
-                ..ResourceEstimate::default()
-            },
+            estimate: ResourceEstimate::default()
+                .set_concurrency_slots(1)
+                .set_output_bytes(10_000),
             mounts: None,
             resource_reservation: None,
             input: json!({"message": "hello wasm"}),
@@ -46,12 +44,10 @@ async fn dispatcher_emits_events_for_wasm_and_script_success() {
         .dispatch_json(CapabilityDispatchRequest {
             capability_id: CapabilityId::new("echo-script.say").unwrap(),
             scope: sample_scope(),
-            estimate: ResourceEstimate {
-                concurrency_slots: Some(1),
-                process_count: Some(1),
-                output_bytes: Some(10_000),
-                ..ResourceEstimate::default()
-            },
+            estimate: ResourceEstimate::default()
+                .set_concurrency_slots(1)
+                .set_process_count(1)
+                .set_output_bytes(10_000),
             mounts: None,
             resource_reservation: None,
             input: json!({"message": "hello script"}),
@@ -104,11 +100,9 @@ async fn dispatcher_ignores_event_sink_failures_on_success() {
         .dispatch_json(CapabilityDispatchRequest {
             capability_id: CapabilityId::new("echo-wasm.say").unwrap(),
             scope: sample_scope(),
-            estimate: ResourceEstimate {
-                concurrency_slots: Some(1),
-                output_bytes: Some(10_000),
-                ..ResourceEstimate::default()
-            },
+            estimate: ResourceEstimate::default()
+                .set_concurrency_slots(1)
+                .set_output_bytes(10_000),
             mounts: None,
             resource_reservation: None,
             input: json!({"message": "event sink fails"}),
@@ -131,11 +125,9 @@ async fn dispatcher_preserves_original_error_when_failure_event_sink_fails() {
         .dispatch_json(CapabilityDispatchRequest {
             capability_id: CapabilityId::new("echo-script.say").unwrap(),
             scope: sample_scope(),
-            estimate: ResourceEstimate {
-                concurrency_slots: Some(1),
-                process_count: Some(1),
-                ..ResourceEstimate::default()
-            },
+            estimate: ResourceEstimate::default()
+                .set_concurrency_slots(1)
+                .set_process_count(1),
             mounts: None,
             resource_reservation: None,
             input: json!({"message": "missing backend"}),
@@ -161,11 +153,9 @@ async fn dispatcher_logs_release_failure_without_masking_dispatch_error() {
     let reservation = ResourceReservation {
         id: ResourceReservationId::new(),
         scope: scope.clone(),
-        estimate: ResourceEstimate {
-            concurrency_slots: Some(1),
-            process_count: Some(1),
-            ..ResourceEstimate::default()
-        },
+        estimate: ResourceEstimate::default()
+            .set_concurrency_slots(1)
+            .set_process_count(1),
     };
     let dispatcher = RuntimeDispatcher::new(&registry, &fs, &governor);
 
@@ -173,11 +163,9 @@ async fn dispatcher_logs_release_failure_without_masking_dispatch_error() {
         .dispatch_json(CapabilityDispatchRequest {
             capability_id: CapabilityId::new("echo-script.say").unwrap(),
             scope,
-            estimate: ResourceEstimate {
-                concurrency_slots: Some(1),
-                process_count: Some(1),
-                ..ResourceEstimate::default()
-            },
+            estimate: ResourceEstimate::default()
+                .set_concurrency_slots(1)
+                .set_process_count(1),
             mounts: None,
             resource_reservation: Some(reservation.clone()),
             input: json!({"message": "missing backend"}),
@@ -216,11 +204,9 @@ async fn dispatcher_emits_redacted_runtime_error_kind_for_adapter_failure() {
         .dispatch_json(CapabilityDispatchRequest {
             capability_id: CapabilityId::new("echo-script.say").unwrap(),
             scope: sample_scope(),
-            estimate: ResourceEstimate {
-                concurrency_slots: Some(1),
-                process_count: Some(1),
-                ..ResourceEstimate::default()
-            },
+            estimate: ResourceEstimate::default()
+                .set_concurrency_slots(1)
+                .set_process_count(1),
             mounts: None,
             resource_reservation: None,
             input: json!({"message": "adapter fails"}),
@@ -259,12 +245,10 @@ async fn dispatcher_emits_events_for_mcp_success() {
         .dispatch_json(CapabilityDispatchRequest {
             capability_id: CapabilityId::new("github-mcp.search").unwrap(),
             scope: sample_scope(),
-            estimate: ResourceEstimate {
-                concurrency_slots: Some(1),
-                process_count: Some(1),
-                output_bytes: Some(10_000),
-                ..ResourceEstimate::default()
-            },
+            estimate: ResourceEstimate::default()
+                .set_concurrency_slots(1)
+                .set_process_count(1)
+                .set_output_bytes(10_000),
             mounts: None,
             resource_reservation: None,
             input: json!({"query": "ironclaw"}),
@@ -299,11 +283,9 @@ async fn dispatcher_emits_failed_event_for_missing_backend_without_reserving() {
         .dispatch_json(CapabilityDispatchRequest {
             capability_id: CapabilityId::new("echo-script.say").unwrap(),
             scope,
-            estimate: ResourceEstimate {
-                concurrency_slots: Some(1),
-                process_count: Some(1),
-                ..ResourceEstimate::default()
-            },
+            estimate: ResourceEstimate::default()
+                .set_concurrency_slots(1)
+                .set_process_count(1),
             mounts: None,
             resource_reservation: None,
             input: json!({"message": "blocked"}),
@@ -426,11 +408,12 @@ fn adapter_result(
     estimate: ResourceEstimate,
     output: Value,
 ) -> Result<RuntimeAdapterResult, DispatchError> {
-    let usage = ResourceUsage {
-        output_bytes: serde_json::to_vec(&output).unwrap().len() as u64,
-        process_count: u32::from(matches!(runtime, RuntimeKind::Script | RuntimeKind::Mcp)),
-        ..ResourceUsage::default()
-    };
+    let usage = ResourceUsage::default()
+        .set_output_bytes(serde_json::to_vec(&output).unwrap().len() as u64)
+        .set_process_count(u32::from(matches!(
+            runtime,
+            RuntimeKind::Script | RuntimeKind::Mcp
+        )));
     let reservation = governor
         .reserve(scope, estimate)
         .map_err(|_| dispatch_error_for_runtime(runtime, RuntimeDispatchErrorKind::Resource))?;

--- a/crates/ironclaw_dispatcher/tests/runtime_dispatcher_integration.rs
+++ b/crates/ironclaw_dispatcher/tests/runtime_dispatcher_integration.rs
@@ -41,11 +41,9 @@ async fn runtime_dispatcher_routes_already_authorized_request_through_public_tra
     governor
         .set_limit(
             account.clone(),
-            ResourceLimits {
-                max_concurrency_slots: Some(1),
-                max_output_bytes: Some(10_000),
-                ..ResourceLimits::default()
-            },
+            ResourceLimits::default()
+                .set_max_concurrency_slots(1)
+                .set_max_output_bytes(10_000),
         )
         .unwrap();
 
@@ -62,11 +60,9 @@ async fn runtime_dispatcher_routes_already_authorized_request_through_public_tra
         .dispatch_json(CapabilityDispatchRequest {
             capability_id: CapabilityId::new("echo.say").unwrap(),
             scope: scope.clone(),
-            estimate: ResourceEstimate {
-                concurrency_slots: Some(1),
-                output_bytes: Some(10_000),
-                ..ResourceEstimate::default()
-            },
+            estimate: ResourceEstimate::default()
+                .set_concurrency_slots(1)
+                .set_output_bytes(10_000),
             mounts: Some(mounts.clone()),
             resource_reservation: None,
             input: json!({"message": "hello through public seam"}),
@@ -158,11 +154,9 @@ async fn runtime_dispatcher_fails_closed_for_missing_backend_before_reservation_
         .dispatch_json(CapabilityDispatchRequest {
             capability_id: CapabilityId::new("script.echo").unwrap(),
             scope,
-            estimate: ResourceEstimate {
-                concurrency_slots: Some(1),
-                process_count: Some(1),
-                ..ResourceEstimate::default()
-            },
+            estimate: ResourceEstimate::default()
+                .set_concurrency_slots(1)
+                .set_process_count(1),
             mounts: None,
             resource_reservation: None,
             input: json!({"message": "blocked"}),
@@ -255,14 +249,12 @@ impl RuntimeAdapter<LocalFilesystem, InMemoryResourceGovernor> for RecordingAdap
         });
 
         let output_bytes = serde_json::to_vec(&self.output).unwrap().len() as u64;
-        let usage = ResourceUsage {
-            output_bytes,
-            process_count: u32::from(matches!(
+        let usage = ResourceUsage::default()
+            .set_output_bytes(output_bytes)
+            .set_process_count(u32::from(matches!(
                 self.runtime,
                 RuntimeKind::Script | RuntimeKind::Mcp
-            )),
-            ..ResourceUsage::default()
-        };
+            )));
         let reservation = request
             .governor
             .reserve(request.scope, request.estimate)


### PR DESCRIPTION
## Summary
- convert sparse dispatcher ResourceEstimate, ResourceUsage, and ResourceLimits fixtures to ::default().set_*() chains
- keep the cleanup scoped to dispatcher test fixtures

## Stack
- Depends on #5791 (agent/default-backed-builders)

## Validation
- cargo fmt --check
- cargo test -p ironclaw_dispatcher