### PR TITLE
feat(extensions): capability-surface vocabulary and manifest projection (NEA-25 stack 1/7)

### DIFF
--- a/crates/ironclaw_extensions/src/host_api/capability_provider.rs
+++ b/crates/ironclaw_extensions/src/host_api/capability_provider.rs
@@ -58,6 +58,7 @@ impl HostApiManifestContract for CapabilityProviderHostApiContract {
     ) -> Result<HostApiManifestProjection, String> {
         Ok(HostApiManifestProjection {
             capabilities: project_capabilities(context, section)?,
+            surfaces: Vec::new(),
         })
     }
 }

--- a/crates/ironclaw_extensions/src/lib.rs
+++ b/crates/ironclaw_extensions/src/lib.rs
@@ -423,11 +423,12 @@ pub use hosted_mcp_discovery::{
     package_with_discovered_hosted_mcp_tools,
 };
 pub use v2::{
-    CapabilityDeclV2, CapabilityVisibility, ExtensionManifestV2, ExtensionRuntimeV2,
-    HookSectionEntryV2, HostApiContractRegistry, HostApiId, HostApiManifestContext,
-    HostApiManifestContract, HostApiManifestProjection, HostApiMultiplicity, HostApiRefV2,
-    MANIFEST_SCHEMA_VERSION, MAX_HOOK_ENTRY_BYTES, MAX_MANIFEST_BYTES, MAX_MANIFEST_HOOKS,
-    ManifestSectionPath, ManifestSource, ManifestV2Error, RESERVED_HOST_BUNDLED_ID_PREFIX,
+    CapabilityDeclV2, CapabilitySurfaceDeclV2, CapabilityVisibility, ExtensionManifestV2,
+    ExtensionRuntimeV2, HookSectionEntryV2, HostApiContractRegistry, HostApiId,
+    HostApiManifestContext, HostApiManifestContract, HostApiManifestProjection,
+    HostApiMultiplicity, HostApiRefV2, MANIFEST_SCHEMA_VERSION, MAX_HOOK_ENTRY_BYTES,
+    MAX_MANIFEST_BYTES, MAX_MANIFEST_HOOKS, ManifestSectionPath, ManifestSource, ManifestV2Error,
+    RESERVED_HOST_BUNDLED_ID_PREFIX,
 };
 
 pub type CapabilityManifest = CapabilityDeclV2;

--- a/crates/ironclaw_extensions/src/v2.rs
+++ b/crates/ironclaw_extensions/src/v2.rs
@@ -38,11 +38,12 @@ use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::sync::Arc;
 
 use ironclaw_host_api::{
-    CapabilityId, CapabilityProfileId, CapabilityProfileSchemaRef, EffectKind, ExtensionId,
-    HostApiError, HostPortCatalog, HostPortId, NetworkScheme, NetworkTargetPattern, PermissionMode,
-    RequestedTrustClass, ResourceProfile, RuntimeCredentialRequirement,
-    RuntimeCredentialRequirementSource, RuntimeCredentialTarget, RuntimeKind, SecretHandle,
-    TrustClass,
+    CapabilityId, CapabilityProfileId, CapabilityProfileSchemaRef, CapabilitySurfaceKind,
+    EffectKind, ExtensionId, HostApiError, HostPortCatalog, HostPortId, NetworkScheme,
+    NetworkTargetPattern, PermissionMode, RequestedTrustClass, ResourceProfile,
+    RuntimeCredentialAccountProviderId, RuntimeCredentialAccountSetup,
+    RuntimeCredentialRequirement, RuntimeCredentialRequirementSource, RuntimeCredentialTarget,
+    RuntimeKind, SecretHandle, TrustClass,
 };
 use serde::{Deserialize, Deserializer};
 use thiserror::Error;
@@ -238,6 +239,12 @@ pub struct HostApiManifestContext<'a> {
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct HostApiManifestProjection {
     pub capabilities: Vec<CapabilityDeclV2>,
+    /// Product-facing surface kinds the validated section declares (e.g. a
+    /// `channel` surface for an external-channel product-adapter section).
+    /// Tool and auth kinds are rejected here — they have dedicated
+    /// declaration paths (capability declarations and product-auth
+    /// credential requirements); see [`CapabilitySurfaceDeclV2`].
+    pub surfaces: Vec<CapabilitySurfaceKind>,
 }
 
 /// Host API contract validator registered by composition.
@@ -310,9 +317,9 @@ impl HostApiContractRegistry {
         manifest: &ExtensionManifestV2,
         sections: &ManifestSectionsV2,
         host_port_catalog: &HostPortCatalog,
-    ) -> Result<HostApiManifestProjection, ManifestV2Error> {
+    ) -> Result<ProjectedManifestV2, ManifestV2Error> {
         let mut counts: BTreeMap<&HostApiId, usize> = BTreeMap::new();
-        let mut projected = HostApiManifestProjection::default();
+        let mut projected = ProjectedManifestV2::default();
         let mut seen_capabilities = BTreeSet::new();
         for host_api in &manifest.host_apis {
             let contract = self.contracts.get(&host_api.id).ok_or_else(|| {
@@ -352,6 +359,32 @@ impl HostApiContractRegistry {
                 }
                 projected.capabilities.push(capability);
             }
+            for kind in section_projection.surfaces {
+                if matches!(
+                    kind,
+                    CapabilitySurfaceKind::Tool | CapabilitySurfaceKind::Auth
+                ) {
+                    // Fail closed: tool and auth surfaces derive from their
+                    // dedicated declaration paths. A contract projecting them
+                    // as opaque section surfaces is an implementation bug.
+                    return Err(ManifestV2Error::HostApiSectionRejected {
+                        id: host_api.id.clone(),
+                        section: host_api.section.clone(),
+                        reason: format!(
+                            "host API contracts must not project '{kind}' section surfaces; \
+                             tool surfaces derive from capability declarations and auth \
+                             surfaces from product-auth credential requirements"
+                        ),
+                    });
+                }
+                projected
+                    .surfaces
+                    .push(CapabilitySurfaceDeclV2::HostApiSection {
+                        kind,
+                        host_api: host_api.id.clone(),
+                        section: host_api.section.clone(),
+                    });
+            }
         }
         sections.reject_unreferenced_operational_sections(&manifest.host_apis)?;
         Ok(projected)
@@ -362,6 +395,15 @@ impl Default for HostApiContractRegistry {
     fn default() -> Self {
         Self::new()
     }
+}
+
+/// Aggregate of every host API contract projection for one manifest:
+/// projected capability declarations plus origin-stamped section surfaces.
+/// Internal to the parse path — contracts see [`HostApiManifestProjection`].
+#[derive(Debug, Default)]
+struct ProjectedManifestV2 {
+    capabilities: Vec<CapabilityDeclV2>,
+    surfaces: Vec<CapabilitySurfaceDeclV2>,
 }
 
 /// Validated v2 capability declaration.
@@ -383,6 +425,50 @@ pub struct CapabilityDeclV2 {
     /// this to populate its egress allowlist directly from the manifest.
     pub network_targets: Vec<NetworkTargetPattern>,
     pub resource_profile: Option<ResourceProfile>,
+}
+
+/// One product-facing surface a validated manifest declares, with the
+/// manifest declaration it derives from.
+///
+/// The surface set answers "which faces of this extension can be configured
+/// and enabled?" — tools, an external channel, provider accounts. It is
+/// derived vocabulary: the owning declarations (capability entries, host API
+/// sections, credential requirements) stay the single source of truth, and
+/// [`ExtensionManifestV2::capability_surfaces`] projects them on demand.
+/// Runtime kind deliberately plays no part in this taxonomy.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CapabilitySurfaceDeclV2 {
+    /// A model/host-callable capability. One per capability declaration
+    /// (top-level or host-API projected).
+    Tool { capability: CapabilityId },
+    /// A provider-account requirement, derived from `product_auth_account`
+    /// runtime-credential sources across all capabilities: one surface per
+    /// distinct provider. When several requirements name the same provider,
+    /// OAuth setups fold to the union of their scopes (sorted, deduplicated)
+    /// and mask weaker manual-token setups — the account is shared, so its
+    /// grant is the union of what the declaring capabilities need.
+    Auth {
+        provider: RuntimeCredentialAccountProviderId,
+        setup: RuntimeCredentialAccountSetup,
+    },
+    /// A surface projected by a host API contract section, stamped with the
+    /// owning contract id and section path (e.g. a `channel` surface from an
+    /// `ironclaw.product_adapter/v1` external-channel section).
+    HostApiSection {
+        kind: CapabilitySurfaceKind,
+        host_api: HostApiId,
+        section: ManifestSectionPath,
+    },
+}
+
+impl CapabilitySurfaceDeclV2 {
+    pub fn kind(&self) -> CapabilitySurfaceKind {
+        match self {
+            Self::Tool { .. } => CapabilitySurfaceKind::Tool,
+            Self::Auth { .. } => CapabilitySurfaceKind::Auth,
+            Self::HostApiSection { kind, .. } => *kind,
+        }
+    }
 }
 
 /// v2 runtime declaration.
@@ -470,6 +556,13 @@ pub struct ExtensionManifestV2 {
     /// [`requested_trust`](Self::requested_trust) request.
     pub host_apis: Vec<HostApiRefV2>,
     pub capabilities: Vec<CapabilityDeclV2>,
+    /// Surfaces projected by host API contract sections during
+    /// `parse_with_host_api_contracts` (channel and future section-declared
+    /// kinds). Tool and auth surfaces are *not* stored here — they derive on
+    /// demand from capability declarations; [`Self::capability_surfaces`]
+    /// returns the complete set. Empty when the manifest was parsed without
+    /// contracts or declares no surface-projecting sections.
+    pub host_api_surfaces: Vec<CapabilitySurfaceDeclV2>,
     /// Declarative hook entries the extension wants installed. Carried as
     /// structurally-typed [`HookSectionEntryV2`] payloads; the composition
     /// loader projects them into typed `ironclaw_hooks::HookManifestEntry`
@@ -704,7 +797,83 @@ impl ExtensionManifestV2 {
     ) -> Result<(), ManifestV2Error> {
         let projection = registry.project_manifest(self, sections, host_port_catalog)?;
         self.capabilities.extend(projection.capabilities);
+        self.host_api_surfaces.extend(projection.surfaces);
         Ok(())
+    }
+
+    /// Derived, order-stable projection of every product-facing surface this
+    /// manifest declares: one tool surface per capability (declaration
+    /// order), then host-API projected surfaces (declaration order), then
+    /// one auth surface per distinct product-auth provider (sorted by
+    /// provider id).
+    ///
+    /// This is the product taxonomy of the extension. Runtime kind (`wasm`,
+    /// `mcp`, `first_party`, ...) deliberately plays no part in it: how an
+    /// adapter loads never decides whether the extension is a tool provider,
+    /// a channel, or both.
+    pub fn capability_surfaces(&self) -> Vec<CapabilitySurfaceDeclV2> {
+        let mut surfaces: Vec<CapabilitySurfaceDeclV2> = self
+            .capabilities
+            .iter()
+            .map(|capability| CapabilitySurfaceDeclV2::Tool {
+                capability: capability.id.clone(),
+            })
+            .collect();
+        surfaces.extend(self.host_api_surfaces.iter().cloned());
+
+        // One auth surface per provider. OAuth setups fold to the union of
+        // their scopes and mask manual-token setups; a provider referenced
+        // only through retired setups still surfaces (as Retired) so
+        // discovery can see the unserviceable requirement instead of
+        // silently dropping it.
+        #[derive(Default)]
+        struct AuthAccumulator {
+            oauth_scopes: Option<BTreeSet<String>>,
+            saw_manual_token: bool,
+        }
+        let mut providers: BTreeMap<RuntimeCredentialAccountProviderId, AuthAccumulator> =
+            BTreeMap::new();
+        for capability in &self.capabilities {
+            for credential in &capability.runtime_credentials {
+                let RuntimeCredentialRequirementSource::ProductAuthAccount { provider, setup } =
+                    &credential.source
+                else {
+                    continue;
+                };
+                let accumulator = providers.entry(provider.clone()).or_default();
+                match setup {
+                    RuntimeCredentialAccountSetup::OAuth { scopes } => {
+                        accumulator
+                            .oauth_scopes
+                            .get_or_insert_with(BTreeSet::new)
+                            .extend(scopes.iter().cloned());
+                    }
+                    RuntimeCredentialAccountSetup::ManualToken => {
+                        accumulator.saw_manual_token = true;
+                    }
+                    RuntimeCredentialAccountSetup::Retired => {}
+                }
+            }
+        }
+        surfaces.extend(providers.into_iter().map(|(provider, accumulator)| {
+            CapabilitySurfaceDeclV2::Auth {
+                provider,
+                setup: match accumulator {
+                    AuthAccumulator {
+                        oauth_scopes: Some(scopes),
+                        ..
+                    } => RuntimeCredentialAccountSetup::OAuth {
+                        scopes: scopes.into_iter().collect(),
+                    },
+                    AuthAccumulator {
+                        saw_manual_token: true,
+                        ..
+                    } => RuntimeCredentialAccountSetup::ManualToken,
+                    AuthAccumulator { .. } => RuntimeCredentialAccountSetup::Retired,
+                },
+            }
+        }));
+        surfaces
     }
 
     /// Construct a manifest from an already-deserialized raw representation.
@@ -810,6 +979,7 @@ impl ExtensionManifestV2 {
             runtime,
             host_apis,
             capabilities,
+            host_api_surfaces: Vec::new(),
             hooks,
         })
     }

--- a/crates/ironclaw_extensions/tests/manifest_v2_contract.rs
+++ b/crates/ironclaw_extensions/tests/manifest_v2_contract.rs
@@ -3,15 +3,18 @@
 use std::sync::Arc;
 
 use ironclaw_extensions::{
-    CapabilityVisibility, ExtensionManifestV2, ExtensionRuntimeV2, HostApiContractRegistry,
-    HostApiId, HostApiManifestContract, HostApiMultiplicity, HostApiRefV2, MANIFEST_SCHEMA_VERSION,
-    ManifestSectionPath, ManifestSource, ManifestV2Error,
+    CapabilityProviderHostApiContract, CapabilitySurfaceDeclV2, CapabilityVisibility,
+    ExtensionManifestV2, ExtensionRuntimeV2, HostApiContractRegistry, HostApiId,
+    HostApiManifestContext, HostApiManifestContract, HostApiManifestProjection,
+    HostApiMultiplicity, HostApiRefV2, MANIFEST_SCHEMA_VERSION, ManifestSectionPath,
+    ManifestSource, ManifestV2Error,
 };
 use ironclaw_host_api::{
-    CapabilityProfileId, ExtensionId, HostPortCatalog, HostPortCatalogEntry, HostPortId,
-    NetworkScheme, NetworkTargetPattern, PermissionMode, RequestedTrustClass,
-    RuntimeCredentialAccountProviderId, RuntimeCredentialRequirementSource,
-    RuntimeCredentialTarget, RuntimeKind, SecretHandle, TrustClass,
+    CapabilityProfileId, CapabilitySurfaceKind, ExtensionId, HostPortCatalog, HostPortCatalogEntry,
+    HostPortId, NetworkScheme, NetworkTargetPattern, PermissionMode, RequestedTrustClass,
+    RuntimeCredentialAccountProviderId, RuntimeCredentialAccountSetup,
+    RuntimeCredentialRequirementSource, RuntimeCredentialTarget, RuntimeKind, SecretHandle,
+    TrustClass,
 };
 
 const TELEGRAM_TOKEN_PORT: &str = "host.secrets.telegram_bot_token";
@@ -1595,4 +1598,349 @@ surface_kind = "telegram"
         matches!(err, ManifestV2Error::DuplicateHostApiSection { .. }),
         "{err:?}"
     );
+}
+
+// ---------------------------------------------------------------------------
+// Capability surface projection
+//
+// The manifest is the single source of truth for which product-facing
+// surfaces an extension declares. `capability_surfaces()` derives tool and
+// auth surfaces from capability declarations and retains contract-projected
+// surfaces (e.g. channel) from `[[host_api]]` sections. Runtime kind must
+// never leak into this taxonomy.
+// ---------------------------------------------------------------------------
+
+/// Fake contract that projects declared surface kinds for its section, the
+/// way `ironclaw.product_adapter/v1` projects a channel surface for
+/// `external_channel` sections.
+struct SurfaceProjectingContract {
+    id: HostApiId,
+    prefix: &'static str,
+    surfaces: Vec<CapabilitySurfaceKind>,
+}
+
+impl HostApiManifestContract for SurfaceProjectingContract {
+    fn id(&self) -> &HostApiId {
+        &self.id
+    }
+
+    fn multiplicity(&self) -> HostApiMultiplicity {
+        HostApiMultiplicity::Multiple
+    }
+
+    fn accepts_section_path(&self, section: &ManifestSectionPath) -> bool {
+        section
+            .as_str()
+            .strip_prefix(self.prefix)
+            .is_some_and(|rest| rest.is_empty() || rest.starts_with('.'))
+    }
+
+    fn validate_section(
+        &self,
+        _host_api: &HostApiRefV2,
+        _section: &toml::Value,
+    ) -> Result<(), String> {
+        Ok(())
+    }
+
+    fn project_section_with_context(
+        &self,
+        _context: &HostApiManifestContext<'_>,
+        _host_api: &HostApiRefV2,
+        _section: &toml::Value,
+    ) -> Result<HostApiManifestProjection, String> {
+        Ok(HostApiManifestProjection {
+            surfaces: self.surfaces.clone(),
+            ..HostApiManifestProjection::default()
+        })
+    }
+}
+
+fn google_backed_manifest(extension_id: &str, handle: &str, scopes: &str) -> String {
+    format!(
+        r#"
+schema_version = "{schema}"
+id = "{ext}"
+name = "Example Google-backed Extension"
+version = "0.1.0"
+description = "test"
+trust = "third_party"
+
+[runtime]
+kind = "wasm"
+module = "wasm/example.wasm"
+
+[[capabilities]]
+id = "{ext}.read"
+description = "Reads provider data"
+effects = ["network", "use_secret"]
+runtime_credentials = [
+  {{ handle = "{handle}", source = {{ type = "product_auth_account", provider = "google", setup = {{ kind = "oauth", scopes = {scopes} }} }}, audience = {{ scheme = "https", host_pattern = "www.googleapis.com" }}, target = {{ type = "header", name = "authorization", prefix = "Bearer " }} }},
+]
+default_permission = "ask"
+visibility = "model"
+input_schema_ref = "schemas/example/read.input.v1.json"
+output_schema_ref = "schemas/example/read.output.v1.json"
+"#,
+        schema = MANIFEST_SCHEMA_VERSION,
+        ext = extension_id,
+        handle = handle,
+        scopes = scopes,
+    )
+}
+
+#[test]
+fn tool_only_manifest_projects_one_tool_surface_per_capability_and_nothing_else() {
+    let toml = third_party_wasm_manifest("acme-tools", "acme-tools.echo");
+    let manifest =
+        ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog()).unwrap();
+
+    let surfaces = manifest.capability_surfaces();
+    assert_eq!(surfaces.len(), 1, "{surfaces:?}");
+    match &surfaces[0] {
+        CapabilitySurfaceDeclV2::Tool { capability } => {
+            assert_eq!(capability.as_str(), "acme-tools.echo");
+        }
+        other => panic!("expected a tool surface, got {other:?}"),
+    }
+    assert_eq!(surfaces[0].kind(), CapabilitySurfaceKind::Tool);
+}
+
+#[test]
+fn product_auth_credentials_project_one_auth_surface_per_provider_with_unioned_scopes() {
+    // Three capabilities against one provider: two OAuth requirements with
+    // overlapping scopes and one manual-token requirement. The extension
+    // needs ONE provider account whose OAuth grant is the union of the
+    // declared scopes (sorted, deduplicated); the weaker manual-token setup
+    // must not mask the OAuth setup.
+    let toml = format!(
+        r#"
+schema_version = "{schema}"
+id = "acme-tools"
+name = "Acme"
+version = "0.1.0"
+description = "test"
+trust = "third_party"
+
+[runtime]
+kind = "wasm"
+module = "wasm/example.wasm"
+
+[[capabilities]]
+id = "acme-tools.search"
+description = "Search"
+effects = ["network", "use_secret"]
+runtime_credentials = [
+  {{ handle = "acme_account", source = {{ type = "product_auth_account", provider = "acme", setup = {{ kind = "oauth", scopes = ["read:b", "read:a"] }} }}, audience = {{ scheme = "https", host_pattern = "api.acme.com" }}, target = {{ type = "header", name = "authorization", prefix = "Bearer " }} }},
+]
+default_permission = "ask"
+visibility = "model"
+input_schema_ref = "schemas/acme/search.input.v1.json"
+output_schema_ref = "schemas/acme/search.output.v1.json"
+
+[[capabilities]]
+id = "acme-tools.send"
+description = "Send"
+effects = ["network", "use_secret"]
+runtime_credentials = [
+  {{ handle = "acme_account", source = {{ type = "product_auth_account", provider = "acme", setup = {{ kind = "oauth", scopes = ["read:a", "write:a"] }} }}, audience = {{ scheme = "https", host_pattern = "api.acme.com" }}, target = {{ type = "header", name = "authorization", prefix = "Bearer " }} }},
+]
+default_permission = "ask"
+visibility = "model"
+input_schema_ref = "schemas/acme/send.input.v1.json"
+output_schema_ref = "schemas/acme/send.output.v1.json"
+
+[[capabilities]]
+id = "acme-tools.legacy"
+description = "Legacy manual-token path"
+effects = ["network", "use_secret"]
+runtime_credentials = [
+  {{ handle = "acme_manual", source = {{ type = "product_auth_account", provider = "acme", setup = {{ kind = "manual_token" }} }}, audience = {{ scheme = "https", host_pattern = "api.acme.com" }}, target = {{ type = "header", name = "authorization", prefix = "Bearer " }} }},
+]
+default_permission = "ask"
+visibility = "model"
+input_schema_ref = "schemas/acme/legacy.input.v1.json"
+output_schema_ref = "schemas/acme/legacy.output.v1.json"
+"#,
+        schema = MANIFEST_SCHEMA_VERSION,
+    );
+    let manifest =
+        ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog()).unwrap();
+
+    let auth_surfaces: Vec<_> = manifest
+        .capability_surfaces()
+        .into_iter()
+        .filter(|surface| surface.kind() == CapabilitySurfaceKind::Auth)
+        .collect();
+    assert_eq!(auth_surfaces.len(), 1, "{auth_surfaces:?}");
+    match &auth_surfaces[0] {
+        CapabilitySurfaceDeclV2::Auth { provider, setup } => {
+            assert_eq!(
+                provider,
+                &RuntimeCredentialAccountProviderId::new("acme").unwrap()
+            );
+            assert_eq!(
+                setup,
+                &RuntimeCredentialAccountSetup::OAuth {
+                    scopes: vec![
+                        "read:a".to_string(),
+                        "read:b".to_string(),
+                        "write:a".to_string(),
+                    ],
+                }
+            );
+        }
+        other => panic!("expected an auth surface, got {other:?}"),
+    }
+}
+
+#[test]
+fn extensions_sharing_one_provider_project_the_same_auth_provider() {
+    // Gmail and Google Drive stay separate extensions but share the `google`
+    // credential authority: the provider id is a credential-authority
+    // namespace, distinct from every extension id that uses it.
+    let gmail = ExtensionManifestV2::parse(
+        &google_backed_manifest(
+            "gmail",
+            "gmail_account",
+            r#"["https://www.googleapis.com/auth/gmail.readonly"]"#,
+        ),
+        ManifestSource::InstalledLocal,
+        &catalog(),
+    )
+    .unwrap();
+    let drive = ExtensionManifestV2::parse(
+        &google_backed_manifest(
+            "google-drive",
+            "google_runtime_token",
+            r#"["https://www.googleapis.com/auth/drive.readonly"]"#,
+        ),
+        ManifestSource::InstalledLocal,
+        &catalog(),
+    )
+    .unwrap();
+
+    let provider_of = |manifest: &ExtensionManifestV2| {
+        manifest
+            .capability_surfaces()
+            .into_iter()
+            .find_map(|surface| match surface {
+                CapabilitySurfaceDeclV2::Auth { provider, .. } => Some(provider),
+                _ => None,
+            })
+            .expect("google-backed manifest must project an auth surface")
+    };
+
+    let gmail_provider = provider_of(&gmail);
+    let drive_provider = provider_of(&drive);
+    let google = RuntimeCredentialAccountProviderId::new("google").unwrap();
+    assert_eq!(gmail_provider, google);
+    assert_eq!(drive_provider, google);
+    // The provider namespace is not the extension id.
+    assert_ne!(gmail_provider.as_str(), gmail.id.as_str());
+    assert_ne!(drive_provider.as_str(), drive.id.as_str());
+}
+
+#[test]
+fn contract_projected_channel_surface_is_retained_with_origin() {
+    // Tool + channel extension: the real capability-provider contract
+    // projects the tool capability; a channel-projecting host API contract
+    // (the product-adapter shape) projects the channel surface. Both must
+    // surface from one manifest, and runtime kind must not decide either.
+    let mut registry = HostApiContractRegistry::new();
+    registry
+        .register(Arc::new(CapabilityProviderHostApiContract::new().unwrap()))
+        .unwrap();
+    registry
+        .register(Arc::new(SurfaceProjectingContract {
+            id: HostApiId::new("ironclaw.product_adapter/v1").unwrap(),
+            prefix: "product_adapter",
+            surfaces: vec![CapabilitySurfaceKind::Channel],
+        }))
+        .unwrap();
+
+    let manifest = ExtensionManifestV2::parse_with_host_api_contracts(
+        &telegram_multi_host_api_manifest(),
+        ManifestSource::InstalledLocal,
+        &catalog(),
+        &registry,
+    )
+    .unwrap();
+
+    let surfaces = manifest.capability_surfaces();
+    let kinds: Vec<_> = surfaces.iter().map(|surface| surface.kind()).collect();
+    assert_eq!(
+        kinds,
+        vec![CapabilitySurfaceKind::Tool, CapabilitySurfaceKind::Channel],
+        "{surfaces:?}"
+    );
+    match &surfaces[0] {
+        CapabilitySurfaceDeclV2::Tool { capability } => {
+            assert_eq!(capability.as_str(), "telegram.send_message");
+        }
+        other => panic!("expected a tool surface, got {other:?}"),
+    }
+    match &surfaces[1] {
+        CapabilitySurfaceDeclV2::HostApiSection {
+            kind,
+            host_api,
+            section,
+        } => {
+            assert_eq!(*kind, CapabilitySurfaceKind::Channel);
+            assert_eq!(host_api.as_str(), "ironclaw.product_adapter/v1");
+            assert_eq!(section.as_str(), "product_adapter.inbound");
+        }
+        other => panic!("expected a channel surface, got {other:?}"),
+    }
+}
+
+#[test]
+fn contracts_cannot_project_tool_or_auth_section_surfaces() {
+    // Tool and auth surfaces each have a dedicated declaration path
+    // (capability declarations and product-auth credential requirements). A
+    // contract that tries to project them as opaque section surfaces is a
+    // contract-implementation bug and must fail closed.
+    for bad_kind in [CapabilitySurfaceKind::Tool, CapabilitySurfaceKind::Auth] {
+        let mut registry = HostApiContractRegistry::new();
+        registry
+            .register(Arc::new(SurfaceProjectingContract {
+                id: HostApiId::new("ironclaw.product_adapter/v1").unwrap(),
+                prefix: "product_adapter",
+                surfaces: vec![bad_kind],
+            }))
+            .unwrap();
+        let toml = format!(
+            r#"
+schema_version = "{schema}"
+id = "telegram"
+name = "Telegram"
+version = "0.1.0"
+description = "Telegram product adapter"
+trust = "third_party"
+
+[runtime]
+kind = "wasm"
+module = "wasm/telegram.wasm"
+
+[[host_api]]
+id = "ironclaw.product_adapter/v1"
+section = "product_adapter.inbound"
+
+[product_adapter.inbound]
+surface_kind = "telegram"
+"#,
+            schema = MANIFEST_SCHEMA_VERSION,
+        );
+        let err = ExtensionManifestV2::parse_with_host_api_contracts(
+            &toml,
+            ManifestSource::InstalledLocal,
+            &catalog(),
+            &registry,
+        )
+        .unwrap_err();
+        assert!(
+            matches!(err, ManifestV2Error::HostApiSectionRejected { .. }),
+            "projecting {bad_kind:?} must fail closed, got {err:?}"
+        );
+    }
 }

--- a/crates/ironclaw_host_api/src/lib.rs
+++ b/crates/ironclaw_host_api/src/lib.rs
@@ -50,6 +50,7 @@ pub mod resource;
 pub mod runtime;
 pub mod runtime_policy;
 pub mod scope;
+pub mod surface;
 pub mod trust;
 
 // Flat re-exports are intentional: downstream Reborn service crates consume
@@ -73,6 +74,7 @@ pub use resource::*;
 pub use runtime::*;
 pub use runtime_policy::*;
 pub use scope::*;
+pub use surface::*;
 pub use trust::*;
 
 /// Canonical timestamp type for host API wire contracts.

--- a/crates/ironclaw_host_api/src/surface.rs
+++ b/crates/ironclaw_host_api/src/surface.rs
@@ -1,0 +1,80 @@
+//! Capability-surface vocabulary.
+//!
+//! A *capability surface* is one product-facing face an installed extension
+//! declares through its manifest: model-callable tools, an external chat
+//! channel, credential/account acquisition, and (reserved) triggers and file
+//! exchange. The surface kind answers "which faces of this extension can be
+//! configured and enabled?" — it is product taxonomy.
+//!
+//! [`crate::RuntimeKind`] is deliberately *not* part of this vocabulary: how
+//! an adapter is loaded (`wasm`, `mcp`, `first_party`, ...) never decides
+//! whether something is a tool, a channel, or an extension.
+
+use serde::{Deserialize, Serialize};
+
+/// The kind of product-facing surface a manifest declaration projects.
+///
+/// Extensions declare any combination of these; hosts discover and wire
+/// generic services from the declared kinds instead of maintaining separate
+/// per-kind registries beside the extension registry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CapabilitySurfaceKind {
+    /// Model/host-callable capability (a tool), e.g. `slack.search_messages`.
+    Tool,
+    /// External conversation surface: event ingress, verification, identity
+    /// binding, and reply egress (e.g. the Slack Events API surface).
+    Channel,
+    /// Credential/account acquisition the extension's other surfaces depend
+    /// on (OAuth accounts, provider tokens).
+    Auth,
+    /// External event/schedule trigger surface. Reserved: no manifest section
+    /// projects this kind yet.
+    Trigger,
+    /// File/attachment exchange surface. Reserved: no manifest section
+    /// projects this kind yet.
+    File,
+}
+
+impl CapabilitySurfaceKind {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Tool => "tool",
+            Self::Channel => "channel",
+            Self::Auth => "auth",
+            Self::Trigger => "trigger",
+            Self::File => "file",
+        }
+    }
+}
+
+impl std::fmt::Display for CapabilitySurfaceKind {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CapabilitySurfaceKind;
+
+    /// Wire shape is snake_case and round-trips; the string form matches the
+    /// serde form so downstream wire fields cannot drift from `as_str()`.
+    #[test]
+    fn surface_kind_wire_shape_is_snake_case_and_matches_as_str() {
+        for (kind, wire) in [
+            (CapabilitySurfaceKind::Tool, "\"tool\""),
+            (CapabilitySurfaceKind::Channel, "\"channel\""),
+            (CapabilitySurfaceKind::Auth, "\"auth\""),
+            (CapabilitySurfaceKind::Trigger, "\"trigger\""),
+            (CapabilitySurfaceKind::File, "\"file\""),
+        ] {
+            assert_eq!(serde_json::to_string(&kind).unwrap(), wire);
+            assert_eq!(
+                serde_json::from_str::<CapabilitySurfaceKind>(wire).unwrap(),
+                kind
+            );
+            assert_eq!(format!("\"{kind}\""), wire);
+        }
+    }
+}

--- a/crates/ironclaw_product_adapter_registry/CLAUDE.md
+++ b/crates/ironclaw_product_adapter_registry/CLAUDE.md
@@ -61,5 +61,10 @@ Owns ProductAdapter host-api projection contracts for IronClaw Reborn.
   ingress credential-coherence matrix (undeclared handle, auth-required route
   missing a credential, duplicate route id, happy projection) has focused
   unit coverage in `src/lib.rs` `mod tests`.
+- Capability-surface projection: the `ironclaw.product_adapter/v1` contract
+  projects a `channel` capability surface for `external_channel` sections
+  (host-native `web`/`cli`/`synchronous_api` sections project none); pinned
+  in `tests/manifest_ingestion.rs` through the real contract. The surface
+  vocabulary contract lives in `docs/reborn/contracts/extensions.md`.
 - `cargo test -p ironclaw_architecture reborn_crate_dependency_boundaries_hold`
   pins crate dependency boundary.

--- a/crates/ironclaw_product_adapter_registry/src/lib.rs
+++ b/crates/ironclaw_product_adapter_registry/src/lib.rs
@@ -18,11 +18,12 @@ use std::sync::Arc;
 use ironclaw_extensions::{
     ExtensionInstallation, ExtensionInstallationError, ExtensionInstallationStore,
     ExtensionManifestRecord, ExtensionManifestV2, HostApiContractRegistry, HostApiId,
-    HostApiManifestContext, HostApiManifestContract, HostApiMultiplicity, HostApiRefV2,
-    ManifestSectionPath, ManifestSource, ManifestV2Error,
+    HostApiManifestContext, HostApiManifestContract, HostApiManifestProjection,
+    HostApiMultiplicity, HostApiRefV2, ManifestSectionPath, ManifestSource, ManifestV2Error,
 };
 use ironclaw_host_api::{
-    ExtensionId, HostPortCatalog, IngressAuthPolicy, IngressRouteDescriptor, IngressRouteId,
+    CapabilitySurfaceKind, ExtensionId, HostPortCatalog, IngressAuthPolicy, IngressRouteDescriptor,
+    IngressRouteId,
 };
 use ironclaw_product_adapters::{
     AuthRequirement, DeclaredEgressTarget, EgressCredentialHandle, ProductAdapterCapabilities,
@@ -424,6 +425,34 @@ impl HostApiManifestContract for ProductAdapterHostApiContract {
         )
         .map(|_| ())
         .map_err(|e| e.to_string())
+    }
+
+    fn project_section_with_context(
+        &self,
+        context: &HostApiManifestContext<'_>,
+        host_api: &HostApiRefV2,
+        section: &toml::Value,
+    ) -> Result<HostApiManifestProjection, String> {
+        let parsed = ProductAdapterHostApiSection::from_value(
+            context.extension_id,
+            host_api.section.clone(),
+            section.clone(),
+        )
+        .map_err(|e| e.to_string())?;
+        // External-channel adapter sections are the extension's channel
+        // surface. The other product surface kinds (`web`, `cli`,
+        // `synchronous_api`) describe host-native surfaces and project no
+        // extension surface.
+        let surfaces = match parsed.surface_kind() {
+            ProductSurfaceKind::ExternalChannel => vec![CapabilitySurfaceKind::Channel],
+            ProductSurfaceKind::Web
+            | ProductSurfaceKind::Cli
+            | ProductSurfaceKind::SynchronousApi => Vec::new(),
+        };
+        Ok(HostApiManifestProjection {
+            capabilities: Vec::new(),
+            surfaces,
+        })
     }
 }
 

--- a/crates/ironclaw_product_adapter_registry/tests/manifest_ingestion.rs
+++ b/crates/ironclaw_product_adapter_registry/tests/manifest_ingestion.rs
@@ -1,5 +1,7 @@
-use ironclaw_extensions::{ExtensionManifestRecord, MANIFEST_SCHEMA_VERSION, ManifestSource};
-use ironclaw_host_api::HostPortCatalog;
+use ironclaw_extensions::{
+    CapabilitySurfaceDeclV2, ExtensionManifestRecord, MANIFEST_SCHEMA_VERSION, ManifestSource,
+};
+use ironclaw_host_api::{CapabilitySurfaceKind, HostPortCatalog};
 use ironclaw_product_adapter_registry::{
     ManifestHash, RegistryError, parse_product_adapter_manifest_record, product_adapter_sections,
 };
@@ -264,5 +266,58 @@ flags = ["inbound_messages"]
     assert!(
         err.to_string().contains("invalid adapter_id"),
         "expected adapter_id validation error, got {err:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Capability-surface projection through the real product-adapter contract
+// ---------------------------------------------------------------------------
+
+#[test]
+fn external_channel_section_projects_a_channel_capability_surface() {
+    let record = parse(&manifest("")).unwrap();
+    let surfaces = record.manifest().capability_surfaces();
+    let channels: Vec<_> = surfaces
+        .iter()
+        .filter(|surface| surface.kind() == CapabilitySurfaceKind::Channel)
+        .collect();
+    assert_eq!(channels.len(), 1, "{surfaces:?}");
+    match channels[0] {
+        CapabilitySurfaceDeclV2::HostApiSection {
+            kind,
+            host_api,
+            section,
+        } => {
+            assert_eq!(*kind, CapabilitySurfaceKind::Channel);
+            assert_eq!(host_api.as_str(), "ironclaw.product_adapter/v1");
+            assert_eq!(section.as_str(), "product_adapter.inbound");
+        }
+        other => panic!("expected a host-API channel surface, got {other:?}"),
+    }
+    // An adapter-only manifest declares no tools: the wasm runtime kind must
+    // not leak a tool (or any other) surface into the product taxonomy.
+    assert!(
+        surfaces
+            .iter()
+            .all(|surface| surface.kind() == CapabilitySurfaceKind::Channel),
+        "{surfaces:?}"
+    );
+}
+
+#[test]
+fn host_native_product_surface_kinds_project_no_channel_surface() {
+    // `web` / `cli` / `synchronous_api` product-adapter sections describe
+    // host-native surfaces; they are not extension channel surfaces.
+    let toml = manifest("").replace(
+        r#"surface_kind = "external_channel""#,
+        r#"surface_kind = "web""#,
+    );
+    let record = parse(&toml).unwrap();
+    let surfaces = record.manifest().capability_surfaces();
+    assert!(
+        surfaces
+            .iter()
+            .all(|surface| surface.kind() != CapabilitySurfaceKind::Channel),
+        "{surfaces:?}"
     );
 }

--- a/docs/reborn/contracts/extensions.md
+++ b/docs/reborn/contracts/extensions.md
@@ -249,6 +249,47 @@ Migration rules:
 - Do not mix `[[host_api]]` with top-level `[[capabilities]]` in one manifest.
 - Deprecated path scope is only legacy top-level capability declarations for installed third-party manifests; extension manifest v2 itself remains active.
 
+### Capability surfaces
+
+The extension is the top-level product object; a *capability surface* is one
+product-facing face the manifest declares. `CapabilitySurfaceKind`
+(`ironclaw_host_api`) enumerates the vocabulary: `tool`, `channel`, `auth`,
+plus reserved `trigger` and `file`. The host discovers and wires generic
+services from declared surfaces; it must not maintain a separate first-class
+channel registry beside the extension registry, and runtime kind (`wasm` /
+`mcp` / `first_party`) must never decide surface taxonomy.
+
+Rules:
+
+- Surfaces are **derived** vocabulary. The owning manifest declarations stay
+  the single source of truth; `ExtensionManifestV2::capability_surfaces()`
+  projects them on demand:
+  - each capability declaration projects one `tool` surface;
+  - each host API contract section projects the surface kinds its contract
+    declares via `HostApiManifestProjection::surfaces` (the
+    `ironclaw.product_adapter/v1` contract projects `channel` for
+    `external_channel` sections; host-native product surface kinds — `web`,
+    `cli`, `synchronous_api` — project nothing), origin-stamped with the
+    owning host API id and section path;
+  - `product_auth_account` runtime-credential sources project one `auth`
+    surface per distinct provider id. OAuth setups fold to the union of
+    declared scopes (sorted, deduplicated) and mask weaker manual-token
+    setups; a provider referenced only through retired setups surfaces as
+    retired rather than being dropped.
+- Host API contracts must not project `tool` or `auth` section surfaces —
+  those kinds have dedicated declaration paths above. Validation fails
+  closed.
+- `ProviderId` (`RuntimeCredentialAccountProviderId`) is the credential
+  authority namespace, not the extension id: several extensions (gmail,
+  google-drive, ...) may share one provider (`google`).
+
+Tests: `crates/ironclaw_extensions/tests/manifest_v2_contract.rs`
+(capability surface projection block) and
+`crates/ironclaw_product_adapter_registry/tests/manifest_ingestion.rs`
+(channel-surface projection through the real product-adapter contract). Run:
+`cargo test -p ironclaw_extensions --test manifest_v2_contract` and
+`cargo test -p ironclaw_product_adapter_registry --test manifest_ingestion`.
+
 ---
 
 ## 5. Runtime declarations
@@ -416,6 +457,11 @@ Local contract tests should prove:
 - discovery reads manifests via `RootFilesystem` and `/system/extensions` virtual paths.
 - discovery rejects missing manifest.
 - discovery rejects manifest ID mismatch with directory name.
+- capability-surface projection: tool-only, channel-only, and tool+channel
+  manifests project exactly their declared surfaces; auth surfaces group by
+  provider with unioned OAuth scopes; extensions sharing one provider project
+  the same provider id (distinct from their extension ids); contracts
+  projecting `tool`/`auth` section surfaces fail closed.
 
 ---
 


### PR DESCRIPTION
## Summary

Stack PR 1/7 for NEA-25 (unified extension surfaces — the top-level product object is always an **extension**; a channel is one capability surface an extension declares, not a sibling product type).

- Adds `CapabilitySurfaceKind` (`tool` / `channel` / `auth` + reserved `trigger` / `file`) to `ironclaw_host_api` — shared vocabulary beside `RuntimeKind`. Placement note: `product_workflow` depends on `host_api` but not on `ironclaw_extensions`, so the vocabulary lives in host_api to keep the facade layer off substrate types.
- Derives an order-stable `ExtensionManifestV2::capability_surfaces()` projection:
  - one `tool` surface per capability declaration (top-level or `capability_provider` projected);
  - host-API contract sections project their declared kinds via `HostApiManifestProjection::surfaces`, origin-stamped with the owning host-API id + section path — the real `ironclaw.product_adapter/v1` contract projects `channel` for `external_channel` sections; host-native `web`/`cli`/`synchronous_api` sections project none;
  - one `auth` surface per distinct product-auth provider (OAuth scopes unioned sorted-dedup; OAuth masks weaker manual-token setups; retired-only providers surface as retired rather than being dropped).
- Fail closed: a contract projecting `tool`/`auth` section surfaces is rejected — those kinds have dedicated declaration paths.
- `RuntimeKind` stays internal: runtime never decides surface taxonomy.
- Contract doc: `docs/reborn/contracts/extensions.md` new "Capability surfaces" section names the pinned tests (house pattern).

No product behavior change: existing manifests parse unchanged; surfaces are derived read-model vocabulary consumed by the next PRs in the stack (surface discovery replaces the connectable-channels rail; Slack unifies to one `slack` extension).

## Testing

- `cargo test -p ironclaw_host_api` — wire-shape pin for the new enum
- `cargo test -p ironclaw_extensions --test manifest_v2_contract` — 52 pass, incl. new: tool-only projection; per-provider auth surface with unioned scopes; gmail/google-drive-shaped manifests sharing provider `google` with provider id ≠ extension id; tool+channel manifest via the real capability-provider contract + a channel-projecting contract; fail-closed tool/auth section-surface rejection
- `cargo test -p ironclaw_product_adapter_registry` — incl. new caller-level tests through `parse_product_adapter_manifest_record` with the real contract: `external_channel` section → channel surface with origin; `web` section → none
- `cargo test -p ironclaw_architecture` — boundary tests pass
- `cargo clippy` on the three touched crates — clean; `cargo check -p ironclaw_host_runtime -p ironclaw_reborn_composition -p ironclaw_reborn_migration --all-features` — clean
- Not run: `--features integration` (no DB-shaped change; substrate parser/vocabulary only — integration harness has no seam observing a pure manifest projection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)