### PR TITLE
perf(threads): raise result_read preview cap 2KB -> 2.75KB

### DIFF
--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -5403,7 +5403,13 @@ output_schema_ref = "schemas/write.output.json"
     const LARGE_ECHO_TAIL: &str = "UNREPLAYED_RAW_TOOL_RESULT_TAIL";
 
     fn large_echo_message() -> String {
-        format!("{}{}", LARGE_ECHO_MESSAGE.repeat(100), LARGE_ECHO_TAIL)
+        // The repeated prefix alone must clearly exceed the result-preview
+        // cap so truncation always lands inside it, well before
+        // `LARGE_ECHO_TAIL` — otherwise the tail (which must never appear in
+        // the model replay) would fit inside an untruncated preview.
+        let cap = ironclaw_threads::TOOL_RESULT_RECORD_READ_MAX_BYTES;
+        let repeats = cap / LARGE_ECHO_MESSAGE.len() + 20;
+        format!("{}{}", LARGE_ECHO_MESSAGE.repeat(repeats), LARGE_ECHO_TAIL)
     }
 
     #[derive(Debug, Default)]

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/tests.rs
@@ -1348,17 +1348,15 @@ mod tests {
         let input_resolver: Arc<dyn LoopCapabilityInputResolver> = capability_io.clone();
         let result_writer: Arc<dyn LoopCapabilityResultWriter> = capability_io.clone();
 
-        // A multi-byte character straddling the 2048-byte preview boundary:
-        // the serialized JSON string (leading `"` + 2046 ASCII bytes) puts the
-        // 3-byte '日' character at bytes [2047, 2050), so byte 2048 (the raw
-        // cap) falls inside it and must round down.
-        let content = format!("{}{}{}", "a".repeat(2046), '日', "a".repeat(100));
+        // A multi-byte character straddling the preview boundary: the
+        // serialized JSON string (leading `"` + (cap - 2) ASCII bytes) puts
+        // the 3-byte '日' character at bytes [cap - 1, cap + 2), so byte `cap`
+        // (the raw cap) falls inside it and must round down.
+        let cap = ironclaw_threads::TOOL_RESULT_RECORD_READ_MAX_BYTES;
+        let content = format!("{}{}{}", "a".repeat(cap - 2), '日', "a".repeat(100));
         let output = serde_json::Value::String(content);
         let full_text = serde_json::to_string(&output).expect("serialize reference output");
-        assert!(
-            full_text.len() > 2048,
-            "fixture must exceed the preview cap"
-        );
+        assert!(full_text.len() > cap, "fixture must exceed the preview cap");
 
         let input_ref = capability_io
             .register_provider_tool_call_input(
@@ -1405,7 +1403,7 @@ mod tests {
             "preview must end on a UTF-8 char boundary"
         );
         assert!(
-            next_offset < 2048,
+            next_offset < cap as u64,
             "the multi-byte char must round the boundary down below the raw cap"
         );
         assert_eq!(
@@ -1475,7 +1473,7 @@ mod tests {
                     serde_json::json!({
                         "result_ref": write_result.result_ref.as_str(),
                         "offset": next_offset,
-                        "max_bytes": 2048,
+                        "max_bytes": cap,
                     }),
                 ),
             ))
@@ -1684,7 +1682,8 @@ mod tests {
         let input_resolver: Arc<dyn LoopCapabilityInputResolver> = capability_io.clone();
         let result_writer: Arc<dyn LoopCapabilityResultWriter> = capability_io.clone();
 
-        let content = "a".repeat(2046 + 100);
+        let cap = ironclaw_threads::TOOL_RESULT_RECORD_READ_MAX_BYTES;
+        let content = "a".repeat(cap - 2 + 100);
         let output = serde_json::Value::String(content);
 
         let input_ref = capability_io
@@ -1775,7 +1774,7 @@ mod tests {
                     serde_json::json!({
                         "result_ref": write_result.result_ref.as_str(),
                         "offset": next_offset,
-                        "max_bytes": 2048,
+                        "max_bytes": cap,
                     }),
                 ),
             ))

--- a/crates/ironclaw_threads/src/contract.rs
+++ b/crates/ironclaw_threads/src/contract.rs
@@ -459,7 +459,7 @@ pub struct PutToolResultRecordRequest {
 }
 
 /// Maximum byte window returned by one durable tool-result read.
-pub const TOOL_RESULT_RECORD_READ_MAX_BYTES: usize = 2 * 1024;
+pub const TOOL_RESULT_RECORD_READ_MAX_BYTES: usize = 2816;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ReadToolResultRecordRequest {

--- a/crates/ironclaw_threads/tests/session_thread_contract.rs
+++ b/crates/ironclaw_threads/tests/session_thread_contract.rs
@@ -2151,12 +2151,12 @@ async fn append_tool_result_reference_persists_model_observation_in_envelope() {
 }
 
 /// Issue #5838: `ironclaw_reborn_composition::local_dev` inlines a first-look
-/// result preview up to `TOOL_RESULT_RECORD_READ_MAX_BYTES` (2048 bytes) into
-/// the `result_reference` observation. This pins that a full-size,
-/// JSON-braces-heavy 2048-byte preview survives this crate's own
-/// `validate_model_observation` boundary (whole-envelope cap 4096 bytes) —
-/// the preview is not dropped, and it appears in the replayed model-visible
-/// content.
+/// result preview up to `TOOL_RESULT_RECORD_READ_MAX_BYTES` into the
+/// `result_reference` observation. This pins that a full-size,
+/// JSON-braces-heavy preview at exactly the production preview cap survives
+/// this crate's own `validate_model_observation` boundary (whole-envelope cap
+/// 4096 bytes) — the preview is not dropped, and it appears in the replayed
+/// model-visible content.
 #[tokio::test]
 async fn append_tool_result_reference_retains_full_size_result_preview() {
     let service = InMemorySessionThreadService::default();
@@ -2172,24 +2172,26 @@ async fn append_tool_result_reference_retains_full_size_result_preview() {
         .await
         .unwrap();
 
-    // JSON-braces-heavy text repeated to exactly 2048 bytes, matching the
-    // production preview cap.
+    // JSON-braces-heavy text repeated to exactly the production preview cap,
+    // derived from the constant rather than a frozen literal so this test
+    // tracks any future change to TOOL_RESULT_RECORD_READ_MAX_BYTES.
     let unit = r#"{"id":1,"value":"x"},"#;
-    let mut preview = unit.repeat(2048 / unit.len() + 1);
-    preview.truncate(2048);
-    assert_eq!(preview.len(), 2048);
+    let cap = TOOL_RESULT_RECORD_READ_MAX_BYTES;
+    let mut preview = unit.repeat(cap / unit.len() + 1);
+    preview.truncate(cap);
+    assert_eq!(preview.len(), cap);
 
     let observation = serde_json::json!({
         "schema_version": 1,
         "status": "success",
-        "summary": "Tool completed; preview truncated, use result_read with the result reference and offset 2048 for more output.",
+        "summary": format!("Tool completed; preview truncated, use result_read with the result reference and offset {cap} for more output."),
         "detail": {
             "kind": "result_reference",
             "result_ref": "result:full-size-result-preview-tool",
             "byte_len": 9000,
             "preview": preview,
             "total_bytes": 9000,
-            "next_offset": 2048
+            "next_offset": cap
         },
         "artifacts": [{
             "artifact_ref": "result:full-size-result-preview-tool",


### PR DESCRIPTION
See commit message for full details: raises TOOL_RESULT_RECORD_READ_MAX_BYTES from 2048 to 2816 bytes based on real ClawBench cost/score data, empirically verified against the MODEL_OBSERVATION_DETAIL_MAX_BYTES envelope cap. Fixes 3 tests with stale hardcoded literals tied to the old value.