### PR TITLE
ci: add main CI Slack alerts

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -91,6 +91,23 @@ trail: the former in-run alert jobs and `nightly-alert-issue.sh` were removed
 in favor of this single external check, because an in-run alert dies with its
 own run on a startup_failure and can never see a cron that didn't fire.
 
+### Main branch alerting
+
+`main-ci-slack-alerts.yml` watches completed `workflow_run` events for the
+current `push` to `main` workflows: Code Style, Tests (Reborn), Reborn E2E,
+Platform & Compat, Replay Snapshot Gate, Code Coverage,
+nearai-bench dispatcher tests, and Release-plz. Any watched run that concludes
+`failure`, `timed_out`, `action_required`, or `startup_failure` posts a Slack
+message with the workflow, conclusion, failed job names, commit, actor, and run
+link.
+
+Alerts go to `secrets.MAIN_CI_SLACK_WEBHOOK_URLS`; the value may be a single
+webhook URL or multiple URLs separated by newlines or commas. This is
+intentionally separate from the canary/nightly `SLACK_WEBHOOK_URL` so main CI
+alerts can target dedicated channels.
+When adding a new workflow that runs on `push` to `main`, add its workflow
+`name:` to the watched list in `main-ci-slack-alerts.yml`.
+
 ## Known accepted gaps (deliberate, revisit as needed)
 
 - **Windows clippy** (`code_style.yml` `clippy-windows`) runs on push only;

--- a/.github/workflows/main-ci-slack-alerts.yml
+++ b/.github/workflows/main-ci-slack-alerts.yml
@@ -1,0 +1,99 @@
+name: Main CI Slack Alerts
+
+on:
+  workflow_run:
+    workflows:
+      - Code Style
+      - Tests (Reborn)
+      - Reborn E2E
+      - Platform & Compat
+      - Replay Snapshot Gate
+      - Code Coverage
+      - nearai-bench dispatcher tests
+      - Release-plz
+    branches:
+      - main
+    types:
+      - completed
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  alert:
+    name: Post Slack alert
+    if: >-
+      github.event.workflow_run.event == 'push' &&
+      contains(fromJSON('["failure","timed_out","action_required","startup_failure"]'), github.event.workflow_run.conclusion)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post main CI failure to Slack
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
+          CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          ACTOR: ${{ github.event.workflow_run.actor.login }}
+          MAIN_CI_SLACK_WEBHOOK_URLS: ${{ secrets.MAIN_CI_SLACK_WEBHOOK_URLS }}
+        run: |
+          set -euo pipefail
+
+          short_sha="${HEAD_SHA:0:10}"
+          failed_jobs="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}/jobs?per_page=100" \
+            --jq '[.jobs[] | select(.conclusion == "failure" or .conclusion == "timed_out" or .conclusion == "action_required" or .conclusion == "startup_failure") | "\(.name) (\(.conclusion))"] | .[0:12] | join(", ")' \
+            2>/dev/null || true)"
+          if [ -z "$failed_jobs" ]; then
+            failed_jobs="No failed jobs listed; inspect the workflow run for startup or workflow-level errors."
+          fi
+
+          text="Main branch CI failed: ${WORKFLOW_NAME} concluded ${CONCLUSION} on ${short_sha}"
+          payload="$(jq -n \
+            --arg text "$text" \
+            --arg workflow "$WORKFLOW_NAME" \
+            --arg conclusion "$CONCLUSION" \
+            --arg branch "$HEAD_BRANCH" \
+            --arg sha "$short_sha" \
+            --arg actor "$ACTOR" \
+            --arg failed_jobs "$failed_jobs" \
+            --arg url "$RUN_URL" \
+            '{
+              text: $text,
+              blocks: [
+                {
+                  type: "header",
+                  text: {type: "plain_text", text: "Main branch CI failed"}
+                },
+                {
+                  type: "section",
+                  text: {
+                    type: "mrkdwn",
+                    text: "*Workflow:* \($workflow)\n*Conclusion:* `\($conclusion)`\n*Branch:* `\($branch)`\n*Commit:* `\($sha)`\n*Actor:* `\($actor)`\n*Failed jobs:* \($failed_jobs)\n<\($url)|Open workflow run>"
+                  }
+                }
+              ]
+            }')"
+
+          webhooks="${MAIN_CI_SLACK_WEBHOOK_URLS:-}"
+          if [ -z "$webhooks" ]; then
+            echo "::error::Set MAIN_CI_SLACK_WEBHOOK_URLS to receive main CI failure alerts."
+            exit 1
+          fi
+
+          webhook_file="$(mktemp)"
+          printf '%s\n' "$webhooks" | tr ',' '\n' | sed '/^[[:space:]]*$/d' > "$webhook_file"
+
+          posted=0
+          while IFS= read -r webhook; do
+            if curl -fsS --max-time 30 -X POST -H 'Content-type: application/json' \
+              --data "$payload" "$webhook" > /dev/null; then
+              posted=$((posted + 1))
+            else
+              echo "::warning::Failed to post alert to webhook (HTTP error or timeout)."
+            fi
+          done < "$webhook_file"
+
+          echo "Posted main CI failure alert to ${posted} Slack webhook(s)."

--- a/.github/workflows/main-ci-slack-alerts.yml
+++ b/.github/workflows/main-ci-slack-alerts.yml
@@ -84,7 +84,8 @@ jobs:
           fi
 
           webhook_file="$(mktemp)"
-          printf '%s\n' "$webhooks" | tr ',' '\n' | sed '/^[[:space:]]*$/d' > "$webhook_file"
+          trap 'rm -f "$webhook_file"' EXIT
+          printf '%s\n' "$webhooks" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//;/^$/d' > "$webhook_file"
 
           posted=0
           while IFS= read -r webhook; do
@@ -95,5 +96,10 @@ jobs:
               echo "::warning::Failed to post alert to webhook (HTTP error or timeout)."
             fi
           done < "$webhook_file"
+
+          if [ "$posted" -eq 0 ]; then
+            echo "::error::Failed to post alert to any Slack webhook."
+            exit 1
+          fi
 
           echo "Posted main CI failure alert to ${posted} Slack webhook(s)."


### PR DESCRIPTION
## Summary
- Add a `workflow_run` Slack alert workflow for failed push-to-main CI workflows.
- Send alerts only through the dedicated `MAIN_CI_SLACK_WEBHOOK_URLS` secret, which can contain one or more Slack webhook URLs.
- Document the main branch alerting contract and update instructions for newly added push-to-main workflows.
- Harden webhook fan-out so individual delivery failures do not skip later webhooks, zero successful sends fail the alert job, webhook URLs are trimmed, and temp files are cleaned up.

## Change Type
- CI / workflow alerting
- Documentation

## Linked Issue
None.

## Security Impact
This introduces a new repository secret, `MAIN_CI_SLACK_WEBHOOK_URLS`, for Slack incoming webhook URLs. The workflow does not print webhook values, removes the temporary file containing them on exit, and uses the dedicated secret rather than reusing the canary/nightly Slack webhook.

## Rollback Plan
Disable or delete `.github/workflows/main-ci-slack-alerts.yml`, or unset `MAIN_CI_SLACK_WEBHOOK_URLS` to stop delivery. The change does not affect test execution or merge-gating workflows themselves.

## Validation
- Parsed the workflow YAML locally.
- Ran `bash -n` on the embedded alert script.
- Ran `git diff --check` for the changed workflow files.

`actionlint` is not installed in this workspace, so it was not run.