### PR TITLE
Handle malformed NEAR streaming tool args as repairable

### DIFF
--- a/crates/ironclaw_llm/src/nearai_chat.rs
+++ b/crates/ironclaw_llm/src/nearai_chat.rs
@@ -26,7 +26,7 @@ use crate::provider::{
     ChatMessage, CompletionRequest, CompletionResponse, CompletionStreamSink, FinishReason,
     LlmProvider, Role, ToolCall, ToolCompletionRequest, ToolCompletionResponse,
 };
-use crate::tool_args::parse_tool_call_args;
+use crate::tool_args::parse_tool_call_args_lossy;
 
 #[path = "nearai_tool_message_flattening.rs"]
 mod nearai_tool_message_flattening;
@@ -619,6 +619,7 @@ impl NearAiChatProvider {
                             state.name = name;
                         }
                         if let Some(arguments) = function.arguments {
+                            state.arguments_delta_seen = true;
                             state.arguments.push_str(&arguments);
                         }
                     }
@@ -1562,28 +1563,40 @@ struct NearAiStreamingToolCallState {
     id: String,
     name: String,
     arguments: String,
+    arguments_delta_seen: bool,
 }
 
 impl NearAiStreamingToolCallState {
     fn into_tool_call(self) -> Result<Option<ToolCall>, LlmError> {
-        if self.id.is_empty() && self.name.is_empty() && self.arguments.is_empty() {
+        let Self {
+            id,
+            name,
+            arguments: raw_arguments,
+            arguments_delta_seen,
+        } = self;
+
+        if id.is_empty() && name.is_empty() && raw_arguments.is_empty() && !arguments_delta_seen {
             return Ok(None);
         }
-        let arguments = if self.arguments.trim().is_empty() {
-            serde_json::Value::Object(Default::default())
-        } else {
-            parse_tool_call_args(&self.arguments).map_err(|error| LlmError::InvalidResponse {
-                provider: "nearai_chat".to_string(),
-                reason: error.reason,
-            })?
-        };
+        let (arguments, arguments_parse_error) =
+            if raw_arguments.is_empty() && !arguments_delta_seen {
+                (serde_json::Value::Object(Default::default()), None)
+            } else {
+                parse_tool_call_args_lossy(&raw_arguments)
+            };
+        let arguments_parse_error = arguments_parse_error.map(|parse_error| {
+            format!(
+                "{parse_error}\nRaw malformed tool-call arguments (verbatim, {} bytes):\n{raw_arguments}",
+                raw_arguments.len()
+            )
+        });
         Ok(Some(ToolCall {
-            id: self.id,
-            name: self.name,
+            id,
+            name,
             arguments,
             reasoning: None,
             signature: None,
-            arguments_parse_error: None,
+            arguments_parse_error,
         }))
     }
 }
@@ -2029,7 +2042,7 @@ data: [DONE]
     }
 
     #[tokio::test]
-    async fn complete_with_tools_streaming_rejects_malformed_tool_arguments_after_done() {
+    async fn complete_with_tools_streaming_preserves_malformed_tool_arguments_for_repair() {
         use tokio::io::AsyncWriteExt;
         use tokio::net::TcpListener;
 
@@ -2063,19 +2076,89 @@ data: [DONE]
 
         let provider = NearAiChatProvider::new(test_nearai_config(&base_url), test_session())
             .expect("provider");
-        let result = complete_search_tool_streaming(provider).await;
+        let response = complete_search_tool_streaming(provider)
+            .await
+            .expect("malformed streamed tool arguments should be preserved for host repair");
 
         server_task.await.expect("server task");
-        match result {
-            Err(LlmError::InvalidResponse { provider, reason }) => {
-                assert_eq!(provider, "nearai_chat");
-                assert!(
-                    reason.starts_with("failed to parse tool-call arguments JSON: "),
-                    "unexpected reason: {reason}"
-                );
-            }
-            other => panic!("expected invalid malformed tool arguments, got {other:?}"),
-        }
+        assert_eq!(response.tool_calls.len(), 1);
+        assert_eq!(response.tool_calls[0].id, "call_search");
+        assert_eq!(response.tool_calls[0].name, "search");
+        assert_eq!(
+            response.tool_calls[0].arguments,
+            serde_json::Value::Object(Default::default())
+        );
+        let parse_error = response.tool_calls[0]
+            .arguments_parse_error
+            .as_deref()
+            .expect("malformed arguments should carry parse error metadata");
+        assert!(
+            parse_error.starts_with("failed to parse tool-call arguments JSON: "),
+            "unexpected parse error: {parse_error}"
+        );
+        assert!(
+            parse_error
+                .contains("Raw malformed tool-call arguments (verbatim, 9 bytes):\n{\"query\":"),
+            "raw malformed arguments must be available for model repair: {parse_error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn complete_with_tools_streaming_marks_empty_tool_arguments_for_repair() {
+        use tokio::io::AsyncWriteExt;
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        let server_task = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.expect("accept request");
+            let (headers, body) = read_http_request_body(&mut socket).await;
+            assert!(headers.starts_with("POST /v1/chat/completions "));
+            let request_json: serde_json::Value =
+                serde_json::from_str(&body).expect("request json");
+            assert_eq!(request_json["stream"], true);
+
+            socket
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\ncache-control: no-cache\r\nconnection: close\r\n\r\n",
+                )
+                .await
+                .expect("write sse headers");
+            socket
+                .write_all(
+                    br#"data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_search","type":"function","function":{"name":"search","arguments":""}}]},"finish_reason":"tool_calls"}]}
+
+data: [DONE]
+
+"#,
+                )
+                .await
+                .expect("write empty-arguments tool call stream");
+        });
+
+        let provider = NearAiChatProvider::new(test_nearai_config(&base_url), test_session())
+            .expect("provider");
+        let response = complete_search_tool_streaming(provider)
+            .await
+            .expect("empty streamed tool arguments should be preserved for host repair");
+
+        server_task.await.expect("server task");
+        assert_eq!(response.tool_calls.len(), 1);
+        assert_eq!(response.tool_calls[0].id, "call_search");
+        assert_eq!(response.tool_calls[0].name, "search");
+        assert_eq!(
+            response.tool_calls[0].arguments,
+            serde_json::Value::Object(Default::default())
+        );
+        let parse_error = response.tool_calls[0]
+            .arguments_parse_error
+            .as_deref()
+            .expect("empty arguments should carry parse error metadata");
+        assert!(parse_error.starts_with("empty arguments string"));
+        assert!(
+            parse_error.contains("Raw malformed tool-call arguments (verbatim, 0 bytes):\n"),
+            "empty raw arguments must still be explicit for model repair: {parse_error}"
+        );
     }
 
     #[test]

--- a/crates/ironclaw_reborn/src/model_gateway.rs
+++ b/crates/ironclaw_reborn/src/model_gateway.rs
@@ -61,6 +61,11 @@ use crate::{
 const MODEL_CREDITS_EXHAUSTED_SUMMARY: &str = "model provider account is out of credits";
 const PROVIDER_TOOL_ARGUMENTS_OMITTED_MARKER: &str =
     "arguments omitted because they exceeded the host provider-tool limit";
+const PROVIDER_TOOL_ARGUMENTS_PARSE_ERROR_PREFIX: &str =
+    "failed to parse tool-call arguments JSON:";
+const PROVIDER_TOOL_ARGUMENTS_INVALID_SUMMARY: &str = "model returned invalid tool-call arguments";
+const PROVIDER_TOOL_ARGUMENTS_INVALID_MARKER: &str =
+    "arguments omitted because the provider emitted malformed tool-call JSON";
 const CONTEXT_SHADOW_TARGET: &str = "ironclaw::reborn::context_shadow";
 const UNAVAILABLE_CAPABILITY_REPLY: &str = "That capability is unavailable or disabled for this request, so I will not route it through another tool.";
 
@@ -1786,6 +1791,19 @@ fn provider_tool_call_from_llm(
     provider_turn_id: String,
     replay_identity: &ProviderReplayIdentity,
 ) -> Result<ProviderToolCall, HostManagedModelError> {
+    if let Some(parse_error) = tool_call.arguments_parse_error.as_deref() {
+        let safe_summary = provider_tool_arguments_parse_error_summary(parse_error);
+        debug!(
+            provider_call_id = tool_call.id.as_str(),
+            tool_name = tool_call.name.as_str(),
+            safe_summary = safe_summary.as_str(),
+            "reborn model gateway rejected malformed provider tool arguments"
+        );
+        return Err(HostManagedModelError::safe(
+            HostManagedModelErrorKind::InvalidOutput,
+            safe_summary,
+        ));
+    }
     let name = ProviderToolName::new(tool_call.name).map_err(|error| {
         debug!(%error, "reborn model gateway rejected invalid provider tool name");
         HostManagedModelError::safe(
@@ -1804,6 +1822,19 @@ fn provider_tool_call_from_llm(
         reasoning: tool_call.reasoning,
         signature: tool_call.signature,
     })
+}
+
+fn provider_tool_arguments_parse_error_summary(parse_error: &str) -> String {
+    let summary_line = parse_error.lines().next().unwrap_or(parse_error);
+    let sanitized = sanitize_model_visible_text(summary_line.to_string());
+    let sanitized = sanitized.trim();
+    if sanitized.starts_with(PROVIDER_TOOL_ARGUMENTS_PARSE_ERROR_PREFIX)
+        && LoopSafeSummary::new(sanitized).is_ok()
+    {
+        sanitized.to_string()
+    } else {
+        PROVIDER_TOOL_ARGUMENTS_INVALID_SUMMARY.to_string()
+    }
 }
 
 fn provider_turn_id(provider_turn_scope: &str, tool_calls: &[ToolCall]) -> String {
@@ -1910,7 +1941,13 @@ fn map_provider_tool_output_error(error: AgentLoopHostError) -> HostManagedModel
 
 fn is_repairable_provider_tool_output_error(error: &HostManagedModelError) -> bool {
     error.kind == HostManagedModelErrorKind::InvalidOutput
-        && is_provider_arguments_too_large_summary(&error.safe_summary)
+        && (is_provider_arguments_too_large_summary(&error.safe_summary)
+            || is_provider_tool_arguments_parse_error_summary(&error.safe_summary))
+}
+
+fn is_provider_tool_arguments_parse_error_summary(safe_summary: &str) -> bool {
+    safe_summary.starts_with(PROVIDER_TOOL_ARGUMENTS_PARSE_ERROR_PREFIX)
+        || safe_summary == PROVIDER_TOOL_ARGUMENTS_INVALID_SUMMARY
 }
 
 fn provider_tool_repair_messages(
@@ -1936,16 +1973,30 @@ fn provider_tool_repair_messages(
             ChatMessage::tool_result(
                 tool_call.id.clone(),
                 tool_call.name.clone(),
-                format!(
-                    "Tool call batch rejected by host: {safe_summary}. None of this response's tool calls were executed. Retry with smaller arguments or answer directly without this tool if it is not needed."
-                ),
+                provider_tool_repair_result_content(tool_call, safe_summary),
             )
         }))
         .collect()
 }
 
+fn provider_tool_repair_result_content(tool_call: &ToolCall, safe_summary: &str) -> String {
+    let mut content = format!("Tool call batch rejected by host: {safe_summary}.");
+    if let Some(parse_error) = tool_call.arguments_parse_error.as_deref() {
+        content.push_str("\n\nMalformed tool-call argument details for this rejected call:\n");
+        content.push_str(parse_error);
+    }
+    content.push_str(
+        "\n\nNone of this response's tool calls were executed. Retry with valid JSON arguments or answer directly without this tool if it is not needed.",
+    );
+    content
+}
+
 fn provider_tool_call_for_repair(tool_call: &ToolCall) -> ToolCall {
-    let arguments = if provider_arguments_exceed_max_bytes(&tool_call.arguments) {
+    let arguments = if tool_call.arguments_parse_error.is_some() {
+        serde_json::json!({
+            "error": PROVIDER_TOOL_ARGUMENTS_INVALID_MARKER,
+        })
+    } else if provider_arguments_exceed_max_bytes(&tool_call.arguments) {
         serde_json::json!({
             "error": PROVIDER_TOOL_ARGUMENTS_OMITTED_MARKER,
         })
@@ -1959,7 +2010,7 @@ fn provider_tool_call_for_repair(tool_call: &ToolCall) -> ToolCall {
         arguments,
         reasoning: tool_call.reasoning.clone(),
         signature: tool_call.signature.clone(),
-        arguments_parse_error: tool_call.arguments_parse_error.clone(),
+        arguments_parse_error: None,
     }
 }
 
@@ -2774,6 +2825,36 @@ mod tests {
             Some(expected_reasoning),
             "recovery must preserve typed reasoning_details onto the recovered response"
         );
+    }
+
+    #[test]
+    fn provider_tool_arguments_parse_error_summary_falls_back_for_unknown_metadata() {
+        let summary = provider_tool_arguments_parse_error_summary(
+            "raw_provider_secret api_key=sk-live-secret malformed payload",
+        );
+
+        assert_eq!(summary, PROVIDER_TOOL_ARGUMENTS_INVALID_SUMMARY);
+    }
+
+    #[test]
+    fn provider_tool_arguments_parse_error_summary_drops_raw_repair_detail() {
+        let summary = provider_tool_arguments_parse_error_summary(
+            "failed to parse tool-call arguments JSON: trailing characters at line 1 column 3\nRaw malformed tool-call arguments (verbatim, 42 bytes):\n{\"api_key\":\"sk-live-secret\"",
+        );
+
+        assert_eq!(
+            summary,
+            "failed to parse tool-call arguments JSON: trailing characters at line 1 column 3"
+        );
+    }
+
+    #[test]
+    fn provider_tool_arguments_parse_error_summary_rejects_unsafe_parser_detail() {
+        let summary = provider_tool_arguments_parse_error_summary(
+            "failed to parse tool-call arguments JSON: expected `,` or `}` at line 1 column 2",
+        );
+
+        assert_eq!(summary, PROVIDER_TOOL_ARGUMENTS_INVALID_SUMMARY);
     }
 
     #[test]

--- a/crates/ironclaw_reborn/tests/llm_gateway.rs
+++ b/crates/ironclaw_reborn/tests/llm_gateway.rs
@@ -790,6 +790,72 @@ async fn gateway_preserves_invalid_output_from_provider_tool_validation() {
     assert!(capabilities.registered.lock().unwrap().is_empty());
 }
 
+fn repair_request_messages(
+    tool_requests: &[ToolCompletionRequest],
+) -> &[ironclaw_llm::ChatMessage] {
+    assert_eq!(tool_requests.len(), 2);
+    &tool_requests[1].messages
+}
+
+fn repair_assistant_tool_calls(messages: &[ironclaw_llm::ChatMessage]) -> &[ToolCall] {
+    messages
+        .iter()
+        .find(|message| message.role == Role::Assistant && message.tool_calls.is_some())
+        .expect("repair request includes assistant tool call replay")
+        .tool_calls
+        .as_ref()
+        .expect("tool calls replayed")
+}
+
+fn repair_tool_result<'a>(
+    messages: &'a [ironclaw_llm::ChatMessage],
+    tool_call_id: &str,
+) -> &'a ironclaw_llm::ChatMessage {
+    messages
+        .iter()
+        .find(|message| {
+            message.role == Role::Tool && message.tool_call_id.as_deref() == Some(tool_call_id)
+        })
+        .expect("repair request includes rejected tool result")
+}
+
+fn malformed_args_repair_provider(
+    parse_error: &str,
+    final_content: &str,
+) -> Arc<ToolAwareProvider> {
+    Arc::new(ToolAwareProvider::tool_response_sequence(vec![
+        ToolCompletionResponse {
+            content: None,
+            tool_calls: vec![ToolCall {
+                id: "call_bad_args".to_string(),
+                name: "demo__echo".to_string(),
+                arguments: serde_json::json!({}),
+                reasoning: Some("malformed args call reasoning".to_string()),
+                signature: None,
+                arguments_parse_error: Some(parse_error.to_string()),
+            }],
+            input_tokens: 1,
+            output_tokens: 1,
+            finish_reason: FinishReason::ToolUse,
+            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: 0,
+            reasoning: Some("response reasoning".to_string()),
+            reasoning_details: None,
+        },
+        ToolCompletionResponse {
+            content: Some(final_content.to_string()),
+            tool_calls: Vec::new(),
+            input_tokens: 2,
+            output_tokens: 2,
+            finish_reason: FinishReason::Stop,
+            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: 0,
+            reasoning: None,
+            reasoning_details: None,
+        },
+    ]))
+}
+
 #[tokio::test]
 async fn gateway_repairs_oversized_provider_tool_arguments_before_registration() {
     // Must exceed the host provider-argument limit so the gateway exercises its
@@ -863,16 +929,8 @@ async fn gateway_repairs_oversized_provider_tool_arguments_before_registration()
     assert!(capabilities.registered.lock().unwrap().is_empty());
 
     let tool_requests = provider.tool_requests.lock().unwrap();
-    assert_eq!(tool_requests.len(), 2);
-    let repair_messages = &tool_requests[1].messages;
-    let repair_assistant = repair_messages
-        .iter()
-        .find(|message| message.role == Role::Assistant && message.tool_calls.is_some())
-        .expect("repair request includes assistant tool call replay");
-    let repair_tool_calls = repair_assistant
-        .tool_calls
-        .as_ref()
-        .expect("tool calls replayed");
+    let repair_messages = repair_request_messages(&tool_requests);
+    let repair_tool_calls = repair_assistant_tool_calls(repair_messages);
     assert_eq!(repair_tool_calls.len(), 2);
     assert_eq!(
         repair_tool_calls[0].arguments,
@@ -892,17 +950,136 @@ async fn gateway_repairs_oversized_provider_tool_arguments_before_registration()
         repair_tool_calls[1].reasoning.as_deref(),
         Some("oversized call reasoning")
     );
-    let repair_tool_result = repair_messages
-        .iter()
-        .find(|message| {
-            message.role == Role::Tool && message.tool_call_id.as_deref() == Some("call_2")
-        })
-        .expect("repair request includes rejected tool result");
+    let repair_tool_result = repair_tool_result(repair_messages, "call_2");
     assert!(repair_tool_result.content.contains(&format!(
         "provider tool arguments exceed {} bytes",
         ironclaw_safety::PROVIDER_ARGUMENTS_MAX_BYTES
     )));
     assert!(!repair_tool_result.content.contains("xxxxx"));
+}
+
+#[tokio::test]
+async fn gateway_repairs_malformed_provider_tool_arguments_before_registration() {
+    let parse_error =
+        "failed to parse tool-call arguments JSON: trailing characters at line 1 column 3";
+    let provider = malformed_args_repair_provider(parse_error, "Finished after parse repair.");
+    let gateway = LlmProviderModelGateway::with_provider_identity(
+        STATIC_PROVIDER_ID,
+        provider.clone(),
+        LlmModelProfilePolicy::new()
+            .allow_model_profile(interactive_model(), Some("host-selected-model".to_string())),
+    );
+    let capabilities = Arc::new(GatewayCapabilityPort::with_tool_surface());
+
+    let response = gateway
+        .stream_model_with_capabilities(model_request(interactive_model()), capabilities.clone())
+        .await
+        .unwrap();
+
+    let usage = response
+        .usage
+        .expect("repaired response reports accumulated provider usage");
+    assert_eq!(usage.input_tokens, 3);
+    assert_eq!(usage.output_tokens, 3);
+
+    let ParentLoopOutput::AssistantReply(reply) = response.output else {
+        panic!("expected repaired assistant reply");
+    };
+    assert_eq!(reply.content, "Finished after parse repair.");
+    assert!(
+        capabilities.registered.lock().unwrap().is_empty(),
+        "malformed provider tool arguments must not register or execute a capability"
+    );
+
+    let tool_requests = provider.tool_requests.lock().unwrap();
+    let repair_messages = repair_request_messages(&tool_requests);
+    let repair_tool_calls = repair_assistant_tool_calls(repair_messages);
+    assert_eq!(repair_tool_calls.len(), 1);
+    assert_eq!(
+        repair_tool_calls[0].arguments,
+        serde_json::json!({
+            "error": "arguments omitted because the provider emitted malformed tool-call JSON"
+        })
+    );
+    assert_eq!(
+        repair_tool_calls[0].reasoning.as_deref(),
+        Some("malformed args call reasoning")
+    );
+    assert!(
+        repair_tool_calls[0].arguments_parse_error.is_none(),
+        "repair replay must not expose internal parse-error metadata as tool-call fields"
+    );
+    let repair_tool_result = repair_tool_result(repair_messages, "call_bad_args");
+    assert!(
+        repair_tool_result.content.contains(parse_error),
+        "repair prompt must carry the parse failure without executing the call"
+    );
+}
+
+#[tokio::test]
+async fn gateway_repairs_streamed_malformed_provider_tool_arguments_before_registration() {
+    let parse_error = "failed to parse tool-call arguments JSON: trailing characters at line 1 column 3\nRaw malformed tool-call arguments (verbatim, 9 bytes):\n{\"query\":";
+    let provider = malformed_args_repair_provider(parse_error, "Finished after streamed repair.");
+    let gateway = LlmProviderModelGateway::with_provider_identity(
+        STATIC_PROVIDER_ID,
+        provider.clone(),
+        LlmModelProfilePolicy::new()
+            .allow_model_profile(interactive_model(), Some("host-selected-model".to_string())),
+    );
+    let capabilities = Arc::new(GatewayCapabilityPort::with_tool_surface());
+    let sink = Arc::new(RecordingHostStreamSink::default());
+
+    let response = gateway
+        .stream_model_with_capabilities_and_progress(
+            model_request(interactive_model()),
+            capabilities.clone(),
+            sink,
+        )
+        .await
+        .unwrap();
+
+    let ParentLoopOutput::AssistantReply(reply) = response.output else {
+        panic!("expected repaired assistant reply");
+    };
+    assert_eq!(reply.content, "Finished after streamed repair.");
+    assert!(
+        capabilities.registered.lock().unwrap().is_empty(),
+        "malformed streamed provider tool arguments must not register or execute a capability"
+    );
+
+    assert_eq!(
+        provider.streaming_tool_requests.lock().unwrap().len(),
+        1,
+        "initial tool-capable provider call must use the streaming gateway path"
+    );
+    let tool_requests = provider.tool_requests.lock().unwrap();
+    assert_eq!(
+        tool_requests.len(),
+        1,
+        "repair retry should be a normal tool-capable provider call"
+    );
+    let repair_messages = &tool_requests[0].messages;
+    let repair_tool_calls = repair_assistant_tool_calls(repair_messages);
+    assert_eq!(repair_tool_calls.len(), 1);
+    assert_eq!(
+        repair_tool_calls[0].arguments,
+        serde_json::json!({
+            "error": "arguments omitted because the provider emitted malformed tool-call JSON"
+        })
+    );
+    assert!(
+        repair_tool_calls[0].arguments_parse_error.is_none(),
+        "repair replay must not expose internal parse-error metadata as tool-call fields"
+    );
+    let repair_tool_result = repair_tool_result(repair_messages, "call_bad_args");
+    assert!(
+        repair_tool_result.content.contains(parse_error),
+        "repair prompt must carry the parse failure from the streamed response"
+    );
+    assert!(
+        repair_tool_result.content.contains("{\"query\":"),
+        "model-only repair prompt must carry raw malformed arguments"
+    );
 }
 
 #[tokio::test]
@@ -3345,6 +3522,7 @@ impl LlmProvider for BarrierRecordingLlmProvider {
 struct ToolAwareProvider {
     complete_requests: Mutex<Vec<CompletionRequest>>,
     tool_requests: Mutex<Vec<ToolCompletionRequest>>,
+    streaming_tool_requests: Mutex<Vec<ToolCompletionRequest>>,
     plain_response: Mutex<Option<CompletionResponse>>,
     tool_responses: Mutex<VecDeque<ToolCompletionResponse>>,
 }
@@ -3354,6 +3532,7 @@ impl ToolAwareProvider {
         Self {
             complete_requests: Mutex::new(Vec::new()),
             tool_requests: Mutex::new(Vec::new()),
+            streaming_tool_requests: Mutex::new(Vec::new()),
             plain_response: Mutex::new(Some(CompletionResponse {
                 content: content.to_string(),
                 input_tokens: 1,
@@ -3403,6 +3582,7 @@ impl ToolAwareProvider {
         Self {
             complete_requests: Mutex::new(Vec::new()),
             tool_requests: Mutex::new(Vec::new()),
+            streaming_tool_requests: Mutex::new(Vec::new()),
             plain_response: Mutex::new(None),
             tool_responses: Mutex::new(responses.into()),
         }
@@ -3434,6 +3614,20 @@ impl LlmProvider for ToolAwareProvider {
         request: ToolCompletionRequest,
     ) -> Result<ToolCompletionResponse, LlmError> {
         self.tool_requests.lock().unwrap().push(request);
+        Ok(self
+            .tool_responses
+            .lock()
+            .unwrap()
+            .pop_front()
+            .expect("tool response configured"))
+    }
+
+    async fn complete_with_tools_streaming(
+        &self,
+        request: ToolCompletionRequest,
+        _sink: Arc<dyn CompletionStreamSink>,
+    ) -> Result<ToolCompletionResponse, LlmError> {
+        self.streaming_tool_requests.lock().unwrap().push(request);
         Ok(self
             .tool_responses
             .lock()


### PR DESCRIPTION
## Summary

- preserve malformed streamed NEAR tool-call arguments as `arguments_parse_error` instead of failing the provider stream
- treat streamed empty `arguments` fields as malformed while preserving the existing omitted-arguments `{}` fallback
- reject malformed provider tool arguments in the Reborn model gateway before capability registration/execution
- route those failures through the existing repairable invalid tool-output path with safe placeholder arguments
- include the full raw malformed streamed argument string in the model-only repair tool result so the model has maximum context to recover
- keep raw malformed arguments out of the safe summary/log path and out of replayed structured tool-call fields

## Root cause

The streamed NEAR parser concatenated tool-call argument deltas and strict-parsed them after `[DONE]`. If NEAR emitted malformed JSON after assistant text had already streamed, the provider returned `InvalidResponse`; the retry layer refused to retry after emitted text, so the run failed instead of giving the model a repair turn. A present-but-empty streamed `arguments` field also collapsed to `{}`, which could bypass the repair metadata.

## Recovery behavior

For malformed streamed NEAR tool arguments, the gateway now rejects the whole provider tool-call batch before any capability is registered or executed. The repair request sent back to the model replays the assistant tool call with safe placeholder arguments, then attaches a tool result containing the parse failure plus the full raw malformed argument text verbatim. That raw detail is model-only repair context; safe summaries/logs use only the sanitized first parse-error line.

## Testing tier note

The malformed-argument repair behavior sits at the provider/gateway seam before capability registration. The Reborn integration harness does not currently expose a production-wired fixture that can inject provider-internal `ToolCall.arguments_parse_error` metadata from a streamed provider response. The crate-tier `llm_gateway` test drives the production `LlmProviderModelGateway::stream_model_with_capabilities_and_progress` caller boundary with a streaming provider fake and the real gateway capability surface fake, which is the narrowest reachable seam for this provider metadata path without adding test-only integration wiring.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p ironclaw_llm complete_with_tools_streaming -- --nocapture`
- `cargo test -p ironclaw_reborn --features root-llm-provider,libsql-secrets,libsql-restart-tests,webui-user-store provider_tool_arguments_parse_error_summary -- --nocapture`
- `cargo test -p ironclaw_reborn --features root-llm-provider,libsql-secrets,libsql-restart-tests,webui-user-store --test llm_gateway gateway_repairs -- --nocapture`
- `cargo clippy -p ironclaw_llm --all-targets --all-features -- -D warnings`
- `cargo clippy -p ironclaw_reborn --features root-llm-provider,libsql-secrets,libsql-restart-tests,webui-user-store --test llm_gateway -- -D warnings`