### PR TITLE
skills/coding: add Verify Before You Finish discipline

### DIFF
--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -7,12 +7,10 @@ activation:
     - "code review"
     - "review changes"
     - "review diff"
-    - "review pr"
     - "review pull request"
     - "review commit"
-    - "review my"
   patterns:
-    - "(?i)review\\s+(this|my|the|these|that|latest|recent)\\s+(code|change|changes|diff|PR|pull request|commit)"
+    - "(?i)review\\s+(?:(this|my|the|these|that|latest|recent)\\s+)?(code|change|changes|diff|\\bPR\\b|pull request|commit)"
     - "(?i)(check|look at|inspect)\\s+(this|my|the|these)\\s+(changes|diff|code)"
     - "(?i)review\\s+[a-z0-9._-]+/[a-z0-9._-]+\\s+#?\\d+"
   tags:

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -4,12 +4,16 @@ version: "2.0.0"
 description: Paranoid architect review of code changes for bugs, security, missing tests, and undocumented assumptions. Works on local git diffs OR a GitHub pull request (e.g. `owner/repo N`). For PRs, can post findings as line-level review comments.
 activation:
   keywords:
-    - "review"
     - "code review"
     - "review changes"
+    - "review diff"
+    - "review pr"
+    - "review pull request"
+    - "review commit"
+    - "review my"
   patterns:
-    - "(?i)review\\s.*(code|changes|diff|PR|pull request|commit)"
-    - "(?i)(check|look at|inspect)\\s.*(changes|diff|code)"
+    - "(?i)review\\s+(this|my|the|these|that|latest|recent)\\s+(code|change|changes|diff|PR|pull request|commit)"
+    - "(?i)(check|look at|inspect)\\s+(this|my|the|these)\\s+(changes|diff|code)"
     - "(?i)review\\s+[a-z0-9._-]+/[a-z0-9._-]+\\s+#?\\d+"
   tags:
     - "code-review"

--- a/skills/coding/SKILL.md
+++ b/skills/coding/SKILL.md
@@ -33,7 +33,7 @@ activation:
   tags:
     - "development"
     - "coding"
-  max_context_tokens: 1500
+  max_context_tokens: 1900
 ---
 
 # Coding Best Practices
@@ -60,3 +60,13 @@ activation:
 - Preserve existing code style and conventions. Match the indentation, naming, and patterns of surrounding code.
 - Test after changes when test infrastructure exists. Use `shell` to run the project's test command.
 - Don't add error handling, fallbacks, or validation for scenarios that can't happen. Trust internal code and framework guarantees.
+
+## Verify Before You Finish
+
+A fix is not done when the code looks right — it is done when you have watched it work and watched everything around it keep working.
+
+- **Reproduce first.** Before changing code, reproduce the reported problem (a failing test, a minimal script, a command) and confirm it fails the way the issue describes. If you can't reproduce it, say so instead of fixing blind.
+- **Re-run the reproduction after the fix** and confirm the behavior actually changed.
+- **Run the existing tests for every file you modified** — the sibling/module test suite, not just your reproduction. Fixes that hardcode the new behavior often break the old one (e.g. forcing a flag unconditionally when the correct fix is conditional on context).
+- **A test you broke is your bug.** If a previously-passing test fails after your change, the fix is wrong or too broad — narrow it until both the new and old behavior pass. Never rationalize a newly-failing test as "unrelated" without proving it fails before your change too.
+- **Re-read the final diff before finishing.** Every hunk must be necessary for the fix; revert stray edits, leftover debug output, and drive-by "improvements". Delete any reproduction scripts you created outside the repo's test layout.

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -5,17 +5,20 @@ description: GitHub API integration via HTTP tool with automatic credential inje
 activation:
   keywords:
     - "github"
-    - "issues"
     - "pull request"
-    - "repository"
-    - "commit"
-    - "branch"
+    - "github issue"
+    - "github repo"
+    - "pr comment"
+    - "open a pr"
+    - "create a pr"
+    - "my prs"
   exclude_keywords:
     - "gitlab"
     - "bitbucket"
   patterns:
-    - "(?i)(list|show|get|fetch|open|close|create|file|merge)\\s.*(issue|PR|pull request|repo)"
+    - "(?i)(list|show|get|fetch|open|close|create|file|merge|comment on)\\s.*(pull request|\\bPR\\b)"
     - "(?i)github\\.com"
+    - "(?i)[a-z0-9._-]+/[a-z0-9._-]+#\\d+"
   tags:
     - "git"
     - "code-review"


### PR DESCRIPTION
## Why

Claw-swe-bench failure analysis (run `799636ce`, post nearai/ironclaw#5959) shows the remaining agent failures are verification gaps, not editing gaps:

- `caddyserver__caddy-6115`: fix makes the new secure-request test pass but hardcodes `Secure: true`, breaking the previously-passing plain-HTTP test in the *same file* — never re-run after the edit.
- `gin-gonic__gin-1957`: patch broke 13 previously-passing tests.

The `skills/coding` skill (embedded into the Reborn capability surface via `ironclaw_reborn_composition/build.rs`, activates on coding keywords) already teaches tool usage and minimal-change discipline but says almost nothing about verification.

## What

Adds a **Verify Before You Finish** section, distilled from the claude-code bundled `verify` skill, sized to the observed failure shapes:

- Reproduce first; re-run the reproduction after the fix.
- Run the sibling/module tests for every modified file, not just the reproduction.
- A newly-failing test is your bug — narrow the fix, don't rationalize.
- Re-read the final diff for minimality; delete stray reproduction scripts.

`max_context_tokens` 1500 → 1900 to cover the added section. Prose-only change; the embed build (`cargo build -p ironclaw_reborn_composition`) parses it clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Also: tighten code-review and github skill activation (second commit)

Both skills were injected into every claw-swe-bench system prompt (~7K tokens/call of irrelevant instructions) because generic keywords/patterns ("review", "repository", "commit", `create\s.*issue`) matched the task template text, and the selector qualifies any skill scoring > 0. Activation is now anchored on explicit requests (determiner-bound review phrases, `owner/repo#N`, GitHub-service keywords). Verified against the vendored bench prompt: zero hits for both, while `skills/coding` still activates on 12 keywords.
