### PR TITLE
Document projects crate W2 decision

### DIFF
--- a/crates/AGENTS.md
+++ b/crates/AGENTS.md
@@ -81,7 +81,7 @@ Boundary rule: if you need an upstream crate in a low-level crate, stop and chec
 | `ironclaw_attachments` | `Cargo.toml`, `src/lib.rs` | The single inbound-attachment landing routine, writing through project-scoped `ScopedFilesystem` (fail-closed on read-only mounts). | Per-channel persistence paths; text extraction (that's `ironclaw_extractors`). |
 | `ironclaw_extractors` | `Cargo.toml`, `src/lib.rs` | Pure bytes→text extraction by MIME (PDF/OOXML/legacy Office) with decompression-bomb caps; no I/O. | Network fetches, storage, channel logic. |
 | `ironclaw_triggers` | `ironclaw_triggers/AGENTS.md`, `docs/reborn/contracts/triggers.md` | Scheduled-trigger substrate: records, cron/timezone validation, deterministic fire identity, poller core, durable libSQL/Postgres repos, trusted-submit request minting. | Poller lifecycle/composition (composition owns it); any parallel agent loop. |
-| `ironclaw_projects` | `ironclaw_projects/CLAUDE.md` | Project entity + membership ACL (live `resolve_access`, never cached) + `ProjectRepository` over `RootFilesystem` with CAS create/delete. | The legacy engine `Project` type; product workflow. |
+| `ironclaw_projects` | `ironclaw_projects/CLAUDE.md` | Project entity + membership ACL (live `resolve_access`, never cached) + `ProjectRepository` over `RootFilesystem` with CAS create/delete. **W2 decision: keep standalone; do not fold into composition.** | The legacy engine `Project` type; product workflow facade logic. If revisited, `ironclaw_product_workflow` is the only acceptable consumer-side target. |
 
 ### Authority, policy, state
 

--- a/crates/ironclaw_projects/CLAUDE.md
+++ b/crates/ironclaw_projects/CLAUDE.md
@@ -7,6 +7,16 @@ Reborn stack. Plan: `docs/plans/2026-06-17-reborn-projects.md`.
 > serves the Reborn stack (`ironclaw_product_workflow` → composition →
 > `ironclaw_webui_v2`).
 
+## W2 crate-count decision
+
+Keep `ironclaw_projects` as a standalone substrate crate for W2. It owns the
+durable project entity, live membership ACL, and repository contract over
+`ScopedFilesystem`; folding that into composition would put domain persistence
+behind the wiring layer. If this boundary is revisited later, the only plausible
+consumer-side target is `ironclaw_product_workflow` (which owns the
+`ProjectService` facade), and only if the project repository/domain contract can
+move there without forcing lower substrate crates to depend upward.
+
 ## What this crate owns
 
 - `ProjectRecord` — the durable project entity. `metadata: serde_json::Value` is

--- a/docs/plans/2026-07-02-reborn-internal-module-refactor.md
+++ b/docs/plans/2026-07-02-reborn-internal-module-refactor.md
@@ -98,7 +98,7 @@ Optional; schedule when loop work next opens both crates anyway.
 | ironclaw_skill_learning | 356 | ironclaw_skills (or consumer) |
 | ironclaw_wasm_sandbox_core | 357 | ironclaw_wasm |
 | ironclaw_reborn_openai_compat_storage | 673 | ironclaw_reborn_openai_compat |
-| ironclaw_projects | 842 | consumer |
+| ironclaw_projects | 842 | **KEEP in W2**; substrate entity/repository. If revisited later, the only acceptable consumer-side target is `ironclaw_product_workflow`, never composition. |
 | ironclaw_product_workflow_storage | 946 | ironclaw_product_workflow |
 
 ### 2.5 Zero fan-in — KEEP all (correction: none are dead)


### PR DESCRIPTION
## Summary

This completes the W2 `ironclaw_projects` decision without folding it into composition.

Decision:

- keep `ironclaw_projects` as a standalone substrate crate for W2
- do not fold project domain/repository logic into composition
- if this is revisited later, the only plausible consumer-side target is `ironclaw_product_workflow`, because it owns the `ProjectService` facade
- any future fold must first prove the project repository/domain contract can move without forcing lower substrate crates to depend upward

## Why

`ironclaw_projects` is not just product facade glue. It owns the durable project entity, live membership ACL, and `ProjectRepository` over `ScopedFilesystem`. Composition currently adapts that repository into the product-facing `ProjectService`, but composition is the wiring layer and should not own durable domain persistence.

Keeping it standalone in W2 preserves the useful boundary while still recording the future crate-count reduction path clearly. This removes the ambiguous `consumer` placeholder from the roadmap.

## Stack

Base: #5852 (`codex/reborn-layer-allowlist-w0-main`)

This is intentionally a small W2 decision PR. It should be retargeted to `main` after W0 lands.

## Validation

- `cargo test -p ironclaw_projects -p ironclaw_architecture`
- `cargo fmt --check`
- `git diff --check`
