### PR TITLE
test(live-canary): promote QA 9/10 Slack canaries into the cron rotation

### DIFF
--- a/.github/workflows/live-canary.yml
+++ b/.github/workflows/live-canary.yml
@@ -836,24 +836,22 @@ jobs:
           - shard_id: qa-8-delivery
             shard_name: QA 8D
             cases: qa_8d_hn_keyword_slack_delivery
-          # Automation delivery probes (wrong-channel / duplicate-delivery /
-          # raw-user-id / per-trigger routing). dispatch_only until the
-          # per-trigger delivery-target fixes (#5898) merge: on pre-fix servers
-          # these are expected-red, so they must not page the 3-hourly cron.
+          # Automation delivery probes, in the 3-hourly cron rotation (the
+          # delivery-routing fixes from #5898 are merged and live-verified
+          # green). Guards regressions in: wrong-channel routine delivery,
+          # duplicate DM delivery, raw Slack user ids leaking into digests,
+          # and per-trigger delivery-target routing.
           - shard_id: qa-9
             shard_name: QA 9
             cases: qa_9a_slack_connect,qa_9b_routine_dm_delivery_exactly_once,qa_9c_slack_digest_names_not_ids,qa_9d_routine_per_trigger_delivery_target
-            dispatch_only: true
-          # Slack tool-correctness probes (self-attribution / status readback
-          # / thread replies / membership honesty / error honesty / mention
-          # encoding / last-sent recall / email hallucination guard /
-          # raw-entity hygiene). dispatch_only: expected-red on pre-fix hosts
-          # (self-identity, status fields, thread replies, structured errors),
-          # so they must not page the 3-hourly cron until the fixes merge.
+          # Slack tool-correctness probes, in the 3-hourly cron rotation (the
+          # tool-surface fixes from #5898 are merged and live-verified green).
+          # Guards regressions in: self-attribution, status readback, thread
+          # replies, membership honesty, error honesty, mention encoding,
+          # last-sent recall, email hallucination, and raw-entity hygiene.
           - shard_id: qa-10
             shard_name: QA 10
             cases: qa_10a_slack_self_attribution,qa_10b_slack_ooo_status,qa_10c_slack_thread_replies,qa_10d_slack_channel_membership,qa_10e_slack_error_honesty,qa_10f_slack_mention_encoding,qa_10g_slack_last_message_sent,qa_10h_slack_email_hallucination_guard,qa_10i_slack_raw_entity_hygiene
-            dispatch_only: true
     env:
       REBORN_WEBUI_V2_LIVE_QA_LLM_API_KEY_ENV: NEARAI_API_KEY
       REBORN_WEBUI_V2_LIVE_QA_LLM_PROVIDER_ID: nearai

--- a/scripts/reborn_webui_v2_live_qa/run_live_qa.py
+++ b/scripts/reborn_webui_v2_live_qa/run_live_qa.py
@@ -6603,27 +6603,22 @@ CASES: dict[str, CaseSpec] = {
         # The workspace sweep runs on the personal token; without this gate a
         # wrong-workspace token would make the sweep structurally blind.
         requires_slack_personal_auth=True,
-        # Expected-red on pre-fix servers; keep out of bare local runs until
-        # promoted off dispatch_only.
-        default_enabled=False,
     ),
     "qa_9c_slack_digest_names_not_ids": CaseSpec(
         case_qa_9c_slack_digest_names_not_ids,
         requires_slack=True,
         requires_slack_personal_auth=True,
-        default_enabled=False,
     ),
     "qa_9d_routine_per_trigger_delivery_target": CaseSpec(
         case_qa_9d_routine_per_trigger_delivery_target,
         requires_slack=True,
         requires_slack_target=True,
         requires_slack_personal_auth=True,
-        default_enabled=False,
     ),
-    # QA 10 family: Slack tool-correctness probes. All expected-red on
-    # pre-fix hosts (self-identity, status fields, thread replies, membership
-    # view, structured errors, mention encoding, entity rendering), so all
-    # stay default_enabled=False / dispatch_only until their fixes merge.
+    # QA 10 family: Slack tool-correctness probes (self-identity, status
+    # fields, thread replies, membership view, structured errors, mention
+    # encoding, entity rendering). Promoted into default runs and the cron
+    # rotation: the fixes merged and were live-verified green (9/9).
     # requires_slack_target marks the cases that seed into / read from a
     # Slack DM (it keeps the prepared home's DM route provisioning on); their
     # seeding/read anchor is the personal↔bot DM
@@ -6633,60 +6628,51 @@ CASES: dict[str, CaseSpec] = {
         requires_slack=True,
         requires_slack_target=True,
         requires_slack_personal_auth=True,
-        default_enabled=False,
     ),
     "qa_10b_slack_ooo_status": CaseSpec(
         case_qa_10b_slack_ooo_status,
         requires_slack=True,
         requires_slack_personal_auth=True,
-        default_enabled=False,
     ),
     "qa_10c_slack_thread_replies": CaseSpec(
         case_qa_10c_slack_thread_replies,
         requires_slack=True,
         requires_slack_target=True,
         requires_slack_personal_auth=True,
-        default_enabled=False,
     ),
     "qa_10d_slack_channel_membership": CaseSpec(
         case_qa_10d_slack_channel_membership,
         requires_slack=True,
         requires_slack_personal_auth=True,
-        default_enabled=False,
     ),
     "qa_10e_slack_error_honesty": CaseSpec(
         case_qa_10e_slack_error_honesty,
         requires_slack=True,
         requires_slack_personal_auth=True,
-        default_enabled=False,
     ),
     "qa_10f_slack_mention_encoding": CaseSpec(
         case_qa_10f_slack_mention_encoding,
         requires_slack=True,
         requires_slack_target=True,
         requires_slack_personal_auth=True,
-        default_enabled=False,
     ),
     "qa_10g_slack_last_message_sent": CaseSpec(
         case_qa_10g_slack_last_message_sent,
         requires_slack=True,
         requires_slack_target=True,
         requires_slack_personal_auth=True,
-        default_enabled=False,
     ),
     "qa_10h_slack_email_hallucination_guard": CaseSpec(
         case_qa_10h_slack_email_hallucination_guard,
         requires_slack=True,
         requires_slack_target=True,
         requires_slack_personal_auth=True,
-        default_enabled=False,
     ),
     "qa_10i_slack_raw_entity_hygiene": CaseSpec(
         case_qa_10i_slack_raw_entity_hygiene,
         requires_slack=True,
         requires_slack_target=True,
         requires_slack_personal_auth=True,
-        default_enabled=False,
     ),
 }
 

--- a/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
+++ b/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
@@ -3627,7 +3627,7 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
                 run_live_qa._outbound_final_reply_targets(Path(tmp)), {}
             )
 
-    def test_exactly_once_case_specs_gate_on_personal_auth_and_stay_dispatch_only(self):
+    def test_exactly_once_case_specs_gate_on_personal_auth_and_run_by_default(self):
         for case_name in (
             "qa_9b_routine_dm_delivery_exactly_once",
             "qa_9d_routine_per_trigger_delivery_target",
@@ -3644,10 +3644,10 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
             "qa_9c_slack_digest_names_not_ids",
             "qa_9d_routine_per_trigger_delivery_target",
         ):
-            self.assertFalse(
+            self.assertTrue(
                 run_live_qa.CASES[case_name].default_enabled,
-                f"{case_name} is expected-red on pre-fix servers and must "
-                "stay out of bare local default runs until promoted",
+                f"{case_name} is promoted (delivery-routing fixes merged and "
+                "live-verified green) and must run in bare local default runs",
             )
 
     def test_exc_text_preserves_type_for_empty_str_exceptions(self):
@@ -4195,7 +4195,7 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
             ):
                 run_live_qa._require_slack_second_user_token(self._dummy_ctx())
 
-    def test_qa_10_case_specs_gate_and_stay_dispatch_only(self):
+    def test_qa_10_case_specs_gate_and_run_by_default(self):
         qa_10_cases = [
             "qa_10a_slack_self_attribution",
             "qa_10b_slack_ooo_status",
@@ -4223,10 +4223,11 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
                 f"{case_name} seeds/reads with the personal token; without "
                 "the workspace-mismatch gate its arms are structurally blind",
             )
-            self.assertFalse(
+            self.assertTrue(
                 spec.default_enabled,
-                f"{case_name} is expected-red on pre-fix hosts and must stay "
-                "out of bare local default runs until promoted",
+                f"{case_name} is promoted (tool-surface fixes merged and "
+                "live-verified 9/9 green) and must run in bare local default "
+                "runs",
             )
             self.assertEqual(
                 spec.requires_slack_target,
@@ -4682,6 +4683,27 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
 
         self.assertEqual(len(sharded_cases), len(set(sharded_cases)))
         self.assertEqual(sharded_cases, selected_cases)
+        # QA 9/10 are promoted: no shard in the matrix is dispatch_only any
+        # more, so every shard (qa-9/qa-10 included) runs on the 3-hourly
+        # schedule and on a default cases=all dispatch. The resolve-step
+        # guard itself stays for any FUTURE expected-red shard.
+        matrix_match = re.search(
+            r"(?ms)^\s+include:\n(?P<matrix>.*?)^\s+env:", match.group("body")
+        )
+        self.assertIsNotNone(matrix_match, "live QA shard matrix missing")
+        self.assertNotIn(
+            "dispatch_only",
+            matrix_match.group("matrix"),
+            "no live QA shard is dispatch_only; qa-9/qa-10 are promoted into "
+            "the cron rotation — only add dispatch_only for a NEW "
+            "expected-red shard",
+        )
+        self.assertIn(
+            "Shard is dispatch_only; skipping on schedule.",
+            match.group("body"),
+            "keep the resolve-step dispatch_only guard for future "
+            "expected-red shards",
+        )
         all_shard_cases_match = re.search(
             r"(?ms)^\s+ALL_SHARD_CASES:\s*>-\n(?P<cases>.*?)(?=^\s+run:\s*\|)",
             match.group("body"),


### PR DESCRIPTION
## Merge ordering

This PR was staged to **MERGE LAST** — only after #5899 (the QA 9/10 canary suite) and #5898 (the Slack delivery-routing + tool-surface fixes) were both on main, because on pre-fix servers these shards are red and would page the 3-hourly cron. Both merged today, so that precondition is now satisfied. It was originally based on `canary/automation-probes` (so #5899's merge would retarget it to `main`), but #5899 squash-merged and its branch was deleted before this PR opened, so it targets `main` directly with the same one-commit diff.

## What

Promotes the QA 9 (automation delivery) and QA 10 (Slack tool correctness) canary shards from dispatch-only into the scheduled rotation, now that the fixes they guard are merged and live-verified green (9/9 QA 10, 4/4 QA 9):

- `.github/workflows/live-canary.yml`: drop `dispatch_only: true` from the qa-9 and qa-10 matrix entries; their comments now state they are in the 3-hourly cron rotation and which failure classes they guard. The resolve-step dispatch_only guard itself stays for any future expected-red shard.
- `scripts/reborn_webui_v2_live_qa/run_live_qa.py`: drop `default_enabled=False` from qa_9b/qa_9c/qa_9d and all nine qa_10* CaseSpec entries, so they run in bare local default runs too.
- `scripts/reborn_webui_v2_live_qa/test_run_live_qa.py`: flip the promoted cases' `default_enabled` pins to True, and pin in the workflow shard-parity test that no matrix shard is dispatch_only (every shard runs on schedule / cases=all) while the resolve-step guard remains.

No probe logic, assertions, or helpers change.

## Out of scope

Fixture cleanup (deleting seeded messages post-assertion) and realistic fixture envelopes ride in a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)