### PR TITLE
fix: serialize concurrent inbound-message writes per thread

### DIFF
--- a/crates/ironclaw_threads/src/filesystem_service.rs
+++ b/crates/ironclaw_threads/src/filesystem_service.rs
@@ -190,6 +190,33 @@ where
     thread_index_cache_epochs: Mutex<HashMap<String, u64>>,
     thread_index_manual_clear_epochs: Mutex<HashMap<String, u64>>,
     thread_index_load_locks: Mutex<HashMap<String, Weak<AsyncMutex<()>>>>,
+    // Issue #6047: on a backend without multi-key transaction support
+    // (`begin()` unimplemented — the production libSQL shape),
+    // `accept_inbound_message` falls back to a non-transactional
+    // reserve-sequence-then-write-message pair. Nothing else serializes
+    // concurrent callers against the same thread, so a message that
+    // reserves a *later* sequence number can still finish writing before
+    // an *earlier* one, making it durably visible out of order. This lock
+    // is acquired only around that reserve+write pair (not the best-effort
+    // index/cache work after it) and restores ordering without touching
+    // the already-safe transactional CAS-retry path.
+    //
+    // Process-local, deliberately: `.claude/rules/database.md` flags a
+    // process-local mutex held across backend I/O because it "cannot
+    // coordinate multiple processes." This crate's filesystem-backed
+    // services already run under a single mounted, single-owner view per
+    // instance (see the `with_fixed_view` boot-owner model used elsewhere
+    // in Reborn's runtime/thread-state services) — the deployment shape
+    // this lock needs to cover is one process per store, matching the
+    // pre-existing `thread_index_load_lock` singleflight lock in this same
+    // file, which has held its own cache-fill read under this exact
+    // mechanism since before this fix. A durable, cross-process ordering
+    // guarantee would need the write itself to become one atomic
+    // domain-level operation (e.g. gap-aware reads with a bounded recovery
+    // contract, or extending the transactional path to a backend that
+    // lacks multi-key transactions) — a materially larger change than this
+    // bug warrants; tracked as a follow-up rather than folded into this fix.
+    inbound_message_write_locks: Mutex<HashMap<String, Weak<AsyncMutex<()>>>>,
     known_thread_index_rows: Mutex<HashSet<String>>,
     known_thread_source_rows: Mutex<HashMap<String, HashSet<ThreadId>>>,
     complete_thread_source_scopes: Mutex<HashSet<String>>,
@@ -210,6 +237,7 @@ where
             thread_index_cache_epochs: Mutex::new(HashMap::new()),
             thread_index_manual_clear_epochs: Mutex::new(HashMap::new()),
             thread_index_load_locks: Mutex::new(HashMap::new()),
+            inbound_message_write_locks: Mutex::new(HashMap::new()),
             known_thread_index_rows: Mutex::new(HashSet::new()),
             known_thread_source_rows: Mutex::new(HashMap::new()),
             complete_thread_source_scopes: Mutex::new(HashSet::new()),
@@ -235,7 +263,7 @@ where
             messages: context_messages_with_summary_replacements(&messages, &[]),
         };
         if let Ok(mut cache) = self.one_shot_context_windows.lock() {
-            let key = one_shot_context_window_cache_key(scope, thread_id);
+            let key = thread_scope_key(scope, thread_id);
             cache.insert(key.clone(), context);
             evict_hash_map_entry_over_limit(
                 &mut cache,
@@ -251,7 +279,7 @@ where
         thread_id: &ThreadId,
         max_messages: usize,
     ) -> Option<ContextWindow> {
-        let key = one_shot_context_window_cache_key(scope, thread_id);
+        let key = thread_scope_key(scope, thread_id);
         let mut context = self.one_shot_context_windows.lock().ok()?.remove(&key)?;
         if max_messages < context.messages.len() {
             let start = context.messages.len() - max_messages;
@@ -262,8 +290,13 @@ where
 
     fn invalidate_one_shot_context_window(&self, scope: &ThreadScope, thread_id: &ThreadId) {
         if let Ok(mut cache) = self.one_shot_context_windows.lock() {
-            cache.remove(&one_shot_context_window_cache_key(scope, thread_id));
+            cache.remove(&thread_scope_key(scope, thread_id));
         }
+    }
+
+    /// See `inbound_message_write_locks` for why this exists.
+    fn inbound_message_write_lock(&self, key: &str) -> Arc<AsyncMutex<()>> {
+        weak_keyed_lock(&self.inbound_message_write_locks, key.to_string())
     }
 
     fn thread_entry(record: &StoredThreadRecord) -> Result<Entry, SessionThreadError> {
@@ -402,7 +435,14 @@ where
         }
     }
 
-    async fn write_new_message(
+    /// CAS-put just the message record itself (`CasExpectation::Absent`) —
+    /// the single step that determines when a message becomes visible to a
+    /// reader (`list_thread_messages` reads these records directly). This is
+    /// split out of `write_new_message` so the issue #6047 fallback-path
+    /// write lock in `accept_inbound_message` can cover only this
+    /// ordering-sensitive step, not the best-effort index/cache work that
+    /// follows it and doesn't affect visibility.
+    async fn put_new_message_record(
         &self,
         scope: &ThreadScope,
         thread_id: &ThreadId,
@@ -421,25 +461,44 @@ where
         )
         .await
         {
-            Ok(()) => {
-                self.write_message_sequence_index(scope, thread_id, message)
-                    .await?;
-                self.write_message_lookup_indexes_best_effort(
-                    scope,
-                    thread_id,
-                    message,
-                    "new message",
-                )
-                .await;
-                self.invalidate_one_shot_context_window(scope, thread_id);
-                Ok(())
-            }
+            Ok(()) => Ok(()),
             Err(PutError::VersionMismatch) => Err(SessionThreadError::Backend(format!(
                 "filesystem CAS Absent rejected new {description} at {}",
                 path.as_str()
             ))),
             Err(PutError::Other(error)) => Err(error),
         }
+    }
+
+    async fn write_new_message(
+        &self,
+        scope: &ThreadScope,
+        thread_id: &ThreadId,
+        message: &ThreadMessageRecord,
+        description: &'static str,
+    ) -> Result<(), SessionThreadError> {
+        self.put_new_message_record(scope, thread_id, message, description)
+            .await?;
+        self.finish_new_message_indexes(scope, thread_id, message)
+            .await
+    }
+
+    /// The best-effort index/cache work that follows a new message record's
+    /// CAS put — not ordering-sensitive, so callers that need the put itself
+    /// under a narrower critical section (the issue #6047 write lock in
+    /// `accept_inbound_message`) run this afterward, unlocked.
+    async fn finish_new_message_indexes(
+        &self,
+        scope: &ThreadScope,
+        thread_id: &ThreadId,
+        message: &ThreadMessageRecord,
+    ) -> Result<(), SessionThreadError> {
+        self.write_message_sequence_index(scope, thread_id, message)
+            .await?;
+        self.write_message_lookup_indexes_best_effort(scope, thread_id, message, "new message")
+            .await;
+        self.invalidate_one_shot_context_window(scope, thread_id);
+        Ok(())
     }
 
     async fn append_message_event(
@@ -1679,9 +1738,23 @@ where
                 return Ok(accepted);
             }
             TransactionalMessageWrite::Unsupported => {
-                let sequence = self.reserve_sequence(&scope, &thread_id).await?;
-                message.sequence = sequence;
-                self.write_new_message(&scope, &thread_id, &message, "message")
+                // Serialize only the ordering-sensitive step (reserve the
+                // sequence, then durably write the message record — the
+                // step that determines when a reader sees this message)
+                // against other concurrent callers for the same thread. See
+                // `inbound_message_write_locks` for why. Held across exactly
+                // two calls, not the best-effort index/cache work below,
+                // which doesn't affect visibility and doesn't need to wait.
+                {
+                    let write_lock =
+                        self.inbound_message_write_lock(&thread_scope_key(&scope, &thread_id));
+                    let _write_guard = write_lock.lock().await;
+                    let sequence = self.reserve_sequence(&scope, &thread_id).await?;
+                    message.sequence = sequence;
+                    self.put_new_message_record(&scope, &thread_id, &message, "message")
+                        .await?;
+                }
+                self.finish_new_message_indexes(&scope, &thread_id, &message)
                     .await?;
 
                 // Non-transactional backends keep the legacy best-effort
@@ -1697,7 +1770,7 @@ where
                         )
                         .await?;
                 }
-                sequence
+                message.sequence
             }
         };
 
@@ -3001,12 +3074,41 @@ fn thread_root_string(scope: &ThreadScope, thread_id: &ThreadId) -> String {
     base
 }
 
-fn one_shot_context_window_cache_key(scope: &ThreadScope, thread_id: &ThreadId) -> String {
+/// Stable per-thread identity string, shared by every cache/lock in this
+/// file keyed on "this one thread" (the one-shot context window cache, the
+/// inbound message write lock). Distinct from, and not interchangeable
+/// with, `thread_index.rs`'s `thread_index_record_cache_key` — that one
+/// keys the thread-index bookkeeping sets/maps and deliberately uses a
+/// different string shape (`thread_index_cache_key(scope) + thread_id`) for
+/// that subsystem.
+fn thread_scope_key(scope: &ThreadScope, thread_id: &ThreadId) -> String {
     format!(
         "{}:{}",
         scope.tenant_id.as_str(),
         thread_root_string(scope, thread_id)
     )
+}
+
+/// Get-or-create a weak-referenced per-key async lock. Callers hold the
+/// returned `Arc` for the duration of their critical section; once the last
+/// holder drops it, `retain` below reclaims the now-dead entry on the next
+/// lookup instead of leaking one lock per key forever.
+fn weak_keyed_lock(
+    locks: &Mutex<HashMap<String, Weak<AsyncMutex<()>>>>,
+    key: String,
+) -> Arc<AsyncMutex<()>> {
+    locks
+        .lock()
+        .map(|mut locks| {
+            locks.retain(|_, lock| lock.strong_count() > 0);
+            if let Some(lock) = locks.get(&key).and_then(|lock| lock.upgrade()) {
+                return lock;
+            }
+            let lock = Arc::new(AsyncMutex::new(()));
+            locks.insert(key, Arc::downgrade(&lock));
+            lock
+        })
+        .unwrap_or_else(|_| Arc::new(AsyncMutex::new(())))
 }
 
 fn evict_hash_map_entry_over_limit<T>(
@@ -3472,7 +3574,13 @@ impl From<FilesystemError> for SessionThreadError {
 
 #[cfg(test)]
 mod tests {
+    use std::{
+        collections::HashMap,
+        sync::{Mutex, Weak},
+    };
+
     use ironclaw_host_api::{AgentId, ProjectId, TenantId, UserId};
+    use tokio::sync::Mutex as AsyncMutex;
 
     use super::message_sequence_index::{sequence_from_index_filename, sequence_index_filename};
     use super::{InboundIdempotencyKey, idempotency_record_key};
@@ -3495,6 +3603,32 @@ mod tests {
             vec![1, 2, 10]
         );
         assert_eq!(sequence_from_index_filename("not-a-sequence.json"), None);
+    }
+
+    /// `weak_keyed_lock` backs both `thread_index_load_locks` and (issue
+    /// #6047) `inbound_message_write_locks`. Its `retain` reclaims a key's
+    /// entry once every `Arc` holder has dropped the guard — without this,
+    /// a long-running instance would accumulate one dead entry per distinct
+    /// thread/key ever seen, unboundedly.
+    #[tokio::test]
+    async fn weak_keyed_lock_reclaims_entry_after_guard_dropped() {
+        let locks: Mutex<HashMap<String, Weak<AsyncMutex<()>>>> = Mutex::new(HashMap::new());
+
+        let first = super::weak_keyed_lock(&locks, "a".to_string());
+        drop(first);
+        assert_eq!(
+            locks.lock().unwrap().len(),
+            1,
+            "not yet reclaimed — no lookup happened"
+        );
+
+        let _second = super::weak_keyed_lock(&locks, "b".to_string());
+        assert_eq!(
+            locks.lock().unwrap().len(),
+            1,
+            "the dead \"a\" entry must be reclaimed on the next lookup, leaving only \"b\""
+        );
+        assert!(locks.lock().unwrap().contains_key("b"));
     }
 
     #[test]

--- a/crates/ironclaw_threads/src/filesystem_service.rs
+++ b/crates/ironclaw_threads/src/filesystem_service.rs
@@ -216,6 +216,18 @@ where
     // contract, or extending the transactional path to a backend that
     // lacks multi-key transactions) — a materially larger change than this
     // bug warrants; tracked as a follow-up rather than folded into this fix.
+    //
+    // This registry lives on the service struct, not on the backend/
+    // filesystem it wraps — so the ordering guarantee above additionally
+    // assumes exactly one `FilesystemSessionThreadService` is ever live for
+    // a given backend at a time. `ironclaw_reborn_composition`'s factory
+    // wiring constructs this service once per store graph at boot, but that
+    // wiring also has a "reopen" code path for rebuilding a store graph
+    // mid-process — whether that path can produce a second live instance
+    // overlapping with in-flight calls on the old one is not yet verified.
+    // If it can, this registry needs to move into shared backend state
+    // instead of living here. Tracked as a follow-up, not re-litigated by
+    // this comment alone.
     inbound_message_write_locks: Mutex<HashMap<String, Weak<AsyncMutex<()>>>>,
     known_thread_index_rows: Mutex<HashSet<String>>,
     known_thread_source_rows: Mutex<HashMap<String, HashSet<ThreadId>>>,
@@ -3081,34 +3093,41 @@ fn thread_root_string(scope: &ThreadScope, thread_id: &ThreadId) -> String {
 /// keys the thread-index bookkeeping sets/maps and deliberately uses a
 /// different string shape (`thread_index_cache_key(scope) + thread_id`) for
 /// that subsystem.
+///
+/// Length-prefixed so the encoding is injective: a plain `"{tenant}:{root}"`
+/// concatenation would let a `:` inside `tenant` collide with the delimiter
+/// (e.g. tenant `"a:b"` + root `"c"` vs. tenant `"a"` + root `"b:c"`), which
+/// would let one thread's cache entry or write lock be served under another
+/// thread's key. Prefixing each component with its byte length removes any
+/// delimiter-placement ambiguity regardless of what characters appear inside
+/// the components.
 fn thread_scope_key(scope: &ThreadScope, thread_id: &ThreadId) -> String {
-    format!(
-        "{}:{}",
-        scope.tenant_id.as_str(),
-        thread_root_string(scope, thread_id)
-    )
+    let tenant = scope.tenant_id.as_str();
+    let root = thread_root_string(scope, thread_id);
+    format!("{}:{tenant}:{}:{root}", tenant.len(), root.len())
 }
 
 /// Get-or-create a weak-referenced per-key async lock. Callers hold the
 /// returned `Arc` for the duration of their critical section; once the last
-/// holder drops it, `retain` below reclaims the now-dead entry on the next
-/// lookup instead of leaking one lock per key forever.
+/// holder drops it, `retain` reclaims the now-dead entry the next time this
+/// key misses, instead of leaking one lock per key forever. The live-key hit
+/// path skips `retain` so repeated lookups for the same in-use key (the
+/// common case on this now-hot path) stay O(1) rather than rescanning the
+/// whole map.
 fn weak_keyed_lock(
     locks: &Mutex<HashMap<String, Weak<AsyncMutex<()>>>>,
     key: String,
 ) -> Arc<AsyncMutex<()>> {
-    locks
+    let mut locks = locks
         .lock()
-        .map(|mut locks| {
-            locks.retain(|_, lock| lock.strong_count() > 0);
-            if let Some(lock) = locks.get(&key).and_then(|lock| lock.upgrade()) {
-                return lock;
-            }
-            let lock = Arc::new(AsyncMutex::new(()));
-            locks.insert(key, Arc::downgrade(&lock));
-            lock
-        })
-        .unwrap_or_else(|_| Arc::new(AsyncMutex::new(())))
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if let Some(lock) = locks.get(&key).and_then(|lock| lock.upgrade()) {
+        return lock;
+    }
+    locks.retain(|_, lock| lock.strong_count() > 0);
+    let lock = Arc::new(AsyncMutex::new(()));
+    locks.insert(key, Arc::downgrade(&lock));
+    lock
 }
 
 fn evict_hash_map_entry_over_limit<T>(
@@ -3583,7 +3602,7 @@ mod tests {
     use tokio::sync::Mutex as AsyncMutex;
 
     use super::message_sequence_index::{sequence_from_index_filename, sequence_index_filename};
-    use super::{InboundIdempotencyKey, idempotency_record_key};
+    use super::{InboundIdempotencyKey, idempotency_record_key, thread_scope_key};
     use crate::ThreadScope;
 
     #[test]
@@ -3649,6 +3668,39 @@ mod tests {
 
         assert!(record_key.starts_with("sha256-"));
         assert_eq!(record_key.len(), "sha256-".len() + 64);
+    }
+
+    /// `thread_scope_key` must stay injective in `(tenant, thread_root)` even
+    /// though `validate_scope_id` allows `:` inside scope ids (it only
+    /// forbids `/`, `\`, and control characters). A plain
+    /// `"{tenant}:{root}"` join is ambiguous once a `:` can appear inside a
+    /// component and land on the delimiter; length-prefixing each component
+    /// removes that ambiguity. These two pairs redistribute a `:` across the
+    /// tenant/agent-id boundary and must still produce distinct keys.
+    #[test]
+    fn thread_scope_key_is_injective_when_ids_contain_the_delimiter_char() {
+        use ironclaw_host_api::ThreadId;
+
+        let scope_a = ThreadScope {
+            tenant_id: TenantId::new("a:b").unwrap(),
+            agent_id: AgentId::new("c").unwrap(),
+            project_id: None,
+            owner_user_id: None,
+            mission_id: None,
+        };
+        let scope_b = ThreadScope {
+            tenant_id: TenantId::new("a").unwrap(),
+            agent_id: AgentId::new("b:c").unwrap(),
+            project_id: None,
+            owner_user_id: None,
+            mission_id: None,
+        };
+        let thread_id = ThreadId::new("d").unwrap();
+
+        assert_ne!(
+            thread_scope_key(&scope_a, &thread_id),
+            thread_scope_key(&scope_b, &thread_id),
+        );
     }
 
     /// Migration safety: a thread that already assigned message sequences under

--- a/crates/ironclaw_threads/src/filesystem_service/thread_index.rs
+++ b/crates/ironclaw_threads/src/filesystem_service/thread_index.rs
@@ -15,7 +15,7 @@ use crate::{FilesystemSessionThreadService, SessionThreadError, SessionThreadRec
 
 use super::{
     LIST_THREADS_MISSING_INDEX_READ_CONCURRENCY, StoredThreadRecord, deserialize, invalid_path,
-    is_not_found, map_cas_error, scope_axes_string, scoped_path, serialize_pretty,
+    is_not_found, map_cas_error, scope_axes_string, scoped_path, serialize_pretty, weak_keyed_lock,
 };
 
 const THREAD_INDEX_KIND: &str = "thread_index";
@@ -495,18 +495,7 @@ where
     }
 
     fn thread_index_load_lock(&self, key: &str) -> Arc<tokio::sync::Mutex<()>> {
-        self.thread_index_load_locks
-            .lock()
-            .map(|mut locks| {
-                locks.retain(|_, lock| lock.strong_count() > 0);
-                if let Some(lock) = locks.get(key).and_then(|lock| lock.upgrade()) {
-                    return lock;
-                }
-                let lock = Arc::new(tokio::sync::Mutex::new(()));
-                locks.insert(key.to_string(), Arc::downgrade(&lock));
-                lock
-            })
-            .unwrap_or_else(|_| Arc::new(tokio::sync::Mutex::new(())))
+        weak_keyed_lock(&self.thread_index_load_locks, key.to_string())
     }
 
     async fn thread_source_listing_for_index_load(

--- a/crates/ironclaw_threads/tests/filesystem_session_thread_contract.rs
+++ b/crates/ironclaw_threads/tests/filesystem_session_thread_contract.rs
@@ -471,6 +471,84 @@ async fn filesystem_accept_inbound_message_write_lock_releases_after_failed_writ
     );
 }
 
+/// PR #6096 review gap: the non-transactional fallback's sequence-index
+/// write (`finish_new_message_indexes` -> `write_message_sequence_index`)
+/// runs *after* `put_new_message_record` succeeds and *after* the issue
+/// #6047 per-thread write lock in `accept_inbound_message` has already been
+/// released (see the `{ ... }` block scoping the lock in
+/// `filesystem_service.rs::accept_inbound_message`). That's the opposite of
+/// `filesystem_accept_inbound_message_write_lock_releases_after_failed_write`
+/// above, which fails *inside* the lock. This test proves both halves for
+/// the outside-the-lock failure: the caller still gets the error, and —
+/// because the lock was already released before the sequence-index write
+/// ran — a subsequent call to the SAME thread is not blocked behind it.
+#[tokio::test]
+async fn filesystem_accept_inbound_message_sequence_index_failure_releases_lock() {
+    let backend = Arc::new(SequenceOrderRaceBackend::new());
+    let scoped = scoped_threads_fs_at(Arc::clone(&backend), "tenant-seq-index-fail", "alice");
+    let service = Arc::new(FilesystemSessionThreadService::new(scoped));
+    let scope = scope("fs-seq-index-fail");
+    let thread = service
+        .ensure_thread(EnsureThreadRequest {
+            scope: scope.clone(),
+            thread_id: Some(ThreadId::new("thread-fs-seq-index-fail").unwrap()),
+            created_by_actor_id: "actor-a".into(),
+            title: None,
+            metadata_json: None,
+        })
+        .await
+        .unwrap();
+
+    backend
+        .fail_next_sequence_index_write
+        .store(true, Ordering::SeqCst);
+
+    let first = service
+        .accept_inbound_message(AcceptInboundMessageRequest {
+            scope: scope.clone(),
+            thread_id: thread.thread_id.clone(),
+            actor_id: "actor-a".into(),
+            source_binding_id: None,
+            reply_target_binding_id: None,
+            external_event_id: None,
+            content: MessageContent::text(
+                "message record write succeeds, sequence index write fails",
+            ),
+        })
+        .await;
+    assert!(
+        first.is_err(),
+        "the injected sequence-index write failure must propagate to the caller even though \
+         the message record itself was already durably written"
+    );
+
+    // The write lock releases before `finish_new_message_indexes` runs, so
+    // this call must not be blocked behind the first call's failure.
+    let second = tokio::time::timeout(
+        std::time::Duration::from_millis(500),
+        service.accept_inbound_message(AcceptInboundMessageRequest {
+            scope: scope.clone(),
+            thread_id: thread.thread_id.clone(),
+            actor_id: "actor-a".into(),
+            source_binding_id: None,
+            reply_target_binding_id: None,
+            external_event_id: None,
+            content: MessageContent::text("second message"),
+        }),
+    )
+    .await
+    .expect(
+        "REGRESSION: the sequence-index failure happens after the write lock is released, so \
+         a subsequent call to the same thread must not hang",
+    )
+    .expect("second call succeeds");
+    assert_eq!(
+        second.sequence, 2,
+        "sequence 1 was reserved by the first attempt, whose message record was written \
+         durably before its sequence-index write failed"
+    );
+}
+
 /// Issue #6047: the per-thread write lock must be scoped per `(scope,
 /// thread_id)`, not globally or per-tenant. A regression that widened the
 /// lock's key (e.g. to the scope alone) would serialize unrelated threads'
@@ -3513,12 +3591,16 @@ impl FailOnceThreadRecordReadBackend {
 /// sequence number and is now stalled on the write). A `put` whose body
 /// contains `FAIL-MARKER` instead fails immediately with a backend error —
 /// used to prove the write lock releases via RAII even when the guarded
-/// write errors out.
+/// write errors out. Setting `fail_next_sequence_index_write` makes the
+/// *next* `put` to a `messages_by_sequence` index path fail once (then
+/// auto-clears) — used to prove the same for a failure that lands after the
+/// write lock has already been released.
 struct SequenceOrderRaceBackend {
     inner: InMemoryBackend,
     a_reserved: Notify,
     release_a: Notify,
     a_reserve_seen: AtomicBool,
+    fail_next_sequence_index_write: AtomicBool,
 }
 
 impl SequenceOrderRaceBackend {
@@ -3528,11 +3610,16 @@ impl SequenceOrderRaceBackend {
             a_reserved: Notify::new(),
             release_a: Notify::new(),
             a_reserve_seen: AtomicBool::new(false),
+            fail_next_sequence_index_write: AtomicBool::new(false),
         }
     }
 
     fn is_message_record_path(path: &VirtualPath) -> bool {
         path.as_str().contains("/messages/") && path.as_str().ends_with(".json")
+    }
+
+    fn is_message_sequence_index_path(path: &VirtualPath) -> bool {
+        path.as_str().contains("/messages_by_sequence/") && path.as_str().ends_with(".json")
     }
 }
 
@@ -3551,6 +3638,19 @@ impl RootFilesystem for SequenceOrderRaceBackend {
         entry: Entry,
         cas: CasExpectation,
     ) -> Result<RecordVersion, FilesystemError> {
+        if Self::is_message_sequence_index_path(path)
+            && self
+                .fail_next_sequence_index_write
+                .swap(false, Ordering::SeqCst)
+        {
+            return Err(FilesystemError::Backend {
+                path: path.clone(),
+                operation: FilesystemOperation::WriteFile,
+                reason: "injected failure for issue #6047 sequence-index lock-release \
+                         regression test"
+                    .to_string(),
+            });
+        }
         if Self::is_message_record_path(path) {
             let contains = |marker: &[u8]| {
                 entry

--- a/crates/ironclaw_threads/tests/filesystem_session_thread_contract.rs
+++ b/crates/ironclaw_threads/tests/filesystem_session_thread_contract.rs
@@ -40,7 +40,7 @@ use ironclaw_threads::{
     SummaryModelContextPolicy, ThreadHistoryRequest, ThreadScope, ToolResultSafeSummary,
     UpdateAssistantDraftRequest,
 };
-use tokio::sync::{Barrier, Mutex, OwnedMutexGuard};
+use tokio::sync::{Barrier, Mutex, Notify, OwnedMutexGuard};
 
 #[tokio::test]
 async fn filesystem_delete_thread_removes_owned_thread_and_hides_missing_or_wrong_scope() {
@@ -259,6 +259,299 @@ async fn filesystem_concurrent_duplicate_tool_result_writes_converge() {
         .expect("converged record exists");
     assert_eq!(stored.content, content);
     assert!(stored.next_offset.is_none());
+}
+
+/// Issue #6047: two `accept_inbound_message` calls for the SAME thread raced
+/// on a backend without multi-key transaction support (`begin()` returns
+/// `Unsupported` — this is the shape of the production libSQL backend, see
+/// `crates/ironclaw_filesystem/src/libsql.rs` which has no `begin` override).
+/// On that path `accept_inbound_message` reserves a sequence number and then
+/// writes the message record as two *separate* steps
+/// (`filesystem_service.rs::accept_inbound_message`, the
+/// `TransactionalMessageWrite::Unsupported` arm). Before the fix, nothing
+/// serialized two concurrent callers against the same `(scope, thread_id)`:
+/// the message that reserved the LOWER sequence (called first) could still
+/// be sitting in its `write_new_message` step while a message that reserved
+/// a HIGHER sequence (called second) finished first and became durably
+/// visible — a later message rendered/acted on ahead of an earlier one
+/// (issue #6047).
+///
+/// This test drives message A into that same blocked-mid-write state and
+/// then submits message B concurrently. The fix's invariant: B must not
+/// reserve a sequence or become visible while A — called first — still
+/// holds the per-thread write lock. B only proceeds once A's write
+/// completes and releases it, so the two calls settle in call order.
+#[tokio::test]
+async fn filesystem_accept_inbound_message_serializes_concurrent_calls_for_same_thread() {
+    let backend = Arc::new(SequenceOrderRaceBackend::new());
+    let scoped = scoped_threads_fs_at(Arc::clone(&backend), "tenant-seq-race", "alice");
+    let service = Arc::new(FilesystemSessionThreadService::new(scoped));
+    let scope = scope("fs-seq-race");
+    let thread = service
+        .ensure_thread(EnsureThreadRequest {
+            scope: scope.clone(),
+            thread_id: Some(ThreadId::new("thread-fs-seq-race").unwrap()),
+            created_by_actor_id: "actor-a".into(),
+            title: None,
+            metadata_json: None,
+        })
+        .await
+        .unwrap();
+
+    let task_a = {
+        let service = Arc::clone(&service);
+        let scope = scope.clone();
+        let thread_id = thread.thread_id.clone();
+        tokio::spawn(async move {
+            service
+                .accept_inbound_message(AcceptInboundMessageRequest {
+                    scope,
+                    thread_id,
+                    actor_id: "actor-a".into(),
+                    source_binding_id: None,
+                    reply_target_binding_id: None,
+                    external_event_id: None,
+                    content: MessageContent::text(
+                        "check my recent emails and add near.ai senders to Sheet ABC \
+                         RACE-MARKER-A"
+                            .to_string(),
+                    ),
+                })
+                .await
+        })
+    };
+
+    // Wait until message A has reserved its (lower) sequence number and is
+    // now blocked inside its own `put` — i.e. A was unambiguously "first"
+    // and is holding the fix's per-thread write lock.
+    backend.a_reserved.notified().await;
+
+    let mut task_b = {
+        let service = Arc::clone(&service);
+        let scope = scope.clone();
+        let thread_id = thread.thread_id.clone();
+        tokio::spawn(async move {
+            service
+                .accept_inbound_message(AcceptInboundMessageRequest {
+                    scope,
+                    thread_id,
+                    actor_id: "actor-a".into(),
+                    source_binding_id: None,
+                    reply_target_binding_id: None,
+                    external_event_id: None,
+                    content: MessageContent::text(
+                        "every 30 minutes check my inbox and add near.ai senders RACE-MARKER-B"
+                            .to_string(),
+                    ),
+                })
+                .await
+        })
+    };
+
+    // REGRESSION (#6047) check: B (called second) must not be able to
+    // complete — i.e. reserve a sequence and become durable — while A
+    // (called first) is still parked mid-write. Pre-fix, B raced ahead and
+    // finished here; post-fix, B blocks on A's held write lock.
+    let raced_ahead = tokio::time::timeout(std::time::Duration::from_millis(200), &mut task_b)
+        .await
+        .is_ok();
+    assert!(
+        !raced_ahead,
+        "REGRESSION (#6047): message B (called second) completed while message A \
+         (called first) was still mid-write — a later message became durable \
+         ahead of an earlier one instead of waiting its turn"
+    );
+
+    let mid_race = service
+        .list_thread_history(ThreadHistoryRequest {
+            scope: scope.clone(),
+            thread_id: thread.thread_id.clone(),
+        })
+        .await
+        .expect("mid-race history read succeeds");
+    assert!(
+        mid_race.messages.is_empty(),
+        "neither message should be durably visible yet — A is still mid-write and B is \
+         blocked behind it, got {:?}",
+        mid_race.messages
+    );
+
+    // Release A's blocked write and let both calls settle.
+    backend.release_a.notify_one();
+    let accepted_a = task_a
+        .await
+        .expect("task A join")
+        .expect("first call completes");
+    assert_eq!(
+        accepted_a.sequence, 1,
+        "A reserved the lower sequence number"
+    );
+    let accepted_b = task_b
+        .await
+        .expect("task B join")
+        .expect("second call completes once A releases the write lock");
+    assert_eq!(
+        accepted_b.sequence, 2,
+        "B reserves the higher sequence number only after A settles"
+    );
+
+    let settled = service
+        .list_thread_history(ThreadHistoryRequest {
+            scope,
+            thread_id: thread.thread_id.clone(),
+        })
+        .await
+        .expect("settled history read succeeds");
+    assert_eq!(settled.messages.len(), 2);
+    assert_eq!(settled.messages[0].sequence, 1);
+    assert_eq!(settled.messages[1].sequence, 2);
+}
+
+/// Issue #6047 regression: the per-thread write lock guarding the
+/// non-transactional fallback (`inbound_message_write_locks`) must release
+/// via RAII even when the guarded write fails, or every subsequent inbound
+/// message to that thread would hang forever behind the never-released
+/// lock — the same class of production wedge this fix exists to prevent.
+#[tokio::test]
+async fn filesystem_accept_inbound_message_write_lock_releases_after_failed_write() {
+    let backend = Arc::new(SequenceOrderRaceBackend::new());
+    let scoped = scoped_threads_fs_at(Arc::clone(&backend), "tenant-lock-release", "alice");
+    let service = Arc::new(FilesystemSessionThreadService::new(scoped));
+    let scope = scope("fs-lock-release");
+    let thread = service
+        .ensure_thread(EnsureThreadRequest {
+            scope: scope.clone(),
+            thread_id: Some(ThreadId::new("thread-fs-lock-release").unwrap()),
+            created_by_actor_id: "actor-a".into(),
+            title: None,
+            metadata_json: None,
+        })
+        .await
+        .unwrap();
+
+    let first = service
+        .accept_inbound_message(AcceptInboundMessageRequest {
+            scope: scope.clone(),
+            thread_id: thread.thread_id.clone(),
+            actor_id: "actor-a".into(),
+            source_binding_id: None,
+            reply_target_binding_id: None,
+            external_event_id: None,
+            content: MessageContent::text("this write is engineered to fail FAIL-MARKER"),
+        })
+        .await;
+    assert!(
+        first.is_err(),
+        "the injected backend failure must propagate to the caller"
+    );
+
+    // If the write-lock guard leaked on the error path above, this call
+    // would hang forever waiting on a lock nobody releases.
+    let second = tokio::time::timeout(
+        std::time::Duration::from_millis(500),
+        service.accept_inbound_message(AcceptInboundMessageRequest {
+            scope: scope.clone(),
+            thread_id: thread.thread_id.clone(),
+            actor_id: "actor-a".into(),
+            source_binding_id: None,
+            reply_target_binding_id: None,
+            external_event_id: None,
+            content: MessageContent::text("second message"),
+        }),
+    )
+    .await
+    .expect(
+        "REGRESSION (#6047): write lock was not released after the first call's write \
+         failed — a subsequent call to the same thread hung",
+    )
+    .expect("second call succeeds");
+    assert_eq!(
+        second.sequence, 2,
+        "sequence 1 was reserved-then-burned by the first attempt's failed write"
+    );
+}
+
+/// Issue #6047: the per-thread write lock must be scoped per `(scope,
+/// thread_id)`, not globally or per-tenant. A regression that widened the
+/// lock's key (e.g. to the scope alone) would serialize unrelated threads'
+/// inbound messages against each other — a throughput regression this test
+/// guards against by proving two different threads never block each other.
+#[tokio::test]
+async fn filesystem_accept_inbound_message_does_not_serialize_across_different_threads() {
+    let backend = Arc::new(SequenceOrderRaceBackend::new());
+    let scoped = scoped_threads_fs_at(Arc::clone(&backend), "tenant-cross-thread", "alice");
+    let service = Arc::new(FilesystemSessionThreadService::new(scoped));
+    let scope = scope("fs-cross-thread");
+    let thread_a = service
+        .ensure_thread(EnsureThreadRequest {
+            scope: scope.clone(),
+            thread_id: Some(ThreadId::new("thread-cross-a").unwrap()),
+            created_by_actor_id: "actor-a".into(),
+            title: None,
+            metadata_json: None,
+        })
+        .await
+        .unwrap();
+    let thread_b = service
+        .ensure_thread(EnsureThreadRequest {
+            scope: scope.clone(),
+            thread_id: Some(ThreadId::new("thread-cross-b").unwrap()),
+            created_by_actor_id: "actor-a".into(),
+            title: None,
+            metadata_json: None,
+        })
+        .await
+        .unwrap();
+
+    let task_a = {
+        let service = Arc::clone(&service);
+        let scope = scope.clone();
+        let thread_id = thread_a.thread_id.clone();
+        tokio::spawn(async move {
+            service
+                .accept_inbound_message(AcceptInboundMessageRequest {
+                    scope,
+                    thread_id,
+                    actor_id: "actor-a".into(),
+                    source_binding_id: None,
+                    reply_target_binding_id: None,
+                    external_event_id: None,
+                    content: MessageContent::text("message to thread A RACE-MARKER-A".to_string()),
+                })
+                .await
+        })
+    };
+
+    // Wait until A is parked mid-write, holding thread A's write lock.
+    backend.a_reserved.notified().await;
+
+    // A message to a DIFFERENT thread must not wait behind A's lock.
+    let accepted_b = tokio::time::timeout(
+        std::time::Duration::from_millis(500),
+        service.accept_inbound_message(AcceptInboundMessageRequest {
+            scope: scope.clone(),
+            thread_id: thread_b.thread_id.clone(),
+            actor_id: "actor-a".into(),
+            source_binding_id: None,
+            reply_target_binding_id: None,
+            external_event_id: None,
+            content: MessageContent::text("message to thread B".to_string()),
+        }),
+    )
+    .await
+    .expect(
+        "REGRESSION: message to a different thread blocked behind another thread's write lock \
+         — the lock key must be scoped per-thread, not globally",
+    )
+    .expect("thread B's message completes");
+    assert_eq!(accepted_b.sequence, 1);
+
+    backend.release_a.notify_one();
+    let accepted_a = task_a
+        .await
+        .expect("task A join")
+        .expect("thread A's message completes once released");
+    assert_eq!(accepted_a.sequence, 1);
 }
 
 #[tokio::test]
@@ -3203,6 +3496,115 @@ impl FailOnceThreadRecordReadBackend {
     fn is_target_thread_record_path(&self, path: &VirtualPath) -> bool {
         path.as_str()
             .contains(&format!("/threads/{}/thread.json", self.thread_id))
+    }
+}
+
+/// Backend deliberately without a `begin()` override, so `RootFilesystem`'s
+/// default impl returns `Unsupported` — matching the production libSQL
+/// backend (`crates/ironclaw_filesystem/src/libsql.rs`), which has no
+/// multi-key transaction support. This forces
+/// `try_write_new_message_transactionally` into its non-transactional
+/// fallback (reserve sequence, then write the message record as a separate
+/// `put`), which is the path issue #6047 targets.
+///
+/// The first `put` of a message record whose body contains `RACE-MARKER-A`
+/// blocks on `release_a` until the test explicitly releases it, after first
+/// signaling `a_reserved` (so the test knows A already reserved its
+/// sequence number and is now stalled on the write). A `put` whose body
+/// contains `FAIL-MARKER` instead fails immediately with a backend error —
+/// used to prove the write lock releases via RAII even when the guarded
+/// write errors out.
+struct SequenceOrderRaceBackend {
+    inner: InMemoryBackend,
+    a_reserved: Notify,
+    release_a: Notify,
+    a_reserve_seen: AtomicBool,
+}
+
+impl SequenceOrderRaceBackend {
+    fn new() -> Self {
+        Self {
+            inner: InMemoryBackend::new(),
+            a_reserved: Notify::new(),
+            release_a: Notify::new(),
+            a_reserve_seen: AtomicBool::new(false),
+        }
+    }
+
+    fn is_message_record_path(path: &VirtualPath) -> bool {
+        path.as_str().contains("/messages/") && path.as_str().ends_with(".json")
+    }
+}
+
+#[async_trait]
+impl RootFilesystem for SequenceOrderRaceBackend {
+    fn capabilities(&self) -> BackendCapabilities {
+        // Report CAS-only support (no `TxnCapability::MultiKey`); combined
+        // with not overriding `begin()`, this mirrors the libSQL backend's
+        // shape for the purposes of this test.
+        self.inner.capabilities()
+    }
+
+    async fn put(
+        &self,
+        path: &VirtualPath,
+        entry: Entry,
+        cas: CasExpectation,
+    ) -> Result<RecordVersion, FilesystemError> {
+        if Self::is_message_record_path(path) {
+            let contains = |marker: &[u8]| {
+                entry
+                    .body
+                    .windows(marker.len())
+                    .any(|window| window == marker)
+            };
+            if contains(b"FAIL-MARKER") {
+                return Err(FilesystemError::Backend {
+                    path: path.clone(),
+                    operation: FilesystemOperation::WriteFile,
+                    reason: "injected failure for issue #6047 lock-release regression test"
+                        .to_string(),
+                });
+            }
+            let is_a = contains(b"RACE-MARKER-A");
+            let is_b = contains(b"RACE-MARKER-B");
+            if is_a && !self.a_reserve_seen.swap(true, Ordering::SeqCst) {
+                self.a_reserved.notify_one();
+                self.release_a.notified().await;
+            } else if is_b {
+                // Let B's write land first; A is (or will be) parked above.
+            }
+        }
+        self.inner.put(path, entry, cas).await
+    }
+
+    async fn get(&self, path: &VirtualPath) -> Result<Option<VersionedEntry>, FilesystemError> {
+        self.inner.get(path).await
+    }
+
+    async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
+        self.inner.list_dir(path).await
+    }
+
+    async fn query(
+        &self,
+        path: &VirtualPath,
+        filter: &Filter,
+        page: Page,
+    ) -> Result<Vec<VersionedEntry>, FilesystemError> {
+        self.inner.query(path, filter, page).await
+    }
+
+    async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
+        self.inner.stat(path).await
+    }
+
+    async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
+        self.inner.delete(path).await
+    }
+
+    async fn reserve_sequence(&self, path: &VirtualPath) -> Result<SeqNo, FilesystemError> {
+        self.inner.reserve_sequence(path).await
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #6047 — two chat messages sent in quick succession to the same thread could be persisted, displayed, and acted on out of chronological order.

## Verified bug

Reproduced with a failing test on `origin/main` @ `d68073336` (before this fix), and confirmed the fix turns it green:

```
cargo test -p ironclaw_threads --test filesystem_session_thread_contract \
  filesystem_accept_inbound_message_serializes_concurrent_calls_for_same_thread -- --nocapture
```

## Root cause

`FilesystemSessionThreadService::accept_inbound_message` (`crates/ironclaw_threads/src/filesystem_service.rs`) falls back to a non-transactional path on backends without multi-key transaction support — this is the shape of the production libSQL backend (`crates/ironclaw_filesystem/src/libsql.rs` has no `begin()` override). On that path, the function:

1. reserves a sequence number, then
2. writes the message record as a **separate**, unsynchronized `put`.

Nothing serialized two concurrent `accept_inbound_message` calls against the same thread, so a message that reserved a *later* sequence number could finish its write before a message that reserved an *earlier* one — making the later message durably visible (and readable by the UI/agent) ahead of the earlier one. The transactional path (backends with `begin()` support) is unaffected: its CAS-retry loop commits reserve+write atomically, and a losing writer retries into a fresh, strictly-later sequence number rather than reusing a stale one.

## Fix

- Added a per-`(scope, thread_id)` in-process async lock, held only around the ordering-sensitive step (`reserve_sequence` + a new `put_new_message_record` — just the message-record CAS put), not the best-effort sequence-index/lookup-index/cache work that follows it.
- Split `write_new_message` into `put_new_message_record` (the CAS put) and `finish_new_message_indexes` (the rest), so both the lock-guarded fallback path and `write_new_message`'s three other callers share the same code with no duplication.
- Extracted a shared `weak_keyed_lock` helper (get-or-create a weak-referenced per-key async lock) used by both the new lock and the pre-existing `thread_index_load_lock` singleflight cache-fill lock in the same file, instead of duplicating that logic.
- Renamed `one_shot_context_window_cache_key` → `thread_scope_key` since it's now shared by two call sites, with a doc comment distinguishing it from the differently-shaped `thread_index_record_cache_key` in the neighboring module.
- The lock is process-local by design — this crate's filesystem-backed services run under a single mounted, single-owner view per instance (matching the `with_fixed_view` boot-owner model used elsewhere in Reborn), and the pre-existing `thread_index_load_lock` already relies on the same mechanism. A durable cross-process ordering guarantee would need the write itself to become one atomic domain-level operation (gap-aware reads with a bounded recovery contract, or transactional support on backends that lack it) — a materially larger change tracked as a follow-up, not folded into this fix.

## Regression tests

All in `crates/ironclaw_threads/tests/filesystem_session_thread_contract.rs`:

- `filesystem_accept_inbound_message_serializes_concurrent_calls_for_same_thread` — the core proof: message B (called second) must not reserve a sequence or become visible while message A (called first) is still mid-write.
- `filesystem_accept_inbound_message_write_lock_releases_after_failed_write` — the lock releases via RAII even when the guarded write errors, so a subsequent call to the same thread doesn't hang forever.
- `filesystem_accept_inbound_message_does_not_serialize_across_different_threads` — the lock is scoped per-thread, not globally/per-tenant; unrelated threads never block each other.
- `weak_keyed_lock_reclaims_entry_after_guard_dropped` (inline unit test) — the shared lock registry doesn't leak an entry per distinct key forever.

## Verification

```
cargo test -p ironclaw_threads       # 78+8+49+56 = 191 passed, 0 failed
cargo clippy -p ironclaw_threads --tests --all-features   # clean
cargo fmt --check -p ironclaw_threads                      # clean
```

## Review

Went through an 8-agent code review + two thermo-nuclear maintainability passes (plan and final diff). Findings addressed: narrowed the lock's critical section (was originally wider), fixed a lock-accessor signature inconsistency, disambiguated the renamed cache-key helper from a same-purpose-but-different-shape sibling, and added the two missing regression tests above. Security, bugs, maintainability, and approach reviewers returned zero findings.

## Deferred (out of scope for this fix)

- A structurally similar TOCTOU exists between `accept_inbound_message` (durable, sequenced) and `submit_turn`'s busy-check in `crates/ironclaw_product_workflow/src/inbound_turn.rs` — a second message can win the "claim the active run" race ahead of an earlier-accepted one. Bigger lift (touches `ironclaw_turns`' `TurnActiveLockKey` machinery); flagging for a follow-up issue rather than folding into this PR.
- `append_assistant_draft` and `append_finalized_assistant_message` use the same reserve-then-write two-step pattern for assistant messages on the same thread — out of scope since #6047 specifically reports user-submitted messages, but worth a maintainer's awareness.