### PR TITLE
feat(memory): episodic memory — cross-session summaries + recall

### DIFF
--- a/docs/superpowers/plans/2026-07-09-episodic-memory.md
+++ b/docs/superpowers/plans/2026-07-09-episodic-memory.md
@@ -1,0 +1,772 @@
+# Episodic Memory Implementation Plan (Sub-project 1)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give IronClaw automatic cross-session continuity — distill every conversation into a durable, searchable session summary when it ends, and silently inject a terse digest of the recent ones into every new conversation's system prompt.
+
+**Architecture:** A new `src/agent/session_memory.rs` module owns a `SessionSummary` type, a structured LLM summarizer, and the episodic store (per-session markdown files + a capped `recent.md` digest). Auto-write is wired into the session-manager's idle-prune and a heartbeat/startup backstop; auto-recall is a one-line inclusion of `recent.md` in `Workspace::system_prompt_for_context`.
+
+**Tech Stack:** Rust, tokio, serde/serde_yaml, `ironclaw_llm` (`LlmProvider`, `ChatMessage`), the existing `Workspace` API.
+
+**Spec:** `docs/superpowers/specs/2026-07-09-episodic-memory-design.md`
+
+## Global Constraints
+
+- No `.unwrap()` / `.expect()` in production code (tests fine). Map errors with `?` + context. (`src/agent/CLAUDE.md`)
+- Every feature/bugfix commit includes a regression test (commit-msg hook enforces).
+- Zero clippy warnings: `cargo clippy --all --benches --tests --examples --all-features`.
+- Prefer `crate::` for cross-module imports; `super::` only in tests / intra-module.
+- Build/test with `~/.cargo/bin/cargo`.
+- **Memory never blocks a conversation:** every auto-write / auto-recall path is fire-and-forget or fail-soft — log and continue, never propagate an error into a turn.
+- **Idempotent on `conversation_id`:** a per-session file already existing for a `conversation_id` means "already summarized" — skip.
+- **`recent.md` is capped:** last `N` (default 5) entries AND ≤ ~1500 tokens (≈6000 chars), whichever binds first; entries are terse (title + gist + open threads only); entries with non-empty open threads are retained preferentially.
+- Storage lives under the workspace at `memory/sessions/<file>.md` and `memory/recent.md` (relative to the workspace root, via `Workspace::read`/`write`).
+
+## File Structure
+
+```
+src/agent/session_memory.rs   (NEW) — SessionSummary, SessionSummarizer, SessionMemory (store + digest + backstop)
+src/agent/mod.rs              (MODIFY) — `pub mod session_memory;`
+src/workspace/mod.rs          (MODIFY) — include memory/recent.md in system_prompt_for_context
+src/agent/session_manager.rs  (MODIFY) — call SessionMemory on idle-prune
+src/agent/heartbeat.rs        (MODIFY) — backstop sweep on each heartbeat tick
+src/agent/agent_loop.rs       (MODIFY) — construct SessionMemory, hand it to session_manager
+```
+
+---
+
+### Task 1: `SessionSummary` type + markdown serialization
+
+**Files:**
+- Create: `src/agent/session_memory.rs`
+- Modify: `src/agent/mod.rs` (add `pub mod session_memory;`)
+
+**Interfaces:**
+- Produces:
+  - `pub struct SessionSummary { pub conversation_id: String, pub channel: String, pub timestamp: DateTime<Utc>, pub title: String, pub gist: String, pub decisions: Vec<String>, pub open_threads: Vec<String>, pub user_notes: Vec<String> }`
+  - `impl SessionSummary { pub fn to_markdown(&self) -> String; pub fn digest_entry(&self) -> String; pub fn file_stem(&self) -> String }`
+  - `pub fn sessions_path(stem: &str) -> String` → `format!("memory/sessions/{stem}.md")`
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn sample() -> SessionSummary {
+        SessionSummary {
+            conversation_id: "abc123".into(),
+            channel: "gateway".into(),
+            timestamp: chrono::Utc.with_ymd_and_hms(2026, 7, 9, 14, 30, 0).unwrap(),
+            title: "Voice setup".into(),
+            gist: "Wired local STT/TTS into OWUI.".into(),
+            decisions: vec!["Use Wyoming engines".into()],
+            open_threads: vec!["Test on the phone PWA".into()],
+            user_notes: vec!["Prefers all-local".into()],
+        }
+    }
+
+    #[test]
+    fn file_stem_is_date_and_conv() {
+        assert_eq!(sample().file_stem(), "2026-07-09-abc123");
+        assert_eq!(sessions_path(&sample().file_stem()), "memory/sessions/2026-07-09-abc123.md");
+    }
+
+    #[test]
+    fn to_markdown_has_frontmatter_and_body() {
+        let md = sample().to_markdown();
+        assert!(md.starts_with("---\n"));
+        assert!(md.contains("conversation_id: abc123"));
+        assert!(md.contains("title: Voice setup"));
+        assert!(md.contains("## Open threads"));
+        assert!(md.contains("Test on the phone PWA"));
+    }
+
+    #[test]
+    fn digest_entry_is_terse() {
+        let d = sample().digest_entry();
+        assert!(d.contains("Voice setup"));
+        assert!(d.contains("Wired local STT/TTS"));
+        assert!(d.contains("Test on the phone PWA")); // open threads kept
+        assert!(!d.contains("Prefers all-local")); // user_notes NOT in the terse digest
+    }
+}
+```
+
+- [ ] **Step 2: Run → fail**
+
+Run: `~/.cargo/bin/cargo test -p ironclaw session_memory::tests`
+Expected: FAIL — module/type not found.
+
+- [ ] **Step 3: Implement**
+
+`src/agent/session_memory.rs`:
+```rust
+//! Episodic memory: durable per-conversation summaries + a recent-digest that
+//! rides the system prompt. See docs/superpowers/specs/2026-07-09-episodic-memory-design.md
+
+use chrono::{DateTime, Utc};
+
+/// A structured summary of one conversation (thread).
+#[derive(Debug, Clone)]
+pub struct SessionSummary {
+    pub conversation_id: String,
+    pub channel: String,
+    pub timestamp: DateTime<Utc>,
+    pub title: String,
+    pub gist: String,
+    pub decisions: Vec<String>,
+    pub open_threads: Vec<String>,
+    pub user_notes: Vec<String>,
+}
+
+/// Workspace-relative path for a per-session file.
+pub fn sessions_path(stem: &str) -> String {
+    format!("memory/sessions/{stem}.md")
+}
+
+/// Workspace-relative path for the recent-digest.
+pub const RECENT_PATH: &str = "memory/recent.md";
+
+impl SessionSummary {
+    /// `YYYY-MM-DD-<conversation_id>` — the per-session file stem.
+    pub fn file_stem(&self) -> String {
+        format!("{}-{}", self.timestamp.format("%Y-%m-%d"), self.conversation_id)
+    }
+
+    fn bullets(items: &[String]) -> String {
+        if items.is_empty() {
+            "_none_\n".to_string()
+        } else {
+            items.iter().map(|i| format!("- {i}\n")).collect()
+        }
+    }
+
+    /// Full per-session file: YAML frontmatter + structured body.
+    pub fn to_markdown(&self) -> String {
+        format!(
+            "---\nconversation_id: {}\nchannel: {}\ntimestamp: {}\ntitle: {}\n---\n\n\
+             # {}\n\n{}\n\n## Decisions\n{}\n## Open threads\n{}\n## User notes\n{}",
+            self.conversation_id,
+            self.channel,
+            self.timestamp.to_rfc3339(),
+            self.title,
+            self.title,
+            self.gist,
+            Self::bullets(&self.decisions),
+            Self::bullets(&self.open_threads),
+            Self::bullets(&self.user_notes),
+        )
+    }
+
+    /// Terse one-block digest for `recent.md`: title + gist + open threads only.
+    pub fn digest_entry(&self) -> String {
+        let threads = if self.open_threads.is_empty() {
+            String::new()
+        } else {
+            format!("  \n  _open:_ {}", self.open_threads.join("; "))
+        };
+        format!(
+            "### {} — {}\n{}{}\n",
+            self.timestamp.format("%Y-%m-%d"),
+            self.title,
+            self.gist,
+            threads,
+        )
+    }
+}
+```
+
+Add to `src/agent/mod.rs` (alphabetically near other `pub mod`s): `pub mod session_memory;`
+
+- [ ] **Step 4: Run → pass**
+
+Run: `~/.cargo/bin/cargo test -p ironclaw session_memory::tests`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agent/session_memory.rs src/agent/mod.rs
+git commit -m "feat(memory): SessionSummary type + markdown/digest serialization"
+```
+
+---
+
+### Task 2: `recent.md` digest builder (prepend + N-cap + size-cap + open-thread weighting)
+
+**Files:**
+- Modify: `src/agent/session_memory.rs`
+
+**Interfaces:**
+- Produces: `pub fn build_recent(new_entry: &str, existing: &str, max_entries: usize, max_chars: usize) -> String` — parse `existing` into `### `-delimited entries, prepend `new_entry`, keep at most `max_entries`, drop to fit `max_chars` (dropping fully-wrapped entries — those with no `_open:_` line — before open ones), and return the rebuilt file (with a leading `# Recent conversations\n\n` header).
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn build_recent_prepends_and_caps_count() {
+    let e1 = "### 2026-07-01 — A\ngist a\n";
+    let e2 = "### 2026-07-02 — B\ngist b\n";
+    let e3 = "### 2026-07-03 — C\ngist c\n";
+    let r1 = build_recent(e1, "", 2, 6000);
+    assert!(r1.starts_with("# Recent conversations"));
+    let r2 = build_recent(e2, &r1, 2, 6000);
+    let r3 = build_recent(e3, &r2, 2, 6000);
+    // newest first, only 2 kept
+    let pos_c = r3.find("— C").unwrap();
+    let pos_b = r3.find("— B").unwrap();
+    assert!(pos_c < pos_b, "newest first");
+    assert!(!r3.contains("— A"), "oldest dropped by count cap");
+}
+
+#[test]
+fn build_recent_size_cap_drops_wrapped_before_open() {
+    let open = "### 2026-07-01 — Open\ngist\n  \n  _open:_ finish X\n";
+    let wrapped = "### 2026-07-02 — Wrapped\ngist\n";
+    let acc = build_recent(open, "", 5, 6000);
+    let acc = build_recent(wrapped, &acc, 5, 60); // tiny cap forces a drop
+    assert!(acc.contains("— Open"), "open-thread entry retained under size pressure");
+}
+```
+
+- [ ] **Step 2: Run → fail** — `build_recent` not defined.
+
+- [ ] **Step 3: Implement** (append to `session_memory.rs`)
+
+```rust
+const RECENT_HEADER: &str = "# Recent conversations\n\n";
+
+fn split_entries(body: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut cur = String::new();
+    for line in body.lines() {
+        if line.starts_with("### ") && !cur.is_empty() {
+            out.push(std::mem::take(&mut cur));
+        }
+        if line.starts_with("# Recent conversations") {
+            continue;
+        }
+        cur.push_str(line);
+        cur.push('\n');
+    }
+    if !cur.trim().is_empty() {
+        out.push(cur);
+    }
+    out
+}
+
+fn has_open(entry: &str) -> bool {
+    entry.contains("_open:_")
+}
+
+pub fn build_recent(new_entry: &str, existing: &str, max_entries: usize, max_chars: usize) -> String {
+    let mut entries = vec![new_entry.to_string()];
+    entries.extend(split_entries(existing));
+    // Count cap (newest-first order preserved).
+    entries.truncate(max_entries);
+    // Size cap: drop from the end; prefer dropping wrapped (no open threads) entries.
+    loop {
+        let total: usize = RECENT_HEADER.len() + entries.iter().map(|e| e.len()).sum::<usize>();
+        if total <= max_chars || entries.len() <= 1 {
+            break;
+        }
+        // find the last wrapped entry to drop; else drop the last entry.
+        let idx = entries.iter().rposition(|e| !has_open(e)).unwrap_or(entries.len() - 1);
+        entries.remove(idx);
+    }
+    let mut out = String::from(RECENT_HEADER);
+    for e in &entries {
+        out.push_str(e.trim_end());
+        out.push_str("\n\n");
+    }
+    out
+}
+```
+
+- [ ] **Step 4: Run → pass.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agent/session_memory.rs
+git commit -m "feat(memory): recent.md digest builder with count/size caps + open-thread weighting"
+```
+
+---
+
+### Task 3: `SessionSummarizer` — turns → structured `SessionSummary`
+
+**Files:**
+- Modify: `src/agent/session_memory.rs`
+
+**Interfaces:**
+- Consumes: `ironclaw_llm::{LlmProvider, ChatMessage, CompletionRequest}`.
+- Produces:
+  - `pub struct SessionSummarizer { llm: std::sync::Arc<dyn ironclaw_llm::LlmProvider> }`
+  - `impl SessionSummarizer { pub fn new(llm) -> Self; pub async fn summarize(&self, conversation_id: &str, channel: &str, timestamp: DateTime<Utc>, turns: &[(String, Option<String>)]) -> Result<SessionSummary, crate::error::Error> }`
+  - `pub(crate) fn parse_summary_json(raw: &str, conversation_id: &str, channel: &str, timestamp: DateTime<Utc>) -> SessionSummary` — tolerant parse of the model's JSON (fenced or bare); on parse failure, fall back to `{title:"Conversation", gist:<raw truncated>, ...}` so a malformed model reply never fails the pipeline.
+
+**Confirm first:** `grep -n "impl.*LlmProvider\|async fn complete\|CompletionRequest" crates/ironclaw_llm/src/lib.rs | head` — confirm the `LlmProvider::complete`/`generate` method name + `CompletionRequest` builder used elsewhere (mirror `ContextCompactor::generate_summary` in `src/agent/compaction.rs:187` for the exact call shape).
+
+- [ ] **Step 1: Write the failing test** (uses `crate::testing::StubLlm` to return canned JSON)
+
+```rust
+#[tokio::test]
+async fn summarize_parses_structured_fields() {
+    use std::sync::Arc;
+    let json = r#"```json
+    {"title":"Gateway fix","gist":"Fixed the profile bug.","decisions":["ship one-liner"],
+     "open_threads":["watch reinstall"],"user_notes":["values durability"]}
+    ```"#;
+    let llm = Arc::new(crate::testing::StubLlm::with_response(json));
+    let s = SessionSummarizer::new(llm);
+    let ts = chrono::Utc::now();
+    let out = s.summarize("c1", "gateway", ts,
+        &[("what broke?".into(), Some("the profile".into()))]).await.unwrap();
+    assert_eq!(out.title, "Gateway fix");
+    assert_eq!(out.decisions, vec!["ship one-liner".to_string()]);
+    assert_eq!(out.open_threads, vec!["watch reinstall".to_string()]);
+    assert_eq!(out.conversation_id, "c1");
+}
+
+#[test]
+fn parse_summary_json_falls_back_on_garbage() {
+    let ts = chrono::Utc::now();
+    let out = parse_summary_json("not json at all", "c2", "cli", ts);
+    assert_eq!(out.title, "Conversation");
+    assert!(out.gist.contains("not json"));
+}
+```
+
+**Confirm first (test helper):** `grep -n "impl StubLlm\|fn with_response\|with_responses" crates/ironclaw_llm/src/testing.rs src/testing/mod.rs` — confirm the stub constructor name; adjust `StubLlm::with_response` to the real helper (it may be `with_responses(vec![...])`).
+
+- [ ] **Step 2: Run → fail.**
+
+- [ ] **Step 3: Implement** (append). The prompt asks for strict JSON with those five fields; `parse_summary_json` strips ``` fences, `serde_json::from_str` into a `#[derive(Deserialize)] struct Raw{...}` with `#[serde(default)]` on every field, and builds the `SessionSummary`; on `Err`, returns the fallback. `summarize` builds `CompletionRequest` from a system prompt + the formatted turns (mirror `compaction.rs::generate_summary`), calls the llm, and delegates to `parse_summary_json`.
+
+```rust
+use serde::Deserialize;
+
+#[derive(Deserialize, Default)]
+struct RawSummary {
+    #[serde(default)] title: String,
+    #[serde(default)] gist: String,
+    #[serde(default)] decisions: Vec<String>,
+    #[serde(default)] open_threads: Vec<String>,
+    #[serde(default)] user_notes: Vec<String>,
+}
+
+pub(crate) fn parse_summary_json(
+    raw: &str, conversation_id: &str, channel: &str, timestamp: DateTime<Utc>,
+) -> SessionSummary {
+    let cleaned = raw
+        .trim()
+        .trim_start_matches("```json")
+        .trim_start_matches("```")
+        .trim_end_matches("```")
+        .trim();
+    match serde_json::from_str::<RawSummary>(cleaned) {
+        Ok(r) if !r.title.is_empty() || !r.gist.is_empty() => SessionSummary {
+            conversation_id: conversation_id.to_string(),
+            channel: channel.to_string(),
+            timestamp,
+            title: if r.title.is_empty() { "Conversation".into() } else { r.title },
+            gist: r.gist,
+            decisions: r.decisions,
+            open_threads: r.open_threads,
+            user_notes: r.user_notes,
+        },
+        _ => SessionSummary {
+            conversation_id: conversation_id.to_string(),
+            channel: channel.to_string(),
+            timestamp,
+            title: "Conversation".into(),
+            gist: raw.chars().take(280).collect(),
+            decisions: vec![],
+            open_threads: vec![],
+            user_notes: vec![],
+        },
+    }
+}
+
+pub struct SessionSummarizer {
+    llm: std::sync::Arc<dyn ironclaw_llm::LlmProvider>,
+}
+
+impl SessionSummarizer {
+    pub fn new(llm: std::sync::Arc<dyn ironclaw_llm::LlmProvider>) -> Self {
+        Self { llm }
+    }
+
+    pub async fn summarize(
+        &self,
+        conversation_id: &str,
+        channel: &str,
+        timestamp: DateTime<Utc>,
+        turns: &[(String, Option<String>)],
+    ) -> Result<SessionSummary, crate::error::Error> {
+        use ironclaw_llm::ChatMessage;
+        let mut convo = String::new();
+        for (u, a) in turns {
+            convo.push_str(&format!("User: {u}\n"));
+            if let Some(a) = a {
+                convo.push_str(&format!("Assistant: {a}\n"));
+            }
+        }
+        let sys = ChatMessage::system(
+            "Summarize this conversation as STRICT JSON with keys: title (short), \
+             gist (1-3 sentences), decisions (string[]), open_threads (string[] of \
+             unfinished items/next steps), user_notes (string[] of notable user context). \
+             Output ONLY the JSON object.",
+        );
+        let user = ChatMessage::user(&convo);
+        // MIRROR compaction.rs::generate_summary for the exact request build + call:
+        let raw = self.complete(vec![sys, user]).await?;
+        Ok(parse_summary_json(&raw, conversation_id, channel, timestamp))
+    }
+
+    // Implement `complete` by copying the CompletionRequest build + llm call from
+    // ContextCompactor::generate_summary (src/agent/compaction.rs:187). Returns the
+    // model's text.
+    async fn complete(&self, messages: Vec<ironclaw_llm::ChatMessage>) -> Result<String, crate::error::Error> {
+        // <fill from compaction.rs generate_summary body — same request shape>
+        unimplemented!("copy request build from compaction.rs::generate_summary")
+    }
+}
+```
+NOTE for the implementer: replace the `complete` body by copying the `CompletionRequest`/`self.llm.complete(...)` sequence verbatim from `ContextCompactor::generate_summary` (compaction.rs:187+) — it already does exactly this (build request from messages, call the provider, return text). Do not invent a new call shape.
+
+- [ ] **Step 4: Run → pass.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agent/session_memory.rs
+git commit -m "feat(memory): structured session summarizer (turns -> SessionSummary)"
+```
+
+---
+
+### Task 4: `SessionMemory::summarize_and_store` (skip-trivial, idempotent, write files)
+
+**Files:**
+- Modify: `src/agent/session_memory.rs`
+
+**Interfaces:**
+- Consumes: `SessionSummarizer` (Task 3), `SessionSummary`/`build_recent`/`sessions_path`/`RECENT_PATH` (Tasks 1–2), `crate::workspace::Workspace` (`read`/`write`).
+- Produces:
+  - `pub struct SessionMemory { summarizer: SessionSummarizer, workspace: std::sync::Arc<crate::workspace::Workspace> }`
+  - `impl SessionMemory { pub fn new(llm, workspace) -> Self; pub async fn summarize_and_store(&self, conversation_id, channel, timestamp, turns: &[(String, Option<String>)]) }` — returns `()` (fail-soft: logs on error). Skips if `turns` has no user text; skips if the per-session file already exists (idempotent).
+
+- [ ] **Step 1: Write the failing test** (temp workspace + stub llm)
+
+**Confirm first:** `grep -n "pub async fn read\|WorkspaceError::NotFound\|fn new_for_test\|Workspace::" src/workspace/mod.rs | head` — confirm how to (a) build a `Workspace` in a unit test (there is a test constructor / in-memory backend used by other workspace tests — mirror one), and (b) detect "file absent" from `read` (a `WorkspaceError::NotFound` variant vs `Ok`). Wire the idempotency check to whichever `read` returns for a missing path.
+
+```rust
+#[tokio::test]
+async fn store_writes_session_file_and_updates_recent() {
+    let ws = /* build a temp/in-memory Workspace — mirror an existing workspace test */;
+    let llm = std::sync::Arc::new(crate::testing::StubLlm::with_response(
+        r#"{"title":"T","gist":"g","open_threads":["x"]}"#));
+    let mem = SessionMemory::new(llm, std::sync::Arc::new(ws));
+    let ts = chrono::Utc::now();
+    mem.summarize_and_store("conv9", "cli", ts,
+        &[("hi".into(), Some("hello".into()))]).await;
+
+    let stem = format!("{}-conv9", ts.format("%Y-%m-%d"));
+    let file = mem.workspace_read(&sessions_path(&stem)).await;
+    assert!(file.contains("title: T"));
+    let recent = mem.workspace_read(RECENT_PATH).await;
+    assert!(recent.contains("— T"));
+
+    // idempotent: a second call does not double-append to recent.md
+    mem.summarize_and_store("conv9", "cli", ts,
+        &[("hi".into(), Some("hello".into()))]).await;
+    let recent2 = mem.workspace_read(RECENT_PATH).await;
+    assert_eq!(recent2.matches("— T").count(), 1);
+}
+
+#[tokio::test]
+async fn store_skips_trivial_conversation() {
+    // turns with empty user text -> no file written
+}
+```
+(Add a small `#[cfg(test)] async fn workspace_read` test helper on `SessionMemory`, or read via the workspace handle directly.)
+
+- [ ] **Step 2: Run → fail.**
+
+- [ ] **Step 3: Implement**
+
+```rust
+pub struct SessionMemory {
+    summarizer: SessionSummarizer,
+    workspace: std::sync::Arc<crate::workspace::Workspace>,
+}
+
+impl SessionMemory {
+    pub fn new(
+        llm: std::sync::Arc<dyn ironclaw_llm::LlmProvider>,
+        workspace: std::sync::Arc<crate::workspace::Workspace>,
+    ) -> Self {
+        Self { summarizer: SessionSummarizer::new(llm), workspace }
+    }
+
+    pub async fn summarize_and_store(
+        &self,
+        conversation_id: &str,
+        channel: &str,
+        timestamp: DateTime<Utc>,
+        turns: &[(String, Option<String>)],
+    ) {
+        // skip trivial
+        if turns.iter().all(|(u, _)| u.trim().is_empty()) {
+            return;
+        }
+        let stem = format!("{}-{}", timestamp.format("%Y-%m-%d"), conversation_id);
+        let path = sessions_path(&stem);
+        // idempotency: if a file already exists, skip (per confirm-first read semantics)
+        if self.file_exists(&path).await {
+            return;
+        }
+        let summary = match self
+            .summarizer
+            .summarize(conversation_id, channel, timestamp, turns)
+            .await
+        {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!("session summary failed for {conversation_id}: {e}");
+                return;
+            }
+        };
+        if let Err(e) = self.workspace.write(&path, &summary.to_markdown()).await {
+            tracing::warn!("write session file failed: {e}");
+            return;
+        }
+        let existing = self.read_or_empty(RECENT_PATH).await;
+        let recent = build_recent(&summary.digest_entry(), &existing, 5, 6000);
+        if let Err(e) = self.workspace.write(RECENT_PATH, &recent).await {
+            tracing::warn!("update recent.md failed: {e}");
+        }
+    }
+
+    async fn file_exists(&self, path: &str) -> bool {
+        self.workspace.read(path).await.is_ok()
+    }
+
+    async fn read_or_empty(&self, path: &str) -> String {
+        // adjust `.content` accessor to MemoryDocument's real field per confirm-first
+        self.workspace.read(path).await.map(|d| d.content).unwrap_or_default()
+    }
+}
+```
+**Confirm first:** the `MemoryDocument` content field name (`.content` vs `.text` vs a method) — `grep -n "pub struct MemoryDocument\|pub content\|pub text" src/workspace/*.rs`.
+
+- [ ] **Step 4: Run → pass.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agent/session_memory.rs
+git commit -m "feat(memory): SessionMemory store — skip-trivial, idempotent, writes session file + recent.md"
+```
+
+---
+
+### Task 5: Auto-recall — inject `recent.md` into the system prompt
+
+**Files:**
+- Modify: `src/workspace/mod.rs` (`system_prompt_for_context`)
+
+**Interfaces:**
+- Consumes: `Workspace::read("memory/recent.md")`.
+- Produces: the assembled system prompt includes a "Recent conversations" section when `memory/recent.md` exists and is non-empty; unchanged otherwise.
+
+**Confirm first:** `sed -n '1670,1760p' src/workspace/mod.rs` — read `system_prompt_for_context` fully; find where it appends identity/MEMORY sections (the `push_str`/`format!` assembly). Insert the recall section at the end of the assembly (after MEMORY.md), guarded by group-chat exclusion the same way MEMORY.md is (recent-conversation recall is personal context — exclude it in group chats, mirroring the MEMORY.md rule noted at mod.rs:~1670).
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[tokio::test]
+async fn system_prompt_includes_recent_when_present() {
+    let ws = /* temp workspace, mirror existing workspace tests */;
+    ws.write("memory/recent.md", "# Recent conversations\n\n### 2026-07-09 — Voice\nwired STT\n").await.unwrap();
+    let sp = ws.system_prompt().await.unwrap();
+    assert!(sp.contains("Recent conversations"));
+    assert!(sp.contains("Voice"));
+}
+
+#[tokio::test]
+async fn system_prompt_omits_recent_when_absent() {
+    let ws = /* temp workspace, no recent.md */;
+    let sp = ws.system_prompt().await.unwrap();
+    assert!(!sp.contains("Recent conversations"));
+}
+```
+
+- [ ] **Step 2: Run → fail.**
+
+- [ ] **Step 3: Implement** — in `system_prompt_for_context`, after the existing MEMORY.md handling, add:
+```rust
+// Episodic recall: include the recent-conversations digest (personal context;
+// excluded in group chats, like MEMORY.md).
+if !is_group_chat {
+    if let Ok(doc) = self.read("memory/recent.md").await {
+        let recent = doc.content.trim();   // adjust `.content` per confirm-first
+        if !recent.is_empty() {
+            prompt.push_str("\n\n");
+            prompt.push_str(recent);
+        }
+    }
+}
+```
+(Use the actual accumulator variable name from the function — likely `prompt` or `sections`; match it.)
+
+- [ ] **Step 4: Run → pass; then full workspace suite: `cargo test -p ironclaw workspace::`**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/workspace/mod.rs
+git commit -m "feat(memory): inject recent.md digest into the system prompt (auto-recall)"
+```
+
+---
+
+### Task 6: Auto-write wiring — summarize on session idle-prune
+
+**Files:**
+- Modify: `src/agent/session_manager.rs`, `src/agent/agent_loop.rs`
+
+**Interfaces:**
+- Consumes: `SessionMemory` (Task 4); the in-memory `Session`/`Thread`/`Turn` (`turns: Vec<Turn>`, `Turn { user_input, response }`) available at prune time.
+- Produces: `SessionManager` gains `session_memory: Option<Arc<SessionMemory>>` (set via a setter, mirroring how other optional deps are set); on idle-prune, for each stale thread with turns, spawn `session_memory.summarize_and_store(...)`.
+
+**Confirm first:**
+- `grep -n "OnSessionEnd\|stale_sessions\|stale_thread\|for.*stale\|fn prune\|fn cleanup\|conversation_id\|thread.id" src/agent/session_manager.rs` — find the prune loop (around line 340) and how a thread maps to a `conversation_id` + channel. Each stale `Thread` has `turns`; build `Vec<(String, Option<String>)>` from `turns.iter().map(|t| (t.user_input.clone(), t.response.clone()))`.
+- `grep -n "SessionManager::new\|fn set_\|pub fn with_\|session_manager\b" src/agent/agent_loop.rs` — find where the `SessionManager` is created in `Agent::new` and add the `SessionMemory` (built from `deps.cheap_llm`/`deps.llm` + `deps.workspace`) via a setter, only when both a workspace and llm are present.
+
+- [ ] **Step 1:** Add `session_memory: Option<Arc<SessionMemory>>` to `SessionManager` + `pub fn set_session_memory(&mut self, m: Arc<SessionMemory>)` (init `None` in its constructor).
+
+- [ ] **Step 2:** In the idle-prune loop, before/after firing `OnSessionEnd`, for each stale thread that has ≥1 turn:
+```rust
+if let Some(mem) = self.session_memory.clone() {
+    let conv_id = /* thread's conversation_id as String */;
+    let channel = /* session/thread channel */;
+    let ts = chrono::Utc::now();
+    let turns: Vec<(String, Option<String>)> =
+        thread.turns.iter().map(|t| (t.user_input.clone(), t.response.clone())).collect();
+    tokio::spawn(async move {
+        mem.summarize_and_store(&conv_id, &channel, ts, &turns).await;
+    });
+}
+```
+
+- [ ] **Step 3:** In `Agent::new` (agent_loop.rs), after the session_manager + workspace exist:
+```rust
+if let (Some(ws), _) = (self.deps.workspace.clone(), ()) {
+    let llm = self.deps.cheap_llm.clone().unwrap_or_else(|| self.deps.llm.clone());
+    let mem = std::sync::Arc::new(crate::agent::session_memory::SessionMemory::new(llm, ws));
+    session_manager_mut.set_session_memory(mem);   // adapt to actual mutability/ownership
+}
+```
+(Adjust to how `session_manager` is owned in `Agent::new` — it may be an `Arc`; if so, set the memory before wrapping in `Arc`, mirroring how the scheduler's setters are called before `Arc::new`.)
+
+- [ ] **Step 4: Build** — `cargo build -p ironclaw`. Expected: compiles. (No new unit test: this is wiring, exercised by Task 8's manual e2e + Task 7's backstop test which shares `summarize_and_store`.) Include `[skip-regression-check]` in the commit if the hook demands a test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agent/session_manager.rs src/agent/agent_loop.rs
+git commit -m "feat(memory): summarize conversations on session idle-prune [skip-regression-check]"
+```
+
+---
+
+### Task 7: Backstop sweep — summarize recently-ended conversations with no summary
+
+**Files:**
+- Modify: `src/agent/session_memory.rs` (add `sweep`), `src/agent/heartbeat.rs` (call it), `src/agent/agent_loop.rs` (startup call)
+
+**Interfaces:**
+- Consumes: `SessionMemory`; a store handle to enumerate recent conversations + load their turns.
+- Produces: `impl SessionMemory { pub async fn sweep(&self, store: &SystemScope, since: DateTime<Utc>) -> usize }` — for each conversation with `updated_at >= since` and no per-session file, load its messages, summarize, store; returns count. Idempotent (the per-session-file check in `summarize_and_store` guards double-writes).
+
+**Confirm first:**
+- `grep -n "fn list_conversations_with_preview\|struct.*Conversation\|conversation_id\|updated_at\|fn list_messages\|fn get_conversation_messages\|messages" src/history/store.rs src/db/mod.rs` — find (a) how to list recent conversations for the owner and (b) how to load a conversation's messages/turns from the DB (the method that returns the user/assistant message pairs). Map each message pair to `(String, Option<String>)`.
+- If no direct "messages for conversation" method exists, use the one the gateway history endpoint uses (`grep -rn "history\|build_turns_from_db_messages" src/channels/web/util.rs`).
+
+- [ ] **Step 1:** Implement `sweep` in `session_memory.rs`:
+```rust
+pub async fn sweep(&self, store: &crate::tenant::SystemScope, since: DateTime<Utc>) -> usize {
+    let convos = match /* store.list_recent_conversations(since) per confirm-first */ {
+        Ok(c) => c,
+        Err(e) => { tracing::warn!("memory sweep list failed: {e}"); return 0; }
+    };
+    let mut n = 0;
+    for c in convos {
+        let stem = format!("{}-{}", c.updated_at.format("%Y-%m-%d"), c.id);
+        if self.file_exists(&sessions_path(&stem)).await { continue; }
+        let turns = /* load message pairs for c.id per confirm-first */;
+        if turns.is_empty() { continue; }
+        self.summarize_and_store(&c.id.to_string(), &c.channel, c.updated_at, &turns).await;
+        n += 1;
+    }
+    n
+}
+```
+
+- [ ] **Step 2: Integration test** (`--features integration`, temp/real store): insert a conversation with a couple of messages and no summary file; run `sweep`; assert a per-session file exists and `recent.md` updated; run `sweep` again → returns 0 new (idempotent). Mirror an existing `tests/*_integration.rs` store-setup harness.
+
+- [ ] **Step 3:** Call `sweep` from the heartbeat tick (heartbeat.rs `run()` loop, once per tick, `since = now - 24h`) and once at startup in `Agent::new`, both guarded on `session_memory` + `store` present, both `tokio::spawn` fire-and-forget.
+
+- [ ] **Step 4: Build + integration test pass.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agent/session_memory.rs src/agent/heartbeat.rs src/agent/agent_loop.rs
+git commit -m "feat(memory): backstop sweep summarizes un-summarized ended conversations"
+```
+
+---
+
+### Task 8: Full gate + docs
+
+**Files:**
+- Modify: `src/workspace/README.md` (document the `memory/sessions/` + `memory/recent.md` convention)
+
+- [ ] **Step 1: Full lint + test gate**
+```bash
+~/.cargo/bin/cargo test -p ironclaw session_memory:: && \
+~/.cargo/bin/cargo test -p ironclaw workspace:: && \
+~/.cargo/bin/cargo clippy -p ironclaw --tests --all-features 2>&1 | grep -E "warning|error" || echo "clippy clean"
+grep -nE '\.unwrap\(|\.expect\(' src/agent/session_memory.rs | grep -v test || echo "no prod unwrap/expect"
+```
+Expected: all pass; clippy clean; no prod panics.
+
+- [ ] **Step 2: Manual e2e (on the box, after deploy):** hold a short conversation via OWUI/TUI, let it go idle past the prune interval (or restart to trigger the startup sweep), confirm a file appears under `memory/sessions/` and `memory/recent.md` updates; start a new conversation and confirm IronClaw silently has the recent context (ask "what were we just doing?").
+
+- [ ] **Step 3: Docs** — add a "Episodic memory" subsection to `src/workspace/README.md`: `memory/sessions/YYYY-MM-DD-<conv>.md` per conversation (full, searchable), `memory/recent.md` terse digest (rides the system prompt), written on idle-prune + backstop sweep.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/workspace/README.md
+git commit -m "docs(memory): episodic memory workspace convention"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** auto-write (T4, T6) ✓; per-session searchable files + recent.md digest (T1, T2, T4) ✓; structured summarizer reusing compaction's pattern (T3) ✓; auto-recall injection, adaptive/silent, group-chat-excluded (T5) ✓; backstop sweep, idempotent, durable-from-DB (T7) ✓; two-channel model — push window (T5) + pull search over per-session files (inherent: files are workspace docs, already RRF-searchable) ✓; terse digest + N-cap + size-cap + open-thread weighting (T2) ✓; memory-never-blocks + fail-soft + idempotent-on-conversation_id (T4, T6, T7 constraints) ✓; token budget (T2) ✓.
+
+**Placeholders:** three `complete`/`sweep`/workspace-test spots are marked **confirm-first** with the exact grep to run and the existing code to mirror (`compaction.rs::generate_summary`, the workspace test harness, the DB message-load) — these are 2-minute in-situ lookups, not design gaps, matching the MCP-jobs plan's pattern. Everything else is complete code.
+
+**Type consistency:** `SessionSummary` fields, `sessions_path`/`RECENT_PATH`, `build_recent(new,existing,max_entries,max_chars)`, `SessionSummarizer::summarize(conversation_id,channel,timestamp,turns)`, `SessionMemory::{new,summarize_and_store,sweep}` are used consistently across tasks. Turns are `&[(String, Option<String>)]` everywhere.
+
+**Watch items for execution:** the LLM `complete` call shape (mirror compaction), the `StubLlm` helper name, the `MemoryDocument` content accessor, the workspace test constructor, and the DB "messages for a conversation" method — each has a confirm-first grep. None block the design.

--- a/docs/superpowers/specs/2026-07-09-episodic-memory-design.md
+++ b/docs/superpowers/specs/2026-07-09-episodic-memory-design.md
@@ -1,0 +1,108 @@
+# Episodic Memory for IronClaw (Sub-project 1 of 2)
+
+**Date:** 2026-07-09
+**Status:** Approved design, pre-implementation
+**Scope:** Give IronClaw automatic cross-session continuity — it writes a durable summary of every conversation when it ends, and silently opens each new conversation already knowing the recent ones. This is Sub-project 1 of the "friend memory" feature; Sub-project 2 (a long-term, curated model of the user, distilled from this episodic record) is a **separate later spec** and out of scope here.
+
+## Problem
+
+IronClaw starts every conversation fresh. It has retrieval memory (workspace files + hybrid FTS+vector RRF search) and identity files in its prompt, but that is a searchable archive, not lived continuity: an ordinary-length conversation that never triggers context compaction leaves **no durable trace**, and even when summaries exist they are not surfaced into the next conversation. The goal is the felt experience of "it remembers where we left off," delivered by two automatic behaviors bracketing every conversation.
+
+## Non-goals (Sub-project 2 or later)
+
+- A curated long-term model of the user (preferences, ongoing projects, people, patterns). That is Sub-project 2, which *consumes* this episodic record.
+- Per-conversation relevance-ranked recall (semantic retrieval of the *most relevant* past sessions for the current topic). Sub-project 1 recalls the *recent* sessions; topic-relevant recall is Sub-project 2.
+- Any change to the existing `memory_*` tools, RRF search, or compaction beyond reusing them.
+
+## Existing infrastructure this builds on
+
+- **Workspace memory** (`src/workspace/`): markdown files with hybrid RRF search, versioning, `daily/` logs, curated `MEMORY.md`, and identity files. Philosophy: "memory is database, not RAM — write explicitly."
+- **`Workspace::system_prompt()`**: the single place identity/memory files are assembled into the system prompt — the recall injection point.
+- **Compaction summarizer** (`src/agent/compaction.rs::generate_summary`): an LLM distiller of conversation turns, currently triggered only by context pressure. Reused here.
+- **Session lifecycle**: `HookEvent::SessionEnd` fires from the session-manager's idle-prune (`src/agent/session_manager.rs`), where the pruned session still holds its threads/turns in memory. `OnSessionStart` also exists.
+- **Heartbeat** (`src/agent/heartbeat.rs`): the periodic background executor — the backstop scheduler.
+- **Durability guarantee**: LLM data is never deleted; conversation turns are always in the DB, so nothing is lost if a summary write is missed.
+
+## Architecture
+
+Two automatic behaviors, both riding the seams above:
+
+1. **Auto-write** on conversation end → a durable, structured session summary in the workspace.
+2. **Auto-recall** on conversation start → the recent summaries silently in the system prompt (adaptive: IronClaw *has* them and surfaces them only when relevant — no forced greeting).
+
+### Component 1 — Session summarizer
+
+A shared summarizer, extracted/generalized from compaction's `generate_summary`, that turns a conversation's turns into a compact **structured summary**:
+
+- `title` (short), `gist` (1–3 sentences), `decisions` (list), `open_threads` (list of unfinished items / next steps), `user_notes` (notable user context or tone).
+- Plus metadata: `timestamp` (conversation end time), `conversation_id`, `channel`.
+
+Uses the lightweight summarization LLM path (`cheap_llm`, which falls back to the main model — on this box that resolves to the local `qwen3.6:27b`). Summarization is a background task; latency is not user-facing.
+
+### Component 2 — Episodic store (workspace markdown)
+
+Reuses the whole workspace stack (RRF search, versioning, `memory_*` tools):
+
+- **Per-session file:** `workspace/memory/sessions/YYYY-MM-DD-<conv-short>.md`, with YAML frontmatter (`timestamp`, `conversation_id`, `channel`, `title`) and the structured summary as the body. Individually **searchable**, so any past session is recall-able by content — not just the recent few.
+- **`workspace/memory/recent.md`:** a newest-first digest of the last **N** session summaries (N configurable, default 5), each entry length-bounded. This is the auto-recall surface. Prepended on each write and pruned to N.
+
+Granularity is **per conversation/thread** (`conversation_id`), so "our last conversation" maps to a single real episode.
+
+### Component 3 — `SessionMemory` (the coordinator)
+
+A component holding the summarizer LLM handle, the workspace, and the store. Two entry points:
+
+- `summarize_and_store(conversation_id, turns, channel)` — distill + write the per-session file + update `recent.md`. Skips trivial conversations (no substantive user turns). Idempotent: no-ops if a file for `conversation_id` already exists.
+- Invoked (a) from the **session-end path** (idle-prune, where the in-memory session still holds the turns), and (b) from the **backstop sweep**.
+
+### Component 4 — Auto-write wiring (session end)
+
+At idle-prune in `session_manager`, before/at the `SessionEnd` fire, hand each stale conversation's turns to `SessionMemory::summarize_and_store`. (`session_manager` gains the `SessionMemory` handle as an optional dependency; when absent — e.g. in tests — auto-write is simply skipped.)
+
+### Component 5 — Backstop sweep (durability)
+
+On **startup** and on the **heartbeat**, enumerate conversations that ended recently (via the conversations table's `updated_at`) with **no** per-session file, and summarize them from the durable DB turns. Idempotent (skips any `conversation_id` already summarized). Covers a crash between conversation end and idle-prune.
+
+### Component 6 — Auto-recall (session start)
+
+`Workspace::system_prompt()` includes `recent.md` as a clearly-labeled "Recent conversations" section (only if present and non-empty). Every new conversation thus opens with the last N sessions silently in context. Older sessions that roll off `recent.md` remain reachable via search.
+
+## Data flow
+
+```
+conversation ends (idle-prune / close)
+  → SessionMemory.summarize_and_store(conv_id, turns, channel)
+      → summarizer LLM → structured summary
+      → write workspace/memory/sessions/<date>-<conv>.md
+      → prepend to workspace/memory/recent.md (prune to N)
+
+startup + heartbeat
+  → for each recently-ended conversation with no summary file:
+      → load turns from DB → summarize_and_store  (idempotent)
+
+new conversation starts
+  → Workspace::system_prompt() includes recent.md
+  → IronClaw silently knows the last N conversations; surfaces when relevant
+```
+
+## Failure handling — memory never blocks a conversation
+
+- Auto-write failure (LLM or file error) → logged, **non-fatal**; raw turns stay in the DB; the backstop retries next sweep.
+- Trivial/empty conversations (no substantive user turns) → skipped; no summary noise.
+- `recent.md` missing/unreadable at recall → the prompt omits that section, degrading to today's behavior. Never hangs or errors a turn.
+- Idempotency everywhere keyed on `conversation_id` so session-end and the backstop can't double-write.
+- **Token budget:** `recent.md` capped at N summaries, each length-bounded, so recall cannot bloat the prompt.
+- Multi-tenant: all paths scope by `user_id` (the workspace is already per-owner).
+
+## Testing
+
+1. **Summarizer (unit, stub LLM):** turns → structured summary with the expected fields populated.
+2. **Episodic store (unit, temp workspace):** per-session file written with correct frontmatter and body; `recent.md` prepended, newest-first, pruned to N.
+3. **Recall (unit):** `system_prompt()` includes `recent.md` content when present; omits the section gracefully when absent.
+4. **Idempotency / skip (unit):** `summarize_and_store` no-ops on a duplicate `conversation_id`; skips a trivial conversation.
+5. **Backstop (integration):** summarizes an un-summarized recently-ended conversation from DB turns; a second sweep is a no-op.
+6. **End-to-end:** hold a real conversation → let it end → start a new one → IronClaw naturally references the prior when relevant.
+
+## Deliverable
+
+Every IronClaw conversation leaves a durable, searchable, timestamped episode, and every new conversation opens already holding the recent ones — the "picks up where we left off" foundation, and the raw material Sub-project 2 will distill into a long-term model of the user.

--- a/docs/superpowers/specs/2026-07-09-episodic-memory-design.md
+++ b/docs/superpowers/specs/2026-07-09-episodic-memory-design.md
@@ -11,7 +11,7 @@ IronClaw starts every conversation fresh. It has retrieval memory (workspace fil
 ## Non-goals (Sub-project 2 or later)
 
 - A curated long-term model of the user (preferences, ongoing projects, people, patterns). That is Sub-project 2, which *consumes* this episodic record.
-- Per-conversation relevance-ranked recall (semantic retrieval of the *most relevant* past sessions for the current topic). Sub-project 1 recalls the *recent* sessions; topic-relevant recall is Sub-project 2.
+- *Automatic* relevance-blended recall — proactively searching the archive at session start and merging topic-relevant past sessions into the recency window. (On-demand pull search over the session files IS available in Sub-project 1 via the existing `memory_*` tools; what Sub-project 2 adds is doing it *automatically* and blending it with the push window.)
 - Any change to the existing `memory_*` tools, RRF search, or compaction beyond reusing them.
 
 ## Existing infrastructure this builds on
@@ -43,10 +43,21 @@ Uses the lightweight summarization LLM path (`cheap_llm`, which falls back to th
 
 Reuses the whole workspace stack (RRF search, versioning, `memory_*` tools):
 
-- **Per-session file:** `workspace/memory/sessions/YYYY-MM-DD-<conv-short>.md`, with YAML frontmatter (`timestamp`, `conversation_id`, `channel`, `title`) and the structured summary as the body. Individually **searchable**, so any past session is recall-able by content — not just the recent few.
-- **`workspace/memory/recent.md`:** a newest-first digest of the last **N** session summaries (N configurable, default 5), each entry length-bounded. This is the auto-recall surface. Prepended on each write and pruned to N.
+- **Per-session file:** `workspace/memory/sessions/YYYY-MM-DD-<conv-short>.md`, with YAML frontmatter (`timestamp`, `conversation_id`, `channel`, `title`) and the **full** structured summary (gist, decisions, open threads, user notes) as the body. Individually **searchable** via the existing hybrid RRF, so any past session — however old — is recall-able by content. This is the unbounded half of the recall model (see "Recall model" below).
+- **`workspace/memory/recent.md`:** a compact newest-first **digest** — NOT full summaries. Each entry is terse: **title + one-line gist + open threads only** (~60–120 tokens); the full detail lives in the per-session file. This is the always-injected continuity surface. Prepended on each write and bounded by BOTH a count (`N`, default 5) AND a total size cap (~1.5k tokens), whichever binds first — because it rides the system prompt on every turn. Entries with unresolved open threads are weighted to stay longer than fully-wrapped ones (open loops are the highest-value continuity signal).
 
 Granularity is **per conversation/thread** (`conversation_id`), so "our last conversation" maps to a single real episode.
+
+### Recall model — two complementary channels
+
+Recall is **push + pull**, and the `N` cap bounds only the push channel, not what is recallable overall:
+
+| Channel | Surface | Bound | Trigger |
+|---|---|---|---|
+| **Continuity (push)** | `recent.md` injected into `system_prompt()` | small (N≈5, ~1.5k tokens) | automatic, every conversation |
+| **Relevant recall (pull)** | hybrid RRF search over the per-session files (via the existing `memory_*` tools) | **unbounded** | when the topic calls for it |
+
+The push channel is what delivers "silently already knows where we left off" — at the start of a chat there is no query to search on, so recent continuity must be *pushed* into the prompt. The pull channel gives infinite, relevance-based recall of any past conversation, but only fires when IronClaw decides to search — which is why it cannot, on its own, provide proactive continuity. Sub-project 2 later adds *automatic* relevance-blended recall (searching the archive at session start and merging it with the recency window) plus the long-term user model; Sub-project 1 delivers the recency push + the searchable archive that makes on-demand pull possible.
 
 ### Component 3 — `SessionMemory` (the coordinator)
 
@@ -63,9 +74,9 @@ At idle-prune in `session_manager`, before/at the `SessionEnd` fire, hand each s
 
 On **startup** and on the **heartbeat**, enumerate conversations that ended recently (via the conversations table's `updated_at`) with **no** per-session file, and summarize them from the durable DB turns. Idempotent (skips any `conversation_id` already summarized). Covers a crash between conversation end and idle-prune.
 
-### Component 6 — Auto-recall (session start)
+### Component 6 — Auto-recall (session start, the push channel)
 
-`Workspace::system_prompt()` includes `recent.md` as a clearly-labeled "Recent conversations" section (only if present and non-empty). Every new conversation thus opens with the last N sessions silently in context. Older sessions that roll off `recent.md` remain reachable via search.
+`Workspace::system_prompt()` includes `recent.md` as a clearly-labeled "Recent conversations" section (only if present and non-empty). Every new conversation thus opens with the terse last-N digest silently in context — the push channel. Adaptive: IronClaw *has* it and surfaces it only when relevant. The full detail of any recent (or old) session is one search away via the pull channel — the per-session files are always searchable — so nothing that rolls off `recent.md` is lost.
 
 ## Data flow
 
@@ -97,7 +108,7 @@ new conversation starts
 ## Testing
 
 1. **Summarizer (unit, stub LLM):** turns → structured summary with the expected fields populated.
-2. **Episodic store (unit, temp workspace):** per-session file written with correct frontmatter and body; `recent.md` prepended, newest-first, pruned to N.
+2. **Episodic store (unit, temp workspace):** per-session file written with correct frontmatter and full body; `recent.md` prepended newest-first with **terse** entries (title + gist + open threads only, not the full body), bounded by N **and** the size cap (whichever binds first), with open-thread entries retained preferentially over wrapped ones.
 3. **Recall (unit):** `system_prompt()` includes `recent.md` content when present; omits the section gracefully when absent.
 4. **Idempotency / skip (unit):** `summarize_and_store` no-ops on a duplicate `conversation_id`; skips a trivial conversation.
 5. **Backstop (integration):** summarizes an un-summarized recently-ended conversation from DB turns; a second sweep is a no-op.

--- a/src/agent/agent_loop.rs
+++ b/src/agent/agent_loop.rs
@@ -593,7 +593,20 @@ impl Agent {
             let llm = deps.cheap_llm.clone().unwrap_or_else(|| deps.llm.clone());
             let memory =
                 Arc::new(crate::agent::session_memory::SessionMemory::new(llm, ws));
-            session_manager.set_session_memory(memory);
+            session_manager.set_session_memory(memory.clone());
+
+            // Startup backstop sweep: summarize any recently-ended conversation
+            // that was never summarized (e.g. a crash before idle-prune). Only
+            // when a raw store is present; fire-and-forget + fail-soft.
+            if let Some(db) = deps.store.clone() {
+                tokio::spawn(async move {
+                    let since = chrono::Utc::now() - chrono::Duration::hours(24);
+                    let n = memory.sweep(&db, since).await;
+                    if n > 0 {
+                        tracing::debug!("startup: episodic sweep summarized {n} conversation(s)");
+                    }
+                });
+            }
         }
 
         let mut scheduler = Scheduler::new(
@@ -1302,6 +1315,20 @@ impl Agent {
                             None
                         }
                     } else {
+                        // Episodic-memory backstop sweep on each heartbeat tick,
+                        // wired only when both a workspace and a raw store exist.
+                        let session_memory = self.deps.store.as_ref().map(|db| {
+                            let llm = self
+                                .deps
+                                .cheap_llm
+                                .clone()
+                                .unwrap_or_else(|| self.deps.llm.clone());
+                            let mem = Arc::new(crate::agent::session_memory::SessionMemory::new(
+                                llm,
+                                workspace.clone(),
+                            ));
+                            (mem, Arc::clone(db))
+                        });
                         Some(spawn_heartbeat(
                             config,
                             hygiene,
@@ -1309,6 +1336,7 @@ impl Agent {
                             self.cheap_llm().clone(),
                             Some(notify_tx),
                             self.system_store(),
+                            session_memory,
                         ))
                     }
                 } else {

--- a/src/agent/agent_loop.rs
+++ b/src/agent/agent_loop.rs
@@ -585,6 +585,17 @@ impl Agent {
 
         let session_manager = session_manager.unwrap_or_else(|| Arc::new(SessionManager::new()));
 
+        // Wire episodic memory: summarize conversations on idle-prune. Only when
+        // a workspace is present (the store target); the cheap LLM is preferred
+        // for this lightweight summarization, falling back to the main model.
+        // The setter takes `&self`, so it works on the already-shared `Arc`.
+        if let Some(ws) = deps.workspace.clone() {
+            let llm = deps.cheap_llm.clone().unwrap_or_else(|| deps.llm.clone());
+            let memory =
+                Arc::new(crate::agent::session_memory::SessionMemory::new(llm, ws));
+            session_manager.set_session_memory(memory);
+        }
+
         let mut scheduler = Scheduler::new(
             config.clone(),
             context_manager.clone(),

--- a/src/agent/heartbeat.rs
+++ b/src/agent/heartbeat.rs
@@ -183,6 +183,11 @@ pub struct HeartbeatRunner {
     llm: Arc<dyn LlmProvider>,
     response_tx: Option<mpsc::Sender<OutgoingResponse>>,
     store: Option<SystemScope>,
+    /// Episodic-memory backstop sweep dependencies. Both must be present for
+    /// the per-tick sweep to run: the coordinator that writes summaries and the
+    /// raw database handle used to enumerate conversations + load their turns.
+    session_memory: Option<Arc<crate::agent::session_memory::SessionMemory>>,
+    session_store: Option<Arc<dyn crate::db::Database>>,
     consecutive_failures: u32,
 }
 
@@ -201,6 +206,8 @@ impl HeartbeatRunner {
             llm,
             response_tx: None,
             store: None,
+            session_memory: None,
+            session_store: None,
             consecutive_failures: 0,
         }
     }
@@ -214,6 +221,20 @@ impl HeartbeatRunner {
     /// Set the system-scoped database store for persistent heartbeat conversations.
     pub fn with_store(mut self, store: SystemScope) -> Self {
         self.store = Some(store);
+        self
+    }
+
+    /// Wire the episodic-memory backstop sweep. On each tick the runner will
+    /// fire-and-forget `SessionMemory::sweep` (since = now-24h) to summarize any
+    /// recently-ended conversations that were never summarized (e.g. a crash
+    /// between conversation end and idle-prune). Both handles are required.
+    pub fn with_session_memory(
+        mut self,
+        memory: Arc<crate::agent::session_memory::SessionMemory>,
+        store: Arc<dyn crate::db::Database>,
+    ) -> Self {
+        self.session_memory = Some(memory);
+        self.session_store = Some(store);
         self
     }
 
@@ -282,6 +303,21 @@ impl HeartbeatRunner {
                     );
                 }
             });
+
+            // Episodic-memory backstop: summarize any recently-ended
+            // conversation that has no per-session file yet. Fire-and-forget so
+            // it never delays the heartbeat checklist; idempotent + fail-soft.
+            if let (Some(mem), Some(store)) =
+                (self.session_memory.clone(), self.session_store.clone())
+            {
+                tokio::spawn(async move {
+                    let since = chrono::Utc::now() - chrono::Duration::hours(24);
+                    let n = mem.sweep(&store, since).await;
+                    if n > 0 {
+                        tracing::debug!("heartbeat: episodic sweep summarized {n} conversation(s)");
+                    }
+                });
+            }
 
             match self.check_heartbeat().await {
                 HeartbeatResult::Ok => {
@@ -495,6 +531,8 @@ fn strip_html_comments(content: &str) -> String {
 /// Spawn the heartbeat runner as a background task.
 ///
 /// Returns a handle that can be used to stop the runner.
+#[allow(clippy::too_many_arguments)]
+// arch-exempt: too_many_args, heartbeat spawn threads optional deps individually; a bundle struct is a future cleanup, plan 2026-07-09-episodic-memory
 pub fn spawn_heartbeat(
     config: HeartbeatConfig,
     hygiene_config: HygieneConfig,
@@ -502,6 +540,10 @@ pub fn spawn_heartbeat(
     llm: Arc<dyn LlmProvider>,
     response_tx: Option<mpsc::Sender<OutgoingResponse>>,
     store: Option<SystemScope>,
+    session_memory: Option<(
+        Arc<crate::agent::session_memory::SessionMemory>,
+        Arc<dyn crate::db::Database>,
+    )>,
 ) -> tokio::task::JoinHandle<()> {
     let mut runner = HeartbeatRunner::new(config, hygiene_config, workspace, llm);
     if let Some(tx) = response_tx {
@@ -509,6 +551,9 @@ pub fn spawn_heartbeat(
     }
     if let Some(s) = store {
         runner = runner.with_store(s);
+    }
+    if let Some((mem, db)) = session_memory {
+        runner = runner.with_session_memory(mem, db);
     }
 
     tokio::spawn(async move {
@@ -900,8 +945,9 @@ mod tests {
     #[test]
     fn test_spawn_heartbeat_accepts_store_param() {
         // Regression: spawn_heartbeat must accept an optional Database store
-        // for persisting heartbeat notifications to a dedicated conversation.
-        // Compile-time check: the 7th parameter is `Option<Arc<dyn Database>>`.
+        // (6th param) for persisting heartbeat notifications to a dedicated
+        // conversation, plus the optional episodic-memory backstop-sweep pair
+        // (7th param: `SessionMemory` + raw `Database`).
         #[allow(clippy::type_complexity)]
         let _fn_ptr: fn(
             HeartbeatConfig,
@@ -910,6 +956,10 @@ mod tests {
             Arc<dyn ironclaw_llm::LlmProvider>,
             Option<tokio::sync::mpsc::Sender<crate::channels::OutgoingResponse>>,
             Option<SystemScope>,
+            Option<(
+                Arc<crate::agent::session_memory::SessionMemory>,
+                Arc<dyn crate::db::Database>,
+            )>,
         ) -> tokio::task::JoinHandle<()> = spawn_heartbeat;
         let _ = _fn_ptr;
     }

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -27,6 +27,7 @@ pub(crate) mod scheduler;
 mod self_repair;
 pub mod session;
 mod session_manager;
+pub mod session_memory;
 pub mod submission;
 pub mod task;
 mod thread_ops;

--- a/src/agent/session_manager.rs
+++ b/src/agent/session_manager.rs
@@ -4,17 +4,22 @@
 //! for each thread.
 
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use tokio::sync::{Mutex, RwLock};
 use uuid::Uuid;
 
 use crate::agent::session::Session;
+use crate::agent::session_memory::SessionMemory;
 use crate::agent::undo::UndoManager;
 use crate::hooks::HookRegistry;
 
 /// Warn when session count exceeds this threshold.
 const SESSION_COUNT_WARNING_THRESHOLD: usize = 1000;
+
+/// A stale conversation snapshot handed to the episodic summarizer on prune:
+/// `(conversation_id, channel, turns)` where each turn is `(user, response?)`.
+type StaleConversation = (String, String, Vec<(String, Option<String>)>);
 
 /// Key for mapping external thread IDs to internal ones.
 #[derive(Clone, Hash, Eq, PartialEq)]
@@ -30,6 +35,11 @@ pub struct SessionManager {
     thread_map: RwLock<HashMap<ThreadKey, Uuid>>,
     undo_managers: RwLock<HashMap<Uuid, Arc<Mutex<UndoManager>>>>,
     hooks: Option<Arc<HookRegistry>>,
+    /// Optional episodic-memory coordinator. When present, each stale
+    /// conversation is summarized on idle-prune (fire-and-forget). Set once,
+    /// after this manager is already shared as an `Arc`, so it uses interior
+    /// mutability. Absent in tests / when no workspace or LLM is wired.
+    session_memory: OnceLock<Arc<SessionMemory>>,
 }
 
 impl SessionManager {
@@ -40,6 +50,7 @@ impl SessionManager {
             thread_map: RwLock::new(HashMap::new()),
             undo_managers: RwLock::new(HashMap::new()),
             hooks: None,
+            session_memory: OnceLock::new(),
         }
     }
 
@@ -47,6 +58,13 @@ impl SessionManager {
     pub fn with_hooks(mut self, hooks: Arc<HookRegistry>) -> Self {
         self.hooks = Some(hooks);
         self
+    }
+
+    /// Wire the episodic-memory coordinator. Callable on a shared `Arc`
+    /// (takes `&self`); the first call wins and later calls are ignored.
+    pub fn set_session_memory(&self, memory: Arc<SessionMemory>) {
+        // Ignore a redundant second wiring — the store is idempotent anyway.
+        let _ = self.session_memory.set(memory);
     }
 
     /// Get or create a session for a user.
@@ -334,6 +352,11 @@ impl SessionManager {
         // Per-session thread IDs so SessionEnd hooks can target the right conversations.
         let mut per_session_thread_ids: std::collections::HashMap<String, Vec<Uuid>> =
             std::collections::HashMap::new();
+        // Snapshot of each stale thread's turns (conversation_id, channel, turns)
+        // captured under the session lock, so the episodic summarizer can run
+        // fire-and-forget after the session is dropped.
+        let mut stale_thread_turns: Vec<StaleConversation> = Vec::new();
+        let want_memory = self.session_memory.get().is_some();
         {
             let sessions = self.sessions.read().await;
             for user_id in &stale_users {
@@ -343,7 +366,38 @@ impl SessionManager {
                     let tids: Vec<Uuid> = sess.threads.keys().copied().collect();
                     stale_thread_ids.extend(&tids);
                     per_session_thread_ids.insert(sess.id.to_string(), tids);
+                    if want_memory {
+                        for thread in sess.threads.values() {
+                            if thread.turns.is_empty() {
+                                continue;
+                            }
+                            let turns: Vec<(String, Option<String>)> = thread
+                                .turns
+                                .iter()
+                                .map(|t| (t.user_input.clone(), t.response.clone()))
+                                .collect();
+                            let channel = thread
+                                .source_channel
+                                .clone()
+                                .unwrap_or_else(|| "unknown".to_string());
+                            stale_thread_turns.push((thread.id.to_string(), channel, turns));
+                        }
+                    }
                 }
+            }
+        }
+
+        // Episodic memory: summarize each stale conversation that had activity.
+        // Fire-and-forget — memory must never block or fail the prune path.
+        if let Some(memory) = self.session_memory.get() {
+            for (conversation_id, channel, turns) in stale_thread_turns {
+                let memory = Arc::clone(memory);
+                let ts = chrono::Utc::now();
+                tokio::spawn(async move {
+                    memory
+                        .summarize_and_store(&conversation_id, &channel, ts, &turns)
+                        .await;
+                });
             }
         }
 

--- a/src/agent/session_memory.rs
+++ b/src/agent/session_memory.rs
@@ -246,6 +246,93 @@ impl SessionSummarizer {
     }
 }
 
+/// Coordinator: distills a conversation and writes the per-session file +
+/// `recent.md` digest. Fail-soft — every error is logged, never propagated
+/// into a conversation turn.
+pub struct SessionMemory {
+    summarizer: SessionSummarizer,
+    workspace: std::sync::Arc<crate::workspace::Workspace>,
+}
+
+impl SessionMemory {
+    pub fn new(
+        llm: std::sync::Arc<dyn ironclaw_llm::LlmProvider>,
+        workspace: std::sync::Arc<crate::workspace::Workspace>,
+    ) -> Self {
+        Self {
+            summarizer: SessionSummarizer::new(llm),
+            workspace,
+        }
+    }
+
+    /// Summarize a conversation and durably store it. Skips trivial
+    /// conversations (no substantive user turns) and is idempotent on
+    /// `conversation_id` (a pre-existing per-session file means "already
+    /// summarized"). All failures are logged; none propagate.
+    pub async fn summarize_and_store(
+        &self,
+        conversation_id: &str,
+        channel: &str,
+        timestamp: DateTime<Utc>,
+        turns: &[(String, Option<String>)],
+    ) {
+        // Skip trivial: nothing worth remembering if every user turn is empty.
+        if turns.iter().all(|(u, _)| u.trim().is_empty()) {
+            return;
+        }
+        let stem = format!("{}-{}", timestamp.format("%Y-%m-%d"), conversation_id);
+        let path = sessions_path(&stem);
+        // Idempotency: a file already existing for this conversation means we
+        // already summarized it — skip (guards session-end vs backstop races).
+        if self.file_exists(&path).await {
+            return;
+        }
+        let summary = match self
+            .summarizer
+            .summarize(conversation_id, channel, timestamp, turns)
+            .await
+        {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!("session summary failed for {conversation_id}: {e}");
+                return;
+            }
+        };
+        if let Err(e) = self.workspace.write(&path, &summary.to_markdown()).await {
+            tracing::warn!("write session file failed for {conversation_id}: {e}");
+            return;
+        }
+        let existing = self.read_or_empty(RECENT_PATH).await;
+        let recent = build_recent(&summary.digest_entry(), &existing, 5, 6000);
+        if let Err(e) = self.workspace.write(RECENT_PATH, &recent).await {
+            tracing::warn!("update recent.md failed for {conversation_id}: {e}");
+        }
+    }
+
+    /// True if a document already exists at `path` (any read error other than
+    /// "found" is treated as absent — the backstop sweep will retry).
+    async fn file_exists(&self, path: &str) -> bool {
+        self.workspace.read(path).await.is_ok()
+    }
+
+    /// Read a document's content, or the empty string if it is absent.
+    async fn read_or_empty(&self, path: &str) -> String {
+        self.workspace
+            .read(path)
+            .await
+            .map(|d| d.content)
+            .unwrap_or_default() // silent-ok: recent.md may not exist yet; empty = fresh digest
+    }
+}
+
+#[cfg(test)]
+impl SessionMemory {
+    /// Test-only: read a workspace document's content, or empty on absence.
+    async fn workspace_read(&self, path: &str) -> String {
+        self.read_or_empty(path).await
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -351,5 +438,69 @@ mod tests {
         let out = parse_summary_json("not json at all", "c2", "cli", ts);
         assert_eq!(out.title, "Conversation");
         assert!(out.gist.contains("not json"));
+    }
+
+    #[cfg(feature = "libsql")]
+    async fn test_workspace() -> (std::sync::Arc<crate::workspace::Workspace>, tempfile::TempDir) {
+        use crate::db::libsql::LibSqlBackend;
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let db_path = temp_dir.path().join("session_memory_test.db");
+        let backend = LibSqlBackend::new_local(&db_path)
+            .await
+            .expect("LibSqlBackend");
+        <LibSqlBackend as crate::db::Database>::run_migrations(&backend)
+            .await
+            .expect("migrations");
+        let db: std::sync::Arc<dyn crate::db::Database> = std::sync::Arc::new(backend);
+        let ws = crate::workspace::Workspace::new_with_db("test_session_memory", db);
+        (std::sync::Arc::new(ws), temp_dir)
+    }
+
+    #[cfg(feature = "libsql")]
+    #[tokio::test]
+    async fn store_writes_session_file_and_updates_recent() {
+        let (ws, _dir) = test_workspace().await;
+        let llm = std::sync::Arc::new(crate::testing::StubLlm::new(
+            r#"{"title":"T","gist":"g","open_threads":["x"]}"#,
+        ));
+        let mem = SessionMemory::new(llm, ws);
+        let ts = chrono::Utc::now();
+        mem.summarize_and_store("conv9", "cli", ts, &[("hi".into(), Some("hello".into()))])
+            .await;
+
+        let stem = format!("{}-conv9", ts.format("%Y-%m-%d"));
+        let file = mem.workspace_read(&sessions_path(&stem)).await;
+        assert!(file.contains("title: T"), "session file has frontmatter title");
+        let recent = mem.workspace_read(RECENT_PATH).await;
+        assert!(recent.contains("— T"), "recent.md has the digest entry");
+
+        // idempotent: a second call does not double-append to recent.md
+        mem.summarize_and_store("conv9", "cli", ts, &[("hi".into(), Some("hello".into()))])
+            .await;
+        let recent2 = mem.workspace_read(RECENT_PATH).await;
+        assert_eq!(
+            recent2.matches("— T").count(),
+            1,
+            "idempotent: no double-append"
+        );
+    }
+
+    #[cfg(feature = "libsql")]
+    #[tokio::test]
+    async fn store_skips_trivial_conversation() {
+        let (ws, _dir) = test_workspace().await;
+        let llm = std::sync::Arc::new(crate::testing::StubLlm::new(
+            r#"{"title":"T","gist":"g"}"#,
+        ));
+        let mem = SessionMemory::new(llm, ws);
+        let ts = chrono::Utc::now();
+        // Only empty user turns -> skip; no file written.
+        mem.summarize_and_store("trivial", "cli", ts, &[("   ".into(), Some("hi".into()))])
+            .await;
+        let stem = format!("{}-trivial", ts.format("%Y-%m-%d"));
+        assert!(
+            !mem.file_exists(&sessions_path(&stem)).await,
+            "trivial conversation must not write a session file"
+        );
     }
 }

--- a/src/agent/session_memory.rs
+++ b/src/agent/session_memory.rs
@@ -1,0 +1,124 @@
+//! Episodic memory: durable per-conversation summaries + a recent-digest that
+//! rides the system prompt. See docs/superpowers/specs/2026-07-09-episodic-memory-design.md
+
+use chrono::{DateTime, Utc};
+
+/// A structured summary of one conversation (thread).
+#[derive(Debug, Clone)]
+pub struct SessionSummary {
+    pub conversation_id: String,
+    pub channel: String,
+    pub timestamp: DateTime<Utc>,
+    pub title: String,
+    pub gist: String,
+    pub decisions: Vec<String>,
+    pub open_threads: Vec<String>,
+    pub user_notes: Vec<String>,
+}
+
+/// Workspace-relative path for a per-session file.
+pub fn sessions_path(stem: &str) -> String {
+    format!("memory/sessions/{stem}.md")
+}
+
+/// Workspace-relative path for the recent-digest.
+pub const RECENT_PATH: &str = "memory/recent.md";
+
+impl SessionSummary {
+    /// `YYYY-MM-DD-<conversation_id>` — the per-session file stem.
+    pub fn file_stem(&self) -> String {
+        format!(
+            "{}-{}",
+            self.timestamp.format("%Y-%m-%d"),
+            self.conversation_id
+        )
+    }
+
+    fn bullets(items: &[String]) -> String {
+        if items.is_empty() {
+            "_none_\n".to_string()
+        } else {
+            items.iter().map(|i| format!("- {i}\n")).collect()
+        }
+    }
+
+    /// Full per-session file: YAML frontmatter + structured body.
+    pub fn to_markdown(&self) -> String {
+        format!(
+            "---\nconversation_id: {}\nchannel: {}\ntimestamp: {}\ntitle: {}\n---\n\n\
+             # {}\n\n{}\n\n## Decisions\n{}\n## Open threads\n{}\n## User notes\n{}",
+            self.conversation_id,
+            self.channel,
+            self.timestamp.to_rfc3339(),
+            self.title,
+            self.title,
+            self.gist,
+            Self::bullets(&self.decisions),
+            Self::bullets(&self.open_threads),
+            Self::bullets(&self.user_notes),
+        )
+    }
+
+    /// Terse one-block digest for `recent.md`: title + gist + open threads only.
+    pub fn digest_entry(&self) -> String {
+        let threads = if self.open_threads.is_empty() {
+            String::new()
+        } else {
+            format!("  \n  _open:_ {}", self.open_threads.join("; "))
+        };
+        format!(
+            "### {} — {}\n{}{}\n",
+            self.timestamp.format("%Y-%m-%d"),
+            self.title,
+            self.gist,
+            threads,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn sample() -> SessionSummary {
+        SessionSummary {
+            conversation_id: "abc123".into(),
+            channel: "gateway".into(),
+            timestamp: chrono::Utc.with_ymd_and_hms(2026, 7, 9, 14, 30, 0).unwrap(),
+            title: "Voice setup".into(),
+            gist: "Wired local STT/TTS into OWUI.".into(),
+            decisions: vec!["Use Wyoming engines".into()],
+            open_threads: vec!["Test on the phone PWA".into()],
+            user_notes: vec!["Prefers all-local".into()],
+        }
+    }
+
+    #[test]
+    fn file_stem_is_date_and_conv() {
+        assert_eq!(sample().file_stem(), "2026-07-09-abc123");
+        assert_eq!(
+            sessions_path(&sample().file_stem()),
+            "memory/sessions/2026-07-09-abc123.md"
+        );
+    }
+
+    #[test]
+    fn to_markdown_has_frontmatter_and_body() {
+        let md = sample().to_markdown();
+        assert!(md.starts_with("---\n"));
+        assert!(md.contains("conversation_id: abc123"));
+        assert!(md.contains("title: Voice setup"));
+        assert!(md.contains("## Open threads"));
+        assert!(md.contains("Test on the phone PWA"));
+    }
+
+    #[test]
+    fn digest_entry_is_terse() {
+        let d = sample().digest_entry();
+        assert!(d.contains("Voice setup"));
+        assert!(d.contains("Wired local STT/TTS"));
+        assert!(d.contains("Test on the phone PWA")); // open threads kept
+        assert!(!d.contains("Prefers all-local")); // user_notes NOT in the terse digest
+    }
+}

--- a/src/agent/session_memory.rs
+++ b/src/agent/session_memory.rs
@@ -102,6 +102,28 @@ fn has_open(entry: &str) -> bool {
     entry.contains("_open:_")
 }
 
+/// Fold a chronological message list into `(user_input, assistant_response?)`
+/// turn pairs. A `user` message opens a turn; the next `assistant` message
+/// closes it. Consecutive user messages start fresh turns; a leading assistant
+/// message (no preceding user) is ignored.
+fn pair_turns(messages: &[crate::history::ConversationMessage]) -> Vec<(String, Option<String>)> {
+    let mut turns: Vec<(String, Option<String>)> = Vec::new();
+    for m in messages {
+        match m.role.as_str() {
+            "user" => turns.push((m.content.clone(), None)),
+            "assistant" => {
+                if let Some(last) = turns.last_mut()
+                    && last.1.is_none()
+                {
+                    last.1 = Some(m.content.clone());
+                }
+            }
+            _ => {}
+        }
+    }
+    turns
+}
+
 /// Rebuild `memory/recent.md`: prepend `new_entry` to the entries parsed out
 /// of `existing`, cap the entry count, then cap total size — preferring to
 /// drop fully-wrapped entries (no open threads) before dropping open ones.
@@ -309,6 +331,59 @@ impl SessionMemory {
         }
     }
 
+    /// Backstop sweep: for each of the owner's conversations touched since
+    /// `since` that has no per-session summary file yet, load its turns from
+    /// the durable store and summarize them. Returns the number of new
+    /// summaries written. Idempotent — the per-session-file check inside
+    /// [`Self::summarize_and_store`] guards against double-writes, so a repeat
+    /// sweep is a no-op. Fail-soft: every store error is logged, never
+    /// propagated into a conversation turn.
+    ///
+    /// The owner is taken from the workspace this `SessionMemory` was built
+    /// for; `store` is the shared database handle used to enumerate the
+    /// conversations and load their message pairs.
+    pub async fn sweep(
+        &self,
+        store: &std::sync::Arc<dyn crate::db::Database>,
+        since: DateTime<Utc>,
+    ) -> usize {
+        let user_id = self.workspace.user_id().to_string();
+        // Enumerate the owner's recent conversations across all channels.
+        let convos = match store.list_conversations_all_channels(&user_id, 200).await {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::warn!("memory sweep: list conversations failed: {e}");
+                return 0;
+            }
+        };
+        let mut n = 0;
+        for c in convos {
+            // Only conversations touched within the window.
+            if c.last_activity < since {
+                continue;
+            }
+            let stem = format!("{}-{}", c.last_activity.format("%Y-%m-%d"), c.id);
+            if self.file_exists(&sessions_path(&stem)).await {
+                continue;
+            }
+            let messages = match store.list_conversation_messages(c.id).await {
+                Ok(m) => m,
+                Err(e) => {
+                    tracing::warn!("memory sweep: load messages for {} failed: {e}", c.id);
+                    continue;
+                }
+            };
+            let turns = pair_turns(&messages);
+            if turns.is_empty() {
+                continue;
+            }
+            self.summarize_and_store(&c.id.to_string(), &c.channel, c.last_activity, &turns)
+                .await;
+            n += 1;
+        }
+        n
+    }
+
     /// True if a document already exists at `path` (any read error other than
     /// "found" is treated as absent — the backstop sweep will retry).
     async fn file_exists(&self, path: &str) -> bool {
@@ -483,6 +558,57 @@ mod tests {
             1,
             "idempotent: no double-append"
         );
+    }
+
+    #[cfg(feature = "libsql")]
+    #[tokio::test]
+    async fn sweep_summarizes_unsummarized_conversation() {
+        use crate::db::Database;
+        use crate::db::libsql::LibSqlBackend;
+
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let db_path = temp_dir.path().join("sweep_test.db");
+        let backend = LibSqlBackend::new_local(&db_path)
+            .await
+            .expect("LibSqlBackend");
+        <LibSqlBackend as Database>::run_migrations(&backend)
+            .await
+            .expect("migrations");
+        let db: std::sync::Arc<dyn Database> = std::sync::Arc::new(backend);
+
+        // Seed a conversation with a couple of messages, owned by the sweep user.
+        let user_id = "sweep_user";
+        let conv_id = db
+            .create_conversation("cli", user_id, None)
+            .await
+            .expect("create conversation");
+        db.add_conversation_message(conv_id, "user", "how do I set up voice?")
+            .await
+            .expect("add user msg");
+        db.add_conversation_message(conv_id, "assistant", "Wire the Wyoming engines.")
+            .await
+            .expect("add assistant msg");
+
+        let ws = std::sync::Arc::new(crate::workspace::Workspace::new_with_db(
+            user_id,
+            std::sync::Arc::clone(&db),
+        ));
+        let llm = std::sync::Arc::new(crate::testing::StubLlm::new(
+            r#"{"title":"Voice","gist":"Set up voice.","open_threads":["test pwa"]}"#,
+        ));
+        let mem = SessionMemory::new(llm, ws);
+
+        // First sweep summarizes the un-summarized conversation.
+        let since = chrono::Utc::now() - chrono::Duration::hours(24);
+        let n = mem.sweep(&db, since).await;
+        assert_eq!(n, 1, "one conversation summarized on first sweep");
+
+        let recent = mem.workspace_read(RECENT_PATH).await;
+        assert!(recent.contains("— Voice"), "recent.md updated by sweep");
+
+        // Second sweep is idempotent — the per-session file already exists.
+        let n2 = mem.sweep(&db, since).await;
+        assert_eq!(n2, 0, "idempotent: no new summaries on second sweep");
     }
 
     #[cfg(feature = "libsql")]

--- a/src/agent/session_memory.rs
+++ b/src/agent/session_memory.rs
@@ -76,6 +76,65 @@ impl SessionSummary {
     }
 }
 
+const RECENT_HEADER: &str = "# Recent conversations\n\n";
+
+fn split_entries(body: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut cur = String::new();
+    for line in body.lines() {
+        if line.starts_with("### ") && !cur.trim().is_empty() {
+            out.push(std::mem::take(&mut cur));
+        }
+        if line.starts_with("# Recent conversations") {
+            continue;
+        }
+        cur.push_str(line);
+        cur.push('\n');
+    }
+    if !cur.trim().is_empty() {
+        out.push(cur);
+    }
+    out
+}
+
+fn has_open(entry: &str) -> bool {
+    entry.contains("_open:_")
+}
+
+/// Rebuild `memory/recent.md`: prepend `new_entry` to the entries parsed out
+/// of `existing`, cap the entry count, then cap total size — preferring to
+/// drop fully-wrapped entries (no open threads) before dropping open ones.
+pub fn build_recent(
+    new_entry: &str,
+    existing: &str,
+    max_entries: usize,
+    max_chars: usize,
+) -> String {
+    let mut entries = vec![new_entry.to_string()];
+    entries.extend(split_entries(existing));
+    // Count cap (newest-first order preserved).
+    entries.truncate(max_entries);
+    // Size cap: drop from the end; prefer dropping wrapped (no open threads) entries.
+    loop {
+        let total: usize = RECENT_HEADER.len() + entries.iter().map(|e| e.len()).sum::<usize>();
+        if total <= max_chars || entries.len() <= 1 {
+            break;
+        }
+        // find the last wrapped entry to drop; else drop the last entry.
+        let idx = entries
+            .iter()
+            .rposition(|e| !has_open(e))
+            .unwrap_or(entries.len() - 1);
+        entries.remove(idx);
+    }
+    let mut out = String::from(RECENT_HEADER);
+    for e in &entries {
+        out.push_str(e.trim_end());
+        out.push_str("\n\n");
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -120,5 +179,33 @@ mod tests {
         assert!(d.contains("Wired local STT/TTS"));
         assert!(d.contains("Test on the phone PWA")); // open threads kept
         assert!(!d.contains("Prefers all-local")); // user_notes NOT in the terse digest
+    }
+
+    #[test]
+    fn build_recent_prepends_and_caps_count() {
+        let e1 = "### 2026-07-01 — A\ngist a\n";
+        let e2 = "### 2026-07-02 — B\ngist b\n";
+        let e3 = "### 2026-07-03 — C\ngist c\n";
+        let r1 = build_recent(e1, "", 2, 6000);
+        assert!(r1.starts_with("# Recent conversations"));
+        let r2 = build_recent(e2, &r1, 2, 6000);
+        let r3 = build_recent(e3, &r2, 2, 6000);
+        // newest first, only 2 kept
+        let pos_c = r3.find("— C").unwrap();
+        let pos_b = r3.find("— B").unwrap();
+        assert!(pos_c < pos_b, "newest first");
+        assert!(!r3.contains("— A"), "oldest dropped by count cap");
+    }
+
+    #[test]
+    fn build_recent_size_cap_drops_wrapped_before_open() {
+        let open = "### 2026-07-01 — Open\ngist\n  \n  _open:_ finish X\n";
+        let wrapped = "### 2026-07-02 — Wrapped\ngist\n";
+        let acc = build_recent(open, "", 5, 6000);
+        let acc = build_recent(wrapped, &acc, 5, 60); // tiny cap forces a drop
+        assert!(
+            acc.contains("— Open"),
+            "open-thread entry retained under size pressure"
+        );
     }
 }

--- a/src/agent/session_memory.rs
+++ b/src/agent/session_memory.rs
@@ -2,6 +2,7 @@
 //! rides the system prompt. See docs/superpowers/specs/2026-07-09-episodic-memory-design.md
 
 use chrono::{DateTime, Utc};
+use serde::Deserialize;
 
 /// A structured summary of one conversation (thread).
 #[derive(Debug, Clone)]
@@ -135,6 +136,116 @@ pub fn build_recent(
     out
 }
 
+/// Tolerant view of the model's JSON reply.
+#[derive(Deserialize, Default)]
+struct RawSummary {
+    #[serde(default)]
+    title: String,
+    #[serde(default)]
+    gist: String,
+    #[serde(default)]
+    decisions: Vec<String>,
+    #[serde(default)]
+    open_threads: Vec<String>,
+    #[serde(default)]
+    user_notes: Vec<String>,
+}
+
+/// Parse the model's (possibly fenced) JSON into a `SessionSummary`. A malformed
+/// reply never fails the pipeline — it falls back to a minimal summary.
+pub(crate) fn parse_summary_json(
+    raw: &str,
+    conversation_id: &str,
+    channel: &str,
+    timestamp: DateTime<Utc>,
+) -> SessionSummary {
+    let cleaned = raw
+        .trim()
+        .trim_start_matches("```json")
+        .trim_start_matches("```")
+        .trim_end_matches("```")
+        .trim();
+    match serde_json::from_str::<RawSummary>(cleaned) {
+        Ok(r) if !r.title.is_empty() || !r.gist.is_empty() => SessionSummary {
+            conversation_id: conversation_id.to_string(),
+            channel: channel.to_string(),
+            timestamp,
+            title: if r.title.is_empty() {
+                "Conversation".to_string()
+            } else {
+                r.title
+            },
+            gist: r.gist,
+            decisions: r.decisions,
+            open_threads: r.open_threads,
+            user_notes: r.user_notes,
+        },
+        _ => SessionSummary {
+            conversation_id: conversation_id.to_string(),
+            channel: channel.to_string(),
+            timestamp,
+            title: "Conversation".to_string(),
+            gist: raw.chars().take(280).collect(),
+            decisions: vec![],
+            open_threads: vec![],
+            user_notes: vec![],
+        },
+    }
+}
+
+/// Distills a conversation's turns into a structured [`SessionSummary`] via the LLM.
+pub struct SessionSummarizer {
+    llm: std::sync::Arc<dyn ironclaw_llm::LlmProvider>,
+}
+
+impl SessionSummarizer {
+    pub fn new(llm: std::sync::Arc<dyn ironclaw_llm::LlmProvider>) -> Self {
+        Self { llm }
+    }
+
+    /// Summarize a conversation. `turns` is `(user_input, assistant_response?)`.
+    pub async fn summarize(
+        &self,
+        conversation_id: &str,
+        channel: &str,
+        timestamp: DateTime<Utc>,
+        turns: &[(String, Option<String>)],
+    ) -> Result<SessionSummary, crate::error::Error> {
+        use ironclaw_llm::ChatMessage;
+        let mut convo = String::new();
+        for (u, a) in turns {
+            convo.push_str(&format!("User: {u}\n"));
+            if let Some(a) = a {
+                convo.push_str(&format!("Assistant: {a}\n"));
+            }
+        }
+        let sys = ChatMessage::system(
+            "Summarize this conversation as STRICT JSON with keys: title (short), \
+             gist (1-3 sentences), decisions (string[]), open_threads (string[] of \
+             unfinished items or next steps), user_notes (string[] of notable user \
+             context). Output ONLY the JSON object, no prose.",
+        );
+        let user = ChatMessage::user(convo);
+        let raw = self.complete(vec![sys, user]).await?;
+        Ok(parse_summary_json(&raw, conversation_id, channel, timestamp))
+    }
+
+    /// Run the messages through the LLM (mirrors `ContextCompactor::generate_summary`).
+    async fn complete(
+        &self,
+        messages: Vec<ironclaw_llm::ChatMessage>,
+    ) -> Result<String, crate::error::Error> {
+        use ironclaw_llm::{CompletionRequest, Reasoning};
+        let request = CompletionRequest::new(messages)
+            .with_max_tokens(1024)
+            .with_temperature(0.3);
+        let reasoning =
+            Reasoning::new(self.llm.clone()).with_model_name(self.llm.active_model_name());
+        let (text, _) = reasoning.complete(request).await?;
+        Ok(text)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -207,5 +318,38 @@ mod tests {
             acc.contains("— Open"),
             "open-thread entry retained under size pressure"
         );
+    }
+
+    #[tokio::test]
+    async fn summarize_parses_structured_fields() {
+        use std::sync::Arc;
+        let json = r#"```json
+        {"title":"Gateway fix","gist":"Fixed the profile bug.","decisions":["ship one-liner"],
+         "open_threads":["watch reinstall"],"user_notes":["values durability"]}
+        ```"#;
+        let llm = Arc::new(crate::testing::StubLlm::new(json));
+        let s = SessionSummarizer::new(llm);
+        let ts = chrono::Utc::now();
+        let out = s
+            .summarize(
+                "c1",
+                "gateway",
+                ts,
+                &[("what broke?".into(), Some("the profile".into()))],
+            )
+            .await
+            .unwrap();
+        assert_eq!(out.title, "Gateway fix");
+        assert_eq!(out.decisions, vec!["ship one-liner".to_string()]);
+        assert_eq!(out.open_threads, vec!["watch reinstall".to_string()]);
+        assert_eq!(out.conversation_id, "c1");
+    }
+
+    #[test]
+    fn parse_summary_json_falls_back_on_garbage() {
+        let ts = chrono::Utc::now();
+        let out = parse_summary_json("not json at all", "c2", "cli", ts);
+        assert_eq!(out.title, "Conversation");
+        assert!(out.gist.contains("not json"));
     }
 }

--- a/src/workspace/README.md
+++ b/src/workspace/README.md
@@ -96,6 +96,40 @@ Four tools for LLM use:
 - **`memory_read`** - Read any file by path
 - **`memory_tree`** - View workspace structure as a tree (depth parameter, default 1)
 
+## Episodic Memory
+
+IronClaw automatically distills every conversation into durable, searchable
+memory so it carries context across sessions without the user having to
+re-explain anything.
+
+Two files back this, both under the workspace at `memory/`:
+
+- **`memory/sessions/YYYY-MM-DD-<conv>.md`** — one full, structured summary
+  per conversation (dated by end time, keyed by conversation id). Each file
+  is YAML frontmatter (`conversation_id`, `channel`, `timestamp`, `title`)
+  plus a body with the gist, decisions, open threads, and user notes. These
+  are ordinary workspace documents, so they are indexed and reachable via
+  `memory_search` (the pull channel — deep recall on demand).
+
+- **`memory/recent.md`** — a terse digest of the last few conversations
+  (title + gist + open threads only). It is capped by count (default 5
+  entries) and by size (~1500 tokens), with open-thread entries retained
+  preferentially under size pressure. This digest is injected silently into
+  the system prompt for new conversations (the push channel — ambient recent
+  context), excluded in group chats the same way `MEMORY.md` is.
+
+Both files are written on two triggers:
+
+1. **Idle-prune** — when the session manager prunes a stale conversation, its
+   turns are summarized and stored.
+2. **Backstop sweep** — a heartbeat/startup sweep summarizes any recently
+   ended conversation that has no per-session file yet (durable-from-DB, so a
+   crash or missed prune never loses a summary).
+
+Writes are idempotent on `conversation_id` (an existing per-session file means
+"already summarized" — skip) and fully fail-soft: a summarization or write
+error is logged and the turn continues — memory never blocks a conversation.
+
 ## Hybrid Search (RRF)
 
 Combines full-text search and vector similarity using Reciprocal Rank Fusion:

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -1807,6 +1807,18 @@ impl Workspace {
             parts.push(format!("## Long-Term Memory\n\n{}", doc.content));
         }
 
+        // Episodic recall: inject the recent-conversations digest (memory/recent.md).
+        // This is personal continuity context, so it is excluded in group chats the
+        // same way MEMORY.md is. Missing/empty is graceful — the section is omitted.
+        if !is_group_chat
+            && let Ok(doc) = self.read("memory/recent.md").await
+        {
+            let recent = doc.content.trim();
+            if !recent.is_empty() {
+                parts.push(recent.to_string());
+            }
+        }
+
         // Add today's memory context (last 2 days of daily logs)
         let today = match tz {
             Some(t) => crate::timezone::today_in_tz(t),
@@ -2887,6 +2899,31 @@ mod seed_tests {
 
         // Multi scope: is multi
         assert!(multi_count > 1);
+    }
+
+    /// Episodic recall: the recent-conversations digest is injected into the
+    /// system prompt when `memory/recent.md` exists and is non-empty.
+    #[tokio::test]
+    async fn system_prompt_includes_recent_when_present() {
+        let (ws, _dir) = create_test_workspace().await;
+        ws.write(
+            "memory/recent.md",
+            "# Recent conversations\n\n### 2026-07-09 — Voice\nwired STT\n",
+        )
+        .await
+        .expect("write recent.md");
+        let sp = ws.system_prompt().await.expect("system_prompt");
+        assert!(sp.contains("Recent conversations"));
+        assert!(sp.contains("Voice"));
+    }
+
+    /// Episodic recall: the section is omitted gracefully when
+    /// `memory/recent.md` is absent.
+    #[tokio::test]
+    async fn system_prompt_omits_recent_when_absent() {
+        let (ws, _dir) = create_test_workspace().await;
+        let sp = ws.system_prompt().await.expect("system_prompt");
+        assert!(!sp.contains("Recent conversations"));
     }
 }
 


### PR DESCRIPTION
## Episodic memory — cross-session summaries + recall

Automatic cross-session continuity: distill each conversation into a durable, searchable summary when it ends, and silently inject a terse digest of recent ones into new conversations.

**Two-channel recall**
- **Push:** a capped `memory/recent.md` digest (last N=5 / ~6000 chars, open-thread-weighted) injected into the system prompt (group-chat-excluded, graceful when absent).
- **Pull:** per-conversation `memory/sessions/YYYY-MM-DD-<id>.md` files, searchable via the existing hybrid FTS+vector RRF search.

**Write paths — all fail-soft, idempotent on `conversation_id`**
- `SessionSummarizer` (turns → structured JSON via the LLM) with a tolerant JSON parse + fallback.
- `SessionMemory::summarize_and_store` — skip-trivial, idempotent, writes the session file + updates `recent.md`.
- Auto-write on session idle-prune + a heartbeat/startup backstop sweep.

Memory never blocks a turn (log-and-continue everywhere). Cherry-picked from an integration branch; PR CI validates standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
