### PR TITLE
docs(reborn): architecture-simplification r2–r7 — capability conduits, dynamic-capability gate contract, editorial dedup

### DIFF
--- a/docs/reborn/2026-07-17-architecture-simplification-dto-dyn-local.md
+++ b/docs/reborn/2026-07-17-architecture-simplification-dto-dyn-local.md
@@ -304,8 +304,8 @@ Separate the **data plane** (the payload, which never changes shape) from the
 // ── ironclaw_host_api (the bottom crate everyone already depends on) ──
 // The loop's pre-trust request — the one genuine loop→host transition (§1.1):
 struct LoopRequest { activity_id: ActivityId, capability: CapabilityId, input_ref: InputRef, resume: Option<ResumeToken> }
-// The host-side payload, resolved at the membrane (input deref'd, actor+scope bound):
-struct Invocation  { activity_id: ActivityId, capability: CapabilityId, input: Json, scope: Scope, actor: ActorId, estimate: Estimate }
+// The host-side payload, resolved at the membrane (input deref'd, actor+scope+origin bound):
+struct Invocation  { activity_id: ActivityId, capability: CapabilityId, input: Json, scope: Scope, actor: ActorId, origin: InvocationOrigin, estimate: Estimate }
 struct Authorized  { /* Invocation + trust/approval/reservation/mounts — SEALED: private, built only by authorize() */ }
 enum   Blocked     { Approval(GateRef), Auth(GateRef), Resource(GateRef) }  // re-entrant gates
 enum   HostFailure { Transient(ErrRef), Permanent(ErrRef) }                 // infra/storage/obligation-cleanup failure
@@ -335,6 +335,11 @@ fn dispatch (auth: &Authorized, lane: &RuntimeLane) -> Result<Outcome, HostFailu
   failure (`Transient` retryable vs `Permanent`); `Outcome` = the tool's own success or
   recoverable failure (model-visible). `invoke = Result<Outcome, InvokeError>` with
   `InvokeError = Blocked | HostFailure` — each failure class in its own channel.
+- **`origin` is sealed at the membrane, like `actor` and `scope`.** The loop is not the
+  only caller of this pipeline: products invoke capabilities directly (settings mutations,
+  admin actions — `ProductSurface::invoke`, §5.2) and so does automation. Each entry point
+  can mint only its own `InvocationOrigin` variant (§5.2.1), and `authorize()` folds origin
+  into policy — per-origin capability allowlists, origin-dependent approval semantics.
 - **`activity_id` is the invocation's idempotency identity** — what §1.1's "dead-future
   `idempotency_key`" *becomes* (unified with the existing `activity_id`, not deleted). The
   host records the authorize/outcome against `activity_id` **before** dispatch; a retry of
@@ -625,16 +630,28 @@ The kernel is the only layer that owns authority; substrates are mechanism it
 mediates; products and loops are replaceable userland reaching the kernel through
 exactly two interfaces (`ProductSurface`, `AgentLoopHost`).
 
-### 5.2 The clean product-surface interface — one, generic, feature-agnostic
+### 5.2 The clean product-surface interface — turn lifecycle plus two generic conduits
 
-Every product talks to the system through **one** narrow interface. Adding a feature
-never adds a method here (that was the change-amplification cost — a feature touching
-5–8 crates because each product method was per-feature). A feature is a new capability
-+ descriptor; the product interface is unchanged.
+Every product talks to the system through **one** narrow interface. An earlier
+draft of this section claimed six conversation methods could carry the whole
+product; that fails by inspection — the proto-`ProductSurface` this replaces
+(`RebornServicesApi`, `ironclaw_product_workflow/src/reborn_services.rs`) has
+**~251 async methods** (verified 2026-07-17), and most are not conversation
+operations: settings mutations, extension install/configure, thread/project
+listing, LLM admin. A conversation API cannot absorb them, and per-feature
+methods must not return (that was the change-amplification cost — a feature
+touching 5–8 crates because each product method was per-feature). The
+resolution is the repo's own standing rule (`.claude/rules/tools.md`):
+**user-triggered mutations go through capability authorization; pure reads go
+through typed query contracts.** Applied here, the product surface is the
+*turn lifecycle* — the kernel's own state machine, irreducible as methods —
+plus **two generic conduits that never grow: `invoke` for commands, `query`
+for reads.**
 
 ```rust
-/// The ONLY surface a product uses. A generic conduit, not a per-feature API.
+/// The ONLY surface a product uses. Turn lifecycle + two conduits; frozen.
 trait ProductSurface {
+    // ── Turn lifecycle — the kernel's state machine (§11.1); irreducible ──
     fn open_conversation(&self, actor: Actor, source: SourceBinding) -> ConversationId;
     fn submit_turn(&self, conv: ConversationId, msg: InboundMessage,
                    idem: IdempotencyKey) -> Result<TurnRunId, SubmitError>;   // all inbound → one door
@@ -642,18 +659,138 @@ trait ProductSurface {
     fn reply(&self, run: TurnRunId) -> Result<AssistantReply, ReplyError>;
     fn resolve_gate(&self, gate: GateRef, decision: GateDecision) -> Result<(), GateError>; // approval/auth
     fn cancel(&self, run: TurnRunId, idem: IdempotencyKey) -> Result<(), CancelError>;
+
+    // ── Commands: the product-side twin of AgentLoopHost::invoke (§5.4).
+    //    Same resolve → authorize → dispatch pipeline (§3), different origin. ──
+    fn invoke(&self, actor: AuthenticatedActor, capability: CapabilityId,
+              input: Json, idem: IdempotencyKey) -> Result<Outcome, InvokeError>;
+
+    // ── Reads: view descriptors over projections; scope-checked, no dispatch. ──
+    fn query(&self, actor: AuthenticatedActor, view: ViewRef,
+             params: Json, cursor: Option<Cursor>) -> Result<ViewPage, QueryError>;
 }
 ```
 
-Six methods, all feature-agnostic. A new settings page, a new tool, a new model
-selector — none add a method; they add a capability the loop can invoke and
-(optionally) one event variant on the projection stream.
+A feature — a settings page, a new tool, a model selector, an admin action —
+adds a **capability descriptor** (+ handler on the `FirstParty` lane) and/or a
+**view descriptor**, and optionally one event variant on the projection
+stream. Never a method. This generalizes §13.3's synthetic-capability
+promotion: the four synthetic product tools are simply the *first four* facade
+operations to make the migration every mutation makes.
+
+### 5.2.1 Origin is part of the `Invocation`, folded by `authorize()`
+
+```rust
+enum InvocationOrigin {
+    LoopRun(TurnRunId),      // model-initiated, trust-attenuated
+    Product(ProductKind),    // direct authenticated user action
+    Automation(RoutineId),   // routine / heartbeat / scheduled
+}
+```
+
+`Invocation` (§3) gains `origin: InvocationOrigin` as a **required** field,
+sealed at the membrane exactly like `actor` and `scope`: product ingress can
+only mint `Product`, the loop host can only mint `LoopRun` — neither can claim
+the other's origin. The seeds already exist in the vocabulary:
+`ExecutionContext.authenticated_actor_user_id` ("authenticated human actor
+sealed by trusted ingress") is the actor binding, and `Principal::System` is
+the automation identity.
+
+Three consequences, all landing in the single `authorize()` fold:
+
+1. **Per-origin capability policy, deny-by-default.** Every descriptor
+   declares which origins may invoke it (`settings.llm_provider_set` →
+   Product-only; `shell` → LoopRun-only; `skill_activate` → both). This is a
+   security *upgrade* over the facade, where the loop/product split is
+   implicit in which trait happens to have the method; after the change it is
+   one auditable declaration per capability. The corresponding risk must be
+   named: the namespace becomes one flat surface, so an origin-policy bug
+   exposes an admin capability to the model. Deny-by-default plus an
+   `ironclaw_architecture` test — *a descriptor with no explicit origin
+   declaration fails* — is the non-negotiable mitigation, not a nicety.
+2. **Approval semantics differ by origin — deliberately.** Approval gates
+   exist to obtain user consent for *model-initiated* actions. A
+   `Product`-origin invocation carries its consent in the act — the user
+   clicked. So `authorize()` auto-satisfies approval gates for `Product`
+   origin, while **auth gates** (credential needed → `Blocked::Auth` →
+   `resolve_gate`) and **resource gates** apply uniformly to every origin.
+   Extension OAuth onboarding from a settings page and from a mid-turn tool
+   call become literally one code path — the shared-resolver requirement the
+   extension/auth invariants (CLAUDE.md) have demanded all along.
+3. **Automation stops being special.** Routines/heartbeat invoke with
+   `Automation` origin under the same descriptor policy — deleting the
+   parallel dispatch path that `composition/src/automation/` (§5.8) wires
+   today.
+
+### 5.2.2 Reads are views, not dispatch
+
+Forcing `GET`-shaped reads through authorize/dispatch/idempotency records is
+ceremony with no invariant behind it, and `tools.md` already draws the line
+("pure product reads through typed query/facade contracts"). The split is
+CQRS-shaped: **commands are capability descriptors; reads are view
+descriptors over the read models/projections**, registered as data the same
+way. `query(view, params, cursor)` is the request/response half of the read
+side; `events(conv, cursor)` is the streaming half. Access is scope-checked
+at the view boundary; no dispatch pipeline, no idempotency record.
+
+### 5.2.3 What irreducibly stays as methods
+
+- **Turn lifecycle.** `submit_turn` cannot itself be a capability without
+  circularity — capabilities execute *inside* turns, and the coordinator owns
+  the active-lock and idempotency machinery that gives `submit` its meaning.
+  These six methods are frozen because the *turn model* is frozen (§11.1).
+- **Identity/session establishment** (SSO, pairing). An invocation cannot be
+  authorized before the actor is known; login lives below the
+  `AuthenticatedActor` boundary, in ingress (§5.8).
+- **Transport** (asset serving, SSE/WS framing) stays in the adapters.
+
+### 5.2.4 The honest cost: type safety moves from the compiler to descriptors
+
+~251 typed methods become descriptors + `Json` input — the compile-time
+contract becomes a runtime schema check. Per `.claude/rules/types.md` this is
+acceptable exactly when the `Json` is treated as a boundary format:
+
+- **Handlers deserialize into a typed request struct as their first act**
+  (identical to capability handlers today); no stringly-typed value crosses
+  into internal flow.
+- **The frontend contract is generated from descriptor schemas** (TS types
+  from the same source of truth), so wire and handler cannot drift.
+- **Every capability ships a conformance case** in the §11.7 harness:
+  allow/deny per origin, invalid input, idempotent replay.
+
+**Atomicity rule: one user gesture = one capability.** Compound operations
+(persist-then-reload, `.claude/rules/error-handling.md`) live *inside* one
+handler, which owns the transaction/rollback — a product never sequences two
+`invoke`s and hopes.
+
+### 5.2.5 Migration and ratchet (feeds §10)
+
+1. **Freeze the facade now.** Check in the current `RebornServicesApi` method
+   set as a set-membership allowlist in `ironclaw_architecture`; any *new*
+   facade method fails CI. New product features land as descriptors from day
+   one — the ratchet stops the bleeding before any migration happens.
+2. **Slice 1 is already decided:** the four synthetic tools (§13.3).
+3. **Then facade mutations, opportunistically** — settings first (simplest
+   handlers), each migration shrinking the allowlist monotonically. Every
+   migrated mutation gains audit, idempotency, redaction, and per-origin
+   policy for free, from the one pipeline.
+4. **Reads migrate to view descriptors separately and later** — lower risk,
+   lower value.
+5. **Definition of done:** the facade *is* this trait — six turn methods +
+   `invoke` + `query` — and the URT's Deletion/Addition tests (§5.9, §10)
+   pass over it.
+
+One further payoff: a WASM extension's capabilities become invocable from
+`Product` origin under the same descriptor policy — extension settings pages
+stop needing bespoke host wiring at all, which is the URT's adapter thesis
+(§5.9) arriving from the kernel side.
 
 ### 5.3 The kernel capability interface — authorize + dispatch
 
 ```rust
 // host_api vocabulary — the frozen kernel types (§4.5)
-struct Invocation { activity_id: ActivityId, capability: CapabilityId, input: Json, scope: Scope, actor: ActorId, estimate: Estimate }
+struct Invocation { activity_id: ActivityId, capability: CapabilityId, input: Json, scope: Scope, actor: ActorId, origin: InvocationOrigin, estimate: Estimate }
+enum   InvocationOrigin { LoopRun(TurnRunId), Product(ProductKind), Automation(RoutineId) }  // sealed per entry point (§5.2.1)
 struct Authorized { /* the Invocation bound to trust/approval/reservation/mounts — SEALED: private, built only by authorize() */ }
 enum   Blocked    { Approval(GateRef), Auth(GateRef), Resource(GateRef) }
 enum   HostFailure { Transient(ErrRef), Permanent(ErrRef) }
@@ -686,6 +823,11 @@ This is the loop's boundary; it is not the only one (§2). Below it, `dispatch` 
 to an **untrusted** `RuntimeLane` (§5.5) with mediated handles, and the `Outcome` it
 returns is **untrusted data** the host validates, bounds, and redacts before it reaches the
 loop or the model. The substrate ports below are where those other two boundaries live.
+
+`AgentLoopHost::invoke` has a product-side twin — `ProductSurface::invoke` (§5.2) — and
+both funnel into the same `authorize` + `dispatch` (§5.3), distinguished only by the
+sealed `InvocationOrigin` each membrane binds (§5.2.1). There is one capability pipeline,
+entered from two membranes.
 
 ### 5.5 Substrate interfaces — mechanism behind narrow ports
 
@@ -735,9 +877,10 @@ flowchart TD
     RL["Runtime lanes: Wasm · Script · Mcp · FirstParty"]
     CFG["DeploymentConfig (data)"]
 
-    P -->|ProductSurface| TC
+    P -->|ProductSurface: turns| TC
+    P -->|"invoke (Product origin)"| CAP
     TC -->|AgentLoopHost| L
-    L -->|invoke Invocation| CAP
+    L -->|"invoke (LoopRun origin)"| CAP
     CAP --> RL
     RL --> FS
     RL --> PS
@@ -748,10 +891,11 @@ flowchart TD
     CFG -. selects .-> FS
 ```
 
-Products enter through **one** interface (`ProductSurface`); loops reach effects
-through **one** membrane (`AgentLoopHost`) that funnels to `authorize`+`dispatch`;
-substrates are mechanism the kernel mediates; and `DeploymentConfig` (data) is the
-only thing that varies per deployment. The kernel box is the slow-moving part — it
+Products enter through **one** interface (`ProductSurface`): turn traffic goes to the
+coordinator, product mutations go straight to `authorize`+`dispatch` via `invoke` under
+`Product` origin (§5.2.1); loops reach effects through **one** membrane (`AgentLoopHost`)
+that funnels to the same `authorize`+`dispatch`; substrates are mechanism the kernel
+mediates; and `DeploymentConfig` (data) is the only thing that varies per deployment. The kernel box is the slow-moving part — it
 changes when the security/recovery model changes, never when a product or feature is
 added.
 
@@ -785,7 +929,10 @@ adapters (their deliver / auth side) or the kernel, not the assembler:
 - `composition/src/outbound/` (~1.8K) — delivery → the adapter's deliver path over the
   outbound port.
 - `composition/src/automation/` (~6.1K), `llm_admin/` (~8.5K) — these are *product
-  surfaces* (a triggers UI, an admin API); each is an adapter, not composition code.
+  operations*, not composition code: their mutations become origin-declared capability
+  descriptors + handlers and their reads become view descriptors (§5.2); what remains is a
+  thin frontend, not an adapter crate's worth of host code. Automation additionally stops
+  being a parallel dispatch path — routines invoke under `Automation` origin (§5.2.1).
 - `composition/src/runtime/` (~14.5K) — the `LocalDev*` capability wiring + synthetic
   capabilities (§4.4): promote the synthetic ops to first-party capabilities; the rest is
   config-gated middleware.
@@ -926,6 +1073,7 @@ plus a test that *proves* containment. That is the entire thesis in one incident
 | `LocalDev*` identifiers | ~66 across 42 files | 0 (one `DeploymentConfig` value) |
 | Deployment modes | struct family (`Local*`/`Hosted*`) | `DeploymentConfig` constants (data) |
 | `host_api` boundary | ~124 types incl. mode/policy | neutral authority vocab, frozen by test |
+| Product facade | ~251-method `RebornServicesApi` | turn lifecycle + `invoke`/`query` (8 methods); mutations are origin-declared descriptors (§5.2) |
 
 ---
 
@@ -1026,6 +1174,7 @@ type duplication in `scripts/check-type-duplicates.py`, cross-tenant behavior in
 | `Local*` types (§4.4) | no `Local` / `LocalDev` / `Hosted` / `Enterprise` in public type names | `ironclaw_architecture` | freeze the ~66-identifier allowlist; fail on any new one | allowlist empty |
 | `host_api` freeze (§4.5) | checked-in allowlist of public type names; `runtime_policy` mode enums absent from `host_api` | `ironclaw_architecture` | freeze the allowlist (set membership); a new type needs a justified allowlist entry | mode enums moved to the edge; only neutral authority vocab remains |
 | Products in composition (§5.8) | no `slack` / `webui` / `telegram` / `openai` / HTTP-route / transport identifier in `ironclaw_reborn_composition` | `ironclaw_architecture` | freeze the current product footprint; fail on new product/transport code landing in composition | composition is assembler-only; products are adapters + a `DeploymentConfig` list |
+| Product facade (§5.2) | `RebornServicesApi` method-set allowlist; every capability descriptor declares allowed origins | `ironclaw_architecture` | freeze the current ~251-method set (set membership); fail on any new method; fail on any descriptor without an explicit origin declaration | facade = turn lifecycle + `invoke`/`query`; all mutations are origin-declared descriptors |
 
 Each axis's "hard ban" column is also its **definition of done**: the migration slice for
 that axis is complete when its ratchet flips from a frozen allowlist to an empty one (or the
@@ -1144,7 +1293,9 @@ Each kernel interface (§5) ships a conformance suite every implementation must 
 adapter/loop/backend inherits correctness instead of re-deriving it:
 
 - **`ProductSurface`** — submit/observe/reply/gate/cancel semantics + idempotency, run against
-  every product adapter (§5.8).
+  every product adapter (§5.8); plus the `invoke`/`query` conduits (§5.2): per-origin
+  allow/deny, rejection of a descriptor with no origin declaration, and idempotent replay
+  of a product mutation.
 - **`AgentLoopHost`** — the trust membrane: a loop reaches effects only through it; direct
   dispatcher/secret/network access is a compile error (boundary test).
 - **`authorize` / `dispatch`** — authority-before-effect, redaction, fail-closed.
@@ -1285,7 +1436,9 @@ decorator gating and synthetic-capability promotion are settled here.**
   scope-binding/mounts for free — closing the scope-binding gap the synthetic handlers
   have (e.g. `result_read` / `outbound_delivery` must be user-scoped). The only
   pre-promotion check is that each descriptor declares the correct scope and defaults
-  hidden until reviewed for the hosted surface.
+  hidden until reviewed for the hosted surface. This promotion is **Slice 1 of the §5.2.5
+  facade migration**: the same descriptor + per-origin-policy shape then absorbs the
+  `RebornServicesApi` mutations one by one.
 
 **Genuinely remaining (tuning/ops, not architecture):** the lease-TTL latency multiplier
 `k` in `lease_ttl ≥ k × backend_p99_write` (§12), and the default `RootFilesystem` backend
@@ -1300,6 +1453,7 @@ knobs to calibrate against measured latency, not open architectural questions.
 - `docs/reborn/2026-05-11-trust-boundary-stack-note.md` — trust-boundary baseline invariants.
 - `docs/reborn/2026-04-25-storage-catalog-and-placement.md` — storage placement.
 - `crates/ironclaw_host_api/` — the neutral vocabulary crate (target home for `Invocation`/`Authorized`/`Outcome`); ~124 public types across 21 files (§4.5).
+- `crates/ironclaw_product_workflow/src/reborn_services.rs` — `RebornServicesApi`: the ~251-method proto-`ProductSurface` that §5.2's `invoke`/`query` conduits replace (methods → origin-declared capability descriptors + view descriptors).
 - `crates/ironclaw_host_api/src/runtime_policy.rs` — `DeploymentMode` / `RuntimeProfile`: the deployment-mode enums that leaked into the kernel vocabulary (§4.4–§4.5).
 - `crates/ironclaw_runtime_policy/` — `EffectiveRuntimePolicy`: the resolved policy *data* the kernel should consume instead of a mode enum.
 - `crates/ironclaw_filesystem/src/in_memory.rs` — `InMemoryBackend: RootFilesystem`: the existing seam that makes every `InMemory*Store` deletable (§4.3).

--- a/docs/reborn/2026-07-17-architecture-simplification-dto-dyn-local.md
+++ b/docs/reborn/2026-07-17-architecture-simplification-dto-dyn-local.md
@@ -17,6 +17,14 @@ annotations and `.claude/rules/architecture.md` cite them; additions get
   `Process` (§4.2/§5.9), served-predicate for `LocalOnlyToken` (§6), evidence
   reframed (§1.5), `type-placement.md` reconciliation (§4.2), batch modeled
   (§11.1), Slice 0 + URT ordering (§9).
+- **r4** 2026-07-17 — PR #6208 review fixes: served predicate tightened (any
+  non-loopback listener/tunnel counts, epoch-synchronized transition, §6);
+  `SpawnedChildRun` correctly non-suspending (§5.3); `ProductSurface`
+  actor-bound at mint (§5.2); product-gesture consent is policy-evaluated
+  evidence, not blanket approval skip (§5.2.1); `resolve`/`authorize`/`abort`
+  Result-wrapped (§3/§5.3); facade count corrected to the 88-method trait
+  block; `CapabilityOutcome` is ten variants; type-count restated as
+  mirrors-not-names (§3/§7); Slice 0 scoped around merged #6200 (§9).
 
 This note proposes a **fundamental** simplification of the Reborn host/runtime
 internals. The goal is to remove three recurring costs without weakening any
@@ -249,9 +257,13 @@ which §3's single-invocation types alone do not do); #6144 is an unenforced
 budget (fixed only because §3 names `authorize()` as the enforcement site for
 `estimate`). The honest causal claim is narrower and still sufficient: the bugs
 live on semantic seams — gates, leases, identity, resume — and the refactor
-gives each of those **one place to be wrong instead of four**, plus a channel
-vocabulary in which misclassification is visible. Fewer hiding places, not
-fewer bug classes.
+gives each decision **a single implementation instead of four interleaved
+copies**: one `authorize()` for pre-flight policy, one gate vocabulary, one
+batch fold. The *seams* themselves remain plural — resolve, authorize,
+dispatch-time auth discovery, abort, batch resume (§5.3.1–§5.3.2) — what
+becomes singular is the implementation of each, plus typed channels in which
+misclassification is visible. Fewer duplicated decision sites, not fewer bug
+classes.
 
 ---
 
@@ -338,17 +350,17 @@ struct LoopRequest { activity_id: ActivityId, capability: CapabilityId, input_re
 struct Invocation  { activity_id: ActivityId, capability: CapabilityId, input: Json, scope: Scope, actor: ActorId, origin: InvocationOrigin, estimate: Estimate }
 struct Authorized  { /* Invocation + lane + trust/approval/reservation/mounts — SEALED: private, built only by authorize() */ }
 enum   Blocked     { Approval(GateRef), Auth(GateRef), Resource(GateRef) }  // re-entrant gates
-enum   Suspension  { Process(ProcessRef), ChildRun(RunRef), DependentRun(GateRef), ExternalTool(GateRef) }  // parked; work continues or control returns to the client
+enum   Suspension  { Process(ProcessRef), DependentRun(GateRef), ExternalTool(GateRef) }  // parked; work continues or control returns to the client
 enum   HostFailure { Transient(ErrRef), Permanent(ErrRef), Uncertain(ErrRef) } // infra/storage/obligation-cleanup; Uncertain = crash between dispatch start and outcome record
 struct Outcome     { /* sanitized refs + typed verdict + summary; tool success OR recoverable tool failure */ }
 enum   Resolution  { Done(Outcome), Denied(DenyRef), Blocked(Blocked), Suspended(Suspension) }  // the composed invoke's answer; AuthorizeResult::Denied maps into it
 
 // ── the host kernel (trusted, below the loop seam) ──
-fn resolve  (req: LoopRequest, scope: &Scope) -> Invocation;              // membrane: deref input, bind actor+scope+origin
-fn authorize(inv: Invocation) -> AuthorizeResult;                         // ALL pre-flightable policy, one place; consumes inv
+fn resolve  (req: LoopRequest, scope: &Scope) -> Result<Invocation, HostFailure>; // membrane: deref input (a ref can be stale/consumed), bind actor+scope+origin
+fn authorize(inv: Invocation) -> Result<AuthorizeResult, HostFailure>;    // ALL pre-flightable policy, one place; reservation/obligation writes can themselves fail
 enum AuthorizeResult { Authorized(Authorized), Denied(DenyRef), Blocked(Blocked) }
 fn dispatch (auth: Authorized, cancel: &CancelSignal) -> Result<Resolution, HostFailure>; // CONSUMES auth (single-use); lane sealed inside; may surface a dispatch-time Auth gate (§5.3.1)
-fn abort    (auth: Authorized);                                           // the not-dispatched path: unwind reservation/obligations explicitly — never in Drop
+fn abort    (auth: Authorized) -> Result<(), HostFailure>;                // not-dispatched path: unwind reservation/obligations explicitly — never in Drop; a failed abort is swept by lease-expiry recovery (§5.3.2)
 ```
 
 - The loop expresses a `LoopRequest` (input by **ref**, resume tokens, pre-trust); the host
@@ -378,10 +390,10 @@ fn abort    (auth: Authorized);                                           // the
   the loop branches on (never summary-string inspection); `Denied` = terminal policy
   denial (model-visible, not re-entrant — the channel today's
   `CapabilityOutcome::Denied` occupies); `Blocked` = re-entrant approval/auth/resource
-  gates; `Suspension` = parked work (spawned process, child run, external tool — the
+  gates; `Suspension` = parked work (spawned process, dependent run, external tool — the
   turn parks, §11.1's `WaitingProcess`); `HostFailure` = infra/storage failure
   (`Transient` retryable, `Permanent`, `Uncertain`). Each failure class in its own
-  channel; the full mapping from today's nine-variant `CapabilityOutcome` is the §5.3
+  channel; the full mapping from today's ten-variant `CapabilityOutcome` is the §5.3
   acceptance table.
 - **`origin` is sealed at the membrane, like `actor` and `scope`.** The loop is not the
   only caller of this pipeline: products invoke capabilities directly (settings mutations,
@@ -401,15 +413,19 @@ fn abort    (auth: Authorized);                                           // the
   at the call site." Here the field cannot ride along unenforced, because the only
   constructor of `Authorized` is the function that reserves against it.
 
-**Type count on a capability call, honestly stated: ~14 request/result shapes →
-~9–10.** Four core payload shapes (`LoopRequest`, `Invocation`, `Authorized`,
-`Outcome`), the resolution vocabulary (`Resolution`, `Blocked`, `Suspension`,
-`Denied`, `HostFailure`), and the per-lane execution types — which **must survive**,
-because the lane boundary is a trust boundary (§2) and each lane's request is its
-mediated contract. The reduction is therefore ~30–40%, matching §1.1's own field-diff
-finding (~2 pure duplications + dead fields out of ~5 request shapes), not the ~70% a
-"14 → 4" reading would suggest. The larger win is qualitative: every surviving type is
-a *distinct state or channel*, not a mirror — nothing left to copy a field through.
+**Type count on a capability call, honestly stated: roughly flat in names, zero
+in mirrors.** Like-for-like (the old ~14 = ~8 request shapes *including* ~3
+per-lane requests + ~6 result shapes): the new path is 3 host-side request
+states (`LoopRequest`, `Invocation`, `Authorized`) + the same ~3 per-lane
+requests (they **must survive** — the lane boundary is a trust boundary, §2) +
+5 channel types (`Resolution`, `Outcome`, `Blocked`, `Suspension`,
+`HostFailure`) ≈ **~12 vs. ~14**. The raw count barely moves because the result
+side deliberately *gains* vocabulary: one overloaded ten-variant enum becomes
+five channels with distinct semantics. The claim this doc actually makes is not
+"fewer type names" — it is **zero mirrors**: the request path drops from 5
+near-identical shapes to 3 distinct states (§1.1's measured duplication), the
+dead fields vanish, and no two surviving types differ by ±a field, so nothing
+is ever again copied layer-to-layer. Count mirrors, not names.
 
 ### 3.1 The three real states, named
 
@@ -744,9 +760,11 @@ Every product talks to the system through **one** narrow interface. An earlier
 draft of this section claimed six conversation methods could carry the whole
 product; that fails by inspection — the proto-`ProductSurface` this replaces
 (`RebornServicesApi`, `ironclaw_product_workflow/src/reborn_services.rs`) has
-**~251 async methods** (verified 2026-07-17), and most are not conversation
-operations: settings mutations, extension install/configure, thread/project
-listing, LLM admin. A conversation API cannot absorb them, and per-feature
+**88 trait methods** (87 async + 1 sync, measured from the `trait
+RebornServicesApi` block, 2026-07-17 — the file's ~251 `async fn`s include
+impls and tests; counts cited here are always trait-block counts), and most
+are not conversation operations: settings mutations, extension
+install/configure, thread/project listing, LLM admin. A conversation API cannot absorb them, and per-feature
 methods must not return (that was the change-amplification cost — a feature
 touching 5–8 crates because each product method was per-feature). The
 resolution is the repo's own standing rule (`.claude/rules/tools.md`):
@@ -758,9 +776,16 @@ for reads.**
 
 ```rust
 /// The ONLY surface a product uses. Turn lifecycle + two conduits; frozen.
+///
+/// ACTOR-BOUND AT MINT: ingress constructs one `ProductSurface` per
+/// authenticated session, sealed to that actor — the facade itself is the
+/// capability. Every method operates under the bound actor; conversation/
+/// run/gate IDs are designators only, NEVER bearer authority. Streaming,
+/// cancellation, and gate resolution authorize against the bound actor,
+/// not against knowledge of an ID.
 trait ProductSurface {
     // ── Turn lifecycle — the kernel's state machine (§11.1); irreducible ──
-    fn open_conversation(&self, actor: Actor, source: SourceBinding) -> ConversationId;
+    fn open_conversation(&self, source: SourceBinding) -> ConversationId;
     fn submit_turn(&self, conv: ConversationId, msg: InboundMessage,
                    idem: IdempotencyKey) -> Result<TurnRunId, SubmitError>;   // all inbound → one door
     fn events(&self, conv: ConversationId, from: EventCursor) -> EventStream;  // redacted projections, resumable
@@ -769,13 +794,14 @@ trait ProductSurface {
     fn cancel(&self, run: TurnRunId, idem: IdempotencyKey) -> Result<(), CancelError>;
 
     // ── Commands: the product-side twin of AgentLoopHost::invoke (§5.4).
-    //    Same resolve → authorize → dispatch pipeline (§3), different origin. ──
-    fn invoke(&self, actor: AuthenticatedActor, capability: CapabilityId,
-              input: Json, idem: IdempotencyKey) -> Result<Resolution, HostFailure>;
+    //    Same resolve → authorize → dispatch pipeline (§3); origin AND actor
+    //    come from the facade's binding, never from the caller. ──
+    fn invoke(&self, capability: CapabilityId, input: Json,
+              idem: IdempotencyKey) -> Result<Resolution, HostFailure>;
 
     // ── Reads: view descriptors over projections; scope-checked, no dispatch. ──
-    fn query(&self, actor: AuthenticatedActor, view: ViewRef,
-             params: Json, cursor: Option<Cursor>) -> Result<ViewPage, QueryError>;
+    fn query(&self, view: ViewRef, params: Json,
+             cursor: Option<Cursor>) -> Result<ViewPage, QueryError>;
 }
 ```
 
@@ -816,15 +842,22 @@ Three consequences, all landing in the single `authorize()` fold:
    exposes an admin capability to the model. Deny-by-default plus an
    `ironclaw_architecture` test — *a descriptor with no explicit origin
    declaration fails* — is the non-negotiable mitigation, not a nicety.
-2. **Approval semantics differ by origin — deliberately.** Approval gates
-   exist to obtain user consent for *model-initiated* actions. A
-   `Product`-origin invocation carries its consent in the act — the user
-   clicked. So `authorize()` auto-satisfies approval gates for `Product`
-   origin, while **auth gates** (credential needed → `Blocked::Auth` →
-   `resolve_gate`) and **resource gates** apply uniformly to every origin.
-   Extension OAuth onboarding from a settings page and from a mid-turn tool
-   call become literally one code path — the shared-resolver requirement the
-   extension/auth invariants (CLAUDE.md) have demanded all along.
+2. **Approval semantics differ by origin — as policy, not as a bypass.** A
+   `Product`-origin invocation carries the user's gesture as **consent
+   evidence bound to this exact (capability, input) pair** — entering through
+   the product membrane proves *who* acted, and the submitted call pins *what*
+   they acted on. Whether that evidence satisfies an approval gate is an
+   `authorize()` **policy decision**, never a blanket skip: the default policy
+   accepts it for gates whose purpose is user consent to a model-initiated
+   action (the common case — asking the user to approve their own click is
+   ceremony), but an `AskAlways` capability, an org-mandated approval, or any
+   policy demanding an explicit review step still blocks and resolves through
+   the same `resolve_gate` flow. **Auth gates** (credential needed →
+   `Blocked::Auth` → `resolve_gate`) and **resource gates** apply uniformly to
+   every origin. Extension OAuth onboarding from a settings page and from a
+   mid-turn tool call become literally one code path — the shared-resolver
+   requirement the extension/auth invariants (CLAUDE.md) have demanded all
+   along.
 3. **Automation stops being special.** Routines/heartbeat invoke with
    `Automation` origin under the same descriptor policy — deleting the
    parallel dispatch path that `composition/src/automation/` (§5.8) wires
@@ -854,7 +887,7 @@ at the view boundary; no dispatch pipeline, no idempotency record.
 
 ### 5.2.4 The honest cost: type safety moves from the compiler to descriptors
 
-~251 typed methods become descriptors + `Json` input — the compile-time
+88 typed methods become descriptors + `Json` input — the compile-time
 contract becomes a runtime schema check. Per `.claude/rules/types.md` this is
 acceptable exactly when the `Json` is treated as a boundary format:
 
@@ -901,15 +934,16 @@ struct Invocation { activity_id: ActivityId, capability: CapabilityId, input: Js
 enum   InvocationOrigin { LoopRun(TurnRunId), Product(ProductKind), Automation(RoutineId) }  // sealed per entry point (§5.2.1)
 struct Authorized { /* the Invocation bound to lane + trust/approval/reservation/mounts + validity deadline — SEALED: private, built only by authorize() */ }
 enum   Blocked    { Approval(GateRef), Auth(GateRef), Resource(GateRef) }        // re-entrant gates
-enum   Suspension { Process(ProcessRef), ChildRun(RunRef), DependentRun(GateRef), ExternalTool(GateRef) } // parked work
+enum   Suspension { Process(ProcessRef), DependentRun(GateRef), ExternalTool(GateRef) } // parked work — matches is_suspension() (host.rs): SpawnedChildRun does NOT park
 enum   HostFailure { Transient(ErrRef), Permanent(ErrRef), Uncertain(ErrRef) }   // Uncertain: crash after dispatch start, before resolution record (§3, §11.3)
 struct Outcome    { refs: OutcomeRefs, verdict: ToolVerdict, summary: SafeSummary } // success OR recoverable failure — typed, never summary-sniffed
 enum   Resolution { Done(Outcome), Denied(DenyRef), Blocked(Blocked), Suspended(Suspension) }
 
 enum AuthorizeResult { Authorized(Authorized), Denied(DenyRef), Blocked(Blocked) }
-fn authorize(inv: Invocation) -> AuthorizeResult;   // consumes inv; binds actor/scope/origin/activity_id; resolves the lane; reserves estimate
+fn resolve  (req: LoopRequest, scope: &Scope) -> Result<Invocation, HostFailure>; // input-ref deref can fail (stale/consumed ref)
+fn authorize(inv: Invocation) -> Result<AuthorizeResult, HostFailure>; // consumes inv; binds actor/scope/origin/activity_id; resolves the lane; reserves estimate — reservation I/O can fail
 fn dispatch (auth: Authorized, cancel: &CancelSignal) -> Result<Resolution, HostFailure>; // CONSUMES auth; lane sealed inside
-fn abort    (auth: Authorized);                     // not-dispatched path: unwind reservation/obligations; explicit, never Drop
+fn abort    (auth: Authorized) -> Result<(), HostFailure>; // not-dispatched path: unwind reservation/obligations; explicit, never Drop; failure swept by lease-expiry recovery (§5.3.2)
 ```
 
 **Acceptance table — every variant of today's `CapabilityOutcome`
@@ -928,7 +962,7 @@ and the new vocabulary must carry all of it:
 | `AuthRequired { .. }` | `Resolution::Blocked(Blocked::Auth)` | authorize-time **or dispatch-time** (§5.3.1) |
 | `ResourceBlocked { .. }` | `Resolution::Blocked(Blocked::Resource)` | authorize-time only |
 | `SpawnedProcess(handle)` | `Resolution::Suspended(Suspension::Process)` | turn parks → §11.1 `WaitingProcess` |
-| `SpawnedChildRun { .. }` | `Resolution::Suspended(Suspension::ChildRun)` | carries result ref + byte len as `OutcomeRefs` do |
+| `SpawnedChildRun { .. }` | `Resolution::Done(Outcome)`, verdict = child spawned | **non-suspending** — `is_suspension()` excludes it; the executor appends the result and continues; result ref + byte len ride in `OutcomeRefs` |
 | `AwaitDependentRun { .. }` | `Resolution::Suspended(Suspension::DependentRun)` | |
 | `ExternalToolPending { .. }` | `Resolution::Suspended(Suspension::ExternalTool)` | host never dispatches; control returns to the API client |
 
@@ -964,10 +998,12 @@ the witness it returns has a lifecycle, not just a type:
   re-dispatching a held witness.
 - **Explicit unwind:** the not-dispatched path (cancel between authorize and
   dispatch, runner handoff, shutdown) calls `abort(auth)`, which releases the
-  reservation and aborts prepared obligations. Unwind is never implicit in
-  `Drop` — destructors do no async I/O. A leaked witness (crash) is recovered
-  by the same lease-expiry sweep that recovers runs: reservations carry the
-  `activity_id` and expire with it.
+  reservation and aborts prepared obligations — and returns
+  `Result<(), HostFailure>`, because unwind is itself I/O that can fail. A
+  failed abort does not strand authority: the reservation carries the
+  `activity_id` and the lease-expiry sweep reclaims it, same as a leaked
+  witness after a crash. Unwind is never implicit in `Drop` — destructors do
+  no async I/O.
 - **Bounded validity:** `Authorized` carries a deadline derived from the
   shortest-lived fact it froze (approval lease, credential lease). `dispatch`
   after the deadline fails closed with `HostFailure::Permanent` — a held
@@ -1001,10 +1037,13 @@ to an **untrusted** `RuntimeLane` (§5.5) with mediated handles, and the `Outcom
 returns is **untrusted data** the host validates, bounds, and redacts before it reaches the
 loop or the model. The substrate ports below are where those other two boundaries live.
 
-`AgentLoopHost::invoke` has a product-side twin — `ProductSurface::invoke` (§5.2) — and
-both funnel into the same `authorize` + `dispatch` (§5.3), distinguished only by the
-sealed `InvocationOrigin` each membrane binds (§5.2.1). There is one capability pipeline,
-entered from two membranes.
+`AgentLoopHost::invoke` has a product-side twin — `ProductSurface::invoke` (§5.2). Each
+membrane keeps its own ingress contract: a `LoopRequest` with ref-based input and resume
+state here; a session-bound actor, raw JSON, and an idempotency key on the product side.
+**Past the membrane the pipeline is identical** — both resolve into the same
+`Invocation` and funnel into the same `authorize` + `dispatch` (§5.3) — and the sealed
+`InvocationOrigin` (§5.2.1) is the only fact the kernel consults about where a call came
+from. One capability pipeline, entered from two membranes with two front doors.
 
 ### 5.5 Substrate interfaces — mechanism behind narrow ports
 
@@ -1231,15 +1270,35 @@ This product family ships tunnels (`src/tunnel/`: cloudflared, ngrok, tailscale,
 custom) and multi-device pairing: a boot that is genuinely local-single-user at
 startup can *become* served afterwards. So `LocalOnlyToken` is not a boot-time
 artifact; it is a capability checked at **every** `ProcessSandbox::spawn` against
-two live facts: (a) exactly one authenticated `UserId` exists, and (b) no public
-ingress is active (no tunnel, no non-loopback listener with SSO enabled). The
-transition is part of the contract: the moment fact (a) or (b) flips —
-a second user authenticates, a tunnel comes up — subsequent host-unsandboxed
-spawns fail closed, **and in-flight host processes are killed**, not drained:
-their containment premise is gone, and a drained process is a live cross-tenant
-window. The §11.2 matrix test drives exactly this transition (spawn under
-single-user, flip the fact, assert kill + fail-closed), not only the static
-two-user case.
+two live facts: (a) exactly one authenticated `UserId` exists, and (b) **no
+non-loopback listener and no tunnel is active — unconditionally.** SSO plays no
+part in (b): a non-loopback listener *without* authentication is a wider
+exposure, not a narrower one, so any reachable-from-off-host surface counts as
+served, authenticated or not.
+
+**The transition is a synchronized protocol, not a pair of independent checks.**
+A per-spawn check alone races the transition: a spawn could pass the predicate,
+miss the transition's sweep, and start *after* the deployment became served.
+So the check and the transition share one admission gate (an epoch/lock over
+the host-process registry):
+
+1. `spawn` executes {validate predicate, register the process in the
+   host-process registry} **atomically under the current epoch** — a process
+   is never running-but-unregistered.
+2. A serving transition (second user authenticating, tunnel/listener coming
+   up) executes, in order: **block new admissions** (advance the epoch — every
+   subsequent spawn fails closed) → **kill every registered host process tree
+   and confirm exit** → only then **publish the new user/ingress fact**. The
+   second user's session, or the tunnel, does not exist until containment is
+   re-established.
+3. The race has two outcomes and no third: a spawn admitted under the old
+   epoch is in the registry and dies in step 2's sweep; a spawn arriving after
+   the epoch advance fails closed. Killed, not drained — a drained host
+   process is a live cross-tenant window.
+
+The §11.2 matrix test drives exactly this transition with barriers (spawn held
+at the admission gate while the transition fires, both interleavings asserted),
+not only the static two-user case.
 - **Fail-closed default:** no verified sandbox ⇒ shell is hidden and rejected
   (`SecureDefault → process None`), never host shell.
 - **Mechanical guarantee** (§9): a two-user integration test drives user B's shell and
@@ -1263,7 +1322,7 @@ containment. That is the entire thesis in one incident.
 
 | | Now | After |
 | --- | --- | --- |
-| Types per capability call | ~14 | ~9–10: 4 payload shapes (`LoopRequest` / `Invocation` / `Authorized` / `Outcome`) + resolution vocabulary + per-lane types (trust boundary, must survive) — every one a distinct state, none a mirror (§3) |
+| Types per capability call | ~14 (5 near-identical request mirrors + one overloaded 10-variant outcome enum) | ~12 like-for-like, **zero mirrors**: request states 5 → 3; outcome enum → 5 typed channels; per-lane types survive (trust boundary) — count mirrors, not names (§3) |
 | Hot-path `dyn` seams | 6+ | 2 + 1 lane enum |
 | Policy decision sites | 4 crates | 1 `authorize()` |
 | Store impls per domain | 2–4 hand-written | 1 (`FsStore<F>`); in-memory is a backend, not a store |
@@ -1271,7 +1330,7 @@ containment. That is the entire thesis in one incident.
 | `LocalDev*` identifiers | ~66 across 42 files | 0 (one `DeploymentConfig` value) |
 | Deployment modes | struct family (`Local*`/`Hosted*`) | `DeploymentConfig` constants (data) |
 | `host_api` boundary | ~124 types incl. mode/policy | neutral authority vocab, frozen by test |
-| Product facade | ~251-method `RebornServicesApi` | turn lifecycle + `invoke`/`query` (8 methods); mutations are origin-declared descriptors (§5.2) |
+| Product facade | 88-method `RebornServicesApi` trait | turn lifecycle + `invoke`/`query` (8 methods); mutations are origin-declared descriptors (§5.2) |
 
 ---
 
@@ -1317,7 +1376,14 @@ oracle the `InMemory*` deletion removes, §4.3) and the instrument that reaches 
 states where the §11.2 invariants live. The repo has no stateful
 property-testing infrastructure today; standing it up — reference model for the
 turn/lease machine, operation generator, invariant checker — is its own scoped
-slice and lands **before** the first store deletion.
+slice and lands **before** any further store deletion.
+
+One exception is already on the books: **#6200 (merged 2026-07-17) deleted the
+`InMemoryProcess*Store`s ahead of this ordering**, styling itself Slice A3.
+Treat it as a landed exception, not a precedent: Slice 0's reference model must
+retroactively cover the process-store semantics #6200 consolidated (its
+replacement oracle is owed, not waived), and no further Slice A domain — the
+turn store above all — lands before Slice 0 does.
 
 Two moves are then low-risk and independently valuable — start there:
 
@@ -1408,7 +1474,7 @@ type duplication in `scripts/check-type-duplicates.py`, cross-tenant behavior in
 | `Local*` types (§4.4) | no `Local` / `LocalDev` / `Hosted` / `Enterprise` in public type names | `ironclaw_architecture` | freeze the ~66-identifier allowlist; fail on any new one | allowlist empty |
 | `host_api` freeze (§4.5) | checked-in allowlist of public type names; `runtime_policy` mode enums absent from `host_api` | `ironclaw_architecture` | freeze the allowlist (set membership); a new type needs a justified allowlist entry | mode enums moved to the edge; only neutral authority vocab remains |
 | Products in composition (§5.8) | no `slack` / `webui` / `telegram` / `openai` / HTTP-route / transport identifier in `ironclaw_reborn_composition` | `ironclaw_architecture` | freeze the current product footprint; fail on new product/transport code landing in composition | composition is assembler-only; products are adapters + a `DeploymentConfig` list |
-| Product facade (§5.2) | `RebornServicesApi` method-set allowlist; every capability descriptor declares allowed origins | `ironclaw_architecture` | freeze the current ~251-method set (set membership); fail on any new method; fail on any descriptor without an explicit origin declaration | facade = turn lifecycle + `invoke`/`query`; all mutations are origin-declared descriptors |
+| Product facade (§5.2) | `RebornServicesApi` method-set allowlist; every capability descriptor declares allowed origins | `ironclaw_architecture` | freeze the current 88-method set, **generated from the trait block itself** (set membership, not a file-wide grep); fail on any new method; fail on any descriptor without an explicit origin declaration | facade = turn lifecycle + `invoke`/`query`; all mutations are origin-declared descriptors |
 
 Each axis's "hard ban" column is also its **definition of done**: the migration slice for
 that axis is complete when its ratchet flips from a frozen allowlist to an empty one (or the
@@ -1710,7 +1776,7 @@ knobs to calibrate against measured latency, not open architectural questions.
 - `docs/reborn/2026-05-11-trust-boundary-stack-note.md` — trust-boundary baseline invariants.
 - `docs/reborn/2026-04-25-storage-catalog-and-placement.md` — storage placement.
 - `crates/ironclaw_host_api/` — the neutral vocabulary crate (target home for `Invocation`/`Authorized`/`Outcome`); ~124 public types across 21 files (§4.5).
-- `crates/ironclaw_product_workflow/src/reborn_services.rs` — `RebornServicesApi`: the ~251-method proto-`ProductSurface` that §5.2's `invoke`/`query` conduits replace (methods → origin-declared capability descriptors + view descriptors).
+- `crates/ironclaw_product_workflow/src/reborn_services.rs` — `RebornServicesApi`: the 88-method proto-`ProductSurface` trait that §5.2's `invoke`/`query` conduits replace (methods → origin-declared capability descriptors + view descriptors).
 - `crates/ironclaw_host_api/src/runtime_policy.rs` — `DeploymentMode` / `RuntimeProfile`: the deployment-mode enums that leaked into the kernel vocabulary (§4.4–§4.5).
 - `crates/ironclaw_runtime_policy/` — `EffectiveRuntimePolicy`: the resolved policy *data* the kernel should consume instead of a mode enum.
 - `crates/ironclaw_filesystem/src/in_memory.rs` — `InMemoryBackend: RootFilesystem`: the existing seam that makes every `InMemory*Store` deletable (§4.3).

--- a/docs/reborn/2026-07-17-architecture-simplification-dto-dyn-local.md
+++ b/docs/reborn/2026-07-17-architecture-simplification-dto-dyn-local.md
@@ -30,6 +30,26 @@ annotations and `.claude/rules/architecture.md` cite them; additions get
   closed, definition of done). Review fixes: type total settled at ~11 across
   §3/§7/§9; §6 admission gate held through process exec (no
   admitted-but-unlaunched window).
+- **r6** 2026-07-18 — dynamic-capability decision folded in: §5.2.1 reworked
+  as an origin→gate **matrix** (the loop may propose admin/config
+  capabilities; gate-by-default for `LoopRun`, `Ungated` allowlist starts
+  empty); added §5.2.6 (meta-capabilities: gating policy is non-degradable),
+  §5.2.7 (persistent approvals are scoped authority), §5.2.8 (gate outcome
+  reporting to the approver), §5.2.9 (gate rendering contract — what the
+  approver sees is host-separated, host-diffed, never model-summarized),
+  §5.3.3 (reservation lifecycle: no-hold on pending gates, origin-scoped
+  budgets, host-derived estimates, one-shot resource-gate delta,
+  pending-gate quota against approval fatigue); budget/quota mutations
+  joined the §5.2.6 meta-set; §10 facade ratchet and §11.7 conformance
+  extended to the matrix, floor, rendering, reservation-lifecycle, and
+  outcome-delivery invariants.
+- **r7** 2026-07-18 — editorial pass, no semantic changes: one canonical
+  vocabulary block (§3; §5.3 keeps only the acceptance contract;
+  `InvocationOrigin` defined once, §5.2.1); §3 commentary compressed to
+  pointers (§5.2.1/§5.3.2/§5.3.3/§11.3 own the detail); §3.1, §5.9 item 1,
+  §7 row 1, and §12.4 deduplicated against the sections they restated; §6's
+  fail-closed-default and mechanical-guarantee bullets rejoined the
+  prevention list they belong to.
 
 This note proposes a **fundamental** simplification of the Reborn host/runtime
 internals. The goal is to remove three recurring costs without weakening any
@@ -357,12 +377,12 @@ struct Authorized  { /* Invocation + lane + trust/approval/reservation/mounts �
 enum   Blocked     { Approval(GateRef), Auth(GateRef), Resource(GateRef) }  // re-entrant gates
 enum   Suspension  { Process(ProcessRef), DependentRun(GateRef), ExternalTool(GateRef) }  // parked; work continues or control returns to the client
 enum   HostFailure { Transient(ErrRef), Permanent(ErrRef), Uncertain(ErrRef) } // infra/storage/obligation-cleanup; Uncertain = crash between dispatch start and outcome record
-struct Outcome     { /* sanitized refs + typed verdict + summary; tool success OR recoverable tool failure */ }
+struct Outcome     { refs: OutcomeRefs, verdict: ToolVerdict, summary: SafeSummary } // tool success OR recoverable failure — typed, never summary-sniffed
 enum   Resolution  { Done(Outcome), Denied(DenyRef), Blocked(Blocked), Suspended(Suspension) }  // the composed invoke's answer; AuthorizeResult::Denied maps into it
 
 // ── the host kernel (trusted, below the loop seam) ──
 fn resolve  (req: LoopRequest, scope: &Scope) -> Result<Invocation, HostFailure>; // membrane: deref input (a ref can be stale/consumed), bind actor+scope+origin
-fn authorize(inv: Invocation) -> Result<AuthorizeResult, HostFailure>;    // ALL pre-flightable policy, one place; reservation/obligation writes can themselves fail
+fn authorize(inv: Invocation) -> Result<AuthorizeResult, HostFailure>;    // ALL pre-flightable policy, one place: binds actor/scope/origin, resolves the lane, reserves estimate; reservation/obligation writes can themselves fail
 enum AuthorizeResult { Authorized(Authorized), Denied(DenyRef), Blocked(Blocked) }
 fn dispatch (auth: Authorized, cancel: &CancelSignal) -> Result<Resolution, HostFailure>; // CONSUMES auth (single-use); lane sealed inside; may surface a dispatch-time Auth gate (§5.3.1)
 fn abort    (auth: Authorized) -> Result<(), HostFailure>;                // not-dispatched path: unwind reservation/obligations explicitly — never in Drop; a failed abort is swept by lease-expiry recovery (§5.3.2)
@@ -376,62 +396,47 @@ fn abort    (auth: Authorized) -> Result<(), HostFailure>;                // not
 - Because `host_api` is the bottom crate, putting the vocabulary there *satisfies* the
   boundary rule (Golden Boundary #1: `host_api` stays vocabulary-only) — finishing a move
   `CapabilityDispatchRequest` already half-made.
-- **`Authorized` is sealed, invocation-bound, *and* lane-bound, with an explicit
-  lifecycle.** Private fields, host-only construction by `authorize()` (the
-  `LoopExitValidationPolicy` witness pattern); it carries the exact `Invocation` it
-  authorized — `activity_id`, `scope`, `actor`, `origin` provenance — **and the
-  `RuntimeLane` resolved from the capability descriptor**, so a caller can neither forge
-  an authority, pair it with a different invocation, nor route it to a lane the
-  descriptor doesn't name (the host-only `Process` lane becomes structural, §5.9).
-  `dispatch` **consumes** it — an authority is single-use; replay goes through
-  `activity_id` idempotency, never through re-dispatching a held witness. The
-  not-dispatched path (cancel or crash between authorize and dispatch) calls `abort()`
-  to unwind reservations/obligations — explicitly, never via `Drop` (no async I/O in
-  destructors). An `Authorized` also carries a validity deadline: dispatch after the
-  deadline fails closed, so a held witness cannot outlive the approval/lease facts it
-  froze.
+- **`Authorized` is sealed, single-use, lane-bound, and deadline-bounded.** Private
+  fields, built only by `authorize()` (the `LoopExitValidationPolicy` witness pattern);
+  it carries the exact `Invocation` it authorized **and the `RuntimeLane` resolved from
+  the descriptor** — no forging, no repairing to a different invocation, no routing to
+  a lane the descriptor doesn't name (the host-only `Process` lane becomes structural,
+  §5.9). `dispatch` consumes it; the not-dispatched path calls `abort()` — explicitly,
+  never via `Drop`. Full lifecycle contract: §5.3.2.
 - **Five distinct resolution channels — no `Ok(Failed)` vs `Err` ambiguity (§1.2).**
-  `Outcome` = the tool's own success or recoverable failure, with a **typed verdict**
-  the loop branches on (never summary-string inspection); `Denied` = terminal policy
-  denial (model-visible, not re-entrant — the channel today's
-  `CapabilityOutcome::Denied` occupies); `Blocked` = re-entrant approval/auth/resource
-  gates; `Suspension` = parked work (spawned process, dependent run, external tool — the
-  turn parks, §11.1's `WaitingProcess`); `HostFailure` = infra/storage failure
-  (`Transient` retryable, `Permanent`, `Uncertain`). Each failure class in its own
-  channel; the full mapping from today's ten-variant `CapabilityOutcome` is the §5.3
-  acceptance table.
+  `Outcome` (tool success or recoverable failure, typed verdict — never summary-string
+  inspection); `Denied` (terminal policy, model-visible, not re-entrant); `Blocked`
+  (re-entrant gates); `Suspension` (parked work, §11.1); `HostFailure` (infra;
+  `Uncertain` = crash between dispatch start and outcome record). The full mapping from
+  today's ten-variant `CapabilityOutcome` is the §5.3 acceptance table.
 - **`origin` is sealed at the membrane, like `actor` and `scope`.** The loop is not the
   only caller of this pipeline: products invoke capabilities directly (settings mutations,
   admin actions — `ProductSurface::invoke`, §5.2) and so does automation. Each entry point
   can mint only its own `InvocationOrigin` variant (§5.2.1), and `authorize()` folds origin
-  into policy — per-origin capability allowlists, origin-dependent approval semantics.
+  into policy — the origin→gate matrix (§5.2.1): per-origin gate requirements and approval
+  semantics, gate-by-default for model-initiated calls.
 - **`activity_id` is the invocation's idempotency identity** — what §1.1's "dead-future
-  `idempotency_key`" *becomes* (unified with the existing `activity_id`, not deleted). The
-  host records the authorize decision against `activity_id` **before** dispatch and the
-  resolution after; a retry of a *resolved* `activity_id` replays the recorded resolution
-  and never re-runs the side effect. A crash **between dispatch start and the resolution
-  record** is the one state with no replayable answer — the side effect may or may not
-  have run — and it maps to `HostFailure::Uncertain`, a terminal the caller sees honestly:
-  at-most-once, never silent re-execution (§11.3).
-- **`estimate` is consumed by `authorize()` at reservation** — naming the enforcement
-  site is the point: #6144's finding was a budget "defined as a field but never enforced
-  at the call site." Here the field cannot ride along unenforced, because the only
-  constructor of `Authorized` is the function that reserves against it.
+  `idempotency_key`" *becomes*, unified rather than deleted. Authorize decision recorded
+  before dispatch, resolution after; a retry of a resolved `activity_id` replays the
+  record and never re-runs the side effect; a crash between the two records maps to
+  `HostFailure::Uncertain` — at-most-once, never silent re-execution. Full contract:
+  §11.3.
+- **`estimate` is consumed by `authorize()` at reservation** — the enforcement site
+  #6144 found missing ("defined as a field but never enforced at the call site"); the
+  field cannot ride along unenforced because the only constructor of `Authorized` is the
+  function that reserves against it. Host-derived, never model-supplied; budgets are
+  origin-scoped — reservation lifecycle decisions in §5.3.3.
 
-**Type count on a capability call, honestly stated: roughly flat in names, zero
-in mirrors.** Like-for-like (the old ~14 = ~8 request shapes *including* ~3
-per-lane requests + ~6 result shapes): the new path is 3 host-side request
-states (`LoopRequest`, `Invocation`, `Authorized`) + the same ~3 per-lane
-requests (they **must survive** — the lane boundary is a trust boundary, §2) +
-5 channel types (`Resolution`, `Outcome`, `Blocked`, `Suspension`,
-`HostFailure`) = **~11 vs. ~14** — the one total used everywhere in this doc
-(§7, §9). The raw count moves only modestly because the result
-side deliberately *gains* vocabulary: one overloaded ten-variant enum becomes
-five channels with distinct semantics. The claim this doc actually makes is not
-"fewer type names" — it is **zero mirrors**: the request path drops from 5
-near-identical shapes to 3 distinct states (§1.1's measured duplication), the
-dead fields vanish, and no two surviving types differ by ±a field, so nothing
-is ever again copied layer-to-layer. Count mirrors, not names.
+**Type count, honestly stated: roughly flat in names, zero in mirrors.**
+Like-for-like: 3 host-side request states (`LoopRequest`, `Invocation`,
+`Authorized`) + the same ~3 per-lane requests (they **must survive** — the
+lane boundary is a trust boundary, §2) + 5 channel types = **~11 vs. ~14**,
+the one total used everywhere in this doc (§7, §9). The raw count barely
+moves because the result side deliberately *gains* vocabulary (one overloaded
+ten-variant enum → five channels). The claim is not "fewer names" — it is
+**zero mirrors**: requests drop from 5 near-identical shapes to 3 distinct
+states, dead fields vanish, and no two surviving types differ by ±a field.
+Count mirrors, not names.
 
 ### 3.1 The three real states, named
 
@@ -445,17 +450,13 @@ the dead fields disappear with them:
 | authorized | `Authorized` (the resolved `Invocation` bound to trust/approval/reservation/mounts) | `RuntimeCapabilityRequest`, `CapabilityInvocationRequest`, `CapabilityDispatchRequest` |
 | resolved-for-a-lane | `Authorized` + resolved handles (package, descriptor, filesystem, governor) | `RuntimeAdapterRequest` |
 
-- **Mechanism 1 (DAG re-declaration) is eliminated:** the one authorized shape is
-  `Authorized`, defined in `host_api`, so `host_runtime` and `capabilities` reference it
-  instead of each re-declaring it.
-- **Mechanism 3 (dead fields) is eliminated:** `trust_decision` vanishes because trust is
-  *computed inside* `authorize()` and lands in `Authorized`, never carried as a request
-  field. `idempotency_key` is **not** deleted — it unifies with the existing `activity_id`
-  (§3), the durable operation identity that makes `invoke` replay-safe (§11.3).
-- **Mechanism 2 (blurred states) becomes explicit:** the three transitions are now named —
-  `LoopRequest`, then `Authorized`, then `+ resolved handles` — rather than five
-  near-identical structs. Mechanism 4 (compose/decompose `context`) goes away because
-  `Authorized` carries `scope`/`actor` in one shape end to end.
+Mechanism 1 (DAG re-declaration) dies because the one authorized shape lives in
+`host_api` and both `host_runtime` and `capabilities` reference it. Mechanism 3's dead
+fields die structurally: trust is *computed inside* `authorize()` and lands in
+`Authorized`, never carried as a request field, and `idempotency_key` unifies with
+`activity_id` (§11.3) rather than being deleted. Mechanisms 2 and 4 dissolve together:
+the three transitions are named types, and `Authorized` carries `scope`/`actor` in one
+shape end to end — nothing is composed and then decomposed.
 
 ---
 
@@ -766,9 +767,8 @@ Every product talks to the system through **one** narrow interface. An earlier
 draft of this section claimed six conversation methods could carry the whole
 product; that fails by inspection — the proto-`ProductSurface` this replaces
 (`RebornServicesApi`, `ironclaw_product_workflow/src/reborn_services.rs`) has
-**88 trait methods** (87 async + 1 sync, measured from the `trait
-RebornServicesApi` block, 2026-07-17 — the file's ~251 `async fn`s include
-impls and tests; counts cited here are always trait-block counts), and most
+**88 trait methods** (trait-block count, 2026-07-17; the file's ~251
+`async fn`s include impls and tests), and most
 are not conversation operations: settings mutations, extension
 install/configure, thread/project listing, LLM admin. A conversation API cannot absorb them, and per-feature
 methods must not return (that was the change-amplification cost — a feature
@@ -818,7 +818,7 @@ stream. Never a method. This generalizes §13.3's synthetic-capability
 promotion: the four synthetic product tools are simply the *first four* facade
 operations to make the migration every mutation makes.
 
-### 5.2.1 Origin is part of the `Invocation`, folded by `authorize()`
+### 5.2.1 Origin is part of the `Invocation`; policy is an origin→gate matrix
 
 ```rust
 enum InvocationOrigin {
@@ -836,29 +836,64 @@ the other's origin. The seeds already exist in the vocabulary:
 sealed by trusted ingress") is the actor binding, and `Principal::System` is
 the automation identity.
 
+**Design intent (decided 2026-07-18): the loop may *propose* nearly
+everything — admin and config capabilities included.** The product direction
+is a dynamic system in which the admin can configure all of IronClaw from
+the LLM loop itself. What stands between a model-initiated call and
+execution is therefore not structural absence but the approval gate: the
+call blocks (`Blocked::Approval`), bubbles to the admin through the same
+`resolve_gate` flow every gate uses, executes through the same pipeline on
+approval, and reports its outcome back to the approver (§5.2.8). Origin
+policy is consequently **not** an allow/deny allowlist — it is a matrix from
+origin to *gate requirement*:
+
+```rust
+/// Declared per descriptor, per origin. Absence of a declaration = Forbidden.
+enum OriginGatePolicy {
+    Forbidden,          // this origin may not invoke the capability at all
+    AskAlways,          // every invocation gates; persistent grants never honored (§5.2.7)
+    GatedUnlessGranted, // gates unless a scoped persistent/policy grant covers it (§5.2.7)
+    ConsentSufficient,  // the origin's own gesture is the consent evidence (Product only)
+    Ungated,            // no approval gate — for LoopRun, requires a reviewed-allowlist entry (§10)
+}
+```
+
+Examples: `settings.llm_provider_set` → `{ Product: ConsentSufficient,
+LoopRun: AskAlways, Automation: Forbidden }`; `shell` → `{ LoopRun:
+GatedUnlessGranted, Product: Forbidden }`; `skill_activate` → `{ Product:
+ConsentSufficient, LoopRun: GatedUnlessGranted, Automation:
+GatedUnlessGranted }`.
+
 Three consequences, all landing in the single `authorize()` fold:
 
-1. **Per-origin capability policy, deny-by-default.** Every descriptor
-   declares which origins may invoke it (`settings.llm_provider_set` →
-   Product-only; `shell` → LoopRun-only; `skill_activate` → both). This is a
-   security *upgrade* over the facade, where the loop/product split is
-   implicit in which trait happens to have the method; after the change it is
-   one auditable declaration per capability. The corresponding risk must be
-   named: the namespace becomes one flat surface, so an origin-policy bug
-   exposes an admin capability to the model. Deny-by-default plus an
-   `ironclaw_architecture` test — *a descriptor with no explicit origin
-   declaration fails* — is the non-negotiable mitigation, not a nicety.
-2. **Approval semantics differ by origin — as policy, not as a bypass.** A
-   `Product`-origin invocation carries the user's gesture as **consent
-   evidence bound to this exact (capability, input) pair** — entering through
-   the product membrane proves *who* acted, and the submitted call pins *what*
-   they acted on. Whether that evidence satisfies an approval gate is an
-   `authorize()` **policy decision**, never a blanket skip: the default policy
-   accepts it for gates whose purpose is user consent to a model-initiated
-   action (the common case — asking the user to approve their own click is
-   ceremony), but an `AskAlways` capability, an org-mandated approval, or any
-   policy demanding an explicit review step still blocks and resolves through
-   the same `resolve_gate` flow. **Auth gates** (credential needed →
+1. **Gate-by-default for the model; deny-by-default for absence.** A
+   descriptor with no declaration for an origin is `Forbidden` from that
+   origin, and a descriptor with no matrix at all fails an
+   `ironclaw_architecture` test. Granting `LoopRun` access normally means
+   `AskAlways` or `GatedUnlessGranted`; `Ungated` for `LoopRun` is the
+   exceptional state and requires an entry in a reviewed, checked-in
+   allowlist that **starts empty** (§10). This restates the flat-namespace
+   risk precisely: the failure mode is not "an admin capability becomes
+   loop-visible" — that is intended — it is "an admin capability becomes
+   loop-invocable *without a gate*," and the empty-until-reviewed `Ungated`
+   allowlist plus the meta-capability floor (§5.2.6) are the structural
+   answer. This is still a security *upgrade* over the facade, where the
+   loop/product split was implicit in which trait happened to have the
+   method; after the change it is one auditable declaration per capability.
+2. **`ConsentSufficient` names the approval semantics of a direct user
+   gesture — as policy, not as a bypass.** A `Product`-origin invocation
+   carries the user's gesture as **consent evidence bound to this exact
+   (capability, input) pair** — entering through the product membrane proves
+   *who* acted, and the submitted call pins *what* they acted on. Whether
+   that evidence satisfies an approval gate is exactly what the matrix
+   declares, never a blanket skip: `ConsentSufficient` accepts it for gates
+   whose purpose is user consent to a model-initiated action (the common
+   case — asking the user to approve their own click is ceremony), while
+   declaring `Product: AskAlways` expresses an org-mandated approval or any
+   policy demanding an explicit review step, which still blocks and resolves
+   through the same `resolve_gate` flow. In every case, what the gate shows
+   the approver is governed by the rendering contract (§5.2.9) — consent is
+   only as strong as what was seen. **Auth gates** (credential needed →
    `Blocked::Auth` → `resolve_gate`) and **resource gates** apply uniformly to
    every origin. Extension OAuth onboarding from a settings page and from a
    mid-turn tool call become literally one code path — the shared-resolver
@@ -902,8 +937,9 @@ acceptable exactly when the `Json` is treated as a boundary format:
   into internal flow.
 - **The frontend contract is generated from descriptor schemas** (TS types
   from the same source of truth), so wire and handler cannot drift.
-- **Every capability ships a conformance case** in the §11.7 harness:
-  allow/deny per origin, invalid input, idempotent replay.
+- **Every capability ships a conformance case** in the §11.7 harness: its
+  origin→gate matrix behavior per origin (§5.2.1), invalid input, idempotent
+  replay.
 
 **Atomicity rule: one user gesture = one capability.** Compound operations
 (persist-then-reload, `.claude/rules/error-handling.md`) live *inside* one
@@ -919,8 +955,8 @@ handler, which owns the transaction/rollback — a product never sequences two
 2. **Slice 1 is already decided:** the four synthetic tools (§13.3).
 3. **Then facade mutations, opportunistically** — settings first (simplest
    handlers), each migration shrinking the allowlist monotonically. Every
-   migrated mutation gains audit, idempotency, redaction, and per-origin
-   policy for free, from the one pipeline.
+   migrated mutation gains audit, idempotency, redaction, and its
+   origin→gate matrix for free, from the one pipeline.
 4. **Reads migrate to view descriptors separately and later** — lower risk,
    lower value.
 5. **Definition of done:** the facade *is* this trait — six turn methods +
@@ -932,25 +968,142 @@ One further payoff: a WASM extension's capabilities become invocable from
 stop needing bespoke host wiring at all, which is the URT's adapter thesis
 (§5.9) arriving from the kernel side.
 
+### 5.2.6 Meta-capabilities: gating policy is non-degradable
+
+If the loop can invoke configuration capabilities (§5.2.1's design intent),
+the highest-value target is the gating machinery itself: "set approval
+policy to auto-approve," "add this id to the `Ungated` allowlist," "widen
+the network policy." One approved call there silently de-fangs every future
+gate. So the **meta-capability set** — every capability that mutates
+approval/gate/origin policy, persistent grants (§5.2.7), network policy,
+process/deployment policy, budget/quota policy (§5.3.3), or the membership
+of this set itself — carries a non-degradation invariant:
+
+- **The gate floor is code, not data.** For meta ids, `authorize()` computes
+  `effective_gate = max(declared, meta_floor)`, and the floor — `AskAlways`
+  for `LoopRun` and `Automation` — is a hardcoded rule in the kernel, not a
+  policy value any capability writes. No sequence of approved invocations
+  can weaken it, because it is not stored anywhere an invocation can reach.
+  (`Product` origin may declare `ConsentSufficient`: the actor is the
+  authenticated admin acting directly; the floor targets model- and
+  automation-initiated paths.)
+- **Never eligible for persistent approval** (§5.2.7): each meta invocation
+  is approved individually or not at all — "don't ask again" is not offered.
+- **Policy mutations are prospective only.** A gate already pending when
+  policy changes still resolves only by an explicit `resolve_gate` decision,
+  evaluated under the policy in force at resolution time — a loosening never
+  auto-resolves a pending gate, and a tightening applies immediately.
+- **The set is pinned.** The meta-capability id set is checked in and
+  enforced by an `ironclaw_architecture` test (set membership, per §10):
+  removing an id from the set, or adding a policy-mutating capability
+  without listing it, fails CI.
+
+### 5.2.7 Persistent approvals are scoped authority, not a blanket
+
+"Don't ask again," granted through a model-initiated gate, converts one
+approval into standing authority — a social-engineering ratchet: the model
+only has to talk the admin into the grant once. Three rules:
+
+- **Eligibility is descriptor-declared.** Only capabilities whose matrix
+  entry is `GatedUnlessGranted` can carry grants at all; `AskAlways`
+  capabilities and the entire meta-set (§5.2.6) are never eligible.
+- **Grants are scoped, enumerable, and revocable.** A grant binds
+  (capability, actor, scope), may narrow further by input hash or input
+  pattern, and carries an expiry. The Product surface exposes standing
+  grants as a view descriptor and revocation as a capability — the admin can
+  always see and retract what has been granted.
+- **Granting or widening a grant is itself a meta-capability** (§5.2.6):
+  `AskAlways` from the loop. The model can *request* standing authority, but
+  the request is always an explicit, individually-approved gate that names
+  the exact scope being granted.
+
+Today's `PersistentApprovalPolicy` / `CapabilityPermissionOverride` /
+auto-approve stores are the current homes of this state; the migration folds
+them into descriptor-declared eligibility checked in `authorize()`.
+
+### 5.2.8 The gate lifecycle ends at the approver: outcome reporting
+
+An approval-gated invocation has two interested parties, and the approver
+may not be watching the conversation where the loop runs (a routine, a
+heartbeat, a background turn). The gate lifecycle therefore gains a final
+stage — `blocked → resolved → dispatched → outcome-reported` — and the
+resolution surface owns the last leg: the `Outcome` (or `Denied` /
+`HostFailure`) of a gated invocation is delivered on the same `GateRef`,
+through the surface that collected the `resolve_gate` decision, as a
+gate-outcome event on the projection stream.
+
+Two sub-cases are mandatory, not best-effort:
+
+- **`HostFailure::Uncertain` reaches the approver as exactly that** — "the
+  change may or may not have applied; verify before retrying" (§11.3). An
+  admin who approved a config change and hears nothing will assume it
+  landed.
+- **A dispatch-time fail-closed after approval is reported, never silent.**
+  If the `Authorized` witness expires (§5.3.2), or facts changed and
+  re-validation fails, the approver is told the approved action did *not*
+  execute and why — an approved-but-unexecuted mutation that evaporates
+  silently is both an audit hole and a trust hole.
+- **Approval followed by a resource block is surfaced, not silent.** Under
+  the no-hold rule (§5.3.3), gate resolution re-enters `authorize()` against
+  then-current budget; if the approved action now blocks on resources, the
+  follow-on `Blocked::Resource` gate is delivered on the same surface — the
+  approver learns the action is waiting on budget and can resolve or abandon
+  it, never left assuming it ran.
+
+The §11.7 `ProductSurface` conformance suite asserts this end to end: every
+gated capability's harness case drives approve → outcome event on the gate
+resolver's channel, including the `Uncertain` and expired-witness paths.
+
+### 5.2.9 What the approver sees: the gate rendering contract
+
+Consent evidence is only as strong as what the approver actually saw. The
+approval prompt for a `LoopRun`-origin gate derives from **model-controlled
+input**: a prompt-injected model can craft an input whose natural rendering
+misleads the approver — an "update display name" whose nested field actually
+rewrites the network allowlist. Binding consent to the exact
+(capability, input) pair (§5.2.1) makes the approval *precise*; this
+contract makes it *informed*. Four rules, structural where possible:
+
+1. **Host facts and model input are separate typed fields in the gate
+   event.** The gate projection event carries `{capability_id, origin,
+   actor, scope, effect_class}` (derived by the kernel from the descriptor
+   and the sealed `Invocation` — never from input) in fields distinct from
+   the input payload, and adapters render the two regions visually
+   distinctly. Model-supplied text cannot spoof a host fact because the
+   separation is in the wire contract, not adapter discipline.
+2. **The thing rendered is the thing bound.** The surface presents the exact
+   input the gate binds — never a model-authored summary of it. If an
+   adapter cannot render the full input (size, medium — e.g. a Telegram
+   approval card), it must degrade to an explicit "N-byte input, view before
+   approving" affordance backed by the raw payload, not to a summary. A
+   host-*generated* condensation (top-level keys, truncation with byte
+   counts) is permitted where it is computed by the host from the payload;
+   model-supplied `summary` fields never reach the approval prompt.
+3. **Config and meta mutations render a host-computed diff.** For
+   capabilities that mutate configuration (§5.2.6's meta-set above all), the
+   gate event includes a `current → proposed` diff computed by the handler
+   from authoritative state at gate-creation time — the approver approves a
+   visible state change, not an opaque input blob. If state moves between
+   gate creation and dispatch such that the diff no longer applies, the
+   `Authorized` re-validation fails closed and §5.2.8 reports it.
+4. **Model text is rendered as data.** Untrusted strings in the input are
+   escaped/delimited in every adapter's gate UI — never interpreted as
+   markup, links, or UI instructions (the standing untrusted-content rule in
+   `ironclaw_safety` applied to the approval surface).
+
+The enforcement seam: rule 1 and rule 3 live in the **gate event
+vocabulary** (typed fields, host-only construction — same sealing discipline
+as `Invocation`), so a conforming adapter cannot conflate regions even
+carelessly; rules 2 and 4 are adapter obligations pinned by the §11.7
+conformance suite, which drives a gate whose input contains markup,
+spoofed "host-fact-looking" text, and an oversized payload, and asserts the
+rendered projection keeps regions separated and unsummarized.
+
 ### 5.3 The kernel capability interface — authorize + dispatch
 
-```rust
-// host_api vocabulary — the frozen kernel types (§4.5)
-struct Invocation { activity_id: ActivityId, capability: CapabilityId, input: Json, scope: Scope, actor: ActorId, origin: InvocationOrigin, estimate: Estimate }
-enum   InvocationOrigin { LoopRun(TurnRunId), Product(ProductKind), Automation(RoutineId) }  // sealed per entry point (§5.2.1)
-struct Authorized { /* the Invocation bound to lane + trust/approval/reservation/mounts + validity deadline — SEALED: private, built only by authorize() */ }
-enum   Blocked    { Approval(GateRef), Auth(GateRef), Resource(GateRef) }        // re-entrant gates
-enum   Suspension { Process(ProcessRef), DependentRun(GateRef), ExternalTool(GateRef) } // parked work — matches is_suspension() (host.rs): SpawnedChildRun does NOT park
-enum   HostFailure { Transient(ErrRef), Permanent(ErrRef), Uncertain(ErrRef) }   // Uncertain: crash after dispatch start, before resolution record (§3, §11.3)
-struct Outcome    { refs: OutcomeRefs, verdict: ToolVerdict, summary: SafeSummary } // success OR recoverable failure — typed, never summary-sniffed
-enum   Resolution { Done(Outcome), Denied(DenyRef), Blocked(Blocked), Suspended(Suspension) }
-
-enum AuthorizeResult { Authorized(Authorized), Denied(DenyRef), Blocked(Blocked) }
-fn resolve  (req: LoopRequest, scope: &Scope) -> Result<Invocation, HostFailure>; // input-ref deref can fail (stale/consumed ref)
-fn authorize(inv: Invocation) -> Result<AuthorizeResult, HostFailure>; // consumes inv; binds actor/scope/origin/activity_id; resolves the lane; reserves estimate — reservation I/O can fail
-fn dispatch (auth: Authorized, cancel: &CancelSignal) -> Result<Resolution, HostFailure>; // CONSUMES auth; lane sealed inside
-fn abort    (auth: Authorized) -> Result<(), HostFailure>; // not-dispatched path: unwind reservation/obligations; explicit, never Drop; failure swept by lease-expiry recovery (§5.3.2)
-```
+The vocabulary and signatures are §3's — one definition each: the types and the
+`resolve`/`authorize`/`dispatch`/`abort` fold live in `host_api` as written there,
+`InvocationOrigin` in §5.2.1. This section is the acceptance contract for them.
 
 **Acceptance table — every variant of today's `CapabilityOutcome`
 (`ironclaw_turns/src/run_profile/host.rs`) maps to exactly one channel.** This
@@ -1018,6 +1171,53 @@ the witness it returns has a lifecycle, not just a type:
   `CancelSignal`; the two-phase cancel (§11.1, `CancelRequested → Cancelled`)
   propagates into the lane through it, and a cancelled dispatch resolves — it
   does not vanish with obligations half-open.
+
+### 5.3.3 Decision: reservation lifecycle and origin-scoped budgets
+
+The dynamic model (§5.2.1) runs every origin through the same `authorize()`
+reservation, which forces five decisions about how resources behave:
+
+- **A pending gate holds no reservation (decided: no-hold).** Reservation
+  happens only on the path that constructs `Authorized`; a `Blocked` result
+  holds nothing. A gate that bubbles to the admin and sits for hours must
+  not park budget — the reserve-at-gate-creation alternative hands the model
+  a DoS primitive (spam gated calls, each locking budget behind an approval
+  nobody resolves). The consequence, stated honestly: gate resolution
+  re-enters `authorize()` and reserves against *then-current* budget, so an
+  approved action can still block on resources — approval is consent, not an
+  execution guarantee (surfaced per §5.2.8, never silent).
+- **Budgets are origin-scoped, parallel to the gate matrix.** Budgets bound
+  *autonomous* behavior: `LoopRun` reserves against the turn/run budget,
+  `Automation` against its routine's budget, and `Product` is by default
+  unmetered (or bound to an org quota) — the admin must never be locked out
+  of operating their own system because the model spent the budget.
+- **Estimates are host-derived — the model is adversarial to its own
+  budget.** `estimate` is computed at resolve/authorize from the
+  descriptor's declared cost class plus measured history (the existing EMA
+  estimation machinery), never model-supplied: a loop-settable estimate
+  invites lowballing under the reservation check. Actuals reconcile
+  post-dispatch (§12.1), and a capability whose actuals persistently exceed
+  its estimates is flagged, not silently absorbed.
+- **Resource-gate resolution grants a one-shot, invocation-bound exception —
+  never a policy change.** Resolving `Blocked::Resource` grants exactly the
+  delta for that invocation. Raising the standing budget is a separate
+  invoke of the budget meta-capability (§5.2.6) with its own gate; anything
+  looser makes resource-gate resolution a side door around the meta floor.
+- **Admin attention is itself a budgeted resource.** Unbounded pending-gate
+  creation is the attack surface the gate model creates: a prompt-injected
+  model floods the admin with plausible requests until fatigue produces the
+  one careless approval that matters. So pending gates carry per-run and
+  per-origin caps, gate creation counts against the turn budget, and
+  unresolved gates expire (TTL) instead of accumulating. An invocation that
+  would exceed the cap resolves as a model-visible recoverable failure
+  ("gate quota exhausted"), not a new gate. This is a security control, not
+  ergonomics — approval fatigue is how gate-based consent is defeated in
+  practice.
+
+One payoff for free: every reservation and reconciled actual carries
+`origin + actor + activity_id`, so per-origin spend (model vs. automation
+vs. direct admin) is just a §5.2.2 view descriptor over the accounting
+records — the spend dashboard costs nothing extra.
 
 ### 5.4 The loop interface — the loop's trust membrane (one of several)
 
@@ -1151,7 +1351,7 @@ adapters (their deliver / auth side) or the kernel, not the assembler:
 - `composition/src/outbound/` (~1.8K) — delivery → the adapter's deliver path over the
   outbound port.
 - `composition/src/automation/` (~6.1K), `llm_admin/` (~8.5K) — these are *product
-  operations*, not composition code: their mutations become origin-declared capability
+  operations*, not composition code: their mutations become matrix-declared capability
   descriptors + handlers and their reads become view descriptors (§5.2); what remains is a
   thin frontend, not an adapter crate's worth of host code. Automation additionally stops
   being a parallel dispatch path — routines invoke under `Automation` origin (§5.2.1).
@@ -1201,19 +1401,15 @@ are the concrete enforcement for the products-in-composition ratchet (§10).
 
 **Integration points — name the seam so neither implementation collides at it:**
 
-1. **One `RuntimeLane` enum; the extension runtime-kind is a subset of it.** Reconcile the
-   two "runtime" vocabularies into one closed *execution* enum
-   `RuntimeLane = { FirstParty | Wasm | Mcp | Process }`. The URT's extension-declarable
-   runtime *kinds* map to a **strict subset**: `first_party → FirstParty`, `wasm → Wasm`,
-   `[mcp] → Mcp`. The **`Process`** lane (the OS-subprocess / script sandbox, §5.5, §6) is
-   **host-only** — no extension manifest can select it; only host built-in capabilities
-   (shell, script) dispatch to it, and only through `ProcessSandbox`. This keeps "runtime
-   kind is a loading detail" (the URT) and "manifests cannot self-assign a raw process lane"
-   (§6) simultaneously true: what an extension *declares* (load kind) is a subset of what the
-   kernel *dispatches to* (execution lane). Note the vocabulary split: the URT's "runtime
-   kind" is a **load** detail; this doc's `RuntimeLane` is an **execution** substrate — a
-   first-party or WASM `invoke` may itself request the `Process` lane via a host capability,
-   so the two are different axes and must not be merged into one field.
+1. **One `RuntimeLane` enum (§4.2); the extension runtime-kind is a strict subset of
+   it** — `first_party → FirstParty`, `wasm → Wasm`, `[mcp] → Mcp`. The **`Process`**
+   lane is **host-only**: no manifest can select it; only host built-in capabilities
+   dispatch to it, through `ProcessSandbox` (§5.5, §6). That keeps "runtime kind is a
+   loading detail" (URT) and "manifests cannot self-assign a raw process lane" (§6)
+   simultaneously true. The two vocabularies remain different axes — the URT's kind is
+   a **load** detail, `RuntimeLane` an **execution** substrate (a first-party or WASM
+   `invoke` may itself request the `Process` lane via a host capability) — and must not
+   be merged into one field.
 
 2. **`ToolPorts` is *derived from* `Authorized`, never constructed independently.** The URT's
    `ToolPorts` (restricted egress + scoped state + logging) is exactly the narrowed effect
@@ -1340,6 +1536,11 @@ unbounded to the user's workspace — reading the host filesystem, shared across
   predicate" below. A served deployment cannot pass the check, at boot or ever after.
 - **Mode is derived from a fact, not a profile string** (§4.4 principle): a multi-user
   boot cannot resolve `LocalSingleUser`; it fails closed at startup.
+- **Fail-closed default:** no verified sandbox ⇒ shell is hidden and rejected
+  (`SecureDefault → process None`), never host shell.
+- **Mechanical guarantee** (§9): a two-user integration test drives user B's shell and
+  asserts it cannot read user A's files — a caller-level cross-tenant escape test, the
+  thing whose absence let this ship.
 
 **The served predicate — defined, because "local" is not decidable once at boot.**
 This product family ships tunnels (`src/tunnel/`: cloudflared, ngrok, tailscale,
@@ -1383,11 +1584,6 @@ the host-process registry):
 The §11.2 matrix test drives exactly this transition with barriers (spawn held
 at the admission gate while the transition fires, both interleavings asserted),
 not only the static two-user case.
-- **Fail-closed default:** no verified sandbox ⇒ shell is hidden and rejected
-  (`SecureDefault → process None`), never host shell.
-- **Mechanical guarantee** (§9): a two-user integration test drives user B's shell and
-  asserts it cannot read user A's files — a caller-level cross-tenant escape test, the
-  thing whose absence let this ship.
 
 The lesson generalizes: the escape existed because isolation was runtime discipline
 over a fail-open default. The target structure is honest about which guarantees are
@@ -1406,7 +1602,7 @@ containment. That is the entire thesis in one incident.
 
 | | Now | After |
 | --- | --- | --- |
-| Types per capability call | ~14 (5 near-identical request mirrors + one overloaded 10-variant outcome enum) | ~11 like-for-like (3 host request states + ~3 lane requests + 5 channels), **zero mirrors**: request states 5 → 3; outcome enum → 5 typed channels; per-lane types survive (trust boundary) — count mirrors, not names (§3) |
+| Types per capability call | ~14 (5 near-identical request mirrors + one overloaded 10-variant outcome enum) | ~11 like-for-like (3 request states + ~3 lane requests + 5 channels), **zero mirrors** — count mirrors, not names (§3) |
 | Hot-path `dyn` seams | 6+ | 2 + 1 lane enum |
 | Policy decision sites | 4 crates | 1 `authorize()` |
 | Store impls per domain | 2–4 hand-written | 1 (`FsStore<F>`); in-memory is a backend, not a store |
@@ -1414,7 +1610,7 @@ containment. That is the entire thesis in one incident.
 | `LocalDev*` identifiers | ~66 across 42 files | 0 (one `DeploymentConfig` value) |
 | Deployment modes | struct family (`Local*`/`Hosted*`) | `DeploymentConfig` constants (data) |
 | `host_api` boundary | ~124 types incl. mode/policy | neutral authority vocab, frozen by test |
-| Product facade | 88-method `RebornServicesApi` trait | turn lifecycle + `invoke`/`query` (8 methods); mutations are origin-declared descriptors (§5.2) |
+| Product facade | 88-method `RebornServicesApi` trait | turn lifecycle + `invoke`/`query` (8 methods); mutations are descriptors with an origin→gate matrix (§5.2.1) |
 
 ---
 
@@ -1518,8 +1714,9 @@ efforts share one seam: the URT's "dispatcher pipeline, implemented once" *is*
 loaders/adapters against that frozen §5.3 interface; the URT's extension/auth
 axis (recipes, `AuthEngine`, adapter seams) proceeds in parallel — it does not
 touch the kernel types. If the URT reaches its dispatcher work before Slice C
-lands, it implements against §5.3's signatures as written, and any change it
-needs is a change request to this doc, not a divergent local shape at the seam.
+lands, it implements against the §3 signatures and §5.3 acceptance contract as
+written, and any change it needs is a change request to this doc, not a
+divergent local shape at the seam.
 
 ### Risks and honest caveats
 
@@ -1558,7 +1755,7 @@ type duplication in `scripts/check-type-duplicates.py`, cross-tenant behavior in
 | `Local*` types (§4.4) | no `Local` / `LocalDev` / `Hosted` / `Enterprise` in public type names | `ironclaw_architecture` | freeze the ~66-identifier allowlist; fail on any new one | allowlist empty |
 | `host_api` freeze (§4.5) | checked-in allowlist of public type names; `runtime_policy` mode enums absent from `host_api` | `ironclaw_architecture` | freeze the allowlist (set membership); a new type needs a justified allowlist entry | mode enums moved to the edge; only neutral authority vocab remains |
 | Products in composition (§5.8) | no `slack` / `webui` / `telegram` / `openai` / HTTP-route / transport identifier in `ironclaw_reborn_composition` | `ironclaw_architecture` | freeze the current product footprint; fail on new product/transport code landing in composition | composition is assembler-only; products are adapters + a `DeploymentConfig` list |
-| Product facade (§5.2) | `RebornServicesApi` method-set allowlist; every capability descriptor declares allowed origins | `ironclaw_architecture` | freeze the current 88-method set, **generated from the trait block itself** (set membership, not a file-wide grep); fail on any new method; fail on any descriptor without an explicit origin declaration | facade = turn lifecycle + `invoke`/`query`; all mutations are origin-declared descriptors |
+| Product facade (§5.2) | `RebornServicesApi` method-set allowlist; every capability descriptor declares an origin→gate matrix (§5.2.1) | `ironclaw_architecture` | freeze the current 88-method set, **generated from the trait block itself** (set membership, not a file-wide grep); fail on any new method; fail on any descriptor without a gate matrix; the `Ungated`-for-`LoopRun` allowlist starts **empty** (set membership); the meta-capability set is pinned with its `AskAlways` floor (§5.2.6) | facade = turn lifecycle + `invoke`/`query`; all mutations are matrix-declared descriptors |
 
 Each axis's "hard ban" column is also its **definition of done**: the migration slice for
 that axis is complete when its ratchet flips from a frozen allowlist to an empty one (or the
@@ -1690,16 +1887,24 @@ Each kernel interface (§5) ships a conformance suite every implementation must 
 adapter/loop/backend inherits correctness instead of re-deriving it:
 
 - **`ProductSurface`** — submit/observe/reply/gate/cancel semantics + idempotency, run against
-  every product adapter (§5.8); plus the `invoke`/`query` conduits (§5.2): per-origin
-  allow/deny, rejection of a descriptor with no origin declaration, and idempotent replay
-  of a product mutation.
+  every product adapter (§5.8); plus the `invoke`/`query` conduits (§5.2): the origin→gate
+  matrix per origin (gate-by-default for `LoopRun`; rejection of a descriptor with no
+  matrix; the §5.2.6 meta floor unweakenable by any sequence of approved invocations),
+  the §5.2.9 rendering contract (host facts / model input / host diff arrive as separate
+  typed fields; a gate with markup, spoofed host-fact text, and an oversized payload
+  renders separated and unsummarized), gate-outcome delivery to the approver including
+  the `Uncertain` and expired-witness paths (§5.2.8), and idempotent replay of a product
+  mutation.
 - **`AgentLoopHost`** — the trust membrane: a loop reaches effects only through it; direct
   dispatcher/secret/network access is a compile error (boundary test).
 - **`authorize` / `dispatch`** — authority-before-effect, redaction, fail-closed; the
   §5.3 acceptance table (every `CapabilityOutcome` row producible, each in its channel);
   §5.3.1's gate discipline (a lane-originated Approval/Resource gate is a
   `HostFailure::Permanent`, never a gate); batch resume redispatches every pending
-  member (§11.1, #6137).
+  member (§11.1, #6137); the §5.3.3 reservation lifecycle (a `Blocked` result leaves
+  zero reservation held; `abort()` releases; approve-then-resource-block surfaces the
+  follow-on gate; a gate flood past the per-run cap resolves as "gate quota exhausted",
+  not an unbounded pending queue).
 - **store traits / `RootFilesystem`** — the §11.5 parity suite.
 
 ### 11.8 Tiering
@@ -1768,20 +1973,13 @@ separately.
 
 ### 12.4 Design guidance to carry into implementation
 
-- **One batched write per transition** (snapshot/delta), not N per-store round-trips —
-  generalize the turn `row_store` journal to all domains.
-- **Heartbeat = a tiny isolated write** on its own connection, never behind the executor's
-  store lock; `lease_ttl ≥ k × backend_p99_write`.
-- **Cache read-mostly authority data** (trust policy, capability descriptors, approval
-  policy) with scope-aware keys (safety cache rule); `authorize()` hits the cache, not the
-  remote DB, per tool call.
-- **Durable event append is atomic with the state transition** (same transaction or an
-  outbox) — a crash must not leave state committed without its events (recovery/audit/
-  projections depend on it). Only the *subscriber fan-out* is async + coalesced +
-  bounded-buffer + `Lagged`, decoupled so delivery failure never corrupts turn state.
-- **Writer concurrency is the throughput ceiling**: document libSQL single-writer; prefer
-  Postgres or shard by tenant/scope for high concurrency.
-- **No lock across remote I/O** — enforced mechanically.
+The implementation checklist is the mitigation column of §12.1 plus §12.2's lock rule:
+one batched write per transition (generalize the turn `row_store` journal to all
+domains); heartbeat as a tiny isolated write with `lease_ttl ≥ k × backend_p99_write`;
+scope-keyed caches for read-mostly authority data so `authorize()` hits the cache per
+tool call; event append atomic with its state transition (same transaction or outbox —
+only *subscriber fan-out* is decoupled); writer concurrency documented as the
+throughput ceiling; no lock across remote I/O, enforced mechanically.
 
 These are performance *invariants* the §11 suite should also guard: a latency-injecting
 backend fake in the property tests surfaces held-lock-across-I/O and heartbeat-vs-TTL
@@ -1845,7 +2043,7 @@ decorator gating and synthetic-capability promotion are settled here.**
   reviewed allowlist** (initially empty). That restores the structural guarantee the
   synthetic mechanism's absence used to provide, while keeping the scope-binding gains.
   This promotion is **Slice 1 of the §5.2.5 facade migration**: the same descriptor +
-  per-origin-policy shape then absorbs the `RebornServicesApi` mutations one by one.
+  origin→gate-matrix shape then absorbs the `RebornServicesApi` mutations one by one.
 
 **Genuinely remaining (tuning/ops, not architecture):** the lease-TTL latency multiplier
 `k` in `lease_ttl ≥ k × backend_p99_write` (§12), and the default `RootFilesystem` backend
@@ -1860,7 +2058,7 @@ knobs to calibrate against measured latency, not open architectural questions.
 - `docs/reborn/2026-05-11-trust-boundary-stack-note.md` — trust-boundary baseline invariants.
 - `docs/reborn/2026-04-25-storage-catalog-and-placement.md` — storage placement.
 - `crates/ironclaw_host_api/` — the neutral vocabulary crate (target home for `Invocation`/`Authorized`/`Outcome`); ~124 public types across 21 files (§4.5).
-- `crates/ironclaw_product_workflow/src/reborn_services.rs` — `RebornServicesApi`: the 88-method proto-`ProductSurface` trait that §5.2's `invoke`/`query` conduits replace (methods → origin-declared capability descriptors + view descriptors).
+- `crates/ironclaw_product_workflow/src/reborn_services.rs` — `RebornServicesApi`: the 88-method proto-`ProductSurface` trait that §5.2's `invoke`/`query` conduits replace (methods → matrix-declared capability descriptors + view descriptors).
 - `crates/ironclaw_host_api/src/runtime_policy.rs` — `DeploymentMode` / `RuntimeProfile`: the deployment-mode enums that leaked into the kernel vocabulary (§4.4–§4.5).
 - `crates/ironclaw_runtime_policy/` — `EffectiveRuntimePolicy`: the resolved policy *data* the kernel should consume instead of a mode enum.
 - `crates/ironclaw_filesystem/src/in_memory.rs` — `InMemoryBackend: RootFilesystem`: the existing seam that makes every `InMemory*Store` deletable (§4.3).

--- a/docs/reborn/2026-07-17-architecture-simplification-dto-dyn-local.md
+++ b/docs/reborn/2026-07-17-architecture-simplification-dto-dyn-local.md
@@ -25,6 +25,11 @@ annotations and `.claude/rules/architecture.md` cite them; additions get
   Result-wrapped (§3/§5.3); facade count corrected to the 88-method trait
   block; `CapabilityOutcome` is ten variants; type-count restated as
   mirrors-not-names (§3/§7); Slice 0 scoped around merged #6200 (§9).
+- **r5** 2026-07-17 — added §5.10 (the five routing surfaces, one table) and
+  §5.11 (composition end-state: assembler module sketch, inputs, boot-fail-
+  closed, definition of done). Review fixes: type total settled at ~11 across
+  §3/§7/§9; §6 admission gate held through process exec (no
+  admitted-but-unlaunched window).
 
 This note proposes a **fundamental** simplification of the Reborn host/runtime
 internals. The goal is to remove three recurring costs without weakening any
@@ -419,7 +424,8 @@ per-lane requests + ~6 result shapes): the new path is 3 host-side request
 states (`LoopRequest`, `Invocation`, `Authorized`) + the same ~3 per-lane
 requests (they **must survive** — the lane boundary is a trust boundary, §2) +
 5 channel types (`Resolution`, `Outcome`, `Blocked`, `Suspension`,
-`HostFailure`) ≈ **~12 vs. ~14**. The raw count barely moves because the result
+`HostFailure`) = **~11 vs. ~14** — the one total used everywhere in this doc
+(§7, §9). The raw count moves only modestly because the result
 side deliberately *gains* vocabulary: one overloaded ten-variant enum becomes
 five channels with distinct semantics. The claim this doc actually makes is not
 "fewer type names" — it is **zero mirrors**: the request path drops from 5
@@ -1226,6 +1232,76 @@ are the concrete enforcement for the products-in-composition ratchet (§10).
    body of this doc's `dispatch(auth)` (the lane is sealed inside `Authorized`, §5.3.2) for the FirstParty/Wasm/Mcp lanes; the
    `Process` lane is the same shape with a `ProcessSandbox` handle in place of raw egress.
 
+### 5.10 The five routing surfaces — the whole system in one table
+
+Everything in the target structure routes through exactly five surfaces. This
+table is the mental model a reviewer should carry; if a change doesn't fit one
+of these rows, it is either policy data (`DeploymentConfig`) or it is in the
+wrong place:
+
+| # | Surface | What routes through it | What it seals/binds | Trust status |
+| --- | --- | --- | --- | --- |
+| 1 | `ProductSurface` (§5.2) | every user-initiated action: 6 turn-lifecycle methods + `invoke` (all mutations) + `query` (all reads) | **actor-bound at mint** — one facade per authenticated session; IDs are designators, never bearer authority | product boundary (trusted↔trusted) |
+| 2 | `AgentLoopHost` (§5.4) | everything the agent loop may do: prompt, model, invoke, transcript, checkpoint, input, cancellation | the loop's membrane — below it the loop cannot name secrets, the dispatcher, or the network | **trust boundary** (untrusted loop → host) |
+| 3 | `authorize()` + `dispatch()` (§5.3) | every effect, from every origin — both membranes and automation resolve into the same `Invocation` | origin/actor/scope sealed at the membrane; policy folded once; `Authorized` = sealed, single-use, lane-bound, deadline-bounded witness | trusted kernel — the convergence point |
+| 4 | `RuntimeLane` (§4.2, §5.5) | execution of extension/tool code: `FirstParty \| Wasm \| Mcp \| Process` | lane sealed inside `Authorized`; lanes receive only derived mediated handles (`ToolPorts`), never ambient authority; returned data is untrusted | **trust boundary** (host → untrusted execution, and back) |
+| 5 | Substrate ports (§5.5) | all mechanism: `RootFilesystem` (single storage plane), `ProcessSandbox` (only OS-process path, served-predicate gated §6), `SecretBroker`, `NetworkPolicy` | backend/medium is injected config, never a type; changes when a backend is added, **never for a feature** | trusted mechanism, kernel-mediated |
+
+The one-line flow: **product/loop → membrane (1 or 2, origin sealed) → kernel
+pipeline (3) → lane (4) → substrates (5).**
+
+Two things deliberately *not* on the list: **`DeploymentConfig` is data, not a
+surface** — nothing routes through it; it selects backends and policy values at
+`build_runtime` — and **composition is an assembler, not a surface** (§5.11). A
+mental model that has either as a routing layer is the drift this structure
+exists to prevent.
+
+### 5.11 Composition end-state: the assembler, fully shrunk
+
+When every §5.8/§4.4 move lands, `ironclaw_reborn_composition` is a small crate
+whose only job is turning a `DeploymentConfig` value into a wired `Runtime`:
+
+```
+ironclaw_reborn_composition/
+├── lib.rs           build_runtime(cfg: DeploymentConfig) -> Runtime   — the one entry point
+├── deployment.rs    DeploymentConfig + LOCAL_DEV / HOSTED / ENTERPRISE constants (data, §4.4)
+├── substrates.rs    RootFilesystem backend selection; ProcessSandbox from ProcessPolicy
+│                    (incl. the served-predicate admission gate, §6); SecretBroker; NetworkPolicy
+├── stores.rs        Filesystem*Store<F> instantiation over the one backend (§4.3)
+├── kernel.rs        turn coordinator + runner/scheduler; authorize()+dispatch() assembly;
+│                    RuntimeLane construction with mediated substrate handles
+├── surfaces.rs      ProductSurface impl (actor-bound mint hook handed to ingress);
+│                    AgentLoopHost factory with config-gated decorators (§4.4.1)
+└── registry.rs      accepts descriptor sets (capability + view) and the product-neutral
+                     adapter factory registry AS INPUTS; activates DeploymentConfig ids
+```
+
+Order of a few thousand lines of declarative wiring. The three deployment modes
+are three constants on one page; the entire local/hosted diff is data.
+
+**What it receives instead of owning.** Two inputs, both constructed *above* it
+in the binary crates (which is where product adapters get linked): the adapter
+factory registry keyed by `ExtensionId`, and the descriptor sets. Composition
+never names `slack`, `webui`, a route, or a vendor — it activates ids. One
+consequence stated plainly: "config lists an adapter id that isn't linked"
+moved from a compile error to a boot error, so `build_runtime` **fails closed
+and loudly on any unresolvable id at startup** — a silent skip would be a
+misconfigured deployment masquerading as a working one.
+
+**What is gone** (destinations in the §5.8 table): the ~40.6K Slack host tree,
+~32.7K `product_auth` (→ recipes + one `AuthEngine`), ~14.5K `runtime/`
+LocalDev wiring (→ config-gated middleware + promoted first-party
+capabilities), `llm_admin`/`automation` (→ descriptor sets; routines invoke
+under `Automation` origin), `outbound/` (→ adapter deliver paths), and every
+`LocalDev*`/`InMemory*` type.
+
+**Definition of done** = the §10 ratchets for this crate flipped: no
+product/transport identifier (the URT Deletion/Addition tests), `Local*`
+allowlist empty, `InMemory*Store` allowlist empty, no mode branching (consumes
+resolved policy values only), and no handler reaching store internals. The
+test of the end-state in one sentence: *if shipping a feature requires editing
+composition, the feature is being built in the wrong crate.*
+
 ---
 
 ## 6. Case study: the shell cross-tenant escape (issue #6170)
@@ -1282,19 +1358,27 @@ miss the transition's sweep, and start *after* the deployment became served.
 So the check and the transition share one admission gate (an epoch/lock over
 the host-process registry):
 
-1. `spawn` executes {validate predicate, register the process in the
-   host-process registry} **atomically under the current epoch** — a process
-   is never running-but-unregistered.
+1. `spawn` holds the admission gate **from validation through successful
+   process start**: {validate predicate, register in the host-process
+   registry, exec, confirm started} all execute under the current epoch — the
+   gate is not released between check and exec, so a process is never
+   running-but-unregistered *and* never admitted-but-launching outside the
+   gate. (Spawn holds the gate only for process start, not process lifetime —
+   the hold is short and bounded.)
 2. A serving transition (second user authenticating, tunnel/listener coming
-   up) executes, in order: **block new admissions** (advance the epoch — every
-   subsequent spawn fails closed) → **kill every registered host process tree
-   and confirm exit** → only then **publish the new user/ingress fact**. The
-   second user's session, or the tunnel, does not exist until containment is
-   re-established.
-3. The race has two outcomes and no third: a spawn admitted under the old
-   epoch is in the registry and dies in step 2's sweep; a spawn arriving after
-   the epoch advance fails closed. Killed, not drained — a drained host
-   process is a live cross-tenant window.
+   up) acquires the same gate **exclusively**, then executes in order:
+   **block new admissions** (advance the epoch — every subsequent spawn fails
+   closed) → **kill every registered host process tree and confirm exit** →
+   only then **publish the new user/ingress fact**. Because the transition
+   holds the gate, no spawn can be between validation and exec while the
+   sweep runs. The second user's session, or the tunnel, does not exist until
+   containment is re-established.
+3. The race has two outcomes and no third: a spawn that acquired the gate
+   before the transition has fully started and is in the registry — it dies
+   in step 2's sweep; a spawn that arrives after fails the epoch check
+   closed. There is no admitted-but-unlaunched window, because exec happens
+   under the gate. Killed, not drained — a drained host process is a live
+   cross-tenant window.
 
 The §11.2 matrix test drives exactly this transition with barriers (spawn held
 at the admission gate while the transition fires, both interleavings asserted),
@@ -1322,7 +1406,7 @@ containment. That is the entire thesis in one incident.
 
 | | Now | After |
 | --- | --- | --- |
-| Types per capability call | ~14 (5 near-identical request mirrors + one overloaded 10-variant outcome enum) | ~12 like-for-like, **zero mirrors**: request states 5 → 3; outcome enum → 5 typed channels; per-lane types survive (trust boundary) — count mirrors, not names (§3) |
+| Types per capability call | ~14 (5 near-identical request mirrors + one overloaded 10-variant outcome enum) | ~11 like-for-like (3 host request states + ~3 lane requests + 5 channels), **zero mirrors**: request states 5 → 3; outcome enum → 5 typed channels; per-lane types survive (trust boundary) — count mirrors, not names (§3) |
 | Hot-path `dyn` seams | 6+ | 2 + 1 lane enum |
 | Policy decision sites | 4 crates | 1 `authorize()` |
 | Store impls per domain | 2–4 hand-written | 1 (`FsStore<F>`); in-memory is a backend, not a store |
@@ -1422,7 +1506,7 @@ mid-migration:
   when the last delegated check is inlined; mark that PR explicitly (it is the
   security milestone of Slice C, not the type introduction).
 - **Type count rises before it falls.** During C the five old request shapes and
-  the new vocabulary coexist (~14 → ~18 → ~9–10). The §10 mirror-DTO ratchet's
+  the new vocabulary coexist (~14 → ~18 → ~11, the §3 total). The §10 mirror-DTO ratchet's
   allowlist is what makes this safe: the old five are frozen entries that may
   only disappear.
 

--- a/docs/reborn/2026-07-17-architecture-simplification-dto-dyn-local.md
+++ b/docs/reborn/2026-07-17-architecture-simplification-dto-dyn-local.md
@@ -4,6 +4,20 @@
 **Status:** Proposal / design note (not yet a contract)
 **Scope:** The capability/turn execution path and storage substrates in `crates/`
 
+**Revision log** (section numbers are frozen identifiers — `arch-exempt`
+annotations and `.claude/rules/architecture.md` cite them; additions get
+`x.y.z` suffixes, existing sections are never renumbered):
+
+- **r1** 2026-07-17 — initial proposal (PR #6175).
+- **r2** 2026-07-17 — §5.2 reworked: product surface = turn lifecycle +
+  `invoke`/`query` capability conduits; `InvocationOrigin` added (§5.2.1).
+- **r3** 2026-07-17 — review hardening: full `CapabilityOutcome` mapping and
+  five-channel resolution model (§5.3), dispatch-time gates and `Authorized`
+  lifecycle settled (§5.3.1–§5.3.2), `RuntimeLane` unified on
+  `Process` (§4.2/§5.9), served-predicate for `LocalOnlyToken` (§6), evidence
+  reframed (§1.5), `type-placement.md` reconciliation (§4.2), batch modeled
+  (§11.1), Slice 0 + URT ordering (§9).
+
 This note proposes a **fundamental** simplification of the Reborn host/runtime
 internals. The goal is to remove three recurring costs without weakening any
 security invariant:
@@ -209,8 +223,11 @@ Two mechanisms:
 
 ### 1.5 The last month agrees
 
-- **≥510 merged PRs; 188 (37%) are `fix(...)`.** Backend fixes cluster on exactly
-  these seams: channel/identity (22), turn/lease (16), capability/gate (12).
+- **≥510 merged PRs; 188 (37%) are `fix(...)`.** No baseline exists for what a
+  healthy fix ratio is at this repo's size, so read the *clustering*, not the
+  rate: backend fixes concentrate on exactly these seams — channel/identity
+  (22), turn/lease (16), capability/gate (12) — though note that is ~50 of 188;
+  most fixes are elsewhere.
 - A **daily automated "failure taxonomy" issue** and a `bug_bash_*` label stream
   exist — institutionalized after-the-fact bug harvesting.
 - Review-iteration churn concentrates on the gate/hold/turn/auth seams (single
@@ -222,6 +239,19 @@ Two mechanisms:
   Also directly on the capability path: **#6137** ("mixed-batch gate resume never
   redispatches the non-first gated call") and **#6138** (harness can't express a
   compound denied-gate + HTTP-egress-error scenario).
+
+**What this evidence does and does not show.** It shows the complexity is real
+and where it sits. It does **not** show that the DTO/`dyn` collapse would have
+prevented the cited bugs, and the claim should not be read that way: #6170 is a
+fail-open policy default (fixed by §6's structure, not by type consolidation);
+#6137 is batch semantics (fixed by *modeling batch in the state machine*, §11.1,
+which §3's single-invocation types alone do not do); #6144 is an unenforced
+budget (fixed only because §3 names `authorize()` as the enforcement site for
+`estimate`). The honest causal claim is narrower and still sufficient: the bugs
+live on semantic seams — gates, leases, identity, resume — and the refactor
+gives each of those **one place to be wrong instead of four**, plus a channel
+vocabulary in which misclassification is visible. Fewer hiding places, not
+fewer bug classes.
 
 ---
 
@@ -306,15 +336,19 @@ Separate the **data plane** (the payload, which never changes shape) from the
 struct LoopRequest { activity_id: ActivityId, capability: CapabilityId, input_ref: InputRef, resume: Option<ResumeToken> }
 // The host-side payload, resolved at the membrane (input deref'd, actor+scope+origin bound):
 struct Invocation  { activity_id: ActivityId, capability: CapabilityId, input: Json, scope: Scope, actor: ActorId, origin: InvocationOrigin, estimate: Estimate }
-struct Authorized  { /* Invocation + trust/approval/reservation/mounts — SEALED: private, built only by authorize() */ }
+struct Authorized  { /* Invocation + lane + trust/approval/reservation/mounts — SEALED: private, built only by authorize() */ }
 enum   Blocked     { Approval(GateRef), Auth(GateRef), Resource(GateRef) }  // re-entrant gates
-enum   HostFailure { Transient(ErrRef), Permanent(ErrRef) }                 // infra/storage/obligation-cleanup failure
-struct Outcome     { /* sanitized refs + summary; carries tool success OR recoverable tool failure */ }
+enum   Suspension  { Process(ProcessRef), ChildRun(RunRef), DependentRun(GateRef), ExternalTool(GateRef) }  // parked; work continues or control returns to the client
+enum   HostFailure { Transient(ErrRef), Permanent(ErrRef), Uncertain(ErrRef) } // infra/storage/obligation-cleanup; Uncertain = crash between dispatch start and outcome record
+struct Outcome     { /* sanitized refs + typed verdict + summary; tool success OR recoverable tool failure */ }
+enum   Resolution  { Done(Outcome), Denied(DenyRef), Blocked(Blocked), Suspended(Suspension) }  // the composed invoke's answer; AuthorizeResult::Denied maps into it
 
 // ── the host kernel (trusted, below the loop seam) ──
-fn resolve  (req: LoopRequest, scope: &Scope) -> Invocation;                // membrane: deref input, bind actor+scope
-fn authorize(inv: Invocation) -> Result<Authorized, Blocked>;              // ALL policy, one place; consumes inv
-fn dispatch (auth: &Authorized, lane: &RuntimeLane) -> Result<Outcome, HostFailure>; // inv is inside auth — can't mismatch
+fn resolve  (req: LoopRequest, scope: &Scope) -> Invocation;              // membrane: deref input, bind actor+scope+origin
+fn authorize(inv: Invocation) -> AuthorizeResult;                         // ALL pre-flightable policy, one place; consumes inv
+enum AuthorizeResult { Authorized(Authorized), Denied(DenyRef), Blocked(Blocked) }
+fn dispatch (auth: Authorized, cancel: &CancelSignal) -> Result<Resolution, HostFailure>; // CONSUMES auth (single-use); lane sealed inside; may surface a dispatch-time Auth gate (§5.3.1)
+fn abort    (auth: Authorized);                                           // the not-dispatched path: unwind reservation/obligations explicitly — never in Drop
 ```
 
 - The loop expresses a `LoopRequest` (input by **ref**, resume tokens, pre-trust); the host
@@ -325,16 +359,30 @@ fn dispatch (auth: &Authorized, lane: &RuntimeLane) -> Result<Outcome, HostFailu
 - Because `host_api` is the bottom crate, putting the vocabulary there *satisfies* the
   boundary rule (Golden Boundary #1: `host_api` stays vocabulary-only) — finishing a move
   `CapabilityDispatchRequest` already half-made.
-- **`Authorized` is sealed *and* invocation-bound.** Private fields, host-only construction
-  by `authorize()` (the `LoopExitValidationPolicy` witness pattern), *and* it carries the
-  exact `Invocation` it authorized — including its `activity_id`, `scope`, and `actor`
-  provenance. So a caller can neither forge an authority nor pair a valid one with a
-  *different* invocation: `dispatch` takes `&Authorized`, not a loose `(inv, auth)` pair.
-- **Three distinct outcome channels — no `Ok(Failed)` vs `Err` ambiguity (§1.2).** `Blocked`
-  = re-entrant approval/auth/resource gates; `HostFailure` = infra/storage/obligation-cleanup
-  failure (`Transient` retryable vs `Permanent`); `Outcome` = the tool's own success or
-  recoverable failure (model-visible). `invoke = Result<Outcome, InvokeError>` with
-  `InvokeError = Blocked | HostFailure` — each failure class in its own channel.
+- **`Authorized` is sealed, invocation-bound, *and* lane-bound, with an explicit
+  lifecycle.** Private fields, host-only construction by `authorize()` (the
+  `LoopExitValidationPolicy` witness pattern); it carries the exact `Invocation` it
+  authorized — `activity_id`, `scope`, `actor`, `origin` provenance — **and the
+  `RuntimeLane` resolved from the capability descriptor**, so a caller can neither forge
+  an authority, pair it with a different invocation, nor route it to a lane the
+  descriptor doesn't name (the host-only `Process` lane becomes structural, §5.9).
+  `dispatch` **consumes** it — an authority is single-use; replay goes through
+  `activity_id` idempotency, never through re-dispatching a held witness. The
+  not-dispatched path (cancel or crash between authorize and dispatch) calls `abort()`
+  to unwind reservations/obligations — explicitly, never via `Drop` (no async I/O in
+  destructors). An `Authorized` also carries a validity deadline: dispatch after the
+  deadline fails closed, so a held witness cannot outlive the approval/lease facts it
+  froze.
+- **Five distinct resolution channels — no `Ok(Failed)` vs `Err` ambiguity (§1.2).**
+  `Outcome` = the tool's own success or recoverable failure, with a **typed verdict**
+  the loop branches on (never summary-string inspection); `Denied` = terminal policy
+  denial (model-visible, not re-entrant — the channel today's
+  `CapabilityOutcome::Denied` occupies); `Blocked` = re-entrant approval/auth/resource
+  gates; `Suspension` = parked work (spawned process, child run, external tool — the
+  turn parks, §11.1's `WaitingProcess`); `HostFailure` = infra/storage failure
+  (`Transient` retryable, `Permanent`, `Uncertain`). Each failure class in its own
+  channel; the full mapping from today's nine-variant `CapabilityOutcome` is the §5.3
+  acceptance table.
 - **`origin` is sealed at the membrane, like `actor` and `scope`.** The loop is not the
   only caller of this pipeline: products invoke capabilities directly (settings mutations,
   admin actions — `ProductSurface::invoke`, §5.2) and so does automation. Each entry point
@@ -342,12 +390,26 @@ fn dispatch (auth: &Authorized, lane: &RuntimeLane) -> Result<Outcome, HostFailu
   into policy — per-origin capability allowlists, origin-dependent approval semantics.
 - **`activity_id` is the invocation's idempotency identity** — what §1.1's "dead-future
   `idempotency_key`" *becomes* (unified with the existing `activity_id`, not deleted). The
-  host records the authorize/outcome against `activity_id` **before** dispatch; a retry of
-  the same `activity_id` replays the recorded `Outcome` and never re-runs the side effect —
-  the durable guarantee §11.3 requires for capability `invoke`.
+  host records the authorize decision against `activity_id` **before** dispatch and the
+  resolution after; a retry of a *resolved* `activity_id` replays the recorded resolution
+  and never re-runs the side effect. A crash **between dispatch start and the resolution
+  record** is the one state with no replayable answer — the side effect may or may not
+  have run — and it maps to `HostFailure::Uncertain`, a terminal the caller sees honestly:
+  at-most-once, never silent re-execution (§11.3).
+- **`estimate` is consumed by `authorize()` at reservation** — naming the enforcement
+  site is the point: #6144's finding was a budget "defined as a field but never enforced
+  at the call site." Here the field cannot ride along unenforced, because the only
+  constructor of `Authorized` is the function that reserves against it.
 
-**Type count on a capability call: ~14 request/result shapes → 4** (`LoopRequest`,
-`Invocation`, `Authorized`, `Outcome`) plus a two-variant error split.
+**Type count on a capability call, honestly stated: ~14 request/result shapes →
+~9–10.** Four core payload shapes (`LoopRequest`, `Invocation`, `Authorized`,
+`Outcome`), the resolution vocabulary (`Resolution`, `Blocked`, `Suspension`,
+`Denied`, `HostFailure`), and the per-lane execution types — which **must survive**,
+because the lane boundary is a trust boundary (§2) and each lane's request is its
+mediated contract. The reduction is therefore ~30–40%, matching §1.1's own field-diff
+finding (~2 pure duplications + dead fields out of ~5 request shapes), not the ~70% a
+"14 → 4" reading would suggest. The larger win is qualitative: every surviving type is
+a *distinct state or channel*, not a mirror — nothing left to copy a field through.
 
 ### 3.1 The three real states, named
 
@@ -389,10 +451,12 @@ goes to zero because nothing mirrors.
 - **Keep** `LoopCapabilityPort` (the loop's trust membrane — one of several trust
   boundaries, §2) and `LlmProvider` (genuine polymorphism).
 - **Replace** `RuntimeAdapter`'s `dyn` with a closed `enum RuntimeLane`
-  (`Wasm | Script | Mcp | FirstParty`). Adding a lane becomes a compile error
-  until every `match` handles it. WASM extensions stay open — they are *data*
-  behind the `Wasm` lane, not new lanes — so a closed lane set costs no real
-  extensibility.
+  (`FirstParty | Wasm | Mcp | Process` — the **one** definition, shared with §5.9;
+  today's script/process adapter executes *on* the `Process` lane, and the name
+  states the trust boundary the way §4.4's `HostProcessPort` rename does). Adding a
+  lane becomes a compile error until every `match` handles it. WASM extensions stay
+  open — they are *data* behind the `Wasm` lane, not new lanes — so a closed lane
+  set costs no real extensibility.
 - **Delete** the `HostRuntime` and `CapabilityDispatcher` traits; make them
   concrete (or a single generic parameter resolved once at composition), and get
   the test seams they currently serve (§1.3, mechanism 1) from generics or one
@@ -401,7 +465,19 @@ goes to zero because nothing mirrors.
   the `dyn` it holds today (`CapabilityHost<'a, dyn CapabilityDispatcher>`), and its
   role folds into the `authorize` + `dispatch` pair.
 
-**Hot-path `dyn`: 6+ → ~2, plus one lane enum.**
+**Relationship to `.claude/rules/type-placement.md` (must be reconciled, not
+ignored).** That rule's 2026-07 audit judged 97.7% of the workspace's traits
+justified, and its justification list includes **test seams** (#3) — the very
+reason `HostRuntime`/`CapabilityDispatcher` exist. This section deliberately
+*narrows* that justification **for hot-path mediator traits only**: on the
+capability path, a test seam is served by a generic parameter or one boundary
+fake, not by a production `Arc<dyn>` that every layer mirrors. Dependency
+inversion (#2) is untouched — `LoopCapabilityPort` stays for exactly that
+reason — as is genuine polymorphism (#1, `LlmProvider`). The rule also states
+that contract *surface* is reduced "only by interface design"; §3 **is** that
+interface design, so the two documents are consistent in intent. The rule must
+be amended in the same PR that lands Slice C (§9) — a checked-in rule and this
+doc disagreeing silently would leave reviewers enforcing both.
 
 ### 4.3 Delete every in-memory store; the storage seam already exists
 
@@ -440,9 +516,28 @@ Why the in-memory stores exist today: they predate the generic
 `Filesystem*Store<F>` and were kept as the fast reference/test path. Now that a
 first-class `InMemoryBackend: RootFilesystem` exists, they are redundant — a whole
 second implementation per domain, kept alive only for tests that a memory-backed
-filesystem serves for free. (Honest caveat: the turn store's ~4,260-LOC in-memory
-impl is larger than the ~1,710-LOC filesystem one, so consolidation is *reconcile
-then delete*, not a blind delete — but the target is one store, backend-injected.)
+filesystem serves for free.
+
+Three costs of the deletion, owned here rather than discovered later:
+
+1. **Inventory before delete.** The turn store's in-memory impl (~4,260 LOC) is
+   2.5× the filesystem one (~1,710 LOC); that delta is the entire risk of the move
+   and must be *inventoried*, not assumed redundant. Slice A's per-domain step is
+   therefore: enumerate what the in-memory impl covers that the filesystem impl
+   does not (semantics, test hooks, or dead weight — each named), reconcile, then
+   delete. A deletion PR without the inventory is not Slice A done correctly.
+2. **The independent oracle is lost.** Today the in-memory and durable stores are
+   two independent implementations of the same semantics, so §11.5's parity suite
+   is a genuine cross-check. After consolidation there is one implementation run
+   over four backends — a bug in the shared store logic passes "parity" on every
+   backend by construction. The replacement oracle is §11.4's reference model,
+   which is why the property-test infrastructure is **Slice 0**, a prerequisite
+   of Slice A (§9), not a follow-up.
+3. **Test-suite latency is a budget, not a hope.** Tests move from a `HashMap`
+   store to journal/delta/row materialization over an in-memory filesystem.
+   Measure the suite before/after the first domain migrates; a significant
+   regression is a signal to optimize the shared store's in-memory path, not a
+   cost to silently absorb.
 
 Open follow-on: consider a shared "leased recoverable work-unit" abstraction over
 `TurnRun` and `ironclaw_processes` (§1.4, mechanism 2), or explicitly document why
@@ -513,6 +608,19 @@ rename to `NodeTraceSubmission*` only if convenient).
 Enforce it with an `ironclaw_architecture` test: **no public type name contains
 `Local`/`LocalDev`/`Hosted`/`Enterprise`.** A deployment mode is a config value that
 selects backends and policy; it is never a type the kernel or a substrate names.
+
+**Why lanes get a closed enum (§4.2) while modes become data — the same-looking
+trade goes opposite ways deliberately.** Both are small, closed, security-relevant
+sets, but they differ in *who is allowed to branch on them*. A `RuntimeLane` is
+branched on in exactly one place — `dispatch()`'s match — and exhaustiveness there
+is the safety property: a new lane must confront every arm. A deployment mode must
+be branched on in exactly **zero** places past the composition edge — that is the
+whole §2.1 thesis — so giving it an enum would hand every crate an invitation to
+`match` on it (which is precisely how the 66-identifier `LocalDev*` family grew).
+The residue to watch: code *will* still branch on the resolved policy **values**
+(`ApprovalPolicy`, `ProcessPolicy` — themselves enums, locally exhaustive); the
+discipline is that those branches live in the substrate that owns the axis, and a
+missing case there is caught by that enum's own exhaustiveness, not by a mode.
 
 ### 4.4.1 Audit: does `DeploymentConfig` express everything? (verified 2026-07-17)
 
@@ -623,7 +731,7 @@ exactly two interfaces; and **deployment** as a config value.
 | Substrate | Secret broker | one-shot leased secrets | `SecretBroker` | (never for features) |
 | Substrate | Network policy | egress mediation | `NetworkPolicy` | (never for features) |
 | Substrate | Events / memory / threads / run-state | durable records, projections | typed stores | a domain record changes |
-| Lane | Wasm / Script / Mcp / FirstParty | executes extension/tool code (untrusted) | `RuntimeLane` (closed enum) | a lane is added (rare) |
+| Lane | FirstParty / Wasm / Mcp / Process | executes extension/tool code (untrusted) | `RuntimeLane` (closed enum) | a lane is added (rare) |
 | Deployment | `DeploymentConfig` | selects backends + policy per target | *is* a value → `build_runtime` | a deployment target changes |
 
 The kernel is the only layer that owns authority; substrates are mechanism it
@@ -663,7 +771,7 @@ trait ProductSurface {
     // ── Commands: the product-side twin of AgentLoopHost::invoke (§5.4).
     //    Same resolve → authorize → dispatch pipeline (§3), different origin. ──
     fn invoke(&self, actor: AuthenticatedActor, capability: CapabilityId,
-              input: Json, idem: IdempotencyKey) -> Result<Outcome, InvokeError>;
+              input: Json, idem: IdempotencyKey) -> Result<Resolution, HostFailure>;
 
     // ── Reads: view descriptors over projections; scope-checked, no dispatch. ──
     fn query(&self, actor: AuthenticatedActor, view: ViewRef,
@@ -791,14 +899,83 @@ stop needing bespoke host wiring at all, which is the URT's adapter thesis
 // host_api vocabulary — the frozen kernel types (§4.5)
 struct Invocation { activity_id: ActivityId, capability: CapabilityId, input: Json, scope: Scope, actor: ActorId, origin: InvocationOrigin, estimate: Estimate }
 enum   InvocationOrigin { LoopRun(TurnRunId), Product(ProductKind), Automation(RoutineId) }  // sealed per entry point (§5.2.1)
-struct Authorized { /* the Invocation bound to trust/approval/reservation/mounts — SEALED: private, built only by authorize() */ }
-enum   Blocked    { Approval(GateRef), Auth(GateRef), Resource(GateRef) }
-enum   HostFailure { Transient(ErrRef), Permanent(ErrRef) }
-struct Outcome    { refs: OutcomeRefs, summary: SafeSummary }  // tool success OR recoverable tool failure
+struct Authorized { /* the Invocation bound to lane + trust/approval/reservation/mounts + validity deadline — SEALED: private, built only by authorize() */ }
+enum   Blocked    { Approval(GateRef), Auth(GateRef), Resource(GateRef) }        // re-entrant gates
+enum   Suspension { Process(ProcessRef), ChildRun(RunRef), DependentRun(GateRef), ExternalTool(GateRef) } // parked work
+enum   HostFailure { Transient(ErrRef), Permanent(ErrRef), Uncertain(ErrRef) }   // Uncertain: crash after dispatch start, before resolution record (§3, §11.3)
+struct Outcome    { refs: OutcomeRefs, verdict: ToolVerdict, summary: SafeSummary } // success OR recoverable failure — typed, never summary-sniffed
+enum   Resolution { Done(Outcome), Denied(DenyRef), Blocked(Blocked), Suspended(Suspension) }
 
-fn authorize(inv: Invocation) -> Result<Authorized, Blocked>;                    // consumes inv; binds actor/scope/activity_id
-fn dispatch (auth: &Authorized, lane: &RuntimeLane) -> Result<Outcome, HostFailure>; // inv is inside auth
+enum AuthorizeResult { Authorized(Authorized), Denied(DenyRef), Blocked(Blocked) }
+fn authorize(inv: Invocation) -> AuthorizeResult;   // consumes inv; binds actor/scope/origin/activity_id; resolves the lane; reserves estimate
+fn dispatch (auth: Authorized, cancel: &CancelSignal) -> Result<Resolution, HostFailure>; // CONSUMES auth; lane sealed inside
+fn abort    (auth: Authorized);                     // not-dispatched path: unwind reservation/obligations; explicit, never Drop
 ```
+
+**Acceptance table — every variant of today's `CapabilityOutcome`
+(`ironclaw_turns/src/run_profile/host.rs`) maps to exactly one channel.** This
+table is the §5.3 definition of done: an implementation that cannot produce a
+row, or produces one in a different channel, is wrong. The old enum is not
+accidental complexity — it is the accumulated record of the non-happy paths,
+and the new vocabulary must carry all of it:
+
+| Today (`CapabilityOutcome`) | New channel | Note |
+| --- | --- | --- |
+| `Completed(msg)` | `Resolution::Done(Outcome)`, verdict = success | |
+| `Failed(failure)` | `Resolution::Done(Outcome)`, verdict = recoverable failure | model-visible; typed verdict replaces variant-matching |
+| `Denied(denied)` | `Resolution::Denied` | terminal, model-visible, **not** re-entrant — distinct from every gate |
+| `ApprovalRequired { .. }` | `Resolution::Blocked(Blocked::Approval)` | authorize-time only |
+| `AuthRequired { .. }` | `Resolution::Blocked(Blocked::Auth)` | authorize-time **or dispatch-time** (§5.3.1) |
+| `ResourceBlocked { .. }` | `Resolution::Blocked(Blocked::Resource)` | authorize-time only |
+| `SpawnedProcess(handle)` | `Resolution::Suspended(Suspension::Process)` | turn parks → §11.1 `WaitingProcess` |
+| `SpawnedChildRun { .. }` | `Resolution::Suspended(Suspension::ChildRun)` | carries result ref + byte len as `OutcomeRefs` do |
+| `AwaitDependentRun { .. }` | `Resolution::Suspended(Suspension::DependentRun)` | |
+| `ExternalToolPending { .. }` | `Resolution::Suspended(Suspension::ExternalTool)` | host never dispatches; control returns to the API client |
+
+Batch invocation (`CapabilityBatchInvocation`, `stop_on_first_suspension`) is
+**not** a tenth row — it is a fold over per-invocation resolutions with its own
+resume state, modeled in §11.1 (the #6137 bug class lives there, not in the
+single-invocation vocabulary).
+
+### 5.3.1 Decision: gates arise at dispatch time too — and only `Auth`
+
+`authorize()` pre-flights everything pre-flightable: trust, approval,
+resources, credential *presence*. But a lane can discover a credential demand
+only by calling the thing — `DispatchError::AuthRequired` is produced today
+inside lane execution (`ironclaw_host_runtime/src/services/wasm_execution.rs`,
+`services/runtime_adapters.rs`), and an MCP server tells you it wants auth by
+returning 401. Pretending otherwise would make the signature forbid something
+the system observably does. So the contract is: **`dispatch` may surface
+exactly one gate kind — `Blocked::Auth`.** Approval and Resource gates are
+always pre-flight (`authorize()`-only), enforced by conformance test (§11.7): a
+lane-originated Approval/Resource gate is a `HostFailure::Permanent`, never a
+gate. "ALL policy, one place" is therefore stated precisely: *all pre-flightable
+policy in `authorize()`; dispatch-time auth discovery re-enters through the
+same gate vocabulary and the same resume path* — one gate model, two points of
+discovery.
+
+### 5.3.2 Decision: the `Authorized` lifecycle is part of the contract
+
+`authorize()` is effectful (reservation write + obligation prepare, §12.1), so
+the witness it returns has a lifecycle, not just a type:
+
+- **Single-use:** `dispatch` consumes `Authorized`. Replay of a resolved
+  `activity_id` goes through the idempotency record (§3), never through
+  re-dispatching a held witness.
+- **Explicit unwind:** the not-dispatched path (cancel between authorize and
+  dispatch, runner handoff, shutdown) calls `abort(auth)`, which releases the
+  reservation and aborts prepared obligations. Unwind is never implicit in
+  `Drop` — destructors do no async I/O. A leaked witness (crash) is recovered
+  by the same lease-expiry sweep that recovers runs: reservations carry the
+  `activity_id` and expire with it.
+- **Bounded validity:** `Authorized` carries a deadline derived from the
+  shortest-lived fact it froze (approval lease, credential lease). `dispatch`
+  after the deadline fails closed with `HostFailure::Permanent` — a held
+  witness cannot outlive its facts.
+- **Cancellation reaches mid-flight dispatch:** `dispatch` takes a
+  `CancelSignal`; the two-phase cancel (§11.1, `CancelRequested → Cancelled`)
+  propagates into the lane through it, and a cancelled dispatch resolves — it
+  does not vanish with obligations half-open.
 
 ### 5.4 The loop interface — the loop's trust membrane (one of several)
 
@@ -811,7 +988,7 @@ trait AgentLoopDriver {                      // userland: agent behavior, replac
 trait AgentLoopHost {
     fn prompt(&self) -> PromptContext;
     fn model(&self, req: ModelRequest) -> ModelResult;
-    fn invoke(&self, req: LoopRequest) -> Result<Outcome, InvokeError>; // → resolve → authorize → dispatch (§3)
+    fn invoke(&self, req: LoopRequest) -> Result<Resolution, HostFailure>; // → resolve → authorize → dispatch (§3); Denied/Blocked/Suspended arrive as Resolution
     fn transcript(&self) -> &dyn TranscriptPort;
     fn checkpoint(&self, state: LoopState) -> CheckpointRef;
     fn input(&self) -> &dyn InputPort;
@@ -874,7 +1051,7 @@ flowchart TD
     SB["SecretBroker"]
     NP["NetworkPolicy"]
     EV["Events / Memory / Threads / RunState"]
-    RL["Runtime lanes: Wasm · Script · Mcp · FirstParty"]
+    RL["Runtime lanes: FirstParty · Wasm · Mcp · Process"]
     CFG["DeploymentConfig (data)"]
 
     P -->|ProductSurface: turns| TC
@@ -1007,7 +1184,7 @@ are the concrete enforcement for the products-in-composition ratchet (§10).
    grants** — it is built only by `dispatch()`, which holds a verified, sealed `Authorized`
    (§3), and the adapter receives only the derived handles, never `Authorized` itself, so it
    cannot re-authorize or widen. So the URT's `ToolAdapter::invoke(call, ports)` **is** the
-   body of this doc's `dispatch(inv, auth, lane)` for the FirstParty/Wasm/Mcp lanes; the
+   body of this doc's `dispatch(auth)` (the lane is sealed inside `Authorized`, §5.3.2) for the FirstParty/Wasm/Mcp lanes; the
    `Process` lane is the same shape with a `ProcessSandbox` handle in place of raw egress.
 
 ---
@@ -1043,11 +1220,26 @@ unbounded to the user's workspace — reading the host filesystem, shared across
 - **`ProcessSandbox` is the only way to run an OS process** (§5.5), and `SandboxMount`
   has only `for_scope` — no `from_host_path`. "Run shell against the host root" is
   *unrepresentable*.
-- **`DeploymentConfig.process`** (§5.6): `HostUnsandboxed` requires a `LocalOnlyToken`
-  a served boot cannot mint, so the host port is **unconstructible** once more than one
-  user is authenticated.
+- **`DeploymentConfig.process`** (§5.6): `HostUnsandboxed` requires a `LocalOnlyToken`,
+  and the token is validated **per spawn, against current facts** — see "the served
+  predicate" below. A served deployment cannot pass the check, at boot or ever after.
 - **Mode is derived from a fact, not a profile string** (§4.4 principle): a multi-user
   boot cannot resolve `LocalSingleUser`; it fails closed at startup.
+
+**The served predicate — defined, because "local" is not decidable once at boot.**
+This product family ships tunnels (`src/tunnel/`: cloudflared, ngrok, tailscale,
+custom) and multi-device pairing: a boot that is genuinely local-single-user at
+startup can *become* served afterwards. So `LocalOnlyToken` is not a boot-time
+artifact; it is a capability checked at **every** `ProcessSandbox::spawn` against
+two live facts: (a) exactly one authenticated `UserId` exists, and (b) no public
+ingress is active (no tunnel, no non-loopback listener with SSO enabled). The
+transition is part of the contract: the moment fact (a) or (b) flips —
+a second user authenticates, a tunnel comes up — subsequent host-unsandboxed
+spawns fail closed, **and in-flight host processes are killed**, not drained:
+their containment premise is gone, and a drained process is a live cross-tenant
+window. The §11.2 matrix test drives exactly this transition (spawn under
+single-user, flip the fact, assert kill + fail-closed), not only the static
+two-user case.
 - **Fail-closed default:** no verified sandbox ⇒ shell is hidden and rejected
   (`SecureDefault → process None`), never host shell.
 - **Mechanical guarantee** (§9): a two-user integration test drives user B's shell and
@@ -1055,9 +1247,15 @@ unbounded to the user's workspace — reading the host filesystem, shared across
   thing whose absence let this ship.
 
 The lesson generalizes: the escape existed because isolation was runtime discipline
-over a fail-open default. In the target structure it is a structural impossibility —
-one sandbox chokepoint, an unconstructible unsafe path, mode-from-fact, fail-closed —
-plus a test that *proves* containment. That is the entire thesis in one incident.
+over a fail-open default. The target structure is honest about which guarantees are
+which: the sandbox chokepoint and the missing `from_host_path` constructor are
+**structural** (unrepresentable); the multi-user impossibility is a **fail-closed
+runtime check at every spawn** (the served predicate above) — still a check, but one
+with a single site, a closed default, and a matrix test that proves it across the
+transition. Calling that second half "impossible by construction" would be the same
+overclaim this document criticizes; what it is instead is *runtime discipline reduced
+to one auditable predicate with a kill-switch semantics* — plus a test that proves
+containment. That is the entire thesis in one incident.
 
 ---
 
@@ -1065,7 +1263,7 @@ plus a test that *proves* containment. That is the entire thesis in one incident
 
 | | Now | After |
 | --- | --- | --- |
-| Types per capability call | ~14 | 4 (`LoopRequest` / `Invocation` / `Authorized` / `Outcome`) |
+| Types per capability call | ~14 | ~9–10: 4 payload shapes (`LoopRequest` / `Invocation` / `Authorized` / `Outcome`) + resolution vocabulary + per-lane types (trust boundary, must survive) — every one a distinct state, none a mirror (§3) |
 | Hot-path `dyn` seams | 6+ | 2 + 1 lane enum |
 | Policy decision sites | 4 crates | 1 `authorize()` |
 | Store impls per domain | 2–4 hand-written | 1 (`FsStore<F>`); in-memory is a backend, not a store |
@@ -1110,7 +1308,18 @@ across the host-kernel chain. Same goal, orthogonal axes — no conflict.
 
 Land in verifiable slices with `ironclaw_architecture` boundary tests green at
 every step. The moves have very different risk, so sequence by risk, not by section
-order. Two are low-risk and independently valuable — start there:
+order.
+
+**Slice 0 (prerequisite — the reference-model property suite, §11.4).** The
+model-based stateful property tests are not a follow-up: they are the safety net
+that makes Slice A's store consolidation checkable (they replace the independent
+oracle the `InMemory*` deletion removes, §4.3) and the instrument that reaches the
+states where the §11.2 invariants live. The repo has no stateful
+property-testing infrastructure today; standing it up — reference model for the
+turn/lease machine, operation generator, invariant checker — is its own scoped
+slice and lands **before** the first store deletion.
+
+Two moves are then low-risk and independently valuable — start there:
 
 **Slice A (lowest risk — delete in-memory stores).** The seam already exists
 (§4.3), so this is subtractive: pick one domain (say approvals), delete its
@@ -1136,6 +1345,31 @@ first-party lane only).**
 
 If C drops the type count with green boundary tests, roll it across the remaining
 lanes, then the `RuntimeLane` enum, then the mediator-trait collapse (§4.2).
+
+Two facts about the intermediate states, stated so nobody discovers them
+mid-migration:
+
+- **The `Authorized` seal is not load-bearing until step 2 completes its
+  inlining.** While `authorize()` delegates to the four existing checks, an
+  `Authorized` is constructible with policy still smeared across four crates —
+  the witness type exists but its guarantee is vacuous. The seal becomes real
+  when the last delegated check is inlined; mark that PR explicitly (it is the
+  security milestone of Slice C, not the type introduction).
+- **Type count rises before it falls.** During C the five old request shapes and
+  the new vocabulary coexist (~14 → ~18 → ~9–10). The §10 mirror-DTO ratchet's
+  allowlist is what makes this safe: the old five are frozen entries that may
+  only disappear.
+
+**Ordering vs. the Unified Extension Runtime (§5.9) — decided.** The two
+efforts share one seam: the URT's "dispatcher pipeline, implemented once" *is*
+`authorize` + `dispatch`, and its `ToolPorts` is derived from `Authorized`
+(§5.9). Therefore **this doc's Slice C lands the kernel vocabulary first**
+(`Invocation`/`Authorized`/`Resolution` in `host_api`), and the URT builds its
+loaders/adapters against that frozen §5.3 interface; the URT's extension/auth
+axis (recipes, `AuthEngine`, adapter seams) proceeds in parallel — it does not
+touch the kernel types. If the URT reaches its dispatcher work before Slice C
+lands, it implements against §5.3's signatures as written, and any change it
+needs is a change request to this doc, not a divergent local shape at the seam.
 
 ### Risks and honest caveats
 
@@ -1181,6 +1415,12 @@ that axis is complete when its ratchet flips from a frozen allowlist to an empty
 structural assertion passes). Until then the frozen allowlist is the contract — it may only
 get shorter.
 
+**Every axis needs a named owner before its ratchet lands.** A ratchet without an
+owner is telemetry: nothing shrinks its allowlist and nothing flips it to a hard
+ban. The PR that lands an axis's check names its owner (the person driving that
+allowlist to empty) in the check's own doc comment — an unowned ratchet PR is
+incomplete the same way a check without a self-test is.
+
 Two rules from the guidance layer apply, because a guardrail is itself code
 (`.claude/rules/review-discipline.md`, `ironclaw-reborn-skill-maintainer`):
 
@@ -1221,7 +1461,8 @@ states where the bugs live*.
 (Flows described in `crates/Architecture.md`; the tests make them enforceable.)
 
 - **Turn/run lifecycle:** `Queued → Running → {BlockedApproval | BlockedAuth | WaitingProcess} → Queued(resume) → … → {Completed | Failed | Cancelled}`, plus lease-expiry and crash/recover edges.
-- **Capability invocation:** `LoopRequest → resolve → authorize → {Authorized | Blocked} → dispatch(lane) → {Outcome | HostFailure}`, with resume / auth-resume re-entry.
+- **Capability invocation:** `LoopRequest → resolve → authorize → {Authorized | Denied | Blocked} → dispatch → {Done | Blocked(Auth) | Suspended | HostFailure}` (§5.3), with resume / auth-resume re-entry, `abort` on the not-dispatched path, and `Uncertain` on crash-mid-dispatch (§11.3).
+- **Batch invocation (#6137's home):** `CapabilityBatchInvocation { invocations, stop_on_first_suspension }` is a fold over per-invocation machines with an explicit batch-resume state: when invocation *k* gates, invocations *k+1..n* are recorded pending; gate resolution re-enters the **batch**, which must redispatch every pending member — not only the first — under their original `activity_id`s. The mixed-resolution states (some `Done`, one `Blocked`, rest pending) are enumerated like any other state; #6137 is the regression test.
 - **Lease:** `unclaimed → claimed(runner, token) → heartbeat* → {released | expired}`; expiry terminal.
 - **Gate/resume:** `blocked(gate_ref, checkpoint) → resolved → requeue(same run/checkpoint)`.
 
@@ -1244,6 +1485,12 @@ Every mutating operation is idempotent by construction, proven *from any state*:
 - **Replay returns the recorded sanitized outcome and re-runs no side effect** — for `submit`, `resume`, `retry`, `cancel`, capability `invoke`, and subagent release.
 - **Replay is safe after the operation already resolved**: submit-after-terminal, resume-after-resumed, cancel-after-cancelled (returns `already_terminal`), double-claim (one winner), double-release (once).
 - **Transient states are deliberately non-replayable** and tested as such: same-thread-busy is a lock state, not an idempotent outcome — its record is kept for audit, never replayed.
+- **Crash-mid-dispatch has no replayable answer, and the contract says so:** a retry
+  that finds the authorize record but no resolution record maps to
+  `HostFailure::Uncertain` (§5.3) — the side effect may or may not have run, the
+  caller is told exactly that, and the operation is **never silently re-executed**.
+  At-most-once is the invariant; fault injection (§11.4) drives the crash into the
+  gap between dispatch start and the resolution write to prove it.
 - **Recorded errors replay as sanitized categories**, never raw causes.
 
 ### 11.4 How to reach "any state"
@@ -1298,7 +1545,11 @@ adapter/loop/backend inherits correctness instead of re-deriving it:
   of a product mutation.
 - **`AgentLoopHost`** — the trust membrane: a loop reaches effects only through it; direct
   dispatcher/secret/network access is a compile error (boundary test).
-- **`authorize` / `dispatch`** — authority-before-effect, redaction, fail-closed.
+- **`authorize` / `dispatch`** — authority-before-effect, redaction, fail-closed; the
+  §5.3 acceptance table (every `CapabilityOutcome` row producible, each in its channel);
+  §5.3.1's gate discipline (a lane-originated Approval/Resource gate is a
+  `HostFailure::Permanent`, never a gate); batch resume redispatches every pending
+  member (§11.1, #6137).
 - **store traits / `RootFilesystem`** — the §11.5 parity suite.
 
 ### 11.8 Tiering
@@ -1436,9 +1687,15 @@ decorator gating and synthetic-capability promotion are settled here.**
   scope-binding/mounts for free — closing the scope-binding gap the synthetic handlers
   have (e.g. `result_read` / `outbound_delivery` must be user-scoped). The only
   pre-promotion check is that each descriptor declares the correct scope and defaults
-  hidden until reviewed for the hosted surface. This promotion is **Slice 1 of the §5.2.5
-  facade migration**: the same descriptor + per-origin-policy shape then absorbs the
-  `RebornServicesApi` mutations one by one.
+  hidden until reviewed for the hosted surface. One honest accounting: today these tools
+  are *structurally absent* from hosted builds; after promotion their hosted absence is a
+  visibility **policy** — a demotion of exactly the kind §6 criticizes. So the default is
+  not left as a descriptor field someone can flip: an `ironclaw_architecture` assertion
+  pins that **no promoted capability id appears in any hosted surface unless it is in a
+  reviewed allowlist** (initially empty). That restores the structural guarantee the
+  synthetic mechanism's absence used to provide, while keeping the scope-binding gains.
+  This promotion is **Slice 1 of the §5.2.5 facade migration**: the same descriptor +
+  per-origin-policy shape then absorbs the `RebornServicesApi` mutations one by one.
 
 **Genuinely remaining (tuning/ops, not architecture):** the lease-TTL latency multiplier
 `k` in `lease_ttl ≥ k × backend_p99_write` (§12), and the default `RootFilesystem` backend
@@ -1459,6 +1716,7 @@ knobs to calibrate against measured latency, not open architectural questions.
 - `crates/ironclaw_filesystem/src/in_memory.rs` — `InMemoryBackend: RootFilesystem`: the existing seam that makes every `InMemory*Store` deletable (§4.3).
 - `crates/ironclaw_reborn_composition/src/local_dev_capability_policy.rs` — `LocalDevConstraintSource` and the ~66-identifier `LocalDev*` shadow runtime to collapse to config (§4.4).
 - `crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs` — boundary tests that must stay green; home for the "no `Local*` type names" and "freeze `host_api`" checks.
+- `.claude/rules/type-placement.md` — the standing type-location/trait-justification rule (2026-07 measurements: ~1% true duplicates, 97.7% of traits justified); §4.2 narrows its test-seam justification for hot-path mediators and must amend it in the Slice C PR.
 - Issue #6170 (shell cross-tenant escape — the §6 case study); `crates/ironclaw_reborn_composition/src/local_runtime_profile.rs` (the `HostedSingleTenant → LocalSingleUser` mapping), `crates/ironclaw_host_runtime/src/planner.rs` (process/filesystem fail-closed rules).
 - Issues: #6168 (composition god-crate), #6144 (unenforced budget), #6137 / #6138 (gate-resume / capability-path).
 - Unified Extension Runtime design note (in progress, BenKurrek) — the detailed extension / adapter / auth design this proposal aligns with (§5.9): https://gist.github.com/BenKurrek/1d0c9189a3b25f5933cb00d4ac188efe


### PR DESCRIPTION
## Summary

Two revisions to `docs/reborn/2026-07-17-architecture-simplification-dto-dyn-local.md`, produced by an adversarial review of the proposal against the code on `main`.

### r2 — §5.2 reworked: product surface = turn lifecycle + `invoke`/`query` capability conduits

The six-method `ProductSurface` could not carry the product: the proto-surface it replaces (`RebornServicesApi`) has **88 trait methods (measured from the trait block; the earlier ~251 was a file-wide count)**, mostly non-conversation operations. Rather than growing methods back, everything now goes through capabilities, per the standing `tools.md` rule:

- Six frozen turn-lifecycle methods + `invoke` (commands — the product-side twin of `AgentLoopHost::invoke`, same `authorize`+`dispatch` pipeline) + `query` (view descriptors over projections, no dispatch).
- **§5.2.1 `InvocationOrigin`** (`LoopRun | Product | Automation`): required, membrane-sealed `Invocation` field; per-origin descriptor policy deny-by-default with an `ironclaw_architecture` test; approval gates auto-satisfied for `Product` origin (the click is the consent), auth/resource gates uniform.
- §5.2.4 names the honest cost (type safety moves to descriptor schemas; handlers deserialize first; TS generated from descriptors) and the atomicity rule (one user gesture = one capability).
- §5.2.5 + §10 ratchet row: freeze the `RebornServicesApi` method set now; Slice 1 is the §13.3 synthetic-tool promotion.

### r3 — contract-gap hardening from the review

**Design holes closed (§5.3 and dependents):**
- **Acceptance table** mapping all ten `CapabilityOutcome` variants (`host.rs:1851`) into a five-channel model — adds the missing `Denied` terminal and `Suspension` (parked work: `SpawnedProcess`/`ChildRun`/`DependentRun`/`ExternalTool`) channels the old 3-channel model could not express.
- **§5.3.1** decides dispatch-time gates: `dispatch` may surface exactly one gate kind (`Blocked::Auth` — lanes discover credential demands at call time; `DispatchError::AuthRequired` is produced in `wasm_execution.rs`/`runtime_adapters.rs` today). Approval/Resource stay pre-flight-only, conformance-enforced.
- **§5.3.2** gives `Authorized` a lifecycle: lane sealed inside (kills the loose `(auth, lane)` pair; host-only `Process` lane becomes structural), `dispatch` consumes the witness, explicit `abort()` (never `Drop`), validity deadline, `CancelSignal` into mid-flight dispatch.
- **`HostFailure::Uncertain`** for crash-between-dispatch-and-record (§3, §11.3): at-most-once stated honestly instead of an unimplementable replay claim.
- **§6 served predicate** defined: `LocalOnlyToken` validated per spawn against live facts (single authenticated user, no public ingress — this product ships tunnels); transition semantics (kill in-flight host processes); "impossible by construction" downgraded to what is actually structural.
- **`RuntimeLane` unified** on `FirstParty | Wasm | Mcp | Process` (§4.2 previously said `Script`, §5.9 said `Process` — the doc's two load-bearing enum definitions disagreed).

**Honesty/consistency:**
- Explicit reconciliation with `.claude/rules/type-placement.md` (whose 2026-07 audit lists test seams as a valid trait justification — §4.2 now narrows that for hot-path mediators only and commits to amending the rule in the Slice C PR). Doubly needed now that `architecture.md` cites this doc as the canonical consolidation plan.
- §1.5 evidence reframed: per-bug causal accounting (#6170 is a policy default, #6137 is batch semantics, #6144 is enforcement — none prevented by type collapse alone); the claim becomes "one place to be wrong instead of four."
- Type-count corrected to ~14 → ~9–10 (§3, §7), consistent with §1.1's own field-diff (~40% duplication); per-lane types survive because the lane boundary is a trust boundary.
- §11.1 models **batch invocation** (the #6137 bug class) as a fold with a batch-resume state; §11.7 conformance extended.
- §4.4 names the enum-vs-data tension (lanes are branched in exactly one place; modes in zero).
- §13.3: hosted-hidden default for promoted synthetic capabilities backed by an `ironclaw_architecture` assertion instead of a flippable descriptor field.

**Migration/process:**
- §9 **Slice 0**: the §11.4 reference-model property suite is a prerequisite of Slice A (it replaces the independent oracle the `InMemory*` deletion removes — §4.3 now owns that loss, plus inventory-before-delete for the 4,260-LOC in-memory turn store and a test-latency budget).
- §9 states when the `Authorized` seal becomes load-bearing and that type count rises before it falls; **URT ordering decided** (kernel vocabulary lands first; URT builds against frozen §5.3).
- §10: named owner required per ratchet axis.
- Revision log added; section numbers declared frozen identifiers (in-code `arch-exempt` annotations cite them).

## Verification

- All code claims re-verified on this checkout: `RebornServicesApi` = 251 async fns (`reborn_services.rs:1751`), `CapabilityOutcome` nine variants + batch types (`ironclaw_turns/src/run_profile/host.rs:1722–1923`), dispatch-time `AuthRequired` producers (`ironclaw_host_runtime/src/services/`), `ExecutionContext.authenticated_actor_user_id` (`ironclaw_host_api/src/scope.rs:47`), `FilesystemTurnStateStore<F>` generic + 4,258-LOC in-memory store.
- Doc-hygiene grep (no absolute paths) clean; docs-only change, no code touched. [skip-regression-check]

## Follow-ups this PR creates (not done here)

- Amend `.claude/rules/type-placement.md` in the Slice C PR (§4.2 commitment).
- `.claude/rules/architecture.md` cites this doc's §5 as the `arch-exempt` plan target — owner of that rule should confirm the r2/r3 section additions read correctly from there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)