### PR TITLE
fix(reborn): skip invalid available-extension manifests at boot catalog load instead of crash-looping (#5966)

### DIFF
--- a/crates/ironclaw_reborn_composition/src/extension_host/available_extension_import.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/available_extension_import.rs
@@ -430,6 +430,103 @@ output_schema_ref = "schemas/search.output.json"
         assert_eq!(catalog.search("slack_bot").count(), 0);
     }
 
+    #[tokio::test]
+    async fn filesystem_catalog_skips_manifest_with_forbidden_trust_instead_of_aborting() {
+        // #5966: pre-#5499 installs materialized bundled first-party manifests
+        // (trust = "first_party_requested") verbatim onto the persistent
+        // volume. Boot rescan stamps filesystem manifests `InstalledLocal`,
+        // which forbids that trust — one stale manifest must be skipped, not
+        // abort the whole catalog load (crash-looping the deployment); the
+        // bundled-assets merge supersedes first-party entries afterwards.
+        let fs = InMemoryBackend::default();
+        for (path, bytes) in importable_tool_bundle_files("aaa-stale") {
+            let bytes = if path == "manifest.toml" {
+                String::from_utf8(bytes)
+                    .unwrap()
+                    .replace("\"third_party\"", "\"first_party_requested\"")
+                    .into_bytes()
+            } else {
+                bytes
+            };
+            fs.write_file(
+                &VirtualPath::new(format!("/system/extensions/aaa-stale/{path}")).unwrap(),
+                &bytes,
+            )
+            .await
+            .unwrap();
+        }
+        for (path, bytes) in importable_tool_bundle_files("uploaded-tool") {
+            fs.write_file(
+                &VirtualPath::new(format!("/system/extensions/uploaded-tool/{path}")).unwrap(),
+                &bytes,
+            )
+            .await
+            .unwrap();
+        }
+
+        let catalog = AvailableExtensionCatalog::from_filesystem_root(
+            &fs,
+            &VirtualPath::new("/system/extensions").unwrap(),
+        )
+        .await
+        .expect("one stale manifest must not abort the catalog load");
+
+        assert!(
+            catalog
+                .search("")
+                .any(|package| package.package_ref.id.as_str() == "uploaded-tool"),
+            "valid extension sorted after the stale one must still load"
+        );
+        assert!(
+            !catalog
+                .search("")
+                .any(|package| package.package_ref.id.as_str() == "aaa-stale"),
+            "stale first-party-trust manifest must be skipped"
+        );
+    }
+
+    #[tokio::test]
+    async fn filesystem_catalog_still_fails_closed_on_transient_manifest_read_error() {
+        // Per-entry fail-open is only for validation failures; infrastructure
+        // IO errors must keep aborting the load so a flaky volume does not
+        // silently drop installed extensions.
+        let error = AvailableExtensionCatalog::from_filesystem_root(
+            &UnreadableManifestFilesystem,
+            &VirtualPath::new("/system/extensions").unwrap(),
+        )
+        .await
+        .expect_err("transient manifest read error must abort the catalog load");
+        assert!(matches!(error, ProductWorkflowError::Transient { .. }));
+    }
+
+    struct UnreadableManifestFilesystem;
+
+    #[async_trait]
+    impl RootFilesystem for UnreadableManifestFilesystem {
+        async fn list_dir(&self, _path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
+            Ok(vec![DirEntry {
+                name: "broken-ext".to_string(),
+                path: VirtualPath::new("/system/extensions/broken-ext").unwrap(),
+                file_type: FileType::Directory,
+            }])
+        }
+
+        async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
+            Err(FilesystemError::NotFound {
+                path: path.clone(),
+                operation: FilesystemOperation::Stat,
+            })
+        }
+
+        async fn read_file(&self, path: &VirtualPath) -> Result<Vec<u8>, FilesystemError> {
+            Err(FilesystemError::Backend {
+                path: path.clone(),
+                operation: FilesystemOperation::ReadFile,
+                reason: "disk unavailable".to_string(),
+            })
+        }
+    }
+
     fn importable_tool_bundle_files(id: &str) -> Vec<(String, Vec<u8>)> {
         let manifest = format!(
             r#"

--- a/crates/ironclaw_reborn_composition/src/extension_host/available_extensions.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/available_extensions.rs
@@ -5,12 +5,13 @@ use std::sync::Arc;
 use ironclaw_auth::SLACK_PERSONAL_PROVIDER_ID;
 use ironclaw_extensions::{
     CapabilityDeclV2, CapabilityVisibility, ExtensionManifestRecord, ExtensionPackage,
-    ExtensionRuntime, ManifestSource,
+    ExtensionRuntime, HostApiContractRegistry, ManifestSource,
 };
-use ironclaw_filesystem::{FileType, FilesystemError, RootFilesystem};
+use ironclaw_filesystem::{DirEntry, FileType, FilesystemError, RootFilesystem};
 use ironclaw_first_party_extensions::is_gsuite_extension_id;
 use ironclaw_host_api::{
-    CapabilityId, ExtensionId, RuntimeCredentialAccountProviderId, VirtualPath, sha256_digest_token,
+    CapabilityId, ExtensionId, HostPortCatalog, RuntimeCredentialAccountProviderId, VirtualPath,
+    sha256_digest_token,
 };
 use ironclaw_product_adapter_registry::product_adapter_sections;
 use ironclaw_product_adapters::ProductSurfaceKind;
@@ -1620,73 +1621,103 @@ where
         if reserved_host_bundled_extension_id(&extension_id) {
             continue;
         }
-        let manifest_path = VirtualPath::new(format!(
-            "{}/manifest.toml",
-            entry.path.as_str().trim_end_matches('/')
-        ))
-        .map_err(map_binding_error)?;
-        let manifest_bytes = match fs.read_file(&manifest_path).await {
-            Ok(bytes) => bytes,
-            Err(FilesystemError::NotFound { .. }) | Err(FilesystemError::MountNotFound { .. }) => {
-                continue;
+        match load_filesystem_package(fs, entry, &host_ports, &contracts).await {
+            Ok(Some(package)) => packages.push(package),
+            Ok(None) => {}
+            // Per-entry validation failure is fail-open: a stale materialized
+            // manifest (e.g. a pre-#5499 first-party copy whose trust
+            // `InstalledLocal` may no longer assert) must not abort the whole
+            // catalog and crash-loop the deployment (#5966); the bundled-assets
+            // merge supersedes first-party ids afterwards. Infrastructure
+            // errors (`Transient`) stay fail-closed so a flaky volume does not
+            // silently drop installed extensions.
+            Err(ProductWorkflowError::InvalidBindingRequest { reason }) => {
+                tracing::warn!(
+                    extension_id = %extension_id,
+                    %reason,
+                    "skipping invalid available extension manifest"
+                );
             }
-            Err(error) => {
-                return Err(ProductWorkflowError::Transient {
-                    reason: format!("failed to read available extension manifest: {error}"),
-                });
-            }
-        };
-        let manifest_toml = String::from_utf8(manifest_bytes).map_err(|error| {
-            ProductWorkflowError::InvalidBindingRequest {
-                reason: format!("available extension manifest is not UTF-8: {error}"),
-            }
-        })?;
-        let record = ExtensionManifestRecord::from_toml_with_contracts(
-            manifest_toml,
-            ManifestSource::InstalledLocal,
-            &host_ports,
-            None,
-            &contracts,
-        )
-        .map_err(map_binding_error)?;
-        let surface_kinds = surface_kinds_from_manifest_record(&record, entry.name.as_str())?;
-        let manifest = record
-            .manifest()
-            .clone()
-            .try_into()
-            .map_err(map_binding_error)?;
-        let package = ExtensionPackage::from_manifest_toml(manifest, entry.path, record.raw_toml())
-            .map_err(map_binding_error)?;
-        // Catalog EVERY file in the extension dir as inline bytes, exactly
-        // like a fresh import. Assets stored as `Filesystem(path)` pointers
-        // into the extension's own materialized dir dangle after `remove`
-        // (which deletes that dir) and break the intended
-        // remove -> available -> reinstall flow with
-        // "failed to read available extension asset"; and cataloging only
-        // manifest + wasm module would lose schemas/prompt docs on reinstall.
-        let assets = inline_extension_dir_assets(fs, &package.root).await?;
-        packages.push(AvailableExtensionPackage {
-            package_ref: LifecyclePackageRef::new(
-                LifecyclePackageKind::Extension,
-                package.id.as_str(),
-            )?,
-            manifest_toml: record.raw_toml().to_string(),
-            // Everything discovered on the filesystem is `InstalledLocal`, per
-            // the `ManifestSource` contract ("Locally installed extension under
-            // `/system/extensions/`"). `HostBundled` — the only tier eligible
-            // for first-party/system trust — is reserved for extensions
-            // compiled into the host binary (`from_first_party_assets`), whose
-            // reserved ids the scan skips above. Uploaded tool bundles
-            // materialize under this root, so stamping discovery `HostBundled`
-            // would let a process restart launder an untrusted upload into
-            // first-party trust (#5459 review: import → restart → install).
-            source: ManifestSource::InstalledLocal,
-            package,
-            surface_kinds,
-            assets,
-        });
+            Err(error) => return Err(error),
+        }
     }
     Ok(packages)
+}
+
+async fn load_filesystem_package<F>(
+    fs: &F,
+    entry: DirEntry,
+    host_ports: &HostPortCatalog,
+    contracts: &HostApiContractRegistry,
+) -> Result<Option<AvailableExtensionPackage>, ProductWorkflowError>
+where
+    F: RootFilesystem + ?Sized,
+{
+    let manifest_path = VirtualPath::new(format!(
+        "{}/manifest.toml",
+        entry.path.as_str().trim_end_matches('/')
+    ))
+    .map_err(map_binding_error)?;
+    let manifest_bytes = match fs.read_file(&manifest_path).await {
+        Ok(bytes) => bytes,
+        Err(FilesystemError::NotFound { .. }) | Err(FilesystemError::MountNotFound { .. }) => {
+            return Ok(None);
+        }
+        Err(error) => {
+            return Err(ProductWorkflowError::Transient {
+                reason: format!("failed to read available extension manifest: {error}"),
+            });
+        }
+    };
+    let manifest_toml = String::from_utf8(manifest_bytes).map_err(|error| {
+        ProductWorkflowError::InvalidBindingRequest {
+            reason: format!("available extension manifest is not UTF-8: {error}"),
+        }
+    })?;
+    let record = ExtensionManifestRecord::from_toml_with_contracts(
+        manifest_toml,
+        ManifestSource::InstalledLocal,
+        host_ports,
+        None,
+        contracts,
+    )
+    .map_err(map_binding_error)?;
+    let surface_kinds = surface_kinds_from_manifest_record(&record, entry.name.as_str())?;
+    let manifest = record
+        .manifest()
+        .clone()
+        .try_into()
+        .map_err(map_binding_error)?;
+    let package = ExtensionPackage::from_manifest_toml(manifest, entry.path, record.raw_toml())
+        .map_err(map_binding_error)?;
+    // Catalog EVERY file in the extension dir as inline bytes, exactly
+    // like a fresh import. Assets stored as `Filesystem(path)` pointers
+    // into the extension's own materialized dir dangle after `remove`
+    // (which deletes that dir) and break the intended
+    // remove -> available -> reinstall flow with
+    // "failed to read available extension asset"; and cataloging only
+    // manifest + wasm module would lose schemas/prompt docs on reinstall.
+    let assets = inline_extension_dir_assets(fs, &package.root).await?;
+    Ok(Some(AvailableExtensionPackage {
+        package_ref: LifecyclePackageRef::new(
+            LifecyclePackageKind::Extension,
+            package.id.as_str(),
+        )?,
+        manifest_toml: record.raw_toml().to_string(),
+        // Everything discovered on the filesystem is `InstalledLocal`, per
+        // the `ManifestSource` contract ("Locally installed extension under
+        // `/system/extensions/`"). `HostBundled` — the only tier eligible
+        // for first-party/system trust — is reserved for extensions
+        // compiled into the host binary (`from_first_party_assets`), whose
+        // reserved ids the scan skips above. Uploaded tool bundles
+        // materialize under this root, so stamping discovery `HostBundled`
+        // would let a process restart launder an untrusted upload into
+        // first-party trust (#5459 review: import → restart → install).
+        source: ManifestSource::InstalledLocal,
+        package,
+        surface_kinds,
+        assets,
+    }))
 }
 
 pub(crate) fn reserved_host_bundled_extension_id(extension_id: &ExtensionId) -> bool {


### PR DESCRIPTION
## Bug (verified)

Hosted single-tenant volume deployment (`ironclaw-reborn serve`, Railway) crash-loops on current `main` (`8625c7136`, #5499):

```
reborn runtime build failed: invalid reborn composition configuration: available extension catalog could not be loaded: invalid binding request: manifest source InstalledLocal is not allowed to assert trust 'FirstPartyRequested'
```

Reproduced red on base `8625c7136` by the regression test in this PR — it failed with exactly that error aborting `AvailableExtensionCatalog::from_filesystem_root`.

## Root cause

- Pre-#5499 installs materialized bundled first-party manifests **verbatim** (`trust = "first_party_requested"`) onto the persistent volume (`materialize_available_extension`).
- #5499 (correctly) stamps boot-rescanned filesystem manifests `ManifestSource::InstalledLocal`, which may not assert first-party trust (`ManifestV2Error::TrustForbiddenForSource`, gate unchanged).
- The catalog load was fail-closed per boot: one stale manifest aborted the whole composition — before the `from_first_party_assets` merge (`factory.rs`) that supersedes first-party entries from compiled-in assets.
- Live trigger: `slack` is absent from `reserved_host_bundled_extension_id`, so an installed Slack's stale manifest reaches the strict parse (follow-up below).

## Fix

`load_filesystem_packages` per-entry body extracted to `load_filesystem_package`; the loop now treats a per-entry validation failure (`InvalidBindingRequest`) as warn + skip, while infrastructure errors (`Transient`) still abort the load. Trust gate and #5499's security property untouched: a stale/forged first-party-trust manifest is now simply absent from the catalog (bundled merge re-supplies real first-party extensions), instead of either being trusted (pre-#5499) or crash-looping the box (post-#5499).

Pre-existing installs need no migration: install/activation records untouched; first-party definitions come from compiled-in assets which always win the merge; third-party/uploaded tools (`trust = "third_party"`) parse as before.

## Regression tests

`crates/ironclaw_reborn_composition/src/extension_host/available_extension_import.rs`:
- `filesystem_catalog_skips_manifest_with_forbidden_trust_instead_of_aborting` — stale first-party-trust manifest sorted before a valid third-party one: load succeeds, valid one present, stale one skipped. **Red on base** with the production error, green with fix.
- `filesystem_catalog_still_fails_closed_on_transient_manifest_read_error` — pins the fail-closed side: backend IO error still aborts (green before and after; guards the skip policy from flattening).

Tier note: crate tier through `from_filesystem_root` — the exact production fn `factory.rs` calls at boot. Integration harness builds one composition per group and cannot exercise the stale-volume-reboot path; the reserved-id skip also makes an in-harness `github` install non-reproducing.

## Verification

- `cargo test -p ironclaw_reborn_composition --lib` — 1127 passed
- `cargo clippy -p ironclaw_reborn_composition --tests` — clean
- `cargo fmt` — applied

## Follow-up (not this PR)

- Add `slack` to `reserved_host_bundled_extension_id` (unconditionally reserving the id changes non-beta import behavior — needs its own decision).
- `available_extensions.rs` is >3k lines; decomposition tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
