### PR TITLE
refactor(reborn): capability-lease store over RootFilesystem, delete InMemoryCapabilityLeaseStore (§4.3)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -296,7 +296,9 @@ ironclaw_approvals = { path = "crates/ironclaw_approvals", version = "0.1.0", fe
 ironclaw_auth = { path = "crates/ironclaw_auth", version = "0.1.0", features = ["test-support"] }
 # C-ATTACH: `InboundAttachment` for `submit_turn_with_image_attachment`.
 ironclaw_attachments = { path = "crates/ironclaw_attachments", version = "0.1.0" }
-ironclaw_authorization = { path = "crates/ironclaw_authorization", version = "0.1.0" }
+# `test-support` enables the in-memory-backed capability-lease store constructor
+# for the integration-test harness (cfg(test) does not propagate into deps).
+ironclaw_authorization = { path = "crates/ironclaw_authorization", version = "0.1.0", features = ["test-support"] }
 ironclaw_extensions = { path = "crates/ironclaw_extensions", version = "0.1.0" }
 ironclaw_filesystem = { path = "crates/ironclaw_filesystem", version = "0.1.0" }
 ironclaw_mcp = { path = "crates/ironclaw_mcp", version = "0.1.0" }

--- a/crates/ironclaw_approvals/Cargo.toml
+++ b/crates/ironclaw_approvals/Cargo.toml
@@ -29,5 +29,7 @@ tokio = { version = "1", features = ["sync"] }
 tracing = "0.1"
 
 [dev-dependencies]
+# Enables the in-memory-backed capability-lease store constructor for tests only.
+ironclaw_authorization = { path = "../ironclaw_authorization", features = ["test-support"] }
 tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }

--- a/crates/ironclaw_approvals/tests/approval_resolution_contract.rs
+++ b/crates/ironclaw_approvals/tests/approval_resolution_contract.rs
@@ -8,7 +8,7 @@ use ironclaw_run_state::*;
 #[tokio::test]
 async fn approving_pending_dispatch_request_issues_scoped_capability_lease() {
     let approvals = InMemoryApprovalRequestStore::new();
-    let leases = InMemoryCapabilityLeaseStore::new();
+    let leases = in_memory_backed_capability_lease_store();
     let resolver = ApprovalResolver::new(&approvals, &leases);
     let invocation_id = InvocationId::new();
     let scope = sample_scope(invocation_id, "tenant1", "user1");
@@ -68,7 +68,7 @@ async fn approving_pending_dispatch_request_issues_scoped_capability_lease() {
 #[tokio::test]
 async fn approving_pending_dispatch_request_preserves_reviewed_grant_constraints() {
     let approvals = InMemoryApprovalRequestStore::new();
-    let leases = InMemoryCapabilityLeaseStore::new();
+    let leases = in_memory_backed_capability_lease_store();
     let resolver = ApprovalResolver::new(&approvals, &leases);
     let invocation_id = InvocationId::new();
     let scope = sample_scope(invocation_id, "tenant1", "user1");
@@ -208,7 +208,7 @@ async fn approving_pending_request_issues_no_lease_when_approval_update_fails() 
             status: ApprovalStatus::Pending,
         },
     };
-    let leases = InMemoryCapabilityLeaseStore::new();
+    let leases = in_memory_backed_capability_lease_store();
     let resolver = ApprovalResolver::new(&approvals, &leases);
 
     let err = resolver
@@ -253,7 +253,7 @@ async fn approving_pending_request_issues_no_lease_when_status_was_resolved_conc
         },
         resolved_status: ApprovalStatus::Denied,
     };
-    let leases = InMemoryCapabilityLeaseStore::new();
+    let leases = in_memory_backed_capability_lease_store();
     let resolver = ApprovalResolver::new(&approvals, &leases);
 
     let err = resolver
@@ -288,7 +288,7 @@ async fn approving_pending_request_issues_no_lease_when_status_was_resolved_conc
 #[tokio::test]
 async fn lease_from_approved_request_is_resume_only_and_not_plain_authority() {
     let approvals = InMemoryApprovalRequestStore::new();
-    let leases = InMemoryCapabilityLeaseStore::new();
+    let leases = in_memory_backed_capability_lease_store();
     let resolver = ApprovalResolver::new(&approvals, &leases);
     let context = execution_context(CapabilitySet::default());
     let descriptor = descriptor(CapabilityId::new("echo.say").unwrap());
@@ -334,7 +334,7 @@ async fn lease_from_approved_request_is_resume_only_and_not_plain_authority() {
 #[tokio::test]
 async fn approving_dispatch_without_fingerprint_fails_without_lease_or_status_change() {
     let approvals = InMemoryApprovalRequestStore::new();
-    let leases = InMemoryCapabilityLeaseStore::new();
+    let leases = in_memory_backed_capability_lease_store();
     let resolver = ApprovalResolver::new(&approvals, &leases);
     let invocation_id = InvocationId::new();
     let scope = sample_scope(invocation_id, "tenant1", "user1");
@@ -385,7 +385,7 @@ async fn approving_dispatch_without_fingerprint_fails_without_lease_or_status_ch
 #[tokio::test]
 async fn approving_pending_dispatch_request_emits_redacted_approval_audit_event() {
     let approvals = InMemoryApprovalRequestStore::new();
-    let leases = InMemoryCapabilityLeaseStore::new();
+    let leases = in_memory_backed_capability_lease_store();
     let audit = InMemoryAuditSink::new();
     let resolver = ApprovalResolver::new(&approvals, &leases).with_audit_sink(&audit);
     let invocation_id = InvocationId::new();
@@ -442,7 +442,7 @@ async fn approving_pending_dispatch_request_emits_redacted_approval_audit_event(
 #[tokio::test]
 async fn denying_pending_dispatch_request_emits_redacted_approval_audit_event() {
     let approvals = InMemoryApprovalRequestStore::new();
-    let leases = InMemoryCapabilityLeaseStore::new();
+    let leases = in_memory_backed_capability_lease_store();
     let audit = InMemoryAuditSink::new();
     let resolver = ApprovalResolver::new(&approvals, &leases).with_audit_sink(&audit);
     let invocation_id = InvocationId::new();
@@ -489,7 +489,7 @@ async fn denying_pending_dispatch_request_emits_redacted_approval_audit_event() 
 #[tokio::test]
 async fn approval_audit_event_sink_failure_does_not_change_resolution_outcome() {
     let approvals = InMemoryApprovalRequestStore::new();
-    let leases = InMemoryCapabilityLeaseStore::new();
+    let leases = in_memory_backed_capability_lease_store();
     let audit = FailingAuditSink;
     let resolver = ApprovalResolver::new(&approvals, &leases).with_audit_sink(&audit);
     let invocation_id = InvocationId::new();
@@ -536,7 +536,7 @@ async fn approval_audit_event_sink_failure_does_not_change_resolution_outcome() 
 #[tokio::test]
 async fn denying_pending_request_does_not_issue_lease() {
     let approvals = InMemoryApprovalRequestStore::new();
-    let leases = InMemoryCapabilityLeaseStore::new();
+    let leases = in_memory_backed_capability_lease_store();
     let resolver = ApprovalResolver::new(&approvals, &leases);
     let invocation_id = InvocationId::new();
     let scope = sample_scope(invocation_id, "tenant1", "user1");
@@ -565,7 +565,7 @@ async fn denying_pending_request_does_not_issue_lease() {
 #[tokio::test]
 async fn denying_non_pending_request_fails_without_changing_status() {
     let approvals = InMemoryApprovalRequestStore::new();
-    let leases = InMemoryCapabilityLeaseStore::new();
+    let leases = in_memory_backed_capability_lease_store();
     let resolver = ApprovalResolver::new(&approvals, &leases);
     let invocation_id = InvocationId::new();
     let scope = sample_scope(invocation_id, "tenant1", "user1");
@@ -608,7 +608,7 @@ async fn denying_non_pending_request_fails_without_changing_status() {
 #[tokio::test]
 async fn approving_request_from_other_tenant_fails_closed() {
     let approvals = InMemoryApprovalRequestStore::new();
-    let leases = InMemoryCapabilityLeaseStore::new();
+    let leases = in_memory_backed_capability_lease_store();
     let resolver = ApprovalResolver::new(&approvals, &leases);
     let invocation_id = InvocationId::new();
     let tenant_a = sample_scope(invocation_id, "tenant1", "user1");
@@ -654,7 +654,7 @@ async fn concurrent_approve_dispatch_on_same_request_is_first_write_wins() {
     // because under F2 ordering the approval write happens before lease
     // issuance, so a loser approval never reaches the lease store.
     let approvals = std::sync::Arc::new(InMemoryApprovalRequestStore::new());
-    let leases = std::sync::Arc::new(InMemoryCapabilityLeaseStore::new());
+    let leases = std::sync::Arc::new(in_memory_backed_capability_lease_store());
     let invocation_id = InvocationId::new();
     let scope = sample_scope(invocation_id, "tenant1", "user1");
     let approval = approval_request(invocation_id, CapabilityId::new("echo.say").unwrap());

--- a/crates/ironclaw_authorization/AGENTS.md
+++ b/crates/ironclaw_authorization/AGENTS.md
@@ -13,7 +13,7 @@
 
 - Grant matching, capability-lease state, and dispatch/spawn authorization decisions (default-deny), currently:
 - Authorizer ports and implementations: `CapabilityDispatchAuthorizer` / `TrustAwareCapabilityDispatchAuthorizer` traits, `GrantAuthorizer`, `LeaseBackedAuthorizer`, and the `grant_exceeds_authority_ceiling` check.
-- Capability-lease state: `CapabilityLease` (+ `CapabilityLeaseStatus`/`CapabilityLeaseError`), the `CapabilityLeaseStore` trait, and its `InMemoryCapabilityLeaseStore` / `FilesystemCapabilityLeaseStore` backends (the filesystem backend writes via bounded compare-and-swap — `CasExpectation::Version` with a retry budget — over versioned roots for cross-process safety, plus per-owner process-local mutation locks; only byte-only/`Unsupported` roots degrade to process-local serialization alone).
+- Capability-lease state: `CapabilityLease` (+ `CapabilityLeaseStatus`/`CapabilityLeaseError`), the `CapabilityLeaseStore` trait, and the one production `FilesystemCapabilityLeaseStore<F>` backend (writes via bounded compare-and-swap — `CasExpectation::Version` with a retry budget — over versioned roots for cross-process safety, plus per-owner process-local mutation locks; only byte-only/`Unsupported` roots degrade to process-local serialization alone). Tests instantiate that same store over an in-memory backend through the `test-support` `in_memory_backed_capability_lease_store()` constructor — "in-memory" is a filesystem backend (`InMemoryBackend`), not a bespoke store (arch-simplification §4.3); the hand-written `InMemoryCapabilityLeaseStore` was deleted.
 - Crate-local public API, tests, and fixtures needed to prove that ownership.
 
 ## Do Not Move In Here

--- a/crates/ironclaw_authorization/Cargo.toml
+++ b/crates/ironclaw_authorization/Cargo.toml
@@ -9,6 +9,11 @@ layer = "kernel"
 
 [features]
 default = []
+# In-memory-backed capability-lease store constructor for this crate's own tests
+# and downstream integration tiers. The store itself is the production
+# `FilesystemCapabilityLeaseStore<InMemoryBackend>`; the helper just wires the
+# in-memory backend seam (arch-simplification §4.3).
+test-support = []
 
 [dependencies]
 async-trait = "0.1"

--- a/crates/ironclaw_authorization/src/lib.rs
+++ b/crates/ironclaw_authorization/src/lib.rs
@@ -1,3 +1,4 @@
+// arch-exempt: large_file, mechanical lease-store migration only — InMemoryCapabilityLeaseStore deleted (net −187 LOC), test-support helper added over FilesystemCapabilityLeaseStore<InMemoryBackend> (arch-simplification §4.3), plan #6168
 //! Capability authorization contracts for IronClaw Reborn.
 //!
 //! `ironclaw_authorization` evaluates authority-bearing host API contracts. It
@@ -7,7 +8,7 @@
 
 use std::{
     collections::HashMap,
-    sync::{Arc, Mutex, MutexGuard},
+    sync::{Arc, Mutex},
 };
 
 use async_trait::async_trait;
@@ -25,14 +26,21 @@ use ironclaw_filesystem::{
 const CAS_RETRY_ATTEMPTS: usize = 3;
 use ironclaw_host_api::{
     AgentId, CapabilityDescriptor, CapabilityGrant, CapabilityGrantId, Decision, DenyReason,
-    EffectKind, ExecutionContext, HostApiError, InvocationFingerprint, InvocationId, MissionId,
-    NetworkPolicy, Obligation, Obligations, Principal, ProjectId, ResourceCeiling,
-    ResourceEstimate, ResourceScope, RuntimeCredentialRequirementSource, RuntimeKind, SandboxQuota,
-    ScopedPath, TenantId, ThreadId, UserId,
+    EffectKind, ExecutionContext, HostApiError, InvocationFingerprint, MissionId, NetworkPolicy,
+    Obligation, Obligations, Principal, ProjectId, ResourceCeiling, ResourceEstimate,
+    ResourceScope, RuntimeCredentialRequirementSource, RuntimeKind, SandboxQuota, ScopedPath,
+    TenantId, ThreadId, UserId,
 };
 use ironclaw_trust::{AuthorityCeiling, TrustDecision};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+
+#[cfg(any(test, feature = "test-support"))]
+mod test_support;
+#[cfg(any(test, feature = "test-support"))]
+pub use test_support::{
+    in_memory_backed_authorization_filesystem, in_memory_backed_capability_lease_store,
+};
 
 /// Authorizes a capability dispatch request against an execution context.
 #[async_trait]
@@ -297,153 +305,6 @@ pub trait CapabilityLeaseStore: Send + Sync {
             .into_iter()
             .filter(|lease| lease.invocation_fingerprint.is_none())
             .map(|lease| lease.grant)
-            .collect()
-    }
-}
-
-/// In-memory lease store for early Reborn flows and tests.
-#[derive(Debug, Default)]
-pub struct InMemoryCapabilityLeaseStore {
-    leases: Mutex<HashMap<CapabilityLeaseKey, CapabilityLease>>,
-}
-
-impl InMemoryCapabilityLeaseStore {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    fn leases_guard(&self) -> MutexGuard<'_, HashMap<CapabilityLeaseKey, CapabilityLease>> {
-        self.leases
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-    }
-}
-
-#[async_trait]
-impl CapabilityLeaseStore for InMemoryCapabilityLeaseStore {
-    async fn issue(&self, lease: CapabilityLease) -> Result<CapabilityLease, CapabilityLeaseError> {
-        self.leases_guard().insert(
-            CapabilityLeaseKey::new(&lease.scope, lease.grant.id),
-            lease.clone(),
-        );
-        Ok(lease)
-    }
-
-    async fn revoke(
-        &self,
-        scope: &ResourceScope,
-        lease_id: CapabilityGrantId,
-    ) -> Result<CapabilityLease, CapabilityLeaseError> {
-        let mut leases = self.leases_guard();
-        let lease = leases
-            .get_mut(&CapabilityLeaseKey::new(scope, lease_id))
-            .ok_or(CapabilityLeaseError::UnknownLease { lease_id })?;
-        lease.status = CapabilityLeaseStatus::Revoked;
-        Ok(lease.clone())
-    }
-
-    async fn get(
-        &self,
-        scope: &ResourceScope,
-        lease_id: CapabilityGrantId,
-    ) -> Option<CapabilityLease> {
-        self.leases_guard()
-            .get(&CapabilityLeaseKey::new(scope, lease_id))
-            .cloned()
-    }
-
-    async fn claim(
-        &self,
-        scope: &ResourceScope,
-        lease_id: CapabilityGrantId,
-        invocation_fingerprint: &InvocationFingerprint,
-    ) -> Result<CapabilityLease, CapabilityLeaseError> {
-        let mut leases = self.leases_guard();
-        let lease = leases
-            .get_mut(&CapabilityLeaseKey::new(scope, lease_id))
-            .ok_or(CapabilityLeaseError::UnknownLease { lease_id })?;
-
-        ensure_claimable(lease, invocation_fingerprint)?;
-        lease.status = CapabilityLeaseStatus::Claimed;
-        Ok(lease.clone())
-    }
-
-    async fn consume(
-        &self,
-        scope: &ResourceScope,
-        lease_id: CapabilityGrantId,
-    ) -> Result<CapabilityLease, CapabilityLeaseError> {
-        let mut leases = self.leases_guard();
-        let lease = leases
-            .get_mut(&CapabilityLeaseKey::new(scope, lease_id))
-            .ok_or(CapabilityLeaseError::UnknownLease { lease_id })?;
-
-        let was_claimed = matches!(
-            lease.status,
-            CapabilityLeaseStatus::Claimed | CapabilityLeaseStatus::Dispatching
-        );
-        ensure_consumable(lease)?;
-        if lease.invocation_fingerprint.is_some() {
-            if let Some(remaining) = lease.grant.constraints.max_invocations.as_mut() {
-                *remaining = 0;
-            }
-            lease.status = CapabilityLeaseStatus::Consumed;
-        } else if let Some(remaining) = lease.grant.constraints.max_invocations.as_mut() {
-            *remaining -= 1;
-            if *remaining == 0 {
-                lease.status = CapabilityLeaseStatus::Consumed;
-            } else if was_claimed {
-                lease.status = CapabilityLeaseStatus::Active;
-            }
-        } else if was_claimed {
-            lease.status = CapabilityLeaseStatus::Active;
-        }
-        Ok(lease.clone())
-    }
-
-    async fn begin_dispatch_claimed(
-        &self,
-        scope: &ResourceScope,
-        lease_id: CapabilityGrantId,
-        invocation_fingerprint: &InvocationFingerprint,
-    ) -> Result<CapabilityLease, CapabilityLeaseError> {
-        let mut leases = self.leases_guard();
-        let lease = leases
-            .get_mut(&CapabilityLeaseKey::new(scope, lease_id))
-            .ok_or(CapabilityLeaseError::UnknownLease { lease_id })?;
-        apply_begin_dispatch_claimed_transition(lease, invocation_fingerprint)?;
-        Ok(lease.clone())
-    }
-
-    async fn abort_dispatch_claimed(
-        &self,
-        scope: &ResourceScope,
-        lease_id: CapabilityGrantId,
-    ) -> Result<CapabilityLease, CapabilityLeaseError> {
-        let mut leases = self.leases_guard();
-        let lease = leases
-            .get_mut(&CapabilityLeaseKey::new(scope, lease_id))
-            .ok_or(CapabilityLeaseError::UnknownLease { lease_id })?;
-        apply_abort_dispatch_claimed_transition(lease)?;
-        Ok(lease.clone())
-    }
-
-    async fn leases_for_scope(&self, scope: &ResourceScope) -> Vec<CapabilityLease> {
-        let mut leases = self
-            .leases_guard()
-            .values()
-            .filter(|lease| same_scope_owner(&lease.scope, scope))
-            .cloned()
-            .collect::<Vec<_>>();
-        leases.sort_by_key(|lease| lease.grant.id.as_uuid());
-        leases
-    }
-
-    async fn active_leases_for_context(&self, context: &ExecutionContext) -> Vec<CapabilityLease> {
-        self.leases_for_scope(&context.resource_scope)
-            .await
-            .into_iter()
-            .filter(|lease| lease_is_authorizing(lease, context))
             .collect()
     }
 }
@@ -952,33 +813,6 @@ where
             .into_iter()
             .filter(|lease| lease_is_authorizing(lease, context))
             .collect()
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct CapabilityLeaseKey {
-    tenant_id: TenantId,
-    user_id: UserId,
-    agent_id: Option<AgentId>,
-    project_id: Option<ProjectId>,
-    mission_id: Option<MissionId>,
-    thread_id: Option<ThreadId>,
-    invocation_id: InvocationId,
-    lease_id: CapabilityGrantId,
-}
-
-impl CapabilityLeaseKey {
-    fn new(scope: &ResourceScope, lease_id: CapabilityGrantId) -> Self {
-        Self {
-            tenant_id: scope.tenant_id.clone(),
-            user_id: scope.user_id.clone(),
-            agent_id: scope.agent_id.clone(),
-            project_id: scope.project_id.clone(),
-            mission_id: scope.mission_id.clone(),
-            thread_id: scope.thread_id.clone(),
-            invocation_id: scope.invocation_id,
-            lease_id,
-        }
     }
 }
 
@@ -1582,10 +1416,9 @@ pub(crate) fn ensure_consumable(lease: &CapabilityLease) -> Result<(), Capabilit
 /// lease is neither expired nor exhausted; on success sets status to
 /// `Dispatching`.
 ///
-/// Both [`InMemoryCapabilityLeaseStore`] and [`FilesystemCapabilityLeaseStore`]
-/// delegate to this function so the transition predicate has a single source of
-/// truth. Each store handles its own persistence / compare-and-swap mechanics
-/// around the call.
+/// [`FilesystemCapabilityLeaseStore`] delegates to this function so the
+/// transition predicate has a single source of truth; the store handles its own
+/// persistence / compare-and-swap mechanics around the call.
 pub(crate) fn apply_begin_dispatch_claimed_transition(
     lease: &mut CapabilityLease,
     invocation_fingerprint: &InvocationFingerprint,
@@ -1611,10 +1444,9 @@ pub(crate) fn apply_begin_dispatch_claimed_transition(
 /// `Dispatching → Claimed`; no-op if already `Claimed`; returns
 /// `InactiveLease` for any other status.
 ///
-/// Both [`InMemoryCapabilityLeaseStore`] and [`FilesystemCapabilityLeaseStore`]
-/// delegate to this function so the transition predicate has a single source of
-/// truth. Each store handles its own persistence / compare-and-swap mechanics
-/// around the call.
+/// [`FilesystemCapabilityLeaseStore`] delegates to this function so the
+/// transition predicate has a single source of truth; the store handles its own
+/// persistence / compare-and-swap mechanics around the call.
 pub(crate) fn apply_abort_dispatch_claimed_transition(
     lease: &mut CapabilityLease,
 ) -> Result<(), CapabilityLeaseError> {

--- a/crates/ironclaw_authorization/src/test_support.rs
+++ b/crates/ironclaw_authorization/src/test_support.rs
@@ -1,0 +1,44 @@
+//! In-memory-backed capability-lease store constructor for tests.
+//!
+//! The Reborn architecture-simplification note
+//! (`docs/reborn/2026-07-17-architecture-simplification-dto-dyn-local.md`, §4.3)
+//! replaces the hand-written `InMemory*Store` parallel implementations with the
+//! one production `Filesystem*Store<F>` exercised over an in-memory backend:
+//! "in-memory" stops being a store and becomes a filesystem backend
+//! (`InMemoryBackend`). This helper wires that seam once — a
+//! `ScopedFilesystem<InMemoryBackend>` mounted at `/authorization` (covering the
+//! lease store's `/authorization/**` path prefix) — so tests instantiate the same
+//! store a deployment runs.
+//!
+//! Gated behind `#[cfg(any(test, feature = "test-support"))]` so nothing here
+//! ships in production binaries; downstream crates enable the `test-support`
+//! feature from their `[dev-dependencies]`.
+
+use std::sync::Arc;
+
+use ironclaw_filesystem::{InMemoryBackend, ScopedFilesystem};
+use ironclaw_host_api::{MountAlias, MountGrant, MountPermissions, MountView, VirtualPath};
+
+use crate::FilesystemCapabilityLeaseStore;
+
+/// A fresh, volatile `ScopedFilesystem<InMemoryBackend>` mounted at
+/// `/authorization` — the in-memory backend seam the lease store uses in tests.
+pub fn in_memory_backed_authorization_filesystem() -> Arc<ScopedFilesystem<InMemoryBackend>> {
+    let mounts = MountView::new(vec![MountGrant::new(
+        MountAlias::new("/authorization").expect("static valid mount alias"), // safety: test-support scaffolding, static literal
+        VirtualPath::new("/engine/authorization").expect("static valid virtual path"), // safety: test-support scaffolding, static literal
+        MountPermissions::read_write_list_delete(),
+    )])
+    .expect("static valid authorization mount view"); // safety: test-support scaffolding, static literal
+    Arc::new(ScopedFilesystem::with_fixed_view(
+        Arc::new(InMemoryBackend::new()),
+        mounts,
+    ))
+}
+
+/// The production capability-lease store over a fresh in-memory backend — the
+/// drop-in replacement for the deleted `InMemoryCapabilityLeaseStore`.
+pub fn in_memory_backed_capability_lease_store() -> FilesystemCapabilityLeaseStore<InMemoryBackend>
+{
+    FilesystemCapabilityLeaseStore::new(in_memory_backed_authorization_filesystem())
+}

--- a/crates/ironclaw_authorization/tests/capability_lease_contract.rs
+++ b/crates/ironclaw_authorization/tests/capability_lease_contract.rs
@@ -13,9 +13,23 @@ use ironclaw_filesystem::{
 use ironclaw_host_api::*;
 use ironclaw_trust::{AuthorityCeiling, EffectiveTrustClass, TrustDecision, TrustProvenance};
 
+/// The production `FilesystemCapabilityLeaseStore` over a fresh in-memory backend
+/// — the drop-in for the deleted `InMemoryCapabilityLeaseStore`
+/// (arch-simplification §4.3): "in-memory" is a filesystem backend, not a bespoke
+/// store. The fixed `/authorization` mount resolves every op to one subtree
+/// regardless of scope, which matches these single-scope state-machine tests;
+/// cross-scope *store visibility* isolation is exercised separately by the
+/// `filesystem_capability_lease_store_isolates_*` tests, which mount per user.
+fn in_memory_lease_store() -> FilesystemCapabilityLeaseStore<InMemoryBackend> {
+    FilesystemCapabilityLeaseStore::new(build_scoped_fs(
+        Arc::new(InMemoryBackend::new()),
+        "/engine/tenants/test/users/test/authorization",
+    ))
+}
+
 #[tokio::test]
 async fn lease_authorizer_allows_matching_active_lease_without_context_grant() {
-    let leases = InMemoryCapabilityLeaseStore::new();
+    let leases = in_memory_lease_store();
     let context = execution_context(CapabilitySet::default());
     let descriptor = descriptor(CapabilityId::new("echo.say").unwrap());
 
@@ -46,7 +60,7 @@ async fn lease_authorizer_allows_matching_active_lease_without_context_grant() {
 
 #[tokio::test]
 async fn lease_backed_authorizer_with_trust_denies_when_authority_ceiling_excludes_effect() {
-    let leases = InMemoryCapabilityLeaseStore::new();
+    let leases = in_memory_lease_store();
     let context = execution_context(CapabilitySet::default());
     let capability = CapabilityId::new("echo.say").unwrap();
     let mut descriptor = descriptor(capability.clone());
@@ -79,7 +93,7 @@ async fn lease_backed_authorizer_with_trust_denies_when_authority_ceiling_exclud
 
 #[tokio::test]
 async fn fingerprinted_approval_lease_does_not_authorize_plain_dispatch() {
-    let leases = InMemoryCapabilityLeaseStore::new();
+    let leases = in_memory_lease_store();
     let context = execution_context(CapabilitySet::default());
     let descriptor = descriptor(CapabilityId::new("echo.say").unwrap());
     let fingerprint = InvocationFingerprint::for_dispatch(
@@ -115,7 +129,7 @@ async fn fingerprinted_approval_lease_does_not_authorize_plain_dispatch() {
 
 #[tokio::test]
 async fn claim_marks_fingerprinted_lease_claimed_and_hides_it_from_authorizer() {
-    let leases = InMemoryCapabilityLeaseStore::new();
+    let leases = in_memory_lease_store();
     let context = execution_context(CapabilitySet::default());
     let descriptor = descriptor(CapabilityId::new("echo.say").unwrap());
     let fingerprint = InvocationFingerprint::for_dispatch(
@@ -157,7 +171,7 @@ async fn claim_marks_fingerprinted_lease_claimed_and_hides_it_from_authorizer() 
 
 #[tokio::test]
 async fn claim_rejects_fingerprint_mismatch_without_mutating_lease() {
-    let leases = InMemoryCapabilityLeaseStore::new();
+    let leases = in_memory_lease_store();
     let context = execution_context(CapabilitySet::default());
     let descriptor = descriptor(CapabilityId::new("echo.say").unwrap());
     let fingerprint = InvocationFingerprint::for_dispatch(
@@ -207,7 +221,7 @@ async fn claim_rejects_fingerprint_mismatch_without_mutating_lease() {
 
 #[tokio::test]
 async fn lease_authorizer_hides_leases_across_tenant_scope() {
-    let leases = InMemoryCapabilityLeaseStore::new();
+    let leases = in_memory_lease_store();
     let context = execution_context(CapabilitySet::default());
     let other_scope = ResourceScope {
         tenant_id: TenantId::new("tenant2").unwrap(),
@@ -247,7 +261,7 @@ async fn lease_authorizer_hides_leases_across_tenant_scope() {
 
 #[tokio::test]
 async fn lease_store_hides_leases_across_agent_scope() {
-    let leases = InMemoryCapabilityLeaseStore::new();
+    let leases = in_memory_lease_store();
     let mut context = execution_context(CapabilitySet::default());
     context.agent_id = Some(AgentId::new("agent-a").unwrap());
     context.resource_scope.agent_id = context.agent_id.clone();
@@ -275,7 +289,7 @@ async fn lease_store_hides_leases_across_agent_scope() {
 
 #[tokio::test]
 async fn lease_store_hides_leases_across_project_scope() {
-    let leases = InMemoryCapabilityLeaseStore::new();
+    let leases = in_memory_lease_store();
     let context = execution_context(CapabilitySet::default());
     let mut other_scope = context.resource_scope.clone();
     other_scope.project_id = Some(ProjectId::new("project2").unwrap());
@@ -301,7 +315,7 @@ async fn lease_store_hides_leases_across_project_scope() {
 
 #[tokio::test]
 async fn lease_authorizer_denies_other_agent_context() {
-    let leases = InMemoryCapabilityLeaseStore::new();
+    let leases = in_memory_lease_store();
     let mut context = execution_context(CapabilitySet::default());
     context.agent_id = Some(AgentId::new("agent-a").unwrap());
     context.resource_scope.agent_id = context.agent_id.clone();
@@ -337,7 +351,22 @@ async fn lease_authorizer_denies_other_agent_context() {
 
 #[tokio::test]
 async fn revocation_is_scoped_to_tenant_and_user() {
-    let leases = InMemoryCapabilityLeaseStore::new();
+    // Tenant scoping of `revoke` is now structural: each tenant resolves to a
+    // distinct `/authorization` mount subtree (arch-simplification §4.3 — the
+    // store no longer hand-keys by the full scope tuple). Model that with two
+    // per-tenant-mounted stores over one shared backend, exactly as
+    // `filesystem_capability_lease_store_isolates_two_tenants_*` does: a revoke
+    // issued against tenant2's mount cannot reach a lease issued under tenant1.
+    let backend = Arc::new(InMemoryBackend::new());
+    let store_tenant1 = FilesystemCapabilityLeaseStore::new(build_scoped_fs(
+        Arc::clone(&backend),
+        "/engine/tenants/tenant1/users/test/authorization",
+    ));
+    let store_tenant2 = FilesystemCapabilityLeaseStore::new(build_scoped_fs(
+        Arc::clone(&backend),
+        "/engine/tenants/tenant2/users/test/authorization",
+    ));
+
     let context = execution_context(CapabilitySet::default());
     let other_scope = ResourceScope {
         tenant_id: TenantId::new("tenant2").unwrap(),
@@ -358,16 +387,19 @@ async fn revocation_is_scoped_to_tenant_and_user() {
         ),
     );
     let lease_id = lease.grant.id;
-    leases.issue(lease.clone()).await.unwrap();
+    store_tenant1.issue(lease.clone()).await.unwrap();
 
-    let err = leases.revoke(&other_scope, lease_id).await.unwrap_err();
+    let err = store_tenant2
+        .revoke(&other_scope, lease_id)
+        .await
+        .unwrap_err();
 
     assert!(matches!(
         err,
         CapabilityLeaseError::UnknownLease { lease_id: id } if id == lease_id
     ));
     assert_eq!(
-        leases
+        store_tenant1
             .get(&context.resource_scope, lease_id)
             .await
             .unwrap()
@@ -378,7 +410,7 @@ async fn revocation_is_scoped_to_tenant_and_user() {
 
 #[tokio::test]
 async fn lease_authorizer_denies_invalid_context_before_grant_match() {
-    let leases = InMemoryCapabilityLeaseStore::new();
+    let leases = in_memory_lease_store();
     let mut context = execution_context(CapabilitySet::default());
     context.tenant_id = TenantId::new("tenant2").unwrap();
     let descriptor = descriptor(CapabilityId::new("echo.say").unwrap());
@@ -409,7 +441,7 @@ async fn lease_authorizer_denies_invalid_context_before_grant_match() {
 
 #[tokio::test]
 async fn one_off_lease_does_not_authorize_different_invocation_in_same_tenant() {
-    let leases = InMemoryCapabilityLeaseStore::new();
+    let leases = in_memory_lease_store();
     let context = execution_context(CapabilitySet::default());
     let mut next_invocation_context = execution_context(CapabilitySet::default());
     next_invocation_context.tenant_id = context.tenant_id.clone();
@@ -448,7 +480,7 @@ async fn one_off_lease_does_not_authorize_different_invocation_in_same_tenant() 
 
 #[tokio::test]
 async fn consume_decrements_remaining_invocations_and_consumes_one_shot_lease() {
-    let leases = InMemoryCapabilityLeaseStore::new();
+    let leases = in_memory_lease_store();
     let context = execution_context(CapabilitySet::default());
     let descriptor = descriptor(CapabilityId::new("echo.say").unwrap());
     let mut grant = grant_for(
@@ -484,7 +516,7 @@ async fn consume_decrements_remaining_invocations_and_consumes_one_shot_lease() 
 
 #[tokio::test]
 async fn consumed_lease_no_longer_authorizes_dispatch() {
-    let leases = InMemoryCapabilityLeaseStore::new();
+    let leases = in_memory_lease_store();
     let context = execution_context(CapabilitySet::default());
     let descriptor = descriptor(CapabilityId::new("echo.say").unwrap());
     let mut grant = grant_for(
@@ -516,7 +548,7 @@ async fn consumed_lease_no_longer_authorizes_dispatch() {
 
 #[tokio::test]
 async fn fingerprinted_lease_cannot_be_consumed_before_claim() {
-    let leases = InMemoryCapabilityLeaseStore::new();
+    let leases = in_memory_lease_store();
     let context = execution_context(CapabilitySet::default());
     let descriptor = descriptor(CapabilityId::new("echo.say").unwrap());
     let fingerprint = InvocationFingerprint::for_dispatch(
@@ -559,7 +591,7 @@ async fn fingerprinted_lease_cannot_be_consumed_before_claim() {
 
 #[tokio::test]
 async fn fingerprinted_lease_without_invocation_limit_is_consumed_after_one_use() {
-    let leases = InMemoryCapabilityLeaseStore::new();
+    let leases = in_memory_lease_store();
     let context = execution_context(CapabilitySet::default());
     let descriptor = descriptor(CapabilityId::new("echo.say").unwrap());
     let fingerprint = InvocationFingerprint::for_dispatch(
@@ -603,7 +635,7 @@ async fn fingerprinted_lease_without_invocation_limit_is_consumed_after_one_use(
 
 #[tokio::test]
 async fn expired_lease_no_longer_authorizes_or_consumes() {
-    let leases = InMemoryCapabilityLeaseStore::new();
+    let leases = in_memory_lease_store();
     let context = execution_context(CapabilitySet::default());
     let descriptor = descriptor(CapabilityId::new("echo.say").unwrap());
     let mut grant = grant_for(
@@ -635,7 +667,7 @@ async fn expired_lease_no_longer_authorizes_or_consumes() {
 
 #[tokio::test]
 async fn consume_is_scoped_to_exact_invocation() {
-    let leases = InMemoryCapabilityLeaseStore::new();
+    let leases = in_memory_lease_store();
     let context = execution_context(CapabilitySet::default());
     let mut next_invocation_scope = execution_context(CapabilitySet::default()).resource_scope;
     next_invocation_scope.tenant_id = context.resource_scope.tenant_id.clone();
@@ -1100,7 +1132,7 @@ async fn filesystem_capability_lease_store_writes_tenant_id_indexed_projection()
 
 #[tokio::test]
 async fn revoked_lease_no_longer_authorizes_dispatch() {
-    let leases = InMemoryCapabilityLeaseStore::new();
+    let leases = in_memory_lease_store();
     let context = execution_context(CapabilitySet::default());
     let descriptor = descriptor(CapabilityId::new("echo.say").unwrap());
     let lease = CapabilityLease::new(

--- a/crates/ironclaw_capabilities/Cargo.toml
+++ b/crates/ironclaw_capabilities/Cargo.toml
@@ -23,6 +23,8 @@ tracing = "0.1"
 [dev-dependencies]
 chrono = "0.4"
 ironclaw_approvals = { path = "../ironclaw_approvals" }
+# Enables the in-memory-backed capability-lease store constructor for tests only.
+ironclaw_authorization = { path = "../ironclaw_authorization", features = ["test-support"] }
 ironclaw_dispatcher = { path = "../ironclaw_dispatcher" }
 ironclaw_events = { path = "../ironclaw_events" }
 ironclaw_filesystem = { path = "../ironclaw_filesystem" }

--- a/crates/ironclaw_capabilities/tests/capability_host_auth_resume_contract.rs
+++ b/crates/ironclaw_capabilities/tests/capability_host_auth_resume_contract.rs
@@ -1,3 +1,4 @@
+// arch-exempt: large_file, mechanical lease-store test repoint to FilesystemCapabilityLeaseStore<InMemoryBackend> helper (arch-simplification §4.3), no new test logic, plan #6168
 // Contract tests for `CapabilityHost::auth_resume_json`.
 //
 // Covers: lease survival across auth-gate re-dispatch, concurrent-claim race
@@ -7,6 +8,7 @@
 use ironclaw_approvals::*;
 use ironclaw_authorization::*;
 use ironclaw_capabilities::*;
+use ironclaw_filesystem::InMemoryBackend;
 use ironclaw_host_api::*;
 use ironclaw_run_state::*;
 use serde_json::json;
@@ -293,7 +295,7 @@ async fn auth_resume_json_rejects_fingerprint_mismatch_on_approval_request() {
     let dispatcher = RecordingDispatcher::default();
     let run_state = InMemoryRunStateStore::new();
     let approval_requests = InMemoryApprovalRequestStore::new();
-    let leases = InMemoryCapabilityLeaseStore::new();
+    let leases = in_memory_backed_capability_lease_store();
 
     // Phase 1: invoke (needs approval).
     let block_host = CapabilityHost::new(&registry, &dispatcher, &ApprovalAuthorizer)
@@ -389,7 +391,7 @@ async fn auth_resume_json_with_approval_request_id_claims_active_lease_and_dispa
     let dispatcher = RecordingDispatcher::default();
     let run_state = InMemoryRunStateStore::new();
     let approval_requests = InMemoryApprovalRequestStore::new();
-    let leases = InMemoryCapabilityLeaseStore::new();
+    let leases = in_memory_backed_capability_lease_store();
 
     // Phase 1: first invocation triggers approval.
     let block_host = CapabilityHost::new(&registry, &dispatcher, &ApprovalAuthorizer)
@@ -564,7 +566,7 @@ async fn auth_resume_json_rejects_approval_not_yet_approved() {
     let dispatcher = RecordingDispatcher::default();
     let run_state = InMemoryRunStateStore::new();
     let approval_requests = InMemoryApprovalRequestStore::new();
-    let leases = InMemoryCapabilityLeaseStore::new();
+    let leases = in_memory_backed_capability_lease_store();
 
     // Start and block at auth.
     let context = execution_context(CapabilitySet {
@@ -838,7 +840,7 @@ async fn auth_resume_after_real_approval_bounce_reuses_claimed_lease() {
     let dispatcher = FirstCallAuthRequiredDispatcher::default();
     let run_state = InMemoryRunStateStore::new();
     let approval_requests = InMemoryApprovalRequestStore::new();
-    let leases = InMemoryCapabilityLeaseStore::new();
+    let leases = in_memory_backed_capability_lease_store();
 
     // ── Phase 1: invoke_json → BlockedApproval ──────────────────────────────
     let block_host = CapabilityHost::new(&registry, &dispatcher, &ApprovalAuthorizer)
@@ -1075,7 +1077,7 @@ async fn auth_resume_json_terminal_dispatch_failure_revokes_claimed_lease() {
     let dispatcher = TerminalFailDispatcher::default();
     let run_state = InMemoryRunStateStore::new();
     let approval_requests = InMemoryApprovalRequestStore::new();
-    let leases = InMemoryCapabilityLeaseStore::new();
+    let leases = in_memory_backed_capability_lease_store();
 
     // Phase 1: invoke → BlockedApproval.
     let block_host = CapabilityHost::new(&registry, &dispatcher, &ApprovalAuthorizer)
@@ -1216,7 +1218,7 @@ async fn auth_resume_json_non_terminal_auth_bounce_leaves_lease_claimed() {
     let dispatcher = AlwaysAuthRequiredDispatcher;
     let run_state = InMemoryRunStateStore::new();
     let approval_requests = InMemoryApprovalRequestStore::new();
-    let leases = InMemoryCapabilityLeaseStore::new();
+    let leases = in_memory_backed_capability_lease_store();
 
     // Phase 1: invoke → BlockedApproval.
     let block_host = CapabilityHost::new(&registry, &dispatcher, &ApprovalAuthorizer)
@@ -1341,18 +1343,18 @@ async fn concurrent_auth_resume_claim_loser_returns_lease_error_without_failing_
     use async_trait::async_trait;
     use std::sync::atomic::{AtomicBool, Ordering};
 
-    // A lease store that delegates everything to an inner InMemoryCapabilityLeaseStore
+    // A lease store that delegates everything to an inner FilesystemCapabilityLeaseStore<InMemoryBackend>
     // except `claim()`, which returns InactiveLease { status: Claimed } once the
     // `fail_next_claim` flag is set — simulating the loser of a concurrent claim race.
     struct ClaimFailingLeaseStore {
-        inner: InMemoryCapabilityLeaseStore,
+        inner: FilesystemCapabilityLeaseStore<InMemoryBackend>,
         fail_next_claim: AtomicBool,
     }
 
     impl ClaimFailingLeaseStore {
         fn new() -> Self {
             Self {
-                inner: InMemoryCapabilityLeaseStore::new(),
+                inner: in_memory_backed_capability_lease_store(),
                 fail_next_claim: AtomicBool::new(false),
             }
         }
@@ -1645,7 +1647,7 @@ async fn auth_resume_json_rejected_prior_approval_fails_blocked_auth_run() {
     let dispatcher = RecordingDispatcher::default();
     let run_state = InMemoryRunStateStore::new();
     let approval_requests = InMemoryApprovalRequestStore::new();
-    let leases = InMemoryCapabilityLeaseStore::new();
+    let leases = in_memory_backed_capability_lease_store();
 
     // Start and block at auth.
     let context = execution_context(CapabilitySet {
@@ -1783,7 +1785,7 @@ async fn concurrent_auth_resume_reuse_loser_does_not_double_dispatch() {
     use tokio::sync::{Barrier, Notify};
 
     // ── Barrier lease store ──────────────────────────────────────────────────
-    // Wraps InMemoryCapabilityLeaseStore and inserts a Barrier(2) inside
+    // Wraps FilesystemCapabilityLeaseStore<InMemoryBackend> and inserts a Barrier(2) inside
     // `leases_for_scope`.  Both concurrent callers block at the barrier
     // inside the helper scan, then both are released together.  This
     // guarantees both see the Claimed lease before either calls
@@ -1791,7 +1793,7 @@ async fn concurrent_auth_resume_reuse_loser_does_not_double_dispatch() {
     // machine transition: one wins (Claimed→Dispatching), the other loses
     // (sees Dispatching → InactiveLease{Dispatching}).
     struct BarrierLeaseStore {
-        inner: InMemoryCapabilityLeaseStore,
+        inner: FilesystemCapabilityLeaseStore<InMemoryBackend>,
         /// Both concurrent auth_resume_json callers rendezvous here after
         /// `leases_for_scope` returns so they race on `begin_dispatch_claimed`.
         scan_barrier: StdArc<Barrier>,
@@ -1804,7 +1806,7 @@ async fn concurrent_auth_resume_reuse_loser_does_not_double_dispatch() {
     impl BarrierLeaseStore {
         fn new(barrier: StdArc<Barrier>) -> Self {
             Self {
-                inner: InMemoryCapabilityLeaseStore::new(),
+                inner: in_memory_backed_capability_lease_store(),
                 scan_barrier: barrier,
                 barrier_armed: std::sync::atomic::AtomicBool::new(false),
             }
@@ -2213,7 +2215,7 @@ async fn auth_resume_json_authorization_deny_revokes_dispatching_lease() {
     let registry = registry_with_echo_capability();
     let run_state = InMemoryRunStateStore::new();
     let approval_requests = InMemoryApprovalRequestStore::new();
-    let leases = InMemoryCapabilityLeaseStore::new();
+    let leases = in_memory_backed_capability_lease_store();
 
     // ── Phase 1: invoke → BlockedApproval ──────────────────────────────────
     let block_dispatcher = AuthRequiredOnFirstCall;
@@ -2367,7 +2369,7 @@ async fn auth_resume_json_authorization_require_approval_revokes_dispatching_lea
     let registry = registry_with_echo_capability();
     let run_state = InMemoryRunStateStore::new();
     let approval_requests = InMemoryApprovalRequestStore::new();
-    let leases = InMemoryCapabilityLeaseStore::new();
+    let leases = in_memory_backed_capability_lease_store();
 
     // ── Phase 1: invoke → BlockedApproval ──────────────────────────────────
     let block_host = CapabilityHost::new(&registry, &AlwaysAuthRequired, &ApprovalAuthorizer)
@@ -2611,7 +2613,7 @@ async fn auth_resume_json_unknown_invocation_when_run_record_missing() {
 async fn setup_blocked_auth_run_with_stores(
     run_state: &InMemoryRunStateStore,
     approval_requests: &InMemoryApprovalRequestStore,
-    leases: &InMemoryCapabilityLeaseStore,
+    leases: &FilesystemCapabilityLeaseStore<InMemoryBackend>,
     context: &ExecutionContext,
 ) {
     let scope = &context.resource_scope;
@@ -2641,7 +2643,7 @@ async fn auth_resume_json_approval_request_mismatch_action() {
     let dispatcher = RecordingDispatcher::default();
     let run_state = InMemoryRunStateStore::new();
     let approval_requests = InMemoryApprovalRequestStore::new();
-    let leases = InMemoryCapabilityLeaseStore::new();
+    let leases = in_memory_backed_capability_lease_store();
 
     let context = execution_context(CapabilitySet {
         grants: vec![dispatch_grant()],
@@ -2725,7 +2727,7 @@ async fn auth_resume_json_approval_request_mismatch_correlation_id() {
     let dispatcher = RecordingDispatcher::default();
     let run_state = InMemoryRunStateStore::new();
     let approval_requests = InMemoryApprovalRequestStore::new();
-    let leases = InMemoryCapabilityLeaseStore::new();
+    let leases = in_memory_backed_capability_lease_store();
 
     let context = execution_context(CapabilitySet {
         grants: vec![dispatch_grant()],
@@ -2815,7 +2817,7 @@ async fn auth_resume_json_approval_request_mismatch_requested_by() {
     let dispatcher = RecordingDispatcher::default();
     let run_state = InMemoryRunStateStore::new();
     let approval_requests = InMemoryApprovalRequestStore::new();
-    let leases = InMemoryCapabilityLeaseStore::new();
+    let leases = in_memory_backed_capability_lease_store();
 
     let context = execution_context(CapabilitySet {
         grants: vec![dispatch_grant()],
@@ -2944,7 +2946,7 @@ async fn concurrent_auth_resume_fresh_active_lease_loser_does_not_double_dispatc
     // caller that runs `matching_approval_lease` during this window finds None
     // (lease is Claimed, not Active) and falls into the REUSE branch.
     struct GatedLeaseStore {
-        inner: InMemoryCapabilityLeaseStore,
+        inner: FilesystemCapabilityLeaseStore<InMemoryBackend>,
         claim_entered: StdArc<Notify>,
         claim_release: StdArc<Notify>,
         armed: std::sync::atomic::AtomicBool,
@@ -2953,7 +2955,7 @@ async fn concurrent_auth_resume_fresh_active_lease_loser_does_not_double_dispatc
     impl GatedLeaseStore {
         fn new(claim_entered: StdArc<Notify>, claim_release: StdArc<Notify>) -> Self {
             Self {
-                inner: InMemoryCapabilityLeaseStore::new(),
+                inner: in_memory_backed_capability_lease_store(),
                 claim_entered,
                 claim_release,
                 armed: std::sync::atomic::AtomicBool::new(false),
@@ -3263,7 +3265,7 @@ async fn auth_resume_json_unknown_capability_does_not_strand_active_approval_lea
     let dispatcher = RecordingDispatcher::default();
     let run_state = InMemoryRunStateStore::new();
     let approval_requests = InMemoryApprovalRequestStore::new();
-    let leases = InMemoryCapabilityLeaseStore::new();
+    let leases = in_memory_backed_capability_lease_store();
 
     // Seed the run in BlockedAuth state (as it would be after a prior auth gate).
     let context = execution_context(CapabilitySet {
@@ -3397,7 +3399,7 @@ async fn auth_resume_json_unknown_capability_does_not_strand_claimed_approval_le
     let dispatcher = RecordingDispatcher::default();
     let run_state = InMemoryRunStateStore::new();
     let approval_requests = InMemoryApprovalRequestStore::new();
-    let leases = InMemoryCapabilityLeaseStore::new();
+    let leases = in_memory_backed_capability_lease_store();
 
     let context = execution_context(CapabilitySet {
         grants: vec![dispatch_grant()],

--- a/crates/ironclaw_capabilities/tests/capability_host_dispatcher_integration.rs
+++ b/crates/ironclaw_capabilities/tests/capability_host_dispatcher_integration.rs
@@ -9,7 +9,7 @@ use ironclaw_dispatcher::{
     RuntimeAdapter, RuntimeAdapterRequest, RuntimeAdapterResult, RuntimeDispatcher,
 };
 use ironclaw_events::{InMemoryEventSink, RuntimeEventKind};
-use ironclaw_filesystem::LocalFilesystem;
+use ironclaw_filesystem::{InMemoryBackend, LocalFilesystem};
 use ironclaw_host_api::*;
 use ironclaw_resources::*;
 use ironclaw_run_state::*;
@@ -90,7 +90,7 @@ async fn capability_host_blocks_then_resumes_approved_dispatch_through_runtime_d
     let (registry, dispatcher, _governor, events) = runtime_dispatcher_stack(Arc::clone(&adapter));
     let run_state = InMemoryRunStateStore::new();
     let approval_requests = InMemoryApprovalRequestStore::new();
-    let leases = InMemoryCapabilityLeaseStore::new();
+    let leases = in_memory_backed_capability_lease_store();
     let block_host = CapabilityHost::new(registry.as_ref(), &dispatcher, &ApprovalAuthorizer)
         .with_run_state(&run_state)
         .with_approval_requests(&approval_requests);
@@ -195,7 +195,7 @@ async fn capability_host_rejects_resume_from_wrong_user_scope_without_dispatch_o
     let (registry, dispatcher, _governor, _events) = runtime_dispatcher_stack(Arc::clone(&adapter));
     let run_state = InMemoryRunStateStore::new();
     let approval_requests = InMemoryApprovalRequestStore::new();
-    let leases = InMemoryCapabilityLeaseStore::new();
+    let leases = in_memory_backed_capability_lease_store();
     let block_host = CapabilityHost::new(registry.as_ref(), &dispatcher, &ApprovalAuthorizer)
         .with_run_state(&run_state)
         .with_approval_requests(&approval_requests);
@@ -257,12 +257,16 @@ async fn capability_host_rejects_resume_from_wrong_user_scope_without_dispatch_o
             .unwrap()
             .is_none()
     );
-    assert!(
-        leases
-            .get(&wrong_context.resource_scope, lease.grant.id)
-            .await
-            .is_none()
-    );
+    // Cross-user *store visibility* isolation is now structural: the production
+    // `FilesystemCapabilityLeaseStore` scopes each user to a distinct subtree via
+    // its per-invocation `MountView`, proven by
+    // `ironclaw_authorization`'s `filesystem_capability_lease_store_isolates_two_tenants_*`
+    // contract test. This integration fixture shares one non-per-user in-memory
+    // mount, so it can't reproduce that mount-level partition here — but the
+    // guarantee this test owns (a wrong-scope resume dispatches nothing and
+    // claims nothing) is asserted directly: `RunStateError::UnknownInvocation`
+    // above, zero adapter requests, and the original lease still `Active`
+    // (unclaimed) below.
     assert_eq!(
         leases.get(&scope, lease.grant.id).await.unwrap().status,
         CapabilityLeaseStatus::Active
@@ -277,7 +281,7 @@ async fn capability_host_rejects_expired_approval_lease_before_dispatch() {
     let (registry, dispatcher, _governor, _events) = runtime_dispatcher_stack(Arc::clone(&adapter));
     let run_state = InMemoryRunStateStore::new();
     let approval_requests = InMemoryApprovalRequestStore::new();
-    let leases = InMemoryCapabilityLeaseStore::new();
+    let leases = in_memory_backed_capability_lease_store();
     let block_host = CapabilityHost::new(registry.as_ref(), &dispatcher, &ApprovalAuthorizer)
         .with_run_state(&run_state)
         .with_approval_requests(&approval_requests);
@@ -443,7 +447,7 @@ fn runtime_dispatcher_stack(
 
 async fn approve_dispatch(
     approval_requests: &InMemoryApprovalRequestStore,
-    leases: &InMemoryCapabilityLeaseStore,
+    leases: &FilesystemCapabilityLeaseStore<InMemoryBackend>,
     scope: &ResourceScope,
     approval_id: ApprovalRequestId,
     expires_at: Option<Timestamp>,

--- a/crates/ironclaw_capabilities/tests/capability_host_github_comment_approval_contract.rs
+++ b/crates/ironclaw_capabilities/tests/capability_host_github_comment_approval_contract.rs
@@ -2,6 +2,7 @@ use async_trait::async_trait;
 use ironclaw_approvals::*;
 use ironclaw_authorization::*;
 use ironclaw_capabilities::*;
+use ironclaw_filesystem::InMemoryBackend;
 use ironclaw_host_api::*;
 use ironclaw_run_state::*;
 use serde_json::json;
@@ -141,7 +142,7 @@ struct GitHubCommentApprovalFixture {
     dispatcher: RecordingDispatcher,
     run_state: InMemoryRunStateStore,
     approval_requests: InMemoryApprovalRequestStore,
-    leases: InMemoryCapabilityLeaseStore,
+    leases: FilesystemCapabilityLeaseStore<InMemoryBackend>,
     context: ExecutionContext,
     scope: ResourceScope,
     invocation_id: InvocationId,
@@ -156,7 +157,7 @@ async fn blocked_github_comment_fixture() -> GitHubCommentApprovalFixture {
     let dispatcher = RecordingDispatcher::default();
     let run_state = InMemoryRunStateStore::new();
     let approval_requests = InMemoryApprovalRequestStore::new();
-    let leases = InMemoryCapabilityLeaseStore::new();
+    let leases = in_memory_backed_capability_lease_store();
     let block_host = CapabilityHost::new(&registry, &dispatcher, &ApprovalAuthorizer)
         .with_run_state(&run_state)
         .with_approval_requests(&approval_requests);

--- a/crates/ironclaw_capabilities/tests/capability_host_run_state_contract.rs
+++ b/crates/ironclaw_capabilities/tests/capability_host_run_state_contract.rs
@@ -1,3 +1,4 @@
+// arch-exempt: large_file, mechanical lease-store test repoint to FilesystemCapabilityLeaseStore<InMemoryBackend> helper (arch-simplification §4.3), no new test logic, plan #6168
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -7,6 +8,7 @@ use ironclaw_approvals::*;
 use ironclaw_authorization::*;
 use ironclaw_capabilities::*;
 use ironclaw_extensions::{ExtensionManifest, ExtensionPackage, ExtensionRegistry, ManifestSource};
+use ironclaw_filesystem::InMemoryBackend;
 use ironclaw_host_api::*;
 use ironclaw_run_state::*;
 use serde_json::json;
@@ -256,7 +258,7 @@ async fn capability_host_leaves_run_blocked_when_resume_is_attempted_before_appr
     let dispatcher = RecordingDispatcher::default();
     let run_state = InMemoryRunStateStore::new();
     let approval_requests = InMemoryApprovalRequestStore::new();
-    let leases = InMemoryCapabilityLeaseStore::new();
+    let leases = in_memory_backed_capability_lease_store();
     let block_host = CapabilityHost::new(&registry, &dispatcher, &ApprovalAuthorizer)
         .with_run_state(&run_state)
         .with_approval_requests(&approval_requests);
@@ -507,7 +509,7 @@ async fn capability_host_returns_resume_business_error_when_run_state_fail_trans
     let dispatcher = RecordingDispatcher::default();
     let run_state = FailOnFailRunStateStore::new();
     let approval_requests = InMemoryApprovalRequestStore::new();
-    let leases = InMemoryCapabilityLeaseStore::new();
+    let leases = in_memory_backed_capability_lease_store();
     let block_host = CapabilityHost::new(&registry, &dispatcher, &ApprovalAuthorizer)
         .with_run_state(&run_state)
         .with_approval_requests(&approval_requests);
@@ -691,7 +693,7 @@ async fn capability_host_resumes_approved_invocation_and_consumes_matching_lease
     let dispatcher = RecordingDispatcher::default();
     let run_state = InMemoryRunStateStore::new();
     let approval_requests = InMemoryApprovalRequestStore::new();
-    let leases = InMemoryCapabilityLeaseStore::new();
+    let leases = in_memory_backed_capability_lease_store();
     let block_host = CapabilityHost::new(&registry, &dispatcher, &ApprovalAuthorizer)
         .with_run_state(&run_state)
         .with_approval_requests(&approval_requests);
@@ -812,7 +814,7 @@ async fn capability_host_returns_dispatch_result_when_run_completion_fails_after
     let dispatcher = RecordingDispatcher::default();
     let run_state = FailCompleteRunStateStore::new();
     let approval_requests = InMemoryApprovalRequestStore::new();
-    let leases = InMemoryCapabilityLeaseStore::new();
+    let leases = in_memory_backed_capability_lease_store();
     let block_host = CapabilityHost::new(&registry, &dispatcher, &ApprovalAuthorizer)
         .with_run_state(&run_state)
         .with_approval_requests(&approval_requests);
@@ -885,7 +887,7 @@ async fn capability_host_denies_resume_when_trust_ceiling_omits_capability_effec
     let dispatcher = RecordingDispatcher::default();
     let run_state = InMemoryRunStateStore::new();
     let approval_requests = InMemoryApprovalRequestStore::new();
-    let leases = InMemoryCapabilityLeaseStore::new();
+    let leases = in_memory_backed_capability_lease_store();
     let block_host = CapabilityHost::new(&registry, &dispatcher, &ApprovalAuthorizer)
         .with_run_state(&run_state)
         .with_approval_requests(&approval_requests);
@@ -967,7 +969,7 @@ async fn capability_host_revokes_claimed_lease_when_dispatch_fails_after_resume(
     let dispatcher = FailingDispatcher;
     let run_state = InMemoryRunStateStore::new();
     let approval_requests = InMemoryApprovalRequestStore::new();
-    let leases = InMemoryCapabilityLeaseStore::new();
+    let leases = in_memory_backed_capability_lease_store();
     let block_dispatcher = RecordingDispatcher::default();
     let block_host = CapabilityHost::new(&registry, &block_dispatcher, &ApprovalAuthorizer)
         .with_run_state(&run_state)
@@ -1222,7 +1224,7 @@ async fn capability_host_rejects_resume_with_mismatched_capability_id() {
     let dispatcher = RecordingDispatcher::default();
     let run_state = InMemoryRunStateStore::new();
     let approval_requests = InMemoryApprovalRequestStore::new();
-    let leases = InMemoryCapabilityLeaseStore::new();
+    let leases = in_memory_backed_capability_lease_store();
     let block_host = CapabilityHost::new(&registry, &dispatcher, &ApprovalAuthorizer)
         .with_run_state(&run_state)
         .with_approval_requests(&approval_requests);
@@ -1289,7 +1291,7 @@ async fn capability_host_rejects_resume_with_mismatched_approval_request_id() {
     let dispatcher = RecordingDispatcher::default();
     let run_state = InMemoryRunStateStore::new();
     let approval_requests = InMemoryApprovalRequestStore::new();
-    let leases = InMemoryCapabilityLeaseStore::new();
+    let leases = in_memory_backed_capability_lease_store();
     let block_host = CapabilityHost::new(&registry, &dispatcher, &ApprovalAuthorizer)
         .with_run_state(&run_state)
         .with_approval_requests(&approval_requests);
@@ -1355,7 +1357,7 @@ async fn capability_host_rejects_resume_with_mutated_input_before_lease_claim_or
     let dispatcher = RecordingDispatcher::default();
     let run_state = InMemoryRunStateStore::new();
     let approval_requests = InMemoryApprovalRequestStore::new();
-    let leases = InMemoryCapabilityLeaseStore::new();
+    let leases = in_memory_backed_capability_lease_store();
     let block_host = CapabilityHost::new(&registry, &dispatcher, &ApprovalAuthorizer)
         .with_run_state(&run_state)
         .with_approval_requests(&approval_requests);
@@ -2104,7 +2106,7 @@ impl RunStateStore for FailOnFailRunStateStore {
 }
 
 struct CoordinatedClaimConflictLeaseStore {
-    inner: InMemoryCapabilityLeaseStore,
+    inner: FilesystemCapabilityLeaseStore<InMemoryBackend>,
     claim_calls: AtomicUsize,
     second_claim_started: tokio::sync::Notify,
     run_completed: Arc<tokio::sync::Notify>,
@@ -2113,7 +2115,7 @@ struct CoordinatedClaimConflictLeaseStore {
 impl CoordinatedClaimConflictLeaseStore {
     fn new(run_completed: Arc<tokio::sync::Notify>) -> Self {
         Self {
-            inner: InMemoryCapabilityLeaseStore::new(),
+            inner: in_memory_backed_capability_lease_store(),
             claim_calls: AtomicUsize::new(0),
             second_claim_started: tokio::sync::Notify::new(),
             run_completed,
@@ -2202,13 +2204,13 @@ impl CapabilityLeaseStore for CoordinatedClaimConflictLeaseStore {
 }
 
 struct ConsumeFailingLeaseStore {
-    inner: InMemoryCapabilityLeaseStore,
+    inner: FilesystemCapabilityLeaseStore<InMemoryBackend>,
 }
 
 impl ConsumeFailingLeaseStore {
     fn new() -> Self {
         Self {
-            inner: InMemoryCapabilityLeaseStore::new(),
+            inner: in_memory_backed_capability_lease_store(),
         }
     }
 }

--- a/crates/ironclaw_capabilities/tests/capability_host_spawn_contract.rs
+++ b/crates/ironclaw_capabilities/tests/capability_host_spawn_contract.rs
@@ -167,7 +167,7 @@ async fn capability_host_resumes_approved_spawn_and_consumes_matching_lease() {
     let process_manager = RecordingProcessManager::default();
     let run_state = InMemoryRunStateStore::new();
     let approval_requests = InMemoryApprovalRequestStore::new();
-    let leases = InMemoryCapabilityLeaseStore::new();
+    let leases = in_memory_backed_capability_lease_store();
     let block_host = CapabilityHost::new(&registry, &dispatcher, &SpawnApprovalAuthorizer)
         .with_process_manager(&process_manager)
         .with_run_state(&run_state)

--- a/crates/ironclaw_host_runtime/Cargo.toml
+++ b/crates/ironclaw_host_runtime/Cargo.toml
@@ -76,6 +76,8 @@ axum = { version = "0.8", features = ["json"] }
 hex = "0.4"
 # Enables the in-memory-backed approval store constructors for tests only.
 ironclaw_approvals = { path = "../ironclaw_approvals", features = ["test-support"] }
+# Enables the in-memory-backed capability-lease store constructor for tests only.
+ironclaw_authorization = { path = "../ironclaw_authorization", features = ["test-support"] }
 ironclaw_event_projections = { path = "../ironclaw_event_projections" }
 sha2 = "0.11"
 tempfile = "3"

--- a/crates/ironclaw_host_runtime/src/services.rs
+++ b/crates/ironclaw_host_runtime/src/services.rs
@@ -12,9 +12,7 @@ use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 use ironclaw_approvals::{ApprovalResolver, PersistentApprovalPolicyStore};
-use ironclaw_authorization::{
-    CapabilityLeaseStore, InMemoryCapabilityLeaseStore, TrustAwareCapabilityDispatchAuthorizer,
-};
+use ironclaw_authorization::{CapabilityLeaseStore, TrustAwareCapabilityDispatchAuthorizer};
 use ironclaw_capabilities::CapabilityObligationHandler;
 use ironclaw_dispatcher::{
     RuntimeAdapter, RuntimeAdapterRequest, RuntimeAdapterResult, RuntimeDispatcher,

--- a/crates/ironclaw_host_runtime/src/services/production_wiring.rs
+++ b/crates/ironclaw_host_runtime/src/services/production_wiring.rs
@@ -3,13 +3,13 @@ use std::any::{TypeId, type_name};
 use thiserror::Error;
 
 use ironclaw_approvals::FilesystemPersistentApprovalPolicyStore;
+use ironclaw_authorization::FilesystemCapabilityLeaseStore;
 use ironclaw_filesystem::InMemoryBackend;
 
 use super::{
     DurableAuditSink, DurableEventSink, EmptyWasmRuntimeCredentials, InMemoryApprovalRequestStore,
-    InMemoryAuditSink, InMemoryCapabilityLeaseStore, InMemoryCredentialBroker,
-    InMemoryDurableAuditLog, InMemoryDurableEventLog, InMemoryEventSink,
-    InMemoryProcessResultStore, InMemoryProcessStore, InMemoryResourceGovernor,
+    InMemoryAuditSink, InMemoryCredentialBroker, InMemoryDurableAuditLog, InMemoryDurableEventLog,
+    InMemoryEventSink, InMemoryProcessResultStore, InMemoryProcessStore, InMemoryResourceGovernor,
     InMemoryRunStateStore, InMemorySecretStore, InMemoryTurnStateStore, LocalFilesystem,
     LocalHostProcessPort, NoopTurnRunWakeNotifier, RebornEventStoreError, RuntimeKind,
 };
@@ -295,14 +295,14 @@ fn classify_component_type<T: ?Sized + 'static>() -> ProductionImplementationRea
             || type_id == TypeId::of::<InMemoryProcessResultStore>()
             || type_id == TypeId::of::<InMemoryRunStateStore>()
             || type_id == TypeId::of::<InMemoryApprovalRequestStore>()
-            || type_id == TypeId::of::<InMemoryCapabilityLeaseStore>()
-            // The persistent-approval store no longer has a bespoke in-memory
-            // implementation; "in-memory" is now the `InMemoryBackend` behind
-            // the one production `FilesystemPersistentApprovalPolicyStore<F>`
+            // The persistent-approval and capability-lease stores no longer have
+            // bespoke in-memory implementations; "in-memory" is now the
+            // `InMemoryBackend` behind the one production `Filesystem*Store<F>`
             // (arch-simplification §4.3). A store backed by `InMemoryBackend` is
             // still local-only; the durable libSQL/Postgres monomorphizations are
             // distinct types and correctly classify as production candidates.
             || type_id == TypeId::of::<FilesystemPersistentApprovalPolicyStore<InMemoryBackend>>()
+            || type_id == TypeId::of::<FilesystemCapabilityLeaseStore<InMemoryBackend>>()
             || type_id == TypeId::of::<InMemoryEventSink>()
             || type_id == TypeId::of::<InMemoryDurableEventLog>()
             || type_id == TypeId::of::<InMemoryAuditSink>()

--- a/crates/ironclaw_host_runtime/tests/host_runtime_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_contract.rs
@@ -1,3 +1,4 @@
+// arch-exempt: large_file, mechanical lease-store test repoint to FilesystemCapabilityLeaseStore<InMemoryBackend> helper (arch-simplification §4.3), no new test logic, plan #6168
 mod support;
 
 use support::legacy_capability_fixture_to_v2;
@@ -13,7 +14,8 @@ use std::{
 use async_trait::async_trait;
 use chrono::Utc;
 use ironclaw_authorization::{
-    GrantAuthorizer, InMemoryCapabilityLeaseStore, TrustAwareCapabilityDispatchAuthorizer,
+    GrantAuthorizer, TrustAwareCapabilityDispatchAuthorizer,
+    in_memory_backed_capability_lease_store,
 };
 use ironclaw_extensions::{
     ExtensionManifest, ExtensionPackage, ExtensionRegistry, ManifestSource, SharedExtensionRegistry,
@@ -116,7 +118,7 @@ async fn default_runtime_surfaces_approval_required_with_persisted_request_id() 
     let run_state = Arc::new(InMemoryRunStateStore::new());
     let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
     let leases: Arc<dyn ironclaw_authorization::CapabilityLeaseStore> =
-        Arc::new(InMemoryCapabilityLeaseStore::new());
+        Arc::new(in_memory_backed_capability_lease_store());
 
     let runtime = DefaultHostRuntime::new(
         registry,
@@ -161,7 +163,7 @@ async fn default_runtime_uses_combined_store_for_atomic_approval_block() {
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(ApprovalAuthorizer);
     let combined_store = Arc::new(RecordingCombinedRunStateApprovalStore::new());
     let leases: Arc<dyn ironclaw_authorization::CapabilityLeaseStore> =
-        Arc::new(InMemoryCapabilityLeaseStore::new());
+        Arc::new(in_memory_backed_capability_lease_store());
 
     let runtime = DefaultHostRuntime::new(
         registry,
@@ -230,7 +232,7 @@ async fn default_runtime_propagates_unavailable_when_run_state_lookup_fails_duri
     });
     let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
     let leases: Arc<dyn ironclaw_authorization::CapabilityLeaseStore> =
-        Arc::new(InMemoryCapabilityLeaseStore::new());
+        Arc::new(in_memory_backed_capability_lease_store());
 
     let runtime = DefaultHostRuntime::new(
         registry,

--- a/crates/ironclaw_host_runtime/tests/host_runtime_credential_preflight_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_credential_preflight_contract.rs
@@ -21,7 +21,7 @@ mod support;
 use std::sync::Arc;
 
 use chrono::Utc;
-use ironclaw_authorization::{GrantAuthorizer, InMemoryCapabilityLeaseStore};
+use ironclaw_authorization::{GrantAuthorizer, in_memory_backed_capability_lease_store};
 use ironclaw_extensions::{ExtensionManifest, ExtensionPackage, ExtensionRegistry, ManifestSource};
 use ironclaw_filesystem::LocalFilesystem;
 use ironclaw_host_api::*;
@@ -187,7 +187,7 @@ fn trust_decision_with_dispatch_authority() -> TrustDecision {
 async fn product_auth_account_credential_does_not_trip_preflight() {
     let run_state = Arc::new(InMemoryRunStateStore::new());
     let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
-    let capability_leases = Arc::new(InMemoryCapabilityLeaseStore::new());
+    let capability_leases = Arc::new(in_memory_backed_capability_lease_store());
     let secret_store = Arc::new(InMemorySecretStore::new());
     // Deliberately do NOT seed any secret under "google_oauth_token".
     // The secret store is empty. If the pre-flight incorrectly probes the
@@ -245,7 +245,7 @@ async fn product_auth_account_credential_does_not_trip_preflight() {
 async fn secret_handle_credential_absent_still_trips_preflight() {
     let run_state = Arc::new(InMemoryRunStateStore::new());
     let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
-    let capability_leases = Arc::new(InMemoryCapabilityLeaseStore::new());
+    let capability_leases = Arc::new(in_memory_backed_capability_lease_store());
     let secret_store = Arc::new(InMemorySecretStore::new());
     // No secret seeded — the SecretHandle pre-flight must fire.
 
@@ -305,7 +305,7 @@ async fn secret_handle_credential_absent_still_trips_preflight() {
 async fn tenant_shared_secret_satisfies_credential_preflight() {
     let run_state = Arc::new(InMemoryRunStateStore::new());
     let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
-    let capability_leases = Arc::new(InMemoryCapabilityLeaseStore::new());
+    let capability_leases = Arc::new(in_memory_backed_capability_lease_store());
     let secret_store = Arc::new(InMemorySecretStore::new());
 
     let services = HostRuntimeServices::new(

--- a/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
@@ -1,3 +1,4 @@
+// arch-exempt: large_file, mechanical lease-store test repoint to FilesystemCapabilityLeaseStore<InMemoryBackend> helper (arch-simplification §4.3), no new test logic, plan #6168
 mod support;
 
 use support::host_runtime_harness::*;
@@ -13,8 +14,8 @@ use std::{
 use chrono::{Duration as ChronoDuration, Utc};
 use ironclaw_approvals::LeaseApproval;
 use ironclaw_authorization::{
-    CapabilityLeaseStatus, CapabilityLeaseStore, GrantAuthorizer, InMemoryCapabilityLeaseStore,
-    TrustAwareCapabilityDispatchAuthorizer,
+    CapabilityLeaseStatus, CapabilityLeaseStore, GrantAuthorizer,
+    TrustAwareCapabilityDispatchAuthorizer, in_memory_backed_capability_lease_store,
 };
 use ironclaw_capabilities::{CapabilityHost, CapabilitySpawnRequest};
 use ironclaw_event_projections::{
@@ -1383,7 +1384,7 @@ async fn host_runtime_services_builds_dispatcher_runtime_and_health_from_registe
     let process_services = ProcessServices::in_memory();
     let run_state = Arc::new(InMemoryRunStateStore::new());
     let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
-    let capability_leases = Arc::new(InMemoryCapabilityLeaseStore::new());
+    let capability_leases = Arc::new(in_memory_backed_capability_lease_store());
     let events = InMemoryEventSink::new();
     let script_runtime = Arc::new(ScriptRuntime::new(
         ScriptRuntimeConfig::for_testing(),
@@ -2044,7 +2045,7 @@ async fn host_runtime_services_jsonl_event_store_projects_same_runtime_sequence_
 async fn host_runtime_services_approval_resolution_projects_durable_audit_metadata_only() {
     let run_state = Arc::new(InMemoryRunStateStore::new());
     let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
-    let capability_leases = Arc::new(InMemoryCapabilityLeaseStore::new());
+    let capability_leases = Arc::new(in_memory_backed_capability_lease_store());
     let audit_log = Arc::new(InMemoryDurableAuditLog::new());
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
@@ -2153,7 +2154,7 @@ async fn host_runtime_services_jsonl_approval_audit_projection_rejects_foreign_c
     let audit_log = Arc::clone(&stores.audit);
     let run_state = Arc::new(InMemoryRunStateStore::new());
     let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
-    let capability_leases = Arc::new(InMemoryCapabilityLeaseStore::new());
+    let capability_leases = Arc::new(in_memory_backed_capability_lease_store());
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
         Arc::new(LocalFilesystem::new()),
@@ -2538,7 +2539,7 @@ async fn host_runtime_services_resumes_approved_capability_and_consumes_lease_on
 async fn host_runtime_services_resume_missing_runtime_secret_returns_auth_gate() {
     let run_state = Arc::new(InMemoryRunStateStore::new());
     let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
-    let capability_leases = Arc::new(InMemoryCapabilityLeaseStore::new());
+    let capability_leases = Arc::new(in_memory_backed_capability_lease_store());
     let secret_store = Arc::new(InMemorySecretStore::new());
     let secret_handle = SecretHandle::new("approval_resume_token").unwrap();
     let script_runtime = Arc::new(RecordingScriptExecutor::default());
@@ -3079,7 +3080,7 @@ async fn host_runtime_services_auth_resume_rejects_changed_actor_before_prefligh
 async fn host_runtime_services_resume_spawn_rejects_changed_actor_before_input_and_preflight() {
     let run_state = Arc::new(InMemoryRunStateStore::new());
     let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
-    let capability_leases = Arc::new(InMemoryCapabilityLeaseStore::new());
+    let capability_leases = Arc::new(in_memory_backed_capability_lease_store());
     let process_services = ProcessServices::in_memory();
     let process_store = process_services.process_store();
     let sandbox_executor = Arc::new(RecordingSandboxProcessExecutor::default());
@@ -3246,7 +3247,7 @@ async fn host_runtime_services_auth_resume_dispatches_blocked_auth_run() {
     // auth_resume_capability dispatches and completes the run.
     let run_state = Arc::new(InMemoryRunStateStore::new());
     let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
-    let capability_leases = Arc::new(InMemoryCapabilityLeaseStore::new());
+    let capability_leases = Arc::new(in_memory_backed_capability_lease_store());
     let secret_store = Arc::new(InMemorySecretStore::new());
     let secret_handle = SecretHandle::new("auth_resume_token").unwrap();
     let script_runtime = Arc::new(RecordingScriptExecutor::default());
@@ -3836,7 +3837,7 @@ async fn host_runtime_spawn_process_sandbox_host_failure_fails_after_preflight()
 async fn host_runtime_spawn_process_sandbox_blocks_for_approval_before_executor() {
     let run_state = Arc::new(InMemoryRunStateStore::new());
     let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
-    let capability_leases = Arc::new(InMemoryCapabilityLeaseStore::new());
+    let capability_leases = Arc::new(in_memory_backed_capability_lease_store());
     let process_services = ProcessServices::in_memory();
     let result_store = process_services.result_store();
     let sandbox_executor = Arc::new(RecordingSandboxProcessExecutor::default());
@@ -3912,7 +3913,7 @@ async fn host_runtime_spawn_process_sandbox_blocks_for_approval_before_executor(
 async fn host_runtime_spawn_process_sandbox_resume_changed_input_fails_before_executor() {
     let run_state = Arc::new(InMemoryRunStateStore::new());
     let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
-    let capability_leases = Arc::new(InMemoryCapabilityLeaseStore::new());
+    let capability_leases = Arc::new(in_memory_backed_capability_lease_store());
     let sandbox_executor = Arc::new(RecordingSandboxProcessExecutor::default());
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_host_bundled_manifest(
@@ -3987,7 +3988,7 @@ async fn host_runtime_spawn_process_sandbox_resume_changed_input_fails_before_ex
 async fn host_runtime_spawn_process_sandbox_resume_invalid_plan_fails_before_executor() {
     let run_state = Arc::new(InMemoryRunStateStore::new());
     let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
-    let capability_leases = Arc::new(InMemoryCapabilityLeaseStore::new());
+    let capability_leases = Arc::new(in_memory_backed_capability_lease_store());
     let sandbox_executor = Arc::new(RecordingSandboxProcessExecutor::default());
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_host_bundled_manifest(
@@ -4081,7 +4082,7 @@ async fn host_runtime_spawn_process_sandbox_resume_invalid_plan_fails_before_exe
 async fn host_runtime_spawn_process_sandbox_resume_host_failure_fails_after_approval() {
     let run_state = Arc::new(InMemoryRunStateStore::new());
     let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
-    let capability_leases = Arc::new(InMemoryCapabilityLeaseStore::new());
+    let capability_leases = Arc::new(in_memory_backed_capability_lease_store());
     let sandbox_executor = Arc::new(RecordingSandboxProcessExecutor::default());
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_host_bundled_manifest(
@@ -6003,7 +6004,7 @@ async fn host_runtime_services_wasm_operation_failed_reconciles_wall_clock_after
 async fn invoke_capability_missing_credential_returns_auth_before_approval() {
     let run_state = Arc::new(InMemoryRunStateStore::new());
     let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
-    let capability_leases = Arc::new(InMemoryCapabilityLeaseStore::new());
+    let capability_leases = Arc::new(in_memory_backed_capability_lease_store());
     let secret_store = Arc::new(InMemorySecretStore::new());
     // Note: the secret "script_api_token" is deliberately NOT inserted.
     let secret_handle = SecretHandle::new("script_api_token").unwrap();
@@ -6076,7 +6077,7 @@ async fn invoke_capability_missing_credential_returns_auth_before_approval() {
 async fn invoke_capability_present_credential_proceeds_to_approval() {
     let run_state = Arc::new(InMemoryRunStateStore::new());
     let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
-    let capability_leases = Arc::new(InMemoryCapabilityLeaseStore::new());
+    let capability_leases = Arc::new(in_memory_backed_capability_lease_store());
     let secret_store = Arc::new(InMemorySecretStore::new());
     let secret_handle = SecretHandle::new("script_api_token").unwrap();
     // Build the request context FIRST so we can seed the secret under the same
@@ -6157,7 +6158,7 @@ async fn invoke_capability_present_credential_proceeds_to_approval() {
 async fn spawn_capability_present_credential_proceeds_to_approval() {
     let run_state = Arc::new(InMemoryRunStateStore::new());
     let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
-    let capability_leases = Arc::new(InMemoryCapabilityLeaseStore::new());
+    let capability_leases = Arc::new(in_memory_backed_capability_lease_store());
     let secret_store = Arc::new(InMemorySecretStore::new());
     let secret_handle = SecretHandle::new("script_api_token").unwrap();
     // Build the request context FIRST so we can seed the secret under the same
@@ -6271,7 +6272,7 @@ async fn invoke_capability_no_credential_requirement_proceeds_normally() {
 async fn spawn_capability_missing_credential_returns_auth_before_approval() {
     let run_state = Arc::new(InMemoryRunStateStore::new());
     let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
-    let capability_leases = Arc::new(InMemoryCapabilityLeaseStore::new());
+    let capability_leases = Arc::new(in_memory_backed_capability_lease_store());
     let secret_store = Arc::new(InMemorySecretStore::new());
     // Note: the secret "script_api_token" is deliberately NOT inserted.
     let secret_handle = SecretHandle::new("script_api_token").unwrap();
@@ -6345,7 +6346,7 @@ async fn spawn_capability_missing_credential_returns_auth_before_approval() {
 async fn invoke_capability_no_credential_requirement_with_wired_store_proceeds_normally() {
     let run_state = Arc::new(InMemoryRunStateStore::new());
     let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
-    let capability_leases = Arc::new(InMemoryCapabilityLeaseStore::new());
+    let capability_leases = Arc::new(in_memory_backed_capability_lease_store());
     // SCRIPT_MANIFEST has no runtime_credentials; wire a secret store anyway to
     // confirm the is_empty() early-exit branch is taken, not the no-store branch.
     let secret_store = Arc::new(InMemorySecretStore::new());
@@ -6429,7 +6430,7 @@ async fn invoke_capability_no_credential_requirement_with_wired_store_proceeds_n
 async fn invoke_capability_secret_store_error_skips_preflight() {
     let run_state = Arc::new(InMemoryRunStateStore::new());
     let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
-    let capability_leases = Arc::new(InMemoryCapabilityLeaseStore::new());
+    let capability_leases = Arc::new(in_memory_backed_capability_lease_store());
     let script_runtime = Arc::new(RecordingScriptExecutor::default());
     // Counts metadata() probes so we can prove the obligation backstop ran on resume.
     let metadata_calls = Arc::new(AtomicUsize::new(0));

--- a/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
@@ -520,6 +520,48 @@ async fn production_wiring_validation_classifies_combined_store_as_run_state_and
 }
 
 #[tokio::test]
+async fn production_wiring_validation_classifies_in_memory_backed_lease_store_as_local_only() {
+    // Regression guard for arch-simplification §4.3 (deleting
+    // `InMemoryCapabilityLeaseStore`): the production-wiring classifier keyed the
+    // now-deleted store as an explicit `LocalOnly` type, and unknown component
+    // types default to `ProductionCandidate`. Its replacement — the production
+    // `FilesystemCapabilityLeaseStore<InMemoryBackend>` the no-durable build and
+    // every test seam wire — must classify the same way, or a volatile in-memory
+    // lease store could silently satisfy production readiness. Drive the real
+    // `HostRuntimeServices` caller so the classification is exercised through the
+    // monomorphized `with_capability_leases::<T>` type capture, not just the
+    // classifier helper.
+    let services = HostRuntimeServices::new(
+        Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
+        Arc::new(LocalFilesystem::new()),
+        Arc::new(InMemoryResourceGovernor::new()),
+        Arc::new(GrantAuthorizer::new()),
+        ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_capability_leases(Arc::new(in_memory_backed_capability_lease_store()));
+
+    let report = services
+        .validate_production_wiring(&ProductionWiringConfig::new([]))
+        .expect_err("in-memory-backed lease store must not pass production validation");
+
+    assert!(
+        report.contains(
+            ProductionWiringComponent::CapabilityLeases,
+            ProductionWiringIssueKind::LocalOnlyImplementation,
+        ),
+        "FilesystemCapabilityLeaseStore<InMemoryBackend> must classify local-only: {report:?}"
+    );
+    assert!(
+        !report.contains(
+            ProductionWiringComponent::CapabilityLeases,
+            ProductionWiringIssueKind::Missing,
+        ),
+        "a wired lease store must satisfy capability-lease presence: {report:?}"
+    );
+}
+
+#[tokio::test]
 async fn production_wiring_validation_rejects_unsupported_runtime_requirements() {
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),

--- a/crates/ironclaw_host_runtime/tests/reborn_e2e_gate.rs
+++ b/crates/ironclaw_host_runtime/tests/reborn_e2e_gate.rs
@@ -11,8 +11,8 @@ use async_trait::async_trait;
 use chrono::Utc;
 use ironclaw_approvals::LeaseApproval;
 use ironclaw_authorization::{
-    CapabilityLeaseStatus, CapabilityLeaseStore, GrantAuthorizer, InMemoryCapabilityLeaseStore,
-    TrustAwareCapabilityDispatchAuthorizer,
+    CapabilityLeaseStatus, CapabilityLeaseStore, FilesystemCapabilityLeaseStore, GrantAuthorizer,
+    TrustAwareCapabilityDispatchAuthorizer, in_memory_backed_capability_lease_store,
 };
 use ironclaw_capabilities::CapabilityObligationHandler;
 use ironclaw_events::{
@@ -641,14 +641,14 @@ type InMemoryServices = HostRuntimeServices<
 struct ApprovalFixture {
     services: InMemoryServices,
     run_state: Arc<InMemoryRunStateStore>,
-    capability_leases: Arc<InMemoryCapabilityLeaseStore>,
+    capability_leases: Arc<FilesystemCapabilityLeaseStore<InMemoryBackend>>,
     events: InMemoryEventSink,
 }
 
 fn approval_resume_fixture() -> ApprovalFixture {
     let run_state = Arc::new(InMemoryRunStateStore::new());
     let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
-    let capability_leases = Arc::new(InMemoryCapabilityLeaseStore::new());
+    let capability_leases = Arc::new(in_memory_backed_capability_lease_store());
     let events = InMemoryEventSink::new();
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),

--- a/crates/ironclaw_host_runtime/tests/support/host_runtime_harness.rs
+++ b/crates/ironclaw_host_runtime/tests/support/host_runtime_harness.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code)]
+// arch-exempt: large_file, mechanical lease-store test repoint to FilesystemCapabilityLeaseStore<InMemoryBackend> helper (arch-simplification §4.3), no new test logic, plan #6168
 
 use super::legacy_capability_fixture_to_v2;
 use std::{
@@ -13,7 +14,8 @@ use async_trait::async_trait;
 use chrono::Utc;
 use ironclaw_approvals::LeaseApproval;
 use ironclaw_authorization::{
-    GrantAuthorizer, InMemoryCapabilityLeaseStore, TrustAwareCapabilityDispatchAuthorizer,
+    FilesystemCapabilityLeaseStore, GrantAuthorizer, TrustAwareCapabilityDispatchAuthorizer,
+    in_memory_backed_capability_lease_store,
 };
 use ironclaw_capabilities::{
     CapabilityHost, CapabilityObligationHandler, CapabilityObligationPhase,
@@ -24,6 +26,7 @@ use ironclaw_events::{
     InMemoryEventSink, ReadScope,
 };
 use ironclaw_extensions::{ExtensionManifest, ExtensionPackage, ExtensionRegistry, ManifestSource};
+use ironclaw_filesystem::InMemoryBackend;
 #[cfg(feature = "libsql")]
 use ironclaw_filesystem::LibSqlRootFilesystem;
 #[cfg(feature = "libsql")]
@@ -378,7 +381,7 @@ pub(crate) struct ApprovalResumeFixture {
     pub(crate) services: InMemoryHostRuntimeServices,
     pub(crate) run_state: Arc<InMemoryRunStateStore>,
     pub(crate) approval_requests: Arc<InMemoryApprovalRequestStore>,
-    pub(crate) capability_leases: Arc<InMemoryCapabilityLeaseStore>,
+    pub(crate) capability_leases: Arc<FilesystemCapabilityLeaseStore<InMemoryBackend>>,
     pub(crate) events: InMemoryEventSink,
 }
 
@@ -392,7 +395,7 @@ pub(crate) fn approval_resume_fixture_with_manifest(
 ) -> ApprovalResumeFixture {
     let run_state = Arc::new(InMemoryRunStateStore::new());
     let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
-    let capability_leases = Arc::new(InMemoryCapabilityLeaseStore::new());
+    let capability_leases = Arc::new(in_memory_backed_capability_lease_store());
     let events = InMemoryEventSink::new();
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(manifest)),

--- a/crates/ironclaw_product_workflow/Cargo.toml
+++ b/crates/ironclaw_product_workflow/Cargo.toml
@@ -61,6 +61,8 @@ uuid = { version = "1", features = ["v4", "v5", "serde"] }
 [dev-dependencies]
 # Enables the in-memory-backed approval store constructors for tests only.
 ironclaw_approvals = { path = "../ironclaw_approvals", features = ["test-support"] }
+# Enables the in-memory-backed capability-lease store constructor for tests only.
+ironclaw_authorization = { path = "../ironclaw_authorization", features = ["test-support"] }
 ironclaw_filesystem = { path = "../ironclaw_filesystem" }
 ironclaw_host_runtime = { path = "../ironclaw_host_runtime" }
 ironclaw_loop_host = { path = "../ironclaw_loop_host" }

--- a/crates/ironclaw_product_workflow/src/approval_interaction/resolver.rs
+++ b/crates/ironclaw_product_workflow/src/approval_interaction/resolver.rs
@@ -262,7 +262,7 @@ fn map_approval_resolution_error(error: ApprovalResolutionError) -> ProductWorkf
 
 #[cfg(test)]
 mod tests {
-    use ironclaw_authorization::InMemoryCapabilityLeaseStore;
+    use ironclaw_authorization::in_memory_backed_capability_lease_store;
     use ironclaw_host_api::{
         Action, ApprovalRequest, CapabilityId, CorrelationId, InvocationId, Principal,
         ResourceEstimate, UserId,
@@ -274,7 +274,7 @@ mod tests {
     #[tokio::test]
     async fn matching_lease_exists_rejects_pending_approval_as_stale() {
         let approvals = Arc::new(InMemoryApprovalRequestStore::new());
-        let leases = Arc::new(InMemoryCapabilityLeaseStore::new());
+        let leases = Arc::new(in_memory_backed_capability_lease_store());
         let scope = resource_scope();
         let request = approval_request(None);
         let request_id = request.id;
@@ -300,7 +300,7 @@ mod tests {
     #[tokio::test]
     async fn matching_lease_exists_rejects_approved_request_without_fingerprint_as_stale() {
         let approvals = Arc::new(InMemoryApprovalRequestStore::new());
-        let leases = Arc::new(InMemoryCapabilityLeaseStore::new());
+        let leases = Arc::new(in_memory_backed_capability_lease_store());
         let scope = resource_scope();
         let request = approval_request(None);
         let request_id = request.id;

--- a/crates/ironclaw_product_workflow/tests/approval_interaction_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/approval_interaction_contract.rs
@@ -15,7 +15,7 @@ use ironclaw_approvals::{
     },
 };
 use ironclaw_authorization::{
-    CapabilityLeaseStatus, CapabilityLeaseStore, InMemoryCapabilityLeaseStore,
+    CapabilityLeaseStatus, CapabilityLeaseStore, in_memory_backed_capability_lease_store,
 };
 use ironclaw_events::InMemoryAuditSink;
 use ironclaw_host_api::{
@@ -2645,7 +2645,7 @@ async fn approval_resolver_port_preserves_audit_sink() {
         .save_pending(resource_scope.clone(), request)
         .await
         .expect("save approval");
-    let leases = Arc::new(InMemoryCapabilityLeaseStore::new());
+    let leases = Arc::new(in_memory_backed_capability_lease_store());
     let audit = Arc::new(InMemoryAuditSink::new());
     let resolver = ApprovalResolverPort::new(approvals, leases).with_audit_sink(audit.clone());
 
@@ -2687,7 +2687,7 @@ async fn approval_resolver_port_retries_missing_lease_for_approved_request() {
         .approve(&resource_scope, request_id)
         .await
         .expect("mark approved");
-    let leases = Arc::new(InMemoryCapabilityLeaseStore::new());
+    let leases = Arc::new(in_memory_backed_capability_lease_store());
     let resolver = ApprovalResolverPort::new(approvals, leases.clone());
 
     resolver
@@ -2730,7 +2730,7 @@ async fn approval_resolver_port_retries_missing_spawn_lease_for_approved_request
         .approve(&resource_scope, request_id)
         .await
         .expect("mark approved");
-    let leases = Arc::new(InMemoryCapabilityLeaseStore::new());
+    let leases = Arc::new(in_memory_backed_capability_lease_store());
     let resolver = ApprovalResolverPort::new(approvals, leases.clone());
     let mut approval = dispatch_lease_approval(Principal::User(alpha_actor.user_id));
     approval
@@ -2766,7 +2766,7 @@ async fn approval_resolver_port_does_not_duplicate_existing_lease_for_approved_r
         .save_pending(resource_scope.clone(), request)
         .await
         .expect("save approval");
-    let leases = Arc::new(InMemoryCapabilityLeaseStore::new());
+    let leases = Arc::new(in_memory_backed_capability_lease_store());
     let resolver = ApprovalResolverPort::new(approvals, leases.clone());
     let approval = dispatch_lease_approval(Principal::User(alpha_actor.user_id.clone()));
     resolver
@@ -2803,7 +2803,7 @@ async fn approval_resolver_port_reissues_when_existing_dispatch_lease_is_claimed
         .save_pending(resource_scope.clone(), request)
         .await
         .expect("save approval");
-    let leases = Arc::new(InMemoryCapabilityLeaseStore::new());
+    let leases = Arc::new(in_memory_backed_capability_lease_store());
     let resolver = ApprovalResolverPort::new(approvals, leases.clone());
     let approval = dispatch_lease_approval(Principal::User(alpha_actor.user_id.clone()));
     resolver
@@ -2866,7 +2866,7 @@ async fn approval_resolver_port_does_not_duplicate_existing_spawn_lease_for_appr
         .save_pending(resource_scope.clone(), request)
         .await
         .expect("save approval");
-    let leases = Arc::new(InMemoryCapabilityLeaseStore::new());
+    let leases = Arc::new(in_memory_backed_capability_lease_store());
     let resolver = ApprovalResolverPort::new(approvals, leases.clone());
     let mut approval = dispatch_lease_approval(Principal::User(alpha_actor.user_id));
     approval

--- a/crates/ironclaw_reborn_composition/Cargo.toml
+++ b/crates/ironclaw_reborn_composition/Cargo.toml
@@ -199,6 +199,8 @@ chrono = "0.4"
 hmac = "0.13"
 # Enables the in-memory-backed approval store constructors for tests only.
 ironclaw_approvals = { path = "../ironclaw_approvals", features = ["test-support"] }
+# Enables the in-memory-backed capability-lease store constructor for tests only.
+ironclaw_authorization = { path = "../ironclaw_authorization", features = ["test-support"] }
 http = "1"
 http-body-util = "0.1"
 # Admin-user-management e2e test drives the composed app with a real session

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -16,12 +16,12 @@ use ironclaw_approvals::{
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 use ironclaw_auth::AuthProviderClient;
 use ironclaw_auth::{AuthProductScope, AuthSurface};
-#[cfg(any(feature = "libsql", feature = "postgres"))]
+// Used by both the durable (`<LocalDevRootFilesystem>`) and no-durable
+// (`<InMemoryBackend>`) capability-lease aliases/builders, so the import is
+// unconditional (arch-simplification §4.3).
 use ironclaw_authorization::FilesystemCapabilityLeaseStore;
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 use ironclaw_authorization::GrantAuthorizer;
-#[cfg(not(any(feature = "libsql", feature = "postgres")))]
-use ironclaw_authorization::InMemoryCapabilityLeaseStore;
 #[cfg(not(any(feature = "libsql", feature = "postgres")))]
 use ironclaw_conversations::InMemoryConversationServices;
 use ironclaw_conversations::{
@@ -289,8 +289,14 @@ pub(crate) type LocalDevApprovalRequestStore = InMemoryApprovalRequestStore;
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 pub(crate) type LocalDevCapabilityLeaseStore =
     FilesystemCapabilityLeaseStore<LocalDevRootFilesystem>;
+// One capability-lease store, backend-injected — the production
+// `FilesystemCapabilityLeaseStore<F>` every deployment uses, never a bespoke
+// `InMemory*Store` (arch-simplification §4.3). The no-durable-features build
+// backs it with `InMemoryBackend` directly, so the concrete type is
+// `<InMemoryBackend>`, which the host-runtime production-wiring guard classifies
+// `LocalOnly`.
 #[cfg(not(any(feature = "libsql", feature = "postgres")))]
-pub(crate) type LocalDevCapabilityLeaseStore = InMemoryCapabilityLeaseStore;
+pub(crate) type LocalDevCapabilityLeaseStore = FilesystemCapabilityLeaseStore<InMemoryBackend>;
 
 // One store per approval domain, backend-injected — the production
 // `Filesystem*Store<F>` every deployment uses, never a bespoke `InMemory*Store`
@@ -298,7 +304,7 @@ pub(crate) type LocalDevCapabilityLeaseStore = InMemoryCapabilityLeaseStore;
 // the no-durable-features build backs them with `InMemoryBackend` directly, so
 // the concrete type is `<InMemoryBackend>` — which the host-runtime
 // production-wiring guard classifies `LocalOnly` (the same way the volatile
-// `InMemoryRunStateStore`/`InMemoryCapabilityLeaseStore` are flagged). Durable
+// `InMemoryRunStateStore` is flagged). Durable
 // builds use the libSQL/Postgres-backed composite root filesystem, whose type is
 // distinct and correctly classifies as a production candidate.
 #[cfg(any(feature = "libsql", feature = "postgres"))]
@@ -2583,7 +2589,9 @@ async fn build_local_dev_store_graph(
     let audit_log = local_dev_audit_log(Arc::clone(&filesystem))?;
     let run_state = Arc::new(InMemoryRunStateStore::new());
     let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
-    let capability_leases = Arc::new(InMemoryCapabilityLeaseStore::new());
+    let capability_leases = Arc::new(FilesystemCapabilityLeaseStore::new(crate::wrap_scoped(
+        Arc::new(InMemoryBackend::new()),
+    )));
     let persistent_approval_policies = Arc::new(FilesystemPersistentApprovalPolicyStore::new(
         Arc::clone(&approvals_filesystem),
     ));

--- a/crates/ironclaw_reborn_composition/tests/refreshing_capability_port_test_support.rs
+++ b/crates/ironclaw_reborn_composition/tests/refreshing_capability_port_test_support.rs
@@ -20,7 +20,7 @@ use ironclaw_approvals::test_support::{
     in_memory_backed_capability_permission_override_store,
     in_memory_backed_persistent_approval_policy_store,
 };
-use ironclaw_authorization::InMemoryCapabilityLeaseStore;
+use ironclaw_authorization::in_memory_backed_capability_lease_store;
 use ironclaw_host_api::{
     AgentId, CapabilityDescriptor, CapabilityId, EffectKind, ExtensionId, MountAlias, MountGrant,
     MountPermissions, MountView, PermissionMode, ProjectId, ProviderToolName, ResourceEstimate,
@@ -406,7 +406,7 @@ fn test_parts(
         auto_approve_settings: Arc::new(in_memory_backed_auto_approve_setting_store()),
         persistent_approval_policies: Arc::new(in_memory_backed_persistent_approval_policy_store()),
         approval_requests: Arc::new(InMemoryApprovalRequestStore::new()),
-        capability_leases: Arc::new(InMemoryCapabilityLeaseStore::new()),
+        capability_leases: Arc::new(in_memory_backed_capability_lease_store()),
         capability_execution_mount_overrides,
         additional_provider_trust,
         capability_id_filter,

--- a/docs/reborn/contracts/capability-access.md
+++ b/docs/reborn/contracts/capability-access.md
@@ -106,10 +106,10 @@ pub trait CapabilityLeaseStore: Send + Sync {
 }
 ```
 
-Lease storage implementations now include:
+There is one production lease store, backend-injected (arch-simplification §4.3 — "in-memory" is a filesystem backend, not a bespoke store):
 
-- `InMemoryCapabilityLeaseStore` for tests and ephemeral composition.
-- `FilesystemCapabilityLeaseStore` for durable virtual-path persistence under `/engine/tenants/{tenant_id}/users/{user_id}/agents/{agent_id-or-_none}/capability-leases/{invocation_id}/{lease_id}.json`.
+- `FilesystemCapabilityLeaseStore<F>` for durable virtual-path persistence under `/engine/tenants/{tenant_id}/users/{user_id}/agents/{agent_id-or-_none}/capability-leases/{invocation_id}/{lease_id}.json`. Production wires it over the libSQL/Postgres-backed root filesystem.
+- Tests and ephemeral composition use the same store over `InMemoryBackend` (`FilesystemCapabilityLeaseStore<InMemoryBackend>`), constructed via the `test-support` `in_memory_backed_capability_lease_store()` helper. The former hand-written `InMemoryCapabilityLeaseStore` was deleted.
 
 The filesystem store persists issue, claim, consume, and revoke transitions with awaited filesystem operations; it must not use nested `block_on` inside async approval/resume paths. Reads are fail-closed for authorization: unreadable or missing lease records do not become ambient grants.
 

--- a/tests/integration/support/harness/mod.rs
+++ b/tests/integration/support/harness/mod.rs
@@ -1486,7 +1486,7 @@ impl HostRuntimeCapabilityHarness {
             .as_ref()
             .map(|parts| Arc::clone(&parts.capability_leases))
             .unwrap_or_else(|| {
-                Arc::new(ironclaw_authorization::InMemoryCapabilityLeaseStore::new())
+                Arc::new(ironclaw_authorization::in_memory_backed_capability_lease_store())
             });
         let tool_permission_overrides: Arc<dyn ironclaw_approvals::ToolPermissionOverrideStore> =
             self.tool_permission_overrides.clone().unwrap_or_else(|| {


### PR DESCRIPTION
## Slice A2 of the architecture-simplification note — authorization lease store

Follows #6195 (now merged). Implements **Slice A** of `docs/reborn/2026-07-17-architecture-simplification-dto-dyn-local.md` (§4.3) for the **authorization** domain: *"in-memory" stops being a bespoke store and becomes a filesystem backend.* There is now **one** production `FilesystemCapabilityLeaseStore<F>` — exercised over `InMemoryBackend` in tests and libSQL/Postgres in production — instead of a hand-written `InMemoryCapabilityLeaseStore` kept in lock-step. (#6195 did the three approval stores and deliberately left the lease store; this is the direct continuation, rebased onto current `main`.)

### What changed
- **`ironclaw_authorization`** — deletes `InMemoryCapabilityLeaseStore` and its now-orphaned private `CapabilityLeaseKey` (the full-scope hashmap key). Adds a `test-support`-gated `in_memory_backed_capability_lease_store()` returning the production `FilesystemCapabilityLeaseStore<InMemoryBackend>` over a fresh `ScopedFilesystem<InMemoryBackend>` mounted at `/authorization`. **Net −187 LOC** in `lib.rs`.
- **composition `factory.rs`** — the no-durable `LocalDevCapabilityLeaseStore` alias collapses to `FilesystemCapabilityLeaseStore<InMemoryBackend>`; the no-durable builder wires it over `wrap_scoped(InMemoryBackend::new())`. The `FilesystemCapabilityLeaseStore` import is now **unconditional** (it was durable-only, but the no-durable path now uses it too).
- **host_runtime production-wiring guard** — the `LocalOnly` classification keys on `FilesystemCapabilityLeaseStore<InMemoryBackend>` instead of the deleted type. Production (`<LibSql>`/`<Postgres>`) and durable-local-dev (`<Composite>`) classifications are **unchanged**.
- **~15 downstream test files** across `ironclaw_capabilities`, `ironclaw_product_workflow`, `ironclaw_approvals`, `ironclaw_host_runtime`, `ironclaw_reborn_composition`, and the integration harness repoint to the helper; the affected crates enable `ironclaw_authorization/test-support` in `[dev-dependencies]`.

### Behavioral reconciliation — not a pure delete
As the doc warns (§4.3, "reconcile-then-delete"), this is not behavior-preserving for *store keying*: the deleted `InMemoryCapabilityLeaseStore` keyed leases by the **full `ResourceScope` tuple**, whereas `FilesystemCapabilityLeaseStore` keys by the **per-invocation `MountView` subtree** (tenant/user come from the mount, not the path). Two tests asserted the old cross-scope store keying and were reconciled to prove isolation **structurally** rather than via a hand-rolled key:
- `ironclaw_capabilities … capability_host_rejects_resume_from_wrong_user_scope_*` — dropped the redundant `leases.get(wrong_user).is_none()` sub-assertion; the real guarantee (resume rejected via `RunStateError::UnknownInvocation`, zero dispatch, lease still `Active`) is asserted directly, and cross-user visibility is proven structurally by authorization's own tenant-isolation contract test.
- `ironclaw_authorization … revocation_is_scoped_to_tenant_and_user` — rewritten to the **two-per-tenant-mounted-stores** pattern (mirroring `filesystem_capability_lease_store_isolates_two_tenants_*`), reproducing the isolation via distinct mount subtrees.

Each reconciled test carries a comment explaining the change.

### Safety
Net subtractive. No trust-boundary or persistence-compatibility change: the in-memory lease store was volatile/test-only; the durable libSQL/Postgres backends are untouched. The production-wiring fail-closed guard's `LocalOnly` contract is preserved (repointed to the new volatile concrete type).

### Verification
- **Tests green:** `ironclaw_authorization` (28, incl. the reconciled isolation test), `ironclaw_capabilities` (all), `ironclaw_approvals` (all), `ironclaw_product_workflow` (14), `ironclaw_host_runtime` (all), `ironclaw_architecture` boundary tests (8 + 34). Composition: only the 3 `llm_admin::nearai_mcp` env-driven tests fail locally (they require `NEARAI_API_KEY` **unset**; unrelated to this change — pass with the env cleared).
- **Compiles on both feature combos:** default/libSQL **and** `--features test-support` (no-durable).
- `ironclaw_authorization` clippy `-D warnings` clean.
- Large-file pre-commit annotations added for the touched `crates/**`/`src/**` files >1,500 lines (matching #6195's `plan #6168` convention).
- ⚠️ **Local-verification caveat.** The tests + both-feature-set compiles above were run on the pre-rebase commit. After #6195 merged, this branch was rebased `--onto` current `main` (dropping the pre-squash #6195 commits); the rebase applied with **zero conflicts** and the resulting commit is self-contained (28 files, none overlapping #6194's WebUI consolidation). The post-rebase clippy/test re-run could **not** complete locally — a concurrent full-workspace build in a sibling checkout exhausted memory and filled the disk (100%). **CI is the authoritative gate here**; flag me if anything fails and I'll fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
