### PR TITLE
fix(webui): recover from stale thread 404s

### DIFF
--- a/crates/ironclaw_webui_v2/frontend/src/i18n/en.ts
+++ b/crates/ironclaw_webui_v2/frontend/src/i18n/en.ts
@@ -1400,6 +1400,7 @@ registerPack("en", {
   "chat.copyMessage": "Copy message",
   "chat.retryMessage": "Retry message",
   "chat.history.loadFailed": "Failed to load conversation history.",
+  "chat.threadNoLongerExists": "This thread no longer exists",
   "chat.finishPairingBeforeSend": "Finish connecting the channel before sending another message.",
   "chat.resolveApprovalBeforeSend": "Resolve the approval request before sending another message.",
   "chat.retryIn": "Retry in {seconds}s",

--- a/crates/ironclaw_webui_v2/frontend/src/lib/thread-errors.test.ts
+++ b/crates/ironclaw_webui_v2/frontend/src/lib/thread-errors.test.ts
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import { test } from "vitest";
 
-import { deleteThreadErrorMessage, isThreadBusyError } from "./thread-errors";
+import {
+  deleteThreadErrorMessage,
+  isThreadBusyError,
+  isThreadNotFoundError,
+} from "./thread-errors";
 
 const t = (key) => key;
 
@@ -13,6 +17,13 @@ test("isThreadBusyError matches the busy kind, not any 409", () => {
   assert.equal(isThreadBusyError({ status: 409 }), false);
   assert.equal(isThreadBusyError({ status: 500 }), false);
   assert.equal(isThreadBusyError(undefined), false);
+});
+
+test("isThreadNotFoundError matches thread request 404s", () => {
+  assert.equal(isThreadNotFoundError({ status: 404 }), true);
+  assert.equal(isThreadNotFoundError({ status: 404, payload: { kind: "not_found" } }), true);
+  assert.equal(isThreadNotFoundError({ status: 500, payload: { kind: "not_found" } }), false);
+  assert.equal(isThreadNotFoundError(undefined), false);
 });
 
 test("deleteThreadErrorMessage surfaces a clear line for a running thread (#4823)", () => {

--- a/crates/ironclaw_webui_v2/frontend/src/lib/thread-errors.ts
+++ b/crates/ironclaw_webui_v2/frontend/src/lib/thread-errors.ts
@@ -13,6 +13,10 @@ export function isThreadBusyError(error) {
   return error?.status === 409 && error?.payload?.kind === "busy";
 }
 
+export function isThreadNotFoundError(error) {
+  return error?.status === 404;
+}
+
 export function deleteThreadErrorMessage(error, t) {
   if (isThreadBusyError(error)) return t("chat.deleteBusy");
   return error?.message || t("chat.deleteFailed");

--- a/crates/ironclaw_webui_v2/frontend/src/pages/chat/chat.tsx
+++ b/crates/ironclaw_webui_v2/frontend/src/pages/chat/chat.tsx
@@ -21,7 +21,11 @@ import { SuggestionChips } from "./components/suggestion-chips";
 import { TypingIndicator } from "./components/typing-indicator";
 import { useChat } from "./hooks/useChat";
 import { channelConnectionDisplayName } from "../../lib/channel-connection-events";
-import { NEW_DRAFT_KEY } from "./lib/draft-store";
+import {
+  NEW_DRAFT_KEY,
+  setDraft,
+  setStagedAttachments,
+} from "./lib/draft-store";
 import { buildRuntimeContext } from "./lib/runtime-context";
 import { buildScopedLogsPath } from "../logs/lib/logs-data";
 import { useInterfacePreferences } from "../../lib/interface-preferences";
@@ -69,10 +73,19 @@ export function Chat({
   const t = useT();
   const { showChatLogsShortcut } = useInterfacePreferences();
   const handleThreadNotFound = React.useCallback(
-    (missingThreadId) => {
+    (missingThreadId, recovery = {}) => {
+      const draft = recovery.composerDraft || "";
+      const stagedAttachments = recovery.stagedAttachments || [];
+      if (draft) setDraft(NEW_DRAFT_KEY, draft);
+      if (stagedAttachments.length > 0) {
+        setStagedAttachments(NEW_DRAFT_KEY, stagedAttachments);
+      }
       clearThreadState(missingThreadId);
       toast(t("chat.threadNoLongerExists"), { tone: "error", duration: 5000 });
-      onSelectThread?.(null, { replace: true });
+      onSelectThread?.(null, {
+        replace: true,
+        ...(draft ? { state: { composerDraft: draft } } : {}),
+      });
     },
     [onSelectThread, t],
   );

--- a/crates/ironclaw_webui_v2/frontend/src/pages/chat/chat.tsx
+++ b/crates/ironclaw_webui_v2/frontend/src/pages/chat/chat.tsx
@@ -25,6 +25,7 @@ import { NEW_DRAFT_KEY } from "./lib/draft-store";
 import { buildRuntimeContext } from "./lib/runtime-context";
 import { buildScopedLogsPath } from "../logs/lib/logs-data";
 import { useInterfacePreferences } from "../../lib/interface-preferences";
+import { toast } from "../../lib/toast";
 
 /* Grace window before an active thread's sidebar state is cleared to idle.
  * Long enough for SSE to rehydrate a gate/run after a thread switch (so a
@@ -67,6 +68,14 @@ export function Chat({
 }) {
   const t = useT();
   const { showChatLogsShortcut } = useInterfacePreferences();
+  const handleThreadNotFound = React.useCallback(
+    (missingThreadId) => {
+      clearThreadState(missingThreadId);
+      toast(t("chat.threadNoLongerExists"), { tone: "error", duration: 5000 });
+      onSelectThread?.(null, { replace: true });
+    },
+    [onSelectThread, t],
+  );
   const {
     messages,
     isProcessing,
@@ -93,7 +102,7 @@ export function Chat({
     submitChannelConnectionPairing,
     startOnboardingOAuth,
     dismissOnboardingPairing,
-  } = useChat(activeThreadId);
+  } = useChat(activeThreadId, { onThreadNotFound: handleThreadNotFound });
 
   const activeThread = React.useMemo(
     () => threads.find((thread) => thread.id === activeThreadId) || null,

--- a/crates/ironclaw_webui_v2/frontend/src/pages/chat/hooks/useChat.ts
+++ b/crates/ironclaw_webui_v2/frontend/src/pages/chat/hooks/useChat.ts
@@ -12,13 +12,14 @@ import {
   subscribeProductAuthOAuthCompletion,
 } from "../../../lib/product-auth-oauth-events";
 import { queryClient } from "../../../lib/query-client";
+import { isThreadNotFoundError } from "../../../lib/thread-errors";
 import React from "react";
 import {
   onboardingBelongsToThread,
   useChannelOnboarding,
 } from "./useChannelOnboarding";
 import { useChatEvents } from "../lib/useChatEvents";
-import { touchThreadInCache } from "../lib/thread-cache";
+import { removeThreadFromCache, touchThreadInCache } from "../lib/thread-cache";
 import {
   addPending,
   recordAcceptedMessageRef,
@@ -47,7 +48,7 @@ import {
 } from "../lib/connection-status";
 import { toRenderAttachment, toWireAttachment } from "../lib/attachments";
 import { failureMessageForRequestError } from "../lib/failureMessages";
-import { useHistory } from "./useHistory";
+import { evictThreadHistory, useHistory } from "./useHistory";
 import { useSSE } from "./useSSE";
 
 const AUTH_TOKEN_FLOW_TIMEOUT_MS = 30000;
@@ -118,8 +119,10 @@ function isPendingOAuthGate(gate) {
 // - resolveGate uses `runId` + `gateRef` from the live event stream, not
 //   a v1-style `requestId`.
 // - cancelRun is a first-class action and posts to the v2 cancel route.
-export function useChat(threadId) {
+export function useChat(threadId, options = {}) {
+  const { onThreadNotFound } = options;
   const threadIdRef = React.useRef(threadId);
+  const missingThreadIdsRef = React.useRef(new Set());
   const pendingMessagesRef = React.useRef(new Map());
   const pendingSeqRef = React.useRef(1);
   const [cooldownUntil, setCooldownUntil] = React.useState(0);
@@ -159,6 +162,17 @@ export function useChat(threadId) {
     [threadId],
   );
 
+  const handleThreadNotFound = React.useCallback(
+    (missingThreadId) => {
+      if (!missingThreadId || missingThreadIdsRef.current.has(missingThreadId)) return;
+      missingThreadIdsRef.current.add(missingThreadId);
+      removeThreadFromCache(missingThreadId);
+      evictThreadHistory(missingThreadId);
+      onThreadNotFound?.(missingThreadId);
+    },
+    [onThreadNotFound],
+  );
+
   const {
     messages,
     messagesThreadId,
@@ -169,7 +183,11 @@ export function useChat(threadId) {
     loadHistory,
     seedThreadMessages,
     setMessages,
-  } = useHistory(threadId, { getPendingMessages, setPendingMessages });
+  } = useHistory(threadId, {
+    getPendingMessages,
+    onThreadNotFound: handleThreadNotFound,
+    setPendingMessages,
+  });
 
   const [isProcessing, setIsProcessingState] = React.useState(false);
   const isProcessingRef = React.useRef(isProcessing);
@@ -776,6 +794,17 @@ export function useChat(threadId) {
         if (err.status === 429) {
           setCooldownUntil(Date.now() + retryAfterMs(err));
         }
+        if (isThreadNotFoundError(err) && sendThreadId) {
+          if (!threadIdRef.current || threadIdRef.current === sendThreadId) {
+            handleThreadNotFound(sendThreadId);
+          } else {
+            removeThreadFromCache(sendThreadId);
+            evictThreadHistory(sendThreadId);
+          }
+          updateCurrentRunState(() => setIsProcessing(false));
+          submitBusyRef.current = false;
+          throw err;
+        }
         const failureContent = failureMessageForRequestError(err);
         // Mark the optimistic user bubble as retryable and append a separate
         // assistant-side error bubble. Apply each updater to both stores because
@@ -826,6 +855,7 @@ export function useChat(threadId) {
     },
     [
       threadId,
+      handleThreadNotFound,
       pendingGate,
       pendingOnboarding,
       setMessages,

--- a/crates/ironclaw_webui_v2/frontend/src/pages/chat/hooks/useChat.ts
+++ b/crates/ironclaw_webui_v2/frontend/src/pages/chat/hooks/useChat.ts
@@ -163,12 +163,12 @@ export function useChat(threadId, options = {}) {
   );
 
   const handleThreadNotFound = React.useCallback(
-    (missingThreadId) => {
+    (missingThreadId, recovery) => {
       if (!missingThreadId || missingThreadIdsRef.current.has(missingThreadId)) return;
       missingThreadIdsRef.current.add(missingThreadId);
       removeThreadFromCache(missingThreadId);
       evictThreadHistory(missingThreadId);
-      onThreadNotFound?.(missingThreadId);
+      onThreadNotFound?.(missingThreadId, recovery);
     },
     [onThreadNotFound],
   );
@@ -276,6 +276,7 @@ export function useChat(threadId, options = {}) {
   // raw setActiveRunState rather than the activeRunRef-mutating wrapper.
   if (stateThreadId !== threadId) {
     setStateThreadId(threadId);
+    missingThreadIdsRef.current.clear();
     setIsProcessingState(false);
     setPendingGateState(null);
     setPendingOnboardingState(null);
@@ -796,13 +797,15 @@ export function useChat(threadId, options = {}) {
         }
         if (isThreadNotFoundError(err) && sendThreadId) {
           if (!threadIdRef.current || threadIdRef.current === sendThreadId) {
-            handleThreadNotFound(sendThreadId);
+            handleThreadNotFound(sendThreadId, {
+              composerDraft: renderContent,
+              stagedAttachments,
+            });
+            updateCurrentRunState(() => setIsProcessing(false));
           } else {
             removeThreadFromCache(sendThreadId);
             evictThreadHistory(sendThreadId);
           }
-          updateCurrentRunState(() => setIsProcessing(false));
-          submitBusyRef.current = false;
           throw err;
         }
         const failureContent = failureMessageForRequestError(err);

--- a/crates/ironclaw_webui_v2/frontend/src/pages/chat/hooks/useHistory.ts
+++ b/crates/ironclaw_webui_v2/frontend/src/pages/chat/hooks/useHistory.ts
@@ -2,6 +2,7 @@
 import React from "react";
 import { fetchTimeline } from "../../../lib/api";
 import { authScope } from "../../../lib/auth-scope";
+import { isThreadNotFoundError } from "../../../lib/thread-errors";
 import { messagesFromTimeline } from "../lib/history-messages";
 import {
   carryFinalAssistantOrderFlags,
@@ -50,8 +51,12 @@ export function clearHistoryCache() {
   historyCache.clear();
 }
 
+export function evictThreadHistory(threadId) {
+  if (threadId) historyCache.delete(cacheKey(threadId));
+}
+
 export function useHistory(threadId, options = {}) {
-  const { getPendingMessages, setPendingMessages } = options;
+  const { getPendingMessages, onThreadNotFound, setPendingMessages } = options;
   const cached = threadId ? historyCache.get(cacheKey(threadId)) : null;
   const [state, setState] = React.useState({
     messages: cached?.messages || [],
@@ -179,9 +184,23 @@ export function useHistory(threadId, options = {}) {
           };
         });
       } catch (err) {
-        console.error("Failed to load timeline:", err);
         // Identity changed mid-flight — the error isn't the new user's.
         if (authScope() !== issuingScope) return;
+        if (isThreadNotFoundError(err)) {
+          evictThreadHistory(threadId);
+          if (threadIdRef.current === threadId) {
+            setState((state) => ({
+              ...state,
+              messages: [],
+              nextCursor: null,
+              isLoading: false,
+              loadError: null,
+            }));
+            onThreadNotFound?.(threadId);
+          }
+          return;
+        }
+        console.error("Failed to load timeline:", err);
         // Stay loud — surface a user-visible error rather than silently
         // masking timeline outages. Ignore a stale resolve for a thread the
         // user already navigated away from (its data is already cached).
@@ -198,7 +217,7 @@ export function useHistory(threadId, options = {}) {
         loadingRef.current.delete(threadId);
       }
     },
-    [threadId, getPendingMessages, setPendingMessages],
+    [threadId, getPendingMessages, onThreadNotFound, setPendingMessages],
   );
 
   React.useEffect(() => {

--- a/crates/ironclaw_webui_v2/frontend/src/pages/chat/hooks/useHistory.ts
+++ b/crates/ironclaw_webui_v2/frontend/src/pages/chat/hooks/useHistory.ts
@@ -4,6 +4,7 @@ import { fetchTimeline } from "../../../lib/api";
 import { authScope } from "../../../lib/auth-scope";
 import { isThreadNotFoundError } from "../../../lib/thread-errors";
 import { messagesFromTimeline } from "../lib/history-messages";
+import { removeThreadFromCache } from "../lib/thread-cache";
 import {
   carryFinalAssistantOrderFlags,
   isFinalAssistantMessage,
@@ -187,6 +188,7 @@ export function useHistory(threadId, options = {}) {
         // Identity changed mid-flight — the error isn't the new user's.
         if (authScope() !== issuingScope) return;
         if (isThreadNotFoundError(err)) {
+          removeThreadFromCache(threadId);
           evictThreadHistory(threadId);
           if (threadIdRef.current === threadId) {
             setState((state) => ({

--- a/crates/ironclaw_webui_v2/frontend/src/pages/chat/lib/chat.test.ts
+++ b/crates/ironclaw_webui_v2/frontend/src/pages/chat/lib/chat.test.ts
@@ -83,6 +83,8 @@ function renderChat({
   showChatLogsShortcut = true,
   selectedThreads = [],
   toasts = [],
+  drafts = [],
+  stagedAttachments = [],
   chatHookOptions = [],
   translations = {},
 }) {
@@ -127,6 +129,9 @@ function renderChat({
     channelConnectionDisplayName,
     setThreadState: (threadId, state) =>
       threadStateUpdates.push({ threadId, state }),
+    setDraft: (key, text) => drafts.push({ key, text }),
+    setStagedAttachments: (key, attachments) =>
+      stagedAttachments.push({ key, attachments }),
     toast: (message, options) => toasts.push({ message, options }),
     setTimeout: () => 1,
     clearTimeout: () => {},
@@ -192,6 +197,52 @@ test("Chat leaves a missing thread and shows the dedicated notice", () => {
       message: "This thread no longer exists",
       options: { tone: "error", duration: 5000 },
     },
+  ]);
+});
+
+test("Chat preserves a submitted draft when a send discovers the thread is missing", () => {
+  const drafts = [];
+  const stagedAttachments = [];
+  const { chatHookOptions, selectedThreads } = renderChat({
+    drafts,
+    stagedAttachments,
+    translations: {
+      "chat.threadNoLongerExists": "This thread no longer exists",
+    },
+    hookState: {
+      messages: [],
+      isProcessing: false,
+      pendingGate: null,
+      suggestions: [],
+      sseStatus: "idle",
+      historyLoading: false,
+      hasMore: false,
+      cooldownSeconds: 0,
+      recoveryNotice: null,
+      activeRun: null,
+      send: async () => ({}),
+      cancelRun: async () => {},
+      retryMessage: () => {},
+      approve: () => {},
+      recoverHistory: () => {},
+      loadMore: () => {},
+      setSuggestions: () => {},
+      submitAuthToken: async () => {},
+    },
+  });
+  const attachment = { id: "attachment-1", filename: "notes.txt" };
+
+  chatHookOptions[0].onThreadNotFound("thread-1", {
+    composerDraft: "recover this send",
+    stagedAttachments: [attachment],
+  });
+
+  assert.deepEqual(drafts, [{ key: "new", text: "recover this send" }]);
+  assert.deepEqual(stagedAttachments, [
+    { key: "new", attachments: [attachment] },
+  ]);
+  assert.deepEqual(JSON.parse(JSON.stringify(selectedThreads)), [
+    [null, { replace: true, state: { composerDraft: "recover this send" } }],
   ]);
 });
 

--- a/crates/ironclaw_webui_v2/frontend/src/pages/chat/lib/chat.test.ts
+++ b/crates/ironclaw_webui_v2/frontend/src/pages/chat/lib/chat.test.ts
@@ -81,6 +81,10 @@ function renderChat({
   threadStateUpdates = [],
   globalAutoApproveEnabled = false,
   showChatLogsShortcut = true,
+  selectedThreads = [],
+  toasts = [],
+  chatHookOptions = [],
+  translations = {},
 }) {
   const components = {
     ApprovalCard() {},
@@ -123,28 +127,73 @@ function renderChat({
     channelConnectionDisplayName,
     setThreadState: (threadId, state) =>
       threadStateUpdates.push({ threadId, state }),
+    toast: (message, options) => toasts.push({ message, options }),
     setTimeout: () => 1,
     clearTimeout: () => {},
     window: {
       addEventListener: () => {},
       removeEventListener: () => {},
     },
-    useChat: () => hookState,
+    useChat: (_threadId, options) => {
+      chatHookOptions.push(options);
+      return hookState;
+    },
     useInterfacePreferences: () => ({ showChatLogsShortcut }),
-    useT: () => (key) => key,
+    useT: () => (key) => translations[key] || key,
   };
 
   vm.runInNewContext(chatSourceForTest(), context);
   const tree = context.globalThis.__testExports.Chat({
     threads: activeThreadId ? [{ id: activeThreadId }] : [],
     activeThreadId,
-    onSelectThread: () => {},
+    onSelectThread: (...args) => selectedThreads.push(args),
     isCreatingThread: false,
     gatewayStatus: {},
     globalAutoApproveEnabled,
   });
-  return { tree, components };
+  return { tree, components, chatHookOptions, selectedThreads, toasts };
 }
+
+test("Chat leaves a missing thread and shows the dedicated notice", () => {
+  const threadStateUpdates = [];
+  const { chatHookOptions, selectedThreads, toasts } = renderChat({
+    threadStateUpdates,
+    translations: {
+      "chat.threadNoLongerExists": "This thread no longer exists",
+    },
+    hookState: {
+      messages: [],
+      isProcessing: false,
+      pendingGate: null,
+      suggestions: [],
+      sseStatus: "idle",
+      historyLoading: false,
+      hasMore: false,
+      cooldownSeconds: 0,
+      recoveryNotice: null,
+      activeRun: null,
+      send: async () => ({}),
+      cancelRun: async () => {},
+      retryMessage: () => {},
+      approve: () => {},
+      recoverHistory: () => {},
+      loadMore: () => {},
+      setSuggestions: () => {},
+      submitAuthToken: async () => {},
+    },
+  });
+
+  chatHookOptions[0].onThreadNotFound("thread-1");
+
+  assert.deepEqual(threadStateUpdates, [{ threadId: "thread-1", state: null }]);
+  assert.deepEqual(JSON.parse(JSON.stringify(selectedThreads)), [[null, { replace: true }]]);
+  assert.deepEqual(JSON.parse(JSON.stringify(toasts)), [
+    {
+      message: "This thread no longer exists",
+      options: { tone: "error", duration: 5000 },
+    },
+  ]);
+});
 
 test("Chat cancel button routes through active thread run cancellation", async () => {
   const cancelReasons = [];

--- a/crates/ironclaw_webui_v2/frontend/src/pages/chat/lib/thread-cache.test.ts
+++ b/crates/ironclaw_webui_v2/frontend/src/pages/chat/lib/thread-cache.test.ts
@@ -23,6 +23,7 @@ globalThis.__testExports = {
   deriveSidebarTitle,
   displaySidebarTitle,
   normalizeSidebarTitle,
+  removeThreadFromList,
   touchThreadList,
   upsertThreadList,
 };`;
@@ -189,4 +190,20 @@ test("touchThreadList creates a minimal missing thread record", () => {
       next_cursor: null,
     },
   );
+});
+
+test("removeThreadFromList evicts only the stale thread and preserves pagination", () => {
+  const { removeThreadFromList } = loadThreadCache();
+  const data = {
+    threads: [
+      { thread_id: "thread-1", title: "Missing" },
+      { id: "thread-2", title: "Still here" },
+    ],
+    next_cursor: "cursor-1",
+  };
+
+  assert.deepEqual(normalize(removeThreadFromList(data, "thread-1")), {
+    threads: [{ id: "thread-2", title: "Still here" }],
+    next_cursor: "cursor-1",
+  });
 });

--- a/crates/ironclaw_webui_v2/frontend/src/pages/chat/lib/thread-cache.ts
+++ b/crates/ironclaw_webui_v2/frontend/src/pages/chat/lib/thread-cache.ts
@@ -106,6 +106,18 @@ export function touchThreadList(data, { threadId, messageContent, updatedAt }) {
   };
 }
 
+export function removeThreadFromList(data, threadId) {
+  if (!threadId) return data;
+
+  const current = threadListData(data);
+  const threads = Array.isArray(current.threads) ? current.threads : [];
+  return {
+    ...current,
+    threads: threads.filter((thread) => threadIdFor(thread) !== threadId),
+    next_cursor: current.next_cursor ?? null,
+  };
+}
+
 export function upsertThreadInCache(thread) {
   queryClient.setQueryData?.(THREADS_QUERY_KEY, (data) =>
     upsertThreadList(data, thread),
@@ -115,5 +127,11 @@ export function upsertThreadInCache(thread) {
 export function touchThreadInCache(update) {
   queryClient.setQueryData?.(THREADS_QUERY_KEY, (data) =>
     touchThreadList(data, update),
+  );
+}
+
+export function removeThreadFromCache(threadId) {
+  queryClient.setQueryData?.(THREADS_QUERY_KEY, (data) =>
+    removeThreadFromList(data, threadId),
   );
 }

--- a/crates/ironclaw_webui_v2/frontend/src/pages/chat/lib/useChat-send.test.ts
+++ b/crates/ironclaw_webui_v2/frontend/src/pages/chat/lib/useChat-send.test.ts
@@ -1096,6 +1096,7 @@ test("useChat.send: a thread 404 evicts stale caches and skips the generic error
   const removedThreads = [];
   const evictedHistories = [];
   const missingThreads = [];
+  const missingThreadRecoveries = [];
   let renderedMessages = [];
 
   const context = {
@@ -1148,15 +1149,100 @@ test("useChat.send: a thread 404 evicts stale caches and skips the generic error
 
   runUseChatSource(context);
   const chat = context.globalThis.__testExports.useChat(threadId, {
-    onThreadNotFound: (id) => missingThreads.push(id),
+    onThreadNotFound: (id, recovery) => {
+      missingThreads.push(id);
+      missingThreadRecoveries.push(recovery);
+    },
   });
 
-  await assert.rejects(chat.send("please answer"), /Not found/);
+  await assert.rejects(
+    chat.send("please answer", { displayContent: "please answer" }),
+    /Not found/,
+  );
 
   assert.deepEqual(removedThreads, [threadId]);
   assert.deepEqual(evictedHistories, [threadId]);
   assert.deepEqual(missingThreads, [threadId]);
+  assert.deepEqual(JSON.parse(JSON.stringify(missingThreadRecoveries)), [
+    { composerDraft: "please answer", stagedAttachments: [] },
+  ]);
   assert.equal(renderedMessages.some((message) => message.role === "error"), false);
+});
+
+test("useChat.send: missing-thread recovery runs again after leaving and reopening a thread", async () => {
+  const threadId = "thread-missing";
+  const stateSlots = new Map();
+  const react = createReactStub({ stateSlots });
+  const missingThreads = [];
+  let renderedMessages = [];
+
+  const context = {
+    AbortController,
+    Date,
+    Error,
+    Map,
+    Math,
+    React: react,
+    addPending,
+    toRenderAttachment,
+    toWireAttachment,
+    cancelRunRequest: async () => {},
+    clearTimeout,
+    createThreadRequest: async () => {
+      throw new Error("thread should already exist");
+    },
+    evictThreadHistory: () => {},
+    globalThis: {},
+    queryClient: { fetchQuery: async () => [], invalidateQueries: () => {} },
+    recordAcceptedMessageRef,
+    removePending,
+    removeThreadFromCache: () => {},
+    resolveGateRequest: async () => {},
+    sendMessage: async () => {
+      throw Object.assign(new Error("Not found"), {
+        status: 404,
+        payload: { kind: "not_found" },
+      });
+    },
+    setInterval,
+    setTimeout,
+    submitManualToken: async () => {},
+    useChatEvents: () => () => {},
+    useHistory: () => ({
+      messages: renderedMessages,
+      hasMore: false,
+      nextCursor: null,
+      isLoading: false,
+      loadHistory: () => {},
+      seedThreadMessages: () => {},
+      setMessages: (updater) => {
+        renderedMessages =
+          typeof updater === "function" ? updater(renderedMessages) : updater;
+      },
+    }),
+    useSSE: () => ({ status: "idle" }),
+  };
+
+  runUseChatSource(context);
+
+  react.__beginRender();
+  let chat = context.globalThis.__testExports.useChat(threadId, {
+    onThreadNotFound: (id) => missingThreads.push(id),
+  });
+  await assert.rejects(chat.send("first"), /Not found/);
+
+  react.__beginRender();
+  context.globalThis.__testExports.useChat(null, {
+    onThreadNotFound: (id) => missingThreads.push(id),
+  });
+
+  react.__beginRender();
+  chat = context.globalThis.__testExports.useChat(threadId, {
+    onThreadNotFound: (id) => missingThreads.push(id),
+  });
+  await assert.rejects(chat.send("second"), /Not found/);
+
+  assert.deepEqual(missingThreads, [threadId, threadId]);
 });
 
 test("useChat.send: create-thread failure appends inline error on new chat", async () => {
@@ -6181,6 +6267,41 @@ test("useChat.send: addresses a second thread in parallel while viewing a runnin
   assert.ok(sentBody(), "the parallel-thread message must reach sendMessage");
   assert.equal(sentBody().threadId, "thread-b");
   assert.ok(result, "send must resolve with a response, not null");
+});
+
+test("useChat.send: a stale target 404 does not clear the viewed thread processing state", async () => {
+  const stateUpdates = [];
+  const removedThreads = [];
+  const evictedHistories = [];
+  const { context } = createParallelSendContext({
+    threadId: "thread-a",
+    isProcessing: true,
+    stateUpdates,
+  });
+  context.removeThreadFromCache = (threadId) => removedThreads.push(threadId);
+  context.evictThreadHistory = (threadId) => evictedHistories.push(threadId);
+  context.sendMessage = async () => {
+    throw Object.assign(new Error("Not found"), {
+      status: 404,
+      payload: { kind: "not_found" },
+    });
+  };
+
+  runUseChatSource(context);
+
+  const chat = context.globalThis.__testExports.useChat("thread-a");
+  await assert.rejects(
+    chat.send("message for deleted background thread", { threadId: "thread-b" }),
+    /Not found/,
+  );
+
+  assert.deepEqual(removedThreads, ["thread-b"]);
+  assert.deepEqual(evictedHistories, ["thread-b"]);
+  assert.deepEqual(
+    stateUpdatesFor(stateUpdates, STATE_SLOT.isProcessing),
+    [],
+    "background 404 must not clear the viewed thread's processing flag",
+  );
 });
 
 test("useChat.send: still blocks a duplicate send into the already-running thread", async () => {

--- a/crates/ironclaw_webui_v2/frontend/src/pages/chat/lib/useChat-send.test.ts
+++ b/crates/ironclaw_webui_v2/frontend/src/pages/chat/lib/useChat-send.test.ts
@@ -131,6 +131,11 @@ function runUseChatSource(context) {
   }
   if (!("touchThreadInCache" in context)) context.touchThreadInCache = () => {};
   if (!("upsertThreadInCache" in context)) context.upsertThreadInCache = () => {};
+  if (!("removeThreadFromCache" in context)) context.removeThreadFromCache = () => {};
+  if (!("evictThreadHistory" in context)) context.evictThreadHistory = () => {};
+  if (!("isThreadNotFoundError" in context)) {
+    context.isThreadNotFoundError = (error) => error?.status === 404;
+  }
   vm.runInNewContext(useChatSourceForTest(), context);
 }
 
@@ -1084,6 +1089,74 @@ test("useChat.send: request failure appends inline error in the active thread", 
     renderedMessages[1].content,
     "inline:AI provider account is out of credits",
   );
+});
+
+test("useChat.send: a thread 404 evicts stale caches and skips the generic error bubble", async () => {
+  const threadId = "thread-missing";
+  const removedThreads = [];
+  const evictedHistories = [];
+  const missingThreads = [];
+  let renderedMessages = [];
+
+  const context = {
+    AbortController,
+    Date,
+    Error,
+    Map,
+    Math,
+    React: createReactStub(),
+    addPending,
+    toRenderAttachment,
+    toWireAttachment,
+    cancelRunRequest: async () => {},
+    clearTimeout,
+    createThreadRequest: async () => {
+      throw new Error("thread should already exist");
+    },
+    evictThreadHistory: (id) => evictedHistories.push(id),
+    globalThis: {},
+    listConnectableChannels: async () => [],
+    queryClient: { fetchQuery: async () => [], invalidateQueries: () => {} },
+    recordAcceptedMessageRef,
+    removePending,
+    removeThreadFromCache: (id) => removedThreads.push(id),
+    resolveGateRequest: async () => {},
+    sendMessage: async () => {
+      throw Object.assign(new Error("Not found"), {
+        status: 404,
+        payload: { kind: "not_found" },
+      });
+    },
+    setInterval,
+    setTimeout,
+    submitManualToken: async () => {},
+    useChatEvents: () => () => {},
+    useHistory: () => ({
+      messages: renderedMessages,
+      hasMore: false,
+      nextCursor: null,
+      isLoading: false,
+      loadHistory: () => {},
+      seedThreadMessages: () => {},
+      setMessages: (updater) => {
+        renderedMessages =
+          typeof updater === "function" ? updater(renderedMessages) : updater;
+      },
+    }),
+    useSSE: () => ({ status: "idle" }),
+  };
+
+  runUseChatSource(context);
+  const chat = context.globalThis.__testExports.useChat(threadId, {
+    onThreadNotFound: (id) => missingThreads.push(id),
+  });
+
+  await assert.rejects(chat.send("please answer"), /Not found/);
+
+  assert.deepEqual(removedThreads, [threadId]);
+  assert.deepEqual(evictedHistories, [threadId]);
+  assert.deepEqual(missingThreads, [threadId]);
+  assert.equal(renderedMessages.some((message) => message.role === "error"), false);
 });
 
 test("useChat.send: create-thread failure appends inline error on new chat", async () => {

--- a/crates/ironclaw_webui_v2/frontend/src/pages/chat/lib/useHistory.test.ts
+++ b/crates/ironclaw_webui_v2/frontend/src/pages/chat/lib/useHistory.test.ts
@@ -39,9 +39,9 @@ function useHistorySourceForTest() {
     }
     lines.push(line.replace(/^export function /, "function "));
   }
-  return `${helperLines.join("\n")}\n${lines.join(
+  return `function isThreadNotFoundError(error) { return error?.status === 404; }\n${helperLines.join("\n")}\n${lines.join(
     "\n",
-  )}\nglobalThis.__testExports = { clearHistoryCache, useHistory, mergeFullRefresh };`;
+  )}\nglobalThis.__testExports = { clearHistoryCache, evictThreadHistory, useHistory, mergeFullRefresh };`;
 }
 
 function createReactStub({ setCalls = [] } = {}) {
@@ -132,6 +132,30 @@ test("useHistory records a load error when timeline fetch fails", async () => {
     "chat.history.loadFailed",
   );
   assert.equal(consoleErrors.length, 1);
+});
+
+test("useHistory reports a missing active thread without a generic load error", async () => {
+  const setCalls = [];
+  const missingThreads = [];
+  const context = {
+    console: { error: () => {} },
+    fetchTimeline: async () => {
+      throw Object.assign(new Error("Not found"), { status: 404 });
+    },
+    authScope: () => "test-user",
+    globalThis: {},
+    messagesFromTimeline: () => [],
+    React: createReactStub({ setCalls }),
+  };
+
+  vm.runInNewContext(useHistorySourceForTest(), context);
+  context.globalThis.__testExports.useHistory("thread-missing", {
+    onThreadNotFound: (threadId) => missingThreads.push(threadId),
+  });
+  await flushMicrotasks();
+
+  assert.deepEqual(missingThreads, ["thread-missing"]);
+  assert.equal(setCalls.some((state) => state?.loadError), false);
 });
 
 test("useHistory tags messages with the thread they belong to (messagesThreadId)", async () => {

--- a/crates/ironclaw_webui_v2/frontend/src/pages/chat/lib/useHistory.test.ts
+++ b/crates/ironclaw_webui_v2/frontend/src/pages/chat/lib/useHistory.test.ts
@@ -39,7 +39,7 @@ function useHistorySourceForTest() {
     }
     lines.push(line.replace(/^export function /, "function "));
   }
-  return `function isThreadNotFoundError(error) { return error?.status === 404; }\n${helperLines.join("\n")}\n${lines.join(
+  return `function isThreadNotFoundError(error) { return error?.status === 404; }\nvar removeThreadFromCache = typeof __removeThreadFromCache === "function" ? __removeThreadFromCache : function () {};\n${helperLines.join("\n")}\n${lines.join(
     "\n",
   )}\nglobalThis.__testExports = { clearHistoryCache, evictThreadHistory, useHistory, mergeFullRefresh };`;
 }
@@ -156,6 +156,43 @@ test("useHistory reports a missing active thread without a generic load error", 
 
   assert.deepEqual(missingThreads, ["thread-missing"]);
   assert.equal(setCalls.some((state) => state?.loadError), false);
+});
+
+test("useHistory evicts sidebar cache when a stale background timeline returns 404", async () => {
+  const react = createPersistentReactStub();
+  const removedThreads = [];
+  const missingThreads = [];
+  let rejectTimeline;
+  const context = {
+    console: { error: () => {} },
+    fetchTimeline: async () =>
+      new Promise((_, reject) => {
+        rejectTimeline = reject;
+      }),
+    authScope: () => "test-user",
+    __removeThreadFromCache: (threadId) => removedThreads.push(threadId),
+    globalThis: {},
+    messagesFromTimeline: () => [],
+    React: react,
+  };
+
+  vm.runInNewContext(useHistorySourceForTest(), context);
+  react.__beginRender();
+  const missingHistory = context.globalThis.__testExports.useHistory("thread-missing", {
+    onThreadNotFound: (threadId) => missingThreads.push(threadId),
+  });
+  const loadPromise = missingHistory.loadHistory();
+
+  react.__beginRender();
+  context.globalThis.__testExports.useHistory("thread-other", {
+    onThreadNotFound: (threadId) => missingThreads.push(threadId),
+  });
+
+  rejectTimeline(Object.assign(new Error("Not found"), { status: 404 }));
+  await loadPromise;
+
+  assert.deepEqual(removedThreads, ["thread-missing"]);
+  assert.deepEqual(missingThreads, []);
 });
 
 test("useHistory tags messages with the thread they belong to (messagesThreadId)", async () => {

--- a/crates/ironclaw_webui_v2/src/static_assets/assets.rs
+++ b/crates/ironclaw_webui_v2/src/static_assets/assets.rs
@@ -236,7 +236,10 @@ mod tests {
         // unit harness injects stubs for unknown identifiers, so only a
         // source-level pin (and the Playwright smoke) catches a re-drop.
         let use_chat = source_text("pages/chat/hooks/useChat.ts");
-        assert!(use_chat.contains("import { touchThreadInCache } from \"../lib/thread-cache\""));
+        assert!(use_chat.contains(
+            "import { removeThreadFromCache, touchThreadInCache } from \"../lib/thread-cache\""
+        ));
+        assert!(use_chat.contains("removeThreadFromCache("));
         assert!(use_chat.contains("touchThreadInCache({"));
     }
 


### PR DESCRIPTION
## Summary

- evict missing threads from sidebar and session transcript caches on thread-scoped 404s, including stale background timeline loads
- navigate an active stale conversation back to `/chat` and show `This thread no longer exists` instead of an inline generic `Not found` error
- preserve the submitted composer text and staged attachments when a send discovers the active thread no longer exists
- keep stale background send cleanup from mutating the newly viewed thread processing state

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation-only
- [ ] Test-only

## Linked Issue

None.

## Validation

- [x] `pnpm test`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] `cargo fmt --all -- --check`
- [ ] `cargo test -p ironclaw_webui_v2 --features webui-v2-beta` post-review rerun deferred to remote CI because local Rust compile was blocked under toolchain load after push
- [x] Browser smoke test for stale timeline 404 and send-time 404 recovery, including draft restoration

## Security Impact

No auth, permission, token, secret, CORS, listener, or trust-boundary behavior changes. The change only handles existing 404 responses in the WebUI v2 client.

## Trust-Boundary Impact

No new trust boundary. The browser still consumes same-origin WebUI v2 APIs and treats backend 404s as missing-thread state.

## DB Impact

None. No schema, migration, persistence, or backend write behavior changes.

## Blast Radius

Scoped to WebUI v2 chat thread history/send error handling and client-side caches/drafts.

## Rollback

Revert this PR. The fallback behavior returns to the prior generic Not found/chat error path for stale thread 404s.

## Review Follow-Through

Addressed Gemini and CodeRabbit feedback by evicting sidebar cache from `useHistory`, preserving send drafts across missing-thread redirects, resetting missing-thread dedupe on thread changes, and keeping stale background send cleanup isolated from the active thread.