### PR TITLE
fix(reborn): prevent live assistant streaming stalls

### DIFF
--- a/crates/ironclaw_reborn_composition/CLAUDE.md
+++ b/crates/ironclaw_reborn_composition/CLAUDE.md
@@ -372,6 +372,13 @@ runtime state stores sit behind the composed local-dev root filesystem
 files). Production durable retention/live fanout still belongs in the
 host runtime/event-store follow-up rather than this composition facade.
 
+Live cumulative assistant-text projections are producer-coalesced: the first
+update is published immediately, rapid replacements publish the latest value
+at most once per 75 ms, and any non-text milestone flushes the pending value
+before that milestone is projected. Reasoning, capability, and lifecycle
+milestones remain ordered and uncoalesced. The in-memory source still records
+the latest projection for replay when no browser subscriber is active.
+
 ```rust
 // Inside a host-owned ingress crate / binary (NOT in this crate —
 // `reborn_product_api_crates_do_not_bind_http_ingress` forbids
@@ -401,6 +408,13 @@ axum::serve(listener, app).with_graceful_shutdown(shutdown).await?;
   — regression guard that the WebUI projection adapter uses the facade
   request actor when selecting the runtime event stream, rather than a
   hidden runtime owner actor.
+- `src/projection/tests/live_progress_stream.rs::live_assistant_text_coalescer_flushes_latest_update_on_timer`
+  — regression guard that rapid cumulative text still advances while the
+  model continues streaming.
+- `src/projection/tests/live_progress_stream.rs::live_assistant_text_burst_stays_subscribed_and_flushes_before_tool_activity`
+  — caller-level regression guard that a provider-rate text burst does not
+  terminate the bounded WebUI subscription and that the latest text is
+  published before the next capability milestone.
 - `tests/webui_v2_serve.rs` — caller-level tests driving the composed
   `Router` through `tower::ServiceExt::oneshot`: bearer happy path,
   missing/invalid bearer 401, SSE `?token=`, timeline rejects `?token=`,

--- a/crates/ironclaw_reborn_composition/src/projection/live_progress.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/live_progress.rs
@@ -357,7 +357,7 @@ impl LiveTextProjectionCoalescer {
         match self.states.lock() {
             Ok(states) => states,
             Err(poisoned) => {
-                tracing::warn!("live text projection coalescer lock recovered after panic");
+                tracing::debug!("live text projection coalescer lock recovered after panic");
                 self.states.clear_poison();
                 poisoned.into_inner()
             }
@@ -368,7 +368,7 @@ impl LiveTextProjectionCoalescer {
         match self.publication_order.lock() {
             Ok(order) => order,
             Err(poisoned) => {
-                tracing::warn!("live text projection publication lock recovered after panic");
+                tracing::debug!("live text projection publication lock recovered after panic");
                 self.publication_order.clear_poison();
                 poisoned.into_inner()
             }

--- a/crates/ironclaw_reborn_composition/src/projection/live_progress.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/live_progress.rs
@@ -65,6 +65,10 @@ pub(crate) struct LiveProjectionPublisher {
 struct LiveTextProjectionCoalescer {
     publisher: Arc<LiveProjectionPublisher>,
     next_generation: AtomicU64,
+    // State mutation and channel publication are separate critical sections.
+    // This guard preserves their relative order without holding `states` while
+    // the broadcast source wakes subscribers.
+    publication_order: Mutex<()>,
     states: Mutex<HashMap<TurnRunId, LiveTextProjectionState>>,
 }
 
@@ -245,6 +249,7 @@ impl LiveTextProjectionCoalescer {
         Self {
             publisher,
             next_generation: AtomicU64::new(0),
+            publication_order: Mutex::new(()),
             states: Mutex::new(HashMap::new()),
         }
     }
@@ -255,32 +260,39 @@ impl LiveTextProjectionCoalescer {
         // than in the generic stream manager, whose other items are lossless.
         let run_id = projection.run_id;
         let mut timer = None;
+        let mut publish_projection = None;
         {
-            let mut states = self.lock_states();
-            match states.get_mut(&run_id) {
-                Some(state) => {
-                    state.pending = Some(projection);
-                    if !state.timer_scheduled {
-                        state.timer_scheduled = true;
-                        timer = Some((
-                            state.generation,
-                            state.last_published_at + LIVE_TEXT_COALESCE_WINDOW,
-                        ));
+            let _publication_order = self.lock_publication_order();
+            {
+                let mut states = self.lock_states();
+                match states.get_mut(&run_id) {
+                    Some(state) => {
+                        state.pending = Some(projection);
+                        if !state.timer_scheduled {
+                            state.timer_scheduled = true;
+                            timer = Some((
+                                state.generation,
+                                state.last_published_at + LIVE_TEXT_COALESCE_WINDOW,
+                            ));
+                        }
+                    }
+                    None => {
+                        let generation = self.next_generation.fetch_add(1, Ordering::Relaxed) + 1;
+                        states.insert(
+                            run_id,
+                            LiveTextProjectionState {
+                                generation,
+                                last_published_at: tokio::time::Instant::now(),
+                                pending: None,
+                                timer_scheduled: false,
+                            },
+                        );
+                        publish_projection = Some(projection);
                     }
                 }
-                None => {
-                    let generation = self.next_generation.fetch_add(1, Ordering::Relaxed) + 1;
-                    self.publish(projection);
-                    states.insert(
-                        run_id,
-                        LiveTextProjectionState {
-                            generation,
-                            last_published_at: tokio::time::Instant::now(),
-                            pending: None,
-                            timer_scheduled: false,
-                        },
-                    );
-                }
+            }
+            if let Some(projection) = publish_projection.take() {
+                self.publish(projection);
             }
         }
 
@@ -294,27 +306,36 @@ impl LiveTextProjectionCoalescer {
     }
 
     fn flush_boundary(&self, run_id: TurnRunId) {
-        let mut states = self.lock_states();
-        if let Some(state) = states.remove(&run_id)
-            && let Some(projection) = state.pending
-        {
+        let _publication_order = self.lock_publication_order();
+        let projection = {
+            let mut states = self.lock_states();
+            states.remove(&run_id).and_then(|state| state.pending)
+        };
+        if let Some(projection) = projection {
             self.publish(projection);
         }
     }
 
     fn flush_timer(&self, run_id: TurnRunId, generation: u64) {
-        let mut states = self.lock_states();
-        let Some(state) = states.get_mut(&run_id) else {
-            return;
-        };
-        if state.generation != generation {
-            return;
-        }
+        let _publication_order = self.lock_publication_order();
+        let projection = {
+            let mut states = self.lock_states();
+            let Some(state) = states.get_mut(&run_id) else {
+                return;
+            };
+            if state.generation != generation {
+                return;
+            }
 
-        state.timer_scheduled = false;
-        if let Some(projection) = state.pending.take() {
+            state.timer_scheduled = false;
+            let projection = state.pending.take();
+            if projection.is_some() {
+                state.last_published_at = tokio::time::Instant::now();
+            }
+            projection
+        };
+        if let Some(projection) = projection {
             self.publish(projection);
-            state.last_published_at = tokio::time::Instant::now();
         }
     }
 
@@ -338,6 +359,17 @@ impl LiveTextProjectionCoalescer {
             Err(poisoned) => {
                 tracing::warn!("live text projection coalescer lock recovered after panic");
                 self.states.clear_poison();
+                poisoned.into_inner()
+            }
+        }
+    }
+
+    fn lock_publication_order(&self) -> MutexGuard<'_, ()> {
+        match self.publication_order.lock() {
+            Ok(order) => order,
+            Err(poisoned) => {
+                tracing::warn!("live text projection publication lock recovered after panic");
+                self.publication_order.clear_poison();
                 poisoned.into_inner()
             }
         }

--- a/crates/ironclaw_reborn_composition/src/projection/live_progress.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/live_progress.rs
@@ -1,6 +1,10 @@
-use std::sync::{
-    Arc,
-    atomic::{AtomicU64, Ordering},
+use std::{
+    collections::HashMap,
+    sync::{
+        Arc, Mutex, MutexGuard,
+        atomic::{AtomicBool, AtomicU64, Ordering},
+    },
+    time::Duration,
 };
 
 use async_trait::async_trait;
@@ -10,8 +14,8 @@ use ironclaw_event_projections::{
     ProjectionScope as EventProjectionScope,
 };
 use ironclaw_event_streams::{
-    InMemoryProjectionUpdateSource, ProductProjectionEnvelope, ThreadLiveProjectionItem,
-    ThreadLiveProjectionUpdate, ThreadLiveWorkSummaryPhase,
+    InMemoryProjectionUpdateSource, ProductProjectionEnvelope, ProjectionStreamError,
+    ThreadLiveProjectionItem, ThreadLiveProjectionUpdate, ThreadLiveWorkSummaryPhase,
 };
 use ironclaw_events::{EventCursor, EventStreamKey, ReadScope, sanitize_error_summary};
 use ironclaw_first_party_extension_ports::{SkillActivationObservedEvent, SkillActivationObserver};
@@ -36,10 +40,12 @@ use ironclaw_turns::{
 // same live broadcast would put low append-log cursors and high synthetic
 // cursors behind the same `last_delivered_cursor` ordering gate.
 const LIVE_PROGRESS_CURSOR_BASE: u64 = 1 << 62;
+const LIVE_TEXT_COALESCE_WINDOW: Duration = Duration::from_millis(75);
 
 pub(super) struct LiveProgressMilestoneSink {
     inner: Arc<dyn LoopHostMilestoneSink>,
     publisher: Arc<LiveProjectionPublisher>,
+    text_coalescer: Arc<LiveTextProjectionCoalescer>,
 }
 
 #[derive(Debug)]
@@ -53,6 +59,27 @@ pub(crate) struct LiveProjectionPublisher {
     // Shared by publishers from the same projection services so live cursors
     // stay monotonic across progress, skill, and other projection updates.
     next_sequence: Arc<AtomicU64>,
+    no_active_subscriber_logged: AtomicBool,
+}
+
+struct LiveTextProjectionCoalescer {
+    publisher: Arc<LiveProjectionPublisher>,
+    next_generation: AtomicU64,
+    states: Mutex<HashMap<TurnRunId, LiveTextProjectionState>>,
+}
+
+struct LiveTextProjectionState {
+    generation: u64,
+    last_published_at: tokio::time::Instant,
+    pending: Option<PendingTextProjection>,
+    timer_scheduled: bool,
+}
+
+struct PendingTextProjection {
+    owner: Option<UserId>,
+    scope: TurnScope,
+    run_id: TurnRunId,
+    body: String,
 }
 
 impl std::fmt::Debug for LiveProjectionPublisher {
@@ -69,7 +96,11 @@ impl LiveProgressMilestoneSink {
         inner: Arc<dyn LoopHostMilestoneSink>,
         publisher: Arc<LiveProjectionPublisher>,
     ) -> Self {
-        Self { inner, publisher }
+        Self {
+            inner,
+            text_coalescer: Arc::new(LiveTextProjectionCoalescer::new(Arc::clone(&publisher))),
+            publisher,
+        }
     }
 }
 
@@ -89,6 +120,7 @@ impl LiveProjectionPublisher {
             update_source,
             actor_user_id,
             next_sequence,
+            no_active_subscriber_logged: AtomicBool::new(false),
         }
     }
 
@@ -112,14 +144,30 @@ impl LiveProjectionPublisher {
             thread_id: scope.thread_id.clone(),
             items: vec![item],
         };
-        if let Err(error) = self
+        match self
             .update_source
             .publish(ProductProjectionEnvelope::ThreadLiveUpdate(update))
         {
-            tracing::debug!(
-                error = %error,
-                "failed to publish live progress projection"
-            );
+            Ok(_) => {
+                self.no_active_subscriber_logged
+                    .store(false, Ordering::Relaxed);
+            }
+            Err(ProjectionStreamError::Source) => {
+                if !self
+                    .no_active_subscriber_logged
+                    .swap(true, Ordering::Relaxed)
+                {
+                    tracing::debug!(
+                        "live progress projection buffered without an active subscriber"
+                    );
+                }
+            }
+            Err(error) => {
+                tracing::debug!(
+                    error = %error,
+                    "failed to publish live progress projection"
+                );
+            }
         }
     }
 
@@ -188,6 +236,110 @@ impl LiveProjectionPublisher {
                 thread_id: Some(scope.thread_id.clone()),
                 process_id: None,
             },
+        }
+    }
+}
+
+impl LiveTextProjectionCoalescer {
+    fn new(publisher: Arc<LiveProjectionPublisher>) -> Self {
+        Self {
+            publisher,
+            next_generation: AtomicU64::new(0),
+            states: Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn submit(self: &Arc<Self>, projection: PendingTextProjection) {
+        // ModelTextDelta carries the full cumulative assistant text, so an
+        // intermediate replacement is redundant. Keep this policy here rather
+        // than in the generic stream manager, whose other items are lossless.
+        let run_id = projection.run_id;
+        let mut timer = None;
+        {
+            let mut states = self.lock_states();
+            match states.get_mut(&run_id) {
+                Some(state) => {
+                    state.pending = Some(projection);
+                    if !state.timer_scheduled {
+                        state.timer_scheduled = true;
+                        timer = Some((
+                            state.generation,
+                            state.last_published_at + LIVE_TEXT_COALESCE_WINDOW,
+                        ));
+                    }
+                }
+                None => {
+                    let generation = self.next_generation.fetch_add(1, Ordering::Relaxed) + 1;
+                    self.publish(projection);
+                    states.insert(
+                        run_id,
+                        LiveTextProjectionState {
+                            generation,
+                            last_published_at: tokio::time::Instant::now(),
+                            pending: None,
+                            timer_scheduled: false,
+                        },
+                    );
+                }
+            }
+        }
+
+        if let Some((generation, deadline)) = timer {
+            let coalescer = Arc::clone(self);
+            tokio::spawn(async move {
+                tokio::time::sleep_until(deadline).await;
+                coalescer.flush_timer(run_id, generation);
+            });
+        }
+    }
+
+    fn flush_boundary(&self, run_id: TurnRunId) {
+        let mut states = self.lock_states();
+        if let Some(state) = states.remove(&run_id)
+            && let Some(projection) = state.pending
+        {
+            self.publish(projection);
+        }
+    }
+
+    fn flush_timer(&self, run_id: TurnRunId, generation: u64) {
+        let mut states = self.lock_states();
+        let Some(state) = states.get_mut(&run_id) else {
+            return;
+        };
+        if state.generation != generation {
+            return;
+        }
+
+        state.timer_scheduled = false;
+        if let Some(projection) = state.pending.take() {
+            self.publish(projection);
+            state.last_published_at = tokio::time::Instant::now();
+        }
+    }
+
+    fn publish(&self, projection: PendingTextProjection) {
+        let sequence = self.publisher.next_live_sequence();
+        self.publisher.publish_live_item(
+            projection.owner.as_ref(),
+            &projection.scope,
+            sequence,
+            ThreadLiveProjectionItem::Text {
+                id: text_id(projection.run_id),
+                run_id: projection.run_id,
+                body: projection.body,
+            },
+        );
+    }
+
+    fn lock_states(&self) -> MutexGuard<'_, HashMap<TurnRunId, LiveTextProjectionState>> {
+        match self.states.lock() {
+            Ok(states) => states,
+            Err(poisoned) => {
+                tracing::warn!("live text projection coalescer lock recovered after panic");
+                self.states.clear_poison();
+                poisoned.into_inner()
+            }
         }
     }
 }
@@ -300,17 +452,12 @@ impl LiveProgressMilestoneSink {
         if body.is_empty() {
             return;
         }
-        let sequence = self.publisher.next_live_sequence();
-        self.publisher.publish_live_item(
-            milestone.actor.as_ref().map(|actor| &actor.user_id),
-            &milestone.scope,
-            sequence,
-            ThreadLiveProjectionItem::Text {
-                id: text_id(milestone.run_id),
-                run_id: milestone.run_id,
-                body,
-            },
-        );
+        self.text_coalescer.submit(PendingTextProjection {
+            owner: milestone.actor.as_ref().map(|actor| actor.user_id.clone()),
+            scope: milestone.scope.clone(),
+            run_id: milestone.run_id,
+            body,
+        });
     }
 
     fn publish_reasoning_delta(&self, milestone: &LoopHostMilestone, safe_delta: &str) {
@@ -445,6 +592,12 @@ impl LoopHostMilestoneSink for LiveProgressMilestoneSink {
         milestone: LoopHostMilestone,
     ) -> Result<(), AgentLoopHostError> {
         self.inner.publish_loop_milestone(milestone.clone()).await?;
+        if !matches!(
+            &milestone.kind,
+            LoopHostMilestoneKind::ModelTextDelta { .. }
+        ) {
+            self.text_coalescer.flush_boundary(milestone.run_id);
+        }
         match &milestone.kind {
             LoopHostMilestoneKind::ModelTextDelta { safe_text } => {
                 self.publish_text_delta(&milestone, safe_text);

--- a/crates/ironclaw_reborn_composition/src/projection/tests/live_progress_stream.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/tests/live_progress_stream.rs
@@ -120,6 +120,21 @@ async fn webui_event_stream_drains_live_assistant_text_projection_from_update_so
             .await
             .unwrap();
     }
+    fixture
+        .sink
+        .publish_loop_milestone(LoopHostMilestone {
+            scope: scope.clone(),
+            actor: None,
+            turn_id: TurnId::new(),
+            run_id,
+            loop_driver_id: LoopDriverId::new("test_loop").unwrap(),
+            kind: LoopHostMilestoneKind::CapabilityInvoked {
+                activity_id: CapabilityActivityId::new(),
+                capability_id: CapabilityId::new("builtin.test").unwrap(),
+            },
+        })
+        .await
+        .unwrap();
 
     let events = fixture
         .services
@@ -163,6 +178,156 @@ async fn webui_event_stream_drains_live_assistant_text_projection_from_update_so
     );
     let wire = serde_json::to_string(&events).unwrap();
     assert!(!wire.contains(secret_like_token));
+}
+
+#[tokio::test]
+async fn live_assistant_text_coalescer_flushes_latest_update_on_timer() {
+    let fixture = live_projection_fixture("webui-text-timer");
+    let scope = fixture.scope.clone();
+    let run_id = TurnRunId::new();
+    let mut subscription = fixture
+        .services
+        .webui_event_stream()
+        .subscribe(ProjectionSubscriptionRequest {
+            actor: TurnActor::new(fixture.user_id.clone()),
+            scope: scope.clone(),
+            after_cursor: None,
+        })
+        .await
+        .unwrap();
+    let milestone = |safe_text| LoopHostMilestone {
+        scope: scope.clone(),
+        actor: None,
+        turn_id: TurnId::new(),
+        run_id,
+        loop_driver_id: LoopDriverId::new("test_loop").unwrap(),
+        kind: LoopHostMilestoneKind::ModelTextDelta { safe_text },
+    };
+
+    fixture
+        .sink
+        .publish_loop_milestone(milestone("first".to_string()))
+        .await
+        .unwrap();
+    fixture
+        .sink
+        .publish_loop_milestone(milestone("latest".to_string()))
+        .await
+        .unwrap();
+
+    let mut text_bodies = Vec::new();
+    for _ in 0..2 {
+        let envelope = tokio::time::timeout(std::time::Duration::from_secs(1), subscription.next())
+            .await
+            .expect("coalesced live projection event")
+            .expect("live projection subscription remains open")
+            .expect("live projection event remains valid");
+        let ProductOutboundPayload::ProjectionUpdate { state } = envelope.payload() else {
+            continue;
+        };
+        text_bodies.extend(state.items.iter().filter_map(|item| match item {
+            ProductProjectionItem::Text {
+                run_id: observed_run_id,
+                body,
+                ..
+            } if *observed_run_id == Some(run_id) => Some(body.clone()),
+            _ => None,
+        }));
+    }
+
+    assert_eq!(text_bodies, vec!["first", "latest"]);
+}
+
+#[tokio::test]
+async fn live_assistant_text_burst_stays_subscribed_and_flushes_before_tool_activity() {
+    let fixture = live_projection_fixture("webui-text-burst");
+    let scope = fixture.scope.clone();
+    let run_id = TurnRunId::new();
+    let capability_id = CapabilityId::new("builtin.http").unwrap();
+    let activity_id = CapabilityActivityId::new();
+    let mut subscription = fixture
+        .services
+        .webui_event_stream()
+        .subscribe(ProjectionSubscriptionRequest {
+            actor: TurnActor::new(fixture.user_id.clone()),
+            scope: scope.clone(),
+            after_cursor: None,
+        })
+        .await
+        .unwrap();
+
+    let milestone = |kind| LoopHostMilestone {
+        scope: scope.clone(),
+        actor: None,
+        turn_id: TurnId::new(),
+        run_id,
+        loop_driver_id: LoopDriverId::new("test_loop").unwrap(),
+        kind,
+    };
+
+    for index in 0..64 {
+        fixture
+            .sink
+            .publish_loop_milestone(milestone(LoopHostMilestoneKind::ModelTextDelta {
+                safe_text: format!("partial answer {index}"),
+            }))
+            .await
+            .unwrap();
+    }
+    fixture
+        .sink
+        .publish_loop_milestone(milestone(LoopHostMilestoneKind::CapabilityInvoked {
+            activity_id,
+            capability_id: capability_id.clone(),
+        }))
+        .await
+        .unwrap();
+
+    let mut text_bodies = Vec::new();
+    let mut saw_tool = false;
+    for _ in 0..8 {
+        let envelope = tokio::time::timeout(std::time::Duration::from_secs(1), subscription.next())
+            .await
+            .expect("live projection event")
+            .expect("live projection subscription remains open")
+            .expect("live projection event remains valid");
+
+        let ProductOutboundPayload::ProjectionUpdate { state } = envelope.payload() else {
+            continue;
+        };
+        for item in &state.items {
+            match item {
+                ProductProjectionItem::Text {
+                    run_id: observed_run_id,
+                    body,
+                    ..
+                } if *observed_run_id == Some(run_id) => text_bodies.push(body.clone()),
+                ProductProjectionItem::CapabilityActivity(activity)
+                    if activity.invocation_id == InvocationId::from_uuid(activity_id.as_uuid()) =>
+                {
+                    saw_tool = true;
+                }
+                _ => {}
+            }
+        }
+        if saw_tool {
+            break;
+        }
+    }
+
+    assert!(
+        saw_tool,
+        "the text burst must not terminate the live subscription"
+    );
+    assert_eq!(
+        text_bodies.last().map(String::as_str),
+        Some("partial answer 63"),
+        "the tool boundary must flush the latest cumulative assistant text"
+    );
+    assert!(
+        text_bodies.len() <= 3,
+        "the 64-update burst should be coalesced before delivery: {text_bodies:#?}"
+    );
 }
 
 // The post-run skill-learning notifier publishes a learned-skill bubble

--- a/crates/ironclaw_reborn_composition/src/projection/tests/live_progress_stream.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/tests/live_progress_stream.rs
@@ -285,6 +285,7 @@ async fn live_assistant_text_burst_stays_subscribed_and_flushes_before_tool_acti
 
     let mut text_bodies = Vec::new();
     let mut saw_tool = false;
+    let mut latest_text_preceded_tool = false;
     for _ in 0..8 {
         let envelope = tokio::time::timeout(std::time::Duration::from_secs(1), subscription.next())
             .await
@@ -305,6 +306,8 @@ async fn live_assistant_text_burst_stays_subscribed_and_flushes_before_tool_acti
                 ProductProjectionItem::CapabilityActivity(activity)
                     if activity.invocation_id == InvocationId::from_uuid(activity_id.as_uuid()) =>
                 {
+                    latest_text_preceded_tool =
+                        text_bodies.last().map(String::as_str) == Some("partial answer 63");
                     saw_tool = true;
                 }
                 _ => {}
@@ -318,6 +321,10 @@ async fn live_assistant_text_burst_stays_subscribed_and_flushes_before_tool_acti
     assert!(
         saw_tool,
         "the text burst must not terminate the live subscription"
+    );
+    assert!(
+        latest_text_preceded_tool,
+        "releasing the state lock must not reorder the latest text after tool activity"
     );
     assert_eq!(
         text_bodies.last().map(String::as_str),


### PR DESCRIPTION
## What changed

- coalesce cumulative live assistant-text projections at the producer boundary
- publish the first text update immediately and the latest replacement at most once every 75 ms
- flush pending text before reasoning, capability, and lifecycle milestones
- reduce missing-subscriber diagnostics to one message per outage period
- add caller-level regressions for sustained text updates and burst backpressure

## Root cause

The model milestone sink published the full cumulative assistant body for every provider chunk. Fast providers could emit roughly 45 updates per second into a bounded 16-item projection subscription. Once that queue filled, the subscriber was terminated for backpressure; subsequent publishes had no receiver and logged `projection stream source failed` for every chunk until the browser reconnected.

## User impact

Assistant text remains responsive—the first update is immediate and subsequent visible updates are capped at roughly 13 per second. Redundant intermediate cumulative snapshots may be skipped, while the latest text and ordered tool/reasoning/lifecycle events are preserved. This prevents provider-rate text bursts from disconnecting SSE/WebSocket streaming.

## Validation

- `cargo test -p ironclaw_reborn_composition --lib --locked projection::tests::live_progress_stream -- --nocapture` — 9 passed
- `cargo clippy -p ironclaw_reborn_composition --lib --no-deps --locked -- -D warnings` — passed for this package
- `cargo fmt --all -- --check` — passed
- `git diff --check` — passed

Full dependency Clippy initially exposed pre-existing dead-code warnings in a dependency; the PR's all-features CI Clippy subsequently passed.

## Railway preview validation

Preview: https://ironclaw-ironclaw-pr-5922.up.railway.app

Tested the deployed commit through the authenticated WebUI v2 API and real SSE endpoint:

- opened three simultaneous thread subscriptions and submitted two concurrent 100-line responses plus one 220-line sustained response
- all submissions returned HTTP 200 and all runs reached `completed`
- the long response streamed 16,623 characters through 322 visible text updates
- update cadence was 76 ms median and 79 ms p95 on the long run
- no SSE disconnects, JSON parse failures, projection-source errors, source lag, or subscriber backpressure
- submitted a 50-line follow-up on the first thread after it became idle; the existing SSE connection resumed without reconnecting
- final timelines contained finalized assistant messages matching the streamed response sizes
- all PR checks, including all-features Clippy and Reborn WebUI smoke/E2E, passed

Visual browser automation was not available because the in-app browser filtered the Railway preview domain and the Chrome extension was unavailable. The deployed HTTP, authentication, concurrency, projection, SSE, and timeline paths were exercised directly.
