### PR TITLE
ci: reuse tested Reborn binary in live canary

### DIFF
--- a/.github/workflows/live-canary.yml
+++ b/.github/workflows/live-canary.yml
@@ -741,21 +741,12 @@ jobs:
           - shard_id: qa-2-workflow
             shard_name: QA 2D-2F
             cases: qa_2d_calendar_prep_live_chat,qa_2e_calendar_prep_email_routine,qa_2f_calendar_prep_email_delivery
-          - shard_id: qa-3-chat
-            shard_name: QA 3A-3B
-            cases: qa_3a_slack_connect,qa_3b_endpoint_status_live_chat
-          - shard_id: qa-3-routine
-            shard_name: QA 3C
-            cases: qa_3c_endpoint_status_slack_routine
-          - shard_id: qa-3-delivery
-            shard_name: QA 3D
-            cases: qa_3d_endpoint_status_slack_delivery
-          - shard_id: qa-4-summary
-            shard_name: QA 4A-4C
-            cases: qa_4a_gmail_connect,qa_4b_github_connect,qa_4c_github_release_live_chat
-          - shard_id: qa-4-automation
-            shard_name: QA 4D-4E
-            cases: qa_4d_github_release_slack_routine,qa_4e_github_release_email_delivery
+          - shard_id: qa-3
+            shard_name: QA 3
+            cases: qa_3a_slack_connect,qa_3b_endpoint_status_live_chat,qa_3c_endpoint_status_slack_routine,qa_3d_endpoint_status_slack_delivery
+          - shard_id: qa-4
+            shard_name: QA 4
+            cases: qa_4a_gmail_connect,qa_4b_github_connect,qa_4c_github_release_live_chat,qa_4d_github_release_slack_routine,qa_4e_github_release_email_delivery
           - shard_id: qa-5
             shard_name: QA 5
             cases: qa_5a_slack_connect,qa_5b_drive_connect,qa_5c_strategy_doc_knowledge_base,qa_5d_slack_strategy_doc_answer

--- a/.github/workflows/live-canary.yml
+++ b/.github/workflows/live-canary.yml
@@ -604,7 +604,7 @@ jobs:
           set -euo pipefail
           artifact_name="reborn-webui-v2-binary-${TARGET_REF}"
           workflow_id="$(gh api "repos/${REPO}/actions/workflows/reborn-e2e.yml" --jq '.id')"
-          mkdir -p .live-qa-binary
+          mkdir -p artifacts/prepared-reborn-webui-v2-binary
           echo "found=0" >> "${GITHUB_OUTPUT}"
 
           for attempt in $(seq 1 20); do
@@ -644,13 +644,13 @@ jobs:
             fi
 
             gh api "repos/${REPO}/actions/artifacts/${artifact_id}/zip" > "${RUNNER_TEMP}/reborn-webui-v2-binary.zip"
-            unzip -q "${RUNNER_TEMP}/reborn-webui-v2-binary.zip" -d .live-qa-binary
-            (cd .live-qa-binary && sha256sum --check ironclaw-reborn.tar.gz.sha256)
+            unzip -q "${RUNNER_TEMP}/reborn-webui-v2-binary.zip" -d artifacts/prepared-reborn-webui-v2-binary
+            (cd artifacts/prepared-reborn-webui-v2-binary && sha256sum --check ironclaw-reborn.tar.gz.sha256)
             jq -e \
               --arg product_ref "${TARGET_REF}" \
               --arg features "webui-v2-beta,slack-v2-host-beta" \
               '.format_version == 1 and .product_ref == $product_ref and .features == $features' \
-              .live-qa-binary/manifest.json > /dev/null
+              artifacts/prepared-reborn-webui-v2-binary/manifest.json > /dev/null
             echo "found=1" >> "${GITHUB_OUTPUT}"
             echo "source=reborn-e2e" >> "${GITHUB_OUTPUT}"
             echo "Using tested Reborn E2E binary from run ${run_id}."
@@ -698,25 +698,25 @@ jobs:
           TARGET_REF: ${{ steps.target.outputs.checkout_ref }}
         run: |
           set -euo pipefail
-          rm -rf .live-qa-binary
-          mkdir -p .live-qa-binary
-          tar -C target/debug -czf .live-qa-binary/ironclaw-reborn.tar.gz ironclaw-reborn
+          rm -rf artifacts/prepared-reborn-webui-v2-binary
+          mkdir -p artifacts/prepared-reborn-webui-v2-binary
+          tar -C target/debug -czf artifacts/prepared-reborn-webui-v2-binary/ironclaw-reborn.tar.gz ironclaw-reborn
           (
-            cd .live-qa-binary
+            cd artifacts/prepared-reborn-webui-v2-binary
             sha256sum ironclaw-reborn.tar.gz > ironclaw-reborn.tar.gz.sha256
           )
           jq -n \
             --arg product_ref "${TARGET_REF}" \
             --arg features "webui-v2-beta,slack-v2-host-beta" \
             '{format_version: 1, product_ref: $product_ref, features: $features}' \
-            > .live-qa-binary/manifest.json
+            > artifacts/prepared-reborn-webui-v2-binary/manifest.json
           echo "source=canary-fallback" >> "${GITHUB_OUTPUT}"
 
       - name: Upload prepared Reborn WebUI v2 binary
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: prepared-reborn-webui-v2-binary-${{ steps.target.outputs.checkout_ref }}
-          path: .live-qa-binary/
+          path: artifacts/prepared-reborn-webui-v2-binary/
           if-no-files-found: error
           retention-days: 1
 

--- a/.github/workflows/live-canary.yml
+++ b/.github/workflows/live-canary.yml
@@ -542,8 +542,187 @@ jobs:
           path: artifacts/live-canary/
           retention-days: 14
 
+  prepare-reborn-webui-v2-live-qa:
+    name: Prepare Reborn WebUI v2 live QA binary
+    if: >
+      (github.event_name == 'schedule' && github.event.schedule == '0 */3 * * *') ||
+      (github.event_name == 'workflow_dispatch' && (inputs.lane == 'all' || inputs.lane == 'reborn-webui-v2-live-qa'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: read
+    outputs:
+      checkout_ref: ${{ steps.target.outputs.checkout_ref }}
+      build_source: ${{ steps.lookup.outputs.source || steps.fallback.outputs.source }}
+    steps:
+      - name: Resolve and validate Reborn WebUI v2 target
+        id: target
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          TARGET_PR: ${{ inputs.target_pr }}
+          TARGET_REF: ${{ inputs.target_ref }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${TARGET_REF}" ]]; then
+            echo "checkout_ref=${GITHUB_SHA}" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          if ! [[ "${TARGET_REF}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::target_ref must be a full commit SHA for reborn-webui-v2-live-qa."
+            exit 1
+          fi
+          if ! [[ "${TARGET_PR}" =~ ^[0-9]+$ ]]; then
+            echo "::error::target_pr is required when target_ref is supplied for reborn-webui-v2-live-qa."
+            exit 1
+          fi
+          pr_json="$(gh pr view "${TARGET_PR}" --repo "${REPO}" --json isCrossRepository,headRefOid)"
+          if [[ "$(jq -r '.isCrossRepository' <<< "${pr_json}")" == "true" ]]; then
+            echo "::error::Refusing to run reborn-webui-v2-live-qa with live secrets on a forked PR."
+            exit 1
+          fi
+          if [[ "$(jq -r '.headRefOid' <<< "${pr_json}")" != "${TARGET_REF}" ]]; then
+            echo "::error::target_ref does not match PR #${TARGET_PR} head SHA."
+            exit 1
+          fi
+          echo "checkout_ref=${TARGET_REF}" >> "${GITHUB_OUTPUT}"
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+          ref: ${{ steps.target.outputs.checkout_ref }}
+
+      - name: Find successful Reborn E2E binary for target SHA
+        id: lookup
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          TARGET_REF: ${{ steps.target.outputs.checkout_ref }}
+        run: |
+          set -euo pipefail
+          artifact_name="reborn-webui-v2-binary-${TARGET_REF}"
+          workflow_id="$(gh api "repos/${REPO}/actions/workflows/reborn-e2e.yml" --jq '.id')"
+          mkdir -p .live-qa-binary
+          echo "found=0" >> "${GITHUB_OUTPUT}"
+
+          for attempt in $(seq 1 20); do
+            runs="$(gh api --method GET "repos/${REPO}/actions/workflows/${workflow_id}/runs" \
+              -f head_sha="${TARGET_REF}" -f per_page=10)"
+            run="$(jq -c '[.workflow_runs[] | select(.head_sha == $sha)] | sort_by(.created_at) | reverse | .[0] // empty' \
+              --arg sha "${TARGET_REF}" <<< "${runs}")"
+            if [[ -z "${run}" ]]; then
+              if [[ ${attempt} -le 2 ]]; then
+                echo "No Reborn E2E run exists for ${TARGET_REF} yet; waiting for CI to start (${attempt}/2)."
+                sleep 15
+                continue
+              fi
+              echo "No Reborn E2E run exists for ${TARGET_REF}; using the canary fallback build."
+              exit 0
+            fi
+
+            status="$(jq -r '.status' <<< "${run}")"
+            conclusion="$(jq -r '.conclusion // ""' <<< "${run}")"
+            run_id="$(jq -r '.id' <<< "${run}")"
+            if [[ "${status}" != "completed" ]]; then
+              echo "Reborn E2E run ${run_id} is ${status}; waiting for its tested binary (${attempt}/20)."
+              sleep 15
+              continue
+            fi
+            if [[ "${conclusion}" != "success" ]]; then
+              echo "Reborn E2E run ${run_id} concluded ${conclusion}; using the canary fallback build."
+              exit 0
+            fi
+
+            artifacts="$(gh api --method GET "repos/${REPO}/actions/runs/${run_id}/artifacts" -f per_page=100)"
+            artifact_id="$(jq -r '[.artifacts[] | select(.expired == false and .name == $name)] | .[0].id // empty' \
+              --arg name "${artifact_name}" <<< "${artifacts}")"
+            if [[ -z "${artifact_id}" ]]; then
+              echo "Successful Reborn E2E run ${run_id} has no ${artifact_name}; using the canary fallback build."
+              exit 0
+            fi
+
+            gh api "repos/${REPO}/actions/artifacts/${artifact_id}/zip" > "${RUNNER_TEMP}/reborn-webui-v2-binary.zip"
+            unzip -q "${RUNNER_TEMP}/reborn-webui-v2-binary.zip" -d .live-qa-binary
+            (cd .live-qa-binary && sha256sum --check ironclaw-reborn.tar.gz.sha256)
+            jq -e \
+              --arg product_ref "${TARGET_REF}" \
+              --arg features "webui-v2-beta,slack-v2-host-beta" \
+              '.format_version == 1 and .product_ref == $product_ref and .features == $features' \
+              .live-qa-binary/manifest.json > /dev/null
+            echo "found=1" >> "${GITHUB_OUTPUT}"
+            echo "source=reborn-e2e" >> "${GITHUB_OUTPUT}"
+            echo "Using tested Reborn E2E binary from run ${run_id}."
+            exit 0
+          done
+
+          echo "Reborn E2E did not finish within five minutes; using the canary fallback build."
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        if: steps.lookup.outputs.found != '1'
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        if: steps.lookup.outputs.found != '1'
+        with:
+          key: live-canary-reborn-webui-v2-live-qa
+
+      - name: Setup OVH sccache
+        if: steps.lookup.outputs.found != '1'
+        uses: ./.github/actions/setup-sccache-dist
+        with:
+          scheduler-url: ${{ vars.SCCACHE_DIST_SCHEDULER_URL }}
+          auth-token: ${{ secrets.SCCACHE_DIST_AUTH_TOKEN }}
+          cache-ssh-host: ${{ vars.SCCACHE_CACHE_SSH_HOST }}
+          cache-ssh-user: ${{ vars.SCCACHE_CACHE_SSH_USER }}
+          cache-ssh-port: ${{ vars.SCCACHE_CACHE_SSH_PORT }}
+          cache-ssh-private-key: ${{ secrets.SCCACHE_CACHE_SSH_PRIVATE_KEY }}
+          cache-ssh-known-hosts: ${{ secrets.SCCACHE_CACHE_SSH_KNOWN_HOSTS }}
+          redis-password: ${{ secrets.SCCACHE_REDIS_PASSWORD }}
+
+      - name: Build fallback Reborn WebUI v2 binary once
+        if: steps.lookup.outputs.found != '1'
+        env:
+          CARGO_INCREMENTAL: "0"
+          CARGO_PROFILE_DEV_DEBUG: "0"
+        run: >-
+          cargo build
+          -p ironclaw_reborn_cli
+          --features webui-v2-beta,slack-v2-host-beta
+          --bin ironclaw-reborn
+
+      - name: Package fallback Reborn WebUI v2 binary
+        id: fallback
+        if: steps.lookup.outputs.found != '1'
+        env:
+          TARGET_REF: ${{ steps.target.outputs.checkout_ref }}
+        run: |
+          set -euo pipefail
+          rm -rf .live-qa-binary
+          mkdir -p .live-qa-binary
+          tar -C target/debug -czf .live-qa-binary/ironclaw-reborn.tar.gz ironclaw-reborn
+          (
+            cd .live-qa-binary
+            sha256sum ironclaw-reborn.tar.gz > ironclaw-reborn.tar.gz.sha256
+          )
+          jq -n \
+            --arg product_ref "${TARGET_REF}" \
+            --arg features "webui-v2-beta,slack-v2-host-beta" \
+            '{format_version: 1, product_ref: $product_ref, features: $features}' \
+            > .live-qa-binary/manifest.json
+          echo "source=canary-fallback" >> "${GITHUB_OUTPUT}"
+
+      - name: Upload prepared Reborn WebUI v2 binary
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: prepared-reborn-webui-v2-binary-${{ steps.target.outputs.checkout_ref }}
+          path: .live-qa-binary/
+          if-no-files-found: error
+          retention-days: 1
+
   reborn-webui-v2-live-qa:
     name: Reborn WebUI v2 Live QA (${{ matrix.shard_name }})
+    needs: prepare-reborn-webui-v2-live-qa
     if: >
       (github.event_name == 'schedule' && github.event.schedule == '0 */3 * * *') ||
       (github.event_name == 'workflow_dispatch' && (inputs.lane == 'all' || inputs.lane == 'reborn-webui-v2-live-qa'))
@@ -657,46 +836,11 @@ jobs:
               echo "Running requested cases in this shard: ${joined}"
             fi
           fi
-      - name: Validate Reborn WebUI v2 live QA target ref
-        id: validate_reborn_webui_v2_target
-        if: steps.resolve_reborn_webui_v2_cases.outputs.skip_shard != '1' && github.event_name == 'workflow_dispatch' && inputs.target_ref != ''
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-          TARGET_PR: ${{ inputs.target_pr }}
-          TARGET_REF: ${{ inputs.target_ref }}
-        run: |
-          set -euo pipefail
-          if ! [[ "${TARGET_REF}" =~ ^[0-9a-f]{40}$ ]]; then
-            echo "::error::target_ref must be a full commit SHA for reborn-webui-v2-live-qa."
-            exit 1
-          fi
-          if ! [[ "${TARGET_PR}" =~ ^[0-9]+$ ]]; then
-            echo "::error::target_pr is required when target_ref is supplied for reborn-webui-v2-live-qa."
-            exit 1
-          fi
-          pr_json="$(gh pr view "${TARGET_PR}" --repo "${REPO}" --json isCrossRepository,headRefOid)"
-          is_cross_repository="$(jq -r '.isCrossRepository' <<< "${pr_json}")"
-          head_sha="$(jq -r '.headRefOid' <<< "${pr_json}")"
-          if [[ "${is_cross_repository}" == "true" ]]; then
-            echo "::error::Refusing to run reborn-webui-v2-live-qa with live secrets on a forked PR."
-            exit 1
-          fi
-          if [[ "${head_sha}" != "${TARGET_REF}" ]]; then
-            echo "::error::target_ref does not match PR #${TARGET_PR} head SHA."
-            exit 1
-          fi
-          echo "checkout_ref=${TARGET_REF}" >> "${GITHUB_OUTPUT}"
-      - name: Resolve default Reborn WebUI v2 live QA checkout ref
-        id: default_reborn_webui_v2_target
-        if: steps.resolve_reborn_webui_v2_cases.outputs.skip_shard != '1' && (github.event_name != 'workflow_dispatch' || inputs.target_ref == '')
-        run: |
-          echo "checkout_ref=${GITHUB_SHA}" >> "${GITHUB_OUTPUT}"
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         if: steps.resolve_reborn_webui_v2_cases.outputs.skip_shard != '1'
         with:
           persist-credentials: false
-          ref: ${{ steps.validate_reborn_webui_v2_target.outputs.checkout_ref || steps.default_reborn_webui_v2_target.outputs.checkout_ref }}
+          ref: ${{ needs.prepare-reborn-webui-v2-live-qa.outputs.checkout_ref }}
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         if: >
           steps.resolve_reborn_webui_v2_cases.outputs.skip_shard != '1' &&
@@ -725,36 +869,34 @@ jobs:
           cp .canonical-live-qa-harness/tests/e2e/ironclaw_e2e.egg-info/requires.txt tests/e2e/ironclaw_e2e.egg-info/requires.txt
           rm -rf .canonical-live-qa-harness
           echo "REBORN_WEBUI_V2_LIVE_QA_HARNESS_REF=${harness_ref}" >> "${GITHUB_ENV}"
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-        if: steps.resolve_reborn_webui_v2_cases.outputs.skip_shard != '1'
-        with:
-          targets: wasm32-wasip2
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         if: steps.resolve_reborn_webui_v2_cases.outputs.skip_shard != '1'
         with:
           python-version: "3.12"
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - name: Download prepared Reborn WebUI v2 binary
         if: steps.resolve_reborn_webui_v2_cases.outputs.skip_shard != '1'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
-          key: live-canary-reborn-webui-v2-live-qa
-      - name: Setup OVH sccache
+          name: prepared-reborn-webui-v2-binary-${{ needs.prepare-reborn-webui-v2-live-qa.outputs.checkout_ref }}
+          path: .live-qa-binary
+
+      - name: Verify and install prepared Reborn WebUI v2 binary
         if: steps.resolve_reborn_webui_v2_cases.outputs.skip_shard != '1'
-        uses: ./.github/actions/setup-sccache-dist
-        with:
-          scheduler-url: ${{ vars.SCCACHE_DIST_SCHEDULER_URL }}
-          auth-token: ${{ secrets.SCCACHE_DIST_AUTH_TOKEN }}
-          cache-ssh-host: ${{ vars.SCCACHE_CACHE_SSH_HOST }}
-          cache-ssh-user: ${{ vars.SCCACHE_CACHE_SSH_USER }}
-          cache-ssh-port: ${{ vars.SCCACHE_CACHE_SSH_PORT }}
-          cache-ssh-private-key: ${{ secrets.SCCACHE_CACHE_SSH_PRIVATE_KEY }}
-          cache-ssh-known-hosts: ${{ secrets.SCCACHE_CACHE_SSH_KNOWN_HOSTS }}
-          redis-password: ${{ secrets.SCCACHE_REDIS_PASSWORD }}
-      - name: Install cargo-component
-        if: steps.resolve_reborn_webui_v2_cases.outputs.skip_shard != '1'
-        run: cargo install cargo-component --locked || true
-      - name: Build WASM channels
-        if: steps.resolve_reborn_webui_v2_cases.outputs.skip_shard != '1'
-        run: ./scripts/build-wasm-extensions.sh --channels
+        env:
+          TARGET_REF: ${{ needs.prepare-reborn-webui-v2-live-qa.outputs.checkout_ref }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "${TARGET_REF}"
+          (cd .live-qa-binary && sha256sum --check ironclaw-reborn.tar.gz.sha256)
+          jq -e \
+            --arg product_ref "${TARGET_REF}" \
+            --arg features "webui-v2-beta,slack-v2-host-beta" \
+            '.format_version == 1 and .product_ref == $product_ref and .features == $features' \
+            .live-qa-binary/manifest.json > /dev/null
+          mkdir -p target/debug
+          tar -C target/debug -xzf .live-qa-binary/ironclaw-reborn.tar.gz
+          chmod 755 target/debug/ironclaw-reborn
       - name: Materialize Reborn WebUI v2 live QA sensitive secrets to files
         if: steps.resolve_reborn_webui_v2_cases.outputs.skip_shard != '1'
         shell: bash
@@ -807,6 +949,8 @@ jobs:
           PROVIDER: reborn-webui-v2-${{ matrix.shard_id }}
           COMMAND_TIMEOUT: 90m
           PLAYWRIGHT_INSTALL: with-deps
+          REBORN_WEBUI_V2_LIVE_QA_BUILD_SOURCE: ${{ needs.prepare-reborn-webui-v2-live-qa.outputs.build_source }}
+          SKIP_BUILD: "1"
         run: scripts/live-canary/run.sh
       - name: Scrub artifacts
         if: always() && steps.resolve_reborn_webui_v2_cases.outputs.skip_shard != '1'

--- a/.github/workflows/live-canary.yml
+++ b/.github/workflows/live-canary.yml
@@ -542,11 +542,74 @@ jobs:
           path: artifacts/live-canary/
           retention-days: 14
 
+  approve-reborn-webui-v2-pr-live-qa:
+    name: Approve PR code for Reborn WebUI v2 live QA
+    if: >
+      github.event_name == 'workflow_dispatch' &&
+      inputs.target_ref != '' &&
+      (inputs.lane == 'all' || inputs.lane == 'reborn-webui-v2-live-qa')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: reborn-live-canary-pr
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Require trusted approval for the exact PR head
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          TARGET_PR: ${{ inputs.target_pr }}
+          TARGET_REF: ${{ inputs.target_ref }}
+        run: |
+          set -euo pipefail
+          if ! [[ "${TARGET_PR}" =~ ^[0-9]+$ && "${TARGET_REF}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::A valid target_pr and full target_ref are required for PR live QA."
+            exit 1
+          fi
+
+          pr_json="$(gh pr view "${TARGET_PR}" --repo "${REPO}" --json isCrossRepository,headRefOid)"
+          if [[ "$(jq -r '.isCrossRepository' <<< "${pr_json}")" == "true" ]]; then
+            echo "::error::Refusing to run live QA with secrets on a forked PR."
+            exit 1
+          fi
+          if [[ "$(jq -r '.headRefOid' <<< "${pr_json}")" != "${TARGET_REF}" ]]; then
+            echo "::error::target_ref does not match PR #${TARGET_PR} head SHA."
+            exit 1
+          fi
+
+          trusted_approval=""
+          while IFS=$'\t' read -r reviewer commit_id; do
+            [[ "${commit_id}" == "${TARGET_REF}" ]] || continue
+            permission="$(gh api "repos/${REPO}/collaborators/${reviewer}/permission" --jq '.permission')"
+            if [[ "${permission}" == "admin" || "${permission}" == "maintain" || "${permission}" == "write" ]]; then
+              trusted_approval="${reviewer}"
+              break
+            fi
+          done < <(
+            gh api --paginate "repos/${REPO}/pulls/${TARGET_PR}/reviews" \
+              --jq 'sort_by(.submitted_at) | group_by(.user.login) | map(last) | .[] | select(.state == "APPROVED") | [.user.login, .commit_id] | @tsv'
+          )
+
+          if [[ -z "${trusted_approval}" ]]; then
+            echo "::error::PR #${TARGET_PR} head ${TARGET_REF} requires an approving review from a collaborator with write access before live secrets can be used."
+            exit 1
+          fi
+          echo "Trusted approval for ${TARGET_REF} was provided by ${trusted_approval}."
+
   prepare-reborn-webui-v2-live-qa:
     name: Prepare Reborn WebUI v2 live QA binary
     if: >
-      (github.event_name == 'schedule' && github.event.schedule == '0 */3 * * *') ||
-      (github.event_name == 'workflow_dispatch' && (inputs.lane == 'all' || inputs.lane == 'reborn-webui-v2-live-qa'))
+      always() &&
+      (
+        (github.event_name == 'schedule' && github.event.schedule == '0 */3 * * *') ||
+        (
+          github.event_name == 'workflow_dispatch' &&
+          (inputs.lane == 'all' || inputs.lane == 'reborn-webui-v2-live-qa') &&
+          (inputs.target_ref == '' || needs.approve-reborn-webui-v2-pr-live-qa.result == 'success')
+        )
+      )
+    needs: approve-reborn-webui-v2-pr-live-qa
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -643,14 +706,22 @@ jobs:
               exit 0
             fi
 
-            gh api "repos/${REPO}/actions/artifacts/${artifact_id}/zip" > "${RUNNER_TEMP}/reborn-webui-v2-binary.zip"
-            unzip -q "${RUNNER_TEMP}/reborn-webui-v2-binary.zip" -d artifacts/prepared-reborn-webui-v2-binary
-            (cd artifacts/prepared-reborn-webui-v2-binary && sha256sum --check ironclaw-reborn.tar.gz.sha256)
-            jq -e \
-              --arg product_ref "${TARGET_REF}" \
-              --arg features "webui-v2-beta,slack-v2-host-beta" \
-              '.format_version == 1 and .product_ref == $product_ref and .features == $features' \
-              artifacts/prepared-reborn-webui-v2-binary/manifest.json > /dev/null
+            if ! (
+              set -e
+              rm -rf artifacts/prepared-reborn-webui-v2-binary
+              mkdir -p artifacts/prepared-reborn-webui-v2-binary
+              gh api "repos/${REPO}/actions/artifacts/${artifact_id}/zip" > "${RUNNER_TEMP}/reborn-webui-v2-binary.zip"
+              unzip -q "${RUNNER_TEMP}/reborn-webui-v2-binary.zip" -d artifacts/prepared-reborn-webui-v2-binary
+              python3 scripts/live-canary/validate_reborn_binary_artifact.py \
+                artifacts/prepared-reborn-webui-v2-binary \
+                "${TARGET_REF}" \
+                "webui-v2-beta,slack-v2-host-beta"
+            ); then
+              echo "::warning::The Reborn E2E artifact could not be downloaded or validated; using the canary fallback build."
+              rm -rf artifacts/prepared-reborn-webui-v2-binary
+              mkdir -p artifacts/prepared-reborn-webui-v2-binary
+              exit 0
+            fi
             echo "found=1" >> "${GITHUB_OUTPUT}"
             echo "source=reborn-e2e" >> "${GITHUB_OUTPUT}"
             echo "Using tested Reborn E2E binary from run ${run_id}."

--- a/.github/workflows/live-canary.yml
+++ b/.github/workflows/live-canary.yml
@@ -735,9 +735,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - shard_id: qa-2
-            shard_name: QA 2
-            cases: qa_2a_gmail_connect,qa_2b_calendar_connect,qa_2c_drive_connect,qa_2d_calendar_prep_live_chat,qa_2e_calendar_prep_email_routine,qa_2f_calendar_prep_email_delivery
+          - shard_id: qa-2-connect
+            shard_name: QA 2A-2C
+            cases: qa_2a_gmail_connect,qa_2b_calendar_connect,qa_2c_drive_connect
+          - shard_id: qa-2-workflow
+            shard_name: QA 2D-2F
+            cases: qa_2d_calendar_prep_live_chat,qa_2e_calendar_prep_email_routine,qa_2f_calendar_prep_email_delivery
           - shard_id: qa-3
             shard_name: QA 3
             cases: qa_3a_slack_connect,qa_3b_endpoint_status_live_chat,qa_3c_endpoint_status_slack_routine,qa_3d_endpoint_status_slack_delivery
@@ -747,15 +750,21 @@ jobs:
           - shard_id: qa-5
             shard_name: QA 5
             cases: qa_5a_slack_connect,qa_5b_drive_connect,qa_5c_strategy_doc_knowledge_base,qa_5d_slack_strategy_doc_answer
-          - shard_id: qa-6
-            shard_name: QA 6
-            cases: qa_6a_gmail_connect,qa_6b_sheets_connect,qa_6c_gmail_to_sheet_live_chat,qa_6d_gmail_to_sheet_routine,qa_6e_gmail_to_sheet_delivery
+          - shard_id: qa-6-connect
+            shard_name: QA 6A-6C
+            cases: qa_6a_gmail_connect,qa_6b_sheets_connect,qa_6c_gmail_to_sheet_live_chat
+          - shard_id: qa-6-workflow
+            shard_name: QA 6D-6E
+            cases: qa_6d_gmail_to_sheet_routine,qa_6e_gmail_to_sheet_delivery
           - shard_id: qa-7
             shard_name: QA 7
             cases: qa_7a_slack_product_channel_connect,qa_7b_sheets_connect,qa_7c_slack_bug_logger_routine,qa_7d_slack_bug_message_trigger,qa_7e_slack_bug_sheet_delivery
-          - shard_id: qa-8
-            shard_name: QA 8
-            cases: qa_8a_slack_connect,qa_8b_hn_keyword_live_chat,qa_8c_hn_keyword_slack_routine,qa_8d_hn_keyword_slack_delivery
+          - shard_id: qa-8-monitor
+            shard_name: QA 8A-8C
+            cases: qa_8a_slack_connect,qa_8b_hn_keyword_live_chat,qa_8c_hn_keyword_slack_routine
+          - shard_id: qa-8-delivery
+            shard_name: QA 8D
+            cases: qa_8d_hn_keyword_slack_delivery
     env:
       REBORN_WEBUI_V2_LIVE_QA_LLM_API_KEY_ENV: NEARAI_API_KEY
       REBORN_WEBUI_V2_LIVE_QA_LLM_PROVIDER_ID: nearai
@@ -873,6 +882,16 @@ jobs:
         if: steps.resolve_reborn_webui_v2_cases.outputs.skip_shard != '1'
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: tests/e2e/pyproject.toml
+
+      - name: Cache Playwright browsers
+        if: steps.resolve_reborn_webui_v2_cases.outputs.skip_shard != '1'
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('tests/e2e/pyproject.toml') }}
+          restore-keys: ${{ runner.os }}-playwright-
 
       - name: Download prepared Reborn WebUI v2 binary
         if: steps.resolve_reborn_webui_v2_cases.outputs.skip_shard != '1'

--- a/.github/workflows/live-canary.yml
+++ b/.github/workflows/live-canary.yml
@@ -741,12 +741,21 @@ jobs:
           - shard_id: qa-2-workflow
             shard_name: QA 2D-2F
             cases: qa_2d_calendar_prep_live_chat,qa_2e_calendar_prep_email_routine,qa_2f_calendar_prep_email_delivery
-          - shard_id: qa-3
-            shard_name: QA 3
-            cases: qa_3a_slack_connect,qa_3b_endpoint_status_live_chat,qa_3c_endpoint_status_slack_routine,qa_3d_endpoint_status_slack_delivery
-          - shard_id: qa-4
-            shard_name: QA 4
-            cases: qa_4a_gmail_connect,qa_4b_github_connect,qa_4c_github_release_live_chat,qa_4d_github_release_slack_routine,qa_4e_github_release_email_delivery
+          - shard_id: qa-3-chat
+            shard_name: QA 3A-3B
+            cases: qa_3a_slack_connect,qa_3b_endpoint_status_live_chat
+          - shard_id: qa-3-routine
+            shard_name: QA 3C
+            cases: qa_3c_endpoint_status_slack_routine
+          - shard_id: qa-3-delivery
+            shard_name: QA 3D
+            cases: qa_3d_endpoint_status_slack_delivery
+          - shard_id: qa-4-summary
+            shard_name: QA 4A-4C
+            cases: qa_4a_gmail_connect,qa_4b_github_connect,qa_4c_github_release_live_chat
+          - shard_id: qa-4-automation
+            shard_name: QA 4D-4E
+            cases: qa_4d_github_release_slack_routine,qa_4e_github_release_email_delivery
           - shard_id: qa-5
             shard_name: QA 5
             cases: qa_5a_slack_connect,qa_5b_drive_connect,qa_5c_strategy_doc_knowledge_base,qa_5d_slack_strategy_doc_answer

--- a/.github/workflows/reborn-e2e.yml
+++ b/.github/workflows/reborn-e2e.yml
@@ -179,7 +179,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ inputs.ref || github.sha }}
+          # Live canary validates and tests the PR head SHA, so publish the
+          # reusable binary for that same immutable commit. Merge-group runs
+          # continue to use github.sha and test the synthesized merge commit.
+          ref: ${{ inputs.ref || (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}
           persist-credentials: false
 
       - name: Install Rust
@@ -210,7 +213,11 @@ jobs:
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
       - name: Build ironclaw-reborn with WebChat v2 surface
-        run: cargo build -p ironclaw_reborn_cli --features webui-v2-beta
+        run: >-
+          cargo build
+          -p ironclaw_reborn_cli
+          --features webui-v2-beta,slack-v2-host-beta
+          --bin ironclaw-reborn
 
       - name: Install Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
@@ -233,6 +240,33 @@ jobs:
 
       - name: Run Reborn WebUI v2 smoke
         run: pytest tests/e2e/scenarios/test_reborn_webui_v2_smoke.py -v --timeout=120
+
+      - name: Package live-canary binary
+        id: live_canary_binary
+        run: |
+          set -euo pipefail
+          product_ref="$(git rev-parse HEAD)"
+          artifact_dir="artifacts/reborn-webui-v2-binary"
+          mkdir -p "${artifact_dir}"
+          tar -C target/debug -czf "${artifact_dir}/ironclaw-reborn.tar.gz" ironclaw-reborn
+          (
+            cd "${artifact_dir}"
+            sha256sum ironclaw-reborn.tar.gz > ironclaw-reborn.tar.gz.sha256
+          )
+          jq -n \
+            --arg product_ref "${product_ref}" \
+            --arg features "webui-v2-beta,slack-v2-host-beta" \
+            '{format_version: 1, product_ref: $product_ref, features: $features}' \
+            > "${artifact_dir}/manifest.json"
+          echo "product_ref=${product_ref}" >> "${GITHUB_OUTPUT}"
+
+      - name: Upload live-canary binary
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: reborn-webui-v2-binary-${{ steps.live_canary_binary.outputs.product_ref }}
+          path: artifacts/reborn-webui-v2-binary/
+          if-no-files-found: error
+          retention-days: 7
 
       - name: Upload screenshots on failure
         if: failure()

--- a/scripts/live-canary/README.md
+++ b/scripts/live-canary/README.md
@@ -53,6 +53,11 @@ Run commands from the repository root.
 
 - `reborn-webui-v2-live-qa`
 
+PR-targeted runs execute the reviewed PR binary with live integration secrets.
+They must pass the `reborn-live-canary-pr` GitHub environment gate and have an
+approving review for the exact PR head commit from a collaborator with write
+access. Scheduled and manual default-branch runs do not require this PR gate.
+
 ## Local Commands
 
 Run the public live smoke lane:

--- a/scripts/live-canary/run.sh
+++ b/scripts/live-canary/run.sh
@@ -107,6 +107,7 @@ write_env_summary() {
     echo "python_bin=${PYTHON_BIN}"
     echo "cases=${CASES:-<default>}"
     echo "reborn_webui_v2_live_qa_harness_ref=${REBORN_WEBUI_V2_LIVE_QA_HARNESS_REF:-<checkout>}"
+    echo "reborn_webui_v2_live_qa_build_source=${REBORN_WEBUI_V2_LIVE_QA_BUILD_SOURCE:-<local>}"
     echo "skip_build=${SKIP_BUILD:-0}"
     echo "skip_python_bootstrap=${SKIP_PYTHON_BOOTSTRAP:-0}"
   } > "${ENV_FILE}"

--- a/scripts/live-canary/test_validate_reborn_binary_artifact.py
+++ b/scripts/live-canary/test_validate_reborn_binary_artifact.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("validate_reborn_binary_artifact.py")
+SPEC = importlib.util.spec_from_file_location("validate_reborn_binary_artifact", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+VALIDATOR = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(VALIDATOR)
+
+
+class ValidateRebornBinaryArtifactTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.artifact_dir = Path(self.temp_dir.name)
+        self.archive = self.artifact_dir / VALIDATOR.ARCHIVE_NAME
+        self.archive.write_bytes(b"tested reborn binary")
+        digest = hashlib.sha256(self.archive.read_bytes()).hexdigest()
+        (self.artifact_dir / VALIDATOR.CHECKSUM_NAME).write_text(
+            f"{digest}  {VALIDATOR.ARCHIVE_NAME}\n",
+            encoding="utf-8",
+        )
+        (self.artifact_dir / VALIDATOR.MANIFEST_NAME).write_text(
+            json.dumps(
+                {
+                    "format_version": 1,
+                    "product_ref": "a" * 40,
+                    "features": "webui-v2-beta,slack-v2-host-beta",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def test_accepts_matching_artifact(self) -> None:
+        VALIDATOR.validate_artifact(
+            self.artifact_dir,
+            "a" * 40,
+            "webui-v2-beta,slack-v2-host-beta",
+        )
+
+    def test_rejects_corrupt_archive(self) -> None:
+        self.archive.write_bytes(b"corrupt")
+
+        with self.assertRaisesRegex(ValueError, "checksum mismatch"):
+            VALIDATOR.validate_artifact(
+                self.artifact_dir,
+                "a" * 40,
+                "webui-v2-beta,slack-v2-host-beta",
+            )
+
+    def test_rejects_mismatched_manifest(self) -> None:
+        with self.assertRaisesRegex(ValueError, "product_ref"):
+            VALIDATOR.validate_artifact(
+                self.artifact_dir,
+                "b" * 40,
+                "webui-v2-beta,slack-v2-host-beta",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/live-canary/validate_reborn_binary_artifact.py
+++ b/scripts/live-canary/validate_reborn_binary_artifact.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Validate a packaged Reborn live-canary binary artifact."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+
+
+ARCHIVE_NAME = "ironclaw-reborn.tar.gz"
+CHECKSUM_NAME = f"{ARCHIVE_NAME}.sha256"
+MANIFEST_NAME = "manifest.json"
+
+
+def validate_artifact(
+    artifact_dir: Path,
+    expected_ref: str,
+    expected_features: str,
+) -> None:
+    archive = artifact_dir / ARCHIVE_NAME
+    checksum = artifact_dir / CHECKSUM_NAME
+    manifest_path = artifact_dir / MANIFEST_NAME
+
+    expected_checksum = checksum.read_text(encoding="utf-8").split()[0]
+    actual_checksum = hashlib.sha256(archive.read_bytes()).hexdigest()
+    if actual_checksum != expected_checksum:
+        raise ValueError(
+            f"archive checksum mismatch: expected {expected_checksum}, got {actual_checksum}"
+        )
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    if manifest.get("format_version") != 1:
+        raise ValueError("unsupported artifact manifest format")
+    if manifest.get("product_ref") != expected_ref:
+        raise ValueError("artifact product_ref does not match the requested commit")
+    if manifest.get("features") != expected_features:
+        raise ValueError("artifact feature set does not match live QA")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("artifact_dir", type=Path)
+    parser.add_argument("expected_ref")
+    parser.add_argument("expected_features")
+    args = parser.parse_args()
+    validate_artifact(args.artifact_dir, args.expected_ref, args.expected_features)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
+++ b/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
@@ -3563,7 +3563,7 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
         self.assertIsNotNone(match, "Reborn WebUI v2 live QA job missing")
 
         shard_case_lines = re.findall(r"^\s+cases:\s*(\S+)\s*$", match.group("body"), re.M)
-        self.assertEqual(len(shard_case_lines), 7)
+        self.assertEqual(len(shard_case_lines), 10)
         sharded_cases = [
             case_name
             for line in shard_case_lines
@@ -3605,6 +3605,8 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
         )
         self.assertIn('SKIP_BUILD: "1"', match.group("body"))
         self.assertIn("REBORN_WEBUI_V2_LIVE_QA_BUILD_SOURCE", match.group("body"))
+        self.assertIn("Cache Playwright browsers", match.group("body"))
+        self.assertIn("cache: pip", match.group("body"))
         self.assertNotIn("Build WASM channels", match.group("body"))
         self.assertNotIn("Setup OVH sccache", match.group("body"))
 

--- a/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
+++ b/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
@@ -3598,6 +3598,12 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
             workflow,
         )
         self.assertIn("target_ref does not match PR #${TARGET_PR} head SHA", workflow)
+        self.assertIn("approve-reborn-webui-v2-pr-live-qa:", workflow)
+        self.assertIn("environment: reborn-live-canary-pr", workflow)
+        self.assertIn(
+            "requires an approving review from a collaborator with write access",
+            workflow,
+        )
         self.assertIn("needs: prepare-reborn-webui-v2-live-qa", match.group("body"))
         self.assertIn(
             "ref: ${{ needs.prepare-reborn-webui-v2-live-qa.outputs.checkout_ref }}",
@@ -3616,9 +3622,12 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
         )
         self.assertIsNotNone(prepare_match, "shared live QA binary preparation job missing")
         prepare_body = prepare_match.group("body")
+        self.assertIn("needs: approve-reborn-webui-v2-pr-live-qa", prepare_body)
         self.assertIn("reborn-webui-v2-binary-${TARGET_REF}", prepare_body)
-        self.assertIn(".product_ref == $product_ref", prepare_body)
         self.assertIn("Build fallback Reborn WebUI v2 binary once", prepare_body)
+        self.assertIn("if ! (", prepare_body)
+        self.assertIn("validate_reborn_binary_artifact.py", prepare_body)
+        self.assertIn("using the canary fallback build", prepare_body)
         self.assertIn("prepared-reborn-webui-v2-binary-${{ steps.target.outputs.checkout_ref }}", prepare_body)
         self.assertIn("path: artifacts/prepared-reborn-webui-v2-binary/", prepare_body)
 

--- a/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
+++ b/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
@@ -3618,6 +3618,7 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
         self.assertIn(".product_ref == $product_ref", prepare_body)
         self.assertIn("Build fallback Reborn WebUI v2 binary once", prepare_body)
         self.assertIn("prepared-reborn-webui-v2-binary-${{ steps.target.outputs.checkout_ref }}", prepare_body)
+        self.assertIn("path: artifacts/prepared-reborn-webui-v2-binary/", prepare_body)
 
         reborn_e2e_path = (
             Path(__file__).resolve().parents[2] / ".github/workflows/reborn-e2e.yml"

--- a/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
+++ b/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
@@ -3563,7 +3563,7 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
         self.assertIsNotNone(match, "Reborn WebUI v2 live QA job missing")
 
         shard_case_lines = re.findall(r"^\s+cases:\s*(\S+)\s*$", match.group("body"), re.M)
-        self.assertEqual(len(shard_case_lines), 13)
+        self.assertEqual(len(shard_case_lines), 10)
         sharded_cases = [
             case_name
             for line in shard_case_lines

--- a/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
+++ b/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
@@ -3563,7 +3563,7 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
         self.assertIsNotNone(match, "Reborn WebUI v2 live QA job missing")
 
         shard_case_lines = re.findall(r"^\s+cases:\s*(\S+)\s*$", match.group("body"), re.M)
-        self.assertEqual(len(shard_case_lines), 10)
+        self.assertEqual(len(shard_case_lines), 13)
         sharded_cases = [
             case_name
             for line in shard_case_lines

--- a/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
+++ b/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
@@ -3592,10 +3592,49 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
             "Unknown Reborn WebUI v2 live QA case",
             match.group("body"),
         )
-        self.assertIn("target_pr is required when target_ref is supplied", match.group("body"))
-        self.assertIn("Refusing to run reborn-webui-v2-live-qa with live secrets on a forked PR", match.group("body"))
-        self.assertIn("target_ref does not match PR #${TARGET_PR} head SHA", match.group("body"))
-        self.assertIn("ref: ${{ steps.validate_reborn_webui_v2_target.outputs.checkout_ref", match.group("body"))
+        self.assertIn("target_pr is required when target_ref is supplied", workflow)
+        self.assertIn(
+            "Refusing to run reborn-webui-v2-live-qa with live secrets on a forked PR",
+            workflow,
+        )
+        self.assertIn("target_ref does not match PR #${TARGET_PR} head SHA", workflow)
+        self.assertIn("needs: prepare-reborn-webui-v2-live-qa", match.group("body"))
+        self.assertIn(
+            "ref: ${{ needs.prepare-reborn-webui-v2-live-qa.outputs.checkout_ref }}",
+            match.group("body"),
+        )
+        self.assertIn('SKIP_BUILD: "1"', match.group("body"))
+        self.assertIn("REBORN_WEBUI_V2_LIVE_QA_BUILD_SOURCE", match.group("body"))
+        self.assertNotIn("Build WASM channels", match.group("body"))
+        self.assertNotIn("Setup OVH sccache", match.group("body"))
+
+        prepare_match = re.search(
+            r"(?ms)^  prepare-reborn-webui-v2-live-qa:\n(?P<body>.*?)^  reborn-webui-v2-live-qa:",
+            workflow,
+        )
+        self.assertIsNotNone(prepare_match, "shared live QA binary preparation job missing")
+        prepare_body = prepare_match.group("body")
+        self.assertIn("reborn-webui-v2-binary-${TARGET_REF}", prepare_body)
+        self.assertIn(".product_ref == $product_ref", prepare_body)
+        self.assertIn("Build fallback Reborn WebUI v2 binary once", prepare_body)
+        self.assertIn("prepared-reborn-webui-v2-binary-${{ steps.target.outputs.checkout_ref }}", prepare_body)
+
+        reborn_e2e_path = (
+            Path(__file__).resolve().parents[2] / ".github/workflows/reborn-e2e.yml"
+        )
+        reborn_e2e = reborn_e2e_path.read_text(encoding="utf-8")
+        self.assertIn(
+            "github.event.pull_request.head.sha",
+            reborn_e2e,
+        )
+        self.assertIn(
+            "--features webui-v2-beta,slack-v2-host-beta",
+            reborn_e2e,
+        )
+        self.assertIn(
+            "name: reborn-webui-v2-binary-${{ steps.live_canary_binary.outputs.product_ref }}",
+            reborn_e2e,
+        )
 
         command_workflow_path = (
             Path(__file__).resolve().parents[2] / ".github/workflows/live-canary-command.yml"

--- a/tests/test_validate_reborn_binary_artifact.py
+++ b/tests/test_validate_reborn_binary_artifact.py
@@ -8,7 +8,8 @@ import unittest
 from pathlib import Path
 
 
-SCRIPT = Path(__file__).with_name("validate_reborn_binary_artifact.py")
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/live-canary/validate_reborn_binary_artifact.py"
 SPEC = importlib.util.spec_from_file_location("validate_reborn_binary_artifact", SCRIPT)
 assert SPEC is not None and SPEC.loader is not None
 VALIDATOR = importlib.util.module_from_spec(SPEC)


### PR DESCRIPTION
## Summary

- publish the exact-SHA `ironclaw-reborn` binary from the existing Reborn WebUI v2 smoke job after that smoke test passes
- add one live-canary preparation job that waits briefly for the matching successful Reborn E2E artifact, verifies its SHA/feature manifest and checksum, and fans it out to all seven QA shards
- fall back to one shared canary build when no matching CI artifact exists, replacing seven per-shard builds without changing live test cases or product behavior
- record whether a run used `reborn-e2e` or `canary-fallback` in canary environment artifacts

## Why

The isolated artifact experiment passed all 33 live cases. With a warm producer it reduced aggregate runner time from 46m10s to 27m24s. Moving the producer into normal Reborn E2E removes that producer from the canary critical path when the exact commit artifact already exists.

Artifacts are keyed by immutable commit SHA. Canary never selects a latest artifact: it validates the requested PR head, requires the matching Reborn E2E workflow run to succeed, verifies the embedded `product_ref` and feature set, and checks the archive checksum.

## Validation

- `actionlint` 1.7.12 on both modified workflows (existing custom `ironclaw-live` runner label ignored)
- `python3 -m unittest scripts.reborn_webui_v2_live_qa.test_run_live_qa` (96 passed, 5 skipped)
- YAML parse and `git diff --check`
- verified through the GitHub Actions API that Reborn E2E PR runs expose the PR head SHA used by `/canary`

## Rollback

Revert this PR. Until then, any missing, delayed, failed, expired, or invalid artifact automatically uses the existing build path once in the preparation job.