### PR TITLE
fix(webui-v2): keep earlier message in place on timeline refresh; dismissable error bubbles

### DIFF
--- a/crates/ironclaw_webui_v2/frontend/src/pages/chat/chat.tsx
+++ b/crates/ironclaw_webui_v2/frontend/src/pages/chat/chat.tsx
@@ -22,6 +22,7 @@ import { TypingIndicator } from "./components/typing-indicator";
 import { useChat } from "./hooks/useChat";
 import { channelConnectionDisplayName } from "../../lib/channel-connection-events";
 import { NEW_DRAFT_KEY } from "./lib/draft-store";
+import { filterVisibleMessages } from "./lib/message-types";
 import { buildRuntimeContext } from "./lib/runtime-context";
 import { buildScopedLogsPath } from "../logs/lib/logs-data";
 import { useInterfacePreferences } from "../../lib/interface-preferences";
@@ -93,7 +94,16 @@ export function Chat({
     submitChannelConnectionPairing,
     startOnboardingOAuth,
     dismissOnboardingPairing,
+    dismissMessage,
   } = useChat(activeThreadId);
+
+  // Hide error bubbles the user has dismissed; state keeps them (flagged) so a
+  // projection replay can't resurrect them (issue #16). Shared predicate so the
+  // regression test guards this exact filter.
+  const visibleMessages = React.useMemo(
+    () => filterVisibleMessages(messages),
+    [messages],
+  );
 
   const activeThread = React.useMemo(
     () => threads.find((thread) => thread.id === activeThreadId) || null,
@@ -143,7 +153,9 @@ export function Chat({
     !activeThreadHasGate &&
     !streamingAssistantTextVisible;
   const hasMessages =
-    messages.length > 0 ||
+    // Use the filtered projection: a thread whose only row is a dismissed
+    // error bubble should fall back to the empty state, not a blank transcript.
+    visibleMessages.length > 0 ||
     activeThreadIsProcessing ||
     activeThreadHasGate ||
     activeThreadHasOnboarding;
@@ -329,11 +341,12 @@ export function Chat({
         (
           <>
           <MessageList
-            messages={messages}
+            messages={visibleMessages}
             isLoading={historyLoading}
             hasMore={hasMore}
             onLoadMore={loadMore}
             onRetryMessage={retryMessage}
+            onDismissMessage={dismissMessage}
             threadId={activeThreadId}
             logsPath={logsPath}
             pending={activeThreadIsProcessing}

--- a/crates/ironclaw_webui_v2/frontend/src/pages/chat/components/message-bubble.test.ts
+++ b/crates/ironclaw_webui_v2/frontend/src/pages/chat/components/message-bubble.test.ts
@@ -237,6 +237,61 @@ test("error bubbles expose structural provider failure metadata", async () => {
   assert.match(html, /data-failure-status="failed"/);
 });
 
+test("error bubbles render a persistent dismiss control inside the bubble when onDismiss is given", async () => {
+  const { MessageBubble } = await import("./message-bubble");
+  // The Icon component is mocked to `<span data-icon="close">`, a stable
+  // marker for the close (×) icon that doesn't depend on i18n resolution.
+  const CLOSE_ICON_MARKER = /data-icon="close"/;
+
+  const withDismiss = renderToStaticMarkup(
+    React.createElement(MessageBubble, {
+      message: {
+        id: "err-1",
+        role: CHAT_MESSAGE_ROLES.ERROR,
+        content: "Provider unavailable",
+        timestamp: "2026-06-02T00:00:00.000Z",
+      },
+      onDismiss: () => {},
+      threadId: "thread-1",
+    }),
+  );
+  assert.match(
+    withDismiss,
+    CLOSE_ICON_MARKER,
+    "an error bubble with onDismiss should render a dismiss control in the bubble body",
+  );
+  // Not gated behind the hover-only meta row (opacity-0) — it lives in the
+  // bubble content so it is discoverable without hovering.
+  const metaRowStart = withDismiss.indexOf('"mt-1 flex min-h-7');
+  assert.notEqual(
+    metaRowStart,
+    -1,
+    "meta row must be present so the negative check below is meaningful",
+  );
+  assert.doesNotMatch(
+    withDismiss.slice(metaRowStart),
+    CLOSE_ICON_MARKER,
+    "the dismiss control should not live in the hover-only meta row",
+  );
+
+  const withoutDismiss = renderToStaticMarkup(
+    React.createElement(MessageBubble, {
+      message: {
+        id: "err-2",
+        role: CHAT_MESSAGE_ROLES.ERROR,
+        content: "Provider unavailable",
+        timestamp: "2026-06-02T00:00:00.000Z",
+      },
+      threadId: "thread-1",
+    }),
+  );
+  assert.doesNotMatch(
+    withoutDismiss,
+    CLOSE_ICON_MARKER,
+    "no dismiss control without an onDismiss handler",
+  );
+});
+
 test("message timestamp and actions share a hover-only meta row", () => {
   assert.match(
     messageBubbleSource,

--- a/crates/ironclaw_webui_v2/frontend/src/pages/chat/components/message-bubble.tsx
+++ b/crates/ironclaw_webui_v2/frontend/src/pages/chat/components/message-bubble.tsx
@@ -30,6 +30,7 @@ const ROLE_STYLES = {
 type MessageBubbleProps = {
   message: ChatMessage;
   onRetry?: (message: ChatMessage) => void;
+  onDismiss?: (messageId: string) => void;
   threadId?: string | null;
 };
 
@@ -72,7 +73,7 @@ function ThinkingDisclosure({ content }: { content?: string }) {
   );
 }
 
-function MessageBubbleImpl({ message, onRetry, threadId }: MessageBubbleProps) {
+function MessageBubbleImpl({ message, onRetry, onDismiss, threadId }: MessageBubbleProps) {
   const t = useT();
   const { role, content, images, attachments, generatedImages, isOptimistic, status, error, toolCalls, timestamp } = message;
   const isUser = role === CHAT_MESSAGE_ROLES.USER;
@@ -165,6 +166,12 @@ function MessageBubbleImpl({ message, onRetry, threadId }: MessageBubbleProps) {
   const contentWidthClass =
     isUser || isError ? "min-w-0 max-w-full" : "w-full min-w-0 max-w-full";
   const showRetryAction = status === "error" && onRetry;
+  // Client-only error bubbles (run failures, connection lost) are never in the
+  // durable timeline and get re-appended at the bottom on every refresh, so a
+  // stale error lingers indefinitely. Render a persistent dismiss (x) in the
+  // bubble's top-right corner (issue #16) — not the hover-only meta row, which
+  // was too hard to find.
+  const showDismissAction = isError && Boolean(onDismiss);
   const showMetaRow = showActions || showRetryAction || timeLabel;
   const contentOpacityClass = isOptimistic ? "opacity-70" : "";
   const roleStyle =
@@ -187,9 +194,25 @@ function MessageBubbleImpl({ message, onRetry, threadId }: MessageBubbleProps) {
             roleStyle,
           ].join(" ")}
         >
-          {role === CHAT_MESSAGE_ROLES.ASSISTANT ||
-          role === CHAT_MESSAGE_ROLES.SYSTEM ||
-          role === CHAT_MESSAGE_ROLES.ERROR
+          {role === CHAT_MESSAGE_ROLES.ERROR
+            ? (
+              <div className="flex items-start gap-2">
+                <div className={["min-w-0 flex-1", contentOpacityClass].join(" ")}><MarkdownRenderer content={content} /></div>
+                {showDismissAction && (
+                  <button
+                    type="button"
+                    onClick={() => onDismiss?.(message.id)}
+                    title={t("common.dismiss")}
+                    aria-label={t("common.dismiss")}
+                    className="v2-button -mr-1 -mt-0.5 inline-grid h-6 w-6 shrink-0 place-items-center rounded-md border-0 bg-transparent p-0 text-red-300/70 hover:bg-red-500/20 hover:text-red-100"
+                  >
+                    <Icon name="close" className="h-3.5 w-3.5" />
+                  </button>
+                )}
+              </div>
+            )
+            : role === CHAT_MESSAGE_ROLES.ASSISTANT ||
+              role === CHAT_MESSAGE_ROLES.SYSTEM
             ? (<div className={contentOpacityClass}><MarkdownRenderer content={content} /></div>)
             : (<div className="v2-wrap-anywhere whitespace-pre-wrap break-words"><span className={contentOpacityClass}>{content}</span></div>)}
 

--- a/crates/ironclaw_webui_v2/frontend/src/pages/chat/components/message-list.tsx
+++ b/crates/ironclaw_webui_v2/frontend/src/pages/chat/components/message-list.tsx
@@ -65,6 +65,7 @@ export function MessageList({
   hasMore,
   onLoadMore,
   onRetryMessage,
+  onDismissMessage,
   threadId,
   logsPath,
   pending = false,
@@ -275,6 +276,7 @@ export function MessageList({
                 key={item.id}
                 message={item.message}
                 onRetry={onRetryMessage}
+                onDismiss={onDismissMessage}
                 threadId={threadId}
               />)
         )}

--- a/crates/ironclaw_webui_v2/frontend/src/pages/chat/hooks/useChat.ts
+++ b/crates/ironclaw_webui_v2/frontend/src/pages/chat/hooks/useChat.ts
@@ -1074,6 +1074,23 @@ export function useChat(threadId) {
     [send, seedThreadMessages, setMessages, threadId],
   );
 
+  // Mark a client-only error bubble dismissed rather than removing it: the id
+  // stays in state so a projection replay (SSE reconnect) hits the dedup
+  // update branch and preserves `dismissed` instead of re-adding the bubble.
+  // Dismissed messages are filtered out of the rendered list.
+  const dismissMessage = React.useCallback(
+    (messageId) => {
+      setMessages((prev) =>
+        prev.map((message) =>
+          message && message.id === messageId
+            ? { ...message, dismissed: true }
+            : message,
+        ),
+      );
+    },
+    [setMessages],
+  );
+
   return {
     // v2-native
     messages,
@@ -1096,6 +1113,7 @@ export function useChat(threadId) {
     dismissOnboardingPairing,
     cancelRun,
     loadMore,
+    dismissMessage,
     // fork-shape compatibility — see comments above
     suggestions: [],
     setSuggestions: noop,

--- a/crates/ironclaw_webui_v2/frontend/src/pages/chat/hooks/useHistory.ts
+++ b/crates/ironclaw_webui_v2/frontend/src/pages/chat/hooks/useHistory.ts
@@ -358,11 +358,19 @@ function insertPreservedAtOriginalPositions(fresh, preserved, current) {
   const currentAnchors = current.map((message) =>
     freshIndexForCurrentMessage(message, freshIndexById),
   );
+  const before = new Map();
   const after = new Map();
   const append = [];
 
   for (const message of preserved) {
-    if (!isRunActivityMessage(message)) {
+    // Anchor run-activity rows AND a surviving optimistic user/assistant
+    // bubble to their original position relative to the fresh timeline.
+    // Previously only run-activity messages were anchored, so a still-
+    // unreconciled optimistic user message fell into `append` and rendered
+    // below later persisted rows — making an earlier message appear last
+    // (issue #16). Client-only error bubbles (err-*) still append at the end
+    // by design.
+    if (!isRunActivityMessage(message) && !isSeededOptimisticMessage(message)) {
       append.push(message);
       continue;
     }
@@ -378,16 +386,38 @@ function insertPreservedAtOriginalPositions(fresh, preserved, current) {
       const group = after.get(previousAnchor) || [];
       group.push(message);
       after.set(previousAnchor, group);
-    } else {
-      append.push(message);
+      continue;
     }
+    // No preceding anchored row. For a surviving optimistic user/assistant
+    // bubble, place it *before* the next anchored row so an earlier message
+    // stays chronological instead of dropping to the bottom. Run-activity rows
+    // keep the legacy append: a prepended in-progress gate activity is meant to
+    // render after the numbered timeline tools, not before them.
+    if (isSeededOptimisticMessage(message)) {
+      let nextAnchor = null;
+      for (let index = originalIndex + 1; index < currentAnchors.length; index += 1) {
+        if (currentAnchors[index] !== null) {
+          nextAnchor = currentAnchors[index];
+          break;
+        }
+      }
+      if (nextAnchor !== null) {
+        const group = before.get(nextAnchor) || [];
+        group.push(message);
+        before.set(nextAnchor, group);
+        continue;
+      }
+    }
+    append.push(message);
   }
 
   const merged = [];
   for (const [index, message] of fresh.entries()) {
+    const beforeGroup = before.get(index);
+    if (beforeGroup) merged.push(...beforeGroup);
     merged.push(message);
-    const group = after.get(index);
-    if (group) merged.push(...group);
+    const afterGroup = after.get(index);
+    if (afterGroup) merged.push(...afterGroup);
   }
   merged.push(...append);
   return merged;

--- a/crates/ironclaw_webui_v2/frontend/src/pages/chat/lib/chat.test.ts
+++ b/crates/ironclaw_webui_v2/frontend/src/pages/chat/lib/chat.test.ts
@@ -5,6 +5,7 @@ import { test } from "vitest";
 import vm from "node:vm";
 
 import { channelConnectionDisplayName } from "../../../lib/channel-connection-events";
+import { filterVisibleMessages } from "./message-types";
 
 function chatSourceForTest() {
   const source = readFileSync(new URL("../chat.tsx", import.meta.url), "utf8");
@@ -121,6 +122,7 @@ function renderChat({
     globalThis: {},
     html: (strings, ...values) => ({ strings: Array.from(strings), values }),
     channelConnectionDisplayName,
+    filterVisibleMessages,
     setThreadState: (threadId, state) =>
       threadStateUpdates.push({ threadId, state }),
     setTimeout: () => 1,

--- a/crates/ironclaw_webui_v2/frontend/src/pages/chat/lib/message-types.ts
+++ b/crates/ironclaw_webui_v2/frontend/src/pages/chat/lib/message-types.ts
@@ -39,6 +39,10 @@ export type ChatMessage = {
   status?: string;
   error?: string;
   toolCalls?: unknown[];
+  // User-dismissed client-only bubble (today only error bubbles). Kept in state
+  // for replay dedup; `filterVisibleMessages` drops it from the rendered list.
+  // See `ErrorChatMessage.dismissed`.
+  dismissed?: boolean;
   [key: string]: unknown;
 };
 
@@ -50,6 +54,11 @@ export type ErrorChatMessage = {
   failureStatus?: string | null;
   failureCategory?: string | null;
   failureSummary?: string | null;
+  // User-dismissed: filter this bubble out of the rendered list, but keep it in
+  // state so a projection replay (SSE reconnect) hits the dedup update branch
+  // and preserves the flag instead of resurrecting the bubble. Set by the chat
+  // page's `dismissMessage` action; client-only state, never set by the server.
+  dismissed?: boolean;
   [key: string]: unknown;
 };
 
@@ -60,6 +69,7 @@ export type ErrorChatMessageInput = {
   failureStatus?: string | null;
   failureCategory?: string | null;
   failureSummary?: string | null;
+  dismissed?: boolean;
   [key: string]: unknown;
 };
 
@@ -132,4 +142,11 @@ export function isRunFailureMessageId(value: unknown): boolean {
     !id.startsWith(REQUEST_FAILURE_ID_PREFIX) &&
     !id.startsWith(STREAM_FAILURE_ID_PREFIX)
   );
+}
+
+// Rendered chat messages minus the ones the user has dismissed. Shared by the
+// chat page's render filter and its regression test so the two cannot drift —
+// see `ErrorChatMessage.dismissed`.
+export function filterVisibleMessages(messages: ChatMessage[]): ChatMessage[] {
+  return (messages || []).filter((message) => message && !message.dismissed);
 }

--- a/crates/ironclaw_webui_v2/frontend/src/pages/chat/lib/useChat-send.test.ts
+++ b/crates/ironclaw_webui_v2/frontend/src/pages/chat/lib/useChat-send.test.ts
@@ -30,6 +30,7 @@ import {
   CHAT_MESSAGE_ROLES,
   createErrorChatMessage,
   createRequestFailureChatMessage,
+  filterVisibleMessages,
   isRequestFailureForMessage,
   requestFailureIdForMessage,
 } from "./message-types";
@@ -6153,4 +6154,108 @@ test("useChat.send: blocks a send addressed to a busy thread that is NOT the vie
   assert.equal(result, null, "send into the busy destination thread is rejected");
   assert.equal(sentBody(), null, "sendMessage must not be called for the busy destination");
   assert.equal(createThreadCalls(), 0);
+});
+
+test("useChat.dismissMessage: flags the bubble dismissed and drops it from the rendered list (issue #16)", () => {
+  // The user-facing half of the dismiss feature: chat.tsx computes
+  // `visibleMessages = messages.filter((m) => !m?.dismissed)` and renders
+  // that list. The replay-survival test in useChatEvents pins the
+  // projection dedup branch; this test pins the call site — the dismiss
+  // action exported by useChat, the state mutation it triggers, and the
+  // filter the chat page applies to the rendered list. Without this, a
+  // regression in the filter (or in the action's argument wiring) would
+  // go uncaught and a stale error bubble would re-appear in the chat
+  // thread even though the dedup branch kept `dismissed: true`.
+  const threadId = "thread-1";
+  const renderedMessages = [
+    {
+      id: "msg-user-1",
+      role: "user",
+      content: "earlier question",
+      timestamp: "2026-07-11T13:45:00Z",
+    },
+    {
+      id: "err-run-1",
+      role: "error",
+      content: "The run stopped after reaching its iteration limit.",
+      timestamp: "2026-07-11T13:46:00Z",
+      failureStatus: "failed",
+      failureCategory: "iteration_limit",
+    },
+  ];
+  const context = {
+    AbortController,
+    Date,
+    Error,
+    Map,
+    Math,
+    React: createReactStub(),
+    addPending,
+    toRenderAttachment,
+    toWireAttachment,
+    cancelRunRequest: async () => {},
+    clearTimeout,
+    createThreadRequest: async () => {
+      throw new Error("dismiss should not create a thread");
+    },
+    globalThis: {},
+    queryClient: {
+      fetchQuery: async () => {
+        throw new Error("dismiss should not fetch channels");
+      },
+      invalidateQueries: () => {},
+    },
+    recordAcceptedMessageRef,
+    removePending,
+    resolveGateRequest: async () => {},
+    sendMessage: async () => {
+      throw new Error("dismiss should not send a message");
+    },
+    setInterval,
+    setTimeout,
+    submitManualToken: async () => {},
+    useChatEvents: () => () => {},
+    useHistory: () => ({
+      messages: renderedMessages,
+      hasMore: false,
+      nextCursor: null,
+      isLoading: false,
+      loadError: null,
+      loadHistory: () => {},
+      seedThreadMessages: () => {},
+      setMessages: (updater) => {
+        const next =
+          typeof updater === "function" ? updater(renderedMessages) : updater;
+        renderedMessages.length = 0;
+        renderedMessages.push(...next);
+      },
+    }),
+    useSSE: () => ({ status: CONNECTION_STATUS.IDLE }),
+  };
+
+  runUseChatSource(context);
+
+  const chat = context.globalThis.__testExports.useChat(threadId);
+  chat.dismissMessage("err-run-1");
+
+  // The dismiss action marks the row, not removes it — the projection dedup
+  // branch in appendRunFailureMessage keys on the surviving id and
+  // preserves `dismissed: true` across replays.
+  const errorBubble = renderedMessages.find((message) => message.id === "err-run-1");
+  assert.ok(errorBubble, "dismissed bubble is still in state, not removed");
+  assert.equal(errorBubble.dismissed, true);
+  // The non-dismissed row is untouched.
+  const userBubble = renderedMessages.find((message) => message.id === "msg-user-1");
+  assert.ok(userBubble);
+  assert.equal(userBubble.dismissed, undefined);
+  // Drive the SAME predicate the chat page renders through
+  // (`filterVisibleMessages`, shared from message-types), so a regression in
+  // that filter — not just a copy of it — is caught here.
+  const visibleMessages = filterVisibleMessages(renderedMessages);
+  assert.deepEqual(
+    visibleMessages.map((message) => message.id),
+    ["msg-user-1"],
+  );
+  // And the export from the hook is the same shape the chat page consumes.
+  assert.equal(typeof chat.dismissMessage, "function");
 });

--- a/crates/ironclaw_webui_v2/frontend/src/pages/chat/lib/useChatEvents.test.ts
+++ b/crates/ironclaw_webui_v2/frontend/src/pages/chat/lib/useChatEvents.test.ts
@@ -1265,6 +1265,55 @@ test("useChatEvents: interrupted driver_unavailable projection shows connection 
   assert.deepEqual(contextRunIds, [runId]);
 });
 
+test("useChatEvents: a dismissed run-failure bubble is not resurrected by a replay (issue #16)", () => {
+  const runId = "run-dismissed";
+  const harness = createUseChatEventsHarness({
+    failureMessageForRunStatus: () =>
+      "The run stopped after reaching its iteration limit.",
+  });
+
+  harness.setCurrentActiveRun({ runId, threadId: "thread-1", status: "running" });
+
+  const failureEvent = {
+    type: "projection_update",
+    frame: {
+      state: {
+        items: [
+          {
+            run_status: {
+              run_id: runId,
+              status: "failed",
+              failure_category: "iteration_limit",
+              failure_summary: "iteration limit reached",
+            },
+          },
+        ],
+      },
+    },
+  };
+
+  harness.handleEvent(failureEvent);
+  assert.equal(harness.messages.length, 1);
+  assert.equal(harness.messages[0].id, `err-${runId}`);
+
+  // User dismisses the bubble: chat marks it `dismissed` but keeps it in state.
+  harness.replaceMessages(
+    harness.messages.map((message) => ({ ...message, dismissed: true })),
+  );
+
+  // SSE reconnect replays the same terminal failure projection. The dedup
+  // update branch must keep the dismissed bubble, not re-add or un-dismiss it.
+  harness.handleEvent(failureEvent);
+
+  assert.equal(harness.messages.length, 1, "no duplicate bubble on replay");
+  assert.equal(harness.messages[0].id, `err-${runId}`);
+  assert.equal(
+    harness.messages[0].dismissed,
+    true,
+    "replay must not resurrect the dismissed error bubble",
+  );
+});
+
 test("useChatEvents: repeated failed projection updates existing error content", () => {
   const harness = createUseChatEventsHarness({
     failureMessageForRunStatus: (input) =>

--- a/crates/ironclaw_webui_v2/frontend/src/pages/chat/lib/useHistory.test.ts
+++ b/crates/ironclaw_webui_v2/frontend/src/pages/chat/lib/useHistory.test.ts
@@ -567,6 +567,89 @@ test("mergeFullRefresh anchors preserved runtime bubbles at their original posit
   );
 });
 
+test("mergeFullRefresh keeps a surviving optimistic user bubble in place, not last (issue #16)", () => {
+  // After a run settles the client refetches the timeline and merges with
+  // `preserveClientOnly`. When an optimistic user message did NOT reconcile
+  // against the fresh timeline (its persisted twin is absent), it must stay in
+  // its original position between the persisted rows — not get appended below
+  // later persisted rows, which made an earlier (1:49 PM) message render after
+  // later (1:53 PM) ones.
+  const context = { globalThis: {}, React: createReactStub() };
+  vm.runInNewContext(useHistorySourceForTest(), context);
+  const { mergeFullRefresh } = context.globalThis.__testExports;
+
+  const merged = mergeFullRefresh(
+    [
+      { id: "msg-a", role: "assistant", timestamp: "2026-07-11T13:45:00Z" },
+      { id: "msg-b", role: "assistant", timestamp: "2026-07-11T13:53:00Z" },
+    ],
+    [
+      { id: "msg-a", role: "assistant", timestamp: "2026-07-11T13:45:00Z" },
+      {
+        id: "pending-u1",
+        role: "user",
+        content: "my 1:49 message",
+        isOptimistic: true,
+        timestamp: "2026-07-11T13:49:00Z",
+      },
+    ],
+    { preserveClientOnly: true },
+  );
+
+  assert.equal(merged.map((m) => m.id).join(","), "msg-a,pending-u1,msg-b");
+});
+
+test("mergeFullRefresh inserts an unanchored earlier optimistic bubble before the next persisted row", () => {
+  // An optimistic bubble with no *preceding* anchored row but a following one
+  // must render before that follower (chronological), not drop to the bottom.
+  const context = { globalThis: {}, React: createReactStub() };
+  vm.runInNewContext(useHistorySourceForTest(), context);
+  const { mergeFullRefresh } = context.globalThis.__testExports;
+
+  const merged = mergeFullRefresh(
+    [
+      { id: "msg-a", role: "assistant", timestamp: "2026-07-11T13:45:00Z" },
+      { id: "msg-b", role: "assistant", timestamp: "2026-07-11T13:53:00Z" },
+    ],
+    [
+      {
+        id: "pending-early",
+        role: "user",
+        content: "earlier optimistic message",
+        isOptimistic: true,
+        timestamp: "2026-07-11T13:40:00Z",
+      },
+      { id: "msg-a", role: "assistant", timestamp: "2026-07-11T13:45:00Z" },
+    ],
+    { preserveClientOnly: true },
+  );
+
+  assert.equal(merged.map((m) => m.id).join(","), "pending-early,msg-a,msg-b");
+});
+
+test("mergeFullRefresh appends a trailing optimistic bubble with no anchor on either side", () => {
+  // No preceding AND no following anchored row → genuinely trailing → append.
+  const context = { globalThis: {}, React: createReactStub() };
+  vm.runInNewContext(useHistorySourceForTest(), context);
+  const { mergeFullRefresh } = context.globalThis.__testExports;
+
+  const merged = mergeFullRefresh(
+    [{ id: "msg-b", role: "assistant", timestamp: "2026-07-11T13:53:00Z" }],
+    [
+      {
+        id: "pending-trailing",
+        role: "user",
+        content: "trailing optimistic message",
+        isOptimistic: true,
+        timestamp: "2026-07-11T13:59:00Z",
+      },
+    ],
+    { preserveClientOnly: true },
+  );
+
+  assert.equal(merged.map((m) => m.id).join(","), "msg-b,pending-trailing");
+});
+
 test("mergeFullRefresh carries optimistic timestamps onto confirmed messages", () => {
   const context = { globalThis: {}, React: createReactStub() };
   vm.runInNewContext(useHistorySourceForTest(), context);


### PR DESCRIPTION
## Summary

Two WebUI v2 chat-rendering fixes, both under `crates/ironclaw_webui_v2/frontend/src/pages/chat`:

- **Timeline ordering.** After a run settles, the client refetches the timeline and merges it against client state. `insertPreservedAtOriginalPositions` only anchored run-activity rows (tool/thinking) to their original position; every other preserved message — a still-unreconciled optimistic **user** bubble — fell into the `append` bucket and rendered below later persisted rows, so an earlier message appeared **last**. Now anchors optimistic user/assistant bubbles too; client-only `err-*` error bubbles still append at the end by design.
- **Dismissable error bubbles.** `err-*` run-failure/connection bubbles are client-only and get re-appended at the thread bottom on every refresh, so a stale error (e.g. the iteration-limit cap) lingers indefinitely. Added a persistent dismiss (×) in the error bubble's top-right corner. The message is **marked** dismissed (not removed) and filtered from the rendered list, so a projection replay (SSE reconnect) hits the dedup update branch and preserves the flag instead of resurrecting the bubble. The render filter is a shared `filterVisibleMessages` predicate used by both the chat page and its regression test.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

None. Found during a hosted-single-tenant + PostgreSQL self-host shakedown of the standalone `ironclaw-reborn` binary.

## Validation

- [x] Frontend unit tests green: `pnpm exec vitest run src/pages/chat/{components/message-bubble.test.ts,lib/useChat-send.test.ts,lib/useHistory.test.ts,lib/useChatEvents.test.ts}` — merge ordering, replay-safe dismiss, and the in-bubble dismiss control placement
- [x] `pnpm build` (vite) green
- Note: this diff is TypeScript-only (WebUI v2 frontend); no Rust surface touched.

## Security Impact

None. Client-side rendering/merge logic only; no auth, network, secrets, or persistence change. Dismiss is a client display flag; error content is unchanged.

## Reborn Trust-Boundary Checklist

N/A — frontend-only change to WebUI v2 chat rendering. No policy/evidence/trust types, no serde/wire contracts, no runtime/DB surface.

## Database Impact

None.

## Blast Radius

`crates/ironclaw_webui_v2/frontend/src/pages/chat` only: `useHistory` merge, `useChat`, `chat.tsx`, `message-list`/`message-bubble`, `message-types`. Worst case is a mis-ordered or non-dismissable chat bubble — no backend behavior touched. Backend timeline ordering (sorted by durable `sequence`) is already correct and unchanged.

## Rollback Plan

Revert the commit. Pure client rendering change; no schema, data, or wire impact.

## Review Follow-Through

Each change carries a regression test. The dismiss mechanism marks-not-removes to stay replay-safe (pinned by `useChatEvents.test` and `useChat-send.test`); the corner placement is pinned by `message-bubble.test`. Reasoning-content persistence (the "thinking" text disappearing on reload) is a separate, larger change and is intentionally out of scope here.

---

**Review track**: A (frontend/tests; low risk, no runtime/DB/security surface)
