### PR TITLE
test(webui-v2): add SSE wire-contract fixture round-trip test

### DIFF
--- a/crates/ironclaw_webui_v2/frontend/src/pages/chat/lib/sse-wire-contract.test.ts
+++ b/crates/ironclaw_webui_v2/frontend/src/pages/chat/lib/sse-wire-contract.test.ts
@@ -1,0 +1,255 @@
+// @ts-nocheck
+//
+// SSE wire-contract fixture round-trip: proves the Rust emission side
+// (`crates/ironclaw_webui_v2/tests/webui_v2_schema_contract.rs`'s
+// `sse_wire_contract_fixtures_match_committed_json`, plus the `error`
+// fixture in `webui_v2_handlers_contract.rs`) and this frontend's SSE
+// parsing agree on wire shape.
+//
+// Today that agreement is pinned by nothing but a comment in `useSSE.ts`
+// ("mirror WebChatV2Event::event_name() in schema.rs") — a renamed or
+// dropped field on either side would only surface nightly, in Playwright.
+// This test drives each committed fixture through the REAL `useSSE` +
+// `useChatEvents` hooks (via the shared `vm`-context harnesses already
+// built for their own unit tests — imported, not reimplemented) and
+// asserts every field the Rust side emits actually lands in observable
+// state.
+//
+// Fixtures are the shared contract artifact: the same JSON files under
+// `../../../../../tests/fixtures/sse_wire_contract/` are read here AND by
+// the Rust test above. Regenerate both together after an intentional wire
+// change:
+//   UPDATE_SSE_FIXTURES=1 cargo test -p ironclaw_webui_v2
+// then re-run this suite (`pnpm test`) to confirm the frontend still
+// consumes every field.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "vitest";
+
+import { createHarness } from "./useSSE.test";
+import { createUseChatEventsHarness } from "./useChatEvents.test";
+import { gateFromEvent, gateFromProjectionGate } from "./gates";
+import { toolCardFromActivity, toolCardFromPreview } from "./history-messages";
+
+const FIXTURE_NAMES = [
+  "final_reply",
+  "running",
+  "capability_progress",
+  "capability_activity",
+  "capability_display_preview",
+  "gate",
+  "auth_required",
+  "projection_snapshot",
+  "projection_update",
+  "keep_alive",
+  "error",
+];
+
+function loadFixture(name) {
+  const raw = readFileSync(
+    new URL(`../../../../../tests/fixtures/sse_wire_contract/${name}.json`, import.meta.url),
+    "utf8",
+  );
+  return JSON.parse(raw);
+}
+
+const fixtures = Object.fromEntries(FIXTURE_NAMES.map((name) => [name, loadFixture(name)]));
+
+// Values `useChatEvents.ts` builds from object literals inside its own
+// source are constructed in the `vm.runInNewContext` sandbox's realm, not
+// this file's — `assert.deepEqual` treats same-shape values from different
+// realms as unequal (different `Object`/`Array` intrinsics). A JSON
+// round-trip strips that, matching `useChatEvents.test.ts`'s own `plain()`
+// helper. Values threaded through an *injected* real function (e.g.
+// `gateFromEvent`, imported in this file's realm) don't need it — the
+// closure's literals bind to the realm where the function was defined.
+function plain(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+test("every committed SSE fixture has a corresponding named event listener in useSSE", () => {
+  // Catches a fixture added on the Rust side without the matching
+  // `V2_EVENT_NAMES` entry on the frontend — the exact class of silent
+  // desync this whole test exists to prevent.
+  const { streams } = createHarness();
+  const stream = streams[0];
+  for (const name of FIXTURE_NAMES) {
+    assert.ok(
+      typeof stream.listener(name) === "function",
+      `useSSE never registered a listener for SSE event "${name}"`,
+    );
+  }
+});
+
+// Dispatches `fixtureName`'s raw JSON through the REAL useSSE `dispatchFrame`
+// closure (via the named listener the hook registered with `EventSource`)
+// and returns exactly what useSSE hands to `onEvent` — i.e. exactly what
+// `useChat.ts` wires into `useChatEvents`'s handler in production.
+function dispatchFixtureThroughUseSSE(fixtureName) {
+  const captured = [];
+  const { streams } = createHarness({ onEvent: (envelope) => captured.push(envelope) });
+  const stream = streams[0];
+  const listener = stream.listener(fixtureName);
+  assert.ok(listener, `no useSSE listener registered for "${fixtureName}"`);
+  listener({
+    data: JSON.stringify(fixtures[fixtureName]),
+    lastEventId: "cursor:wire-contract-test",
+  });
+  assert.equal(captured.length, 1, `dispatchFrame did not call onEvent for "${fixtureName}"`);
+  return captured[0];
+}
+
+for (const name of FIXTURE_NAMES) {
+  test(`useSSE round-trips the committed "${name}" fixture without dropping fields`, () => {
+    const envelope = dispatchFixtureThroughUseSSE(name);
+    // `frame.type` is the canonical source; frames with no `type` field
+    // (the `error` frame) fall back to the SSE `event:` name — the one
+    // behavior only observable by driving the real named listener rather
+    // than calling a parsing function directly.
+    assert.equal(envelope.type, fixtures[name].type || "error");
+    assert.deepEqual(envelope.frame, fixtures[name]);
+  });
+}
+
+test('useChatEvents "final_reply": every reply field lands in the rendered message', () => {
+  const envelope = dispatchFixtureThroughUseSSE("final_reply");
+  const harness = createUseChatEventsHarness();
+  harness.handleEvent(envelope);
+
+  const { reply } = fixtures.final_reply;
+  assert.equal(harness.messages.length, 1);
+  assert.equal(harness.messages[0].content, reply.text);
+  assert.equal(harness.messages[0].timestamp, reply.generated_at);
+  assert.equal(harness.messages[0].turnRunId, reply.turn_run_id);
+  assert.equal(harness.messages[0].isFinalReply, true);
+  assert.equal(harness.isProcessing, false);
+});
+
+for (const name of ["running", "capability_progress"]) {
+  test(`useChatEvents "${name}": progress.turn_run_id drives the active run`, () => {
+    const envelope = dispatchFixtureThroughUseSSE(name);
+    const harness = createUseChatEventsHarness();
+    harness.handleEvent(envelope);
+
+    const { progress } = fixtures[name];
+    assert.deepEqual(plain(harness.activeRun), {
+      runId: progress.turn_run_id,
+      threadId: "thread-1",
+      status: "running",
+    });
+    assert.equal(harness.isProcessing, true);
+  });
+}
+
+test('useChatEvents "capability_activity": activity fields reach the tool-activity card', () => {
+  const envelope = dispatchFixtureThroughUseSSE("capability_activity");
+  const harness = createUseChatEventsHarness();
+  harness.handleEvent(envelope);
+
+  const { activity } = fixtures.capability_activity;
+  const expectedCard = toolCardFromActivity(activity);
+  const message = harness.messages.find(
+    (candidate) => candidate.id === `tool-${activity.invocation_id}`,
+  );
+  assert.ok(message, "expected a tool_activity message for the fixture's invocation_id");
+  assert.equal(message.role, "tool_activity");
+  assert.equal(message.invocationId, activity.invocation_id);
+  assert.equal(message.turnRunId, activity.turn_run_id);
+  assert.equal(message.capabilityId, activity.capability_id);
+  assert.equal(message.toolStatus, expectedCard.toolStatus);
+  assert.equal(message.toolDetail, expectedCard.toolDetail);
+});
+
+test('useChatEvents "capability_display_preview": preview fields reach the tool-activity card', () => {
+  const envelope = dispatchFixtureThroughUseSSE("capability_display_preview");
+  const harness = createUseChatEventsHarness();
+  harness.handleEvent(envelope);
+
+  const { preview } = fixtures.capability_display_preview;
+  const expectedCard = toolCardFromPreview(preview);
+  const message = harness.messages.find(
+    (candidate) => candidate.id === `tool-${preview.invocation_id}`,
+  );
+  assert.ok(message, "expected a tool_activity message for the fixture's invocation_id");
+  assert.equal(message.invocationId, preview.invocation_id);
+  assert.equal(message.turnRunId, preview.turn_run_id);
+  assert.equal(message.toolStatus, expectedCard.toolStatus);
+  assert.equal(message.toolName, expectedCard.toolName);
+  assert.equal(message.capabilityId, preview.capability_id);
+  assert.equal(message.toolDetail, expectedCard.toolDetail);
+  assert.equal(message.resultRef, expectedCard.resultRef);
+  assert.equal(message.truncated, expectedCard.truncated);
+  assert.equal(message.outputBytes, expectedCard.outputBytes);
+  assert.equal(message.outputKind, expectedCard.outputKind);
+});
+
+for (const name of ["gate", "auth_required"]) {
+  test(`useChatEvents "${name}": prompt fields reach pendingGate via the real gateFromEvent mapping`, () => {
+    const envelope = dispatchFixtureThroughUseSSE(name);
+    const harness = createUseChatEventsHarness({ gateFromEvent });
+    harness.handleEvent(envelope);
+
+    const { prompt } = fixtures[name];
+    // Computed from the real mapping function on the same fixture data,
+    // rather than a hand-duplicated expected shape, so this assertion
+    // tracks `gates.ts` instead of drifting from it.
+    assert.deepEqual(harness.pendingGate, gateFromEvent(name, prompt));
+    assert.equal(harness.isProcessing, false);
+  });
+}
+
+for (const name of ["projection_snapshot", "projection_update"]) {
+  test(`useChatEvents "${name}": run_status/text/gate items all land in observable state`, () => {
+    const envelope = dispatchFixtureThroughUseSSE(name);
+    const harness = createUseChatEventsHarness({ gateFromProjectionGate });
+    harness.handleEvent(envelope);
+
+    const [runStatusItem, textItem, gateItem] = fixtures[name].state.items;
+
+    assert.deepEqual(plain(harness.activeRun), {
+      runId: runStatusItem.run_status.run_id,
+      threadId: "thread-1",
+      status: runStatusItem.run_status.status,
+    });
+    assert.equal(
+      harness.messages.some(
+        (message) =>
+          message.id === `text-${textItem.text.id}` && message.content === textItem.text.body,
+      ),
+      true,
+      "expected the projection text item to render as an assistant message",
+    );
+    assert.deepEqual(harness.pendingGate, gateFromProjectionGate(gateItem.gate));
+  });
+}
+
+test('useChatEvents "keep_alive": mutates no observable state', () => {
+  const envelope = dispatchFixtureThroughUseSSE("keep_alive");
+  const harness = createUseChatEventsHarness();
+  harness.handleEvent(envelope);
+
+  assert.deepEqual(harness.messages, []);
+  assert.equal(harness.pendingGate, null);
+  assert.equal(harness.isProcessing, false);
+  assert.equal(harness.activeRun, null);
+});
+
+test('useChatEvents "error": error/kind/retryable reach onStreamError and the transcript', () => {
+  const envelope = dispatchFixtureThroughUseSSE("error");
+  const seenErrors = [];
+  const harness = createUseChatEventsHarness({
+    onStreamError: (payload) => seenErrors.push(payload),
+  });
+  harness.handleEvent(envelope);
+
+  const fixture = fixtures.error;
+  assert.deepEqual(plain(seenErrors), [
+    { error: fixture.error, kind: fixture.kind, retryable: fixture.retryable },
+  ]);
+  assert.equal(harness.messages.length, 1);
+  assert.equal(harness.messages[0].role, "error");
+  assert.equal(
+    harness.messages[0].content,
+    `stream:${fixture.error}:${fixture.kind}:${fixture.retryable}`,
+  );
+});

--- a/crates/ironclaw_webui_v2/frontend/src/pages/chat/lib/useChatEvents.test.ts
+++ b/crates/ironclaw_webui_v2/frontend/src/pages/chat/lib/useChatEvents.test.ts
@@ -57,7 +57,10 @@ function useChatEventsSourceForTest() {
   return `${lines.join("\n")}\nglobalThis.__testExports = { useChatEvents };`;
 }
 
-function createUseChatEventsHarness({
+// Exported so the SSE wire-contract fixture round-trip test
+// (`sse-wire-contract.test.ts`) can drive the real `useChatEvents` parsing
+// code against committed fixtures without re-implementing this vm harness.
+export function createUseChatEventsHarness({
   DateImpl = Date,
   gateFromEvent = () => null,
   failureMessageForRunStatus = () => "run failed",

--- a/crates/ironclaw_webui_v2/frontend/src/pages/chat/lib/useSSE.test.ts
+++ b/crates/ironclaw_webui_v2/frontend/src/pages/chat/lib/useSSE.test.ts
@@ -24,7 +24,14 @@ function useSSESourceForTest() {
   return `${lines.join("\n")}\nglobalThis.__testExports = { useSSE };`;
 }
 
-function createHarness({ online = true, visibilityState = "visible" } = {}) {
+// Exported so the SSE wire-contract fixture round-trip test
+// (`sse-wire-contract.test.ts`) can drive the real `useSSE` parsing code
+// against committed fixtures without re-implementing this vm harness.
+export function createHarness({
+  online = true,
+  visibilityState = "visible",
+  onEvent = () => {},
+} = {}) {
   const statuses = [];
   const streams = [];
   const timers = [];
@@ -95,7 +102,7 @@ function createHarness({ online = true, visibilityState = "visible" } = {}) {
   const result = context.globalThis.__testExports.useSSE({
     threadId: "thread-1",
     enabled: true,
-    onEvent: () => {},
+    onEvent,
   });
 
   return {

--- a/crates/ironclaw_webui_v2/tests/fixtures/sse_wire_contract/auth_required.json
+++ b/crates/ironclaw_webui_v2/tests/fixtures/sse_wire_contract/auth_required.json
@@ -1,0 +1,22 @@
+{
+  "cursor": "cursor:auth_required",
+  "prompt": {
+    "account_label": "user@example.test",
+    "auth_request_ref": "auth:fixture",
+    "body": "Paste the code from the connection screen.",
+    "challenge_kind": "manual_token",
+    "connection": {
+      "channel": "telegram",
+      "error_message": "That code did not match.",
+      "input_placeholder": "Pairing code",
+      "instructions": "Open the Telegram bot and send /pair.",
+      "strategy": "inbound_proof_code",
+      "submit_label": "Connect"
+    },
+    "expires_at": "2026-01-01T00:00:00Z",
+    "headline": "Connect your Google account",
+    "provider": "google",
+    "turn_run_id": "00000000-0000-0000-0000-000000000001"
+  },
+  "type": "auth_required"
+}

--- a/crates/ironclaw_webui_v2/tests/fixtures/sse_wire_contract/capability_activity.json
+++ b/crates/ironclaw_webui_v2/tests/fixtures/sse_wire_contract/capability_activity.json
@@ -1,0 +1,20 @@
+{
+  "activity": {
+    "activity_order": 1,
+    "capability_id": "script.echo",
+    "error_kind": null,
+    "input_summary": "path: src/main.rs",
+    "invocation_id": "00000000-0000-0000-0000-000000000002",
+    "output_bytes": null,
+    "process_id": null,
+    "provider": "script",
+    "runtime": "script",
+    "status": "running",
+    "subtitle": "src/main.rs",
+    "thread_id": "thread-fixture",
+    "turn_run_id": "00000000-0000-0000-0000-000000000001",
+    "updated_at": "2026-01-01T00:00:00Z"
+  },
+  "cursor": "cursor:capability_activity",
+  "type": "capability_activity"
+}

--- a/crates/ironclaw_webui_v2/tests/fixtures/sse_wire_contract/capability_display_preview.json
+++ b/crates/ironclaw_webui_v2/tests/fixtures/sse_wire_contract/capability_display_preview.json
@@ -1,0 +1,23 @@
+{
+  "cursor": "cursor:capability_display_preview",
+  "preview": {
+    "activity_order": 2,
+    "capability_id": "builtin.read_file",
+    "input_summary": "path: src/main.rs",
+    "invocation_id": "00000000-0000-0000-0000-000000000002",
+    "output_bytes": 12,
+    "output_kind": "text",
+    "output_preview": "fn main() {}",
+    "output_summary": "Read 12 bytes.",
+    "result_ref": "result:tool-output",
+    "status": "completed",
+    "subtitle": "src/main.rs",
+    "thread_id": "thread-fixture",
+    "timeline_message_id": "timeline-message-1",
+    "title": "read_file",
+    "truncated": false,
+    "turn_run_id": "00000000-0000-0000-0000-000000000001",
+    "updated_at": "2026-01-01T00:00:00Z"
+  },
+  "type": "capability_display_preview"
+}

--- a/crates/ironclaw_webui_v2/tests/fixtures/sse_wire_contract/capability_progress.json
+++ b/crates/ironclaw_webui_v2/tests/fixtures/sse_wire_contract/capability_progress.json
@@ -1,0 +1,9 @@
+{
+  "cursor": "cursor:capability_progress",
+  "progress": {
+    "generated_at": "2026-01-01T00:00:00Z",
+    "kind": "tool_running",
+    "turn_run_id": "00000000-0000-0000-0000-000000000001"
+  },
+  "type": "capability_progress"
+}

--- a/crates/ironclaw_webui_v2/tests/fixtures/sse_wire_contract/error.json
+++ b/crates/ironclaw_webui_v2/tests/fixtures/sse_wire_contract/error.json
@@ -1,0 +1,5 @@
+{
+  "error": "forbidden",
+  "kind": "participant_denied",
+  "retryable": false
+}

--- a/crates/ironclaw_webui_v2/tests/fixtures/sse_wire_contract/final_reply.json
+++ b/crates/ironclaw_webui_v2/tests/fixtures/sse_wire_contract/final_reply.json
@@ -1,0 +1,9 @@
+{
+  "cursor": "cursor:final_reply",
+  "reply": {
+    "generated_at": "2026-01-01T00:00:00Z",
+    "text": "This is the assistant's final reply.",
+    "turn_run_id": "00000000-0000-0000-0000-000000000001"
+  },
+  "type": "final_reply"
+}

--- a/crates/ironclaw_webui_v2/tests/fixtures/sse_wire_contract/gate.json
+++ b/crates/ironclaw_webui_v2/tests/fixtures/sse_wire_contract/gate.json
@@ -1,0 +1,32 @@
+{
+  "cursor": "cursor:gate",
+  "prompt": {
+    "allow_always": true,
+    "approval_context": {
+      "action": {
+        "label": "Run a shell command"
+      },
+      "destination": {
+        "label": "Local sandbox"
+      },
+      "details": [
+        {
+          "label": "Command",
+          "value": "echo hello"
+        }
+      ],
+      "reason": "The assistant wants to run a command.",
+      "scope": {
+        "label": "This action only",
+        "reusable": false
+      },
+      "tool_name": "shell"
+    },
+    "body": "This action needs your approval.",
+    "gate_ref": "gate:approval-fixture",
+    "headline": "Approve the fixture action",
+    "invocation_id": "00000000-0000-0000-0000-000000000002",
+    "turn_run_id": "00000000-0000-0000-0000-000000000001"
+  },
+  "type": "gate"
+}

--- a/crates/ironclaw_webui_v2/tests/fixtures/sse_wire_contract/keep_alive.json
+++ b/crates/ironclaw_webui_v2/tests/fixtures/sse_wire_contract/keep_alive.json
@@ -1,0 +1,4 @@
+{
+  "cursor": "cursor:keep_alive",
+  "type": "keep_alive"
+}

--- a/crates/ironclaw_webui_v2/tests/fixtures/sse_wire_contract/projection_snapshot.json
+++ b/crates/ironclaw_webui_v2/tests/fixtures/sse_wire_contract/projection_snapshot.json
@@ -1,0 +1,33 @@
+{
+  "cursor": "cursor:projection_snapshot",
+  "state": {
+    "items": [
+      {
+        "run_status": {
+          "run_id": "00000000-0000-0000-0000-000000000001",
+          "status": "blocked_approval"
+        }
+      },
+      {
+        "text": {
+          "body": "Working on it...",
+          "id": "message-1",
+          "run_id": "00000000-0000-0000-0000-000000000001"
+        }
+      },
+      {
+        "gate": {
+          "allow_always": false,
+          "body": "This action needs your approval.",
+          "gate_kind": "approval",
+          "gate_ref": "gate:projection-fixture",
+          "headline": "Approve the fixture action",
+          "invocation_id": "00000000-0000-0000-0000-000000000002",
+          "run_id": "00000000-0000-0000-0000-000000000001"
+        }
+      }
+    ],
+    "thread_id": "thread-fixture"
+  },
+  "type": "projection_snapshot"
+}

--- a/crates/ironclaw_webui_v2/tests/fixtures/sse_wire_contract/projection_update.json
+++ b/crates/ironclaw_webui_v2/tests/fixtures/sse_wire_contract/projection_update.json
@@ -1,0 +1,33 @@
+{
+  "cursor": "cursor:projection_update",
+  "state": {
+    "items": [
+      {
+        "run_status": {
+          "run_id": "00000000-0000-0000-0000-000000000001",
+          "status": "blocked_approval"
+        }
+      },
+      {
+        "text": {
+          "body": "Working on it...",
+          "id": "message-1",
+          "run_id": "00000000-0000-0000-0000-000000000001"
+        }
+      },
+      {
+        "gate": {
+          "allow_always": false,
+          "body": "This action needs your approval.",
+          "gate_kind": "approval",
+          "gate_ref": "gate:projection-fixture",
+          "headline": "Approve the fixture action",
+          "invocation_id": "00000000-0000-0000-0000-000000000002",
+          "run_id": "00000000-0000-0000-0000-000000000001"
+        }
+      }
+    ],
+    "thread_id": "thread-fixture"
+  },
+  "type": "projection_update"
+}

--- a/crates/ironclaw_webui_v2/tests/fixtures/sse_wire_contract/running.json
+++ b/crates/ironclaw_webui_v2/tests/fixtures/sse_wire_contract/running.json
@@ -1,0 +1,9 @@
+{
+  "cursor": "cursor:running",
+  "progress": {
+    "generated_at": "2026-01-01T00:00:00Z",
+    "kind": "typing",
+    "turn_run_id": "00000000-0000-0000-0000-000000000001"
+  },
+  "type": "running"
+}

--- a/crates/ironclaw_webui_v2/tests/support/golden_json.rs
+++ b/crates/ironclaw_webui_v2/tests/support/golden_json.rs
@@ -1,0 +1,60 @@
+//! Tiny shared golden-JSON-fixture helper for the SSE wire-contract
+//! fixtures (`webui_v2_schema_contract.rs`'s
+//! `sse_wire_contract_fixtures_match_committed_json` and
+//! `webui_v2_handlers_contract.rs`'s facade-error fixture test).
+//!
+//! Deliberately not `insta` (already a workspace dependency and used this
+//! way by `tests/integration/support/golden.rs`): these specific fixtures
+//! are also read directly by the frontend Vitest suite
+//! (`frontend/src/pages/chat/lib/sse-wire-contract.test.ts`) via
+//! `JSON.parse`, so they must be plain JSON files with no YAML frontmatter,
+//! which `insta`'s default `.snap` format carries.
+#![allow(dead_code)]
+
+use std::path::PathBuf;
+
+use serde_json::Value;
+
+fn fixtures_dir() -> PathBuf {
+    PathBuf::from(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/fixtures/sse_wire_contract"
+    ))
+}
+
+/// Compare `value` (pretty-printed, trailing newline) against the committed
+/// fixture `<name>.json`. With `UPDATE_SSE_FIXTURES=1` set, writes/
+/// overwrites the fixture instead of comparing — the regeneration path for
+/// an intentional wire-schema change. Missing fixture + no
+/// `UPDATE_SSE_FIXTURES` fails loudly rather than silently creating one, so
+/// a typo'd fixture name cannot "pass" on its first run.
+pub fn assert_or_update_json_fixture(name: &str, value: &Value) {
+    let rendered = format!(
+        "{}\n",
+        serde_json::to_string_pretty(value).expect("fixture value serializes to JSON")
+    );
+    let path = fixtures_dir().join(format!("{name}.json"));
+
+    if std::env::var_os("UPDATE_SSE_FIXTURES").is_some() {
+        std::fs::create_dir_all(path.parent().expect("fixture path has a parent directory"))
+            .expect("create SSE wire-contract fixtures directory");
+        std::fs::write(&path, &rendered).expect("write SSE wire-contract fixture");
+        return;
+    }
+
+    let committed = std::fs::read_to_string(&path).unwrap_or_else(|error| {
+        panic!(
+            "missing SSE wire-contract fixture {path:?}: {error}\n\
+             run `UPDATE_SSE_FIXTURES=1 cargo test -p ironclaw_webui_v2` to create it, \
+             review the diff, and commit it"
+        )
+    });
+    assert_eq!(
+        committed, rendered,
+        "SSE wire-contract fixture {path:?} is out of date.\n\
+         Run `UPDATE_SSE_FIXTURES=1 cargo test -p ironclaw_webui_v2` to regenerate, \
+         review the diff, and commit it. The frontend Vitest suite \
+         (frontend/src/pages/chat/lib/sse-wire-contract.test.ts) reads the same file — \
+         re-run it too after regenerating."
+    );
+}

--- a/crates/ironclaw_webui_v2/tests/webui_v2_handlers_contract.rs
+++ b/crates/ironclaw_webui_v2/tests/webui_v2_handlers_contract.rs
@@ -79,6 +79,9 @@ use serde_json::Value;
 use tokio::sync::{Notify, mpsc};
 use tower::ServiceExt;
 
+#[path = "support/golden_json.rs"]
+mod golden_json;
+
 fn caller() -> WebUiAuthenticatedCaller {
     caller_for_user("user-alpha")
 }
@@ -5875,6 +5878,60 @@ async fn stream_events_facade_error_emits_redacted_error_event_and_closes() {
         closed,
         "facade error must close the SSE stream, but body.frame() yielded another chunk"
     );
+}
+
+// Part of the SSE wire-contract fixture set pinned in
+// `webui_v2_schema_contract.rs`'s `sse_wire_contract_fixtures_match_-
+// committed_json` (see that test's doc comment for the full scope and the
+// `UPDATE_SSE_FIXTURES=1` regeneration command). The `error` frame lives
+// here instead of there because it is not a `WebChatV2Event` — it is the
+// standalone `SseErrorPayload` built by `sse_error_event`, only reachable
+// by actually driving the facade-error path through the real handler, the
+// same path `stream_events_facade_error_emits_redacted_error_event_and_-
+// closes` above already proves in detail (redaction, stream closure). This
+// test only adds the fixture dump so the frontend Vitest suite has an
+// `error` frame to round-trip through the real `useSSE`/`useChatEvents`
+// parsing code.
+#[tokio::test]
+async fn stream_events_facade_error_emits_error_fixture() {
+    let services = Arc::new(StubServices::default());
+    services.enqueue_stream_events(Err(RebornServicesError {
+        code: RebornServicesErrorCode::Forbidden,
+        kind: RebornServicesErrorKind::ParticipantDenied,
+        status_code: 403,
+        retryable: false,
+        field: Some("thread_id".into()),
+        validation_code: None,
+    }));
+
+    let router = router_with(services.clone());
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method(Method::GET)
+                .uri("/api/webchat/v2/threads/thread-x/events")
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("oneshot");
+
+    let mut body = response.into_body();
+    let bytes = collect_sse_until(&mut body, Duration::from_secs(2), |buf| {
+        buf.windows(b"event: error".len())
+            .any(|w| w == b"event: error")
+            && buf.windows(2).any(|w| w == b"\n\n")
+    })
+    .await;
+
+    let events = parse_sse_events(&bytes);
+    let error_event = events
+        .iter()
+        .find(|event| event.event.as_deref() == Some("error"))
+        .unwrap_or_else(|| panic!("expected an SSE `error` event, got: {events:?}"));
+    let payload: Value = serde_json::from_str(error_event.data.as_deref().expect("error data"))
+        .expect("error data is JSON");
+    golden_json::assert_or_update_json_fixture("error", &payload);
 }
 
 #[tokio::test]

--- a/crates/ironclaw_webui_v2/tests/webui_v2_schema_contract.rs
+++ b/crates/ironclaw_webui_v2/tests/webui_v2_schema_contract.rs
@@ -1,5 +1,10 @@
 use chrono::Utc;
 use ironclaw_host_api::{CapabilityId, ExtensionId, InvocationId, RuntimeKind, ThreadId};
+use ironclaw_product_adapters::{
+    ApprovalPromptActionView, ApprovalPromptContextView, ApprovalPromptDestinationView,
+    ApprovalPromptDetailView, ApprovalPromptScopeView, AuthPromptChallengeKind,
+    CapabilityDisplayPreviewViewInput, ConnectionPromptContext, ProductGateKind,
+};
 use ironclaw_product_workflow::{
     AuthPromptView, CapabilityActivityStatusView, CapabilityActivityView,
     CapabilityDisplayPreviewView, FinalReplyView, GatePromptView, ProductOutboundPayload,
@@ -13,6 +18,9 @@ use ironclaw_turns::{
 };
 use ironclaw_webui_v2::{WebChatV2Event, WebChatV2EventFrame};
 use serde_json::Value;
+
+#[path = "support/golden_json.rs"]
+mod golden_json;
 
 fn cursor() -> ProjectionCursor {
     ProjectionCursor::new("cursor:webchat:v2:1").expect("cursor")
@@ -377,6 +385,259 @@ fn outbound_payload_mapping_covers_every_browser_event_variant() {
         assert_eq!(json["cursor"], "cursor:webchat:v2:1");
         assert_eq!(json["type"], expected_type);
         assert_no_forbidden_metadata(&json);
+    }
+}
+
+// ===== SSE wire-contract fixtures (Rust emission <-> frontend parsing) =====
+//
+// `webchat_sse_event_from_envelope` (`src/handlers.rs`) does nothing to a
+// `WebChatV2EventFrame` beyond `serde_json::to_string(&frame)` before
+// putting it on the wire as the SSE `data:` field, so serializing a frame
+// directly here reproduces the exact browser payload without needing the
+// HTTP router or a stub `RebornServicesApi`.
+//
+// Scope is the 10 variants `outbound_payload_mapping_covers_every_browser_-
+// event_variant` above already proves are reachable via
+// `From<ProductOutboundPayload>` (including `keep_alive`:
+// `ProductOutboundPayload::KeepAlive` is genuinely emitted by
+// `ironclaw_reborn_composition::projection`, not merely a theoretical wire
+// shape). This test builds each `WebChatV2Event` directly instead of
+// round-tripping through that `From` impl again — the mapping is already
+// covered above; what's new here is dumping the exact serialized bytes as a
+// committed fixture. `accepted`, `cancelled`, and
+// `failed` are deliberately excluded: grepping
+// `WebChatV2Event::Accepted|Cancelled|Failed` across `crates/` turns up no
+// production constructor anywhere — `RebornSubmitTurnResponse` and
+// `RebornCancelRunResponse` reach the browser as plain JSON HTTP response
+// bodies (`send_message`/`cancel_run`), never through SSE. There is no real
+// wire shape to pin for those three today. The 11th fixture, `error`, is
+// not a `WebChatV2Event` at all (a standalone `SseErrorPayload`) and can
+// only be produced by driving the real facade-error path through the HTTP
+// handler — that fixture is dumped by
+// `webui_v2_handlers_contract.rs`'s `stream_events_facade_error_emits_-
+// error_fixture`, not here.
+//
+// Regenerate after an intentional schema change:
+//   UPDATE_SSE_FIXTURES=1 cargo test -p ironclaw_webui_v2 --test webui_v2_schema_contract sse_wire_contract
+// then review the diff under `tests/fixtures/sse_wire_contract/` and commit
+// it. The companion Vitest suite
+// (`frontend/src/pages/chat/lib/sse-wire-contract.test.ts`) reads the same
+// files and drives them through the real `useSSE`/`useChatEvents` parsing
+// code — this test only pins the Rust half of the contract.
+fn fixture_turn_run_id() -> TurnRunId {
+    TurnRunId::parse("00000000-0000-0000-0000-000000000001").expect("valid uuid")
+}
+
+fn fixture_invocation_id() -> InvocationId {
+    InvocationId::parse("00000000-0000-0000-0000-000000000002").expect("valid uuid")
+}
+
+fn fixture_timestamp() -> chrono::DateTime<Utc> {
+    "2026-01-01T00:00:00Z".parse().expect("valid timestamp")
+}
+
+fn fixture_thread_id() -> ThreadId {
+    ThreadId::new("thread-fixture").expect("thread id")
+}
+
+fn fixture_projection_state() -> ProductProjectionState {
+    ProductProjectionState::new(
+        "thread-fixture",
+        vec![
+            // `blocked_approval`, not `running`: a `Gate{Approval}` item only
+            // renders as `pendingGate` on the frontend when the batch's
+            // `run_status` is one of the gate-active statuses
+            // (`useChatEvents.ts`'s `isObsoleteProjectionGate`) — pairing it
+            // with `running` here would make the frontend correctly treat the
+            // gate as stale/obsolete, which is real behavior but not what
+            // this fixture is for.
+            ProductProjectionItem::RunStatus {
+                run_id: fixture_turn_run_id(),
+                status: "blocked_approval".to_string(),
+                failure_category: None,
+                failure_summary: None,
+                retryable: None,
+            },
+            ProductProjectionItem::Text {
+                id: "message-1".to_string(),
+                run_id: Some(fixture_turn_run_id()),
+                body: "Working on it...".to_string(),
+            },
+            ProductProjectionItem::Gate {
+                run_id: fixture_turn_run_id(),
+                gate_kind: ProductGateKind::Approval,
+                gate_ref: "gate:projection-fixture".to_string(),
+                invocation_id: Some(fixture_invocation_id()),
+                headline: "Approve the fixture action".to_string(),
+                body: Some("This action needs your approval.".to_string()),
+                allow_always: false,
+                auth_context: None,
+            },
+        ],
+    )
+    .expect("projection state")
+}
+
+#[test]
+fn sse_wire_contract_fixtures_match_committed_json() {
+    let cases: Vec<(&str, WebChatV2Event)> = vec![
+        (
+            "final_reply",
+            WebChatV2Event::FinalReply {
+                reply: FinalReplyView {
+                    turn_run_id: fixture_turn_run_id(),
+                    text: "This is the assistant's final reply.".to_string(),
+                    generated_at: fixture_timestamp(),
+                },
+            },
+        ),
+        (
+            "running",
+            WebChatV2Event::Running {
+                progress: ProgressUpdateView {
+                    turn_run_id: fixture_turn_run_id(),
+                    kind: ProgressKind::Typing,
+                    generated_at: fixture_timestamp(),
+                },
+            },
+        ),
+        (
+            "capability_progress",
+            WebChatV2Event::CapabilityProgress {
+                progress: ProgressUpdateView {
+                    turn_run_id: fixture_turn_run_id(),
+                    kind: ProgressKind::ToolRunning,
+                    generated_at: fixture_timestamp(),
+                },
+            },
+        ),
+        (
+            "capability_activity",
+            WebChatV2Event::CapabilityActivity {
+                activity: CapabilityActivityView {
+                    invocation_id: fixture_invocation_id(),
+                    turn_run_id: Some(fixture_turn_run_id()),
+                    thread_id: Some(fixture_thread_id()),
+                    capability_id: CapabilityId::new("script.echo").expect("capability id"),
+                    status: CapabilityActivityStatusView::Running,
+                    provider: Some(ExtensionId::new("script").expect("provider id")),
+                    runtime: Some(RuntimeKind::Script),
+                    process_id: None,
+                    output_bytes: None,
+                    error_kind: None,
+                    error_detail: None,
+                    subtitle: Some("src/main.rs".to_string()),
+                    input_summary: Some("path: src/main.rs".to_string()),
+                    updated_at: fixture_timestamp(),
+                    activity_order: Some(1),
+                },
+            },
+        ),
+        (
+            "capability_display_preview",
+            WebChatV2Event::CapabilityDisplayPreview {
+                preview: CapabilityDisplayPreviewView::new(CapabilityDisplayPreviewViewInput {
+                    timeline_message_id: Some("timeline-message-1".to_string()),
+                    invocation_id: fixture_invocation_id(),
+                    turn_run_id: Some(fixture_turn_run_id()),
+                    thread_id: Some(fixture_thread_id()),
+                    capability_id: CapabilityId::new("builtin.read_file").expect("capability id"),
+                    status: CapabilityActivityStatusView::Completed,
+                    error_kind: None,
+                    title: "read_file".to_string(),
+                    subtitle: Some("src/main.rs".to_string()),
+                    input_summary: Some("path: src/main.rs".to_string()),
+                    output_summary: Some("Read 12 bytes.".to_string()),
+                    output_preview: Some("fn main() {}".to_string()),
+                    output_kind: Some("text".to_string()),
+                    output_bytes: Some(12),
+                    result_ref: Some("result:tool-output".to_string()),
+                    truncated: false,
+                    updated_at: fixture_timestamp(),
+                    activity_order: Some(2),
+                })
+                .expect("capability display preview"),
+            },
+        ),
+        (
+            "gate",
+            WebChatV2Event::Gate {
+                prompt: GatePromptView {
+                    turn_run_id: fixture_turn_run_id(),
+                    gate_ref: "gate:approval-fixture".to_string(),
+                    invocation_id: Some(fixture_invocation_id()),
+                    headline: "Approve the fixture action".to_string(),
+                    body: "This action needs your approval.".to_string(),
+                    allow_always: true,
+                    approval_context: Some(
+                        ApprovalPromptContextView::new(
+                            "shell",
+                            ApprovalPromptActionView::new("Run a shell command", None)
+                                .expect("action"),
+                            ApprovalPromptScopeView::new("This action only", false).expect("scope"),
+                            Some("The assistant wants to run a command.".to_string()),
+                            Some(ApprovalPromptDestinationView {
+                                label: "Local sandbox".to_string(),
+                                url: None,
+                                domain: None,
+                            }),
+                            vec![ApprovalPromptDetailView {
+                                label: "Command".to_string(),
+                                value: "echo hello".to_string(),
+                            }],
+                        )
+                        .expect("approval context"),
+                    ),
+                },
+            },
+        ),
+        (
+            "auth_required",
+            WebChatV2Event::AuthRequired {
+                prompt: AuthPromptView {
+                    turn_run_id: fixture_turn_run_id(),
+                    auth_request_ref: "auth:fixture".to_string(),
+                    invocation_id: None,
+                    headline: "Connect your Google account".to_string(),
+                    body: "Paste the code from the connection screen.".to_string(),
+                    challenge_kind: Some(AuthPromptChallengeKind::ManualToken),
+                    provider: Some("google".to_string()),
+                    account_label: Some("user@example.test".to_string()),
+                    authorization_url: None,
+                    expires_at: Some(fixture_timestamp()),
+                    connection: Some(ConnectionPromptContext {
+                        channel: "telegram".to_string(),
+                        strategy: Some("inbound_proof_code".to_string()),
+                        instructions: Some("Open the Telegram bot and send /pair.".to_string()),
+                        input_placeholder: Some("Pairing code".to_string()),
+                        submit_label: Some("Connect".to_string()),
+                        error_message: Some("That code did not match.".to_string()),
+                    }),
+                },
+            },
+        ),
+        (
+            "projection_snapshot",
+            WebChatV2Event::ProjectionSnapshot {
+                state: fixture_projection_state(),
+            },
+        ),
+        (
+            "projection_update",
+            WebChatV2Event::ProjectionUpdate {
+                state: fixture_projection_state(),
+            },
+        ),
+        ("keep_alive", WebChatV2Event::KeepAlive),
+    ];
+
+    for (name, event) in cases {
+        let frame = WebChatV2EventFrame {
+            cursor: ProjectionCursor::new(format!("cursor:{name}")).expect("cursor"),
+            event,
+        };
+        let json = serde_json::to_value(&frame).expect("serialize frame");
+        golden_json::assert_or_update_json_fixture(name, &json);
     }
 }
 


### PR DESCRIPTION
## Summary

`submit_turn`'s SSE emission (`WebChatV2Event` in `crates/ironclaw_webui_v2/src/schema.rs`) and the WebUI v2 frontend's parsing of it (`useSSE.ts` / `useChatEvents.ts`) were tied together by **a comment, nothing else** — `V2_EVENT_NAMES` in `useSSE.ts` just says in a comment that it mirrors the Rust side. This is the class of bug Playwright currently only catches nightly (e.g. #6082, #5275). This PR closes that gap with a fixture round-trip test, per `docs/plans/2026-07-15-reborn-tier2-extension-plan.md` section 4 (an internal planning doc, not committed).

**Approach (as scoped):** fixture round-trip, not generated-types codegen — smaller, ships faster, doesn't touch `useChatEvents.ts`'s `@ts-nocheck` (left untouched by design, a separate future effort).

## What's covered

11 fixture files under `crates/ironclaw_webui_v2/tests/fixtures/sse_wire_contract/*.json` — one per **real, production-reachable** SSE wire shape:

- `final_reply`, `running`, `capability_progress`, `capability_activity`, `capability_display_preview`, `gate`, `auth_required`, `projection_snapshot`, `projection_update`, `keep_alive` — the 10 `WebChatV2Event` variants reachable via `From<ProductOutboundPayload>` (already proven reachable by the pre-existing `outbound_payload_mapping_covers_every_browser_event_variant` test).
- `error` — the ad-hoc `SseErrorPayload` frame from the facade-error path (not a `WebChatV2Event` variant).

**Deliberately excluded, and why:** `WebChatV2Event::Accepted`/`Cancelled`/`Failed` exist in the tagged union but have **no production constructor anywhere in the repo** — `RebornSubmitTurnResponse`/`RebornCancelRunResponse` reach the browser as plain JSON HTTP response bodies (`send_message`/`cancel_run` handlers), never through SSE. Confirmed via `grep -rn "WebChatV2Event::Accepted|Cancelled|Failed" crates/` (only hits: `schema.rs` itself and its own round-trip tests). There is no real wire shape to pin for those three today — flagging as a pre-existing observation, not fixed by this PR.

## Mechanism

- **Rust side** (`webui_v2_schema_contract.rs`'s `sse_wire_contract_fixtures_match_committed_json`, + one small addition to `webui_v2_handlers_contract.rs` for the `error` fixture): constructs `WebChatV2Event` values directly and serializes them. This reproduces the exact wire payload without needing the HTTP router — `webchat_sse_event_from_envelope` (`src/handlers.rs`) does nothing to a frame beyond `serde_json::to_string(&frame)` before it hits the SSE `data:` field, so direct construction is provably equivalent and avoids coupling this test to `StubServices`/the router (which the pre-existing ~6.6k-line `webui_v2_handlers_contract.rs` already houses, and which isn't reasonably extractable in a coverage-only PR).
- **Sync mechanism**: a small hand-rolled golden-JSON helper (`tests/support/golden_json.rs`), deliberately *not* this repo's `insta` crate — `insta`'s `.snap` format carries YAML frontmatter, and these fixtures are also read directly by Vitest via `JSON.parse`, so they must be plain JSON. Regenerate after an intentional wire-schema change:
  ```
  UPDATE_SSE_FIXTURES=1 cargo test -p ironclaw_webui_v2
  ```
  then review the diff and re-run the Vitest suite.
- **Frontend side** (`frontend/src/pages/chat/lib/sse-wire-contract.test.ts`): loads the same fixtures and drives them through the **actual** `useSSE`/`useChatEvents` hooks — via the `vm.runInNewContext` harness pattern already established by this codebase's own `useSSE.test.ts`/`useChatEvents.test.ts` (their `createHarness`/`createUseChatEventsHarness` factories are exported and reused, not reimplemented). Asserts the fields each fixture carries land in observable state (messages, pendingGate, activeRun, isProcessing) or, for `keep_alive`, that no state changes.

## Red/green proof

- **Rust side red**: hand-edited the committed `final_reply.json` fixture (renamed a key) → `sse_wire_contract_fixtures_match_committed_json` failed with a clear diff. Reverted → green.
- **Frontend side red**: temporarily typo'd the field read in `useChatEvents.ts`'s `case "final_reply"` (`reply.turn_run_id` → `reply.turn_run_id_typo`) → the new Vitest test failed for the right reason (also rippled into the pre-existing `useChatEvents.test.ts` suite, confirming the change is load-bearing). Reverted → green (835/835 frontend tests, 5/5 + 106/106 relevant Rust tests).

## Verification commands run

```
cargo fmt -p ironclaw_webui_v2
cargo clippy -p ironclaw_webui_v2 --tests --all-features -- -D warnings
cargo test -p ironclaw_webui_v2 --test webui_v2_schema_contract --test webui_v2_handlers_contract
cd crates/ironclaw_webui_v2/frontend && npx vitest run   # 92 files, 835 tests
npm run lint:conventions && npm run typecheck
```

## Review

Ran `code-review` (local, 8 parallel reviewers) and a `thermo-nuclear-code-quality-review` pass on the plan and again on the final diff. Applied:
- Broadened `capability_display_preview` assertions to match the field breadth already asserted for `capability_activity` (tests reviewer, confidence 75).
- Fixed a misleading doc-comment implying `keep_alive` isn't payload-mapped when it already is, per the pre-existing sibling test (local-patterns reviewer, confidence 80).

**Consciously not applied**: a maintainability finding (confidence 55, Low severity) suggesting the two exported test harnesses (`createHarness`, `createUseChatEventsHarness`) move into dedicated `test-support/` files rather than being exported from their original `*.test.ts` files. The separately-run thermo-nuclear pass explicitly reviewed this exact question and approved the export-based reuse as "minimal... genuinely reused, not reimplemented... justified." Given that and the "no over-engineering" scope for this PR, moving already-green test files for a purely organizational preference wasn't applied — noting it here in case a reviewer disagrees.

## Test plan

- [x] `sse_wire_contract_fixtures_match_committed_json` (Rust, 10 fixtures)
- [x] `stream_events_facade_error_emits_error_fixture` (Rust, `error` fixture)
- [x] `sse-wire-contract.test.ts` (Vitest, 81 assertions across the 11 fixtures)
- [x] Full existing Rust + Vitest suites still green
- [x] Red/green sanity check on both sides (see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)