### PR TITLE
test(e2e): wait for composer readiness between replies

### DIFF
--- a/tests/e2e/scenarios/test_reborn_webui_v2_legacy_core.py
+++ b/tests/e2e/scenarios/test_reborn_webui_v2_legacy_core.py
@@ -255,6 +255,11 @@ async def test_reborn_legacy_core_multiple_messages(reborn_v2_page):
     await expect(reborn_v2_page.locator(SEL_V2["msg_assistant"])).to_have_count(
         1, timeout=30000
     )
+    await expect(composer).to_have_attribute(
+        "data-send-disabled",
+        "false",
+        timeout=30000,
+    )
 
     await composer.fill("What is 2+2?")
     await composer.press("Enter")


### PR DESCRIPTION
## Summary

- wait for the Reborn composer to become send-ready before submitting the second message
- synchronize the legacy multi-message scenario with the terminal run state instead of the first streamed assistant projection

## Root cause

After assistant streaming landed, the first assistant bubble appears while the active run is still processing. The composer accepts draft text during that window but intentionally ignores Enter because data-send-disabled remains true. The test treated bubble creation as completion, so its second Enter was dropped and the user-message count timed out.

This addresses the unresolved failure in Actions run 29224074235. The separate Responses API failure in run 29225682315 is already covered by #5902 and passed in the immediate follow-up coverage run.

## Verification

- exact failing scenario: 1 passed
- legacy-core-ui workflow shard: 19 passed
- git diff --check