### PR TITLE
build(reborn): ship extension ownership migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5025,7 +5025,6 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
- "tokio-postgres",
  "tracing",
  "tracing-subscriber",
  "ulid",

--- a/Dockerfile.reborn
+++ b/Dockerfile.reborn
@@ -60,6 +60,12 @@ RUN cargo chef cook \
     --package ironclaw_reborn_cli \
     --features webui-v2-beta,slack-v2-host-beta,libsql,postgres,inmemory-turn-state \
     --recipe-path recipe.json
+RUN cargo chef cook \
+    --profile dist \
+    --package ironclaw_reborn_migration \
+    --no-default-features \
+    --features libsql \
+    --recipe-path recipe.json
 
 FROM deps AS builder
 

--- a/Dockerfile.reborn
+++ b/Dockerfile.reborn
@@ -85,6 +85,13 @@ RUN cargo build \
     --features webui-v2-beta,slack-v2-host-beta,libsql,postgres,inmemory-turn-state \
     --bin ironclaw-reborn
 
+RUN cargo build \
+    --profile dist \
+    --package ironclaw_reborn_migration \
+    --no-default-features \
+    --features libsql \
+    --bin ironclaw-reborn-extension-ownership-migration
+
 FROM debian:bookworm-slim AS runtime
 
 RUN apt-get -o Acquire::Retries=3 update \
@@ -95,6 +102,7 @@ RUN apt-get -o Acquire::Retries=3 update \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /app/target/dist/ironclaw-reborn /usr/local/bin/ironclaw-reborn
+COPY --from=builder /app/target/dist/ironclaw-reborn-extension-ownership-migration /usr/local/bin/ironclaw-reborn-extension-ownership-migration
 COPY docker/reborn/config.toml /opt/ironclaw/reborn/config.toml
 COPY docker/reborn/config.hosted-single-tenant.toml /opt/ironclaw/reborn/config.hosted-single-tenant.toml
 COPY docker/reborn/config.hosted-single-tenant-volume.toml /opt/ironclaw/reborn/config.hosted-single-tenant-volume.toml

--- a/crates/ironclaw_reborn_cli/tests/smoke.rs
+++ b/crates/ironclaw_reborn_cli/tests/smoke.rs
@@ -154,6 +154,30 @@ fn dockerfile_reborn_builds_with_postgres_feature() {
 }
 
 #[test]
+fn dockerfile_reborn_ships_extension_ownership_migration() {
+    let dockerfile = std::fs::read_to_string(workspace_root().join("Dockerfile.reborn"))
+        .expect("Dockerfile.reborn");
+    let builder_stage = dockerfile
+        .split_once("FROM deps AS builder")
+        .map(|(_, stage)| stage)
+        .expect("Dockerfile.reborn should define a builder stage");
+
+    assert!(
+        builder_stage.contains("--package ironclaw_reborn_migration")
+            && builder_stage.contains("--no-default-features")
+            && builder_stage.contains("--features libsql")
+            && builder_stage.contains("--bin ironclaw-reborn-extension-ownership-migration"),
+        "Dockerfile.reborn must build the libSQL-only extension ownership migration binary: {dockerfile}"
+    );
+    assert!(
+        dockerfile.contains(
+            "COPY --from=builder /app/target/dist/ironclaw-reborn-extension-ownership-migration /usr/local/bin/ironclaw-reborn-extension-ownership-migration"
+        ),
+        "Dockerfile.reborn must copy the extension ownership migration into the runtime image: {dockerfile}"
+    );
+}
+
+#[test]
 fn run_reborn_webui_builds_frontend_before_cargo() {
     let launcher = std::fs::read_to_string(workspace_root().join("scripts/run-reborn-webui.sh"))
         .expect("scripts/run-reborn-webui.sh");

--- a/crates/ironclaw_reborn_cli/tests/smoke.rs
+++ b/crates/ironclaw_reborn_cli/tests/smoke.rs
@@ -1,3 +1,4 @@
+// arch-exempt: large_file, centralized CLI and Dockerfile smoke contracts, plan #6058
 #[cfg(feature = "webui-v2-beta")]
 use std::io::BufRead;
 use std::{
@@ -157,11 +158,23 @@ fn dockerfile_reborn_builds_with_postgres_feature() {
 fn dockerfile_reborn_ships_extension_ownership_migration() {
     let dockerfile = std::fs::read_to_string(workspace_root().join("Dockerfile.reborn"))
         .expect("Dockerfile.reborn");
+    let deps_stage = dockerfile
+        .split_once("FROM chef AS deps")
+        .and_then(|(_, stages)| stages.split_once("FROM deps AS builder"))
+        .map(|(stage, _)| stage)
+        .expect("Dockerfile.reborn should define a deps stage");
     let builder_stage = dockerfile
         .split_once("FROM deps AS builder")
         .map(|(_, stage)| stage)
         .expect("Dockerfile.reborn should define a builder stage");
 
+    assert!(
+        deps_stage.contains("--package ironclaw_reborn_migration")
+            && deps_stage.contains("--no-default-features")
+            && deps_stage.contains("--features libsql")
+            && deps_stage.contains("--recipe-path recipe.json"),
+        "Dockerfile.reborn must cache the libSQL-only extension ownership migration dependencies: {dockerfile}"
+    );
     assert!(
         builder_stage.contains("--package ironclaw_reborn_migration")
             && builder_stage.contains("--no-default-features")

--- a/crates/ironclaw_reborn_migration/Cargo.toml
+++ b/crates/ironclaw_reborn_migration/Cargo.toml
@@ -42,8 +42,7 @@ libsql = [
 ]
 postgres = [
     "dep:deadpool-postgres",
-    "dep:tokio-postgres",
-    "ironclaw/postgres",
+    "ironclaw?/postgres",
     "ironclaw_filesystem/postgres",
     "ironclaw_triggers/postgres",
     "ironclaw_reborn_composition/postgres",
@@ -87,7 +86,6 @@ uuid = { version = "1", features = ["v4", "v5", "serde"] }
 # backend-specific handles (optional, pulled in by feature)
 deadpool-postgres = { version = "0.14", optional = true }
 libsql = { version = "0.9", optional = true, default-features = false, features = ["core", "replication", "remote", "tls"] }
-tokio-postgres = { version = "0.7", optional = true, features = ["with-serde_json-1"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/ironclaw_reborn_migration/Cargo.toml
+++ b/crates/ironclaw_reborn_migration/Cargo.toml
@@ -21,19 +21,21 @@ dist = false
 [[bin]]
 name = "ironclaw-reborn-migration"
 path = "src/main.rs"
+required-features = ["full-migration"]
 
 [[bin]]
 name = "ironclaw-reborn-extension-ownership-migration"
 path = "src/extension_ownership_main.rs"
 
 [features]
-default = ["libsql", "postgres"]
-# Each backend feature forwards into the v1 read stack (root `ironclaw` crate)
-# and every Reborn write stack that dispatches on a backend, so a single
-# `--features libsql` build wires the whole read→write path over one backend.
+default = ["full-migration", "libsql", "postgres"]
+full-migration = ["dep:ironclaw"]
+# Backend features wire every Reborn write stack that dispatches on that
+# backend. When `full-migration` is also enabled, `ironclaw?/libsql` forwards
+# the same backend into the optional v1 read stack.
 libsql = [
     "dep:libsql",
-    "ironclaw/libsql",
+    "ironclaw?/libsql",
     "ironclaw_filesystem/libsql",
     "ironclaw_triggers/libsql",
     "ironclaw_reborn_composition/libsql",
@@ -49,7 +51,7 @@ postgres = [
 
 [dependencies]
 # ── v1 / engine-v2 read side (the legacy monolith) ──────────────────────────
-ironclaw = { path = "../..", default-features = false }
+ironclaw = { path = "../..", default-features = false, optional = true }
 
 # ── Reborn write side (path deps; versions intentionally unpinned) ───────────
 ironclaw_common = { path = "../ironclaw_common" }
@@ -91,9 +93,9 @@ tokio-postgres = { version = "0.7", optional = true, features = ["with-serde_jso
 tempfile = "3"
 
 # Docker-free acceptance test: seeds a rich v1+engine-v2 libSQL fixture, runs the
-# migration, and asserts the round-trip + the exact gap set. Gated on libsql so a
-# no-libsql build still compiles.
+# migration, and asserts the round-trip + the exact gap set. Gated on the full
+# migration plus libsql so the ownership-only operator build stays legacy-free.
 [[test]]
 name = "migration_roundtrip"
 path = "tests/migration_roundtrip.rs"
-required-features = ["libsql"]
+required-features = ["full-migration", "libsql"]

--- a/crates/ironclaw_reborn_migration/src/lib.rs
+++ b/crates/ironclaw_reborn_migration/src/lib.rs
@@ -14,13 +14,18 @@ pub mod error;
 pub mod options;
 pub mod report;
 
-mod mounts;
-mod source;
 mod target;
-mod v2_model;
 
-mod convert;
 mod extension_ownership;
+
+#[cfg(feature = "full-migration")]
+mod convert;
+#[cfg(feature = "full-migration")]
+mod mounts;
+#[cfg(feature = "full-migration")]
+mod source;
+#[cfg(feature = "full-migration")]
+mod v2_model;
 
 pub use extension_ownership::{
     ExtensionOwnershipMigrationOptions, ExtensionOwnershipMigrationReport,
@@ -37,6 +42,7 @@ pub use report::{Domain, LossReason, LossyItem, MigrationReport, MigrationStats}
 /// Infrastructure failures (cannot open a store, cannot write a record) abort
 /// with a [`MigrationError`]. Per-item representation gaps do not abort — they
 /// are accumulated as [`LossyItem`]s on the returned report.
+#[cfg(feature = "full-migration")]
 pub async fn run_migration(options: MigrationOptions) -> Result<MigrationReport, MigrationError> {
     let mut report = MigrationReport::new(options.dry_run);
 

--- a/crates/ironclaw_reborn_migration/src/report.rs
+++ b/crates/ironclaw_reborn_migration/src/report.rs
@@ -7,8 +7,10 @@
 //! can inspect exactly what carried over and what was dropped. Nothing is ever
 //! silently lost: a value that has no Reborn home lands here as a `LossyItem`.
 
-use ironclaw_host_api::UserId;
 use serde::{Deserialize, Serialize};
+
+#[cfg(feature = "full-migration")]
+use ironclaw_host_api::UserId;
 
 /// The domain a converted item or a loss belongs to. Keeps report entries
 /// grouped and greppable rather than free-text.
@@ -118,6 +120,7 @@ impl MigrationReport {
     /// (threads owner, secrets, memory docs, identities, routines, missions) so
     /// the "validate → skip + record" shape has a single definition and cannot
     /// drift between copies.
+    #[cfg(feature = "full-migration")]
     pub(crate) fn valid_user_id(
         &mut self,
         domain: Domain,

--- a/crates/ironclaw_reborn_migration/src/target.rs
+++ b/crates/ironclaw_reborn_migration/src/target.rs
@@ -12,20 +12,33 @@ use std::sync::Arc;
 
 use ironclaw_extensions::ExtensionInstallationStore;
 use ironclaw_filesystem::{RootFilesystem, ScopedFilesystem};
-use ironclaw_host_api::{AgentId, ProjectId, TenantId, UserId};
+use ironclaw_host_api::{AgentId, TenantId, UserId};
+use ironclaw_reborn_identity::{FilesystemRebornIdentityStore, RebornUserDirectory};
+
+#[cfg(feature = "full-migration")]
+use ironclaw_host_api::ProjectId;
+#[cfg(feature = "full-migration")]
 use ironclaw_memory::MemoryService;
+#[cfg(feature = "full-migration")]
 use ironclaw_memory_native::NativeMemoryService;
-use ironclaw_reborn_identity::{
-    FilesystemRebornIdentityStore, RebornIdentityResolver, RebornUserDirectory,
-};
+#[cfg(feature = "full-migration")]
+use ironclaw_reborn_identity::RebornIdentityResolver;
+#[cfg(feature = "full-migration")]
 use ironclaw_secrets::{FilesystemSecretStore, SecretStore, SecretsCrypto};
+#[cfg(feature = "full-migration")]
 use ironclaw_threads::{FilesystemSessionThreadService, SessionThreadService};
+#[cfg(feature = "full-migration")]
 use ironclaw_triggers::TriggerRepository;
+#[cfg(feature = "full-migration")]
 use secrecy::SecretString;
 
 use crate::error::MigrationError;
+use crate::options::TargetStore;
+
+#[cfg(feature = "full-migration")]
 use crate::mounts;
-use crate::options::{MigrationOptions, TargetStore};
+#[cfg(feature = "full-migration")]
+use crate::options::MigrationOptions;
 
 /// The concrete Reborn backend the migration writes into. Both the KV substrate
 /// and the triggers DB share this one handle.
@@ -35,17 +48,20 @@ pub(crate) enum Backend {
         root: Arc<ironclaw_filesystem::LibSqlRootFilesystem>,
         /// Shared handle for the triggers repo, which uses the raw DB (not the
         /// KV substrate). `LibSqlRootFilesystem` does not re-expose it.
+        #[cfg(feature = "full-migration")]
         db: Arc<libsql::Database>,
     },
     #[cfg(feature = "postgres")]
     Postgres {
         root: Arc<ironclaw_filesystem::PostgresRootFilesystem>,
+        #[cfg(feature = "full-migration")]
         pool: deadpool_postgres::Pool,
     },
 }
 
 /// Live Reborn write target: opened backend plus every constructed write
 /// service and the scope migrated records are written under.
+#[cfg(feature = "full-migration")]
 pub(crate) struct RebornTarget {
     /// Held for `identity_store` (the identity row-by-row follow-up); the other
     /// services already retain their own root/db Arcs.
@@ -108,6 +124,7 @@ impl ExtensionOwnershipTarget {
     }
 }
 
+#[cfg(feature = "full-migration")]
 impl RebornTarget {
     pub(crate) async fn open(options: &MigrationOptions) -> Result<Self, MigrationError> {
         let crypto = match &options.secret_master_key {
@@ -171,12 +188,14 @@ impl RebornTarget {
     }
 }
 
+#[cfg(feature = "full-migration")]
 fn build_crypto(key: &SecretString) -> Result<SecretsCrypto, MigrationError> {
     SecretsCrypto::new(key.clone())
         .map_err(|e| MigrationError::OpenTarget(format!("secrets master key: {e}")))
 }
 
 /// The KV-substrate write services built over one backend.
+#[cfg(feature = "full-migration")]
 type KvServices = (
     Arc<dyn SessionThreadService>,
     Arc<dyn MemoryService>,
@@ -185,6 +204,7 @@ type KvServices = (
 
 /// Build the filesystem-backed KV services over one concrete backend, returning
 /// them as trait objects.
+#[cfg(feature = "full-migration")]
 fn build_kv_services<F>(root: Arc<F>, crypto: Option<Arc<SecretsCrypto>>) -> KvServices
 where
     F: RootFilesystem + 'static,
@@ -213,6 +233,7 @@ where
     (thread_service, memory_service, secret_store)
 }
 
+#[cfg(feature = "full-migration")]
 #[allow(dead_code)] // wired for the identity row-by-row follow-up
 fn build_identity_store<F>(
     root: Arc<F>,
@@ -256,6 +277,7 @@ where
     Ok(store)
 }
 
+#[cfg(feature = "full-migration")]
 async fn build_trigger_repo(
     backend: &Backend,
 ) -> Result<Arc<dyn TriggerRepository>, MigrationError> {
@@ -298,7 +320,11 @@ async fn open_backend(target: &TargetStore) -> Result<Backend, MigrationError> {
             root.run_migrations()
                 .await
                 .map_err(|e| MigrationError::OpenTarget(e.to_string()))?;
-            Ok(Backend::LibSql { root, db })
+            Ok(Backend::LibSql {
+                root,
+                #[cfg(feature = "full-migration")]
+                db,
+            })
         }
         #[cfg(not(feature = "libsql"))]
         TargetStore::LibSql { .. } => Err(MigrationError::OpenTarget(
@@ -313,7 +339,11 @@ async fn open_backend(target: &TargetStore) -> Result<Backend, MigrationError> {
             root.run_migrations()
                 .await
                 .map_err(|e| MigrationError::OpenTarget(e.to_string()))?;
-            Ok(Backend::Postgres { root, pool })
+            Ok(Backend::Postgres {
+                root,
+                #[cfg(feature = "full-migration")]
+                pool,
+            })
         }
         #[cfg(not(feature = "postgres"))]
         TargetStore::Postgres { .. } => Err(MigrationError::OpenTarget(

--- a/crates/ironclaw_reborn_migration/src/target.rs
+++ b/crates/ironclaw_reborn_migration/src/target.rs
@@ -352,76 +352,13 @@ async fn open_backend(target: &TargetStore) -> Result<Backend, MigrationError> {
     }
 }
 
-/// Build the Reborn target Postgres pool with the repo's remote-TLS rule:
-/// remote hosts must use TLS (mirrors `ironclaw_reborn_event_store` and
-/// `src/db/tls.rs`). A remote `sslmode=disable` is rejected rather than sending
-/// migration traffic — including decrypted secrets — in cleartext; local
-/// connections keep plain TCP. TLS wiring is reused from `ironclaw::db::tls`.
+/// Build the Reborn target Postgres pool through the production composition
+/// helper so migrations inherit the same fail-closed remote-TLS policy without
+/// linking the legacy root crate.
 #[cfg(feature = "postgres")]
 fn open_postgres_pool(
     url: &secrecy::SecretString,
 ) -> Result<deadpool_postgres::Pool, MigrationError> {
-    use secrecy::ExposeSecret;
-
-    let raw = url.expose_secret();
-    let pg_config = raw
-        .parse::<tokio_postgres::Config>()
-        .map_err(|e| MigrationError::OpenTarget(format!("parse Postgres URL: {e}")))?;
-    let remote = !is_local_postgres_config(&pg_config);
-    let ssl_mode = match pg_config.get_ssl_mode() {
-        tokio_postgres::config::SslMode::Disable => {
-            if remote {
-                return Err(MigrationError::OpenTarget(
-                    "remote Postgres target requires TLS; sslmode=disable is rejected for \
-                     migration traffic (it carries decrypted secrets)"
-                        .into(),
-                ));
-            }
-            ironclaw::config::SslMode::Disable
-        }
-        // `Prefer`/`Require`/future variants: force TLS on remote, allow the
-        // parsed intent on local.
-        _ if remote => ironclaw::config::SslMode::Require,
-        _ => ironclaw::config::SslMode::Prefer,
-    };
-
-    let mut dp_config = deadpool_postgres::Config::new();
-    dp_config.url = Some(raw.to_string());
-    ironclaw::db::tls::create_pool(&dp_config, ssl_mode)
-        .map_err(|e| MigrationError::OpenTarget(e.to_string()))
-}
-
-/// True when the parsed Postgres `Config` targets only loopback hosts / Unix
-/// sockets. Anything else is treated as remote and must use TLS. Mirrors the
-/// event-store's `is_local_postgres_config`.
-#[cfg(feature = "postgres")]
-fn is_local_postgres_config(config: &tokio_postgres::Config) -> bool {
-    use tokio_postgres::config::Host;
-
-    let hosts = config.get_hosts();
-    let hostaddrs = config.get_hostaddrs();
-    if hosts.is_empty() && hostaddrs.is_empty() {
-        // Empty host list means libpq's compiled-in default socket directory.
-        return true;
-    }
-    for host in hosts {
-        match host {
-            #[cfg(unix)]
-            Host::Unix(_) => continue,
-            Host::Tcp(name) => {
-                if !matches!(
-                    name.as_str(),
-                    "localhost" | "127.0.0.1" | "::1" | "[::1]" | "0.0.0.0"
-                ) {
-                    return false;
-                }
-            }
-        }
-    }
-    for addr in hostaddrs {
-        if !addr.is_loopback() && !addr.is_unspecified() {
-            return false;
-        }
-    }
-    true
+    ironclaw_reborn_composition::open_reborn_postgres_pool(url.clone())
+        .map_err(|error| MigrationError::OpenTarget(error.to_string()))
 }

--- a/docs/superpowers/plans/2026-07-13-railway-extension-ownership-migration-packaging.md
+++ b/docs/superpowers/plans/2026-07-13-railway-extension-ownership-migration-packaging.md
@@ -1,0 +1,106 @@
+# Railway Extension Ownership Migration Packaging Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the existing libSQL extension-ownership migration binary in the Reborn Railway runtime image without changing normal startup behavior.
+
+**Architecture:** `Dockerfile.reborn` compiles the migration crate as a libSQL-only operator binary in the existing builder stage, then copies it into `/usr/local/bin` in the runtime stage. A `full-migration` feature keeps the legacy v1 read stack enabled by default while allowing the ownership-only operator binary to compile without the legacy root crate, whose source is intentionally absent from the Reborn Docker builder. The existing Reborn CLI smoke suite enforces both build and copy steps as a static deploy-artifact contract.
+
+**Tech Stack:** Rust 2024, Cargo, Docker multi-stage builds, Rust smoke tests.
+
+## Global Constraints
+
+- Keep the existing `ironclaw-reborn-entrypoint` and default startup behavior unchanged.
+- Build `ironclaw-reborn-extension-ownership-migration` with `--no-default-features --features libsql`.
+- Do not add automatic migration execution, remote-libSQL support, or a separate migration image.
+- Do not add new dependencies.
+
+---
+
+### Task 1: Package the migration binary
+
+**Files:**
+- Modify: `crates/ironclaw_reborn_cli/tests/smoke.rs`
+- Modify: `Dockerfile.reborn`
+- Modify: `crates/ironclaw_reborn_migration/Cargo.toml`
+- Modify: `crates/ironclaw_reborn_migration/src/lib.rs`
+- Modify: `crates/ironclaw_reborn_migration/src/report.rs`
+- Modify: `crates/ironclaw_reborn_migration/src/target.rs`
+
+**Interfaces:**
+- Consumes: the existing `ironclaw-reborn-extension-ownership-migration` binary target from `ironclaw_reborn_migration`.
+- Produces: `/usr/local/bin/ironclaw-reborn-extension-ownership-migration` in the Reborn runtime image.
+
+- [x] **Step 1: Write the failing Dockerfile contract test**
+
+Add `dockerfile_reborn_ships_extension_ownership_migration` to `crates/ironclaw_reborn_cli/tests/smoke.rs`. It must assert that the builder stage contains all of:
+
+```text
+--package ironclaw_reborn_migration
+--no-default-features
+--features libsql
+--bin ironclaw-reborn-extension-ownership-migration
+```
+
+It must also assert that the runtime image contains this exact copy contract:
+
+```dockerfile
+COPY --from=builder /app/target/dist/ironclaw-reborn-extension-ownership-migration /usr/local/bin/ironclaw-reborn-extension-ownership-migration
+```
+
+- [x] **Step 2: Run the targeted test and verify RED**
+
+Run:
+
+```bash
+cargo test -p ironclaw_reborn_cli --test smoke dockerfile_reborn_ships_extension_ownership_migration -- --exact
+```
+
+Expected: FAIL because `Dockerfile.reborn` does not yet build or copy the migration binary.
+
+- [x] **Step 3: Add the minimal Dockerfile implementation**
+
+Add this builder command after the existing CLI build:
+
+```dockerfile
+RUN cargo build \
+    --profile dist \
+    --package ironclaw_reborn_migration \
+    --no-default-features \
+    --features libsql \
+    --bin ironclaw-reborn-extension-ownership-migration
+```
+
+Add this runtime copy beside the existing `ironclaw-reborn` copy:
+
+```dockerfile
+COPY --from=builder /app/target/dist/ironclaw-reborn-extension-ownership-migration /usr/local/bin/ironclaw-reborn-extension-ownership-migration
+```
+
+- [x] **Step 4: Keep the ownership-only build independent of the legacy root crate**
+
+Make the existing full migration an explicit default feature and gate its source/conversion-only modules. The `--no-default-features --features libsql` ownership binary must not contain the workspace root `ironclaw` package in its dependency graph, while default builds must retain the existing full migration behavior.
+
+- [x] **Step 5: Run targeted and crate verification**
+
+Run:
+
+```bash
+cargo test -p ironclaw_reborn_cli --test smoke dockerfile_reborn_ships_extension_ownership_migration -- --exact
+cargo test -p ironclaw_reborn_cli --test smoke dockerfile_reborn_builds_with_postgres_feature -- --exact
+cargo test -p ironclaw_reborn_cli
+cargo clippy -p ironclaw_reborn_cli --all-targets --all-features -- -D warnings
+git diff --check
+```
+
+Expected: every command exits successfully with zero test failures and zero warnings.
+
+- [x] **Step 6: Commit and publish**
+
+```bash
+git add Dockerfile.reborn crates/ironclaw_reborn_cli/tests/smoke.rs crates/ironclaw_reborn_migration/Cargo.toml crates/ironclaw_reborn_migration/src/lib.rs crates/ironclaw_reborn_migration/src/report.rs crates/ironclaw_reborn_migration/src/target.rs docs/superpowers/plans/2026-07-13-railway-extension-ownership-migration-packaging.md
+git commit -m "build(reborn): ship extension ownership migration"
+git push -u origin codex/ship-extension-ownership-migration
+```
+
+Open a PR describing the unchanged entrypoint, libSQL-only migration binary, smoke-test coverage, and QA backup/dry-run/apply procedure.

--- a/docs/superpowers/specs/2026-07-13-extension-ownership-migration-design.md
+++ b/docs/superpowers/specs/2026-07-13-extension-ownership-migration-design.md
@@ -76,3 +76,32 @@ On the existing port-8745 hosted-volume stack:
 6. Remove a non-Slack extension as Account A and confirm Account B keeps it.
 7. After connecting Slack for both users, remove it as Account A and confirm A's
    personal Slack state is cleaned while B remains installed and connected.
+
+## Railway QA Packaging
+
+The Reborn Railway runtime image must include the existing
+`ironclaw-reborn-extension-ownership-migration` binary so an operator can run
+the migration against a volume-backed libSQL database. The binary is built with
+only the `libsql` backend enabled and copied into the runtime image beside
+`ironclaw-reborn`. The normal image entrypoint and application startup behavior
+remain unchanged; merely deploying the image never runs the migration.
+
+The existing CLI Dockerfile smoke suite must verify both sides of this contract:
+
+1. the builder compiles the exact migration binary from
+   `ironclaw_reborn_migration` with `--no-default-features --features libsql`;
+2. the runtime stage copies that exact binary into `/usr/local/bin`.
+
+The alternatives are intentionally rejected for this one-time operation:
+
+- a separate migration image would require moving or reattaching the one-volume
+  Railway service and add avoidable operational risk;
+- remote-libSQL URL/token support would expand the migration's storage contract
+  even though QA already exposes the database as a mounted filesystem;
+- a Railway pre-deploy command cannot be used because Railway does not mount
+  persistent volumes into pre-deploy containers.
+
+The QA run remains an explicit operator sequence: deploy the image, create a
+manual Railway volume backup, run a read-only dry run, stop application writers,
+apply once against the discovered `reborn-local-dev.db`, restart the normal
+entrypoint, and run a final dry run that reports no changed extensions.

--- a/docs/superpowers/specs/2026-07-13-extension-ownership-migration-design.md
+++ b/docs/superpowers/specs/2026-07-13-extension-ownership-migration-design.md
@@ -82,9 +82,11 @@ On the existing port-8745 hosted-volume stack:
 The Reborn Railway runtime image must include the existing
 `ironclaw-reborn-extension-ownership-migration` binary so an operator can run
 the migration against a volume-backed libSQL database. The binary is built with
-only the `libsql` backend enabled and copied into the runtime image beside
-`ironclaw-reborn`. The normal image entrypoint and application startup behavior
-remain unchanged; merely deploying the image never runs the migration.
+only the `libsql` backend enabled and without the optional legacy full-migration
+read stack, then copied into the runtime image beside `ironclaw-reborn`. Default
+migration crate builds still include the full legacy-to-Reborn migrator. The
+normal image entrypoint and application startup behavior remain unchanged;
+merely deploying the image never runs the migration.
 
 The existing CLI Dockerfile smoke suite must verify both sides of this contract:
 


### PR DESCRIPTION
## Summary

- Ship the explicit extension-ownership migration binary in the Reborn Railway runtime image.
- Cache its libSQL-only dependency graph with cargo-chef so normal source changes do not rebuild the entire migration graph.
- Keep libSQL- and Postgres-only ownership builds independent of the legacy root crate; Postgres pool creation delegates to the Reborn production TLS helper.
- Preserve the existing entrypoint and startup behavior. Deploying the image never runs the migration automatically.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [x] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Related #5953

## Validation

- [x] cargo fmt --all -- --check
- [x] cargo clippy --workspace --all-targets --all-features -- -D warnings
- [x] cargo build: full Reborn runtime image built successfully before the review follow-up; updated cargo-chef deps stage built successfully after the follow-up
- [x] Relevant tests pass: migration ownership unit tests and the Reborn CLI Dockerfile packaging smoke test
- [ ] cargo test --features integration: no schema or runtime lifecycle behavior changed in this packaging follow-up
- [x] Manual testing: verified both app and migration executables in the runtime image and verified migration --help
- [x] Review feedback was read, verified, implemented, and retested

Additional feature-matrix checks:

- libSQL-only migration clippy passes without the legacy root crate
- Postgres-only migration check and clippy pass without the legacy root crate
- default full-migration check passes
- pre-commit safety checks pass

## Security Impact

No new permissions, network surface, secret handling, file access, tool execution, or sandbox policy. Postgres migration pool creation now reuses the Reborn production helper and retains fail-closed remote TLS enforcement.

## Reborn Trust-Boundary Checklist

- [x] Public policy/evidence/trust-bearing types: N/A; no public trust-bearing types changed.
- [x] Untrusted content enters prompts only through an envelope/escaping primitive: N/A; no prompt path changed.
- [x] Hashes declare purpose: N/A; no hashes changed.
- [x] New/changed status, exit, policy, runtime, or error variants: N/A; none changed.
- [x] Security/durability serde(default) fields fail closed or have migration tests: N/A; no serialized schema changed.
- [x] Queues/maps/buffers/counters have bounds and overflow-safe arithmetic: N/A; none added.
- [x] Driver/operator-visible errors have stable class semantics: existing migration error mapping retained.
- [x] Sandbox/native/host names accurately describe trust boundary: N/A; no runtime lane changed.

## Database Impact

No schema or automatic database migration. The shipped operator command can explicitly rewrite existing extension installation ownership using the typed installation store. Operators must back up the Railway volume, dry-run, stop application writers, apply once, restart, and confirm a final no-op dry-run.

## Blast Radius

Reborn Docker build/cache layers and the standalone migration crate feature matrix. The normal Reborn binary, entrypoint, startup sequence, and extension lifecycle are unchanged.

## Rollback Plan

Before invoking the migration, roll back by deploying the previous image. After invoking it, restore the manual Railway volume backup, then deploy the previous image. Merely deploying this PR does not mutate data.

## Review Follow-Through

- Added a matching cargo-chef migration cook step and a smoke assertion for the cache contract.
- Made the Postgres feature weakly forward the legacy feature and delegated pool creation to the Reborn-owned production TLS helper.
- Both Gemini inline threads are addressed and will be resolved after this update.

---

**Review track**: C (runtime image and explicit DB operator tooling)