### PR TITLE
Use default setters in turn state fixtures

### DIFF
--- a/crates/ironclaw_turns/src/filesystem_store/row_store/delta.rs
+++ b/crates/ironclaw_turns/src/filesystem_store/row_store/delta.rs
@@ -143,6 +143,24 @@ pub(super) struct SnapshotDelta {
 }
 
 impl SnapshotDelta {
+    pub(super) fn set_turns_upsert(mut self, turns_upsert: Vec<TurnRecord>) -> Self {
+        self.turns_upsert = turns_upsert;
+        self
+    }
+
+    pub(super) fn set_runs_upsert(mut self, runs_upsert: Vec<TurnRunRecord>) -> Self {
+        self.runs_upsert = runs_upsert;
+        self
+    }
+
+    pub(super) fn set_loop_checkpoints_upsert(
+        mut self,
+        loop_checkpoints_upsert: Vec<LoopCheckpointRecord>,
+    ) -> Self {
+        self.loop_checkpoints_upsert = loop_checkpoints_upsert;
+        self
+    }
+
     pub(super) fn is_empty(&self) -> bool {
         self.turns_upsert.is_empty()
             && self.turns_delete.is_empty()
@@ -507,11 +525,9 @@ pub(super) fn submit_turn_targeted_delta(
         .ok_or_else(|| TurnError::Unavailable {
             reason: "accepted run missing from row-store hot state".to_string(),
         })?;
-    let mut delta = SnapshotDelta {
-        turns_upsert: vec![turn.clone()],
-        runs_upsert: vec![run],
-        ..SnapshotDelta::default()
-    };
+    let mut delta = SnapshotDelta::default()
+        .set_turns_upsert(vec![turn.clone()])
+        .set_runs_upsert(vec![run]);
     if let Some(lock) = store.active_lock_record(&turn.scope) {
         delta.active_locks_upsert.push(lock);
     }

--- a/crates/ironclaw_turns/src/filesystem_store/row_store/traits.rs
+++ b/crates/ironclaw_turns/src/filesystem_store/row_store/traits.rs
@@ -334,10 +334,7 @@ where
         );
         async move {
             let record = loop_checkpoint_record_from_request(request);
-            let delta = SnapshotDelta {
-                loop_checkpoints_upsert: vec![record.clone()],
-                ..SnapshotDelta::default()
-            };
+            let delta = SnapshotDelta::default().set_loop_checkpoints_upsert(vec![record.clone()]);
             let ack = {
                 let _commit_guard = self.commit_gate.lock().await;
                 let ack = self

--- a/crates/ironclaw_turns/src/filesystem_store/runner_lease.rs
+++ b/crates/ironclaw_turns/src/filesystem_store/runner_lease.rs
@@ -508,18 +508,15 @@ mod tests {
         let runner_id = TurnRunnerId::new();
         let lease_token = TurnLeaseToken::new();
         let now = Utc::now();
-        let snapshot = TurnPersistenceSnapshot {
-            runs: vec![turn_run_record(
-                run_id,
-                runner_id,
-                lease_token,
-                TurnStatus::Running,
-                now,
-                now,
-                EventCursor(1),
-            )],
-            ..TurnPersistenceSnapshot::default()
-        };
+        let snapshot = TurnPersistenceSnapshot::default().set_runs(vec![turn_run_record(
+            run_id,
+            runner_id,
+            lease_token,
+            TurnStatus::Running,
+            now,
+            now,
+            EventCursor(1),
+        )]);
         let existing = RunnerLeaseRecord {
             run_id,
             runner_id,

--- a/crates/ironclaw_turns/src/loop_exit/tests/mod.rs
+++ b/crates/ironclaw_turns/src/loop_exit/tests/mod.rs
@@ -443,10 +443,7 @@ fn iteration_limit_failure_maps_to_stable_sanitized_runner_failure_after_host_ve
         LoopFailureKind::IterationLimit,
         exit_id("exit:max-iterations"),
     )
-    .validate(LoopExitValidationPolicy {
-        failure_evidence_verified: true,
-        ..LoopExitValidationPolicy::default()
-    });
+    .validate(LoopExitValidationPolicy::default().with_host_verified_failure_evidence());
 
     assert_eq!(
         decision.mapping,
@@ -566,11 +563,11 @@ fn strict_final_checkpoint_policy_trusts_failed_exit_only_after_verification() {
 
     // Before the final checkpoint is host-verified the failed exit is a
     // protocol violation.
-    let rejected = exit.clone().validate(LoopExitValidationPolicy {
-        require_final_checkpoint: true,
-        failure_evidence_verified: true,
-        ..LoopExitValidationPolicy::default()
-    });
+    let rejected = exit.clone().validate(
+        LoopExitValidationPolicy::default()
+            .require_final_checkpoint()
+            .with_host_verified_failure_evidence(),
+    );
     assert_eq!(
         rejected.violation.as_ref().map(LoopExitViolation::kind),
         Some(LoopExitViolationKind::MissingFinalCheckpoint)
@@ -585,12 +582,12 @@ fn strict_final_checkpoint_policy_trusts_failed_exit_only_after_verification() {
 
     // After verification, the trusted failed outcome surfaces the sanitized
     // failure category.
-    let accepted = exit.validate(LoopExitValidationPolicy {
-        require_final_checkpoint: true,
-        final_checkpoint_verified: true,
-        failure_evidence_verified: true,
-        ..LoopExitValidationPolicy::default()
-    });
+    let accepted = exit.validate(
+        LoopExitValidationPolicy::default()
+            .require_final_checkpoint()
+            .with_host_verified_final_checkpoint()
+            .with_host_verified_failure_evidence(),
+    );
     assert_eq!(accepted.violation, None);
     assert_eq!(
         accepted.mapping,
@@ -900,10 +897,7 @@ fn blocked_variants_map_to_correct_blocked_reason() {
             state_ref: state_ref.clone(),
             exit_id: exit_id("exit:blocked-variant"),
         })
-        .validate(LoopExitValidationPolicy {
-            blocked_evidence_verified: true,
-            ..LoopExitValidationPolicy::default()
-        });
+        .validate(LoopExitValidationPolicy::default().with_host_verified_blocked_evidence());
 
         let expected_reason = match kind {
             LoopBlockedKind::Approval => BlockedReason::Approval { gate_ref },
@@ -996,12 +990,8 @@ fn all_failure_kinds_produce_stable_sanitized_category_strings() {
     }
 
     for (kind, expected_category) in variants {
-        let decision = LoopExit::failed(*kind, exit_id("exit:failure-variant")).validate(
-            LoopExitValidationPolicy {
-                failure_evidence_verified: true,
-                ..LoopExitValidationPolicy::default()
-            },
-        );
+        let decision = LoopExit::failed(*kind, exit_id("exit:failure-variant"))
+            .validate(LoopExitValidationPolicy::default().with_host_verified_failure_evidence());
 
         assert_eq!(
             decision.violation, None,
@@ -1046,10 +1036,8 @@ fn cancelled_with_checkpoint_and_interrupted_refs_maps_to_cancelled_outcome() {
         exit_id: exit_id("exit:cancelled-with-checkpoint"),
     });
 
-    let decision = exit.validate(LoopExitValidationPolicy {
-        host_cancellation_observed: true,
-        ..LoopExitValidationPolicy::default()
-    });
+    let decision =
+        exit.validate(LoopExitValidationPolicy::default().with_host_cancellation_observed());
 
     assert_eq!(decision.violation, None);
     assert_eq!(decision.mapping, TurnRunnerOutcome::Cancelled.into());

--- a/crates/ironclaw_turns/src/memory/mod.rs
+++ b/crates/ironclaw_turns/src/memory/mod.rs
@@ -144,6 +144,52 @@ impl Default for InMemoryTurnStateStoreLimits {
     }
 }
 
+impl InMemoryTurnStateStoreLimits {
+    pub fn set_max_events(mut self, max_events: usize) -> Self {
+        self.max_events = max_events;
+        self
+    }
+
+    pub fn set_max_terminal_records(mut self, max_terminal_records: usize) -> Self {
+        self.max_terminal_records = max_terminal_records;
+        self
+    }
+
+    pub fn set_max_idempotency_records(mut self, max_idempotency_records: usize) -> Self {
+        self.max_idempotency_records = max_idempotency_records;
+        self
+    }
+
+    pub fn set_runner_lease_ttl(mut self, runner_lease_ttl: ChronoDuration) -> Self {
+        self.runner_lease_ttl = runner_lease_ttl;
+        self
+    }
+
+    pub fn set_max_concurrent_runs_per_user(
+        mut self,
+        max_concurrent_runs_per_user: Option<std::num::NonZeroU32>,
+    ) -> Self {
+        self.max_concurrent_runs_per_user = max_concurrent_runs_per_user;
+        self
+    }
+
+    pub fn set_max_concurrent_trigger_runs(
+        mut self,
+        max_concurrent_trigger_runs: Option<std::num::NonZeroU32>,
+    ) -> Self {
+        self.max_concurrent_trigger_runs = max_concurrent_trigger_runs;
+        self
+    }
+
+    pub fn set_max_concurrent_conversation_runs(
+        mut self,
+        max_concurrent_conversation_runs: Option<std::num::NonZeroU32>,
+    ) -> Self {
+        self.max_concurrent_conversation_runs = max_concurrent_conversation_runs;
+        self
+    }
+}
+
 pub struct InMemoryTurnStateStore {
     inner: Mutex<Inner>,
     submit_idempotency_ready: Notify,
@@ -3913,10 +3959,7 @@ mod tests {
 
     #[tokio::test]
     async fn terminal_pruning_removes_orphaned_turn_records() {
-        let limits = InMemoryTurnStateStoreLimits {
-            max_terminal_records: 1,
-            ..InMemoryTurnStateStoreLimits::default()
-        };
+        let limits = InMemoryTurnStateStoreLimits::default().set_max_terminal_records(1);
         let store = InMemoryTurnStateStore::with_limits(limits);
         let policy = AllowAllTurnAdmissionPolicy;
         let resolver = TestRunProfileResolver;

--- a/crates/ironclaw_turns/src/store.rs
+++ b/crates/ironclaw_turns/src/store.rs
@@ -487,6 +487,23 @@ pub struct TurnPersistenceSnapshot {
     pub spawn_tree_reservations: Vec<SpawnTreeReservation>,
 }
 
+impl TurnPersistenceSnapshot {
+    pub fn set_runs(mut self, runs: Vec<TurnRunRecord>) -> Self {
+        self.runs = runs;
+        self
+    }
+
+    pub fn set_checkpoints(mut self, checkpoints: Vec<TurnCheckpointRecord>) -> Self {
+        self.checkpoints = checkpoints;
+        self
+    }
+
+    pub fn set_events(mut self, events: Vec<TurnLifecycleEvent>) -> Self {
+        self.events = events;
+        self
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{

--- a/crates/ironclaw_turns/tests/checkpoint_state_store_contract.rs
+++ b/crates/ironclaw_turns/tests/checkpoint_state_store_contract.rs
@@ -513,8 +513,8 @@ fn turn_checkpoint_public_status_does_not_expose_checkpoint_payload() {
         retryable: None,
         detail: None,
     };
-    let snapshot = TurnPersistenceSnapshot {
-        checkpoints: vec![TurnCheckpointRecord {
+    let snapshot = TurnPersistenceSnapshot::default()
+        .set_checkpoints(vec![TurnCheckpointRecord {
             checkpoint_id,
             run_id,
             scope: Some(scope.clone()),
@@ -524,10 +524,8 @@ fn turn_checkpoint_public_status_does_not_expose_checkpoint_payload() {
             kind: LoopCheckpointKind::BeforeBlock,
             state_ref: LoopCheckpointStateRef::new("checkpoint:public-status").unwrap(),
             created_at: fixed_time(),
-        }],
-        events: vec![event.clone()],
-        ..TurnPersistenceSnapshot::default()
-    };
+        }])
+        .set_events(vec![event.clone()]);
 
     let public_wire = format!(
         "{}{}{}{:?}",
@@ -853,10 +851,7 @@ fn turn_persistence_snapshot_legacy_run_defaults_resume_disposition_to_none() {
 
     // Serialize the snapshot — auth_resume_disposition (the wire key) must be absent
     // in the output when resume_disposition is None.
-    let snapshot = TurnPersistenceSnapshot {
-        runs: vec![record],
-        ..TurnPersistenceSnapshot::default()
-    };
+    let snapshot = TurnPersistenceSnapshot::default().set_runs(vec![record]);
     let mut json_val = serde_json::to_value(&snapshot).expect("serialize snapshot");
 
     // Verify the key is indeed absent (proving our legacy simulation is accurate).
@@ -992,10 +987,7 @@ fn turn_persistence_snapshot_legacy_run_preserves_denied_resume_disposition() {
         resume_disposition: None,
     };
 
-    let snapshot = TurnPersistenceSnapshot {
-        runs: vec![record],
-        ..TurnPersistenceSnapshot::default()
-    };
+    let snapshot = TurnPersistenceSnapshot::default().set_runs(vec![record]);
     let mut json_val = serde_json::to_value(&snapshot).expect("serialize snapshot");
 
     // Inject the legacy key into the run object to simulate a persisted record

--- a/crates/ironclaw_turns/tests/filesystem_turn_state_contract.rs
+++ b/crates/ironclaw_turns/tests/filesystem_turn_state_contract.rs
@@ -2396,12 +2396,10 @@ async fn filesystem_turn_state_row_store_loop_checkpoint_survives_concurrent_ful
 async fn filesystem_turn_state_row_store_evicted_terminal_run_remains_queryable() {
     let backend = Arc::new(engine_filesystem());
     let scoped = scoped_turns_fs(Arc::clone(&backend));
-    let limits = InMemoryTurnStateStoreLimits {
-        max_events: 2,
-        max_terminal_records: 1,
-        max_idempotency_records: 1,
-        ..InMemoryTurnStateStoreLimits::default()
-    };
+    let limits = InMemoryTurnStateStoreLimits::default()
+        .set_max_events(2)
+        .set_max_terminal_records(1)
+        .set_max_idempotency_records(1);
     let store = FilesystemTurnStateRowStore::new(Arc::clone(&scoped)).with_limits(limits);
     let resolver = InMemoryRunProfileResolver::default();
 

--- a/crates/ironclaw_turns/tests/per_inbound_type_concurrency_cap.rs
+++ b/crates/ironclaw_turns/tests/per_inbound_type_concurrency_cap.rs
@@ -117,17 +117,17 @@ fn resolver() -> InMemoryRunProfileResolver {
 }
 
 fn make_trigger_capped_store(cap: u32) -> InMemoryTurnStateStore {
-    InMemoryTurnStateStore::with_limits(InMemoryTurnStateStoreLimits {
-        max_concurrent_trigger_runs: std::num::NonZeroU32::new(cap),
-        ..InMemoryTurnStateStoreLimits::default()
-    })
+    InMemoryTurnStateStore::with_limits(
+        InMemoryTurnStateStoreLimits::default()
+            .set_max_concurrent_trigger_runs(std::num::NonZeroU32::new(cap)),
+    )
 }
 
 fn make_conversation_capped_store(cap: u32) -> InMemoryTurnStateStore {
-    InMemoryTurnStateStore::with_limits(InMemoryTurnStateStoreLimits {
-        max_concurrent_conversation_runs: std::num::NonZeroU32::new(cap),
-        ..InMemoryTurnStateStoreLimits::default()
-    })
+    InMemoryTurnStateStore::with_limits(
+        InMemoryTurnStateStoreLimits::default()
+            .set_max_concurrent_conversation_runs(std::num::NonZeroU32::new(cap)),
+    )
 }
 
 fn accepted_run_id(resp: &SubmitTurnResponse) -> ironclaw_turns::TurnRunId {
@@ -872,10 +872,8 @@ async fn snapshot_rebuild_restores_nonzero_origin_class_counter() {
     // must already be 1 without claiming again.
     let restored = InMemoryTurnStateStore::from_persistence_snapshot(
         snapshot,
-        InMemoryTurnStateStoreLimits {
-            max_concurrent_trigger_runs: std::num::NonZeroU32::new(10),
-            ..InMemoryTurnStateStoreLimits::default()
-        },
+        InMemoryTurnStateStoreLimits::default()
+            .set_max_concurrent_trigger_runs(std::num::NonZeroU32::new(10)),
     )
     .unwrap();
     assert_eq!(

--- a/crates/ironclaw_turns/tests/per_user_concurrency_cap.rs
+++ b/crates/ironclaw_turns/tests/per_user_concurrency_cap.rs
@@ -91,10 +91,10 @@ fn make_store() -> InMemoryTurnStateStore {
 }
 
 fn make_capped_store(cap: u32) -> InMemoryTurnStateStore {
-    InMemoryTurnStateStore::with_limits(InMemoryTurnStateStoreLimits {
-        max_concurrent_runs_per_user: std::num::NonZeroU32::new(cap),
-        ..InMemoryTurnStateStoreLimits::default()
-    })
+    InMemoryTurnStateStore::with_limits(
+        InMemoryTurnStateStoreLimits::default()
+            .set_max_concurrent_runs_per_user(std::num::NonZeroU32::new(cap)),
+    )
 }
 
 fn resolver() -> InMemoryRunProfileResolver {
@@ -845,10 +845,8 @@ async fn snapshot_rebuild_restores_nonzero_running_counter() {
     // already be 1 without claiming again.
     let restored = InMemoryTurnStateStore::from_persistence_snapshot(
         snapshot,
-        InMemoryTurnStateStoreLimits {
-            max_concurrent_runs_per_user: std::num::NonZeroU32::new(10),
-            ..InMemoryTurnStateStoreLimits::default()
-        },
+        InMemoryTurnStateStoreLimits::default()
+            .set_max_concurrent_runs_per_user(std::num::NonZeroU32::new(10)),
     )
     .unwrap();
     assert_eq!(

--- a/crates/ironclaw_turns/tests/turn_coordinator_contract.rs
+++ b/crates/ironclaw_turns/tests/turn_coordinator_contract.rs
@@ -2780,10 +2780,7 @@ async fn turn_lifecycle_projection_replays_cancelled_terminal_without_raw_refs()
 #[tokio::test]
 async fn turn_lifecycle_projection_requires_rebase_for_pruned_or_fabricated_cursors() {
     let store = Arc::new(InMemoryTurnStateStore::with_limits(
-        InMemoryTurnStateStoreLimits {
-            max_events: 2,
-            ..InMemoryTurnStateStoreLimits::default()
-        },
+        InMemoryTurnStateStoreLimits::default().set_max_events(2),
     ));
     let coordinator = DefaultTurnCoordinator::new(store.clone());
     let mut request = submit_request("thread-turn-gap", "idem-turn-gap-submit");
@@ -3945,10 +3942,7 @@ async fn record_model_route_snapshot_is_idempotent_and_rejects_route_changes() {
 #[tokio::test]
 async fn terminal_record_pruning_bounds_released_admission_reservations() {
     let store = Arc::new(InMemoryTurnStateStore::with_limits(
-        InMemoryTurnStateStoreLimits {
-            max_terminal_records: 1,
-            ..InMemoryTurnStateStoreLimits::default()
-        },
+        InMemoryTurnStateStoreLimits::default().set_max_terminal_records(1),
     ));
     let coordinator = DefaultTurnCoordinator::new(store.clone());
     let first_run_id = accepted_run_id(
@@ -4017,10 +4011,7 @@ async fn terminal_record_pruning_bounds_released_admission_reservations() {
 #[tokio::test]
 async fn terminal_root_with_tree_reservation_survives_terminal_pruning() {
     let store = Arc::new(InMemoryTurnStateStore::with_limits(
-        InMemoryTurnStateStoreLimits {
-            max_terminal_records: 1,
-            ..InMemoryTurnStateStoreLimits::default()
-        },
+        InMemoryTurnStateStoreLimits::default().set_max_terminal_records(1),
     ));
     let coordinator = DefaultTurnCoordinator::new(store.clone());
     let parent_scope = scope("thread-tree-root-pruned");
@@ -4081,10 +4072,7 @@ async fn terminal_root_with_tree_reservation_survives_terminal_pruning() {
 #[tokio::test]
 async fn terminal_root_release_does_not_duplicate_pruning_queue() {
     let store = Arc::new(InMemoryTurnStateStore::with_limits(
-        InMemoryTurnStateStoreLimits {
-            max_terminal_records: 1,
-            ..InMemoryTurnStateStoreLimits::default()
-        },
+        InMemoryTurnStateStoreLimits::default().set_max_terminal_records(1),
     ));
     let coordinator = DefaultTurnCoordinator::new(store.clone());
     let parent_scope = scope("thread-tree-root-release");
@@ -4121,10 +4109,7 @@ async fn terminal_root_release_does_not_duplicate_pruning_queue() {
 #[tokio::test]
 async fn releasing_old_reserved_terminal_root_keeps_newer_terminal_record() {
     let store = Arc::new(InMemoryTurnStateStore::with_limits(
-        InMemoryTurnStateStoreLimits {
-            max_terminal_records: 1,
-            ..InMemoryTurnStateStoreLimits::default()
-        },
+        InMemoryTurnStateStoreLimits::default().set_max_terminal_records(1),
     ));
     let coordinator = DefaultTurnCoordinator::new(store.clone());
     let parent_scope = scope("thread-tree-root-release-after-churn");
@@ -5032,10 +5017,7 @@ fn capacity_exceeded_idempotency_replay_preserves_resource_and_cap() {
 #[tokio::test]
 async fn idempotency_persistence_snapshot_retains_each_operation_kind_capacity() {
     let store = Arc::new(InMemoryTurnStateStore::with_limits(
-        InMemoryTurnStateStoreLimits {
-            max_idempotency_records: 1,
-            ..InMemoryTurnStateStoreLimits::default()
-        },
+        InMemoryTurnStateStoreLimits::default().set_max_idempotency_records(1),
     ));
     let coordinator = DefaultTurnCoordinator::new(store.clone());
     let run_id = accepted_run_id(
@@ -5107,10 +5089,7 @@ async fn idempotency_persistence_snapshot_retains_each_operation_kind_capacity()
 #[tokio::test]
 async fn idempotency_persistence_snapshot_drops_records_when_replay_cache_prunes_them() {
     let store = Arc::new(InMemoryTurnStateStore::with_limits(
-        InMemoryTurnStateStoreLimits {
-            max_idempotency_records: 1,
-            ..InMemoryTurnStateStoreLimits::default()
-        },
+        InMemoryTurnStateStoreLimits::default().set_max_idempotency_records(1),
     ));
     let coordinator = DefaultTurnCoordinator::new(store.clone());
 
@@ -5222,10 +5201,7 @@ async fn idempotency_replay_helpers_require_matching_operation_kind() {
 #[tokio::test]
 async fn idempotency_retention_keeps_the_newest_result_when_pruned() {
     let store = Arc::new(InMemoryTurnStateStore::with_limits(
-        InMemoryTurnStateStoreLimits {
-            max_idempotency_records: 2,
-            ..InMemoryTurnStateStoreLimits::default()
-        },
+        InMemoryTurnStateStoreLimits::default().set_max_idempotency_records(2),
     ));
     let coordinator = DefaultTurnCoordinator::new(store);
 
@@ -5460,10 +5436,8 @@ async fn runner_claims_queued_run_with_lease_and_heartbeat_requires_matching_lea
 
 #[tokio::test]
 async fn cancel_requested_runner_heartbeat_does_not_extend_lease() {
-    let limits = InMemoryTurnStateStoreLimits {
-        runner_lease_ttl: ChronoDuration::milliseconds(40),
-        ..InMemoryTurnStateStoreLimits::default()
-    };
+    let limits = InMemoryTurnStateStoreLimits::default()
+        .set_runner_lease_ttl(ChronoDuration::milliseconds(40));
     let store = Arc::new(InMemoryTurnStateStore::with_limits(limits));
     let coordinator = DefaultTurnCoordinator::new(store.clone());
     let request = submit_request("thread-cancel-heartbeat", "idem-submit-cancel-heartbeat");
@@ -5521,10 +5495,8 @@ async fn cancel_requested_runner_heartbeat_does_not_extend_lease() {
 
 #[tokio::test]
 async fn expired_runner_lease_rejects_heartbeat_and_terminal_completion_before_recovery_sweep() {
-    let limits = InMemoryTurnStateStoreLimits {
-        runner_lease_ttl: ChronoDuration::milliseconds(-1),
-        ..InMemoryTurnStateStoreLimits::default()
-    };
+    let limits = InMemoryTurnStateStoreLimits::default()
+        .set_runner_lease_ttl(ChronoDuration::milliseconds(-1));
     let store = Arc::new(InMemoryTurnStateStore::with_limits(limits));
     let coordinator = DefaultTurnCoordinator::new(store.clone());
     let run_id = accepted_run_id(
@@ -5587,10 +5559,8 @@ async fn expired_runner_lease_rejects_heartbeat_and_terminal_completion_before_r
 
 #[tokio::test]
 async fn expired_runner_lease_rejects_fail_and_runner_side_cancel_before_recovery_sweep() {
-    let limits = InMemoryTurnStateStoreLimits {
-        runner_lease_ttl: ChronoDuration::milliseconds(-1),
-        ..InMemoryTurnStateStoreLimits::default()
-    };
+    let limits = InMemoryTurnStateStoreLimits::default()
+        .set_runner_lease_ttl(ChronoDuration::milliseconds(-1));
     let store = Arc::new(InMemoryTurnStateStore::with_limits(limits));
     let coordinator = DefaultTurnCoordinator::new(store.clone());
 


### PR DESCRIPTION
## Summary
- Add default-backed setters for large turn-state limit and snapshot helper structs.
- Replace sparse InMemoryTurnStateStoreLimits, TurnPersistenceSnapshot, and SnapshotDelta default-tail literals with setter chains.
- Use existing LoopExitValidationPolicy verification methods instead of default-tail private policy literals.

## Stack
- Base: #5791

## Validation
- cargo fmt --check
- cargo test -p ironclaw_turns