### PR TITLE
fix(reborn_cli): unify crate process-env test lock — kill build_runtime_input flake (#6015)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4830,6 +4830,7 @@ dependencies = [
  "clap_complete",
  "dotenvy",
  "hex",
+ "ironclaw_common",
  "ironclaw_reborn_composition",
  "ironclaw_reborn_config",
  "ironclaw_reborn_traces",

--- a/crates/ironclaw_reborn_cli/Cargo.toml
+++ b/crates/ironclaw_reborn_cli/Cargo.toml
@@ -104,6 +104,12 @@ uuid = { version = "1", features = ["v4", "v5", "serde"] }
 # runtime-owned `RebornRuntime::open_reborn_identity_resolver` accessor
 # instead. Feature-unifies with the `[dependencies]` entry above.
 ironclaw_reborn_composition = { path = "../ironclaw_reborn_composition", version = "0.1.0", features = ["test-support"] }
+# Canonical workspace-wide process-env test lock. Env-mutating unit tests in
+# this crate serialize on `ironclaw_common::env_helpers::lock_env()` — the same
+# mutex the composition/llm/auth crates and `src/` use — so no crate defines a
+# second, non-serializing lock domain (the #6015 flake). Dev-only: the lock is
+# reached solely from `#[cfg(test)]` code in `runtime::test_env`.
+ironclaw_common = { path = "../ironclaw_common", version = "0.4.2" }
 
 [[bin]]
 name = "ironclaw-reborn"

--- a/crates/ironclaw_reborn_cli/src/commands/serve.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/serve.rs
@@ -1072,7 +1072,7 @@ mod tests {
     const WEBUI_BASE_URL_ENV: &str = "IRONCLAW_REBORN_WEBUI_BASE_URL";
 
     fn clear_webui_env() {
-        // SAFETY: tests are serialized by `WEBUI_BASE_URL_ENV_LOCK`; no other
+        // SAFETY: tests are serialized by `the shared crate process-env lock`; no other
         // thread reads or writes this env var while the guard is held.
         unsafe { std::env::remove_var(WEBUI_BASE_URL_ENV) };
     }
@@ -1682,11 +1682,9 @@ slack_user_id = "U123"
     #[tokio::test]
     async fn webui_serve_wires_notion_dcr_with_public_base_url_env_origin() {
         let callback_origin = {
-            let _guard = crate::commands::serve_sso::WEBUI_BASE_URL_ENV_LOCK
-                .lock()
-                .expect("env lock");
+            let _guard = crate::runtime::test_env::lock_runtime_env();
             clear_webui_env();
-            // SAFETY: serialized by WEBUI_BASE_URL_ENV_LOCK; cleaned up before the guard drops.
+            // SAFETY: serialized by the shared crate process-env lock; cleaned up before the guard drops.
             unsafe {
                 std::env::set_var(WEBUI_BASE_URL_ENV, " https://configured.example/ ");
             }
@@ -1722,11 +1720,9 @@ slack_user_id = "U123"
 
     #[test]
     fn webui_notion_dcr_callback_origin_rejects_slash_only_public_base_url_env() {
-        let _guard = crate::commands::serve_sso::WEBUI_BASE_URL_ENV_LOCK
-            .lock()
-            .expect("env lock");
+        let _guard = crate::runtime::test_env::lock_runtime_env();
         clear_webui_env();
-        // SAFETY: serialized by WEBUI_BASE_URL_ENV_LOCK; cleaned up before the guard drops.
+        // SAFETY: serialized by the shared crate process-env lock; cleaned up before the guard drops.
         unsafe {
             std::env::set_var(WEBUI_BASE_URL_ENV, "/");
         }
@@ -1743,11 +1739,9 @@ slack_user_id = "U123"
 
     #[test]
     fn webui_notion_dcr_callback_origin_rejects_public_cleartext_base_url_env() {
-        let _guard = crate::commands::serve_sso::WEBUI_BASE_URL_ENV_LOCK
-            .lock()
-            .expect("env lock");
+        let _guard = crate::runtime::test_env::lock_runtime_env();
         clear_webui_env();
-        // SAFETY: serialized by WEBUI_BASE_URL_ENV_LOCK; cleaned up before the guard drops.
+        // SAFETY: serialized by the shared crate process-env lock; cleaned up before the guard drops.
         unsafe {
             std::env::set_var(WEBUI_BASE_URL_ENV, "http://configured.example");
         }

--- a/crates/ironclaw_reborn_cli/src/commands/serve_sso.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/serve_sso.rs
@@ -28,9 +28,6 @@ use secrecy::SecretString;
 
 const WEBUI_BASE_URL_ENV: &str = "IRONCLAW_REBORN_WEBUI_BASE_URL";
 
-#[cfg(test)]
-pub(crate) static WEBUI_BASE_URL_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
 /// Resolved SSO startup config: the providers to mount plus the public
 /// base URL their callback URLs are built from. Constructed by
 /// [`sso_startup_config_from_env`]; consumed by `serve.rs`, which adds
@@ -446,7 +443,7 @@ mod tests {
 
     fn clear_sso_env() {
         for var in SSO_ENV_VARS {
-            // SAFETY: tests are serialized by `WEBUI_BASE_URL_ENV_LOCK`; no other thread
+            // SAFETY: tests are serialized by `the shared crate process-env lock`; no other thread
             // reads or writes these vars while the guard is held.
             unsafe { std::env::remove_var(var) };
         }
@@ -460,9 +457,9 @@ mod tests {
     /// same caller succeeds once the allowlist is supplied.
     #[test]
     fn startup_fails_closed_when_providers_set_but_allowlist_missing() {
-        let _guard = WEBUI_BASE_URL_ENV_LOCK.lock().expect("env lock");
+        let _guard = crate::runtime::test_env::lock_runtime_env();
         clear_sso_env();
-        // SAFETY: serialized by WEBUI_BASE_URL_ENV_LOCK; cleaned up before the guard drops.
+        // SAFETY: serialized by the shared crate process-env lock; cleaned up before the guard drops.
         unsafe {
             std::env::set_var("IRONCLAW_REBORN_WEBUI_GOOGLE_CLIENT_ID", "client-id");
             std::env::set_var(
@@ -479,7 +476,7 @@ mod tests {
         );
 
         // Blank allowlist → same fail-closed result.
-        // SAFETY: serialized by WEBUI_BASE_URL_ENV_LOCK.
+        // SAFETY: serialized by the shared crate process-env lock.
         unsafe {
             std::env::set_var("IRONCLAW_REBORN_WEBUI_ALLOWED_EMAIL_DOMAINS", "  , ,");
         }
@@ -489,7 +486,7 @@ mod tests {
         );
 
         // Supplying the allowlist makes the same caller succeed.
-        // SAFETY: serialized by WEBUI_BASE_URL_ENV_LOCK.
+        // SAFETY: serialized by the shared crate process-env lock.
         unsafe {
             std::env::set_var("IRONCLAW_REBORN_WEBUI_ALLOWED_EMAIL_DOMAINS", "example.com");
         }
@@ -510,14 +507,14 @@ mod tests {
     /// caller `sso_startup_config_from_env`, since the helper is private.
     #[test]
     fn client_id_without_secret_fails_startup() {
-        let _guard = WEBUI_BASE_URL_ENV_LOCK.lock().expect("env lock");
+        let _guard = crate::runtime::test_env::lock_runtime_env();
 
         for id_var in [
             "IRONCLAW_REBORN_WEBUI_GOOGLE_CLIENT_ID",
             "IRONCLAW_REBORN_WEBUI_GITHUB_CLIENT_ID",
         ] {
             clear_sso_env();
-            // SAFETY: serialized by WEBUI_BASE_URL_ENV_LOCK; cleared before/after.
+            // SAFETY: serialized by the shared crate process-env lock; cleared before/after.
             unsafe { std::env::set_var(id_var, "client-id") };
             assert!(
                 sso_startup_config_from_env(addr("127.0.0.1:3000")).is_err(),
@@ -533,7 +530,7 @@ mod tests {
     /// since the allowlist gate only fires once a provider is configured.)
     #[test]
     fn no_provider_configured_returns_none() {
-        let _guard = WEBUI_BASE_URL_ENV_LOCK.lock().expect("env lock");
+        let _guard = crate::runtime::test_env::lock_runtime_env();
         clear_sso_env();
         let resolved = sso_startup_config_from_env(addr("127.0.0.1:3000"))
             .expect("no provider configured is not an error");
@@ -542,9 +539,9 @@ mod tests {
 
     #[test]
     fn webui_oauth_base_url_prefers_explicit_reborn_env() {
-        let _guard = WEBUI_BASE_URL_ENV_LOCK.lock().expect("env lock");
+        let _guard = crate::runtime::test_env::lock_runtime_env();
         clear_sso_env();
-        // SAFETY: serialized by WEBUI_BASE_URL_ENV_LOCK; cleaned up before the guard drops.
+        // SAFETY: serialized by the shared crate process-env lock; cleaned up before the guard drops.
         unsafe {
             std::env::set_var(WEBUI_BASE_URL_ENV, " https://configured.example/ ");
         }
@@ -559,9 +556,9 @@ mod tests {
 
     #[test]
     fn webui_public_base_url_from_env_rejects_blank_normalized_values() {
-        let _guard = WEBUI_BASE_URL_ENV_LOCK.lock().expect("env lock");
+        let _guard = crate::runtime::test_env::lock_runtime_env();
         clear_sso_env();
-        // SAFETY: serialized by WEBUI_BASE_URL_ENV_LOCK; cleaned up before the guard drops.
+        // SAFETY: serialized by the shared crate process-env lock; cleaned up before the guard drops.
         unsafe {
             std::env::set_var(WEBUI_BASE_URL_ENV, "/");
         }
@@ -572,7 +569,7 @@ mod tests {
             "error should name env var, got: {error}"
         );
 
-        // SAFETY: serialized by WEBUI_BASE_URL_ENV_LOCK; cleaned up before the guard drops.
+        // SAFETY: serialized by the shared crate process-env lock; cleaned up before the guard drops.
         unsafe {
             std::env::set_var(WEBUI_BASE_URL_ENV, " / ");
         }
@@ -586,9 +583,9 @@ mod tests {
 
     #[test]
     fn sso_startup_config_uses_explicit_webui_base_url() {
-        let _guard = WEBUI_BASE_URL_ENV_LOCK.lock().expect("env lock");
+        let _guard = crate::runtime::test_env::lock_runtime_env();
         clear_sso_env();
-        // SAFETY: serialized by WEBUI_BASE_URL_ENV_LOCK; cleaned up before the guard drops.
+        // SAFETY: serialized by the shared crate process-env lock; cleaned up before the guard drops.
         unsafe {
             std::env::set_var("IRONCLAW_REBORN_WEBUI_GOOGLE_CLIENT_ID", "client-id");
             std::env::set_var(
@@ -613,7 +610,7 @@ mod tests {
 
     #[test]
     fn webui_oauth_base_url_falls_back_to_listener() {
-        let _guard = WEBUI_BASE_URL_ENV_LOCK.lock().expect("env lock");
+        let _guard = crate::runtime::test_env::lock_runtime_env();
         clear_sso_env();
 
         assert_eq!(
@@ -633,9 +630,9 @@ mod tests {
     /// sent at exchange matches what Google stored.
     #[test]
     fn non_empty_env_trims_surrounding_whitespace() {
-        let _guard = WEBUI_BASE_URL_ENV_LOCK.lock().expect("env lock");
+        let _guard = crate::runtime::test_env::lock_runtime_env();
         clear_sso_env();
-        // SAFETY: serialized by WEBUI_BASE_URL_ENV_LOCK; cleared before/after.
+        // SAFETY: serialized by the shared crate process-env lock; cleared before/after.
         unsafe {
             std::env::set_var(
                 "IRONCLAW_REBORN_WEBUI_GOOGLE_CLIENT_SECRET",
@@ -649,7 +646,7 @@ mod tests {
         );
 
         // Whitespace-only stays None — it is not a configured value.
-        // SAFETY: serialized by WEBUI_BASE_URL_ENV_LOCK.
+        // SAFETY: serialized by the shared crate process-env lock.
         unsafe {
             std::env::set_var("IRONCLAW_REBORN_WEBUI_GOOGLE_CLIENT_SECRET", "   \n\t");
         }
@@ -669,9 +666,9 @@ mod tests {
     /// rejected or forwarded.
     #[test]
     fn whitespace_padded_oauth_credentials_still_configure_provider() {
-        let _guard = WEBUI_BASE_URL_ENV_LOCK.lock().expect("env lock");
+        let _guard = crate::runtime::test_env::lock_runtime_env();
         clear_sso_env();
-        // SAFETY: serialized by WEBUI_BASE_URL_ENV_LOCK; cleared before/after.
+        // SAFETY: serialized by the shared crate process-env lock; cleared before/after.
         unsafe {
             std::env::set_var("IRONCLAW_REBORN_WEBUI_GOOGLE_CLIENT_ID", "  client-id\n");
             std::env::set_var(

--- a/crates/ironclaw_reborn_cli/src/runtime/mod.rs
+++ b/crates/ironclaw_reborn_cli/src/runtime/mod.rs
@@ -36,8 +36,13 @@ use tokio_util::sync::CancellationToken;
 
 use crate::context::RebornCliContext;
 
+// Crate-wide process-env lock lives here (see test_env.rs). `pub(crate)` so
+// non-runtime env-mutating tests (e.g. commands::serve_sso) serialize against
+// the same mutex — all unit tests link into one binary, so a second, separate
+// env lock would not serialize and races the shared process environment
+// (#6015).
 #[cfg(test)]
-mod test_env;
+pub(crate) mod test_env;
 mod trigger_poller;
 
 use trigger_poller::trigger_poller_settings;

--- a/crates/ironclaw_reborn_cli/src/runtime/test_env.rs
+++ b/crates/ironclaw_reborn_cli/src/runtime/test_env.rs
@@ -13,22 +13,25 @@
 //! the `runtime::tests::build_runtime_input_production_*` env assertions
 //! (#6015). Hence `pub(crate)` and the scope-neutral name.
 //!
+//! To make "exactly one lock" hold beyond this crate too, [`lock_runtime_env`]
+//! does not own a crate-local mutex — it delegates to the canonical
+//! workspace-wide [`ironclaw_common::env_helpers::lock_env`], the same
+//! `ENV_MUTEX` that `ironclaw_reborn_composition` (which these tests build
+//! services against), `ironclaw_llm`, `ironclaw_auth`, and the `src/` crate
+//! already serialize on. So a future env-mutating test anywhere in this binary
+//! that reaches for the canonical lock still serializes against these — it
+//! cannot form the second, non-serializing lock domain that flaked #6015.
+//!
 //! Not exposed outside `#[cfg(test)]`.
 
-use std::sync::{LazyLock, Mutex, MutexGuard};
-
-/// Serializes every test that touches process env vars so they cannot race
-/// each other. cargo test runs tests in parallel by default; without this
-/// each env-mutating test would observe sibling tests' mutations. Held for
-/// the whole body of every env-touching test.
-static RUNTIME_ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+use std::sync::MutexGuard;
 
 /// Acquire the single crate-wide process-env lock. `pub(crate)` so
 /// env-mutating tests outside `runtime` (e.g. `commands::serve_sso`) share it.
+/// Delegates to [`ironclaw_common::env_helpers::lock_env`] so the whole
+/// workspace serializes on one mutex rather than a per-crate copy.
 pub(crate) fn lock_runtime_env() -> MutexGuard<'static, ()> {
-    RUNTIME_ENV_LOCK
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
+    ironclaw_common::env_helpers::lock_env()
 }
 
 /// RAII guard that snapshots an env var on construction and restores it
@@ -75,19 +78,22 @@ mod tests {
 
     /// Regression for #6015. The crate must expose exactly ONE process-env
     /// lock: `commands::serve_sso` previously defined its own
-    /// `WEBUI_BASE_URL_ENV_LOCK`, which did not serialize against
-    /// `RUNTIME_ENV_LOCK`, so the two lock domains raced `std::env` mutation
-    /// (UB on Rust 1.82+) and flaked the `build_runtime_input_production_*`
-    /// assertions. This pins that the shared accessor hands out a genuinely
-    /// exclusive mutex — a second acquisition while one is held is contended —
-    /// so re-introducing a parallel lock (which would break serialization)
-    /// stands out against this single canonical one.
+    /// `WEBUI_BASE_URL_ENV_LOCK`, which did not serialize against the runtime
+    /// lock, so the two lock domains raced `std::env` mutation (UB on Rust
+    /// 1.82+) and flaked the `build_runtime_input_production_*` assertions.
+    /// This pins two things: (1) `lock_runtime_env` hands out a genuinely
+    /// exclusive mutex, and (2) that mutex *is* the canonical workspace lock
+    /// `ironclaw_common::env_helpers::ENV_MUTEX` — so while the accessor's
+    /// guard is held, the canonical mutex is contended. Re-introducing a
+    /// parallel crate-local lock (which would break serialization against the
+    /// rest of the workspace) stands out against this single canonical one.
     #[test]
-    fn process_env_lock_is_a_single_exclusive_mutex() {
+    fn process_env_lock_is_the_single_canonical_mutex() {
         let _held = lock_runtime_env();
         assert!(
-            RUNTIME_ENV_LOCK.try_lock().is_err(),
-            "the crate-wide process-env lock must be one shared, exclusive mutex"
+            ironclaw_common::env_helpers::ENV_MUTEX.try_lock().is_err(),
+            "lock_runtime_env must hand out the canonical workspace env mutex, \
+             not a second crate-local one"
         );
     }
 }

--- a/crates/ironclaw_reborn_cli/src/runtime/test_env.rs
+++ b/crates/ironclaw_reborn_cli/src/runtime/test_env.rs
@@ -1,10 +1,17 @@
-//! Shared test-only env-var harness for `runtime::tests` and
-//! `runtime::trigger_poller::tests`. These modules read or mutate process
-//! env vars (`IRONCLAW_TRIGGER_POLLER_*`, `IRONCLAW_REBORN_RUNNER_*`, OAuth
-//! knobs, credential-refresh knobs); without a single lock + single `EnvGuard`
-//! they would race in the same test binary. The lock is process-wide across
-//! all runtime env-var tests (trigger, runner, OAuth, credential refresh),
-//! hence the scope-neutral name.
+//! Crate-wide test-only env-var harness. Any test in `ironclaw_reborn_cli`
+//! that reads or mutates process env vars (`IRONCLAW_TRIGGER_POLLER_*`,
+//! `IRONCLAW_REBORN_RUNNER_*`, `IRONCLAW_REBORN_WEBUI_*`, OAuth knobs,
+//! credential-refresh knobs) must hold this single lock and mutate through
+//! `EnvGuard`.
+//!
+//! All of a crate's unit tests link into ONE test binary and run in parallel,
+//! so the lock must be process-wide across *every* env-mutating module, not
+//! just `runtime`. A second, separate mutex (e.g. the former
+//! `commands::serve_sso::WEBUI_BASE_URL_ENV_LOCK`) does not serialize against
+//! this one: concurrent `std::env::set_var` from the two lock domains races
+//! the shared C environment — UB on Rust 1.82+ — and intermittently corrupts
+//! the `runtime::tests::build_runtime_input_production_*` env assertions
+//! (#6015). Hence `pub(crate)` and the scope-neutral name.
 //!
 //! Not exposed outside `#[cfg(test)]`.
 
@@ -16,7 +23,9 @@ use std::sync::{LazyLock, Mutex, MutexGuard};
 /// the whole body of every env-touching test.
 static RUNTIME_ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
-pub(super) fn lock_runtime_env() -> MutexGuard<'static, ()> {
+/// Acquire the single crate-wide process-env lock. `pub(crate)` so
+/// env-mutating tests outside `runtime` (e.g. `commands::serve_sso`) share it.
+pub(crate) fn lock_runtime_env() -> MutexGuard<'static, ()> {
     RUNTIME_ENV_LOCK
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner())
@@ -57,5 +66,28 @@ impl Drop for EnvGuard {
             // SAFETY: see EnvGuard::set.
             None => unsafe { std::env::remove_var(self.key) },
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression for #6015. The crate must expose exactly ONE process-env
+    /// lock: `commands::serve_sso` previously defined its own
+    /// `WEBUI_BASE_URL_ENV_LOCK`, which did not serialize against
+    /// `RUNTIME_ENV_LOCK`, so the two lock domains raced `std::env` mutation
+    /// (UB on Rust 1.82+) and flaked the `build_runtime_input_production_*`
+    /// assertions. This pins that the shared accessor hands out a genuinely
+    /// exclusive mutex — a second acquisition while one is held is contended —
+    /// so re-introducing a parallel lock (which would break serialization)
+    /// stands out against this single canonical one.
+    #[test]
+    fn process_env_lock_is_a_single_exclusive_mutex() {
+        let _held = lock_runtime_env();
+        assert!(
+            RUNTIME_ENV_LOCK.try_lock().is_err(),
+            "the crate-wide process-env lock must be one shared, exclusive mutex"
+        );
     }
 }


### PR DESCRIPTION
Fixes #6015. Part of #6014.

## Root cause (a real test-isolation defect)
The `build_runtime_input_production_*` block (14 tests) flaked intermittently in the all-features coverage leg. The tests themselves are correct — they all serialize on `runtime::test_env::RUNTIME_ENV_LOCK`. But `commands::serve_sso` defined a **second, independent** mutex `WEBUI_BASE_URL_ENV_LOCK` (also used by `commands::serve` tests).

All of a crate's unit tests link into **one** test binary and run in parallel, so the two lock domains never serialized against each other. Concurrent `std::env::set_var` across them races the shared C environment — UB on Rust 1.82+ — which intermittently corrupted the runtime tests' env-derived assertions (`assertion failed: rendered.contains("IRONCLAW_REBORN_ALLOW_REMOTE_POSTGRES_CLEAR_TEXT")` and siblings).

## Fix
Unify on a single crate-wide process-env lock:
- Promote `runtime::test_env` to `pub(crate)` and broaden its doc to "crate-wide", not "runtime".
- Route the `serve` / `serve_sso` env-mutating tests through `test_env::lock_runtime_env()`.
- Delete the duplicate `WEBUI_BASE_URL_ENV_LOCK`.

No production code changes — this is entirely test-harness serialization.

## Regression test
`process_env_lock_is_a_single_exclusive_mutex` pins that the shared accessor hands out one genuinely exclusive mutex, so a re-introduced parallel lock stands out against the single canonical one. (A deterministic red-before test isn't possible for a UB data race; this anchors the structural invariant instead.)

> Note: PR #6022 (issue #6018) adds a pre-push `check-hermetic-env.sh` that guards the *related* class — newly-added unguarded `std::env::set_var`.

## Verification
`cargo test -p ironclaw_reborn_cli --all-features`: the 14 `build_runtime_input_production_*` + 43 `serve`/`serve_sso` tests + the new lock test all pass. `cargo clippy --all-features` clean; `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)