### PR TITLE
perf(agent-loop): raise default loop iteration ceiling 32 → 256

### DIFF
--- a/crates/ironclaw_agent_loop/src/default_planner.rs
+++ b/crates/ironclaw_agent_loop/src/default_planner.rs
@@ -326,7 +326,7 @@ mod tests {
         let planner = DefaultPlanner::compose_default();
         let state = LoopExecutionState::initial_for_run(&test_run_context());
 
-        assert_eq!(planner.budget().iteration_limit(&state), 32);
+        assert_eq!(planner.budget().iteration_limit(&state), 256);
         assert_eq!(planner.batch().policy(&state, &[]), BatchPolicy::Parallel);
 
         let filter = planner.capability().filter(&state).await;

--- a/crates/ironclaw_agent_loop/src/families/mod.rs
+++ b/crates/ironclaw_agent_loop/src/families/mod.rs
@@ -26,7 +26,7 @@ const DEFAULT_FAMILY_FINGERPRINT: &[u8] = concat!(
     "reply_admission:DefaultReplyAdmissionStrategy(reject_empty_and_provider_transcript_artifacts),",
     "stop:DefaultStopConditionStrategy(window=5,repeat=3,failure_run=3,rejected_reply=invalid_model_output),",
     "drain:DefaultInputDrainStrategy(steering=true,followup=true),",
-    "budget:DefaultBudgetStrategy(iteration_limit=32,wall_clock_limit=none)"
+    "budget:DefaultBudgetStrategy(iteration_limit=256,wall_clock_limit=none)"
 )
 .as_bytes();
 
@@ -35,8 +35,8 @@ const DEFAULT_FAMILY_FINGERPRINT: &[u8] = concat!(
 /// Update this digest when the default family composition, planner behavior, or
 /// identity schema changes in a replay-relevant way.
 pub const DEFAULT_FAMILY_DIGEST: ComponentDigest = ComponentDigest([
-    0xdd, 0x1f, 0x20, 0xe1, 0x17, 0xde, 0xcb, 0xe2, 0x2d, 0x48, 0x15, 0x8b, 0x05, 0x19, 0x27, 0xc4,
-    0x2f, 0xf6, 0x85, 0xd9, 0x43, 0x27, 0x25, 0x37, 0xe8, 0x38, 0x7c, 0xe6, 0xd1, 0xe5, 0xe7, 0x25,
+    0x64, 0xda, 0x2c, 0x33, 0x7d, 0x86, 0x96, 0x50, 0x4e, 0xde, 0x0a, 0x9e, 0xf1, 0xed, 0xf6, 0x13,
+    0x27, 0xf0, 0x79, 0xaf, 0xf2, 0x8e, 0xed, 0x57, 0x8f, 0xf7, 0x06, 0x08, 0x39, 0x2d, 0xfa, 0xcf,
 ]);
 
 /// The default loop family: the text-tool-use baseline.
@@ -51,7 +51,7 @@ pub fn default() -> LoopFamily {
 /// The default loop family with a caller-supplied iteration limit.
 ///
 /// Intended for test and local harnesses that need to exercise the hard budget
-/// path without waiting for the production default of 32 iterations.
+/// path without waiting for the production default of 256 iterations.
 pub fn default_with_iteration_limit(iteration_limit: u32) -> LoopFamily {
     let planner = DefaultPlanner::compose_default().with_budget(Arc::new(DefaultBudgetStrategy {
         iteration_limit,

--- a/crates/ironclaw_agent_loop/src/strategies/budget.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/budget.rs
@@ -22,14 +22,21 @@ pub(crate) trait BudgetStrategy: Send + Sync {
 #[allow(dead_code)]
 fn assert_budget_strategy_object_safe(_: &dyn BudgetStrategy) {}
 
-/// Reference baseline `BudgetStrategy`: 32-iteration cap with no wall-clock
+/// Reference baseline `BudgetStrategy`: 256-iteration cap with no wall-clock
 /// limit.
 ///
-/// The 32-iteration ceiling is the first safety net. Loop families that need
+/// The iteration ceiling is the first safety net. Loop families that need
 /// shorter or longer budgets construct this struct directly.
+///
+/// Default is `256`. The prior `32` was too low for legitimately tool-heavy
+/// turns — e.g. reading a large document/log in chunks and then computing over
+/// it — which exhausted the cap mid-task and fail-closed with no final answer.
+/// 256 leaves ample headroom for such turns while still bounding a runaway loop;
+/// it is a ceiling, so well-behaved turns (the vast majority, which finish in a
+/// handful of iterations) are unaffected.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DefaultBudgetStrategy {
-    /// Hard ceiling on iteration count. Default `32`.
+    /// Hard ceiling on iteration count. Default `256`.
     pub iteration_limit: u32,
     /// Optional wall-clock cap. Default `None` (no limit).
     pub wall_clock_limit: Option<Duration>,
@@ -38,7 +45,7 @@ pub struct DefaultBudgetStrategy {
 impl Default for DefaultBudgetStrategy {
     fn default() -> Self {
         Self {
-            iteration_limit: 32,
+            iteration_limit: 256,
             wall_clock_limit: None,
         }
     }
@@ -85,16 +92,16 @@ mod tests {
                 strategy.iteration_limit(&state),
                 strategy.wall_clock_limit(&state)
             ),
-            (32, None)
+            (256, None)
         );
     }
 
     #[test]
-    fn default_budget_strategy_returns_32_iterations_no_wall_clock() {
+    fn default_budget_strategy_returns_256_iterations_no_wall_clock() {
         let strategy = DefaultBudgetStrategy::default();
         let state = LoopExecutionState::initial_for_run(&test_run_context());
 
-        assert_eq!(strategy.iteration_limit(&state), 32);
+        assert_eq!(strategy.iteration_limit(&state), 256);
         assert_eq!(strategy.wall_clock_limit(&state), None);
     }
 


### PR DESCRIPTION
## What
Raise `DefaultBudgetStrategy`'s default iteration ceiling from **32 → 256**.

## Why
32 is too low for legitimately tool-heavy turns — reading a large document/log in chunks and then computing over it. Such turns exhaust the cap mid-task and the loop **fail-closes with no final answer**: the model has done the work but never reaches the point of writing its output / synthesizing a reply.

Observed concretely on reborn PinchBench tasks (large gov-meeting-transcript QA, multi-chunk log analysis). Raising the reborn loop iteration limit via `IRONCLAW_REBORN_PLANNED_DEFAULT_ITERATION_LIMIT` (which feeds the same budget-strategy limit) flipped consistently-failing tasks — e.g. a syslog-analysis task **0.35 → 0.92** (it was hitting the 32-call cap). This makes that headroom the default so production reborn benefits, not just an env-overridden bench run.

It's a **ceiling, not a target**: the vast majority of turns finish in a handful of iterations and are unaffected. It still bounds a genuine runaway loop — just at a level that doesn't sever real work.

## Changes
- `DefaultBudgetStrategy::default().iteration_limit`: 32 → 256
- Updated the default-family fingerprint string and **recomputed `DEFAULT_FAMILY_DIGEST`** (BLAKE3 of the fingerprint) — replay-relevant identity change.
- Updated the budget / default_planner tests that pinned 32.
- **Unchanged:** subagent family (16), and `ResourceBudgetPolicy` model/capability-call caps.

## Tests
`cargo test -p ironclaw_agent_loop --lib` → **375 passed, 0 failed** (incl. the recomputed default-family digest test and `default_budget_strategy_returns_256_iterations`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)