### PR TITLE
test(reborn): storage-mode audit + operator LLM-config tier-2 coverage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -321,7 +321,15 @@ ironclaw_runner = { path = "crates/ironclaw_runner", version = "0.1.0", features
 # all 17 gated modules into every int-tier test binary — real, one-time
 # build-time cost for the lane, behaviorally inert for suites that never
 # reference Slack types.
-ironclaw_reborn_composition = { path = "crates/ironclaw_reborn_composition", version = "0.1.0", features = ["test-support", "libsql", "webui-v2-beta", "slack-v2-host-beta"] }
+# `root-llm-provider` unlocks `RebornRuntimeInput::with_boot_config` and the
+# real `RebornLlmConfigService` (operator LLM-provider CRUD) for int-tier —
+# needed by tests/integration/operator_llm_config.rs. Dev-dependency only;
+# the shipped `ironclaw-reborn` binary already carries this feature via
+# `ironclaw_reborn_cli`'s own `default = ["root-llm-provider"]`, so this adds
+# no new production surface, only compile-time reach for tests. Feature
+# unification recompiles the crate's `llm_admin`/openai-compat modules into
+# every int-tier test binary — real, one-time build-time cost for the lane.
+ironclaw_reborn_composition = { path = "crates/ironclaw_reborn_composition", version = "0.1.0", features = ["test-support", "libsql", "webui-v2-beta", "slack-v2-host-beta", "root-llm-provider"] }
 # Direct dev-dep: composition deliberately does NOT re-export the bare
 # `webui_v2_router`/`WebUiV2State` (facade-only rule), and the router smoke
 # drives the bare router, not the `webui_v2_app` wrapper.
@@ -516,6 +524,10 @@ path = "tests/integration/mcp.rs"
 [[test]]
 name = "reborn_integration_oauth_connect"
 path = "tests/integration/oauth_connect.rs"
+
+[[test]]
+name = "reborn_integration_operator_llm_config"
+path = "tests/integration/operator_llm_config.rs"
 
 [[test]]
 name = "reborn_integration_outbound_store_durability"

--- a/tests/integration/operator_llm_config.rs
+++ b/tests/integration/operator_llm_config.rs
@@ -1,0 +1,200 @@
+//! Reborn integration test — operator LLM-provider CRUD through the real
+//! `webui_v2` router + real `RebornLlmConfigService`.
+//!
+//! Tier-2 audit finding (docs/plans/2026-07-15-reborn-tier2-extension-plan.md
+//! §5b, "multi-user/admin/misc"): "Operator API has zero tier-2 coverage:
+//! LLM-provider CRUD (including the `api_key` never echoed back redaction
+//! invariant) ... no `tests/integration/` file touches any of it." This is a
+//! new, dedicated bin rather than an addition to `webui_v2_product_api.rs`
+//! (already 1300+ lines covering a different set of route families) —
+//! operator LLM config is its own first-class, zero-to-one area.
+//!
+//! Same real-runtime construction as `webui_v2_product_api.rs`
+//! (`RebornBuildInput::local_dev` -> `build_reborn_runtime` ->
+//! `build_webui_services`), plus `.with_boot_config(...)`: the WebUI facade
+//! only composes the real `RebornLlmConfigService` when the runtime carries a
+//! boot config (`crates/ironclaw_reborn_composition/src/webui/facade.rs`'s
+//! `build_llm_config_service`), so this is the one extra step beyond that
+//! file's existing pattern needed to reach the LLM-config routes for real.
+
+#[allow(dead_code)]
+#[path = "support/mod.rs"]
+mod reborn_support;
+#[allow(dead_code)]
+#[path = "../support/mod.rs"]
+mod support;
+
+use std::sync::Arc;
+
+use axum::Router;
+use axum::http::StatusCode;
+use ironclaw_host_api::{AgentId, TenantId, UserId};
+use ironclaw_product_workflow::WebUiAuthenticatedCaller;
+use ironclaw_reborn_composition::test_support::BudgetTestGateway;
+use ironclaw_reborn_composition::{
+    RebornBuildInput, RebornRuntimeIdentity, RebornRuntimeInput, build_reborn_runtime,
+    build_webui_services, local_dev_runtime_policy,
+};
+use ironclaw_reborn_config::{RebornBootConfig, RebornHome, RebornProfile};
+use ironclaw_webui_v2::{
+    DEFAULT_SSE_MAX_CONCURRENT_PER_CALLER, WebUiV2Capabilities, WebUiV2State, webui_v2_router,
+};
+use reborn_support::webui_mount::{get_json, post_json};
+use serde_json::json;
+use tempfile::tempdir;
+
+/// A real operator caller over the real `webui_v2_router`, backed by a
+/// production `RebornRuntime` built WITH a boot config so the LLM-config
+/// settings service is actually wired (mirrors
+/// `webui_v2_product_api.rs`'s operator-route construction, plus
+/// `.with_boot_config(..)`).
+async fn operator_router_with_llm_config() -> Router {
+    let root = tempdir().expect("runtime storage tempdir");
+    let storage_root = root.path().join("local-dev");
+    let reborn_home = root.path().join("reborn-home");
+    let tenant_id = TenantId::new("operator-llm-tenant").expect("tenant id");
+    let agent_id = AgentId::new("operator-llm-agent").expect("agent id");
+    let operator_id = UserId::new("operator-llm-operator").expect("operator id");
+
+    let home = RebornHome::resolve_from_env_parts(Some(reborn_home.into_os_string()), None, None)
+        .expect("valid reborn home");
+    let boot = RebornBootConfig::new(home, RebornProfile::LocalDev);
+
+    let input = RebornBuildInput::local_dev(operator_id.as_str(), storage_root)
+        .with_local_runtime_identity(tenant_id.clone(), agent_id.clone())
+        .with_runtime_policy(local_dev_runtime_policy().expect("local-dev policy"));
+    let runtime = build_reborn_runtime(
+        RebornRuntimeInput::from_services(input)
+            .with_identity(RebornRuntimeIdentity {
+                tenant_id: tenant_id.as_str().to_string(),
+                agent_id: agent_id.as_str().to_string(),
+                source_binding_id: "operator-llm-source".to_string(),
+                reply_target_binding_id: "operator-llm-reply".to_string(),
+            })
+            .with_model_gateway_override(Arc::new(BudgetTestGateway::with_constant("unused", 0, 0)))
+            .with_boot_config(boot),
+    )
+    .await
+    .expect("production Reborn runtime builds");
+    let webui = build_webui_services(&runtime, None).expect("production WebUI facade builds");
+
+    let operator_caller =
+        WebUiAuthenticatedCaller::new(tenant_id, operator_id, Some(agent_id), None)
+            .with_operator_webui_config(true);
+
+    webui_v2_router(WebUiV2State::new(
+        Arc::clone(&webui.api),
+        DEFAULT_SSE_MAX_CONCURRENT_PER_CALLER,
+    ))
+    .layer(axum::Extension(operator_caller))
+    .layer(axum::Extension(WebUiV2Capabilities {
+        operator_webui_config: true,
+    }))
+}
+
+/// Full LLM-provider CRUD path through the real router + real
+/// `RebornLlmConfigService`: upsert a custom provider with an API key, assert
+/// the key value never appears in the response and `api_key_set` flips true,
+/// re-fetch via GET to prove the redaction invariant holds on read (not just
+/// on the write response), then delete and confirm the provider is gone.
+/// `UpsertLlmProviderRequest` derives `Deserialize` only (no `Serialize`) and
+/// `LlmProviderView` carries only `api_key_set: bool` — this test pins that
+/// structural invariant end-to-end through the real HTTP contract, not a
+/// unit test of a redaction function (there isn't one; the type shape IS the
+/// guarantee).
+#[tokio::test]
+async fn upsert_llm_provider_never_echoes_api_key_then_get_then_delete() {
+    let secret_key = "sk-test-should-never-appear-in-any-response";
+    let router = operator_router_with_llm_config().await;
+
+    let (status, snapshot) = post_json(
+        router.clone(),
+        "/api/webchat/v2/llm/providers",
+        json!({
+            "id": "acme",
+            "name": "Acme",
+            "adapter": "open_ai_completions",
+            "base_url": "https://api.acme.test/v1",
+            "default_model": "acme-1",
+            "api_key": secret_key,
+            "set_active": true,
+            "model": "acme-1",
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "upsert response: {snapshot:?}");
+    assert_redacted_snapshot_carries_acme(&snapshot, secret_key);
+
+    // Re-fetch via GET on a fresh request against the SAME router/runtime —
+    // the redaction invariant must hold on read, not just on the upsert
+    // response, and the write must actually have persisted (not merely
+    // echoed back in-memory).
+    let (status, refetched) = get_json(router.clone(), "/api/webchat/v2/llm/providers").await;
+    assert_eq!(status, StatusCode::OK, "get response: {refetched:?}");
+    assert_redacted_snapshot_carries_acme(&refetched, secret_key);
+
+    let (status, after_delete) = post_json(
+        router.clone(),
+        "/api/webchat/v2/llm/providers/acme/delete",
+        json!({}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "delete response: {after_delete:?}");
+    let providers_after_delete = after_delete["providers"]
+        .as_array()
+        .expect("providers array");
+    assert!(
+        providers_after_delete
+            .iter()
+            .all(|provider| provider["id"] != "acme"),
+        "acme provider must be gone after delete: {after_delete:?}"
+    );
+    assert!(
+        !after_delete.to_string().contains(secret_key),
+        "api_key value must never appear in the delete response either: {after_delete:?}"
+    );
+
+    // Deleting the same (now-gone) provider id again is the same code path an
+    // unknown-provider-id delete takes: `delete_async` reports nothing
+    // removed -> `LlmConfigServiceError::NotFound` -> HTTP 404. No existing
+    // suite drives this branch (crate-tier unit tests only cover the
+    // key-cleanup-failure NotFound path; the contract suite only exercises
+    // 403-unauthorized and happy-delete for this handler).
+    let (status, not_found_body) = post_json(
+        router,
+        "/api/webchat/v2/llm/providers/acme/delete",
+        json!({}),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::NOT_FOUND,
+        "deleting an already-deleted (unknown) provider id must 404: {not_found_body:?}"
+    );
+}
+
+/// Shared assertions for both the upsert response and the GET re-fetch: the
+/// literal key value is absent everywhere in the body, the provider carries
+/// `api_key_set: true`, and no `api_key` field exists on the provider view at
+/// all (the type only has `api_key_set`).
+fn assert_redacted_snapshot_carries_acme(snapshot: &serde_json::Value, secret_key: &str) {
+    let body_text = snapshot.to_string();
+    assert!(
+        !body_text.contains(secret_key),
+        "api_key value must never appear anywhere in the response body: {body_text}"
+    );
+    let acme = snapshot["providers"]
+        .as_array()
+        .expect("providers array")
+        .iter()
+        .find(|provider| provider["id"] == "acme")
+        .unwrap_or_else(|| panic!("acme provider present in snapshot: {snapshot:?}"));
+    assert_eq!(
+        acme["api_key_set"], true,
+        "api_key_set must be true after a keyed upsert: {acme:?}"
+    );
+    assert!(
+        acme.get("api_key").is_none(),
+        "no api_key field may exist on the provider view: {acme:?}"
+    );
+}

--- a/tests/integration/tool_call.rs
+++ b/tests/integration/tool_call.rs
@@ -10,9 +10,10 @@ mod reborn_support;
 mod support;
 
 use ironclaw_threads::MessageKind;
-use reborn_support::builder::RebornIntegrationHarness;
+use reborn_support::builder::{RebornIntegrationHarness, StorageMode};
 use reborn_support::group::RebornIntegrationGroup;
 use reborn_support::reply::RebornScriptedReply;
+use rstest::rstest;
 use serde_json::json;
 
 const SLACK_PERSONAL_SCOPES: &[&str] = &[
@@ -544,9 +545,20 @@ async fn durable_large_read_file_result_reaches_model_as_truncated_preview() {
 /// byte-exactly from the SAME canonical serialization `tool_result_output`
 /// returns for `read_file` — no gap, no overlap — and reports the true
 /// `total_bytes` of the durable record.
+///
+/// Backend-parametrized (design §7, `backend_matrix.rs`'s matrix exemplar):
+/// `.with_durable_capability_io_file_tools()` wires the durable-preview seam
+/// to the group's REAL thread service (`install_durable_capability_io`),
+/// which is backed by whichever `RootFilesystem` `StorageMode` selects — so
+/// this byte-offset continuation genuinely round-trips through LibSql's real
+/// SQL storage on that case, not just `InMemory`'s `Vec<u8>` staging store.
+#[rstest]
+#[case(StorageMode::InMemory)]
+#[case(StorageMode::LibSql)]
 #[tokio::test]
-async fn result_read_continues_a_durable_result_byte_exactly() {
+async fn result_read_continues_a_durable_result_byte_exactly(#[case] storage: StorageMode) {
     let h = RebornIntegrationHarness::test_default()
+        .storage(storage)
         .with_durable_capability_io_file_tools()
         .script([
             RebornScriptedReply::tool_call(


### PR DESCRIPTION
## Summary

Lane 1 of a 4-lane parallel extension to the Reborn tier-2 integration harness. Two pieces now in this PR:

1. **Section 1 of the tier-2 extension plan** ("Storage-mode audit: InMemory vs LibSql") — audited all 86 test-module files across the 50 `reborn_*` bins for assertions reading back persisted state without opting into `StorageMode::LibSql`.
2. **A scoped follow-up** ("§5b, operator API zero-to-one gap") — the plan doc's own audit flagged "Operator API has zero tier-2 coverage: LLM-provider CRUD (including the `api_key` never echoed back redaction invariant) ... no `tests/integration/` file touches any of it." Closed that specific gap.

Two other requested follow-ups were investigated and NOT implemented — see "Scope note" below for why.

## 1. Storage-mode audit

**Method**: re-verified against current `main` that 4 of 50 bins already opt into LibSql (`backend_matrix.rs`, `reopen_resume_through_gate.rs`, `webui_v2_product_api.rs`, `group_approvals`'s `approvals_group_libsql_e2e`). Went file-by-file through the remaining 82 files: keyword grep (`reopen|restart|rehydrat|cold_get|survive|durab|reload|fresh|storage_root_for_test|open_local_dev_|byte_exact|offset|libsql`), then for every hit, traced the actual store being asserted against back to its construction to determine whether it's genuinely gated by `RebornIntegrationHarness`'s `StorageMode`, or a separate always-on-disk local-dev store.

**Finding — one genuine candidate**: `tests/integration/tool_call.rs::result_read_continues_a_durable_result_byte_exactly`. Traced `install_durable_capability_io` → `group.rs`'s `group_thread_harness.service` → `base.composite` → `build_storage_composite(self.storage, ...)` — i.e. `.with_durable_capability_io_file_tools()`'s content storage genuinely round-trips through whichever backend `StorageMode` selects. This test reads a byte-exact continuation slice at a specific offset from persisted content — the one test in the suite doing that — and rode `InMemory` only.

**Change**: parametrized it with `#[rstest] #[case(StorageMode::InMemory)] #[case(StorageMode::LibSql)]`, following `tests/integration/backend_matrix.rs`'s established convention exactly.

**Left alone (with reasoning)**: sibling test in the same file (backend-agnostic truncation decision, no new signal from LibSql); approval-request/trigger-repository/extension-installation/outbound-preferences/secret-store reopen tests (all confirmed always-on-disk local-dev stores independent of `StorageMode`, several self-documented "C-DURABLE"); `group_multiuser/scenario_turn_state_isolation_across_actors.rs` (traced `FilesystemTurnStateStore::get_run_state` — the scope-isolation check delegates to backend-agnostic shared code); all `*_cross_thread`/`*_isolation` group scenarios (same-process shared `Arc`, proving live visibility not durability); `auth_failure.rs`/top-level `secrets.rs` (feature-gated or bypass `StorageMode` entirely).

## 2. Operator API — LLM-provider CRUD (new)

**New file**: `tests/integration/operator_llm_config.rs` (dedicated bin — `webui_v2_product_api.rs` is already 1300+ lines covering a different set of route families; operator/LLM-config is its own first-class, zero-to-one area).

Drives the REAL `webui_v2_router` + REAL `RebornLlmConfigService` (not a stub), reusing the exact runtime-construction pattern already established 4× in `webui_v2_product_api.rs` (`RebornBuildInput::local_dev` → `build_reborn_runtime` → `build_webui_services`), plus one new step: `.with_boot_config(...)` on `RebornRuntimeInput`, which is what makes the WebUI facade actually wire the real LLM-config service (`crates/ironclaw_reborn_composition/src/webui/facade.rs`'s `build_llm_config_service` only fires when a boot config is present).

One cohesive test (`upsert_llm_provider_never_echoes_api_key_then_get_then_delete`) covers the full CRUD path: upsert a provider with an API key → assert the key value never appears anywhere in the response and `api_key_set` flips `true` → GET re-fetch → same redaction assertion on read (not just write) → delete → assert gone → delete again → assert `404` (the unknown-provider-id branch — not covered by any existing crate-tier unit test or the `webui_v2_handlers_contract.rs` contract suite, which only exercises 403-unauthorized and happy-delete for this handler).

**One infrastructure line required, not a `.rs` production change**: `root-llm-provider` was missing from the root `Cargo.toml`'s `ironclaw_reborn_composition` dev-dependency feature list — without it, `.with_boot_config` and the real LLM-config service don't exist in the `tests/integration` build at all. Added it, with a rationale comment matching the file's own established convention for that line. Verified dev-dependency-only and behavior-neutral: the shipped `ironclaw-reborn` binary (`ironclaw_reborn_cli`) already has `default = ["root-llm-provider"]`, so production behavior is unchanged. Confirmed with a clean build and the existing `webui_v2_product_api.rs` suite passing identically (21/21, same tests) before vs. after enabling the feature.

## Scope note — two items investigated, not implemented

**Filesystem/project-browsing API tier-2 coverage** (also flagged as a zero-to-one gap): investigated and found genuinely blocked without a **production crate-source change**. The concrete reader types (`ProjectScopedFilesystemReader`, `MountScopedFilesystemReader`) and the `RebornRuntime` accessors that would hand back an instance are `pub(crate)` to `ironclaw_reborn_composition` — `tests/integration` is a separate crate and can't name either. The one already-public test-support escape hatch (`local_dev_profile_filesystem_for_test`) only exposes the raw `RootFilesystem`, which would mean reimplementing the production reader's path-scoping/traversal-protection logic in test code — testing a reimplementation, not the real production code, which would be worse than no coverage. Closing this for real needs a new `#[cfg(feature = "test-support")]` accessor in `crates/ironclaw_reborn_composition/src/factory.rs` (precedented by 3 sibling `_for_test` accessors in that exact file, but still a production-crate diff). Not implementing per the test-only constraint on this PR; reporting instead.

**`golden_payload.rs:232-242`'s two "NOT implemented — blocked" compaction gaps** (`classify_compaction_message`, `ActiveTaskPreservingCompactionStrategy::should_compact`): read the comment and both functions directly. Turns out both are already genuinely covered at tier-2 through a real turn — `tests/integration/http_matcher.rs::multi_tool_turn_survives_failed_forced_compaction_after_results` scripts enough content to trip the real ~8,000-token force-compaction threshold and reach both functions, asserted via `assert_compaction_failed_since(..., "security rejected")`. `golden_payload.rs`'s own docstring states its design constraint ("curated scenario set... add a scenario only when an existing one can't absorb it") — the multi-thousand-token transcript needed would produce an unreviewable golden snapshot, so that file's exclusion is a correct, deliberate scope decision already satisfied elsewhere, not an actual gap. Nothing to add for the two named functions. (A smaller, separate, genuinely-real gap exists — only the `Include`/security-reject disposition of `classify_compaction_message` is exercised through a real turn, the other 3 dispositions are unit-tested only — but closing it needs new test-support harness scaffolding to seed specific message statuses, a distinct piece of design work, not a one-scenario add. Flagging as a follow-up, not bolting it onto this PR.)

## Verification

- `cargo test --test reborn_integration_tool_call` — 28/28 pass, including both new `StorageMode` cases.
- `cargo test --test reborn_integration_operator_llm_config` — 13/13 pass; mutation-tested the core assertion (flipped an expected value, confirmed the test fails for the right reason with the real provider snapshot in the panic message) to confirm it's genuinely discriminating, not vacuous.
- `cargo test --test reborn_integration_webui_v2_product_api --test reborn_integration_webui_v2_router_smoke` — unchanged 21+1/22 pass before/after the `root-llm-provider` feature flip, confirming zero behavioral effect on existing coverage.
- `cargo test -p ironclaw_architecture` — 34/34 pass (dependency/composition boundaries unaffected).
- `cargo fmt --check` / `cargo clippy --all-features` on all touched files — clean, zero warnings.
- Reviewed both plans with `thermo-nuclear-code-quality-review` before implementing (twice total across the two work items), and the final diffs after (twice) — no structural blockers either pass.
- Ran the 8-agent `code-review` skill in local mode on both diffs. First pass (storage-mode parametrization): zero findings. Second pass (operator API + Cargo.toml): 2 actionable findings, both addressed — a missing 404-unknown-provider negative-path assertion (added by extending the existing test) and a missing build-cost rationale comment on the Cargo.toml feature addition (added, matching the file's own convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)