### PR TITLE
ci: static pre-push checks — include_str/Docker-COPY + hermetic env (#6018)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -9,10 +9,27 @@ SCRIPT_DIR="$REPO_ROOT/scripts/ci"
 # Default: baseline quality gate
 "$SCRIPT_DIR/quality_gate.sh"
 
+# Fast static checks (no compile) — catch deterministic breakers that a
+# host-only build misses. See issue #6018.
+#   - include_str! targets exist AND are in every Dockerfile build context
+#     (the #5603 Docker outage class).
+#   - newly-added raw std::env::set_var/remove_var is guarded (the #6015
+#     coverage-flake / Rust 1.82 UB class).
+echo "==> static: include_str! paths + Docker COPY coverage"
+"$SCRIPT_DIR/check-include-str-paths.sh"
+echo "==> static: hermetic env mutation"
+"$SCRIPT_DIR/check-hermetic-env.sh"
+
 # Optional strict delta lint (env-gated)
 if [ "${IRONCLAW_STRICT_DELTA_LINT:-0}" = "1" ]; then
     "$SCRIPT_DIR/delta_lint.sh" "$1"
 elif [ "${IRONCLAW_STRICT_LINT:-0}" = "1" ]; then
-    echo "==> clippy (strict: all warnings)"
+    echo "==> clippy (strict: all warnings, default features)"
     cargo clippy --locked --all-targets -- -D warnings
+    # Feature-matrix leg: the libsql-only build gates a distinct set of
+    # `cfg`/`dead_code` lints that default-feature clippy never sees — the
+    # class that reds `Clippy (libsql-only)` on main (e.g. the `Prebuilt`
+    # dead_code break, #5840). Cheap relative to a full test run.
+    echo "==> clippy (strict: libsql-only feature leg)"
+    cargo clippy --locked --no-default-features --features libsql --all-targets -- -D warnings
 fi

--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           CHANGED_FILES="$(git diff --name-only "$BASE_SHA"..."$HEAD_SHA")"
 
-          if printf '%s\n' "$CHANGED_FILES" | grep -Eq '^(src/|crates/|channels-src/|tools-src/|tests/|migrations/|Cargo\.toml$|Cargo\.lock$|Dockerfile$|build\.rs$|\.gitignore$|scripts/check_no_panics\.py$|scripts/check_gateway_boundaries\.py$|\.github/workflows/code_style\.yml$)'; then
+          if printf '%s\n' "$CHANGED_FILES" | grep -Eq '^(src/|crates/|channels-src/|tools-src/|tests/|migrations/|Cargo\.toml$|Cargo\.lock$|Dockerfile|build\.rs$|\.gitignore$|scripts/ci/|\.githooks/|scripts/check_no_panics\.py$|scripts/check_gateway_boundaries\.py$|\.github/workflows/code_style\.yml$)'; then
             echo "has_code=true" >> "$GITHUB_OUTPUT"
           else
             echo "has_code=false" >> "$GITHUB_OUTPUT"
@@ -209,6 +209,19 @@ jobs:
       # no compile — safe on a shallow checkout.
       - name: include_str! paths + Docker COPY coverage
         run: scripts/ci/check-include-str-paths.sh
+      # Guards the #6015 coverage-flake class on the actual PR diff (not just
+      # the synthetic self-tests below): a newly-added unguarded env mutation
+      # fails here. The checker diffs the working tree against the PR base, so
+      # fetch that base tip first (a shallow checkout lacks origin/<base>).
+      - name: Hermetic env mutation guard (PR diff)
+        env:
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+        run: |
+          if [ -n "${GITHUB_BASE_REF:-}" ]; then
+            git fetch --no-tags --depth=1 origin \
+              "+refs/heads/${GITHUB_BASE_REF}:refs/remotes/origin/${GITHUB_BASE_REF}"
+          fi
+          scripts/ci/check-hermetic-env.sh
       # Lock in the checkers' own behaviour (they build hermetic temp repos).
       - name: Static-check self-tests
         run: |

--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -194,6 +194,27 @@ jobs:
             exit 1
           fi
 
+  static-checks:
+    name: Static checks (include_str, hermetic env)
+    needs: changes
+    if: needs.changes.outputs.has_code == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      # Guards the #5603 Docker-outage class: every include_str! target must
+      # exist and be present in each Dockerfile build context. Whole-repo scan,
+      # no compile — safe on a shallow checkout.
+      - name: include_str! paths + Docker COPY coverage
+        run: scripts/ci/check-include-str-paths.sh
+      # Lock in the checkers' own behaviour (they build hermetic temp repos).
+      - name: Static-check self-tests
+        run: |
+          scripts/ci/test-check-include-str-paths.sh
+          scripts/ci/test-check-hermetic-env.sh
+
   clippy:
     name: Clippy (${{ matrix.name }})
     needs: [changes, clippy-matrix]
@@ -387,6 +408,7 @@ jobs:
       - clippy-windows
       - deny-check
       - tracked-ignored-files
+      - static-checks
       - reborn-cli-smoke
       - no-panics
       - gateway-boundaries
@@ -414,6 +436,7 @@ jobs:
             "clippy=${{ needs.clippy.result }}" \
             "deny-check=${{ needs.deny-check.result }}" \
             "tracked-ignored-files=${{ needs.tracked-ignored-files.result }}" \
+            "static-checks=${{ needs.static-checks.result }}" \
             "gateway-boundaries=${{ needs.gateway-boundaries.result }}" \
             "webui-v2-js-lint=${{ needs.webui-v2-js-lint.result }}"; do
             name="${job_result%%=*}"

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -26,9 +26,12 @@ COPY build.rs build.rs
 COPY src/ src/
 COPY tests/ tests/
 COPY migrations/ migrations/
+COPY prompts/ prompts/
+COPY profiles/ profiles/
 COPY registry/ registry/
 COPY channels-src/ channels-src/
 COPY wit/ wit/
+COPY providers.json providers.json
 
 RUN cargo build --release --no-default-features --features libsql --bin ironclaw
 

--- a/scripts/ci/check-hermetic-env.sh
+++ b/scripts/ci/check-hermetic-env.sh
@@ -35,7 +35,14 @@ SUPPRESS_RE='// env-hermetic:'
 # Diff source: staged changes if any, else the working tree vs the upstream base.
 if git diff --cached --quiet 2>/dev/null; then
     BASE_REF=""
-    for ref in "@{upstream}" "origin/HEAD" "origin/main" "origin/master" "main" "master"; do
+    # In CI (GitHub Actions) the PR base is exposed via GITHUB_BASE_REF; a
+    # shallow checkout may lack `origin/main`, so try the PR base first.
+    CANDIDATES=()
+    if [ -n "${GITHUB_BASE_REF:-}" ]; then
+        CANDIDATES+=("origin/$GITHUB_BASE_REF" "$GITHUB_BASE_REF")
+    fi
+    CANDIDATES+=("@{upstream}" "origin/HEAD" "origin/main" "origin/master" "main" "master")
+    for ref in "${CANDIDATES[@]}"; do
         if git rev-parse --verify --quiet "$ref" >/dev/null 2>&1; then
             BASE_REF="$ref"
             break
@@ -46,9 +53,12 @@ if git diff --cached --quiet 2>/dev/null; then
         echo "hermetic-env: no base ref to diff against; skipping"
         exit 0
     fi
-    DIFF=$(git diff -W "$BASE_REF" -- '*.rs' 2>/dev/null || true)
+    # No `|| true`: a git-diff failure must abort (set -e), not silently yield
+    # an empty diff that would bypass the guard. `git diff` returns 0 on a
+    # clean run regardless of content, so this only surfaces real errors.
+    DIFF=$(git diff -W "$BASE_REF" -- '*.rs')
 else
-    DIFF=$(git diff --cached -W -- '*.rs' 2>/dev/null || true)
+    DIFF=$(git diff --cached -W -- '*.rs')
 fi
 
 [ -n "$DIFF" ] || { echo "hermetic-env: no Rust changes; OK"; exit 0; }
@@ -66,8 +76,13 @@ HITS=$(printf '%s\n' "$DIFF" | awk -v guard="$GUARD_RE" -v mut="$MUT_RE" -v supp
     /^@@ / { flush(); next }
     {
         # A guard token anywhere in the function hunk (added or context)
-        # clears the whole hunk.
-        if ($0 ~ guard) has_guard = 1
+        # clears the whole hunk — but only when it names real lock/RAII
+        # construction, not when it merely appears in a `//` comment. Strip
+        # the line comment before testing so `// EnvGuard` does not exempt an
+        # adjacent raw mutation.
+        code = $0
+        sub(/\/\/.*/, "", code)
+        if (code ~ guard) has_guard = 1
         # Only ADDED lines that mutate env and are not suppressed accumulate.
         if ($0 ~ /^\+/ && $0 ~ mut && $0 !~ suppress) {
             line = $0

--- a/scripts/ci/check-hermetic-env.sh
+++ b/scripts/ci/check-hermetic-env.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Static check: newly-added raw `std::env::set_var(...)` / `remove_var(...)`
+# must be guarded by the crate env lock (`lock_env()` / `lock_runtime_env()` /
+# `ENV_MUTEX`) or the `EnvGuard` RAII helper.
+#
+# Motivation: issue #6015 and the broader coverage-flake class in #6014. The
+# largest source of `Code Coverage` red on main is non-hermetic tests that
+# mutate process-global env in parallel and race each other (e.g. the
+# `build_runtime_input_production_*` block, 14 tests failing together). Since
+# Rust 1.82 `std::env::set_var` is also UB in a multi-threaded program unless
+# serialized. `crates/ironclaw_common/src/env_helpers.rs` documents the
+# sanctioned pattern: acquire `lock_env()` and mutate through an `EnvGuard`.
+#
+# Delta-scoped and function-scoped: it inspects `git diff -W` (whole-function
+# context) so it only fires on NEW env mutation whose enclosing function has no
+# lock guard. This keeps it quiet on the ~700 pre-existing (guarded) call sites
+# and only gates newly-introduced unguarded ones.
+#
+# Suppress a genuine single-threaded case (e.g. a startup shim that runs before
+# any thread spawns) with an inline `// env-hermetic: <reason>` comment on the
+# mutating line.
+
+cd "$(git rev-parse --show-toplevel)"
+
+# Guard tokens whose presence in the same function means the mutation is
+# serialized (or wrapped in the restore-on-drop helper).
+GUARD_RE='lock_env|lock_runtime_env|ENV_MUTEX|EnvGuard'
+# Raw process-env mutation (not the thread-safe `set_runtime_env` map API).
+# Literal `(` written as `[(]` so it survives awk's ERE (where `\(` is invalid).
+MUT_RE='env::(set_var|remove_var)[[:space:]]*[(]'
+SUPPRESS_RE='// env-hermetic:'
+
+# Diff source: staged changes if any, else the working tree vs the upstream base.
+if git diff --cached --quiet 2>/dev/null; then
+    BASE_REF=""
+    for ref in "@{upstream}" "origin/HEAD" "origin/main" "origin/master" "main" "master"; do
+        if git rev-parse --verify --quiet "$ref" >/dev/null 2>&1; then
+            BASE_REF="$ref"
+            break
+        fi
+    done
+    if [ -z "$BASE_REF" ]; then
+        # No base ref (fresh repo / detached) — nothing to diff against.
+        echo "hermetic-env: no base ref to diff against; skipping"
+        exit 0
+    fi
+    DIFF=$(git diff -W "$BASE_REF" -- '*.rs' 2>/dev/null || true)
+else
+    DIFF=$(git diff --cached -W -- '*.rs' 2>/dev/null || true)
+fi
+
+[ -n "$DIFF" ] || { echo "hermetic-env: no Rust changes; OK"; exit 0; }
+
+HITS=$(printf '%s\n' "$DIFF" | awk -v guard="$GUARD_RE" -v mut="$MUT_RE" -v suppress="$SUPPRESS_RE" '
+    function flush() {
+        if (buf != "" && !has_guard) {
+            printf "%s", buf
+        }
+        buf = ""
+        has_guard = 0
+    }
+    /^\+\+\+ b\// { flush(); file = substr($0, 7); next }
+    /^--- / { next }
+    /^@@ / { flush(); next }
+    {
+        # A guard token anywhere in the function hunk (added or context)
+        # clears the whole hunk.
+        if ($0 ~ guard) has_guard = 1
+        # Only ADDED lines that mutate env and are not suppressed accumulate.
+        if ($0 ~ /^\+/ && $0 ~ mut && $0 !~ suppress) {
+            line = $0
+            sub(/^\+/, "", line)
+            buf = buf "    " file ": " line "\n"
+        }
+    }
+    END { flush() }
+')
+
+if [ -n "$HITS" ]; then
+    echo "✗ Newly-added raw std::env::set_var/remove_var without an env guard:"
+    printf '%s' "$HITS"
+    echo ""
+    echo "Process env is global; unguarded mutation races parallel tests (see #6015)"
+    echo "and is UB on Rust 1.82+. Acquire crate::env_helpers::lock_env() (or the"
+    echo "module's lock_runtime_env()) and mutate through an EnvGuard, per"
+    echo "crates/ironclaw_common/src/env_helpers.rs."
+    echo "Genuine single-threaded case? Annotate the line with '// env-hermetic: <reason>'."
+    echo "Bypass (not recommended): git push --no-verify"
+    exit 1
+fi
+
+echo "hermetic-env: OK (no unguarded env mutation added)"

--- a/scripts/ci/check-include-str-paths.sh
+++ b/scripts/ci/check-include-str-paths.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Static check: every `include_str!("...")` target must (A) exist on disk and
+# (B) be present in the Docker build context of any Dockerfile that compiles
+# the referencing crate.
+#
+# Motivation: issue #5603 / the 2026-07-03 Docker outage. Two new
+# `include_str!("../../prompts/*.md")` call sites were added in `src/`, but the
+# repo-root `prompts/` directory was not `COPY`d into the Dockerfile builder
+# stage. The host build passed (the files exist in the repo) while every Docker
+# build failed for ~15 consecutive runs with:
+#   error: couldn't read `src/hooks/../../prompts/session_summary.md`
+# A host-only compile can never catch this class; a static context check can,
+# in milliseconds, with no compile.
+#
+# Runs standalone (`bash scripts/ci/check-include-str-paths.sh`) and from the
+# pre-push hook. Whole-repo scan (not delta) — it is cheap and the invariant is
+# global.
+
+# Root to scan. Defaults to the git top-level; tests pass an explicit tree.
+REPO_ROOT="${1:-$(git rev-parse --show-toplevel)}"
+
+python3 - "$REPO_ROOT" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+repo = Path(sys.argv[1]).resolve()
+
+INCLUDE_RE = re.compile(r'include_str!\(\s*"([^"]+)"\s*\)')
+CFG_TEST_RE = re.compile(r'#\[cfg\(test\)\]')
+# `COPY <src>... <dest>` but not `COPY --from=<stage> ...` (those pull from a
+# previous build stage, not the local context).
+COPY_RE = re.compile(r'^\s*COPY\s+(?!--from=)(.+?)\s*$', re.IGNORECASE)
+CARGO_BUILD_RE = re.compile(r'cargo\s+build')
+
+
+def top_segment(rel: str) -> str:
+    parts = Path(rel).parts
+    return parts[0] if parts else ""
+
+
+def cfg_test_spans(lines):
+    """Return a list of (start, end) 0-based line index ranges guarded by
+    `#[cfg(test)]`. `cargo build` does not compile these, so include_str!
+    targets referenced only from test code are not required in a Docker
+    build context. Brace-aware: handles `#[cfg(test)] mod tests { ... }` and
+    `#[cfg(test)] fn helper() { ... }`."""
+    spans = []
+    i = 0
+    n = len(lines)
+    while i < n:
+        if CFG_TEST_RE.search(lines[i]):
+            # Find the opening brace of the guarded item.
+            j = i
+            while j < n and "{" not in lines[j]:
+                j += 1
+            if j >= n:
+                break
+            depth = 0
+            k = j
+            while k < n:
+                depth += lines[k].count("{") - lines[k].count("}")
+                if depth <= 0:
+                    break
+                k += 1
+            spans.append((i, k))
+            i = k + 1
+        else:
+            i += 1
+    return spans
+
+
+def in_any_span(idx, spans):
+    return any(start <= idx <= end for start, end in spans)
+
+
+# ── Collect include_str! references from library/binary code ──────────────
+# Restrict to src/ and crates/ — the code that actually ships in the binary.
+# tests/ and tools/ prompt fixtures are lower-stakes and covered by broad
+# `COPY tests/`/`COPY tools/...` lines anyway.
+rs_files = []
+for base in ("src", "crates"):
+    d = repo / base
+    if d.is_dir():
+        rs_files.extend(sorted(d.rglob("*.rs")))
+
+missing = []          # (referencing_file, raw_path)
+refs = []             # (referencing_relpath, target_relpath)
+for f in rs_files:
+    try:
+        text = f.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        continue
+    if "include_str!" not in text:
+        continue
+    f_rel = f.relative_to(repo)
+    lines = text.splitlines()
+    spans = cfg_test_spans(lines) if "#[cfg(test)]" in text else []
+    # Precompute character offset → line index for span filtering.
+    for m in INCLUDE_RE.finditer(text):
+        line_idx = text.count("\n", 0, m.start())
+        if in_any_span(line_idx, spans):
+            # Test-only include_str! — not compiled by `cargo build`.
+            continue
+        raw = m.group(1)
+        target = (f.parent / raw).resolve()
+        if not target.exists():
+            missing.append((f_rel, raw))
+            continue
+        try:
+            target_rel = target.relative_to(repo)
+        except ValueError:
+            # Resolves outside the repo — unusual, but not a Docker-context
+            # concern. Skip (existence already confirmed above).
+            continue
+        refs.append((f_rel, target_rel))
+
+
+# ── Parse Dockerfiles that build the binary from local source ─────────────
+def parse_dockerfile(text):
+    roots = set()
+    full_copy = False
+    builds = False
+    for line in text.splitlines():
+        if CARGO_BUILD_RE.search(line):
+            builds = True
+        m = COPY_RE.match(line)
+        if not m:
+            continue
+        tokens = [t for t in m.group(1).split() if t]
+        if len(tokens) < 2:
+            continue
+        srcs = tokens[:-1]  # last token is the destination
+        for s in srcs:
+            if s.startswith("--"):  # --chown=, --chmod=, etc.
+                continue
+            if s in (".", "./"):
+                full_copy = True
+                continue
+            roots.add(top_segment(s))
+    return roots, full_copy, builds
+
+
+dockerfiles = sorted(repo.glob("Dockerfile*"))
+coverage_errors = []  # (dockerfile, referencing_file, target, missing_root)
+for df in dockerfiles:
+    try:
+        text = df.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        continue
+    roots, full_copy, builds = parse_dockerfile(text)
+    if not builds or full_copy:
+        # Doesn't compile from local source, or copies the whole context
+        # (`COPY . .`) — every include_str! target is present by construction.
+        continue
+    df_rel = df.relative_to(repo)
+    for ref_file, target in refs:
+        ref_top = top_segment(str(ref_file))
+        # Only enforce for referencing files this Dockerfile actually copies
+        # (i.e. actually compiles). A Dockerfile that never copies `src/`
+        # (e.g. Dockerfile.reborn) does not compile `src/hooks/*.rs`, so a
+        # repo-root `prompts/` reference from there is irrelevant to it.
+        if ref_top not in roots:
+            continue
+        target_top = top_segment(str(target))
+        if target_top not in roots:
+            coverage_errors.append((df_rel, ref_file, target, target_top))
+
+
+# ── Report ────────────────────────────────────────────────────────────────
+failed = False
+
+if missing:
+    failed = True
+    print("✗ include_str!() targets that do not exist on disk:")
+    for ref_file, raw in missing:
+        print(f"    {ref_file}: include_str!(\"{raw}\") — file not found")
+    print()
+
+if coverage_errors:
+    failed = True
+    print("✗ include_str!() targets missing from a Dockerfile build context:")
+    # Group by (dockerfile, missing_root) so the fix is obvious.
+    seen = set()
+    for df_rel, ref_file, target, missing_root in coverage_errors:
+        key = (str(df_rel), missing_root)
+        if key in seen:
+            continue
+        seen.add(key)
+        # A top-level file (e.g. `providers.json`) is copied without a
+        # trailing slash; a directory root gets `dir/ dir/`.
+        is_file = str(target) == missing_root
+        copy_hint = (f"COPY {missing_root} {missing_root}" if is_file
+                     else f"COPY {missing_root}/ {missing_root}/")
+        print(f"    {df_rel}: compiles code that does "
+              f"include_str!(\"…/{target}\") but never COPYs `{missing_root}`.")
+        print(f"        e.g. {ref_file} → {target}")
+        print(f"        Fix: add `{copy_hint}` to the "
+              f"builder stage of {df_rel} (before the `cargo build`).")
+    print()
+
+if failed:
+    print("include_str! path check failed. See CLAUDE.md 'Prompt templates live "
+          "in files' and issue #6018.")
+    print("Bypass (not recommended): git push --no-verify")
+    sys.exit(1)
+
+print("include_str! path + Docker-COPY coverage: OK "
+      f"({len(refs)} references across {len(dockerfiles)} Dockerfile(s))")
+PY

--- a/scripts/ci/check-include-str-paths.sh
+++ b/scripts/ci/check-include-str-paths.sh
@@ -41,6 +41,20 @@ def top_segment(rel: str) -> str:
     return parts[0] if parts else ""
 
 
+def is_covered(rel, roots):
+    """True if `rel` (a repo-relative path) is at or under any COPY root. A
+    root is the normalized copied path (e.g. `crates/foo` from
+    `COPY crates/foo/ crates/foo/`), so a narrowed crate copy covers that
+    crate but not its siblings."""
+    p = Path(rel)
+    while True:
+        if str(p) in roots:
+            return True
+        if p.parent == p:
+            return False
+        p = p.parent
+
+
 def cfg_test_spans(lines):
     """Return a list of (start, end) 0-based line index ranges guarded by
     `#[cfg(test)]`. `cargo build` does not compile these, so include_str!
@@ -52,10 +66,22 @@ def cfg_test_spans(lines):
     n = len(lines)
     while i < n:
         if CFG_TEST_RE.search(lines[i]):
-            # Find the opening brace of the guarded item.
+            # Find the opening brace of the guarded item. A braceless item
+            # (e.g. `#[cfg(test)] use foo;`) terminates at the first `;` — do
+            # NOT run forward to the next unrelated `{`, which would swallow
+            # real (non-test) code below and hide its include_str! calls.
             j = i
+            braceless = False
             while j < n and "{" not in lines[j]:
+                if ";" in lines[j]:
+                    braceless = True
+                    break
                 j += 1
+            if braceless:
+                # Single-line guarded item with no block; span is just it.
+                spans.append((i, j))
+                i = j + 1
+                continue
             if j >= n:
                 break
             depth = 0
@@ -85,8 +111,14 @@ for base in ("src", "crates"):
     d = repo / base
     if d.is_dir():
         rs_files.extend(sorted(d.rglob("*.rs")))
+# The repo-root build.rs is compiled by `cargo build` too (and COPYd into the
+# builder stage), so an include_str! it reads is equally a Docker-context risk.
+root_build = repo / "build.rs"
+if root_build.is_file():
+    rs_files.append(root_build)
 
 missing = []          # (referencing_file, raw_path)
+outside = []          # (referencing_file, raw_path) — resolves outside the repo
 refs = []             # (referencing_relpath, target_relpath)
 for f in rs_files:
     try:
@@ -112,8 +144,9 @@ for f in rs_files:
         try:
             target_rel = target.relative_to(repo)
         except ValueError:
-            # Resolves outside the repo — unusual, but not a Docker-context
-            # concern. Skip (existence already confirmed above).
+            # Resolves outside the repo: it exists on the host but can never be
+            # inside a Docker build context, so the image build would fail.
+            outside.append((f_rel, raw))
             continue
         refs.append((f_rel, target_rel))
 
@@ -139,7 +172,10 @@ def parse_dockerfile(text):
             if s in (".", "./"):
                 full_copy = True
                 continue
-            roots.add(top_segment(s))
+            # Store the full normalized copied path (not just its top segment)
+            # so a narrowed copy like `COPY crates/foo/` covers crates/foo but
+            # not sibling crates.
+            roots.add(str(Path(s)))
     return roots, full_copy, builds
 
 
@@ -157,16 +193,14 @@ for df in dockerfiles:
         continue
     df_rel = df.relative_to(repo)
     for ref_file, target in refs:
-        ref_top = top_segment(str(ref_file))
         # Only enforce for referencing files this Dockerfile actually copies
         # (i.e. actually compiles). A Dockerfile that never copies `src/`
         # (e.g. Dockerfile.reborn) does not compile `src/hooks/*.rs`, so a
         # repo-root `prompts/` reference from there is irrelevant to it.
-        if ref_top not in roots:
+        if not is_covered(ref_file, roots):
             continue
-        target_top = top_segment(str(target))
-        if target_top not in roots:
-            coverage_errors.append((df_rel, ref_file, target, target_top))
+        if not is_covered(target, roots):
+            coverage_errors.append((df_rel, ref_file, target, top_segment(str(target))))
 
 
 # ── Report ────────────────────────────────────────────────────────────────
@@ -177,6 +211,14 @@ if missing:
     print("✗ include_str!() targets that do not exist on disk:")
     for ref_file, raw in missing:
         print(f"    {ref_file}: include_str!(\"{raw}\") — file not found")
+    print()
+
+if outside:
+    failed = True
+    print("✗ include_str!() targets that resolve outside the build context "
+          "(exist on host, but no Docker COPY can ever include them):")
+    for ref_file, raw in outside:
+        print(f"    {ref_file}: include_str!(\"{raw}\") — resolves outside the repo")
     print()
 
 if coverage_errors:

--- a/scripts/ci/quality_gate_strict.sh
+++ b/scripts/ci/quality_gate_strict.sh
@@ -48,6 +48,16 @@ echo "==> WebUI frontend build"
 echo "==> clippy (all warnings)"
 cargo clippy --locked --all --benches --tests --examples --all-features -- -D warnings
 
+# Feature-matrix leg: the libsql-only build surfaces `cfg`/`dead_code` lints
+# that the all-features build hides (a variant constructed only under other
+# features reads as never-constructed here). This is the class that reds
+# `Clippy (libsql-only)` on main — e.g. the `Prebuilt` dead_code break (#5840).
+echo "==> clippy (libsql-only feature leg)"
+cargo clippy --locked --no-default-features --features libsql --all-targets -- -D warnings
+
+echo "==> static: include_str! paths + Docker COPY coverage"
+"$(git rev-parse --show-toplevel)/scripts/ci/check-include-str-paths.sh"
+
 echo "==> cargo deny"
 require_command cargo-deny "install with: cargo install cargo-deny"
 cargo deny check

--- a/scripts/ci/test-check-hermetic-env.sh
+++ b/scripts/ci/test-check-hermetic-env.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Regression tests for check-hermetic-env.sh.
+#
+# Each case builds a throwaway git repo, commits a base, stages a change, and
+# asserts the checker blocks/allows it. Mirrors the temp-repo harness in
+# test-pre-commit-safety.sh.
+
+set -euo pipefail
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CHECK="$ROOT_DIR/scripts/ci/check-hermetic-env.sh"
+
+PASS=0
+FAIL=0
+
+# assert <mode: blocks|allows> <label> <path> <base> <staged>
+assert() {
+    local mode="$1" label="$2" path="$3" base="$4" staged="$5"
+    local tmp out status
+    tmp=$(mktemp -d "${TMPDIR:-/tmp}/hermetic-env.XXXXXX")
+    (
+        cd "$tmp"
+        git init -q
+        git config user.email t@e.com
+        git config user.name t
+        git checkout -q -b main
+        mkdir -p "$(dirname "$path")"
+        printf '%b' "$base" > "$path"
+        git add "$path"
+        git commit -qm base
+        printf '%b' "$staged" > "$path"
+        git add "$path"
+    )
+    set +e
+    out=$(cd "$tmp" && bash "$CHECK" 2>&1)
+    status=$?
+    set -e
+    rm -rf "$tmp"
+    local ok=0
+    if [ "$mode" = "blocks" ] && [ "$status" -ne 0 ]; then ok=1; fi
+    if [ "$mode" = "allows" ] && [ "$status" -eq 0 ]; then ok=1; fi
+    if [ "$ok" -eq 1 ]; then
+        echo "OK: $label ($mode)"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $label — expected $mode, got status $status"
+        printf '%s\n' "$out" | sed 's/^/    /'
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# ── Unguarded env mutation in a new test → blocked ─────────────────────────
+assert blocks "unguarded set_var in a new test" "src/lib.rs" \
+    "fn a() {}\n" \
+    'fn a() {}\n#[test]\nfn t() {\n    unsafe { std::env::set_var("FOO", "1"); }\n    assert_eq!(1, 1);\n}\n'
+
+# ── Guarded with lock_env() in same fn → allowed ───────────────────────────
+assert allows "set_var guarded by lock_env()" "src/lib.rs" \
+    "fn a() {}\n" \
+    'fn a() {}\n#[test]\nfn t() {\n    let _g = lock_env();\n    unsafe { std::env::set_var("FOO", "1"); }\n}\n'
+
+# ── Guarded by module lock_runtime_env() → allowed ─────────────────────────
+assert allows "set_var guarded by lock_runtime_env()" "src/runtime.rs" \
+    "fn a() {}\n" \
+    'fn a() {}\n#[test]\nfn t() {\n    let _g = lock_runtime_env();\n    unsafe { std::env::remove_var("BAR"); }\n}\n'
+
+# ── EnvGuard RAII wrapper present → allowed ────────────────────────────────
+assert allows "mutation inside EnvGuard helper" "src/env.rs" \
+    "fn a() {}\n" \
+    'fn a() {}\nimpl EnvGuard {\n    fn set(k: &str) {\n        unsafe { std::env::set_var(k, "1"); }\n    }\n}\n'
+
+# ── Inline suppression → allowed ───────────────────────────────────────────
+assert allows "explicit // env-hermetic: annotation" "src/boot.rs" \
+    "fn a() {}\n" \
+    'fn a() {}\nfn boot() {\n    unsafe { std::env::set_var("DB", "libsql"); } // env-hermetic: startup, pre-thread-spawn\n}\n'
+
+# ── Thread-safe set_runtime_env is not raw mutation → allowed ──────────────
+assert allows "set_runtime_env (map API) is not flagged" "src/lib.rs" \
+    "fn a() {}\n" \
+    'fn a() {}\n#[test]\nfn t() {\n    set_runtime_env("FOO", "1");\n    remove_runtime_env("FOO");\n}\n'
+
+# ── Pre-existing unguarded mutation, unrelated edit → allowed (delta-only) ──
+assert allows "pre-existing unguarded set_var, unrelated new fn" "src/lib.rs" \
+    'fn t() {\n    unsafe { std::env::set_var("FOO", "1"); }\n}\n' \
+    'fn t() {\n    unsafe { std::env::set_var("FOO", "1"); }\n}\nfn unrelated() { let _ = 2; }\n'
+
+echo ""
+echo "Passed: $PASS, Failed: $FAIL"
+[ "$FAIL" -eq 0 ]

--- a/scripts/ci/test-check-hermetic-env.sh
+++ b/scripts/ci/test-check-hermetic-env.sh
@@ -83,6 +83,14 @@ assert allows "pre-existing unguarded set_var, unrelated new fn" "src/lib.rs" \
     'fn t() {\n    unsafe { std::env::set_var("FOO", "1"); }\n}\n' \
     'fn t() {\n    unsafe { std::env::set_var("FOO", "1"); }\n}\nfn unrelated() { let _ = 2; }\n'
 
+# ── A guard token in a COMMENT must not exempt a raw mutation → blocked ─────
+# The guard tokens (EnvGuard/lock_env/…) only serialize when they name real
+# lock/RAII construction. A bare `// EnvGuard` comment beside raw set_var is
+# not serialization and must NOT clear the hunk.
+assert blocks "comment 'EnvGuard' does not exempt raw set_var" "src/lib.rs" \
+    "fn a() {}\n" \
+    'fn a() {}\n#[test]\nfn t() {\n    // EnvGuard would go here\n    unsafe { std::env::set_var("FOO", "1"); }\n}\n'
+
 echo ""
 echo "Passed: $PASS, Failed: $FAIL"
 [ "$FAIL" -eq 0 ]

--- a/scripts/ci/test-check-include-str-paths.sh
+++ b/scripts/ci/test-check-include-str-paths.sh
@@ -110,6 +110,55 @@ mk "$T7" "prompts/session_summary.md" "hello\n"
 mk "$T7" "Dockerfile" 'FROM rust AS builder\nCOPY . .\nRUN cargo build --bin ironclaw\n'
 assert_allows "COPY . . copies the whole context" "$T7"
 
+# ── Case 8: braceless #[cfg(test)] item must not swallow following code ─────
+# A single-line `#[cfg(test)] use ...;` has no braces; the span scan must stop
+# at the `;`, not run forward to the next unrelated `{` and mark a real
+# (non-test) include_str! below it as test-only. Here the include_str! is
+# compiled by cargo build and its target is NOT COPYd, so it must be blocked.
+T8="$TMP/case8"
+mk "$T8" "src/hooks/summary.rs" '#[cfg(test)]\nuse std::fmt;\n\nfn real() {\n    let _ = include_str!("../../prompts/needed.md");\n}\n'
+mk "$T8" "prompts/needed.md" "hi\n"
+mk "$T8" "Dockerfile" 'FROM rust AS builder\nCOPY src/ src/\nRUN cargo build --bin ironclaw\n'
+assert_blocks "braceless cfg(test) does not hide a real include_str!" "$T8" "never COPYs \`prompts\`"
+
+# ── Case 9: narrowed COPY of one crate must not cover a sibling crate ───────
+# `COPY crates/foo/` copies only crates/foo; a prompt referenced from
+# crates/bar is NOT in the build context and must be flagged (top-segment
+# matching would wrongly treat all of `crates/` as covered).
+T9="$TMP/case9"
+mk "$T9" "crates/bar/src/lib.rs" 'const Q: &str = include_str!("../assets/x.md");\n'
+mk "$T9" "crates/bar/assets/x.md" "y\n"
+mk "$T9" "crates/foo/src/lib.rs" 'fn f() {}\n'
+mk "$T9" "Dockerfile" 'FROM rust AS builder\nCOPY crates/foo/ crates/foo/\nRUN cargo build --bin ironclaw\n'
+assert_allows "narrowed COPY crates/foo/ does not compile crates/bar (not blamed)" "$T9"
+
+# ── Case 10: narrowed COPY covers its own crate's nested prompt ────────────
+T10="$TMP/case10"
+mk "$T10" "crates/foo/src/lib.rs" 'const Q: &str = include_str!("../prompts/p.md");\n'
+mk "$T10" "crates/foo/prompts/p.md" "y\n"
+mk "$T10" "Dockerfile" 'FROM rust AS builder\nCOPY crates/foo/ crates/foo/\nRUN cargo build --bin ironclaw\n'
+assert_allows "narrowed COPY crates/foo/ covers crates/foo's own nested prompt" "$T10"
+
+# ── Case 11: root build.rs include_str! target must be covered ─────────────
+# `cargo build` compiles the repo-root build.rs; a prompt it reads that is not
+# COPYd fails the Docker build exactly like a src/ reference.
+T11="$TMP/case11"
+mk "$T11" "build.rs" 'fn main() { let _ = include_str!("prompts/gen.md"); }\n'
+mk "$T11" "prompts/gen.md" "hi\n"
+mk "$T11" "Dockerfile" 'FROM rust AS builder\nCOPY build.rs build.rs\nRUN cargo build --bin ironclaw\n'
+assert_blocks "root build.rs include_str! missing from COPY is flagged" "$T11" "never COPYs \`prompts\`"
+
+# ── Case 12: include_str! target resolving outside the repo is flagged ─────
+# The target exists on the host but lives outside the repo root, so no Docker
+# COPY can include it — the image build would fail. `outside_ext.md` is a
+# sibling of the repo tree; `../../../outside_ext.md` from src/hooks/ climbs
+# above the repo root to reach it.
+T12="$TMP/case12"
+mk "$T12" "src/hooks/summary.rs" 'const P: &str = include_str!("../../../outside_ext.md");\n'
+mk "$T12" "Dockerfile" 'FROM rust AS builder\nCOPY src/ src/\nRUN cargo build --bin ironclaw\n'
+printf 'x\n' > "$TMP/outside_ext.md"
+assert_blocks "include_str! target outside the repo is flagged" "$T12" "outside the build context"
+
 echo ""
 echo "Passed: $PASS, Failed: $FAIL"
 [ "$FAIL" -eq 0 ]

--- a/scripts/ci/test-check-include-str-paths.sh
+++ b/scripts/ci/test-check-include-str-paths.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Regression tests for check-include-str-paths.sh.
+#
+# Builds synthetic repo trees and asserts the checker blocks/allows the right
+# ones — including a direct reproduction of the #5603 Docker outage (a
+# repo-root prompt referenced from `src/` but never COPYd into the builder).
+
+set -euo pipefail
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CHECK="$ROOT_DIR/scripts/ci/check-include-str-paths.sh"
+
+PASS=0
+FAIL=0
+
+# Create a minimal tree: $1=dir. Populated by the caller before running.
+run_check() {
+    bash "$CHECK" "$1" 2>&1
+}
+
+assert_blocks() {
+    local label="$1" tree="$2" expect="$3"
+    local out status
+    set +e
+    out=$(run_check "$tree")
+    status=$?
+    set -e
+    if [ "$status" -ne 0 ] && printf '%s\n' "$out" | grep -Fq "$expect"; then
+        echo "OK: $label (blocked)"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $label — expected block containing '$expect', got status $status"
+        printf '%s\n' "$out" | sed 's/^/    /'
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_allows() {
+    local label="$1" tree="$2"
+    local out status
+    set +e
+    out=$(run_check "$tree")
+    status=$?
+    set -e
+    if [ "$status" -eq 0 ]; then
+        echo "OK: $label (allowed)"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $label — expected allow, got status $status"
+        printf '%s\n' "$out" | sed 's/^/    /'
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+mk() { # mk <tree> <relpath> <content>
+    mkdir -p "$1/$(dirname "$2")"
+    printf '%b' "$3" > "$1/$2"
+}
+
+TMP=$(mktemp -d "${TMPDIR:-/tmp}/check-include-str.XXXXXX")
+trap 'rm -rf "$TMP"' EXIT
+
+# ── Case 1: #5603 reproduction — repo-root prompt not COPYd ────────────────
+T1="$TMP/case1"
+mk "$T1" "src/hooks/summary.rs" 'const P: &str = include_str!("../../prompts/session_summary.md");\n'
+mk "$T1" "prompts/session_summary.md" "hello\n"
+mk "$T1" "Dockerfile" 'FROM rust AS builder\nCOPY src/ src/\nRUN cargo build --bin ironclaw\n'
+assert_blocks "missing COPY prompts/ (the #5603 outage)" "$T1" "never COPYs \`prompts\`"
+
+# ── Case 2: same tree, but Dockerfile now COPYs prompts/ ───────────────────
+T2="$TMP/case2"
+mk "$T2" "src/hooks/summary.rs" 'const P: &str = include_str!("../../prompts/session_summary.md");\n'
+mk "$T2" "prompts/session_summary.md" "hello\n"
+mk "$T2" "Dockerfile" 'FROM rust AS builder\nCOPY src/ src/\nCOPY prompts/ prompts/\nRUN cargo build --bin ironclaw\n'
+assert_allows "prompts/ COPYd — build context complete" "$T2"
+
+# ── Case 3: include_str! target does not exist at all ──────────────────────
+T3="$TMP/case3"
+mk "$T3" "src/hooks/summary.rs" 'const P: &str = include_str!("../../prompts/missing.md");\n'
+mk "$T3" "Dockerfile" 'FROM rust AS builder\nCOPY . .\nRUN cargo build --bin ironclaw\n'
+assert_blocks "nonexistent include_str! target" "$T3" "file not found"
+
+# ── Case 4: test-only include_str! (#[cfg(test)]) is NOT required in image ──
+T4="$TMP/case4"
+mk "$T4" "src/lib.rs" '#[cfg(test)]\nmod tests {\n    const F: &str = include_str!("../fixtures/data.toml");\n}\n'
+mk "$T4" "fixtures/data.toml" "x\n"
+mk "$T4" "Dockerfile" 'FROM rust AS builder\nCOPY src/ src/\nRUN cargo build --bin ironclaw\n'
+assert_allows "cfg(test) include_str! not enforced in build context" "$T4"
+
+# ── Case 5: Dockerfile that never compiles src/ is not blamed ──────────────
+# (models Dockerfile.reborn: builds only crates/, so a src/ prompt is moot)
+T5="$TMP/case5"
+mk "$T5" "src/hooks/summary.rs" 'const P: &str = include_str!("../../prompts/session_summary.md");\n'
+mk "$T5" "prompts/session_summary.md" "hello\n"
+mk "$T5" "crates/foo/src/lib.rs" 'const Q: &str = include_str!("../assets/x.md");\n'
+mk "$T5" "crates/foo/assets/x.md" "y\n"
+mk "$T5" "Dockerfile.reborn" 'FROM rust AS builder\nCOPY crates/ crates/\nRUN cargo build --bin ironclaw-reborn\n'
+assert_allows "Dockerfile that omits src/ is not blamed for a src/ prompt" "$T5"
+
+# ── Case 6: crate-local prompt under crates/ is fine (top segment covered) ──
+T6="$TMP/case6"
+mk "$T6" "crates/foo/src/lib.rs" 'const Q: &str = include_str!("../prompts/p.md");\n'
+mk "$T6" "crates/foo/prompts/p.md" "y\n"
+mk "$T6" "Dockerfile" 'FROM rust AS builder\nCOPY crates/ crates/\nRUN cargo build --bin ironclaw\n'
+assert_allows "crate-local prompt covered by COPY crates/" "$T6"
+
+# ── Case 7: full-context COPY . . is never blamed ──────────────────────────
+T7="$TMP/case7"
+mk "$T7" "src/hooks/summary.rs" 'const P: &str = include_str!("../../prompts/session_summary.md");\n'
+mk "$T7" "prompts/session_summary.md" "hello\n"
+mk "$T7" "Dockerfile" 'FROM rust AS builder\nCOPY . .\nRUN cargo build --bin ironclaw\n'
+assert_allows "COPY . . copies the whole context" "$T7"
+
+echo ""
+echo "Passed: $PASS, Failed: $FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Implements #6018. Adds three static checks mapped to the deterministic (non-flaky) main-branch CI failure classes surfaced in the CI-failure categorization, and wires them into the pre-push hook + merge-queue path.

## Checks

**1. `include_str!` path + Docker-COPY coverage** — `scripts/ci/check-include-str-paths.sh`
Every `include_str!("…")` target must exist **and** be present in the build context of each Dockerfile that compiles the referencing crate. Guards the #5603 class (host build passes; Docker build fails because a repo-root `prompts/` dir was never `COPY`d). Whole-repo, no compile.
- Excludes `#[cfg(test)]` includes (not compiled by `cargo build`) and `COPY . .` images.
- Attributes per-Dockerfile, so `Dockerfile.reborn` is never blamed for a `src/` prompt it doesn't compile.
- **Surfaced a real latent bug:** `Dockerfile.test` builds `--bin ironclaw` but omitted `COPY prompts/` / `profiles/` / `providers.json` (all required by unconditional prod `const`s). Fixed in this PR.

**2. Hermetic env guard** — `scripts/ci/check-hermetic-env.sh`
Delta + function-scoped (`git diff -W`): flags only **newly-added** raw `std::env::set_var/remove_var` whose enclosing function lacks a lock guard (`lock_env`/`lock_runtime_env`/`ENV_MUTEX`/`EnvGuard`). Targets the #6015 coverage-flake class and Rust 1.82 `set_var` UB. Quiet on the ~700 existing sites; `// env-hermetic: <reason>` suppresses genuine single-threaded cases.

**3. libsql-only clippy leg**
Added to the pre-push strict branch and `quality_gate_strict.sh`. Catches the `cfg`/`dead_code` class (#5840 `Prebuilt`) that default-feature clippy misses.

## Wiring
- `.githooks/pre-push`: checks 1 & 2 on every push (no compile); check 3 under `IRONCLAW_STRICT_LINT`.
- `code_style.yml`: new required `static-checks` job runs check 1 + both self-test suites, added to the roll-up gate.

## Tests
14 self-test cases (`test-check-include-str-paths.sh` 7, `test-check-hermetic-env.sh` 7), including a direct #5603 reproduction. Both green; checks pass on the current tree; workflow YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)