### PR TITLE
Use default setters in capability resource tests

### DIFF
--- a/crates/ironclaw_capabilities/tests/capability_host_contract.rs
+++ b/crates/ironclaw_capabilities/tests/capability_host_contract.rs
@@ -81,10 +81,7 @@ async fn capability_host_authorized_dispatch_uses_neutral_dispatch_port() {
         .invoke_json(CapabilityInvocationRequest {
             context,
             capability_id: capability_id(),
-            estimate: ResourceEstimate {
-                output_bytes: Some(4096),
-                ..ResourceEstimate::default()
-            },
+            estimate: ResourceEstimate::default().set_output_bytes(4096),
             input: json!({"message": "authorized"}),
             trust_decision: trust_decision(),
         })

--- a/crates/ironclaw_capabilities/tests/capability_host_dispatcher_integration.rs
+++ b/crates/ironclaw_capabilities/tests/capability_host_dispatcher_integration.rs
@@ -33,10 +33,7 @@ async fn capability_host_invokes_through_runtime_dispatcher_and_completes_run() 
     });
     let scope = context.resource_scope.clone();
     let invocation_id = context.invocation_id;
-    let estimate = ResourceEstimate {
-        output_bytes: Some(4_096),
-        ..ResourceEstimate::default()
-    };
+    let estimate = ResourceEstimate::default().set_output_bytes(4_096);
     let input = json!({"message":"authorized"});
 
     let result = host
@@ -100,10 +97,7 @@ async fn capability_host_blocks_then_resumes_approved_dispatch_through_runtime_d
     let context = execution_context(CapabilitySet::default());
     let scope = context.resource_scope.clone();
     let invocation_id = context.invocation_id;
-    let estimate = ResourceEstimate {
-        output_bytes: Some(1_024),
-        ..ResourceEstimate::default()
-    };
+    let estimate = ResourceEstimate::default().set_output_bytes(1_024);
     let input = json!({"message":"approved"});
 
     let err = block_host
@@ -179,10 +173,7 @@ async fn capability_host_blocks_then_resumes_approved_dispatch_through_runtime_d
             context,
             approval_request_id: approval_id,
             capability_id: capability_id(),
-            estimate: ResourceEstimate {
-                output_bytes: Some(1_024),
-                ..ResourceEstimate::default()
-            },
+            estimate: ResourceEstimate::default().set_output_bytes(1_024),
             input: json!({"message":"approved"}),
             trust_decision: trust_decision(),
         })
@@ -401,10 +392,8 @@ impl RuntimeAdapter<LocalFilesystem, InMemoryResourceGovernor> for RecordingRunt
             input: request.input.clone(),
         });
         let output = self.output.clone();
-        let usage = ResourceUsage {
-            output_bytes: serde_json::to_vec(&output).unwrap().len() as u64,
-            ..ResourceUsage::default()
-        };
+        let usage = ResourceUsage::default()
+            .set_output_bytes(serde_json::to_vec(&output).unwrap().len() as u64);
         let reservation = match request.resource_reservation {
             Some(reservation) => reservation,
             None => request

--- a/crates/ironclaw_capabilities/tests/capability_host_process_integration.rs
+++ b/crates/ironclaw_capabilities/tests/capability_host_process_integration.rs
@@ -41,11 +41,9 @@ async fn capability_host_spawn_runs_background_process_through_process_host() {
     let invocation_id = context.invocation_id;
     let mounts = context.mounts.clone();
     let grants = context.grants.clone();
-    let estimate = ResourceEstimate {
-        output_bytes: Some(2_048),
-        process_count: Some(1),
-        ..ResourceEstimate::default()
-    };
+    let estimate = ResourceEstimate::default()
+        .set_output_bytes(2_048)
+        .set_process_count(1);
     let input = json!({"message":"background"});
 
     let spawned = host

--- a/crates/ironclaw_capabilities/tests/capability_obligation_handler_contract.rs
+++ b/crates/ironclaw_capabilities/tests/capability_obligation_handler_contract.rs
@@ -90,10 +90,7 @@ async fn capability_host_passes_prepared_effects_to_dispatch() {
         "/projects/demo",
         MountPermissions::read_write(),
     );
-    let estimate = ResourceEstimate {
-        concurrency_slots: Some(1),
-        ..ResourceEstimate::default()
-    };
+    let estimate = ResourceEstimate::default().set_concurrency_slots(1);
     let scope = context.resource_scope.clone();
     let authorizer = ObligatingAuthorizer::new(vec![
         Obligation::UseScopedMounts {


### PR DESCRIPTION
## Summary
- Replace sparse ResourceEstimate and ResourceUsage fixtures in ironclaw_capabilities tests with default-backed setter chains.
- Keep capability request and descriptor structure unchanged.

## Stack
- Base: #5791

## Validation
- cargo fmt --check
- cargo test -p ironclaw_capabilities