### PR TITLE
Use default setters in wasm resource fixtures

### DIFF
--- a/crates/ironclaw_wasm/tests/wasm_dispatch_integration.rs
+++ b/crates/ironclaw_wasm/tests/wasm_dispatch_integration.rs
@@ -836,12 +836,10 @@ fn governor_with_default_limit(account: ResourceAccount) -> InMemoryResourceGove
     governor
         .set_limit(
             account,
-            ResourceLimits {
-                max_concurrency_slots: Some(10),
-                max_process_count: Some(10),
-                max_output_bytes: Some(100_000),
-                ..ResourceLimits::default()
-            },
+            ResourceLimits::default()
+                .set_max_concurrency_slots(10)
+                .set_max_process_count(10)
+                .set_max_output_bytes(100_000),
         )
         .unwrap();
     governor
@@ -851,12 +849,10 @@ fn dispatch_request(capability: &str, input: Value) -> CapabilityDispatchRequest
     CapabilityDispatchRequest {
         capability_id: CapabilityId::new(capability).unwrap(),
         scope: sample_scope(),
-        estimate: ResourceEstimate {
-            concurrency_slots: Some(1),
-            process_count: Some(1),
-            output_bytes: Some(10_000),
-            ..ResourceEstimate::default()
-        },
+        estimate: ResourceEstimate::default()
+            .set_concurrency_slots(1)
+            .set_process_count(1)
+            .set_output_bytes(10_000),
         mounts: None,
         resource_reservation: None,
         input,


### PR DESCRIPTION
## Summary
- Replace sparse ResourceLimits and ResourceEstimate fixtures in ironclaw_wasm dispatch integration helpers with default-backed setter chains.

## Stack
- Base: #5791

## Validation
- cargo fmt --check
- cargo test -p ironclaw_wasm