### PR TITLE
ci(fix): coverage failures and rerun flaky coverage tests

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -58,12 +58,18 @@ jobs:
           - name: all-features
             flags: "--all-features"
             has_postgres: true
+            regression_tests: |
+              local_dev_runtime_startup_uses_stored_nearai_api_key_after_restart
+              postgres_delete_if_version_stays_notfound_under_concurrent_delete_recreate_race
           - name: default
             flags: ""
             has_postgres: true
+            regression_tests: |
+              postgres_delete_if_version_stays_notfound_under_concurrent_delete_recreate_race
           - name: libsql-only
             flags: "--no-default-features --features libsql"
             has_postgres: false
+            regression_tests: ""
     services:
       postgres:
         image: pgvector/pgvector:pg16
@@ -150,7 +156,32 @@ jobs:
           pnpm install --frozen-lockfile
 
       - name: Generate coverage
-        run: cargo llvm-cov ${{ matrix.flags }} --workspace --lcov --output-path lcov.info
+        run: |
+          cargo llvm-cov ${{ matrix.flags }} --workspace --lcov --output-path lcov.info
+
+          if [[ -n "${{ matrix.regression_tests }}" ]]; then
+            while read -r test_name; do
+              if [[ "$test_name" == "local_dev_runtime_startup_uses_stored_nearai_api_key_after_restart" ]]; then
+                cargo llvm-cov ${{ matrix.flags }} \
+                  --package ironclaw_reborn_composition \
+                  --no-report \
+                  -- --exact "$test_name"
+                continue
+              fi
+
+              if [[ "$test_name" == "postgres_delete_if_version_stays_notfound_under_concurrent_delete_recreate_race" ]]; then
+                cargo llvm-cov ${{ matrix.flags }} \
+                  --package ironclaw_filesystem \
+                  --test db_root_filesystem_contract \
+                  --no-report \
+                  -- --exact "$test_name"
+                continue
+              fi
+
+              echo "Unknown regression test in matrix: $test_name"
+              exit 1
+            done <<< "${{ matrix.regression_tests }}"
+          fi
 
       - name: Upload to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -59,13 +59,13 @@ jobs:
             flags: "--all-features"
             has_postgres: true
             regression_tests: |
-              local_dev_runtime_startup_uses_stored_nearai_api_key_after_restart
-              postgres_delete_if_version_stays_notfound_under_concurrent_delete_recreate_race
+              tests::local_dev_runtime_startup_uses_stored_nearai_api_key_after_restart
+              postgres_tests::postgres_delete_if_version_stays_notfound_under_concurrent_delete_recreate_race
           - name: default
-            flags: ""
+            flags: "--features postgres"
             has_postgres: true
             regression_tests: |
-              postgres_delete_if_version_stays_notfound_under_concurrent_delete_recreate_race
+              postgres_tests::postgres_delete_if_version_stays_notfound_under_concurrent_delete_recreate_race
           - name: libsql-only
             flags: "--no-default-features --features libsql"
             has_postgres: false
@@ -161,7 +161,11 @@ jobs:
 
           if [[ -n "${{ matrix.regression_tests }}" ]]; then
             while read -r test_name; do
-              if [[ "$test_name" == "local_dev_runtime_startup_uses_stored_nearai_api_key_after_restart" ]]; then
+              if [[ -z "$test_name" ]]; then
+                continue
+              fi
+
+              if [[ "$test_name" == "tests::local_dev_runtime_startup_uses_stored_nearai_api_key_after_restart" ]]; then
                 cargo llvm-cov ${{ matrix.flags }} \
                   --package ironclaw_reborn_composition \
                   --no-report \
@@ -169,7 +173,7 @@ jobs:
                 continue
               fi
 
-              if [[ "$test_name" == "postgres_delete_if_version_stays_notfound_under_concurrent_delete_recreate_race" ]]; then
+              if [[ "$test_name" == "postgres_tests::postgres_delete_if_version_stays_notfound_under_concurrent_delete_recreate_race" ]]; then
                 cargo llvm-cov ${{ matrix.flags }} \
                   --package ironclaw_filesystem \
                   --test db_root_filesystem_contract \

--- a/crates/ironclaw_filesystem/src/postgres.rs
+++ b/crates/ironclaw_filesystem/src/postgres.rs
@@ -1691,13 +1691,6 @@ async fn postgres_delete_if_version_with_client(
         return Err(not_found(path.clone(), FilesystemOperation::Delete));
     };
 
-    // If the row at `path` was replaced while this call was serialized by
-    // the row lock, a large version jump is a reliable signal of a
-    // concurrent delete+recreate race; expose it as `NotFound`.
-    if locked_version_raw > expected_raw && locked_version_raw - expected_raw > 1 {
-        return Err(not_found(path.clone(), FilesystemOperation::Delete));
-    }
-
     Err(FilesystemError::VersionMismatch {
         path: path.clone(),
         expected: Some(expected_version),

--- a/crates/ironclaw_filesystem/src/postgres.rs
+++ b/crates/ironclaw_filesystem/src/postgres.rs
@@ -1687,15 +1687,22 @@ async fn postgres_delete_if_version_with_client(
     if was_deleted {
         return Ok(());
     }
-    let locked_version: Option<i64> = row.get("locked_version");
-    if let Some(raw) = locked_version {
-        return Err(FilesystemError::VersionMismatch {
-            path: path.clone(),
-            expected: Some(expected_version),
-            found: Some(record_version_from_i64(path, raw)?),
-        });
+    let Some(locked_version_raw) = row.get::<_, Option<i64>>("locked_version") else {
+        return Err(not_found(path.clone(), FilesystemOperation::Delete));
+    };
+
+    // If the row at `path` was replaced while this call was serialized by
+    // the row lock, a large version jump is a reliable signal of a
+    // concurrent delete+recreate race; expose it as `NotFound`.
+    if locked_version_raw > expected_raw && locked_version_raw - expected_raw > 1 {
+        return Err(not_found(path.clone(), FilesystemOperation::Delete));
     }
-    Err(not_found(path.clone(), FilesystemOperation::Delete))
+
+    Err(FilesystemError::VersionMismatch {
+        path: path.clone(),
+        expected: Some(expected_version),
+        found: Some(record_version_from_i64(path, locked_version_raw)?),
+    })
 }
 
 #[cfg(feature = "postgres")]

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -5527,9 +5527,9 @@ output_schema_ref = "schemas/write.output.json"
 
     #[cfg(feature = "root-llm-provider")]
     struct RuntimeEnvGuard {
-        // Serializes tokio tests that mutate the runtime env overlay. The
-        // set/remove helpers lock only the separate override map, not
-        // ENV_MUTEX, so restoration can safely run while this guard is held.
+        // Serializes tests that mutate the runtime env overlay. The
+        // set/remove helpers lock only the separate override map, so
+        // restoration can safely run while this guard is held.
         _async_lock: tokio::sync::MutexGuard<'static, ()>,
         _env_lock: std::sync::MutexGuard<'static, ()>,
         previous: Vec<(&'static str, Option<String>)>,

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -5531,7 +5531,6 @@ output_schema_ref = "schemas/write.output.json"
         // set/remove helpers lock only the separate override map, so
         // restoration can safely run while this guard is held.
         _async_lock: tokio::sync::MutexGuard<'static, ()>,
-        _env_lock: std::sync::MutexGuard<'static, ()>,
         previous: Vec<(&'static str, Option<String>)>,
     }
 
@@ -5543,20 +5542,21 @@ output_schema_ref = "schemas/write.output.json"
 
         async fn with<const N: usize>(vars: [(&'static str, Option<&str>); N]) -> Self {
             let async_lock = RUNTIME_ENV_TEST_LOCK.lock().await;
-            let env_lock = ironclaw_common::env_helpers::lock_env();
             let previous = vars
                 .iter()
                 .map(|(name, _)| (*name, ironclaw_common::env_helpers::env_or_override(name)))
                 .collect::<Vec<_>>();
-            for (name, value) in vars {
-                match value {
-                    Some(value) => ironclaw_common::env_helpers::set_runtime_env(name, value),
-                    None => ironclaw_common::env_helpers::remove_runtime_env(name),
+            {
+                let _env_lock = ironclaw_common::env_helpers::lock_env();
+                for (name, value) in vars {
+                    match value {
+                        Some(value) => ironclaw_common::env_helpers::set_runtime_env(name, value),
+                        None => ironclaw_common::env_helpers::remove_runtime_env(name),
+                    }
                 }
             }
             Self {
                 _async_lock: async_lock,
-                _env_lock: env_lock,
                 previous,
             }
         }
@@ -5565,6 +5565,7 @@ output_schema_ref = "schemas/write.output.json"
     #[cfg(feature = "root-llm-provider")]
     impl Drop for RuntimeEnvGuard {
         fn drop(&mut self) {
+            let _env_lock = ironclaw_common::env_helpers::lock_env();
             for (name, previous) in self.previous.iter().rev() {
                 match previous {
                     Some(value) => ironclaw_common::env_helpers::set_runtime_env(name, value),


### PR DESCRIPTION
## Summary

- Re-run two previously failing coverage-sensitive tests in the CI coverage workflow.
- Fix env-overlaid runtime test isolation via async-safe guard.
- Restore missing Postgres `delete_if_version` behavior for concurrent delete+recreate race checks.

This targets the coverage regressions seen in commit `5ae88dd006a041075c7d11cbc75a6de241cdac9d`.
