### PR TITLE
Fix flaky Slack trigger hook e2e with deterministic poller tick

### DIFF
--- a/crates/ironclaw_reborn_composition/src/automation/trigger_poller.rs
+++ b/crates/ironclaw_reborn_composition/src/automation/trigger_poller.rs
@@ -37,6 +37,8 @@ pub(crate) const TRIGGER_POLLER_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs
 pub(crate) struct TriggerPollerRuntimeHandle {
     cancel: CancellationToken,
     handle: JoinHandle<()>,
+    #[cfg(any(test, feature = "test-support"))]
+    test_worker: Option<Arc<TriggerPollerWorker>>,
 }
 
 impl TriggerPollerRuntimeHandle {
@@ -65,6 +67,16 @@ impl TriggerPollerRuntimeHandle {
                 }
             }
         }
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    pub(crate) async fn tick_once_for_test(
+        &self,
+    ) -> Option<Result<ironclaw_triggers::TriggerPollerTickReport, ironclaw_triggers::TriggerError>> {
+        let Some(worker) = &self.test_worker else {
+            return None;
+        };
+        Some(worker.tick_once(Utc::now()).await)
     }
 }
 
@@ -110,11 +122,18 @@ pub(crate) fn spawn_trigger_poller(
             fire_settlement_observer,
         },
     )?;
+    let worker = Arc::new(worker);
     let task_cancel = cancel.clone();
+    let task_worker = Arc::clone(&worker);
     let handle = tokio::spawn(async move {
-        run_trigger_poller(worker, settings, task_cancel).await;
+        run_trigger_poller(task_worker, settings, task_cancel).await;
     });
-    Ok(Some(TriggerPollerRuntimeHandle { cancel, handle }))
+    Ok(Some(TriggerPollerRuntimeHandle {
+        cancel,
+        handle,
+        #[cfg(any(test, feature = "test-support"))]
+        test_worker: Some(worker),
+    }))
 }
 
 #[cfg(feature = "slack-v2-host-beta")]
@@ -232,7 +251,7 @@ impl TriggerFireSettlementObserver for PostSubmitHookObserver {
 }
 
 async fn run_trigger_poller(
-    worker: TriggerPollerWorker,
+    worker: Arc<TriggerPollerWorker>,
     settings: TriggerPollerSettings,
     cancel: CancellationToken,
 ) {
@@ -326,7 +345,12 @@ mod tests {
             task_cancel.cancelled().await;
             std::future::pending::<()>().await;
         });
-        let runtime_handle = TriggerPollerRuntimeHandle { cancel, handle };
+        let runtime_handle = TriggerPollerRuntimeHandle {
+            cancel,
+            handle,
+            #[cfg(any(test, feature = "test-support"))]
+            test_worker: None,
+        };
 
         runtime_handle.shutdown(Duration::from_millis(1)).await;
     }

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -1545,6 +1545,16 @@ impl RebornRuntime {
             .map(|local_runtime| Arc::clone(&local_runtime.trigger_repository))
     }
 
+    #[cfg(any(test, feature = "test-support"))]
+    pub(crate) async fn trigger_poller_tick_once_for_test(
+        &self,
+    ) -> Option<Result<ironclaw_triggers::TriggerPollerTickReport, ironclaw_triggers::TriggerError>> {
+        let Some(handle) = &self.trigger_poller_handle else {
+            return None;
+        };
+        handle.tick_once_for_test().await
+    }
+
     /// Test-only accessor for the SAME `ConversationActorPairingService`
     /// instance the spawned trigger poller's
     /// [`ConversationContentRefMaterializer`] consults. Integration tests

--- a/crates/ironclaw_reborn_composition/src/slack/slack_host_beta.rs
+++ b/crates/ironclaw_reborn_composition/src/slack/slack_host_beta.rs
@@ -4894,6 +4894,12 @@ mod tests {
         let mut fired_run_id = None;
         let mut last_trigger_state = None;
         while Instant::now() < deadline {
+            if let Some(result) = runtime
+                .trigger_poller_tick_once_for_test()
+                .await
+            {
+                result.expect("manual trigger poller tick should succeed in test");
+            }
             tokio::time::sleep(std::time::Duration::from_millis(100)).await;
             let current = repo
                 .get_trigger(tenant_id.clone(), trigger_id)
@@ -4910,6 +4916,7 @@ mod tests {
                 current.last_status,
                 current.active_fire_slot,
                 current.active_run_ref,
+                current.last_fired_slot,
             ));
         }
 
@@ -4941,8 +4948,10 @@ mod tests {
 
         assert!(
             fired_run_id.is_some(),
-            "trigger did not fire within {:?} — hook wiring e2e stalled; last_trigger_state={last_trigger_state:?}",
+            "trigger did not fire within {:?} — hook wiring e2e stalled; last_trigger_state={:?}",
             TRIGGER_HOOK_E2E_FIRE_TIMEOUT
+            ,
+            last_trigger_state
         );
         assert!(
             delivery_record.is_some(),


### PR DESCRIPTION
## Summary
- Added a test-only deterministic trigger-poller seam so Reborn tests can force a single poller tick without waiting on background scheduling jitter.
- Wired the seam through `TriggerPollerRuntimeHandle` (test-only) and `RebornRuntime`.
- Updated the flaky Slack host beta hook wiring e2e helper to trigger a poller tick in its assertion loop and include additional trigger state in the timeout message.

## Why
The `build_slack_host_beta_mounts_wires_trigger_delivery_hook_writes_record` path in CI (`Coverage (libsql-only)`) could intermittently time out waiting for background trigger fire timing. Forcing a deterministic tick makes the behavior robust under scheduling contention.

## Impact
No production-path behavior changes. The new APIs are test-only (`#[cfg(any(test, feature = "test-support"))]`) and keep existing timing defaults intact.

## Checks
- Not run in this pass (as requested). Please run targeted composition e2e/reborn trigger tests before merge.
