### PR TITLE
feat(extension-runtime): P0 — architecture gates + acme fixture (runtime PR 1/8)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4072,6 +4072,8 @@ name = "ironclaw_architecture"
 version = "0.1.0"
 dependencies = [
  "serde_json",
+ "tempfile",
+ "toml 1.1.2+spec-1.1.0",
 ]
 
 [[package]]

--- a/crates/ironclaw_architecture/Cargo.toml
+++ b/crates/ironclaw_architecture/Cargo.toml
@@ -9,3 +9,5 @@ layer = "app"
 
 [dev-dependencies]
 serde_json = "1"
+tempfile = "3"
+toml = "1.1"

--- a/crates/ironclaw_architecture/tests/reborn_extension_specificity.rs
+++ b/crates/ironclaw_architecture/tests/reborn_extension_specificity.rs
@@ -1,0 +1,1815 @@
+//! Concrete-name specificity gate for the unified extension runtime.
+//!
+//! Goal (docs/reborn/extension-runtime/overview.md §1): no generic crate
+//! contains a concrete product name, vendor id, or vendor API host. The
+//! forbidden vocabulary is **derived from the bundled package inventory**
+//! (`crates/ironclaw_first_party_extensions/assets/` plus the test fixture
+//! inventory `tests/fixtures/extensions/`), so a future `discord` package is
+//! caught without editing this scanner (checklist TEST-6).
+//!
+//! Scope: the `src/` tree and `Cargo.toml` of every generic Reborn workspace
+//! crate, plus the WebUI frontend sources. Excluded, by category:
+//!
+//! - **Concrete extension crates** (`CONCRETE_EXTENSION_CRATES`) — they *are*
+//!   the product code.
+//! - **The package inventory crate** (`ironclaw_first_party_extensions`) —
+//!   it owns the concrete packages and their native executors.
+//! - **Sanctioned assemblers** — `ironclaw_reborn_cli` (the binary assembles
+//!   the native factory registry; overview §4.0), `ironclaw_reborn_migration`
+//!   (one-time forward migrations name what they fold forward), and this
+//!   architecture crate (names terms on purpose).
+//! - **Legacy-layer / v1 crates** — the v1 enclave is being strangled
+//!   wholesale, not policed term-by-term (same footing as
+//!   `reborn_retired_taxonomy.rs`).
+//! - **Test code** — tests may name concrete products (overview §8); `tests/`
+//!   directories, `tests.rs` / `*_tests.rs` files, and `#[cfg(test)]` blocks
+//!   inside `src/` are stripped before matching.
+//!
+//! Term-collision carve-outs (`TERM_COLLISIONS`, `PATH_TERM_COLLISIONS`):
+//! some inventory-derived identifiers are *also* vocabulary of a different
+//! product domain that legitimately and permanently lives in generic crates.
+//! Exactly four such domains exist: LLM providers (`nearai`/`api.near.ai` is
+//! the assistant's LLM+embeddings backend; Google is Gemini; GitHub is
+//! Copilot), WebUI browser-login SSO providers (Google/GitHub OIDC), GitHub
+//! as a skill/code host (skill installation from repositories), and vendor
+//! credential-format detection (leak/secret scanners must know Slack/GitHub
+//! token shapes). Bare `nearai` terms are carved out globally with the
+//! compound extension forms (`nearai_mcp`, `private.near.ai`, …) still
+//! scanned; the rest are path-scoped. Each carve-out names its collision and
+//! fails when stale; adding one for any other reason is a violation of this
+//! gate's purpose.
+//!
+//! Allowlist discipline (checklist TEST-7): `ALLOWLIST` enumerates today's
+//! violations as exact `(path, term)` pairs. A new violating pair fails; a
+//! stale pair (the file no longer matches the term) also fails, so the list
+//! can only shrink. It must be **empty** by P7 (checklist DEL-8).
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value;
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|path| path.parent())
+        .expect("architecture crate under crates")
+        .to_path_buf()
+}
+
+// ---------------------------------------------------------------------------
+// Inventory-derived forbidden terms
+// ---------------------------------------------------------------------------
+
+/// Directories whose `*/manifest.toml` files form the package inventory the
+/// forbidden vocabulary derives from.
+fn inventory_dirs(root: &Path) -> Vec<PathBuf> {
+    vec![
+        root.join("crates/ironclaw_first_party_extensions/assets"),
+        root.join("tests/fixtures/extensions"),
+    ]
+}
+
+/// Bare terms carved out of the derived set because they collide with a
+/// non-extension taxonomy that legitimately lives in generic crates. Compound
+/// forms derived from the same package (directory-name variants, specific
+/// hosts) remain scanned.
+const TERM_COLLISIONS: &[(&str, &str)] = &[
+    (
+        "nearai",
+        "`nearai` is also the assistant's LLM backend id (crates/ironclaw_llm, \
+         crates/ironclaw_reborn_config); the extension forms `nearai-mcp`/`nearai_mcp` \
+         and the MCP host stay scanned",
+    ),
+    (
+        "near.ai",
+        "`api.near.ai` is the LLM/embeddings API host; the hosted-MCP endpoint \
+         `private.near.ai` stays scanned",
+    ),
+];
+
+/// Path-scoped permanent carve-outs for identifiers that belong to a
+/// **different product domain** which legitimately owns the vocabulary.
+/// Four classes only — LLM providers, WebUI browser-login SSO providers,
+/// GitHub as a skill/code host, and vendor credential-format detection.
+/// Every entry must keep matching (staleness fails) and the exact list is
+/// pinned by a self-test; broadening it is a gate regression, not a fix.
+const PATH_TERM_COLLISIONS: &[(&str, &str, &str)] = &[
+    (
+        "crates/ironclaw_llm/src/",
+        "google",
+        "Google is an LLM vendor (Gemini endpoints, google/gemma model ids) inside the \
+         multi-provider LLM crate, independent of the google extensions vendor",
+    ),
+    (
+        "crates/ironclaw_llm/src/",
+        "github",
+        "GitHub Copilot is an LLM provider (github_copilot*.rs), independent of the github \
+         extension",
+    ),
+    (
+        "crates/ironclaw_llm/src/",
+        "private.near.ai",
+        "the NEAR AI LLM API base URL (session/config defaults), independent of the \
+         nearai-mcp extension endpoint",
+    ),
+    (
+        "crates/ironclaw_reborn_webui_ingress/src/auth/",
+        "google",
+        "WebUI browser-login SSO provider (OIDC), not the extensions vendor",
+    ),
+    (
+        "crates/ironclaw_reborn_webui_ingress/src/auth/",
+        "github",
+        "WebUI browser-login SSO provider, not the extensions vendor",
+    ),
+    (
+        "crates/ironclaw_reborn_webui_ingress/src/lib.rs",
+        "google",
+        "re-export of the SSO login providers",
+    ),
+    (
+        "crates/ironclaw_reborn_webui_ingress/src/lib.rs",
+        "github",
+        "re-export of the SSO login providers",
+    ),
+    (
+        "crates/ironclaw_host_runtime/src/first_party_tools/skill_url_install",
+        "github",
+        "skill installation from GitHub repositories — GitHub as a code host, not the \
+         github extension",
+    ),
+    (
+        "crates/ironclaw_host_runtime/src/first_party_tools/skill_url_install.rs",
+        "api.github.com",
+        "GitHub content API allowlist for skill installation",
+    ),
+    (
+        "crates/ironclaw_host_runtime/src/first_party_tools/skill_management.rs",
+        "github",
+        "skill-install tool description names GitHub as a skill source",
+    ),
+    (
+        "crates/ironclaw_host_runtime/src/first_party_tools/schemas.rs",
+        "github",
+        "skill-install input schema names GitHub as a skill source",
+    ),
+    (
+        "crates/ironclaw_safety/src/leak_detector.rs",
+        "github",
+        "vendor token-format leak detection",
+    ),
+    (
+        "crates/ironclaw_safety/src/leak_detector.rs",
+        "google",
+        "vendor token-format leak detection",
+    ),
+    (
+        "crates/ironclaw_safety/src/leak_detector.rs",
+        "slack",
+        "vendor token-format leak detection",
+    ),
+    (
+        "crates/ironclaw_reborn_config/src/secrets_guard.rs",
+        "github",
+        "vendor token-format inline-secret rejection",
+    ),
+    (
+        "crates/ironclaw_reborn_config/src/secrets_guard.rs",
+        "google",
+        "vendor token-format inline-secret rejection",
+    ),
+    (
+        "crates/ironclaw_reborn_config/src/secrets_guard.rs",
+        "slack",
+        "vendor token-format inline-secret rejection",
+    ),
+    (
+        "crates/ironclaw_events/src/runtime_event.rs",
+        "github",
+        "credential-prefix redaction (github_pat_)",
+    ),
+    (
+        "crates/ironclaw_loop_support/src/capability_port.rs",
+        "github",
+        "credential-prefix redaction (github_pat_)",
+    ),
+    (
+        "crates/ironclaw_turns/src/run_profile/host.rs",
+        "github",
+        "credential-prefix redaction (github_pat_)",
+    ),
+    (
+        "crates/ironclaw_turns/src/run_profile/prompt_text.rs",
+        "github",
+        "credential-prefix redaction (github_pat_)",
+    ),
+];
+
+/// Path fragments allowed to reference concrete extension identities for a
+/// structural reason, mirroring `reborn_retired_taxonomy.rs`: the one-time
+/// forward data migrations name what they fold forward.
+const SANCTIONED_PATHS: &[&str] = &[
+    "extension_host/extension_installation_store.rs",
+    "product_auth/durable/",
+];
+
+/// Derive the forbidden term set from every `manifest.toml` under the given
+/// inventory directories. Terms are lowercase; multi-part identifiers add
+/// `-`, `_`, and compact variants so camel-case compounds are caught.
+fn derive_forbidden_terms(inventory: &[PathBuf]) -> BTreeSet<String> {
+    let mut terms = BTreeSet::new();
+    for dir in inventory {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let package_dir = entry.path();
+            if !package_dir.is_dir() {
+                continue;
+            }
+            let manifest_path = package_dir.join("manifest.toml");
+            let Ok(contents) = std::fs::read_to_string(&manifest_path) else {
+                continue;
+            };
+            let manifest = contents.parse::<toml::Table>().unwrap_or_else(|error| {
+                panic!(
+                    "unparseable inventory manifest {} — fix the package before the scanner \
+                     can derive from it: {error}",
+                    manifest_path.display()
+                )
+            });
+            let manifest = toml::Value::Table(manifest);
+            let dir_name = entry.file_name().to_string_lossy().to_string();
+            add_identifier_variants(&mut terms, &dir_name);
+            collect_manifest_terms(&manifest, &mut terms);
+        }
+    }
+    for (term, _reason) in TERM_COLLISIONS {
+        terms.remove(*term);
+    }
+    terms.retain(|term| term.len() >= 4);
+    terms
+}
+
+/// Walk a manifest value tree collecting extension ids, vendor ids, and
+/// vendor API hosts. Key-path driven so it covers both the v2 and v3 schema
+/// shapes without enumerating either:
+///
+/// - top-level `id` — the extension id;
+/// - top-level `[auth.<vendor>]` table keys — v3 vendor ids;
+/// - `provider` (v2) / `vendor` (v3) string values at any depth;
+/// - `host` / `host_pattern` values and the hosts of URL-valued declarations
+///   (`url`, `server`, recipe endpoints) at any depth.
+fn collect_manifest_terms(value: &toml::Value, terms: &mut BTreeSet<String>) {
+    collect_terms_inner(value, &mut Vec::new(), terms);
+}
+
+fn collect_terms_inner<'v>(
+    value: &'v toml::Value,
+    path: &mut Vec<&'v str>,
+    terms: &mut BTreeSet<String>,
+) {
+    match value {
+        toml::Value::Table(table) => {
+            for (child_key, child) in table {
+                if path.as_slice() == ["auth"] {
+                    add_identifier_variants(terms, child_key);
+                }
+                path.push(child_key.as_str());
+                collect_terms_inner(child, path, terms);
+                path.pop();
+            }
+        }
+        toml::Value::Array(items) => {
+            for item in items {
+                collect_terms_inner(item, path, terms);
+            }
+        }
+        toml::Value::String(text) => match path.last().copied() {
+            Some("id") if path.len() == 1 => {
+                add_identifier_variants(terms, text);
+            }
+            Some("provider") | Some("vendor") => {
+                add_identifier_variants(terms, text);
+            }
+            Some("host_pattern") | Some("host") => {
+                add_host_term(terms, text);
+            }
+            Some("url")
+            | Some("server")
+            | Some("authorization_endpoint")
+            | Some("token_endpoint")
+            | Some("endpoint") => {
+                if let Some(host) = url_host(text) {
+                    add_host_term(terms, &host);
+                }
+            }
+            _ => {}
+        },
+        _ => {}
+    }
+}
+
+fn add_identifier_variants(terms: &mut BTreeSet<String>, identifier: &str) {
+    let lower = identifier.trim().to_ascii_lowercase();
+    if lower.is_empty() {
+        return;
+    }
+    terms.insert(lower.clone());
+    if lower.contains('-') || lower.contains('_') {
+        terms.insert(lower.replace('-', "_"));
+        terms.insert(lower.replace('_', "-"));
+        terms.insert(lower.replace(['-', '_'], ""));
+    }
+}
+
+fn add_host_term(terms: &mut BTreeSet<String>, host: &str) {
+    let host = host.trim().trim_start_matches("*.").to_ascii_lowercase();
+    if host.is_empty() {
+        return;
+    }
+    terms.insert(host);
+}
+
+fn url_host(url: &str) -> Option<String> {
+    let rest = url.split("://").nth(1)?;
+    let host = rest.split(['/', '?', '#']).next()?;
+    let host = host.split('@').next_back()?;
+    let host = host.split(':').next()?;
+    if host.is_empty() {
+        None
+    } else {
+        Some(host.to_string())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Scan scope
+// ---------------------------------------------------------------------------
+
+/// Reborn layers whose crates are "generic" for this gate. Legacy-layer and
+/// unlayered (non-workspace) crates are the v1 enclave.
+const REBORN_LAYERS: &[&str] = &[
+    "contracts",
+    "substrates",
+    "runtimes",
+    "kernel",
+    "loops",
+    "products",
+    "app",
+];
+
+/// Crates that are the concrete product code (present or planned). A missing
+/// directory is tolerated so the planned extension crates are covered from
+/// the day they appear.
+const CONCRETE_EXTENSION_CRATES: &[&str] = &[
+    "ironclaw_slack_v2_adapter",
+    "ironclaw_telegram_v2_adapter",
+    "ironclaw_slack_extension",
+    "ironclaw_telegram_extension",
+];
+
+/// Generic-side crates excluded from the scan for a documented structural
+/// reason (see the module header).
+const SANCTIONED_SCAN_EXEMPT_CRATES: &[&str] = &[
+    // The package inventory + native executors for bundled extensions.
+    "ironclaw_first_party_extensions",
+    // The binary assembles the native factory registry (overview §4.0).
+    "ironclaw_reborn_cli",
+    // One-time forward migrations name what they fold forward.
+    "ironclaw_reborn_migration",
+    // This crate's tests name every term on purpose.
+    "ironclaw_architecture",
+    // Load/stress tooling, not product code.
+    "ironclaw_stress",
+];
+
+struct ScanRoot {
+    crate_name: String,
+    crate_dir: PathBuf,
+}
+
+fn generic_scan_roots(metadata: &Value, root: &Path) -> Vec<ScanRoot> {
+    let packages = metadata["packages"]
+        .as_array()
+        .expect("cargo metadata must include packages");
+    let mut roots = Vec::new();
+    for package in packages {
+        let Some(name) = package["name"].as_str() else {
+            continue;
+        };
+        if !(name == "ironclaw" || name.starts_with("ironclaw_")) {
+            continue;
+        }
+        if CONCRETE_EXTENSION_CRATES.contains(&name)
+            || SANCTIONED_SCAN_EXEMPT_CRATES.contains(&name)
+        {
+            continue;
+        }
+        let layer = package
+            .get("metadata")
+            .and_then(|metadata| metadata.get("ironclaw"))
+            .and_then(|ironclaw| ironclaw.get("layer"))
+            .and_then(|layer| layer.as_str());
+        if !layer.is_some_and(|layer| REBORN_LAYERS.contains(&layer)) {
+            continue;
+        }
+        let Some(manifest_path) = package["manifest_path"].as_str() else {
+            continue;
+        };
+        let crate_dir = PathBuf::from(manifest_path)
+            .parent()
+            .expect("manifest has parent dir")
+            .to_path_buf();
+        // Only police crates inside this workspace checkout.
+        if !crate_dir.starts_with(root) {
+            continue;
+        }
+        roots.push(ScanRoot {
+            crate_name: name.to_string(),
+            crate_dir,
+        });
+    }
+    roots.sort_by(|a, b| a.crate_name.cmp(&b.crate_name));
+    roots
+}
+
+// ---------------------------------------------------------------------------
+// File scanning
+// ---------------------------------------------------------------------------
+
+fn is_test_source_path(path: &Path) -> bool {
+    let mut components = path
+        .components()
+        .map(|component| component.as_os_str().to_string_lossy().to_string());
+    if components.any(|component| {
+        component == "tests" || component == "__tests__" || component == "test-utils"
+    }) {
+        return true;
+    }
+    let name = path
+        .file_name()
+        .map(|name| name.to_string_lossy().to_string())
+        .unwrap_or_default();
+    name == "tests.rs"
+        || name.ends_with("_tests.rs")
+        || name.contains(".test.")
+        || name.contains(".spec.")
+}
+
+/// Remove `#[cfg(test)]` items (inline `mod tests { … }` blocks and
+/// `mod tests;` declarations) before matching: tests may name concrete
+/// products (overview §8). Line-based brace counting — the same heuristic
+/// `scripts/pre-commit-safety.sh` uses for its test-stripping.
+fn strip_cfg_test_blocks(source: &str) -> String {
+    let mut kept = String::with_capacity(source.len());
+    let mut lines = source.lines().peekable();
+    while let Some(line) = lines.next() {
+        if !line.trim_start().starts_with("#[cfg(test)]") {
+            kept.push_str(line);
+            kept.push('\n');
+            continue;
+        }
+        // Skip attribute lines, then the annotated item.
+        let mut depth: i64 = 0;
+        let mut opened = false;
+        for skipped in lines.by_ref() {
+            let trimmed = skipped.trim_start();
+            if !opened && trimmed.starts_with("#[") {
+                continue;
+            }
+            depth += skipped.matches('{').count() as i64;
+            depth -= skipped.matches('}').count() as i64;
+            if !opened {
+                if skipped.contains('{') {
+                    opened = true;
+                } else if trimmed.ends_with(';') {
+                    // `mod tests;` — single-line item, nothing else to skip.
+                    break;
+                }
+            }
+            if opened && depth <= 0 {
+                break;
+            }
+        }
+    }
+    kept
+}
+
+/// Mask non-extension references before matching:
+///
+/// - GitHub *repository URLs* (issue/PR citations, upstream repo links) so
+///   the `github` term matches product/API references rather than routine
+///   code citations;
+/// - `metadata.google.internal` — the cloud metadata endpoint named by SSRF
+///   guards, which is security vocabulary, not the google extensions vendor.
+fn mask_non_extension_references(source: &str) -> String {
+    const REPO_MARKER: &str = "github.com/";
+    let mut masked = String::with_capacity(source.len());
+    let mut rest = source;
+    while let Some(index) = rest.find(REPO_MARKER) {
+        masked.push_str(&rest[..index]);
+        let after = &rest[index + REPO_MARKER.len()..];
+        let end = after
+            .find(|c: char| c.is_whitespace() || matches!(c, '"' | '\'' | '`' | ')' | '>' | ','))
+            .unwrap_or(after.len());
+        rest = &after[end..];
+    }
+    masked.push_str(rest);
+    masked.replace("metadata.google.internal", "")
+}
+
+fn scannable_kind(path: &Path) -> Option<FileKind> {
+    let name = path.file_name()?.to_string_lossy();
+    if name.ends_with(".rs") {
+        Some(FileKind::Rust)
+    } else if name.ends_with(".ts") || name.ends_with(".tsx") {
+        Some(FileKind::Frontend)
+    } else if name.ends_with(".toml") {
+        Some(FileKind::Toml)
+    } else {
+        None
+    }
+}
+
+#[derive(Clone, Copy, PartialEq)]
+enum FileKind {
+    Rust,
+    Frontend,
+    Toml,
+}
+
+fn scan_file(path: &Path, kind: FileKind, terms: &BTreeSet<String>) -> Vec<String> {
+    let Ok(contents) = std::fs::read_to_string(path) else {
+        return Vec::new();
+    };
+    let contents = match kind {
+        FileKind::Rust => strip_cfg_test_blocks(&contents),
+        FileKind::Frontend | FileKind::Toml => contents,
+    };
+    let haystack = mask_non_extension_references(&contents).to_ascii_lowercase();
+    terms
+        .iter()
+        .filter(|term| haystack.contains(term.as_str()))
+        .cloned()
+        .collect()
+}
+
+fn scan_dir(
+    root: &Path,
+    dir: &Path,
+    terms: &BTreeSet<String>,
+    hits: &mut BTreeMap<String, BTreeSet<String>>,
+) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let name = entry.file_name().to_string_lossy().to_string();
+        if path.is_dir() {
+            if name == "target" || name == "node_modules" || name == ".git" {
+                continue;
+            }
+            if is_test_source_path(Path::new(&name)) {
+                continue;
+            }
+            scan_dir(root, &path, terms, hits);
+            continue;
+        }
+        if is_test_source_path(&path) {
+            continue;
+        }
+        let Some(kind) = scannable_kind(&path) else {
+            continue;
+        };
+        let matched = scan_file(&path, kind, terms);
+        if matched.is_empty() {
+            continue;
+        }
+        let relative = path
+            .strip_prefix(root)
+            .unwrap_or(&path)
+            .to_string_lossy()
+            .replace('\\', "/");
+        hits.entry(relative).or_default().extend(matched);
+    }
+}
+
+fn collect_workspace_hits(root: &Path, terms: &BTreeSet<String>) -> BTreeSet<(String, String)> {
+    let metadata = cargo_metadata(root);
+    let mut hits: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    for scan_root in generic_scan_roots(&metadata, root) {
+        let src = scan_root.crate_dir.join("src");
+        scan_dir(root, &src, terms, &mut hits);
+        let manifest = scan_root.crate_dir.join("Cargo.toml");
+        if manifest.exists() {
+            let matched = scan_file(&manifest, FileKind::Toml, terms);
+            if !matched.is_empty() {
+                let relative = manifest
+                    .strip_prefix(root)
+                    .unwrap_or(&manifest)
+                    .to_string_lossy()
+                    .replace('\\', "/");
+                hits.entry(relative).or_default().extend(matched);
+            }
+        }
+    }
+    // The WebUI frontend ships from a non-src directory of a generic crate.
+    let frontend = root.join("crates/ironclaw_webui_v2/frontend/src");
+    scan_dir(root, &frontend, terms, &mut hits);
+
+    hits.into_iter()
+        .filter(|(path, _)| {
+            !SANCTIONED_PATHS
+                .iter()
+                .any(|fragment| path.contains(fragment))
+        })
+        .flat_map(|(path, terms)| {
+            terms
+                .into_iter()
+                .map(move |term| (path.clone(), term))
+                .collect::<Vec<_>>()
+        })
+        .collect()
+}
+
+/// Split raw hits into (permanently carved-out, policed). Carve-outs that no
+/// longer match anything are returned as stale so the list cannot rot.
+fn apply_path_term_collisions(
+    hits: BTreeSet<(String, String)>,
+) -> (BTreeSet<(String, String)>, Vec<String>) {
+    let mut used: BTreeSet<(&str, &str)> = BTreeSet::new();
+    let policed: BTreeSet<(String, String)> = hits
+        .into_iter()
+        .filter(|(path, term)| {
+            let carved = PATH_TERM_COLLISIONS
+                .iter()
+                .find(|(fragment, carved_term, _)| path.contains(fragment) && term == carved_term);
+            if let Some((fragment, carved_term, _)) = carved {
+                used.insert((fragment, carved_term));
+                return false;
+            }
+            true
+        })
+        .collect();
+    let stale = PATH_TERM_COLLISIONS
+        .iter()
+        .filter(|(fragment, term, _)| !used.contains(&(fragment, term)))
+        .map(|(fragment, term, _)| format!("{fragment} :: {term}"))
+        .collect();
+    (policed, stale)
+}
+
+// ---------------------------------------------------------------------------
+// Allowlist — today's violations, shrink-only, empty by P7 (DEL-8)
+// ---------------------------------------------------------------------------
+
+/// Exact `(path, term)` pairs allowed to match today. Every entry is existing
+/// debt scheduled for deletion by the extension-runtime phases (P1–P7). Do
+/// not add entries for new code — fix the code instead.
+const ALLOWLIST: &[(&str, &str)] = &[
+    ("crates/ironclaw_auth/src/lib.rs", "gmail"),
+    ("crates/ironclaw_auth/src/lib.rs", "google"),
+    ("crates/ironclaw_auth/src/lib.rs", "google_calendar"),
+    ("crates/ironclaw_auth/src/lib.rs", "slack"),
+    ("crates/ironclaw_auth/src/oauth.rs", "gmail"),
+    ("crates/ironclaw_auth/src/oauth.rs", "google"),
+    ("crates/ironclaw_auth/src/oauth.rs", "google_calendar"),
+    ("crates/ironclaw_auth/src/oauth.rs", "google_docs"),
+    ("crates/ironclaw_auth/src/oauth.rs", "google_drive"),
+    ("crates/ironclaw_auth/src/oauth.rs", "google_sheets"),
+    ("crates/ironclaw_auth/src/oauth.rs", "google_slides"),
+    ("crates/ironclaw_auth/src/oauth.rs", "notion"),
+    ("crates/ironclaw_auth/src/oauth.rs", "slack"),
+    ("crates/ironclaw_auth/src/oauth.rs", "slack.com"),
+    ("crates/ironclaw_auth/src/oauth.rs", "www.googleapis.com"),
+    ("crates/ironclaw_auth/src/scope.rs", "google"),
+    ("crates/ironclaw_common/src/identity.rs", "github"),
+    ("crates/ironclaw_common/src/identity.rs", "gmail"),
+    ("crates/ironclaw_common/src/identity.rs", "google"),
+    ("crates/ironclaw_common/src/identity.rs", "google-calendar"),
+    ("crates/ironclaw_common/src/identity.rs", "google_calendar"),
+    ("crates/ironclaw_common/src/identity.rs", "notion"),
+    ("crates/ironclaw_common/src/identity.rs", "slack"),
+    ("crates/ironclaw_filesystem/src/index.rs", "acme"),
+    ("crates/ironclaw_host_api/src/capability.rs", "slack"),
+    ("crates/ironclaw_host_api/src/http.rs", "slack"),
+    ("crates/ironclaw_host_api/src/ids.rs", "github"),
+    ("crates/ironclaw_host_api/src/surface.rs", "slack"),
+    (
+        "crates/ironclaw_host_runtime/src/document_output.rs",
+        "google",
+    ),
+    (
+        "crates/ironclaw_host_runtime/src/document_output.rs",
+        "google-drive",
+    ),
+    (
+        "crates/ironclaw_host_runtime/src/first_party_tools/http.rs",
+        "github",
+    ),
+    (
+        "crates/ironclaw_llm/src/gemini_oauth.rs",
+        "www.googleapis.com",
+    ),
+    ("crates/ironclaw_llm/src/reasoning.rs", "slack"),
+    (
+        "crates/ironclaw_llm/src/tool_schema/placeholder_stripping.rs",
+        "notion",
+    ),
+    (
+        "crates/ironclaw_loop_support/src/capability_port.rs",
+        "gmail",
+    ),
+    ("crates/ironclaw_oauth/src/lib.rs", "google"),
+    ("crates/ironclaw_oauth/src/lib.rs", "notion"),
+    (
+        "crates/ironclaw_outbound/src/delivered_gate_routes.rs",
+        "slack",
+    ),
+    (
+        "crates/ironclaw_product_adapter_registry/src/lib.rs",
+        "github",
+    ),
+    (
+        "crates/ironclaw_product_adapter_registry/src/lib.rs",
+        "slack",
+    ),
+    ("crates/ironclaw_product_adapters/src/identity.rs", "slack"),
+    ("crates/ironclaw_product_adapters/src/outbound.rs", "github"),
+    ("crates/ironclaw_product_adapters/src/outbound.rs", "google"),
+    ("crates/ironclaw_product_adapters/src/outbound.rs", "notion"),
+    ("crates/ironclaw_product_adapters/src/outbound.rs", "slack"),
+    (
+        "crates/ironclaw_product_workflow/src/conversation_binding.rs",
+        "slack",
+    ),
+    (
+        "crates/ironclaw_product_workflow/src/reborn_services.rs",
+        "slack",
+    ),
+    (
+        "crates/ironclaw_product_workflow/src/reborn_services/extensions.rs",
+        "slack",
+    ),
+    (
+        "crates/ironclaw_product_workflow/src/reborn_services/llm_config.rs",
+        "github",
+    ),
+    (
+        "crates/ironclaw_product_workflow/src/reborn_services/llm_config.rs",
+        "google",
+    ),
+    (
+        "crates/ironclaw_product_workflow/src/reborn_services/projects.rs",
+        "github",
+    ),
+    ("crates/ironclaw_product_workflow/src/workflow.rs", "slack"),
+    ("crates/ironclaw_projects/src/lib.rs", "github"),
+    ("crates/ironclaw_reborn/src/loop_driver_host.rs", "slack"),
+    ("crates/ironclaw_reborn/src/tool_disclosure.rs", "google"),
+    (
+        "crates/ironclaw_reborn/src/tool_disclosure.rs",
+        "google-calendar",
+    ),
+    (
+        "crates/ironclaw_reborn/src/tool_disclosure.rs",
+        "web-access",
+    ),
+    (
+        "crates/ironclaw_reborn/src/tool_disclosure_port.rs",
+        "google",
+    ),
+    (
+        "crates/ironclaw_reborn/src/tool_disclosure_port.rs",
+        "google-calendar",
+    ),
+    ("crates/ironclaw_reborn_composition/Cargo.toml", "slack"),
+    (
+        "crates/ironclaw_reborn_composition/src/automation/trigger_poller.rs",
+        "slack",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/blocked_auth_resume.rs",
+        "google",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/blocked_auth_resume.rs",
+        "slack",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/delivered_gate_routing.rs",
+        "slack",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/extension_host/available_extensions.rs",
+        "github",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/extension_host/available_extensions.rs",
+        "gmail",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/extension_host/available_extensions.rs",
+        "google",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/extension_host/available_extensions.rs",
+        "google-calendar",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/extension_host/available_extensions.rs",
+        "google-docs",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/extension_host/available_extensions.rs",
+        "google-drive",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/extension_host/available_extensions.rs",
+        "google-sheets",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/extension_host/available_extensions.rs",
+        "google-slides",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/extension_host/available_extensions.rs",
+        "google_calendar",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/extension_host/available_extensions.rs",
+        "google_docs",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/extension_host/available_extensions.rs",
+        "google_drive",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/extension_host/available_extensions.rs",
+        "google_sheets",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/extension_host/available_extensions.rs",
+        "google_slides",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/extension_host/available_extensions.rs",
+        "nearai-mcp",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/extension_host/available_extensions.rs",
+        "nearai_mcp",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/extension_host/available_extensions.rs",
+        "nearaimcp",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/extension_host/available_extensions.rs",
+        "notion",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/extension_host/available_extensions.rs",
+        "notion-mcp",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/extension_host/available_extensions.rs",
+        "notion_mcp",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/extension_host/available_extensions.rs",
+        "slack",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/extension_host/available_extensions.rs",
+        "web-access",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/extension_host/available_extensions.rs",
+        "web_access",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/extension_host/extension_activation_credentials.rs",
+        "slack",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/extension_host/extension_lifecycle.rs",
+        "github",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/extension_host/extension_lifecycle.rs",
+        "slack",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/extension_host/extension_lifecycle/hosted_mcp_test_support.rs",
+        "notion",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/extension_host/gsuite.rs",
+        "google",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/factory.rs",
+        "github",
+    ),
+    ("crates/ironclaw_reborn_composition/src/factory.rs", "gmail"),
+    (
+        "crates/ironclaw_reborn_composition/src/factory.rs",
+        "google",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/factory.rs",
+        "google-calendar",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/factory.rs",
+        "google-docs",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/factory.rs",
+        "google-drive",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/factory.rs",
+        "google-sheets",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/factory.rs",
+        "google-slides",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/factory.rs",
+        "google_calendar",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/factory.rs",
+        "google_docs",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/factory.rs",
+        "google_drive",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/factory.rs",
+        "google_sheets",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/factory.rs",
+        "google_slides",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/factory.rs",
+        "nearai_mcp",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/factory.rs",
+        "notion",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/factory.rs",
+        "notion_mcp",
+    ),
+    ("crates/ironclaw_reborn_composition/src/factory.rs", "slack"),
+    (
+        "crates/ironclaw_reborn_composition/src/factory.rs",
+        "web-access",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/factory.rs",
+        "web_access",
+    ),
+    ("crates/ironclaw_reborn_composition/src/input.rs", "google"),
+    (
+        "crates/ironclaw_reborn_composition/src/input.rs",
+        "nearai_mcp",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/input.rs",
+        "nearaimcp",
+    ),
+    ("crates/ironclaw_reborn_composition/src/input.rs", "notion"),
+    ("crates/ironclaw_reborn_composition/src/input.rs", "slack"),
+    ("crates/ironclaw_reborn_composition/src/lib.rs", "github"),
+    ("crates/ironclaw_reborn_composition/src/lib.rs", "google"),
+    (
+        "crates/ironclaw_reborn_composition/src/lib.rs",
+        "nearai_mcp",
+    ),
+    ("crates/ironclaw_reborn_composition/src/lib.rs", "nearaimcp"),
+    ("crates/ironclaw_reborn_composition/src/lib.rs", "slack"),
+    (
+        "crates/ironclaw_reborn_composition/src/lib.rs",
+        "web_access",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/llm_admin/mod.rs",
+        "nearai_mcp",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/llm_admin/nearai_login_serve.rs",
+        "github",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/llm_admin/nearai_login_serve.rs",
+        "google",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/llm_admin/nearai_mcp.rs",
+        "nearai_mcp",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/llm_admin/nearai_mcp.rs",
+        "nearaimcp",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/outbound/outbound_delivery_capability_surface.rs",
+        "slack",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/outbound/outbound_preferences.rs",
+        "slack",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/product_auth/api/auth.rs",
+        "google",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/product_auth/api/auth.rs",
+        "nearai_mcp",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/product_auth/api/auth.rs",
+        "slack",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/product_auth/api/auth_prompt.rs",
+        "slack",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/product_auth/credentials/credential_refresh_worker.rs",
+        "google",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/product_auth/credentials/product_auth_providers.rs",
+        "google",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/product_auth/credentials/product_auth_providers.rs",
+        "slack",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/product_auth/credentials/product_auth_refresh_lock.rs",
+        "google",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/product_auth/credentials/runtime_credentials.rs",
+        "google",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/product_auth/oauth/google_oauth/mod.rs",
+        "google",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/product_auth/oauth/mod.rs",
+        "google",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/product_auth/oauth/mod.rs",
+        "notion",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/product_auth/oauth/notion_oauth.rs",
+        "mcp.notion.com",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/product_auth/oauth/notion_oauth.rs",
+        "notion",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/product_auth/oauth/oauth_gate.rs",
+        "google",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/product_auth/oauth/oauth_gate.rs",
+        "slack",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/product_auth/oauth/oauth_provider_client.rs",
+        "google",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/product_auth/oauth/oauth_provider_client.rs",
+        "notion",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/product_auth/oauth/oauth_provider_client.rs",
+        "slack",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/product_auth/serve/mod.rs",
+        "google",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/product_auth/serve/mod.rs",
+        "slack",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/product_auth/serve/oauth.rs",
+        "google",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/product_auth/serve/oauth.rs",
+        "slack",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/projection.rs",
+        "slack",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/projection/display_preview.rs",
+        "web-access",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/projection/turn_events.rs",
+        "slack",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/root/communication_context.rs",
+        "slack",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/runtime.rs",
+        "github",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/runtime.rs",
+        "google",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/runtime.rs",
+        "nearai_mcp",
+    ),
+    ("crates/ironclaw_reborn_composition/src/runtime.rs", "slack"),
+    (
+        "crates/ironclaw_reborn_composition/src/runtime/local_dev/extension_surface.rs",
+        "web_access",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/runtime_input.rs",
+        "google",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/slack/mod.rs",
+        "slack",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/slack/slack_channel_connection.rs",
+        "slack",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/slack/slack_channel_routes.rs",
+        "slack",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/slack/slack_channel_routes/allowed.rs",
+        "slack",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/slack/slack_channel_routes/setup.rs",
+        "slack",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/slack/slack_channel_routes/subjects.rs",
+        "slack",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/slack/slack_delivery.rs",
+        "slack",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/slack/slack_delivery.rs",
+        "slack.com",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/slack/slack_dm_open.rs",
+        "slack",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/slack/slack_egress.rs",
+        "slack",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/slack/slack_host_beta.rs",
+        "slack",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/slack/slack_host_beta/runtime_setup.rs",
+        "slack",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/slack/slack_host_state.rs",
+        "slack",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/slack/slack_outbound_targets.rs",
+        "slack",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/slack/slack_personal_binding.rs",
+        "slack",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/slack/slack_personal_binding_serve.rs",
+        "slack",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/slack/slack_personal_oauth.rs",
+        "google",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/slack/slack_personal_oauth.rs",
+        "slack",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/slack/slack_serve.rs",
+        "slack",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/slack/slack_serve/installation.rs",
+        "slack",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/slack/slack_setup.rs",
+        "slack",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/test_support/mod.rs",
+        "google",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/test_support/oauth_product_auth.rs",
+        "google",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/web_access.rs",
+        "web_access",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/web_access.rs",
+        "webaccess",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/webui/webui_serve.rs",
+        "google",
+    ),
+    (
+        "crates/ironclaw_reborn_composition/src/webui/webui_serve.rs",
+        "slack",
+    ),
+    ("crates/ironclaw_reborn_config/src/config_file.rs", "slack"),
+    ("crates/ironclaw_reborn_config/src/lib.rs", "slack"),
+    (
+        "crates/ironclaw_reborn_identity/src/filesystem_store.rs",
+        "slack",
+    ),
+    ("crates/ironclaw_reborn_identity/src/key.rs", "github"),
+    ("crates/ironclaw_reborn_identity/src/key.rs", "google"),
+    ("crates/ironclaw_reborn_identity/src/key.rs", "slack"),
+    ("crates/ironclaw_reborn_identity/src/lib.rs", "github"),
+    ("crates/ironclaw_reborn_identity/src/lib.rs", "google"),
+    ("crates/ironclaw_reborn_identity/src/lib.rs", "slack"),
+    ("crates/ironclaw_reborn_traces/src/client.rs", "slack"),
+    (
+        "crates/ironclaw_reborn_traces/src/contribution.rs",
+        "github",
+    ),
+    ("crates/ironclaw_reborn_traces/src/contribution.rs", "gmail"),
+    ("crates/ironclaw_reborn_traces/src/contribution.rs", "slack"),
+    ("crates/ironclaw_skills/src/selector.rs", "github"),
+    ("crates/ironclaw_skills/src/types.rs", "github"),
+    ("crates/ironclaw_skills/src/types.rs", "google"),
+    ("crates/ironclaw_skills/src/types.rs", "slack"),
+    (
+        "crates/ironclaw_wasm_product_adapters/src/auth_verifier.rs",
+        "slack",
+    ),
+    (
+        "crates/ironclaw_wasm_product_adapters/src/egress_policy.rs",
+        "slack",
+    ),
+    (
+        "crates/ironclaw_wasm_product_adapters/src/egress_policy.rs",
+        "slack.com",
+    ),
+    (
+        "crates/ironclaw_wasm_product_adapters/src/runner.rs",
+        "slack",
+    ),
+    (
+        "crates/ironclaw_wasm_product_adapters/src/runner_immediate_ack.rs",
+        "slack",
+    ),
+    (
+        "crates/ironclaw_webui_v2/frontend/src/components/slack-channel-picker.tsx",
+        "slack",
+    ),
+    (
+        "crates/ironclaw_webui_v2/frontend/src/components/slack-setup-panel.tsx",
+        "slack",
+    ),
+    ("crates/ironclaw_webui_v2/frontend/src/i18n/ar.ts", "github"),
+    ("crates/ironclaw_webui_v2/frontend/src/i18n/ar.ts", "google"),
+    ("crates/ironclaw_webui_v2/frontend/src/i18n/ar.ts", "slack"),
+    ("crates/ironclaw_webui_v2/frontend/src/i18n/de.ts", "github"),
+    ("crates/ironclaw_webui_v2/frontend/src/i18n/de.ts", "google"),
+    ("crates/ironclaw_webui_v2/frontend/src/i18n/de.ts", "slack"),
+    ("crates/ironclaw_webui_v2/frontend/src/i18n/en.ts", "github"),
+    ("crates/ironclaw_webui_v2/frontend/src/i18n/en.ts", "google"),
+    ("crates/ironclaw_webui_v2/frontend/src/i18n/en.ts", "slack"),
+    ("crates/ironclaw_webui_v2/frontend/src/i18n/es.ts", "github"),
+    ("crates/ironclaw_webui_v2/frontend/src/i18n/es.ts", "google"),
+    ("crates/ironclaw_webui_v2/frontend/src/i18n/es.ts", "slack"),
+    ("crates/ironclaw_webui_v2/frontend/src/i18n/fr.ts", "github"),
+    ("crates/ironclaw_webui_v2/frontend/src/i18n/fr.ts", "google"),
+    ("crates/ironclaw_webui_v2/frontend/src/i18n/fr.ts", "slack"),
+    ("crates/ironclaw_webui_v2/frontend/src/i18n/hi.ts", "github"),
+    ("crates/ironclaw_webui_v2/frontend/src/i18n/hi.ts", "google"),
+    ("crates/ironclaw_webui_v2/frontend/src/i18n/hi.ts", "slack"),
+    ("crates/ironclaw_webui_v2/frontend/src/i18n/ja.ts", "github"),
+    ("crates/ironclaw_webui_v2/frontend/src/i18n/ja.ts", "google"),
+    ("crates/ironclaw_webui_v2/frontend/src/i18n/ja.ts", "slack"),
+    ("crates/ironclaw_webui_v2/frontend/src/i18n/ko.ts", "github"),
+    ("crates/ironclaw_webui_v2/frontend/src/i18n/ko.ts", "google"),
+    ("crates/ironclaw_webui_v2/frontend/src/i18n/ko.ts", "slack"),
+    (
+        "crates/ironclaw_webui_v2/frontend/src/i18n/pt-BR.ts",
+        "github",
+    ),
+    (
+        "crates/ironclaw_webui_v2/frontend/src/i18n/pt-BR.ts",
+        "google",
+    ),
+    (
+        "crates/ironclaw_webui_v2/frontend/src/i18n/pt-BR.ts",
+        "slack",
+    ),
+    ("crates/ironclaw_webui_v2/frontend/src/i18n/uk.ts", "github"),
+    ("crates/ironclaw_webui_v2/frontend/src/i18n/uk.ts", "google"),
+    ("crates/ironclaw_webui_v2/frontend/src/i18n/uk.ts", "slack"),
+    (
+        "crates/ironclaw_webui_v2/frontend/src/i18n/zh-CN.ts",
+        "github",
+    ),
+    (
+        "crates/ironclaw_webui_v2/frontend/src/i18n/zh-CN.ts",
+        "google",
+    ),
+    (
+        "crates/ironclaw_webui_v2/frontend/src/i18n/zh-CN.ts",
+        "slack",
+    ),
+    (
+        "crates/ironclaw_webui_v2/frontend/src/lib/channel-connection-events.ts",
+        "slack",
+    ),
+    (
+        "crates/ironclaw_webui_v2/frontend/src/lib/slack-channels-api.ts",
+        "slack",
+    ),
+    (
+        "crates/ironclaw_webui_v2/frontend/src/lib/slack-setup-api.ts",
+        "slack",
+    ),
+    (
+        "crates/ironclaw_webui_v2/frontend/src/pages/automations/components/automation-delivery-defaults-panel.tsx",
+        "slack",
+    ),
+    (
+        "crates/ironclaw_webui_v2/frontend/src/pages/chat/chat.tsx",
+        "slack",
+    ),
+    (
+        "crates/ironclaw_webui_v2/frontend/src/pages/chat/components/auth-oauth-card.tsx",
+        "github",
+    ),
+    (
+        "crates/ironclaw_webui_v2/frontend/src/pages/chat/components/auth-oauth-card.tsx",
+        "google",
+    ),
+    (
+        "crates/ironclaw_webui_v2/frontend/src/pages/chat/components/auth-oauth-card.tsx",
+        "notion",
+    ),
+    (
+        "crates/ironclaw_webui_v2/frontend/src/pages/chat/components/auth-oauth-card.tsx",
+        "slack",
+    ),
+    (
+        "crates/ironclaw_webui_v2/frontend/src/pages/chat/lib/gates.ts",
+        "github",
+    ),
+    (
+        "crates/ironclaw_webui_v2/frontend/src/pages/extensions/components/channels-tab.tsx",
+        "slack",
+    ),
+    (
+        "crates/ironclaw_webui_v2/frontend/src/pages/extensions/components/configure-modal.tsx",
+        "slack",
+    ),
+    (
+        "crates/ironclaw_webui_v2/frontend/src/pages/extensions/lib/pairing-api.ts",
+        "slack",
+    ),
+    (
+        "crates/ironclaw_webui_v2/frontend/src/pages/login/components/oauth-provider-buttons.tsx",
+        "github",
+    ),
+    (
+        "crates/ironclaw_webui_v2/frontend/src/pages/login/components/oauth-provider-buttons.tsx",
+        "google",
+    ),
+    (
+        "crates/ironclaw_webui_v2/frontend/src/pages/login/hooks/useOAuthProviders.ts",
+        "github",
+    ),
+    (
+        "crates/ironclaw_webui_v2/frontend/src/pages/login/hooks/useOAuthProviders.ts",
+        "google",
+    ),
+    (
+        "crates/ironclaw_webui_v2/frontend/src/pages/onboarding/onboarding-page.tsx",
+        "github",
+    ),
+    (
+        "crates/ironclaw_webui_v2/frontend/src/pages/onboarding/onboarding-page.tsx",
+        "google",
+    ),
+    (
+        "crates/ironclaw_webui_v2/frontend/src/pages/settings/components/provider-card.tsx",
+        "github",
+    ),
+    (
+        "crates/ironclaw_webui_v2/frontend/src/pages/settings/components/provider-card.tsx",
+        "google",
+    ),
+    (
+        "crates/ironclaw_webui_v2/frontend/src/pages/settings/hooks/useProviderLogin.ts",
+        "github",
+    ),
+    (
+        "crates/ironclaw_webui_v2/frontend/src/pages/settings/hooks/useProviderLogin.ts",
+        "google",
+    ),
+    (
+        "crates/ironclaw_webui_v2/frontend/src/pages/settings/hooks/useProviderLogin.ts",
+        "private.near.ai",
+    ),
+];
+
+/// One `(relative path, matched term)` scanner hit.
+type HitEntry = (String, String);
+
+fn classify_hits(
+    hits: &BTreeSet<HitEntry>,
+    allowlist: &[(&str, &str)],
+) -> (Vec<HitEntry>, Vec<HitEntry>) {
+    let allowed: BTreeSet<HitEntry> = allowlist
+        .iter()
+        .map(|(path, term)| (path.to_string(), term.to_string()))
+        .collect();
+    let new_violations = hits.difference(&allowed).cloned().collect();
+    let stale_entries = allowed.difference(hits).cloned().collect();
+    (new_violations, stale_entries)
+}
+
+// ---------------------------------------------------------------------------
+// The gate
+// ---------------------------------------------------------------------------
+
+#[test]
+fn reborn_generic_code_names_no_concrete_extension() {
+    let root = workspace_root();
+    let terms = derive_forbidden_terms(&inventory_dirs(&root));
+    assert!(
+        !terms.is_empty(),
+        "inventory-derived term set must not be empty — is the package inventory readable?"
+    );
+    let raw_hits = collect_workspace_hits(&root, &terms);
+    let (hits, stale_carve_outs) = apply_path_term_collisions(raw_hits);
+    let (new_violations, stale_entries) = classify_hits(&hits, ALLOWLIST);
+
+    let mut failures = Vec::new();
+    if !stale_carve_outs.is_empty() {
+        failures.push(format!(
+            "stale PATH_TERM_COLLISIONS carve-outs (nothing matches any more — delete \
+             them):\n{}",
+            stale_carve_outs.join("\n")
+        ));
+    }
+    if !new_violations.is_empty() {
+        failures.push(format!(
+            "concrete extension names in generic code (fix the code, or — for pre-existing \
+             debt only — add the exact entries below to ALLOWLIST):\n{}",
+            new_violations
+                .iter()
+                .map(|(path, term)| format!("    (\"{path}\", \"{term}\"),"))
+                .collect::<Vec<_>>()
+                .join("\n")
+        ));
+    }
+    if !stale_entries.is_empty() {
+        failures.push(format!(
+            "stale ALLOWLIST entries (the file no longer matches the term — delete the \
+             entries; the allowlist only shrinks):\n{}",
+            stale_entries
+                .iter()
+                .map(|(path, term)| format!("    (\"{path}\", \"{term}\"),"))
+                .collect::<Vec<_>>()
+                .join("\n")
+        ));
+    }
+    assert!(
+        failures.is_empty(),
+        "extension specificity gate failed:\n\n{}",
+        failures.join("\n\n")
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Dependency gate — only the binary and tests link concrete extension crates
+// ---------------------------------------------------------------------------
+
+/// Production (normal/build) dependency edges onto concrete extension crates
+/// that predate the unified runtime. Each names the phase that deletes it; a
+/// stale entry (edge no longer present) fails so the list only shrinks.
+/// Checklist DEL-7 requires this list empty.
+const CONCRETE_DEPENDENCY_EXCEPTIONS: &[(&str, &str, &str)] = &[(
+    "ironclaw_reborn_composition",
+    "ironclaw_slack_v2_adapter",
+    "P6 deletes composition/src/slack/** and the slack-v2-host-beta feature (DEL-1, DEL-3)",
+)];
+
+#[test]
+fn concrete_extension_crates_link_only_from_the_binary_and_tests() {
+    let root = workspace_root();
+    let metadata = cargo_metadata(&root);
+    let packages = metadata["packages"]
+        .as_array()
+        .expect("cargo metadata must include packages");
+
+    // Fail-open guard: a concrete crate with a Cargo.toml on disk must be a
+    // registered workspace member, or its edges would be invisible here.
+    let registered: BTreeSet<&str> = packages
+        .iter()
+        .filter_map(|package| package["name"].as_str())
+        .collect();
+    for concrete in CONCRETE_EXTENSION_CRATES {
+        let manifest = root.join("crates").join(concrete).join("Cargo.toml");
+        if manifest.exists() {
+            assert!(
+                registered.contains(concrete),
+                "{concrete} has a Cargo.toml but is not in cargo metadata; register it as a \
+                 workspace member so this gate actually checks its dependents"
+            );
+        }
+    }
+
+    let mut violations = Vec::new();
+    let mut used_exceptions = BTreeSet::new();
+    for package in packages {
+        let Some(name) = package["name"].as_str() else {
+            continue;
+        };
+        if !(name == "ironclaw" || name.starts_with("ironclaw_")) {
+            continue;
+        }
+        if name == "ironclaw_reborn_cli" || CONCRETE_EXTENSION_CRATES.contains(&name) {
+            continue;
+        }
+        let Some(dependencies) = package["dependencies"].as_array() else {
+            continue;
+        };
+        for dependency in dependencies {
+            let Some(dependency_name) = dependency["name"].as_str() else {
+                continue;
+            };
+            if !CONCRETE_EXTENSION_CRATES.contains(&dependency_name) {
+                continue;
+            }
+            // Dev-dependencies are the sanctioned test linkage.
+            if dependency["kind"].as_str() == Some("dev") {
+                continue;
+            }
+            if CONCRETE_DEPENDENCY_EXCEPTIONS
+                .iter()
+                .any(|(dependent, concrete, _)| *dependent == name && *concrete == dependency_name)
+            {
+                used_exceptions.insert((name.to_string(), dependency_name.to_string()));
+                continue;
+            }
+            violations.push(format!(
+                "{name} takes a production dependency on concrete extension crate \
+                 {dependency_name}; only ironclaw_reborn_cli (native factory assembly) and \
+                 dev-dependencies may"
+            ));
+        }
+    }
+    assert!(
+        violations.is_empty(),
+        "concrete extension crate dependency gate failed:\n{}",
+        violations.join("\n")
+    );
+
+    let stale: Vec<String> = CONCRETE_DEPENDENCY_EXCEPTIONS
+        .iter()
+        .filter(|(dependent, concrete, _)| {
+            !used_exceptions.contains(&(dependent.to_string(), concrete.to_string()))
+        })
+        .map(|(dependent, concrete, removes_in)| {
+            format!("{dependent} -> {concrete} (scheduled removal: {removes_in})")
+        })
+        .collect();
+    assert!(
+        stale.is_empty(),
+        "stale CONCRETE_DEPENDENCY_EXCEPTIONS entries — the edge is gone, delete the \
+         exception:\n{}",
+        stale.join("\n")
+    );
+}
+
+fn cargo_metadata(root: &Path) -> Value {
+    let output = Command::new("cargo")
+        .args(["metadata", "--format-version", "1", "--manifest-path"])
+        .arg(root.join("Cargo.toml"))
+        .output()
+        .expect("cargo metadata must run");
+    assert!(
+        output.status.success(),
+        "cargo metadata failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).expect("cargo metadata must be valid JSON")
+}
+
+// ---------------------------------------------------------------------------
+// Scanner self-tests (TEST-6, TEST-7)
+// ---------------------------------------------------------------------------
+
+/// TEST-6: the forbidden vocabulary derives from the inventory — an invented
+/// package id is caught without editing the scanner.
+#[test]
+fn scanner_derives_terms_from_an_invented_inventory_package() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let package_dir = temp.path().join("zephyr-chat");
+    std::fs::create_dir_all(&package_dir).expect("create package dir");
+    std::fs::write(
+        package_dir.join("manifest.toml"),
+        r#"
+schema_version = "reborn.extension_manifest.v3"
+id = "zephyr-chat"
+name = "Zephyr Chat"
+version = "0.1.0"
+description = "invented"
+trust = "first_party_requested"
+
+[runtime]
+kind = "first_party"
+service = "zephyr-chat.extension/v1"
+
+[[tools]]
+id = "zephyr.send"
+description = "send"
+effects = ["network"]
+default_permission = "ask"
+visibility = "model"
+input_schema_ref = "schemas/zephyr/send.input.v1.json"
+
+[[tools.credentials]]
+handle = "zephyr_token"
+vendor = "zephyr"
+scopes = ["send"]
+audience = { scheme = "https", host = "api.zephyr.example" }
+injection = { type = "header", name = "authorization", prefix = "Bearer " }
+
+[auth.zephyr]
+method = "oauth2_code"
+display_name = "Zephyr account"
+authorization_endpoint = "https://auth.zephyr.example/authorize"
+token_endpoint = "https://auth.zephyr.example/token"
+scopes = ["send"]
+"#,
+    )
+    .expect("write manifest");
+
+    let terms = derive_forbidden_terms(&[temp.path().to_path_buf()]);
+    for expected in [
+        "zephyr-chat",
+        "zephyr_chat",
+        "zephyrchat",
+        "zephyr",
+        "api.zephyr.example",
+        "auth.zephyr.example",
+    ] {
+        assert!(
+            terms.contains(expected),
+            "expected derived term `{expected}`; derived set: {terms:?}"
+        );
+    }
+
+    // A generic source file naming the invented product is caught, including
+    // the camel-case compound form.
+    let source_dir = temp.path().join("generic_crate/src");
+    std::fs::create_dir_all(&source_dir).expect("create src dir");
+    let source_path = source_dir.join("lib.rs");
+    std::fs::write(
+        &source_path,
+        "pub struct ZephyrChatDelivery;\npub fn route() -> &'static str { \"generic\" }\n",
+    )
+    .expect("write source");
+    let matched = scan_file(&source_path, FileKind::Rust, &terms);
+    assert!(
+        matched.contains(&"zephyrchat".to_string()),
+        "camel-case compound must be caught; matched: {matched:?}"
+    );
+}
+
+/// TEST-7: the allowlist can only shrink — stale entries fail and new
+/// violations fail.
+#[test]
+fn scanner_allowlist_is_shrink_only() {
+    let hits: BTreeSet<(String, String)> = [
+        ("crates/a/src/lib.rs".to_string(), "slack".to_string()),
+        ("crates/b/src/lib.rs".to_string(), "github".to_string()),
+    ]
+    .into_iter()
+    .collect();
+    let allowlist = [
+        ("crates/a/src/lib.rs", "slack"),
+        ("crates/gone/src/lib.rs", "gmail"),
+    ];
+    let (new_violations, stale_entries) = classify_hits(&hits, &allowlist);
+    assert_eq!(
+        new_violations,
+        vec![("crates/b/src/lib.rs".to_string(), "github".to_string())],
+        "an unlisted hit must be reported as a new violation"
+    );
+    assert_eq!(
+        stale_entries,
+        vec![("crates/gone/src/lib.rs".to_string(), "gmail".to_string())],
+        "an allowlist entry with no matching hit must be reported stale"
+    );
+}
+
+/// The carve-out list stays scoped to the documented LLM-vocabulary
+/// collisions; broadening it is a gate regression.
+#[test]
+fn term_collision_carve_outs_stay_documented_and_narrow() {
+    assert_eq!(
+        TERM_COLLISIONS
+            .iter()
+            .map(|(term, _)| *term)
+            .collect::<Vec<_>>(),
+        vec!["nearai", "near.ai"],
+        "bare-term carve-outs are reserved for LLM-provider vocabulary collisions"
+    );
+    let carved_terms: BTreeSet<&str> = PATH_TERM_COLLISIONS
+        .iter()
+        .map(|(_, term, _)| *term)
+        .collect();
+    assert_eq!(
+        carved_terms,
+        BTreeSet::from([
+            "google",
+            "github",
+            "slack",
+            "api.github.com",
+            "private.near.ai"
+        ]),
+        "path-scoped carve-outs are reserved for the four documented collision domains \
+         (LLM providers, SSO login, GitHub-as-skill-source, credential-format detection); \
+         new terms here are a gate regression"
+    );
+    let carved_paths: BTreeSet<&str> = PATH_TERM_COLLISIONS
+        .iter()
+        .map(|(fragment, _, _)| *fragment)
+        .collect();
+    for fragment in &carved_paths {
+        assert!(
+            !fragment.contains("composition") && !fragment.contains("product_workflow"),
+            "carve-outs must never cover the product assembly/workflow crates — those are \
+             debt, not collisions: {fragment}"
+        );
+    }
+    let root = workspace_root();
+    let terms = derive_forbidden_terms(&inventory_dirs(&root));
+    for compound in ["nearai-mcp", "nearai_mcp", "nearaimcp", "private.near.ai"] {
+        assert!(
+            terms.contains(compound),
+            "compound extension forms must survive the carve-outs; missing `{compound}`"
+        );
+    }
+}

--- a/docs/reborn/extension-runtime/checklist.md
+++ b/docs/reborn/extension-runtime/checklist.md
@@ -308,11 +308,16 @@ Rules — kept short on purpose:
   integration harness.
 - [ ] TEST-5 Slack and Telegram each have exactly one inbound and one outbound
   integration proof; protocol details are unit-tested inside their crates.
-- [ ] TEST-6 The specificity scanner derives forbidden names from the package
+- [x] TEST-6 The specificity scanner derives forbidden names from the package
   inventory (an invented product id in a fixture is caught without editing the
-  scanner).
-- [ ] TEST-7 Allowlist shrinkage is enforced: stale entries fail, new
-  violations fail.
+  scanner). — `scanner_derives_terms_from_an_invented_inventory_package`
+  (`crates/ironclaw_architecture/tests/reborn_extension_specificity.rs`); the
+  acme fixture itself is derivation input.
+- [x] TEST-7 Allowlist shrinkage is enforced: stale entries fail, new
+  violations fail. — `scanner_allowlist_is_shrink_only` plus the stale-entry
+  and stale-carve-out assertions inside
+  `reborn_generic_code_names_no_concrete_extension`; same discipline on the
+  dependency gate (`concrete_extension_crates_link_only_from_the_binary_and_tests`).
 
 ## 12. Release (REL)
 

--- a/scripts/ci/check-generic-without-concrete.sh
+++ b/scripts/ci/check-generic-without-concrete.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# The automated deletion test (docs/reborn/extension-runtime/overview.md §8,
+# checklist DEL-9): every generic Reborn crate's dependency graph must be free
+# of concrete extension crates, and its tests must pass without them.
+#
+# Generic crates are derived from `cargo metadata` — every `ironclaw_*`
+# workspace crate declaring a Reborn layer — minus the concrete extension
+# crates themselves, the package inventory crate, and the sanctioned
+# assemblers (the binary, the migration app, the architecture test crate).
+# This mirrors `crates/ironclaw_architecture/tests/reborn_extension_specificity.rs`;
+# keep the two lists in sync.
+#
+# TEMPORARY_EXCEPTIONS below mirrors CONCRETE_DEPENDENCY_EXCEPTIONS in that
+# test: crates listed there are skipped with a warning until the phase that
+# deletes the edge lands. The list must be empty by P7 (checklist DEL-7/DEL-9).
+#
+# Usage: scripts/ci/check-generic-without-concrete.sh [--trees-only]
+#   --trees-only  verify dependency graphs but skip the per-crate test runs
+#                 (fast local mode; CI runs the full form)
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+TREES_ONLY=false
+if [ "${1:-}" = "--trees-only" ]; then
+  TREES_ONLY=true
+fi
+
+CONCRETE_CRATES=(
+  ironclaw_slack_v2_adapter
+  ironclaw_telegram_v2_adapter
+  ironclaw_slack_extension
+  ironclaw_telegram_extension
+)
+
+# dependent-crate:removal-phase — mirrors CONCRETE_DEPENDENCY_EXCEPTIONS.
+TEMPORARY_EXCEPTIONS=(
+  "ironclaw_reborn_composition:P6"
+)
+
+GENERIC_CRATES=()
+while IFS= read -r crate_name; do
+  GENERIC_CRATES+=("$crate_name")
+done < <(cargo metadata --format-version 1 | python3 -c '
+import json, sys
+
+REBORN_LAYERS = {"contracts", "substrates", "runtimes", "kernel", "loops", "products", "app"}
+EXCLUDED = {
+    # Concrete extension crates (the deletion test subjects, not its scope).
+    "ironclaw_slack_v2_adapter",
+    "ironclaw_telegram_v2_adapter",
+    "ironclaw_slack_extension",
+    "ironclaw_telegram_extension",
+    # The package inventory crate owns the concrete packages.
+    "ironclaw_first_party_extensions",
+    # Sanctioned assemblers.
+    "ironclaw_reborn_cli",
+    "ironclaw_reborn_migration",
+    "ironclaw_architecture",
+    "ironclaw_stress",
+}
+
+metadata = json.load(sys.stdin)
+for package in metadata["packages"]:
+    name = package["name"]
+    if not (name == "ironclaw" or name.startswith("ironclaw_")):
+        continue
+    if name in EXCLUDED:
+        continue
+    layer = (package.get("metadata") or {}).get("ironclaw", {}).get("layer")
+    if layer in REBORN_LAYERS:
+        print(name)
+' | sort)
+
+if [ "${#GENERIC_CRATES[@]}" -eq 0 ]; then
+  echo "error: derived no generic crates from cargo metadata" >&2
+  exit 1
+fi
+
+echo "checking ${#GENERIC_CRATES[@]} generic crates for concrete extension dependencies"
+
+is_excepted() {
+  local crate="$1"
+  for entry in "${TEMPORARY_EXCEPTIONS[@]}"; do
+    if [ "${entry%%:*}" = "$crate" ]; then
+      echo "${entry##*:}"
+      return 0
+    fi
+  done
+  return 1
+}
+
+failures=()
+for crate in "${GENERIC_CRATES[@]}"; do
+  if phase="$(is_excepted "$crate")"; then
+    echo "SKIP  $crate (temporary exception, removed in $phase)"
+    continue
+  fi
+  tree="$(cargo tree -p "$crate" --all-features -e normal,build --prefix none 2>/dev/null || true)"
+  if [ -z "$tree" ]; then
+    failures+=("$crate: cargo tree produced no output")
+    continue
+  fi
+  for concrete in "${CONCRETE_CRATES[@]}"; do
+    if printf '%s\n' "$tree" | grep -q "^${concrete} "; then
+      failures+=("$crate: dependency graph contains concrete extension crate ${concrete}")
+    fi
+  done
+done
+
+if [ "${#failures[@]}" -gt 0 ]; then
+  printf 'concrete extension crates leaked into generic dependency graphs:\n' >&2
+  printf '  %s\n' "${failures[@]}" >&2
+  exit 1
+fi
+echo "dependency graphs clean"
+
+if [ "$TREES_ONLY" = true ]; then
+  echo "--trees-only: skipping per-crate test runs"
+  exit 0
+fi
+
+for crate in "${GENERIC_CRATES[@]}"; do
+  if phase="$(is_excepted "$crate")"; then
+    continue
+  fi
+  echo "==> cargo test -p $crate"
+  cargo test -p "$crate" --quiet
+done
+echo "generic crates build and pass tests without concrete extension crates"

--- a/tests/fixtures/extensions/acme-messenger/manifest.toml
+++ b/tests/fixtures/extensions/acme-messenger/manifest.toml
@@ -1,0 +1,99 @@
+# The invented-vendor fixture extension (overview.md §8, implementation.md §12).
+#
+# Drives every generic end-to-end path in the integration harness — install →
+# configure → connect → inbound → turn → outbound → upgrade → remove — proving
+# that no generic path needs a real product. Its identifiers ("acme", the
+# acme.example hosts) are part of the package inventory the specificity
+# scanner derives from, so generic production code can never hardcode them.
+schema_version = "reborn.extension_manifest.v3"
+id = "acme-messenger"
+name = "Acme Messenger"
+version = "0.1.0"
+description = "Invented-vendor fixture: one tool, one channel, and an OAuth recipe for the generic extension runtime's conformance and integration suites."
+trust = "first_party_requested"
+
+[runtime]
+kind = "first_party"
+service = "acme-messenger.extension/v1"
+
+# ---- tool surface ----------------------------------------------------------
+
+[[tools]]
+id = "acme.send_note"
+description = "Send a note to an Acme Messenger conversation as the connected user. Side effect inside a job; never used to deliver the final answer."
+effects = ["network", "use_secret", "external_write"]
+default_permission = "ask"
+visibility = "model"
+input_schema_ref = "schemas/acme/send_note.input.v1.json"
+prompt_doc_ref = "prompts/acme/send_note.md"
+
+[[tools.credentials]]
+handle = "acme_user_token"
+vendor = "acme"
+scopes = ["notes:write"]
+audience = { scheme = "https", host = "api.acme.example" }
+injection = { type = "header", name = "authorization", prefix = "Bearer " }
+
+# ---- channel surface (at most one per extension) ---------------------------
+
+[channel]
+id = "messages"
+display_name = "Acme messages"
+inbound = true
+outbound = true
+conversation_model = "continuous"
+
+[channel.ingress]
+route_suffix = "events"           # served at /webhooks/extensions/acme-messenger/events
+method = "post"
+body_limit_bytes = 1048576
+
+[channel.ingress.verification]
+kind = "hmac_sha256"
+secret_handle = "acme_signing_secret"
+signature_header = "X-Acme-Signature"
+signature_prefix = "v0="
+signature_encoding = "hex"
+timestamp_header = "X-Acme-Request-Timestamp"
+max_age_seconds = 300
+signed_payload = [
+  { literal = "v0:" },
+  { header = "X-Acme-Request-Timestamp" },
+  { literal = ":" },
+  { body = true },
+]
+
+[channel.config]                  # operator setup; the host renders the generic form
+fields = [
+  { handle = "acme_bot_token", label = "Bot token", secret = true },
+  { handle = "acme_signing_secret", label = "Signing secret", secret = true },
+]
+
+[[channel.egress]]
+scheme = "https"
+host = "api.acme.example"
+methods = ["post"]
+credential_handle = "acme_bot_token"
+
+[channel.presentation]
+supports_markdown = true
+supports_threads = false
+max_message_chars = 4000
+
+# ---- auth surface: recipe data, zero extension code ------------------------
+
+[auth.acme]                       # section key = the vendor id
+method = "oauth2_code"
+display_name = "Acme account"
+authorization_endpoint = "https://auth.acme.example/oauth/authorize"
+token_endpoint = "https://auth.acme.example/oauth/token"
+pkce = "s256"
+scopes = ["notes:write"]
+client_credentials = { client_id_handle = "acme_oauth_client_id", client_secret_handle = "acme_oauth_client_secret" }
+
+[auth.acme.token_response]
+access_token = "/access_token"
+scope = { path = "/scope", missing = "fallback_to_requested" }
+
+[auth.acme.identity]
+account_id = "/account/id"

--- a/tests/fixtures/extensions/acme-messenger/prompts/acme/send_note.md
+++ b/tests/fixtures/extensions/acme-messenger/prompts/acme/send_note.md
@@ -1,0 +1,10 @@
+# acme.send_note
+
+Send a note into an Acme Messenger conversation as the connected user.
+
+- Use only when the job explicitly requires posting into Acme Messenger as a
+  side effect.
+- Never use this tool to deliver the final answer; the host delivers final
+  replies on the conversation's outbound channel.
+- `conversation_id` comes from context or an earlier listing; do not invent
+  ids.

--- a/tests/fixtures/extensions/acme-messenger/schemas/acme/send_note.input.v1.json
+++ b/tests/fixtures/extensions/acme-messenger/schemas/acme/send_note.input.v1.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "acme.send_note input",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["conversation_id", "text"],
+  "properties": {
+    "conversation_id": {
+      "type": "string",
+      "description": "Acme conversation id to post the note into.",
+      "minLength": 1,
+      "maxLength": 128
+    },
+    "text": {
+      "type": "string",
+      "description": "Note body.",
+      "minLength": 1,
+      "maxLength": 4000
+    }
+  }
+}


### PR DESCRIPTION
**Runtime train, PR 1 of 8 — phase P0.** First of the P0–P7 runtime PRs (`docs/reborn/extension-runtime/implementation.md` §13), stacked on the NEA-25 taxonomy tip. Additive only — no production runtime behavior — so it is green and reviewable standalone.

## Contents

- **Concrete-name specificity scanner** (`crates/ironclaw_architecture/tests/reborn_extension_specificity.rs`): forbidden vocabulary derived from the bundled package inventory (a future `discord` package is caught with no scanner edit); a shrink-only `(path, term)` allowlist enumerating today's 269 violations; four documented, self-test-pinned permanent collision carve-outs (LLM providers, WebUI SSO login, GitHub-as-skill-source, credential-format detectors).
- **Dependency gate**: only the binary and dev-dependencies may link concrete extension crates (one staleness-enforced exception for the pre-existing composition→slack_v2_adapter edge, scheduled for P6).
- **`scripts/ci/check-generic-without-concrete.sh`**: the automated deletion test — every generic crate's graph free of concrete extension crates.
- **`tests/fixtures/extensions/acme-messenger/`**: the invented-vendor v3 fixture used by the later phases' conformance/integration suites.

## Verification

architecture gates 47/0 · `check-generic-without-concrete.sh --trees-only` clean across 63 generic crates · fmt/clippy clean. Checklist TEST-6, TEST-7 checked with named evidence.

## Stack

Next: **PR 10 = P1** (manifest v3 + VendorId + recipes + resolved record), **PR 11 = P2** (adapters + ExtensionHost + dispatch cutover, WIP). Full target is 16 PRs (8 taxonomy + P0–P7 runtime).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
