### PR TITLE
fix(coding): virtualize the workspace root

### DIFF
--- a/crates/ironclaw_capabilities/src/host.rs
+++ b/crates/ironclaw_capabilities/src/host.rs
@@ -1371,10 +1371,11 @@ where
                 return Err(error);
             }
         };
-        let effective_mounts = obligation_outcome
-            .mounts
-            .clone()
-            .unwrap_or_else(|| authorized_context.mounts.clone());
+        let effective_mounts = effective_dispatch_mounts(
+            obligation_outcome.mounts.clone(),
+            &authorized_context.mounts,
+        )
+        .unwrap_or_default();
         let resource_reservation_id = obligation_outcome
             .resource_reservation
             .as_ref()
@@ -1684,10 +1685,9 @@ where
             }
         }
 
-        let effective_mounts = obligation_outcome
-            .mounts
-            .clone()
-            .unwrap_or_else(|| request.context.mounts.clone());
+        let effective_mounts =
+            effective_dispatch_mounts(obligation_outcome.mounts.clone(), &request.context.mounts)
+                .unwrap_or_default();
         let resource_reservation_id = obligation_outcome
             .resource_reservation
             .as_ref()

--- a/crates/ironclaw_capabilities/src/host.rs
+++ b/crates/ironclaw_capabilities/src/host.rs
@@ -5,8 +5,8 @@ use ironclaw_extensions::ExtensionRegistry;
 use ironclaw_host_api::{
     CapabilityDescriptor, CapabilityDispatchRequest, CapabilityDispatchResult,
     CapabilityDispatcher, CapabilityGrantId, CapabilityId, Decision, DenyReason, DispatchError,
-    ExecutionContext, InvocationFingerprint, InvocationId, Obligation, ProcessId, ResourceEstimate,
-    ResourceScope,
+    ExecutionContext, InvocationFingerprint, InvocationId, MountView, Obligation, ProcessId,
+    ResourceEstimate, ResourceScope,
 };
 use ironclaw_processes::{ProcessManager, ProcessStart};
 use ironclaw_run_state::{
@@ -94,6 +94,23 @@ struct ResumedDispatchParams<'r> {
     descriptor: &'r CapabilityDescriptor,
     /// Approval-lease state for this resume.  See [`ResumedLeaseState`].
     lease_state: ResumedLeaseState<'r>,
+}
+
+fn effective_dispatch_mounts(
+    obligation_mounts: Option<MountView>,
+    context_mounts: &MountView,
+) -> Option<MountView> {
+    // Empty obligation mount views mean "no additional mount terms" for
+    // ambient grants; they must not erase the execution context's mounts.
+    obligation_mounts
+        .filter(|mounts| !mounts.mounts.is_empty())
+        .or_else(|| {
+            if context_mounts.mounts.is_empty() {
+                None
+            } else {
+                Some(context_mounts.clone())
+            }
+        })
 }
 
 impl<'a, D> CapabilityHost<'a, D>
@@ -494,6 +511,8 @@ where
             }
         }
 
+        let dispatch_mounts =
+            effective_dispatch_mounts(obligation_outcome.mounts.clone(), &request.context.mounts);
         debug!("capability dispatch starting");
         let dispatch = match self
             .dispatcher
@@ -501,7 +520,7 @@ where
                 capability_id: request.capability_id.clone(),
                 scope: scope.clone(),
                 estimate: request.estimate.clone(),
-                mounts: obligation_outcome.mounts.clone(),
+                mounts: dispatch_mounts,
                 resource_reservation: obligation_outcome.resource_reservation.clone(),
                 input: request.input,
             })
@@ -1894,13 +1913,17 @@ where
             }
         };
 
+        let dispatch_mounts = effective_dispatch_mounts(
+            obligation_outcome.mounts.clone(),
+            &authorized_context.mounts,
+        );
         let dispatch = match self
             .dispatcher
             .dispatch_json(CapabilityDispatchRequest {
                 capability_id: capability_id.clone(),
                 scope: scope.clone(),
                 estimate: estimate.clone(),
-                mounts: obligation_outcome.mounts.clone(),
+                mounts: dispatch_mounts,
                 resource_reservation: obligation_outcome.resource_reservation.clone(),
                 input,
             })

--- a/crates/ironclaw_first_party_extensions/src/coding/file.rs
+++ b/crates/ironclaw_first_party_extensions/src/coding/file.rs
@@ -20,10 +20,10 @@ use super::{
     operation_error_with_summary,
     patch::{parse_apply_patch_input, replacement_error},
     paths::{
-        create_parent_dir_unless_sensitive, deny_sensitive_existing_path, filesystem_error,
-        is_excluded_name, is_sensitive_scoped_path, is_workspace_path, operation_allowed,
-        resolve_optional_path, resolve_required_path, scoped_child_path, stat_optional,
-        virtual_to_relative,
+        create_parent_dir_unless_sensitive, filesystem_error, is_excluded_name,
+        is_sensitive_scoped_path, is_workspace_path, list_dir_or_empty_mount_root,
+        operation_allowed, resolve_optional_path, resolve_required_path, scoped_child_path,
+        stat_optional, stat_or_empty_mount_root, virtual_to_relative,
     },
     state::{SharedCodingEditLocks, read_scope_key},
     text::{
@@ -375,7 +375,12 @@ pub(super) async fn list_dir(
     request: &CodingCapabilityRequest<'_>,
 ) -> Result<Value, CodingCapabilityError> {
     let resolved = resolve_optional_path(request, FilesystemOperation::ListDir)?;
-    deny_sensitive_existing_path(request, &resolved.virtual_path).await?;
+    let root_stat = stat_or_empty_mount_root(request, &resolved).await?;
+    if root_stat.is_some_and(|stat| stat.sensitive) {
+        return Err(CodingCapabilityError::new(
+            RuntimeDispatchErrorKind::FilesystemDenied,
+        ));
+    }
     let recursive = request
         .input
         .get("recursive")
@@ -405,11 +410,7 @@ async fn collect_list_entries(
     let mut stack = vec![(root.virtual_path.clone(), 0usize)];
     let mut visited = 0usize;
     while let Some((dir, depth)) = stack.pop() {
-        let entries = request
-            .filesystem
-            .list_dir(&dir)
-            .await
-            .map_err(filesystem_error)?;
+        let entries = list_dir_or_empty_mount_root(request, root, &dir).await?;
         for entry in entries {
             visited += 1;
             if visited > MAX_VISITED_ENTRIES {

--- a/crates/ironclaw_first_party_extensions/src/coding/glob_tool.rs
+++ b/crates/ironclaw_first_party_extensions/src/coding/glob_tool.rs
@@ -13,7 +13,8 @@ use super::{
     inputs::{optional_usize, required_str},
     paths::{
         filesystem_error, is_excluded_name, is_excluded_relative_path, is_sensitive_scoped_path,
-        resolve_optional_path, scoped_child_path, validate_relative_pattern, virtual_to_relative,
+        list_dir_or_empty_mount_root, resolve_optional_path, scoped_child_path,
+        validate_relative_pattern, virtual_to_relative,
     },
     types::ResolvedPath,
 };
@@ -89,11 +90,7 @@ async fn walk_entries(
     let mut stack = vec![root.virtual_path.clone()];
     let mut visited = 0usize;
     while let Some(dir) = stack.pop() {
-        let entries = request
-            .filesystem
-            .list_dir(&dir)
-            .await
-            .map_err(filesystem_error)?;
+        let entries = list_dir_or_empty_mount_root(request, root, &dir).await?;
         for entry in entries {
             visited += 1;
             if visited > MAX_VISITED_ENTRIES {

--- a/crates/ironclaw_first_party_extensions/src/coding/grep_tool.rs
+++ b/crates/ironclaw_first_party_extensions/src/coding/grep_tool.rs
@@ -22,9 +22,9 @@ use super::{
     input_error,
     inputs::{optional_usize, optional_usize_allow_zero, required_str},
     paths::{
-        filesystem_error, is_excluded_name, is_sensitive_scoped_path, operation_allowed,
-        resolve_optional_path, scoped_child_path, type_filter_matches, validate_relative_pattern,
-        virtual_to_relative,
+        filesystem_error, is_excluded_name, is_sensitive_scoped_path, list_dir_or_empty_mount_root,
+        operation_allowed, resolve_optional_path, scoped_child_path, stat_or_empty_mount_root,
+        type_filter_matches, validate_relative_pattern, virtual_to_relative,
     },
     text::{decode_text, previous_char_boundary, reject_binary_probe},
     types::{GrepFileResult, GrepLine, ResolvedPath},
@@ -39,24 +39,25 @@ pub(super) async fn grep(
             RuntimeDispatchErrorKind::FilesystemDenied,
         ));
     }
-    let root_stat = request
-        .filesystem
-        .stat(&resolved.virtual_path)
-        .await
-        .map_err(filesystem_error)?;
-    if root_stat.sensitive {
+    let root_stat = stat_or_empty_mount_root(request, &resolved).await?;
+    if root_stat.as_ref().is_some_and(|stat| stat.sensitive) {
         return Err(CodingCapabilityError::new(
             RuntimeDispatchErrorKind::FilesystemDenied,
         ));
     }
-    if root_stat.file_type == FileType::Directory
+    if root_stat
+        .as_ref()
+        .is_some_and(|stat| stat.file_type == FileType::Directory)
         && !operation_allowed(&resolved.grant.permissions, FilesystemOperation::ListDir)
     {
         return Err(CodingCapabilityError::new(
             RuntimeDispatchErrorKind::FilesystemDenied,
         ));
     }
-    if !matches!(root_stat.file_type, FileType::File | FileType::Directory) {
+    if root_stat
+        .as_ref()
+        .is_some_and(|stat| !matches!(stat.file_type, FileType::File | FileType::Directory))
+    {
         return Err(CodingCapabilityError::new(
             RuntimeDispatchErrorKind::Resource,
         ));
@@ -187,11 +188,14 @@ enum ScanLimit {
 async fn walk_files(
     request: &CodingCapabilityRequest<'_>,
     root: &ResolvedPath,
-    root_stat: FileStat,
+    root_stat: Option<FileStat>,
     mut include: impl FnMut(&str) -> bool,
     mut visit: impl FnMut(&str, &[u8], Option<SystemTime>) -> Result<bool, CodingCapabilityError>,
 ) -> Result<WalkFilesResult, CodingCapabilityError> {
     let mut walk_result = WalkFilesResult::default();
+    let Some(root_stat) = root_stat else {
+        return Ok(walk_result);
+    };
     if root_stat.file_type == FileType::File {
         let relative = root_file_relative(&root.scoped_path);
         if include(&relative)
@@ -216,11 +220,7 @@ async fn walk_files(
     let mut stack = vec![root.virtual_path.clone()];
     let mut visited = 0usize;
     while let Some(dir) = stack.pop() {
-        let entries = request
-            .filesystem
-            .list_dir(&dir)
-            .await
-            .map_err(filesystem_error)?;
+        let entries = list_dir_or_empty_mount_root(request, root, &dir).await?;
         for entry in entries {
             visited += 1;
             if visited > MAX_VISITED_ENTRIES {

--- a/crates/ironclaw_first_party_extensions/src/coding/grep_tool.rs
+++ b/crates/ironclaw_first_party_extensions/src/coding/grep_tool.rs
@@ -45,9 +45,11 @@ pub(super) async fn grep(
             RuntimeDispatchErrorKind::FilesystemDenied,
         ));
     }
-    if root_stat
+    let root_is_directory = root_stat
         .as_ref()
-        .is_some_and(|stat| stat.file_type == FileType::Directory)
+        .map(|stat| stat.file_type == FileType::Directory)
+        .unwrap_or(true);
+    if root_is_directory
         && !operation_allowed(&resolved.grant.permissions, FilesystemOperation::ListDir)
     {
         return Err(CodingCapabilityError::new(

--- a/crates/ironclaw_first_party_extensions/src/coding/paths.rs
+++ b/crates/ironclaw_first_party_extensions/src/coding/paths.rs
@@ -1,4 +1,4 @@
-use ironclaw_filesystem::{FileStat, FilesystemError, FilesystemOperation};
+use ironclaw_filesystem::{DirEntry, FileStat, FilesystemError, FilesystemOperation};
 use ironclaw_host_api::{RuntimeDispatchErrorKind, ScopedPath, VirtualPath};
 use ironclaw_safety::sensitive_paths::is_sensitive_path_str;
 use serde_json::Value;
@@ -70,15 +70,15 @@ fn resolve_path(
 }
 
 fn scoped_path_input(path: &str) -> String {
-    if path == "." || path.is_empty() {
+    if path == "." || path.is_empty() || path == "/" {
         DEFAULT_SCOPED_ROOT.to_string()
     } else if path.starts_with('/') {
         path.to_string()
-    } else if let Some(scoped_workspace_path) = workspace_scoped_alias(path) {
-        scoped_workspace_path
     } else {
-        let relative = path.trim_start_matches("./");
-        format!("{DEFAULT_SCOPED_ROOT}/{relative}")
+        workspace_scoped_alias(path).unwrap_or_else(|| {
+            let relative = path.trim_start_matches("./");
+            format!("{DEFAULT_SCOPED_ROOT}/{relative}")
+        })
     }
 }
 
@@ -144,6 +144,41 @@ pub(super) async fn stat_optional(
     }
 }
 
+/// A caller's mount target is logically an empty directory until its first
+/// write. Backends such as libSQL do not materialize that directory, so reads
+/// of the mount root must preserve the virtual filesystem contract and return
+/// an empty result. Missing subpaths remain errors.
+pub(super) async fn stat_or_empty_mount_root(
+    request: &CodingCapabilityRequest<'_>,
+    resolved: &ResolvedPath,
+) -> Result<Option<FileStat>, CodingCapabilityError> {
+    match request.filesystem.stat(&resolved.virtual_path).await {
+        Ok(stat) => Ok(Some(stat)),
+        Err(FilesystemError::NotFound { .. }) if is_mount_root(resolved) => Ok(None),
+        Err(error) => Err(filesystem_error(error)),
+    }
+}
+
+pub(super) async fn list_dir_or_empty_mount_root(
+    request: &CodingCapabilityRequest<'_>,
+    root: &ResolvedPath,
+    path: &VirtualPath,
+) -> Result<Vec<DirEntry>, CodingCapabilityError> {
+    match request.filesystem.list_dir(path).await {
+        Ok(entries) => Ok(entries),
+        Err(FilesystemError::NotFound { .. })
+            if path == &root.virtual_path && is_mount_root(root) =>
+        {
+            Ok(Vec::new())
+        }
+        Err(error) => Err(filesystem_error(error)),
+    }
+}
+
+fn is_mount_root(resolved: &ResolvedPath) -> bool {
+    resolved.virtual_path == resolved.grant.target
+}
+
 pub(super) async fn create_parent_dir_unless_sensitive(
     request: &CodingCapabilityRequest<'_>,
     path: &VirtualPath,
@@ -157,23 +192,6 @@ pub(super) async fn create_parent_dir_unless_sensitive(
         .create_dir_all(&parent)
         .await
         .map_err(filesystem_denied_if_not_found)
-}
-
-pub(super) async fn deny_sensitive_existing_path(
-    request: &CodingCapabilityRequest<'_>,
-    path: &VirtualPath,
-) -> Result<(), CodingCapabilityError> {
-    let stat = request
-        .filesystem
-        .stat(path)
-        .await
-        .map_err(filesystem_error)?;
-    if stat.sensitive {
-        return Err(CodingCapabilityError::new(
-            RuntimeDispatchErrorKind::FilesystemDenied,
-        ));
-    }
-    Ok(())
 }
 
 /// Walk up the directory tree, denying if any existing parent is sensitive.

--- a/crates/ironclaw_host_runtime/src/first_party_tools/shell.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/shell.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use ironclaw_host_api::{
     EffectKind, PermissionMode, ResourceCeiling, ResourceEstimate, ResourceProfile,
-    RuntimeDispatchErrorKind, SandboxQuota, ScopedPath, VirtualPath,
+    RuntimeDispatchErrorKind, SandboxQuota, VirtualPath,
 };
 use serde_json::{Value, json};
 
@@ -64,7 +64,7 @@ pub(super) async fn dispatch(
     request: &FirstPartyCapabilityRequest,
 ) -> Result<(Value, Duration), FirstPartyCapabilityError> {
     let parsed = shell_core::parse_shell_request(&request.input).map_err(shell_error)?;
-    reject_unbacked_scoped_workdir(request, parsed.workdir.as_deref())?;
+    ensure_scoped_workdir_is_mounted(request, parsed.workdir.as_deref())?;
     if parsed
         .timeout_secs
         .is_some_and(|timeout_secs| timeout_secs > MAX_SHELL_TIMEOUT_SECS)
@@ -206,7 +206,7 @@ fn render_shell_output(
     format!("{output}\n\n{note}")
 }
 
-fn reject_unbacked_scoped_workdir(
+fn ensure_scoped_workdir_is_mounted(
     request: &FirstPartyCapabilityRequest,
     workdir: Option<&str>,
 ) -> Result<(), FirstPartyCapabilityError> {
@@ -220,23 +220,22 @@ fn reject_unbacked_scoped_workdir(
     else {
         return Ok(());
     };
-    let scoped_path = ScopedPath::new(workdir.to_string())
+    let scoped_path = mounts
+        .scoped_path(workdir.to_string())
         .map_err(|_| FirstPartyCapabilityError::new(RuntimeDispatchErrorKind::InputEncode))?;
     let (_virtual_path, grant) = mounts
         .resolve_with_grant(&scoped_path)
         .map_err(|_| FirstPartyCapabilityError::new(RuntimeDispatchErrorKind::Client))?;
-    if !grant.permissions.execute {
+    if !(grant.permissions.read
+        || grant.permissions.write
+        || grant.permissions.list
+        || grant.permissions.execute)
+    {
         return Err(FirstPartyCapabilityError::new(
             RuntimeDispatchErrorKind::Client,
         ));
     }
-
-    // Shell execution still uses the local process fallback. Until the resolved
-    // process backend can receive virtual cwd + scoped mounts, fail closed rather
-    // than translating scoped paths to ambient host paths in this handler.
-    Err(FirstPartyCapabilityError::new(
-        RuntimeDispatchErrorKind::Client,
-    ))
+    Ok(())
 }
 
 fn shell_error(error: shell_core::ShellExecutionError) -> FirstPartyCapabilityError {

--- a/crates/ironclaw_host_runtime/src/first_party_tools/shell.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/shell.rs
@@ -220,12 +220,23 @@ fn ensure_scoped_workdir_is_mounted(
     else {
         return Ok(());
     };
-    let scoped_path = mounts
-        .scoped_path(workdir.to_string())
-        .map_err(|_| FirstPartyCapabilityError::new(RuntimeDispatchErrorKind::InputEncode))?;
-    let (_virtual_path, grant) = mounts
-        .resolve_with_grant(&scoped_path)
-        .map_err(|_| FirstPartyCapabilityError::new(RuntimeDispatchErrorKind::Client))?;
+    let scoped_path = mounts.scoped_path(workdir.to_string()).map_err(|error| {
+        tracing::debug!(
+            workdir,
+            %error,
+            "rejecting shell workdir because it is not a valid scoped path"
+        );
+        FirstPartyCapabilityError::new(RuntimeDispatchErrorKind::InputEncode)
+    })?;
+    let (_virtual_path, grant) = mounts.resolve_with_grant(&scoped_path).map_err(|error| {
+        tracing::debug!(
+            workdir,
+            scoped_path = scoped_path.as_str(),
+            %error,
+            "rejecting shell workdir because it is not backed by the authorized mount view"
+        );
+        FirstPartyCapabilityError::new(RuntimeDispatchErrorKind::Client)
+    })?;
     if !(grant.permissions.read
         || grant.permissions.write
         || grant.permissions.list

--- a/crates/ironclaw_host_runtime/src/process_aliases.rs
+++ b/crates/ironclaw_host_runtime/src/process_aliases.rs
@@ -28,6 +28,10 @@ impl LocalHostWorkdirAlias {
         &self.alias
     }
 
+    pub(crate) fn host_path(&self) -> &Path {
+        &self.host_path
+    }
+
     fn resolve(&self, workdir: &str) -> Option<PathBuf> {
         if workdir == self.alias {
             return Some(PathBuf::new());

--- a/crates/ironclaw_host_runtime/src/process_aliases.rs
+++ b/crates/ironclaw_host_runtime/src/process_aliases.rs
@@ -24,6 +24,10 @@ impl LocalHostWorkdirAlias {
         Ok(Self { alias, host_path })
     }
 
+    pub(crate) fn alias(&self) -> &str {
+        &self.alias
+    }
+
     fn resolve(&self, workdir: &str) -> Option<PathBuf> {
         if workdir == self.alias {
             return Some(PathBuf::new());

--- a/crates/ironclaw_host_runtime/src/process_port.rs
+++ b/crates/ironclaw_host_runtime/src/process_port.rs
@@ -390,6 +390,7 @@ impl LocalHostProcessPort {
         validate_mount_source_path(cwd, &guards, "working directory")?;
         validate_raw_mount_source_paths(command, &guards)?;
         validate_relative_mount_source_paths(command, cwd, &guards)?;
+        validate_mount_sensitive_shell_expansions(command, &guards)?;
         Ok(())
     }
 
@@ -601,6 +602,75 @@ fn validate_relative_mount_source_paths(
         search_start = token_end;
     }
     Ok(())
+}
+
+fn validate_mount_sensitive_shell_expansions(
+    command: &str,
+    guards: &[LocalHostMountSourceGuard],
+) -> Result<(), RuntimeProcessError> {
+    if !guards.iter().any(LocalHostMountSourceGuard::is_scoped) {
+        return Ok(());
+    }
+    if command.contains('`') || command.contains("$(") {
+        return Err(disallowed_mount_source_path("command expansion"));
+    }
+    let bytes = command.as_bytes();
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] != b'$' {
+            index += 1;
+            continue;
+        }
+        let Some(next) = bytes.get(index + 1).copied() else {
+            break;
+        };
+        if next == b'{' {
+            let Some(relative_end) = command[index + 2..].find('}') else {
+                return Err(disallowed_mount_source_path("command expansion"));
+            };
+            let name_start = index + 2;
+            let name_end = name_start + relative_end;
+            let variable = &command[name_start..name_end];
+            if variable != "PWD"
+                || command[name_end + 1..]
+                    .chars()
+                    .next()
+                    .is_some_and(|ch| ch == '/' || ch == '\\')
+            {
+                return Err(disallowed_mount_source_path("command expansion"));
+            }
+            index = name_end + 2;
+            continue;
+        }
+        if shell_variable_start(next) {
+            let name_start = index + 1;
+            let mut name_end = name_start + 1;
+            while name_end < bytes.len() && shell_variable_char(bytes[name_end]) {
+                name_end += 1;
+            }
+            let variable = &command[name_start..name_end];
+            if variable != "PWD"
+                || command[name_end..]
+                    .chars()
+                    .next()
+                    .is_some_and(|ch| ch == '/' || ch == '\\')
+            {
+                return Err(disallowed_mount_source_path("command expansion"));
+            }
+            index = name_end;
+            continue;
+        }
+        index += 1;
+    }
+    Ok(())
+}
+
+fn shell_variable_start(byte: u8) -> bool {
+    byte.is_ascii_alphabetic() || byte == b'_'
+}
+
+fn shell_variable_char(byte: u8) -> bool {
+    shell_variable_start(byte) || byte.is_ascii_digit()
 }
 
 fn scoped_allowed_root_for_path<'a>(
@@ -1444,6 +1514,51 @@ mod tests {
 
         assert_eq!(output.exit_code, 0);
         assert_eq!(output.output, "..");
+    }
+
+    #[tokio::test]
+    async fn local_host_process_port_rejects_mount_sensitive_shell_expansion() {
+        let workspace = tempfile::tempdir().expect("workspace tempdir");
+        let workspace_root = workspace
+            .path()
+            .canonicalize()
+            .expect("canonical workspace");
+        let scoped_user_root = workspace_root.join("tenants/tenant-a/users/user-a");
+        std::fs::create_dir_all(&scoped_user_root).expect("scoped user dir");
+        let port = LocalHostProcessPort::new_inherited_env()
+            .with_workdir_alias("/workspace", workspace_root.clone())
+            .with_mount_source("/projects/workspace", workspace_root);
+        let mounts = MountView::new(vec![MountGrant::new(
+            MountAlias::new("/workspace").expect("workspace alias"),
+            VirtualPath::new("/projects/workspace/tenants/tenant-a/users/user-a")
+                .expect("workspace target"),
+            MountPermissions::read_write(),
+        )])
+        .expect("mount view");
+
+        for command in [
+            "printf '%s' \"$(pwd)\"",
+            "printf '%s' `pwd`",
+            "printf '%s' \"$HOME\"",
+            "printf hacked > \"$PWD/../user-b/pwned.md\"",
+        ] {
+            let error = port
+                .run_command(CommandExecutionRequest {
+                    scope: ResourceScope::system(),
+                    mounts: Some(mounts.clone()),
+                    command: command.to_string(),
+                    workdir: Some("/workspace".to_string()),
+                    timeout_secs: Some(5),
+                    extra_env: HashMap::new(),
+                })
+                .await
+                .expect_err("mount-sensitive shell expansion should be rejected");
+
+            assert!(
+                matches!(error, RuntimeProcessError::ExecutionFailed(message) if message.contains("outside the mounted workspace")),
+                "unexpected error for {command:?}: {error:?}"
+            );
+        }
     }
 
     #[cfg(windows)]

--- a/crates/ironclaw_host_runtime/src/process_port.rs
+++ b/crates/ironclaw_host_runtime/src/process_port.rs
@@ -1555,7 +1555,7 @@ mod tests {
                 .expect_err("mount-sensitive shell expansion should be rejected");
 
             assert!(
-                matches!(error, RuntimeProcessError::ExecutionFailed(message) if message.contains("outside the mounted workspace")),
+                matches!(&error, RuntimeProcessError::ExecutionFailed(message) if message.contains("outside the mounted workspace")),
                 "unexpected error for {command:?}: {error:?}"
             );
         }

--- a/crates/ironclaw_host_runtime/src/process_port.rs
+++ b/crates/ironclaw_host_runtime/src/process_port.rs
@@ -6,10 +6,15 @@
 //! existing local-host behavior behind an explicit port without changing
 //! placement semantics.
 
-use std::{collections::HashMap, path::PathBuf, process::Stdio, time::Duration};
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+    process::Stdio,
+    time::Duration,
+};
 
 use async_trait::async_trait;
-use ironclaw_host_api::{MountView, ResourceScope};
+use ironclaw_host_api::{MountGrant, MountView, ResourceScope, VirtualPath};
 #[cfg(unix)]
 use libc::{SIGKILL, kill};
 use thiserror::Error;
@@ -176,6 +181,13 @@ pub(crate) enum LocalHostProcessEnvMode {
 pub struct LocalHostProcessPort {
     env_mode: LocalHostProcessEnvMode,
     workdir_aliases: Vec<LocalHostWorkdirAlias>,
+    mount_sources: Vec<LocalHostMountSource>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct LocalHostMountSource {
+    virtual_root: VirtualPath,
+    host_root: PathBuf,
 }
 
 impl LocalHostProcessPort {
@@ -183,6 +195,7 @@ impl LocalHostProcessPort {
         Self {
             env_mode: LocalHostProcessEnvMode::Scrubbed,
             workdir_aliases: Vec::new(),
+            mount_sources: Vec::new(),
         }
     }
 
@@ -190,6 +203,7 @@ impl LocalHostProcessPort {
         Self {
             env_mode: LocalHostProcessEnvMode::Inherited,
             workdir_aliases: Vec::new(),
+            mount_sources: Vec::new(),
         }
     }
 
@@ -207,6 +221,154 @@ impl LocalHostProcessPort {
         }
         self
     }
+
+    pub fn with_mount_source(
+        mut self,
+        virtual_root: impl Into<String>,
+        host_root: impl Into<PathBuf>,
+    ) -> Self {
+        let virtual_root = match VirtualPath::new(virtual_root.into()) {
+            Ok(virtual_root) => virtual_root,
+            Err(reason) => {
+                tracing::debug!(
+                    reason = %reason,
+                    "ignoring invalid local host process mount source"
+                );
+                return self;
+            }
+        };
+        let host_root = match std::fs::canonicalize(host_root.into()) {
+            Ok(host_root) if host_root.is_dir() => host_root,
+            Ok(host_root) => {
+                tracing::debug!(
+                    host_root = ?host_root,
+                    "ignoring local host process mount source because it is not a directory"
+                );
+                return self;
+            }
+            Err(reason) => {
+                tracing::debug!(
+                    reason = %reason,
+                    "ignoring unresolved local host process mount source"
+                );
+                return self;
+            }
+        };
+        if self
+            .mount_sources
+            .iter()
+            .any(|source| source.virtual_root == virtual_root)
+        {
+            tracing::debug!(
+                virtual_root = %virtual_root,
+                "ignoring duplicate local host process mount source"
+            );
+            return self;
+        }
+        self.mount_sources.push(LocalHostMountSource {
+            virtual_root,
+            host_root,
+        });
+        self
+    }
+
+    fn effective_workdir_aliases(
+        &self,
+        mounts: Option<&MountView>,
+    ) -> Result<Vec<LocalHostWorkdirAlias>, RuntimeProcessError> {
+        let mut aliases = self.workdir_aliases.clone();
+        let Some(mounts) = mounts else {
+            return Ok(aliases);
+        };
+
+        for grant in &mounts.mounts {
+            let source = self.resolve_mount_source(grant)?;
+            let Some(host_path) = source else {
+                continue;
+            };
+            let alias = LocalHostWorkdirAlias::try_new(grant.alias.as_str(), host_path)
+                .map_err(RuntimeProcessError::ExecutionFailed)?;
+            if let Some(existing) = aliases
+                .iter_mut()
+                .find(|existing| existing.alias() == alias.alias())
+            {
+                *existing = alias;
+            } else {
+                aliases.push(alias);
+            }
+        }
+
+        Ok(aliases)
+    }
+
+    fn resolve_mount_source(
+        &self,
+        grant: &MountGrant,
+    ) -> Result<Option<PathBuf>, RuntimeProcessError> {
+        let source = self
+            .mount_sources
+            .iter()
+            .filter(|source| {
+                virtual_path_prefix_matches(source.virtual_root.as_str(), grant.target.as_str())
+            })
+            .max_by_key(|source| source.virtual_root.as_str().len());
+
+        let Some(source) = source else {
+            if self
+                .workdir_aliases
+                .iter()
+                .any(|alias| alias.alias() == grant.alias.as_str())
+            {
+                return Err(RuntimeProcessError::ExecutionFailed(format!(
+                    "no trusted local host mount source is configured for virtual path {}",
+                    grant.target
+                )));
+            }
+            return Ok(None);
+        };
+
+        let mut joined = source.host_root.clone();
+        let tail = grant
+            .target
+            .as_str()
+            .strip_prefix(source.virtual_root.as_str())
+            .unwrap_or_default()
+            .trim_start_matches('/');
+        if !tail.is_empty() {
+            for segment in tail.split('/') {
+                joined.push(segment);
+            }
+        }
+
+        if grant.permissions.write {
+            std::fs::create_dir_all(&joined).map_err(|error| {
+                RuntimeProcessError::ExecutionFailed(format!(
+                    "local host mount target {} could not be initialized: {error}",
+                    grant.target
+                ))
+            })?;
+        }
+        let canonical = std::fs::canonicalize(&joined).map_err(|error| {
+            RuntimeProcessError::ExecutionFailed(format!(
+                "local host mount target {} could not be resolved: {error}",
+                grant.target
+            ))
+        })?;
+        if !canonical.starts_with(&source.host_root) {
+            return Err(RuntimeProcessError::ExecutionFailed(format!(
+                "local host mount target {} escapes its trusted source",
+                grant.target
+            )));
+        }
+        if !canonical.is_dir() {
+            return Err(RuntimeProcessError::ExecutionFailed(format!(
+                "local host mount target {} is not a directory",
+                grant.target
+            )));
+        }
+
+        Ok(Some(canonical))
+    }
 }
 
 #[async_trait]
@@ -215,7 +377,8 @@ impl RuntimeProcessPort for LocalHostProcessPort {
         &self,
         request: CommandExecutionRequest,
     ) -> Result<CommandExecutionOutput, RuntimeProcessError> {
-        let cwd = resolve_local_host_workdir(request.workdir.as_deref(), &self.workdir_aliases)
+        let workdir_aliases = self.effective_workdir_aliases(request.mounts.as_ref())?;
+        let cwd = resolve_local_host_workdir(request.workdir.as_deref(), &workdir_aliases)
             .map_err(|e| {
                 RuntimeProcessError::ExecutionFailed(format!(
                     "cannot determine working directory: {e}"
@@ -231,7 +394,7 @@ impl RuntimeProcessPort for LocalHostProcessPort {
                 "running local host command with inherited environment"
             );
         }
-        let command = rewrite_local_host_command_aliases(&request.command, &self.workdir_aliases);
+        let command = rewrite_local_host_command_aliases(&request.command, &workdir_aliases);
         let start = std::time::Instant::now();
         let (output, exit_code) = execute_local_command(
             &request.scope,
@@ -248,7 +411,7 @@ impl RuntimeProcessPort for LocalHostProcessPort {
         // `/workspace` terms and never leaks the host layout into the reply.
         // (The saved-output full result is a separate, non-model-facing UI
         // surface and is left to the result-fetch path.)
-        let preview = rewrite_local_host_output_aliases(&output.preview, &self.workdir_aliases);
+        let preview = rewrite_local_host_output_aliases(&output.preview, &workdir_aliases);
         Ok(CommandExecutionOutput {
             output: preview,
             saved_output: output.saved_output,
@@ -257,6 +420,10 @@ impl RuntimeProcessPort for LocalHostProcessPort {
             duration: start.elapsed(),
         })
     }
+}
+
+fn virtual_path_prefix_matches(prefix: &str, path: &str) -> bool {
+    Path::new(path).starts_with(Path::new(prefix))
 }
 
 async fn execute_local_command(
@@ -363,6 +530,7 @@ mod tests {
     use crate::process_output::COMMAND_MAX_OUTPUT_SIZE;
     #[cfg(unix)]
     use crate::process_output::SavedCommandOutputSanitization;
+    use ironclaw_host_api::{MountAlias, MountPermissions};
     use std::sync::Mutex;
 
     #[derive(Debug)]
@@ -694,6 +862,50 @@ mod tests {
         assert_eq!(output.exit_code, 0);
         assert_eq!(output.output, "ok");
         assert!(scratch.exists());
+    }
+
+    #[tokio::test]
+    async fn local_host_process_port_scopes_workspace_alias_from_request_mounts() {
+        let workspace = tempfile::tempdir().expect("workspace tempdir");
+        let workspace_root = workspace
+            .path()
+            .canonicalize()
+            .expect("canonical workspace");
+        let port = LocalHostProcessPort::new_inherited_env()
+            .with_workdir_alias("/workspace", workspace_root.clone())
+            .with_mount_source("/projects/workspace", workspace_root.clone());
+        let mounts = MountView::new(vec![MountGrant::new(
+            MountAlias::new("/workspace").expect("workspace alias"),
+            VirtualPath::new("/projects/workspace/tenants/tenant-a/users/user-a")
+                .expect("workspace target"),
+            MountPermissions::read_write(),
+        )])
+        .expect("mount view");
+
+        let output = port
+            .run_command(CommandExecutionRequest {
+                scope: ResourceScope::system(),
+                mounts: Some(mounts),
+                command: "printf '# Hello\\n' > /workspace/hello.md && printf '%s' \"$PWD\""
+                    .to_string(),
+                workdir: Some("/workspace".to_string()),
+                timeout_secs: Some(5),
+                extra_env: HashMap::new(),
+            })
+            .await
+            .expect("command succeeds");
+
+        assert_eq!(output.exit_code, 0);
+        assert_eq!(output.output, "/workspace");
+        assert_eq!(
+            std::fs::read_to_string(workspace_root.join("tenants/tenant-a/users/user-a/hello.md"))
+                .expect("scoped shell artifact"),
+            "# Hello\n"
+        );
+        assert!(
+            !workspace_root.join("hello.md").exists(),
+            "scoped shell writes must not land in the raw workspace root"
+        );
     }
 
     #[cfg(windows)]

--- a/crates/ironclaw_host_runtime/src/process_port.rs
+++ b/crates/ironclaw_host_runtime/src/process_port.rs
@@ -563,6 +563,9 @@ fn validate_raw_mount_source_paths(
             break;
         };
         let token = Path::new(&command[token_start..token_end]);
+        if token == Path::new("/") && guards.iter().any(LocalHostMountSourceGuard::is_scoped) {
+            return Err(disallowed_mount_source_path("command path"));
+        }
         if token.is_absolute() {
             validate_mount_source_path(token, guards, "command path")?;
         }
@@ -1323,6 +1326,43 @@ mod tests {
         assert!(
             !other_user_file.exists(),
             "raw host workspace path must not write another user's artifact"
+        );
+    }
+
+    #[tokio::test]
+    async fn local_host_process_port_rejects_raw_root_for_scoped_workspace() {
+        let workspace = tempfile::tempdir().expect("workspace tempdir");
+        let workspace_root = workspace
+            .path()
+            .canonicalize()
+            .expect("canonical workspace");
+        let scoped_user_root = workspace_root.join("tenants/tenant-a/users/user-a");
+        std::fs::create_dir_all(&scoped_user_root).expect("scoped user dir");
+        let port = LocalHostProcessPort::new_inherited_env()
+            .with_workdir_alias("/workspace", workspace_root.clone())
+            .with_mount_source("/projects/workspace", workspace_root);
+        let mounts = MountView::new(vec![MountGrant::new(
+            MountAlias::new("/workspace").expect("workspace alias"),
+            VirtualPath::new("/projects/workspace/tenants/tenant-a/users/user-a")
+                .expect("workspace target"),
+            MountPermissions::read_write(),
+        )])
+        .expect("mount view");
+
+        let error = port
+            .run_command(CommandExecutionRequest {
+                scope: ResourceScope::system(),
+                mounts: Some(mounts),
+                command: "ls /".to_string(),
+                workdir: Some("/workspace".to_string()),
+                timeout_secs: Some(5),
+                extra_env: HashMap::new(),
+            })
+            .await
+            .expect_err("scoped shell must not expose the host root");
+
+        assert!(
+            matches!(error, RuntimeProcessError::ExecutionFailed(message) if message.contains("outside the mounted workspace"))
         );
     }
 

--- a/crates/ironclaw_host_runtime/src/process_port.rs
+++ b/crates/ironclaw_host_runtime/src/process_port.rs
@@ -8,7 +8,7 @@
 
 use std::{
     collections::HashMap,
-    path::{Path, PathBuf},
+    path::{Component, Path, PathBuf},
     process::Stdio,
     time::Duration,
 };
@@ -188,6 +188,7 @@ pub struct LocalHostProcessPort {
 struct LocalHostMountSource {
     virtual_root: VirtualPath,
     host_root: PathBuf,
+    host_root_spellings: Vec<PathBuf>,
 }
 
 impl LocalHostProcessPort {
@@ -237,7 +238,8 @@ impl LocalHostProcessPort {
                 return self;
             }
         };
-        let host_root = match std::fs::canonicalize(host_root.into()) {
+        let configured_host_root = host_root.into();
+        let host_root = match std::fs::canonicalize(&configured_host_root) {
             Ok(host_root) if host_root.is_dir() => host_root,
             Ok(host_root) => {
                 tracing::debug!(
@@ -254,6 +256,10 @@ impl LocalHostProcessPort {
                 return self;
             }
         };
+        let mut host_root_spellings = vec![host_root.clone()];
+        if configured_host_root.is_absolute() && configured_host_root != host_root {
+            host_root_spellings.push(configured_host_root);
+        }
         if self
             .mount_sources
             .iter()
@@ -268,6 +274,7 @@ impl LocalHostProcessPort {
         self.mount_sources.push(LocalHostMountSource {
             virtual_root,
             host_root,
+            host_root_spellings,
         });
         self
     }
@@ -369,6 +376,38 @@ impl LocalHostProcessPort {
 
         Ok(Some(canonical))
     }
+
+    fn validate_mount_source_access(
+        &self,
+        command: &str,
+        cwd: &Path,
+        workdir_aliases: &[LocalHostWorkdirAlias],
+    ) -> Result<(), RuntimeProcessError> {
+        let guards = mount_source_guards(&self.mount_sources, workdir_aliases);
+        if guards.is_empty() {
+            return Ok(());
+        }
+        validate_mount_source_path(cwd, &guards, "working directory")?;
+        validate_raw_mount_source_paths(command, &guards)?;
+        validate_relative_mount_source_paths(command, cwd, &guards)?;
+        Ok(())
+    }
+
+    fn default_scoped_workdir_alias(
+        &self,
+        workdir_aliases: &[LocalHostWorkdirAlias],
+    ) -> Option<String> {
+        workdir_aliases
+            .iter()
+            .filter(|alias| {
+                let host_path = canonicalize_existing_path_prefix(alias.host_path());
+                self.mount_sources.iter().any(|source| {
+                    host_path.starts_with(&source.host_root) && host_path != source.host_root
+                })
+            })
+            .max_by_key(|alias| alias.alias().len())
+            .map(|alias| alias.alias().to_string())
+    }
 }
 
 #[async_trait]
@@ -378,12 +417,19 @@ impl RuntimeProcessPort for LocalHostProcessPort {
         request: CommandExecutionRequest,
     ) -> Result<CommandExecutionOutput, RuntimeProcessError> {
         let workdir_aliases = self.effective_workdir_aliases(request.mounts.as_ref())?;
-        let cwd = resolve_local_host_workdir(request.workdir.as_deref(), &workdir_aliases)
-            .map_err(|e| {
-                RuntimeProcessError::ExecutionFailed(format!(
-                    "cannot determine working directory: {e}"
-                ))
-            })?;
+        let default_workdir = if request.workdir.is_none() {
+            self.default_scoped_workdir_alias(&workdir_aliases)
+        } else {
+            None
+        };
+        let cwd = resolve_local_host_workdir(
+            request.workdir.as_deref().or(default_workdir.as_deref()),
+            &workdir_aliases,
+        )
+        .map_err(|e| {
+            RuntimeProcessError::ExecutionFailed(format!("cannot determine working directory: {e}"))
+        })?;
+        let canonical_cwd = std::fs::canonicalize(&cwd).unwrap_or_else(|_| cwd.clone());
         let timeout = request
             .timeout_secs
             .map(Duration::from_secs)
@@ -395,6 +441,7 @@ impl RuntimeProcessPort for LocalHostProcessPort {
             );
         }
         let command = rewrite_local_host_command_aliases(&request.command, &workdir_aliases);
+        self.validate_mount_source_access(&command, &canonical_cwd, &workdir_aliases)?;
         let start = std::time::Instant::now();
         let (output, exit_code) = execute_local_command(
             &request.scope,
@@ -420,6 +467,260 @@ impl RuntimeProcessPort for LocalHostProcessPort {
             duration: start.elapsed(),
         })
     }
+}
+
+struct LocalHostMountSourceGuard {
+    source_root: PathBuf,
+    source_spellings: Vec<PathBuf>,
+    allowed_roots: Vec<PathBuf>,
+}
+
+impl LocalHostMountSourceGuard {
+    fn is_scoped(&self) -> bool {
+        self.allowed_roots
+            .iter()
+            .all(|allowed_root| allowed_root != &self.source_root)
+    }
+}
+
+fn mount_source_guards(
+    mount_sources: &[LocalHostMountSource],
+    workdir_aliases: &[LocalHostWorkdirAlias],
+) -> Vec<LocalHostMountSourceGuard> {
+    mount_sources
+        .iter()
+        .map(|source| LocalHostMountSourceGuard {
+            source_root: source.host_root.clone(),
+            source_spellings: source.host_root_spellings.to_vec(),
+            allowed_roots: workdir_aliases
+                .iter()
+                .map(LocalHostWorkdirAlias::host_path)
+                .map(canonicalize_existing_path_prefix)
+                .filter(|host_path| host_path.starts_with(&source.host_root))
+                .collect(),
+        })
+        .collect()
+}
+
+fn validate_mount_source_path(
+    path: &Path,
+    guards: &[LocalHostMountSourceGuard],
+    label: &str,
+) -> Result<(), RuntimeProcessError> {
+    let resolved_path = canonicalize_existing_path_prefix(path);
+    let Some(guard) = guards
+        .iter()
+        .find(|guard| resolved_path.starts_with(&guard.source_root))
+    else {
+        return Ok(());
+    };
+    if path_has_parent_dir(path)
+        || !guard
+            .allowed_roots
+            .iter()
+            .any(|allowed_root| resolved_path.starts_with(allowed_root))
+    {
+        return Err(disallowed_mount_source_path(label));
+    }
+    Ok(())
+}
+
+fn validate_raw_mount_source_paths(
+    command: &str,
+    guards: &[LocalHostMountSourceGuard],
+) -> Result<(), RuntimeProcessError> {
+    for guard in guards {
+        for spelling in &guard.source_spellings {
+            let Some(source_root) = spelling.to_str() else {
+                continue;
+            };
+            if source_root.is_empty() {
+                continue;
+            }
+            let mut search_start = 0;
+            while let Some(relative_index) = command[search_start..].find(source_root) {
+                let index = search_start + relative_index;
+                let prefix_end = index + source_root.len();
+                if !command_path_start_boundary(command, index)
+                    || !command_path_end_boundary(command, prefix_end)
+                {
+                    search_start = prefix_end;
+                    continue;
+                }
+                let token_end = command_path_token_end(command, prefix_end);
+                validate_mount_source_path(
+                    Path::new(&command[index..token_end]),
+                    guards,
+                    "command path",
+                )?;
+                search_start = token_end;
+            }
+        }
+    }
+    let mut search_start = 0;
+    while search_start < command.len() {
+        let Some((token_start, token_end)) = next_command_path_token(command, search_start) else {
+            break;
+        };
+        let token = Path::new(&command[token_start..token_end]);
+        if token.is_absolute() {
+            validate_mount_source_path(token, guards, "command path")?;
+        }
+        search_start = token_end;
+    }
+    Ok(())
+}
+
+fn validate_relative_mount_source_paths(
+    command: &str,
+    cwd: &Path,
+    guards: &[LocalHostMountSourceGuard],
+) -> Result<(), RuntimeProcessError> {
+    let Some(scoped_root) = scoped_allowed_root_for_path(cwd, guards) else {
+        return Ok(());
+    };
+    let mut search_start = 0;
+    while search_start < command.len() {
+        let Some((token_start, token_end)) = next_command_path_token(command, search_start) else {
+            break;
+        };
+        let token = &command[token_start..token_end];
+        let path = Path::new(token);
+        if path.is_relative()
+            && path_has_parent_dir(path)
+            && (token.contains('/') || previous_command_word(command, token_start) == Some("cd"))
+        {
+            let resolved = normalize_path_lexically(&cwd.join(path));
+            if !resolved.starts_with(scoped_root) {
+                return Err(disallowed_mount_source_path("relative command path"));
+            }
+        }
+        search_start = token_end;
+    }
+    Ok(())
+}
+
+fn scoped_allowed_root_for_path<'a>(
+    path: &Path,
+    guards: &'a [LocalHostMountSourceGuard],
+) -> Option<&'a Path> {
+    guards
+        .iter()
+        .filter(|guard| guard.is_scoped())
+        .flat_map(|guard| guard.allowed_roots.iter().map(PathBuf::as_path))
+        .filter(|allowed_root| path.starts_with(allowed_root))
+        .max_by_key(|allowed_root| allowed_root.as_os_str().len())
+}
+
+fn next_command_path_token(command: &str, search_start: usize) -> Option<(usize, usize)> {
+    let mut token_start = None;
+    for (relative_index, ch) in command[search_start..].char_indices() {
+        if command_path_char(ch) {
+            token_start = Some(search_start + relative_index);
+            break;
+        }
+    }
+    let token_start = token_start?;
+    Some((token_start, command_path_token_end(command, token_start)))
+}
+
+fn command_path_token_end(command: &str, mut index: usize) -> usize {
+    while index < command.len() {
+        let Some(ch) = command[index..].chars().next() else {
+            break;
+        };
+        if !command_path_char(ch) {
+            break;
+        }
+        index += ch.len_utf8();
+    }
+    index
+}
+
+fn command_path_start_boundary(command: &str, index: usize) -> bool {
+    if index == 0 {
+        return true;
+    }
+    command[..index]
+        .chars()
+        .next_back()
+        .is_none_or(|ch| !command_path_char(ch))
+}
+
+fn command_path_end_boundary(command: &str, index: usize) -> bool {
+    if index >= command.len() {
+        return true;
+    }
+    command[index..]
+        .chars()
+        .next()
+        .is_some_and(|ch| ch == '/' || !command_path_char(ch))
+}
+
+fn command_path_char(ch: char) -> bool {
+    ch.is_ascii_alphanumeric() || matches!(ch, '/' | '_' | '-' | '.')
+}
+
+fn previous_command_word(command: &str, token_start: usize) -> Option<&str> {
+    let prefix = &command[..token_start];
+    let end = prefix.trim_end().len();
+    if end == 0 {
+        return None;
+    }
+    let start = prefix[..end]
+        .rfind(|ch: char| !(ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-')))
+        .map(|index| index + 1)
+        .unwrap_or(0);
+    Some(&prefix[start..end])
+}
+
+fn path_has_parent_dir(path: &Path) -> bool {
+    path.components()
+        .any(|component| matches!(component, Component::ParentDir))
+}
+
+fn normalize_path_lexically(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
+            Component::RootDir => normalized.push(component.as_os_str()),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            Component::Normal(segment) => normalized.push(segment),
+        }
+    }
+    normalized
+}
+
+fn canonicalize_existing_path_prefix(path: &Path) -> PathBuf {
+    let mut current = path;
+    let mut missing_tail = Vec::new();
+    loop {
+        if let Ok(canonical) = std::fs::canonicalize(current) {
+            let mut resolved = canonical;
+            for segment in missing_tail.iter().rev() {
+                resolved.push(segment);
+            }
+            return resolved;
+        }
+        let Some(parent) = current.parent() else {
+            return path.to_path_buf();
+        };
+        let Some(file_name) = current.file_name() else {
+            return path.to_path_buf();
+        };
+        missing_tail.push(file_name.to_os_string());
+        current = parent;
+    }
+}
+
+fn disallowed_mount_source_path(label: &str) -> RuntimeProcessError {
+    RuntimeProcessError::ExecutionFailed(format!(
+        "{label} references a host workspace path outside the mounted workspace"
+    ))
 }
 
 fn virtual_path_prefix_matches(prefix: &str, path: &str) -> bool {
@@ -906,6 +1207,203 @@ mod tests {
             !workspace_root.join("hello.md").exists(),
             "scoped shell writes must not land in the raw workspace root"
         );
+    }
+
+    #[tokio::test]
+    async fn local_host_process_port_defaults_to_scoped_workspace_workdir() {
+        let workspace = tempfile::tempdir().expect("workspace tempdir");
+        let workspace_root = workspace
+            .path()
+            .canonicalize()
+            .expect("canonical workspace");
+        let port = LocalHostProcessPort::new_inherited_env()
+            .with_workdir_alias("/workspace", workspace_root.clone())
+            .with_mount_source("/projects/workspace", workspace_root.clone());
+        let mounts = MountView::new(vec![MountGrant::new(
+            MountAlias::new("/workspace").expect("workspace alias"),
+            VirtualPath::new("/projects/workspace/tenants/tenant-a/users/user-a")
+                .expect("workspace target"),
+            MountPermissions::read_write(),
+        )])
+        .expect("mount view");
+
+        let output = port
+            .run_command(CommandExecutionRequest {
+                scope: ResourceScope::system(),
+                mounts: Some(mounts),
+                command: "printf '# Hello\\n' > /workspace/hello.md && printf '%s' \"$PWD\""
+                    .to_string(),
+                workdir: None,
+                timeout_secs: Some(5),
+                extra_env: HashMap::new(),
+            })
+            .await
+            .expect("command succeeds");
+
+        assert_eq!(output.exit_code, 0);
+        assert_eq!(output.output, "/workspace");
+        assert_eq!(
+            std::fs::read_to_string(workspace_root.join("tenants/tenant-a/users/user-a/hello.md"))
+                .expect("scoped shell artifact"),
+            "# Hello\n"
+        );
+        assert!(
+            !workspace_root.join("hello.md").exists(),
+            "default shell workdir must not write to the raw workspace root"
+        );
+    }
+
+    #[tokio::test]
+    async fn local_host_process_port_allows_noncanonical_owner_workspace_alias() {
+        let workspace = tempfile::tempdir().expect("workspace tempdir");
+        let workspace_root = workspace.path().to_path_buf();
+        let shell_workdir = workspace_root.join("qa-coding-smoke");
+        std::fs::create_dir_all(&shell_workdir).expect("nested workspace dir");
+        let host_home = tempfile::tempdir().expect("host home tempdir");
+        let port = LocalHostProcessPort::new_inherited_env()
+            .with_workdir_alias("/workspace", workspace_root.clone())
+            .with_mount_source("/projects/workspace", workspace_root)
+            .with_workdir_alias("/host", host_home.path().to_path_buf());
+
+        let output = port
+            .run_command(CommandExecutionRequest {
+                scope: ResourceScope::system(),
+                mounts: None,
+                command: "mkdir -p /workspace/qa-coding-smoke && test -d /host && printf ok"
+                    .to_string(),
+                workdir: Some("/workspace/qa-coding-smoke".to_string()),
+                timeout_secs: Some(5),
+                extra_env: HashMap::new(),
+            })
+            .await
+            .expect("command succeeds");
+
+        assert_eq!(output.exit_code, 0);
+        assert_eq!(output.output, "ok");
+    }
+
+    #[tokio::test]
+    async fn local_host_process_port_rejects_raw_workspace_source_escape() {
+        let workspace = tempfile::tempdir().expect("workspace tempdir");
+        let workspace_root = workspace
+            .path()
+            .canonicalize()
+            .expect("canonical workspace");
+        let scoped_user_root = workspace_root.join("tenants/tenant-a/users/user-a");
+        let other_user_root = workspace_root.join("tenants/tenant-a/users/user-b");
+        std::fs::create_dir_all(&scoped_user_root).expect("scoped user dir");
+        std::fs::create_dir_all(&other_user_root).expect("other user dir");
+        let other_user_file = other_user_root.join("pwned.md");
+        let port = LocalHostProcessPort::new_inherited_env()
+            .with_workdir_alias("/workspace", workspace_root.clone())
+            .with_mount_source("/projects/workspace", workspace_root.clone());
+        let mounts = MountView::new(vec![MountGrant::new(
+            MountAlias::new("/workspace").expect("workspace alias"),
+            VirtualPath::new("/projects/workspace/tenants/tenant-a/users/user-a")
+                .expect("workspace target"),
+            MountPermissions::read_write(),
+        )])
+        .expect("mount view");
+
+        let error = port
+            .run_command(CommandExecutionRequest {
+                scope: ResourceScope::system(),
+                mounts: Some(mounts),
+                command: format!("printf hacked > {}", other_user_file.display()),
+                workdir: Some("/workspace".to_string()),
+                timeout_secs: Some(5),
+                extra_env: HashMap::new(),
+            })
+            .await
+            .expect_err("raw host workspace escape should be rejected");
+
+        assert!(
+            matches!(error, RuntimeProcessError::ExecutionFailed(message) if message.contains("outside the mounted workspace"))
+        );
+        assert!(
+            !other_user_file.exists(),
+            "raw host workspace path must not write another user's artifact"
+        );
+    }
+
+    #[tokio::test]
+    async fn local_host_process_port_rejects_relative_workspace_escape() {
+        let workspace = tempfile::tempdir().expect("workspace tempdir");
+        let workspace_root = workspace
+            .path()
+            .canonicalize()
+            .expect("canonical workspace");
+        let scoped_user_root = workspace_root.join("tenants/tenant-a/users/user-a");
+        let other_user_root = workspace_root.join("tenants/tenant-a/users/user-b");
+        std::fs::create_dir_all(&scoped_user_root).expect("scoped user dir");
+        std::fs::create_dir_all(&other_user_root).expect("other user dir");
+        let other_user_file = other_user_root.join("pwned.md");
+        let port = LocalHostProcessPort::new_inherited_env()
+            .with_workdir_alias("/workspace", workspace_root.clone())
+            .with_mount_source("/projects/workspace", workspace_root.clone());
+        let mounts = MountView::new(vec![MountGrant::new(
+            MountAlias::new("/workspace").expect("workspace alias"),
+            VirtualPath::new("/projects/workspace/tenants/tenant-a/users/user-a")
+                .expect("workspace target"),
+            MountPermissions::read_write(),
+        )])
+        .expect("mount view");
+
+        let error = port
+            .run_command(CommandExecutionRequest {
+                scope: ResourceScope::system(),
+                mounts: Some(mounts),
+                command: "printf hacked > ../user-b/pwned.md".to_string(),
+                workdir: Some("/workspace".to_string()),
+                timeout_secs: Some(5),
+                extra_env: HashMap::new(),
+            })
+            .await
+            .expect_err("relative workspace escape should be rejected");
+
+        assert!(
+            matches!(error, RuntimeProcessError::ExecutionFailed(message) if message.contains("outside the mounted workspace"))
+        );
+        assert!(
+            !other_user_file.exists(),
+            "relative parent traversal must not write another user's artifact"
+        );
+    }
+
+    #[tokio::test]
+    async fn local_host_process_port_allows_literal_parent_text_in_scoped_command() {
+        let workspace = tempfile::tempdir().expect("workspace tempdir");
+        let workspace_root = workspace
+            .path()
+            .canonicalize()
+            .expect("canonical workspace");
+        let scoped_user_root = workspace_root.join("tenants/tenant-a/users/user-a");
+        std::fs::create_dir_all(&scoped_user_root).expect("scoped user dir");
+        let port = LocalHostProcessPort::new_inherited_env()
+            .with_workdir_alias("/workspace", workspace_root.clone())
+            .with_mount_source("/projects/workspace", workspace_root);
+        let mounts = MountView::new(vec![MountGrant::new(
+            MountAlias::new("/workspace").expect("workspace alias"),
+            VirtualPath::new("/projects/workspace/tenants/tenant-a/users/user-a")
+                .expect("workspace target"),
+            MountPermissions::read_write(),
+        )])
+        .expect("mount view");
+
+        let output = port
+            .run_command(CommandExecutionRequest {
+                scope: ResourceScope::system(),
+                mounts: Some(mounts),
+                command: "printf '..'".to_string(),
+                workdir: Some("/workspace".to_string()),
+                timeout_secs: Some(5),
+                extra_env: HashMap::new(),
+            })
+            .await
+            .expect("literal parent text should not be treated as traversal");
+
+        assert_eq!(output.exit_code, 0);
+        assert_eq!(output.output, "..");
     }
 
     #[cfg(windows)]

--- a/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
@@ -3430,7 +3430,7 @@ async fn builtin_shell_does_not_inherit_unlisted_parent_env() {
 }
 
 #[tokio::test]
-async fn builtin_shell_rejects_scoped_mount_workdir_until_process_backend_handles_it() {
+async fn builtin_shell_rejects_scoped_mount_workdir_without_trusted_mount_source() {
     let temp = tempfile::tempdir().unwrap();
     let mut permissions = MountPermissions::read_write();
     permissions.execute = true;

--- a/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
@@ -3209,7 +3209,7 @@ async fn builtin_shell_delegates_command_execution_to_process_port() {
         requests[0]
             .mounts
             .as_ref()
-            .is_some_and(|mounts| mounts.mounts.is_empty())
+            .is_none_or(|mounts| mounts.mounts.is_empty())
     );
     assert!(requests[0].extra_env.is_empty());
     assert_eq!(requests[0].scope.user_id.as_str(), "user");

--- a/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
@@ -6343,6 +6343,105 @@ async fn builtin_read_file_rejects_tenant_workspace_before_filesystem_access() {
 }
 
 #[tokio::test]
+async fn builtin_coding_virtual_root_maps_to_default_workspace_mount() {
+    let temp = tempfile::tempdir().unwrap();
+    std::fs::write(temp.path().join("README.md"), "virtual root marker\n").unwrap();
+    let (filesystem, mounts) = mounted_filesystem(temp.path(), MountPermissions::read_write());
+    let runtime = runtime_with_filesystem(filesystem);
+    let context = execution_context_with_mounts(all_builtin_capability_ids(), mounts);
+
+    let listed = invoke_with_context(
+        &runtime,
+        LIST_DIR_CAPABILITY_ID,
+        json!({"path": "/"}),
+        context.clone(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(listed["entries"], json!(["README.md (20B)"]));
+
+    let globbed = invoke_with_context(
+        &runtime,
+        GLOB_CAPABILITY_ID,
+        json!({"path": "/", "pattern": "*.md"}),
+        context.clone(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(globbed["files"], json!(["README.md"]));
+
+    let grepped = invoke_with_context(
+        &runtime,
+        GREP_CAPABILITY_ID,
+        json!({"path": "/", "pattern": "virtual root marker"}),
+        context,
+    )
+    .await
+    .unwrap();
+    assert_eq!(grepped["files"], json!(["README.md"]));
+}
+
+#[tokio::test]
+async fn builtin_coding_empty_virtual_root_is_readable_before_first_write() {
+    let temp = tempfile::tempdir().unwrap();
+    let mut filesystem = LocalFilesystem::new();
+    filesystem
+        .mount_local(
+            VirtualPath::new("/projects/coding-pack").unwrap(),
+            HostPath::from_path_buf(temp.path().to_path_buf()),
+        )
+        .unwrap();
+    let mounts = MountView::new(vec![MountGrant::new(
+        MountAlias::new("/workspace").unwrap(),
+        VirtualPath::new("/projects/coding-pack/tenants/tenant-a/users/user-a").unwrap(),
+        MountPermissions::read_write(),
+    )])
+    .unwrap();
+    let runtime = runtime_with_filesystem(filesystem);
+    let context = execution_context_with_mounts(all_builtin_capability_ids(), mounts);
+
+    let listed = invoke_with_context(
+        &runtime,
+        LIST_DIR_CAPABILITY_ID,
+        json!({"path": "/"}),
+        context.clone(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(listed["entries"], json!([]));
+
+    let globbed = invoke_with_context(
+        &runtime,
+        GLOB_CAPABILITY_ID,
+        json!({"path": "/", "pattern": "*.md"}),
+        context.clone(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(globbed["files"], json!([]));
+
+    let grepped = invoke_with_context(
+        &runtime,
+        GREP_CAPABILITY_ID,
+        json!({"path": "/", "pattern": "needle"}),
+        context.clone(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(grepped["files"], json!([]));
+
+    let missing_subpath = invoke_with_context(
+        &runtime,
+        LIST_DIR_CAPABILITY_ID,
+        json!({"path": "/workspace/missing"}),
+        context,
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(missing_subpath, RuntimeFailureKind::OperationFailed);
+}
+
+#[tokio::test]
 async fn builtin_coding_tools_match_v1_read_write_list_glob_and_grep_shapes() {
     let temp = tempfile::tempdir().unwrap();
     std::fs::create_dir_all(temp.path().join("src")).unwrap();

--- a/crates/ironclaw_host_runtime/tests/first_party_coding_tools.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_coding_tools.rs
@@ -80,6 +80,36 @@ async fn builtin_coding_grep_skips_oversized_files_like_resilient_v1_search() {
 }
 
 #[tokio::test]
+async fn builtin_coding_grep_rejects_unmaterialized_mount_root_without_list_permission() {
+    let permissions = MountPermissions {
+        read: true,
+        write: false,
+        delete: false,
+        list: false,
+        execute: false,
+    };
+    let mounts = MountView::new(vec![MountGrant::new(
+        MountAlias::new("/workspace").unwrap(),
+        VirtualPath::new("/projects/coding-pack").unwrap(),
+        permissions,
+    )])
+    .unwrap();
+    let runtime = runtime_with_filesystem(MissingMountRootFilesystem);
+    let context = execution_context_with_mounts(coding_capability_ids(), mounts);
+
+    let error = invoke_with_context(
+        &runtime,
+        GREP_CAPABILITY_ID,
+        json!({"path": "/workspace", "pattern": "needle"}),
+        context,
+    )
+    .await
+    .unwrap_err();
+
+    assert_eq!(error, RuntimeFailureKind::Authorization);
+}
+
+#[tokio::test]
 async fn builtin_coding_grep_reports_scan_budget_truncation_for_all_output_modes() {
     let temp = tempfile::tempdir().unwrap();
     for index in 0..50 {
@@ -1219,6 +1249,49 @@ impl RootFilesystem for ManySkippedEntriesFilesystem {
             path: path.clone(),
             operation: FilesystemOperation::Stat,
             reason: "injected stat failure".to_string(),
+        })
+    }
+
+    async fn read_file(&self, path: &VirtualPath) -> Result<Vec<u8>, FilesystemError> {
+        Err(FilesystemError::Backend {
+            path: path.clone(),
+            operation: FilesystemOperation::ReadFile,
+            reason: "unexpected read".to_string(),
+        })
+    }
+
+    async fn write_file(&self, path: &VirtualPath, _bytes: &[u8]) -> Result<(), FilesystemError> {
+        Err(FilesystemError::Backend {
+            path: path.clone(),
+            operation: FilesystemOperation::WriteFile,
+            reason: "unexpected write".to_string(),
+        })
+    }
+
+    async fn create_dir_all(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
+        Err(FilesystemError::Backend {
+            path: path.clone(),
+            operation: FilesystemOperation::CreateDirAll,
+            reason: "unexpected mkdir".to_string(),
+        })
+    }
+}
+
+struct MissingMountRootFilesystem;
+
+#[async_trait]
+impl RootFilesystem for MissingMountRootFilesystem {
+    async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
+        Err(FilesystemError::NotFound {
+            path: path.clone(),
+            operation: FilesystemOperation::ListDir,
+        })
+    }
+
+    async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
+        Err(FilesystemError::NotFound {
+            path: path.clone(),
+            operation: FilesystemOperation::Stat,
         })
     }
 

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -181,8 +181,9 @@ use crate::input::{RebornLocalRuntimeIdentity, RebornRuntimeProcessBinding, Rebo
 use crate::local_dev_authorization::{StoreApprovalSettingsProvider, local_dev_authorizer};
 use crate::local_dev_capability_policy::{LocalDevCapabilityPolicy, local_dev_capability_policy};
 use crate::local_dev_mounts::{
-    ambient_workspace_mount_view, memory_mount_view, scoped_skill_context_mount_view,
-    skill_management_mount_view, system_extensions_lifecycle_mount_view, workspace_mount_view,
+    WORKSPACE_TARGET, ambient_workspace_mount_view, memory_mount_view,
+    scoped_skill_context_mount_view, skill_management_mount_view,
+    system_extensions_lifecycle_mount_view, workspace_mount_view,
 };
 use crate::product_auth::credentials::product_auth_providers::{
     OAuthProviderComposition, compose_provider_client,
@@ -352,6 +353,7 @@ fn local_dev_process_port_for_policy(
         LocalHostProcessPort::new()
     }
     .with_workdir_alias("/workspace", workspace_root);
+    process_port = process_port.with_mount_source(WORKSPACE_TARGET, workspace_root);
     if let Some(host_home_root) = host_home_root {
         process_port =
             process_port.with_workdir_alias("/host", host_home_root.canonical_root.clone());

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -181,7 +181,7 @@ use crate::input::{RebornLocalRuntimeIdentity, RebornRuntimeProcessBinding, Rebo
 use crate::local_dev_authorization::{StoreApprovalSettingsProvider, local_dev_authorizer};
 use crate::local_dev_capability_policy::{LocalDevCapabilityPolicy, local_dev_capability_policy};
 use crate::local_dev_mounts::{
-    WORKSPACE_TARGET, ambient_workspace_mount_view, memory_mount_view,
+    HOST_TARGET, WORKSPACE_TARGET, ambient_workspace_mount_view, memory_mount_view,
     scoped_skill_context_mount_view, skill_management_mount_view,
     system_extensions_lifecycle_mount_view, workspace_mount_view,
 };
@@ -355,6 +355,8 @@ fn local_dev_process_port_for_policy(
     .with_workdir_alias("/workspace", workspace_root);
     process_port = process_port.with_mount_source(WORKSPACE_TARGET, workspace_root);
     if let Some(host_home_root) = host_home_root {
+        process_port =
+            process_port.with_mount_source(HOST_TARGET, host_home_root.canonical_root.clone());
         process_port =
             process_port.with_workdir_alias("/host", host_home_root.canonical_root.clone());
         for alias in host_home_root.aliases() {

--- a/crates/ironclaw_reborn_composition/src/local_dev_mounts.rs
+++ b/crates/ironclaw_reborn_composition/src/local_dev_mounts.rs
@@ -7,7 +7,7 @@ use ironclaw_host_api::{
 pub(crate) const WORKSPACE_ALIAS: &str = "/workspace";
 pub(crate) const WORKSPACE_TARGET: &str = "/projects/workspace";
 const HOST_ALIAS: &str = "/host";
-const HOST_TARGET: &str = "/projects/host";
+pub(crate) const HOST_TARGET: &str = "/projects/host";
 const MEMORY_ALIAS: &str = "/memory";
 const MEMORY_TARGET: &str = "/memory";
 

--- a/crates/ironclaw_reborn_composition/src/local_dev_mounts.rs
+++ b/crates/ironclaw_reborn_composition/src/local_dev_mounts.rs
@@ -5,7 +5,7 @@ use ironclaw_host_api::{
 };
 
 pub(crate) const WORKSPACE_ALIAS: &str = "/workspace";
-const WORKSPACE_TARGET: &str = "/projects/workspace";
+pub(crate) const WORKSPACE_TARGET: &str = "/projects/workspace";
 const HOST_ALIAS: &str = "/host";
 const HOST_TARGET: &str = "/projects/host";
 const MEMORY_ALIAS: &str = "/memory";

--- a/crates/ironclaw_reborn_composition/src/local_dev_mounts.rs
+++ b/crates/ironclaw_reborn_composition/src/local_dev_mounts.rs
@@ -18,6 +18,21 @@ pub(crate) fn workspace_mount_view(
     ambient_workspace_mount_view(permissions, &[], host_home_aliases)
 }
 
+pub(crate) fn scoped_workspace_mount_view(
+    scope: &ResourceScope,
+    permissions: MountPermissions,
+) -> Result<MountView, HostApiError> {
+    MountView::new(vec![grant(
+        WORKSPACE_ALIAS,
+        &format!(
+            "{WORKSPACE_TARGET}/tenants/{}/users/{}",
+            scope.tenant_id.as_str(),
+            scope.user_id.as_str()
+        ),
+        permissions,
+    )?])
+}
+
 /// Build the workspace mount view used by local-dev capability grants.
 ///
 /// `workspace_aliases` is load-bearing for local-dev-yolo ambient coding tools:
@@ -242,6 +257,32 @@ mod tests {
                 .count(),
             1
         );
+    }
+
+    #[test]
+    fn scoped_workspace_mount_targets_user_workspace_projection() {
+        let scope = ResourceScope {
+            tenant_id: ironclaw_host_api::TenantId::new("tenant-a").expect("tenant id"),
+            user_id: ironclaw_host_api::UserId::new("user-b").expect("user id"),
+            agent_id: None,
+            project_id: None,
+            mission_id: None,
+            thread_id: None,
+            invocation_id: ironclaw_host_api::InvocationId::new(),
+        };
+        let mounts =
+            scoped_workspace_mount_view(&scope, MountPermissions::read_write()).expect("mounts");
+        let mount = mounts
+            .mounts
+            .iter()
+            .find(|mount| mount.alias.as_str() == WORKSPACE_ALIAS)
+            .expect("workspace mount");
+
+        assert_eq!(
+            mount.target.as_str(),
+            "/projects/workspace/tenants/tenant-a/users/user-b"
+        );
+        assert_eq!(mount.permissions, MountPermissions::read_write());
     }
 
     #[test]

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -798,6 +798,7 @@ pub(crate) fn build_local_dev_approval_interaction_service_with_turn_run_source(
             Arc::new(approval::LocalDevApprovalLeaseTermsProvider::new(
                 local_dev_capability_policy,
                 Arc::clone(&local_runtime.extension_registry),
+                local_runtime.owner_user_id.clone(),
                 local_runtime.workspace_mounts.clone(),
                 local_runtime.skill_mounts.clone(),
                 local_runtime.memory_mounts.clone(),

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -796,16 +796,21 @@ pub(crate) fn build_local_dev_approval_interaction_service_with_turn_run_source(
         DefaultApprovalInteractionService::new(
             approval_read_model,
             Arc::new(approval::LocalDevApprovalLeaseTermsProvider::new(
-                local_dev_capability_policy,
-                Arc::clone(&local_runtime.extension_registry),
-                local_runtime.owner_user_id.clone(),
-                local_runtime.workspace_mounts.clone(),
-                local_runtime.skill_mounts.clone(),
-                local_runtime.memory_mounts.clone(),
-                local_runtime.system_extensions_lifecycle_mounts.clone(),
-                local_dev::extension_surface::LocalDevExtensionSurfaceSource::new(
-                    local_runtime.extension_management.clone(),
-                ),
+                approval::LocalDevApprovalLeaseTermsProviderConfig {
+                    policy: local_dev_capability_policy,
+                    registry: Arc::clone(&local_runtime.extension_registry),
+                    owner_user_id: local_runtime.owner_user_id.clone(),
+                    workspace_mounts: local_runtime.workspace_mounts.clone(),
+                    skill_mounts: local_runtime.skill_mounts.clone(),
+                    memory_mounts: local_runtime.memory_mounts.clone(),
+                    system_extensions_lifecycle_mounts: local_runtime
+                        .system_extensions_lifecycle_mounts
+                        .clone(),
+                    extension_surface_source:
+                        local_dev::extension_surface::LocalDevExtensionSurfaceSource::new(
+                            local_runtime.extension_management.clone(),
+                        ),
+                },
             )),
             approval_resolver,
             turn_coordinator,

--- a/crates/ironclaw_reborn_composition/src/runtime/approval.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/approval.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use ironclaw_approvals::{LeaseApproval, permission_mode_allows_persistent_approval};
 use ironclaw_extensions::ExtensionRegistry;
-use ironclaw_host_api::{EffectKind, MountView, Principal};
+use ironclaw_host_api::{EffectKind, MountView, Principal, UserId};
 use ironclaw_product_workflow::{
     ApprovalGateRecord, ApprovalInteractionRejectionKind, ApprovalLeaseTermsProvider,
     ProductWorkflowError,
@@ -13,6 +13,7 @@ use crate::local_dev_capability_policy::{
     LocalDevApprovalPolicyAction, LocalDevCapabilityPolicy, LocalDevCapabilityPolicyError,
     local_dev_one_shot_lease_approval,
 };
+use crate::local_dev_mounts::{WORKSPACE_ALIAS, scoped_workspace_mount_view};
 use crate::outbound::OUTBOUND_DELIVERY_TARGET_SET_CAPABILITY_ID;
 
 use super::local_dev::extension_surface::LocalDevExtensionSurfaceSource;
@@ -20,6 +21,7 @@ use super::local_dev::extension_surface::LocalDevExtensionSurfaceSource;
 pub(super) struct LocalDevApprovalLeaseTermsProvider {
     policy: Arc<LocalDevCapabilityPolicy>,
     registry: Arc<ExtensionRegistry>,
+    owner_user_id: UserId,
     workspace_mounts: MountView,
     skill_mounts: MountView,
     memory_mounts: MountView,
@@ -31,6 +33,7 @@ impl LocalDevApprovalLeaseTermsProvider {
     pub(super) fn new(
         policy: Arc<LocalDevCapabilityPolicy>,
         registry: Arc<ExtensionRegistry>,
+        owner_user_id: UserId,
         workspace_mounts: MountView,
         skill_mounts: MountView,
         memory_mounts: MountView,
@@ -40,6 +43,7 @@ impl LocalDevApprovalLeaseTermsProvider {
         Self {
             policy,
             registry,
+            owner_user_id,
             workspace_mounts,
             skill_mounts,
             memory_mounts,
@@ -123,6 +127,35 @@ impl LocalDevApprovalLeaseTermsProvider {
             capability.default_permission,
         ))
     }
+
+    fn workspace_mounts_for_gate(
+        &self,
+        gate: &ApprovalGateRecord,
+    ) -> Result<MountView, ProductWorkflowError> {
+        let scope = gate.resource_scope();
+        if scope.user_id == self.owner_user_id {
+            return Ok(self.workspace_mounts.clone());
+        }
+        let permissions = self
+            .workspace_mounts
+            .mounts
+            .iter()
+            .find(|grant| grant.alias.as_str() == WORKSPACE_ALIAS)
+            .map(|grant| grant.permissions.clone())
+            .ok_or_else(|| {
+                tracing::error!(
+                    "local-dev approval lease terms are unavailable: workspace mount is missing"
+                );
+                lease_terms_unavailable()
+            })?;
+        scoped_workspace_mount_view(scope, permissions).map_err(|error| {
+            tracing::error!(
+                %error,
+                "local-dev approval lease terms are unavailable: workspace mount could not be scoped"
+            );
+            lease_terms_unavailable()
+        })
+    }
 }
 
 #[async_trait]
@@ -142,9 +175,10 @@ impl ApprovalLeaseTermsProvider for LocalDevApprovalLeaseTermsProvider {
         {
             return Ok(approval);
         }
+        let workspace_mounts = self.workspace_mounts_for_gate(gate)?;
         match self.policy.lease_approval_for(
             action,
-            &self.workspace_mounts,
+            &workspace_mounts,
             &self.skill_mounts,
             &self.memory_mounts,
             &self.system_extensions_lifecycle_mounts,
@@ -177,9 +211,10 @@ impl ApprovalLeaseTermsProvider for LocalDevApprovalLeaseTermsProvider {
             });
         }
         if action.capability_id().as_str() == OUTBOUND_DELIVERY_TARGET_SET_CAPABILITY_ID {
+            let workspace_mounts = self.workspace_mounts_for_gate(gate)?;
             match self.policy.lease_approval_for(
                 action,
-                &self.workspace_mounts,
+                &workspace_mounts,
                 &self.skill_mounts,
                 &self.memory_mounts,
                 &self.system_extensions_lifecycle_mounts,
@@ -220,8 +255,8 @@ mod tests {
 
     use ironclaw_host_api::{
         Action, ApprovalRequest, ApprovalRequestId, CapabilityId, CorrelationId, EffectKind,
-        ExtensionId, InvocationId, PermissionMode, ResourceEstimate, ResourceScope, SecretHandle,
-        TenantId, ThreadId, UserId,
+        ExtensionId, InvocationId, MountPermissions, PermissionMode, ResourceEstimate,
+        ResourceScope, SecretHandle, TenantId, ThreadId, UserId,
     };
     use ironclaw_product_workflow::approval_gate_ref;
     use ironclaw_turns::{GateRef, TurnRunId};
@@ -233,6 +268,55 @@ mod tests {
     };
 
     use super::*;
+
+    #[tokio::test]
+    async fn non_owner_workspace_lease_terms_use_scoped_workspace_mounts() {
+        let owner = UserId::new("owner").expect("owner user id");
+        let terms_provider = LocalDevApprovalLeaseTermsProvider::new(
+            Arc::new(local_dev_capability_policy().expect("policy parses")),
+            Arc::new(ExtensionRegistry::new()),
+            owner,
+            crate::local_dev_mounts::workspace_mount_view(MountPermissions::read_write(), &[])
+                .expect("workspace mounts"),
+            MountView::default(),
+            MountView::default(),
+            MountView::default(),
+            LocalDevExtensionSurfaceSource::default(),
+        );
+        let capability = CapabilityId::new("builtin.read_file").expect("capability id");
+        let resource_scope = ResourceScope {
+            tenant_id: TenantId::new("tenant-sso").expect("tenant id"),
+            user_id: UserId::new("sso-user").expect("user id"),
+            agent_id: None,
+            project_id: None,
+            mission_id: None,
+            thread_id: Some(ThreadId::new("thread").expect("thread id")),
+            invocation_id: InvocationId::new(),
+        };
+        let gate = approval_gate_record_for_scope(
+            resource_scope,
+            ApprovalRequestId::new(),
+            Principal::Extension(ExtensionId::new("loop-driver").expect("caller id")),
+            Action::Dispatch {
+                capability,
+                estimated_resources: ResourceEstimate::default(),
+            },
+        );
+
+        let approval = terms_provider
+            .lease_terms_for(&gate)
+            .await
+            .expect("workspace lease terms");
+
+        assert_eq!(approval.constraints.mounts.mounts.len(), 1);
+        let grant = &approval.constraints.mounts.mounts[0];
+        assert_eq!(grant.alias.as_str(), "/workspace");
+        assert_eq!(
+            grant.target.as_str(),
+            "/projects/workspace/tenants/tenant-sso/users/sso-user"
+        );
+        assert_eq!(grant.permissions, MountPermissions::read_write());
+    }
 
     #[tokio::test]
     async fn extension_capability_missing_from_builtin_policy_gets_one_shot_lease_terms() {
@@ -251,6 +335,7 @@ mod tests {
         let terms_provider = LocalDevApprovalLeaseTermsProvider::new(
             Arc::new(local_dev_capability_policy().expect("policy parses")),
             Arc::new(ExtensionRegistry::new()),
+            UserId::new("owner").expect("owner user id"),
             MountView::default(),
             MountView::default(),
             MountView::default(),
@@ -321,6 +406,7 @@ mod tests {
         let terms_provider = LocalDevApprovalLeaseTermsProvider::new(
             Arc::new(local_dev_capability_policy().expect("policy parses")),
             Arc::new(ExtensionRegistry::new()),
+            UserId::new("owner").expect("owner user id"),
             MountView::default(),
             MountView::default(),
             MountView::default(),
@@ -372,6 +458,7 @@ mod tests {
         let terms_provider = LocalDevApprovalLeaseTermsProvider::new(
             Arc::new(local_dev_capability_policy().expect("policy parses")),
             Arc::new(ExtensionRegistry::new()),
+            UserId::new("owner").expect("owner user id"),
             MountView::default(),
             MountView::default(),
             MountView::default(),
@@ -410,6 +497,7 @@ mod tests {
         let terms_provider = LocalDevApprovalLeaseTermsProvider::new(
             Arc::new(local_dev_capability_policy().expect("policy parses")),
             Arc::new(ExtensionRegistry::new()),
+            UserId::new("owner").expect("owner user id"),
             MountView::default(),
             MountView::default(),
             MountView::default(),
@@ -439,6 +527,7 @@ mod tests {
         let terms_provider = LocalDevApprovalLeaseTermsProvider::new(
             Arc::new(local_dev_capability_policy().expect("policy parses")),
             Arc::new(ExtensionRegistry::new()),
+            UserId::new("owner").expect("owner user id"),
             MountView::default(),
             MountView::default(),
             MountView::default(),
@@ -477,6 +566,7 @@ mod tests {
         let terms_provider = LocalDevApprovalLeaseTermsProvider::new(
             Arc::new(local_dev_capability_policy().expect("policy parses")),
             Arc::new(ExtensionRegistry::new()),
+            UserId::new("owner").expect("owner user id"),
             MountView::default(),
             MountView::default(),
             MountView::default(),
@@ -519,6 +609,15 @@ mod tests {
             thread_id: Some(ThreadId::new("thread").expect("thread id")),
             invocation_id: InvocationId::new(),
         };
+        approval_gate_record_for_scope(resource_scope, request_id, requested_by, action)
+    }
+
+    fn approval_gate_record_for_scope(
+        resource_scope: ResourceScope,
+        request_id: ApprovalRequestId,
+        requested_by: Principal,
+        action: Action,
+    ) -> ApprovalGateRecord {
         let gate_ref: GateRef = approval_gate_ref(request_id).expect("approval gate ref");
         ApprovalGateRecord::new(
             resource_scope,

--- a/crates/ironclaw_reborn_composition/src/runtime/approval.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/approval.rs
@@ -29,17 +29,29 @@ pub(super) struct LocalDevApprovalLeaseTermsProvider {
     extension_surface_source: LocalDevExtensionSurfaceSource,
 }
 
+pub(super) struct LocalDevApprovalLeaseTermsProviderConfig {
+    pub(super) policy: Arc<LocalDevCapabilityPolicy>,
+    pub(super) registry: Arc<ExtensionRegistry>,
+    pub(super) owner_user_id: UserId,
+    pub(super) workspace_mounts: MountView,
+    pub(super) skill_mounts: MountView,
+    pub(super) memory_mounts: MountView,
+    pub(super) system_extensions_lifecycle_mounts: MountView,
+    pub(super) extension_surface_source: LocalDevExtensionSurfaceSource,
+}
+
 impl LocalDevApprovalLeaseTermsProvider {
-    pub(super) fn new(
-        policy: Arc<LocalDevCapabilityPolicy>,
-        registry: Arc<ExtensionRegistry>,
-        owner_user_id: UserId,
-        workspace_mounts: MountView,
-        skill_mounts: MountView,
-        memory_mounts: MountView,
-        system_extensions_lifecycle_mounts: MountView,
-        extension_surface_source: LocalDevExtensionSurfaceSource,
-    ) -> Self {
+    pub(super) fn new(config: LocalDevApprovalLeaseTermsProviderConfig) -> Self {
+        let LocalDevApprovalLeaseTermsProviderConfig {
+            policy,
+            registry,
+            owner_user_id,
+            workspace_mounts,
+            skill_mounts,
+            memory_mounts,
+            system_extensions_lifecycle_mounts,
+            extension_surface_source,
+        } = config;
         Self {
             policy,
             registry,
@@ -269,18 +281,41 @@ mod tests {
 
     use super::*;
 
+    fn terms_provider(
+        owner_user_id: UserId,
+        workspace_mounts: MountView,
+        extension_surface_source: LocalDevExtensionSurfaceSource,
+    ) -> LocalDevApprovalLeaseTermsProvider {
+        LocalDevApprovalLeaseTermsProvider::new(LocalDevApprovalLeaseTermsProviderConfig {
+            policy: Arc::new(local_dev_capability_policy().expect("policy parses")),
+            registry: Arc::new(ExtensionRegistry::new()),
+            owner_user_id,
+            workspace_mounts,
+            skill_mounts: MountView::default(),
+            memory_mounts: MountView::default(),
+            system_extensions_lifecycle_mounts: MountView::default(),
+            extension_surface_source,
+        })
+    }
+
+    fn default_terms_provider(
+        extension_surface_source: LocalDevExtensionSurfaceSource,
+    ) -> LocalDevApprovalLeaseTermsProvider {
+        terms_provider(
+            UserId::new("user").expect("owner user id"),
+            crate::local_dev_mounts::workspace_mount_view(MountPermissions::read_write(), &[])
+                .expect("workspace mounts"),
+            extension_surface_source,
+        )
+    }
+
     #[tokio::test]
     async fn non_owner_workspace_lease_terms_use_scoped_workspace_mounts() {
         let owner = UserId::new("owner").expect("owner user id");
-        let terms_provider = LocalDevApprovalLeaseTermsProvider::new(
-            Arc::new(local_dev_capability_policy().expect("policy parses")),
-            Arc::new(ExtensionRegistry::new()),
+        let terms_provider = terms_provider(
             owner,
             crate::local_dev_mounts::workspace_mount_view(MountPermissions::read_write(), &[])
                 .expect("workspace mounts"),
-            MountView::default(),
-            MountView::default(),
-            MountView::default(),
             LocalDevExtensionSurfaceSource::default(),
         );
         let capability = CapabilityId::new("builtin.read_file").expect("capability id");
@@ -332,16 +367,7 @@ mod tests {
                 runtime_credentials: Vec::new(),
             }]),
         );
-        let terms_provider = LocalDevApprovalLeaseTermsProvider::new(
-            Arc::new(local_dev_capability_policy().expect("policy parses")),
-            Arc::new(ExtensionRegistry::new()),
-            UserId::new("owner").expect("owner user id"),
-            MountView::default(),
-            MountView::default(),
-            MountView::default(),
-            MountView::default(),
-            source,
-        );
+        let terms_provider = default_terms_provider(source);
         let request_id = ApprovalRequestId::new();
         let gate = approval_gate_record(
             request_id,
@@ -403,16 +429,7 @@ mod tests {
                 }],
             }]),
         );
-        let terms_provider = LocalDevApprovalLeaseTermsProvider::new(
-            Arc::new(local_dev_capability_policy().expect("policy parses")),
-            Arc::new(ExtensionRegistry::new()),
-            UserId::new("owner").expect("owner user id"),
-            MountView::default(),
-            MountView::default(),
-            MountView::default(),
-            MountView::default(),
-            source,
-        );
+        let terms_provider = default_terms_provider(source);
         let request_id = ApprovalRequestId::new();
         let gate = approval_gate_record(
             request_id,
@@ -455,16 +472,7 @@ mod tests {
                 runtime_credentials: Vec::new(),
             }]),
         );
-        let terms_provider = LocalDevApprovalLeaseTermsProvider::new(
-            Arc::new(local_dev_capability_policy().expect("policy parses")),
-            Arc::new(ExtensionRegistry::new()),
-            UserId::new("owner").expect("owner user id"),
-            MountView::default(),
-            MountView::default(),
-            MountView::default(),
-            MountView::default(),
-            source,
-        );
+        let terms_provider = default_terms_provider(source);
         let gate = approval_gate_record(
             ApprovalRequestId::new(),
             Principal::Extension(caller),
@@ -494,16 +502,7 @@ mod tests {
                 runtime_credentials: Vec::new(),
             }]),
         );
-        let terms_provider = LocalDevApprovalLeaseTermsProvider::new(
-            Arc::new(local_dev_capability_policy().expect("policy parses")),
-            Arc::new(ExtensionRegistry::new()),
-            UserId::new("owner").expect("owner user id"),
-            MountView::default(),
-            MountView::default(),
-            MountView::default(),
-            MountView::default(),
-            source,
-        );
+        let terms_provider = default_terms_provider(source);
         let gate = approval_gate_record(
             ApprovalRequestId::new(),
             Principal::Extension(caller),
@@ -524,16 +523,7 @@ mod tests {
         let capability =
             CapabilityId::new(OUTBOUND_DELIVERY_TARGET_SET_CAPABILITY_ID).expect("capability id");
         let caller = ExtensionId::new("loop-driver").expect("caller id");
-        let terms_provider = LocalDevApprovalLeaseTermsProvider::new(
-            Arc::new(local_dev_capability_policy().expect("policy parses")),
-            Arc::new(ExtensionRegistry::new()),
-            UserId::new("owner").expect("owner user id"),
-            MountView::default(),
-            MountView::default(),
-            MountView::default(),
-            MountView::default(),
-            LocalDevExtensionSurfaceSource::default(),
-        );
+        let terms_provider = default_terms_provider(LocalDevExtensionSurfaceSource::default());
         let gate = approval_gate_record(
             ApprovalRequestId::new(),
             Principal::Extension(caller),
@@ -563,16 +553,7 @@ mod tests {
                 runtime_credentials: Vec::new(),
             }]),
         );
-        let terms_provider = LocalDevApprovalLeaseTermsProvider::new(
-            Arc::new(local_dev_capability_policy().expect("policy parses")),
-            Arc::new(ExtensionRegistry::new()),
-            UserId::new("owner").expect("owner user id"),
-            MountView::default(),
-            MountView::default(),
-            MountView::default(),
-            MountView::default(),
-            source,
-        );
+        let terms_provider = default_terms_provider(source);
         let gate = approval_gate_record(
             ApprovalRequestId::new(),
             Principal::Extension(caller),

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev.rs
@@ -8,8 +8,8 @@ use uuid::Uuid;
 
 use ironclaw_authorization::CapabilityLeaseStore;
 use ironclaw_host_api::{
-    CapabilityId, EffectKind, ExecutionContext, ExtensionId, InvocationId, MountView,
-    ResourceScope, RuntimeKind, TrustClass, UserId,
+    CapabilityId, EffectKind, ExecutionContext, ExtensionId, InvocationId, MountPermissions,
+    MountView, ResourceScope, RuntimeKind, TrustClass, UserId,
 };
 use ironclaw_host_runtime::{
     CapabilitySurfacePolicy, HostRuntime, SurfaceKind,
@@ -43,7 +43,7 @@ use crate::local_dev_authorization::{
     StoreApprovalSettingsProvider, local_dev_effects_require_approval,
 };
 use crate::local_dev_capability_policy::LocalDevCapabilityPolicy;
-use crate::local_dev_mounts::scoped_skill_management_mount_view;
+use crate::local_dev_mounts::{scoped_skill_management_mount_view, scoped_workspace_mount_view};
 use crate::profile_approval_authorization::ApprovalSettingsProvider;
 use crate::{
     RebornServices,
@@ -217,17 +217,21 @@ impl LoopCapabilityPortFactory for LocalDevLoopCapabilityPortFactory {
         &self,
         run_context: &LoopRunContext,
     ) -> Result<Arc<dyn LoopCapabilityPort>, AgentLoopHostError> {
-        let skill_mounts = scoped_skill_management_mount_view(&local_dev_resource_scope_for_run(
-            run_context,
-            &self.fallback_user_id,
-        ))
-        .map_err(host_api_agent_loop_error)?;
+        let resource_scope = local_dev_resource_scope_for_run(run_context, &self.fallback_user_id);
+        let skill_mounts = scoped_skill_management_mount_view(&resource_scope)
+            .map_err(host_api_agent_loop_error)?;
+        let workspace_mounts = if resource_scope.user_id == self.fallback_user_id {
+            self.workspace_mounts.clone()
+        } else {
+            scoped_workspace_mount_view(&resource_scope, MountPermissions::read_write())
+                .map_err(host_api_agent_loop_error)?
+        };
         create_refreshing_local_dev_capability_port(RefreshingLocalDevCapabilityPortConfig {
             runtime: Arc::clone(&self.runtime),
             run_context: run_context.clone(),
             fallback_user_id: self.fallback_user_id.clone(),
             policy: Arc::clone(&self.policy),
-            workspace_mounts: self.workspace_mounts.clone(),
+            workspace_mounts,
             skill_mounts,
             memory_mounts: self.memory_mounts.clone(),
             system_extensions_lifecycle_mounts: self.system_extensions_lifecycle_mounts.clone(),

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev.rs
@@ -43,7 +43,9 @@ use crate::local_dev_authorization::{
     StoreApprovalSettingsProvider, local_dev_effects_require_approval,
 };
 use crate::local_dev_capability_policy::LocalDevCapabilityPolicy;
-use crate::local_dev_mounts::{scoped_skill_management_mount_view, scoped_workspace_mount_view};
+use crate::local_dev_mounts::{
+    WORKSPACE_ALIAS, scoped_skill_management_mount_view, scoped_workspace_mount_view,
+};
 use crate::profile_approval_authorization::ApprovalSettingsProvider;
 use crate::{
     RebornServices,
@@ -223,8 +225,11 @@ impl LoopCapabilityPortFactory for LocalDevLoopCapabilityPortFactory {
         let workspace_mounts = if resource_scope.user_id == self.fallback_user_id {
             self.workspace_mounts.clone()
         } else {
-            scoped_workspace_mount_view(&resource_scope, MountPermissions::read_write())
-                .map_err(host_api_agent_loop_error)?
+            scoped_workspace_mount_view(
+                &resource_scope,
+                configured_workspace_permissions(&self.workspace_mounts)?,
+            )
+            .map_err(host_api_agent_loop_error)?
         };
         create_refreshing_local_dev_capability_port(RefreshingLocalDevCapabilityPortConfig {
             runtime: Arc::clone(&self.runtime),
@@ -1080,15 +1085,33 @@ fn capability_io_error() -> AgentLoopHostError {
     )
 }
 
+fn configured_workspace_permissions(
+    workspace_mounts: &MountView,
+) -> Result<MountPermissions, AgentLoopHostError> {
+    workspace_mounts
+        .mounts
+        .iter()
+        .find(|grant| grant.alias.as_str() == WORKSPACE_ALIAS)
+        .map(|grant| grant.permissions.clone())
+        .ok_or_else(|| {
+            tracing::error!(
+                "local-dev capability port workspace mounts are unavailable: workspace mount is missing"
+            );
+            AgentLoopHostError::new(
+                AgentLoopHostErrorKind::InvalidInvocation,
+                "local-dev workspace mount is unavailable",
+            )
+        })
+}
+
 fn host_api_agent_loop_error(
     error: impl std::fmt::Debug + std::fmt::Display,
 ) -> AgentLoopHostError {
-    let safe_summary = error.to_string();
     ironclaw_loop_support::raw_agent_loop_host_error(
         "local_dev_host_api",
         "validate_local_dev_runtime_input",
         AgentLoopHostErrorKind::InvalidInvocation,
-        safe_summary,
+        "local-dev runtime input is invalid",
         format!("{error:?}"),
     )
 }

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/shell_tests.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/shell_tests.rs
@@ -83,11 +83,11 @@ fn local_dev_shell_factory(
     let input_resolver: Arc<dyn LoopCapabilityInputResolver> = capability_io.clone();
     let result_writer: Arc<dyn LoopCapabilityResultWriter> = capability_io.clone();
     LocalDevLoopCapabilityPortFactory {
-        runtime: services.host_runtime.clone().expect("host runtime"),
-        fallback_user_id: UserId::new(fallback_user_id).expect("user id"),
+        runtime: services.host_runtime.clone().expect("host runtime"), // safety: test-only local-dev service builder always wires host runtime.
+        fallback_user_id: UserId::new(fallback_user_id).expect("user id"), // safety: test helper passes static valid user IDs.
         policy: Arc::new(
             crate::local_dev_capability_policy::local_dev_capability_policy()
-                .expect("policy parses"),
+                .expect("policy parses"), // safety: test-only assertion for static policy definition.
         ),
         workspace_mounts: local_runtime.workspace_mounts.clone(),
         memory_mounts: local_runtime.memory_mounts.clone(),

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/shell_tests.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/shell_tests.rs
@@ -71,6 +71,49 @@ fn provider_tool_call(arguments: serde_json::Value) -> ProviderToolCall {
     }
 }
 
+fn local_dev_shell_factory(
+    services: &crate::RebornServices,
+    fallback_user_id: &str,
+    capability_io: Arc<LocalDevCapabilityIo>,
+) -> LocalDevLoopCapabilityPortFactory {
+    let local_runtime = services
+        .local_runtime
+        .as_ref()
+        .expect("local runtime substrate"); // safety: test-only assertion in #[cfg(test)] module.
+    let input_resolver: Arc<dyn LoopCapabilityInputResolver> = capability_io.clone();
+    let result_writer: Arc<dyn LoopCapabilityResultWriter> = capability_io.clone();
+    LocalDevLoopCapabilityPortFactory {
+        runtime: services.host_runtime.clone().expect("host runtime"),
+        fallback_user_id: UserId::new(fallback_user_id).expect("user id"),
+        policy: Arc::new(
+            crate::local_dev_capability_policy::local_dev_capability_policy()
+                .expect("policy parses"),
+        ),
+        workspace_mounts: local_runtime.workspace_mounts.clone(),
+        memory_mounts: local_runtime.memory_mounts.clone(),
+        system_extensions_lifecycle_mounts: local_runtime
+            .system_extensions_lifecycle_mounts
+            .clone(),
+        extension_surface_source: LocalDevExtensionSurfaceSource::default(),
+        input_resolver,
+        result_writer,
+        milestone_sink: Arc::new(InMemoryLoopHostMilestoneSink::default()),
+        skill_activation_source: None,
+        project_service: Arc::clone(&local_runtime.project_service),
+        trajectory_observer: None,
+        outbound_preferences_facade: None,
+        outbound_delivery_target_set_requires_approval: false,
+        approval_settings: Arc::new(
+            crate::profile_approval_authorization::EmptyApprovalSettingsProvider,
+        ),
+        approval_requests: local_runtime.approval_requests.clone(),
+        capability_leases: local_runtime.capability_leases.clone(),
+        external_tool_catalog: std::sync::Arc::new(
+            ironclaw_turns::InMemoryExternalToolCatalog::new(),
+        ),
+    }
+}
+
 #[tokio::test]
 async fn local_dev_yolo_shell_translates_workspace_workdir_without_scoped_mounts() {
     let dir = tempfile::tempdir().expect("tempdir");
@@ -95,46 +138,16 @@ async fn local_dev_yolo_shell_translates_workspace_workdir_without_scoped_mounts
     )
     .await
     .expect("local-dev services build");
-    let runtime = services.host_runtime.clone().expect("host runtime");
     let local_runtime = services
         .local_runtime
         .as_ref()
         .expect("local runtime substrate"); // safety: test-only assertion in #[cfg(test)] module.
-    let workspace_mounts = local_runtime.workspace_mounts.clone();
-    let memory_mounts = local_runtime.memory_mounts.clone();
-    let policy = Arc::new(
-        crate::local_dev_capability_policy::local_dev_capability_policy().expect("policy parses"),
-    );
     let capability_io = Arc::new(LocalDevCapabilityIo::default());
-    let input_resolver: Arc<dyn LoopCapabilityInputResolver> = capability_io.clone();
-    let result_writer: Arc<dyn LoopCapabilityResultWriter> = capability_io.clone();
-    let factory = LocalDevLoopCapabilityPortFactory {
-        runtime,
-        fallback_user_id: UserId::new("local-dev-shell-user").expect("user id"),
-        policy,
-        workspace_mounts,
-        memory_mounts,
-        system_extensions_lifecycle_mounts: local_runtime
-            .system_extensions_lifecycle_mounts
-            .clone(),
-        extension_surface_source: LocalDevExtensionSurfaceSource::default(),
-        input_resolver,
-        result_writer,
-        milestone_sink: Arc::new(InMemoryLoopHostMilestoneSink::default()),
-        skill_activation_source: None,
-        project_service: Arc::clone(&local_runtime.project_service),
-        trajectory_observer: None,
-        outbound_preferences_facade: None,
-        outbound_delivery_target_set_requires_approval: false,
-        approval_settings: Arc::new(
-            crate::profile_approval_authorization::EmptyApprovalSettingsProvider,
-        ),
-        approval_requests: local_runtime.approval_requests.clone(),
-        capability_leases: local_runtime.capability_leases.clone(),
-        external_tool_catalog: std::sync::Arc::new(
-            ironclaw_turns::InMemoryExternalToolCatalog::new(),
-        ),
-    };
+    let factory = local_dev_shell_factory(
+        &services,
+        "local-dev-shell-user",
+        Arc::clone(&capability_io),
+    );
     let run_context = run_context("shell-workdir").await;
     // Turn on the global auto-approve switch for this run's actor scope so the
     // scripted shell call exercises the dispatch path instead of stopping at the
@@ -226,46 +239,16 @@ async fn local_dev_shell_scopes_non_owner_workspace_writes() {
     )
     .await
     .expect("local-dev services build");
-    let runtime = services.host_runtime.clone().expect("host runtime");
     let local_runtime = services
         .local_runtime
         .as_ref()
         .expect("local runtime substrate"); // safety: test-only assertion in #[cfg(test)] module.
-    let workspace_mounts = local_runtime.workspace_mounts.clone();
-    let memory_mounts = local_runtime.memory_mounts.clone();
-    let policy = Arc::new(
-        crate::local_dev_capability_policy::local_dev_capability_policy().expect("policy parses"),
-    );
     let capability_io = Arc::new(LocalDevCapabilityIo::default());
-    let input_resolver: Arc<dyn LoopCapabilityInputResolver> = capability_io.clone();
-    let result_writer: Arc<dyn LoopCapabilityResultWriter> = capability_io.clone();
-    let factory = LocalDevLoopCapabilityPortFactory {
-        runtime,
-        fallback_user_id: UserId::new("local-dev-shell-owner").expect("user id"),
-        policy,
-        workspace_mounts,
-        memory_mounts,
-        system_extensions_lifecycle_mounts: local_runtime
-            .system_extensions_lifecycle_mounts
-            .clone(),
-        extension_surface_source: LocalDevExtensionSurfaceSource::default(),
-        input_resolver,
-        result_writer,
-        milestone_sink: Arc::new(InMemoryLoopHostMilestoneSink::default()),
-        skill_activation_source: None,
-        project_service: Arc::clone(&local_runtime.project_service),
-        trajectory_observer: None,
-        outbound_preferences_facade: None,
-        outbound_delivery_target_set_requires_approval: false,
-        approval_settings: Arc::new(
-            crate::profile_approval_authorization::EmptyApprovalSettingsProvider,
-        ),
-        approval_requests: local_runtime.approval_requests.clone(),
-        capability_leases: local_runtime.capability_leases.clone(),
-        external_tool_catalog: std::sync::Arc::new(
-            ironclaw_turns::InMemoryExternalToolCatalog::new(),
-        ),
-    };
+    let factory = local_dev_shell_factory(
+        &services,
+        "local-dev-shell-owner",
+        Arc::clone(&capability_io),
+    );
     let run_context = owned_run_context("sso-shell-workspace", "sso-shell-user").await;
     {
         let mut scope = run_context.scope.to_resource_scope();
@@ -360,46 +343,16 @@ async fn local_dev_shell_rejects_non_owner_raw_workspace_escape() {
         workspace_root.join("tenants/tenant-raw-shell-workspace/users/other-shell-user/pwned.md");
     std::fs::create_dir_all(other_user_file.parent().expect("other user parent"))
         .expect("other user dir");
-    let runtime = services.host_runtime.clone().expect("host runtime");
     let local_runtime = services
         .local_runtime
         .as_ref()
         .expect("local runtime substrate"); // safety: test-only assertion in #[cfg(test)] module.
-    let workspace_mounts = local_runtime.workspace_mounts.clone();
-    let memory_mounts = local_runtime.memory_mounts.clone();
-    let policy = Arc::new(
-        crate::local_dev_capability_policy::local_dev_capability_policy().expect("policy parses"),
-    );
     let capability_io = Arc::new(LocalDevCapabilityIo::default());
-    let input_resolver: Arc<dyn LoopCapabilityInputResolver> = capability_io.clone();
-    let result_writer: Arc<dyn LoopCapabilityResultWriter> = capability_io.clone();
-    let factory = LocalDevLoopCapabilityPortFactory {
-        runtime,
-        fallback_user_id: UserId::new("local-dev-shell-owner").expect("user id"),
-        policy,
-        workspace_mounts,
-        memory_mounts,
-        system_extensions_lifecycle_mounts: local_runtime
-            .system_extensions_lifecycle_mounts
-            .clone(),
-        extension_surface_source: LocalDevExtensionSurfaceSource::default(),
-        input_resolver,
-        result_writer,
-        milestone_sink: Arc::new(InMemoryLoopHostMilestoneSink::default()),
-        skill_activation_source: None,
-        project_service: Arc::clone(&local_runtime.project_service),
-        trajectory_observer: None,
-        outbound_preferences_facade: None,
-        outbound_delivery_target_set_requires_approval: false,
-        approval_settings: Arc::new(
-            crate::profile_approval_authorization::EmptyApprovalSettingsProvider,
-        ),
-        approval_requests: local_runtime.approval_requests.clone(),
-        capability_leases: local_runtime.capability_leases.clone(),
-        external_tool_catalog: std::sync::Arc::new(
-            ironclaw_turns::InMemoryExternalToolCatalog::new(),
-        ),
-    };
+    let factory = local_dev_shell_factory(
+        &services,
+        "local-dev-shell-owner",
+        Arc::clone(&capability_io),
+    );
     let run_context = owned_run_context("raw-shell-workspace", "sso-shell-user").await;
     {
         let mut scope = run_context.scope.to_resource_scope();

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/shell_tests.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/shell_tests.rs
@@ -37,6 +37,25 @@ async fn run_context(label: &str) -> LoopRunContext {
     )
 }
 
+async fn owned_run_context(label: &str, owner_user_id: &str) -> LoopRunContext {
+    let resolved = InMemoryRunProfileResolver::default()
+        .resolve_run_profile(RunProfileResolutionRequest::interactive_default())
+        .await
+        .expect("profile resolves"); // safety: test-only assertion in #[cfg(test)] module.
+    LoopRunContext::new(
+        TurnScope::new_with_owner(
+            TenantId::new(format!("tenant-{label}")).expect("tenant id"), // safety: test-only assertion in #[cfg(test)] module.
+            Some(AgentId::new(format!("agent-{label}")).expect("agent id")), // safety: test-only assertion in #[cfg(test)] module.
+            Some(ProjectId::new(format!("project-{label}")).expect("project id")), // safety: test-only assertion in #[cfg(test)] module.
+            ThreadId::new(format!("thread-{label}")).expect("thread id"), // safety: test-only assertion in #[cfg(test)] module.
+            Some(UserId::new(owner_user_id).expect("owner user id")), // safety: test-only assertion in #[cfg(test)] module.
+        ),
+        TurnId::new(),
+        TurnRunId::new(),
+        resolved,
+    )
+}
+
 fn provider_tool_call(arguments: serde_json::Value) -> ProviderToolCall {
     ProviderToolCall {
         provider_id: "test-provider".to_string(),
@@ -181,5 +200,136 @@ async fn local_dev_yolo_shell_translates_workspace_workdir_without_scoped_mounts
     assert_eq!(
         output["output"],
         serde_json::json!("local-dev-shell-ok:/workspace/qa-coding-smoke")
+    );
+}
+
+#[tokio::test]
+async fn local_dev_shell_scopes_non_owner_workspace_writes() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let storage_root = dir.path().join("local-dev");
+    let workspace_root = dir.path().join("workspace");
+    let host_home = dir.path().join("home");
+    std::fs::create_dir_all(&host_home).expect("host home root");
+    let services = crate::build_reborn_services(
+        crate::local_runtime_build_input_with_options(
+            crate::RebornCompositionProfile::LocalDevYolo,
+            "local-dev-shell-owner",
+            storage_root,
+            crate::RebornLocalRuntimeProfileOptions {
+                confirm_host_access: true,
+            },
+        )
+        .expect("local yolo input")
+        .with_local_dev_workspace_root(workspace_root.clone())
+        .with_local_dev_confirmed_host_home_root(host_home),
+    )
+    .await
+    .expect("local-dev services build");
+    let runtime = services.host_runtime.clone().expect("host runtime");
+    let local_runtime = services
+        .local_runtime
+        .as_ref()
+        .expect("local runtime substrate"); // safety: test-only assertion in #[cfg(test)] module.
+    let workspace_mounts = local_runtime.workspace_mounts.clone();
+    let memory_mounts = local_runtime.memory_mounts.clone();
+    let policy = Arc::new(
+        crate::local_dev_capability_policy::local_dev_capability_policy().expect("policy parses"),
+    );
+    let capability_io = Arc::new(LocalDevCapabilityIo::default());
+    let input_resolver: Arc<dyn LoopCapabilityInputResolver> = capability_io.clone();
+    let result_writer: Arc<dyn LoopCapabilityResultWriter> = capability_io.clone();
+    let factory = LocalDevLoopCapabilityPortFactory {
+        runtime,
+        fallback_user_id: UserId::new("local-dev-shell-owner").expect("user id"),
+        policy,
+        workspace_mounts,
+        memory_mounts,
+        system_extensions_lifecycle_mounts: local_runtime
+            .system_extensions_lifecycle_mounts
+            .clone(),
+        extension_surface_source: LocalDevExtensionSurfaceSource::default(),
+        input_resolver,
+        result_writer,
+        milestone_sink: Arc::new(InMemoryLoopHostMilestoneSink::default()),
+        skill_activation_source: None,
+        project_service: Arc::clone(&local_runtime.project_service),
+        trajectory_observer: None,
+        outbound_preferences_facade: None,
+        outbound_delivery_target_set_requires_approval: false,
+        approval_settings: Arc::new(
+            crate::profile_approval_authorization::EmptyApprovalSettingsProvider,
+        ),
+        approval_requests: local_runtime.approval_requests.clone(),
+        capability_leases: local_runtime.capability_leases.clone(),
+        external_tool_catalog: std::sync::Arc::new(
+            ironclaw_turns::InMemoryExternalToolCatalog::new(),
+        ),
+    };
+    let run_context = owned_run_context("sso-shell-workspace", "sso-shell-user").await;
+    {
+        let mut scope = run_context.scope.to_resource_scope();
+        scope.user_id = UserId::new("sso-shell-user").expect("user id");
+        ironclaw_approvals::AutoApproveSettingStore::set(
+            local_runtime.auto_approve_settings.as_ref(),
+            ironclaw_approvals::AutoApproveSettingInput {
+                updated_by: ironclaw_host_api::Principal::User(scope.user_id.clone()),
+                scope,
+                enabled: true,
+            },
+        )
+        .await
+        .expect("enabling global auto-approve should succeed");
+    }
+    let port = factory
+        .create_capability_port(&run_context)
+        .await
+        .expect("capability port");
+    let surface = port
+        .visible_capabilities(VisibleCapabilityRequest {})
+        .await
+        .expect("visible surface");
+    let input_ref = capability_io
+        .register_provider_tool_call_input(
+            &run_context,
+            &provider_tool_call(serde_json::json!({
+                "command": "printf '# Hello\\n' > /workspace/hello.md && printf '%s' \"$PWD\"",
+                "workdir": "/workspace"
+            })),
+        )
+        .await
+        .expect("input ref");
+
+    let outcome = port
+        .invoke_capability(CapabilityInvocation {
+            activity_id: ironclaw_turns::CapabilityActivityId::new(),
+            surface_version: surface.version,
+            capability_id: CapabilityId::new(SHELL_CAPABILITY_ID).expect("shell capability id"),
+            input_ref,
+            approval_resume: None,
+            auth_resume: None,
+        })
+        .await
+        .expect("shell invocation");
+
+    let CapabilityOutcome::Completed(completed) = outcome else {
+        panic!("expected completed shell invocation");
+    };
+    let output = capability_io
+        .result_output(completed.result_ref.as_str())
+        .expect("result output lookup")
+        .expect("result output");
+    assert_eq!(output["exit_code"], serde_json::json!(0));
+    assert_eq!(output["success"], serde_json::json!(true));
+    assert_eq!(output["output"], serde_json::json!("/workspace"));
+    assert_eq!(
+        std::fs::read_to_string(
+            workspace_root.join("tenants/tenant-sso-shell-workspace/users/sso-shell-user/hello.md")
+        )
+        .expect("scoped shell artifact"),
+        "# Hello\n"
+    );
+    assert!(
+        !workspace_root.join("hello.md").exists(),
+        "non-owner shell writes must not land in the raw workspace root"
     );
 }

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/shell_tests.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/shell_tests.rs
@@ -10,8 +10,9 @@ use ironclaw_loop_support::{
 use ironclaw_turns::{
     RunProfileResolutionRequest, RunProfileResolver, TurnId, TurnRunId, TurnScope,
     run_profile::{
-        CapabilityInvocation, CapabilityOutcome, InMemoryLoopHostMilestoneSink,
-        InMemoryRunProfileResolver, LoopRunContext, ProviderToolCall, VisibleCapabilityRequest,
+        CapabilityFailureKind, CapabilityInvocation, CapabilityOutcome,
+        InMemoryLoopHostMilestoneSink, InMemoryRunProfileResolver, LoopRunContext,
+        ProviderToolCall, VisibleCapabilityRequest,
     },
 };
 
@@ -185,7 +186,7 @@ async fn local_dev_yolo_shell_translates_workspace_workdir_without_scoped_mounts
         .expect("shell invocation");
 
     let CapabilityOutcome::Completed(completed) = outcome else {
-        panic!("expected completed shell invocation");
+        panic!("expected completed shell invocation, got {outcome:?}");
     };
     let output = capability_io
         .result_output(completed.result_ref.as_str())
@@ -292,8 +293,7 @@ async fn local_dev_shell_scopes_non_owner_workspace_writes() {
         .register_provider_tool_call_input(
             &run_context,
             &provider_tool_call(serde_json::json!({
-                "command": "printf '# Hello\\n' > /workspace/hello.md && printf '%s' \"$PWD\"",
-                "workdir": "/workspace"
+                "command": "printf '# Hello\\n' > /workspace/hello.md && printf '%s' \"$PWD\""
             })),
         )
         .await
@@ -331,5 +331,129 @@ async fn local_dev_shell_scopes_non_owner_workspace_writes() {
     assert!(
         !workspace_root.join("hello.md").exists(),
         "non-owner shell writes must not land in the raw workspace root"
+    );
+}
+
+#[tokio::test]
+async fn local_dev_shell_rejects_non_owner_raw_workspace_escape() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let storage_root = dir.path().join("local-dev");
+    let workspace_root = dir.path().join("workspace");
+    let host_home = dir.path().join("home");
+    std::fs::create_dir_all(&host_home).expect("host home root");
+    let services = crate::build_reborn_services(
+        crate::local_runtime_build_input_with_options(
+            crate::RebornCompositionProfile::LocalDevYolo,
+            "local-dev-shell-owner",
+            storage_root,
+            crate::RebornLocalRuntimeProfileOptions {
+                confirm_host_access: true,
+            },
+        )
+        .expect("local yolo input")
+        .with_local_dev_workspace_root(workspace_root.clone())
+        .with_local_dev_confirmed_host_home_root(host_home),
+    )
+    .await
+    .expect("local-dev services build");
+    let other_user_file =
+        workspace_root.join("tenants/tenant-raw-shell-workspace/users/other-shell-user/pwned.md");
+    std::fs::create_dir_all(other_user_file.parent().expect("other user parent"))
+        .expect("other user dir");
+    let runtime = services.host_runtime.clone().expect("host runtime");
+    let local_runtime = services
+        .local_runtime
+        .as_ref()
+        .expect("local runtime substrate"); // safety: test-only assertion in #[cfg(test)] module.
+    let workspace_mounts = local_runtime.workspace_mounts.clone();
+    let memory_mounts = local_runtime.memory_mounts.clone();
+    let policy = Arc::new(
+        crate::local_dev_capability_policy::local_dev_capability_policy().expect("policy parses"),
+    );
+    let capability_io = Arc::new(LocalDevCapabilityIo::default());
+    let input_resolver: Arc<dyn LoopCapabilityInputResolver> = capability_io.clone();
+    let result_writer: Arc<dyn LoopCapabilityResultWriter> = capability_io.clone();
+    let factory = LocalDevLoopCapabilityPortFactory {
+        runtime,
+        fallback_user_id: UserId::new("local-dev-shell-owner").expect("user id"),
+        policy,
+        workspace_mounts,
+        memory_mounts,
+        system_extensions_lifecycle_mounts: local_runtime
+            .system_extensions_lifecycle_mounts
+            .clone(),
+        extension_surface_source: LocalDevExtensionSurfaceSource::default(),
+        input_resolver,
+        result_writer,
+        milestone_sink: Arc::new(InMemoryLoopHostMilestoneSink::default()),
+        skill_activation_source: None,
+        project_service: Arc::clone(&local_runtime.project_service),
+        trajectory_observer: None,
+        outbound_preferences_facade: None,
+        outbound_delivery_target_set_requires_approval: false,
+        approval_settings: Arc::new(
+            crate::profile_approval_authorization::EmptyApprovalSettingsProvider,
+        ),
+        approval_requests: local_runtime.approval_requests.clone(),
+        capability_leases: local_runtime.capability_leases.clone(),
+        external_tool_catalog: std::sync::Arc::new(
+            ironclaw_turns::InMemoryExternalToolCatalog::new(),
+        ),
+    };
+    let run_context = owned_run_context("raw-shell-workspace", "sso-shell-user").await;
+    {
+        let mut scope = run_context.scope.to_resource_scope();
+        scope.user_id = UserId::new("sso-shell-user").expect("user id");
+        ironclaw_approvals::AutoApproveSettingStore::set(
+            local_runtime.auto_approve_settings.as_ref(),
+            ironclaw_approvals::AutoApproveSettingInput {
+                updated_by: ironclaw_host_api::Principal::User(scope.user_id.clone()),
+                scope,
+                enabled: true,
+            },
+        )
+        .await
+        .expect("enabling global auto-approve should succeed");
+    }
+    let port = factory
+        .create_capability_port(&run_context)
+        .await
+        .expect("capability port");
+    let surface = port
+        .visible_capabilities(VisibleCapabilityRequest {})
+        .await
+        .expect("visible surface");
+    let input_ref = capability_io
+        .register_provider_tool_call_input(
+            &run_context,
+            &provider_tool_call(serde_json::json!({
+                "command": format!("printf hacked > {}", other_user_file.display()),
+                "workdir": "/workspace"
+            })),
+        )
+        .await
+        .expect("input ref");
+
+    let outcome = port
+        .invoke_capability(CapabilityInvocation {
+            activity_id: ironclaw_turns::CapabilityActivityId::new(),
+            surface_version: surface.version,
+            capability_id: CapabilityId::new(SHELL_CAPABILITY_ID).expect("shell capability id"),
+            input_ref,
+            approval_resume: None,
+            auth_resume: None,
+        })
+        .await
+        .expect("shell invocation should return a model-visible failure");
+
+    match outcome {
+        CapabilityOutcome::Failed(failure) => {
+            assert_eq!(failure.error_kind, CapabilityFailureKind::Backend);
+        }
+        other => panic!("expected raw workspace shell escape to fail, got {other:?}"),
+    }
+    assert!(
+        !other_user_file.exists(),
+        "non-owner shell must not write another user's raw workspace artifact"
     );
 }

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/tests.rs
@@ -207,6 +207,46 @@ mod tests {
         provider_tool_call_with_name("builtin_echo", arguments)
     }
 
+    async fn invoke_write_file_tool(
+        wiring: &LocalDevCapabilityWiring,
+        run_context: &LoopRunContext,
+        path: &str,
+        content: &str,
+    ) {
+        let port = wiring
+            .capability_factory
+            .create_capability_port(run_context)
+            .await
+            .expect("capability port");
+        let write_tool = port
+            .tool_definitions()
+            .expect("tool definitions")
+            .into_iter()
+            .find(|definition| definition.capability_id.as_str() == WRITE_FILE_CAPABILITY_ID)
+            .expect("write_file tool definition");
+        let candidate = port
+            .register_provider_tool_call(RegisterProviderToolCallRequest::new(
+                provider_tool_call_with_name(
+                    write_tool.name.as_str(),
+                    serde_json::json!({
+                        "path": path,
+                        "content": content,
+                    }),
+                ),
+            ))
+            .await
+            .expect("write_file provider call stages");
+        let outcome = port
+            .invoke_capability(invocation_for_candidate(&candidate))
+            .await
+            .expect("write_file invocation");
+
+        match outcome {
+            CapabilityOutcome::Completed(_) => {}
+            other => panic!("expected completed write_file invocation, got {other:?}"),
+        }
+    }
+
     fn invocation_for_candidate(candidate: &CapabilityCallCandidate) -> CapabilityInvocation {
         CapabilityInvocation {
             activity_id: candidate.activity_id,
@@ -2873,6 +2913,80 @@ mod tests {
         assert_eq!(
             output["content"],
             serde_json::json!("     1│ safe workspace file")
+        );
+    }
+
+    #[tokio::test]
+    async fn local_dev_capability_port_scopes_non_owner_workspace_writes() {
+        let dir = tempfile::tempdir().expect("tempdir"); // safety: test-only setup in #[cfg(test)] module.
+        let storage_root = dir.path().join("local-dev");
+        let workspace_root = dir.path().join("workspace");
+        let owner_id = UserId::new("local-dev-artifact-owner").expect("owner user id");
+        let sso_user_id = UserId::new("sso-artifact-user").expect("sso user id");
+        let services = crate::build_reborn_services(
+            crate::RebornBuildInput::local_dev(owner_id.as_str(), storage_root)
+                .with_local_dev_workspace_root(workspace_root.clone()),
+        )
+        .await
+        .expect("local-dev services build");
+        let wiring = capability_wiring(
+            &services,
+            Arc::new(InMemorySessionThreadService::default()),
+            owner_id.clone(),
+            Arc::new(
+                crate::local_dev_capability_policy::local_dev_capability_policy()
+                    .expect("policy parses"),
+            ),
+            Arc::new(UnavailableModelGateway),
+            Arc::new(InMemoryLoopHostMilestoneSink::default()),
+            None,
+            None,
+            None,
+        )
+        .expect("local-dev capability wiring");
+
+        let sso_run_context = run_context("sso-artifact-write")
+            .await
+            .with_actor(TurnActor::new(sso_user_id.clone()));
+        enable_global_auto_approve_for_run(&services, &sso_run_context, &sso_user_id).await;
+        invoke_write_file_tool(
+            &wiring,
+            &sso_run_context,
+            "/workspace/hello1.md",
+            "hello from sso\n",
+        )
+        .await;
+
+        let scoped_sso_path = workspace_root
+            .join("tenants")
+            .join("tenant-sso-artifact-write")
+            .join("users")
+            .join(sso_user_id.as_str())
+            .join("hello1.md");
+        assert_eq!(
+            std::fs::read_to_string(scoped_sso_path).expect("scoped sso artifact"),
+            "hello from sso\n"
+        );
+        assert!(
+            !workspace_root.join("hello1.md").exists(),
+            "non-owner writes must not land in the shared raw workspace root"
+        );
+
+        let owner_run_context = run_context("owner-artifact-write")
+            .await
+            .with_actor(TurnActor::new(owner_id.clone()));
+        enable_global_auto_approve_for_run(&services, &owner_run_context, &owner_id).await;
+        invoke_write_file_tool(
+            &wiring,
+            &owner_run_context,
+            "/workspace/owner.md",
+            "hello from owner\n",
+        )
+        .await;
+
+        assert_eq!(
+            std::fs::read_to_string(workspace_root.join("owner.md")).expect("owner artifact"),
+            "hello from owner\n"
         );
     }
 


### PR DESCRIPTION
## Summary
- Map coding-tool path `/` to the workspace mount.
- Make an unmaterialized workspace root read as empty for `list_dir`, `glob`, and `grep`.
- Preserve errors for missing paths beneath the root.
- Scope local-dev workspace writes by the run user when a scoped workspace mount is present.
- Keep shell artifacts inside the scoped workspace mount instead of the raw shared workspace root.
- Reject raw host workspace paths, relative parent traversal escapes, and raw `/` shell access for scoped workspaces.

## Relationship to #5831
#5831 now only changes the WebUI Workspace/Memory presentation. This PR owns the tool/host execution behavior that could affect agents and benchmark scores: coding tools, shell workdir mapping, and scoped-workspace shell escape guards.

## Current Behavior
- `list_dir`, `glob`, and `grep` can treat logical `/` as the workspace root without requiring the physical workspace directory to already exist.
- Missing nested paths still fail normally, so only the virtual root gets the empty-root affordance.
- Shell commands in scoped hosted workspaces can operate inside `/workspace`, but attempts to use raw shared workspace paths, `..` escapes to sibling users, or raw `/` are rejected at the host boundary.

## Validation
- `cargo fmt --all --check`
- `cargo test -p ironclaw_host_runtime builtin_coding_ --test first_party_builtin_tools --features test-support,libsql -- --nocapture`
- `cargo test -p ironclaw_host_runtime local_host_process_port_rejects_raw_root_for_scoped_workspace --lib --features test-support,libsql -- --nocapture`
- Previously run before this PR absorbed the shell-scope commits: `cargo clippy -p ironclaw_first_party_extensions -p ironclaw_host_runtime --all-targets --features test-support,libsql -- -D warnings`
- Previously run before this PR absorbed the shell-scope commits: `git diff --check`
