### PR TITLE
fix(webui): remove deleted threads from sidebar immediately

### DIFF
--- a/crates/ironclaw_webui_v2/frontend/src/pages/chat/hooks/useThreads.test.ts
+++ b/crates/ironclaw_webui_v2/frontend/src/pages/chat/hooks/useThreads.test.ts
@@ -81,7 +81,11 @@ function instantiate(createThreadRequest, overrides = {}) {
       const trimmed = String(title || "").trim();
       return trimmed && trimmed !== threadId ? trimmed : null;
     },
-    queryClient: { invalidateQueries: () => {} },
+    removeThreadList: (data, threadId) => ({
+      ...data,
+      threads: data.threads.filter((thread) => (thread.thread_id || thread.id) !== threadId),
+    }),
+    queryClient: { setQueryData: () => {}, invalidateQueries: () => {} },
     upsertThreadInCache: () => {},
     globalThis: {},
     ...overrides,
@@ -144,10 +148,18 @@ test("handleCreateThread upserts the created thread without refetching the list"
   assert.deepEqual(upserted, [{ thread_id: "thread-created", title: "Created" }]);
 });
 
-test("handleDeleteThread deletes the requested thread and refreshes the list", async () => {
+test("handleDeleteThread removes the requested thread from cache before refreshing", async () => {
   const deleted = [];
   const invalidations = [];
+  const cacheWrites = [];
   const stateChanges = [];
+  let cachedData = {
+    threads: [
+      { thread_id: "thread-old" },
+      { thread_id: "thread-keep" },
+    ],
+    next_cursor: "cursor-1",
+  };
   const hook = instantiate(
     async () => ({ thread: { thread_id: "unused" } }),
     {
@@ -159,6 +171,10 @@ test("handleDeleteThread deletes the requested thread and refreshes the list", a
         deleted.push(threadId);
       },
       queryClient: {
+        setQueryData: (queryKey, update) => {
+          cacheWrites.push([...queryKey]);
+          cachedData = update(cachedData);
+        },
         invalidateQueries: (request) => invalidations.push([...request.queryKey]),
       },
     },
@@ -168,6 +184,11 @@ test("handleDeleteThread deletes the requested thread and refreshes the list", a
 
   assert.deepEqual(deleted, ["thread-old"]);
   assert.deepEqual(stateChanges, [{ index: 0, value: null }]);
+  assert.deepEqual(cacheWrites, [["threads"]]);
+  assert.deepEqual(cachedData, {
+    threads: [{ thread_id: "thread-keep" }],
+    next_cursor: "cursor-1",
+  });
   assert.deepEqual(invalidations, [["threads"]]);
 });
 
@@ -185,6 +206,7 @@ test("handleDeleteThread preserves active thread state when deletion fails", asy
         throw new Error("delete failed");
       },
       queryClient: {
+        setQueryData: (queryKey) => invalidations.push(["cache-write", ...queryKey]),
         invalidateQueries: (request) => invalidations.push([...request.queryKey]),
       },
     },

--- a/crates/ironclaw_webui_v2/frontend/src/pages/chat/hooks/useThreads.ts
+++ b/crates/ironclaw_webui_v2/frontend/src/pages/chat/hooks/useThreads.ts
@@ -7,7 +7,7 @@ import {
 } from "../../../lib/api";
 import { queryClient } from "../../../lib/query-client";
 import { normalizeSidebarTitle } from "../../../lib/thread-title";
-import { upsertThreadInCache } from "../lib/thread-cache";
+import { removeThreadList, upsertThreadInCache } from "../lib/thread-cache";
 
 export function useThreads() {
   // No polling: the sidebar is kept current by local cache writes after
@@ -59,6 +59,7 @@ export function useThreads() {
       if (activeThreadId === threadId) {
         setActiveThreadId(null);
       }
+      queryClient.setQueryData(["threads"], (data) => removeThreadList(data, threadId));
       queryClient.invalidateQueries({ queryKey: ["threads"] });
     },
     [activeThreadId]

--- a/crates/ironclaw_webui_v2/frontend/src/pages/chat/lib/thread-cache.test.ts
+++ b/crates/ironclaw_webui_v2/frontend/src/pages/chat/lib/thread-cache.test.ts
@@ -23,6 +23,7 @@ globalThis.__testExports = {
   deriveSidebarTitle,
   displaySidebarTitle,
   normalizeSidebarTitle,
+  removeThreadList,
   touchThreadList,
   upsertThreadList,
 };`;
@@ -134,6 +135,30 @@ test("upsertThreadList preserves cached title when incoming record has raw threa
       next_cursor: null,
     },
   );
+});
+
+test("removeThreadList removes only the matching cached thread", () => {
+  const { removeThreadList } = loadThreadCache();
+  const data = {
+    threads: [
+      { thread_id: "thread-keep", title: "Keep" },
+      { thread_id: "thread-drop", title: "Drop" },
+    ],
+    next_cursor: "cursor-1",
+  };
+
+  assert.deepEqual(normalize(removeThreadList(data, "thread-drop")), {
+    threads: [{ thread_id: "thread-keep", title: "Keep" }],
+    next_cursor: "cursor-1",
+  });
+});
+
+test("removeThreadList preserves cache identity when the thread is absent", () => {
+  const { removeThreadList } = loadThreadCache();
+  const data = { threads: [{ thread_id: "thread-keep" }], next_cursor: null };
+
+  assert.equal(removeThreadList(data, "thread-missing"), data);
+  assert.equal(removeThreadList(undefined, "thread-missing"), undefined);
 });
 
 test("touchThreadList updates activity without overwriting an existing title", () => {

--- a/crates/ironclaw_webui_v2/frontend/src/pages/chat/lib/thread-cache.ts
+++ b/crates/ironclaw_webui_v2/frontend/src/pages/chat/lib/thread-cache.ts
@@ -64,6 +64,15 @@ export function upsertThreadList(data, thread) {
   };
 }
 
+export function removeThreadList(data, threadId) {
+  if (!data || !threadId || !Array.isArray(data.threads)) return data;
+
+  const threads = data.threads.filter((thread) => threadIdFor(thread) !== threadId);
+  if (threads.length === data.threads.length) return data;
+
+  return { ...data, threads };
+}
+
 export function touchThreadList(data, { threadId, messageContent, updatedAt }) {
   if (!threadId) return data;
 

--- a/tests/e2e/helpers.py
+++ b/tests/e2e/helpers.py
@@ -235,6 +235,9 @@ SEL_V2 = {
     "sidebar":        "#gateway-sidebar",  # app navigation sidebar
     "sidebar_button": "#gateway-sidebar button",
     "sidebar_toggle": "button[aria-label='Toggle sidebar']",
+    "thread_delete_for": (
+        "[data-testid='thread-delete'][data-thread-id='{id}']"
+    ),
     "sign_out_button": "button[title='Sign out']",
     "chat_composer":  "[data-testid='chat-composer']",  # message textarea on /chat
     "attachment_file_input": "input[type=file][multiple]",

--- a/tests/e2e/scenarios/test_reborn_webui_v2_smoke.py
+++ b/tests/e2e/scenarios/test_reborn_webui_v2_smoke.py
@@ -934,7 +934,7 @@ async def test_reborn_v2_thread_list_and_delete(reborn_v2_server):
 
 
 async def test_reborn_v2_ui_delete_removes_sidebar_thread_without_refetch(
-    reborn_v2_server, reborn_v2_browser
+    reborn_v2_server, reborn_v2_page
 ):
     """A successful delete updates the rendered sidebar before list revalidation returns."""
     headers = {"Authorization": f"Bearer {REBORN_V2_AUTH_TOKEN}"}
@@ -942,13 +942,16 @@ async def test_reborn_v2_ui_delete_removes_sidebar_thread_without_refetch(
         keep_id = await _create_thread(client, reborn_v2_server)
         drop_id = await _create_thread(client, reborn_v2_server)
 
-    context = await reborn_v2_browser.new_context(viewport={"width": 1280, "height": 720})
-    page = await context.new_page()
+    page = reborn_v2_page
+    # The shared page is opened before this test creates its API fixtures, so
+    # reload once during setup to populate the sidebar. No reload occurs after
+    # deletion; the assertion below runs while list revalidation is blocked.
+    await page.reload()
     release_refetch = asyncio.Event()
     refetch_started = asyncio.Event()
     refetch_finished = asyncio.Event()
 
-    async def delay_thread_list_refetch(route, _request):
+    async def delay_thread_list_refetch(route, _request) -> None:
         refetch_started.set()
         try:
             await release_refetch.wait()
@@ -956,7 +959,7 @@ async def test_reborn_v2_ui_delete_removes_sidebar_thread_without_refetch(
         finally:
             refetch_finished.set()
 
-    async def accept_delete_dialog(dialog):
+    async def accept_delete_dialog(dialog) -> None:
         await dialog.accept()
 
     try:
@@ -983,7 +986,6 @@ async def test_reborn_v2_ui_delete_removes_sidebar_thread_without_refetch(
         if refetch_started.is_set():
             await asyncio.wait_for(refetch_finished.wait(), timeout=5)
         await page.unroute("**/api/webchat/v2/threads", delay_thread_list_refetch)
-        await context.close()
 
 
 async def test_reborn_v2_timeline_pagination(reborn_v2_server):

--- a/tests/e2e/scenarios/test_reborn_webui_v2_smoke.py
+++ b/tests/e2e/scenarios/test_reborn_webui_v2_smoke.py
@@ -933,6 +933,59 @@ async def test_reborn_v2_thread_list_and_delete(reborn_v2_server):
         assert keep_id in remaining, "untouched thread must remain in the list"
 
 
+async def test_reborn_v2_ui_delete_removes_sidebar_thread_without_refetch(
+    reborn_v2_server, reborn_v2_browser
+):
+    """A successful delete updates the rendered sidebar before list revalidation returns."""
+    headers = {"Authorization": f"Bearer {REBORN_V2_AUTH_TOKEN}"}
+    async with httpx.AsyncClient(headers=headers) as client:
+        keep_id = await _create_thread(client, reborn_v2_server)
+        drop_id = await _create_thread(client, reborn_v2_server)
+
+    context = await reborn_v2_browser.new_context(viewport={"width": 1280, "height": 720})
+    page = await context.new_page()
+    release_refetch = asyncio.Event()
+    refetch_started = asyncio.Event()
+    refetch_finished = asyncio.Event()
+
+    async def delay_thread_list_refetch(route, _request):
+        refetch_started.set()
+        try:
+            await release_refetch.wait()
+            await route.continue_()
+        finally:
+            refetch_finished.set()
+
+    async def accept_delete_dialog(dialog):
+        await dialog.accept()
+
+    try:
+        await page.goto(f"{reborn_v2_server}/v2/?token={REBORN_V2_AUTH_TOKEN}")
+        await expect(page.locator(SEL_V2["chat_composer"])).to_be_visible(timeout=15000)
+
+        keep_button = page.locator(SEL_V2["thread_delete_for"].format(id=keep_id))
+        drop_button = page.locator(SEL_V2["thread_delete_for"].format(id=drop_id))
+        await expect(keep_button).to_have_count(1, timeout=15000)
+        await expect(drop_button).to_have_count(1, timeout=15000)
+
+        # Hold the delete-triggered list revalidation open. The deleted row must
+        # disappear from the local React Query cache before this request returns.
+        thread_list_pattern = "**/api/webchat/v2/threads"
+        await page.route(thread_list_pattern, delay_thread_list_refetch)
+        page.once("dialog", accept_delete_dialog)
+        await drop_button.click()
+        await asyncio.wait_for(refetch_started.wait(), timeout=5)
+
+        await expect(drop_button).to_have_count(0, timeout=2000)
+        await expect(keep_button).to_have_count(1)
+    finally:
+        release_refetch.set()
+        if refetch_started.is_set():
+            await asyncio.wait_for(refetch_finished.wait(), timeout=5)
+        await page.unroute("**/api/webchat/v2/threads", delay_thread_list_refetch)
+        await context.close()
+
+
 async def test_reborn_v2_timeline_pagination(reborn_v2_server):
     """Timeline honors `limit` and pages older messages via the opaque `next_cursor`."""
     headers = {"Authorization": f"Bearer {REBORN_V2_AUTH_TOKEN}"}


### PR DESCRIPTION
## Summary

- Removes a successfully deleted thread from the React Query sidebar cache immediately instead of waiting for a list refetch.
- Preserves the remaining thread list and pagination metadata, and clears active-thread state only after the backend delete succeeds.
- Adds helper-level and caller-level regression coverage for cache removal and failure behavior.
- Adds a browser E2E regression that holds list revalidation open and verifies the deleted sidebar row disappears without a page refresh.

<img width="608" height="854" alt="iShot_2026-07-13_19 37 06" src="https://github.com/user-attachments/assets/1da72585-e83a-4f8a-9528-83d6461403cc" />


## Linked Issue

Closes #5947

## Validation

- [x] `TZ=America/Los_Angeles pnpm test`
- [x] `pnpm build`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `cargo test -p ironclaw_webui_v2 --features webui-v2-beta`
- [x] `cargo test -p ironclaw_architecture`
- [x] Playwright regression: `test_reborn_v2_ui_delete_removes_sidebar_thread_without_refetch`
- [x] `git diff --check`

## Security Impact

No. This changes client-side thread-list cache synchronization only.

## Database Impact

No schema, migration, or persistence changes.

## Blast Radius

Limited to successful thread deletion in the Reborn WebChat v2 sidebar and its frontend tests.

## Rollback Plan

Revert this PR to return to refetch-only sidebar synchronization after deletion.

---

**Review track**: A