### PR TITLE
fix: update IronLoop auto-review config

### DIFF
--- a/.ironloop/agents.yaml
+++ b/.ironloop/agents.yaml
@@ -6,7 +6,6 @@ reviewers:
     network_access: true
     auto_review:
       enabled: true
-      on_update: false
 
 developers:
   - id: implementer


### PR DESCRIPTION
## Summary

- remove the unsupported `auto_review.on_update` field
- keep automatic review enabled with the current IronLoop schema

## Validation

- parsed `.ironloop/agents.yaml` with IronLoop's current strict config parser
- `git diff --check`