### PR TITLE
ci: defer broad WASM compatibility checks to merge queue

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -18,6 +18,12 @@ on `push` to main, the merge queue must run it in the same shape first
 instead). External/live checks (canaries, deploys, releases, benchmark
 thresholds) are exempt: they stay out of the queue by design.
 
+The WASM WIT compatibility lane uses two risk scopes. Pull requests run it only
+for direct WIT, WASM host, extension, compatibility-test, or lane-workflow
+changes. Root `Cargo.toml` and `Cargo.lock` changes are broader workspace risk:
+they run the lane in the merge queue, before landing, without adding the full
+WASM build to ordinary PR feedback. Push and deep-CI runs remain exhaustive.
+
 History: the slim-vs-full clippy matrix violated this — the queue linted only
 `--all-features` while push linted `all-features`/`default`/`libsql-only`, so
 feature-gated dead code (e.g. a `#[cfg(feature = "postgres")]`-constructed enum

--- a/.github/workflows/platform-and-compat.yml
+++ b/.github/workflows/platform-and-compat.yml
@@ -243,9 +243,10 @@ jobs:
   wasm-wit-compat:
     name: WASM WIT Compatibility
     needs: changes
+    # WIT and registry paths are outside the shared legacy-test classifier;
+    # the event-specific WASM risk outputs are authoritative for this job.
     if: >
       needs.changes.outputs.docs_only != 'true' &&
-      needs.changes.outputs.has_legacy_tests == 'true' &&
       (github.event_name == 'push' ||
        inputs.deep == true ||
        (github.event_name == 'merge_group' && needs.changes.outputs.has_wasm_abi_risk == 'true') ||

--- a/.github/workflows/platform-and-compat.yml
+++ b/.github/workflows/platform-and-compat.yml
@@ -59,6 +59,7 @@ jobs:
       has_core_code: ${{ steps.non_diff.outputs.has_core_code || steps.diff.outputs.has_core_code }}
       has_runtime_heavy_risk: ${{ steps.non_diff.outputs.has_runtime_heavy_risk || steps.diff.outputs.has_runtime_heavy_risk }}
       has_web_risk: ${{ steps.non_diff.outputs.has_web_risk || steps.diff.outputs.has_web_risk }}
+      has_direct_wasm_abi_risk: ${{ steps.non_diff.outputs.has_direct_wasm_abi_risk || steps.diff.outputs.has_direct_wasm_abi_risk }}
       has_wasm_abi_risk: ${{ steps.non_diff.outputs.has_wasm_abi_risk || steps.diff.outputs.has_wasm_abi_risk }}
       has_telegram_risk: ${{ steps.non_diff.outputs.has_telegram_risk || steps.diff.outputs.has_telegram_risk }}
       has_slack_risk: ${{ steps.non_diff.outputs.has_slack_risk || steps.diff.outputs.has_slack_risk }}
@@ -76,6 +77,7 @@ jobs:
           # workflow. The merge queue runs only smoke coverage for web-risk
           # changes so queued merges remain fast.
           echo "has_web_risk=false" >> "$GITHUB_OUTPUT"
+          echo "has_direct_wasm_abi_risk=true" >> "$GITHUB_OUTPUT"
           echo "has_wasm_abi_risk=true" >> "$GITHUB_OUTPUT"
           echo "has_telegram_risk=true" >> "$GITHUB_OUTPUT"
           echo "has_slack_risk=true" >> "$GITHUB_OUTPUT"
@@ -118,7 +120,13 @@ jobs:
             echo "has_web_risk=false" >> "$GITHUB_OUTPUT"
           fi
 
-          if has_match '^(wit/|crates/ironclaw_common/|crates/ironclaw_first_party_extensions/assets/.*/(manifest\.toml|wasm-src/)|src/(channels/wasm|extensions|registry|tools/mcp|tools/wasm)/|channels-src/|tools-src/|registry/|scripts/build-wasm-extensions\.sh$|scripts/check-version-bumps\.sh$|tests/wit_compat\.rs$|tests/wasm_channel_integration\.rs$|tests/e2e_wasm_.*|Cargo\.toml$|Cargo\.lock$|\.github/workflows/(test|nightly-deep-ci)\.yml$)'; then
+          has_direct_wasm_abi_risk=false
+          if has_match '^(wit/|crates/ironclaw_common/|crates/ironclaw_first_party_extensions/assets/.*/(manifest\.toml|wasm-src/)|src/(channels/wasm|extensions|registry|tools/mcp|tools/wasm)/|channels-src/|tools-src/|registry/|scripts/build-wasm-extensions\.sh$|scripts/check-version-bumps\.sh$|tests/wit_compat\.rs$|tests/wasm_channel_integration\.rs$|tests/e2e_wasm_.*|\.github/workflows/(platform-and-compat|test|nightly-deep-ci)\.yml$)'; then
+            has_direct_wasm_abi_risk=true
+          fi
+          echo "has_direct_wasm_abi_risk=$has_direct_wasm_abi_risk" >> "$GITHUB_OUTPUT"
+
+          if [ "$has_direct_wasm_abi_risk" = true ] || has_match '^(Cargo\.toml|Cargo\.lock)$'; then
             echo "has_wasm_abi_risk=true" >> "$GITHUB_OUTPUT"
           else
             echo "has_wasm_abi_risk=false" >> "$GITHUB_OUTPUT"
@@ -238,7 +246,10 @@ jobs:
     if: >
       needs.changes.outputs.docs_only != 'true' &&
       needs.changes.outputs.has_legacy_tests == 'true' &&
-      (github.event_name == 'push' || inputs.deep == true || needs.changes.outputs.has_wasm_abi_risk == 'true')
+      (github.event_name == 'push' ||
+       inputs.deep == true ||
+       (github.event_name == 'merge_group' && needs.changes.outputs.has_wasm_abi_risk == 'true') ||
+       (github.event_name == 'pull_request' && needs.changes.outputs.has_direct_wasm_abi_risk == 'true'))
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:


### PR DESCRIPTION
## Summary

- split WASM compatibility scope into direct ABI risk and broader workspace risk
- keep direct WIT, WASM host, extension, test, and workflow changes in PR feedback
- defer root `Cargo.toml` and `Cargo.lock` risk to the merge queue while retaining push and deep-CI coverage
- document the two-scope policy in the CI contract

## Why

The full WASM WIT compatibility lane takes roughly 19-30 minutes and was triggered by any root Cargo metadata change. That made unrelated workspace changes, including crate renames, pay the full WASM build cost during PR iteration. The merge queue already tests the merged state before `main`, so broad Cargo risk can move there without becoming a post-merge-only failure.

## Validation

- `actionlint` v1.7.7
- Ruby YAML parse
- `git diff --check`
- representative direct/broad classifier cases
- PR #5901 changed-file classification: `direct_wasm_risk=false`, `broad_wasm_risk=true`
