### PR TITLE
docs(reborn): reschedule W5 boundary exceptions

### DIFF
--- a/crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs
+++ b/crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs
@@ -3141,8 +3141,8 @@ const LAYER_MATRIX_EXCEPTIONS: &[LayerMatrixException] = &[
         crate_name: "ironclaw_host_runtime",
         dependency_name: "ironclaw_skills",
         introduced: "2026-07-09",
-        removes_in: "W5",
-        reason: "host_runtime still wires skill host behavior that should move behind the loop-host boundary",
+        removes_in: "W7",
+        reason: "host_runtime still owns first-party skill management tools and skill URL install limits; remove when kernel consolidation or a dedicated skill-host extraction moves that execution surface out of host_runtime",
     },
     LayerMatrixException {
         crate_name: "ironclaw_capabilities",
@@ -3232,8 +3232,8 @@ const LAYER_MATRIX_EXCEPTIONS: &[LayerMatrixException] = &[
         crate_name: "ironclaw_mcp",
         dependency_name: "ironclaw_extensions",
         introduced: "2026-07-09",
-        removes_in: "W5",
-        reason: "MCP runtime support still exposes extension-host wiring that should move behind the loop-host boundary",
+        removes_in: "W7",
+        reason: "MCP runtime still consumes ExtensionPackage and ExtensionRuntime manifest DTOs; remove when extension runtime descriptors move to a neutral contract or runtime lanes are folded behind the extension-host boundary",
     },
     LayerMatrixException {
         crate_name: "ironclaw_mcp",
@@ -3246,8 +3246,8 @@ const LAYER_MATRIX_EXCEPTIONS: &[LayerMatrixException] = &[
         crate_name: "ironclaw_scripts",
         dependency_name: "ironclaw_extensions",
         introduced: "2026-07-09",
-        removes_in: "W5",
-        reason: "script runtime support still exposes extension-host wiring that should move behind the loop-host boundary",
+        removes_in: "W7",
+        reason: "script runtime still consumes ExtensionPackage and ExtensionRuntime manifest DTOs; remove when extension runtime descriptors move to a neutral contract or runtime lanes are folded behind the extension-host boundary",
     },
     LayerMatrixException {
         crate_name: "ironclaw_scripts",


### PR DESCRIPTION
## Summary

W5 merged in #5925, but three layer-matrix exceptions were still marked `removes_in: "W5"`:

- `ironclaw_host_runtime -> ironclaw_skills`
- `ironclaw_mcp -> ironclaw_extensions`
- `ironclaw_scripts -> ironclaw_extensions`

This PR updates those exception records to point at W7-style boundary consolidation instead of the already-merged W5.

## Why

These are real dependency edges, not stale exception entries:

- `ironclaw_host_runtime -> ironclaw_skills` backs the first-party skill list/install/remove tools and the skill URL install limits.
- `ironclaw_mcp -> ironclaw_extensions` consumes `ExtensionPackage`, `ExtensionRuntime`, and hosted MCP manifest DTOs.
- `ironclaw_scripts -> ironclaw_extensions` consumes `ExtensionPackage` and `ExtensionRuntime` to execute manifest-declared script capabilities.

Removing those edges would require either a neutral extension-runtime descriptor contract, a dedicated skill-host extraction, or later kernel/extension-host consolidation. That is larger than W5.1 and should not be represented as already completed by W5.

## What changed

- Rescheduled the three stale `removes_in: "W5"` entries to `W7`.
- Reworded each reason to describe the actual dependency surface that remains.
- Did not relax the layer matrix or remove any boundary coverage.

## Validation

- `cargo fmt -p ironclaw_architecture`
- `cargo test -p ironclaw_architecture reborn_workspace_crates_declare_layers_and_follow_layer_matrix`
- `cargo test -p ironclaw_architecture`
