### PR TITLE
chore: review user-created pull requests on open

### DIFF
--- a/.ironloop/agents.yaml
+++ b/.ironloop/agents.yaml
@@ -6,8 +6,8 @@ reviewers:
     network_access: true
     auto_review:
       enabled: true
-      unmanaged_on_open: true
-      unmanaged_on_update: false
+      external_on_open: true
+      external_on_update: false
 
 developers:
   - id: implementer

--- a/.ironloop/agents.yaml
+++ b/.ironloop/agents.yaml
@@ -6,6 +6,7 @@ reviewers:
     network_access: true
     auto_review:
       enabled: true
+      unmanaged_on_open: true
 
 developers:
   - id: implementer

--- a/.ironloop/agents.yaml
+++ b/.ironloop/agents.yaml
@@ -7,6 +7,7 @@ reviewers:
     auto_review:
       enabled: true
       unmanaged_on_open: true
+      unmanaged_on_update: false
 
 developers:
   - id: implementer

--- a/.ironloop/agents.yaml
+++ b/.ironloop/agents.yaml
@@ -6,8 +6,8 @@ reviewers:
     network_access: true
     auto_review:
       enabled: true
-      external_on_open: true
-      external_on_update: false
+      user_open: true
+      user_update: false
 
 developers:
   - id: implementer


### PR DESCRIPTION
## Summary
- enable IronLoop auto-review when a user-created pull request is opened
- keep automatic review on user-created pull request updates disabled
- use the `user_open` and `user_update` settings introduced by nearai/ironloop#228

## Validation
- parsed `.ironloop/agents.yaml` as YAML