### PR TITLE
Use default setters in memory native fixtures

### DIFF
--- a/crates/ironclaw_memory_native/src/backend.rs
+++ b/crates/ironclaw_memory_native/src/backend.rs
@@ -47,6 +47,58 @@ pub struct MemoryBackendCapabilities {
     pub transactions: bool,
 }
 
+impl MemoryBackendCapabilities {
+    pub fn set_file_documents(mut self, file_documents: bool) -> Self {
+        self.file_documents = file_documents;
+        self
+    }
+
+    pub fn set_metadata(mut self, metadata: bool) -> Self {
+        self.metadata = metadata;
+        self
+    }
+
+    pub fn set_versioning(mut self, versioning: bool) -> Self {
+        self.versioning = versioning;
+        self
+    }
+
+    pub fn set_prompt_write_safety(mut self, prompt_write_safety: bool) -> Self {
+        self.prompt_write_safety = prompt_write_safety;
+        self
+    }
+
+    pub fn set_full_text_search(mut self, full_text_search: bool) -> Self {
+        self.full_text_search = full_text_search;
+        self
+    }
+
+    pub fn set_vector_search(mut self, vector_search: bool) -> Self {
+        self.vector_search = vector_search;
+        self
+    }
+
+    pub fn set_embeddings(mut self, embeddings: bool) -> Self {
+        self.embeddings = embeddings;
+        self
+    }
+
+    pub fn set_graph_memory(mut self, graph_memory: bool) -> Self {
+        self.graph_memory = graph_memory;
+        self
+    }
+
+    pub fn set_delete(mut self, delete: bool) -> Self {
+        self.delete = delete;
+        self
+    }
+
+    pub fn set_transactions(mut self, transactions: bool) -> Self {
+        self.transactions = transactions;
+        self
+    }
+}
+
 // `MemoryContext` moved to `ironclaw_memory`; re-exported so
 // `crate::backend::MemoryContext` and the backend code below keep resolving.
 // NOTE: the backend's "already enforced" signal (`prompt_safety_already_enforced`)
@@ -227,13 +279,11 @@ where
             repository,
             indexer: None,
             embedding_provider: None,
-            capabilities: MemoryBackendCapabilities {
-                file_documents: true,
-                metadata: true,
-                versioning: true,
-                prompt_write_safety: true,
-                ..MemoryBackendCapabilities::default()
-            },
+            capabilities: MemoryBackendCapabilities::default()
+                .set_file_documents(true)
+                .set_metadata(true)
+                .set_versioning(true)
+                .set_prompt_write_safety(true),
             prompt_safety_policy: Some(Arc::new(DefaultPromptWriteSafetyPolicy::with_registry(
                 registry.clone(),
             ))),
@@ -1082,10 +1132,8 @@ mod tests {
 
     #[tokio::test]
     async fn file_document_capability_rejects_direct_backend_file_operations() {
-        let backend = make_backend().with_capabilities(MemoryBackendCapabilities {
-            file_documents: false,
-            ..MemoryBackendCapabilities::default()
-        });
+        let backend = make_backend()
+            .with_capabilities(MemoryBackendCapabilities::default().set_file_documents(false));
         assert!(
             backend
                 .read_document(&alpha_context(), &alpha_path())
@@ -1114,12 +1162,12 @@ mod tests {
 
     #[tokio::test]
     async fn vector_request_fails_closed_when_vector_search_is_unsupported() {
-        let backend = make_search_backend(MemoryBackendCapabilities {
-            full_text_search: true,
-            vector_search: false,
-            embeddings: true,
-            ..MemoryBackendCapabilities::default()
-        });
+        let backend = make_search_backend(
+            MemoryBackendCapabilities::default()
+                .set_full_text_search(true)
+                .set_vector_search(false)
+                .set_embeddings(true),
+        );
         let request = MemorySearchRequest::new("query").unwrap();
         let err = backend.search(&alpha_context(), request).await.unwrap_err();
         assert!(err.to_string().contains("vector search"));
@@ -1127,12 +1175,12 @@ mod tests {
 
     #[tokio::test]
     async fn vector_request_fails_closed_when_embedding_generation_is_disabled() {
-        let backend = make_search_backend(MemoryBackendCapabilities {
-            full_text_search: true,
-            vector_search: true,
-            embeddings: false,
-            ..MemoryBackendCapabilities::default()
-        });
+        let backend = make_search_backend(
+            MemoryBackendCapabilities::default()
+                .set_full_text_search(true)
+                .set_vector_search(true)
+                .set_embeddings(false),
+        );
         let request = MemorySearchRequest::new("query").unwrap();
         let err = backend.search(&alpha_context(), request).await.unwrap_err();
         assert!(err.to_string().contains("embedding generation"));
@@ -1144,12 +1192,12 @@ mod tests {
         let backend = RepositoryMemoryBackend::new(repo)
             .without_prompt_write_safety_policy()
             .with_embedding_provider(Arc::new(FailingEmbeddingProvider))
-            .with_capabilities(MemoryBackendCapabilities {
-                full_text_search: true,
-                vector_search: true,
-                embeddings: true,
-                ..MemoryBackendCapabilities::default()
-            });
+            .with_capabilities(
+                MemoryBackendCapabilities::default()
+                    .set_full_text_search(true)
+                    .set_vector_search(true)
+                    .set_embeddings(true),
+            );
 
         let request = MemorySearchRequest::new("query").unwrap();
         let err = backend.search(&alpha_context(), request).await.unwrap_err();
@@ -1166,12 +1214,12 @@ mod tests {
 
     #[tokio::test]
     async fn full_text_only_search_ignores_stale_query_embedding_dimension() {
-        let backend = make_search_backend(MemoryBackendCapabilities {
-            full_text_search: true,
-            vector_search: true,
-            embeddings: true,
-            ..MemoryBackendCapabilities::default()
-        });
+        let backend = make_search_backend(
+            MemoryBackendCapabilities::default()
+                .set_full_text_search(true)
+                .set_vector_search(true)
+                .set_embeddings(true),
+        );
         let request = MemorySearchRequest::new("query")
             .unwrap()
             .with_vector(false)

--- a/crates/ironclaw_memory_native/src/filesystem.rs
+++ b/crates/ironclaw_memory_native/src/filesystem.rs
@@ -64,10 +64,7 @@ fn memory_context_with_prompt_safety_enforcement(
 /// Backend write options the adapter passes after it has already run
 /// prompt-write safety, telling the backend to skip its own re-enforcement.
 fn adapter_enforced_backend_write_options() -> MemoryBackendWriteOptions {
-    MemoryBackendWriteOptions {
-        prompt_safety_already_enforced: true,
-        ..MemoryBackendWriteOptions::default()
-    }
+    MemoryBackendWriteOptions::default().with_prompt_safety_already_enforced()
 }
 
 /// [`RootFilesystem`] adapter exposing any [`MemoryBackend`] as `/memory` files.

--- a/crates/ironclaw_memory_native/src/metadata.rs
+++ b/crates/ironclaw_memory_native/src/metadata.rs
@@ -16,6 +16,13 @@ pub struct MemoryWriteOptions {
     pub changed_by: Option<String>,
 }
 
+impl MemoryWriteOptions {
+    pub fn set_changed_by(mut self, changed_by: impl Into<String>) -> Self {
+        self.changed_by = Some(changed_by.into());
+        self
+    }
+}
+
 /// Backend-facing options for a document write.
 #[derive(Debug, Clone, Default)]
 pub struct MemoryBackendWriteOptions {
@@ -42,6 +49,11 @@ impl MemoryBackendWriteOptions {
             metadata_overlay,
             prompt_safety_already_enforced: false,
         }
+    }
+
+    pub(crate) fn with_prompt_safety_already_enforced(mut self) -> Self {
+        self.prompt_safety_already_enforced = true;
+        self
     }
 }
 

--- a/crates/ironclaw_memory_native/src/repo/filesystem.rs
+++ b/crates/ironclaw_memory_native/src/repo/filesystem.rs
@@ -526,10 +526,8 @@ where
         // Direct repository writes pick up the same default
         // `changed_by` the native repos used so version-history
         // attribution survives bypass of the higher backend seam.
-        let options = MemoryWriteOptions {
-            changed_by: Some(scoped_memory_changed_by_key(path.scope())),
-            ..MemoryWriteOptions::default()
-        };
+        let options = MemoryWriteOptions::default()
+            .set_changed_by(scoped_memory_changed_by_key(path.scope()));
         self.write_document_with_options(path, bytes, &options)
             .await
     }
@@ -1179,10 +1177,7 @@ mod tests {
         let (_, repo) = fresh_repo();
         let path = doc("notes/skip-version.md");
         repo.write_document(&path, b"alpha").await.unwrap();
-        let mut options = MemoryWriteOptions {
-            changed_by: Some("test".to_string()),
-            ..Default::default()
-        };
+        let mut options = MemoryWriteOptions::default().set_changed_by("test");
         options.metadata.skip_versioning = Some(true);
         repo.write_document_with_options(&path, b"beta", &options)
             .await
@@ -1241,10 +1236,7 @@ mod tests {
         let path = doc("notes/append.md");
         repo.write_document(&path, b"hello").await.unwrap();
         let expected = content_sha256("hello");
-        let options = MemoryWriteOptions {
-            changed_by: Some("test".to_string()),
-            ..Default::default()
-        };
+        let options = MemoryWriteOptions::default().set_changed_by("test");
         let outcome = repo
             .compare_and_append_document_with_options(&path, Some(&expected), b" world", &options)
             .await

--- a/crates/ironclaw_memory_native/src/service.rs
+++ b/crates/ironclaw_memory_native/src/service.rs
@@ -420,16 +420,16 @@ fn build_native_backend(
     let indexer = Arc::new(ChunkingMemoryDocumentIndexer::new(Arc::clone(&repository)));
     let mut backend = RepositoryMemoryBackend::new(Arc::clone(&repository))
         .with_indexer(indexer)
-        .with_capabilities(MemoryBackendCapabilities {
-            file_documents: true,
-            metadata: true,
-            versioning: true,
-            prompt_write_safety: true,
-            full_text_search: true,
-            delete: true,
-            transactions: true,
-            ..MemoryBackendCapabilities::default()
-        });
+        .with_capabilities(
+            MemoryBackendCapabilities::default()
+                .set_file_documents(true)
+                .set_metadata(true)
+                .set_versioning(true)
+                .set_prompt_write_safety(true)
+                .set_full_text_search(true)
+                .set_delete(true)
+                .set_transactions(true),
+        );
     if let Some(prompt_write_safety_event_sink) = prompt_write_safety_event_sink {
         backend = backend.with_prompt_write_safety_event_sink(prompt_write_safety_event_sink);
     }
@@ -485,10 +485,7 @@ fn write_options(metadata_overlay: Option<&DocumentMetadata>) -> MemoryBackendWr
     // Service writes are direct backend callers: leave
     // `prompt_safety_already_enforced` at its fail-closed default (false) so the
     // backend runs prompt-write safety itself.
-    MemoryBackendWriteOptions {
-        metadata_overlay: metadata_overlay.cloned(),
-        ..MemoryBackendWriteOptions::default()
-    }
+    MemoryBackendWriteOptions::with_metadata_overlay(metadata_overlay.cloned())
 }
 
 fn reject_local_or_traversal_path(path: &str) -> Result<(), MemoryServiceError> {

--- a/crates/ironclaw_memory_native/tests/memory_backend_contract.rs
+++ b/crates/ironclaw_memory_native/tests/memory_backend_contract.rs
@@ -341,12 +341,10 @@ async fn adapter_enforces_when_backend_advertises_capability_but_does_not_protec
     #[async_trait]
     impl MemoryBackend for PromptSafetyAdvertisingBackend {
         fn capabilities(&self) -> MemoryBackendCapabilities {
-            MemoryBackendCapabilities {
-                file_documents: true,
-                // **The footgun**: backend says "I do prompt-write safety"…
-                prompt_write_safety: true,
-                ..MemoryBackendCapabilities::default()
-            }
+            // **The footgun**: backend says "I do prompt-write safety"…
+            MemoryBackendCapabilities::default()
+                .set_file_documents(true)
+                .set_prompt_write_safety(true)
         }
 
         // …but reports protecting *no* paths. Adapter-classified files
@@ -1271,10 +1269,7 @@ impl RecordingBackend {
 #[async_trait]
 impl MemoryBackend for RecordingBackend {
     fn capabilities(&self) -> MemoryBackendCapabilities {
-        MemoryBackendCapabilities {
-            file_documents: true,
-            ..MemoryBackendCapabilities::default()
-        }
+        MemoryBackendCapabilities::default().set_file_documents(true)
     }
 
     async fn read_document(
@@ -1320,11 +1315,9 @@ impl BackendPromptSafetyRejects {
 #[async_trait]
 impl MemoryBackend for BackendPromptSafetyRejects {
     fn capabilities(&self) -> MemoryBackendCapabilities {
-        MemoryBackendCapabilities {
-            file_documents: true,
-            prompt_write_safety: true,
-            ..MemoryBackendCapabilities::default()
-        }
+        MemoryBackendCapabilities::default()
+            .set_file_documents(true)
+            .set_prompt_write_safety(true)
     }
 
     // The adapter defers to this backend only when it reports that it
@@ -1561,10 +1554,7 @@ impl ConflictOnceAppendBackend {
 #[async_trait]
 impl MemoryBackend for ConflictOnceAppendBackend {
     fn capabilities(&self) -> MemoryBackendCapabilities {
-        MemoryBackendCapabilities {
-            file_documents: true,
-            ..MemoryBackendCapabilities::default()
-        }
+        MemoryBackendCapabilities::default().set_file_documents(true)
     }
 
     async fn read_document(

--- a/crates/ironclaw_memory_native/tests/memory_service_facade.rs
+++ b/crates/ironclaw_memory_native/tests/memory_service_facade.rs
@@ -516,10 +516,7 @@ struct AlwaysConflictProfileBackend;
 #[async_trait]
 impl MemoryBackend for MockSearchBackend {
     fn capabilities(&self) -> MemoryBackendCapabilities {
-        MemoryBackendCapabilities {
-            full_text_search: true,
-            ..MemoryBackendCapabilities::default()
-        }
+        MemoryBackendCapabilities::default().set_full_text_search(true)
     }
 
     async fn search(
@@ -541,10 +538,7 @@ impl MemoryBackend for MockSearchBackend {
 #[async_trait]
 impl MemoryBackend for AlwaysConflictProfileBackend {
     fn capabilities(&self) -> MemoryBackendCapabilities {
-        MemoryBackendCapabilities {
-            file_documents: true,
-            ..MemoryBackendCapabilities::default()
-        }
+        MemoryBackendCapabilities::default().set_file_documents(true)
     }
 
     async fn read_document(


### PR DESCRIPTION
## Summary
- Add default-backed setters for MemoryBackendCapabilities and MemoryWriteOptions.
- Replace sparse memory capability and write-option default-tail literals with setter chains.
- Use existing/added MemoryBackendWriteOptions constructors for backend write options.

## Stack
- Base: #5791

## Validation
- cargo fmt --check
- cargo test -p ironclaw_memory_native