### PR TITLE
refactor(extensions)!: complete manifest v2 cutover — host_api contracts everywhere (NEA-25 stack 2/7)

### DIFF
--- a/crates/ironclaw_capabilities/tests/capability_host_run_state_contract.rs
+++ b/crates/ironclaw_capabilities/tests/capability_host_run_state_contract.rs
@@ -77,7 +77,13 @@ trust = "third_party"
 kind = "wasm"
 module = "builtin.wasm"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "builtin.shell"
 description = "Runs a shell command."
 effects = ["dispatch_capability", "spawn_process", "execute_code", "network"]
@@ -90,6 +96,7 @@ output_schema_ref = "schemas/shell.output.v1.json"
         manifest_toml,
         ManifestSource::InstalledLocal,
         &HostPortCatalog::empty(),
+        &capability_provider_contracts(),
     )
     .unwrap();
     let package = ExtensionPackage::from_manifest(
@@ -2282,4 +2289,15 @@ impl CapabilityLeaseStore for ConsumeFailingLeaseStore {
     async fn active_leases_for_context(&self, context: &ExecutionContext) -> Vec<CapabilityLease> {
         self.inner.active_leases_for_context(context).await
     }
+}
+
+fn capability_provider_contracts() -> ironclaw_extensions::HostApiContractRegistry {
+    let mut contracts = ironclaw_extensions::HostApiContractRegistry::new();
+    contracts
+        .register(std::sync::Arc::new(
+            ironclaw_extensions::CapabilityProviderHostApiContract::new()
+                .expect("capability provider contract"),
+        ))
+        .expect("register capability provider contract");
+    contracts
 }

--- a/crates/ironclaw_capabilities/tests/capability_host_spawn_contract.rs
+++ b/crates/ironclaw_capabilities/tests/capability_host_spawn_contract.rs
@@ -78,7 +78,13 @@ trust = "third_party"
 kind = "wasm"
 module = "acme.wasm"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "acme.shell"
 description = "Runs a shell command."
 effects = ["dispatch_capability", "spawn_process", "execute_code", "network"]
@@ -91,6 +97,7 @@ output_schema_ref = "schemas/shell.output.v1.json"
         manifest_toml,
         ManifestSource::InstalledLocal,
         &HostPortCatalog::empty(),
+        &capability_provider_contracts(),
     )
     .unwrap();
     let package = ExtensionPackage::from_manifest(
@@ -623,4 +630,15 @@ impl TrustAwareCapabilityDispatchAuthorizer for SpawnAuthorizer {
             obligations: Obligations::empty(),
         }
     }
+}
+
+fn capability_provider_contracts() -> ironclaw_extensions::HostApiContractRegistry {
+    let mut contracts = ironclaw_extensions::HostApiContractRegistry::new();
+    contracts
+        .register(std::sync::Arc::new(
+            ironclaw_extensions::CapabilityProviderHostApiContract::new()
+                .expect("capability provider contract"),
+        ))
+        .expect("register capability provider contract");
+    contracts
 }

--- a/crates/ironclaw_capabilities/tests/support/mod.rs
+++ b/crates/ironclaw_capabilities/tests/support/mod.rs
@@ -157,6 +157,7 @@ pub fn registry_with_echo_capability() -> ExtensionRegistry {
         ECHO_MANIFEST,
         ManifestSource::InstalledLocal,
         &HostPortCatalog::empty(),
+        &capability_provider_contracts(),
     )
     .unwrap();
     let package = ExtensionPackage::from_manifest(
@@ -174,6 +175,7 @@ pub fn registry_with_github_comment_capability() -> ExtensionRegistry {
         GITHUB_COMMENT_MANIFEST,
         ManifestSource::InstalledLocal,
         &HostPortCatalog::empty(),
+        &capability_provider_contracts(),
     )
     .unwrap();
     let package = ExtensionPackage::from_manifest(
@@ -270,7 +272,13 @@ trust = "third_party"
 kind = "wasm"
 module = "echo.wasm"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "echo.say"
 description = "Echoes input"
 effects = ["dispatch_capability"]
@@ -292,7 +300,13 @@ trust = "third_party"
 kind = "wasm"
 module = "wasm/github_tool.wasm"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "github.comment_issue"
 description = "Add a comment to a GitHub issue or pull request."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
@@ -302,3 +316,14 @@ input_schema_ref = "schemas/github/comment_issue.input.v1.json"
 output_schema_ref = "schemas/github/comment_issue.output.v1.json"
 prompt_doc_ref = "prompts/github/comment_issue.md"
 "#;
+
+fn capability_provider_contracts() -> ironclaw_extensions::HostApiContractRegistry {
+    let mut contracts = ironclaw_extensions::HostApiContractRegistry::new();
+    contracts
+        .register(std::sync::Arc::new(
+            ironclaw_extensions::CapabilityProviderHostApiContract::new()
+                .expect("capability provider contract"),
+        ))
+        .expect("register capability provider contract");
+    contracts
+}

--- a/crates/ironclaw_dispatcher/tests/dispatch_contract.rs
+++ b/crates/ironclaw_dispatcher/tests/dispatch_contract.rs
@@ -524,6 +524,7 @@ fn parse_manifest(manifest: &str) -> ExtensionManifest {
         &manifest,
         ManifestSource::InstalledLocal,
         &HostPortCatalog::empty(),
+        &capability_provider_contracts(),
     )
     .unwrap()
 }
@@ -600,3 +601,14 @@ effects = ["dispatch_capability"]
 default_permission = "allow"
 parameters_schema = { type = "object" }
 "#;
+
+fn capability_provider_contracts() -> ironclaw_extensions::HostApiContractRegistry {
+    let mut contracts = ironclaw_extensions::HostApiContractRegistry::new();
+    contracts
+        .register(std::sync::Arc::new(
+            ironclaw_extensions::CapabilityProviderHostApiContract::new()
+                .expect("capability provider contract"),
+        ))
+        .expect("register capability provider contract");
+    contracts
+}

--- a/crates/ironclaw_dispatcher/tests/event_dispatch_contract.rs
+++ b/crates/ironclaw_dispatcher/tests/event_dispatch_contract.rs
@@ -474,7 +474,7 @@ async fn discover_legacy_fixture_registry(fs: &LocalFilesystem) -> ExtensionRegi
         &VirtualPath::new("/system/extensions").unwrap(),
         ManifestSource::HostBundled,
         &HostPortCatalog::empty(),
-        &HostApiContractRegistry::new(),
+        &capability_provider_contracts(),
     )
     .await
     .unwrap()
@@ -510,6 +510,7 @@ fn parse_manifest(manifest: &str) -> ExtensionManifest {
         &manifest,
         ManifestSource::InstalledLocal,
         &HostPortCatalog::empty(),
+        &capability_provider_contracts(),
     )
     .unwrap()
 }
@@ -586,3 +587,14 @@ effects = ["dispatch_capability"]
 default_permission = "allow"
 parameters_schema = { type = "object" }
 "#;
+
+fn capability_provider_contracts() -> ironclaw_extensions::HostApiContractRegistry {
+    let mut contracts = ironclaw_extensions::HostApiContractRegistry::new();
+    contracts
+        .register(std::sync::Arc::new(
+            ironclaw_extensions::CapabilityProviderHostApiContract::new()
+                .expect("capability provider contract"),
+        ))
+        .expect("register capability provider contract");
+    contracts
+}

--- a/crates/ironclaw_dispatcher/tests/runtime_dispatcher_integration.rs
+++ b/crates/ironclaw_dispatcher/tests/runtime_dispatcher_integration.rs
@@ -325,6 +325,7 @@ fn parse_manifest(manifest: &str) -> ExtensionManifest {
         &manifest,
         ManifestSource::InstalledLocal,
         &HostPortCatalog::empty(),
+        &capability_provider_contracts(),
     )
     .unwrap()
 }
@@ -406,3 +407,14 @@ effects = ["dispatch_capability", "execute_code"]
 default_permission = "ask"
 parameters_schema = { type = "object" }
 "#;
+
+fn capability_provider_contracts() -> ironclaw_extensions::HostApiContractRegistry {
+    let mut contracts = ironclaw_extensions::HostApiContractRegistry::new();
+    contracts
+        .register(std::sync::Arc::new(
+            ironclaw_extensions::CapabilityProviderHostApiContract::new()
+                .expect("capability provider contract"),
+        ))
+        .expect("register capability provider contract");
+    contracts
+}

--- a/crates/ironclaw_dispatcher/tests/support/mod.rs
+++ b/crates/ironclaw_dispatcher/tests/support/mod.rs
@@ -2,7 +2,7 @@
 
 pub fn legacy_capability_fixture_to_v2(manifest: &str) -> String {
     if manifest.contains("schema_version") {
-        return manifest.to_string();
+        return project_top_level_capabilities_to_host_api(manifest.to_string());
     }
     let mut converted = "schema_version = \"reborn.extension_manifest.v2\"\n".to_string();
     for line in manifest.lines() {
@@ -20,5 +20,23 @@ pub fn legacy_capability_fixture_to_v2(manifest: &str) -> String {
             converted.push('\n');
         }
     }
-    converted
+    project_top_level_capabilities_to_host_api(converted)
+}
+
+/// Project a v2-legacy fixture (top-level `[[capabilities]]`) onto the
+/// host_api capability-provider form the parser requires.
+fn project_top_level_capabilities_to_host_api(manifest: String) -> String {
+    if !manifest.contains("[[capabilities]]") || manifest.contains("[[host_api]]") {
+        return manifest;
+    }
+    let host_api_block = "[[host_api]]\nid = \"ironclaw.capability_provider/v1\"\nsection = \"capability_provider.tools\"\n\n[capability_provider.tools]\n\n";
+    let idx = manifest.find("[[capabilities]]").expect("checked above");
+    let mut out = String::with_capacity(manifest.len() + host_api_block.len());
+    out.push_str(&manifest[..idx]);
+    out.push_str(host_api_block);
+    out.push_str(&manifest[idx..]);
+    out.replace(
+        "[[capabilities]]",
+        "[[capability_provider.tools.capabilities]]",
+    )
 }

--- a/crates/ironclaw_dispatcher/tests/vertical_slice_contract.rs
+++ b/crates/ironclaw_dispatcher/tests/vertical_slice_contract.rs
@@ -215,7 +215,7 @@ async fn discover_legacy_fixture_registry(fs: &LocalFilesystem) -> ExtensionRegi
         &VirtualPath::new("/system/extensions").unwrap(),
         ManifestSource::HostBundled,
         &HostPortCatalog::empty(),
-        &HostApiContractRegistry::new(),
+        &capability_provider_contracts(),
     )
     .await
     .unwrap()
@@ -293,3 +293,14 @@ effects = ["dispatch_capability"]
 default_permission = "allow"
 parameters_schema = { type = "object", required = ["message"], properties = { message = { type = "string" } } }
 "#;
+
+fn capability_provider_contracts() -> ironclaw_extensions::HostApiContractRegistry {
+    let mut contracts = ironclaw_extensions::HostApiContractRegistry::new();
+    contracts
+        .register(std::sync::Arc::new(
+            ironclaw_extensions::CapabilityProviderHostApiContract::new()
+                .expect("capability provider contract"),
+        ))
+        .expect("register capability provider contract");
+    contracts
+}

--- a/crates/ironclaw_event_projections/tests/extension_lifecycle_projection_contract.rs
+++ b/crates/ironclaw_event_projections/tests/extension_lifecycle_projection_contract.rs
@@ -42,6 +42,7 @@ async fn extension_lifecycle_projects_metadata_only_from_durable_audit_log() {
             EXTENSION_MANIFEST_WITH_RAW_SENTINELS,
             ManifestSource::InstalledLocal,
             &HostPortCatalog::empty(),
+            &capability_provider_contracts(),
         )
         .unwrap(),
         VirtualPath::new("/system/extensions/echo").unwrap(),
@@ -54,6 +55,7 @@ async fn extension_lifecycle_projects_metadata_only_from_durable_audit_log() {
                 .replace("echo.say", "echo.reply"),
             ManifestSource::InstalledLocal,
             &HostPortCatalog::empty(),
+            &capability_provider_contracts(),
         )
         .unwrap(),
         VirtualPath::new("/system/extensions/echo").unwrap(),
@@ -234,7 +236,13 @@ trust = "untrusted"
 kind = "wasm"
 module = "wasm/extension_raw_asset_sentinel_3022.wasm"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "echo.say"
 description = "Echo safely"
 effects = ["dispatch_capability"]
@@ -243,3 +251,14 @@ visibility = "model"
 input_schema_ref = "schemas/echo/extension_raw_schema_sentinel_3022.input.v1.json"
 output_schema_ref = "schemas/echo/extension_raw_schema_sentinel_3022.output.v1.json"
 "#;
+
+fn capability_provider_contracts() -> ironclaw_extensions::HostApiContractRegistry {
+    let mut contracts = ironclaw_extensions::HostApiContractRegistry::new();
+    contracts
+        .register(std::sync::Arc::new(
+            ironclaw_extensions::CapabilityProviderHostApiContract::new()
+                .expect("capability provider contract"),
+        ))
+        .expect("register capability provider contract");
+    contracts
+}

--- a/crates/ironclaw_extensions/src/host_api/capability_provider.rs
+++ b/crates/ironclaw_extensions/src/host_api/capability_provider.rs
@@ -4,7 +4,8 @@ use serde::Deserialize;
 
 use crate::v2::{
     CapabilityDeclV2, HostApiId, HostApiManifestContext, HostApiManifestContract,
-    HostApiManifestProjection, HostApiRefV2, ManifestSectionPath, ManifestV2Error, RawCapabilityV2,
+    HostApiManifestProjection, HostApiRefV2, HostApiSectionError, ManifestSectionPath,
+    ManifestV2Error, RawCapabilityV2,
 };
 
 pub const CAPABILITY_PROVIDER_HOST_API_ID: &str = "ironclaw.capability_provider/v1";
@@ -36,8 +37,10 @@ impl HostApiManifestContract for CapabilityProviderHostApiContract {
         &self,
         _host_api: &HostApiRefV2,
         _section: &toml::Value,
-    ) -> Result<(), String> {
-        Err("capability provider validation requires manifest context".to_string())
+    ) -> Result<(), HostApiSectionError> {
+        Err(HostApiSectionError::from(
+            "capability provider validation requires manifest context",
+        ))
     }
 
     fn validate_section_with_context(
@@ -45,7 +48,7 @@ impl HostApiManifestContract for CapabilityProviderHostApiContract {
         context: &HostApiManifestContext<'_>,
         _host_api: &HostApiRefV2,
         section: &toml::Value,
-    ) -> Result<(), String> {
+    ) -> Result<(), HostApiSectionError> {
         let _ = project_capabilities(context, section)?;
         Ok(())
     }
@@ -55,7 +58,7 @@ impl HostApiManifestContract for CapabilityProviderHostApiContract {
         context: &HostApiManifestContext<'_>,
         _host_api: &HostApiRefV2,
         section: &toml::Value,
-    ) -> Result<HostApiManifestProjection, String> {
+    ) -> Result<HostApiManifestProjection, HostApiSectionError> {
         Ok(HostApiManifestProjection {
             capabilities: project_capabilities(context, section)?,
             surfaces: Vec::new(),
@@ -66,26 +69,27 @@ impl HostApiManifestContract for CapabilityProviderHostApiContract {
 fn project_capabilities(
     context: &HostApiManifestContext<'_>,
     section: &toml::Value,
-) -> Result<Vec<CapabilityDeclV2>, String> {
+) -> Result<Vec<CapabilityDeclV2>, HostApiSectionError> {
     let parsed: CapabilityProviderToolsSection = section
         .clone()
         .try_into()
-        .map_err(|error: toml::de::Error| error.to_string())?;
+        .map_err(|error: toml::de::Error| HostApiSectionError::from(error.to_string()))?;
     if parsed.capabilities.is_empty() {
-        return Err("capability_provider.tools must declare at least one capability".to_string());
+        return Err(HostApiSectionError::from(
+            "capability_provider.tools must declare at least one capability",
+        ));
     }
 
     let mut seen = BTreeSet::new();
     let mut capabilities = Vec::with_capacity(parsed.capabilities.len());
     for raw in parsed.capabilities {
+        // `from_raw` errors keep their typed `ManifestV2Error` variants so
+        // capability validation reports identically however the capability
+        // is declared.
         let capability =
-            CapabilityDeclV2::from_raw(raw, context.extension_id, context.host_port_catalog)
-                .map_err(|error| error.to_string())?;
+            CapabilityDeclV2::from_raw(raw, context.extension_id, context.host_port_catalog)?;
         if !seen.insert(capability.id.clone()) {
-            return Err(format!(
-                "duplicate capability id {}",
-                capability.id.as_str()
-            ));
+            return Err(ManifestV2Error::DuplicateCapability { id: capability.id }.into());
         }
         capabilities.push(capability);
     }

--- a/crates/ironclaw_extensions/src/hosted_mcp_discovery.rs
+++ b/crates/ironclaw_extensions/src/hosted_mcp_discovery.rs
@@ -243,7 +243,13 @@ kind = "mcp"
 transport = "http"
 url = "https://mcp.notion.com/mcp"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "notion.notion-fetch"
 description = "Fetch a Notion page"
 effects = ["dispatch_capability", "network", "use_secret"]
@@ -348,11 +354,22 @@ runtime_credentials = [
         );
     }
 
+    fn capability_provider_contracts() -> crate::HostApiContractRegistry {
+        let mut contracts = crate::HostApiContractRegistry::new();
+        contracts
+            .register(std::sync::Arc::new(
+                crate::CapabilityProviderHostApiContract::new().expect("contract"),
+            ))
+            .expect("register capability provider contract");
+        contracts
+    }
+
     fn notion_package() -> ExtensionPackage {
         let manifest = ExtensionManifest::parse(
             NOTION_MANIFEST,
             ManifestSource::HostBundled,
             &HostPortCatalog::default(),
+            &capability_provider_contracts(),
         )
         .expect("valid Notion manifest");
         ExtensionPackage::from_manifest(

--- a/crates/ironclaw_extensions/src/installations.rs
+++ b/crates/ironclaw_extensions/src/installations.rs
@@ -54,31 +54,10 @@ impl ExtensionManifestRecord {
         source: ManifestSource,
         host_port_catalog: &HostPortCatalog,
         manifest_hash: Option<ManifestHash>,
-    ) -> Result<Self, ExtensionInstallationError> {
-        let contracts = HostApiContractRegistry::new();
-        Self::from_toml_with_contracts(
-            raw_toml,
-            source,
-            host_port_catalog,
-            manifest_hash,
-            &contracts,
-        )
-    }
-
-    pub fn from_toml_with_contracts(
-        raw_toml: impl Into<String>,
-        source: ManifestSource,
-        host_port_catalog: &HostPortCatalog,
-        manifest_hash: Option<ManifestHash>,
         contracts: &HostApiContractRegistry,
     ) -> Result<Self, ExtensionInstallationError> {
         let raw_toml = raw_toml.into();
-        let manifest = ExtensionManifestV2::parse_with_optional_host_api_contracts(
-            &raw_toml,
-            source,
-            host_port_catalog,
-            contracts,
-        )?;
+        let manifest = ExtensionManifestV2::parse(&raw_toml, source, host_port_catalog, contracts)?;
         Ok(Self {
             raw_toml,
             manifest,
@@ -1000,12 +979,23 @@ mod tests {
         assert!(store.get_manifest(&extension_id).await.unwrap().is_some());
     }
 
+    fn capability_provider_contracts() -> crate::HostApiContractRegistry {
+        let mut contracts = crate::HostApiContractRegistry::new();
+        contracts
+            .register(std::sync::Arc::new(
+                crate::CapabilityProviderHostApiContract::new().expect("contract"),
+            ))
+            .expect("register capability provider contract");
+        contracts
+    }
+
     fn manifest_record(extension_id: &str, hash: Option<&str>) -> ExtensionManifestRecord {
         ExtensionManifestRecord::from_toml(
             manifest_toml(extension_id),
             ManifestSource::HostBundled,
             &HostPortCatalog::empty(),
             hash.map(|value| ManifestHash::new(value).expect("hash")),
+            &capability_provider_contracts(),
         )
         .expect("manifest record")
     }
@@ -1111,7 +1101,13 @@ trust = "third_party"
 kind = "wasm"
 module = "wasm/{extension_id}.wasm"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "{extension_id}.read"
 description = "read"
 effects = ["network"]

--- a/crates/ironclaw_extensions/src/lib.rs
+++ b/crates/ironclaw_extensions/src/lib.rs
@@ -170,38 +170,9 @@ impl ExtensionManifest {
         input: &str,
         source: ManifestSource,
         host_port_catalog: &HostPortCatalog,
-    ) -> Result<Self, ExtensionError> {
-        ExtensionManifestV2::parse(input, source, host_port_catalog)?.try_into()
-    }
-
-    pub fn parse_with_host_api_contracts(
-        input: &str,
-        source: ManifestSource,
-        host_port_catalog: &HostPortCatalog,
         registry: &HostApiContractRegistry,
     ) -> Result<Self, ExtensionError> {
-        ExtensionManifestV2::parse_with_host_api_contracts(
-            input,
-            source,
-            host_port_catalog,
-            registry,
-        )?
-        .try_into()
-    }
-
-    pub fn parse_with_optional_host_api_contracts(
-        input: &str,
-        source: ManifestSource,
-        host_port_catalog: &HostPortCatalog,
-        registry: &HostApiContractRegistry,
-    ) -> Result<Self, ExtensionError> {
-        ExtensionManifestV2::parse_with_optional_host_api_contracts(
-            input,
-            source,
-            host_port_catalog,
-            registry,
-        )?
-        .try_into()
+        ExtensionManifestV2::parse(input, source, host_port_catalog, registry)?.try_into()
     }
 
     pub fn runtime_kind(&self) -> RuntimeKind {
@@ -426,9 +397,9 @@ pub use v2::{
     CapabilityDeclV2, CapabilitySurfaceDeclV2, CapabilityVisibility, ExtensionManifestV2,
     ExtensionRuntimeV2, HookSectionEntryV2, HostApiContractRegistry, HostApiId,
     HostApiManifestContext, HostApiManifestContract, HostApiManifestProjection,
-    HostApiMultiplicity, HostApiRefV2, MANIFEST_SCHEMA_VERSION, MAX_HOOK_ENTRY_BYTES,
-    MAX_MANIFEST_BYTES, MAX_MANIFEST_HOOKS, ManifestSectionPath, ManifestSource, ManifestV2Error,
-    RESERVED_HOST_BUNDLED_ID_PREFIX,
+    HostApiMultiplicity, HostApiRefV2, HostApiSectionError, MANIFEST_SCHEMA_VERSION,
+    MAX_HOOK_ENTRY_BYTES, MAX_MANIFEST_BYTES, MAX_MANIFEST_HOOKS, ManifestSectionPath,
+    ManifestSource, ManifestV2Error, RESERVED_HOST_BUNDLED_ID_PREFIX,
 };
 
 pub type CapabilityManifest = CapabilityDeclV2;
@@ -450,25 +421,6 @@ pub use registry::{ExtensionRegistry, SharedExtensionRegistry};
 pub struct ExtensionDiscovery;
 
 impl ExtensionDiscovery {
-    pub async fn discover<F>(
-        fs: &F,
-        root: &VirtualPath,
-    ) -> Result<ExtensionRegistry, ExtensionError>
-    where
-        F: RootFilesystem,
-    {
-        let host_port_catalog = HostPortCatalog::empty();
-        let host_api_contracts = HostApiContractRegistry::new();
-        Self::discover_with_manifest_contracts(
-            fs,
-            root,
-            ManifestSource::InstalledLocal,
-            &host_port_catalog,
-            &host_api_contracts,
-        )
-        .await
-    }
-
     pub async fn discover_with_manifest_contracts<F>(
         fs: &F,
         root: &VirtualPath,
@@ -663,12 +615,8 @@ impl ExtensionDiscovery {
         let text = String::from_utf8(bytes).map_err(|error| ExtensionError::ManifestParse {
             reason: error.to_string(),
         })?;
-        let manifest = ExtensionManifest::parse_with_optional_host_api_contracts(
-            &text,
-            source,
-            host_port_catalog,
-            host_api_contracts,
-        )?;
+        let manifest =
+            ExtensionManifest::parse(&text, source, host_port_catalog, host_api_contracts)?;
         if manifest.id != expected {
             return Err(ExtensionError::ManifestIdMismatch {
                 root: entry.path.clone(),

--- a/crates/ironclaw_extensions/src/lifecycle.rs
+++ b/crates/ironclaw_extensions/src/lifecycle.rs
@@ -230,6 +230,16 @@ mod tests {
         }
     }
 
+    fn capability_provider_contracts() -> crate::HostApiContractRegistry {
+        let mut contracts = crate::HostApiContractRegistry::new();
+        contracts
+            .register(std::sync::Arc::new(
+                crate::CapabilityProviderHostApiContract::new().expect("contract"),
+            ))
+            .expect("register capability provider contract");
+        contracts
+    }
+
     fn test_package(extension_id: &str) -> ExtensionPackage {
         let manifest = format!(
             r#"
@@ -244,7 +254,13 @@ trust = "third_party"
 kind = "wasm"
 module = "wasm/{extension_id}.wasm"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "{extension_id}.read"
 description = "read"
 effects = ["network"]
@@ -258,6 +274,7 @@ output_schema_ref = "schemas/read.output.json"
             &manifest,
             ManifestSource::HostBundled,
             &HostPortCatalog::empty(),
+            &capability_provider_contracts(),
         )
         .expect("manifest parses");
         ExtensionPackage::from_manifest(

--- a/crates/ironclaw_extensions/src/registry.rs
+++ b/crates/ironclaw_extensions/src/registry.rs
@@ -453,7 +453,7 @@ mod tests {
             .map(|name| {
                 format!(
                     r#"
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "{extension_id}.{name}"
 description = "{name}"
 effects = ["network"]
@@ -477,6 +477,12 @@ trust = "third_party"
 [runtime]
 kind = "wasm"
 module = "wasm/{extension_id}.wasm"
+
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
 {capability_blocks}
 "#
         );
@@ -484,6 +490,7 @@ module = "wasm/{extension_id}.wasm"
             &manifest,
             ManifestSource::HostBundled,
             &HostPortCatalog::empty(),
+            &capability_provider_contracts(),
         )
         .expect("manifest parses");
         ExtensionPackage::from_manifest(
@@ -491,6 +498,16 @@ module = "wasm/{extension_id}.wasm"
             VirtualPath::new(format!("/system/extensions/{extension_id}")).expect("root"),
         )
         .expect("package builds")
+    }
+
+    fn capability_provider_contracts() -> crate::HostApiContractRegistry {
+        let mut contracts = crate::HostApiContractRegistry::new();
+        contracts
+            .register(std::sync::Arc::new(
+                crate::CapabilityProviderHostApiContract::new().expect("contract"),
+            ))
+            .expect("register capability provider contract");
+        contracts
     }
 
     fn extension_id(value: &str) -> ExtensionId {

--- a/crates/ironclaw_extensions/src/v2.rs
+++ b/crates/ironclaw_extensions/src/v2.rs
@@ -9,6 +9,9 @@
 //! - manifests carry a loader-supplied [`ManifestSource`]; first-party / system
 //!   trust and runtime are only ever effective for [`ManifestSource::HostBundled`];
 //! - extension IDs starting with `ironclaw.` are reserved for HostBundled;
+//! - every manifest declares at least one `[[host_api]]` contract; top-level
+//!   `[[capabilities]]` is rejected — capabilities are declared under
+//!   `ironclaw.capability_provider/v1` sections;
 //! - installed manifests must use `wasm` / `mcp` / `script` runtimes only;
 //! - every capability declares `visibility`, relative
 //!   [`CapabilityProfileSchemaRef`] input/output schema refs, optional lazy
@@ -247,11 +250,43 @@ pub struct HostApiManifestProjection {
     pub surfaces: Vec<CapabilitySurfaceKind>,
 }
 
+/// Error a host API contract raises for one manifest section.
+///
+/// Contracts that validate with this crate's own vocabulary (the
+/// capability-provider contract parses [`CapabilityDeclV2`] declarations)
+/// preserve the typed [`ManifestV2Error`] so callers keep precise variants
+/// (`DuplicateEffect`, `UnknownHostPort`, ...). Domain crates outside this
+/// crate report a redacted reason string, which the parse path wraps as
+/// [`ManifestV2Error::HostApiSectionRejected`].
+#[derive(Debug)]
+pub enum HostApiSectionError {
+    Manifest(Box<ManifestV2Error>),
+    Contract(String),
+}
+
+impl From<ManifestV2Error> for HostApiSectionError {
+    fn from(error: ManifestV2Error) -> Self {
+        Self::Manifest(Box::new(error))
+    }
+}
+
+impl From<String> for HostApiSectionError {
+    fn from(reason: String) -> Self {
+        Self::Contract(reason)
+    }
+}
+
+impl From<&str> for HostApiSectionError {
+    fn from(reason: &str) -> Self {
+        Self::Contract(reason.to_string())
+    }
+}
+
 /// Host API contract validator registered by composition.
 ///
 /// `ironclaw_extensions` owns the generic envelope and section dispatch. Domain
-/// crates own section patterns, cardinality, typed schema validation, and
-/// projection into their read models.
+/// crates own section patterns, cardinality, typed section schema validation,
+/// and projection into their read models.
 pub trait HostApiManifestContract: Send + Sync {
     fn id(&self) -> &HostApiId;
 
@@ -265,14 +300,14 @@ pub trait HostApiManifestContract: Send + Sync {
         &self,
         host_api: &HostApiRefV2,
         section: &toml::Value,
-    ) -> Result<(), String>;
+    ) -> Result<(), HostApiSectionError>;
 
     fn validate_section_with_context(
         &self,
         context: &HostApiManifestContext<'_>,
         host_api: &HostApiRefV2,
         section: &toml::Value,
-    ) -> Result<(), String> {
+    ) -> Result<(), HostApiSectionError> {
         let _ = context;
         self.validate_section(host_api, section)
     }
@@ -282,7 +317,7 @@ pub trait HostApiManifestContract: Send + Sync {
         context: &HostApiManifestContext<'_>,
         host_api: &HostApiRefV2,
         section: &toml::Value,
-    ) -> Result<HostApiManifestProjection, String> {
+    ) -> Result<HostApiManifestProjection, HostApiSectionError> {
         self.validate_section_with_context(context, host_api, section)?;
         Ok(HostApiManifestProjection::default())
     }
@@ -348,10 +383,15 @@ impl HostApiContractRegistry {
             };
             let section_projection = contract
                 .project_section_with_context(&context, host_api, section)
-                .map_err(|reason| ManifestV2Error::HostApiSectionRejected {
-                    id: host_api.id.clone(),
-                    section: host_api.section.clone(),
-                    reason,
+                .map_err(|error| match error {
+                    HostApiSectionError::Manifest(error) => *error,
+                    HostApiSectionError::Contract(reason) => {
+                        ManifestV2Error::HostApiSectionRejected {
+                            id: host_api.id.clone(),
+                            section: host_api.section.clone(),
+                            reason,
+                        }
+                    }
                 })?;
             for capability in section_projection.capabilities {
                 if !seen_capabilities.insert(capability.id.clone()) {
@@ -546,8 +586,9 @@ pub struct ExtensionManifestV2 {
     /// the policy; they must not read this field as authoritative.
     pub descriptor_trust_default: TrustClass,
     pub runtime: ExtensionRuntimeV2,
-    /// Host API contracts this extension implements. Empty only for legacy v2
-    /// capability-only manifests during cutover.
+    /// Host API contracts this extension implements. Never empty: every
+    /// manifest declares at least one contract, and every capability and
+    /// surface reaches the manifest through one.
     ///
     /// Contract handlers must treat manifest trust fields as untrusted
     /// declaration metadata. Runtime authority and effective trust must come
@@ -557,7 +598,7 @@ pub struct ExtensionManifestV2 {
     pub host_apis: Vec<HostApiRefV2>,
     pub capabilities: Vec<CapabilityDeclV2>,
     /// Surfaces projected by host API contract sections during
-    /// `parse_with_host_api_contracts` (channel and future section-declared
+    /// [`Self::parse`] (channel and future section-declared
     /// kinds). Tool and auth surfaces are *not* stored here — they derive on
     /// demand from capability declarations; [`Self::capability_surfaces`]
     /// returns the complete set. Empty when the manifest was parsed without
@@ -626,10 +667,6 @@ pub enum ManifestV2Error {
         prefix: &'static str,
     },
     #[error(
-        "manifest source {manifest_source:?} is not allowed to use legacy top-level capabilities; declare ironclaw.capability_provider/v1 host_api instead"
-    )]
-    LegacyTopLevelCapabilitiesForInstalledSource { manifest_source: ManifestSource },
-    #[error(
         "capability {capability} declares unknown host port '{port}' (not in host-defined catalog)"
     )]
     UnknownHostPort {
@@ -691,13 +728,21 @@ impl ExtensionManifestV2 {
         self.runtime.kind()
     }
 
-    /// Parse a v2 manifest TOML body and validate it against `host_port_catalog`.
+    /// Parse a v2 manifest TOML body: validate the envelope against
+    /// `host_port_catalog`, require at least one `[[host_api]]` contract,
+    /// and validate/project every declared contract section through the
+    /// composition-supplied registry.
+    ///
+    /// This is the only parse entry point. Every capability, surface, and
+    /// operational section reaches the manifest through a registered host
+    /// API contract — there is no contract-free manifest form.
     ///
     /// `source` is supplied by the loader/install path, never read from TOML.
     pub fn parse(
         input: &str,
         source: ManifestSource,
         host_port_catalog: &HostPortCatalog,
+        registry: &HostApiContractRegistry,
     ) -> Result<Self, ManifestV2Error> {
         // Fail closed on pathological inputs *before* invoking the TOML parser.
         // `toml::from_str` will otherwise read and allocate the full input.
@@ -708,84 +753,12 @@ impl ExtensionManifestV2 {
             });
         }
         let document = RawManifestDocumentV2::parse(input)?;
-        if !document.raw.host_api.is_empty() {
-            return Err(ManifestV2Error::Invalid {
-                reason: "host_api manifests require parse_with_host_api_contracts".to_string(),
-            });
-        }
-        if let Some(key) = document.sections.first_non_envelope_top_level_key() {
-            return Err(ManifestV2Error::Parse {
-                reason: format!("unknown top-level field {key:?}"),
-            });
-        }
-        Self::from_raw(document.raw, source, host_port_catalog, &document.sections)
-    }
-
-    /// Parse a v2 manifest and validate every `[[host_api]]` contract through
-    /// the composition-supplied registry.
-    pub fn parse_with_host_api_contracts(
-        input: &str,
-        source: ManifestSource,
-        host_port_catalog: &HostPortCatalog,
-        registry: &HostApiContractRegistry,
-    ) -> Result<Self, ManifestV2Error> {
-        if input.len() > MAX_MANIFEST_BYTES {
-            return Err(ManifestV2Error::ManifestTooLarge {
-                bytes: input.len(),
-                max: MAX_MANIFEST_BYTES,
-            });
-        }
-        let document = RawManifestDocumentV2::parse(input)?;
-        let mut manifest =
-            Self::from_raw(document.raw, source, host_port_catalog, &document.sections)?;
+        let mut manifest = Self::from_raw(document.raw, source, &document.sections)?;
         manifest.project_and_extend_capabilities(
             &document.sections,
             host_port_catalog,
             registry,
         )?;
-        Ok(manifest)
-    }
-
-    /// Parse a v2 manifest for production discovery.
-    ///
-    /// Legacy top-level capability manifests keep the stricter no-extra-table
-    /// rule from [`Self::parse`]. Manifests that declare `[[host_api]]` are
-    /// validated through the composition-supplied contract registry.
-    pub fn parse_with_optional_host_api_contracts(
-        input: &str,
-        source: ManifestSource,
-        host_port_catalog: &HostPortCatalog,
-        registry: &HostApiContractRegistry,
-    ) -> Result<Self, ManifestV2Error> {
-        if input.len() > MAX_MANIFEST_BYTES {
-            return Err(ManifestV2Error::ManifestTooLarge {
-                bytes: input.len(),
-                max: MAX_MANIFEST_BYTES,
-            });
-        }
-        let document = RawManifestDocumentV2::parse(input)?;
-        let mut manifest =
-            Self::from_raw(document.raw, source, host_port_catalog, &document.sections)?;
-        if manifest.host_apis.is_empty() {
-            if let Some(key) = document.sections.first_non_envelope_top_level_key() {
-                return Err(ManifestV2Error::Parse {
-                    reason: format!("unknown top-level field {key:?}"),
-                });
-            }
-            if !source.allows_first_party() && !manifest.capabilities.is_empty() {
-                return Err(
-                    ManifestV2Error::LegacyTopLevelCapabilitiesForInstalledSource {
-                        manifest_source: source,
-                    },
-                );
-            }
-        } else {
-            manifest.project_and_extend_capabilities(
-                &document.sections,
-                host_port_catalog,
-                registry,
-            )?;
-        }
         Ok(manifest)
     }
 
@@ -880,7 +853,6 @@ impl ExtensionManifestV2 {
     fn from_raw(
         raw: RawManifestV2,
         source: ManifestSource,
-        host_port_catalog: &HostPortCatalog,
         sections: &ManifestSectionsV2,
     ) -> Result<Self, ManifestV2Error> {
         if raw.schema_version != MANIFEST_SCHEMA_VERSION {
@@ -908,17 +880,16 @@ impl ExtensionManifestV2 {
                 reason: "description must not be empty".to_string(),
             });
         }
-        if raw.capabilities.is_empty() && raw.host_api.is_empty() {
+        if !raw.capabilities.is_empty() {
             return Err(ManifestV2Error::Invalid {
-                reason: "at least one host_api contract or legacy capability is required"
+                reason: "top-level [[capabilities]] is not supported; declare capabilities \
+                         under an ironclaw.capability_provider/v1 host_api section"
                     .to_string(),
             });
         }
-        if !raw.host_api.is_empty() && !raw.capabilities.is_empty() {
+        if raw.host_api.is_empty() {
             return Err(ManifestV2Error::Invalid {
-                reason:
-                    "top-level capabilities are not allowed when host_api contracts are declared"
-                        .to_string(),
+                reason: "at least one host_api contract is required".to_string(),
             });
         }
 
@@ -957,16 +928,9 @@ impl ExtensionManifestV2 {
 
         let hooks = validate_hook_entries(raw.hooks)?;
 
-        let mut seen_capabilities = BTreeSet::new();
-        let mut capabilities = Vec::with_capacity(raw.capabilities.len());
-        for raw_cap in raw.capabilities {
-            let cap = CapabilityDeclV2::from_raw(raw_cap, &id, host_port_catalog)?;
-            if !seen_capabilities.insert(cap.id.clone()) {
-                return Err(ManifestV2Error::DuplicateCapability { id: cap.id });
-            }
-            capabilities.push(cap);
-        }
-
+        // `capabilities` and `host_api_surfaces` start empty and are filled
+        // exclusively by host API contract projection in
+        // [`Self::project_and_extend_capabilities`].
         Ok(Self {
             schema_version: raw.schema_version,
             id,
@@ -978,7 +942,7 @@ impl ExtensionManifestV2 {
             descriptor_trust_default,
             runtime,
             host_apis,
-            capabilities,
+            capabilities: Vec::new(),
             host_api_surfaces: Vec::new(),
             hooks,
         })
@@ -1497,13 +1461,6 @@ struct ManifestSectionsV2 {
 }
 
 impl ManifestSectionsV2 {
-    fn first_non_envelope_top_level_key(&self) -> Option<&str> {
-        self.table
-            .keys()
-            .find(|key| !is_envelope_key(key))
-            .map(String::as_str)
-    }
-
     fn get(&self, path: &ManifestSectionPath) -> Result<&toml::Value, ManifestV2Error> {
         let mut current = &self.table;
         let mut segments = path.segments().peekable();
@@ -1617,8 +1574,12 @@ struct RawManifestV2 {
     runtime: RawRuntimeV2,
     #[serde(default)]
     host_api: Vec<RawHostApiRefV2>,
+    /// Legacy top-level `[[capabilities]]` payload. Kept only so its
+    /// presence can be rejected with an actionable error; entries are never
+    /// parsed. Capabilities are declared under
+    /// `ironclaw.capability_provider/v1` host_api sections.
     #[serde(default)]
-    capabilities: Vec<RawCapabilityV2>,
+    capabilities: Vec<toml::Value>,
     /// Raw `[[hooks]]` entries. Each is an arbitrary TOML table validated
     /// structurally here (table shape, non-empty `id`, size bound) and
     /// projected into a typed hook entry by the composition loader. Kept as

--- a/crates/ironclaw_extensions/tests/discovery_manifest_bound.rs
+++ b/crates/ironclaw_extensions/tests/discovery_manifest_bound.rs
@@ -62,9 +62,15 @@ async fn discovery_rejects_oversized_manifest_before_reading_the_body() {
     let fs = OversizedManifestFs;
     let root = VirtualPath::new("/system/extensions").expect("root");
 
-    let err = ExtensionDiscovery::discover(&fs, &root)
-        .await
-        .expect_err("oversized manifest must be rejected");
+    let err = ExtensionDiscovery::discover_with_manifest_contracts(
+        &fs,
+        &root,
+        ManifestSource::InstalledLocal,
+        &HostPortCatalog::empty(),
+        &HostApiContractRegistry::new(),
+    )
+    .await
+    .expect_err("oversized manifest must be rejected");
 
     match err {
         ExtensionError::InvalidManifest { reason } => {
@@ -116,9 +122,12 @@ async fn discovery_within_bound_proceeds_to_read() {
         }
     }
 
-    let err = ExtensionDiscovery::discover(
+    let err = ExtensionDiscovery::discover_with_manifest_contracts(
         &WithinBoundFs,
         &VirtualPath::new("/system/extensions").unwrap(),
+        ManifestSource::InstalledLocal,
+        &HostPortCatalog::empty(),
+        &HostApiContractRegistry::new(),
     )
     .await
     .expect_err("within-bound manifest reaches the body read (which errors here)");

--- a/crates/ironclaw_extensions/tests/extension_contract.rs
+++ b/crates/ironclaw_extensions/tests/extension_contract.rs
@@ -99,6 +99,7 @@ fn registry_rejects_host_bundled_package_with_mutated_parameters_schema() {
         WASM_MANIFEST,
         ManifestSource::HostBundled,
         &HostPortCatalog::empty(),
+        &contracts(),
     )
     .unwrap();
     let mut package = package_from_manifest(manifest, "echo");
@@ -170,7 +171,7 @@ async fn discovery_reads_host_bundled_legacy_manifests_from_filesystem_virtual_r
         &VirtualPath::new("/system/extensions").unwrap(),
         ManifestSource::HostBundled,
         &HostPortCatalog::empty(),
-        &HostApiContractRegistry::new(),
+        &contracts(),
     )
     .await
     .unwrap();
@@ -204,9 +205,15 @@ async fn discovery_rejects_installed_local_privileged_manifest() {
     )
     .unwrap();
 
-    let err = ExtensionDiscovery::discover(&fs, &VirtualPath::new("/system/extensions").unwrap())
-        .await
-        .unwrap_err();
+    let err = ExtensionDiscovery::discover_with_manifest_contracts(
+        &fs,
+        &VirtualPath::new("/system/extensions").unwrap(),
+        ManifestSource::InstalledLocal,
+        &HostPortCatalog::empty(),
+        &contracts(),
+    )
+    .await
+    .unwrap_err();
 
     assert!(matches!(
         err,
@@ -218,44 +225,46 @@ async fn discovery_rejects_installed_local_privileged_manifest() {
 }
 
 #[test]
-fn production_parser_rejects_installed_legacy_top_level_capabilities() {
-    let err = ExtensionManifest::parse_with_optional_host_api_contracts(
-        WASM_MANIFEST,
-        ManifestSource::InstalledLocal,
-        &HostPortCatalog::empty(),
-        &HostApiContractRegistry::new(),
-    )
-    .unwrap_err();
-
-    assert!(matches!(
-        err,
-        ExtensionError::ManifestV2(
-            ManifestV2Error::LegacyTopLevelCapabilitiesForInstalledSource {
-                manifest_source: ManifestSource::InstalledLocal,
-            }
+fn top_level_capabilities_are_rejected_for_every_source() {
+    // The legacy manifest form is gone for host-bundled manifests exactly as
+    // for installed ones: capabilities are declared under an
+    // ironclaw.capability_provider/v1 host_api section.
+    let legacy = WASM_MANIFEST
+        .replace(
+            "[[host_api]]\nid = \"ironclaw.capability_provider/v1\"\nsection = \"capability_provider.tools\"\n\n[capability_provider.tools]\n\n",
+            "",
         )
-    ));
-}
-
-#[test]
-fn production_parser_allows_host_bundled_legacy_top_level_capabilities() {
-    let manifest = ExtensionManifest::parse_with_optional_host_api_contracts(
-        WASM_MANIFEST,
+        .replace("[[capability_provider.tools.capabilities]]", "[[capabilities]]");
+    for source in [
+        ManifestSource::InstalledLocal,
+        ManifestSource::RegistryInstalled,
         ManifestSource::HostBundled,
-        &HostPortCatalog::empty(),
-        &HostApiContractRegistry::new(),
-    )
-    .unwrap();
-
-    assert_eq!(manifest.id.as_str(), "echo");
-    assert_eq!(manifest.capabilities.len(), 1);
+    ] {
+        let err =
+            ExtensionManifest::parse(&legacy, source, &HostPortCatalog::empty(), &contracts())
+                .unwrap_err();
+        assert!(
+            matches!(
+                &err,
+                ExtensionError::ManifestV2(ManifestV2Error::Invalid { reason })
+                    if reason.contains("top-level [[capabilities]] is not supported")
+            ),
+            "{source:?}: {err:?}"
+        );
+    }
 }
 
 #[tokio::test]
-async fn discovery_rejects_installed_legacy_top_level_capabilities() {
+async fn discovery_rejects_legacy_top_level_capability_manifests() {
+    let legacy = WASM_MANIFEST
+        .replace(
+            "[[host_api]]\nid = \"ironclaw.capability_provider/v1\"\nsection = \"capability_provider.tools\"\n\n[capability_provider.tools]\n\n",
+            "",
+        )
+        .replace("[[capability_provider.tools.capabilities]]", "[[capabilities]]");
     let storage = tempdir().unwrap();
     std::fs::create_dir_all(storage.path().join("echo")).unwrap();
-    std::fs::write(storage.path().join("echo/manifest.toml"), WASM_MANIFEST).unwrap();
+    std::fs::write(storage.path().join("echo/manifest.toml"), legacy).unwrap();
 
     let mut fs = LocalFilesystem::new();
     fs.mount_local(
@@ -264,17 +273,20 @@ async fn discovery_rejects_installed_legacy_top_level_capabilities() {
     )
     .unwrap();
 
-    let err = ExtensionDiscovery::discover(&fs, &VirtualPath::new("/system/extensions").unwrap())
-        .await
-        .unwrap_err();
+    let err = ExtensionDiscovery::discover_with_manifest_contracts(
+        &fs,
+        &VirtualPath::new("/system/extensions").unwrap(),
+        ManifestSource::InstalledLocal,
+        &HostPortCatalog::empty(),
+        &contracts(),
+    )
+    .await
+    .unwrap_err();
 
     assert!(matches!(
-        err,
-        ExtensionError::ManifestV2(
-            ManifestV2Error::LegacyTopLevelCapabilitiesForInstalledSource {
-                manifest_source: ManifestSource::InstalledLocal,
-            }
-        )
+        &err,
+        ExtensionError::ManifestV2(ManifestV2Error::Invalid { reason })
+            if reason.contains("top-level [[capabilities]] is not supported")
     ));
 }
 
@@ -359,7 +371,7 @@ async fn discovery_registers_capability_provider_projected_capabilities() {
 
 #[test]
 fn capability_provider_host_api_contract_accepts_valid_manifest() {
-    let manifest = ExtensionManifest::parse_with_host_api_contracts(
+    let manifest = ExtensionManifest::parse(
         CAPABILITY_PROVIDER_MANIFEST,
         ManifestSource::InstalledLocal,
         &HostPortCatalog::empty(),
@@ -407,7 +419,7 @@ runtime_credentials = [
   { handle = "telegram_token", audience = { scheme = "https", host_pattern = "api.telegram.org" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]"#,
     );
-    let manifest = ExtensionManifest::parse_with_host_api_contracts(
+    let manifest = ExtensionManifest::parse(
         &manifest,
         ManifestSource::InstalledLocal,
         &HostPortCatalog::empty(),
@@ -469,7 +481,7 @@ runtime_credentials = [
 ]"#
             ),
         );
-        let err = ExtensionManifest::parse_with_host_api_contracts(
+        let err = ExtensionManifest::parse(
             &manifest,
             ManifestSource::InstalledLocal,
             &HostPortCatalog::empty(),
@@ -477,20 +489,23 @@ runtime_credentials = [
         )
         .unwrap_err();
 
+        // Typed capability-validation errors pass through the contract
+        // channel unflattened; their diagnostic text is preserved on Display.
+        let rendered = err.to_string();
         assert!(
-            matches!(
-                err,
-                ExtensionError::ManifestV2(ManifestV2Error::HostApiSectionRejected { ref reason, .. })
-                    if reason.contains(expected)
-            ),
-            "expected reason containing {expected:?}, got {err:?}"
+            matches!(err, ExtensionError::ManifestV2(_)),
+            "expected a manifest error, got {err:?}"
+        );
+        assert!(
+            rendered.contains(expected),
+            "expected diagnostic containing {expected:?}, got {rendered}"
         );
     }
 }
 
 #[test]
 fn capability_provider_host_api_fails_without_registered_contract() {
-    let err = ExtensionManifest::parse_with_host_api_contracts(
+    let err = ExtensionManifest::parse(
         CAPABILITY_PROVIDER_MANIFEST,
         ManifestSource::InstalledLocal,
         &HostPortCatalog::empty(),
@@ -517,7 +532,7 @@ fn capability_provider_host_api_rejects_wrong_section_path() {
             "[[capability_provider.tools.capabilities]]",
             "[[capability_provider.other.capabilities]]",
         );
-    let err = ExtensionManifest::parse_with_host_api_contracts(
+    let err = ExtensionManifest::parse(
         &manifest,
         ManifestSource::InstalledLocal,
         &HostPortCatalog::empty(),
@@ -540,7 +555,7 @@ fn capability_provider_host_api_rejects_unknown_section_fields() {
         "[capability_provider.tools]",
         "[capability_provider.tools]\nraw_secret = \"not allowed\"",
     );
-    let err = ExtensionManifest::parse_with_host_api_contracts(
+    let err = ExtensionManifest::parse(
         &manifest,
         ManifestSource::InstalledLocal,
         &HostPortCatalog::empty(),
@@ -572,20 +587,23 @@ fn capability_provider_host_api_reuses_capability_validation() {
     ];
 
     for (manifest, expected) in cases {
-        let err = ExtensionManifest::parse_with_host_api_contracts(
+        let err = ExtensionManifest::parse(
             &manifest,
             ManifestSource::InstalledLocal,
             &HostPortCatalog::empty(),
             &capability_provider_contracts(),
         )
         .unwrap_err();
+        // Capability validation reports the same typed variants however the
+        // capability is declared; the diagnostic text survives on Display.
+        let rendered = err.to_string();
         assert!(
-            matches!(
-                err,
-                ExtensionError::ManifestV2(ManifestV2Error::HostApiSectionRejected { ref reason, .. })
-                    if reason.contains(expected)
-            ),
-            "expected reason containing {expected:?}, got {err:?}"
+            matches!(err, ExtensionError::ManifestV2(_)),
+            "expected a manifest error, got {err:?}"
+        );
+        assert!(
+            rendered.contains(expected),
+            "expected diagnostic containing {expected:?}, got {rendered}"
         );
     }
 }
@@ -597,7 +615,7 @@ fn capability_provider_host_api_allows_missing_prompt_doc_ref() {
         "",
     );
 
-    let manifest = ExtensionManifest::parse_with_host_api_contracts(
+    let manifest = ExtensionManifest::parse(
         &manifest,
         ManifestSource::InstalledLocal,
         &HostPortCatalog::empty(),
@@ -624,7 +642,7 @@ prompt_doc_ref = "prompts/telegram/send_message.md"
 
 [[capability_provider.tools.capabilities]]"#,
     );
-    let err = ExtensionManifest::parse_with_host_api_contracts(
+    let err = ExtensionManifest::parse(
         &manifest,
         ManifestSource::InstalledLocal,
         &HostPortCatalog::empty(),
@@ -634,8 +652,8 @@ prompt_doc_ref = "prompts/telegram/send_message.md"
 
     assert!(matches!(
         err,
-        ExtensionError::ManifestV2(ManifestV2Error::HostApiSectionRejected { reason, .. })
-            if reason.contains("duplicate capability id")
+        ExtensionError::ManifestV2(ManifestV2Error::DuplicateCapability { id })
+            if id.as_str() == "telegram.send_message"
     ));
 }
 
@@ -650,7 +668,10 @@ fn capability_provider_host_api_rejects_contextless_validation() {
 
     let err = contract.validate_section(&host_api, &section).unwrap_err();
 
-    assert!(err.contains("requires manifest context"));
+    assert!(matches!(
+        &err,
+        HostApiSectionError::Contract(reason) if reason.contains("requires manifest context")
+    ));
 }
 
 #[test]
@@ -660,7 +681,7 @@ fn capability_provider_host_api_validates_required_host_ports() {
         "prompt_doc_ref = \"prompts/telegram/send_message.md\"\nrequired_host_ports = [\"host.runtime.http_egress\"]\n",
     );
 
-    let missing_port = ExtensionManifest::parse_with_host_api_contracts(
+    let missing_port = ExtensionManifest::parse(
         &manifest,
         ManifestSource::InstalledLocal,
         &HostPortCatalog::empty(),
@@ -669,15 +690,15 @@ fn capability_provider_host_api_validates_required_host_ports() {
     .unwrap_err();
     assert!(matches!(
         missing_port,
-        ExtensionError::ManifestV2(ManifestV2Error::HostApiSectionRejected { reason, .. })
-            if reason.contains("unknown host port")
+        ExtensionError::ManifestV2(ManifestV2Error::UnknownHostPort { port, .. })
+            if port.as_str() == "host.runtime.http_egress"
     ));
 
     let catalog = HostPortCatalog::new(vec![HostPortCatalogEntry::new(
         HostPortId::new("host.runtime.http_egress").unwrap(),
     )])
     .unwrap();
-    ExtensionManifest::parse_with_host_api_contracts(
+    ExtensionManifest::parse(
         &manifest,
         ManifestSource::InstalledLocal,
         &catalog,
@@ -702,7 +723,7 @@ prompt_doc_ref = "prompts/telegram/send_message.md"
 "#,
         "",
     );
-    let err = ExtensionManifest::parse_with_host_api_contracts(
+    let err = ExtensionManifest::parse(
         &manifest,
         ManifestSource::InstalledLocal,
         &HostPortCatalog::empty(),
@@ -743,7 +764,7 @@ async fn discovery_validates_capability_manifest_with_supplied_host_port_catalog
         &VirtualPath::new("/system/extensions").unwrap(),
         ManifestSource::HostBundled,
         &catalog,
-        &HostApiContractRegistry::new(),
+        &contracts(),
     )
     .await
     .unwrap();
@@ -779,7 +800,7 @@ async fn discovery_rejects_manifest_id_mismatch_with_directory() {
         &VirtualPath::new("/system/extensions").unwrap(),
         ManifestSource::HostBundled,
         &HostPortCatalog::empty(),
-        &HostApiContractRegistry::new(),
+        &contracts(),
     )
     .await
     .unwrap_err();
@@ -887,11 +908,22 @@ async fn lifecycle_service_does_not_install_when_required_event_sink_fails() {
     );
 }
 
+fn contracts() -> HostApiContractRegistry {
+    let mut registry = HostApiContractRegistry::new();
+    registry
+        .register(std::sync::Arc::new(
+            CapabilityProviderHostApiContract::new().unwrap(),
+        ))
+        .unwrap();
+    registry
+}
+
 fn parse_manifest(raw: &str) -> ExtensionManifest {
     ExtensionManifest::parse(
         raw,
         ManifestSource::InstalledLocal,
         &HostPortCatalog::empty(),
+        &contracts(),
     )
     .unwrap()
 }
@@ -945,7 +977,13 @@ trust = "untrusted"
 kind = "{runtime_kind}"
 {runtime_fields}
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "{capability}"
 description = "Run {capability}"
 effects = ["dispatch_capability"]
@@ -1012,7 +1050,7 @@ impl HostApiManifestContract for TestProductAdapterContract {
         &self,
         _host_api: &HostApiRefV2,
         section: &toml::Value,
-    ) -> Result<(), String> {
+    ) -> Result<(), HostApiSectionError> {
         let surface = section
             .get("surface_kind")
             .and_then(toml::Value::as_str)
@@ -1020,7 +1058,7 @@ impl HostApiManifestContract for TestProductAdapterContract {
         if surface == "telegram" {
             Ok(())
         } else {
-            Err("surface_kind must be telegram".to_string())
+            Err(HostApiSectionError::from("surface_kind must be telegram"))
         }
     }
 }
@@ -1036,7 +1074,13 @@ trust = "untrusted"
 kind = "wasm"
 module = "wasm/echo.wasm"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "echo.say"
 description = "Echo text"
 effects = ["dispatch_capability"]
@@ -1058,7 +1102,13 @@ trust = "untrusted"
 kind = "wasm"
 module = "wasm/echo.wasm"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "echo.say"
 description = "Echo text"
 effects = ["dispatch_capability"]
@@ -1131,7 +1181,13 @@ image = "python:3.12-slim"
 command = "pytest"
 args = ["tests/"]
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "project-tools.pytest"
 description = "Run pytest"
 effects = ["execute_code"]
@@ -1155,7 +1211,13 @@ transport = "stdio"
 command = "github-mcp-server"
 args = ["--stdio"]
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "github-mcp.search_issues"
 description = "Search GitHub issues"
 effects = ["network", "dispatch_capability"]
@@ -1187,7 +1249,13 @@ trust = "untrusted"
 kind = "wasm"
 module = "wasm/tool.wasm"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "hookext.run"
 description = "Run hookext"
 effects = ["dispatch_capability"]
@@ -1279,6 +1347,7 @@ type = "always"
         &manifest_with_hooks(hooks),
         ManifestSource::InstalledLocal,
         &HostPortCatalog::empty(),
+        &contracts(),
     )
     .expect_err("hook entry without id must be rejected");
     assert!(
@@ -1303,7 +1372,13 @@ hooks = ["not-a-table"]
 kind = "wasm"
 module = "wasm/tool.wasm"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "hookext.run"
 description = "Run hookext"
 effects = ["dispatch_capability"]
@@ -1317,6 +1392,7 @@ prompt_doc_ref = "prompts/hookext/run.md"
         manifest,
         ManifestSource::InstalledLocal,
         &HostPortCatalog::empty(),
+        &contracts(),
     )
     .expect_err("non-table hook entry must be rejected");
     assert!(
@@ -1343,6 +1419,7 @@ type = "always"
         &manifest_with_hooks(hooks),
         ManifestSource::InstalledLocal,
         &HostPortCatalog::empty(),
+        &contracts(),
     )
     .expect_err("whitespace-only hook id must be rejected");
     assert!(
@@ -1376,6 +1453,7 @@ type = "always"
         &manifest_with_hooks(&hooks),
         ManifestSource::InstalledLocal,
         &HostPortCatalog::empty(),
+        &contracts(),
     )
     .expect_err("oversized hook entry must be rejected");
     assert!(
@@ -1409,6 +1487,7 @@ export = "observe"
         &manifest_with_hooks(hooks),
         ManifestSource::InstalledLocal,
         &HostPortCatalog::empty(),
+        &contracts(),
     )
     .expect_err("duplicate hook ids must be rejected");
     assert!(
@@ -1440,6 +1519,7 @@ type = "always"
         &manifest_with_hooks(&hooks),
         ManifestSource::InstalledLocal,
         &HostPortCatalog::empty(),
+        &contracts(),
     )
     .expect_err("over-cap hook count must be rejected");
     assert!(
@@ -1476,6 +1556,7 @@ type = "always"
         &manifest_with_hooks(&hooks),
         ManifestSource::InstalledLocal,
         &HostPortCatalog::empty(),
+        &contracts(),
     )
     .expect("exactly MAX_MANIFEST_HOOKS entries must be accepted");
     assert_eq!(manifest.hooks.len(), MAX_MANIFEST_HOOKS);
@@ -1501,6 +1582,7 @@ type = "always"
         &manifest_with_hooks(hooks),
         ManifestSource::InstalledLocal,
         &HostPortCatalog::empty(),
+        &contracts(),
     )
     .unwrap();
     assert_eq!(v2.hooks.len(), 1);

--- a/crates/ironclaw_extensions/tests/installations_contract.rs
+++ b/crates/ironclaw_extensions/tests/installations_contract.rs
@@ -2,10 +2,11 @@ use std::collections::BTreeSet;
 
 use chrono::Utc;
 use ironclaw_extensions::{
-    ExtensionActivationState, ExtensionCredentialBinding, ExtensionCredentialHandle,
-    ExtensionHealthMessage, ExtensionHealthSnapshot, ExtensionHealthStatus, ExtensionInstallation,
-    ExtensionInstallationError, ExtensionInstallationId, ExtensionInstallationPersistedParts,
-    ExtensionInstallationStore, ExtensionManifestRecord, ExtensionManifestRef,
+    CapabilityProviderHostApiContract, ExtensionActivationState, ExtensionCredentialBinding,
+    ExtensionCredentialHandle, ExtensionHealthMessage, ExtensionHealthSnapshot,
+    ExtensionHealthStatus, ExtensionInstallation, ExtensionInstallationError,
+    ExtensionInstallationId, ExtensionInstallationPersistedParts, ExtensionInstallationStore,
+    ExtensionManifestRecord, ExtensionManifestRef, HostApiContractRegistry,
     InMemoryExtensionInstallationStore, InstallationOwner, MANIFEST_SCHEMA_VERSION, ManifestHash,
     ManifestSource, ManifestV2Error,
 };
@@ -23,7 +24,7 @@ fn manifest_hash(value: &str) -> ManifestHash {
     ManifestHash::new(value).unwrap()
 }
 
-fn raw_legacy_capability_manifest() -> String {
+fn raw_capability_provider_manifest() -> String {
     format!(
         r#"
 schema_version = "{schema}"
@@ -37,7 +38,13 @@ trust = "third_party"
 kind = "wasm"
 module = "wasm/acme.wasm"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "acme-tools.echo"
 description = "Echoes input"
 default_permission = "allow"
@@ -50,12 +57,23 @@ prompt_doc_ref = "prompts/acme/echo.md"
     )
 }
 
+fn contracts() -> HostApiContractRegistry {
+    let mut registry = HostApiContractRegistry::new();
+    registry
+        .register(std::sync::Arc::new(
+            CapabilityProviderHostApiContract::new().unwrap(),
+        ))
+        .unwrap();
+    registry
+}
+
 fn manifest(hash: &str) -> ExtensionManifestRecord {
     ExtensionManifestRecord::from_toml(
-        raw_legacy_capability_manifest(),
+        raw_capability_provider_manifest(),
         ManifestSource::HostBundled,
         &HostPortCatalog::empty(),
         Some(manifest_hash(hash)),
+        &contracts(),
     )
     .unwrap()
 }
@@ -87,23 +105,39 @@ fn installation_with_manifest_hash(hash: Option<&str>) -> ExtensionInstallation 
 }
 
 #[test]
-fn installed_legacy_top_level_capabilities_are_rejected() {
-    let err = ExtensionManifestRecord::from_toml(
-        raw_legacy_capability_manifest(),
-        ManifestSource::InstalledLocal,
-        &HostPortCatalog::empty(),
-        Some(manifest_hash("sha256:abc")),
-    )
-    .unwrap_err();
-
-    assert!(matches!(
-        err,
-        ExtensionInstallationError::Manifest(
-            ManifestV2Error::LegacyTopLevelCapabilitiesForInstalledSource {
-                manifest_source: ManifestSource::InstalledLocal
-            }
+fn top_level_capabilities_are_rejected_for_every_source() {
+    // The legacy manifest form is gone: capabilities are declared under an
+    // ironclaw.capability_provider/v1 host_api section, for host-bundled
+    // manifests exactly as for installed ones.
+    let legacy = raw_capability_provider_manifest()
+        .replace(
+            "[[host_api]]\nid = \"ironclaw.capability_provider/v1\"\nsection = \"capability_provider.tools\"\n\n[capability_provider.tools]\n\n",
+            "",
         )
-    ));
+        .replace("[[capability_provider.tools.capabilities]]", "[[capabilities]]");
+    for source in [
+        ManifestSource::InstalledLocal,
+        ManifestSource::RegistryInstalled,
+        ManifestSource::HostBundled,
+    ] {
+        let err = ExtensionManifestRecord::from_toml(
+            legacy.clone(),
+            source,
+            &HostPortCatalog::empty(),
+            Some(manifest_hash("sha256:abc")),
+            &contracts(),
+        )
+        .unwrap_err();
+        match err {
+            ExtensionInstallationError::Manifest(ManifestV2Error::Invalid { reason }) => {
+                assert!(
+                    reason.contains("top-level [[capabilities]] is not supported"),
+                    "{source:?}: {reason}"
+                );
+            }
+            other => panic!("{source:?}: expected Invalid, got {other:?}"),
+        }
+    }
 }
 
 #[tokio::test]
@@ -255,10 +289,11 @@ async fn manifest_hash_presence_mismatch_is_rejected() {
 
     let store = InMemoryExtensionInstallationStore::default();
     let manifest_without_hash = ExtensionManifestRecord::from_toml(
-        raw_legacy_capability_manifest(),
+        raw_capability_provider_manifest(),
         ManifestSource::HostBundled,
         &HostPortCatalog::empty(),
         None,
+        &contracts(),
     )
     .unwrap();
     store.upsert_manifest(manifest_without_hash).await.unwrap();

--- a/crates/ironclaw_extensions/tests/manifest_v2_contract.rs
+++ b/crates/ironclaw_extensions/tests/manifest_v2_contract.rs
@@ -6,8 +6,8 @@ use ironclaw_extensions::{
     CapabilityProviderHostApiContract, CapabilitySurfaceDeclV2, CapabilityVisibility,
     ExtensionManifestV2, ExtensionRuntimeV2, HostApiContractRegistry, HostApiId,
     HostApiManifestContext, HostApiManifestContract, HostApiManifestProjection,
-    HostApiMultiplicity, HostApiRefV2, MANIFEST_SCHEMA_VERSION, ManifestSectionPath,
-    ManifestSource, ManifestV2Error,
+    HostApiMultiplicity, HostApiRefV2, HostApiSectionError, MANIFEST_SCHEMA_VERSION,
+    ManifestSectionPath, ManifestSource, ManifestV2Error,
 };
 use ironclaw_host_api::{
     CapabilityProfileId, CapabilitySurfaceKind, ExtensionId, HostPortCatalog, HostPortCatalogEntry,
@@ -20,6 +20,16 @@ use ironclaw_host_api::{
 const TELEGRAM_TOKEN_PORT: &str = "host.secrets.telegram_bot_token";
 const AUDIT_PORT: &str = "host.events.audit";
 const SQL_TX_PORT: &str = "host.storage.sql_transaction.first_party";
+
+fn contracts() -> HostApiContractRegistry {
+    let mut registry = HostApiContractRegistry::new();
+    registry
+        .register(Arc::new(
+            CapabilityProviderHostApiContract::new().expect("contract"),
+        ))
+        .expect("register capability provider contract");
+    registry
+}
 
 fn catalog() -> HostPortCatalog {
     HostPortCatalog::new(vec![
@@ -44,7 +54,13 @@ trust = "third_party"
 kind = "wasm"
 module = "wasm/example.wasm"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "{cap}"
 description = "Echoes input"
 default_permission = "allow"
@@ -61,8 +77,13 @@ output_schema_ref = "schemas/example/echo.output.v1.json"
 #[test]
 fn parses_minimum_valid_v2_manifest_for_installed_third_party_extension() {
     let toml = third_party_wasm_manifest("acme-tools", "acme-tools.echo");
-    let manifest =
-        ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog()).unwrap();
+    let manifest = ExtensionManifestV2::parse(
+        &toml,
+        ManifestSource::InstalledLocal,
+        &catalog(),
+        &contracts(),
+    )
+    .unwrap();
 
     assert_eq!(manifest.schema_version, MANIFEST_SCHEMA_VERSION);
     assert_eq!(manifest.id, ExtensionId::new("acme-tools").unwrap());
@@ -87,8 +108,13 @@ runtime_credentials = [
 ]
 default_permission = "allow""#,
     );
-    let manifest =
-        ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog()).unwrap();
+    let manifest = ExtensionManifestV2::parse(
+        &toml,
+        ManifestSource::InstalledLocal,
+        &catalog(),
+        &contracts(),
+    )
+    .unwrap();
 
     let credential = &manifest.capabilities[0].runtime_credentials[0];
     assert_eq!(
@@ -127,8 +153,13 @@ runtime_credentials = [
 ]
 default_permission = "allow""#,
     );
-    let manifest =
-        ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog()).unwrap();
+    let manifest = ExtensionManifestV2::parse(
+        &toml,
+        ManifestSource::InstalledLocal,
+        &catalog(),
+        &contracts(),
+    )
+    .unwrap();
 
     assert_eq!(
         manifest.capabilities[0].runtime_credentials[0].source,
@@ -149,8 +180,13 @@ runtime_credentials = [
 ]
 default_permission = "allow""#,
     );
-    let manifest =
-        ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog()).unwrap();
+    let manifest = ExtensionManifestV2::parse(
+        &toml,
+        ManifestSource::InstalledLocal,
+        &catalog(),
+        &contracts(),
+    )
+    .unwrap();
 
     assert_eq!(
         manifest.capabilities[0].runtime_credentials[0].provider_scopes,
@@ -177,8 +213,13 @@ default_permission = "allow""#
             ),
         );
 
-        let err = ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog())
-            .unwrap_err();
+        let err = ExtensionManifestV2::parse(
+            &toml,
+            ManifestSource::InstalledLocal,
+            &catalog(),
+            &contracts(),
+        )
+        .unwrap_err();
         assert!(matches!(err, ManifestV2Error::Invalid { .. }), "{err:?}");
         assert!(
             err.to_string().contains("provider scope"),
@@ -197,8 +238,13 @@ runtime_credentials = [
 ]
 default_permission = "allow""#,
     );
-    let err =
-        ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog()).unwrap_err();
+    let err = ExtensionManifestV2::parse(
+        &toml,
+        ManifestSource::InstalledLocal,
+        &catalog(),
+        &contracts(),
+    )
+    .unwrap_err();
 
     assert!(matches!(err, ManifestV2Error::Invalid { .. }), "{err:?}");
     assert!(
@@ -216,8 +262,13 @@ fn rejects_runtime_credentials_without_use_secret_effect() {
 ]
 default_permission = "allow""#,
     );
-    let err =
-        ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog()).unwrap_err();
+    let err = ExtensionManifestV2::parse(
+        &toml,
+        ManifestSource::InstalledLocal,
+        &catalog(),
+        &contracts(),
+    )
+    .unwrap_err();
     assert!(matches!(err, ManifestV2Error::Invalid { .. }), "{err:?}");
     assert!(err.to_string().contains("use_secret"), "{err:?}");
 }
@@ -234,8 +285,13 @@ network_targets = [
 ]
 default_permission = "allow""#,
     );
-    let manifest =
-        ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog()).unwrap();
+    let manifest = ExtensionManifestV2::parse(
+        &toml,
+        ManifestSource::InstalledLocal,
+        &catalog(),
+        &contracts(),
+    )
+    .unwrap();
 
     let cap = &manifest.capabilities[0];
     assert!(
@@ -262,8 +318,13 @@ network_targets = [
 ]
 default_permission = "allow""#,
     );
-    let err =
-        ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog()).unwrap_err();
+    let err = ExtensionManifestV2::parse(
+        &toml,
+        ManifestSource::InstalledLocal,
+        &catalog(),
+        &contracts(),
+    )
+    .unwrap_err();
     assert!(matches!(err, ManifestV2Error::Invalid { .. }), "{err:?}");
     assert!(
         err.to_string().contains("network_targets without network"),
@@ -282,8 +343,13 @@ network_targets = [
 ]
 default_permission = "allow""#,
     );
-    let err =
-        ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog()).unwrap_err();
+    let err = ExtensionManifestV2::parse(
+        &toml,
+        ManifestSource::InstalledLocal,
+        &catalog(),
+        &contracts(),
+    )
+    .unwrap_err();
     assert!(matches!(err, ManifestV2Error::Invalid { .. }), "{err:?}");
     assert!(
         err.to_string().contains("duplicate network target"),
@@ -301,8 +367,13 @@ runtime_credentials = [
 ]
 default_permission = "allow""#,
     );
-    let err =
-        ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog()).unwrap_err();
+    let err = ExtensionManifestV2::parse(
+        &toml,
+        ManifestSource::InstalledLocal,
+        &catalog(),
+        &contracts(),
+    )
+    .unwrap_err();
     assert!(matches!(err, ManifestV2Error::Invalid { .. }), "{err:?}");
     assert!(
         err.to_string()
@@ -321,8 +392,13 @@ runtime_credentials = [
 ]
 default_permission = "allow""#,
     );
-    let err =
-        ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog()).unwrap_err();
+    let err = ExtensionManifestV2::parse(
+        &toml,
+        ManifestSource::InstalledLocal,
+        &catalog(),
+        &contracts(),
+    )
+    .unwrap_err();
     assert!(matches!(err, ManifestV2Error::Invalid { .. }), "{err:?}");
     assert!(
         err.to_string()
@@ -347,8 +423,13 @@ runtime_credentials = [
 default_permission = "allow""#
             ),
         );
-        let err = ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog())
-            .unwrap_err();
+        let err = ExtensionManifestV2::parse(
+            &toml,
+            ManifestSource::InstalledLocal,
+            &catalog(),
+            &contracts(),
+        )
+        .unwrap_err();
         assert!(matches!(err, ManifestV2Error::Invalid { .. }), "{err:?}");
         assert!(err.to_string().contains("https scheme"), "{err:?}");
     }
@@ -364,8 +445,13 @@ runtime_credentials = [
 ]
 default_permission = "allow""#,
     );
-    let err =
-        ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog()).unwrap_err();
+    let err = ExtensionManifestV2::parse(
+        &toml,
+        ManifestSource::InstalledLocal,
+        &catalog(),
+        &contracts(),
+    )
+    .unwrap_err();
     assert!(err.to_string().contains("invalid secret"), "{err:?}");
 }
 
@@ -381,12 +467,22 @@ runtime_credentials = [
 ]
 default_permission = "allow""#,
     );
-    let err =
-        ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog()).unwrap_err();
-    // Unknown source.type produces a Parse error (serde unknown variant), not Invalid.
+    let err = ExtensionManifestV2::parse(
+        &toml,
+        ManifestSource::InstalledLocal,
+        &catalog(),
+        &contracts(),
+    )
+    .unwrap_err();
+    // Unknown source.type fails the owning capability-provider section
+    // fail-closed (serde unknown variant), never silently defaulting.
     assert!(
-        matches!(err, ManifestV2Error::Parse { .. }),
-        "expected parse error for unknown source type, got {err:?}"
+        matches!(
+            &err,
+            ManifestV2Error::HostApiSectionRejected { reason, .. }
+                if reason.contains("unknown variant `oauth_token_v99`")
+        ),
+        "expected section rejection for unknown source type, got {err:?}"
     );
 }
 
@@ -401,8 +497,13 @@ runtime_credentials = [
 ]
 default_permission = "allow""#,
     );
-    let err =
-        ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog()).unwrap_err();
+    let err = ExtensionManifestV2::parse(
+        &toml,
+        ManifestSource::InstalledLocal,
+        &catalog(),
+        &contracts(),
+    )
+    .unwrap_err();
     assert!(matches!(err, ManifestV2Error::Invalid { .. }), "{err:?}");
     assert!(
         err.to_string().contains("duplicate runtime credential"),
@@ -425,7 +526,13 @@ oops = true
 kind = "wasm"
 module = "wasm/echo.wasm"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "acme-tools.echo"
 description = "echo"
 default_permission = "allow"
@@ -433,22 +540,39 @@ visibility = "host_internal"
 input_schema_ref = "schemas/acme/echo.input.v1.json"
 output_schema_ref = "schemas/acme/echo.output.v1.json"
 "#;
-    let err =
-        ExtensionManifestV2::parse(toml, ManifestSource::InstalledLocal, &catalog()).unwrap_err();
+    let err = ExtensionManifestV2::parse(
+        toml,
+        ManifestSource::InstalledLocal,
+        &catalog(),
+        &contracts(),
+    )
+    .unwrap_err();
     assert!(matches!(err, ManifestV2Error::Parse { .. }), "{err:?}");
 }
 
 #[test]
-fn rejects_unknown_top_level_tables_in_legacy_capability_manifests() {
+fn rejects_unknown_top_level_tables_as_unreferenced_operational_sections() {
     let toml = third_party_wasm_manifest("acme-tools", "acme-tools.echo")
         + r#"
 
 [surprise]
 enabled = true
 "#;
-    let err =
-        ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog()).unwrap_err();
-    assert!(matches!(err, ManifestV2Error::Parse { .. }), "{err:?}");
+    let err = ExtensionManifestV2::parse(
+        &toml,
+        ManifestSource::InstalledLocal,
+        &catalog(),
+        &contracts(),
+    )
+    .unwrap_err();
+    assert!(
+        matches!(
+            &err,
+            ManifestV2Error::UnreferencedOperationalSection { section }
+                if section.as_str() == "surprise"
+        ),
+        "{err:?}"
+    );
 }
 
 #[test]
@@ -466,7 +590,13 @@ trust = "first_party_requested"
 kind = "wasm"
 module = "wasm/echo.wasm"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "acme-tools.echo"
 description = "echo"
 default_permission = "allow"
@@ -476,8 +606,13 @@ output_schema_ref = "schemas/acme/echo.output.v1.json"
 "#,
         schema = MANIFEST_SCHEMA_VERSION,
     );
-    let err =
-        ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog()).unwrap_err();
+    let err = ExtensionManifestV2::parse(
+        &toml,
+        ManifestSource::InstalledLocal,
+        &catalog(),
+        &contracts(),
+    )
+    .unwrap_err();
     assert!(
         matches!(
             err,
@@ -505,7 +640,13 @@ trust = "third_party"
 kind = "first_party"
 service = "native_memory_provider"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "acme-tools.echo"
 description = "echo"
 default_permission = "allow"
@@ -515,8 +656,13 @@ output_schema_ref = "schemas/acme/echo.output.v1.json"
 "#,
         schema = MANIFEST_SCHEMA_VERSION,
     );
-    let err =
-        ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog()).unwrap_err();
+    let err = ExtensionManifestV2::parse(
+        &toml,
+        ManifestSource::InstalledLocal,
+        &catalog(),
+        &contracts(),
+    )
+    .unwrap_err();
     assert!(
         matches!(
             err,
@@ -544,7 +690,13 @@ trust = "first_party_requested"
 kind = "first_party"
 service = "native_memory_provider"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "ironclaw.memory.native.context.retrieve"
 implements = ["memory.context_retrieval.v1"]
 description = "Retrieve bounded provider-neutral memory context."
@@ -560,7 +712,8 @@ required_host_ports = [
         schema = MANIFEST_SCHEMA_VERSION,
     );
     let manifest =
-        ExtensionManifestV2::parse(&toml, ManifestSource::HostBundled, &catalog()).unwrap();
+        ExtensionManifestV2::parse(&toml, ManifestSource::HostBundled, &catalog(), &contracts())
+            .unwrap();
     assert_eq!(
         manifest.requested_trust,
         RequestedTrustClass::FirstPartyRequested
@@ -585,8 +738,13 @@ required_host_ports = [
 #[test]
 fn rejects_reserved_id_prefix_for_installed_source() {
     let toml = third_party_wasm_manifest("ironclaw.fake", "ironclaw.fake.echo");
-    let err = ExtensionManifestV2::parse(&toml, ManifestSource::RegistryInstalled, &catalog())
-        .unwrap_err();
+    let err = ExtensionManifestV2::parse(
+        &toml,
+        ManifestSource::RegistryInstalled,
+        &catalog(),
+        &contracts(),
+    )
+    .unwrap_err();
     assert!(
         matches!(err, ManifestV2Error::ReservedIdForInstalledSource { .. }),
         "{err:?}"
@@ -596,8 +754,13 @@ fn rejects_reserved_id_prefix_for_installed_source() {
 #[test]
 fn rejects_capability_id_without_provider_prefix() {
     let toml = third_party_wasm_manifest("acme-tools", "other.echo");
-    let err =
-        ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog()).unwrap_err();
+    let err = ExtensionManifestV2::parse(
+        &toml,
+        ManifestSource::InstalledLocal,
+        &catalog(),
+        &contracts(),
+    )
+    .unwrap_err();
     assert!(
         matches!(err, ManifestV2Error::CapabilityIdNotPrefixed { .. }),
         "{err:?}"
@@ -619,7 +782,13 @@ trust = "third_party"
 kind = "wasm"
 module = "wasm/echo.wasm"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "acme-tools.echo"
 description = "echo"
 default_permission = "allow"
@@ -630,8 +799,13 @@ required_host_ports = ["host.does.not.exist"]
 "#,
         schema = MANIFEST_SCHEMA_VERSION,
     );
-    let err =
-        ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog()).unwrap_err();
+    let err = ExtensionManifestV2::parse(
+        &toml,
+        ManifestSource::InstalledLocal,
+        &catalog(),
+        &contracts(),
+    )
+    .unwrap_err();
     assert!(
         matches!(err, ManifestV2Error::UnknownHostPort { .. }),
         "{err:?}"
@@ -653,7 +827,13 @@ trust = "third_party"
 kind = "wasm"
 module = "wasm/echo.wasm"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "acme-tools.echo"
 description = "echo"
 default_permission = "allow"
@@ -663,8 +843,13 @@ output_schema_ref = "schemas/acme/echo.output.v1.json"
 "#,
         schema = MANIFEST_SCHEMA_VERSION,
     );
-    let manifest =
-        ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog()).unwrap();
+    let manifest = ExtensionManifestV2::parse(
+        &toml,
+        ManifestSource::InstalledLocal,
+        &catalog(),
+        &contracts(),
+    )
+    .unwrap();
     assert_eq!(manifest.capabilities.len(), 1);
     assert!(manifest.capabilities[0].prompt_doc_ref.is_none());
 }
@@ -690,7 +875,13 @@ trust = "third_party"
 kind = "wasm"
 module = "wasm/echo.wasm"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "acme-tools.echo"
 description = "echo"
 default_permission = "allow"
@@ -701,8 +892,13 @@ output_schema_ref = "schemas/acme/echo.output.v1.json"
             schema = MANIFEST_SCHEMA_VERSION,
             bad = bad_ref,
         );
-        let err = ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog())
-            .unwrap_err();
+        let err = ExtensionManifestV2::parse(
+            &toml,
+            ManifestSource::InstalledLocal,
+            &catalog(),
+            &contracts(),
+        )
+        .unwrap_err();
         assert!(
             matches!(
                 err,
@@ -730,7 +926,13 @@ trust = "third_party"
 kind = "wasm"
 module = "wasm/echo.wasm"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "acme-tools.echo"
 description = "echo"
 default_permission = "allow"
@@ -738,8 +940,13 @@ visibility = "host_internal"
 input_schema_ref = "schemas/acme/echo.input.v1.json"
 output_schema_ref = "schemas/acme/echo.output.v1.json"
 "#;
-    let err =
-        ExtensionManifestV2::parse(toml, ManifestSource::InstalledLocal, &catalog()).unwrap_err();
+    let err = ExtensionManifestV2::parse(
+        toml,
+        ManifestSource::InstalledLocal,
+        &catalog(),
+        &contracts(),
+    )
+    .unwrap_err();
     assert!(
         matches!(err, ManifestV2Error::SchemaVersion { .. }),
         "{err:?}"
@@ -760,7 +967,13 @@ description = "x"
 kind = "wasm"
 module = "wasm/echo.wasm"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "acme-tools.echo"
 description = "echo"
 default_permission = "allow"
@@ -770,8 +983,13 @@ output_schema_ref = "schemas/acme/echo.output.v1.json"
 "#,
         schema = MANIFEST_SCHEMA_VERSION,
     );
-    let manifest =
-        ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog()).unwrap();
+    let manifest = ExtensionManifestV2::parse(
+        &toml,
+        ManifestSource::InstalledLocal,
+        &catalog(),
+        &contracts(),
+    )
+    .unwrap();
     assert_eq!(manifest.requested_trust, RequestedTrustClass::Untrusted);
     assert_eq!(manifest.descriptor_trust_default, TrustClass::Sandbox);
 }
@@ -792,7 +1010,13 @@ trust = "third_party"
 kind = "wasm"
 module = "wasm/echo.wasm"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "acme-tools.echo"
 description = "echo"
 default_permission = "allow"
@@ -805,8 +1029,13 @@ output_schema_ref = "schemas/acme/echo.output.v1.json"
             version = if field == "version" { value } else { "0.1" },
             description = if field == "description" { value } else { "x" },
         );
-        let err = ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog())
-            .unwrap_err();
+        let err = ExtensionManifestV2::parse(
+            &toml,
+            ManifestSource::InstalledLocal,
+            &catalog(),
+            &contracts(),
+        )
+        .unwrap_err();
         assert!(
             matches!(err, ManifestV2Error::Invalid { .. }),
             "{field}={value:?} should be rejected, got {err:?}"
@@ -842,7 +1071,13 @@ trust = "third_party"
 kind = "wasm"
 module = "{bad}"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "acme-tools.echo"
 description = "echo"
 default_permission = "allow"
@@ -853,8 +1088,13 @@ output_schema_ref = "schemas/acme/echo.output.v1.json"
             schema = MANIFEST_SCHEMA_VERSION,
             bad = bad.replace('\\', "\\\\"),
         );
-        let err = ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog())
-            .unwrap_err();
+        let err = ExtensionManifestV2::parse(
+            &toml,
+            ManifestSource::InstalledLocal,
+            &catalog(),
+            &contracts(),
+        )
+        .unwrap_err();
         assert!(
             matches!(err, ManifestV2Error::InvalidWasmModuleRef { .. }),
             "wasm module {bad:?} should be rejected, got {err:?}"
@@ -865,7 +1105,13 @@ output_schema_ref = "schemas/acme/echo.output.v1.json"
 #[test]
 fn mcp_runtime_enforces_transport_and_shape() {
     let cap_block = r#"
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "acme-mcp.search"
 description = "search"
 default_permission = "allow"
@@ -892,8 +1138,13 @@ trust = "third_party"
         "[runtime]\nkind = \"mcp\"\ntransport = \"sse\"\nurl = \"https://example.com/mcp\"\n",
     ] {
         let toml = format!("{header}\n{runtime}\n{cap_block}");
-        ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog())
-            .unwrap_or_else(|err| panic!("valid mcp runtime rejected: {err:?}\n{runtime}"));
+        ExtensionManifestV2::parse(
+            &toml,
+            ManifestSource::InstalledLocal,
+            &catalog(),
+            &contracts(),
+        )
+        .unwrap_or_else(|err| panic!("valid mcp runtime rejected: {err:?}\n{runtime}"));
     }
 
     // rejects: stdio with url; http without url; http with command; unknown transport; ftp url.
@@ -907,8 +1158,13 @@ trust = "third_party"
         "[runtime]\nkind = \"mcp\"\ntransport = \"\"\n",
     ] {
         let toml = format!("{header}\n{runtime}\n{cap_block}");
-        let err = ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog())
-            .unwrap_err();
+        let err = ExtensionManifestV2::parse(
+            &toml,
+            ManifestSource::InstalledLocal,
+            &catalog(),
+            &contracts(),
+        )
+        .unwrap_err();
         assert!(
             matches!(err, ManifestV2Error::InvalidMcpRuntime { .. }),
             "runtime should be rejected:\n{runtime}\n got {err:?}"
@@ -931,7 +1187,13 @@ trust = "third_party"
 kind = "wasm"
 module = "wasm/echo.wasm"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "acme-tools.echo"
 description = "echo"
 default_permission = "allow"
@@ -942,8 +1204,13 @@ required_host_ports = ["host.events.audit", "host.events.audit"]
 "#,
         schema = MANIFEST_SCHEMA_VERSION,
     );
-    let err =
-        ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog()).unwrap_err();
+    let err = ExtensionManifestV2::parse(
+        &toml,
+        ManifestSource::InstalledLocal,
+        &catalog(),
+        &contracts(),
+    )
+    .unwrap_err();
     assert!(
         matches!(err, ManifestV2Error::DuplicateRequiredHostPort { .. }),
         "{err:?}"
@@ -965,7 +1232,13 @@ trust = "third_party"
 kind = "wasm"
 module = "wasm/echo.wasm"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "acme-tools.echo"
 implements = ["memory.context_retrieval.v1", "memory.context_retrieval.v1"]
 description = "echo"
@@ -976,8 +1249,13 @@ output_schema_ref = "schemas/acme/echo.output.v1.json"
 "#,
         schema = MANIFEST_SCHEMA_VERSION,
     );
-    let err =
-        ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog()).unwrap_err();
+    let err = ExtensionManifestV2::parse(
+        &toml,
+        ManifestSource::InstalledLocal,
+        &catalog(),
+        &contracts(),
+    )
+    .unwrap_err();
     assert!(
         matches!(err, ManifestV2Error::DuplicateImplementedProfile { .. }),
         "{err:?}"
@@ -999,7 +1277,13 @@ trust = "third_party"
 kind = "wasm"
 module = "wasm/echo.wasm"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "acme-tools.echo"
 description = "echo"
 default_permission = "allow"
@@ -1010,9 +1294,21 @@ sneaky = true
 "#,
         schema = MANIFEST_SCHEMA_VERSION,
     );
-    let err =
-        ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog()).unwrap_err();
-    assert!(matches!(err, ManifestV2Error::Parse { .. }), "{err:?}");
+    let err = ExtensionManifestV2::parse(
+        &toml,
+        ManifestSource::InstalledLocal,
+        &catalog(),
+        &contracts(),
+    )
+    .unwrap_err();
+    assert!(
+        matches!(
+            &err,
+            ManifestV2Error::HostApiSectionRejected { reason, .. }
+                if reason.contains("unknown field `sneaky`")
+        ),
+        "{err:?}"
+    );
 }
 
 #[test]
@@ -1030,7 +1326,13 @@ trust = "third_party"
 kind = "wasm"
 module = "wasm/echo.wasm"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "acme-tools.echo"
 description = "echo"
 default_permission = "allow"
@@ -1038,7 +1340,7 @@ visibility = "host_internal"
 input_schema_ref = "schemas/acme/echo.input.v1.json"
 output_schema_ref = "schemas/acme/echo.output.v1.json"
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "acme-tools.echo"
 description = "echo (dup)"
 default_permission = "allow"
@@ -1048,8 +1350,13 @@ output_schema_ref = "schemas/acme/echo.output.v1.json"
 "#,
         schema = MANIFEST_SCHEMA_VERSION,
     );
-    let err =
-        ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog()).unwrap_err();
+    let err = ExtensionManifestV2::parse(
+        &toml,
+        ManifestSource::InstalledLocal,
+        &catalog(),
+        &contracts(),
+    )
+    .unwrap_err();
     assert!(
         matches!(err, ManifestV2Error::DuplicateCapability { .. }),
         "{err:?}"
@@ -1068,7 +1375,8 @@ fn host_bundled_accepts_non_reserved_id() {
     // accidentally become a "must use" rule downstream.
     let toml = third_party_wasm_manifest("memory-native", "memory-native.echo");
     let manifest =
-        ExtensionManifestV2::parse(&toml, ManifestSource::HostBundled, &catalog()).unwrap();
+        ExtensionManifestV2::parse(&toml, ManifestSource::HostBundled, &catalog(), &contracts())
+            .unwrap();
     assert_eq!(manifest.source, ManifestSource::HostBundled);
     assert_eq!(manifest.id, ExtensionId::new("memory-native").unwrap());
 }
@@ -1088,7 +1396,13 @@ trust = "third_party"
 kind = "wasm"
 module = "wasm/acme.wasm"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "acme-tools.echo"
 implements = ["acme.echo.v1"]
 description = "echo"
@@ -1097,7 +1411,7 @@ visibility = "host_internal"
 input_schema_ref = "schemas/acme/echo.input.v1.json"
 output_schema_ref = "schemas/acme/echo.output.v1.json"
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "acme-tools.reverse"
 implements = ["acme.reverse.v1", "acme.string_ops.v1"]
 description = "reverse a string"
@@ -1109,8 +1423,13 @@ prompt_doc_ref = "prompt/acme/reverse.md"
 "#,
         schema = MANIFEST_SCHEMA_VERSION,
     );
-    let manifest =
-        ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog()).unwrap();
+    let manifest = ExtensionManifestV2::parse(
+        &toml,
+        ManifestSource::InstalledLocal,
+        &catalog(),
+        &contracts(),
+    )
+    .unwrap();
     assert_eq!(manifest.capabilities.len(), 2);
     assert_eq!(
         manifest.capabilities[0].implements,
@@ -1135,8 +1454,13 @@ fn rejects_manifest_exceeding_max_size() {
     while huge.len() <= MAX_MANIFEST_BYTES {
         huge.push_str("# filler line to defeat short-circuit eval\n");
     }
-    let err =
-        ExtensionManifestV2::parse(&huge, ManifestSource::InstalledLocal, &catalog()).unwrap_err();
+    let err = ExtensionManifestV2::parse(
+        &huge,
+        ManifestSource::InstalledLocal,
+        &catalog(),
+        &contracts(),
+    )
+    .unwrap_err();
     assert!(
         matches!(err, ManifestV2Error::ManifestTooLarge { bytes, max } if bytes == huge.len() && max == MAX_MANIFEST_BYTES),
         "{err:?}"
@@ -1158,7 +1482,13 @@ trust = "third_party"
 kind = "wasm"
 module = "wasm/acme.wasm"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "acme-tools.echo"
 description = "echo"
 default_permission = "allow"
@@ -1169,8 +1499,13 @@ output_schema_ref = "schemas/acme/echo.output.v1.json"
 "#,
         schema = MANIFEST_SCHEMA_VERSION,
     );
-    let err =
-        ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog()).unwrap_err();
+    let err = ExtensionManifestV2::parse(
+        &toml,
+        ManifestSource::InstalledLocal,
+        &catalog(),
+        &contracts(),
+    )
+    .unwrap_err();
     assert!(
         matches!(err, ManifestV2Error::DuplicateEffect { .. }),
         "{err:?}"
@@ -1195,7 +1530,13 @@ trust = "third_party"
 kind = "wasm"
 module = "wasm/acme.wasm"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "acme-tools.echo"
 description = "echo"
 default_permission = "allow"
@@ -1205,8 +1546,13 @@ output_schema_ref = "schemas/acme/echo.output.v1.json"
 "#,
         schema = MANIFEST_SCHEMA_VERSION,
     );
-    let err =
-        ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog()).unwrap_err();
+    let err = ExtensionManifestV2::parse(
+        &toml,
+        ManifestSource::InstalledLocal,
+        &catalog(),
+        &contracts(),
+    )
+    .unwrap_err();
     match err {
         ManifestV2Error::InvalidSchemaRef { field, .. } => {
             assert_eq!(field, "input_schema_ref");
@@ -1258,14 +1604,17 @@ impl HostApiManifestContract for FakeHostApiContract {
         &self,
         _host_api: &HostApiRefV2,
         section: &toml::Value,
-    ) -> Result<(), String> {
+    ) -> Result<(), HostApiSectionError> {
         let table = section
             .as_table()
-            .ok_or_else(|| "section must be a table".to_string())?;
+            .ok_or_else(|| HostApiSectionError::from("section must be a table"))?;
         if table.contains_key(self.required_key) {
             Ok(())
         } else {
-            Err(format!("missing required key {}", self.required_key))
+            Err(HostApiSectionError::from(format!(
+                "missing required key {}",
+                self.required_key
+            )))
         }
     }
 }
@@ -1334,7 +1683,7 @@ prompt_doc_ref = "prompts/telegram/send_message.md"
 #[test]
 fn parses_multi_host_api_extension_contracts_with_explicit_sections() {
     let registry = host_api_registry();
-    let manifest = ExtensionManifestV2::parse_with_host_api_contracts(
+    let manifest = ExtensionManifestV2::parse(
         &telegram_multi_host_api_manifest(),
         ManifestSource::InstalledLocal,
         &catalog(),
@@ -1364,28 +1713,13 @@ fn parses_multi_host_api_extension_contracts_with_explicit_sections() {
 }
 
 #[test]
-fn host_api_manifests_require_contract_registry() {
-    let err = ExtensionManifestV2::parse(
-        &telegram_multi_host_api_manifest(),
-        ManifestSource::InstalledLocal,
-        &catalog(),
-    )
-    .unwrap_err();
-    assert!(matches!(err, ManifestV2Error::Invalid { .. }), "{err:?}");
-}
-
-#[test]
 fn rejects_unknown_host_api_fail_closed() {
     let registry = host_api_registry();
     let toml = telegram_multi_host_api_manifest()
         .replace("ironclaw.product_adapter/v1", "ironclaw.unknown/v1");
-    let err = ExtensionManifestV2::parse_with_host_api_contracts(
-        &toml,
-        ManifestSource::InstalledLocal,
-        &catalog(),
-        &registry,
-    )
-    .unwrap_err();
+    let err =
+        ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog(), &registry)
+            .unwrap_err();
     assert!(
         matches!(err, ManifestV2Error::UnknownHostApi { .. }),
         "{err:?}"
@@ -1405,13 +1739,9 @@ section = "capability_provider.more_tools"
 [capability_provider.more_tools]
 capabilities = [{ id = "edit_message" }]
 "#;
-    let err = ExtensionManifestV2::parse_with_host_api_contracts(
-        &toml,
-        ManifestSource::InstalledLocal,
-        &catalog(),
-        &registry,
-    )
-    .unwrap_err();
+    let err =
+        ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog(), &registry)
+            .unwrap_err();
     assert!(
         matches!(err, ManifestV2Error::DuplicateHostApi { .. }),
         "{err:?}"
@@ -1431,13 +1761,9 @@ section = "product_adapter.admin"
 [product_adapter.admin]
 surface_kind = "telegram_admin"
 "#;
-    let manifest = ExtensionManifestV2::parse_with_host_api_contracts(
-        &toml,
-        ManifestSource::InstalledLocal,
-        &catalog(),
-        &registry,
-    )
-    .unwrap();
+    let manifest =
+        ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog(), &registry)
+            .unwrap();
     assert_eq!(manifest.host_apis.len(), 3);
 }
 
@@ -1448,13 +1774,9 @@ fn rejects_missing_referenced_host_api_section() {
         "section = \"product_adapter.inbound\"",
         "section = \"product_adapter.missing\"",
     );
-    let err = ExtensionManifestV2::parse_with_host_api_contracts(
-        &toml,
-        ManifestSource::InstalledLocal,
-        &catalog(),
-        &registry,
-    )
-    .unwrap_err();
+    let err =
+        ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog(), &registry)
+            .unwrap_err();
     assert!(
         matches!(err, ManifestV2Error::MissingHostApiSection { .. }),
         "{err:?}"
@@ -1476,13 +1798,9 @@ icon = "telegram"
 [x.experimental]
 note = "ignored by core parser"
 "#;
-    let err = ExtensionManifestV2::parse_with_host_api_contracts(
-        &toml,
-        ManifestSource::InstalledLocal,
-        &catalog(),
-        &registry,
-    )
-    .unwrap_err();
+    let err =
+        ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog(), &registry)
+            .unwrap_err();
     assert!(
         matches!(err, ManifestV2Error::UnreferencedOperationalSection { .. }),
         "{err:?}"
@@ -1503,13 +1821,9 @@ visibility = "host_internal"
 input_schema_ref = "schemas/telegram/legacy.input.v1.json"
 output_schema_ref = "schemas/telegram/legacy.output.v1.json"
 "#;
-    let err = ExtensionManifestV2::parse_with_host_api_contracts(
-        &toml,
-        ManifestSource::InstalledLocal,
-        &catalog(),
-        &registry,
-    )
-    .unwrap_err();
+    let err =
+        ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog(), &registry)
+            .unwrap_err();
     assert!(matches!(err, ManifestV2Error::Invalid { .. }), "{err:?}");
 }
 
@@ -1545,7 +1859,7 @@ fn duplicate_contract_registration_does_not_replace_existing_contract() {
     );
     registry.register(capabilities).unwrap();
 
-    ExtensionManifestV2::parse_with_host_api_contracts(
+    ExtensionManifestV2::parse(
         &telegram_multi_host_api_manifest(),
         ManifestSource::InstalledLocal,
         &catalog(),
@@ -1587,13 +1901,9 @@ surface_kind = "telegram"
         schema = MANIFEST_SCHEMA_VERSION,
     );
 
-    let err = ExtensionManifestV2::parse_with_host_api_contracts(
-        &toml,
-        ManifestSource::InstalledLocal,
-        &catalog(),
-        &registry,
-    )
-    .unwrap_err();
+    let err =
+        ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog(), &registry)
+            .unwrap_err();
     assert!(
         matches!(err, ManifestV2Error::DuplicateHostApiSection { .. }),
         "{err:?}"
@@ -1639,7 +1949,7 @@ impl HostApiManifestContract for SurfaceProjectingContract {
         &self,
         _host_api: &HostApiRefV2,
         _section: &toml::Value,
-    ) -> Result<(), String> {
+    ) -> Result<(), HostApiSectionError> {
         Ok(())
     }
 
@@ -1648,7 +1958,7 @@ impl HostApiManifestContract for SurfaceProjectingContract {
         _context: &HostApiManifestContext<'_>,
         _host_api: &HostApiRefV2,
         _section: &toml::Value,
-    ) -> Result<HostApiManifestProjection, String> {
+    ) -> Result<HostApiManifestProjection, HostApiSectionError> {
         Ok(HostApiManifestProjection {
             surfaces: self.surfaces.clone(),
             ..HostApiManifestProjection::default()
@@ -1670,7 +1980,13 @@ trust = "third_party"
 kind = "wasm"
 module = "wasm/example.wasm"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "{ext}.read"
 description = "Reads provider data"
 effects = ["network", "use_secret"]
@@ -1692,8 +2008,13 @@ output_schema_ref = "schemas/example/read.output.v1.json"
 #[test]
 fn tool_only_manifest_projects_one_tool_surface_per_capability_and_nothing_else() {
     let toml = third_party_wasm_manifest("acme-tools", "acme-tools.echo");
-    let manifest =
-        ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog()).unwrap();
+    let manifest = ExtensionManifestV2::parse(
+        &toml,
+        ManifestSource::InstalledLocal,
+        &catalog(),
+        &contracts(),
+    )
+    .unwrap();
 
     let surfaces = manifest.capability_surfaces();
     assert_eq!(surfaces.len(), 1, "{surfaces:?}");
@@ -1726,7 +2047,13 @@ trust = "third_party"
 kind = "wasm"
 module = "wasm/example.wasm"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "acme-tools.search"
 description = "Search"
 effects = ["network", "use_secret"]
@@ -1738,7 +2065,7 @@ visibility = "model"
 input_schema_ref = "schemas/acme/search.input.v1.json"
 output_schema_ref = "schemas/acme/search.output.v1.json"
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "acme-tools.send"
 description = "Send"
 effects = ["network", "use_secret"]
@@ -1750,7 +2077,7 @@ visibility = "model"
 input_schema_ref = "schemas/acme/send.input.v1.json"
 output_schema_ref = "schemas/acme/send.output.v1.json"
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "acme-tools.legacy"
 description = "Legacy manual-token path"
 effects = ["network", "use_secret"]
@@ -1764,8 +2091,13 @@ output_schema_ref = "schemas/acme/legacy.output.v1.json"
 "#,
         schema = MANIFEST_SCHEMA_VERSION,
     );
-    let manifest =
-        ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog()).unwrap();
+    let manifest = ExtensionManifestV2::parse(
+        &toml,
+        ManifestSource::InstalledLocal,
+        &catalog(),
+        &contracts(),
+    )
+    .unwrap();
 
     let auth_surfaces: Vec<_> = manifest
         .capability_surfaces()
@@ -1807,6 +2139,7 @@ fn extensions_sharing_one_provider_project_the_same_auth_provider() {
         ),
         ManifestSource::InstalledLocal,
         &catalog(),
+        &contracts(),
     )
     .unwrap();
     let drive = ExtensionManifestV2::parse(
@@ -1817,6 +2150,7 @@ fn extensions_sharing_one_provider_project_the_same_auth_provider() {
         ),
         ManifestSource::InstalledLocal,
         &catalog(),
+        &contracts(),
     )
     .unwrap();
 
@@ -1859,7 +2193,7 @@ fn contract_projected_channel_surface_is_retained_with_origin() {
         }))
         .unwrap();
 
-    let manifest = ExtensionManifestV2::parse_with_host_api_contracts(
+    let manifest = ExtensionManifestV2::parse(
         &telegram_multi_host_api_manifest(),
         ManifestSource::InstalledLocal,
         &catalog(),
@@ -1931,7 +2265,7 @@ surface_kind = "telegram"
 "#,
             schema = MANIFEST_SCHEMA_VERSION,
         );
-        let err = ExtensionManifestV2::parse_with_host_api_contracts(
+        let err = ExtensionManifestV2::parse(
             &toml,
             ManifestSource::InstalledLocal,
             &catalog(),

--- a/crates/ironclaw_first_party_extensions/assets/gmail/manifest.toml
+++ b/crates/ironclaw_first_party_extensions/assets/gmail/manifest.toml
@@ -9,7 +9,13 @@ trust = "first_party_requested"
 kind = "first_party"
 service = "gmail"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "gmail.list_messages"
 description = "List Gmail messages."
 effects = ["dispatch_capability", "network", "use_secret"]
@@ -22,7 +28,7 @@ input_schema_ref = "schemas/gmail/list_messages.input.v1.json"
 output_schema_ref = "schemas/gmail/list_messages.output.v1.json"
 prompt_doc_ref = "prompts/gmail/list_messages.md"
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "gmail.get_message"
 description = "Get a Gmail message."
 effects = ["dispatch_capability", "network", "use_secret"]
@@ -35,7 +41,7 @@ input_schema_ref = "schemas/gmail/get_message.input.v1.json"
 output_schema_ref = "schemas/gmail/get_message.output.v1.json"
 prompt_doc_ref = "prompts/gmail/get_message.md"
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "gmail.send_message"
 description = "Send a Gmail message."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
@@ -48,7 +54,7 @@ input_schema_ref = "schemas/gmail/send_message.input.v1.json"
 output_schema_ref = "schemas/gmail/send_message.output.v1.json"
 prompt_doc_ref = "prompts/gmail/send_message.md"
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "gmail.create_draft"
 description = "Create a Gmail draft."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
@@ -61,7 +67,7 @@ input_schema_ref = "schemas/gmail/create_draft.input.v1.json"
 output_schema_ref = "schemas/gmail/create_draft.output.v1.json"
 prompt_doc_ref = "prompts/gmail/create_draft.md"
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "gmail.reply_to_message"
 description = "Reply to a Gmail message."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
@@ -74,7 +80,7 @@ input_schema_ref = "schemas/gmail/reply_to_message.input.v1.json"
 output_schema_ref = "schemas/gmail/reply_to_message.output.v1.json"
 prompt_doc_ref = "prompts/gmail/reply_to_message.md"
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "gmail.trash_message"
 description = "Move a Gmail message to trash."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]

--- a/crates/ironclaw_first_party_extensions/assets/google-calendar/manifest.toml
+++ b/crates/ironclaw_first_party_extensions/assets/google-calendar/manifest.toml
@@ -9,7 +9,13 @@ trust = "first_party_requested"
 kind = "first_party"
 service = "google-calendar"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "google-calendar.list_calendars"
 description = "List Google calendars."
 effects = ["dispatch_capability", "network", "use_secret"]
@@ -22,7 +28,7 @@ input_schema_ref = "schemas/google-calendar/list_calendars.input.v1.json"
 output_schema_ref = "schemas/google-calendar/list_calendars.output.v1.json"
 prompt_doc_ref = "prompts/google-calendar/list_calendars.md"
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "google-calendar.list_events"
 description = "List Google Calendar events. Defaults to upcoming expanded events ordered by start time; use include_all_calendars or calendar_ids to cover more than the primary calendar."
 effects = ["dispatch_capability", "network", "use_secret"]
@@ -35,7 +41,7 @@ input_schema_ref = "schemas/google-calendar/list_events.input.v1.json"
 output_schema_ref = "schemas/google-calendar/list_events.output.v1.json"
 prompt_doc_ref = "prompts/google-calendar/list_events.md"
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "google-calendar.get_event"
 description = "Get a Google Calendar event."
 effects = ["dispatch_capability", "network", "use_secret"]
@@ -48,7 +54,7 @@ input_schema_ref = "schemas/google-calendar/get_event.input.v1.json"
 output_schema_ref = "schemas/google-calendar/get_event.output.v1.json"
 prompt_doc_ref = "prompts/google-calendar/get_event.md"
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "google-calendar.find_free_slots"
 description = "Find Google Calendar free slots."
 effects = ["dispatch_capability", "network", "use_secret"]
@@ -61,7 +67,7 @@ input_schema_ref = "schemas/google-calendar/find_free_slots.input.v1.json"
 output_schema_ref = "schemas/google-calendar/find_free_slots.output.v1.json"
 prompt_doc_ref = "prompts/google-calendar/find_free_slots.md"
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "google-calendar.create_event"
 description = "Create a Google Calendar event."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
@@ -74,7 +80,7 @@ input_schema_ref = "schemas/google-calendar/create_event.input.v1.json"
 output_schema_ref = "schemas/google-calendar/create_event.output.v1.json"
 prompt_doc_ref = "prompts/google-calendar/create_event.md"
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "google-calendar.update_event"
 description = "Update a Google Calendar event."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
@@ -87,7 +93,7 @@ input_schema_ref = "schemas/google-calendar/update_event.input.v1.json"
 output_schema_ref = "schemas/google-calendar/update_event.output.v1.json"
 prompt_doc_ref = "prompts/google-calendar/update_event.md"
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "google-calendar.delete_event"
 description = "Delete a Google Calendar event."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
@@ -100,7 +106,7 @@ input_schema_ref = "schemas/google-calendar/delete_event.input.v1.json"
 output_schema_ref = "schemas/google-calendar/delete_event.output.v1.json"
 prompt_doc_ref = "prompts/google-calendar/delete_event.md"
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "google-calendar.add_attendees"
 description = "Add attendees to a Google Calendar event."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
@@ -113,7 +119,7 @@ input_schema_ref = "schemas/google-calendar/add_attendees.input.v1.json"
 output_schema_ref = "schemas/google-calendar/add_attendees.output.v1.json"
 prompt_doc_ref = "prompts/google-calendar/add_attendees.md"
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "google-calendar.set_reminder"
 description = "Set Google Calendar event reminders."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]

--- a/crates/ironclaw_first_party_extensions/assets/google-docs/manifest.toml
+++ b/crates/ironclaw_first_party_extensions/assets/google-docs/manifest.toml
@@ -9,7 +9,13 @@ trust = "first_party_requested"
 kind = "wasm"
 module = "wasm/google_docs_tool.wasm"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "google-docs.create_document"
 description = "Create a new Google Docs document."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
@@ -23,7 +29,7 @@ output_schema_ref = "schemas/google-docs/raw_output.v1.json"
 prompt_doc_ref = "prompts/google-docs/create_document.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "google-docs.get_document"
 description = "Get document metadata and structure."
 effects = ["dispatch_capability", "network", "use_secret"]
@@ -37,7 +43,7 @@ output_schema_ref = "schemas/google-docs/raw_output.v1.json"
 prompt_doc_ref = "prompts/google-docs/get_document.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "google-docs.read_content"
 description = "Read the document body as plain text."
 effects = ["dispatch_capability", "network", "use_secret"]
@@ -51,7 +57,7 @@ output_schema_ref = "schemas/google-docs/raw_output.v1.json"
 prompt_doc_ref = "prompts/google-docs/read_content.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "google-docs.insert_text"
 description = "Insert text at a document position."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
@@ -65,7 +71,7 @@ output_schema_ref = "schemas/google-docs/raw_output.v1.json"
 prompt_doc_ref = "prompts/google-docs/insert_text.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "google-docs.delete_content"
 description = "Delete document content in a range."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
@@ -79,7 +85,7 @@ output_schema_ref = "schemas/google-docs/raw_output.v1.json"
 prompt_doc_ref = "prompts/google-docs/delete_content.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "google-docs.replace_text"
 description = "Find and replace text."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
@@ -93,7 +99,7 @@ output_schema_ref = "schemas/google-docs/raw_output.v1.json"
 prompt_doc_ref = "prompts/google-docs/replace_text.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "google-docs.format_text"
 description = "Format text in a range."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
@@ -107,7 +113,7 @@ output_schema_ref = "schemas/google-docs/raw_output.v1.json"
 prompt_doc_ref = "prompts/google-docs/format_text.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "google-docs.format_paragraph"
 description = "Set paragraph style."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
@@ -121,7 +127,7 @@ output_schema_ref = "schemas/google-docs/raw_output.v1.json"
 prompt_doc_ref = "prompts/google-docs/format_paragraph.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "google-docs.insert_table"
 description = "Insert a table."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
@@ -135,7 +141,7 @@ output_schema_ref = "schemas/google-docs/raw_output.v1.json"
 prompt_doc_ref = "prompts/google-docs/insert_table.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "google-docs.create_list"
 description = "Create a bulleted or numbered list."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
@@ -149,7 +155,7 @@ output_schema_ref = "schemas/google-docs/raw_output.v1.json"
 prompt_doc_ref = "prompts/google-docs/create_list.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "google-docs.batch_update"
 description = "Execute raw Docs API batchUpdate requests."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]

--- a/crates/ironclaw_first_party_extensions/assets/google-drive/manifest.toml
+++ b/crates/ironclaw_first_party_extensions/assets/google-drive/manifest.toml
@@ -9,7 +9,13 @@ trust = "first_party_requested"
 kind = "wasm"
 module = "wasm/google_drive_tool.wasm"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "google-drive.list_files"
 description = "Search or list files and folders, including Google Sheets/spreadsheets by name or title."
 effects = ["dispatch_capability", "network", "use_secret"]
@@ -23,7 +29,7 @@ output_schema_ref = "schemas/google-drive/raw_output.v1.json"
 prompt_doc_ref = "prompts/google-drive/list_files.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "google-drive.get_file"
 description = "Get file metadata."
 effects = ["dispatch_capability", "network", "use_secret"]
@@ -37,7 +43,7 @@ output_schema_ref = "schemas/google-drive/raw_output.v1.json"
 prompt_doc_ref = "prompts/google-drive/get_file.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "google-drive.download_file"
 description = "Download a file's content as text — including binary documents (PDF, PPTX, DOCX, XLSX), which are converted to extracted text automatically — or export a Google Workspace file. No shell or separate downloader needed."
 effects = ["dispatch_capability", "network", "use_secret"]
@@ -51,7 +57,7 @@ output_schema_ref = "schemas/google-drive/raw_output.v1.json"
 prompt_doc_ref = "prompts/google-drive/download_file.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "google-drive.upload_file"
 description = "Upload a new text file."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
@@ -65,7 +71,7 @@ output_schema_ref = "schemas/google-drive/raw_output.v1.json"
 prompt_doc_ref = "prompts/google-drive/upload_file.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "google-drive.update_file"
 description = "Update file metadata or move/star a file."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
@@ -79,7 +85,7 @@ output_schema_ref = "schemas/google-drive/raw_output.v1.json"
 prompt_doc_ref = "prompts/google-drive/update_file.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "google-drive.create_folder"
 description = "Create a folder."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
@@ -93,7 +99,7 @@ output_schema_ref = "schemas/google-drive/raw_output.v1.json"
 prompt_doc_ref = "prompts/google-drive/create_folder.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "google-drive.delete_file"
 description = "Permanently delete a file or folder."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
@@ -107,7 +113,7 @@ output_schema_ref = "schemas/google-drive/raw_output.v1.json"
 prompt_doc_ref = "prompts/google-drive/delete_file.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "google-drive.trash_file"
 description = "Move a file or folder to trash."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
@@ -121,7 +127,7 @@ output_schema_ref = "schemas/google-drive/raw_output.v1.json"
 prompt_doc_ref = "prompts/google-drive/trash_file.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "google-drive.share_file"
 description = "Share a file or folder with someone."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
@@ -135,7 +141,7 @@ output_schema_ref = "schemas/google-drive/raw_output.v1.json"
 prompt_doc_ref = "prompts/google-drive/share_file.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "google-drive.list_permissions"
 description = "List file permissions."
 effects = ["dispatch_capability", "network", "use_secret"]
@@ -149,7 +155,7 @@ output_schema_ref = "schemas/google-drive/raw_output.v1.json"
 prompt_doc_ref = "prompts/google-drive/list_permissions.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "google-drive.remove_permission"
 description = "Revoke a file permission."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
@@ -163,7 +169,7 @@ output_schema_ref = "schemas/google-drive/raw_output.v1.json"
 prompt_doc_ref = "prompts/google-drive/remove_permission.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "google-drive.list_shared_drives"
 description = "List shared drives."
 effects = ["dispatch_capability", "network", "use_secret"]

--- a/crates/ironclaw_first_party_extensions/assets/google-sheets/manifest.toml
+++ b/crates/ironclaw_first_party_extensions/assets/google-sheets/manifest.toml
@@ -9,7 +9,13 @@ trust = "first_party_requested"
 kind = "wasm"
 module = "wasm/google_sheets_tool.wasm"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "google-sheets.create_spreadsheet"
 description = "Create a new spreadsheet."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
@@ -23,7 +29,7 @@ output_schema_ref = "schemas/google-sheets/raw_output.v1.json"
 prompt_doc_ref = "prompts/google-sheets/create_spreadsheet.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "google-sheets.get_spreadsheet"
 description = "Get spreadsheet metadata by spreadsheet ID. If the user only provided a spreadsheet name/title, search Google Drive first."
 effects = ["dispatch_capability", "network", "use_secret"]
@@ -37,7 +43,7 @@ output_schema_ref = "schemas/google-sheets/raw_output.v1.json"
 prompt_doc_ref = "prompts/google-sheets/get_spreadsheet.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "google-sheets.read_values"
 description = "Read cell values from a range by spreadsheet ID. If the user only provided a spreadsheet name/title, search Google Drive first."
 effects = ["dispatch_capability", "network", "use_secret"]
@@ -51,7 +57,7 @@ output_schema_ref = "schemas/google-sheets/raw_output.v1.json"
 prompt_doc_ref = "prompts/google-sheets/read_values.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "google-sheets.batch_read_values"
 description = "Read values from multiple ranges."
 effects = ["dispatch_capability", "network", "use_secret"]
@@ -65,7 +71,7 @@ output_schema_ref = "schemas/google-sheets/raw_output.v1.json"
 prompt_doc_ref = "prompts/google-sheets/batch_read_values.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "google-sheets.write_values"
 description = "Write values to a range."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
@@ -79,7 +85,7 @@ output_schema_ref = "schemas/google-sheets/raw_output.v1.json"
 prompt_doc_ref = "prompts/google-sheets/write_values.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "google-sheets.append_values"
 description = "Append rows after existing data by spreadsheet ID. If the user only provided a spreadsheet name/title, search Google Drive first."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
@@ -93,7 +99,7 @@ output_schema_ref = "schemas/google-sheets/raw_output.v1.json"
 prompt_doc_ref = "prompts/google-sheets/append_values.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "google-sheets.clear_values"
 description = "Clear values from a range."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
@@ -107,7 +113,7 @@ output_schema_ref = "schemas/google-sheets/raw_output.v1.json"
 prompt_doc_ref = "prompts/google-sheets/clear_values.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "google-sheets.add_sheet"
 description = "Add a sheet tab."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
@@ -121,7 +127,7 @@ output_schema_ref = "schemas/google-sheets/raw_output.v1.json"
 prompt_doc_ref = "prompts/google-sheets/add_sheet.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "google-sheets.delete_sheet"
 description = "Delete a sheet tab."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
@@ -135,7 +141,7 @@ output_schema_ref = "schemas/google-sheets/raw_output.v1.json"
 prompt_doc_ref = "prompts/google-sheets/delete_sheet.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "google-sheets.rename_sheet"
 description = "Rename a sheet tab."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
@@ -149,7 +155,7 @@ output_schema_ref = "schemas/google-sheets/raw_output.v1.json"
 prompt_doc_ref = "prompts/google-sheets/rename_sheet.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "google-sheets.format_cells"
 description = "Format cells in a range."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]

--- a/crates/ironclaw_first_party_extensions/assets/google-slides/manifest.toml
+++ b/crates/ironclaw_first_party_extensions/assets/google-slides/manifest.toml
@@ -9,7 +9,13 @@ trust = "first_party_requested"
 kind = "wasm"
 module = "wasm/google_slides_tool.wasm"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "google-slides.create_presentation"
 description = "Create a new presentation."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
@@ -23,7 +29,7 @@ output_schema_ref = "schemas/google-slides/raw_output.v1.json"
 prompt_doc_ref = "prompts/google-slides/create_presentation.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "google-slides.get_presentation"
 description = "Get presentation metadata."
 effects = ["dispatch_capability", "network", "use_secret"]
@@ -37,7 +43,7 @@ output_schema_ref = "schemas/google-slides/raw_output.v1.json"
 prompt_doc_ref = "prompts/google-slides/get_presentation.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "google-slides.get_thumbnail"
 description = "Get a slide thumbnail URL."
 effects = ["dispatch_capability", "network", "use_secret"]
@@ -51,7 +57,7 @@ output_schema_ref = "schemas/google-slides/raw_output.v1.json"
 prompt_doc_ref = "prompts/google-slides/get_thumbnail.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "google-slides.create_slide"
 description = "Create a new slide."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
@@ -65,7 +71,7 @@ output_schema_ref = "schemas/google-slides/raw_output.v1.json"
 prompt_doc_ref = "prompts/google-slides/create_slide.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "google-slides.delete_object"
 description = "Delete a slide or page element."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
@@ -79,7 +85,7 @@ output_schema_ref = "schemas/google-slides/raw_output.v1.json"
 prompt_doc_ref = "prompts/google-slides/delete_object.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "google-slides.insert_text"
 description = "Insert text into a shape."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
@@ -93,7 +99,7 @@ output_schema_ref = "schemas/google-slides/raw_output.v1.json"
 prompt_doc_ref = "prompts/google-slides/insert_text.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "google-slides.delete_text"
 description = "Delete text from a shape."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
@@ -107,7 +113,7 @@ output_schema_ref = "schemas/google-slides/raw_output.v1.json"
 prompt_doc_ref = "prompts/google-slides/delete_text.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "google-slides.replace_all_text"
 description = "Find and replace text."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
@@ -121,7 +127,7 @@ output_schema_ref = "schemas/google-slides/raw_output.v1.json"
 prompt_doc_ref = "prompts/google-slides/replace_all_text.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "google-slides.create_shape"
 description = "Create a shape or text box."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
@@ -135,7 +141,7 @@ output_schema_ref = "schemas/google-slides/raw_output.v1.json"
 prompt_doc_ref = "prompts/google-slides/create_shape.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "google-slides.insert_image"
 description = "Insert an image on a slide."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
@@ -149,7 +155,7 @@ output_schema_ref = "schemas/google-slides/raw_output.v1.json"
 prompt_doc_ref = "prompts/google-slides/insert_image.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "google-slides.format_text"
 description = "Format text in a shape."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
@@ -163,7 +169,7 @@ output_schema_ref = "schemas/google-slides/raw_output.v1.json"
 prompt_doc_ref = "prompts/google-slides/format_text.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "google-slides.format_paragraph"
 description = "Set paragraph alignment."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
@@ -177,7 +183,7 @@ output_schema_ref = "schemas/google-slides/raw_output.v1.json"
 prompt_doc_ref = "prompts/google-slides/format_paragraph.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "google-slides.replace_shapes_with_image"
 description = "Replace matching shapes with an image."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
@@ -191,7 +197,7 @@ output_schema_ref = "schemas/google-slides/raw_output.v1.json"
 prompt_doc_ref = "prompts/google-slides/replace_shapes_with_image.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "google-slides.batch_update"
 description = "Execute raw Slides API batchUpdate requests."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]

--- a/crates/ironclaw_first_party_extensions/assets/nearai-mcp/manifest.toml
+++ b/crates/ironclaw_first_party_extensions/assets/nearai-mcp/manifest.toml
@@ -10,7 +10,13 @@ kind = "mcp"
 transport = "http"
 url = "https://private.near.ai/mcp"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "nearai.web_search"
 description = "Search through the NEAR AI MCP server."
 effects = ["dispatch_capability", "network", "use_secret"]

--- a/crates/ironclaw_first_party_extensions/assets/notion-mcp/manifest.toml
+++ b/crates/ironclaw_first_party_extensions/assets/notion-mcp/manifest.toml
@@ -10,7 +10,13 @@ kind = "mcp"
 transport = "http"
 url = "https://mcp.notion.com/mcp"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "notion.notion-search"
 description = "Search Notion workspace content and connected sources through Notion MCP."
 effects = ["dispatch_capability", "network", "use_secret"]
@@ -24,7 +30,7 @@ output_schema_ref = "schemas/notion/notion-search.output.v1.json"
 prompt_doc_ref = "prompts/notion/notion-search.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "notion.notion-fetch"
 description = "Fetch a Notion page, database, or data source by URL or ID through Notion MCP."
 effects = ["dispatch_capability", "network", "use_secret"]
@@ -38,7 +44,7 @@ output_schema_ref = "schemas/notion/notion-fetch.output.v1.json"
 prompt_doc_ref = "prompts/notion/notion-fetch.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "notion.notion-create-pages"
 description = "Create one or more Notion pages with properties, content, templates, icons, or covers through Notion MCP."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
@@ -52,7 +58,7 @@ output_schema_ref = "schemas/notion/notion-create-pages.output.v1.json"
 prompt_doc_ref = "prompts/notion/notion-create-pages.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "notion.notion-update-page"
 description = "Update a Notion page's properties, content, icon, cover, or template through Notion MCP."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
@@ -66,7 +72,7 @@ output_schema_ref = "schemas/notion/notion-update-page.output.v1.json"
 prompt_doc_ref = "prompts/notion/notion-update-page.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "notion.notion-move-pages"
 description = "Move one or more Notion pages or databases to a new parent through Notion MCP."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
@@ -80,7 +86,7 @@ output_schema_ref = "schemas/notion/notion-move-pages.output.v1.json"
 prompt_doc_ref = "prompts/notion/notion-move-pages.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "notion.notion-duplicate-page"
 description = "Duplicate a Notion page within the connected workspace through Notion MCP."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
@@ -94,7 +100,7 @@ output_schema_ref = "schemas/notion/notion-duplicate-page.output.v1.json"
 prompt_doc_ref = "prompts/notion/notion-duplicate-page.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "notion.notion-create-database"
 description = "Create a Notion database, initial data source, and initial view through Notion MCP."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
@@ -108,7 +114,7 @@ output_schema_ref = "schemas/notion/notion-create-database.output.v1.json"
 prompt_doc_ref = "prompts/notion/notion-create-database.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "notion.notion-update-data-source"
 description = "Update a Notion data source's properties, name, description, or other attributes through Notion MCP."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
@@ -122,7 +128,7 @@ output_schema_ref = "schemas/notion/notion-update-data-source.output.v1.json"
 prompt_doc_ref = "prompts/notion/notion-update-data-source.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "notion.notion-create-view"
 description = "Create a Notion database view with filters, sorts, grouping, or display configuration through Notion MCP."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
@@ -136,7 +142,7 @@ output_schema_ref = "schemas/notion/notion-create-view.output.v1.json"
 prompt_doc_ref = "prompts/notion/notion-create-view.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "notion.notion-update-view"
 description = "Update a Notion database view's name, filters, sorts, grouping, or display configuration through Notion MCP."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
@@ -150,7 +156,7 @@ output_schema_ref = "schemas/notion/notion-update-view.output.v1.json"
 prompt_doc_ref = "prompts/notion/notion-update-view.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "notion.notion-query-data-sources"
 description = "Query across multiple Notion data sources with structured summaries, grouping, and filters through Notion MCP."
 effects = ["dispatch_capability", "network", "use_secret"]
@@ -164,7 +170,7 @@ output_schema_ref = "schemas/notion/notion-query-data-sources.output.v1.json"
 prompt_doc_ref = "prompts/notion/notion-query-data-sources.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "notion.notion-query-database-view"
 description = "Query data from a Notion database using a predefined view's filters and sorts through Notion MCP."
 effects = ["dispatch_capability", "network", "use_secret"]
@@ -178,7 +184,7 @@ output_schema_ref = "schemas/notion/notion-query-database-view.output.v1.json"
 prompt_doc_ref = "prompts/notion/notion-query-database-view.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "notion.notion-create-comment"
 description = "Add a page-level, block-level, inline, or reply comment through Notion MCP."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
@@ -192,7 +198,7 @@ output_schema_ref = "schemas/notion/notion-create-comment.output.v1.json"
 prompt_doc_ref = "prompts/notion/notion-create-comment.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "notion.notion-get-comments"
 description = "List comments and discussions on a Notion page through Notion MCP."
 effects = ["dispatch_capability", "network", "use_secret"]
@@ -206,7 +212,7 @@ output_schema_ref = "schemas/notion/notion-get-comments.output.v1.json"
 prompt_doc_ref = "prompts/notion/notion-get-comments.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "notion.notion-get-teams"
 description = "Retrieve teams and teamspaces in the connected Notion workspace through Notion MCP."
 effects = ["dispatch_capability", "network", "use_secret"]
@@ -220,7 +226,7 @@ output_schema_ref = "schemas/notion/notion-get-teams.output.v1.json"
 prompt_doc_ref = "prompts/notion/notion-get-teams.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "notion.notion-get-users"
 description = "List users in the connected Notion workspace through Notion MCP."
 effects = ["dispatch_capability", "network", "use_secret"]
@@ -234,7 +240,7 @@ output_schema_ref = "schemas/notion/notion-get-users.output.v1.json"
 prompt_doc_ref = "prompts/notion/notion-get-users.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "notion.notion-get-user"
 description = "Retrieve Notion user information by ID through Notion MCP."
 effects = ["dispatch_capability", "network", "use_secret"]
@@ -248,7 +254,7 @@ output_schema_ref = "schemas/notion/notion-get-user.output.v1.json"
 prompt_doc_ref = "prompts/notion/notion-get-user.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "notion.notion-get-self"
 description = "Retrieve the connected bot user and workspace information through Notion MCP."
 effects = ["dispatch_capability", "network", "use_secret"]

--- a/crates/ironclaw_first_party_extensions/assets/slack/manifest.toml
+++ b/crates/ironclaw_first_party_extensions/assets/slack/manifest.toml
@@ -16,7 +16,13 @@ module = "wasm/slack_user_tool.wasm"
 # read-only users needs a write-opt-in / scope-upgrade re-consent flow — tracked
 # separately (see the follow-up issue referenced on SLACK_PERSONAL_OAUTH_SETUP_SCOPES).
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "slack.search_messages"
 description = "Search across all messages you can see (your DMs, group DMs, and channels you belong to). This is indexed search: do not use it to answer the single newest message when a conversation is known; call slack.get_conversation_history instead for newest-first history. Matches carry the author's resolved user_display_name, and mentions inside match text are already resolved to @display-names (use display names in user-facing output); threaded hits carry thread_ts (follow up with slack.get_thread_replies). When total exceeds count, fetch more with page. Requires the search:read user scope. Raw Slack ids (U…/W…/C…/D…) are for tool calls only — never include one in a reply, not even in parentheses; refer to people and channels by name."
 effects = ["dispatch_capability", "network", "use_secret"]
@@ -30,7 +36,7 @@ output_schema_ref = "schemas/slack/raw_output.v1.json"
 prompt_doc_ref = "prompts/slack/search_messages.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "slack.list_conversations"
 description = "List channels, private channels, DMs (im), and group DMs (mpim) visible to you — not only ones you belong to; is_member=true is the authoritative membership signal. Use this to discover DM conversation IDs. DM entries include the raw counterpart user id in their user field for subsequent tool calls or <@U…> mentions, plus the resolved user_display_name for user-facing text. Results page: pass the previous call's next_cursor as cursor until next_cursor is absent. Raw Slack ids (U…/W…/C…/D…) are for tool calls only — never include one in a reply, not even in parentheses; refer to people and channels by name."
 effects = ["dispatch_capability", "network", "use_secret"]
@@ -44,7 +50,7 @@ output_schema_ref = "schemas/slack/list_conversations.output.v1.json"
 prompt_doc_ref = "prompts/slack/list_conversations.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "slack.get_conversation_history"
 description = "Read message history from any channel or DM you can see, identified by its conversation ID. Results are newest-first, at most 999 per call (limit above 999 is clamped; Slack rejects 1000); when has_more is true, fetch older messages by calling again with latest set to the oldest returned ts. Messages include the author's raw user id plus user_display_name and humanized text whose mentions are already resolved to @display-names — use user_display_name and humanized text in user-facing output. Messages with is_current_user=true were written by the connected account (result-level current_user_id): they are the requesting user's own words — attribute them to the requester, not a third party. Thread replies are NOT included — a parent's reply_count > 0 means there is a thread; fetch it with slack.get_thread_replies. Raw Slack ids (U…/W…/C…/D…) are for subsequent tool calls only — never include one in a reply, not even in parentheses; refer to people and channels by name."
 effects = ["dispatch_capability", "network", "use_secret"]
@@ -58,7 +64,7 @@ output_schema_ref = "schemas/slack/get_conversation_history.output.v1.json"
 prompt_doc_ref = "prompts/slack/get_conversation_history.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "slack.get_thread_replies"
 description = "Read the replies of one thread (channel + the parent message's thread_ts). Conversation history only shows thread parents (reply_count), never the replies — use this whenever a thread's content matters. Same output shape as history: resolved user_display_name per message, is_current_user marking, and current_user_id. Raw Slack ids (U…/W…/C…/D…) are for tool calls only — never include one in a reply, not even in parentheses; refer to people and channels by name."
 effects = ["dispatch_capability", "network", "use_secret"]
@@ -72,7 +78,7 @@ output_schema_ref = "schemas/slack/get_thread_replies.output.v1.json"
 prompt_doc_ref = "prompts/slack/get_thread_replies.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "slack.get_user_info"
 description = "Get information about a Slack user (name, real name); includes presence-relevant profile fields: status text/emoji, timezone, and title. History and DM-list outputs already carry resolved display names; use this for extra fields on a specific user, e.g. before answering whether someone is away or what time it is for them. Raw Slack ids (U…/W…/C…/D…) are for tool calls only — never include one in a reply, not even in parentheses; refer to people and channels by name."
 effects = ["dispatch_capability", "network", "use_secret"]
@@ -86,7 +92,7 @@ output_schema_ref = "schemas/slack/get_user_info.output.v1.json"
 prompt_doc_ref = "prompts/slack/get_user_info.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "slack.whoami"
 description = "Resolve who the connected Slack account is: the user id (and display name when resolvable) that search/history/DM results belong to. Call this before answering anything that depends on which messages are the requester's own. Takes no parameters. Raw Slack ids (U…/W…/C…/D…) are for tool calls only — never include one in a reply, not even in parentheses; refer to people and channels by name."
 effects = ["dispatch_capability", "network", "use_secret"]
@@ -100,7 +106,7 @@ output_schema_ref = "schemas/slack/whoami.output.v1.json"
 prompt_doc_ref = "prompts/slack/whoami.md"
 required_host_ports = ["host.runtime.http_egress"]
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "slack.send_message"
 description = "Send a message as you to a channel or DM; it appears to come from your account and requires the chat:write user scope. Never call this — or instruct a trigger to call it — for that run's own final reply when outbound delivery or delivery_target_id is configured; that result is delivered automatically to the configured outbound delivery target. Do not use this to deliver your reply or a routine/trigger result — it would arrive twice. Use it only when messaging someone else or posting somewhere is itself the requested task. To notify someone in the text, use the mention encoding <@U…> with their real user id (e.g. <@U0123ABCD>); a plain @name does not notify anyone. Never guess a user id or derive one from a channel or DM conversation id. If only a name or DM conversation id is known, first call slack.list_conversations, match the DM entry, and use that DM entry's user field as the authoritative real user id."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]

--- a/crates/ironclaw_first_party_extensions/assets/web-access/manifest.toml
+++ b/crates/ironclaw_first_party_extensions/assets/web-access/manifest.toml
@@ -9,7 +9,13 @@ trust = "first_party_requested"
 kind = "first_party"
 service = "web-access"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "web-access.search"
 description = "Search the web with zero-config Exa MCP and return cited source results. Prefer GitHub extension capabilities for GitHub repository, issue, pull request, release, or workflow data when they are available."
 effects = ["dispatch_capability", "network"]
@@ -19,7 +25,7 @@ input_schema_ref = "schemas/web-access/search.input.v1.json"
 output_schema_ref = "schemas/web-access/search.output.v1.json"
 prompt_doc_ref = "prompts/web-access/search.md"
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "web-access.get_content"
 description = "Retrieve full web page content through Exa MCP, or read content cached from a previous web search response."
 effects = ["dispatch_capability", "network"]

--- a/crates/ironclaw_host_runtime/src/production.rs
+++ b/crates/ironclaw_host_runtime/src/production.rs
@@ -2498,7 +2498,13 @@ kind = "script"
 runner = "sandboxed_process"
 command = "echo"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "test.cap"
 description = "Test capability"
 effects = ["network"]
@@ -2511,6 +2517,7 @@ output_schema_ref = "schemas/test.output.json"
             MANIFEST,
             ManifestSource::HostBundled,
             &HostPortCatalog::empty(),
+            &capability_provider_contracts(),
         )
         .unwrap();
         let package = ExtensionPackage::from_manifest_toml(
@@ -2982,6 +2989,7 @@ output_schema_ref = "schemas/test.output.json"
             manifest_toml,
             ManifestSource::InstalledLocal,
             &HostPortCatalog::empty(),
+            &capability_provider_contracts(),
         )
         .expect("manifest must parse");
         let cap_id = manifest.capabilities[0].id.clone();
@@ -3016,7 +3024,13 @@ runner = "sandboxed_process"
 command = "echo"
 args = []
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "script.echo"
 description = "Echo through Script"
 effects = ["dispatch_capability", "use_secret"]
@@ -3026,7 +3040,7 @@ input_schema_ref = "schemas/test/input.v1.json"
 output_schema_ref = "schemas/test/output.v1.json"
 prompt_doc_ref = "prompts/test.md"
 
-[[capabilities.runtime_credentials]]
+[[capability_provider.tools.capabilities.runtime_credentials]]
 handle = "script_api_token"
 source = { type = "secret_handle" }
 audience = { scheme = "https", host_pattern = "api.example.com" }
@@ -3087,7 +3101,13 @@ runner = "sandboxed_process"
 command = "echo"
 args = []
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "script.echo"
 description = "Echo through Script"
 effects = ["dispatch_capability", "use_secret"]
@@ -3097,7 +3117,7 @@ input_schema_ref = "schemas/test/input.v1.json"
 output_schema_ref = "schemas/test/output.v1.json"
 prompt_doc_ref = "prompts/test.md"
 
-[[capabilities.runtime_credentials]]
+[[capability_provider.tools.capabilities.runtime_credentials]]
 handle = "optional_api_token"
 source = { type = "secret_handle" }
 audience = { scheme = "https", host_pattern = "api.example.com" }
@@ -3140,7 +3160,13 @@ runner = "sandboxed_process"
 command = "echo"
 args = []
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "script.echo"
 description = "Echo through Script"
 effects = ["dispatch_capability", "use_secret"]
@@ -3150,7 +3176,7 @@ input_schema_ref = "schemas/test/input.v1.json"
 output_schema_ref = "schemas/test/output.v1.json"
 prompt_doc_ref = "prompts/test.md"
 
-[[capabilities.runtime_credentials]]
+[[capability_provider.tools.capabilities.runtime_credentials]]
 handle = "github_runtime_token"
 source = { type = "product_auth_account", provider = "github" }
 audience = { scheme = "https", host_pattern = "api.github.com" }
@@ -3274,5 +3300,16 @@ required = true
             }
             other => panic!("expected Unavailable, got {other:?}"),
         }
+    }
+
+    fn capability_provider_contracts() -> ironclaw_extensions::HostApiContractRegistry {
+        let mut contracts = ironclaw_extensions::HostApiContractRegistry::new();
+        contracts
+            .register(std::sync::Arc::new(
+                ironclaw_extensions::CapabilityProviderHostApiContract::new()
+                    .expect("capability provider contract"),
+            ))
+            .expect("register capability provider contract");
+        contracts
     }
 }

--- a/crates/ironclaw_host_runtime/src/services/tests.rs
+++ b/crates/ironclaw_host_runtime/src/services/tests.rs
@@ -1123,6 +1123,7 @@ fn test_package(manifest: &str, extension_id: &str) -> ExtensionPackage {
         manifest,
         ManifestSource::HostBundled,
         &HostPortCatalog::empty(),
+        &capability_provider_contracts(),
     )
     .expect("test manifest should parse");
     ExtensionPackage::from_manifest(
@@ -1384,7 +1385,13 @@ runner = "sandboxed_process"
 command = "sh"
 args = ["-c", "cat"]
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "test-script.run"
 description = "Run script"
 effects = ["execute_code"]
@@ -1406,7 +1413,13 @@ trust = "untrusted"
 kind = "wasm"
 module = "test.wasm"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "test-wasm.run"
 description = "Run WASM"
 effects = ["network"]
@@ -1577,4 +1590,15 @@ async fn registered_runtime_health_returns_empty_when_all_required_available() {
         missing.is_empty(),
         "expected no missing kinds; got {missing:?}"
     );
+}
+
+fn capability_provider_contracts() -> ironclaw_extensions::HostApiContractRegistry {
+    let mut contracts = ironclaw_extensions::HostApiContractRegistry::new();
+    contracts
+        .register(std::sync::Arc::new(
+            ironclaw_extensions::CapabilityProviderHostApiContract::new()
+                .expect("capability provider contract"),
+        ))
+        .expect("register capability provider contract");
+    contracts
 }

--- a/crates/ironclaw_host_runtime/src/services/tests/mcp_runtime_adapter.rs
+++ b/crates/ironclaw_host_runtime/src/services/tests/mcp_runtime_adapter.rs
@@ -77,7 +77,13 @@ kind = "mcp"
 transport = "http"
 url = "https://mcp.example.test/rpc"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "test.capability"
 description = "Search through MCP"
 effects = ["network"]

--- a/crates/ironclaw_host_runtime/src/wasm_credentials.rs
+++ b/crates/ironclaw_host_runtime/src/wasm_credentials.rs
@@ -378,7 +378,13 @@ trust = "third_party"
 kind = "wasm"
 module = "wasm/test.wasm"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "test-wasm.fetch"
 description = "fetch"
 effects = ["network", "use_secret"]
@@ -521,7 +527,13 @@ trust = "third_party"
 kind = "wasm"
 module = "wasm/test.wasm"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "test-wasm.fetch"
 description = "fetch"
 effects = ["network", "use_secret"]
@@ -599,6 +611,7 @@ runtime_credentials = [
             manifest,
             ManifestSource::HostBundled,
             &HostPortCatalog::empty(),
+            &capability_provider_contracts(),
         )
         .expect("test manifest should parse");
         ExtensionPackage::from_manifest(
@@ -651,5 +664,16 @@ runtime_credentials = [
         });
 
         assert_eq!(result, Err(CredentialStageError::Backend));
+    }
+
+    fn capability_provider_contracts() -> ironclaw_extensions::HostApiContractRegistry {
+        let mut contracts = ironclaw_extensions::HostApiContractRegistry::new();
+        contracts
+            .register(std::sync::Arc::new(
+                ironclaw_extensions::CapabilityProviderHostApiContract::new()
+                    .expect("capability provider contract"),
+            ))
+            .expect("register capability provider contract");
+        contracts
     }
 }

--- a/crates/ironclaw_host_runtime/tests/builtin_obligation_handler_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/builtin_obligation_handler_contract.rs
@@ -1226,6 +1226,7 @@ fn parse_manifest(manifest: &str) -> ExtensionManifest {
         &manifest,
         ManifestSource::InstalledLocal,
         &HostPortCatalog::empty(),
+        &capability_provider_contracts(),
     )
     .unwrap()
 }
@@ -1678,3 +1679,14 @@ effects = ["dispatch_capability"]
 default_permission = "allow"
 parameters_schema = {}
 "#;
+
+fn capability_provider_contracts() -> ironclaw_extensions::HostApiContractRegistry {
+    let mut contracts = ironclaw_extensions::HostApiContractRegistry::new();
+    contracts
+        .register(std::sync::Arc::new(
+            ironclaw_extensions::CapabilityProviderHostApiContract::new()
+                .expect("capability provider contract"),
+        ))
+        .expect("register capability provider contract");
+    contracts
+}

--- a/crates/ironclaw_host_runtime/tests/extension_v2_lifecycle_e2e.rs
+++ b/crates/ironclaw_host_runtime/tests/extension_v2_lifecycle_e2e.rs
@@ -137,7 +137,7 @@ async fn github_v2_package_discovers_and_publishes_issue_hot_catalog() {
     assert!(github_asset_root.join("wasm-src/Cargo.toml").is_file());
 
     let (_storage, fs) = mounted_github_package_fs();
-    let manifest = ExtensionManifest::parse_with_host_api_contracts(
+    let manifest = ExtensionManifest::parse(
         &std::fs::read_to_string(github_asset_root.join("manifest.toml")).unwrap(),
         ManifestSource::HostBundled,
         &default_host_port_catalog().unwrap(),

--- a/crates/ironclaw_host_runtime/tests/github_wasm_runtime_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/github_wasm_runtime_contract.rs
@@ -2031,7 +2031,7 @@ impl RuntimeCredentialAccountResolver for FixedSlackRuntimeCredentialAccountReso
 }
 
 fn registry_with_slack_user_package() -> ExtensionRegistry {
-    let manifest = ExtensionManifest::parse_with_host_api_contracts(
+    let manifest = ExtensionManifest::parse(
         &std::fs::read_to_string(slack_user_asset_root().join("manifest.toml")).unwrap(),
         ManifestSource::HostBundled,
         &default_host_port_catalog().unwrap(),
@@ -2126,7 +2126,7 @@ fn slack_user_first_party_trust_policy() -> HostTrustPolicy {
 }
 
 fn registry_with_github_package() -> ExtensionRegistry {
-    let manifest = ExtensionManifest::parse_with_host_api_contracts(
+    let manifest = ExtensionManifest::parse(
         &std::fs::read_to_string(github_asset_root().join("manifest.toml")).unwrap(),
         ManifestSource::HostBundled,
         &default_host_port_catalog().unwrap(),
@@ -2163,7 +2163,7 @@ fn filesystem_with_google_drive_package() -> LocalFilesystem {
 }
 
 fn registry_with_google_package(package_id: &str) -> ExtensionRegistry {
-    let manifest = ExtensionManifest::parse_with_host_api_contracts(
+    let manifest = ExtensionManifest::parse(
         &std::fs::read_to_string(google_asset_root(package_id).join("manifest.toml")).unwrap(),
         ManifestSource::HostBundled,
         &default_host_port_catalog().unwrap(),

--- a/crates/ironclaw_host_runtime/tests/host_runtime_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_contract.rs
@@ -1581,6 +1581,7 @@ fn parse_manifest(manifest: &str) -> ExtensionManifest {
         &manifest,
         ManifestSource::InstalledLocal,
         &HostPortCatalog::empty(),
+        &capability_provider_contracts(),
     )
     .unwrap()
 }
@@ -1654,4 +1655,15 @@ fn capability_id() -> CapabilityId {
 
 fn extension_id() -> ExtensionId {
     ExtensionId::new("echo").unwrap()
+}
+
+fn capability_provider_contracts() -> ironclaw_extensions::HostApiContractRegistry {
+    let mut contracts = ironclaw_extensions::HostApiContractRegistry::new();
+    contracts
+        .register(std::sync::Arc::new(
+            ironclaw_extensions::CapabilityProviderHostApiContract::new()
+                .expect("capability provider contract"),
+        ))
+        .expect("register capability provider contract");
+    contracts
 }

--- a/crates/ironclaw_host_runtime/tests/host_runtime_credential_preflight_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_credential_preflight_contract.rs
@@ -67,7 +67,7 @@ effects = ["dispatch_capability", "use_secret"]
 default_permission = "allow"
 parameters_schema = { type = "object" }
 
-[[capabilities.runtime_credentials]]
+[[capability_provider.tools.capabilities.runtime_credentials]]
 handle = "google_oauth_token"
 source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/gmail.readonly"] } }
 audience = { scheme = "https", host_pattern = "gmail.googleapis.com" }
@@ -98,7 +98,7 @@ effects = ["dispatch_capability", "use_secret"]
 default_permission = "allow"
 parameters_schema = { type = "object" }
 
-[[capabilities.runtime_credentials]]
+[[capability_provider.tools.capabilities.runtime_credentials]]
 handle = "script_api_token"
 source = { type = "secret_handle" }
 audience = { scheme = "https", host_pattern = "api.example.com" }
@@ -114,6 +114,7 @@ fn registry_with_manifest(manifest: &str) -> ExtensionRegistry {
         &manifest,
         ManifestSource::InstalledLocal,
         &HostPortCatalog::empty(),
+        &capability_provider_contracts(),
     )
     .expect("manifest must parse");
     let root = VirtualPath::new(format!("/system/extensions/{}", manifest.id.as_str())).unwrap();
@@ -490,4 +491,15 @@ async fn spawn_capability_forged_scope_fails_before_preflight() {
             panic!("expected Err(InvalidRequest) for forged-scope spawn; got Err({other:?})")
         }
     }
+}
+
+fn capability_provider_contracts() -> ironclaw_extensions::HostApiContractRegistry {
+    let mut contracts = ironclaw_extensions::HostApiContractRegistry::new();
+    contracts
+        .register(std::sync::Arc::new(
+            ironclaw_extensions::CapabilityProviderHostApiContract::new()
+                .expect("capability provider contract"),
+        ))
+        .expect("register capability provider contract");
+    contracts
 }

--- a/crates/ironclaw_host_runtime/tests/host_runtime_persistent_approvals_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_persistent_approvals_contract.rs
@@ -953,6 +953,7 @@ fn parse_manifest(manifest: &str) -> ExtensionManifest {
         &manifest,
         ManifestSource::InstalledLocal,
         &HostPortCatalog::empty(),
+        &capability_provider_contracts(),
     )
     .unwrap()
 }
@@ -1036,4 +1037,15 @@ fn capability_id() -> CapabilityId {
 
 fn extension_id() -> ExtensionId {
     ExtensionId::new("echo").unwrap()
+}
+
+fn capability_provider_contracts() -> ironclaw_extensions::HostApiContractRegistry {
+    let mut contracts = ironclaw_extensions::HostApiContractRegistry::new();
+    contracts
+        .register(std::sync::Arc::new(
+            ironclaw_extensions::CapabilityProviderHostApiContract::new()
+                .expect("capability provider contract"),
+        ))
+        .expect("register capability provider contract");
+    contracts
 }

--- a/crates/ironclaw_host_runtime/tests/obligation_services_composition_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/obligation_services_composition_contract.rs
@@ -300,6 +300,7 @@ fn parse_manifest(manifest: &str) -> ExtensionManifest {
         &manifest,
         ManifestSource::InstalledLocal,
         &HostPortCatalog::empty(),
+        &capability_provider_contracts(),
     )
     .unwrap()
 }
@@ -370,3 +371,14 @@ effects = ["dispatch_capability"]
 default_permission = "allow"
 parameters_schema = {}
 "#;
+
+fn capability_provider_contracts() -> ironclaw_extensions::HostApiContractRegistry {
+    let mut contracts = ironclaw_extensions::HostApiContractRegistry::new();
+    contracts
+        .register(std::sync::Arc::new(
+            ironclaw_extensions::CapabilityProviderHostApiContract::new()
+                .expect("capability provider contract"),
+        ))
+        .expect("register capability provider contract");
+    contracts
+}

--- a/crates/ironclaw_host_runtime/tests/production_trust_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/production_trust_contract.rs
@@ -234,6 +234,7 @@ fn parse_manifest(manifest: &str) -> ExtensionManifest {
         &manifest,
         ManifestSource::InstalledLocal,
         &HostPortCatalog::empty(),
+        &capability_provider_contracts(),
     )
     .unwrap()
 }
@@ -333,3 +334,14 @@ effects = ["dispatch_capability"]
 default_permission = "allow"
 parameters_schema = {}
 "#;
+
+fn capability_provider_contracts() -> ironclaw_extensions::HostApiContractRegistry {
+    let mut contracts = ironclaw_extensions::HostApiContractRegistry::new();
+    contracts
+        .register(std::sync::Arc::new(
+            ironclaw_extensions::CapabilityProviderHostApiContract::new()
+                .expect("capability provider contract"),
+        ))
+        .expect("register capability provider contract");
+    contracts
+}

--- a/crates/ironclaw_host_runtime/tests/reborn_durable_restart_integration.rs
+++ b/crates/ironclaw_host_runtime/tests/reborn_durable_restart_integration.rs
@@ -911,6 +911,7 @@ fn parse_manifest(manifest: &str) -> ExtensionManifest {
         &manifest,
         ManifestSource::InstalledLocal,
         &HostPortCatalog::empty(),
+        &capability_provider_contracts(),
     )
     .unwrap()
 }
@@ -1073,3 +1074,14 @@ effects = ["dispatch_capability"]
 default_permission = "allow"
 parameters_schema = { type = "object" }
 "#;
+
+fn capability_provider_contracts() -> ironclaw_extensions::HostApiContractRegistry {
+    let mut contracts = ironclaw_extensions::HostApiContractRegistry::new();
+    contracts
+        .register(std::sync::Arc::new(
+            ironclaw_extensions::CapabilityProviderHostApiContract::new()
+                .expect("capability provider contract"),
+        ))
+        .expect("register capability provider contract");
+    contracts
+}

--- a/crates/ironclaw_host_runtime/tests/reborn_e2e_gate.rs
+++ b/crates/ironclaw_host_runtime/tests/reborn_e2e_gate.rs
@@ -867,6 +867,7 @@ fn parse_manifest(manifest: &str) -> ExtensionManifest {
         &manifest,
         ManifestSource::InstalledLocal,
         &HostPortCatalog::empty(),
+        &capability_provider_contracts(),
     )
     .unwrap()
 }
@@ -1017,3 +1018,14 @@ effects = ["dispatch_capability"]
 default_permission = "allow"
 parameters_schema = { type = "object" }
 "#;
+
+fn capability_provider_contracts() -> ironclaw_extensions::HostApiContractRegistry {
+    let mut contracts = ironclaw_extensions::HostApiContractRegistry::new();
+    contracts
+        .register(std::sync::Arc::new(
+            ironclaw_extensions::CapabilityProviderHostApiContract::new()
+                .expect("capability provider contract"),
+        ))
+        .expect("register capability provider contract");
+    contracts
+}

--- a/crates/ironclaw_host_runtime/tests/reborn_invoke_vertical_slice.rs
+++ b/crates/ironclaw_host_runtime/tests/reborn_invoke_vertical_slice.rs
@@ -325,6 +325,7 @@ fn parse_manifest(manifest: &str) -> ExtensionManifest {
         &manifest,
         ManifestSource::InstalledLocal,
         &HostPortCatalog::empty(),
+        &capability_provider_contracts(),
     )
     .unwrap()
 }
@@ -416,3 +417,14 @@ effects = ["dispatch_capability"]
 default_permission = "allow"
 parameters_schema = {}
 "#;
+
+fn capability_provider_contracts() -> ironclaw_extensions::HostApiContractRegistry {
+    let mut contracts = ironclaw_extensions::HostApiContractRegistry::new();
+    contracts
+        .register(std::sync::Arc::new(
+            ironclaw_extensions::CapabilityProviderHostApiContract::new()
+                .expect("capability provider contract"),
+        ))
+        .expect("register capability provider contract");
+    contracts
+}

--- a/crates/ironclaw_host_runtime/tests/support/host_runtime_harness.rs
+++ b/crates/ironclaw_host_runtime/tests/support/host_runtime_harness.rs
@@ -1680,7 +1680,13 @@ pub(crate) fn parse_manifest_from_source(
     source: ManifestSource,
 ) -> ExtensionManifest {
     let manifest = legacy_capability_fixture_to_v2(manifest);
-    ExtensionManifest::parse(&manifest, source, &HostPortCatalog::empty()).unwrap()
+    ExtensionManifest::parse(
+        &manifest,
+        source,
+        &HostPortCatalog::empty(),
+        &capability_provider_contracts(),
+    )
+    .unwrap()
 }
 
 pub(crate) fn execution_context_without_grants() -> ExecutionContext {
@@ -2320,7 +2326,7 @@ effects = ["dispatch_capability", "use_secret"]
 default_permission = "allow"
 parameters_schema = { type = "object" }
 
-[[capabilities.runtime_credentials]]
+[[capability_provider.tools.capabilities.runtime_credentials]]
 handle = "script_api_token"
 source = { type = "secret_handle" }
 audience = { scheme = "https", host_pattern = "api.example.com" }
@@ -2682,3 +2688,14 @@ pub(crate) const HTTP_TOOL_WAT: &str = r#"
   (export "_initialize" (func $_initialize))
 )
 "#;
+
+fn capability_provider_contracts() -> ironclaw_extensions::HostApiContractRegistry {
+    let mut contracts = ironclaw_extensions::HostApiContractRegistry::new();
+    contracts
+        .register(std::sync::Arc::new(
+            ironclaw_extensions::CapabilityProviderHostApiContract::new()
+                .expect("capability provider contract"),
+        ))
+        .expect("register capability provider contract");
+    contracts
+}

--- a/crates/ironclaw_host_runtime/tests/support/mod.rs
+++ b/crates/ironclaw_host_runtime/tests/support/mod.rs
@@ -28,7 +28,7 @@ fn legacy_capability_fixture_to_v2_with_refs(
     schema_refs: impl Fn(&str) -> (String, String),
 ) -> String {
     if manifest.contains("schema_version") {
-        return manifest.to_string();
+        return project_top_level_capabilities_to_host_api(manifest.to_string());
     }
     let mut converted = "schema_version = \"reborn.extension_manifest.v2\"\n".to_string();
     for line in manifest.lines() {
@@ -47,5 +47,23 @@ fn legacy_capability_fixture_to_v2_with_refs(
             converted.push('\n');
         }
     }
-    converted
+    project_top_level_capabilities_to_host_api(converted)
+}
+
+/// Project a v2-legacy fixture (top-level `[[capabilities]]`) onto the
+/// host_api capability-provider form the parser requires.
+fn project_top_level_capabilities_to_host_api(manifest: String) -> String {
+    if !manifest.contains("[[capabilities]]") || manifest.contains("[[host_api]]") {
+        return manifest;
+    }
+    let host_api_block = "[[host_api]]\nid = \"ironclaw.capability_provider/v1\"\nsection = \"capability_provider.tools\"\n\n[capability_provider.tools]\n\n";
+    let idx = manifest.find("[[capabilities]]").expect("checked above");
+    let mut out = String::with_capacity(manifest.len() + host_api_block.len());
+    out.push_str(&manifest[..idx]);
+    out.push_str(host_api_block);
+    out.push_str(&manifest[idx..]);
+    out.replace(
+        "[[capabilities]]",
+        "[[capability_provider.tools.capabilities]]",
+    )
 }

--- a/crates/ironclaw_host_runtime/tests/tool_surface_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/tool_surface_contract.rs
@@ -319,6 +319,7 @@ fn hot_capability_manifest_rejects_traversal_schema_ref_at_parse_boundary() {
         &manifest,
         ManifestSource::InstalledLocal,
         &HostPortCatalog::empty(),
+        &capability_provider_contracts(),
     )
     .unwrap_err();
 
@@ -410,7 +411,13 @@ trust = "first_party_requested"
 kind = "wasm"
 module = "wasm/github.wasm"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "github.search_issues"
 description = "search"
 effects = ["network"]
@@ -419,7 +426,7 @@ visibility = "model"
 input_schema_ref = "schemas/github/search.input.json"
 output_schema_ref = "schemas/github/search.output.json"
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "github.get_issue"
 description = "get"
 effects = ["network"]
@@ -428,7 +435,7 @@ visibility = "model"
 input_schema_ref = "schemas/github/get.input.json"
 output_schema_ref = "schemas/github/get.output.json"
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "github.comment_issue"
 description = "comment"
 effects = ["network", "external_write"]
@@ -441,6 +448,7 @@ output_schema_ref = "schemas/github/comment.output.json"
         manifest,
         ManifestSource::HostBundled,
         &HostPortCatalog::empty(),
+        &capability_provider_contracts(),
     )
     .unwrap();
     let package = ExtensionPackage::from_manifest(
@@ -1879,6 +1887,7 @@ fn hot_catalog_fixture_with_prompt_bytes(
         HOT_CAPABILITY_MANIFEST,
         ManifestSource::InstalledLocal,
         &HostPortCatalog::empty(),
+        &capability_provider_contracts(),
     )
     .unwrap();
     hot_catalog_fixture_with_manifest(input_schema, output_schema, prompt_doc, manifest)
@@ -1931,6 +1940,7 @@ fn manifest_without_prompt_doc_ref() -> ExtensionManifest {
         HOT_CAPABILITY_MANIFEST,
         ManifestSource::InstalledLocal,
         &HostPortCatalog::empty(),
+        &capability_provider_contracts(),
     )
     .unwrap();
     manifest.capabilities[0].prompt_doc_ref = None;
@@ -1942,6 +1952,7 @@ fn manifest_with_visibility(visibility: CapabilityVisibility) -> ExtensionManife
         HOT_CAPABILITY_MANIFEST,
         ManifestSource::InstalledLocal,
         &HostPortCatalog::empty(),
+        &capability_provider_contracts(),
     )
     .unwrap();
     manifest.capabilities[0].visibility = visibility;
@@ -2021,6 +2032,7 @@ fn parse_manifest(manifest: &str) -> ExtensionManifest {
         &manifest,
         ManifestSource::InstalledLocal,
         &HostPortCatalog::empty(),
+        &capability_provider_contracts(),
     )
     .unwrap()
 }
@@ -2273,7 +2285,13 @@ trust = "third_party"
 kind = "wasm"
 module = "echo.wasm"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "echo.say"
 description = "Echoes input"
 effects = ["dispatch_capability"]
@@ -2478,3 +2496,14 @@ effects = ["dispatch_capability"]
 default_permission = "allow"
 parameters_schema = {}
 "#;
+
+fn capability_provider_contracts() -> ironclaw_extensions::HostApiContractRegistry {
+    let mut contracts = ironclaw_extensions::HostApiContractRegistry::new();
+    contracts
+        .register(std::sync::Arc::new(
+            ironclaw_extensions::CapabilityProviderHostApiContract::new()
+                .expect("capability provider contract"),
+        ))
+        .expect("register capability provider contract");
+    contracts
+}

--- a/crates/ironclaw_mcp/tests/mcp_adapter_contract.rs
+++ b/crates/ironclaw_mcp/tests/mcp_adapter_contract.rs
@@ -1950,7 +1950,7 @@ impl ResourceGovernor for ReleaseFailingGovernor {
 }
 
 fn package_from_manifest(manifest: &str) -> ExtensionPackage {
-    let manifest = ExtensionManifest::parse_with_optional_host_api_contracts(
+    let manifest = ExtensionManifest::parse(
         manifest,
         ManifestSource::InstalledLocal,
         &HostPortCatalog::empty(),

--- a/crates/ironclaw_mcp/tests/mcp_dispatch_integration.rs
+++ b/crates/ironclaw_mcp/tests/mcp_dispatch_integration.rs
@@ -168,7 +168,7 @@ fn mcp_governor() -> (InMemoryResourceGovernor, ResourceAccount) {
 }
 
 fn package_from_manifest(manifest: &str) -> ExtensionPackage {
-    let manifest = ExtensionManifest::parse_with_optional_host_api_contracts(
+    let manifest = ExtensionManifest::parse(
         manifest,
         ManifestSource::InstalledLocal,
         &HostPortCatalog::empty(),

--- a/crates/ironclaw_product_adapter_registry/src/lib.rs
+++ b/crates/ironclaw_product_adapter_registry/src/lib.rs
@@ -19,7 +19,8 @@ use ironclaw_extensions::{
     ExtensionInstallation, ExtensionInstallationError, ExtensionInstallationStore,
     ExtensionManifestRecord, ExtensionManifestV2, HostApiContractRegistry, HostApiId,
     HostApiManifestContext, HostApiManifestContract, HostApiManifestProjection,
-    HostApiMultiplicity, HostApiRefV2, ManifestSectionPath, ManifestSource, ManifestV2Error,
+    HostApiMultiplicity, HostApiRefV2, HostApiSectionError, ManifestSectionPath, ManifestSource,
+    ManifestV2Error,
 };
 use ironclaw_host_api::{
     CapabilitySurfaceKind, ExtensionId, HostPortCatalog, IngressAuthPolicy, IngressRouteDescriptor,
@@ -49,7 +50,7 @@ pub fn parse_product_adapter_manifest_record(
 ) -> Result<ExtensionManifestRecord, RegistryError> {
     let mut contracts = HostApiContractRegistry::new();
     register_product_adapter_host_api_contract(&mut contracts)?;
-    let record = ExtensionManifestRecord::from_toml_with_contracts(
+    let record = ExtensionManifestRecord::from_toml(
         raw_toml,
         source,
         host_port_catalog,
@@ -395,21 +396,22 @@ impl HostApiManifestContract for ProductAdapterHostApiContract {
         &self,
         host_api: &HostApiRefV2,
         section: &toml::Value,
-    ) -> Result<(), String> {
+    ) -> Result<(), HostApiSectionError> {
         // The contract hook runs while the generic manifest parser is still
         // validating the host-api section envelope, before it exposes the real
         // extension id to contract implementations. `from_value` needs an id
         // only to derive the adapter_id that this shape-only path discards;
         // cross-field checks involving the real extension id belong in
         // `project_product_adapter_sections` below.
-        let placeholder = ExtensionId::new("x").map_err(|e| e.to_string())?;
+        let placeholder =
+            ExtensionId::new("x").map_err(|e| HostApiSectionError::from(e.to_string()))?;
         ProductAdapterHostApiSection::from_value(
             &placeholder,
             host_api.section.clone(),
             section.clone(),
         )
         .map(|_| ())
-        .map_err(|e| e.to_string())
+        .map_err(|e| HostApiSectionError::from(e.to_string()))
     }
 
     fn validate_section_with_context(
@@ -417,14 +419,14 @@ impl HostApiManifestContract for ProductAdapterHostApiContract {
         context: &HostApiManifestContext<'_>,
         host_api: &HostApiRefV2,
         section: &toml::Value,
-    ) -> Result<(), String> {
+    ) -> Result<(), HostApiSectionError> {
         ProductAdapterHostApiSection::from_value(
             context.extension_id,
             host_api.section.clone(),
             section.clone(),
         )
         .map(|_| ())
-        .map_err(|e| e.to_string())
+        .map_err(|e| HostApiSectionError::from(e.to_string()))
     }
 
     fn project_section_with_context(
@@ -432,13 +434,13 @@ impl HostApiManifestContract for ProductAdapterHostApiContract {
         context: &HostApiManifestContext<'_>,
         host_api: &HostApiRefV2,
         section: &toml::Value,
-    ) -> Result<HostApiManifestProjection, String> {
+    ) -> Result<HostApiManifestProjection, HostApiSectionError> {
         let parsed = ProductAdapterHostApiSection::from_value(
             context.extension_id,
             host_api.section.clone(),
             section.clone(),
         )
-        .map_err(|e| e.to_string())?;
+        .map_err(|e| HostApiSectionError::from(e.to_string()))?;
         // External-channel adapter sections are the extension's channel
         // surface. The other product surface kinds (`web`, `cli`,
         // `synchronous_api`) describe host-native surfaces and project no

--- a/crates/ironclaw_product_adapter_registry/tests/registry_contract.rs
+++ b/crates/ironclaw_product_adapter_registry/tests/registry_contract.rs
@@ -138,7 +138,13 @@ trust = "third_party"
 kind = "wasm"
 module = "wasm/plain.wasm"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "plain-tool.do"
 description = "Do something"
 default_permission = "ask"
@@ -150,11 +156,18 @@ prompt_doc_ref = "prompts/do.md"
         schema = MANIFEST_SCHEMA_VERSION,
     );
     let plain_id = ExtensionId::new("plain-tool").unwrap();
+    let mut contracts = ironclaw_extensions::HostApiContractRegistry::new();
+    contracts
+        .register(std::sync::Arc::new(
+            ironclaw_extensions::CapabilityProviderHostApiContract::new().unwrap(),
+        ))
+        .unwrap();
     let plain_manifest = ExtensionManifestRecord::from_toml(
         plain_raw,
         ManifestSource::HostBundled,
         &ironclaw_host_api::HostPortCatalog::empty(),
         Some(manifest_hash("sha256:plain")),
+        &contracts,
     )
     .unwrap();
     let plain_install = ExtensionInstallation::new(

--- a/crates/ironclaw_reborn_composition/src/extension_host/available_extension_import.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/available_extension_import.rs
@@ -172,7 +172,7 @@ pub(crate) fn imported_extension_package(
         })?;
     // Uploads are always validated as InstalledLocal. Only binary-compiled
     // packages may claim the HostBundled trust/runtime tier.
-    let record = ExtensionManifestRecord::from_toml_with_contracts(
+    let record = ExtensionManifestRecord::from_toml(
         manifest_toml,
         ManifestSource::InstalledLocal,
         &host_ports,
@@ -604,7 +604,7 @@ prompt_doc_ref = "prompts/run.md"
                 ironclaw_host_runtime::default_host_port_catalog().expect("host port catalog");
             let contracts = ironclaw_host_runtime::default_host_api_contract_registry()
                 .expect("host API contracts");
-            let record = ExtensionManifestRecord::from_toml_with_contracts(
+            let record = ExtensionManifestRecord::from_toml(
                 manifest,
                 ManifestSource::InstalledLocal,
                 &host_ports,

--- a/crates/ironclaw_reborn_composition/src/extension_host/available_extensions.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/available_extensions.rs
@@ -706,9 +706,17 @@ fn nearai_mcp_manifest_toml_for_endpoint(
     runtime.insert("url".to_string(), Value::String(endpoint.url.clone()));
 
     let capabilities = manifest
-        .get_mut("capabilities")
+        .get_mut("capability_provider")
+        .and_then(Value::as_table_mut)
+        .and_then(|section| section.get_mut("tools"))
+        .and_then(Value::as_table_mut)
+        .and_then(|tools| tools.get_mut("capabilities"))
         .and_then(Value::as_array_mut)
-        .ok_or_else(|| map_binding_error("bundled NEAR AI manifest lacks capabilities array"))?;
+        .ok_or_else(|| {
+            map_binding_error(
+                "bundled NEAR AI manifest lacks capability_provider.tools capabilities array",
+            )
+        })?;
     let search = capabilities
         .first_mut()
         .and_then(Value::as_table_mut)
@@ -762,7 +770,7 @@ fn bundled_extension_package(
             reason: format!("host API contracts rejected bundled {label} extension: {error}"),
         }
     })?;
-    let record = ExtensionManifestRecord::from_toml_with_contracts(
+    let record = ExtensionManifestRecord::from_toml(
         manifest_toml,
         ManifestSource::HostBundled,
         &host_ports,
@@ -1674,7 +1682,7 @@ where
             reason: format!("available extension manifest is not UTF-8: {error}"),
         }
     })?;
-    let record = ExtensionManifestRecord::from_toml_with_contracts(
+    let record = ExtensionManifestRecord::from_toml(
         manifest_toml,
         ManifestSource::InstalledLocal,
         host_ports,
@@ -1760,6 +1768,17 @@ fn visible_capabilities(
 
 #[cfg(test)]
 mod tests {
+
+    fn capability_provider_contracts() -> ironclaw_extensions::HostApiContractRegistry {
+        let mut contracts = ironclaw_extensions::HostApiContractRegistry::new();
+        contracts
+            .register(std::sync::Arc::new(
+                ironclaw_extensions::CapabilityProviderHostApiContract::new()
+                    .expect("capability provider contract"),
+            ))
+            .expect("register capability provider contract");
+        contracts
+    }
     use std::{
         collections::{BTreeSet, HashMap, HashSet},
         sync::{Arc, Mutex},
@@ -2743,15 +2762,10 @@ handle = "web_token"
             manifest["runtime"]["url"].as_str(),
             Some("https://10.0.0.12:8443/%22%0Atrust=%22system/mcp")
         );
-        assert_eq!(
-            manifest["capabilities"][0]["runtime_credentials"][0]["audience"]["host_pattern"]
-                .as_str(),
-            Some("10.0.0.12")
-        );
-        assert_eq!(
-            manifest["capabilities"][0]["runtime_credentials"][0]["audience"]["port"].as_integer(),
-            Some(8443)
-        );
+        let audience = &manifest["capability_provider"]["tools"]["capabilities"][0]["runtime_credentials"]
+            [0]["audience"];
+        assert_eq!(audience["host_pattern"].as_str(), Some("10.0.0.12"));
+        assert_eq!(audience["port"].as_integer(), Some(8443));
     }
 
     #[cfg(not(any(feature = "libsql", feature = "postgres")))]
@@ -3050,7 +3064,13 @@ trust = "third_party"
 kind = "wasm"
 module = "wasm/fixture.wasm"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "fixture.search"
 description = "Search"
 effects = ["network"]
@@ -3059,7 +3079,7 @@ visibility = "model"
 input_schema_ref = "schemas/search.input.json"
 output_schema_ref = "schemas/search.output.json"
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "fixture.write"
 description = "Write"
 effects = ["external_write"]
@@ -3072,6 +3092,7 @@ output_schema_ref = "schemas/write.output.json"
             MANIFEST,
             ManifestSource::HostBundled,
             &HostPortCatalog::empty(),
+            &capability_provider_contracts(),
         )
         .expect("manifest");
         let package = ExtensionPackage::from_manifest(

--- a/crates/ironclaw_reborn_composition/src/extension_host/extension_installation_store.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/extension_installation_store.rs
@@ -263,7 +263,7 @@ impl WireManifestRecord {
             .map_err(invalid_installation_error)?;
         let contracts =
             product_extension_host_api_contract_registry().map_err(invalid_installation_error)?;
-        ExtensionManifestRecord::from_toml_with_contracts(
+        ExtensionManifestRecord::from_toml(
             self.raw_toml,
             self.source.into_manifest_source(),
             &host_ports,

--- a/crates/ironclaw_reborn_composition/src/extension_host/extension_installation_store/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/extension_installation_store/tests.rs
@@ -65,6 +65,7 @@ async fn load_at_persists_state_to_custom_path() {
         ExtensionInstallationId::new("gmail".to_string()).expect("valid installation id");
     let extension_id = ExtensionId::new("gmail").expect("valid extension id");
     let manifest_ref = ExtensionManifestRef::new(extension_id.clone(), None);
+    let contracts = product_extension_host_api_contract_registry().expect("host api contracts");
     let manifest = ExtensionManifestRecord::from_toml(
         format!(
             r#"
@@ -79,7 +80,13 @@ trust = "third_party"
 kind = "wasm"
 module = "wasm/gmail.wasm"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "gmail.echo"
 description = "Echoes input"
 default_permission = "allow"
@@ -93,6 +100,7 @@ prompt_doc_ref = "prompts/gmail/echo.md"
         ManifestSource::HostBundled,
         &HostPortCatalog::empty(),
         None,
+        &contracts,
     )
     .expect("valid manifest");
     store
@@ -483,14 +491,16 @@ async fn seed_state(
 
 fn test_manifest_record() -> ExtensionManifestRecord {
     let manifest = format!(
-        "schema_version = \"{}\"\nid = \"canonical-tools\"\nname = \"Canonical Tools\"\nversion = \"0.1.0\"\ndescription = \"test\"\ntrust = \"third_party\"\n\n[runtime]\nkind = \"wasm\"\nmodule = \"wasm/canonical-tools.wasm\"\n\n[[capabilities]]\nid = \"canonical-tools.echo\"\ndescription = \"Echo\"\ndefault_permission = \"allow\"\nvisibility = \"model\"\ninput_schema_ref = \"schemas/echo.input.json\"\noutput_schema_ref = \"schemas/echo.output.json\"\n",
+        "schema_version = \"{}\"\nid = \"canonical-tools\"\nname = \"Canonical Tools\"\nversion = \"0.1.0\"\ndescription = \"test\"\ntrust = \"third_party\"\n\n[runtime]\nkind = \"wasm\"\nmodule = \"wasm/canonical-tools.wasm\"\n\n[[host_api]]\nid = \"ironclaw.capability_provider/v1\"\nsection = \"capability_provider.tools\"\n\n[capability_provider.tools]\n\n[[capability_provider.tools.capabilities]]\nid = \"canonical-tools.echo\"\ndescription = \"Echo\"\ndefault_permission = \"allow\"\nvisibility = \"model\"\ninput_schema_ref = \"schemas/echo.input.json\"\noutput_schema_ref = \"schemas/echo.output.json\"\n",
         MANIFEST_SCHEMA_VERSION
     );
+    let contracts = product_extension_host_api_contract_registry().expect("host api contracts");
     ExtensionManifestRecord::from_toml(
         manifest,
         ManifestSource::HostBundled,
         &HostPortCatalog::empty(),
         None,
+        &contracts,
     )
     .unwrap()
 }

--- a/crates/ironclaw_reborn_composition/src/extension_host/extension_lifecycle.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/extension_lifecycle.rs
@@ -1879,7 +1879,7 @@ fn prepare_install(
     // stamping everything `HostBundled` here would launder an imported
     // (`InstalledLocal`) bundle into the stored-manifest tier that is allowed
     // first-party trust and the bundled hash-migration path below.
-    let manifest_record = ExtensionManifestRecord::from_toml_with_contracts(
+    let manifest_record = ExtensionManifestRecord::from_toml(
         &available.manifest_toml,
         available.source,
         &host_ports,
@@ -1927,7 +1927,7 @@ fn prepare_manifest_migration(
     // (`migrate_host_bundled_manifest_hash`) additionally requires the STORED
     // manifest to be `HostBundled` before migrating, so an imported extension
     // whose on-disk manifest changed fails closed instead of migrating.
-    let manifest_record = ExtensionManifestRecord::from_toml_with_contracts(
+    let manifest_record = ExtensionManifestRecord::from_toml(
         &available.manifest_toml,
         available.source,
         &host_ports,
@@ -2301,6 +2301,17 @@ fn compensation_failure(
 
 #[cfg(test)]
 mod tests {
+
+    fn capability_provider_contracts() -> ironclaw_extensions::HostApiContractRegistry {
+        let mut contracts = ironclaw_extensions::HostApiContractRegistry::new();
+        contracts
+            .register(std::sync::Arc::new(
+                ironclaw_extensions::CapabilityProviderHostApiContract::new()
+                    .expect("capability provider contract"),
+            ))
+            .expect("register capability provider contract");
+        contracts
+    }
     use std::{
         collections::BTreeSet,
         sync::atomic::{AtomicUsize, Ordering},
@@ -6514,7 +6525,13 @@ trust = "first_party_requested"
 kind = "wasm"
 module = "wasm/fixture.wasm"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "fixture.search"
 description = "Search fixture data"
 effects = ["network"]
@@ -6523,7 +6540,7 @@ visibility = "model"
 input_schema_ref = "schemas/search.input.json"
 output_schema_ref = "schemas/search.output.json"
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "fixture.write"
 description = "Write fixture data"
 effects = ["network", "external_write"]
@@ -6641,6 +6658,7 @@ output_schema_ref = "schemas/search.output.json"
             manifest_toml,
             ManifestSource::HostBundled,
             &HostPortCatalog::empty(),
+            &capability_provider_contracts(),
         )
         .expect("fixture manifest");
         fixture_extension_package_from_parsed_manifest(manifest_toml, root_id, manifest)
@@ -6657,7 +6675,7 @@ output_schema_ref = "schemas/search.output.json"
                     .expect("product adapter host API contract"),
             ))
             .expect("register product adapter host API contract");
-        let manifest = ExtensionManifest::parse_with_host_api_contracts(
+        let manifest = ExtensionManifest::parse(
             manifest_toml,
             ManifestSource::HostBundled,
             &HostPortCatalog::empty(),
@@ -6706,7 +6724,7 @@ output_schema_ref = "schemas/search.output.json"
         let host_ports =
             ironclaw_host_runtime::default_host_port_catalog().expect("host port catalog");
         let contracts = product_extension_host_api_contract_registry().expect("host API contracts");
-        ExtensionManifestRecord::from_toml_with_contracts(
+        ExtensionManifestRecord::from_toml(
             manifest_toml,
             source,
             &host_ports,

--- a/crates/ironclaw_reborn_composition/src/host_ingress.rs
+++ b/crates/ironclaw_reborn_composition/src/host_ingress.rs
@@ -47,7 +47,7 @@ pub(crate) fn bundled_host_ingress_descriptors(
 ) -> Result<Vec<IngressRouteDescriptor>, HostIngressProjectionError> {
     let host_ports = ironclaw_host_runtime::default_host_port_catalog().map_err(projection)?;
     let contracts = product_extension_host_api_contract_registry().map_err(projection)?;
-    let record = ExtensionManifestRecord::from_toml_with_contracts(
+    let record = ExtensionManifestRecord::from_toml(
         manifest_toml,
         ManifestSource::HostBundled,
         &host_ports,

--- a/crates/ironclaw_reborn_composition/src/observability/hooks/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/observability/hooks/tests.rs
@@ -82,7 +82,13 @@ trust = "untrusted"
 kind = "wasm"
 module = "wasm/{id}.wasm"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "{id}.run"
 description = "Run {id}"
 effects = ["dispatch_capability"]
@@ -104,8 +110,13 @@ fn registry_with_manifest_source(
     toml: &str,
     source: ManifestSource,
 ) -> ExtensionRegistry {
-    let manifest =
-        ExtensionManifest::parse(toml, source, &HostPortCatalog::empty()).expect("manifest parses");
+    let manifest = ExtensionManifest::parse(
+        toml,
+        source,
+        &HostPortCatalog::empty(),
+        &capability_provider_contracts(),
+    )
+    .expect("manifest parses");
     let package = ExtensionPackage::from_manifest(
         manifest,
         VirtualPath::new(format!("/system/extensions/{id}")).expect("valid root path"),
@@ -287,6 +298,7 @@ fn projection_with(packages: &[(&str, ManifestSource, String)]) -> HookProjectio
             &manifest_toml(id, hooks_block),
             *source,
             &HostPortCatalog::empty(),
+            &capability_provider_contracts(),
         )
         .expect("manifest parses");
         let package = ExtensionPackage::from_manifest(
@@ -897,7 +909,7 @@ async fn failed_merge_does_not_consume_hook_budget() {
     let contracts = ironclaw_host_runtime::default_host_api_contract_registry()
         .expect("default host api contracts");
     let dup = ExtensionPackage::from_manifest(
-        ExtensionManifest::parse_with_host_api_contracts(
+        ExtensionManifest::parse(
             &manifest_toml_with_hook("alpha"),
             ManifestSource::InstalledLocal,
             &HostPortCatalog::empty(),
@@ -996,4 +1008,15 @@ body = { mode = "nonsense" }
         "the tenant-attributed entry point must NOT fall back to the synthetic \
          audit tenant; captured {captured:?}"
     );
+}
+
+fn capability_provider_contracts() -> ironclaw_extensions::HostApiContractRegistry {
+    let mut contracts = ironclaw_extensions::HostApiContractRegistry::new();
+    contracts
+        .register(std::sync::Arc::new(
+            ironclaw_extensions::CapabilityProviderHostApiContract::new()
+                .expect("capability provider contract"),
+        ))
+        .expect("register capability provider contract");
+    contracts
 }

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -4715,6 +4715,17 @@ fn build_stub_gateway() -> Arc<dyn ironclaw_loop_host::HostManagedModelGateway> 
 
 #[cfg(test)]
 mod tests {
+
+    fn capability_provider_contracts() -> ironclaw_extensions::HostApiContractRegistry {
+        let mut contracts = ironclaw_extensions::HostApiContractRegistry::new();
+        contracts
+            .register(std::sync::Arc::new(
+                ironclaw_extensions::CapabilityProviderHostApiContract::new()
+                    .expect("capability provider contract"),
+            ))
+            .expect("register capability provider contract");
+        contracts
+    }
     use std::sync::{
         Arc, Mutex as StdMutex,
         atomic::{AtomicUsize, Ordering},
@@ -4759,7 +4770,13 @@ trust = "third_party"
 kind = "wasm"
 module = "wasm/approval-provider.wasm"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "approval-provider.write"
 description = "write"
 effects = ["external_write"]
@@ -4772,6 +4789,7 @@ output_schema_ref = "schemas/write.output.json"
             manifest,
             ironclaw_extensions::ManifestSource::HostBundled,
             &ironclaw_host_api::HostPortCatalog::empty(),
+            &capability_provider_contracts(),
         )
         .expect("manifest parses");
         let package = ironclaw_extensions::ExtensionPackage::from_manifest(

--- a/crates/ironclaw_reborn_composition/src/webui/facade.rs
+++ b/crates/ironclaw_reborn_composition/src/webui/facade.rs
@@ -1032,6 +1032,17 @@ fn status_check(
 
 #[cfg(test)]
 mod tests {
+
+    fn capability_provider_contracts() -> ironclaw_extensions::HostApiContractRegistry {
+        let mut contracts = ironclaw_extensions::HostApiContractRegistry::new();
+        contracts
+            .register(std::sync::Arc::new(
+                ironclaw_extensions::CapabilityProviderHostApiContract::new()
+                    .expect("capability provider contract"),
+            ))
+            .expect("register capability provider contract");
+        contracts
+    }
     use super::*;
     use async_trait::async_trait;
     use ironclaw_extensions::{
@@ -1109,7 +1120,9 @@ mod tests {
                  id = \"{ext}\"\nname = \"{ext}\"\nversion = \"0.1.0\"\n\
                  description = \"test\"\ntrust = \"third_party\"\n\n\
                  [runtime]\nkind = \"wasm\"\nmodule = \"wasm/{ext}.wasm\"\n\n\
-                 [[capabilities]]\nid = \"{ext}.{capability}\"\ndescription = \"{capability}\"\n\
+                 [[host_api]]\nid = \"ironclaw.capability_provider/v1\"\nsection = \"capability_provider.tools\"\n\n\
+                 [capability_provider.tools]\n\n\
+                 [[capability_provider.tools.capabilities]]\nid = \"{ext}.{capability}\"\ndescription = \"{capability}\"\n\
                  effects = [\"network\"]\ndefault_permission = \"ask\"\nvisibility = \"model\"\n\
                  input_schema_ref = \"schemas/{capability}.input.json\"\n\
                  output_schema_ref = \"schemas/{capability}.output.json\"\n"
@@ -1119,6 +1132,7 @@ mod tests {
                 ManifestSource::HostBundled,
                 &HostPortCatalog::empty(),
                 None,
+                &capability_provider_contracts(),
             )
             .expect("manifest record")
         }
@@ -1810,7 +1824,13 @@ trust = "third_party"
 kind = "wasm"
 module = "wasm/{extension_id}.wasm"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "{extension_id}.{capability_name}"
 description = "{capability_name}"
 effects = ["network"]
@@ -1824,6 +1844,7 @@ output_schema_ref = "schemas/{capability_name}.output.json"
             &manifest_toml,
             ManifestSource::HostBundled,
             &HostPortCatalog::empty(),
+            &capability_provider_contracts(),
         )
         .expect("manifest parses");
         ExtensionPackage::from_manifest(

--- a/crates/ironclaw_reborn_composition/tests/gsuite.rs
+++ b/crates/ironclaw_reborn_composition/tests/gsuite.rs
@@ -131,6 +131,7 @@ fn asset_manifest(extension_id: &str) -> ironclaw_extensions::ExtensionManifest 
         manifest_toml,
         ManifestSource::HostBundled,
         &ironclaw_host_api::HostPortCatalog::empty(),
+        &capability_provider_contracts(),
     )
     .unwrap()
 }
@@ -705,4 +706,15 @@ async fn bundled_gsuite_handler_projects_stage_backend_to_first_party_dispatch_b
         Some(RuntimeDispatchErrorKind::Backend),
         "stage Backend must produce Dispatch {{ kind: Backend }}"
     );
+}
+
+fn capability_provider_contracts() -> ironclaw_extensions::HostApiContractRegistry {
+    let mut contracts = ironclaw_extensions::HostApiContractRegistry::new();
+    contracts
+        .register(std::sync::Arc::new(
+            ironclaw_extensions::CapabilityProviderHostApiContract::new()
+                .expect("capability provider contract"),
+        ))
+        .expect("register capability provider contract");
+    contracts
 }

--- a/crates/ironclaw_reborn_migration/src/convert/extensions.rs
+++ b/crates/ironclaw_reborn_migration/src/convert/extensions.rs
@@ -267,7 +267,7 @@ async fn write_canonical_installation(
         &first.version,
         &first.description,
     );
-    let manifest = match ExtensionManifestRecord::from_toml_with_contracts(
+    let manifest = match ExtensionManifestRecord::from_toml(
         manifest_toml,
         ManifestSource::InstalledLocal,
         catalog,

--- a/crates/ironclaw_runner/tests/loop_driver_host.rs
+++ b/crates/ironclaw_runner/tests/loop_driver_host.rs
@@ -8155,6 +8155,7 @@ fn e2e_registry_with_manifest(manifest: &str) -> ExtensionRegistry {
         manifest,
         ManifestSource::InstalledLocal,
         &HostPortCatalog::empty(),
+        &capability_provider_contracts(),
     )
     .unwrap();
     let package = ExtensionPackage::from_manifest(
@@ -8207,7 +8208,13 @@ runner = "sandboxed_process"
 command = "echo-script"
 args = []
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "script.echo"
 description = "Echo text through Reborn adapter e2e"
 effects = ["dispatch_capability"]
@@ -9427,4 +9434,15 @@ impl LoopModelBudgetAccountant for RejectingSystemInferenceBudgetAccountant {
     ) -> Result<(), LoopModelGatewayError> {
         panic!("post_model_work must not run when pre_model_work rejects")
     }
+}
+
+fn capability_provider_contracts() -> ironclaw_extensions::HostApiContractRegistry {
+    let mut contracts = ironclaw_extensions::HostApiContractRegistry::new();
+    contracts
+        .register(std::sync::Arc::new(
+            ironclaw_extensions::CapabilityProviderHostApiContract::new()
+                .expect("capability provider contract"),
+        ))
+        .expect("register capability provider contract");
+    contracts
 }

--- a/crates/ironclaw_scripts/tests/script_dispatch_integration.rs
+++ b/crates/ironclaw_scripts/tests/script_dispatch_integration.rs
@@ -117,7 +117,7 @@ fn script_governor() -> (InMemoryResourceGovernor, ResourceAccount) {
 }
 
 fn package_from_manifest(manifest: &str) -> ExtensionPackage {
-    let manifest = ExtensionManifest::parse_with_optional_host_api_contracts(
+    let manifest = ExtensionManifest::parse(
         manifest,
         ManifestSource::InstalledLocal,
         &HostPortCatalog::empty(),

--- a/crates/ironclaw_scripts/tests/script_runner_contract.rs
+++ b/crates/ironclaw_scripts/tests/script_runner_contract.rs
@@ -395,7 +395,7 @@ fn wasm_package() -> ExtensionPackage {
 }
 
 fn package_from_manifest(manifest: &str) -> ExtensionPackage {
-    let manifest = ExtensionManifest::parse_with_optional_host_api_contracts(
+    let manifest = ExtensionManifest::parse(
         manifest,
         ManifestSource::InstalledLocal,
         &HostPortCatalog::empty(),

--- a/crates/ironclaw_wasm/tests/wasm_dispatch_integration.rs
+++ b/crates/ironclaw_wasm/tests/wasm_dispatch_integration.rs
@@ -809,7 +809,7 @@ fn registry_with_package(manifest: &str) -> ironclaw_extensions::ExtensionRegist
 }
 
 fn package_from_manifest(manifest: &str) -> ExtensionPackage {
-    let manifest = ExtensionManifest::parse_with_optional_host_api_contracts(
+    let manifest = ExtensionManifest::parse(
         manifest,
         ManifestSource::InstalledLocal,
         &HostPortCatalog::empty(),

--- a/docs/reborn/contracts/extensions.md
+++ b/docs/reborn/contracts/extensions.md
@@ -86,13 +86,12 @@ Production manifests use `schema_version = "reborn.extension_manifest.v2"`.
 The older top-level `parameters_schema` manifest shape is no longer parsed on
 production discovery paths.
 
-Installed third-party manifests (`InstalledLocal` / `RegistryInstalled`) declare
-model-visible tools through `[[host_api]] id = "ironclaw.capability_provider/v1"`.
-Legacy top-level `[[capabilities]]` declarations are accepted only for
-`ManifestSource::HostBundled` packages such as host-owned built-ins and explicit
-compatibility fixtures.
+Every manifest — host-bundled exactly as installed — declares its sections
+through `[[host_api]]` contracts; tools live under
+`[[host_api]] id = "ironclaw.capability_provider/v1"`. Top-level
+`[[capabilities]]` is rejected for every manifest source.
 
-Legacy host-bundled WASM manifest:
+Host-bundled WASM manifest:
 
 ```toml
 schema_version = "reborn.extension_manifest.v2"
@@ -106,7 +105,13 @@ trust = "untrusted"
 kind = "wasm"
 module = "wasm/echo.wasm"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "echo.say"
 description = "Echo text"
 effects = ["dispatch_capability"]
@@ -116,7 +121,7 @@ input_schema_ref = "schemas/echo/say.input.v1.json"
 output_schema_ref = "schemas/echo/say.output.v1.json"
 ```
 
-Legacy host-bundled script/CLI manifest:
+Host-bundled script/CLI manifest:
 
 ```toml
 schema_version = "reborn.extension_manifest.v2"
@@ -133,7 +138,13 @@ image = "python:3.12-slim"
 command = "pytest"
 args = ["tests/"]
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "project-tools.pytest"
 description = "Run pytest"
 effects = ["execute_code"]
@@ -143,7 +154,7 @@ input_schema_ref = "schemas/project-tools/pytest.input.v1.json"
 output_schema_ref = "schemas/project-tools/pytest.output.v1.json"
 ```
 
-Legacy host-bundled MCP adapter manifest:
+Host-bundled MCP adapter manifest:
 
 ```toml
 schema_version = "reborn.extension_manifest.v2"
@@ -159,7 +170,13 @@ transport = "stdio"
 command = "github-mcp-server"
 args = ["--stdio"]
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "github-mcp.search_issues"
 description = "Search GitHub issues"
 effects = ["network", "dispatch_capability"]
@@ -242,12 +259,18 @@ Rules:
 - Manifest validation is atomic: any invalid host API contract invalidates the extension manifest.
 - Runtime loading, handshakes, catalog publication, authority grants, and execution remain outside `ironclaw_extensions`.
 
-Migration rules:
+Cutover (complete):
 
-- Installed third-party extensions must move each model-visible top-level `[[capabilities]]` entry under `[[capability_provider.tools.capabilities]]` and reference it from `[[host_api]] id = "ironclaw.capability_provider/v1"`.
-- Host-bundled built-ins may keep top-level `[[capabilities]]` while first-party packaging remains synthetic/host-owned.
-- Do not mix `[[host_api]]` with top-level `[[capabilities]]` in one manifest.
-- Deprecated path scope is only legacy top-level capability declarations for installed third-party manifests; extension manifest v2 itself remains active.
+- Every manifest — host-bundled exactly as installed — declares at least one
+  `[[host_api]]` contract; there is no contract-free manifest form and no
+  contract-free parse or discovery entry point.
+- Top-level `[[capabilities]]` is rejected for every manifest source with an
+  actionable error. Capabilities are declared under
+  `[[capability_provider.tools.capabilities]]` and referenced from
+  `[[host_api]] id = "ironclaw.capability_provider/v1"`.
+- Host API contracts raise `HostApiSectionError`: this crate's own contracts
+  (capability provider) preserve typed `ManifestV2Error` variants; domain
+  crates report redacted reasons wrapped as `HostApiSectionRejected`.
 
 ### Capability surfaces
 
@@ -338,8 +361,8 @@ Rules:
   (`header` or `query_param`), and optional `required` flag. The field is only
   valid when the capability declares `use_secret`; duplicate handles within one
   capability are invalid. The manifest never contains raw secret material.
-- top-level legacy capabilities must provide `input_schema_ref` and
-  `output_schema_ref`; `prompt_doc_ref` is optional lazy help metadata.
+- every capability must provide `input_schema_ref` and `output_schema_ref`;
+  `prompt_doc_ref` is optional lazy help metadata.
 - during this cutover, `CapabilityDescriptor.parameters_schema` is a projection
   placeholder of the form `{ "$ref": input_schema_ref }`. Catalog publication is
   responsible for resolving schema/doc refs into hot per-turn tool descriptors.

--- a/tests/integration/support/extension_surface.rs
+++ b/tests/integration/support/extension_surface.rs
@@ -197,7 +197,7 @@ const BUNDLED_EXTENSION_MANIFEST_ASSET_DIRS: &[&str] = &[
 /// Real capability ids declared by every non-github bundled first-party
 /// extension's production `manifest.toml` asset — parsed the same way
 /// `github::capability_ids()` parses github's
-/// (`ExtensionManifest::parse_with_host_api_contracts` over the actual
+/// (`ExtensionManifest::parse` over the actual
 /// shipped asset file), so this is production truth, not a second
 /// hand-transcribed test-only id list like `BUNDLED_EXTENSION_CAPABILITY_IDS`
 /// above.
@@ -208,7 +208,7 @@ pub fn bundled_extension_manifest_capability_ids()
         let asset_root = repo_root()
             .join("crates/ironclaw_first_party_extensions/assets")
             .join(dir_name);
-        let manifest = ironclaw_extensions::ExtensionManifest::parse_with_host_api_contracts(
+        let manifest = ironclaw_extensions::ExtensionManifest::parse(
             &std::fs::read_to_string(asset_root.join("manifest.toml"))?,
             ironclaw_extensions::ManifestSource::HostBundled,
             &ironclaw_host_runtime::default_host_port_catalog()?,

--- a/tests/integration/support/github.rs
+++ b/tests/integration/support/github.rs
@@ -55,7 +55,7 @@ pub fn extension_registry() -> GithubSupportResult<ExtensionRegistry> {
 /// feeds it into `publish_bundled_extension_for_test` for github.* dispatch
 /// without a scripted install/activate handshake.
 pub fn extension_package() -> GithubSupportResult<ExtensionPackage> {
-    let manifest = ExtensionManifest::parse_with_host_api_contracts(
+    let manifest = ExtensionManifest::parse(
         &std::fs::read_to_string(asset_root().join("manifest.toml"))?,
         ManifestSource::HostBundled,
         &default_host_port_catalog()?,

--- a/tests/integration/support/harness/profiles/extension.rs
+++ b/tests/integration/support/harness/profiles/extension.rs
@@ -93,7 +93,13 @@ trust = "first_party_requested"
 kind = "wasm"
 module = "wasm/visprobe.wasm"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "visprobe.search"
 description = "Model-visible probe capability"
 effects = ["network"]
@@ -102,7 +108,7 @@ visibility = "model"
 input_schema_ref = "schemas/search.input.json"
 output_schema_ref = "schemas/search.output.json"
 
-[[capabilities]]
+[[capability_provider.tools.capabilities]]
 id = "visprobe.audit"
 description = "Host-internal probe capability"
 effects = ["network", "external_write"]
@@ -117,6 +123,7 @@ fn visibility_probe_package() -> HarnessResult<ironclaw_extensions::ExtensionPac
         VISIBILITY_PROBE_MANIFEST,
         ironclaw_extensions::ManifestSource::HostBundled,
         &ironclaw_host_api::host_port::HostPortCatalog::empty(),
+        &capability_provider_contracts(),
     )?;
     Ok(ironclaw_extensions::ExtensionPackage::from_manifest(
         manifest,
@@ -262,4 +269,15 @@ fn extension_lifecycle_credential_seeds() -> &'static [ExtensionLifecycleCredent
             scopes: &[],
         },
     ]
+}
+
+fn capability_provider_contracts() -> ironclaw_extensions::HostApiContractRegistry {
+    let mut contracts = ironclaw_extensions::HostApiContractRegistry::new();
+    contracts
+        .register(std::sync::Arc::new(
+            ironclaw_extensions::CapabilityProviderHostApiContract::new()
+                .expect("capability provider contract"),
+        ))
+        .expect("register capability provider contract");
+    contracts
 }

--- a/tests/integration/support/harness_web_access.rs
+++ b/tests/integration/support/harness_web_access.rs
@@ -13,7 +13,7 @@
 //!
 //! `web_access_extension_package()` mirrors `github.rs`'s
 //! `extension_registry()`: reads the REAL production manifest off disk via
-//! `ExtensionManifest::parse_with_host_api_contracts` rather than hand-
+//! `ExtensionManifest::parse` rather than hand-
 //! authoring a synthetic one. Schema `$ref`s resolve later against the real
 //! schema files mounted at `/system/extensions/web-access`.
 //!
@@ -55,12 +55,12 @@ pub(super) const WEB_ACCESS_PROVIDER_ID: &str = "web-access";
 /// Build the `ExtensionPackage` for the real `web-access` provider by parsing
 /// its production manifest off disk, mirroring `github.rs`'s
 /// `extension_registry()` construction 1:1 via
-/// `ExtensionManifest::parse_with_host_api_contracts` and
+/// `ExtensionManifest::parse` and
 /// `ExtensionPackage::from_manifest`. The two capability manifests,
 /// `web-access.search` and `web-access.get_content`, and their real JSON
 /// Schema refs come from the manifest itself — no hand-authored schema.
 pub(super) fn web_access_extension_package() -> HarnessResult<ExtensionPackage> {
-    let manifest = ExtensionManifest::parse_with_host_api_contracts(
+    let manifest = ExtensionManifest::parse(
         &std::fs::read_to_string(asset_root().join("manifest.toml"))?,
         ManifestSource::HostBundled,
         &default_host_port_catalog()?,


### PR DESCRIPTION
## Summary

Stack PR 2/7 for NEA-25, on top of #5833. Per Ben's directive the stack carries **zero residual legacy code**: this PR finishes the manifest v2 cutover instead of keeping the legacy form alive for host-bundled packages.

- **All manifests declare `[[host_api]]` contracts.** Top-level `[[capabilities]]` is rejected for *every* `ManifestSource` (host-bundled exactly as installed) with an actionable error. The 10 remaining legacy first-party manifests (gmail, google-calendar/docs/drive/sheets/slides, nearai-mcp, notion-mcp, slack, web-access) are converted to `ironclaw.capability_provider/v1` sections.
- **One parse entry point.** `ExtensionManifestV2::parse(input, source, catalog, contracts)`; deleted: the 3-arg contract-free `parse`, `parse_with_host_api_contracts`, `parse_with_optional_host_api_contracts`, contract-free `ExtensionManifestRecord::from_toml` (the `_with_contracts` variant becomes `from_toml`), contract-free `ExtensionDiscovery::discover`, and `ManifestV2Error::LegacyTopLevelCapabilitiesForInstalledSource`.
- **Typed contract errors.** New `HostApiSectionError { Manifest(ManifestV2Error), Contract(String) }`: in-crate contracts preserve precise typed variants (`DuplicateEffect`, `UnknownHostPort`, `CapabilityIdNotPrefixed`, …) through the section channel — previously only the deleted legacy path reported them typed; the host_api path string-flattened everything. Domain crates (product-adapter registry) keep redacted reasons wrapped as `HostApiSectionRejected`.
- Production TOML surgery (NEAR AI endpoint audience rewrite in composition) navigates the new section path; the shared test fixture converters (`legacy_capability_fixture_to_v2` in dispatcher + host_runtime test support) emit host_api form, so pre-v2 fixtures keep working through one converter instead of ~100 hand edits.
- Contract doc: `docs/reborn/contracts/extensions.md` — "Cutover (complete)" replaces the migration-rules section; examples converted; §11 test list extended.

No persisted-state impact: installed manifests (`InstalledLocal`/`RegistryInstalled`) already could not use the legacy form; it was exclusively host-bundled assets, synthesis, and test fixtures.

## Testing

- `cargo check --workspace --all-targets --all-features` — clean
- Suites green: `ironclaw_extensions` (incl. new pins: top-level capabilities rejected for every source; unknown top-level tables → `UnreferencedOperationalSection`; typed variant passthrough), `ironclaw_product_adapter_registry`, `ironclaw_host_runtime`, `ironclaw_capabilities`, `ironclaw_event_projections`, `ironclaw_mcp`, `ironclaw_wasm`, `ironclaw_scripts`, `ironclaw_dispatcher`, `ironclaw_reborn_migration`, `ironclaw_reborn`, `ironclaw_reborn_composition` (1,050 tests incl. NEAR AI renderer path), `ironclaw_reborn_cli`, `ironclaw_architecture`
- `cargo clippy --all --benches --tests --examples --all-features` — zero warnings
- Not run here: 3 pre-existing `sandbox_process` tests that need a live Docker socket (none on this machine; unrelated to this change), and `--features integration` Postgres tier (no DB-shaped change — parse-layer only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)