### PR TITLE
fix(ci): authorize maintainer canary triggers

### DIFF
--- a/.github/workflows/live-canary-command.yml
+++ b/.github/workflows/live-canary-command.yml
@@ -119,6 +119,7 @@ jobs:
           HEAD_SHA: ${{ steps.parse.outputs.head_sha }}
           PR: ${{ github.event.issue.number }}
           REPO: ${{ github.repository }}
+          TRIGGER_ACTOR: ${{ github.event.comment.user.login }}
           TRIGGER_CONTEXT: ${{ steps.parse.outputs.trigger_context }}
         run: |
           set -euo pipefail
@@ -130,6 +131,7 @@ jobs:
             -f target_ref="$HEAD_SHA" \
             -f target_branch="$HEAD_REF" \
             -f target_pr="$PR" \
+            -f trigger_actor="$TRIGGER_ACTOR" \
             -f trigger_context="$TRIGGER_CONTEXT"
 
       - name: Post started comment

--- a/.github/workflows/live-canary.yml
+++ b/.github/workflows/live-canary.yml
@@ -66,6 +66,11 @@ on:
         type: string
         required: false
         default: ""
+      trigger_actor:
+        description: "Optional GitHub login of the maintainer who authorized a ChatOps PR live-QA run."
+        type: string
+        required: false
+        default: ""
       use_target_harness:
         description: "Use target_ref's Reborn WebUI v2 live QA harness instead of restoring the canonical main harness."
         type: boolean
@@ -555,12 +560,17 @@ jobs:
       contents: read
       pull-requests: read
     steps:
-      - name: Require trusted approval for the exact PR head
+      - name: Require trusted approval or maintainer-triggered PR live QA
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           TARGET_PR: ${{ inputs.target_pr }}
           TARGET_REF: ${{ inputs.target_ref }}
+          # A workflow_dispatch created by Live Canary Command is attributed to
+          # github-actions[bot]. The command verifies this original actor has
+          # repository write access before dispatching; direct dispatches use
+          # GitHub's real triggering actor instead.
+          TRIGGER_ACTOR: ${{ inputs.trigger_actor || github.triggering_actor }}
         run: |
           set -euo pipefail
           if ! [[ "${TARGET_PR}" =~ ^[0-9]+$ && "${TARGET_REF}" =~ ^[0-9a-f]{40}$ ]]; then
@@ -591,11 +601,18 @@ jobs:
               --jq 'sort_by(.submitted_at) | group_by(.user.login) | map(last) | .[] | select(.state == "APPROVED") | [.user.login, .commit_id] | @tsv'
           )
 
+          if [[ -z "${trusted_approval}" && "${TRIGGER_ACTOR}" =~ ^[A-Za-z0-9-]+$ ]]; then
+            permission="$(gh api "repos/${REPO}/collaborators/${TRIGGER_ACTOR}/permission" --jq '.permission')"
+            if [[ "${permission}" == "admin" || "${permission}" == "maintain" || "${permission}" == "write" ]]; then
+              trusted_approval="${TRIGGER_ACTOR} (authorized trigger)"
+            fi
+          fi
+
           if [[ -z "${trusted_approval}" ]]; then
-            echo "::error::PR #${TARGET_PR} head ${TARGET_REF} requires an approving review from a collaborator with write access before live secrets can be used."
+            echo "::error::PR #${TARGET_PR} head ${TARGET_REF} requires either an approving review from a collaborator with write access or a trigger by a collaborator with write access before live secrets can be used."
             exit 1
           fi
-          echo "Trusted approval for ${TARGET_REF} was provided by ${trusted_approval}."
+          echo "Trusted authorization for ${TARGET_REF} was provided by ${trusted_approval}."
 
   prepare-reborn-webui-v2-live-qa:
     name: Prepare Reborn WebUI v2 live QA binary

--- a/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
+++ b/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
@@ -4732,9 +4732,15 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
         self.assertIn("approve-reborn-webui-v2-pr-live-qa:", workflow)
         self.assertIn("environment: reborn-live-canary-pr", workflow)
         self.assertIn(
-            "requires an approving review from a collaborator with write access",
+            "requires either an approving review from a collaborator with write access or a trigger by a collaborator with write access",
             workflow,
         )
+        self.assertIn("trigger_actor:", workflow)
+        self.assertIn(
+            "inputs.trigger_actor || github.triggering_actor",
+            workflow,
+        )
+        self.assertIn("(authorized trigger)", workflow)
         self.assertIn("needs: prepare-reborn-webui-v2-live-qa", match.group("body"))
         self.assertIn("always() &&", match.group("body"))
         self.assertIn(
@@ -4792,6 +4798,8 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
         command_workflow = command_workflow_path.read_text(encoding="utf-8")
         self.assertIn('-f target_ref="$HEAD_SHA"', command_workflow)
         self.assertIn('-f target_pr="$PR"', command_workflow)
+        self.assertIn('TRIGGER_ACTOR: ${{ github.event.comment.user.login }}', command_workflow)
+        self.assertIn('-f trigger_actor="$TRIGGER_ACTOR"', command_workflow)
 
     def test_case_manifest_distinguishes_targeted_from_placeholder_gates(self):
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary

- propagate the verified `/canary` commenter into the live-QA dispatch
- accept a write, maintain, or admin trigger as an alternative to exact-head review
- retain exact SHA and fork validation

## Root cause

The follow-on `workflow_dispatch` run was attributed to `github-actions[bot]`, so the exact-head review gate could not recognize the maintainer who initiated `/canary`.

## Validation

- Ruby YAML parse for both workflows
- `git diff --check`
- mocked authorization fallback for `serrrfirat` with admin permission