### PR TITLE
ci(canary): refresh Google OAuth tokens per run

### DIFF
--- a/.github/scripts/google_oauth_cases.py
+++ b/.github/scripts/google_oauth_cases.py
@@ -4,8 +4,8 @@
 from __future__ import annotations
 
 import argparse
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Iterable
 
 
 def parse_cases(value: str) -> list[str]:

--- a/.github/scripts/google_oauth_cases.py
+++ b/.github/scripts/google_oauth_cases.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Select live-QA cases that can run without Google OAuth."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Iterable
+
+
+def parse_cases(value: str) -> list[str]:
+    return [case.strip() for case in value.split(",") if case.strip()]
+
+
+def requires_google(cases: Iterable[str], google_cases: set[str]) -> bool:
+    return any(case in google_cases for case in cases)
+
+
+def retain_without_google(cases: Iterable[str], google_cases: set[str]) -> list[str]:
+    return [case for case in cases if case not in google_cases]
+
+
+def _append(path: Path | None, line: str) -> None:
+    if path is not None:
+        with path.open("a", encoding="utf-8") as output:
+            output.write(f"{line}\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--cases", required=True)
+    parser.add_argument("--google-cases", required=True)
+    parser.add_argument("--mode", choices=("needs-google", "suppress"), required=True)
+    parser.add_argument("--status", default="unknown")
+    parser.add_argument("--github-env", type=Path)
+    parser.add_argument("--github-output", type=Path)
+    args = parser.parse_args()
+
+    cases = parse_cases(args.cases)
+    google_cases = set(parse_cases(args.google_cases))
+    if args.mode == "needs-google":
+        return 0 if requires_google(cases, google_cases) else 1
+
+    retained = retain_without_google(cases, google_cases)
+    if not retained:
+        _append(args.github_output, "skip_shard=1")
+        print(
+            "All selected cases require Google OAuth; "
+            f"refresh status={args.status or 'unknown'}."
+        )
+        return 0
+
+    joined = ",".join(retained)
+    _append(args.github_env, f"CASES={joined}")
+    _append(args.github_output, "skip_shard=0")
+    print(f"Google OAuth unavailable; continuing with non-Google cases: {joined}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/live-canary.yml
+++ b/.github/workflows/live-canary.yml
@@ -862,6 +862,13 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+    env:
+      REBORN_WEBUI_V2_GOOGLE_CASES: >-
+        qa_2a_gmail_connect,qa_2b_calendar_connect,qa_2c_drive_connect,qa_2d_calendar_prep_live_chat,qa_2e_calendar_prep_email_routine,qa_2f_calendar_prep_email_delivery,
+        qa_4a_gmail_connect,qa_4e_github_release_email_delivery,
+        qa_5b_drive_connect,qa_5c_strategy_doc_knowledge_base,qa_5d_slack_strategy_doc_answer,
+        qa_6a_gmail_connect,qa_6b_sheets_connect,qa_6c_gmail_to_sheet_live_chat,qa_6d_gmail_to_sheet_routine,qa_6e_gmail_to_sheet_delivery,
+        qa_7b_sheets_connect,qa_7c_slack_bug_logger_routine,qa_7e_slack_bug_sheet_delivery
     strategy:
       fail-fast: false
       matrix:
@@ -1013,18 +1020,17 @@ jobs:
               echo "Running requested cases in this shard: ${joined}"
             fi
           fi
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        if: steps.resolve_reborn_webui_v2_cases.outputs.skip_shard != '1'
+        with:
+          persist-credentials: false
+          ref: ${{ needs.prepare-reborn-webui-v2-live-qa.outputs.checkout_ref }}
       - name: Suppress Google cases after OAuth preflight failure
         id: filter_reborn_webui_v2_google_cases
         shell: bash
         env:
           RESOLVE_SKIP_SHARD: ${{ steps.resolve_reborn_webui_v2_cases.outputs.skip_shard }}
           GOOGLE_OAUTH_STATUS: ${{ needs.preflight-reborn-webui-v2-google-oauth.outputs.status }}
-          GOOGLE_CASES: >-
-            qa_2a_gmail_connect,qa_2b_calendar_connect,qa_2c_drive_connect,qa_2d_calendar_prep_live_chat,qa_2e_calendar_prep_email_routine,qa_2f_calendar_prep_email_delivery,
-            qa_4a_gmail_connect,qa_4e_github_release_email_delivery,
-            qa_5b_drive_connect,qa_5c_strategy_doc_knowledge_base,qa_5d_slack_strategy_doc_answer,
-            qa_6a_gmail_connect,qa_6b_sheets_connect,qa_6c_gmail_to_sheet_live_chat,qa_6d_gmail_to_sheet_routine,qa_6e_gmail_to_sheet_delivery,
-            qa_7b_sheets_connect,qa_7c_slack_bug_logger_routine,qa_7e_slack_bug_sheet_delivery
         run: |
           set -euo pipefail
           if [[ "${RESOLVE_SKIP_SHARD}" == "1" ]]; then
@@ -1036,35 +1042,13 @@ jobs:
             exit 0
           fi
 
-          declare -A google_cases=()
-          IFS=',' read -ra configured_google_cases <<< "${GOOGLE_CASES}"
-          for case_name in "${configured_google_cases[@]}"; do
-            case_name="$(echo "${case_name}" | xargs)"
-            [[ -n "${case_name}" ]] && google_cases["${case_name}"]=1
-          done
-          retained=()
-          IFS=',' read -ra selected_cases <<< "${CASES:-}"
-          for case_name in "${selected_cases[@]}"; do
-            case_name="$(echo "${case_name}" | xargs)"
-            [[ -n "${case_name}" ]] || continue
-            if [[ -z "${google_cases[${case_name}]+x}" ]]; then
-              retained+=("${case_name}")
-            fi
-          done
-          if [[ ${#retained[@]} -eq 0 ]]; then
-            echo "skip_shard=1" >> "${GITHUB_OUTPUT}"
-            echo "All selected cases require Google OAuth; preflight status=${GOOGLE_OAUTH_STATUS:-unknown}."
-            exit 0
-          fi
-          joined="$(IFS=,; echo "${retained[*]}")"
-          echo "CASES=${joined}" >> "${GITHUB_ENV}"
-          echo "skip_shard=0" >> "${GITHUB_OUTPUT}"
-          echo "Google OAuth unavailable; continuing with non-Google cases: ${joined}"
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        if: steps.filter_reborn_webui_v2_google_cases.outputs.skip_shard != '1'
-        with:
-          persist-credentials: false
-          ref: ${{ needs.prepare-reborn-webui-v2-live-qa.outputs.checkout_ref }}
+          python3 .github/scripts/google_oauth_cases.py \
+            --mode suppress \
+            --cases "${CASES:-}" \
+            --google-cases "${REBORN_WEBUI_V2_GOOGLE_CASES}" \
+            --status "${GOOGLE_OAUTH_STATUS:-unknown}" \
+            --github-env "${GITHUB_ENV}" \
+            --github-output "${GITHUB_OUTPUT}"
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         if: >
           steps.filter_reborn_webui_v2_google_cases.outputs.skip_shard != '1' &&
@@ -1182,22 +1166,40 @@ jobs:
           write_secret "TELEGRAM_BOT_TOKEN" "${TELEGRAM_BOT_TOKEN:-}"
           write_secret "TELEGRAM_WEBHOOK_SECRET" "${TELEGRAM_WEBHOOK_SECRET:-}"
       - name: Mint fresh Google OAuth access token for selected cases
+        id: mint_reborn_webui_v2_google_token
         if: steps.filter_reborn_webui_v2_google_cases.outputs.skip_shard != '1'
         shell: bash
         run: |
           set +x
           set -euo pipefail
-          google_cases='qa_2|qa_4a_|qa_4e_|qa_5[b-d]_|qa_6|qa_7b_|qa_7c_|qa_7e_'
-          if ! tr ',' '\n' <<< "${CASES}" | grep -Eq "^(${google_cases})"; then
+          if ! python3 .github/scripts/google_oauth_cases.py \
+            --mode needs-google --cases "${CASES}" \
+            --google-cases "${REBORN_WEBUI_V2_GOOGLE_CASES}"; then
+            echo "skip_shard=0" >> "${GITHUB_OUTPUT}"
             echo "Selected cases do not require Google OAuth."
             exit 0
           fi
           access_token_path="${RUNNER_TEMP}/reborn-webui-v2-live-qa-secrets/AUTH_LIVE_GOOGLE_ACCESS_TOKEN"
-          python3 scripts/reborn_webui_v2_live_qa/refresh_google_oauth.py \
-            --access-token-path "${access_token_path}"
-          echo "AUTH_LIVE_GOOGLE_ACCESS_TOKEN_PATH=${access_token_path}" >> "${GITHUB_ENV}"
+          refresh_status_path="${RUNNER_TEMP}/reborn-webui-v2-google-refresh-output"
+          if python3 scripts/reborn_webui_v2_live_qa/refresh_google_oauth.py \
+            --access-token-path "${access_token_path}" \
+            --github-output "${refresh_status_path}"; then
+            echo "AUTH_LIVE_GOOGLE_ACCESS_TOKEN_PATH=${access_token_path}" >> "${GITHUB_ENV}"
+            echo "skip_shard=0" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          refresh_status="$(sed -n 's/^status=//p' "${refresh_status_path}" | tail -1)"
+          python3 .github/scripts/google_oauth_cases.py \
+            --mode suppress \
+            --cases "${CASES}" \
+            --google-cases "${REBORN_WEBUI_V2_GOOGLE_CASES}" \
+            --status "${refresh_status:-unknown}" \
+            --github-env "${GITHUB_ENV}" \
+            --github-output "${GITHUB_OUTPUT}"
       - name: Run Reborn WebUI v2 live QA lane
-        if: steps.filter_reborn_webui_v2_google_cases.outputs.skip_shard != '1'
+        if: >
+          steps.filter_reborn_webui_v2_google_cases.outputs.skip_shard != '1' &&
+          steps.mint_reborn_webui_v2_google_token.outputs.skip_shard != '1'
         env:
           LANE: reborn-webui-v2-live-qa
           PROVIDER: reborn-webui-v2-${{ matrix.shard_id }}

--- a/.github/workflows/live-canary.yml
+++ b/.github/workflows/live-canary.yml
@@ -862,13 +862,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-    env:
-      REBORN_WEBUI_V2_GOOGLE_CASES: >-
-        qa_2a_gmail_connect,qa_2b_calendar_connect,qa_2c_drive_connect,qa_2d_calendar_prep_live_chat,qa_2e_calendar_prep_email_routine,qa_2f_calendar_prep_email_delivery,
-        qa_4a_gmail_connect,qa_4e_github_release_email_delivery,
-        qa_5b_drive_connect,qa_5c_strategy_doc_knowledge_base,qa_5d_slack_strategy_doc_answer,
-        qa_6a_gmail_connect,qa_6b_sheets_connect,qa_6c_gmail_to_sheet_live_chat,qa_6d_gmail_to_sheet_routine,qa_6e_gmail_to_sheet_delivery,
-        qa_7b_sheets_connect,qa_7c_slack_bug_logger_routine,qa_7e_slack_bug_sheet_delivery
     strategy:
       fail-fast: false
       matrix:
@@ -920,6 +913,12 @@ jobs:
             shard_name: QA 10
             cases: qa_10a_slack_self_attribution,qa_10b_slack_ooo_status,qa_10c_slack_thread_replies,qa_10d_slack_channel_membership,qa_10e_slack_error_honesty,qa_10f_slack_mention_encoding,qa_10g_slack_last_message_sent,qa_10h_slack_email_hallucination_guard,qa_10i_slack_raw_entity_hygiene
     env:
+      REBORN_WEBUI_V2_GOOGLE_CASES: >-
+        qa_2a_gmail_connect,qa_2b_calendar_connect,qa_2c_drive_connect,qa_2d_calendar_prep_live_chat,qa_2e_calendar_prep_email_routine,qa_2f_calendar_prep_email_delivery,
+        qa_4a_gmail_connect,qa_4e_github_release_email_delivery,
+        qa_5b_drive_connect,qa_5c_strategy_doc_knowledge_base,qa_5d_slack_strategy_doc_answer,
+        qa_6a_gmail_connect,qa_6b_sheets_connect,qa_6c_gmail_to_sheet_live_chat,qa_6d_gmail_to_sheet_routine,qa_6e_gmail_to_sheet_delivery,
+        qa_7b_sheets_connect,qa_7c_slack_bug_logger_routine,qa_7e_slack_bug_sheet_delivery
       REBORN_WEBUI_V2_LIVE_QA_LLM_API_KEY_ENV: NEARAI_API_KEY
       REBORN_WEBUI_V2_LIVE_QA_LLM_PROVIDER_ID: nearai
       REBORN_WEBUI_V2_LIVE_QA_LLM_MODEL: ${{ vars.REBORN_WEBUI_V2_LIVE_QA_LLM_MODEL || 'deepseek-ai/DeepSeek-V4-Flash' }}

--- a/.github/workflows/live-canary.yml
+++ b/.github/workflows/live-canary.yml
@@ -614,6 +614,43 @@ jobs:
           fi
           echo "Trusted authorization for ${TARGET_REF} was provided by ${trusted_approval}."
 
+  preflight-reborn-webui-v2-google-oauth:
+    name: Preflight Reborn WebUI v2 Google OAuth
+    needs: approve-reborn-webui-v2-pr-live-qa
+    if: >
+      always() &&
+      (
+        github.event_name == 'schedule' ||
+        (github.event_name == 'workflow_dispatch' && (inputs.lane == 'all' || inputs.lane == 'reborn-webui-v2-live-qa'))
+      ) &&
+      (inputs.target_ref == '' || needs.approve-reborn-webui-v2-pr-live-qa.result == 'success')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      status: ${{ steps.refresh.outputs.status }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - name: Refresh Google OAuth access token
+        id: refresh
+        continue-on-error: true
+        env:
+          IRONCLAW_REBORN_GOOGLE_CLIENT_ID: ${{ secrets.IRONCLAW_REBORN_GOOGLE_CLIENT_ID || secrets.GOOGLE_CLIENT_ID || secrets.GOOGLE_OAUTH_CLIENT_ID }}
+          IRONCLAW_REBORN_GOOGLE_CLIENT_SECRET: ${{ secrets.IRONCLAW_REBORN_GOOGLE_CLIENT_SECRET || secrets.GOOGLE_CLIENT_SECRET || secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
+          AUTH_LIVE_GOOGLE_REFRESH_TOKEN: ${{ secrets.AUTH_LIVE_GOOGLE_REFRESH_TOKEN }}
+        run: >-
+          python3 scripts/reborn_webui_v2_live_qa/refresh_google_oauth.py
+          --github-output "${GITHUB_OUTPUT}"
+      - name: Report Google OAuth infrastructure failure
+        if: steps.refresh.outcome != 'success'
+        env:
+          GOOGLE_OAUTH_STATUS: ${{ steps.refresh.outputs.status }}
+        run: |
+          echo "::error::Reborn WebUI v2 Google OAuth preflight failed: ${GOOGLE_OAUTH_STATUS:-unknown}. Google-dependent cases will be skipped; non-Google cases will continue."
+          exit 1
+
   prepare-reborn-webui-v2-live-qa:
     name: Prepare Reborn WebUI v2 live QA binary
     if: >
@@ -810,7 +847,9 @@ jobs:
 
   reborn-webui-v2-live-qa:
     name: Reborn WebUI v2 Live QA (${{ matrix.shard_name }})
-    needs: prepare-reborn-webui-v2-live-qa
+    needs:
+      - prepare-reborn-webui-v2-live-qa
+      - preflight-reborn-webui-v2-google-oauth
     if: >
       always() &&
       needs.prepare-reborn-webui-v2-live-qa.result == 'success' &&
@@ -974,14 +1013,61 @@ jobs:
               echo "Running requested cases in this shard: ${joined}"
             fi
           fi
+      - name: Suppress Google cases after OAuth preflight failure
+        id: filter_reborn_webui_v2_google_cases
+        shell: bash
+        env:
+          RESOLVE_SKIP_SHARD: ${{ steps.resolve_reborn_webui_v2_cases.outputs.skip_shard }}
+          GOOGLE_OAUTH_STATUS: ${{ needs.preflight-reborn-webui-v2-google-oauth.outputs.status }}
+          GOOGLE_CASES: >-
+            qa_2a_gmail_connect,qa_2b_calendar_connect,qa_2c_drive_connect,qa_2d_calendar_prep_live_chat,qa_2e_calendar_prep_email_routine,qa_2f_calendar_prep_email_delivery,
+            qa_4a_gmail_connect,qa_4e_github_release_email_delivery,
+            qa_5b_drive_connect,qa_5c_strategy_doc_knowledge_base,qa_5d_slack_strategy_doc_answer,
+            qa_6a_gmail_connect,qa_6b_sheets_connect,qa_6c_gmail_to_sheet_live_chat,qa_6d_gmail_to_sheet_routine,qa_6e_gmail_to_sheet_delivery,
+            qa_7b_sheets_connect,qa_7c_slack_bug_logger_routine,qa_7e_slack_bug_sheet_delivery
+        run: |
+          set -euo pipefail
+          if [[ "${RESOLVE_SKIP_SHARD}" == "1" ]]; then
+            echo "skip_shard=1" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          if [[ "${GOOGLE_OAUTH_STATUS}" == "healthy" ]]; then
+            echo "skip_shard=0" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          declare -A google_cases=()
+          IFS=',' read -ra configured_google_cases <<< "${GOOGLE_CASES}"
+          for case_name in "${configured_google_cases[@]}"; do
+            case_name="$(echo "${case_name}" | xargs)"
+            [[ -n "${case_name}" ]] && google_cases["${case_name}"]=1
+          done
+          retained=()
+          IFS=',' read -ra selected_cases <<< "${CASES:-}"
+          for case_name in "${selected_cases[@]}"; do
+            case_name="$(echo "${case_name}" | xargs)"
+            [[ -n "${case_name}" ]] || continue
+            if [[ -z "${google_cases[${case_name}]+x}" ]]; then
+              retained+=("${case_name}")
+            fi
+          done
+          if [[ ${#retained[@]} -eq 0 ]]; then
+            echo "skip_shard=1" >> "${GITHUB_OUTPUT}"
+            echo "All selected cases require Google OAuth; preflight status=${GOOGLE_OAUTH_STATUS:-unknown}."
+            exit 0
+          fi
+          joined="$(IFS=,; echo "${retained[*]}")"
+          echo "CASES=${joined}" >> "${GITHUB_ENV}"
+          echo "skip_shard=0" >> "${GITHUB_OUTPUT}"
+          echo "Google OAuth unavailable; continuing with non-Google cases: ${joined}"
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        if: steps.resolve_reborn_webui_v2_cases.outputs.skip_shard != '1'
+        if: steps.filter_reborn_webui_v2_google_cases.outputs.skip_shard != '1'
         with:
           persist-credentials: false
           ref: ${{ needs.prepare-reborn-webui-v2-live-qa.outputs.checkout_ref }}
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         if: >
-          steps.resolve_reborn_webui_v2_cases.outputs.skip_shard != '1' &&
+          steps.filter_reborn_webui_v2_google_cases.outputs.skip_shard != '1' &&
           github.event_name == 'workflow_dispatch' &&
           inputs.target_ref != '' &&
           inputs.use_target_harness != true
@@ -991,7 +1077,7 @@ jobs:
           path: .canonical-live-qa-harness
       - name: Restore canonical Reborn WebUI v2 live QA harness
         if: >
-          steps.resolve_reborn_webui_v2_cases.outputs.skip_shard != '1' &&
+          steps.filter_reborn_webui_v2_google_cases.outputs.skip_shard != '1' &&
           github.event_name == 'workflow_dispatch' &&
           inputs.target_ref != '' &&
           inputs.use_target_harness != true
@@ -1008,14 +1094,14 @@ jobs:
           rm -rf .canonical-live-qa-harness
           echo "REBORN_WEBUI_V2_LIVE_QA_HARNESS_REF=${harness_ref}" >> "${GITHUB_ENV}"
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
-        if: steps.resolve_reborn_webui_v2_cases.outputs.skip_shard != '1'
+        if: steps.filter_reborn_webui_v2_google_cases.outputs.skip_shard != '1'
         with:
           python-version: "3.12"
           cache: pip
           cache-dependency-path: tests/e2e/pyproject.toml
 
       - name: Cache Playwright browsers
-        if: steps.resolve_reborn_webui_v2_cases.outputs.skip_shard != '1'
+        if: steps.filter_reborn_webui_v2_google_cases.outputs.skip_shard != '1'
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cache/ms-playwright
@@ -1023,14 +1109,14 @@ jobs:
           restore-keys: ${{ runner.os }}-playwright-
 
       - name: Download prepared Reborn WebUI v2 binary
-        if: steps.resolve_reborn_webui_v2_cases.outputs.skip_shard != '1'
+        if: steps.filter_reborn_webui_v2_google_cases.outputs.skip_shard != '1'
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: prepared-reborn-webui-v2-binary-${{ needs.prepare-reborn-webui-v2-live-qa.outputs.checkout_ref }}
           path: .live-qa-binary
 
       - name: Verify and install prepared Reborn WebUI v2 binary
-        if: steps.resolve_reborn_webui_v2_cases.outputs.skip_shard != '1'
+        if: steps.filter_reborn_webui_v2_google_cases.outputs.skip_shard != '1'
         env:
           TARGET_REF: ${{ needs.prepare-reborn-webui-v2-live-qa.outputs.checkout_ref }}
         run: |
@@ -1046,7 +1132,7 @@ jobs:
           tar -C target/debug -xzf .live-qa-binary/ironclaw-reborn.tar.gz
           chmod 755 target/debug/ironclaw-reborn
       - name: Materialize Reborn WebUI v2 live QA sensitive secrets to files
-        if: steps.resolve_reborn_webui_v2_cases.outputs.skip_shard != '1'
+        if: steps.filter_reborn_webui_v2_google_cases.outputs.skip_shard != '1'
         shell: bash
         env:
           NEARAI_API_KEY: ${{ secrets.NEARAI_API_KEY || secrets.LIVE_OPENAI_COMPATIBLE_API_KEY }}
@@ -1095,8 +1181,23 @@ jobs:
           write_secret "AUTH_LIVE_GITHUB_TOKEN" "${AUTH_LIVE_GITHUB_TOKEN:-}"
           write_secret "TELEGRAM_BOT_TOKEN" "${TELEGRAM_BOT_TOKEN:-}"
           write_secret "TELEGRAM_WEBHOOK_SECRET" "${TELEGRAM_WEBHOOK_SECRET:-}"
+      - name: Mint fresh Google OAuth access token for selected cases
+        if: steps.filter_reborn_webui_v2_google_cases.outputs.skip_shard != '1'
+        shell: bash
+        run: |
+          set +x
+          set -euo pipefail
+          google_cases='qa_2|qa_4a_|qa_4e_|qa_5[b-d]_|qa_6|qa_7b_|qa_7c_|qa_7e_'
+          if ! tr ',' '\n' <<< "${CASES}" | grep -Eq "^(${google_cases})"; then
+            echo "Selected cases do not require Google OAuth."
+            exit 0
+          fi
+          access_token_path="${RUNNER_TEMP}/reborn-webui-v2-live-qa-secrets/AUTH_LIVE_GOOGLE_ACCESS_TOKEN"
+          python3 scripts/reborn_webui_v2_live_qa/refresh_google_oauth.py \
+            --access-token-path "${access_token_path}"
+          echo "AUTH_LIVE_GOOGLE_ACCESS_TOKEN_PATH=${access_token_path}" >> "${GITHUB_ENV}"
       - name: Run Reborn WebUI v2 live QA lane
-        if: steps.resolve_reborn_webui_v2_cases.outputs.skip_shard != '1'
+        if: steps.filter_reborn_webui_v2_google_cases.outputs.skip_shard != '1'
         env:
           LANE: reborn-webui-v2-live-qa
           PROVIDER: reborn-webui-v2-${{ matrix.shard_id }}
@@ -1106,10 +1207,10 @@ jobs:
           SKIP_BUILD: "1"
         run: scripts/live-canary/run.sh
       - name: Scrub artifacts
-        if: always() && steps.resolve_reborn_webui_v2_cases.outputs.skip_shard != '1'
+        if: always() && steps.filter_reborn_webui_v2_google_cases.outputs.skip_shard != '1'
         run: scripts/live-canary/scrub-artifacts.sh artifacts/live-canary
       - name: Upload artifacts
-        if: always() && steps.resolve_reborn_webui_v2_cases.outputs.skip_shard != '1'
+        if: always() && steps.filter_reborn_webui_v2_google_cases.outputs.skip_shard != '1'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: live-canary-reborn-webui-v2-live-qa-${{ matrix.shard_id }}
@@ -1436,6 +1537,7 @@ jobs:
       - auth-live-seeded
       - auth-browser-consent
       - workflow-canary
+      - preflight-reborn-webui-v2-google-oauth
       - reborn-webui-v2-live-qa
       - deterministic-replay
       - public-smoke
@@ -1485,6 +1587,7 @@ jobs:
           CANARY_TARGET_PR: ${{ github.event_name == 'workflow_dispatch' && inputs.target_pr || '' }}
           CANARY_TARGET_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.target_ref || '' }}
           CANARY_TRIGGER_CONTEXT: ${{ github.event_name == 'workflow_dispatch' && inputs.trigger_context || '' }}
+          REBORN_GOOGLE_OAUTH_PREFLIGHT_STATUS: ${{ needs.preflight-reborn-webui-v2-google-oauth.outputs.status }}
           CANARY_CREATE_ISSUES: "0"
           CANARY_POST_PR_COMMENT: ${{ github.event_name == 'workflow_dispatch' && inputs.target_pr != '' && '1' || '0' }}
         run: |

--- a/scripts/live-canary/ACCOUNTS.md
+++ b/scripts/live-canary/ACCOUNTS.md
@@ -105,6 +105,18 @@ existing auth-live Google token secrets:
 - `AUTH_LIVE_GOOGLE_ACCESS_TOKEN`
 - `AUTH_LIVE_GOOGLE_REFRESH_TOKEN`
 
+GitHub Actions validates the refresh token once before the Reborn shard fan-out.
+Each shard containing Google-dependent cases then exchanges that refresh token
+again and writes the newly minted access token to its private runner temporary
+directory. The stored `AUTH_LIVE_GOOGLE_ACCESS_TOKEN` is therefore only a local
+fallback; CI does not rely on it remaining current. Access tokens are never
+passed through job outputs or uploaded artifacts.
+
+If the shared refresh preflight fails, Google-dependent cases are suppressed and
+the preflight job reports the single infrastructure failure. Non-Google cases in
+mixed shards continue running. A revoked refresh token still requires interactive
+re-authorization; it cannot be repaired by another refresh attempt.
+
 For copied Reborn homes whose stored Google access tokens have expired, the
 runtime/side-effect rows also require a Google OAuth client secret that matches
 the client ID used by the stored Google consent flow. Set one of these to that

--- a/scripts/live-canary/notify_slack.py
+++ b/scripts/live-canary/notify_slack.py
@@ -1241,6 +1241,27 @@ def fallback_payload(reports: list[LaneReport], run_url: str | None) -> dict:
     return {"text": text}
 
 
+def google_oauth_preflight_report(status: str) -> LaneReport | None:
+    status = status.strip()
+    if not status or status == "healthy":
+        return None
+    return LaneReport(
+        lane="reborn-webui-v2-google-oauth-preflight",
+        provider="google-oauth",
+        failed=1,
+        tests=1,
+        status="fail",
+        reason=f"Google OAuth refresh failed: {status}",
+        test_name="google_oauth_refresh_preflight",
+        error=status,
+        root_cause="The live Google refresh token could not mint an access token.",
+        fix=(
+            "Re-authorize the dedicated QA account with the configured OAuth client "
+            "and rotate AUTH_LIVE_GOOGLE_REFRESH_TOKEN."
+        ),
+    )
+
+
 def main() -> int:
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument("--artifacts-dir", default="artifacts/live-canary",
@@ -1290,7 +1311,10 @@ def main() -> int:
 
     artifacts_root = Path(args.artifacts_dir)
     lane_dirs = discover_lane_dirs(artifacts_root)
-    if not lane_dirs:
+    preflight_report = google_oauth_preflight_report(
+        os.environ.get("REBORN_GOOGLE_OAUTH_PREFLIGHT_STATUS", "")
+    )
+    if not lane_dirs and preflight_report is None:
         print(f"[notify_slack] no lane artifacts under {artifacts_root}", file=sys.stderr)
         return 0
 
@@ -1328,6 +1352,14 @@ def main() -> int:
     else:
         print("[notify_slack] no ANTHROPIC_API_KEY — skipping haiku enrichment",
               file=sys.stderr)
+
+    if preflight_report is not None:
+        reports.append(preflight_report)
+        print(
+            "[notify_slack] added Reborn Google OAuth infrastructure failure: "
+            f"{preflight_report.error}",
+            file=sys.stderr,
+        )
 
     # Second-pass categorization across all failed lanes — only fires
     # when there are 2+ failures since one failure is already obvious

--- a/scripts/live-canary/test_notify_slack.py
+++ b/scripts/live-canary/test_notify_slack.py
@@ -124,6 +124,22 @@ class ParseSummaryStatusTests(unittest.TestCase):
             -1,
         )
 
+
+class GoogleOauthPreflightReportTests(unittest.TestCase):
+    def test_healthy_or_absent_preflight_adds_no_failure(self):
+        self.assertIsNone(notify.google_oauth_preflight_report(""))
+        self.assertIsNone(notify.google_oauth_preflight_report("healthy"))
+
+    def test_invalid_grant_becomes_one_actionable_infrastructure_failure(self):
+        report = notify.google_oauth_preflight_report("invalid_grant")
+
+        self.assertIsNotNone(report)
+        self.assertEqual(report.failed, 1)
+        self.assertEqual(report.tests, 1)
+        self.assertEqual(report.status, "fail")
+        self.assertEqual(report.error, "invalid_grant")
+        self.assertIn("AUTH_LIVE_GOOGLE_REFRESH_TOKEN", report.fix)
+
     def test_large_status_is_preserved(self):
         # Bash exit codes wrap at 256, but the regex is unbounded;
         # ensure no accidental truncation/clamping by the parser.

--- a/scripts/live-canary/test_notify_slack.py
+++ b/scripts/live-canary/test_notify_slack.py
@@ -20,7 +20,9 @@ Or directly::
 from __future__ import annotations
 
 import importlib.util
+import io
 import json
+import os
 import sys
 import tempfile
 import unittest
@@ -139,6 +141,31 @@ class GoogleOauthPreflightReportTests(unittest.TestCase):
         self.assertEqual(report.status, "fail")
         self.assertEqual(report.error, "invalid_grant")
         self.assertIn("AUTH_LIVE_GOOGLE_REFRESH_TOKEN", report.fix)
+
+    def test_main_reports_google_preflight_failure_without_lane_artifacts(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            argv = [
+                "notify_slack.py",
+                "--artifacts-dir",
+                tmpdir,
+                "--dry-run",
+                "--run-url",
+                "https://github.com/nearai/ironclaw/actions/runs/1",
+                "--commit",
+                "abcdef0123456789",
+            ]
+            stdout = io.StringIO()
+            env = {"REBORN_GOOGLE_OAUTH_PREFLIGHT_STATUS": "invalid_grant"}
+            with mock.patch.dict(os.environ, env, clear=True), mock.patch.object(
+                sys, "argv", argv
+            ), mock.patch("sys.stdout", stdout):
+                self.assertEqual(notify.main(), 0)
+
+        payload = json.loads(stdout.getvalue())
+        payload_text = json.dumps(payload)
+        self.assertIn("invalid_grant", payload_text)
+        self.assertIn("AUTH_LIVE_GOOGLE_REFRESH_TOKEN", payload_text)
+        self.assertEqual(payload_text.count("invalid_grant"), 1)
 
     def test_large_status_is_preserved(self):
         # Bash exit codes wrap at 256, but the regex is unbounded;

--- a/scripts/reborn_webui_v2_live_qa/refresh_google_oauth.py
+++ b/scripts/reborn_webui_v2_live_qa/refresh_google_oauth.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Refresh the live QA Google access token without exposing token material."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import stat
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Optional, Tuple
+
+
+TOKEN_URL = "https://oauth2.googleapis.com/token"
+
+
+def _secret(name: str) -> str:
+    path = os.environ.get(f"{name}_PATH", "").strip()
+    if path:
+        return Path(path).read_text(encoding="utf-8").strip()
+    return os.environ.get(name, "").strip()
+
+
+def refresh_access_token() -> Tuple[Optional[str], str]:
+    client_id = _secret("IRONCLAW_REBORN_GOOGLE_CLIENT_ID")
+    client_secret = _secret("IRONCLAW_REBORN_GOOGLE_CLIENT_SECRET")
+    refresh_token = _secret("AUTH_LIVE_GOOGLE_REFRESH_TOKEN")
+    missing = [
+        name
+        for name, value in (
+            ("IRONCLAW_REBORN_GOOGLE_CLIENT_ID", client_id),
+            ("IRONCLAW_REBORN_GOOGLE_CLIENT_SECRET", client_secret),
+            ("AUTH_LIVE_GOOGLE_REFRESH_TOKEN", refresh_token),
+        )
+        if not value
+    ]
+    if missing:
+        return None, f"missing:{','.join(missing)}"
+
+    request = urllib.request.Request(
+        TOKEN_URL,
+        data=urllib.parse.urlencode(
+            {
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "refresh_token": refresh_token,
+                "grant_type": "refresh_token",
+            }
+        ).encode(),
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=20) as response:
+            payload = json.load(response)
+    except urllib.error.HTTPError as exc:
+        try:
+            payload = json.loads(exc.read().decode("utf-8", errors="replace"))
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            payload = {}
+        return None, str(payload.get("error") or f"http_{exc.code}")
+    except (OSError, urllib.error.URLError) as exc:
+        return None, f"network:{type(exc).__name__}"
+
+    access_token = str(payload.get("access_token") or "").strip()
+    if not access_token:
+        return None, "missing_access_token"
+    return access_token, "healthy"
+
+
+def _write_output(path: Path, value: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(value, encoding="utf-8")
+    path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--access-token-path", type=Path)
+    parser.add_argument("--github-output", type=Path)
+    args = parser.parse_args()
+
+    access_token, status = refresh_access_token()
+    if args.github_output:
+        with args.github_output.open("a", encoding="utf-8") as output:
+            output.write(f"status={status}\n")
+    if access_token and args.access_token_path:
+        _write_output(args.access_token_path, access_token)
+
+    if access_token:
+        print("Google OAuth refresh succeeded; minted a fresh access token.")
+        return 0
+    print(f"Google OAuth refresh failed: {status}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/reborn_webui_v2_live_qa/refresh_google_oauth.py
+++ b/scripts/reborn_webui_v2_live_qa/refresh_google_oauth.py
@@ -68,8 +68,17 @@ def refresh_access_token() -> Tuple[Optional[str], str]:
         try:
             payload = json.loads(exc.read().decode("utf-8", errors="replace"))
         except (json.JSONDecodeError, UnicodeDecodeError, OSError):
-            payload = {}
-        return None, str(payload.get("error") or f"http_{exc.code}")
+            return None, f"http_{exc.code}"
+        if not isinstance(payload, dict):
+            return None, f"http_{exc.code}"
+        error = payload.get("error")
+        if (
+            not isinstance(error, str)
+            or not 1 <= len(error) <= 128
+            or not all(character.isascii() and (character.isalnum() or character in "._-") for character in error)
+        ):
+            return None, f"http_{exc.code}"
+        return None, error
     except (OSError, urllib.error.URLError) as exc:
         return None, f"network:{type(exc).__name__}"
 

--- a/scripts/reborn_webui_v2_live_qa/refresh_google_oauth.py
+++ b/scripts/reborn_webui_v2_live_qa/refresh_google_oauth.py
@@ -7,7 +7,6 @@ import argparse
 import json
 import os
 from pathlib import Path
-import stat
 import sys
 import urllib.error
 import urllib.parse
@@ -21,7 +20,10 @@ TOKEN_URL = "https://oauth2.googleapis.com/token"
 def _secret(name: str) -> str:
     path = os.environ.get(f"{name}_PATH", "").strip()
     if path:
-        return Path(path).read_text(encoding="utf-8").strip()
+        try:
+            return Path(path).read_text(encoding="utf-8").strip()
+        except OSError:
+            return ""
     return os.environ.get(name, "").strip()
 
 
@@ -56,11 +58,16 @@ def refresh_access_token() -> Tuple[Optional[str], str]:
     )
     try:
         with urllib.request.urlopen(request, timeout=20) as response:
-            payload = json.load(response)
+            try:
+                payload = json.load(response)
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                return None, "invalid_json"
+            if not isinstance(payload, dict):
+                return None, "invalid_json"
     except urllib.error.HTTPError as exc:
         try:
             payload = json.loads(exc.read().decode("utf-8", errors="replace"))
-        except (json.JSONDecodeError, UnicodeDecodeError):
+        except (json.JSONDecodeError, UnicodeDecodeError, OSError):
             payload = {}
         return None, str(payload.get("error") or f"http_{exc.code}")
     except (OSError, urllib.error.URLError) as exc:
@@ -74,8 +81,10 @@ def refresh_access_token() -> Tuple[Optional[str], str]:
 
 def _write_output(path: Path, value: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(value, encoding="utf-8")
-    path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    os.fchmod(fd, 0o600)
+    with os.fdopen(fd, "w", encoding="utf-8") as output:
+        output.write(value)
 
 
 def main() -> int:

--- a/scripts/reborn_webui_v2_live_qa/test_google_oauth_cases.py
+++ b/scripts/reborn_webui_v2_live_qa/test_google_oauth_cases.py
@@ -1,0 +1,81 @@
+import importlib.util
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+
+_SPEC = importlib.util.spec_from_file_location(
+    "google_oauth_cases",
+    Path(__file__).resolve().parents[2] / ".github/scripts/google_oauth_cases.py",
+)
+google_cases = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = google_cases
+_SPEC.loader.exec_module(google_cases)
+
+
+GOOGLE_CASES = "qa_2a_gmail_connect,qa_4e_github_release_email_delivery"
+
+
+class GoogleOauthCasesTests(unittest.TestCase):
+    def test_filter_and_mint_decisions_share_the_same_case_set(self):
+        configured = set(google_cases.parse_cases(GOOGLE_CASES))
+        selected = google_cases.parse_cases(
+            "qa_2a_gmail_connect,qa_4b_github_connect,qa_4e_github_release_email_delivery"
+        )
+        self.assertTrue(google_cases.requires_google(selected, configured))
+        self.assertEqual(
+            google_cases.retain_without_google(selected, configured),
+            ["qa_4b_github_connect"],
+        )
+
+    def test_cli_preserves_non_google_cases_after_mint_failure(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            github_env = Path(tmpdir) / "env"
+            github_output = Path(tmpdir) / "output"
+            argv = [
+                "google_oauth_cases.py",
+                "--mode",
+                "suppress",
+                "--cases",
+                "qa_2a_gmail_connect,qa_4b_github_connect",
+                "--google-cases",
+                GOOGLE_CASES,
+                "--status",
+                "invalid_grant",
+                "--github-env",
+                str(github_env),
+                "--github-output",
+                str(github_output),
+            ]
+            with patch.object(sys, "argv", argv):
+                self.assertEqual(google_cases.main(), 0)
+            self.assertEqual(
+                github_env.read_text(encoding="utf-8"), "CASES=qa_4b_github_connect\n"
+            )
+            self.assertEqual(github_output.read_text(encoding="utf-8"), "skip_shard=0\n")
+
+    def test_cli_skips_an_all_google_shard_after_mint_failure(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            github_output = Path(tmpdir) / "output"
+            argv = [
+                "google_oauth_cases.py",
+                "--mode",
+                "suppress",
+                "--cases",
+                "qa_2a_gmail_connect,qa_4e_github_release_email_delivery",
+                "--google-cases",
+                GOOGLE_CASES,
+                "--status",
+                "network:URLError",
+                "--github-output",
+                str(github_output),
+            ]
+            with patch.object(sys, "argv", argv):
+                self.assertEqual(google_cases.main(), 0)
+            self.assertEqual(github_output.read_text(encoding="utf-8"), "skip_shard=1\n")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/reborn_webui_v2_live_qa/test_refresh_google_oauth.py
+++ b/scripts/reborn_webui_v2_live_qa/test_refresh_google_oauth.py
@@ -1,0 +1,92 @@
+import io
+import os
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+import urllib.error
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import refresh_google_oauth  # noqa: E402
+
+
+class FakeResponse:
+    def __init__(self, body: str):
+        self.body = body
+
+    def __enter__(self):
+        return io.StringIO(self.body)
+
+    def __exit__(self, *_args):
+        return False
+
+
+class RefreshGoogleOauthTests(unittest.TestCase):
+    def test_refresh_returns_fresh_access_token(self):
+        env = {
+            "IRONCLAW_REBORN_GOOGLE_CLIENT_ID": "client-id",
+            "IRONCLAW_REBORN_GOOGLE_CLIENT_SECRET": "client-secret",
+            "AUTH_LIVE_GOOGLE_REFRESH_TOKEN": "refresh-token",
+        }
+        with patch.dict(os.environ, env, clear=True), patch.object(
+            refresh_google_oauth.urllib.request,
+            "urlopen",
+            return_value=FakeResponse('{"access_token":"fresh-token"}'),
+        ):
+            token, status = refresh_google_oauth.refresh_access_token()
+
+        self.assertEqual(token, "fresh-token")
+        self.assertEqual(status, "healthy")
+
+    def test_refresh_reports_invalid_grant_without_response_details(self):
+        error = urllib.error.HTTPError(
+            refresh_google_oauth.TOKEN_URL,
+            400,
+            "Bad Request",
+            {},
+            io.BytesIO(b'{"error":"invalid_grant","error_description":"secret detail"}'),
+        )
+        env = {
+            "IRONCLAW_REBORN_GOOGLE_CLIENT_ID": "client-id",
+            "IRONCLAW_REBORN_GOOGLE_CLIENT_SECRET": "client-secret",
+            "AUTH_LIVE_GOOGLE_REFRESH_TOKEN": "refresh-token",
+        }
+        with patch.dict(os.environ, env, clear=True), patch.object(
+            refresh_google_oauth.urllib.request,
+            "urlopen",
+            side_effect=error,
+        ):
+            token, status = refresh_google_oauth.refresh_access_token()
+
+        self.assertIsNone(token)
+        self.assertEqual(status, "invalid_grant")
+
+    def test_secret_file_takes_precedence_and_output_mode_is_private(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            secret_path = Path(tmpdir) / "refresh"
+            output_path = Path(tmpdir) / "access"
+            secret_path.write_text("file-refresh-token", encoding="utf-8")
+            env = {
+                "IRONCLAW_REBORN_GOOGLE_CLIENT_ID": "client-id",
+                "IRONCLAW_REBORN_GOOGLE_CLIENT_SECRET": "client-secret",
+                "AUTH_LIVE_GOOGLE_REFRESH_TOKEN": "env-refresh-token",
+                "AUTH_LIVE_GOOGLE_REFRESH_TOKEN_PATH": str(secret_path),
+            }
+            with patch.dict(os.environ, env, clear=True), patch.object(
+                refresh_google_oauth.urllib.request,
+                "urlopen",
+                return_value=FakeResponse('{"access_token":"fresh-token"}'),
+            ) as urlopen:
+                token, _ = refresh_google_oauth.refresh_access_token()
+                refresh_google_oauth._write_output(output_path, token or "")
+
+            request = urlopen.call_args.args[0]
+            self.assertIn(b"refresh_token=file-refresh-token", request.data)
+            self.assertEqual(output_path.read_text(encoding="utf-8"), "fresh-token")
+            self.assertEqual(output_path.stat().st_mode & 0o777, 0o600)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/reborn_webui_v2_live_qa/test_refresh_google_oauth.py
+++ b/scripts/reborn_webui_v2_live_qa/test_refresh_google_oauth.py
@@ -24,6 +24,13 @@ class FakeResponse:
 
 
 class RefreshGoogleOauthTests(unittest.TestCase):
+    def setUp(self):
+        self.env = {
+            "IRONCLAW_REBORN_GOOGLE_CLIENT_ID": "client-id",
+            "IRONCLAW_REBORN_GOOGLE_CLIENT_SECRET": "client-secret",
+            "AUTH_LIVE_GOOGLE_REFRESH_TOKEN": "refresh-token",
+        }
+
     def test_refresh_returns_fresh_access_token(self):
         env = {
             "IRONCLAW_REBORN_GOOGLE_CLIENT_ID": "client-id",
@@ -86,6 +93,114 @@ class RefreshGoogleOauthTests(unittest.TestCase):
             self.assertIn(b"refresh_token=file-refresh-token", request.data)
             self.assertEqual(output_path.read_text(encoding="utf-8"), "fresh-token")
             self.assertEqual(output_path.stat().st_mode & 0o777, 0o600)
+
+    def test_refresh_reports_sanitized_failure_statuses(self):
+        scenarios = (
+            (FakeResponse("not-json"), "invalid_json"),
+            (FakeResponse("[]"), "invalid_json"),
+            (FakeResponse("{}"), "missing_access_token"),
+            (urllib.error.URLError("private network detail"), "network:URLError"),
+        )
+        for result, expected_status in scenarios:
+            with self.subTest(status=expected_status), patch.dict(
+                os.environ, self.env, clear=True
+            ), patch.object(
+                refresh_google_oauth.urllib.request,
+                "urlopen",
+                return_value=result if isinstance(result, FakeResponse) else None,
+                side_effect=result if isinstance(result, BaseException) else None,
+            ):
+                token, status = refresh_google_oauth.refresh_access_token()
+            self.assertIsNone(token)
+            self.assertEqual(status, expected_status)
+
+        with patch.dict(os.environ, {}, clear=True):
+            token, status = refresh_google_oauth.refresh_access_token()
+        self.assertIsNone(token)
+        self.assertTrue(status.startswith("missing:"))
+        self.assertNotIn("client-id", status)
+
+    def test_unreadable_secret_path_becomes_missing_status(self):
+        env = {
+            **self.env,
+            "AUTH_LIVE_GOOGLE_REFRESH_TOKEN_PATH": "/does/not/exist",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            token, status = refresh_google_oauth.refresh_access_token()
+        self.assertIsNone(token)
+        self.assertEqual(status, "missing:AUTH_LIVE_GOOGLE_REFRESH_TOKEN")
+
+    def test_malformed_http_error_body_is_sanitized(self):
+        error = urllib.error.HTTPError(
+            refresh_google_oauth.TOKEN_URL,
+            503,
+            "secret response detail",
+            {},
+            io.BytesIO(b"not-json"),
+        )
+        with patch.dict(os.environ, self.env, clear=True), patch.object(
+            refresh_google_oauth.urllib.request, "urlopen", side_effect=error
+        ):
+            token, status = refresh_google_oauth.refresh_access_token()
+        self.assertIsNone(token)
+        self.assertEqual(status, "http_503")
+
+    def test_unreadable_http_error_body_is_sanitized(self):
+        class UnreadableBody:
+            def read(self):
+                raise OSError("private transport detail")
+
+            def close(self):
+                pass
+
+        error = urllib.error.HTTPError(
+            refresh_google_oauth.TOKEN_URL,
+            502,
+            "secret response detail",
+            {},
+            UnreadableBody(),
+        )
+        with patch.dict(os.environ, self.env, clear=True), patch.object(
+            refresh_google_oauth.urllib.request, "urlopen", side_effect=error
+        ):
+            token, status = refresh_google_oauth.refresh_access_token()
+        self.assertIsNone(token)
+        self.assertEqual(status, "http_502")
+
+    def test_main_writes_status_and_token_only_on_success(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            output_path = root / "github-output"
+            token_path = root / "access-token"
+            argv = [
+                "refresh_google_oauth.py",
+                "--github-output",
+                str(output_path),
+                "--access-token-path",
+                str(token_path),
+            ]
+            with patch.object(sys, "argv", argv), patch.object(
+                refresh_google_oauth,
+                "refresh_access_token",
+                return_value=("fresh-token", "healthy"),
+            ):
+                self.assertEqual(refresh_google_oauth.main(), 0)
+            self.assertEqual(output_path.read_text(encoding="utf-8"), "status=healthy\n")
+            self.assertEqual(token_path.read_text(encoding="utf-8"), "fresh-token")
+            self.assertEqual(token_path.stat().st_mode & 0o777, 0o600)
+
+            token_path.unlink()
+            with patch.object(sys, "argv", argv), patch.object(
+                refresh_google_oauth,
+                "refresh_access_token",
+                return_value=(None, "invalid_grant"),
+            ):
+                self.assertEqual(refresh_google_oauth.main(), 1)
+            self.assertEqual(
+                output_path.read_text(encoding="utf-8"),
+                "status=healthy\nstatus=invalid_grant\n",
+            )
+            self.assertFalse(token_path.exists())
 
 
 if __name__ == "__main__":

--- a/scripts/reborn_webui_v2_live_qa/test_refresh_google_oauth.py
+++ b/scripts/reborn_webui_v2_live_qa/test_refresh_google_oauth.py
@@ -3,6 +3,7 @@ import os
 from pathlib import Path
 import sys
 import tempfile
+from typing import NoReturn
 import unittest
 import urllib.error
 from unittest.mock import patch
@@ -145,12 +146,37 @@ class RefreshGoogleOauthTests(unittest.TestCase):
         self.assertIsNone(token)
         self.assertEqual(status, "http_503")
 
+    def test_non_object_and_unsafe_http_errors_use_status_fallback(self):
+        bodies = (
+            b'[]',
+            b'null',
+            b'"invalid_grant"',
+            b'{"error":"contains a space"}',
+            b'{"error":"line\\nbreak"}',
+            b'{"error":"' + (b"x" * 129) + b'"}',
+        )
+        for body in bodies:
+            with self.subTest(body=body):
+                error = urllib.error.HTTPError(
+                    refresh_google_oauth.TOKEN_URL,
+                    429,
+                    "secret response detail",
+                    {},
+                    io.BytesIO(body),
+                )
+                with patch.dict(os.environ, self.env, clear=True), patch.object(
+                    refresh_google_oauth.urllib.request, "urlopen", side_effect=error
+                ):
+                    token, status = refresh_google_oauth.refresh_access_token()
+                self.assertIsNone(token)
+                self.assertEqual(status, "http_429")
+
     def test_unreadable_http_error_body_is_sanitized(self):
         class UnreadableBody:
-            def read(self):
-                raise OSError("private transport detail")
+            def read(self) -> NoReturn:
+                raise OSError
 
-            def close(self):
+            def close(self) -> None:
                 pass
 
         error = urllib.error.HTTPError(

--- a/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
+++ b/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
@@ -4773,6 +4773,11 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
         )
         self.assertIn("REBORN_WEBUI_V2_GOOGLE_CASES", match.group("body"))
         self.assertEqual(
+            len(re.findall(r"^    env:\s*$", match.group("body"), re.M)),
+            1,
+            "the job must have one env mapping so Google-case gating is not overwritten",
+        )
+        self.assertEqual(
             match.group("body").count(".github/scripts/google_oauth_cases.py"),
             3,
             "preflight filtering, mint selection, and mint-failure filtering "

--- a/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
+++ b/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
@@ -4741,7 +4741,11 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
             workflow,
         )
         self.assertIn("(authorized trigger)", workflow)
-        self.assertIn("needs: prepare-reborn-webui-v2-live-qa", match.group("body"))
+        self.assertIn("- prepare-reborn-webui-v2-live-qa", match.group("body"))
+        self.assertIn(
+            "- preflight-reborn-webui-v2-google-oauth",
+            match.group("body"),
+        )
         self.assertIn("always() &&", match.group("body"))
         self.assertIn(
             "needs.prepare-reborn-webui-v2-live-qa.result == 'success'",
@@ -4759,6 +4763,40 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
         self.assertIn("cache: pip", match.group("body"))
         self.assertNotIn("Build WASM channels", match.group("body"))
         self.assertNotIn("Setup OVH sccache", match.group("body"))
+        self.assertIn(
+            "Suppress Google cases after OAuth preflight failure",
+            match.group("body"),
+        )
+        self.assertIn(
+            "Mint fresh Google OAuth access token for selected cases",
+            match.group("body"),
+        )
+        self.assertIn(
+            "AUTH_LIVE_GOOGLE_ACCESS_TOKEN_PATH=${access_token_path}",
+            match.group("body"),
+        )
+
+        google_preflight_match = re.search(
+            r"(?ms)^  preflight-reborn-webui-v2-google-oauth:\n"
+            r"(?P<body>.*?)^  prepare-reborn-webui-v2-live-qa:",
+            workflow,
+        )
+        self.assertIsNotNone(
+            google_preflight_match,
+            "shared Google OAuth preflight job missing",
+        )
+        google_preflight_body = google_preflight_match.group("body")
+        self.assertIn("refresh_google_oauth.py", google_preflight_body)
+        self.assertIn("continue-on-error: true", google_preflight_body)
+        self.assertIn(
+            "Google-dependent cases will be skipped; non-Google cases will continue",
+            google_preflight_body,
+        )
+        self.assertIn(
+            "REBORN_GOOGLE_OAUTH_PREFLIGHT_STATUS: "
+            "${{ needs.preflight-reborn-webui-v2-google-oauth.outputs.status }}",
+            workflow,
+        )
 
         prepare_match = re.search(
             r"(?ms)^  prepare-reborn-webui-v2-live-qa:\n(?P<body>.*?)^  reborn-webui-v2-live-qa:",

--- a/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
+++ b/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
@@ -4771,6 +4771,18 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
             "Mint fresh Google OAuth access token for selected cases",
             match.group("body"),
         )
+        self.assertIn("REBORN_WEBUI_V2_GOOGLE_CASES", match.group("body"))
+        self.assertEqual(
+            match.group("body").count(".github/scripts/google_oauth_cases.py"),
+            3,
+            "preflight filtering, mint selection, and mint-failure filtering "
+            "must use the same executable case classifier",
+        )
+        self.assertNotIn("google_cases='", match.group("body"))
+        self.assertIn(
+            "steps.mint_reborn_webui_v2_google_token.outputs.skip_shard != '1'",
+            match.group("body"),
+        )
         self.assertIn(
             "AUTH_LIVE_GOOGLE_ACCESS_TOKEN_PATH=${access_token_path}",
             match.group("body"),


### PR DESCRIPTION
## Summary

- validate the Reborn WebUI v2 Google refresh token once before live-QA shard fan-out
- mint a fresh short-lived access token inside every Google-dependent shard without exposing it through outputs or artifacts
- degrade refresh failures by dropping only Google-dependent cases while continuing runnable non-Google cases
- include one sanitized OAuth infrastructure failure and remediation in the canary Slack report

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [x] CI/Infrastructure
- [x] Security
- [ ] Dependencies

## Linked Issue

None.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all --benches --tests --examples --all-features`
- [ ] `cargo build` (covered by clippy compilation)
- [x] Relevant tests pass: 164 focused Python tests, 5 existing skips, 29 subtests
- [ ] `cargo test --features integration` (not database-backed)
- [x] Manual testing: parsed the workflow with PyYAML and exercised preflight-only dry-run Slack output
- [x] Multi-agent review was run before requesting review

`cargo test --lib` compiled and started all 4,588 tests, then the monolithic test process terminated with SIGABRT without reporting a failing assertion. The focused suites and clippy gate pass.

## Security Impact

This changes OAuth secret-file and network-error handling. Access and refresh tokens are never printed, passed through GitHub job outputs, or uploaded as artifacts. Fresh access tokens are created with mode `0600` from the first write and only sanitized failure classes reach reports.

## Reborn Trust-Boundary Checklist

- [x] Public policy/evidence/trust-bearing types: N/A; no Rust trust-bearing types changed.
- [x] Untrusted content enters prompts only through an envelope/escaping primitive: N/A; no prompt flow changed.
- [x] Hashes declare purpose: N/A; no hashes changed.
- [x] Downstream status/error consumers audited: workflow filtering and Slack reporting consume sanitized refresh statuses.
- [x] Security/durability `serde(default)` fields: N/A; no serde types changed.
- [x] Queues/maps/buffers/counters bounded: N/A; no persistent collections changed.
- [x] Driver/operator-visible errors have stable class semantics: OAuth failures remain sanitized status strings such as `invalid_grant`, `http_503`, and `network:URLError`.
- [x] Sandbox/native/host names accurately describe trust boundary: N/A; no runtime boundary names changed.

## Database Impact

None.

## Blast Radius

Limited to the Reborn WebUI v2 live-canary Google OAuth preflight, per-shard case selection/token minting, and canary Slack reporting. A classifier regression could incorrectly skip or retain Google-dependent QA cases; executable mixed-shard and all-Google tests cover both outcomes.

## Rollback Plan

Revert this PR/commit to restore the previous static-token and hard-failure behavior. No migration or persistent data rollback is required.

## Review Follow-Through

All ten review threads from Gemini, CodeRabbit, and the multi-agent review were addressed in commit `40d5d5a13` and resolved. Re-check new review threads and CI after the push.

---

**Review track**: C (security/runtime/CI)
