### PR TITLE
docs: require IronLoop agents to validate fixability

### DIFF
--- a/.ironloop/agents/small-fix-implementer/AGENTS.md
+++ b/.ironloop/agents/small-fix-implementer/AGENTS.md
@@ -3,16 +3,25 @@
 Implement only small, clear, low-risk IronClaw issue requests. This agent is enabled for a limited
 dogfood rollout, so prefer narrow fixes that are easy for humans to review.
 
+Before editing any files, explicitly decide whether the issue is valid, reproducible from the
+available context, and actually fixable by this agent. It is acceptable to conclude that the issue
+itself may be wrong, expected behavior, already fixed, not reproducible, or missing the information
+needed for a safe fix. It is also acceptable to state that you are not confident how to fix it. In
+those cases, do not make speculative edits; refuse the implementation and explain the reason in the
+final result.
+
 Accept an issue implementation only when all of the following are true:
 
 - The issue request is specific and unambiguous.
+- The issue appears real and the requested behavior appears correct after checking the surrounding
+  code and context.
 - The expected change is small and local to a clearly identifiable file, crate, doc, or test.
 - The fix does not require secrets, production access, manual product decisions, migrations, broad
   architecture work, or risky runtime/security policy changes.
 
-If the request is too broad, ambiguous, risky, or likely to require multi-PR design work, stop and
-explain what clarification or human decision is needed in the final result. Do not partially
-implement speculative work.
+If the request is too broad, ambiguous, risky, likely invalid, not reproducible, already fixed, or
+likely to require multi-PR design work, stop and explain what clarification or human decision is
+needed in the final result. Do not partially implement speculative work.
 
 When implementing an accepted task:
 

--- a/.ironloop/agents/small-fix-resolver/AGENTS.md
+++ b/.ironloop/agents/small-fix-resolver/AGENTS.md
@@ -3,16 +3,25 @@
 Resolve focused pull request review feedback by updating the existing PR branch with the smallest
 coherent change that addresses the unresolved review threads provided by IronLoop.
 
+Before editing any files, explicitly decide whether the review feedback is valid, still applies to
+the current PR head, and is actually fixable by this agent. It is acceptable to conclude that the
+feedback itself may be wrong, expected behavior, already addressed, stale, not reproducible, or
+missing the information needed for a safe fix. It is also acceptable to state that you are not
+confident how to fix it. In those cases, do not make speculative edits; refuse the repair and
+explain the reason in the final result.
+
 Accept a review repair only when all of the following are true:
 
 - The unresolved review feedback is concrete and actionable.
+- The feedback appears valid and still applicable after checking the current diff, surrounding code,
+  and context.
 - The expected repair is small and local to a clearly identifiable file, crate, doc, or test.
 - The repair does not require secrets, production access, manual product decisions, migrations,
   broad architecture work, or risky runtime/security policy changes.
 
-If the feedback is too broad, ambiguous, risky, stale, or likely to require multi-PR design work,
-stop and explain what human decision or clarification is needed in the final result. Do not
-partially implement speculative work.
+If the feedback is too broad, ambiguous, risky, likely invalid, stale, not reproducible, already
+addressed, or likely to require multi-PR design work, stop and explain what human decision or
+clarification is needed in the final result. Do not partially implement speculative work.
 
 When repairing an accepted review thread:
 

--- a/.ironloop/agents/small-fix-resolver/AGENTS.md
+++ b/.ironloop/agents/small-fix-resolver/AGENTS.md
@@ -3,25 +3,30 @@
 Resolve focused pull request review feedback by updating the existing PR branch with the smallest
 coherent change that addresses the unresolved review threads provided by IronLoop.
 
-Before editing any files, explicitly decide whether the review feedback is valid, still applies to
-the current PR head, and is actually fixable by this agent. It is acceptable to conclude that the
-feedback itself may be wrong, expected behavior, already addressed, stale, not reproducible, or
-missing the information needed for a safe fix. It is also acceptable to state that you are not
-confident how to fix it. In those cases, do not make speculative edits; refuse the repair and
-explain the reason in the final result.
+Before editing any files, explicitly decide whether each review thread is valid, still applies to
+the current PR head, and is actually fixable by this agent. It is acceptable to conclude that some
+feedback may be wrong, expected behavior, already addressed, stale, not reproducible, or missing the
+information needed for a safe fix. It is also acceptable to state that you are not confident how to
+fix a particular thread.
+
+When IronLoop provides multiple review comments, evaluate them independently. If at least one thread
+is still valid, actionable, and safe to repair, fix that subset instead of refusing the entire
+resolver task just because other comments are stale, invalid, or not reproducible. In the final
+result, explain which comments were repaired and which were skipped with reasons. Refuse the repair
+only when no provided feedback can be safely and confidently addressed.
 
 Accept a review repair only when all of the following are true:
 
-- The unresolved review feedback is concrete and actionable.
-- The feedback appears valid and still applicable after checking the current diff, surrounding code,
-  and context.
+- At least one unresolved review thread is concrete and actionable.
+- Each feedback item being repaired appears valid and still applicable after checking the current
+  diff, surrounding code, and context.
 - The expected repair is small and local to a clearly identifiable file, crate, doc, or test.
 - The repair does not require secrets, production access, manual product decisions, migrations,
   broad architecture work, or risky runtime/security policy changes.
 
-If the feedback is too broad, ambiguous, risky, likely invalid, stale, not reproducible, already
-addressed, or likely to require multi-PR design work, stop and explain what human decision or
-clarification is needed in the final result. Do not partially implement speculative work.
+If all provided feedback is too broad, ambiguous, risky, likely invalid, stale, not reproducible,
+already addressed, or likely to require multi-PR design work, stop and explain what human decision
+or clarification is needed in the final result. Do not partially implement speculative work.
 
 When repairing an accepted review thread:
 


### PR DESCRIPTION
## Summary

- Require the small-fix implementer to check whether an issue is valid, reproducible, and safely fixable before editing.
- Require the small-fix resolver to check whether review feedback is valid, still applicable, and safely fixable before editing.
- Explicitly allow both agents to refuse speculative fixes and explain when an issue or feedback may be wrong, expected behavior, already fixed, stale, or unclear.

## Validation

- `git diff --check`

Closes #5861