### PR TITLE
refactor(reborn): budget-gate store over RootFilesystem, delete InMemoryBudgetGateStore (§4.3)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -312,7 +312,7 @@ ironclaw_hooks = { path = "crates/ironclaw_hooks", version = "0.1.0" }
 ironclaw_host_runtime = { path = "crates/ironclaw_host_runtime", version = "0.1.0" }
 ironclaw_network = { path = "crates/ironclaw_network", version = "0.1.0" }
 ironclaw_processes = { path = "crates/ironclaw_processes", version = "0.1.0", features = ["test-support"] }
-ironclaw_resources = { path = "crates/ironclaw_resources", version = "0.1.0" }
+ironclaw_resources = { path = "crates/ironclaw_resources", version = "0.1.0", features = ["test-support"] }
 ironclaw_secrets = { path = "crates/ironclaw_secrets", version = "0.1.0" }
 ironclaw_product_adapters = { path = "crates/ironclaw_product_adapters", version = "0.1.0", features = ["test-support"] }
 ironclaw_product_workflow = { path = "crates/ironclaw_product_workflow", version = "0.1.0", features = ["test-support"] }

--- a/crates/ironclaw_approvals/src/policy.rs
+++ b/crates/ironclaw_approvals/src/policy.rs
@@ -565,7 +565,7 @@ fn invalid_path(error: HostApiError) -> PersistentApprovalPolicyError {
 mod tests {
     use std::sync::Arc;
 
-    use ironclaw_filesystem::{InMemoryBackend, LocalFilesystem, ScopedFilesystem};
+    use ironclaw_filesystem::{DiskFilesystem, InMemoryBackend, ScopedFilesystem};
     use ironclaw_host_api::{
         AgentId, EffectKind, GrantConstraints, HostPath, InvocationId, MountAlias, MountGrant,
         MountPermissions, MountView, NetworkPolicy, ProjectId, ThreadId, VirtualPath,
@@ -672,7 +672,7 @@ mod tests {
     #[tokio::test]
     async fn filesystem_policy_store_rejects_versioned_mutation_on_byte_only_backend() {
         let tempdir = tempfile::tempdir().expect("tempdir");
-        let mut backend = LocalFilesystem::new();
+        let mut backend = DiskFilesystem::new();
         backend
             .mount_local(
                 VirtualPath::new("/engine").unwrap(),

--- a/crates/ironclaw_architecture/tests/reborn_inmemory_store_ratchet.rs
+++ b/crates/ironclaw_architecture/tests/reborn_inmemory_store_ratchet.rs
@@ -59,7 +59,6 @@ const FROZEN_INMEMORY_STORES: &[&str] = &[
     // --- peripheral stores (outside §4.3's five core domains; listed so the
     //     ratchet stays exhaustive and no new InMemory store slips in) ---
     "InMemoryBoundedSubagentGoalStore",
-    "InMemoryBudgetGateStore",
     "InMemoryDeliveredGateRouteStore",
     "InMemoryExtensionInstallationStore",
     "InMemoryOpenAiCompatRefStore",

--- a/crates/ironclaw_architecture/tests/reborn_localdev_typename_ratchet.rs
+++ b/crates/ironclaw_architecture/tests/reborn_localdev_typename_ratchet.rs
@@ -31,7 +31,7 @@
 //! Definition of done for this axis (§4.4/§10): the allowlist reaches the empty
 //! set — no `LocalDev*` type remains; local-dev is one `DeploymentConfig`
 //! constant. (Scoped to `LocalDev*` specifically: the broader §4.4 `Local*` /
-//! `Hosted*` name audit — Bucket 2 renames like `LocalFilesystem`→`DiskFilesystem`
+//! `Hosted*` name audit — Bucket 2 renames like `DiskFilesystem`→`DiskFilesystem`
 //! and Bucket 3 false positives like `Locale`, `HostedMcp*`, `NodeTraceSubmission*`
 //! — is a separate concern, so this ratchet stays high-signal with a clean
 //! empty-set goal.)

--- a/crates/ironclaw_architecture/tests/reborn_localdev_typename_ratchet.rs
+++ b/crates/ironclaw_architecture/tests/reborn_localdev_typename_ratchet.rs
@@ -31,7 +31,7 @@
 //! Definition of done for this axis (§4.4/§10): the allowlist reaches the empty
 //! set — no `LocalDev*` type remains; local-dev is one `DeploymentConfig`
 //! constant. (Scoped to `LocalDev*` specifically: the broader §4.4 `Local*` /
-//! `Hosted*` name audit — Bucket 2 renames like `DiskFilesystem`→`DiskFilesystem`
+//! `Hosted*` name audit — Bucket 2 renames like `LocalFilesystem`→`DiskFilesystem`
 //! and Bucket 3 false positives like `Locale`, `HostedMcp*`, `NodeTraceSubmission*`
 //! — is a separate concern, so this ratchet stays high-signal with a clean
 //! empty-set goal.)

--- a/crates/ironclaw_authorization/src/lib.rs
+++ b/crates/ironclaw_authorization/src/lib.rs
@@ -403,7 +403,7 @@ where
     /// other writer can collide with.
     /// Write the lease through the backend with the given CAS expectation.
     ///
-    /// Backends that don't track per-row versions (e.g. `LocalFilesystem`)
+    /// Backends that don't track per-row versions (e.g. `DiskFilesystem`)
     /// reject `CasExpectation::Version(_)` with `Unsupported`. For those,
     /// fall back to `CasExpectation::Any` and carry the safety invariant
     /// via the per-owner `mutation_lock` — same trade-off documented on
@@ -432,7 +432,7 @@ where
             &lease_owner_prefix(&lease.scope)?,
         )
         .await?;
-        // Byte-only backends (LocalFilesystem) reject BOTH non-`Any` CAS
+        // Byte-only backends (DiskFilesystem) reject BOTH non-`Any` CAS
         // AND entries with a populated `indexed` projection in a single
         // `Unsupported` response. Strip the projection and downgrade CAS
         // to `Any` so byte-only mounts stay writeable — the per-owner
@@ -543,7 +543,7 @@ where
                 IndexValue::Text(scope.tenant_id.as_str().to_string()),
             );
         ensure_tenant_id_index(&self.filesystem, scope, &lease_owner_prefix(scope)?).await?;
-        // Byte-only backends (LocalFilesystem) reject entries with a
+        // Byte-only backends (DiskFilesystem) reject entries with a
         // populated `indexed` projection. Fall back to the plain-bytes
         // shape for those — the tenant projection is best-effort defense
         // in depth, and dropping it on byte-only mounts is acceptable
@@ -1648,7 +1648,7 @@ fn index_name_authorization_tenant() -> IndexName {
 }
 
 /// Declare the `tenant_id` exact-equality index on `prefix`, tolerating
-/// backends that don't materialize indexes (LocalFilesystem). Idempotent
+/// backends that don't materialize indexes (DiskFilesystem). Idempotent
 /// across the mount lifetime; mirrors the engine/processes stores'
 /// `ensure_*_index` shape so byte-only backends degrade gracefully
 /// instead of failing closed.

--- a/crates/ironclaw_authorization/tests/capability_lease_contract.rs
+++ b/crates/ironclaw_authorization/tests/capability_lease_contract.rs
@@ -7,7 +7,7 @@ use async_trait::async_trait;
 use chrono::Utc;
 use ironclaw_authorization::*;
 use ironclaw_filesystem::{
-    DirEntry, FileStat, FilesystemError, InMemoryBackend, LocalFilesystem, RootFilesystem,
+    DirEntry, DiskFilesystem, FileStat, FilesystemError, InMemoryBackend, RootFilesystem,
     ScopedFilesystem,
 };
 use ironclaw_host_api::*;
@@ -740,7 +740,7 @@ async fn filesystem_lease_store_persists_and_reloads_issued_leases() {
 
 #[tokio::test]
 async fn filesystem_lease_store_lists_from_owner_index_without_scanning_invocation_roots() {
-    // Wrap the underlying [`LocalFilesystem`] in a [`CountingFilesystem`]
+    // Wrap the underlying [`DiskFilesystem`] in a [`CountingFilesystem`]
     // so we can assert that `leases_for_scope` reads the owner index
     // rather than fanning out to `list_dir` per invocation. The
     // [`ScopedFilesystem`] layer on top binds the `/authorization` alias
@@ -1164,12 +1164,12 @@ async fn revoked_lease_no_longer_authorizes_dispatch() {
 }
 
 struct CountingFilesystem {
-    inner: LocalFilesystem,
+    inner: DiskFilesystem,
     list_dir_calls: Arc<AtomicUsize>,
 }
 
 impl CountingFilesystem {
-    fn new(inner: LocalFilesystem) -> Self {
+    fn new(inner: DiskFilesystem) -> Self {
         Self {
             inner,
             list_dir_calls: Arc::new(AtomicUsize::new(0)),
@@ -1217,7 +1217,7 @@ impl RootFilesystem for CountingFilesystem {
     }
 
     // After PR #3659 the trait default `get`/`put` are `Unsupported`.
-    // Forward to the inner LocalFilesystem (which implements them
+    // Forward to the inner DiskFilesystem (which implements them
     // natively) so this counting wrapper keeps participating in the
     // unified surface used by FilesystemCapabilityLeaseStore's read_lease
     // / write_lease / read_lease_index / write_lease_index ops.
@@ -1295,20 +1295,20 @@ fn timestamp(value: &str) -> Timestamp {
     serde_json::from_value(serde_json::Value::String(value.to_string())).unwrap()
 }
 
-fn engine_filesystem() -> Arc<ScopedFilesystem<LocalFilesystem>> {
+fn engine_filesystem() -> Arc<ScopedFilesystem<DiskFilesystem>> {
     build_scoped_fs(
         Arc::new(local_filesystem_with_engine_mount()),
         "/engine/tenants/test/users/test/authorization",
     )
 }
 
-/// Build a [`LocalFilesystem`] with a temp directory mounted at `/engine`
+/// Build a [`DiskFilesystem`] with a temp directory mounted at `/engine`
 /// so tests can target paths beneath it via `ScopedFilesystem`.
-fn local_filesystem_with_engine_mount() -> LocalFilesystem {
+fn local_filesystem_with_engine_mount() -> DiskFilesystem {
     let storage = tempfile::tempdir().unwrap().keep();
     let engine_root = storage.join("engine");
     std::fs::create_dir_all(&engine_root).unwrap();
-    let mut fs = LocalFilesystem::new();
+    let mut fs = DiskFilesystem::new();
     fs.mount_local(
         VirtualPath::new("/engine").unwrap(),
         HostPath::from_path_buf(engine_root),

--- a/crates/ironclaw_capabilities/tests/capability_host_dispatcher_integration.rs
+++ b/crates/ironclaw_capabilities/tests/capability_host_dispatcher_integration.rs
@@ -9,7 +9,7 @@ use ironclaw_dispatcher::{
     RuntimeAdapter, RuntimeAdapterRequest, RuntimeAdapterResult, RuntimeDispatcher,
 };
 use ironclaw_events::{InMemoryEventSink, RuntimeEventKind};
-use ironclaw_filesystem::{InMemoryBackend, LocalFilesystem};
+use ironclaw_filesystem::{DiskFilesystem, InMemoryBackend};
 use ironclaw_host_api::*;
 use ironclaw_resources::*;
 use ironclaw_run_state::*;
@@ -382,10 +382,10 @@ impl RecordingRuntimeAdapter {
 }
 
 #[async_trait]
-impl RuntimeAdapter<LocalFilesystem, InMemoryResourceGovernor> for RecordingRuntimeAdapter {
+impl RuntimeAdapter<DiskFilesystem, InMemoryResourceGovernor> for RecordingRuntimeAdapter {
     async fn dispatch_json(
         &self,
-        request: RuntimeAdapterRequest<'_, LocalFilesystem, InMemoryResourceGovernor>,
+        request: RuntimeAdapterRequest<'_, DiskFilesystem, InMemoryResourceGovernor>,
     ) -> Result<RuntimeAdapterResult, DispatchError> {
         self.requests.lock().unwrap().push(RecordedRuntimeRequest {
             capability_id: request.capability_id.clone(),
@@ -430,12 +430,12 @@ fn runtime_dispatcher_stack(
     adapter: Arc<RecordingRuntimeAdapter>,
 ) -> (
     Arc<ironclaw_extensions::ExtensionRegistry>,
-    RuntimeDispatcher<'static, LocalFilesystem, InMemoryResourceGovernor>,
+    RuntimeDispatcher<'static, DiskFilesystem, InMemoryResourceGovernor>,
     Arc<InMemoryResourceGovernor>,
     InMemoryEventSink,
 ) {
     let registry = Arc::new(registry_with_echo_capability());
-    let filesystem = Arc::new(LocalFilesystem::new());
+    let filesystem = Arc::new(DiskFilesystem::new());
     let governor = Arc::new(InMemoryResourceGovernor::new());
     let events = InMemoryEventSink::new();
     let dispatcher =

--- a/crates/ironclaw_conversations/src/filesystem_store.rs
+++ b/crates/ironclaw_conversations/src/filesystem_store.rs
@@ -353,7 +353,7 @@ fn index_key_tenant_ids() -> IndexKey {
 ///
 /// Mirrors the secrets / processes / run-state stores: record-shaped
 /// entries and non-`Any` CAS are stripped/downgraded when the backend
-/// reports `Unsupported` so byte-only mounts (LocalFilesystem) keep
+/// reports `Unsupported` so byte-only mounts (DiskFilesystem) keep
 /// working. The single-instance `mutation_lock` on
 /// [`InMemoryConversationServices`] is the caller-side ordering guarantee
 /// that CAS would otherwise provide on byte-only backends.

--- a/crates/ironclaw_dispatcher/tests/dispatch_contract.rs
+++ b/crates/ironclaw_dispatcher/tests/dispatch_contract.rs
@@ -449,10 +449,10 @@ struct RecordedAdapterRequest {
 }
 
 #[async_trait]
-impl RuntimeAdapter<LocalFilesystem, InMemoryResourceGovernor> for RecordingAdapter {
+impl RuntimeAdapter<DiskFilesystem, InMemoryResourceGovernor> for RecordingAdapter {
     async fn dispatch_json(
         &self,
-        request: RuntimeAdapterRequest<'_, LocalFilesystem, InMemoryResourceGovernor>,
+        request: RuntimeAdapterRequest<'_, DiskFilesystem, InMemoryResourceGovernor>,
     ) -> Result<RuntimeAdapterResult, DispatchError> {
         self.requests.lock().unwrap().push(RecordedAdapterRequest {
             provider: request.package.id.clone(),
@@ -510,9 +510,9 @@ fn dispatch_error_for_runtime(
     }
 }
 
-fn mounted_empty_extension_root() -> LocalFilesystem {
+fn mounted_empty_extension_root() -> DiskFilesystem {
     let storage = tempfile::tempdir().unwrap().keep();
-    let mut fs = LocalFilesystem::new();
+    let mut fs = DiskFilesystem::new();
     fs.mount_local(
         VirtualPath::new("/system/extensions").unwrap(),
         HostPath::from_path_buf(storage),

--- a/crates/ironclaw_dispatcher/tests/event_dispatch_contract.rs
+++ b/crates/ironclaw_dispatcher/tests/event_dispatch_contract.rs
@@ -352,10 +352,10 @@ impl EchoAdapter {
 }
 
 #[async_trait]
-impl RuntimeAdapter<LocalFilesystem, InMemoryResourceGovernor> for EchoAdapter {
+impl RuntimeAdapter<DiskFilesystem, InMemoryResourceGovernor> for EchoAdapter {
     async fn dispatch_json(
         &self,
-        request: RuntimeAdapterRequest<'_, LocalFilesystem, InMemoryResourceGovernor>,
+        request: RuntimeAdapterRequest<'_, DiskFilesystem, InMemoryResourceGovernor>,
     ) -> Result<RuntimeAdapterResult, DispatchError> {
         adapter_result(
             self.runtime,
@@ -380,10 +380,10 @@ impl StaticAdapter {
 }
 
 #[async_trait]
-impl RuntimeAdapter<LocalFilesystem, InMemoryResourceGovernor> for StaticAdapter {
+impl RuntimeAdapter<DiskFilesystem, InMemoryResourceGovernor> for StaticAdapter {
     async fn dispatch_json(
         &self,
-        request: RuntimeAdapterRequest<'_, LocalFilesystem, InMemoryResourceGovernor>,
+        request: RuntimeAdapterRequest<'_, DiskFilesystem, InMemoryResourceGovernor>,
     ) -> Result<RuntimeAdapterResult, DispatchError> {
         adapter_result(
             self.runtime,
@@ -408,10 +408,10 @@ impl FailingRuntimeAdapter {
 }
 
 #[async_trait]
-impl RuntimeAdapter<LocalFilesystem, InMemoryResourceGovernor> for FailingRuntimeAdapter {
+impl RuntimeAdapter<DiskFilesystem, InMemoryResourceGovernor> for FailingRuntimeAdapter {
     async fn dispatch_json(
         &self,
-        _request: RuntimeAdapterRequest<'_, LocalFilesystem, InMemoryResourceGovernor>,
+        _request: RuntimeAdapterRequest<'_, DiskFilesystem, InMemoryResourceGovernor>,
     ) -> Result<RuntimeAdapterResult, DispatchError> {
         Err(dispatch_error_for_runtime(self.runtime, self.kind))
     }
@@ -463,11 +463,11 @@ fn dispatch_error_for_runtime(
     }
 }
 
-fn filesystem_with_echo_extensions() -> LocalFilesystem {
+fn filesystem_with_echo_extensions() -> DiskFilesystem {
     let storage = tempfile::tempdir().unwrap().keep();
     write_echo_extensions(&storage);
 
-    let mut fs = LocalFilesystem::new();
+    let mut fs = DiskFilesystem::new();
     fs.mount_local(
         VirtualPath::new("/system/extensions").unwrap(),
         HostPath::from_path_buf(storage),
@@ -476,7 +476,7 @@ fn filesystem_with_echo_extensions() -> LocalFilesystem {
     fs
 }
 
-async fn discover_legacy_fixture_registry(fs: &LocalFilesystem) -> ExtensionRegistry {
+async fn discover_legacy_fixture_registry(fs: &DiskFilesystem) -> ExtensionRegistry {
     ExtensionDiscovery::discover_with_manifest_contracts(
         fs,
         &VirtualPath::new("/system/extensions").unwrap(),

--- a/crates/ironclaw_dispatcher/tests/runtime_dispatcher_integration.rs
+++ b/crates/ironclaw_dispatcher/tests/runtime_dispatcher_integration.rs
@@ -246,10 +246,10 @@ struct RecordedAdapterRequest {
 }
 
 #[async_trait]
-impl RuntimeAdapter<LocalFilesystem, InMemoryResourceGovernor> for RecordingAdapter {
+impl RuntimeAdapter<DiskFilesystem, InMemoryResourceGovernor> for RecordingAdapter {
     async fn dispatch_json(
         &self,
-        request: RuntimeAdapterRequest<'_, LocalFilesystem, InMemoryResourceGovernor>,
+        request: RuntimeAdapterRequest<'_, DiskFilesystem, InMemoryResourceGovernor>,
     ) -> Result<RuntimeAdapterResult, DispatchError> {
         self.requests.lock().unwrap().push(RecordedAdapterRequest {
             provider: request.package.id.clone(),
@@ -332,9 +332,9 @@ fn parse_manifest(manifest: &str) -> ExtensionManifest {
     .unwrap()
 }
 
-fn mounted_empty_extension_root() -> LocalFilesystem {
+fn mounted_empty_extension_root() -> DiskFilesystem {
     let storage = tempfile::tempdir().unwrap().keep();
-    let mut fs = LocalFilesystem::new();
+    let mut fs = DiskFilesystem::new();
     fs.mount_local(
         VirtualPath::new("/system/extensions").unwrap(),
         HostPath::from_path_buf(storage),

--- a/crates/ironclaw_dispatcher/tests/vertical_slice_contract.rs
+++ b/crates/ironclaw_dispatcher/tests/vertical_slice_contract.rs
@@ -125,10 +125,10 @@ impl EchoAdapter {
 }
 
 #[async_trait]
-impl RuntimeAdapter<LocalFilesystem, InMemoryResourceGovernor> for EchoAdapter {
+impl RuntimeAdapter<DiskFilesystem, InMemoryResourceGovernor> for EchoAdapter {
     async fn dispatch_json(
         &self,
-        request: RuntimeAdapterRequest<'_, LocalFilesystem, InMemoryResourceGovernor>,
+        request: RuntimeAdapterRequest<'_, DiskFilesystem, InMemoryResourceGovernor>,
     ) -> Result<RuntimeAdapterResult, DispatchError> {
         let output = request.input;
         let usage = ResourceUsage::default()
@@ -177,7 +177,7 @@ fn dispatch_error_for_runtime(
     }
 }
 
-fn filesystem_with_echo_extensions() -> LocalFilesystem {
+fn filesystem_with_echo_extensions() -> DiskFilesystem {
     let storage = tempfile::tempdir().unwrap().keep();
     let wasm_root = storage.join("echo-wasm");
     std::fs::create_dir_all(&wasm_root).unwrap();
@@ -203,7 +203,7 @@ fn filesystem_with_echo_extensions() -> LocalFilesystem {
     )
     .unwrap();
 
-    let mut fs = LocalFilesystem::new();
+    let mut fs = DiskFilesystem::new();
     fs.mount_local(
         VirtualPath::new("/system/extensions").unwrap(),
         HostPath::from_path_buf(storage),
@@ -212,7 +212,7 @@ fn filesystem_with_echo_extensions() -> LocalFilesystem {
     fs
 }
 
-async fn discover_legacy_fixture_registry(fs: &LocalFilesystem) -> ExtensionRegistry {
+async fn discover_legacy_fixture_registry(fs: &DiskFilesystem) -> ExtensionRegistry {
     ExtensionDiscovery::discover_with_manifest_contracts(
         fs,
         &VirtualPath::new("/system/extensions").unwrap(),

--- a/crates/ironclaw_extensions/tests/extension_contract.rs
+++ b/crates/ironclaw_extensions/tests/extension_contract.rs
@@ -1,3 +1,4 @@
+// arch-exempt: large_file, mechanical LocalFilesystem->DiskFilesystem Bucket-2 rename (arch-simplification §4.4), no logic change, plan #6168
 use ironclaw_extensions::*;
 use ironclaw_filesystem::*;
 use ironclaw_host_api::*;
@@ -158,7 +159,7 @@ async fn discovery_reads_host_bundled_legacy_manifests_from_filesystem_virtual_r
     std::fs::create_dir_all(storage.path().join("echo")).unwrap();
     std::fs::write(storage.path().join("echo/manifest.toml"), WASM_MANIFEST).unwrap();
 
-    let mut fs = LocalFilesystem::new();
+    let mut fs = DiskFilesystem::new();
     fs.mount_local(
         VirtualPath::new("/system/extensions").unwrap(),
         HostPath::from_path_buf(storage.path().to_path_buf()),
@@ -197,7 +198,7 @@ async fn discovery_rejects_installed_local_privileged_manifest() {
     )
     .unwrap();
 
-    let mut fs = LocalFilesystem::new();
+    let mut fs = DiskFilesystem::new();
     fs.mount_local(
         VirtualPath::new("/system/extensions").unwrap(),
         HostPath::from_path_buf(storage.path().to_path_buf()),
@@ -257,7 +258,7 @@ async fn discovery_rejects_installed_legacy_top_level_capabilities() {
     std::fs::create_dir_all(storage.path().join("echo")).unwrap();
     std::fs::write(storage.path().join("echo/manifest.toml"), WASM_MANIFEST).unwrap();
 
-    let mut fs = LocalFilesystem::new();
+    let mut fs = DiskFilesystem::new();
     fs.mount_local(
         VirtualPath::new("/system/extensions").unwrap(),
         HostPath::from_path_buf(storage.path().to_path_buf()),
@@ -288,7 +289,7 @@ async fn discovery_validates_host_api_manifest_with_supplied_contracts() {
     )
     .unwrap();
 
-    let mut fs = LocalFilesystem::new();
+    let mut fs = DiskFilesystem::new();
     fs.mount_local(
         VirtualPath::new("/system/extensions").unwrap(),
         HostPath::from_path_buf(storage.path().to_path_buf()),
@@ -328,7 +329,7 @@ async fn discovery_registers_capability_provider_projected_capabilities() {
     )
     .unwrap();
 
-    let mut fs = LocalFilesystem::new();
+    let mut fs = DiskFilesystem::new();
     fs.mount_local(
         VirtualPath::new("/system/extensions").unwrap(),
         HostPath::from_path_buf(storage.path().to_path_buf()),
@@ -727,7 +728,7 @@ async fn discovery_validates_capability_manifest_with_supplied_host_port_catalog
     )
     .unwrap();
 
-    let mut fs = LocalFilesystem::new();
+    let mut fs = DiskFilesystem::new();
     fs.mount_local(
         VirtualPath::new("/system/extensions").unwrap(),
         HostPath::from_path_buf(storage.path().to_path_buf()),
@@ -767,7 +768,7 @@ async fn discovery_rejects_manifest_id_mismatch_with_directory() {
     )
     .unwrap();
 
-    let mut fs = LocalFilesystem::new();
+    let mut fs = DiskFilesystem::new();
     fs.mount_local(
         VirtualPath::new("/system/extensions").unwrap(),
         HostPath::from_path_buf(storage.path().to_path_buf()),

--- a/crates/ironclaw_filesystem/AGENTS.md
+++ b/crates/ironclaw_filesystem/AGENTS.md
@@ -18,7 +18,7 @@
 - Filesystem vocabulary in `types`: `BackendCapabilities`/`BackendId`/`BackendKind`/`Capability`/`TxnCapability`, `FileStat`/`DirEntry`/`FileType`/`ContentKind`, `StorageClass`, `IndexPolicy`/`IndexConflictReason`, `FilesystemError`/`FilesystemOperation`; supporting handles `StorageTxn`/`EventRecord` (`backend`).
 - Mount table + catalog: `CompositeRootFilesystem`, `MountDescriptor`, `PathPlacement` (`catalog`) — longest-prefix mount routing and inherent catalog inspection.
 - Invocation-scoped view `ScopedFilesystem` + `MountViewResolver` (`scoped`) — checks permission against `MountView` before any backend dispatch.
-- Backends, all implementing `RootFilesystem`: `LocalFilesystem`, `PostgresRootFilesystem`, `LibSqlRootFilesystem`, `InMemoryBackend`, `HsmBackend`; plus backend containment (symlink traversal, mount escape, raw-host-path prevention).
+- Backends, all implementing `RootFilesystem`: `DiskFilesystem`, `PostgresRootFilesystem`, `LibSqlRootFilesystem`, `InMemoryBackend`, `HsmBackend`; plus backend containment (symlink traversal, mount escape, raw-host-path prevention).
 - Crate-local public API, tests, and fixtures needed to prove that ownership.
 - Note: this supersedes the older "bytes mount; structured records stay typed" boundary (ADR `docs/reborn/2026-05-14-universal-fs-dispatch.md`). The legacy bytes-plane methods and `src/db.rs` are transitional and slated for removal — do not add new consumers.
 

--- a/crates/ironclaw_filesystem/CLAUDE.md
+++ b/crates/ironclaw_filesystem/CLAUDE.md
@@ -32,7 +32,7 @@ codified in `docs/reborn/2026-05-14-universal-fs-dispatch.md` (the new ADR).
 - `ScopedFilesystem` (`src/scoped.rs`) — the invocation-scoped view that
   higher-level stores accept in their constructor. Performs the permission
   check against `MountView` before any backend dispatch.
-- Backends: `LocalFilesystem`, `PostgresRootFilesystem`,
+- Backends: `DiskFilesystem`, `PostgresRootFilesystem`,
   `LibSqlRootFilesystem`, `InMemoryBackend`. All implement
   `RootFilesystem`.
 - Backend containment checks (symlink traversal, mount escape, raw-host
@@ -81,7 +81,7 @@ codified in `docs/reborn/2026-05-14-universal-fs-dispatch.md` (the new ADR).
    into a store. `cas_update` fails **closed** on a non-CAS backend
    (`CasUpdateError::CasUnsupported`) rather than falling back to a blind
    `CasExpectation::Any` overwrite; all production store mounts resolve to
-   CAS-capable db/in-memory backends (`LocalFilesystem` is byte-only and is
+   CAS-capable db/in-memory backends (`DiskFilesystem` is byte-only and is
    structurally unreachable from those mounts), so fail-closed is correct.
    See `docs/plans/2026-06-25-cas-migration.md`.
 

--- a/crates/ironclaw_filesystem/src/cas/tests.rs
+++ b/crates/ironclaw_filesystem/src/cas/tests.rs
@@ -948,7 +948,7 @@ async fn encode_failure_maps_to_apply_without_write() {
 /// time) whose `get` returns `Ok(None)` (absent → first write) and whose `put`
 /// gates on `entry.kind.is_some()`: a record-shaped entry is rejected with
 /// `FilesystemError::Unsupported { operation: WriteFile }`, while a byte-only
-/// entry (kind = None) would be accepted. This models `LocalFilesystem`'s check
+/// entry (kind = None) would be accepted. This models `DiskFilesystem`'s check
 /// at local.rs:189-208: `if entry.kind.is_some() || !entry.indexed.is_empty() {
 /// return Unsupported { WriteFile } }`.
 ///
@@ -993,7 +993,7 @@ impl RootFilesystem for KindGatedByteOnlyBackend {
             "first writes must use CasExpectation::Absent"
         );
         if entry.kind.is_some() {
-            // Record-shaped entries are rejected — mirrors `LocalFilesystem`'s
+            // Record-shaped entries are rejected — mirrors `DiskFilesystem`'s
             // `if entry.kind.is_some() || !entry.indexed.is_empty()` guard.
             Err(FilesystemError::Unsupported {
                 path: path.clone(),
@@ -1021,7 +1021,7 @@ async fn record_shaped_first_write_fails_closed_on_byte_only_backend() {
     // Regression for the byte-only first-write fail-closed gap.
     //
     // Store encoders now set `entry.kind = Some(RecordKind)` (record-shaped).
-    // `LocalFilesystem` rejects record-shaped entries with `Unsupported { WriteFile }`
+    // `DiskFilesystem` rejects record-shaped entries with `Unsupported { WriteFile }`
     // BEFORE the CAS check (local.rs:189-208: `if entry.kind.is_some() ||
     // !entry.indexed.is_empty() { return Unsupported { WriteFile } }`), even for
     // `CasExpectation::Absent`. This means `cas_update` with a record-shaped encode

--- a/crates/ironclaw_filesystem/src/lib.rs
+++ b/crates/ironclaw_filesystem/src/lib.rs
@@ -47,7 +47,7 @@ pub use in_memory::InMemoryBackend;
 pub use index::{Filter, IndexKey, IndexKind, IndexName, IndexSpec, IndexValue, Page};
 #[cfg(feature = "libsql")]
 pub use libsql::LibSqlRootFilesystem;
-pub use local::LocalFilesystem;
+pub use local::DiskFilesystem;
 #[cfg(feature = "postgres")]
 pub use postgres::PostgresRootFilesystem;
 pub use record::{

--- a/crates/ironclaw_filesystem/src/local.rs
+++ b/crates/ironclaw_filesystem/src/local.rs
@@ -15,9 +15,15 @@ use crate::{
 
 static LOCAL_WRITE_TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
-/// Local filesystem backend mounted into the virtual namespace.
+/// The on-disk `RootFilesystem` backend, mounted into the virtual namespace.
+///
+/// The name states the **storage medium** — disk, a peer of `InMemoryBackend`,
+/// `LibSqlRootFilesystem`, and `PostgresRootFilesystem` — not a deployment mode.
+/// Renamed from `LocalFilesystem` because `Local` read like a deployment tier
+/// while this is simply the disk backend a `DeploymentConfig` may select
+/// (arch-simplification §4.4 Bucket 2).
 #[derive(Debug, Default)]
-pub struct LocalFilesystem {
+pub struct DiskFilesystem {
     mounts: Vec<LocalMount>,
 }
 
@@ -27,7 +33,7 @@ struct LocalMount {
     host_root: PathBuf,
 }
 
-impl LocalFilesystem {
+impl DiskFilesystem {
     pub fn new() -> Self {
         Self::default()
     }
@@ -176,7 +182,7 @@ impl LocalFilesystem {
 }
 
 #[async_trait]
-impl RootFilesystem for LocalFilesystem {
+impl RootFilesystem for DiskFilesystem {
     /// Native `put` for the byte-only local filesystem. Opaque-file entries
     /// (`kind = None`, empty `indexed`) support `CasExpectation::Any` and
     /// `CasExpectation::Absent`; record-shaped entries, populated indexed
@@ -371,7 +377,7 @@ impl RootFilesystem for LocalFilesystem {
     }
 }
 
-impl LocalFilesystem {
+impl DiskFilesystem {
     async fn write_file_with_cas(
         &self,
         path: &VirtualPath,
@@ -582,7 +588,7 @@ mod tests {
     #[tracing_test::traced_test]
     async fn missing_local_paths_do_not_log_backend_error() {
         let storage = tempdir().unwrap();
-        let mut root = LocalFilesystem::new();
+        let mut root = DiskFilesystem::new();
         root.mount_local(
             VirtualPath::new("/projects").unwrap(),
             HostPath::from_path_buf(storage.path().to_path_buf()),

--- a/crates/ironclaw_filesystem/src/root.rs
+++ b/crates/ironclaw_filesystem/src/root.rs
@@ -53,7 +53,7 @@ pub trait RootFilesystem: Send + Sync {
     /// the unified surface must implement `put` natively. Byte-only backends
     /// can do this with a thin delegation to their own native `write_file`,
     /// gated on `kind = None`, empty `indexed`, and `CasExpectation::Any`;
-    /// see `LocalFilesystem::put` for the canonical pattern. We deliberately
+    /// see `DiskFilesystem::put` for the canonical pattern. We deliberately
     /// do **not** route the default `put` through `self.write_file`, because
     /// the default `write_file` routes through `self.put` — a backend that
     /// overrode neither would recurse to a stack overflow.
@@ -73,7 +73,7 @@ pub trait RootFilesystem: Send + Sync {
     /// other direction in the trait default. Byte-only backends implement
     /// `get` by wrapping their native `read_file` result in
     /// `Some(VersionedEntry { entry: Entry::bytes(body), version: 0 })`
-    /// directly. See `LocalFilesystem::get` for the canonical pattern.
+    /// directly. See `DiskFilesystem::get` for the canonical pattern.
     async fn get(&self, path: &VirtualPath) -> Result<Option<VersionedEntry>, FilesystemError> {
         unsupported(path, FilesystemOperation::ReadFile)
     }

--- a/crates/ironclaw_filesystem/src/types.rs
+++ b/crates/ironclaw_filesystem/src/types.rs
@@ -267,7 +267,7 @@ impl BackendId {
 /// Coarse class of backend implementation behind a virtual mount.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum BackendKind {
-    LocalFilesystem,
+    DiskFilesystem,
     DatabaseFilesystem,
     MemoryDocuments,
     ObjectStore,

--- a/crates/ironclaw_filesystem/tests/catalog_contract.rs
+++ b/crates/ironclaw_filesystem/tests/catalog_contract.rs
@@ -60,14 +60,14 @@ async fn composite_routes_filesystem_operations_to_matching_backend() {
     std::fs::write(memory_dir.path().join("MEMORY.md"), b"remember this").unwrap();
     std::fs::write(project_dir.path().join("README.md"), b"project readme").unwrap();
 
-    let mut memory_backend = LocalFilesystem::new();
+    let mut memory_backend = DiskFilesystem::new();
     memory_backend
         .mount_local(
             VirtualPath::new("/memory").unwrap(),
             HostPath::from_path_buf(memory_dir.path().to_path_buf()),
         )
         .unwrap();
-    let mut project_backend = LocalFilesystem::new();
+    let mut project_backend = DiskFilesystem::new();
     project_backend
         .mount_local(
             VirtualPath::new("/projects").unwrap(),
@@ -92,7 +92,7 @@ async fn composite_routes_filesystem_operations_to_matching_backend() {
         descriptor(
             "/projects",
             "project-files",
-            BackendKind::LocalFilesystem,
+            BackendKind::DiskFilesystem,
             StorageClass::FileContent,
             ContentKind::ProjectFile,
             IndexPolicy::NotIndexed,
@@ -169,7 +169,7 @@ async fn catalog_mounts_are_sorted_for_stable_diagnostics() {
         descriptor(
             "/projects",
             "project-files",
-            BackendKind::LocalFilesystem,
+            BackendKind::DiskFilesystem,
             StorageClass::FileContent,
             ContentKind::ProjectFile,
             IndexPolicy::NotIndexed,
@@ -399,9 +399,9 @@ async fn composite_append_batch_returns_mount_not_found() {
     );
 }
 
-fn empty_local_backend(virtual_root: &str) -> (LocalFilesystem, tempfile::TempDir) {
+fn empty_local_backend(virtual_root: &str) -> (DiskFilesystem, tempfile::TempDir) {
     let dir = tempdir().unwrap();
-    let mut backend = LocalFilesystem::new();
+    let mut backend = DiskFilesystem::new();
     backend
         .mount_local(
             VirtualPath::new(virtual_root).unwrap(),
@@ -441,7 +441,7 @@ fn descriptor(
         // IndexPolicy (catalog hint about how upstream services index path
         // content) is intentionally separate from `Capability::IndexFts` /
         // `Capability::IndexVector` (backend op support for `ensure_index`
-        // / `query` on indexed projections). Test mounts use a LocalFilesystem
+        // / `query` on indexed projections). Test mounts use a DiskFilesystem
         // which doesn't ship those record-plane ops, so the descriptor
         // doesn't claim them — IndexPolicy on the descriptor still drives
         // upstream behavior independently.

--- a/crates/ironclaw_filesystem/tests/filesystem_contract.rs
+++ b/crates/ironclaw_filesystem/tests/filesystem_contract.rs
@@ -14,7 +14,7 @@ async fn scoped_read_resolves_mount_view_and_reads_bytes() {
     )
     .unwrap();
 
-    let mut root = LocalFilesystem::new();
+    let mut root = DiskFilesystem::new();
     root.mount_local(
         VirtualPath::new("/projects").unwrap(),
         HostPath::from_path_buf(storage.path().to_path_buf()),
@@ -48,7 +48,7 @@ async fn bounded_read_returns_none_without_materializing_oversized_local_file() 
     std::fs::create_dir_all(storage.path().join("project1")).unwrap();
     std::fs::write(storage.path().join("project1/schema.json"), b"abcdef").unwrap();
 
-    let mut root = LocalFilesystem::new();
+    let mut root = DiskFilesystem::new();
     root.mount_local(
         VirtualPath::new("/projects").unwrap(),
         HostPath::from_path_buf(storage.path().to_path_buf()),
@@ -69,7 +69,7 @@ async fn local_put_absent_rejects_existing_file_without_overwrite() {
     let storage = tempdir().unwrap();
     std::fs::create_dir_all(storage.path().join("project1")).unwrap();
 
-    let mut root = LocalFilesystem::new();
+    let mut root = DiskFilesystem::new();
     root.mount_local(
         VirtualPath::new("/projects").unwrap(),
         HostPath::from_path_buf(storage.path().to_path_buf()),
@@ -105,7 +105,7 @@ async fn scoped_write_is_denied_on_read_only_mount() {
     let storage = tempdir().unwrap();
     std::fs::create_dir_all(storage.path().join("project1")).unwrap();
 
-    let mut root = LocalFilesystem::new();
+    let mut root = DiskFilesystem::new();
     root.mount_local(
         VirtualPath::new("/projects").unwrap(),
         HostPath::from_path_buf(storage.path().to_path_buf()),
@@ -277,7 +277,7 @@ async fn list_requires_list_permission_through_scoped_api() {
     let storage = tempdir().unwrap();
     std::fs::create_dir_all(storage.path().join("project1/src")).unwrap();
 
-    let mut root = LocalFilesystem::new();
+    let mut root = DiskFilesystem::new();
     root.mount_local(
         VirtualPath::new("/projects").unwrap(),
         HostPath::from_path_buf(storage.path().to_path_buf()),
@@ -325,7 +325,7 @@ async fn longest_backend_virtual_mount_wins() {
     std::fs::write(broad.path().join("project1/value.txt"), b"broad").unwrap();
     std::fs::write(narrow.path().join("value.txt"), b"narrow").unwrap();
 
-    let mut root = LocalFilesystem::new();
+    let mut root = DiskFilesystem::new();
     root.mount_local(
         VirtualPath::new("/projects").unwrap(),
         HostPath::from_path_buf(broad.path().to_path_buf()),
@@ -348,7 +348,7 @@ async fn longest_backend_virtual_mount_wins() {
 #[tokio::test]
 async fn unknown_scoped_alias_fails_closed_through_filesystem_api() {
     let storage = tempdir().unwrap();
-    let mut root = LocalFilesystem::new();
+    let mut root = DiskFilesystem::new();
     root.mount_local(
         VirtualPath::new("/projects").unwrap(),
         HostPath::from_path_buf(storage.path().to_path_buf()),
@@ -372,7 +372,7 @@ async fn unknown_scoped_alias_fails_closed_through_filesystem_api() {
 async fn artifact_write_is_confined_to_approved_virtual_mount() {
     let artifacts = tempdir().unwrap();
 
-    let mut root = LocalFilesystem::new();
+    let mut root = DiskFilesystem::new();
     root.mount_local(
         VirtualPath::new("/engine/tmp/invocations/inv1/artifacts").unwrap(),
         HostPath::from_path_buf(artifacts.path().to_path_buf()),
@@ -407,7 +407,7 @@ async fn artifact_write_is_confined_to_approved_virtual_mount() {
 #[tokio::test]
 async fn display_errors_do_not_leak_raw_host_paths() {
     let storage = tempdir().unwrap();
-    let mut root = LocalFilesystem::new();
+    let mut root = DiskFilesystem::new();
     root.mount_local(
         VirtualPath::new("/projects").unwrap(),
         HostPath::from_path_buf(storage.path().to_path_buf()),
@@ -440,7 +440,7 @@ async fn local_backend_denies_symlink_escape() {
     )
     .unwrap();
 
-    let mut root = LocalFilesystem::new();
+    let mut root = DiskFilesystem::new();
     root.mount_local(
         VirtualPath::new("/projects").unwrap(),
         HostPath::from_path_buf(storage.path().to_path_buf()),
@@ -612,7 +612,7 @@ async fn workspace_write_creates_parent_directories() {
 #[tokio::test]
 async fn duplicate_backend_mount_is_rejected() {
     let storage = tempdir().unwrap();
-    let mut root = LocalFilesystem::new();
+    let mut root = DiskFilesystem::new();
     root.mount_local(
         VirtualPath::new("/projects").unwrap(),
         HostPath::from_path_buf(storage.path().to_path_buf()),
@@ -633,7 +633,7 @@ async fn duplicate_backend_mount_is_rejected() {
 async fn nonexistent_backend_mount_root_fails_without_leaking_host_path() {
     let storage = tempdir().unwrap();
     let missing = storage.path().join("missing-root");
-    let mut root = LocalFilesystem::new();
+    let mut root = DiskFilesystem::new();
 
     let err = root
         .mount_local(
@@ -766,8 +766,8 @@ async fn local_backend_denies_write_through_symlinked_parent_escape() {
     assert!(!outside.path().join("new.txt").exists());
 }
 
-fn local_root_with_projects_mount(path: &std::path::Path) -> LocalFilesystem {
-    let mut root = LocalFilesystem::new();
+fn local_root_with_projects_mount(path: &std::path::Path) -> DiskFilesystem {
+    let mut root = DiskFilesystem::new();
     root.mount_local(
         VirtualPath::new("/projects").unwrap(),
         HostPath::from_path_buf(path.to_path_buf()),
@@ -779,7 +779,7 @@ fn local_root_with_projects_mount(path: &std::path::Path) -> LocalFilesystem {
 fn scoped_project_fs(
     path: &std::path::Path,
     permissions: MountPermissions,
-) -> ScopedFilesystem<LocalFilesystem> {
+) -> ScopedFilesystem<DiskFilesystem> {
     ScopedFilesystem::with_fixed_view(
         Arc::new(local_root_with_projects_mount(path)),
         MountView::new(vec![MountGrant::new(

--- a/crates/ironclaw_first_party_extensions/src/coding/mod.rs
+++ b/crates/ironclaw_first_party_extensions/src/coding/mod.rs
@@ -266,7 +266,7 @@ fn bound_safe_summary(summary: String) -> String {
 mod tests {
     use std::sync::Arc;
 
-    use ironclaw_filesystem::{LocalFilesystem, RootFilesystem};
+    use ironclaw_filesystem::{DiskFilesystem, RootFilesystem};
     use ironclaw_host_api::{
         CapabilityId, HostPath, InvocationId, MountAlias, MountGrant, MountPermissions, MountView,
         ResourceScope, RuntimeDispatchErrorKind, UserId, VirtualPath,
@@ -306,7 +306,7 @@ mod tests {
     #[tokio::test]
     async fn coding_file_tools_treat_bare_workspace_prefix_as_scoped_alias() {
         let temp_root = tempfile::TempDir::new().expect("temp root");
-        let mut local_filesystem = LocalFilesystem::new();
+        let mut local_filesystem = DiskFilesystem::new();
         local_filesystem
             .mount_local(
                 VirtualPath::new("/projects").expect("virtual path"),
@@ -471,7 +471,7 @@ mod tests {
             let temp_root = tempfile::TempDir::new().expect("temp root");
             let workspace_dir = temp_root.path().join("workspace");
             std::fs::create_dir_all(&workspace_dir).expect("workspace dir");
-            let mut local_filesystem = LocalFilesystem::new();
+            let mut local_filesystem = DiskFilesystem::new();
             local_filesystem
                 .mount_local(
                     VirtualPath::new("/projects").expect("virtual path"),
@@ -671,7 +671,7 @@ mod tests {
         // raw-path summary would silently degrade to the generic category
         // sentence at the runtime boundary.
         let temp_root = tempfile::TempDir::new().expect("temp root");
-        let mut local_filesystem = LocalFilesystem::new();
+        let mut local_filesystem = DiskFilesystem::new();
         local_filesystem
             .mount_local(
                 VirtualPath::new("/projects").expect("virtual path"),
@@ -732,7 +732,7 @@ mod tests {
         // detail channel.
         let temp_root = tempfile::TempDir::new().expect("temp root");
         std::fs::create_dir_all(temp_root.path().join("workspace")).expect("workspace dir");
-        let mut local_filesystem = LocalFilesystem::new();
+        let mut local_filesystem = DiskFilesystem::new();
         local_filesystem
             .mount_local(
                 VirtualPath::new("/projects").expect("virtual path"),

--- a/crates/ironclaw_host_runtime/src/first_party_tools/trace_commons.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/trace_commons.rs
@@ -1329,7 +1329,7 @@ mod tests {
 
     use async_trait::async_trait;
     use chrono::{DateTime, Utc};
-    use ironclaw_filesystem::LocalFilesystem;
+    use ironclaw_filesystem::DiskFilesystem;
     use ironclaw_host_api::{CapabilityId, ResourceEstimate, ResourceScope};
     use ironclaw_reborn_traces::contribution::{
         StandingTraceContributionPolicy, TraceCreditReport,
@@ -1366,7 +1366,7 @@ mod tests {
             estimate: ResourceEstimate::default(),
             mounts: None,
             services: InvocationServices {
-                filesystem: Arc::new(LocalFilesystem::new()),
+                filesystem: Arc::new(DiskFilesystem::new()),
                 runtime_http_egress: None,
                 tool_call_http_egress: None,
                 runtime_secret_material_stager: None,

--- a/crates/ironclaw_host_runtime/src/invocation_services/tests.rs
+++ b/crates/ironclaw_host_runtime/src/invocation_services/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use async_trait::async_trait;
 use ironclaw_filesystem::{
-    FilesystemError, FilesystemOperation, InMemoryBackend, LocalFilesystem, RootFilesystem,
+    DiskFilesystem, FilesystemError, FilesystemOperation, InMemoryBackend, RootFilesystem,
 };
 use ironclaw_host_api::{
     CapabilityId, MountAlias, MountGrant, MountPermissions, ResourceScope, VirtualPath,
@@ -122,7 +122,7 @@ async fn local_resolver_routes_post_edit_check_to_the_deployment_isolated_proces
     // tenant's sandbox, never on the provider host), and nothing when no backend
     // can run it in isolation.
     let resolver = LocalInvocationServicesResolver::new(
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         None,
         Arc::new(NamedProcessPort("local-host")),
         None,
@@ -796,7 +796,7 @@ fn local_resolver_rejects_required_network_when_egress_service_is_absent() {
 #[test]
 fn local_resolver_accepts_brokered_required_network_with_egress_service() {
     let resolver = LocalInvocationServicesResolver::new(
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Some(Arc::new(NoopRuntimeHttpEgress)),
         Arc::new(NoopProcessPort),
         None,
@@ -823,7 +823,7 @@ fn local_resolver_accepts_brokered_required_network_with_egress_service() {
 #[test]
 fn local_resolver_accepts_hosted_brokered_required_network() {
     let resolver = LocalInvocationServicesResolver::new(
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Some(Arc::new(NoopRuntimeHttpEgress)),
         Arc::new(NoopProcessPort),
         None,
@@ -852,7 +852,7 @@ fn local_resolver_accepts_hosted_brokered_required_network() {
 #[test]
 fn local_resolver_accepts_hosted_and_enterprise_allowlist_required_network() {
     let resolver = LocalInvocationServicesResolver::new(
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Some(Arc::new(NoopRuntimeHttpEgress)),
         Arc::new(NoopProcessPort),
         None,
@@ -889,7 +889,7 @@ fn local_resolver_accepts_hosted_and_enterprise_allowlist_required_network() {
 #[test]
 fn local_resolver_rejects_hosted_direct_required_network() {
     let resolver = LocalInvocationServicesResolver::new(
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Some(Arc::new(NoopRuntimeHttpEgress)),
         Arc::new(NoopProcessPort),
         None,
@@ -924,7 +924,7 @@ fn local_resolver_rejects_hosted_direct_required_network() {
 #[test]
 fn local_resolver_accepts_direct_required_network_with_egress_service() {
     let resolver = LocalInvocationServicesResolver::new(
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Some(Arc::new(NoopRuntimeHttpEgress)),
         Arc::new(NoopProcessPort),
         None,
@@ -951,7 +951,7 @@ fn local_resolver_accepts_direct_required_network_with_egress_service() {
 #[test]
 fn local_resolver_allows_raw_diagnostics_only_for_local_dev_and_yolo() {
     let resolver = LocalInvocationServicesResolver::new(
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Some(Arc::new(NoopRuntimeHttpEgress)),
         Arc::new(NoopProcessPort),
         None,
@@ -998,7 +998,7 @@ fn local_resolver_allows_raw_diagnostics_only_for_local_dev_and_yolo() {
 #[test]
 fn local_resolver_hides_runtime_http_egress_when_network_is_not_required() {
     let resolver = LocalInvocationServicesResolver::new(
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Some(Arc::new(NoopRuntimeHttpEgress)),
         Arc::new(NoopProcessPort),
         None,
@@ -1025,7 +1025,7 @@ fn local_resolver_hides_runtime_http_egress_when_network_is_not_required() {
 #[test]
 fn local_resolver_hides_secret_store_when_secret_is_not_required() {
     let resolver = LocalInvocationServicesResolver::new(
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         None,
         Arc::new(NoopProcessPort),
         Some(Arc::new(InMemorySecretStore::new())),
@@ -1078,7 +1078,7 @@ fn local_resolver_rejects_required_secret_when_secret_store_is_absent() {
 #[test]
 fn local_resolver_accepts_brokered_required_secret_with_secret_store() {
     let resolver = LocalInvocationServicesResolver::new(
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         None,
         Arc::new(NoopProcessPort),
         Some(Arc::new(InMemorySecretStore::new())),
@@ -1106,7 +1106,7 @@ fn local_resolver_accepts_brokered_required_secret_with_secret_store() {
 #[test]
 fn local_resolver_accepts_tenant_and_org_broker_required_secrets() {
     let resolver = LocalInvocationServicesResolver::new(
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         None,
         Arc::new(NoopProcessPort),
         Some(Arc::new(InMemorySecretStore::new())),
@@ -1149,7 +1149,7 @@ fn local_resolver_accepts_tenant_and_org_broker_required_secrets() {
 #[test]
 fn local_resolver_rejects_hosted_inherited_env_secret() {
     let resolver = LocalInvocationServicesResolver::new(
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         None,
         Arc::new(NoopProcessPort),
         Some(Arc::new(InMemorySecretStore::new())),
@@ -1185,7 +1185,7 @@ fn local_resolver_rejects_hosted_inherited_env_secret() {
 #[test]
 fn local_resolver_accepts_required_secret_when_secret_store_is_available() {
     let resolver = LocalInvocationServicesResolver::new(
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         None,
         Arc::new(NoopProcessPort),
         Some(Arc::new(InMemorySecretStore::new())),
@@ -1225,7 +1225,7 @@ fn first_party_tools_do_not_select_process_backends() {
 
 fn resolver_without_http() -> LocalInvocationServicesResolver {
     LocalInvocationServicesResolver::new(
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         None,
         Arc::new(NoopProcessPort),
         None,

--- a/crates/ironclaw_host_runtime/src/services.rs
+++ b/crates/ironclaw_host_runtime/src/services.rs
@@ -27,7 +27,7 @@ use ironclaw_extensions::{ExtensionRegistry, ExtensionRuntime, SharedExtensionRe
 use ironclaw_filesystem::LibSqlRootFilesystem;
 #[cfg(feature = "postgres")]
 use ironclaw_filesystem::PostgresRootFilesystem;
-use ironclaw_filesystem::{LocalFilesystem, RootFilesystem, ScopedFilesystem};
+use ironclaw_filesystem::{DiskFilesystem, RootFilesystem, ScopedFilesystem};
 use ironclaw_host_api::{
     CapabilityDispatcher, CapabilityId, DispatchError, ResourceReservationId, ResourceScope,
     ResourceUsage, RuntimeDispatchErrorKind, RuntimeHttpEgress, RuntimeKind, SecretHandle,

--- a/crates/ironclaw_host_runtime/src/services/production_wiring.rs
+++ b/crates/ironclaw_host_runtime/src/services/production_wiring.rs
@@ -9,10 +9,10 @@ use ironclaw_processes::{FilesystemProcessResultStore, FilesystemProcessStore};
 use ironclaw_run_state::{FilesystemApprovalRequestStore, FilesystemRunStateStore};
 
 use super::{
-    DurableAuditSink, DurableEventSink, EmptyWasmRuntimeCredentials, HostProcessPort,
-    InMemoryAuditSink, InMemoryCredentialBroker, InMemoryDurableAuditLog, InMemoryDurableEventLog,
-    InMemoryEventSink, InMemoryResourceGovernor, InMemorySecretStore, InMemoryTurnStateStore,
-    LocalFilesystem, NoopTurnRunWakeNotifier, RebornEventStoreError, RuntimeKind,
+    DiskFilesystem, DurableAuditSink, DurableEventSink, EmptyWasmRuntimeCredentials,
+    HostProcessPort, InMemoryAuditSink, InMemoryCredentialBroker, InMemoryDurableAuditLog,
+    InMemoryDurableEventLog, InMemoryEventSink, InMemoryResourceGovernor, InMemorySecretStore,
+    InMemoryTurnStateStore, NoopTurnRunWakeNotifier, RebornEventStoreError, RuntimeKind,
 };
 
 #[derive(Debug, Error)]
@@ -290,7 +290,7 @@ pub(super) fn component_name(component: Option<ProductionComponentType>) -> Opti
 fn classify_component_type<T: ?Sized + 'static>() -> ProductionImplementationReadiness {
     let type_id = TypeId::of::<T>();
     match () {
-        () if type_id == TypeId::of::<LocalFilesystem>()
+        () if type_id == TypeId::of::<DiskFilesystem>()
             || type_id == TypeId::of::<InMemoryResourceGovernor>()
             // The process lifecycle/result stores no longer have bespoke
             // in-memory implementations; "in-memory" is the `InMemoryBackend`

--- a/crates/ironclaw_host_runtime/src/services/tests.rs
+++ b/crates/ironclaw_host_runtime/src/services/tests.rs
@@ -13,7 +13,7 @@ use ironclaw_capabilities::{
     CapabilityObligationRequest,
 };
 use ironclaw_extensions::{ExtensionManifest, ExtensionPackage, ExtensionRegistry, ManifestSource};
-use ironclaw_filesystem::{InMemoryBackend, LocalFilesystem};
+use ironclaw_filesystem::{DiskFilesystem, InMemoryBackend};
 use ironclaw_host_api::{
     AgentId, CapabilityDescriptor, CapabilityDispatchResult, CapabilityId, CapabilitySet,
     CorrelationId, DispatchError, EffectKind, ExecutionContext, ExtensionId, HostPortCatalog,
@@ -675,13 +675,13 @@ async fn service_guard_releases_reservation_on_planner_denial() {
     let adapter = ServiceResolvedRuntimeAdapter::new(
         Arc::clone(&inner),
         Arc::new(LocalInvocationServicesResolver::new(
-            Arc::new(LocalFilesystem::new()),
+            Arc::new(DiskFilesystem::new()),
             None,
             Arc::new(HostProcessPort::new()),
             None,
         )),
     );
-    let filesystem = LocalFilesystem::new();
+    let filesystem = DiskFilesystem::new();
     let governor = InMemoryResourceGovernor::new();
     let scope = sample_scope();
     let estimate = ResourceEstimate::default().set_process_count(1);
@@ -737,13 +737,13 @@ async fn service_guard_rejects_resolution_before_wasm_dispatch() {
     let adapter = ServiceResolvedRuntimeAdapter::new(
         Arc::clone(&inner),
         Arc::new(LocalInvocationServicesResolver::new(
-            Arc::new(LocalFilesystem::new()),
+            Arc::new(DiskFilesystem::new()),
             None,
             Arc::new(HostProcessPort::new()),
             None,
         )),
     );
-    let filesystem = LocalFilesystem::new();
+    let filesystem = DiskFilesystem::new();
     let governor = InMemoryResourceGovernor::new();
     let scope = sample_scope();
     let estimate = ResourceEstimate::default();
@@ -790,13 +790,13 @@ async fn service_guard_releases_reservation_on_invocation_service_resolution_den
     let adapter = ServiceResolvedRuntimeAdapter::new(
         Arc::clone(&inner),
         Arc::new(LocalInvocationServicesResolver::new(
-            Arc::new(LocalFilesystem::new()),
+            Arc::new(DiskFilesystem::new()),
             None,
             Arc::new(HostProcessPort::new()),
             None,
         )),
     );
-    let filesystem = LocalFilesystem::new();
+    let filesystem = DiskFilesystem::new();
     let governor = InMemoryResourceGovernor::new();
     let scope = sample_scope();
     let estimate = ResourceEstimate::default().set_network_egress_bytes(1);
@@ -856,13 +856,13 @@ async fn service_guard_rejects_required_secret_without_secret_store_before_dispa
     let adapter = ServiceResolvedRuntimeAdapter::new(
         Arc::clone(&inner),
         Arc::new(LocalInvocationServicesResolver::new(
-            Arc::new(LocalFilesystem::new()),
+            Arc::new(DiskFilesystem::new()),
             None,
             Arc::new(HostProcessPort::new()),
             None,
         )),
     );
-    let filesystem = LocalFilesystem::new();
+    let filesystem = DiskFilesystem::new();
     let governor = InMemoryResourceGovernor::new();
     let scope = sample_scope();
     let estimate = ResourceEstimate::default();
@@ -913,13 +913,13 @@ async fn first_party_adapter_releases_reservation_when_invocation_service_resolu
     let adapter = FirstPartyRuntimeAdapter::from_registry(
         registry,
         Arc::new(LocalInvocationServicesResolver::new(
-            Arc::new(LocalFilesystem::new()),
+            Arc::new(DiskFilesystem::new()),
             None,
             Arc::new(HostProcessPort::new()),
             None,
         )),
     );
-    let filesystem = LocalFilesystem::new();
+    let filesystem = DiskFilesystem::new();
     let governor = InMemoryResourceGovernor::new();
     let scope = sample_scope();
     let tenant_account = ResourceAccount::tenant(scope.tenant_id.clone());
@@ -1044,13 +1044,13 @@ async fn first_party_adapter_releases_reservation_when_planner_denies() {
     let adapter = FirstPartyRuntimeAdapter::from_registry(
         registry,
         Arc::new(LocalInvocationServicesResolver::new(
-            Arc::new(LocalFilesystem::new()),
+            Arc::new(DiskFilesystem::new()),
             None,
             Arc::new(HostProcessPort::new()),
             None,
         )),
     );
-    let filesystem = LocalFilesystem::new();
+    let filesystem = DiskFilesystem::new();
     let governor = InMemoryResourceGovernor::new();
     let scope = sample_scope();
     let tenant_account = ResourceAccount::tenant(scope.tenant_id.clone());
@@ -1102,14 +1102,14 @@ async fn first_party_adapter_releases_reservation_when_planner_denies() {
 }
 
 fn test_services() -> HostRuntimeServices<
-    LocalFilesystem,
+    DiskFilesystem,
     InMemoryResourceGovernor,
     FilesystemProcessStore<InMemoryBackend>,
     FilesystemProcessResultStore<InMemoryBackend>,
 > {
     HostRuntimeServices::new(
         Arc::new(ExtensionRegistry::new()),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -1215,13 +1215,13 @@ async fn assert_first_party_denies_before_handler(
     let adapter = FirstPartyRuntimeAdapter::from_registry(
         registry,
         Arc::new(LocalInvocationServicesResolver::new(
-            Arc::new(LocalFilesystem::new()),
+            Arc::new(DiskFilesystem::new()),
             None,
             Arc::new(HostProcessPort::new()),
             Some(Arc::new(InMemorySecretStore::new())),
         )),
     );
-    let filesystem = LocalFilesystem::new();
+    let filesystem = DiskFilesystem::new();
     let governor = InMemoryResourceGovernor::new();
     let package = test_package(WASM_MANIFEST, "test-wasm");
 
@@ -1264,10 +1264,10 @@ impl RecordingRuntimeAdapter {
 }
 
 #[async_trait]
-impl RuntimeAdapter<LocalFilesystem, InMemoryResourceGovernor> for RecordingRuntimeAdapter {
+impl RuntimeAdapter<DiskFilesystem, InMemoryResourceGovernor> for RecordingRuntimeAdapter {
     async fn dispatch_json(
         &self,
-        request: RuntimeAdapterRequest<'_, LocalFilesystem, InMemoryResourceGovernor>,
+        request: RuntimeAdapterRequest<'_, DiskFilesystem, InMemoryResourceGovernor>,
     ) -> Result<RuntimeAdapterResult, DispatchError> {
         *self.calls.lock().unwrap() += 1;
         let usage = ResourceUsage::default();

--- a/crates/ironclaw_host_runtime/src/services/tests/first_party_runtime_adapter.rs
+++ b/crates/ironclaw_host_runtime/src/services/tests/first_party_runtime_adapter.rs
@@ -22,13 +22,13 @@ async fn first_party_handler_receives_authenticated_actor_distinct_from_subject_
     let adapter = FirstPartyRuntimeAdapter::from_registry(
         registry,
         Arc::new(LocalInvocationServicesResolver::new(
-            Arc::new(LocalFilesystem::new()),
+            Arc::new(DiskFilesystem::new()),
             None,
             Arc::new(HostProcessPort::new()),
             None,
         )),
     );
-    let filesystem = LocalFilesystem::new();
+    let filesystem = DiskFilesystem::new();
     let governor = InMemoryResourceGovernor::new();
     let mut scope = sample_scope();
     scope.user_id = UserId::new("shared-subject").expect("valid subject user id");
@@ -104,13 +104,13 @@ async fn first_party_adapter_maps_handler_auth_required_to_dispatch_auth_require
     let adapter = FirstPartyRuntimeAdapter::from_registry(
         registry,
         Arc::new(LocalInvocationServicesResolver::new(
-            Arc::new(LocalFilesystem::new()),
+            Arc::new(DiskFilesystem::new()),
             None,
             Arc::new(HostProcessPort::new()),
             None,
         )),
     );
-    let filesystem = LocalFilesystem::new();
+    let filesystem = DiskFilesystem::new();
     let governor = InMemoryResourceGovernor::new();
     let scope = sample_scope();
     let package = test_package(WASM_MANIFEST, "test-wasm");
@@ -167,13 +167,13 @@ async fn first_party_adapter_releases_reservation_when_handler_returns_auth_requ
     let adapter = FirstPartyRuntimeAdapter::from_registry(
         registry,
         Arc::new(LocalInvocationServicesResolver::new(
-            Arc::new(LocalFilesystem::new()),
+            Arc::new(DiskFilesystem::new()),
             None,
             Arc::new(HostProcessPort::new()),
             None,
         )),
     );
-    let filesystem = LocalFilesystem::new();
+    let filesystem = DiskFilesystem::new();
     let governor = InMemoryResourceGovernor::new();
     let scope = sample_scope();
     let tenant_account = ResourceAccount::tenant(scope.tenant_id.clone());
@@ -224,13 +224,13 @@ async fn first_party_adapter_forwards_required_secrets_from_auth_required_handle
     let adapter = FirstPartyRuntimeAdapter::from_registry(
         registry,
         Arc::new(LocalInvocationServicesResolver::new(
-            Arc::new(LocalFilesystem::new()),
+            Arc::new(DiskFilesystem::new()),
             None,
             Arc::new(HostProcessPort::new()),
             None,
         )),
     );
-    let filesystem = LocalFilesystem::new();
+    let filesystem = DiskFilesystem::new();
     let governor = InMemoryResourceGovernor::new();
     let scope = sample_scope();
     let package = test_package(WASM_MANIFEST, "test-wasm");
@@ -289,13 +289,13 @@ async fn first_party_adapter_forwards_credential_requirements_from_auth_required
     let adapter = FirstPartyRuntimeAdapter::from_registry(
         registry,
         Arc::new(LocalInvocationServicesResolver::new(
-            Arc::new(LocalFilesystem::new()),
+            Arc::new(DiskFilesystem::new()),
             None,
             Arc::new(HostProcessPort::new()),
             None,
         )),
     );
-    let filesystem = LocalFilesystem::new();
+    let filesystem = DiskFilesystem::new();
     let governor = InMemoryResourceGovernor::new();
     let scope = sample_scope();
     let package = test_package(WASM_MANIFEST, "test-wasm");
@@ -345,13 +345,13 @@ async fn first_party_adapter_maps_panicking_handler_to_backend() {
     let adapter = FirstPartyRuntimeAdapter::from_registry(
         registry,
         Arc::new(LocalInvocationServicesResolver::new(
-            Arc::new(LocalFilesystem::new()),
+            Arc::new(DiskFilesystem::new()),
             None,
             Arc::new(HostProcessPort::new()),
             None,
         )),
     );
-    let filesystem = LocalFilesystem::new();
+    let filesystem = DiskFilesystem::new();
     let governor = InMemoryResourceGovernor::new();
     let scope = sample_scope();
     let tenant_account = ResourceAccount::tenant(scope.tenant_id.clone());
@@ -532,13 +532,13 @@ async fn first_party_adapter_releases_reservation_when_reconcile_fails_after_suc
     let adapter = FirstPartyRuntimeAdapter::from_registry(
         registry,
         Arc::new(LocalInvocationServicesResolver::new(
-            Arc::new(LocalFilesystem::new()),
+            Arc::new(DiskFilesystem::new()),
             None,
             Arc::new(HostProcessPort::new()),
             None,
         )),
     );
-    let filesystem = LocalFilesystem::new();
+    let filesystem = DiskFilesystem::new();
     let governor = ReconcileFailingGovernor::new();
     let scope = sample_scope();
     let tenant_account = ResourceAccount::tenant(scope.tenant_id.clone());
@@ -632,13 +632,13 @@ async fn first_party_adapter_releases_reservation_when_dispatch_future_is_cancel
     let adapter = FirstPartyRuntimeAdapter::from_registry(
         registry,
         Arc::new(LocalInvocationServicesResolver::new(
-            Arc::new(LocalFilesystem::new()),
+            Arc::new(DiskFilesystem::new()),
             None,
             Arc::new(HostProcessPort::new()),
             None,
         )),
     );
-    let filesystem = LocalFilesystem::new();
+    let filesystem = DiskFilesystem::new();
     let governor = InMemoryResourceGovernor::new();
     let scope = sample_scope();
     let tenant_account = ResourceAccount::tenant(scope.tenant_id.clone());
@@ -746,13 +746,13 @@ async fn first_party_adapter_preserves_handler_error_when_account_failed_reconci
     let adapter = FirstPartyRuntimeAdapter::from_registry(
         registry,
         Arc::new(LocalInvocationServicesResolver::new(
-            Arc::new(LocalFilesystem::new()),
+            Arc::new(DiskFilesystem::new()),
             None,
             Arc::new(HostProcessPort::new()),
             None,
         )),
     );
-    let filesystem = LocalFilesystem::new();
+    let filesystem = DiskFilesystem::new();
     let governor = ReconcileFailingGovernor::new();
     let scope = sample_scope();
     let tenant_account = ResourceAccount::tenant(scope.tenant_id.clone());

--- a/crates/ironclaw_host_runtime/src/services/tests/mcp_runtime_adapter.rs
+++ b/crates/ironclaw_host_runtime/src/services/tests/mcp_runtime_adapter.rs
@@ -24,7 +24,7 @@ async fn mcp_adapter_maps_executor_auth_required_to_dispatch_auth_required() {
         requirement: requirement.clone(),
     }));
     let descriptor = test_descriptor(RuntimeKind::Mcp, Vec::new());
-    let filesystem = LocalFilesystem::new();
+    let filesystem = DiskFilesystem::new();
     let governor = InMemoryResourceGovernor::new();
     let package = test_package(MCP_MANIFEST, "test");
     let policy = policy_with(

--- a/crates/ironclaw_host_runtime/tests/extension_v2_lifecycle_e2e.rs
+++ b/crates/ironclaw_host_runtime/tests/extension_v2_lifecycle_e2e.rs
@@ -12,7 +12,7 @@ use ironclaw_extensions::{
     CapabilityVisibility, ExtensionError, ExtensionLifecycleService, ExtensionManifest,
     ExtensionPackage, ExtensionRegistry, ExtensionRuntime, ManifestSource, ManifestV2Error,
 };
-use ironclaw_filesystem::LocalFilesystem;
+use ironclaw_filesystem::DiskFilesystem;
 use ironclaw_host_api::{
     CapabilityId, EffectKind, ExtensionId, HostPath, MountView, NetworkScheme,
     NetworkTargetPattern, PermissionMode, ReservationStatus, ResourceEstimate,
@@ -470,10 +470,10 @@ struct RecordedAdapterRequest {
 }
 
 #[async_trait]
-impl RuntimeAdapter<LocalFilesystem, InMemoryResourceGovernor> for RecordingAdapter {
+impl RuntimeAdapter<DiskFilesystem, InMemoryResourceGovernor> for RecordingAdapter {
     async fn dispatch_json(
         &self,
-        request: RuntimeAdapterRequest<'_, LocalFilesystem, InMemoryResourceGovernor>,
+        request: RuntimeAdapterRequest<'_, DiskFilesystem, InMemoryResourceGovernor>,
     ) -> Result<RuntimeAdapterResult, DispatchError> {
         self.requests.lock().unwrap().push(RecordedAdapterRequest {
             provider: request.package.id.clone(),
@@ -540,7 +540,7 @@ fn dispatch_error_for_runtime(
     }
 }
 
-fn mounted_extension_fs(id: &str, manifest: &str) -> (tempfile::TempDir, LocalFilesystem) {
+fn mounted_extension_fs(id: &str, manifest: &str) -> (tempfile::TempDir, DiskFilesystem) {
     let storage = tempdir().unwrap();
     let extension_root = storage.path().join(id);
     std::fs::create_dir_all(extension_root.join("schemas/script")).unwrap();
@@ -562,7 +562,7 @@ fn mounted_extension_fs(id: &str, manifest: &str) -> (tempfile::TempDir, LocalFi
     )
     .unwrap();
 
-    let mut fs = LocalFilesystem::new();
+    let mut fs = DiskFilesystem::new();
     fs.mount_local(
         VirtualPath::new("/system/extensions").unwrap(),
         HostPath::from_path_buf(storage.path().to_path_buf()),
@@ -571,7 +571,7 @@ fn mounted_extension_fs(id: &str, manifest: &str) -> (tempfile::TempDir, LocalFi
     (storage, fs)
 }
 
-fn mounted_github_package_fs() -> (tempfile::TempDir, LocalFilesystem) {
+fn mounted_github_package_fs() -> (tempfile::TempDir, DiskFilesystem) {
     let storage = tempdir().unwrap();
     let source_root = github_first_party_asset_root();
     let package_root = storage.path().join("github");
@@ -586,7 +586,7 @@ fn mounted_github_package_fs() -> (tempfile::TempDir, LocalFilesystem) {
         &package_root.join("prompts/github"),
     );
 
-    let mut fs = LocalFilesystem::new();
+    let mut fs = DiskFilesystem::new();
     fs.mount_local(
         VirtualPath::new("/system/extensions").unwrap(),
         HostPath::from_path_buf(storage.path().to_path_buf()),

--- a/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
@@ -1,3 +1,4 @@
+// arch-exempt: large_file, mechanical LocalFilesystem->DiskFilesystem Bucket-2 rename (arch-simplification §4.4), no logic change, plan #6168
 use std::{
     collections::{BTreeMap, HashMap},
     io::Write,
@@ -17,7 +18,7 @@ use ironclaw_events::InMemoryAuditSink;
 use ironclaw_extensions::ExtensionRegistry;
 #[cfg(feature = "libsql")]
 use ironclaw_filesystem::LibSqlRootFilesystem;
-use ironclaw_filesystem::{InMemoryBackend, LocalFilesystem, RootFilesystem};
+use ironclaw_filesystem::{DiskFilesystem, InMemoryBackend, RootFilesystem};
 use ironclaw_host_api::runtime_policy::{
     ApprovalPolicy, AuditMode, DeploymentMode, EffectiveRuntimePolicy, FilesystemBackendKind,
     NetworkMode, ProcessBackendKind, RuntimeProfile, SecretMode,
@@ -4277,7 +4278,7 @@ async fn builtin_http_save_uses_strict_host_egress_when_tool_call_port_exists() 
     );
     let runtime = HostRuntimeServices::new(
         Arc::new(registry()),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::ProcessServices::in_memory(),
@@ -8144,7 +8145,7 @@ fn failure_input_issue<'a>(
 }
 
 fn runtime() -> impl HostRuntime {
-    runtime_with_filesystem(LocalFilesystem::new())
+    runtime_with_filesystem(DiskFilesystem::new())
 }
 
 fn runtime_with_filesystem<F>(filesystem: F) -> impl HostRuntime
@@ -8170,7 +8171,7 @@ where
 
 fn runtime_with_trigger_repository(repository: Arc<dyn TriggerRepository>) -> impl HostRuntime {
     runtime_with_filesystem_policy_and_trigger_repository(
-        LocalFilesystem::new(),
+        DiskFilesystem::new(),
         local_dev_policy(),
         repository,
     )
@@ -8182,7 +8183,7 @@ fn runtime_with_trigger_repository_and_create_hook(
 ) -> impl HostRuntime {
     HostRuntimeServices::new(
         Arc::new(registry()),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::ProcessServices::in_memory(),
@@ -8213,7 +8214,7 @@ fn runtime_with_trigger_repository_and_clock(
 ) -> impl HostRuntime {
     HostRuntimeServices::new(
         Arc::new(registry()),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::ProcessServices::in_memory(),
@@ -8943,7 +8944,7 @@ where
 {
     HostRuntimeServices::new(
         Arc::new(registry()),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::ProcessServices::in_memory(),
@@ -8969,7 +8970,7 @@ where
 {
     HostRuntimeServices::new(
         Arc::new(registry()),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::ProcessServices::in_memory(),
@@ -8989,7 +8990,7 @@ where
 fn runtime_with_policy(policy: EffectiveRuntimePolicy) -> impl HostRuntime {
     HostRuntimeServices::new(
         Arc::new(registry()),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::ProcessServices::in_memory(),
@@ -9054,7 +9055,7 @@ where
 {
     HostRuntimeServices::new(
         Arc::new(registry()),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::ProcessServices::in_memory(),
@@ -9078,7 +9079,7 @@ where
 {
     HostRuntimeServices::new(
         Arc::new(registry()),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         governor,
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::ProcessServices::in_memory(),
@@ -9098,7 +9099,7 @@ where
 {
     HostRuntimeServices::new(
         Arc::new(registry()),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::ProcessServices::in_memory(),
@@ -9118,7 +9119,7 @@ where
 {
     HostRuntimeServices::new(
         Arc::new(registry()),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::ProcessServices::in_memory(),
@@ -9187,8 +9188,8 @@ fn all_builtin_capability_ids() -> Vec<&'static str> {
     ]
 }
 
-fn mounted_filesystem(path: &Path, permissions: MountPermissions) -> (LocalFilesystem, MountView) {
-    let mut filesystem = LocalFilesystem::new();
+fn mounted_filesystem(path: &Path, permissions: MountPermissions) -> (DiskFilesystem, MountView) {
+    let mut filesystem = DiskFilesystem::new();
     filesystem
         .mount_local(
             VirtualPath::new("/projects/coding-pack").unwrap(),
@@ -9226,8 +9227,8 @@ fn memory_mounts(permissions: MountPermissions) -> MountView {
     .unwrap()
 }
 
-fn mounted_skill_filesystem(path: &Path) -> (LocalFilesystem, MountView) {
-    let mut filesystem = LocalFilesystem::new();
+fn mounted_skill_filesystem(path: &Path) -> (DiskFilesystem, MountView) {
+    let mut filesystem = DiskFilesystem::new();
     filesystem
         .mount_local(
             VirtualPath::new("/projects/skills").unwrap(),
@@ -9246,8 +9247,8 @@ fn mounted_skill_filesystem(path: &Path) -> (LocalFilesystem, MountView) {
 fn mounted_host_filesystem(
     path: &Path,
     permissions: MountPermissions,
-) -> (LocalFilesystem, MountView) {
-    let mut filesystem = LocalFilesystem::new();
+) -> (DiskFilesystem, MountView) {
+    let mut filesystem = DiskFilesystem::new();
     filesystem
         .mount_local(
             VirtualPath::new("/projects/host").unwrap(),

--- a/crates/ironclaw_host_runtime/tests/first_party_coding_tools.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_coding_tools.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use ironclaw_authorization::GrantAuthorizer;
 use ironclaw_extensions::ExtensionRegistry;
 use ironclaw_filesystem::{
-    DirEntry, FileStat, FileType, FilesystemError, FilesystemOperation, LocalFilesystem,
+    DirEntry, DiskFilesystem, FileStat, FileType, FilesystemError, FilesystemOperation,
     RootFilesystem,
 };
 use ironclaw_host_api::runtime_policy::{
@@ -1809,8 +1809,8 @@ fn coding_capability_ids() -> [&'static str; 6] {
     ]
 }
 
-fn mounted_filesystem(path: &Path, permissions: MountPermissions) -> (LocalFilesystem, MountView) {
-    let mut filesystem = LocalFilesystem::new();
+fn mounted_filesystem(path: &Path, permissions: MountPermissions) -> (DiskFilesystem, MountView) {
+    let mut filesystem = DiskFilesystem::new();
     filesystem
         .mount_local(
             VirtualPath::new("/projects/coding-pack").unwrap(),
@@ -1827,7 +1827,7 @@ fn mounted_filesystem(path: &Path, permissions: MountPermissions) -> (LocalFiles
 }
 
 struct StatFailureFilesystem {
-    inner: LocalFilesystem,
+    inner: DiskFilesystem,
     fail_suffix: &'static str,
 }
 
@@ -1862,7 +1862,7 @@ impl RootFilesystem for StatFailureFilesystem {
 }
 
 struct StatLenOverrideFilesystem {
-    inner: LocalFilesystem,
+    inner: DiskFilesystem,
     suffix: &'static str,
     len: u64,
 }
@@ -1895,7 +1895,7 @@ impl RootFilesystem for StatLenOverrideFilesystem {
 }
 
 struct ReadFailureFilesystem {
-    inner: LocalFilesystem,
+    inner: DiskFilesystem,
     fail_suffix: &'static str,
 }
 
@@ -1930,7 +1930,7 @@ impl RootFilesystem for ReadFailureFilesystem {
 }
 
 struct WriteFailureFilesystem {
-    inner: LocalFilesystem,
+    inner: DiskFilesystem,
     fail_suffix: &'static str,
 }
 
@@ -1965,7 +1965,7 @@ impl RootFilesystem for WriteFailureFilesystem {
 }
 
 struct ReadInfrastructureFailureFilesystem {
-    inner: LocalFilesystem,
+    inner: DiskFilesystem,
     fail_suffix: &'static str,
 }
 

--- a/crates/ironclaw_host_runtime/tests/first_party_runtime_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_runtime_contract.rs
@@ -12,7 +12,7 @@ use ironclaw_extensions::{
     CapabilityManifest, CapabilityVisibility, ExtensionManifest, ExtensionPackage,
     ExtensionRegistry, ExtensionRuntime, MANIFEST_SCHEMA_VERSION, ManifestSource,
 };
-use ironclaw_filesystem::LocalFilesystem;
+use ironclaw_filesystem::DiskFilesystem;
 use ironclaw_host_api::*;
 use ironclaw_host_runtime::{
     CapabilitySurfaceVersion, FirstPartyCapabilityError, FirstPartyCapabilityHandler,
@@ -47,7 +47,7 @@ async fn host_runtime_invokes_first_party_handler_through_capability_host() {
     let governor = Arc::new(InMemoryResourceGovernor::new());
     let runtime = HostRuntimeServices::new(
         Arc::new(first_party_registry()),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::clone(&governor),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -126,7 +126,7 @@ async fn first_party_handler_uses_staged_secret_through_production_host_egress()
             EffectKind::Network,
             EffectKind::UseSecret,
         ])),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -359,7 +359,7 @@ async fn http_error_kind_maps_all_reason_codes() {
 async fn production_wiring_rejects_first_party_registry_without_declared_handler() {
     let services = HostRuntimeServices::new(
         Arc::new(first_party_registry()),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -384,7 +384,7 @@ async fn production_wiring_rejects_first_party_registry_without_declared_handler
 async fn host_runtime_health_reports_missing_first_party_backend_for_empty_registry() {
     let runtime = HostRuntimeServices::new(
         Arc::new(first_party_registry()),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -415,7 +415,7 @@ async fn first_party_handler_error_reconciles_reported_usage_after_side_effect()
     let governor = Arc::new(InMemoryResourceGovernor::new());
     let runtime = HostRuntimeServices::new(
         Arc::new(first_party_registry()),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::clone(&governor),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -458,7 +458,7 @@ async fn first_party_handler_panic_fails_closed_and_releases_reservation() {
     let governor = Arc::new(InMemoryResourceGovernor::new());
     let runtime = HostRuntimeServices::new(
         Arc::new(first_party_registry()),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::clone(&governor),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -511,7 +511,7 @@ async fn first_party_missing_handler_fails_closed_without_side_effect_handler() 
     let events = InMemoryEventSink::new();
     let runtime = HostRuntimeServices::new(
         Arc::new(first_party_registry()),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -784,7 +784,7 @@ fn http_error_kind(reason: RuntimeHttpEgressReasonCode) -> RuntimeDispatchErrorK
 fn http_first_party_services(
     handle: &SecretHandle,
 ) -> HostRuntimeServices<
-    LocalFilesystem,
+    DiskFilesystem,
     InMemoryResourceGovernor,
     ironclaw_processes::FilesystemProcessStore<ironclaw_filesystem::InMemoryBackend>,
     ironclaw_processes::FilesystemProcessResultStore<ironclaw_filesystem::InMemoryBackend>,
@@ -797,7 +797,7 @@ fn http_first_party_services(
 
     HostRuntimeServices::new(
         Arc::new(first_party_http_registry()),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::in_memory_backed_process_services(),

--- a/crates/ironclaw_host_runtime/tests/github_wasm_runtime_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/github_wasm_runtime_contract.rs
@@ -1,10 +1,11 @@
+// arch-exempt: large_file, mechanical LocalFilesystem->DiskFilesystem Bucket-2 rename (arch-simplification §4.4), no logic change, plan #6168
 use std::sync::Arc;
 
 use async_trait::async_trait;
 use chrono::Utc;
 use ironclaw_authorization::TrustAwareCapabilityDispatchAuthorizer;
 use ironclaw_extensions::{ExtensionManifest, ExtensionPackage, ExtensionRegistry, ManifestSource};
-use ironclaw_filesystem::LocalFilesystem;
+use ironclaw_filesystem::DiskFilesystem;
 use ironclaw_host_api::{
     AgentId, CapabilityDescriptor, CapabilityGrant, CapabilityGrantId, CapabilityId, CapabilitySet,
     CorrelationId, CredentialStageError, Decision, EffectKind, ExecutionContext, ExtensionId,
@@ -2048,8 +2049,8 @@ fn registry_with_slack_user_package() -> ExtensionRegistry {
     registry
 }
 
-fn filesystem_with_slack_user_package() -> LocalFilesystem {
-    let mut filesystem = LocalFilesystem::new();
+fn filesystem_with_slack_user_package() -> DiskFilesystem {
+    let mut filesystem = DiskFilesystem::new();
     filesystem
         .mount_local(
             VirtualPath::new("/system/extensions").unwrap(),
@@ -2147,8 +2148,8 @@ fn registry_with_google_drive_package() -> ExtensionRegistry {
     registry_with_google_package("google-drive")
 }
 
-fn filesystem_with_github_package() -> LocalFilesystem {
-    let mut filesystem = LocalFilesystem::new();
+fn filesystem_with_github_package() -> DiskFilesystem {
+    let mut filesystem = DiskFilesystem::new();
     filesystem
         .mount_local(
             VirtualPath::new("/system/extensions").unwrap(),
@@ -2158,7 +2159,7 @@ fn filesystem_with_github_package() -> LocalFilesystem {
     filesystem
 }
 
-fn filesystem_with_google_drive_package() -> LocalFilesystem {
+fn filesystem_with_google_drive_package() -> DiskFilesystem {
     filesystem_with_google_package("google-drive")
 }
 
@@ -2180,8 +2181,8 @@ fn registry_with_google_package(package_id: &str) -> ExtensionRegistry {
     registry
 }
 
-fn filesystem_with_google_package(package_id: &str) -> LocalFilesystem {
-    let mut filesystem = LocalFilesystem::new();
+fn filesystem_with_google_package(package_id: &str) -> DiskFilesystem {
+    let mut filesystem = DiskFilesystem::new();
     filesystem
         .mount_local(
             VirtualPath::new("/system/extensions").unwrap(),

--- a/crates/ironclaw_host_runtime/tests/host_api_contract_composition.rs
+++ b/crates/ironclaw_host_runtime/tests/host_api_contract_composition.rs
@@ -1,7 +1,7 @@
 use ironclaw_extensions::{
     CAPABILITY_PROVIDER_HOST_API_ID, CAPABILITY_PROVIDER_SECTION, ExtensionError, ManifestV2Error,
 };
-use ironclaw_filesystem::LocalFilesystem;
+use ironclaw_filesystem::DiskFilesystem;
 use ironclaw_host_api::{
     CapabilityId, ExtensionId, HOST_RUNTIME_HTTP_EGRESS_PORT_ID, HostPath, HostPortId, VirtualPath,
 };
@@ -90,12 +90,12 @@ async fn default_host_port_catalog_rejects_unknown_required_port() {
     );
 }
 
-fn mounted_extension_fs(id: &str, manifest: &str) -> (tempfile::TempDir, LocalFilesystem) {
+fn mounted_extension_fs(id: &str, manifest: &str) -> (tempfile::TempDir, DiskFilesystem) {
     let storage = tempdir().unwrap();
     std::fs::create_dir_all(storage.path().join(id)).unwrap();
     std::fs::write(storage.path().join(id).join("manifest.toml"), manifest).unwrap();
 
-    let mut fs = LocalFilesystem::new();
+    let mut fs = DiskFilesystem::new();
     fs.mount_local(
         VirtualPath::new("/system/extensions").unwrap(),
         HostPath::from_path_buf(storage.path().to_path_buf()),

--- a/crates/ironclaw_host_runtime/tests/host_runtime_credential_preflight_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_credential_preflight_contract.rs
@@ -23,7 +23,7 @@ use std::sync::Arc;
 use chrono::Utc;
 use ironclaw_authorization::{GrantAuthorizer, in_memory_backed_capability_lease_store};
 use ironclaw_extensions::{ExtensionManifest, ExtensionPackage, ExtensionRegistry, ManifestSource};
-use ironclaw_filesystem::LocalFilesystem;
+use ironclaw_filesystem::DiskFilesystem;
 use ironclaw_host_api::*;
 use ironclaw_host_runtime::{
     CapabilitySurfaceVersion, HostRuntime, HostRuntimeError, HostRuntimeServices,
@@ -198,7 +198,7 @@ async fn product_auth_account_credential_does_not_trip_preflight() {
 
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_WITH_PRODUCT_AUTH_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ProcessServices::in_memory(),
@@ -256,7 +256,7 @@ async fn secret_handle_credential_absent_still_trips_preflight() {
 
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_WITH_SECRET_HANDLE_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ProcessServices::in_memory(),
@@ -318,7 +318,7 @@ async fn tenant_shared_secret_satisfies_credential_preflight() {
 
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_WITH_SECRET_HANDLE_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ProcessServices::in_memory(),
@@ -383,7 +383,7 @@ async fn invoke_capability_forged_scope_fails_before_preflight() {
 
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_WITH_SECRET_HANDLE_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ProcessServices::in_memory(),
@@ -449,7 +449,7 @@ async fn spawn_capability_forged_scope_fails_before_preflight() {
 
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_WITH_SECRET_HANDLE_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ProcessServices::in_memory(),

--- a/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
@@ -571,7 +571,7 @@ async fn production_wiring_validation_classifies_in_memory_backed_run_state_and_
     // helper (the combined-store path hard-codes `LocalOnly` and bypasses it).
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::in_memory_backed_process_services(),

--- a/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
@@ -30,9 +30,9 @@ use ironclaw_events::{
     InMemoryEventSink, ReadScope, RuntimeEventKind,
 };
 use ironclaw_extensions::ExtensionRegistry;
+use ironclaw_filesystem::DiskFilesystem;
 #[cfg(feature = "libsql")]
 use ironclaw_filesystem::LibSqlRootFilesystem;
-use ironclaw_filesystem::LocalFilesystem;
 #[cfg(feature = "libsql")]
 use ironclaw_filesystem::RootFilesystem;
 use ironclaw_host_api::*;
@@ -123,7 +123,7 @@ async fn assert_alice_run_status(
 async fn production_wiring_validation_rejects_missing_components_and_local_only_defaults() {
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -246,7 +246,7 @@ async fn production_wiring_validation_rejects_missing_components_and_local_only_
 async fn production_wiring_validation_rejects_local_only_runtime_policy() {
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -298,7 +298,7 @@ async fn production_wiring_validation_rejects_each_local_only_runtime_policy_fie
 async fn production_wiring_validation_accepts_production_safe_runtime_policy_shape() {
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -327,7 +327,7 @@ async fn production_wiring_validation_accepts_persistent_resource_governor_compo
     ));
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         governor,
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -370,7 +370,7 @@ async fn with_filesystem_resource_governor_persists_reservations_across_handles(
 
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -414,7 +414,7 @@ async fn with_filesystem_resource_governor_closes_process_reservations_on_cancel
 
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         process_services,
@@ -469,7 +469,7 @@ async fn with_filesystem_resource_governor_closes_process_reservations_on_cancel
 async fn production_wiring_validation_classifies_combined_store_as_run_state_and_approvals() {
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -527,7 +527,7 @@ async fn production_wiring_validation_classifies_in_memory_backed_lease_store_as
     // classifier helper.
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -612,7 +612,7 @@ async fn production_wiring_validation_classifies_in_memory_backed_run_state_and_
 async fn production_wiring_validation_rejects_unsupported_runtime_requirements() {
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -647,7 +647,7 @@ async fn production_wiring_validation_rejects_unsupported_runtime_requirements()
 //
 // The equivalent guardrail surface for the filesystem-backed wiring is
 // exercised by `tests/reborn_durable_restart_integration.rs` (services
-// graph restart over `LocalFilesystem`) and the `ironclaw_run_state`
+// graph restart over `DiskFilesystem`) and the `ironclaw_run_state`
 // contract suite.
 
 #[cfg(feature = "libsql")]
@@ -661,7 +661,7 @@ async fn production_root_filesystem_selection_accepts_libsql_root_filesystem() {
 
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -695,7 +695,7 @@ async fn production_turn_state_selection_accepts_filesystem_turn_state_store() {
 
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -733,7 +733,7 @@ async fn production_turn_coordinator_uses_configured_store_and_notifier() {
 
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -773,7 +773,7 @@ async fn production_turn_coordinator_requires_explicit_run_profile_resolver() {
 
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -796,7 +796,7 @@ async fn production_turn_coordinator_requires_explicit_run_profile_resolver() {
 async fn production_wiring_validation_rejects_noop_turn_wake_notifier() {
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -820,7 +820,7 @@ async fn production_wiring_validation_rejects_noop_turn_wake_notifier() {
 async fn production_wiring_validation_accepts_configured_turn_wake_notifier() {
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -852,7 +852,7 @@ async fn production_event_store_config_rejects_jsonl_without_single_node_accepta
     let temp = tempfile::tempdir().unwrap();
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -880,7 +880,7 @@ async fn local_reborn_event_store_config_does_not_satisfy_production_wiring() {
     let temp = tempfile::tempdir().unwrap();
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -921,7 +921,7 @@ async fn production_event_store_config_installs_verified_event_and_audit_sinks()
     let temp = tempfile::tempdir().unwrap();
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -975,7 +975,7 @@ async fn production_event_store_config_installs_verified_event_and_audit_sinks()
 async fn production_wiring_validation_uses_configured_runtime_requirements() {
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -1023,7 +1023,7 @@ async fn production_wiring_validation_uses_configured_runtime_requirements() {
 async fn production_wiring_validation_sees_underlying_in_memory_durable_logs() {
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -1058,7 +1058,7 @@ async fn production_wiring_validation_rejects_direct_durable_sink_wrappers_as_un
     let audit_log: Arc<dyn DurableAuditLog> = Arc::new(InMemoryDurableAuditLog::new());
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -1091,7 +1091,7 @@ async fn production_wiring_validation_rejects_direct_durable_sink_wrappers_as_un
 async fn production_wiring_validation_accepts_verified_host_http_egress_shape() {
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -1118,7 +1118,7 @@ async fn production_wiring_validation_accepts_verified_host_http_egress_shape() 
 async fn host_http_egress_helper_requires_graph_secret_store() {
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -1140,7 +1140,7 @@ async fn host_http_egress_helper_requires_graph_secret_store() {
 async fn production_wiring_validation_requires_credential_broker_when_configured() {
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -1172,7 +1172,7 @@ async fn production_wiring_validation_rejects_local_only_credential_broker() {
     let broker = Arc::new(InMemoryCredentialBroker::new());
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -1204,7 +1204,7 @@ async fn production_wiring_validation_rejects_local_only_credential_broker() {
 async fn production_wiring_validation_rejects_unverified_runtime_http_egress() {
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -1231,7 +1231,7 @@ async fn production_wiring_validation_rejects_unverified_runtime_http_egress() {
 async fn production_wiring_validation_tracks_process_port_for_builtin_shell() {
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_builtin_first_party_package()),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -1255,7 +1255,7 @@ async fn production_wiring_validation_tracks_process_port_for_builtin_shell() {
 
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_builtin_first_party_package()),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -1283,7 +1283,7 @@ async fn production_wiring_validation_tracks_process_port_for_builtin_shell() {
 async fn production_wiring_validation_tracks_tenant_sandbox_process_port_for_builtin_shell() {
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_builtin_first_party_package()),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -1308,7 +1308,7 @@ async fn production_wiring_validation_tracks_tenant_sandbox_process_port_for_bui
 
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_builtin_first_party_package()),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -1341,7 +1341,7 @@ async fn production_wiring_validation_tracks_tenant_sandbox_process_port_for_bui
 
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_builtin_first_party_package()),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -1375,7 +1375,7 @@ async fn production_wiring_validation_tracks_tenant_sandbox_process_port_for_bui
 async fn production_wiring_validation_rejects_empty_verified_wasm_credentials() {
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(WASM_HTTP_SUCCESS_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -1404,7 +1404,7 @@ async fn production_wiring_validation_rejects_empty_verified_wasm_credentials() 
 async fn production_wiring_validation_rejects_wasm_credentials_added_after_adapter() {
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(WASM_HTTP_SUCCESS_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -1435,7 +1435,7 @@ async fn production_wiring_validation_rejects_wasm_credentials_added_after_adapt
 async fn production_wiring_validation_rejects_wasm_credentials_replaced_after_adapter() {
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(WASM_HTTP_SUCCESS_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -1466,7 +1466,7 @@ async fn production_wiring_validation_rejects_wasm_credentials_replaced_after_ad
 #[tokio::test]
 async fn host_runtime_services_builds_dispatcher_runtime_and_health_from_registered_adapters() {
     let registry = Arc::new(registry_with_manifest(SCRIPT_MANIFEST));
-    let filesystem = Arc::new(LocalFilesystem::new());
+    let filesystem = Arc::new(DiskFilesystem::new());
     let governor = Arc::new(InMemoryResourceGovernor::new());
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> =
         Arc::new(GrantAuthorizer::new());
@@ -1542,7 +1542,7 @@ async fn host_runtime_services_builds_dispatcher_runtime_and_health_from_registe
 async fn host_runtime_services_wires_combined_store_for_atomic_approval_block() {
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(ApprovalThenGrantAuthorizer),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -1568,7 +1568,7 @@ async fn host_runtime_services_preserves_combined_store_after_root_filesystem_se
     filesystem.run_migrations().await.unwrap();
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(ApprovalThenGrantAuthorizer),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -1586,7 +1586,7 @@ async fn host_runtime_services_preserves_combined_store_after_root_filesystem_se
 #[tokio::test]
 async fn host_runtime_services_writes_runtime_events_to_durable_event_log_metadata_only() {
     let registry = Arc::new(registry_with_manifest(SCRIPT_MANIFEST));
-    let filesystem = Arc::new(LocalFilesystem::new());
+    let filesystem = Arc::new(DiskFilesystem::new());
     let governor = Arc::new(InMemoryResourceGovernor::new());
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> =
         Arc::new(GrantAuthorizer::new());
@@ -1699,7 +1699,7 @@ async fn host_runtime_services_consumes_reborn_jsonl_event_store_without_v1_comp
 
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -1765,7 +1765,7 @@ async fn host_runtime_services_durable_event_replay_cursor_and_gap_behavior() {
     ));
     let services = HostRuntimeServices::new(
         registry,
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -1852,7 +1852,7 @@ async fn host_runtime_services_runtime_events_project_through_replay_projection_
     let event_log = Arc::new(InMemoryDurableEventLog::new());
     let services = HostRuntimeServices::new(
         registry,
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -1940,7 +1940,7 @@ async fn host_runtime_services_projection_rejects_foreign_cursor_and_surfaces_re
     let event_log = Arc::new(InMemoryDurableEventLog::new());
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -2049,7 +2049,7 @@ async fn host_runtime_services_jsonl_event_store_projects_same_runtime_sequence_
     let event_log = Arc::clone(&stores.events);
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -2138,7 +2138,7 @@ async fn host_runtime_services_approval_resolution_projects_durable_audit_metada
     let audit_log = Arc::new(InMemoryDurableAuditLog::new());
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(SentinelApprovalAuthorizer),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -2246,7 +2246,7 @@ async fn host_runtime_services_jsonl_approval_audit_projection_rejects_foreign_c
     let capability_leases = Arc::new(in_memory_backed_capability_lease_store());
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(SentinelApprovalAuthorizer),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -2465,7 +2465,7 @@ async fn host_runtime_services_cancel_projects_kill_event_from_configured_event_
     let result_store = process_services.result_store();
     let runtime = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         process_services,
@@ -2634,7 +2634,7 @@ async fn host_runtime_services_resume_missing_runtime_secret_returns_auth_gate()
     let script_runtime = Arc::new(RecordingScriptExecutor::default());
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(ApprovalThenSecretObligationAuthorizer {
             handle: secret_handle,
@@ -3177,7 +3177,7 @@ async fn host_runtime_services_resume_spawn_rejects_changed_actor_before_input_a
         Arc::new(registry_with_host_bundled_manifest(
             PROCESS_SANDBOX_MANIFEST,
         )),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(ApprovalThenGrantAuthorizer),
         process_services.clone(),
@@ -3216,7 +3216,7 @@ async fn host_runtime_services_resume_spawn_rejects_changed_actor_before_input_a
     let lease = approve_spawn_for_services(&services, &scope, approval_request_id, None).await;
     let broken_runtime = HostRuntimeServices::new(
         Arc::new(ExtensionRegistry::new()),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(ApprovalThenGrantAuthorizer),
         process_services,
@@ -3342,7 +3342,7 @@ async fn host_runtime_services_auth_resume_dispatches_blocked_auth_run() {
     let script_runtime = Arc::new(RecordingScriptExecutor::default());
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(ApprovalThenSecretObligationAuthorizer {
             handle: secret_handle.clone(),
@@ -3652,7 +3652,7 @@ async fn host_runtime_services_auth_resume_with_approval_id_fails_blocked_auth_r
 async fn host_runtime_services_resume_without_backing_stores_fails_closed() {
     let runtime = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(ApprovalThenGrantAuthorizer),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -3695,7 +3695,7 @@ async fn host_runtime_services_registered_runtime_health_tracks_script_mcp_and_w
             MCP_MANIFEST,
             WASM_MANIFEST,
         ])),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -3717,7 +3717,7 @@ async fn host_runtime_services_registered_runtime_health_tracks_script_mcp_and_w
 async fn host_runtime_services_health_fails_closed_for_unregistered_required_runtime() {
     let runtime = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -3738,7 +3738,7 @@ async fn host_runtime_routes_system_process_sandbox_to_configured_executor() {
     let sandbox_executor = Arc::new(RecordingSandboxProcessExecutor::default());
     let runtime = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         process_services,
@@ -3769,7 +3769,7 @@ async fn host_runtime_spawn_process_sandbox_routes_approved_request_to_configure
         Arc::new(registry_with_host_bundled_manifest(
             PROCESS_SANDBOX_MANIFEST,
         )),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         process_services,
@@ -3806,7 +3806,7 @@ async fn host_runtime_spawn_process_sandbox_rejects_invalid_plan_before_executor
         Arc::new(registry_with_host_bundled_manifest(
             PROCESS_SANDBOX_MANIFEST,
         )),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -3861,7 +3861,7 @@ async fn host_runtime_spawn_process_sandbox_runtime_policy_denial_fails_before_e
         Arc::new(registry_with_host_bundled_manifest(
             PROCESS_SANDBOX_MANIFEST,
         )),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -3895,7 +3895,7 @@ async fn host_runtime_spawn_process_sandbox_host_failure_fails_after_preflight()
         Arc::new(registry_with_host_bundled_manifest(
             PROCESS_SANDBOX_MANIFEST,
         )),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -3934,7 +3934,7 @@ async fn host_runtime_spawn_process_sandbox_blocks_for_approval_before_executor(
         Arc::new(registry_with_host_bundled_manifest(
             PROCESS_SANDBOX_MANIFEST,
         )),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(ApprovalThenGrantAuthorizer),
         process_services,
@@ -4008,7 +4008,7 @@ async fn host_runtime_spawn_process_sandbox_resume_changed_input_fails_before_ex
         Arc::new(registry_with_host_bundled_manifest(
             PROCESS_SANDBOX_MANIFEST,
         )),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(ApprovalThenGrantAuthorizer),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -4083,7 +4083,7 @@ async fn host_runtime_spawn_process_sandbox_resume_invalid_plan_fails_before_exe
         Arc::new(registry_with_host_bundled_manifest(
             PROCESS_SANDBOX_MANIFEST,
         )),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(ApprovalThenGrantAuthorizer),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -4177,7 +4177,7 @@ async fn host_runtime_spawn_process_sandbox_resume_host_failure_fails_after_appr
         Arc::new(registry_with_host_bundled_manifest(
             PROCESS_SANDBOX_MANIFEST,
         )),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(ApprovalThenGrantAuthorizer),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -4238,7 +4238,7 @@ async fn host_runtime_spawn_process_sandbox_resume_host_failure_fails_after_appr
 #[tokio::test]
 async fn host_runtime_services_installs_builtin_obligation_handler_with_audit_sink() {
     let registry = Arc::new(registry_with_manifest(SCRIPT_MANIFEST));
-    let filesystem = Arc::new(LocalFilesystem::new());
+    let filesystem = Arc::new(DiskFilesystem::new());
     let governor = Arc::new(InMemoryResourceGovernor::new());
     let audit = Arc::new(InMemoryAuditSink::new());
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> =
@@ -4293,7 +4293,7 @@ async fn host_runtime_services_maps_script_exit_failure_through_private_adapter(
     ));
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(ObligatingAuthorizer::new(Vec::new())),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -4320,7 +4320,7 @@ async fn host_runtime_services_maps_script_exit_failure_through_private_adapter(
 async fn host_runtime_services_maps_mcp_client_failure_through_private_adapter() {
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(MCP_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(ObligatingAuthorizer::new(Vec::new())),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -4360,7 +4360,7 @@ async fn host_runtime_services_applies_scoped_mount_obligation_to_script_runtime
     let script_runtime = Arc::new(RecordingScriptExecutor::default());
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(ObligatingAuthorizer::new(vec![
             Obligation::UseScopedMounts {
@@ -4409,7 +4409,7 @@ async fn host_runtime_services_rejects_broader_scoped_mount_before_dispatch() {
     let script_runtime = Arc::new(RecordingScriptExecutor::default());
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(ObligatingAuthorizer::new(vec![
             Obligation::UseScopedMounts {
@@ -4451,7 +4451,7 @@ async fn host_runtime_services_rejects_broader_scoped_mount_before_dispatch() {
 #[tokio::test]
 async fn host_runtime_services_writes_obligation_audit_records_to_durable_log_metadata_only() {
     let registry = Arc::new(registry_with_manifest(SCRIPT_MANIFEST));
-    let filesystem = Arc::new(LocalFilesystem::new());
+    let filesystem = Arc::new(DiskFilesystem::new());
     let governor = Arc::new(InMemoryResourceGovernor::new());
     let audit_log = Arc::new(InMemoryDurableAuditLog::new());
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> =
@@ -4575,7 +4575,7 @@ async fn host_runtime_services_projects_resource_network_secret_obligation_audit
         ]));
     let services: InMemoryHostRuntimeServices = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::clone(&governor),
         authorizer,
         ironclaw_processes::in_memory_backed_process_services(),
@@ -4706,7 +4706,7 @@ async fn host_runtime_services_enforces_output_limit_and_reconciles_resource_usa
     ));
     let services = HostRuntimeServices::new(
         registry,
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::clone(&governor),
         authorizer,
         ironclaw_processes::in_memory_backed_process_services(),
@@ -4765,7 +4765,7 @@ async fn host_runtime_services_releases_reservation_when_dispatch_preflight_fail
     let reservation_id = ResourceReservationId::new();
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::clone(&governor),
         Arc::new(ObligatingAuthorizer::new(vec![
             Obligation::ReserveResources { reservation_id },
@@ -4812,7 +4812,7 @@ async fn host_runtime_services_releases_reservation_when_dispatch_preflight_fail
 #[tokio::test]
 async fn host_runtime_services_fails_closed_when_durable_obligation_audit_append_fails() {
     let registry = Arc::new(registry_with_manifest(SCRIPT_MANIFEST));
-    let filesystem = Arc::new(LocalFilesystem::new());
+    let filesystem = Arc::new(DiskFilesystem::new());
     let governor = Arc::new(InMemoryResourceGovernor::new());
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> =
         Arc::new(ObligatingAuthorizer::new(vec![Obligation::AuditBefore]));
@@ -5315,7 +5315,7 @@ async fn host_runtime_services_cancel_and_status_share_process_result_and_cancel
     let registry = Arc::new(registry_with_manifest(SCRIPT_MANIFEST));
     let runtime = HostRuntimeServices::new(
         registry,
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         process_services,
@@ -5368,7 +5368,7 @@ async fn host_runtime_services_cancel_writes_killed_result_when_reservation_is_s
     let registry = Arc::new(registry_with_manifest(SCRIPT_MANIFEST));
     let runtime = HostRuntimeServices::new(
         registry,
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         process_services,
@@ -5414,7 +5414,7 @@ async fn host_runtime_services_cancel_records_kill_side_effects_when_cleanup_fai
     let registry = Arc::new(registry_with_manifest(SCRIPT_MANIFEST));
     let runtime = HostRuntimeServices::new(
         registry,
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(FailingCleanupResourceGovernor),
         Arc::new(GrantAuthorizer::new()),
         process_services,
@@ -6097,7 +6097,7 @@ async fn invoke_capability_missing_credential_returns_auth_before_approval() {
     let script_runtime = Arc::new(RecordingScriptExecutor::default());
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_WITH_CREDENTIAL_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(ApprovalThenSecretObligationAuthorizer {
             handle: secret_handle,
@@ -6186,7 +6186,7 @@ async fn invoke_capability_present_credential_proceeds_to_approval() {
     let script_runtime = Arc::new(RecordingScriptExecutor::default());
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_WITH_CREDENTIAL_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(ApprovalThenSecretObligationAuthorizer {
             handle: secret_handle,
@@ -6267,7 +6267,7 @@ async fn spawn_capability_present_credential_proceeds_to_approval() {
     let script_runtime = Arc::new(RecordingScriptExecutor::default());
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_WITH_CREDENTIAL_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         // ApprovalThenGrantAuthorizer implements authorize_spawn_with_trust correctly:
         // RequireApproval when grants are empty, delegates to GrantAuthorizer when grants
@@ -6365,7 +6365,7 @@ async fn spawn_capability_missing_credential_returns_auth_before_approval() {
     let script_runtime = Arc::new(RecordingScriptExecutor::default());
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_WITH_CREDENTIAL_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(ApprovalThenSecretObligationAuthorizer {
             handle: secret_handle,
@@ -6439,7 +6439,7 @@ async fn invoke_capability_no_credential_requirement_with_wired_store_proceeds_n
     let secret_handle = SecretHandle::new("any_token").unwrap();
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(ApprovalThenSecretObligationAuthorizer {
             handle: secret_handle,
@@ -6522,7 +6522,7 @@ async fn invoke_capability_secret_store_error_skips_preflight() {
     let metadata_calls = Arc::new(AtomicUsize::new(0));
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_WITH_CREDENTIAL_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         // ApprovalThenGrantAuthorizer: requires approval first, grants on resume, and
         // injects NO secret obligation of its own. Credential enforcement on the resume

--- a/crates/ironclaw_host_runtime/tests/reborn_durable_restart_integration.rs
+++ b/crates/ironclaw_host_runtime/tests/reborn_durable_restart_integration.rs
@@ -17,7 +17,7 @@ use ironclaw_events::{
 use ironclaw_extensions::{ExtensionManifest, ExtensionPackage, ExtensionRegistry, ManifestSource};
 #[cfg(feature = "libsql")]
 use ironclaw_filesystem::LibSqlRootFilesystem;
-use ironclaw_filesystem::{InMemoryBackend, LocalFilesystem, RootFilesystem, ScopedFilesystem};
+use ironclaw_filesystem::{DiskFilesystem, InMemoryBackend, RootFilesystem, ScopedFilesystem};
 use ironclaw_host_api::*;
 use ironclaw_host_runtime::{
     CapabilitySurfaceVersion, HostRuntime, HostRuntimeServices, RuntimeCapabilityOutcome,
@@ -480,15 +480,15 @@ async fn jsonl_event_and_audit_replay_survive_reopen_without_raw_sentinels() {
 }
 
 type DurableProcessServices = ProcessServices<
-    FilesystemProcessStore<LocalFilesystem>,
-    FilesystemProcessResultStore<LocalFilesystem>,
+    FilesystemProcessStore<DiskFilesystem>,
+    FilesystemProcessResultStore<DiskFilesystem>,
 >;
 
 type DurableHostRuntimeServices = HostRuntimeServices<
-    LocalFilesystem,
+    DiskFilesystem,
     InMemoryResourceGovernor,
-    FilesystemProcessStore<LocalFilesystem>,
-    FilesystemProcessResultStore<LocalFilesystem>,
+    FilesystemProcessStore<DiskFilesystem>,
+    FilesystemProcessResultStore<DiskFilesystem>,
 >;
 
 struct DurableServices<F = InMemoryBackend>
@@ -498,7 +498,7 @@ where
     services: DurableHostRuntimeServices,
     run_state: Arc<FilesystemRunStateStore<F>>,
     approval_requests: Arc<FilesystemApprovalRequestStore<F>>,
-    capability_leases: Arc<FilesystemCapabilityLeaseStore<LocalFilesystem>>,
+    capability_leases: Arc<FilesystemCapabilityLeaseStore<DiskFilesystem>>,
     events: RebornEventStores,
 }
 
@@ -506,7 +506,7 @@ where
 /// backend, generic over the backend type so the same mount shape can be
 /// reused for the shared in-memory backend (service-graph-restart coverage)
 /// and a real durable backend like [`LibSqlRootFilesystem`] (durable-reopen
-/// coverage). `LocalFilesystem` rejects the record-shaped entries
+/// coverage). `DiskFilesystem` rejects the record-shaped entries
 /// (`entry.kind = Some(RecordKind::new(…))`) these stores write, so callers
 /// must pick a backend whose `BackendCapabilities` accept them.
 fn scoped_run_state_filesystem<F>(backend: Arc<F>) -> Arc<ScopedFilesystem<F>>
@@ -692,22 +692,22 @@ fn durable_mount_view() -> MountView {
     .unwrap()
 }
 
-/// Build a fresh [`ScopedFilesystem`] over a [`LocalFilesystem`] rooted at
+/// Build a fresh [`ScopedFilesystem`] over a [`DiskFilesystem`] rooted at
 /// `engine_root`. The restart contract spawns multiple service graphs against
 /// the same on-disk root, so each call here constructs a distinct
-/// `ScopedFilesystem` over a freshly-mounted `LocalFilesystem`; identity of
+/// `ScopedFilesystem` over a freshly-mounted `DiskFilesystem`; identity of
 /// the wrapping struct is irrelevant — durability lives on disk, and the
 /// per-path lock map is process-global by design.
-fn scoped_engine_filesystem(engine_root: &Path) -> Arc<ScopedFilesystem<LocalFilesystem>> {
+fn scoped_engine_filesystem(engine_root: &Path) -> Arc<ScopedFilesystem<DiskFilesystem>> {
     Arc::new(ScopedFilesystem::with_fixed_view(
         Arc::new(mounted_engine_filesystem(engine_root)),
         durable_mount_view(),
     ))
 }
 
-fn mounted_engine_filesystem(engine_root: &Path) -> LocalFilesystem {
+fn mounted_engine_filesystem(engine_root: &Path) -> DiskFilesystem {
     std::fs::create_dir_all(engine_root).unwrap();
-    let mut filesystem = LocalFilesystem::new();
+    let mut filesystem = DiskFilesystem::new();
     // Backend mount for `/engine` plus the consumer-store virtual roots
     // exposed via `durable_mount_view`. Each top-level root resolves to a
     // sibling subdirectory under `engine_root` so durable-restart fixtures

--- a/crates/ironclaw_host_runtime/tests/reborn_e2e_gate.rs
+++ b/crates/ironclaw_host_runtime/tests/reborn_e2e_gate.rs
@@ -20,7 +20,7 @@ use ironclaw_events::{
     ReadScope, RuntimeEventKind,
 };
 use ironclaw_extensions::{ExtensionManifest, ExtensionPackage, ExtensionRegistry, ManifestSource};
-use ironclaw_filesystem::{InMemoryBackend, LocalFilesystem, RootFilesystem};
+use ironclaw_filesystem::{DiskFilesystem, InMemoryBackend, RootFilesystem};
 use ironclaw_host_api::*;
 use ironclaw_host_runtime::{
     BuiltinObligationServices, CapabilitySurfacePolicy, CapabilitySurfaceVersion, HostRuntime,
@@ -269,7 +269,7 @@ async fn reborn_e2e_gate_fails_unsupported_obligations_before_runtime_events_or_
     let governor = Arc::new(InMemoryResourceGovernor::new());
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::clone(&governor),
         Arc::new(ObligatingAuthorizer::new(vec![Obligation::AuditBefore])),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -320,7 +320,7 @@ async fn reborn_e2e_gate_redacts_runtime_output_before_public_result() {
     let events = InMemoryEventSink::new();
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(ObligatingAuthorizer::new(vec![Obligation::RedactOutput])),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -384,7 +384,7 @@ async fn reborn_e2e_gate_sanitizes_runtime_backend_failure_before_public_surface
     let events = InMemoryEventSink::new();
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -463,7 +463,7 @@ async fn reborn_e2e_gate_blocks_oversized_runtime_output_before_publication() {
     let events = InMemoryEventSink::new();
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(ObligatingAuthorizer::new(vec![
             Obligation::EnforceOutputLimit { bytes: 8 },
@@ -630,7 +630,7 @@ async fn reborn_e2e_gate_host_http_consumes_staged_policy_and_secret_once() {
 }
 
 type InMemoryServices = HostRuntimeServices<
-    LocalFilesystem,
+    DiskFilesystem,
     InMemoryResourceGovernor,
     FilesystemProcessStore<InMemoryBackend>,
     FilesystemProcessResultStore<InMemoryBackend>,
@@ -651,7 +651,7 @@ fn approval_resume_fixture() -> ApprovalFixture {
     let events = InMemoryEventSink::new();
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(ApprovalThenGrantAuthorizer),
         ironclaw_processes::in_memory_backed_process_services(),

--- a/crates/ironclaw_host_runtime/tests/reborn_invoke_vertical_slice.rs
+++ b/crates/ironclaw_host_runtime/tests/reborn_invoke_vertical_slice.rs
@@ -15,7 +15,7 @@ use ironclaw_dispatcher::{
 };
 use ironclaw_events::{InMemoryEventSink, RuntimeEventKind};
 use ironclaw_extensions::{ExtensionManifest, ExtensionPackage, ExtensionRegistry, ManifestSource};
-use ironclaw_filesystem::LocalFilesystem;
+use ironclaw_filesystem::DiskFilesystem;
 use ironclaw_host_api::*;
 use ironclaw_host_runtime::{
     CapabilitySurfaceVersion, DefaultHostRuntime, HostRuntime, RuntimeCapabilityOutcome,
@@ -200,10 +200,10 @@ impl RecordingRuntimeAdapter {
 }
 
 #[async_trait]
-impl RuntimeAdapter<LocalFilesystem, InMemoryResourceGovernor> for RecordingRuntimeAdapter {
+impl RuntimeAdapter<DiskFilesystem, InMemoryResourceGovernor> for RecordingRuntimeAdapter {
     async fn dispatch_json(
         &self,
-        request: RuntimeAdapterRequest<'_, LocalFilesystem, InMemoryResourceGovernor>,
+        request: RuntimeAdapterRequest<'_, DiskFilesystem, InMemoryResourceGovernor>,
     ) -> Result<RuntimeAdapterResult, DispatchError> {
         self.requests.lock().unwrap().push(RecordedRuntimeRequest {
             capability_id: request.capability_id.clone(),
@@ -292,12 +292,12 @@ fn runtime_dispatcher_stack(
     adapter: Arc<RecordingRuntimeAdapter>,
 ) -> (
     Arc<ExtensionRegistry>,
-    RuntimeDispatcher<'static, LocalFilesystem, InMemoryResourceGovernor>,
+    RuntimeDispatcher<'static, DiskFilesystem, InMemoryResourceGovernor>,
     Arc<InMemoryResourceGovernor>,
     InMemoryEventSink,
 ) {
     let registry = Arc::new(registry_with_echo_capability());
-    let filesystem = Arc::new(LocalFilesystem::new());
+    let filesystem = Arc::new(DiskFilesystem::new());
     let governor = Arc::new(InMemoryResourceGovernor::new());
     let events = InMemoryEventSink::new();
     let dispatcher =

--- a/crates/ironclaw_host_runtime/tests/runtime_http_egress_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/runtime_http_egress_contract.rs
@@ -1,8 +1,9 @@
+// arch-exempt: large_file, mechanical LocalFilesystem->DiskFilesystem Bucket-2 rename (arch-simplification §4.4), no logic change, plan #6168
 use ironclaw_capabilities::{
     CapabilityObligationHandler, CapabilityObligationPhase, CapabilityObligationRequest,
 };
 use ironclaw_events::InMemoryAuditSink;
-use ironclaw_filesystem::{InMemoryBackend, LocalFilesystem, RootFilesystem, ScopedFilesystem};
+use ironclaw_filesystem::{DiskFilesystem, InMemoryBackend, RootFilesystem, ScopedFilesystem};
 use ironclaw_host_api::{
     AgentId, CapabilityHostHttpRequest, CapabilityId, CapabilitySet, CredentialStageError,
     ExecutionContext, ExtensionId, InvocationId, MountAlias, MountGrant, MountPermissions,
@@ -3641,7 +3642,7 @@ async fn host_http_egress_fails_closed_when_real_scoped_filesystem_write_fails()
         },
     });
     let temp = tempdir().unwrap();
-    let mut root = LocalFilesystem::new();
+    let mut root = DiskFilesystem::new();
     root.mount_local(
         VirtualPath::new("/projects/workspace").unwrap(),
         ironclaw_host_api::HostPath::from_path_buf(temp.path().to_path_buf()),

--- a/crates/ironclaw_host_runtime/tests/support/host_runtime_harness.rs
+++ b/crates/ironclaw_host_runtime/tests/support/host_runtime_harness.rs
@@ -31,7 +31,7 @@ use ironclaw_filesystem::InMemoryBackend;
 use ironclaw_filesystem::LibSqlRootFilesystem;
 #[cfg(feature = "libsql")]
 use ironclaw_filesystem::ScopedFilesystem;
-use ironclaw_filesystem::{LocalFilesystem, RootFilesystem};
+use ironclaw_filesystem::{DiskFilesystem, RootFilesystem};
 use ironclaw_host_api::*;
 use ironclaw_host_runtime::{
     BuiltinObligationHandler, BuiltinObligationServices, CapabilitySurfaceVersion,
@@ -217,7 +217,7 @@ pub(crate) fn assert_completed_outcome(
 }
 
 pub(crate) type InMemoryHostRuntimeServices = HostRuntimeServices<
-    LocalFilesystem,
+    DiskFilesystem,
     InMemoryResourceGovernor,
     FilesystemProcessStore<InMemoryBackend>,
     FilesystemProcessResultStore<InMemoryBackend>,
@@ -404,7 +404,7 @@ pub(crate) fn approval_resume_fixture_with_manifest(
     let events = InMemoryEventSink::new();
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(manifest)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(ApprovalThenGrantAuthorizer),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -437,7 +437,7 @@ pub(crate) fn resume_runtime_with_empty_registry(
 ) -> DefaultHostRuntime {
     HostRuntimeServices::new(
         Arc::new(ExtensionRegistry::new()),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(ApprovalThenGrantAuthorizer),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -463,7 +463,7 @@ pub(crate) fn resume_runtime_with_policy(
 ) -> DefaultHostRuntime {
     HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_NETWORK_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(ApprovalThenGrantAuthorizer),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -1906,7 +1906,7 @@ pub(crate) fn assert_local_only_runtime_policy_rejected(
 ) {
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::in_memory_backed_process_services(),
@@ -2152,7 +2152,7 @@ pub(crate) async fn filesystem_with_wasm_component(
     extension_id: &str,
     module_path: &str,
     wasm_bytes: &[u8],
-) -> LocalFilesystem {
+) -> DiskFilesystem {
     let fs = mounted_empty_extension_root();
     let path =
         VirtualPath::new(format!("/system/extensions/{extension_id}/{module_path}")).unwrap();
@@ -2160,9 +2160,9 @@ pub(crate) async fn filesystem_with_wasm_component(
     fs
 }
 
-pub(crate) fn mounted_empty_extension_root() -> LocalFilesystem {
+pub(crate) fn mounted_empty_extension_root() -> DiskFilesystem {
     let storage = tempfile::tempdir().unwrap().keep();
-    let mut fs = LocalFilesystem::new();
+    let mut fs = DiskFilesystem::new();
     fs.mount_local(
         VirtualPath::new("/system/extensions").unwrap(),
         HostPath::from_path_buf(storage),

--- a/crates/ironclaw_host_runtime/tests/support/trace_commons_dispatch.rs
+++ b/crates/ironclaw_host_runtime/tests/support/trace_commons_dispatch.rs
@@ -25,7 +25,7 @@ use axum::{Router, extract::State, routing::post};
 use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64_STANDARD};
 use ironclaw_authorization::GrantAuthorizer;
 use ironclaw_extensions::ExtensionRegistry;
-use ironclaw_filesystem::LocalFilesystem;
+use ironclaw_filesystem::DiskFilesystem;
 use ironclaw_host_api::{
     runtime_policy::{
         ApprovalPolicy, AuditMode, DeploymentMode, EffectiveRuntimePolicy, FilesystemBackendKind,
@@ -324,7 +324,7 @@ pub fn runtime() -> impl HostRuntime {
     ));
     HostRuntimeServices::new(
         Arc::new(registry()),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::ProcessServices::in_memory(),

--- a/crates/ironclaw_host_runtime/tests/tool_surface_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/tool_surface_contract.rs
@@ -1,3 +1,4 @@
+// arch-exempt: large_file, mechanical LocalFilesystem->DiskFilesystem Bucket-2 rename (arch-simplification §4.4), no logic change, plan #6168
 mod support;
 
 use support::legacy_capability_fixture_to_v2_with_schema_suffix as legacy_capability_fixture_to_v2;
@@ -18,7 +19,7 @@ use ironclaw_extensions::{
     CapabilityVisibility, ExtensionManifest, ExtensionPackage, ExtensionRegistry, ManifestSource,
 };
 use ironclaw_filesystem::{
-    DirEntry, FileStat, FileType, FilesystemError, FilesystemOperation, LocalFilesystem,
+    DirEntry, DiskFilesystem, FileStat, FileType, FilesystemError, FilesystemOperation,
     RootFilesystem,
 };
 use ironclaw_host_api::*;
@@ -1866,7 +1867,7 @@ fn hot_catalog_fixture(
     input_schema: Option<&str>,
     output_schema: &str,
     prompt_doc: &str,
-) -> (tempfile::TempDir, LocalFilesystem, ExtensionRegistry) {
+) -> (tempfile::TempDir, DiskFilesystem, ExtensionRegistry) {
     hot_catalog_fixture_with_prompt_bytes(input_schema, output_schema, prompt_doc.as_bytes())
 }
 
@@ -1874,7 +1875,7 @@ fn hot_catalog_fixture_with_prompt_bytes(
     input_schema: Option<&str>,
     output_schema: &str,
     prompt_doc: &[u8],
-) -> (tempfile::TempDir, LocalFilesystem, ExtensionRegistry) {
+) -> (tempfile::TempDir, DiskFilesystem, ExtensionRegistry) {
     let manifest = ExtensionManifest::parse(
         HOT_CAPABILITY_MANIFEST,
         ManifestSource::InstalledLocal,
@@ -1889,7 +1890,7 @@ fn hot_catalog_fixture_with_manifest(
     output_schema: &str,
     prompt_doc: &[u8],
     manifest: ExtensionManifest,
-) -> (tempfile::TempDir, LocalFilesystem, ExtensionRegistry) {
+) -> (tempfile::TempDir, DiskFilesystem, ExtensionRegistry) {
     let storage = tempdir().unwrap();
     let extension_root = storage.path().join("echo");
     std::fs::create_dir_all(extension_root.join("schemas/echo")).unwrap();
@@ -1908,7 +1909,7 @@ fn hot_catalog_fixture_with_manifest(
     .unwrap();
     std::fs::write(extension_root.join("prompts/echo/say.md"), prompt_doc).unwrap();
 
-    let mut fs = LocalFilesystem::new();
+    let mut fs = DiskFilesystem::new();
     fs.mount_local(
         VirtualPath::new("/system/extensions").unwrap(),
         HostPath::from_path_buf(storage.path().to_path_buf()),

--- a/crates/ironclaw_loop_host/tests/filesystem_checkpoint_state_contract.rs
+++ b/crates/ironclaw_loop_host/tests/filesystem_checkpoint_state_contract.rs
@@ -1,12 +1,12 @@
 //! Contract tests for [`FilesystemCheckpointStateStore`] against a
-//! [`ScopedFilesystem`] over [`LocalFilesystem`].
+//! [`ScopedFilesystem`] over [`DiskFilesystem`].
 
 use std::sync::Arc;
 
 use async_trait::async_trait;
 use ironclaw_filesystem::{
-    BackendCapabilities, CasExpectation, DirEntry, Entry, FileStat, FilesystemError,
-    FilesystemOperation, InMemoryBackend, LocalFilesystem, RecordVersion, RootFilesystem,
+    BackendCapabilities, CasExpectation, DirEntry, DiskFilesystem, Entry, FileStat,
+    FilesystemError, FilesystemOperation, InMemoryBackend, RecordVersion, RootFilesystem,
     ScopedFilesystem, VersionedEntry,
 };
 use ironclaw_host_api::{
@@ -21,9 +21,9 @@ use ironclaw_turns::{
     run_profile::LoopCheckpointStateRef,
 };
 
-fn engine_filesystem() -> LocalFilesystem {
+fn engine_filesystem() -> DiskFilesystem {
     let storage = tempfile::tempdir().unwrap().keep();
-    let mut fs = LocalFilesystem::new();
+    let mut fs = DiskFilesystem::new();
     fs.mount_local(
         VirtualPath::new("/engine").unwrap(),
         HostPath::from_path_buf(storage),

--- a/crates/ironclaw_outbound/src/filesystem_store.rs
+++ b/crates/ironclaw_outbound/src/filesystem_store.rs
@@ -1,3 +1,4 @@
+// arch-exempt: large_file, mechanical LocalFilesystem->DiskFilesystem Bucket-2 rename (arch-simplification §4.4), no logic change, plan #6168
 //! Filesystem-backed [`OutboundStateStore`] implementation.
 //!
 //! Persists outbound metadata under a fixed [`ScopedPath`] tree rooted at the
@@ -171,7 +172,7 @@ where
     /// Write `entry` with the given CAS expectation, falling back to a
     /// metadata-stripped opaque write + `CasExpectation::Any` for backends
     /// that reject record-shape entries or non-`Any` CAS (e.g.
-    /// `LocalFilesystem`). Mirrors
+    /// `DiskFilesystem`). Mirrors
     /// [`ironclaw_processes::filesystem_store::put_with_byte_fallback`] so
     /// every byte-only mount in the workspace stays writeable through the
     /// new filesystem stores.
@@ -358,12 +359,12 @@ where
     /// same path will overwrite them.
     ///
     /// Note on `put_with_byte_fallback`: when the underlying mount is a
-    /// `LocalFilesystem`, the fallback leg strips the CAS expectation and
+    /// `DiskFilesystem`, the fallback leg strips the CAS expectation and
     /// retries with `CasExpectation::Any`. That means the versioned-CAS
     /// guarantee is not available for local-filesystem mounts; concurrent
     /// writes on that backend still risk last-write-wins. This is accepted
     /// because (a) local-filesystem mounts are dev/test only and (b) the
-    /// `LocalFilesystem` has no version-tracking sidecar yet. The fallback
+    /// `DiskFilesystem` has no version-tracking sidecar yet. The fallback
     /// is kept to avoid breaking those mounts entirely; production
     /// (libSQL/Postgres) backends honour the CAS expectation.
     async fn retry_conv_idx(

--- a/crates/ironclaw_processes/src/filesystem_store.rs
+++ b/crates/ironclaw_processes/src/filesystem_store.rs
@@ -107,7 +107,7 @@ where
 
     /// Declare the indexed-projection fields on the per-owner `records/`
     /// prefix so `records_for_scope` can use a native `query` filter.
-    /// Tolerates `Unsupported` for byte-only backends (e.g. LocalFilesystem)
+    /// Tolerates `Unsupported` for byte-only backends (e.g. DiskFilesystem)
     /// so the existing list+get fallback path is still reachable.
     async fn ensure_indexes(&self, scope: &ResourceScope) -> Result<(), ProcessError> {
         let prefix = process_records_root(scope)?;
@@ -163,7 +163,7 @@ where
     /// and try again until either the CAS succeeds or
     /// [`MAX_CAS_RETRIES`] is exhausted.
     ///
-    /// Backends without versioning (LocalFilesystem) return version `0`
+    /// Backends without versioning (DiskFilesystem) return version `0`
     /// for every read and reject `CasExpectation::Version` with
     /// `Unsupported`; for those, [`put_with_byte_fallback`] falls
     /// through to `CasExpectation::Any` so the existing single-instance
@@ -328,7 +328,7 @@ where
         // produce the right rows. The post-query `same_scope_owner`
         // check guards the remaining sub-scope (agent/project/mission/
         // thread) axes that are not in the index spec yet. Backends
-        // without index support (LocalFilesystem) return `Unsupported`
+        // without index support (DiskFilesystem) return `Unsupported`
         // and we fall back to the legacy list+get scan.
         self.ensure_indexes(scope).await?;
         let filter = Filter::And(vec![
@@ -363,7 +363,7 @@ where
     F: RootFilesystem,
 {
     /// Legacy list+get scan used as the fallback for byte-only backends
-    /// (LocalFilesystem) that cannot serve `query` over indexed
+    /// (DiskFilesystem) that cannot serve `query` over indexed
     /// projections. Production deployments on libSQL / Postgres / the
     /// in-memory backend take the indexed path in [`records_for_scope`].
     async fn records_for_scope_via_list(
@@ -791,7 +791,7 @@ fn process_status_label(status: ProcessStatus) -> &'static str {
 
 /// `put` with a fallback to an opaque (byte-only) entry on `Unsupported`.
 ///
-/// Backends that don't yet implement records (LocalFilesystem with no
+/// Backends that don't yet implement records (DiskFilesystem with no
 /// sidecar metadata) reject `kind = Some(_)` or any non-`Any` CAS
 /// expectation. We try the indexed write first so SQL and in-memory
 /// backends get the projection, then retry with the same body stripped

--- a/crates/ironclaw_processes/tests/process_services_contract.rs
+++ b/crates/ironclaw_processes/tests/process_services_contract.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use async_trait::async_trait;
-use ironclaw_filesystem::{InMemoryBackend, LocalFilesystem, RootFilesystem, ScopedFilesystem};
+use ironclaw_filesystem::{DiskFilesystem, InMemoryBackend, RootFilesystem, ScopedFilesystem};
 use ironclaw_host_api::*;
 use ironclaw_processes::*;
 use serde_json::json;
@@ -269,9 +269,9 @@ fn process_start(
     }
 }
 
-fn engine_filesystem() -> Arc<ScopedFilesystem<LocalFilesystem>> {
+fn engine_filesystem() -> Arc<ScopedFilesystem<DiskFilesystem>> {
     let storage = tempfile::tempdir().unwrap().keep();
-    let mut fs = LocalFilesystem::new();
+    let mut fs = DiskFilesystem::new();
     fs.mount_local(
         VirtualPath::new("/engine").unwrap(),
         HostPath::from_path_buf(storage),

--- a/crates/ironclaw_processes/tests/process_store_contract.rs
+++ b/crates/ironclaw_processes/tests/process_store_contract.rs
@@ -11,8 +11,8 @@ use std::{
 use async_trait::async_trait;
 use ironclaw_events::{InMemoryEventSink, RuntimeEventKind};
 use ironclaw_filesystem::{
-    CasExpectation, DirEntry, Entry, FileStat, FilesystemError, FilesystemOperation,
-    InMemoryBackend, LocalFilesystem, RecordVersion, RootFilesystem, ScopedFilesystem,
+    CasExpectation, DirEntry, DiskFilesystem, Entry, FileStat, FilesystemError,
+    FilesystemOperation, InMemoryBackend, RecordVersion, RootFilesystem, ScopedFilesystem,
 };
 use ironclaw_host_api::*;
 use ironclaw_processes::*;
@@ -2153,7 +2153,7 @@ impl RootFilesystem for BackendErrorFilesystem {
     // After the PR #3666 fix that breaks the put/write_file recursion, the
     // trait's default `get` is `Unsupported`. A test backend that wants to
     // fault-inject through the unified read path has to override `get`
-    // explicitly — same shape that `LocalFilesystem` adopts in its native
+    // explicitly — same shape that `DiskFilesystem` adopts in its native
     // impl. Mirroring the same fault here keeps the consumer test
     // exercising the "backend error mentions not_found" propagation.
     async fn get(
@@ -2649,14 +2649,14 @@ fn stored_process_owner_root(scope: &ResourceScope) -> String {
     base
 }
 
-/// Build a `Arc<ScopedFilesystem<LocalFilesystem>>` over a fresh tempdir
+/// Build a `Arc<ScopedFilesystem<DiskFilesystem>>` over a fresh tempdir
 /// mounted at `/engine`, with the `/processes` alias resolving to the
 /// default tenant1/user1 target. Tests that need a different mount
 /// target (e.g. cross-tenant isolation tests) construct a
 /// `ScopedFilesystem` directly with their own `MountView`.
-fn engine_filesystem() -> Arc<ScopedFilesystem<LocalFilesystem>> {
+fn engine_filesystem() -> Arc<ScopedFilesystem<DiskFilesystem>> {
     let storage = tempfile::tempdir().unwrap().keep();
-    let mut fs = LocalFilesystem::new();
+    let mut fs = DiskFilesystem::new();
     fs.mount_local(
         VirtualPath::new("/engine").unwrap(),
         HostPath::from_path_buf(storage),

--- a/crates/ironclaw_reborn_composition/Cargo.toml
+++ b/crates/ironclaw_reborn_composition/Cargo.toml
@@ -205,6 +205,8 @@ ironclaw_authorization = { path = "../ironclaw_authorization", features = ["test
 ironclaw_processes = { path = "../ironclaw_processes", features = ["test-support"] }
 # Enables the in-memory-backed run-state/approval store constructors for tests only.
 ironclaw_run_state = { path = "../ironclaw_run_state", features = ["test-support"] }
+# Enables the in-memory-backed budget-gate store constructor for tests only.
+ironclaw_resources = { path = "../ironclaw_resources", features = ["test-support"] }
 http = "1"
 http-body-util = "0.1"
 # Admin-user-management e2e test drives the composed app with a real session

--- a/crates/ironclaw_reborn_composition/src/extension_host/bundled_skills.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/bundled_skills.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 use ironclaw_filesystem::{
-    CasExpectation, Entry, FileType, FilesystemError, LocalFilesystem, RootFilesystem,
+    CasExpectation, DiskFilesystem, Entry, FileType, FilesystemError, RootFilesystem,
 };
 use ironclaw_host_api::{HostPath, VirtualPath};
 use ironclaw_loop_host::SkillFilePath;
@@ -125,9 +125,9 @@ fn embedded_reborn_skill_bundles() -> Result<Vec<EmbeddedRebornSkillBundle>, Reb
 
 fn local_dev_storage_filesystem(
     local_dev_storage_root: &Path,
-) -> Result<LocalFilesystem, RebornBuildError> {
+) -> Result<DiskFilesystem, RebornBuildError> {
     let storage_root = prepare_local_dev_storage_root(local_dev_storage_root)?;
-    let mut filesystem = LocalFilesystem::new();
+    let mut filesystem = DiskFilesystem::new();
     filesystem
         .mount_local(
             VirtualPath::new("/projects")?,

--- a/crates/ironclaw_reborn_composition/src/extension_host/extension_lifecycle.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/extension_lifecycle.rs
@@ -2474,7 +2474,7 @@ mod tests {
         SharedExtensionRegistry,
     };
     use ironclaw_filesystem::{
-        DirEntry, FileStat, FilesystemError, FilesystemOperation, LocalFilesystem,
+        DirEntry, DiskFilesystem, FileStat, FilesystemError, FilesystemOperation,
     };
     use ironclaw_host_api::{
         AgentId, CapabilityId, ExtensionLifecycleOperation, HostPath, HostPortCatalog,
@@ -4836,7 +4836,7 @@ output_schema_ref = "schemas/run.output.json"
         );
         let installation_store_trait: Arc<dyn ExtensionInstallationStore> =
             installation_store.clone();
-        let filesystem: Arc<dyn RootFilesystem> = Arc::new(LocalFilesystem::new());
+        let filesystem: Arc<dyn RootFilesystem> = Arc::new(DiskFilesystem::new());
 
         restore_extension_lifecycle_state(
             &AvailableExtensionCatalog::from_packages(Vec::new()),
@@ -5135,7 +5135,7 @@ output_schema_ref = "schemas/run.output.json"
             Arc::clone(&restored_trust_policy),
         );
         let installation_store: Arc<dyn ExtensionInstallationStore> = installation_store;
-        let filesystem: Arc<dyn RootFilesystem> = Arc::new(LocalFilesystem::new());
+        let filesystem: Arc<dyn RootFilesystem> = Arc::new(DiskFilesystem::new());
 
         let error = restore_extension_lifecycle_state(
             &catalog,
@@ -5838,7 +5838,7 @@ output_schema_ref = "schemas/run.output.json"
         let dir = tempfile::tempdir().expect("tempdir");
         let storage_root = dir.path().join("local-dev");
         std::fs::create_dir_all(storage_root.join("system/extensions")).expect("storage root");
-        let mut filesystem = LocalFilesystem::new();
+        let mut filesystem = DiskFilesystem::new();
         filesystem
             .mount_local(
                 VirtualPath::new("/system/extensions").expect("valid virtual path"),
@@ -7001,7 +7001,7 @@ output_schema_ref = "schemas/run.output.json"
         let storage_root = dir.path().join("local-dev");
         std::fs::create_dir_all(storage_root.join("system/extensions")).expect("storage root");
 
-        let mut filesystem = LocalFilesystem::new();
+        let mut filesystem = DiskFilesystem::new();
         filesystem
             .mount_local(
                 VirtualPath::new("/projects").expect("valid virtual path"),
@@ -7115,7 +7115,7 @@ output_schema_ref = "schemas/run.output.json"
         let storage_root = dir.path().join("local-dev");
         std::fs::create_dir_all(storage_root.join("system/extensions")).expect("storage root");
 
-        let mut filesystem = LocalFilesystem::new();
+        let mut filesystem = DiskFilesystem::new();
         filesystem
             .mount_local(
                 VirtualPath::new("/projects").expect("valid virtual path"),
@@ -7205,7 +7205,7 @@ output_schema_ref = "schemas/run.output.json"
         let storage_root = dir.path().join("local-dev");
         std::fs::create_dir_all(storage_root.join("system/extensions")).expect("storage root");
 
-        let mut filesystem = LocalFilesystem::new();
+        let mut filesystem = DiskFilesystem::new();
         filesystem
             .mount_local(
                 VirtualPath::new("/projects").expect("valid virtual path"),
@@ -7336,7 +7336,7 @@ output_schema_ref = "schemas/run.output.json"
         let dir = tempfile::tempdir().expect("tempdir");
         let storage_root = dir.path().join("local-dev");
         std::fs::create_dir_all(storage_root.join("system/extensions")).expect("storage root");
-        let mut filesystem = LocalFilesystem::new();
+        let mut filesystem = DiskFilesystem::new();
         filesystem
             .mount_local(
                 VirtualPath::new("/projects").expect("valid virtual path"),
@@ -7380,7 +7380,7 @@ output_schema_ref = "schemas/run.output.json"
         let dir = tempfile::tempdir().expect("tempdir");
         let storage_root = dir.path().join("local-dev");
         std::fs::create_dir_all(storage_root.join("system/extensions")).expect("storage root");
-        let mut filesystem = LocalFilesystem::new();
+        let mut filesystem = DiskFilesystem::new();
         filesystem
             .mount_local(
                 VirtualPath::new("/projects").expect("valid virtual path"),

--- a/crates/ironclaw_reborn_composition/src/extension_host/lifecycle.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/lifecycle.rs
@@ -2,7 +2,7 @@ use std::{path::PathBuf, sync::Arc};
 
 use crate::local_dev_mounts::scoped_skill_management_mount_view;
 use async_trait::async_trait;
-use ironclaw_filesystem::{LocalFilesystem, RootFilesystem};
+use ironclaw_filesystem::{DiskFilesystem, RootFilesystem};
 use ironclaw_host_api::{
     HostApiError, HostPath, InvocationId, MountView, ResourceScope, RuntimeHttpEgress, UserId,
     VirtualPath,
@@ -195,7 +195,7 @@ pub(crate) fn build_existing_local_dev_skill_management_port(
         });
     }
 
-    let mut filesystem = LocalFilesystem::new();
+    let mut filesystem = DiskFilesystem::new();
     filesystem.mount_local(
         VirtualPath::new("/projects")?,
         HostPath::from_path_buf(local_dev_storage_root),
@@ -667,7 +667,7 @@ fn map_local_skill_management_error(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ironclaw_filesystem::LocalFilesystem;
+    use ironclaw_filesystem::DiskFilesystem;
     use ironclaw_host_api::{
         AgentId, HostPath, MountAlias, MountGrant, MountPermissions, ProjectId, TenantId,
         VirtualPath,
@@ -810,7 +810,7 @@ mod tests {
         )
         .expect("system skill");
 
-        let mut filesystem = LocalFilesystem::new();
+        let mut filesystem = DiskFilesystem::new();
         filesystem
             .mount_local(
                 VirtualPath::new("/projects").expect("valid virtual path"),
@@ -981,7 +981,7 @@ mod tests {
         let storage_root = dir.path().join("local-dev");
         std::fs::create_dir_all(&storage_root).expect("storage root");
 
-        let mut filesystem = LocalFilesystem::new();
+        let mut filesystem = DiskFilesystem::new();
         filesystem
             .mount_local(
                 VirtualPath::new("/projects").expect("valid virtual path"),

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -46,7 +46,7 @@ use ironclaw_filesystem::{
     BackendCapabilities, BackendId, BackendKind, CompositeRootFilesystem, ContentKind, IndexPolicy,
     MountDescriptor, RootFilesystem, StorageClass,
 };
-use ironclaw_filesystem::{LocalFilesystem, ScopedFilesystem};
+use ironclaw_filesystem::{DiskFilesystem, ScopedFilesystem};
 #[cfg(feature = "test-support")]
 use ironclaw_first_party_extensions::{
     EXA_MCP_HOST, NETWORK_EGRESS_LIMIT, WEB_ACCESS_EXTENSION_ID, WEB_GET_CONTENT_CAPABILITY_ID,
@@ -3168,8 +3168,8 @@ fn local_dev_project_filesystem(
     root: &Path,
     workspace_root: &Path,
     host_home_root: Option<&LocalDevHostHomeRoot>,
-) -> Result<LocalFilesystem, RebornBuildError> {
-    let mut filesystem = LocalFilesystem::new();
+) -> Result<DiskFilesystem, RebornBuildError> {
+    let mut filesystem = DiskFilesystem::new();
     filesystem.mount_local(
         VirtualPath::new("/projects")?,
         HostPath::from_path_buf(root.to_path_buf()),
@@ -3457,13 +3457,13 @@ where
 
 fn mount_local_dev_project_roots(
     root: &mut CompositeRootFilesystem,
-    local: Arc<LocalFilesystem>,
+    local: Arc<DiskFilesystem>,
 ) -> Result<(), RebornBuildError> {
     root.mount(
         local_dev_mount_descriptor(
             "/projects",
             "local-dev-project-files",
-            BackendKind::LocalFilesystem,
+            BackendKind::DiskFilesystem,
             StorageClass::FileContent,
             ContentKind::ProjectFile,
             IndexPolicy::NotIndexed,
@@ -3475,7 +3475,7 @@ fn mount_local_dev_project_roots(
         local_dev_mount_descriptor(
             "/system/extensions",
             "local-dev-system-extensions",
-            BackendKind::LocalFilesystem,
+            BackendKind::DiskFilesystem,
             StorageClass::FileContent,
             ContentKind::ExtensionPackage,
             IndexPolicy::NotIndexed,
@@ -6265,7 +6265,7 @@ mod tests {
     fn attach_hosted_mcp_runtime_skips_services_without_http_egress() {
         let services = HostRuntimeServices::new(
             Arc::new(ExtensionRegistry::new()),
-            Arc::new(LocalFilesystem::new()),
+            Arc::new(DiskFilesystem::new()),
             Arc::new(InMemoryResourceGovernor::new()),
             Arc::new(GrantAuthorizer::new()),
             ProcessServices::in_memory(),
@@ -7462,7 +7462,7 @@ mod tests {
     fn attach_hosted_mcp_runtime_skips_services_without_runtime_http_egress() {
         let services = HostRuntimeServices::new(
             Arc::new(ExtensionRegistry::new()),
-            Arc::new(LocalFilesystem::new()),
+            Arc::new(DiskFilesystem::new()),
             Arc::new(InMemoryResourceGovernor::new()),
             Arc::new(GrantAuthorizer::new()),
             ProcessServices::in_memory(),

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -99,10 +99,14 @@ use ironclaw_product_workflow::{
 };
 use ironclaw_projects::ProjectRepository;
 use ironclaw_resources::InMemoryResourceGovernor;
+// `FilesystemBudgetGateStore` backs both the durable and the no-durable
+// (`<InMemoryBackend>`) budget-gate wiring — the deleted `InMemoryBudgetGateStore`
+// had no cfg gate either — so its import must be unconditional, not gated behind
+// the durable-backend features (arch-simplification §4.3).
+use ironclaw_resources::FilesystemBudgetGateStore;
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 use ironclaw_resources::{
-    BroadcastBudgetEventSink, BudgetGateStore, FilesystemBudgetGateStore,
-    FilesystemResourceGovernor, ResourceGovernor,
+    BroadcastBudgetEventSink, BudgetGateStore, FilesystemResourceGovernor, ResourceGovernor,
 };
 // Used by both the durable (`<LocalDevRootFilesystem>`) and no-durable
 // (`<InMemoryBackend>`) run-state/approval aliases + builders, so the import is
@@ -2651,8 +2655,14 @@ async fn build_local_dev_store_graph(
         in_memory_budget_event_sink,
         broadcast_budget_event_sink,
     } = build_budget_sinks();
-    let budget_gate_store: Arc<dyn ironclaw_resources::BudgetGateStore> =
-        Arc::new(ironclaw_resources::InMemoryBudgetGateStore::new());
+    // §4.3: the deleted `InMemoryBudgetGateStore` is replaced by the one
+    // production `FilesystemBudgetGateStore` over an in-memory backend. Unlike
+    // the old scope-ignoring HashMap, this scopes each gate under the caller's
+    // tenant/user mount — strictly more correct for multi-tenant no-durable
+    // deployments — while remaining volatile (fresh `InMemoryBackend`).
+    let budget_gate_store: Arc<dyn ironclaw_resources::BudgetGateStore> = Arc::new(
+        FilesystemBudgetGateStore::new(crate::wrap_scoped(Arc::new(InMemoryBackend::new()))),
+    );
     let resource_governor: Arc<LocalDevResourceGovernor> =
         Arc::new(InMemoryResourceGovernor::new().with_event_sink(Arc::clone(&budget_event_sink)));
     let skill_mounts =

--- a/crates/ironclaw_reborn_composition/src/observability/budget.rs
+++ b/crates/ironclaw_reborn_composition/src/observability/budget.rs
@@ -87,9 +87,8 @@ mod tests {
     use super::*;
     use ironclaw_host_api::{InvocationId, ResourceEstimate, ResourceScope, TenantId, UserId};
     use ironclaw_loop_host::ZeroCostTable;
-    use ironclaw_resources::{
-        InMemoryBudgetEventSink, InMemoryBudgetGateStore, InMemoryResourceGovernor, ResourceAccount,
-    };
+    use ironclaw_resources::test_support::in_memory_backed_budget_gate_store;
+    use ironclaw_resources::{InMemoryBudgetEventSink, InMemoryResourceGovernor, ResourceAccount};
     use rust_decimal_macros::dec;
 
     /// The helper installs the compiled-default $5 user cap on the
@@ -100,7 +99,7 @@ mod tests {
     #[tokio::test]
     async fn seeds_compiled_default_user_cap_on_first_touch() {
         let governor: Arc<dyn ResourceGovernor> = Arc::new(InMemoryResourceGovernor::new());
-        let gate_store: Arc<dyn BudgetGateStore> = Arc::new(InMemoryBudgetGateStore::new());
+        let gate_store: Arc<dyn BudgetGateStore> = Arc::new(in_memory_backed_budget_gate_store());
         let cost_table: Arc<dyn ModelCostTable> = Arc::new(ZeroCostTable);
         let event_sink: Arc<dyn BudgetEventSink> = Arc::new(InMemoryBudgetEventSink::new());
         let defaults = BudgetDefaults::compiled_defaults();

--- a/crates/ironclaw_reborn_composition/src/slack/slack_egress.rs
+++ b/crates/ironclaw_reborn_composition/src/slack/slack_egress.rs
@@ -332,7 +332,7 @@ mod tests {
     use async_trait::async_trait;
     use ironclaw_authorization::GrantAuthorizer;
     use ironclaw_extensions::ExtensionRegistry;
-    use ironclaw_filesystem::{InMemoryBackend, LocalFilesystem};
+    use ironclaw_filesystem::{DiskFilesystem, InMemoryBackend};
     use ironclaw_host_runtime::{CapabilitySurfaceVersion, HostRuntimeServices};
     use ironclaw_network::{
         NetworkHttpEgress, NetworkHttpError, NetworkHttpRequest, NetworkHttpResponse, NetworkUsage,
@@ -412,14 +412,14 @@ mod tests {
     }
 
     fn test_host_runtime_services() -> HostRuntimeServices<
-        LocalFilesystem,
+        DiskFilesystem,
         InMemoryResourceGovernor,
         FilesystemProcessStore<InMemoryBackend>,
         FilesystemProcessResultStore<InMemoryBackend>,
     > {
         HostRuntimeServices::new(
             Arc::new(ExtensionRegistry::new()),
-            Arc::new(LocalFilesystem::new()),
+            Arc::new(DiskFilesystem::new()),
             Arc::new(InMemoryResourceGovernor::new()),
             Arc::new(GrantAuthorizer::new()),
             ironclaw_processes::in_memory_backed_process_services(),

--- a/crates/ironclaw_reborn_composition/src/slack/slack_host_beta.rs
+++ b/crates/ironclaw_reborn_composition/src/slack/slack_host_beta.rs
@@ -1345,7 +1345,7 @@ mod tests {
     use http_body_util::BodyExt;
     use ironclaw_authorization::GrantAuthorizer;
     use ironclaw_extensions::ExtensionRegistry;
-    use ironclaw_filesystem::{InMemoryBackend, LocalFilesystem};
+    use ironclaw_filesystem::{DiskFilesystem, InMemoryBackend};
     use ironclaw_host_runtime::{
         CapabilitySurfaceVersion, HostRuntimeHttpEgressPort, HostRuntimeServices,
     };
@@ -4042,14 +4042,14 @@ mod tests {
     }
 
     fn test_host_runtime_services() -> HostRuntimeServices<
-        LocalFilesystem,
+        DiskFilesystem,
         InMemoryResourceGovernor,
         FilesystemProcessStore<InMemoryBackend>,
         FilesystemProcessResultStore<InMemoryBackend>,
     > {
         HostRuntimeServices::new(
             Arc::new(ExtensionRegistry::new()),
-            Arc::new(LocalFilesystem::new()),
+            Arc::new(DiskFilesystem::new()),
             Arc::new(InMemoryResourceGovernor::new()),
             Arc::new(GrantAuthorizer::new()),
             ironclaw_processes::in_memory_backed_process_services(),

--- a/crates/ironclaw_reborn_composition/src/webui/facade.rs
+++ b/crates/ironclaw_reborn_composition/src/webui/facade.rs
@@ -1074,7 +1074,7 @@ mod tests {
         ExtensionManifest, ExtensionManifestRecord, ExtensionPackage, ExtensionRegistry,
         InMemoryExtensionInstallationStore, ManifestSource,
     };
-    use ironclaw_filesystem::LocalFilesystem;
+    use ironclaw_filesystem::DiskFilesystem;
     use ironclaw_host_api::{
         ExtensionId, HostPath, HostPortCatalog, MountAlias, MountGrant, MountPermissions,
         MountView, TenantId, UserId, VirtualPath,
@@ -1212,7 +1212,7 @@ mod tests {
             .expect("trust policy"),
         );
         let port = Arc::new(RebornLocalExtensionManagementPort::new(
-            Arc::new(LocalFilesystem::new()),
+            Arc::new(DiskFilesystem::new()),
             AvailableExtensionCatalog::from_packages(Vec::new()),
             installation_store,
             Arc::new(Mutex::new(ExtensionLifecycleService::new(
@@ -1515,7 +1515,7 @@ mod tests {
         let storage_root = dir.path().join("local-dev");
         std::fs::create_dir_all(&storage_root).expect("storage root");
 
-        let mut filesystem = LocalFilesystem::new();
+        let mut filesystem = DiskFilesystem::new();
         filesystem
             .mount_local(
                 VirtualPath::new("/projects").expect("valid virtual path"),
@@ -1582,7 +1582,7 @@ mod tests {
         let storage_root = dir.path().join("local-dev");
         std::fs::create_dir_all(&storage_root).expect("storage root");
 
-        let mut filesystem = LocalFilesystem::new();
+        let mut filesystem = DiskFilesystem::new();
         filesystem
             .mount_local(
                 VirtualPath::new("/projects").expect("valid virtual path"),
@@ -1628,7 +1628,7 @@ mod tests {
         )
         .expect("system skill");
 
-        let mut filesystem = LocalFilesystem::new();
+        let mut filesystem = DiskFilesystem::new();
         filesystem
             .mount_local(
                 VirtualPath::new("/projects").expect("valid virtual path"),
@@ -1899,7 +1899,7 @@ output_schema_ref = "schemas/{capability_name}.output.json"
     }
 
     fn local_skills_facade(storage_root: &Path) -> LocalSkillsProductFacade {
-        let mut filesystem = LocalFilesystem::new();
+        let mut filesystem = DiskFilesystem::new();
         filesystem
             .mount_local(
                 VirtualPath::new("/projects").expect("valid virtual path"),

--- a/crates/ironclaw_resources/Cargo.toml
+++ b/crates/ironclaw_resources/Cargo.toml
@@ -19,7 +19,7 @@ default = []
 libsql = []
 postgres = []
 # Exposes `test_support` in-memory-backed store constructors for downstream
-# crates' tests. Ships zero bytes in production binaries.
+# crates' tests. Disabled by default; enable only from [dev-dependencies].
 test-support = []
 
 [dependencies]

--- a/crates/ironclaw_resources/Cargo.toml
+++ b/crates/ironclaw_resources/Cargo.toml
@@ -18,6 +18,9 @@ layer = "kernel"
 default = []
 libsql = []
 postgres = []
+# Exposes `test_support` in-memory-backed store constructors for downstream
+# crates' tests. Ships zero bytes in production binaries.
+test-support = []
 
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }

--- a/crates/ironclaw_resources/src/gate.rs
+++ b/crates/ironclaw_resources/src/gate.rs
@@ -18,8 +18,6 @@
 use chrono::{DateTime, Utc};
 use ironclaw_host_api::{ResourceScope, UserId};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
-use std::sync::Mutex;
 
 use crate::{ResourceApprovalNeeded, ResourceLimits};
 
@@ -194,12 +192,14 @@ impl crate::cas_snapshot::StorageError for BudgetGateError {
 ///
 /// Every operation takes the caller's [`ResourceScope`] so a single
 /// shared store instance can naturally route work to the right tenant
-/// path under a multi-tenant deployment. The current
-/// [`InMemoryBudgetGateStore`] is single-snapshot and ignores scope
-/// (suitable for tests / single-tenant local-dev), while the
-/// filesystem-backed store uses the scope to write under the correct
-/// tenant's mount view (review feedback Thermo-Nuclear #2: scope at the
-/// store-operation boundary, not at construction).
+/// path under a multi-tenant deployment. The sole implementation,
+/// [`FilesystemBudgetGateStore`](crate::FilesystemBudgetGateStore), uses
+/// that scope to write under the correct tenant's mount view (review
+/// feedback Thermo-Nuclear #2: scope at the store-operation boundary, not
+/// at construction). Over an [`InMemoryBackend`](ironclaw_filesystem::InMemoryBackend)
+/// it is the volatile store tests and local-dev composition use — the
+/// hand-written `InMemoryBudgetGateStore` was deleted in favor of this one
+/// production store per arch-simplification §4.3.
 pub trait BudgetGateStore: Send + Sync + std::fmt::Debug {
     fn open(&self, scope: &ResourceScope, gate: BudgetApprovalGate) -> Result<(), BudgetGateError>;
     fn resolve(
@@ -223,101 +223,6 @@ pub trait BudgetGateStore: Send + Sync + std::fmt::Debug {
         &self,
         scope: &ResourceScope,
     ) -> Result<Vec<BudgetApprovalGate>, BudgetGateError>;
-}
-
-/// In-memory store used by tests and the local-dev runtime. Production
-/// composition can swap in a filesystem-backed store mirroring the
-/// resource-governor snapshot shape (deferred to a follow-up).
-#[derive(Debug, Default)]
-pub struct InMemoryBudgetGateStore {
-    gates: Mutex<HashMap<BudgetGateId, BudgetApprovalGate>>,
-}
-
-impl InMemoryBudgetGateStore {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    fn lock(&self) -> std::sync::MutexGuard<'_, HashMap<BudgetGateId, BudgetApprovalGate>> {
-        self.gates
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-    }
-}
-
-impl BudgetGateStore for InMemoryBudgetGateStore {
-    fn open(
-        &self,
-        _scope: &ResourceScope,
-        gate: BudgetApprovalGate,
-    ) -> Result<(), BudgetGateError> {
-        let mut guard = self.lock();
-        guard.insert(gate.id, gate);
-        Ok(())
-    }
-
-    fn resolve(
-        &self,
-        _scope: &ResourceScope,
-        id: BudgetGateId,
-        outcome: BudgetGateOutcome,
-        at: DateTime<Utc>,
-    ) -> Result<BudgetApprovalGate, BudgetGateError> {
-        let mut guard = self.lock();
-        let gate = guard.get_mut(&id).ok_or(BudgetGateError::Unknown { id })?;
-        if gate.status.is_terminal() {
-            return Err(BudgetGateError::AlreadyResolved { id });
-        }
-        gate.status = match outcome {
-            BudgetGateOutcome::Approve {
-                increased_limit,
-                by,
-            } => BudgetGateStatus::Approved {
-                increased_limit,
-                by,
-                at,
-            },
-            BudgetGateOutcome::Cancel { by } => BudgetGateStatus::Cancelled { by, at },
-        };
-        Ok(gate.clone())
-    }
-
-    fn expire_pending_older_than(
-        &self,
-        _scope: &ResourceScope,
-        cutoff: DateTime<Utc>,
-    ) -> Result<Vec<BudgetApprovalGate>, BudgetGateError> {
-        let mut guard = self.lock();
-        let mut expired = Vec::new();
-        for gate in guard.values_mut() {
-            if matches!(gate.status, BudgetGateStatus::Pending) && gate.expires_at <= cutoff {
-                gate.status = BudgetGateStatus::Expired { at: cutoff };
-                expired.push(gate.clone());
-            }
-        }
-        Ok(expired)
-    }
-
-    fn get(
-        &self,
-        _scope: &ResourceScope,
-        id: BudgetGateId,
-    ) -> Result<Option<BudgetApprovalGate>, BudgetGateError> {
-        let guard = self.lock();
-        Ok(guard.get(&id).cloned())
-    }
-
-    fn list_pending(
-        &self,
-        _scope: &ResourceScope,
-    ) -> Result<Vec<BudgetApprovalGate>, BudgetGateError> {
-        let guard = self.lock();
-        Ok(guard
-            .values()
-            .filter(|g| matches!(g.status, BudgetGateStatus::Pending))
-            .cloned()
-            .collect())
-    }
 }
 
 #[cfg(test)]
@@ -352,7 +257,7 @@ mod tests {
 
     #[test]
     fn open_then_get_returns_pending_gate() {
-        let store = InMemoryBudgetGateStore::new();
+        let store = crate::test_support::in_memory_backed_budget_gate_store();
         let scope = ResourceScope::system();
         let gate = sample_gate();
         let id = gate.id;
@@ -364,7 +269,7 @@ mod tests {
 
     #[test]
     fn approve_resolves_gate_with_increased_limit() {
-        let store = InMemoryBudgetGateStore::new();
+        let store = crate::test_support::in_memory_backed_budget_gate_store();
         let scope = ResourceScope::system();
         let gate = sample_gate();
         let id = gate.id;
@@ -512,7 +417,7 @@ mod tests {
 
     #[test]
     fn cancel_resolves_gate_as_cancelled() {
-        let store = InMemoryBudgetGateStore::new();
+        let store = crate::test_support::in_memory_backed_budget_gate_store();
         let scope = ResourceScope::system();
         let gate = sample_gate();
         let id = gate.id;
@@ -534,7 +439,7 @@ mod tests {
 
     #[test]
     fn second_resolve_fails_already_resolved() {
-        let store = InMemoryBudgetGateStore::new();
+        let store = crate::test_support::in_memory_backed_budget_gate_store();
         let scope = ResourceScope::system();
         let gate = sample_gate();
         let id = gate.id;
@@ -561,7 +466,7 @@ mod tests {
 
     #[test]
     fn resolve_unknown_gate_fails_with_unknown() {
-        let store = InMemoryBudgetGateStore::new();
+        let store = crate::test_support::in_memory_backed_budget_gate_store();
         let scope = ResourceScope::system();
         let user = UserId::new("alice").unwrap();
         let unknown_id = BudgetGateId::new();
@@ -578,7 +483,7 @@ mod tests {
 
     #[test]
     fn expire_pending_older_than_marks_stale_gates_expired() {
-        let store = InMemoryBudgetGateStore::new();
+        let store = crate::test_support::in_memory_backed_budget_gate_store();
         let scope = ResourceScope::system();
         let mut gate = sample_gate();
         gate.expires_at = Utc::now() - chrono::Duration::hours(1);
@@ -592,7 +497,7 @@ mod tests {
 
     #[test]
     fn list_pending_excludes_resolved_gates() {
-        let store = InMemoryBudgetGateStore::new();
+        let store = crate::test_support::in_memory_backed_budget_gate_store();
         let scope = ResourceScope::system();
         let pending = sample_gate();
         let resolved = sample_gate();

--- a/crates/ironclaw_resources/src/lib.rs
+++ b/crates/ironclaw_resources/src/lib.rs
@@ -24,6 +24,9 @@ mod filesystem_governor;
 mod filesystem_store;
 mod gate;
 mod period;
+// arch-exempt: large_file, +test_support module decl for §4.3 budget-gate store consolidation (delete InMemoryBudgetGateStore), no logic change, plan #6168
+#[cfg(any(test, feature = "test-support"))]
+pub mod test_support;
 
 pub use event::{
     BroadcastBudgetEventSink, BudgetEvent, BudgetEventSink, CompositeBudgetEventSink,
@@ -33,7 +36,7 @@ pub use filesystem_governor::FilesystemResourceGovernor;
 pub use filesystem_store::{FilesystemBudgetGateStore, FilesystemResourceGovernorStore};
 pub use gate::{
     BudgetApprovalGate, BudgetGateError, BudgetGateId, BudgetGateOutcome, BudgetGateStatus,
-    BudgetGateStore, InMemoryBudgetGateStore,
+    BudgetGateStore,
 };
 pub use period::{
     BudgetPeriod, BudgetThresholds, BudgetThresholdsError, PeriodUnit, period_bounds,

--- a/crates/ironclaw_resources/src/test_support.rs
+++ b/crates/ironclaw_resources/src/test_support.rs
@@ -25,9 +25,9 @@
 //! composition keeps the default bounded retention via plain
 //! [`FilesystemBudgetGateStore::new`].
 //!
-//! Gated behind `#[cfg(any(test, feature = "test-support"))]` so nothing here
-//! ships in production binaries; downstream crates enable the `test-support`
-//! feature from their `[dev-dependencies]`.
+//! Gated behind `#[cfg(any(test, feature = "test-support"))]` and disabled by
+//! default. Downstream crates should enable `test-support` only from their
+//! `[dev-dependencies]`.
 
 use std::sync::Arc;
 

--- a/crates/ironclaw_resources/src/test_support.rs
+++ b/crates/ironclaw_resources/src/test_support.rs
@@ -1,0 +1,60 @@
+//! In-memory-backed budget-gate store constructor for tests.
+//!
+//! The Reborn architecture-simplification note
+//! (`docs/reborn/2026-07-17-architecture-simplification-dto-dyn-local.md`, §4.3)
+//! replaces hand-written `InMemory*Store` parallel implementations with the one
+//! production `Filesystem*Store<F>` exercised over an in-memory backend:
+//! "in-memory" stops being a store and becomes a filesystem backend
+//! (`InMemoryBackend`). This helper wires that seam for the budget-gate store —
+//! a `ScopedFilesystem<InMemoryBackend>` mounting `/resources` (the alias the
+//! store persists its `/resources/budget-gates.json` snapshot under) — so tests
+//! instantiate the same store a deployment runs.
+//!
+//! Note on isolation: [`FilesystemBudgetGateStore`] serializes a single snapshot
+//! file per `/resources` mount, keyed internally by `BudgetGateId`; it carries no
+//! scope in the path, so tenant/user isolation lives entirely in the
+//! `MountView`. The single fixed mount below therefore behaves exactly like the
+//! deleted `InMemoryBudgetGateStore` did — one shared snapshot regardless of the
+//! per-op `ResourceScope` — which is what the single-scope gate-lifecycle tests
+//! (open/get/resolve/list/expire under one scope) need. Cross-tenant isolation is
+//! exercised by the per-tenant-mount tests in `filesystem_store.rs`.
+//!
+//! Terminal retention is disabled ([`with_terminal_retention(None)`]) so tests
+//! can inspect resolved/expired gates without a time window — matching the
+//! retain-forever semantics of the deleted in-memory store. Production
+//! composition keeps the default bounded retention via plain
+//! [`FilesystemBudgetGateStore::new`].
+//!
+//! Gated behind `#[cfg(any(test, feature = "test-support"))]` so nothing here
+//! ships in production binaries; downstream crates enable the `test-support`
+//! feature from their `[dev-dependencies]`.
+
+use std::sync::Arc;
+
+use ironclaw_filesystem::{InMemoryBackend, ScopedFilesystem};
+use ironclaw_host_api::{MountAlias, MountGrant, MountPermissions, MountView, VirtualPath};
+
+use crate::FilesystemBudgetGateStore;
+
+/// A fresh, volatile `ScopedFilesystem<InMemoryBackend>` mounting `/resources` —
+/// the in-memory backend seam the budget-gate store persists under.
+pub fn in_memory_backed_resources_filesystem() -> Arc<ScopedFilesystem<InMemoryBackend>> {
+    let mounts = MountView::new(vec![MountGrant::new(
+        MountAlias::new("/resources").expect("static valid mount alias"), // safety: test-support scaffolding, static literal
+        VirtualPath::new("/engine/resources").expect("static valid virtual path"), // safety: test-support scaffolding, static literal
+        MountPermissions::read_write_list_delete(),
+    )])
+    .expect("static valid resources mount view"); // safety: test-support scaffolding, static literal
+    Arc::new(ScopedFilesystem::with_fixed_view(
+        Arc::new(InMemoryBackend::new()),
+        mounts,
+    ))
+}
+
+/// The production budget-gate store over a fresh in-memory backend — the drop-in
+/// replacement for the deleted `InMemoryBudgetGateStore`. Terminal retention is
+/// disabled so tests can inspect resolved/expired gates.
+pub fn in_memory_backed_budget_gate_store() -> FilesystemBudgetGateStore<InMemoryBackend> {
+    FilesystemBudgetGateStore::new(in_memory_backed_resources_filesystem())
+        .with_terminal_retention(None)
+}

--- a/crates/ironclaw_resources/tests/resource_governor_contract.rs
+++ b/crates/ironclaw_resources/tests/resource_governor_contract.rs
@@ -1696,7 +1696,7 @@ async fn filesystem_resource_governor_fails_closed_then_recovers_after_delta_app
 /// supports versioned CAS and therefore never takes the
 /// `CasUnsupported` branch.
 ///
-/// `LocalFilesystem` is used here because it is the canonical byte-only
+/// `DiskFilesystem` is used here because it is the canonical byte-only
 /// `RootFilesystem`: its `put` impl rejects entries with
 /// `entry.kind.is_some()`, which `cas_update` maps to `CasUnsupported`.
 /// Mirrors `ironclaw_run_state`'s
@@ -1706,13 +1706,13 @@ async fn filesystem_resource_governor_fails_closed_then_recovers_after_delta_app
 /// the resources crate's CAS snapshot stores.
 #[tokio::test]
 async fn filesystem_resource_governor_store_fails_closed_on_byte_only_backend() {
-    use ironclaw_filesystem::{LocalFilesystem, ScopedFilesystem};
+    use ironclaw_filesystem::{DiskFilesystem, ScopedFilesystem};
     use ironclaw_host_api::{
         HostPath, MountAlias, MountGrant, MountPermissions, MountView, VirtualPath,
     };
 
     let dir = tempdir().expect("temp dir");
-    let mut local_fs = LocalFilesystem::new();
+    let mut local_fs = DiskFilesystem::new();
     local_fs
         .mount_local(
             VirtualPath::new("/tenants").expect("virtual root"),
@@ -1742,7 +1742,7 @@ async fn filesystem_resource_governor_store_fails_closed_on_byte_only_backend() 
 
     assert!(
         matches!(&err, ResourceError::Storage { reason } if reason.contains("compare-and-swap")),
-        "expected Storage(CasUnsupported) from byte-only LocalFilesystem but got {err:?}",
+        "expected Storage(CasUnsupported) from byte-only DiskFilesystem but got {err:?}",
     );
 }
 
@@ -1754,13 +1754,13 @@ async fn filesystem_resource_governor_store_fails_closed_on_byte_only_backend() 
 /// pending gate.
 #[tokio::test]
 async fn filesystem_budget_gate_store_fails_closed_on_byte_only_backend() {
-    use ironclaw_filesystem::{LocalFilesystem, ScopedFilesystem};
+    use ironclaw_filesystem::{DiskFilesystem, ScopedFilesystem};
     use ironclaw_host_api::{
         HostPath, MountAlias, MountGrant, MountPermissions, MountView, VirtualPath,
     };
 
     let dir = tempdir().expect("temp dir");
-    let mut local_fs = LocalFilesystem::new();
+    let mut local_fs = DiskFilesystem::new();
     local_fs
         .mount_local(
             VirtualPath::new("/tenants").expect("virtual root"),
@@ -1801,7 +1801,7 @@ async fn filesystem_budget_gate_store_fails_closed_on_byte_only_backend() {
     let err = store.open(&scope, gate).unwrap_err();
     assert!(
         matches!(&err, BudgetGateError::Storage { reason } if reason.contains("compare-and-swap")),
-        "expected Storage(CasUnsupported) from byte-only LocalFilesystem but got {err:?}",
+        "expected Storage(CasUnsupported) from byte-only DiskFilesystem but got {err:?}",
     );
 }
 

--- a/crates/ironclaw_run_state/src/lib.rs
+++ b/crates/ironclaw_run_state/src/lib.rs
@@ -238,7 +238,7 @@ pub trait RunStateApprovalStore: RunStateStore + ApprovalRequestStore {
 }
 
 /// `RecordKind` tag written on every run-state entry so byte-only backends
-/// (e.g. `LocalFilesystem`) are rejected with `Unsupported{WriteFile}` on
+/// (e.g. `DiskFilesystem`) are rejected with `Unsupported{WriteFile}` on
 /// first put, which `cas_update` maps to `CasUnsupported` (fail-closed).
 const RUN_STATE_RECORD_KIND: &str = "run_state_record";
 

--- a/crates/ironclaw_run_state/tests/run_state_contract.rs
+++ b/crates/ironclaw_run_state/tests/run_state_contract.rs
@@ -7,7 +7,7 @@ use std::{
 
 use async_trait::async_trait;
 use ironclaw_filesystem::{
-    DirEntry, FileStat, FilesystemError, FilesystemOperation, InMemoryBackend, LocalFilesystem,
+    DirEntry, DiskFilesystem, FileStat, FilesystemError, FilesystemOperation, InMemoryBackend,
     RootFilesystem, ScopedFilesystem,
 };
 use ironclaw_host_api::*;
@@ -1193,14 +1193,14 @@ async fn filesystem_run_state_store_isolates_two_tenants_with_same_user_project_
 /// set) surface `CasUnsupported` via `cas_update` rather than silently
 /// succeeding on a blind `CasExpectation::Absent` write.
 ///
-/// `LocalFilesystem` is used here because it is the canonical byte-only
+/// `DiskFilesystem` is used here because it is the canonical byte-only
 /// `RootFilesystem`: its `put` impl returns `Unsupported{WriteFile}` when
 /// `entry.kind.is_some()`, which `cas_update` maps to `CasUnsupported`,
 /// which `map_cas_error` surfaces as `RunStateError::Backend(...)`.
 #[tokio::test]
 async fn filesystem_approval_store_fails_closed_on_byte_only_backend() {
     let dir = tempfile::tempdir().expect("temp dir");
-    let mut local_fs = LocalFilesystem::new();
+    let mut local_fs = DiskFilesystem::new();
     local_fs
         .mount_local(
             VirtualPath::new("/engine").expect("virtual root"),
@@ -1216,7 +1216,7 @@ async fn filesystem_approval_store_fails_closed_on_byte_only_backend() {
     let err = store.save_pending(scope, approval).await.unwrap_err();
     assert!(
         matches!(&err, RunStateError::Backend(msg) if msg.contains("compare-and-swap")),
-        "expected Backend(CasUnsupported) from byte-only LocalFilesystem but got {err:?}",
+        "expected Backend(CasUnsupported) from byte-only DiskFilesystem but got {err:?}",
     );
 }
 
@@ -1228,7 +1228,7 @@ async fn filesystem_approval_store_fails_closed_on_byte_only_backend() {
 #[tokio::test]
 async fn filesystem_run_state_store_start_fails_closed_on_byte_only_backend() {
     let dir = tempfile::tempdir().expect("temp dir");
-    let mut local_fs = LocalFilesystem::new();
+    let mut local_fs = DiskFilesystem::new();
     local_fs
         .mount_local(
             VirtualPath::new("/engine").expect("virtual root"),
@@ -1252,7 +1252,7 @@ async fn filesystem_run_state_store_start_fails_closed_on_byte_only_backend() {
         .unwrap_err();
     assert!(
         matches!(&err, RunStateError::Backend(msg) if msg.contains("compare-and-swap")),
-        "expected Backend(CasUnsupported) from byte-only LocalFilesystem but got {err:?}",
+        "expected Backend(CasUnsupported) from byte-only DiskFilesystem but got {err:?}",
     );
 }
 
@@ -1529,7 +1529,7 @@ impl RootFilesystem for DisappearingApprovalReadFilesystem {
 
 /// Build an [`InMemoryBackend`] for use in tests. The backend supports
 /// full CAS semantics including `Version`-preconditioned writes, which
-/// `LocalFilesystem` does not. The `/run-state` and `/approvals` mount
+/// `DiskFilesystem` does not. The `/run-state` and `/approvals` mount
 /// aliases on the outer [`ScopedFilesystem`] resolve under `/engine/...`
 /// so the fault-injection wrappers (which match by post-resolution path)
 /// keep working unchanged.

--- a/crates/ironclaw_runner/tests/loop_driver_host.rs
+++ b/crates/ironclaw_runner/tests/loop_driver_host.rs
@@ -1,3 +1,4 @@
+// arch-exempt: large_file, mechanical LocalFilesystem->DiskFilesystem Bucket-2 rename (arch-simplification §4.4), no logic change, plan #6168
 use std::{
     collections::{BTreeMap, HashMap, VecDeque},
     sync::{
@@ -10,7 +11,7 @@ use async_trait::async_trait;
 use chrono::Utc;
 use ironclaw_authorization::GrantAuthorizer;
 use ironclaw_extensions::{ExtensionManifest, ExtensionPackage, ExtensionRegistry, ManifestSource};
-use ironclaw_filesystem::{InMemoryBackend, LocalFilesystem, RootFilesystem, ScopedFilesystem};
+use ironclaw_filesystem::{DiskFilesystem, InMemoryBackend, RootFilesystem, ScopedFilesystem};
 use ironclaw_hooks::{
     HookId, HookLocalId, HookRegistrar, HookRegistry, HookVersion,
     dispatch::HookDispatcherBuilder,
@@ -8150,9 +8151,9 @@ fn host_runtime_visible_request_with_dispatch_grant(
     request
 }
 
-async fn e2e_script_filesystem() -> LocalFilesystem {
+async fn e2e_script_filesystem() -> DiskFilesystem {
     let storage = tempfile::tempdir().unwrap().keep();
-    let mut filesystem = LocalFilesystem::new();
+    let mut filesystem = DiskFilesystem::new();
     filesystem
         .mount_local(
             VirtualPath::new("/system/extensions").unwrap(),

--- a/crates/ironclaw_runner/tests/turn_scheduler_contract.rs
+++ b/crates/ironclaw_runner/tests/turn_scheduler_contract.rs
@@ -1,3 +1,4 @@
+// arch-exempt: large_file, mechanical LocalFilesystem->DiskFilesystem Bucket-2 rename (arch-simplification §4.4), no logic change, plan #6168
 use std::{
     sync::{
         Arc, Mutex,
@@ -10,7 +11,7 @@ use async_trait::async_trait;
 use chrono::{Duration as ChronoDuration, Utc};
 use ironclaw_authorization::GrantAuthorizer;
 use ironclaw_extensions::ExtensionRegistry;
-use ironclaw_filesystem::LocalFilesystem;
+use ironclaw_filesystem::DiskFilesystem;
 use ironclaw_host_api::{AgentId, ProjectId, TenantId, ThreadId, UserId};
 use ironclaw_host_runtime::{
     CapabilitySurfaceVersion, HostRuntimeServices, ProductionWiringComponent,
@@ -995,7 +996,7 @@ fn production_services_expose_verified_transition_port_without_notifier() {
     let store = Arc::new(DurableTurnStoreStub);
     let services = HostRuntimeServices::new(
         Arc::new(ExtensionRegistry::new()),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ProcessServices::in_memory(),
@@ -1016,7 +1017,7 @@ fn production_services_reject_unverified_scheduler_transition_port() {
     let transition_port = Arc::new(DurableTurnStoreStub);
     let services = HostRuntimeServices::new(
         Arc::new(ExtensionRegistry::new()),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ProcessServices::in_memory(),
@@ -1076,7 +1077,7 @@ async fn production_services_scheduler_and_coordinator_execute_turn_end_to_end()
     let store = Arc::new(DurableLikeTurnStore::default());
     let services = HostRuntimeServices::new(
         Arc::new(ExtensionRegistry::new()),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ProcessServices::in_memory(),

--- a/crates/ironclaw_secrets/src/filesystem_store.rs
+++ b/crates/ironclaw_secrets/src/filesystem_store.rs
@@ -1,3 +1,4 @@
+// arch-exempt: large_file, mechanical LocalFilesystem->DiskFilesystem Bucket-2 rename (arch-simplification §4.4), no logic change, plan #6168
 //! Filesystem-backed implementations of the scoped secret and credential stores.
 //!
 //! Routes persistence through the unified
@@ -70,7 +71,7 @@ use crate::{
 // Every persisted entry must carry a `RecordKind` so that record-aware
 // backends (Postgres, libSQL) can distinguish schema families and reject
 // byte-only `CasExpectation::Absent` blind-write attempts that the
-// `LocalFilesystem` byte-only backend would otherwise let through.
+// `DiskFilesystem` byte-only backend would otherwise let through.
 
 const SECRET_RECORD_KIND: &str = "secret_record";
 const SECRET_LEASE_KIND: &str = "secret_lease";
@@ -1368,7 +1369,7 @@ fn tag_entry_with_tenant(entry: Entry, scope: &ResourceScope) -> Entry {
 }
 
 /// Declare the `tenant_id` exact-equality index on the `/secrets` mount,
-/// tolerating backends that don't materialize indexes (LocalFilesystem).
+/// tolerating backends that don't materialize indexes (DiskFilesystem).
 /// Idempotent across the mount lifetime and avoids per-owner DDL churn under
 /// concurrent secret/lease writes.
 async fn ensure_tenant_id_index_secret<F>(

--- a/crates/ironclaw_threads/src/filesystem_service.rs
+++ b/crates/ironclaw_threads/src/filesystem_service.rs
@@ -90,7 +90,7 @@ const FILESYSTEM_CAS_RETRIES: usize = 8;
 
 /// [`RecordKind`] discriminants for the four record types persisted by this
 /// service. Setting `entry.kind` makes writes record-shaped so
-/// [`LocalFilesystem`] (which rejects record-shaped puts) triggers the
+/// [`DiskFilesystem`] (which rejects record-shaped puts) triggers the
 /// fail-closed path on the CAS gate instead of accepting a byte-only first
 /// write without CAS enforcement.
 const SESSION_THREAD_KIND: &str = "session_thread";
@@ -3377,7 +3377,7 @@ fn summary_covers_redacted_or_deleted_content(
 // `FilesystemError::VersionMismatch` — that's correct and matches
 // `cas_update`'s contract. The `Unsupported` → `CasExpectation::Any`
 // fallback below only triggers on byte-only backends (e.g.
-// `LocalFilesystem`), which production does not mount for these
+// `DiskFilesystem`), which production does not mount for these
 // stores; it is not protected by any lock map. Migrating these
 // single-record RMWs onto `cas_update` (fail-closed on a non-CAS
 // backend) is a tracked, deferred follow-up sibling to the

--- a/crates/ironclaw_threads/tests/filesystem_session_thread_contract.rs
+++ b/crates/ironclaw_threads/tests/filesystem_session_thread_contract.rs
@@ -19,8 +19,8 @@ use std::{
 use async_trait::async_trait;
 use chrono::Utc;
 use ironclaw_filesystem::{
-    BackendCapabilities, CasExpectation, DirEntry, Entry, FileStat, FilesystemError,
-    FilesystemOperation, Filter, InMemoryBackend, LocalFilesystem, Page, RecordVersion,
+    BackendCapabilities, CasExpectation, DirEntry, DiskFilesystem, Entry, FileStat,
+    FilesystemError, FilesystemOperation, Filter, InMemoryBackend, Page, RecordVersion,
     RootFilesystem, ScopedFilesystem, SeqNo, StorageTxn, TxnCapability, VersionedEntry,
 };
 use ironclaw_host_api::{
@@ -3000,7 +3000,7 @@ async fn legacy_deferred_busy_message_round_trips_through_filesystem_store() {
 /// byte-only/`Unsupported` fail-closed branch for thread creation was
 /// unpinned.
 ///
-/// `LocalFilesystem` is the canonical byte-only `RootFilesystem`: its
+/// `DiskFilesystem` is the canonical byte-only `RootFilesystem`: its
 /// `put` impl rejects entries with `kind.is_some()`, which `cas_update`
 /// surfaces as `CasUnsupported`. This mirrors
 /// `filesystem_approval_store_fails_closed_on_byte_only_backend` in
@@ -3008,7 +3008,7 @@ async fn legacy_deferred_busy_message_round_trips_through_filesystem_store() {
 #[tokio::test]
 async fn filesystem_session_thread_ensure_thread_fails_closed_on_byte_only_backend() {
     let dir = tempfile::tempdir().expect("temp dir");
-    let mut local_fs = LocalFilesystem::new();
+    let mut local_fs = DiskFilesystem::new();
     local_fs
         .mount_local(
             VirtualPath::new("/tenants").expect("virtual root"),
@@ -3030,7 +3030,7 @@ async fn filesystem_session_thread_ensure_thread_fails_closed_on_byte_only_backe
         .expect_err("ensure_thread must fail closed on a byte-only backend");
     assert!(
         matches!(&err, SessionThreadError::Backend(msg) if msg.contains("compare-and-swap")),
-        "expected Backend(CasUnsupported) from byte-only LocalFilesystem but got {err:?}",
+        "expected Backend(CasUnsupported) from byte-only DiskFilesystem but got {err:?}",
     );
 }
 

--- a/crates/ironclaw_turns/tests/filesystem_turn_state_contract.rs
+++ b/crates/ironclaw_turns/tests/filesystem_turn_state_contract.rs
@@ -16,8 +16,8 @@ use async_trait::async_trait;
 use chrono::{TimeZone, Utc};
 use ironclaw_filesystem::{
     BackendCapabilities, BackendId, BackendKind, CasExpectation, CompositeRootFilesystem,
-    ContentKind, DirEntry, Entry, FileStat, FilesystemError, FilesystemOperation, InMemoryBackend,
-    IndexPolicy, LocalFilesystem, MountDescriptor, RecordVersion, RootFilesystem, ScopedFilesystem,
+    ContentKind, DirEntry, DiskFilesystem, Entry, FileStat, FilesystemError, FilesystemOperation,
+    InMemoryBackend, IndexPolicy, MountDescriptor, RecordVersion, RootFilesystem, ScopedFilesystem,
     SeqNo, StorageClass, VersionedEntry,
 };
 use ironclaw_host_api::{
@@ -50,9 +50,9 @@ fn engine_filesystem() -> InMemoryBackend {
     InMemoryBackend::new()
 }
 
-fn byte_only_filesystem() -> LocalFilesystem {
+fn byte_only_filesystem() -> DiskFilesystem {
     let storage = tempfile::tempdir().unwrap().keep();
-    let mut fs = LocalFilesystem::new();
+    let mut fs = DiskFilesystem::new();
     fs.mount_local(
         VirtualPath::new("/engine").unwrap(),
         HostPath::from_path_buf(storage),

--- a/crates/ironclaw_wasm/tests/wasm_dispatch_integration.rs
+++ b/crates/ironclaw_wasm/tests/wasm_dispatch_integration.rs
@@ -16,7 +16,7 @@ use ironclaw_extensions::{
     CapabilityProviderHostApiContract, ExtensionManifest, ExtensionPackage, ExtensionRuntime,
     HostApiContractRegistry, ManifestSource,
 };
-use ironclaw_filesystem::{LocalFilesystem, RootFilesystem};
+use ironclaw_filesystem::{DiskFilesystem, RootFilesystem};
 use ironclaw_host_api::*;
 use ironclaw_resources::*;
 use ironclaw_wasm::wasm_sandbox_core::SandboxLimits;
@@ -628,10 +628,10 @@ impl WasmRuntimeAdapter {
 }
 
 #[async_trait]
-impl RuntimeAdapter<LocalFilesystem, InMemoryResourceGovernor> for WasmRuntimeAdapter {
+impl RuntimeAdapter<DiskFilesystem, InMemoryResourceGovernor> for WasmRuntimeAdapter {
     async fn dispatch_json(
         &self,
-        request: RuntimeAdapterRequest<'_, LocalFilesystem, InMemoryResourceGovernor>,
+        request: RuntimeAdapterRequest<'_, DiskFilesystem, InMemoryResourceGovernor>,
     ) -> Result<RuntimeAdapterResult, DispatchError> {
         let module_path = match &request.package.manifest.runtime {
             ExtensionRuntime::Wasm { module } => module
@@ -694,7 +694,7 @@ fn execute_prepared_wasm(
     runtime: &WitToolRuntime,
     prepared: &PreparedWitTool,
     host: WitToolHost,
-    request: RuntimeAdapterRequest<'_, LocalFilesystem, InMemoryResourceGovernor>,
+    request: RuntimeAdapterRequest<'_, DiskFilesystem, InMemoryResourceGovernor>,
 ) -> Result<RuntimeAdapterResult, DispatchError> {
     let input_json = serde_json::to_string(&request.input).map_err(|_| DispatchError::Wasm {
         kind: RuntimeDispatchErrorKind::InputEncode,
@@ -828,9 +828,9 @@ fn capability_provider_contracts() -> HostApiContractRegistry {
     contracts
 }
 
-fn mounted_empty_extension_root() -> LocalFilesystem {
+fn mounted_empty_extension_root() -> DiskFilesystem {
     let storage = tempfile::tempdir().unwrap().keep();
-    let mut fs = LocalFilesystem::new();
+    let mut fs = DiskFilesystem::new();
     fs.mount_local(
         VirtualPath::new("/system/extensions").unwrap(),
         HostPath::from_path_buf(storage),
@@ -843,7 +843,7 @@ async fn filesystem_with_wasm_component(
     extension_id: &str,
     module_path: &str,
     wasm_bytes: &[u8],
-) -> LocalFilesystem {
+) -> DiskFilesystem {
     let fs = mounted_empty_extension_root();
     let path =
         VirtualPath::new(format!("/system/extensions/{extension_id}/{module_path}")).unwrap();

--- a/docs/reborn/contracts/filesystem.md
+++ b/docs/reborn/contracts/filesystem.md
@@ -327,7 +327,7 @@ Rules:
 V1 backend types:
 
 ```text
-LocalFilesystem
+DiskFilesystem
 PostgresRootFilesystem   // feature = "postgres"
 LibSqlRootFilesystem     // feature = "libsql"
 Memory/test backends as needed

--- a/docs/reborn/contracts/live-vertical-slice.md
+++ b/docs/reborn/contracts/live-vertical-slice.md
@@ -11,7 +11,7 @@
 This slice proves the first Reborn host path is runnable:
 
 ```text
-LocalFilesystem mounted at /system/extensions
+DiskFilesystem mounted at /system/extensions
 -> ExtensionDiscovery reads manifests
 -> ExtensionRegistry registers capabilities
 -> RuntimeDispatcher receives already-authorized dispatch requests
@@ -62,7 +62,7 @@ The default dispatcher example uses in-crate echo adapters so `ironclaw_dispatch
 
 The integration test `crates/ironclaw_dispatcher/tests/vertical_slice_contract.rs` validates:
 
-- extension manifests are read from `LocalFilesystem` via `/system/extensions`
+- extension manifests are read from `DiskFilesystem` via `/system/extensions`
 - extension discovery returns WASM, Script, and MCP packages
 - dispatcher crate tests exercise already-authorized `CapabilityDispatchRequest` values directly
 - higher-level caller workflow stays out of dispatcher crate dev surfaces

--- a/tests/integration/support/filesystem.rs
+++ b/tests/integration/support/filesystem.rs
@@ -7,8 +7,8 @@ use ironclaw_product_workflow::ResolvedBinding;
 
 use async_trait::async_trait;
 use ironclaw_filesystem::{
-    BackendCapabilities, CasExpectation, DirEntry, Entry, FileStat, FilesystemError, Filter,
-    IndexSpec, LocalFilesystem, Page, RecordVersion, RootFilesystem, VersionedEntry,
+    BackendCapabilities, CasExpectation, DirEntry, DiskFilesystem, Entry, FileStat,
+    FilesystemError, Filter, IndexSpec, Page, RecordVersion, RootFilesystem, VersionedEntry,
 };
 use ironclaw_host_api::{HostPath, VirtualPath};
 
@@ -41,8 +41,8 @@ pub fn turns_scope_path(root_prefix: &str, binding: &ResolvedBinding) -> String 
     }
 }
 
-pub fn local_filesystem(root: &Path) -> Result<LocalFilesystem, FilesystemError> {
-    let mut fs = LocalFilesystem::new();
+pub fn local_filesystem(root: &Path) -> Result<DiskFilesystem, FilesystemError> {
+    let mut fs = DiskFilesystem::new();
     fs.mount_local(
         VirtualPath::new("/engine").expect("valid test virtual path"),
         HostPath::from_path_buf(root.to_path_buf()),

--- a/tests/integration/support/group.rs
+++ b/tests/integration/support/group.rs
@@ -73,9 +73,10 @@ use ironclaw_product_workflow::{
 use ironclaw_reborn_composition::build_default_budget_accountant;
 use ironclaw_reborn_composition::test_support::SlackChannelConnectionTestBundle;
 use ironclaw_reborn_config::BudgetDefaults;
+use ironclaw_resources::test_support::in_memory_backed_budget_gate_store;
 use ironclaw_resources::{
-    BudgetEventSink, BudgetGateStore, InMemoryBudgetEventSink, InMemoryBudgetGateStore,
-    InMemoryResourceGovernor, ResourceAccount, ResourceGovernor,
+    BudgetEventSink, BudgetGateStore, InMemoryBudgetEventSink, InMemoryResourceGovernor,
+    ResourceAccount, ResourceGovernor,
 };
 use ironclaw_runner::loop_driver_host::HookDispatcherBuilderFactory;
 use ironclaw_runner::loop_exit_applier::{
@@ -886,7 +887,7 @@ impl RebornIntegrationGroupBuilder {
             let accountant = build_default_budget_accountant(
                 Arc::clone(&governor) as Arc<dyn ResourceGovernor>,
                 Arc::new(ZeroCostTable) as Arc<dyn ModelCostTable>,
-                Arc::new(InMemoryBudgetGateStore::new()) as Arc<dyn BudgetGateStore>,
+                Arc::new(in_memory_backed_budget_gate_store()) as Arc<dyn BudgetGateStore>,
                 Arc::new(InMemoryBudgetEventSink::new()) as Arc<dyn BudgetEventSink>,
                 &BudgetDefaults::compiled_defaults(),
             );

--- a/tests/integration/support/harness/assembly.rs
+++ b/tests/integration/support/harness/assembly.rs
@@ -11,7 +11,7 @@ use ironclaw_authorization::GrantAuthorizer;
 use ironclaw_extensions::ExtensionRegistry;
 use ironclaw_filesystem::{
     BackendCapabilities, BackendId, BackendKind, CompositeRootFilesystem, ContentKind,
-    InMemoryBackend, IndexPolicy, LocalFilesystem, MountDescriptor, RootFilesystem, StorageClass,
+    DiskFilesystem, InMemoryBackend, IndexPolicy, MountDescriptor, RootFilesystem, StorageClass,
 };
 use ironclaw_host_api::{
     CapabilityId, CredentialStageError, EffectKind, ExtensionId, HostPath, MountAlias, MountGrant,
@@ -284,7 +284,7 @@ pub(crate) fn local_dev_root_filesystem(
     storage_root: PathBuf,
     mounts: LocalDevRootMounts,
 ) -> HarnessResult<Arc<CompositeRootFilesystem>> {
-    let mut local = LocalFilesystem::new();
+    let mut local = DiskFilesystem::new();
     local.mount_local(
         VirtualPath::new("/projects")?,
         HostPath::from_path_buf(storage_root),
@@ -308,7 +308,7 @@ pub(crate) fn local_dev_root_filesystem(
         local_dev_mount_descriptor(
             "/projects",
             "local-dev-projects",
-            BackendKind::LocalFilesystem,
+            BackendKind::DiskFilesystem,
             StorageClass::FileContent,
             ContentKind::ProjectFile,
             IndexPolicy::NotIndexed,
@@ -321,7 +321,7 @@ pub(crate) fn local_dev_root_filesystem(
             local_dev_mount_descriptor(
                 "/system/extensions/github",
                 "local-dev-github-assets",
-                BackendKind::LocalFilesystem,
+                BackendKind::DiskFilesystem,
                 StorageClass::FileContent,
                 ContentKind::ExtensionPackage,
                 IndexPolicy::NotIndexed,
@@ -335,7 +335,7 @@ pub(crate) fn local_dev_root_filesystem(
             local_dev_mount_descriptor(
                 "/system/extensions/web-access",
                 "local-dev-web-access-assets",
-                BackendKind::LocalFilesystem,
+                BackendKind::DiskFilesystem,
                 StorageClass::FileContent,
                 ContentKind::ExtensionPackage,
                 IndexPolicy::NotIndexed,

--- a/tests/integration/support/product_workflow.rs
+++ b/tests/integration/support/product_workflow.rs
@@ -6,7 +6,7 @@ use std::{
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use ironclaw_filesystem::{FilesystemError, LocalFilesystem, RootFilesystem, ScopedFilesystem};
+use ironclaw_filesystem::{DiskFilesystem, FilesystemError, RootFilesystem, ScopedFilesystem};
 use ironclaw_host_api::{
     AgentId, HostApiError, MountAlias, MountGrant, MountPermissions, MountView, ProjectId,
     ResourceScope, ScopedPath, TenantId, ThreadId, UserId, VirtualPath,
@@ -37,8 +37,8 @@ pub enum RebornProductWorkflowHarnessError {
 
 pub struct RebornProductWorkflowHarness {
     pub scope: ResourceScope,
-    filesystem: Arc<ScopedFilesystem<LocalFilesystem>>,
-    backend: Arc<LocalFilesystem>,
+    filesystem: Arc<ScopedFilesystem<DiskFilesystem>>,
+    backend: Arc<DiskFilesystem>,
     root: Arc<tempfile::TempDir>,
     idempotency_lock: Arc<Mutex<()>>,
 }
@@ -54,7 +54,7 @@ impl RebornProductWorkflowHarness {
 
     pub fn filesystem_shared_backend(
         scope: ResourceScope,
-        backend: Arc<LocalFilesystem>,
+        backend: Arc<DiskFilesystem>,
         root: Arc<tempfile::TempDir>,
     ) -> Result<Self, RebornProductWorkflowHarnessError> {
         let idempotency_lock = idempotency_lock_for_workflow_root(&root, &scope);
@@ -63,7 +63,7 @@ impl RebornProductWorkflowHarness {
 
     fn filesystem_shared_backend_with_lock(
         scope: ResourceScope,
-        backend: Arc<LocalFilesystem>,
+        backend: Arc<DiskFilesystem>,
         root: Arc<tempfile::TempDir>,
         idempotency_lock: Arc<Mutex<()>>,
     ) -> Result<Self, RebornProductWorkflowHarnessError> {
@@ -101,7 +101,7 @@ impl RebornProductWorkflowHarness {
     pub fn binding_service(
         &self,
     ) -> Result<
-        FilesystemConversationBindingService<LocalFilesystem>,
+        FilesystemConversationBindingService<DiskFilesystem>,
         RebornProductWorkflowHarnessError,
     > {
         let agent_id = self
@@ -117,7 +117,7 @@ impl RebornProductWorkflowHarness {
         ))
     }
 
-    pub fn idempotency_ledger(&self) -> FilesystemIdempotencyLedger<LocalFilesystem> {
+    pub fn idempotency_ledger(&self) -> FilesystemIdempotencyLedger<DiskFilesystem> {
         FilesystemIdempotencyLedger::new_with_lock(
             Arc::clone(&self.filesystem),
             self.scope.clone(),
@@ -129,7 +129,7 @@ impl RebornProductWorkflowHarness {
     pub fn idempotency_ledger_with_ttl(
         &self,
         lease_ttl: Duration,
-    ) -> FilesystemIdempotencyLedger<LocalFilesystem> {
+    ) -> FilesystemIdempotencyLedger<DiskFilesystem> {
         FilesystemIdempotencyLedger::new_with_lock(
             Arc::clone(&self.filesystem),
             self.scope.clone(),

--- a/tests/integration/support/session_thread.rs
+++ b/tests/integration/support/session_thread.rs
@@ -25,7 +25,7 @@ pub enum RebornThreadHarnessError {
 /// Thin harness over `FilesystemSessionThreadService<F>` for asserting thread history.
 ///
 /// Defaults to `InMemoryBackend` (CAS-capable, models the production DB-backed filesystem)
-/// rather than the byte-only `LocalFilesystem` (see e3e155803). The integration tier uses
+/// rather than the byte-only `DiskFilesystem` (see e3e155803). The integration tier uses
 /// `RebornThreadHarness<CompositeRootFilesystem>` via `filesystem_shared_composite`, mounted
 /// on the per-`build()` production-path composite.
 pub struct RebornThreadHarness<F = InMemoryBackend>

--- a/tests/reborn_authenticated_actor_dispatch_parity.rs
+++ b/tests/reborn_authenticated_actor_dispatch_parity.rs
@@ -6,7 +6,7 @@ use std::{
 use async_trait::async_trait;
 use ironclaw_authorization::GrantAuthorizer;
 use ironclaw_extensions::ExtensionRegistry;
-use ironclaw_filesystem::LocalFilesystem;
+use ironclaw_filesystem::DiskFilesystem;
 use ironclaw_host_api::{
     CapabilityGrant, CapabilityGrantId, CapabilityId, CapabilitySet, EffectKind, ExecutionContext,
     ExtensionId, GrantConstraints, MountView, NetworkPolicy, PackageId, PackageSource, Principal,
@@ -67,7 +67,7 @@ async fn loop_run_dispatch_preserves_authenticated_actor_distinct_from_shared_su
     let runtime = Arc::new(
         HostRuntimeServices::new(
             Arc::new(registry),
-            Arc::new(LocalFilesystem::new()),
+            Arc::new(DiskFilesystem::new()),
             Arc::new(InMemoryResourceGovernor::new()),
             Arc::new(GrantAuthorizer::new()),
             ProcessServices::in_memory(),

--- a/tests/support/reborn_parity_qa/binary_e2e.rs
+++ b/tests/support/reborn_parity_qa/binary_e2e.rs
@@ -17,7 +17,7 @@
 use std::{path::PathBuf, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
-use ironclaw_filesystem::{InMemoryBackend, LocalFilesystem};
+use ironclaw_filesystem::{DiskFilesystem, InMemoryBackend};
 use ironclaw_host_api::{
     CapabilityId, NetworkPolicy, ProviderToolName, ResourceScope, RuntimeHttpEgressRequest,
     ThreadId,
@@ -122,7 +122,7 @@ pub struct SubmittedTurn {
 
 #[derive(Clone)]
 pub struct RebornHarnessSharedStorage {
-    product_backend: Arc<LocalFilesystem>,
+    product_backend: Arc<DiskFilesystem>,
     product_root: Arc<tempfile::TempDir>,
     thread_backend: Arc<InMemoryBackend>,
     turn_backend: Arc<HarnessTurnStorageBackend>,


### PR DESCRIPTION
## What

Continues the arch-simplification **§4.3** store consolidation (after approvals/authorization/processes/run-state): deletes the hand-written `InMemoryBudgetGateStore` and uses the one production `FilesystemBudgetGateStore` over an in-memory backend. The code already flagged this as a TODO ("Production composition can swap in a filesystem-backed store … deferred to a follow-up") — this is that follow-up.

## Behavior change — strictly more correct

The deleted in-memory store was a single global `HashMap` that **ignored `ResourceScope`**. `FilesystemBudgetGateStore` routes each gate under the caller's tenant/user mount via the same `cas_update(scoped_fs, &scope, path)` mechanism the merged capability-lease store (#6197) uses — so budget gates are now properly **tenant-isolated** in the no-durable path instead of globally shared.

The `open → get` gate lifecycle is preserved (both flow from the same user's turn scope). All existing gate tests use a single scope, so none needed A2-style reconciliation. `resolve()` has no production caller today; only `open()` (budget accountant) and `get()` (`apply_resolved_budget_gate`) are wired.

## Changes

- **`ironclaw_resources`**: delete `InMemoryBudgetGateStore` struct+impl and its `pub use`; add a `test-support` feature + `test_support.rs` with `in_memory_backed_budget_gate_store()` (terminal retention disabled to match the old retain-forever test semantics). Migrate the 7 gate.rs unit tests onto the helper.
- **Composition factory** no-durable path: `FilesystemBudgetGateStore::new(wrap_scoped(InMemoryBackend::new()))`, mirroring the capability-lease wiring. Observability + integration (`tests/integration/support/group.rs`) test doubles use the `test-support` helper.
- **R1 ratchet** (`reborn_inmemory_store_ratchet`): drop `InMemoryBudgetGateStore` from the frozen allowlist (the ratchet forces this trim in the same PR as the deletion — shrinking toward the §10 empty-set goal).

**Wire-safe**: `BudgetApprovalGate`/`BudgetGateStatus` serde shapes unchanged (the filesystem store reuses the same records).

## Verification

- `cargo test -p ironclaw_resources --features test-support` — 64 pass
- `cargo test -p ironclaw_reborn_composition --lib observability::budget` — 5 pass
- `cargo test -p ironclaw_architecture --test reborn_inmemory_store_ratchet` — pass
- `cargo build -p ironclaw_reborn_composition` (default + libsql) — clean
- `cargo clippy -p ironclaw_resources -p ironclaw_reborn_composition --all-targets --all-features -- -D warnings` — clean
- `cargo test --features integration --no-run` — rc=0 (integration harness compiles)
- `cargo fmt --check` + `scripts/pre-commit-safety.sh` — clean

## Stack

Stacked on #6209. Part of the incremental arch-simplification refactor (`docs/reborn/2026-07-17-architecture-simplification-dto-dyn-local.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)