### PR TITLE
refactor(reborn): approval stores over RootFilesystem, delete InMemory*Store (§4.3)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -289,7 +289,7 @@ insta = { version = "1.46.3", features = ["yaml"] }
 # fault-injection helpers don't ship in release binaries.
 ironclaw_llm = { path = "crates/ironclaw_llm", version = "0.1.0", features = ["testing"] }
 ironclaw_agent_loop = { path = "crates/ironclaw_agent_loop", version = "0.1.0", features = ["test-support"] }
-ironclaw_approvals = { path = "crates/ironclaw_approvals", version = "0.1.0" }
+ironclaw_approvals = { path = "crates/ironclaw_approvals", version = "0.1.0", features = ["test-support"] }
 # Pull the auth crate's `test-support` feature in only for tests so the
 # `test_support::conformance` OAuth-flow suite (used by the
 # `reborn_integration_oauth_connect` test) doesn't ship in release binaries.

--- a/crates/ironclaw_approvals/Cargo.toml
+++ b/crates/ironclaw_approvals/Cargo.toml
@@ -7,6 +7,13 @@ publish = false
 [package.metadata.ironclaw]
 layer = "kernel"
 
+[features]
+# In-memory-backed approval store constructors for this crate's own tests and
+# downstream integration tiers. The stores themselves are the production
+# `Filesystem*Store<InMemoryBackend>`; the helpers just wire the in-memory
+# backend seam. Ships zero bytes in production binaries.
+test-support = []
+
 [dependencies]
 async-trait = "0.1"
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }

--- a/crates/ironclaw_approvals/src/auto_approve.rs
+++ b/crates/ironclaw_approvals/src/auto_approve.rs
@@ -15,7 +15,7 @@
 
 use std::{
     collections::HashMap,
-    sync::{Arc, Mutex, RwLock},
+    sync::{Arc, Mutex},
 };
 
 use async_trait::async_trait;
@@ -94,56 +94,6 @@ pub trait AutoApproveSettingStore: Send + Sync {
             .get(&key)
             .await?
             .map_or(AUTO_APPROVE_DEFAULT_ENABLED, |record| record.enabled))
-    }
-}
-
-#[derive(Debug, Default)]
-pub struct InMemoryAutoApproveSettingStore {
-    settings: RwLock<HashMap<AutoApproveSettingKey, AutoApproveSettingRecord>>,
-}
-
-impl InMemoryAutoApproveSettingStore {
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
-#[async_trait]
-impl AutoApproveSettingStore for InMemoryAutoApproveSettingStore {
-    async fn set(
-        &self,
-        input: AutoApproveSettingInput,
-    ) -> Result<AutoApproveSettingRecord, ToolPermissionStoreError> {
-        let key = AutoApproveSettingKey::from_resource_scope(&input.scope);
-        let mut settings = self
-            .settings
-            .write()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        let now = Utc::now();
-        let created_at = settings
-            .get(&key)
-            .map_or(now, |existing| existing.created_at);
-        let record = AutoApproveSettingRecord {
-            key: key.clone(),
-            enabled: input.enabled,
-            updated_by: input.updated_by,
-            created_at,
-            updated_at: now,
-        };
-        settings.insert(key, record.clone());
-        Ok(record)
-    }
-
-    async fn get(
-        &self,
-        key: &AutoApproveSettingKey,
-    ) -> Result<Option<AutoApproveSettingRecord>, ToolPermissionStoreError> {
-        Ok(self
-            .settings
-            .read()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .get(key)
-            .cloned())
     }
 }
 
@@ -388,23 +338,33 @@ mod tests {
         Arc::new(ScopedFilesystem::with_fixed_view(backend, mounts))
     }
 
+    // The single production store, exercised over the in-memory filesystem
+    // backend — the seam that replaced the deleted `InMemoryAutoApproveSettingStore`.
+    fn memory_store() -> FilesystemAutoApproveSettingStore<InMemoryBackend> {
+        FilesystemAutoApproveSettingStore::new(scoped_fs(
+            Arc::new(InMemoryBackend::new()),
+            "tenant-a",
+            "alice",
+        ))
+    }
+
     #[tokio::test]
-    async fn in_memory_defaults_to_enabled_when_unset() {
-        let store = InMemoryAutoApproveSettingStore::new();
+    async fn defaults_to_enabled_when_unset() {
+        let store = memory_store();
         assert!(store.is_enabled(&scope("alice", None, None)).await.unwrap());
     }
 
     #[tokio::test]
-    async fn in_memory_explicit_disable_is_honored() {
-        let store = InMemoryAutoApproveSettingStore::new();
+    async fn explicit_disable_is_honored() {
+        let store = memory_store();
         let scope = scope("alice", None, None);
         store.set(input(scope.clone(), false)).await.unwrap();
         assert!(!store.is_enabled(&scope).await.unwrap());
     }
 
     #[tokio::test]
-    async fn in_memory_set_get_roundtrip_and_update() {
-        let store = InMemoryAutoApproveSettingStore::new();
+    async fn set_get_roundtrip_and_update() {
+        let store = memory_store();
         let scope = scope("alice", None, None);
 
         let saved = store.set(input(scope.clone(), true)).await.unwrap();
@@ -421,7 +381,7 @@ mod tests {
     async fn setting_is_agent_and_project_agnostic() {
         // A user-level toggle written without agent/project resolves the same
         // way at dispatch time when the runtime scope carries an agent/project.
-        let store = InMemoryAutoApproveSettingStore::new();
+        let store = memory_store();
         store
             .set(input(scope("alice", None, None), true))
             .await
@@ -437,7 +397,7 @@ mod tests {
 
     #[tokio::test]
     async fn setting_isolates_users() {
-        let store = InMemoryAutoApproveSettingStore::new();
+        let store = memory_store();
         store
             .set(input(scope("alice", None, None), true))
             .await

--- a/crates/ironclaw_approvals/src/capability_permission.rs
+++ b/crates/ironclaw_approvals/src/capability_permission.rs
@@ -13,10 +13,7 @@
 //! override store: it lives as a persistent approval grant so there is a single
 //! source of truth for auto-run authority.
 
-use std::{
-    collections::HashMap,
-    sync::{Arc, RwLock},
-};
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use chrono::Utc;
@@ -207,86 +204,6 @@ pub trait CapabilityPermissionOverrideStore: Send + Sync {
         &self,
         key: &CapabilityPermissionOverrideKey,
     ) -> Result<(), CapabilityPermissionStoreError>;
-}
-
-#[derive(Debug, Default)]
-pub struct InMemoryCapabilityPermissionOverrideStore {
-    overrides: RwLock<HashMap<CapabilityPermissionOverrideKey, CapabilityPermissionOverrideRecord>>,
-}
-
-impl InMemoryCapabilityPermissionOverrideStore {
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
-#[async_trait]
-impl CapabilityPermissionOverrideStore for InMemoryCapabilityPermissionOverrideStore {
-    async fn set(
-        &self,
-        input: CapabilityPermissionOverrideInput,
-    ) -> Result<CapabilityPermissionOverrideRecord, CapabilityPermissionStoreError> {
-        let key = CapabilityPermissionOverrideKey::new(&input.scope, input.capability_id);
-        let mut overrides = self
-            .overrides
-            .write()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        let now = Utc::now();
-        let created_at = overrides
-            .get(&key)
-            .map_or(now, |existing| existing.created_at);
-        let record = CapabilityPermissionOverrideRecord {
-            key: key.clone(),
-            state: input.state,
-            updated_by: input.updated_by,
-            created_at,
-            updated_at: now,
-        };
-        overrides.insert(key, record.clone());
-        Ok(record)
-    }
-
-    async fn get(
-        &self,
-        key: &CapabilityPermissionOverrideKey,
-    ) -> Result<Option<CapabilityPermissionOverrideRecord>, CapabilityPermissionStoreError> {
-        Ok(self
-            .overrides
-            .read()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .get(key)
-            .cloned())
-    }
-
-    fn supports_scope_listing(&self) -> bool {
-        true
-    }
-
-    async fn list_for_scope(
-        &self,
-        scope: &ResourceScope,
-    ) -> Result<Vec<CapabilityPermissionOverrideRecord>, CapabilityPermissionStoreError> {
-        let target_scope = PersistentApprovalScope::from_resource_scope(scope);
-        Ok(self
-            .overrides
-            .read()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .values()
-            .filter(|record| record.key.scope == target_scope)
-            .cloned()
-            .collect())
-    }
-
-    async fn clear(
-        &self,
-        key: &CapabilityPermissionOverrideKey,
-    ) -> Result<(), CapabilityPermissionStoreError> {
-        self.overrides
-            .write()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .remove(key);
-        Ok(())
-    }
 }
 
 pub struct FilesystemCapabilityPermissionOverrideStore<F>
@@ -651,6 +568,17 @@ mod tests {
         Arc::new(ScopedFilesystem::with_fixed_view(backend, mounts))
     }
 
+    // The single production store, exercised over the in-memory filesystem
+    // backend — the seam that replaced the deleted
+    // `InMemoryCapabilityPermissionOverrideStore`.
+    fn memory_store() -> FilesystemCapabilityPermissionOverrideStore<InMemoryBackend> {
+        FilesystemCapabilityPermissionOverrideStore::new(scoped_fs(
+            Arc::new(InMemoryBackend::new()),
+            "tenant-a",
+            "alice",
+        ))
+    }
+
     struct VersionMismatchOnceBackend {
         inner: Arc<InMemoryBackend>,
         injected: AtomicBool,
@@ -882,8 +810,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn in_memory_set_get_clear_roundtrip() {
-        let store = InMemoryCapabilityPermissionOverrideStore::new();
+    async fn set_get_clear_roundtrip() {
+        let store = memory_store();
         let scope = scope(None, Some("thread-a"));
         let key = key_for(&scope);
 
@@ -1215,7 +1143,7 @@ mod tests {
 
     #[tokio::test]
     async fn override_scope_isolates_users() {
-        let store = InMemoryCapabilityPermissionOverrideStore::new();
+        let store = memory_store();
         let alice = scope(None, Some("thread-a"));
         let bob = ResourceScope {
             user_id: UserId::new("bob").unwrap(),
@@ -1234,7 +1162,7 @@ mod tests {
     #[tokio::test]
     async fn override_scope_is_thread_agnostic() {
         // Mirrors persistent-approval scoping: thread id is not part of the key.
-        let store = InMemoryCapabilityPermissionOverrideStore::new();
+        let store = memory_store();
         let thread_a = scope(None, Some("thread-a"));
         let thread_b = scope(None, Some("thread-b"));
 

--- a/crates/ironclaw_approvals/src/lib.rs
+++ b/crates/ironclaw_approvals/src/lib.rs
@@ -9,6 +9,9 @@ mod capability_permission;
 mod cas_record;
 mod policy;
 
+#[cfg(any(test, feature = "test-support"))]
+pub mod test_support;
+
 use ironclaw_authorization::{CapabilityLease, CapabilityLeaseError, CapabilityLeaseStore};
 use ironclaw_events::AuditSink;
 use ironclaw_host_api::{
@@ -21,20 +24,18 @@ use thiserror::Error;
 pub use auto_approve::{
     AUTO_APPROVE_DEFAULT_ENABLED, AutoApproveSettingInput, AutoApproveSettingKey,
     AutoApproveSettingRecord, AutoApproveSettingStore, FilesystemAutoApproveSettingStore,
-    InMemoryAutoApproveSettingStore,
 };
 pub use capability_permission::{
     CapabilityPermissionOverride, CapabilityPermissionOverrideInput,
     CapabilityPermissionOverrideKey, CapabilityPermissionOverrideRecord,
     CapabilityPermissionOverrideStore, CapabilityPermissionState, CapabilityPermissionStoreError,
-    FilesystemCapabilityPermissionOverrideStore, InMemoryCapabilityPermissionOverrideStore,
+    FilesystemCapabilityPermissionOverrideStore,
 };
 pub use policy::{
-    FilesystemPersistentApprovalPolicyStore, InMemoryPersistentApprovalPolicyStore,
-    PersistentApprovalAction, PersistentApprovalPolicy, PersistentApprovalPolicyError,
-    PersistentApprovalPolicyInput, PersistentApprovalPolicyKey, PersistentApprovalPolicyStore,
-    PersistentApprovalScope, permission_mode_allows_persistent_approval,
-    persistent_approval_grant_issuer,
+    FilesystemPersistentApprovalPolicyStore, PersistentApprovalAction, PersistentApprovalPolicy,
+    PersistentApprovalPolicyError, PersistentApprovalPolicyInput, PersistentApprovalPolicyKey,
+    PersistentApprovalPolicyStore, PersistentApprovalScope,
+    permission_mode_allows_persistent_approval, persistent_approval_grant_issuer,
 };
 
 pub type ToolPermissionOverride = CapabilityPermissionOverride;
@@ -44,7 +45,6 @@ pub type ToolPermissionOverrideRecord = CapabilityPermissionOverrideRecord;
 pub type ToolPermissionState = CapabilityPermissionState;
 pub type ToolPermissionStoreError = CapabilityPermissionStoreError;
 pub type FilesystemToolPermissionOverrideStore<F> = FilesystemCapabilityPermissionOverrideStore<F>;
-pub type InMemoryToolPermissionOverrideStore = InMemoryCapabilityPermissionOverrideStore;
 
 pub trait ToolPermissionOverrideStore: CapabilityPermissionOverrideStore {}
 

--- a/crates/ironclaw_approvals/src/policy.rs
+++ b/crates/ironclaw_approvals/src/policy.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::HashMap,
-    sync::{Arc, RwLock},
-};
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use chrono::Utc;
@@ -217,126 +214,6 @@ pub trait PersistentApprovalPolicyStore: Send + Sync {
         key: &PersistentApprovalPolicyKey,
         source_approval_request_id: ApprovalRequestId,
     ) -> Result<Option<PersistentApprovalPolicy>, PersistentApprovalPolicyError>;
-}
-
-#[derive(Debug, Default)]
-pub struct InMemoryPersistentApprovalPolicyStore {
-    policies: RwLock<HashMap<PersistentApprovalPolicyKey, PersistentApprovalPolicy>>,
-}
-
-impl InMemoryPersistentApprovalPolicyStore {
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
-#[async_trait]
-impl PersistentApprovalPolicyStore for InMemoryPersistentApprovalPolicyStore {
-    async fn allow(
-        &self,
-        mut input: PersistentApprovalPolicyInput,
-    ) -> Result<PersistentApprovalPolicy, PersistentApprovalPolicyError> {
-        input.constraints.max_invocations = None;
-        let scope = input.scope.clone();
-        let key = PersistentApprovalPolicyKey::new(
-            &scope,
-            input.action,
-            input.capability_id,
-            input.grantee,
-        );
-        let mut policies = self
-            .policies
-            .write()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        let now = Utc::now();
-        let (created_at, grant_id) = policies
-            .get(&key)
-            .map_or((now, CapabilityGrantId::new()), |existing| {
-                (existing.created_at, existing.grant_id)
-            });
-        let policy = PersistentApprovalPolicy {
-            key: key.clone(),
-            grant_id,
-            approved_by: input.approved_by,
-            constraints: input.constraints,
-            source_approval_request_id: input.source_approval_request_id,
-            created_at,
-            updated_at: now,
-            revoked_at: None,
-        };
-        policies.insert(key, policy.clone());
-        Ok(policy)
-    }
-
-    async fn lookup(
-        &self,
-        key: &PersistentApprovalPolicyKey,
-    ) -> Result<Option<PersistentApprovalPolicy>, PersistentApprovalPolicyError> {
-        Ok(self
-            .policies
-            .read()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .get(key)
-            .cloned())
-    }
-
-    fn supports_scope_listing(&self) -> bool {
-        true
-    }
-
-    async fn list_for_scope_action(
-        &self,
-        scope: &ResourceScope,
-        action: PersistentApprovalAction,
-    ) -> Result<Vec<PersistentApprovalPolicy>, PersistentApprovalPolicyError> {
-        let target_scope = PersistentApprovalScope::from_resource_scope(scope);
-        Ok(self
-            .policies
-            .read()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .values()
-            .filter(|policy| policy.key.scope == target_scope && policy.key.action == action)
-            .cloned()
-            .collect())
-    }
-
-    async fn revoke(
-        &self,
-        key: &PersistentApprovalPolicyKey,
-    ) -> Result<PersistentApprovalPolicy, PersistentApprovalPolicyError> {
-        let mut policies = self
-            .policies
-            .write()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        let policy = policies
-            .get_mut(key)
-            .ok_or(PersistentApprovalPolicyError::UnknownPolicy)?;
-        let now = Utc::now();
-        policy.revoked_at = Some(now);
-        policy.updated_at = now;
-        Ok(policy.clone())
-    }
-
-    async fn revoke_if_source_approval_request(
-        &self,
-        key: &PersistentApprovalPolicyKey,
-        source_approval_request_id: ApprovalRequestId,
-    ) -> Result<Option<PersistentApprovalPolicy>, PersistentApprovalPolicyError> {
-        let mut policies = self
-            .policies
-            .write()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        let Some(policy) = policies.get_mut(key) else {
-            return Ok(None);
-        };
-        if policy.source_approval_request_id != Some(source_approval_request_id) {
-            return Ok(None);
-        }
-        let now = Utc::now();
-        policy.revoked_at = Some(now);
-        policy.updated_at = now;
-        Ok(Some(policy.clone()))
-    }
 }
 
 pub struct FilesystemPersistentApprovalPolicyStore<F>
@@ -696,6 +573,17 @@ mod tests {
 
     use super::*;
 
+    // The single production store, exercised over the in-memory filesystem
+    // backend — the seam that replaced the deleted
+    // `InMemoryPersistentApprovalPolicyStore`.
+    fn memory_store() -> FilesystemPersistentApprovalPolicyStore<InMemoryBackend> {
+        FilesystemPersistentApprovalPolicyStore::new(scoped_fs(
+            Arc::new(InMemoryBackend::new()),
+            "tenant-a",
+            "alice",
+        ))
+    }
+
     #[test]
     fn permission_modes_allowed_for_persistent_approval_are_explicit() {
         assert!(permission_mode_allows_persistent_approval(
@@ -710,8 +598,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn in_memory_policy_revoke_removes_active_grant() {
-        let store = InMemoryPersistentApprovalPolicyStore::new();
+    async fn policy_revoke_removes_active_grant() {
+        let store = memory_store();
         let scope = scope(None, Some("thread-a"));
         let key = key_for(&scope);
 
@@ -839,7 +727,7 @@ mod tests {
 
     #[tokio::test]
     async fn revoke_if_source_approval_request_preserves_newer_policy() {
-        let store = InMemoryPersistentApprovalPolicyStore::new();
+        let store = memory_store();
         let scope = scope(None, Some("thread-a"));
         let key = key_for(&scope);
         let first_source = ApprovalRequestId::new();
@@ -869,20 +757,9 @@ mod tests {
         let key = key_for(&scope);
         let source = ApprovalRequestId::new();
 
-        let in_memory = InMemoryPersistentApprovalPolicyStore::new();
+        let store = memory_store();
         assert!(
-            in_memory
-                .revoke_if_source_approval_request(&key, source)
-                .await
-                .expect("conditional revoke")
-                .is_none()
-        );
-
-        let backend = Arc::new(InMemoryBackend::new());
-        let scoped = scoped_fs(backend, "tenant-a", "alice");
-        let filesystem = FilesystemPersistentApprovalPolicyStore::new(scoped);
-        assert!(
-            filesystem
+            store
                 .revoke_if_source_approval_request(&key, source)
                 .await
                 .expect("conditional revoke")
@@ -1032,7 +909,7 @@ mod tests {
 
     #[tokio::test]
     async fn active_grant_returns_none_for_expired_policy() {
-        let store = InMemoryPersistentApprovalPolicyStore::new();
+        let store = memory_store();
         let scope = scope(None, Some("thread-a"));
         let mut input = input(scope);
         input.constraints.expires_at = Some(Utc::now() - chrono::Duration::seconds(1));
@@ -1044,7 +921,7 @@ mod tests {
 
     #[tokio::test]
     async fn active_grant_reuses_persisted_policy_grant_id() {
-        let store = InMemoryPersistentApprovalPolicyStore::new();
+        let store = memory_store();
         let scope = scope(None, Some("thread-a"));
         let key = key_for(&scope);
 
@@ -1061,7 +938,7 @@ mod tests {
 
     #[tokio::test]
     async fn active_grant_uses_persistent_approval_issuer_marker() {
-        let store = InMemoryPersistentApprovalPolicyStore::new();
+        let store = memory_store();
         let scope = scope(None, Some("thread-a"));
 
         let policy = store.allow(input(scope)).await.expect("allow policy");

--- a/crates/ironclaw_approvals/src/test_support.rs
+++ b/crates/ironclaw_approvals/src/test_support.rs
@@ -1,0 +1,60 @@
+//! In-memory-backed approval store constructors for tests.
+//!
+//! The Reborn architecture-simplification note
+//! (`docs/reborn/2026-07-17-architecture-simplification-dto-dyn-local.md`, §4.3)
+//! replaces the hand-written `InMemory*Store` parallel implementations with the
+//! one production `Filesystem*Store<F>` exercised over an in-memory backend:
+//! "in-memory" stops being a store and becomes a filesystem backend
+//! (`InMemoryBackend`). These helpers wire that seam once — a
+//! `ScopedFilesystem<InMemoryBackend>` mounted at `/approvals` (covering every
+//! approval store's `/approvals/**` path prefix) — so tests instantiate the same
+//! store a deployment runs.
+//!
+//! Gated behind `#[cfg(any(test, feature = "test-support"))]` so nothing here
+//! ships in production binaries; downstream crates enable the `test-support`
+//! feature from their `[dev-dependencies]`.
+
+use std::sync::Arc;
+
+use ironclaw_filesystem::{InMemoryBackend, ScopedFilesystem};
+use ironclaw_host_api::{MountAlias, MountGrant, MountPermissions, MountView, VirtualPath};
+
+use crate::{
+    FilesystemAutoApproveSettingStore, FilesystemCapabilityPermissionOverrideStore,
+    FilesystemPersistentApprovalPolicyStore,
+};
+
+/// A fresh, volatile `ScopedFilesystem<InMemoryBackend>` mounted at `/approvals`
+/// — the in-memory backend seam every approval store uses in tests.
+pub fn in_memory_backed_approvals_filesystem() -> Arc<ScopedFilesystem<InMemoryBackend>> {
+    let mounts = MountView::new(vec![MountGrant::new(
+        MountAlias::new("/approvals").expect("static valid mount alias"), // safety: test-support scaffolding, static literal
+        VirtualPath::new("/engine/approvals").expect("static valid virtual path"), // safety: test-support scaffolding, static literal
+        MountPermissions::read_write_list_delete(),
+    )])
+    .expect("static valid approvals mount view"); // safety: test-support scaffolding, static literal
+    Arc::new(ScopedFilesystem::with_fixed_view(
+        Arc::new(InMemoryBackend::new()),
+        mounts,
+    ))
+}
+
+/// The production auto-approve store over a fresh in-memory backend.
+pub fn in_memory_backed_auto_approve_setting_store()
+-> FilesystemAutoApproveSettingStore<InMemoryBackend> {
+    FilesystemAutoApproveSettingStore::new(in_memory_backed_approvals_filesystem())
+}
+
+/// The production persistent-approval-policy store over a fresh in-memory
+/// backend.
+pub fn in_memory_backed_persistent_approval_policy_store()
+-> FilesystemPersistentApprovalPolicyStore<InMemoryBackend> {
+    FilesystemPersistentApprovalPolicyStore::new(in_memory_backed_approvals_filesystem())
+}
+
+/// The production capability-permission-override store over a fresh in-memory
+/// backend.
+pub fn in_memory_backed_capability_permission_override_store()
+-> FilesystemCapabilityPermissionOverrideStore<InMemoryBackend> {
+    FilesystemCapabilityPermissionOverrideStore::new(in_memory_backed_approvals_filesystem())
+}

--- a/crates/ironclaw_host_runtime/Cargo.toml
+++ b/crates/ironclaw_host_runtime/Cargo.toml
@@ -74,6 +74,8 @@ zip = { version = "8", default-features = false, features = ["deflate"] }
 [dev-dependencies]
 axum = { version = "0.8", features = ["json"] }
 hex = "0.4"
+# Enables the in-memory-backed approval store constructors for tests only.
+ironclaw_approvals = { path = "../ironclaw_approvals", features = ["test-support"] }
 ironclaw_event_projections = { path = "../ironclaw_event_projections" }
 sha2 = "0.11"
 tempfile = "3"

--- a/crates/ironclaw_host_runtime/src/services.rs
+++ b/crates/ironclaw_host_runtime/src/services.rs
@@ -11,9 +11,7 @@ mod process_executor;
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
-use ironclaw_approvals::{
-    ApprovalResolver, InMemoryPersistentApprovalPolicyStore, PersistentApprovalPolicyStore,
-};
+use ironclaw_approvals::{ApprovalResolver, PersistentApprovalPolicyStore};
 use ironclaw_authorization::{
     CapabilityLeaseStore, InMemoryCapabilityLeaseStore, TrustAwareCapabilityDispatchAuthorizer,
 };

--- a/crates/ironclaw_host_runtime/src/services/production_wiring.rs
+++ b/crates/ironclaw_host_runtime/src/services/production_wiring.rs
@@ -2,14 +2,16 @@ use std::any::{TypeId, type_name};
 
 use thiserror::Error;
 
+use ironclaw_approvals::FilesystemPersistentApprovalPolicyStore;
+use ironclaw_filesystem::InMemoryBackend;
+
 use super::{
     DurableAuditSink, DurableEventSink, EmptyWasmRuntimeCredentials, InMemoryApprovalRequestStore,
     InMemoryAuditSink, InMemoryCapabilityLeaseStore, InMemoryCredentialBroker,
     InMemoryDurableAuditLog, InMemoryDurableEventLog, InMemoryEventSink,
-    InMemoryPersistentApprovalPolicyStore, InMemoryProcessResultStore, InMemoryProcessStore,
-    InMemoryResourceGovernor, InMemoryRunStateStore, InMemorySecretStore, InMemoryTurnStateStore,
-    LocalFilesystem, LocalHostProcessPort, NoopTurnRunWakeNotifier, RebornEventStoreError,
-    RuntimeKind,
+    InMemoryProcessResultStore, InMemoryProcessStore, InMemoryResourceGovernor,
+    InMemoryRunStateStore, InMemorySecretStore, InMemoryTurnStateStore, LocalFilesystem,
+    LocalHostProcessPort, NoopTurnRunWakeNotifier, RebornEventStoreError, RuntimeKind,
 };
 
 #[derive(Debug, Error)]
@@ -294,7 +296,13 @@ fn classify_component_type<T: ?Sized + 'static>() -> ProductionImplementationRea
             || type_id == TypeId::of::<InMemoryRunStateStore>()
             || type_id == TypeId::of::<InMemoryApprovalRequestStore>()
             || type_id == TypeId::of::<InMemoryCapabilityLeaseStore>()
-            || type_id == TypeId::of::<InMemoryPersistentApprovalPolicyStore>()
+            // The persistent-approval store no longer has a bespoke in-memory
+            // implementation; "in-memory" is now the `InMemoryBackend` behind
+            // the one production `FilesystemPersistentApprovalPolicyStore<F>`
+            // (arch-simplification §4.3). A store backed by `InMemoryBackend` is
+            // still local-only; the durable libSQL/Postgres monomorphizations are
+            // distinct types and correctly classify as production candidates.
+            || type_id == TypeId::of::<FilesystemPersistentApprovalPolicyStore<InMemoryBackend>>()
             || type_id == TypeId::of::<InMemoryEventSink>()
             || type_id == TypeId::of::<InMemoryDurableEventLog>()
             || type_id == TypeId::of::<InMemoryAuditSink>()

--- a/crates/ironclaw_host_runtime/src/services/tests.rs
+++ b/crates/ironclaw_host_runtime/src/services/tests.rs
@@ -1,10 +1,11 @@
+// arch-exempt: large_file, mechanical approval-store migration only — InMemory*Store deleted, guard test repointed to Filesystem*Store<InMemoryBackend> (arch-simplification §4.3), no new test logic, plan #6168
 use std::{
     sync::{Arc, Mutex},
     time::Duration,
 };
 
 use async_trait::async_trait;
-use ironclaw_approvals::InMemoryPersistentApprovalPolicyStore;
+use ironclaw_approvals::test_support::in_memory_backed_persistent_approval_policy_store;
 use ironclaw_authorization::GrantAuthorizer;
 use ironclaw_capabilities::{
     CapabilityObligationCompletionRequest, CapabilityObligationError,
@@ -75,8 +76,9 @@ async fn production_wiring_reports_missing_persistent_approval_policies() {
 
 #[tokio::test]
 async fn production_wiring_reports_local_only_persistent_approval_policies() {
-    let services = test_services()
-        .with_persistent_approval_policies(Arc::new(InMemoryPersistentApprovalPolicyStore::new()));
+    let services = test_services().with_persistent_approval_policies(Arc::new(
+        in_memory_backed_persistent_approval_policy_store(),
+    ));
 
     let report = services
         .validate_production_wiring(&ProductionWiringConfig::new([]))

--- a/crates/ironclaw_host_runtime/src/services/tests.rs
+++ b/crates/ironclaw_host_runtime/src/services/tests.rs
@@ -74,6 +74,13 @@ async fn production_wiring_reports_missing_persistent_approval_policies() {
     ));
 }
 
+// The volatile, in-memory-backed persistent-approval store must never satisfy
+// production wiring. `in_memory_backed_persistent_approval_policy_store()` returns
+// `FilesystemPersistentApprovalPolicyStore<InMemoryBackend>` — the exact concrete
+// type the no-durable-features composition wires (factory.rs
+// `LocalDevPersistentApprovalPolicyStore`), so this guards the real shape, not a
+// synthetic one. The durable libSQL/Postgres monomorphizations are distinct types
+// and fall through to `ProductionCandidate`.
 #[tokio::test]
 async fn production_wiring_reports_local_only_persistent_approval_policies() {
     let services = test_services().with_persistent_approval_policies(Arc::new(

--- a/crates/ironclaw_host_runtime/tests/host_runtime_persistent_approvals_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_persistent_approvals_contract.rs
@@ -7,9 +7,9 @@ use std::sync::{Arc, Mutex};
 use async_trait::async_trait;
 use chrono::Utc;
 use ironclaw_approvals::{
-    FilesystemPersistentApprovalPolicyStore, InMemoryPersistentApprovalPolicyStore,
-    PersistentApprovalAction, PersistentApprovalPolicy, PersistentApprovalPolicyError,
-    PersistentApprovalPolicyInput, PersistentApprovalPolicyKey, PersistentApprovalPolicyStore,
+    FilesystemPersistentApprovalPolicyStore, PersistentApprovalAction, PersistentApprovalPolicy,
+    PersistentApprovalPolicyError, PersistentApprovalPolicyInput, PersistentApprovalPolicyKey,
+    PersistentApprovalPolicyStore, test_support::in_memory_backed_persistent_approval_policy_store,
 };
 use ironclaw_authorization::{GrantAuthorizer, TrustAwareCapabilityDispatchAuthorizer};
 use ironclaw_extensions::{ExtensionManifest, ExtensionPackage, ExtensionRegistry, ManifestSource};
@@ -38,7 +38,7 @@ async fn default_runtime_uses_persistent_policy_as_dispatch_authority() {
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
     let run_state = Arc::new(InMemoryRunStateStore::new());
     let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
-    let policies = Arc::new(InMemoryPersistentApprovalPolicyStore::new());
+    let policies = Arc::new(in_memory_backed_persistent_approval_policy_store());
     let context = execution_context_without_grants();
     policies
         .allow(PersistentApprovalPolicyInput {
@@ -112,7 +112,7 @@ async fn default_runtime_uses_persistent_policy_as_auth_resume_authority() {
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
     let run_state = Arc::new(InMemoryRunStateStore::new());
     let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
-    let policies = Arc::new(InMemoryPersistentApprovalPolicyStore::new());
+    let policies = Arc::new(in_memory_backed_persistent_approval_policy_store());
     let context = execution_context_without_grants();
     let scope = context.resource_scope.clone();
     let invocation_id = context.invocation_id;
@@ -207,7 +207,7 @@ async fn default_runtime_uses_user_grantee_persistent_policy_as_dispatch_authori
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
     let run_state = Arc::new(InMemoryRunStateStore::new());
     let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
-    let policies = Arc::new(InMemoryPersistentApprovalPolicyStore::new());
+    let policies = Arc::new(in_memory_backed_persistent_approval_policy_store());
     let context = execution_context_without_grants();
     policies
         .allow(PersistentApprovalPolicyInput {
@@ -347,7 +347,7 @@ async fn default_runtime_does_not_replay_tenant_grantee_persistent_policy() {
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
     let run_state = Arc::new(InMemoryRunStateStore::new());
     let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
-    let policies = Arc::new(InMemoryPersistentApprovalPolicyStore::new());
+    let policies = Arc::new(in_memory_backed_persistent_approval_policy_store());
     let context = execution_context_without_grants();
     policies
         .allow(PersistentApprovalPolicyInput {
@@ -411,7 +411,7 @@ async fn default_runtime_skips_unusable_persistent_policy_for_later_match() {
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
     let run_state = Arc::new(InMemoryRunStateStore::new());
     let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
-    let policies = Arc::new(InMemoryPersistentApprovalPolicyStore::new());
+    let policies = Arc::new(in_memory_backed_persistent_approval_policy_store());
     let context = execution_context_without_grants();
     policies
         .allow(PersistentApprovalPolicyInput {
@@ -539,7 +539,7 @@ async fn default_runtime_reuses_persistent_policy_for_manifest_ask() {
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
     let run_state = Arc::new(InMemoryRunStateStore::new());
     let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
-    let policies = Arc::new(InMemoryPersistentApprovalPolicyStore::new());
+    let policies = Arc::new(in_memory_backed_persistent_approval_policy_store());
     let context = execution_context_without_grants();
     policies
         .allow(PersistentApprovalPolicyInput {
@@ -603,7 +603,7 @@ async fn default_runtime_skips_expired_persistent_policy() {
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
     let run_state = Arc::new(InMemoryRunStateStore::new());
     let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
-    let policies = Arc::new(InMemoryPersistentApprovalPolicyStore::new());
+    let policies = Arc::new(in_memory_backed_persistent_approval_policy_store());
     let context = execution_context_without_grants();
     policies
         .allow(PersistentApprovalPolicyInput {
@@ -670,7 +670,7 @@ async fn default_runtime_uses_persistent_policy_for_no_project_no_thread_scope()
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
     let run_state = Arc::new(InMemoryRunStateStore::new());
     let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
-    let policies = Arc::new(InMemoryPersistentApprovalPolicyStore::new());
+    let policies = Arc::new(in_memory_backed_persistent_approval_policy_store());
     let mut context = execution_context_without_grants();
     context.project_id = None;
     context.thread_id = None;
@@ -740,7 +740,7 @@ async fn default_runtime_uses_persistent_policy_as_spawn_capability_authority() 
     let run_state = Arc::new(InMemoryRunStateStore::new());
     let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
     let process_manager = Arc::new(RecordingProcessManager);
-    let policies = Arc::new(InMemoryPersistentApprovalPolicyStore::new());
+    let policies = Arc::new(in_memory_backed_persistent_approval_policy_store());
     let context = execution_context_without_grants();
     policies
         .allow(PersistentApprovalPolicyInput {

--- a/crates/ironclaw_product_workflow/Cargo.toml
+++ b/crates/ironclaw_product_workflow/Cargo.toml
@@ -59,6 +59,8 @@ url = "2"
 uuid = { version = "1", features = ["v4", "v5", "serde"] }
 
 [dev-dependencies]
+# Enables the in-memory-backed approval store constructors for tests only.
+ironclaw_approvals = { path = "../ironclaw_approvals", features = ["test-support"] }
 ironclaw_filesystem = { path = "../ironclaw_filesystem" }
 ironclaw_host_runtime = { path = "../ironclaw_host_runtime" }
 ironclaw_loop_host = { path = "../ironclaw_loop_host" }

--- a/crates/ironclaw_product_workflow/tests/approval_interaction_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/approval_interaction_contract.rs
@@ -1,14 +1,18 @@
+// arch-exempt: large_file, mechanical approval-store migration only — InMemory*Store deleted, tests repointed to Filesystem*Store<InMemoryBackend> (arch-simplification §4.3), no new test logic, plan #6168
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 use chrono::Utc;
 use ironclaw_approvals::{
-    CapabilityPermissionOverrideStore, DenyApproval, InMemoryPersistentApprovalPolicyStore,
-    InMemoryToolPermissionOverrideStore, LeaseApproval, PersistentApprovalAction,
+    CapabilityPermissionOverrideStore, DenyApproval, LeaseApproval, PersistentApprovalAction,
     PersistentApprovalPolicy, PersistentApprovalPolicyError, PersistentApprovalPolicyInput,
     PersistentApprovalPolicyKey, PersistentApprovalPolicyStore, ToolPermissionOverride,
     ToolPermissionOverrideInput, ToolPermissionOverrideKey, ToolPermissionOverrideStore,
+    test_support::{
+        in_memory_backed_capability_permission_override_store,
+        in_memory_backed_persistent_approval_policy_store,
+    },
 };
 use ironclaw_authorization::{
     CapabilityLeaseStatus, CapabilityLeaseStore, InMemoryCapabilityLeaseStore,
@@ -751,10 +755,14 @@ fn approval_request_by(reason: &str, requested_by: Principal) -> ApprovalRequest
 /// Filesystem scope paths are part of the fix, so both must pass. `prefix`
 /// distinguishes the per-backend idempotency keys.
 fn caller_level_store_pair(prefix: &str) -> [(Arc<dyn PersistentApprovalPolicyStore>, String); 2] {
+    // Both entries are the one production `FilesystemPersistentApprovalPolicyStore`
+    // over the in-memory backend; they differ only in mount configuration — the
+    // helper's default `/approvals` mount vs. the tenant/user-scoped mount that
+    // the settings-scope fix exercises.
     [
         (
-            Arc::new(InMemoryPersistentApprovalPolicyStore::new()),
-            format!("{prefix}-in-memory"),
+            Arc::new(in_memory_backed_persistent_approval_policy_store()),
+            format!("{prefix}-default-mount"),
         ),
         (
             Arc::new(
@@ -763,7 +771,7 @@ fn caller_level_store_pair(prefix: &str) -> [(Arc<dyn PersistentApprovalPolicySt
                     "user-alpha",
                 )),
             ),
-            format!("{prefix}-filesystem"),
+            format!("{prefix}-scoped-mount"),
         ),
     ]
 }
@@ -906,7 +914,7 @@ async fn always_allow_resolves_gate_and_persists_reusable_policy() {
         Principal::User(UserId::new("user-alpha").expect("user")),
     );
     let (service, resolver, coordinator, run_id, gate_ref) = service_fixture_for_request(request);
-    let policies = Arc::new(InMemoryPersistentApprovalPolicyStore::new());
+    let policies = Arc::new(in_memory_backed_persistent_approval_policy_store());
     let policy_store: Arc<dyn PersistentApprovalPolicyStore> = policies.clone();
     let service = service.with_persistent_policy_store(policy_store);
 
@@ -952,8 +960,8 @@ async fn always_allow_clears_existing_ask_each_time_override() {
     let policy_scope = resource_scope(&actor("user-alpha"));
     let override_key = ToolPermissionOverrideKey::new(&settings_scope(&policy_scope), capability);
     let (service, _resolver, _coordinator, run_id, gate_ref) = service_fixture_for_request(request);
-    let policies = Arc::new(InMemoryPersistentApprovalPolicyStore::new());
-    let overrides = Arc::new(InMemoryToolPermissionOverrideStore::new());
+    let policies = Arc::new(in_memory_backed_persistent_approval_policy_store());
+    let overrides = Arc::new(in_memory_backed_capability_permission_override_store());
     overrides
         .set(ToolPermissionOverrideInput {
             scope: settings_scope(&policy_scope),
@@ -1008,8 +1016,8 @@ async fn always_allow_persists_provider_grantee_when_resolver_supplies_one() {
         Principal::Extension(provider.clone()),
     );
     let (service, _resolver, _coordinator, run_id, gate_ref) = service_fixture_for_request(request);
-    let policies = Arc::new(InMemoryPersistentApprovalPolicyStore::new());
-    let overrides = Arc::new(InMemoryToolPermissionOverrideStore::new());
+    let policies = Arc::new(in_memory_backed_persistent_approval_policy_store());
+    let overrides = Arc::new(in_memory_backed_capability_permission_override_store());
     overrides
         .set(ToolPermissionOverrideInput {
             scope: settings_scope(&policy_scope),
@@ -1148,8 +1156,8 @@ async fn drive_spawn_always_allow(
 
 /// Acceptance criterion 1: an "always allow" granted while resolving a gate in
 /// thread 1 (no project) is persisted at the same tenant/user scope that the
-/// Settings > Tools surface reads. Covered against both InMemory and Filesystem
-/// stores because the filesystem scope path is part of the fix.
+/// Settings > Tools surface reads. Covered against the store over two mount
+/// configurations because the filesystem scope path is part of the fix.
 #[tokio::test]
 async fn always_allow_grants_reuse_in_new_thread_without_project() {
     for (store, idempotency) in caller_level_store_pair("reuse") {
@@ -1396,7 +1404,7 @@ async fn always_allow_disallowed_by_policy_rejects_without_persisting_or_approvi
         actor.clone(),
         gate_ref.clone(),
     ));
-    let policies = Arc::new(InMemoryPersistentApprovalPolicyStore::new());
+    let policies = Arc::new(in_memory_backed_persistent_approval_policy_store());
     let policy_store: Arc<dyn PersistentApprovalPolicyStore> = policies.clone();
     let service = DefaultApprovalInteractionService::new(
         Arc::new(FakeReadModel::with_gate(gate)),
@@ -1465,7 +1473,7 @@ async fn always_allow_does_not_persist_policy_when_resolution_fails() {
         actor.clone(),
         gate_ref.clone(),
     ));
-    let policies = Arc::new(InMemoryPersistentApprovalPolicyStore::new());
+    let policies = Arc::new(in_memory_backed_persistent_approval_policy_store());
     let policy_store: Arc<dyn PersistentApprovalPolicyStore> = policies.clone();
     let service = DefaultApprovalInteractionService::new(
         Arc::new(FakeReadModel::with_gate(gate)),
@@ -1531,7 +1539,7 @@ async fn always_allow_resolution_failure_preserves_existing_policy() {
         actor.clone(),
         gate_ref.clone(),
     ));
-    let policies = Arc::new(InMemoryPersistentApprovalPolicyStore::new());
+    let policies = Arc::new(in_memory_backed_persistent_approval_policy_store());
     let existing_source = ApprovalRequestId::new();
     policies
         .allow(PersistentApprovalPolicyInput {
@@ -1734,7 +1742,7 @@ async fn already_approved_always_allow_replay_rejects_without_persisting_policy(
     let (service, resolver, coordinator, run_id, gate_ref) =
         service_fixture_for_request_status(request, ApprovalStatus::Approved);
     coordinator.set_status(TurnStatus::Queued);
-    let policies = Arc::new(InMemoryPersistentApprovalPolicyStore::new());
+    let policies = Arc::new(in_memory_backed_persistent_approval_policy_store());
     let policy_store: Arc<dyn PersistentApprovalPolicyStore> = policies.clone();
     let service = service.with_persistent_policy_store(policy_store);
 

--- a/crates/ironclaw_product_workflow/tests/reborn_services_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/reborn_services_contract.rs
@@ -8441,10 +8441,15 @@ fn services_with_operator_approval_config() -> RebornServices {
 
 fn services_with_operator_approval_config_parts() -> (
     RebornServices,
-    Arc<ironclaw_approvals::InMemoryPersistentApprovalPolicyStore>,
+    Arc<
+        ironclaw_approvals::FilesystemPersistentApprovalPolicyStore<
+            ironclaw_filesystem::InMemoryBackend,
+        >,
+    >,
 ) {
-    let persistent_policies =
-        Arc::new(ironclaw_approvals::InMemoryPersistentApprovalPolicyStore::new());
+    let persistent_policies = Arc::new(
+        ironclaw_approvals::test_support::in_memory_backed_persistent_approval_policy_store(),
+    );
     let policy_store: Arc<dyn PersistentApprovalPolicyStore> = persistent_policies.clone();
     let services = services_with_operator_approval_config_policy_store(policy_store);
     (services, persistent_policies)
@@ -8454,7 +8459,7 @@ fn services_with_operator_approval_config_policy_store(
     persistent_policies: Arc<dyn PersistentApprovalPolicyStore>,
 ) -> RebornServices {
     services_with_operator_approval_config_stores(
-        Arc::new(ironclaw_approvals::InMemoryAutoApproveSettingStore::new()),
+        Arc::new(ironclaw_approvals::test_support::in_memory_backed_auto_approve_setting_store()),
         persistent_policies,
     )
 }
@@ -8468,7 +8473,10 @@ fn services_with_operator_approval_config_stores(
         Arc::new(FakeTurnCoordinator::default()),
     )
     .with_operator_approval_config(
-        Arc::new(ironclaw_approvals::InMemoryToolPermissionOverrideStore::new()),
+        Arc::new(
+            ironclaw_approvals::test_support::in_memory_backed_capability_permission_override_store(
+            ),
+        ),
         auto_approve,
         persistent_policies.clone(),
         Arc::new(StaticOperatorToolCatalogForTest {
@@ -8604,7 +8612,9 @@ async fn global_auto_approve_enabled_scopes_read_by_caller_tenant_and_user() {
     let auto_approve = Arc::new(RecordingAutoApproveSettingStore::default());
     let services = services_with_operator_approval_config_stores(
         auto_approve.clone(),
-        Arc::new(ironclaw_approvals::InMemoryPersistentApprovalPolicyStore::new()),
+        Arc::new(
+            ironclaw_approvals::test_support::in_memory_backed_persistent_approval_policy_store(),
+        ),
     );
     let caller = WebUiAuthenticatedCaller::new(
         TenantId::new("tenant-scope").expect("tenant"),

--- a/crates/ironclaw_reborn_composition/Cargo.toml
+++ b/crates/ironclaw_reborn_composition/Cargo.toml
@@ -196,6 +196,8 @@ uuid = { version = "1", features = ["v4"] }
 async-trait = "0.1"
 chrono = "0.4"
 hmac = "0.13"
+# Enables the in-memory-backed approval store constructors for tests only.
+ironclaw_approvals = { path = "../ironclaw_approvals", features = ["test-support"] }
 http = "1"
 http-body-util = "0.1"
 # Admin-user-management e2e test drives the composed app with a real session

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -292,17 +292,35 @@ pub(crate) type LocalDevCapabilityLeaseStore =
 #[cfg(not(any(feature = "libsql", feature = "postgres")))]
 pub(crate) type LocalDevCapabilityLeaseStore = InMemoryCapabilityLeaseStore;
 
-// One store per approval domain, backend-injected. Local-dev runs the same
-// production `Filesystem*Store<F>` every deployment uses, over the local-dev
-// root filesystem (in-memory when no durable backend feature is enabled,
-// libSQL/Postgres otherwise) — no bespoke `InMemory*Store` type
-// (arch-simplification §4.3).
+// One store per approval domain, backend-injected — the production
+// `Filesystem*Store<F>` every deployment uses, never a bespoke `InMemory*Store`
+// (arch-simplification §4.3). The store's backend type encodes its durability:
+// the no-durable-features build backs them with `InMemoryBackend` directly, so
+// the concrete type is `<InMemoryBackend>` — which the host-runtime
+// production-wiring guard classifies `LocalOnly` (the same way the volatile
+// `InMemoryRunStateStore`/`InMemoryCapabilityLeaseStore` are flagged). Durable
+// builds use the libSQL/Postgres-backed composite root filesystem, whose type is
+// distinct and correctly classifies as a production candidate.
+#[cfg(any(feature = "libsql", feature = "postgres"))]
 pub(crate) type LocalDevPersistentApprovalPolicyStore =
     FilesystemPersistentApprovalPolicyStore<LocalDevRootFilesystem>;
+#[cfg(not(any(feature = "libsql", feature = "postgres")))]
+pub(crate) type LocalDevPersistentApprovalPolicyStore =
+    FilesystemPersistentApprovalPolicyStore<InMemoryBackend>;
+
+#[cfg(any(feature = "libsql", feature = "postgres"))]
 pub(crate) type LocalDevToolPermissionOverrideStore =
     FilesystemToolPermissionOverrideStore<LocalDevRootFilesystem>;
+#[cfg(not(any(feature = "libsql", feature = "postgres")))]
+pub(crate) type LocalDevToolPermissionOverrideStore =
+    FilesystemToolPermissionOverrideStore<InMemoryBackend>;
+
+#[cfg(any(feature = "libsql", feature = "postgres"))]
 pub(crate) type LocalDevAutoApproveSettingStore =
     FilesystemAutoApproveSettingStore<LocalDevRootFilesystem>;
+#[cfg(not(any(feature = "libsql", feature = "postgres")))]
+pub(crate) type LocalDevAutoApproveSettingStore =
+    FilesystemAutoApproveSettingStore<InMemoryBackend>;
 
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 type LocalDevProcessServices = ProcessServices<
@@ -2554,17 +2572,20 @@ async fn build_local_dev_store_graph(
         project_repository,
         turn_state_store_limits,
     } = input;
-    // Approval stores run the production `Filesystem*Store<F>` over the local-dev
-    // root filesystem (here backed by `InMemoryBackend`, since no durable backend
-    // feature is enabled) — no bespoke `InMemory*Store` (arch-simplification §4.3).
-    let scoped_filesystem = local_dev_scoped_filesystem(Arc::clone(&filesystem));
+    // Approval stores run the production `Filesystem*Store<F>` over a dedicated
+    // `InMemoryBackend` (volatile) — no bespoke `InMemory*Store`
+    // (arch-simplification §4.3). Backing them with `InMemoryBackend` *directly*
+    // (rather than the composite root filesystem) keeps the store's concrete type
+    // `<InMemoryBackend>`, so the host-runtime production-wiring guard classifies it
+    // `LocalOnly` — matching the volatile run-state/lease stores in this build.
+    let approvals_filesystem = crate::wrap_scoped(Arc::new(InMemoryBackend::new()));
     let event_log = local_dev_event_log(Arc::clone(&filesystem))?;
     let audit_log = local_dev_audit_log(Arc::clone(&filesystem))?;
     let run_state = Arc::new(InMemoryRunStateStore::new());
     let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
     let capability_leases = Arc::new(InMemoryCapabilityLeaseStore::new());
     let persistent_approval_policies = Arc::new(FilesystemPersistentApprovalPolicyStore::new(
-        Arc::clone(&scoped_filesystem),
+        Arc::clone(&approvals_filesystem),
     ));
     let turn_state = Arc::new(InMemoryTurnStateStore::with_limits(turn_state_store_limits));
     let checkpoint_state_store: Arc<dyn CheckpointStateStore> =
@@ -2592,10 +2613,10 @@ async fn build_local_dev_store_graph(
         }
     })?);
     let tool_permission_overrides = Arc::new(LocalDevToolPermissionOverrideStore::new(Arc::clone(
-        &scoped_filesystem,
+        &approvals_filesystem,
     )));
     let auto_approve_settings = Arc::new(LocalDevAutoApproveSettingStore::new(Arc::clone(
-        &scoped_filesystem,
+        &approvals_filesystem,
     )));
     let memory_mounts =
         memory_mount_view(MountPermissions::read_write_list_delete()).map_err(|error| {
@@ -3678,6 +3699,7 @@ fn local_dev_mount_descriptor(
     })
 }
 
+#[cfg(any(feature = "libsql", feature = "postgres"))]
 fn local_dev_scoped_filesystem(
     filesystem: Arc<LocalDevRootFilesystem>,
 ) -> Arc<ScopedFilesystem<LocalDevRootFilesystem>> {

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -9,15 +9,9 @@ use std::{
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 use crate::product_auth::durable::{FilesystemAuthProductServices, UnavailableAuthProviderClient};
 use crate::support::fs::RebornProjectService;
-#[cfg(any(feature = "libsql", feature = "postgres"))]
 use ironclaw_approvals::{
     FilesystemAutoApproveSettingStore, FilesystemPersistentApprovalPolicyStore,
     FilesystemToolPermissionOverrideStore,
-};
-#[cfg(not(any(feature = "libsql", feature = "postgres")))]
-use ironclaw_approvals::{
-    InMemoryAutoApproveSettingStore, InMemoryPersistentApprovalPolicyStore,
-    InMemoryToolPermissionOverrideStore,
 };
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 use ironclaw_auth::AuthProviderClient;
@@ -298,23 +292,17 @@ pub(crate) type LocalDevCapabilityLeaseStore =
 #[cfg(not(any(feature = "libsql", feature = "postgres")))]
 pub(crate) type LocalDevCapabilityLeaseStore = InMemoryCapabilityLeaseStore;
 
-#[cfg(any(feature = "libsql", feature = "postgres"))]
+// One store per approval domain, backend-injected. Local-dev runs the same
+// production `Filesystem*Store<F>` every deployment uses, over the local-dev
+// root filesystem (in-memory when no durable backend feature is enabled,
+// libSQL/Postgres otherwise) — no bespoke `InMemory*Store` type
+// (arch-simplification §4.3).
 pub(crate) type LocalDevPersistentApprovalPolicyStore =
     FilesystemPersistentApprovalPolicyStore<LocalDevRootFilesystem>;
-#[cfg(not(any(feature = "libsql", feature = "postgres")))]
-pub(crate) type LocalDevPersistentApprovalPolicyStore = InMemoryPersistentApprovalPolicyStore;
-
-#[cfg(any(feature = "libsql", feature = "postgres"))]
 pub(crate) type LocalDevToolPermissionOverrideStore =
     FilesystemToolPermissionOverrideStore<LocalDevRootFilesystem>;
-#[cfg(not(any(feature = "libsql", feature = "postgres")))]
-pub(crate) type LocalDevToolPermissionOverrideStore = InMemoryToolPermissionOverrideStore;
-
-#[cfg(any(feature = "libsql", feature = "postgres"))]
 pub(crate) type LocalDevAutoApproveSettingStore =
     FilesystemAutoApproveSettingStore<LocalDevRootFilesystem>;
-#[cfg(not(any(feature = "libsql", feature = "postgres")))]
-pub(crate) type LocalDevAutoApproveSettingStore = InMemoryAutoApproveSettingStore;
 
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 type LocalDevProcessServices = ProcessServices<
@@ -2566,12 +2554,18 @@ async fn build_local_dev_store_graph(
         project_repository,
         turn_state_store_limits,
     } = input;
+    // Approval stores run the production `Filesystem*Store<F>` over the local-dev
+    // root filesystem (here backed by `InMemoryBackend`, since no durable backend
+    // feature is enabled) — no bespoke `InMemory*Store` (arch-simplification §4.3).
+    let scoped_filesystem = local_dev_scoped_filesystem(Arc::clone(&filesystem));
     let event_log = local_dev_event_log(Arc::clone(&filesystem))?;
     let audit_log = local_dev_audit_log(Arc::clone(&filesystem))?;
     let run_state = Arc::new(InMemoryRunStateStore::new());
     let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
     let capability_leases = Arc::new(InMemoryCapabilityLeaseStore::new());
-    let persistent_approval_policies = Arc::new(InMemoryPersistentApprovalPolicyStore::new());
+    let persistent_approval_policies = Arc::new(FilesystemPersistentApprovalPolicyStore::new(
+        Arc::clone(&scoped_filesystem),
+    ));
     let turn_state = Arc::new(InMemoryTurnStateStore::with_limits(turn_state_store_limits));
     let checkpoint_state_store: Arc<dyn CheckpointStateStore> =
         Arc::new(InMemoryCheckpointStateStore::default());
@@ -2597,8 +2591,12 @@ async fn build_local_dev_store_graph(
             reason: format!("local-dev capability policy is invalid: {error}"),
         }
     })?);
-    let tool_permission_overrides = Arc::new(LocalDevToolPermissionOverrideStore::new());
-    let auto_approve_settings = Arc::new(LocalDevAutoApproveSettingStore::new());
+    let tool_permission_overrides = Arc::new(LocalDevToolPermissionOverrideStore::new(Arc::clone(
+        &scoped_filesystem,
+    )));
+    let auto_approve_settings = Arc::new(LocalDevAutoApproveSettingStore::new(Arc::clone(
+        &scoped_filesystem,
+    )));
     let memory_mounts =
         memory_mount_view(MountPermissions::read_write_list_delete()).map_err(|error| {
             RebornBuildError::InvalidConfig {
@@ -3680,7 +3678,6 @@ fn local_dev_mount_descriptor(
     })
 }
 
-#[cfg(any(feature = "libsql", feature = "postgres"))]
 fn local_dev_scoped_filesystem(
     filesystem: Arc<LocalDevRootFilesystem>,
 ) -> Arc<ScopedFilesystem<LocalDevRootFilesystem>> {

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -568,10 +568,8 @@ use ironclaw_authorization::CapabilityLeaseError;
 use ironclaw_filesystem::LibSqlRootFilesystem;
 #[cfg(feature = "postgres")]
 use ironclaw_filesystem::PostgresRootFilesystem;
-#[cfg(any(feature = "libsql", feature = "postgres"))]
 use ironclaw_filesystem::{RootFilesystem, ScopedFilesystem};
 use ironclaw_host_api::ProcessBackendKind;
-#[cfg(any(feature = "libsql", feature = "postgres"))]
 use ironclaw_host_api::{
     MountAlias, MountGrant, MountPermissions, MountView, ResourceScope, SYSTEM_RESERVED_ID,
     VirtualPath,
@@ -618,7 +616,6 @@ pub type PostgresProductionHostRuntimeServices = HostRuntimeServices<
 /// `/tenants/<tenant>/users/<user>/<alias>` for the caller's scope, so
 /// two tenants sharing one underlying [`RootFilesystem`] cannot collide
 /// on identically-shaped paths.
-#[cfg(any(feature = "libsql", feature = "postgres"))]
 const PER_USER_ALIASES: &[&str] = &[
     "/processes",
     "/secrets",
@@ -651,7 +648,6 @@ const PER_USER_ALIASES: &[&str] = &[
 /// `/tenants/__system__/users/__system__/<alias>`. Production code uses
 /// it for process-global records whose paths already encode per-tenant
 /// identity (event-log stream keys, conversation singleton state).
-#[cfg(any(feature = "libsql", feature = "postgres"))]
 pub fn invocation_mount_view(
     scope: &ResourceScope,
 ) -> Result<MountView, ironclaw_host_api::HostApiError> {
@@ -661,7 +657,6 @@ pub fn invocation_mount_view(
     )
 }
 
-#[cfg(any(feature = "libsql", feature = "postgres"))]
 fn resource_scope_path_segment(value: &str) -> &str {
     if value == SYSTEM_RESERVED_ID {
         "__system__"
@@ -670,7 +665,6 @@ fn resource_scope_path_segment(value: &str) -> &str {
     }
 }
 
-#[cfg(any(feature = "libsql", feature = "postgres"))]
 fn invocation_mount_view_for_segments(
     tenant_id: &str,
     user_id: &str,
@@ -770,7 +764,6 @@ pub(crate) fn slack_host_state_mount_view(
 /// [`invocation_mount_view`]. The returned filesystem is the single
 /// production handle — every consumer-store call routes per-scope
 /// through this one instance.
-#[cfg(any(feature = "libsql", feature = "postgres"))]
 pub fn wrap_scoped<F>(root: Arc<F>) -> Arc<ScopedFilesystem<F>>
 where
     F: RootFilesystem,

--- a/crates/ironclaw_reborn_composition/src/local_dev_authorization/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/local_dev_authorization/tests.rs
@@ -7,11 +7,17 @@ use ironclaw_approvals::{
     AutoApproveSettingInput, AutoApproveSettingKey, AutoApproveSettingRecord,
     AutoApproveSettingStore, CapabilityPermissionOverrideInput, CapabilityPermissionOverrideKey,
     CapabilityPermissionOverrideRecord, CapabilityPermissionOverrideStore,
-    CapabilityPermissionStoreError, InMemoryAutoApproveSettingStore,
-    InMemoryPersistentApprovalPolicyStore, InMemoryToolPermissionOverrideStore,
+    CapabilityPermissionStoreError, FilesystemAutoApproveSettingStore,
+    FilesystemPersistentApprovalPolicyStore, FilesystemToolPermissionOverrideStore,
     PersistentApprovalPolicy, PersistentApprovalPolicyError, PersistentApprovalPolicyInput,
     PersistentApprovalPolicyKey,
+    test_support::{
+        in_memory_backed_auto_approve_setting_store,
+        in_memory_backed_capability_permission_override_store,
+        in_memory_backed_persistent_approval_policy_store,
+    },
 };
+use ironclaw_filesystem::InMemoryBackend;
 use ironclaw_host_api::{
     CapabilityDescriptor, CapabilityId, EffectKind, ExecutionContext, ExtensionId, MountView,
     PermissionMode, Principal, ResourceEstimate, RuntimeKind, Timestamp, TrustClass, UserId,
@@ -35,14 +41,14 @@ struct CountingAutoApproveSettingStore {
 }
 
 struct CountingToolPermissionOverrideStore {
-    inner: InMemoryToolPermissionOverrideStore,
+    inner: FilesystemToolPermissionOverrideStore<InMemoryBackend>,
     gets: AtomicUsize,
     lists: AtomicUsize,
     delay: Duration,
 }
 
 struct CountingPersistentApprovalPolicyStore {
-    inner: InMemoryPersistentApprovalPolicyStore,
+    inner: FilesystemPersistentApprovalPolicyStore<InMemoryBackend>,
     lookups: AtomicUsize,
     lists: AtomicUsize,
     delay: Duration,
@@ -73,7 +79,7 @@ impl CountingAutoApproveSettingStore {
 impl CountingToolPermissionOverrideStore {
     fn with_delay(delay: Duration) -> Self {
         Self {
-            inner: InMemoryToolPermissionOverrideStore::new(),
+            inner: in_memory_backed_capability_permission_override_store(),
             gets: AtomicUsize::new(0),
             lists: AtomicUsize::new(0),
             delay,
@@ -92,7 +98,7 @@ impl CountingToolPermissionOverrideStore {
 impl CountingPersistentApprovalPolicyStore {
     fn with_delay(delay: Duration) -> Self {
         Self {
-            inner: InMemoryPersistentApprovalPolicyStore::new(),
+            inner: in_memory_backed_persistent_approval_policy_store(),
             lookups: AtomicUsize::new(0),
             lists: AtomicUsize::new(0),
             delay,
@@ -293,7 +299,10 @@ fn local_dev_shell_authorization_inputs_with_permission(
     (descriptor, context, trust_decision)
 }
 
-async fn enable_global_auto_approve(store: &InMemoryAutoApproveSettingStore, user_id: &UserId) {
+async fn enable_global_auto_approve(
+    store: &FilesystemAutoApproveSettingStore<InMemoryBackend>,
+    user_id: &UserId,
+) {
     let scope = ironclaw_host_api::ResourceScope::local_default(
         user_id.clone(),
         ironclaw_host_api::InvocationId::new(),
@@ -310,7 +319,7 @@ async fn enable_global_auto_approve(store: &InMemoryAutoApproveSettingStore, use
 }
 
 async fn seed_shell_tool_override(
-    store: &InMemoryToolPermissionOverrideStore,
+    store: &FilesystemToolPermissionOverrideStore<InMemoryBackend>,
     user_id: &UserId,
     state: ToolPermissionOverride,
 ) {
@@ -525,12 +534,12 @@ async fn local_dev_trace_commons_onboard_skips_approval_gate() {
 #[tokio::test]
 async fn local_dev_authorizer_refreshes_approval_settings_on_next_invocation() {
     let user_id = UserId::new("test-user").expect("user id");
-    let overrides = Arc::new(InMemoryToolPermissionOverrideStore::new());
-    let auto_approve = Arc::new(InMemoryAutoApproveSettingStore::new());
+    let overrides = Arc::new(in_memory_backed_capability_permission_override_store());
+    let auto_approve = Arc::new(in_memory_backed_auto_approve_setting_store());
     let settings = Arc::new(StoreApprovalSettingsProvider::new(
         overrides,
         auto_approve.clone(),
-        Arc::new(ironclaw_approvals::InMemoryPersistentApprovalPolicyStore::new()),
+        Arc::new(in_memory_backed_persistent_approval_policy_store()),
     ));
     let policy = Arc::new(local_dev_capability_policy().expect("capability policy"));
     let authorizer = local_dev_authorizer(None, policy, settings);
@@ -583,12 +592,12 @@ async fn local_dev_authorizer_refreshes_approval_settings_on_next_invocation() {
 #[tokio::test]
 async fn local_dev_authorizer_observes_global_auto_approve_revocation_on_next_invocation() {
     let user_id = UserId::new("test-user").expect("user id");
-    let auto_approve = Arc::new(InMemoryAutoApproveSettingStore::new());
+    let auto_approve = Arc::new(in_memory_backed_auto_approve_setting_store());
     enable_global_auto_approve(&auto_approve, &user_id).await;
     let settings = Arc::new(StoreApprovalSettingsProvider::new(
-        Arc::new(InMemoryToolPermissionOverrideStore::new()),
+        Arc::new(in_memory_backed_capability_permission_override_store()),
         auto_approve.clone(),
-        Arc::new(InMemoryPersistentApprovalPolicyStore::new()),
+        Arc::new(in_memory_backed_persistent_approval_policy_store()),
     ));
     let policy = Arc::new(local_dev_capability_policy().expect("capability policy"));
     let authorizer = local_dev_authorizer(None, policy, settings);
@@ -625,9 +634,9 @@ async fn local_dev_authorizer_caches_global_auto_approve_within_one_invocation()
     let user_id = UserId::new("test-user").expect("user id");
     let auto_approve = Arc::new(CountingAutoApproveSettingStore::enabled());
     let settings = Arc::new(StoreApprovalSettingsProvider::new(
-        Arc::new(InMemoryToolPermissionOverrideStore::new()),
+        Arc::new(in_memory_backed_capability_permission_override_store()),
         auto_approve.clone(),
-        Arc::new(ironclaw_approvals::InMemoryPersistentApprovalPolicyStore::new()),
+        Arc::new(in_memory_backed_persistent_approval_policy_store()),
     ));
     let policy = Arc::new(local_dev_capability_policy().expect("capability policy"));
     let authorizer = local_dev_authorizer(None, policy, settings);
@@ -702,9 +711,9 @@ async fn local_dev_authorizer_coalesces_concurrent_global_auto_approve_misses() 
         Duration::from_millis(25),
     ));
     let settings = Arc::new(StoreApprovalSettingsProvider::new(
-        Arc::new(InMemoryToolPermissionOverrideStore::new()),
+        Arc::new(in_memory_backed_capability_permission_override_store()),
         auto_approve.clone(),
-        Arc::new(ironclaw_approvals::InMemoryPersistentApprovalPolicyStore::new()),
+        Arc::new(in_memory_backed_persistent_approval_policy_store()),
     ));
     let policy = Arc::new(local_dev_capability_policy().expect("capability policy"));
     let authorizer = local_dev_authorizer(None, policy, settings);
@@ -762,7 +771,7 @@ async fn local_dev_authorizer_coalesces_concurrent_scope_listing_settings_misses
     ));
     let settings = Arc::new(StoreApprovalSettingsProvider::new(
         overrides.clone(),
-        Arc::new(InMemoryAutoApproveSettingStore::new()),
+        Arc::new(in_memory_backed_auto_approve_setting_store()),
         persistent_policies.clone(),
     ));
 
@@ -846,9 +855,9 @@ async fn local_dev_authorizer_releases_global_auto_approve_inflight_when_leader_
         Duration::from_millis(100),
     ));
     let settings = Arc::new(StoreApprovalSettingsProvider::new(
-        Arc::new(InMemoryToolPermissionOverrideStore::new()),
+        Arc::new(in_memory_backed_capability_permission_override_store()),
         auto_approve.clone(),
-        Arc::new(ironclaw_approvals::InMemoryPersistentApprovalPolicyStore::new()),
+        Arc::new(in_memory_backed_persistent_approval_policy_store()),
     ));
 
     let leader_settings = Arc::clone(&settings);
@@ -883,7 +892,7 @@ async fn local_dev_authorizer_releases_global_auto_approve_inflight_when_leader_
 #[tokio::test]
 async fn local_dev_authorizer_fails_closed_when_override_lookup_errors() {
     let user_id = UserId::new("test-user").expect("user id");
-    let auto_approve = Arc::new(InMemoryAutoApproveSettingStore::new());
+    let auto_approve = Arc::new(in_memory_backed_auto_approve_setting_store());
     let scope = ironclaw_host_api::ResourceScope::local_default(
         user_id.clone(),
         ironclaw_host_api::InvocationId::new(),
@@ -901,7 +910,7 @@ async fn local_dev_authorizer_fails_closed_when_override_lookup_errors() {
     let settings = Arc::new(StoreApprovalSettingsProvider::new(
         Arc::new(ErroringToolPermissionOverrideStore),
         auto_approve,
-        Arc::new(ironclaw_approvals::InMemoryPersistentApprovalPolicyStore::new()),
+        Arc::new(in_memory_backed_persistent_approval_policy_store()),
     ));
     let policy = Arc::new(local_dev_capability_policy().expect("capability policy"));
     let authorizer = local_dev_authorizer(None, policy, settings);
@@ -919,15 +928,15 @@ async fn local_dev_authorizer_fails_closed_when_override_lookup_errors() {
 #[tokio::test]
 async fn per_tool_disabled_overrides_global_auto_approve_through_store() {
     let user_id = UserId::new("test-user").expect("user id");
-    let overrides = Arc::new(InMemoryToolPermissionOverrideStore::new());
-    let auto_approve = Arc::new(InMemoryAutoApproveSettingStore::new());
+    let overrides = Arc::new(in_memory_backed_capability_permission_override_store());
+    let auto_approve = Arc::new(in_memory_backed_auto_approve_setting_store());
     enable_global_auto_approve(&auto_approve, &user_id).await;
     seed_shell_tool_override(&overrides, &user_id, ToolPermissionOverride::Disabled).await;
 
     let settings = Arc::new(StoreApprovalSettingsProvider::new(
         overrides,
         auto_approve,
-        Arc::new(ironclaw_approvals::InMemoryPersistentApprovalPolicyStore::new()),
+        Arc::new(in_memory_backed_persistent_approval_policy_store()),
     ));
     let policy = Arc::new(local_dev_capability_policy().expect("capability policy"));
     let authorizer = local_dev_authorizer(None, policy, settings);
@@ -942,15 +951,15 @@ async fn per_tool_disabled_overrides_global_auto_approve_through_store() {
 #[tokio::test]
 async fn per_tool_ask_each_time_overrides_global_auto_approve_through_store() {
     let user_id = UserId::new("test-user").expect("user id");
-    let overrides = Arc::new(InMemoryToolPermissionOverrideStore::new());
-    let auto_approve = Arc::new(InMemoryAutoApproveSettingStore::new());
+    let overrides = Arc::new(in_memory_backed_capability_permission_override_store());
+    let auto_approve = Arc::new(in_memory_backed_auto_approve_setting_store());
     enable_global_auto_approve(&auto_approve, &user_id).await;
     seed_shell_tool_override(&overrides, &user_id, ToolPermissionOverride::AskEachTime).await;
 
     let settings = Arc::new(StoreApprovalSettingsProvider::new(
         overrides,
         auto_approve,
-        Arc::new(ironclaw_approvals::InMemoryPersistentApprovalPolicyStore::new()),
+        Arc::new(in_memory_backed_persistent_approval_policy_store()),
     ));
     let policy = Arc::new(local_dev_capability_policy().expect("capability policy"));
     let authorizer = local_dev_authorizer(None, policy, settings);
@@ -968,13 +977,13 @@ async fn per_tool_ask_each_time_overrides_global_auto_approve_through_store() {
 #[tokio::test]
 async fn global_auto_approve_does_not_bypass_manifest_ineligible_tool_through_store() {
     let user_id = UserId::new("test-user").expect("user id");
-    let auto_approve = Arc::new(InMemoryAutoApproveSettingStore::new());
+    let auto_approve = Arc::new(in_memory_backed_auto_approve_setting_store());
     enable_global_auto_approve(&auto_approve, &user_id).await;
 
     let settings = Arc::new(StoreApprovalSettingsProvider::new(
-        Arc::new(InMemoryToolPermissionOverrideStore::new()),
+        Arc::new(in_memory_backed_capability_permission_override_store()),
         auto_approve,
-        Arc::new(ironclaw_approvals::InMemoryPersistentApprovalPolicyStore::new()),
+        Arc::new(in_memory_backed_persistent_approval_policy_store()),
     ));
     let policy = Arc::new(local_dev_capability_policy().expect("capability policy"));
     let authorizer = local_dev_authorizer(None, policy, settings);

--- a/crates/ironclaw_reborn_composition/tests/refreshing_capability_port_test_support.rs
+++ b/crates/ironclaw_reborn_composition/tests/refreshing_capability_port_test_support.rs
@@ -15,9 +15,10 @@ use std::sync::Mutex as StdMutex;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use async_trait::async_trait;
-use ironclaw_approvals::{
-    InMemoryAutoApproveSettingStore, InMemoryCapabilityPermissionOverrideStore,
-    InMemoryPersistentApprovalPolicyStore,
+use ironclaw_approvals::test_support::{
+    in_memory_backed_auto_approve_setting_store,
+    in_memory_backed_capability_permission_override_store,
+    in_memory_backed_persistent_approval_policy_store,
 };
 use ironclaw_authorization::InMemoryCapabilityLeaseStore;
 use ironclaw_host_api::{
@@ -401,9 +402,9 @@ fn test_parts(
         trajectory_observer: None,
         outbound_preferences_facade: None,
         outbound_delivery_target_set_requires_approval: false,
-        tool_permission_overrides: Arc::new(InMemoryCapabilityPermissionOverrideStore::new()),
-        auto_approve_settings: Arc::new(InMemoryAutoApproveSettingStore::new()),
-        persistent_approval_policies: Arc::new(InMemoryPersistentApprovalPolicyStore::new()),
+        tool_permission_overrides: Arc::new(in_memory_backed_capability_permission_override_store()),
+        auto_approve_settings: Arc::new(in_memory_backed_auto_approve_setting_store()),
+        persistent_approval_policies: Arc::new(in_memory_backed_persistent_approval_policy_store()),
         approval_requests: Arc::new(InMemoryApprovalRequestStore::new()),
         capability_leases: Arc::new(InMemoryCapabilityLeaseStore::new()),
         capability_execution_mount_overrides,

--- a/tests/integration/support/harness/mod.rs
+++ b/tests/integration/support/harness/mod.rs
@@ -1490,11 +1490,15 @@ impl HostRuntimeCapabilityHarness {
             });
         let tool_permission_overrides: Arc<dyn ironclaw_approvals::ToolPermissionOverrideStore> =
             self.tool_permission_overrides.clone().unwrap_or_else(|| {
-                Arc::new(ironclaw_approvals::InMemoryCapabilityPermissionOverrideStore::new())
+                Arc::new(
+                    ironclaw_approvals::test_support::in_memory_backed_capability_permission_override_store(),
+                )
             });
         let auto_approve_settings: Arc<dyn ironclaw_approvals::AutoApproveSettingStore> =
             self.auto_approve_settings.clone().unwrap_or_else(|| {
-                Arc::new(ironclaw_approvals::InMemoryAutoApproveSettingStore::new())
+                Arc::new(
+                    ironclaw_approvals::test_support::in_memory_backed_auto_approve_setting_store(),
+                )
             });
         let persistent_approval_policies: Arc<
             dyn ironclaw_approvals::PersistentApprovalPolicyStore,
@@ -1502,7 +1506,9 @@ impl HostRuntimeCapabilityHarness {
             .persistent_approval_policies
             .clone()
             .unwrap_or_else(|| {
-                Arc::new(ironclaw_approvals::InMemoryPersistentApprovalPolicyStore::new())
+                Arc::new(
+                    ironclaw_approvals::test_support::in_memory_backed_persistent_approval_policy_store(),
+                )
             });
         let outbound_preferences_facade = self.outbound_target_tools.as_ref().map(|parts| {
             Arc::clone(&parts.facade)


### PR DESCRIPTION
## First slice of the architecture-simplification note

Implements **Slice A** of `docs/reborn/2026-07-17-architecture-simplification-dto-dyn-local.md` (§4.3): *"in-memory" stops being a bespoke store and becomes a filesystem backend.* Each approval domain now has **one** production `Filesystem*Store<F>` — exercised over `InMemoryBackend` in tests and libSQL/Postgres in production — instead of a hand-written `InMemory*Store` that had to be kept in lock-step.

### A note on scope (the doc's premise didn't fully hold)
The doc framed Slice A as purely *subtractive* ("in-memory/test-only"). Verification against live code showed the in-memory approval stores were **not** test-only: they were the local-dev backend for the no-durable-features build (`factory.rs`) and were referenced by the host-runtime **fail-closed production-wiring guard**. So this slice is a real (still net-subtractive) consolidation that touches that wiring and the guard's classification — done carefully, with the guard's contract preserved.

### What changed
- **`ironclaw_approvals`** — deletes `InMemoryAutoApproveSettingStore`, `InMemoryPersistentApprovalPolicyStore`, `InMemoryCapabilityPermissionOverrideStore` (+ the `InMemoryToolPermissionOverrideStore` alias). Adds a `test-support`-gated helper module (`in_memory_backed_*`) returning the production store over a fresh `InMemoryBackend` mounted at `/approvals`. The stores' own unit tests move onto `Filesystem*Store<InMemoryBackend>`, proving it covers the deleted cases.
- **composition `factory.rs`** — the `LocalDev*` approval-store aliases collapse to one unconditional `Filesystem*Store<LocalDevRootFilesystem>`; the no-durable-features local-dev builder wires them over the composite (in-memory-backed) root filesystem via the existing scoped-filesystem path. `wrap_scoped` / `invocation_mount_view` and the `/approvals` mount machinery are un-gated so both builders share one path.
- **host_runtime production-wiring guard** — the `LocalOnly` classification now keys on `FilesystemPersistentApprovalPolicyStore<InMemoryBackend>` instead of the deleted type. Production (`<LibSql>`/`<Postgres>`) and durable-local-dev (`<Composite>`) classifications are **unchanged**; the guard contract test is repointed and still asserts `LocalOnly`.
- **downstream tests** (host_runtime, composition, product_workflow) repoint to the helpers; the affected crates enable `ironclaw_approvals/test-support` in `[dev-dependencies]`.

### Safety
Net **−136 LOC**. No trust-boundary or persistence-compatibility change: the in-memory approval stores were volatile/local-only; the durable libSQL/Postgres backends are untouched.

### Verification
- `cargo test -p ironclaw_approvals --all-features` (56 tests), guard contract test, `host_runtime_persistent_approvals_contract` (11), `local_dev_authorization` (13), `approval_interaction_contract` (46), `reborn_services_contract` (222) — all green.
- `ironclaw_architecture` boundary tests (8 + 34) green.
- clippy `-D warnings` clean on all four crates, **default (no-durable) and libSQL** configs; `cargo fmt --check` clean; `scripts/pre-commit-safety.sh` clean.

Base: `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
