### PR TITLE
Use default setters in MCP resource fixtures

### DIFF
--- a/crates/ironclaw_mcp/src/lib.rs
+++ b/crates/ironclaw_mcp/src/lib.rs
@@ -529,10 +529,7 @@ where
             .await
             .map_err(mcp_client_http_error)?;
 
-        let usage = ResourceUsage {
-            network_egress_bytes: response.request_bytes,
-            ..ResourceUsage::default()
-        };
+        let usage = ResourceUsage::default().set_network_egress_bytes(response.request_bytes);
 
         if !(200..300).contains(&response.status) {
             if is_mcp_auth_response_status(response.status) {

--- a/crates/ironclaw_mcp/tests/mcp_adapter_contract.rs
+++ b/crates/ironclaw_mcp/tests/mcp_adapter_contract.rs
@@ -20,12 +20,10 @@ async fn mcp_runtime_reserves_calls_adapter_and_reconciles_success() {
     governor
         .set_limit(
             account.clone(),
-            ResourceLimits {
-                max_concurrency_slots: Some(1),
-                max_process_count: Some(1),
-                max_output_bytes: Some(10_000),
-                ..ResourceLimits::default()
-            },
+            ResourceLimits::default()
+                .set_max_concurrency_slots(1)
+                .set_max_process_count(1)
+                .set_max_output_bytes(10_000),
         )
         .unwrap();
 
@@ -36,12 +34,10 @@ async fn mcp_runtime_reserves_calls_adapter_and_reconciles_success() {
                 package: &package,
                 capability_id: &CapabilityId::new("github-mcp.search").unwrap(),
                 scope,
-                estimate: ResourceEstimate {
-                    concurrency_slots: Some(1),
-                    process_count: Some(1),
-                    output_bytes: Some(10_000),
-                    ..ResourceEstimate::default()
-                },
+                estimate: ResourceEstimate::default()
+                    .set_concurrency_slots(1)
+                    .set_process_count(1)
+                    .set_output_bytes(10_000),
                 resource_reservation: None,
                 invocation: McpInvocation {
                     input: json!({"query": "ironclaw"}),
@@ -1007,10 +1003,7 @@ async fn mcp_runtime_denies_budget_before_adapter_call() {
     governor
         .set_limit(
             account.clone(),
-            ResourceLimits {
-                max_output_bytes: Some(1),
-                ..ResourceLimits::default()
-            },
+            ResourceLimits::default().set_max_output_bytes(1),
         )
         .unwrap();
 
@@ -1021,10 +1014,7 @@ async fn mcp_runtime_denies_budget_before_adapter_call() {
                 package: &package,
                 capability_id: &CapabilityId::new("github-mcp.search").unwrap(),
                 scope,
-                estimate: ResourceEstimate {
-                    output_bytes: Some(10_000),
-                    ..ResourceEstimate::default()
-                },
+                estimate: ResourceEstimate::default().set_output_bytes(10_000),
                 resource_reservation: None,
                 invocation: McpInvocation { input: json!({}) },
             },
@@ -1053,10 +1043,7 @@ async fn mcp_runtime_releases_reservation_when_adapter_fails() {
                 package: &package,
                 capability_id: &CapabilityId::new("github-mcp.search").unwrap(),
                 scope,
-                estimate: ResourceEstimate {
-                    concurrency_slots: Some(1),
-                    ..ResourceEstimate::default()
-                },
+                estimate: ResourceEstimate::default().set_concurrency_slots(1),
                 resource_reservation: None,
                 invocation: McpInvocation { input: json!({}) },
             },
@@ -1084,10 +1071,7 @@ async fn mcp_runtime_preserves_adapter_error_when_release_cleanup_fails() {
                 package: &package,
                 capability_id: &CapabilityId::new("github-mcp.search").unwrap(),
                 scope: sample_scope(),
-                estimate: ResourceEstimate {
-                    concurrency_slots: Some(1),
-                    ..ResourceEstimate::default()
-                },
+                estimate: ResourceEstimate::default().set_concurrency_slots(1),
                 resource_reservation: None,
                 invocation: McpInvocation { input: json!({}) },
             },
@@ -1110,10 +1094,7 @@ async fn mcp_runtime_rejects_non_mcp_or_undeclared_capability_before_reserving()
     governor
         .set_limit(
             account.clone(),
-            ResourceLimits {
-                max_concurrency_slots: Some(0),
-                ..ResourceLimits::default()
-            },
+            ResourceLimits::default().set_max_concurrency_slots(0),
         )
         .unwrap();
 
@@ -1124,10 +1105,7 @@ async fn mcp_runtime_rejects_non_mcp_or_undeclared_capability_before_reserving()
                 package: &non_mcp,
                 capability_id: &CapabilityId::new("script.echo").unwrap(),
                 scope: scope.clone(),
-                estimate: ResourceEstimate {
-                    concurrency_slots: Some(1),
-                    ..ResourceEstimate::default()
-                },
+                estimate: ResourceEstimate::default().set_concurrency_slots(1),
                 resource_reservation: None,
                 invocation: McpInvocation { input: json!({}) },
             },
@@ -1149,10 +1127,7 @@ async fn mcp_runtime_rejects_non_mcp_or_undeclared_capability_before_reserving()
                 package: &mcp,
                 capability_id: &CapabilityId::new("github-mcp.missing").unwrap(),
                 scope,
-                estimate: ResourceEstimate {
-                    concurrency_slots: Some(1),
-                    ..ResourceEstimate::default()
-                },
+                estimate: ResourceEstimate::default().set_concurrency_slots(1),
                 resource_reservation: None,
                 invocation: McpInvocation { input: json!({}) },
             },
@@ -1190,11 +1165,9 @@ async fn mcp_runtime_enforces_output_limit_and_releases_reservation() {
                 package: &package,
                 capability_id: &CapabilityId::new("github-mcp.search").unwrap(),
                 scope,
-                estimate: ResourceEstimate {
-                    concurrency_slots: Some(1),
-                    output_bytes: Some(10_000),
-                    ..ResourceEstimate::default()
-                },
+                estimate: ResourceEstimate::default()
+                    .set_concurrency_slots(1)
+                    .set_output_bytes(10_000),
                 resource_reservation: None,
                 invocation: McpInvocation { input: json!({}) },
             },
@@ -1232,11 +1205,9 @@ async fn mcp_runtime_can_enforce_client_reported_output_size_without_serializing
                 package: &package,
                 capability_id: &CapabilityId::new("github-mcp.search").unwrap(),
                 scope,
-                estimate: ResourceEstimate {
-                    concurrency_slots: Some(1),
-                    output_bytes: Some(10_000),
-                    ..ResourceEstimate::default()
-                },
+                estimate: ResourceEstimate::default()
+                    .set_concurrency_slots(1)
+                    .set_output_bytes(10_000),
                 resource_reservation: None,
                 invocation: McpInvocation { input: json!({}) },
             },
@@ -1277,11 +1248,9 @@ async fn mcp_runtime_rejects_output_when_adapter_under_reports_size() {
                 package: &package,
                 capability_id: &CapabilityId::new("github-mcp.search").unwrap(),
                 scope,
-                estimate: ResourceEstimate {
-                    concurrency_slots: Some(1),
-                    output_bytes: Some(10_000),
-                    ..ResourceEstimate::default()
-                },
+                estimate: ResourceEstimate::default()
+                    .set_concurrency_slots(1)
+                    .set_output_bytes(10_000),
                 resource_reservation: None,
                 invocation: McpInvocation { input: json!({}) },
             },

--- a/crates/ironclaw_mcp/tests/mcp_dispatch_integration.rs
+++ b/crates/ironclaw_mcp/tests/mcp_dispatch_integration.rs
@@ -14,10 +14,7 @@ use serde_json::json;
 async fn mcp_lane_executes_manifest_transport_and_reconciles_resources() {
     let client = RecordingMcpClient::new(Ok(McpClientOutput {
         output: json!({"items":["issue-1"]}),
-        usage: ResourceUsage {
-            wall_clock_ms: 9,
-            ..ResourceUsage::default()
-        },
+        usage: ResourceUsage::default().set_wall_clock_ms(9),
         output_bytes: None,
     }));
     let runtime = McpRuntime::new(McpRuntimeConfig::for_testing(), client.clone());
@@ -195,12 +192,10 @@ fn governor_with_default_limit(account: ResourceAccount) -> InMemoryResourceGove
     governor
         .set_limit(
             account,
-            ResourceLimits {
-                max_concurrency_slots: Some(10),
-                max_process_count: Some(10),
-                max_output_bytes: Some(100_000),
-                ..ResourceLimits::default()
-            },
+            ResourceLimits::default()
+                .set_max_concurrency_slots(10)
+                .set_max_process_count(10)
+                .set_max_output_bytes(100_000),
         )
         .unwrap();
     governor
@@ -220,12 +215,10 @@ fn mcp_request_from_manifest(
         package,
         capability_id,
         scope: sample_scope(),
-        estimate: ResourceEstimate {
-            concurrency_slots: Some(1),
-            process_count: Some(1),
-            output_bytes: Some(10_000),
-            ..ResourceEstimate::default()
-        },
+        estimate: ResourceEstimate::default()
+            .set_concurrency_slots(1)
+            .set_process_count(1)
+            .set_output_bytes(10_000),
         resource_reservation: None,
         invocation: McpInvocation { input },
     }


### PR DESCRIPTION
## Summary
- convert sparse MCP ResourceEstimate, ResourceUsage, and ResourceLimits fixtures to ::default().set_*() chains
- simplify MCP adapter/integration resource setup while preserving explicit behavior assertions

## Stack
- Depends on #5791 (agent/default-backed-builders)

## Validation
- cargo fmt --check
- cargo test -p ironclaw_mcp