### PR TITLE
test(reborn): integration pins for capability-guard misfire fixes (#5817/#5782)

### DIFF
--- a/tests/integration/tool_call.rs
+++ b/tests/integration/tool_call.rs
@@ -125,6 +125,54 @@ async fn runs_http_save_tool_call_through_recorded_egress() {
         .expect("final reply finalized");
 }
 
+/// Regression for #5817: a decimal lifted from prose (`0.95`) tokenizes as
+/// `digits.digits`, satisfying the capability-id shape check. The guard must
+/// not mistake it for a requested-but-unavailable capability and suppress the
+/// model's real `builtin.http` call.
+#[tokio::test]
+async fn decimal_number_in_prompt_does_not_suppress_tool_call() {
+    let h = RebornIntegrationHarness::test_default()
+        .with_builtin_http_tools()
+        .script([
+            RebornScriptedReply::tool_call("builtin.http", json!({"url": HTTP_TOOL_URL})),
+            RebornScriptedReply::text("fetched"),
+        ])
+        .build()
+        .await
+        .expect("harness builds");
+    h.submit_turn(
+        "compute the correlation-adjusted 95% = 0.95 (use 0.95 in formulas), then fetch items",
+    )
+    .await
+    .expect("turn completes");
+    h.assert_tool_invoked("builtin.http")
+        .await
+        .expect("http tool ran; guard must not misfire on the decimal 0.95");
+}
+
+/// Regression for #5782: a backticked code reference (`playwright.sync_api`,
+/// a Python module) tokenizes like a capability id sitting after "use". The
+/// guard must not mistake it for a capability request and suppress the
+/// model's real `builtin.http` call.
+#[tokio::test]
+async fn backticked_code_reference_in_prompt_does_not_suppress_tool_call() {
+    let h = RebornIntegrationHarness::test_default()
+        .with_builtin_http_tools()
+        .script([
+            RebornScriptedReply::tool_call("builtin.http", json!({"url": HTTP_TOOL_URL})),
+            RebornScriptedReply::text("fetched"),
+        ])
+        .build()
+        .await
+        .expect("harness builds");
+    h.submit_turn("use `playwright.sync_api` (Python sync API) as reference, then fetch items")
+        .await
+        .expect("turn completes");
+    h.assert_tool_invoked("builtin.http")
+        .await
+        .expect("http tool ran; guard must not misfire on the code reference playwright.sync_api");
+}
+
 /// The globally-disabled `builtin.spawn_subagent` capability (configured
 /// through `DefaultPlannedRuntimeConfig::disabled_capability_ids`, applied as
 /// the OUTERMOST `PerSurfaceCapabilityDenyDecorator` in

--- a/tests/integration/tool_call.rs
+++ b/tests/integration/tool_call.rs
@@ -148,6 +148,12 @@ async fn decimal_number_in_prompt_does_not_suppress_tool_call() {
     h.assert_tool_invoked("builtin.http")
         .await
         .expect("http tool ran; guard must not misfire on the decimal 0.95");
+    h.assert_egress_request_matching("api.example.test")
+        .await
+        .expect("scripted http call crossed the recording egress");
+    h.assert_reply_contains("fetched")
+        .await
+        .expect("final reply finalized");
 }
 
 /// Regression for #5782: a backticked code reference (`playwright.sync_api`,
@@ -171,6 +177,12 @@ async fn backticked_code_reference_in_prompt_does_not_suppress_tool_call() {
     h.assert_tool_invoked("builtin.http")
         .await
         .expect("http tool ran; guard must not misfire on the code reference playwright.sync_api");
+    h.assert_egress_request_matching("api.example.test")
+        .await
+        .expect("scripted http call crossed the recording egress");
+    h.assert_reply_contains("fetched")
+        .await
+        .expect("final reply finalized");
 }
 
 /// The globally-disabled `builtin.spawn_subagent` capability (configured


### PR DESCRIPTION
## Summary

Backfills integration-tier regression pins for two merged fixes that shipped with crate-tier tests only:

- **#5817** — decimal numbers in prompt text (e.g. `0.95`) must not be parsed as requested capability ids and suppress tool calls.
- **#5782** — backticked code references (e.g. `playwright.sync_api`) must not trip the unavailable-capability guard.

Both new tests drive the full turn path through the scripted-model harness (`build → submit_turn → assert_tool_invoked`), pinning that `unavailable_requested_capability_guard` is reached inside the real `LlmProviderModelGateway` path (`model_gateway.rs:1129`) — one tier above the existing crate-level parser tests, per the integration-first coverage rule.

## Tests

- `decimal_number_in_prompt_does_not_suppress_tool_call` (pins #5817)
- `backticked_code_reference_in_prompt_does_not_suppress_tool_call` (pins #5782)

Consolidated into the existing `reborn_integration_tool_call` binary (no new file/`[[test]]`). Kept as two independent harnesses deliberately: `assert_tool_invoked`'s baseline delta is monotonic within one harness, so merging them would make the second assertion vacuous.

**Mutation-verified**: neutralizing each heuristic in `model_gateway.rs` makes exactly its own test fail (`capability "builtin.http" was not invoked`); code paths are disjoint.

## Verification

- `cargo test --test reborn_integration_tool_call` — 17/17 pass
- `cargo fmt` / `cargo clippy` on the touched target — zero warnings
- Test-only diff; no production code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)