### PR TITLE
Use default setters in first party extension resources

### DIFF
--- a/crates/ironclaw_first_party_extensions/src/gsuite/handlers.rs
+++ b/crates/ironclaw_first_party_extensions/src/gsuite/handlers.rs
@@ -436,11 +436,9 @@ impl GsuiteExecutor {
                             .with_reason(GsuiteCredentialDispatchReason::AuthRequired {
                                 required_secrets: vec![refreshed.access_secret.clone()],
                             })
-                            .with_usage(ResourceUsage {
-                                network_egress_bytes: network_egress_bytes
-                                    .saturating_add(retry_network_egress_bytes),
-                                ..ResourceUsage::default()
-                            });
+                            .with_usage(ResourceUsage::default().set_network_egress_bytes(
+                                network_egress_bytes.saturating_add(retry_network_egress_bytes),
+                            ));
                         trace_gsuite_latency_error(
                             "execute_retry",
                             latency_fields.as_ref(),
@@ -512,12 +510,10 @@ impl GsuiteExecutor {
         let wall_clock_ms = started.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
         Ok(GsuiteDispatchResult {
             output,
-            usage: ResourceUsage {
-                wall_clock_ms,
-                output_bytes,
-                network_egress_bytes,
-                ..ResourceUsage::default()
-            },
+            usage: ResourceUsage::default()
+                .set_wall_clock_ms(wall_clock_ms)
+                .set_output_bytes(output_bytes)
+                .set_network_egress_bytes(network_egress_bytes),
         })
     }
 
@@ -1281,10 +1277,8 @@ fn map_egress_error(error: RuntimeHttpEgressError) -> GsuiteDispatchError {
             RuntimeDispatchErrorKind::OutputTooLarge
         }
     };
-    GsuiteDispatchError::new(kind).with_usage(ResourceUsage {
-        network_egress_bytes: error.request_bytes(),
-        ..ResourceUsage::default()
-    })
+    GsuiteDispatchError::new(kind)
+        .with_usage(ResourceUsage::default().set_network_egress_bytes(error.request_bytes()))
 }
 
 fn map_recovery_kind(recovery: &CredentialRecoveryProjection) -> RuntimeDispatchErrorKind {

--- a/crates/ironclaw_first_party_extensions/src/gsuite/manifest.rs
+++ b/crates/ironclaw_first_party_extensions/src/gsuite/manifest.rs
@@ -283,12 +283,10 @@ pub const fn gmail_package_spec() -> GsuitePackageSpec {
 
 pub fn gsuite_resource_profile() -> ResourceProfile {
     ResourceProfile {
-        default_estimate: ResourceEstimate {
-            wall_clock_ms: Some(u64::from(GSUITE_TIMEOUT_MS)),
-            output_bytes: Some(GSUITE_OUTPUT_BYTES_LIMIT),
-            network_egress_bytes: Some(DEFAULT_NETWORK_EGRESS_BYTES),
-            ..ResourceEstimate::default()
-        },
+        default_estimate: ResourceEstimate::default()
+            .set_wall_clock_ms(u64::from(GSUITE_TIMEOUT_MS))
+            .set_output_bytes(GSUITE_OUTPUT_BYTES_LIMIT)
+            .set_network_egress_bytes(DEFAULT_NETWORK_EGRESS_BYTES),
         hard_ceiling: Some(ResourceCeiling {
             max_usd: None,
             max_input_tokens: None,

--- a/crates/ironclaw_first_party_extensions/src/web_access.rs
+++ b/crates/ironclaw_first_party_extensions/src/web_access.rs
@@ -162,10 +162,7 @@ impl WebAccessDispatchError {
 
     /// Override the `network_egress_bytes` in the usage, preserving the error kind.
     fn with_accumulated_bytes(self, bytes: u64) -> Self {
-        self.with_usage(ResourceUsage {
-            network_egress_bytes: bytes,
-            ..ResourceUsage::default()
-        })
+        self.with_usage(ResourceUsage::default().set_network_egress_bytes(bytes))
     }
 
     pub fn kind(&self) -> RuntimeDispatchErrorKind {
@@ -349,11 +346,9 @@ impl WebAccessExecutor {
         let output_bytes = json_bytes(&output);
         Ok(WebAccessDispatchResult {
             output,
-            usage: ResourceUsage {
-                output_bytes,
-                network_egress_bytes: response_text.request_bytes,
-                ..ResourceUsage::default()
-            },
+            usage: ResourceUsage::default()
+                .set_output_bytes(output_bytes)
+                .set_network_egress_bytes(response_text.request_bytes),
         })
     }
 
@@ -431,11 +426,9 @@ impl WebAccessExecutor {
         let output_bytes = json_bytes(&output);
         Ok(WebAccessDispatchResult {
             output,
-            usage: ResourceUsage {
-                output_bytes,
-                network_egress_bytes: total_request_bytes,
-                ..ResourceUsage::default()
-            },
+            usage: ResourceUsage::default()
+                .set_output_bytes(output_bytes)
+                .set_network_egress_bytes(total_request_bytes),
         })
     }
 }
@@ -1260,10 +1253,8 @@ fn map_egress_error(error: RuntimeHttpEgressError) -> WebAccessDispatchError {
             RuntimeDispatchErrorKind::OutputTooLarge
         }
     };
-    WebAccessDispatchError::new(kind).with_usage(ResourceUsage {
-        network_egress_bytes: error.request_bytes(),
-        ..ResourceUsage::default()
-    })
+    WebAccessDispatchError::new(kind)
+        .with_usage(ResourceUsage::default().set_network_egress_bytes(error.request_bytes()))
 }
 
 fn input_error() -> WebAccessDispatchError {


### PR DESCRIPTION
## Summary
- Replace sparse ResourceEstimate and ResourceUsage construction in first-party extension resource paths with default-backed setter chains.
- Leave small private latency metric literals and explicit ResourceCeiling/SandboxQuota shape unchanged.

## Stack
- Base: #5791

## Validation
- cargo fmt --check
- cargo test -p ironclaw_first_party_extensions