### PR TITLE
test(e2e): expand Emulate fixture coverage

### DIFF
--- a/crates/ironclaw_first_party_extensions/tests/gsuite_core.rs
+++ b/crates/ironclaw_first_party_extensions/tests/gsuite_core.rs
@@ -28,8 +28,9 @@ use ironclaw_first_party_extensions::{
     gsuite_resource_profile,
 };
 use ironclaw_host_api::{
-    ExtensionId, NetworkMethod, NetworkScheme, RUNTIME_HTTP_REASON_RESPONSE_BODY_LIMIT_EXCEEDED,
-    RuntimeDispatchErrorKind, RuntimeHttpEgressError, SecretHandle,
+    ExtensionId, InvocationId, NetworkMethod, NetworkScheme,
+    RUNTIME_HTTP_REASON_RESPONSE_BODY_LIMIT_EXCEEDED, ResourceScope, RuntimeDispatchErrorKind,
+    RuntimeHttpEgressError, SecretHandle, UserId,
 };
 use serde_json::json;
 use support::*;
@@ -1079,6 +1080,78 @@ async fn gsuite_handler_uses_selected_credential_handle_for_runtime_egress() {
     assert_eq!(
         requests[0].credential_injections[0].handle,
         SecretHandle::new("google-access-token").unwrap()
+    );
+}
+
+#[tokio::test]
+async fn gsuite_handler_uses_trigger_owner_account_not_other_active_user() {
+    let owner_scope =
+        ResourceScope::local_default(UserId::new("routine-owner").unwrap(), InvocationId::new())
+            .unwrap();
+    let other_scope = ResourceScope::local_default(
+        UserId::new("interactive-user").unwrap(),
+        InvocationId::new(),
+    )
+    .unwrap();
+    let auth = Arc::new(InMemoryAuthProductServices::new());
+
+    for (scope, label, handle) in [
+        (
+            &owner_scope,
+            "routine owner Google",
+            "routine-owner-google-token",
+        ),
+        (
+            &other_scope,
+            "interactive user Google",
+            "interactive-user-google-token",
+        ),
+    ] {
+        ironclaw_auth::CredentialAccountService::create_account(
+            auth.as_ref(),
+            NewCredentialAccount {
+                scope: auth_scope(scope),
+                provider: google_provider_id().unwrap(),
+                label: CredentialAccountLabel::new(label).unwrap(),
+                status: CredentialAccountStatus::Configured,
+                ownership: CredentialOwnership::UserReusable,
+                owner_extension: None,
+                granted_extensions: Vec::new(),
+                access_secret: Some(SecretHandle::new(handle).unwrap()),
+                refresh_secret: None,
+                scopes: vec![provider_scope(GOOGLE_GMAIL_READONLY_SCOPE)],
+            },
+        )
+        .await
+        .unwrap();
+    }
+
+    let executor = GsuiteExecutor::new(auth.clone(), auth, noop_credential_stager());
+    let capability_id = capability_id(GMAIL_LIST_MESSAGES_CAPABILITY_ID);
+    let egress = Arc::new(RecordingEgress::permissive_success());
+    let result = executor
+        .dispatch(GsuiteDispatchRequest {
+            capability_id: &capability_id,
+            scope: &owner_scope,
+            input: &json!({"query": "is:unread"}),
+            runtime_http_egress: egress.clone(),
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(result.output["status"], 200);
+    let requests = egress.requests();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].credential_injections.len(), 1);
+    assert_eq!(
+        requests[0].credential_injections[0].handle,
+        SecretHandle::new("routine-owner-google-token").unwrap(),
+        "a scheduled run must use its owner's Google account"
+    );
+    assert_ne!(
+        requests[0].credential_injections[0].handle,
+        SecretHandle::new("interactive-user-google-token").unwrap(),
+        "the other active user's account must remain isolated"
     );
 }
 

--- a/crates/ironclaw_reborn_composition/src/slack/slack_delivery.rs
+++ b/crates/ironclaw_reborn_composition/src/slack/slack_delivery.rs
@@ -3830,23 +3830,11 @@ mod tests {
         scope: &TurnScope,
         channel_id: &str,
     ) -> Arc<crate::slack::slack_outbound_targets::SlackHostBetaOutboundTargetProvider> {
-        shared_channel_target_provider_for_channels(install, scope, &[channel_id])
-    }
-
-    fn shared_channel_target_provider_for_channels(
-        install: &str,
-        scope: &TurnScope,
-        channel_ids: &[&str],
-    ) -> Arc<crate::slack::slack_outbound_targets::SlackHostBetaOutboundTargetProvider> {
         use crate::slack::slack_channel_routes::InMemorySlackChannelRouteStore;
         use crate::slack::slack_outbound_targets::{
             InMemorySlackPersonalDmTargetStore, SlackConfiguredChannelRoute,
             SlackHostBetaOutboundTargetProvider, SlackOutboundTargetProviderConfig,
         };
-        let owner = scope
-            .explicit_owner_user_id()
-            .cloned()
-            .expect("test scope has owner");
         Arc::new(SlackHostBetaOutboundTargetProvider::new(
             SlackOutboundTargetProviderConfig {
                 tenant_id: scope.tenant_id.clone(),
@@ -3854,12 +3842,13 @@ mod tests {
                 project_id: scope.project_id.clone(),
                 installation_id: AdapterInstallationId::new(install).expect("installation id"),
                 team_id: crate::slack::slack_serve::SlackTeamId::new("T123"),
-                configured_channel_routes: channel_ids
-                    .iter()
-                    .map(|channel_id| {
-                        SlackConfiguredChannelRoute::new((*channel_id).to_string(), owner.clone())
-                    })
-                    .collect(),
+                configured_channel_routes: vec![SlackConfiguredChannelRoute::new(
+                    channel_id.to_string(),
+                    scope
+                        .explicit_owner_user_id()
+                        .cloned()
+                        .expect("test scope has owner"),
+                )],
             },
             Arc::new(InMemorySlackChannelRouteStore::new()),
             Arc::new(InMemorySlackPersonalDmTargetStore::new()),
@@ -3947,115 +3936,6 @@ mod tests {
             !posts[0].contains("D456"),
             "delivery must not fall back to the user-global preference DM: {}",
             posts[0]
-        );
-    }
-
-    /// Two independently persisted automation targets must remain isolated at
-    /// delivery time. This drives the real triggered-run delivery caller twice
-    /// and asserts one Slack side effect per run, in the intended channel.
-    #[tokio::test]
-    async fn two_trigger_fires_preserve_separate_delivery_targets_exactly_once() {
-        let install = "test-install";
-        let scope = personal_turn_scope();
-        let first_run_id = TurnRunId::new();
-        let second_run_id = TurnRunId::new();
-
-        let coordinator = Arc::new(ScriptedTurnCoordinator::with_single_status(
-            TurnStatus::Completed,
-        ));
-        let thread_service = Arc::new(InMemorySessionThreadService::default());
-        seed_finalized_assistant_message(
-            &thread_service,
-            &scope,
-            first_run_id,
-            "First routine result",
-        )
-        .await;
-        seed_finalized_assistant_message(
-            &thread_service,
-            &scope,
-            second_run_id,
-            "Second routine result",
-        )
-        .await;
-
-        let outbound = Arc::new(InMemoryOutboundStateStore::default());
-        let egress = Arc::new(FakeProtocolHttpEgress::new(vec!["slack.com".to_string()]));
-        egress.allow_credential_handle("slack_bot_token");
-        for (channel, ts) in [("C789", "1234.1"), ("C987", "1234.2")] {
-            egress.program_response(
-                "slack.com",
-                Ok(EgressResponse::new(200, slack_post_ok_json(channel, ts))),
-            );
-        }
-
-        let delivery_store = Arc::new(InMemoryTriggeredRunDeliveryStore::default());
-        let route_store = Arc::new(InMemoryDeliveredGateRouteStore::default());
-        let services = make_services(
-            coordinator,
-            thread_service,
-            egress.clone(),
-            outbound,
-            install,
-        );
-        let settings = SlackFinalReplyDeliverySettings {
-            poll_interval: std::time::Duration::ZERO,
-            max_wait: std::time::Duration::from_secs(5),
-            max_concurrent_deliveries: NonZeroUsize::new(1).unwrap(),
-            max_pending_deliveries: NonZeroUsize::new(8).unwrap(),
-        };
-        let driver =
-            TriggeredRunDeliveryDriver::with_settings(
-                services,
-                settings,
-                delivery_store.clone(),
-                route_store,
-                scope.agent_id.clone().expect("test scope has agent"),
-            )
-            .with_outbound_target_provider(
-                shared_channel_target_provider_for_channels(install, &scope, &["C789", "C987"]),
-            );
-
-        for (run_id, channel) in [(first_run_id, "C789"), (second_run_id, "C987")] {
-            let mut fire = minimal_trigger_fire(None);
-            fire.delivery_target = Some(
-                ironclaw_triggers::TriggerDeliveryTargetId::new(format!(
-                    "slack:shared-channel:T123:{channel}"
-                ))
-                .expect("delivery target id"),
-            );
-            driver
-                .on_trigger_submitted(fire, run_id, scope.clone())
-                .await;
-            let record = wait_for_delivery_record(&delivery_store, run_id).await;
-            assert_eq!(record.outcome, TriggeredRunDeliveryOutcomeKind::Delivered);
-        }
-
-        let posts = egress
-            .calls()
-            .into_iter()
-            .filter(|call| call.path == "/api/chat.postMessage")
-            .map(|call| {
-                serde_json::from_slice::<serde_json::Value>(&call.body)
-                    .expect("Slack post body is JSON")
-            })
-            .collect::<Vec<_>>();
-        assert_eq!(posts.len(), 2, "one delivery post per trigger fire");
-        assert_eq!(
-            posts
-                .iter()
-                .filter(|body| body["channel"] == "C789")
-                .count(),
-            1,
-            "first target must receive exactly one routine result"
-        );
-        assert_eq!(
-            posts
-                .iter()
-                .filter(|body| body["channel"] == "C987")
-                .count(),
-            1,
-            "second target must receive exactly one routine result"
         );
     }
 

--- a/crates/ironclaw_reborn_composition/src/slack/slack_delivery.rs
+++ b/crates/ironclaw_reborn_composition/src/slack/slack_delivery.rs
@@ -3830,11 +3830,23 @@ mod tests {
         scope: &TurnScope,
         channel_id: &str,
     ) -> Arc<crate::slack::slack_outbound_targets::SlackHostBetaOutboundTargetProvider> {
+        shared_channel_target_provider_for_channels(install, scope, &[channel_id])
+    }
+
+    fn shared_channel_target_provider_for_channels(
+        install: &str,
+        scope: &TurnScope,
+        channel_ids: &[&str],
+    ) -> Arc<crate::slack::slack_outbound_targets::SlackHostBetaOutboundTargetProvider> {
         use crate::slack::slack_channel_routes::InMemorySlackChannelRouteStore;
         use crate::slack::slack_outbound_targets::{
             InMemorySlackPersonalDmTargetStore, SlackConfiguredChannelRoute,
             SlackHostBetaOutboundTargetProvider, SlackOutboundTargetProviderConfig,
         };
+        let owner = scope
+            .explicit_owner_user_id()
+            .cloned()
+            .expect("test scope has owner");
         Arc::new(SlackHostBetaOutboundTargetProvider::new(
             SlackOutboundTargetProviderConfig {
                 tenant_id: scope.tenant_id.clone(),
@@ -3842,13 +3854,12 @@ mod tests {
                 project_id: scope.project_id.clone(),
                 installation_id: AdapterInstallationId::new(install).expect("installation id"),
                 team_id: crate::slack::slack_serve::SlackTeamId::new("T123"),
-                configured_channel_routes: vec![SlackConfiguredChannelRoute::new(
-                    channel_id.to_string(),
-                    scope
-                        .explicit_owner_user_id()
-                        .cloned()
-                        .expect("test scope has owner"),
-                )],
+                configured_channel_routes: channel_ids
+                    .iter()
+                    .map(|channel_id| {
+                        SlackConfiguredChannelRoute::new((*channel_id).to_string(), owner.clone())
+                    })
+                    .collect(),
             },
             Arc::new(InMemorySlackChannelRouteStore::new()),
             Arc::new(InMemorySlackPersonalDmTargetStore::new()),
@@ -3936,6 +3947,115 @@ mod tests {
             !posts[0].contains("D456"),
             "delivery must not fall back to the user-global preference DM: {}",
             posts[0]
+        );
+    }
+
+    /// Two independently persisted automation targets must remain isolated at
+    /// delivery time. This drives the real triggered-run delivery caller twice
+    /// and asserts one Slack side effect per run, in the intended channel.
+    #[tokio::test]
+    async fn two_trigger_fires_preserve_separate_delivery_targets_exactly_once() {
+        let install = "test-install";
+        let scope = personal_turn_scope();
+        let first_run_id = TurnRunId::new();
+        let second_run_id = TurnRunId::new();
+
+        let coordinator = Arc::new(ScriptedTurnCoordinator::with_single_status(
+            TurnStatus::Completed,
+        ));
+        let thread_service = Arc::new(InMemorySessionThreadService::default());
+        seed_finalized_assistant_message(
+            &thread_service,
+            &scope,
+            first_run_id,
+            "First routine result",
+        )
+        .await;
+        seed_finalized_assistant_message(
+            &thread_service,
+            &scope,
+            second_run_id,
+            "Second routine result",
+        )
+        .await;
+
+        let outbound = Arc::new(InMemoryOutboundStateStore::default());
+        let egress = Arc::new(FakeProtocolHttpEgress::new(vec!["slack.com".to_string()]));
+        egress.allow_credential_handle("slack_bot_token");
+        for (channel, ts) in [("C789", "1234.1"), ("C987", "1234.2")] {
+            egress.program_response(
+                "slack.com",
+                Ok(EgressResponse::new(200, slack_post_ok_json(channel, ts))),
+            );
+        }
+
+        let delivery_store = Arc::new(InMemoryTriggeredRunDeliveryStore::default());
+        let route_store = Arc::new(InMemoryDeliveredGateRouteStore::default());
+        let services = make_services(
+            coordinator,
+            thread_service,
+            egress.clone(),
+            outbound,
+            install,
+        );
+        let settings = SlackFinalReplyDeliverySettings {
+            poll_interval: std::time::Duration::ZERO,
+            max_wait: std::time::Duration::from_secs(5),
+            max_concurrent_deliveries: NonZeroUsize::new(1).unwrap(),
+            max_pending_deliveries: NonZeroUsize::new(8).unwrap(),
+        };
+        let driver =
+            TriggeredRunDeliveryDriver::with_settings(
+                services,
+                settings,
+                delivery_store.clone(),
+                route_store,
+                scope.agent_id.clone().expect("test scope has agent"),
+            )
+            .with_outbound_target_provider(
+                shared_channel_target_provider_for_channels(install, &scope, &["C789", "C987"]),
+            );
+
+        for (run_id, channel) in [(first_run_id, "C789"), (second_run_id, "C987")] {
+            let mut fire = minimal_trigger_fire(None);
+            fire.delivery_target = Some(
+                ironclaw_triggers::TriggerDeliveryTargetId::new(format!(
+                    "slack:shared-channel:T123:{channel}"
+                ))
+                .expect("delivery target id"),
+            );
+            driver
+                .on_trigger_submitted(fire, run_id, scope.clone())
+                .await;
+            let record = wait_for_delivery_record(&delivery_store, run_id).await;
+            assert_eq!(record.outcome, TriggeredRunDeliveryOutcomeKind::Delivered);
+        }
+
+        let posts = egress
+            .calls()
+            .into_iter()
+            .filter(|call| call.path == "/api/chat.postMessage")
+            .map(|call| {
+                serde_json::from_slice::<serde_json::Value>(&call.body)
+                    .expect("Slack post body is JSON")
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(posts.len(), 2, "one delivery post per trigger fire");
+        assert_eq!(
+            posts
+                .iter()
+                .filter(|body| body["channel"] == "C789")
+                .count(),
+            1,
+            "first target must receive exactly one routine result"
+        );
+        assert_eq!(
+            posts
+                .iter()
+                .filter(|body| body["channel"] == "C987")
+                .count(),
+            1,
+            "second target must receive exactly one routine result"
         );
     }
 

--- a/tests/e2e/CLAUDE.md
+++ b/tests/e2e/CLAUDE.md
@@ -97,8 +97,8 @@ full-path Emulate tests still start the legacy gateway binary.
 
 | File | What it tests |
 |------|--------------|
-| `test_emulate_reborn_provider_contracts.py` | Reborn Emulate fixture contracts: Google/Slack/GitHub seeded reads + stateful writes |
-| `test_reborn_emulate_full_path.py` | Install/auth a first-party extension, drive a scripted tool call, assert provider state via Emulate |
+| `test_emulate_reborn_provider_contracts.py` | Reborn Emulate fixture contracts: Google account isolation and stateful reads/writes, Slack QA 9/10 provider shapes and strict-scope failures, and GitHub identity plus positive/negative state transitions |
+| `test_reborn_emulate_full_path.py` | Install/auth a first-party extension, drive scripted Gmail/Calendar/Drive/GitHub tool calls, assert provider state and cleanup via Emulate |
 | `test_oauth_refresh.py` | Hosted Gmail OAuth refresh: expire token, real tool call, refresh via mock proxy without leaking `client_secret` |
 | `test_extension_uninstall_cleanup.py` | Install/remove for WASM tools/channels, shared Google tools, MCP; uninstall deletes secrets, preserves shared creds |
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -59,7 +59,7 @@ Then Playwright drives a headless Chromium browser against the gateway, making D
 | `test_extensions.py` | Extensions tab: install, remove, configure, OAuth, auth card, activate |
 | `test_oauth_refresh.py` | Hosted Gmail/MCP OAuth refresh; the Gmail path refreshes through the proxy and reads seeded Gmail data from Emulate |
 | `test_emulate_reborn_provider_contracts.py` | Emulate provider contracts for Reborn-backed Google Gmail/Calendar/Drive reads, writes, missing resources, and account isolation; Slack QA 9/10 channel/thread/DM routing, strict-scope failures, profiles, mentions, and identity shapes; and GitHub identity, negative-result, repo/issue/PR/search/branch/git-object/release/fork/action-route surfaces |
-| `test_reborn_emulate_full_path.py` | Full-path Reborn + Emulate coverage: install/auth a first-party extension, drive scripted Gmail/Calendar/Drive/GitHub tool calls, and assert provider-side state and cleanup |
+| `test_reborn_emulate_full_path.py` | Full-path IronClaw + Emulate coverage: install/auth extensions, drive scripted Gmail/Calendar/Drive/GitHub/Slack calls, assert provider-side state, and exercise GitHub→Slack, Calendar+Drive→Slack, Gmail→Slack, and Slack→Drive→Slack dispatch |
 
 ## Reborn coverage gate
 
@@ -85,13 +85,15 @@ Emulate coverage is intentionally limited to provider APIs that match Reborn
 features already present in the codebase:
 
 - Google: Gmail, Calendar, and Drive seeded reads plus Gmail send, Calendar
-  event create/delete, and Drive upload/readback.
+  event create/delete, and Drive upload/update/readback with two isolated users.
 - Slack: auth, conversations, channel/thread/DM delivery, reactions, user
-  lookup, and readback.
+  lookup, membership, self-authored/last-sent identity, missing email/scope,
+  mention encoding, two isolated DM targets, and exact-count readback.
 - GitHub: authenticated user, repo create/list/metadata, fork list/create,
   release create/latest/list, issue create/read/comment/list/search, PR
   create/read/list/files/review/comment/merge, search, branch/ref mutation,
-  Git blob/tree/commit read/write, and Actions workflow/run route readback.
+  Git blob/tree/commit read/write, Actions workflow/run route readback, two
+  repositories with distinct latest releases, and private-account isolation.
 
 Google Docs, Sheets, and Slides exist as first-party extension assets, but
 Emulate 0.7.0 does not expose those API families directly. Cover those with
@@ -110,6 +112,15 @@ Reborn + Emulate tests should use `hosted_google_emulate_server` or a matching
 provider fixture, install/auth the extension through IronClaw, drive
 `/api/chat/send` with the scripted mock LLM, and assert provider state through
 Emulate readback.
+
+Do not duplicate account binding, refresh/reconnect, malformed-provider,
+duplicate-inbound, or repeated-delivery contracts as provider-only fixtures.
+Those are caller/runtime properties and remain covered at their existing
+hermetic seams (`runtime_credentials`, `gsuite_core`,
+`github_wasm_runtime_contract`, `idempotent_replay`, trigger/outbound
+integration tests, and `test_v2_auth_oauth_matrix.py`). Emulate supplies the
+provider state for full-path flows; it is not an OAuth authority or a fault
+injection proxy.
 
 ### Manual QA mapping
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -58,8 +58,8 @@ Then Playwright drives a headless Chromium browser against the gateway, making D
 | `test_html_injection.py` | HTML injection security |
 | `test_extensions.py` | Extensions tab: install, remove, configure, OAuth, auth card, activate |
 | `test_oauth_refresh.py` | Hosted Gmail/MCP OAuth refresh; the Gmail path refreshes through the proxy and reads seeded Gmail data from Emulate |
-| `test_emulate_reborn_provider_contracts.py` | Emulate provider contracts for Reborn-backed Google Gmail/Calendar/Drive reads and writes, Slack channel/thread/DM delivery plus reactions/user lookup, and GitHub repo/issue/PR/search/branch/git-object/release/fork/action-route surfaces |
-| `test_reborn_emulate_full_path.py` | Full-path Reborn + Emulate coverage: install/auth a first-party extension, drive a scripted model tool call, and assert provider-side Emulate state |
+| `test_emulate_reborn_provider_contracts.py` | Emulate provider contracts for Reborn-backed Google Gmail/Calendar/Drive reads, writes, missing resources, and account isolation; Slack QA 9/10 channel/thread/DM routing, strict-scope failures, profiles, mentions, and identity shapes; and GitHub identity, negative-result, repo/issue/PR/search/branch/git-object/release/fork/action-route surfaces |
+| `test_reborn_emulate_full_path.py` | Full-path Reborn + Emulate coverage: install/auth a first-party extension, drive scripted Gmail/Calendar/Drive/GitHub tool calls, and assert provider-side state and cleanup |
 
 ## Reborn coverage gate
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1012,6 +1012,42 @@ async def hosted_github_emulate_server(
 
 
 @pytest.fixture(scope="session")
+async def hosted_provider_emulate_server(
+    ironclaw_binary,
+    mock_llm_server,
+    emulate_google_server,
+    emulate_github_server,
+    emulate_slack_server,
+    wasm_tools_dir,
+):
+    """Start hosted mode with Google, GitHub, and Slack routed to Emulate."""
+    rewrite_map = {
+        "gmail.googleapis.com": emulate_google_server["url"],
+        "www.googleapis.com": emulate_google_server["url"],
+        "api.github.com": emulate_github_server["url"],
+        "slack.com": emulate_slack_server["url"],
+    }
+    async for server in _run_hosted_oauth_refresh_server(
+        ironclaw_binary,
+        mock_llm_server,
+        wasm_tools_dir,
+        extra_env={
+            "IRONCLAW_TEST_HTTP_REWRITE_MAP": json.dumps(rewrite_map),
+            "GITHUB_OAUTH_CLIENT_ID": "hosted-github-client-id",
+            "GITHUB_OAUTH_CLIENT_SECRET": "hosted-github-client-secret",
+            "SLACK_OAUTH_CLIENT_ID": "hosted-slack-client-id",
+            "SLACK_OAUTH_CLIENT_SECRET": "hosted-slack-client-secret",
+        },
+        extra_result={
+            "emulate_google_url": emulate_google_server["url"],
+            "emulate_github_url": emulate_github_server["url"],
+            "emulate_slack_url": emulate_slack_server["url"],
+        },
+    ):
+        yield server
+
+
+@pytest.fixture(scope="session")
 async def hosted_google_oauth_refresh_server(hosted_google_emulate_server):
     """Compatibility fixture for hosted Gmail OAuth refresh regression tests."""
     yield hosted_google_emulate_server

--- a/tests/e2e/emulate_provider.py
+++ b/tests/e2e/emulate_provider.py
@@ -11,16 +11,16 @@ from helpers import (
 )
 
 
-def google_headers() -> dict[str, str]:
-    return {"Authorization": f"Bearer {EMULATE_GOOGLE_BEARER}"}
+def google_headers(token: str = EMULATE_GOOGLE_BEARER) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
 
 
-def slack_headers() -> dict[str, str]:
-    return {"Authorization": f"Bearer {EMULATE_SLACK_BEARER}"}
+def slack_headers(token: str = EMULATE_SLACK_BEARER) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
 
 
-def github_headers() -> dict[str, str]:
-    return {"Authorization": f"Bearer {EMULATE_GITHUB_BEARER}"}
+def github_headers(token: str = EMULATE_GITHUB_BEARER) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
 
 
 def gmail_header(message: dict, name: str) -> str | None:
@@ -46,15 +46,19 @@ async def slack_post(
     base_url: str,
     method: str,
     payload: dict | None = None,
+    *,
+    token: str = EMULATE_SLACK_BEARER,
+    expect_ok: bool = True,
 ) -> dict:
     response = await client.post(
         f"{base_url}/api/{method}",
-        headers=slack_headers(),
+        headers=slack_headers(token),
         json=payload or {},
     )
     response.raise_for_status()
     body = response.json()
-    assert body.get("ok") is True, f"Slack {method} failed: {body}"
+    if expect_ok:
+        assert body.get("ok") is True, f"Slack {method} failed: {body}"
     return body
 
 

--- a/tests/e2e/fixtures/emulate/github.yaml
+++ b/tests/e2e/fixtures/emulate/github.yaml
@@ -4,12 +4,20 @@ tokens:
     scopes:
       - repo
       - user
+  ghp_emulate_github_secondary_token:
+    login: reborn-reviewer
+    scopes:
+      - repo
+      - user
 
 github:
   users:
     - login: reborn-dev
       name: Reborn Dev
       email: reborn-dev@example.com
+    - login: reborn-reviewer
+      name: Reborn Reviewer
+      email: reborn-reviewer@example.com
   orgs:
     - login: nearai
       name: NEAR AI

--- a/tests/e2e/fixtures/emulate/google_gmail.yaml
+++ b/tests/e2e/fixtures/emulate/google_gmail.yaml
@@ -17,11 +17,22 @@ tokens:
       - https://www.googleapis.com/auth/calendar.events
       - https://www.googleapis.com/auth/drive.readonly
       - https://www.googleapis.com/auth/drive.file
+  emulate-google-secondary-token:
+    login: secondary.google@example.com
+    scopes:
+      - https://www.googleapis.com/auth/gmail.readonly
+      - https://www.googleapis.com/auth/gmail.send
+      - https://www.googleapis.com/auth/calendar.readonly
+      - https://www.googleapis.com/auth/calendar.events
+      - https://www.googleapis.com/auth/drive.readonly
+      - https://www.googleapis.com/auth/drive.file
 
 google:
   users:
     - email: e2e.google@example.com
       name: E2E Google User
+    - email: secondary.google@example.com
+      name: Secondary Google User
   messages:
     - id: msg_emulate_unread
       user_email: e2e.google@example.com
@@ -43,11 +54,29 @@ google:
       label_ids:
         - INBOX
         - UNREAD
+    - id: msg_emulate_secondary_private
+      user_email: secondary.google@example.com
+      from: private-sender@example.com
+      to: secondary.google@example.com
+      subject: Secondary account private message
+      body_text: This message must never appear in the primary account.
+      date: "2026-06-22T11:50:00.000Z"
+      label_ids:
+        - INBOX
+        - UNREAD
   calendars:
     - id: primary
       user_email: e2e.google@example.com
       summary: E2E Primary Calendar
       description: Calendar data seeded by Emulate for Reborn QA.
+      time_zone: UTC
+      primary: true
+      selected: true
+      access_role: owner
+    - id: primary
+      user_email: secondary.google@example.com
+      summary: Secondary Primary Calendar
+      description: Isolated calendar for the secondary Emulate identity.
       time_zone: UTC
       primary: true
       selected: true
@@ -73,6 +102,13 @@ google:
       attendees:
         - email: buyer@pepsico.example
           display_name: PepsiCo Buyer
+    - id: evt_secondary_private
+      user_email: secondary.google@example.com
+      calendar_id: primary
+      summary: Secondary private planning
+      description: This event belongs only to the secondary identity.
+      start_date_time: "2026-06-22T16:00:00.000Z"
+      end_date_time: "2026-06-22T16:30:00.000Z"
   drive_items:
     - id: drv_reborn_qa_brief
       user_email: e2e.google@example.com
@@ -95,3 +131,10 @@ google:
       parent_google_ids:
         - root
       data: "NEAR AI Strategy: user-owned agents keep credentials and data under user control."
+    - id: drv_secondary_private
+      user_email: secondary.google@example.com
+      name: Secondary Private Brief
+      mime_type: text/plain
+      parent_google_ids:
+        - root
+      data: "This Drive item belongs only to the secondary identity."

--- a/tests/e2e/fixtures/emulate/slack.yaml
+++ b/tests/e2e/fixtures/emulate/slack.yaml
@@ -11,6 +11,13 @@ slack:
       real_name: QA Reviewer
       email: qa-reviewer@example.com
       presence: active
+      profile:
+        title: Release reviewer
+        status_text: Reviewing the release candidate
+        status_emoji: ":mag:"
+    - name: no-email-user
+      real_name: No Email User
+      presence: away
   channels:
     - name: reborn-alerts
       topic: Reborn alert delivery
@@ -28,6 +35,17 @@ slack:
         - im:write
         - im:history
         - users:read
+        - users.profile:read
+        - users.profile:write
+        - channels:join
+        - channels:manage
+        - files:read
+        - files:write
         - reactions:read
         - reactions:write
+    - token: emulate-slack-limited-token
+      user: qa-reviewer
+      scopes:
+        - users:read
+        - users.profile:read
   strict_scopes: true

--- a/tests/e2e/helpers.py
+++ b/tests/e2e/helpers.py
@@ -215,8 +215,11 @@ AUTH_TOKEN = "e2e-test-token"
 OWNER_SCOPE_ID = "e2e-owner-scope"
 HTTP_WEBHOOK_SECRET = "e2e-http-webhook-secret"
 EMULATE_GOOGLE_BEARER = "mock-refreshed-access-token"
+EMULATE_GOOGLE_SECONDARY_BEARER = "emulate-google-secondary-token"
 EMULATE_SLACK_BEARER = "emulate-slack-token"
+EMULATE_SLACK_LIMITED_BEARER = "emulate-slack-limited-token"
 EMULATE_GITHUB_BEARER = "ghp_emulate_github_token"
+EMULATE_GITHUB_SECONDARY_BEARER = "ghp_emulate_github_secondary_token"
 
 # Bearer token for the Reborn WebUI v2 surface (`ironclaw-reborn serve`).
 # Must be >= 32 bytes: `serve` also uses this value as the SSO session-signing

--- a/tests/e2e/mock_llm.py
+++ b/tests/e2e/mock_llm.py
@@ -113,6 +113,7 @@ CANNED_RESPONSES = [
 ]
 DEFAULT_RESPONSE = "I understand your request."
 EMULATE_GITHUB_BEARER = "ghp_emulate_github_token"
+EMULATE_SLACK_BEARER = "emulate-slack-token"
 
 TOOL_FAILURE_TRIGGER = re.compile(r"issue 1780 tool failure", re.IGNORECASE)
 TRUNCATED_TOOL_CALL_TRIGGER = re.compile(
@@ -138,6 +139,31 @@ GCAL_LIFECYCLE_TRIGGER = re.compile(
 )
 GDRIVE_UPLOAD_LIFECYCLE_TRIGGER = re.compile(
     r"upload a google drive file titled",
+    re.IGNORECASE,
+)
+SLACK_DELIVERY_LIFECYCLE_TRIGGER = re.compile(
+    r"send slack canary (?P<marker>\S+) to (?P<channel>[A-Z0-9]+)",
+    re.IGNORECASE,
+)
+GITHUB_RELEASE_SLACK_TRIGGER = re.compile(
+    r"notify slack channel (?P<channel>[A-Z0-9]+) about the latest release in "
+    r"(?P<owner>[A-Za-z0-9_.-]+)/(?P<repo>[A-Za-z0-9_.-]+) with marker "
+    r"(?P<marker>\S+)",
+    re.IGNORECASE,
+)
+CALENDAR_DRIVE_SLACK_TRIGGER = re.compile(
+    r"prepare meeting and notify slack channel (?P<channel>[A-Z0-9]+) with marker "
+    r"(?P<marker>\S+)",
+    re.IGNORECASE,
+)
+GMAIL_SLACK_TRIGGER = re.compile(
+    r"check unread gmail and notify slack channel (?P<channel>[A-Z0-9]+) with "
+    r"marker (?P<marker>\S+)",
+    re.IGNORECASE,
+)
+SLACK_DRIVE_SLACK_TRIGGER = re.compile(
+    r"read slack channel (?P<source>[A-Z0-9]+), look up drive, and notify "
+    r"(?P<target>[A-Z0-9]+) with marker (?P<marker>\S+)",
     re.IGNORECASE,
 )
 NOTION_SEARCH_LIFECYCLE_TRIGGER = re.compile(
@@ -2088,6 +2114,176 @@ def match_special_response(
             "text": "google_drive lifecycle complete. File uploaded and downloaded.",
         }
 
+    # ── Lifecycle canary: Slack send through the real extension ─────────
+    m = SLACK_DELIVERY_LIFECYCLE_TRIGGER.search(last_user)
+    if m and has_tools:
+        tool_results = _find_named_tool_results(messages, "slack_tool")
+        if not tool_results:
+            return {
+                "type": "tool_call",
+                "tool_call": {
+                    "tool_name": "slack_tool",
+                    "arguments": {
+                        "action": "send_message",
+                        "channel": m.group("channel"),
+                        "text": m.group("marker"),
+                    },
+                },
+            }
+        return {
+            "type": "text",
+            "text": "slack delivery lifecycle complete. Message sent exactly once.",
+        }
+
+    # ── Cross-provider canary: GitHub release → Slack ───────────────────
+    m = GITHUB_RELEASE_SLACK_TRIGGER.search(last_user)
+    if m and has_tools:
+        github_results = _find_named_tool_results(messages, "github")
+        slack_results = _find_named_tool_results(messages, "slack_tool")
+        if not github_results:
+            return {
+                "type": "tool_call",
+                "tool_call": {
+                    "tool_name": "github",
+                    "arguments": {
+                        "action": "list_releases",
+                        "owner": m.group("owner"),
+                        "repo": m.group("repo"),
+                        "limit": 1,
+                    },
+                },
+            }
+        if not slack_results:
+            return {
+                "type": "tool_call",
+                "tool_call": {
+                    "tool_name": "slack_tool",
+                    "arguments": {
+                        "action": "send_message",
+                        "channel": m.group("channel"),
+                        "text": m.group("marker"),
+                    },
+                },
+            }
+        return {
+            "type": "text",
+            "text": "github release to slack lifecycle complete.",
+        }
+
+    # ── Cross-provider canary: Calendar + Drive → Slack ─────────────────
+    m = CALENDAR_DRIVE_SLACK_TRIGGER.search(last_user)
+    if m and has_tools:
+        if not _find_named_tool_results(messages, "google_calendar"):
+            return {
+                "type": "tool_call",
+                "tool_call": {
+                    "tool_name": "google_calendar",
+                    "arguments": {
+                        "action": "list_events",
+                        "calendar_id": "primary",
+                        "time_min": "2026-01-01T00:00:00Z",
+                        "max_results": 5,
+                        "query": "PepsiCo",
+                    },
+                },
+            }
+        if not _find_named_tool_results(messages, "google_drive"):
+            return {
+                "type": "tool_call",
+                "tool_call": {
+                    "tool_name": "google_drive",
+                    "arguments": {
+                        "action": "list_files",
+                        "query": "name contains 'PepsiCo'",
+                        "page_size": 5,
+                    },
+                },
+            }
+        if not _find_named_tool_results(messages, "slack_tool"):
+            return {
+                "type": "tool_call",
+                "tool_call": {
+                    "tool_name": "slack_tool",
+                    "arguments": {
+                        "action": "send_message",
+                        "channel": m.group("channel"),
+                        "text": m.group("marker"),
+                    },
+                },
+            }
+        return {"type": "text", "text": "calendar drive to slack complete."}
+
+    # ── Cross-provider canary: Gmail → Slack ────────────────────────────
+    m = GMAIL_SLACK_TRIGGER.search(last_user)
+    if m and has_tools:
+        if not _find_named_tool_results(messages, "gmail"):
+            return {
+                "type": "tool_call",
+                "tool_call": {
+                    "tool_name": "gmail",
+                    "arguments": {
+                        "action": "list_messages",
+                        "query": "is:unread",
+                        "max_results": 5,
+                    },
+                },
+            }
+        if not _find_named_tool_results(messages, "slack_tool"):
+            return {
+                "type": "tool_call",
+                "tool_call": {
+                    "tool_name": "slack_tool",
+                    "arguments": {
+                        "action": "send_message",
+                        "channel": m.group("channel"),
+                        "text": m.group("marker"),
+                    },
+                },
+            }
+        return {"type": "text", "text": "gmail to slack complete."}
+
+    # ── Cross-provider canary: Slack → Drive → Slack ────────────────────
+    m = SLACK_DRIVE_SLACK_TRIGGER.search(last_user)
+    if m and has_tools:
+        slack_results = _find_named_tool_results(messages, "slack_tool")
+        if not slack_results:
+            return {
+                "type": "tool_call",
+                "tool_call": {
+                    "tool_name": "slack_tool",
+                    "arguments": {
+                        "action": "get_channel_history",
+                        "channel": m.group("source"),
+                        "limit": 10,
+                    },
+                },
+            }
+        if not _find_named_tool_results(messages, "google_drive"):
+            return {
+                "type": "tool_call",
+                "tool_call": {
+                    "tool_name": "google_drive",
+                    "arguments": {
+                        "action": "list_files",
+                        "query": "name contains 'Reborn QA Brief'",
+                        "page_size": 5,
+                    },
+                },
+            }
+        if len(slack_results) == 1:
+            return {
+                "type": "tool_call",
+                "tool_call": {
+                    "tool_name": "slack_tool",
+                    "arguments": {
+                        "action": "send_message",
+                        "channel": m.group("target"),
+                        "text": m.group("marker"),
+                    },
+                },
+            }
+        return {"type": "text", "text": "slack drive to slack complete."}
+
     # ── Lifecycle canary: Notion search → search again ────────────────────
     if NOTION_SEARCH_LIFECYCLE_TRIGGER.search(last_user) and has_tools:
         tool_results = _find_tool_results(messages)
@@ -2191,6 +2387,11 @@ async def chat_completions(request: web.Request) -> web.StreamResponse:
         GMAIL_ROUNDTRIP_TRIGGER,
         GCAL_LIFECYCLE_TRIGGER,
         GDRIVE_UPLOAD_LIFECYCLE_TRIGGER,
+        SLACK_DELIVERY_LIFECYCLE_TRIGGER,
+        GITHUB_RELEASE_SLACK_TRIGGER,
+        CALENDAR_DRIVE_SLACK_TRIGGER,
+        GMAIL_SLACK_TRIGGER,
+        SLACK_DRIVE_SLACK_TRIGGER,
         NOTION_SEARCH_LIFECYCLE_TRIGGER,
     ):
         if special and _conversation_has_user_trigger(messages, lifecycle_trigger):
@@ -2519,6 +2720,13 @@ def _is_github_token_url(url: str) -> bool:
     return "github.com/login/oauth/access_token" in url.lower()
 
 
+def _is_slack_token_url(url: str) -> bool:
+    if not url:
+        return False
+    lowered = url.lower()
+    return "slack.com/api/oauth.v2.access" in lowered
+
+
 async def oauth_exchange(request: web.Request) -> web.Response:
     """Mock OAuth token exchange proxy for E2E tests.
 
@@ -2566,6 +2774,14 @@ async def oauth_exchange(request: web.Request) -> web.Response:
             access_token_field: EMULATE_GITHUB_BEARER,
             "refresh_token": "mock-github-refresh-token",
             "expires_in": 3600,
+        })
+
+    if _is_slack_token_url(data.get("token_url", "")):
+        return web.json_response({
+            access_token_field: EMULATE_SLACK_BEARER,
+            "token_type": "bot",
+            "scope": "chat:write,channels:read,channels:history,users:read",
+            "bot_user_id": "B_EMULATE_REBORN_BOT",
         })
 
     return web.json_response({

--- a/tests/e2e/scenarios/test_emulate_reborn_provider_contracts.py
+++ b/tests/e2e/scenarios/test_emulate_reborn_provider_contracts.py
@@ -12,10 +12,16 @@ import httpx
 
 from emulate_provider import (
     github_json,
+    github_headers,
     gmail_header,
     google_headers,
     raw_mime,
     slack_post,
+)
+from helpers import (
+    EMULATE_GITHUB_SECONDARY_BEARER,
+    EMULATE_GOOGLE_SECONDARY_BEARER,
+    EMULATE_SLACK_LIMITED_BEARER,
 )
 
 
@@ -718,3 +724,219 @@ async def test_emulate_github_covers_reborn_repo_surfaces(emulate_github_server)
             "/repos/nearai/ironclaw/actions/workflows",
         )
         assert workflows["workflows"] == []
+
+
+async def test_emulate_google_keeps_seeded_accounts_isolated(emulate_google_server):
+    """Provider fixtures must not make cross-account reads pass vacuously."""
+    base_url = emulate_google_server["url"]
+    primary = google_headers()
+    secondary = google_headers(EMULATE_GOOGLE_SECONDARY_BEARER)
+
+    async with httpx.AsyncClient(timeout=10) as client:
+        primary_messages = await client.get(
+            f"{base_url}/gmail/v1/users/me/messages",
+            headers=primary,
+        )
+        secondary_messages = await client.get(
+            f"{base_url}/gmail/v1/users/me/messages",
+            headers=secondary,
+        )
+        primary_messages.raise_for_status()
+        secondary_messages.raise_for_status()
+        primary_ids = {item["id"] for item in primary_messages.json()["messages"]}
+        secondary_ids = {item["id"] for item in secondary_messages.json()["messages"]}
+        assert "msg_emulate_secondary_private" not in primary_ids
+        assert "msg_emulate_secondary_private" in secondary_ids
+        assert "msg_emulate_unread" in primary_ids
+        assert "msg_emulate_unread" not in secondary_ids
+
+        primary_events = await client.get(
+            f"{base_url}/calendar/v3/calendars/primary/events",
+            headers=primary,
+        )
+        secondary_events = await client.get(
+            f"{base_url}/calendar/v3/calendars/primary/events",
+            headers=secondary,
+        )
+        primary_events.raise_for_status()
+        secondary_events.raise_for_status()
+        primary_event_ids = {item["id"] for item in primary_events.json()["items"]}
+        secondary_event_ids = {item["id"] for item in secondary_events.json()["items"]}
+        assert "evt_secondary_private" not in primary_event_ids
+        assert "evt_secondary_private" in secondary_event_ids
+
+        primary_files = await client.get(
+            f"{base_url}/drive/v3/files",
+            headers=primary,
+        )
+        secondary_files = await client.get(
+            f"{base_url}/drive/v3/files",
+            headers=secondary,
+        )
+        primary_files.raise_for_status()
+        secondary_files.raise_for_status()
+        primary_file_ids = {item["id"] for item in primary_files.json()["files"]}
+        secondary_file_ids = {item["id"] for item in secondary_files.json()["files"]}
+        assert "drv_secondary_private" not in primary_file_ids
+        assert "drv_secondary_private" in secondary_file_ids
+
+
+async def test_emulate_google_covers_missing_resource_errors(emulate_google_server):
+    async with httpx.AsyncClient(timeout=10) as client:
+        response = await client.get(
+            f"{emulate_google_server['url']}/gmail/v1/users/me/messages/missing-message",
+            headers=google_headers(),
+        )
+    assert response.status_code == 404, response.text
+
+
+async def test_emulate_slack_covers_qa9_and_qa10_provider_shapes(
+    emulate_slack_server,
+):
+    """Pin the stateful Slack shapes used by the live QA 9/10 assertions."""
+    base_url = emulate_slack_server["url"]
+    async with httpx.AsyncClient(timeout=10) as client:
+        users = await slack_post(client, base_url, "users.list")
+        by_name = {member["name"]: member for member in users["members"]}
+        reviewer = by_name["qa-reviewer"]
+        no_email_user = by_name["no-email-user"]
+
+        profile = await slack_post(
+            client,
+            base_url,
+            "users.profile.get",
+            {"user": reviewer["id"]},
+        )
+        assert profile["profile"]["status_text"] == "Reviewing the release candidate"
+
+        no_email = await slack_post(
+            client,
+            base_url,
+            "users.info",
+            {"user": no_email_user["id"]},
+        )
+        assert not no_email["user"].get("profile", {}).get("email")
+
+        channels = await slack_post(
+            client,
+            base_url,
+            "conversations.list",
+            {"types": "public_channel"},
+        )
+        alerts = next(
+            item for item in channels["channels"] if item["name"] == "reborn-alerts"
+        )
+
+        missing_scope = await slack_post(
+            client,
+            base_url,
+            "chat.postMessage",
+            {"channel": alerts["id"], "text": "must be denied"},
+            token=EMULATE_SLACK_LIMITED_BEARER,
+            expect_ok=False,
+        )
+        assert missing_scope["ok"] is False
+        assert missing_scope["error"] == "missing_scope"
+        assert "chat:write" in missing_scope["needed"]
+
+        dm_channels: dict[str, str] = {}
+        markers = {
+            "qa-reviewer": "QA9 delivery target reviewer",
+            "no-email-user": "QA9 delivery target no-email-user",
+        }
+        for user_name, marker in markers.items():
+            opened = await slack_post(
+                client,
+                base_url,
+                "conversations.open",
+                {"users": by_name[user_name]["id"], "return_im": True},
+            )
+            dm_channel = opened["channel"]["id"]
+            dm_channels[user_name] = dm_channel
+            await slack_post(
+                client,
+                base_url,
+                "chat.postMessage",
+                {"channel": dm_channel, "text": marker},
+            )
+
+        for user_name, marker in markers.items():
+            history = await slack_post(
+                client,
+                base_url,
+                "conversations.history",
+                {"channel": dm_channels[user_name]},
+            )
+            texts = [message["text"] for message in history["messages"]]
+            assert texts.count(marker) == 1
+            assert all(
+                other_marker not in texts
+                for other_marker in markers.values()
+                if other_marker != marker
+            )
+
+        mention_text = f"Release review requested from <@{reviewer['id']}>"
+        mention = await slack_post(
+            client,
+            base_url,
+            "chat.postMessage",
+            {"channel": alerts["id"], "text": mention_text},
+        )
+        assert mention["message"]["text"] == mention_text
+
+        root = await slack_post(
+            client,
+            base_url,
+            "chat.postMessage",
+            {"channel": alerts["id"], "text": "QA10 thread root"},
+        )
+        await slack_post(
+            client,
+            base_url,
+            "chat.postMessage",
+            {
+                "channel": alerts["id"],
+                "thread_ts": root["ts"],
+                "text": "QA10 visible thread reply",
+            },
+        )
+        replies = await slack_post(
+            client,
+            base_url,
+            "conversations.replies",
+            {"channel": alerts["id"], "ts": root["ts"]},
+        )
+        assert [message["text"] for message in replies["messages"]].count(
+            "QA10 visible thread reply"
+        ) == 1
+
+
+async def test_emulate_github_covers_identity_and_negative_results(
+    emulate_github_server,
+):
+    base_url = emulate_github_server["url"]
+    async with httpx.AsyncClient(timeout=10) as client:
+        primary = await github_json(client, base_url, "GET", "/user")
+        secondary = await client.get(
+            f"{base_url}/user",
+            headers=github_headers(EMULATE_GITHUB_SECONDARY_BEARER),
+        )
+        secondary.raise_for_status()
+        assert primary["login"] == "reborn-dev"
+        assert secondary.json()["login"] == "reborn-reviewer"
+
+        missing = await client.get(
+            f"{base_url}/repos/nearai/does-not-exist",
+            headers=github_headers(),
+        )
+        assert missing.status_code == 404
+
+        empty_search = await github_json(
+            client,
+            base_url,
+            "GET",
+            "/search/issues",
+            params={"q": "repo:nearai/ironclaw no-such-emulate-result"},
+        )
+        assert empty_search["total_count"] == 0
+        assert empty_search["items"] == []

--- a/tests/e2e/scenarios/test_emulate_reborn_provider_contracts.py
+++ b/tests/e2e/scenarios/test_emulate_reborn_provider_contracts.py
@@ -911,6 +911,153 @@ async def test_emulate_slack_covers_qa9_and_qa10_provider_shapes(
         ) == 1
 
 
+async def test_emulate_slack_covers_identity_membership_and_last_sent(
+    emulate_slack_server,
+):
+    """Cover the remaining deterministic inputs consumed by Slack transforms."""
+    base_url = emulate_slack_server["url"]
+    async with httpx.AsyncClient(timeout=10) as client:
+        identity = await slack_post(client, base_url, "auth.test")
+        assert identity["user"] == "reborn-user"
+        assert identity["user_id"].startswith("U")
+
+        channels = await slack_post(
+            client,
+            base_url,
+            "conversations.list",
+            {"types": "public_channel"},
+        )
+        alerts = next(
+            channel
+            for channel in channels["channels"]
+            if channel["name"] == "reborn-alerts"
+        )
+        await slack_post(
+            client,
+            base_url,
+            "conversations.join",
+            {"channel": alerts["id"]},
+        )
+        joined_channels = await slack_post(
+            client,
+            base_url,
+            "conversations.list",
+            {"types": "public_channel"},
+        )
+        joined_alerts = next(
+            channel
+            for channel in joined_channels["channels"]
+            if channel["id"] == alerts["id"]
+        )
+        assert joined_alerts["is_member"] is True
+
+        first_marker = "QA10 self-authored earlier message"
+        last_marker = "QA10 self-authored last-sent message"
+        await slack_post(
+            client,
+            base_url,
+            "chat.postMessage",
+            {"channel": alerts["id"], "text": first_marker},
+        )
+        posted = await slack_post(
+            client,
+            base_url,
+            "chat.postMessage",
+            {"channel": alerts["id"], "text": last_marker},
+        )
+        history = await slack_post(
+            client,
+            base_url,
+            "conversations.history",
+            {"channel": alerts["id"], "limit": 10},
+        )
+        matching = [
+            message
+            for message in history["messages"]
+            if message["text"] in {first_marker, last_marker}
+        ]
+        assert matching[0]["text"] == last_marker
+        assert matching[0]["user"] == identity["user_id"]
+        assert posted["message"]["user"] == identity["user_id"]
+
+
+async def test_emulate_google_drive_update_roundtrips(emulate_google_server):
+    """Pin Drive update semantics in addition to create/read coverage."""
+    base_url = emulate_google_server["url"]
+    async with httpx.AsyncClient(timeout=10) as client:
+        renamed = await client.patch(
+            f"{base_url}/drive/v3/files/drv_reborn_qa_brief",
+            headers=google_headers(),
+            json={"name": "Reborn QA Brief Updated"},
+        )
+        renamed.raise_for_status()
+        assert renamed.json()["name"] == "Reborn QA Brief Updated"
+
+        readback = await client.get(
+            f"{base_url}/drive/v3/files/drv_reborn_qa_brief",
+            headers=google_headers(),
+        )
+        readback.raise_for_status()
+        assert readback.json()["name"] == "Reborn QA Brief Updated"
+
+
+async def test_emulate_github_distinguishes_repositories_and_private_accounts(
+    emulate_github_server,
+):
+    base_url = emulate_github_server["url"]
+    async with httpx.AsyncClient(timeout=10) as client:
+        second_repo = await github_json(
+            client,
+            base_url,
+            "POST",
+            "/user/repos",
+            payload={
+                "name": "release-fixture-secondary",
+                "private": True,
+                "auto_init": True,
+            },
+            expected_status=201,
+        )
+        primary_release = await github_json(
+            client,
+            base_url,
+            "POST",
+            "/repos/nearai/ironclaw/releases",
+            payload={"tag_name": "fixture-primary-v2", "name": "Primary v2"},
+            expected_status=201,
+        )
+        secondary_release = await github_json(
+            client,
+            base_url,
+            "POST",
+            f"/repos/{second_repo['full_name']}/releases",
+            payload={"tag_name": "fixture-secondary-v7", "name": "Secondary v7"},
+            expected_status=201,
+        )
+
+        latest_primary = await github_json(
+            client,
+            base_url,
+            "GET",
+            "/repos/nearai/ironclaw/releases/latest",
+        )
+        latest_secondary = await github_json(
+            client,
+            base_url,
+            "GET",
+            f"/repos/{second_repo['full_name']}/releases/latest",
+        )
+        assert latest_primary["id"] == primary_release["id"]
+        assert latest_secondary["id"] == secondary_release["id"]
+        assert latest_primary["tag_name"] != latest_secondary["tag_name"]
+
+        foreign_private = await client.get(
+            f"{base_url}/repos/{second_repo['full_name']}",
+            headers=github_headers(EMULATE_GITHUB_SECONDARY_BEARER),
+        )
+        assert foreign_private.status_code in (403, 404), foreign_private.text
+
+
 async def test_emulate_github_covers_identity_and_negative_results(
     emulate_github_server,
 ):

--- a/tests/e2e/scenarios/test_reborn_emulate_full_path.py
+++ b/tests/e2e/scenarios/test_reborn_emulate_full_path.py
@@ -4,7 +4,13 @@ import uuid
 
 import httpx
 
-from emulate_provider import github_json, gmail_header, google_headers
+from emulate_provider import (
+    github_json,
+    gmail_header,
+    google_headers,
+    slack_post,
+)
+from helpers import EMULATE_SLACK_BEARER, api_post
 from reborn_emulate_harness import (
     complete_oauth_setup,
     completed_tool_results,
@@ -260,3 +266,203 @@ async def test_reborn_gmail_lifecycle_mutates_emulate(
     message = readback.json()
     assert gmail_header(message, "Subject") == subject
     assert "TRASH" in message["labelIds"]
+
+
+async def test_reborn_slack_delivery_and_github_release_cross_provider_path(
+    hosted_provider_emulate_server,
+):
+    """Drive real extension callers and verify exact Slack side effects."""
+    server = hosted_provider_emulate_server["base_url"]
+    mock_llm_url = hosted_provider_emulate_server["mock_llm_url"]
+    github_url = hosted_provider_emulate_server["emulate_github_url"]
+    slack_url = hosted_provider_emulate_server["emulate_slack_url"]
+    tools_dir = hosted_provider_emulate_server["wasm_tools_dir"]
+
+    await install_extension(server, "slack_tool")
+    slack_setup = await api_post(
+        server,
+        "/api/extensions/slack_tool/setup",
+        json={"secrets": {"slack_bot_token": EMULATE_SLACK_BEARER}},
+        timeout=30,
+    )
+    assert slack_setup.status_code == 200, slack_setup.text
+    assert slack_setup.json().get("success") is True, slack_setup.text
+    await complete_oauth_setup(
+        server,
+        "slack_tool",
+        code="mock_slack_full_path_code",
+        mock_base_url=mock_llm_url,
+    )
+    slack = await get_extension(server, "slack_tool")
+    assert slack is not None, await extension_names(server)
+    assert slack["authenticated"] is True, slack
+    assert "slack_tool" in slack.get("tools", []), slack
+
+    await install_extension(server, "github")
+    patch_extension_validation_endpoint(
+        tools_dir,
+        "github",
+        f"{github_url}/user",
+    )
+    await complete_oauth_setup(
+        server,
+        "github",
+        code="mock_github_cross_provider_code",
+        mock_base_url=mock_llm_url,
+    )
+
+    for extension_name in ("google-calendar", "google-drive", "gmail"):
+        await install_extension(server, extension_name)
+        await complete_oauth_setup(
+            server,
+            extension_name,
+            code="mock_auth_code",
+            mock_base_url=mock_llm_url,
+        )
+
+    async with httpx.AsyncClient(timeout=10) as client:
+        users = await slack_post(client, slack_url, "users.list")
+        reviewers = {
+            member["name"]: member["id"]
+            for member in users["members"]
+            if member["name"] in {"qa-reviewer", "no-email-user"}
+        }
+        dm_channels = {}
+        for name, user_id in reviewers.items():
+            opened = await slack_post(
+                client,
+                slack_url,
+                "conversations.open",
+                {"users": user_id, "return_im": True},
+            )
+            dm_channels[name] = opened["channel"]["id"]
+
+        release_tag = f"reborn-cross-provider-{uuid.uuid4().hex[:8]}"
+        await github_json(
+            client,
+            github_url,
+            "POST",
+            "/repos/nearai/ironclaw/releases",
+            payload={
+                "tag_name": release_tag,
+                "name": "Reborn cross-provider canary",
+                "body": "Fixture release for GitHub to Slack dispatch.",
+            },
+            expected_status=201,
+        )
+
+    # Two separate deliveries prove that channel selection is not shared and
+    # that each requested target receives the marker exactly once.
+    markers = {
+        "qa-reviewer": f"slack-dm-a-{uuid.uuid4().hex[:8]}",
+        "no-email-user": f"slack-dm-b-{uuid.uuid4().hex[:8]}",
+    }
+    for name, marker in markers.items():
+        thread_id = await new_thread(server)
+        await send_chat(
+            server,
+            thread_id,
+            f"send slack canary {marker} to {dm_channels[name]}",
+        )
+        delivery_history = await wait_for_response_containing(
+            server,
+            thread_id,
+            "slack delivery lifecycle complete",
+            timeout=90,
+        )
+        responses = " ".join(
+            turn.get("response") or ""
+            for turn in delivery_history.get("turns", [])
+        )
+        assert dm_channels[name] not in responses
+        assert reviewers[name] not in responses
+
+    cross_marker = f"github-release-slack-{uuid.uuid4().hex[:8]}"
+    cross_thread_id = await new_thread(server)
+    await send_chat(
+        server,
+        cross_thread_id,
+        "notify slack channel "
+        f"{dm_channels['qa-reviewer']} about the latest release in "
+        f"nearai/ironclaw with marker {cross_marker}",
+    )
+    cross_history = await wait_for_response_containing(
+        server,
+        cross_thread_id,
+        "github release to slack lifecycle complete",
+        timeout=90,
+    )
+    assert completed_tool_results(cross_history, "github"), cross_history
+    assert completed_tool_results(cross_history, "slack_tool"), cross_history
+
+    async with httpx.AsyncClient(timeout=10) as client:
+        histories = {}
+        for name, channel in dm_channels.items():
+            response = await slack_post(
+                client,
+                slack_url,
+                "conversations.history",
+                {"channel": channel},
+            )
+            histories[name] = [message["text"] for message in response["messages"]]
+
+    for name, marker in markers.items():
+        assert histories[name].count(marker) == 1
+        other_name = next(candidate for candidate in markers if candidate != name)
+        assert markers[other_name] not in histories[name]
+    assert histories["qa-reviewer"].count(cross_marker) == 1
+    assert cross_marker not in histories["no-email-user"]
+
+    cross_provider_cases = [
+        (
+            "prepare meeting and notify slack channel "
+            f"{dm_channels['qa-reviewer']} with marker {{marker}}",
+            "calendar drive to slack complete",
+            ("google_calendar", "google_drive", "slack_tool"),
+        ),
+        (
+            "check unread gmail and notify slack channel "
+            f"{dm_channels['qa-reviewer']} with marker {{marker}}",
+            "gmail to slack complete",
+            ("gmail", "slack_tool"),
+        ),
+        (
+            f"read slack channel {dm_channels['qa-reviewer']}, look up drive, "
+            f"and notify {dm_channels['no-email-user']} with marker {{marker}}",
+            "slack drive to slack complete",
+            ("slack_tool", "google_drive"),
+        ),
+    ]
+    workflow_markers = []
+    for prompt_template, completion, expected_tools in cross_provider_cases:
+        marker = f"cross-provider-{uuid.uuid4().hex[:8]}"
+        workflow_markers.append(marker)
+        thread_id = await new_thread(server)
+        await send_chat(server, thread_id, prompt_template.format(marker=marker))
+        workflow_history = await wait_for_response_containing(
+            server,
+            thread_id,
+            completion,
+            timeout=90,
+        )
+        for tool_name in expected_tools:
+            assert completed_tool_results(workflow_history, tool_name), workflow_history
+
+    async with httpx.AsyncClient(timeout=10) as client:
+        reviewer_history = await slack_post(
+            client,
+            slack_url,
+            "conversations.history",
+            {"channel": dm_channels["qa-reviewer"]},
+        )
+        no_email_history = await slack_post(
+            client,
+            slack_url,
+            "conversations.history",
+            {"channel": dm_channels["no-email-user"]},
+        )
+    reviewer_texts = [message["text"] for message in reviewer_history["messages"]]
+    no_email_texts = [message["text"] for message in no_email_history["messages"]]
+    assert reviewer_texts.count(workflow_markers[0]) == 1
+    assert reviewer_texts.count(workflow_markers[1]) == 1
+    assert no_email_texts.count(workflow_markers[2]) == 1

--- a/tests/e2e/scenarios/test_reborn_emulate_full_path.py
+++ b/tests/e2e/scenarios/test_reborn_emulate_full_path.py
@@ -4,7 +4,7 @@ import uuid
 
 import httpx
 
-from emulate_provider import github_json, google_headers
+from emulate_provider import github_json, gmail_header, google_headers
 from reborn_emulate_harness import (
     complete_oauth_setup,
     completed_tool_results,
@@ -209,3 +209,54 @@ async def test_reborn_google_drive_lifecycle_mutates_emulate(
     media.raise_for_status()
     assert metadata.json()["name"] == title
     assert media.text == expected_content
+
+
+async def test_reborn_gmail_lifecycle_mutates_emulate(
+    hosted_google_emulate_server,
+):
+    """Drive the real extension caller through send, readback, and cleanup."""
+    server = hosted_google_emulate_server["base_url"]
+    emulate_google_url = hosted_google_emulate_server["emulate_google_url"]
+
+    await install_extension(server, "gmail")
+    await complete_oauth_setup(server, "gmail", code="mock_auth_code")
+
+    gmail = await get_extension(server, "gmail")
+    assert gmail is not None, (
+        "gmail should be installed; "
+        f"available extensions: {await extension_names(server)}"
+    )
+    assert gmail["authenticated"] is True, gmail
+    assert "gmail" in gmail.get("tools", []), gmail
+
+    subject = f"[canary] reborn-emulate-gmail-{uuid.uuid4().hex[:8]}"
+    thread_id = await new_thread(server)
+    await send_chat(
+        server,
+        thread_id,
+        f"send an email to e2e.google@example.com with subject '{subject}'",
+    )
+
+    history = await wait_for_response_containing(
+        server,
+        thread_id,
+        "gmail roundtrip complete",
+        timeout=90,
+    )
+    tool_results = completed_tool_results(history, "gmail")
+    assert len(tool_results) >= 3, [tool_result_text(result) for result in tool_results]
+
+    sent = tool_result_json(tool_results[0])
+    sent_message = sent.get("message", sent)
+    message_id = sent_message["id"]
+
+    async with httpx.AsyncClient(timeout=10) as client:
+        readback = await client.get(
+            f"{emulate_google_url}/gmail/v1/users/me/messages/{message_id}",
+            headers=google_headers(),
+            params={"format": "full"},
+        )
+    readback.raise_for_status()
+    message = readback.json()
+    assert gmail_header(message, "Subject") == subject
+    assert "TRASH" in message["labelIds"]


### PR DESCRIPTION
## What changed

- expand Google, Slack, and GitHub Emulate state for two-user/account isolation, strict scopes, identity, membership, missing email, distinct repositories, and negative results
- add deterministic provider contracts for Slack QA 9/10 shapes, Drive update, GitHub private-account isolation, and distinct latest releases
- add full caller-path Slack extension coverage with OAuth, two separate DM targets, exactly-once readback, and final-response raw-ID hygiene
- add scripted cross-provider paths through real IronClaw extensions: GitHub release → Slack, Calendar + Drive → Slack, Gmail → Slack, and Slack → Drive → Slack
- add a Google capability caller contract proving a scheduled run uses its owner account even when another active user has a configured account
- keep reconnect, malformed-provider, duplicate-inbound, pagination, and automatic Slack delivery guarantees at their existing dedicated caller/runtime seams

## Why

The live canary remains valuable for real-model and real-provider drift, but deterministic routing, authorization, provider state, account ownership, and side effects should gate releases without LLM cost or stochastic failures. These tests add coverage without removing or changing any live-canary scenario.

## Validation

- `pytest tests/e2e/scenarios/test_emulate_reborn_provider_contracts.py tests/e2e/scenarios/test_reborn_emulate_full_path.py -q` — 16 passed
- focused owner-account test — passed
- live non-Telegram suite count contract — 46 passed; with 3 Telegram cases the total remains 49
- `rustfmt`, `git diff --check`, and focused reruns — passed
- no diff under `.github/workflows/live-canary.yml` or `scripts/reborn_webui_v2_live_qa/`

## Scope note

Emulate does not faithfully reject arbitrary Google bearer tokens and is not a provider fault-injection proxy. Invalid-token fidelity, malformed payloads, and forced provider failures remain covered by the existing local fake/runtime tests instead of misleading Emulate-only assertions. Google Sheets and Docs remain outside Emulate 0.7.0.