### PR TITLE
Surface new post-edit check diagnostics on reborn coding edits

### DIFF
--- a/crates/ironclaw_host_runtime/src/first_party.rs
+++ b/crates/ironclaw_host_runtime/src/first_party.rs
@@ -95,6 +95,7 @@ impl FirstPartyCapabilityRequest {
                 secret_store: None,
                 audit_sink: None,
                 unsafe_raw_diagnostics_allowed: false,
+                post_edit_check: None,
             },
             input,
         }

--- a/crates/ironclaw_host_runtime/src/first_party_tools/memory.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/memory.rs
@@ -570,6 +570,7 @@ mod tests {
                 secret_store: None,
                 audit_sink: None,
                 unsafe_raw_diagnostics_allowed: false,
+                post_edit_check: None,
             },
             input,
         }

--- a/crates/ironclaw_host_runtime/src/first_party_tools/mod.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/mod.rs
@@ -462,6 +462,45 @@ fn first_party_capability_manifest(
 pub struct BuiltinFirstPartyTools {
     coding_state: CodingCapabilityState,
     memory_state: memory::MemoryCapabilityState,
+    post_edit_check_seen: crate::post_edit_check::PostEditCheckSeenLines,
+}
+
+impl BuiltinFirstPartyTools {
+    /// Run the operator-configured post-edit check after a SUCCESSFUL
+    /// `write_file` / `apply_patch` and append the advisory `post_edit_check`
+    /// value to the edit's model-visible output. Read-only coding tools never
+    /// trigger it, and it never fails the edit — the edit already succeeded
+    /// when this runs.
+    async fn append_post_edit_check(
+        &self,
+        kind: CodingCapabilityKind,
+        request: &FirstPartyCapabilityRequest,
+        output: &mut serde_json::Value,
+    ) {
+        if !matches!(
+            kind,
+            CodingCapabilityKind::WriteFile | CodingCapabilityKind::ApplyPatch
+        ) {
+            return;
+        }
+        let Some(config) = &request.services.post_edit_check else {
+            return;
+        };
+        let Some(check) = crate::post_edit_check::run_post_edit_check(
+            &self.post_edit_check_seen,
+            request.services.process.as_ref(),
+            &request.scope,
+            request.mounts.as_ref(),
+            config,
+        )
+        .await
+        else {
+            return;
+        };
+        if let Some(object) = output.as_object_mut() {
+            object.insert("post_edit_check".to_string(), check);
+        }
+    }
 }
 
 #[async_trait]
@@ -552,7 +591,7 @@ impl FirstPartyCapabilityHandler for BuiltinFirstPartyTools {
                         RuntimeDispatchErrorKind::UndeclaredCapability,
                     ));
                 };
-                let request = CodingCapabilityRequest::new(
+                let coding_request = CodingCapabilityRequest::new(
                     &request.capability_id,
                     metadata.kind,
                     &request.scope,
@@ -561,11 +600,13 @@ impl FirstPartyCapabilityHandler for BuiltinFirstPartyTools {
                     Arc::clone(&request.services.filesystem),
                     &request.input,
                 );
-                let result = self
+                let mut result = self
                     .coding_state
-                    .dispatch(&request)
+                    .dispatch(&coding_request)
                     .await
                     .map_err(coding_error)?;
+                self.append_post_edit_check(metadata.kind, &request, &mut result.output)
+                    .await;
                 (result.output, result.display_preview)
             }
         };

--- a/crates/ironclaw_host_runtime/src/first_party_tools/mod.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/mod.rs
@@ -470,21 +470,26 @@ impl BuiltinFirstPartyTools {
     /// `write_file` / `apply_patch` and append the advisory `post_edit_check`
     /// value to the edit's model-visible output. Read-only coding tools never
     /// trigger it, and it never fails the edit — the edit already succeeded
-    /// when this runs.
+    /// when this runs. The invocation-services resolver only supplies
+    /// `services.post_edit_check` when the process policy permits spawning
+    /// through `services.process`, so no placement decision happens here.
+    ///
+    /// Returns `true` when a check process actually ran (completed or timed
+    /// out), so the caller can account for it like a `builtin.shell` spawn.
     async fn append_post_edit_check(
         &self,
         kind: CodingCapabilityKind,
         request: &FirstPartyCapabilityRequest,
         output: &mut serde_json::Value,
-    ) {
+    ) -> bool {
         if !matches!(
             kind,
             CodingCapabilityKind::WriteFile | CodingCapabilityKind::ApplyPatch
         ) {
-            return;
+            return false;
         }
         let Some(config) = &request.services.post_edit_check else {
-            return;
+            return false;
         };
         let Some(check) = crate::post_edit_check::run_post_edit_check(
             &self.post_edit_check_seen,
@@ -495,11 +500,12 @@ impl BuiltinFirstPartyTools {
         )
         .await
         else {
-            return;
+            return false;
         };
         if let Some(object) = output.as_object_mut() {
             object.insert("post_edit_check".to_string(), check);
         }
+        true
     }
 }
 
@@ -513,6 +519,7 @@ impl FirstPartyCapabilityHandler for BuiltinFirstPartyTools {
         normalize_optional_null_sentinels(&mut request);
         let start = Instant::now();
         let mut network_egress_bytes = 0;
+        let mut process_count = 0u32;
         let (output, display_preview) = match request.capability_id.as_str() {
             ECHO_CAPABILITY_ID => (echo::dispatch(&request.input)?, None),
             TIME_CAPABILITY_ID => (time::dispatch(&request.input)?, None),
@@ -605,8 +612,14 @@ impl FirstPartyCapabilityHandler for BuiltinFirstPartyTools {
                     .dispatch(&coding_request)
                     .await
                     .map_err(coding_error)?;
-                self.append_post_edit_check(metadata.kind, &request, &mut result.output)
-                    .await;
+                if self
+                    .append_post_edit_check(metadata.kind, &request, &mut result.output)
+                    .await
+                {
+                    // The advisory check spawned one process; account for it
+                    // exactly like a `builtin.shell` invocation.
+                    process_count = 1;
+                }
                 (result.output, result.display_preview)
             }
         };
@@ -616,11 +629,12 @@ impl FirstPartyCapabilityHandler for BuiltinFirstPartyTools {
             _ => FIRST_PARTY_MAX_OUTPUT_BYTES,
         };
         let output_bytes = bounded_output_bytes(&output, output_limit_bytes).map_err(|error| {
-            if network_egress_bytes > 0 {
+            if network_egress_bytes > 0 || process_count > 0 {
                 error.with_usage(
                     ResourceUsage::default()
                         .set_wall_clock_ms(wall_clock_ms)
-                        .set_network_egress_bytes(network_egress_bytes),
+                        .set_network_egress_bytes(network_egress_bytes)
+                        .set_process_count(process_count),
                 )
             } else {
                 error
@@ -629,7 +643,8 @@ impl FirstPartyCapabilityHandler for BuiltinFirstPartyTools {
         let usage = ResourceUsage::default()
             .set_wall_clock_ms(wall_clock_ms)
             .set_output_bytes(output_bytes)
-            .set_network_egress_bytes(network_egress_bytes);
+            .set_network_egress_bytes(network_egress_bytes)
+            .set_process_count(process_count);
         Ok(FirstPartyCapabilityResult::new(output, usage).with_display_preview(display_preview))
     }
 }

--- a/crates/ironclaw_host_runtime/src/first_party_tools/profile_set.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/profile_set.rs
@@ -134,6 +134,7 @@ mod tests {
                 secret_store: None,
                 audit_sink: None,
                 unsafe_raw_diagnostics_allowed: false,
+                post_edit_check: None,
             },
             input,
         }

--- a/crates/ironclaw_host_runtime/src/first_party_tools/trace_commons.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/trace_commons.rs
@@ -1,3 +1,4 @@
+// arch-exempt: large_file, trace-commons capability family shares one dispatch surface, plan #4539
 //! First-party Trace Commons capabilities: onboard, status, credits, profile token, profile set,
 //! and account login link.
 //!
@@ -1373,6 +1374,7 @@ mod tests {
                 secret_store: None,
                 audit_sink: None,
                 unsafe_raw_diagnostics_allowed: false,
+                post_edit_check: None,
             },
             input,
         }

--- a/crates/ironclaw_host_runtime/src/invocation_services.rs
+++ b/crates/ironclaw_host_runtime/src/invocation_services.rs
@@ -56,7 +56,11 @@ pub struct InvocationServices {
     /// Operator-configured post-edit check appended to successful
     /// `builtin.write_file` / `builtin.apply_patch` output. Resolved once at
     /// composition time (never from env in per-call handlers); `None` keeps
-    /// the feature off.
+    /// the feature off. Resolvers must only populate this when the plan's
+    /// process policy permits spawning through [`InvocationServices::process`]
+    /// — the edit plans themselves never declare a process effect, so this
+    /// field is the policy gate that keeps the check from bypassing
+    /// process-backend selection.
     pub post_edit_check: Option<PostEditCheckConfig>,
 }
 
@@ -248,9 +252,7 @@ impl InvocationServicesResolver for LocalInvocationServicesResolver {
         let filesystem = self.filesystem_for_plan(plan, request.mounts)?;
         let process = if plan.requires_process {
             match plan.process_backend {
-                ProcessBackendKind::LocalHost
-                    if matches!(plan.deployment, DeploymentMode::LocalSingleUser) =>
-                {
+                ProcessBackendKind::LocalHost if local_host_process_execution_permitted(plan) => {
                     Arc::clone(&self.process)
                 }
                 ProcessBackendKind::TenantSandbox => self.tenant_sandbox_process.clone().ok_or(
@@ -302,9 +304,29 @@ impl InvocationServicesResolver for LocalInvocationServicesResolver {
                 plan.deployment,
                 plan.resolved_profile,
             ),
-            post_edit_check: self.post_edit_check.clone(),
+            // The post-edit check spawns an operator command through the
+            // default `process` port above, from edit plans that never
+            // declare a process effect. Withhold it unless the effective
+            // process policy is the one under which that default port is
+            // the policy-approved backend (the same LocalHost +
+            // LocalSingleUser arm that `requires_process` plans resolve
+            // to); under `ProcessBackendKind::None` or sandbox-backed
+            // policies the advisory check is disabled instead of escaping
+            // onto the provider host.
+            post_edit_check: self
+                .post_edit_check
+                .clone()
+                .filter(|_| local_host_process_execution_permitted(plan)),
         })
     }
+}
+
+/// Whether the plan's process policy resolves process execution to the local
+/// host port for this resolver — the condition under which `resolve` hands
+/// `self.process` to a process-requiring plan such as `builtin.shell`.
+fn local_host_process_execution_permitted(plan: &ExecutionPlan) -> bool {
+    matches!(plan.process_backend, ProcessBackendKind::LocalHost)
+        && matches!(plan.deployment, DeploymentMode::LocalSingleUser)
 }
 
 impl LocalInvocationServicesResolver {

--- a/crates/ironclaw_host_runtime/src/invocation_services.rs
+++ b/crates/ironclaw_host_runtime/src/invocation_services.rs
@@ -28,7 +28,7 @@ use ironclaw_host_api::{
 use ironclaw_secrets::SecretStore;
 use thiserror::Error;
 
-use crate::{ExecutionPlan, RuntimeProcessPort, RuntimeSecretMaterialStager};
+use crate::{ExecutionPlan, PostEditCheckConfig, RuntimeProcessPort, RuntimeSecretMaterialStager};
 
 /// Concrete host API bindings for an already-authorized invocation.
 ///
@@ -53,6 +53,11 @@ pub struct InvocationServices {
     pub secret_store: Option<Arc<dyn SecretStore>>,
     pub audit_sink: Option<Arc<dyn AuditSink>>,
     pub unsafe_raw_diagnostics_allowed: bool,
+    /// Operator-configured post-edit check appended to successful
+    /// `builtin.write_file` / `builtin.apply_patch` output. Resolved once at
+    /// composition time (never from env in per-call handlers); `None` keeps
+    /// the feature off.
+    pub post_edit_check: Option<PostEditCheckConfig>,
 }
 
 impl fmt::Debug for InvocationServices {
@@ -87,6 +92,10 @@ impl fmt::Debug for InvocationServices {
             .field(
                 "unsafe_raw_diagnostics_allowed",
                 &self.unsafe_raw_diagnostics_allowed,
+            )
+            .field(
+                "post_edit_check",
+                &self.post_edit_check.as_ref().map(|_| "[CONFIGURED]"),
             )
             .finish()
     }
@@ -167,6 +176,7 @@ pub struct LocalInvocationServicesResolver {
     tenant_sandbox_process: Option<Arc<dyn RuntimeProcessPort>>,
     secret_store: Option<Arc<dyn SecretStore>>,
     audit_sink: Option<Arc<dyn AuditSink>>,
+    post_edit_check: Option<PostEditCheckConfig>,
 }
 
 impl LocalInvocationServicesResolver {
@@ -185,6 +195,7 @@ impl LocalInvocationServicesResolver {
             tenant_sandbox_process: None,
             secret_store,
             audit_sink: None,
+            post_edit_check: None,
         }
     }
 
@@ -219,6 +230,11 @@ impl LocalInvocationServicesResolver {
 
     pub fn with_audit_sink(mut self, audit_sink: Arc<dyn AuditSink>) -> Self {
         self.audit_sink = Some(audit_sink);
+        self
+    }
+
+    pub fn with_post_edit_check(mut self, post_edit_check: PostEditCheckConfig) -> Self {
+        self.post_edit_check = Some(post_edit_check);
         self
     }
 }
@@ -286,6 +302,7 @@ impl InvocationServicesResolver for LocalInvocationServicesResolver {
                 plan.deployment,
                 plan.resolved_profile,
             ),
+            post_edit_check: self.post_edit_check.clone(),
         })
     }
 }

--- a/crates/ironclaw_host_runtime/src/invocation_services/tests.rs
+++ b/crates/ironclaw_host_runtime/src/invocation_services/tests.rs
@@ -113,6 +113,74 @@ fn local_resolver_rejects_hosted_local_host_process_backend() {
 }
 
 #[test]
+fn local_resolver_provides_post_edit_check_only_under_local_host_process_policy() {
+    // The post-edit check spawns an operator command through the default
+    // process port from plans that never declare a process effect, so the
+    // resolver must withhold it whenever the effective process policy would
+    // not hand a local host port to a process-requiring plan.
+    let resolver = resolver_without_http()
+        .with_post_edit_check(PostEditCheckConfig::new(
+            "cargo check",
+            std::time::Duration::from_secs(30),
+        ))
+        .with_tenant_sandbox_process_port(Arc::new(NamedProcessPort("tenant-sandbox")));
+
+    let resolve = |process_backend, deployment, resolved_profile| {
+        let mut plan = plan(process_backend, false, false, NetworkMode::Deny, false);
+        plan.deployment = deployment;
+        plan.resolved_profile = resolved_profile;
+        resolver
+            .resolve(InvocationServicesResolutionRequest {
+                plan: &plan,
+                scope: &ResourceScope::system(),
+                mounts: None,
+            })
+            .expect("non-process plans must still resolve")
+    };
+
+    let local = resolve(
+        ProcessBackendKind::LocalHost,
+        DeploymentMode::LocalSingleUser,
+        RuntimeProfile::LocalDev,
+    );
+    assert!(
+        local.post_edit_check.is_some(),
+        "local-dev LocalHost policy keeps the post-edit check available"
+    );
+
+    let no_process = resolve(
+        ProcessBackendKind::None,
+        DeploymentMode::LocalSingleUser,
+        RuntimeProfile::SecureDefault,
+    );
+    assert!(
+        no_process.post_edit_check.is_none(),
+        "ProcessBackendKind::None must withhold the post-edit check"
+    );
+
+    let tenant_sandbox = resolve(
+        ProcessBackendKind::TenantSandbox,
+        DeploymentMode::HostedMultiTenant,
+        RuntimeProfile::HostedDev,
+    );
+    assert!(
+        tenant_sandbox.post_edit_check.is_none(),
+        "tenant-sandbox process policy must withhold the post-edit check even \
+         when a sandbox port is configured"
+    );
+
+    let hosted_local_host = resolve(
+        ProcessBackendKind::LocalHost,
+        DeploymentMode::HostedMultiTenant,
+        RuntimeProfile::HostedDev,
+    );
+    assert!(
+        hosted_local_host.post_edit_check.is_none(),
+        "hosted deployments must never run the check on the provider host"
+    );
+}
+
+#[test]
 fn local_resolver_rejects_sandbox_process_backend_without_local_fallback() {
     let resolver = resolver_without_http();
     let plan = plan(

--- a/crates/ironclaw_host_runtime/src/lib.rs
+++ b/crates/ironclaw_host_runtime/src/lib.rs
@@ -48,6 +48,7 @@ mod latency;
 pub mod memory_context;
 mod obligations;
 mod planner;
+mod post_edit_check;
 mod process_aliases;
 mod process_output;
 mod process_port;
@@ -112,6 +113,9 @@ pub use obligations::{
     RuntimeCredentialAccountRequest, RuntimeCredentialAccountResolver,
 };
 pub use planner::{ExecutionPlan, PlannerError, plan_capability};
+pub use post_edit_check::{
+    POST_EDIT_CHECK_ENV, POST_EDIT_CHECK_TIMEOUT_ENV, PostEditCheckConfig, PostEditCheckConfigError,
+};
 pub use process_output::{SavedCommandOutput, SavedCommandOutputSanitization};
 pub use process_port::{
     CommandExecutionOutput, CommandExecutionRequest, LocalHostProcessPort, RuntimeProcessError,

--- a/crates/ironclaw_host_runtime/src/post_edit_check.rs
+++ b/crates/ironclaw_host_runtime/src/post_edit_check.rs
@@ -15,7 +15,14 @@
 //! [`PostEditCheckConfig::from_env`] (the composition layer calls this
 //! module-owned factory; nothing here reads the environment per call) and is
 //! threaded through `HostRuntimeServices::with_post_edit_check` into
-//! [`InvocationServices`](crate::InvocationServices).
+//! [`InvocationServices`](crate::InvocationServices). Because the edit plans
+//! never declare a process effect, the invocation-services resolver only
+//! populates `InvocationServices::post_edit_check` when the effective
+//! process policy permits local host execution (`ProcessBackendKind::
+//! LocalHost` under `DeploymentMode::LocalSingleUser`); under
+//! `ProcessBackendKind::None` or sandbox-backed policies the advisory check
+//! is disabled instead of bypassing process-backend selection. A check that
+//! does run is accounted as one spawned process, like `builtin.shell`.
 //!
 //! v1 limitation (kept deliberately simple): the seen-line registry is
 //! global per scope — editing a file again does not clear previously

--- a/crates/ironclaw_host_runtime/src/post_edit_check.rs
+++ b/crates/ironclaw_host_runtime/src/post_edit_check.rs
@@ -1,0 +1,488 @@
+//! Operator-configured post-edit check for the coding tools.
+//!
+//! After a successful `builtin.write_file` / `builtin.apply_patch` dispatch,
+//! host runtime can run one operator-configured shell command (for example
+//! `cargo check --message-format=short 2>&1`) through the invocation's
+//! [`RuntimeProcessPort`](crate::RuntimeProcessPort) and append only the
+//! *new* diagnostic lines to the edit's model-visible output. This catches
+//! the classic agent failure of breaking adjacent code without noticing,
+//! without re-reporting the same diagnostics after every edit.
+//!
+//! The check is advisory: it never fails the edit (the edit already
+//! succeeded), and a check that cannot run at all is only logged at debug.
+//!
+//! Configuration is resolved once at composition time via
+//! [`PostEditCheckConfig::from_env`] (the composition layer calls this
+//! module-owned factory; nothing here reads the environment per call) and is
+//! threaded through `HostRuntimeServices::with_post_edit_check` into
+//! [`InvocationServices`](crate::InvocationServices).
+//!
+//! v1 limitation (kept deliberately simple): the seen-line registry is
+//! global per scope — editing a file again does not clear previously
+//! reported findings for that file, so a diagnostic that disappears and
+//! later reappears unchanged is not re-reported until its line is evicted
+//! from the bounded registry.
+
+use std::{
+    collections::{HashMap, HashSet, VecDeque},
+    sync::Mutex,
+    time::Duration,
+};
+
+use ironclaw_host_api::{MountView, ResourceScope};
+use serde_json::{Value, json};
+
+use crate::{CommandExecutionRequest, RuntimeProcessError, RuntimeProcessPort};
+
+/// Shell command run after successful edits. Feature is OFF when unset/empty.
+pub const POST_EDIT_CHECK_ENV: &str = "IRONCLAW_POST_EDIT_CHECK";
+/// Check timeout in whole seconds. Defaults to [`DEFAULT_TIMEOUT_SECS`].
+pub const POST_EDIT_CHECK_TIMEOUT_ENV: &str = "IRONCLAW_POST_EDIT_CHECK_TIMEOUT_SECS";
+
+const DEFAULT_TIMEOUT_SECS: u64 = 30;
+
+/// Cap on remembered diagnostic lines per scope. FIFO eviction beyond this;
+/// an evicted line may be re-reported by a later check.
+const MAX_SEEN_LINES_PER_SCOPE: usize = 500;
+/// Cap on tracked scopes; an arbitrary scope is evicted beyond this (same
+/// fail-safe posture as the coding read-state registry).
+const MAX_SEEN_SCOPES: usize = 512;
+/// Report caps: at most this many new lines per edit...
+const MAX_REPORT_LINES: usize = 30;
+/// ...and at most this many bytes of new output per edit.
+const MAX_REPORT_BYTES: usize = 4000;
+
+/// Operator configuration for the post-edit check.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PostEditCheckConfig {
+    command: String,
+    timeout: Duration,
+}
+
+impl PostEditCheckConfig {
+    pub fn new(command: impl Into<String>, timeout: Duration) -> Self {
+        Self {
+            command: command.into(),
+            timeout,
+        }
+    }
+
+    pub fn command(&self) -> &str {
+        &self.command
+    }
+
+    pub fn timeout(&self) -> Duration {
+        self.timeout
+    }
+
+    /// Resolve the config from the process environment.
+    ///
+    /// Module-owned factory intended to be called once from the composition
+    /// layer (see `ironclaw_reborn_composition::factory`); per-call handlers
+    /// must consume the already-resolved config instead of reading env.
+    /// Returns `Ok(None)` when `IRONCLAW_POST_EDIT_CHECK` is unset or blank.
+    pub fn from_env() -> Result<Option<Self>, PostEditCheckConfigError> {
+        Self::from_values(
+            optional_env(POST_EDIT_CHECK_ENV)?,
+            optional_env(POST_EDIT_CHECK_TIMEOUT_ENV)?,
+        )
+    }
+
+    fn from_values(
+        command: Option<String>,
+        timeout_secs: Option<String>,
+    ) -> Result<Option<Self>, PostEditCheckConfigError> {
+        let Some(command) = command.filter(|command| !command.trim().is_empty()) else {
+            return Ok(None);
+        };
+        let timeout_secs = match timeout_secs {
+            None => DEFAULT_TIMEOUT_SECS,
+            Some(raw) => {
+                let parsed =
+                    raw.trim()
+                        .parse::<u64>()
+                        .map_err(|error| PostEditCheckConfigError {
+                            reason: format!(
+                                "{POST_EDIT_CHECK_TIMEOUT_ENV} must be a positive integer: {error}"
+                            ),
+                        })?;
+                if parsed == 0 {
+                    return Err(PostEditCheckConfigError {
+                        reason: format!("{POST_EDIT_CHECK_TIMEOUT_ENV} must be greater than zero"),
+                    });
+                }
+                parsed
+            }
+        };
+        Ok(Some(Self::new(command, Duration::from_secs(timeout_secs))))
+    }
+}
+
+fn optional_env(key: &'static str) -> Result<Option<String>, PostEditCheckConfigError> {
+    match std::env::var(key) {
+        Ok(value) => {
+            let trimmed = value.trim();
+            if trimmed.is_empty() {
+                Ok(None)
+            } else {
+                Ok(Some(trimmed.to_string()))
+            }
+        }
+        Err(std::env::VarError::NotPresent) => Ok(None),
+        Err(error) => Err(PostEditCheckConfigError {
+            reason: format!("could not read {key}: {error}"),
+        }),
+    }
+}
+
+/// Invalid post-edit check configuration.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("invalid post-edit check config: {reason}")]
+pub struct PostEditCheckConfigError {
+    reason: String,
+}
+
+/// Diagnostic lines already reported to the model, keyed by the same scope
+/// dimensions as the coding read-state registry. Bounded in both scope count
+/// and lines per scope; eviction only means a line may be reported again.
+#[derive(Debug, Default)]
+pub(crate) struct PostEditCheckSeenLines {
+    scopes: Mutex<HashMap<SeenScopeKey, ScopeSeenLines>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct SeenScopeKey {
+    tenant_id: String,
+    user_id: String,
+    agent_id: Option<String>,
+    project_id: Option<String>,
+    mission_id: Option<String>,
+    thread_id: Option<String>,
+}
+
+impl SeenScopeKey {
+    fn from_scope(scope: &ResourceScope) -> Self {
+        Self {
+            tenant_id: scope.tenant_id.as_str().to_string(),
+            user_id: scope.user_id.as_str().to_string(),
+            agent_id: scope.agent_id.as_ref().map(|id| id.as_str().to_string()),
+            project_id: scope.project_id.as_ref().map(|id| id.as_str().to_string()),
+            mission_id: scope.mission_id.as_ref().map(|id| id.as_str().to_string()),
+            thread_id: scope.thread_id.as_ref().map(|id| id.as_str().to_string()),
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct ScopeSeenLines {
+    set: HashSet<String>,
+    order: VecDeque<String>,
+}
+
+impl ScopeSeenLines {
+    fn record(&mut self, line: &str) {
+        if !self.set.insert(line.to_string()) {
+            return;
+        }
+        self.order.push_back(line.to_string());
+        while self.order.len() > MAX_SEEN_LINES_PER_SCOPE {
+            if let Some(evicted) = self.order.pop_front() {
+                self.set.remove(&evicted);
+            }
+        }
+    }
+}
+
+impl PostEditCheckSeenLines {
+    /// Return the check-output lines not previously reported for this scope,
+    /// capped at [`MAX_REPORT_LINES`] / [`MAX_REPORT_BYTES`] with a trailing
+    /// `+N more new lines` note when trimmed. Only the *reported* lines are
+    /// recorded as seen, so lines trimmed by the caps surface on a later
+    /// check instead of being silently dropped. Returns `None` when the
+    /// output carries no new lines.
+    pub(crate) fn filter_new(&self, scope: &ResourceScope, output: &str) -> Option<String> {
+        let key = SeenScopeKey::from_scope(scope);
+        let mut scopes = match self.scopes.lock() {
+            Ok(guard) => guard,
+            // A poisoned lock means another thread panicked mid-update; the
+            // map stays coherent (single-entry ops), so keep serving.
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        if scopes.len() >= MAX_SEEN_SCOPES && !scopes.contains_key(&key) {
+            // Evict an arbitrary scope to keep memory bounded; that scope
+            // just re-reports previously seen lines on its next check.
+            if let Some(evicted) = scopes.keys().next().cloned() {
+                scopes.remove(&evicted);
+            }
+        }
+        let seen = scopes.entry(key).or_default();
+
+        let mut batch: HashSet<&str> = HashSet::new();
+        let new_lines: Vec<&str> = output
+            .lines()
+            .map(|line| line.trim_end_matches('\r'))
+            .filter(|line| !line.trim().is_empty())
+            .filter(|line| !seen.set.contains(*line))
+            .filter(|line| batch.insert(*line))
+            .collect();
+        if new_lines.is_empty() {
+            return None;
+        }
+
+        let mut reported = Vec::new();
+        let mut bytes = 0usize;
+        for line in &new_lines {
+            if reported.len() >= MAX_REPORT_LINES {
+                break;
+            }
+            let cost = line.len() + usize::from(!reported.is_empty());
+            if bytes + cost > MAX_REPORT_BYTES {
+                if reported.is_empty() {
+                    // A single oversized line: report a bounded prefix but
+                    // remember the full line so it is never re-reported.
+                    let budget = truncation_boundary(line, MAX_REPORT_BYTES);
+                    reported.push(&line[..budget]); // safety: truncation_boundary returns is_char_boundary() indices
+                    seen.record(line);
+                }
+                break;
+            }
+            bytes += cost;
+            reported.push(line);
+            seen.record(line);
+        }
+
+        let mut rendered = reported.join("\n");
+        let trimmed = new_lines.len() - reported.len();
+        if trimmed > 0 {
+            rendered.push_str(&format!("\n+{trimmed} more new lines"));
+        }
+        Some(rendered)
+    }
+}
+
+/// Largest index `<= max_bytes` that is a UTF-8 char boundary of `line`.
+fn truncation_boundary(line: &str, max_bytes: usize) -> usize {
+    let mut boundary = max_bytes.min(line.len());
+    while boundary > 0 && !line.is_char_boundary(boundary) {
+        boundary -= 1;
+    }
+    boundary
+}
+
+/// Run the configured check after a successful edit and shape the advisory
+/// `post_edit_check` value for the edit's model-visible output.
+///
+/// - New findings: `{"exit_code": N, "new_output": "..."}`
+/// - No new findings: `{"exit_code": N}` (token-lean)
+/// - Timeout: `{"timed_out": true}`
+/// - Check could not run at all: `None` (debug-logged; the edit already
+///   succeeded and must not fail because of the advisory check)
+///
+/// The command runs with the first read+write mount alias as its working
+/// directory (the process port resolves the alias to the host root backing
+/// `/workspace`, exactly as it does for shell workdirs); without mounts it
+/// falls back to the port's default working directory like `builtin.shell`.
+pub(crate) async fn run_post_edit_check(
+    seen: &PostEditCheckSeenLines,
+    process: &dyn RuntimeProcessPort,
+    scope: &ResourceScope,
+    mounts: Option<&MountView>,
+    config: &PostEditCheckConfig,
+) -> Option<Value> {
+    let workdir = mounts.and_then(|mounts| {
+        mounts
+            .mounts
+            .iter()
+            .find(|grant| grant.permissions.read && grant.permissions.write)
+            .map(|grant| grant.alias.as_str().to_string())
+    });
+    let outcome = process
+        .run_command(CommandExecutionRequest {
+            scope: scope.clone(),
+            mounts: mounts.cloned(),
+            command: config.command().to_string(),
+            workdir,
+            timeout_secs: Some(config.timeout().as_secs()),
+            extra_env: HashMap::new(),
+        })
+        .await;
+    match outcome {
+        Ok(output) => {
+            let mut value = json!({"exit_code": output.exit_code});
+            if let Some(new_output) = seen.filter_new(scope, &output.output)
+                && let Some(object) = value.as_object_mut()
+            {
+                object.insert("new_output".to_string(), Value::String(new_output));
+            }
+            Some(value)
+        }
+        Err(RuntimeProcessError::Timeout(_)) => Some(json!({"timed_out": true})),
+        Err(RuntimeProcessError::ExecutionFailed(reason)) => {
+            tracing::debug!(reason = %reason, "post-edit check could not run");
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ironclaw_host_api::{InvocationId, UserId};
+
+    fn scope(user: &str) -> ResourceScope {
+        ResourceScope::local_default(UserId::new(user).unwrap(), InvocationId::new()).unwrap()
+    }
+
+    #[test]
+    fn filter_new_dedups_across_calls_within_a_scope() {
+        let seen = PostEditCheckSeenLines::default();
+        let scope = scope("dedup-user");
+
+        let first = seen
+            .filter_new(&scope, "error: one\nwarning: two\n")
+            .expect("first call reports both lines");
+        assert_eq!(first, "error: one\nwarning: two");
+
+        assert_eq!(
+            seen.filter_new(&scope, "error: one\nwarning: two\n"),
+            None,
+            "identical output must report nothing"
+        );
+
+        let third = seen
+            .filter_new(&scope, "error: one\nerror: three\n")
+            .expect("only the unseen line is reported");
+        assert_eq!(third, "error: three");
+    }
+
+    #[test]
+    fn filter_new_is_keyed_per_scope() {
+        let seen = PostEditCheckSeenLines::default();
+
+        assert!(seen.filter_new(&scope("scope-a"), "error: one\n").is_some());
+        assert!(
+            seen.filter_new(&scope("scope-b"), "error: one\n").is_some(),
+            "another scope must get its own seen-set"
+        );
+    }
+
+    #[test]
+    fn filter_new_skips_blank_lines_and_batch_duplicates() {
+        let seen = PostEditCheckSeenLines::default();
+
+        let reported = seen
+            .filter_new(&scope("blank-user"), "\nerror: one\r\n   \nerror: one\n")
+            .expect("one real line");
+        assert_eq!(reported, "error: one");
+    }
+
+    #[test]
+    fn filter_new_caps_lines_and_counts_the_rest() {
+        let seen = PostEditCheckSeenLines::default();
+        let scope = scope("cap-user");
+        let output: String = (0..40).map(|index| format!("error: e{index}\n")).collect();
+
+        let reported = seen.filter_new(&scope, &output).expect("new lines");
+        assert_eq!(reported.lines().count(), MAX_REPORT_LINES + 1);
+        assert!(reported.ends_with("+10 more new lines"));
+        assert!(reported.contains("error: e29"));
+        assert!(!reported.contains("error: e30"));
+
+        // Trimmed lines were not marked seen: the next identical run surfaces them.
+        let next = seen.filter_new(&scope, &output).expect("trimmed remainder");
+        assert!(next.starts_with("error: e30"));
+        assert!(next.contains("error: e39"));
+    }
+
+    #[test]
+    fn filter_new_caps_bytes_and_counts_the_rest() {
+        let seen = PostEditCheckSeenLines::default();
+        let scope = scope("byte-user");
+        // 3980 + newline + 16-byte tail-one = 3997 fits; tail-two would not.
+        let big = "x".repeat(3980);
+        let output = format!("{big}\nerror: tail-one\nerror: tail-two\n");
+
+        let reported = seen.filter_new(&scope, &output).expect("new lines");
+        assert!(reported.len() <= MAX_REPORT_BYTES + "\n+1 more new lines".len());
+        assert!(reported.contains(&big));
+        assert!(reported.contains("tail-one"));
+        assert!(!reported.contains("tail-two"));
+        assert!(reported.ends_with("+1 more new lines"));
+
+        // The byte-trimmed line was not marked seen and surfaces next run.
+        assert_eq!(
+            seen.filter_new(&scope, &output).as_deref(),
+            Some("error: tail-two")
+        );
+    }
+
+    #[test]
+    fn filter_new_bounds_a_single_oversized_line_and_never_repeats_it() {
+        let seen = PostEditCheckSeenLines::default();
+        let scope = scope("oversized-user");
+        let huge = format!("error: {}", "y".repeat(5000));
+
+        let reported = seen.filter_new(&scope, &huge).expect("bounded prefix");
+        assert_eq!(reported.len(), MAX_REPORT_BYTES);
+        assert!(
+            seen.filter_new(&scope, &huge).is_none(),
+            "the full oversized line must be recorded as seen"
+        );
+    }
+
+    #[test]
+    fn seen_lines_evict_oldest_beyond_the_per_scope_cap() {
+        let seen = PostEditCheckSeenLines::default();
+        let scope = scope("evict-user");
+
+        // Fill the registry past its cap in reported (<=30 line) batches.
+        for batch in 0..20 {
+            let output: String = (0..30)
+                .map(|index| format!("error: b{batch}-l{index}\n"))
+                .collect();
+            assert!(seen.filter_new(&scope, &output).is_some());
+        }
+        // 600 recorded lines > 500 cap: the earliest batch was evicted and is
+        // reported again; the latest batch is still deduplicated.
+        assert!(seen.filter_new(&scope, "error: b0-l0\n").is_some());
+        assert!(seen.filter_new(&scope, "error: b19-l29\n").is_none());
+    }
+
+    #[test]
+    fn from_values_is_off_without_a_command() {
+        assert_eq!(PostEditCheckConfig::from_values(None, None), Ok(None));
+        assert_eq!(
+            PostEditCheckConfig::from_values(Some("   ".to_string()), None),
+            Ok(None)
+        );
+    }
+
+    #[test]
+    fn from_values_defaults_and_parses_the_timeout() {
+        let default = PostEditCheckConfig::from_values(Some("cargo check".to_string()), None)
+            .unwrap()
+            .unwrap();
+        assert_eq!(default.command(), "cargo check");
+        assert_eq!(default.timeout(), Duration::from_secs(DEFAULT_TIMEOUT_SECS));
+
+        let explicit = PostEditCheckConfig::from_values(
+            Some("cargo check".to_string()),
+            Some("90".to_string()),
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(explicit.timeout(), Duration::from_secs(90));
+    }
+
+    #[test]
+    fn from_values_rejects_invalid_timeouts() {
+        for invalid in ["0", "-1", "soon"] {
+            let error = PostEditCheckConfig::from_values(
+                Some("cargo check".to_string()),
+                Some(invalid.to_string()),
+            )
+            .expect_err("invalid timeout must be a config error");
+            assert!(error.to_string().contains(POST_EDIT_CHECK_TIMEOUT_ENV));
+        }
+    }
+}

--- a/crates/ironclaw_host_runtime/src/services.rs
+++ b/crates/ironclaw_host_runtime/src/services.rs
@@ -81,7 +81,7 @@ use crate::{
     BuiltinObligationHandler, CapabilitySurfaceVersion, DefaultHostRuntime,
     FirstPartyCapabilityRegistry, FirstPartyCapabilityRequest, HostRuntimeError,
     HostRuntimeHttpEgressPort, InvocationServicesResolutionRequest, InvocationServicesResolver,
-    LocalHostProcessPort, LocalInvocationServicesResolver, PlannerError,
+    LocalHostProcessPort, LocalInvocationServicesResolver, PlannerError, PostEditCheckConfig,
     ProcessObligationLifecycleStore, RuntimeBackendHealth, RuntimeProcessPort,
     RuntimeSecretMaterialStager, RuntimeSecretStageError, TenantSandboxProcessPort,
     ToolCallHttpEgress, plan_capability,
@@ -167,6 +167,7 @@ where
     run_profile_resolver: Option<Arc<dyn RunProfileResolver>>,
     turn_run_transition_port: Option<Arc<dyn TurnRunTransitionPort>>,
     turn_run_wake_notifier: Option<Arc<dyn TurnRunWakeNotifier>>,
+    post_edit_check: Option<PostEditCheckConfig>,
     component_types: ProductionComponentTypes,
 }
 
@@ -338,6 +339,7 @@ where
             run_profile_resolver: None,
             turn_run_transition_port: None,
             turn_run_wake_notifier: None,
+            post_edit_check: None,
             component_types: ProductionComponentTypes {
                 trust_policy: None,
                 trust_policy_verified: false,
@@ -410,6 +412,10 @@ where
         if let Some(process_port) = &self.tenant_sandbox_process_port {
             invocation_services_resolver = invocation_services_resolver
                 .with_tenant_sandbox_process_port(Arc::clone(process_port));
+        }
+        if let Some(post_edit_check) = &self.post_edit_check {
+            invocation_services_resolver =
+                invocation_services_resolver.with_post_edit_check(post_edit_check.clone());
         }
         let invocation_services: Arc<dyn InvocationServicesResolver> =
             Arc::new(invocation_services_resolver);

--- a/crates/ironclaw_host_runtime/src/services/builder.rs
+++ b/crates/ironclaw_host_runtime/src/services/builder.rs
@@ -83,6 +83,7 @@ where
             run_profile_resolver,
             turn_run_transition_port,
             turn_run_wake_notifier,
+            post_edit_check,
             mut component_types,
         } = self;
         component_types.filesystem = ProductionComponentType::of::<T>();
@@ -127,6 +128,7 @@ where
             run_profile_resolver,
             turn_run_transition_port,
             turn_run_wake_notifier,
+            post_edit_check,
             component_types,
         }
     }
@@ -192,6 +194,7 @@ where
             run_profile_resolver,
             turn_run_transition_port,
             turn_run_wake_notifier,
+            post_edit_check,
             mut component_types,
         } = self;
         let lifecycle_governor: Arc<dyn ResourceGovernor> = governor.clone();
@@ -246,6 +249,7 @@ where
             run_profile_resolver,
             turn_run_transition_port,
             turn_run_wake_notifier,
+            post_edit_check,
             component_types,
         }
     }
@@ -725,6 +729,15 @@ where
         self.component_types.runtime_process_port = ProductionComponentType::of::<T>();
         self.process_port = process_port;
         self.managed_process_port = false;
+        self
+    }
+
+    /// Configure the operator post-edit check appended to successful
+    /// `builtin.write_file` / `builtin.apply_patch` output. Composition
+    /// resolves the config once (see `PostEditCheckConfig::from_env`) and
+    /// threads it here; the feature stays off when this is never called.
+    pub fn with_post_edit_check(mut self, post_edit_check: crate::PostEditCheckConfig) -> Self {
+        self.post_edit_check = Some(post_edit_check);
         self
     }
 

--- a/crates/ironclaw_host_runtime/tests/first_party_coding_tools.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_coding_tools.rs
@@ -8,14 +8,18 @@ use ironclaw_filesystem::{
     DirEntry, FileStat, FileType, FilesystemError, FilesystemOperation, LocalFilesystem,
     RootFilesystem,
 };
+use ironclaw_host_api::runtime_policy::{
+    ApprovalPolicy, AuditMode, DeploymentMode, EffectiveRuntimePolicy, FilesystemBackendKind,
+    NetworkMode, ProcessBackendKind, RuntimeProfile, SecretMode,
+};
 use ironclaw_host_api::*;
 use ironclaw_host_runtime::{
     APPLY_PATCH_CAPABILITY_ID, CapabilitySurfaceVersion, CommandExecutionOutput,
     CommandExecutionRequest, GLOB_CAPABILITY_ID, GREP_CAPABILITY_ID, HostRuntime,
     HostRuntimeServices, LIST_DIR_CAPABILITY_ID, PostEditCheckConfig, READ_FILE_CAPABILITY_ID,
     RuntimeCapabilityOutcome, RuntimeCapabilityRequest, RuntimeFailureKind, RuntimeProcessError,
-    RuntimeProcessPort, WRITE_FILE_CAPABILITY_ID, builtin_first_party_handlers,
-    builtin_first_party_package,
+    RuntimeProcessPort, SandboxCommandTransport, TenantSandboxProcessPort,
+    WRITE_FILE_CAPABILITY_ID, builtin_first_party_handlers, builtin_first_party_package,
 };
 use ironclaw_resources::InMemoryResourceGovernor;
 use ironclaw_triggers::InMemoryTriggerRepository;
@@ -1222,14 +1226,19 @@ async fn builtin_edit_tools_append_new_post_edit_check_findings_only() {
         "read_file must not trigger the post-edit check"
     );
 
-    let first = invoke_with_context(
+    let first_completed = invoke_completed_with_context(
         &runtime,
         APPLY_PATCH_CAPABILITY_ID,
         json!({"path": "/workspace/main.rs", "old_string": "alpha", "new_string": "gamma"}),
         context.clone(),
     )
-    .await
-    .unwrap();
+    .await;
+    assert_eq!(
+        first_completed.usage.process_count, 1,
+        "an edit whose post-edit check ran must account for the spawned \
+         process exactly like builtin.shell"
+    );
+    let first = first_completed.output;
 
     assert_eq!(first["success"], json!(true), "edit itself must succeed");
     assert_eq!(first["post_edit_check"]["exit_code"], json!(1));
@@ -1357,6 +1366,106 @@ async fn builtin_edit_tools_omit_new_output_when_check_passes_clean() {
     .unwrap();
 
     assert_eq!(written["post_edit_check"], json!({"exit_code": 0}));
+}
+
+#[tokio::test]
+async fn builtin_edit_tools_disable_post_edit_check_when_process_backend_is_none() {
+    // Regression (PR #5979 review): write_file/apply_patch declare only
+    // filesystem effects, so their plan never requires a process — but a
+    // configured post-edit check used to spawn through the default process
+    // port anyway, bypassing ProcessBackendKind::None entirely. Under a
+    // no-process policy the advisory check must be withheld: the edit
+    // succeeds, no process port is touched, and nothing is accounted.
+    let temp = tempfile::tempdir().unwrap();
+
+    let (filesystem, mounts) = mounted_filesystem(temp.path(), MountPermissions::read_write());
+    let check_port = Arc::new(ScriptedProcessPort::completing("diagnostics", 1));
+    let runtime = runtime_with_post_edit_check_and_policy(
+        filesystem,
+        Arc::clone(&check_port),
+        None,
+        PostEditCheckConfig::new("cargo check", Duration::from_secs(30)),
+        process_denied_runtime_policy(),
+    );
+    let context = execution_context_with_mounts(coding_capability_ids(), mounts);
+
+    let completed = invoke_completed_with_context(
+        &runtime,
+        WRITE_FILE_CAPABILITY_ID,
+        json!({"path": "/workspace/new.rs", "content": "fn hello() {}\n"}),
+        context,
+    )
+    .await;
+
+    assert_eq!(
+        completed.output["success"],
+        json!(true),
+        "edit must succeed"
+    );
+    assert!(
+        completed.output.get("post_edit_check").is_none(),
+        "ProcessBackendKind::None must disable the post-edit check"
+    );
+    assert!(
+        check_port.requests().is_empty(),
+        "a no-process policy must never spawn the check on the local host port"
+    );
+    assert_eq!(
+        completed.usage.process_count, 0,
+        "no process ran, so none may be accounted"
+    );
+}
+
+#[tokio::test]
+async fn builtin_edit_tools_disable_post_edit_check_under_tenant_sandbox_policy() {
+    // Regression (PR #5979 review): under a tenant-sandbox process policy the
+    // default process port handed to non-process plans is still the raw local
+    // host port, so a configured check used to escape the sandbox onto the
+    // provider host. The check must be withheld outright — not spawned on the
+    // local host port, and not silently rerouted to the sandbox port either.
+    let temp = tempfile::tempdir().unwrap();
+
+    let (filesystem, mounts) = mounted_filesystem(temp.path(), MountPermissions::read_write());
+    let local_port = Arc::new(ScriptedProcessPort::completing("diagnostics", 1));
+    let sandbox_transport = Arc::new(RecordingSandboxTransport::default());
+    let runtime = runtime_with_post_edit_check_and_policy(
+        filesystem,
+        Arc::clone(&local_port),
+        Some(Arc::new(TenantSandboxProcessPort::new(
+            Arc::clone(&sandbox_transport) as Arc<dyn SandboxCommandTransport>,
+        ))),
+        PostEditCheckConfig::new("cargo check", Duration::from_secs(30)),
+        tenant_sandbox_runtime_policy(),
+    );
+    let context = execution_context_with_mounts(coding_capability_ids(), mounts);
+
+    let completed = invoke_completed_with_context(
+        &runtime,
+        WRITE_FILE_CAPABILITY_ID,
+        json!({"path": "/workspace/new.rs", "content": "fn hello() {}\n"}),
+        context,
+    )
+    .await;
+
+    assert_eq!(
+        completed.output["success"],
+        json!(true),
+        "edit must succeed"
+    );
+    assert!(
+        completed.output.get("post_edit_check").is_none(),
+        "a tenant-sandbox process policy must disable the post-edit check"
+    );
+    assert!(
+        local_port.requests().is_empty(),
+        "the check must not escape the sandbox policy onto the local host port"
+    );
+    assert_eq!(
+        sandbox_transport.request_count(),
+        0,
+        "the withheld check must not be rerouted through the sandbox port"
+    );
+    assert_eq!(completed.usage.process_count, 0);
 }
 
 fn assert_aggregate_scan_limit(output: &Value) {
@@ -1522,6 +1631,106 @@ where
     .with_post_edit_check(post_edit_check)
     .with_trust_policy(Arc::new(trust_policy()))
     .host_runtime_for_local_testing()
+}
+
+/// Like `runtime_with_filesystem_process_port_and_post_edit_check`, but with
+/// an explicit runtime policy (and optionally a tenant sandbox process port)
+/// so tests can pin how the process policy gates the post-edit check.
+fn runtime_with_post_edit_check_and_policy<F, P>(
+    filesystem: F,
+    process_port: Arc<P>,
+    tenant_sandbox_process_port: Option<Arc<TenantSandboxProcessPort>>,
+    post_edit_check: PostEditCheckConfig,
+    policy: EffectiveRuntimePolicy,
+) -> impl HostRuntime
+where
+    F: RootFilesystem + 'static,
+    P: RuntimeProcessPort + 'static,
+{
+    let mut services = HostRuntimeServices::new(
+        Arc::new(registry()),
+        Arc::new(filesystem),
+        Arc::new(InMemoryResourceGovernor::new()),
+        Arc::new(GrantAuthorizer::new()),
+        ironclaw_processes::ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_first_party_capabilities(Arc::new(
+        builtin_first_party_handlers(Arc::new(InMemoryTriggerRepository::default())).unwrap(),
+    ))
+    .with_runtime_process_port(process_port)
+    .with_post_edit_check(post_edit_check)
+    .with_runtime_policy(policy)
+    .with_trust_policy(Arc::new(trust_policy()));
+    if let Some(tenant_sandbox_process_port) = tenant_sandbox_process_port {
+        services = services.with_tenant_sandbox_process_port(tenant_sandbox_process_port);
+    }
+    services.host_runtime_for_local_testing()
+}
+
+/// SecureDefault-shaped local policy: scoped-virtual filesystem, no process
+/// backend. Approval stays at AskDestructive so the only axis under test is
+/// the process backend.
+fn process_denied_runtime_policy() -> EffectiveRuntimePolicy {
+    EffectiveRuntimePolicy {
+        deployment: DeploymentMode::LocalSingleUser,
+        requested_profile: RuntimeProfile::SecureDefault,
+        resolved_profile: RuntimeProfile::SecureDefault,
+        filesystem_backend: FilesystemBackendKind::ScopedVirtual,
+        process_backend: ProcessBackendKind::None,
+        network_mode: NetworkMode::Brokered,
+        secret_mode: SecretMode::BrokeredHandles,
+        approval_policy: ApprovalPolicy::AskDestructive,
+        audit_mode: AuditMode::LocalMinimal,
+    }
+}
+
+/// HostedDev-shaped tenant policy with a tenant-sandbox process backend. The
+/// filesystem backend is ScopedVirtual (not the hosted TenantWorkspace)
+/// because the local invocation-services resolver under test can only serve
+/// mount-scoped filesystem plans; the axis under test is the process backend.
+fn tenant_sandbox_runtime_policy() -> EffectiveRuntimePolicy {
+    EffectiveRuntimePolicy {
+        deployment: DeploymentMode::HostedMultiTenant,
+        requested_profile: RuntimeProfile::HostedDev,
+        resolved_profile: RuntimeProfile::HostedDev,
+        filesystem_backend: FilesystemBackendKind::ScopedVirtual,
+        process_backend: ProcessBackendKind::TenantSandbox,
+        network_mode: NetworkMode::Allowlist,
+        secret_mode: SecretMode::TenantBroker,
+        approval_policy: ApprovalPolicy::AskDestructive,
+        audit_mode: AuditMode::Standard,
+    }
+}
+
+/// Sandbox transport double that counts requests; the tenant-sandbox test
+/// asserts the withheld post-edit check is not rerouted through it.
+#[derive(Default)]
+struct RecordingSandboxTransport {
+    requests: std::sync::Mutex<Vec<CommandExecutionRequest>>,
+}
+
+impl RecordingSandboxTransport {
+    fn request_count(&self) -> usize {
+        self.requests.lock().unwrap().len()
+    }
+}
+
+#[async_trait]
+impl SandboxCommandTransport for RecordingSandboxTransport {
+    async fn run_command(
+        &self,
+        request: CommandExecutionRequest,
+    ) -> Result<CommandExecutionOutput, RuntimeProcessError> {
+        self.requests.lock().unwrap().push(request);
+        Ok(CommandExecutionOutput {
+            output: "sandbox diagnostics".to_string(),
+            saved_output: None,
+            exit_code: 0,
+            sandboxed: true,
+            duration: Duration::from_millis(3),
+        })
+    }
 }
 
 /// Process-port double that records every request and replays one scripted

--- a/crates/ironclaw_host_runtime/tests/first_party_coding_tools.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_coding_tools.rs
@@ -1,4 +1,5 @@
-use std::{path::Path, sync::Arc};
+// arch-exempt: large_file, caller-tier coding-tool suite shares one runtime/mount fixture set, plan #4539
+use std::{path::Path, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use ironclaw_authorization::GrantAuthorizer;
@@ -9,10 +10,12 @@ use ironclaw_filesystem::{
 };
 use ironclaw_host_api::*;
 use ironclaw_host_runtime::{
-    APPLY_PATCH_CAPABILITY_ID, CapabilitySurfaceVersion, GLOB_CAPABILITY_ID, GREP_CAPABILITY_ID,
-    HostRuntime, HostRuntimeServices, LIST_DIR_CAPABILITY_ID, READ_FILE_CAPABILITY_ID,
-    RuntimeCapabilityOutcome, RuntimeCapabilityRequest, RuntimeFailureKind,
-    WRITE_FILE_CAPABILITY_ID, builtin_first_party_handlers, builtin_first_party_package,
+    APPLY_PATCH_CAPABILITY_ID, CapabilitySurfaceVersion, CommandExecutionOutput,
+    CommandExecutionRequest, GLOB_CAPABILITY_ID, GREP_CAPABILITY_ID, HostRuntime,
+    HostRuntimeServices, LIST_DIR_CAPABILITY_ID, PostEditCheckConfig, READ_FILE_CAPABILITY_ID,
+    RuntimeCapabilityOutcome, RuntimeCapabilityRequest, RuntimeFailureKind, RuntimeProcessError,
+    RuntimeProcessPort, WRITE_FILE_CAPABILITY_ID, builtin_first_party_handlers,
+    builtin_first_party_package,
 };
 use ironclaw_resources::InMemoryResourceGovernor;
 use ironclaw_triggers::InMemoryTriggerRepository;
@@ -1191,6 +1194,171 @@ async fn builtin_coding_glob_reports_visited_entry_budget_as_truncated_result() 
     assert_eq!(output["files"], json!([]));
 }
 
+#[tokio::test]
+async fn builtin_edit_tools_append_new_post_edit_check_findings_only() {
+    // The operator-configured post-edit check runs after a successful edit and
+    // surfaces its diagnostics to the model. A second edit whose check output
+    // is identical must not repeat previously-reported lines (new-only diff).
+    let temp = tempfile::tempdir().unwrap();
+    std::fs::write(temp.path().join("main.rs"), "alpha beta\n").unwrap();
+
+    let (filesystem, mounts) = mounted_filesystem(temp.path(), MountPermissions::read_write());
+    let check_port = Arc::new(ScriptedProcessPort::completing(
+        "error[E0308]: mismatched types\nwarning: unused variable `x`\n",
+        1,
+    ));
+    let runtime = runtime_with_filesystem_process_port_and_post_edit_check(
+        filesystem,
+        Arc::clone(&check_port),
+        PostEditCheckConfig::new(
+            "cargo check --message-format=short 2>&1",
+            Duration::from_secs(7),
+        ),
+    );
+    let context = execution_context_with_mounts(coding_capability_ids(), mounts);
+    seed_read_state(&runtime, "/workspace/main.rs", context.clone()).await;
+    assert!(
+        check_port.requests().is_empty(),
+        "read_file must not trigger the post-edit check"
+    );
+
+    let first = invoke_with_context(
+        &runtime,
+        APPLY_PATCH_CAPABILITY_ID,
+        json!({"path": "/workspace/main.rs", "old_string": "alpha", "new_string": "gamma"}),
+        context.clone(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(first["success"], json!(true), "edit itself must succeed");
+    assert_eq!(first["post_edit_check"]["exit_code"], json!(1));
+    let new_output = first["post_edit_check"]["new_output"]
+        .as_str()
+        .expect("first edit surfaces the check findings as new_output");
+    assert!(new_output.contains("error[E0308]: mismatched types"));
+    assert!(new_output.contains("unused variable"));
+
+    let requests = check_port.requests();
+    assert_eq!(requests.len(), 1, "one check per successful edit");
+    assert_eq!(
+        requests[0].command,
+        "cargo check --message-format=short 2>&1"
+    );
+    assert_eq!(requests[0].timeout_secs, Some(7));
+    assert_eq!(
+        requests[0].workdir.as_deref(),
+        Some("/workspace"),
+        "check must run at the writable mount root so the process port \
+         resolves it exactly like a shell workdir"
+    );
+
+    let second = invoke_with_context(
+        &runtime,
+        APPLY_PATCH_CAPABILITY_ID,
+        json!({"path": "/workspace/main.rs", "old_string": "beta", "new_string": "delta"}),
+        context,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        second["post_edit_check"],
+        json!({"exit_code": 1}),
+        "identical check output must carry no repeated lines"
+    );
+    assert_eq!(check_port.requests().len(), 2);
+}
+
+#[tokio::test]
+async fn builtin_edit_tools_skip_post_edit_check_when_unconfigured() {
+    // Feature off (no config): the mutating tools must not touch the process
+    // port at all and the model-facing output carries no post_edit_check field.
+    let temp = tempfile::tempdir().unwrap();
+
+    let (filesystem, mounts) = mounted_filesystem(temp.path(), MountPermissions::read_write());
+    let check_port = Arc::new(ScriptedProcessPort::completing("diagnostics", 1));
+    let runtime = runtime_with_filesystem_and_process_port(filesystem, Arc::clone(&check_port));
+    let context = execution_context_with_mounts(coding_capability_ids(), mounts);
+
+    let written = invoke_with_context(
+        &runtime,
+        WRITE_FILE_CAPABILITY_ID,
+        json!({"path": "/workspace/new.rs", "content": "fn hello() {}\n"}),
+        context,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(written["success"], json!(true));
+    assert!(
+        written.get("post_edit_check").is_none(),
+        "unconfigured runtime must not emit a post_edit_check field"
+    );
+    assert!(
+        check_port.requests().is_empty(),
+        "unconfigured runtime must not invoke the process port"
+    );
+}
+
+#[tokio::test]
+async fn builtin_edit_tools_report_post_edit_check_timeout_without_failing_the_edit() {
+    // The check is advisory: a timed-out check must not fail the already
+    // successful edit, and the model learns the check timed out.
+    let temp = tempfile::tempdir().unwrap();
+
+    let (filesystem, mounts) = mounted_filesystem(temp.path(), MountPermissions::read_write());
+    let check_port = Arc::new(ScriptedProcessPort::timing_out(Duration::from_secs(7)));
+    let runtime = runtime_with_filesystem_process_port_and_post_edit_check(
+        filesystem,
+        Arc::clone(&check_port),
+        PostEditCheckConfig::new("cargo check", Duration::from_secs(7)),
+    );
+    let context = execution_context_with_mounts(coding_capability_ids(), mounts);
+
+    let written = invoke_with_context(
+        &runtime,
+        WRITE_FILE_CAPABILITY_ID,
+        json!({"path": "/workspace/new.rs", "content": "fn hello() {}\n"}),
+        context,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(written["success"], json!(true), "edit must not fail");
+    assert_eq!(written["post_edit_check"], json!({"timed_out": true}));
+    assert_eq!(
+        std::fs::read_to_string(temp.path().join("new.rs")).unwrap(),
+        "fn hello() {}\n"
+    );
+}
+
+#[tokio::test]
+async fn builtin_edit_tools_omit_new_output_when_check_passes_clean() {
+    // A passing check with no new findings stays token-lean: exit_code only.
+    let temp = tempfile::tempdir().unwrap();
+
+    let (filesystem, mounts) = mounted_filesystem(temp.path(), MountPermissions::read_write());
+    let check_port = Arc::new(ScriptedProcessPort::completing("", 0));
+    let runtime = runtime_with_filesystem_process_port_and_post_edit_check(
+        filesystem,
+        Arc::clone(&check_port),
+        PostEditCheckConfig::new("cargo check", Duration::from_secs(30)),
+    );
+    let context = execution_context_with_mounts(coding_capability_ids(), mounts);
+
+    let written = invoke_with_context(
+        &runtime,
+        WRITE_FILE_CAPABILITY_ID,
+        json!({"path": "/workspace/new.rs", "content": "fn hello() {}\n"}),
+        context,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(written["post_edit_check"], json!({"exit_code": 0}));
+}
+
 fn assert_aggregate_scan_limit(output: &Value) {
     assert_eq!(output["truncated"], json!(true));
     assert_eq!(output["limit_reason"], json!("aggregate_scan_bytes"));
@@ -1304,6 +1472,103 @@ where
     ))
     .with_trust_policy(Arc::new(trust_policy()))
     .host_runtime_for_local_testing()
+}
+
+fn runtime_with_filesystem_and_process_port<F, P>(
+    filesystem: F,
+    process_port: Arc<P>,
+) -> impl HostRuntime
+where
+    F: RootFilesystem + 'static,
+    P: RuntimeProcessPort + 'static,
+{
+    HostRuntimeServices::new(
+        Arc::new(registry()),
+        Arc::new(filesystem),
+        Arc::new(InMemoryResourceGovernor::new()),
+        Arc::new(GrantAuthorizer::new()),
+        ironclaw_processes::ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_first_party_capabilities(Arc::new(
+        builtin_first_party_handlers(Arc::new(InMemoryTriggerRepository::default())).unwrap(),
+    ))
+    .with_runtime_process_port(process_port)
+    .with_trust_policy(Arc::new(trust_policy()))
+    .host_runtime_for_local_testing()
+}
+
+fn runtime_with_filesystem_process_port_and_post_edit_check<F, P>(
+    filesystem: F,
+    process_port: Arc<P>,
+    post_edit_check: PostEditCheckConfig,
+) -> impl HostRuntime
+where
+    F: RootFilesystem + 'static,
+    P: RuntimeProcessPort + 'static,
+{
+    HostRuntimeServices::new(
+        Arc::new(registry()),
+        Arc::new(filesystem),
+        Arc::new(InMemoryResourceGovernor::new()),
+        Arc::new(GrantAuthorizer::new()),
+        ironclaw_processes::ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_first_party_capabilities(Arc::new(
+        builtin_first_party_handlers(Arc::new(InMemoryTriggerRepository::default())).unwrap(),
+    ))
+    .with_runtime_process_port(process_port)
+    .with_post_edit_check(post_edit_check)
+    .with_trust_policy(Arc::new(trust_policy()))
+    .host_runtime_for_local_testing()
+}
+
+/// Process-port double that records every request and replays one scripted
+/// outcome, mirroring the recording port used by the builtin.shell tests.
+struct ScriptedProcessPort {
+    requests: std::sync::Mutex<Vec<CommandExecutionRequest>>,
+    response: Result<(String, i64), RuntimeProcessError>,
+}
+
+impl ScriptedProcessPort {
+    fn completing(output: &str, exit_code: i64) -> Self {
+        Self {
+            requests: std::sync::Mutex::new(Vec::new()),
+            response: Ok((output.to_string(), exit_code)),
+        }
+    }
+
+    fn timing_out(timeout: Duration) -> Self {
+        Self {
+            requests: std::sync::Mutex::new(Vec::new()),
+            response: Err(RuntimeProcessError::Timeout(timeout)),
+        }
+    }
+
+    fn requests(&self) -> Vec<CommandExecutionRequest> {
+        self.requests.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl RuntimeProcessPort for ScriptedProcessPort {
+    async fn run_command(
+        &self,
+        request: CommandExecutionRequest,
+    ) -> Result<CommandExecutionOutput, RuntimeProcessError> {
+        self.requests.lock().unwrap().push(request);
+        match &self.response {
+            Ok((output, exit_code)) => Ok(CommandExecutionOutput {
+                output: output.clone(),
+                saved_output: None,
+                exit_code: *exit_code,
+                sandboxed: false,
+                duration: Duration::from_millis(3),
+            }),
+            Err(error) => Err(error.clone()),
+        }
+    }
 }
 
 fn registry() -> ExtensionRegistry {

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -74,7 +74,8 @@ use ironclaw_host_api::{
 use ironclaw_host_api::{HostApiError, MountAlias, MountGrant};
 use ironclaw_host_runtime::{
     CapabilitySurfaceVersion, FirstPartyCapabilityRegistry, HostRuntimeHttpEgressPort,
-    HostRuntimeServices, LocalHostProcessPort, ProductAuthProviderRuntimePorts, TriggerCreateHook,
+    HostRuntimeServices, LocalHostProcessPort, PostEditCheckConfig,
+    ProductAuthProviderRuntimePorts, TriggerCreateHook,
     builtin_first_party_handlers_with_trigger_create_hook, builtin_first_party_package,
 };
 #[cfg(any(feature = "libsql", feature = "postgres"))]
@@ -334,6 +335,29 @@ where
         RebornRuntimeProcessBinding::TenantSandbox { process_port } => {
             services.with_tenant_sandbox_process_port(process_port)
         }
+    }
+}
+
+/// Composition-layer optional-env seam for the coding post-edit check
+/// (`IRONCLAW_POST_EDIT_CHECK` / `IRONCLAW_POST_EDIT_CHECK_TIMEOUT_SECS`).
+/// Parsing lives in the module-owned `PostEditCheckConfig::from_env`; this
+/// only threads the resolved config into host runtime services. The feature
+/// stays off when the command env is unset or blank.
+fn apply_post_edit_check_from_env<F, G, S, R>(
+    services: HostRuntimeServices<F, G, S, R>,
+) -> Result<HostRuntimeServices<F, G, S, R>, RebornBuildError>
+where
+    F: ironclaw_filesystem::RootFilesystem + 'static,
+    G: ironclaw_resources::ResourceGovernor + 'static,
+    S: ironclaw_processes::ProcessStore + 'static,
+    R: ironclaw_processes::ProcessResultStore + 'static,
+{
+    match PostEditCheckConfig::from_env() {
+        Ok(Some(post_edit_check)) => Ok(services.with_post_edit_check(post_edit_check)),
+        Ok(None) => Ok(services),
+        Err(error) => Err(RebornBuildError::InvalidConfig {
+            reason: error.to_string(),
+        }),
     }
 }
 
@@ -1650,6 +1674,7 @@ async fn build_local_runtime(input: RebornBuildInput) -> Result<RebornServices, 
         services = services.with_runtime_process_port(Arc::new(process_port));
     }
     services = apply_runtime_process_binding(services, runtime_process_binding);
+    services = apply_post_edit_check_from_env(services)?;
     services = attach_hosted_mcp_runtime(services)?;
     let product_auth_runtime_ports = require_product_auth_runtime_ports(&services)?;
     let provider_composition = compose_provider_client(


### PR DESCRIPTION
**Stack 4/4 on the edit-guardrails PR.**

Benchmark failure analysis shows the dominant remaining agent failure is collateral damage: a fix passes its own reproduction but breaks adjacent code the agent never re-checked. Claude Code pushes NEW diagnostics to the model after each edit (baseline→diff, deduped, capped). This is the reborn v1.

## What

- Env-gated, off by default: `IRONCLAW_POST_EDIT_CHECK` (operator command, e.g. `cargo check --message-format=short 2>&1`) + `IRONCLAW_POST_EDIT_CHECK_TIMEOUT_SECS` (default 30). Env read once in composition (`apply_post_edit_check_from_env`, following the optional-env pattern), threaded through `HostRuntimeServices` → `InvocationServices` — no per-call env reads.
- Hook site: the coding fallback arm of `BuiltinFirstPartyTools::dispatch`, the one place where the successful edit result, the `RuntimeProcessPort` (same port `builtin.shell` uses, same `/workspace` workdir-alias semantics), scope, and mounts coexist. Only fires for `write_file`/`apply_patch`.
- New-only filtering: per-scope seen-line registry (500 lines/scope FIFO, 512 scopes); output capped 30 lines / 4000 bytes with "+N more new lines".
- Surfaced as a `post_edit_check` field on the edit's tool output: `{"exit_code": N, "new_output": ...}` on findings; `{"exit_code": 0}` when clean (token-lean); `{"timed_out": true}` on timeout. The check is advisory — it never fails the edit.

## Testing

Red-then-green caller-tier tests drive `invoke_capability` through the full runtime with a scripted process port: output carries new diagnostics; a second identical check output produces no repeated lines; unconfigured → zero port invocations and no field; timeout-advisory and clean-pass cases. 10 unit tests on filter/config (dedup, caps, FIFO eviction, invalid-timeout). All three crates green; fmt + clippy clean; pre-commit safety script exit 0.

Deferred (documented): per-file seen-set clearing, hosted/multi-tenant composition wiring (local-dev only by design), resource accounting for the check run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)