### PR TITLE
fix(ci): stop safety ReDoS timing guards flaking under coverage

### DIFF
--- a/crates/ironclaw_safety/src/leak_detector.rs
+++ b/crates/ironclaw_safety/src/leak_detector.rs
@@ -1070,7 +1070,7 @@ mod tests {
             let _result = detector.scan(&payload);
             let elapsed = start.elapsed();
             assert!(
-                elapsed.as_millis() < 100,
+                elapsed.as_millis() < crate::REDOS_SCAN_BUDGET_MS,
                 "openai_key pattern took {}ms on 100KB near-miss",
                 elapsed.as_millis()
             );
@@ -1088,7 +1088,7 @@ mod tests {
             let _result = detector.scan(&payload);
             let elapsed = start.elapsed();
             assert!(
-                elapsed.as_millis() < 100,
+                elapsed.as_millis() < crate::REDOS_SCAN_BUDGET_MS,
                 "high_entropy_hex pattern took {}ms on 100KB near-miss",
                 elapsed.as_millis()
             );
@@ -1106,7 +1106,7 @@ mod tests {
             let _result = detector.scan(&payload);
             let elapsed = start.elapsed();
             assert!(
-                elapsed.as_millis() < 100,
+                elapsed.as_millis() < crate::REDOS_SCAN_BUDGET_MS,
                 "bearer_token pattern took {}ms on 100KB near-miss",
                 elapsed.as_millis()
             );
@@ -1124,7 +1124,7 @@ mod tests {
             let _result = detector.scan(&payload);
             let elapsed = start.elapsed();
             assert!(
-                elapsed.as_millis() < 100,
+                elapsed.as_millis() < crate::REDOS_SCAN_BUDGET_MS,
                 "authorization pattern took {}ms on 100KB near-miss",
                 elapsed.as_millis()
             );
@@ -1142,7 +1142,7 @@ mod tests {
             let _result = detector.scan(&payload);
             let elapsed = start.elapsed();
             assert!(
-                elapsed.as_millis() < 100,
+                elapsed.as_millis() < crate::REDOS_SCAN_BUDGET_MS,
                 "anthropic_api_key pattern took {}ms on 100KB near-miss",
                 elapsed.as_millis()
             );
@@ -1160,7 +1160,7 @@ mod tests {
             let _result = detector.scan(&payload);
             let elapsed = start.elapsed();
             assert!(
-                elapsed.as_millis() < 100,
+                elapsed.as_millis() < crate::REDOS_SCAN_BUDGET_MS,
                 "aws_access_key pattern took {}ms on 100KB near-miss",
                 elapsed.as_millis()
             );
@@ -1178,7 +1178,7 @@ mod tests {
             let _result = detector.scan(&payload);
             let elapsed = start.elapsed();
             assert!(
-                elapsed.as_millis() < 100,
+                elapsed.as_millis() < crate::REDOS_SCAN_BUDGET_MS,
                 "github_token pattern took {}ms on 100KB near-miss",
                 elapsed.as_millis()
             );
@@ -1196,7 +1196,7 @@ mod tests {
             let _result = detector.scan(&payload);
             let elapsed = start.elapsed();
             assert!(
-                elapsed.as_millis() < 100,
+                elapsed.as_millis() < crate::REDOS_SCAN_BUDGET_MS,
                 "github_fine_grained_pat pattern took {}ms on 100KB near-miss",
                 elapsed.as_millis()
             );
@@ -1214,7 +1214,7 @@ mod tests {
             let _result = detector.scan(&payload);
             let elapsed = start.elapsed();
             assert!(
-                elapsed.as_millis() < 100,
+                elapsed.as_millis() < crate::REDOS_SCAN_BUDGET_MS,
                 "stripe_api_key pattern took {}ms on 100KB near-miss",
                 elapsed.as_millis()
             );
@@ -1232,7 +1232,7 @@ mod tests {
             let _result = detector.scan(&payload);
             let elapsed = start.elapsed();
             assert!(
-                elapsed.as_millis() < 100,
+                elapsed.as_millis() < crate::REDOS_SCAN_BUDGET_MS,
                 "nearai_session pattern took {}ms on 100KB near-miss",
                 elapsed.as_millis()
             );
@@ -1250,7 +1250,7 @@ mod tests {
             let _result = detector.scan(&payload);
             let elapsed = start.elapsed();
             assert!(
-                elapsed.as_millis() < 100,
+                elapsed.as_millis() < crate::REDOS_SCAN_BUDGET_MS,
                 "pem_private_key pattern took {}ms on 100KB near-miss",
                 elapsed.as_millis()
             );
@@ -1268,7 +1268,7 @@ mod tests {
             let _result = detector.scan(&payload);
             let elapsed = start.elapsed();
             assert!(
-                elapsed.as_millis() < 100,
+                elapsed.as_millis() < crate::REDOS_SCAN_BUDGET_MS,
                 "ssh_private_key pattern took {}ms on 100KB near-miss",
                 elapsed.as_millis()
             );
@@ -1286,7 +1286,7 @@ mod tests {
             let _result = detector.scan(&payload);
             let elapsed = start.elapsed();
             assert!(
-                elapsed.as_millis() < 100,
+                elapsed.as_millis() < crate::REDOS_SCAN_BUDGET_MS,
                 "google_api_key pattern took {}ms on 100KB near-miss",
                 elapsed.as_millis()
             );
@@ -1304,7 +1304,7 @@ mod tests {
             let _result = detector.scan(&payload);
             let elapsed = start.elapsed();
             assert!(
-                elapsed.as_millis() < 100,
+                elapsed.as_millis() < crate::REDOS_SCAN_BUDGET_MS,
                 "slack_token pattern took {}ms on 100KB near-miss",
                 elapsed.as_millis()
             );
@@ -1322,7 +1322,7 @@ mod tests {
             let _result = detector.scan(&payload);
             let elapsed = start.elapsed();
             assert!(
-                elapsed.as_millis() < 100,
+                elapsed.as_millis() < crate::REDOS_SCAN_BUDGET_MS,
                 "twilio_api_key pattern took {}ms on 100KB near-miss",
                 elapsed.as_millis()
             );
@@ -1340,7 +1340,7 @@ mod tests {
             let _result = detector.scan(&payload);
             let elapsed = start.elapsed();
             assert!(
-                elapsed.as_millis() < 100,
+                elapsed.as_millis() < crate::REDOS_SCAN_BUDGET_MS,
                 "sendgrid_api_key pattern took {}ms on 100KB near-miss",
                 elapsed.as_millis()
             );
@@ -1356,7 +1356,7 @@ mod tests {
             let result = detector.scan(&payload);
             let elapsed = start.elapsed();
             assert!(
-                elapsed.as_millis() < 100,
+                elapsed.as_millis() < crate::REDOS_SCAN_BUDGET_MS,
                 "full scan took {}ms on 100KB clean text",
                 elapsed.as_millis()
             );

--- a/crates/ironclaw_safety/src/lib.rs
+++ b/crates/ironclaw_safety/src/lib.rs
@@ -18,6 +18,20 @@ mod sanitizer;
 pub mod sensitive_paths;
 mod validator;
 
+/// Wall-clock budget (ms) for the ReDoS / catastrophic-backtracking regression
+/// guards in the safety-crate test suites.
+///
+/// The adversarial tests feed ~100 KB near-miss payloads to a regex scan and
+/// assert it finishes quickly. The bound exists to catch *catastrophic*
+/// backtracking — which blows up to seconds or hangs outright — not micro-perf
+/// drift, so it is deliberately generous. A normal linear scan finishes in well
+/// under 1 ms, but under `cargo llvm-cov` instrumentation on shared CI runners
+/// the same scan can take ~100 ms (a hard 100 ms bound flaked on exactly this).
+/// A 2 s budget keeps a large margin below any real ReDoS while tolerating that
+/// instrumentation and scheduling overhead.
+#[cfg(test)]
+pub(crate) const REDOS_SCAN_BUDGET_MS: u128 = 2000;
+
 pub use credential_detect::{
     http_parts_contain_manual_credentials, params_contain_manual_credentials,
 };

--- a/crates/ironclaw_safety/src/policy.rs
+++ b/crates/ironclaw_safety/src/policy.rs
@@ -324,7 +324,7 @@ mod tests {
             let violations = policy.check(&payload);
             let elapsed = start.elapsed();
             assert!(
-                elapsed.as_millis() < 500,
+                elapsed.as_millis() < crate::REDOS_SCAN_BUDGET_MS,
                 "excessive_urls pattern took {}ms on 100KB near-miss",
                 elapsed.as_millis()
             );
@@ -349,7 +349,7 @@ mod tests {
             let violations = policy.check(&payload);
             let elapsed = start.elapsed();
             assert!(
-                elapsed.as_millis() < 500,
+                elapsed.as_millis() < crate::REDOS_SCAN_BUDGET_MS,
                 "obfuscated_string pattern took {}ms on 100KB near-miss",
                 elapsed.as_millis()
             );
@@ -370,7 +370,7 @@ mod tests {
             let _violations = policy.check(&payload);
             let elapsed = start.elapsed();
             assert!(
-                elapsed.as_millis() < 500,
+                elapsed.as_millis() < crate::REDOS_SCAN_BUDGET_MS,
                 "shell_injection pattern took {}ms on 100KB near-miss",
                 elapsed.as_millis()
             );
@@ -387,7 +387,7 @@ mod tests {
             let _violations = policy.check(&payload);
             let elapsed = start.elapsed();
             assert!(
-                elapsed.as_millis() < 500,
+                elapsed.as_millis() < crate::REDOS_SCAN_BUDGET_MS,
                 "sql_pattern took {}ms on 100KB near-miss",
                 elapsed.as_millis()
             );
@@ -405,7 +405,7 @@ mod tests {
             let _violations = policy.check(&payload);
             let elapsed = start.elapsed();
             assert!(
-                elapsed.as_millis() < 500,
+                elapsed.as_millis() < crate::REDOS_SCAN_BUDGET_MS,
                 "crypto_private_key pattern took {}ms on 100KB near-miss",
                 elapsed.as_millis()
             );
@@ -423,7 +423,7 @@ mod tests {
             let _violations = policy.check(&payload);
             let elapsed = start.elapsed();
             assert!(
-                elapsed.as_millis() < 500,
+                elapsed.as_millis() < crate::REDOS_SCAN_BUDGET_MS,
                 "system_file_access pattern took {}ms on 100KB near-miss",
                 elapsed.as_millis()
             );
@@ -441,7 +441,7 @@ mod tests {
             let _violations = policy.check(&payload);
             let elapsed = start.elapsed();
             assert!(
-                elapsed.as_millis() < 500,
+                elapsed.as_millis() < crate::REDOS_SCAN_BUDGET_MS,
                 "encoded_exploit pattern took {}ms on 100KB near-miss",
                 elapsed.as_millis()
             );

--- a/crates/ironclaw_safety/src/sanitizer.rs
+++ b/crates/ironclaw_safety/src/sanitizer.rs
@@ -453,9 +453,10 @@ mod tests {
             let _result = sanitizer.sanitize(&payload);
             let elapsed = start.elapsed();
             assert!(
-                elapsed.as_millis() < 100,
-                "base64 pattern took {}ms on 100KB near-miss (threshold: 100ms)",
-                elapsed.as_millis()
+                elapsed.as_millis() < crate::REDOS_SCAN_BUDGET_MS,
+                "base64 pattern took {}ms on 100KB near-miss (budget: {}ms)",
+                elapsed.as_millis(),
+                crate::REDOS_SCAN_BUDGET_MS
             );
         }
 
@@ -470,7 +471,7 @@ mod tests {
             let _result = sanitizer.sanitize(&payload);
             let elapsed = start.elapsed();
             assert!(
-                elapsed.as_millis() < 100,
+                elapsed.as_millis() < crate::REDOS_SCAN_BUDGET_MS,
                 "eval pattern took {}ms on 100KB input",
                 elapsed.as_millis()
             );
@@ -487,7 +488,7 @@ mod tests {
             let _result = sanitizer.sanitize(&payload);
             let elapsed = start.elapsed();
             assert!(
-                elapsed.as_millis() < 100,
+                elapsed.as_millis() < crate::REDOS_SCAN_BUDGET_MS,
                 "exec pattern took {}ms on 100KB input",
                 elapsed.as_millis()
             );
@@ -505,7 +506,7 @@ mod tests {
             let _result = sanitizer.sanitize(&payload);
             let elapsed = start.elapsed();
             assert!(
-                elapsed.as_millis() < 100,
+                elapsed.as_millis() < crate::REDOS_SCAN_BUDGET_MS,
                 "null_byte pattern took {}ms on 100KB input",
                 elapsed.as_millis()
             );
@@ -522,7 +523,7 @@ mod tests {
             let _result = sanitizer.sanitize(&payload);
             let elapsed = start.elapsed();
             assert!(
-                elapsed.as_millis() < 100,
+                elapsed.as_millis() < crate::REDOS_SCAN_BUDGET_MS,
                 "Aho-Corasick scan took {}ms on 100KB clean input",
                 elapsed.as_millis()
             );

--- a/crates/ironclaw_safety/src/validator.rs
+++ b/crates/ironclaw_safety/src/validator.rs
@@ -487,7 +487,7 @@ mod tests {
             let _result = validator.validate(&payload);
             let elapsed = start.elapsed();
             assert!(
-                elapsed.as_millis() < 100,
+                elapsed.as_millis() < crate::REDOS_SCAN_BUDGET_MS,
                 "validate() took {}ms on 100KB input",
                 elapsed.as_millis()
             );
@@ -502,7 +502,7 @@ mod tests {
             let result = validator.validate(&payload);
             let elapsed = start.elapsed();
             assert!(
-                elapsed.as_millis() < 100,
+                elapsed.as_millis() < crate::REDOS_SCAN_BUDGET_MS,
                 "repetition check took {}ms on 100KB",
                 elapsed.as_millis()
             );
@@ -529,7 +529,7 @@ mod tests {
             let _result = validator.validate_tool_params(&value);
             let elapsed = start.elapsed();
             assert!(
-                elapsed.as_millis() < 100,
+                elapsed.as_millis() < crate::REDOS_SCAN_BUDGET_MS,
                 "tool_params validation took {}ms on wide JSON",
                 elapsed.as_millis()
             );


### PR DESCRIPTION
## Problem

The `Coverage (default)` job on `main` failed ([run 29555194141](https://github.com/nearai/ironclaw/actions/runs/29555194141/job/87805701467)):

```
thread 'leak_detector::tests::adversarial::anthropic_key_pattern_100kb_near_miss'
panicked at crates/ironclaw_safety/src/leak_detector.rs:1144:13:
anthropic_api_key pattern took 101ms on 100KB near-miss
```

This is **not a real regression** — it's a flaky timing assertion. The `*_100kb_near_miss` adversarial tests in `ironclaw_safety` are ReDoS guards: they feed a ~100 KB near-miss payload to a regex scan and assert it finishes fast enough to rule out *catastrophic backtracking* (which would take seconds or hang). They used a hard **100 ms** bound.

Under `cargo llvm-cov` instrumentation on a shared CI runner the linear scan is ~100× slower, so it landed at **101 ms** — 1 ms over. Only the instrumented coverage job is affected; `all-features`, `libsql-only`, and `e2e` all passed.

## Fix

Replace the per-test hard thresholds (100 ms in `leak_detector`/`validator`/`sanitizer`, 500 ms already in `policy`) with one documented shared constant in the crate root:

```rust
#[cfg(test)]
pub(crate) const REDOS_SCAN_BUDGET_MS: u128 = 2000;
```

2 s keeps a large margin below any real ReDoS (seconds→minutes/hang) while tolerating instrumentation and scheduling overhead. The guards still fail loudly on genuine catastrophic backtracking. 32 assertions across the four files now reference the constant; also fixed a stale `(threshold: 100ms)` message to print the actual budget.

## Verification

- `cargo test -p ironclaw_safety --lib adversarial` → 100 passed
- `cargo clippy -p ironclaw_safety --all-targets --all-features -- -D warnings` → clean

## Note

Test-only change; no production behavior is touched, so the commit carries `[skip-regression-check]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)