### PR TITLE
feat(reborn): add per-user MCP registration store

### DIFF
--- a/crates/ironclaw_extensions/src/lib.rs
+++ b/crates/ironclaw_extensions/src/lib.rs
@@ -490,7 +490,7 @@ impl ExtensionDiscovery {
                 root,
                 &entry,
                 expected,
-                source,
+                source.clone(),
                 host_port_catalog,
                 host_api_contracts,
             )
@@ -573,7 +573,7 @@ impl ExtensionDiscovery {
                 root,
                 &entry,
                 expected.clone(),
-                source,
+                source.clone(),
                 host_port_catalog,
                 host_api_contracts,
             )

--- a/crates/ironclaw_extensions/src/v2.rs
+++ b/crates/ironclaw_extensions/src/v2.rs
@@ -42,7 +42,7 @@ use ironclaw_host_api::{
     HostApiError, HostPortCatalog, HostPortId, NetworkScheme, NetworkTargetPattern, PermissionMode,
     RequestedTrustClass, ResourceProfile, RuntimeCredentialRequirement,
     RuntimeCredentialRequirementSource, RuntimeCredentialTarget, RuntimeKind, SecretHandle,
-    TrustClass,
+    TrustClass, UserId,
 };
 use serde::{Deserialize, Deserializer};
 use thiserror::Error;
@@ -116,7 +116,7 @@ pub struct HookSectionEntryV2 {
 }
 
 /// Loader-supplied source for a manifest. Never read from TOML.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ManifestSource {
     /// Compiled or bundled with the host binary. Only source eligible for
     /// effective FirstParty/System trust and runtime.
@@ -127,11 +127,16 @@ pub enum ManifestSource {
     /// Installed from registry/catalog with digest/signature metadata. Never
     /// eligible for effective FirstParty/System in v2.
     RegistryInstalled,
+    /// Registered by a specific user through the MCP-registration store
+    /// (`/system/extensions/registered/<owner>/<id>/`). Never eligible for
+    /// effective FirstParty/System. Carries the owning [`UserId`] so
+    /// downstream storage/composition code can scope visibility per owner.
+    UserRegistered { owner: UserId },
 }
 
 impl ManifestSource {
     /// True if the source is allowed to assert FirstParty/System trust/runtime.
-    pub fn allows_first_party(self) -> bool {
+    pub fn allows_first_party(&self) -> bool {
         matches!(self, Self::HostBundled)
     }
 }
@@ -667,8 +672,12 @@ impl ExtensionManifestV2 {
             });
         }
         let document = RawManifestDocumentV2::parse(input)?;
-        let mut manifest =
-            Self::from_raw(document.raw, source, host_port_catalog, &document.sections)?;
+        let mut manifest = Self::from_raw(
+            document.raw,
+            source.clone(),
+            host_port_catalog,
+            &document.sections,
+        )?;
         if manifest.host_apis.is_empty() {
             if let Some(key) = document.sections.first_non_envelope_top_level_key() {
                 return Err(ManifestV2Error::Parse {
@@ -735,7 +744,16 @@ impl ExtensionManifestV2 {
                 reason: "description must not be empty".to_string(),
             });
         }
-        if raw.capabilities.is_empty() && raw.host_api.is_empty() {
+        // A user-registered hosted-MCP server declares no static capabilities; it
+        // discovers its tools at activation. Gated on provenance AND the raw runtime
+        // variant, never `runtime.kind() == Mcp` alone — that also covers
+        // `transport = "stdio"`, admitting a zero-capability stdio descriptor from an
+        // `InstalledLocal` drop-in.
+        let is_zero_content_registered_mcp =
+            matches!(source, ManifestSource::UserRegistered { .. })
+                && matches!(raw.runtime, RawRuntimeV2::Mcp { .. });
+        if raw.capabilities.is_empty() && raw.host_api.is_empty() && !is_zero_content_registered_mcp
+        {
             return Err(ManifestV2Error::Invalid {
                 reason: "at least one host_api contract or legacy capability is required"
                     .to_string(),

--- a/crates/ironclaw_reborn_composition/src/extension_host/available_extensions.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/available_extensions.rs
@@ -1688,14 +1688,33 @@ where
                 reason: format!("available extension manifest is not UTF-8: {error}"),
             }
         })?;
-        let record = ExtensionManifestRecord::from_toml_with_contracts(
+        let record = match ExtensionManifestRecord::from_toml_with_contracts(
             manifest_toml,
             source.clone(),
             &host_ports,
             None,
             &contracts,
-        )
-        .map_err(map_binding_error)?;
+        ) {
+            Ok(record) => record,
+            Err(error) => {
+                // Skip-and-log, not `?`: this loop is shared by every owner's
+                // registered-store listing (`RegisteredExtensionStore::list_for_owner`/
+                // `list_all`, reached from both the live search path and boot-time
+                // `resolve_any_owner_for_restore`). Propagating a single owner's
+                // unparseable `manifest.toml` here would hard-fail every other
+                // owner's listing and boot restore — a cross-tenant DoS via one
+                // corrupt descriptor. `debug!` (not `warn!`/`info!`): this loop
+                // runs on a live/foreground search path as well as boot, and
+                // per CLAUDE.md `info!`/`warn!` corrupt the REPL/TUI — this is
+                // internal diagnostic, not REPL-intentional user-facing status.
+                tracing::debug!(
+                    path = %entry.path.as_str(),
+                    error = %error,
+                    "skipping unparseable available extension manifest"
+                );
+                continue;
+            }
+        };
         let surface_kinds = surface_kinds_from_manifest_record(&record, entry.name.as_str())?;
         let manifest = record
             .manifest()

--- a/crates/ironclaw_reborn_composition/src/extension_host/available_extensions.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/available_extensions.rs
@@ -139,19 +139,24 @@ impl HostManagedCredentialExtension {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct AvailableExtensionAsset {
     pub(crate) path: String,
     pub(crate) content: AvailableExtensionAssetContent,
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum AvailableExtensionAssetContent {
     Bytes(Vec<u8>),
     Filesystem(VirtualPath),
 }
 
-#[derive(Debug)]
+/// Cloneable so an owner-registered package resolved from
+/// [`crate::extension_host::registered_extension_store`] (freshly loaded
+/// from disk, never borrowed from the shared first-party catalog) and a
+/// first-party catalog hit can flow through the same owned
+/// `AvailableExtensionPackage` return type in `resolve_with_owner_overlay`.
+#[derive(Debug, Clone)]
 pub(crate) struct AvailableExtensionPackage {
     pub(crate) package_ref: LifecyclePackageRef,
     pub(crate) manifest_toml: String,
@@ -427,7 +432,7 @@ impl AvailableExtensionCatalog {
         F: RootFilesystem + ?Sized,
     {
         Ok(Self::from_packages(
-            load_filesystem_packages(fs, root).await?,
+            load_filesystem_packages(fs, root, ManifestSource::HostBundled).await?,
         ))
     }
 
@@ -456,7 +461,10 @@ impl AvailableExtensionCatalog {
     }
 }
 
-fn package_matches_search(package: &AvailableExtensionPackage, normalized_query: &str) -> bool {
+pub(crate) fn package_matches_search(
+    package: &AvailableExtensionPackage,
+    normalized_query: &str,
+) -> bool {
     normalized_query.is_empty()
         || package_search_terms(package)
             .iter()
@@ -1606,9 +1614,20 @@ where
     }
 }
 
-async fn load_filesystem_packages<F>(
+/// Load extension packages from every immediate child directory of `root`
+/// that has a `manifest.toml`, tagging each with `source`. Reused for both
+/// the shared first-party catalog root (`/system/extensions`, `source =
+/// HostBundled`) and an owner's registered-extension subtree
+/// (`/system/extensions/registered/<owner>`, `source = UserRegistered`) —
+/// see [`crate::extension_host::registered_extension_store`]. The resulting
+/// package's `root` is always the canonical `/system/extensions/<id>` path
+/// (see [`canonical_extension_root`]), never `root` itself, so a package
+/// loaded from a nested owner subtree still satisfies
+/// `ExtensionPackage`'s own root/id matching invariant.
+pub(crate) async fn load_filesystem_packages<F>(
     fs: &F,
     root: &VirtualPath,
+    source: ManifestSource,
 ) -> Result<Vec<AvailableExtensionPackage>, ProductWorkflowError>
 where
     F: RootFilesystem + ?Sized,
@@ -1671,7 +1690,7 @@ where
         })?;
         let record = ExtensionManifestRecord::from_toml_with_contracts(
             manifest_toml,
-            ManifestSource::HostBundled,
+            source.clone(),
             &host_ports,
             None,
             &contracts,
@@ -1683,8 +1702,10 @@ where
             .clone()
             .try_into()
             .map_err(map_binding_error)?;
-        let package = ExtensionPackage::from_manifest_toml(manifest, entry.path, record.raw_toml())
-            .map_err(map_binding_error)?;
+        let package_root = canonical_extension_root(&extension_id)?;
+        let package =
+            ExtensionPackage::from_manifest_toml(manifest, package_root, record.raw_toml())
+                .map_err(map_binding_error)?;
         let mut assets = vec![AvailableExtensionAsset {
             path: "manifest.toml".to_string(),
             content: AvailableExtensionAssetContent::Bytes(record.raw_toml().as_bytes().to_vec()),
@@ -1719,12 +1740,26 @@ fn reserved_host_bundled_extension_id(extension_id: &ExtensionId) -> bool {
     ) || is_gsuite_extension_id(extension_id)
 }
 
+/// The canonical `/system/extensions/<id>` root every `ExtensionPackage`
+/// must carry (`ensure_extension_root_matches` in `ironclaw_extensions`
+/// requires it). Used both for the shared first-party catalog (where it is
+/// also the package's real on-disk location) and, via
+/// [`load_filesystem_packages`], for packages loaded from a nested
+/// owner-scoped subtree — those are never materialized under this synthetic
+/// root (see the registered-store skip in `extension_lifecycle.rs`), so the
+/// mismatch between this synthetic root and the real read location is inert.
+fn canonical_extension_root(
+    extension_id: &ExtensionId,
+) -> Result<VirtualPath, ProductWorkflowError> {
+    VirtualPath::new(format!("/system/extensions/{}", extension_id.as_str()))
+        .map_err(map_binding_error)
+}
+
 fn extension_asset_path(
     extension_id: &ExtensionId,
     asset_path: &str,
 ) -> Result<VirtualPath, ProductWorkflowError> {
-    let root = VirtualPath::new(format!("/system/extensions/{}", extension_id.as_str()))
-        .map_err(map_binding_error)?;
+    let root = canonical_extension_root(extension_id)?;
     ExtensionAssetPath::new(asset_path.to_string())
         .map_err(map_binding_error)?
         .resolve_under(&root)

--- a/crates/ironclaw_reborn_composition/src/extension_host/extension_installation_store.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/extension_installation_store.rs
@@ -5,7 +5,7 @@ use ironclaw_extensions::{
     ExtensionManifestRecord, InMemoryExtensionInstallationStore, ManifestHash, ManifestSource,
 };
 use ironclaw_filesystem::{FilesystemError, RootFilesystem};
-use ironclaw_host_api::{ExtensionId, VirtualPath};
+use ironclaw_host_api::{ExtensionId, UserId, VirtualPath};
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
 
@@ -246,18 +246,19 @@ impl From<ExtensionManifestRecord> for WireManifestRecord {
     fn from(record: ExtensionManifestRecord) -> Self {
         Self {
             raw_toml: record.raw_toml().to_string(),
-            source: WireManifestSource::from_manifest_source(record.manifest().source),
+            source: WireManifestSource::from_manifest_source(record.manifest().source.clone()),
             manifest_hash: record.manifest_hash().cloned(),
         }
     }
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 enum WireManifestSource {
     HostBundled,
     InstalledLocal,
     RegistryInstalled,
+    UserRegistered { owner: String },
 }
 
 impl WireManifestSource {
@@ -266,6 +267,9 @@ impl WireManifestSource {
             ManifestSource::HostBundled => Self::HostBundled,
             ManifestSource::InstalledLocal => Self::InstalledLocal,
             ManifestSource::RegistryInstalled => Self::RegistryInstalled,
+            ManifestSource::UserRegistered { owner } => Self::UserRegistered {
+                owner: owner.into_string(),
+            },
         }
     }
 
@@ -274,6 +278,9 @@ impl WireManifestSource {
             Self::HostBundled => ManifestSource::HostBundled,
             Self::InstalledLocal => ManifestSource::InstalledLocal,
             Self::RegistryInstalled => ManifestSource::RegistryInstalled,
+            Self::UserRegistered { owner } => ManifestSource::UserRegistered {
+                owner: UserId::from_trusted(owner),
+            },
         }
     }
 }

--- a/crates/ironclaw_reborn_composition/src/extension_host/extension_lifecycle.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/extension_lifecycle.rs
@@ -18,8 +18,8 @@ use ironclaw_extensions::{
 use ironclaw_filesystem::RootFilesystem;
 use ironclaw_host_api::{
     CapabilityDescriptor, CapabilityId, EffectKind, ExtensionId, PermissionMode, ResourceScope,
-    RuntimeCredentialAuthRequirement, RuntimeCredentialRequirement, RuntimeHttpEgress, VirtualPath,
-    sha256_digest_token,
+    RuntimeCredentialAuthRequirement, RuntimeCredentialRequirement, RuntimeHttpEgress, UserId,
+    VirtualPath, sha256_digest_token,
 };
 use ironclaw_product_adapter_registry::PRODUCT_ADAPTER_HOST_API_ID;
 use ironclaw_product_workflow::{
@@ -82,6 +82,10 @@ use crate::extension_host::extension_credential_requirements::package_runtime_cr
 use crate::extension_host::lifecycle::response_with_payload;
 use crate::extension_host::mcp_discovery::{
     HostedMcpDiscoveryError, discover_hosted_mcp_package, is_hosted_http_mcp_package,
+};
+use crate::extension_host::registered_extension_store::{
+    is_owner_registered, resolve_any_owner_for_restore, resolve_with_owner_overlay,
+    search_with_owner_overlay,
 };
 
 pub(crate) use active_publication::ActiveExtensionPublisher;
@@ -174,17 +178,30 @@ pub(crate) async fn restore_extension_lifecycle_state(
             LifecyclePackageKind::Extension,
             installation.extension_id().as_str(),
         )?;
-        let available = catalog.resolve(&package_ref)?;
-        if let Err(hash_error) = validate_restored_manifest_hash(&installation, available) {
+        // The shared catalog never contains `UserRegistered` packages (T1's
+        // fix for the boot-leak blocker), so a miss here falls back to an
+        // any-owner registered-store lookup — see
+        // `registered_extension_store::resolve_any_owner_for_restore`.
+        let available = match catalog.resolve(&package_ref) {
+            Ok(available) => available.clone(),
+            Err(_) => resolve_any_owner_for_restore(filesystem.as_ref(), &package_ref).await?,
+        };
+        if let Err(hash_error) = validate_restored_manifest_hash(&installation, &available) {
             migrate_host_bundled_manifest_hash(
                 installation_store,
-                available,
+                &available,
                 &installation,
                 hash_error,
             )
             .await?;
         }
-        materialize_available_extension(filesystem.as_ref(), available).await?;
+        // Owner-registered manifests already live at their owner-scoped path;
+        // materializing them under `/system/extensions/<id>/` would let the
+        // next boot's catalog scan re-adopt them as first-party (see
+        // `is_owner_registered`).
+        if !is_owner_registered(&available.package.manifest.source) {
+            materialize_available_extension(filesystem.as_ref(), &available).await?;
+        }
         {
             let mut lifecycle = lifecycle_service.lock().await;
             lifecycle
@@ -288,10 +305,18 @@ impl RebornLocalExtensionManagementPort {
         &self,
         query: &str,
         credential_gate: Option<&RuntimeExtensionActivationCredentialGate>,
+        owner: Option<&UserId>,
     ) -> Result<LifecycleProductResponse, ProductWorkflowError> {
         let extensions = self.catalog.search(query);
         let mut summaries = Vec::new();
         for extension in extensions {
+            summaries.push(self.search_summary(extension, credential_gate).await?);
+        }
+        // Owner-registered packages never enter the shared catalog above
+        // (boot-leak fix), so they are searched separately and overlaid here.
+        let owner_overlay =
+            search_with_owner_overlay(self.filesystem.as_ref(), owner, query).await?;
+        for extension in &owner_overlay {
             summaries.push(self.search_summary(extension, credential_gate).await?);
         }
         let count = summaries.len();
@@ -472,17 +497,26 @@ impl RebornLocalExtensionManagementPort {
     pub(crate) async fn install(
         &self,
         package_ref: LifecyclePackageRef,
+        owner: Option<&UserId>,
     ) -> Result<LifecycleProductResponse, ProductWorkflowError> {
-        let available = self.catalog.resolve(&package_ref)?;
+        // Owner-registered packages never enter the shared catalog (boot-leak
+        // fix), so a catalog miss falls back to `owner`'s registered set.
+        let available = resolve_with_owner_overlay(
+            &self.catalog,
+            self.filesystem.as_ref(),
+            owner,
+            &package_ref,
+        )
+        .await?;
         let _operation_guard = self.operation_lock.lock().await;
-        self.install_available_locked(available).await?;
+        self.install_available_locked(&available).await?;
 
         Ok(response_with_payload(
             Some(package_ref.clone()),
             LifecyclePhase::Installed,
             LifecycleProductPayload::ExtensionInstall {
                 installed: true,
-                visible_capability_ids: visible_capability_ids(available)
+                visible_capability_ids: visible_capability_ids(&available)
                     .map(|id| id.as_str().to_string())
                     .collect(),
                 next_step: format!(
@@ -502,9 +536,15 @@ impl RebornLocalExtensionManagementPort {
             .await?;
         self.register_lifecycle_package(&available.package).await?;
 
-        if let Err(error) =
+        // Owner-registered manifests are never materialized under the shared
+        // `/system/extensions/<id>/` directory (mirrors the guard in
+        // `restore_extension_lifecycle_state` — see `is_owner_registered`).
+        let materialize_result = if is_owner_registered(&available.package.manifest.source) {
+            Ok(())
+        } else {
             materialize_available_extension(self.filesystem.as_ref(), available).await
-        {
+        };
+        if let Err(error) = materialize_result {
             if let Err(rollback_error) =
                 self.rollback_lifecycle_install(&available.package.id).await
             {
@@ -1329,9 +1369,14 @@ fn prepare_install(
             reason: format!("host API contract registry rejected extension install: {error}"),
         }
     })?;
+    // Preserve the resolved package's real provenance (first-party catalog
+    // vs. owner-registered) in the persisted record, rather than hardcoding
+    // `HostBundled` for every install — `migrate_host_bundled_manifest_hash`
+    // reads this back at restore time to decide hash-mismatch migration
+    // eligibility, which must stay HostBundled-only.
     let manifest_record = ExtensionManifestRecord::from_toml_with_contracts(
         &available.manifest_toml,
-        ManifestSource::HostBundled,
+        available.package.manifest.source.clone(),
         &host_ports,
         Some(manifest_hash.clone()),
         &contracts,
@@ -2135,7 +2180,7 @@ mod tests {
         let slack_ref =
             LifecyclePackageRef::new(LifecyclePackageKind::Extension, "slack").expect("slack ref");
 
-        port.install(slack_ref.clone())
+        port.install(slack_ref.clone(), None)
             .await
             .expect("install Slack tools extension");
 
@@ -2163,7 +2208,10 @@ mod tests {
         assert_eq!(count, 1);
         assert_eq!(extensions[0].summary.package_ref.id.as_str(), "slack");
 
-        let search = port.search("slack", None).await.expect("search slack");
+        let search = port
+            .search("slack", None, None)
+            .await
+            .expect("search slack");
         let Some(LifecycleProductPayload::ExtensionSearch { extensions, .. }) = search.payload
         else {
             panic!("expected extension search payload");
@@ -2212,7 +2260,7 @@ mod tests {
         let slack_ref =
             LifecyclePackageRef::new(LifecyclePackageKind::Extension, "slack").expect("slack ref");
 
-        port.install(slack_ref.clone())
+        port.install(slack_ref.clone(), None)
             .await
             .expect("install public Slack extension");
 
@@ -2268,7 +2316,7 @@ mod tests {
         let slack_ref =
             LifecyclePackageRef::new(LifecyclePackageKind::Extension, "slack").expect("slack ref");
 
-        port.install(slack_ref.clone())
+        port.install(slack_ref.clone(), None)
             .await
             .expect("install public Slack extension");
         port.activate_with_prechecked_credentials_for_test(
@@ -2319,7 +2367,7 @@ mod tests {
             .expect("seed builtin package");
         let package_ref = LifecyclePackageRef::new(LifecyclePackageKind::Extension, "fixture")
             .expect("valid ref");
-        port.install(package_ref.clone())
+        port.install(package_ref.clone(), None)
             .await
             .expect("install fixture extension");
         port.activate_with_prechecked_credentials_for_test(
@@ -2414,7 +2462,7 @@ mod tests {
             LifecyclePackageRef::new(LifecyclePackageKind::Extension, "notion").expect("valid ref");
         let egress = Arc::new(HostedMcpDiscoveryEgress::default());
 
-        port.install(package_ref.clone())
+        port.install(package_ref.clone(), None)
             .await
             .expect("install Notion MCP");
         port.activate_with_prechecked_credentials_for_test(
@@ -2472,7 +2520,7 @@ mod tests {
         let package_ref =
             LifecyclePackageRef::new(LifecyclePackageKind::Extension, "notion").expect("valid ref");
 
-        port.install(package_ref.clone())
+        port.install(package_ref.clone(), None)
             .await
             .expect("install Notion MCP");
         let activate = port
@@ -2512,7 +2560,7 @@ mod tests {
         };
         let calls = Arc::clone(&credential_gate.calls);
 
-        port.install(package_ref.clone())
+        port.install(package_ref.clone(), None)
             .await
             .expect("install Notion MCP");
         let error = port
@@ -2559,7 +2607,7 @@ mod tests {
         let (egress, tools_list_started, release_tools_list) =
             BlockingToolsListHostedMcpEgress::new();
 
-        port.install(package_ref.clone())
+        port.install(package_ref.clone(), None)
             .await
             .expect("install Notion MCP");
         let activation = tokio::spawn({
@@ -2615,7 +2663,7 @@ mod tests {
             TrustClass::Sandbox
         );
 
-        port.install(package_ref.clone())
+        port.install(package_ref.clone(), None)
             .await
             .expect("install fixture extension");
         port.activate_with_prechecked_credentials_for_test(
@@ -2668,7 +2716,7 @@ mod tests {
         let package_ref = LifecyclePackageRef::new(LifecyclePackageKind::Extension, "fixture")
             .expect("valid ref");
 
-        port.install(package_ref.clone())
+        port.install(package_ref.clone(), None)
             .await
             .expect("install extension");
         let error = port
@@ -2708,7 +2756,7 @@ mod tests {
         let package_ref = LifecyclePackageRef::new(LifecyclePackageKind::Extension, "fixture")
             .expect("valid ref");
 
-        port.install(package_ref.clone())
+        port.install(package_ref.clone(), None)
             .await
             .expect("install extension");
         let error = port
@@ -2748,7 +2796,7 @@ mod tests {
         let extension_id = ExtensionId::new("fixture").expect("valid extension id");
         let installation_id = ExtensionInstallationId::new("fixture").expect("valid installation");
 
-        port.install(package_ref.clone())
+        port.install(package_ref.clone(), None)
             .await
             .expect("install extension");
         installation_store
@@ -2789,7 +2837,7 @@ mod tests {
             );
 
         let error = port
-            .search("fixture", None)
+            .search("fixture", None, None)
             .await
             .expect_err("search reports installation-store read failure");
 
@@ -2809,7 +2857,7 @@ mod tests {
             );
 
         let error = port
-            .search("fixture", None)
+            .search("fixture", None, None)
             .await
             .expect_err("search reports mismatched installation row");
 
@@ -2829,7 +2877,7 @@ mod tests {
         let package_ref = LifecyclePackageRef::new(LifecyclePackageKind::Extension, "fixture")
             .expect("valid ref");
 
-        port.install(package_ref.clone())
+        port.install(package_ref.clone(), None)
             .await
             .expect("install fixture extension");
         port.activate_with_prechecked_credentials_for_test(
@@ -2867,7 +2915,7 @@ mod tests {
             );
         let package_ref = LifecyclePackageRef::new(LifecyclePackageKind::Extension, "fixture")
             .expect("valid ref");
-        port.install(package_ref.clone())
+        port.install(package_ref.clone(), None)
             .await
             .expect("install fixture extension");
         port.activate_with_prechecked_credentials_for_test(
@@ -3007,7 +3055,7 @@ mod tests {
             );
         let package_ref = LifecyclePackageRef::new(LifecyclePackageKind::Extension, "fixture")
             .expect("valid ref");
-        port.install(package_ref.clone())
+        port.install(package_ref.clone(), None)
             .await
             .expect("install fixture extension");
         port.activate_with_prechecked_credentials_for_test(
@@ -3057,7 +3105,7 @@ mod tests {
             );
         let package_ref = LifecyclePackageRef::new(LifecyclePackageKind::Extension, "fixture")
             .expect("valid ref");
-        port.install(package_ref.clone())
+        port.install(package_ref.clone(), None)
             .await
             .expect("install fixture extension");
         port.activate_with_prechecked_credentials_for_test(
@@ -3936,7 +3984,7 @@ mod tests {
         let package_ref = LifecyclePackageRef::new(LifecyclePackageKind::Extension, "fixture")
             .expect("valid ref");
 
-        port.install(package_ref.clone())
+        port.install(package_ref.clone(), None)
             .await
             .expect("install extension");
         port.activate_with_prechecked_credentials_for_test(
@@ -3999,7 +4047,7 @@ mod tests {
         let package_ref = LifecyclePackageRef::new(LifecyclePackageKind::Extension, "fixture")
             .expect("valid ref");
 
-        port.install(package_ref.clone())
+        port.install(package_ref.clone(), None)
             .await
             .expect("install extension");
         port.activate_with_prechecked_credentials_for_test(
@@ -4038,7 +4086,7 @@ mod tests {
         let package_ref = LifecyclePackageRef::new(LifecyclePackageKind::Extension, "fixture")
             .expect("valid ref");
 
-        port.install(package_ref.clone())
+        port.install(package_ref.clone(), None)
             .await
             .expect("install extension");
         port.activate_with_prechecked_credentials_for_test(

--- a/crates/ironclaw_reborn_composition/src/extension_host/extension_lifecycle_capabilities.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/extension_lifecycle_capabilities.rs
@@ -159,13 +159,20 @@ impl FirstPartyCapabilityHandler for ExtensionLifecycleToolHandler {
                     Arc::clone(&self.credential_accounts),
                 );
                 self.extension_management
-                    .search(&input.query, Some(&credential_gate))
+                    .search(
+                        &input.query,
+                        Some(&credential_gate),
+                        Some(&request.scope.user_id),
+                    )
                     .await
             }
             EXTENSION_INSTALL_CAPABILITY_ID => {
                 let input: ExtensionIdInput = parse_input(request.input)?;
                 self.extension_management
-                    .install(extension_package_ref(input.extension_id)?)
+                    .install(
+                        extension_package_ref(input.extension_id)?,
+                        Some(&request.scope.user_id),
+                    )
                     .await
             }
             EXTENSION_ACTIVATE_CAPABILITY_ID => {

--- a/crates/ironclaw_reborn_composition/src/extension_host/extension_lifecycle_registered_store_tests.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/extension_lifecycle_registered_store_tests.rs
@@ -1,0 +1,200 @@
+//! MCP-registration spec test #6 (boot-order restore), RED for T1
+//! (docs/plans/2026-07-08-mcp-reg-t1-plan.md). Sibling test file (module-split
+//! mandate: overlay/composition logic — and its tests — may not land in the
+//! 5505-line `extension_lifecycle.rs`), wired the same way
+//! `extension_lifecycle_capabilities_auth_tests.rs` is
+//! (`extension_host/mod.rs`'s `#[cfg(test)] pub(crate) mod ...;`).
+//!
+//! SCOPE LIMIT (plan risk 4): capability publication is tenant-global today
+//! (`active_model_visible_capabilities` filters by the global installation
+//! store, not by owner), pre-existing and out of scope for T1. This file
+//! asserts only that restore publishes the owner's registered extension after
+//! a reboot-like rebuild — it does NOT assert cross-actor publication
+//! isolation, which T1 does not provide.
+
+use std::sync::Arc;
+
+use ironclaw_extensions::{
+    ExtensionActivationState, ExtensionInstallation, ExtensionInstallationId,
+    ExtensionInstallationStore, ExtensionLifecycleService, ExtensionManifestRecord,
+    ExtensionManifestRef, ExtensionRegistry, InMemoryExtensionInstallationStore, ManifestHash,
+    ManifestSource, SharedExtensionRegistry,
+};
+use ironclaw_filesystem::{LocalFilesystem, RootFilesystem};
+use ironclaw_host_api::{ExtensionId, HostPath, UserId, VirtualPath, sha256_digest_token};
+use ironclaw_trust::{AdminConfig, HostTrustPolicy, InvalidationBus};
+use tokio::sync::Mutex;
+
+use crate::extension_host::available_extensions::AvailableExtensionCatalog;
+use crate::extension_host::extension_lifecycle::{
+    ActiveExtensionPublisher, restore_extension_lifecycle_state,
+};
+
+const OWNER_USER_ID: &str = "3eee560a-7fe5-474c-965a-67cb69df3d04";
+const REGISTERED_EXTENSION_ID: &str = "acme-mcp-boot";
+// A user-registered hosted-MCP server discovers its tools at runtime, so its
+// descriptor declares zero static `[[capabilities]]` — the shape only
+// `ManifestSource::UserRegistered` + an MCP runtime is allowed to parse
+// (`ironclaw_extensions::v2::ExtensionManifestV2::from_raw`).
+const REGISTERED_MANIFEST_TOML: &str = r#"
+schema_version = "reborn.extension_manifest.v2"
+id = "acme-mcp-boot"
+name = "Acme Boot MCP"
+version = "0.1.0"
+description = "User-registered hosted MCP server (T1 boot-order fixture)"
+trust = "third_party"
+
+[runtime]
+kind = "mcp"
+transport = "http"
+url = "http://127.0.0.1:9/mcp"
+"#;
+
+/// Boot-order restore: an owner-registered extension's installation must
+/// survive a reboot (fresh in-memory `ExtensionLifecycleService` +
+/// `ActiveExtensionPublisher` over the SAME durable filesystem +
+/// installation store) even though the static `AvailableExtensionCatalog`
+/// never contains `UserRegistered` packages (T1's fix for the boot-leak
+/// blocker in the plan). Today `restore_extension_lifecycle_state` has no
+/// registered-store fallback on `catalog.resolve()` miss, so this fails.
+#[tokio::test]
+async fn restore_publishes_owner_registered_extension_without_static_catalog_entry() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let storage_root = dir.path().join("local-dev");
+    std::fs::create_dir_all(storage_root.join("system/extensions")).expect("storage root");
+
+    let mut local_filesystem = LocalFilesystem::new();
+    local_filesystem
+        .mount_local(
+            VirtualPath::new("/system/extensions").expect("valid virtual path"),
+            HostPath::from_path_buf(storage_root.join("system/extensions")),
+        )
+        .expect("mount system extensions");
+    let filesystem: Arc<dyn RootFilesystem> = Arc::new(local_filesystem);
+
+    // Seed: write the registered manifest at T1's owner-scoped path convention
+    // directly onto disk (`RegisteredExtensionStore::put()` doesn't exist yet)
+    // and durably persist the installation the same way an owner-aware
+    // `install()` would (that doesn't exist yet either).
+    let owner_dir = storage_root
+        .join("system/extensions/registered")
+        .join(OWNER_USER_ID)
+        .join(REGISTERED_EXTENSION_ID);
+    std::fs::create_dir_all(&owner_dir).expect("registered manifest dir");
+    std::fs::write(owner_dir.join("manifest.toml"), REGISTERED_MANIFEST_TOML)
+        .expect("write registered manifest");
+
+    let host_ports = ironclaw_host_runtime::default_host_port_catalog().expect("host port catalog");
+    let contracts =
+        ironclaw_host_runtime::default_host_api_contract_registry().expect("host API contracts");
+    // A real owner-aware install persists the manifest hash on BOTH the stored
+    // manifest record and the installation record (`prepare_install`), and the
+    // installation store cross-validates the two. Seeding it here keeps them
+    // consistent and lets restore's `validate_restored_manifest_hash` match on
+    // the clean path. Seeding `None` would instead force restore through
+    // `migrate_host_bundled_manifest_hash`, which is HostBundled-only and
+    // aborts for a `UserRegistered` source — unrelated to what this test pins
+    // (registered-store fallback + publish).
+    let manifest_hash = ManifestHash::new(sha256_digest_token(REGISTERED_MANIFEST_TOML.as_bytes()))
+        .expect("valid manifest hash");
+    let manifest_record = ExtensionManifestRecord::from_toml_with_contracts(
+        REGISTERED_MANIFEST_TOML,
+        // Real provenance: a user-registered descriptor. This is the same
+        // source the boot-time restore fallback re-parses the on-disk manifest
+        // under, so the seeded record matches what restore reconstructs.
+        ManifestSource::UserRegistered {
+            owner: UserId::new(OWNER_USER_ID).expect("valid owner id"),
+        },
+        &host_ports,
+        Some(manifest_hash.clone()),
+        &contracts,
+    )
+    .expect("registered manifest record");
+    let extension_id = ExtensionId::new(REGISTERED_EXTENSION_ID).expect("valid extension id");
+    let installation = ExtensionInstallation::new(
+        ExtensionInstallationId::new(REGISTERED_EXTENSION_ID).expect("valid installation id"),
+        extension_id.clone(),
+        ExtensionActivationState::Enabled,
+        ExtensionManifestRef::new(extension_id.clone(), Some(manifest_hash)),
+        Vec::new(),
+        chrono::Utc::now(),
+    )
+    .expect("owner-registered installation");
+    let installation_store: Arc<dyn ExtensionInstallationStore> =
+        Arc::new(InMemoryExtensionInstallationStore::default());
+    installation_store
+        .upsert_manifest(manifest_record)
+        .await
+        .expect("seed registered manifest record");
+    installation_store
+        .upsert_installation(installation)
+        .await
+        .expect("seed owner-registered installation");
+
+    // "Reboot": fresh, empty in-memory lifecycle service + active registry.
+    // The static catalog never contains `UserRegistered` packages (T1's fix
+    // for the boot-leak blocker), so restore's ONLY path to this owner's
+    // installation is a registered-store fallback on `catalog.resolve()` miss.
+    let empty_catalog = AvailableExtensionCatalog::from_packages(Vec::new());
+    let lifecycle_service = Arc::new(Mutex::new(ExtensionLifecycleService::new(
+        ExtensionRegistry::new(),
+    )));
+    let active_registry = Arc::new(SharedExtensionRegistry::new(ExtensionRegistry::new()));
+    let trust_policy =
+        Arc::new(HostTrustPolicy::new(vec![Box::new(AdminConfig::new())]).expect("trust policy"));
+    let active_extensions = ActiveExtensionPublisher::new(
+        Arc::clone(&active_registry),
+        Arc::clone(&trust_policy),
+        Arc::new(InvalidationBus::new()),
+    );
+
+    restore_extension_lifecycle_state(
+        &empty_catalog,
+        &filesystem,
+        &installation_store,
+        &lifecycle_service,
+        &active_extensions,
+    )
+    .await
+    .expect(
+        "T1: restore must fall back to the registered store when the static catalog has no \
+         entry for an owner-registered extension (RED until RegisteredExtensionStore lands)",
+    );
+
+    assert!(
+        active_registry
+            .snapshot()
+            .get_extension(&extension_id)
+            .is_some(),
+        "owner-registered extension's capability must be published after restore"
+    );
+}
+
+/// Safety invariant the registered-store's owner-scoped path convention
+/// (`/system/extensions/registered/<owner>/<id>/manifest.toml`, T1) relies
+/// on: `UserId`'s own validation rejects any value that could escape that
+/// path prefix, so composing a `VirtualPath` from a valid `UserId` can never
+/// traverse out of the owner's directory. Passes today (pins an existing
+/// invariant, not new T1 behavior).
+#[test]
+fn owner_user_id_rejects_path_traversal_segments_for_registered_store_paths() {
+    for unsafe_owner in ["..", ".", "../../etc", "a/b", "a\\b", ""] {
+        assert!(
+            UserId::new(unsafe_owner).is_err(),
+            "UserId::new({unsafe_owner:?}) must reject path-unsafe segments"
+        );
+    }
+
+    let owner = UserId::new(OWNER_USER_ID).expect("valid owner id");
+    let path = VirtualPath::new(format!(
+        "/system/extensions/registered/{}/{REGISTERED_EXTENSION_ID}/manifest.toml",
+        owner.as_str()
+    ))
+    .expect("owner-scoped registered manifest path is valid");
+    assert_eq!(
+        path.as_str(),
+        format!(
+            "/system/extensions/registered/{OWNER_USER_ID}/{REGISTERED_EXTENSION_ID}/manifest.toml"
+        )
+    );
+}

--- a/crates/ironclaw_reborn_composition/src/extension_host/extension_lifecycle_registered_store_tests.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/extension_lifecycle_registered_store_tests.rs
@@ -22,6 +22,7 @@ use ironclaw_extensions::{
 };
 use ironclaw_filesystem::{LocalFilesystem, RootFilesystem};
 use ironclaw_host_api::{ExtensionId, HostPath, UserId, VirtualPath, sha256_digest_token};
+use ironclaw_product_workflow::{LifecyclePackageKind, LifecyclePackageRef};
 use ironclaw_trust::{AdminConfig, HostTrustPolicy, InvalidationBus};
 use tokio::sync::Mutex;
 
@@ -29,6 +30,7 @@ use crate::extension_host::available_extensions::AvailableExtensionCatalog;
 use crate::extension_host::extension_lifecycle::{
     ActiveExtensionPublisher, restore_extension_lifecycle_state,
 };
+use crate::extension_host::registered_extension_store::RegisteredExtensionStore;
 
 const OWNER_USER_ID: &str = "3eee560a-7fe5-474c-965a-67cb69df3d04";
 const REGISTERED_EXTENSION_ID: &str = "acme-mcp-boot";
@@ -167,6 +169,219 @@ async fn restore_publishes_owner_registered_extension_without_static_catalog_ent
             .get_extension(&extension_id)
             .is_some(),
         "owner-registered extension's capability must be published after restore"
+    );
+}
+
+const OTHER_OWNER_USER_ID: &str = "b2222222-7fe5-474c-965a-67cb69df3d05";
+const OWNER_A_GOOD_EXTENSION_ID: &str = "acme-mcp-good";
+const OWNER_A_CORRUPT_EXTENSION_ID: &str = "acme-mcp-corrupt";
+const OWNER_B_EXTENSION_ID: &str = "widgets-mcp";
+
+const OWNER_A_GOOD_MANIFEST_TOML: &str = r#"
+schema_version = "reborn.extension_manifest.v2"
+id = "acme-mcp-good"
+name = "Acme Good MCP"
+version = "0.1.0"
+description = "User-registered hosted MCP server (T1 blast-radius fixture)"
+trust = "third_party"
+
+[runtime]
+kind = "mcp"
+transport = "http"
+url = "http://127.0.0.1:9/mcp"
+"#;
+
+const OWNER_B_MANIFEST_TOML: &str = r#"
+schema_version = "reborn.extension_manifest.v2"
+id = "widgets-mcp"
+name = "Widgets MCP"
+version = "0.1.0"
+description = "User-registered hosted MCP server (T1 blast-radius fixture, owner B)"
+trust = "third_party"
+
+[runtime]
+kind = "mcp"
+transport = "http"
+url = "http://127.0.0.1:9/mcp"
+"#;
+
+/// Not valid TOML at all (unterminated table header) — this is what a
+/// corrupted or half-written `manifest.toml` looks like on disk. The bug this
+/// pins is not "invalid manifest content" (that's rejected everywhere, by
+/// design) but "one owner's corrupt descriptor takes down every OTHER
+/// owner's listing and boot restore".
+const CORRUPT_MANIFEST_TOML: &str = "[runtime\nkind = \"mcp\"\n";
+
+/// T1 amend (docs/plans/2026-07-08-mcp-reg-t3-plan.md, "Folds into
+/// already-shipped slices" / AC3): `load_filesystem_packages`
+/// (`available_extensions.rs`) used to `?`-propagate on the first
+/// unparseable `manifest.toml` in a directory scan, hard-failing the whole
+/// listing. Once T3 makes `/system/extensions/registered/<owner>/` end-user
+/// writable, one corrupt descriptor under owner A is a cross-tenant DoS:
+/// `RegisteredExtensionStore::list_for_owner`/`list_all` both go through the
+/// loop, and `list_all` backs `resolve_any_owner_for_restore`, the boot-order
+/// fallback every owner's restore can hit. This pins the real blast radius,
+/// not just "owner A's own listing survives its own corrupt entry":
+///   (i)  owner A's OTHER registered entries still list despite the corrupt
+///        sibling, and
+///   (ii) owner B — a wholly unrelated owner — still gets a successful boot
+///        restore (`restore_extension_lifecycle_state` /
+///        `resolve_any_owner_for_restore`) with their extension published,
+///        even though owner A's directory (scanned as part of the any-owner
+///        restore fallback) contains a corrupt manifest.
+/// RED before the skip-and-log fix: both assertions fail with a propagated
+/// `ProductWorkflowError` instead of the corrupt entry being skipped.
+#[tokio::test]
+async fn corrupt_manifest_under_one_owner_does_not_break_other_owners_listing_or_restore() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let storage_root = dir.path().join("local-dev");
+    std::fs::create_dir_all(storage_root.join("system/extensions")).expect("storage root");
+
+    let mut local_filesystem = LocalFilesystem::new();
+    local_filesystem
+        .mount_local(
+            VirtualPath::new("/system/extensions").expect("valid virtual path"),
+            HostPath::from_path_buf(storage_root.join("system/extensions")),
+        )
+        .expect("mount system extensions");
+    let filesystem: Arc<dyn RootFilesystem> = Arc::new(local_filesystem);
+
+    let owner_a = UserId::new(OWNER_USER_ID).expect("valid owner id");
+    let owner_b = UserId::new(OTHER_OWNER_USER_ID).expect("valid owner id");
+
+    // Seed owner A: one healthy descriptor + one corrupt descriptor sitting
+    // right next to it in the same owner-scoped directory scan.
+    let owner_a_good_dir = storage_root
+        .join("system/extensions/registered")
+        .join(OWNER_USER_ID)
+        .join(OWNER_A_GOOD_EXTENSION_ID);
+    std::fs::create_dir_all(&owner_a_good_dir).expect("owner A good manifest dir");
+    std::fs::write(
+        owner_a_good_dir.join("manifest.toml"),
+        OWNER_A_GOOD_MANIFEST_TOML,
+    )
+    .expect("write owner A good manifest");
+
+    let owner_a_corrupt_dir = storage_root
+        .join("system/extensions/registered")
+        .join(OWNER_USER_ID)
+        .join(OWNER_A_CORRUPT_EXTENSION_ID);
+    std::fs::create_dir_all(&owner_a_corrupt_dir).expect("owner A corrupt manifest dir");
+    std::fs::write(
+        owner_a_corrupt_dir.join("manifest.toml"),
+        CORRUPT_MANIFEST_TOML,
+    )
+    .expect("write owner A corrupt manifest");
+
+    // Seed owner B: one healthy, wholly unrelated descriptor.
+    let owner_b_dir = storage_root
+        .join("system/extensions/registered")
+        .join(OTHER_OWNER_USER_ID)
+        .join(OWNER_B_EXTENSION_ID);
+    std::fs::create_dir_all(&owner_b_dir).expect("owner B manifest dir");
+    std::fs::write(owner_b_dir.join("manifest.toml"), OWNER_B_MANIFEST_TOML)
+        .expect("write owner B manifest");
+
+    // ── (i) owner A's OTHER registered entries still list ───────────────────
+    let owner_a_packages = RegisteredExtensionStore::list_for_owner(filesystem.as_ref(), &owner_a)
+        .await
+        .expect(
+            "owner A's listing must skip the corrupt sibling manifest and return the healthy \
+             entry, not propagate an error for the whole directory (RED until skip-and-log lands)",
+        );
+    assert_eq!(
+        owner_a_packages.len(),
+        1,
+        "owner A's listing must contain exactly the healthy entry, corrupt sibling skipped"
+    );
+    assert_eq!(
+        owner_a_packages[0].package_ref,
+        LifecyclePackageRef::new(LifecyclePackageKind::Extension, OWNER_A_GOOD_EXTENSION_ID)
+            .expect("valid package ref"),
+        "owner A's surviving entry must be the healthy one"
+    );
+
+    // ── (ii) owner B's boot restore is unaffected by owner A's corruption ──
+    let host_ports = ironclaw_host_runtime::default_host_port_catalog().expect("host port catalog");
+    let contracts =
+        ironclaw_host_runtime::default_host_api_contract_registry().expect("host API contracts");
+
+    let seed_installation = |manifest_toml: &'static str, owner: UserId, extension_id_str: &str| {
+        let manifest_hash = ManifestHash::new(sha256_digest_token(manifest_toml.as_bytes()))
+            .expect("manifest hash");
+        let manifest_record = ExtensionManifestRecord::from_toml_with_contracts(
+            manifest_toml,
+            ManifestSource::UserRegistered { owner },
+            &host_ports,
+            Some(manifest_hash.clone()),
+            &contracts,
+        )
+        .expect("registered manifest record");
+        let extension_id = ExtensionId::new(extension_id_str).expect("valid extension id");
+        let installation = ExtensionInstallation::new(
+            ExtensionInstallationId::new(extension_id_str).expect("valid installation id"),
+            extension_id.clone(),
+            ExtensionActivationState::Enabled,
+            ExtensionManifestRef::new(extension_id.clone(), Some(manifest_hash)),
+            Vec::new(),
+            chrono::Utc::now(),
+        )
+        .expect("owner-registered installation");
+        (manifest_record, installation, extension_id)
+    };
+
+    let (owner_b_manifest_record, owner_b_installation, owner_b_extension_id) =
+        seed_installation(OWNER_B_MANIFEST_TOML, owner_b.clone(), OWNER_B_EXTENSION_ID);
+    let installation_store: Arc<dyn ExtensionInstallationStore> =
+        Arc::new(InMemoryExtensionInstallationStore::default());
+    installation_store
+        .upsert_manifest(owner_b_manifest_record)
+        .await
+        .expect("seed owner B manifest record");
+    installation_store
+        .upsert_installation(owner_b_installation)
+        .await
+        .expect("seed owner B installation");
+
+    // "Reboot": fresh, empty in-memory lifecycle service + active registry,
+    // static catalog empty (T1's boot-leak fix), so restore's only path to
+    // owner B's installation is the any-owner registered-store fallback —
+    // the exact fallback whose directory scan walks over owner A's corrupt
+    // manifest too.
+    let empty_catalog = AvailableExtensionCatalog::from_packages(Vec::new());
+    let lifecycle_service = Arc::new(Mutex::new(ExtensionLifecycleService::new(
+        ExtensionRegistry::new(),
+    )));
+    let active_registry = Arc::new(SharedExtensionRegistry::new(ExtensionRegistry::new()));
+    let trust_policy =
+        Arc::new(HostTrustPolicy::new(vec![Box::new(AdminConfig::new())]).expect("trust policy"));
+    let active_extensions = ActiveExtensionPublisher::new(
+        Arc::clone(&active_registry),
+        Arc::clone(&trust_policy),
+        Arc::new(InvalidationBus::new()),
+    );
+
+    restore_extension_lifecycle_state(
+        &empty_catalog,
+        &filesystem,
+        &installation_store,
+        &lifecycle_service,
+        &active_extensions,
+    )
+    .await
+    .expect(
+        "owner B's boot restore must succeed even though owner A's registered directory (also \
+         walked by the any-owner restore fallback) contains a corrupt manifest.toml (RED until \
+         skip-and-log lands)",
+    );
+
+    assert!(
+        active_registry
+            .snapshot()
+            .get_extension(&owner_b_extension_id)
+            .is_some(),
+        "owner B's registered extension must be published after restore, unaffected by owner \
+         A's corrupt sibling manifest"
     );
 }
 

--- a/crates/ironclaw_reborn_composition/src/extension_host/lifecycle.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/lifecycle.rs
@@ -347,8 +347,9 @@ impl RebornLocalLifecycleFacade {
                 } else {
                     None
                 };
+                let owner = lifecycle_resource_scope(&context)?.user_id;
                 extension_management
-                    .search(&query, credential_gate.as_ref())
+                    .search(&query, credential_gate.as_ref(), Some(&owner))
                     .await
             }
             LifecycleProductAction::ExtensionList => {
@@ -361,7 +362,10 @@ impl RebornLocalLifecycleFacade {
                 let Some(extension_management) = &self.extension_management else {
                     return unsupported_projection(Some(package_ref));
                 };
-                extension_management.install(package_ref).await
+                let owner = lifecycle_resource_scope(&context)?.user_id;
+                extension_management
+                    .install(package_ref, Some(&owner))
+                    .await
             }
             LifecycleProductAction::ExtensionActivate { package_ref } => {
                 let Some(extension_management) = &self.extension_management else {

--- a/crates/ironclaw_reborn_composition/src/extension_host/mod.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/mod.rs
@@ -7,9 +7,11 @@
 //! installation store and lifecycle command/capability stack
 //! (`extension_installation_store`, `extension_lifecycle`,
 //! `extension_lifecycle_capabilities`, `extension_lifecycle_command`,
-//! `lifecycle`, `skill_learning`, `skill_listing`), and MCP discovery
-//! (`mcp`, `mcp_discovery`) behind one internal module. The crate root re-exports
-//! the same public items from here so the crate's public API is unchanged.
+//! `lifecycle`, `skill_learning`, `skill_listing`), owner-scoped
+//! user-registered extension storage (`registered_extension_store`), and MCP
+//! discovery (`mcp`, `mcp_discovery`) behind one internal module. The crate
+//! root re-exports the same public items from here so the crate's public API
+//! is unchanged.
 
 pub(crate) mod available_extensions;
 pub(crate) mod bundled_skills;
@@ -21,11 +23,14 @@ pub(crate) mod extension_lifecycle_capabilities;
 #[cfg(test)]
 pub(crate) mod extension_lifecycle_capabilities_auth_tests;
 pub(crate) mod extension_lifecycle_command;
+#[cfg(test)]
+pub(crate) mod extension_lifecycle_registered_store_tests;
 pub(crate) mod gsuite;
 pub(crate) mod host_api_contracts;
 pub(crate) mod lifecycle;
 pub(crate) mod mcp;
 pub(crate) mod mcp_discovery;
+pub(crate) mod registered_extension_store;
 pub(crate) mod skill_learning;
 pub(crate) mod skill_listing;
 pub(crate) mod webui_extension_credentials;

--- a/crates/ironclaw_reborn_composition/src/extension_host/registered_extension_store.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/registered_extension_store.rs
@@ -1,0 +1,184 @@
+//! Owner-scoped storage and catalog composition for user-registered MCP
+//! extensions. Descriptors live at
+//! `/system/extensions/registered/<owner>/<id>/manifest.toml`.
+//!
+//! **Boot-leak invariant (do not weaken):** the shared, process-wide
+//! `AvailableExtensionCatalog` must never contain a `UserRegistered` package.
+//! Its `search`/`resolve` do no owner filtering, so a registered package
+//! reachable through it is installable by any owner. Every helper here reads
+//! the owner overlay separately and merges at the call site.
+//!
+//! The write side (`put`/`delete`) lands with the register verb in T3.
+
+use ironclaw_extensions::ManifestSource;
+use ironclaw_filesystem::{FileType, FilesystemError, RootFilesystem};
+use ironclaw_host_api::{UserId, VirtualPath};
+use ironclaw_product_workflow::{LifecyclePackageRef, ProductWorkflowError};
+
+use crate::extension_host::available_extensions::{
+    AvailableExtensionCatalog, AvailableExtensionPackage, is_internal_extension_package_ref,
+    load_filesystem_packages, package_matches_search,
+};
+
+const REGISTERED_ROOT: &str = "/system/extensions/registered";
+
+/// True for a package owned by a user's registered store. Such a package must
+/// never be materialized under the shared `/system/extensions/<id>/` directory:
+/// the next boot's catalog scan would re-adopt it as a first-party entry,
+/// reopening the boot leak. Both writers in `extension_lifecycle.rs` (install
+/// and restore) gate on this.
+pub(crate) fn is_owner_registered(source: &ManifestSource) -> bool {
+    matches!(source, ManifestSource::UserRegistered { .. })
+}
+
+/// Owner-scoped read access to user-registered extension manifests.
+pub(crate) struct RegisteredExtensionStore;
+
+impl RegisteredExtensionStore {
+    fn registered_root() -> Result<VirtualPath, ProductWorkflowError> {
+        VirtualPath::new(REGISTERED_ROOT).map_err(map_binding_error)
+    }
+
+    /// `/system/extensions/registered/<owner>` — the directory
+    /// [`load_filesystem_packages`] lists for one owner's registered set.
+    fn owner_root(owner: &UserId) -> Result<VirtualPath, ProductWorkflowError> {
+        VirtualPath::new(format!("{REGISTERED_ROOT}/{}", owner.as_str())).map_err(map_binding_error)
+    }
+
+    /// One owner's registered packages, reusing the shared filesystem
+    /// package parser tagged with `ManifestSource::UserRegistered`.
+    pub(crate) async fn list_for_owner<F>(
+        fs: &F,
+        owner: &UserId,
+    ) -> Result<Vec<AvailableExtensionPackage>, ProductWorkflowError>
+    where
+        F: RootFilesystem + ?Sized,
+    {
+        let root = Self::owner_root(owner)?;
+        load_filesystem_packages(
+            fs,
+            &root,
+            ManifestSource::UserRegistered {
+                owner: owner.clone(),
+            },
+        )
+        .await
+    }
+
+    /// Every owner's registered packages. Boot-time-only concern: an
+    /// `ExtensionInstallation` record carries no owner field yet (plan risk
+    /// 2), so restore's fallback must search across all owners. Never call
+    /// this from the live search/install path, which must stay scoped to
+    /// the calling owner via [`list_for_owner`].
+    pub(crate) async fn list_all<F>(
+        fs: &F,
+    ) -> Result<Vec<AvailableExtensionPackage>, ProductWorkflowError>
+    where
+        F: RootFilesystem + ?Sized,
+    {
+        let root = Self::registered_root()?;
+        let entries = match fs.list_dir(&root).await {
+            Ok(entries) => entries,
+            Err(FilesystemError::NotFound { .. }) | Err(FilesystemError::MountNotFound { .. }) => {
+                return Ok(Vec::new());
+            }
+            Err(error) => {
+                return Err(ProductWorkflowError::Transient {
+                    reason: format!("failed to list registered extension owners: {error}"),
+                });
+            }
+        };
+        let mut packages = Vec::new();
+        for entry in entries {
+            if entry.file_type != FileType::Directory {
+                continue;
+            }
+            let Ok(owner) = UserId::new(entry.name.clone()) else {
+                continue;
+            };
+            packages.extend(Self::list_for_owner(fs, &owner).await?);
+        }
+        Ok(packages)
+    }
+}
+
+fn not_found() -> ProductWorkflowError {
+    ProductWorkflowError::InvalidBindingRequest {
+        reason: "available extension was not found".to_string(),
+    }
+}
+
+fn map_binding_error(error: impl std::fmt::Display) -> ProductWorkflowError {
+    ProductWorkflowError::InvalidBindingRequest {
+        reason: error.to_string(),
+    }
+}
+
+/// The additional (owner-registered) search matches to overlay on top of the
+/// shared catalog's own `catalog.search(query)` results. `owner: None` (no
+/// caller identity — e.g. a boot-time/system caller) contributes no overlay:
+/// registered packages are visible only to their own owner, never to an
+/// unscoped caller.
+pub(crate) async fn search_with_owner_overlay<F>(
+    fs: &F,
+    owner: Option<&UserId>,
+    query: &str,
+) -> Result<Vec<AvailableExtensionPackage>, ProductWorkflowError>
+where
+    F: RootFilesystem + ?Sized,
+{
+    let Some(owner) = owner else {
+        return Ok(Vec::new());
+    };
+    let normalized_query = query.trim().to_ascii_lowercase();
+    let packages = RegisteredExtensionStore::list_for_owner(fs, owner).await?;
+    Ok(packages
+        .into_iter()
+        .filter(|package| !is_internal_extension_package_ref(&package.package_ref))
+        .filter(|package| package_matches_search(package, &normalized_query))
+        .collect())
+}
+
+/// Resolve one package by ref: shared first-party catalog first, then `owner`'s
+/// registered set. `owner: None` is a caller with no owner scope (the boot-time
+/// NEAR AI bootstrap installer) and can reach first-party packages only.
+pub(crate) async fn resolve_with_owner_overlay<F>(
+    catalog: &AvailableExtensionCatalog,
+    fs: &F,
+    owner: Option<&UserId>,
+    package_ref: &LifecyclePackageRef,
+) -> Result<AvailableExtensionPackage, ProductWorkflowError>
+where
+    F: RootFilesystem + ?Sized,
+{
+    if let Ok(available) = catalog.resolve(package_ref) {
+        return Ok(available.clone());
+    }
+    let Some(owner) = owner else {
+        return Err(not_found());
+    };
+    let owner_packages = RegisteredExtensionStore::list_for_owner(fs, owner).await?;
+    owner_packages
+        .into_iter()
+        .find(|package| &package.package_ref == package_ref)
+        .ok_or_else(not_found)
+}
+
+/// Boot-only restore fallback, reached on a `catalog.resolve()` miss during
+/// `restore_extension_lifecycle_state`. Deliberately any-owner because
+/// installations carry no owner field yet; never call it from a live
+/// search/install path, which must stay scoped via
+/// [`resolve_with_owner_overlay`].
+pub(crate) async fn resolve_any_owner_for_restore<F>(
+    fs: &F,
+    package_ref: &LifecyclePackageRef,
+) -> Result<AvailableExtensionPackage, ProductWorkflowError>
+where
+    F: RootFilesystem + ?Sized,
+{
+    let packages = RegisteredExtensionStore::list_all(fs).await?;
+    packages
+        .into_iter()
+        .find(|package| &package.package_ref == package_ref)
+        .ok_or_else(not_found)
+}

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -5949,7 +5949,7 @@ mod tests {
                 .expect("valid ref");
 
         extension_management
-            .install(gmail_ref.clone())
+            .install(gmail_ref.clone(), None)
             .await
             .expect("install Gmail");
         extension_management
@@ -5960,7 +5960,7 @@ mod tests {
             .await
             .expect("activate Gmail");
         extension_management
-            .install(calendar_ref.clone())
+            .install(calendar_ref.clone(), None)
             .await
             .expect("install Google Calendar");
         extension_management
@@ -6087,7 +6087,7 @@ mod tests {
         assert!(capability_ids.contains(&"notion.notion-get-self"));
 
         extension_management
-            .install(notion_ref.clone())
+            .install(notion_ref.clone(), None)
             .await
             .expect("install Notion MCP");
         extension_management
@@ -6143,7 +6143,7 @@ mod tests {
                 .expect("valid ref");
 
         extension_management
-            .install(web_access_ref.clone())
+            .install(web_access_ref.clone(), None)
             .await
             .expect("install Web Access");
         extension_management

--- a/crates/ironclaw_reborn_composition/src/llm_admin/nearai_mcp.rs
+++ b/crates/ironclaw_reborn_composition/src/llm_admin/nearai_mcp.rs
@@ -324,7 +324,7 @@ pub(crate) async fn bootstrap_nearai_mcp(
 
     if phase == LifecyclePhase::Discovered {
         extension_management
-            .install(package_ref.clone())
+            .install(package_ref.clone(), None)
             .await
             .map_err(|error| RebornBuildError::InvalidConfig {
                 reason: format!("NEAR AI MCP extension install failed: {error}"),

--- a/crates/ironclaw_reborn_composition/src/observability/hooks/projection.rs
+++ b/crates/ironclaw_reborn_composition/src/observability/hooks/projection.rs
@@ -65,7 +65,7 @@ impl HookProjection {
         Some(Self {
             extension_id: package.manifest.id.clone(),
             version: package.manifest.version.clone(),
-            source: package.manifest.source,
+            source: package.manifest.source.clone(),
             root: package.root.clone(),
             hooks: package.manifest.hooks.clone(),
         })

--- a/crates/ironclaw_reborn_composition/src/observability/hooks/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/observability/hooks/tests.rs
@@ -285,7 +285,7 @@ fn projection_with(packages: &[(&str, ManifestSource, String)]) -> HookProjectio
     for (id, source, hooks_block) in packages {
         let manifest = ExtensionManifest::parse(
             &manifest_toml(id, hooks_block),
-            *source,
+            source.clone(),
             &HostPortCatalog::empty(),
         )
         .expect("manifest parses");
@@ -581,7 +581,7 @@ fn surplus_extensions_beyond_consider_cap_are_quarantined() {
     }
     let refs: Vec<(&str, ManifestSource, String)> = packages
         .iter()
-        .map(|(id, src, hooks)| (id.as_str(), *src, hooks.clone()))
+        .map(|(id, src, hooks)| (id.as_str(), src.clone(), hooks.clone()))
         .collect();
     let registry = projection_with(&refs);
 

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -7597,7 +7597,7 @@ output_schema_ref = "schemas/write.output.json"
         let notion_ref = LifecyclePackageRef::new(LifecyclePackageKind::Extension, "notion")
             .expect("valid notion ref");
         extension_management
-            .install(notion_ref.clone())
+            .install(notion_ref.clone(), None)
             .await
             .expect("install Notion MCP");
         extension_management

--- a/tests/integration/group_multiuser/main.rs
+++ b/tests/integration/group_multiuser/main.rs
@@ -16,6 +16,7 @@ mod reborn_support;
 mod support;
 
 mod scenario_auto_approve_isolation_across_actors;
+mod scenario_extension_registration_isolation_across_actors;
 mod scenario_memory_isolation_across_actors;
 mod scenario_turn_state_isolation_across_actors;
 mod scenario_two_actors_own_threads;
@@ -64,6 +65,19 @@ async fn multiuser_group_e2e() {
     report.record(
         "turn_state_isolation_across_actors",
         scenario_turn_state_isolation_across_actors::run(&g).await,
+    );
+
+    // Scenario 5 (MCP-registration spec test #2): per-user extension-registration
+    // isolation — see scenario_extension_registration_isolation_across_actors for
+    // the seam. RED until T1 (docs/plans/2026-07-08-mcp-reg-t1-plan.md).
+    let extension_registration_group =
+        RebornIntegrationGroup::multiuser_extension_lifecycle_tools()
+            .await
+            .expect("multiuser extension-lifecycle group builds");
+    report.record(
+        "extension_registration_isolation_across_actors",
+        scenario_extension_registration_isolation_across_actors::run(&extension_registration_group)
+            .await,
     );
 
     report.assert_all_passed();

--- a/tests/integration/group_multiuser/scenario_extension_registration_isolation_across_actors.rs
+++ b/tests/integration/group_multiuser/scenario_extension_registration_isolation_across_actors.rs
@@ -1,0 +1,167 @@
+//! MCP-registration spec test #2 (per-user isolation), RED for T1
+//! (docs/plans/2026-07-08-mcp-reg-t1-plan.md): actor A registers an MCP server
+//! descriptor; actor B must not see it in search or be able to install it.
+//! `RegisteredExtensionStore::put()` doesn't exist yet, so the descriptor is
+//! seeded by writing `manifest.toml` directly onto the harness's on-disk
+//! `/system/extensions/registered/<owner>/<id>/` tree — the same physical
+//! layout `load_filesystem_packages` reads for `/system/extensions/<id>/`,
+//! one level shallower (`extension_host/available_extensions.rs`). Drives the
+//! AGENT path (`builtin.extension_search`/`builtin.extension_install` via real
+//! `submit_turn`s) through `ExtensionLifecycleToolHandler::dispatch`
+//! (`extension_lifecycle_capabilities.rs`), the load-bearing caller the T1
+//! review flagged as easy to miss.
+
+use super::reborn_support::assertions::ToolErrorClass;
+use super::reborn_support::group::{HarnessResult, RebornIntegrationGroup};
+use super::reborn_support::reply::RebornScriptedReply;
+use serde_json::json;
+
+/// Distinctive id/name only the seeded fixture carries — a search hit is
+/// unambiguous evidence the registered descriptor was surfaced.
+const REGISTERED_EXTENSION_ID: &str = "acme-mcp-registered";
+
+const REGISTERED_MANIFEST_TOML: &str = r#"
+schema_version = "reborn.extension_manifest.v2"
+id = "acme-mcp-registered"
+name = "Acme Support MCP"
+version = "0.1.0"
+description = "User-registered hosted MCP server (T1 fixture)"
+trust = "third_party"
+
+[runtime]
+kind = "mcp"
+transport = "http"
+url = "http://127.0.0.1:9/mcp"
+"#;
+
+pub async fn run(g: &RebornIntegrationGroup) -> HarnessResult<()> {
+    // ── Actor A (default actor) ──────────────────────────────────────────────
+    let a = g
+        .thread("conv-ext-reg-iso-a-search")
+        .script([
+            RebornScriptedReply::tool_call(
+                "builtin.extension_search",
+                json!({ "query": REGISTERED_EXTENSION_ID }),
+            ),
+            RebornScriptedReply::text("searched"),
+        ])
+        .build()
+        .await?;
+
+    // ── Seed: write A's registered manifest onto the shared on-disk tree ─────
+    // Production `RegisteredExtensionStore::put()` (T1) does not exist yet;
+    // this is the filesystem seam it will write through.
+    let capability_harness = g.capability_harness().ok_or(
+        "multiuser_extension_lifecycle_tools group must wire a HostRuntime capability harness",
+    )?;
+    let owner_user_id = a
+        .binding
+        .subject_user_id
+        .as_ref()
+        .ok_or("actor A's resolved binding has no subject_user_id")?;
+    let manifest_dir = capability_harness.storage_root_for_test().join(format!(
+        "system/extensions/registered/{}/{}",
+        owner_user_id.as_str(),
+        REGISTERED_EXTENSION_ID
+    ));
+    std::fs::create_dir_all(&manifest_dir)
+        .map_err(|e| format!("[seed] create registered manifest dir: {e}"))?;
+    std::fs::write(manifest_dir.join("manifest.toml"), REGISTERED_MANIFEST_TOML)
+        .map_err(|e| format!("[seed] write registered manifest: {e}"))?;
+
+    // ── A searches: the owner's own registered server must be discoverable ──
+    a.submit_turn("search for my registered acme MCP server")
+        .await
+        .map_err(|e| format!("[A search submit] {e}"))?;
+    a.assert_tool_invoked("builtin.extension_search")
+        .await
+        .map_err(|e| format!("[A search invoked] {e}"))?;
+    // RED: nothing today reads `/system/extensions/registered/...` — this is
+    // the missing overlay `search()` (T1) must add.
+    a.assert_tool_result_contains(REGISTERED_EXTENSION_ID)
+        .await
+        .map_err(|e| {
+            format!(
+                "[RED, expected until T1] owner A's search did not surface its own \
+                 registered extension {REGISTERED_EXTENSION_ID}: {e}"
+            )
+        })?;
+
+    // ── Actor B (DISTINCT actor, SAME shared backend) ────────────────────────
+    // Built AFTER A's search so B's capability-result baseline
+    // (`baseline_result_count`, captured at `.build()`) starts past A's search
+    // result. The group's capability recorder is shared and the isolation
+    // assertion below reads the `[baseline..]` delta; building B first would
+    // fold A's result into B's slice and mask real isolation. Mirrors the
+    // sibling `scenario_memory_isolation_across_actors`, which likewise builds
+    // actor B only after actor A's write.
+    let b_search = g
+        .thread("conv-ext-reg-iso-b-search")
+        .with_actor_id("reborn-actor-b")
+        .script([
+            RebornScriptedReply::tool_call(
+                "builtin.extension_search",
+                json!({ "query": REGISTERED_EXTENSION_ID }),
+            ),
+            RebornScriptedReply::text("searched"),
+        ])
+        .build()
+        .await?;
+    // Non-vacuity: if `with_actor_id` regressed to a no-op, both actors would
+    // share one owner and the isolation pins below would trivially "pass".
+    if a.binding.subject_user_id == b_search.binding.subject_user_id {
+        return Err("with_actor_id seam no-op: both actors resolved the same owner".into());
+    }
+
+    // ── B searches: must NOT see A's registered server ───────────────────────
+    b_search
+        .submit_turn("search for my registered acme MCP server")
+        .await
+        .map_err(|e| format!("[B search submit] {e}"))?;
+    b_search
+        .assert_tool_invoked("builtin.extension_search")
+        .await
+        .map_err(|e| format!("[B search invoked] {e}"))?;
+    if b_search
+        .assert_tool_result_contains(REGISTERED_EXTENSION_ID)
+        .await
+        .is_ok()
+    {
+        return Err(format!(
+            "isolation failure: actor B's extension_search surfaced actor A's \
+             registered extension {REGISTERED_EXTENSION_ID}"
+        )
+        .into());
+    }
+
+    // ── B installs A's package id: must fail, not silently succeed ──────────
+    let b_install = g
+        .thread("conv-ext-reg-iso-b-install")
+        .with_actor_id("reborn-actor-b")
+        .script([
+            RebornScriptedReply::tool_call(
+                "builtin.extension_install",
+                json!({ "extension_id": REGISTERED_EXTENSION_ID }),
+            ),
+            RebornScriptedReply::text("install attempted"),
+        ])
+        .build()
+        .await?;
+    b_install
+        .submit_turn(&format!("install {REGISTERED_EXTENSION_ID}"))
+        .await
+        .map_err(|e| format!("[B install submit] {e}"))?;
+    b_install
+        .assert_tool_invoked("builtin.extension_install")
+        .await
+        .map_err(|e| format!("[B install invoked] {e}"))?;
+    // Same `catalog.resolve()`-miss reason `scenario_install_unknown_extension_id_fails_safely`
+    // pins for an unknown id — B's view of A's registered id must resolve the
+    // same way (not found), never silently install.
+    b_install
+        .assert_tool_error(ToolErrorClass::Failed, "invalid_input")
+        .await
+        .map_err(|e| format!("[B install must fail, not silently succeed] {e}"))?;
+
+    Ok(())
+}

--- a/tests/integration/support/group_constructors.rs
+++ b/tests/integration/support/group_constructors.rs
@@ -143,6 +143,20 @@ impl RebornIntegrationGroup {
         Self::builder().multiuser_memory_tools().await
     }
 
+    /// C-MULTIUSER variant of [`extension_lifecycle`](Self::extension_lifecycle):
+    /// same capability surface (extension_search/install/activate/remove) with
+    /// **per-actor capability scoping** (`with_run_owner_scoped_capability_dispatch`),
+    /// so `builtin.extension_search`/`builtin.extension_install` dispatch under
+    /// each thread's OWN run owner instead of the group's single fixed
+    /// constructor user. Needed for MCP-registration per-user isolation
+    /// (`scenario_extension_registration_isolation_across_actors`) — without the
+    /// flag every actor's extension-lifecycle calls collapse onto one shared
+    /// `(tenant, user)` scope, which would make an owner-scoped registered-store
+    /// test vacuous.
+    pub async fn multiuser_extension_lifecycle_tools() -> HarnessResult<Self> {
+        Self::builder().multiuser_extension_lifecycle_tools().await
+    }
+
     /// C-MULTIUSER: file-approval tools (write_file/read_file @ `Ask`) with
     /// **per-actor capability scoping**. A grant via
     /// [`RebornIntegrationGroup::enable_auto_approve_for_owner`] and an explicit
@@ -386,6 +400,20 @@ impl RebornIntegrationGroupBuilder {
             super::super::harness::profiles::core_builtin::core_builtin_tools_default()
                 .await?
                 .with_run_owner_scoped_capability_dispatch();
+        let capability = GroupCapability::HostRuntime(Arc::new(host_runtime));
+        self.build_with_capability(capability).await
+    }
+
+    /// Per-actor-scoped extension-lifecycle group. See
+    /// [`RebornIntegrationGroup::multiuser_extension_lifecycle_tools`]. Same
+    /// capability surface as [`extension_lifecycle`](Self::extension_lifecycle)
+    /// but with per-actor capability dispatch.
+    pub async fn multiuser_extension_lifecycle_tools(
+        self,
+    ) -> HarnessResult<RebornIntegrationGroup> {
+        let host_runtime = super::super::harness::profiles::extension::extension_lifecycle_tools()
+            .await?
+            .with_run_owner_scoped_capability_dispatch();
         let capability = GroupCapability::HostRuntime(Arc::new(host_runtime));
         self.build_with_capability(capability).await
     }


### PR DESCRIPTION
## Summary

Adds the tenant-scoped registered-MCP extension store and catalog foundation.

- stores registered server identity and endpoint metadata without exposing capabilities
- keeps malformed manifests and cross-tenant access fail-closed
- wires zero-capability registered entries into extension visibility/lifecycle boundaries
- preserves PostgreSQL/libSQL parity and existing extension lifecycle behavior

## Validation

Targeted composition, extension, lifecycle, and WebUI tests passed; formatting and diff checks are clean.

## Stack

This is the base PR for the MCP registration stack. T2 and T3 are based on this branch.