### PR TITLE
test(reborn): Slack channel lifecycle state-machine integration scenario (#6105)

### DIFF
--- a/crates/ironclaw_reborn_composition/src/slack/slack_channel_connection.rs
+++ b/crates/ironclaw_reborn_composition/src/slack/slack_channel_connection.rs
@@ -383,6 +383,48 @@ pub(crate) fn slack_channel_connection_facade(
     })
 }
 
+/// Stores for the test-support facade constructor below. Same shape the
+/// production constructor reads off [`SlackHostBetaMounts`]; grouped so the
+/// constructor stays within argument-count discipline.
+#[cfg(feature = "test-support")]
+pub(crate) struct SlackChannelConnectionFacadeTestParts {
+    pub(crate) tenant_id: TenantId,
+    pub(crate) personal_connection_scope: SlackPersonalConnectionScope,
+    pub(crate) user_identity_lookup: Arc<dyn RebornUserIdentityLookup>,
+    pub(crate) user_identity_delete_store: Arc<dyn RebornUserIdentityBindingDeleteStore>,
+    pub(crate) user_binding_lifecycle_store: Arc<dyn SlackUserBindingLifecycleStore>,
+    pub(crate) conversation_actor_pairings: Arc<dyn ConversationActorPairingService>,
+    pub(crate) personal_dm_target_store: Arc<dyn SlackPersonalDmTargetStore>,
+    pub(crate) personal_credential_cleanup: Option<Arc<dyn SlackPersonalCredentialCleanup>>,
+}
+
+/// Test-support constructor for the REAL per-user facade over caller-supplied
+/// stores. Mirrors [`slack_channel_connection_facade`] (the production
+/// constructor over [`SlackHostBetaMounts`], called from
+/// `build_webui_services_with_slack_host_beta_mounts`) so integration tests
+/// drive the identical `SlackChannelConnectionFacade` implementation — not a
+/// parallel test copy. For tests only; ships zero bytes in production builds.
+#[cfg(feature = "test-support")]
+pub(crate) fn slack_channel_connection_facade_from_test_parts(
+    parts: SlackChannelConnectionFacadeTestParts,
+) -> Arc<dyn ChannelConnectionFacade> {
+    use crate::slack::slack_host_beta::StaticSlackPersonalConnectionScopeResolver;
+
+    Arc::new(SlackChannelConnectionFacade {
+        tenant_id: parts.tenant_id,
+        personal_connection_scope: Some(parts.personal_connection_scope.clone()),
+        personal_connection_scope_resolver: Some(Arc::new(
+            StaticSlackPersonalConnectionScopeResolver::new(Some(parts.personal_connection_scope)),
+        )),
+        user_identity_lookup: parts.user_identity_lookup,
+        user_identity_delete_store: parts.user_identity_delete_store,
+        user_binding_lifecycle_store: parts.user_binding_lifecycle_store,
+        conversation_actor_pairings: parts.conversation_actor_pairings,
+        personal_dm_target_store: parts.personal_dm_target_store,
+        personal_credential_cleanup: parts.personal_credential_cleanup,
+    })
+}
+
 fn slack_identity_conversation_actor(
     binding: &RebornUserIdentityBinding,
 ) -> Result<

--- a/crates/ironclaw_reborn_composition/src/test_support/mod.rs
+++ b/crates/ironclaw_reborn_composition/src/test_support/mod.rs
@@ -52,6 +52,11 @@
 //! 14. [`result_read`] — `wrap_result_read_capability_for_test`, the
 //!     production `result_read` synthetic-capability wrap, for the same
 //!     durable tool-result projection coverage (issue #5838).
+//! 15. [`slack_channel_connection`] — `build_slack_channel_connection_for_test`,
+//!     [`SlackChannelConnectionTestBundle`] — the REAL Slack channel-connection
+//!     facade over durable host state, late-bound into the extension-lifecycle
+//!     cleanup slot, plus an OAuth-callback-shaped connect for the channel
+//!     lifecycle state machine (C-SLACK-LIFECYCLE seam, issue #6105).
 
 mod automation;
 mod budget_gateway;
@@ -65,6 +70,8 @@ mod projection;
 mod refreshing_capability_port;
 mod result_read;
 mod skill_activation;
+#[cfg(feature = "slack-v2-host-beta")]
+mod slack_channel_connection;
 mod trace_capture;
 mod trigger_materializer;
 mod user_profile;
@@ -117,6 +124,11 @@ pub use result_read::{RESULT_READ_CAPABILITY_ID, wrap_result_read_capability_for
 pub use skill_activation::{
     SKILL_ACTIVATE_CAPABILITY_ID, SkillActivationTestSource,
     build_local_dev_skill_context_source_for_test,
+};
+#[cfg(all(feature = "test-support", feature = "slack-v2-host-beta"))]
+pub use slack_channel_connection::{
+    SlackChannelConnectionTestBundle, SlackChannelConnectionTestConfig,
+    build_slack_channel_connection_for_test,
 };
 #[cfg(feature = "test-support")]
 pub use trace_capture::trace_capture_turn_event_sink_for_test;

--- a/crates/ironclaw_reborn_composition/src/test_support/slack_channel_connection.rs
+++ b/crates/ironclaw_reborn_composition/src/test_support/slack_channel_connection.rs
@@ -1,0 +1,265 @@
+//! Slack channel-connection test support (C-SLACK-LIFECYCLE seam, issue #6105).
+//!
+//! Builds the REAL [`SlackChannelConnectionFacade`] over the composed
+//! local-dev runtime's durable Slack host state and late-binds it into
+//! `RebornLocalRuntimeServices::channel_connection_facade_slot`, mirroring the
+//! production wiring in
+//! `slack_connectable_channel::build_webui_services_with_slack_host_beta_mounts`
+//! (facade construction + `set_channel_connection_facade`). With the slot
+//! filled, `builtin.extension_remove` of the Slack extension runs the real
+//! `SlackPersonalConnectionCleanupAdapter` → `disconnect_channel_for_caller`
+//! path, exactly as a hosted deployment does.
+//!
+//! [`SlackChannelConnectionTestBundle::connect_personal_user`] mirrors the
+//! successful `slack_personal` OAuth callback
+//! (`slack_host_beta/runtime_setup.rs` — `begin_connection` then
+//! `bind_personal_user_for_epoch_with_rollback`), so integration tests can
+//! drive connect → disconnect → reconnect against durable identity bindings
+//! without a browser or Slack.
+//!
+//! For tests only — gated behind `test-support`, ships zero bytes in
+//! production builds.
+
+use std::sync::Arc;
+
+use ironclaw_host_api::{AgentId, TenantId, UserId};
+use ironclaw_product_workflow::{ChannelConnectionFacade, WebUiAuthenticatedCaller};
+
+use crate::factory::RebornServices;
+use crate::slack::slack_actor_identity::{RebornUserIdentityLookup, SLACK_IDENTITY_PROVIDER};
+use crate::slack::slack_channel_connection::{
+    SlackChannelConnectionFacadeTestParts, SlackPersonalCredentialCleanup,
+    slack_channel_connection_facade_from_test_parts,
+};
+use crate::slack::slack_host_beta::SlackPersonalConnectionScope;
+use crate::slack::slack_host_state::FilesystemSlackHostState;
+use crate::slack::slack_personal_binding::{
+    RebornUserIdentityBindingDeleteStore, RebornUserIdentityBindingStore, SlackConnectionEpoch,
+    SlackConnectionOwner, SlackPersonalBindingInstallation, SlackPersonalBindingPrincipal,
+    SlackPersonalUserBindingRequest, SlackPersonalUserBindingService,
+    SlackUserBindingLifecycleStore,
+};
+use crate::slack::slack_serve::{
+    SlackApiAppId, SlackInstallationSelector, SlackTeamId, SlackUserId,
+};
+
+/// Identity inputs for [`build_slack_channel_connection_for_test`]. Plain
+/// strings so harness callers outside this crate don't need the internal
+/// Slack id newtypes; validated at construction.
+pub struct SlackChannelConnectionTestConfig {
+    pub tenant_id: String,
+    /// Host/runtime user that owns the durable Slack host state
+    /// (`SlackHostBetaConfig::user_id` in production).
+    pub host_user_id: String,
+    pub agent_id: String,
+    pub installation_id: String,
+    pub team_id: String,
+    pub api_app_id: String,
+}
+
+/// Handles for driving the Slack personal connection state machine in tests.
+/// See the module doc for the production call sites each method mirrors.
+pub struct SlackChannelConnectionTestBundle {
+    tenant_id: TenantId,
+    agent_id: AgentId,
+    installation_id: ironclaw_product_adapters::AdapterInstallationId,
+    team_id: SlackTeamId,
+    api_app_id: SlackApiAppId,
+    facade: Arc<dyn ChannelConnectionFacade>,
+    binding_service: SlackPersonalUserBindingService,
+    lifecycle_store: Arc<dyn SlackUserBindingLifecycleStore>,
+    user_identity_lookup: Arc<dyn RebornUserIdentityLookup>,
+}
+
+/// Build the real Slack channel-connection facade over `services`' local-dev
+/// Slack host state and fill the extension-lifecycle handler's late-binding
+/// facade slot. Mirrors `build_webui_services_with_slack_host_beta_mounts`
+/// (`slack_connectable_channel.rs`): same `FilesystemSlackHostState`
+/// construction as `build_slack_host_beta_mounts`, same
+/// `personal_credential_cleanup` sourced from `services.product_auth`, same
+/// slot fill production performs via
+/// `RebornRuntime::set_channel_connection_facade`.
+///
+/// Fails loud when the slot is already occupied — a second facade would not
+/// be the one extension-removal cleanup dispatches to, so a test composing
+/// twice must find out immediately.
+pub fn build_slack_channel_connection_for_test(
+    services: &RebornServices,
+    config: SlackChannelConnectionTestConfig,
+) -> Result<SlackChannelConnectionTestBundle, String> {
+    let local_runtime = services
+        .local_runtime
+        .as_ref()
+        .ok_or("slack channel-connection test support requires a local-dev runtime")?;
+    let tenant_id = TenantId::new(config.tenant_id).map_err(|error| error.to_string())?;
+    let host_user_id = UserId::new(config.host_user_id).map_err(|error| error.to_string())?;
+    let agent_id = AgentId::new(config.agent_id).map_err(|error| error.to_string())?;
+    let installation_id =
+        ironclaw_product_adapters::AdapterInstallationId::new(config.installation_id)
+            .map_err(|error| error.to_string())?;
+    let team_id = SlackTeamId::new(config.team_id);
+    let api_app_id = SlackApiAppId::new(config.api_app_id);
+
+    // Same durable host-state construction as `build_slack_host_beta_mounts`
+    // (`slack_host_beta.rs`), over the SAME `host_state_filesystem` the
+    // production Slack host uses.
+    let state = Arc::new(FilesystemSlackHostState::new(
+        Arc::clone(&local_runtime.host_state_filesystem),
+        tenant_id.clone(),
+        host_user_id,
+        agent_id.clone(),
+        None,
+    ));
+    let binding_store: Arc<dyn RebornUserIdentityBindingStore> = state.clone();
+    let binding_service = SlackPersonalUserBindingService::new(
+        [SlackPersonalBindingInstallation {
+            tenant_id: tenant_id.clone(),
+            installation_id: installation_id.clone(),
+            selector: SlackInstallationSelector::app_team(
+                api_app_id.as_str().to_string(),
+                team_id.as_str().to_string(),
+            ),
+        }],
+        binding_store,
+    );
+    let lifecycle_store: Arc<dyn SlackUserBindingLifecycleStore> = state.clone();
+    let identity_delete_store: Arc<dyn RebornUserIdentityBindingDeleteStore> = state.clone();
+    let user_identity_lookup: Arc<dyn RebornUserIdentityLookup> = state.clone();
+    // Mirrors `build_webui_services_with_slack_host_beta_mounts`: the caller's
+    // `slack_personal` credential is revoked through the same product-auth
+    // lifecycle cleanup production disconnect uses.
+    let personal_credential_cleanup = services
+        .product_auth
+        .clone()
+        .map(|auth| auth as Arc<dyn SlackPersonalCredentialCleanup>);
+    let facade =
+        slack_channel_connection_facade_from_test_parts(SlackChannelConnectionFacadeTestParts {
+            tenant_id: tenant_id.clone(),
+            personal_connection_scope: SlackPersonalConnectionScope {
+                installation_id: installation_id.clone(),
+            },
+            user_identity_lookup: Arc::clone(&user_identity_lookup),
+            user_identity_delete_store: identity_delete_store,
+            user_binding_lifecycle_store: Arc::clone(&lifecycle_store),
+            conversation_actor_pairings: Arc::new(
+                ironclaw_conversations::InMemoryConversationServices::default(),
+            ),
+            personal_dm_target_store: state,
+            personal_credential_cleanup,
+        });
+    if local_runtime
+        .channel_connection_facade_slot
+        .set(Arc::clone(&facade))
+        .is_err()
+    {
+        return Err(
+            "channel connection facade slot is already occupied; extension-removal cleanup \
+             would dispatch to a different facade than this bundle"
+                .to_string(),
+        );
+    }
+    Ok(SlackChannelConnectionTestBundle {
+        tenant_id,
+        agent_id,
+        installation_id,
+        team_id,
+        api_app_id,
+        facade,
+        binding_service,
+        lifecycle_store,
+        user_identity_lookup,
+    })
+}
+
+impl SlackChannelConnectionTestBundle {
+    /// Connect `user_id`'s personal Slack account, mirroring the successful
+    /// `slack_personal` OAuth callback: `begin_connection` on the durable
+    /// lifecycle store, then the same
+    /// `bind_personal_user_for_epoch_with_rollback` the production callback
+    /// identity hook calls (`slack_host_beta/runtime_setup.rs`). A fresh
+    /// connection epoch is minted per call, so calling again after a
+    /// disconnect models a real reconnect.
+    pub async fn connect_personal_user(
+        &self,
+        user_id: &UserId,
+        slack_user_id: &str,
+    ) -> Result<(), String> {
+        let epoch = SlackConnectionEpoch::new(ironclaw_auth::AuthFlowId::new());
+        self.lifecycle_store
+            .begin_connection(
+                &SlackConnectionOwner::new(
+                    self.tenant_id.clone(),
+                    user_id.clone(),
+                    self.installation_id.clone(),
+                ),
+                epoch,
+                chrono::Utc::now() + chrono::Duration::minutes(5),
+            )
+            .await
+            .map_err(|error| error.to_string())?;
+        self.binding_service
+            .bind_personal_user_for_epoch_with_rollback(
+                SlackPersonalBindingPrincipal {
+                    tenant_id: self.tenant_id.clone(),
+                    user_id: user_id.clone(),
+                },
+                SlackPersonalUserBindingRequest {
+                    installation_id: self.installation_id.clone(),
+                    slack_user_id: SlackUserId::new(slack_user_id),
+                    team_id: self.team_id.clone(),
+                    enterprise_id: None,
+                    api_app_id: self.api_app_id.clone(),
+                },
+                epoch,
+            )
+            .await
+            .map(|_| ())
+            .map_err(|error| error.to_string())
+    }
+
+    /// The real facade, for callers that need the full
+    /// [`ChannelConnectionFacade`] surface.
+    pub fn facade(&self) -> Arc<dyn ChannelConnectionFacade> {
+        Arc::clone(&self.facade)
+    }
+
+    /// Surface (a) of the extensions page: what
+    /// `list_extensions` merges via
+    /// `ChannelConnectionFacade::caller_channel_connections`
+    /// (`ironclaw_product_workflow/src/reborn_services/extensions.rs`).
+    /// Returns the `"slack"` entry for `user_id`.
+    pub async fn caller_channel_connected(&self, user_id: &UserId) -> Result<bool, String> {
+        let connections = self
+            .facade
+            .caller_channel_connections(WebUiAuthenticatedCaller::new(
+                self.tenant_id.clone(),
+                user_id.clone(),
+                Some(self.agent_id.clone()),
+                None,
+            ))
+            .await
+            .map_err(|error| format!("{:?}", error.code))?;
+        connections
+            .get("slack")
+            .copied()
+            .ok_or_else(|| "facade response is missing the slack channel entry".to_string())
+    }
+
+    /// Durable-state evidence: whether ANY active Slack identity binding is
+    /// persisted for `user_id`, across all installations (prefix-unscoped,
+    /// unlike [`Self::caller_channel_connected`]). Uses the same
+    /// active-state predicate the production connected read uses; disconnect
+    /// TOMBSTONES identity records rather than deleting rows (the
+    /// cleanup-enumeration store surface still lists tombstones for retry),
+    /// so active-state is the correct "binding gone" evidence.
+    pub async fn has_any_active_identity_binding(&self, user_id: &UserId) -> Result<bool, String> {
+        self.user_identity_lookup
+            .user_has_provider_binding_with_provider_user_id_prefix(
+                SLACK_IDENTITY_PROVIDER,
+                user_id,
+                None,
+            )
+            .await
+            .map_err(|error| error.to_string())
+    }
+}

--- a/tests/integration/group_extensions/main.rs
+++ b/tests/integration/group_extensions/main.rs
@@ -23,6 +23,7 @@ mod scenario_activate_then_active_cross_thread;
 mod scenario_install_then_visible_cross_thread;
 mod scenario_install_unknown_extension_id_fails_safely;
 mod scenario_remove_then_absent_cross_thread;
+mod scenario_slack_channel_lifecycle_state_machine;
 mod scenario_uninstalled_tool_call_denied_until_activated;
 
 use reborn_support::group::{RebornIntegrationGroup, ScenarioReport};
@@ -70,6 +71,16 @@ async fn extensions_group_e2e() {
     report.record(
         "uninstalled_tool_call_denied_until_activated",
         scenario_uninstalled_tool_call_denied_until_activated::run(&g).await,
+    );
+
+    // Scenario 6 (issue #6105): the Slack channel lifecycle state machine —
+    // install → activate → connect → use → remove (real personal-connection
+    // cleanup) → reconnect → reinstall → use again, asserting connection
+    // state, durable bindings, lifecycle phase, and tool dispatchability stay
+    // consistent at every transition. Uses "slack" (untouched by 1-5).
+    report.record(
+        "slack_channel_lifecycle_state_machine",
+        scenario_slack_channel_lifecycle_state_machine::run(&g).await,
     );
 
     report.assert_all_passed();

--- a/tests/integration/group_extensions/scenario_slack_channel_lifecycle_state_machine.rs
+++ b/tests/integration/group_extensions/scenario_slack_channel_lifecycle_state_machine.rs
@@ -1,0 +1,249 @@
+//! Scenario 6 (C-SLACK-LIFECYCLE, issue #6105): the Slack channel-extension
+//! lifecycle STATE MACHINE — install → activate → connect → use → disconnect
+//! (via `builtin.extension_remove`, the production path: there is no separate
+//! disconnect route) → reconnect → reinstall/activate → use again — with
+//! surface consistency asserted after every transition.
+//!
+//! The three surfaces that disagreed in issue #6091 are each read through
+//! their REAL implementation:
+//! - **connection state**: the production `SlackChannelConnectionFacade`
+//!   over durable host-state identity bindings (what the Extensions page
+//!   merges via `caller_channel_connections`), plus the binding store itself
+//!   as durable evidence;
+//! - **capability surface**: whether a scripted `slack.*` call actually
+//!   dispatches through the model gateway + capability port;
+//! - **lifecycle phase**: `builtin.extension_search`'s `installation_phase`.
+//!
+//! Key distinctions this pins (the #6091 divergence axes):
+//! - activation publishes tools but does NOT connect (installed ≠ connected);
+//! - removal runs the REAL personal-connection cleanup — connection state,
+//!   durable bindings, lifecycle phase, and tool dispatchability must ALL
+//!   flip together, not drift;
+//! - a reconnect (new OAuth epoch) + reinstall restores service end to end.
+//!
+//! Uses the group's Slack channel-connection bundle
+//! (`ironclaw_reborn_composition::test_support`), whose connect mirrors the
+//! `slack_personal` OAuth callback and whose facade is late-bound into the
+//! same cleanup slot `extension_remove` dispatches to.
+
+use super::reborn_support::group::{HarnessResult, RebornIntegrationGroup};
+use super::reborn_support::reply::RebornScriptedReply;
+use serde_json::json;
+
+/// Mirrors the `slack_personal` scope union the extension-lifecycle profile
+/// seeds (`profiles/extension.rs`): read scopes for `search_messages` plus
+/// `chat:write` for `send_message`.
+const SLACK_PERSONAL_SCOPES: &[&str] = &[
+    "search:read",
+    "channels:history",
+    "groups:history",
+    "im:history",
+    "mpim:history",
+    "channels:read",
+    "groups:read",
+    "im:read",
+    "mpim:read",
+    "users:read",
+    "chat:write",
+];
+
+pub async fn run(g: &RebornIntegrationGroup) -> HarnessResult<()> {
+    let slack = g
+        .slack_channel_connection()
+        .ok_or("extension_lifecycle group must carry the Slack channel-connection bundle")?;
+    // Direct-chat bindings resolve subject == actor, so this one identity is
+    // both the capability dispatch user and the authenticated actor removal
+    // cleanup disconnects.
+    let actor = g.canonical_actor_user();
+
+    // ── Phase 0: nothing installed, nothing connected ────────────────────────
+    if slack.caller_channel_connected(&actor).await? {
+        return Err("slack must not report connected before any OAuth connect".into());
+    }
+    if slack.has_any_active_identity_binding(&actor).await? {
+        return Err("no active slack identity binding may exist before connect".into());
+    }
+
+    // ── Phase 1: install + activate publishes tools, but does NOT connect ───
+    let lifecycle = g
+        .thread("slack-lifecycle-install")
+        .script([
+            RebornScriptedReply::tool_call(
+                "builtin.extension_install",
+                json!({"extension_id": "slack"}),
+            ),
+            RebornScriptedReply::tool_call(
+                "builtin.extension_activate",
+                json!({"extension_id": "slack"}),
+            ),
+            RebornScriptedReply::text("slack ready"),
+        ])
+        .build()
+        .await?;
+    // Activation's credential gate and dispatch-time staging select a
+    // `slack_personal` account under the capability dispatch scope.
+    lifecycle
+        .seed_capability_credential_account("slack_personal", "itest slack", SLACK_PERSONAL_SCOPES)
+        .await?;
+    lifecycle.submit_turn("install and activate slack").await?;
+    lifecycle
+        .assert_tool_result_contains("\"installed\":true")
+        .await?;
+    lifecycle
+        .assert_tool_result_contains("\"activated\":true")
+        .await?;
+    // Activation published the tool surface…
+    lifecycle
+        .assert_tool_result_contains(r#""slack.send_message""#)
+        .await?;
+    // …but activation is NOT connection (the #6091 distinction).
+    if slack.caller_channel_connected(&actor).await? {
+        return Err("slack must not report connected after activate alone; \
+             activation published tools without any OAuth connect"
+            .into());
+    }
+
+    // ── Phase 2: connect (OAuth-callback-shaped) flips connection state ─────
+    slack.connect_personal_user(&actor, "U-ITEST-ALPHA").await?;
+    if !slack.caller_channel_connected(&actor).await? {
+        return Err("slack must report connected after the personal OAuth connect".into());
+    }
+    if !slack.has_any_active_identity_binding(&actor).await? {
+        return Err("connect must persist an active slack identity binding".into());
+    }
+
+    // ── Phase 3: use — a slack.* call dispatches through the real port ──────
+    let caller = g
+        .thread("slack-lifecycle-caller")
+        .script([
+            RebornScriptedReply::tool_call(
+                "slack.search_messages",
+                json!({"query": "from:me lifecycle"}),
+            ),
+            RebornScriptedReply::text("searched slack"),
+            RebornScriptedReply::tool_call(
+                "slack.send_message",
+                json!({"channel": "C-ITEST", "text": "hello after remove?"}),
+            ),
+            RebornScriptedReply::text("slack unavailable"),
+            RebornScriptedReply::tool_call(
+                "slack.send_message",
+                json!({"channel": "C-ITEST", "text": "hello again"}),
+            ),
+            RebornScriptedReply::text("sent slack message"),
+        ])
+        .build()
+        .await?;
+    caller.submit_turn("search my slack messages").await?;
+    caller.assert_tool_invoked("slack.search_messages").await?;
+    caller.assert_reply_contains("searched slack").await?;
+
+    // ── Phase 4: disconnect = extension_remove runs the REAL cleanup ────────
+    let remover = g
+        .thread("slack-lifecycle-remove")
+        .script([
+            RebornScriptedReply::tool_call(
+                "builtin.extension_remove",
+                json!({"extension_id": "slack"}),
+            ),
+            RebornScriptedReply::text("slack removed"),
+        ])
+        .build()
+        .await?;
+    remover.submit_turn("remove slack").await?;
+    remover
+        .assert_tool_result_contains("\"removed\":true")
+        .await?;
+    // Every surface flips together: connection facade…
+    if slack.caller_channel_connected(&actor).await? {
+        return Err("slack still reports connected after extension_remove; \
+             removal did not run the personal-connection cleanup (issue #6091 shape)"
+            .into());
+    }
+    // …durable identity bindings (tombstoned out of the active state)…
+    if slack.has_any_active_identity_binding(&actor).await? {
+        return Err("extension_remove must deactivate durable slack identity bindings".into());
+    }
+    // …and the lifecycle phase seen by extension_search (fresh viewer thread
+    // so earlier `"activated":true` results can't satisfy the negative check).
+    let viewer = g
+        .thread("slack-lifecycle-viewer-after-remove")
+        .script([
+            RebornScriptedReply::tool_call("builtin.extension_search", json!({"query": "slack"})),
+            RebornScriptedReply::text("searched catalog"),
+        ])
+        .build()
+        .await?;
+    viewer.submit_turn("search slack after removal").await?;
+    if viewer
+        .assert_tool_result_contains(r#""installation_phase":"active""#)
+        .await
+        .is_ok()
+    {
+        return Err(
+            "slack still shows installation_phase:active after extension_remove; \
+             lifecycle phase and connection state have drifted apart"
+                .into(),
+        );
+    }
+    // Non-vacuity: the catalog entry itself must still be discoverable.
+    viewer.assert_tool_result_contains("\"slack\"").await?;
+
+    // ── Phase 5: use after remove — the identical call no longer dispatches ─
+    caller.submit_turn("send a slack message").await?;
+    if caller
+        .assert_tool_invoked("slack.send_message")
+        .await
+        .is_ok()
+    {
+        return Err("slack.send_message dispatched after extension_remove; \
+             removal must unpublish the capability surface"
+            .into());
+    }
+    caller.assert_reply_contains("slack unavailable").await?;
+
+    // ── Phase 6: reconnect (new epoch) + reinstall/activate restores service ─
+    // A real reconnect is a fresh OAuth grant: new credential, new epoch.
+    let restorer = g
+        .thread("slack-lifecycle-restore")
+        .script([
+            RebornScriptedReply::tool_call(
+                "builtin.extension_install",
+                json!({"extension_id": "slack"}),
+            ),
+            RebornScriptedReply::tool_call(
+                "builtin.extension_activate",
+                json!({"extension_id": "slack"}),
+            ),
+            RebornScriptedReply::text("slack restored"),
+        ])
+        .build()
+        .await?;
+    restorer
+        .seed_capability_credential_account(
+            "slack_personal",
+            "itest slack reconnect",
+            SLACK_PERSONAL_SCOPES,
+        )
+        .await?;
+    slack.connect_personal_user(&actor, "U-ITEST-ALPHA").await?;
+    if !slack.caller_channel_connected(&actor).await? {
+        return Err("slack must report connected after reconnect; \
+             a completed disconnect must not fence out a NEW connection epoch (issue #6092 shape)"
+            .into());
+    }
+    restorer.submit_turn("reinstall and activate slack").await?;
+    restorer
+        .assert_tool_result_contains("\"installed\":true")
+        .await?;
+    restorer
+        .assert_tool_result_contains("\"activated\":true")
+        .await?;
+
+    // ── Phase 7: use again — the same call that was rejected now dispatches ─
+    caller.submit_turn("send the slack message again").await?;
+    caller.assert_tool_invoked("slack.send_message").await?;
+    caller.assert_reply_contains("sent slack message").await?;
+
+    Ok(())
+}

--- a/tests/integration/support/group.rs
+++ b/tests/integration/support/group.rs
@@ -70,6 +70,7 @@ use ironclaw_product_workflow::{
     IdempotencyLedger, InboundTurnService, ResolvedBinding,
 };
 use ironclaw_reborn_composition::build_default_budget_accountant;
+use ironclaw_reborn_composition::test_support::SlackChannelConnectionTestBundle;
 use ironclaw_reborn_config::BudgetDefaults;
 use ironclaw_resources::{
     BudgetEventSink, BudgetGateStore, InMemoryBudgetEventSink, InMemoryBudgetGateStore,
@@ -174,6 +175,12 @@ pub(crate) struct GroupSharedStorage {
     /// Capability backend. Groups use `HostRuntime`; the degenerate single-shot
     /// path may use `Recording`.
     pub(crate) capability: GroupCapability,
+    /// C-SLACK-LIFECYCLE (issue #6105): the REAL Slack channel-connection
+    /// facade + OAuth-callback-shaped connect handles, built over the
+    /// capability harness's own `RebornServices` (same durable host state,
+    /// same late-bound cleanup slot `extension_remove` dispatches to).
+    /// `Some` only for `extension_lifecycle()` groups.
+    pub(crate) slack_channel_connection: Option<Arc<SlackChannelConnectionTestBundle>>,
     /// The group's single shared `TurnCoordinator`, over the ONE planned
     /// runtime built once at group construction (Option P: one
     /// scheduler/coordinator/executor over the shared turn-run queue, exactly
@@ -367,6 +374,7 @@ impl RebornIntegrationGroup {
             runner_lease_ttl_override: None,
             lease_recovery_interval_override: None,
             real_gate_dispatch_services: false,
+            slack_channel_connection: None,
         }
     }
 
@@ -376,6 +384,21 @@ impl RebornIntegrationGroup {
     /// to assert an enrolled turn queued a contribution envelope.
     pub fn trace_capture_scope(&self) -> Option<&str> {
         self.shared.trace_capture_scope.as_deref()
+    }
+
+    /// C-SLACK-LIFECYCLE (issue #6105): the real Slack channel-connection
+    /// bundle for this group. `Some` only for [`Self::extension_lifecycle`]
+    /// groups.
+    pub fn slack_channel_connection(&self) -> Option<Arc<SlackChannelConnectionTestBundle>> {
+        self.shared.slack_channel_connection.clone()
+    }
+
+    /// The group-canonical binding's ACTOR user id — the identity capability
+    /// dispatch stamps as `authenticated_actor_user_id` on execution contexts
+    /// (loop-host capability port reads `run_context.actor()`), and therefore
+    /// the caller identity extension-removal channel cleanup disconnects.
+    pub fn canonical_actor_user(&self) -> UserId {
+        self.shared.canonical_binding.actor_user_id.clone()
     }
 
     /// Create a per-thread *workflow* builder for `conversation_id`, over the
@@ -569,6 +592,11 @@ pub struct RebornIntegrationGroupBuilder {
     /// keeps the `Rejecting*InteractionService` stubs, matching today's
     /// behavior byte-for-byte).
     real_gate_dispatch_services: bool,
+    /// C-SLACK-LIFECYCLE (issue #6105): the real Slack channel-connection
+    /// bundle built over the capability harness's own `RebornServices`.
+    /// Set by `extension_lifecycle()` before `into_group`; `None` for every
+    /// other constructor.
+    slack_channel_connection: Option<Arc<SlackChannelConnectionTestBundle>>,
 }
 
 impl RebornIntegrationGroupBuilder {
@@ -943,6 +971,7 @@ impl RebornIntegrationGroupBuilder {
                 budget_account,
                 planned_runtime_parts_shape,
                 real_gate_dispatch_services: self.real_gate_dispatch_services,
+                slack_channel_connection: self.slack_channel_connection,
             }),
         })
     }

--- a/tests/integration/support/group_constructors.rs
+++ b/tests/integration/support/group_constructors.rs
@@ -249,7 +249,7 @@ impl RebornIntegrationGroupBuilder {
     }
 
     /// Build an extension-lifecycle group. See [`RebornIntegrationGroup::extension_lifecycle`].
-    pub async fn extension_lifecycle(self) -> HarnessResult<RebornIntegrationGroup> {
+    pub async fn extension_lifecycle(mut self) -> HarnessResult<RebornIntegrationGroup> {
         let base = self.build_base().await?;
         // Lifecycle ownership is caller-derived. Align the shared capability
         // harness with the group's canonical binding subject so install and
@@ -259,6 +259,33 @@ impl RebornIntegrationGroupBuilder {
             &base,
         )
         .await?;
+        // C-SLACK-LIFECYCLE (issue #6105): wire the REAL Slack channel-connection
+        // facade over this harness's own `RebornServices`, mirroring the
+        // production `build_webui_services_with_slack_host_beta_mounts` slot
+        // fill — so `builtin.extension_remove("slack")` runs the real
+        // personal-connection cleanup instead of failing closed on an unset
+        // facade slot. Identities come from the group's single-source dispatch
+        // scope so the facade's tenant check matches dispatch-time callers.
+        let scope = &base.product_harness.scope;
+        let slack =
+            ironclaw_reborn_composition::test_support::build_slack_channel_connection_for_test(
+                host_runtime
+                    .reborn_services_for_test()
+                    .ok_or("extension_lifecycle harness is missing its RebornServices bundle")?,
+                ironclaw_reborn_composition::test_support::SlackChannelConnectionTestConfig {
+                    tenant_id: scope.tenant_id.as_str().to_string(),
+                    host_user_id: scope.user_id.as_str().to_string(),
+                    agent_id: scope
+                        .agent_id
+                        .as_ref()
+                        .map(|agent| agent.as_str().to_string())
+                        .ok_or("group product scope is missing an agent id")?,
+                    installation_id: "itest-slack-install".to_string(),
+                    team_id: "T-ITEST".to_string(),
+                    api_app_id: "A-ITEST".to_string(),
+                },
+            )?;
+        self.slack_channel_connection = Some(Arc::new(slack));
         let capability = GroupCapability::HostRuntime(Arc::new(host_runtime));
         self.into_group(base, capability).await
     }


### PR DESCRIPTION
## Summary

First deliverable for #6105: the extension/channel lifecycle **state-machine test** for Slack at the integration tier — `install → activate → connect → use → disconnect (extension_remove) → reconnect → reinstall/activate → use again`, with surface consistency asserted after **every** transition. This pins the #6091 failure shape (surfaces disagreeing about connection state after disconnect) and the reconnect axis of #6092 against the real production paths.

## What's in it

**1. C-SLACK-LIFECYCLE test-support seam** (`crates/ironclaw_reborn_composition/src/test_support/slack_channel_connection.rs`, `test-support`-gated, zero bytes in production):
- `build_slack_channel_connection_for_test` builds the **real** `SlackChannelConnectionFacade` over the composed local-dev runtime's durable Slack host state (same `FilesystemSlackHostState` construction as `build_slack_host_beta_mounts`) and fills the same late-binding `channel_connection_facade_slot` that production fills via `build_webui_services_with_slack_host_beta_mounts`. With the slot filled, `builtin.extension_remove("slack")` runs the real `SlackPersonalConnectionCleanupAdapter → disconnect_channel_for_caller` cleanup — previously unreachable at this tier (the slot was unset, so remove failed closed).
- `connect_personal_user` mirrors the successful `slack_personal` OAuth callback (`begin_connection` + `bind_personal_user_for_epoch_with_rollback`), minting a fresh connection epoch per call so a post-disconnect call models a genuine reconnect.
- `slack_channel_connection.rs` gains a small `from_test_parts` constructor (gated) so the seam constructs the **identical** facade implementation, not a parallel test copy.

**2. Group wiring**: `RebornIntegrationGroup::extension_lifecycle()` builds the bundle with the group's single-source dispatch-scope identities (facade + cleanup silently no-op on tenant mismatch, so this must be exact); new `slack_channel_connection()` / `canonical_actor_user()` accessors.

**3. Scenario 6** in `reborn_group_extensions` (extends the existing group per the consolidation rule) asserts at each transition across three surfaces — the connection facade the Extensions page merges, the durable identity-binding store, and actual `slack.*` dispatchability + `extension_search` phase:
- activation publishes `slack.*` but does **not** connect (installed ≠ connected — the #6091 divergence axis)
- OAuth-shaped connect flips the facade and persists an active binding
- `slack.search_messages` dispatches through the real capability port
- `extension_remove` flips **all** surfaces together: facade disconnected, bindings tombstoned out of the active state, phase downgraded, `slack.send_message` rejected fail-closed (run recovers, does not wedge)
- a new-epoch reconnect + reinstall restores dispatch for the exact call that was rejected

Found & encoded along the way: disconnect **tombstones** identity records rather than deleting rows (LLM-data-never-deleted); the live "connected" predicate requires `state == Active` while the cleanup-enumeration store surface still lists tombstones for retry — the scenario's durable evidence reads the active-state predicate production reads.

## Canary scheduling (issue part 2)

Investigated and deliberately **not** changed in this PR: the scheduled `reborn-webui-v2-live-qa` lane already runs the Slack connect/routine/delivery QA cases (`qa_3a/3c/3d`, `qa_5a`) every 3h with `cases=all`. The legacy v1 `auth-channels` lane is marked diagnostic-only/unstable by its own README — scheduling it would add exactly the flaky-red noise #6103 is eliminating. The remaining gap is a **disconnect→reconnect live-QA case** in `scripts/reborn_webui_v2_live_qa/`, which belongs to the #6067 live-test series; noted as a follow-up on #6105.

## Testing

- `cargo test --test reborn_group_extensions` — 13 passed (all 6 scenarios; suite runtime ~7s)
- `cargo clippy -p ironclaw_reborn_composition --all-targets --all-features -- -D warnings` — clean
- `cargo clippy --test reborn_group_extensions --all-features -- -D warnings` — clean
- `cargo test -p ironclaw_architecture` — 42 passed
- Test-first: the scenario's first run failed on the durable-binding evidence assertion, which surfaced the tombstone-vs-active-state distinction now documented in the seam.

Part of #6105 (state-machine test, Slack first). Follow-ups tracked there: generic ExternalChannel + Gmail/GitHub OAuth variants, run-status-vs-delivery honesty (#5944 shape), disconnect→reconnect live-QA case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)