### PR TITLE
test(reborn): add fault-injection scenarios for provider-error and compound-denial paths

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -474,6 +474,10 @@ name = "reborn_integration_comm_context"
 path = "tests/integration/comm_context.rs"
 
 [[test]]
+name = "reborn_integration_denied_mid_turn_tool_in_flight"
+path = "tests/integration/denied_mid_turn_tool_in_flight.rs"
+
+[[test]]
 name = "reborn_integration_durable"
 path = "tests/integration/durable.rs"
 

--- a/tests/integration/cancel.rs
+++ b/tests/integration/cancel.rs
@@ -168,6 +168,17 @@ async fn mid_turn_provider_error_reaches_failed_with_model_error_category() {
         "model_context_overflow",
         "expected the context-overflow fidelity category (ContextLengthExceeded), got {failure:?}"
     );
+    // The category alone doesn't prove the SAFE-SUMMARY text reaching the
+    // model-visible failure explainer is real, not the generic catch-all
+    // (`map_provider_error`'s `_ => "model service is unavailable"`,
+    // `crates/ironclaw_runner/src/model_gateway.rs`). A genuine, non-masked
+    // provider error gets its own class-specific summary.
+    assert_eq!(
+        failure.detail(),
+        Some("model request exceeded its context budget"),
+        "expected the context-overflow-specific safe summary (not the generic \
+         \"model service is unavailable\" catch-all), got {failure:?}"
+    );
 }
 
 /// Regression guard, `Failed`-path sibling of

--- a/tests/integration/denied_mid_turn_tool_in_flight.rs
+++ b/tests/integration/denied_mid_turn_tool_in_flight.rs
@@ -1,0 +1,189 @@
+//! Compound fault-injection scenario: a capability call that already
+//! completed and persisted a real side effect survives a LATER gate denial
+//! on the same conversation, rather than being rolled back, corrupted, or
+//! masked.
+//!
+//! Real path (`RebornIntegrationGroup::live_approvals`, the same real gate
+//! path `scenario_gate_then_approve.rs`/`scenario_gate_then_deny.rs` drive,
+//! composed across two turns on one thread): turn 1 scripts a
+//! `builtin.write_file` call, approved -- a real, persisted, "already in
+//! flight" side effect from earlier in the SAME conversation. Turn 2 scripts
+//! a DIFFERENT `builtin.write_file` call, denied. `deny_gate` resumes the run
+//! so the executor surfaces a non-retryable authorization failure for turn
+//! 2's write; turn 1's file must remain exactly as it was.
+//!
+//! Closes a gap `scenario_gate_then_deny.rs` doesn't cover: that scenario's
+//! thread has no prior committed capability side effect, so nothing proves a
+//! LATER denial leaves an EARLIER approved write untouched. (An earlier
+//! design tried this within a single model step -- one scripted
+//! `tool_calls([..])` batch mixing an ungated `read_file` with a gated
+//! `write_file` -- but empirically, resuming a gate raised by the
+//! non-first call in a mixed batch does not re-dispatch the gated capability
+//! at all, approved or denied; that path needs its own investigation and is
+//! out of scope here. The two-turn shape below uses only the proven
+//! single-call-per-turn gate/resume mechanism each of those two scenarios
+//! already exercises independently.)
+
+#[allow(dead_code)]
+#[path = "support/mod.rs"]
+mod reborn_support;
+#[allow(dead_code)]
+#[path = "../support/mod.rs"]
+mod support;
+
+use ironclaw_turns::TurnStatus;
+use reborn_support::group::RebornIntegrationGroup;
+use reborn_support::reply::RebornScriptedReply;
+use serde_json::json;
+
+const ALREADY_IN_FLIGHT_CONTENT: &str = "already-in-flight approved content";
+
+#[tokio::test]
+async fn approved_write_survives_a_later_denied_gate_on_the_same_thread() {
+    let g = RebornIntegrationGroup::live_approvals()
+        .await
+        .expect("group builds");
+    let h = g
+        .thread("conv-denied-mid-turn-tool-in-flight")
+        .script([
+            // Turn 1: approved write -- the "already in flight" committed
+            // side effect from earlier in this conversation.
+            RebornScriptedReply::tool_call(
+                "builtin.write_file",
+                json!({"path": "/workspace/already-in-flight.txt", "content": ALREADY_IN_FLIGHT_CONTENT}),
+            ),
+            RebornScriptedReply::text("first file written"),
+            // Turn 2: a DIFFERENT write, denied.
+            RebornScriptedReply::tool_call(
+                "builtin.write_file",
+                json!({"path": "/workspace/denied.txt", "content": "should not persist"}),
+            ),
+            RebornScriptedReply::text("the second write was not authorized"),
+        ])
+        .build()
+        .await
+        .expect("harness builds");
+
+    // Turn 1: approve. Real, persisted side effect -- not scripted/faked.
+    let (run1, gate1) = h
+        .submit_turn_until_blocked("write the first file")
+        .await
+        .expect("blocked on the first write's approval gate");
+    h.approve_gate(run1, &gate1)
+        .await
+        .expect("first gate approved");
+    h.wait_for_status(run1, TurnStatus::Completed)
+        .await
+        .expect("first turn completes");
+    h.assert_workspace_file_contains("already-in-flight.txt", ALREADY_IN_FLIGHT_CONTENT)
+        .await
+        .expect("first write persisted");
+
+    // Turn 2: deny. A DIFFERENT gate, on the SAME thread, after the first
+    // write already completed.
+    let (run2, gate2) = h
+        .submit_turn_until_blocked("write the second file")
+        .await
+        .expect("blocked on the second write's approval gate");
+    h.deny_gate(run2, &gate2).await.expect("second gate denied");
+    h.wait_for_status(run2, TurnStatus::Completed)
+        .await
+        .expect("run reaches Completed after the denial (not hung, not Failed)");
+
+    // The denied write must NOT have executed.
+    h.assert_workspace_file_absent("denied.txt")
+        .await
+        .expect("the denied write never ran");
+
+    // The compound-failure invariant under test: the EARLIER, already-
+    // committed write is untouched by the LATER gate's denial -- not rolled
+    // back, corrupted, or masked.
+    h.assert_workspace_file_contains("already-in-flight.txt", ALREADY_IN_FLIGHT_CONTENT)
+        .await
+        .expect(
+            "the already-in-flight write from turn 1 must survive turn 2's gate denial \
+             unchanged",
+        );
+
+    // Non-vacuous: the model's final reply persisted, proving genuine
+    // completion rather than a masked/hung terminal state.
+    h.assert_reply_contains("was not authorized")
+        .await
+        .expect("final reply persisted after the denial");
+}
+
+/// Pins the CURRENT (undesirable, needs its own follow-up investigation --
+/// see the module doc) behavior of the mixed-batch shape this file's main
+/// scenario deliberately avoids: a single scripted step with an ungated
+/// `builtin.read_file` call before a gated `builtin.write_file` call. Empirically,
+/// resuming the write's gate -- even via `approve_gate` -- never re-dispatches
+/// it: the file is absent regardless of approve or deny. This test locks in
+/// that observation as a named, non-silent regression guard rather than
+/// leaving it as an undocumented discovery, so a future fix to the mixed-batch
+/// resume path (making `approve_gate` actually create the file) trips this
+/// test and prompts an intentional update instead of an unnoticed behavior
+/// change.
+#[tokio::test]
+async fn mixed_batch_gate_resume_does_not_currently_redispatch_the_gated_call() {
+    let g = RebornIntegrationGroup::live_approvals()
+        .await
+        .expect("group builds");
+    let h = g
+        .thread("conv-mixed-batch-gate-resume-pin")
+        .script([
+            RebornScriptedReply::tool_call(
+                "builtin.write_file",
+                json!({"path": "/workspace/seed.txt", "content": ALREADY_IN_FLIGHT_CONTENT}),
+            ),
+            RebornScriptedReply::text("seed written"),
+            RebornScriptedReply::tool_calls([
+                ("builtin.read_file", json!({"path": "/workspace/seed.txt"})),
+                (
+                    "builtin.write_file",
+                    json!({"path": "/workspace/mixed-batch.txt", "content": "should have persisted"}),
+                ),
+            ]),
+            RebornScriptedReply::text("read the seed and wrote the second file"),
+        ])
+        .build()
+        .await
+        .expect("harness builds");
+
+    let (seed_run, seed_gate) = h
+        .submit_turn_until_blocked("seed the file")
+        .await
+        .expect("blocked on the seed write's approval gate");
+    h.approve_gate(seed_run, &seed_gate)
+        .await
+        .expect("seed gate approved");
+    h.wait_for_status(seed_run, TurnStatus::Completed)
+        .await
+        .expect("seed turn completes");
+
+    let (run_id, gate_ref) = h
+        .submit_turn_until_blocked("read the seed and write a second file")
+        .await
+        .expect("blocked on the mixed batch's write gate");
+    h.assert_tool_invoked("builtin.read_file")
+        .await
+        .expect("the ungated read dispatched before the write's gate blocked the batch");
+
+    // Approving (not denying) the gate -- if the write genuinely re-dispatched
+    // on resume, "mixed-batch.txt" would exist afterward.
+    h.approve_gate(run_id, &gate_ref)
+        .await
+        .expect("mixed-batch gate approved");
+    h.wait_for_status(run_id, TurnStatus::Completed)
+        .await
+        .expect("run reaches Completed after the approval");
+
+    h.assert_workspace_file_absent("mixed-batch.txt")
+        .await
+        .expect(
+            "CURRENT (documented, follow-up-needed) behavior: approving a gate raised by the \
+             non-first call in a mixed batch does not re-dispatch the write. If this now \
+             fails, the mixed-batch resume path was fixed -- update this test (and the \
+             module doc) to reflect the corrected behavior instead of just deleting the \
+             assertion.",
+        );
+}


### PR DESCRIPTION
## Summary

Lane 3 of the Reborn tier-2 integration harness extension (section 3, "Fault-injection scenarios"). Closes two gaps:

1. **Promote `ErrLlm` beyond cancellation.** `tests/integration/cancel.rs`'s existing `mid_turn_provider_error_reaches_failed_with_model_error_category` already drove a genuine non-retryable provider error (`LlmError::ContextLengthExceeded` via `fail_model()`) to `TurnStatus::Failed` and asserted `failure.category() == "model_context_overflow"` — but never asserted the safe-summary `detail` text, so nothing proved that text wasn't the generic catch-all (`map_provider_error`'s `_ => "model service is unavailable"`, `crates/ironclaw_runner/src/model_gateway.rs`). Extended the existing test (not a new file — it already drove the exact scenario shape; the only gap was one more assertion) with `assert_eq!(failure.detail(), Some("model request exceeded its context budget"), ...)`.
2. **Compound fault: an already-committed side effect surviving a later denial.** New `tests/integration/denied_mid_turn_tool_in_flight.rs`, using the same real `RebornIntegrationGroup::live_approvals()` gate mechanism `scenario_gate_then_approve.rs`/`scenario_gate_then_deny.rs` each prove individually, composed across two turns on one thread: turn 1's write is approved and persists; turn 2's (different) write is denied. Asserts turn 1's file survives turn 2's denial unchanged, turn 2's file never exists, and the run reaches `Completed` (not hung/Failed).

### A genuine architectural finding (not fixed here)

The originally-planned shape for item 2 was `deny_gate` combined with `ScriptedHttpResponse::egress_error` in one turn. Investigation found this is currently structurally unreachable: approval-gate capability (`PermissionMode::Ask`) is only available on harnesses built through `RebornServices`/`build_reborn_services` (`ToolsProfile`/`new_with_options`), which never wires a scriptable runtime HTTP egress (`http_egress: None`, always); keyed-HTTP scripting (`ScriptedHttpResponse`) is only available on hand-built harnesses (`core_builtin_tools_from_runtime`), which use `GrantAuthorizer` — an authorizer that structurally never returns `Decision::RequireApproval`. Combining them needs either new production-composition plumbing (a scriptable HTTP egress reachable from an approval-aware runtime) or a bespoke test-only authorizer + wiring real run-state/approval stores directly into a hand-built `HostRuntime` — both bigger, riskier lifts than this coverage PR's scope, in the same spirit as the plan doc's own delay/latency-injection carve-out. Rescoped to the closest faithful compound using only proven, existing primitives.

Separately, while iterating on the (ultimately abandoned) single-batch design, found and pinned a real, previously-undocumented behavior gap: resuming a gate raised by the **non-first** call in a single scripted `tool_calls([..])` batch (an ungated call before a gated `write_file`) does not re-dispatch the gated capability at all — approving OR denying it, the write never happens. `mixed_batch_gate_resume_does_not_currently_redispatch_the_gated_call` pins this as a named regression guard (not a fix — that's a production behavior change out of scope here) so a future fix trips the test intentionally instead of an unnoticed behavior change.

### Red/green proof

- **Item 1**: temporarily swapped `model_gateway.rs`'s `ContextLengthExceeded` arm to the generic `"model service is unavailable"` text while keeping the category unchanged (isolates the NEW assertion from the pre-existing category assertion) → new assertion failed for the right reason (`left: Some("model service is unavailable") right: Some("model request exceeded its context budget")`) while the category assertion still passed. Reverted; confirmed green (all 17 tests in the binary pass).
- **Item 2**: flipped turn 2's `deny_gate` to `approve_gate` → `assert_workspace_file_absent("denied.txt")` correctly failed (`workspace file "denied.txt" exists ... but should not`), proving the assertion discriminates real deny-vs-approve behavior, not a vacuous pass. Reverted; confirmed green.

### Review

Ran the `code-review` skill (8 parallel reviewers) and a self-administered thermo-nuclear pass on the final diff. Zero Critical/High findings; `bugs` and `conventions` reviewers returned empty (bugs reviewer independently traced the full `ErrLlm` → `SanitizedFailure.detail` mapping chain and verified every harness method used). `tests` reviewer's two findings: (a) the mixed-batch gap above — addressed by adding the pinning test; (b) a Low-confidence suggestion for reverse-order coverage (denied-then-approved-later) — not added, a scope call for a follow-up, not this PR.

## Test plan

- [x] `cargo test --test reborn_integration_cancel` — 17/17 pass
- [x] `cargo test --test reborn_integration_denied_mid_turn_tool_in_flight` — 14/14 pass
- [x] `cargo fmt` / `cargo clippy --test reborn_integration_cancel --test reborn_integration_denied_mid_turn_tool_in_flight -- -D warnings` — clean
- [x] Red/green proof for both new assertions (see above)
- [x] Multi-agent `code-review` + thermo-nuclear pass on final diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)