### PR TITLE
Fix WebUI memory browse isolation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4883,6 +4883,7 @@ dependencies = [
  "ironclaw_llm",
  "ironclaw_loop_host",
  "ironclaw_mcp",
+ "ironclaw_memory",
  "ironclaw_network",
  "ironclaw_observability",
  "ironclaw_outbound",

--- a/crates/ironclaw_product_workflow/src/reborn_services.rs
+++ b/crates/ironclaw_product_workflow/src/reborn_services.rs
@@ -3971,8 +3971,9 @@ impl RebornServicesApi for RebornServices {
         request: RebornFsListRequest,
     ) -> Result<RebornFsListResponse, RebornServicesError> {
         let browser = self.require_filesystem_browser(request.mount)?;
-        // Scope is derived from the authenticated caller, never the request.
-        let scope = caller_browse_scope(&caller);
+        let scope = self
+            .authorize_browse_scope(caller, request.project_id)
+            .await?;
         // dispatch-exempt: read-only, caller-scoped internal-filesystem listing
         // through the facade's own port — not an in-turn mutating tool call.
         let entries = browser
@@ -3992,7 +3993,9 @@ impl RebornServicesApi for RebornServices {
         request: RebornFsStatRequest,
     ) -> Result<RebornFsStatResponse, RebornServicesError> {
         let browser = self.require_filesystem_browser(request.mount)?;
-        let scope = caller_browse_scope(&caller);
+        let scope = self
+            .authorize_browse_scope(caller, request.project_id)
+            .await?;
         // dispatch-exempt: read-only, caller-scoped internal-filesystem stat.
         let stat = browser
             .stat(&scope, request.mount, &request.path)
@@ -4007,7 +4010,9 @@ impl RebornServicesApi for RebornServices {
         request: RebornFsReadRequest,
     ) -> Result<ProjectFsFile, RebornServicesError> {
         let browser = self.require_filesystem_browser(request.mount)?;
-        let scope = caller_browse_scope(&caller);
+        let scope = self
+            .authorize_browse_scope(caller, request.project_id)
+            .await?;
         // dispatch-exempt: read-only, caller-scoped internal-filesystem download.
         browser
             .read_file(&scope, request.mount, &request.path)
@@ -5993,7 +5998,7 @@ impl RebornServices {
     /// scope is returned unchanged.
     async fn authorize_create_thread_project(
         &self,
-        mut caller: WebUiAuthenticatedCaller,
+        caller: WebUiAuthenticatedCaller,
         requested_project_id: Option<String>,
     ) -> Result<WebUiAuthenticatedCaller, RebornServicesError> {
         let Some(raw) = requested_project_id else {
@@ -6009,6 +6014,16 @@ impl RebornServices {
                 WebUiInboundValidationCode::InvalidId,
             ))
         })?;
+        self.authorize_project_caller(caller, project_id).await
+    }
+
+    /// Authorize a project selector through the project service and adopt it
+    /// only after the access probe succeeds.
+    async fn authorize_project_caller(
+        &self,
+        mut caller: WebUiAuthenticatedCaller,
+        project_id: ProjectId,
+    ) -> Result<WebUiAuthenticatedCaller, RebornServicesError> {
         self.get_project(
             caller.clone(),
             RebornGetProjectRequest {
@@ -6018,6 +6033,20 @@ impl RebornServices {
         .await?;
         caller.project_id = Some(project_id);
         Ok(caller)
+    }
+
+    /// Resolve the one authorized scope used by all standalone browse reads.
+    /// An omitted selector preserves the caller's existing project scope.
+    async fn authorize_browse_scope(
+        &self,
+        caller: WebUiAuthenticatedCaller,
+        project_id: Option<ProjectId>,
+    ) -> Result<ResourceScope, RebornServicesError> {
+        let caller = match project_id {
+            Some(project_id) => self.authorize_project_caller(caller, project_id).await?,
+            None => caller,
+        };
+        Ok(caller_browse_scope(&caller))
     }
 
     /// Verify the caller may access the thread and return the project-scoped

--- a/crates/ironclaw_product_workflow/src/reborn_services/fs_browse.rs
+++ b/crates/ironclaw_product_workflow/src/reborn_services/fs_browse.rs
@@ -10,8 +10,9 @@
 //! Design notes:
 //!
 //! - **Mount, not thread.** The browse scope is derived by the facade from the
-//!   authenticated caller (tenant/user/agent/project), never from a thread id or
-//!   the request body. A [`FsMount`] selects *which* virtual mount to read;
+//!   authenticated caller (tenant/user/agent/project). An optional typed
+//!   project selector is authorized through the project service before it is
+//!   adopted; it never directly supplies a filesystem scope. A [`FsMount`] selects *which* virtual mount to read;
 //!   paths are mount-relative (`""`/`"/"` is the mount root) so a host or
 //!   virtual path is never serialized across the boundary.
 //! - **Substrate-free.** Like the project-fs port, this re-uses the coarse
@@ -24,7 +25,7 @@
 //!   sole mutation path.
 
 use async_trait::async_trait;
-use ironclaw_host_api::ResourceScope;
+use ironclaw_host_api::{ProjectId, ResourceScope};
 use serde::{Deserialize, Serialize};
 
 use super::project_fs::{ProjectFsEntry, ProjectFsError, ProjectFsFile, ProjectFsStat};
@@ -89,6 +90,10 @@ pub struct RebornFsListRequest {
     pub mount: FsMount,
     #[serde(default)]
     pub path: String,
+    /// Optional project selector. When absent, the authenticated caller's
+    /// default project scope is preserved.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project_id: Option<ProjectId>,
 }
 
 /// Directory listing response. Echoes the requested `mount`/`path` so the
@@ -107,6 +112,10 @@ pub struct RebornFsStatRequest {
     pub mount: FsMount,
     #[serde(default)]
     pub path: String,
+    /// Optional project selector. The facade authorizes it before resolving
+    /// the browse scope.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project_id: Option<ProjectId>,
 }
 
 /// Path metadata response.
@@ -121,6 +130,10 @@ pub struct RebornFsReadRequest {
     pub mount: FsMount,
     #[serde(default)]
     pub path: String,
+    /// Optional project selector. The facade authorizes it before resolving
+    /// the browse scope.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project_id: Option<ProjectId>,
 }
 
 /// Read-only navigation + download access to the agent's internal filesystem

--- a/crates/ironclaw_product_workflow/tests/reborn_services_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/reborn_services_contract.rs
@@ -34,29 +34,31 @@ use ironclaw_product_workflow::{
     ApprovalInteractionDecision, ApprovalInteractionScope, ApprovalInteractionService,
     AuthInteractionDecision, AuthInteractionService, AutomationListRequest, AutomationName,
     AutomationProductFacade, CodexLoginStart, ExtensionCredentialSetupService,
-    ExtensionCredentialStatusRequest, ExtensionCredentialSubmitRequest, InboundAttachmentLander,
-    InboundAttachmentReader, LifecycleExtensionCredentialRequirement,
-    LifecycleExtensionCredentialSetup, LifecycleExtensionOnboarding, LifecycleExtensionRuntimeKind,
-    LifecycleExtensionSource, LifecycleExtensionSummary, LifecycleInstalledExtensionSummary,
-    LifecyclePackageKind, LifecyclePackageRef, LifecyclePhase, LifecycleProductAction,
-    LifecycleProductContext, LifecycleProductFacade, LifecycleProductPayload,
-    LifecycleProductResponse, LifecycleReadinessBlocker, ListPendingApprovalsRequest,
-    ListPendingApprovalsResponse, ListPendingAuthInteractionsRequest,
-    ListPendingAuthInteractionsResponse, LlmActiveSelection, LlmConfigService,
-    LlmConfigServiceError, LlmConfigSnapshot, LlmModelsResult, LlmProbeRequest, LlmProbeResult,
-    LlmProviderView, NearAiLoginRequest, NearAiLoginStart, NearAiWalletLoginRequest,
-    NearAiWalletLoginResult, OperatorLogsService, OperatorServiceLifecycleService,
-    OperatorStatusService, OutboundPreferencesProductFacade, PendingApprovalInteractionView,
-    ProductAgentBoundCaller, ProductWorkflowError, ProjectCaller, ProjectService,
+    ExtensionCredentialStatusRequest, ExtensionCredentialSubmitRequest, FilesystemBrowseReader,
+    FsMount, InboundAttachmentLander, InboundAttachmentReader,
+    LifecycleExtensionCredentialRequirement, LifecycleExtensionCredentialSetup,
+    LifecycleExtensionOnboarding, LifecycleExtensionRuntimeKind, LifecycleExtensionSource,
+    LifecycleExtensionSummary, LifecycleInstalledExtensionSummary, LifecyclePackageKind,
+    LifecyclePackageRef, LifecyclePhase, LifecycleProductAction, LifecycleProductContext,
+    LifecycleProductFacade, LifecycleProductPayload, LifecycleProductResponse,
+    LifecycleReadinessBlocker, ListPendingApprovalsRequest, ListPendingApprovalsResponse,
+    ListPendingAuthInteractionsRequest, ListPendingAuthInteractionsResponse, LlmActiveSelection,
+    LlmConfigService, LlmConfigServiceError, LlmConfigSnapshot, LlmModelsResult, LlmProbeRequest,
+    LlmProbeResult, LlmProviderView, NearAiLoginRequest, NearAiLoginStart,
+    NearAiWalletLoginRequest, NearAiWalletLoginResult, OperatorLogsService,
+    OperatorServiceLifecycleService, OperatorStatusService, OutboundPreferencesProductFacade,
+    PendingApprovalInteractionView, ProductAgentBoundCaller, ProductWorkflowError, ProjectCaller,
+    ProjectFsEntry, ProjectFsError, ProjectFsFile, ProjectFsStat, ProjectService,
     ProjectServiceError, RebornAddMemberRequest, RebornAttachmentRequest, RebornAutomationInfo,
     RebornAutomationMutationResponse, RebornAutomationRecentRunInfo,
     RebornAutomationRecentRunStatus, RebornAutomationRunStatus, RebornAutomationSource,
     RebornAutomationState, RebornChannelConnectAction, RebornChannelConnectStrategy,
     RebornConnectableChannelInfo, RebornCreateProjectRequest, RebornDeleteProjectRequest,
-    RebornDeleteThreadRequest, RebornExtensionOnboardingState, RebornGetProjectRequest,
-    RebornGetRunStateRequest, RebornListMembersRequest, RebornListMembersResponse,
-    RebornListProjectsRequest, RebornListProjectsResponse, RebornLogLevel, RebornLogQueryRequest,
-    RebornLogQueryResponse, RebornOperatorConfigDiagnosticSeverity, RebornOperatorConfigSetRequest,
+    RebornDeleteThreadRequest, RebornExtensionOnboardingState, RebornFsListRequest,
+    RebornGetProjectRequest, RebornGetRunStateRequest, RebornListMembersRequest,
+    RebornListMembersResponse, RebornListProjectsRequest, RebornListProjectsResponse,
+    RebornLogLevel, RebornLogQueryRequest, RebornLogQueryResponse,
+    RebornOperatorConfigDiagnosticSeverity, RebornOperatorConfigSetRequest,
     RebornOperatorLogsQuery, RebornOperatorSetupRequest, RebornOperatorSetupStatus,
     RebornOperatorStatusCheck, RebornOperatorStatusResponse, RebornOperatorStatusSeverity,
     RebornOperatorStatusState, RebornOperatorSurfaceStatus, RebornOperatorToolCatalog,
@@ -2282,6 +2284,79 @@ impl ProjectService for AuthorizingProjectService {
     ) -> Result<(), ProjectServiceError> {
         Err(ProjectServiceError::Internal)
     }
+}
+
+struct EmptyFilesystemBrowser;
+
+#[async_trait]
+impl FilesystemBrowseReader for EmptyFilesystemBrowser {
+    fn available_mounts(&self) -> Vec<FsMount> {
+        vec![FsMount::Memory]
+    }
+
+    async fn list_dir(
+        &self,
+        _scope: &ResourceScope,
+        _mount: FsMount,
+        _path: &str,
+    ) -> Result<Vec<ProjectFsEntry>, ProjectFsError> {
+        Ok(Vec::new())
+    }
+
+    async fn read_file(
+        &self,
+        _scope: &ResourceScope,
+        _mount: FsMount,
+        _path: &str,
+    ) -> Result<ProjectFsFile, ProjectFsError> {
+        Err(ProjectFsError::NotFound)
+    }
+
+    async fn stat(
+        &self,
+        _scope: &ResourceScope,
+        _mount: FsMount,
+        _path: &str,
+    ) -> Result<ProjectFsStat, ProjectFsError> {
+        Err(ProjectFsError::NotFound)
+    }
+}
+
+#[tokio::test]
+async fn browse_fs_authorizes_project_selector_and_fails_closed() {
+    let services = RebornServices::new(
+        Arc::new(InMemorySessionThreadService::default()),
+        Arc::new(FakeTurnCoordinator::default()),
+    )
+    .with_filesystem_browser(Arc::new(EmptyFilesystemBrowser))
+    .with_project_service(Arc::new(AuthorizingProjectService {
+        allowed_project_id: "project-scoped".to_string(),
+    }));
+
+    let response = services
+        .browse_fs_dir(
+            caller_with_project(Some("project-alpha")),
+            RebornFsListRequest {
+                mount: FsMount::Memory,
+                path: String::new(),
+                project_id: Some(ProjectId::new("project-scoped").expect("project id")),
+            },
+        )
+        .await;
+    assert!(response.is_ok(), "authorized project selector must browse");
+
+    let error = services
+        .browse_fs_dir(
+            caller_with_project(Some("project-alpha")),
+            RebornFsListRequest {
+                mount: FsMount::Memory,
+                path: String::new(),
+                project_id: Some(ProjectId::new("project-denied").expect("project id")),
+            },
+        )
+        .await
+        .expect_err("unauthorized project selector must fail closed");
+    assert_eq!(error.code, RebornServicesErrorCode::NotFound);
 }
 
 #[tokio::test]

--- a/crates/ironclaw_reborn_composition/Cargo.toml
+++ b/crates/ironclaw_reborn_composition/Cargo.toml
@@ -130,6 +130,7 @@ ironclaw_host_api = { path = "../ironclaw_host_api" }
 ironclaw_host_runtime = { path = "../ironclaw_host_runtime" }
 ironclaw_llm = { path = "../ironclaw_llm", optional = true, default-features = false }
 ironclaw_loop_host = { path = "../ironclaw_loop_host" }
+ironclaw_memory = { path = "../ironclaw_memory" }
 ironclaw_mcp = { path = "../ironclaw_mcp" }
 ironclaw_network = { path = "../ironclaw_network" }
 ironclaw_observability = { path = "../ironclaw_observability" }

--- a/crates/ironclaw_reborn_composition/src/local_dev_mounts.rs
+++ b/crates/ironclaw_reborn_composition/src/local_dev_mounts.rs
@@ -3,6 +3,7 @@ use std::{collections::HashSet, path::Path};
 use ironclaw_host_api::{
     HostApiError, MountAlias, MountGrant, MountPermissions, MountView, ResourceScope, VirtualPath,
 };
+use ironclaw_memory::MemoryDocumentScope;
 
 pub(crate) const WORKSPACE_ALIAS: &str = "/workspace";
 const WORKSPACE_TARGET: &str = "/projects/workspace";
@@ -138,15 +139,30 @@ pub(crate) fn system_extensions_lifecycle_mount_view() -> Result<MountView, Host
 /// [`BROWSE_MEMORY_ALIAS`]/[`WORKSPACE_ALIAS`].
 pub(crate) const BROWSE_MEMORY_ALIAS: &str = MEMORY_ALIAS;
 
-pub(crate) fn browse_mount_view() -> Result<MountView, HostApiError> {
+pub(crate) fn scoped_browse_mount_view(scope: &ResourceScope) -> Result<MountView, HostApiError> {
+    let memory_target = scoped_memory_target(scope)?;
     MountView::new(vec![
         grant(
             WORKSPACE_ALIAS,
             WORKSPACE_TARGET,
             MountPermissions::read_only(),
         )?,
-        grant(MEMORY_ALIAS, MEMORY_TARGET, MountPermissions::read_only())?,
+        grant(
+            MEMORY_ALIAS,
+            memory_target.as_str(),
+            MountPermissions::read_only(),
+        )?,
     ])
+}
+
+fn scoped_memory_target(scope: &ResourceScope) -> Result<VirtualPath, HostApiError> {
+    MemoryDocumentScope::new_with_agent(
+        scope.tenant_id.as_str(),
+        scope.user_id.as_str(),
+        scope.agent_id.as_ref().map(|id| id.as_str()),
+        scope.project_id.as_ref().map(|id| id.as_str()),
+    )?
+    .virtual_prefix()
 }
 
 fn grant(

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -1852,8 +1852,9 @@ impl RebornRuntime {
 
     /// Read-only scoped filesystem spanning every mount the standalone WebUI
     /// filesystem viewer can browse (workspace files + persistent memory), over
-    /// the same composite root the agent's tools resolve through. `None` when no
-    /// local runtime is composed, or when the browse mount view can't be built.
+    /// the same composite root the agent's tools resolve through. `None` only
+    /// when no local runtime is composed; scope-specific mount resolution errors
+    /// surface during browse operations.
     ///
     /// Distinct from [`Self::webui_workspace_filesystem`]: that handle is the
     /// read-write workspace-only view used to land attachments, whereas this is

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -1863,26 +1863,10 @@ impl RebornRuntime {
     ) -> Option<Arc<ironclaw_filesystem::ScopedFilesystem<crate::factory::LocalDevRootFilesystem>>>
     {
         let rt = self.services.local_runtime.as_ref()?;
-        let view = match crate::local_dev_mounts::browse_mount_view() {
-            Ok(view) => view,
-            Err(error) => {
-                // Built from static aliases/targets, so this should never fail;
-                // if it does, log loudly rather than silently disabling the
-                // filesystem viewer with a bare `None`.
-                tracing::error!(
-                    target = "ironclaw_reborn_composition::webui",
-                    %error,
-                    "failed to build webui browse mount view; filesystem viewer unavailable",
-                );
-                return None;
-            }
-        };
-        Some(Arc::new(
-            ironclaw_filesystem::ScopedFilesystem::with_fixed_view(
-                Arc::clone(&rt.extension_filesystem),
-                view,
-            ),
-        ))
+        Some(Arc::new(ironclaw_filesystem::ScopedFilesystem::new(
+            Arc::clone(&rt.extension_filesystem),
+            crate::local_dev_mounts::scoped_browse_mount_view,
+        )))
     }
 
     /// Test-only handle on the resource governor backing the budget

--- a/crates/ironclaw_reborn_composition/src/support/fs/mount_filesystem_reader.rs
+++ b/crates/ironclaw_reborn_composition/src/support/fs/mount_filesystem_reader.rs
@@ -5,7 +5,7 @@
 //! Files" viewer calls to navigate the agent's internal filesystem (persistent
 //! memory + project working files, which include landed attachments). It reads
 //! through a single read-only [`ScopedFilesystem`] whose mount view spans every
-//! browsable alias (see [`browse_mount_view`](crate::local_dev_mounts)). A
+//! browsable alias (see [`scoped_browse_mount_view`](crate::local_dev_mounts)). A
 //! [`FsMount`] selects which alias to confine to; paths in and out are
 //! mount-relative so neither an alias nor a host path crosses the boundary.
 //!
@@ -249,7 +249,7 @@ mod tests {
     use ironclaw_filesystem::InMemoryBackend;
     use ironclaw_host_api::{
         AgentId, InvocationId, MountAlias, MountGrant, MountPermissions, MountView, ResourceScope,
-        TenantId, UserId, VirtualPath,
+        ScopedPath, TenantId, UserId, VirtualPath,
     };
 
     fn browse_fs() -> Arc<ScopedFilesystem<InMemoryBackend>> {
@@ -305,6 +305,13 @@ mod tests {
         }
     }
 
+    fn user_scope(user_id: &str) -> ResourceScope {
+        ResourceScope {
+            user_id: UserId::new(user_id).unwrap(),
+            ..scope()
+        }
+    }
+
     #[tokio::test]
     async fn available_mounts_excludes_unwired_skills() {
         let reader = MountScopedFilesystemReader::new(browse_fs());
@@ -346,6 +353,56 @@ mod tests {
         assert_eq!(file.bytes, b"# notes");
         assert_eq!(file.path, "daily/today.md");
         assert_eq!(file.filename.as_deref(), Some("today.md"));
+    }
+
+    #[tokio::test]
+    async fn memory_browse_is_scoped_to_requesting_user() {
+        let root = Arc::new(InMemoryBackend::new());
+        let reader = MountScopedFilesystemReader::new(Arc::new(ScopedFilesystem::new(
+            Arc::clone(&root),
+            crate::local_dev_mounts::scoped_browse_mount_view,
+        )));
+        let alice = user_scope("alice");
+        let bob = user_scope("bob");
+
+        root.write_file(
+            &VirtualPath::new(
+                "/memory/tenants/tenant-test/users/alice/agents/agent-test/projects/_none/private-poem.md",
+            )
+            .unwrap(),
+            b"alice-only poem",
+        )
+        .await
+        .expect("seed alice memory");
+
+        let alice_entries = reader
+            .list_dir(&alice, FsMount::Memory, "")
+            .await
+            .expect("list alice memory");
+        assert!(
+            alice_entries
+                .iter()
+                .any(|entry| entry.name == "private-poem.md"),
+            "Alice should see her own memory document: {alice_entries:?}"
+        );
+
+        let bob_entries = reader
+            .list_dir(&bob, FsMount::Memory, "")
+            .await
+            .expect("list bob memory");
+        assert!(
+            !bob_entries
+                .iter()
+                .any(|entry| entry.name == "private-poem.md"),
+            "Bob must not see Alice's memory document: {bob_entries:?}"
+        );
+        assert_eq!(
+            reader
+                .read_file(&bob, FsMount::Memory, "private-poem.md")
+                .await
+                .expect_err("Bob must not read Alice's memory"),
+            ProjectFsError::NotFound
+        );
     }
 
     #[tokio::test]

--- a/crates/ironclaw_reborn_composition/tests/webui_v2_e2e.rs
+++ b/crates/ironclaw_reborn_composition/tests/webui_v2_e2e.rs
@@ -55,10 +55,13 @@ use tower::ServiceExt;
 // ─── identities ───────────────────────────────────────────────────────
 
 const VALID_TOKEN: &str = "valid-e2e-token";
+const USER_B_TOKEN: &str = "valid-e2e-token-b";
 const TENANT: &str = "e2e-tenant";
 const USER: &str = "e2e-owner";
+const USER_B: &str = "e2e-viewer-b";
 const AGENT: &str = "e2e-agent";
 const SENSITIVE_TOOL_SENTINEL: &str = "sk-e2e-progress-secret";
+const MEMORY_ISOLATION_MARKER: &str = "webui-memory-owner-a-secret-5460";
 
 // ─── auth stub ────────────────────────────────────────────────────────
 
@@ -81,6 +84,23 @@ impl WebuiAuthenticator for ValidTokenForUser {
             Some(WebuiAuthentication::user(self.user_id.clone()))
         } else {
             None
+        }
+    }
+}
+
+struct TwoUserTokens;
+
+#[async_trait]
+impl WebuiAuthenticator for TwoUserTokens {
+    async fn authenticate(&self, token: &str) -> Option<WebuiAuthentication> {
+        match token {
+            VALID_TOKEN => Some(WebuiAuthentication::user(
+                UserId::new(USER).expect("valid user id"),
+            )),
+            USER_B_TOKEN => Some(WebuiAuthentication::user(
+                UserId::new(USER_B).expect("valid user id"),
+            )),
+            _ => None,
         }
     }
 }
@@ -351,6 +371,11 @@ struct WriteFileGateway {
     call_count: StdMutex<usize>,
 }
 
+#[derive(Debug, Default)]
+struct MemoryWriteGateway {
+    call_count: StdMutex<usize>,
+}
+
 async fn register_write(
     capabilities: &Arc<dyn LoopCapabilityPort>,
     tool_name: ProviderToolName,
@@ -446,6 +471,87 @@ impl HostManagedModelGateway for WriteFileGateway {
         Ok(HostManagedModelResponse::assistant_reply(format!(
             "Saved {CSV_PATH} and {PDF_PATH} — both are ready to download."
         )))
+    }
+}
+
+#[async_trait]
+impl HostManagedModelGateway for MemoryWriteGateway {
+    async fn stream_model(
+        &self,
+        _request: HostManagedModelRequest,
+    ) -> Result<HostManagedModelResponse, HostManagedModelError> {
+        Err(HostManagedModelError::safe(
+            HostManagedModelErrorKind::InvalidRequest,
+            "MemoryWriteGateway requires the capability-aware model path",
+        ))
+    }
+
+    async fn stream_model_with_capabilities(
+        &self,
+        _request: HostManagedModelRequest,
+        capabilities: Arc<dyn LoopCapabilityPort>,
+    ) -> Result<HostManagedModelResponse, HostManagedModelError> {
+        let call_index = {
+            let mut count = self
+                .call_count
+                .lock()
+                .expect("memory gateway call lock poisoned");
+            let index = *count;
+            *count += 1;
+            index
+        };
+        if call_index > 0 {
+            let tool_result = _request
+                .messages
+                .iter()
+                .find(|message| message.role == HostManagedModelMessageRole::ToolResult)
+                .expect("follow-up model call must include memory_write result");
+            assert!(
+                tool_result.content.contains("status written")
+                    && tool_result.content.contains("path MEMORY.md"),
+                "memory_write must persist MEMORY.md before the browser isolation assertion, got: {}",
+                tool_result.content
+            );
+            return Ok(HostManagedModelResponse::assistant_reply("memory saved"));
+        }
+
+        let memory_write_id =
+            CapabilityId::new("builtin.memory_write").expect("memory_write capability id");
+        let memory_write_tool = capabilities
+            .tool_definitions()
+            .map_err(|err| {
+                HostManagedModelError::safe(
+                    HostManagedModelErrorKind::InvalidRequest,
+                    format!("tool_definitions failed: {err}"),
+                )
+            })?
+            .into_iter()
+            .find(|def| def.capability_id == memory_write_id)
+            .expect("builtin.memory_write must be visible in local-dev capability surface");
+        let write = capabilities
+            .register_provider_tool_call(RegisterProviderToolCallRequest::new(ProviderToolCall {
+                provider_id: "e2e-provider".to_string(),
+                provider_model_id: "e2e-model".to_string(),
+                turn_id: Some("e2e-memory-turn".to_string()),
+                id: "e2e-memory-write".to_string(),
+                name: memory_write_tool.name,
+                arguments: json!({
+                    "target": "memory",
+                    "content": format!("owner A private memory: {MEMORY_ISOLATION_MARKER}"),
+                    "append": false
+                }),
+                response_reasoning: None,
+                reasoning: None,
+                signature: None,
+            }))
+            .await
+            .map_err(|err| {
+                HostManagedModelError::safe(
+                    HostManagedModelErrorKind::InvalidRequest,
+                    format!("register_provider_tool_call(memory_write) failed: {err}"),
+                )
+            })?;
+        Ok(HostManagedModelResponse::capability_calls(vec![write], ""))
     }
 }
 
@@ -572,6 +678,63 @@ async fn build_harness_at_with_runtime_owner_and_auth_user(
     }
 }
 
+async fn build_two_user_harness(
+    gateway: Arc<dyn HostManagedModelGateway>,
+    policy: EffectiveRuntimePolicy,
+) -> Harness {
+    let root = tempfile::tempdir().expect("tempdir");
+    let storage_root = root.path().join("local-dev");
+    let input = RebornRuntimeInput::from_services(
+        RebornBuildInput::local_dev(USER, storage_root).with_runtime_policy(policy),
+    )
+    .with_identity(RebornRuntimeIdentity {
+        tenant_id: TENANT.to_string(),
+        agent_id: AGENT.to_string(),
+        source_binding_id: "e2e-source".to_string(),
+        reply_target_binding_id: "e2e-reply".to_string(),
+    })
+    .with_poll_settings(PollSettings {
+        interval: Duration::from_millis(10),
+        max_total: Duration::from_secs(10),
+    })
+    .with_model_gateway_override(gateway);
+
+    let runtime = build_reborn_runtime(input).await.expect("runtime builds");
+    runtime
+        .services()
+        .local_dev_auto_approve_settings_for_test()
+        .expect("local-dev exposes auto-approve settings for test")
+        .set(ironclaw_approvals::AutoApproveSettingInput {
+            updated_by: ironclaw_host_api::Principal::User(UserId::new(USER).expect("user")),
+            scope: ResourceScope {
+                tenant_id: TenantId::new(TENANT).expect("tenant"),
+                user_id: UserId::new(USER).expect("user"),
+                agent_id: Some(AgentId::new(AGENT).expect("agent")),
+                project_id: None,
+                mission_id: None,
+                thread_id: None,
+                invocation_id: InvocationId::new(),
+            },
+            enabled: true,
+        })
+        .await
+        .expect("enable global auto-approve for user A");
+    let bundle = build_webui_services(&runtime, None).expect("webui bundle");
+    let config = WebuiServeConfig::new(
+        TenantId::new(TENANT).expect("tenant"),
+        Arc::new(TwoUserTokens),
+        vec![HeaderValue::from_static("http://localhost:0")],
+    )
+    .with_default_agent_id(AgentId::new(AGENT).expect("agent"));
+    let router = webui_v2_app(bundle, config).expect("webui v2 app");
+
+    Harness {
+        runtime,
+        router,
+        _root: Some(root),
+    }
+}
+
 async fn read_json(response: axum::response::Response) -> Value {
     let bytes = to_bytes(response.into_body(), 256 * 1024)
         .await
@@ -591,6 +754,15 @@ fn bearer_post(uri: &str, body: Value) -> Request<Body> {
 
 fn bearer_get(uri: &str) -> Request<Body> {
     bearer_get_with_last_event_id(uri, None)
+}
+
+fn bearer_get_with_token(uri: &str, token: &str) -> Request<Body> {
+    Request::builder()
+        .method(Method::GET)
+        .uri(uri)
+        .header(header::AUTHORIZATION, format!("Bearer {token}"))
+        .body(Body::empty())
+        .expect("bearer GET request")
 }
 
 fn bearer_get_with_last_event_id(uri: &str, last_event_id: Option<&str>) -> Request<Body> {
@@ -1776,6 +1948,104 @@ async fn wait_for_assistant_reply(router: &axum::Router, thread_id: &str, needle
         tokio::time::sleep(Duration::from_millis(300)).await;
     }
     panic!("turn never produced an assistant reply containing {needle:?}; timeline={timeline:#?}");
+}
+
+#[tokio::test]
+async fn webui_filesystem_memory_mount_is_scoped_to_authenticated_user() {
+    let harness = build_two_user_harness(
+        Arc::new(MemoryWriteGateway::default()),
+        local_dev_effective_policy(),
+    )
+    .await;
+    let router = &harness.router;
+
+    let thread_id = create_thread(router, "e2e-memory-isolation-create").await;
+    send_message(router, &thread_id, "e2e-memory-isolation-save").await;
+    wait_for_assistant_reply(router, &thread_id, "memory saved").await;
+
+    let owner_raw_memory_path =
+        format!("tenants/{TENANT}/users/{USER}/agents/{AGENT}/projects/_none/MEMORY.md");
+    let response = router
+        .clone()
+        .oneshot(bearer_get_with_token(
+            &format!("/api/webchat/v2/fs/content?mount=memory&path={owner_raw_memory_path}"),
+            USER_B_TOKEN,
+        ))
+        .await
+        .expect("user B memory read oneshot");
+    let status = response.status();
+    let body = String::from_utf8_lossy(&read_body_bytes(response).await).to_string();
+    assert!(
+        status == StatusCode::NOT_FOUND || status == StatusCode::FORBIDDEN,
+        "user B must not read user A's memory document through the WebUI filesystem browser; status={status}, body={body}"
+    );
+    assert!(
+        !body.contains(MEMORY_ISOLATION_MARKER),
+        "user B response body leaked user A's memory marker: {body}"
+    );
+
+    let response = router
+        .clone()
+        .oneshot(bearer_get_with_token(
+            "/api/webchat/v2/fs/list?mount=memory",
+            USER_B_TOKEN,
+        ))
+        .await
+        .expect("user B memory list oneshot");
+    assert_eq!(response.status(), StatusCode::OK, "user B memory listing");
+    let listing = read_json(response).await;
+    let entries = listing["entries"]
+        .as_array()
+        .expect("memory list response carries entries");
+    assert!(
+        entries.iter().all(|entry| {
+            let name = entry["name"].as_str().unwrap_or_default();
+            let path = entry["path"].as_str().unwrap_or_default();
+            name != "tenants" && name != "MEMORY.md" && !path.contains(USER)
+        }),
+        "user B memory root must not expose user A's document or the raw memory tree: {listing:#?}"
+    );
+
+    let response = router
+        .clone()
+        .oneshot(bearer_get_with_token(
+            "/api/webchat/v2/fs/list?mount=memory",
+            VALID_TOKEN,
+        ))
+        .await
+        .expect("user A memory list oneshot");
+    assert_eq!(response.status(), StatusCode::OK, "user A memory listing");
+    let owner_listing = read_json(response).await;
+    assert!(
+        owner_listing["entries"].as_array().is_some_and(|entries| {
+            entries.iter().any(|entry| {
+                entry["name"].as_str() == Some("MEMORY.md")
+                    && entry["path"].as_str() == Some("MEMORY.md")
+            })
+        }),
+        "user A should see her own memory document: {owner_listing:#?}"
+    );
+
+    let response = router
+        .clone()
+        .oneshot(bearer_get_with_token(
+            "/api/webchat/v2/fs/content?mount=memory&path=MEMORY.md",
+            VALID_TOKEN,
+        ))
+        .await
+        .expect("user A memory read oneshot");
+    assert_eq!(response.status(), StatusCode::OK, "user A memory read");
+    let body = String::from_utf8_lossy(&read_body_bytes(response).await).to_string();
+    assert!(
+        body.contains(MEMORY_ISOLATION_MARKER),
+        "user A should read her own memory marker through the WebUI filesystem browser: {body}"
+    );
+
+    harness
+        .runtime
+        .shutdown()
+        .await
+        .expect("runtime shutdown clean");
 }
 
 /// End-to-end: the agent writes a CSV and a PDF into its project workspace via

--- a/crates/ironclaw_reborn_composition/tests/webui_v2_e2e.rs
+++ b/crates/ironclaw_reborn_composition/tests/webui_v2_e2e.rs
@@ -488,7 +488,7 @@ impl HostManagedModelGateway for MemoryWriteGateway {
 
     async fn stream_model_with_capabilities(
         &self,
-        _request: HostManagedModelRequest,
+        request: HostManagedModelRequest,
         capabilities: Arc<dyn LoopCapabilityPort>,
     ) -> Result<HostManagedModelResponse, HostManagedModelError> {
         let call_index = {
@@ -501,14 +501,14 @@ impl HostManagedModelGateway for MemoryWriteGateway {
             index
         };
         if call_index > 0 {
-            let tool_result = _request
+            let tool_result = request
                 .messages
                 .iter()
                 .find(|message| message.role == HostManagedModelMessageRole::ToolResult)
                 .expect("follow-up model call must include memory_write result");
             assert!(
-                tool_result.content.contains("status written")
-                    && tool_result.content.contains("path MEMORY.md"),
+                tool_result.content.contains("written")
+                    && tool_result.content.contains("MEMORY.md"),
                 "memory_write must persist MEMORY.md before the browser isolation assertion, got: {}",
                 tool_result.content
             );
@@ -1975,9 +1975,10 @@ async fn webui_filesystem_memory_mount_is_scoped_to_authenticated_user() {
         .expect("user B memory read oneshot");
     let status = response.status();
     let body = String::from_utf8_lossy(&read_body_bytes(response).await).to_string();
-    assert!(
-        status == StatusCode::NOT_FOUND || status == StatusCode::FORBIDDEN,
-        "user B must not read user A's memory document through the WebUI filesystem browser; status={status}, body={body}"
+    assert_eq!(
+        status,
+        StatusCode::NOT_FOUND,
+        "user B must not read user A's memory document through the WebUI filesystem browser; body={body}"
     );
     assert!(
         !body.contains(MEMORY_ISOLATION_MARKER),
@@ -2039,6 +2040,25 @@ async fn webui_filesystem_memory_mount_is_scoped_to_authenticated_user() {
     assert!(
         body.contains(MEMORY_ISOLATION_MARKER),
         "user A should read her own memory marker through the WebUI filesystem browser: {body}"
+    );
+
+    let response = router
+        .clone()
+        .oneshot(bearer_get_with_token(
+            "/api/webchat/v2/fs/content?mount=memory&path=MEMORY.md",
+            USER_B_TOKEN,
+        ))
+        .await
+        .expect("user B canonical memory read oneshot");
+    assert_eq!(
+        response.status(),
+        StatusCode::NOT_FOUND,
+        "user B must not read user A's canonical memory document"
+    );
+    let body = String::from_utf8_lossy(&read_body_bytes(response).await).to_string();
+    assert!(
+        !body.contains(MEMORY_ISOLATION_MARKER),
+        "user B canonical memory response body leaked user A's memory marker: {body}"
     );
 
     harness

--- a/crates/ironclaw_webui_v2/src/handlers.rs
+++ b/crates/ironclaw_webui_v2/src/handlers.rs
@@ -509,12 +509,16 @@ fn project_fs_download_response(file: ProjectFsFile) -> Result<Response, WebUiV2
 
 /// Query parameters for the standalone filesystem-browser read routes. `mount`
 /// selects which logical mount to read (memory/workspace/…); `path` is a
-/// mount-relative path (absent/blank means the mount root for listing).
+/// mount-relative path (absent/blank means the mount root for listing), and
+/// `project_id` optionally selects an authorized project scope.
 #[derive(Debug, Deserialize)]
 pub struct FsBrowseQuery {
     pub mount: FsMount,
     #[serde(default)]
     pub path: Option<String>,
+    /// Optional project to browse, authorized by the product-workflow facade.
+    #[serde(default)]
+    pub project_id: Option<ironclaw_host_api::ProjectId>,
 }
 
 /// `GET /api/webchat/v2/fs/mounts`
@@ -528,7 +532,7 @@ pub async fn list_fs_mounts(
     Ok(Json(response))
 }
 
-/// `GET /api/webchat/v2/fs/list?mount=…&path=…`
+/// `GET /api/webchat/v2/fs/list?mount=…&path=…&project_id=…`
 ///
 /// List a directory on a browsable mount. Caller-scoped read-only navigation
 /// over the agent's internal filesystem.
@@ -544,12 +548,13 @@ pub async fn browse_fs_dir(
             .path
             .filter(|path| !path.trim().is_empty())
             .unwrap_or_default(),
+        project_id: query.project_id,
     };
     let response = state.services().browse_fs_dir(caller, request).await?;
     Ok(Json(response))
 }
 
-/// `GET /api/webchat/v2/fs/stat?mount=…&path=…`
+/// `GET /api/webchat/v2/fs/stat?mount=…&path=…&project_id=…`
 ///
 /// Return metadata for a path on a browsable mount.
 pub async fn stat_fs_path(
@@ -560,12 +565,13 @@ pub async fn stat_fs_path(
     let request = RebornFsStatRequest {
         mount: query.mount,
         path: require_fs_browse_path(query.path)?,
+        project_id: query.project_id,
     };
     let response = state.services().stat_fs_path(caller, request).await?;
     Ok(Json(response))
 }
 
-/// `GET /api/webchat/v2/fs/content?mount=…&path=…`
+/// `GET /api/webchat/v2/fs/content?mount=…&path=…&project_id=…`
 ///
 /// Download/preview a file's bytes from a browsable mount. Served as an
 /// attachment with `nosniff`, exactly like the project-file route.
@@ -577,6 +583,7 @@ pub async fn read_fs_file(
     let request = RebornFsReadRequest {
         mount: query.mount,
         path: require_fs_browse_path(query.path)?,
+        project_id: query.project_id,
     };
     let file = state.services().read_fs_file(caller, request).await?;
     project_fs_download_response(file)

--- a/crates/ironclaw_webui_v2/tests/webui_v2_handlers_contract.rs
+++ b/crates/ironclaw_webui_v2/tests/webui_v2_handlers_contract.rs
@@ -245,6 +245,7 @@ struct StubServices {
     delete_thread_calls: Mutex<Vec<RebornDeleteThreadRequest>>,
     submit_turn_calls: Mutex<Vec<WebUiSendMessageRequest>>,
     get_timeline_calls: Mutex<Vec<RebornTimelineRequest>>,
+    browse_fs_calls: Mutex<Vec<RebornFsListRequest>>,
     global_auto_approve_enabled: Mutex<bool>,
     global_auto_approve_calls: Mutex<usize>,
     stall_global_auto_approve: Mutex<bool>,
@@ -640,6 +641,10 @@ impl RebornServicesApi for StubServices {
         _caller: WebUiAuthenticatedCaller,
         request: RebornFsListRequest,
     ) -> Result<RebornFsListResponse, RebornServicesError> {
+        self.browse_fs_calls
+            .lock()
+            .expect("lock")
+            .push(request.clone());
         Ok(RebornFsListResponse {
             mount: request.mount,
             path: request.path,
@@ -6350,6 +6355,31 @@ async fn browse_fs_dir_lists_mount_relative_entries() {
     assert_eq!(body["mount"], "memory");
     assert_eq!(body["entries"][0]["name"], "today.md");
     assert_eq!(body["entries"][0]["path"], "daily/today.md");
+}
+
+#[tokio::test]
+async fn browse_fs_dir_forwards_optional_project_selector() {
+    let services = Arc::new(StubServices::default());
+    let router = router_with(services.clone());
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method(Method::GET)
+                .uri("/api/webchat/v2/fs/list?mount=memory&path=daily&project_id=project-beta")
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("oneshot");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let calls = services.browse_fs_calls.lock().expect("lock");
+    assert_eq!(calls.len(), 1);
+    assert_eq!(
+        calls[0].project_id.as_ref().map(ProjectId::as_str),
+        Some("project-beta")
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- Scope the WebUI v2 memory browse mount with the authenticated caller instead of exposing the raw `/memory` tree.
- Reuse `MemoryDocumentScope::virtual_prefix()` so the browser mount follows the canonical memory path contract.
- Add a WebUI v2 E2E regression: user A writes `MEMORY.md` through `builtin.memory_write`; user B cannot read/list it through `/api/webchat/v2/fs`; user A still can.

Closes #5460

## Verification
- RED on origin/main + final E2E patch: `cargo test -p ironclaw_reborn_composition --test webui_v2_e2e webui_filesystem_memory_mount_is_scoped_to_authenticated_user --features webui-v2-beta,test-support --no-default-features` failed with `status=200 OK, body=owner A private memory: webui-memory-owner-a-secret-5460`.
- GREEN: `cargo fmt --check`
- GREEN: `cargo test -p ironclaw_reborn_composition --test webui_v2_e2e webui_filesystem_memory_mount_is_scoped_to_authenticated_user --features webui-v2-beta,test-support --no-default-features`
- GREEN: `cargo test -p ironclaw_reborn_composition memory_browse_is_scoped_to_requesting_user --features webui-v2-beta --no-default-features`

## Notes
- No PostgreSQL/libSQL matrix added: the regression is in the WebUI browse mount resolver, not backend query parity.
