### PR TITLE
Use default setters in event projection fixtures

### DIFF
--- a/crates/ironclaw_event_projections/src/lib.rs
+++ b/crates/ironclaw_event_projections/src/lib.rs
@@ -481,6 +481,13 @@ pub struct MemoryAuditProjectionMetadata {
     pub finding_count: Option<u64>,
 }
 
+impl MemoryAuditProjectionMetadata {
+    pub fn set_byte_count(mut self, byte_count: Option<u64>) -> Self {
+        self.byte_count = byte_count;
+        self
+    }
+}
+
 #[derive(Debug, Error)]
 pub enum AuditProjectionError {
     #[error("audit projection request rejected: {reason}")]
@@ -1546,10 +1553,7 @@ fn parse_memory_audit_metadata(
         return None;
     }
 
-    let mut metadata = MemoryAuditProjectionMetadata {
-        byte_count: output_bytes,
-        ..MemoryAuditProjectionMetadata::default()
-    };
+    let mut metadata = MemoryAuditProjectionMetadata::default().set_byte_count(output_bytes);
     for segment in segments {
         let (key, value) = segment.split_once('=')?;
         match key {

--- a/crates/ironclaw_event_projections/tests/memory_significant_events_projection_contract.rs
+++ b/crates/ironclaw_event_projections/tests/memory_significant_events_projection_contract.rs
@@ -47,15 +47,15 @@ async fn memory_write_index_and_search_project_metadata_only_from_jsonl_audit_lo
     let backend = Arc::new(
         RepositoryMemoryBackend::new(Arc::clone(&repository))
             .without_prompt_write_safety_policy()
-            .with_capabilities(MemoryBackendCapabilities {
-                file_documents: true,
-                metadata: true,
-                versioning: true,
-                full_text_search: true,
-                vector_search: false,
-                embeddings: false,
-                ..MemoryBackendCapabilities::default()
-            })
+            .with_capabilities(
+                MemoryBackendCapabilities::default()
+                    .set_file_documents(true)
+                    .set_metadata(true)
+                    .set_versioning(true)
+                    .set_full_text_search(true)
+                    .set_vector_search(false)
+                    .set_embeddings(false),
+            )
             .with_indexer(indexer)
             .with_memory_event_sink(Arc::clone(&memory_events)),
     );


### PR DESCRIPTION
## Summary
- Use memory capability setters for event-projection memory backend test setup.
- Add and use a narrow default-backed byte-count setter for MemoryAuditProjectionMetadata.

## Stack
- Base: #5791
- Depends on: #5811

## Validation
- cargo fmt --check
- cargo test -p ironclaw_event_projections