### PR TITLE
Use default setters in loop support resource fixtures

### DIFF
--- a/crates/ironclaw_loop_support/src/budget_accountant.rs
+++ b/crates/ironclaw_loop_support/src/budget_accountant.rs
@@ -808,10 +808,7 @@ mod tests {
         governor
             .set_limit(
                 account,
-                ResourceLimits {
-                    max_usd: Some(dec!(0.000001)),
-                    ..ResourceLimits::default()
-                },
+                ResourceLimits::default().set_max_usd(dec!(0.000001)),
             )
             .unwrap();
         let cost = ModelCost {
@@ -839,15 +836,13 @@ mod tests {
         governor
             .set_limit(
                 account,
-                ResourceLimits {
-                    max_usd: Some(dec!(10.00)),
-                    period: BudgetPeriod::Rolling24h,
-                    thresholds: BudgetThresholds {
+                ResourceLimits::default()
+                    .set_max_usd(dec!(10.00))
+                    .set_period(BudgetPeriod::Rolling24h)
+                    .set_thresholds(BudgetThresholds {
                         warn_at: 0.75,
                         pause_at: 0.90,
-                    },
-                    ..ResourceLimits::default()
-                },
+                    }),
             )
             .unwrap();
         let cost = ModelCost {
@@ -985,10 +980,7 @@ mod tests {
         governor
             .set_limit(
                 user_account.clone(),
-                ResourceLimits {
-                    max_usd: Some(dec!(100.00)),
-                    ..ResourceLimits::default()
-                },
+                ResourceLimits::default().set_max_usd(dec!(100.00)),
             )
             .unwrap();
 
@@ -1022,11 +1014,9 @@ mod tests {
         governor
             .set_limit(
                 user_account.clone(),
-                ResourceLimits {
-                    max_usd: Some(dec!(100.00)),
-                    period: BudgetPeriod::Rolling24h,
-                    ..ResourceLimits::default()
-                },
+                ResourceLimits::default()
+                    .set_max_usd(dec!(100.00))
+                    .set_period(BudgetPeriod::Rolling24h),
             )
             .unwrap();
         let cost = ModelCost {
@@ -1076,11 +1066,9 @@ mod tests {
         governor
             .set_limit(
                 user_account.clone(),
-                ResourceLimits {
-                    max_usd: Some(dec!(10_000.00)),
-                    period: BudgetPeriod::Rolling24h,
-                    ..ResourceLimits::default()
-                },
+                ResourceLimits::default()
+                    .set_max_usd(dec!(10_000.00))
+                    .set_period(BudgetPeriod::Rolling24h),
             )
             .unwrap();
         let cost = ModelCost {

--- a/crates/ironclaw_loop_support/src/budget_seeding.rs
+++ b/crates/ironclaw_loop_support/src/budget_seeding.rs
@@ -30,18 +30,14 @@ impl BudgetSeedingPolicy {
         period: BudgetPeriod,
         thresholds: BudgetThresholds,
     ) -> Self {
-        let user_daily = ResourceLimits {
-            max_usd: Some(user_daily_usd),
-            period: period.clone(),
-            thresholds,
-            ..ResourceLimits::default()
-        };
-        let project_daily = ResourceLimits {
-            max_usd: Some(project_daily_usd),
-            period,
-            thresholds,
-            ..ResourceLimits::default()
-        };
+        let user_daily = ResourceLimits::default()
+            .set_max_usd(user_daily_usd)
+            .set_period(period.clone())
+            .set_thresholds(thresholds);
+        let project_daily = ResourceLimits::default()
+            .set_max_usd(project_daily_usd)
+            .set_period(period)
+            .set_thresholds(thresholds);
         Self {
             user_daily,
             project_daily,

--- a/crates/ironclaw_loop_support/src/capability_port.rs
+++ b/crates/ironclaw_loop_support/src/capability_port.rs
@@ -8269,10 +8269,7 @@ mod tests {
                     capability_id: request.capability_id,
                     output: serde_json::json!({"ok": true}),
                     display_preview: None,
-                    usage: ResourceUsage {
-                        output_bytes: RECORDING_OUTPUT_BYTES,
-                        ..ResourceUsage::default()
-                    },
+                    usage: ResourceUsage::default().set_output_bytes(RECORDING_OUTPUT_BYTES),
                 },
             )))
         }
@@ -8372,10 +8369,7 @@ mod tests {
                     capability_id: request.capability_id,
                     output: serde_json::json!({"resumed": true}),
                     display_preview: None,
-                    usage: ResourceUsage {
-                        output_bytes: RECORDING_OUTPUT_BYTES,
-                        ..ResourceUsage::default()
-                    },
+                    usage: ResourceUsage::default().set_output_bytes(RECORDING_OUTPUT_BYTES),
                 },
             )))
         }


### PR DESCRIPTION
## Summary
- Replace sparse ResourceLimits and ResourceUsage default-tail fixtures in ironclaw_loop_support with default-backed setter chains.
- Convert BudgetSeedingPolicy limit construction to the same builder style.
- Leave the production ResourceEstimate cost builder and small SubagentSpawnLimits test literals explicit because setter conversion would not simplify them.

## Stack
- Base: #5791

## Validation
- cargo fmt --check
- cargo test -p ironclaw_loop_support