### PR TITLE
feat(reborn-tests): add fixture-sourced LLM seam for tier-2 integration harness

### DIFF
--- a/tests/integration/support/builder.rs
+++ b/tests/integration/support/builder.rs
@@ -172,7 +172,12 @@ impl RebornIntegrationHarnessBuilder {
     /// `tests/fixtures/llm_traces/reborn_qa/`) instead of hand-written
     /// `RebornScriptedReply`s — same vendor-SDK seam, realistic reply content.
     /// Mutually exclusive with `.script(...)`: the last call wins (see
-    /// `ReplySource`).
+    /// `ReplySource`). Only replays `steps` (reply content) — a caller wanting
+    /// the fixture's `http_exchanges` to also drive realistic tool output must
+    /// separately wire them into `.with_keyed_http_responses(...)`, as
+    /// `tests/integration/tool_call.rs::runs_qa_fixture_trace_through_builtin_http_tools`
+    /// does; see that test's doc comment for why `expected_tool_results` and
+    /// multi-turn `TraceExpects` have no consumer.
     pub fn script_from_trace(mut self, trace: LlmTrace) -> Self {
         self.reply_source = ReplySource::Trace(Box::new(trace));
         self

--- a/tests/integration/support/builder.rs
+++ b/tests/integration/support/builder.rs
@@ -56,7 +56,7 @@ use super::capability_backend::{
     CapabilityScriptingInputs, MOCK_MCP_PROVIDER_ID, RebornCapabilityBackend, ShellMode,
 };
 use super::doubles::ParkingCapabilityGate;
-use super::group::{GroupCapability, GroupSharedStorage, RebornIntegrationGroup};
+use super::group::{GroupCapability, GroupSharedStorage, RebornIntegrationGroup, ReplySource};
 use super::harness::{HarnessCapabilityRecorder, HarnessTurnBackend, RecordedCapabilityResult};
 use super::http_matcher::ScriptedHttpResponse;
 use super::planned_runtime_parts_shape::DefaultPlannedRuntimePartsShape;
@@ -65,7 +65,7 @@ use super::reply::RebornScriptedReply;
 use super::scripted_provider::ParkingModelGate;
 use super::session_thread::RebornThreadHarness;
 use super::test_adapter::RebornTestIngress;
-use crate::support::trace_llm::TraceLlm;
+use crate::support::trace_llm::{LlmTrace, TraceLlm};
 
 type HarnessResult<T> = Result<T, Box<dyn std::error::Error + Send + Sync>>;
 
@@ -99,7 +99,7 @@ pub enum StorageMode {
 /// queue.
 pub struct RebornIntegrationHarnessBuilder {
     conversation_id: String,
-    replies: Vec<RebornScriptedReply>,
+    reply_source: ReplySource,
     capability: RebornCapabilityBackend,
     keyed_http_responses: Vec<ScriptedHttpResponse>,
     web_access_response_bodies: Vec<Vec<u8>>,
@@ -159,9 +159,22 @@ pub struct RebornIntegrationHarnessBuilder {
 }
 
 impl RebornIntegrationHarnessBuilder {
-    /// Set the scripted model replies (consumed in order at the raw-provider seam).
+    /// Set the scripted model replies (consumed in order at the raw-provider
+    /// seam). Mutually exclusive with `.script_from_trace(...)`: the last
+    /// call wins (see `ReplySource`).
     pub fn script(mut self, replies: impl IntoIterator<Item = RebornScriptedReply>) -> Self {
-        self.replies = replies.into_iter().collect();
+        self.reply_source = ReplySource::Scripted(replies.into_iter().collect());
+        self
+    }
+
+    /// Script this harness's model replies from a raw `LlmTrace` (e.g. loaded
+    /// via `LlmTrace::from_file` from a tier-5 QA fixture under
+    /// `tests/fixtures/llm_traces/reborn_qa/`) instead of hand-written
+    /// `RebornScriptedReply`s — same vendor-SDK seam, realistic reply content.
+    /// Mutually exclusive with `.script(...)`: the last call wins (see
+    /// `ReplySource`).
+    pub fn script_from_trace(mut self, trace: LlmTrace) -> Self {
+        self.reply_source = ReplySource::Trace(Box::new(trace));
         self
     }
 
@@ -534,7 +547,7 @@ impl RebornIntegrationHarnessBuilder {
             .await?;
         group
             .thread(self.conversation_id)
-            .script(self.replies)
+            .with_reply_source(self.reply_source)
             .park_model_opt(self.park_gate)
             .fail_model_opt(self.fail_model)
             .build()
@@ -622,7 +635,7 @@ impl RebornIntegrationHarness {
     pub fn builder(conversation_id: impl Into<String>) -> RebornIntegrationHarnessBuilder {
         RebornIntegrationHarnessBuilder {
             conversation_id: conversation_id.into(),
-            replies: Vec::new(),
+            reply_source: ReplySource::default(),
             capability: RebornCapabilityBackend::Echo,
             keyed_http_responses: Vec::new(),
             web_access_response_bodies: Vec::new(),

--- a/tests/integration/support/group.rs
+++ b/tests/integration/support/group.rs
@@ -127,7 +127,7 @@ use super::scripted_provider::{
 };
 use super::session_thread::RebornThreadHarness;
 use super::test_adapter::{RebornTestIngress, RebornTestProductAdapter};
-use crate::support::trace_llm::TraceLlm;
+use crate::support::trace_llm::{LlmTrace, TraceLlm};
 
 /// Per-capability preset constructors layered on `build_base`/`into_group`
 /// below. A private child module (not `pub mod` from `mod.rs`) so its only
@@ -412,7 +412,7 @@ impl RebornIntegrationGroup {
         RebornThreadBuilder {
             group: self,
             conversation_id: conversation_id.into(),
-            replies: Vec::new(),
+            reply_source: ReplySource::default(),
             actor_id: None,
             model_mode: ThreadModelMode::Normal,
             model_override: None,
@@ -1027,7 +1027,7 @@ impl TurnEventSink for FanOutTurnEventSink {
 pub struct RebornThreadBuilder<'g> {
     group: &'g RebornIntegrationGroup,
     conversation_id: String,
-    replies: Vec<RebornScriptedReply>,
+    reply_source: ReplySource,
     actor_id: Option<String>,
     model_mode: ThreadModelMode,
     /// C-ATTACH seam: overrides `LlmModelProfileRoute.model_override` (the same
@@ -1036,6 +1036,43 @@ pub struct RebornThreadBuilder<'g> {
     /// are dropped); `Some` routes through a vision-capable id so `convert_messages`
     /// builds `ContentPart::ImageUrl` parts.
     model_override: Option<String>,
+}
+
+/// A thread's source of scripted model replies: hand-written
+/// `RebornScriptedReply`s (the default, via `.script(...)`) or a raw
+/// `LlmTrace` loaded from a recorded fixture (via `.script_from_trace(...)`,
+/// e.g. a tier-5 QA trace under `tests/fixtures/llm_traces/reborn_qa/`). One
+/// enum instead of a `Vec` + `Option<LlmTrace>` pair (mirrors `ThreadModelMode`
+/// below) so the two sources are mutually exclusive BY CONSTRUCTION — a
+/// `.script(...)` call can never be silently shadowed by an earlier
+/// `.script_from_trace(...)` call left over from a copy-pasted test, or vice
+/// versa; whichever was called last simply IS the state.
+pub(crate) enum ReplySource {
+    /// Hand-written replies (the default, empty until `.script(...)` is called).
+    Scripted(Vec<RebornScriptedReply>),
+    /// A raw trace loaded from a fixture, replayed as-is — bypasses
+    /// `RebornScriptedReply` and its tool-call-id canonicalization entirely
+    /// (design §4.2's "no raw `LlmTrace` construction" rule governs
+    /// hand-rolled steps in test bodies, not loading a recorded fixture
+    /// through this sanctioned seam). Boxed: `LlmTrace` is far larger than
+    /// `Vec<RebornScriptedReply>`'s pointer-sized representation, and
+    /// clippy's `large_enum_variant` flags the unboxed size gap.
+    Trace(Box<LlmTrace>),
+}
+
+impl Default for ReplySource {
+    fn default() -> Self {
+        Self::Scripted(Vec::new())
+    }
+}
+
+impl ReplySource {
+    fn into_trace_llm(self) -> TraceLlm {
+        match self {
+            Self::Scripted(replies) => scripted_trace_llm(replies),
+            Self::Trace(trace) => TraceLlm::from_trace(*trace),
+        }
+    }
 }
 
 /// A thread's model-call behavior: exactly one of normal scripted playback,
@@ -1060,9 +1097,30 @@ enum ThreadModelMode {
 
 impl<'g> RebornThreadBuilder<'g> {
     /// Set the scripted model replies for this thread (consumed in order at the
-    /// raw-provider seam, one per model turn).
+    /// raw-provider seam, one per model turn). Mutually exclusive with
+    /// `.script_from_trace(...)`: the last call wins (see `ReplySource`).
     pub fn script(mut self, replies: impl IntoIterator<Item = RebornScriptedReply>) -> Self {
-        self.replies = replies.into_iter().collect();
+        self.reply_source = ReplySource::Scripted(replies.into_iter().collect());
+        self
+    }
+
+    /// Script this thread's model replies from a raw `LlmTrace` (e.g. loaded via
+    /// `LlmTrace::from_file` from a tier-5 QA fixture under
+    /// `tests/fixtures/llm_traces/reborn_qa/`) instead of hand-written
+    /// `RebornScriptedReply`s — same vendor-SDK seam, realistic reply content.
+    /// Mutually exclusive with `.script(...)`: the last call wins (see
+    /// `ReplySource`).
+    pub fn script_from_trace(mut self, trace: LlmTrace) -> Self {
+        self.reply_source = ReplySource::Trace(Box::new(trace));
+        self
+    }
+
+    /// Internal: set the reply source directly (used by the flat builder to
+    /// thread its own `.script(...)`/`.script_from_trace(...)` choice through
+    /// the degenerate one-thread group — mirrors `park_model_opt`/
+    /// `fail_model_opt` below).
+    pub(crate) fn with_reply_source(mut self, source: ReplySource) -> Self {
+        self.reply_source = source;
         self
     }
 
@@ -1175,7 +1233,7 @@ impl<'g> RebornThreadBuilder<'g> {
         // wraps it in a parking provider at the SAME vendor-SDK seam (decorator
         // chain still runs on top), so captured requests stay inspectable either
         // way.
-        let scripted_llm: Arc<TraceLlm> = Arc::new(scripted_trace_llm(self.replies));
+        let scripted_llm: Arc<TraceLlm> = Arc::new(self.reply_source.into_trace_llm());
         // C-ERRORS: `Failing` swaps in `ErrLlm` at the same vendor-SDK seam;
         // `Parked` swaps in the parking wrapper. `ThreadModelMode` makes the
         // three modes mutually exclusive by construction — no priority rule

--- a/tests/integration/support/group.rs
+++ b/tests/integration/support/group.rs
@@ -1109,7 +1109,12 @@ impl<'g> RebornThreadBuilder<'g> {
     /// `tests/fixtures/llm_traces/reborn_qa/`) instead of hand-written
     /// `RebornScriptedReply`s — same vendor-SDK seam, realistic reply content.
     /// Mutually exclusive with `.script(...)`: the last call wins (see
-    /// `ReplySource`).
+    /// `ReplySource`). Only replays `steps` (reply content) — a caller wanting
+    /// the fixture's `http_exchanges` to also drive realistic tool output must
+    /// separately wire them into `.with_keyed_http_responses(...)`, as
+    /// `tests/integration/tool_call.rs::runs_qa_fixture_trace_through_builtin_http_tools`
+    /// does; see that test's doc comment for why `expected_tool_results` and
+    /// multi-turn `TraceExpects` have no consumer.
     pub fn script_from_trace(mut self, trace: LlmTrace) -> Self {
         self.reply_source = ReplySource::Trace(Box::new(trace));
         self

--- a/tests/integration/tool_call.rs
+++ b/tests/integration/tool_call.rs
@@ -14,6 +14,7 @@ use reborn_support::builder::RebornIntegrationHarness;
 use reborn_support::group::RebornIntegrationGroup;
 use reborn_support::reply::RebornScriptedReply;
 use serde_json::json;
+use support::trace_llm::LlmTrace;
 
 const SLACK_PERSONAL_SCOPES: &[&str] = &[
     "search:read",
@@ -110,6 +111,79 @@ async fn runs_http_tool_call_through_recorded_egress() {
 }
 
 const HTTP_TOOL_URL: &str = "https://api.example.test/v1/items";
+
+/// Loads the `web_hn_search` tier-5 QA fixture (two parallel `builtin.http`
+/// tool calls, then a text reply) shared by the `script_from_trace` tests
+/// below, so neither test body carries the path-join/file-load boilerplate.
+fn web_hn_search_trace() -> LlmTrace {
+    let fixture_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/llm_traces/reborn_qa/web_hn_search.json");
+    LlmTrace::from_file(&fixture_path)
+        .unwrap_or_else(|error| panic!("QA fixture {} loads: {error}", fixture_path.display()))
+}
+
+/// The fixture's own recorded user turn — must match its
+/// `request_hint.last_user_message_contains` so the FIFO/hint-scan replay in
+/// `TraceLlm::next_step` plays steps back in the fixture's own recorded order.
+const WEB_HN_SEARCH_USER_TURN: &str =
+    "search Hacker News for any recent posts mentioning 'IronClaw' or 'NEAR AI'";
+
+/// Proves `RebornIntegrationHarnessBuilder::script_from_trace` — the
+/// fixture-sourced LLM seam. Replays a tier-5 QA fixture directly through the
+/// SAME vendor-SDK `TraceLlm` seam `.script(...)` uses, bypassing
+/// `RebornScriptedReply` entirely. Unlike the hand-written replies elsewhere
+/// in this file, this content came from a real recorded model exchange, so
+/// this is the proof the new entry point actually replays a realistic trace
+/// end to end (real coordinator, real dispatch, real recorded egress) — not
+/// just that it compiles. `http_exchanges`/`expected_tool_results` on the
+/// fixture have no consumer yet at this seam; this test only replays
+/// `steps` and asserts on the finalized reply and tool dispatch.
+#[tokio::test]
+async fn runs_qa_fixture_trace_through_builtin_http_tools() {
+    let h = RebornIntegrationHarness::test_default()
+        .with_builtin_http_tools()
+        .script_from_trace(web_hn_search_trace())
+        .build()
+        .await
+        .expect("harness builds from a fixture-sourced trace");
+
+    h.submit_turn(WEB_HN_SEARCH_USER_TURN)
+        .await
+        .expect("fixture-scripted turn completes");
+    h.assert_tool_invoked("builtin.http")
+        .await
+        .expect("fixture's builtin.http calls ran through the real recorded egress");
+    h.assert_reply_contains("Hacker News")
+        .await
+        .expect("fixture's final text reply is the turn's finalized output");
+}
+
+/// `ReplySource`'s documented "last call wins" contract: chaining
+/// `.script(...)` then `.script_from_trace(...)` on the same builder must
+/// replay the trace, not merge with or fall back to the earlier hand-written
+/// reply. Proven by asserting the fixture's `builtin.http` call actually ran
+/// — the hand-scripted reply below is text-only, so a tool invocation can
+/// only come from the trace having overridden it.
+#[tokio::test]
+async fn script_from_trace_after_script_overrides_scripted_replies() {
+    let h = RebornIntegrationHarness::test_default()
+        .with_builtin_http_tools()
+        .script([RebornScriptedReply::text(
+            "must not play back: overridden by script_from_trace",
+        )])
+        .script_from_trace(web_hn_search_trace())
+        .build()
+        .await
+        .expect("harness builds");
+
+    h.submit_turn(WEB_HN_SEARCH_USER_TURN)
+        .await
+        .expect("turn completes from the fixture trace, not the earlier .script(...) call");
+    h.assert_tool_invoked("builtin.http").await.expect(
+        "later .script_from_trace(...) call wins: the fixture's tool call ran, proving the \
+         earlier .script(...) reply was overridden, not merged",
+    );
+}
 
 /// A prior assistant refusal is conversation history, not capability truth.
 /// Once Slack is installed and activated, the refreshed tool definitions must

--- a/tests/integration/tool_call.rs
+++ b/tests/integration/tool_call.rs
@@ -12,6 +12,7 @@ mod support;
 use ironclaw_threads::MessageKind;
 use reborn_support::builder::RebornIntegrationHarness;
 use reborn_support::group::RebornIntegrationGroup;
+use reborn_support::http_matcher::ScriptedHttpResponse;
 use reborn_support::reply::RebornScriptedReply;
 use serde_json::json;
 use support::trace_llm::LlmTrace;
@@ -128,6 +129,25 @@ fn web_hn_search_trace() -> LlmTrace {
 const WEB_HN_SEARCH_USER_TURN: &str =
     "search Hacker News for any recent posts mentioning 'IronClaw' or 'NEAR AI'";
 
+/// Converts a trace's recorded `http_exchanges` into keyed scripted HTTP
+/// responses (`.with_keyed_http_responses(...)`), so a `builtin.http` tool
+/// call replays the SAME real response the fixture recorded instead of a
+/// generic canned body. Kept alongside `web_hn_search_trace()` so the test
+/// body stays in the `build -> submit_turn -> assert` shape.
+fn keyed_http_responses_from_trace(trace: &LlmTrace) -> Vec<ScriptedHttpResponse> {
+    trace
+        .http_exchanges
+        .iter()
+        .map(|exchange| {
+            ScriptedHttpResponse::for_url(
+                exchange.request.url.clone(),
+                exchange.response.body.clone(),
+            )
+            .with_status(exchange.response.status)
+        })
+        .collect()
+}
+
 /// Proves `RebornIntegrationHarnessBuilder::script_from_trace` — the
 /// fixture-sourced LLM seam. Replays a tier-5 QA fixture directly through the
 /// SAME vendor-SDK `TraceLlm` seam `.script(...)` uses, bypassing
@@ -135,14 +155,41 @@ const WEB_HN_SEARCH_USER_TURN: &str =
 /// in this file, this content came from a real recorded model exchange, so
 /// this is the proof the new entry point actually replays a realistic trace
 /// end to end (real coordinator, real dispatch, real recorded egress) — not
-/// just that it compiles. `http_exchanges`/`expected_tool_results` on the
-/// fixture have no consumer yet at this seam; this test only replays
-/// `steps` and asserts on the finalized reply and tool dispatch.
+/// just that it compiles.
+///
+/// `http_exchanges` (this fixture's 2 recorded `builtin.http` request/response
+/// pairs) IS consumed: wired into `.with_keyed_http_responses(...)` so each of
+/// the 2 parallel tool calls replays its OWN real recorded HTTP response
+/// instead of a generic canned body, then asserted via distinctive substrings
+/// unique to each recorded response — proving both per-call URL-keyed routing
+/// and that `builtin.http` handles realistic (20KB+) response bodies correctly.
+///
+/// `expected_tool_results` deliberately has NO consumer here — investigated
+/// and found not composable without a production change. It is captured at
+/// recording time as literally `ChatMessage{role: Role::Tool}.content`
+/// (`crates/ironclaw_llm/src/recording.rs:986-994`), but today's harness
+/// (every capability-IO mode) always renders a compact `ToolResultReference`
+/// observation envelope there, never that fixture's old verbose flattened
+/// content — a real production tool-result-serialization change since these
+/// fixtures were recorded, not a test-harness gap. Tier-5's own more mature
+/// QA harness independently confirms this: `strip_expected_tool_results`
+/// (`tests/support/reborn_parity_qa/qa_trace.rs`) runs before every real
+/// runtime replay in `tests/reborn_qa_recorded_behavior.rs` — even the
+/// gateway-seam harness never exact-matches this field against live-executed
+/// tool output. Reproducing it would mean reverting production's tool-result
+/// serialization to a shape it no longer uses, out of scope for a test-only
+/// change.
+///
+/// Multi-turn `TraceExpects` also has no consumer: every fixture under
+/// `tests/fixtures/llm_traces/reborn_qa/` is single-turn (exactly one
+/// `user_input` step each), so there is no real fixture data to drive a
+/// multi-turn `script_from_trace` test against.
 #[tokio::test]
 async fn runs_qa_fixture_trace_through_builtin_http_tools() {
+    let trace = web_hn_search_trace();
     let h = RebornIntegrationHarness::test_default()
-        .with_builtin_http_tools()
-        .script_from_trace(web_hn_search_trace())
+        .with_keyed_http_responses(keyed_http_responses_from_trace(&trace))
+        .script_from_trace(trace)
         .build()
         .await
         .expect("harness builds from a fixture-sourced trace");
@@ -153,6 +200,15 @@ async fn runs_qa_fixture_trace_through_builtin_http_tools() {
     h.assert_tool_invoked("builtin.http")
         .await
         .expect("fixture's builtin.http calls ran through the real recorded egress");
+    // Each recorded exchange's real HN result title — presence of BOTH proves
+    // the 2 parallel tool calls each replayed their OWN recorded response
+    // (not both landing on the same exchange or a generic default body).
+    h.assert_tool_result_contains("IronClaw: a Rust-based clawd")
+        .await
+        .expect("first recorded HTTP exchange's real body reached the tool result");
+    h.assert_tool_result_contains("Commercial jet collides with Black Hawk helicopter")
+        .await
+        .expect("second recorded HTTP exchange's real body reached the tool result");
     h.assert_reply_contains("Hacker News")
         .await
         .expect("fixture's final text reply is the turn's finalized output");


### PR DESCRIPTION
## Summary

Lane 2/4 of the Reborn tier-2 integration harness extension plan (`docs/plans/2026-07-15-reborn-tier2-extension-plan.md`, section 2 "Realistic-fixture LLM seam"). Scope limited to that section only — sibling lanes cover sections 1/3/4 in separate worktrees.

**Problem:** tier-2's scripted LLM replies (`RebornScriptedReply`) are hand-written and can't catch real provider quirks. Tier-5 (`tests/fixtures/llm_traces/reborn_qa/*.json`) already has recorded real traces in the same `LlmTrace`/`TraceStep` schema, but tier-2 had no way to consume them — `RebornIntegrationHarnessBuilder::script()` only accepted `RebornScriptedReply`, and the already-existing `TraceLlm::from_file`/`from_trace` were never called from `tests/integration/`.

**What was added (commit 1):**
- `RebornIntegrationHarnessBuilder::script_from_trace(LlmTrace)` and the matching `RebornThreadBuilder::script_from_trace` (`tests/integration/support/builder.rs`, `tests/integration/support/group.rs`) — bypasses `RebornScriptedReply` entirely and assigns `TraceLlm::from_trace(trace)` at the same vendor-SDK seam `.script(...)` uses. Zero-setup/offline, same as today.
- A `ReplySource` enum (`Scripted(Vec<RebornScriptedReply>) | Trace(Box<LlmTrace>)`) replacing the old bare `Vec<RebornScriptedReply>` field on both builders, so the two reply sources are mutually exclusive **by construction** instead of a silently-shadowable `Vec` + `Option` pair — mirrors the existing `ThreadModelMode` pattern in the same file. `RebornThreadBuilder::with_reply_source` is the internal passthrough the flat builder uses, mirroring the existing `park_model_opt`/`fail_model_opt` convention.
- Two new tests in `tests/integration/tool_call.rs`, both loading `tests/fixtures/llm_traces/reborn_qa/web_hn_search.json` (two parallel `builtin.http` tool calls + a text reply):
  - `runs_qa_fixture_trace_through_builtin_http_tools` — drives the fixture end to end (real coordinator, real dispatch, real recorded egress).
  - `script_from_trace_after_script_overrides_scripted_replies` — pins the `ReplySource` "last call wins" contract.

**What was added (commit 2 — follow-up expansion, same PR):** since this is test-only work (zero production behavior change, only ever increases coverage), expanded the same fixture's still-unconsumed fields rather than deferring:
- **`http_exchanges`** — now consumed. `runs_qa_fixture_trace_through_builtin_http_tools` wires the fixture's 2 recorded HTTP request/response pairs into the harness's existing `.with_keyed_http_responses(...)` (via a small `keyed_http_responses_from_trace` test helper), so each of the 2 parallel `builtin.http` calls replays its *own* real recorded response instead of a generic canned body. New assertions check for a distinctive substring from *each* recorded response, proving both per-call URL-keyed routing correctness and that `builtin.http` handles realistic (20KB+) response bodies correctly — genuinely stronger coverage than the original commit's version, which never touched real tool-call content.
- **`expected_tool_results`** — investigated, found **not composable without a production code change**, documented instead of forced. `expected_tool_results[i].content` is captured at recording time as literally `ChatMessage{role: Role::Tool}.content` (`crates/ironclaw_llm/src/recording.rs:986-994`). Empirically confirmed (via a throwaway diagnostic test, since removed) that *every* capability-IO mode in today's harness renders a compact `ToolResultReference` observation envelope for that field, never the fixture's old verbose recorded content — a genuine production tool-result-serialization change since these fixtures were recorded, not a test-harness gap. Independently corroborated by tier-5's own more mature QA harness: `strip_expected_tool_results` (`tests/support/reborn_parity_qa/qa_trace.rs`) runs before *every* real-runtime replay in `tests/reborn_qa_recorded_behavior.rs` — even the gateway-seam harness never exact-matches this field against live-executed tool output. Reproducing it would mean reverting production's tool-result serialization to a shape it no longer uses.
- **Multi-turn `TraceExpects`** — investigated, found **no real fixture data exists to exercise it**. Every fixture under `tests/fixtures/llm_traces/reborn_qa/` is single-turn (exactly one `user_input` step each), confirmed against `LlmTrace`'s own turn-splitting deserialization logic. No test was added rather than hand-constructing a synthetic multi-turn trace (which would also violate the repo's own "no raw `LlmTrace` construction in test bodies" convention).

## Verification

```
cargo test --test reborn_integration_tool_call         # 29/29 passed
cargo clippy --test reborn_integration_tool_call --all-features -- -D warnings   # clean
cargo check --tests                                      # all ~50 integration test bins compile
cargo clippy --all --benches --tests --examples --all-features -- -D warnings   # clean, full workspace
cargo fmt                                                 # applied
```

Written test-first (both tests initially failed to compile against the not-yet-existing `.script_from_trace(...)` method, then passed once the builder method was added — red/green).

## Review

- Plan reviewed with `thermo-nuclear-code-quality-review` before each round of implementation.
- `code-review` skill run in local mode twice (round 1: 7/8 reviewers, `maintainability` didn't return within the session, superseded by a manual thermo-nuclear pass; round 2: 8/8 reviewers, all returned). Real findings across both rounds, all fixed or explicitly deferred with rationale:
  - Missing "last call wins" test → fixed.
  - Test body exceeded the `tests/integration/CLAUDE.md` build→submit_turn→assert shape (round 1, then again in round 2 for the new `http_exchanges` wiring) → fixed both times by extracting shared helpers.
  - No test calling `RebornThreadBuilder::script_from_trace` directly on a multi-thread group → deferred (same code path as the already-tested flat-builder passthrough; sibling methods `park_model_opt`/`fail_model_opt` have the identical shape with no dedicated group-direct test).
  - Round 2's `approach` reviewer independently corroborated that tier-5's `HttpExchange`-native replay mechanism (`ReplayingHttpInterceptor`) rides a different seam than tier-2's `ScriptedHttpResponse`/`RuntimeHttpEgress` matcher and isn't directly reusable — matching this PR's own investigation.

## Guardrail respected

No production (`src/`/`crates/`) code was touched in either commit — only `tests/integration/support/*.rs` (test-support/harness code) and `tests/integration/tool_call.rs` (test file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)