### PR TITLE
feat(reborn-cli): background service install (launchd/systemd) + service restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - *(reborn)* automations and `trigger_list` now surface why a scheduled trigger is currently held (approval/auth/in-progress) and how many scheduled occurrences elapsed while held ([#5886](https://github.com/nearai/ironclaw/issues/5886)).
+- *(reborn)* `ironclaw-reborn service install`/`start`/`stop`/`restart`/`status`/`uninstall` manage the standalone Reborn binary as an OS-native service (launchd user agent on macOS, systemd user unit on Linux), with a webui-token-file fallback for `serve` and atomic install with rollback on failure.
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4837,6 +4837,7 @@ dependencies = [
  "ironclaw_reborn_config",
  "ironclaw_reborn_traces",
  "ironclaw_reborn_webui_ingress",
+ "rand 0.10.1",
  "reqwest 0.12.28",
  "secrecy",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4837,6 +4837,7 @@ dependencies = [
  "ironclaw_reborn_config",
  "ironclaw_reborn_traces",
  "ironclaw_reborn_webui_ingress",
+ "libc",
  "rand 0.10.1",
  "reqwest 0.12.28",
  "secrecy",

--- a/FEATURE_PARITY.md
+++ b/FEATURE_PARITY.md
@@ -551,7 +551,7 @@ Trace Commons issuer/TenantCtx note: the server-side `zmanian/tracedao-server` s
 | Config recovery on clobber | ✅ | ❌ | Restore last-known-good config on critical clobber signatures (missing metadata, missing `gateway.mode`, sharp size drops); foreground/service notices include rejected paths |
 | Modular `$include` files | ✅ | ❌ | Single-file top-level includes for isolated mutations; `plugins install`/`update` updates `plugins.json5` instead of flattening |
 | `config set --merge`/`--replace` | ✅ | ❌ | Additive vs intentional clobber for provider model maps |
-| Wrapper-based service install | ✅ | ❌ | `--wrapper`/`OPENCLAW_WRAPPER` validated executable LaunchAgent/systemd wrappers |
+| Wrapper-based service install | ✅ | ✅ (Reborn) | `--wrapper`/`OPENCLAW_WRAPPER` validated executable LaunchAgent/systemd wrappers; Reborn's `ironclaw-reborn service install` covers launchd (macOS)/systemd (Linux) with a webui-token-file fallback and atomic install + rollback on failure |
 
 ### Owner: _Unassigned_
 

--- a/crates/ironclaw_reborn_cli/Cargo.toml
+++ b/crates/ironclaw_reborn_cli/Cargo.toml
@@ -35,6 +35,7 @@ full = [
     "postgres",
     "inmemory-turn-state",
     "openai-compat-beta",
+    "root-llm-provider",
 ]
 # Wire a real LLM provider into the assembled runtime. Mirrors the same
 # `root-llm-provider` feature on `ironclaw_reborn_composition` /

--- a/crates/ironclaw_reborn_cli/Cargo.toml
+++ b/crates/ironclaw_reborn_cli/Cargo.toml
@@ -19,7 +19,23 @@ layer = "app"
 dist = false
 
 [features]
-default = ["root-llm-provider"]
+# libsql is the default storage backend: a file-backed local database needs
+# no external server, so a default `ironclaw-reborn` build is runnable as-is.
+# `postgres` remains opt-in for deployments that point `[storage]` at a server.
+default = ["root-llm-provider", "libsql"]
+# Everything a full-fat local/desktop build ships: the WebChat v2 HTTP
+# gateway (and with it `serve` + `service`), the Slack and OpenAI-compat
+# host mounts, and every storage backend so the binary can honor whatever
+# `[storage]` the operator's config selects at runtime rather than being
+# pinned at compile time.
+full = [
+    "webui-v2-beta",
+    "slack-v2-host-beta",
+    "libsql",
+    "postgres",
+    "inmemory-turn-state",
+    "openai-compat-beta",
+]
 # Wire a real LLM provider into the assembled runtime. Mirrors the same
 # `root-llm-provider` feature on `ironclaw_reborn_composition` /
 # `ironclaw_runner`, so building without it produces a CLI binary that
@@ -85,6 +101,7 @@ ironclaw_reborn_composition = { path = "../ironclaw_reborn_composition", version
 ironclaw_reborn_config = { path = "../ironclaw_reborn_config", version = "0.1.0" }
 ironclaw_reborn_traces = { path = "../ironclaw_reborn_traces", version = "0.1.0" }
 ironclaw_reborn_webui_ingress = { path = "../ironclaw_reborn_webui_ingress", version = "0.1.0", optional = true }
+rand = "0.10"
 reqwest = { version = "0.12", default-features = false, features = ["json", "multipart", "rustls-tls-native-roots", "stream"] }
 secrecy = "0.10"
 serde = { version = "1", features = ["derive"] }

--- a/crates/ironclaw_reborn_cli/Cargo.toml
+++ b/crates/ironclaw_reborn_cli/Cargo.toml
@@ -115,6 +115,14 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 uuid = { version = "1", features = ["v4", "v5", "serde"] }
 
+[target.'cfg(unix)'.dependencies]
+# O_NOFOLLOW for the single-handle, symlink-safe token file open in
+# `webui_token::read_token_file_checked` — the flag's raw value differs
+# across unix platforms (Linux vs macOS), so it must come from `libc`
+# rather than being hardcoded. Already present transitively; pinned here
+# as a direct dependency of the code that now uses it.
+libc = "0.2"
+
 [dev-dependencies]
 # Enable the composition crate's `test-support` seam for CLI unit tests so
 # `open_reborn_identity_resolver` (the test-only standalone resolver opener)

--- a/crates/ironclaw_reborn_cli/src/commands/mod.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/mod.rs
@@ -18,6 +18,8 @@ pub(crate) mod serve;
 pub(crate) mod serve_slack;
 #[cfg(feature = "webui-v2-beta")]
 pub(crate) mod serve_sso;
+#[cfg(feature = "webui-v2-beta")]
+pub(crate) mod service;
 pub(crate) mod skills;
 pub(crate) mod status;
 pub(crate) mod traces;
@@ -58,6 +60,12 @@ pub(crate) enum Command {
     /// before being linked into a production binary.
     #[cfg(feature = "webui-v2-beta")]
     Serve(serve::ServeCommand),
+    /// Install/start/stop/status/uninstall the standalone Reborn binary
+    /// as an OS-native service (launchd on macOS, systemd on Linux).
+    /// Available only when built with the `webui-v2-beta` Cargo feature,
+    /// since the installed unit runs `serve`.
+    #[cfg(feature = "webui-v2-beta")]
+    Service(service::ServiceCommand),
     /// Inspect configured Reborn skills.
     Skills(skills::SkillsCommand),
     /// Show Reborn runtime status snapshot.
@@ -95,6 +103,10 @@ impl Command {
             }
             #[cfg(feature = "webui-v2-beta")]
             Self::Serve(command) => {
+                command.execute(crate::context::RebornCliContext::resolve_from_env()?)
+            }
+            #[cfg(feature = "webui-v2-beta")]
+            Self::Service(command) => {
                 command.execute(crate::context::RebornCliContext::resolve_from_env()?)
             }
             Self::Skills(command) => {

--- a/crates/ironclaw_reborn_cli/src/commands/onboard.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/onboard.rs
@@ -39,6 +39,11 @@ impl OnboardCommand {
         }
 
         let outcome = write_default_config_files(home, self.force, ExistingConfigPolicy::Preserve)?;
+        // Independent of `--force`: a valid existing token is never
+        // regenerated (see `ensure_webui_token_file`'s doc for why), so a
+        // repeated `onboard --force` cannot invalidate sessions or an
+        // operator-copied env var keyed to the current token value.
+        let webui_token_action = crate::webui_token::ensure_webui_token_file(home.path())?;
         let marker_action =
             write_onboarding_marker(home, &marker_path, self.force, self.import_history)?;
 
@@ -47,6 +52,11 @@ impl OnboardCommand {
         println!("home_source: {}", home.source_label());
         println!("{}", outcome.config.display_line());
         println!("{}", outcome.providers.display_line());
+        println!(
+            "webui_token: {} ({})",
+            crate::webui_token::webui_token_file_path(home.path()).display(),
+            webui_token_action
+        );
         println!(
             "onboarding_marker: {} ({})",
             marker_path.display(),
@@ -57,6 +67,7 @@ impl OnboardCommand {
         println!("completed:");
         println!("- reborn home initialized");
         println!("- config.toml and providers.json available");
+        println!("- webui bearer token provisioned (used by `serve` when the env var is unset)");
         println!("- onboarding completion marker available");
         println!();
         println!("remaining:");
@@ -90,6 +101,15 @@ fn print_dry_run(home: &RebornHome, marker_path: &Path, force: bool, import_hist
         "would_write_or_preserve: {}",
         home.providers_file_path().display()
     );
+    let webui_token_action = if crate::webui_token::webui_token_file_is_valid(home.path()) {
+        "would_preserve"
+    } else {
+        "would_write"
+    };
+    println!(
+        "{webui_token_action}: {}",
+        crate::webui_token::webui_token_file_path(home.path()).display()
+    );
     let marker_action = if marker_path.exists() && !force {
         "would_preserve"
     } else {
@@ -116,9 +136,11 @@ fn write_onboarding_marker(
         "home_source": home.source_label(),
         "config_file": home.config_file_path(),
         "providers_file": home.providers_file_path(),
+        "webui_token_file": crate::webui_token::webui_token_file_path(home.path()),
         "steps_completed": [
             "reborn_home",
             "config_files",
+            "webui_token",
             "completion_marker"
         ],
         "steps_pending": pending_steps(import_history),

--- a/crates/ironclaw_reborn_cli/src/commands/onboard.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/onboard.rs
@@ -34,7 +34,7 @@ impl OnboardCommand {
         let marker_path = onboarding_marker_path(home);
 
         if self.dry_run {
-            print_dry_run(home, &marker_path, self.force, self.import_history);
+            print_dry_run(home, &marker_path, self.force, self.import_history)?;
             return Ok(());
         }
 
@@ -88,7 +88,12 @@ pub(crate) fn onboarding_marker_path(home: &RebornHome) -> PathBuf {
     home.path().join(ONBOARDING_MARKER_FILE)
 }
 
-fn print_dry_run(home: &RebornHome, marker_path: &Path, force: bool, import_history: bool) {
+fn print_dry_run(
+    home: &RebornHome,
+    marker_path: &Path,
+    force: bool,
+    import_history: bool,
+) -> anyhow::Result<()> {
     println!("IronClaw Reborn onboarding dry run");
     println!("reborn_home: {}", home.path().display());
     println!("home_source: {}", home.source_label());
@@ -101,7 +106,11 @@ fn print_dry_run(home: &RebornHome, marker_path: &Path, force: bool, import_hist
         "would_write_or_preserve: {}",
         home.providers_file_path().display()
     );
-    let webui_token_action = if crate::webui_token::webui_token_file_is_valid(home.path()) {
+    // Propagates rather than defaulting to "would_write" on an I/O error:
+    // an unreadable-but-present token file must be reported as an error,
+    // not silently promised a (destructive) overwrite that wouldn't
+    // actually happen the same way on a real run.
+    let webui_token_action = if crate::webui_token::webui_token_file_is_valid(home.path())? {
         "would_preserve"
     } else {
         "would_write"
@@ -118,6 +127,7 @@ fn print_dry_run(home: &RebornHome, marker_path: &Path, force: bool, import_hist
     println!("{marker_action}: {}", marker_path.display());
     println!("import_history_requested: {import_history}");
     println!("v1_state: not-used");
+    Ok(())
 }
 
 fn write_onboarding_marker(

--- a/crates/ironclaw_reborn_cli/src/commands/serve.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/serve.rs
@@ -47,6 +47,28 @@ const DEFAULT_ENV_USER_ID_VAR: &str = "IRONCLAW_REBORN_WEBUI_USER_ID";
 /// year: this is a long-lived programmatic credential, not a browser session.
 const ADMIN_API_TOKEN_LIFETIME_DAYS: i64 = 365;
 
+/// Read an env var, distinguishing "unset" from "set but not valid UTF-8".
+///
+/// `std::env::var(name).ok()` collapses both `VarError::NotPresent` and
+/// `VarError::NotUnicode` to `None` — which for the WebChat v2 bearer
+/// token env var is dangerous: an operator whose token value got mangled
+/// into invalid UTF-8 (a shell/CI export bug, a truncated byte sequence)
+/// would silently fall through to the `<reborn_home>/webui-token` file
+/// credential instead of failing loudly. Only `NotPresent` means "treat
+/// as unset"; `NotUnicode` is a real configuration error and must
+/// propagate with context naming the variable.
+fn present_unicode_env_var(name: &str) -> anyhow::Result<Option<String>> {
+    match env::var(name) {
+        Ok(value) => Ok(Some(value)),
+        Err(env::VarError::NotPresent) => Ok(None),
+        Err(env::VarError::NotUnicode(raw)) => Err(anyhow!(
+            "{name} is set but is not valid UTF-8 ({} raw bytes); refusing to silently treat it \
+             as unset, which would otherwise fall through to the WebChat v2 token file credential.",
+            raw.as_encoded_bytes().len()
+        )),
+    }
+}
+
 /// Mints the admin-created-user API bearer over a signed session store. The
 /// store is deterministic in its signing key (operator secret + tenant), so a
 /// token minted here validates under the SSO login surface's own store.
@@ -152,7 +174,7 @@ impl ServeCommand {
         // the value opaquely.
         let token_value = crate::webui_token::resolve_webui_token(
             env_token_var,
-            env::var(env_token_var).ok().as_deref(),
+            present_unicode_env_var(env_token_var)?.as_deref(),
             boot_config.home().path(),
         )?;
         let user_id_raw = env::var(env_user_id_var).map_err(|_| {
@@ -1069,6 +1091,65 @@ mod tests {
     use super::*;
 
     const WEBUI_BASE_URL_ENV: &str = "IRONCLAW_REBORN_WEBUI_BASE_URL";
+
+    #[test]
+    fn present_unicode_env_var_treats_unset_as_none() {
+        let _guard = crate::runtime::test_env::lock_runtime_env();
+        const VAR: &str = "IRONCLAW_REBORN_CLI_TEST_ABSENT_VAR";
+        // SAFETY: serialized by `lock_runtime_env`; no other thread touches
+        // this test-local var name.
+        unsafe { std::env::remove_var(VAR) };
+        assert_eq!(
+            present_unicode_env_var(VAR).expect("unset is not an error"),
+            None
+        );
+    }
+
+    #[test]
+    fn present_unicode_env_var_returns_a_present_value() {
+        let _guard = crate::runtime::test_env::lock_runtime_env();
+        const VAR: &str = "IRONCLAW_REBORN_CLI_TEST_PRESENT_VAR";
+        // SAFETY: serialized by `lock_runtime_env`; restored below.
+        unsafe { std::env::set_var(VAR, "a-token-value") };
+        let result = present_unicode_env_var(VAR);
+        // SAFETY: serialized by `lock_runtime_env`.
+        unsafe { std::env::remove_var(VAR) };
+        assert_eq!(
+            result.expect("present unicode value is not an error"),
+            Some("a-token-value".to_string())
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn present_unicode_env_var_propagates_not_unicode_instead_of_treating_it_as_unset() {
+        // Before this fix, `env::var(name).ok()` collapsed `NotUnicode`
+        // (a real configuration error — the bearer token env var got
+        // mangled into invalid UTF-8) into `None`, silently falling
+        // through to the WebChat v2 token file credential instead of
+        // failing loudly at startup.
+        use std::os::unix::ffi::OsStringExt as _;
+
+        let _guard = crate::runtime::test_env::lock_runtime_env();
+        const VAR: &str = "IRONCLAW_REBORN_CLI_TEST_NON_UNICODE_VAR";
+        let invalid_utf8 = std::ffi::OsString::from_vec(vec![0xFF, 0xFE, 0xFD]);
+        // SAFETY: serialized by `lock_runtime_env`; restored below.
+        unsafe { std::env::set_var(VAR, &invalid_utf8) };
+        let result = present_unicode_env_var(VAR);
+        // SAFETY: serialized by `lock_runtime_env`.
+        unsafe { std::env::remove_var(VAR) };
+
+        let error = result.expect_err("non-UTF-8 env value must be a real error, not `Ok(None)`");
+        let message = error.to_string();
+        assert!(
+            message.contains(VAR),
+            "error must name the variable: {message}"
+        );
+        assert!(
+            message.contains("not valid UTF-8"),
+            "error must explain why: {message}"
+        );
+    }
 
     fn clear_webui_env() {
         // SAFETY: tests are serialized by `the shared crate process-env lock`; no other

--- a/crates/ironclaw_reborn_cli/src/commands/serve.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/serve.rs
@@ -141,13 +141,20 @@ impl ServeCommand {
             .and_then(|section| section.env_user_id_var.as_deref())
             .unwrap_or(DEFAULT_ENV_USER_ID_VAR);
 
-        let token_value = env::var(env_token_var).map_err(|_| {
-            anyhow!(
-                "{env_token_var} must be set to the WebChat v2 bearer token. \
-                 Override the variable name via `[webui].env_token_var` in {}.",
-                boot_config.home().config_file_path().display(),
-            )
-        })?;
+        // Precedence: `env_token_var` (if set and non-empty), else
+        // `<reborn_home>/webui-token` (the `onboard`-provisioned fallback a
+        // service-installed serve, whose unit environment carries only
+        // HOME/PROFILE, still needs — see `serve_invocation.rs`). Also
+        // enforces the >=32-byte entropy floor (this token doubles as the
+        // session-signing HMAC key — see the comment near
+        // `session_signing_secret` below) so a weak or missing token fails
+        // closed here rather than starting the server and having it reject
+        // the value opaquely.
+        let token_value = crate::webui_token::resolve_webui_token(
+            env_token_var,
+            env::var(env_token_var).ok().as_deref(),
+            boot_config.home().path(),
+        )?;
         let user_id_raw = env::var(env_user_id_var).map_err(|_| {
             anyhow!(
                 "{env_user_id_var} must be set to the UserId an env-bearer-authenticated caller maps to. \
@@ -161,10 +168,10 @@ impl ServeCommand {
         // Keep a copy of the operator secret to key the SSO session-token
         // HMAC before the value is moved into the env-bearer authenticator.
         // Held as `SecretString` so it is redacted in `Debug`/logs and
-        // zeroed on drop — it doubles as the session-signing key. Capture
-        // its byte length first (for the session-signing entropy floor below)
-        // since the value is consumed here.
-        let token_byte_len = token_value.len();
+        // zeroed on drop — it doubles as the session-signing key.
+        // `resolve_webui_token` above already enforced the >=32-byte
+        // entropy floor this key needs, regardless of which of its two
+        // sources (env var or `<reborn_home>/webui-token`) produced it.
         let session_signing_secret = SecretString::from(token_value.clone());
         let env_authenticator: Arc<dyn WebuiAuthenticator> = Arc::new(EnvBearerAuthenticator::new(
             SecretString::from(token_value),
@@ -314,29 +321,21 @@ impl ServeCommand {
         // the login wiring are assembled inside the async runtime below,
         // because opening the libSQL user store is async.
         let sso_startup = crate::commands::serve_sso::sso_startup_config_from_env(listen_addr)?;
-        // This token keys the stateless session HMAC, so a weak value becomes
+        // This token keys the stateless session HMAC, so a weak value would be
         // an OFFLINE forgery target: an attacker who obtains one legitimate
-        // `{payload}.{hmac}` session pair can brute-force a low-entropy key
+        // `{payload}.{hmac}` session pair could brute-force a low-entropy key
         // locally, then mint a session for any user/tenant. Two paths mint
-        // such user-visible session tokens, so the floor is unconditional:
+        // such user-visible session tokens, so the entropy floor is
+        // unconditional:
         //   - SSO login (`sso_startup`) signs a session on every login, and
         //   - admin user-management (wired above via
         //     `with_admin_api_token_minter`) mints a one-time session bearer
         //     on `POST /admin/users`.
         // The admin minter is always installed, so a signed session token can
-        // always be produced regardless of whether SSO is configured. Pre-admin
-        // the token only ever gated an online, rate-limited bearer guess; now it
-        // signs offline-verifiable tokens, so require real entropy and fail
-        // closed rather than warn.
-        if token_byte_len < 32 {
-            return Err(anyhow!(
-                "{env_token_var} is also the WebChat session-signing key (it signs the \
-                 stateless, user-visible session tokens issued by SSO login and by admin \
-                 user creation) and must be at least 32 bytes of high-entropy random \
-                 material. The current value is {token_byte_len} bytes — generate one with \
-                 e.g. `openssl rand -hex 32`."
-            ));
-        }
+        // always be produced regardless of whether SSO is configured.
+        // `crate::webui_token::resolve_webui_token` already enforced the
+        // >=32-byte floor when `token_value` was resolved above, so no
+        // separate check is needed here.
         // Sidecar DB used by the local-runtime trigger-fire access checker. It
         // backs the local trigger-fire
         // access store used to seed default-user and SSO-user trigger access;

--- a/crates/ironclaw_reborn_cli/src/commands/service/launchd.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/service/launchd.rs
@@ -224,6 +224,18 @@ pub(super) fn install_with_runner(
 }
 
 pub(super) fn start_with_runner(runner: &mut dyn ServiceCommandRunner) -> Result<()> {
+    start_with_runner_impl(runner, true)
+}
+
+/// Same start sequence, but without the "Service started" line — used by
+/// [`restart_with_runner`] via [`super::restart_generic`], which prints its
+/// own single restart summary instead of letting the inner start/stop calls
+/// print their own lines too.
+fn start_with_runner_quiet(runner: &mut dyn ServiceCommandRunner) -> Result<()> {
+    start_with_runner_impl(runner, false)
+}
+
+fn start_with_runner_impl(runner: &mut dyn ServiceCommandRunner, verbose: bool) -> Result<()> {
     let plist = plist_path()?;
     if !plist.exists() {
         bail!("Service not installed. Run `ironclaw-reborn service install` first.");
@@ -236,20 +248,36 @@ pub(super) fn start_with_runner(runner: &mut dyn ServiceCommandRunner) -> Result
         "launchctl start",
         Command::new("launchctl").arg("start").arg(SERVICE_LABEL),
     )?;
-    println!("Service started");
+    if verbose {
+        println!("Service started");
+    }
     Ok(())
 }
 
 pub(super) fn stop_with_runner(runner: &mut dyn ServiceCommandRunner) -> Result<()> {
+    stop_with_runner_impl(runner, true)
+}
+
+/// Same stop sequence, but without the "Service stopped" line — see
+/// [`start_with_runner_quiet`].
+fn stop_with_runner_quiet(runner: &mut dyn ServiceCommandRunner) -> Result<()> {
+    stop_with_runner_impl(runner, false)
+}
+
+fn stop_with_runner_impl(runner: &mut dyn ServiceCommandRunner, verbose: bool) -> Result<()> {
     let plist = plist_path()?;
     if !plist.exists() {
-        println!("Service stopped");
+        if verbose {
+            println!("Service stopped");
+        }
         return Ok(());
     }
     let list =
         runner.run_capture_checked("launchctl list", Command::new("launchctl").arg("list"))?;
     if !service_running(&list) {
-        println!("Service stopped");
+        if verbose {
+            println!("Service stopped");
+        }
         return Ok(());
     }
     runner.run_checked(
@@ -263,7 +291,9 @@ pub(super) fn stop_with_runner(runner: &mut dyn ServiceCommandRunner) -> Result<
             .arg("-w")
             .arg(&plist),
     )?;
-    println!("Service stopped");
+    if verbose {
+        println!("Service stopped");
+    }
     Ok(())
 }
 
@@ -283,8 +313,8 @@ pub(super) fn restart_with_runner(runner: &mut dyn ServiceCommandRunner) -> Resu
         runner,
         installed,
         was_running,
-        stop_with_runner,
-        start_with_runner,
+        stop_with_runner_quiet,
+        start_with_runner_quiet,
     )
 }
 

--- a/crates/ironclaw_reborn_cli/src/commands/service/launchd.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/service/launchd.rs
@@ -167,6 +167,43 @@ fn stop_with_runner(runner: &mut dyn ServiceCommandRunner) -> Result<()> {
     Ok(())
 }
 
+pub(super) fn restart() -> Result<()> {
+    restart_with_runner(&mut OsServiceCommandRunner)
+}
+
+/// Composes [`stop_with_runner`] and [`start_with_runner`]: a running
+/// service is stopped then started, an already-stopped service is just
+/// started, and a start failure after a successful stop is reported as
+/// leaving the service stopped rather than a silent half-restart.
+fn restart_with_runner(runner: &mut dyn ServiceCommandRunner) -> Result<()> {
+    let plist = plist_path()?;
+    if !plist.exists() {
+        bail!("Service not installed. Run `ironclaw-reborn service install` first.");
+    }
+    let list =
+        runner.run_capture_checked("launchctl list", Command::new("launchctl").arg("list"))?;
+    let was_running = service_running(&list);
+
+    if was_running {
+        stop_with_runner(runner)?;
+    }
+    if let Err(start_error) = start_with_runner(runner) {
+        if was_running {
+            bail!(
+                "service restart: stop succeeded but start failed; the service is now \
+                 STOPPED: {start_error:#}"
+            );
+        }
+        return Err(start_error);
+    }
+    if was_running {
+        println!("Service restarted");
+    } else {
+        println!("Service was not running; started");
+    }
+    Ok(())
+}
+
 pub(super) fn status() -> Result<()> {
     status_with_runner(&mut OsServiceCommandRunner)
 }
@@ -609,6 +646,136 @@ mod tests {
         }
 
         assert!(result.is_err());
+    }
+
+    // ── restart ─────────────────────────────────────────────────
+
+    #[test]
+    fn restart_running_service_stops_then_starts() {
+        let _lock = crate::runtime::test_env::lock_runtime_env();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let prior = std::env::var_os("HOME");
+        // SAFETY: serialized by `lock_runtime_env`; restored below.
+        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let file = plist_path().expect("plist path");
+        std::fs::create_dir_all(file.parent().expect("plist parent")).expect("create parent");
+        std::fs::write(&file, "plist").expect("write plist");
+        let mut runner = RecordingRunner {
+            launchctl_list: format!("123\t0\t{SERVICE_LABEL}\n"),
+            ..RecordingRunner::default()
+        };
+        let result = restart_with_runner(&mut runner);
+        // SAFETY: serialized by `lock_runtime_env`.
+        unsafe {
+            match prior {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+
+        result.expect("restart of a running service must succeed");
+        assert_eq!(
+            runner.labels,
+            [
+                "launchctl list",
+                "launchctl list",
+                "launchctl stop",
+                "launchctl unload",
+                "launchctl load",
+                "launchctl start",
+            ]
+        );
+    }
+
+    #[test]
+    fn restart_stopped_service_just_starts() {
+        let _lock = crate::runtime::test_env::lock_runtime_env();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let prior = std::env::var_os("HOME");
+        // SAFETY: serialized by `lock_runtime_env`; restored below.
+        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let file = plist_path().expect("plist path");
+        std::fs::create_dir_all(file.parent().expect("plist parent")).expect("create parent");
+        std::fs::write(&file, "plist").expect("write plist");
+        let mut runner = RecordingRunner::default();
+        let result = restart_with_runner(&mut runner);
+        // SAFETY: serialized by `lock_runtime_env`.
+        unsafe {
+            match prior {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+
+        result.expect("restart of a stopped service must succeed without error");
+        assert_eq!(
+            runner.labels,
+            ["launchctl list", "launchctl load", "launchctl start"]
+        );
+    }
+
+    #[test]
+    fn restart_not_installed_errors_with_install_guidance() {
+        let _lock = crate::runtime::test_env::lock_runtime_env();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let prior = std::env::var_os("HOME");
+        // SAFETY: serialized by `lock_runtime_env`; restored below.
+        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let mut runner = RecordingRunner::default();
+        let result = restart_with_runner(&mut runner);
+        // SAFETY: serialized by `lock_runtime_env`.
+        unsafe {
+            match prior {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+
+        let error = result.expect_err("restart without an installed service must error");
+        assert!(error.to_string().contains("service install"));
+        assert!(runner.labels.is_empty(), "no commands should run");
+    }
+
+    #[test]
+    fn restart_reports_stopped_when_start_fails_after_successful_stop() {
+        let _lock = crate::runtime::test_env::lock_runtime_env();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let prior = std::env::var_os("HOME");
+        // SAFETY: serialized by `lock_runtime_env`; restored below.
+        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let file = plist_path().expect("plist path");
+        std::fs::create_dir_all(file.parent().expect("plist parent")).expect("create parent");
+        std::fs::write(&file, "plist").expect("write plist");
+        let mut runner = RecordingRunner {
+            launchctl_list: format!("123\t0\t{SERVICE_LABEL}\n"),
+            fail_args: Some(vec!["start", SERVICE_LABEL]),
+            ..RecordingRunner::default()
+        };
+        let result = restart_with_runner(&mut runner);
+        // SAFETY: serialized by `lock_runtime_env`.
+        unsafe {
+            match prior {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+
+        let error = result.expect_err("failed start after successful stop must error");
+        assert!(
+            error.to_string().contains("STOPPED"),
+            "error must report the service as stopped, got: {error}"
+        );
+        assert_eq!(
+            runner.labels,
+            [
+                "launchctl list",
+                "launchctl list",
+                "launchctl stop",
+                "launchctl unload",
+                "launchctl load",
+                "launchctl start",
+            ]
+        );
     }
 
     #[test]

--- a/crates/ironclaw_reborn_cli/src/commands/service/launchd.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/service/launchd.rs
@@ -240,10 +240,19 @@ fn start_with_runner_impl(runner: &mut dyn ServiceCommandRunner, verbose: bool) 
     if !plist.exists() {
         bail!("Service not installed. Run `ironclaw-reborn service install` first.");
     }
-    runner.run_checked(
-        "launchctl load",
-        Command::new("launchctl").arg("load").arg("-w").arg(&plist),
-    )?;
+    // A bare `launchctl load -w` fails when the label is already loaded
+    // (loaded-but-stopped, i.e. a `-` PID) — the same condition `install`
+    // already reloads around. Query first and skip straight to `start`
+    // when the label is already registered with launchd; only a
+    // not-loaded label needs the `load` step.
+    let list =
+        runner.run_capture_checked("launchctl list", Command::new("launchctl").arg("list"))?;
+    if !service_loaded(&list) {
+        runner.run_checked(
+            "launchctl load",
+            Command::new("launchctl").arg("load").arg("-w").arg(&plist),
+        )?;
+    }
     runner.run_checked(
         "launchctl start",
         Command::new("launchctl").arg("start").arg(SERVICE_LABEL),
@@ -405,6 +414,19 @@ mod tests {
                     .eq(expected.iter().copied())
             }) {
                 anyhow::bail!("injected argv failure: {label}");
+            }
+            // Keep `launchctl_list` (read back by subsequent
+            // `run_capture_checked("launchctl list", ...)` calls) in sync
+            // with the label/unload/bootout operations this mock just
+            // recorded, so a test spanning multiple `launchctl list`
+            // queries (e.g. `restart` composing `stop` then `start`, both
+            // of which query the label's loaded state) observes the same
+            // state transitions the real `launchctl` daemon would report,
+            // instead of a stale snapshot from before this call.
+            match label {
+                "launchctl unload" | "launchctl bootout" => self.launchctl_list.clear(),
+                "launchctl load" => self.launchctl_list = format!("123\t0\t{SERVICE_LABEL}\n"),
+                _ => {}
             }
             Ok(())
         }
@@ -1051,6 +1073,73 @@ mod tests {
         );
     }
 
+    // ── start ───────────────────────────────────────────────────
+
+    #[test]
+    fn start_on_already_loaded_label_skips_bare_load_and_goes_straight_to_start() {
+        // RED-then-green: a bare `launchctl load -w` errors on an
+        // already-loaded label, while `install` over a loaded job
+        // literally tells the operator to run `service start` next. This
+        // pins that `start` queries `launchctl list` first and, when the
+        // label is already loaded, issues only `launchctl start` — no
+        // `load` call that would fail against launchd.
+        let _lock = crate::runtime::test_env::lock_runtime_env();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let prior = std::env::var_os("HOME");
+        // SAFETY: serialized by `lock_runtime_env`; restored below.
+        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let file = plist_path().expect("plist path");
+        std::fs::create_dir_all(file.parent().expect("plist parent")).expect("create parent");
+        std::fs::write(&file, "plist").expect("write plist");
+        let mut runner = RecordingRunner {
+            launchctl_list: format!("-\t0\t{SERVICE_LABEL}\n"),
+            ..RecordingRunner::default()
+        };
+        let result = start_with_runner(&mut runner);
+        // SAFETY: serialized by `lock_runtime_env`.
+        unsafe {
+            match prior {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+
+        result.expect("start on an already-loaded label must succeed");
+        assert_eq!(
+            runner.labels,
+            ["launchctl list", "launchctl start"],
+            "an already-loaded label must not be re-loaded with a bare `launchctl load`"
+        );
+    }
+
+    #[test]
+    fn start_on_not_loaded_label_loads_then_starts() {
+        let _lock = crate::runtime::test_env::lock_runtime_env();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let prior = std::env::var_os("HOME");
+        // SAFETY: serialized by `lock_runtime_env`; restored below.
+        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let file = plist_path().expect("plist path");
+        std::fs::create_dir_all(file.parent().expect("plist parent")).expect("create parent");
+        std::fs::write(&file, "plist").expect("write plist");
+        let mut runner = RecordingRunner::default();
+        let result = start_with_runner(&mut runner);
+        // SAFETY: serialized by `lock_runtime_env`.
+        unsafe {
+            match prior {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+
+        result.expect("start on a not-loaded label must succeed");
+        assert_eq!(
+            runner.labels,
+            ["launchctl list", "launchctl load", "launchctl start"],
+            "a not-loaded label must still be loaded before starting"
+        );
+    }
+
     // ── restart ─────────────────────────────────────────────────
 
     #[test]
@@ -1084,6 +1173,12 @@ mod tests {
                 "launchctl list",
                 "launchctl stop",
                 "launchctl unload",
+                // `start`'s own label-loaded check (the launchd
+                // start-on-loaded guard): by this point `stop` has
+                // unloaded the label, so this query correctly reports
+                // not-loaded and `start` proceeds to `load` + `start`
+                // rather than skipping straight to `start`.
+                "launchctl list",
                 "launchctl load",
                 "launchctl start",
             ]
@@ -1113,7 +1208,14 @@ mod tests {
         result.expect("restart of a stopped service must succeed without error");
         assert_eq!(
             runner.labels,
-            ["launchctl list", "launchctl load", "launchctl start"]
+            [
+                "launchctl list",
+                // `start`'s own label-loaded check — see the comment in
+                // `restart_running_service_stops_then_starts`.
+                "launchctl list",
+                "launchctl load",
+                "launchctl start",
+            ]
         );
     }
 
@@ -1156,6 +1258,9 @@ mod tests {
                 "launchctl list",
                 "launchctl stop",
                 "launchctl unload",
+                // `start`'s own label-loaded check — see the comment in
+                // `restart_running_service_stops_then_starts`.
+                "launchctl list",
                 "launchctl load",
                 "launchctl start",
             ],
@@ -1221,6 +1326,9 @@ mod tests {
                 "launchctl list",
                 "launchctl stop",
                 "launchctl unload",
+                // `start`'s own label-loaded check — see the comment in
+                // `restart_running_service_stops_then_starts`.
+                "launchctl list",
                 "launchctl load",
                 "launchctl start",
             ]

--- a/crates/ironclaw_reborn_cli/src/commands/service/launchd.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/service/launchd.rs
@@ -109,7 +109,7 @@ pub(super) fn install(context: &RebornCliContext, invocation: &ServeInvocation) 
     let stdout_log = logs_dir.join("serve.stdout.log");
     let stderr_log = logs_dir.join("serve.stderr.log");
     let plist = plist_content(invocation, &stdout_log, &stderr_log);
-    std::fs::write(&file, plist).with_context(|| format!("write {}", file.display()))?;
+    super::write_atomic(&file, plist.as_bytes())?;
     println!("Installed launchd service: {}", file.display());
     println!("  Start with: ironclaw-reborn service start");
     Ok(())
@@ -171,37 +171,25 @@ pub(super) fn restart() -> Result<()> {
     restart_with_runner(&mut OsServiceCommandRunner)
 }
 
-/// Composes [`stop_with_runner`] and [`start_with_runner`]: a running
-/// service is stopped then started, an already-stopped service is just
-/// started, and a start failure after a successful stop is reported as
-/// leaving the service stopped rather than a silent half-restart.
+/// Detects install/running state, then delegates the stop/start decision
+/// tree to [`super::restart_generic`], which both platforms share.
 fn restart_with_runner(runner: &mut dyn ServiceCommandRunner) -> Result<()> {
     let plist = plist_path()?;
-    if !plist.exists() {
-        bail!("Service not installed. Run `ironclaw-reborn service install` first.");
-    }
-    let list =
-        runner.run_capture_checked("launchctl list", Command::new("launchctl").arg("list"))?;
-    let was_running = service_running(&list);
-
-    if was_running {
-        stop_with_runner(runner)?;
-    }
-    if let Err(start_error) = start_with_runner(runner) {
-        if was_running {
-            bail!(
-                "service restart: stop succeeded but start failed; the service is now \
-                 STOPPED: {start_error:#}"
-            );
-        }
-        return Err(start_error);
-    }
-    if was_running {
-        println!("Service restarted");
+    let installed = plist.exists();
+    let was_running = if installed {
+        let list =
+            runner.run_capture_checked("launchctl list", Command::new("launchctl").arg("list"))?;
+        service_running(&list)
     } else {
-        println!("Service was not running; started");
-    }
-    Ok(())
+        false
+    };
+    super::restart_generic(
+        runner,
+        installed,
+        was_running,
+        stop_with_runner,
+        start_with_runner,
+    )
 }
 
 pub(super) fn status() -> Result<()> {
@@ -209,17 +197,17 @@ pub(super) fn status() -> Result<()> {
 }
 
 fn status_with_runner(runner: &mut dyn ServiceCommandRunner) -> Result<()> {
-    let out =
-        runner.run_capture_checked("launchctl list", Command::new("launchctl").arg("list"))?;
-    println!(
-        "Service: {}",
-        if service_running(&out) {
-            "running/loaded"
-        } else {
-            "not loaded"
-        }
-    );
-    println!("Unit: {}", plist_path()?.display());
+    let plist = plist_path()?;
+    let installed = plist.exists();
+    let running = if installed {
+        let out =
+            runner.run_capture_checked("launchctl list", Command::new("launchctl").arg("list"))?;
+        service_running(&out)
+    } else {
+        false
+    };
+    println!("Service: {}", super::status_label(installed, running));
+    println!("Unit: {}", plist.display());
     Ok(())
 }
 
@@ -629,9 +617,13 @@ mod tests {
     #[test]
     fn status_propagates_launchctl_list_failure() {
         let _lock = crate::runtime::test_env::lock_runtime_env();
+        let tmp = tempfile::tempdir().expect("tempdir");
         let prior = std::env::var_os("HOME");
         // SAFETY: serialized by `lock_runtime_env`; restored below.
-        unsafe { std::env::set_var("HOME", "/home/op") };
+        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let file = plist_path().expect("plist path");
+        std::fs::create_dir_all(file.parent().expect("plist parent")).expect("create parent");
+        std::fs::write(&file, "plist").expect("write plist");
         let mut runner = RecordingRunner {
             fail_capture_args: Some(vec!["list"]),
             ..RecordingRunner::default()
@@ -646,6 +638,30 @@ mod tests {
         }
 
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn status_reports_not_installed_and_skips_launchctl_query_when_plist_absent() {
+        let _lock = crate::runtime::test_env::lock_runtime_env();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let prior = std::env::var_os("HOME");
+        // SAFETY: serialized by `lock_runtime_env`; restored below.
+        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let mut runner = RecordingRunner::default();
+        let result = status_with_runner(&mut runner);
+        // SAFETY: serialized by `lock_runtime_env`.
+        unsafe {
+            match prior {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+
+        result.expect("status succeeds when not installed");
+        assert!(
+            runner.labels.is_empty(),
+            "must not query launchctl when the plist is absent"
+        );
     }
 
     // ── restart ─────────────────────────────────────────────────
@@ -781,9 +797,13 @@ mod tests {
     #[test]
     fn status_classifies_loaded_and_not_loaded_from_exact_list_command() {
         let _lock = crate::runtime::test_env::lock_runtime_env();
+        let tmp = tempfile::tempdir().expect("tempdir");
         let prior = std::env::var_os("HOME");
         // SAFETY: serialized by `lock_runtime_env`; restored below.
-        unsafe { std::env::set_var("HOME", "/home/op") };
+        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let file = plist_path().expect("plist path");
+        std::fs::create_dir_all(file.parent().expect("plist parent")).expect("create parent");
+        std::fs::write(&file, "plist").expect("write plist");
         for output in [
             format!("123\t0\t{SERVICE_LABEL}\n"),
             "123\t0\tcom.apple.other\n".to_string(),

--- a/crates/ironclaw_reborn_cli/src/commands/service/launchd.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/service/launchd.rs
@@ -9,7 +9,7 @@ use anyhow::{Context, Result, bail};
 use crate::context::RebornCliContext;
 use crate::serve_invocation::ServeInvocation;
 
-use super::{OsServiceCommandRunner, SERVICE_LABEL, ServiceCommandRunner, home_dir};
+use super::{SERVICE_LABEL, ServiceCommandRunner, home_dir};
 
 // ── Escaping ────────────────────────────────────────────────────
 
@@ -223,11 +223,7 @@ pub(super) fn install_with_runner(
     Ok(replaced_existing)
 }
 
-pub(super) fn start() -> Result<()> {
-    start_with_runner(&mut OsServiceCommandRunner)
-}
-
-fn start_with_runner(runner: &mut dyn ServiceCommandRunner) -> Result<()> {
+pub(super) fn start_with_runner(runner: &mut dyn ServiceCommandRunner) -> Result<()> {
     let plist = plist_path()?;
     if !plist.exists() {
         bail!("Service not installed. Run `ironclaw-reborn service install` first.");
@@ -244,11 +240,7 @@ fn start_with_runner(runner: &mut dyn ServiceCommandRunner) -> Result<()> {
     Ok(())
 }
 
-pub(super) fn stop() -> Result<()> {
-    stop_with_runner(&mut OsServiceCommandRunner)
-}
-
-fn stop_with_runner(runner: &mut dyn ServiceCommandRunner) -> Result<()> {
+pub(super) fn stop_with_runner(runner: &mut dyn ServiceCommandRunner) -> Result<()> {
     let plist = plist_path()?;
     if !plist.exists() {
         println!("Service stopped");
@@ -275,13 +267,9 @@ fn stop_with_runner(runner: &mut dyn ServiceCommandRunner) -> Result<()> {
     Ok(())
 }
 
-pub(super) fn restart() -> Result<()> {
-    restart_with_runner(&mut OsServiceCommandRunner)
-}
-
 /// Detects install/running state, then delegates the stop/start decision
 /// tree to [`super::restart_generic`], which both platforms share.
-fn restart_with_runner(runner: &mut dyn ServiceCommandRunner) -> Result<()> {
+pub(super) fn restart_with_runner(runner: &mut dyn ServiceCommandRunner) -> Result<()> {
     let plist = plist_path()?;
     let installed = plist.exists();
     let was_running = if installed {
@@ -300,11 +288,7 @@ fn restart_with_runner(runner: &mut dyn ServiceCommandRunner) -> Result<()> {
     )
 }
 
-pub(super) fn status() -> Result<()> {
-    status_with_runner(&mut OsServiceCommandRunner)
-}
-
-fn status_with_runner(runner: &mut dyn ServiceCommandRunner) -> Result<()> {
+pub(super) fn status_with_runner(runner: &mut dyn ServiceCommandRunner) -> Result<()> {
     let plist = plist_path()?;
     let file_exists = plist.exists();
     // Query launchctl unconditionally — a plist that was removed
@@ -317,10 +301,6 @@ fn status_with_runner(runner: &mut dyn ServiceCommandRunner) -> Result<()> {
     println!("Service: {}", super::status_label(installed, running));
     println!("Unit: {}", plist.display());
     Ok(())
-}
-
-pub(super) fn uninstall() -> Result<()> {
-    uninstall_with_runner(&mut OsServiceCommandRunner)
 }
 
 pub(super) fn uninstall_with_runner(runner: &mut dyn ServiceCommandRunner) -> Result<()> {

--- a/crates/ironclaw_reborn_cli/src/commands/service/launchd.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/service/launchd.rs
@@ -1,0 +1,639 @@
+//! macOS launchd generators, path resolution, status matching, and verb
+//! bodies for `ironclaw-reborn service`.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{Context, Result, bail};
+
+use crate::context::RebornCliContext;
+use crate::serve_invocation::ServeInvocation;
+
+use super::{OsServiceCommandRunner, SERVICE_LABEL, ServiceCommandRunner, home_dir};
+
+// ── Escaping ────────────────────────────────────────────────────
+
+/// XML-escape a value for embedding in a `.plist` `<string>` element.
+fn xml_escape(raw: &str) -> String {
+    raw.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&apos;")
+}
+
+// ── Plist generation ────────────────────────────────────────────
+
+fn plist_content(invocation: &ServeInvocation, stdout_log: &Path, stderr_log: &Path) -> String {
+    let program_arguments: String = std::iter::once(invocation.exe.display().to_string())
+        .chain(invocation.args.iter().cloned())
+        .map(|value| format!("    <string>{}</string>", xml_escape(&value)))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let environment_variables: String = invocation
+        .env
+        .iter()
+        .map(|(key, value)| {
+            format!(
+                "    <key>{}</key>\n    <string>{}</string>",
+                xml_escape(key),
+                xml_escape(value)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>{label}</string>
+  <key>ProgramArguments</key>
+  <array>
+{program_arguments}
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>EnvironmentVariables</key>
+  <dict>
+{environment_variables}
+  </dict>
+  <key>StandardOutPath</key>
+  <string>{stdout}</string>
+  <key>StandardErrorPath</key>
+  <string>{stderr}</string>
+</dict>
+</plist>
+"#,
+        label = SERVICE_LABEL,
+        stdout = xml_escape(&stdout_log.display().to_string()),
+        stderr = xml_escape(&stderr_log.display().to_string()),
+    )
+}
+
+// ── Path helpers ────────────────────────────────────────────────
+
+fn plist_path() -> Result<PathBuf> {
+    Ok(home_dir()?
+        .join("Library")
+        .join("LaunchAgents")
+        .join(format!("{SERVICE_LABEL}.plist")))
+}
+
+// ── Status matching ─────────────────────────────────────────────
+
+fn service_running(launchctl_list_output: &str) -> bool {
+    launchctl_list_output.lines().any(|line| {
+        let mut fields = line.split_whitespace();
+        fields.next().is_some()
+            && fields.next().is_some()
+            && fields.next() == Some(SERVICE_LABEL)
+            && fields.next().is_none()
+    })
+}
+
+// ── Verb bodies ─────────────────────────────────────────────────
+
+pub(super) fn install(context: &RebornCliContext, invocation: &ServeInvocation) -> Result<()> {
+    let file = plist_path()?;
+    if let Some(parent) = file.parent() {
+        std::fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
+    }
+    let logs_dir = context.boot_config().home().path().join("logs");
+    std::fs::create_dir_all(&logs_dir).with_context(|| format!("create {}", logs_dir.display()))?;
+    let stdout_log = logs_dir.join("serve.stdout.log");
+    let stderr_log = logs_dir.join("serve.stderr.log");
+    let plist = plist_content(invocation, &stdout_log, &stderr_log);
+    std::fs::write(&file, plist).with_context(|| format!("write {}", file.display()))?;
+    println!("Installed launchd service: {}", file.display());
+    println!("  Start with: ironclaw-reborn service start");
+    Ok(())
+}
+
+pub(super) fn start() -> Result<()> {
+    start_with_runner(&mut OsServiceCommandRunner)
+}
+
+fn start_with_runner(runner: &mut dyn ServiceCommandRunner) -> Result<()> {
+    let plist = plist_path()?;
+    if !plist.exists() {
+        bail!("Service not installed. Run `ironclaw-reborn service install` first.");
+    }
+    runner.run_checked(
+        "launchctl load",
+        Command::new("launchctl").arg("load").arg("-w").arg(&plist),
+    )?;
+    runner.run_checked(
+        "launchctl start",
+        Command::new("launchctl").arg("start").arg(SERVICE_LABEL),
+    )?;
+    println!("Service started");
+    Ok(())
+}
+
+pub(super) fn stop() -> Result<()> {
+    stop_with_runner(&mut OsServiceCommandRunner)
+}
+
+fn stop_with_runner(runner: &mut dyn ServiceCommandRunner) -> Result<()> {
+    let plist = plist_path()?;
+    if !plist.exists() {
+        println!("Service stopped");
+        return Ok(());
+    }
+    let list =
+        runner.run_capture_checked("launchctl list", Command::new("launchctl").arg("list"))?;
+    if !service_running(&list) {
+        println!("Service stopped");
+        return Ok(());
+    }
+    runner.run_checked(
+        "launchctl stop",
+        Command::new("launchctl").arg("stop").arg(SERVICE_LABEL),
+    )?;
+    runner.run_checked(
+        "launchctl unload",
+        Command::new("launchctl")
+            .arg("unload")
+            .arg("-w")
+            .arg(&plist),
+    )?;
+    println!("Service stopped");
+    Ok(())
+}
+
+pub(super) fn status() -> Result<()> {
+    status_with_runner(&mut OsServiceCommandRunner)
+}
+
+fn status_with_runner(runner: &mut dyn ServiceCommandRunner) -> Result<()> {
+    let out =
+        runner.run_capture_checked("launchctl list", Command::new("launchctl").arg("list"))?;
+    println!(
+        "Service: {}",
+        if service_running(&out) {
+            "running/loaded"
+        } else {
+            "not loaded"
+        }
+    );
+    println!("Unit: {}", plist_path()?.display());
+    Ok(())
+}
+
+pub(super) fn uninstall() -> Result<()> {
+    uninstall_with_runner(&mut OsServiceCommandRunner)
+}
+
+pub(super) fn uninstall_with_runner(runner: &mut dyn ServiceCommandRunner) -> Result<()> {
+    let file = plist_path()?;
+    let list =
+        runner.run_capture_checked("launchctl list", Command::new("launchctl").arg("list"))?;
+    if service_running(&list) {
+        // `stop` alone is insufficient for a KeepAlive agent: launchd
+        // immediately restarts it. Target the registered label so a loaded
+        // job left behind by an older broken uninstall can still be removed
+        // even when its plist path is already absent.
+        runner.run_checked(
+            "launchctl stop",
+            Command::new("launchctl").arg("stop").arg(SERVICE_LABEL),
+        )?;
+        let uid = runner
+            .run_capture_checked("id -u", Command::new("id").arg("-u"))?
+            .trim()
+            .parse::<u32>()
+            .context("parse numeric uid from `id -u`")?;
+        runner.run_checked(
+            "launchctl bootout",
+            Command::new("launchctl")
+                .arg("bootout")
+                .arg(format!("gui/{uid}/{SERVICE_LABEL}")),
+        )?;
+    }
+    if file.exists() {
+        std::fs::remove_file(&file).with_context(|| format!("remove {}", file.display()))?;
+    }
+    println!("Service uninstalled ({})", file.display());
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Default)]
+    struct RecordingRunner {
+        labels: Vec<String>,
+        args: Vec<Vec<String>>,
+        launchctl_list: String,
+        fail_args: Option<Vec<&'static str>>,
+        fail_capture_args: Option<Vec<&'static str>>,
+    }
+
+    impl ServiceCommandRunner for RecordingRunner {
+        fn run_checked(&mut self, label: &str, command: &mut Command) -> Result<()> {
+            self.labels.push(label.to_string());
+            self.args.push(
+                command
+                    .get_args()
+                    .map(|arg| arg.to_string_lossy().into_owned())
+                    .collect(),
+            );
+            if self.fail_args.as_ref().is_some_and(|expected| {
+                command
+                    .get_args()
+                    .map(|arg| arg.to_string_lossy())
+                    .eq(expected.iter().copied())
+            }) {
+                anyhow::bail!("injected argv failure: {label}");
+            }
+            Ok(())
+        }
+
+        fn run_capture_checked(&mut self, label: &str, command: &mut Command) -> Result<String> {
+            self.labels.push(label.to_string());
+            self.args.push(
+                command
+                    .get_args()
+                    .map(|arg| arg.to_string_lossy().into_owned())
+                    .collect(),
+            );
+            if self.fail_capture_args.as_ref().is_some_and(|expected| {
+                command
+                    .get_args()
+                    .map(|arg| arg.to_string_lossy())
+                    .eq(expected.iter().copied())
+            }) {
+                anyhow::bail!("injected argv capture failure: {label}");
+            }
+            let program = command.get_program().to_string_lossy();
+            let args = self.args.last().cloned().unwrap_or_default();
+            match (program.as_ref(), args.as_slice()) {
+                ("launchctl", [arg]) if arg == "list" => Ok(self.launchctl_list.clone()),
+                ("id", [arg]) if arg == "-u" => Ok("501\n".to_string()),
+                _ => anyhow::bail!("unexpected capture argv: {program} {args:?}"),
+            }
+        }
+    }
+
+    fn sample_invocation() -> ServeInvocation {
+        ServeInvocation {
+            exe: PathBuf::from("/usr/local/bin/ironclaw-reborn"),
+            args: vec!["serve".to_string()],
+            env: vec![(
+                "IRONCLAW_REBORN_HOME".to_string(),
+                "/home/op/.ironclaw/reborn".to_string(),
+            )],
+        }
+    }
+
+    #[test]
+    fn xml_escape_handles_reserved_chars() {
+        let escaped = xml_escape("<&>\"' and text");
+        assert_eq!(escaped, "&lt;&amp;&gt;&quot;&apos; and text");
+    }
+
+    #[test]
+    fn xml_escape_passes_through_plain_text() {
+        assert_eq!(xml_escape("hello world"), "hello world");
+    }
+
+    #[test]
+    fn plist_content_includes_label() {
+        let plist = plist_content(
+            &sample_invocation(),
+            Path::new("/home/op/.ironclaw/reborn/logs/serve.stdout.log"),
+            Path::new("/home/op/.ironclaw/reborn/logs/serve.stderr.log"),
+        );
+        assert!(plist.contains("<key>Label</key>"));
+        assert!(plist.contains(SERVICE_LABEL));
+    }
+
+    #[test]
+    fn plist_content_includes_program_arguments() {
+        let plist = plist_content(
+            &sample_invocation(),
+            Path::new("/tmp/o.log"),
+            Path::new("/tmp/e.log"),
+        );
+        assert!(plist.contains("<string>/usr/local/bin/ironclaw-reborn</string>"));
+        assert!(plist.contains("<string>serve</string>"));
+    }
+
+    #[test]
+    fn plist_content_includes_environment_variables() {
+        let plist = plist_content(
+            &sample_invocation(),
+            Path::new("/tmp/o.log"),
+            Path::new("/tmp/e.log"),
+        );
+        assert!(plist.contains("<key>IRONCLAW_REBORN_HOME</key>"));
+        assert!(plist.contains("<string>/home/op/.ironclaw/reborn</string>"));
+    }
+
+    #[test]
+    fn plist_content_marks_run_at_load_and_keep_alive_true() {
+        let plist = plist_content(
+            &sample_invocation(),
+            Path::new("/tmp/o.log"),
+            Path::new("/tmp/e.log"),
+        );
+        assert!(plist.contains("<key>RunAtLoad</key>"));
+        assert!(plist.contains("<key>KeepAlive</key>"));
+        // Two `<true/>` markers: one for RunAtLoad, one for KeepAlive.
+        assert_eq!(plist.matches("<true/>").count(), 2);
+    }
+
+    #[test]
+    fn plist_content_includes_stdout_and_stderr_log_paths() {
+        let plist = plist_content(
+            &sample_invocation(),
+            Path::new("/home/op/.ironclaw/reborn/logs/serve.stdout.log"),
+            Path::new("/home/op/.ironclaw/reborn/logs/serve.stderr.log"),
+        );
+        assert!(plist.contains("<string>/home/op/.ironclaw/reborn/logs/serve.stdout.log</string>"));
+        assert!(plist.contains("<string>/home/op/.ironclaw/reborn/logs/serve.stderr.log</string>"));
+    }
+
+    #[test]
+    fn plist_content_escapes_xml_reserved_chars_in_env_value() {
+        let invocation = ServeInvocation {
+            exe: PathBuf::from("/usr/local/bin/ironclaw-reborn"),
+            args: vec!["serve".to_string()],
+            env: vec![(
+                "IRONCLAW_REBORN_PROFILE".to_string(),
+                "a&b<c>d\"e'f".to_string(),
+            )],
+        };
+        let plist = plist_content(
+            &invocation,
+            Path::new("/tmp/o.log"),
+            Path::new("/tmp/e.log"),
+        );
+        assert!(plist.contains("a&amp;b&lt;c&gt;d&quot;e&apos;f"));
+        assert!(!plist.contains("a&b<c>d\"e'f"));
+    }
+
+    #[test]
+    fn plist_path_ends_with_expected_suffix() {
+        let _lock = crate::runtime::test_env::lock_runtime_env();
+        let prior = std::env::var_os("HOME");
+        // SAFETY: serialized by `lock_runtime_env`; restored before returning.
+        unsafe { std::env::set_var("HOME", "/home/op") };
+        let path = plist_path();
+        // SAFETY: see above.
+        unsafe {
+            match prior {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+        assert_eq!(
+            path.expect("must resolve"),
+            PathBuf::from("/home/op/Library/LaunchAgents/com.ironclaw.reborn.daemon.plist")
+        );
+    }
+
+    #[test]
+    fn service_running_matches_only_the_label_line() {
+        let output = "-\t0\tcom.apple.something\n123\t0\tcom.ironclaw.reborn.daemon\n";
+        assert!(service_running(output));
+    }
+
+    #[test]
+    fn service_running_false_when_label_absent() {
+        let output = "com.apple.something\t0\t0\n";
+        assert!(!service_running(output));
+        assert!(!service_running(&format!(
+            "123\t0\t{SERVICE_LABEL}.helper\n"
+        )));
+    }
+
+    #[test]
+    fn uninstall_boots_out_loaded_keepalive_job_before_removing_plist() {
+        let _lock = crate::runtime::test_env::lock_runtime_env();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let prior = std::env::var_os("HOME");
+        // SAFETY: serialized by `lock_runtime_env`; restored below.
+        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let file = plist_path().expect("plist path");
+        std::fs::create_dir_all(file.parent().expect("plist parent")).expect("create parent");
+        std::fs::write(&file, "plist").expect("write plist");
+        let mut runner = RecordingRunner {
+            launchctl_list: format!("-\t0\t{SERVICE_LABEL}\n"),
+            ..RecordingRunner::default()
+        };
+        let result = uninstall_with_runner(&mut runner);
+        // SAFETY: serialized by `lock_runtime_env`.
+        unsafe {
+            match prior {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+
+        result.expect("uninstall succeeds");
+        assert!(!file.exists());
+        assert_eq!(
+            runner.labels,
+            [
+                "launchctl list",
+                "launchctl stop",
+                "id -u",
+                "launchctl bootout"
+            ]
+        );
+        assert_eq!(runner.args[1], ["stop", SERVICE_LABEL]);
+        assert_eq!(runner.args[2], ["-u"]);
+        assert_eq!(
+            runner.args[3],
+            [
+                "bootout".to_string(),
+                "gui/501/com.ironclaw.reborn.daemon".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn uninstall_bootout_failure_preserves_plist() {
+        let _lock = crate::runtime::test_env::lock_runtime_env();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let prior = std::env::var_os("HOME");
+        // SAFETY: serialized by `lock_runtime_env`; restored below.
+        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let file = plist_path().expect("plist path");
+        std::fs::create_dir_all(file.parent().expect("plist parent")).expect("create parent");
+        std::fs::write(&file, "plist").expect("write plist");
+        let mut runner = RecordingRunner {
+            launchctl_list: format!("123\t0\t{SERVICE_LABEL}\n"),
+            fail_args: Some(vec!["bootout", "gui/501/com.ironclaw.reborn.daemon"]),
+            ..RecordingRunner::default()
+        };
+        let result = uninstall_with_runner(&mut runner);
+        // SAFETY: serialized by `lock_runtime_env`.
+        unsafe {
+            match prior {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+
+        assert!(result.is_err());
+        assert!(file.exists(), "failed bootout must not remove the plist");
+    }
+
+    #[test]
+    fn uninstall_is_idempotent_when_plist_is_absent() {
+        let _lock = crate::runtime::test_env::lock_runtime_env();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let prior = std::env::var_os("HOME");
+        // SAFETY: serialized by `lock_runtime_env`; restored below.
+        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let mut runner = RecordingRunner::default();
+        let result = uninstall_with_runner(&mut runner);
+        // SAFETY: serialized by `lock_runtime_env`.
+        unsafe {
+            match prior {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+
+        result.expect("repeated uninstall succeeds");
+        assert_eq!(runner.labels, ["launchctl list"]);
+    }
+
+    #[test]
+    fn uninstall_boots_out_loaded_label_when_plist_is_absent() {
+        let _lock = crate::runtime::test_env::lock_runtime_env();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let prior = std::env::var_os("HOME");
+        // SAFETY: serialized by `lock_runtime_env`; restored below.
+        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let mut runner = RecordingRunner {
+            launchctl_list: format!("123\t0\t{SERVICE_LABEL}\n"),
+            ..RecordingRunner::default()
+        };
+        let result = uninstall_with_runner(&mut runner);
+        // SAFETY: serialized by `lock_runtime_env`.
+        unsafe {
+            match prior {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+
+        result.expect("loaded orphan uninstall succeeds");
+        assert_eq!(
+            runner.args,
+            [
+                vec!["list"],
+                vec!["stop", SERVICE_LABEL],
+                vec!["-u"],
+                vec!["bootout", "gui/501/com.ironclaw.reborn.daemon"]
+            ]
+        );
+    }
+
+    #[test]
+    fn uninstall_preserves_plist_when_launchctl_list_fails() {
+        let _lock = crate::runtime::test_env::lock_runtime_env();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let prior = std::env::var_os("HOME");
+        // SAFETY: serialized by `lock_runtime_env`; restored below.
+        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let file = plist_path().expect("plist path");
+        std::fs::create_dir_all(file.parent().expect("plist parent")).expect("create parent");
+        std::fs::write(&file, "plist").expect("write plist");
+        let mut runner = RecordingRunner {
+            fail_capture_args: Some(vec!["list"]),
+            ..RecordingRunner::default()
+        };
+        let result = uninstall_with_runner(&mut runner);
+        // SAFETY: serialized by `lock_runtime_env`.
+        unsafe {
+            match prior {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+
+        assert!(result.is_err());
+        assert!(file.exists(), "failed list must not delete the plist");
+        assert_eq!(runner.labels, ["launchctl list"]);
+    }
+
+    #[test]
+    fn stop_is_idempotent_when_plist_is_absent() {
+        let _lock = crate::runtime::test_env::lock_runtime_env();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let prior = std::env::var_os("HOME");
+        // SAFETY: serialized by `lock_runtime_env`; restored below.
+        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let mut runner = RecordingRunner::default();
+        let result = stop_with_runner(&mut runner);
+        // SAFETY: serialized by `lock_runtime_env`.
+        unsafe {
+            match prior {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+
+        result.expect("absent stop succeeds");
+        assert!(runner.labels.is_empty());
+    }
+
+    #[test]
+    fn status_propagates_launchctl_list_failure() {
+        let _lock = crate::runtime::test_env::lock_runtime_env();
+        let prior = std::env::var_os("HOME");
+        // SAFETY: serialized by `lock_runtime_env`; restored below.
+        unsafe { std::env::set_var("HOME", "/home/op") };
+        let mut runner = RecordingRunner {
+            fail_capture_args: Some(vec!["list"]),
+            ..RecordingRunner::default()
+        };
+        let result = status_with_runner(&mut runner);
+        // SAFETY: serialized by `lock_runtime_env`.
+        unsafe {
+            match prior {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn status_classifies_loaded_and_not_loaded_from_exact_list_command() {
+        let _lock = crate::runtime::test_env::lock_runtime_env();
+        let prior = std::env::var_os("HOME");
+        // SAFETY: serialized by `lock_runtime_env`; restored below.
+        unsafe { std::env::set_var("HOME", "/home/op") };
+        for output in [
+            format!("123\t0\t{SERVICE_LABEL}\n"),
+            "123\t0\tcom.apple.other\n".to_string(),
+        ] {
+            let mut runner = RecordingRunner {
+                launchctl_list: output,
+                ..RecordingRunner::default()
+            };
+            status_with_runner(&mut runner).expect("status succeeds");
+            assert_eq!(runner.args, [vec!["list"]]);
+        }
+        // SAFETY: serialized by `lock_runtime_env`.
+        unsafe {
+            match prior {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+    }
+}

--- a/crates/ironclaw_reborn_cli/src/commands/service/launchd.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/service/launchd.rs
@@ -274,12 +274,16 @@ fn stop_with_runner_impl(runner: &mut dyn ServiceCommandRunner, verbose: bool) -
     }
     let list =
         runner.run_capture_checked("launchctl list", Command::new("launchctl").arg("list"))?;
-    if !service_running(&list) {
+    if !service_loaded(&list) {
         if verbose {
             println!("Service stopped");
         }
         return Ok(());
     }
+    // A loaded job — running or not (a `-` PID) — stays registered with
+    // launchd for respawn until unloaded; gating on `service_running` alone
+    // (the finding-1 bug, already fixed for `status`/`uninstall`) left a
+    // loaded-but-stopped KeepAlive job undisturbed.
     runner.run_checked(
         "launchctl stop",
         Command::new("launchctl").arg("stop").arg(SERVICE_LABEL),
@@ -299,20 +303,27 @@ fn stop_with_runner_impl(runner: &mut dyn ServiceCommandRunner, verbose: bool) -
 
 /// Detects install/running state, then delegates the stop/start decision
 /// tree to [`super::restart_generic`], which both platforms share.
+///
+/// Passes `service_loaded` (not `service_running`) as the "was active"
+/// flag: a loaded-but-not-running (`-` PID) job must go through the same
+/// stop-then-start reload as a running one, since launchd errors on a bare
+/// `launchctl load` of an already-loaded label. `service_running` implies
+/// `service_loaded`, so this subsumes the previously-running case without
+/// changing its behavior.
 pub(super) fn restart_with_runner(runner: &mut dyn ServiceCommandRunner) -> Result<()> {
     let plist = plist_path()?;
     let installed = plist.exists();
-    let was_running = if installed {
+    let was_active = if installed {
         let list =
             runner.run_capture_checked("launchctl list", Command::new("launchctl").arg("list"))?;
-        service_running(&list)
+        service_loaded(&list)
     } else {
         false
     };
     super::restart_generic(
         runner,
         installed,
-        was_running,
+        was_active,
         stop_with_runner_quiet,
         start_with_runner_quiet,
     )
@@ -901,6 +912,43 @@ mod tests {
     }
 
     #[test]
+    fn stop_unloads_loaded_job_with_dash_pid() {
+        // Mirrors the finding-1 gap already fixed for `status`/`uninstall`:
+        // a KeepAlive job with a `-` PID is loaded-but-not-running, and
+        // stays registered for respawn until unloaded. The old
+        // `stop_with_runner_impl` gated on `service_running` alone, so it
+        // read this state as "already stopped" and returned early without
+        // ever unloading the job.
+        let _lock = crate::runtime::test_env::lock_runtime_env();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let prior = std::env::var_os("HOME");
+        // SAFETY: serialized by `lock_runtime_env`; restored below.
+        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let file = plist_path().expect("plist path");
+        std::fs::create_dir_all(file.parent().expect("plist parent")).expect("create parent");
+        std::fs::write(&file, "plist").expect("write plist");
+        let mut runner = RecordingRunner {
+            launchctl_list: format!("-\t0\t{SERVICE_LABEL}\n"),
+            ..RecordingRunner::default()
+        };
+        let result = stop_with_runner(&mut runner);
+        // SAFETY: serialized by `lock_runtime_env`.
+        unsafe {
+            match prior {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+
+        result.expect("stop of a loaded-not-running job succeeds");
+        assert_eq!(
+            runner.labels,
+            ["launchctl list", "launchctl stop", "launchctl unload"],
+            "a loaded-but-not-running job must still be stopped/unloaded, not treated as already stopped"
+        );
+    }
+
+    #[test]
     fn stop_is_idempotent_when_plist_is_absent() {
         let _lock = crate::runtime::test_env::lock_runtime_env();
         let tmp = tempfile::tempdir().expect("tempdir");
@@ -1066,6 +1114,52 @@ mod tests {
         assert_eq!(
             runner.labels,
             ["launchctl list", "launchctl load", "launchctl start"]
+        );
+    }
+
+    #[test]
+    fn restart_loaded_not_running_reloads_instead_of_bare_load() {
+        // Mirrors the finding-1 gap fixed above for `stop`: a KeepAlive job
+        // with a `-` PID is loaded but not running. The old
+        // `restart_with_runner` derived `was_running` from `service_running`
+        // alone, so this state skipped the stop step entirely and issued a
+        // bare `launchctl load` on a label that's already loaded (which
+        // launchd errors on). It must instead go through the same
+        // stop-then-start reload sequence as the running case, so the
+        // already-loaded label is unloaded before it's reloaded.
+        let _lock = crate::runtime::test_env::lock_runtime_env();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let prior = std::env::var_os("HOME");
+        // SAFETY: serialized by `lock_runtime_env`; restored below.
+        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let file = plist_path().expect("plist path");
+        std::fs::create_dir_all(file.parent().expect("plist parent")).expect("create parent");
+        std::fs::write(&file, "plist").expect("write plist");
+        let mut runner = RecordingRunner {
+            launchctl_list: format!("-\t0\t{SERVICE_LABEL}\n"),
+            ..RecordingRunner::default()
+        };
+        let result = restart_with_runner(&mut runner);
+        // SAFETY: serialized by `lock_runtime_env`.
+        unsafe {
+            match prior {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+
+        result.expect("restart of a loaded-not-running job must succeed");
+        assert_eq!(
+            runner.labels,
+            [
+                "launchctl list",
+                "launchctl list",
+                "launchctl stop",
+                "launchctl unload",
+                "launchctl load",
+                "launchctl start",
+            ],
+            "a loaded-but-not-running label must be unloaded before reload, not bare-loaded"
         );
     }
 

--- a/crates/ironclaw_reborn_cli/src/commands/service/launchd.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/service/launchd.rs
@@ -87,29 +87,115 @@ fn plist_path() -> Result<PathBuf> {
 
 // ── Status matching ─────────────────────────────────────────────
 
-fn service_running(launchctl_list_output: &str) -> bool {
-    launchctl_list_output.lines().any(|line| {
-        let mut fields = line.split_whitespace();
-        fields.next().is_some()
-            && fields.next().is_some()
-            && fields.next() == Some(SERVICE_LABEL)
-            && fields.next().is_none()
+/// The three states `launchctl list` can report for a given label, read
+/// from its three whitespace-separated columns (PID, last-exit-status,
+/// label). Mirrors `launchd_status_from_line` in
+/// `ironclaw_reborn_composition::observability::operator_service_lifecycle`
+/// (copied shape, not imported — that module is a different crate and
+/// this one intentionally does not depend on it for a few lines of
+/// parsing).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LaunchdStatus {
+    Running,
+    Stopped,
+    Failed,
+}
+
+/// Parse one `launchctl list` line into `(status, label)`. The PID
+/// column is `-` when the job is loaded but not currently running (the
+/// bug this fixes: the old `service_running` treated any 3-field line —
+/// including a `-` PID — as running). A numeric PID means running; a
+/// non-numeric PID with a nonzero last-exit-status means the job died
+/// and hasn't been respawned yet (`Failed`); anything else is `Stopped`.
+fn launchd_status_from_line(line: &str) -> Option<(LaunchdStatus, &str)> {
+    let mut columns = line.split_whitespace();
+    let pid = columns.next()?;
+    let exit_status = columns.next()?;
+    let label = columns.next()?;
+    let status = if pid.parse::<i32>().is_ok() {
+        LaunchdStatus::Running
+    } else if exit_status.parse::<i32>().is_ok_and(|status| status != 0) {
+        LaunchdStatus::Failed
+    } else {
+        LaunchdStatus::Stopped
+    };
+    Some((status, label))
+}
+
+/// The status of our label's line in `launchctl list`, if it appears at
+/// all (i.e. the job is currently loaded, running or not).
+fn find_label_status(launchctl_list_output: &str) -> Option<LaunchdStatus> {
+    launchctl_list_output.lines().find_map(|line| {
+        launchd_status_from_line(line)
+            .and_then(|(status, label)| (label == SERVICE_LABEL).then_some(status))
     })
+}
+
+fn service_running(launchctl_list_output: &str) -> bool {
+    find_label_status(launchctl_list_output) == Some(LaunchdStatus::Running)
+}
+
+/// Whether the label is registered with launchd at all, regardless of
+/// whether it currently has a live PID. Used where a loaded-but-stopped
+/// job still needs to be torn down / reloaded (uninstall, reinstall) —
+/// unlike `service_running`, which only asks "does it have a PID right
+/// now" (used for the user-facing running/stopped status line).
+fn service_loaded(launchctl_list_output: &str) -> bool {
+    find_label_status(launchctl_list_output).is_some()
+}
+
+/// Whether `service status` should report the service as installed:
+/// either the plist file exists, or launchd still has the label loaded
+/// (an orphan left behind after the plist was removed out-of-band).
+fn resolve_installed(file_exists: bool, loaded: bool) -> bool {
+    file_exists || loaded
 }
 
 // ── Verb bodies ─────────────────────────────────────────────────
 
 pub(super) fn install(context: &RebornCliContext, invocation: &ServeInvocation) -> Result<()> {
+    install_with_runner(context, invocation, &mut OsServiceCommandRunner)
+}
+
+fn install_with_runner(
+    context: &RebornCliContext,
+    invocation: &ServeInvocation,
+    runner: &mut dyn ServiceCommandRunner,
+) -> Result<()> {
     let file = plist_path()?;
     if let Some(parent) = file.parent() {
         std::fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
     }
     let logs_dir = context.boot_config().home().path().join("logs");
     std::fs::create_dir_all(&logs_dir).with_context(|| format!("create {}", logs_dir.display()))?;
+    // Unrotated: launchd appends to these paths forever across restarts.
+    // This module wires no rotation (e.g. `newsyslog`) — operators must
+    // add it externally if long-running installs need it.
     let stdout_log = logs_dir.join("serve.stdout.log");
     let stderr_log = logs_dir.join("serve.stderr.log");
+    let list =
+        runner.run_capture_checked("launchctl list", Command::new("launchctl").arg("list"))?;
+    let was_loaded = service_loaded(&list);
     let plist = plist_content(invocation, &stdout_log, &stderr_log);
     super::write_atomic(&file, plist.as_bytes())?;
+    if was_loaded {
+        // A loaded job keeps running off its in-memory definition until
+        // reloaded; overwriting the plist file alone does not make it
+        // pick up the new ProgramArguments/EnvironmentVariables. Force a
+        // reload with the same legacy verbs `start`/`stop` already use.
+        runner.run_checked(
+            "launchctl unload",
+            Command::new("launchctl").arg("unload").arg("-w").arg(&file),
+        )?;
+        runner.run_checked(
+            "launchctl load",
+            Command::new("launchctl").arg("load").arg("-w").arg(&file),
+        )?;
+        runner.run_checked(
+            "launchctl start",
+            Command::new("launchctl").arg("start").arg(SERVICE_LABEL),
+        )?;
+    }
     println!("Installed launchd service: {}", file.display());
     println!("  Start with: ironclaw-reborn service start");
     Ok(())
@@ -198,14 +284,14 @@ pub(super) fn status() -> Result<()> {
 
 fn status_with_runner(runner: &mut dyn ServiceCommandRunner) -> Result<()> {
     let plist = plist_path()?;
-    let installed = plist.exists();
-    let running = if installed {
-        let out =
-            runner.run_capture_checked("launchctl list", Command::new("launchctl").arg("list"))?;
-        service_running(&out)
-    } else {
-        false
-    };
+    let file_exists = plist.exists();
+    // Query launchctl unconditionally — a plist that was removed
+    // out-of-band while the job is still loaded is an orphan we must
+    // still report as installed, not silently claim "not installed".
+    let list =
+        runner.run_capture_checked("launchctl list", Command::new("launchctl").arg("list"))?;
+    let running = service_running(&list);
+    let installed = resolve_installed(file_exists, service_loaded(&list));
     println!("Service: {}", super::status_label(installed, running));
     println!("Unit: {}", plist.display());
     Ok(())
@@ -219,7 +305,7 @@ pub(super) fn uninstall_with_runner(runner: &mut dyn ServiceCommandRunner) -> Re
     let file = plist_path()?;
     let list =
         runner.run_capture_checked("launchctl list", Command::new("launchctl").arg("list"))?;
-    if service_running(&list) {
+    if service_loaded(&list) {
         // `stop` alone is insufficient for a KeepAlive agent: launchd
         // immediately restarts it. Target the registered label so a loaded
         // job left behind by an older broken uninstall can still be removed
@@ -315,6 +401,66 @@ mod tests {
                 "/home/op/.ironclaw/reborn".to_string(),
             )],
         }
+    }
+
+    #[test]
+    fn install_reloads_when_label_is_already_loaded() {
+        let _lock = crate::runtime::test_env::lock_runtime_env();
+        let home_tmp = tempfile::tempdir().expect("tempdir");
+        let prior = std::env::var_os("HOME");
+        // SAFETY: serialized by `lock_runtime_env`; restored below.
+        unsafe { std::env::set_var("HOME", home_tmp.path()) };
+        let (_ctx_tmp, context) = RebornCliContext::test_context();
+        let mut runner = RecordingRunner {
+            launchctl_list: format!("123\t0\t{SERVICE_LABEL}\n"),
+            ..RecordingRunner::default()
+        };
+        let result = install_with_runner(&context, &sample_invocation(), &mut runner);
+        // SAFETY: serialized by `lock_runtime_env`.
+        unsafe {
+            match prior {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+
+        result.expect("install must succeed");
+        assert_eq!(
+            runner.labels,
+            [
+                "launchctl list",
+                "launchctl unload",
+                "launchctl load",
+                "launchctl start",
+            ],
+            "an already-loaded job must be reloaded so it picks up the new plist"
+        );
+    }
+
+    #[test]
+    fn install_skips_reload_when_label_is_not_loaded() {
+        let _lock = crate::runtime::test_env::lock_runtime_env();
+        let home_tmp = tempfile::tempdir().expect("tempdir");
+        let prior = std::env::var_os("HOME");
+        // SAFETY: serialized by `lock_runtime_env`; restored below.
+        unsafe { std::env::set_var("HOME", home_tmp.path()) };
+        let (_ctx_tmp, context) = RebornCliContext::test_context();
+        let mut runner = RecordingRunner::default();
+        let result = install_with_runner(&context, &sample_invocation(), &mut runner);
+        // SAFETY: serialized by `lock_runtime_env`.
+        unsafe {
+            match prior {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+
+        result.expect("install must succeed");
+        assert_eq!(
+            runner.labels,
+            ["launchctl list"],
+            "a fresh (not-loaded) install must not issue a reload sequence"
+        );
     }
 
     #[test]
@@ -641,7 +787,13 @@ mod tests {
     }
 
     #[test]
-    fn status_reports_not_installed_and_skips_launchctl_query_when_plist_absent() {
+    fn status_queries_launchctl_unconditionally_and_reports_not_installed_when_absent_everywhere() {
+        // Was: "skips launchctl query when plist absent". That skip was
+        // itself the orphan-hiding bug (finding 5) — a plist removed
+        // out-of-band while still loaded in launchd would silently read
+        // as "not installed". The query must always run so an orphan can
+        // be detected; only report "not installed" when the file AND the
+        // manager both show nothing.
         let _lock = crate::runtime::test_env::lock_runtime_env();
         let tmp = tempfile::tempdir().expect("tempdir");
         let prior = std::env::var_os("HOME");
@@ -658,9 +810,35 @@ mod tests {
         }
 
         result.expect("status succeeds when not installed");
+        assert_eq!(
+            runner.labels,
+            ["launchctl list"],
+            "must query launchctl even when the plist is absent, to detect orphans"
+        );
+    }
+
+    #[test]
+    fn resolve_installed_true_when_file_absent_but_manager_still_shows_it_loaded() {
+        assert!(!resolve_installed(false, false));
+        assert!(resolve_installed(false, true), "orphaned unit still loaded");
+        assert!(resolve_installed(true, false));
+        assert!(resolve_installed(true, true));
+    }
+
+    #[test]
+    fn service_running_false_when_loaded_but_stopped_with_dash_pid() {
+        // The finding-1 bug: `launchctl list` reports `-` in the PID
+        // column for a job that is loaded but not currently running. The
+        // old `service_running` only checked that 3 fields were present,
+        // so it misread this as running.
+        let output = format!("-\t0\t{SERVICE_LABEL}\n");
         assert!(
-            runner.labels.is_empty(),
-            "must not query launchctl when the plist is absent"
+            !service_running(&output),
+            "dash PID must not read as running"
+        );
+        assert!(
+            service_loaded(&output),
+            "the label is still registered with launchd even though stopped"
         );
     }
 

--- a/crates/ironclaw_reborn_cli/src/commands/service/launchd.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/service/launchd.rs
@@ -151,17 +151,26 @@ fn resolve_installed(file_exists: bool, loaded: bool) -> bool {
     file_exists || loaded
 }
 
-// ── Verb bodies ─────────────────────────────────────────────────
-
-pub(super) fn install(context: &RebornCliContext, invocation: &ServeInvocation) -> Result<()> {
-    install_with_runner(context, invocation, &mut OsServiceCommandRunner).map(|_replaced| ())
+/// Gate for the shared "keeps the OLD definition" advisory, launchd side.
+/// The unload/load/start reload `install_with_runner` runs when the label
+/// was already loaded makes the new definition live immediately, so the
+/// note (which claims a running process is still on the old definition)
+/// would be false in that case — suppress it. When the label was NOT
+/// loaded no reload ran, so a replaced file leaves the advisory accurate.
+fn launchd_install_advisory(replaced_existing: bool, was_loaded: bool) -> Option<&'static str> {
+    super::replaced_existing_service_file_note(replaced_existing && !was_loaded)
 }
+
+// ── Verb bodies ─────────────────────────────────────────────────
 
 /// Returns whether a pre-existing plist file at the target path was
 /// replaced by this install (captured before the write). Exposed for
-/// tests; production wraps this via [`install`], which discards the
-/// bool once the advisory line has been printed.
-fn install_with_runner(
+/// tests, and for `super::ServicePlatform::install_with_runner` (the
+/// runner-injectable install path driven by the `service install`
+/// preflight-warning integration test); production wraps this via
+/// [`install`], which discards the bool once the advisory line has been
+/// printed.
+pub(super) fn install_with_runner(
     context: &RebornCliContext,
     invocation: &ServeInvocation,
     runner: &mut dyn ServiceCommandRunner,
@@ -207,7 +216,7 @@ fn install_with_runner(
         )?;
     }
     println!("Installed launchd service: {}", file.display());
-    if let Some(note) = super::replaced_existing_service_file_note(replaced_existing) {
+    if let Some(note) = launchd_install_advisory(replaced_existing, was_loaded) {
         println!("{note}");
     }
     println!("  Start with: ironclaw-reborn service start");
@@ -437,7 +446,7 @@ mod tests {
             }
         }
 
-        result.expect("install must succeed");
+        let replaced = result.expect("install must succeed");
         assert_eq!(
             runner.labels,
             [
@@ -447,6 +456,79 @@ mod tests {
                 "launchctl start",
             ],
             "an already-loaded job must be reloaded so it picks up the new plist"
+        );
+        // The unload/load/start sequence above already makes the new
+        // definition live, so the "keeps the OLD definition until
+        // restart" advisory would be false here and must not print —
+        // even though this is a fresh install with no prior plist file
+        // (`replaced_existing` is false regardless).
+        assert!(
+            !replaced,
+            "a fresh install (no prior plist) must not report a replacement"
+        );
+    }
+
+    #[test]
+    fn install_suppresses_stale_definition_note_when_reload_already_happened() {
+        // Pins the launchd advisory fix: replacing an existing plist while
+        // the label is already loaded triggers the unload/load/start
+        // reload above, so the running process picks up the new
+        // definition immediately. The "keeps the OLD definition until
+        // `service restart`" note would be false in that case and must
+        // not print. `install_with_runner` only returns `replaced_existing`
+        // (not `was_loaded`), so this pins the actual gate
+        // `launchd_install_advisory` applies, driven by the same
+        // `replaced_existing = true` this scenario produces.
+        let _lock = crate::runtime::test_env::lock_runtime_env();
+        let home_tmp = tempfile::tempdir().expect("tempdir");
+        let prior = std::env::var_os("HOME");
+        // SAFETY: serialized by `lock_runtime_env`; restored below.
+        unsafe { std::env::set_var("HOME", home_tmp.path()) };
+        let (_ctx_tmp, context) = RebornCliContext::test_context();
+        let file = plist_path().expect("plist path");
+        std::fs::create_dir_all(file.parent().expect("plist parent")).expect("create parent");
+        std::fs::write(&file, "pre-existing plist").expect("write pre-existing plist");
+        let mut runner = RecordingRunner {
+            launchctl_list: format!("123\t0\t{SERVICE_LABEL}\n"),
+            ..RecordingRunner::default()
+        };
+        let result = install_with_runner(&context, &sample_invocation(), &mut runner);
+        // SAFETY: serialized by `lock_runtime_env`.
+        unsafe {
+            match prior {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+
+        let replaced = result.expect("install over a loaded label must succeed");
+        assert!(
+            replaced,
+            "a pre-existing plist was in fact replaced on disk"
+        );
+        assert!(
+            launchd_install_advisory(replaced, /* was_loaded */ true).is_none(),
+            "the note must be suppressed once the label was already loaded and reloaded in place"
+        );
+    }
+
+    #[test]
+    fn launchd_install_advisory_prints_only_when_replaced_and_not_reloaded() {
+        assert!(
+            launchd_install_advisory(true, false).is_some(),
+            "a replaced file with no in-place reload must keep the stale-definition advisory"
+        );
+        assert!(
+            launchd_install_advisory(true, true).is_none(),
+            "a replaced file that was reloaded in place must not claim a stale definition"
+        );
+        assert!(
+            launchd_install_advisory(false, false).is_none(),
+            "a fresh install has nothing to advise"
+        );
+        assert!(
+            launchd_install_advisory(false, true).is_none(),
+            "a fresh install has nothing to advise even if the label was already loaded"
         );
     }
 

--- a/crates/ironclaw_reborn_cli/src/commands/service/launchd.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/service/launchd.rs
@@ -154,14 +154,18 @@ fn resolve_installed(file_exists: bool, loaded: bool) -> bool {
 // ── Verb bodies ─────────────────────────────────────────────────
 
 pub(super) fn install(context: &RebornCliContext, invocation: &ServeInvocation) -> Result<()> {
-    install_with_runner(context, invocation, &mut OsServiceCommandRunner)
+    install_with_runner(context, invocation, &mut OsServiceCommandRunner).map(|_replaced| ())
 }
 
+/// Returns whether a pre-existing plist file at the target path was
+/// replaced by this install (captured before the write). Exposed for
+/// tests; production wraps this via [`install`], which discards the
+/// bool once the advisory line has been printed.
 fn install_with_runner(
     context: &RebornCliContext,
     invocation: &ServeInvocation,
     runner: &mut dyn ServiceCommandRunner,
-) -> Result<()> {
+) -> Result<bool> {
     let file = plist_path()?;
     if let Some(parent) = file.parent() {
         std::fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
@@ -176,6 +180,12 @@ fn install_with_runner(
     let list =
         runner.run_capture_checked("launchctl list", Command::new("launchctl").arg("list"))?;
     let was_loaded = service_loaded(&list);
+    // Captured before the write: a pre-existing file at this path may
+    // have been installed by this CLI's own prior run, or by the WebUI
+    // operator facade (`RebornLocalServiceLifecycle`) — both surfaces
+    // target the same label/path by design (see the module doc). Either
+    // way the write below atomically replaces it.
+    let replaced_existing = file.exists();
     let plist = plist_content(invocation, &stdout_log, &stderr_log);
     super::write_atomic(&file, plist.as_bytes())?;
     if was_loaded {
@@ -197,8 +207,11 @@ fn install_with_runner(
         )?;
     }
     println!("Installed launchd service: {}", file.display());
+    if let Some(note) = super::replaced_existing_service_file_note(replaced_existing) {
+        println!("{note}");
+    }
     println!("  Start with: ironclaw-reborn service start");
-    Ok(())
+    Ok(replaced_existing)
 }
 
 pub(super) fn start() -> Result<()> {
@@ -455,11 +468,67 @@ mod tests {
             }
         }
 
-        result.expect("install must succeed");
+        let replaced = result.expect("install must succeed");
         assert_eq!(
             runner.labels,
             ["launchctl list"],
             "a fresh (not-loaded) install must not issue a reload sequence"
+        );
+        assert!(
+            !replaced,
+            "a fresh install (no prior plist) must not report a replacement"
+        );
+        assert!(
+            super::super::replaced_existing_service_file_note(replaced).is_none(),
+            "fresh install must not carry a replaced-file advisory"
+        );
+    }
+
+    #[test]
+    fn install_reports_replaced_existing_when_plist_already_present() {
+        // Covers the shared-identity collision case (design doc: "adopt
+        // identity"): a plist at this path may have been written by a
+        // prior CLI install, or by the WebUI operator facade
+        // (`RebornLocalServiceLifecycle`) — both target the same label/
+        // path. Either way, `install` must report the replacement so the
+        // operator knows a currently-running service (if any) keeps the
+        // OLD definition until `service restart`.
+        let _lock = crate::runtime::test_env::lock_runtime_env();
+        let home_tmp = tempfile::tempdir().expect("tempdir");
+        let prior = std::env::var_os("HOME");
+        // SAFETY: serialized by `lock_runtime_env`; restored below.
+        unsafe { std::env::set_var("HOME", home_tmp.path()) };
+        let (_ctx_tmp, context) = RebornCliContext::test_context();
+        let file = plist_path().expect("plist path");
+        std::fs::create_dir_all(file.parent().expect("plist parent")).expect("create parent");
+        // Simulate a pre-existing unit — e.g. one written by the WebUI
+        // operator facade with a baked-in secret — that this install
+        // must atomically overwrite.
+        std::fs::write(&file, "pre-existing plist with a baked-in secret")
+            .expect("write pre-existing plist");
+        let mut runner = RecordingRunner::default();
+        let result = install_with_runner(&context, &sample_invocation(), &mut runner);
+        // SAFETY: serialized by `lock_runtime_env`.
+        unsafe {
+            match prior {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+
+        let replaced = result.expect("install over an existing plist must succeed");
+        assert!(
+            replaced,
+            "install must report that a pre-existing plist was replaced"
+        );
+        let note = super::super::replaced_existing_service_file_note(replaced)
+            .expect("a replaced install must carry an advisory line");
+        assert!(note.contains("Replaced an existing service definition"));
+        assert!(note.contains("service restart"));
+        let contents = std::fs::read_to_string(&file).expect("read plist after install");
+        assert!(
+            !contents.contains("baked-in secret"),
+            "the pre-existing file's contents must be fully replaced"
         );
     }
 
@@ -566,13 +635,13 @@ mod tests {
         }
         assert_eq!(
             path.expect("must resolve"),
-            PathBuf::from("/home/op/Library/LaunchAgents/com.ironclaw.reborn.daemon.plist")
+            PathBuf::from("/home/op/Library/LaunchAgents/com.ironclaw.reborn.plist")
         );
     }
 
     #[test]
     fn service_running_matches_only_the_label_line() {
-        let output = "-\t0\tcom.apple.something\n123\t0\tcom.ironclaw.reborn.daemon\n";
+        let output = "-\t0\tcom.apple.something\n123\t0\tcom.ironclaw.reborn\n";
         assert!(service_running(output));
     }
 
@@ -625,7 +694,7 @@ mod tests {
             runner.args[3],
             [
                 "bootout".to_string(),
-                "gui/501/com.ironclaw.reborn.daemon".to_string()
+                "gui/501/com.ironclaw.reborn".to_string()
             ]
         );
     }
@@ -642,7 +711,7 @@ mod tests {
         std::fs::write(&file, "plist").expect("write plist");
         let mut runner = RecordingRunner {
             launchctl_list: format!("123\t0\t{SERVICE_LABEL}\n"),
-            fail_args: Some(vec!["bootout", "gui/501/com.ironclaw.reborn.daemon"]),
+            fail_args: Some(vec!["bootout", "gui/501/com.ironclaw.reborn"]),
             ..RecordingRunner::default()
         };
         let result = uninstall_with_runner(&mut runner);
@@ -706,7 +775,7 @@ mod tests {
                 vec!["list"],
                 vec!["stop", SERVICE_LABEL],
                 vec!["-u"],
-                vec!["bootout", "gui/501/com.ironclaw.reborn.daemon"]
+                vec!["bootout", "gui/501/com.ironclaw.reborn"]
             ]
         );
     }

--- a/crates/ironclaw_reborn_cli/src/commands/service/mod.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/service/mod.rs
@@ -100,7 +100,7 @@ impl ServiceCommand {
     pub(crate) fn execute(self, context: RebornCliContext) -> Result<()> {
         let platform = ServicePlatform::detect()?;
         match self.command {
-            ServiceVerb::Install => platform.install(&context),
+            ServiceVerb::Install => platform.install(&context).map(|_warnings| ()),
             ServiceVerb::Start => platform.start(),
             ServiceVerb::Stop => platform.stop(),
             ServiceVerb::Restart => platform.restart(),
@@ -132,15 +132,38 @@ impl ServicePlatform {
         }
     }
 
-    fn install(&self, context: &RebornCliContext) -> Result<()> {
-        for warning in preflight_warnings(context) {
+    /// Production install path: real `launchctl`/`systemctl` commands via
+    /// [`OsServiceCommandRunner`].
+    fn install(&self, context: &RebornCliContext) -> Result<Vec<String>> {
+        self.install_with_runner(context, &mut OsServiceCommandRunner)
+    }
+
+    /// Runner-injectable install path shared by production (via
+    /// [`Self::install`]) and the `service install` preflight-warning
+    /// integration test: computes and prints the same non-fatal
+    /// readiness warnings [`Self::install`] always has, then dispatches
+    /// to the platform-specific install with the given
+    /// [`ServiceCommandRunner`]. Returns the printed warnings (not just
+    /// `()`) so a test can assert on their content without reaching for
+    /// `preflight_warnings` directly — driving the assertion through the
+    /// same call site `service install` actually uses.
+    fn install_with_runner(
+        &self,
+        context: &RebornCliContext,
+        runner: &mut dyn ServiceCommandRunner,
+    ) -> Result<Vec<String>> {
+        let warnings = preflight_warnings(context)?;
+        for warning in &warnings {
             eprintln!("warning: {warning}");
         }
         let invocation = serve_invocation()?;
         match self {
-            Self::MacOs => launchd::install(context, &invocation),
-            Self::Linux => systemd::install(&invocation),
+            Self::MacOs => {
+                launchd::install_with_runner(context, &invocation, runner).map(|_replaced| ())?
+            }
+            Self::Linux => systemd::install_with_runner(&invocation, runner).map(|_replaced| ())?,
         }
+        Ok(warnings)
     }
 
     fn start(&self) -> Result<()> {
@@ -203,7 +226,13 @@ fn home_dir() -> Result<PathBuf> {
 /// WebUI token until `ironclaw-reborn onboard` runs. Checks the
 /// onboarding marker, `config.toml`, and the WebUI token file's entropy
 /// floor.
-fn preflight_warnings(context: &RebornCliContext) -> Vec<String> {
+///
+/// Fallible: a real I/O error reading the token file (unreadable,
+/// symlinked, oversized — see `webui_token::webui_token_file_is_valid`)
+/// is a genuine problem distinct from "token absent/too short" and must
+/// surface as an `install` error rather than being folded into the same
+/// generic warning text.
+fn preflight_warnings(context: &RebornCliContext) -> Result<Vec<String>> {
     let home = context.boot_config().home();
     let mut warnings = Vec::new();
 
@@ -224,7 +253,7 @@ fn preflight_warnings(context: &RebornCliContext) -> Vec<String> {
         ));
     }
 
-    if !crate::webui_token::webui_token_file_is_valid(home.path()) {
+    if !crate::webui_token::webui_token_file_is_valid(home.path())? {
         warnings.push(format!(
             "WebUI token not found or too short at {} — run `ironclaw-reborn onboard` first so \
              `serve` has a valid WebUI bearer token",
@@ -232,7 +261,7 @@ fn preflight_warnings(context: &RebornCliContext) -> Vec<String> {
         ));
     }
 
-    warnings
+    Ok(warnings)
 }
 
 // ── Restart decision tree ───────────────────────────────────────
@@ -298,15 +327,25 @@ fn status_label(installed: bool, running: bool) -> &'static str {
 // ── Install advisory ────────────────────────────────────────────
 
 /// Advisory line printed after `service install` when a pre-existing
-/// unit/plist file at the target path was replaced by this install —
-/// `None` when the install wrote a fresh file, nothing to advise. Shared
-/// by both platforms so the wording (and the "must `service restart`"
-/// guidance) can't drift between them. Covers both a prior install by
-/// this same CLI and one by the WebUI operator facade
-/// (`RebornLocalServiceLifecycle`, see the module doc): either way the
-/// write already happened atomically by the time this is read; a
-/// currently-running service process keeps running off the old
-/// definition until restarted.
+/// unit/plist file at the target path was replaced by this install, and
+/// a currently-running service process still keeps running off the OLD
+/// definition until `service restart` — `None` when there is nothing to
+/// advise. Shared by both platforms so the wording (and the "must
+/// `service restart`" guidance) can't drift between them. Covers both a
+/// prior install by this same CLI and one by the WebUI operator facade
+/// (`RebornLocalServiceLifecycle`, see the module doc).
+///
+/// Callers decide whether the "keeps the OLD definition" claim is true
+/// for their platform and pass that pre-resolved bool in: systemd never
+/// reloads a running unit as part of `install` (`daemon-reload` alone
+/// does not restart the service), so a replaced unit always leaves a
+/// running process on the old definition and `systemd::install_with_runner`
+/// passes `replaced_existing` through unchanged. launchd's `install`
+/// forces an unload/load/start reload when the label was already loaded
+/// (see `launchd::install_with_runner`), which makes the new definition
+/// live immediately — so `launchd::install_with_runner` passes
+/// `replaced_existing && !was_loaded`, suppressing the note exactly when
+/// it would be false.
 fn replaced_existing_service_file_note(replaced_existing: bool) -> Option<&'static str> {
     replaced_existing.then_some(
         "  Replaced an existing service definition at this path; if the service is currently \
@@ -429,6 +468,19 @@ mod tests {
             match label {
                 "launchctl list" => Ok(String::new()),
                 "id -u" => Ok("501\n".to_string()),
+                // `install_with_runner` (both platforms) now queries unit
+                // state before writing the unit/plist file (see
+                // `systemd::query_unit_state`). The strict `Key=Value`
+                // parser errors on a blank/malformed response rather than
+                // silently defaulting to "not loaded" (a malformed
+                // response must never read as `enabled=false`, which
+                // would make an install-failure rollback skip re-enabling
+                // a unit that actually was enabled) — so this mock must
+                // return well-formed output, mirroring the dedicated
+                // systemd tests' `unit_state_output` pattern.
+                "systemctl show unit state" => {
+                    Ok("LoadState=loaded\nUnitFileState=enabled\n".to_string())
+                }
                 _ => Ok(String::new()),
             }
         }
@@ -467,17 +519,63 @@ mod tests {
         )
         .expect("write webui token");
 
-        assert!(preflight_warnings(&context).is_empty());
+        assert!(
+            preflight_warnings(&context)
+                .expect("preflight_warnings must succeed")
+                .is_empty()
+        );
     }
 
     #[test]
     fn preflight_warnings_flags_missing_marker_config_and_webui_token() {
         let (_tmp, context) = RebornCliContext::test_context();
-        let warnings = preflight_warnings(&context);
+        let warnings =
+            preflight_warnings(&context).expect("preflight_warnings must succeed when absent");
         assert_eq!(warnings.len(), 3);
         assert!(warnings[0].contains("onboarding marker not found"));
         assert!(warnings[1].contains("config.toml not found"));
         assert!(warnings[2].contains("WebUI token not found or too short"));
+    }
+
+    #[test]
+    fn install_with_runner_surfaces_missing_webui_token_warning_through_the_real_path() {
+        // Per the repo's "test through the caller" rule: a unit test on
+        // `preflight_warnings` alone doesn't prove `service install`
+        // actually calls it with the right inputs and doesn't swallow
+        // the result. Drive `ServicePlatform::install_with_runner` (the
+        // same call `install()`/`ServiceCommand::execute` use) with a
+        // fake runner, marker + config present, and the WebUI token
+        // absent, and assert the token warning comes back from the real
+        // path.
+        let _lock = crate::runtime::test_env::lock_runtime_env();
+        let home_tmp = tempfile::tempdir().expect("tempdir");
+        let _home = TempHomeGuard::set(home_tmp.path());
+        let (_ctx_tmp, context) = RebornCliContext::test_context();
+        let reborn_home = context.boot_config().home();
+        std::fs::create_dir_all(reborn_home.path()).expect("create reborn home");
+        std::fs::write(
+            crate::commands::onboard::onboarding_marker_path(reborn_home),
+            "{}",
+        )
+        .expect("write marker");
+        std::fs::write(reborn_home.config_file_path(), "").expect("write config");
+        // WebUI token deliberately absent.
+
+        let platform = ServicePlatform::detect().expect("detect must resolve on macOS/Linux");
+        let mut runner = SuccessfulServiceCommandRunner;
+        let warnings = platform
+            .install_with_runner(&context, &mut runner)
+            .expect("install must succeed even with the token warning outstanding");
+
+        assert_eq!(
+            warnings.len(),
+            1,
+            "marker and config are present; only the token warning should fire: {warnings:?}"
+        );
+        assert!(
+            warnings[0].contains("WebUI token not found or too short"),
+            "warnings: {warnings:?}"
+        );
     }
 
     #[cfg(unix)]

--- a/crates/ironclaw_reborn_cli/src/commands/service/mod.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/service/mod.rs
@@ -46,6 +46,12 @@ pub(crate) struct ServiceCommand {
 #[derive(Debug, Subcommand)]
 enum ServiceVerb {
     /// Install the OS service (launchd on macOS, systemd on Linux).
+    ///
+    /// On macOS, stdout/stderr are captured to
+    /// `<reborn_home>/logs/serve.std{out,err}.log`. These files are
+    /// never rotated by this tool — set up external rotation (e.g.
+    /// `newsyslog`) if a long-running install needs it. On Linux, output
+    /// goes to the systemd user journal, which the OS already rotates.
     Install,
     /// Start the installed service.
     Start,
@@ -163,8 +169,10 @@ fn home_dir() -> Result<PathBuf> {
 
 /// Non-fatal readiness warnings for `service install`: warn, don't
 /// fail, when onboarding hasn't run yet — the service can still be
-/// installed, but `serve` starts without config/providers/token until
-/// `ironclaw-reborn onboard` runs.
+/// installed, but `serve` starts without config, providers, or a valid
+/// WebUI token until `ironclaw-reborn onboard` runs. Checks the
+/// onboarding marker, `config.toml`, and the WebUI token file's entropy
+/// floor.
 fn preflight_warnings(context: &RebornCliContext) -> Vec<String> {
     let home = context.boot_config().home();
     let mut warnings = Vec::new();
@@ -183,6 +191,14 @@ fn preflight_warnings(context: &RebornCliContext) -> Vec<String> {
         warnings.push(format!(
             "config.toml not found at {} — `serve` will run with compiled-in defaults only",
             config.display()
+        ));
+    }
+
+    if !crate::webui_token::webui_token_file_is_valid(home.path()) {
+        warnings.push(format!(
+            "WebUI token not found or too short at {} — run `ironclaw-reborn onboard` first so \
+             `serve` has a valid WebUI bearer token",
+            crate::webui_token::webui_token_file_path(home.path()).display()
         ));
     }
 
@@ -270,6 +286,15 @@ fn write_atomic(path: &Path, contents: &[u8]) -> Result<()> {
         let temp = parent.join(format!(".{file_name}.tmp-{}-{suffix}", std::process::id()));
         let mut options = std::fs::OpenOptions::new();
         options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            // Service definition files can carry operator env values
+            // (`ServeInvocation::env`); keep them unreadable to other
+            // local users from the moment they're created, same as
+            // `operator_service_lifecycle::write_service_file`.
+            options.mode(0o600);
+        }
         let mut file = match options.open(&temp) {
             Ok(file) => file,
             Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
@@ -380,24 +405,45 @@ mod tests {
     }
 
     #[test]
-    fn preflight_warnings_empty_when_marker_and_config_present() {
+    fn preflight_warnings_empty_when_marker_config_and_token_present() {
         let (_tmp, context) = RebornCliContext::test_context();
         let home = context.boot_config().home();
         std::fs::create_dir_all(home.path()).expect("create home");
         std::fs::write(crate::commands::onboard::onboarding_marker_path(home), "{}")
             .expect("write marker");
         std::fs::write(home.config_file_path(), "").expect("write config");
+        std::fs::write(
+            crate::webui_token::webui_token_file_path(home.path()),
+            "0".repeat(crate::webui_token::WEBUI_TOKEN_MIN_BYTES),
+        )
+        .expect("write webui token");
 
         assert!(preflight_warnings(&context).is_empty());
     }
 
     #[test]
-    fn preflight_warnings_flags_missing_marker_and_config() {
+    fn preflight_warnings_flags_missing_marker_config_and_webui_token() {
         let (_tmp, context) = RebornCliContext::test_context();
         let warnings = preflight_warnings(&context);
-        assert_eq!(warnings.len(), 2);
+        assert_eq!(warnings.len(), 3);
         assert!(warnings[0].contains("onboarding marker not found"));
         assert!(warnings[1].contains("config.toml not found"));
+        assert!(warnings[2].contains("WebUI token not found or too short"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_atomic_creates_file_with_0600_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("service-file");
+        write_atomic(&path, b"contents").expect("write succeeds");
+        let mode = std::fs::metadata(&path)
+            .expect("stat service file")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600, "service file must be 0600, got {mode:o}");
     }
 
     #[test]

--- a/crates/ironclaw_reborn_cli/src/commands/service/mod.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/service/mod.rs
@@ -725,27 +725,36 @@ mod tests {
     // ── Command-level file lifecycle (temp-$HOME) ──────────────────
 
     /// RAII guard pointing the OS home (`$HOME`, read by `home_dir()`)
-    /// at a tempdir, and clearing IRONCLAW_REBORN_HOME so the derived
+    /// at a tempdir, clearing IRONCLAW_REBORN_HOME so the derived
     /// Reborn home nests under the same tempdir (RebornHome falls back
-    /// to `$HOME/.ironclaw/reborn` when unset). Restores both on drop.
-    /// Caller must hold `lock_runtime_env()`.
+    /// to `$HOME/.ironclaw/reborn` when unset), and clearing
+    /// `$XDG_CONFIG_HOME` so `systemd::unit_path()` resolves under the
+    /// tempdir too instead of a real XDG path that may already exist on
+    /// the host (CI runners have been observed setting
+    /// `XDG_CONFIG_HOME=$HOME/.config`, which `config_home()` correctly
+    /// prefers over `$HOME`). Restores all three on drop. Caller must
+    /// hold `lock_runtime_env()`.
     struct TempHomeGuard {
         prior_home: Option<std::ffi::OsString>,
         prior_reborn_home: Option<std::ffi::OsString>,
+        prior_xdg: Option<std::ffi::OsString>,
     }
 
     impl TempHomeGuard {
         fn set(tmp: &std::path::Path) -> Self {
             let prior_home = std::env::var_os("HOME");
             let prior_reborn_home = std::env::var_os("IRONCLAW_REBORN_HOME");
+            let prior_xdg = std::env::var_os("XDG_CONFIG_HOME");
             // SAFETY: caller holds `lock_runtime_env()` for this guard's lifetime.
             unsafe {
                 std::env::set_var("HOME", tmp);
                 std::env::remove_var("IRONCLAW_REBORN_HOME");
+                std::env::remove_var("XDG_CONFIG_HOME");
             }
             Self {
                 prior_home,
                 prior_reborn_home,
+                prior_xdg,
             }
         }
     }
@@ -761,6 +770,10 @@ mod tests {
                 match self.prior_reborn_home.take() {
                     Some(v) => std::env::set_var("IRONCLAW_REBORN_HOME", v),
                     None => std::env::remove_var("IRONCLAW_REBORN_HOME"),
+                }
+                match self.prior_xdg.take() {
+                    Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
+                    None => std::env::remove_var("XDG_CONFIG_HOME"),
                 }
             }
         }

--- a/crates/ironclaw_reborn_cli/src/commands/service/mod.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/service/mod.rs
@@ -49,6 +49,9 @@ enum ServiceVerb {
     Start,
     /// Stop the running service.
     Stop,
+    /// Restart the service: stop then start if running, or just start if
+    /// stopped. Errors if the service is not installed.
+    Restart,
     /// Show service status.
     Status,
     /// Uninstall the OS service and remove the unit file.
@@ -62,6 +65,7 @@ impl ServiceCommand {
             ServiceVerb::Install => platform.install(&context),
             ServiceVerb::Start => platform.start(),
             ServiceVerb::Stop => platform.stop(),
+            ServiceVerb::Restart => platform.restart(),
             ServiceVerb::Status => platform.status(),
             ServiceVerb::Uninstall => platform.uninstall(),
         }
@@ -112,6 +116,13 @@ impl ServicePlatform {
         match self {
             Self::MacOs => launchd::stop(),
             Self::Linux => systemd::stop(),
+        }
+    }
+
+    fn restart(&self) -> Result<()> {
+        match self {
+            Self::MacOs => launchd::restart(),
+            Self::Linux => systemd::restart(),
         }
     }
 

--- a/crates/ironclaw_reborn_cli/src/commands/service/mod.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/service/mod.rs
@@ -12,13 +12,15 @@
 //! shared or reused.
 //!
 //! Platform dispatch happens once, in [`ServicePlatform::detect`], called
-//! a single time from [`ServiceCommand::execute`]. The five verbs are
-//! methods on [`ServicePlatform`] that each `match self` to delegate
-//! into the OS-specific implementation (`launchd` or `systemd`), rather
-//! than every verb re-checking `cfg!(target_os)`.
+//! a single time from [`ServiceCommand::execute`]. Each verb is a method
+//! on [`ServicePlatform`] that `match self`es to delegate into the
+//! OS-specific implementation (`launchd` or `systemd`), rather than every
+//! verb re-checking `cfg!(target_os)`.
 
-use std::path::PathBuf;
+use std::io::Write;
+use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use anyhow::{Context, Result, bail};
 use clap::{Args, Subcommand};
@@ -187,6 +189,108 @@ fn preflight_warnings(context: &RebornCliContext) -> Vec<String> {
     warnings
 }
 
+// ── Restart decision tree ───────────────────────────────────────
+
+/// Shared restart decision tree for both platforms: a running service is
+/// stopped then started, an already-stopped-but-installed service is just
+/// started, and a start failure after a successful stop is reported as
+/// leaving the service stopped rather than a silent half-restart. Each
+/// platform does its own installed/running detection, then delegates here.
+///
+/// `stop`/`start` are function pointers, not closures — closures would
+/// each need to capture (and thus mutably borrow) `runner`, but `runner`
+/// is already borrowed by this function's own `&mut dyn` parameter, so two
+/// closures over it would double-mutably-borrow. Plain `fn` items sidestep
+/// that: they capture nothing and take `runner` as an explicit argument.
+fn restart_generic(
+    runner: &mut dyn ServiceCommandRunner,
+    installed: bool,
+    was_running: bool,
+    stop: fn(&mut dyn ServiceCommandRunner) -> Result<()>,
+    start: fn(&mut dyn ServiceCommandRunner) -> Result<()>,
+) -> Result<()> {
+    if !installed {
+        bail!("Service not installed. Run `ironclaw-reborn service install` first.");
+    }
+    if was_running {
+        stop(runner)?;
+    }
+    if let Err(start_error) = start(runner) {
+        if was_running {
+            bail!(
+                "service restart: stop succeeded but start failed; the service is now \
+                 STOPPED: {start_error:#}"
+            );
+        }
+        return Err(start_error);
+    }
+    println!(
+        "{}",
+        if was_running {
+            "Service restarted"
+        } else {
+            "Service was not running; started"
+        }
+    );
+    Ok(())
+}
+
+// ── Status vocabulary ───────────────────────────────────────────
+
+/// Normalized `service status` line, shared by both platforms so the
+/// running/stopped/not-installed vocabulary can't drift between them.
+fn status_label(installed: bool, running: bool) -> &'static str {
+    if !installed {
+        "not installed"
+    } else if running {
+        "running"
+    } else {
+        "stopped"
+    }
+}
+
+// ── Atomic file writes ──────────────────────────────────────────
+
+static TEMP_FILE_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// Write `contents` to `path` via create-temp-then-rename in the same
+/// directory, so a reader never observes a partially written file and a
+/// crash mid-write never corrupts the previous contents. Used by both
+/// platforms' install paths (the systemd unit file and the launchd plist).
+fn write_atomic(path: &Path, contents: &[u8]) -> Result<()> {
+    let parent = path
+        .parent()
+        .context("service file path has no parent directory")?;
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("service-file");
+    for _ in 0..16 {
+        let suffix = TEMP_FILE_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let temp = parent.join(format!(".{file_name}.tmp-{}-{suffix}", std::process::id()));
+        let mut options = std::fs::OpenOptions::new();
+        options.write(true).create_new(true);
+        let mut file = match options.open(&temp) {
+            Ok(file) => file,
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(error).with_context(|| format!("create {}", temp.display())),
+        };
+        let result = (|| -> Result<()> {
+            file.write_all(contents)
+                .with_context(|| format!("write {}", temp.display()))?;
+            file.sync_all()
+                .with_context(|| format!("sync {}", temp.display()))?;
+            std::fs::rename(&temp, path).with_context(|| format!("replace {}", path.display()))?;
+            Ok(())
+        })();
+        if result.is_err() {
+            let _ = std::fs::remove_file(&temp);
+        }
+        return result;
+    }
+    bail!("could not allocate temporary service file")
+}
+
 // ── Shell helpers ───────────────────────────────────────────────
 
 /// Run `command`, treating a non-zero exit as an error. `label` names
@@ -254,6 +358,14 @@ mod tests {
                 _ => Ok(String::new()),
             }
         }
+    }
+
+    #[test]
+    fn status_label_covers_running_stopped_and_not_installed() {
+        assert_eq!(status_label(false, false), "not installed");
+        assert_eq!(status_label(false, true), "not installed");
+        assert_eq!(status_label(true, false), "stopped");
+        assert_eq!(status_label(true, true), "running");
     }
 
     #[test]

--- a/crates/ironclaw_reborn_cli/src/commands/service/mod.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/service/mod.rs
@@ -2,7 +2,7 @@
 //! binary as an OS-native service.
 //!
 //! - **macOS**: launchd user agent at
-//!   `~/Library/LaunchAgents/com.ironclaw.reborn.daemon.plist`.
+//!   `~/Library/LaunchAgents/com.ironclaw.reborn.plist`.
 //! - **Linux**: systemd user unit at
 //!   `~/.config/systemd/user/ironclaw-reborn.service`.
 //!
@@ -16,6 +16,28 @@
 //! on [`ServicePlatform`] that `match self`es to delegate into the
 //! OS-specific implementation (`launchd` or `systemd`), rather than every
 //! verb re-checking `cfg!(target_os)`.
+//!
+//! ## Canonical service identity, shared with the WebUI operator facade
+//!
+//! [`SERVICE_LABEL`] and [`SYSTEMD_UNIT`] name the **one** OS service
+//! identity for the standalone Reborn binary. Two surfaces install and
+//! manage it today: this CLI (`ironclaw-reborn service install`), and the
+//! WebUI operator facade (`RebornLocalServiceLifecycle` in
+//! `ironclaw_reborn_composition::observability::operator_service_lifecycle`,
+//! behind `POST /api/webchat/v2/operator/service`). Both target the same
+//! plist/unit path, so an install from either surface atomically replaces
+//! whatever the other last wrote there — see [`write_atomic`].
+//!
+//! The two implementations are not yet unified: `composition` cannot
+//! depend on this CLI crate (dependency direction runs the other way), so
+//! there is no shared crate to host one implementation today. Until that
+//! consolidation lands, this CLI's unit is the target state — it is
+//! secret-free (only `HOME`/profile env, no bearer token; `serve` reads
+//! the WebUI token from the 0600 token file at start), where the facade's
+//! generated unit bakes the WebUI bearer token directly into the unit
+//! file's `Environment=` lines. A CLI install replacing a facade-installed
+//! unit is therefore a security improvement, not just a collision to
+//! avoid.
 
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -31,7 +53,15 @@ use crate::serve_invocation::serve_invocation;
 mod launchd;
 mod systemd;
 
-const SERVICE_LABEL: &str = "com.ironclaw.reborn.daemon";
+/// launchd label / systemd unit name for the canonical Reborn service
+/// identity. Shared, deliberately, with `RebornLocalServiceLifecycle` in
+/// `ironclaw_reborn_composition::observability::operator_service_lifecycle`
+/// (the WebUI operator-service facade) — see the module doc above. An
+/// install from either surface atomically replaces the other's file at
+/// this same path; do not fork these constants to "avoid collisions"
+/// without updating both sides together.
+const SERVICE_LABEL: &str = "com.ironclaw.reborn";
+/// See [`SERVICE_LABEL`] — same shared-identity contract, Linux side.
 const SYSTEMD_UNIT: &str = "ironclaw-reborn.service";
 const UNSUPPORTED_OS_MESSAGE: &str = "Service management is only supported on macOS and Linux";
 
@@ -263,6 +293,25 @@ fn status_label(installed: bool, running: bool) -> &'static str {
     } else {
         "stopped"
     }
+}
+
+// ── Install advisory ────────────────────────────────────────────
+
+/// Advisory line printed after `service install` when a pre-existing
+/// unit/plist file at the target path was replaced by this install —
+/// `None` when the install wrote a fresh file, nothing to advise. Shared
+/// by both platforms so the wording (and the "must `service restart`"
+/// guidance) can't drift between them. Covers both a prior install by
+/// this same CLI and one by the WebUI operator facade
+/// (`RebornLocalServiceLifecycle`, see the module doc): either way the
+/// write already happened atomically by the time this is read; a
+/// currently-running service process keeps running off the old
+/// definition until restarted.
+fn replaced_existing_service_file_note(replaced_existing: bool) -> Option<&'static str> {
+    replaced_existing.then_some(
+        "  Replaced an existing service definition at this path; if the service is currently \
+         running, it keeps the OLD definition until `ironclaw-reborn service restart`.",
+    )
 }
 
 // ── Atomic file writes ──────────────────────────────────────────
@@ -527,7 +576,8 @@ mod tests {
         let _home = TempHomeGuard::set(tmp.path());
         let invocation = serve_invocation().expect("serve invocation");
         let mut runner = SuccessfulServiceCommandRunner;
-        systemd::install_with_runner(&invocation, &mut runner).expect("install must succeed");
+        let fresh_replaced =
+            systemd::install_with_runner(&invocation, &mut runner).expect("install must succeed");
         let unit_path = tmp
             .path()
             .join(".config/systemd/user/ironclaw-reborn.service");
@@ -535,10 +585,27 @@ mod tests {
         let contents = std::fs::read_to_string(&unit_path).expect("read unit file");
         assert!(contents.contains("ExecStart="));
         assert!(contents.contains("IRONCLAW_REBORN_HOME="));
+        assert!(
+            !fresh_replaced,
+            "a fresh install must not report a replaced unit"
+        );
+        assert!(replaced_existing_service_file_note(fresh_replaced).is_none());
 
-        // Idempotent reinstall: overwrites cleanly, no fail or duplicate.
-        systemd::install_with_runner(&invocation, &mut runner).expect("reinstall must succeed");
+        // Idempotent reinstall: overwrites cleanly, no fail or duplicate —
+        // and, per the shared-identity contract with the WebUI operator
+        // facade (`RebornLocalServiceLifecycle`), must now report that it
+        // replaced an existing unit (this reinstall stands in for the
+        // facade's unit being atomically replaced by the CLI's).
+        let reinstall_replaced =
+            systemd::install_with_runner(&invocation, &mut runner).expect("reinstall must succeed");
         assert!(unit_path.exists());
+        assert!(
+            reinstall_replaced,
+            "reinstalling over an existing unit must report the replacement"
+        );
+        let note = replaced_existing_service_file_note(reinstall_replaced)
+            .expect("a replaced install must carry an advisory line");
+        assert!(note.contains("service restart"));
 
         systemd::uninstall_with_runner(&mut runner).expect("uninstall must succeed");
         assert!(!unit_path.exists(), "unit file must be removed");
@@ -560,7 +627,7 @@ mod tests {
             .expect("install must succeed");
         let plist_path = tmp
             .path()
-            .join("Library/LaunchAgents/com.ironclaw.reborn.daemon.plist");
+            .join("Library/LaunchAgents/com.ironclaw.reborn.plist");
         assert!(plist_path.exists(), "plist file must be written");
         let contents = std::fs::read_to_string(&plist_path).expect("read plist file");
         assert!(contents.contains(SERVICE_LABEL));

--- a/crates/ironclaw_reborn_cli/src/commands/service/mod.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/service/mod.rs
@@ -167,37 +167,65 @@ impl ServicePlatform {
     }
 
     fn start(&self) -> Result<()> {
+        self.start_with_runner(&mut OsServiceCommandRunner)
+    }
+
+    /// Runner-injectable `start`, mirroring [`Self::install_with_runner`]:
+    /// lets a test drive the same dispatch `start()`/`ServiceCommand::execute`
+    /// use, with a fake [`ServiceCommandRunner`] instead of the host's real
+    /// `launchctl`/`systemctl`.
+    fn start_with_runner(&self, runner: &mut dyn ServiceCommandRunner) -> Result<()> {
         match self {
-            Self::MacOs => launchd::start(),
-            Self::Linux => systemd::start(),
+            Self::MacOs => launchd::start_with_runner(runner),
+            Self::Linux => systemd::start_with_runner(runner),
         }
     }
 
     fn stop(&self) -> Result<()> {
+        self.stop_with_runner(&mut OsServiceCommandRunner)
+    }
+
+    /// Runner-injectable `stop` — see [`Self::start_with_runner`].
+    fn stop_with_runner(&self, runner: &mut dyn ServiceCommandRunner) -> Result<()> {
         match self {
-            Self::MacOs => launchd::stop(),
-            Self::Linux => systemd::stop(),
+            Self::MacOs => launchd::stop_with_runner(runner),
+            Self::Linux => systemd::stop_with_runner(runner),
         }
     }
 
     fn restart(&self) -> Result<()> {
+        self.restart_with_runner(&mut OsServiceCommandRunner)
+    }
+
+    /// Runner-injectable `restart` — see [`Self::start_with_runner`].
+    fn restart_with_runner(&self, runner: &mut dyn ServiceCommandRunner) -> Result<()> {
         match self {
-            Self::MacOs => launchd::restart(),
-            Self::Linux => systemd::restart(),
+            Self::MacOs => launchd::restart_with_runner(runner),
+            Self::Linux => systemd::restart_with_runner(runner),
         }
     }
 
     fn status(&self) -> Result<()> {
+        self.status_with_runner(&mut OsServiceCommandRunner)
+    }
+
+    /// Runner-injectable `status` — see [`Self::start_with_runner`].
+    fn status_with_runner(&self, runner: &mut dyn ServiceCommandRunner) -> Result<()> {
         match self {
-            Self::MacOs => launchd::status(),
-            Self::Linux => systemd::status(),
+            Self::MacOs => launchd::status_with_runner(runner),
+            Self::Linux => systemd::status_with_runner(runner),
         }
     }
 
     fn uninstall(&self) -> Result<()> {
+        self.uninstall_with_runner(&mut OsServiceCommandRunner)
+    }
+
+    /// Runner-injectable `uninstall` — see [`Self::start_with_runner`].
+    fn uninstall_with_runner(&self, runner: &mut dyn ServiceCommandRunner) -> Result<()> {
         match self {
-            Self::MacOs => launchd::uninstall(),
-            Self::Linux => systemd::uninstall(),
+            Self::MacOs => launchd::uninstall_with_runner(runner),
+            Self::Linux => systemd::uninstall_with_runner(runner),
         }
     }
 }
@@ -457,14 +485,23 @@ mod tests {
     use super::*;
 
     #[derive(Default)]
-    struct SuccessfulServiceCommandRunner;
+    struct SuccessfulServiceCommandRunner {
+        /// Labels of every command run through this stub, in call order.
+        /// Used by [`service_verbs_dispatch_through_the_injectable_runner_path`]
+        /// to prove a verb actually reached the injected runner rather than
+        /// bailing out before calling it (e.g. an "not installed" short
+        /// circuit).
+        labels: Vec<String>,
+    }
 
     impl ServiceCommandRunner for SuccessfulServiceCommandRunner {
-        fn run_checked(&mut self, _label: &str, _command: &mut Command) -> Result<()> {
+        fn run_checked(&mut self, label: &str, _command: &mut Command) -> Result<()> {
+            self.labels.push(label.to_string());
             Ok(())
         }
 
         fn run_capture_checked(&mut self, label: &str, _command: &mut Command) -> Result<String> {
+            self.labels.push(label.to_string());
             match label {
                 "launchctl list" => Ok(String::new()),
                 "id -u" => Ok("501\n".to_string()),
@@ -562,7 +599,7 @@ mod tests {
         // WebUI token deliberately absent.
 
         let platform = ServicePlatform::detect().expect("detect must resolve on macOS/Linux");
-        let mut runner = SuccessfulServiceCommandRunner;
+        let mut runner = SuccessfulServiceCommandRunner::default();
         let warnings = platform
             .install_with_runner(&context, &mut runner)
             .expect("install must succeed even with the token warning outstanding");
@@ -576,6 +613,69 @@ mod tests {
             warnings[0].contains("WebUI token not found or too short"),
             "warnings: {warnings:?}"
         );
+    }
+
+    #[test]
+    fn service_verbs_dispatch_through_the_injectable_runner_path() {
+        // Before this fix, only `install` had a runner-injectable split
+        // (`install_with_runner`, exercised above) — `start`/`stop`/
+        // `restart`/`status`/`uninstall` existed only as `pub(super) fn
+        // verb()`, hardcoding `OsServiceCommandRunner` with no way to drive
+        // `ServiceCommand`'s dispatch wiring itself without touching the
+        // real service manager. This parses each verb via clap (the same
+        // way `ServiceCommand` does) and drives it through
+        // `ServicePlatform`'s new `*_with_runner` methods with a stub
+        // runner, proving the dispatch wiring end to end. It deliberately
+        // does NOT re-assert each verb's own behavior (installed/running
+        // detection, rollback, etc.) — that's already covered by the
+        // dedicated per-platform tests in systemd.rs and launchd.rs.
+        let _lock = crate::runtime::test_env::lock_runtime_env();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _home = TempHomeGuard::set(tmp.path());
+        let context = RebornCliContext::from_boot_config(
+            ironclaw_reborn_config::RebornBootConfig::resolve_from_env()
+                .expect("boot config must resolve under temp HOME"),
+        );
+        let platform = ServicePlatform::detect().expect("detect must resolve on macOS/Linux");
+        let mut runner = SuccessfulServiceCommandRunner::default();
+        platform.install_with_runner(&context, &mut runner).expect(
+            "install must succeed so start/stop/restart/status/uninstall have a unit to act on",
+        );
+
+        use clap::Parser;
+
+        #[derive(clap::Parser)]
+        struct VerbParser {
+            #[command(subcommand)]
+            verb: ServiceVerb,
+        }
+
+        for (args, verb_name) in [
+            (["ironclaw-reborn", "start"], "start"),
+            (["ironclaw-reborn", "stop"], "stop"),
+            (["ironclaw-reborn", "restart"], "restart"),
+            (["ironclaw-reborn", "status"], "status"),
+            (["ironclaw-reborn", "uninstall"], "uninstall"),
+        ] {
+            let parsed = VerbParser::try_parse_from(args)
+                .unwrap_or_else(|e| panic!("{verb_name} must parse via clap: {e}"));
+            let before = runner.labels.len();
+            let result = match parsed.verb {
+                ServiceVerb::Install => unreachable!("install is not under test here"),
+                ServiceVerb::Start => platform.start_with_runner(&mut runner),
+                ServiceVerb::Stop => platform.stop_with_runner(&mut runner),
+                ServiceVerb::Restart => platform.restart_with_runner(&mut runner),
+                ServiceVerb::Status => platform.status_with_runner(&mut runner),
+                ServiceVerb::Uninstall => platform.uninstall_with_runner(&mut runner),
+            };
+            result.unwrap_or_else(|e| {
+                panic!("{verb_name} through the injected runner must succeed: {e:#}")
+            });
+            assert!(
+                runner.labels.len() > before,
+                "{verb_name} must reach the injected runner, not bail out before calling it"
+            );
+        }
     }
 
     #[cfg(unix)]
@@ -673,7 +773,7 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir");
         let _home = TempHomeGuard::set(tmp.path());
         let invocation = serve_invocation().expect("serve invocation");
-        let mut runner = SuccessfulServiceCommandRunner;
+        let mut runner = SuccessfulServiceCommandRunner::default();
         let fresh_replaced =
             systemd::install_with_runner(&invocation, &mut runner).expect("install must succeed");
         let unit_path = tmp
@@ -737,7 +837,7 @@ mod tests {
             .expect("reinstall must succeed");
         assert!(plist_path.exists());
 
-        let mut runner = SuccessfulServiceCommandRunner;
+        let mut runner = SuccessfulServiceCommandRunner::default();
         launchd::uninstall_with_runner(&mut runner).expect("uninstall must succeed");
         assert!(!plist_path.exists(), "plist file must be removed");
     }

--- a/crates/ironclaw_reborn_cli/src/commands/service/mod.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/service/mod.rs
@@ -1,0 +1,410 @@
+//! `ironclaw-reborn service` — install/manage the standalone Reborn
+//! binary as an OS-native service.
+//!
+//! - **macOS**: launchd user agent at
+//!   `~/Library/LaunchAgents/com.ironclaw.reborn.daemon.plist`.
+//! - **Linux**: systemd user unit at
+//!   `~/.config/systemd/user/ironclaw-reborn.service`.
+//!
+//! The installed service runs `<current_exe> serve`, restarting
+//! automatically on failure. Mirrors v1's `src/service.rs` shape with
+//! Reborn's label, paths, and env-passthrough contract; no v1 code is
+//! shared or reused.
+//!
+//! Platform dispatch happens once, in [`ServicePlatform::detect`], called
+//! a single time from [`ServiceCommand::execute`]. The five verbs are
+//! methods on [`ServicePlatform`] that each `match self` to delegate
+//! into the OS-specific implementation (`launchd` or `systemd`), rather
+//! than every verb re-checking `cfg!(target_os)`.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use anyhow::{Context, Result, bail};
+use clap::{Args, Subcommand};
+
+use crate::context::RebornCliContext;
+use crate::serve_invocation::serve_invocation;
+
+mod launchd;
+mod systemd;
+
+const SERVICE_LABEL: &str = "com.ironclaw.reborn.daemon";
+const SYSTEMD_UNIT: &str = "ironclaw-reborn.service";
+const UNSUPPORTED_OS_MESSAGE: &str = "Service management is only supported on macOS and Linux";
+
+// ── Clap surface ────────────────────────────────────────────────
+
+#[derive(Debug, Args)]
+pub(crate) struct ServiceCommand {
+    #[command(subcommand)]
+    command: ServiceVerb,
+}
+
+#[derive(Debug, Subcommand)]
+enum ServiceVerb {
+    /// Install the OS service (launchd on macOS, systemd on Linux).
+    Install,
+    /// Start the installed service.
+    Start,
+    /// Stop the running service.
+    Stop,
+    /// Show service status.
+    Status,
+    /// Uninstall the OS service and remove the unit file.
+    Uninstall,
+}
+
+impl ServiceCommand {
+    pub(crate) fn execute(self, context: RebornCliContext) -> Result<()> {
+        let platform = ServicePlatform::detect()?;
+        match self.command {
+            ServiceVerb::Install => platform.install(&context),
+            ServiceVerb::Start => platform.start(),
+            ServiceVerb::Stop => platform.stop(),
+            ServiceVerb::Status => platform.status(),
+            ServiceVerb::Uninstall => platform.uninstall(),
+        }
+    }
+}
+
+// ── Platform dispatch ───────────────────────────────────────────
+
+/// The two supported service-management targets. Detected once per
+/// invocation via [`ServicePlatform::detect`]; every verb dispatches
+/// off the resolved variant instead of re-checking `cfg!(target_os)`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ServicePlatform {
+    MacOs,
+    Linux,
+}
+
+impl ServicePlatform {
+    fn detect() -> Result<Self> {
+        if cfg!(target_os = "macos") {
+            Ok(Self::MacOs)
+        } else if cfg!(target_os = "linux") {
+            Ok(Self::Linux)
+        } else {
+            bail!(UNSUPPORTED_OS_MESSAGE);
+        }
+    }
+
+    fn install(&self, context: &RebornCliContext) -> Result<()> {
+        for warning in preflight_warnings(context) {
+            eprintln!("warning: {warning}");
+        }
+        let invocation = serve_invocation()?;
+        match self {
+            Self::MacOs => launchd::install(context, &invocation),
+            Self::Linux => systemd::install(&invocation),
+        }
+    }
+
+    fn start(&self) -> Result<()> {
+        match self {
+            Self::MacOs => launchd::start(),
+            Self::Linux => systemd::start(),
+        }
+    }
+
+    fn stop(&self) -> Result<()> {
+        match self {
+            Self::MacOs => launchd::stop(),
+            Self::Linux => systemd::stop(),
+        }
+    }
+
+    fn status(&self) -> Result<()> {
+        match self {
+            Self::MacOs => launchd::status(),
+            Self::Linux => systemd::status(),
+        }
+    }
+
+    fn uninstall(&self) -> Result<()> {
+        match self {
+            Self::MacOs => launchd::uninstall(),
+            Self::Linux => systemd::uninstall(),
+        }
+    }
+}
+
+// ── Path helpers ────────────────────────────────────────────────
+
+/// The OS user's real home directory (`$HOME`), used only for the
+/// service-definition file location. Distinct from the Reborn home
+/// (`IRONCLAW_REBORN_HOME`), which holds operator config/logs and may
+/// point anywhere. Windows never reaches this — `ServicePlatform::detect`
+/// bails first — so only `$HOME` (POSIX) is read.
+fn home_dir() -> Result<PathBuf> {
+    let raw = std::env::var_os("HOME").context("HOME must be set to manage an OS service")?;
+    let path = PathBuf::from(raw);
+    if !path.is_absolute() {
+        bail!("HOME must be an absolute path to manage an OS service");
+    }
+    Ok(path)
+}
+
+// ── Preflight ───────────────────────────────────────────────────
+
+/// Non-fatal readiness warnings for `service install`: warn, don't
+/// fail, when onboarding hasn't run yet — the service can still be
+/// installed, but `serve` starts without config/providers/token until
+/// `ironclaw-reborn onboard` runs.
+fn preflight_warnings(context: &RebornCliContext) -> Vec<String> {
+    let home = context.boot_config().home();
+    let mut warnings = Vec::new();
+
+    let marker = crate::commands::onboard::onboarding_marker_path(home);
+    if !marker.exists() {
+        warnings.push(format!(
+            "onboarding marker not found at {} — run `ironclaw-reborn onboard` first so \
+             `serve` has config, providers, and the WebUI token available",
+            marker.display()
+        ));
+    }
+
+    let config = home.config_file_path();
+    if !config.exists() {
+        warnings.push(format!(
+            "config.toml not found at {} — `serve` will run with compiled-in defaults only",
+            config.display()
+        ));
+    }
+
+    warnings
+}
+
+// ── Shell helpers ───────────────────────────────────────────────
+
+/// Run `command`, treating a non-zero exit as an error. `label` names
+/// the operation for the error message (e.g. "launchctl load").
+fn run_checked(label: &str, command: &mut Command) -> Result<()> {
+    let output = command
+        .output()
+        .with_context(|| format!("failed to spawn command for {label}"))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("{label} failed: {}", stderr.trim());
+    }
+    Ok(())
+}
+
+fn run_capture_checked(label: &str, command: &mut Command) -> Result<String> {
+    let output = command
+        .output()
+        .with_context(|| format!("failed to spawn command for {label}"))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("{label} failed: {}", stderr.trim());
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+/// Injectable command boundary for service-manager lifecycle operations.
+///
+/// Production uses [`OsServiceCommandRunner`]. Tests provide a recorder so
+/// failure propagation and command ordering are verified without reaching the
+/// host's real launchd/systemd instance.
+trait ServiceCommandRunner {
+    fn run_checked(&mut self, label: &str, command: &mut Command) -> Result<()>;
+    fn run_capture_checked(&mut self, label: &str, command: &mut Command) -> Result<String>;
+}
+
+struct OsServiceCommandRunner;
+
+impl ServiceCommandRunner for OsServiceCommandRunner {
+    fn run_checked(&mut self, label: &str, command: &mut Command) -> Result<()> {
+        run_checked(label, command)
+    }
+
+    fn run_capture_checked(&mut self, label: &str, command: &mut Command) -> Result<String> {
+        run_capture_checked(label, command)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Default)]
+    struct SuccessfulServiceCommandRunner;
+
+    impl ServiceCommandRunner for SuccessfulServiceCommandRunner {
+        fn run_checked(&mut self, _label: &str, _command: &mut Command) -> Result<()> {
+            Ok(())
+        }
+
+        fn run_capture_checked(&mut self, label: &str, _command: &mut Command) -> Result<String> {
+            match label {
+                "launchctl list" => Ok(String::new()),
+                "id -u" => Ok("501\n".to_string()),
+                _ => Ok(String::new()),
+            }
+        }
+    }
+
+    #[test]
+    fn detect_returns_a_supported_platform_on_this_test_host() {
+        // This test only runs in CI/dev on macOS or Linux, so detect()
+        // must resolve to one of the two supported variants, never bail.
+        let platform = ServicePlatform::detect().expect("detect must resolve on macOS/Linux");
+        assert!(matches!(
+            platform,
+            ServicePlatform::MacOs | ServicePlatform::Linux
+        ));
+    }
+
+    #[test]
+    fn preflight_warnings_empty_when_marker_and_config_present() {
+        let (_tmp, context) = RebornCliContext::test_context();
+        let home = context.boot_config().home();
+        std::fs::create_dir_all(home.path()).expect("create home");
+        std::fs::write(crate::commands::onboard::onboarding_marker_path(home), "{}")
+            .expect("write marker");
+        std::fs::write(home.config_file_path(), "").expect("write config");
+
+        assert!(preflight_warnings(&context).is_empty());
+    }
+
+    #[test]
+    fn preflight_warnings_flags_missing_marker_and_config() {
+        let (_tmp, context) = RebornCliContext::test_context();
+        let warnings = preflight_warnings(&context);
+        assert_eq!(warnings.len(), 2);
+        assert!(warnings[0].contains("onboarding marker not found"));
+        assert!(warnings[1].contains("config.toml not found"));
+    }
+
+    #[test]
+    fn run_capture_checked_reads_stdout() {
+        let out = run_capture_checked("test echo", Command::new("sh").args(["-c", "echo hello"]))
+            .expect("stdout capture should succeed");
+        assert_eq!(out.trim(), "hello");
+    }
+
+    #[test]
+    fn run_capture_checked_rejects_non_zero_exit() {
+        let error = run_capture_checked(
+            "test capture",
+            Command::new("sh").args(["-c", "echo warn 1>&2; exit 17"]),
+        )
+        .expect_err("non-zero capture must fail");
+        assert!(error.to_string().contains("test capture failed: warn"));
+    }
+
+    #[test]
+    fn run_checked_errors_on_non_zero_exit_and_names_the_label() {
+        let err = run_checked("test exit 17", Command::new("sh").args(["-c", "exit 17"]))
+            .expect_err("non-zero exit should error");
+        assert!(err.to_string().contains("test exit 17 failed"));
+    }
+
+    #[test]
+    fn run_checked_succeeds_on_zero_exit() {
+        assert!(run_checked("test exit 0", Command::new("sh").args(["-c", "exit 0"])).is_ok());
+    }
+
+    // ── Command-level file lifecycle (temp-$HOME) ──────────────────
+
+    /// RAII guard pointing the OS home (`$HOME`, read by `home_dir()`)
+    /// at a tempdir, and clearing IRONCLAW_REBORN_HOME so the derived
+    /// Reborn home nests under the same tempdir (RebornHome falls back
+    /// to `$HOME/.ironclaw/reborn` when unset). Restores both on drop.
+    /// Caller must hold `lock_runtime_env()`.
+    struct TempHomeGuard {
+        prior_home: Option<std::ffi::OsString>,
+        prior_reborn_home: Option<std::ffi::OsString>,
+    }
+
+    impl TempHomeGuard {
+        fn set(tmp: &std::path::Path) -> Self {
+            let prior_home = std::env::var_os("HOME");
+            let prior_reborn_home = std::env::var_os("IRONCLAW_REBORN_HOME");
+            // SAFETY: caller holds `lock_runtime_env()` for this guard's lifetime.
+            unsafe {
+                std::env::set_var("HOME", tmp);
+                std::env::remove_var("IRONCLAW_REBORN_HOME");
+            }
+            Self {
+                prior_home,
+                prior_reborn_home,
+            }
+        }
+    }
+
+    impl Drop for TempHomeGuard {
+        fn drop(&mut self) {
+            // SAFETY: see `set`.
+            unsafe {
+                match self.prior_home.take() {
+                    Some(v) => std::env::set_var("HOME", v),
+                    None => std::env::remove_var("HOME"),
+                }
+                match self.prior_reborn_home.take() {
+                    Some(v) => std::env::set_var("IRONCLAW_REBORN_HOME", v),
+                    None => std::env::remove_var("IRONCLAW_REBORN_HOME"),
+                }
+            }
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn install_then_uninstall_linux_writes_and_removes_unit_file() {
+        let _lock = crate::runtime::test_env::lock_runtime_env();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _home = TempHomeGuard::set(tmp.path());
+        let invocation = serve_invocation().expect("serve invocation");
+        let mut runner = SuccessfulServiceCommandRunner;
+        systemd::install_with_runner(&invocation, &mut runner).expect("install must succeed");
+        let unit_path = tmp
+            .path()
+            .join(".config/systemd/user/ironclaw-reborn.service");
+        assert!(unit_path.exists(), "unit file must be written");
+        let contents = std::fs::read_to_string(&unit_path).expect("read unit file");
+        assert!(contents.contains("ExecStart="));
+        assert!(contents.contains("IRONCLAW_REBORN_HOME="));
+
+        // Idempotent reinstall: overwrites cleanly, no fail or duplicate.
+        systemd::install_with_runner(&invocation, &mut runner).expect("reinstall must succeed");
+        assert!(unit_path.exists());
+
+        systemd::uninstall_with_runner(&mut runner).expect("uninstall must succeed");
+        assert!(!unit_path.exists(), "unit file must be removed");
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn install_then_uninstall_macos_writes_and_removes_plist() {
+        let _lock = crate::runtime::test_env::lock_runtime_env();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _home = TempHomeGuard::set(tmp.path());
+        let context = RebornCliContext::from_boot_config(
+            ironclaw_reborn_config::RebornBootConfig::resolve_from_env()
+                .expect("boot config must resolve under temp HOME"),
+        );
+
+        ServicePlatform::MacOs
+            .install(&context)
+            .expect("install must succeed");
+        let plist_path = tmp
+            .path()
+            .join("Library/LaunchAgents/com.ironclaw.reborn.daemon.plist");
+        assert!(plist_path.exists(), "plist file must be written");
+        let contents = std::fs::read_to_string(&plist_path).expect("read plist file");
+        assert!(contents.contains(SERVICE_LABEL));
+        assert!(contents.contains("<key>IRONCLAW_REBORN_HOME</key>"));
+
+        // Idempotent reinstall.
+        ServicePlatform::MacOs
+            .install(&context)
+            .expect("reinstall must succeed");
+        assert!(plist_path.exists());
+
+        let mut runner = SuccessfulServiceCommandRunner;
+        launchd::uninstall_with_runner(&mut runner).expect("uninstall must succeed");
+        assert!(!plist_path.exists(), "plist file must be removed");
+    }
+}

--- a/crates/ironclaw_reborn_cli/src/commands/service/systemd.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/service/systemd.rs
@@ -278,6 +278,50 @@ fn stop_with_runner(runner: &mut dyn ServiceCommandRunner) -> Result<()> {
     Ok(())
 }
 
+pub(super) fn restart() -> Result<()> {
+    restart_with_runner(&mut OsServiceCommandRunner)
+}
+
+/// Composes [`stop_with_runner`] and [`start_with_runner`]: a running
+/// service is stopped then started, an already-stopped service is just
+/// started, and a start failure after a successful stop is reported as
+/// leaving the service stopped rather than a silent half-restart.
+fn restart_with_runner(runner: &mut dyn ServiceCommandRunner) -> Result<()> {
+    if !unit_path()?.exists() {
+        bail!("Service not installed. Run `ironclaw-reborn service install` first.");
+    }
+    let active_state = runner.run_capture_checked(
+        "systemctl show ActiveState",
+        Command::new("systemctl").args([
+            "--user",
+            "show",
+            "--property=ActiveState",
+            "--value",
+            SYSTEMD_UNIT,
+        ]),
+    )?;
+    let was_running = active_state.trim() == "active";
+
+    if was_running {
+        stop_with_runner(runner)?;
+    }
+    if let Err(start_error) = start_with_runner(runner) {
+        if was_running {
+            bail!(
+                "service restart: stop succeeded but start failed; the service is now \
+                 STOPPED: {start_error:#}"
+            );
+        }
+        return Err(start_error);
+    }
+    if was_running {
+        println!("Service restarted");
+    } else {
+        println!("Service was not running; started");
+    }
+    Ok(())
+}
+
 pub(super) fn status() -> Result<()> {
     status_with_runner(&mut OsServiceCommandRunner)
 }
@@ -991,6 +1035,139 @@ mod tests {
         }
 
         assert!(result.is_err());
+    }
+
+    // ── restart ─────────────────────────────────────────────────
+
+    #[test]
+    fn restart_running_service_stops_then_starts() {
+        let _lock = crate::runtime::test_env::lock_runtime_env();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let prior = std::env::var_os("HOME");
+        // SAFETY: serialized by `lock_runtime_env`; restored below.
+        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let file = unit_path().expect("unit path");
+        std::fs::create_dir_all(file.parent().expect("unit parent")).expect("create parent");
+        std::fs::write(&file, "unit").expect("write unit");
+        let mut runner = RecordingRunner {
+            active_state_output: Some("active\n".to_string()),
+            ..RecordingRunner::default()
+        };
+        let result = restart_with_runner(&mut runner);
+        // SAFETY: serialized by `lock_runtime_env`.
+        unsafe {
+            match prior {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+
+        result.expect("restart of a running service must succeed");
+        assert_eq!(
+            runner.labels,
+            [
+                "systemctl show ActiveState",
+                "systemctl stop",
+                "systemctl daemon-reload",
+                "systemctl start",
+            ]
+        );
+    }
+
+    #[test]
+    fn restart_stopped_service_just_starts() {
+        let _lock = crate::runtime::test_env::lock_runtime_env();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let prior = std::env::var_os("HOME");
+        // SAFETY: serialized by `lock_runtime_env`; restored below.
+        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let file = unit_path().expect("unit path");
+        std::fs::create_dir_all(file.parent().expect("unit parent")).expect("create parent");
+        std::fs::write(&file, "unit").expect("write unit");
+        let mut runner = RecordingRunner {
+            active_state_output: Some("inactive\n".to_string()),
+            ..RecordingRunner::default()
+        };
+        let result = restart_with_runner(&mut runner);
+        // SAFETY: serialized by `lock_runtime_env`.
+        unsafe {
+            match prior {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+
+        result.expect("restart of a stopped service must succeed without error");
+        assert_eq!(
+            runner.labels,
+            [
+                "systemctl show ActiveState",
+                "systemctl daemon-reload",
+                "systemctl start",
+            ]
+        );
+    }
+
+    #[test]
+    fn restart_not_installed_errors_with_install_guidance() {
+        let _lock = crate::runtime::test_env::lock_runtime_env();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let prior = std::env::var_os("HOME");
+        // SAFETY: serialized by `lock_runtime_env`; restored below.
+        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let mut runner = RecordingRunner::default();
+        let result = restart_with_runner(&mut runner);
+        // SAFETY: serialized by `lock_runtime_env`.
+        unsafe {
+            match prior {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+
+        let error = result.expect_err("restart without an installed service must error");
+        assert!(error.to_string().contains("service install"));
+        assert!(runner.labels.is_empty(), "no commands should run");
+    }
+
+    #[test]
+    fn restart_reports_stopped_when_start_fails_after_successful_stop() {
+        let _lock = crate::runtime::test_env::lock_runtime_env();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let prior = std::env::var_os("HOME");
+        // SAFETY: serialized by `lock_runtime_env`; restored below.
+        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let file = unit_path().expect("unit path");
+        std::fs::create_dir_all(file.parent().expect("unit parent")).expect("create parent");
+        std::fs::write(&file, "unit").expect("write unit");
+        let mut runner = RecordingRunner {
+            active_state_output: Some("active\n".to_string()),
+            fail_args: Some(vec!["--user", "start", SYSTEMD_UNIT]),
+            ..RecordingRunner::default()
+        };
+        let result = restart_with_runner(&mut runner);
+        // SAFETY: serialized by `lock_runtime_env`.
+        unsafe {
+            match prior {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+
+        let error = result.expect_err("failed start after successful stop must error");
+        assert!(
+            error.to_string().contains("STOPPED"),
+            "error must report the service as stopped, got: {error}"
+        );
+        assert_eq!(
+            runner.labels,
+            [
+                "systemctl show ActiveState",
+                "systemctl stop",
+                "systemctl daemon-reload",
+                "systemctl start",
+            ]
+        );
     }
 
     #[test]

--- a/crates/ironclaw_reborn_cli/src/commands/service/systemd.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/service/systemd.rs
@@ -277,9 +277,28 @@ pub(super) fn status() -> Result<()> {
     status_with_runner(&mut OsServiceCommandRunner)
 }
 
+/// Secondary detail line for a non-`active` raw `ActiveState`, e.g. a
+/// crashed unit (`failed`) versus one that was simply never started
+/// (`inactive`). `None` when the raw state doesn't warrant a detail line
+/// (unit is `active`; line 1 already says `running`).
+///
+/// Chosen rule: always show the raw state when not running — simplest and
+/// most minimal; no allowlist of "interesting" states to keep in sync with
+/// systemd's ActiveState vocabulary (active/reloading/inactive/failed/
+/// activating/deactivating).
+fn systemd_status_detail(raw_state: &str) -> Option<String> {
+    let trimmed = raw_state.trim();
+    if trimmed == "active" {
+        None
+    } else {
+        Some(format!("  systemd ActiveState: {trimmed}"))
+    }
+}
+
 fn status_with_runner(runner: &mut dyn ServiceCommandRunner) -> Result<()> {
     let file = unit_path()?;
     let installed = file.exists();
+    let mut detail = None;
     let running = if installed {
         // `is-active` uses non-zero exits for ordinary inactive states.
         // `show` returns those states in stdout and reserves failure for a
@@ -294,11 +313,15 @@ fn status_with_runner(runner: &mut dyn ServiceCommandRunner) -> Result<()> {
                 SYSTEMD_UNIT,
             ]),
         )?;
+        detail = systemd_status_detail(&state);
         state.trim() == "active"
     } else {
         false
     };
     println!("Service: {}", super::status_label(installed, running));
+    if let Some(detail) = detail {
+        println!("{detail}");
+    }
     println!("Unit: {}", file.display());
     Ok(())
 }
@@ -1144,6 +1167,20 @@ mod tests {
                 "systemctl daemon-reload",
                 "systemctl start",
             ]
+        );
+    }
+
+    #[test]
+    fn status_detail_line_reports_raw_failed_state_but_omits_for_active() {
+        assert_eq!(
+            systemd_status_detail("failed\n"),
+            Some("  systemd ActiveState: failed".to_string()),
+            "a crashed unit's raw ActiveState must survive as a detail line"
+        );
+        assert_eq!(
+            systemd_status_detail("active\n"),
+            None,
+            "line 1 already says running; no redundant detail line for active"
         );
     }
 

--- a/crates/ironclaw_reborn_cli/src/commands/service/systemd.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/service/systemd.rs
@@ -510,6 +510,50 @@ fn uninstall_with_runner_and_remover(
 mod tests {
     use super::*;
 
+    /// RAII guard pointing `$HOME` at a tempdir and clearing
+    /// `$XDG_CONFIG_HOME` for the guard's lifetime, so `unit_path()`
+    /// resolves under the tempdir instead of a real XDG path that may
+    /// already exist on the host (CI runners have been observed setting
+    /// `XDG_CONFIG_HOME=$HOME/.config`, which `config_home()` correctly
+    /// prefers over `$HOME` — see `unit_path_honors_xdg_config_home_when_set_and_nonempty`
+    /// below). Restores both on drop. Caller must hold `lock_runtime_env()`.
+    struct TempHomeGuard {
+        prior_home: Option<std::ffi::OsString>,
+        prior_xdg: Option<std::ffi::OsString>,
+    }
+
+    impl TempHomeGuard {
+        fn set(tmp: &Path) -> Self {
+            let prior_home = std::env::var_os("HOME");
+            let prior_xdg = std::env::var_os("XDG_CONFIG_HOME");
+            // SAFETY: caller holds `lock_runtime_env()` for this guard's lifetime.
+            unsafe {
+                std::env::set_var("HOME", tmp);
+                std::env::remove_var("XDG_CONFIG_HOME");
+            }
+            Self {
+                prior_home,
+                prior_xdg,
+            }
+        }
+    }
+
+    impl Drop for TempHomeGuard {
+        fn drop(&mut self) {
+            // SAFETY: see `set`.
+            unsafe {
+                match self.prior_home.take() {
+                    Some(v) => std::env::set_var("HOME", v),
+                    None => std::env::remove_var("HOME"),
+                }
+                match self.prior_xdg.take() {
+                    Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
+                    None => std::env::remove_var("XDG_CONFIG_HOME"),
+                }
+            }
+        }
+    }
+
     #[derive(Default)]
     struct RecordingRunner {
         labels: Vec<String>,
@@ -794,21 +838,12 @@ mod tests {
     fn install_propagates_daemon_reload_failure_before_enable() {
         let _lock = crate::runtime::test_env::lock_runtime_env();
         let tmp = tempfile::tempdir().expect("tempdir");
-        let prior = std::env::var_os("HOME");
-        // SAFETY: serialized by `lock_runtime_env`; restored below.
-        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let _home = TempHomeGuard::set(tmp.path());
         let mut runner = RecordingRunner {
             fail_args: Some(vec!["--user", "daemon-reload"]),
             ..RecordingRunner::default()
         };
         let result = install_with_runner(&sample_invocation(), &mut runner);
-        // SAFETY: serialized by `lock_runtime_env`.
-        unsafe {
-            match prior {
-                Some(value) => std::env::set_var("HOME", value),
-                None => std::env::remove_var("HOME"),
-            }
-        }
 
         assert!(result.is_err());
         assert_eq!(
@@ -825,21 +860,12 @@ mod tests {
     fn install_propagates_enable_failure() {
         let _lock = crate::runtime::test_env::lock_runtime_env();
         let tmp = tempfile::tempdir().expect("tempdir");
-        let prior = std::env::var_os("HOME");
-        // SAFETY: serialized by `lock_runtime_env`; restored below.
-        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let _home = TempHomeGuard::set(tmp.path());
         let mut runner = RecordingRunner {
             fail_nth_args: Some((vec!["--user", "enable", SYSTEMD_UNIT], 1)),
             ..RecordingRunner::default()
         };
         let result = install_with_runner(&sample_invocation(), &mut runner);
-        // SAFETY: serialized by `lock_runtime_env`.
-        unsafe {
-            match prior {
-                Some(value) => std::env::set_var("HOME", value),
-                None => std::env::remove_var("HOME"),
-            }
-        }
 
         assert!(result.is_err());
         assert_eq!(
@@ -863,9 +889,7 @@ mod tests {
     fn uninstall_disables_before_removing_and_reloading() {
         let _lock = crate::runtime::test_env::lock_runtime_env();
         let tmp = tempfile::tempdir().expect("tempdir");
-        let prior = std::env::var_os("HOME");
-        // SAFETY: serialized by `lock_runtime_env`; restored below.
-        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let _home = TempHomeGuard::set(tmp.path());
         let file = unit_path().expect("unit path");
         std::fs::create_dir_all(file.parent().expect("unit parent")).expect("create parent");
         std::fs::write(&file, "unit").expect("write unit");
@@ -874,13 +898,6 @@ mod tests {
             ..RecordingRunner::default()
         };
         let result = uninstall_with_runner(&mut runner);
-        // SAFETY: serialized by `lock_runtime_env`.
-        unsafe {
-            match prior {
-                Some(value) => std::env::set_var("HOME", value),
-                None => std::env::remove_var("HOME"),
-            }
-        }
 
         result.expect("uninstall succeeds");
         assert!(!file.exists());
@@ -906,9 +923,7 @@ mod tests {
         // the same rollback path as the other two.
         let _lock = crate::runtime::test_env::lock_runtime_env();
         let tmp = tempfile::tempdir().expect("tempdir");
-        let prior = std::env::var_os("HOME");
-        // SAFETY: serialized by `lock_runtime_env`; restored below.
-        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let _home = TempHomeGuard::set(tmp.path());
         let file = unit_path().expect("unit path");
         std::fs::create_dir_all(file.parent().expect("unit parent")).expect("create parent");
         std::fs::write(&file, "unit").expect("write unit");
@@ -918,13 +933,6 @@ mod tests {
             ..RecordingRunner::default()
         };
         let result = uninstall_with_runner(&mut runner);
-        // SAFETY: serialized by `lock_runtime_env`.
-        unsafe {
-            match prior {
-                Some(value) => std::env::set_var("HOME", value),
-                None => std::env::remove_var("HOME"),
-            }
-        }
 
         let error = result.expect_err("a failed disable must propagate");
         assert!(file.exists(), "failed disable must not remove the unit");
@@ -946,9 +954,7 @@ mod tests {
     fn failed_reinstall_restores_previous_unit() {
         let _lock = crate::runtime::test_env::lock_runtime_env();
         let tmp = tempfile::tempdir().expect("tempdir");
-        let prior = std::env::var_os("HOME");
-        // SAFETY: serialized by `lock_runtime_env`; restored below.
-        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let _home = TempHomeGuard::set(tmp.path());
         let file = unit_path().expect("unit path");
         std::fs::create_dir_all(file.parent().expect("unit parent")).expect("create parent");
         std::fs::write(&file, "previous unit").expect("write previous unit");
@@ -958,13 +964,6 @@ mod tests {
             ..RecordingRunner::default()
         };
         let result = install_with_runner(&sample_invocation(), &mut runner);
-        // SAFETY: serialized by `lock_runtime_env`.
-        unsafe {
-            match prior {
-                Some(value) => std::env::set_var("HOME", value),
-                None => std::env::remove_var("HOME"),
-            }
-        }
 
         assert!(result.is_err());
         assert_eq!(
@@ -994,9 +993,7 @@ mod tests {
     fn failed_reinstall_does_not_enable_previously_disabled_unit() {
         let _lock = crate::runtime::test_env::lock_runtime_env();
         let tmp = tempfile::tempdir().expect("tempdir");
-        let prior = std::env::var_os("HOME");
-        // SAFETY: serialized by `lock_runtime_env`; restored below.
-        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let _home = TempHomeGuard::set(tmp.path());
         let file = unit_path().expect("unit path");
         std::fs::create_dir_all(file.parent().expect("unit parent")).expect("create parent");
         std::fs::write(&file, "previous unit").expect("write previous unit");
@@ -1006,13 +1003,6 @@ mod tests {
             ..RecordingRunner::default()
         };
         let result = install_with_runner(&sample_invocation(), &mut runner);
-        // SAFETY: serialized by `lock_runtime_env`.
-        unsafe {
-            match prior {
-                Some(value) => std::env::set_var("HOME", value),
-                None => std::env::remove_var("HOME"),
-            }
-        }
 
         assert!(result.is_err());
         assert_eq!(
@@ -1041,18 +1031,9 @@ mod tests {
     fn absent_uninstall_queries_manager_then_no_ops_when_not_found() {
         let _lock = crate::runtime::test_env::lock_runtime_env();
         let tmp = tempfile::tempdir().expect("tempdir");
-        let prior = std::env::var_os("HOME");
-        // SAFETY: serialized by `lock_runtime_env`; restored below.
-        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let _home = TempHomeGuard::set(tmp.path());
         let mut runner = RecordingRunner::default();
         let result = uninstall_with_runner(&mut runner);
-        // SAFETY: serialized by `lock_runtime_env`.
-        unsafe {
-            match prior {
-                Some(value) => std::env::set_var("HOME", value),
-                None => std::env::remove_var("HOME"),
-            }
-        }
 
         result.expect("absent uninstall succeeds");
         assert_eq!(runner.labels, ["systemctl show unit state"]);
@@ -1062,21 +1043,12 @@ mod tests {
     fn absent_uninstall_disables_loaded_or_enabled_manager_state() {
         let _lock = crate::runtime::test_env::lock_runtime_env();
         let tmp = tempfile::tempdir().expect("tempdir");
-        let prior = std::env::var_os("HOME");
-        // SAFETY: serialized by `lock_runtime_env`; restored below.
-        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let _home = TempHomeGuard::set(tmp.path());
         let mut runner = RecordingRunner {
             unit_state_output: Some("LoadState=loaded\nUnitFileState=enabled\n".to_string()),
             ..RecordingRunner::default()
         };
         let result = uninstall_with_runner(&mut runner);
-        // SAFETY: serialized by `lock_runtime_env`.
-        unsafe {
-            match prior {
-                Some(value) => std::env::set_var("HOME", value),
-                None => std::env::remove_var("HOME"),
-            }
-        }
 
         result.expect("orphan manager state uninstall succeeds");
         assert_eq!(
@@ -1099,9 +1071,7 @@ mod tests {
     fn enable_failure_reports_compensating_reload_failure_with_primary_error() {
         let _lock = crate::runtime::test_env::lock_runtime_env();
         let tmp = tempfile::tempdir().expect("tempdir");
-        let prior = std::env::var_os("HOME");
-        // SAFETY: serialized by `lock_runtime_env`; restored below.
-        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let _home = TempHomeGuard::set(tmp.path());
         let mut runner = RecordingRunner {
             fail_args: Some(vec!["--user", "enable", SYSTEMD_UNIT]),
             fail_nth_args: Some((vec!["--user", "daemon-reload"], 2)),
@@ -1109,13 +1079,6 @@ mod tests {
         };
         let error = install_with_runner(&sample_invocation(), &mut runner)
             .expect_err("enable and compensating reload failure must surface");
-        // SAFETY: serialized by `lock_runtime_env`.
-        unsafe {
-            match prior {
-                Some(value) => std::env::set_var("HOME", value),
-                None => std::env::remove_var("HOME"),
-            }
-        }
 
         // Top-level `Display` (`to_string()`) now only shows the rollback
         // context, matching anyhow's chain convention; the primary failure
@@ -1141,9 +1104,7 @@ mod tests {
         // asserts the primary is preserved as the combined error's source.
         let _lock = crate::runtime::test_env::lock_runtime_env();
         let tmp = tempfile::tempdir().expect("tempdir");
-        let prior = std::env::var_os("HOME");
-        // SAFETY: serialized by `lock_runtime_env`; restored below.
-        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let _home = TempHomeGuard::set(tmp.path());
         let mut runner = RecordingRunner {
             fail_args: Some(vec!["--user", "enable", SYSTEMD_UNIT]),
             fail_nth_args: Some((vec!["--user", "daemon-reload"], 2)),
@@ -1151,13 +1112,6 @@ mod tests {
         };
         let error = install_with_runner(&sample_invocation(), &mut runner)
             .expect_err("enable and compensating reload failure must surface");
-        // SAFETY: serialized by `lock_runtime_env`.
-        unsafe {
-            match prior {
-                Some(value) => std::env::set_var("HOME", value),
-                None => std::env::remove_var("HOME"),
-            }
-        }
 
         let source = error
             .source()
@@ -1173,9 +1127,7 @@ mod tests {
     fn uninstall_reload_failure_restores_unit_for_recovery() {
         let _lock = crate::runtime::test_env::lock_runtime_env();
         let tmp = tempfile::tempdir().expect("tempdir");
-        let prior = std::env::var_os("HOME");
-        // SAFETY: serialized by `lock_runtime_env`; restored below.
-        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let _home = TempHomeGuard::set(tmp.path());
         let file = unit_path().expect("unit path");
         std::fs::create_dir_all(file.parent().expect("unit parent")).expect("create parent");
         std::fs::write(&file, "previous unit").expect("write unit");
@@ -1185,13 +1137,6 @@ mod tests {
             ..RecordingRunner::default()
         };
         let result = uninstall_with_runner(&mut runner);
-        // SAFETY: serialized by `lock_runtime_env`.
-        unsafe {
-            match prior {
-                Some(value) => std::env::set_var("HOME", value),
-                None => std::env::remove_var("HOME"),
-            }
-        }
 
         assert!(result.is_err());
         assert_eq!(
@@ -1227,9 +1172,7 @@ mod tests {
         // red-before-green regression check.
         let _lock = crate::runtime::test_env::lock_runtime_env();
         let tmp = tempfile::tempdir().expect("tempdir");
-        let prior = std::env::var_os("HOME");
-        // SAFETY: serialized by `lock_runtime_env`; restored below.
-        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let _home = TempHomeGuard::set(tmp.path());
         let file = unit_path().expect("unit path");
         std::fs::create_dir_all(file.parent().expect("unit parent")).expect("create parent");
         std::fs::write(&file, "previous unit").expect("write unit");
@@ -1241,13 +1184,6 @@ mod tests {
             Err(std::io::Error::other("injected remove_file failure"))
         }
         let result = uninstall_with_runner_and_remover(&mut runner, failing_remove_file);
-        // SAFETY: serialized by `lock_runtime_env`.
-        unsafe {
-            match prior {
-                Some(value) => std::env::set_var("HOME", value),
-                None => std::env::remove_var("HOME"),
-            }
-        }
 
         let error = result.expect_err("an injected remove_file failure must propagate");
         // `Display` on `anyhow::Error` only prints the outermost context
@@ -1286,9 +1222,7 @@ mod tests {
     fn stop_propagates_service_manager_failure_when_unit_exists() {
         let _lock = crate::runtime::test_env::lock_runtime_env();
         let tmp = tempfile::tempdir().expect("tempdir");
-        let prior = std::env::var_os("HOME");
-        // SAFETY: serialized by `lock_runtime_env`; restored below.
-        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let _home = TempHomeGuard::set(tmp.path());
         let file = unit_path().expect("unit path");
         std::fs::create_dir_all(file.parent().expect("unit parent")).expect("create parent");
         std::fs::write(file, "unit").expect("write unit");
@@ -1297,13 +1231,6 @@ mod tests {
             ..RecordingRunner::default()
         };
         let result = stop_with_runner(&mut runner);
-        // SAFETY: serialized by `lock_runtime_env`.
-        unsafe {
-            match prior {
-                Some(value) => std::env::set_var("HOME", value),
-                None => std::env::remove_var("HOME"),
-            }
-        }
 
         assert!(result.is_err());
         assert_eq!(runner.labels, ["systemctl stop"]);
@@ -1319,21 +1246,12 @@ mod tests {
         // `systemctl stop`.
         let _lock = crate::runtime::test_env::lock_runtime_env();
         let tmp = tempfile::tempdir().expect("tempdir");
-        let prior = std::env::var_os("HOME");
-        // SAFETY: serialized by `lock_runtime_env`; restored below.
-        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let _home = TempHomeGuard::set(tmp.path());
         let mut runner = RecordingRunner {
             unit_state_output: Some("LoadState=loaded\nUnitFileState=enabled\n".to_string()),
             ..RecordingRunner::default()
         };
         let result = stop_with_runner(&mut runner);
-        // SAFETY: serialized by `lock_runtime_env`.
-        unsafe {
-            match prior {
-                Some(value) => std::env::set_var("HOME", value),
-                None => std::env::remove_var("HOME"),
-            }
-        }
 
         result.expect("stop of an orphaned loaded unit succeeds");
         assert_eq!(
@@ -1353,18 +1271,9 @@ mod tests {
         // file AND the manager both show nothing.
         let _lock = crate::runtime::test_env::lock_runtime_env();
         let tmp = tempfile::tempdir().expect("tempdir");
-        let prior = std::env::var_os("HOME");
-        // SAFETY: serialized by `lock_runtime_env`; restored below.
-        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let _home = TempHomeGuard::set(tmp.path());
         let mut runner = RecordingRunner::default();
         let result = status_with_runner(&mut runner);
-        // SAFETY: serialized by `lock_runtime_env`.
-        unsafe {
-            match prior {
-                Some(value) => std::env::set_var("HOME", value),
-                None => std::env::remove_var("HOME"),
-            }
-        }
 
         result.expect("status succeeds when not installed");
         assert_eq!(
@@ -1426,9 +1335,7 @@ mod tests {
     fn status_propagates_capture_failure() {
         let _lock = crate::runtime::test_env::lock_runtime_env();
         let tmp = tempfile::tempdir().expect("tempdir");
-        let prior = std::env::var_os("HOME");
-        // SAFETY: serialized by `lock_runtime_env`; restored below.
-        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let _home = TempHomeGuard::set(tmp.path());
         let file = unit_path().expect("unit path");
         std::fs::create_dir_all(file.parent().expect("unit parent")).expect("create parent");
         std::fs::write(file, "unit").expect("write unit");
@@ -1443,13 +1350,6 @@ mod tests {
             ..RecordingRunner::default()
         };
         let result = status_with_runner(&mut runner);
-        // SAFETY: serialized by `lock_runtime_env`.
-        unsafe {
-            match prior {
-                Some(value) => std::env::set_var("HOME", value),
-                None => std::env::remove_var("HOME"),
-            }
-        }
 
         assert!(result.is_err());
     }
@@ -1460,9 +1360,7 @@ mod tests {
     fn restart_running_service_stops_then_starts() {
         let _lock = crate::runtime::test_env::lock_runtime_env();
         let tmp = tempfile::tempdir().expect("tempdir");
-        let prior = std::env::var_os("HOME");
-        // SAFETY: serialized by `lock_runtime_env`; restored below.
-        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let _home = TempHomeGuard::set(tmp.path());
         let file = unit_path().expect("unit path");
         std::fs::create_dir_all(file.parent().expect("unit parent")).expect("create parent");
         std::fs::write(&file, "unit").expect("write unit");
@@ -1471,13 +1369,6 @@ mod tests {
             ..RecordingRunner::default()
         };
         let result = restart_with_runner(&mut runner);
-        // SAFETY: serialized by `lock_runtime_env`.
-        unsafe {
-            match prior {
-                Some(value) => std::env::set_var("HOME", value),
-                None => std::env::remove_var("HOME"),
-            }
-        }
 
         result.expect("restart of a running service must succeed");
         assert_eq!(
@@ -1495,9 +1386,7 @@ mod tests {
     fn restart_stopped_service_just_starts() {
         let _lock = crate::runtime::test_env::lock_runtime_env();
         let tmp = tempfile::tempdir().expect("tempdir");
-        let prior = std::env::var_os("HOME");
-        // SAFETY: serialized by `lock_runtime_env`; restored below.
-        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let _home = TempHomeGuard::set(tmp.path());
         let file = unit_path().expect("unit path");
         std::fs::create_dir_all(file.parent().expect("unit parent")).expect("create parent");
         std::fs::write(&file, "unit").expect("write unit");
@@ -1506,13 +1395,6 @@ mod tests {
             ..RecordingRunner::default()
         };
         let result = restart_with_runner(&mut runner);
-        // SAFETY: serialized by `lock_runtime_env`.
-        unsafe {
-            match prior {
-                Some(value) => std::env::set_var("HOME", value),
-                None => std::env::remove_var("HOME"),
-            }
-        }
 
         result.expect("restart of a stopped service must succeed without error");
         assert_eq!(
@@ -1529,18 +1411,9 @@ mod tests {
     fn restart_not_installed_errors_with_install_guidance() {
         let _lock = crate::runtime::test_env::lock_runtime_env();
         let tmp = tempfile::tempdir().expect("tempdir");
-        let prior = std::env::var_os("HOME");
-        // SAFETY: serialized by `lock_runtime_env`; restored below.
-        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let _home = TempHomeGuard::set(tmp.path());
         let mut runner = RecordingRunner::default();
         let result = restart_with_runner(&mut runner);
-        // SAFETY: serialized by `lock_runtime_env`.
-        unsafe {
-            match prior {
-                Some(value) => std::env::set_var("HOME", value),
-                None => std::env::remove_var("HOME"),
-            }
-        }
 
         let error = result.expect_err("restart without an installed service must error");
         assert!(error.to_string().contains("service install"));
@@ -1551,9 +1424,7 @@ mod tests {
     fn restart_reports_stopped_when_start_fails_after_successful_stop() {
         let _lock = crate::runtime::test_env::lock_runtime_env();
         let tmp = tempfile::tempdir().expect("tempdir");
-        let prior = std::env::var_os("HOME");
-        // SAFETY: serialized by `lock_runtime_env`; restored below.
-        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let _home = TempHomeGuard::set(tmp.path());
         let file = unit_path().expect("unit path");
         std::fs::create_dir_all(file.parent().expect("unit parent")).expect("create parent");
         std::fs::write(&file, "unit").expect("write unit");
@@ -1563,13 +1434,6 @@ mod tests {
             ..RecordingRunner::default()
         };
         let result = restart_with_runner(&mut runner);
-        // SAFETY: serialized by `lock_runtime_env`.
-        unsafe {
-            match prior {
-                Some(value) => std::env::set_var("HOME", value),
-                None => std::env::remove_var("HOME"),
-            }
-        }
 
         let error = result.expect_err("failed start after successful stop must error");
         assert!(
@@ -1605,9 +1469,7 @@ mod tests {
     fn status_accepts_active_and_inactive_states_from_exact_show_command() {
         let _lock = crate::runtime::test_env::lock_runtime_env();
         let tmp = tempfile::tempdir().expect("tempdir");
-        let prior = std::env::var_os("HOME");
-        // SAFETY: serialized by `lock_runtime_env`; restored below.
-        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let _home = TempHomeGuard::set(tmp.path());
         let file = unit_path().expect("unit path");
         std::fs::create_dir_all(file.parent().expect("unit parent")).expect("create parent");
         std::fs::write(file, "unit").expect("write unit");
@@ -1636,13 +1498,6 @@ mod tests {
                     ]
                 ]
             );
-        }
-        // SAFETY: serialized by `lock_runtime_env`.
-        unsafe {
-            match prior {
-                Some(value) => std::env::set_var("HOME", value),
-                None => std::env::remove_var("HOME"),
-            }
         }
     }
 }

--- a/crates/ironclaw_reborn_cli/src/commands/service/systemd.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/service/systemd.rs
@@ -152,14 +152,13 @@ fn unit_path() -> Result<PathBuf> {
 
 // ── Verb bodies ─────────────────────────────────────────────────
 
-pub(super) fn install(invocation: &ServeInvocation) -> Result<()> {
-    install_with_runner(invocation, &mut OsServiceCommandRunner).map(|_replaced| ())
-}
-
 /// Returns whether a pre-existing unit file at the target path was
 /// replaced by this install (captured before the write). Exposed for
-/// tests; production wraps this via [`install`], which discards the
-/// bool once the advisory line has been printed.
+/// tests, and for `super::ServicePlatform::install_with_runner` (the
+/// runner-injectable install path driven by the `service install`
+/// preflight-warning integration test); production reaches this through
+/// [`super::ServicePlatform::install`], which discards the bool once the
+/// advisory line has been printed.
 pub(super) fn install_with_runner(
     invocation: &ServeInvocation,
     runner: &mut dyn ServiceCommandRunner,
@@ -411,6 +410,28 @@ fn rollback_uninstall(
 }
 
 pub(super) fn uninstall_with_runner(runner: &mut dyn ServiceCommandRunner) -> Result<()> {
+    uninstall_with_runner_and_remover(runner, remove_unit_file)
+}
+
+/// Non-generic wrapper around `std::fs::remove_file` so it can be named as
+/// a concrete `fn(&Path) -> io::Result<()>` pointer (the generic
+/// `std::fs::remove_file::<P: AsRef<Path>>` item cannot itself coerce to a
+/// fixed fn-pointer type without an instantiation hint).
+fn remove_unit_file(path: &Path) -> std::io::Result<()> {
+    std::fs::remove_file(path)
+}
+
+/// Same as [`uninstall_with_runner`] but with the unit-file removal step
+/// itself injectable, mirroring how [`ServiceCommandRunner`] is already
+/// injected for the `systemctl` calls. Lets a test force a `remove_file`
+/// failure deterministically — unlike locking down the parent directory's
+/// permission bits (0o555), which a root-running process (some CI
+/// containers) bypasses entirely, making that regression test a silent
+/// no-op instead of a real red-before-green check.
+fn uninstall_with_runner_and_remover(
+    runner: &mut dyn ServiceCommandRunner,
+    remove_file: fn(&Path) -> std::io::Result<()>,
+) -> Result<()> {
     let file = unit_path()?;
     let previous = match std::fs::read(&file) {
         Ok(contents) => Some(contents),
@@ -429,8 +450,7 @@ pub(super) fn uninstall_with_runner(runner: &mut dyn ServiceCommandRunner) -> Re
         )?;
     }
     if previous.is_some()
-        && let Err(error) =
-            std::fs::remove_file(&file).with_context(|| format!("remove {}", file.display()))
+        && let Err(error) = remove_file(&file).with_context(|| format!("remove {}", file.display()))
     {
         let rollback_errors = rollback_uninstall(&file, previous.as_deref(), manager_state, runner);
         return Err(combined_failure(error, rollback_errors));
@@ -1017,7 +1037,6 @@ mod tests {
         );
     }
 
-    #[cfg(unix)]
     #[test]
     fn uninstall_remove_file_failure_rolls_back_like_reload_failure() {
         // Before this fix, a `remove_file` error after a successful
@@ -1026,27 +1045,29 @@ mod tests {
         // enabled) never got re-enabled. This pins that the failure now
         // goes through the same rollback path as a daemon-reload
         // failure.
-        use std::os::unix::fs::PermissionsExt;
+        //
+        // The failure is injected through `uninstall_with_runner_and_remover`
+        // rather than by chmod-locking the parent directory: a
+        // root-running test process (some CI containers) bypasses
+        // directory permission checks entirely, which made the old
+        // version of this test a silent no-op instead of a real
+        // red-before-green regression check.
         let _lock = crate::runtime::test_env::lock_runtime_env();
         let tmp = tempfile::tempdir().expect("tempdir");
         let prior = std::env::var_os("HOME");
         // SAFETY: serialized by `lock_runtime_env`; restored below.
         unsafe { std::env::set_var("HOME", tmp.path()) };
         let file = unit_path().expect("unit path");
-        let parent = file.parent().expect("unit parent").to_path_buf();
-        std::fs::create_dir_all(&parent).expect("create parent");
+        std::fs::create_dir_all(file.parent().expect("unit parent")).expect("create parent");
         std::fs::write(&file, "previous unit").expect("write unit");
-        // Strip write+execute on the parent dir so `remove_file` fails
-        // with a permission error while the file itself remains readable.
-        std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o555))
-            .expect("lock parent dir");
         let mut runner = RecordingRunner {
             unit_state_output: Some("LoadState=loaded\nUnitFileState=enabled\n".to_string()),
             ..RecordingRunner::default()
         };
-        let result = uninstall_with_runner(&mut runner);
-        std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o755))
-            .expect("restore parent dir perms for cleanup");
+        fn failing_remove_file(_path: &Path) -> std::io::Result<()> {
+            Err(std::io::Error::other("injected remove_file failure"))
+        }
+        let result = uninstall_with_runner_and_remover(&mut runner, failing_remove_file);
         // SAFETY: serialized by `lock_runtime_env`.
         unsafe {
             match prior {
@@ -1055,12 +1076,23 @@ mod tests {
             }
         }
 
-        if result.is_ok() {
-            // Running as root (some CI containers) bypasses directory
-            // permission checks entirely, so `remove_file` can succeed
-            // even with the parent locked down. Nothing to assert then.
-            return;
-        }
+        let error = result.expect_err("an injected remove_file failure must propagate");
+        // `Display` on `anyhow::Error` only prints the outermost context
+        // (`remove <path>`); the alternate `{:#}` form walks the full
+        // source chain down to the injected io::Error's own message.
+        let rendered = format!("{error:#}");
+        assert!(
+            rendered.contains("injected remove_file failure"),
+            "error: {rendered}"
+        );
+        assert!(
+            file.exists(),
+            "the unit file rollback must restore it after a failed removal"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&file).expect("read restored unit"),
+            "previous unit"
+        );
         assert!(
             runner
                 .labels

--- a/crates/ironclaw_reborn_cli/src/commands/service/systemd.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/service/systemd.rs
@@ -239,6 +239,18 @@ pub(super) fn install_with_runner(
 }
 
 pub(super) fn start_with_runner(runner: &mut dyn ServiceCommandRunner) -> Result<()> {
+    start_with_runner_impl(runner, true)
+}
+
+/// Same start sequence, but without the "Service started" line — used by
+/// [`restart_with_runner`] via [`super::restart_generic`], which prints its
+/// own single restart summary instead of letting the inner start/stop calls
+/// print their own lines too.
+fn start_with_runner_quiet(runner: &mut dyn ServiceCommandRunner) -> Result<()> {
+    start_with_runner_impl(runner, false)
+}
+
+fn start_with_runner_impl(runner: &mut dyn ServiceCommandRunner, verbose: bool) -> Result<()> {
     if !unit_path()?.exists() {
         bail!("Service not installed. Run `ironclaw-reborn service install` first.");
     }
@@ -250,20 +262,36 @@ pub(super) fn start_with_runner(runner: &mut dyn ServiceCommandRunner) -> Result
         "systemctl start",
         Command::new("systemctl").args(["--user", "start", SYSTEMD_UNIT]),
     )?;
-    println!("Service started");
+    if verbose {
+        println!("Service started");
+    }
     Ok(())
 }
 
 pub(super) fn stop_with_runner(runner: &mut dyn ServiceCommandRunner) -> Result<()> {
+    stop_with_runner_impl(runner, true)
+}
+
+/// Same stop sequence, but without the "Service stopped" line — see
+/// [`start_with_runner_quiet`].
+fn stop_with_runner_quiet(runner: &mut dyn ServiceCommandRunner) -> Result<()> {
+    stop_with_runner_impl(runner, false)
+}
+
+fn stop_with_runner_impl(runner: &mut dyn ServiceCommandRunner, verbose: bool) -> Result<()> {
     if !unit_path()?.exists() {
-        println!("Service stopped");
+        if verbose {
+            println!("Service stopped");
+        }
         return Ok(());
     }
     runner.run_checked(
         "systemctl stop",
         Command::new("systemctl").args(["--user", "stop", SYSTEMD_UNIT]),
     )?;
-    println!("Service stopped");
+    if verbose {
+        println!("Service stopped");
+    }
     Ok(())
 }
 
@@ -290,8 +318,8 @@ pub(super) fn restart_with_runner(runner: &mut dyn ServiceCommandRunner) -> Resu
         runner,
         installed,
         was_running,
-        stop_with_runner,
-        start_with_runner,
+        stop_with_runner_quiet,
+        start_with_runner_quiet,
     )
 }
 

--- a/crates/ironclaw_reborn_cli/src/commands/service/systemd.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/service/systemd.rs
@@ -280,10 +280,18 @@ fn stop_with_runner_quiet(runner: &mut dyn ServiceCommandRunner) -> Result<()> {
 
 fn stop_with_runner_impl(runner: &mut dyn ServiceCommandRunner, verbose: bool) -> Result<()> {
     if !unit_path()?.exists() {
-        if verbose {
-            println!("Service stopped");
+        // The unit file is gone, but it may still be an orphan: removed
+        // out-of-band while systemd still shows it loaded/enabled (mirrors
+        // the manager-state check `status`/`uninstall` already do via
+        // `resolve_installed`/`query_unit_state`). Only skip the stop when
+        // the manager also shows nothing.
+        let unit_state = query_unit_state(runner)?;
+        if !unit_state.loaded && !unit_state.enabled {
+            if verbose {
+                println!("Service stopped");
+            }
+            return Ok(());
         }
-        return Ok(());
     }
     runner.run_checked(
         "systemctl stop",
@@ -1209,6 +1217,40 @@ mod tests {
 
         assert!(result.is_err());
         assert_eq!(runner.labels, ["systemctl stop"]);
+    }
+
+    #[test]
+    fn absent_stop_stops_loaded_or_enabled_manager_state() {
+        // Mirrors `absent_uninstall_disables_loaded_or_enabled_manager_state`:
+        // a unit file removed out-of-band while systemd still shows it
+        // loaded/enabled is an orphan that still needs tearing down. The old
+        // `stop_with_runner_impl` gated solely on `unit_path()?.exists()`,
+        // so this state printed "Service stopped" without ever calling
+        // `systemctl stop`.
+        let _lock = crate::runtime::test_env::lock_runtime_env();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let prior = std::env::var_os("HOME");
+        // SAFETY: serialized by `lock_runtime_env`; restored below.
+        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let mut runner = RecordingRunner {
+            unit_state_output: Some("LoadState=loaded\nUnitFileState=enabled\n".to_string()),
+            ..RecordingRunner::default()
+        };
+        let result = stop_with_runner(&mut runner);
+        // SAFETY: serialized by `lock_runtime_env`.
+        unsafe {
+            match prior {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+
+        result.expect("stop of an orphaned loaded unit succeeds");
+        assert_eq!(
+            runner.labels,
+            ["systemctl show unit state", "systemctl stop"],
+            "a unit file absent from disk but still loaded/enabled in the manager must still be stopped"
+        );
     }
 
     #[test]

--- a/crates/ironclaw_reborn_cli/src/commands/service/systemd.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/service/systemd.rs
@@ -146,11 +146,29 @@ fn combined_failure(primary: anyhow::Error, rollback_errors: Vec<String>) -> any
 // ── Path helpers ────────────────────────────────────────────────
 
 fn unit_path() -> Result<PathBuf> {
-    Ok(home_dir()?
-        .join(".config")
+    Ok(config_home()?
         .join("systemd")
         .join("user")
         .join(SYSTEMD_UNIT))
+}
+
+/// The base config directory for the user systemd unit search path, per
+/// systemd's own rule: prefer `$XDG_CONFIG_HOME` when it is set and
+/// non-empty, otherwise fall back to `$HOME/.config` (systemd's
+/// documented default when `XDG_CONFIG_HOME` is unset). An empty
+/// `XDG_CONFIG_HOME` is treated as unset, matching the XDG base directory
+/// spec.
+fn config_home() -> Result<PathBuf> {
+    match std::env::var_os("XDG_CONFIG_HOME") {
+        Some(value) if !value.is_empty() => {
+            let path = PathBuf::from(value);
+            if !path.is_absolute() {
+                bail!("XDG_CONFIG_HOME must be an absolute path to manage an OS service");
+            }
+            Ok(path)
+        }
+        _ => Ok(home_dir()?.join(".config")),
+    }
 }
 
 // ── Verb bodies ─────────────────────────────────────────────────
@@ -683,15 +701,87 @@ mod tests {
     #[test]
     fn unit_path_ends_with_expected_suffix() {
         let _lock = crate::runtime::test_env::lock_runtime_env();
-        let prior = std::env::var_os("HOME");
+        let prior_home = std::env::var_os("HOME");
+        let prior_xdg = std::env::var_os("XDG_CONFIG_HOME");
         // SAFETY: serialized by `lock_runtime_env`; restored before returning.
-        unsafe { std::env::set_var("HOME", "/home/op") };
+        unsafe {
+            std::env::set_var("HOME", "/home/op");
+            std::env::remove_var("XDG_CONFIG_HOME");
+        }
         let path = unit_path();
         // SAFETY: see above.
         unsafe {
-            match prior {
+            match prior_home {
                 Some(v) => std::env::set_var("HOME", v),
                 None => std::env::remove_var("HOME"),
+            }
+            match prior_xdg {
+                Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
+                None => std::env::remove_var("XDG_CONFIG_HOME"),
+            }
+        }
+        assert_eq!(
+            path.expect("must resolve"),
+            PathBuf::from("/home/op/.config/systemd/user/ironclaw-reborn.service")
+        );
+    }
+
+    #[test]
+    fn unit_path_honors_xdg_config_home_when_set_and_nonempty() {
+        // RED-then-green: systemd's user-unit search path prefers
+        // `$XDG_CONFIG_HOME/systemd/user` over `$HOME/.config/systemd/user`
+        // when `XDG_CONFIG_HOME` is set and non-empty. Before this fix,
+        // `unit_path()` ignored `XDG_CONFIG_HOME` entirely and always wrote
+        // under `$HOME/.config`, which a systemd install with a customized
+        // `XDG_CONFIG_HOME` would never look at.
+        let _lock = crate::runtime::test_env::lock_runtime_env();
+        let prior_home = std::env::var_os("HOME");
+        let prior_xdg = std::env::var_os("XDG_CONFIG_HOME");
+        // SAFETY: serialized by `lock_runtime_env`; restored before returning.
+        unsafe {
+            std::env::set_var("HOME", "/home/op");
+            std::env::set_var("XDG_CONFIG_HOME", "/custom/xdg-config");
+        }
+        let path = unit_path();
+        // SAFETY: see above.
+        unsafe {
+            match prior_home {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+            match prior_xdg {
+                Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
+                None => std::env::remove_var("XDG_CONFIG_HOME"),
+            }
+        }
+        assert_eq!(
+            path.expect("must resolve"),
+            PathBuf::from("/custom/xdg-config/systemd/user/ironclaw-reborn.service")
+        );
+    }
+
+    #[test]
+    fn unit_path_falls_back_to_home_config_when_xdg_config_home_is_empty() {
+        // An empty `XDG_CONFIG_HOME` must be treated as unset (XDG base
+        // directory spec), not as a literal empty-string base path.
+        let _lock = crate::runtime::test_env::lock_runtime_env();
+        let prior_home = std::env::var_os("HOME");
+        let prior_xdg = std::env::var_os("XDG_CONFIG_HOME");
+        // SAFETY: serialized by `lock_runtime_env`; restored before returning.
+        unsafe {
+            std::env::set_var("HOME", "/home/op");
+            std::env::set_var("XDG_CONFIG_HOME", "");
+        }
+        let path = unit_path();
+        // SAFETY: see above.
+        unsafe {
+            match prior_home {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+            match prior_xdg {
+                Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
+                None => std::env::remove_var("XDG_CONFIG_HOME"),
             }
         }
         assert_eq!(

--- a/crates/ironclaw_reborn_cli/src/commands/service/systemd.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/service/systemd.rs
@@ -1,0 +1,1031 @@
+//! Linux systemd user-unit generators, path resolution, and verb
+//! bodies for `ironclaw-reborn service`.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use anyhow::{Context, Result, bail};
+
+use crate::serve_invocation::ServeInvocation;
+
+use super::{OsServiceCommandRunner, SYSTEMD_UNIT, ServiceCommandRunner, home_dir};
+
+// ── Quoting ─────────────────────────────────────────────────────
+
+fn unit_quote(value: &str, escape_dollar: bool) -> Result<String> {
+    let mut escaped = String::with_capacity(value.len() + 2);
+    escaped.push('"');
+    for character in value.chars() {
+        match character {
+            '\0' => bail!("systemd unit value contains NUL"),
+            '\\' => escaped.push_str("\\\\"),
+            '"' => escaped.push_str("\\\""),
+            '\n' => escaped.push_str("\\n"),
+            '\r' => escaped.push_str("\\r"),
+            '\t' => escaped.push_str("\\t"),
+            '%' => escaped.push_str("%%"),
+            '$' if escape_dollar => escaped.push_str("$$"),
+            character if character.is_control() => {
+                bail!("systemd unit value contains unsupported control character")
+            }
+            character => escaped.push(character),
+        }
+    }
+    escaped.push('"');
+    Ok(escaped)
+}
+
+// ── Unit generation ─────────────────────────────────────────────
+
+fn unit_content(invocation: &ServeInvocation) -> Result<String> {
+    let environment_lines = invocation
+        .env
+        .iter()
+        .map(|(key, value)| {
+            unit_quote(&format!("{key}={value}"), false)
+                .map(|value| format!("Environment={value}\n"))
+        })
+        .collect::<Result<String>>()?;
+
+    let exec_start_args = std::iter::once(invocation.exe.display().to_string())
+        .chain(invocation.args.iter().cloned())
+        .map(|value| unit_quote(&value, true))
+        .collect::<Result<Vec<_>>>()?
+        .join(" ");
+
+    Ok(format!(
+        "[Unit]\n\
+         Description=IronClaw Reborn daemon\n\
+         After=network.target\n\
+         \n\
+         [Service]\n\
+         Type=simple\n\
+         {environment_lines}\
+         ExecStart={exec_start_args}\n\
+         Restart=always\n\
+         RestartSec=3\n\
+         \n\
+         [Install]\n\
+         WantedBy=default.target\n",
+    ))
+}
+
+static TEMP_FILE_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn write_atomic(path: &Path, contents: &[u8]) -> Result<()> {
+    let parent = path
+        .parent()
+        .context("systemd unit path has no parent directory")?;
+    for _ in 0..16 {
+        let suffix = TEMP_FILE_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let temp = parent.join(format!(
+            ".{SYSTEMD_UNIT}.tmp-{}-{suffix}",
+            std::process::id()
+        ));
+        let mut options = std::fs::OpenOptions::new();
+        options.write(true).create_new(true);
+        let mut file = match options.open(&temp) {
+            Ok(file) => file,
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(error).with_context(|| format!("create {}", temp.display())),
+        };
+        let result = (|| -> Result<()> {
+            file.write_all(contents)
+                .with_context(|| format!("write {}", temp.display()))?;
+            file.sync_all()
+                .with_context(|| format!("sync {}", temp.display()))?;
+            std::fs::rename(&temp, path).with_context(|| format!("replace {}", path.display()))?;
+            Ok(())
+        })();
+        if result.is_err() {
+            let _ = std::fs::remove_file(&temp);
+        }
+        return result;
+    }
+    bail!("could not allocate temporary systemd unit file")
+}
+
+fn restore_previous_unit(path: &Path, previous: Option<&[u8]>) -> Result<()> {
+    match previous {
+        Some(contents) => write_atomic(path, contents),
+        None if path.exists() => {
+            std::fs::remove_file(path).with_context(|| format!("remove {}", path.display()))
+        }
+        None => Ok(()),
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct SystemdUnitState {
+    loaded: bool,
+    enabled: bool,
+}
+
+fn query_unit_state(runner: &mut dyn ServiceCommandRunner) -> Result<SystemdUnitState> {
+    let output = runner.run_capture_checked(
+        "systemctl show unit state",
+        Command::new("systemctl").args([
+            "--user",
+            "show",
+            "--property=LoadState",
+            "--property=UnitFileState",
+            "--value",
+            SYSTEMD_UNIT,
+        ]),
+    )?;
+    let mut lines = output.split('\n');
+    let load_state = lines.next().unwrap_or_default().trim();
+    let unit_file_state = lines.next().unwrap_or_default().trim();
+    Ok(SystemdUnitState {
+        loaded: !matches!(load_state, "" | "not-found"),
+        enabled: matches!(
+            unit_file_state,
+            "enabled" | "enabled-runtime" | "linked" | "linked-runtime" | "alias"
+        ),
+    })
+}
+
+fn combined_failure(primary: anyhow::Error, rollback_errors: Vec<String>) -> anyhow::Error {
+    if rollback_errors.is_empty() {
+        primary
+    } else {
+        anyhow::anyhow!(
+            "{primary:#}; rollback failures: {}",
+            rollback_errors.join("; ")
+        )
+    }
+}
+
+// ── Path helpers ────────────────────────────────────────────────
+
+fn unit_path() -> Result<PathBuf> {
+    Ok(home_dir()?
+        .join(".config")
+        .join("systemd")
+        .join("user")
+        .join(SYSTEMD_UNIT))
+}
+
+// ── Verb bodies ─────────────────────────────────────────────────
+
+pub(super) fn install(invocation: &ServeInvocation) -> Result<()> {
+    install_with_runner(invocation, &mut OsServiceCommandRunner)
+}
+
+pub(super) fn install_with_runner(
+    invocation: &ServeInvocation,
+    runner: &mut dyn ServiceCommandRunner,
+) -> Result<()> {
+    let file = unit_path()?;
+    if let Some(parent) = file.parent() {
+        std::fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
+    }
+    let previous = match std::fs::read(&file) {
+        Ok(contents) => Some(contents),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+        Err(error) => return Err(error).with_context(|| format!("read {}", file.display())),
+    };
+    let unit = unit_content(invocation)?;
+    let previous_state = query_unit_state(runner)?;
+    write_atomic(&file, unit.as_bytes())?;
+    if let Err(error) = runner.run_checked(
+        "systemctl daemon-reload",
+        Command::new("systemctl").args(["--user", "daemon-reload"]),
+    ) {
+        let mut rollback_errors = Vec::new();
+        if let Err(rollback) = restore_previous_unit(&file, previous.as_deref()) {
+            rollback_errors.push(format!("restore unit: {rollback:#}"));
+        }
+        if let Err(rollback) = runner.run_checked(
+            "systemctl rollback daemon-reload",
+            Command::new("systemctl").args(["--user", "daemon-reload"]),
+        ) {
+            rollback_errors.push(format!("reload restored unit: {rollback:#}"));
+        }
+        return Err(combined_failure(error, rollback_errors));
+    }
+    if let Err(error) = runner.run_checked(
+        "systemctl enable",
+        Command::new("systemctl").args(["--user", "enable", SYSTEMD_UNIT]),
+    ) {
+        let mut rollback_errors = Vec::new();
+        if let Err(rollback) = runner.run_checked(
+            "systemctl rollback disable",
+            Command::new("systemctl").args(["--user", "disable", SYSTEMD_UNIT]),
+        ) {
+            rollback_errors.push(format!("disable partially enabled unit: {rollback:#}"));
+        }
+        if let Err(rollback) = restore_previous_unit(&file, previous.as_deref()) {
+            rollback_errors.push(format!("restore unit: {rollback:#}"));
+        }
+        if let Err(rollback) = runner.run_checked(
+            "systemctl rollback daemon-reload",
+            Command::new("systemctl").args(["--user", "daemon-reload"]),
+        ) {
+            rollback_errors.push(format!("reload restored unit: {rollback:#}"));
+        }
+        if previous_state.enabled
+            && let Err(rollback) = runner.run_checked(
+                "systemctl rollback enable previous unit",
+                Command::new("systemctl").args(["--user", "enable", SYSTEMD_UNIT]),
+            )
+        {
+            rollback_errors.push(format!("re-enable previous unit: {rollback:#}"));
+        }
+        return Err(combined_failure(error, rollback_errors));
+    }
+    println!("Installed systemd user service: {}", file.display());
+    println!("  Start with: ironclaw-reborn service start");
+    Ok(())
+}
+
+pub(super) fn start() -> Result<()> {
+    start_with_runner(&mut OsServiceCommandRunner)
+}
+
+fn start_with_runner(runner: &mut dyn ServiceCommandRunner) -> Result<()> {
+    if !unit_path()?.exists() {
+        bail!("Service not installed. Run `ironclaw-reborn service install` first.");
+    }
+    runner.run_checked(
+        "systemctl daemon-reload",
+        Command::new("systemctl").args(["--user", "daemon-reload"]),
+    )?;
+    runner.run_checked(
+        "systemctl start",
+        Command::new("systemctl").args(["--user", "start", SYSTEMD_UNIT]),
+    )?;
+    println!("Service started");
+    Ok(())
+}
+
+pub(super) fn stop() -> Result<()> {
+    stop_with_runner(&mut OsServiceCommandRunner)
+}
+
+fn stop_with_runner(runner: &mut dyn ServiceCommandRunner) -> Result<()> {
+    if !unit_path()?.exists() {
+        println!("Service stopped");
+        return Ok(());
+    }
+    runner.run_checked(
+        "systemctl stop",
+        Command::new("systemctl").args(["--user", "stop", SYSTEMD_UNIT]),
+    )?;
+    println!("Service stopped");
+    Ok(())
+}
+
+pub(super) fn status() -> Result<()> {
+    status_with_runner(&mut OsServiceCommandRunner)
+}
+
+fn status_with_runner(runner: &mut dyn ServiceCommandRunner) -> Result<()> {
+    let file = unit_path()?;
+    if !file.exists() {
+        println!("Service state: not installed");
+        println!("Unit: {}", file.display());
+        return Ok(());
+    }
+    // `is-active` uses non-zero exits for ordinary inactive states. `show`
+    // returns those states in stdout and reserves failure for a broken query.
+    let state = runner.run_capture_checked(
+        "systemctl show ActiveState",
+        Command::new("systemctl").args([
+            "--user",
+            "show",
+            "--property=ActiveState",
+            "--value",
+            SYSTEMD_UNIT,
+        ]),
+    )?;
+    println!("Service state: {}", state.trim());
+    println!("Unit: {}", file.display());
+    Ok(())
+}
+
+pub(super) fn uninstall() -> Result<()> {
+    uninstall_with_runner(&mut OsServiceCommandRunner)
+}
+
+pub(super) fn uninstall_with_runner(runner: &mut dyn ServiceCommandRunner) -> Result<()> {
+    let file = unit_path()?;
+    let previous = match std::fs::read(&file) {
+        Ok(contents) => Some(contents),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+        Err(error) => return Err(error).with_context(|| format!("read {}", file.display())),
+    };
+    let manager_state = query_unit_state(runner)?;
+    if previous.is_none() && !manager_state.loaded && !manager_state.enabled {
+        println!("Service uninstalled ({})", file.display());
+        return Ok(());
+    }
+    if manager_state.loaded || manager_state.enabled {
+        runner.run_checked(
+            "systemctl disable",
+            Command::new("systemctl").args(["--user", "disable", "--now", SYSTEMD_UNIT]),
+        )?;
+    }
+    if previous.is_some() {
+        std::fs::remove_file(&file).with_context(|| format!("remove {}", file.display()))?;
+    }
+    if let Err(error) = runner.run_checked(
+        "systemctl daemon-reload",
+        Command::new("systemctl").args(["--user", "daemon-reload"]),
+    ) {
+        let mut rollback_errors = Vec::new();
+        if let Err(rollback) = restore_previous_unit(&file, previous.as_deref()) {
+            rollback_errors.push(format!("restore unit: {rollback:#}"));
+        }
+        if let Err(rollback) = runner.run_checked(
+            "systemctl rollback daemon-reload",
+            Command::new("systemctl").args(["--user", "daemon-reload"]),
+        ) {
+            rollback_errors.push(format!("reload restored unit: {rollback:#}"));
+        }
+        if manager_state.enabled
+            && let Err(rollback) = runner.run_checked(
+                "systemctl rollback enable previous unit",
+                Command::new("systemctl").args(["--user", "enable", SYSTEMD_UNIT]),
+            )
+        {
+            rollback_errors.push(format!("re-enable previous unit: {rollback:#}"));
+        }
+        return Err(combined_failure(error, rollback_errors));
+    }
+    println!("Service uninstalled ({})", file.display());
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Default)]
+    struct RecordingRunner {
+        labels: Vec<String>,
+        args: Vec<Vec<String>>,
+        fail_args: Option<Vec<&'static str>>,
+        fail_nth_args: Option<(Vec<&'static str>, usize)>,
+        fail_capture_args: Option<Vec<&'static str>>,
+        unit_state_output: Option<String>,
+        active_state_output: Option<String>,
+    }
+
+    impl ServiceCommandRunner for RecordingRunner {
+        fn run_checked(&mut self, label: &str, command: &mut Command) -> Result<()> {
+            self.labels.push(label.to_string());
+            self.args.push(
+                command
+                    .get_args()
+                    .map(|arg| arg.to_string_lossy().into_owned())
+                    .collect(),
+            );
+            if self.fail_args.as_ref().is_some_and(|expected| {
+                command
+                    .get_args()
+                    .map(|arg| arg.to_string_lossy())
+                    .eq(expected.iter().copied())
+            }) {
+                anyhow::bail!("injected argv failure: {label}");
+            }
+            if let Some((expected, occurrence)) = self.fail_nth_args.as_ref() {
+                let current_args = self.args.last().cloned().unwrap_or_default();
+                let seen = self
+                    .args
+                    .iter()
+                    .filter(|args| *args == &current_args)
+                    .count();
+                if current_args
+                    .iter()
+                    .map(String::as_str)
+                    .eq(expected.iter().copied())
+                    && seen == *occurrence
+                {
+                    anyhow::bail!("injected nth argv failure: {label}");
+                }
+            }
+            Ok(())
+        }
+
+        fn run_capture_checked(&mut self, label: &str, command: &mut Command) -> Result<String> {
+            self.labels.push(label.to_string());
+            self.args.push(
+                command
+                    .get_args()
+                    .map(|arg| arg.to_string_lossy().into_owned())
+                    .collect(),
+            );
+            if self.fail_capture_args.as_ref().is_some_and(|expected| {
+                command
+                    .get_args()
+                    .map(|arg| arg.to_string_lossy())
+                    .eq(expected.iter().copied())
+            }) {
+                anyhow::bail!("injected argv capture failure: {label}");
+            }
+            let args = self.args.last().cloned().unwrap_or_default();
+            match args.as_slice() {
+                [user, show, load, unit_file, value, unit]
+                    if user == "--user"
+                        && show == "show"
+                        && load == "--property=LoadState"
+                        && unit_file == "--property=UnitFileState"
+                        && value == "--value"
+                        && unit == SYSTEMD_UNIT =>
+                {
+                    Ok(self
+                        .unit_state_output
+                        .clone()
+                        .unwrap_or_else(|| "not-found\n\n".to_string()))
+                }
+                [user, show, property, value, unit]
+                    if user == "--user"
+                        && show == "show"
+                        && property == "--property=ActiveState"
+                        && value == "--value"
+                        && unit == SYSTEMD_UNIT =>
+                {
+                    Ok(self
+                        .active_state_output
+                        .clone()
+                        .unwrap_or_else(|| "inactive\n".to_string()))
+                }
+                _ => anyhow::bail!("unexpected capture argv: {args:?}"),
+            }
+        }
+    }
+
+    fn sample_invocation() -> ServeInvocation {
+        ServeInvocation {
+            exe: PathBuf::from("/usr/local/bin/ironclaw-reborn"),
+            args: vec!["serve".to_string()],
+            env: vec![(
+                "IRONCLAW_REBORN_HOME".to_string(),
+                "/home/op/.ironclaw/reborn".to_string(),
+            )],
+        }
+    }
+
+    #[test]
+    fn unit_quote_escapes_backslash_and_double_quote() {
+        assert_eq!(
+            unit_quote(r#"a"b\c"#, false).expect("valid value"),
+            r#""a\"b\\c""#
+        );
+    }
+
+    #[test]
+    fn unit_quote_escapes_directive_and_exec_expansion_syntax() {
+        assert_eq!(
+            unit_quote("line\n%h$HOME", true).expect("valid exec value"),
+            "\"line\\n%%h$$HOME\""
+        );
+        assert_eq!(
+            unit_quote("value%h$HOME", false).expect("valid environment value"),
+            "\"value%%h$HOME\""
+        );
+        assert!(unit_quote("bad\0value", false).is_err());
+    }
+
+    #[test]
+    fn unit_content_includes_service_type() {
+        let unit = unit_content(&sample_invocation()).expect("valid unit");
+        assert!(unit.contains("Type=simple"));
+    }
+
+    #[test]
+    fn unit_content_includes_exec_start_tokens() {
+        let unit = unit_content(&sample_invocation()).expect("valid unit");
+        assert!(unit.contains(r#""/usr/local/bin/ironclaw-reborn""#));
+        assert!(unit.contains(r#""serve""#));
+    }
+
+    #[test]
+    fn unit_content_includes_environment_line() {
+        let unit = unit_content(&sample_invocation()).expect("valid unit");
+        assert!(unit.contains(r#"Environment="IRONCLAW_REBORN_HOME=/home/op/.ironclaw/reborn""#));
+    }
+
+    #[test]
+    fn unit_content_includes_restart_policy_and_install_target() {
+        let unit = unit_content(&sample_invocation()).expect("valid unit");
+        assert!(unit.contains("Restart=always"));
+        assert!(unit.contains("RestartSec=3"));
+        assert!(unit.contains("WantedBy=default.target"));
+    }
+
+    #[test]
+    fn unit_content_escapes_quotes_in_env_value() {
+        let invocation = ServeInvocation {
+            exe: PathBuf::from("/usr/local/bin/ironclaw-reborn"),
+            args: vec!["serve".to_string()],
+            env: vec![(
+                "IRONCLAW_REBORN_PROFILE".to_string(),
+                r#"has"quote"#.to_string(),
+            )],
+        };
+        let unit = unit_content(&invocation).expect("valid unit");
+        assert!(unit.contains(r#"IRONCLAW_REBORN_PROFILE=has\"quote"#));
+    }
+
+    #[test]
+    fn unit_content_cannot_inject_directives_through_newlines() {
+        let invocation = ServeInvocation {
+            exe: PathBuf::from("/opt/%n/$bin\nInjected=true"),
+            args: vec!["serve\nEnvironment=EVIL=yes".to_string()],
+            env: vec![(
+                "IRONCLAW_REBORN_PROFILE".to_string(),
+                "safe\nExecStart=/bin/evil%h".to_string(),
+            )],
+        };
+        let unit = unit_content(&invocation).expect("escaped unit");
+
+        assert!(
+            unit.contains(r#"Environment="IRONCLAW_REBORN_PROFILE=safe\nExecStart=/bin/evil%%h""#)
+        );
+        assert!(unit.contains(r#""/opt/%%n/$$bin\nInjected=true""#));
+        assert!(unit.contains(r#""serve\nEnvironment=EVIL=yes""#));
+        assert!(!unit.lines().any(|line| line == "Injected=true"));
+        assert!(!unit.lines().any(|line| line == "Environment=EVIL=yes"));
+    }
+
+    #[test]
+    fn unit_path_ends_with_expected_suffix() {
+        let _lock = crate::runtime::test_env::lock_runtime_env();
+        let prior = std::env::var_os("HOME");
+        // SAFETY: serialized by `lock_runtime_env`; restored before returning.
+        unsafe { std::env::set_var("HOME", "/home/op") };
+        let path = unit_path();
+        // SAFETY: see above.
+        unsafe {
+            match prior {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+        assert_eq!(
+            path.expect("must resolve"),
+            PathBuf::from("/home/op/.config/systemd/user/ironclaw-reborn.service")
+        );
+    }
+
+    #[test]
+    fn install_propagates_daemon_reload_failure_before_enable() {
+        let _lock = crate::runtime::test_env::lock_runtime_env();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let prior = std::env::var_os("HOME");
+        // SAFETY: serialized by `lock_runtime_env`; restored below.
+        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let mut runner = RecordingRunner {
+            fail_args: Some(vec!["--user", "daemon-reload"]),
+            ..RecordingRunner::default()
+        };
+        let result = install_with_runner(&sample_invocation(), &mut runner);
+        // SAFETY: serialized by `lock_runtime_env`.
+        unsafe {
+            match prior {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+
+        assert!(result.is_err());
+        assert_eq!(
+            runner.labels,
+            [
+                "systemctl show unit state",
+                "systemctl daemon-reload",
+                "systemctl rollback daemon-reload"
+            ]
+        );
+    }
+
+    #[test]
+    fn install_propagates_enable_failure() {
+        let _lock = crate::runtime::test_env::lock_runtime_env();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let prior = std::env::var_os("HOME");
+        // SAFETY: serialized by `lock_runtime_env`; restored below.
+        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let mut runner = RecordingRunner {
+            fail_nth_args: Some((vec!["--user", "enable", SYSTEMD_UNIT], 1)),
+            ..RecordingRunner::default()
+        };
+        let result = install_with_runner(&sample_invocation(), &mut runner);
+        // SAFETY: serialized by `lock_runtime_env`.
+        unsafe {
+            match prior {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+
+        assert!(result.is_err());
+        assert_eq!(
+            runner.labels,
+            [
+                "systemctl show unit state",
+                "systemctl daemon-reload",
+                "systemctl enable",
+                "systemctl rollback disable",
+                "systemctl rollback daemon-reload"
+            ]
+        );
+        assert_eq!(
+            runner.args[3],
+            ["--user", "disable", SYSTEMD_UNIT],
+            "a possibly partial enable must be compensated before file rollback"
+        );
+    }
+
+    #[test]
+    fn uninstall_disables_before_removing_and_reloading() {
+        let _lock = crate::runtime::test_env::lock_runtime_env();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let prior = std::env::var_os("HOME");
+        // SAFETY: serialized by `lock_runtime_env`; restored below.
+        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let file = unit_path().expect("unit path");
+        std::fs::create_dir_all(file.parent().expect("unit parent")).expect("create parent");
+        std::fs::write(&file, "unit").expect("write unit");
+        let mut runner = RecordingRunner {
+            unit_state_output: Some("loaded\nenabled\n".to_string()),
+            ..RecordingRunner::default()
+        };
+        let result = uninstall_with_runner(&mut runner);
+        // SAFETY: serialized by `lock_runtime_env`.
+        unsafe {
+            match prior {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+
+        result.expect("uninstall succeeds");
+        assert!(!file.exists());
+        assert_eq!(
+            runner.labels,
+            [
+                "systemctl show unit state",
+                "systemctl disable",
+                "systemctl daemon-reload"
+            ]
+        );
+        assert_eq!(runner.args[1], ["--user", "disable", "--now", SYSTEMD_UNIT]);
+    }
+
+    #[test]
+    fn uninstall_disable_failure_preserves_unit_file() {
+        let _lock = crate::runtime::test_env::lock_runtime_env();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let prior = std::env::var_os("HOME");
+        // SAFETY: serialized by `lock_runtime_env`; restored below.
+        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let file = unit_path().expect("unit path");
+        std::fs::create_dir_all(file.parent().expect("unit parent")).expect("create parent");
+        std::fs::write(&file, "unit").expect("write unit");
+        let mut runner = RecordingRunner {
+            fail_args: Some(vec!["--user", "disable", "--now", SYSTEMD_UNIT]),
+            unit_state_output: Some("loaded\nenabled\n".to_string()),
+            ..RecordingRunner::default()
+        };
+        let result = uninstall_with_runner(&mut runner);
+        // SAFETY: serialized by `lock_runtime_env`.
+        unsafe {
+            match prior {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+
+        assert!(result.is_err());
+        assert!(file.exists(), "failed disable must not remove the unit");
+        assert_eq!(
+            runner.labels,
+            ["systemctl show unit state", "systemctl disable"]
+        );
+    }
+
+    #[test]
+    fn failed_reinstall_restores_previous_unit() {
+        let _lock = crate::runtime::test_env::lock_runtime_env();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let prior = std::env::var_os("HOME");
+        // SAFETY: serialized by `lock_runtime_env`; restored below.
+        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let file = unit_path().expect("unit path");
+        std::fs::create_dir_all(file.parent().expect("unit parent")).expect("create parent");
+        std::fs::write(&file, "previous unit").expect("write previous unit");
+        let mut runner = RecordingRunner {
+            unit_state_output: Some("loaded\nenabled\n".to_string()),
+            fail_nth_args: Some((vec!["--user", "enable", SYSTEMD_UNIT], 1)),
+            ..RecordingRunner::default()
+        };
+        let result = install_with_runner(&sample_invocation(), &mut runner);
+        // SAFETY: serialized by `lock_runtime_env`.
+        unsafe {
+            match prior {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+
+        assert!(result.is_err());
+        assert_eq!(
+            std::fs::read_to_string(file).expect("restored unit"),
+            "previous unit"
+        );
+        assert_eq!(
+            runner.args,
+            [
+                vec![
+                    "--user",
+                    "show",
+                    "--property=LoadState",
+                    "--property=UnitFileState",
+                    "--value",
+                    SYSTEMD_UNIT,
+                ],
+                vec!["--user", "daemon-reload"],
+                vec!["--user", "enable", SYSTEMD_UNIT],
+                vec!["--user", "disable", SYSTEMD_UNIT],
+                vec!["--user", "daemon-reload"],
+                vec!["--user", "enable", SYSTEMD_UNIT],
+            ]
+        );
+    }
+
+    #[test]
+    fn failed_reinstall_does_not_enable_previously_disabled_unit() {
+        let _lock = crate::runtime::test_env::lock_runtime_env();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let prior = std::env::var_os("HOME");
+        // SAFETY: serialized by `lock_runtime_env`; restored below.
+        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let file = unit_path().expect("unit path");
+        std::fs::create_dir_all(file.parent().expect("unit parent")).expect("create parent");
+        std::fs::write(&file, "previous unit").expect("write previous unit");
+        let mut runner = RecordingRunner {
+            unit_state_output: Some("loaded\ndisabled\n".to_string()),
+            fail_nth_args: Some((vec!["--user", "enable", SYSTEMD_UNIT], 1)),
+            ..RecordingRunner::default()
+        };
+        let result = install_with_runner(&sample_invocation(), &mut runner);
+        // SAFETY: serialized by `lock_runtime_env`.
+        unsafe {
+            match prior {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+
+        assert!(result.is_err());
+        assert_eq!(
+            std::fs::read_to_string(file).expect("restored unit"),
+            "previous unit"
+        );
+        assert_eq!(
+            runner.args,
+            [
+                vec![
+                    "--user",
+                    "show",
+                    "--property=LoadState",
+                    "--property=UnitFileState",
+                    "--value",
+                    SYSTEMD_UNIT,
+                ],
+                vec!["--user", "daemon-reload"],
+                vec!["--user", "enable", SYSTEMD_UNIT],
+                vec!["--user", "disable", SYSTEMD_UNIT],
+                vec!["--user", "daemon-reload"],
+            ]
+        );
+    }
+
+    #[test]
+    fn absent_uninstall_queries_manager_then_no_ops_when_not_found() {
+        let _lock = crate::runtime::test_env::lock_runtime_env();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let prior = std::env::var_os("HOME");
+        // SAFETY: serialized by `lock_runtime_env`; restored below.
+        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let mut runner = RecordingRunner::default();
+        let result = uninstall_with_runner(&mut runner);
+        // SAFETY: serialized by `lock_runtime_env`.
+        unsafe {
+            match prior {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+
+        result.expect("absent uninstall succeeds");
+        assert_eq!(runner.labels, ["systemctl show unit state"]);
+    }
+
+    #[test]
+    fn absent_uninstall_disables_loaded_or_enabled_manager_state() {
+        let _lock = crate::runtime::test_env::lock_runtime_env();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let prior = std::env::var_os("HOME");
+        // SAFETY: serialized by `lock_runtime_env`; restored below.
+        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let mut runner = RecordingRunner {
+            unit_state_output: Some("loaded\nenabled\n".to_string()),
+            ..RecordingRunner::default()
+        };
+        let result = uninstall_with_runner(&mut runner);
+        // SAFETY: serialized by `lock_runtime_env`.
+        unsafe {
+            match prior {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+
+        result.expect("orphan manager state uninstall succeeds");
+        assert_eq!(
+            runner.args,
+            [
+                vec![
+                    "--user",
+                    "show",
+                    "--property=LoadState",
+                    "--property=UnitFileState",
+                    "--value",
+                    SYSTEMD_UNIT,
+                ],
+                vec!["--user", "disable", "--now", SYSTEMD_UNIT],
+                vec!["--user", "daemon-reload"],
+            ]
+        );
+    }
+
+    #[test]
+    fn enable_failure_reports_compensating_reload_failure_with_primary_error() {
+        let _lock = crate::runtime::test_env::lock_runtime_env();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let prior = std::env::var_os("HOME");
+        // SAFETY: serialized by `lock_runtime_env`; restored below.
+        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let mut runner = RecordingRunner {
+            fail_args: Some(vec!["--user", "enable", SYSTEMD_UNIT]),
+            fail_nth_args: Some((vec!["--user", "daemon-reload"], 2)),
+            ..RecordingRunner::default()
+        };
+        let error = install_with_runner(&sample_invocation(), &mut runner)
+            .expect_err("enable and compensating reload failure must surface");
+        // SAFETY: serialized by `lock_runtime_env`.
+        unsafe {
+            match prior {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+
+        let rendered = error.to_string();
+        assert!(rendered.contains("systemctl enable"), "{rendered}");
+        assert!(rendered.contains("reload restored unit"), "{rendered}");
+        assert!(rendered.contains("rollback failures"), "{rendered}");
+    }
+
+    #[test]
+    fn uninstall_reload_failure_restores_unit_for_recovery() {
+        let _lock = crate::runtime::test_env::lock_runtime_env();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let prior = std::env::var_os("HOME");
+        // SAFETY: serialized by `lock_runtime_env`; restored below.
+        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let file = unit_path().expect("unit path");
+        std::fs::create_dir_all(file.parent().expect("unit parent")).expect("create parent");
+        std::fs::write(&file, "previous unit").expect("write unit");
+        let mut runner = RecordingRunner {
+            unit_state_output: Some("loaded\nenabled\n".to_string()),
+            fail_nth_args: Some((vec!["--user", "daemon-reload"], 1)),
+            ..RecordingRunner::default()
+        };
+        let result = uninstall_with_runner(&mut runner);
+        // SAFETY: serialized by `lock_runtime_env`.
+        unsafe {
+            match prior {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+
+        assert!(result.is_err());
+        assert_eq!(
+            std::fs::read_to_string(file).expect("restored unit"),
+            "previous unit"
+        );
+        assert!(
+            runner
+                .labels
+                .contains(&"systemctl rollback daemon-reload".to_string())
+        );
+        assert!(
+            runner
+                .labels
+                .contains(&"systemctl rollback enable previous unit".to_string())
+        );
+    }
+
+    #[test]
+    fn stop_propagates_service_manager_failure_when_unit_exists() {
+        let _lock = crate::runtime::test_env::lock_runtime_env();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let prior = std::env::var_os("HOME");
+        // SAFETY: serialized by `lock_runtime_env`; restored below.
+        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let file = unit_path().expect("unit path");
+        std::fs::create_dir_all(file.parent().expect("unit parent")).expect("create parent");
+        std::fs::write(file, "unit").expect("write unit");
+        let mut runner = RecordingRunner {
+            fail_args: Some(vec!["--user", "stop", SYSTEMD_UNIT]),
+            ..RecordingRunner::default()
+        };
+        let result = stop_with_runner(&mut runner);
+        // SAFETY: serialized by `lock_runtime_env`.
+        unsafe {
+            match prior {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+
+        assert!(result.is_err());
+        assert_eq!(runner.labels, ["systemctl stop"]);
+    }
+
+    #[test]
+    fn status_propagates_capture_failure() {
+        let _lock = crate::runtime::test_env::lock_runtime_env();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let prior = std::env::var_os("HOME");
+        // SAFETY: serialized by `lock_runtime_env`; restored below.
+        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let file = unit_path().expect("unit path");
+        std::fs::create_dir_all(file.parent().expect("unit parent")).expect("create parent");
+        std::fs::write(file, "unit").expect("write unit");
+        let mut runner = RecordingRunner {
+            fail_capture_args: Some(vec![
+                "--user",
+                "show",
+                "--property=ActiveState",
+                "--value",
+                SYSTEMD_UNIT,
+            ]),
+            ..RecordingRunner::default()
+        };
+        let result = status_with_runner(&mut runner);
+        // SAFETY: serialized by `lock_runtime_env`.
+        unsafe {
+            match prior {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn status_accepts_active_and_inactive_states_from_exact_show_command() {
+        let _lock = crate::runtime::test_env::lock_runtime_env();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let prior = std::env::var_os("HOME");
+        // SAFETY: serialized by `lock_runtime_env`; restored below.
+        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let file = unit_path().expect("unit path");
+        std::fs::create_dir_all(file.parent().expect("unit parent")).expect("create parent");
+        std::fs::write(file, "unit").expect("write unit");
+        for state in ["active\n", "inactive\n"] {
+            let mut runner = RecordingRunner {
+                active_state_output: Some(state.to_string()),
+                ..RecordingRunner::default()
+            };
+            status_with_runner(&mut runner).expect("status succeeds");
+            assert_eq!(
+                runner.args,
+                [vec![
+                    "--user",
+                    "show",
+                    "--property=ActiveState",
+                    "--value",
+                    SYSTEMD_UNIT,
+                ]]
+            );
+        }
+        // SAFETY: serialized by `lock_runtime_env`.
+        unsafe {
+            match prior {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+    }
+}

--- a/crates/ironclaw_reborn_cli/src/commands/service/systemd.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/service/systemd.rs
@@ -129,14 +129,17 @@ fn query_unit_state(runner: &mut dyn ServiceCommandRunner) -> Result<SystemdUnit
     })
 }
 
+/// Combines a primary operation failure with any errors hit while rolling
+/// back its partial effects. The primary is kept as the error's `source()`
+/// (via `.context()`) rather than flattened into a single formatted string,
+/// so an operator inspecting the chain (`{:?}`/`{:#}`/`.source()`) can still
+/// see the underlying cause (e.g. permission-denied vs. disk-full) beneath
+/// the rollback outcome, instead of losing it inside one opaque message.
 fn combined_failure(primary: anyhow::Error, rollback_errors: Vec<String>) -> anyhow::Error {
     if rollback_errors.is_empty() {
         primary
     } else {
-        anyhow::anyhow!(
-            "{primary:#}; rollback failures: {}",
-            rollback_errors.join("; ")
-        )
+        primary.context(format!("rollback failures: {}", rollback_errors.join("; ")))
     }
 }
 
@@ -990,10 +993,56 @@ mod tests {
             }
         }
 
+        // Top-level `Display` (`to_string()`) now only shows the rollback
+        // context, matching anyhow's chain convention; the primary failure
+        // lives in `source()`/`{:#}` — see `enable_failure_preserves_primary_error_as_source`.
         let rendered = error.to_string();
-        assert!(rendered.contains("systemctl enable"), "{rendered}");
-        assert!(rendered.contains("reload restored unit"), "{rendered}");
         assert!(rendered.contains("rollback failures"), "{rendered}");
+        assert!(rendered.contains("reload restored unit"), "{rendered}");
+
+        let chained = format!("{error:#}");
+        assert!(chained.contains("systemctl enable"), "{chained}");
+        assert!(chained.contains("reload restored unit"), "{chained}");
+        assert!(chained.contains("rollback failures"), "{chained}");
+    }
+
+    #[test]
+    fn enable_failure_preserves_primary_error_as_source() {
+        // RED-then-green regression for the reviewer-flagged flattening bug:
+        // `combined_failure` used to fold the primary error into a single
+        // formatted string via `anyhow!("{primary:#}; ...")`, which drops
+        // the source chain entirely (`.source()` was `None`). An operator
+        // could no longer tell a permission-denied primary failure apart
+        // from a disk-full one once a rollback step also failed. This
+        // asserts the primary is preserved as the combined error's source.
+        let _lock = crate::runtime::test_env::lock_runtime_env();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let prior = std::env::var_os("HOME");
+        // SAFETY: serialized by `lock_runtime_env`; restored below.
+        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let mut runner = RecordingRunner {
+            fail_args: Some(vec!["--user", "enable", SYSTEMD_UNIT]),
+            fail_nth_args: Some((vec!["--user", "daemon-reload"], 2)),
+            ..RecordingRunner::default()
+        };
+        let error = install_with_runner(&sample_invocation(), &mut runner)
+            .expect_err("enable and compensating reload failure must surface");
+        // SAFETY: serialized by `lock_runtime_env`.
+        unsafe {
+            match prior {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+
+        let source = error
+            .source()
+            .expect("combined failure must retain a source chain");
+        let source_text = format!("{source:#}");
+        assert!(
+            source_text.contains("systemctl enable"),
+            "primary error text must survive under source(): {source_text}"
+        );
     }
 
     #[test]

--- a/crates/ironclaw_reborn_cli/src/commands/service/systemd.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/service/systemd.rs
@@ -1,10 +1,8 @@
 //! Linux systemd user-unit generators, path resolution, and verb
 //! bodies for `ironclaw-reborn service`.
 
-use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::sync::atomic::{AtomicU64, Ordering};
 
 use anyhow::{Context, Result, bail};
 
@@ -72,44 +70,9 @@ fn unit_content(invocation: &ServeInvocation) -> Result<String> {
     ))
 }
 
-static TEMP_FILE_COUNTER: AtomicU64 = AtomicU64::new(0);
-
-fn write_atomic(path: &Path, contents: &[u8]) -> Result<()> {
-    let parent = path
-        .parent()
-        .context("systemd unit path has no parent directory")?;
-    for _ in 0..16 {
-        let suffix = TEMP_FILE_COUNTER.fetch_add(1, Ordering::Relaxed);
-        let temp = parent.join(format!(
-            ".{SYSTEMD_UNIT}.tmp-{}-{suffix}",
-            std::process::id()
-        ));
-        let mut options = std::fs::OpenOptions::new();
-        options.write(true).create_new(true);
-        let mut file = match options.open(&temp) {
-            Ok(file) => file,
-            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
-            Err(error) => return Err(error).with_context(|| format!("create {}", temp.display())),
-        };
-        let result = (|| -> Result<()> {
-            file.write_all(contents)
-                .with_context(|| format!("write {}", temp.display()))?;
-            file.sync_all()
-                .with_context(|| format!("sync {}", temp.display()))?;
-            std::fs::rename(&temp, path).with_context(|| format!("replace {}", path.display()))?;
-            Ok(())
-        })();
-        if result.is_err() {
-            let _ = std::fs::remove_file(&temp);
-        }
-        return result;
-    }
-    bail!("could not allocate temporary systemd unit file")
-}
-
 fn restore_previous_unit(path: &Path, previous: Option<&[u8]>) -> Result<()> {
     match previous {
-        Some(contents) => write_atomic(path, contents),
+        Some(contents) => super::write_atomic(path, contents),
         None if path.exists() => {
             std::fs::remove_file(path).with_context(|| format!("remove {}", path.display()))
         }
@@ -189,7 +152,7 @@ pub(super) fn install_with_runner(
     };
     let unit = unit_content(invocation)?;
     let previous_state = query_unit_state(runner)?;
-    write_atomic(&file, unit.as_bytes())?;
+    super::write_atomic(&file, unit.as_bytes())?;
     if let Err(error) = runner.run_checked(
         "systemctl daemon-reload",
         Command::new("systemctl").args(["--user", "daemon-reload"]),
@@ -282,44 +245,32 @@ pub(super) fn restart() -> Result<()> {
     restart_with_runner(&mut OsServiceCommandRunner)
 }
 
-/// Composes [`stop_with_runner`] and [`start_with_runner`]: a running
-/// service is stopped then started, an already-stopped service is just
-/// started, and a start failure after a successful stop is reported as
-/// leaving the service stopped rather than a silent half-restart.
+/// Detects install/running state, then delegates the stop/start decision
+/// tree to [`super::restart_generic`], which both platforms share.
 fn restart_with_runner(runner: &mut dyn ServiceCommandRunner) -> Result<()> {
-    if !unit_path()?.exists() {
-        bail!("Service not installed. Run `ironclaw-reborn service install` first.");
-    }
-    let active_state = runner.run_capture_checked(
-        "systemctl show ActiveState",
-        Command::new("systemctl").args([
-            "--user",
-            "show",
-            "--property=ActiveState",
-            "--value",
-            SYSTEMD_UNIT,
-        ]),
-    )?;
-    let was_running = active_state.trim() == "active";
-
-    if was_running {
-        stop_with_runner(runner)?;
-    }
-    if let Err(start_error) = start_with_runner(runner) {
-        if was_running {
-            bail!(
-                "service restart: stop succeeded but start failed; the service is now \
-                 STOPPED: {start_error:#}"
-            );
-        }
-        return Err(start_error);
-    }
-    if was_running {
-        println!("Service restarted");
+    let installed = unit_path()?.exists();
+    let was_running = if installed {
+        let active_state = runner.run_capture_checked(
+            "systemctl show ActiveState",
+            Command::new("systemctl").args([
+                "--user",
+                "show",
+                "--property=ActiveState",
+                "--value",
+                SYSTEMD_UNIT,
+            ]),
+        )?;
+        active_state.trim() == "active"
     } else {
-        println!("Service was not running; started");
-    }
-    Ok(())
+        false
+    };
+    super::restart_generic(
+        runner,
+        installed,
+        was_running,
+        stop_with_runner,
+        start_with_runner,
+    )
 }
 
 pub(super) fn status() -> Result<()> {
@@ -328,24 +279,26 @@ pub(super) fn status() -> Result<()> {
 
 fn status_with_runner(runner: &mut dyn ServiceCommandRunner) -> Result<()> {
     let file = unit_path()?;
-    if !file.exists() {
-        println!("Service state: not installed");
-        println!("Unit: {}", file.display());
-        return Ok(());
-    }
-    // `is-active` uses non-zero exits for ordinary inactive states. `show`
-    // returns those states in stdout and reserves failure for a broken query.
-    let state = runner.run_capture_checked(
-        "systemctl show ActiveState",
-        Command::new("systemctl").args([
-            "--user",
-            "show",
-            "--property=ActiveState",
-            "--value",
-            SYSTEMD_UNIT,
-        ]),
-    )?;
-    println!("Service state: {}", state.trim());
+    let installed = file.exists();
+    let running = if installed {
+        // `is-active` uses non-zero exits for ordinary inactive states.
+        // `show` returns those states in stdout and reserves failure for a
+        // broken query.
+        let state = runner.run_capture_checked(
+            "systemctl show ActiveState",
+            Command::new("systemctl").args([
+                "--user",
+                "show",
+                "--property=ActiveState",
+                "--value",
+                SYSTEMD_UNIT,
+            ]),
+        )?;
+        state.trim() == "active"
+    } else {
+        false
+    };
+    println!("Service: {}", super::status_label(installed, running));
     println!("Unit: {}", file.display());
     Ok(())
 }
@@ -1003,6 +956,30 @@ mod tests {
 
         assert!(result.is_err());
         assert_eq!(runner.labels, ["systemctl stop"]);
+    }
+
+    #[test]
+    fn status_reports_not_installed_and_skips_systemctl_query_when_unit_absent() {
+        let _lock = crate::runtime::test_env::lock_runtime_env();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let prior = std::env::var_os("HOME");
+        // SAFETY: serialized by `lock_runtime_env`; restored below.
+        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let mut runner = RecordingRunner::default();
+        let result = status_with_runner(&mut runner);
+        // SAFETY: serialized by `lock_runtime_env`.
+        unsafe {
+            match prior {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+
+        result.expect("status succeeds when not installed");
+        assert!(
+            runner.labels.is_empty(),
+            "must not query systemctl when the unit file is absent"
+        );
     }
 
     #[test]

--- a/crates/ironclaw_reborn_cli/src/commands/service/systemd.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/service/systemd.rs
@@ -153,13 +153,17 @@ fn unit_path() -> Result<PathBuf> {
 // ── Verb bodies ─────────────────────────────────────────────────
 
 pub(super) fn install(invocation: &ServeInvocation) -> Result<()> {
-    install_with_runner(invocation, &mut OsServiceCommandRunner)
+    install_with_runner(invocation, &mut OsServiceCommandRunner).map(|_replaced| ())
 }
 
+/// Returns whether a pre-existing unit file at the target path was
+/// replaced by this install (captured before the write). Exposed for
+/// tests; production wraps this via [`install`], which discards the
+/// bool once the advisory line has been printed.
 pub(super) fn install_with_runner(
     invocation: &ServeInvocation,
     runner: &mut dyn ServiceCommandRunner,
-) -> Result<()> {
+) -> Result<bool> {
     let file = unit_path()?;
     if let Some(parent) = file.parent() {
         std::fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
@@ -169,6 +173,12 @@ pub(super) fn install_with_runner(
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
         Err(error) => return Err(error).with_context(|| format!("read {}", file.display())),
     };
+    // Captured before the write: a pre-existing file at this path may
+    // have been installed by this CLI's own prior run, or by the WebUI
+    // operator facade (`RebornLocalServiceLifecycle`) — both surfaces
+    // target the same unit name/path by design (see the module doc). The
+    // write below atomically replaces it.
+    let replaced_existing = previous.is_some();
     let unit = unit_content(invocation)?;
     let previous_state = query_unit_state(runner)?;
     super::write_atomic(&file, unit.as_bytes())?;
@@ -219,8 +229,11 @@ pub(super) fn install_with_runner(
         return Err(combined_failure(error, rollback_errors));
     }
     println!("Installed systemd user service: {}", file.display());
+    if let Some(note) = super::replaced_existing_service_file_note(replaced_existing) {
+        println!("{note}");
+    }
     println!("  Start with: ironclaw-reborn service start");
-    Ok(())
+    Ok(replaced_existing)
 }
 
 pub(super) fn start() -> Result<()> {

--- a/crates/ironclaw_reborn_cli/src/commands/service/systemd.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/service/systemd.rs
@@ -8,7 +8,7 @@ use anyhow::{Context, Result, bail};
 
 use crate::serve_invocation::ServeInvocation;
 
-use super::{OsServiceCommandRunner, SYSTEMD_UNIT, ServiceCommandRunner, home_dir};
+use super::{SYSTEMD_UNIT, ServiceCommandRunner, home_dir};
 
 // ── Quoting ─────────────────────────────────────────────────────
 
@@ -238,11 +238,7 @@ pub(super) fn install_with_runner(
     Ok(replaced_existing)
 }
 
-pub(super) fn start() -> Result<()> {
-    start_with_runner(&mut OsServiceCommandRunner)
-}
-
-fn start_with_runner(runner: &mut dyn ServiceCommandRunner) -> Result<()> {
+pub(super) fn start_with_runner(runner: &mut dyn ServiceCommandRunner) -> Result<()> {
     if !unit_path()?.exists() {
         bail!("Service not installed. Run `ironclaw-reborn service install` first.");
     }
@@ -258,11 +254,7 @@ fn start_with_runner(runner: &mut dyn ServiceCommandRunner) -> Result<()> {
     Ok(())
 }
 
-pub(super) fn stop() -> Result<()> {
-    stop_with_runner(&mut OsServiceCommandRunner)
-}
-
-fn stop_with_runner(runner: &mut dyn ServiceCommandRunner) -> Result<()> {
+pub(super) fn stop_with_runner(runner: &mut dyn ServiceCommandRunner) -> Result<()> {
     if !unit_path()?.exists() {
         println!("Service stopped");
         return Ok(());
@@ -275,13 +267,9 @@ fn stop_with_runner(runner: &mut dyn ServiceCommandRunner) -> Result<()> {
     Ok(())
 }
 
-pub(super) fn restart() -> Result<()> {
-    restart_with_runner(&mut OsServiceCommandRunner)
-}
-
 /// Detects install/running state, then delegates the stop/start decision
 /// tree to [`super::restart_generic`], which both platforms share.
-fn restart_with_runner(runner: &mut dyn ServiceCommandRunner) -> Result<()> {
+pub(super) fn restart_with_runner(runner: &mut dyn ServiceCommandRunner) -> Result<()> {
     let installed = unit_path()?.exists();
     let was_running = if installed {
         let active_state = runner.run_capture_checked(
@@ -305,10 +293,6 @@ fn restart_with_runner(runner: &mut dyn ServiceCommandRunner) -> Result<()> {
         stop_with_runner,
         start_with_runner,
     )
-}
-
-pub(super) fn status() -> Result<()> {
-    status_with_runner(&mut OsServiceCommandRunner)
 }
 
 /// Secondary detail line for a non-`active` raw `ActiveState`, e.g. a
@@ -337,7 +321,7 @@ fn resolve_installed(file_exists: bool, unit_state: SystemdUnitState) -> bool {
     file_exists || unit_state.loaded || unit_state.enabled
 }
 
-fn status_with_runner(runner: &mut dyn ServiceCommandRunner) -> Result<()> {
+pub(super) fn status_with_runner(runner: &mut dyn ServiceCommandRunner) -> Result<()> {
     let file = unit_path()?;
     let file_exists = file.exists();
     // Query the manager unconditionally — a unit file removed out-of-band
@@ -374,10 +358,6 @@ fn status_with_runner(runner: &mut dyn ServiceCommandRunner) -> Result<()> {
     }
     println!("Unit: {}", file.display());
     Ok(())
-}
-
-pub(super) fn uninstall() -> Result<()> {
-    uninstall_with_runner(&mut OsServiceCommandRunner)
 }
 
 /// Shared uninstall rollback: restore the previous unit file (or remove
@@ -446,11 +426,14 @@ fn uninstall_with_runner_and_remover(
         println!("Service uninstalled ({})", file.display());
         return Ok(());
     }
-    if manager_state.loaded || manager_state.enabled {
-        runner.run_checked(
+    if (manager_state.loaded || manager_state.enabled)
+        && let Err(error) = runner.run_checked(
             "systemctl disable",
             Command::new("systemctl").args(["--user", "disable", "--now", SYSTEMD_UNIT]),
-        )?;
+        )
+    {
+        let rollback_errors = rollback_uninstall(&file, previous.as_deref(), manager_state, runner);
+        return Err(combined_failure(error, rollback_errors));
     }
     if previous.is_some()
         && let Err(error) = remove_file(&file).with_context(|| format!("remove {}", file.display()))
@@ -787,7 +770,14 @@ mod tests {
     }
 
     #[test]
-    fn uninstall_disable_failure_preserves_unit_file() {
+    fn uninstall_disable_failure_rolls_back_like_reload_failure() {
+        // Before this fix, a `disable --now` error propagated with a bare
+        // `?` and no rollback, unlike every sibling failure branch in this
+        // function (remove_file, daemon-reload), which routes through
+        // `rollback_uninstall` + `combined_failure`. A disable failure can
+        // leave the unit partially disabled with no compensating
+        // daemon-reload/re-enable, so this pins that it now goes through
+        // the same rollback path as the other two.
         let _lock = crate::runtime::test_env::lock_runtime_env();
         let tmp = tempfile::tempdir().expect("tempdir");
         let prior = std::env::var_os("HOME");
@@ -810,11 +800,19 @@ mod tests {
             }
         }
 
-        assert!(result.is_err());
+        let error = result.expect_err("a failed disable must propagate");
         assert!(file.exists(), "failed disable must not remove the unit");
+        let rendered = format!("{error:#}");
+        assert!(rendered.contains("systemctl disable"), "{rendered}");
         assert_eq!(
             runner.labels,
-            ["systemctl show unit state", "systemctl disable"]
+            [
+                "systemctl show unit state",
+                "systemctl disable",
+                "systemctl rollback daemon-reload",
+                "systemctl rollback enable previous unit",
+            ],
+            "a disable failure must run the same rollback sequence as a reload failure"
         );
     }
 

--- a/crates/ironclaw_reborn_cli/src/commands/service/systemd.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/service/systemd.rs
@@ -86,6 +86,14 @@ struct SystemdUnitState {
     enabled: bool,
 }
 
+/// Query `LoadState`/`UnitFileState` and parse them as `Key=Value` lines
+/// (no `--value`, so the output is self-describing and order-independent
+/// — `--value` alone would print bare values in property-declaration
+/// order, which is undocumented and not guaranteed to be stable across
+/// systemd versions). A required key missing from the output is an
+/// error, not a silently-assumed default: a malformed/truncated response
+/// must not read as `enabled=false`, which would make an install-failure
+/// rollback skip re-enabling a unit that actually was enabled.
 fn query_unit_state(runner: &mut dyn ServiceCommandRunner) -> Result<SystemdUnitState> {
     let output = runner.run_capture_checked(
         "systemctl show unit state",
@@ -94,13 +102,24 @@ fn query_unit_state(runner: &mut dyn ServiceCommandRunner) -> Result<SystemdUnit
             "show",
             "--property=LoadState",
             "--property=UnitFileState",
-            "--value",
             SYSTEMD_UNIT,
         ]),
     )?;
-    let mut lines = output.split('\n');
-    let load_state = lines.next().unwrap_or_default().trim();
-    let unit_file_state = lines.next().unwrap_or_default().trim();
+    let mut load_state = None;
+    let mut unit_file_state = None;
+    for line in output.lines() {
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        match key {
+            "LoadState" => load_state = Some(value.trim()),
+            "UnitFileState" => unit_file_state = Some(value.trim()),
+            _ => {}
+        }
+    }
+    let load_state = load_state.context("systemctl show output missing LoadState=... line")?;
+    let unit_file_state =
+        unit_file_state.context("systemctl show output missing UnitFileState=... line")?;
     Ok(SystemdUnitState {
         loaded: !matches!(load_state, "" | "not-found"),
         enabled: matches!(
@@ -295,28 +314,44 @@ fn systemd_status_detail(raw_state: &str) -> Option<String> {
     }
 }
 
+/// Whether `service status` should report the service as installed:
+/// either the unit file exists, or systemd still shows it loaded or
+/// enabled (an orphan left behind after the unit file was removed
+/// out-of-band).
+fn resolve_installed(file_exists: bool, unit_state: SystemdUnitState) -> bool {
+    file_exists || unit_state.loaded || unit_state.enabled
+}
+
 fn status_with_runner(runner: &mut dyn ServiceCommandRunner) -> Result<()> {
     let file = unit_path()?;
-    let installed = file.exists();
-    let mut detail = None;
-    let running = if installed {
-        // `is-active` uses non-zero exits for ordinary inactive states.
-        // `show` returns those states in stdout and reserves failure for a
-        // broken query.
-        let state = runner.run_capture_checked(
-            "systemctl show ActiveState",
-            Command::new("systemctl").args([
-                "--user",
-                "show",
-                "--property=ActiveState",
-                "--value",
-                SYSTEMD_UNIT,
-            ]),
-        )?;
-        detail = systemd_status_detail(&state);
-        state.trim() == "active"
+    let file_exists = file.exists();
+    // Query the manager unconditionally — a unit file removed out-of-band
+    // while systemd still has it loaded/enabled is an orphan we must
+    // still report as installed, not silently claim "not installed".
+    let unit_state = query_unit_state(runner)?;
+    // `is-active` uses non-zero exits for ordinary inactive states.
+    // `show` returns those states in stdout and reserves failure for a
+    // broken query.
+    let active_state = runner.run_capture_checked(
+        "systemctl show ActiveState",
+        Command::new("systemctl").args([
+            "--user",
+            "show",
+            "--property=ActiveState",
+            "--value",
+            SYSTEMD_UNIT,
+        ]),
+    )?;
+    let running = active_state.trim() == "active";
+    let installed = resolve_installed(file_exists, unit_state);
+    // Detail line stays keyed off file presence: for a genuine orphan
+    // (no unit file) the `Service: running/stopped` line already covers
+    // it, and there's no installed-config context to attach the raw
+    // ActiveState to.
+    let detail = if file_exists {
+        systemd_status_detail(&active_state)
     } else {
-        false
+        None
     };
     println!("Service: {}", super::status_label(installed, running));
     if let Some(detail) = detail {
@@ -328,6 +363,38 @@ fn status_with_runner(runner: &mut dyn ServiceCommandRunner) -> Result<()> {
 
 pub(super) fn uninstall() -> Result<()> {
     uninstall_with_runner(&mut OsServiceCommandRunner)
+}
+
+/// Shared uninstall rollback: restore the previous unit file (or remove
+/// it if there was none), reload the manager, and — if the unit was
+/// previously enabled — re-enable it. Used by both the `remove_file`
+/// failure path and the `daemon-reload` failure path, which must leave
+/// the host in the same recovered state regardless of which step failed.
+fn rollback_uninstall(
+    file: &Path,
+    previous: Option<&[u8]>,
+    manager_state: SystemdUnitState,
+    runner: &mut dyn ServiceCommandRunner,
+) -> Vec<String> {
+    let mut rollback_errors = Vec::new();
+    if let Err(rollback) = restore_previous_unit(file, previous) {
+        rollback_errors.push(format!("restore unit: {rollback:#}"));
+    }
+    if let Err(rollback) = runner.run_checked(
+        "systemctl rollback daemon-reload",
+        Command::new("systemctl").args(["--user", "daemon-reload"]),
+    ) {
+        rollback_errors.push(format!("reload restored unit: {rollback:#}"));
+    }
+    if manager_state.enabled
+        && let Err(rollback) = runner.run_checked(
+            "systemctl rollback enable previous unit",
+            Command::new("systemctl").args(["--user", "enable", SYSTEMD_UNIT]),
+        )
+    {
+        rollback_errors.push(format!("re-enable previous unit: {rollback:#}"));
+    }
+    rollback_errors
 }
 
 pub(super) fn uninstall_with_runner(runner: &mut dyn ServiceCommandRunner) -> Result<()> {
@@ -348,31 +415,18 @@ pub(super) fn uninstall_with_runner(runner: &mut dyn ServiceCommandRunner) -> Re
             Command::new("systemctl").args(["--user", "disable", "--now", SYSTEMD_UNIT]),
         )?;
     }
-    if previous.is_some() {
-        std::fs::remove_file(&file).with_context(|| format!("remove {}", file.display()))?;
+    if previous.is_some()
+        && let Err(error) =
+            std::fs::remove_file(&file).with_context(|| format!("remove {}", file.display()))
+    {
+        let rollback_errors = rollback_uninstall(&file, previous.as_deref(), manager_state, runner);
+        return Err(combined_failure(error, rollback_errors));
     }
     if let Err(error) = runner.run_checked(
         "systemctl daemon-reload",
         Command::new("systemctl").args(["--user", "daemon-reload"]),
     ) {
-        let mut rollback_errors = Vec::new();
-        if let Err(rollback) = restore_previous_unit(&file, previous.as_deref()) {
-            rollback_errors.push(format!("restore unit: {rollback:#}"));
-        }
-        if let Err(rollback) = runner.run_checked(
-            "systemctl rollback daemon-reload",
-            Command::new("systemctl").args(["--user", "daemon-reload"]),
-        ) {
-            rollback_errors.push(format!("reload restored unit: {rollback:#}"));
-        }
-        if manager_state.enabled
-            && let Err(rollback) = runner.run_checked(
-                "systemctl rollback enable previous unit",
-                Command::new("systemctl").args(["--user", "enable", SYSTEMD_UNIT]),
-            )
-        {
-            rollback_errors.push(format!("re-enable previous unit: {rollback:#}"));
-        }
+        let rollback_errors = rollback_uninstall(&file, previous.as_deref(), manager_state, runner);
         return Err(combined_failure(error, rollback_errors));
     }
     println!("Service uninstalled ({})", file.display());
@@ -448,18 +502,17 @@ mod tests {
             }
             let args = self.args.last().cloned().unwrap_or_default();
             match args.as_slice() {
-                [user, show, load, unit_file, value, unit]
+                [user, show, load, unit_file, unit]
                     if user == "--user"
                         && show == "show"
                         && load == "--property=LoadState"
                         && unit_file == "--property=UnitFileState"
-                        && value == "--value"
                         && unit == SYSTEMD_UNIT =>
                 {
                     Ok(self
                         .unit_state_output
                         .clone()
-                        .unwrap_or_else(|| "not-found\n\n".to_string()))
+                        .unwrap_or_else(|| "LoadState=not-found\nUnitFileState=\n".to_string()))
                 }
                 [user, show, property, value, unit]
                     if user == "--user"
@@ -672,7 +725,7 @@ mod tests {
         std::fs::create_dir_all(file.parent().expect("unit parent")).expect("create parent");
         std::fs::write(&file, "unit").expect("write unit");
         let mut runner = RecordingRunner {
-            unit_state_output: Some("loaded\nenabled\n".to_string()),
+            unit_state_output: Some("LoadState=loaded\nUnitFileState=enabled\n".to_string()),
             ..RecordingRunner::default()
         };
         let result = uninstall_with_runner(&mut runner);
@@ -709,7 +762,7 @@ mod tests {
         std::fs::write(&file, "unit").expect("write unit");
         let mut runner = RecordingRunner {
             fail_args: Some(vec!["--user", "disable", "--now", SYSTEMD_UNIT]),
-            unit_state_output: Some("loaded\nenabled\n".to_string()),
+            unit_state_output: Some("LoadState=loaded\nUnitFileState=enabled\n".to_string()),
             ..RecordingRunner::default()
         };
         let result = uninstall_with_runner(&mut runner);
@@ -740,7 +793,7 @@ mod tests {
         std::fs::create_dir_all(file.parent().expect("unit parent")).expect("create parent");
         std::fs::write(&file, "previous unit").expect("write previous unit");
         let mut runner = RecordingRunner {
-            unit_state_output: Some("loaded\nenabled\n".to_string()),
+            unit_state_output: Some("LoadState=loaded\nUnitFileState=enabled\n".to_string()),
             fail_nth_args: Some((vec!["--user", "enable", SYSTEMD_UNIT], 1)),
             ..RecordingRunner::default()
         };
@@ -766,7 +819,6 @@ mod tests {
                     "show",
                     "--property=LoadState",
                     "--property=UnitFileState",
-                    "--value",
                     SYSTEMD_UNIT,
                 ],
                 vec!["--user", "daemon-reload"],
@@ -789,7 +841,7 @@ mod tests {
         std::fs::create_dir_all(file.parent().expect("unit parent")).expect("create parent");
         std::fs::write(&file, "previous unit").expect("write previous unit");
         let mut runner = RecordingRunner {
-            unit_state_output: Some("loaded\ndisabled\n".to_string()),
+            unit_state_output: Some("LoadState=loaded\nUnitFileState=disabled\n".to_string()),
             fail_nth_args: Some((vec!["--user", "enable", SYSTEMD_UNIT], 1)),
             ..RecordingRunner::default()
         };
@@ -815,7 +867,6 @@ mod tests {
                     "show",
                     "--property=LoadState",
                     "--property=UnitFileState",
-                    "--value",
                     SYSTEMD_UNIT,
                 ],
                 vec!["--user", "daemon-reload"],
@@ -855,7 +906,7 @@ mod tests {
         // SAFETY: serialized by `lock_runtime_env`; restored below.
         unsafe { std::env::set_var("HOME", tmp.path()) };
         let mut runner = RecordingRunner {
-            unit_state_output: Some("loaded\nenabled\n".to_string()),
+            unit_state_output: Some("LoadState=loaded\nUnitFileState=enabled\n".to_string()),
             ..RecordingRunner::default()
         };
         let result = uninstall_with_runner(&mut runner);
@@ -876,7 +927,6 @@ mod tests {
                     "show",
                     "--property=LoadState",
                     "--property=UnitFileState",
-                    "--value",
                     SYSTEMD_UNIT,
                 ],
                 vec!["--user", "disable", "--now", SYSTEMD_UNIT],
@@ -924,7 +974,7 @@ mod tests {
         std::fs::create_dir_all(file.parent().expect("unit parent")).expect("create parent");
         std::fs::write(&file, "previous unit").expect("write unit");
         let mut runner = RecordingRunner {
-            unit_state_output: Some("loaded\nenabled\n".to_string()),
+            unit_state_output: Some("LoadState=loaded\nUnitFileState=enabled\n".to_string()),
             fail_nth_args: Some((vec!["--user", "daemon-reload"], 1)),
             ..RecordingRunner::default()
         };
@@ -951,6 +1001,66 @@ mod tests {
             runner
                 .labels
                 .contains(&"systemctl rollback enable previous unit".to_string())
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn uninstall_remove_file_failure_rolls_back_like_reload_failure() {
+        // Before this fix, a `remove_file` error after a successful
+        // `disable` propagated with a bare `?` and no rollback: the unit
+        // stayed disabled with no unit file, and (if it had been
+        // enabled) never got re-enabled. This pins that the failure now
+        // goes through the same rollback path as a daemon-reload
+        // failure.
+        use std::os::unix::fs::PermissionsExt;
+        let _lock = crate::runtime::test_env::lock_runtime_env();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let prior = std::env::var_os("HOME");
+        // SAFETY: serialized by `lock_runtime_env`; restored below.
+        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let file = unit_path().expect("unit path");
+        let parent = file.parent().expect("unit parent").to_path_buf();
+        std::fs::create_dir_all(&parent).expect("create parent");
+        std::fs::write(&file, "previous unit").expect("write unit");
+        // Strip write+execute on the parent dir so `remove_file` fails
+        // with a permission error while the file itself remains readable.
+        std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o555))
+            .expect("lock parent dir");
+        let mut runner = RecordingRunner {
+            unit_state_output: Some("LoadState=loaded\nUnitFileState=enabled\n".to_string()),
+            ..RecordingRunner::default()
+        };
+        let result = uninstall_with_runner(&mut runner);
+        std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o755))
+            .expect("restore parent dir perms for cleanup");
+        // SAFETY: serialized by `lock_runtime_env`.
+        unsafe {
+            match prior {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+
+        if result.is_ok() {
+            // Running as root (some CI containers) bypasses directory
+            // permission checks entirely, so `remove_file` can succeed
+            // even with the parent locked down. Nothing to assert then.
+            return;
+        }
+        assert!(
+            runner
+                .labels
+                .contains(&"systemctl rollback daemon-reload".to_string()),
+            "remove_file failure must roll back like a reload failure: {:?}",
+            runner.labels
+        );
+        assert!(
+            runner
+                .labels
+                .contains(&"systemctl rollback enable previous unit".to_string()),
+            "a previously-enabled unit must be re-enabled during rollback: {:?}",
+            runner.labels
         );
     }
 
@@ -982,7 +1092,13 @@ mod tests {
     }
 
     #[test]
-    fn status_reports_not_installed_and_skips_systemctl_query_when_unit_absent() {
+    fn status_queries_systemctl_unconditionally_and_reports_not_installed_when_absent_everywhere() {
+        // Was: "skips systemctl query when unit absent". That skip was
+        // itself the orphan-hiding bug (finding 5) — a unit file removed
+        // out-of-band while systemd still had it loaded/enabled would
+        // silently read as "not installed". The query must always run so
+        // an orphan can be detected; only report "not installed" when the
+        // file AND the manager both show nothing.
         let _lock = crate::runtime::test_env::lock_runtime_env();
         let tmp = tempfile::tempdir().expect("tempdir");
         let prior = std::env::var_os("HOME");
@@ -999,10 +1115,59 @@ mod tests {
         }
 
         result.expect("status succeeds when not installed");
-        assert!(
-            runner.labels.is_empty(),
-            "must not query systemctl when the unit file is absent"
+        assert_eq!(
+            runner.labels,
+            ["systemctl show unit state", "systemctl show ActiveState"],
+            "must query systemd even when the unit file is absent, to detect orphans"
         );
+    }
+
+    #[test]
+    fn resolve_installed_true_when_file_absent_but_manager_still_shows_it_loaded_or_enabled() {
+        let none = SystemdUnitState {
+            loaded: false,
+            enabled: false,
+        };
+        let loaded_only = SystemdUnitState {
+            loaded: true,
+            enabled: false,
+        };
+        let enabled_only = SystemdUnitState {
+            loaded: false,
+            enabled: true,
+        };
+        assert!(!resolve_installed(false, none));
+        assert!(
+            resolve_installed(false, loaded_only),
+            "orphaned unit still loaded"
+        );
+        assert!(
+            resolve_installed(false, enabled_only),
+            "orphaned unit still enabled"
+        );
+        assert!(resolve_installed(true, none));
+    }
+
+    #[test]
+    fn query_unit_state_parses_key_value_lines_regardless_of_order() {
+        let mut runner = RecordingRunner {
+            unit_state_output: Some("UnitFileState=enabled\nLoadState=loaded\n".to_string()),
+            ..RecordingRunner::default()
+        };
+        let state = query_unit_state(&mut runner).expect("out-of-order lines must parse");
+        assert!(state.loaded);
+        assert!(state.enabled);
+    }
+
+    #[test]
+    fn query_unit_state_errors_when_a_required_key_is_missing() {
+        let mut runner = RecordingRunner {
+            unit_state_output: Some("LoadState=loaded\n".to_string()),
+            ..RecordingRunner::default()
+        };
+        let error = query_unit_state(&mut runner)
+            .expect_err("a missing UnitFileState line must error, not silently default");
+        assert!(error.to_string().contains("UnitFileState"));
     }
 
     #[test]
@@ -1202,13 +1367,22 @@ mod tests {
             status_with_runner(&mut runner).expect("status succeeds");
             assert_eq!(
                 runner.args,
-                [vec![
-                    "--user",
-                    "show",
-                    "--property=ActiveState",
-                    "--value",
-                    SYSTEMD_UNIT,
-                ]]
+                [
+                    vec![
+                        "--user",
+                        "show",
+                        "--property=LoadState",
+                        "--property=UnitFileState",
+                        SYSTEMD_UNIT,
+                    ],
+                    vec![
+                        "--user",
+                        "show",
+                        "--property=ActiveState",
+                        "--value",
+                        SYSTEMD_UNIT,
+                    ]
+                ]
             );
         }
         // SAFETY: serialized by `lock_runtime_env`.

--- a/crates/ironclaw_reborn_cli/src/main.rs
+++ b/crates/ironclaw_reborn_cli/src/main.rs
@@ -6,6 +6,9 @@ mod file_write;
 mod operator_env;
 mod render;
 mod runtime;
+#[cfg(feature = "webui-v2-beta")]
+mod serve_invocation;
+mod webui_token;
 
 fn main() -> anyhow::Result<()> {
     // Mirror the v1 binary's behavior so dev workflows can keep LLM

--- a/crates/ironclaw_reborn_cli/src/serve_invocation.rs
+++ b/crates/ironclaw_reborn_cli/src/serve_invocation.rs
@@ -1,0 +1,160 @@
+//! Resolves how to invoke `ironclaw-reborn serve` as a child process.
+//!
+//! Consumed by the `service` subcommand's plist/unit generators
+//! (`commands/service/`) so the installed service unit's `serve`
+//! invocation agrees with the installing process on Reborn home/profile.
+
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use ironclaw_reborn_config::{REBORN_HOME_ENV, REBORN_PROFILE_ENV, RebornBootConfig};
+
+/// A fully resolved way to launch `ironclaw-reborn serve` as a child
+/// process: the binary path, its arguments, and the environment pairs a
+/// caller must set so `serve` resolves the same Reborn home/profile as
+/// the invoking process.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServeInvocation {
+    pub exe: PathBuf,
+    pub args: Vec<String>,
+    pub env: Vec<(String, String)>,
+}
+
+/// Resolve the current executable and the `serve` invocation environment.
+///
+/// `IRONCLAW_REBORN_HOME` is always included — the resolved home path —
+/// so a spawned `serve` always agrees with the spawning process on where
+/// state lives. `IRONCLAW_REBORN_PROFILE` is included only when the
+/// operator set it explicitly: this reads the raw env var rather than
+/// `RebornBootConfig::profile()` (which always resolves to a default),
+/// because baking a silently-defaulted profile into a long-lived service
+/// unit would pin behavior the operator never asked for.
+pub fn serve_invocation() -> Result<ServeInvocation> {
+    let exe = std::env::current_exe().context("failed to resolve current executable")?;
+    let boot_config = RebornBootConfig::resolve_from_env()
+        .context("failed to resolve Reborn home for the serve invocation")?;
+
+    let mut env = vec![(
+        REBORN_HOME_ENV.to_string(),
+        boot_config.home().path().display().to_string(),
+    )];
+    if let Ok(profile) = std::env::var(REBORN_PROFILE_ENV) {
+        env.push((REBORN_PROFILE_ENV.to_string(), profile));
+    }
+
+    Ok(ServeInvocation {
+        exe,
+        args: vec!["serve".to_string()],
+        env,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// RAII guard restoring IRONCLAW_REBORN_HOME/IRONCLAW_REBORN_PROFILE
+    /// on drop. Caller must hold `lock_runtime_env()` for the guard's
+    /// lifetime — mirrors serve_sso.rs's manual save/set/restore pattern.
+    struct EnvPairGuard {
+        prior_home: Option<std::ffi::OsString>,
+        prior_profile: Option<std::ffi::OsString>,
+    }
+
+    impl EnvPairGuard {
+        fn set_home_only(tmp: &std::path::Path) -> Self {
+            let prior_home = std::env::var_os("IRONCLAW_REBORN_HOME");
+            let prior_profile = std::env::var_os("IRONCLAW_REBORN_PROFILE");
+            // SAFETY: caller holds `lock_runtime_env()` for this guard's lifetime.
+            unsafe {
+                std::env::set_var("IRONCLAW_REBORN_HOME", tmp);
+                std::env::remove_var("IRONCLAW_REBORN_PROFILE");
+            }
+            Self {
+                prior_home,
+                prior_profile,
+            }
+        }
+
+        fn set_home_and_profile(tmp: &std::path::Path, profile: &str) -> Self {
+            let prior_home = std::env::var_os("IRONCLAW_REBORN_HOME");
+            let prior_profile = std::env::var_os("IRONCLAW_REBORN_PROFILE");
+            // SAFETY: see `set_home_only`.
+            unsafe {
+                std::env::set_var("IRONCLAW_REBORN_HOME", tmp);
+                std::env::set_var("IRONCLAW_REBORN_PROFILE", profile);
+            }
+            Self {
+                prior_home,
+                prior_profile,
+            }
+        }
+    }
+
+    impl Drop for EnvPairGuard {
+        fn drop(&mut self) {
+            // SAFETY: see `set_home_only`.
+            unsafe {
+                match self.prior_home.take() {
+                    Some(v) => std::env::set_var("IRONCLAW_REBORN_HOME", v),
+                    None => std::env::remove_var("IRONCLAW_REBORN_HOME"),
+                }
+                match self.prior_profile.take() {
+                    Some(v) => std::env::set_var("IRONCLAW_REBORN_PROFILE", v),
+                    None => std::env::remove_var("IRONCLAW_REBORN_PROFILE"),
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn includes_resolved_home_and_omits_profile_when_unset() {
+        let _lock = crate::runtime::test_env::lock_runtime_env();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _guard = EnvPairGuard::set_home_only(tmp.path());
+
+        let invocation =
+            serve_invocation().expect("serve_invocation must resolve under a valid HOME");
+
+        assert_eq!(invocation.args, vec!["serve".to_string()]);
+        assert_eq!(
+            invocation.env,
+            vec![(
+                "IRONCLAW_REBORN_HOME".to_string(),
+                tmp.path().display().to_string()
+            )]
+        );
+    }
+
+    #[test]
+    fn includes_profile_when_explicitly_set() {
+        let _lock = crate::runtime::test_env::lock_runtime_env();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _guard = EnvPairGuard::set_home_and_profile(tmp.path(), "production");
+
+        let invocation =
+            serve_invocation().expect("serve_invocation must resolve with an explicit profile");
+
+        assert_eq!(
+            invocation.env,
+            vec![
+                (
+                    "IRONCLAW_REBORN_HOME".to_string(),
+                    tmp.path().display().to_string()
+                ),
+                (
+                    "IRONCLAW_REBORN_PROFILE".to_string(),
+                    "production".to_string()
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn resolves_current_exe_as_an_existing_absolute_path() {
+        let _lock = crate::runtime::test_env::lock_runtime_env();
+        let invocation = serve_invocation().expect("serve_invocation must resolve");
+        assert!(invocation.exe.is_absolute());
+        assert!(invocation.exe.exists());
+    }
+}

--- a/crates/ironclaw_reborn_cli/src/webui_token.rs
+++ b/crates/ironclaw_reborn_cli/src/webui_token.rs
@@ -55,6 +55,99 @@ pub(crate) fn webui_token_file_path(reborn_home: &Path) -> PathBuf {
 /// silently reading as absent, which would let a caller like
 /// [`ensure_webui_token_file`] overwrite an existing-but-unreadable
 /// secret.
+///
+/// On unix this opens the path exactly once with `O_NOFOLLOW` and drives
+/// every subsequent check (regular-file type, size, contents) off that
+/// same handle's `fstat`/read — a symlink swapped in, or the target
+/// enlarged, after a separate `symlink_metadata()` call but before the
+/// read can't smuggle a different file through (TOCTOU), and a non-regular
+/// file (FIFO, device) that would otherwise pass a standalone length check
+/// and then block the read indefinitely is rejected before any read is
+/// attempted. Non-unix targets keep the previous best-effort
+/// stat-then-read shape (no `O_NOFOLLOW`/single-handle primitive in
+/// `std` there).
+#[cfg(unix)]
+fn read_token_file_checked(path: &Path) -> anyhow::Result<Option<String>> {
+    use std::io::Read as _;
+    use std::os::unix::fs::OpenOptionsExt as _;
+
+    // `O_NONBLOCK` alongside `O_NOFOLLOW`: a read-only open of a FIFO
+    // blocks until a writer connects, which would otherwise hang `serve`
+    // startup indefinitely on a FIFO planted at the token path (it would
+    // have passed a standalone pre-read length check too). `O_NONBLOCK`
+    // makes the open return immediately regardless of a writer; it has
+    // no effect on the regular-file case once we reach the read below
+    // (POSIX ignores O_NONBLOCK for regular files).
+    let mut options = fs::OpenOptions::new();
+    options
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK);
+    let file = match options.open(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        // `O_NOFOLLOW` surfaces a symlink at `path` as `ELOOP`
+        // (`ErrorKind::FilesystemLoop` on recent stds, `Uncategorized`/
+        // `Other` on older ones) rather than a distinct error kind we can
+        // match reliably across platforms/std versions — so probe
+        // `symlink_metadata` only on open failure to produce the
+        // targeted message, instead of trusting `open`'s raw errno
+        // classification.
+        Err(open_error) => {
+            if fs::symlink_metadata(path)
+                .map(|metadata| metadata.file_type().is_symlink())
+                .unwrap_or(false)
+            {
+                anyhow::bail!(
+                    "{} is a symlink; refusing to read the WebChat v2 token file through it. \
+                     Remove it and re-run `ironclaw-reborn onboard` to provision a regular file.",
+                    path.display()
+                );
+            }
+            return Err(open_error).with_context(|| format!("open {}", path.display()));
+        }
+    };
+
+    let metadata = file
+        .metadata()
+        .with_context(|| format!("stat {}", path.display()))?;
+    if !metadata.is_file() {
+        anyhow::bail!(
+            "{} is not a regular file; refusing to read the WebChat v2 token file through it. \
+             Remove it and re-run `ironclaw-reborn onboard` to provision a regular file.",
+            path.display()
+        );
+    }
+    if metadata.len() > WEBUI_TOKEN_FILE_MAX_BYTES {
+        anyhow::bail!(
+            "{} is {} bytes, over the {WEBUI_TOKEN_FILE_MAX_BYTES}-byte cap for the \
+             WebChat v2 token file; refusing to read it.",
+            path.display(),
+            metadata.len()
+        );
+    }
+
+    // Bound the read itself (not just the pre-read `fstat`'d size) to
+    // `MAX_BYTES + 1`: a file that grows between the `fstat` above and
+    // this read (e.g. concurrently appended to) is still caught here
+    // instead of being read unbounded.
+    let mut buf = Vec::new();
+    (&file)
+        .take(WEBUI_TOKEN_FILE_MAX_BYTES + 1)
+        .read_to_end(&mut buf)
+        .with_context(|| format!("read {}", path.display()))?;
+    if buf.len() as u64 > WEBUI_TOKEN_FILE_MAX_BYTES {
+        anyhow::bail!(
+            "{} exceeds the {WEBUI_TOKEN_FILE_MAX_BYTES}-byte cap for the WebChat v2 token \
+             file; refusing to read it.",
+            path.display()
+        );
+    }
+    let contents = String::from_utf8(buf)
+        .map_err(|_| anyhow::anyhow!("{} is not valid UTF-8", path.display()))?;
+    Ok(Some(contents))
+}
+
+#[cfg(not(unix))]
 fn read_token_file_checked(path: &Path) -> anyhow::Result<Option<String>> {
     match fs::symlink_metadata(path) {
         Ok(metadata) => {
@@ -504,6 +597,34 @@ mod tests {
             .mode()
             & 0o777;
         assert_eq!(mode, 0o600, "mode must be repaired to 0600, got {mode:o}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn webui_token_file_is_valid_rejects_a_fifo_without_blocking() {
+        // Before the single-handle O_NONBLOCK|O_NOFOLLOW fix, a FIFO
+        // planted at the token path would pass a standalone
+        // `symlink_metadata().len()` check (FIFOs report length 0, well
+        // under the cap) and then a blocking `read_to_string` open would
+        // hang forever waiting for a writer — hanging `serve` startup
+        // indefinitely. This must return promptly with a "not a regular
+        // file" error instead.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = webui_token_file_path(dir.path());
+        let c_path = std::ffi::CString::new(path.as_os_str().as_encoded_bytes())
+            .expect("path has no interior NUL");
+        // SAFETY: `mkfifo` with a valid NUL-terminated path and a
+        // regular permission-bits argument; no aliasing/lifetime hazards.
+        let rc = unsafe { libc::mkfifo(c_path.as_ptr(), 0o600) };
+        assert_eq!(rc, 0, "mkfifo failed: {}", std::io::Error::last_os_error());
+
+        let error = webui_token_file_is_valid(dir.path()).expect_err(
+            "a FIFO at the token path must be rejected, not read through or blocked on",
+        );
+        assert!(
+            error.to_string().contains("not a regular file"),
+            "error: {error}"
+        );
     }
 
     #[test]

--- a/crates/ironclaw_reborn_cli/src/webui_token.rs
+++ b/crates/ironclaw_reborn_cli/src/webui_token.rs
@@ -16,6 +16,8 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use anyhow::Context as _;
+
 use crate::file_write::FileWriteAction;
 
 /// Filename of the onboarding-provisioned WebChat v2 bearer token,
@@ -30,20 +32,106 @@ pub(crate) const WEBUI_TOKEN_FILENAME: &str = "webui-token";
 /// offline, then mint a session for any user/tenant.
 pub(crate) const WEBUI_TOKEN_MIN_BYTES: usize = 32;
 
+/// Upper bound on the on-disk size of the token file before we refuse to
+/// read it. A legitimate token (hex-encoded, [`WEBUI_TOKEN_MIN_BYTES`]
+/// bytes) plus generous whitespace is a few dozen bytes; this cap is wide
+/// headroom over that while still bounding memory use against an
+/// oversized or corrupt file, since the read is otherwise unbounded.
+const WEBUI_TOKEN_FILE_MAX_BYTES: u64 = 4096;
+
 /// Absolute path of the onboarding-provisioned token file under
 /// `<reborn_home>`.
 pub(crate) fn webui_token_file_path(reborn_home: &Path) -> PathBuf {
     reborn_home.join(WEBUI_TOKEN_FILENAME)
 }
 
-/// `true` when a token file exists at `<reborn_home>/webui-token` and
-/// its trimmed contents meet the entropy floor. Read-only — used both
-/// by [`ensure_webui_token_file`] (to decide whether to skip writing)
-/// and by `onboard --dry-run` (to report what it *would* do).
-pub(crate) fn webui_token_file_is_valid(reborn_home: &Path) -> bool {
-    fs::read_to_string(webui_token_file_path(reborn_home))
-        .map(|contents| contents.trim().len() >= WEBUI_TOKEN_MIN_BYTES)
-        .unwrap_or(false)
+/// Read the token file's raw contents through the shared safety checks:
+/// reject a symlink (it could point outside `<reborn_home>` at a file the
+/// operator does not control) and reject a file over
+/// [`WEBUI_TOKEN_FILE_MAX_BYTES`] (bound the read) before trusting the
+/// path enough to read it. `Ok(None)` means "no file here" (`NotFound`
+/// only); every other I/O failure — permission denied, a directory at
+/// this path, etc. — is a real error and must propagate rather than
+/// silently reading as absent, which would let a caller like
+/// [`ensure_webui_token_file`] overwrite an existing-but-unreadable
+/// secret.
+fn read_token_file_checked(path: &Path) -> anyhow::Result<Option<String>> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) => {
+            if metadata.file_type().is_symlink() {
+                anyhow::bail!(
+                    "{} is a symlink; refusing to read the WebChat v2 token file through it. \
+                     Remove it and re-run `ironclaw-reborn onboard` to provision a regular file.",
+                    path.display()
+                );
+            }
+            if metadata.len() > WEBUI_TOKEN_FILE_MAX_BYTES {
+                anyhow::bail!(
+                    "{} is {} bytes, over the {WEBUI_TOKEN_FILE_MAX_BYTES}-byte cap for the \
+                     WebChat v2 token file; refusing to read it.",
+                    path.display(),
+                    metadata.len()
+                );
+            }
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error).with_context(|| format!("stat {}", path.display())),
+    }
+    match fs::read_to_string(path) {
+        Ok(contents) => Ok(Some(contents)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error).with_context(|| format!("read {}", path.display())),
+    }
+}
+
+/// Repair a token file's permissions to `0600` if they aren't already,
+/// logging a warning. Called only from the "accept this token" paths
+/// ([`ensure_webui_token_file`]'s preserve branch, [`resolve_webui_token`]'s
+/// file-fallback branch) — never from a read-only reporting path like
+/// `onboard --dry-run` — on the principle that a wrongly-permissioned but
+/// otherwise valid token should be repaired in place rather than
+/// rejected (repair-over-reject: least user breakage, and it matches the
+/// 0600 discipline [`write_token_file`] already enforces for freshly
+/// written tokens).
+#[cfg(unix)]
+fn repair_token_file_mode(path: &Path) -> anyhow::Result<()> {
+    use std::os::unix::fs::PermissionsExt as _;
+    let metadata =
+        fs::metadata(path).with_context(|| format!("stat {} for mode repair", path.display()))?;
+    let mode = metadata.permissions().mode() & 0o777;
+    if mode == 0o600 {
+        return Ok(());
+    }
+    tracing::warn!(
+        target: "ironclaw::reborn::cli::webui_token",
+        path = %path.display(),
+        mode = format!("{mode:o}"),
+        "repairing WebChat v2 token file permissions to 0600"
+    );
+    fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+        .with_context(|| format!("repair permissions on {}", path.display()))
+}
+
+#[cfg(not(unix))]
+fn repair_token_file_mode(_path: &Path) -> anyhow::Result<()> {
+    Ok(())
+}
+
+/// `Ok(true)` when a token file exists at `<reborn_home>/webui-token` and
+/// its trimmed contents meet the entropy floor; `Ok(false)` when it is
+/// absent or too short. Read-only (no mode repair, no writes) — used by
+/// `onboard --dry-run` to report what it *would* do without mutating
+/// anything. [`ensure_webui_token_file`] additionally repairs the mode
+/// on its own accept path rather than relying on this helper for that.
+///
+/// Propagates a real error for any I/O failure that isn't "file absent"
+/// (unreadable file, symlink, oversized file) — see
+/// [`read_token_file_checked`].
+pub(crate) fn webui_token_file_is_valid(reborn_home: &Path) -> anyhow::Result<bool> {
+    Ok(
+        read_token_file_checked(&webui_token_file_path(reborn_home))?
+            .is_some_and(|contents| contents.trim().len() >= WEBUI_TOKEN_MIN_BYTES),
+    )
 }
 
 /// Ensure `<reborn_home>/webui-token` holds a valid (>= entropy floor)
@@ -53,11 +141,13 @@ pub(crate) fn webui_token_file_is_valid(reborn_home: &Path) -> bool {
 /// Idempotent by design, independent of any `--force` flag: a valid
 /// existing token is never regenerated, because operators may already
 /// have long-lived sessions or an externally-copied env var keyed to
-/// its current value. Only a missing or invalid (too-short/unreadable)
-/// file is (re)written.
+/// its current value. Only a missing or invalid (too-short) file is
+/// (re)written; an unreadable-but-present file is a hard error here
+/// (never silently treated as "missing, go ahead and overwrite it").
 pub(crate) fn ensure_webui_token_file(reborn_home: &Path) -> anyhow::Result<FileWriteAction> {
     let file_path = webui_token_file_path(reborn_home);
-    if webui_token_file_is_valid(reborn_home) {
+    if webui_token_file_is_valid(reborn_home)? {
+        repair_token_file_mode(&file_path)?;
         return Ok(FileWriteAction::Preserved);
     }
     let overwrote = file_path.exists();
@@ -149,14 +239,21 @@ pub(crate) fn resolve_webui_token(
     }
 
     let file_path = webui_token_file_path(reborn_home);
-    let file_value = fs::read_to_string(&file_path)
-        .ok()
+    // `read_token_file_checked` rejects a symlinked or oversized file and
+    // propagates real I/O errors instead of reading them as "absent" —
+    // an unreadable token file must fail closed here, not silently fall
+    // through to the "neither source found" error below.
+    let file_value = read_token_file_checked(&file_path)?
         .map(|contents| contents.trim().to_string())
         .filter(|trimmed| !trimmed.is_empty());
 
     match file_value {
         Some(token) => {
             validate_token_entropy(&token, env_var_name, reborn_home)?;
+            // Accepting this token as the live credential: repair a
+            // wrongly-permissioned file in place (see
+            // `repair_token_file_mode`'s doc for why repair, not reject).
+            repair_token_file_mode(&file_path)?;
             Ok(token)
         }
         None => Err(anyhow::anyhow!(
@@ -319,5 +416,142 @@ mod tests {
             "message: {message}"
         );
         assert!(message.contains("at least 32 bytes"), "message: {message}");
+    }
+
+    // ── Hygiene: unreadable / symlinked / oversized token files ────
+
+    #[test]
+    fn ensure_webui_token_file_propagates_a_real_read_error_instead_of_overwriting() {
+        // Before this fix, `webui_token_file_is_valid` mapped ANY read
+        // error (not just "file absent") to `false` via `.unwrap_or(false)`,
+        // so `ensure_webui_token_file` would silently overwrite an
+        // existing-but-unreadable secret. A directory at the token path
+        // reproduces "exists but unreadable as a file" without relying on
+        // permission bits that root bypasses in CI.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = webui_token_file_path(dir.path());
+        fs::create_dir_all(&path).expect("seed a directory at the token path");
+
+        let error = ensure_webui_token_file(dir.path())
+            .expect_err("a real I/O error reading the token path must propagate, not overwrite");
+        assert!(
+            error.to_string().contains(&path.display().to_string()),
+            "error should name the token path: {error}"
+        );
+        assert!(path.is_dir(), "must not have written through the error");
+    }
+
+    #[test]
+    fn webui_token_file_is_valid_propagates_a_real_read_error() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = webui_token_file_path(dir.path());
+        fs::create_dir_all(&path).expect("seed a directory at the token path");
+
+        webui_token_file_is_valid(dir.path())
+            .expect_err("a directory at the token path is a real I/O error, not `Ok(false)`");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn webui_token_file_is_valid_rejects_a_symlinked_token_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let target = dir.path().join("elsewhere");
+        fs::write(&target, "0".repeat(WEBUI_TOKEN_MIN_BYTES)).expect("write symlink target");
+        let path = webui_token_file_path(dir.path());
+        std::os::unix::fs::symlink(&target, &path).expect("create symlink");
+
+        let error = webui_token_file_is_valid(dir.path())
+            .expect_err("a symlinked token file must be rejected, not read through");
+        assert!(error.to_string().contains("symlink"), "error: {error}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ensure_webui_token_file_rejects_a_symlinked_token_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let target = dir.path().join("elsewhere");
+        fs::write(&target, "0".repeat(WEBUI_TOKEN_MIN_BYTES)).expect("write symlink target");
+        let path = webui_token_file_path(dir.path());
+        std::os::unix::fs::symlink(&target, &path).expect("create symlink");
+
+        ensure_webui_token_file(dir.path())
+            .expect_err("must refuse to read through, repair, or overwrite a symlinked token file");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ensure_webui_token_file_repairs_a_wrongly_permissioned_valid_token_in_place() {
+        use std::os::unix::fs::PermissionsExt as _;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = webui_token_file_path(dir.path());
+        let token = "0".repeat(WEBUI_TOKEN_MIN_BYTES);
+        fs::write(&path, &token).expect("seed valid token file");
+        fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644))
+            .expect("loosen permissions to 0644");
+
+        let action = ensure_webui_token_file(dir.path())
+            .expect("a valid token with a wrong mode must be repaired, not rejected");
+        assert_eq!(
+            action,
+            FileWriteAction::Preserved,
+            "repair-in-place must not regenerate the token value"
+        );
+        let contents = fs::read_to_string(&path).expect("read token file");
+        assert_eq!(contents, token, "repair must not change the token content");
+        let mode = fs::metadata(&path)
+            .expect("stat token file")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600, "mode must be repaired to 0600, got {mode:o}");
+    }
+
+    #[test]
+    fn ensure_webui_token_file_rejects_an_oversized_token_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = webui_token_file_path(dir.path());
+        fs::write(&path, "0".repeat(WEBUI_TOKEN_FILE_MAX_BYTES as usize + 1))
+            .expect("seed oversized token file");
+
+        let error = ensure_webui_token_file(dir.path())
+            .expect_err("an oversized token file must be rejected, not read unbounded");
+        assert!(error.to_string().contains("bytes"), "error: {error}");
+    }
+
+    #[cfg(feature = "webui-v2-beta")]
+    #[cfg(unix)]
+    #[test]
+    fn resolve_rejects_a_symlinked_token_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let target = dir.path().join("elsewhere");
+        fs::write(&target, VALID_TOKEN).expect("write symlink target");
+        let path = webui_token_file_path(dir.path());
+        std::os::unix::fs::symlink(&target, &path).expect("create symlink");
+
+        let error = resolve_webui_token("SOME_TOKEN_VAR", None, dir.path())
+            .expect_err("serve must refuse to authenticate off a symlinked token file");
+        assert!(error.to_string().contains("symlink"), "error: {error}");
+    }
+
+    #[cfg(feature = "webui-v2-beta")]
+    #[cfg(unix)]
+    #[test]
+    fn resolve_repairs_a_wrongly_permissioned_token_file_on_accept() {
+        use std::os::unix::fs::PermissionsExt as _;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = webui_token_file_path(dir.path());
+        fs::write(&path, VALID_TOKEN).expect("seed valid token file");
+        fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644))
+            .expect("loosen permissions to 0644");
+
+        let token = resolve_webui_token("SOME_TOKEN_VAR", None, dir.path())
+            .expect("a valid token with a wrong mode must still be accepted");
+        assert_eq!(token, VALID_TOKEN);
+        let mode = fs::metadata(&path)
+            .expect("stat token file")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600, "mode must be repaired to 0600, got {mode:o}");
     }
 }

--- a/crates/ironclaw_reborn_cli/src/webui_token.rs
+++ b/crates/ironclaw_reborn_cli/src/webui_token.rs
@@ -1,0 +1,323 @@
+//! Shared WebChat v2 bearer token resolution and provisioning.
+//!
+//! The token doubles as both the WebChat v2 env-bearer credential *and*
+//! the stateless session-signing HMAC key (see `commands/serve.rs`), so
+//! it must be high-entropy (>= [`WEBUI_TOKEN_MIN_BYTES`]) regardless of
+//! whether it comes from the environment or the onboarding-provisioned
+//! `<reborn_home>/webui-token` fallback file.
+//!
+//! `onboard` (unconditional — [`ensure_webui_token_file`]) provisions the
+//! fallback file so a service-installed `serve` (launchd/systemd), whose
+//! unit environment carries only `HOME`/`PROFILE` (see
+//! `serve_invocation.rs`), still has a token to read. `serve` (gated
+//! behind the `webui-v2-beta` feature — [`resolve_webui_token`]) reads
+//! through this same precedence and entropy validation.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::file_write::FileWriteAction;
+
+/// Filename of the onboarding-provisioned WebChat v2 bearer token,
+/// relative to `<reborn_home>`. Shared by `onboard` (which writes it)
+/// and `serve` (which reads it as a fallback when the env var naming
+/// the token is unset or empty).
+pub(crate) const WEBUI_TOKEN_FILENAME: &str = "webui-token";
+
+/// Minimum byte length for the WebChat v2 bearer token, mirroring the
+/// server-side session-signing entropy floor: an attacker who obtains
+/// one legitimate signed session can brute-force a low-entropy key
+/// offline, then mint a session for any user/tenant.
+pub(crate) const WEBUI_TOKEN_MIN_BYTES: usize = 32;
+
+/// Absolute path of the onboarding-provisioned token file under
+/// `<reborn_home>`.
+pub(crate) fn webui_token_file_path(reborn_home: &Path) -> PathBuf {
+    reborn_home.join(WEBUI_TOKEN_FILENAME)
+}
+
+/// `true` when a token file exists at `<reborn_home>/webui-token` and
+/// its trimmed contents meet the entropy floor. Read-only — used both
+/// by [`ensure_webui_token_file`] (to decide whether to skip writing)
+/// and by `onboard --dry-run` (to report what it *would* do).
+pub(crate) fn webui_token_file_is_valid(reborn_home: &Path) -> bool {
+    fs::read_to_string(webui_token_file_path(reborn_home))
+        .map(|contents| contents.trim().len() >= WEBUI_TOKEN_MIN_BYTES)
+        .unwrap_or(false)
+}
+
+/// Ensure `<reborn_home>/webui-token` holds a valid (>= entropy floor)
+/// token, generating and writing one with `0600` permissions (unix) if
+/// none exists yet.
+///
+/// Idempotent by design, independent of any `--force` flag: a valid
+/// existing token is never regenerated, because operators may already
+/// have long-lived sessions or an externally-copied env var keyed to
+/// its current value. Only a missing or invalid (too-short/unreadable)
+/// file is (re)written.
+pub(crate) fn ensure_webui_token_file(reborn_home: &Path) -> anyhow::Result<FileWriteAction> {
+    let file_path = webui_token_file_path(reborn_home);
+    if webui_token_file_is_valid(reborn_home) {
+        return Ok(FileWriteAction::Preserved);
+    }
+    let overwrote = file_path.exists();
+    let token = generate_webui_token();
+    write_token_file(&file_path, &token)?;
+    Ok(if overwrote {
+        FileWriteAction::Overwrote
+    } else {
+        FileWriteAction::Wrote
+    })
+}
+
+/// Generate a cryptographically-random token comfortably over the
+/// entropy floor: [`WEBUI_TOKEN_MIN_BYTES`] random bytes, hex-encoded
+/// (twice the byte length as ASCII characters).
+fn generate_webui_token() -> String {
+    use rand::RngExt as _;
+    let mut bytes = [0_u8; WEBUI_TOKEN_MIN_BYTES];
+    rand::rng().fill(&mut bytes);
+    hex::encode(bytes)
+}
+
+/// Write `token` to `path` atomically (temp file + rename) with `0600`
+/// permissions on unix, creating the parent directory if needed.
+fn write_token_file(path: &Path, token: &str) -> anyhow::Result<()> {
+    use std::io::Write as _;
+
+    let parent = path
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("{} has no parent directory", path.display()))?;
+    fs::create_dir_all(parent)
+        .map_err(|error| anyhow::anyhow!("create {}: {error}", parent.display()))?;
+    let mut tmp = tempfile::NamedTempFile::new_in(parent)
+        .map_err(|error| anyhow::anyhow!("create temp file in {}: {error}", parent.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        tmp.as_file()
+            .set_permissions(std::fs::Permissions::from_mode(0o600))
+            .map_err(|error| {
+                anyhow::anyhow!("set permissions on {}: {error}", tmp.path().display())
+            })?;
+    }
+    tmp.write_all(token.as_bytes())
+        .map_err(|error| anyhow::anyhow!("write {}: {error}", tmp.path().display()))?;
+    tmp.flush()
+        .map_err(|error| anyhow::anyhow!("flush {}: {error}", tmp.path().display()))?;
+    tmp.persist(path).map_err(|error| {
+        anyhow::anyhow!(
+            "persist {} -> {}: {}",
+            error.file.path().display(),
+            path.display(),
+            error.error
+        )
+    })?;
+    Ok(())
+}
+
+/// Resolve the WebChat v2 bearer token with precedence:
+///
+/// 1. `env_value` — the value of the operator's `[webui].env_token_var`
+///    (default `IRONCLAW_REBORN_WEBUI_TOKEN`) — when `Some` and
+///    non-empty;
+/// 2. `<reborn_home>/webui-token`, trimmed, when it exists and is
+///    non-empty (the `onboard`-provisioned fallback — see the module
+///    doc for why a service-installed `serve` needs this);
+/// 3. otherwise a fail-closed error naming both the env var and the
+///    fallback file path.
+///
+/// Either source must independently meet [`WEBUI_TOKEN_MIN_BYTES`] — a
+/// short value fails closed rather than letting `serve` start and the
+/// server reject it opaquely later.
+///
+/// Pure: takes the env value and home path as parameters instead of
+/// reading `std::env` itself, so callers own env access (trivially
+/// unit-testable without mutating process env) and control which env
+/// var name is in play (`[webui].env_token_var` may rename it).
+#[cfg(feature = "webui-v2-beta")]
+pub(crate) fn resolve_webui_token(
+    env_var_name: &str,
+    env_value: Option<&str>,
+    reborn_home: &Path,
+) -> anyhow::Result<String> {
+    if let Some(value) = env_value
+        && !value.is_empty()
+    {
+        validate_token_entropy(value, env_var_name, reborn_home)?;
+        return Ok(value.to_string());
+    }
+
+    let file_path = webui_token_file_path(reborn_home);
+    let file_value = fs::read_to_string(&file_path)
+        .ok()
+        .map(|contents| contents.trim().to_string())
+        .filter(|trimmed| !trimmed.is_empty());
+
+    match file_value {
+        Some(token) => {
+            validate_token_entropy(&token, env_var_name, reborn_home)?;
+            Ok(token)
+        }
+        None => Err(anyhow::anyhow!(
+            "{env_var_name} must be set to the WebChat v2 bearer token, or a token file must \
+             exist at {} (written by `ironclaw-reborn onboard`). Neither was found.",
+            file_path.display()
+        )),
+    }
+}
+
+#[cfg(feature = "webui-v2-beta")]
+fn validate_token_entropy(
+    value: &str,
+    env_var_name: &str,
+    reborn_home: &Path,
+) -> anyhow::Result<()> {
+    if value.len() >= WEBUI_TOKEN_MIN_BYTES {
+        return Ok(());
+    }
+    Err(anyhow::anyhow!(
+        "the WebChat v2 bearer token (from {env_var_name} or {}) is only {} bytes; it is also \
+         the WebChat v2 session-signing key and must be at least {WEBUI_TOKEN_MIN_BYTES} bytes \
+         of high-entropy random material. Generate one with e.g. `openssl rand -hex 32`, or run \
+         `ironclaw-reborn onboard` to provision a valid token file.",
+        webui_token_file_path(reborn_home).display(),
+        value.len(),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(feature = "webui-v2-beta")]
+    const VALID_TOKEN: &str = "reborn-smoke-test-token-0123456789abcdef"; // 40 bytes
+
+    #[test]
+    fn ensure_webui_token_file_creates_valid_token_with_0600_perms() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let action = ensure_webui_token_file(dir.path()).expect("token file should be created");
+        assert_eq!(action, FileWriteAction::Wrote);
+
+        let path = webui_token_file_path(dir.path());
+        let contents = fs::read_to_string(&path).expect("read token file");
+        assert!(
+            contents.trim().len() >= WEBUI_TOKEN_MIN_BYTES,
+            "generated token must meet the entropy floor: {} bytes",
+            contents.trim().len()
+        );
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            let mode = fs::metadata(&path)
+                .expect("stat token file")
+                .permissions()
+                .mode()
+                & 0o777;
+            assert_eq!(mode, 0o600, "token file must be 0600, got {mode:o}");
+        }
+    }
+
+    #[test]
+    fn ensure_webui_token_file_is_idempotent_when_existing_token_is_valid() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let first = ensure_webui_token_file(dir.path()).expect("first write");
+        assert_eq!(first, FileWriteAction::Wrote);
+        let path = webui_token_file_path(dir.path());
+        let first_contents = fs::read_to_string(&path).expect("read token file");
+
+        let second = ensure_webui_token_file(dir.path()).expect("second call must not fail");
+        assert_eq!(
+            second,
+            FileWriteAction::Preserved,
+            "a valid existing token must never be clobbered"
+        );
+        let second_contents = fs::read_to_string(&path).expect("read token file again");
+        assert_eq!(
+            first_contents, second_contents,
+            "idempotent onboard must not regenerate a valid token"
+        );
+    }
+
+    #[test]
+    fn ensure_webui_token_file_replaces_a_too_short_existing_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = webui_token_file_path(dir.path());
+        fs::write(&path, "too-short\n").expect("seed short token file");
+
+        let action = ensure_webui_token_file(dir.path()).expect("should regenerate");
+        assert_eq!(action, FileWriteAction::Overwrote);
+        let contents = fs::read_to_string(&path).expect("read token file");
+        assert!(contents.trim().len() >= WEBUI_TOKEN_MIN_BYTES);
+    }
+
+    #[cfg(feature = "webui-v2-beta")]
+    #[test]
+    fn resolve_prefers_env_value_when_set() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let token = resolve_webui_token("SOME_TOKEN_VAR", Some(VALID_TOKEN), dir.path())
+            .expect("env value should resolve");
+        assert_eq!(token, VALID_TOKEN);
+    }
+
+    #[cfg(feature = "webui-v2-beta")]
+    #[test]
+    fn resolve_falls_back_to_home_file_when_env_unset() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = webui_token_file_path(dir.path());
+        fs::write(&path, format!("  {VALID_TOKEN}  \n")).expect("seed token file");
+
+        let token = resolve_webui_token("SOME_TOKEN_VAR", None, dir.path())
+            .expect("file fallback should resolve");
+        assert_eq!(token, VALID_TOKEN, "file value must be trimmed");
+    }
+
+    #[cfg(feature = "webui-v2-beta")]
+    #[test]
+    fn resolve_errors_naming_both_var_and_file_when_neither_is_present() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let error = resolve_webui_token("SOME_TOKEN_VAR", None, dir.path())
+            .expect_err("neither source is present");
+        let message = error.to_string();
+        assert!(
+            message.contains("SOME_TOKEN_VAR must be set"),
+            "message: {message}"
+        );
+        assert!(
+            message.contains(&webui_token_file_path(dir.path()).display().to_string()),
+            "message: {message}"
+        );
+    }
+
+    #[cfg(feature = "webui-v2-beta")]
+    #[test]
+    fn resolve_rejects_a_too_short_env_token() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let error = resolve_webui_token("SOME_TOKEN_VAR", Some("short"), dir.path())
+            .expect_err("short env token must be rejected");
+        let message = error.to_string();
+        assert!(
+            message.contains("session-signing key"),
+            "message: {message}"
+        );
+        assert!(message.contains("at least 32 bytes"), "message: {message}");
+    }
+
+    #[cfg(feature = "webui-v2-beta")]
+    #[test]
+    fn resolve_rejects_a_too_short_home_file_token() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = webui_token_file_path(dir.path());
+        fs::write(&path, "short\n").expect("seed short token file");
+
+        let error = resolve_webui_token("SOME_TOKEN_VAR", None, dir.path())
+            .expect_err("short file token must be rejected");
+        let message = error.to_string();
+        assert!(
+            message.contains("session-signing key"),
+            "message: {message}"
+        );
+        assert!(message.contains("at least 32 bytes"), "message: {message}");
+    }
+}

--- a/crates/ironclaw_reborn_cli/tests/smoke.rs
+++ b/crates/ironclaw_reborn_cli/tests/smoke.rs
@@ -3159,6 +3159,50 @@ fn onboard_dry_run_reports_existing_marker_as_preserved() {
 }
 
 #[test]
+fn onboard_dry_run_propagates_a_webui_token_io_error_without_mutating_home() {
+    // `print_dry_run` propagates `webui_token_file_is_valid`'s error with
+    // `?` instead of defaulting to "would_write" on an I/O failure (see
+    // that fn's doc comment). Pin the end-to-end behavior: a directory
+    // planted at the token path is a real I/O error, the process exits
+    // non-zero, and the dry run's read-only contract still holds — no
+    // marker or config file gets written to the (already-existing)
+    // Reborn home.
+    let temp = tempfile::tempdir().expect("tempdir");
+    let reborn_home = temp.path().join("reborn-home");
+    std::fs::create_dir_all(&reborn_home).expect("mkdir reborn_home");
+    std::fs::create_dir_all(reborn_home.join("webui-token"))
+        .expect("seed a directory at token path");
+
+    let output = Command::new(reborn_bin())
+        .args(["onboard", "--dry-run"])
+        .env_clear()
+        .env("IRONCLAW_REBORN_HOME", &reborn_home)
+        .output()
+        .expect("ironclaw-reborn onboard --dry-run should run");
+
+    assert!(
+        !output.status.success(),
+        "a directory at the token path must fail dry-run, not silently proceed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !reborn_home.join(".onboard-completed.json").exists(),
+        "a failed dry-run must not write the onboarding marker"
+    );
+    assert!(
+        !reborn_home.join("config.toml").exists(),
+        "a failed dry-run must not write config.toml"
+    );
+    assert!(
+        std::fs::metadata(reborn_home.join("webui-token"))
+            .expect("token path still present")
+            .is_dir(),
+        "a failed dry-run must not touch the pre-existing token path"
+    );
+}
+
+#[test]
 fn onboard_import_history_records_pending_step() {
     let temp = tempfile::tempdir().expect("tempdir");
     let reborn_home = temp.path().join("reborn-home");

--- a/crates/ironclaw_reborn_cli/tests/smoke.rs
+++ b/crates/ironclaw_reborn_cli/tests/smoke.rs
@@ -485,12 +485,42 @@ fn help_mentions_reborn_commands() {
     assert!(stdout.contains("profile"), "stdout: {stdout}");
     assert!(stdout.contains("repl"), "stdout: {stdout}");
     assert!(stdout.contains("run"), "stdout: {stdout}");
-    // `serve` is gated behind the `webui-v2-beta` Cargo feature so a
-    // default binary build does not link the beta HTTP/auth gateway.
-    // The dedicated `serve_*` tests below also `#[cfg]` themselves.
+    // `serve` and `service` are gated behind the `webui-v2-beta` Cargo
+    // feature so a default binary build does not link the beta HTTP/auth
+    // gateway or the OS-service installer that runs it. The dedicated
+    // `serve_*`/`service_*` tests below also `#[cfg]` themselves.
     #[cfg(feature = "webui-v2-beta")]
     assert!(stdout.contains("serve"), "stdout: {stdout}");
+    #[cfg(feature = "webui-v2-beta")]
+    assert!(stdout.contains("service"), "stdout: {stdout}");
     assert!(stdout.contains("skills"), "stdout: {stdout}");
+    // No standalone `tui` subcommand exists (Reborn's interactive surface
+    // is `repl`); pin this so a `full`-feature build never grows one
+    // without an explicit, reviewed decision.
+    assert!(
+        !stdout.to_lowercase().contains("tui"),
+        "unexpected tui subcommand: {stdout}"
+    );
+}
+
+#[cfg(feature = "webui-v2-beta")]
+#[test]
+fn service_help_lists_all_verbs() {
+    let output = Command::new(reborn_bin())
+        .arg("service")
+        .arg("--help")
+        .output()
+        .expect("ironclaw-reborn service --help should run");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for verb in ["install", "start", "stop", "status", "restart", "uninstall"] {
+        assert!(stdout.contains(verb), "missing `{verb}` verb: {stdout}");
+    }
 }
 
 #[test]

--- a/crates/ironclaw_reborn_cli/tests/smoke.rs
+++ b/crates/ironclaw_reborn_cli/tests/smoke.rs
@@ -1460,7 +1460,14 @@ fn serve_fails_closed_when_env_user_id_var_is_unset() {
         .arg("0")
         .env("IRONCLAW_REBORN_HOME", temp.path().join("reborn-home"))
         .env_remove("IRONCLAW_REBORN_PROFILE")
-        .env("IRONCLAW_REBORN_WEBUI_TOKEN", "any-non-empty-token")
+        // >=32 bytes: must clear the token's own entropy floor (enforced by
+        // `webui_token::resolve_webui_token` as soon as the token is
+        // resolved, before the user-id var is read) so this test isolates
+        // the user-id-var-missing failure it's meant to exercise.
+        .env(
+            "IRONCLAW_REBORN_WEBUI_TOKEN",
+            "reborn-smoke-test-token-0123456789abcdef",
+        )
         .env_remove("IRONCLAW_REBORN_WEBUI_USER_ID")
         .output()
         .expect("ironclaw-reborn serve should run");
@@ -1601,6 +1608,81 @@ fn serve_with_env_auth_seeds_reborn_config_before_binding() {
         !config.contains("[llm.default]"),
         "serve seed must preserve no-LLM behavior: {config}"
     );
+}
+
+#[cfg(feature = "webui-v2-beta")]
+#[test]
+fn serve_resolves_bearer_token_from_reborn_home_webui_token_file() {
+    // Regression for the service-install crash loop: a launchd/systemd unit
+    // whose environment carries only HOME/PROFILE (see serve_invocation.rs)
+    // never sets IRONCLAW_REBORN_WEBUI_TOKEN, so `serve` must also accept
+    // the `onboard`-provisioned `<reborn_home>/webui-token` fallback file.
+    // Mirrors `serve_with_env_auth_seeds_reborn_config_before_binding` but
+    // omits the env var and seeds the file instead.
+    let temp = tempfile::tempdir().expect("tempdir");
+    let reborn_home = temp.path().join("reborn-home");
+    let home = temp.path().join("home");
+    std::fs::create_dir_all(&home).expect("home dir");
+    std::fs::create_dir_all(&reborn_home).expect("reborn home dir");
+    std::fs::write(
+        reborn_home.join("webui-token"),
+        // >=32 bytes: same entropy floor as the env-var path.
+        "reborn-smoke-test-token-0123456789abcdef",
+    )
+    .expect("seed webui-token file");
+    let port = unused_local_port();
+
+    let mut child = Command::new(reborn_bin())
+        .args(["serve", "--host", "127.0.0.1", "--port"])
+        .arg(port.to_string())
+        .env_clear()
+        .env("HOME", &home)
+        .env("IRONCLAW_REBORN_HOME", &reborn_home)
+        .env_remove("IRONCLAW_REBORN_WEBUI_TOKEN")
+        .env("IRONCLAW_REBORN_WEBUI_USER_ID", "test-user")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("ironclaw-reborn serve should start");
+    let stderr = child.stderr.take().expect("stderr should be piped");
+    let (stderr_tx, stderr_rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        for line in std::io::BufReader::new(stderr).lines() {
+            if stderr_tx.send(line).is_err() {
+                break;
+            }
+        }
+    });
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
+    let mut stderr_text = String::new();
+    loop {
+        if let Some(status) = child.try_wait().expect("serve child status") {
+            panic!("serve exited before binding with {status}; stderr: {stderr_text}");
+        }
+        if std::time::Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!("serve did not reach listener banner; stderr: {stderr_text}");
+        }
+        match stderr_rx.recv_timeout(std::time::Duration::from_millis(100)) {
+            Ok(Ok(line)) => {
+                stderr_text.push_str(&line);
+                stderr_text.push('\n');
+                if stderr_text.contains("ironclaw-reborn: WebChat v2 listener") {
+                    break;
+                }
+            }
+            Ok(Err(error)) => panic!("failed to read serve stderr: {error}"),
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                panic!("serve stderr closed before banner; stderr: {stderr_text}");
+            }
+        }
+    }
+
+    let _ = child.kill();
+    let _ = child.wait();
 }
 
 #[cfg(all(feature = "webui-v2-beta", feature = "slack-v2-host-beta"))]
@@ -2910,6 +2992,29 @@ fn onboard_bootstraps_reborn_home_without_touching_v1_state() {
         reborn_home.join("providers.json").exists(),
         "providers.json missing"
     );
+    // onboard also provisions a `<reborn_home>/webui-token` fallback file
+    // so a service-installed `serve` (unit env carries only HOME/PROFILE)
+    // still has a bearer token to read when IRONCLAW_REBORN_WEBUI_TOKEN is
+    // unset.
+    let webui_token_path = reborn_home.join("webui-token");
+    assert!(webui_token_path.exists(), "webui-token file missing");
+    let webui_token_text = std::fs::read_to_string(&webui_token_path).expect("read webui-token");
+    assert!(
+        webui_token_text.trim().len() >= 32,
+        "generated webui-token must meet the >=32 byte entropy floor: {} bytes",
+        webui_token_text.trim().len()
+    );
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = std::fs::metadata(&webui_token_path)
+            .expect("stat webui-token")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600, "webui-token file must be 0600, got {mode:o}");
+    }
+    assert_stdout_labeled_action(&stdout, "webui_token:", "wrote");
     let marker_path = reborn_home.join(".onboard-completed.json");
     assert!(marker_path.exists(), "onboarding marker missing");
     let marker_text = std::fs::read_to_string(marker_path).expect("read marker");
@@ -2919,6 +3024,49 @@ fn onboard_bootstraps_reborn_home_without_touching_v1_state() {
     assert!(
         !v1_home.exists(),
         "onboard must not create or read explicit v1 state"
+    );
+}
+
+#[test]
+fn onboard_is_idempotent_for_the_webui_token_file() {
+    // The token doubles as `serve`'s session-signing key, so a re-run of
+    // `onboard` must never clobber a valid existing token — that would
+    // invalidate every signed session and any env var an operator copied
+    // from the first run.
+    let temp = tempfile::tempdir().expect("tempdir");
+    let reborn_home = temp.path().join("reborn-home");
+
+    let first = Command::new(reborn_bin())
+        .arg("onboard")
+        .env_clear()
+        .env("IRONCLAW_REBORN_HOME", &reborn_home)
+        .output()
+        .expect("first onboard should run");
+    assert!(
+        first.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&first.stderr)
+    );
+    let token_path = reborn_home.join("webui-token");
+    let first_token = std::fs::read_to_string(&token_path).expect("read webui-token");
+
+    let second = Command::new(reborn_bin())
+        .arg("onboard")
+        .env_clear()
+        .env("IRONCLAW_REBORN_HOME", &reborn_home)
+        .output()
+        .expect("second onboard should run");
+    assert!(
+        second.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&second.stderr)
+    );
+    let second_stdout = String::from_utf8_lossy(&second.stdout);
+    assert_stdout_labeled_action(&second_stdout, "webui_token:", "preserved");
+    let second_token = std::fs::read_to_string(&token_path).expect("read webui-token again");
+    assert_eq!(
+        first_token, second_token,
+        "re-running onboard must not regenerate a valid webui-token"
     );
 }
 


### PR DESCRIPTION
## Summary

Extracts the **service half of #6157** (which stays open, parked, with the TUI). `ironclaw-reborn` gains a background-service story: install/uninstall/start/stop/status/restart on launchd (macOS LaunchAgent) and systemd (`--user` unit), plus the `full` feature bundle and libsql as the default storage backend so a default build is runnable as-is.

- `service install` writes the plist/unit atomically with rollback-on-failure (systemd) and bakes ONLY `IRONCLAW_REBORN_HOME` (+ optional profile) — never secrets. Pinned by exact-match tests on the env block.
- `service restart` composes stop+start through a shared `restart_generic` (fn-pointer seam): running → restarted; stopped → started; not installed → guidance error; stop-ok-start-fail → reported as STOPPED, never a silent half-restart.
- `service status` prints one normalized vocabulary on both platforms (`Service: running|stopped|not installed`); systemd preserves the raw ActiveState (e.g. `failed`) as a detail line.
- `serve` gains a token-file fallback (`<reborn_home>/webui-token`, 0600, atomic write) so a daemon with no shell env can authenticate — env var still wins when set.
- Surface invariants pinned in smoke tests: `tui` absent from a full build, all six service verbs listed.

Hosted safety: `Dockerfile.reborn` and workflows untouched; the reborn_cli build lines pass an explicit feature list without `--no-default-features`, and `libsql` was already in that list, so the default-feature change is a no-op for the hosted image.

## Review

Ran a 4-lane review (thermo-nuclear + approach/local-patterns/maintainability): no MUST-FIX; all Medium findings fixed in-branch (restart dedup via `restart_generic`, status vocabulary normalization + a real missing not-installed check on launchd, stale doc, `write_atomic` hoisted so launchd plist writes are crash-safe).

Deferred with rationale:
- `systemd.rs` test-module split (file is 1.2k lines, ~800 of which are `#[cfg(test)]` pinning every rollback branch) — reviewer's own verdict: reasonable to defer for a new, well-tested file.
- `sample_invocation` test-fixture dedup — tied to the above split.
- Native `systemctl restart` instead of composed stop+start — superseded by `restart_generic`, which keeps cross-platform behavior (accurate was-not-running messaging, uniform STOPPED contract) identical.

## Known gap (deliberate)

No CI workflow currently compiles `ironclaw_reborn_cli --features full`; closest lanes cover subsets. Suggested follow-up: add a `cargo build -p ironclaw_reborn_cli --features full` step to an existing reborn workflow. Not done here to keep this PR service-only.

## Test plan

- `cargo test -p ironclaw_reborn_cli --features full` — 426 tests green (service verbs at the fake-runner seam incl. all rollback branches; smoke tests drive the real binary for onboard/serve/token/help surfaces)
- `cargo clippy --all-targets --features full -- -D warnings`, `cargo fmt --check`, `cargo build --workspace` — clean
- Known pre-existing flake (`opt_in_persists_invite_code_when_set`, untouched file, passes in isolation) documented, not modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)