### PR TITLE
feat(reborn): add hosted-single-tenant-multi-user profile without host shell

### DIFF
--- a/crates/ironclaw_reborn_cli/src/commands/config/init.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/config/init.rs
@@ -147,9 +147,11 @@ api_version = "{api_version}"
 
 [boot]
 # Composition profile. One of: local-dev, local-dev-yolo, hosted-single-tenant,
-# hosted-single-tenant-volume, production, migration-dry-run.
-# Today local-dev, local-dev-yolo, hosted-single-tenant, and
-# hosted-single-tenant-volume are wired end-to-end.
+# hosted-single-tenant-volume, hosted-single-tenant-multi-user, production,
+# migration-dry-run.
+# Today local-dev, local-dev-yolo, hosted-single-tenant,
+# hosted-single-tenant-volume, and hosted-single-tenant-multi-user are wired
+# end-to-end.
 # local-dev-yolo also requires --confirm-host-access at runtime.
 profile = "local-dev"
 

--- a/crates/ironclaw_reborn_cli/src/commands/skills.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/skills.rs
@@ -94,7 +94,7 @@ fn build_skill_list_config(config: &RebornBootConfig) -> anyhow::Result<SkillLis
     let profile = crate::runtime::effective_profile(config, config_file.as_ref())?;
     if !profile.supports_local_runtime_skill_management() {
         anyhow::bail!(
-            "ironclaw-reborn skills currently supports profile=local-dev, profile=local-dev-yolo, profile=hosted-single-tenant, or profile=hosted-single-tenant-volume; got profile={profile}"
+            "ironclaw-reborn skills currently supports profile=local-dev, profile=local-dev-yolo, profile=hosted-single-tenant, profile=hosted-single-tenant-volume, or profile=hosted-single-tenant-multi-user; got profile={profile}"
         );
     }
     Ok(SkillListConfig {

--- a/crates/ironclaw_reborn_cli/src/runtime/mod.rs
+++ b/crates/ironclaw_reborn_cli/src/runtime/mod.rs
@@ -16,6 +16,8 @@ use ironclaw_reborn_composition::SlackPersonalSetupServiceSlot;
 use ironclaw_reborn_composition::host_api::UserId;
 use ironclaw_reborn_composition::host_api::{AgentId, TenantId};
 #[cfg(feature = "postgres")]
+use ironclaw_reborn_composition::hosted_single_tenant_multi_user_runtime_policy;
+#[cfg(feature = "postgres")]
 use ironclaw_reborn_composition::hosted_single_tenant_runtime_policy;
 use ironclaw_reborn_composition::{
     CredentialRefreshSettings, OAuthClientConfig, OperatorLogLayer, PollSettings, RebornBuildInput,
@@ -281,12 +283,12 @@ pub(crate) async fn open_trigger_access_store_for_profile(
     local_store_path: &Path,
 ) -> anyhow::Result<Arc<dyn LocalTriggerAccessStore>> {
     match profile {
-        RebornProfile::HostedSingleTenant => {
+        RebornProfile::HostedSingleTenant | RebornProfile::HostedSingleTenantMultiUser => {
             #[cfg(feature = "postgres")]
             {
-                let services = runtime_input.services.as_ref().context(
-                    "profile=hosted-single-tenant requires runtime services before trigger-fire access can be wired",
-                )?;
+                let services = runtime_input.services.as_ref().with_context(|| format!(
+                    "profile={profile} requires runtime services before trigger-fire access can be wired"
+                ))?;
                 let store = services
                     .open_hosted_single_tenant_trigger_access_store()
                     .await
@@ -299,7 +301,7 @@ pub(crate) async fn open_trigger_access_store_for_profile(
                 let _ = runtime_input;
                 let _ = local_store_path;
                 anyhow::bail!(
-                    "profile=hosted-single-tenant requires the `postgres` feature for trigger-fire access"
+                    "profile={profile} requires the `postgres` feature for trigger-fire access"
                 );
             }
         }
@@ -641,12 +643,14 @@ pub(crate) fn build_services_input_with_options(
         | RebornProfile::HostedSingleTenantVolume => {
             build_standalone_local_runtime_services_input(profile, owner_id, config, options)?
         }
-        RebornProfile::HostedSingleTenant => build_hosted_single_tenant_services_input(
-            profile,
-            owner_id,
-            config,
-            config_file.as_ref(),
-        )?,
+        RebornProfile::HostedSingleTenant | RebornProfile::HostedSingleTenantMultiUser => {
+            build_hosted_single_tenant_services_input(
+                profile,
+                owner_id,
+                config,
+                config_file.as_ref(),
+            )?
+        }
         RebornProfile::Production | RebornProfile::MigrationDryRun => {
             // MigrationDryRun needs production storage handles so follow-up migration
             // code can inspect durable schema state; this branch only constructs
@@ -722,8 +726,16 @@ fn build_hosted_single_tenant_services_input(
 ) -> anyhow::Result<RebornBuildInput> {
     let workspace_root = std::env::current_dir()
         .context("failed to resolve current directory for hosted single-tenant workspace")?;
-    let runtime_policy = hosted_single_tenant_runtime_policy()
-        .context("failed to resolve hosted single-tenant runtime policy")?;
+    // `hosted-single-tenant-multi-user` shares the Postgres storage wiring below
+    // with `hosted-single-tenant` but resolves against the sandboxed
+    // HostedMultiTenant+SecureDefault policy instead of the shell-capable
+    // local-dev policy shape (issue #6170).
+    let runtime_policy = if profile == RebornProfile::HostedSingleTenantMultiUser {
+        hosted_single_tenant_multi_user_runtime_policy()
+    } else {
+        hosted_single_tenant_runtime_policy()
+    }
+    .context("failed to resolve hosted single-tenant runtime policy")?;
     Ok(
         RebornBuildInput::hosted_single_tenant_postgres_from_config_and_env(
             composition_profile(profile),
@@ -915,6 +927,9 @@ fn composition_profile(profile: RebornProfile) -> RebornCompositionProfile {
         RebornProfile::HostedSingleTenantVolume => {
             RebornCompositionProfile::HostedSingleTenantVolume
         }
+        RebornProfile::HostedSingleTenantMultiUser => {
+            RebornCompositionProfile::HostedSingleTenantMultiUser
+        }
         RebornProfile::Production => RebornCompositionProfile::Production,
         RebornProfile::MigrationDryRun => RebornCompositionProfile::MigrationDryRun,
     }
@@ -1028,6 +1043,7 @@ fn reject_unsupported_runtime_sections(
         && !matches!(
             profile,
             RebornProfile::HostedSingleTenant
+                | RebornProfile::HostedSingleTenantMultiUser
                 | RebornProfile::Production
                 | RebornProfile::MigrationDryRun
         )
@@ -2320,6 +2336,64 @@ secret_master_key_env = "IRONCLAW_REBORN_SECRET_MASTER_KEY"
         );
         assert_eq!(policy.requested_profile.as_str(), "local_dev");
         assert!(!services.grants_trusted_laptop_access());
+        drop(pool_max_size);
+        drop(secret_master_key);
+        drop(postgres_url);
+        drop(database_sslmode);
+        drop(allow_cleartext);
+    }
+
+    #[cfg(feature = "postgres")]
+    #[test]
+    fn build_runtime_input_hosted_single_tenant_multi_user_constructs_postgres_input() {
+        // issue #6170: hosted-single-tenant-multi-user shares the Postgres
+        // storage wiring with hosted-single-tenant but must resolve the
+        // sandboxed HostedMultiTenant+SecureDefault policy (no host process
+        // execution), not the shell-capable local-dev policy shape.
+        let _lock = lock_runtime_env();
+        let (_enabled, _interval) = clear_trigger_poller_env();
+        let (database_sslmode, allow_cleartext) = clear_reborn_postgres_tls_env();
+        let postgres_url = EnvGuard::set(
+            "IRONCLAW_REBORN_POSTGRES_URL",
+            "postgres://event_user:RAW_PASSWORD_SENTINEL_3162@db.example.com/events?sslmode=require",
+        );
+        let secret_master_key =
+            EnvGuard::set("IRONCLAW_REBORN_SECRET_MASTER_KEY", "test-master-key");
+        let pool_max_size = EnvGuard::set("IRONCLAW_REBORN_POSTGRES_POOL_MAX_SIZE", "1");
+        let (_temp, config) = boot_config_with_config_toml(
+            "hosted-single-tenant-multi-user",
+            r#"
+[storage]
+backend = "postgres"
+url_env = "IRONCLAW_REBORN_POSTGRES_URL"
+secret_master_key_env = "IRONCLAW_REBORN_SECRET_MASTER_KEY"
+"#,
+        );
+
+        let runtime_input =
+            build_runtime_input(&config, RuntimeInputCaller::Serve).expect("runtime input");
+        let services = runtime_input.services.expect("services input");
+        let policy = services.runtime_policy().expect("runtime policy");
+
+        assert_eq!(
+            services.profile(),
+            RebornCompositionProfile::HostedSingleTenantMultiUser
+        );
+        assert_eq!(policy.requested_profile.as_str(), "secure_default");
+        assert_eq!(policy.process_backend.as_str(), "none");
+        assert!(!services.grants_trusted_laptop_access());
+        assert_eq!(
+            local_runtime_storage_root(
+                &config,
+                ironclaw_reborn_config::RebornProfile::HostedSingleTenantMultiUser,
+            )
+            .file_name()
+            .and_then(|name| name.to_str()),
+            Some("hosted-single-tenant-multi-user"),
+            "hosted-single-tenant-multi-user must use its own storage scratch subdir, distinct \
+             from hosted-single-tenant, so shell-capable and sandboxed profiles never share \
+             local runtime scratch state"
+        );
         drop(pool_max_size);
         drop(secret_master_key);
         drop(postgres_url);

--- a/crates/ironclaw_reborn_cli/tests/smoke.rs
+++ b/crates/ironclaw_reborn_cli/tests/smoke.rs
@@ -600,7 +600,7 @@ fn profile_list_json_is_stable_and_does_not_resolve_reborn_home() {
     let json: serde_json::Value = serde_json::from_str(stdout.trim()).expect("valid JSON");
     assert_eq!(json["selector"], "IRONCLAW_REBORN_PROFILE");
     let profiles = json["profiles"].as_array().expect("profiles array");
-    assert_eq!(profiles.len(), 6);
+    assert_eq!(profiles.len(), 7);
     assert!(
         profiles
             .iter()
@@ -623,6 +623,10 @@ fn profile_list_json_is_stable_and_does_not_resolve_reborn_home() {
             .any(|profile| profile["name"] == "hosted-single-tenant-volume"
                 && profile["default"] == false)
     );
+    assert!(profiles.iter().any(
+        |profile| profile["name"] == "hosted-single-tenant-multi-user"
+            && profile["default"] == false
+    ));
     assert!(
         profiles
             .iter()

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -1265,7 +1265,8 @@ pub async fn build_reborn_services(
         RebornCompositionProfile::LocalDev
         | RebornCompositionProfile::LocalDevYolo
         | RebornCompositionProfile::HostedSingleTenant
-        | RebornCompositionProfile::HostedSingleTenantVolume => build_local_runtime(input).await,
+        | RebornCompositionProfile::HostedSingleTenantVolume
+        | RebornCompositionProfile::HostedSingleTenantMultiUser => build_local_runtime(input).await,
         RebornCompositionProfile::Production | RebornCompositionProfile::MigrationDryRun => {
             build_production_shaped(input).await
         }
@@ -1401,12 +1402,13 @@ async fn build_local_runtime(input: RebornBuildInput) -> Result<RebornServices, 
         postgres_resource_governor_singleton,
     ) = match storage {
         RebornStorageInput::LocalDev { .. }
-            if profile == RebornCompositionProfile::HostedSingleTenant =>
+            if profile.uses_hosted_single_tenant_postgres_storage_input() =>
         {
             return Err(RebornBuildError::InvalidConfig {
-                    reason: "profile=hosted-single-tenant requires hosted single-tenant Postgres storage input"
-                        .to_string(),
-                });
+                reason: format!(
+                    "profile={profile} requires hosted single-tenant Postgres storage input"
+                ),
+            });
         }
         RebornStorageInput::LocalDev {
             root,
@@ -1422,7 +1424,7 @@ async fn build_local_runtime(input: RebornBuildInput) -> Result<RebornServices, 
         ),
         #[cfg(feature = "postgres")]
         RebornStorageInput::HostedSingleTenantPostgres { .. }
-            if profile != RebornCompositionProfile::HostedSingleTenant =>
+            if !profile.uses_hosted_single_tenant_postgres_storage_input() =>
         {
             return Err(RebornBuildError::InvalidConfig {
                 reason: format!("{profile} profile requires local-runtime storage input"),
@@ -5903,6 +5905,35 @@ mod tests {
         let error = match build_reborn_services(input).await {
             Ok(_) => {
                 panic!("hosted single-tenant must use hosted single-tenant Postgres storage")
+            }
+            Err(error) => error,
+        };
+        let RebornBuildError::InvalidConfig { reason } = error else {
+            panic!("expected invalid config, got {error:?}");
+        };
+        assert!(
+            reason.contains("hosted single-tenant Postgres storage input"),
+            "reason: {reason}"
+        );
+    }
+
+    #[tokio::test]
+    async fn hosted_single_tenant_multi_user_rejects_local_dev_storage_input() {
+        // issue #6170: the multi-user profile shares the HostedSingleTenant
+        // Postgres storage contract, not the local-dev/volume one — a
+        // LocalDev storage input must fail closed here too.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut input = RebornBuildInput::local_dev(
+            "hosted-single-tenant-multi-user-local-storage-owner",
+            dir.path().join("local-dev"),
+        );
+        input.profile = RebornCompositionProfile::HostedSingleTenantMultiUser;
+
+        let error = match build_reborn_services(input).await {
+            Ok(_) => {
+                panic!(
+                    "hosted single-tenant multi-user must use hosted single-tenant Postgres storage"
+                )
             }
             Err(error) => error,
         };

--- a/crates/ironclaw_reborn_composition/src/input.rs
+++ b/crates/ironclaw_reborn_composition/src/input.rs
@@ -319,10 +319,10 @@ impl RebornBuildInput {
         pool: deadpool_postgres::Pool,
         secret_master_key: ironclaw_secrets::SecretMaterial,
     ) -> Result<Self, RebornBuildError> {
-        if profile != RebornCompositionProfile::HostedSingleTenant {
+        if !profile.uses_hosted_single_tenant_postgres_storage_input() {
             return Err(RebornBuildError::InvalidConfig {
                 reason: format!(
-                    "hosted single-tenant Postgres storage requires profile=hosted-single-tenant; got profile={profile}"
+                    "hosted single-tenant Postgres storage requires profile=hosted-single-tenant or profile=hosted-single-tenant-multi-user; got profile={profile}"
                 ),
             });
         }
@@ -347,10 +347,10 @@ impl RebornBuildInput {
         root: PathBuf,
         config_file: Option<&ironclaw_reborn_config::RebornConfigFile>,
     ) -> Result<Self, RebornBuildError> {
-        if profile != RebornCompositionProfile::HostedSingleTenant {
+        if !profile.uses_hosted_single_tenant_postgres_storage_input() {
             return Err(RebornBuildError::InvalidConfig {
                 reason: format!(
-                    "hosted single-tenant Postgres storage requires profile=hosted-single-tenant; got profile={profile}"
+                    "hosted single-tenant Postgres storage requires profile=hosted-single-tenant or profile=hosted-single-tenant-multi-user; got profile={profile}"
                 ),
             });
         }

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -144,8 +144,9 @@ pub use llm_admin::provider_admin_product_command::RebornProviderAdminProductCom
 pub use llm_admin::provider_repo::{ProviderRepo, ProviderRepoError};
 pub use local_runtime_profile::{
     RebornLocalRuntimeProfileError, RebornLocalRuntimeProfileOptions,
-    hosted_single_tenant_runtime_policy, hosted_single_tenant_volume_runtime_policy,
-    local_dev_runtime_policy, local_dev_yolo_runtime_policy, local_runtime_build_input,
+    hosted_single_tenant_multi_user_runtime_policy, hosted_single_tenant_runtime_policy,
+    hosted_single_tenant_volume_runtime_policy, local_dev_runtime_policy,
+    local_dev_yolo_runtime_policy, local_runtime_build_input,
     local_runtime_build_input_with_options,
 };
 pub use observability::budget::build_default_budget_accountant;

--- a/crates/ironclaw_reborn_composition/src/local_runtime_profile.rs
+++ b/crates/ironclaw_reborn_composition/src/local_runtime_profile.rs
@@ -97,6 +97,22 @@ pub fn hosted_single_tenant_runtime_policy() -> Result<ResolvedRuntimePolicy, Re
 /// scoped virtual filesystem, brokered network, brokered secret handles, and
 /// ask-always approval posture from the resolver-owned secure default.
 pub fn hosted_single_tenant_volume_runtime_policy() -> Result<ResolvedRuntimePolicy, ResolveError> {
+    hosted_multi_tenant_secure_default_policy()
+}
+
+/// Resolved policy for the hosted single-tenant profile with the same
+/// processless, sandboxed shape as [`hosted_single_tenant_volume_runtime_policy`],
+/// but paired with durable Postgres storage instead of the local-runtime
+/// volume. Shares the resolver call so the two policies cannot drift.
+pub fn hosted_single_tenant_multi_user_runtime_policy()
+-> Result<ResolvedRuntimePolicy, ResolveError> {
+    hosted_multi_tenant_secure_default_policy()
+}
+
+/// Shared resolver call behind both the volume-backed and Postgres-backed
+/// hosted single-tenant multi-user profiles: `resolve(HostedMultiTenant,
+/// SecureDefault)`. Process execution is impossible under this policy.
+fn hosted_multi_tenant_secure_default_policy() -> Result<ResolvedRuntimePolicy, ResolveError> {
     let request = ironclaw_runtime_policy::ResolveRequest::new(
         DeploymentMode::HostedMultiTenant,
         RuntimeProfile::SecureDefault,
@@ -139,6 +155,7 @@ fn local_runtime_policy(
         }
         RebornCompositionProfile::Disabled
         | RebornCompositionProfile::HostedSingleTenant
+        | RebornCompositionProfile::HostedSingleTenantMultiUser
         | RebornCompositionProfile::Production
         | RebornCompositionProfile::MigrationDryRun => {
             return Err(RebornLocalRuntimeProfileError::UnsupportedProfile { profile });

--- a/crates/ironclaw_reborn_composition/src/readiness.rs
+++ b/crates/ironclaw_reborn_composition/src/readiness.rs
@@ -14,6 +14,7 @@ pub enum RebornReadinessState {
     DevOnly,
     HostedSingleTenantValidated,
     HostedSingleTenantVolumePreviewValidated,
+    HostedSingleTenantMultiUserValidated,
     ProductionValidated,
     MigrationDryRunValidated,
 }
@@ -79,6 +80,7 @@ pub enum RebornReadinessDiagnosticReason {
     Disabled,
     DevOnlyProfile,
     HostedSingleTenantVolumePreview,
+    HostedSingleTenantMultiUser,
     Missing,
     LocalOnly,
     Unverified,
@@ -92,6 +94,7 @@ impl RebornReadinessDiagnosticReason {
             Self::Disabled => "disabled",
             Self::DevOnlyProfile => "dev-only-profile",
             Self::HostedSingleTenantVolumePreview => "hosted-single-tenant-volume-preview",
+            Self::HostedSingleTenantMultiUser => "hosted-single-tenant-multi-user",
             Self::Missing => "missing",
             Self::LocalOnly => "local-only",
             Self::Unverified => "unverified",
@@ -120,6 +123,7 @@ impl<'de> Deserialize<'de> for RebornReadinessDiagnosticReason {
             "disabled" => Self::Disabled,
             "dev-only-profile" => Self::DevOnlyProfile,
             "hosted-single-tenant-volume-preview" => Self::HostedSingleTenantVolumePreview,
+            "hosted-single-tenant-multi-user" => Self::HostedSingleTenantMultiUser,
             "missing" => Self::Missing,
             "local-only" => Self::LocalOnly,
             "unverified" => Self::Unverified,
@@ -287,6 +291,10 @@ pub(crate) fn readiness_contract_for_profile(
             RebornReadinessState::HostedSingleTenantVolumePreviewValidated,
             vec![RebornReadinessDiagnostic::hosted_single_tenant_volume()],
         ),
+        RebornCompositionProfile::HostedSingleTenantMultiUser => (
+            RebornReadinessState::HostedSingleTenantMultiUserValidated,
+            vec![RebornReadinessDiagnostic::hosted_single_tenant_multi_user()],
+        ),
         RebornCompositionProfile::Production => {
             (RebornReadinessState::ProductionValidated, Vec::new())
         }
@@ -330,6 +338,16 @@ impl RebornReadinessDiagnostic {
             profile: RebornCompositionProfile::HostedSingleTenant,
             component: RebornReadinessDiagnosticComponent::CompositionProfile,
             reason: RebornReadinessDiagnosticReason::Unverified,
+            status: RebornReadinessDiagnosticStatus::Info,
+            blocks_production: false,
+        }
+    }
+
+    pub fn hosted_single_tenant_multi_user() -> Self {
+        Self {
+            profile: RebornCompositionProfile::HostedSingleTenantMultiUser,
+            component: RebornReadinessDiagnosticComponent::CompositionProfile,
+            reason: RebornReadinessDiagnosticReason::HostedSingleTenantMultiUser,
             status: RebornReadinessDiagnosticStatus::Info,
             blocks_production: false,
         }

--- a/crates/ironclaw_reborn_composition/src/root/profile.rs
+++ b/crates/ironclaw_reborn_composition/src/root/profile.rs
@@ -12,6 +12,7 @@ pub enum RebornCompositionProfile {
     LocalDevYolo,
     HostedSingleTenant,
     HostedSingleTenantVolume,
+    HostedSingleTenantMultiUser,
     Production,
     MigrationDryRun,
 }
@@ -24,6 +25,7 @@ impl RebornCompositionProfile {
             Self::LocalDevYolo => "local-dev-yolo",
             Self::HostedSingleTenant => "hosted-single-tenant",
             Self::HostedSingleTenantVolume => "hosted-single-tenant-volume",
+            Self::HostedSingleTenantMultiUser => "hosted-single-tenant-multi-user",
             Self::Production => "production",
             Self::MigrationDryRun => "migration-dry-run",
         }
@@ -44,6 +46,7 @@ impl RebornCompositionProfile {
                 | Self::LocalDevYolo
                 | Self::HostedSingleTenant
                 | Self::HostedSingleTenantVolume
+                | Self::HostedSingleTenantMultiUser
         )
     }
 
@@ -54,6 +57,17 @@ impl RebornCompositionProfile {
         )
     }
 
+    /// Whether this profile is wired against the hosted single-tenant
+    /// Postgres storage path (shared guard for `input.rs` and `factory.rs`
+    /// storage-pairing checks so `HostedSingleTenant` and
+    /// `HostedSingleTenantMultiUser` cannot drift from each other).
+    pub fn uses_hosted_single_tenant_postgres_storage_input(self) -> bool {
+        matches!(
+            self,
+            Self::HostedSingleTenant | Self::HostedSingleTenantMultiUser
+        )
+    }
+
     pub fn starts_live_runtime(self) -> bool {
         matches!(
             self,
@@ -61,6 +75,7 @@ impl RebornCompositionProfile {
                 | Self::LocalDevYolo
                 | Self::HostedSingleTenant
                 | Self::HostedSingleTenantVolume
+                | Self::HostedSingleTenantMultiUser
                 | Self::Production
         )
     }
@@ -68,7 +83,9 @@ impl RebornCompositionProfile {
     pub fn uses_hosted_extension_installation_state(self) -> bool {
         matches!(
             self,
-            Self::HostedSingleTenant | Self::HostedSingleTenantVolume
+            Self::HostedSingleTenant
+                | Self::HostedSingleTenantVolume
+                | Self::HostedSingleTenantMultiUser
         )
     }
 
@@ -78,7 +95,8 @@ impl RebornCompositionProfile {
             | Self::LocalDev
             | Self::LocalDevYolo
             | Self::HostedSingleTenant
-            | Self::HostedSingleTenantVolume => {
+            | Self::HostedSingleTenantVolume
+            | Self::HostedSingleTenantMultiUser => {
                 ironclaw_reborn_event_store::RebornProfile::LocalDev
             }
             Self::Production | Self::MigrationDryRun => {
@@ -99,6 +117,7 @@ impl FromStr for RebornCompositionProfile {
             "local-dev-yolo" => Ok(Self::LocalDevYolo),
             "hosted-single-tenant" => Ok(Self::HostedSingleTenant),
             "hosted-single-tenant-volume" => Ok(Self::HostedSingleTenantVolume),
+            "hosted-single-tenant-multi-user" => Ok(Self::HostedSingleTenantMultiUser),
             "production" => Ok(Self::Production),
             "migration-dry-run" => Ok(Self::MigrationDryRun),
             _ => Err(RebornCompositionProfileParseError { value: normalized }),

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -461,6 +461,17 @@ fn enforce_runtime_cutover_gate(
             }
             Ok(())
         }
+        RebornCompositionProfile::HostedSingleTenantMultiUser => {
+            if readiness.state != RebornReadinessState::HostedSingleTenantMultiUserValidated {
+                return Err(RebornRuntimeError::InvalidArgument {
+                    reason: format!(
+                        "profile=hosted-single-tenant-multi-user cannot start Reborn runtime before hosted single-tenant multi-user readiness is validated; required_state=HostedSingleTenantMultiUserValidated, state={:?}",
+                        readiness.state
+                    ),
+                });
+            }
+            Ok(())
+        }
         RebornCompositionProfile::LocalDev | RebornCompositionProfile::LocalDevYolo => Ok(()),
     }
 }
@@ -3021,7 +3032,9 @@ impl RebornRuntime {
 ///
 /// **Currently supported profiles:** `RebornCompositionProfile::LocalDev`,
 /// `RebornCompositionProfile::LocalDevYolo`,
-/// `RebornCompositionProfile::HostedSingleTenant`, and
+/// `RebornCompositionProfile::HostedSingleTenant`,
+/// `RebornCompositionProfile::HostedSingleTenantVolume`,
+/// `RebornCompositionProfile::HostedSingleTenantMultiUser`, and
 /// `RebornCompositionProfile::Production` are wired end-to-end here. Production
 /// starts only after readiness diagnostics validate that live traffic can be
 /// exposed without a partial cutover.
@@ -3165,7 +3178,8 @@ pub async fn build_reborn_runtime(
         RebornCompositionProfile::LocalDev
         | RebornCompositionProfile::LocalDevYolo
         | RebornCompositionProfile::HostedSingleTenant
-        | RebornCompositionProfile::HostedSingleTenantVolume => {
+        | RebornCompositionProfile::HostedSingleTenantVolume
+        | RebornCompositionProfile::HostedSingleTenantMultiUser => {
             let local_runtime =
                 services
                     .local_runtime
@@ -5087,6 +5101,50 @@ output_schema_ref = "schemas/write.output.json"
         assert!(reason.contains("hosted-single-tenant"), "reason: {reason}");
         assert!(
             reason.contains("HostedSingleTenantValidated"),
+            "reason: {reason}"
+        );
+    }
+
+    #[test]
+    fn runtime_cutover_gate_allows_hosted_single_tenant_multi_user_readiness() {
+        let readiness = readiness_for_runtime_gate(
+            RebornCompositionProfile::HostedSingleTenantMultiUser,
+            RebornReadinessState::HostedSingleTenantMultiUserValidated,
+            Vec::new(),
+        );
+
+        super::enforce_runtime_cutover_gate(
+            RebornCompositionProfile::HostedSingleTenantMultiUser,
+            &readiness,
+        )
+        .expect("validated hosted single-tenant multi-user runtime can start");
+    }
+
+    #[test]
+    fn runtime_cutover_gate_rejects_foreign_hosted_readiness_for_multi_user() {
+        // The shell-capable profile's readiness state must not validate the
+        // sandboxed multi-user profile's cutover — the dedicated state exists
+        // to keep those postures discriminated.
+        let readiness = readiness_for_runtime_gate(
+            RebornCompositionProfile::HostedSingleTenantMultiUser,
+            RebornReadinessState::HostedSingleTenantValidated,
+            Vec::new(),
+        );
+
+        let error = super::enforce_runtime_cutover_gate(
+            RebornCompositionProfile::HostedSingleTenantMultiUser,
+            &readiness,
+        )
+        .expect_err("multi-user runtime requires its own validated readiness state");
+        let RebornRuntimeError::InvalidArgument { reason } = error else {
+            panic!("expected invalid argument, got {error:?}");
+        };
+        assert!(
+            reason.contains("hosted-single-tenant-multi-user"),
+            "reason: {reason}"
+        );
+        assert!(
+            reason.contains("HostedSingleTenantMultiUserValidated"),
             "reason: {reason}"
         );
     }

--- a/crates/ironclaw_reborn_composition/src/webui/facade.rs
+++ b/crates/ironclaw_reborn_composition/src/webui/facade.rs
@@ -872,6 +872,11 @@ fn status_response_from_readiness(readiness: &RebornReadiness) -> RebornOperator
             RebornOperatorStatusSeverity::Warning,
             Some("mounted-volume hosted preview is ready for single-tenant validation but is not production storage".to_string()),
         ),
+        crate::RebornReadinessState::HostedSingleTenantMultiUserValidated => (
+            RebornOperatorStatusState::Ready,
+            RebornOperatorStatusSeverity::Info,
+            None,
+        ),
         crate::RebornReadinessState::ProductionValidated => (
             RebornOperatorStatusState::Ready,
             RebornOperatorStatusSeverity::Info,

--- a/crates/ironclaw_reborn_composition/tests/profile_acceptance.rs
+++ b/crates/ironclaw_reborn_composition/tests/profile_acceptance.rs
@@ -7,8 +7,9 @@ use ironclaw_reborn_composition::{
     RebornLocalRuntimeProfileOptions, RebornReadiness, RebornReadinessDiagnostic,
     RebornReadinessDiagnosticComponent, RebornReadinessDiagnosticReason,
     RebornReadinessDiagnosticStatus, RebornReadinessState, RebornWorkerReadiness,
-    build_reborn_services, hosted_single_tenant_volume_runtime_policy,
-    local_dev_yolo_runtime_policy, local_runtime_build_input_with_options,
+    build_reborn_services, hosted_single_tenant_multi_user_runtime_policy,
+    hosted_single_tenant_volume_runtime_policy, local_dev_yolo_runtime_policy,
+    local_runtime_build_input_with_options,
 };
 
 use ironclaw_host_api::runtime_policy::{FilesystemBackendKind, RuntimeProfile, SecretMode};
@@ -66,6 +67,18 @@ fn profile_parse_accepts_kebab_and_snake_case() {
         RebornCompositionProfile::HostedSingleTenantVolume
     );
     assert_eq!(
+        "hosted_single_tenant_multi_user"
+            .parse::<RebornCompositionProfile>()
+            .unwrap(),
+        RebornCompositionProfile::HostedSingleTenantMultiUser
+    );
+    assert_eq!(
+        "hosted-single-tenant-multi-user"
+            .parse::<RebornCompositionProfile>()
+            .unwrap(),
+        RebornCompositionProfile::HostedSingleTenantMultiUser
+    );
+    assert_eq!(
         "migration-dry-run"
             .parse::<RebornCompositionProfile>()
             .unwrap(),
@@ -80,6 +93,7 @@ fn full_graph_profiles_match_production_strictness() {
     assert!(!RebornCompositionProfile::LocalDevYolo.requires_production_shape());
     assert!(!RebornCompositionProfile::HostedSingleTenant.requires_production_shape());
     assert!(!RebornCompositionProfile::HostedSingleTenantVolume.requires_production_shape());
+    assert!(!RebornCompositionProfile::HostedSingleTenantMultiUser.requires_production_shape());
     assert!(RebornCompositionProfile::Production.requires_production_shape());
     assert!(RebornCompositionProfile::MigrationDryRun.requires_production_shape());
 }
@@ -91,6 +105,7 @@ fn profile_predicates_capture_hosted_volume_substrate_contract() {
     assert!(RebornCompositionProfile::LocalDevYolo.uses_local_runtime_substrate());
     assert!(RebornCompositionProfile::HostedSingleTenant.uses_local_runtime_substrate());
     assert!(RebornCompositionProfile::HostedSingleTenantVolume.uses_local_runtime_substrate());
+    assert!(RebornCompositionProfile::HostedSingleTenantMultiUser.uses_local_runtime_substrate());
     assert!(!RebornCompositionProfile::Production.uses_local_runtime_substrate());
     assert!(!RebornCompositionProfile::MigrationDryRun.uses_local_runtime_substrate());
 
@@ -99,6 +114,7 @@ fn profile_predicates_capture_hosted_volume_substrate_contract() {
     assert!(RebornCompositionProfile::LocalDevYolo.uses_local_dev_storage_input());
     assert!(!RebornCompositionProfile::HostedSingleTenant.uses_local_dev_storage_input());
     assert!(RebornCompositionProfile::HostedSingleTenantVolume.uses_local_dev_storage_input());
+    assert!(!RebornCompositionProfile::HostedSingleTenantMultiUser.uses_local_dev_storage_input());
     assert!(!RebornCompositionProfile::Production.uses_local_dev_storage_input());
     assert!(!RebornCompositionProfile::MigrationDryRun.uses_local_dev_storage_input());
 
@@ -112,6 +128,10 @@ fn profile_predicates_capture_hosted_volume_substrate_contract() {
         RebornCompositionProfile::HostedSingleTenantVolume
             .uses_hosted_extension_installation_state()
     );
+    assert!(
+        RebornCompositionProfile::HostedSingleTenantMultiUser
+            .uses_hosted_extension_installation_state()
+    );
     assert!(!RebornCompositionProfile::Production.uses_hosted_extension_installation_state());
     assert!(!RebornCompositionProfile::MigrationDryRun.uses_hosted_extension_installation_state());
 
@@ -120,8 +140,24 @@ fn profile_predicates_capture_hosted_volume_substrate_contract() {
     assert!(RebornCompositionProfile::LocalDevYolo.starts_live_runtime());
     assert!(RebornCompositionProfile::HostedSingleTenant.starts_live_runtime());
     assert!(RebornCompositionProfile::HostedSingleTenantVolume.starts_live_runtime());
+    assert!(RebornCompositionProfile::HostedSingleTenantMultiUser.starts_live_runtime());
     assert!(RebornCompositionProfile::Production.starts_live_runtime());
     assert!(!RebornCompositionProfile::MigrationDryRun.starts_live_runtime());
+
+    assert!(!RebornCompositionProfile::Disabled.uses_hosted_single_tenant_postgres_storage_input());
+    assert!(
+        RebornCompositionProfile::HostedSingleTenant
+            .uses_hosted_single_tenant_postgres_storage_input()
+    );
+    assert!(
+        RebornCompositionProfile::HostedSingleTenantMultiUser
+            .uses_hosted_single_tenant_postgres_storage_input()
+    );
+    assert!(
+        !RebornCompositionProfile::HostedSingleTenantVolume
+            .uses_hosted_single_tenant_postgres_storage_input()
+    );
+    assert!(!RebornCompositionProfile::LocalDev.uses_hosted_single_tenant_postgres_storage_input());
 }
 
 #[test]
@@ -153,6 +189,21 @@ fn local_dev_yolo_runtime_policy_requires_disclosure() {
 fn hosted_single_tenant_volume_runtime_policy_is_processless_secure_default() {
     let policy =
         hosted_single_tenant_volume_runtime_policy().expect("hosted volume policy resolves");
+
+    assert_eq!(policy.process_backend.as_str(), "none");
+    assert_eq!(policy.filesystem_backend.as_str(), "scoped_virtual");
+    assert_eq!(policy.secret_mode.as_str(), "brokered_handles");
+    assert_eq!(policy.network_mode.as_str(), "brokered");
+}
+
+#[test]
+fn hosted_single_tenant_multi_user_runtime_policy_is_processless_secure_default() {
+    // issue #6170: hosted-single-tenant-multi-user must resolve the exact same
+    // sandboxed HostedMultiTenant+SecureDefault shape as the volume-backed
+    // preview profile — Postgres storage differs, process/filesystem/secret/
+    // network policy must not.
+    let policy = hosted_single_tenant_multi_user_runtime_policy()
+        .expect("hosted multi-user policy resolves");
 
     assert_eq!(policy.process_backend.as_str(), "none");
     assert_eq!(policy.filesystem_backend.as_str(), "scoped_virtual");
@@ -384,6 +435,7 @@ fn production_blocker_rejects_non_production_shaped_profiles() {
         RebornCompositionProfile::LocalDevYolo,
         RebornCompositionProfile::HostedSingleTenant,
         RebornCompositionProfile::HostedSingleTenantVolume,
+        RebornCompositionProfile::HostedSingleTenantMultiUser,
     ] {
         let diagnostic = RebornReadinessDiagnostic::production_blocker(
             profile,
@@ -439,6 +491,26 @@ fn hosted_single_tenant_volume_is_visible_as_preview_readiness() {
     );
     assert_eq!(diagnostic.status, RebornReadinessDiagnosticStatus::Warning);
     assert!(diagnostic.blocks_production);
+}
+
+#[test]
+fn hosted_single_tenant_multi_user_is_visible_as_ready_readiness() {
+    let diagnostic = RebornReadinessDiagnostic::hosted_single_tenant_multi_user();
+
+    assert_eq!(
+        diagnostic.profile,
+        RebornCompositionProfile::HostedSingleTenantMultiUser
+    );
+    assert_eq!(
+        diagnostic.component,
+        RebornReadinessDiagnosticComponent::CompositionProfile
+    );
+    assert_eq!(
+        diagnostic.reason,
+        RebornReadinessDiagnosticReason::HostedSingleTenantMultiUser
+    );
+    assert_eq!(diagnostic.status, RebornReadinessDiagnosticStatus::Info);
+    assert!(!diagnostic.blocks_production);
 }
 
 #[cfg(feature = "libsql")]

--- a/crates/ironclaw_reborn_config/src/home.rs
+++ b/crates/ironclaw_reborn_config/src/home.rs
@@ -328,7 +328,7 @@ impl fmt::Display for RebornConfigError {
             ),
             Self::InvalidProfile { name, value } => write!(
                 formatter,
-                "{name} must be one of local-dev, local-dev-yolo, hosted-single-tenant, hosted-single-tenant-volume, production, migration-dry-run; got {value:?}"
+                "{name} must be one of local-dev, local-dev-yolo, hosted-single-tenant, hosted-single-tenant-volume, hosted-single-tenant-multi-user, production, migration-dry-run; got {value:?}"
             ),
         }
     }

--- a/crates/ironclaw_reborn_config/src/profile.rs
+++ b/crates/ironclaw_reborn_config/src/profile.rs
@@ -22,6 +22,15 @@ pub enum RebornProfile {
     /// persistent volume. Intended for SSO-only Railway-style deployments while
     /// the full PostgreSQL production composition continues to mature.
     HostedSingleTenantVolume,
+    /// Single-tenant hosted startup with durable PostgreSQL storage, same as
+    /// `HostedSingleTenant`, but running under the sandboxed
+    /// `HostedMultiTenant`+`SecureDefault` runtime policy (no host process
+    /// execution) instead of the shell-capable local-dev policy shape.
+    ///
+    /// The delta is sandboxing only: storage and owner scoping are unchanged
+    /// from `HostedSingleTenant`; this profile does not add per-user data
+    /// isolation.
+    HostedSingleTenantMultiUser,
     /// Production startup. Future runtime composition must fail closed here if
     /// required durable services are absent.
     Production,
@@ -31,11 +40,12 @@ pub enum RebornProfile {
 }
 
 impl RebornProfile {
-    const ALL: [Self; 6] = [
+    const ALL: [Self; 7] = [
         Self::LocalDev,
         Self::LocalDevYolo,
         Self::HostedSingleTenant,
         Self::HostedSingleTenantVolume,
+        Self::HostedSingleTenantMultiUser,
         Self::Production,
         Self::MigrationDryRun,
     ];
@@ -58,6 +68,7 @@ impl RebornProfile {
             Self::LocalDevYolo => "local-dev-yolo",
             Self::HostedSingleTenant => "hosted-single-tenant",
             Self::HostedSingleTenantVolume => "hosted-single-tenant-volume",
+            Self::HostedSingleTenantMultiUser => "hosted-single-tenant-multi-user",
             Self::Production => "production",
             Self::MigrationDryRun => "migration-dry-run",
         }
@@ -66,7 +77,9 @@ impl RebornProfile {
     pub fn starts_hosted_single_tenant_listener(self) -> bool {
         matches!(
             self,
-            Self::HostedSingleTenant | Self::HostedSingleTenantVolume
+            Self::HostedSingleTenant
+                | Self::HostedSingleTenantVolume
+                | Self::HostedSingleTenantMultiUser
         )
     }
 
@@ -81,6 +94,7 @@ impl RebornProfile {
         match self {
             Self::HostedSingleTenant => "hosted-single-tenant",
             Self::HostedSingleTenantVolume => "hosted-single-tenant-volume",
+            Self::HostedSingleTenantMultiUser => "hosted-single-tenant-multi-user",
             Self::LocalDev | Self::LocalDevYolo | Self::Production | Self::MigrationDryRun => {
                 "local-dev"
             }
@@ -94,6 +108,7 @@ impl RebornProfile {
                 | Self::LocalDevYolo
                 | Self::HostedSingleTenant
                 | Self::HostedSingleTenantVolume
+                | Self::HostedSingleTenantMultiUser
         )
     }
 }
@@ -107,6 +122,7 @@ impl FromStr for RebornProfile {
             "local-dev-yolo" => Ok(Self::LocalDevYolo),
             "hosted-single-tenant" => Ok(Self::HostedSingleTenant),
             "hosted-single-tenant-volume" => Ok(Self::HostedSingleTenantVolume),
+            "hosted-single-tenant-multi-user" => Ok(Self::HostedSingleTenantMultiUser),
             "production" => Ok(Self::Production),
             "migration-dry-run" => Ok(Self::MigrationDryRun),
             other => Err(RebornConfigError::InvalidProfile {

--- a/crates/ironclaw_reborn_config/tests/profile_contract.rs
+++ b/crates/ironclaw_reborn_config/tests/profile_contract.rs
@@ -16,6 +16,10 @@ fn profile_wire_values_are_stable() {
         RebornProfile::HostedSingleTenantVolume.as_str(),
         "hosted-single-tenant-volume"
     );
+    assert_eq!(
+        RebornProfile::HostedSingleTenantMultiUser.as_str(),
+        "hosted-single-tenant-multi-user"
+    );
     assert_eq!(RebornProfile::Production.as_str(), "production");
     assert_eq!(RebornProfile::MigrationDryRun.as_str(), "migration-dry-run");
 }
@@ -29,6 +33,7 @@ fn all_profiles_are_exposed_in_display_order() {
             RebornProfile::LocalDevYolo,
             RebornProfile::HostedSingleTenant,
             RebornProfile::HostedSingleTenantVolume,
+            RebornProfile::HostedSingleTenantMultiUser,
             RebornProfile::Production,
             RebornProfile::MigrationDryRun,
         ]
@@ -54,6 +59,10 @@ fn profile_parsing_accepts_expected_values() {
         Ok(RebornProfile::HostedSingleTenantVolume)
     );
     assert_eq!(
+        RebornProfile::from_str("hosted-single-tenant-multi-user"),
+        Ok(RebornProfile::HostedSingleTenantMultiUser)
+    );
+    assert_eq!(
         RebornProfile::from_str("production"),
         Ok(RebornProfile::Production)
     );
@@ -69,6 +78,7 @@ fn profile_predicates_capture_hosted_volume_local_runtime_contract() {
     assert!(!RebornProfile::LocalDevYolo.starts_hosted_single_tenant_listener());
     assert!(RebornProfile::HostedSingleTenant.starts_hosted_single_tenant_listener());
     assert!(RebornProfile::HostedSingleTenantVolume.starts_hosted_single_tenant_listener());
+    assert!(RebornProfile::HostedSingleTenantMultiUser.starts_hosted_single_tenant_listener());
     assert!(!RebornProfile::Production.starts_hosted_single_tenant_listener());
     assert!(!RebornProfile::MigrationDryRun.starts_hosted_single_tenant_listener());
 
@@ -76,6 +86,7 @@ fn profile_predicates_capture_hosted_volume_local_runtime_contract() {
     assert!(RebornProfile::LocalDevYolo.uses_standalone_local_runtime_volume());
     assert!(!RebornProfile::HostedSingleTenant.uses_standalone_local_runtime_volume());
     assert!(RebornProfile::HostedSingleTenantVolume.uses_standalone_local_runtime_volume());
+    assert!(!RebornProfile::HostedSingleTenantMultiUser.uses_standalone_local_runtime_volume());
     assert!(!RebornProfile::Production.uses_standalone_local_runtime_volume());
     assert!(!RebornProfile::MigrationDryRun.uses_standalone_local_runtime_volume());
 
@@ -96,6 +107,10 @@ fn profile_predicates_capture_hosted_volume_local_runtime_contract() {
         "hosted-single-tenant-volume"
     );
     assert_eq!(
+        RebornProfile::HostedSingleTenantMultiUser.local_runtime_storage_subdir(),
+        "hosted-single-tenant-multi-user"
+    );
+    assert_eq!(
         RebornProfile::Production.local_runtime_storage_subdir(),
         "local-dev"
     );
@@ -108,6 +123,7 @@ fn profile_predicates_capture_hosted_volume_local_runtime_contract() {
     assert!(RebornProfile::LocalDevYolo.supports_local_runtime_skill_management());
     assert!(RebornProfile::HostedSingleTenant.supports_local_runtime_skill_management());
     assert!(RebornProfile::HostedSingleTenantVolume.supports_local_runtime_skill_management());
+    assert!(RebornProfile::HostedSingleTenantMultiUser.supports_local_runtime_skill_management());
     assert!(!RebornProfile::Production.supports_local_runtime_skill_management());
     assert!(!RebornProfile::MigrationDryRun.supports_local_runtime_skill_management());
 }

--- a/docs/plans/composition-pubuse.snapshot
+++ b/docs/plans/composition-pubuse.snapshot
@@ -67,8 +67,9 @@ pub use llm_admin::provider_admin_product_command::RebornProviderAdminProductCom
 pub use llm_admin::provider_repo::{ProviderRepo, ProviderRepoError};
 pub use local_runtime_profile::{
     RebornLocalRuntimeProfileError, RebornLocalRuntimeProfileOptions,
-    hosted_single_tenant_runtime_policy, hosted_single_tenant_volume_runtime_policy,
-    local_dev_runtime_policy, local_dev_yolo_runtime_policy, local_runtime_build_input,
+    hosted_single_tenant_multi_user_runtime_policy, hosted_single_tenant_runtime_policy,
+    hosted_single_tenant_volume_runtime_policy, local_dev_runtime_policy,
+    local_dev_yolo_runtime_policy, local_runtime_build_input,
     local_runtime_build_input_with_options,
 };
 pub use observability::budget::build_default_budget_accountant;


### PR DESCRIPTION
## Bug (verified)

Multi-user instances served under `hosted-single-tenant` hand every WebUI user an unsandboxed host shell. Verified on base `c17cd940d`: `hosted_single_tenant_runtime_policy()` delegates to `local_runtime_policy_for_local_dev_shape`, which hard-codes the LocalDev shape → `resolve(LocalSingleUser, LocalDev)` → resolver row with `ProcessBackendKind::LocalHost` and `FilesystemBackendKind::HostWorkspace` (`crates/ironclaw_runtime_policy/src/resolver.rs`). Shell is process-port-backed, so any user's `ls -al /` runs on the real host filesystem.

## Fix

`hosted-single-tenant` is intentionally **unchanged** — existing single-user deployments rely on its shell. Instead this adds one new composition profile:

- **`hosted-single-tenant-multi-user`** — identical wiring to `hosted-single-tenant` (same Postgres storage input path, listener, trigger-access store, skill management), but its runtime policy is the **existing** resolver row `resolve(HostedMultiTenant, SecureDefault)`: `process_backend: None` (shell structurally impossible — no process backend exists to plan against), scoped virtual filesystem, brokered network + secrets, ask-always approvals. Zero new policy logic; the row is shared with `hosted-single-tenant-volume` via one private helper so the two cannot drift, and is already pinned by the resolver invariant test `hosted_family_never_resolves_to_provider_host_filesystem_or_shell`.
- Storage-pairing guards collapse to one predicate (`uses_hosted_single_tenant_postgres_storage_input`) used at all four guard sites.
- Dedicated readiness state `HostedSingleTenantMultiUserValidated` + cutover-gate arm, so the shell-capable profile's readiness can never validate the sandboxed profile's startup (and vice versa).
- Distinct local scratch subdir, so the shell-capable and sandboxed profiles never share runtime scratch state.

Operators of multi-user instances switch with `IRONCLAW_REBORN_PROFILE=hosted-single-tenant-multi-user`.

## Regression tests (red → green)

Red evidence: with production sources at base and only the new tests applied, compilation fails (`E0599: no variant ... HostedSingleTenantMultiUser`, `E0432` unresolved policy import).

- `hosted_single_tenant_multi_user_runtime_policy_is_processless_secure_default` (profile_acceptance) — pins `process_backend == "none"`, `scoped_virtual`, `brokered_handles`, `brokered`.
- `build_runtime_input_hosted_single_tenant_multi_user_constructs_postgres_input` (CLI) — full boot path asserts `secure_default` policy, `process_backend == "none"`, distinct scratch subdir.
- `hosted_single_tenant_multi_user_rejects_local_dev_storage_input` (factory) — storage pairing fails closed.
- `runtime_cutover_gate_allows_hosted_single_tenant_multi_user_readiness` / `runtime_cutover_gate_rejects_foreign_hosted_readiness_for_multi_user` — gate discrimination between shell-capable and sandboxed postures.
- Parse/predicate/`profile list` contract tests extended in `profile_acceptance.rs`, `profile_contract.rs`, `smoke.rs`.

## Coverage limit

The Reborn integration harness structurally boots only `LocalDevYolo` (`tests/integration/support/harness/mod.rs`), and `wiring_parity`'s scope doc excludes `HostedSingleTenant*` — the integration tier cannot reach this profile's policy-resolution path, so coverage is crate-tier per `.claude/rules/testing.md`.

## Verification

- `cargo test -p ironclaw_reborn_composition --features libsql,postgres` (1197 lib + acceptance/factory suites)
- `cargo test -p ironclaw_reborn_config` / `-p ironclaw_reborn_cli --features postgres` (smoke 102)
- `cargo test -p ironclaw_architecture` (pub-use snapshot updated for the new policy fn)
- `cargo fmt --check`, `cargo clippy --tests --all-features` — clean, non-postgres CLI build warning-free
- Multi-agent code-review + thermo-nuclear maintainability review: no blockers; deferred follow-ups noted below

## Deferred (pre-existing patterns, out of scope)

- `enforce_runtime_cutover_gate` per-profile arms could be data-driven (third copy of a pre-existing shape).
- `hosted-single-tenant` remains shell-capable by design; the issue's structural proposals (derive deployment mode from observed multi-user facts, unconstructible host port in served contexts) remain open follow-ups.

Closes #6170

🤖 Generated with [Claude Code](https://claude.com/claude-code)