### PR TITLE
feat(mcp): per-server timeouts + background-job bridge

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,11 @@ DATABASE_POOL_SIZE=30  # multi-tenant default; reduce to 5-10 for single-user or
 #      When both NEARAI_BASE_URL and NEARAI_API_KEY are set at startup,
 #      IronClaw also bootstraps a persisted `nearai` MCP server using the
 #      same base URL and Authorization header.
+#
+# NOTE: MCP per-server settings (call timeout, background-job eligibility) are
+#   NOT env vars — they are per-server DB config. Set them when adding a server:
+#     ironclaw mcp add <name> ... --timeout-secs 3600 --allow-background
+#   Default timeout is 30s (clamped 5..=21600). See src/tools/README.md.
 NEARAI_MODEL=Qwen/Qwen3.5-122B-A10B
 NEARAI_BASE_URL=https://private.near.ai
 NEARAI_AUTH_URL=https://private.near.ai

--- a/docs/superpowers/plans/2026-07-09-mcp-background-jobs.md
+++ b/docs/superpowers/plans/2026-07-09-mcp-background-jobs.md
@@ -1,0 +1,623 @@
+# MCP Background Jobs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add (1) a per-MCP-server configurable call timeout that lifts the hardcoded 30s transport cap, and (2) a generic bridge that runs a long-running MCP tool call as a first-class, durable IronClaw job that auto-resumes the originating agent thread on completion.
+
+**Architecture:** Phase 1 threads a configurable timeout from `McpServerConfig` through the transports and the `McpToolWrapper`. Phase 2 adds `tool_job_start` / `tool_job_status` builtin tools that create a persisted `JobContext` and spawn a lightweight non-LLM runner (mirroring the Container job path) which calls the MCP tool at the server's long timeout, streams `JobEvent`s to SSE, and injects the (safety-scanned) result back into the originating thread via the agent-loop inject channel.
+
+**Tech Stack:** Rust, tokio, async-trait, serde, axum (gateway), PostgreSQL + libSQL dual backend.
+
+## Global Constraints
+
+- No `.unwrap()` / `.expect()` in production code (tests are fine). Map errors with `?` + context. (`src/agent/CLAUDE.md`, `.claude/rules/error-handling.md`)
+- Every bug fix / feature commit includes a regression test (commit-msg hook enforces). (`.claude/rules/testing.md`)
+- Test *through the caller*, not just the helper, when a helper gates a side effect. Integration tier = `cargo test --features integration`. (`.claude/rules/testing.md`)
+- External tool output reaching the LLM MUST pass the safety layer (sanitize + wrap) first. (`.claude/rules/safety-and-sandbox.md`)
+- MCP/sandbox tool output is untrusted external data — `requires_sanitization() == true`.
+- Zero clippy warnings: `cargo clippy --all --benches --tests --examples --all-features`.
+- Prefer `crate::` for cross-module imports; `super::` only in tests / intra-module.
+- Config precedence is DB > env > toml > defaults; per-server settings live on the `McpServerConfig` row (single source of truth) — do NOT add a parallel generic `settings` key.
+- Timeout default when unset stays **30s** (today's behavior); new `timeout_secs` clamps to `5..=21600` (6h).
+
+**Reference spec:** `docs/superpowers/specs/2026-07-08-mcp-background-jobs-design.md`
+
+---
+
+## Phase 1 — Per-server configurable timeout
+
+### Task 1: Add `timeout_secs` + `allow_background` to `McpServerConfig`
+
+**Files:**
+- Modify: `src/tools/mcp/config.rs:37-70` (struct), plus a helper for the clamped duration
+- Test: same file, `#[cfg(test)] mod tests`
+
+**Interfaces:**
+- Produces: `McpServerConfig.timeout_secs: Option<u64>`, `McpServerConfig.allow_background: bool`, `McpServerConfig::effective_timeout() -> std::time::Duration`
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn effective_timeout_defaults_to_30s_and_clamps() {
+    let mut c = McpServerConfig::new("s", "http://x");
+    assert_eq!(c.effective_timeout(), std::time::Duration::from_secs(30));
+    c.timeout_secs = Some(3600);
+    assert_eq!(c.effective_timeout(), std::time::Duration::from_secs(3600));
+    c.timeout_secs = Some(1); // below floor
+    assert_eq!(c.effective_timeout(), std::time::Duration::from_secs(5));
+    c.timeout_secs = Some(999_999); // above ceiling
+    assert_eq!(c.effective_timeout(), std::time::Duration::from_secs(21600));
+}
+
+#[test]
+fn allow_background_defaults_false_and_roundtrips() {
+    let c = McpServerConfig::new("s", "http://x");
+    assert!(!c.allow_background);
+    let json = serde_json::to_string(&c).unwrap();
+    let back: McpServerConfig = serde_json::from_str(&json).unwrap();
+    assert!(!back.allow_background);
+    assert_eq!(back.timeout_secs, None);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p ironclaw mcp::config::tests::effective_timeout_defaults_to_30s_and_clamps`
+Expected: FAIL — no field `timeout_secs` / no method `effective_timeout`.
+
+- [ ] **Step 3: Add the fields + helper**
+
+In the struct (after `cached_tools`), add:
+```rust
+    /// Max seconds for a single call to this server before the transport times
+    /// out. `None` uses the default 30s. Clamped to 5..=21600 by
+    /// `effective_timeout()`. Local backends (a cold 27B sandbox) need more.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout_secs: Option<u64>,
+
+    /// Whether this server's tools may be run as background jobs
+    /// (`tool_job_start`). Opt-in; defaults false.
+    #[serde(default)]
+    pub allow_background: bool,
+```
+Add `timeout_secs: None,` and `allow_background: false,` to BOTH `new()` and `new_stdio()` initializers. Add the helper in `impl McpServerConfig`:
+```rust
+    /// Per-call transport timeout, clamped to a sane range. Default 30s.
+    pub fn effective_timeout(&self) -> std::time::Duration {
+        let secs = self.timeout_secs.unwrap_or(30).clamp(5, 21_600);
+        std::time::Duration::from_secs(secs)
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p ironclaw mcp::config::tests::`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tools/mcp/config.rs
+git commit -m "feat(mcp): add per-server timeout_secs + allow_background to McpServerConfig"
+```
+
+---
+
+### Task 2: Thread the timeout into the stdio + HTTP transports
+
+**Files:**
+- Modify: `src/tools/mcp/stdio_transport.rs:114-129` (the `send` impl), and the transport struct to hold a `timeout: Duration`
+- Modify: `src/tools/mcp/http_transport.rs:42-68` (`new`), add a `with_timeout` builder
+- Test: `src/tools/mcp/stdio_transport.rs` `#[cfg(test)]`
+
+**Interfaces:**
+- Consumes: `Duration` from `McpServerConfig::effective_timeout()` (Task 1)
+- Produces: `StdioMcpTransport` uses its stored `timeout` in `stream_transport_send`; `HttpMcpTransport::with_timeout(Duration) -> Self`
+
+**Confirm first:** `grep -n "self.timeout\|timeout" src/tools/mcp/stdio_transport.rs` — verify whether the struct already stores a timeout field. If not, add `timeout: Duration` to the struct and set it in `spawn(...)` (default `Duration::from_secs(30)` for the current call sites; a `with_timeout` setter to override).
+
+- [ ] **Step 1: Write the failing test** (stdio struct carries + uses timeout)
+
+```rust
+#[tokio::test]
+async fn stdio_transport_uses_configured_timeout() {
+    // A transport constructed with a 7s override reports 7s.
+    // (Construct via the same path spawn() uses; assert the stored field.)
+    let t = StdioMcpTransport::spawn("t", "cat", Vec::<String>::new(), Vec::<(String,String)>::new())
+        .await
+        .expect("spawn cat")
+        .with_timeout(std::time::Duration::from_secs(7));
+    assert_eq!(t.timeout, std::time::Duration::from_secs(7));
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p ironclaw mcp::stdio_transport::tests::stdio_transport_uses_configured_timeout`
+Expected: FAIL — no `with_timeout` / no `timeout` field.
+
+- [ ] **Step 3: Implement**
+
+In `stdio_transport.rs`: add `timeout: Duration` to the struct; initialize to `Duration::from_secs(30)` in `spawn`; add:
+```rust
+    /// Override the per-request timeout (default 30s).
+    pub fn with_timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = timeout;
+        self
+    }
+```
+Change the `send` body to use `self.timeout` instead of the literal:
+```rust
+        stream_transport_send(
+            &self.stdin,
+            &self.pending,
+            request,
+            &self.server_name,
+            self.timeout,
+        )
+        .await
+```
+In `http_transport.rs`: keep the `reqwest::Client::builder().timeout(Duration::from_secs(30))` default in `new`, and add a builder that rebuilds the client with an override:
+```rust
+    /// Override the HTTP request timeout (default 30s).
+    pub fn with_timeout(mut self, timeout: std::time::Duration) -> Self {
+        self.http_client = reqwest::Client::builder()
+            .timeout(timeout)
+            .build()
+            .expect("Failed to create HTTP client"); // safety: rustls init cannot fail
+        self
+    }
+```
+
+- [ ] **Step 4: Run tests + clippy**
+
+Run: `cargo test -p ironclaw mcp::stdio_transport && cargo clippy -p ironclaw`
+Expected: PASS, zero warnings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tools/mcp/stdio_transport.rs src/tools/mcp/http_transport.rs
+git commit -m "feat(mcp): transports accept a configurable per-request timeout"
+```
+
+---
+
+### Task 3: Wire the configured timeout through the factory + wrapper
+
+**Files:**
+- Modify: `src/tools/mcp/factory.rs:64-147` (pass `server.effective_timeout()` to the transports)
+- Modify: `src/tools/mcp/client.rs:759-802` (`create_tools_with_store`) + `896-966` (`McpToolWrapper`) — carry a `timeout` field and return it from `execution_timeout()`
+- Test: `src/tools/mcp/client.rs` `#[cfg(test)]`
+
+**Interfaces:**
+- Consumes: `McpServerConfig::effective_timeout()` (Task 1); transport `with_timeout` (Task 2)
+- Produces: `McpToolWrapper::execution_timeout()` returns the server's configured timeout (≥ transport timeout, so `execute.rs`/`dispatch.rs` don't re-clip)
+
+**Confirm first:** `grep -n "process_manager.spawn_stdio\|effective_transport\|fn effective_timeout\|self.config\|server\b" src/tools/mcp/factory.rs` and `grep -n "server_name\|self.config\|McpServerConfig" src/tools/mcp/client.rs` — the factory has `server` in scope (it's `Some(server)` passed to `McpClient::new_with_transport`). Confirm the stdio path constructs through `process_manager.spawn_stdio` (a pooled path) — if so, apply `.with_timeout(...)` to the returned transport before wrapping, or thread the duration into `spawn_stdio`. Pick whichever keeps one construction path; prefer `.with_timeout()` on the returned `Arc`-inner transport if the pool returns an owned transport, else add a `timeout` param to `spawn_stdio`.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[tokio::test]
+async fn mcp_tool_wrapper_reports_server_timeout() {
+    // Build a wrapper with an explicit 900s timeout and assert execution_timeout().
+    let store = std::sync::Arc::new(crate::tools::mcp::McpClientStore::new());
+    let w = McpToolWrapper {
+        tool: /* minimal McpTool fixture */ mcp_tool_fixture("do_thing"),
+        prefixed_name: "srv__do_thing".into(),
+        provider_extension: "srv".into(),
+        server_name: "srv".into(),
+        client_store: store,
+        timeout: std::time::Duration::from_secs(900),
+    };
+    assert_eq!(w.execution_timeout(), std::time::Duration::from_secs(900));
+}
+```
+(Add a small `mcp_tool_fixture(name)` test helper mirroring `client_store.rs`'s `tool_with_annotations`.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p ironclaw mcp::client::tests::mcp_tool_wrapper_reports_server_timeout`
+Expected: FAIL — `McpToolWrapper` has no `timeout` field / no `execution_timeout` override.
+
+- [ ] **Step 3: Implement**
+
+Add `timeout: std::time::Duration` to the `McpToolWrapper` struct. In `create_tools_with_store`, compute the timeout once from the server config the client already holds (confirm accessor: `grep -n "fn server_config\|self.config\|effective_timeout" src/tools/mcp/client.rs`; if the client stores `Option<McpServerConfig>`, use `self.config.as_ref().map(|c| c.effective_timeout()).unwrap_or(Duration::from_secs(30))`) and set `timeout` on each wrapper. Add to `impl Tool for McpToolWrapper`:
+```rust
+    fn execution_timeout(&self) -> std::time::Duration {
+        self.timeout
+    }
+```
+In `factory.rs`, apply `.with_timeout(server.effective_timeout())` to each transport before it is wrapped in the `McpClient`.
+
+- [ ] **Step 4: Run tests + clippy**
+
+Run: `cargo test -p ironclaw mcp:: && cargo clippy -p ironclaw`
+Expected: PASS, zero warnings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tools/mcp/factory.rs src/tools/mcp/client.rs
+git commit -m "feat(mcp): honor per-server timeout in transport + tool execution cap"
+```
+
+---
+
+### Task 4: Expose `--timeout-secs` / `--allow-background` on `mcp add`
+
+**Files:**
+- Modify: `src/cli/mcp.rs:23-70` (`McpAddArgs`) + `add_server` (`:167-261`)
+- Test: `src/cli/mcp.rs` `#[cfg(test)]` (arg parsing → config fields)
+
+**Interfaces:**
+- Consumes: `McpServerConfig.timeout_secs`, `.allow_background` (Task 1)
+
+**Confirm first:** `grep -n "servers.upsert\|McpAddArgs\|clap\|arg" src/cli/mcp.rs` — confirm `mcp add` upserts (line ~257) so it doubles as edit, and see how existing flags are declared (clap derive vs builder).
+
+- [ ] **Step 1: Write the failing test** — parse args including the new flags and assert the built `McpServerConfig` carries them.
+
+```rust
+#[test]
+fn add_args_set_timeout_and_background() {
+    let args = McpAddArgs {
+        name: "srv".into(), timeout_secs: Some(3600), allow_background: true,
+        /* ..existing fields with defaults.. */ ..default_add_args()
+    };
+    let cfg = args.to_config().expect("build config"); // extract config-building into a helper
+    assert_eq!(cfg.timeout_secs, Some(3600));
+    assert!(cfg.allow_background);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p ironclaw cli::mcp::tests::add_args_set_timeout_and_background`
+Expected: FAIL — no such fields / no `to_config`.
+
+- [ ] **Step 3: Implement** — add `#[arg(long)] pub timeout_secs: Option<u64>` and `#[arg(long)] pub allow_background: bool` to `McpAddArgs`; set them on the `McpServerConfig` in `add_server` (extract the config-building into `McpAddArgs::to_config()` so it's unit-testable). Persist via the existing `servers.upsert(config)`.
+
+- [ ] **Step 4: Run tests + a manual smoke**
+
+Run: `cargo test -p ironclaw cli::mcp`
+Expected: PASS. (Manual, after build: `ironclaw mcp add srv --transport http --url http://x --timeout-secs 60 --allow-background` then `ironclaw mcp list --verbose` shows them.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cli/mcp.rs
+git commit -m "feat(cli): mcp add accepts --timeout-secs and --allow-background"
+```
+
+---
+
+### Task 5: Document Phase 1 config
+
+**Files:**
+- Modify: `.env.example` (note the per-server setting is DB-config, not env), `src/channels/web/CLAUDE.md` (Auth/section noting MCP per-server timeout)
+
+- [ ] **Step 1:** Add a short note under the MCP section of `src/channels/web/CLAUDE.md` and a comment in `.env.example` pointing to `ironclaw mcp add --timeout-secs`. No code.
+- [ ] **Step 2: Commit**
+
+```bash
+git add .env.example src/channels/web/CLAUDE.md
+git commit -m "docs(mcp): document per-server timeout + allow_background"
+```
+
+**Phase 1 is independently shippable and delivers the sync-path timeout fix.** After Phase 1, enabling msbsandbox: `ironclaw mcp add msbsandbox ... --timeout-secs 3600 --allow-background`.
+
+---
+
+## Phase 2 — Generic MCP→job bridge (auto-resume)
+
+### Task 6: Job descriptor + `mcp_job` metadata shape
+
+**Files:**
+- Create: `src/worker/mcp_job.rs` (module skeleton + `McpJobSpec`)
+- Modify: `src/worker/mod.rs` (add `pub mod mcp_job;`)
+- Test: `src/worker/mcp_job.rs` `#[cfg(test)]`
+
+**Interfaces:**
+- Produces:
+```rust
+pub struct McpJobSpec {
+    pub server: String,       // MCP server name (e.g. "msbsandbox")
+    pub tool: String,         // unprefixed MCP tool name (e.g. "run_python")
+    pub params: serde_json::Value,
+    pub user_id: String,
+    pub channel: String,      // originating channel (for injection)
+    pub thread_id: Option<String>,
+}
+impl McpJobSpec {
+    pub fn to_metadata(&self) -> serde_json::Value; // {"mode":"mcp_tool","server":..,"tool":..,"params":..}
+    pub fn from_metadata(meta: &serde_json::Value, user_id: &str, channel: &str, thread_id: Option<String>) -> Option<Self>;
+}
+```
+Rationale: the "mode" lives in `JobContext.metadata` (already `serde_json::Value`), avoiding a change to the orchestrator `JobMode` enum which is not on the dispatch path.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn metadata_roundtrip() {
+    let spec = McpJobSpec {
+        server: "msbsandbox".into(), tool: "run_python".into(),
+        params: serde_json::json!({"code":"print(1)"}),
+        user_id: "u1".into(), channel: "gateway".into(), thread_id: Some("t1".into()),
+    };
+    let meta = spec.to_metadata();
+    assert_eq!(meta["mode"], "mcp_tool");
+    let back = McpJobSpec::from_metadata(&meta, "u1", "gateway", Some("t1".into())).unwrap();
+    assert_eq!(back.server, "msbsandbox");
+    assert_eq!(back.tool, "run_python");
+    assert_eq!(back.params["code"], "print(1)");
+    assert!(McpJobSpec::from_metadata(&serde_json::json!({"mode":"other"}), "u","c",None).is_none());
+}
+```
+
+- [ ] **Step 2: Run → fail; Step 3: implement `McpJobSpec` + the two methods; Step 4: run → pass.**
+
+Run: `cargo test -p ironclaw worker::mcp_job::tests::metadata_roundtrip`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/worker/mcp_job.rs src/worker/mod.rs
+git commit -m "feat(worker): McpJobSpec descriptor + job metadata shape"
+```
+
+---
+
+### Task 7: The MCP job runner (non-LLM, streams events, injects result)
+
+**Files:**
+- Modify: `src/worker/mcp_job.rs` — add `run_mcp_job(...)`
+- Test: `src/worker/mcp_job.rs` `#[cfg(test)]` (integration-tier, feature `integration`)
+
+**Interfaces:**
+- Consumes: `McpJobSpec` (Task 6); `McpClientStore::get` → `McpClient::call_tool` (extraction §5); `ContextManager::update_context` (§7); `SafetyLayer::sanitize_tool_output` + `wrap_for_llm` (§11); `SseManager::broadcast` (§ wiring); `IncomingMessage::new(..).into_internal().with_thread(..)` (§9); `store.update_job_status` / `save_job_event` (§13)
+- Produces:
+```rust
+pub struct McpJobDeps {
+    pub context_manager: Arc<ContextManager>,
+    pub store: Option<SystemScope>,
+    pub sse_tx: Option<Arc<crate::channels::web::sse::SseManager>>,
+    pub inject_tx: Option<tokio::sync::mpsc::Sender<IncomingMessage>>,
+    pub client_store: Arc<crate::tools::mcp::McpClientStore>,
+    pub safety: Arc<SafetyLayer>,
+}
+pub async fn run_mcp_job(job_id: uuid::Uuid, spec: McpJobSpec, deps: McpJobDeps);
+```
+
+**Behavior (in order):**
+1. `deps.context_manager.update_context(job_id, |c| c.transition_to(JobState::InProgress, Some("mcp job started".into())))` (ignore idempotent Err per §6 semantics; log on real failure). Persist: if `store`, `store.update_job_status(job_id, JobState::InProgress).await` (silent-ok: next poll reconciles).
+2. Emit status: build `AppEvent::JobStatus { job_id: job_id.to_string(), message: format!("Running {} in background", spec.tool) }`; `if let Some(sse) = &deps.sse_tx { sse.broadcast(evt) }`. Also persist via `store.save_job_event(job_id, "status", &json!({"message": ...}))`.
+3. Resolve client: `let client = deps.client_store.get(&spec.user_id, &spec.server).await` → on `None`, treat as failure (server inactive).
+4. `let result = client.call_tool(&spec.tool, spec.params.clone()).await;` — uses the server's configured long transport timeout (Phase 1).
+5. Convert to a `Result<String, String>`: on `Ok(r)` join `r.content` text parts (mirror `McpToolWrapper::execute` §3); if `r.is_error` treat as `Err(content)`.
+6. **Safety scan** (required): `let sanitized = deps.safety.sanitize_tool_output(&spec.tool, &raw); let wrapped = deps.safety.wrap_for_llm(&spec.tool, &sanitized.content);` — `wrapped` is what gets injected.
+7. Transition + persist: `Completed` on success else `Failed`; `store.update_job_status(...)`.
+8. Emit `AppEvent::JobResult { job_id, status: JobResultStatus::Completed|Failed, session_id: None, fallback_deliverable: None }` to SSE + `save_job_event(job_id, "result", ...)`.
+9. Inject completion into the originating thread:
+```rust
+if let Some(tx) = &deps.inject_tx {
+    let body = format!("[Background job {}] {} {}: {}",
+        short_id(job_id), spec.tool,
+        if ok {"completed"} else {"failed"}, wrapped);
+    let mut msg = IncomingMessage::new(spec.channel.clone(), spec.user_id.clone(), body).into_internal();
+    if let Some(t) = &spec.thread_id { msg = msg.with_thread(t.clone()); }
+    let _ = tx.send(msg).await; // silent-ok: agent may be idle; job state already persisted
+}
+```
+
+**Confirm first:** `grep -n "fn sanitize_tool_output\|fn wrap_for_llm" crates/ironclaw_safety/src/*.rs src/safety/*.rs` for exact `SafetyLayer` method signatures; `grep -n "fn into_internal\|fn with_thread\|fn new" src/channels/mod.rs` for `IncomingMessage` builders; `grep -n "fn update_job_status\|fn save_job_event" src/db/*.rs` for the store method signatures and the `SystemScope` wrapper.
+
+- [ ] **Step 1: Write the failing integration test** — a stub `McpClient`/`McpClientStore` entry whose `call_tool` returns a known string; drive `run_mcp_job`; assert (a) job transitions to `Completed` in the `ContextManager`, and (b) an `IncomingMessage` is received on a test `inject_tx` receiver containing the (wrapped) output.
+
+```rust
+#[tokio::test]
+async fn mcp_job_runs_completes_and_injects() {
+    // Arrange: ContextManager with a Pending mcp job; a client_store with a stub
+    // server returning "RESULT_OK"; an mpsc inject channel.
+    // Act: run_mcp_job(job_id, spec, deps).await;
+    // Assert: ctx.state == Completed; injected message contains "RESULT_OK".
+}
+```
+(If a real `McpClient` stub is impractical, add a thin `McpCaller` trait boundary — `async fn call(&self, tool, params) -> Result<String,String>` — implemented for the real client-store lookup and by a test fake. This keeps the runner testable per the test-through-the-caller rule.)
+
+- [ ] **Step 2: Run → fail; Step 3: implement `run_mcp_job` + `McpJobDeps`; Step 4: run → pass.**
+
+Run: `cargo test -p ironclaw --features integration worker::mcp_job::tests::mcp_job_runs_completes_and_injects`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/worker/mcp_job.rs
+git commit -m "feat(worker): run_mcp_job — non-LLM MCP job runner with safety scan + auto-resume inject"
+```
+
+---
+
+### Task 8: `Scheduler::dispatch_mcp_job` — persist + spawn the runner
+
+**Files:**
+- Modify: `src/agent/scheduler.rs` (add `dispatch_mcp_job`, mirroring `dispatch_job_inner:183-252`); add `client_store` + `inject_tx` to `Scheduler` (or accept them as args)
+- Test: `src/agent/scheduler.rs` `#[cfg(test)]` (integration)
+
+**Interfaces:**
+- Consumes: `McpJobSpec` (Task 6), `run_mcp_job` + `McpJobDeps` (Task 7)
+- Produces: `Scheduler::dispatch_mcp_job(&self, spec: McpJobSpec) -> Result<Uuid, JobError>`
+
+**Behavior:** mirror `dispatch_job_inner` but skip the `Worker`:
+1. `let job_id = self.context_manager.create_job_for_user(&spec.user_id, &title, &desc).await?;` (title e.g. `format!("mcp:{}/{}", spec.server, spec.tool)`).
+2. `self.context_manager.update_context_and_get(job_id, |c| { c.metadata = spec.to_metadata(); }).await?` → `ctx`.
+3. `if let Some(store) = &self.store { store.save_job(&ctx).await.map_err(...)?; }` (FK-valid before spawn).
+4. Transition to `InProgress` is done inside `run_mcp_job` (do NOT double-transition here; unlike `schedule_with_context` which does it for LLM workers).
+5. Build `McpJobDeps` from scheduler fields + `spec.clone()` and `tokio::spawn(run_mcp_job(job_id, spec, deps));`
+6. Return `job_id`.
+
+**Confirm first:** `grep -n "client_store\|inject_tx\|msg_tx\|SchedulerDeps\|pub fn new" src/agent/scheduler.rs` — `Scheduler` currently lacks `client_store`/`inject_tx`. Add them to `SchedulerDeps` (or a `set_mcp_deps(...)` setter mirroring `set_sse_sender:110`) and wire in `app.rs` (Task 10). The `inject_tx` is the same `mpsc::Sender<IncomingMessage>` the channels use to feed the agent loop.
+
+- [ ] **Step 1: Write the failing integration test** — call `dispatch_mcp_job` with a spec (stub client returns a value), assert a job row is persisted (`store.get_job(job_id)` is `Some`) and eventually `Completed`.
+- [ ] **Step 2: Run → fail; Step 3: implement `dispatch_mcp_job` + scheduler deps; Step 4: run → pass.**
+
+Run: `cargo test -p ironclaw --features integration agent::scheduler::tests::dispatch_mcp_job`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agent/scheduler.rs
+git commit -m "feat(scheduler): dispatch_mcp_job persists + spawns the MCP runner (no LLM worker)"
+```
+
+---
+
+### Task 9: `tool_job_start` / `tool_job_status` builtin tools
+
+**Files:**
+- Create: `src/tools/builtin/tool_job.rs`
+- Modify: `src/tools/builtin/mod.rs` (declare module + export)
+- Test: `src/tools/builtin/tool_job.rs` `#[cfg(test)]`
+
+**Interfaces:**
+- Consumes: `Scheduler::dispatch_mcp_job` (Task 8) via a `SchedulerSlot` (`src/tools/builtin/job.rs:33-36`); the `ToolRegistry` to resolve a prefixed tool name → `(server, tool)`; `McpServerConfig.allow_background` (Task 1) via the client-store/config
+- Produces two `Tool` impls (`CreateMcpJobTool` → name `tool_job_start`, `McpJobStatusTool` → name `tool_job_status`)
+
+**`tool_job_start` params schema:** `{ "tool": string (prefixed, e.g. "msbsandbox__run_python"), "arguments": object }`. Behavior:
+1. Split the prefixed name into `(server, mcp_tool)` (mirror `mcp_tool_id`/its inverse in `client.rs`; confirm separator via `grep -n "fn mcp_tool_id" src/tools/mcp/client.rs`).
+2. Verify the server exists, is active for `ctx.user_id`, and has `allow_background == true` — else `Err(ToolError::InvalidParameters("server '..' is not enabled for background jobs"))`.
+3. Honor approval: if the underlying tool `requires_approval`, return `ToolError::NotAuthorized(...)` guiding the caller to run it synchronously (v1 keeps approval on the sync path).
+4. Build `McpJobSpec` (channel/thread from `ctx` metadata — confirm how job/thread context is available to a tool via `JobContext`; the originating channel/thread come from the dispatching turn's metadata).
+5. `let job_id = scheduler.dispatch_mcp_job(spec).await?;`
+6. `Ok(ToolOutput::success(json!({"job_id": job_id, "state": "in_progress"}), start.elapsed()))`.
+
+**`tool_job_status` params:** `{ "job_id": string }` → look up via `context_manager.get_context` / `store.get_job`; return `{state, result?}` (result only when Completed; read from the last `result` job_event or a stashed field). 
+
+**Confirm first:** `grep -rn "CreateJobTool::new\|\.register\|register_builtin_tools\|with_scheduler_slot" src/app.rs src/tools/builtin/mod.rs src/tools/registry.rs` — find exactly where `CreateJobTool` is constructed + registered and mirror it (same `SchedulerSlot`, `inject_tx`, `client_store`, `secrets` deps).
+
+- [ ] **Step 1: Write the failing test** — construct `CreateMcpJobTool` with a fake scheduler slot; call `execute` with `{tool:"srv__do", arguments:{}}` where `srv` has `allow_background=false` → assert `InvalidParameters`; then with `allow_background=true` → assert it returns a `job_id`.
+- [ ] **Step 2: Run → fail; Step 3: implement both tools + schema; Step 4: run → pass.**
+
+Run: `cargo test -p ironclaw tools::builtin::tool_job::tests::`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tools/builtin/tool_job.rs src/tools/builtin/mod.rs
+git commit -m "feat(tools): tool_job_start / tool_job_status builtins (generic MCP-as-job)"
+```
+
+---
+
+### Task 10: Wire deps in `app.rs` + register the tools
+
+**Files:**
+- Modify: `src/app.rs` (near `:544` `register_builtin_tools` and wherever `CreateJobTool` is wired) — construct the two new tools with `context_manager`, the `SchedulerSlot`, `client_store`, `inject_tx`, `sse`, `safety`, `store`; give the `Scheduler` its `client_store` + `inject_tx` (Task 8).
+- Test: covered by Task 11 e2e.
+
+**Confirm first:** `grep -n "CreateJobTool\|scheduler\|client_store\|inject_tx\|msg_tx\|set_sse_sender\|register" src/app.rs` — locate the scheduler construction, the `msg_tx`/inject channel, and the `McpClientStore` instance to share.
+
+- [ ] **Step 1:** Construct + register `CreateMcpJobTool` and `McpJobStatusTool` alongside `CreateJobTool`; call the new scheduler setter with `client_store` + `inject_tx`.
+- [ ] **Step 2: Build**
+
+Run: `cargo build -p ironclaw`
+Expected: compiles.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app.rs
+git commit -m "feat(app): wire MCP-job tools + scheduler client_store/inject deps"
+```
+
+---
+
+### Task 11: Startup reconcile — in-flight MCP jobs → `Stuck`
+
+**Files:**
+- Modify: `src/app.rs` (boot path, after store init) — a `reconcile_mcp_jobs_on_startup(store)` call
+- Create helper: `src/worker/mcp_job.rs::reconcile_orphaned_mcp_jobs(store) -> usize`
+- Test: `src/worker/mcp_job.rs` `#[cfg(test)]` (integration)
+
+**Interfaces:**
+- Consumes: `store.list_jobs_by_status(JobState::InProgress)` (§13) filtered to `metadata.mode == "mcp_tool"`
+- Produces: `pub async fn reconcile_orphaned_mcp_jobs(store: &SystemScope) -> Result<usize, DatabaseError>` — transitions each to `Stuck`, returns count.
+
+**Confirm first:** `grep -n "list_jobs_by_status\|list_agent_jobs\|update_job_status\|find_stuck_jobs" src/db/*.rs src/context/manager.rs` — confirm the exact enumeration method; if `list_jobs_by_status` is absent, use `list_agent_jobs_for_user` per user or add the query.
+
+- [ ] **Step 1: Write the failing integration test** — persist an `InProgress` job with `metadata.mode="mcp_tool"`; run `reconcile_orphaned_mcp_jobs`; assert it becomes `Stuck` and the returned count is 1; a non-mcp InProgress job is untouched.
+- [ ] **Step 2: Run → fail; Step 3: implement; Step 4: run → pass.**
+
+Run: `cargo test -p ironclaw --features integration worker::mcp_job::tests::reconcile`
+
+- [ ] **Step 5:** Call it once during boot in `app.rs` (log the count). **Commit:**
+
+```bash
+git add src/worker/mcp_job.rs src/app.rs
+git commit -m "feat(worker): reconcile orphaned in-flight MCP jobs to Stuck on startup"
+```
+
+---
+
+### Task 12: Surface MCP-job `mode` in `/api/jobs`
+
+**Files:**
+- Modify: `src/channels/web/features/jobs/mod.rs:109-130` (`list_agent_jobs_for_user` mapping → set `JobInfo.kind`/`mode` from `metadata.mode`)
+- Modify: `src/channels/web/types.rs` (`JobInfo` — add an optional `mode: Option<String>` if not present)
+- Test: `src/channels/web/features/jobs/` handler test (or reuse existing jobs handler test harness)
+
+**Confirm first:** `grep -n "struct JobInfo\|mode\|kind\|get_sandbox_job_mode" src/channels/web/types.rs src/channels/web/features/jobs/mod.rs` — `JobInfo` may already carry a `mode`/`kind` used by sandbox jobs; reuse it, don't add a duplicate (wire-contract single-name rule, `.claude/rules/types.md`).
+
+- [ ] **Step 1: Write the failing test** — an agent job whose metadata mode is `mcp_tool` lists with `JobInfo.mode == Some("mcp_tool")`.
+- [ ] **Step 2: Run → fail; Step 3: map metadata→mode in the agent-jobs branch; Step 4: run → pass.**
+
+Run: `cargo test -p ironclaw --features integration <jobs handler test>`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/channels/web/features/jobs/mod.rs src/channels/web/types.rs
+git commit -m "feat(gateway): surface mcp_tool mode on /api/jobs agent-job entries"
+```
+
+---
+
+### Task 13: End-to-end verification + docs
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-07-08-mcp-background-jobs-design.md` (mark shipped), `src/channels/web/CLAUDE.md` (document the two tools + `/api/jobs` mode)
+- No new production code.
+
+- [ ] **Step 1: Full test + lint gate**
+
+Run:
+```bash
+cargo test -p ironclaw
+cargo test -p ironclaw --features integration
+cargo clippy --all --benches --tests --examples --all-features
+grep -rnE '\.unwrap\(|\.expect\(' src/worker/mcp_job.rs src/tools/builtin/tool_job.rs
+```
+Expected: all pass; zero clippy warnings; no `unwrap`/`expect` in the new production files.
+
+- [ ] **Step 2: Manual smoke against a real deploy** (after building + deploying the binary):
+  - `ironclaw mcp add msbsandbox ... --timeout-secs 3600 --allow-background`
+  - From a chat turn, have the agent call `tool_job_start(tool="msbsandbox__run_python", arguments={code:"import time; time.sleep(150); print('done')"})`.
+  - Confirm: returns a `job_id` immediately; job appears in `/api/jobs` with `mode=mcp_tool`, state `in_progress`; ~150s later the thread receives an injected completion carrying `done` and the agent continues. (This is the >120s-without-blank proof for the async path.)
+
+- [ ] **Step 3: Commit docs**
+
+```bash
+git add docs/superpowers/specs/2026-07-08-mcp-background-jobs-design.md src/channels/web/CLAUDE.md
+git commit -m "docs: MCP background jobs shipped — tools, /api/jobs mode, config"
+```
+
+---
+
+## Self-Review notes (author)
+
+- **Spec coverage:** Phase 1 (timeout) → Tasks 1–5. Bridge trigger tools → Task 9. Runner + auto-resume → Task 7. Dispatch/persist → Task 8. Durability/reconcile → Task 11. Gateway surface → Task 12. Config surface → Tasks 4–5. Safety scan → Task 7 step 6. Approval gate → Task 9 step 3. All spec sections map to a task.
+- **Deviation from spec (deliberate):** the "mode" is carried in `JobContext.metadata` rather than a new `JobMode::McpTool` enum variant, because `JobMode` (orchestrator) is not on the dispatch path and metadata already flows through persistence + the gateway. Noted in Task 6.
+- **Confirm-first steps:** each Phase-2 task begins with an exact `grep` for the 1–2 signatures that the extraction could not fully verify (safety method names, `IncomingMessage` builders, store method names, registration site). These are 2-minute lookups, not design gaps.
+- **Type consistency:** `McpJobSpec`, `McpJobDeps`, `run_mcp_job`, `dispatch_mcp_job`, `reconcile_orphaned_mcp_jobs`, `tool_job_start`/`tool_job_status` names are used consistently across tasks 6–13.

--- a/docs/superpowers/specs/2026-07-08-mcp-background-jobs-design.md
+++ b/docs/superpowers/specs/2026-07-08-mcp-background-jobs-design.md
@@ -1,7 +1,17 @@
 # MCP Background Jobs — Per-Server Timeouts + Generic MCP→Job Bridge
 
 **Date:** 2026-07-08
-**Status:** Approved design, pre-implementation
+**Status:** SHIPPED 2026-07-09 (Phase 1 + Phase 2 complete on `reborn-integration`, local — not pushed). See the SDD ledger `.superpowers/sdd/mcp-jobs-progress.md` for the task-by-task record.
+
+**Shipped notes / deviations:**
+- **"mode" storage:** carried in `JobContext.metadata` (`{"mode":"mcp_tool",...}`) rather than a new `JobMode` enum variant, as planned (Task 6). **But** the startup reconcile (Task 11) and the `/api/jobs` surface (Task 12) identify MCP jobs by the **durable `mcp:` title prefix** (`worker::mcp_job::MCP_JOB_TITLE_PREFIX`) instead of `metadata.mode`, because the **libSQL backend does not persist `JobContext.metadata`** (`save_job` omits it; `get_job` returns `Null`). The metadata mode still works at runtime via the in-memory `ContextManager`; the title prefix is the cross-backend-durable signal.
+- **Testable seams:** `McpCaller` (runner) and `BackgroundPolicy` (tools) trait seams keep the logic unit-testable without live MCP clients or PostgreSQL.
+- **`tool_job_start` interface:** takes **separate `server` + `tool` params**, not a joined prefixed name (`mcp_tool_id` is a lossy, non-invertible single-underscore join).
+- **Live smoke (spec Step 2)** — building + deploying the release binary and running a real >120s async turn — is a deploy step, pending a redeploy of the live service.
+
+---
+
+**(original) Status:** Approved design, pre-implementation
 **Scope:** Two composable changes — (1) per-MCP-server configurable call timeout, and (2) a generic bridge that runs a long-running MCP tool call as a first-class, durable IronClaw job with auto-resume of the originating agent thread.
 
 ## Problem

--- a/docs/superpowers/specs/2026-07-08-mcp-background-jobs-design.md
+++ b/docs/superpowers/specs/2026-07-08-mcp-background-jobs-design.md
@@ -1,0 +1,153 @@
+# MCP Background Jobs — Per-Server Timeouts + Generic MCP→Job Bridge
+
+**Date:** 2026-07-08
+**Status:** Approved design, pre-implementation
+**Scope:** Two composable changes — (1) per-MCP-server configurable call timeout, and (2) a generic bridge that runs a long-running MCP tool call as a first-class, durable IronClaw job with auto-resume of the originating agent thread.
+
+## Problem
+
+Every MCP tool call (code sandbox, Playwright, TREK, OCR, …) is capped by **three nested timeouts**, all hardcoded:
+
+| Layer | Value | Location |
+|-------|-------|----------|
+| Transport (per request) | **30s** — fires first | `src/tools/mcp/stdio_transport.rs:126` (stdio), `src/tools/mcp/http_transport.rs:62` (HTTP/reqwest) |
+| Tool execution | 60s | `src/tools/tool.rs:422` default; `McpToolWrapper` (`src/tools/mcp/client.rs:905`) does not override it |
+| Gateway Responses API | 600s (now env-configurable) | `src/channels/web/responses_api.rs` |
+
+The real first-firing ceiling on any single MCP call is therefore **30s**. `McpServerConfig` has no timeout field and neither transport reads any override, so there is no way to run a longer MCP operation. This blocks any genuinely long sandbox job (a model training run, a large build, a multi-minute data-processing script, a long browser crawl): it dies at 30s with a transport `Timeout`, surfacing to the agent as a failed tool call.
+
+## Goals
+
+1. **Per-server configurable timeout** so a specific server (e.g. `msbsandbox`) can run calls far longer than 30s, while other servers keep the tight, fail-fast default.
+2. **Generic MCP→job bridge**: an explicit "run this MCP tool as a background job" capability, usable by *any* MCP server, that:
+   - returns immediately with a job handle,
+   - runs the work in a first-class IronClaw job (persisted, visible in `/api/jobs`, event-streamed),
+   - **auto-resumes** the originating agent thread on completion (injects the result so the agent continues reasoning unattended),
+   - degrades honestly across a service restart (job row survives; in-flight work is marked `Stuck`).
+
+## Non-goals (v1)
+
+- **Full in-flight recovery** across a restart (re-attaching to a still-running microVM). Deferred.
+- **Auto-escalation** (start sync, transparently convert to a job on timeout). Rejected in favor of explicit async tools.
+- **Per-server generated async tool variants** (`msbsandbox_run_python_async`). One generic builtin covers all servers.
+- **Routing through the Docker per-project sandbox** machinery — that is a filesystem mount backend, not a job system.
+- `/api/jobs/{id}/restart` re-dispatch for MCP-tool jobs. Noted follow-up.
+
+## Design decisions (settled during brainstorming)
+
+| Decision | Choice |
+|----------|--------|
+| Completion model | **Auto-resume** the originating thread via the existing job-monitor injection path |
+| Async trigger | **Explicit async tools** — the LLM deliberately calls a "run as job" tool |
+| Abstraction level | **Generic** MCP→job bridge; the sandbox is the first consumer |
+| Restart durability | **Job row survives; in-flight → `Stuck`** (retry is manual in v1); completed results durable |
+| Bridge implementation | **Approach A** — model the MCP job on the existing Container/ClaudeCode job path (external work + `JobEvent` stream + `spawn_job_monitor` injection), not the agentic LLM `Worker` loop |
+
+## Architecture
+
+### Part 1 — Per-server configurable timeout (foundation)
+
+Both the synchronous path and the background runner need a call to be *able* to exceed 30s, so this is shared groundwork.
+
+- **`McpServerConfig`** (`src/tools/mcp/config.rs`) gains two optional fields:
+  - `timeout_secs: Option<u64>` — serde default `None`; when set, clamped to a sane range (≈ 5s..=6h). `None` preserves today's 30s behavior.
+  - `allow_background: bool` — serde default `false`; gates which servers may be run as jobs (Part 2).
+- **Transports** take the timeout as a constructor/param instead of the hardcoded `Duration::from_secs(30)`:
+  - `src/tools/mcp/stdio_transport.rs` (the `stream_transport_send` call at :126)
+  - `src/tools/mcp/http_transport.rs` (the reqwest `.timeout(...)` at :62)
+  - `src/tools/mcp/factory.rs` reads `server.timeout_secs` (default 30s) and passes it when constructing each transport.
+- **`McpToolWrapper`** (`src/tools/mcp/client.rs:896`) carries the resolved timeout as a field (set at construction from config) and returns it from `execution_timeout()`, so the 60s tool-level cap in `src/tools/execute.rs` / `src/tools/dispatch.rs` cannot re-clip a server configured for longer.
+
+This alone removes the 30s sync wall for configured servers.
+
+### Part 2 — Generic MCP→job bridge (modeled on the Container/ClaudeCode job path)
+
+IronClaw already runs external, non-LLM work as first-class jobs: the Claude Code / container jobs execute an external process, stream `JobEvent`s, and use `spawn_job_monitor` (`src/agent/job_monitor.rs:45`) to inject the result back into the thread. An MCP-tool job is the same shape, simpler — one `call_tool` instead of an interactive process.
+
+**New job mode.** Add `JobMode::McpTool` to the job-mode enum (alongside `Worker` / `ClaudeCode` / `Acp`). The MCP payload `{ server, tool, params }` is carried in `JobContext` metadata.
+
+**Trigger — two new generic builtin tools** (`src/tools/builtin/tool_job.rs`, new):
+
+- `tool_job_start { tool: "<prefixed_tool_name>", arguments: {…} }`
+  - Resolves the prefixed tool name → `(server_name, mcp_tool_name)`.
+  - Verifies the server exists, is active for the user, and has `allow_background: true`. On any failure it returns a synchronous error (no job created).
+  - Honors the underlying tool's `requires_approval` gate *before* dispatch (no privilege escalation via backgrounding).
+  - Creates an `McpTool` job via the scheduler and **returns `{ job_id, state }` immediately**.
+- `tool_job_status { job_id }`
+  - Returns the job state, and the (safety-scanned) result if completed. Belt-and-suspenders alongside auto-resume.
+
+One generic builtin (not per-server generated variants) keeps the mechanism universal: any `allow_background` server is instantly usable.
+
+**Dispatch.** `Scheduler::dispatch_mcp_job()` (`src/agent/scheduler.rs`, parallel to `dispatch_job()`):
+1. Creates and persists the `JobContext` (via `ContextManager` + `JobStore`) so the row and FK targets exist immediately.
+2. Spawns the runner task.
+3. Registers `spawn_job_monitor` for completion injection into the originating thread.
+
+**Runner** (`src/worker/mcp_job.rs`, new; mirrors `src/worker/container.rs`):
+1. Transition `Pending → InProgress` (persisted).
+2. Emit `JobStatus` ("running `<tool>` in background") through the existing `log_event` path → SSE + `job_events` persistence.
+3. Call `mcp_client.call_tool(mcp_tool_name, params)` at the server's configured (long) timeout. Because the runner calls the client directly, it uses the transport timeout from Part 1, not the 60s wrapper cap.
+4. Run the output through the **safety layer** (sanitize + leak-detect, `<tool_output>` wrap) exactly as `src/tools/execute.rs::process_tool_result` does — the result will reach the LLM via injection, so it must be scanned first.
+5. Emit `JobResult(Completed, <scanned output>)` on success, or `JobResult(Failed, <sanitized error>)` on error/timeout; transition state accordingly.
+
+**Auto-resume.** `spawn_job_monitor` subscribes to the job's event stream; on `JobResult` it injects an internal `IncomingMessage` into the originating `thread_id` (via `inject_tx`) summarizing the outcome, so the agent wakes, reads the result, and continues — even if the user has walked away. This is the exact mechanism already used for Claude Code jobs.
+
+## Data flow (happy path)
+
+1. Agent (in a thread) judges a sandbox task to be long → calls `tool_job_start(tool="msbsandbox__run_python", arguments={code})`.
+2. Builtin resolves `server=msbsandbox`, checks `allow_background`, creates the `McpTool` job, returns `job_id`. The agent's current turn can end ("started job X — I'll report when it's done").
+3. The runner executes in the background; its `JobEvent`s stream to SSE and persist → the job is visible in `/api/jobs` and the chat event stream.
+4. On completion, the job monitor injects "Background job X (`run_python`) completed: `<result>`" into the thread → the agent auto-resumes, reads the result, and continues (e.g. summarizes to the user).
+
+## Error handling
+
+- **Synchronous rejection** (no job created): unknown/inactive server, tool not found, or `allow_background` unset → `tool_job_start` returns a descriptive error.
+- **Runtime failure:** `call_tool` error or timeout → `JobResult(Failed, <sanitized error>)`, job `Failed`; the injected completion states the failure so the agent may retry. Channel-edge error mapping per `.claude/rules/error-handling.md` — no raw transport errors or filesystem paths leak to the user.
+- **Safety:** the runner's output passes through the safety layer before it is persisted or injected (per `.claude/rules/safety-and-sandbox.md` "every ingress scans before LLM"). The injection is never raw tool output.
+- **Approval:** if the underlying tool `requires_approval`, the gate is honored before dispatch. (In this deployment the sandbox tools are auto-approved, so it is transparent; the rule is correct generically.)
+
+## Durability
+
+- `JobContext` persists to `agent_jobs`; events to `job_events`. Both PostgreSQL and libSQL backends.
+- **Startup reconcile:** on boot, any `McpTool` job still `InProgress` (its runner did not survive the restart) transitions to `Stuck`, visible in `/api/jobs`. Completed results remain durable. In-flight external calls are not resumed — a documented limit. `/api/jobs/{id}/restart` re-dispatch for `McpTool` mode is a follow-up.
+
+## Testing (test through the caller — `.claude/rules/testing.md`)
+
+- **Unit:** `timeout_secs` parse + clamp; transports use the configured timeout; `McpToolWrapper::execution_timeout()` reflects config.
+- **Integration** (stub MCP server; both DB backends):
+  - Drive `tool_job_start` end-to-end → job created, runs, `JobResult` emitted, state `Completed`, **and** a completion message is injected into the thread — asserted at the builtin + scheduler layer, not just the runner helper.
+  - Failure path: stub tool errors → job `Failed`, error sanitized.
+  - Restart reconcile: an `InProgress` `McpTool` job transitions to `Stuck` on startup.
+- Regression test accompanies each fix (repo commit hook enforces).
+
+## File-by-file touch list
+
+| File | Change |
+|------|--------|
+| `src/tools/mcp/config.rs` | `+ timeout_secs`, `+ allow_background` |
+| `src/tools/mcp/factory.rs` | pass configured timeout to transports |
+| `src/tools/mcp/stdio_transport.rs`, `src/tools/mcp/http_transport.rs` | timeout as parameter (drop hardcoded 30s) |
+| `src/tools/mcp/client.rs` | `McpToolWrapper` carries timeout; `execution_timeout()` returns it |
+| `src/context/state.rs` *or* `src/orchestrator/job_manager.rs` | `JobMode::McpTool` (locate the canonical mode enum during implementation) |
+| `src/worker/mcp_job.rs` *(new)* | the runner (mirrors `container.rs`) |
+| `src/agent/scheduler.rs` | `dispatch_mcp_job()` |
+| `src/tools/builtin/tool_job.rs` *(new)* | `tool_job_start` + `tool_job_status` |
+| `src/agent/job_monitor.rs` | reuse; add a route variant if the existing one is Claude-Code-specific |
+| `src/app.rs` | wire builtins (mcp client store + scheduler slot), startup reconcile |
+| `src/channels/web/features/jobs/`, `src/channels/web/types.rs` | surface a `mode`/`kind` so MCP jobs are distinguishable in `/api/jobs` |
+| `src/cli/mcp.rs` | `--timeout-secs` / `--allow-background` flags on `mcp add` / `mcp update` |
+| `.env.example`, `src/channels/web/CLAUDE.md` | document the new config + tools |
+
+## Config surface (enabling msbsandbox after build)
+
+```
+ironclaw mcp update msbsandbox --timeout-secs 3600 --allow-background
+```
+
+(or the DB-settings equivalent). The agent can then background long sandbox jobs; every other server and every quick call stays fast-and-synchronous.
+
+## Open implementation questions (resolve during planning, not blocking)
+
+- Exact home of the canonical `JobMode` enum (`src/context/state.rs` vs `src/orchestrator/job_manager.rs`).
+- Whether `spawn_job_monitor` is reusable as-is or needs an `McpTool` route variant.
+- Whether the startup reconcile belongs in `app.rs` boot or a scheduler init hook.

--- a/docs/superpowers/specs/2026-07-08-mcp-background-jobs-design.md
+++ b/docs/superpowers/specs/2026-07-08-mcp-background-jobs-design.md
@@ -135,16 +135,22 @@ One generic builtin (not per-server generated variants) keeps the mechanism univ
 | `src/agent/job_monitor.rs` | reuse; add a route variant if the existing one is Claude-Code-specific |
 | `src/app.rs` | wire builtins (mcp client store + scheduler slot), startup reconcile |
 | `src/channels/web/features/jobs/`, `src/channels/web/types.rs` | surface a `mode`/`kind` so MCP jobs are distinguishable in `/api/jobs` |
-| `src/cli/mcp.rs` | `--timeout-secs` / `--allow-background` flags on `mcp add` / `mcp update` |
+| `src/cli/mcp.rs` | `--timeout-secs` / `--allow-background` flags on the existing `mcp add` (already an upsert at `:257`, so it doubles as edit — no new `update` subcommand) |
 | `.env.example`, `src/channels/web/CLAUDE.md` | document the new config + tools |
 
 ## Config surface (enabling msbsandbox after build)
 
+`timeout_secs` and `allow_background` are **per-server properties**, so they live on the `McpServerConfig` row — which is already DB-persisted via `servers.upsert(config)` (`src/cli/mcp.rs:257`). That row is the single source of truth. Deliberately **not** exposed as a generic `settings` key (e.g. `mcp.msbsandbox.timeout_secs`), which would duplicate the source of truth and violate the single-source rule (`.claude/rules/types.md`, `.claude/rules/architecture.md`).
+
+Because `mcp add` already upserts, it doubles as the edit path — no new `update` subcommand:
+
 ```
-ironclaw mcp update msbsandbox --timeout-secs 3600 --allow-background
+ironclaw mcp add msbsandbox --transport stdio --command node \
+  --arg /usr/local/lib/msb-mcp-shim.js --env MSB_BIN=/home/ironclaw/.microsandbox/bin/msb \
+  --timeout-secs 3600 --allow-background
 ```
 
-(or the DB-settings equivalent). The agent can then background long sandbox jobs; every other server and every quick call stays fast-and-synchronous.
+(A direct DB edit of the server-config row remains a power-user escape hatch, not the documented path.) The agent can then background long sandbox jobs; every other server and every quick call stays fast-and-synchronous.
 
 ## Open implementation questions (resolve during planning, not blocking)
 

--- a/src/agent/agent_loop.rs
+++ b/src/agent/agent_loop.rs
@@ -612,6 +612,17 @@ impl Agent {
             // dispatcher (#3243 HIGH iteration-2 gap).
             scheduler.set_runtime_policy(policy.clone());
         }
+        // Wire MCP background jobs: the caller resolves per-user MCP clients via
+        // the extension manager's shared store, and finished jobs resume the
+        // originating thread through the channels' inject channel. Both are
+        // available here, before the scheduler is shared as an `Arc`.
+        if let Some(ref em) = deps.extension_manager {
+            let caller: Arc<dyn crate::worker::mcp_job::McpCaller> =
+                Arc::new(crate::worker::mcp_job::StoreMcpCaller {
+                    client_store: em.mcp_client_store(),
+                });
+            scheduler.set_mcp_deps(caller, channels.inject_sender());
+        }
         let scheduler = Arc::new(scheduler);
 
         Self {

--- a/src/agent/scheduler.rs
+++ b/src/agent/scheduler.rs
@@ -9,6 +9,7 @@ use tokio::task::JoinHandle;
 use uuid::Uuid;
 
 use crate::agent::task::{Task, TaskContext, TaskOutput};
+use crate::channels::IncomingMessage;
 use crate::config::AgentConfig;
 use crate::context::{ContextManager, JobContext, JobState};
 use crate::error::{Error, JobError};
@@ -20,6 +21,7 @@ use crate::tools::{
     prepare_tool_params,
 };
 use crate::worker::job::{Worker, WorkerDeps};
+use crate::worker::mcp_job::{McpCaller, McpJobDeps, McpJobSpec, run_mcp_job};
 use ironclaw_llm::LlmProvider;
 use ironclaw_safety::SafetyLayer;
 
@@ -74,6 +76,13 @@ pub struct Scheduler {
     /// model-facing tool list filter applies to background jobs too.
     /// `None` in tests / before `Config::with_runtime_overrides` runs.
     runtime_policy: Option<ironclaw_host_api::runtime_policy::EffectiveRuntimePolicy>,
+    /// Caller used by `dispatch_mcp_job` to invoke MCP tools. `None` until
+    /// wired (MCP background jobs disabled). Held as a trait object so it is
+    /// injectable in tests (production wires `StoreMcpCaller`).
+    mcp_caller: Option<Arc<dyn McpCaller>>,
+    /// Injection channel into the agent loop — how a finished MCP job resumes
+    /// the originating thread. Same `mpsc::Sender` the channels feed.
+    inject_tx: Option<mpsc::Sender<IncomingMessage>>,
     /// Running jobs (main LLM-driven jobs).
     jobs: Arc<RwLock<HashMap<Uuid, ScheduledJob>>>,
     /// Running sub-tasks (tool executions, background tasks).
@@ -101,6 +110,8 @@ impl Scheduler {
             sse_tx: None,
             http_interceptor: None,
             runtime_policy: None,
+            mcp_caller: None,
+            inject_tx: None,
             jobs: Arc::new(RwLock::new(HashMap::new())),
             subtasks: Arc::new(RwLock::new(HashMap::new())),
         }
@@ -109,6 +120,18 @@ impl Scheduler {
     /// Set the SSE manager for live job event streaming.
     pub fn set_sse_sender(&mut self, sse: Arc<crate::channels::web::sse::SseManager>) {
         self.sse_tx = Some(sse);
+    }
+
+    /// Wire the dependencies MCP background jobs need: the `McpCaller` that
+    /// invokes tools and the injection channel that resumes the originating
+    /// thread on completion. Until this is called, `dispatch_mcp_job` errors.
+    pub fn set_mcp_deps(
+        &mut self,
+        caller: Arc<dyn McpCaller>,
+        inject_tx: mpsc::Sender<IncomingMessage>,
+    ) {
+        self.mcp_caller = Some(caller);
+        self.inject_tx = Some(inject_tx);
     }
 
     /// Set the HTTP interceptor for trace recording/replay.
@@ -248,6 +271,52 @@ impl Scheduler {
         }
 
         self.schedule_with_context(job_id, approval_context).await?;
+        Ok(job_id)
+    }
+
+    /// Dispatch a single MCP tool call as a durable background job: persist the
+    /// job (so the runner's FK references are valid) then spawn the non-LLM
+    /// [`run_mcp_job`] runner. Unlike LLM jobs there is no `Worker` and no
+    /// scheduling here — and we do NOT transition to `InProgress`, because
+    /// `run_mcp_job` owns that transition. Returns the new job id.
+    pub async fn dispatch_mcp_job(&self, spec: McpJobSpec) -> Result<Uuid, JobError> {
+        // Check config before creating a job so we never leave an orphan.
+        let caller = self.mcp_caller.clone().ok_or_else(|| JobError::Failed {
+            id: Uuid::nil(),
+            reason: "MCP background jobs are not configured".to_string(),
+        })?;
+
+        let title = format!("mcp:{}/{}", spec.server, spec.tool);
+        let description = format!("Background MCP tool call: {}", spec.tool);
+        let job_id = self
+            .context_manager
+            .create_job_for_user(&spec.user_id, &title, &description)
+            .await?;
+
+        // Persist the `mcp_tool` metadata atomically and read the context back
+        // for an FK-valid DB row before spawning (mirrors `dispatch_job_inner`).
+        let ctx = self
+            .context_manager
+            .update_context_and_get(job_id, |c| {
+                c.metadata = spec.to_metadata();
+            })
+            .await?;
+        if let Some(ref store) = self.store {
+            store.save_job(&ctx).await.map_err(|e| JobError::Failed {
+                id: job_id,
+                reason: format!("failed to persist mcp job: {e}"),
+            })?;
+        }
+
+        let deps = McpJobDeps {
+            context_manager: self.context_manager.clone(),
+            store: self.store.clone(),
+            sse_tx: self.sse_tx.clone(),
+            inject_tx: self.inject_tx.clone(),
+            caller,
+            safety: self.safety.clone(),
+        };
+        tokio::spawn(run_mcp_job(job_id, spec, deps));
         Ok(job_id)
     }
 
@@ -928,6 +997,65 @@ mod tests {
         assert!(ctx.metadata.is_null() || ctx.metadata == serde_json::json!({})); // safety: test code
         // No user tokens AND unlimited config means max_tokens stays at default
         assert_eq!(ctx.max_tokens, 0, "unlimited config"); // safety: test code
+    }
+
+    fn test_mcp_spec() -> McpJobSpec {
+        McpJobSpec {
+            server: "msbsandbox".into(),
+            tool: "run_python".into(),
+            params: serde_json::json!({"code":"print(1)"}),
+            user_id: "u1".into(),
+            channel: "gateway".into(),
+            thread_id: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn dispatch_mcp_job_creates_completes_and_injects() {
+        struct FakeCaller;
+        #[async_trait::async_trait]
+        impl McpCaller for FakeCaller {
+            async fn call(
+                &self,
+                _user_id: &str,
+                _server: &str,
+                _tool: &str,
+                _params: serde_json::Value,
+            ) -> Result<String, String> {
+                Ok("RESULT_OK".into())
+            }
+        }
+
+        let mut sched = make_test_scheduler(0);
+        let (tx, mut rx) = mpsc::channel(4);
+        sched.set_mcp_deps(Arc::new(FakeCaller), tx);
+
+        let job_id = sched.dispatch_mcp_job(test_mcp_spec()).await.unwrap();
+
+        // Dispatch tagged the job with the mcp_tool mode.
+        let ctx = sched.context_manager.get_context(job_id).await.unwrap();
+        assert_eq!(
+            ctx.metadata.get("mode").and_then(|v| v.as_str()),
+            Some("mcp_tool")
+        );
+
+        // The spawned runner completes and injects the wrapped result — waiting
+        // on the inject channel is the completion signal.
+        let msg = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+            .await
+            .expect("runner should inject within 5s")
+            .expect("an inject message");
+        assert!(msg.content.contains("RESULT_OK"), "body: {}", msg.content);
+
+        let ctx = sched.context_manager.get_context(job_id).await.unwrap();
+        assert_eq!(ctx.state, JobState::Completed);
+    }
+
+    #[tokio::test]
+    async fn dispatch_mcp_job_without_caller_errors() {
+        // No set_mcp_deps → MCP jobs unconfigured → clean error, no orphan job.
+        let sched = make_test_scheduler(0);
+        assert!(sched.dispatch_mcp_job(test_mcp_spec()).await.is_err());
     }
 
     #[test]

--- a/src/agent/scheduler.rs
+++ b/src/agent/scheduler.rs
@@ -286,7 +286,12 @@ impl Scheduler {
             reason: "MCP background jobs are not configured".to_string(),
         })?;
 
-        let title = format!("mcp:{}/{}", spec.server, spec.tool);
+        let title = format!(
+            "{}{}/{}",
+            crate::worker::mcp_job::MCP_JOB_TITLE_PREFIX,
+            spec.server,
+            spec.tool
+        );
         let description = format!("Background MCP tool call: {}", spec.tool);
         let job_id = self
             .context_manager

--- a/src/channels/web/CLAUDE.md
+++ b/src/channels/web/CLAUDE.md
@@ -105,6 +105,17 @@ subset that can later be replaced by a typed `Deps` alias.
 | GET | `/api/jobs/{id}/files/list` | List files in job workspace |
 | GET | `/api/jobs/{id}/files/read` | Read a file from job workspace |
 
+`GET /api/jobs` merges sandbox jobs and agent jobs. Each `JobInfo` carries an
+optional `mode` field, omitted for ordinary jobs and set to `"mcp_tool"` for
+**MCP background jobs** (a long MCP tool call run as a durable job via the
+`tool_job_start` builtin). MCP jobs are identified by their durable `mcp:`
+title prefix (`worker::mcp_job::MCP_JOB_TITLE_PREFIX`), not `metadata.mode` —
+job metadata is not persisted on the libSQL backend. The agent starts one with
+`tool_job_start(server, tool, arguments)` (returns a `job_id` immediately; the
+safety-scanned result is injected back into the originating thread on
+completion) and polls it with `tool_job_status(job_id)`. Only servers added
+with `--allow-background` are eligible.
+
 ### Skills
 | Method | Path | Description |
 |--------|------|-------------|

--- a/src/channels/web/features/jobs/mod.rs
+++ b/src/channels/web/features/jobs/mod.rs
@@ -17,6 +17,15 @@ use crate::channels::web::types::*;
 use crate::orchestrator::job_manager::{ContainerJobManager, JobCreationParams, JobMode};
 use crate::ownership::Owned;
 
+/// The `mode` label for a job-list entry. Background MCP-tool jobs are
+/// identified by the durable `mcp:` title prefix (`MCP_JOB_TITLE_PREFIX`) rather
+/// than `metadata.mode`, which is not persisted across all DB backends.
+fn job_mode_for_title(title: &str) -> Option<String> {
+    title
+        .starts_with(crate::worker::mcp_job::MCP_JOB_TITLE_PREFIX)
+        .then(|| "mcp_tool".to_string())
+}
+
 fn db_error(context: &str, e: impl std::fmt::Display) -> (StatusCode, String) {
     tracing::error!(%e, context, "Database error in jobs handler");
     (
@@ -97,6 +106,7 @@ pub async fn jobs_list_handler(
                     user_id: j.user_id.clone(),
                     created_at: j.created_at.to_rfc3339(),
                     started_at: j.started_at.map(|dt| dt.to_rfc3339()),
+                    mode: None,
                 });
             }
         }
@@ -119,6 +129,7 @@ pub async fn jobs_list_handler(
                     user_id: j.user_id.clone(),
                     created_at: j.created_at.to_rfc3339(),
                     started_at: j.started_at.map(|dt| dt.to_rfc3339()),
+                    mode: job_mode_for_title(&j.title),
                 });
             }
         }
@@ -944,6 +955,17 @@ mod tests {
 
     use crate::orchestrator::TokenStore;
     use crate::orchestrator::job_manager::ContainerJobConfig;
+
+    #[test]
+    fn job_mode_flags_mcp_jobs_by_title_prefix() {
+        assert_eq!(
+            job_mode_for_title("mcp:msbsandbox/run_python"),
+            Some("mcp_tool".to_string())
+        );
+        assert_eq!(job_mode_for_title("chat turn"), None);
+        // Requires the full `mcp:` prefix, not just "mcp".
+        assert_eq!(job_mode_for_title("mcp"), None);
+    }
 
     #[cfg(feature = "libsql")]
     #[tokio::test]

--- a/src/channels/web/types.rs
+++ b/src/channels/web/types.rs
@@ -322,6 +322,10 @@ pub struct JobInfo {
     pub user_id: String,
     pub created_at: String,
     pub started_at: Option<String>,
+    /// Job kind label. `Some("mcp_tool")` for background MCP-tool jobs; omitted
+    /// for ordinary agent/sandbox jobs.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mode: Option<String>,
 }
 
 #[derive(Debug, Serialize)]

--- a/src/cli/mcp.rs
+++ b/src/cli/mcp.rs
@@ -70,6 +70,94 @@ pub struct McpAddArgs {
     /// Server description
     #[arg(long)]
     pub description: Option<String>,
+
+    /// Per-call transport timeout in seconds (default 30, clamped 5..=21600).
+    /// Raise it for slow local backends (e.g. a cold 27B sandbox).
+    #[arg(long)]
+    pub timeout_secs: Option<u64>,
+
+    /// Allow this server's tools to run as background jobs (opt-in).
+    #[arg(long)]
+    pub allow_background: bool,
+}
+
+impl McpAddArgs {
+    /// Build a validated `McpServerConfig` from the parsed CLI args.
+    ///
+    /// Extracted from `add_server` so the arg→config mapping (including the
+    /// timeout / background flags) is unit-testable without touching the DB.
+    pub fn to_config(&self) -> anyhow::Result<McpServerConfig> {
+        let transport_lower = self.transport.to_lowercase();
+
+        let mut config =
+            match transport_lower.as_str() {
+                "stdio" => {
+                    let cmd = self.command.clone().ok_or_else(|| {
+                        anyhow::anyhow!("--command is required for stdio transport")
+                    })?;
+                    let env_map: HashMap<String, String> = self.env.iter().cloned().collect();
+                    McpServerConfig::new_stdio(&self.name, &cmd, self.cmd_args.clone(), env_map)
+                }
+                "unix" => {
+                    let socket_path = self.socket.clone().ok_or_else(|| {
+                        anyhow::anyhow!("--socket is required for unix transport")
+                    })?;
+                    McpServerConfig::new_unix(&self.name, &socket_path)
+                }
+                "http" => {
+                    let url_val = self
+                        .url
+                        .as_deref()
+                        .ok_or_else(|| anyhow::anyhow!("URL is required for http transport"))?;
+                    McpServerConfig::new(&self.name, url_val)
+                }
+                other => {
+                    anyhow::bail!(
+                        "Unknown transport type '{}'. Supported: http, stdio, unix",
+                        other
+                    );
+                }
+            };
+
+        if !self.headers.is_empty() {
+            let headers_map: HashMap<String, String> = self.headers.iter().cloned().collect();
+            config = config.with_headers(headers_map);
+        }
+
+        if let Some(desc) = self.description.clone() {
+            config = config.with_description(desc);
+        }
+
+        // Set up OAuth if client_id is provided (HTTP transport only)
+        if let Some(client_id) = self.client_id.clone() {
+            if transport_lower != "http" {
+                anyhow::bail!("OAuth authentication is only supported with http transport");
+            }
+
+            let mut oauth = OAuthConfig::new(client_id);
+
+            if let (Some(auth), Some(token)) = (self.auth_url.clone(), self.token_url.clone()) {
+                oauth = oauth.with_endpoints(auth, token);
+            }
+
+            if let Some(scopes_str) = self.scopes.clone() {
+                let scope_list: Vec<String> = scopes_str
+                    .split(',')
+                    .map(|s| s.trim().to_string())
+                    .collect();
+                oauth = oauth.with_scopes(scope_list);
+            }
+
+            config = config.with_oauth(oauth);
+        }
+
+        // Fields are public on McpServerConfig (Task 1); set directly.
+        config.timeout_secs = self.timeout_secs;
+        config.allow_background = self.allow_background;
+
+        config.validate()?;
+        Ok(config)
+    }
 }
 
 #[derive(Subcommand, Debug, Clone)]
@@ -165,91 +253,11 @@ pub async fn run_mcp_command(cmd: McpCommand) -> anyhow::Result<()> {
 
 /// Add a new MCP server.
 async fn add_server(args: McpAddArgs) -> anyhow::Result<()> {
-    let McpAddArgs {
-        name,
-        url,
-        transport,
-        command,
-        cmd_args,
-        env,
-        socket,
-        headers,
-        client_id,
-        auth_url,
-        token_url,
-        scopes,
-        description,
-    } = args;
+    let config = args.to_config()?;
 
-    let transport_lower = transport.to_lowercase();
-
-    let mut config = match transport_lower.as_str() {
-        "stdio" => {
-            let cmd = command
-                .clone()
-                .ok_or_else(|| anyhow::anyhow!("--command is required for stdio transport"))?;
-            let env_map: HashMap<String, String> = env.into_iter().collect();
-            McpServerConfig::new_stdio(&name, &cmd, cmd_args.clone(), env_map)
-        }
-        "unix" => {
-            let socket_path = socket
-                .clone()
-                .ok_or_else(|| anyhow::anyhow!("--socket is required for unix transport"))?;
-            McpServerConfig::new_unix(&name, &socket_path)
-        }
-        "http" => {
-            let url_val = url
-                .as_deref()
-                .ok_or_else(|| anyhow::anyhow!("URL is required for http transport"))?;
-            McpServerConfig::new(&name, url_val)
-        }
-        other => {
-            anyhow::bail!(
-                "Unknown transport type '{}'. Supported: http, stdio, unix",
-                other
-            );
-        }
-    };
-
-    // Apply headers if any
-    if !headers.is_empty() {
-        let headers_map: HashMap<String, String> = headers.into_iter().collect();
-        config = config.with_headers(headers_map);
-    }
-
-    if let Some(desc) = description {
-        config = config.with_description(desc);
-    }
-
-    // Track if auth is required
-    let requires_auth = client_id.is_some();
-
-    // Set up OAuth if client_id is provided (HTTP transport only)
-    if let Some(client_id) = client_id {
-        if transport_lower != "http" {
-            anyhow::bail!("OAuth authentication is only supported with http transport");
-        }
-
-        let mut oauth = OAuthConfig::new(client_id);
-
-        if let (Some(auth), Some(token)) = (auth_url, token_url) {
-            oauth = oauth.with_endpoints(auth, token);
-        }
-
-        if let Some(scopes_str) = scopes {
-            let scope_list: Vec<String> = scopes_str
-                .split(',')
-                .map(|s| s.trim().to_string())
-                .collect();
-            oauth = oauth.with_scopes(scope_list);
-        }
-
-        config = config.with_oauth(oauth);
-    }
-
-    // Validate
-    config.validate()?;
+    let requires_auth = args.client_id.is_some();
     let has_custom_auth_header = config.has_custom_auth_header();
+    let transport_lower = args.transport.to_lowercase();
 
     // Save (DB if available, else disk)
     let (db, owner_id) = connect_db().await;
@@ -258,29 +266,29 @@ async fn add_server(args: McpAddArgs) -> anyhow::Result<()> {
     save_servers(db.as_deref(), &owner_id, &servers).await?;
 
     println!();
-    println!("  ✓ Added MCP server '{}'", name);
+    println!("  ✓ Added MCP server '{}'", args.name);
 
     match transport_lower.as_str() {
         "stdio" => {
             println!(
                 "    Transport: stdio (command: {})",
-                command.as_deref().unwrap_or("")
+                args.command.as_deref().unwrap_or("")
             );
         }
         "unix" => {
             println!(
                 "    Transport: unix (socket: {})",
-                socket.as_deref().unwrap_or("")
+                args.socket.as_deref().unwrap_or("")
             );
         }
         _ => {
-            println!("    URL: {}", url.as_deref().unwrap_or(""));
+            println!("    URL: {}", args.url.as_deref().unwrap_or(""));
         }
     }
 
     if requires_auth && !has_custom_auth_header {
         println!();
-        println!("  Run 'ironclaw mcp auth {}' to authenticate.", name);
+        println!("  Run 'ironclaw mcp auth {}' to authenticate.", args.name);
     }
 
     println!();
@@ -689,6 +697,51 @@ fn truncate_description(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Baseline `mcp add` args for an http server with all optional flags
+    /// at their defaults; tests override just the field under test.
+    fn base_add_args(name: &str) -> McpAddArgs {
+        McpAddArgs {
+            name: name.to_string(),
+            url: Some("http://localhost:9999".to_string()),
+            transport: "http".to_string(),
+            command: None,
+            cmd_args: Vec::new(),
+            env: Vec::new(),
+            socket: None,
+            headers: Vec::new(),
+            client_id: None,
+            auth_url: None,
+            token_url: None,
+            scopes: None,
+            description: None,
+            timeout_secs: None,
+            allow_background: false,
+        }
+    }
+
+    #[test]
+    fn add_args_set_timeout_and_background() {
+        let mut args = base_add_args("srv");
+        args.timeout_secs = Some(3600);
+        args.allow_background = true;
+
+        let cfg = args.to_config().expect("build config");
+        assert_eq!(cfg.timeout_secs, Some(3600));
+        assert!(cfg.allow_background);
+        // effective_timeout reflects the override, not the 30s default.
+        assert_eq!(
+            cfg.effective_timeout(),
+            std::time::Duration::from_secs(3600)
+        );
+    }
+
+    #[test]
+    fn add_args_default_flags_are_conservative() {
+        let cfg = base_add_args("srv").to_config().expect("build config");
+        assert_eq!(cfg.timeout_secs, None);
+        assert!(!cfg.allow_background);
+    }
 
     #[test]
     fn test_mcp_command_parsing() {

--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -1477,7 +1477,7 @@ impl ExtensionManager {
     /// the global `ToolRegistry` hold an `Arc<McpClientStore>` and resolve
     /// the caller's client at dispatch time via
     /// `store.get(ctx.user_id, server_name)`.
-    pub(crate) fn mcp_client_store(&self) -> Arc<crate::tools::mcp::McpClientStore> {
+    pub fn mcp_client_store(&self) -> Arc<crate::tools::mcp::McpClientStore> {
         Arc::clone(&self.mcp_clients)
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -879,6 +879,18 @@ async fn async_main() -> anyhow::Result<()> {
         components.secrets_store.clone(),
     );
 
+    // Generic MCP-as-background-job tools. `tool_job_start` needs the shared
+    // MCP client store (owned by the extension manager) for the per-server
+    // `allow_background` check; falls back to status-only without it.
+    components.tools.register_mcp_job_tools(
+        Arc::clone(&components.context_manager),
+        Some(scheduler_slot.clone()),
+        components
+            .extension_manager
+            .as_ref()
+            .map(|em| em.mcp_client_store()),
+    );
+
     // ── Gateway channel ────────────────────────────────────────────────
 
     let mut gateway_url: Option<String> = None;

--- a/src/main.rs
+++ b/src/main.rs
@@ -891,6 +891,17 @@ async fn async_main() -> anyhow::Result<()> {
             .map(|em| em.mcp_client_store()),
     );
 
+    // Reconcile MCP jobs left in-flight by a previous run: their in-memory
+    // runner died with the process, so mark them Stuck for self-repair.
+    if let Some(ref db) = components.db {
+        let store = ironclaw::tenant::SystemScope::new(Arc::clone(db));
+        match ironclaw::worker::mcp_job::reconcile_orphaned_mcp_jobs(&store).await {
+            Ok(0) => {}
+            Ok(n) => tracing::info!("Reconciled {n} orphaned in-flight MCP job(s) to Stuck"),
+            Err(e) => tracing::warn!("MCP job startup reconcile failed: {e}"),
+        }
+    }
+
     // ── Gateway channel ────────────────────────────────────────────────
 
     let mut gateway_url: Option<String> = None;

--- a/src/tools/README.md
+++ b/src/tools/README.md
@@ -139,3 +139,22 @@ Both are first-class in the extension system (`ironclaw tool install` handles bo
 | Multiple tools share one OAuth token (e.g., Google suite) | **WASM** |
 
 The LLM-facing interface is identical for both (tool name, schema, execute), so swapping between them is transparent to the agent.
+
+### MCP per-server timeout
+
+Each MCP server has its own per-call transport timeout. The default is **30s**;
+raise it for slow local backends (e.g. a cold 27B sandbox or a long shell job)
+and it is clamped to `5..=21600` seconds (6h). This is **per-server DB config**,
+not an environment variable — set it when adding or editing the server:
+
+```bash
+ironclaw mcp add msbsandbox --transport stdio --command node \
+    --arg /usr/local/lib/msb-mcp-shim.js \
+    --timeout-secs 3600 --allow-background
+```
+
+`--allow-background` (opt-in, default off) marks the server's tools as eligible
+to run as durable background jobs. `mcp add` upserts, so re-running it on an
+existing server name edits these settings in place. The configured timeout also
+becomes the tool's execution cap (so a long call isn't re-clipped to the generic
+60s tool default) and is preserved across automatic stdio-process restarts.

--- a/src/tools/builtin/mod.rs
+++ b/src/tools/builtin/mod.rs
@@ -22,6 +22,7 @@ pub mod skill_tools;
 pub mod system;
 mod time;
 mod tool_info;
+mod tool_job;
 
 pub use echo::EchoTool;
 pub use extension_tools::{
@@ -53,6 +54,7 @@ pub use skill_tools::{SkillInstallTool, SkillListTool, SkillRemoveTool, SkillSea
 pub use system::{SystemToolsListTool, SystemVersionTool};
 pub use time::TimeTool;
 pub use tool_info::ToolInfoTool;
+pub use tool_job::{BackgroundPolicy, CreateMcpJobTool, McpJobStatusTool, StoreBackgroundPolicy};
 mod html_converter;
 pub mod image_analyze;
 pub mod image_edit;

--- a/src/tools/builtin/tool_job.rs
+++ b/src/tools/builtin/tool_job.rs
@@ -1,0 +1,335 @@
+//! Generic "run an MCP tool as a background job" builtins.
+//!
+//! `tool_job_start` launches a long-running MCP tool call as a durable
+//! background job (via [`crate::agent::Scheduler::dispatch_mcp_job`]) and
+//! returns immediately with a job id; the wrapped result is later injected back
+//! into the originating thread. `tool_job_status` reports a job's state.
+//!
+//! The MCP tool is named by **separate `server` + `tool`** params rather than a
+//! single prefixed name: `mcp_tool_id` (the prefix scheme) is a lossy
+//! single-underscore join and is not reliably invertible.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use uuid::Uuid;
+
+use crate::context::{ContextManager, JobContext};
+use crate::tools::mcp::McpClientStore;
+use crate::tools::tool::{Tool, ToolError, ToolOutput, require_str};
+use crate::worker::mcp_job::McpJobSpec;
+
+use super::job::SchedulerSlot;
+
+/// Resolves whether a server's tools may run as background jobs, for a user.
+///
+/// A seam over the client store so the tools are testable without live MCP
+/// clients (mirrors the `McpCaller` seam on the runner).
+#[async_trait]
+pub trait BackgroundPolicy: Send + Sync {
+    /// `Some(true)` = server active and background-enabled; `Some(false)` =
+    /// active but not enabled (opt-in missing); `None` = not active for the user.
+    async fn allows_background(&self, user_id: &str, server: &str) -> Option<bool>;
+}
+
+/// Production policy: reads the per-user active client's `allow_background`.
+pub struct StoreBackgroundPolicy {
+    pub client_store: Arc<McpClientStore>,
+}
+
+#[async_trait]
+impl BackgroundPolicy for StoreBackgroundPolicy {
+    async fn allows_background(&self, user_id: &str, server: &str) -> Option<bool> {
+        self.client_store
+            .get(user_id, server)
+            .await
+            .map(|c| c.allows_background())
+    }
+}
+
+/// `tool_job_start` — launch an MCP tool call as a background job.
+pub struct CreateMcpJobTool {
+    scheduler_slot: SchedulerSlot,
+    policy: Arc<dyn BackgroundPolicy>,
+}
+
+impl CreateMcpJobTool {
+    pub fn new(scheduler_slot: SchedulerSlot, policy: Arc<dyn BackgroundPolicy>) -> Self {
+        Self {
+            scheduler_slot,
+            policy,
+        }
+    }
+}
+
+#[async_trait]
+impl Tool for CreateMcpJobTool {
+    fn name(&self) -> &str {
+        "tool_job_start"
+    }
+
+    fn description(&self) -> &str {
+        "Run a long-running MCP tool call as a background job. Returns a job_id \
+         immediately; the result is delivered back into this conversation when it \
+         finishes. Only works for MCP servers enabled for background jobs. Use \
+         tool_job_status to poll."
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "server": { "type": "string", "description": "MCP server name, e.g. 'msbsandbox'" },
+                "tool": { "type": "string", "description": "MCP tool name on that server, e.g. 'run_python'" },
+                "arguments": { "type": "object", "description": "Arguments object passed to the tool" }
+            },
+            "required": ["server", "tool"]
+        })
+    }
+
+    async fn execute(
+        &self,
+        params: serde_json::Value,
+        ctx: &JobContext,
+    ) -> Result<ToolOutput, ToolError> {
+        let start = std::time::Instant::now();
+
+        let server = require_str(&params, "server")?.to_string();
+        let tool = require_str(&params, "tool")?.to_string();
+        let arguments = params
+            .get("arguments")
+            .cloned()
+            .unwrap_or_else(|| serde_json::json!({}));
+
+        match self.policy.allows_background(&ctx.user_id, &server).await {
+            None => {
+                return Err(ToolError::InvalidParameters(format!(
+                    "MCP server '{server}' is not active for you; add and enable it first"
+                )));
+            }
+            Some(false) => {
+                return Err(ToolError::InvalidParameters(format!(
+                    "MCP server '{server}' is not enabled for background jobs \
+                     (re-add it with --allow-background)"
+                )));
+            }
+            Some(true) => {}
+        }
+
+        let scheduler = {
+            let guard = self.scheduler_slot.read().await;
+            guard.clone()
+        }
+        .ok_or_else(|| {
+            ToolError::ExecutionFailed("scheduler is not available for background jobs".to_string())
+        })?;
+
+        // Originating channel/thread for the auto-resume injection come from the
+        // dispatching turn's context metadata; fall back to the gateway channel.
+        let channel = ctx
+            .metadata
+            .get("channel")
+            .and_then(|v| v.as_str())
+            .unwrap_or("gateway")
+            .to_string();
+        let thread_id = ctx
+            .metadata
+            .get("thread_id")
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
+
+        let spec = McpJobSpec {
+            server: server.clone(),
+            tool: tool.clone(),
+            params: arguments,
+            user_id: ctx.user_id.clone(),
+            channel,
+            thread_id,
+        };
+
+        let job_id = scheduler.dispatch_mcp_job(spec).await.map_err(|e| {
+            ToolError::ExecutionFailed(format!("failed to start background job: {e}"))
+        })?;
+
+        Ok(ToolOutput::success(
+            serde_json::json!({
+                "job_id": job_id.to_string(),
+                "state": "in_progress",
+                "message": format!("Started {tool} on {server} as a background job"),
+            }),
+            start.elapsed(),
+        ))
+    }
+}
+
+/// `tool_job_status` — report the state of a background (or any) job.
+pub struct McpJobStatusTool {
+    context_manager: Arc<ContextManager>,
+}
+
+impl McpJobStatusTool {
+    pub fn new(context_manager: Arc<ContextManager>) -> Self {
+        Self { context_manager }
+    }
+}
+
+#[async_trait]
+impl Tool for McpJobStatusTool {
+    fn name(&self) -> &str {
+        "tool_job_status"
+    }
+
+    fn description(&self) -> &str {
+        "Check the state of a background job started with tool_job_start, by job_id."
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "job_id": { "type": "string", "description": "The job id returned by tool_job_start" }
+            },
+            "required": ["job_id"]
+        })
+    }
+
+    async fn execute(
+        &self,
+        params: serde_json::Value,
+        ctx: &JobContext,
+    ) -> Result<ToolOutput, ToolError> {
+        let start = std::time::Instant::now();
+        let job_id_str = require_str(&params, "job_id")?;
+        let job_id = Uuid::parse_str(job_id_str).map_err(|_| {
+            ToolError::InvalidParameters(format!("'{job_id_str}' is not a valid job id"))
+        })?;
+
+        let jc = self
+            .context_manager
+            .get_context(job_id)
+            .await
+            .map_err(|_| {
+                ToolError::InvalidParameters(format!("no job found for '{job_id_str}'"))
+            })?;
+
+        // Don't leak other users' jobs.
+        if jc.user_id != ctx.user_id {
+            return Err(ToolError::NotAuthorized(
+                "that job belongs to another user".to_string(),
+            ));
+        }
+
+        Ok(ToolOutput::success(
+            serde_json::json!({
+                "job_id": job_id.to_string(),
+                "state": format!("{:?}", jc.state),
+                "title": jc.title,
+            }),
+            start.elapsed(),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::sync::RwLock;
+
+    struct FakePolicy(Option<bool>);
+
+    #[async_trait]
+    impl BackgroundPolicy for FakePolicy {
+        async fn allows_background(&self, _user_id: &str, _server: &str) -> Option<bool> {
+            self.0
+        }
+    }
+
+    fn caller_ctx(user: &str) -> JobContext {
+        let mut jc = JobContext::new("caller", "caller turn");
+        jc.user_id = user.to_string();
+        jc
+    }
+
+    fn tool_with_policy(policy: Option<bool>) -> CreateMcpJobTool {
+        let slot: SchedulerSlot = Arc::new(RwLock::new(None)); // empty scheduler
+        CreateMcpJobTool::new(slot, Arc::new(FakePolicy(policy)))
+    }
+
+    #[tokio::test]
+    async fn start_rejects_inactive_server() {
+        let tool = tool_with_policy(None);
+        let params = serde_json::json!({"server":"srv","tool":"do"});
+        let err = tool.execute(params, &caller_ctx("u1")).await.unwrap_err();
+        assert!(matches!(err, ToolError::InvalidParameters(_)));
+    }
+
+    #[tokio::test]
+    async fn start_rejects_non_background_server() {
+        let tool = tool_with_policy(Some(false));
+        let params = serde_json::json!({"server":"srv","tool":"do"});
+        let err = tool.execute(params, &caller_ctx("u1")).await.unwrap_err();
+        match err {
+            ToolError::InvalidParameters(m) => assert!(m.contains("background")),
+            other => panic!("expected InvalidParameters, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn start_requires_server_and_tool() {
+        let tool = tool_with_policy(Some(true));
+        let err = tool
+            .execute(serde_json::json!({"server":"srv"}), &caller_ctx("u1"))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ToolError::InvalidParameters(_)));
+    }
+
+    #[tokio::test]
+    async fn start_passes_validation_then_needs_scheduler() {
+        // Eligible server + valid params, but the scheduler slot is empty →
+        // proves validation passed and the tool reached the dispatch step.
+        // (The eligible→job_id dispatch itself is covered by the scheduler's
+        // dispatch_mcp_job test.)
+        let tool = tool_with_policy(Some(true));
+        let params = serde_json::json!({"server":"srv","tool":"do","arguments":{"x":1}});
+        let err = tool.execute(params, &caller_ctx("u1")).await.unwrap_err();
+        assert!(matches!(err, ToolError::ExecutionFailed(_)));
+    }
+
+    #[tokio::test]
+    async fn status_reports_state_and_guards_ownership() {
+        let cm = Arc::new(ContextManager::new(5));
+        let job_id = cm.create_job_for_user("u1", "bg", "desc").await.unwrap();
+        let tool = McpJobStatusTool::new(cm);
+
+        // Owner sees the state.
+        let out = tool
+            .execute(
+                serde_json::json!({"job_id": job_id.to_string()}),
+                &caller_ctx("u1"),
+            )
+            .await
+            .unwrap();
+        assert_eq!(out.result.get("job_id").unwrap(), &job_id.to_string());
+
+        // A different user is denied.
+        let err = tool
+            .execute(
+                serde_json::json!({"job_id": job_id.to_string()}),
+                &caller_ctx("intruder"),
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ToolError::NotAuthorized(_)));
+
+        // Unknown id → InvalidParameters.
+        let err = tool
+            .execute(
+                serde_json::json!({"job_id": Uuid::new_v4().to_string()}),
+                &caller_ctx("u1"),
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ToolError::InvalidParameters(_)));
+    }
+}

--- a/src/tools/mcp/client.rs
+++ b/src/tools/mcp/client.rs
@@ -283,6 +283,7 @@ impl McpClient {
         let user_id_str: String = user_id.into();
         let transport = Arc::new(
             HttpMcpTransport::new(config.url.clone(), validated_name.as_str())
+                .with_timeout(config.effective_timeout())
                 .with_session_manager(session_manager.clone(), &user_id_str),
         );
 
@@ -762,6 +763,14 @@ impl McpClient {
     ) -> Result<Vec<Arc<dyn Tool>>, ToolError> {
         let mcp_tools = self.list_tools().await?;
         let server_name = self.server_name.as_str().to_string();
+        // Cap each tool's execution at the server's configured timeout so a
+        // long-timeout server isn't re-clipped to the generic tool default.
+        // Falls back to 30s (the transport default) when no config is held.
+        let timeout = self
+            .server_config
+            .as_ref()
+            .map(|c| c.effective_timeout())
+            .unwrap_or_else(|| std::time::Duration::from_secs(30));
 
         // Detect post-normalization collisions before registering. This is
         // a single linear pass; the n is small (a typical MCP server lists
@@ -798,6 +807,7 @@ impl McpClient {
                     provider_extension: server_name.clone(),
                     server_name: server_name.clone(),
                     client_store: store.clone(),
+                    timeout,
                 }) as Arc<dyn Tool>
             })
             .collect())
@@ -899,6 +909,11 @@ struct McpToolWrapper {
     provider_extension: String,
     server_name: String,
     client_store: Arc<super::McpClientStore>,
+    /// Execution cap for this tool, taken from the server's configured
+    /// `effective_timeout()` so a long-timeout MCP server isn't re-clipped
+    /// to the generic 60s tool default. Defaults to 30s when the client
+    /// holds no server config.
+    timeout: std::time::Duration,
 }
 
 #[async_trait]
@@ -915,6 +930,10 @@ impl Tool for McpToolWrapper {
 
     fn provider_extension(&self) -> Option<&str> {
         Some(&self.provider_extension)
+    }
+
+    fn execution_timeout(&self) -> std::time::Duration {
+        self.timeout
     }
 
     async fn execute(
@@ -1708,7 +1727,17 @@ mod tests {
             provider_extension: server.to_string(),
             server_name: server.to_string(),
             client_store: Arc::new(crate::tools::mcp::McpClientStore::new()),
+            timeout: std::time::Duration::from_secs(30),
         }
+    }
+
+    #[test]
+    fn mcp_tool_wrapper_reports_server_timeout() {
+        // A wrapper built with an explicit 900s cap reports it verbatim from
+        // execution_timeout(), rather than the generic 60s tool default.
+        let mut w = test_wrapper(make_test_mcp_tool(false), "srv");
+        w.timeout = std::time::Duration::from_secs(900);
+        assert_eq!(w.execution_timeout(), std::time::Duration::from_secs(900));
     }
 
     #[test]

--- a/src/tools/mcp/client.rs
+++ b/src/tools/mcp/client.rs
@@ -384,6 +384,16 @@ impl McpClient {
         self.server_name.as_str()
     }
 
+    /// Whether this server's tools may be run as background jobs. Reads the
+    /// `allow_background` opt-in from the server config; defaults `false` when
+    /// the client holds no config (e.g. transport-only test clients).
+    pub fn allows_background(&self) -> bool {
+        self.server_config
+            .as_ref()
+            .map(|c| c.allow_background)
+            .unwrap_or(false)
+    }
+
     /// Get the typed server name.
     pub fn server_name_typed(&self) -> &McpServerName {
         &self.server_name

--- a/src/tools/mcp/config.rs
+++ b/src/tools/mcp/config.rs
@@ -67,6 +67,17 @@ pub struct McpServerConfig {
     /// while the server is currently inactive.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub cached_tools: Vec<McpTool>,
+
+    /// Max seconds for a single call to this server before the transport times
+    /// out. `None` uses the default 30s. Clamped to 5..=21600 by
+    /// `effective_timeout()`. Local backends (a cold 27B sandbox) need more.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout_secs: Option<u64>,
+
+    /// Whether this server's tools may be run as background jobs
+    /// (`tool_job_start`). Opt-in; defaults false.
+    #[serde(default)]
+    pub allow_background: bool,
 }
 
 fn default_true() -> bool {
@@ -85,6 +96,8 @@ impl McpServerConfig {
             enabled: true,
             description: None,
             cached_tools: Vec::new(),
+            timeout_secs: None,
+            allow_background: false,
         }
     }
 
@@ -108,6 +121,8 @@ impl McpServerConfig {
             enabled: true,
             description: None,
             cached_tools: Vec::new(),
+            timeout_secs: None,
+            allow_background: false,
         }
     }
 
@@ -124,6 +139,8 @@ impl McpServerConfig {
             enabled: true,
             description: None,
             cached_tools: Vec::new(),
+            timeout_secs: None,
+            allow_background: false,
         }
     }
 
@@ -156,6 +173,12 @@ impl McpServerConfig {
                 EffectiveTransport::Unix { socket_path }
             }
         }
+    }
+
+    /// Per-call transport timeout, clamped to a sane range. Default 30s.
+    pub fn effective_timeout(&self) -> std::time::Duration {
+        let secs = self.timeout_secs.unwrap_or(30).clamp(5, 21_600);
+        std::time::Duration::from_secs(secs)
     }
 
     /// Validate the server configuration.
@@ -1761,5 +1784,27 @@ mod tests {
             std::env::remove_var("NEARAI_BASE_URL");
             std::env::remove_var("NEARAI_API_KEY");
         }
+    }
+
+    #[test]
+    fn effective_timeout_defaults_to_30s_and_clamps() {
+        let mut c = McpServerConfig::new("s", "http://x");
+        assert_eq!(c.effective_timeout(), std::time::Duration::from_secs(30));
+        c.timeout_secs = Some(3600);
+        assert_eq!(c.effective_timeout(), std::time::Duration::from_secs(3600));
+        c.timeout_secs = Some(1); // below floor
+        assert_eq!(c.effective_timeout(), std::time::Duration::from_secs(5));
+        c.timeout_secs = Some(999_999); // above ceiling
+        assert_eq!(c.effective_timeout(), std::time::Duration::from_secs(21600));
+    }
+
+    #[test]
+    fn allow_background_defaults_false_and_roundtrips() {
+        let c = McpServerConfig::new("s", "http://x");
+        assert!(!c.allow_background);
+        let json = serde_json::to_string(&c).unwrap();
+        let back: McpServerConfig = serde_json::from_str(&json).unwrap();
+        assert!(!back.allow_background);
+        assert_eq!(back.timeout_secs, None);
     }
 }

--- a/src/tools/mcp/factory.rs
+++ b/src/tools/mcp/factory.rs
@@ -70,6 +70,7 @@ pub async fn create_client_from_config(
                     command,
                     args.to_vec(),
                     env.clone(),
+                    server.effective_timeout(),
                 )
                 .await
                 .map_err(|e| McpFactoryError::StdioSpawn {
@@ -133,6 +134,7 @@ pub async fn create_client_from_config(
             // transport must know about it to read/write the header.
             let transport = Arc::new(
                 HttpMcpTransport::new(server.url.clone(), validated_name.as_str())
+                    .with_timeout(server.effective_timeout())
                     .with_session_manager(Arc::clone(session_manager), user_id),
             );
             Ok(McpClient::new_with_transport(

--- a/src/tools/mcp/http_transport.rs
+++ b/src/tools/mcp/http_transport.rs
@@ -69,9 +69,6 @@ impl HttpMcpTransport {
     }
 
     /// Override the HTTP request timeout (default 30s).
-    // Wired into the MCP transport factory in Task 3 (per-server
-    // effective_timeout); allow the transient dead-code gap until then.
-    #[allow(dead_code)]
     pub fn with_timeout(mut self, timeout: std::time::Duration) -> Self {
         self.http_client = reqwest::Client::builder()
             .timeout(timeout)

--- a/src/tools/mcp/http_transport.rs
+++ b/src/tools/mcp/http_transport.rs
@@ -68,6 +68,18 @@ impl HttpMcpTransport {
         }
     }
 
+    /// Override the HTTP request timeout (default 30s).
+    // Wired into the MCP transport factory in Task 3 (per-server
+    // effective_timeout); allow the transient dead-code gap until then.
+    #[allow(dead_code)]
+    pub fn with_timeout(mut self, timeout: std::time::Duration) -> Self {
+        self.http_client = reqwest::Client::builder()
+            .timeout(timeout)
+            .build()
+            .expect("Failed to create HTTP client"); // safety: rustls init cannot fail
+        self
+    }
+
     /// Attach a session manager for Mcp-Session-Id tracking.
     pub fn with_session_manager(
         mut self,
@@ -742,6 +754,54 @@ mod tests {
             method: method.to_string(),
             params: None,
         }
+    }
+
+    /// Regression: `with_timeout` must actually rebuild the client with the
+    /// override applied, not just store the duration. A server that sleeps
+    /// longer than the configured timeout must cause `send` to fail quickly
+    /// rather than hang for the default 30s.
+    #[tokio::test]
+    async fn test_with_timeout_enforces_shorter_deadline() {
+        use axum::{Router, routing::post};
+        use tokio::net::TcpListener;
+
+        async fn slow_response() -> axum::http::StatusCode {
+            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+            axum::http::StatusCode::ACCEPTED
+        }
+
+        let app = Router::new().route("/", post(slow_response));
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("Failed to bind to an ephemeral port");
+        let addr = listener
+            .local_addr()
+            .expect("Failed to get listener's local address");
+        let url = format!("http://127.0.0.1:{}", addr.port());
+
+        tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("Test server failed to run");
+        });
+
+        let transport = HttpMcpTransport::new(&url, "slow-test")
+            .with_timeout(std::time::Duration::from_millis(200));
+        let request = notification_request("notifications/initialized");
+
+        let start = std::time::Instant::now();
+        let result = transport.send(&request, &HashMap::new()).await;
+        let elapsed = start.elapsed();
+
+        assert!(
+            result.is_err(),
+            "request should time out before the server responds"
+        );
+        assert!(
+            elapsed < std::time::Duration::from_secs(2),
+            "timeout override should fire well before the default 30s or the server's 5s sleep, took {:?}",
+            elapsed
+        );
     }
 
     #[tokio::test]

--- a/src/tools/mcp/process.rs
+++ b/src/tools/mcp/process.rs
@@ -19,6 +19,9 @@ pub struct StdioSpawnConfig {
     pub command: String,
     pub args: Vec<String>,
     pub env: HashMap<String, String>,
+    /// Per-request transport timeout, preserved across restarts so a
+    /// long-timeout server keeps its timeout after an auto-restart.
+    pub timeout: Duration,
 }
 
 /// Composite key for a stdio MCP child process: the activating user
@@ -77,6 +80,7 @@ impl McpProcessManager {
         command: impl Into<String>,
         args: Vec<String>,
         env: HashMap<String, String>,
+        timeout: Duration,
     ) -> Result<Arc<StdioMcpTransport>, ToolError> {
         let name = name.into();
         let command = command.into();
@@ -115,10 +119,15 @@ impl McpProcessManager {
                 command: command.clone(),
                 args: args.clone(),
                 env: env.clone(),
+                timeout,
             },
         );
 
-        let transport = Arc::new(StdioMcpTransport::spawn(&name, &command, args, env).await?);
+        let transport = Arc::new(
+            StdioMcpTransport::spawn(&name, &command, args, env)
+                .await?
+                .with_timeout(timeout),
+        );
 
         self.transports
             .write()
@@ -220,7 +229,7 @@ impl McpProcessManager {
             .await
             {
                 Ok(transport) => {
-                    let transport = Arc::new(transport);
+                    let transport = Arc::new(transport.with_timeout(config.timeout));
                     self.transports
                         .write()
                         .await

--- a/src/tools/mcp/stdio_transport.rs
+++ b/src/tools/mcp/stdio_transport.rs
@@ -29,6 +29,7 @@ pub struct StdioMcpTransport {
     reader_handle: Mutex<Option<JoinHandle<()>>>,
     stderr_handle: Mutex<Option<JoinHandle<()>>>,
     child: Arc<Mutex<Child>>,
+    timeout: Duration,
 }
 
 impl StdioMcpTransport {
@@ -107,7 +108,14 @@ impl StdioMcpTransport {
             reader_handle: Mutex::new(Some(reader_handle)),
             stderr_handle: Mutex::new(Some(stderr_handle)),
             child: Arc::new(Mutex::new(child)),
+            timeout: Duration::from_secs(30),
         })
+    }
+
+    /// Override the per-request timeout (default 30s).
+    pub fn with_timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = timeout;
+        self
     }
 }
 
@@ -123,7 +131,7 @@ impl McpTransport for StdioMcpTransport {
             &self.pending,
             request,
             &self.server_name,
-            Duration::from_secs(30),
+            self.timeout,
         )
         .await
     }
@@ -192,6 +200,22 @@ mod tests {
 
         // Verify shutdown completes without error.
         transport.shutdown().await.expect("shutdown should succeed");
+    }
+
+    #[tokio::test]
+    async fn stdio_transport_uses_configured_timeout() {
+        // A transport constructed with a 7s override reports 7s.
+        // (Construct via the same path spawn() uses; assert the stored field.)
+        let t = StdioMcpTransport::spawn(
+            "t",
+            "cat",
+            Vec::<String>::new(),
+            Vec::<(String, String)>::new(),
+        )
+        .await
+        .expect("spawn cat")
+        .with_timeout(std::time::Duration::from_secs(7));
+        assert_eq!(t.timeout, std::time::Duration::from_secs(7));
     }
 
     #[tokio::test]

--- a/src/tools/registry.rs
+++ b/src/tools/registry.rs
@@ -720,6 +720,38 @@ impl ToolRegistry {
         tracing::debug!("Registered {} job management tools", job_tool_count);
     }
 
+    /// Register the generic "run an MCP tool as a background job" tools
+    /// (`tool_job_start`, `tool_job_status`).
+    ///
+    /// `tool_job_status` only needs the context manager, so it is always
+    /// registered. `tool_job_start` additionally needs the scheduler slot (to
+    /// dispatch) and the MCP client store (to check per-server
+    /// `allow_background`); if either is absent it is skipped and only status
+    /// polling is available.
+    pub fn register_mcp_job_tools(
+        &self,
+        context_manager: Arc<ContextManager>,
+        scheduler_slot: Option<crate::tools::builtin::SchedulerSlot>,
+        mcp_client_store: Option<Arc<crate::tools::mcp::McpClientStore>>,
+    ) {
+        self.register_sync(Arc::new(crate::tools::builtin::McpJobStatusTool::new(
+            Arc::clone(&context_manager),
+        )));
+        if let (Some(slot), Some(store)) = (scheduler_slot, mcp_client_store) {
+            let policy = Arc::new(crate::tools::builtin::StoreBackgroundPolicy {
+                client_store: store,
+            });
+            self.register_sync(Arc::new(crate::tools::builtin::CreateMcpJobTool::new(
+                slot, policy,
+            )));
+            tracing::debug!("Registered MCP background-job tools (start + status)");
+        } else {
+            tracing::debug!(
+                "Registered tool_job_status only (no scheduler slot / MCP client store)"
+            );
+        }
+    }
+
     /// Register secret management tools (list, delete).
     ///
     /// These allow the LLM to persist API keys and tokens encrypted in the database.

--- a/src/worker/mcp_job.rs
+++ b/src/worker/mcp_job.rs
@@ -4,7 +4,19 @@
 //! The job "mode" lives in `JobContext.metadata` (a `serde_json::Value`) rather
 //! than the orchestrator `JobMode` enum, which is not on this dispatch path.
 
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use ironclaw_common::{AppEvent, JobResultStatus};
+use ironclaw_safety::SafetyLayer;
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::channels::IncomingMessage;
+use crate::channels::web::sse::SseManager;
+use crate::context::{ContextManager, JobState};
+use crate::tenant::SystemScope;
+use crate::tools::mcp::McpClientStore;
 
 /// Everything needed to run one MCP tool call as a background job and inject
 /// its result back into the originating agent thread on completion.
@@ -66,6 +78,224 @@ impl McpJobSpec {
     }
 }
 
+/// Minimal seam for invoking an MCP tool, so `run_mcp_job` is testable
+/// without a live `McpClient`. The real implementation resolves the per-user
+/// client through the `McpClientStore`; tests supply a fake.
+#[async_trait]
+pub trait McpCaller: Send + Sync {
+    /// Call `tool` on `server` for `user_id`, returning the joined text output.
+    /// `Err(msg)` on an inactive server, a transport error, or a tool that
+    /// reports `is_error` (msg carries the error text).
+    async fn call(
+        &self,
+        user_id: &str,
+        server: &str,
+        tool: &str,
+        params: serde_json::Value,
+    ) -> Result<String, String>;
+}
+
+/// Production `McpCaller`: looks up the per-user client and joins the text
+/// content parts exactly as `McpToolWrapper::execute` does.
+pub struct StoreMcpCaller {
+    pub client_store: Arc<McpClientStore>,
+}
+
+#[async_trait]
+impl McpCaller for StoreMcpCaller {
+    async fn call(
+        &self,
+        user_id: &str,
+        server: &str,
+        tool: &str,
+        params: serde_json::Value,
+    ) -> Result<String, String> {
+        let client = self
+            .client_store
+            .get(user_id, server)
+            .await
+            .ok_or_else(|| format!("MCP server '{server}' is not active for this user"))?;
+        let result = client
+            .call_tool(tool, params)
+            .await
+            .map_err(|e| e.to_string())?;
+        let content: String = result
+            .content
+            .iter()
+            .filter_map(|b| b.as_text())
+            .collect::<Vec<_>>()
+            .join("\n");
+        if result.is_error {
+            Err(content)
+        } else {
+            Ok(content)
+        }
+    }
+}
+
+/// Dependencies for `run_mcp_job`. `store` / `sse_tx` / `inject_tx` are all
+/// optional so the runner degrades gracefully (and stays unit-testable) when a
+/// layer is absent — the job state in the `ContextManager` is always updated.
+pub struct McpJobDeps {
+    pub context_manager: Arc<ContextManager>,
+    pub store: Option<SystemScope>,
+    pub sse_tx: Option<Arc<SseManager>>,
+    pub inject_tx: Option<tokio::sync::mpsc::Sender<IncomingMessage>>,
+    pub caller: Arc<dyn McpCaller>,
+    pub safety: Arc<SafetyLayer>,
+}
+
+/// First 8 chars of a job id, for human-facing job references.
+fn short_id(id: Uuid) -> String {
+    id.simple().to_string().chars().take(8).collect()
+}
+
+/// Move a job to `state` in the `ContextManager`, treating an invalid/idempotent
+/// transition as benign (debug log) and a missing context as a real warning.
+async fn transition(cm: &ContextManager, job_id: Uuid, state: JobState, reason: Option<String>) {
+    match cm
+        .update_context(job_id, move |c| c.transition_to(state, reason))
+        .await
+    {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => tracing::debug!("mcp job {job_id}: benign transition skip: {e}"),
+        Err(e) => tracing::warn!("mcp job {job_id}: context missing on transition: {e}"),
+    }
+}
+
+/// Best-effort persistence of job status (silent-ok: a missed write is
+/// reconciled by the next poll / startup reconcile).
+async fn persist_status(
+    store: &Option<SystemScope>,
+    job_id: Uuid,
+    status: JobState,
+    reason: Option<&str>,
+) {
+    if let Some(store) = store
+        && let Err(e) = store.update_job_status(job_id, status, reason).await
+    {
+        tracing::warn!("mcp job {job_id}: failed to persist status: {e}");
+    }
+}
+
+/// Best-effort persistence of a job event to the store + live SSE broadcast.
+async fn emit_event(
+    deps: &McpJobDeps,
+    job_id: Uuid,
+    event_type: &str,
+    data: serde_json::Value,
+    sse: AppEvent,
+) {
+    if let Some(store) = &deps.store
+        && let Err(e) = store.save_job_event(job_id, event_type, &data).await
+    {
+        tracing::warn!("mcp job {job_id}: failed to persist {event_type} event: {e}");
+    }
+    if let Some(sse_tx) = &deps.sse_tx {
+        sse_tx.broadcast(sse);
+    }
+}
+
+/// Run a single MCP tool call as a durable background job: mark it in-progress,
+/// invoke the tool at the server's configured (long) timeout, safety-scan the
+/// untrusted output, record the terminal state, and inject the wrapped result
+/// back into the originating thread so the agent resumes.
+pub async fn run_mcp_job(job_id: Uuid, spec: McpJobSpec, deps: McpJobDeps) {
+    // 1. In-progress.
+    transition(
+        &deps.context_manager,
+        job_id,
+        JobState::InProgress,
+        Some("mcp job started".into()),
+    )
+    .await;
+    persist_status(&deps.store, job_id, JobState::InProgress, None).await;
+
+    // 2. Status event.
+    let running = format!("Running {} in background", spec.tool);
+    emit_event(
+        &deps,
+        job_id,
+        "status",
+        serde_json::json!({ "message": running }),
+        AppEvent::JobStatus {
+            job_id: job_id.to_string(),
+            message: running.clone(),
+        },
+    )
+    .await;
+
+    // 3-5. Invoke the tool (at the server's Phase-1 long timeout) and reduce to
+    // a Result<String, String>.
+    let call_res = deps
+        .caller
+        .call(&spec.user_id, &spec.server, &spec.tool, spec.params.clone())
+        .await;
+    let ok = call_res.is_ok();
+    let raw = match call_res {
+        Ok(out) => out,
+        Err(e) => e,
+    };
+
+    // 6. Safety scan — MCP output is untrusted external data and MUST be
+    // sanitized + wrapped before it reaches the LLM.
+    let sanitized = deps.safety.sanitize_tool_output(&spec.tool, &raw);
+    let wrapped = deps.safety.wrap_for_llm(&spec.tool, &sanitized.content);
+
+    // 7. Terminal state.
+    let final_state = if ok {
+        JobState::Completed
+    } else {
+        JobState::Failed
+    };
+    let reason = if ok {
+        None
+    } else {
+        Some("mcp tool call failed".to_string())
+    };
+    transition(&deps.context_manager, job_id, final_state, reason.clone()).await;
+    persist_status(&deps.store, job_id, final_state, reason.as_deref()).await;
+
+    // 8. Result event.
+    let result_status = if ok {
+        JobResultStatus::Completed
+    } else {
+        JobResultStatus::Failed
+    };
+    emit_event(
+        &deps,
+        job_id,
+        "result",
+        serde_json::json!({ "status": if ok { "completed" } else { "failed" } }),
+        AppEvent::JobResult {
+            job_id: job_id.to_string(),
+            status: result_status,
+            session_id: None,
+            fallback_deliverable: None,
+        },
+    )
+    .await;
+
+    // 9. Inject the wrapped result back into the originating thread so the agent
+    // resumes. Silent-ok: the agent may be idle; the job state is already
+    // persisted and durable.
+    if let Some(tx) = &deps.inject_tx {
+        let body = format!(
+            "[Background job {}] {} {}: {}",
+            short_id(job_id),
+            spec.tool,
+            if ok { "completed" } else { "failed" },
+            wrapped
+        );
+        let mut msg =
+            IncomingMessage::new(spec.channel.clone(), spec.user_id.clone(), body).into_internal();
+        if let Some(t) = &spec.thread_id {
+            msg = msg.with_thread(t.clone());
+        }
+        let _ = tx.send(msg).await;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -97,5 +327,103 @@ mod tests {
         // mode is right but required fields missing → None (no panic).
         let meta = serde_json::json!({"mode":"mcp_tool","server":"s"});
         assert!(McpJobSpec::from_metadata(&meta, "u", "c", None).is_none());
+    }
+
+    /// Fake `McpCaller` returning a fixed result, so the runner is exercised
+    /// end-to-end without a live MCP client or the DB store.
+    struct FakeCaller {
+        out: Result<String, String>,
+    }
+
+    #[async_trait]
+    impl McpCaller for FakeCaller {
+        async fn call(
+            &self,
+            _user_id: &str,
+            _server: &str,
+            _tool: &str,
+            _params: serde_json::Value,
+        ) -> Result<String, String> {
+            self.out.clone()
+        }
+    }
+
+    fn test_safety() -> Arc<SafetyLayer> {
+        Arc::new(SafetyLayer::new(&ironclaw_safety::SafetyConfig {
+            max_output_length: 100_000,
+            injection_check_enabled: false,
+        }))
+    }
+
+    fn test_spec() -> McpJobSpec {
+        McpJobSpec {
+            server: "msbsandbox".into(),
+            tool: "run_python".into(),
+            params: serde_json::json!({"code":"print(1)"}),
+            user_id: "u1".into(),
+            channel: "gateway".into(),
+            thread_id: Some("t1".into()),
+        }
+    }
+
+    #[tokio::test]
+    async fn mcp_job_runs_completes_and_injects() {
+        let cm = Arc::new(ContextManager::new(5));
+        let job_id = cm.create_job("bg", "run tool").await.unwrap();
+        let (tx, mut rx) = tokio::sync::mpsc::channel(4);
+
+        let deps = McpJobDeps {
+            context_manager: cm.clone(),
+            store: None,
+            sse_tx: None,
+            inject_tx: Some(tx),
+            caller: Arc::new(FakeCaller {
+                out: Ok("RESULT_OK".into()),
+            }),
+            safety: test_safety(),
+        };
+        run_mcp_job(job_id, test_spec(), deps).await;
+
+        // Job reached Completed in the context manager.
+        let ctx = cm.get_context(job_id).await.unwrap();
+        assert_eq!(ctx.state, JobState::Completed);
+
+        // The originating thread received the wrapped result as an internal msg.
+        let msg = rx.try_recv().expect("an inject message");
+        assert!(
+            msg.content.contains("RESULT_OK"),
+            "injected body was: {}",
+            msg.content
+        );
+        assert!(
+            msg.is_internal,
+            "injected message must bypass user pipeline"
+        );
+        assert_eq!(msg.thread_id.as_ref().map(|t| t.as_str()), Some("t1"));
+    }
+
+    #[tokio::test]
+    async fn mcp_job_failure_marks_failed_and_still_injects() {
+        let cm = Arc::new(ContextManager::new(5));
+        let job_id = cm.create_job("bg", "run tool").await.unwrap();
+        let (tx, mut rx) = tokio::sync::mpsc::channel(4);
+
+        let deps = McpJobDeps {
+            context_manager: cm.clone(),
+            store: None,
+            sse_tx: None,
+            inject_tx: Some(tx),
+            caller: Arc::new(FakeCaller {
+                out: Err("BOOM".into()),
+            }),
+            safety: test_safety(),
+        };
+        run_mcp_job(job_id, test_spec(), deps).await;
+
+        let ctx = cm.get_context(job_id).await.unwrap();
+        assert_eq!(ctx.state, JobState::Failed);
+        let msg = rx.try_recv().expect("an inject message even on failure");
+        assert!(msg.content.contains("failed"), "body: {}", msg.content);
+        assert!(msg.content.contains("BOOM"), "body: {}", msg.content);
     }
 }

--- a/src/worker/mcp_job.rs
+++ b/src/worker/mcp_job.rs
@@ -15,6 +15,7 @@ use uuid::Uuid;
 use crate::channels::IncomingMessage;
 use crate::channels::web::sse::SseManager;
 use crate::context::{ContextManager, JobState};
+use crate::error::DatabaseError;
 use crate::tenant::SystemScope;
 use crate::tools::mcp::McpClientStore;
 
@@ -296,6 +297,34 @@ pub async fn run_mcp_job(job_id: Uuid, spec: McpJobSpec, deps: McpJobDeps) {
     }
 }
 
+/// Title prefix `dispatch_mcp_job` gives every MCP background job
+/// (`mcp:<server>/<tool>`). Used as the durable discriminator for the startup
+/// reconcile: unlike `JobContext.metadata` (which the libSQL backend neither
+/// persists nor hydrates), the title round-trips through both backends.
+pub(crate) const MCP_JOB_TITLE_PREFIX: &str = "mcp:";
+
+/// On startup, transition any MCP-tool jobs left `InProgress` by a previous run
+/// to `Stuck`. Their in-memory runner died with the process, so they can never
+/// complete on their own; `Stuck` lets self-repair surface them. Non-MCP jobs
+/// are left to their own recovery paths. Returns how many were reconciled.
+///
+/// MCP jobs are identified by their `mcp:` title prefix rather than
+/// `metadata.mode`, because job metadata is not durably persisted across all
+/// DB backends whereas the title is.
+pub async fn reconcile_orphaned_mcp_jobs(store: &SystemScope) -> Result<usize, DatabaseError> {
+    let records = store.list_agent_jobs().await?;
+    let mut reconciled = 0;
+    for rec in records {
+        if rec.status == "in_progress" && rec.title.starts_with(MCP_JOB_TITLE_PREFIX) {
+            store
+                .update_job_status(rec.id, JobState::Stuck, Some("orphaned by restart"))
+                .await?;
+            reconciled += 1;
+        }
+    }
+    Ok(reconciled)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -400,6 +429,48 @@ mod tests {
             "injected message must bypass user pipeline"
         );
         assert_eq!(msg.thread_id.as_ref().map(|t| t.as_str()), Some("t1"));
+    }
+
+    #[cfg(feature = "libsql")]
+    #[tokio::test]
+    async fn reconcile_marks_orphaned_mcp_jobs_stuck() {
+        use crate::context::JobContext;
+        use crate::db::Database;
+        use crate::db::libsql::LibSqlBackend;
+
+        // A file-backed libSQL DB (not `:memory:`, whose per-connection isolation
+        // would put migrations and writes in separate empty databases).
+        let dir = tempfile::tempdir().unwrap();
+        let backend = LibSqlBackend::new_local(&dir.path().join("t.db"))
+            .await
+            .expect("open db");
+        backend.run_migrations().await.expect("migrate");
+        let store = SystemScope::new(Arc::new(backend) as Arc<dyn Database>);
+
+        // An orphaned in-flight MCP job — identified by its `mcp:` title prefix
+        // (the durable discriminator `dispatch_mcp_job` sets).
+        let mut mcp = JobContext::with_user("u1", "mcp:msbsandbox/run_python", "bg");
+        mcp.transition_to(JobState::InProgress, None).unwrap();
+        store.save_job(&mcp).await.expect("save mcp job");
+
+        // A non-MCP in-flight job that must be left alone.
+        let mut other = JobContext::with_user("u1", "chat turn", "job");
+        other.transition_to(JobState::InProgress, None).unwrap();
+        store.save_job(&other).await.expect("save other job");
+
+        let n = reconcile_orphaned_mcp_jobs(&store)
+            .await
+            .expect("reconcile");
+        assert_eq!(n, 1, "only the mcp job should be reconciled");
+
+        let mcp_after = store.get_job(mcp.job_id).await.unwrap().unwrap();
+        assert_eq!(mcp_after.state, JobState::Stuck);
+        let other_after = store.get_job(other.job_id).await.unwrap().unwrap();
+        assert_eq!(
+            other_after.state,
+            JobState::InProgress,
+            "non-mcp job untouched"
+        );
     }
 
     #[tokio::test]

--- a/src/worker/mcp_job.rs
+++ b/src/worker/mcp_job.rs
@@ -1,0 +1,101 @@
+//! Background-job descriptor for running a single MCP tool call as a durable
+//! IronClaw job (Phase 2 of the MCP background-jobs design).
+//!
+//! The job "mode" lives in `JobContext.metadata` (a `serde_json::Value`) rather
+//! than the orchestrator `JobMode` enum, which is not on this dispatch path.
+
+use serde::{Deserialize, Serialize};
+
+/// Everything needed to run one MCP tool call as a background job and inject
+/// its result back into the originating agent thread on completion.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct McpJobSpec {
+    /// MCP server name (e.g. "msbsandbox").
+    pub server: String,
+    /// Unprefixed MCP tool name (e.g. "run_python").
+    pub tool: String,
+    /// Tool call parameters.
+    pub params: serde_json::Value,
+    /// Owning user.
+    pub user_id: String,
+    /// Originating channel, used to inject the result on completion.
+    pub channel: String,
+    /// Originating thread, if any.
+    pub thread_id: Option<String>,
+}
+
+impl McpJobSpec {
+    /// The metadata blob persisted on the job's `JobContext`. Identity fields
+    /// (`user_id` / `channel` / `thread_id`) live on the context itself, not
+    /// here, so they are intentionally omitted.
+    pub fn to_metadata(&self) -> serde_json::Value {
+        serde_json::json!({
+            "mode": "mcp_tool",
+            "server": self.server,
+            "tool": self.tool,
+            "params": self.params,
+        })
+    }
+
+    /// Rebuild a spec from a persisted metadata blob plus the context-supplied
+    /// identity fields. Returns `None` unless `mode == "mcp_tool"` and the
+    /// required `server` / `tool` fields are present.
+    pub fn from_metadata(
+        meta: &serde_json::Value,
+        user_id: &str,
+        channel: &str,
+        thread_id: Option<String>,
+    ) -> Option<Self> {
+        if meta.get("mode").and_then(|m| m.as_str()) != Some("mcp_tool") {
+            return None;
+        }
+        let server = meta.get("server").and_then(|v| v.as_str())?.to_string();
+        let tool = meta.get("tool").and_then(|v| v.as_str())?.to_string();
+        let params = meta
+            .get("params")
+            .cloned()
+            .unwrap_or(serde_json::Value::Null);
+        Some(Self {
+            server,
+            tool,
+            params,
+            user_id: user_id.to_string(),
+            channel: channel.to_string(),
+            thread_id,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn metadata_roundtrip() {
+        let spec = McpJobSpec {
+            server: "msbsandbox".into(),
+            tool: "run_python".into(),
+            params: serde_json::json!({"code":"print(1)"}),
+            user_id: "u1".into(),
+            channel: "gateway".into(),
+            thread_id: Some("t1".into()),
+        };
+        let meta = spec.to_metadata();
+        assert_eq!(meta["mode"], "mcp_tool");
+        let back = McpJobSpec::from_metadata(&meta, "u1", "gateway", Some("t1".into())).unwrap();
+        assert_eq!(back.server, "msbsandbox");
+        assert_eq!(back.tool, "run_python");
+        assert_eq!(back.params["code"], "print(1)");
+        assert!(
+            McpJobSpec::from_metadata(&serde_json::json!({"mode":"other"}), "u", "c", None)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn from_metadata_requires_server_and_tool() {
+        // mode is right but required fields missing → None (no panic).
+        let meta = serde_json::json!({"mode":"mcp_tool","server":"s"});
+        assert!(McpJobSpec::from_metadata(&meta, "u", "c", None).is_none());
+    }
+}

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -30,6 +30,7 @@ mod autonomous_recovery;
 pub mod claude_bridge;
 pub mod container;
 pub mod job;
+pub mod mcp_job;
 pub mod proxy_llm;
 
 pub use acp_bridge::AcpBridgeRuntime;


### PR DESCRIPTION
## Per-server MCP timeouts + background-job bridge

**Phase 1 — per-server timeouts.** Lifts the hardcoded 30s transport cap: `timeout_secs` + `allow_background` on `McpServerConfig` (`effective_timeout()` clamps 5..=21600s), honored in both stdio + HTTP transports and the tool-execution cap; `mcp add --timeout-secs/--allow-background` CLI flags. Long-running MCP tools (e.g. sandboxed code exec) no longer die at 30s.

**Phase 2 — MCP → durable-job bridge.** Run a long MCP tool call as a background job that auto-resumes the agent thread on completion:
- `tool_job_start(server, tool, args)` → `Scheduler::dispatch_mcp_job` persists + spawns `run_mcp_job` (non-LLM runner) → safety scan → auto-resume inject into the originating thread; `tool_job_status(job_id)` polls.
- Startup reconcile marks orphaned in-flight MCP jobs `Stuck`; `/api/jobs` surfaces `mode=mcp_tool`.
- Dual-backend (Postgres + libSQL); durable MCP-job discriminator is an `mcp:` title prefix (libSQL doesn't persist `JobContext.metadata`).

Cherry-picked from an integration branch; PR CI validates standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
