### PR TITLE
fix(reborn): surface unwired component in production validation error

### DIFF
--- a/crates/ironclaw_host_runtime/src/services/production_wiring.rs
+++ b/crates/ironclaw_host_runtime/src/services/production_wiring.rs
@@ -187,21 +187,11 @@ impl ProductionWiringIssue {
 
 impl fmt::Display for ProductionWiringIssue {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self.implementation {
-            Some(implementation) => write!(
-                formatter,
-                "{}={} ({})",
-                self.component.as_str(),
-                implementation,
-                self.kind.as_str()
-            ),
-            None => write!(
-                formatter,
-                "{} ({})",
-                self.component.as_str(),
-                self.kind.as_str()
-            ),
+        formatter.write_str(self.component.as_str())?;
+        if let Some(implementation) = self.implementation {
+            write!(formatter, "={implementation}")?;
         }
+        write!(formatter, " ({})", self.kind.as_str())
     }
 }
 

--- a/crates/ironclaw_host_runtime/src/services/production_wiring.rs
+++ b/crates/ironclaw_host_runtime/src/services/production_wiring.rs
@@ -1,4 +1,5 @@
 use std::any::{TypeId, type_name};
+use std::fmt;
 
 use thiserror::Error;
 
@@ -16,7 +17,7 @@ use super::{
 pub enum ProductionEventStoreWiringError {
     #[error("failed to build Reborn event stores: {0}")]
     EventStore(#[from] RebornEventStoreError),
-    #[error("host runtime production wiring failed")]
+    #[error("host runtime production wiring failed: {0}")]
     ProductionWiring(ProductionWiringReport),
 }
 
@@ -142,6 +143,17 @@ pub enum ProductionWiringIssueKind {
     UnverifiedProductionImplementation,
 }
 
+impl ProductionWiringIssueKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Missing => "missing",
+            Self::UnsupportedRequirement => "unsupported_requirement",
+            Self::LocalOnlyImplementation => "local_only_implementation",
+            Self::UnverifiedProductionImplementation => "unverified_production_implementation",
+        }
+    }
+}
+
 /// One production wiring issue for a component in the host-runtime graph.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProductionWiringIssue {
@@ -173,6 +185,26 @@ impl ProductionWiringIssue {
     }
 }
 
+impl fmt::Display for ProductionWiringIssue {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.implementation {
+            Some(implementation) => write!(
+                formatter,
+                "{}={} ({})",
+                self.component.as_str(),
+                implementation,
+                self.kind.as_str()
+            ),
+            None => write!(
+                formatter,
+                "{} ({})",
+                self.component.as_str(),
+                self.kind.as_str()
+            ),
+        }
+    }
+}
+
 /// Report returned when a host-runtime graph is not production-ready.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProductionWiringReport {
@@ -197,6 +229,26 @@ impl ProductionWiringReport {
         self.issues
             .iter()
             .any(|issue| issue.component == component && issue.kind == kind)
+    }
+}
+
+impl fmt::Display for ProductionWiringReport {
+    /// Render the unwired components so an operator sees *which* component
+    /// failed production validation, not just that validation failed. The
+    /// `issues` list is built deterministically by the wiring check, so the
+    /// order is stable; `implementation` is a compile-time `type_name`, never
+    /// a secret or host path, so it is safe to surface to the operator.
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.issues.is_empty() {
+            return formatter.write_str("no production wiring issues recorded");
+        }
+        for (index, issue) in self.issues.iter().enumerate() {
+            if index > 0 {
+                formatter.write_str("; ")?;
+            }
+            write!(formatter, "{issue}")?;
+        }
+        Ok(())
     }
 }
 
@@ -314,5 +366,59 @@ fn classify_component_type<T: ?Sized + 'static>() -> ProductionImplementationRea
             ProductionImplementationReadiness::UnverifiedProductionImplementation
         }
         () => ProductionImplementationReadiness::ProductionCandidate,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn report_display_names_component_kind_and_implementation() {
+        let report = ProductionWiringReport {
+            issues: vec![
+                ProductionWiringIssue {
+                    component: ProductionWiringComponent::TurnState,
+                    kind: ProductionWiringIssueKind::LocalOnlyImplementation,
+                    implementation: Some("ironclaw_turns::InMemoryTurnStateStore"),
+                },
+                ProductionWiringIssue {
+                    component: ProductionWiringComponent::SecretStore,
+                    kind: ProductionWiringIssueKind::Missing,
+                    implementation: None,
+                },
+            ],
+        };
+
+        assert_eq!(
+            report.to_string(),
+            "turn_state=ironclaw_turns::InMemoryTurnStateStore (local_only_implementation); \
+             secret_store (missing)"
+        );
+    }
+
+    #[test]
+    fn report_display_handles_empty_issue_list() {
+        let report = ProductionWiringReport { issues: Vec::new() };
+
+        assert_eq!(report.to_string(), "no production wiring issues recorded");
+    }
+
+    #[test]
+    fn event_store_wiring_error_surfaces_report_detail() {
+        let error = ProductionEventStoreWiringError::from(ProductionWiringReport {
+            issues: vec![ProductionWiringIssue {
+                component: ProductionWiringComponent::EventSink,
+                kind: ProductionWiringIssueKind::LocalOnlyImplementation,
+                implementation: Some("ironclaw_host_runtime::InMemoryEventSink"),
+            }],
+        });
+
+        let rendered = error.to_string();
+        assert!(rendered.contains("event_sink"), "got: {rendered}");
+        assert!(
+            rendered.contains("local_only_implementation"),
+            "got: {rendered}"
+        );
     }
 }

--- a/crates/ironclaw_reborn_composition/src/error.rs
+++ b/crates/ironclaw_reborn_composition/src/error.rs
@@ -113,6 +113,25 @@ mod tests {
     }
 
     #[test]
+    fn production_composition_error_display_names_failing_component() {
+        let report = ProductionWiringReport::for_test(vec![ProductionWiringIssue::for_test(
+            ProductionWiringComponent::TurnState,
+            ProductionWiringIssueKind::LocalOnlyImplementation,
+        )]);
+        let error = crate::RebornCompositionError::ProductionWiring { report };
+
+        let rendered = error.to_string();
+        assert!(
+            rendered.contains("turn_state"),
+            "expected the failing component in Display, got: {rendered}"
+        );
+        assert!(
+            rendered.contains("local_only_implementation"),
+            "expected the issue kind in Display, got: {rendered}"
+        );
+    }
+
+    #[test]
     fn composition_missing_secret_master_key_stays_typed_for_facade_errors() {
         let error = RebornBuildError::from(crate::RebornCompositionError::MissingSecretMasterKey);
 

--- a/crates/ironclaw_reborn_composition/src/error.rs
+++ b/crates/ironclaw_reborn_composition/src/error.rs
@@ -18,7 +18,7 @@ pub enum RebornBuildError {
     MissingSecretMasterKey,
     #[error("reborn planned run-profile resolver build failed: {reason}")]
     PlannedRunProfileResolver { reason: String },
-    #[error("reborn composition failed production validation")]
+    #[error("reborn composition failed production validation: {report}")]
     ProductionWiring {
         report: ironclaw_host_runtime::ProductionWiringReport,
     },
@@ -88,6 +88,29 @@ impl From<crate::RebornCompositionError> for RebornBuildError {
 #[cfg(test)]
 mod tests {
     use super::RebornBuildError;
+    use ironclaw_host_runtime::{
+        ProductionWiringComponent, ProductionWiringIssue, ProductionWiringIssueKind,
+        ProductionWiringReport,
+    };
+
+    #[test]
+    fn production_wiring_error_display_names_failing_component() {
+        let report = ProductionWiringReport::for_test(vec![ProductionWiringIssue::for_test(
+            ProductionWiringComponent::TurnState,
+            ProductionWiringIssueKind::LocalOnlyImplementation,
+        )]);
+        let error = RebornBuildError::ProductionWiring { report };
+
+        let rendered = error.to_string();
+        assert!(
+            rendered.contains("turn_state"),
+            "expected the failing component in Display, got: {rendered}"
+        );
+        assert!(
+            rendered.contains("local_only_implementation"),
+            "expected the issue kind in Display, got: {rendered}"
+        );
+    }
 
     #[test]
     fn composition_missing_secret_master_key_stays_typed_for_facade_errors() {

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -848,7 +848,7 @@ pub enum RebornCompositionError {
         "production runtime policy uses {process_backend:?} but a tenant sandbox process binding was supplied"
     )]
     UnexpectedTenantSandboxProcessPort { process_backend: ProcessBackendKind },
-    #[error("reborn production wiring failed: {report:?}")]
+    #[error("reborn production wiring failed: {report}")]
     ProductionWiring {
         report: ironclaw_host_runtime::ProductionWiringReport,
     },


### PR DESCRIPTION
## Summary

- `ironclaw-reborn serve` under `IRONCLAW_REBORN_PROFILE=production` (`--features postgres`) could fail composition with only `reborn composition failed production validation` — never naming *which* component was unwired.
- The `ProductionWiringReport` was dropped from all three error carriers: two rendered a static string, one used a `{report:?}` Debug dump.
- Add `Display` for `ProductionWiringReport` / `ProductionWiringIssue` (+ `ProductionWiringIssueKind::as_str`) and render it in every carrier, so boot failures surface e.g. `… : turn_state=ironclaw_turns::InMemoryTurnStateStore (local_only_implementation); secret_store (missing)`.
- Diagnostics-only: no control-flow, type, or wire change.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

None. Found during a hosted-single-tenant + PostgreSQL self-host shakedown of the standalone `ironclaw-reborn` binary.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [x] `cargo build`
- [x] Relevant tests pass: `production_wiring` (host_runtime), `error_display_names_failing_component` (reborn_composition — both `RebornBuildError` and `RebornCompositionError` carriers)
- [ ] `cargo test --features integration` if database-backed or integration behavior changed — N/A, no DB/integration behavior changed
- [x] Manual testing: rendered strings asserted by unit tests; empty-report path returns `no production wiring issues recorded`
- [x] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

## Security Impact

None. Only error-message text changes. The surfaced `implementation` is `std::any::type_name` (a compile-time type path), never a secret, credential, or host path; component/kind render from fixed enum strings.

## Reborn Trust-Boundary Checklist

- [x] Public policy/evidence/trust-bearing types: who can construct them? — N/A. No new trust-bearing types; added `Display` impls + `ProductionWiringIssueKind::as_str` only.
- [x] Untrusted content enters prompts only through an envelope/escaping primitive. — N/A, no prompt path.
- [x] Hashes declare purpose; trust/binding/authenticity uses SHA-256/BLAKE3 or separate authenticity check. — N/A, no hashing.
- [x] New/changed status, exit, policy, runtime, or error variants: downstream match sites audited. Command/output: `grep -rn "ProductionWiring" crates/ src/` — no error *variants* added/removed; only thiserror format strings changed and a new `as_str()`. No match site changes.
- [x] Security/durability `serde(default)` fields fail closed or have migration tests. — N/A, no serde changes.
- [x] Queues/maps/buffers/counters have bounds and overflow-safe arithmetic. — N/A.
- [x] Driver/operator-visible errors have stable class semantics. — Preserved: error variants and their typing are unchanged; only the human-readable `Display` message is enriched.
- [x] Sandbox/native/host names accurately describe trust boundary. — N/A.

## Database Impact

None.

## Blast Radius

`ironclaw_host_runtime::services::production_wiring` and `ironclaw_reborn_composition` error rendering only. Touches the `Display` output of production-wiring errors on the `serve` boot path; no change to control flow, wiring classification, or error typing. Worst case is a differently-worded operator error string.

## Rollback Plan

Revert the commit. Pure diagnostics change — no schema, data, or wire-format impact, so revert is safe and self-contained.

## Review Follow-Through

Automated review notes addressed on-branch: added a caller-level `Display` test for the third carrier (`RebornCompositionError::ProductionWiring`), and collapsed `ProductionWiringIssue`'s `Display` to a single non-duplicated write. No open reviewer questions.

---

**Review track**: C (runtime — operator-visible error surface; low risk, diagnostics-only)
