### PR TITLE
feat(reborn): expose production LocalDev capability-port assembly to tests (seam PR-A)

### DIFF
--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -1151,6 +1151,22 @@ pub(crate) fn wrap_outbound_delivery_capabilities_for_test(
     local_dev::wrap_outbound_delivery_capabilities_for_test(inner, parts)
 }
 
+/// Test-support forwarder (harness-port-seam P1 seam) for
+/// `create_refreshing_local_dev_capability_port`
+/// (`refreshing_capability_port.rs:75`), production's sole capability-port
+/// factory. Bridges the private `local_dev` module to `test_support`; mirrors
+/// the `outbound_delivery` forwarder above. For tests only -- gated behind
+/// `test-support`, ships zero bytes in production builds.
+#[cfg(feature = "test-support")]
+pub(crate) async fn create_refreshing_local_dev_capability_port_for_test(
+    parts: crate::test_support::RefreshingLocalDevCapabilityPortTestParts,
+) -> Result<
+    std::sync::Arc<dyn ironclaw_turns::run_profile::LoopCapabilityPort>,
+    ironclaw_turns::run_profile::AgentLoopHostError,
+> {
+    local_dev::create_refreshing_local_dev_capability_port_for_test(parts).await
+}
+
 #[async_trait::async_trait]
 impl ApprovalGateEvidenceStore for LocalDevApprovalGateEvidence {
     async fn pending_approval_gate(

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeMap, HashMap, VecDeque},
+    collections::{BTreeMap, HashMap, HashSet, VecDeque},
     sync::{Arc, Mutex as StdMutex},
 };
 
@@ -81,6 +81,8 @@ pub(crate) use skill_activation::SKILL_ACTIVATE_CAPABILITY_ID;
 pub(super) use outbound_delivery::wrap_outbound_delivery_capabilities_for_test;
 #[cfg(feature = "test-support")]
 pub(super) use project_create::wrap_project_create_capability_for_test;
+#[cfg(feature = "test-support")]
+pub(super) use refreshing_capability_port::create_refreshing_local_dev_capability_port_for_test;
 #[cfg(feature = "test-support")]
 pub(super) use skill_activation::wrap_skill_activation_capability_for_test;
 
@@ -248,6 +250,11 @@ impl LoopCapabilityPortFactory for LocalDevLoopCapabilityPortFactory {
             approval_requests: Arc::clone(&self.approval_requests),
             capability_leases: Arc::clone(&self.capability_leases),
             external_tool_catalog: Arc::clone(&self.external_tool_catalog),
+            // Test-support-only knobs (see each field's doc-comment on
+            // `RefreshingLocalDevCapabilityPortConfig`): always empty here.
+            capability_execution_mount_overrides: HashMap::new(),
+            additional_provider_trust: BTreeMap::new(),
+            capability_id_filter: HashSet::new(),
         })
         .await
     }
@@ -979,6 +986,10 @@ struct LocalDevVisibleCapabilityInputs<'a> {
     system_extensions_lifecycle_mounts: &'a MountView,
     policy: &'a LocalDevCapabilityPolicy,
     extension_surface: &'a LocalDevExtensionSurface,
+    /// Test-support-only extra provider-trust entries (empty in production,
+    /// see `RefreshingLocalDevCapabilityPortConfig::additional_provider_trust`'s
+    /// doc-comment).
+    additional_provider_trust: &'a BTreeMap<ExtensionId, TrustDecision>,
 }
 
 fn local_dev_visible_capability_request(
@@ -1040,6 +1051,7 @@ fn local_dev_visible_capability_request(
         },
     );
     provider_trust.extend(inputs.extension_surface.provider_trust(&context.user_id));
+    provider_trust.extend(inputs.additional_provider_trust.clone());
 
     Ok(HostVisibleCapabilityRequest::new(
         context,

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev.rs
@@ -986,10 +986,6 @@ struct LocalDevVisibleCapabilityInputs<'a> {
     system_extensions_lifecycle_mounts: &'a MountView,
     policy: &'a LocalDevCapabilityPolicy,
     extension_surface: &'a LocalDevExtensionSurface,
-    /// Test-support-only extra provider-trust entries (empty in production,
-    /// see `RefreshingLocalDevCapabilityPortConfig::additional_provider_trust`'s
-    /// doc-comment).
-    additional_provider_trust: &'a BTreeMap<ExtensionId, TrustDecision>,
 }
 
 fn local_dev_visible_capability_request(
@@ -1051,7 +1047,6 @@ fn local_dev_visible_capability_request(
         },
     );
     provider_trust.extend(inputs.extension_surface.provider_trust(&context.user_id));
-    provider_trust.extend(inputs.additional_provider_trust.clone());
 
     Ok(HostVisibleCapabilityRequest::new(
         context,

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/refreshing_capability_port.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/refreshing_capability_port.rs
@@ -1,13 +1,15 @@
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::{Arc, Mutex as StdMutex};
 
 use ironclaw_authorization::CapabilityLeaseStore;
-use ironclaw_host_api::{MountView, UserId};
+use ironclaw_host_api::{CapabilityId, ExtensionId, MountView, UserId};
 use ironclaw_host_runtime::HostRuntime;
 use ironclaw_loop_support::{
     HostRuntimeLoopCapabilityPortFactory, LoopCapabilityInputResolver, LoopCapabilityResultWriter,
 };
 use ironclaw_product_workflow::{OutboundPreferencesProductFacade, ProjectService};
 use ironclaw_run_state::ApprovalRequestStore;
+use ironclaw_trust::TrustDecision;
 use ironclaw_turns::ExternalToolCatalog;
 use ironclaw_turns::run_profile::{
     AgentLoopHostError, AgentLoopHostErrorKind, CapabilityBatchInvocation, CapabilityBatchOutcome,
@@ -34,7 +36,7 @@ use super::{
     local_dev_visible_capability_request,
 };
 
-pub(super) struct RefreshingLocalDevCapabilityPortConfig {
+pub(crate) struct RefreshingLocalDevCapabilityPortConfig {
     pub(super) runtime: Arc<dyn HostRuntime>,
     pub(super) run_context: LoopRunContext,
     pub(super) fallback_user_id: UserId,
@@ -56,9 +58,21 @@ pub(super) struct RefreshingLocalDevCapabilityPortConfig {
     pub(super) approval_requests: Arc<dyn ApprovalRequestStore>,
     pub(super) capability_leases: Arc<dyn CapabilityLeaseStore>,
     pub(super) external_tool_catalog: Arc<dyn ExternalToolCatalog>,
+    /// Per-capability mount overrides, merged via `with_capability_execution_mount`.
+    /// Always empty at the sole production call site (`local_dev.rs`'s `create_capability_port`);
+    /// populated only by the `test-support` constructor.
+    pub(super) capability_execution_mount_overrides: HashMap<CapabilityId, MountView>,
+    /// Extra provider-trust entries merged into the visible request's
+    /// provider-trust map. Always empty at the sole production call site
+    /// (`local_dev.rs`'s `create_capability_port`); populated only by the `test-support` constructor.
+    pub(super) additional_provider_trust: BTreeMap<ExtensionId, TrustDecision>,
+    /// Narrows the builtin-grant set to this id set (empty = no filtering,
+    /// production's value). Always empty at the sole production call site
+    /// (`local_dev.rs`'s `create_capability_port`); populated only by the `test-support` constructor.
+    pub(super) capability_id_filter: HashSet<CapabilityId>,
 }
 
-pub(super) async fn create_refreshing_local_dev_capability_port(
+pub(crate) async fn create_refreshing_local_dev_capability_port(
     config: RefreshingLocalDevCapabilityPortConfig,
 ) -> Result<Arc<dyn LoopCapabilityPort>, AgentLoopHostError> {
     let port = Arc::new(RefreshingLocalDevCapabilityPort {
@@ -84,6 +98,9 @@ pub(super) async fn create_refreshing_local_dev_capability_port(
         approval_requests: config.approval_requests,
         capability_leases: config.capability_leases,
         external_tool_catalog: config.external_tool_catalog,
+        capability_execution_mount_overrides: config.capability_execution_mount_overrides,
+        additional_provider_trust: config.additional_provider_trust,
+        capability_id_filter: config.capability_id_filter,
         current: StdMutex::new(None),
         refresh_lock: AsyncMutex::new(()),
     });
@@ -116,6 +133,9 @@ struct RefreshingLocalDevCapabilityPort {
     approval_requests: Arc<dyn ApprovalRequestStore>,
     capability_leases: Arc<dyn CapabilityLeaseStore>,
     external_tool_catalog: Arc<dyn ExternalToolCatalog>,
+    capability_execution_mount_overrides: HashMap<CapabilityId, MountView>,
+    additional_provider_trust: BTreeMap<ExtensionId, TrustDecision>,
+    capability_id_filter: HashSet<CapabilityId>,
     current: StdMutex<Option<Arc<dyn LoopCapabilityPort>>>,
     refresh_lock: AsyncMutex<()>,
 }
@@ -127,7 +147,7 @@ impl RefreshingLocalDevCapabilityPort {
             .snapshot()
             .await
             .map_err(host_api_agent_loop_error)?;
-        let visible_request = local_dev_visible_capability_request(
+        let mut visible_request = local_dev_visible_capability_request(
             &self.run_context,
             &self.fallback_user_id,
             LocalDevVisibleCapabilityInputs {
@@ -137,8 +157,19 @@ impl RefreshingLocalDevCapabilityPort {
                 system_extensions_lifecycle_mounts: &self.system_extensions_lifecycle_mounts,
                 policy: &self.policy,
                 extension_surface: &extension_surface,
+                additional_provider_trust: &self.additional_provider_trust,
             },
         )?;
+        // Test-support-only narrowing (empty in production, see the config
+        // field doc-comment): restrict the builtin-granted capability set to
+        // `capability_id_filter` after `builtin_grants` has run.
+        if !self.capability_id_filter.is_empty() {
+            visible_request
+                .context
+                .grants
+                .grants
+                .retain(|grant| self.capability_id_filter.contains(&grant.capability));
+        }
         let mut factory = HostRuntimeLoopCapabilityPortFactory::new(
             Arc::clone(&self.runtime),
             visible_request,
@@ -168,6 +199,13 @@ impl RefreshingLocalDevCapabilityPort {
                 capability_id.clone(),
                 self.system_extensions_lifecycle_mounts.clone(),
             );
+        }
+        // Test-support-only overrides (empty in production, see the config
+        // field doc-comment): the factory bakes mounts in at construction, so
+        // this is the only seam that can reach per-capability test mounts.
+        for (capability_id, mounts) in &self.capability_execution_mount_overrides {
+            factory =
+                factory.with_capability_execution_mount(capability_id.clone(), mounts.clone());
         }
         let port = factory.for_run_context(self.run_context.clone());
         let mut synthetic_capabilities = match &self.skill_activation_source {
@@ -321,4 +359,83 @@ impl LoopCapabilityPort for RefreshingLocalDevCapabilityPort {
             .invoke_capability_batch(request)
             .await
     }
+}
+
+/// Test-support constructor (harness-port-seam P1 seam): assembles a
+/// [`RefreshingLocalDevCapabilityPortConfig`] from the harness's injectable
+/// parts and drives the REAL [`create_refreshing_local_dev_capability_port`]
+/// above, so the harness exercises every wrap layer `build_inner` applies.
+/// Parts the harness has no opinion on get the same no-op production types
+/// the sole call site (`local_dev.rs`'s `create_capability_port`) passes -- never `capability_wiring`'s
+/// `RebornServices`-entangled defaults. For tests only -- gated behind
+/// `test-support`, ships zero bytes in production builds.
+#[cfg(feature = "test-support")]
+pub(crate) async fn create_refreshing_local_dev_capability_port_for_test(
+    parts: crate::test_support::RefreshingLocalDevCapabilityPortTestParts,
+) -> Result<Arc<dyn LoopCapabilityPort>, AgentLoopHostError> {
+    let crate::test_support::RefreshingLocalDevCapabilityPortTestParts {
+        runtime,
+        run_context,
+        fallback_user_id,
+        workspace_mounts,
+        skill_mounts,
+        memory_mounts,
+        system_extensions_lifecycle_mounts,
+        input_resolver,
+        result_writer,
+        milestone_sink,
+        skill_activation_source,
+        project_service,
+        trajectory_observer,
+        outbound_preferences_facade,
+        outbound_delivery_target_set_requires_approval,
+        tool_permission_overrides,
+        auto_approve_settings,
+        persistent_approval_policies,
+        approval_requests,
+        capability_leases,
+        capability_execution_mount_overrides,
+        additional_provider_trust,
+        capability_id_filter,
+    } = parts;
+
+    let policy = Arc::new(
+        crate::local_dev_capability_policy::local_dev_capability_policy()
+            .map_err(host_api_agent_loop_error)?,
+    );
+    let approval_settings: Arc<dyn ApprovalSettingsProvider> = Arc::new(
+        crate::local_dev_authorization::StoreApprovalSettingsProvider::new(
+            tool_permission_overrides,
+            auto_approve_settings,
+            persistent_approval_policies,
+        ),
+    );
+
+    create_refreshing_local_dev_capability_port(RefreshingLocalDevCapabilityPortConfig {
+        runtime,
+        run_context,
+        fallback_user_id,
+        policy,
+        workspace_mounts,
+        skill_mounts,
+        memory_mounts,
+        system_extensions_lifecycle_mounts,
+        extension_surface_source: LocalDevExtensionSurfaceSource::new(None),
+        input_resolver,
+        result_writer,
+        milestone_sink,
+        skill_activation_source,
+        project_service,
+        trajectory_observer,
+        outbound_preferences_facade,
+        outbound_delivery_target_set_requires_approval,
+        approval_settings,
+        approval_requests,
+        capability_leases,
+        external_tool_catalog: Arc::new(ironclaw_turns::InMemoryExternalToolCatalog::new()),
+        capability_execution_mount_overrides,
+        additional_provider_trust,
+        capability_id_filter,
+    })
+    .await
 }

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/refreshing_capability_port.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/refreshing_capability_port.rs
@@ -66,9 +66,18 @@ pub(crate) struct RefreshingLocalDevCapabilityPortConfig {
     /// provider-trust map. Always empty at the sole production call site
     /// (`local_dev.rs`'s `create_capability_port`); populated only by the `test-support` constructor.
     pub(super) additional_provider_trust: BTreeMap<ExtensionId, TrustDecision>,
-    /// Narrows the builtin-grant set to this id set (empty = no filtering,
-    /// production's value). Always empty at the sole production call site
-    /// (`local_dev.rs`'s `create_capability_port`); populated only by the `test-support` constructor.
+    /// Narrows the FULL granted-capability set -- builtin grants AND any
+    /// activated extension grants `local_dev_visible_capability_request`
+    /// appended -- to this id set (empty = no filtering, production's
+    /// value). Applied in `build_inner` as a single `retain` AFTER
+    /// extension grants are appended, so callers that want an extension
+    /// capability visible must list its id explicitly; there is no
+    /// separate builtin-only carve-out (see the harness-port-seam plan's
+    /// "one narrowing input at the grants layer" design: this field is the
+    /// only narrowing surface, and it narrows everything a run could see).
+    /// Always empty at the sole production call site (`local_dev.rs`'s
+    /// `create_capability_port`); populated only by the `test-support`
+    /// constructor.
     pub(super) capability_id_filter: HashSet<CapabilityId>,
 }
 
@@ -160,8 +169,10 @@ impl RefreshingLocalDevCapabilityPort {
             },
         )?;
         // Test-support-only narrowing (empty in production, see the config
-        // field doc-comment): restrict the builtin-granted capability set to
-        // `capability_id_filter` after `builtin_grants` has run.
+        // field doc-comment): restrict the FULL granted capability set --
+        // builtin grants plus any activated extension grants the call above
+        // just appended -- to `capability_id_filter`. Callers must list
+        // extension capability ids explicitly to keep them visible.
         if !self.capability_id_filter.is_empty() {
             visible_request
                 .context

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/refreshing_capability_port.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/refreshing_capability_port.rs
@@ -157,7 +157,6 @@ impl RefreshingLocalDevCapabilityPort {
                 system_extensions_lifecycle_mounts: &self.system_extensions_lifecycle_mounts,
                 policy: &self.policy,
                 extension_surface: &extension_surface,
-                additional_provider_trust: &self.additional_provider_trust,
             },
         )?;
         // Test-support-only narrowing (empty in production, see the config
@@ -169,6 +168,15 @@ impl RefreshingLocalDevCapabilityPort {
                 .grants
                 .grants
                 .retain(|grant| self.capability_id_filter.contains(&grant.capability));
+        }
+        // Test-support-only extra provider-trust entries (empty in production,
+        // see the config field doc-comment): merge after the canonical helper
+        // has built the base provider-trust map, so the production helper
+        // stays byte-identical to the pre-seam version.
+        if !self.additional_provider_trust.is_empty() {
+            visible_request
+                .provider_trust
+                .extend(self.additional_provider_trust.clone());
         }
         let mut factory = HostRuntimeLoopCapabilityPortFactory::new(
             Arc::clone(&self.runtime),
@@ -410,6 +418,10 @@ pub(crate) async fn create_refreshing_local_dev_capability_port_for_test(
             persistent_approval_policies,
         ),
     );
+    // Recover the crate-private `LocalDevSelectableSkillContextSource` from
+    // the opaque `SkillActivationTestSource` handle the harness passed in
+    // (see the field's doc-comment on `RefreshingLocalDevCapabilityPortTestParts`).
+    let skill_activation_source = skill_activation_source.map(|handle| handle.activation_source());
 
     create_refreshing_local_dev_capability_port(RefreshingLocalDevCapabilityPortConfig {
         runtime,

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/tests.rs
@@ -173,7 +173,6 @@ mod tests {
         let policy = crate::local_dev_capability_policy::local_dev_capability_policy()
             .expect("policy parses");
         let empty_mounts = MountView::default();
-        let empty_provider_trust = std::collections::BTreeMap::new();
 
         local_dev_visible_capability_request(
             run_context,
@@ -185,7 +184,6 @@ mod tests {
                 system_extensions_lifecycle_mounts: &empty_mounts,
                 policy: &policy,
                 extension_surface: &LocalDevExtensionSurface::default(),
-                additional_provider_trust: &empty_provider_trust,
             },
         )
         .expect("visible request")

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/tests.rs
@@ -173,6 +173,7 @@ mod tests {
         let policy = crate::local_dev_capability_policy::local_dev_capability_policy()
             .expect("policy parses");
         let empty_mounts = MountView::default();
+        let empty_provider_trust = std::collections::BTreeMap::new();
 
         local_dev_visible_capability_request(
             run_context,
@@ -184,6 +185,7 @@ mod tests {
                 system_extensions_lifecycle_mounts: &empty_mounts,
                 policy: &policy,
                 extension_surface: &LocalDevExtensionSurface::default(),
+                additional_provider_trust: &empty_provider_trust,
             },
         )
         .expect("visible request")

--- a/crates/ironclaw_reborn_composition/src/test_support/mod.rs
+++ b/crates/ironclaw_reborn_composition/src/test_support/mod.rs
@@ -41,6 +41,10 @@
 //! 11. [`projection`] — `build_webui_event_stream_for_test`, a deliberately
 //!     narrowed `ProjectionStream` (turn-lifecycle events only) for the SSE
 //!     activity-stream scenario (W5-WEBUI-API-1 Enabler A).
+//! 12. [`refreshing_capability_port`] — `create_refreshing_local_dev_capability_port_for_test`,
+//!     the production `create_refreshing_local_dev_capability_port` factory
+//!     (all wrap layers) driven with harness-injectable parts (harness-port-seam
+//!     P1 seam).
 
 mod automation;
 mod budget_gateway;
@@ -50,6 +54,7 @@ mod oauth_product_auth;
 mod outbound_delivery;
 mod project_create;
 mod projection;
+mod refreshing_capability_port;
 mod skill_activation;
 mod trace_capture;
 mod trigger_materializer;
@@ -90,6 +95,10 @@ pub use outbound_delivery::{
 pub use project_create::{PROJECT_CREATE_CAPABILITY_ID, wrap_project_create_capability_for_test};
 #[cfg(feature = "test-support")]
 pub use projection::build_webui_event_stream_for_test;
+#[cfg(feature = "test-support")]
+pub use refreshing_capability_port::{
+    RefreshingLocalDevCapabilityPortTestParts, create_refreshing_local_dev_capability_port_for_test,
+};
 #[cfg(feature = "test-support")]
 pub use skill_activation::{
     SKILL_ACTIVATE_CAPABILITY_ID, SkillActivationTestSource,

--- a/crates/ironclaw_reborn_composition/src/test_support/refreshing_capability_port.rs
+++ b/crates/ironclaw_reborn_composition/src/test_support/refreshing_capability_port.rs
@@ -1,0 +1,75 @@
+//! Production capability-port assembly test support (harness-port-seam P1).
+//!
+//! Lets the Reborn integration-test harness assemble its capability port
+//! through the REAL production factory
+//! (`create_refreshing_local_dev_capability_port`,
+//! `runtime::local_dev::refreshing_capability_port.rs:75`) instead of hand-
+//! rebuilding the wrap order, so every current and future production layer
+//! (surface disclosure, external tools, StaleSurface refresh, the shared
+//! `LocalDevCapabilityIo`) is automatically exercised by the harness too.
+
+/// Typed bundle of the parts the harness controls, passed by value through
+/// the `test_support` -> `runtime` -> `runtime::local_dev` forwarding chain
+/// so no layer needs `#[allow(clippy::too_many_arguments)]`. Mirrors
+/// `RefreshingLocalDevCapabilityPortConfig` minus the no-op-by-default parts
+/// (`extension_surface_source`, `external_tool_catalog`, `policy`).
+#[cfg(feature = "test-support")]
+pub struct RefreshingLocalDevCapabilityPortTestParts {
+    /// Host runtime the assembled port dispatches builtin capabilities
+    /// through (harness passes a recording double).
+    pub runtime: std::sync::Arc<dyn ironclaw_host_runtime::HostRuntime>,
+    pub run_context: ironclaw_turns::run_profile::LoopRunContext,
+    pub fallback_user_id: ironclaw_host_api::UserId,
+    pub workspace_mounts: ironclaw_host_api::MountView,
+    pub skill_mounts: ironclaw_host_api::MountView,
+    pub memory_mounts: ironclaw_host_api::MountView,
+    pub system_extensions_lifecycle_mounts: ironclaw_host_api::MountView,
+    /// Input resolver AND [`result_writer`](Self::result_writer) must be two
+    /// `Arc::clone`s of the SAME shared io object — production assigns one
+    /// `LocalDevCapabilityIo` to both roles so input-ref/result-ref
+    /// correlation by `call_id` works; never source them independently.
+    pub input_resolver: std::sync::Arc<dyn ironclaw_loop_support::LoopCapabilityInputResolver>,
+    pub result_writer: std::sync::Arc<dyn ironclaw_loop_support::LoopCapabilityResultWriter>,
+    pub milestone_sink: std::sync::Arc<dyn ironclaw_turns::run_profile::LoopHostMilestoneSink>,
+    pub skill_activation_source:
+        Option<std::sync::Arc<crate::runtime::LocalDevSelectableSkillContextSource>>,
+    pub project_service: std::sync::Arc<dyn ironclaw_product_workflow::ProjectService>,
+    pub trajectory_observer: Option<std::sync::Arc<dyn crate::RebornTrajectoryObserver>>,
+    pub outbound_preferences_facade:
+        Option<std::sync::Arc<dyn ironclaw_product_workflow::OutboundPreferencesProductFacade>>,
+    pub outbound_delivery_target_set_requires_approval: bool,
+    /// Per-tool approval-setting overrides; wrapped into the same
+    /// `StoreApprovalSettingsProvider` production wires (`local_dev.rs:1002`).
+    pub tool_permission_overrides:
+        std::sync::Arc<dyn ironclaw_approvals::ToolPermissionOverrideStore>,
+    pub auto_approve_settings: std::sync::Arc<dyn ironclaw_approvals::AutoApproveSettingStore>,
+    pub persistent_approval_policies:
+        std::sync::Arc<dyn ironclaw_approvals::PersistentApprovalPolicyStore>,
+    pub approval_requests: std::sync::Arc<dyn ironclaw_run_state::ApprovalRequestStore>,
+    pub capability_leases: std::sync::Arc<dyn ironclaw_authorization::CapabilityLeaseStore>,
+    /// Test-only config extension (empty = production behavior). See
+    /// `RefreshingLocalDevCapabilityPortConfig::capability_execution_mount_overrides`.
+    pub capability_execution_mount_overrides:
+        std::collections::HashMap<ironclaw_host_api::CapabilityId, ironclaw_host_api::MountView>,
+    /// Test-only config extension (empty = production behavior). See
+    /// `RefreshingLocalDevCapabilityPortConfig::additional_provider_trust`.
+    pub additional_provider_trust:
+        std::collections::BTreeMap<ironclaw_host_api::ExtensionId, ironclaw_trust::TrustDecision>,
+    /// Test-only config extension (empty = production behavior, i.e. no
+    /// filtering). See `RefreshingLocalDevCapabilityPortConfig::capability_id_filter`.
+    pub capability_id_filter: std::collections::HashSet<ironclaw_host_api::CapabilityId>,
+}
+
+/// Test-support entry point that drives the real
+/// `create_refreshing_local_dev_capability_port` (production's sole port
+/// factory) with the harness's injectable parts, supplying the same no-op
+/// defaults production uses for the rest. Never hand-rebuilds the wrap order.
+#[cfg(feature = "test-support")]
+pub async fn create_refreshing_local_dev_capability_port_for_test(
+    parts: RefreshingLocalDevCapabilityPortTestParts,
+) -> Result<
+    std::sync::Arc<dyn ironclaw_turns::run_profile::LoopCapabilityPort>,
+    ironclaw_turns::run_profile::AgentLoopHostError,
+> {
+    crate::runtime::create_refreshing_local_dev_capability_port_for_test(parts).await
+}

--- a/crates/ironclaw_reborn_composition/src/test_support/refreshing_capability_port.rs
+++ b/crates/ironclaw_reborn_composition/src/test_support/refreshing_capability_port.rs
@@ -31,8 +31,15 @@ pub struct RefreshingLocalDevCapabilityPortTestParts {
     pub input_resolver: std::sync::Arc<dyn ironclaw_loop_support::LoopCapabilityInputResolver>,
     pub result_writer: std::sync::Arc<dyn ironclaw_loop_support::LoopCapabilityResultWriter>,
     pub milestone_sink: std::sync::Arc<dyn ironclaw_turns::run_profile::LoopHostMilestoneSink>,
+    /// Opaque handle built by
+    /// `test_support::build_local_dev_skill_context_source_for_test`. Wraps
+    /// the crate-private `LocalDevSelectableSkillContextSource` so it never
+    /// appears in this (public, `test-support`-gated) struct's field types;
+    /// the private type is recovered internally via
+    /// `SkillActivationTestSource::activation_source` when forwarding to the
+    /// production factory.
     pub skill_activation_source:
-        Option<std::sync::Arc<crate::runtime::LocalDevSelectableSkillContextSource>>,
+        Option<std::sync::Arc<crate::test_support::SkillActivationTestSource>>,
     pub project_service: std::sync::Arc<dyn ironclaw_product_workflow::ProjectService>,
     pub trajectory_observer: Option<std::sync::Arc<dyn crate::RebornTrajectoryObserver>>,
     pub outbound_preferences_facade:

--- a/crates/ironclaw_reborn_composition/src/test_support/skill_activation.rs
+++ b/crates/ironclaw_reborn_composition/src/test_support/skill_activation.rs
@@ -27,6 +27,17 @@ impl SkillActivationTestSource {
     ) -> std::sync::Arc<dyn ironclaw_loop_support::HostSkillContextSource> {
         self.source.clone()
     }
+
+    /// Crate-internal accessor for the wrapped activation source. Kept
+    /// `pub(crate)` (never `pub`) so the crate-private
+    /// `LocalDevSelectableSkillContextSource` type never appears in this
+    /// crate's public API; only `runtime::local_dev`'s test-support
+    /// constructor (which already names the type) may call this.
+    pub(crate) fn activation_source(
+        &self,
+    ) -> std::sync::Arc<crate::runtime::LocalDevSelectableSkillContextSource> {
+        self.activation_source.clone()
+    }
 }
 
 /// Build the local-dev skill context source (`HostSkillContextSource` for

--- a/crates/ironclaw_reborn_composition/tests/refreshing_capability_port_test_support.rs
+++ b/crates/ironclaw_reborn_composition/tests/refreshing_capability_port_test_support.rs
@@ -145,6 +145,7 @@ impl HostRuntime for StubHostRuntime {
                     effects: vec![EffectKind::ReadFilesystem],
                     default_permission: PermissionMode::Allow,
                     runtime_credentials: Vec::new(),
+                    network_targets: Vec::new(),
                     resource_profile: None,
                 },
                 access: VisibleCapabilityAccess::Available,

--- a/crates/ironclaw_reborn_composition/tests/refreshing_capability_port_test_support.rs
+++ b/crates/ironclaw_reborn_composition/tests/refreshing_capability_port_test_support.rs
@@ -21,8 +21,9 @@ use ironclaw_approvals::{
 };
 use ironclaw_authorization::InMemoryCapabilityLeaseStore;
 use ironclaw_host_api::{
-    AgentId, CapabilityDescriptor, CapabilityId, EffectKind, ExtensionId, PermissionMode,
-    ProjectId, ProviderToolName, ResourceEstimate, RuntimeKind, TenantId, ThreadId, UserId,
+    AgentId, CapabilityDescriptor, CapabilityId, EffectKind, ExtensionId, MountAlias, MountGrant,
+    MountPermissions, MountView, PermissionMode, ProjectId, ProviderToolName, ResourceEstimate,
+    RuntimeKind, TenantId, ThreadId, UserId, VirtualPath,
 };
 use ironclaw_host_runtime::RuntimeCapabilityOutcome;
 use ironclaw_host_runtime::{
@@ -44,7 +45,8 @@ use ironclaw_product_workflow::{
     RebornUpdateMemberRoleRequest, RebornUpdateProjectRequest,
 };
 use ironclaw_reborn_composition::test_support::{
-    RefreshingLocalDevCapabilityPortTestParts, create_refreshing_local_dev_capability_port_for_test,
+    PROJECT_CREATE_CAPABILITY_ID, RefreshingLocalDevCapabilityPortTestParts,
+    create_refreshing_local_dev_capability_port_for_test,
 };
 use ironclaw_run_state::InMemoryApprovalRequestStore;
 use ironclaw_turns::run_profile::{
@@ -57,17 +59,57 @@ use ironclaw_turns::{RunProfileResolver, TurnId, TurnRunId, TurnScope};
 /// Echoes a runtime-visible capability for every grant in the request's
 /// context, so `capability_id_filter` narrowing (applied upstream of this
 /// stub, in `build_inner`) is directly observable in `tool_definitions()`.
-struct StubHostRuntime;
+/// Also records the `ExecutionContext` of every `invoke_capability` call and
+/// the `provider_trust` map of every `visible_capabilities` call, so tests
+/// can observe what `build_inner` actually resolved and handed to the host
+/// runtime (mount overrides, extra provider trust) rather than just that the
+/// port assembled.
+struct StubHostRuntime {
+    invocation_contexts: StdMutex<Vec<ironclaw_host_api::ExecutionContext>>,
+    visible_provider_trust: StdMutex<Vec<BTreeMap<ExtensionId, ironclaw_trust::TrustDecision>>>,
+}
+
+impl StubHostRuntime {
+    fn new() -> Self {
+        Self {
+            invocation_contexts: StdMutex::new(Vec::new()),
+            visible_provider_trust: StdMutex::new(Vec::new()),
+        }
+    }
+
+    fn invocation_contexts(&self) -> Vec<ironclaw_host_api::ExecutionContext> {
+        self.invocation_contexts
+            .lock()
+            .expect("invocation contexts lock")
+            .clone()
+    }
+
+    fn visible_provider_trust(&self) -> Vec<BTreeMap<ExtensionId, ironclaw_trust::TrustDecision>> {
+        self.visible_provider_trust
+            .lock()
+            .expect("visible provider trust lock")
+            .clone()
+    }
+}
 
 #[async_trait]
 impl HostRuntime for StubHostRuntime {
     async fn invoke_capability(
         &self,
-        _request: RuntimeCapabilityRequest,
+        request: RuntimeCapabilityRequest,
     ) -> Result<RuntimeCapabilityOutcome, HostRuntimeError> {
-        Err(HostRuntimeError::unavailable(
-            "stub host runtime does not execute capabilities",
-        ))
+        self.invocation_contexts
+            .lock()
+            .expect("invocation contexts lock")
+            .push(request.context.clone());
+        Ok(RuntimeCapabilityOutcome::Completed(Box::new(
+            ironclaw_host_runtime::RuntimeCapabilityCompleted {
+                capability_id: request.capability_id,
+                output: serde_json::json!({"ok": true}),
+                display_preview: None,
+                usage: ironclaw_host_api::ResourceUsage::default(),
+            },
+        )))
     }
 
     async fn resume_capability(
@@ -83,6 +125,10 @@ impl HostRuntime for StubHostRuntime {
         &self,
         request: VisibleCapabilityRequest,
     ) -> Result<VisibleCapabilitySurface, HostRuntimeError> {
+        self.visible_provider_trust
+            .lock()
+            .expect("visible provider trust lock")
+            .push(request.provider_trust.clone());
         let capabilities = request
             .context
             .grants
@@ -330,11 +376,14 @@ async fn run_context(label: &str) -> LoopRunContext {
 
 fn test_parts(
     run_context: LoopRunContext,
+    runtime: Arc<StubHostRuntime>,
     shared_io: Arc<SharedStubCapabilityIo>,
     capability_id_filter: HashSet<CapabilityId>,
+    capability_execution_mount_overrides: HashMap<CapabilityId, ironclaw_host_api::MountView>,
+    additional_provider_trust: BTreeMap<ExtensionId, ironclaw_trust::TrustDecision>,
 ) -> RefreshingLocalDevCapabilityPortTestParts {
     RefreshingLocalDevCapabilityPortTestParts {
-        runtime: Arc::new(StubHostRuntime),
+        runtime,
         run_context,
         fallback_user_id: UserId::new("user-stub").expect("user id"),
         workspace_mounts: ironclaw_host_api::MountView::default(),
@@ -354,8 +403,8 @@ fn test_parts(
         persistent_approval_policies: Arc::new(InMemoryPersistentApprovalPolicyStore::new()),
         approval_requests: Arc::new(InMemoryApprovalRequestStore::new()),
         capability_leases: Arc::new(InMemoryCapabilityLeaseStore::new()),
-        capability_execution_mount_overrides: HashMap::new(),
-        additional_provider_trust: BTreeMap::new(),
+        capability_execution_mount_overrides,
+        additional_provider_trust,
         capability_id_filter,
     }
 }
@@ -366,7 +415,14 @@ fn test_parts(
 #[tokio::test]
 async fn port_builds_and_includes_synthetic_capabilities() {
     let shared_io = Arc::new(SharedStubCapabilityIo::new());
-    let parts = test_parts(run_context("builds").await, shared_io, HashSet::new());
+    let parts = test_parts(
+        run_context("builds").await,
+        Arc::new(StubHostRuntime::new()),
+        shared_io,
+        HashSet::new(),
+        HashMap::new(),
+        BTreeMap::new(),
+    );
     let port = create_refreshing_local_dev_capability_port_for_test(parts)
         .await
         .expect("port assembles through the real production factory");
@@ -375,7 +431,7 @@ async fn port_builds_and_includes_synthetic_capabilities() {
     assert!(
         definitions
             .iter()
-            .any(|definition| definition.capability_id.as_str() == "builtin.project_create"),
+            .any(|definition| definition.capability_id.as_str() == PROJECT_CREATE_CAPABILITY_ID),
         "synthetic project_create capability must be present: {definitions:?}"
     );
     assert!(
@@ -394,7 +450,14 @@ async fn capability_id_filter_narrows_visible_surface() {
     let shared_io = Arc::new(SharedStubCapabilityIo::new());
     let mut filter = HashSet::new();
     filter.insert(CapabilityId::new("builtin.echo").expect("capability id"));
-    let parts = test_parts(run_context("filter").await, shared_io, filter);
+    let parts = test_parts(
+        run_context("filter").await,
+        Arc::new(StubHostRuntime::new()),
+        shared_io,
+        filter,
+        HashMap::new(),
+        BTreeMap::new(),
+    );
     let port = create_refreshing_local_dev_capability_port_for_test(parts)
         .await
         .expect("port assembles");
@@ -403,7 +466,7 @@ async fn capability_id_filter_narrows_visible_surface() {
     let builtin_ids: Vec<&str> = definitions
         .iter()
         .map(|definition| definition.capability_id.as_str())
-        .filter(|id| id.starts_with("builtin.") && *id != "builtin.project_create")
+        .filter(|id| id.starts_with("builtin.") && *id != PROJECT_CREATE_CAPABILITY_ID)
         .collect();
     assert_eq!(
         builtin_ids,
@@ -420,7 +483,14 @@ async fn capability_id_filter_narrows_visible_surface() {
 #[tokio::test]
 async fn input_and_result_refs_correlate_through_one_shared_io() {
     let shared_io = Arc::new(SharedStubCapabilityIo::new());
-    let parts = test_parts(run_context("io").await, shared_io.clone(), HashSet::new());
+    let parts = test_parts(
+        run_context("io").await,
+        Arc::new(StubHostRuntime::new()),
+        shared_io.clone(),
+        HashSet::new(),
+        HashMap::new(),
+        BTreeMap::new(),
+    );
     let port = create_refreshing_local_dev_capability_port_for_test(parts)
         .await
         .expect("port assembles");
@@ -478,4 +548,137 @@ async fn input_and_result_refs_correlate_through_one_shared_io() {
         staged_result.is_some(),
         "result_ref must resolve through the SAME shared io the input was staged in"
     );
+}
+
+fn mount_view(alias: &str, target: &str) -> MountView {
+    MountView::new(vec![MountGrant::new(
+        MountAlias::new(alias).expect("valid mount alias"),
+        VirtualPath::new(target).expect("valid virtual path"),
+        MountPermissions::read_write_list_delete(),
+    )])
+    .expect("valid mount view")
+}
+
+/// (v) `capability_execution_mount_overrides` (the review-flagged FIX C
+/// coverage gap): a non-empty override for `builtin.echo` must be the mount
+/// view the STUB host runtime actually sees on `ExecutionContext.mounts` when
+/// that capability is invoked -- not just baked into port construction.
+#[tokio::test]
+async fn capability_execution_mount_overrides_reach_invocation_context() {
+    let shared_io = Arc::new(SharedStubCapabilityIo::new());
+    let runtime = Arc::new(StubHostRuntime::new());
+    let echo_id = CapabilityId::new("builtin.echo").expect("capability id");
+    let override_mounts = mount_view("/override-alias", "/projects/override-target");
+    let mut overrides = HashMap::new();
+    overrides.insert(echo_id.clone(), override_mounts.clone());
+    let parts = test_parts(
+        run_context("mount-override").await,
+        runtime.clone(),
+        shared_io,
+        HashSet::new(),
+        overrides,
+        BTreeMap::new(),
+    );
+    let port = create_refreshing_local_dev_capability_port_for_test(parts)
+        .await
+        .expect("port assembles");
+
+    let tool_call = ProviderToolCall {
+        provider_id: "stub-provider".to_string(),
+        provider_model_id: "stub-model".to_string(),
+        turn_id: Some("turn-1".to_string()),
+        id: "call-1".to_string(),
+        name: ProviderToolName::new("builtin__echo").expect("tool name"),
+        arguments: serde_json::json!({}),
+        response_reasoning: None,
+        reasoning: None,
+        signature: None,
+    };
+    let candidate = port
+        .register_provider_tool_call(RegisterProviderToolCallRequest {
+            tool_call,
+            activity_id: None,
+        })
+        .await
+        .expect("registers the builtin.echo provider tool call");
+
+    port.invoke_capability(CapabilityInvocation {
+        activity_id: candidate.activity_id,
+        surface_version: candidate.surface_version,
+        capability_id: candidate.capability_id,
+        input_ref: candidate.input_ref,
+        approval_resume: None,
+        auth_resume: None,
+    })
+    .await
+    .expect("invokes builtin.echo");
+
+    let invocations = runtime.invocation_contexts();
+    assert_eq!(invocations.len(), 1, "expected exactly one invocation");
+    assert_eq!(
+        invocations[0].mounts, override_mounts,
+        "the override mount, not the default, must reach the invocation ExecutionContext"
+    );
+}
+
+fn distinguishing_trust_decision() -> ironclaw_trust::TrustDecision {
+    ironclaw_trust::TrustDecision {
+        effective_trust: ironclaw_trust::EffectiveTrustClass::user_trusted(),
+        authority_ceiling: ironclaw_trust::AuthorityCeiling {
+            allowed_effects: vec![EffectKind::ReadFilesystem],
+            max_resource_ceiling: None,
+        },
+        // `Bundled` is never produced by `local_dev_visible_capability_request`
+        // itself (which only ever inserts `AdminConfig`), so seeing it back
+        // out proves the test's entry -- not the canonical helper's -- won.
+        provenance: ironclaw_trust::TrustProvenance::Bundled,
+        evaluated_at: chrono::Utc::now(),
+    }
+}
+
+/// (vi) `additional_provider_trust` (the review-flagged FIX D coverage gap):
+/// a non-empty entry must be observable in the `VisibleCapabilityRequest`
+/// the STUB host runtime receives, and -- since `build_inner` merges it in
+/// AFTER the canonical helper's base map -- an entry keyed by the same
+/// provider the canonical helper already populates (`builtin`) must
+/// overwrite the base value.
+#[tokio::test]
+async fn additional_provider_trust_is_forwarded_to_visible_request() {
+    let shared_io = Arc::new(SharedStubCapabilityIo::new());
+    let runtime = Arc::new(StubHostRuntime::new());
+    let builtin_provider = ExtensionId::new("builtin").expect("provider id");
+    let override_trust = distinguishing_trust_decision();
+    let mut additional_provider_trust = BTreeMap::new();
+    additional_provider_trust.insert(builtin_provider.clone(), override_trust.clone());
+    let parts = test_parts(
+        run_context("provider-trust").await,
+        runtime.clone(),
+        shared_io,
+        HashSet::new(),
+        HashMap::new(),
+        additional_provider_trust,
+    );
+    let port = create_refreshing_local_dev_capability_port_for_test(parts)
+        .await
+        .expect("port assembles");
+    // Construction already triggers one `visible_capabilities` refresh; drive
+    // a second one explicitly through the public port API so the assertion
+    // exercises the same seam a real loop run would.
+    port.visible_capabilities(ironclaw_turns::run_profile::VisibleCapabilityRequest)
+        .await
+        .expect("visible capabilities refresh");
+
+    let observed = runtime.visible_provider_trust();
+    assert!(
+        !observed.is_empty(),
+        "host runtime must have observed at least one visible-capabilities request"
+    );
+    for provider_trust in &observed {
+        assert_eq!(
+            provider_trust.get(&builtin_provider),
+            Some(&override_trust),
+            "additional_provider_trust must overwrite the canonical helper's base \
+             `builtin` provider-trust entry, not merge alongside it"
+        );
+    }
 }

--- a/crates/ironclaw_reborn_composition/tests/refreshing_capability_port_test_support.rs
+++ b/crates/ironclaw_reborn_composition/tests/refreshing_capability_port_test_support.rs
@@ -1,0 +1,481 @@
+//! Crate-tier RED-then-GREEN coverage for the harness-port-seam P1 Change 1
+//! test-support constructor: `test_support::create_refreshing_local_dev_capability_port_for_test`
+//! must drive the REAL production capability-port factory
+//! (`create_refreshing_local_dev_capability_port`) with in-crate stub
+//! doubles, not a hand-rebuilt wrap order.
+//!
+//! Stubs here are intentionally minimal: a `HostRuntime` that echoes back a
+//! `VisibleCapability` per granted capability id (so `capability_id_filter`
+//! narrowing is observable), and a shared input/result io double standing in
+//! for production's `LocalDevCapabilityIo` (one object, both roles).
+
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::sync::Arc;
+use std::sync::Mutex as StdMutex;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use async_trait::async_trait;
+use ironclaw_approvals::{
+    InMemoryAutoApproveSettingStore, InMemoryCapabilityPermissionOverrideStore,
+    InMemoryPersistentApprovalPolicyStore,
+};
+use ironclaw_authorization::InMemoryCapabilityLeaseStore;
+use ironclaw_host_api::{
+    AgentId, CapabilityDescriptor, CapabilityId, EffectKind, ExtensionId, PermissionMode,
+    ProjectId, ProviderToolName, ResourceEstimate, RuntimeKind, TenantId, ThreadId, UserId,
+};
+use ironclaw_host_runtime::RuntimeCapabilityOutcome;
+use ironclaw_host_runtime::{
+    CancelRuntimeWorkOutcome, CancelRuntimeWorkRequest, CapabilitySurfaceVersion, HostRuntime,
+    HostRuntimeError, HostRuntimeHealth, HostRuntimeStatus, RuntimeCapabilityRequest,
+    RuntimeCapabilityResumeRequest, RuntimeStatusRequest, VisibleCapability,
+    VisibleCapabilityAccess, VisibleCapabilityRequest, VisibleCapabilitySurface,
+};
+use ironclaw_loop_support::{
+    CapabilityResultWrite, CapabilityWriteResult, LoopCapabilityInputResolver,
+    LoopCapabilityResultWriter,
+};
+use ironclaw_product_workflow::{
+    ProjectCaller, ProjectService, ProjectServiceError, RebornAddMemberRequest,
+    RebornCreateProjectRequest, RebornDeleteProjectRequest, RebornGetProjectRequest,
+    RebornListMembersRequest, RebornListMembersResponse, RebornListProjectsRequest,
+    RebornListProjectsResponse, RebornProjectInfo, RebornProjectMemberInfo, RebornProjectResponse,
+    RebornProjectRole, RebornProjectState, RebornRemoveMemberRequest,
+    RebornUpdateMemberRoleRequest, RebornUpdateProjectRequest,
+};
+use ironclaw_reborn_composition::test_support::{
+    RefreshingLocalDevCapabilityPortTestParts, create_refreshing_local_dev_capability_port_for_test,
+};
+use ironclaw_run_state::InMemoryApprovalRequestStore;
+use ironclaw_turns::run_profile::{
+    AgentLoopHostError, AgentLoopHostErrorKind, CapabilityInputRef, CapabilityInvocation,
+    CapabilityOutcome, InMemoryLoopHostMilestoneSink, InMemoryRunProfileResolver, LoopRunContext,
+    ProviderToolCall, RegisterProviderToolCallRequest, RunProfileResolutionRequest,
+};
+use ironclaw_turns::{RunProfileResolver, TurnId, TurnRunId, TurnScope};
+
+/// Echoes a runtime-visible capability for every grant in the request's
+/// context, so `capability_id_filter` narrowing (applied upstream of this
+/// stub, in `build_inner`) is directly observable in `tool_definitions()`.
+struct StubHostRuntime;
+
+#[async_trait]
+impl HostRuntime for StubHostRuntime {
+    async fn invoke_capability(
+        &self,
+        _request: RuntimeCapabilityRequest,
+    ) -> Result<RuntimeCapabilityOutcome, HostRuntimeError> {
+        Err(HostRuntimeError::unavailable(
+            "stub host runtime does not execute capabilities",
+        ))
+    }
+
+    async fn resume_capability(
+        &self,
+        _request: RuntimeCapabilityResumeRequest,
+    ) -> Result<RuntimeCapabilityOutcome, HostRuntimeError> {
+        Err(HostRuntimeError::unavailable(
+            "stub host runtime does not resume capabilities",
+        ))
+    }
+
+    async fn visible_capabilities(
+        &self,
+        request: VisibleCapabilityRequest,
+    ) -> Result<VisibleCapabilitySurface, HostRuntimeError> {
+        let capabilities = request
+            .context
+            .grants
+            .grants
+            .iter()
+            .map(|grant| VisibleCapability {
+                descriptor: CapabilityDescriptor {
+                    id: grant.capability.clone(),
+                    provider: ExtensionId::new("builtin").expect("static provider id is valid"),
+                    runtime: RuntimeKind::FirstParty,
+                    trust_ceiling: ironclaw_host_api::TrustClass::UserTrusted,
+                    description: format!("stub capability {}", grant.capability.as_str()),
+                    parameters_schema: serde_json::json!({"type": "object", "properties": {}}),
+                    effects: vec![EffectKind::ReadFilesystem],
+                    default_permission: PermissionMode::Allow,
+                    runtime_credentials: Vec::new(),
+                    resource_profile: None,
+                },
+                access: VisibleCapabilityAccess::Available,
+                estimated_resources: ResourceEstimate::default(),
+            })
+            .collect();
+        Ok(VisibleCapabilitySurface {
+            version: CapabilitySurfaceVersion::new("stub-v1").expect("static version is valid"),
+            capabilities,
+        })
+    }
+
+    async fn cancel_work(
+        &self,
+        _request: CancelRuntimeWorkRequest,
+    ) -> Result<CancelRuntimeWorkOutcome, HostRuntimeError> {
+        Ok(CancelRuntimeWorkOutcome {
+            cancelled: Vec::new(),
+            already_terminal: Vec::new(),
+            unsupported: Vec::new(),
+        })
+    }
+
+    async fn runtime_status(
+        &self,
+        _request: RuntimeStatusRequest,
+    ) -> Result<HostRuntimeStatus, HostRuntimeError> {
+        Ok(HostRuntimeStatus {
+            active_work: Vec::new(),
+        })
+    }
+
+    async fn health(&self) -> Result<HostRuntimeHealth, HostRuntimeError> {
+        Ok(HostRuntimeHealth::default())
+    }
+}
+
+/// Stands in for production's `LocalDevCapabilityIo`: ONE object implementing
+/// both `LoopCapabilityInputResolver` and `LoopCapabilityResultWriter`, so
+/// `Arc::clone`s into both config fields let input-ref/result-ref correlate
+/// through a single shared store (the invariant the config's shared-io
+/// doc-comment pins).
+struct SharedStubCapabilityIo {
+    inputs: StdMutex<HashMap<String, serde_json::Value>>,
+    results: StdMutex<HashMap<String, serde_json::Value>>,
+    next_id: AtomicU64,
+}
+
+impl SharedStubCapabilityIo {
+    fn new() -> Self {
+        Self {
+            inputs: StdMutex::new(HashMap::new()),
+            results: StdMutex::new(HashMap::new()),
+            next_id: AtomicU64::new(0),
+        }
+    }
+
+    fn staged_result(&self, result_ref: &str) -> Option<serde_json::Value> {
+        self.results
+            .lock()
+            .expect("results lock")
+            .get(result_ref)
+            .cloned()
+    }
+}
+
+#[async_trait]
+impl LoopCapabilityInputResolver for SharedStubCapabilityIo {
+    async fn resolve_capability_input(
+        &self,
+        _run_context: &LoopRunContext,
+        input_ref: &CapabilityInputRef,
+    ) -> Result<serde_json::Value, AgentLoopHostError> {
+        self.inputs
+            .lock()
+            .expect("inputs lock")
+            .get(input_ref.as_str())
+            .cloned()
+            .ok_or_else(|| {
+                AgentLoopHostError::new(AgentLoopHostErrorKind::Internal, "missing staged input")
+            })
+    }
+
+    async fn register_provider_tool_call_input(
+        &self,
+        _run_context: &LoopRunContext,
+        tool_call: &ProviderToolCall,
+    ) -> Result<CapabilityInputRef, AgentLoopHostError> {
+        let n = self.next_id.fetch_add(1, Ordering::SeqCst);
+        let input_ref = CapabilityInputRef::new(format!("input:stub-run:{n}"))
+            .map_err(|reason| AgentLoopHostError::new(AgentLoopHostErrorKind::Internal, reason))?;
+        self.inputs
+            .lock()
+            .expect("inputs lock")
+            .insert(input_ref.as_str().to_string(), tool_call.arguments.clone());
+        Ok(input_ref)
+    }
+}
+
+#[async_trait]
+impl LoopCapabilityResultWriter for SharedStubCapabilityIo {
+    async fn write_capability_result(
+        &self,
+        write: CapabilityResultWrite<'_>,
+    ) -> Result<CapabilityWriteResult, AgentLoopHostError> {
+        let n = self.next_id.fetch_add(1, Ordering::SeqCst);
+        let result_ref = ironclaw_turns::LoopResultRef::new(format!("result:stub-run.{n}"))
+            .map_err(|reason| AgentLoopHostError::new(AgentLoopHostErrorKind::Internal, reason))?;
+        let byte_len = serde_json::to_vec(&write.output)
+            .map(|bytes| bytes.len() as u64)
+            .unwrap_or(0);
+        self.results
+            .lock()
+            .expect("results lock")
+            .insert(result_ref.as_str().to_string(), write.output);
+        Ok(CapabilityWriteResult::without_output_digest(
+            result_ref, byte_len,
+        ))
+    }
+}
+
+/// Always creates a single fixed project; enough for the `project_create`
+/// synthetic capability's dispatch path — this test does not exercise
+/// listing/reading/updating projects.
+struct StubProjectService;
+
+#[async_trait]
+impl ProjectService for StubProjectService {
+    async fn list_projects(
+        &self,
+        _caller: ProjectCaller,
+        _request: RebornListProjectsRequest,
+    ) -> Result<RebornListProjectsResponse, ProjectServiceError> {
+        Err(ProjectServiceError::Unavailable)
+    }
+
+    async fn create_project(
+        &self,
+        caller: ProjectCaller,
+        request: RebornCreateProjectRequest,
+    ) -> Result<RebornProjectResponse, ProjectServiceError> {
+        let now = chrono::Utc::now();
+        Ok(RebornProjectResponse {
+            project: RebornProjectInfo {
+                project_id: format!("project-{}", caller.user_id.as_str()),
+                name: request.name,
+                description: request.description,
+                icon: None,
+                color: None,
+                metadata: serde_json::Value::Null,
+                state: RebornProjectState::Active,
+                role: RebornProjectRole::Owner,
+                created_at: now,
+                updated_at: now,
+            },
+        })
+    }
+
+    async fn get_project(
+        &self,
+        _caller: ProjectCaller,
+        _request: RebornGetProjectRequest,
+    ) -> Result<RebornProjectResponse, ProjectServiceError> {
+        Err(ProjectServiceError::NotFound)
+    }
+
+    async fn update_project(
+        &self,
+        _caller: ProjectCaller,
+        _request: RebornUpdateProjectRequest,
+    ) -> Result<RebornProjectResponse, ProjectServiceError> {
+        Err(ProjectServiceError::NotFound)
+    }
+
+    async fn delete_project(
+        &self,
+        _caller: ProjectCaller,
+        _request: RebornDeleteProjectRequest,
+    ) -> Result<(), ProjectServiceError> {
+        Err(ProjectServiceError::NotFound)
+    }
+
+    async fn list_members(
+        &self,
+        _caller: ProjectCaller,
+        _request: RebornListMembersRequest,
+    ) -> Result<RebornListMembersResponse, ProjectServiceError> {
+        Err(ProjectServiceError::NotFound)
+    }
+
+    async fn add_member(
+        &self,
+        _caller: ProjectCaller,
+        _request: RebornAddMemberRequest,
+    ) -> Result<RebornProjectMemberInfo, ProjectServiceError> {
+        Err(ProjectServiceError::NotFound)
+    }
+
+    async fn update_member_role(
+        &self,
+        _caller: ProjectCaller,
+        _request: RebornUpdateMemberRoleRequest,
+    ) -> Result<RebornProjectMemberInfo, ProjectServiceError> {
+        Err(ProjectServiceError::NotFound)
+    }
+
+    async fn remove_member(
+        &self,
+        _caller: ProjectCaller,
+        _request: RebornRemoveMemberRequest,
+    ) -> Result<(), ProjectServiceError> {
+        Err(ProjectServiceError::NotFound)
+    }
+}
+
+async fn run_context(label: &str) -> LoopRunContext {
+    let scope = TurnScope::new(
+        TenantId::new(format!("tenant-{label}")).expect("tenant id"),
+        Some(AgentId::new(format!("agent-{label}")).expect("agent id")),
+        Some(ProjectId::new(format!("project-{label}")).expect("project id")),
+        ThreadId::new(format!("thread-{label}")).expect("thread id"),
+    );
+    let resolved = InMemoryRunProfileResolver::default()
+        .resolve_run_profile(RunProfileResolutionRequest::interactive_default())
+        .await
+        .expect("profile resolves");
+    LoopRunContext::new(scope, TurnId::new(), TurnRunId::new(), resolved)
+}
+
+fn test_parts(
+    run_context: LoopRunContext,
+    shared_io: Arc<SharedStubCapabilityIo>,
+    capability_id_filter: HashSet<CapabilityId>,
+) -> RefreshingLocalDevCapabilityPortTestParts {
+    RefreshingLocalDevCapabilityPortTestParts {
+        runtime: Arc::new(StubHostRuntime),
+        run_context,
+        fallback_user_id: UserId::new("user-stub").expect("user id"),
+        workspace_mounts: ironclaw_host_api::MountView::default(),
+        skill_mounts: ironclaw_host_api::MountView::default(),
+        memory_mounts: ironclaw_host_api::MountView::default(),
+        system_extensions_lifecycle_mounts: ironclaw_host_api::MountView::default(),
+        input_resolver: shared_io.clone(),
+        result_writer: shared_io,
+        milestone_sink: Arc::new(InMemoryLoopHostMilestoneSink::default()),
+        skill_activation_source: None,
+        project_service: Arc::new(StubProjectService),
+        trajectory_observer: None,
+        outbound_preferences_facade: None,
+        outbound_delivery_target_set_requires_approval: false,
+        tool_permission_overrides: Arc::new(InMemoryCapabilityPermissionOverrideStore::new()),
+        auto_approve_settings: Arc::new(InMemoryAutoApproveSettingStore::new()),
+        persistent_approval_policies: Arc::new(InMemoryPersistentApprovalPolicyStore::new()),
+        approval_requests: Arc::new(InMemoryApprovalRequestStore::new()),
+        capability_leases: Arc::new(InMemoryCapabilityLeaseStore::new()),
+        capability_execution_mount_overrides: HashMap::new(),
+        additional_provider_trust: BTreeMap::new(),
+        capability_id_filter,
+    }
+}
+
+/// (i) the port builds and (ii) `tool_definitions()` includes the mandatory
+/// `project_create` synthetic capability alongside the stub HostRuntime's
+/// builtin-policy-derived capabilities.
+#[tokio::test]
+async fn port_builds_and_includes_synthetic_capabilities() {
+    let shared_io = Arc::new(SharedStubCapabilityIo::new());
+    let parts = test_parts(run_context("builds").await, shared_io, HashSet::new());
+    let port = create_refreshing_local_dev_capability_port_for_test(parts)
+        .await
+        .expect("port assembles through the real production factory");
+
+    let definitions = port.tool_definitions().expect("tool definitions");
+    assert!(
+        definitions
+            .iter()
+            .any(|definition| definition.capability_id.as_str() == "builtin.project_create"),
+        "synthetic project_create capability must be present: {definitions:?}"
+    );
+    assert!(
+        definitions
+            .iter()
+            .any(|definition| definition.capability_id.as_str() == "builtin.echo"),
+        "stub host-runtime builtin capability must be present: {definitions:?}"
+    );
+}
+
+/// (iii) `capability_id_filter` narrows the builtin-policy-derived surface
+/// (synthetic capabilities are unaffected, since they bypass the filtered
+/// grants entirely).
+#[tokio::test]
+async fn capability_id_filter_narrows_visible_surface() {
+    let shared_io = Arc::new(SharedStubCapabilityIo::new());
+    let mut filter = HashSet::new();
+    filter.insert(CapabilityId::new("builtin.echo").expect("capability id"));
+    let parts = test_parts(run_context("filter").await, shared_io, filter);
+    let port = create_refreshing_local_dev_capability_port_for_test(parts)
+        .await
+        .expect("port assembles");
+
+    let definitions = port.tool_definitions().expect("tool definitions");
+    let builtin_ids: Vec<&str> = definitions
+        .iter()
+        .map(|definition| definition.capability_id.as_str())
+        .filter(|id| id.starts_with("builtin.") && *id != "builtin.project_create")
+        .collect();
+    assert_eq!(
+        builtin_ids,
+        vec!["builtin.echo"],
+        "only the filtered-in builtin capability should remain: {definitions:?}"
+    );
+}
+
+/// (iv) input-ref/result-ref correlate through ONE shared io: register a
+/// provider tool call for `project_create`, invoke it, and confirm the
+/// result staged under the returned `result_ref` is readable back through
+/// the SAME `SharedStubCapabilityIo` the config's `input_resolver` and
+/// `result_writer` both point at.
+#[tokio::test]
+async fn input_and_result_refs_correlate_through_one_shared_io() {
+    let shared_io = Arc::new(SharedStubCapabilityIo::new());
+    let parts = test_parts(run_context("io").await, shared_io.clone(), HashSet::new());
+    let port = create_refreshing_local_dev_capability_port_for_test(parts)
+        .await
+        .expect("port assembles");
+
+    let tool_call = ProviderToolCall {
+        provider_id: "stub-provider".to_string(),
+        provider_model_id: "stub-model".to_string(),
+        turn_id: Some("turn-1".to_string()),
+        id: "call-1".to_string(),
+        name: ProviderToolName::new("builtin__project_create").expect("tool name"),
+        arguments: serde_json::json!({"name": "My Project"}),
+        response_reasoning: None,
+        reasoning: None,
+        signature: None,
+    };
+    let candidate = port
+        .register_provider_tool_call(RegisterProviderToolCallRequest {
+            tool_call,
+            activity_id: None,
+        })
+        .await
+        .expect("registers the project_create provider tool call");
+
+    // The input the synthetic capability will read back is staged under
+    // `candidate.input_ref` in `shared_io` -- resolve it directly to confirm
+    // the SAME io object served the registration.
+    let staged_input = shared_io
+        .inputs
+        .lock()
+        .expect("inputs lock")
+        .get(candidate.input_ref.as_str())
+        .cloned();
+    assert_eq!(
+        staged_input,
+        Some(serde_json::json!({"name": "My Project"}))
+    );
+
+    let outcome = port
+        .invoke_capability(CapabilityInvocation {
+            activity_id: candidate.activity_id,
+            surface_version: candidate.surface_version,
+            capability_id: candidate.capability_id,
+            input_ref: candidate.input_ref,
+            approval_resume: None,
+            auth_resume: None,
+        })
+        .await
+        .expect("invokes project_create");
+
+    let CapabilityOutcome::Completed(message) = outcome else {
+        panic!("expected a completed outcome, got {outcome:?}");
+    };
+    let staged_result = shared_io.staged_result(message.result_ref.as_str());
+    assert!(
+        staged_result.is_some(),
+        "result_ref must resolve through the SAME shared io the input was staged in"
+    );
+}

--- a/crates/ironclaw_reborn_composition/tests/refreshing_capability_port_test_support.rs
+++ b/crates/ironclaw_reborn_composition/tests/refreshing_capability_port_test_support.rs
@@ -694,3 +694,133 @@ async fn additional_provider_trust_is_forwarded_to_visible_request() {
         );
     }
 }
+
+/// Review follow-up: pins the "many" edge of all three collection-valued
+/// config knobs together in one port build, since the five tests above each
+/// exercise a single entry. `capability_id_filter` must keep BOTH listed ids
+/// (dropping the rest); `capability_execution_mount_overrides` must resolve
+/// EACH capability's invocation against its OWN mount, not the other's or the
+/// default; `additional_provider_trust` must land BOTH entries in the
+/// observed provider-trust map. See PR #5950 review.
+#[tokio::test]
+async fn multi_entry_collection_knobs_round_trip() {
+    let shared_io = Arc::new(SharedStubCapabilityIo::new());
+    let runtime = Arc::new(StubHostRuntime::new());
+
+    let echo_id = CapabilityId::new("builtin.echo").expect("capability id");
+    let time_id = CapabilityId::new("builtin.time").expect("capability id");
+    let mut filter = HashSet::new();
+    filter.insert(echo_id.clone());
+    filter.insert(time_id.clone());
+
+    let echo_mounts = mount_view("/echo-alias", "/projects/echo-target");
+    let time_mounts = mount_view("/time-alias", "/projects/time-target");
+    let mut overrides = HashMap::new();
+    overrides.insert(echo_id.clone(), echo_mounts.clone());
+    overrides.insert(time_id.clone(), time_mounts.clone());
+
+    let builtin_provider = ExtensionId::new("builtin").expect("provider id");
+    let other_provider = ExtensionId::new("other-provider").expect("provider id");
+    // `builtin_trust` overrides the "builtin" provider used to invoke both
+    // capabilities below, so its ceiling must cover both grants' effects
+    // (`dispatch_capability`/`read_filesystem`/`write_filesystem` per
+    // local_dev_capability_policy.toml) or invocation is denied as untrusted.
+    let mut builtin_trust = distinguishing_trust_decision();
+    builtin_trust.authority_ceiling.allowed_effects = vec![
+        EffectKind::DispatchCapability,
+        EffectKind::ReadFilesystem,
+        EffectKind::WriteFilesystem,
+    ];
+    let other_trust = distinguishing_trust_decision();
+    let mut additional_provider_trust = BTreeMap::new();
+    additional_provider_trust.insert(builtin_provider.clone(), builtin_trust.clone());
+    additional_provider_trust.insert(other_provider.clone(), other_trust.clone());
+
+    let parts = test_parts(
+        run_context("multi-entry").await,
+        runtime.clone(),
+        shared_io,
+        filter,
+        overrides,
+        additional_provider_trust,
+    );
+    let port = create_refreshing_local_dev_capability_port_for_test(parts)
+        .await
+        .expect("port assembles");
+
+    // capability_id_filter: both listed builtin ids survive, everything else
+    // (e.g. builtin.shell, builtin.read_file, ...) is dropped.
+    let definitions = port.tool_definitions().expect("tool definitions");
+    let mut builtin_ids: Vec<&str> = definitions
+        .iter()
+        .map(|definition| definition.capability_id.as_str())
+        .filter(|id| id.starts_with("builtin.") && *id != PROJECT_CREATE_CAPABILITY_ID)
+        .collect();
+    builtin_ids.sort_unstable();
+    assert_eq!(
+        builtin_ids,
+        vec!["builtin.echo", "builtin.time"],
+        "both filtered-in builtin capabilities should remain, and no others: {definitions:?}"
+    );
+
+    // capability_execution_mount_overrides: invoke both and check each one's
+    // ExecutionContext carries ITS OWN override mount, not the other's.
+    async fn invoke(
+        port: &dyn ironclaw_turns::run_profile::LoopCapabilityPort,
+        provider_tool_name: &str,
+    ) {
+        let tool_call = ProviderToolCall {
+            provider_id: "stub-provider".to_string(),
+            provider_model_id: "stub-model".to_string(),
+            turn_id: Some("turn-1".to_string()),
+            id: format!("call-{provider_tool_name}"),
+            name: ProviderToolName::new(provider_tool_name).expect("tool name"),
+            arguments: serde_json::json!({}),
+            response_reasoning: None,
+            reasoning: None,
+            signature: None,
+        };
+        let candidate = port
+            .register_provider_tool_call(RegisterProviderToolCallRequest {
+                tool_call,
+                activity_id: None,
+            })
+            .await
+            .expect("registers the provider tool call");
+        port.invoke_capability(CapabilityInvocation {
+            activity_id: candidate.activity_id,
+            surface_version: candidate.surface_version,
+            capability_id: candidate.capability_id,
+            input_ref: candidate.input_ref,
+            approval_resume: None,
+            auth_resume: None,
+        })
+        .await
+        .expect("invokes capability");
+    }
+    invoke(port.as_ref(), "builtin__echo").await;
+    invoke(port.as_ref(), "builtin__time").await;
+
+    let invocations = runtime.invocation_contexts();
+    assert_eq!(invocations.len(), 2, "expected exactly two invocations");
+    assert_eq!(
+        invocations[0].mounts, echo_mounts,
+        "builtin.echo must resolve against its own override mount"
+    );
+    assert_eq!(
+        invocations[1].mounts, time_mounts,
+        "builtin.time must resolve against its own override mount, not builtin.echo's"
+    );
+
+    // additional_provider_trust: both entries land in the observed
+    // visible_capabilities provider-trust map.
+    port.visible_capabilities(ironclaw_turns::run_profile::VisibleCapabilityRequest)
+        .await
+        .expect("visible capabilities refresh");
+    let observed = runtime.visible_provider_trust();
+    let last = observed
+        .last()
+        .expect("host runtime must have observed at least one visible-capabilities request");
+    assert_eq!(last.get(&builtin_provider), Some(&builtin_trust));
+    assert_eq!(last.get(&other_provider), Some(&other_trust));
+}

--- a/crates/ironclaw_reborn_composition/tests/refreshing_capability_port_test_support.rs
+++ b/crates/ironclaw_reborn_composition/tests/refreshing_capability_port_test_support.rs
@@ -442,9 +442,21 @@ async fn port_builds_and_includes_synthetic_capabilities() {
     );
 }
 
-/// (iii) `capability_id_filter` narrows the builtin-policy-derived surface
-/// (synthetic capabilities are unaffected, since they bypass the filtered
-/// grants entirely).
+/// (iii) `capability_id_filter` narrows the FULL granted-capability set
+/// (builtin AND any activated extension grants -- see the config field's
+/// doc-comment), not a builtin-only subset. Synthetic capabilities are
+/// unaffected, since they bypass the filtered grants entirely.
+///
+/// This test only exercises builtin grants because there is no cheap way to
+/// inject an extension-grant fixture from this external integration-test
+/// crate: `LocalDevExtensionSurfaceSource`'s test constructors
+/// (`from_surface`/`from_active_capabilities`) are `#[cfg(test)]`-gated to
+/// the crate's own unit tests, and `RefreshingLocalDevCapabilityPortTestParts`
+/// does not expose `extension_surface_source` at all -- the test-support
+/// constructor always wires `LocalDevExtensionSurfaceSource::new(None)`
+/// (empty extension surface). The whole-set semantic is pinned by the
+/// doc-comment on `RefreshingLocalDevCapabilityPortConfig::capability_id_filter`
+/// and the inline comment at its `retain` call site in `build_inner`.
 #[tokio::test]
 async fn capability_id_filter_narrows_visible_surface() {
     let shared_io = Arc::new(SharedStubCapabilityIo::new());


### PR DESCRIPTION
## Summary

PR-A of the harness-port-seam plan: makes the production LocalDev capability-port assembly consumable by the integration harness, so the harness can stop hand-rebuilding the port wrapper stack (that switch is PR-B, a separate follow-up).

Background: the integration harness currently reproduces only 3 of production's 7 port layers — `wrap_local_dev_surface_disclosure`, `wrap_local_dev_external_tools`, the StaleSurface refresh wrapper, and the projection result writer are silently absent, which is why PR #5902's `builtin.result_read` could only get crate-tier coverage. This PR adds the seam that fixes the class.

## Changes (purely additive — production behavior byte-identical)

- **`RefreshingLocalDevCapabilityPortConfig`**: three new empty-by-default fields, each feeding an existing mechanism: `capability_execution_mount_overrides` (→ `with_capability_execution_mount`; the factory bakes mounts at construction, so config-time is the only possible seam), `additional_provider_trust` (→ `provider_trust.extend()` before `.with_provider_trust(..)`), `capability_id_filter` (grant narrowing after `builtin_grants`; empty = production's no-filtering). Documented exception to the test-only-populated-knob smell (`architecture.md` #2): each field's doc-comment states it's always empty at the sole production call site, and no post-construction seam exists.
- **`test-support` constructor** (`create_refreshing_local_dev_capability_port_for_test`): drives the REAL production factory with injectable trait-object parts; parts callers don't supply get no-op production types (`LocalDevExtensionSurfaceSource::new(None)`, `InMemoryExternalToolCatalog`, the same `local_dev_capability_policy()` singleton production uses). Never calls `capability_wiring`. Follows the house forwarder/accessor split; zero bytes in production builds.
- Visibility widening `pub(super)` → `pub(crate)` on the config + factory, matching the existing `*_for_test` forwarder precedent.

## Tests

`tests/refreshing_capability_port_test_support.rs` (runs under `--features test-support`):
- `port_builds_and_includes_synthetic_capabilities`
- `capability_id_filter_narrows_visible_surface` (asserts the exact remaining id set)
- `input_and_result_refs_correlate_through_one_shared_io` (pins the one-`LocalDevCapabilityIo`-both-roles invariant)

Deferred with citation: direct assertions for `capability_execution_mount_overrides` and `additional_provider_trust` land with PR-B, whose GitHub/MCP harness lanes exercise both seams end-to-end (thermo review finding 1 — agreed not blocking a purely-additive PR with no callers yet).

## Verification

- `cargo test -p ironclaw_reborn_composition --features test-support` — 1061 lib + all test targets green
- `cargo clippy --all --benches --tests --examples --all-features` — zero warnings
- `cargo build --tests --all-features` — green
- Reviewed: thermo-nuclear (SHIP) + code review (2 nits, fixed: stale line citations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)