### PR TITLE
fix(reborn): name blocked provider in Slack auth-unavailable notice; stop misclassifying installation-store I/O faults as invalid input

### DIFF
--- a/crates/ironclaw_extensions/src/installations.rs
+++ b/crates/ironclaw_extensions/src/installations.rs
@@ -1313,6 +1313,8 @@ pub enum ExtensionInstallationError {
     ManifestNotFound { extension_id: ExtensionId },
     #[error("invalid installation: {reason}")]
     InvalidInstallation { reason: String },
+    #[error("extension installation backend error: {reason}")]
+    Backend { reason: String },
     #[error("duplicate credential binding {handle}")]
     DuplicateCredentialBinding { handle: ExtensionCredentialHandle },
     #[error("conflicting manifest references for extension {extension_id}")]

--- a/crates/ironclaw_reborn_composition/src/extension_host/extension_installation_store.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/extension_installation_store.rs
@@ -58,7 +58,7 @@ impl FilesystemExtensionInstallationStore {
                     state_path = %state_path.as_str(),
                     "extension installation state load failed"
                 );
-                return Err(invalid_installation_error(INSTALLATION_STATE_IO_ERROR));
+                return Err(backend_installation_error(INSTALLATION_STATE_IO_ERROR));
             }
         }
         Ok(Self {
@@ -94,7 +94,7 @@ async fn write_snapshot(
                 state_path = %state_path.as_str(),
                 "extension installation state write failed"
             );
-            invalid_installation_error(INSTALLATION_STATE_IO_ERROR)
+            backend_installation_error(INSTALLATION_STATE_IO_ERROR)
         })
 }
 
@@ -316,6 +316,12 @@ impl WireManifestSource {
 
 fn invalid_installation_error(error: impl std::fmt::Display) -> ExtensionInstallationError {
     ExtensionInstallationError::InvalidInstallation {
+        reason: error.to_string(),
+    }
+}
+
+fn backend_installation_error(error: impl std::fmt::Display) -> ExtensionInstallationError {
+    ExtensionInstallationError::Backend {
         reason: error.to_string(),
     }
 }

--- a/crates/ironclaw_reborn_composition/src/extension_host/extension_installation_store/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/extension_installation_store/tests.rs
@@ -63,10 +63,14 @@ async fn load_at_sanitizes_filesystem_read_errors() {
         .expect("valid state path");
 
     let error = match FilesystemExtensionInstallationStore::load_at(filesystem, state_path).await {
-        Ok(_) => panic!("backend read failure should surface as invalid installation"),
+        Ok(_) => panic!("backend read failure should surface as a transient backend error"),
         Err(error) => error,
     };
 
+    // Must be `Backend`, not `InvalidInstallation` — a transient I/O fault is
+    // not malformed content, and `map_extension_installation_error` only
+    // routes `Backend` to a retryable classification (#5878).
+    assert!(matches!(error, ExtensionInstallationError::Backend { .. }));
     let rendered = error.to_string();
     assert!(rendered.contains("failed to load extension installation state"));
     assert!(!rendered.contains("/tenants/acme"));
@@ -379,7 +383,7 @@ async fn load_at_returns_rewrite_failure_without_exposing_normalized_store() {
         };
     assert_eq!(
         error,
-        ExtensionInstallationError::InvalidInstallation {
+        ExtensionInstallationError::Backend {
             reason: "failed to load extension installation state".to_string(),
         }
     );

--- a/crates/ironclaw_reborn_composition/src/extension_host/extension_lifecycle.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/extension_lifecycle.rs
@@ -2368,10 +2368,13 @@ fn map_extension_error(error: ExtensionError) -> ProductWorkflowError {
 }
 
 fn map_extension_installation_error(error: ExtensionInstallationError) -> ProductWorkflowError {
-    // TODO(#4091): split durable-store transient failures from malformed
-    // lifecycle requests when ExtensionInstallationStore grows a DB backend.
-    ProductWorkflowError::InvalidBindingRequest {
-        reason: error.to_string(),
+    match error {
+        ExtensionInstallationError::Backend { .. } => ProductWorkflowError::Transient {
+            reason: error.to_string(),
+        },
+        _ => ProductWorkflowError::InvalidBindingRequest {
+            reason: error.to_string(),
+        },
     }
 }
 
@@ -2492,6 +2495,30 @@ mod tests {
     use ironclaw_trust::{HostTrustPolicy, InvalidationBus, TrustPolicy};
 
     mod private_install_tests;
+
+    #[test]
+    fn map_extension_installation_error_treats_backend_faults_as_transient() {
+        // A transient installation-store I/O fault (e.g. concurrent-write
+        // contention) must not surface to the model as an invalid-request /
+        // encoding failure — that previously produced the misleading "the
+        // tool input could not be encoded" message reported in #5878.
+        let error = ExtensionInstallationError::Backend {
+            reason: "failed to load extension installation state".to_string(),
+        };
+        assert!(matches!(
+            map_extension_installation_error(error),
+            ProductWorkflowError::Transient { .. }
+        ));
+    }
+
+    #[test]
+    fn map_extension_installation_error_treats_other_faults_as_invalid_binding_request() {
+        let error = ExtensionInstallationError::EmptyOwnerMembers;
+        assert!(matches!(
+            map_extension_installation_error(error),
+            ProductWorkflowError::InvalidBindingRequest { .. }
+        ));
+    }
 
     #[tokio::test]
     async fn lifecycle_owner_projections_reject_duplicate_extension_ids() {

--- a/crates/ironclaw_reborn_composition/src/slack/slack_delivery.rs
+++ b/crates/ironclaw_reborn_composition/src/slack/slack_delivery.rs
@@ -509,7 +509,7 @@ impl SlackFinalReplyDeliveryObserver {
                     if let Err(error) = post_slack_message(
                         self.services.egress.as_ref(),
                         envelope.external_conversation_ref(),
-                        SLACK_AUTH_UNAVAILABLE_MESSAGE,
+                        &slack_auth_unavailable_notice(view.provider.as_deref()),
                     )
                     .await
                     {
@@ -1172,6 +1172,22 @@ fn slack_auth_setup_link_is_private(envelope: &ProductInboundEnvelope) -> bool {
         ProductInboundPayload::UserMessage(payload)
             if payload.trigger == ironclaw_product_adapters::ProductTriggerReason::DirectChat
     )
+}
+
+/// Names the blocked provider when known instead of a blanket "this needs a
+/// credential" notice — a stored-but-rejected (e.g. externally revoked)
+/// credential looks identical to a never-configured one without it (#5884).
+/// Deliberately does not claim the provider was previously connected: the
+/// same gate shape covers both a revoked credential and one that was never
+/// set up, and only the provider identity — not which case this is — is
+/// known here.
+fn slack_auth_unavailable_notice(provider: Option<&str>) -> String {
+    match provider {
+        Some(provider) => {
+            format!("This needs your {provider} credential. {SLACK_AUTH_UNAVAILABLE_MESSAGE}")
+        }
+        None => SLACK_AUTH_UNAVAILABLE_MESSAGE.to_string(),
+    }
 }
 
 fn slack_approval_gate_prompt_view(
@@ -2706,7 +2722,8 @@ async fn triggered_notification_for_state(
                     payload: ProductOutboundPayload::FinalReply(FinalReplyView {
                         turn_run_id: run_id,
                         text: format!(
-                            "{SLACK_AUTH_UNAVAILABLE_MESSAGE}{}",
+                            "{}{}",
+                            slack_auth_unavailable_notice(view.provider.as_deref()),
                             triggered_update_footer(trigger_label)
                         ),
                         generated_at: Utc::now(),
@@ -3098,6 +3115,26 @@ mod tests {
     };
     use ironclaw_turns::AcceptedMessageRef;
 
+    #[test]
+    fn slack_auth_unavailable_notice_without_provider_is_the_blanket_message() {
+        assert_eq!(
+            slack_auth_unavailable_notice(None),
+            SLACK_AUTH_UNAVAILABLE_MESSAGE
+        );
+    }
+
+    #[test]
+    fn slack_auth_unavailable_notice_with_provider_names_it_without_claiming_reconnect() {
+        let notice = slack_auth_unavailable_notice(Some("github"));
+        assert!(notice.contains("github"));
+        assert!(notice.contains(SLACK_AUTH_UNAVAILABLE_MESSAGE));
+        assert!(
+            !notice.to_ascii_lowercase().contains("reconnect"),
+            "must not claim a prior connection existed — the same gate shape \
+             also covers a never-configured extension, got: {notice}"
+        );
+    }
+
     fn accepted_ack() -> ProductInboundAck {
         ProductInboundAck::Accepted {
             accepted_message_ref: AcceptedMessageRef::new("slack:test-message")
@@ -3234,6 +3271,7 @@ mod tests {
     struct ScriptedRunState {
         status: TurnStatus,
         gate_ref: Option<GateRef>,
+        credential_requirements: Vec<ironclaw_host_api::RuntimeCredentialAuthRequirement>,
     }
 
     struct ScriptedTurnCoordinator {
@@ -3281,6 +3319,7 @@ mod tests {
             Self::with_states(vec![ScriptedRunState {
                 status,
                 gate_ref: None,
+                credential_requirements: Vec::new(),
             }])
         }
 
@@ -3387,7 +3426,7 @@ mod tests {
                 checkpoint_id: None,
                 gate_ref: scripted.gate_ref,
                 blocked_activity_id: None,
-                credential_requirements: Vec::new(),
+                credential_requirements: scripted.credential_requirements.clone(),
                 failure: None,
                 event_cursor: EventCursor(1),
                 product_context: None,
@@ -3427,6 +3466,29 @@ mod tests {
         ScriptedRunState {
             status,
             gate_ref: gate_ref.map(|s| GateRef::new(s).expect("gate ref")),
+            credential_requirements: Vec::new(),
+        }
+    }
+
+    /// Like [`scripted_state`] but carries a single manual-token (PAT)
+    /// credential requirement, as `extension_activate`'s auth gate produces
+    /// for a provider like GitHub. Used to assert the auth-unavailable
+    /// notice names the blocked provider instead of a blanket message (#5884).
+    fn scripted_state_with_manual_token_requirement(
+        status: TurnStatus,
+        gate_ref: Option<&str>,
+        provider: &str,
+    ) -> ScriptedRunState {
+        ScriptedRunState {
+            credential_requirements: vec![ironclaw_host_api::RuntimeCredentialAuthRequirement {
+                provider: ironclaw_host_api::RuntimeCredentialAccountProviderId::new(provider)
+                    .expect("valid provider id"),
+                setup: ironclaw_host_api::RuntimeCredentialAccountSetup::ManualToken,
+                requester_extension: ironclaw_host_api::ExtensionId::new(provider)
+                    .expect("valid extension id"),
+                provider_scopes: Vec::new(),
+            }],
+            ..scripted_state(status, gate_ref)
         }
     }
 
@@ -5166,10 +5228,13 @@ mod tests {
         );
 
         let outbound = Arc::new(InMemoryOutboundStateStore::default());
-        let coordinator = Arc::new(ScriptedTurnCoordinator::with_states(vec![scripted_state(
-            TurnStatus::BlockedAuth,
-            Some("gate:auth-cancel-test"),
-        )]));
+        let coordinator = Arc::new(ScriptedTurnCoordinator::with_states(vec![
+            scripted_state_with_manual_token_requirement(
+                TurnStatus::BlockedAuth,
+                Some("gate:auth-cancel-test"),
+                "github",
+            ),
+        ]));
         let observer = make_observer(
             Arc::clone(&coordinator) as Arc<dyn TurnCoordinator>,
             egress.clone(),
@@ -5205,6 +5270,12 @@ mod tests {
         assert!(
             body.contains(SLACK_AUTH_UNAVAILABLE_MESSAGE),
             "body must contain SLACK_AUTH_UNAVAILABLE_MESSAGE text, got: {body}"
+        );
+        // #5884: the notice must name the blocked provider instead of reading
+        // identically to a never-configured extension.
+        assert!(
+            body.contains("github"),
+            "body must name the github provider, got: {body}"
         );
         assert!(
             !body.contains("Authentication required"),
@@ -6774,9 +6845,16 @@ mod tests {
         let binding_ref =
             test_slack_binding_ref(install, scope.agent_id.as_ref().expect("agent").as_str());
 
-        // First poll → BlockedAuth with gate_ref; second poll → Completed.
+        // First poll → BlockedAuth with gate_ref; second poll → Completed. The
+        // BlockedAuth state carries a single manual-token (PAT) credential
+        // requirement for "github", matching what a revoked-but-present GitHub
+        // token's runtime 401 (or a never-configured extension) produces.
         let coordinator = Arc::new(ScriptedTurnCoordinator::with_states(vec![
-            scripted_state(TurnStatus::BlockedAuth, Some(gate_ref_str)),
+            scripted_state_with_manual_token_requirement(
+                TurnStatus::BlockedAuth,
+                Some(gate_ref_str),
+                "github",
+            ),
             scripted_state(TurnStatus::Completed, None),
         ]));
         let thread_service = Arc::new(InMemorySessionThreadService::default());
@@ -6872,6 +6950,12 @@ mod tests {
                 .iter()
                 .any(|b| b.contains(SLACK_AUTH_UNAVAILABLE_MESSAGE)),
             "expected the auth-unavailable notice to be posted; got: {posted:?}"
+        );
+        // #5884: the notice must name the blocked provider instead of reading
+        // identically to a never-configured extension.
+        assert!(
+            posted.iter().any(|b| b.contains("github")),
+            "expected the auth-unavailable notice to name the github provider; got: {posted:?}"
         );
     }
 


### PR DESCRIPTION
## Summary

Two independently-verified bugs, both surfaced from the same GitHub-token-revocation bug-bash scenario, both about **misleading error surfacing** rather than actual credential-revocation detection:

- **#5884** — a triggered/routine run blocked on a non-OAuth (PAT) credential posted the exact same generic "needs a credential" Slack message whether the extension was never configured or its token was externally revoked.
- **#5878** — a transient extension-installation-store I/O fault was misclassified the same way as genuinely malformed installation content, surfacing as "the tool input could not be encoded" instead of a retryable failure.

## Root cause

**#5884**: `triggered_notification_for_state` / `notification_for_actionable_state` in `slack_delivery.rs` build an `AuthPromptView` that already carries the blocked provider's identity (`view.provider`, sourced from the typed `RuntimeCredentialAuthRequirement` — manifest-controlled, not user input). For a non-OAuth (PAT/`ManualToken`) challenge, the code discarded `view` entirely and posted a fixed constant, `SLACK_AUTH_UNAVAILABLE_MESSAGE`, with no reference to which extension was blocked.

**#5878**: `FilesystemExtensionInstallationStore::write_snapshot`/`load_at` collapsed *any* `FilesystemError` — including transient I/O (e.g. concurrent-write contention through the store's own `save_lock`) — into `ExtensionInstallationError::InvalidInstallation`, the same variant used for genuinely malformed persisted content. `map_extension_installation_error` then unconditionally mapped every variant to `ProductWorkflowError::InvalidBindingRequest`, which `lifecycle_error` maps to `RuntimeDispatchErrorKind::InputEncode` — the misleading "tool input could not be encoded" text. The removed `TODO(#4091)` comment already named exactly this gap (that issue number turned out to be a stale/unrelated citation — tracks multi-tenant lifecycle wiring, not this).

**Explicitly out of scope**: neither fix detects a revoked credential directly. I traced the full call path for both issues and confirmed nothing in the codebase currently calls `CredentialAccountService::update_status(..., Revoked)` reactively on a live 401 for *any* provider — pre-flight credential resolution is presence-only by design. That's a larger, separately-scoped reactive-invalidation seam (see `docs/plans/2026-06-23-github-pat-auth-bugs-1-2.md` §2.3, still unimplemented) and is not attempted here. Both fixes here make the *existing* failure messaging honest and specific instead of misleading — which is what both issues actually reported when read closely.

## Fix

- `slack_delivery.rs`: new `slack_auth_unavailable_notice(provider: Option<&str>)` helper, colocated with the other view-formatting helpers. Names the provider when known (`"This needs your {provider} credential. ..."`) without claiming a prior connection existed — the same gate shape covers both a revoked and a never-configured credential, so the wording is deliberately connection-agnostic. The original `SLACK_AUTH_UNAVAILABLE_MESSAGE` constant is preserved byte-for-byte as a substring.
- `installations.rs` / `extension_installation_store.rs` / `extension_lifecycle.rs`: new `ExtensionInstallationError::Backend { reason }` variant (mirrors the existing `CredentialStageError::Backend` / `ExtensionError::Filesystem` sibling pattern already in the same file), used only for the store's genuine I/O-failure branches. `map_extension_installation_error` now routes `Backend` to `ProductWorkflowError::Transient` (already correctly mapped downstream to `RuntimeDispatchErrorKind::OperationFailed` — no change needed there) instead of `InvalidBindingRequest`.

## Regression tests

- `extension_installation_store/tests.rs`: both the read-failure and rewrite-failure tests strengthened to assert the `Backend` variant explicitly (previously only checked a message substring shared by both the old and new variant — a real gap caught in review).
- `extension_lifecycle.rs`: 2 new unit tests directly on the production classifier `map_extension_installation_error` (`Backend` → `Transient`; everything else → `InvalidBindingRequest`).
- `slack_delivery.rs`: 2 new direct unit tests on `slack_auth_unavailable_notice` (no-provider fallback == blanket message; with-provider names it and never claims "reconnect"). The existing interactive (`blocked_auth_cancels_run_and_posts_unavailable_message`) and triggered (`triggered_non_oauth_auth_is_denied_without_gate_route`) BlockedAuth-deny tests extended to thread a manual-token credential requirement through the existing `ScriptedTurnCoordinator` fixture (additive field via struct-update syntax — the ~15 other existing callers are untouched) and assert the provider name appears in the posted Slack message.

## Coverage limitation (documented per repo testing rules)

No test drives `extension_activate` end-to-end through the real `FilesystemExtensionInstallationStore` with fault injection to the model-visible message — every existing lifecycle-capability test fixture in this file uses `InMemoryExtensionInstallationStore`, not the filesystem-backed store, so building that harness would require substantial new test infrastructure disproportionate to this fix. The two seams that chain together to produce the fix's effect (the store's error classification, and the classifier function that all ~20 real lifecycle-capability call sites route through) are each tested directly at the real production call site instead.

## Verification

```
cargo fmt --check
cargo clippy -p ironclaw_extensions -p ironclaw_reborn_composition --all-targets --features slack-v2-host-beta -- -D warnings
cargo test -p ironclaw_reborn_composition --lib --features slack-v2-host-beta slack_delivery   # 85 passed
cargo test -p ironclaw_reborn_composition --lib extension_host                                  # 196 passed
cargo test -p ironclaw_architecture                                                             # 34 passed
```

All green.

Closes #5884
Closes #5878