### PR TITLE
fix(reborn): recover Slack host after OAuth activation

### DIFF
--- a/crates/ironclaw_reborn_composition/src/extension_host/available_extensions.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/available_extensions.rs
@@ -631,6 +631,7 @@ fn bundled_extension_package(
             reason: format!("bundled {label} extension package is invalid: {error}"),
         },
     )?;
+    validate_bundled_package_assets(label, &package, &assets)?;
     Ok(AvailableExtensionPackage {
         package_ref,
         manifest_toml: record.raw_toml().to_string(),
@@ -644,6 +645,73 @@ fn bundled_extension_package(
         onboarding_override: None,
         oauth_setup_override: None,
     })
+}
+
+/// Fail catalog construction before a package can be installed when its
+/// manifest points at a static file the bundle does not carry. Dynamic hosted
+/// MCP schemas are inlined at discovery time and are the only intentional
+/// non-file references.
+fn validate_bundled_package_assets(
+    label: &str,
+    package: &ExtensionPackage,
+    assets: &[AvailableExtensionAsset],
+) -> Result<(), ProductWorkflowError> {
+    let has_asset = |path: &str| assets.iter().any(|asset| asset.path == path);
+    let dynamic_schema_prefix = format!("schemas/{}/dynamic/", package.id.as_str());
+    let is_inline_dynamic_schema_ref = |field: &str, path: &str| {
+        crate::extension_host::mcp_discovery::is_hosted_http_mcp_package(package)
+            && matches!(field, "input_schema_ref" | "output_schema_ref")
+            && path
+                .strip_prefix(&dynamic_schema_prefix)
+                .is_some_and(|suffix| !suffix.is_empty())
+    };
+    let require_asset = |field: &str, path: &str| {
+        if has_asset(path) {
+            Ok(())
+        } else {
+            Err(ProductWorkflowError::InvalidBindingRequest {
+                reason: format!(
+                    "bundled {label} extension {field} references missing package asset {path}"
+                ),
+            })
+        }
+    };
+
+    require_asset("manifest", "manifest.toml")?;
+    if let ExtensionRuntime::Wasm { module } = &package.manifest.runtime {
+        require_asset("runtime.module", module.as_str())?;
+    }
+
+    for capability in &package.manifest.capabilities {
+        let refs = [
+            (
+                "input_schema_ref",
+                Some(capability.input_schema_ref.as_str()),
+            ),
+            (
+                "output_schema_ref",
+                capability
+                    .output_schema_ref
+                    .as_ref()
+                    .map(|path| path.as_str()),
+            ),
+            (
+                "prompt_doc_ref",
+                capability.prompt_doc_ref.as_ref().map(|path| path.as_str()),
+            ),
+        ];
+        for (field, path) in refs {
+            let Some(path) = path else { continue };
+            if is_inline_dynamic_schema_ref(field, path) {
+                continue;
+            }
+            require_asset(
+                &format!("capability {} {field}", capability.id.as_str()),
+                path,
+            )?;
+        }
+    }
+    Ok(())
 }
 
 pub(crate) fn surface_kinds_from_manifest_record(
@@ -1026,23 +1094,31 @@ mod tests {
                 .map(|asset| asset.path.as_str())
                 .collect::<HashSet<_>>();
 
-            // Synthetic inline-dynamic refs ("schemas/{id}/dynamic/…", e.g. the
-            // hosted-MCP connection template's input schema) ship NO package
-            // asset on purpose: discovered/dynamic schemas are inlined at
-            // discovery time, not packaged files.
-            let is_dynamic_ref = |schema_ref: &str| schema_ref.contains("/dynamic/");
-
+            assert!(
+                assets.contains("manifest.toml"),
+                "{extension_id} missing packaged manifest.toml"
+            );
             if let ExtensionRuntime::Wasm { module } = &package.package.manifest.runtime {
                 assert!(
                     assets.contains(module.as_str()),
-                    "{extension_id} missing wasm runtime module asset {}",
+                    "{extension_id} missing WASM module asset {}",
                     module.as_str()
                 );
             }
 
+            // Hosted-MCP inline schemas under this package's exact dynamic
+            // prefix ship no package asset; every other ref remains static.
+            let dynamic_schema_prefix = format!("schemas/{extension_id}/dynamic/");
+            let is_dynamic_schema_ref = |schema_ref: &str| {
+                crate::extension_host::mcp_discovery::is_hosted_http_mcp_package(&package.package)
+                    && schema_ref
+                        .strip_prefix(&dynamic_schema_prefix)
+                        .is_some_and(|suffix| !suffix.is_empty())
+            };
+
             for capability in &package.package.manifest.capabilities {
                 assert!(
-                    is_dynamic_ref(capability.input_schema_ref.as_str())
+                    is_dynamic_schema_ref(capability.input_schema_ref.as_str())
                         || assets.contains(capability.input_schema_ref.as_str()),
                     "{extension_id} capability {} missing input schema asset {}",
                     capability.id,
@@ -1050,7 +1126,7 @@ mod tests {
                 );
                 if let Some(output_schema_ref) = &capability.output_schema_ref {
                     assert!(
-                        is_dynamic_ref(output_schema_ref.as_str())
+                        is_dynamic_schema_ref(output_schema_ref.as_str())
                             || assets.contains(output_schema_ref.as_str()),
                         "{extension_id} capability {} missing output schema asset {}",
                         capability.id,
@@ -1059,8 +1135,7 @@ mod tests {
                 }
                 if let Some(prompt_doc_ref) = &capability.prompt_doc_ref {
                     assert!(
-                        is_dynamic_ref(prompt_doc_ref.as_str())
-                            || assets.contains(prompt_doc_ref.as_str()),
+                        assets.contains(prompt_doc_ref.as_str()),
                         "{extension_id} capability {} missing prompt doc asset {}",
                         capability.id,
                         prompt_doc_ref.as_str()
@@ -1068,6 +1143,116 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn bundled_extension_package_rejects_missing_static_capability_assets() {
+        const MANIFEST: &str = r#"
+schema_version = "reborn.extension_manifest.v2"
+id = "missing-assets"
+name = "Missing Assets"
+version = "0.1.0"
+description = "A package with a dangling schema reference."
+trust = "third_party"
+
+[runtime]
+kind = "wasm"
+module = "wasm/missing-assets.wasm"
+
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
+id = "missing-assets.run"
+description = "Run"
+effects = []
+default_permission = "ask"
+visibility = "model"
+input_schema_ref = "schemas/missing-assets/run.input.v1.json"
+"#;
+        let assets = vec![
+            bytes_asset("manifest.toml", MANIFEST.as_bytes()),
+            bytes_asset("wasm/missing-assets.wasm", b"wasm"),
+        ];
+
+        let error = bundled_extension_package("missing-assets", "Missing Assets", MANIFEST, assets)
+            .expect_err("a dangling static capability reference must fail catalog construction");
+        let ProductWorkflowError::InvalidBindingRequest { reason } = error else {
+            panic!("expected invalid binding request");
+        };
+        assert!(
+            reason.contains("schemas/missing-assets/run.input.v1.json"),
+            "error should name the missing package asset: {reason}"
+        );
+
+        let dynamic_manifest = MANIFEST.replace(
+            "schemas/missing-assets/run.input.v1.json",
+            "schemas/missing-assets/dynamic/run.input.v1.json",
+        );
+        let dynamic_assets = vec![
+            bytes_asset("manifest.toml", dynamic_manifest.as_bytes()),
+            bytes_asset("wasm/missing-assets.wasm", b"wasm"),
+        ];
+        let error = bundled_extension_package(
+            "missing-assets",
+            "Missing Assets",
+            &dynamic_manifest,
+            dynamic_assets,
+        )
+        .expect_err("a WASM schema cannot claim the hosted-MCP dynamic exemption");
+        let ProductWorkflowError::InvalidBindingRequest { reason } = error else {
+            panic!("expected invalid binding request");
+        };
+        assert!(
+            reason.contains("schemas/missing-assets/dynamic/run.input.v1.json"),
+            "error should name the invalid dynamic package ref: {reason}"
+        );
+    }
+
+    #[test]
+    fn bundled_static_mcp_package_cannot_claim_dynamic_schema_exemption() {
+        const MANIFEST: &str = r#"
+schema_version = "reborn.extension_manifest.v2"
+id = "static-mcp"
+name = "Static MCP"
+version = "0.1.0"
+description = "A stdio MCP package with a dangling dynamic-shaped schema reference."
+trust = "third_party"
+
+[runtime]
+kind = "mcp"
+transport = "stdio"
+command = "static-mcp-server"
+args = ["--stdio"]
+
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
+id = "static-mcp.run"
+description = "Run"
+effects = ["dispatch_capability"]
+default_permission = "ask"
+visibility = "model"
+input_schema_ref = "schemas/static-mcp/dynamic/run.input.v1.json"
+"#;
+        let assets = vec![bytes_asset("manifest.toml", MANIFEST.as_bytes())];
+
+        let error = bundled_extension_package("static-mcp", "Static MCP", MANIFEST, assets)
+            .expect_err("a non-hosted MCP package must carry dynamic-shaped schema refs");
+        let ProductWorkflowError::InvalidBindingRequest { reason } = error else {
+            panic!("expected invalid binding request");
+        };
+        assert!(
+            reason.contains("schemas/static-mcp/dynamic/run.input.v1.json"),
+            "error should name the missing static MCP schema asset: {reason}"
+        );
     }
 
     #[test]
@@ -1718,8 +1903,13 @@ flags = ["inbound_messages"]
 handle = "web_token"
 "#;
 
-        let package = bundled_extension_package("web-product", "Web Product", MANIFEST, Vec::new())
-            .expect("valid package");
+        let package = bundled_extension_package(
+            "web-product",
+            "Web Product",
+            MANIFEST,
+            vec![bytes_asset("manifest.toml", MANIFEST.as_bytes())],
+        )
+        .expect("valid package");
 
         assert_eq!(package.summary().surface_kinds, Vec::new());
     }
@@ -1803,9 +1993,13 @@ handle = "web_token"
         // The connection credential's audience is not rendered into the TOML;
         // it derives from the [mcp].server host automatically when the
         // manifest is parsed.
-        let package =
-            bundled_extension_package(NEARAI_EXTENSION_ID, "NEAR AI", &manifest_toml, Vec::new())
-                .expect("patched NEAR AI manifest parses");
+        let package = bundled_extension_package(
+            NEARAI_EXTENSION_ID,
+            "NEAR AI",
+            &manifest_toml,
+            nearai_mcp_assets(&manifest_toml),
+        )
+        .expect("patched NEAR AI manifest parses");
         let template = package
             .package
             .manifest

--- a/crates/ironclaw_reborn_composition/src/extension_host/channel_dm_provisioning.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/channel_dm_provisioning.rs
@@ -9,11 +9,12 @@
 //! convention the retired lane used); adapters without target listing
 //! simply provision nothing.
 //!
-//! Provisioning is fire-and-forget: a failure is logged and retried on the
-//! next OAuth connection — it never fails the callback that already bound
-//! the identity.
+//! Provisioning is fire-and-forget and never fails the callback that already
+//! bound the identity. OAuth continuation can publish activation just after
+//! the bind, so an inactive snapshot waits on the generic host's publication
+//! signal and retries against each new generation for a bounded interval.
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use ironclaw_host_api::UserId;
 use ironclaw_product_adapters::TargetQuery;
@@ -26,6 +27,22 @@ use crate::extension_host::channel_identity::{
     ChannelIdentityPostBind, ChannelIdentityPostBindFactory,
 };
 
+const ACTIVATION_PUBLICATION_TIMEOUT: Duration = Duration::from_secs(10);
+
+#[derive(Debug, thiserror::Error)]
+enum DmTargetProvisioningError {
+    #[error("channel extension is not active in the snapshot")]
+    ExtensionInactive,
+    #[error("channel target discovery failed: {0}")]
+    TargetDiscovery(String),
+    #[error("channel DM-target persistence failed: {0}")]
+    Persistence(String),
+    #[error("timed out waiting for channel extension activation")]
+    ActivationTimeout,
+    #[error("channel extension activation publisher stopped")]
+    ActivationPublisherStopped,
+}
+
 /// The direct-conversation target query grammar adapters interpret.
 fn direct_conversation_query(external_actor_id: &str) -> String {
     format!("im:{external_actor_id}")
@@ -37,14 +54,20 @@ fn direct_conversation_query(external_actor_id: &str) -> String {
 pub(crate) struct ChannelDmTargetProvisioning {
     delivery: Arc<dyn ChannelDeliveryResolver>,
     store: Arc<FilesystemChannelDmTargetStore>,
+    snapshot_updates: tokio::sync::watch::Receiver<u64>,
 }
 
 impl ChannelDmTargetProvisioning {
     pub(crate) fn new(
         delivery: Arc<dyn ChannelDeliveryResolver>,
         store: Arc<FilesystemChannelDmTargetStore>,
+        snapshot_updates: tokio::sync::watch::Receiver<u64>,
     ) -> Self {
-        Self { delivery, store }
+        Self {
+            delivery,
+            store,
+            snapshot_updates,
+        }
     }
 }
 
@@ -57,6 +80,7 @@ impl ChannelIdentityPostBindFactory for ChannelDmTargetProvisioning {
             extension_id: extension_id.to_string(),
             delivery: Arc::clone(&self.delivery),
             store: Arc::clone(&self.store),
+            snapshot_updates: self.snapshot_updates.clone(),
         }))
     }
 }
@@ -66,6 +90,7 @@ struct ChannelDmTargetPostBind {
     extension_id: String,
     delivery: Arc<dyn ChannelDeliveryResolver>,
     store: Arc<FilesystemChannelDmTargetStore>,
+    snapshot_updates: tokio::sync::watch::Receiver<u64>,
 }
 
 impl ChannelIdentityPostBind for ChannelDmTargetPostBind {
@@ -73,14 +98,16 @@ impl ChannelIdentityPostBind for ChannelDmTargetPostBind {
         let extension_id = self.extension_id.clone();
         let delivery = Arc::clone(&self.delivery);
         let store = Arc::clone(&self.store);
+        let snapshot_updates = self.snapshot_updates.clone();
         let external_actor_id = external_actor_id.to_string();
         tokio::spawn(async move {
-            match provision_dm_target(
+            match provision_dm_target_after_bind(
                 &extension_id,
                 &delivery,
                 &store,
                 &user_id,
                 &external_actor_id,
+                snapshot_updates,
             )
             .await
             {
@@ -95,11 +122,35 @@ impl ChannelIdentityPostBind for ChannelDmTargetPostBind {
                 Err(reason) => tracing::warn!(
                     extension_id,
                     %reason,
-                    "channel DM-target provisioning failed after identity bind; \
-                     will retry on the next OAuth connection"
+                    "channel DM-target provisioning failed after identity bind"
                 ),
             }
         });
+    }
+}
+
+async fn provision_dm_target_after_bind(
+    extension_id: &str,
+    delivery: &Arc<dyn ChannelDeliveryResolver>,
+    store: &Arc<FilesystemChannelDmTargetStore>,
+    user_id: &UserId,
+    external_actor_id: &str,
+    mut snapshot_updates: tokio::sync::watch::Receiver<u64>,
+) -> Result<bool, DmTargetProvisioningError> {
+    let deadline = tokio::time::Instant::now() + ACTIVATION_PUBLICATION_TIMEOUT;
+    loop {
+        match provision_dm_target(extension_id, delivery, store, user_id, external_actor_id).await {
+            Err(DmTargetProvisioningError::ExtensionInactive) => {
+                match tokio::time::timeout_at(deadline, snapshot_updates.changed()).await {
+                    Ok(Ok(())) => continue,
+                    Ok(Err(_)) => {
+                        return Err(DmTargetProvisioningError::ActivationPublisherStopped);
+                    }
+                    Err(_) => return Err(DmTargetProvisioningError::ActivationTimeout),
+                }
+            }
+            result => return result,
+        }
     }
 }
 
@@ -107,15 +158,15 @@ impl ChannelIdentityPostBind for ChannelDmTargetPostBind {
 /// delivery, ask the adapter for the caller's direct conversation, persist
 /// the generic record. `Ok(false)` when the adapter does not support target
 /// listing or returns no candidate.
-pub(crate) async fn provision_dm_target(
+async fn provision_dm_target(
     extension_id: &str,
     delivery: &Arc<dyn ChannelDeliveryResolver>,
     store: &Arc<FilesystemChannelDmTargetStore>,
     user_id: &UserId,
     external_actor_id: &str,
-) -> Result<bool, String> {
+) -> Result<bool, DmTargetProvisioningError> {
     let Some(channel) = delivery.resolve_channel_delivery(extension_id) else {
-        return Err("channel extension is not active in the snapshot".to_string());
+        return Err(DmTargetProvisioningError::ExtensionInactive);
     };
     let candidates = match channel
         .adapter
@@ -132,7 +183,11 @@ pub(crate) async fn provision_dm_target(
     {
         Ok(candidates) => candidates,
         Err(ironclaw_product_adapters::ChannelError::Unsupported) => return Ok(false),
-        Err(error) => return Err(error.to_string()),
+        Err(error) => {
+            return Err(DmTargetProvisioningError::TargetDiscovery(
+                error.to_string(),
+            ));
+        }
     };
     let Some(candidate) = candidates.first() else {
         return Ok(false);
@@ -148,13 +203,16 @@ pub(crate) async fn provision_dm_target(
             ),
         )
         .await
-        .map_err(|error| error.to_string())?;
+        .map_err(|error| DmTargetProvisioningError::Persistence(error.to_string()))?;
     Ok(true)
 }
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Mutex;
+    use std::sync::{
+        Mutex,
+        atomic::{AtomicBool, Ordering},
+    };
 
     use async_trait::async_trait;
     use ironclaw_filesystem::InMemoryBackend;
@@ -265,6 +323,25 @@ mod tests {
         }
     }
 
+    struct EventuallyActiveDeliveryResolver {
+        active: Arc<AtomicBool>,
+        adapter: Arc<RecordingAdapter>,
+    }
+
+    impl ChannelDeliveryResolver for EventuallyActiveDeliveryResolver {
+        fn resolve_channel_delivery(&self, extension_id: &str) -> Option<ResolvedChannelDelivery> {
+            if extension_id != "vendorx" || !self.active.load(Ordering::SeqCst) {
+                return None;
+            }
+            Some(ResolvedChannelDelivery {
+                extension_id: extension_id.to_string(),
+                installation_id: "vendorx-install-1".to_string(),
+                adapter: Arc::clone(&self.adapter) as Arc<dyn ChannelAdapter>,
+                egress: Arc::new(NoopEgress),
+            })
+        }
+    }
+
     fn store() -> Arc<FilesystemChannelDmTargetStore> {
         Arc::new(FilesystemChannelDmTargetStore::new(
             Arc::new(InMemoryBackend::new()),
@@ -301,8 +378,11 @@ mod tests {
         assert_eq!(record.target["conversation_id"], "DM-77");
 
         // The factory hands the same behavior to the identity hook.
-        let provisioning =
-            ChannelDmTargetProvisioning::new(Arc::clone(&delivery), Arc::clone(&store));
+        let provisioning = ChannelDmTargetProvisioning::new(
+            Arc::clone(&delivery),
+            Arc::clone(&store),
+            tokio::sync::watch::channel(0_u64).1,
+        );
         assert!(
             provisioning.post_bind_for_extension("vendorx").is_some(),
             "every discovered extension gets a post-bind provisioner"
@@ -337,7 +417,57 @@ mod tests {
         let error = provision_dm_target("ghost", &delivery, &store, &user, "U777")
             .await
             .expect_err("inactive extension fails");
-        assert!(error.contains("not active"), "{error}");
+        assert!(
+            matches!(error, DmTargetProvisioningError::ExtensionInactive),
+            "{error}"
+        );
         assert!(store.load("ghost", &user).await.expect("load").is_none());
+    }
+
+    #[tokio::test]
+    async fn post_bind_provisioning_waits_for_extension_activation_publication() {
+        let adapter = Arc::new(RecordingAdapter::with_candidate(Some("S-9"), "DM-77"));
+        let active = Arc::new(AtomicBool::new(false));
+        let delivery: Arc<dyn ChannelDeliveryResolver> =
+            Arc::new(EventuallyActiveDeliveryResolver {
+                active: Arc::clone(&active),
+                adapter: Arc::clone(&adapter),
+            });
+        let store = store();
+        let user = UserId::new("user-alice").expect("user");
+        let (snapshot_published, snapshot_updates) = tokio::sync::watch::channel(0_u64);
+
+        let provision = provision_dm_target_after_bind(
+            "vendorx",
+            &delivery,
+            &store,
+            &user,
+            "U777",
+            snapshot_updates,
+        );
+        let activate = async {
+            tokio::task::yield_now().await;
+            assert!(
+                store
+                    .load("vendorx", &user)
+                    .await
+                    .expect("load before activation")
+                    .is_none(),
+                "provisioning must wait while the channel extension is inactive"
+            );
+            active.store(true, Ordering::SeqCst);
+            snapshot_published.send_replace(1);
+        };
+
+        let (result, ()) = tokio::join!(provision, activate);
+        assert!(result.expect("provisioning resumes after activation"));
+        assert!(
+            store
+                .load("vendorx", &user)
+                .await
+                .expect("load after activation")
+                .is_some(),
+            "activation publication should unblock and persist the DM target"
+        );
     }
 }

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -1550,13 +1550,21 @@ impl RebornRuntime {
             .extension_management
             .as_ref()
             .map(|management| management.installation_store_handle());
+        let snapshot_updates = local_runtime
+            .extension_management
+            .as_ref()
+            .and_then(|management| management.generic_host())
+            .map(|host| host.snapshot_watch().subscribe());
         let post_bind_factory = match (
             self.services.channel_delivery_resolver(),
             local_runtime.channel_dm_target_store.clone(),
+            snapshot_updates,
         ) {
-            (Some(delivery), Some(store)) => Some(Arc::new(
+            (Some(delivery), Some(store), Some(snapshot_updates)) => Some(Arc::new(
                 crate::extension_host::channel_dm_provisioning::ChannelDmTargetProvisioning::new(
-                    delivery, store,
+                    delivery,
+                    store,
+                    snapshot_updates,
                 ),
             )
                 as Arc<
@@ -4719,6 +4727,38 @@ mod tests {
     use chrono::Utc;
     use ironclaw_auth::{GOOGLE_CALENDAR_EVENTS_SCOPE, GOOGLE_CALENDAR_READONLY_SCOPE};
 
+    #[derive(Default)]
+    struct SlackDmOpenNetworkEgress {
+        calls: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl ironclaw_network::NetworkHttpEgress for SlackDmOpenNetworkEgress {
+        async fn execute(
+            &self,
+            request: ironclaw_network::NetworkHttpRequest,
+        ) -> Result<ironclaw_network::NetworkHttpResponse, ironclaw_network::NetworkHttpError>
+        {
+            assert!(
+                request.url.ends_with("/api/conversations.open"),
+                "unexpected Slack request: {}",
+                request.url
+            );
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            let body = br#"{"ok":true,"channel":{"id":"D-RUNTIME-RACE"}}"#.to_vec();
+            Ok(ironclaw_network::NetworkHttpResponse {
+                status: 200,
+                headers: vec![("content-type".to_string(), "application/json".to_string())],
+                usage: ironclaw_network::NetworkUsage {
+                    request_bytes: request.body.len() as u64,
+                    response_bytes: body.len() as u64,
+                    resolved_ip: None,
+                },
+                body,
+            })
+        }
+    }
+
     #[test]
     fn persistent_grantee_resolver_maps_outbound_delivery_target_set_to_synthetic_provider() {
         let registry = Arc::new(ironclaw_extensions::ExtensionRegistry::new());
@@ -4882,6 +4922,140 @@ output_schema_ref = "schemas/write.output.json"
             auth.is_none(),
             "auth accessor must be None without a local-dev runtime"
         );
+    }
+
+    #[tokio::test]
+    async fn runtime_channel_identity_bind_waits_for_activation_snapshot_before_dm_provisioning() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let network_egress = Arc::new(SlackDmOpenNetworkEgress::default());
+        let build_input = RebornBuildInput::local_dev(
+            "runtime-channel-bind-race-owner",
+            root.path().join("local-dev"),
+        )
+        .with_runtime_policy(local_dev_runtime_policy())
+        .with_network_http_egress_for_test(network_egress.clone())
+        .with_channel_extension_bindings(vec![crate::input::ChannelExtensionBinding {
+            extension_id: "slack".to_string(),
+            adapter: Arc::new(ironclaw_slack_extension::SlackChannelAdapter),
+            inbound_payload_classifier: None,
+            preference_target_codec: None,
+        }]);
+        let input =
+            RebornRuntimeInput::from_services(build_input).with_identity(RebornRuntimeIdentity {
+                tenant_id: "runtime-channel-bind-race-tenant".to_string(),
+                agent_id: "runtime-channel-bind-race-agent".to_string(),
+                source_binding_id: "runtime-channel-bind-race-source".to_string(),
+                reply_target_binding_id: "runtime-channel-bind-race-reply".to_string(),
+            });
+        let runtime = build_reborn_runtime(input).await.expect("runtime builds");
+        let local_runtime = runtime
+            .services
+            .local_runtime
+            .as_ref()
+            .expect("local runtime services");
+        let extension_management = local_runtime
+            .extension_management
+            .as_ref()
+            .expect("extension management");
+        let operator = extension_management
+            .tenant_operator_user_id_for_test()
+            .clone();
+        let slack_ref = LifecyclePackageRef::new(LifecyclePackageKind::Extension, "slack")
+            .expect("valid Slack ref");
+        extension_management
+            .install(slack_ref.clone(), &operator)
+            .await
+            .expect("install Slack before OAuth callback");
+
+        let slack_id = ironclaw_host_api::ExtensionId::new("slack").expect("Slack extension id");
+        local_runtime
+            .channel_config
+            .as_ref()
+            .expect("channel config service")
+            .save(
+                &slack_id,
+                vec![
+                    ("slack_bot_token".to_string(), "xoxb-test".to_string()),
+                    (
+                        "slack_signing_secret".to_string(),
+                        "signing-test".to_string(),
+                    ),
+                    ("slack_team_id".to_string(), "T-RUNTIME".to_string()),
+                    ("slack_api_app_id".to_string(), "A-RUNTIME".to_string()),
+                ],
+            )
+            .await
+            .expect("configure Slack channel deployment values");
+
+        let binding_config = runtime
+            .channel_identity_binding_config()
+            .expect("production runtime channel identity binding config");
+        let mut resource = ResourceScope::local_default(operator.clone(), InvocationId::new())
+            .expect("callback resource scope");
+        resource.tenant_id = runtime.thread_scope.tenant_id.clone();
+        let callback_scope =
+            ironclaw_auth::AuthProductScope::new(resource, ironclaw_auth::AuthSurface::Callback);
+        let identity = ironclaw_auth::OAuthProviderIdentity::new(
+            "U-RUNTIME",
+            Some("T-RUNTIME".to_string()),
+            None,
+            Some("A-RUNTIME".to_string()),
+        )
+        .expect("proven Slack identity");
+        let rollback =
+            crate::extension_host::channel_identity::bind_channel_identities_for_callback(
+                &binding_config,
+                "slack",
+                &callback_scope,
+                Some(&identity),
+            )
+            .await
+            .expect("bind Slack identity before activation")
+            .expect("Slack callback maps to the installed channel extension");
+        drop(rollback);
+
+        // Give the spawned production post-bind hook a deterministic turn
+        // while Slack is still absent from the generic host snapshot. The old
+        // one-shot implementation exits here and can never provision later.
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+        let dm_targets = local_runtime
+            .channel_dm_target_store
+            .as_ref()
+            .expect("channel DM-target store");
+        assert!(
+            dm_targets
+                .load("slack", &operator)
+                .await
+                .expect("load pre-activation DM target")
+                .is_none(),
+            "OAuth binding alone must not fabricate a target before activation"
+        );
+
+        extension_management
+            .activate_with_prechecked_credentials_for_test(
+                slack_ref,
+                ExtensionActivationMode::Static,
+            )
+            .await
+            .expect("activate Slack and publish the generic host snapshot");
+
+        let record = tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                if let Some(record) = dm_targets
+                    .load("slack", &operator)
+                    .await
+                    .expect("load post-activation DM target")
+                {
+                    break record;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("activation publication should unblock DM provisioning");
+        assert_eq!(record.target["conversation_id"], "D-RUNTIME-RACE");
+        assert_eq!(network_egress.calls.load(Ordering::SeqCst), 1);
     }
 
     /// Wiring guard: the `regex_skill_activation_enabled` flag from

--- a/crates/ironclaw_reborn_composition/src/test_support/channel_connection.rs
+++ b/crates/ironclaw_reborn_composition/src/test_support/channel_connection.rs
@@ -140,14 +140,20 @@ pub fn build_channel_connection_for_test(
     // Same assembly as `RebornRuntime::channel_identity_binding_config`: the
     // generic post-OAuth binding hook over the same installation + identity
     // stores, with DM-target provisioning when the composition can deliver.
+    let snapshot_updates = local_runtime
+        .extension_management
+        .as_ref()
+        .and_then(|management| management.generic_host())
+        .map(|host| host.snapshot_watch().subscribe());
     let post_bind_factory = match (
         services.channel_delivery_resolver(),
         local_runtime.channel_dm_target_store.clone(),
+        snapshot_updates,
     ) {
-        (Some(delivery), Some(store)) => {
-            Some(Arc::new(ChannelDmTargetProvisioning::new(delivery, store))
-                as Arc<dyn ChannelIdentityPostBindFactory>)
-        }
+        (Some(delivery), Some(store), Some(snapshot_updates)) => Some(Arc::new(
+            ChannelDmTargetProvisioning::new(delivery, store, snapshot_updates),
+        )
+            as Arc<dyn ChannelIdentityPostBindFactory>),
         _ => None,
     };
     let identity_binding = ChannelIdentityBindingConfig {


### PR DESCRIPTION
## Summary

- fail catalog construction when a host-bundled extension manifest references a missing static manifest, WASM module, schema, or prompt asset
- keep the only asset exemption constrained to canonical hosted HTTP MCP packages and their exact inline dynamic schema namespace
- make post-OAuth channel DM-target provisioning wait on generic-host snapshot publications when identity binding races extension activation
- wire the production runtime and test-support path to the same snapshot watch
- cover the real production path from inactive Slack install -> OAuth identity bind -> lifecycle activation -> real Slack `conversations.open` adapter call -> durable DM target

## Why

Two distinct problems were visible around Slack connect:

1. A bundled package could install and activate with a dangling static asset reference, then fail the next host-capability refresh. The target branch already contains the immediate Slack asset additions in `cc947a67f`; this PR makes that class of package invalid at catalog construction so it cannot recur for Slack or another bundled extension.
2. The OAuth callback can bind the Slack identity just before the activation continuation publishes the generic host snapshot. The old fire-and-forget provisioner checked once, saw an inactive extension, and exited permanently. It now waits on snapshot generations for a bounded 10-second interval and retries only when the host publishes.

The callback remains successful and fire-and-forget; provisioning failure is still isolated and logged.

## Verification

- `cargo test --quiet -p ironclaw_reborn_composition --lib -- --skip factory::auth_tests::production_libsql_oauth_callback_fans_out_to_all_owner_provider_blocked_runs`
  - 1,204 passed, 0 failed, 1 filtered out
- focused regressions:
  - bundled catalog asset coverage
  - missing static package asset rejection
  - non-hosted/static MCP cannot claim the dynamic-schema exemption
  - production runtime OAuth-before-activation recovery and durable DM-target persistence
- `cargo clippy -p ironclaw_reborn_composition --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- independent read-only review: no Critical or Important findings; ready to merge

### Known base failure

`factory::auth_tests::production_libsql_oauth_callback_fans_out_to_all_owner_provider_blocked_runs` fails independently on the current base `ec60077fd` with `BlockedAuth` vs expected `Queued`. The exact test was rerun on the untouched base SHA and excluded from the otherwise complete crate run above.

## Compatibility, security, and rollback

- no persistence schema, public API, route, or credential format changes
- no secret values are logged or added to fixtures
- tenant/user keys and installation scoping are unchanged
- rollback is a single-commit revert; the prior one-shot post-bind behavior is restored
