### PR TITLE
test(auth): shared OAuth-flow conformance suite over fake and durable AuthFlowManager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4092,6 +4092,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "chrono",
+ "ironclaw_auth",
  "ironclaw_common",
  "ironclaw_host_api",
  "secrecy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -290,6 +290,10 @@ insta = { version = "1.46.3", features = ["yaml"] }
 ironclaw_llm = { path = "crates/ironclaw_llm", version = "0.1.0", features = ["testing"] }
 ironclaw_agent_loop = { path = "crates/ironclaw_agent_loop", version = "0.1.0", features = ["test-support"] }
 ironclaw_approvals = { path = "crates/ironclaw_approvals", version = "0.1.0" }
+# Pull the auth crate's `test-support` feature in only for tests so the
+# `test_support::conformance` OAuth-flow suite (used by the
+# `reborn_integration_oauth_connect` test) doesn't ship in release binaries.
+ironclaw_auth = { path = "crates/ironclaw_auth", version = "0.1.0", features = ["test-support"] }
 # C-ATTACH: `InboundAttachment` for `submit_turn_with_image_attachment`.
 ironclaw_attachments = { path = "crates/ironclaw_attachments", version = "0.1.0" }
 ironclaw_authorization = { path = "crates/ironclaw_authorization", version = "0.1.0" }

--- a/crates/ironclaw_auth/Cargo.toml
+++ b/crates/ironclaw_auth/Cargo.toml
@@ -14,6 +14,13 @@ publish = false
 [package.metadata.ironclaw]
 layer = "substrates"
 
+[features]
+# Compile the panic-on-violation conformance harnesses in `test_support`. Off
+# by default so production binaries carry zero bytes of the assertion suites;
+# this crate's own tests and downstream crates enable it from
+# `[dev-dependencies]`.
+test-support = []
+
 [dependencies]
 async-trait = "0.1"
 base64 = "0.22"
@@ -31,5 +38,9 @@ urlencoding = "2"
 uuid = { version = "1", features = ["v4", "serde"] }
 
 [dev-dependencies]
+# Self-reference with `test-support` so this crate's own `tests/` integration
+# binaries (which link the lib as an external crate, without `cfg(test)`) can
+# reach `ironclaw_auth::test_support`.
+ironclaw_auth = { path = ".", features = ["test-support"] }
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "rt", "sync"] }

--- a/crates/ironclaw_auth/src/conformance.rs
+++ b/crates/ironclaw_auth/src/conformance.rs
@@ -1,0 +1,404 @@
+//! OAuth-flow state-machine CONFORMANCE suite — shared, observable-behavior
+//! assertions every [`AuthFlowManager`] implementation must satisfy.
+//!
+//! Two production-facing implementations exist: this crate's
+//! [`InMemoryAuthProductServices`](crate::InMemoryAuthProductServices) fake
+//! (what most consumer tests run against) and the durable
+//! `FilesystemAuthProductServices` in `ironclaw_reborn_composition` (what
+//! production runs). Their VALIDATION core is shared (`domain.rs`'s
+//! `validate_callback_claim` / `prepare_callback_flow`), but each hand-rolls
+//! its orchestration around it — terminal-idempotency sets, expiry
+//! write-back, account minting — so the suites could drift apart with nothing
+//! failing. Until this module existed their agreement was coincidence, not
+//! contract (found while pinning the #6105 T4 replay arm).
+//!
+//! Call [`assert_auth_flow_callback_conformance`] from each implementation's
+//! own test tier:
+//! - fake: `tests/auth_product_contract/oauth_flow_contract.rs` (this crate);
+//! - durable: root `tests/integration/oauth_connect.rs`, over the composed
+//!   `OAuthProductAuthTestBundle`'s `flow_manager()`.
+//!
+//! Panics with a case-labeled message on the first violation, matching the
+//! contract-test style of both call sites. Lives unconditionally in the lib
+//! (like `fakes.rs`): this crate's charter is auth contracts *and* their test
+//! vocabulary.
+
+use chrono::{Duration, Utc};
+
+use crate::{
+    AuthChallenge, AuthContinuationRef, AuthFlowId, AuthFlowKind, AuthFlowManager, AuthFlowRecord,
+    AuthFlowStatus, AuthProductError, AuthProductScope, AuthProviderId, AuthorizationCodeHash,
+    CredentialAccountLabel, NewAuthFlow, OAuthAuthorizationUrl, OAuthCallbackInput,
+    OAuthProviderExchange, OpaqueStateHash, PkceVerifierHash, ProviderCallbackOutcome,
+};
+use ironclaw_host_api::SecretHandle;
+
+/// Deterministic 64-hex digest for conformance hash newtypes.
+fn digest(tag: &str) -> String {
+    format!(
+        "{:064x}",
+        tag.bytes().fold(0_u64, |hash, byte| {
+            hash.wrapping_mul(31).wrapping_add(u64::from(byte))
+        })
+    )
+}
+
+fn state_hash(tag: &str) -> OpaqueStateHash {
+    OpaqueStateHash::new(digest(tag)).expect("conformance state hash is valid")
+}
+
+fn pkce_hash(tag: &str) -> PkceVerifierHash {
+    PkceVerifierHash::new(digest(tag)).expect("conformance pkce hash is valid")
+}
+
+fn new_flow(
+    scope: &AuthProductScope,
+    provider: &AuthProviderId,
+    tag: &str,
+    expires_at: chrono::DateTime<Utc>,
+) -> NewAuthFlow {
+    NewAuthFlow {
+        id: None,
+        scope: scope.clone(),
+        kind: AuthFlowKind::IntegrationCredential,
+        provider: provider.clone(),
+        challenge: AuthChallenge::OAuthUrl {
+            authorization_url: OAuthAuthorizationUrl::new("https://provider.example/oauth")
+                .expect("conformance authorization url is valid"),
+            expires_at,
+        },
+        continuation: AuthContinuationRef::SetupOnly,
+        update_binding: None,
+        opaque_state_hash: Some(state_hash(tag)),
+        pkce_verifier_hash: Some(pkce_hash(tag)),
+        expires_at,
+    }
+}
+
+fn authorized_outcome(provider: &AuthProviderId, tag: &str) -> ProviderCallbackOutcome {
+    ProviderCallbackOutcome::Authorized {
+        exchange: Box::new(OAuthProviderExchange {
+            provider: provider.clone(),
+            account_label: CredentialAccountLabel::new(format!("conformance {tag}"))
+                .expect("conformance account label is valid"),
+            authorization_code_hash: AuthorizationCodeHash::new(digest(&format!("code-{tag}")))
+                .expect("conformance code hash is valid"),
+            pkce_verifier_hash: pkce_hash(tag),
+            access_secret: SecretHandle::new("conformance_access_secret")
+                .expect("conformance secret handle is valid"),
+            refresh_secret: None,
+            scopes: Vec::new(),
+            account_id: None,
+            provider_identity: None,
+        }),
+    }
+}
+
+fn callback_input(
+    flow_id: AuthFlowId,
+    tag: &str,
+    outcome: ProviderCallbackOutcome,
+) -> OAuthCallbackInput {
+    OAuthCallbackInput {
+        flow_id,
+        opaque_state_hash: state_hash(tag),
+        outcome,
+    }
+}
+
+async fn read_flow(
+    flows: &dyn AuthFlowManager,
+    scope: &AuthProductScope,
+    flow_id: AuthFlowId,
+    case: &str,
+) -> AuthFlowRecord {
+    flows
+        .get_flow(scope, flow_id)
+        .await
+        .unwrap_or_else(|error| panic!("[{case}] get_flow must not error: {error:?}"))
+        .unwrap_or_else(|| panic!("[{case}] flow record must remain readable"))
+}
+
+/// Run the OAuth-callback state-machine conformance cases against
+/// `flows`. `scope`/`provider` come from the caller's tier (the fake uses a
+/// plain local scope; the durable tier its composed test scope). Panics with
+/// a case-labeled message on the first violation.
+pub async fn assert_auth_flow_callback_conformance(
+    flows: &dyn AuthFlowManager,
+    scope: &AuthProductScope,
+    provider: &AuthProviderId,
+) {
+    completed_flow_claim_idempotent_and_complete_rejects_replay(flows, scope, provider).await;
+    expired_flow_rejects_and_marks_expired(flows, scope, provider).await;
+    canceled_flow_rejects_completion_as_canceled(flows, scope, provider).await;
+    unknown_flow_rejects_completion(flows, scope, provider).await;
+    state_hash_mismatch_denies_without_burning_the_flow(flows, scope, provider).await;
+}
+
+/// Happy completion, then both replay arms — the exact split the hosted
+/// callback route depends on: a replayed CLAIM is idempotent (returns the
+/// completed record so a duplicated browser redirect can short-circuit to
+/// success), while a replayed COMPLETE stays fail-closed
+/// (`FlowAlreadyTerminal`; nothing re-mints or overwrites the grant).
+async fn completed_flow_claim_idempotent_and_complete_rejects_replay(
+    flows: &dyn AuthFlowManager,
+    scope: &AuthProductScope,
+    provider: &AuthProviderId,
+) {
+    const CASE: &str = "completed-flow replay arms";
+    let tag = "conformance-completed";
+    let flow = flows
+        .create_flow(new_flow(
+            scope,
+            provider,
+            tag,
+            Utc::now() + Duration::minutes(5),
+        ))
+        .await
+        .unwrap_or_else(|error| panic!("[{CASE}] create_flow: {error:?}"));
+
+    let claimed = flows
+        .claim_oauth_callback(
+            scope,
+            crate::OAuthCallbackClaimRequest {
+                flow_id: flow.id,
+                opaque_state_hash: state_hash(tag),
+                provider: provider.clone(),
+                pkce_verifier_hash: pkce_hash(tag),
+            },
+        )
+        .await
+        .unwrap_or_else(|error| panic!("[{CASE}] first claim: {error:?}"));
+    assert_eq!(
+        claimed.status,
+        AuthFlowStatus::CallbackReceived,
+        "[{CASE}] first claim moves the flow to CallbackReceived"
+    );
+
+    let completed = flows
+        .complete_oauth_callback(
+            scope,
+            callback_input(flow.id, tag, authorized_outcome(provider, tag)),
+        )
+        .await
+        .unwrap_or_else(|error| panic!("[{CASE}] complete: {error:?}"));
+    assert_eq!(
+        completed.status,
+        AuthFlowStatus::Completed,
+        "[{CASE}] authorized completion lands on Completed"
+    );
+    let account_id = completed
+        .credential_account_id
+        .unwrap_or_else(|| panic!("[{CASE}] completion must mint a credential account"));
+
+    // Replayed CLAIM (duplicated redirect): idempotent, same terminal record.
+    let reclaimed = flows
+        .claim_oauth_callback(
+            scope,
+            crate::OAuthCallbackClaimRequest {
+                flow_id: flow.id,
+                opaque_state_hash: state_hash(tag),
+                provider: provider.clone(),
+                pkce_verifier_hash: pkce_hash(tag),
+            },
+        )
+        .await
+        .unwrap_or_else(|error| {
+            panic!("[{CASE}] a replayed claim on a completed flow must be idempotent: {error:?}")
+        });
+    assert_eq!(
+        reclaimed.status,
+        AuthFlowStatus::Completed,
+        "[{CASE}] replayed claim returns the completed record"
+    );
+    assert_eq!(
+        reclaimed.credential_account_id,
+        Some(account_id),
+        "[{CASE}] replayed claim returns the ORIGINAL grant's account"
+    );
+
+    // Replayed COMPLETE: fail-closed, and the record is untouched.
+    let replay = flows
+        .complete_oauth_callback(
+            scope,
+            callback_input(flow.id, tag, ProviderCallbackOutcome::Denied),
+        )
+        .await
+        .expect_err("a replayed complete on a terminal flow must be rejected");
+    assert_eq!(
+        replay,
+        AuthProductError::FlowAlreadyTerminal,
+        "[{CASE}] replayed complete rejects FlowAlreadyTerminal"
+    );
+    let record = read_flow(flows, scope, flow.id, CASE).await;
+    assert_eq!(
+        record.status,
+        AuthFlowStatus::Completed,
+        "[{CASE}] record stays Completed"
+    );
+    assert_eq!(
+        record.credential_account_id,
+        Some(account_id),
+        "[{CASE}] the original grant survives the rejected replay"
+    );
+}
+
+/// A callback for a lapsed flow is rejected `UnknownOrExpiredFlow` and the
+/// record is durably marked terminal `Expired` — not left half-claimable.
+async fn expired_flow_rejects_and_marks_expired(
+    flows: &dyn AuthFlowManager,
+    scope: &AuthProductScope,
+    provider: &AuthProviderId,
+) {
+    const CASE: &str = "expired flow";
+    let tag = "conformance-expired";
+    let flow = flows
+        .create_flow(new_flow(
+            scope,
+            provider,
+            tag,
+            Utc::now() - Duration::seconds(1),
+        ))
+        .await
+        .unwrap_or_else(|error| panic!("[{CASE}] create_flow: {error:?}"));
+
+    let error = flows
+        .complete_oauth_callback(
+            scope,
+            callback_input(flow.id, tag, authorized_outcome(provider, tag)),
+        )
+        .await
+        .expect_err("completing a lapsed flow must be rejected");
+    assert_eq!(
+        error,
+        AuthProductError::UnknownOrExpiredFlow,
+        "[{CASE}] lapsed completion rejects UnknownOrExpiredFlow"
+    );
+    let record = read_flow(flows, scope, flow.id, CASE).await;
+    assert_eq!(
+        record.status,
+        AuthFlowStatus::Expired,
+        "[{CASE}] the record is marked terminal Expired (write-back), not left pending"
+    );
+}
+
+/// A canceled flow rejects completion with the cancel-specific error, and
+/// cancel itself is not silently repeatable.
+async fn canceled_flow_rejects_completion_as_canceled(
+    flows: &dyn AuthFlowManager,
+    scope: &AuthProductScope,
+    provider: &AuthProviderId,
+) {
+    const CASE: &str = "canceled flow";
+    let tag = "conformance-canceled";
+    let flow = flows
+        .create_flow(new_flow(
+            scope,
+            provider,
+            tag,
+            Utc::now() + Duration::minutes(5),
+        ))
+        .await
+        .unwrap_or_else(|error| panic!("[{CASE}] create_flow: {error:?}"));
+    flows
+        .cancel_flow(scope, flow.id)
+        .await
+        .unwrap_or_else(|error| panic!("[{CASE}] cancel_flow: {error:?}"));
+
+    let error = flows
+        .complete_oauth_callback(
+            scope,
+            callback_input(flow.id, tag, authorized_outcome(provider, tag)),
+        )
+        .await
+        .expect_err("completing a canceled flow must be rejected");
+    assert_eq!(
+        error,
+        AuthProductError::Canceled,
+        "[{CASE}] completion rejects with the cancel-specific error, not a generic terminal one"
+    );
+    let recancel = flows
+        .cancel_flow(scope, flow.id)
+        .await
+        .expect_err("re-canceling a canceled flow must be rejected");
+    assert_eq!(
+        recancel,
+        AuthProductError::Canceled,
+        "[{CASE}] re-cancel rejects as Canceled"
+    );
+}
+
+/// A callback for a flow id that was never created is rejected without
+/// leaking whether the id ever existed.
+async fn unknown_flow_rejects_completion(
+    flows: &dyn AuthFlowManager,
+    scope: &AuthProductScope,
+    provider: &AuthProviderId,
+) {
+    const CASE: &str = "unknown flow";
+    let tag = "conformance-unknown";
+    let error = flows
+        .complete_oauth_callback(
+            scope,
+            callback_input(AuthFlowId::new(), tag, authorized_outcome(provider, tag)),
+        )
+        .await
+        .expect_err("completing an unknown flow must be rejected");
+    assert_eq!(
+        error,
+        AuthProductError::UnknownOrExpiredFlow,
+        "[{CASE}] unknown flow rejects UnknownOrExpiredFlow"
+    );
+}
+
+/// A state-hash mismatch is denied as cross-scope — and the flow is NOT
+/// burned by the failed attempt: the genuine callback still completes.
+async fn state_hash_mismatch_denies_without_burning_the_flow(
+    flows: &dyn AuthFlowManager,
+    scope: &AuthProductScope,
+    provider: &AuthProviderId,
+) {
+    const CASE: &str = "state-hash mismatch";
+    let tag = "conformance-mismatch";
+    let flow = flows
+        .create_flow(new_flow(
+            scope,
+            provider,
+            tag,
+            Utc::now() + Duration::minutes(5),
+        ))
+        .await
+        .unwrap_or_else(|error| panic!("[{CASE}] create_flow: {error:?}"));
+
+    let error = flows
+        .complete_oauth_callback(
+            scope,
+            OAuthCallbackInput {
+                flow_id: flow.id,
+                opaque_state_hash: state_hash("conformance-mismatch-WRONG"),
+                outcome: authorized_outcome(provider, tag),
+            },
+        )
+        .await
+        .expect_err("a mismatched state hash must be rejected");
+    assert_eq!(
+        error,
+        AuthProductError::CrossScopeDenied,
+        "[{CASE}] mismatch rejects CrossScopeDenied"
+    );
+
+    let completed = flows
+        .complete_oauth_callback(
+            scope,
+            callback_input(flow.id, tag, authorized_outcome(provider, tag)),
+        )
+        .await
+        .unwrap_or_else(|error| {
+            panic!("[{CASE}] the genuine callback must still complete after a mismatch: {error:?}")
+        });
+    assert_eq!(
+        completed.status,
+        AuthFlowStatus::Completed,
+        "[{CASE}] a rejected mismatch must not consume the flow"
+    );
+}

--- a/crates/ironclaw_auth/src/lib.rs
+++ b/crates/ironclaw_auth/src/lib.rs
@@ -10,6 +10,7 @@
 //! pending maps, V1 extension manager authority, or V1 secret stores.
 
 mod cleanup;
+pub mod conformance;
 mod credential;
 pub mod domain;
 mod error;

--- a/crates/ironclaw_auth/src/lib.rs
+++ b/crates/ironclaw_auth/src/lib.rs
@@ -10,7 +10,6 @@
 //! pending maps, V1 extension manager authority, or V1 secret stores.
 
 mod cleanup;
-pub mod conformance;
 mod credential;
 pub mod domain;
 mod error;
@@ -22,6 +21,8 @@ mod loopback_oauth;
 pub mod oauth;
 mod provider;
 mod scope;
+#[cfg(any(test, feature = "test-support"))]
+pub mod test_support;
 
 pub use cleanup::{
     OAuthCompletionCompensationOutcome, OAuthCompletionCompensationRequest,

--- a/crates/ironclaw_auth/src/test_support.rs
+++ b/crates/ironclaw_auth/src/test_support.rs
@@ -1,0 +1,8 @@
+//! Test-support vocabulary for auth contracts — deterministic conformance
+//! suites shared across this crate's own tier and downstream integration
+//! tiers. Gated behind `#[cfg(any(test, feature = "test-support"))]` so the
+//! panic-on-violation assertion harnesses ship zero bytes in production
+//! binaries; downstream crates enable the `test-support` feature from their
+//! `[dev-dependencies]`.
+
+pub mod conformance;

--- a/crates/ironclaw_auth/src/test_support/conformance.rs
+++ b/crates/ironclaw_auth/src/test_support/conformance.rs
@@ -19,9 +19,10 @@
 //!   `OAuthProductAuthTestBundle`'s `flow_manager()`.
 //!
 //! Panics with a case-labeled message on the first violation, matching the
-//! contract-test style of both call sites. Lives unconditionally in the lib
-//! (like `fakes.rs`): this crate's charter is auth contracts *and* their test
-//! vocabulary.
+//! contract-test style of both call sites. Feature-gated test vocabulary
+//! (`#[cfg(any(test, feature = "test-support"))]`, under [`crate::test_support`]):
+//! this crate's charter is auth contracts *and* their test vocabulary, but the
+//! panic-on-violation harness must not ship in production binaries.
 
 use chrono::{Duration, Utc};
 
@@ -257,7 +258,9 @@ async fn expired_flow_rejects_and_marks_expired(
             scope,
             provider,
             tag,
-            Utc::now() - Duration::seconds(1),
+            // 10s (not 1s) so second-precision timestamp truncation on durable
+            // backends still lands the flow firmly in the past.
+            Utc::now() - Duration::seconds(10),
         ))
         .await
         .unwrap_or_else(|error| panic!("[{CASE}] create_flow: {error:?}"));

--- a/crates/ironclaw_auth/tests/auth_product_contract/oauth_flow_contract.rs
+++ b/crates/ironclaw_auth/tests/auth_product_contract/oauth_flow_contract.rs
@@ -1,5 +1,23 @@
 use crate::common::*;
 
+/// Cross-implementation conformance: the shared OAuth-callback state-machine
+/// suite (`ironclaw_auth::conformance`) holds for the in-memory fake. The
+/// durable `FilesystemAuthProductServices` runs the SAME suite from the root
+/// `tests/integration/oauth_connect.rs` — together they turn the two
+/// implementations' agreement into an enforced contract instead of a
+/// coincidence of two disjoint test suites.
+#[tokio::test]
+async fn oauth_flow_state_machine_conformance_holds_for_in_memory_fake() {
+    let services = InMemoryAuthProductServices::new();
+    let owner = scope("conformance");
+    ironclaw_auth::conformance::assert_auth_flow_callback_conformance(
+        &services,
+        &owner,
+        &provider(),
+    )
+    .await;
+}
+
 async fn completed_oauth_flow_with_continuation(
     services: &InMemoryAuthProductServices,
     owner: &AuthProductScope,

--- a/crates/ironclaw_auth/tests/auth_product_contract/oauth_flow_contract.rs
+++ b/crates/ironclaw_auth/tests/auth_product_contract/oauth_flow_contract.rs
@@ -1,7 +1,7 @@
 use crate::common::*;
 
 /// Cross-implementation conformance: the shared OAuth-callback state-machine
-/// suite (`ironclaw_auth::conformance`) holds for the in-memory fake. The
+/// suite (`ironclaw_auth::test_support::conformance`) holds for the in-memory fake. The
 /// durable `FilesystemAuthProductServices` runs the SAME suite from the root
 /// `tests/integration/oauth_connect.rs` — together they turn the two
 /// implementations' agreement into an enforced contract instead of a
@@ -10,7 +10,7 @@ use crate::common::*;
 async fn oauth_flow_state_machine_conformance_holds_for_in_memory_fake() {
     let services = InMemoryAuthProductServices::new();
     let owner = scope("conformance");
-    ironclaw_auth::conformance::assert_auth_flow_callback_conformance(
+    ironclaw_auth::test_support::conformance::assert_auth_flow_callback_conformance(
         &services,
         &owner,
         &provider(),

--- a/tests/integration/oauth_connect.rs
+++ b/tests/integration/oauth_connect.rs
@@ -141,6 +141,27 @@ async fn oauth_connect_flow_persists_credential_account() {
     );
 }
 
+/// Cross-implementation conformance: the durable `FilesystemAuthProductServices`
+/// must satisfy the same observable OAuth-callback state machine
+/// (`ironclaw_auth::conformance`) as the in-memory fake most consumer tests
+/// run against; the fake's invocation lives in
+/// `crates/ironclaw_auth/tests/auth_product_contract/oauth_flow_contract.rs`.
+/// The suite drives `AuthFlowManager` directly with pre-exchanged outcomes,
+/// so no token-exchange egress is involved — the exchange leg is covered by
+/// the surrounding tests in this file.
+#[tokio::test]
+async fn durable_flow_manager_satisfies_shared_oauth_flow_conformance() {
+    let bundle = build_oauth_product_auth_for_test();
+    let scope = test_scope();
+    let provider = AuthProviderId::new("test-oauth-provider").unwrap();
+    ironclaw_auth::conformance::assert_auth_flow_callback_conformance(
+        bundle.services.flow_manager().as_ref(),
+        &scope,
+        &provider,
+    )
+    .await;
+}
+
 /// Guard test: attempting an OAuth callback for a non-existent flow must fail
 /// with `UnknownOrExpiredFlow`.  No credential account must be created, and no
 /// token-exchange call should be made.

--- a/tests/integration/oauth_connect.rs
+++ b/tests/integration/oauth_connect.rs
@@ -143,7 +143,7 @@ async fn oauth_connect_flow_persists_credential_account() {
 
 /// Cross-implementation conformance: the durable `FilesystemAuthProductServices`
 /// must satisfy the same observable OAuth-callback state machine
-/// (`ironclaw_auth::conformance`) as the in-memory fake most consumer tests
+/// (`ironclaw_auth::test_support::conformance`) as the in-memory fake most consumer tests
 /// run against; the fake's invocation lives in
 /// `crates/ironclaw_auth/tests/auth_product_contract/oauth_flow_contract.rs`.
 /// The suite drives `AuthFlowManager` directly with pre-exchanged outcomes,
@@ -154,7 +154,7 @@ async fn durable_flow_manager_satisfies_shared_oauth_flow_conformance() {
     let bundle = build_oauth_product_auth_for_test();
     let scope = test_scope();
     let provider = AuthProviderId::new("test-oauth-provider").unwrap();
-    ironclaw_auth::conformance::assert_auth_flow_callback_conformance(
+    ironclaw_auth::test_support::conformance::assert_auth_flow_callback_conformance(
         bundle.services.flow_manager().as_ref(),
         &scope,
         &provider,


### PR DESCRIPTION
## Summary

Closes the fake↔durable conformance gap in product-auth OAuth flows, found while pinning the #6105 T4 replay arm (PR #6113): the in-memory `InMemoryAuthProductServices` fake and the durable `FilesystemAuthProductServices` had **disjoint test suites**, so any behavioral divergence between them was structurally undetectable.

Investigating the apparent replay divergence showed the two implementations actually **agree** at every `AuthFlowManager` method — `claim_oauth_callback` is replay-idempotent on terminal flows in both, `complete_oauth_callback` is fail-closed (`FlowAlreadyTerminal`) in both via the shared `prepare_callback_flow`. What differed in #6113's observation was the call path (wrapper-level `handle_oauth_callback` short-circuits at the idempotent claim), not the implementations. But that agreement was a coincidence of two suites: each impl hand-rolls its terminal-idempotency sets and expiry write-back separately from the shared validation helpers, so they could drift with nothing failing.

## What's in it

**`ironclaw_auth::conformance`** — a shared, observable-behavior state-machine suite over `&dyn AuthFlowManager` (lives unconditionally in the lib next to `fakes.rs`, per the crate's "auth contracts and fake services" charter). Cases:

- happy completion + **both replay arms**: a replayed *claim* is idempotent (returns the completed record with the original grant — what the hosted, unauthenticated callback route depends on for duplicated browser redirects), while a replayed *complete* stays fail-closed and leaves the record untouched;
- lapsed flow → `UnknownOrExpiredFlow` **and** the record is written back terminal `Expired`;
- canceled flow → cancel-specific rejection, re-cancel rejected;
- unknown flow id → `UnknownOrExpiredFlow`;
- state-hash mismatch → `CrossScopeDenied` **without burning the flow** (the genuine callback still completes).

**Both implementations invoke it:**
- fake: `crates/ironclaw_auth/tests/auth_product_contract/oauth_flow_contract.rs`
- durable: `tests/integration/oauth_connect.rs` over the composed `OAuthProductAuthTestBundle`'s `flow_manager()` (real `FilesystemAuthProductServices`; the suite drives pre-exchanged outcomes, so no token-exchange egress — that leg keeps its existing coverage in the same file)

## Not covered here

- The crash window between provider token store and flow completion (orphaned-token cleanup) — that's #4202's core and needs fault injection at the provider-client seam.
- The same fakes-only-testing class in `ironclaw_reborn_identity` — tracked by #5617.

## Testing

- `cargo test -p ironclaw_auth` — 111 passed (incl. the new fake-tier conformance invocation)
- `cargo test --test reborn_integration_oauth_connect` — 3 passed (incl. the durable-tier invocation)
- `cargo clippy -p ironclaw_auth --all-targets --all-features` and `cargo clippy --test reborn_integration_oauth_connect --all-features` — clean; `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
