### PR TITLE
Use default setters in skill activation tests

### DIFF
--- a/crates/ironclaw_first_party_extension_ports/src/activation.rs
+++ b/crates/ironclaw_first_party_extension_ports/src/activation.rs
@@ -89,6 +89,28 @@ impl Default for SkillActivationSelectorConfig {
     }
 }
 
+impl SkillActivationSelectorConfig {
+    pub fn set_max_active_skills(mut self, max_active_skills: usize) -> Self {
+        self.max_active_skills = max_active_skills;
+        self
+    }
+
+    pub fn set_max_context_tokens(mut self, max_context_tokens: usize) -> Self {
+        self.max_context_tokens = max_context_tokens;
+        self
+    }
+
+    pub fn set_selection_mode(mut self, selection_mode: SkillActivationSelectionMode) -> Self {
+        self.selection_mode = selection_mode;
+        self
+    }
+
+    pub fn set_regex_activation_enabled(mut self, regex_activation_enabled: bool) -> Self {
+        self.regex_activation_enabled = regex_activation_enabled;
+        self
+    }
+}
+
 /// Result of selecting skill activations from one user message.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SkillActivationSelection {
@@ -1757,10 +1779,7 @@ mod tests {
         ]));
         let selectable = SelectableSkillContextSource::new(
             source,
-            SkillActivationSelectorConfig {
-                regex_activation_enabled: false,
-                ..SkillActivationSelectorConfig::default()
-            },
+            SkillActivationSelectorConfig::default().set_regex_activation_enabled(false),
         );
         let context = run_context().await;
         selectable
@@ -1796,10 +1815,7 @@ mod tests {
         )]));
         let selectable = SelectableSkillContextSource::new(
             source,
-            SkillActivationSelectorConfig {
-                regex_activation_enabled: false,
-                ..SkillActivationSelectorConfig::default()
-            },
+            SkillActivationSelectorConfig::default().set_regex_activation_enabled(false),
         );
         let context = run_context().await;
         selectable
@@ -1838,10 +1854,8 @@ mod tests {
         )]));
         let selectable = SelectableSkillContextSource::new(
             source,
-            SkillActivationSelectorConfig {
-                selection_mode: SkillActivationSelectionMode::ExplicitOnly,
-                ..SkillActivationSelectorConfig::default()
-            },
+            SkillActivationSelectorConfig::default()
+                .set_selection_mode(SkillActivationSelectionMode::ExplicitOnly),
         );
         let context = run_context().await;
         selectable
@@ -1895,10 +1909,8 @@ mod tests {
         )]));
         let selectable = SelectableSkillContextSource::new(
             source,
-            SkillActivationSelectorConfig {
-                selection_mode: SkillActivationSelectionMode::ExplicitOnly,
-                ..SkillActivationSelectorConfig::default()
-            },
+            SkillActivationSelectorConfig::default()
+                .set_selection_mode(SkillActivationSelectionMode::ExplicitOnly),
         );
         let context = run_context().await;
 
@@ -1941,10 +1953,8 @@ mod tests {
         ]));
         let selectable = SelectableSkillContextSource::new(
             source.clone(),
-            SkillActivationSelectorConfig {
-                selection_mode: SkillActivationSelectionMode::ExplicitOnly,
-                ..SkillActivationSelectorConfig::default()
-            },
+            SkillActivationSelectorConfig::default()
+                .set_selection_mode(SkillActivationSelectionMode::ExplicitOnly),
         );
         let context = run_context().await;
 
@@ -1981,10 +1991,7 @@ mod tests {
         )]));
         let selectable = SelectableSkillContextSource::new(
             source,
-            SkillActivationSelectorConfig {
-                max_active_skills: 0,
-                ..SkillActivationSelectorConfig::default()
-            },
+            SkillActivationSelectorConfig::default().set_max_active_skills(0),
         );
         let context = run_context().await;
 
@@ -2193,10 +2200,7 @@ mod tests {
         ]));
         let selectable = SelectableSkillContextSource::new(
             source,
-            SkillActivationSelectorConfig {
-                max_active_skills: 1,
-                ..SkillActivationSelectorConfig::default()
-            },
+            SkillActivationSelectorConfig::default().set_max_active_skills(1),
         );
         let context = run_context().await;
 
@@ -2599,11 +2603,9 @@ mod tests {
         ]));
         let selectable = SelectableSkillContextSource::new(
             source,
-            SkillActivationSelectorConfig {
-                max_active_skills: 1,
-                max_context_tokens: 4,
-                ..SkillActivationSelectorConfig::default()
-            },
+            SkillActivationSelectorConfig::default()
+                .set_max_active_skills(1)
+                .set_max_context_tokens(4),
         );
         let context = run_context().await;
         selectable


### PR DESCRIPTION
## Summary
- Add default-backed setters for SkillActivationSelectorConfig.
- Replace sparse skill activation selector test configs with setter chains.

## Stack
- Base: #5791

## Validation
- cargo fmt --check
- cargo test -p ironclaw_first_party_extension_ports