### PR TITLE
refactor(reborn): run-state + approval stores over RootFilesystem, delete InMemory*Store (§4.3)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -339,7 +339,7 @@ ironclaw_webui = { path = "crates/ironclaw_webui", version = "0.1.0" }
 ironclaw_slack_v2_adapter = { path = "crates/ironclaw_slack_v2_adapter", version = "0.1.0" }
 ironclaw_reborn_config = { path = "crates/ironclaw_reborn_config", version = "0.1.0" }
 ironclaw_reborn_openai_compat = { path = "crates/ironclaw_reborn_openai_compat", version = "0.1.0", features = ["openai-compat-beta"] }
-ironclaw_run_state = { path = "crates/ironclaw_run_state", version = "0.1.0" }
+ironclaw_run_state = { path = "crates/ironclaw_run_state", version = "0.1.0", features = ["test-support"] }
 ironclaw_threads = { path = "crates/ironclaw_threads", version = "0.1.0" }
 # `InMemoryDurableEventLog` for the W5-WEBUI-API-1 SSE scenario's test-local
 # `ProjectionStream` wiring (`build_webui_event_stream_for_test`).

--- a/crates/ironclaw_approvals/Cargo.toml
+++ b/crates/ironclaw_approvals/Cargo.toml
@@ -31,5 +31,7 @@ tracing = "0.1"
 [dev-dependencies]
 # Enables the in-memory-backed capability-lease store constructor for tests only.
 ironclaw_authorization = { path = "../ironclaw_authorization", features = ["test-support"] }
+# Enables the in-memory-backed run-state/approval store constructors for tests only.
+ironclaw_run_state = { path = "../ironclaw_run_state", features = ["test-support"] }
 tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }

--- a/crates/ironclaw_approvals/tests/approval_resolution_contract.rs
+++ b/crates/ironclaw_approvals/tests/approval_resolution_contract.rs
@@ -7,7 +7,7 @@ use ironclaw_run_state::*;
 
 #[tokio::test]
 async fn approving_pending_dispatch_request_issues_scoped_capability_lease() {
-    let approvals = InMemoryApprovalRequestStore::new();
+    let approvals = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = in_memory_backed_capability_lease_store();
     let resolver = ApprovalResolver::new(&approvals, &leases);
     let invocation_id = InvocationId::new();
@@ -67,7 +67,7 @@ async fn approving_pending_dispatch_request_issues_scoped_capability_lease() {
 
 #[tokio::test]
 async fn approving_pending_dispatch_request_preserves_reviewed_grant_constraints() {
-    let approvals = InMemoryApprovalRequestStore::new();
+    let approvals = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = in_memory_backed_capability_lease_store();
     let resolver = ApprovalResolver::new(&approvals, &leases);
     let invocation_id = InvocationId::new();
@@ -145,7 +145,7 @@ async fn approving_pending_request_marks_request_approved_even_when_lease_issue_
     // request must stay `Approved` (not roll back to `Pending`) so that
     // the system can surface the error to the caller and re-attempt
     // lease issuance later.
-    let approvals = InMemoryApprovalRequestStore::new();
+    let approvals = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = FailingIssueLeaseStore;
     let resolver = ApprovalResolver::new(&approvals, &leases);
     let invocation_id = InvocationId::new();
@@ -287,7 +287,7 @@ async fn approving_pending_request_issues_no_lease_when_status_was_resolved_conc
 
 #[tokio::test]
 async fn lease_from_approved_request_is_resume_only_and_not_plain_authority() {
-    let approvals = InMemoryApprovalRequestStore::new();
+    let approvals = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = in_memory_backed_capability_lease_store();
     let resolver = ApprovalResolver::new(&approvals, &leases);
     let context = execution_context(CapabilitySet::default());
@@ -333,7 +333,7 @@ async fn lease_from_approved_request_is_resume_only_and_not_plain_authority() {
 
 #[tokio::test]
 async fn approving_dispatch_without_fingerprint_fails_without_lease_or_status_change() {
-    let approvals = InMemoryApprovalRequestStore::new();
+    let approvals = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = in_memory_backed_capability_lease_store();
     let resolver = ApprovalResolver::new(&approvals, &leases);
     let invocation_id = InvocationId::new();
@@ -384,7 +384,7 @@ async fn approving_dispatch_without_fingerprint_fails_without_lease_or_status_ch
 
 #[tokio::test]
 async fn approving_pending_dispatch_request_emits_redacted_approval_audit_event() {
-    let approvals = InMemoryApprovalRequestStore::new();
+    let approvals = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = in_memory_backed_capability_lease_store();
     let audit = InMemoryAuditSink::new();
     let resolver = ApprovalResolver::new(&approvals, &leases).with_audit_sink(&audit);
@@ -441,7 +441,7 @@ async fn approving_pending_dispatch_request_emits_redacted_approval_audit_event(
 
 #[tokio::test]
 async fn denying_pending_dispatch_request_emits_redacted_approval_audit_event() {
-    let approvals = InMemoryApprovalRequestStore::new();
+    let approvals = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = in_memory_backed_capability_lease_store();
     let audit = InMemoryAuditSink::new();
     let resolver = ApprovalResolver::new(&approvals, &leases).with_audit_sink(&audit);
@@ -488,7 +488,7 @@ async fn denying_pending_dispatch_request_emits_redacted_approval_audit_event() 
 
 #[tokio::test]
 async fn approval_audit_event_sink_failure_does_not_change_resolution_outcome() {
-    let approvals = InMemoryApprovalRequestStore::new();
+    let approvals = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = in_memory_backed_capability_lease_store();
     let audit = FailingAuditSink;
     let resolver = ApprovalResolver::new(&approvals, &leases).with_audit_sink(&audit);
@@ -535,7 +535,7 @@ async fn approval_audit_event_sink_failure_does_not_change_resolution_outcome() 
 
 #[tokio::test]
 async fn denying_pending_request_does_not_issue_lease() {
-    let approvals = InMemoryApprovalRequestStore::new();
+    let approvals = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = in_memory_backed_capability_lease_store();
     let resolver = ApprovalResolver::new(&approvals, &leases);
     let invocation_id = InvocationId::new();
@@ -564,7 +564,7 @@ async fn denying_pending_request_does_not_issue_lease() {
 
 #[tokio::test]
 async fn denying_non_pending_request_fails_without_changing_status() {
-    let approvals = InMemoryApprovalRequestStore::new();
+    let approvals = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = in_memory_backed_capability_lease_store();
     let resolver = ApprovalResolver::new(&approvals, &leases);
     let invocation_id = InvocationId::new();
@@ -607,7 +607,7 @@ async fn denying_non_pending_request_fails_without_changing_status() {
 
 #[tokio::test]
 async fn approving_request_from_other_tenant_fails_closed() {
-    let approvals = InMemoryApprovalRequestStore::new();
+    let approvals = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = in_memory_backed_capability_lease_store();
     let resolver = ApprovalResolver::new(&approvals, &leases);
     let invocation_id = InvocationId::new();
@@ -653,7 +653,8 @@ async fn concurrent_approve_dispatch_on_same_request_is_first_write_wins() {
     // and the lease store ends up with exactly one lease — never two —
     // because under F2 ordering the approval write happens before lease
     // issuance, so a loser approval never reaches the lease store.
-    let approvals = std::sync::Arc::new(InMemoryApprovalRequestStore::new());
+    let approvals =
+        std::sync::Arc::new(ironclaw_run_state::in_memory_backed_approval_request_store());
     let leases = std::sync::Arc::new(in_memory_backed_capability_lease_store());
     let invocation_id = InvocationId::new();
     let scope = sample_scope(invocation_id, "tenant1", "user1");

--- a/crates/ironclaw_capabilities/Cargo.toml
+++ b/crates/ironclaw_capabilities/Cargo.toml
@@ -27,6 +27,8 @@ ironclaw_approvals = { path = "../ironclaw_approvals" }
 ironclaw_authorization = { path = "../ironclaw_authorization", features = ["test-support"] }
 # Enables the in-memory-backed process store constructors for tests only.
 ironclaw_processes = { path = "../ironclaw_processes", features = ["test-support"] }
+# Enables the in-memory-backed run-state/approval store constructors for tests only.
+ironclaw_run_state = { path = "../ironclaw_run_state", features = ["test-support"] }
 ironclaw_dispatcher = { path = "../ironclaw_dispatcher" }
 ironclaw_events = { path = "../ironclaw_events" }
 ironclaw_filesystem = { path = "../ironclaw_filesystem" }

--- a/crates/ironclaw_capabilities/tests/capability_host_auth_required_enrichment_contract.rs
+++ b/crates/ironclaw_capabilities/tests/capability_host_auth_required_enrichment_contract.rs
@@ -246,7 +246,7 @@ async fn invoke_json_preserves_non_empty_credential_requirements_from_dispatcher
 
 #[tokio::test]
 async fn auth_resume_json_enriches_auth_required_credential_requirements_from_obligations() {
-    use ironclaw_run_state::{InMemoryRunStateStore, RunStateStore, RunStatus};
+    use ironclaw_run_state::{RunStateStore, RunStatus};
 
     // A dispatcher that returns AuthRequired with an empty credential_requirements
     // list on every call (simulating a WASM adapter at both invoke and resume time).
@@ -276,7 +276,7 @@ async fn auth_resume_json_enriches_auth_required_credential_requirements_from_ob
     };
     let dispatcher = AlwaysAuthRequiredDispatcher;
     let handler = PassthroughObligationHandler;
-    let run_state = InMemoryRunStateStore::new();
+    let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
 
     let host = CapabilityHost::new(&registry, &dispatcher, &authorizer)
         .with_obligation_handler(&handler)

--- a/crates/ironclaw_capabilities/tests/capability_host_auth_resume_contract.rs
+++ b/crates/ironclaw_capabilities/tests/capability_host_auth_resume_contract.rs
@@ -44,7 +44,7 @@ async fn auth_resume_json_accepts_blocked_auth_run_and_dispatches() {
     let registry = registry_with_echo_capability();
     let authorizer = GrantAuthorizer::new();
     let dispatcher = RecordingDispatcher::default();
-    let run_state = InMemoryRunStateStore::new();
+    let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
 
     // Simulate a run that was previously blocked at an auth gate.
     let context = execution_context(CapabilitySet {
@@ -95,7 +95,7 @@ async fn auth_resume_preserves_original_actor_and_rejects_forged_actor() {
     let registry = registry_with_echo_capability();
     let authorizer = GrantAuthorizer::new();
     let dispatcher = RecordingDispatcher::default();
-    let run_state = InMemoryRunStateStore::new();
+    let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
 
     let mut alice_context = execution_context(CapabilitySet {
         grants: vec![dispatch_grant()],
@@ -175,8 +175,8 @@ async fn auth_resume_preserves_original_actor_and_rejects_forged_actor() {
 async fn auth_resume_json_rejects_run_in_blocked_approval_status() {
     let registry = registry_with_echo_capability();
     let dispatcher = RecordingDispatcher::default();
-    let run_state = InMemoryRunStateStore::new();
-    let approval_requests = InMemoryApprovalRequestStore::new();
+    let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
+    let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
 
     // Block the invocation at an approval gate (not auth).
     let block_host = CapabilityHost::new(&registry, &dispatcher, &ApprovalAuthorizer)
@@ -238,7 +238,7 @@ async fn auth_resume_json_rejects_run_in_running_status() {
     let registry = registry_with_echo_capability();
     let authorizer = GrantAuthorizer::new();
     let dispatcher = RecordingDispatcher::default();
-    let run_state = InMemoryRunStateStore::new();
+    let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
 
     let context = execution_context(CapabilitySet {
         grants: vec![dispatch_grant()],
@@ -293,8 +293,8 @@ async fn auth_resume_json_rejects_fingerprint_mismatch_on_approval_request() {
     // attempt auth_resume with different input — should reject before lease claim.
     let registry = registry_with_echo_capability();
     let dispatcher = RecordingDispatcher::default();
-    let run_state = InMemoryRunStateStore::new();
-    let approval_requests = InMemoryApprovalRequestStore::new();
+    let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
+    let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = in_memory_backed_capability_lease_store();
 
     // Phase 1: invoke (needs approval).
@@ -389,8 +389,8 @@ async fn auth_resume_json_with_approval_request_id_claims_active_lease_and_dispa
     // auth_resume_json → finds Active lease, claims it, dispatches.
     let registry = registry_with_echo_capability();
     let dispatcher = RecordingDispatcher::default();
-    let run_state = InMemoryRunStateStore::new();
-    let approval_requests = InMemoryApprovalRequestStore::new();
+    let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
+    let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = in_memory_backed_capability_lease_store();
 
     // Phase 1: first invocation triggers approval.
@@ -494,7 +494,7 @@ async fn auth_resume_json_rejects_capability_id_mismatch_against_run_record() {
     let registry = registry_with_echo_capability();
     let authorizer = GrantAuthorizer::new();
     let dispatcher = RecordingDispatcher::default();
-    let run_state = InMemoryRunStateStore::new();
+    let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
 
     // Start the run with the canonical capability_id.
     let context = execution_context(CapabilitySet {
@@ -564,8 +564,8 @@ async fn auth_resume_json_rejects_approval_not_yet_approved() {
     let registry = registry_with_echo_capability();
     let authorizer = GrantAuthorizer::new();
     let dispatcher = RecordingDispatcher::default();
-    let run_state = InMemoryRunStateStore::new();
-    let approval_requests = InMemoryApprovalRequestStore::new();
+    let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
+    let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = in_memory_backed_capability_lease_store();
 
     // Start and block at auth.
@@ -664,7 +664,7 @@ async fn auth_resume_json_returns_store_missing_when_approval_requests_absent() 
     let registry = registry_with_echo_capability();
     let authorizer = GrantAuthorizer::new();
     let dispatcher = RecordingDispatcher::default();
-    let run_state = InMemoryRunStateStore::new();
+    let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
 
     let context = execution_context(CapabilitySet {
         grants: vec![dispatch_grant()],
@@ -729,7 +729,7 @@ async fn auth_resume_json_without_approval_request_id_skips_lease_path_and_dispa
     let registry = registry_with_echo_capability();
     let authorizer = GrantAuthorizer::new();
     let dispatcher = RecordingDispatcher::default();
-    let run_state = InMemoryRunStateStore::new();
+    let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
 
     let context = execution_context(CapabilitySet {
         grants: vec![dispatch_grant()],
@@ -838,8 +838,8 @@ async fn auth_resume_after_real_approval_bounce_reuses_claimed_lease() {
 
     let registry = registry_with_echo_capability();
     let dispatcher = FirstCallAuthRequiredDispatcher::default();
-    let run_state = InMemoryRunStateStore::new();
-    let approval_requests = InMemoryApprovalRequestStore::new();
+    let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
+    let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = in_memory_backed_capability_lease_store();
 
     // ── Phase 1: invoke_json → BlockedApproval ──────────────────────────────
@@ -1075,8 +1075,8 @@ async fn auth_resume_json_terminal_dispatch_failure_revokes_claimed_lease() {
 
     let registry = registry_with_echo_capability();
     let dispatcher = TerminalFailDispatcher::default();
-    let run_state = InMemoryRunStateStore::new();
-    let approval_requests = InMemoryApprovalRequestStore::new();
+    let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
+    let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = in_memory_backed_capability_lease_store();
 
     // Phase 1: invoke → BlockedApproval.
@@ -1216,8 +1216,8 @@ async fn auth_resume_json_non_terminal_auth_bounce_leaves_lease_claimed() {
 
     let registry = registry_with_echo_capability();
     let dispatcher = AlwaysAuthRequiredDispatcher;
-    let run_state = InMemoryRunStateStore::new();
-    let approval_requests = InMemoryApprovalRequestStore::new();
+    let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
+    let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = in_memory_backed_capability_lease_store();
 
     // Phase 1: invoke → BlockedApproval.
@@ -1449,8 +1449,8 @@ async fn concurrent_auth_resume_claim_loser_returns_lease_error_without_failing_
 
     let registry = registry_with_echo_capability();
     let dispatcher = RecordingDispatcher::default();
-    let run_state = InMemoryRunStateStore::new();
-    let approval_requests = InMemoryApprovalRequestStore::new();
+    let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
+    let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = ClaimFailingLeaseStore::new();
 
     // Phase 1: invoke → BlockedApproval.
@@ -1560,8 +1560,8 @@ async fn auth_resume_json_returns_store_missing_when_capability_leases_absent() 
     let registry = registry_with_echo_capability();
     let authorizer = GrantAuthorizer::new();
     let dispatcher = RecordingDispatcher::default();
-    let run_state = InMemoryRunStateStore::new();
-    let approval_requests = InMemoryApprovalRequestStore::new();
+    let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
+    let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
 
     // Start and block at auth.
     let context = execution_context(CapabilitySet {
@@ -1645,8 +1645,8 @@ async fn auth_resume_json_rejected_prior_approval_fails_blocked_auth_run() {
     let registry = registry_with_echo_capability();
     let authorizer = GrantAuthorizer::new();
     let dispatcher = RecordingDispatcher::default();
-    let run_state = InMemoryRunStateStore::new();
-    let approval_requests = InMemoryApprovalRequestStore::new();
+    let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
+    let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = in_memory_backed_capability_lease_store();
 
     // Start and block at auth.
@@ -1946,8 +1946,9 @@ async fn concurrent_auth_resume_reuse_loser_does_not_double_dispatch() {
         in_dispatch: StdArc::clone(&in_dispatch),
         release: StdArc::clone(&release),
     });
-    let run_state = StdArc::new(InMemoryRunStateStore::new());
-    let approval_requests = StdArc::new(InMemoryApprovalRequestStore::new());
+    let run_state = StdArc::new(ironclaw_run_state::in_memory_backed_run_state_store());
+    let approval_requests =
+        StdArc::new(ironclaw_run_state::in_memory_backed_approval_request_store());
     let leases = StdArc::new(BarrierLeaseStore::new(StdArc::clone(&scan_barrier)));
 
     // ── Phase 1: invoke → BlockedApproval ──────────────────────────────────
@@ -2213,8 +2214,8 @@ async fn auth_resume_json_authorization_deny_revokes_dispatching_lease() {
     }
 
     let registry = registry_with_echo_capability();
-    let run_state = InMemoryRunStateStore::new();
-    let approval_requests = InMemoryApprovalRequestStore::new();
+    let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
+    let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = in_memory_backed_capability_lease_store();
 
     // ── Phase 1: invoke → BlockedApproval ──────────────────────────────────
@@ -2367,8 +2368,8 @@ async fn auth_resume_json_authorization_require_approval_revokes_dispatching_lea
     }
 
     let registry = registry_with_echo_capability();
-    let run_state = InMemoryRunStateStore::new();
-    let approval_requests = InMemoryApprovalRequestStore::new();
+    let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
+    let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = in_memory_backed_capability_lease_store();
 
     // ── Phase 1: invoke → BlockedApproval ──────────────────────────────────
@@ -2556,7 +2557,7 @@ async fn auth_resume_json_unknown_invocation_when_run_record_missing() {
     let registry = registry_with_echo_capability();
     let authorizer = GrantAuthorizer::new();
     let dispatcher = RecordingDispatcher::default();
-    let run_state = InMemoryRunStateStore::new();
+    let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
     // No run record seeded — the store is empty.
 
     let context = execution_context(CapabilitySet {
@@ -2611,8 +2612,10 @@ async fn auth_resume_json_unknown_invocation_when_run_record_missing() {
 /// Helper: seed a run record in BlockedAuth and build a host wired with all
 /// necessary stores for the approval-validation path.
 async fn setup_blocked_auth_run_with_stores(
-    run_state: &InMemoryRunStateStore,
-    approval_requests: &InMemoryApprovalRequestStore,
+    run_state: &ironclaw_run_state::FilesystemRunStateStore<ironclaw_filesystem::InMemoryBackend>,
+    approval_requests: &ironclaw_run_state::FilesystemApprovalRequestStore<
+        ironclaw_filesystem::InMemoryBackend,
+    >,
     leases: &FilesystemCapabilityLeaseStore<InMemoryBackend>,
     context: &ExecutionContext,
 ) {
@@ -2641,8 +2644,8 @@ async fn auth_resume_json_approval_request_mismatch_action() {
     let registry = registry_with_echo_capability();
     let authorizer = GrantAuthorizer::new();
     let dispatcher = RecordingDispatcher::default();
-    let run_state = InMemoryRunStateStore::new();
-    let approval_requests = InMemoryApprovalRequestStore::new();
+    let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
+    let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = in_memory_backed_capability_lease_store();
 
     let context = execution_context(CapabilitySet {
@@ -2725,8 +2728,8 @@ async fn auth_resume_json_approval_request_mismatch_correlation_id() {
     let registry = registry_with_echo_capability();
     let authorizer = GrantAuthorizer::new();
     let dispatcher = RecordingDispatcher::default();
-    let run_state = InMemoryRunStateStore::new();
-    let approval_requests = InMemoryApprovalRequestStore::new();
+    let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
+    let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = in_memory_backed_capability_lease_store();
 
     let context = execution_context(CapabilitySet {
@@ -2815,8 +2818,8 @@ async fn auth_resume_json_approval_request_mismatch_requested_by() {
     let registry = registry_with_echo_capability();
     let authorizer = GrantAuthorizer::new();
     let dispatcher = RecordingDispatcher::default();
-    let run_state = InMemoryRunStateStore::new();
-    let approval_requests = InMemoryApprovalRequestStore::new();
+    let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
+    let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = in_memory_backed_capability_lease_store();
 
     let context = execution_context(CapabilitySet {
@@ -3056,8 +3059,9 @@ async fn concurrent_auth_resume_fresh_active_lease_loser_does_not_double_dispatc
 
     let registry = StdArc::new(registry_with_echo_capability());
     let dispatcher = StdArc::new(RecordingDispatcher::default());
-    let run_state = StdArc::new(InMemoryRunStateStore::new());
-    let approval_requests = StdArc::new(InMemoryApprovalRequestStore::new());
+    let run_state = StdArc::new(ironclaw_run_state::in_memory_backed_run_state_store());
+    let approval_requests =
+        StdArc::new(ironclaw_run_state::in_memory_backed_approval_request_store());
     let leases = StdArc::new(GatedLeaseStore::new(
         StdArc::clone(&claim_entered),
         StdArc::clone(&claim_release),
@@ -3263,8 +3267,8 @@ async fn auth_resume_json_unknown_capability_does_not_strand_active_approval_lea
     let empty_registry = ironclaw_extensions::ExtensionRegistry::new();
     let authorizer = GrantAuthorizer::new();
     let dispatcher = RecordingDispatcher::default();
-    let run_state = InMemoryRunStateStore::new();
-    let approval_requests = InMemoryApprovalRequestStore::new();
+    let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
+    let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = in_memory_backed_capability_lease_store();
 
     // Seed the run in BlockedAuth state (as it would be after a prior auth gate).
@@ -3397,8 +3401,8 @@ async fn auth_resume_json_unknown_capability_does_not_strand_claimed_approval_le
     let empty_registry = ironclaw_extensions::ExtensionRegistry::new();
     let authorizer = GrantAuthorizer::new();
     let dispatcher = RecordingDispatcher::default();
-    let run_state = InMemoryRunStateStore::new();
-    let approval_requests = InMemoryApprovalRequestStore::new();
+    let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
+    let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = in_memory_backed_capability_lease_store();
 
     let context = execution_context(CapabilitySet {

--- a/crates/ironclaw_capabilities/tests/capability_host_auth_run_state_contract.rs
+++ b/crates/ironclaw_capabilities/tests/capability_host_auth_run_state_contract.rs
@@ -13,7 +13,7 @@ use support::*;
 async fn capability_host_blocks_auth_when_obligation_requires_secret_recovery() {
     let registry = registry_with_echo_capability();
     let dispatcher = RecordingDispatcher::default();
-    let run_state = InMemoryRunStateStore::new();
+    let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
     let handler = AuthRequiredObligationHandler;
     let host = CapabilityHost::new(&registry, &dispatcher, &ObligatingAuthorizer)
         .with_run_state(&run_state)
@@ -49,7 +49,7 @@ async fn capability_host_blocks_auth_when_dispatch_returns_auth_required() {
     // the run to BlockedAuth, not Failed, so auth-resume can pick it up.
     let registry = registry_with_echo_capability();
     let dispatcher = AuthRequiredDispatcher;
-    let run_state = InMemoryRunStateStore::new();
+    let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
     let authorizer = PlainAllowAuthorizer;
     let host = CapabilityHost::new(&registry, &dispatcher, &authorizer).with_run_state(&run_state);
     let context = execution_context(CapabilitySet::default());
@@ -87,7 +87,7 @@ async fn capability_host_blocks_auth_when_dispatch_returns_auth_required() {
 async fn capability_host_fails_post_dispatch_auth_required_without_retryable_gate() {
     let registry = registry_with_echo_capability();
     let dispatcher = RecordingDispatcher::default();
-    let run_state = InMemoryRunStateStore::new();
+    let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
     let handler = PostDispatchAuthRequiredObligationHandler;
     let host = CapabilityHost::new(&registry, &dispatcher, &ObligatingAuthorizer)
         .with_run_state(&run_state)

--- a/crates/ironclaw_capabilities/tests/capability_host_dispatcher_integration.rs
+++ b/crates/ironclaw_capabilities/tests/capability_host_dispatcher_integration.rs
@@ -24,7 +24,7 @@ async fn capability_host_invokes_through_runtime_dispatcher_and_completes_run() 
         json!({"via":"runtime-dispatcher"}),
     ));
     let (registry, dispatcher, governor, events) = runtime_dispatcher_stack(Arc::clone(&adapter));
-    let run_state = InMemoryRunStateStore::new();
+    let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
     let authorizer = GrantAuthorizer::new();
     let host =
         CapabilityHost::new(registry.as_ref(), &dispatcher, &authorizer).with_run_state(&run_state);
@@ -88,8 +88,8 @@ async fn capability_host_invokes_through_runtime_dispatcher_and_completes_run() 
 async fn capability_host_blocks_then_resumes_approved_dispatch_through_runtime_dispatcher() {
     let adapter = Arc::new(RecordingRuntimeAdapter::new(json!({"approved":true})));
     let (registry, dispatcher, _governor, events) = runtime_dispatcher_stack(Arc::clone(&adapter));
-    let run_state = InMemoryRunStateStore::new();
-    let approval_requests = InMemoryApprovalRequestStore::new();
+    let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
+    let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = in_memory_backed_capability_lease_store();
     let block_host = CapabilityHost::new(registry.as_ref(), &dispatcher, &ApprovalAuthorizer)
         .with_run_state(&run_state)
@@ -193,8 +193,8 @@ async fn capability_host_blocks_then_resumes_approved_dispatch_through_runtime_d
 async fn capability_host_rejects_resume_from_wrong_user_scope_without_dispatch_or_lease_claim() {
     let adapter = Arc::new(RecordingRuntimeAdapter::new(json!({"must_not":"dispatch"})));
     let (registry, dispatcher, _governor, _events) = runtime_dispatcher_stack(Arc::clone(&adapter));
-    let run_state = InMemoryRunStateStore::new();
-    let approval_requests = InMemoryApprovalRequestStore::new();
+    let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
+    let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = in_memory_backed_capability_lease_store();
     let block_host = CapabilityHost::new(registry.as_ref(), &dispatcher, &ApprovalAuthorizer)
         .with_run_state(&run_state)
@@ -279,8 +279,8 @@ async fn capability_host_rejects_resume_from_wrong_user_scope_without_dispatch_o
 async fn capability_host_rejects_expired_approval_lease_before_dispatch() {
     let adapter = Arc::new(RecordingRuntimeAdapter::new(json!({"must_not":"dispatch"})));
     let (registry, dispatcher, _governor, _events) = runtime_dispatcher_stack(Arc::clone(&adapter));
-    let run_state = InMemoryRunStateStore::new();
-    let approval_requests = InMemoryApprovalRequestStore::new();
+    let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
+    let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = in_memory_backed_capability_lease_store();
     let block_host = CapabilityHost::new(registry.as_ref(), &dispatcher, &ApprovalAuthorizer)
         .with_run_state(&run_state)
@@ -446,7 +446,9 @@ fn runtime_dispatcher_stack(
 }
 
 async fn approve_dispatch(
-    approval_requests: &InMemoryApprovalRequestStore,
+    approval_requests: &ironclaw_run_state::FilesystemApprovalRequestStore<
+        ironclaw_filesystem::InMemoryBackend,
+    >,
     leases: &FilesystemCapabilityLeaseStore<InMemoryBackend>,
     scope: &ResourceScope,
     approval_id: ApprovalRequestId,

--- a/crates/ironclaw_capabilities/tests/capability_host_github_comment_approval_contract.rs
+++ b/crates/ironclaw_capabilities/tests/capability_host_github_comment_approval_contract.rs
@@ -140,8 +140,9 @@ async fn capability_host_rejects_mutated_github_comment_issue_replay_before_disp
 struct GitHubCommentApprovalFixture {
     registry: ironclaw_extensions::ExtensionRegistry,
     dispatcher: RecordingDispatcher,
-    run_state: InMemoryRunStateStore,
-    approval_requests: InMemoryApprovalRequestStore,
+    run_state: ironclaw_run_state::FilesystemRunStateStore<ironclaw_filesystem::InMemoryBackend>,
+    approval_requests:
+        ironclaw_run_state::FilesystemApprovalRequestStore<ironclaw_filesystem::InMemoryBackend>,
     leases: FilesystemCapabilityLeaseStore<InMemoryBackend>,
     context: ExecutionContext,
     scope: ResourceScope,
@@ -155,8 +156,8 @@ struct GitHubCommentApprovalFixture {
 async fn blocked_github_comment_fixture() -> GitHubCommentApprovalFixture {
     let registry = registry_with_github_comment_capability();
     let dispatcher = RecordingDispatcher::default();
-    let run_state = InMemoryRunStateStore::new();
-    let approval_requests = InMemoryApprovalRequestStore::new();
+    let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
+    let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = in_memory_backed_capability_lease_store();
     let block_host = CapabilityHost::new(&registry, &dispatcher, &ApprovalAuthorizer)
         .with_run_state(&run_state)

--- a/crates/ironclaw_capabilities/tests/capability_host_process_integration.rs
+++ b/crates/ironclaw_capabilities/tests/capability_host_process_integration.rs
@@ -18,7 +18,7 @@ use support::*;
 async fn capability_host_spawn_runs_background_process_through_process_host() {
     let registry = registry_with_echo_capability();
     let dispatcher = RecordingDispatcher::default();
-    let run_state = InMemoryRunStateStore::new();
+    let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
     let process_services = ProcessServices::in_memory();
     let executor = Arc::new(RecordingSuccessExecutor::default());
     let process_manager = process_services.background_manager(Arc::clone(&executor));
@@ -154,7 +154,7 @@ async fn capability_spawn_process_host_hides_cross_scope_status_and_output() {
 async fn capability_host_spawn_fails_closed_on_unsupported_obligations_before_process_start() {
     let registry = registry_with_echo_capability();
     let dispatcher = RecordingDispatcher::default();
-    let run_state = InMemoryRunStateStore::new();
+    let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
     let process_services = ProcessServices::in_memory();
     let executor = Arc::new(RecordingSuccessExecutor::default());
     let process_manager = process_services.background_manager(Arc::clone(&executor));

--- a/crates/ironclaw_capabilities/tests/capability_host_run_state_contract.rs
+++ b/crates/ironclaw_capabilities/tests/capability_host_run_state_contract.rs
@@ -20,8 +20,8 @@ use support::*;
 async fn capability_host_blocks_for_approval_without_dispatch() {
     let registry = registry_with_echo_capability();
     let dispatcher = RecordingDispatcher::default();
-    let run_state = InMemoryRunStateStore::new();
-    let approval_requests = InMemoryApprovalRequestStore::new();
+    let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
+    let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let host = CapabilityHost::new(&registry, &dispatcher, &ApprovalAuthorizer)
         .with_run_state(&run_state)
         .with_approval_requests(&approval_requests);
@@ -102,8 +102,8 @@ output_schema_ref = "schemas/shell.output.v1.json"
     let mut registry = ExtensionRegistry::new();
     registry.insert(package).unwrap();
     let dispatcher = RecordingDispatcher::default();
-    let run_state = InMemoryRunStateStore::new();
-    let approval_requests = InMemoryApprovalRequestStore::new();
+    let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
+    let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let host = CapabilityHost::new(&registry, &dispatcher, &ApprovalAuthorizer)
         .with_run_state(&run_state)
         .with_approval_requests(&approval_requests);
@@ -214,7 +214,7 @@ async fn capability_host_separate_store_setters_clear_combined_atomic_path() {
     let registry = registry_with_echo_capability();
     let dispatcher = RecordingDispatcher::default();
     let combined = RecordingCombinedRunStateApprovalStore::new();
-    let separate_run_state = InMemoryRunStateStore::new();
+    let separate_run_state = ironclaw_run_state::in_memory_backed_run_state_store();
     let host = CapabilityHost::new(&registry, &dispatcher, &ApprovalAuthorizer)
         .with_run_state_approval_store(&combined)
         .with_run_state(&separate_run_state);
@@ -256,8 +256,8 @@ async fn capability_host_separate_store_setters_clear_combined_atomic_path() {
 async fn capability_host_leaves_run_blocked_when_resume_is_attempted_before_approval_resolves() {
     let registry = registry_with_echo_capability();
     let dispatcher = RecordingDispatcher::default();
-    let run_state = InMemoryRunStateStore::new();
-    let approval_requests = InMemoryApprovalRequestStore::new();
+    let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
+    let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = in_memory_backed_capability_lease_store();
     let block_host = CapabilityHost::new(&registry, &dispatcher, &ApprovalAuthorizer)
         .with_run_state(&run_state)
@@ -352,8 +352,8 @@ async fn assert_mismatched_approval_request_rejected(
 ) {
     let registry = registry_with_echo_capability();
     let dispatcher = RecordingDispatcher::default();
-    let run_state = InMemoryRunStateStore::new();
-    let approval_requests = InMemoryApprovalRequestStore::new();
+    let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
+    let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let authorizer = MismatchedApprovalRequestAuthorizer { mismatch };
     let host = CapabilityHost::new(&registry, &dispatcher, &authorizer)
         .with_run_state(&run_state)
@@ -396,7 +396,7 @@ async fn assert_mismatched_approval_request_rejected(
 async fn capability_host_does_not_point_run_at_approval_before_approval_is_persisted() {
     let registry = registry_with_echo_capability();
     let dispatcher = RecordingDispatcher::default();
-    let run_state = InMemoryRunStateStore::new();
+    let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
     let approval_requests = HangingSaveApprovalRequestStore::new();
     let host = CapabilityHost::new(&registry, &dispatcher, &ApprovalAuthorizer)
         .with_run_state(&run_state)
@@ -445,7 +445,7 @@ async fn capability_host_does_not_point_run_at_approval_before_approval_is_persi
 async fn capability_host_marks_run_failed_when_obligations_are_unsupported() {
     let registry = registry_with_echo_capability();
     let dispatcher = RecordingDispatcher::default();
-    let run_state = InMemoryRunStateStore::new();
+    let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
     let host = CapabilityHost::new(&registry, &dispatcher, &ObligatingAuthorizer)
         .with_run_state(&run_state);
     let context = execution_context(CapabilitySet::default());
@@ -508,7 +508,7 @@ async fn capability_host_returns_resume_business_error_when_run_state_fail_trans
     let registry = registry_with_echo_capability();
     let dispatcher = RecordingDispatcher::default();
     let run_state = FailOnFailRunStateStore::new();
-    let approval_requests = InMemoryApprovalRequestStore::new();
+    let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = in_memory_backed_capability_lease_store();
     let block_host = CapabilityHost::new(&registry, &dispatcher, &ApprovalAuthorizer)
         .with_run_state(&run_state)
@@ -636,8 +636,8 @@ async fn capability_host_does_not_orphan_approval_when_run_block_fails() {
 async fn capability_host_returns_specific_error_for_authorizer_fingerprint_mismatch() {
     let registry = registry_with_echo_capability();
     let dispatcher = RecordingDispatcher::default();
-    let run_state = InMemoryRunStateStore::new();
-    let approval_requests = InMemoryApprovalRequestStore::new();
+    let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
+    let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let host = CapabilityHost::new(&registry, &dispatcher, &MismatchedApprovalAuthorizer)
         .with_run_state(&run_state)
         .with_approval_requests(&approval_requests);
@@ -691,8 +691,8 @@ async fn capability_host_returns_dispatch_result_when_run_completion_fails_after
 async fn capability_host_resumes_approved_invocation_and_consumes_matching_lease() {
     let registry = registry_with_echo_capability();
     let dispatcher = RecordingDispatcher::default();
-    let run_state = InMemoryRunStateStore::new();
-    let approval_requests = InMemoryApprovalRequestStore::new();
+    let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
+    let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = in_memory_backed_capability_lease_store();
     let block_host = CapabilityHost::new(&registry, &dispatcher, &ApprovalAuthorizer)
         .with_run_state(&run_state)
@@ -813,7 +813,7 @@ async fn capability_host_returns_dispatch_result_when_run_completion_fails_after
     let registry = registry_with_echo_capability();
     let dispatcher = RecordingDispatcher::default();
     let run_state = FailCompleteRunStateStore::new();
-    let approval_requests = InMemoryApprovalRequestStore::new();
+    let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = in_memory_backed_capability_lease_store();
     let block_host = CapabilityHost::new(&registry, &dispatcher, &ApprovalAuthorizer)
         .with_run_state(&run_state)
@@ -885,8 +885,8 @@ async fn capability_host_returns_dispatch_result_when_run_completion_fails_after
 async fn capability_host_denies_resume_when_trust_ceiling_omits_capability_effect() {
     let registry = registry_with_echo_capability();
     let dispatcher = RecordingDispatcher::default();
-    let run_state = InMemoryRunStateStore::new();
-    let approval_requests = InMemoryApprovalRequestStore::new();
+    let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
+    let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = in_memory_backed_capability_lease_store();
     let block_host = CapabilityHost::new(&registry, &dispatcher, &ApprovalAuthorizer)
         .with_run_state(&run_state)
@@ -967,8 +967,8 @@ async fn capability_host_denies_resume_when_trust_ceiling_omits_capability_effec
 async fn capability_host_revokes_claimed_lease_when_dispatch_fails_after_resume() {
     let registry = registry_with_echo_capability();
     let dispatcher = FailingDispatcher;
-    let run_state = InMemoryRunStateStore::new();
-    let approval_requests = InMemoryApprovalRequestStore::new();
+    let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
+    let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = in_memory_backed_capability_lease_store();
     let block_dispatcher = RecordingDispatcher::default();
     let block_host = CapabilityHost::new(&registry, &block_dispatcher, &ApprovalAuthorizer)
@@ -1058,8 +1058,8 @@ async fn capability_host_revokes_claimed_lease_when_dispatch_fails_after_resume(
 async fn capability_host_returns_dispatch_result_when_lease_consume_fails_after_dispatch() {
     let registry = registry_with_echo_capability();
     let dispatcher = RecordingDispatcher::default();
-    let run_state = InMemoryRunStateStore::new();
-    let approval_requests = InMemoryApprovalRequestStore::new();
+    let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
+    let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = ConsumeFailingLeaseStore::new();
     let block_host = CapabilityHost::new(&registry, &dispatcher, &ApprovalAuthorizer)
         .with_run_state(&run_state)
@@ -1137,7 +1137,7 @@ async fn capability_host_does_not_overwrite_completed_run_when_concurrent_resume
     let dispatcher = RecordingDispatcher::default();
     let complete_notify = Arc::new(tokio::sync::Notify::new());
     let run_state = CompleteNotifyingRunStateStore::new(complete_notify.clone());
-    let approval_requests = InMemoryApprovalRequestStore::new();
+    let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = CoordinatedClaimConflictLeaseStore::new(complete_notify);
     let block_host = CapabilityHost::new(&registry, &dispatcher, &ApprovalAuthorizer)
         .with_run_state(&run_state)
@@ -1222,8 +1222,8 @@ async fn capability_host_does_not_overwrite_completed_run_when_concurrent_resume
 async fn capability_host_rejects_resume_with_mismatched_capability_id() {
     let registry = registry_with_echo_capability();
     let dispatcher = RecordingDispatcher::default();
-    let run_state = InMemoryRunStateStore::new();
-    let approval_requests = InMemoryApprovalRequestStore::new();
+    let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
+    let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = in_memory_backed_capability_lease_store();
     let block_host = CapabilityHost::new(&registry, &dispatcher, &ApprovalAuthorizer)
         .with_run_state(&run_state)
@@ -1289,8 +1289,8 @@ async fn capability_host_rejects_resume_with_mismatched_capability_id() {
 async fn capability_host_rejects_resume_with_mismatched_approval_request_id() {
     let registry = registry_with_echo_capability();
     let dispatcher = RecordingDispatcher::default();
-    let run_state = InMemoryRunStateStore::new();
-    let approval_requests = InMemoryApprovalRequestStore::new();
+    let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
+    let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = in_memory_backed_capability_lease_store();
     let block_host = CapabilityHost::new(&registry, &dispatcher, &ApprovalAuthorizer)
         .with_run_state(&run_state)
@@ -1355,8 +1355,8 @@ async fn capability_host_rejects_resume_with_mismatched_approval_request_id() {
 async fn capability_host_rejects_resume_with_mutated_input_before_lease_claim_or_dispatch() {
     let registry = registry_with_echo_capability();
     let dispatcher = RecordingDispatcher::default();
-    let run_state = InMemoryRunStateStore::new();
-    let approval_requests = InMemoryApprovalRequestStore::new();
+    let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
+    let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = in_memory_backed_capability_lease_store();
     let block_host = CapabilityHost::new(&registry, &dispatcher, &ApprovalAuthorizer)
         .with_run_state(&run_state)
@@ -1502,7 +1502,7 @@ impl TrustAwareCapabilityDispatchAuthorizer for MismatchedApprovalRequestAuthori
 }
 
 struct HangingSaveApprovalRequestStore {
-    inner: InMemoryApprovalRequestStore,
+    inner: ironclaw_run_state::FilesystemApprovalRequestStore<ironclaw_filesystem::InMemoryBackend>,
     save_started: std::sync::atomic::AtomicBool,
     save_started_notify: tokio::sync::Notify,
     release_save: tokio::sync::Notify,
@@ -1511,7 +1511,7 @@ struct HangingSaveApprovalRequestStore {
 impl HangingSaveApprovalRequestStore {
     fn new() -> Self {
         Self {
-            inner: InMemoryApprovalRequestStore::new(),
+            inner: ironclaw_run_state::in_memory_backed_approval_request_store(),
             save_started: std::sync::atomic::AtomicBool::new(false),
             save_started_notify: tokio::sync::Notify::new(),
             release_save: tokio::sync::Notify::new(),
@@ -1575,8 +1575,9 @@ impl ApprovalRequestStore for HangingSaveApprovalRequestStore {
 }
 
 struct RecordingCombinedRunStateApprovalStore {
-    runs: InMemoryRunStateStore,
-    approvals: InMemoryApprovalRequestStore,
+    runs: ironclaw_run_state::FilesystemRunStateStore<ironclaw_filesystem::InMemoryBackend>,
+    approvals:
+        ironclaw_run_state::FilesystemApprovalRequestStore<ironclaw_filesystem::InMemoryBackend>,
     combined_calls: AtomicUsize,
     separate_save_calls: AtomicUsize,
 }
@@ -1584,8 +1585,8 @@ struct RecordingCombinedRunStateApprovalStore {
 impl RecordingCombinedRunStateApprovalStore {
     fn new() -> Self {
         Self {
-            runs: InMemoryRunStateStore::new(),
-            approvals: InMemoryApprovalRequestStore::new(),
+            runs: ironclaw_run_state::in_memory_backed_run_state_store(),
+            approvals: ironclaw_run_state::in_memory_backed_approval_request_store(),
             combined_calls: AtomicUsize::new(0),
             separate_save_calls: AtomicUsize::new(0),
         }
@@ -1729,13 +1730,13 @@ impl RunStateApprovalStore for RecordingCombinedRunStateApprovalStore {
 }
 
 struct FailCompleteRunStateStore {
-    inner: InMemoryRunStateStore,
+    inner: ironclaw_run_state::FilesystemRunStateStore<ironclaw_filesystem::InMemoryBackend>,
 }
 
 impl FailCompleteRunStateStore {
     fn new() -> Self {
         Self {
-            inner: InMemoryRunStateStore::new(),
+            inner: ironclaw_run_state::in_memory_backed_run_state_store(),
         }
     }
 }
@@ -1804,13 +1805,13 @@ impl RunStateStore for FailCompleteRunStateStore {
 }
 
 struct FailBlockApprovalRunStateStore {
-    inner: InMemoryRunStateStore,
+    inner: ironclaw_run_state::FilesystemRunStateStore<ironclaw_filesystem::InMemoryBackend>,
 }
 
 impl FailBlockApprovalRunStateStore {
     fn new() -> Self {
         Self {
-            inner: InMemoryRunStateStore::new(),
+            inner: ironclaw_run_state::in_memory_backed_run_state_store(),
         }
     }
 }
@@ -1876,17 +1877,17 @@ impl RunStateStore for FailBlockApprovalRunStateStore {
     }
 }
 
-/// Spy over `InMemoryApprovalRequestStore`: records the `save_pending` id,
+/// Spy over `ironclaw_run_state::FilesystemApprovalRequestStore<ironclaw_filesystem::InMemoryBackend>`: records the `save_pending` id,
 /// since `run_state.fail()` clears `RunRecord.approval_request_id` (#5467).
 struct RecordingApprovalStore {
-    inner: InMemoryApprovalRequestStore,
+    inner: ironclaw_run_state::FilesystemApprovalRequestStore<ironclaw_filesystem::InMemoryBackend>,
     last_saved_id: Mutex<Option<ApprovalRequestId>>,
 }
 
 impl RecordingApprovalStore {
     fn new() -> Self {
         Self {
-            inner: InMemoryApprovalRequestStore::new(),
+            inner: ironclaw_run_state::in_memory_backed_approval_request_store(),
             last_saved_id: Mutex::new(None),
         }
     }
@@ -1954,14 +1955,14 @@ impl ApprovalRequestStore for RecordingApprovalStore {
 }
 
 struct CompleteNotifyingRunStateStore {
-    inner: InMemoryRunStateStore,
+    inner: ironclaw_run_state::FilesystemRunStateStore<ironclaw_filesystem::InMemoryBackend>,
     complete_notify: Arc<tokio::sync::Notify>,
 }
 
 impl CompleteNotifyingRunStateStore {
     fn new(complete_notify: Arc<tokio::sync::Notify>) -> Self {
         Self {
-            inner: InMemoryRunStateStore::new(),
+            inner: ironclaw_run_state::in_memory_backed_run_state_store(),
             complete_notify,
         }
     }
@@ -2031,13 +2032,13 @@ impl RunStateStore for CompleteNotifyingRunStateStore {
 }
 
 struct FailOnFailRunStateStore {
-    inner: InMemoryRunStateStore,
+    inner: ironclaw_run_state::FilesystemRunStateStore<ironclaw_filesystem::InMemoryBackend>,
 }
 
 impl FailOnFailRunStateStore {
     fn new() -> Self {
         Self {
-            inner: InMemoryRunStateStore::new(),
+            inner: ironclaw_run_state::in_memory_backed_run_state_store(),
         }
     }
 }

--- a/crates/ironclaw_capabilities/tests/capability_host_spawn_contract.rs
+++ b/crates/ironclaw_capabilities/tests/capability_host_spawn_contract.rs
@@ -18,8 +18,8 @@ async fn capability_host_blocks_spawn_for_approval_without_starting_process() {
     let registry = registry_with_echo_capability();
     let dispatcher = RecordingDispatcher::default();
     let process_manager = RecordingProcessManager::default();
-    let run_state = InMemoryRunStateStore::new();
-    let approval_requests = InMemoryApprovalRequestStore::new();
+    let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
+    let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let host = CapabilityHost::new(&registry, &dispatcher, &SpawnApprovalAuthorizer)
         .with_process_manager(&process_manager)
         .with_run_state(&run_state)
@@ -102,8 +102,8 @@ output_schema_ref = "schemas/shell.output.v1.json"
     registry.insert(package).unwrap();
     let dispatcher = RecordingDispatcher::default();
     let process_manager = RecordingProcessManager::default();
-    let run_state = InMemoryRunStateStore::new();
-    let approval_requests = InMemoryApprovalRequestStore::new();
+    let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
+    let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let host = CapabilityHost::new(&registry, &dispatcher, &ShellSpawnApprovalAuthorizer)
         .with_process_manager(&process_manager)
         .with_run_state(&run_state)
@@ -165,8 +165,8 @@ async fn capability_host_resumes_approved_spawn_and_consumes_matching_lease() {
     let registry = registry_with_echo_capability();
     let dispatcher = RecordingDispatcher::default();
     let process_manager = RecordingProcessManager::default();
-    let run_state = InMemoryRunStateStore::new();
-    let approval_requests = InMemoryApprovalRequestStore::new();
+    let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
+    let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = in_memory_backed_capability_lease_store();
     let block_host = CapabilityHost::new(&registry, &dispatcher, &SpawnApprovalAuthorizer)
         .with_process_manager(&process_manager)
@@ -416,13 +416,13 @@ impl RecordingProcessManager {
 }
 
 struct FailCompleteRunStateStore {
-    inner: InMemoryRunStateStore,
+    inner: ironclaw_run_state::FilesystemRunStateStore<ironclaw_filesystem::InMemoryBackend>,
 }
 
 impl FailCompleteRunStateStore {
     fn new() -> Self {
         Self {
-            inner: InMemoryRunStateStore::new(),
+            inner: ironclaw_run_state::in_memory_backed_run_state_store(),
         }
     }
 }

--- a/crates/ironclaw_host_runtime/Cargo.toml
+++ b/crates/ironclaw_host_runtime/Cargo.toml
@@ -81,6 +81,8 @@ ironclaw_authorization = { path = "../ironclaw_authorization", features = ["test
 ironclaw_event_projections = { path = "../ironclaw_event_projections" }
 # Enables the in-memory-backed process store constructors for tests only.
 ironclaw_processes = { path = "../ironclaw_processes", features = ["test-support"] }
+# Enables the in-memory-backed run-state/approval store constructors for tests only.
+ironclaw_run_state = { path = "../ironclaw_run_state", features = ["test-support"] }
 sha2 = "0.11"
 tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt", "sync", "time"] }

--- a/crates/ironclaw_host_runtime/src/services.rs
+++ b/crates/ironclaw_host_runtime/src/services.rs
@@ -49,7 +49,7 @@ use ironclaw_reborn_event_store::{
 use ironclaw_resources::{FilesystemResourceGovernor, InMemoryResourceGovernor, ResourceGovernor};
 use ironclaw_run_state::{
     ApprovalRequestStore, FilesystemApprovalRequestStore, FilesystemRunStateStore,
-    InMemoryApprovalRequestStore, InMemoryRunStateStore, RunStateApprovalStore, RunStateStore,
+    RunStateApprovalStore, RunStateStore,
 };
 use ironclaw_scripts::{ScriptError, ScriptExecutionRequest, ScriptExecutor, ScriptInvocation};
 use ironclaw_secrets::{

--- a/crates/ironclaw_host_runtime/src/services/production_wiring.rs
+++ b/crates/ironclaw_host_runtime/src/services/production_wiring.rs
@@ -6,13 +6,13 @@ use ironclaw_approvals::FilesystemPersistentApprovalPolicyStore;
 use ironclaw_authorization::FilesystemCapabilityLeaseStore;
 use ironclaw_filesystem::InMemoryBackend;
 use ironclaw_processes::{FilesystemProcessResultStore, FilesystemProcessStore};
+use ironclaw_run_state::{FilesystemApprovalRequestStore, FilesystemRunStateStore};
 
 use super::{
-    DurableAuditSink, DurableEventSink, EmptyWasmRuntimeCredentials, InMemoryApprovalRequestStore,
-    InMemoryAuditSink, InMemoryCredentialBroker, InMemoryDurableAuditLog, InMemoryDurableEventLog,
-    InMemoryEventSink, InMemoryResourceGovernor, InMemoryRunStateStore, InMemorySecretStore,
-    InMemoryTurnStateStore, LocalFilesystem, LocalHostProcessPort, NoopTurnRunWakeNotifier,
-    RebornEventStoreError, RuntimeKind,
+    DurableAuditSink, DurableEventSink, EmptyWasmRuntimeCredentials, InMemoryAuditSink,
+    InMemoryCredentialBroker, InMemoryDurableAuditLog, InMemoryDurableEventLog, InMemoryEventSink,
+    InMemoryResourceGovernor, InMemorySecretStore, InMemoryTurnStateStore, LocalFilesystem,
+    LocalHostProcessPort, NoopTurnRunWakeNotifier, RebornEventStoreError, RuntimeKind,
 };
 
 #[derive(Debug, Error)]
@@ -299,8 +299,13 @@ fn classify_component_type<T: ?Sized + 'static>() -> ProductionImplementationRea
             // still local-only; libSQL/Postgres monomorphizations are distinct.
             || type_id == TypeId::of::<FilesystemProcessStore<InMemoryBackend>>()
             || type_id == TypeId::of::<FilesystemProcessResultStore<InMemoryBackend>>()
-            || type_id == TypeId::of::<InMemoryRunStateStore>()
-            || type_id == TypeId::of::<InMemoryApprovalRequestStore>()
+            // The run-state and approval-request stores no longer have bespoke
+            // in-memory implementations; "in-memory" is the `InMemoryBackend`
+            // behind the one production `Filesystem*Store<F>` (arch-simplification
+            // §4.3). A store backed by `InMemoryBackend` is still local-only;
+            // libSQL/Postgres monomorphizations are distinct.
+            || type_id == TypeId::of::<FilesystemRunStateStore<InMemoryBackend>>()
+            || type_id == TypeId::of::<FilesystemApprovalRequestStore<InMemoryBackend>>()
             // The persistent-approval and capability-lease stores no longer have
             // bespoke in-memory implementations; "in-memory" is now the
             // `InMemoryBackend` behind the one production `Filesystem*Store<F>`

--- a/crates/ironclaw_host_runtime/tests/first_party_runtime_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_runtime_contract.rs
@@ -25,7 +25,7 @@ use ironclaw_network::{
     NetworkHttpEgress, NetworkHttpError, NetworkHttpRequest, NetworkHttpResponse, NetworkUsage,
 };
 use ironclaw_resources::{InMemoryResourceGovernor, ResourceAccount, ResourceTally};
-use ironclaw_run_state::{InMemoryRunStateStore, RunStateStore, RunStatus};
+use ironclaw_run_state::{RunStateStore, RunStatus};
 use ironclaw_secrets::{InMemorySecretStore, SecretMaterial, SecretStore};
 use ironclaw_trust::{
     AdminConfig, AdminEntry, AuthorityCeiling, EffectiveTrustClass, HostTrustAssignment,
@@ -43,7 +43,7 @@ async fn host_runtime_invokes_first_party_handler_through_capability_host() {
     let first_party =
         FirstPartyCapabilityRegistry::new().with_handler(capability_id(), Arc::clone(&handler));
     let events = InMemoryEventSink::new();
-    let run_state = Arc::new(InMemoryRunStateStore::new());
+    let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
     let governor = Arc::new(InMemoryResourceGovernor::new());
     let runtime = HostRuntimeServices::new(
         Arc::new(first_party_registry()),
@@ -454,7 +454,7 @@ async fn first_party_handler_panic_fails_closed_and_releases_reservation() {
     let first_party =
         FirstPartyCapabilityRegistry::new().with_handler(capability_id(), Arc::clone(&handler));
     let events = InMemoryEventSink::new();
-    let run_state = Arc::new(InMemoryRunStateStore::new());
+    let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
     let governor = Arc::new(InMemoryResourceGovernor::new());
     let runtime = HostRuntimeServices::new(
         Arc::new(first_party_registry()),

--- a/crates/ironclaw_host_runtime/tests/host_runtime_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_contract.rs
@@ -33,8 +33,8 @@ use ironclaw_processes::{
     ProcessError, ProcessRecord, ProcessResultStore, ProcessStart, ProcessStatus, ProcessStore,
 };
 use ironclaw_run_state::{
-    ApprovalRecord, ApprovalRequestStore, InMemoryApprovalRequestStore, InMemoryRunStateStore,
-    RunRecord, RunStart, RunStateApprovalStore, RunStateError, RunStateStore,
+    ApprovalRecord, ApprovalRequestStore, RunRecord, RunStart, RunStateApprovalStore,
+    RunStateError, RunStateStore,
 };
 use ironclaw_trust::{
     AdminConfig, AdminEntry, AuthorityCeiling, EffectiveTrustClass, HostTrustAssignment,
@@ -74,8 +74,8 @@ async fn default_runtime_returns_completed_outcome_for_authorized_dispatch() {
     let registry = Arc::new(registry_with_echo_capability());
     let dispatcher = Arc::new(RecordingDispatcher::default());
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
-    let run_state = Arc::new(InMemoryRunStateStore::new());
-    let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
+    let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
+    let approval_requests = Arc::new(ironclaw_run_state::in_memory_backed_approval_request_store());
 
     let runtime = DefaultHostRuntime::new(
         registry.clone(),
@@ -115,8 +115,8 @@ async fn default_runtime_surfaces_approval_required_with_persisted_request_id() 
     let registry = Arc::new(registry_with_echo_capability());
     let dispatcher = Arc::new(RecordingDispatcher::default());
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(ApprovalAuthorizer);
-    let run_state = Arc::new(InMemoryRunStateStore::new());
-    let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
+    let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
+    let approval_requests = Arc::new(ironclaw_run_state::in_memory_backed_approval_request_store());
     let leases: Arc<dyn ironclaw_authorization::CapabilityLeaseStore> =
         Arc::new(in_memory_backed_capability_lease_store());
 
@@ -226,11 +226,11 @@ async fn default_runtime_propagates_unavailable_when_run_state_lookup_fails_duri
     let registry = Arc::new(registry_with_echo_capability());
     let dispatcher = Arc::new(RecordingDispatcher::default());
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(ApprovalAuthorizer);
-    let inner_run_state = Arc::new(InMemoryRunStateStore::new());
+    let inner_run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
     let run_state: Arc<dyn RunStateStore> = Arc::new(FailingGetRunStateStore {
         inner: inner_run_state.clone(),
     });
-    let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
+    let approval_requests = Arc::new(ironclaw_run_state::in_memory_backed_approval_request_store());
     let leases: Arc<dyn ironclaw_authorization::CapabilityLeaseStore> =
         Arc::new(in_memory_backed_capability_lease_store());
 
@@ -273,7 +273,7 @@ async fn default_runtime_returns_failed_for_unknown_capability() {
     let registry = Arc::new(ExtensionRegistry::new());
     let dispatcher = Arc::new(RecordingDispatcher::default());
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
-    let run_state = Arc::new(InMemoryRunStateStore::new());
+    let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
     let runtime = DefaultHostRuntime::new(
         registry,
         dispatcher.clone(),
@@ -444,7 +444,7 @@ async fn default_runtime_status_propagates_unavailable_on_run_state_error() {
     let registry = Arc::new(ExtensionRegistry::new());
     let dispatcher = Arc::new(RecordingDispatcher::default());
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
-    let inner = Arc::new(InMemoryRunStateStore::new());
+    let inner = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
     let run_state: Arc<dyn RunStateStore> = Arc::new(FailingRecordsRunStateStore { inner });
     let runtime = DefaultHostRuntime::new(
         registry,
@@ -522,7 +522,7 @@ async fn default_runtime_status_filters_to_running_records_only() {
     let registry = Arc::new(registry_with_echo_capability());
     let dispatcher = Arc::new(RecordingDispatcher::default());
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
-    let run_state = Arc::new(InMemoryRunStateStore::new());
+    let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
 
     let runtime = DefaultHostRuntime::new(
         registry,
@@ -689,7 +689,7 @@ async fn default_runtime_status_reports_running_invocations_only() {
     let registry = Arc::new(registry_with_echo_capability());
     let dispatcher = Arc::new(RecordingDispatcher::default());
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
-    let run_state = Arc::new(InMemoryRunStateStore::new());
+    let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
 
     let runtime = DefaultHostRuntime::new(
         registry,
@@ -733,7 +733,7 @@ async fn default_runtime_cancel_reports_running_invocations_as_unsupported() {
     let registry = Arc::new(registry_with_echo_capability());
     let dispatcher = Arc::new(RecordingDispatcher::default());
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
-    let run_state = Arc::new(InMemoryRunStateStore::new());
+    let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
     let runtime = DefaultHostRuntime::new(
         registry,
         dispatcher,
@@ -937,7 +937,7 @@ async fn default_runtime_status_does_not_duplicate_process_backed_invocations() 
     let registry = Arc::new(registry_with_echo_capability());
     let dispatcher = Arc::new(RecordingDispatcher::default());
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
-    let run_state = Arc::new(InMemoryRunStateStore::new());
+    let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
     let process_store = Arc::new(ironclaw_processes::in_memory_backed_process_store());
     let runtime = DefaultHostRuntime::new(
         registry,
@@ -1068,10 +1068,10 @@ fn process_start(context: &ExecutionContext, process_id: ProcessId) -> ProcessSt
     }
 }
 
-/// Wraps an [`InMemoryRunStateStore`] but fails every `records_for_scope`
+/// Wraps an [`ironclaw_run_state::FilesystemRunStateStore<ironclaw_filesystem::InMemoryBackend>`] but fails every `records_for_scope`
 /// call so we can exercise the runtime-status error-propagation path.
 struct FailingRecordsRunStateStore {
-    inner: Arc<InMemoryRunStateStore>,
+    inner: Arc<ironclaw_run_state::FilesystemRunStateStore<ironclaw_filesystem::InMemoryBackend>>,
 }
 
 #[async_trait]
@@ -1196,12 +1196,12 @@ impl ProcessStore for FailingRecordsProcessStore {
     }
 }
 
-/// Wraps an [`InMemoryRunStateStore`] but fails every `get` call so we can
+/// Wraps an [`ironclaw_run_state::FilesystemRunStateStore<ironclaw_filesystem::InMemoryBackend>`] but fails every `get` call so we can
 /// exercise the approval-lookup error-propagation path. Writes pass through
 /// to the inner store so the capability host can complete its own
 /// `start`/`block_approval` writes before we reach the broken read.
 struct FailingGetRunStateStore {
-    inner: Arc<InMemoryRunStateStore>,
+    inner: Arc<ironclaw_run_state::FilesystemRunStateStore<ironclaw_filesystem::InMemoryBackend>>,
 }
 
 #[async_trait]
@@ -1268,8 +1268,9 @@ impl RunStateStore for FailingGetRunStateStore {
 }
 
 struct RecordingCombinedRunStateApprovalStore {
-    runs: InMemoryRunStateStore,
-    approvals: InMemoryApprovalRequestStore,
+    runs: ironclaw_run_state::FilesystemRunStateStore<ironclaw_filesystem::InMemoryBackend>,
+    approvals:
+        ironclaw_run_state::FilesystemApprovalRequestStore<ironclaw_filesystem::InMemoryBackend>,
     combined_calls: AtomicUsize,
     separate_save_calls: AtomicUsize,
 }
@@ -1277,8 +1278,8 @@ struct RecordingCombinedRunStateApprovalStore {
 impl RecordingCombinedRunStateApprovalStore {
     fn new() -> Self {
         Self {
-            runs: InMemoryRunStateStore::new(),
-            approvals: InMemoryApprovalRequestStore::new(),
+            runs: ironclaw_run_state::in_memory_backed_run_state_store(),
+            approvals: ironclaw_run_state::in_memory_backed_approval_request_store(),
             combined_calls: AtomicUsize::new(0),
             separate_save_calls: AtomicUsize::new(0),
         }

--- a/crates/ironclaw_host_runtime/tests/host_runtime_credential_preflight_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_credential_preflight_contract.rs
@@ -31,7 +31,6 @@ use ironclaw_host_runtime::{
 };
 use ironclaw_processes::ProcessServices;
 use ironclaw_resources::InMemoryResourceGovernor;
-use ironclaw_run_state::{InMemoryApprovalRequestStore, InMemoryRunStateStore};
 use ironclaw_secrets::{InMemorySecretStore, SecretMaterial, SecretStore};
 use ironclaw_trust::{
     AdminConfig, AdminEntry, AuthorityCeiling, EffectiveTrustClass, HostTrustAssignment,
@@ -185,8 +184,11 @@ fn trust_decision_with_dispatch_authority() -> TrustDecision {
 /// the flow proceeds to the approval gate.
 #[tokio::test]
 async fn product_auth_account_credential_does_not_trip_preflight() {
-    let run_state = Arc::new(InMemoryRunStateStore::new());
-    let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
+    let fs = ironclaw_run_state::in_memory_backed_run_state_filesystem();
+    let run_state = Arc::new(ironclaw_run_state::FilesystemRunStateStore::new(
+        std::sync::Arc::clone(&fs),
+    ));
+    let approval_requests = Arc::new(ironclaw_run_state::FilesystemApprovalRequestStore::new(fs));
     let capability_leases = Arc::new(in_memory_backed_capability_lease_store());
     let secret_store = Arc::new(InMemorySecretStore::new());
     // Deliberately do NOT seed any secret under "google_oauth_token".
@@ -243,8 +245,11 @@ async fn product_auth_account_credential_does_not_trip_preflight() {
 /// for SecretHandle credentials.
 #[tokio::test]
 async fn secret_handle_credential_absent_still_trips_preflight() {
-    let run_state = Arc::new(InMemoryRunStateStore::new());
-    let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
+    let fs = ironclaw_run_state::in_memory_backed_run_state_filesystem();
+    let run_state = Arc::new(ironclaw_run_state::FilesystemRunStateStore::new(
+        std::sync::Arc::clone(&fs),
+    ));
+    let approval_requests = Arc::new(ironclaw_run_state::FilesystemApprovalRequestStore::new(fs));
     let capability_leases = Arc::new(in_memory_backed_capability_lease_store());
     let secret_store = Arc::new(InMemorySecretStore::new());
     // No secret seeded — the SecretHandle pre-flight must fire.
@@ -303,8 +308,11 @@ async fn secret_handle_credential_absent_still_trips_preflight() {
 /// `credential_preflight_check`, not just the `secret_owner_scope` helper.
 #[tokio::test]
 async fn tenant_shared_secret_satisfies_credential_preflight() {
-    let run_state = Arc::new(InMemoryRunStateStore::new());
-    let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
+    let fs = ironclaw_run_state::in_memory_backed_run_state_filesystem();
+    let run_state = Arc::new(ironclaw_run_state::FilesystemRunStateStore::new(
+        std::sync::Arc::clone(&fs),
+    ));
+    let approval_requests = Arc::new(ironclaw_run_state::FilesystemApprovalRequestStore::new(fs));
     let capability_leases = Arc::new(in_memory_backed_capability_lease_store());
     let secret_store = Arc::new(InMemorySecretStore::new());
 

--- a/crates/ironclaw_host_runtime/tests/host_runtime_persistent_approvals_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_persistent_approvals_contract.rs
@@ -22,9 +22,7 @@ use ironclaw_host_runtime::{
 use ironclaw_processes::{
     ProcessError, ProcessManager, ProcessRecord, ProcessStart, ProcessStatus,
 };
-use ironclaw_run_state::{
-    InMemoryApprovalRequestStore, InMemoryRunStateStore, RunStart, RunStateStore, RunStatus,
-};
+use ironclaw_run_state::{RunStart, RunStateStore, RunStatus};
 use ironclaw_trust::{
     AdminConfig, AdminEntry, AuthorityCeiling, EffectiveTrustClass, HostTrustAssignment,
     HostTrustPolicy, TrustDecision, TrustProvenance,
@@ -36,8 +34,8 @@ async fn default_runtime_uses_persistent_policy_as_dispatch_authority() {
     let registry = Arc::new(registry_with_echo_capability());
     let dispatcher = Arc::new(RecordingDispatcher::default());
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
-    let run_state = Arc::new(InMemoryRunStateStore::new());
-    let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
+    let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
+    let approval_requests = Arc::new(ironclaw_run_state::in_memory_backed_approval_request_store());
     let policies = Arc::new(in_memory_backed_persistent_approval_policy_store());
     let context = execution_context_without_grants();
     policies
@@ -110,8 +108,8 @@ async fn default_runtime_uses_persistent_policy_as_auth_resume_authority() {
     let registry = Arc::new(registry_with_echo_capability());
     let dispatcher = Arc::new(RecordingDispatcher::default());
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
-    let run_state = Arc::new(InMemoryRunStateStore::new());
-    let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
+    let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
+    let approval_requests = Arc::new(ironclaw_run_state::in_memory_backed_approval_request_store());
     let policies = Arc::new(in_memory_backed_persistent_approval_policy_store());
     let context = execution_context_without_grants();
     let scope = context.resource_scope.clone();
@@ -205,8 +203,8 @@ async fn default_runtime_uses_user_grantee_persistent_policy_as_dispatch_authori
     let registry = Arc::new(registry_with_echo_capability());
     let dispatcher = Arc::new(RecordingDispatcher::default());
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
-    let run_state = Arc::new(InMemoryRunStateStore::new());
-    let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
+    let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
+    let approval_requests = Arc::new(ironclaw_run_state::in_memory_backed_approval_request_store());
     let policies = Arc::new(in_memory_backed_persistent_approval_policy_store());
     let context = execution_context_without_grants();
     policies
@@ -269,8 +267,8 @@ async fn default_runtime_uses_threadless_filesystem_policy_after_thread_change()
     let registry = Arc::new(registry_with_echo_capability());
     let dispatcher = Arc::new(RecordingDispatcher::default());
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
-    let run_state = Arc::new(InMemoryRunStateStore::new());
-    let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
+    let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
+    let approval_requests = Arc::new(ironclaw_run_state::in_memory_backed_approval_request_store());
     let scoped = scoped_approval_fs();
     let policies = Arc::new(FilesystemPersistentApprovalPolicyStore::new(Arc::clone(
         &scoped,
@@ -345,8 +343,8 @@ async fn default_runtime_does_not_replay_tenant_grantee_persistent_policy() {
     let registry = Arc::new(registry_with_echo_capability());
     let dispatcher = Arc::new(RecordingDispatcher::default());
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
-    let run_state = Arc::new(InMemoryRunStateStore::new());
-    let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
+    let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
+    let approval_requests = Arc::new(ironclaw_run_state::in_memory_backed_approval_request_store());
     let policies = Arc::new(in_memory_backed_persistent_approval_policy_store());
     let context = execution_context_without_grants();
     policies
@@ -409,8 +407,8 @@ async fn default_runtime_skips_unusable_persistent_policy_for_later_match() {
     let registry = Arc::new(registry_with_echo_capability());
     let dispatcher = Arc::new(RecordingDispatcher::default());
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
-    let run_state = Arc::new(InMemoryRunStateStore::new());
-    let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
+    let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
+    let approval_requests = Arc::new(ironclaw_run_state::in_memory_backed_approval_request_store());
     let policies = Arc::new(in_memory_backed_persistent_approval_policy_store());
     let context = execution_context_without_grants();
     policies
@@ -493,8 +491,8 @@ async fn default_runtime_falls_back_when_persistent_policy_lookup_fails() {
     let registry = Arc::new(registry_with_echo_capability());
     let dispatcher = Arc::new(RecordingDispatcher::default());
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
-    let run_state = Arc::new(InMemoryRunStateStore::new());
-    let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
+    let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
+    let approval_requests = Arc::new(ironclaw_run_state::in_memory_backed_approval_request_store());
     let policies: Arc<dyn PersistentApprovalPolicyStore> =
         Arc::new(FailingLookupPersistentApprovalPolicyStore);
     let context = execution_context_without_grants();
@@ -537,8 +535,8 @@ async fn default_runtime_reuses_persistent_policy_for_manifest_ask() {
     let registry = Arc::new(registry_with_echo_capability_permission("ask"));
     let dispatcher = Arc::new(RecordingDispatcher::default());
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
-    let run_state = Arc::new(InMemoryRunStateStore::new());
-    let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
+    let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
+    let approval_requests = Arc::new(ironclaw_run_state::in_memory_backed_approval_request_store());
     let policies = Arc::new(in_memory_backed_persistent_approval_policy_store());
     let context = execution_context_without_grants();
     policies
@@ -601,8 +599,8 @@ async fn default_runtime_skips_expired_persistent_policy() {
     let registry = Arc::new(registry_with_echo_capability());
     let dispatcher = Arc::new(RecordingDispatcher::default());
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
-    let run_state = Arc::new(InMemoryRunStateStore::new());
-    let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
+    let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
+    let approval_requests = Arc::new(ironclaw_run_state::in_memory_backed_approval_request_store());
     let policies = Arc::new(in_memory_backed_persistent_approval_policy_store());
     let context = execution_context_without_grants();
     policies
@@ -668,8 +666,8 @@ async fn default_runtime_uses_persistent_policy_for_no_project_no_thread_scope()
     let registry = Arc::new(registry_with_echo_capability());
     let dispatcher = Arc::new(RecordingDispatcher::default());
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
-    let run_state = Arc::new(InMemoryRunStateStore::new());
-    let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
+    let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
+    let approval_requests = Arc::new(ironclaw_run_state::in_memory_backed_approval_request_store());
     let policies = Arc::new(in_memory_backed_persistent_approval_policy_store());
     let mut context = execution_context_without_grants();
     context.project_id = None;
@@ -737,8 +735,8 @@ async fn default_runtime_uses_persistent_policy_as_spawn_capability_authority() 
     let registry = Arc::new(registry_with_echo_capability());
     let dispatcher = Arc::new(RecordingDispatcher::default());
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
-    let run_state = Arc::new(InMemoryRunStateStore::new());
-    let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
+    let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
+    let approval_requests = Arc::new(ironclaw_run_state::in_memory_backed_approval_request_store());
     let process_manager = Arc::new(RecordingProcessManager);
     let policies = Arc::new(in_memory_backed_persistent_approval_policy_store());
     let context = execution_context_without_grants();

--- a/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
@@ -54,10 +54,7 @@ use ironclaw_resources::{
     InMemoryResourceGovernor, JsonFileResourceGovernorStore, PersistentResourceGovernor,
     ResourceAccount, ResourceError, ResourceGovernor, ResourceLimits, ResourceTally,
 };
-use ironclaw_run_state::{
-    ApprovalRequestStore, InMemoryApprovalRequestStore, InMemoryRunStateStore, RunStart,
-    RunStateStore, RunStatus,
-};
+use ironclaw_run_state::{ApprovalRequestStore, RunStart, RunStateStore, RunStatus};
 use ironclaw_scripts::{ScriptRuntime, ScriptRuntimeConfig};
 use ironclaw_secrets::{
     InMemoryCredentialBroker, InMemorySecretStore, SecretMaterial, SecretStore,
@@ -102,7 +99,7 @@ fn assert_actor_policy_denied(outcome: RuntimeCapabilityOutcome) {
 }
 
 async fn assert_alice_run_status(
-    run_state: &InMemoryRunStateStore,
+    run_state: &ironclaw_run_state::FilesystemRunStateStore<ironclaw_filesystem::InMemoryBackend>,
     scope: &ResourceScope,
     invocation_id: InvocationId,
     expected_status: RunStatus,
@@ -1421,8 +1418,8 @@ async fn host_runtime_services_builds_dispatcher_runtime_and_health_from_registe
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> =
         Arc::new(GrantAuthorizer::new());
     let process_services = ironclaw_processes::in_memory_backed_process_services();
-    let run_state = Arc::new(InMemoryRunStateStore::new());
-    let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
+    let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
+    let approval_requests = Arc::new(ironclaw_run_state::in_memory_backed_approval_request_store());
     let capability_leases = Arc::new(in_memory_backed_capability_lease_store());
     let events = InMemoryEventSink::new();
     let script_runtime = Arc::new(ScriptRuntime::new(
@@ -2082,8 +2079,8 @@ async fn host_runtime_services_jsonl_event_store_projects_same_runtime_sequence_
 
 #[tokio::test]
 async fn host_runtime_services_approval_resolution_projects_durable_audit_metadata_only() {
-    let run_state = Arc::new(InMemoryRunStateStore::new());
-    let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
+    let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
+    let approval_requests = Arc::new(ironclaw_run_state::in_memory_backed_approval_request_store());
     let capability_leases = Arc::new(in_memory_backed_capability_lease_store());
     let audit_log = Arc::new(InMemoryDurableAuditLog::new());
     let services = HostRuntimeServices::new(
@@ -2191,8 +2188,8 @@ async fn host_runtime_services_jsonl_approval_audit_projection_rejects_foreign_c
     .await
     .unwrap();
     let audit_log = Arc::clone(&stores.audit);
-    let run_state = Arc::new(InMemoryRunStateStore::new());
-    let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
+    let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
+    let approval_requests = Arc::new(ironclaw_run_state::in_memory_backed_approval_request_store());
     let capability_leases = Arc::new(in_memory_backed_capability_lease_store());
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
@@ -2576,8 +2573,8 @@ async fn host_runtime_services_resumes_approved_capability_and_consumes_lease_on
 
 #[tokio::test]
 async fn host_runtime_services_resume_missing_runtime_secret_returns_auth_gate() {
-    let run_state = Arc::new(InMemoryRunStateStore::new());
-    let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
+    let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
+    let approval_requests = Arc::new(ironclaw_run_state::in_memory_backed_approval_request_store());
     let capability_leases = Arc::new(in_memory_backed_capability_lease_store());
     let secret_store = Arc::new(InMemorySecretStore::new());
     let secret_handle = SecretHandle::new("approval_resume_token").unwrap();
@@ -3117,8 +3114,8 @@ async fn host_runtime_services_auth_resume_rejects_changed_actor_before_prefligh
 
 #[tokio::test]
 async fn host_runtime_services_resume_spawn_rejects_changed_actor_before_input_and_preflight() {
-    let run_state = Arc::new(InMemoryRunStateStore::new());
-    let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
+    let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
+    let approval_requests = Arc::new(ironclaw_run_state::in_memory_backed_approval_request_store());
     let capability_leases = Arc::new(in_memory_backed_capability_lease_store());
     let process_services = ironclaw_processes::in_memory_backed_process_services();
     let process_store = process_services.process_store();
@@ -3284,8 +3281,8 @@ async fn host_runtime_services_auth_resume_dispatches_blocked_auth_run() {
     // fires an approval gate, and the first resume (missing credential) bounces
     // to BlockedAuth.  After adding the credential we verify that
     // auth_resume_capability dispatches and completes the run.
-    let run_state = Arc::new(InMemoryRunStateStore::new());
-    let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
+    let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
+    let approval_requests = Arc::new(ironclaw_run_state::in_memory_backed_approval_request_store());
     let capability_leases = Arc::new(in_memory_backed_capability_lease_store());
     let secret_store = Arc::new(InMemorySecretStore::new());
     let secret_handle = SecretHandle::new("auth_resume_token").unwrap();
@@ -3874,8 +3871,8 @@ async fn host_runtime_spawn_process_sandbox_host_failure_fails_after_preflight()
 
 #[tokio::test]
 async fn host_runtime_spawn_process_sandbox_blocks_for_approval_before_executor() {
-    let run_state = Arc::new(InMemoryRunStateStore::new());
-    let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
+    let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
+    let approval_requests = Arc::new(ironclaw_run_state::in_memory_backed_approval_request_store());
     let capability_leases = Arc::new(in_memory_backed_capability_lease_store());
     let process_services = ironclaw_processes::in_memory_backed_process_services();
     let result_store = process_services.result_store();
@@ -3950,8 +3947,8 @@ async fn host_runtime_spawn_process_sandbox_blocks_for_approval_before_executor(
 
 #[tokio::test]
 async fn host_runtime_spawn_process_sandbox_resume_changed_input_fails_before_executor() {
-    let run_state = Arc::new(InMemoryRunStateStore::new());
-    let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
+    let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
+    let approval_requests = Arc::new(ironclaw_run_state::in_memory_backed_approval_request_store());
     let capability_leases = Arc::new(in_memory_backed_capability_lease_store());
     let sandbox_executor = Arc::new(RecordingSandboxProcessExecutor::default());
     let services = HostRuntimeServices::new(
@@ -4025,8 +4022,8 @@ async fn host_runtime_spawn_process_sandbox_resume_changed_input_fails_before_ex
 
 #[tokio::test]
 async fn host_runtime_spawn_process_sandbox_resume_invalid_plan_fails_before_executor() {
-    let run_state = Arc::new(InMemoryRunStateStore::new());
-    let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
+    let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
+    let approval_requests = Arc::new(ironclaw_run_state::in_memory_backed_approval_request_store());
     let capability_leases = Arc::new(in_memory_backed_capability_lease_store());
     let sandbox_executor = Arc::new(RecordingSandboxProcessExecutor::default());
     let services = HostRuntimeServices::new(
@@ -4119,8 +4116,8 @@ async fn host_runtime_spawn_process_sandbox_resume_invalid_plan_fails_before_exe
 
 #[tokio::test]
 async fn host_runtime_spawn_process_sandbox_resume_host_failure_fails_after_approval() {
-    let run_state = Arc::new(InMemoryRunStateStore::new());
-    let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
+    let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
+    let approval_requests = Arc::new(ironclaw_run_state::in_memory_backed_approval_request_store());
     let capability_leases = Arc::new(in_memory_backed_capability_lease_store());
     let sandbox_executor = Arc::new(RecordingSandboxProcessExecutor::default());
     let services = HostRuntimeServices::new(
@@ -4643,7 +4640,7 @@ async fn host_runtime_services_enforces_output_limit_and_reconciles_resource_usa
                 .set_max_output_bytes(10_000),
         )
         .unwrap();
-    let run_state = Arc::new(InMemoryRunStateStore::new());
+    let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
     let reservation_id = ResourceReservationId::new();
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> =
         Arc::new(ObligatingAuthorizer::new(vec![
@@ -4711,7 +4708,7 @@ async fn host_runtime_services_releases_reservation_when_dispatch_preflight_fail
             ResourceLimits::default().set_max_concurrency_slots(1),
         )
         .unwrap();
-    let run_state = Arc::new(InMemoryRunStateStore::new());
+    let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
     let reservation_id = ResourceReservationId::new();
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
@@ -6038,8 +6035,8 @@ async fn host_runtime_services_wasm_operation_failed_reconciles_wall_clock_after
 /// immediately, approval gate never fires.
 #[tokio::test]
 async fn invoke_capability_missing_credential_returns_auth_before_approval() {
-    let run_state = Arc::new(InMemoryRunStateStore::new());
-    let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
+    let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
+    let approval_requests = Arc::new(ironclaw_run_state::in_memory_backed_approval_request_store());
     let capability_leases = Arc::new(in_memory_backed_capability_lease_store());
     let secret_store = Arc::new(InMemorySecretStore::new());
     // Note: the secret "script_api_token" is deliberately NOT inserted.
@@ -6111,8 +6108,8 @@ async fn invoke_capability_missing_credential_returns_auth_before_approval() {
 /// gate as it did before Fix B — the pre-flight must not block happy-path flows.
 #[tokio::test]
 async fn invoke_capability_present_credential_proceeds_to_approval() {
-    let run_state = Arc::new(InMemoryRunStateStore::new());
-    let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
+    let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
+    let approval_requests = Arc::new(ironclaw_run_state::in_memory_backed_approval_request_store());
     let capability_leases = Arc::new(in_memory_backed_capability_lease_store());
     let secret_store = Arc::new(InMemorySecretStore::new());
     let secret_handle = SecretHandle::new("script_api_token").unwrap();
@@ -6192,8 +6189,8 @@ async fn invoke_capability_present_credential_proceeds_to_approval() {
 /// `ApprovalRequired` (not a false `AuthRequired`).
 #[tokio::test]
 async fn spawn_capability_present_credential_proceeds_to_approval() {
-    let run_state = Arc::new(InMemoryRunStateStore::new());
-    let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
+    let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
+    let approval_requests = Arc::new(ironclaw_run_state::in_memory_backed_approval_request_store());
     let capability_leases = Arc::new(in_memory_backed_capability_lease_store());
     let secret_store = Arc::new(InMemorySecretStore::new());
     let secret_handle = SecretHandle::new("script_api_token").unwrap();
@@ -6306,8 +6303,8 @@ async fn invoke_capability_no_credential_requirement_proceeds_normally() {
 /// path through the spawn dispatch lane.
 #[tokio::test]
 async fn spawn_capability_missing_credential_returns_auth_before_approval() {
-    let run_state = Arc::new(InMemoryRunStateStore::new());
-    let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
+    let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
+    let approval_requests = Arc::new(ironclaw_run_state::in_memory_backed_approval_request_store());
     let capability_leases = Arc::new(in_memory_backed_capability_lease_store());
     let secret_store = Arc::new(InMemorySecretStore::new());
     // Note: the secret "script_api_token" is deliberately NOT inserted.
@@ -6380,8 +6377,8 @@ async fn spawn_capability_missing_credential_returns_auth_before_approval() {
 /// approval gate normally.
 #[tokio::test]
 async fn invoke_capability_no_credential_requirement_with_wired_store_proceeds_normally() {
-    let run_state = Arc::new(InMemoryRunStateStore::new());
-    let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
+    let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
+    let approval_requests = Arc::new(ironclaw_run_state::in_memory_backed_approval_request_store());
     let capability_leases = Arc::new(in_memory_backed_capability_lease_store());
     // SCRIPT_MANIFEST has no runtime_credentials; wire a secret store anyway to
     // confirm the is_empty() early-exit branch is taken, not the no-store branch.
@@ -6464,8 +6461,8 @@ async fn invoke_capability_no_credential_requirement_with_wired_store_proceeds_n
 /// `runtime_credentials` backstop.
 #[tokio::test]
 async fn invoke_capability_secret_store_error_skips_preflight() {
-    let run_state = Arc::new(InMemoryRunStateStore::new());
-    let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
+    let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
+    let approval_requests = Arc::new(ironclaw_run_state::in_memory_backed_approval_request_store());
     let capability_leases = Arc::new(in_memory_backed_capability_lease_store());
     let script_runtime = Arc::new(RecordingScriptExecutor::default());
     // Counts metadata() probes so we can prove the obligation backstop ran on resume.

--- a/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
@@ -556,6 +556,59 @@ async fn production_wiring_validation_classifies_in_memory_backed_lease_store_as
 }
 
 #[tokio::test]
+async fn production_wiring_validation_classifies_in_memory_backed_run_state_and_approval_stores_as_local_only()
+ {
+    // Regression guard for arch-simplification §4.3 (deleting
+    // `InMemoryRunStateStore` / `InMemoryApprovalRequestStore`): the classifier
+    // keyed the now-deleted stores as explicit `LocalOnly` types, and unknown
+    // component types default to `ProductionCandidate`. Their replacements — the
+    // production `Filesystem*Store<InMemoryBackend>` pair the no-durable build
+    // and every test seam wire — must classify the same way, or volatile
+    // in-memory run-state/approval stores could silently satisfy production
+    // readiness. Drive the real `HostRuntimeServices` caller so classification
+    // is exercised through the monomorphized `with_run_state::<T>` /
+    // `with_approval_requests::<T>` type capture, not just the classifier
+    // helper (the combined-store path hard-codes `LocalOnly` and bypasses it).
+    let services = HostRuntimeServices::new(
+        Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
+        Arc::new(LocalFilesystem::new()),
+        Arc::new(InMemoryResourceGovernor::new()),
+        Arc::new(GrantAuthorizer::new()),
+        ironclaw_processes::in_memory_backed_process_services(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_run_state(Arc::new(
+        ironclaw_run_state::in_memory_backed_run_state_store(),
+    ))
+    .with_approval_requests(Arc::new(
+        ironclaw_run_state::in_memory_backed_approval_request_store(),
+    ));
+
+    let report = services
+        .validate_production_wiring(&ProductionWiringConfig::new([]))
+        .expect_err(
+            "in-memory-backed run-state/approval stores must not pass production validation",
+        );
+
+    for component in [
+        ProductionWiringComponent::RunState,
+        ProductionWiringComponent::ApprovalRequests,
+    ] {
+        assert!(
+            report.contains(
+                component,
+                ProductionWiringIssueKind::LocalOnlyImplementation
+            ),
+            "Filesystem store<InMemoryBackend> for {component:?} must classify local-only: {report:?}"
+        );
+        assert!(
+            !report.contains(component, ProductionWiringIssueKind::Missing),
+            "a wired store must satisfy {component:?} presence: {report:?}"
+        );
+    }
+}
+
+#[tokio::test]
 async fn production_wiring_validation_rejects_unsupported_runtime_requirements() {
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),

--- a/crates/ironclaw_host_runtime/tests/reborn_e2e_gate.rs
+++ b/crates/ironclaw_host_runtime/tests/reborn_e2e_gate.rs
@@ -32,9 +32,7 @@ use ironclaw_network::{
 };
 use ironclaw_processes::{FilesystemProcessResultStore, FilesystemProcessStore};
 use ironclaw_resources::{InMemoryResourceGovernor, ResourceAccount, ResourceTally};
-use ironclaw_run_state::{
-    InMemoryApprovalRequestStore, InMemoryRunStateStore, RunStateStore, RunStatus,
-};
+use ironclaw_run_state::{RunStateStore, RunStatus};
 use ironclaw_scripts::{
     ScriptBackend, ScriptBackendOutput, ScriptBackendRequest, ScriptRuntime, ScriptRuntimeConfig,
 };
@@ -48,7 +46,7 @@ use serde_json::json;
 #[tokio::test]
 async fn reborn_e2e_gate_invokes_script_through_host_runtime_with_status_events_and_resources() {
     let governor = Arc::new(InMemoryResourceGovernor::new());
-    let run_state = Arc::new(InMemoryRunStateStore::new());
+    let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
     let event_log = Arc::new(InMemoryDurableEventLog::new());
     let filesystem = Arc::new(InMemoryBackend::new());
     seed_script_manifest_assets(filesystem.as_ref()).await;
@@ -266,7 +264,7 @@ async fn reborn_e2e_gate_blocks_for_approval_resumes_once_and_rejects_replay() {
 
 #[tokio::test]
 async fn reborn_e2e_gate_fails_unsupported_obligations_before_runtime_events_or_success() {
-    let run_state = Arc::new(InMemoryRunStateStore::new());
+    let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
     let events = InMemoryEventSink::new();
     let governor = Arc::new(InMemoryResourceGovernor::new());
     let services = HostRuntimeServices::new(
@@ -318,7 +316,7 @@ async fn reborn_e2e_gate_fails_unsupported_obligations_before_runtime_events_or_
 
 #[tokio::test]
 async fn reborn_e2e_gate_redacts_runtime_output_before_public_result() {
-    let run_state = Arc::new(InMemoryRunStateStore::new());
+    let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
     let events = InMemoryEventSink::new();
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
@@ -382,7 +380,7 @@ async fn reborn_e2e_gate_redacts_runtime_output_before_public_result() {
 
 #[tokio::test]
 async fn reborn_e2e_gate_sanitizes_runtime_backend_failure_before_public_surfaces() {
-    let run_state = Arc::new(InMemoryRunStateStore::new());
+    let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
     let events = InMemoryEventSink::new();
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
@@ -461,7 +459,7 @@ async fn reborn_e2e_gate_sanitizes_runtime_backend_failure_before_public_surface
 
 #[tokio::test]
 async fn reborn_e2e_gate_blocks_oversized_runtime_output_before_publication() {
-    let run_state = Arc::new(InMemoryRunStateStore::new());
+    let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
     let events = InMemoryEventSink::new();
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
@@ -640,14 +638,15 @@ type InMemoryServices = HostRuntimeServices<
 
 struct ApprovalFixture {
     services: InMemoryServices,
-    run_state: Arc<InMemoryRunStateStore>,
+    run_state:
+        Arc<ironclaw_run_state::FilesystemRunStateStore<ironclaw_filesystem::InMemoryBackend>>,
     capability_leases: Arc<FilesystemCapabilityLeaseStore<InMemoryBackend>>,
     events: InMemoryEventSink,
 }
 
 fn approval_resume_fixture() -> ApprovalFixture {
-    let run_state = Arc::new(InMemoryRunStateStore::new());
-    let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
+    let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
+    let approval_requests = Arc::new(ironclaw_run_state::in_memory_backed_approval_request_store());
     let capability_leases = Arc::new(in_memory_backed_capability_lease_store());
     let events = InMemoryEventSink::new();
     let services = HostRuntimeServices::new(

--- a/crates/ironclaw_host_runtime/tests/reborn_invoke_vertical_slice.rs
+++ b/crates/ironclaw_host_runtime/tests/reborn_invoke_vertical_slice.rs
@@ -24,7 +24,7 @@ use ironclaw_host_runtime::{
 use ironclaw_resources::{
     InMemoryResourceGovernor, ResourceAccount, ResourceGovernor, ResourceTally,
 };
-use ironclaw_run_state::{InMemoryRunStateStore, RunStateStore, RunStatus};
+use ironclaw_run_state::{RunStateStore, RunStatus};
 use ironclaw_trust::{
     AdminConfig, AdminEntry, AuthorityCeiling, EffectiveTrustClass, HostTrustAssignment,
     HostTrustPolicy, TrustDecision, TrustProvenance,
@@ -45,7 +45,7 @@ async fn default_host_runtime_invokes_through_runtime_dispatcher_with_resources_
     let (registry, dispatcher, governor, events) = runtime_dispatcher_stack(Arc::clone(&adapter));
     let dispatcher: Arc<dyn CapabilityDispatcher> = Arc::new(dispatcher);
     let authorizer = Arc::new(CountingGrantAuthorizer::default());
-    let run_state = Arc::new(InMemoryRunStateStore::new());
+    let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
     let runtime = DefaultHostRuntime::new(
         Arc::clone(&registry),
         dispatcher,
@@ -114,7 +114,7 @@ async fn default_host_runtime_fails_unsupported_obligations_before_runtime_dispa
     let adapter = Arc::new(RecordingRuntimeAdapter::new(json!({"must_not":"dispatch"})));
     let (registry, dispatcher, governor, events) = runtime_dispatcher_stack(Arc::clone(&adapter));
     let dispatcher: Arc<dyn CapabilityDispatcher> = Arc::new(dispatcher);
-    let run_state = Arc::new(InMemoryRunStateStore::new());
+    let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
     let runtime = DefaultHostRuntime::new(
         Arc::clone(&registry),
         dispatcher,

--- a/crates/ironclaw_host_runtime/tests/support/host_runtime_harness.rs
+++ b/crates/ironclaw_host_runtime/tests/support/host_runtime_harness.rs
@@ -55,8 +55,8 @@ use ironclaw_resources::{
     InMemoryResourceGovernor, ResourceAccount, ResourceError, ResourceGovernor, ResourceLimits,
 };
 use ironclaw_run_state::{
-    ApprovalRecord, ApprovalRequestStore, InMemoryApprovalRequestStore, InMemoryRunStateStore,
-    RunRecord, RunStart, RunStateApprovalStore, RunStateError, RunStateStore, RunStatus,
+    ApprovalRecord, ApprovalRequestStore, RunRecord, RunStart, RunStateApprovalStore,
+    RunStateError, RunStateStore, RunStatus,
 };
 use ironclaw_scripts::{
     ScriptBackend, ScriptBackendOutput, ScriptBackendRequest, ScriptExecutionRequest,
@@ -224,8 +224,10 @@ pub(crate) type InMemoryHostRuntimeServices = HostRuntimeServices<
 >;
 
 pub(crate) struct InMemoryRecordingCombinedRunStateApprovalStore {
-    pub(crate) runs: InMemoryRunStateStore,
-    pub(crate) approvals: InMemoryApprovalRequestStore,
+    pub(crate) runs:
+        ironclaw_run_state::FilesystemRunStateStore<ironclaw_filesystem::InMemoryBackend>,
+    pub(crate) approvals:
+        ironclaw_run_state::FilesystemApprovalRequestStore<ironclaw_filesystem::InMemoryBackend>,
     pub(crate) combined_calls: AtomicUsize,
     pub(crate) separate_save_calls: AtomicUsize,
 }
@@ -233,8 +235,8 @@ pub(crate) struct InMemoryRecordingCombinedRunStateApprovalStore {
 impl InMemoryRecordingCombinedRunStateApprovalStore {
     pub(crate) fn new() -> Self {
         Self {
-            runs: InMemoryRunStateStore::new(),
-            approvals: InMemoryApprovalRequestStore::new(),
+            runs: ironclaw_run_state::in_memory_backed_run_state_store(),
+            approvals: ironclaw_run_state::in_memory_backed_approval_request_store(),
             combined_calls: AtomicUsize::new(0),
             separate_save_calls: AtomicUsize::new(0),
         }
@@ -379,8 +381,11 @@ impl RunStateApprovalStore for InMemoryRecordingCombinedRunStateApprovalStore {
 
 pub(crate) struct ApprovalResumeFixture {
     pub(crate) services: InMemoryHostRuntimeServices,
-    pub(crate) run_state: Arc<InMemoryRunStateStore>,
-    pub(crate) approval_requests: Arc<InMemoryApprovalRequestStore>,
+    pub(crate) run_state:
+        Arc<ironclaw_run_state::FilesystemRunStateStore<ironclaw_filesystem::InMemoryBackend>>,
+    pub(crate) approval_requests: Arc<
+        ironclaw_run_state::FilesystemApprovalRequestStore<ironclaw_filesystem::InMemoryBackend>,
+    >,
     pub(crate) capability_leases: Arc<FilesystemCapabilityLeaseStore<InMemoryBackend>>,
     pub(crate) events: InMemoryEventSink,
 }
@@ -393,8 +398,8 @@ pub(crate) fn approval_resume_fixture_with_manifest(
     manifest: &str,
     trust_effects: Vec<EffectKind>,
 ) -> ApprovalResumeFixture {
-    let run_state = Arc::new(InMemoryRunStateStore::new());
-    let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
+    let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
+    let approval_requests = Arc::new(ironclaw_run_state::in_memory_backed_approval_request_store());
     let capability_leases = Arc::new(in_memory_backed_capability_lease_store());
     let events = InMemoryEventSink::new();
     let services = HostRuntimeServices::new(

--- a/crates/ironclaw_product_workflow/Cargo.toml
+++ b/crates/ironclaw_product_workflow/Cargo.toml
@@ -63,6 +63,8 @@ uuid = { version = "1", features = ["v4", "v5", "serde"] }
 ironclaw_approvals = { path = "../ironclaw_approvals", features = ["test-support"] }
 # Enables the in-memory-backed capability-lease store constructor for tests only.
 ironclaw_authorization = { path = "../ironclaw_authorization", features = ["test-support"] }
+# Enables the in-memory-backed run-state/approval store constructors for tests only.
+ironclaw_run_state = { path = "../ironclaw_run_state", features = ["test-support"] }
 ironclaw_filesystem = { path = "../ironclaw_filesystem" }
 ironclaw_host_runtime = { path = "../ironclaw_host_runtime" }
 ironclaw_loop_host = { path = "../ironclaw_loop_host" }

--- a/crates/ironclaw_product_workflow/src/approval_interaction/resolver.rs
+++ b/crates/ironclaw_product_workflow/src/approval_interaction/resolver.rs
@@ -267,13 +267,13 @@ mod tests {
         Action, ApprovalRequest, CapabilityId, CorrelationId, InvocationId, Principal,
         ResourceEstimate, UserId,
     };
-    use ironclaw_run_state::{ApprovalRequestStore, InMemoryApprovalRequestStore};
+    use ironclaw_run_state::ApprovalRequestStore;
 
     use super::*;
 
     #[tokio::test]
     async fn matching_lease_exists_rejects_pending_approval_as_stale() {
-        let approvals = Arc::new(InMemoryApprovalRequestStore::new());
+        let approvals = Arc::new(ironclaw_run_state::in_memory_backed_approval_request_store());
         let leases = Arc::new(in_memory_backed_capability_lease_store());
         let scope = resource_scope();
         let request = approval_request(None);
@@ -299,7 +299,7 @@ mod tests {
 
     #[tokio::test]
     async fn matching_lease_exists_rejects_approved_request_without_fingerprint_as_stale() {
-        let approvals = Arc::new(InMemoryApprovalRequestStore::new());
+        let approvals = Arc::new(ironclaw_run_state::in_memory_backed_approval_request_store());
         let leases = Arc::new(in_memory_backed_capability_lease_store());
         let scope = resource_scope();
         let request = approval_request(None);

--- a/crates/ironclaw_product_workflow/tests/approval_interaction_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/approval_interaction_contract.rs
@@ -32,7 +32,7 @@ use ironclaw_product_workflow::{
     ResolveApprovalInteractionRequest, ResolveApprovalInteractionResponse,
     RunStateApprovalInteractionReadModel, approval_gate_ref,
 };
-use ironclaw_run_state::{ApprovalRequestStore, ApprovalStatus, InMemoryApprovalRequestStore};
+use ironclaw_run_state::{ApprovalRequestStore, ApprovalStatus};
 use ironclaw_turns::{
     AcceptedMessageRef, CancelRunRequest, CancelRunResponse, EventCursor, GateRef,
     GateResumeDisposition, GetRunStateRequest, IdempotencyKey, ReplyTargetBindingRef,
@@ -1784,7 +1784,7 @@ async fn already_approved_product_replay_without_run_hint_recovers_historical_ru
     let request_id = request.id;
     let gate_ref = approval_gate_ref(request_id).expect("approval gate");
     let run_id = TurnRunId::new();
-    let approvals = Arc::new(InMemoryApprovalRequestStore::new());
+    let approvals = Arc::new(ironclaw_run_state::in_memory_backed_approval_request_store());
     approvals
         .save_pending(approval_scope.clone(), request)
         .await
@@ -2363,7 +2363,7 @@ async fn resolve_rejects_malformed_approval_gate_ref_without_side_effects() {
     ));
     let service = DefaultApprovalInteractionService::new(
         Arc::new(RunStateApprovalInteractionReadModel::new(
-            Arc::new(InMemoryApprovalRequestStore::new()),
+            Arc::new(ironclaw_run_state::in_memory_backed_approval_request_store()),
             Arc::new(FakeTurnRunLocator::with_run(
                 TurnRunId::new(),
                 bad_gate_ref.clone(),
@@ -2640,7 +2640,7 @@ async fn approval_resolver_port_preserves_audit_sink() {
     let resource_scope = resource_scope(&alpha_actor);
     let request = approval_request("approval required");
     let request_id = request.id;
-    let approvals = Arc::new(InMemoryApprovalRequestStore::new());
+    let approvals = Arc::new(ironclaw_run_state::in_memory_backed_approval_request_store());
     approvals
         .save_pending(resource_scope.clone(), request)
         .await
@@ -2678,7 +2678,7 @@ async fn approval_resolver_port_retries_missing_lease_for_approved_request() {
         .expect("fingerprint"),
     );
     let request_id = request.id;
-    let approvals = Arc::new(InMemoryApprovalRequestStore::new());
+    let approvals = Arc::new(ironclaw_run_state::in_memory_backed_approval_request_store());
     approvals
         .save_pending(resource_scope.clone(), request)
         .await
@@ -2721,7 +2721,7 @@ async fn approval_resolver_port_retries_missing_spawn_lease_for_approved_request
         .expect("fingerprint"),
     );
     let request_id = request.id;
-    let approvals = Arc::new(InMemoryApprovalRequestStore::new());
+    let approvals = Arc::new(ironclaw_run_state::in_memory_backed_approval_request_store());
     approvals
         .save_pending(resource_scope.clone(), request)
         .await
@@ -2761,7 +2761,7 @@ async fn approval_resolver_port_does_not_duplicate_existing_lease_for_approved_r
         .expect("fingerprint"),
     );
     let request_id = request.id;
-    let approvals = Arc::new(InMemoryApprovalRequestStore::new());
+    let approvals = Arc::new(ironclaw_run_state::in_memory_backed_approval_request_store());
     approvals
         .save_pending(resource_scope.clone(), request)
         .await
@@ -2798,7 +2798,7 @@ async fn approval_resolver_port_reissues_when_existing_dispatch_lease_is_claimed
     );
     let fingerprint = request.invocation_fingerprint.clone().expect("fingerprint");
     let request_id = request.id;
-    let approvals = Arc::new(InMemoryApprovalRequestStore::new());
+    let approvals = Arc::new(ironclaw_run_state::in_memory_backed_approval_request_store());
     approvals
         .save_pending(resource_scope.clone(), request)
         .await
@@ -2861,7 +2861,7 @@ async fn approval_resolver_port_does_not_duplicate_existing_spawn_lease_for_appr
         .expect("fingerprint"),
     );
     let request_id = request.id;
-    let approvals = Arc::new(InMemoryApprovalRequestStore::new());
+    let approvals = Arc::new(ironclaw_run_state::in_memory_backed_approval_request_store());
     approvals
         .save_pending(resource_scope.clone(), request)
         .await
@@ -2897,7 +2897,7 @@ async fn run_state_read_model_uses_parked_turn_run_id_for_pending_approvals() {
         parked_turn_run_id, invocation_derived_run_id,
         "test must prove capability invocation ids are not turn run ids"
     );
-    let approvals = Arc::new(InMemoryApprovalRequestStore::new());
+    let approvals = Arc::new(ironclaw_run_state::in_memory_backed_approval_request_store());
     approvals
         .save_pending(resource_scope.clone(), request.clone())
         .await

--- a/crates/ironclaw_reborn_composition/Cargo.toml
+++ b/crates/ironclaw_reborn_composition/Cargo.toml
@@ -203,6 +203,8 @@ ironclaw_approvals = { path = "../ironclaw_approvals", features = ["test-support
 ironclaw_authorization = { path = "../ironclaw_authorization", features = ["test-support"] }
 # Enables the in-memory-backed process store constructors for tests only.
 ironclaw_processes = { path = "../ironclaw_processes", features = ["test-support"] }
+# Enables the in-memory-backed run-state/approval store constructors for tests only.
+ironclaw_run_state = { path = "../ironclaw_run_state", features = ["test-support"] }
 http = "1"
 http-body-util = "0.1"
 # Admin-user-management e2e test drives the composed app with a real session

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -104,10 +104,10 @@ use ironclaw_resources::{
     BroadcastBudgetEventSink, BudgetGateStore, FilesystemBudgetGateStore,
     FilesystemResourceGovernor, ResourceGovernor,
 };
-#[cfg(any(feature = "libsql", feature = "postgres"))]
+// Used by both the durable (`<LocalDevRootFilesystem>`) and no-durable
+// (`<InMemoryBackend>`) run-state/approval aliases + builders, so the import is
+// unconditional (arch-simplification §4.3).
 use ironclaw_run_state::{FilesystemApprovalRequestStore, FilesystemRunStateStore};
-#[cfg(not(any(feature = "libsql", feature = "postgres")))]
-use ironclaw_run_state::{InMemoryApprovalRequestStore, InMemoryRunStateStore};
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 use ironclaw_secrets::FilesystemCredentialBroker;
 #[cfg(any(feature = "libsql", feature = "postgres"))]
@@ -276,16 +276,21 @@ type LocalDevResourceGovernor = FilesystemResourceGovernor<LocalDevRootFilesyste
 #[cfg(not(any(feature = "libsql", feature = "postgres")))]
 type LocalDevResourceGovernor = InMemoryResourceGovernor;
 
+// One run-state / approval-request store, backend-injected — the production
+// `Filesystem*Store<F>` every deployment uses, never a bespoke `InMemory*Store`
+// (arch-simplification §4.3). The no-durable-features build backs them with
+// `InMemoryBackend` directly, so the concrete type is `<InMemoryBackend>`, which
+// the host-runtime production-wiring guard classifies `LocalOnly`.
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 type LocalDevRunStateStore = FilesystemRunStateStore<LocalDevRootFilesystem>;
 #[cfg(not(any(feature = "libsql", feature = "postgres")))]
-type LocalDevRunStateStore = InMemoryRunStateStore;
+type LocalDevRunStateStore = FilesystemRunStateStore<InMemoryBackend>;
 
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 pub(crate) type LocalDevApprovalRequestStore =
     FilesystemApprovalRequestStore<LocalDevRootFilesystem>;
 #[cfg(not(any(feature = "libsql", feature = "postgres")))]
-pub(crate) type LocalDevApprovalRequestStore = InMemoryApprovalRequestStore;
+pub(crate) type LocalDevApprovalRequestStore = FilesystemApprovalRequestStore<InMemoryBackend>;
 
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 pub(crate) type LocalDevCapabilityLeaseStore =
@@ -305,9 +310,9 @@ pub(crate) type LocalDevCapabilityLeaseStore = FilesystemCapabilityLeaseStore<In
 // the no-durable-features build backs them with `InMemoryBackend` directly, so
 // the concrete type is `<InMemoryBackend>` — which the host-runtime
 // production-wiring guard classifies `LocalOnly` (the same way the volatile
-// `InMemoryRunStateStore` is flagged). Durable
-// builds use the libSQL/Postgres-backed composite root filesystem, whose type is
-// distinct and correctly classifies as a production candidate.
+// `<InMemoryBackend>`-backed run-state/approval/lease stores are flagged).
+// Durable builds use the libSQL/Postgres-backed composite root filesystem, whose
+// type is distinct and correctly classifies as a production candidate.
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 pub(crate) type LocalDevPersistentApprovalPolicyStore =
     FilesystemPersistentApprovalPolicyStore<LocalDevRootFilesystem>;
@@ -2618,8 +2623,16 @@ async fn build_local_dev_store_graph(
     let approvals_filesystem = crate::wrap_scoped(Arc::new(InMemoryBackend::new()));
     let event_log = local_dev_event_log(Arc::clone(&filesystem))?;
     let audit_log = local_dev_audit_log(Arc::clone(&filesystem))?;
-    let run_state = Arc::new(InMemoryRunStateStore::new());
-    let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
+    // Run-state and approval-request records live under sibling aliases on the
+    // same volatile in-memory backend (§4.3), so both share `approvals_filesystem`
+    // (the full-alias in-memory scoped filesystem) — a blocked run and its approval
+    // record resolve against one consistent view.
+    let run_state = Arc::new(FilesystemRunStateStore::new(Arc::clone(
+        &approvals_filesystem,
+    )));
+    let approval_requests = Arc::new(FilesystemApprovalRequestStore::new(Arc::clone(
+        &approvals_filesystem,
+    )));
     let capability_leases = Arc::new(FilesystemCapabilityLeaseStore::new(crate::wrap_scoped(
         Arc::new(InMemoryBackend::new()),
     )));

--- a/crates/ironclaw_reborn_composition/src/projection/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/tests.rs
@@ -21,9 +21,7 @@ use ironclaw_product_adapters::{
     AuthPromptChallengeKind, CapabilityActivityStatusView, ProductGateKind,
     ProductOutboundEnvelope, ProductOutboundPayload, ProductProjectionItem,
 };
-use ironclaw_run_state::{
-    ApprovalRecord, ApprovalRequestStore, InMemoryApprovalRequestStore, RunStateError,
-};
+use ironclaw_run_state::{ApprovalRecord, ApprovalRequestStore, RunStateError};
 use ironclaw_turns::{
     AcceptedMessageRef, CancelRunRequest, CancelRunResponse, EventCursor as TurnEventCursor,
     GateRef, GetRunStateRequest, ResumeTurnRequest, ResumeTurnResponse, RunProfileId,

--- a/crates/ironclaw_reborn_composition/src/projection/tests/turn_stream.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/tests/turn_stream.rs
@@ -209,7 +209,7 @@ async fn webui_event_stream_offers_always_for_typed_approval_gate() {
     );
     let approval_request_id = ApprovalRequestId::new();
     let gate_ref = GateRef::new(format!("gate:approval-{approval_request_id}")).unwrap();
-    let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
+    let approval_requests = Arc::new(ironclaw_run_state::in_memory_backed_approval_request_store());
     let capability = CapabilityId::new("builtin.http").unwrap();
     let blocked_invocation = InvocationId::new();
     approval_requests
@@ -345,7 +345,7 @@ async fn webui_event_stream_projects_network_approval_context() {
     let network_run = TurnRunId::new();
     let network_request_id = ApprovalRequestId::new();
     let network_gate_ref = GateRef::new(format!("gate:approval-{network_request_id}")).unwrap();
-    let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
+    let approval_requests = Arc::new(ironclaw_run_state::in_memory_backed_approval_request_store());
     let approval_scope = resource_scope(
         &tenant_id,
         &user_id,
@@ -470,7 +470,7 @@ async fn webui_event_stream_projects_spawn_approval_context() {
     );
     let approval_request_id = ApprovalRequestId::new();
     let gate_ref = GateRef::new(format!("gate:approval-{approval_request_id}")).unwrap();
-    let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
+    let approval_requests = Arc::new(ironclaw_run_state::in_memory_backed_approval_request_store());
     approval_requests
         .save_pending(
             resource_scope(

--- a/crates/ironclaw_reborn_composition/tests/refreshing_capability_port_test_support.rs
+++ b/crates/ironclaw_reborn_composition/tests/refreshing_capability_port_test_support.rs
@@ -50,7 +50,6 @@ use ironclaw_reborn_composition::test_support::{
     RefreshingLocalDevCapabilityPortTestParts,
     create_refreshing_local_dev_capability_port_for_test,
 };
-use ironclaw_run_state::InMemoryApprovalRequestStore;
 use ironclaw_turns::run_profile::{
     AgentLoopHostError, AgentLoopHostErrorKind, CapabilityInputRef, CapabilityInvocation,
     CapabilityOutcome, InMemoryLoopHostMilestoneSink, InMemoryRunProfileResolver, LoopRunContext,
@@ -405,7 +404,7 @@ fn test_parts(
         tool_permission_overrides: Arc::new(in_memory_backed_capability_permission_override_store()),
         auto_approve_settings: Arc::new(in_memory_backed_auto_approve_setting_store()),
         persistent_approval_policies: Arc::new(in_memory_backed_persistent_approval_policy_store()),
-        approval_requests: Arc::new(InMemoryApprovalRequestStore::new()),
+        approval_requests: Arc::new(ironclaw_run_state::in_memory_backed_approval_request_store()),
         capability_leases: Arc::new(in_memory_backed_capability_lease_store()),
         capability_execution_mount_overrides,
         additional_provider_trust,

--- a/crates/ironclaw_run_state/Cargo.toml
+++ b/crates/ironclaw_run_state/Cargo.toml
@@ -9,6 +9,11 @@ layer = "kernel"
 
 [features]
 default = []
+# In-memory-backed run-state / approval-request store constructors for this
+# crate's own tests and downstream tiers. The stores are the production
+# `Filesystem*Store<InMemoryBackend>`; the helpers just wire the in-memory backend
+# seam (arch-simplification §4.3).
+test-support = []
 postgres = ["dep:deadpool-postgres", "dep:tokio-postgres"]
 libsql = ["dep:libsql"]
 

--- a/crates/ironclaw_run_state/src/lib.rs
+++ b/crates/ironclaw_run_state/src/lib.rs
@@ -11,10 +11,7 @@
 //! local-disk) is made at the filesystem layer — the consumer-store level no
 //! longer carries per-backend impls.
 
-use std::{
-    collections::HashMap,
-    sync::{Arc, Mutex, MutexGuard},
-};
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use ironclaw_filesystem::{
@@ -22,11 +19,19 @@ use ironclaw_filesystem::{
     ScopedFilesystem, cas_update,
 };
 use ironclaw_host_api::{
-    AgentId, ApprovalRequest, ApprovalRequestId, CapabilityId, HostApiError, InvocationId,
-    MissionId, ProjectId, ResourceScope, ScopedPath, TenantId, ThreadId, UserId,
+    ApprovalRequest, ApprovalRequestId, CapabilityId, HostApiError, InvocationId, ResourceScope,
+    ScopedPath, UserId,
 };
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+
+#[cfg(any(test, feature = "test-support"))]
+mod test_support;
+#[cfg(any(test, feature = "test-support"))]
+pub use test_support::{
+    in_memory_backed_approval_request_store, in_memory_backed_run_state_filesystem,
+    in_memory_backed_run_state_store,
+};
 
 /// Current lifecycle state for one invocation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -78,56 +83,6 @@ pub struct ApprovalRecord {
     pub scope: ResourceScope,
     pub request: ApprovalRequest,
     pub status: ApprovalStatus,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct RunStateKey {
-    tenant_id: TenantId,
-    user_id: UserId,
-    agent_id: Option<AgentId>,
-    project_id: Option<ProjectId>,
-    mission_id: Option<MissionId>,
-    thread_id: Option<ThreadId>,
-    invocation_id: InvocationId,
-}
-
-impl RunStateKey {
-    fn new(scope: &ResourceScope, invocation_id: InvocationId) -> Self {
-        Self {
-            tenant_id: scope.tenant_id.clone(),
-            user_id: scope.user_id.clone(),
-            agent_id: scope.agent_id.clone(),
-            project_id: scope.project_id.clone(),
-            mission_id: scope.mission_id.clone(),
-            thread_id: scope.thread_id.clone(),
-            invocation_id,
-        }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct ApprovalKey {
-    tenant_id: TenantId,
-    user_id: UserId,
-    agent_id: Option<AgentId>,
-    project_id: Option<ProjectId>,
-    mission_id: Option<MissionId>,
-    thread_id: Option<ThreadId>,
-    request_id: ApprovalRequestId,
-}
-
-impl ApprovalKey {
-    fn new(scope: &ResourceScope, request_id: ApprovalRequestId) -> Self {
-        Self {
-            tenant_id: scope.tenant_id.clone(),
-            user_id: scope.user_id.clone(),
-            agent_id: scope.agent_id.clone(),
-            project_id: scope.project_id.clone(),
-            mission_id: scope.mission_id.clone(),
-            thread_id: scope.thread_id.clone(),
-            request_id,
-        }
-    }
 }
 
 /// Run-state and approval persistence errors.
@@ -280,268 +235,6 @@ pub trait RunStateApprovalStore: RunStateStore + ApprovalRequestStore {
         invocation_id: InvocationId,
         approval: ApprovalRequest,
     ) -> Result<RunRecord, RunStateError>;
-}
-
-/// In-memory run-state store for tests and early host wiring.
-#[derive(Debug, Default)]
-pub struct InMemoryRunStateStore {
-    records: Mutex<HashMap<RunStateKey, RunRecord>>,
-}
-
-impl InMemoryRunStateStore {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    fn update(
-        &self,
-        scope: &ResourceScope,
-        invocation_id: InvocationId,
-        update: impl FnOnce(&mut RunRecord),
-    ) -> Result<RunRecord, RunStateError> {
-        let key = RunStateKey::new(scope, invocation_id);
-        let mut records = self.records_guard();
-        let record = records
-            .get_mut(&key)
-            .ok_or(RunStateError::UnknownInvocation { invocation_id })?;
-        update(record);
-        Ok(record.clone())
-    }
-
-    fn records_guard(&self) -> MutexGuard<'_, HashMap<RunStateKey, RunRecord>> {
-        self.records
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-    }
-}
-
-#[async_trait]
-impl RunStateStore for InMemoryRunStateStore {
-    async fn start(&self, start: RunStart) -> Result<RunRecord, RunStateError> {
-        let record = RunRecord {
-            invocation_id: start.invocation_id,
-            capability_id: start.capability_id,
-            scope: start.scope,
-            authenticated_actor_user_id: start.authenticated_actor_user_id,
-            status: RunStatus::Running,
-            approval_request_id: None,
-            error_kind: None,
-        };
-        let key = RunStateKey::new(&record.scope, record.invocation_id);
-        let mut records = self.records_guard();
-        if records.contains_key(&key) {
-            return Err(RunStateError::InvocationAlreadyExists {
-                invocation_id: record.invocation_id,
-            });
-        }
-        records.insert(key, record.clone());
-        Ok(record)
-    }
-
-    async fn block_approval(
-        &self,
-        scope: &ResourceScope,
-        invocation_id: InvocationId,
-        approval: ApprovalRequest,
-    ) -> Result<RunRecord, RunStateError> {
-        self.update(scope, invocation_id, |record| {
-            record.status = RunStatus::BlockedApproval;
-            record.approval_request_id = Some(approval.id);
-            record.error_kind = None;
-        })
-    }
-
-    async fn block_auth(
-        &self,
-        scope: &ResourceScope,
-        invocation_id: InvocationId,
-        error_kind: String,
-    ) -> Result<RunRecord, RunStateError> {
-        self.update(scope, invocation_id, |record| {
-            record.status = RunStatus::BlockedAuth;
-            record.approval_request_id = None;
-            record.error_kind = Some(error_kind);
-        })
-    }
-
-    async fn complete(
-        &self,
-        scope: &ResourceScope,
-        invocation_id: InvocationId,
-    ) -> Result<RunRecord, RunStateError> {
-        self.update(scope, invocation_id, |record| {
-            record.status = RunStatus::Completed;
-            record.approval_request_id = None;
-            record.error_kind = None;
-        })
-    }
-
-    async fn fail(
-        &self,
-        scope: &ResourceScope,
-        invocation_id: InvocationId,
-        error_kind: String,
-    ) -> Result<RunRecord, RunStateError> {
-        self.update(scope, invocation_id, |record| {
-            record.status = RunStatus::Failed;
-            record.approval_request_id = None;
-            record.error_kind = Some(error_kind);
-        })
-    }
-
-    async fn get(
-        &self,
-        scope: &ResourceScope,
-        invocation_id: InvocationId,
-    ) -> Result<Option<RunRecord>, RunStateError> {
-        Ok(self
-            .records_guard()
-            .get(&RunStateKey::new(scope, invocation_id))
-            .cloned())
-    }
-
-    async fn records_for_scope(
-        &self,
-        scope: &ResourceScope,
-    ) -> Result<Vec<RunRecord>, RunStateError> {
-        let mut records = self
-            .records_guard()
-            .values()
-            .filter(|record| same_scope_owner(&record.scope, scope))
-            .cloned()
-            .collect::<Vec<_>>();
-        records.sort_by_key(|record| record.invocation_id.as_uuid());
-        Ok(records)
-    }
-}
-
-/// In-memory approval request store for tests and early host wiring.
-#[derive(Debug, Default)]
-pub struct InMemoryApprovalRequestStore {
-    records: Mutex<HashMap<ApprovalKey, ApprovalRecord>>,
-}
-
-impl InMemoryApprovalRequestStore {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    fn update_status(
-        &self,
-        scope: &ResourceScope,
-        request_id: ApprovalRequestId,
-        status: ApprovalStatus,
-    ) -> Result<ApprovalRecord, RunStateError> {
-        let mut records = self.records_guard();
-        let record = records
-            .get_mut(&ApprovalKey::new(scope, request_id))
-            .ok_or(RunStateError::UnknownApprovalRequest { request_id })?;
-        if record.status != ApprovalStatus::Pending {
-            return Err(RunStateError::ApprovalNotPending {
-                request_id,
-                status: record.status,
-            });
-        }
-        record.status = status;
-        Ok(record.clone())
-    }
-
-    fn records_guard(&self) -> MutexGuard<'_, HashMap<ApprovalKey, ApprovalRecord>> {
-        self.records
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-    }
-}
-
-#[async_trait]
-impl ApprovalRequestStore for InMemoryApprovalRequestStore {
-    async fn save_pending(
-        &self,
-        scope: ResourceScope,
-        request: ApprovalRequest,
-    ) -> Result<ApprovalRecord, RunStateError> {
-        let record = ApprovalRecord {
-            scope,
-            request,
-            status: ApprovalStatus::Pending,
-        };
-        let key = ApprovalKey::new(&record.scope, record.request.id);
-        let mut records = self.records_guard();
-        if records.contains_key(&key) {
-            return Err(RunStateError::ApprovalRequestAlreadyExists {
-                request_id: record.request.id,
-            });
-        }
-        records.insert(key, record.clone());
-        Ok(record)
-    }
-
-    async fn get(
-        &self,
-        scope: &ResourceScope,
-        request_id: ApprovalRequestId,
-    ) -> Result<Option<ApprovalRecord>, RunStateError> {
-        Ok(self
-            .records_guard()
-            .get(&ApprovalKey::new(scope, request_id))
-            .cloned()
-            .filter(|record| record.status != ApprovalStatus::Discarded))
-    }
-
-    async fn approve(
-        &self,
-        scope: &ResourceScope,
-        request_id: ApprovalRequestId,
-    ) -> Result<ApprovalRecord, RunStateError> {
-        self.update_status(scope, request_id, ApprovalStatus::Approved)
-    }
-
-    async fn deny(
-        &self,
-        scope: &ResourceScope,
-        request_id: ApprovalRequestId,
-    ) -> Result<ApprovalRecord, RunStateError> {
-        self.update_status(scope, request_id, ApprovalStatus::Denied)
-    }
-
-    async fn discard_pending(
-        &self,
-        scope: &ResourceScope,
-        request_id: ApprovalRequestId,
-    ) -> Result<ApprovalRecord, RunStateError> {
-        let mut records = self.records_guard();
-        let key = ApprovalKey::new(scope, request_id);
-        let record = records
-            .get_mut(&key)
-            .ok_or(RunStateError::UnknownApprovalRequest { request_id })?;
-        if record.status != ApprovalStatus::Pending {
-            return Err(RunStateError::ApprovalNotPending {
-                request_id,
-                status: record.status,
-            });
-        }
-        // Tombstone in place (#5467), mirroring FilesystemApprovalRequestStore:
-        // blocks id reuse via save_pending. Return pre-mutation clone (Pending).
-        let original = record.clone();
-        record.status = ApprovalStatus::Discarded;
-        Ok(original)
-    }
-
-    async fn records_for_scope(
-        &self,
-        scope: &ResourceScope,
-    ) -> Result<Vec<ApprovalRecord>, RunStateError> {
-        let mut records = self
-            .records_guard()
-            .values()
-            .filter(|record| {
-                same_scope_owner(&record.scope, scope) && record.status != ApprovalStatus::Discarded
-            })
-            .cloned()
-            .collect::<Vec<_>>();
-        records.sort_by_key(|record| record.request.id.as_uuid());
-        Ok(records)
-    }
 }
 
 /// `RecordKind` tag written on every run-state entry so byte-only backends

--- a/crates/ironclaw_run_state/src/test_support.rs
+++ b/crates/ironclaw_run_state/src/test_support.rs
@@ -22,9 +22,9 @@
 //! approval resolution that reads the blocked run and its approval record sees a
 //! consistent view.
 //!
-//! Gated behind `#[cfg(any(test, feature = "test-support"))]` so nothing here
-//! ships in production binaries; downstream crates enable the `test-support`
-//! feature from their `[dev-dependencies]`.
+//! Gated behind `#[cfg(any(test, feature = "test-support"))]` and disabled by
+//! default. Downstream crates should enable `test-support` only from their
+//! `[dev-dependencies]`.
 
 use std::sync::Arc;
 

--- a/crates/ironclaw_run_state/src/test_support.rs
+++ b/crates/ironclaw_run_state/src/test_support.rs
@@ -1,0 +1,70 @@
+//! In-memory-backed run-state / approval-request store constructors for tests.
+//!
+//! The Reborn architecture-simplification note
+//! (`docs/reborn/2026-07-17-architecture-simplification-dto-dyn-local.md`, §4.3)
+//! replaces the hand-written `InMemory*Store` parallel implementations with the
+//! one production `Filesystem*Store<F>` exercised over an in-memory backend:
+//! "in-memory" stops being a store and becomes a filesystem backend
+//! (`InMemoryBackend`). These helpers wire that seam once — a
+//! `ScopedFilesystem<InMemoryBackend>` mounting both `/run-state` and
+//! `/approvals` (the two aliases this crate persists under) — so tests
+//! instantiate the same store a deployment runs.
+//!
+//! Note on isolation: the run-state/approval stores encode
+//! agent/project/mission/thread in the path (structural under any mount) while
+//! tenant/user isolation lives in the `MountView`. The single fixed mount below
+//! therefore isolates by agent/project/mission/thread but not by tenant/user —
+//! which matches single-tenant state-machine tests; cross-tenant isolation is
+//! exercised by the per-tenant-mount tests in the contract suites.
+//!
+//! Run-state and approval records live under sibling aliases on **one** backend,
+//! so a single `in_memory_backed_run_state_filesystem()` feeds both stores — an
+//! approval resolution that reads the blocked run and its approval record sees a
+//! consistent view.
+//!
+//! Gated behind `#[cfg(any(test, feature = "test-support"))]` so nothing here
+//! ships in production binaries; downstream crates enable the `test-support`
+//! feature from their `[dev-dependencies]`.
+
+use std::sync::Arc;
+
+use ironclaw_filesystem::{InMemoryBackend, ScopedFilesystem};
+use ironclaw_host_api::{MountAlias, MountGrant, MountPermissions, MountView, VirtualPath};
+
+use crate::{FilesystemApprovalRequestStore, FilesystemRunStateStore};
+
+/// A fresh, volatile `ScopedFilesystem<InMemoryBackend>` mounting both
+/// `/run-state` and `/approvals` — the in-memory backend seam the run-state and
+/// approval-request stores share in tests.
+pub fn in_memory_backed_run_state_filesystem() -> Arc<ScopedFilesystem<InMemoryBackend>> {
+    let mounts = MountView::new(vec![
+        MountGrant::new(
+            MountAlias::new("/run-state").expect("static valid mount alias"), // safety: test-support scaffolding, static literal
+            VirtualPath::new("/engine/run-state").expect("static valid virtual path"), // safety: test-support scaffolding, static literal
+            MountPermissions::read_write_list_delete(),
+        ),
+        MountGrant::new(
+            MountAlias::new("/approvals").expect("static valid mount alias"), // safety: test-support scaffolding, static literal
+            VirtualPath::new("/engine/approvals").expect("static valid virtual path"), // safety: test-support scaffolding, static literal
+            MountPermissions::read_write_list_delete(),
+        ),
+    ])
+    .expect("static valid run-state mount view"); // safety: test-support scaffolding, static literal
+    Arc::new(ScopedFilesystem::with_fixed_view(
+        Arc::new(InMemoryBackend::new()),
+        mounts,
+    ))
+}
+
+/// The production run-state store over a fresh in-memory backend — the drop-in
+/// replacement for the deleted `InMemoryRunStateStore`.
+pub fn in_memory_backed_run_state_store() -> FilesystemRunStateStore<InMemoryBackend> {
+    FilesystemRunStateStore::new(in_memory_backed_run_state_filesystem())
+}
+
+/// The production approval-request store over a fresh in-memory backend — the
+/// drop-in replacement for the deleted `InMemoryApprovalRequestStore`.
+pub fn in_memory_backed_approval_request_store() -> FilesystemApprovalRequestStore<InMemoryBackend>
+{
+    FilesystemApprovalRequestStore::new(in_memory_backed_run_state_filesystem())
+}

--- a/crates/ironclaw_run_state/tests/approval_resolution_contract.rs
+++ b/crates/ironclaw_run_state/tests/approval_resolution_contract.rs
@@ -6,7 +6,7 @@ use ironclaw_run_state::*;
 
 #[tokio::test]
 async fn approval_store_marks_pending_request_approved_or_denied_with_scope() {
-    let store = InMemoryApprovalRequestStore::new();
+    let store = in_mem_approval_request_store();
     let invocation_id = InvocationId::new();
     let scope = sample_scope(invocation_id, "tenant1", "user1");
     let approval = approval_request(invocation_id);
@@ -34,7 +34,7 @@ async fn approval_store_marks_pending_request_approved_or_denied_with_scope() {
 
 #[tokio::test]
 async fn approval_resolution_is_scoped_to_tenant_and_user() {
-    let store = InMemoryApprovalRequestStore::new();
+    let store = in_mem_approval_request_store();
     let invocation_id = InvocationId::new();
     let tenant_a = sample_scope(invocation_id, "tenant1", "user1");
     let tenant_b = sample_scope(invocation_id, "tenant2", "user1");
@@ -53,7 +53,7 @@ async fn approval_resolution_is_scoped_to_tenant_and_user() {
 
 #[tokio::test]
 async fn approval_store_rejects_second_resolution_attempt() {
-    let store = InMemoryApprovalRequestStore::new();
+    let store = in_mem_approval_request_store();
     let invocation_id = InvocationId::new();
     let scope = sample_scope(invocation_id, "tenant1", "user1");
     let approval = approval_request(invocation_id);
@@ -75,7 +75,7 @@ async fn approval_store_rejects_second_resolution_attempt() {
 
 #[tokio::test]
 async fn approval_store_rejects_duplicate_pending_save() {
-    let store = InMemoryApprovalRequestStore::new();
+    let store = in_mem_approval_request_store();
     let invocation_id = InvocationId::new();
     let scope = sample_scope(invocation_id, "tenant1", "user1");
     let approval = approval_request(invocation_id);
@@ -157,6 +157,15 @@ async fn filesystem_approval_store_rejects_duplicate_pending_save() {
 
 fn engine_filesystem() -> ironclaw_filesystem::InMemoryBackend {
     ironclaw_filesystem::InMemoryBackend::new()
+}
+
+/// The production approval-request store over a fresh in-memory backend — the
+/// drop-in for the deleted `InMemoryApprovalRequestStore` (arch-simplification §4.3).
+fn in_mem_approval_request_store()
+-> ironclaw_run_state::FilesystemApprovalRequestStore<ironclaw_filesystem::InMemoryBackend> {
+    ironclaw_run_state::FilesystemApprovalRequestStore::new(scoped_run_state_fs(
+        std::sync::Arc::new(engine_filesystem()),
+    ))
 }
 
 /// Build a [`ScopedFilesystem`] exposing `/run-state` and `/approvals`

--- a/crates/ironclaw_run_state/tests/run_state_contract.rs
+++ b/crates/ironclaw_run_state/tests/run_state_contract.rs
@@ -1,3 +1,4 @@
+// arch-exempt: large_file, mechanical run-state/approval store repoint to Filesystem*Store<InMemoryBackend> helpers + cross-tenant coexistence reconciliation (arch-simplification §4.3), plan #6168
 use std::{
     sync::Arc,
     sync::atomic::{AtomicBool, AtomicUsize, Ordering},
@@ -38,7 +39,7 @@ fn legacy_run_record_without_authenticated_actor_deserializes_to_none() {
 
 #[tokio::test]
 async fn in_memory_run_state_tracks_running_to_completed() {
-    let store = InMemoryRunStateStore::new();
+    let store = in_mem_run_state_store();
     let invocation_id = InvocationId::new();
     let capability_id = CapabilityId::new("echo.say").unwrap();
     let scope = sample_scope(invocation_id, "tenant1", "user1");
@@ -71,7 +72,7 @@ async fn in_memory_run_state_tracks_running_to_completed() {
 
 #[tokio::test]
 async fn in_memory_run_state_tracks_blocked_approval_with_request_id() {
-    let store = InMemoryRunStateStore::new();
+    let store = in_mem_run_state_store();
     let invocation_id = InvocationId::new();
     let scope = sample_scope(invocation_id, "tenant1", "user1");
     store
@@ -97,7 +98,7 @@ async fn in_memory_run_state_tracks_blocked_approval_with_request_id() {
 
 #[tokio::test]
 async fn in_memory_run_state_tracks_failed_with_error_kind() {
-    let store = InMemoryRunStateStore::new();
+    let store = in_mem_run_state_store();
     let invocation_id = InvocationId::new();
     let scope = sample_scope(invocation_id, "tenant1", "user1");
     store
@@ -121,7 +122,7 @@ async fn in_memory_run_state_tracks_failed_with_error_kind() {
 
 #[tokio::test]
 async fn run_state_transitions_fail_for_unknown_invocation() {
-    let store = InMemoryRunStateStore::new();
+    let store = in_mem_run_state_store();
     let missing = InvocationId::new();
     let scope = sample_scope(missing, "tenant1", "user1");
 
@@ -134,7 +135,7 @@ async fn run_state_transitions_fail_for_unknown_invocation() {
 
 #[tokio::test]
 async fn in_memory_run_state_rejects_duplicate_invocation_in_same_tenant_user() {
-    let store = InMemoryRunStateStore::new();
+    let store = in_mem_run_state_store();
     let invocation_id = InvocationId::new();
     let scope = sample_scope(invocation_id, "tenant1", "user1");
 
@@ -262,14 +263,28 @@ async fn filesystem_run_state_duplicate_start_is_serialized_across_store_instanc
     );
 }
 
+/// The same invocation_id under two tenants coexists because each tenant resolves
+/// to a distinct `/run-state` mount subtree (arch-simplification §4.3 — the store
+/// no longer hand-keys the full scope tuple; tenant/user come from the mount). Two
+/// per-tenant-mounted stores over one shared backend model that.
 #[tokio::test]
-async fn in_memory_run_state_allows_same_invocation_id_in_different_tenants() {
-    let store = InMemoryRunStateStore::new();
+async fn run_state_allows_same_invocation_id_in_different_tenants() {
+    let backend = Arc::new(engine_filesystem());
+    let store_a = FilesystemRunStateStore::new(scoped_run_state_fs_at(
+        Arc::clone(&backend),
+        "tenant1",
+        "user1",
+    ));
+    let store_b = FilesystemRunStateStore::new(scoped_run_state_fs_at(
+        Arc::clone(&backend),
+        "tenant2",
+        "user1",
+    ));
     let invocation_id = InvocationId::new();
     let tenant_a = sample_scope(invocation_id, "tenant1", "user1");
     let tenant_b = sample_scope(invocation_id, "tenant2", "user1");
 
-    store
+    store_a
         .start(RunStart {
             invocation_id,
             capability_id: CapabilityId::new("echo.one").unwrap(),
@@ -278,7 +293,7 @@ async fn in_memory_run_state_allows_same_invocation_id_in_different_tenants() {
         })
         .await
         .unwrap();
-    store
+    store_b
         .start(RunStart {
             invocation_id,
             capability_id: CapabilityId::new("echo.two").unwrap(),
@@ -289,7 +304,7 @@ async fn in_memory_run_state_allows_same_invocation_id_in_different_tenants() {
         .unwrap();
 
     assert_eq!(
-        store
+        store_a
             .get(&tenant_a, invocation_id)
             .await
             .unwrap()
@@ -298,7 +313,7 @@ async fn in_memory_run_state_allows_same_invocation_id_in_different_tenants() {
         CapabilityId::new("echo.one").unwrap()
     );
     assert_eq!(
-        store
+        store_b
             .get(&tenant_b, invocation_id)
             .await
             .unwrap()
@@ -310,7 +325,7 @@ async fn in_memory_run_state_allows_same_invocation_id_in_different_tenants() {
 
 #[tokio::test]
 async fn in_memory_run_state_hides_records_from_other_tenants_and_users() {
-    let store = InMemoryRunStateStore::new();
+    let store = in_mem_run_state_store();
     let invocation_id = InvocationId::new();
     let tenant_a = sample_scope(invocation_id, "tenant1", "user1");
     let tenant_b = sample_scope(invocation_id, "tenant2", "user1");
@@ -495,7 +510,7 @@ async fn filesystem_approval_request_listing_ignores_records_deleted_after_list(
 
 #[tokio::test]
 async fn in_memory_approval_request_store_discards_pending_request() {
-    let store = InMemoryApprovalRequestStore::new();
+    let store = in_mem_approval_request_store();
     let invocation_id = InvocationId::new();
     let scope = sample_scope(invocation_id, "tenant1", "user1");
     let approval = approval_request(invocation_id);
@@ -532,7 +547,7 @@ async fn filesystem_approval_request_store_discards_pending_request() {
 /// the tombstone. Sibling of `filesystem_discard_tombstone_prevents_request_id_reuse`.
 #[tokio::test]
 async fn in_memory_discard_tombstone_prevents_request_id_reuse() {
-    let store = InMemoryApprovalRequestStore::new();
+    let store = in_mem_approval_request_store();
     let invocation_id = InvocationId::new();
     let scope = sample_scope(invocation_id, "tenant1", "user1");
     let approval = approval_request(invocation_id);
@@ -745,25 +760,38 @@ async fn filesystem_discard_toctou_race_loses_to_concurrent_approve() {
     assert_eq!(record.status, ApprovalStatus::Approved);
 }
 
+/// Same approval request_id under two tenants coexists via distinct `/approvals`
+/// mount subtrees (arch-simplification §4.3), modeled with two per-tenant-mounted
+/// stores over one shared backend.
 #[tokio::test]
-async fn in_memory_approval_store_allows_same_request_id_in_different_tenants() {
-    let store = InMemoryApprovalRequestStore::new();
+async fn approval_store_allows_same_request_id_in_different_tenants() {
+    let backend = Arc::new(engine_filesystem());
+    let store_a = FilesystemApprovalRequestStore::new(scoped_run_state_fs_at(
+        Arc::clone(&backend),
+        "tenant1",
+        "user1",
+    ));
+    let store_b = FilesystemApprovalRequestStore::new(scoped_run_state_fs_at(
+        Arc::clone(&backend),
+        "tenant2",
+        "user1",
+    ));
     let invocation_id = InvocationId::new();
     let tenant_a = sample_scope(invocation_id, "tenant1", "user1");
     let tenant_b = sample_scope(invocation_id, "tenant2", "user1");
     let approval = approval_request(invocation_id);
 
-    store
+    store_a
         .save_pending(tenant_a.clone(), approval.clone())
         .await
         .unwrap();
-    store
+    store_b
         .save_pending(tenant_b.clone(), approval.clone())
         .await
         .unwrap();
 
     assert_eq!(
-        store
+        store_a
             .get(&tenant_a, approval.id)
             .await
             .unwrap()
@@ -772,7 +800,7 @@ async fn in_memory_approval_store_allows_same_request_id_in_different_tenants() 
         tenant_a
     );
     assert_eq!(
-        store
+        store_b
             .get(&tenant_b, approval.id)
             .await
             .unwrap()
@@ -817,7 +845,7 @@ async fn approval_request_store_hides_records_from_other_tenants_and_users() {
 
 #[tokio::test]
 async fn run_state_isolates_records_by_agent_scope() {
-    let store = InMemoryRunStateStore::new();
+    let store = in_mem_run_state_store();
     let invocation_id = InvocationId::new();
     let agent_a = sample_scope_with_agent(invocation_id, "tenant1", "user1", Some("agent-a"));
     let agent_b = sample_scope_with_agent(invocation_id, "tenant1", "user1", Some("agent-b"));
@@ -865,7 +893,7 @@ async fn filesystem_run_state_uses_agent_scoped_paths() {
 
 #[tokio::test]
 async fn approval_request_store_isolates_records_by_agent_scope() {
-    let store = InMemoryApprovalRequestStore::new();
+    let store = in_mem_approval_request_store();
     let invocation_id = InvocationId::new();
     let agent_a = sample_scope_with_agent(invocation_id, "tenant1", "user1", Some("agent-a"));
     let agent_b = sample_scope_with_agent(invocation_id, "tenant1", "user1", Some("agent-b"));
@@ -886,7 +914,7 @@ async fn approval_request_store_isolates_records_by_agent_scope() {
 
 #[tokio::test]
 async fn run_state_isolates_records_by_project_scope() {
-    let store = InMemoryRunStateStore::new();
+    let store = in_mem_run_state_store();
     let invocation_id = InvocationId::new();
     let project_a = sample_scope(invocation_id, "tenant1", "user1");
     let mut project_b = project_a.clone();
@@ -954,7 +982,7 @@ async fn filesystem_run_state_isolates_records_by_project_scope() {
 
 #[tokio::test]
 async fn run_state_clears_stale_approval_request_on_non_approval_transitions() {
-    let store = InMemoryRunStateStore::new();
+    let store = in_mem_run_state_store();
     let invocation_id = InvocationId::new();
     let scope = sample_scope(invocation_id, "tenant1", "user1");
     store
@@ -997,7 +1025,7 @@ async fn run_state_clears_stale_approval_request_on_non_approval_transitions() {
 
 #[tokio::test]
 async fn approval_request_store_isolates_records_by_project_scope() {
-    let store = InMemoryApprovalRequestStore::new();
+    let store = in_mem_approval_request_store();
     let invocation_id = InvocationId::new();
     let project_a = sample_scope(invocation_id, "tenant1", "user1");
     let mut project_b = project_a.clone();
@@ -1507,6 +1535,21 @@ impl RootFilesystem for DisappearingApprovalReadFilesystem {
 /// keep working unchanged.
 fn engine_filesystem() -> InMemoryBackend {
     InMemoryBackend::new()
+}
+
+/// The production run-state store over a fresh in-memory backend — the drop-in
+/// for the deleted `InMemoryRunStateStore` (arch-simplification §4.3). Single
+/// fixed `/run-state` mount: isolates by agent/project/mission/thread (path) but
+/// not tenant/user (mount-scoped); cross-tenant isolation is exercised by the
+/// `filesystem_run_state_store_hides_records_from_other_tenants_and_users` test.
+fn in_mem_run_state_store() -> FilesystemRunStateStore<InMemoryBackend> {
+    FilesystemRunStateStore::new(scoped_run_state_fs(Arc::new(engine_filesystem())))
+}
+
+/// The production approval-request store over a fresh in-memory backend — the
+/// drop-in for the deleted `InMemoryApprovalRequestStore`.
+fn in_mem_approval_request_store() -> FilesystemApprovalRequestStore<InMemoryBackend> {
+    FilesystemApprovalRequestStore::new(scoped_run_state_fs(Arc::new(engine_filesystem())))
 }
 
 /// Wrap a [`RootFilesystem`] in a [`ScopedFilesystem`] that exposes

--- a/tests/integration/support/doubles/recording_approval_request_store.rs
+++ b/tests/integration/support/doubles/recording_approval_request_store.rs
@@ -1,6 +1,5 @@
-/// Test double substituting the production `ApprovalRequestStore` impls
-/// (`InMemoryApprovalRequestStore` / `FilesystemApprovalRequestStore`,
-/// `crates/ironclaw_run_state/src/lib.rs`).
+/// Test double substituting the production `ApprovalRequestStore` impl
+/// (`FilesystemApprovalRequestStore`, `crates/ironclaw_run_state/src/lib.rs`).
 use std::{
     collections::HashMap,
     sync::{Arc, Mutex},

--- a/tests/integration/support/harness/mod.rs
+++ b/tests/integration/support/harness/mod.rs
@@ -1475,7 +1475,9 @@ impl HostRuntimeCapabilityHarness {
             .approval_parts
             .as_ref()
             .map(|parts| Arc::clone(&parts.approval_requests))
-            .unwrap_or_else(|| Arc::new(ironclaw_run_state::InMemoryApprovalRequestStore::new()));
+            .unwrap_or_else(|| {
+                Arc::new(ironclaw_run_state::in_memory_backed_approval_request_store())
+            });
         let approval_requests: Arc<dyn ironclaw_run_state::ApprovalRequestStore> =
             Arc::new(super::doubles::RecordingApprovalRequestStore {
                 inner: inner_approval_requests,


### PR DESCRIPTION
## Slice A4 of the architecture-simplification note — run-state + approval stores

Stacked on #6200 (processes). Implements **Slice A** of `docs/reborn/2026-07-17-architecture-simplification-dto-dyn-local.md` (§4.3) for the **run_state** domain — the last small Slice-A domain before turns. One production `FilesystemRunStateStore<F>` / `FilesystemApprovalRequestStore<F>` pair (over `InMemoryBackend` in tests, libSQL/Postgres in production) replaces `InMemoryRunStateStore` / `InMemoryApprovalRequestStore`.

> **Base:** `refactor/reborn-processes-stores-over-rootfs` (#6200), not `main` — stacked so the diff is only the A4 slice. Rebase onto `main` once #6200 merges.

### What changed
- **`ironclaw_run_state`** — deletes both `InMemory*Store`s and their private keys (`RunStateKey`, `ApprovalKey`) from `lib.rs`. Adds a `test-support`-gated helper module (`in_memory_backed_run_state_store` / `_approval_request_store` / `_run_state_filesystem`); the filesystem mounts **both** `/run-state` and `/approvals`.
- **composition `factory.rs`** — no-durable `LocalDev{RunState,ApprovalRequest}Store` aliases collapse to the `<InMemoryBackend>` filesystem stores; the no-durable builder wires both over the shared `approvals_filesystem`. The `use ironclaw_run_state::{Filesystem*Store}` import is now unconditional (was durable-cfg-gated).
- **host_runtime production-wiring guard** — `LocalOnly` classification keys on the `Filesystem*Store<InMemoryBackend>` types instead of the deleted InMemory ones.
- **~24 downstream test files** across host_runtime, capabilities, approvals, product_workflow, composition, and the root integration harness repoint to the helpers; consuming crates enable `ironclaw_run_state/test-support` in `[dev-dependencies]`.

### Behavioral reconciliation (the doc's "reconcile-then-delete")
Tenant/user isolation is **mount-structural** (tenant/user come from the `MountView`, not the record key). The store's `get`/transitions check `same_scope_owner` **on read**, so cross-tenant "hides / fails-closed" tests pass even on a single fixed mount. The only cases needing per-tenant mounts are the "same id in **different tenants coexist**" tests (two tenants collide at the same path on `start`/`save_pending`) — reconciled to two per-tenant-mounted stores over one backend, mirroring the existing `filesystem_*_hides_records_from_other_tenants` tests. Run-state and approval records live under distinct aliases with no cross-read, so standalone in-memory backends per store stay self-consistent (no shared-backend plumbing needed, unlike the processes `output_ref` case in #6200).

### Safety
Net subtractive. No trust-boundary or persistence-compatibility change: the in-memory stores were volatile/test-only; the durable backends are untouched.

### Verification
- **Tests green** (`NEARAI_API_KEY` unset): `ironclaw_run_state` (34), `ironclaw_capabilities` (15+), `ironclaw_approvals` (4), `ironclaw_product_workflow` (14), `ironclaw_host_runtime` (25+), `ironclaw_reborn_composition` (green). No shared-backend or cross-tenant regressions.
- clippy `-D warnings` clean on run_state, capabilities, approvals, product_workflow, host_runtime, composition (default + no-durable).
- `scripts/pre-commit-safety.sh` clean; large-file arch-exempt added for the one over-budget test file.
- ⚠️ Rebased onto the current #6200 head (which had a CI-fix commit); the rebase applied with zero conflicts and the commit is self-contained. CI is the authoritative gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
