### PR TITLE
Constrain failure explanations to reply-only

### DIFF
--- a/crates/ironclaw_agent_loop/src/executor/failure_explanation.rs
+++ b/crates/ironclaw_agent_loop/src/executor/failure_explanation.rs
@@ -4,8 +4,8 @@ use ironclaw_turns::{
     LoopFailureKind, LoopMessageRef,
     run_profile::{
         AgentLoopHostError, AgentLoopHostErrorKind, FinalizeAssistantMessage, LoopInlineMessage,
-        LoopInlineMessageBody, LoopInlineMessageRole, LoopModelRequest, LoopModelResponse,
-        LoopPromptBundleRequest, ParentLoopOutput, PromptMode,
+        LoopInlineMessageBody, LoopInlineMessageRole, LoopModelCapabilityView, LoopModelRequest,
+        LoopModelResponse, LoopPromptBundleRequest, ParentLoopOutput, PromptMode,
     },
 };
 
@@ -75,7 +75,9 @@ pub(super) async fn explain_failure(
             messages,
             surface_version: None,
             model_preference: None,
-            capability_view: None,
+            capability_view: Some(LoopModelCapabilityView {
+                visible_capability_ids: Vec::new(),
+            }),
         }),
     )
     .await

--- a/crates/ironclaw_agent_loop/src/executor/tests.rs
+++ b/crates/ironclaw_agent_loop/src/executor/tests.rs
@@ -2878,7 +2878,15 @@ async fn capability_abort_finalizes_explanation_and_failed_exit_refs_partial_fir
     );
     let requests = host.model_requests();
     assert_eq!(requests.len(), 2);
-    assert!(requests[1].capability_view.is_none());
+    let explanation_capability_view = requests[1]
+        .capability_view
+        .as_ref()
+        .expect("failure explanation model request must suppress tools");
+    assert!(
+        explanation_capability_view
+            .visible_capability_ids
+            .is_empty()
+    );
     assert!(requests[1].surface_version.is_none());
     assert!(requests[1].model_preference.is_none());
 }


### PR DESCRIPTION
## Summary

- Force failure-explanation model calls to run with an explicit empty capability view.
- Keep the prompt inline-only/context-free, but also make the provider call tool-free.
- Add a regression assertion that the failure-explanation model request suppresses tools.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

None.

## Why

The failure-explanation step exists only to produce plain diagnostic text, for example: "The run failed because compaction could not complete."

Before this change, the request used `capability_view: None`. In this codebase, `None` means the normal/default tool surface can still be used. That allowed the model to return tool calls such as `builtin__memory_read` instead of an assistant reply, which made incidents harder to understand.

This change uses an explicit empty capability view so no tools are visible and the model is constrained to answer in text.

## Validation

- [x] `cargo fmt --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [ ] `cargo build`
- [x] Relevant tests pass: `cargo test -p ironclaw_agent_loop failure_explanation`; `cargo test -p ironclaw_agent_loop capability_abort_finalizes_explanation_and_failed_exit_refs_partial_first`; `cargo test -p ironclaw_agent_loop`
- [ ] `cargo test --features integration` if database-backed or integration behavior changed
- [ ] Manual testing: N/A
- [x] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review: Gemini, CodeRabbit, and IronLoop reported no actionable code feedback.

## Security Impact

No permission, network, secrets, file access, tool execution, or sandbox policy changes. This reduces the capability surface for failure-explanation model calls to zero visible tools.

## Reborn Trust-Boundary Checklist

- [x] Public policy/evidence/trust-bearing types: who can construct them? No new trust-bearing types; uses existing `LoopModelCapabilityView` request contract.
- [x] Untrusted content enters prompts only through an envelope/escaping primitive. Prompt construction remains the existing inline-only failure-explanation path.
- [x] Hashes declare purpose; trust/binding/authenticity uses SHA-256/BLAKE3 or separate authenticity check. N/A, no hash changes.
- [x] New/changed status, exit, policy, runtime, or error variants: downstream match sites audited. No new variants.
- [x] Security/durability `serde(default)` fields fail closed or have migration tests. No serde/schema changes.
- [x] Queues/maps/buffers/counters have bounds and overflow-safe arithmetic. No queue/map/buffer/counter changes.
- [x] Driver/operator-visible errors have stable class semantics (`Transient`, `Permanent`, `Misconfigured`, `PolicyDenied` or equivalent). No error classification changes.
- [x] Sandbox/native/host names accurately describe trust boundary. No sandbox/native/host naming changes.

## Database Impact

None. No migrations or schema changes.

## Blast Radius

Agent-loop failure explanation path only. If this regresses, failed runs may skip model-written failure explanations, but normal loop tool execution is unchanged.

## Rollback Plan

Revert this PR to restore the previous failure-explanation model request shape.

## Review Follow-Through

Gemini and CodeRabbit had no actionable code comments. IronLoop approved with no blocking findings. CodeRabbit’s PR-description template warning is addressed by this body.

---

**Review track**: C (runtime/tool-surface behavior)
