### PR TITLE
fix(filesystem): skip directory fsync on Windows, which cannot flush a directory handle

### DIFF
--- a/crates/ironclaw_filesystem/src/local.rs
+++ b/crates/ironclaw_filesystem/src/local.rs
@@ -472,13 +472,37 @@ fn unique_temp_path(
     Ok(parent.join(format!(".{name}.tmp.{counter}")))
 }
 
+/// Flush the parent directory entry so a create/rename is durable.
+///
+/// This is a POSIX durability step: on Linux and macOS, the rename is only
+/// guaranteed to survive a crash once the *directory* has been fsync'd.
+///
+/// Windows has no equivalent, and cannot express one. `File::open(dir)` yields a
+/// handle without write access, and `sync_all()` on it becomes `FlushFileBuffers`,
+/// which fails with `ERROR_ACCESS_DENIED` (`io::ErrorKind::PermissionDenied`) for
+/// exactly that reason. Because this runs at the end of `atomic_write_file`, the
+/// error propagates and **every write through `LocalFilesystem` fails on
+/// Windows** — including the bundled-skill install that `local-dev` performs at
+/// boot, so `ironclaw-reborn run`/`serve` cannot start at all.
+///
+/// NTFS orders and persists directory-entry changes for create/rename without an
+/// explicit directory flush, so the step is a no-op there. POSIX durability
+/// semantics are preserved everywhere they exist.
 async fn sync_parent_dir(virtual_path: &VirtualPath, parent: &Path) -> Result<(), FilesystemError> {
-    let dir = tokio::fs::File::open(parent)
-        .await
-        .map_err(|error| io_error(virtual_path.clone(), FilesystemOperation::WriteFile, error))?;
-    dir.sync_all()
-        .await
-        .map_err(|error| io_error(virtual_path.clone(), FilesystemOperation::WriteFile, error))
+    #[cfg(windows)]
+    {
+        let _ = (virtual_path, parent);
+        Ok(())
+    }
+    #[cfg(not(windows))]
+    {
+        let dir = tokio::fs::File::open(parent).await.map_err(|error| {
+            io_error(virtual_path.clone(), FilesystemOperation::WriteFile, error)
+        })?;
+        dir.sync_all()
+            .await
+            .map_err(|error| io_error(virtual_path.clone(), FilesystemOperation::WriteFile, error))
+    }
 }
 
 async fn ensure_existing_ancestor_contained(


### PR DESCRIPTION
## Problem

**Every write through `LocalFilesystem` fails on Windows**, which means `ironclaw-reborn run` / `serve` cannot boot there at all: the `local-dev` bundled-skill install writes through this path and aborts.

It is visible in the existing test suite today — on Windows, `catalog_contract::composite_routes_filesystem_operations_to_matching_backend` fails:

```
called `Result::unwrap()` on an `Err` value:
  Backend { path: VirtualPath("/memory/notes/new.md"),
            operation: WriteFile,
            reason: "permission denied" }
```

## Cause

`atomic_write_file` ends by fsync-ing the parent directory, so that a create/rename is durably persisted. That is a POSIX durability step, and Windows has no equivalent:

```rust
let dir = tokio::fs::File::open(parent).await?;   // handle without write access
dir.sync_all().await?;                            // → FlushFileBuffers → ERROR_ACCESS_DENIED
```

`File::open` yields a read-only handle, and `sync_all()` on it becomes `FlushFileBuffers`, which requires write access — so it returns `ERROR_ACCESS_DENIED` (`io::ErrorKind::PermissionDenied`). Since `sync_parent_dir` runs at the end of *every* atomic write, the error propagates out of every write.

## Fix

Make the directory fsync a no-op on Windows, guarded with `#[cfg(windows)]`. Every other platform is byte-for-byte unchanged, so POSIX durability semantics are preserved everywhere they exist.

NTFS orders and persists directory-entry changes for create/rename without an explicit directory flush, so there is nothing to skip. This is the standard approach in the ecosystem (`tempfile`, and the usual DB-durability crates, do the same).

## Verification

Windows 11, MSVC toolchain:

- `cargo test -p ironclaw_filesystem` — from **1 failing test** to **88 passing**.
- `cargo clippy -p ironclaw_filesystem --all-targets -- -D warnings` — clean.
- With the fix applied, `ironclaw-reborn serve` boots on Windows and writes its bundled skills.

(`--all-features` was not run here: `libsql-ffi` needs a C toolchain I don't have configured. The change is platform-gated and does not touch the libsql backend.)

## Context

Found while building a Windows desktop client on `ironclaw-reborn serve`. Same work produced #5998, #5999, #6076. Happy to adjust the shape of the fix if you'd prefer a different guard (e.g. tolerating `PermissionDenied` from `sync_all` rather than a `cfg`).
