### PR TITLE
ci: build and validate Reborn release binaries across seven targets

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -65,8 +65,10 @@ Rules for a roll-up job that is (or may become) required:
 `ironclaw-reborn` binary. The tag-driven `release.yml` calls it and will not run
 its `host` job unless every target succeeds. The existing `release.yml` also
 owns the pull-request trigger, so a PR can validate the reusable workflow before
-that new workflow file reaches the default branch. After merge, the compile-only
-workflow can also run directly through `workflow_dispatch`.
+that new workflow file reaches the default branch. Pull-request runs skip the
+cargo-dist plan, packaging, host, and Docker jobs; those release jobs remain
+tag-only. After merge, the compile-only workflow can also run directly through
+`workflow_dispatch`.
 
 | Rust target | GitHub runner |
 |---|---|

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -81,7 +81,7 @@ seven-platform release matrix.
 Each matrix entry performs a final `cargo build --locked --profile dist` link
 for `ironclaw_reborn_cli` / `ironclaw` with an explicit compile feature
 contract owned by this workflow:
-`webui-v2-beta,slack-v2-host-beta,libsql,postgres,inmemory-turn-state`.
+`root-llm-provider,webui-v2-beta,slack-v2-host-beta,libsql,postgres,inmemory-turn-state`.
 Before upload, the workflow executes that exact native binary with `--version`,
 `--help`, and `profile list --json`. The musl entries also use `readelf` to
 reject a program interpreter or dynamic-library dependency, which prevents an

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -59,6 +59,43 @@ Rules for a roll-up job that is (or may become) required:
    merge-queue/push run's clippy matrix is missing any of the three feature
    lanes, so a "green but slim" regression cannot come back silently.
 
+## Reborn release binary compile matrix
+
+`reborn-release-compile.yml` is a compile-only preflight for the shipping
+`ironclaw-reborn` binary. The tag-driven `release.yml` calls it and will not run
+its `host` job unless every target succeeds. The existing `release.yml` also
+owns the pull-request trigger, so a PR can validate the reusable workflow before
+that new workflow file reaches the default branch. After merge, the compile-only
+workflow can also run directly through `workflow_dispatch`.
+
+| Rust target | GitHub runner |
+|---|---|
+| `x86_64-unknown-linux-gnu` | `ubuntu-22.04` |
+| `x86_64-unknown-linux-musl` | `ubuntu-22.04` |
+| `aarch64-unknown-linux-gnu` | `ubuntu-24.04-arm` |
+| `aarch64-unknown-linux-musl` | `ubuntu-24.04-arm` |
+| `x86_64-apple-darwin` | `macos-15-intel` |
+| `aarch64-apple-darwin` | `macos-15` |
+| `x86_64-pc-windows-msvc` | `windows-2022` |
+
+Each matrix entry performs a final `cargo build --locked --profile dist` link
+for `ironclaw_reborn_cli` / `ironclaw-reborn` with an explicit compile feature
+contract owned by this workflow:
+`webui-v2-beta,slack-v2-host-beta,libsql,postgres,inmemory-turn-state`.
+This proves compilation only; it does not provide runtime smoke coverage,
+installers, or cargo-dist release packaging. The feature list is intentionally
+not inferred from Docker or #6122.
+
+The uploaded `reborn-compile-*` artifacts are short-lived compile evidence.
+Their prefix deliberately does not match the release host's `artifacts-*`
+download pattern, so they are not attached to the GitHub Release. Until #3483
+defines the standalone Reborn tag/version/installer contract,
+`ironclaw_reborn_cli` remains `dist = false`.
+
+For #6160, the `release.yml` Docker caller remains present but has a constant
+false condition. This skips Docker build/publish on the release path without
+changing `docker.yml`; its manual and scheduled entry points remain available.
+
 ## Deep tier (nightly)
 
 `nightly-deep-ci.yml` (04:00 UTC) reuses `platform-and-compat.yml`,

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -62,7 +62,7 @@ Rules for a roll-up job that is (or may become) required:
 ## Reborn release binary compile matrix
 
 `reborn-release-compile.yml` is a compile-and-smoke preflight for the shipping
-`ironclaw-reborn` binary. The tag-only `release.yml` calls it for matching
+Reborn `ironclaw` binary. The tag-only `release.yml` calls it for matching
 release tags and will not run its `host` job unless every target succeeds. The
 preflight workflow can also run directly through `workflow_dispatch`; it is not
 triggered by pull requests, so ordinary CLI and WebUI changes do not start the
@@ -79,7 +79,7 @@ seven-platform release matrix.
 | `x86_64-pc-windows-msvc` | `windows-2022` |
 
 Each matrix entry performs a final `cargo build --locked --profile dist` link
-for `ironclaw_reborn_cli` / `ironclaw-reborn` with an explicit compile feature
+for `ironclaw_reborn_cli` / `ironclaw` with an explicit compile feature
 contract owned by this workflow:
 `webui-v2-beta,slack-v2-host-beta,libsql,postgres,inmemory-turn-state`.
 Before upload, the workflow executes that exact native binary with `--version`,
@@ -93,7 +93,7 @@ intentionally not inferred from Docker or #6122.
 The uploaded `reborn-compile-*` artifacts are short-lived preflight evidence.
 Their prefix deliberately does not match the release host's `artifacts-*`
 download pattern, so they are not attached to the GitHub Release. Until #3483
-defines the standalone Reborn tag/version/installer contract,
+defines the canonical Reborn package/tag/installer contract,
 `ironclaw_reborn_cli` remains `dist = false`.
 
 ## Deep tier (nightly)

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -61,13 +61,13 @@ Rules for a roll-up job that is (or may become) required:
 
 ## Reborn release binary compile matrix
 
-`reborn-release-compile.yml` is a compile-only preflight for the shipping
+`reborn-release-compile.yml` is a compile-and-smoke preflight for the shipping
 `ironclaw-reborn` binary. The tag-driven `release.yml` calls it and will not run
 its `host` job unless every target succeeds. The existing `release.yml` also
 owns the pull-request trigger, so a PR can validate the reusable workflow before
 that new workflow file reaches the default branch. Pull-request runs skip the
 cargo-dist plan, packaging, host, and Docker jobs; those release jobs remain
-tag-only. After merge, the compile-only workflow can also run directly through
+tag-only. After merge, the preflight workflow can also run directly through
 `workflow_dispatch`.
 
 | Rust target | GitHub runner |
@@ -84,11 +84,15 @@ Each matrix entry performs a final `cargo build --locked --profile dist` link
 for `ironclaw_reborn_cli` / `ironclaw-reborn` with an explicit compile feature
 contract owned by this workflow:
 `webui-v2-beta,slack-v2-host-beta,libsql,postgres,inmemory-turn-state`.
-This proves compilation only; it does not provide runtime smoke coverage,
-installers, or cargo-dist release packaging. The feature list is intentionally
-not inferred from Docker or #6122.
+Before upload, the workflow executes that exact native binary with `--version`,
+`--help`, and `profile list --json`. The musl entries also use `readelf` to
+reject a program interpreter or dynamic-library dependency, which prevents an
+installed musl loader on the build runner from hiding a non-portable artifact.
+This is shallow CLI startup coverage; it does not validate `serve`, external
+services, installers, or cargo-dist release packaging. The feature list is
+intentionally not inferred from Docker or #6122.
 
-The uploaded `reborn-compile-*` artifacts are short-lived compile evidence.
+The uploaded `reborn-compile-*` artifacts are short-lived preflight evidence.
 Their prefix deliberately does not match the release host's `artifacts-*`
 download pattern, so they are not attached to the GitHub Release. Until #3483
 defines the standalone Reborn tag/version/installer contract,

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -98,10 +98,6 @@ download pattern, so they are not attached to the GitHub Release. Until #3483
 defines the standalone Reborn tag/version/installer contract,
 `ironclaw_reborn_cli` remains `dist = false`.
 
-For #6160, the `release.yml` Docker caller remains present but has a constant
-false condition. This skips Docker build/publish on the release path without
-changing `docker.yml`; its manual and scheduled entry points remain available.
-
 ## Deep tier (nightly)
 
 `nightly-deep-ci.yml` (04:00 UTC) reuses `platform-and-compat.yml`,

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -62,13 +62,11 @@ Rules for a roll-up job that is (or may become) required:
 ## Reborn release binary compile matrix
 
 `reborn-release-compile.yml` is a compile-and-smoke preflight for the shipping
-`ironclaw-reborn` binary. The tag-driven `release.yml` calls it and will not run
-its `host` job unless every target succeeds. The existing `release.yml` also
-owns the pull-request trigger, so a PR can validate the reusable workflow before
-that new workflow file reaches the default branch. Pull-request runs skip the
-cargo-dist plan, packaging, host, and Docker jobs; those release jobs remain
-tag-only. After merge, the preflight workflow can also run directly through
-`workflow_dispatch`.
+`ironclaw-reborn` binary. The tag-only `release.yml` calls it for matching
+release tags and will not run its `host` job unless every target succeeds. The
+preflight workflow can also run directly through `workflow_dispatch`; it is not
+triggered by pull requests, so ordinary CLI and WebUI changes do not start the
+seven-platform release matrix.
 
 | Rust target | GitHub runner |
 |---|---|

--- a/.github/workflows/reborn-release-compile.yml
+++ b/.github/workflows/reborn-release-compile.yml
@@ -1,0 +1,151 @@
+name: Reborn Release Binary Compile
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: Commit SHA or ref to compile
+        required: false
+        type: string
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  # #6160 owns this compile contract. Keep it independent from cargo-dist and
+  # Docker changes so this workflow does not depend on the #6122 migration.
+  REBORN_RELEASE_FEATURES: webui-v2-beta,slack-v2-host-beta,libsql,postgres,inmemory-turn-state
+
+jobs:
+  compile:
+    name: ironclaw-reborn (${{ matrix.target }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            runner: ubuntu-22.04
+            binary: ironclaw-reborn
+            musl: false
+          - target: x86_64-unknown-linux-musl
+            runner: ubuntu-22.04
+            binary: ironclaw-reborn
+            musl: true
+            cc_env: CC_x86_64_unknown_linux_musl=musl-gcc
+            linker_env: CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc
+          - target: aarch64-unknown-linux-gnu
+            runner: ubuntu-24.04-arm
+            binary: ironclaw-reborn
+            musl: false
+          - target: aarch64-unknown-linux-musl
+            runner: ubuntu-24.04-arm
+            binary: ironclaw-reborn
+            musl: true
+            cc_env: CC_aarch64_unknown_linux_musl=musl-gcc
+            linker_env: CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc
+          - target: x86_64-apple-darwin
+            runner: macos-15-intel
+            binary: ironclaw-reborn
+            musl: false
+          - target: aarch64-apple-darwin
+            runner: macos-15
+            binary: ironclaw-reborn
+            musl: false
+          - target: x86_64-pc-windows-msvc
+            runner: windows-2022
+            binary: ironclaw-reborn.exe
+            musl: false
+    steps:
+      - name: Enable Windows long paths
+        if: runner.os == 'Windows'
+        run: git config --global core.longpaths true
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+          persist-credentials: false
+
+      - name: Install Rust target
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install Node.js for the embedded WebUI
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
+        with:
+          node-version: "22"
+
+      - name: Enable pnpm
+        run: corepack enable pnpm
+
+      - name: Install musl toolchain
+        if: matrix.musl
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes musl-tools
+
+      - name: Configure musl compiler
+        if: matrix.musl
+        shell: bash
+        env:
+          CC_ENV: ${{ matrix.cc_env }}
+          LINKER_ENV: ${{ matrix.linker_env }}
+        run: |
+          echo "$CC_ENV" >> "$GITHUB_ENV"
+          echo "$LINKER_ENV" >> "$GITHUB_ENV"
+
+      - name: Restore Rust cache
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          key: reborn-release-${{ matrix.target }}
+          save-if: ${{ github.event_name != 'pull_request' }}
+
+      - id: build
+        name: Compile ironclaw-reborn
+        shell: bash
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          cargo build --locked --profile dist \
+            --package ironclaw_reborn_cli \
+            --bin ironclaw-reborn \
+            --target "$TARGET" \
+            --features "$REBORN_RELEASE_FEATURES"
+
+      # These are compile evidence only. The reborn-compile-* prefix keeps the
+      # existing release host's artifacts-* download pattern from publishing them.
+      - id: upload
+        name: Upload compile evidence
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: reborn-compile-${{ matrix.target }}
+          path: target/${{ matrix.target }}/dist/${{ matrix.binary }}
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Summarize compile result
+        if: always()
+        shell: bash
+        env:
+          TARGET: ${{ matrix.target }}
+          RUNNER: ${{ matrix.runner }}
+          BINARY: ${{ matrix.binary }}
+          BUILD_RESULT: ${{ steps.build.outcome || 'not-run' }}
+          UPLOAD_RESULT: ${{ steps.upload.outcome || 'not-run' }}
+        run: |
+          {
+            echo "### ironclaw-reborn compile"
+            echo
+            echo "- Target: \`$TARGET\`"
+            echo "- Runner: \`$RUNNER\`"
+            echo "- Features: \`$REBORN_RELEASE_FEATURES\`"
+            echo "- Binary: \`target/$TARGET/dist/$BINARY\`"
+            echo "- Build result: \`$BUILD_RESULT\`"
+            echo "- Compile evidence upload: \`$UPLOAD_RESULT\`"
+            echo "- Docker publish: skipped by the release workflow for #6160"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/reborn-release-compile.yml
+++ b/.github/workflows/reborn-release-compile.yml
@@ -23,6 +23,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 120
     strategy:
+      # Run every target so one release attempt reports the complete platform matrix.
       fail-fast: false
       matrix:
         include:
@@ -72,6 +73,7 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      # webui-v2-beta embeds the frontend during compilation and requires Node/pnpm.
       - name: Install Node.js for the embedded WebUI
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
         with:
@@ -85,7 +87,7 @@ jobs:
         shell: bash
         run: |
           sudo apt-get update
-          sudo apt-get install --yes musl-tools
+          sudo apt-get install --yes musl-tools binutils
 
       - name: Configure musl C compiler
         if: matrix.musl
@@ -160,7 +162,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: reborn-compile-${{ matrix.target }}
-          path: target/${{ matrix.target }}/dist/${{ matrix.binary }}
+          path: "target/${{ matrix.target }}/dist/${{ matrix.binary }}"
           if-no-files-found: error
           retention-days: 7
 

--- a/.github/workflows/reborn-release-compile.yml
+++ b/.github/workflows/reborn-release-compile.yml
@@ -35,7 +35,6 @@ jobs:
             binary: ironclaw-reborn
             musl: true
             cc_env: CC_x86_64_unknown_linux_musl=musl-gcc
-            linker_env: CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc
           - target: aarch64-unknown-linux-gnu
             runner: ubuntu-24.04-arm
             binary: ironclaw-reborn
@@ -45,7 +44,6 @@ jobs:
             binary: ironclaw-reborn
             musl: true
             cc_env: CC_aarch64_unknown_linux_musl=musl-gcc
-            linker_env: CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc
           - target: x86_64-apple-darwin
             runner: macos-15-intel
             binary: ironclaw-reborn
@@ -89,15 +87,13 @@ jobs:
           sudo apt-get update
           sudo apt-get install --yes musl-tools
 
-      - name: Configure musl compiler
+      - name: Configure musl C compiler
         if: matrix.musl
         shell: bash
         env:
           CC_ENV: ${{ matrix.cc_env }}
-          LINKER_ENV: ${{ matrix.linker_env }}
         run: |
           echo "$CC_ENV" >> "$GITHUB_ENV"
-          echo "$LINKER_ENV" >> "$GITHUB_ENV"
 
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
@@ -117,7 +113,48 @@ jobs:
             --target "$TARGET" \
             --features "$REBORN_RELEASE_FEATURES"
 
-      # These are compile evidence only. The reborn-compile-* prefix keeps the
+      # Rust's musl targets provide a self-contained static CRT. Do not set the
+      # final Rust linker to musl-gcc: Ubuntu 22's wrapper mishandles x86_64
+      # static PIE and can leave an otherwise-static binary with a PT_INTERP.
+      - id: linkage
+        name: Verify musl portability
+        if: matrix.musl
+        shell: bash
+        env:
+          TARGET: ${{ matrix.target }}
+          BINARY: ${{ matrix.binary }}
+        run: |
+          binary_path="target/$TARGET/dist/$BINARY"
+          program_headers="$(readelf --program-headers --wide "$binary_path")"
+          dynamic_tags="$(readelf --dynamic --wide "$binary_path")"
+
+          if grep -Eq '^[[:space:]]*INTERP[[:space:]]' <<< "$program_headers"; then
+            echo "::error::$TARGET must not require a musl program interpreter"
+            echo "$program_headers"
+            exit 1
+          fi
+
+          if grep -q '(NEEDED)' <<< "$dynamic_tags"; then
+            echo "::error::$TARGET must not contain dynamic library dependencies"
+            echo "$dynamic_tags"
+            exit 1
+          fi
+
+          file "$binary_path"
+
+      - id: smoke
+        name: Smoke compiled binary
+        shell: bash
+        env:
+          TARGET: ${{ matrix.target }}
+          BINARY: ${{ matrix.binary }}
+        run: |
+          binary_path="target/$TARGET/dist/$BINARY"
+          "$binary_path" --version
+          "$binary_path" --help > /dev/null
+          "$binary_path" profile list --json > /dev/null
+
+      # These are preflight evidence only. The reborn-compile-* prefix keeps the
       # existing release host's artifacts-* download pattern from publishing them.
       - id: upload
         name: Upload compile evidence
@@ -136,6 +173,8 @@ jobs:
           RUNNER: ${{ matrix.runner }}
           BINARY: ${{ matrix.binary }}
           BUILD_RESULT: ${{ steps.build.outcome || 'not-run' }}
+          LINKAGE_RESULT: ${{ steps.linkage.outcome || 'not-run' }}
+          SMOKE_RESULT: ${{ steps.smoke.outcome || 'not-run' }}
           UPLOAD_RESULT: ${{ steps.upload.outcome || 'not-run' }}
         run: |
           {
@@ -146,6 +185,8 @@ jobs:
             echo "- Features: \`$REBORN_RELEASE_FEATURES\`"
             echo "- Binary: \`target/$TARGET/dist/$BINARY\`"
             echo "- Build result: \`$BUILD_RESULT\`"
-            echo "- Compile evidence upload: \`$UPLOAD_RESULT\`"
+            echo "- musl portability: \`$LINKAGE_RESULT\`"
+            echo "- Native CLI smoke: \`$SMOKE_RESULT\`"
+            echo "- Preflight evidence upload: \`$UPLOAD_RESULT\`"
             echo "- Docker publish: skipped by the release workflow for #6160"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/reborn-release-compile.yml
+++ b/.github/workflows/reborn-release-compile.yml
@@ -15,7 +15,9 @@ permissions:
 env:
   # #6160 owns this compile contract. Keep it independent from cargo-dist and
   # Docker changes so this workflow does not depend on the #6122 migration.
-  REBORN_RELEASE_FEATURES: webui-v2-beta,slack-v2-host-beta,libsql,postgres,inmemory-turn-state
+  # Keep the production LLM provider explicit even though Cargo defaults also
+  # enable it today, so a future default-feature change cannot weaken releases.
+  REBORN_RELEASE_FEATURES: root-llm-provider,webui-v2-beta,slack-v2-host-beta,libsql,postgres,inmemory-turn-state
 
 jobs:
   compile:
@@ -87,7 +89,7 @@ jobs:
         shell: bash
         run: |
           sudo apt-get update
-          sudo apt-get install --yes musl-tools binutils
+          sudo apt-get install --yes musl-tools binutils file
 
       - name: Configure musl C compiler
         if: matrix.musl

--- a/.github/workflows/reborn-release-compile.yml
+++ b/.github/workflows/reborn-release-compile.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   compile:
-    name: ironclaw-reborn (${{ matrix.target }})
+    name: ironclaw (Reborn, ${{ matrix.target }})
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 120
     strategy:
@@ -28,33 +28,33 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             runner: ubuntu-22.04
-            binary: ironclaw-reborn
+            binary: ironclaw
             musl: false
           - target: x86_64-unknown-linux-musl
             runner: ubuntu-22.04
-            binary: ironclaw-reborn
+            binary: ironclaw
             musl: true
             cc_env: CC_x86_64_unknown_linux_musl=musl-gcc
           - target: aarch64-unknown-linux-gnu
             runner: ubuntu-24.04-arm
-            binary: ironclaw-reborn
+            binary: ironclaw
             musl: false
           - target: aarch64-unknown-linux-musl
             runner: ubuntu-24.04-arm
-            binary: ironclaw-reborn
+            binary: ironclaw
             musl: true
             cc_env: CC_aarch64_unknown_linux_musl=musl-gcc
           - target: x86_64-apple-darwin
             runner: macos-15-intel
-            binary: ironclaw-reborn
+            binary: ironclaw
             musl: false
           - target: aarch64-apple-darwin
             runner: macos-15
-            binary: ironclaw-reborn
+            binary: ironclaw
             musl: false
           - target: x86_64-pc-windows-msvc
             runner: windows-2022
-            binary: ironclaw-reborn.exe
+            binary: ironclaw.exe
             musl: false
     steps:
       - name: Enable Windows long paths
@@ -101,14 +101,14 @@ jobs:
           key: reborn-release-${{ matrix.target }}
 
       - id: build
-        name: Compile ironclaw-reborn
+        name: Compile ironclaw
         shell: bash
         env:
           TARGET: ${{ matrix.target }}
         run: |
           cargo build --locked --profile dist \
             --package ironclaw_reborn_cli \
-            --bin ironclaw-reborn \
+            --bin ironclaw \
             --target "$TARGET" \
             --features "$REBORN_RELEASE_FEATURES"
 
@@ -177,7 +177,7 @@ jobs:
           UPLOAD_RESULT: ${{ steps.upload.outcome || 'not-run' }}
         run: |
           {
-            echo "### ironclaw-reborn compile"
+            echo "### ironclaw (Reborn) compile"
             echo
             echo "- Target: \`$TARGET\`"
             echo "- Runner: \`$RUNNER\`"

--- a/.github/workflows/reborn-release-compile.yml
+++ b/.github/workflows/reborn-release-compile.yml
@@ -188,5 +188,4 @@ jobs:
             echo "- musl portability: \`$LINKAGE_RESULT\`"
             echo "- Native CLI smoke: \`$SMOKE_RESULT\`"
             echo "- Preflight evidence upload: \`$UPLOAD_RESULT\`"
-            echo "- Docker publish: skipped by the release workflow for #6160"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/reborn-release-compile.yml
+++ b/.github/workflows/reborn-release-compile.yml
@@ -99,7 +99,6 @@ jobs:
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: reborn-release-${{ matrix.target }}
-          save-if: ${{ github.event_name != 'pull_request' }}
 
       - id: build
         name: Compile ironclaw-reborn

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,18 +42,6 @@ on:
   push:
     tags:
       - 'ironclaw-v[0-9]+.[0-9]+.[0-9]+*'
-  # release.yml already exists on the default branch, so this trigger can
-  # validate the new reusable workflow before that new file is merged.
-  pull_request:
-    branches:
-      - main
-    paths:
-      - '.github/workflows/release.yml'
-      - '.github/workflows/reborn-release-compile.yml'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
-      - 'crates/ironclaw_reborn_cli/**'
-      - 'crates/ironclaw_webui_v2/**'
 
 jobs:
   # Compile the shipping Reborn binary on every supported release target.
@@ -67,9 +55,6 @@ jobs:
 
   # Run 'dist plan' (or host) to determine what tasks we need to do
   plan:
-    # Pull requests use this existing workflow only as the trusted entry point
-    # for the Reborn compile matrix. Keep cargo-dist's release planning tag-only.
-    if: ${{ github.event_name != 'pull_request' }}
     runs-on: "ubuntu-22.04"
     outputs:
       val: ${{ steps.plan.outputs.manifest }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -496,11 +496,10 @@ jobs:
           # shellcheck disable=SC2086  # PRERELEASE_FLAG is '--prerelease' or empty
           gh release create "$RELEASE_TAG" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
 
-  # Keep the Docker caller visible but disabled while #6160 validates release
-  # binaries. docker.yml remains available through its own manual/scheduled runs.
+  # Build and push Docker Hub images (:version, :latest, :sha-*) after the GitHub Release exists.
   docker-image:
     needs: host
-    if: ${{ false }}
+    if: ${{ always() && needs.host.result == 'success' }}
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,9 @@ jobs:
 
   # Run 'dist plan' (or host) to determine what tasks we need to do
   plan:
+    # Pull requests use this existing workflow only as the trusted entry point
+    # for the Reborn compile matrix. Keep cargo-dist's release planning tag-only.
+    if: ${{ github.event_name != 'pull_request' }}
     runs-on: "ubuntu-22.04"
     outputs:
       val: ${{ steps.plan.outputs.manifest }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,8 +42,29 @@ on:
   push:
     tags:
       - 'ironclaw-v[0-9]+.[0-9]+.[0-9]+*'
+  # release.yml already exists on the default branch, so this trigger can
+  # validate the new reusable workflow before that new file is merged.
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/release.yml'
+      - '.github/workflows/reborn-release-compile.yml'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'crates/ironclaw_reborn_cli/**'
+      - 'crates/ironclaw_webui_v2/**'
 
 jobs:
+  # Compile the shipping Reborn binary on every supported release target.
+  # This is intentionally separate from cargo-dist until #3483 resolves the
+  # Reborn package/tag/installer contract.
+  reborn-binary-compile:
+    name: Reborn binary compile
+    uses: ./.github/workflows/reborn-release-compile.yml
+    with:
+      ref: ${{ github.sha }}
+
   # Run 'dist plan' (or host) to determine what tasks we need to do
   plan:
     runs-on: "ubuntu-22.04"
@@ -402,8 +423,10 @@ jobs:
       - build-local-artifacts
       - build-global-artifacts
       - build-wasm-extensions
-    # Only run if we're "publishing", and only if plan, local, global, and wasm didn't fail (skipped is fine)
-    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') && (needs.build-wasm-extensions.result == 'skipped' || needs.build-wasm-extensions.result == 'success') }}
+      - reborn-binary-compile
+    # Only publish after the explicit Reborn target matrix succeeds. Existing
+    # cargo-dist jobs may still be skipped, but a failed Reborn compile is fatal.
+    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') && (needs.build-wasm-extensions.result == 'skipped' || needs.build-wasm-extensions.result == 'success') && needs.reborn-binary-compile.result == 'success' }}
     permissions:
       contents: write
     env:
@@ -470,10 +493,11 @@ jobs:
           # shellcheck disable=SC2086  # PRERELEASE_FLAG is '--prerelease' or empty
           gh release create "$RELEASE_TAG" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
 
-  # Build and push Docker Hub images (:version, :latest, :sha-*) after the GitHub Release exists.
+  # Keep the Docker caller visible but disabled while #6160 validates release
+  # binaries. docker.yml remains available through its own manual/scheduled runs.
   docker-image:
     needs: host
-    if: ${{ always() && needs.host.result == 'success' }}
+    if: ${{ false }}
     permissions:
       contents: read
       packages: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### CI / Release
 
-- *(release)* compile `ironclaw-reborn` across the seven supported OS/CPU targets before hosting a release ([#6160](https://github.com/nearai/ironclaw/issues/6160)).
+- *(release)* compile `ironclaw-reborn` across the seven supported OS/CPU targets as a tag-driven release preflight ([#6160](https://github.com/nearai/ironclaw/issues/6160)).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### CI / Release
 
-- *(release)* compile `ironclaw-reborn` across the seven supported OS/CPU targets as a tag-driven release preflight ([#6160](https://github.com/nearai/ironclaw/issues/6160)).
+- *(release)* compile the canonical Reborn `ironclaw` binary across the seven supported OS/CPU targets as a tag-driven release preflight ([#6160](https://github.com/nearai/ironclaw/issues/6160)).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### CI / Release
 
-- *(release)* compile `ironclaw-reborn` across the seven supported OS/CPU targets before hosting a release, and temporarily skip Docker publishing on that path ([#6160](https://github.com/nearai/ironclaw/issues/6160)).
+- *(release)* compile `ironclaw-reborn` across the seven supported OS/CPU targets before hosting a release ([#6160](https://github.com/nearai/ironclaw/issues/6160)).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - *(channels)* v1 Slack DM policy now defaults to `allowlist` (previously `pairing`); existing installs still configured with `dm_policy=pairing` fall through to `allowlist` as Slack relay pairing is retired ([#5604](https://github.com/nearai/ironclaw/pull/5604)).
 - *(reborn-cli)* **Breaking:** `ironclaw-reborn serve` now rejects the legacy `[slack]` config fields (`installation_id`, `team_id`, `api_app_id`, `slack_user_id`, `user_id`, `shared_subject_user_id`, `signing_secret_env`, `bot_token_env`, `channel_routes`). Slack bot credentials and routing are configured from the WebUI channel setup page; per-user identity comes only from Slack OAuth. `[slack].enabled` / `IRONCLAW_REBORN_SLACK_ENABLED` still gate whether the channel mounts ([#5604](https://github.com/nearai/ironclaw/pull/5604)).
 
+### CI / Release
+
+- *(release)* compile `ironclaw-reborn` across the seven supported OS/CPU targets before hosting a release, and temporarily skip Docker publishing on that path ([#6160](https://github.com/nearai/ironclaw/issues/6160)).
+
 ### Removed
 
 - *(channels)* remove the v1 `pairing_approve` builtin tool and the generic `channel_connection_resume` machinery as part of retiring Slack relay pairing; existing Slack pairing users reconnect via OAuth (Telegram/WASM self-service pairing via the pairing endpoints is unaffected) ([#5604](https://github.com/nearai/ironclaw/pull/5604)).

--- a/crates/ironclaw_reborn_cli/tests/smoke.rs
+++ b/crates/ironclaw_reborn_cli/tests/smoke.rs
@@ -272,33 +272,26 @@ fn release_ci_compiles_reborn_for_all_supported_targets() {
         "compile evidence must stay outside cargo-dist's artifacts-* release namespace"
     );
 
-    let release_pr_trigger = concat!(
-        "  pull_request:\n",
-        "    branches:\n",
-        "      - main\n",
-        "    paths:\n",
-        "      - '.github/workflows/release.yml'\n",
-        "      - '.github/workflows/reborn-release-compile.yml'\n",
-        "      - 'Cargo.toml'\n",
-        "      - 'Cargo.lock'\n",
-        "      - 'crates/ironclaw_reborn_cli/**'\n",
-        "      - 'crates/ironclaw_webui_v2/**'\n",
+    let release_tag_trigger = concat!(
+        "  push:\n",
+        "    tags:\n",
+        "      - 'ironclaw-v[0-9]+.[0-9]+.[0-9]+*'\n",
     );
     assert!(
-        release_workflow.contains("uses: ./.github/workflows/reborn-release-compile.yml")
+        release_workflow.contains(release_tag_trigger)
+            && release_workflow.contains("uses: ./.github/workflows/reborn-release-compile.yml")
             && release_workflow.contains("needs.reborn-binary-compile.result == 'success'")
-            && release_workflow.contains(release_pr_trigger)
+            && compile_workflow.contains("  workflow_call:\n")
+            && compile_workflow.contains("  workflow_dispatch:\n")
+            && !release_workflow.contains("\n  pull_request:\n")
             && !compile_workflow.contains("  pull_request:\n"),
-        "the existing release workflow must own PR validation for main and every release input, and wait for the Reborn matrix"
+        "the tag-only release workflow must wait for the Reborn matrix while keeping an independent manual preflight"
     );
     assert!(
-        release_workflow.contains("publishing: ${{ !github.event.pull_request }}")
-            && release_workflow.contains("needs.plan.outputs.publishing == 'true'")
-            && release_workflow.contains(
-                "  plan:\n    # Pull requests use this existing workflow only as the trusted entry point\n    # for the Reborn compile matrix. Keep cargo-dist's release planning tag-only.\n    if: ${{ github.event_name != 'pull_request' }}"
-            )
+        release_workflow.contains("needs.plan.outputs.publishing == 'true'")
+            && !release_workflow.contains("if: ${{ github.event_name != 'pull_request' }}")
             && compile_workflow.contains("permissions:\n  contents: read"),
-        "PR compile validation must remain read-only and must skip cargo-dist planning and release publishing"
+        "release compilation must remain read-only without adding PR-only cargo-dist gates"
     );
     assert!(
         cli_manifest.contains("[package.metadata.dist]\ndist = false"),

--- a/crates/ironclaw_reborn_cli/tests/smoke.rs
+++ b/crates/ironclaw_reborn_cli/tests/smoke.rs
@@ -246,8 +246,11 @@ fn release_ci_compiles_reborn_for_all_supported_targets_without_docker_publish()
     assert!(
         release_workflow.contains("publishing: ${{ !github.event.pull_request }}")
             && release_workflow.contains("needs.plan.outputs.publishing == 'true'")
+            && release_workflow.contains(
+                "  plan:\n    # Pull requests use this existing workflow only as the trusted entry point\n    # for the Reborn compile matrix. Keep cargo-dist's release planning tag-only.\n    if: ${{ github.event_name != 'pull_request' }}"
+            )
             && compile_workflow.contains("permissions:\n  contents: read"),
-        "PR compile validation must remain read-only and must not enter release publishing"
+        "PR compile validation must remain read-only and must skip cargo-dist planning and release publishing"
     );
     let docker_job = release_workflow
         .split_once("  docker-image:\n")

--- a/crates/ironclaw_reborn_cli/tests/smoke.rs
+++ b/crates/ironclaw_reborn_cli/tests/smoke.rs
@@ -221,13 +221,46 @@ fn release_ci_compiles_reborn_for_all_supported_targets_without_docker_publish()
     assert!(
         compile_workflow.matches("musl: true").count() == 2
             && compile_workflow.contains("sudo apt-get install --yes musl-tools")
-            && compile_workflow.contains("CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER")
-            && compile_workflow.contains("CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER")
+            && compile_workflow.contains("CC_x86_64_unknown_linux_musl=musl-gcc")
+            && compile_workflow.contains("CC_aarch64_unknown_linux_musl=musl-gcc")
+            && !compile_workflow.contains("CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER")
+            && !compile_workflow.contains("CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER")
             && compile_workflow.contains("node-version: \"22\"")
             && compile_workflow.contains("corepack enable pnpm")
             && compile_workflow.contains("binary: ironclaw-reborn.exe")
             && compile_workflow.contains("core.longpaths true"),
-        "release CI must install the target-specific native and WebUI build prerequisites"
+        "release CI must use musl-gcc for C dependencies without overriding Rust's self-contained musl linker"
+    );
+    assert!(
+        compile_workflow.contains("name: Verify musl portability\n        if: matrix.musl")
+            && compile_workflow.contains("readelf --program-headers --wide")
+            && compile_workflow.contains("readelf --dynamic --wide")
+            && compile_workflow.contains("INTERP")
+            && compile_workflow.contains("(NEEDED)")
+            && compile_workflow.contains("name: Smoke compiled binary")
+            && compile_workflow.contains("\"$binary_path\" --version")
+            && compile_workflow.contains("\"$binary_path\" --help > /dev/null")
+            && compile_workflow.contains("\"$binary_path\" profile list --json > /dev/null"),
+        "release CI must reject non-portable musl binaries and smoke the exact native artifacts"
+    );
+
+    let build_position = compile_workflow
+        .find("name: Compile ironclaw-reborn")
+        .expect("compile step");
+    let linkage_position = compile_workflow
+        .find("name: Verify musl portability")
+        .expect("musl linkage step");
+    let smoke_position = compile_workflow
+        .find("name: Smoke compiled binary")
+        .expect("binary smoke step");
+    let upload_position = compile_workflow
+        .find("name: Upload compile evidence")
+        .expect("compile evidence upload step");
+    assert!(
+        build_position < linkage_position
+            && linkage_position < smoke_position
+            && smoke_position < upload_position,
+        "linkage and runtime validation must gate artifact upload"
     );
     assert!(
         compile_workflow.contains("name: reborn-compile-${{ matrix.target }}")

--- a/crates/ironclaw_reborn_cli/tests/smoke.rs
+++ b/crates/ironclaw_reborn_cli/tests/smoke.rs
@@ -214,7 +214,8 @@ fn release_ci_compiles_reborn_for_all_supported_targets() {
         compile_workflow.contains("fail-fast: false")
             && compile_workflow.contains("cargo build --locked --profile dist")
             && compile_workflow.contains("--package ironclaw_reborn_cli")
-            && compile_workflow.contains("--bin ironclaw-reborn")
+            && compile_workflow.contains("            --bin ironclaw \\\n")
+            && !compile_workflow.contains("--bin ironclaw-reborn")
             && compile_workflow.contains("--target \"$TARGET\"")
             && compile_workflow
                 .contains(&format!("  REBORN_RELEASE_FEATURES: {release_features}\n"))
@@ -230,7 +231,8 @@ fn release_ci_compiles_reborn_for_all_supported_targets() {
             && !compile_workflow.contains("CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER")
             && compile_workflow.contains("node-version: \"22\"")
             && compile_workflow.contains("corepack enable pnpm")
-            && compile_workflow.contains("binary: ironclaw-reborn.exe")
+            && compile_workflow.contains("binary: ironclaw.exe")
+            && !compile_workflow.contains("binary: ironclaw-reborn")
             && compile_workflow.contains("core.longpaths true"),
         "release CI must use musl-gcc for C dependencies without overriding Rust's self-contained musl linker"
     );
@@ -248,7 +250,7 @@ fn release_ci_compiles_reborn_for_all_supported_targets() {
     );
 
     let build_position = compile_workflow
-        .find("name: Compile ironclaw-reborn")
+        .find("name: Compile ironclaw")
         .expect("compile step");
     let linkage_position = compile_workflow
         .find("name: Verify musl portability")

--- a/crates/ironclaw_reborn_cli/tests/smoke.rs
+++ b/crates/ironclaw_reborn_cli/tests/smoke.rs
@@ -173,15 +173,13 @@ fn dockerfile_reborn_builds_with_production_features() {
 }
 
 #[test]
-fn release_ci_compiles_reborn_for_all_supported_targets_without_docker_publish() {
+fn release_ci_compiles_reborn_for_all_supported_targets() {
     let root = workspace_root();
     let compile_workflow =
         std::fs::read_to_string(root.join(".github/workflows/reborn-release-compile.yml"))
             .expect("Reborn release compile workflow");
     let release_workflow = std::fs::read_to_string(root.join(".github/workflows/release.yml"))
         .expect("release workflow");
-    let docker_workflow = std::fs::read_to_string(root.join(".github/workflows/docker.yml"))
-        .expect("Docker workflow");
     let cli_manifest = std::fs::read_to_string(root.join("crates/ironclaw_reborn_cli/Cargo.toml"))
         .expect("Reborn CLI manifest");
 
@@ -284,20 +282,6 @@ fn release_ci_compiles_reborn_for_all_supported_targets_without_docker_publish()
             )
             && compile_workflow.contains("permissions:\n  contents: read"),
         "PR compile validation must remain read-only and must skip cargo-dist planning and release publishing"
-    );
-    let docker_job = release_workflow
-        .split_once("  docker-image:\n")
-        .and_then(|(_, jobs)| jobs.split_once("\n  update-registry-checksums:"))
-        .map(|(job, _)| job)
-        .expect("release workflow should retain the Docker caller job");
-    assert!(
-        docker_job.contains("if: ${{ false }}")
-            && docker_job.contains("uses: ./.github/workflows/docker.yml"),
-        "release CI must retain but skip its Docker caller"
-    );
-    assert!(
-        docker_workflow.contains("workflow_dispatch:") && docker_workflow.contains("schedule:"),
-        "the independent Docker workflow must remain manually and periodically runnable"
     );
     assert!(
         cli_manifest.contains("[package.metadata.dist]\ndist = false"),

--- a/crates/ironclaw_reborn_cli/tests/smoke.rs
+++ b/crates/ironclaw_reborn_cli/tests/smoke.rs
@@ -177,11 +177,14 @@ fn release_ci_compiles_reborn_for_all_supported_targets() {
     let root = workspace_root();
     let compile_workflow =
         std::fs::read_to_string(root.join(".github/workflows/reborn-release-compile.yml"))
-            .expect("Reborn release compile workflow");
+            .expect("Reborn release compile workflow")
+            .replace("\r\n", "\n");
     let release_workflow = std::fs::read_to_string(root.join(".github/workflows/release.yml"))
-        .expect("release workflow");
+        .expect("release workflow")
+        .replace("\r\n", "\n");
     let cli_manifest = std::fs::read_to_string(root.join("crates/ironclaw_reborn_cli/Cargo.toml"))
-        .expect("Reborn CLI manifest");
+        .expect("Reborn CLI manifest")
+        .replace("\r\n", "\n");
 
     let target_runners = [
         ("x86_64-unknown-linux-gnu", "ubuntu-22.04"),
@@ -213,7 +216,9 @@ fn release_ci_compiles_reborn_for_all_supported_targets() {
             && compile_workflow.contains("--package ironclaw_reborn_cli")
             && compile_workflow.contains("--bin ironclaw-reborn")
             && compile_workflow.contains("--target \"$TARGET\"")
-            && compile_workflow.contains(release_features),
+            && compile_workflow
+                .contains(&format!("  REBORN_RELEASE_FEATURES: {release_features}\n"))
+            && compile_workflow.contains("            --features \"$REBORN_RELEASE_FEATURES\""),
         "Reborn release CI must fully link the shipping binary and keep all target results"
     );
     assert!(
@@ -267,12 +272,24 @@ fn release_ci_compiles_reborn_for_all_supported_targets() {
         "compile evidence must stay outside cargo-dist's artifacts-* release namespace"
     );
 
+    let release_pr_trigger = concat!(
+        "  pull_request:\n",
+        "    branches:\n",
+        "      - main\n",
+        "    paths:\n",
+        "      - '.github/workflows/release.yml'\n",
+        "      - '.github/workflows/reborn-release-compile.yml'\n",
+        "      - 'Cargo.toml'\n",
+        "      - 'Cargo.lock'\n",
+        "      - 'crates/ironclaw_reborn_cli/**'\n",
+        "      - 'crates/ironclaw_webui_v2/**'\n",
+    );
     assert!(
         release_workflow.contains("uses: ./.github/workflows/reborn-release-compile.yml")
             && release_workflow.contains("needs.reborn-binary-compile.result == 'success'")
-            && release_workflow.contains("  pull_request:\n")
+            && release_workflow.contains(release_pr_trigger)
             && !compile_workflow.contains("  pull_request:\n"),
-        "the existing release workflow must own PR validation and wait for the Reborn matrix"
+        "the existing release workflow must own PR validation for main and every release input, and wait for the Reborn matrix"
     );
     assert!(
         release_workflow.contains("publishing: ${{ !github.event.pull_request }}")

--- a/crates/ironclaw_reborn_cli/tests/smoke.rs
+++ b/crates/ironclaw_reborn_cli/tests/smoke.rs
@@ -173,6 +173,103 @@ fn dockerfile_reborn_builds_with_production_features() {
 }
 
 #[test]
+fn release_ci_compiles_reborn_for_all_supported_targets_without_docker_publish() {
+    let root = workspace_root();
+    let compile_workflow =
+        std::fs::read_to_string(root.join(".github/workflows/reborn-release-compile.yml"))
+            .expect("Reborn release compile workflow");
+    let release_workflow = std::fs::read_to_string(root.join(".github/workflows/release.yml"))
+        .expect("release workflow");
+    let docker_workflow = std::fs::read_to_string(root.join(".github/workflows/docker.yml"))
+        .expect("Docker workflow");
+    let cli_manifest = std::fs::read_to_string(root.join("crates/ironclaw_reborn_cli/Cargo.toml"))
+        .expect("Reborn CLI manifest");
+
+    let target_runners = [
+        ("x86_64-unknown-linux-gnu", "ubuntu-22.04"),
+        ("x86_64-unknown-linux-musl", "ubuntu-22.04"),
+        ("aarch64-unknown-linux-gnu", "ubuntu-24.04-arm"),
+        ("aarch64-unknown-linux-musl", "ubuntu-24.04-arm"),
+        ("x86_64-apple-darwin", "macos-15-intel"),
+        ("aarch64-apple-darwin", "macos-15"),
+        ("x86_64-pc-windows-msvc", "windows-2022"),
+    ];
+    let release_features = "webui-v2-beta,slack-v2-host-beta,libsql,postgres,inmemory-turn-state";
+
+    assert_eq!(
+        compile_workflow.matches("          - target: ").count(),
+        target_runners.len(),
+        "Reborn release compile matrix must contain exactly seven targets"
+    );
+    for (target, runner) in target_runners {
+        let matrix_entry = format!("          - target: {target}\n            runner: {runner}\n");
+        assert!(
+            compile_workflow.contains(&matrix_entry),
+            "Reborn release compile matrix must map {target} to {runner}"
+        );
+    }
+
+    assert!(
+        compile_workflow.contains("fail-fast: false")
+            && compile_workflow.contains("cargo build --locked --profile dist")
+            && compile_workflow.contains("--package ironclaw_reborn_cli")
+            && compile_workflow.contains("--bin ironclaw-reborn")
+            && compile_workflow.contains("--target \"$TARGET\"")
+            && compile_workflow.contains(release_features),
+        "Reborn release CI must fully link the shipping binary and keep all target results"
+    );
+    assert!(
+        compile_workflow.matches("musl: true").count() == 2
+            && compile_workflow.contains("sudo apt-get install --yes musl-tools")
+            && compile_workflow.contains("CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER")
+            && compile_workflow.contains("CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER")
+            && compile_workflow.contains("node-version: \"22\"")
+            && compile_workflow.contains("corepack enable pnpm")
+            && compile_workflow.contains("binary: ironclaw-reborn.exe")
+            && compile_workflow.contains("core.longpaths true"),
+        "release CI must install the target-specific native and WebUI build prerequisites"
+    );
+    assert!(
+        compile_workflow.contains("name: reborn-compile-${{ matrix.target }}")
+            && compile_workflow.contains("if-no-files-found: error")
+            && !compile_workflow.contains("name: artifacts-reborn"),
+        "compile evidence must stay outside cargo-dist's artifacts-* release namespace"
+    );
+
+    assert!(
+        release_workflow.contains("uses: ./.github/workflows/reborn-release-compile.yml")
+            && release_workflow.contains("needs.reborn-binary-compile.result == 'success'")
+            && release_workflow.contains("  pull_request:\n")
+            && !compile_workflow.contains("  pull_request:\n"),
+        "the existing release workflow must own PR validation and wait for the Reborn matrix"
+    );
+    assert!(
+        release_workflow.contains("publishing: ${{ !github.event.pull_request }}")
+            && release_workflow.contains("needs.plan.outputs.publishing == 'true'")
+            && compile_workflow.contains("permissions:\n  contents: read"),
+        "PR compile validation must remain read-only and must not enter release publishing"
+    );
+    let docker_job = release_workflow
+        .split_once("  docker-image:\n")
+        .and_then(|(_, jobs)| jobs.split_once("\n  update-registry-checksums:"))
+        .map(|(job, _)| job)
+        .expect("release workflow should retain the Docker caller job");
+    assert!(
+        docker_job.contains("if: ${{ false }}")
+            && docker_job.contains("uses: ./.github/workflows/docker.yml"),
+        "release CI must retain but skip its Docker caller"
+    );
+    assert!(
+        docker_workflow.contains("workflow_dispatch:") && docker_workflow.contains("schedule:"),
+        "the independent Docker workflow must remain manually and periodically runnable"
+    );
+    assert!(
+        cli_manifest.contains("[package.metadata.dist]\ndist = false"),
+        "#6160 must not opt Reborn into cargo-dist before #3483 is resolved"
+    );
+}
+
+#[test]
 fn dockerfile_reborn_ships_extension_ownership_migration() {
     let dockerfile = std::fs::read_to_string(workspace_root().join("Dockerfile.reborn"))
         .expect("Dockerfile.reborn");

--- a/crates/ironclaw_reborn_cli/tests/smoke.rs
+++ b/crates/ironclaw_reborn_cli/tests/smoke.rs
@@ -197,7 +197,8 @@ fn release_ci_compiles_reborn_for_all_supported_targets() {
         ("aarch64-apple-darwin", "macos-15"),
         ("x86_64-pc-windows-msvc", "windows-2022"),
     ];
-    let release_features = "webui-v2-beta,slack-v2-host-beta,libsql,postgres,inmemory-turn-state";
+    let release_features =
+        "root-llm-provider,webui-v2-beta,slack-v2-host-beta,libsql,postgres,inmemory-turn-state";
 
     assert_eq!(
         compile_workflow.matches("          - target: ").count(),
@@ -226,7 +227,7 @@ fn release_ci_compiles_reborn_for_all_supported_targets() {
     );
     assert!(
         compile_workflow.matches("musl: true").count() == 2
-            && compile_workflow.contains("sudo apt-get install --yes musl-tools binutils")
+            && compile_workflow.contains("sudo apt-get install --yes musl-tools binutils file")
             && compile_workflow.contains("CC_x86_64_unknown_linux_musl=musl-gcc")
             && compile_workflow.contains("CC_aarch64_unknown_linux_musl=musl-gcc")
             && !compile_workflow.contains("CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER")
@@ -237,6 +238,40 @@ fn release_ci_compiles_reborn_for_all_supported_targets() {
             && !compile_workflow.contains("binary: ironclaw-reborn")
             && compile_workflow.contains("core.longpaths true"),
         "release CI must use musl-gcc for C dependencies without overriding Rust's self-contained musl linker"
+    );
+    for matrix_entry in [
+        concat!(
+            "          - target: x86_64-unknown-linux-musl\n",
+            "            runner: ubuntu-22.04\n",
+            "            binary: ironclaw\n",
+            "            musl: true\n",
+            "            cc_env: CC_x86_64_unknown_linux_musl=musl-gcc\n",
+        ),
+        concat!(
+            "          - target: aarch64-unknown-linux-musl\n",
+            "            runner: ubuntu-24.04-arm\n",
+            "            binary: ironclaw\n",
+            "            musl: true\n",
+            "            cc_env: CC_aarch64_unknown_linux_musl=musl-gcc\n",
+        ),
+    ] {
+        assert!(
+            compile_workflow.contains(matrix_entry),
+            "musl matrix entry must bind its target to the matching compiler: {matrix_entry}"
+        );
+    }
+    let configure_musl_compiler = concat!(
+        "      - name: Configure musl C compiler\n",
+        "        if: matrix.musl\n",
+        "        shell: bash\n",
+        "        env:\n",
+        "          CC_ENV: ${{ matrix.cc_env }}\n",
+        "        run: |\n",
+        "          echo \"$CC_ENV\" >> \"$GITHUB_ENV\"\n",
+    );
+    assert!(
+        compile_workflow.contains(configure_musl_compiler),
+        "musl compiler variables must be applied only to musl matrix entries"
     );
     assert!(
         compile_workflow.contains("name: Verify musl portability\n        if: matrix.musl")
@@ -274,6 +309,20 @@ fn release_ci_compiles_reborn_for_all_supported_targets() {
             && compile_workflow.contains("if-no-files-found: error")
             && !compile_workflow.contains("name: artifacts-reborn"),
         "compile evidence must stay outside cargo-dist's artifacts-* release namespace"
+    );
+    let host_job = release_workflow
+        .split_once("\n  host:\n")
+        .and_then(|(_, jobs)| jobs.split_once("\n  docker-image:\n"))
+        .map(|(host, _)| host)
+        .expect("release workflow host job");
+    assert_eq!(
+        host_job.matches("pattern: artifacts-*").count(),
+        2,
+        "release host must download only cargo-dist artifacts for staging and upload"
+    );
+    assert!(
+        !host_job.contains("reborn-compile-"),
+        "release host must not publish Reborn compile evidence"
     );
 
     let release_tag_trigger = concat!(

--- a/crates/ironclaw_reborn_cli/tests/smoke.rs
+++ b/crates/ironclaw_reborn_cli/tests/smoke.rs
@@ -174,6 +174,8 @@ fn dockerfile_reborn_builds_with_production_features() {
 
 #[test]
 fn release_ci_compiles_reborn_for_all_supported_targets() {
+    // This is a structural contract for release workflow wiring. Hosted Actions
+    // runs provide the behavioral cross-platform compile and startup validation.
     let root = workspace_root();
     let compile_workflow =
         std::fs::read_to_string(root.join(".github/workflows/reborn-release-compile.yml"))
@@ -224,7 +226,7 @@ fn release_ci_compiles_reborn_for_all_supported_targets() {
     );
     assert!(
         compile_workflow.matches("musl: true").count() == 2
-            && compile_workflow.contains("sudo apt-get install --yes musl-tools")
+            && compile_workflow.contains("sudo apt-get install --yes musl-tools binutils")
             && compile_workflow.contains("CC_x86_64_unknown_linux_musl=musl-gcc")
             && compile_workflow.contains("CC_aarch64_unknown_linux_musl=musl-gcc")
             && !compile_workflow.contains("CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER")

--- a/docs/reborn-binary.md
+++ b/docs/reborn-binary.md
@@ -626,7 +626,8 @@ Do not port the current `src/cli/*` command tree wholesale. Port commands one at
 
 ## Release packaging decision
 
-`ironclaw-reborn` is **not yet included in cargo-dist release artifacts**.
+The canonical Reborn `ironclaw` binary from `ironclaw_reborn_cli` is **not yet
+included in cargo-dist release artifacts**.
 
 The tag-driven release pipeline preflights the shipping binary directly through
 `.github/workflows/reborn-release-compile.yml`. That matrix performs a final
@@ -637,11 +638,11 @@ CLI startup checks. The musl jobs additionally reject `PT_INTERP` and
 loader. Its short-lived `reborn-compile-*` workflow artifacts are preflight
 evidence only and are excluded from the `artifacts-*` set uploaded to the
 GitHub Release. It does not claim `serve`, external-service, installer, or
-standalone Reborn packaging coverage.
+canonical Reborn packaging coverage.
 
-Current `dist plan --output-format=json` with `crates/ironclaw_reborn_cli` marked `dist = false` emits only the root `ironclaw` package artifacts. Removing `dist = false` alone is not enough to ship `ironclaw-reborn` in the existing `ironclaw-v*` release workflow because that workflow is shaped around the root `ironclaw` package tag. Enabling a standalone `ironclaw_reborn_cli` release also requires cargo-dist WiX metadata/template work and an explicit tag/versioning decision.
+Current `dist plan --output-format=json` with `crates/ironclaw_reborn_cli` marked `dist = false` emits only the root legacy package artifacts (`ironclaw` package, `ironclaw-legacy` executable). Removing `dist = false` alone is not enough to ship the canonical Reborn `ironclaw` executable in the existing `ironclaw-v*` release workflow because that workflow is shaped around the root `ironclaw` package tag. Enabling the `ironclaw_reborn_cli` release also requires cargo-dist WiX metadata/template work and an explicit package/tag/versioning decision.
 
-Follow-up issue: #3483 tracks packaging `ironclaw-reborn` in release artifacts.
+Follow-up issue: #3483 tracks packaging the canonical Reborn binary in release artifacts.
 
 Until #3483 is resolved, keep:
 

--- a/docs/reborn-binary.md
+++ b/docs/reborn-binary.md
@@ -628,16 +628,16 @@ Do not port the current `src/cli/*` command tree wholesale. Port commands one at
 
 `ironclaw-reborn` is **not yet included in cargo-dist release artifacts**.
 
-The release pipeline still preflights the shipping binary directly through
-`.github/workflows/reborn-release-compile.yml` before hosting a release. That
-matrix performs a final link on the two GNU Linux, two musl Linux, two macOS,
-and one Windows target configured for releases, then runs the exact native
-output through config-free CLI startup checks. The musl jobs additionally
-reject `PT_INTERP` and `DT_NEEDED` entries so their outputs remain portable to
-systems without a musl loader. Its short-lived `reborn-compile-*` workflow
-artifacts are preflight evidence only and are excluded from the `artifacts-*`
-set uploaded to the GitHub Release. It does not claim `serve`, external-service,
-installer, or standalone Reborn packaging coverage.
+The tag-driven release pipeline preflights the shipping binary directly through
+`.github/workflows/reborn-release-compile.yml`. That matrix performs a final
+link on the two GNU Linux, two musl Linux, two macOS, and one Windows target
+configured for releases, then runs the exact native output through config-free
+CLI startup checks. The musl jobs additionally reject `PT_INTERP` and
+`DT_NEEDED` entries so their outputs remain portable to systems without a musl
+loader. Its short-lived `reborn-compile-*` workflow artifacts are preflight
+evidence only and are excluded from the `artifacts-*` set uploaded to the
+GitHub Release. It does not claim `serve`, external-service, installer, or
+standalone Reborn packaging coverage.
 
 Current `dist plan --output-format=json` with `crates/ironclaw_reborn_cli` marked `dist = false` emits only the root `ironclaw` package artifacts. Removing `dist = false` alone is not enough to ship `ironclaw-reborn` in the existing `ironclaw-v*` release workflow because that workflow is shaped around the root `ironclaw` package tag. Enabling a standalone `ironclaw_reborn_cli` release also requires cargo-dist WiX metadata/template work and an explicit tag/versioning decision.
 

--- a/docs/reborn-binary.md
+++ b/docs/reborn-binary.md
@@ -628,6 +628,14 @@ Do not port the current `src/cli/*` command tree wholesale. Port commands one at
 
 `ironclaw-reborn` is **not yet included in cargo-dist release artifacts**.
 
+The release pipeline still compiles the shipping binary directly through
+`.github/workflows/reborn-release-compile.yml` before hosting a release. That
+compile-only matrix performs a final link on the two GNU Linux, two musl Linux,
+two macOS, and one Windows target configured for releases. Its short-lived
+`reborn-compile-*` workflow artifacts are build evidence only and are excluded
+from the `artifacts-*` set uploaded to the GitHub Release. It does not claim
+runtime validation, installer coverage, or standalone Reborn packaging.
+
 Current `dist plan --output-format=json` with `crates/ironclaw_reborn_cli` marked `dist = false` emits only the root `ironclaw` package artifacts. Removing `dist = false` alone is not enough to ship `ironclaw-reborn` in the existing `ironclaw-v*` release workflow because that workflow is shaped around the root `ironclaw` package tag. Enabling a standalone `ironclaw_reborn_cli` release also requires cargo-dist WiX metadata/template work and an explicit tag/versioning decision.
 
 Follow-up issue: #3483 tracks packaging `ironclaw-reborn` in release artifacts.

--- a/docs/reborn-binary.md
+++ b/docs/reborn-binary.md
@@ -628,13 +628,16 @@ Do not port the current `src/cli/*` command tree wholesale. Port commands one at
 
 `ironclaw-reborn` is **not yet included in cargo-dist release artifacts**.
 
-The release pipeline still compiles the shipping binary directly through
+The release pipeline still preflights the shipping binary directly through
 `.github/workflows/reborn-release-compile.yml` before hosting a release. That
-compile-only matrix performs a final link on the two GNU Linux, two musl Linux,
-two macOS, and one Windows target configured for releases. Its short-lived
-`reborn-compile-*` workflow artifacts are build evidence only and are excluded
-from the `artifacts-*` set uploaded to the GitHub Release. It does not claim
-runtime validation, installer coverage, or standalone Reborn packaging.
+matrix performs a final link on the two GNU Linux, two musl Linux, two macOS,
+and one Windows target configured for releases, then runs the exact native
+output through config-free CLI startup checks. The musl jobs additionally
+reject `PT_INTERP` and `DT_NEEDED` entries so their outputs remain portable to
+systems without a musl loader. Its short-lived `reborn-compile-*` workflow
+artifacts are preflight evidence only and are excluded from the `artifacts-*`
+set uploaded to the GitHub Release. It does not claim `serve`, external-service,
+installer, or standalone Reborn packaging coverage.
 
 Current `dist plan --output-format=json` with `crates/ironclaw_reborn_cli` marked `dist = false` emits only the root `ironclaw` package artifacts. Removing `dist = false` alone is not enough to ship `ironclaw-reborn` in the existing `ironclaw-v*` release workflow because that workflow is shaped around the root `ironclaw` package tag. Enabling a standalone `ironclaw_reborn_cli` release also requires cargo-dist WiX metadata/template work and an explicit tag/versioning decision.
 


### PR DESCRIPTION
## Summary

- Add a read-only Reborn release preflight that fully links the canonical `ironclaw` binary from `ironclaw_reborn_cli` for all seven supported release targets with an explicit feature contract.
- Run the exact `target/<target>/dist/ironclaw[.exe]` output on every native runner with `--version`, `--help`, and `profile list --json` before upload.
- Keep musl C build scripts on `musl-gcc`, but leave the final Rust linker self-contained; reject musl artifacts containing `PT_INTERP` or `DT_NEEDED` so a runner-installed loader cannot mask a non-portable binary.
- Call the matrix from the existing tag-only `release.yml`; ordinary pull requests do not start the seven-platform Release workflow.
- Keep `workflow_dispatch` on the reusable preflight for isolated manual validation.
- Keep Reborn outside cargo-dist release artifacts and keep Docker policy out of this PR.

## Dependency and merge order

#6185 has merged. This branch is rebased onto the merge and its package/binary contract now explicitly builds `--package ironclaw_reborn_cli --bin ironclaw`; it does not accidentally build the root legacy `ironclaw-legacy` target.

Remaining order:

1. Merge this PR after review.
2. Rebase #6188 onto the result, validate the combined Reborn-only tag flow in a fork, then merge #6188 last.

This work does **not** depend on #6122.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [x] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Refs #6160

## Validation

- [x] `cargo +1.96.0 fmt --all -- --check`
- [x] Focused release-workflow smoke contract (1 passed)
- [x] Full `ironclaw_reborn_cli` smoke suite after rebasing onto #6185 (107 passed)
- [x] `cargo +1.96.0 clippy -p ironclaw_reborn_cli --all-targets --all-features -- -D warnings`
- [x] YAML parse for `release.yml` and `reborn-release-compile.yml`
- [x] actionlint for both workflows
- [x] `scripts/pre-commit-safety.sh`
- [x] `git diff --check`
- [x] [Introduction-time seven-target run 29575232668](https://github.com/nearai/ironclaw/actions/runs/29575232668): all seven native jobs compiled, ran the exact evidence artifact, and uploaded it; both musl jobs passed the ELF portability checks. This historical run used the pre-#6185 executable name.
- [x] [Combined fork tag run 29610386170](https://github.com/hanakannzashi/ironclaw/actions/runs/29610386170): proved the #6176 + #6188 job graph skips the legacy release roots; this historical run also predates the canonical executable rename.
- [x] [Canonical combined fork tag run 29668508858](https://github.com/hanakannzashi/ironclaw/actions/runs/29668508858): all seven `ironclaw` / `ironclaw.exe` jobs passed compile, native CLI smoke, and evidence upload; both musl jobs passed ELF portability checks. The legacy plan/WASM/local/global/host/Docker/checksum/announce chain skipped, exactly seven `reborn-compile-*` artifacts were created, and no GitHub Release or checksum PR was created.

The temporary `pull_request` trigger used for the introduction-time proof has been removed and is not part of the policy proposed for `main`.

## Security Impact

No product trust-boundary change. The reusable preflight has only `contents: read`, receives no publishing secrets, and uploads short-lived evidence artifacts outside cargo-dist's release namespace. Removing the PR trigger also prevents untrusted PR changes from starting this Release workflow.

## Reborn Trust-Boundary Checklist

N/A — this changes release CI validation only and does not alter runtime, persistence, ingress, capability, or security-policy code.

## Database Impact

None.

## Blast Radius

Matching release tags run the seven-platform Reborn compile matrix. The reusable preflight can also be started manually. Ordinary pull requests do not run it. This PR does not publish the evidence artifacts and does not change Docker behavior; #6188 owns the final Reborn-only release policy.

## Rollback Plan

Revert the #6160 binary-preflight commits to remove the reusable matrix and tag caller. No schema, package version, artifact format, Docker policy, or persisted state requires migration.

---

**Review track**: C (CI/release)
