### PR TITLE
test(e2e): stabilize Reborn Playwright fixtures

### DIFF
--- a/tests/e2e/scenarios/test_reborn_webui_v2_legacy_dom_resource_limits.py
+++ b/tests/e2e/scenarios/test_reborn_webui_v2_legacy_dom_resource_limits.py
@@ -504,6 +504,9 @@ async def test_reborn_sse_reconnect_timer_clears_when_tab_hidden(
             const stream = streams[streams.length - 1];
             if (!stream) throw new Error("no EventSource stream is open");
             window.__sseFailCalls = (window.__sseFailCalls || 0) + 1;
+            // A closed stream takes useSSE's explicit 2-second fallback path;
+            // an open stream instead uses the native reconnect watchdog.
+            stream.readyState = 2;
             if (typeof stream.onerror === "function") stream.onerror(new Event("error"));
           };
         })();

--- a/tests/e2e/scenarios/test_reborn_webui_v2_legacy_pending_messages.py
+++ b/tests/e2e/scenarios/test_reborn_webui_v2_legacy_pending_messages.py
@@ -192,6 +192,10 @@ async def _open_mocked_pending_page(
         f"{reborn_v2_server}/v2/chat/{initial_thread_id}?token={REBORN_V2_AUTH_TOKEN}"
     )
     await expect(page.locator(SEL_V2["chat_composer"])).to_be_visible(timeout=15000)
+    # Composer visibility alone does not prove the route's thread has hydrated.
+    # Wait for the thread-scoped timeline request so sends cannot race through
+    # useChat's new-conversation path with a still-null activeThreadId.
+    await _wait_for_request_count(timeline_requests, 0)
 
     return {
         "context": context,

--- a/tests/e2e/scenarios/test_reborn_webui_v2_legacy_sse_history.py
+++ b/tests/e2e/scenarios/test_reborn_webui_v2_legacy_sse_history.py
@@ -262,6 +262,10 @@ async def test_reborn_legacy_sse_error_reconnect_resumes_after_last_cursor(
             if (typeof stream.onerror !== "function") {
               throw new Error("EventSource has no error handler");
             }
+            // Model a terminal EventSource failure so useSSE exercises its
+            // explicit fresh-stream fallback, rather than the browser-native
+            // reconnect watchdog path.
+            stream.readyState = 2;
             stream.onerror(new Event("error"));
           };
         })();


### PR DESCRIPTION
## Summary

- model terminal EventSource failures as closed in the two Reborn Playwright fixtures
- keep the existing assertions on the explicit fresh-stream fallback path
- wait for the pending-message fixture's initial thread timeline to hydrate before tests send

## Root cause

`useSSE` now distinguishes a closed stream from a browser-native reconnect. The fixtures emitted an error while leaving the fake EventSource open, so they exercised the 10-second native watchdog while asserting the closed-stream 2-second fallback behavior.

The pending-message helper also treated composer visibility as thread readiness. A send could therefore race with route hydration, reach `useChat` with a null `activeThreadId`, and take the new-conversation path before rendering its optimistic message.

## Impact

Fixes the scheduled Reborn Playwright failures without changing production behavior.

## Verification

- Python compilation for all three changed Playwright scenario files
- `git diff --check`
- Reborn Playwright branch run `29147485021`: both SSE fixture failures passed; exposed the pending-message hydration race fixed by the follow-up commit

The full Reborn Playwright matrix is rerun after each pushed fix.
