### PR TITLE
Fix WebUI v2 live canary final-response waits

### DIFF
--- a/crates/ironclaw_webui_v2/frontend/src/pages/chat/components/message-bubble.test.ts
+++ b/crates/ironclaw_webui_v2/frontend/src/pages/chat/components/message-bubble.test.ts
@@ -24,6 +24,19 @@ test("conversation message bubbles use readable typography", () => {
   );
 });
 
+test("assistant bubbles expose final reply state for live QA", () => {
+  assert.match(
+    messageBubbleSource,
+    /const finalReplyState =[\s\S]*message\.isFinalReply/,
+    "assistant messages should derive a DOM-readable final reply state",
+  );
+  assert.match(
+    messageBubbleSource,
+    /data-final-reply=\{finalReplyState\}/,
+    "live QA should be able to distinguish streaming text from the final answer",
+  );
+});
+
 test("markdown body and code blocks inherit readable message sizing", () => {
   assert.match(
     appCssSource,

--- a/crates/ironclaw_webui_v2/frontend/src/pages/chat/components/message-bubble.tsx
+++ b/crates/ironclaw_webui_v2/frontend/src/pages/chat/components/message-bubble.tsx
@@ -61,6 +61,10 @@ function MessageBubbleImpl({ message, onRetry, threadId }) {
   const t = useT();
   const { role, content, images, attachments, generatedImages, isOptimistic, status, error, toolCalls, timestamp } = message;
   const isUser = role === "user";
+  const finalReplyState =
+    role === "assistant" && typeof message.isFinalReply === "boolean"
+      ? String(message.isFinalReply)
+      : undefined;
   const [copied, setCopied] = React.useState(false);
   // The attachment currently open in the preview modal (null when closed).
   const [previewAttachment, setPreviewAttachment] = React.useState(null);
@@ -130,6 +134,7 @@ function MessageBubbleImpl({ message, onRetry, threadId }) {
   return (
     <div
       data-testid={`msg-${role}`}
+      data-final-reply={finalReplyState}
       className={["group flex w-full min-w-0 flex-col", isUser ? "items-end" : "items-start"].join(" ")}
     >
       <div className={["flex min-w-0 flex-col", bubbleWidthClass].join(" ")}>

--- a/scripts/reborn_webui_v2_live_qa/run_live_qa.py
+++ b/scripts/reborn_webui_v2_live_qa/run_live_qa.py
@@ -1132,7 +1132,13 @@ class AssistantReplyWaitResult:
     text_excerpt: str
     semantic_judge_used: bool
     semantic_judge_reason: str
+    final_reply_wait_ms: int
+    final_reply_reason: str
     semantic_judge: dict[str, object] | None = None
+
+
+ASSISTANT_REPLY_FALLBACK_QUIET_SECONDS = 2.0
+ASSISTANT_REPLY_POLL_SECONDS = 0.5
 
 
 def _result(case_name: str, success: bool, started: float, details: dict[str, object]) -> ProbeResult:
@@ -1160,6 +1166,8 @@ def _record_assistant_reply_wait_result(
     observed["text_excerpt"] = reply.text_excerpt
     observed["semantic_judge_used"] = reply.semantic_judge_used
     observed["semantic_judge_reason"] = reply.semantic_judge_reason
+    observed["assistant_reply_wait_ms"] = reply.final_reply_wait_ms
+    observed["assistant_reply_wait_reason"] = reply.final_reply_reason
     if reply.semantic_judge is not None:
         observed["semantic_judge"] = reply.semantic_judge
 
@@ -1425,9 +1433,13 @@ async def _wait_for_assistant_reply(
     timeout: float,
     semantic_goal: str | None = None,
 ) -> AssistantReplyWaitResult:
+    started = time.monotonic()
     deadline = time.monotonic() + timeout
     assistant = page.locator("[data-testid='msg-assistant']").last  # type: ignore[attr-defined]
     last_text = ""
+    last_observed_text = ""
+    last_text_change_at = started
+    last_final_reply_state: str | None = None
     while time.monotonic() < deadline:
         await _approve_visible_tool_gate(page)
         assistant_blocks = page.locator("[data-testid='msg-assistant']")  # type: ignore[attr-defined]
@@ -1436,6 +1448,13 @@ async def _wait_for_assistant_reply(
                 text = await assistant.inner_text(timeout=1000)
             except Exception:
                 text = ""
+            try:
+                last_final_reply_state = await assistant.get_attribute(
+                    "data-final-reply",
+                    timeout=1000,
+                )
+            except Exception:
+                last_final_reply_state = None
             try:
                 block_texts = [
                     block.strip()
@@ -1447,23 +1466,42 @@ async def _wait_for_assistant_reply(
             if block_texts:
                 text = "\n".join(block_texts)
             if text:
+                now = time.monotonic()
+                if text != last_observed_text:
+                    last_observed_text = text
+                    last_text_change_at = now
                 last_text = text
             normalized = text.lower()
             marker_matches = not marker or marker in text
             if marker_matches and required_text_matches(normalized, required_text):
+                final_reply_observed = last_final_reply_state in ("true", "false")
+                if final_reply_observed and last_final_reply_state != "true":
+                    await asyncio.sleep(ASSISTANT_REPLY_POLL_SECONDS)
+                    continue
+                if not final_reply_observed:
+                    quiet_for = time.monotonic() - last_text_change_at
+                    if quiet_for < ASSISTANT_REPLY_FALLBACK_QUIET_SECONDS:
+                        await asyncio.sleep(ASSISTANT_REPLY_POLL_SECONDS)
+                        continue
                 return AssistantReplyWaitResult(
                     text_excerpt=text[-2000:],
                     semantic_judge_used=False,
                     semantic_judge_reason="literal_required_text_matched",
+                    final_reply_wait_ms=int((time.monotonic() - started) * 1000),
+                    final_reply_reason=(
+                        "final_reply_marker_matched"
+                        if final_reply_observed
+                        else "fallback_quiet_period_matched"
+                    ),
                 )
-        await asyncio.sleep(0.5)
+        await asyncio.sleep(ASSISTANT_REPLY_POLL_SECONDS)
     main_text = ""
     try:
         main_text = await page.locator("main").inner_text(timeout=1000)  # type: ignore[attr-defined]
     except Exception:
         pass
     semantic_judge: dict[str, object] | None = None
-    if last_text and (not marker or marker in last_text):
+    if last_text and (not marker or marker in last_text) and last_final_reply_state != "false":
         semantic_judge = await _judge_assistant_reply_completion(
             marker=marker,
             required_text=required_text,
@@ -1476,11 +1514,18 @@ async def _wait_for_assistant_reply(
                 text_excerpt=last_text[-2000:],
                 semantic_judge_used=True,
                 semantic_judge_reason="semantic_judge_completed",
+                final_reply_wait_ms=int((time.monotonic() - started) * 1000),
+                final_reply_reason=(
+                    "semantic_judge_final_reply_marker_matched"
+                    if last_final_reply_state == "true"
+                    else "semantic_judge_timeout_fallback"
+                ),
                 semantic_judge=semantic_judge,
             )
     raise AssertionError(
         "assistant reply did not contain required text before timeout. "
         f"marker={marker!r} required_text={required_text!r} "
+        f"latest_final_reply_state={last_final_reply_state!r} "
         f"last_assistant={last_text[-500:]!r} main_excerpt={main_text[-1000:]!r} "
         f"semantic_judge={_compact_json(semantic_judge)}"
     )

--- a/scripts/reborn_webui_v2_live_qa/run_live_qa.py
+++ b/scripts/reborn_webui_v2_live_qa/run_live_qa.py
@@ -1660,6 +1660,31 @@ def _trigger_record_count(reborn_home: Path, routine_name: str | None = None) ->
     return int(value)
 
 
+ROUTINE_TRIGGER_RECORD_WAIT_TIMEOUT_SECONDS = 120.0
+ROUTINE_TRIGGER_RECORD_POLL_SECONDS = 2.0
+
+
+async def _wait_for_trigger_record_after_count(
+    reborn_home: Path,
+    routine_name: str | None,
+    *,
+    before_count: int,
+    timeout: float = ROUTINE_TRIGGER_RECORD_WAIT_TIMEOUT_SECONDS,
+    poll_interval: float = ROUTINE_TRIGGER_RECORD_POLL_SECONDS,
+) -> tuple[int, int]:
+    started = time.monotonic()
+    deadline = started + timeout
+    last_count = _trigger_record_count(reborn_home, routine_name)
+    while last_count <= before_count:
+        now = time.monotonic()
+        if now >= deadline:
+            break
+        await asyncio.sleep(min(poll_interval, deadline - now))
+        last_count = _trigger_record_count(reborn_home, routine_name)
+    waited_ms = int((time.monotonic() - started) * 1000)
+    return last_count, waited_ms
+
+
 def _trigger_run_rows(reborn_home: Path, routine_name: str) -> list[dict[str, object]]:
     db_path = reborn_home / "local-dev" / "reborn-local-dev.db"
     if not db_path.exists():
@@ -3280,13 +3305,25 @@ async def _routine_creation_case(
             extra_details=details,
             routine_confirmation_follow_up=True,
         )
-    after_count = _trigger_record_count(ctx.reborn_home, count_name)
+    if result.success:
+        after_count, wait_ms = await _wait_for_trigger_record_after_count(
+            ctx.reborn_home,
+            count_name,
+            before_count=before_count,
+        )
+    else:
+        after_count = _trigger_record_count(ctx.reborn_home, count_name)
+        wait_ms = 0
     result.details["trigger_records_after"] = after_count
+    result.details["trigger_record_wait_ms"] = wait_ms
+    result.details["trigger_record_wait_timeout_ms"] = int(
+        ROUTINE_TRIGGER_RECORD_WAIT_TIMEOUT_SECONDS * 1000
+    )
     if result.success and after_count <= before_count:
         result.success = False
         result.details["error"] = (
-            f"assistant returned success but routine scope {routine_name!r} "
-            "did not add a trigger_record"
+            "assistant matched required routine text before trigger_create completed; "
+            f"routine scope {routine_name!r} did not add a trigger_record"
         )
     return result
 

--- a/scripts/reborn_webui_v2_live_qa/run_live_qa.py
+++ b/scripts/reborn_webui_v2_live_qa/run_live_qa.py
@@ -1449,12 +1449,14 @@ async def _wait_for_assistant_reply(
             except Exception:
                 text = ""
             try:
-                last_final_reply_state = await assistant.get_attribute(
+                observed_final_reply_state = await assistant.get_attribute(
                     "data-final-reply",
                     timeout=1000,
                 )
             except Exception:
-                last_final_reply_state = None
+                observed_final_reply_state = last_final_reply_state
+            else:
+                last_final_reply_state = observed_final_reply_state
             try:
                 block_texts = [
                     block.strip()

--- a/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
+++ b/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
@@ -44,7 +44,12 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
             env={},
         )
 
-    def _fake_assistant_reply_page(self, response_text: str):
+    def _fake_assistant_reply_page(
+        self,
+        response_text: str,
+        *,
+        final_reply_state: str | None = "true",
+    ):
         class FakeApprove:
             @property
             def last(self):
@@ -63,6 +68,11 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
 
             async def inner_text(self, **_kwargs):
                 return response_text
+
+            async def get_attribute(self, name, **_kwargs):
+                if name == "data-final-reply":
+                    return final_reply_state
+                return None
 
             async def all_inner_texts(self):
                 return [response_text]
@@ -1009,6 +1019,11 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
             async def inner_text(self, **_kwargs):
                 return "latest news on that company\nEmails a concise briefing"
 
+            async def get_attribute(self, name, **_kwargs):
+                if name == "data-final-reply":
+                    return "true"
+                return None
+
             async def all_inner_texts(self):
                 return [
                     'The routine has been created successfully. Routine: "30-min meeting briefing"',
@@ -1038,6 +1053,68 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
         self.assertIn("emails", text.lower())
         self.assertFalse(reply.semantic_judge_used)
         self.assertEqual(reply.semantic_judge_reason, "literal_required_text_matched")
+        self.assertEqual(reply.final_reply_reason, "final_reply_marker_matched")
+
+    def test_wait_for_assistant_reply_waits_for_final_marked_message(self):
+        state = {"index": 0, "sleep_calls": 0}
+        responses = [
+            ("I'll connect Google Calendar and get it connected.", "false"),
+            ("Google Calendar connected.", "true"),
+        ]
+
+        class FakeApprove:
+            @property
+            def last(self):
+                return self
+
+            async def is_visible(self, **_kwargs):
+                return False
+
+        class FakeAssistantBlocks:
+            @property
+            def last(self):
+                return self
+
+            async def count(self):
+                return 1
+
+            async def inner_text(self, **_kwargs):
+                return responses[state["index"]][0]
+
+            async def get_attribute(self, name, **_kwargs):
+                if name == "data-final-reply":
+                    return responses[state["index"]][1]
+                return None
+
+            async def all_inner_texts(self):
+                return [responses[state["index"]][0]]
+
+        class FakePage:
+            def locator(self, selector):
+                if selector != "[data-testid='msg-assistant']":
+                    raise AssertionError(f"unexpected selector: {selector}")
+                return FakeAssistantBlocks()
+
+            def get_by_role(self, _role, **_kwargs):
+                return FakeApprove()
+
+        async def fake_sleep(_seconds):
+            state["sleep_calls"] += 1
+            state["index"] = min(1, state["index"] + 1)
+
+        with patch.object(run_live_qa.asyncio, "sleep", side_effect=fake_sleep):
+            reply = asyncio.run(
+                run_live_qa._wait_for_assistant_reply(
+                    FakePage(),
+                    marker=None,
+                    required_text=["Google Calendar", "connected"],
+                    timeout=1.0,
+                )
+            )
+
+        self.assertGreaterEqual(state["sleep_calls"], 1)
+        self.assertEqual(reply.text_excerpt, "Google Calendar connected.")
+        self.assertEqual(reply.final_reply_reason, "final_reply_marker_matched")
 
     def test_wait_for_assistant_reply_uses_semantic_judge_for_text_mismatch(self):
         response_text = (

--- a/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
+++ b/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
@@ -762,7 +762,12 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
                 "_live_chat_case",
                 side_effect=fake_live_chat_case,
             ),
-            patch.object(run_live_qa, "_trigger_record_count", side_effect=[0, 0]),
+            patch.object(run_live_qa, "_trigger_record_count", return_value=0),
+            patch.object(
+                run_live_qa,
+                "_wait_for_trigger_record_after_count",
+                return_value=(0, 25),
+            ),
         ):
             result = asyncio.run(
                 run_live_qa._routine_creation_case(
@@ -779,7 +784,41 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
         self.assertEqual(captured_prompts, ["original sheet prompt"])
         self.assertEqual(captured_follow_up_flags, [True])
         self.assertEqual(result.details["trigger_records_after"], 0)
+        self.assertEqual(result.details["trigger_record_wait_ms"], 25)
         self.assertIn("did not add a trigger_record", result.details["error"])
+
+    def test_wait_for_trigger_record_after_count_polls_until_record_added(self):
+        counts = iter([0, 0, 1])
+        observed_sleeps: list[float] = []
+
+        def fake_trigger_record_count(_home: Path, routine_name: str | None) -> int:
+            self.assertIsNone(routine_name)
+            return next(counts)
+
+        async def fake_sleep(seconds: float) -> None:
+            observed_sleeps.append(seconds)
+
+        with (
+            patch.object(
+                run_live_qa,
+                "_trigger_record_count",
+                side_effect=fake_trigger_record_count,
+            ),
+            patch.object(run_live_qa.asyncio, "sleep", new=fake_sleep),
+        ):
+            after_count, waited_ms = asyncio.run(
+                run_live_qa._wait_for_trigger_record_after_count(
+                    Path("/tmp/reborn-home"),
+                    None,
+                    before_count=0,
+                    timeout=10.0,
+                    poll_interval=0.01,
+                )
+            )
+
+        self.assertEqual(after_count, 1)
+        self.assertGreaterEqual(len(observed_sleeps), 1)
+        self.assertGreaterEqual(waited_ms, 0)
 
     def test_routine_confirmation_follow_up_answers_timezone_confirmation(self):
         text = (

--- a/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
+++ b/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
@@ -1116,6 +1116,71 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
         self.assertEqual(reply.text_excerpt, "Google Calendar connected.")
         self.assertEqual(reply.final_reply_reason, "final_reply_marker_matched")
 
+    def test_wait_for_assistant_reply_preserves_non_final_state_on_attribute_error(self):
+        state = {"index": 0, "sleep_calls": 0}
+        responses = [
+            ("Google Calendar connected.", "false"),
+            ("Google Calendar connected.", RuntimeError("transient attr failure")),
+            ("Google Calendar connected.", "true"),
+        ]
+
+        class FakeApprove:
+            @property
+            def last(self):
+                return self
+
+            async def is_visible(self, **_kwargs):
+                return False
+
+        class FakeAssistantBlocks:
+            @property
+            def last(self):
+                return self
+
+            async def count(self):
+                return 1
+
+            async def inner_text(self, **_kwargs):
+                return responses[state["index"]][0]
+
+            async def get_attribute(self, name, **_kwargs):
+                if name != "data-final-reply":
+                    return None
+                value = responses[state["index"]][1]
+                if isinstance(value, Exception):
+                    raise value
+                return value
+
+            async def all_inner_texts(self):
+                return [responses[state["index"]][0]]
+
+        class FakePage:
+            def locator(self, selector):
+                if selector != "[data-testid='msg-assistant']":
+                    raise AssertionError(f"unexpected selector: {selector}")
+                return FakeAssistantBlocks()
+
+            def get_by_role(self, _role, **_kwargs):
+                return FakeApprove()
+
+        async def fake_sleep(_seconds):
+            state["sleep_calls"] += 1
+            state["index"] = min(len(responses) - 1, state["index"] + 1)
+
+        with patch.object(run_live_qa.asyncio, "sleep", side_effect=fake_sleep):
+            reply = asyncio.run(
+                run_live_qa._wait_for_assistant_reply(
+                    FakePage(),
+                    marker=None,
+                    required_text=["Google Calendar", "connected"],
+                    timeout=1.0,
+                )
+            )
+
+        self.assertGreaterEqual(state["sleep_calls"], 2)
+        self.assertEqual(reply.text_excerpt, "Google Calendar connected.")
+        self.assertEqual(reply.final_reply_reason, "final_reply_marker_matched")
+
     def test_wait_for_assistant_reply_uses_semantic_judge_for_text_mismatch(self):
         response_text = (
             "Schedule: Every hour\n"


### PR DESCRIPTION
## Summary
- expose WebUI v2 assistant final-reply state as a DOM test hook
- make the live QA harness wait for the final assistant reply before matching required text
- keep the trigger-record side-effect wait for routine creation cases
- record assistant reply wait reason/timing in canary artifacts

## Validation
- python3 scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
- pnpm vitest run src/pages/chat/components/message-bubble.test.ts
- git diff --check
- Live Canary Reborn WebUI v2 full suite: https://github.com/nearai/ironclaw/actions/runs/29035239093 (33 passed, 0 failed)