### PR TITLE
fix(reborn-cli): disable channels/hooks/logs stubs, fix models feature-gate stub

### DIFF
--- a/FEATURE_PARITY.md
+++ b/FEATURE_PARITY.md
@@ -224,7 +224,7 @@ This document tracks feature parity between IronClaw (Rust implementation) and O
 | `tui` | ✅ | ✅ | - | Ratatui TUI |
 | `config` | ✅ | ✅ | - | Read/write config plus validate/path helpers |
 | `backup` | ✅ | ❌ | P3 | Create/verify local backup archives |
-| `channels` | ✅ | 🚧 | P2 | `list` implemented; `enable`/`disable`/`status` deferred pending config source unification |
+| `channels` | ✅ | 🚧 | P2 | Reborn `channels list` stays visible in `--help`/completions but exits nonzero as unimplemented (stub disabled); `enable`/`disable`/`status` deferred pending config source unification |
 | `models` | ✅ | 🚧 | P1 | Reborn now uses a shared composition provider-admin facade for CLI `models list [<provider>]` (`--verbose`, `--json`), `models status`, `models set <model>`, `models set-provider <provider> [--model model]`, plus Product Workflow typed `model set-provider ...` parsing without touching v1 state. Remaining: live model fetching, OAuth/API-key login flows, and wiring the provider-admin ProductCommandService into product surfaces. |
 | `status` | ✅ | ✅ | - | System status (enriched session details) |
 | `agents` | ✅ | ❌ | P3 | Multi-agent management |
@@ -234,14 +234,14 @@ This document tracks feature parity between IronClaw (Rust implementation) and O
 | `pairing` | ✅ | ✅ | - | list/approve, account selector |
 | `nodes` | ✅ | ❌ | P3 | Device management, remove/clear flows |
 | `plugins` | ✅ | ❌ | P3 | Plugin management |
-| `hooks` | ✅ | ✅ | P2 | `hooks list` (bundled + plugin discovery, `--verbose`, `--json`) |
+| `hooks` | ✅ | 🚧 | P2 | Reborn `hooks list` stays visible in `--help`/completions but exits nonzero as unimplemented (stub disabled); v1 `hooks list` supports bundled + plugin discovery, `--verbose`, `--json` |
 | `cron` | ✅ | 🚧 | P2 | list/create/edit/enable/disable/delete/history; TODO: `cron run`, model/thinking fields |
 | `webhooks` | ✅ | ❌ | P3 | Webhook config |
 | `message send` | ✅ | ❌ | P2 | Send to channels |
 | `browser` | ✅ | ❌ | P3 | Browser automation |
 | `sandbox` | ✅ | ✅ | - | WASM sandbox |
 | `doctor` | ✅ | 🚧 | P2 | 16 subsystem checks |
-| `logs` | ✅ | 🚧 | P3 | `logs` (gateway.log tail), `--follow` (SSE live stream), `--level` (get/set). WebUI v2 exposes bounded in-memory log projection at `/api/webchat/v2/logs` for non-operators and `/api/webchat/v2/operator/logs` for operators, both with level/target and run/thread/turn/tool/source scoped filters. No DB-persisted log history. |
+| `logs` | ✅ | 🚧 | P3 | Reborn CLI `logs` stays visible but exits nonzero as unimplemented (stub disabled). v1: `logs` (gateway.log tail), `--follow` (SSE live stream), `--level` (get/set). WebUI v2 exposes bounded in-memory log projection at `/api/webchat/v2/logs` for non-operators and `/api/webchat/v2/operator/logs` for operators, both with level/target and run/thread/turn/tool/source scoped filters. No DB-persisted log history. |
 | `traces` | ➖ | 🚧 | - | <ul><li>IronClaw-native Trace Commons client MVP, not an OpenClaw parity feature.</li><li>Local opt-in capture, redaction, queueing, queue-status diagnostics, scoped web APIs, revocation, and periodic credit notices.</li><li>CLI opt-in writes the runtime/web user-scope policy that autonomous capture reads, and credentialed submit/status/revoke calls use bounded no-redirect HTTP.</li><li>Authenticated web paths are user-scoped and keep ingestion endpoint/credential settings out of user-managed policy updates.</li><li>Private TraceDAO server ingest/review/export/audit/retention/vector/credit infrastructure now lives in the standalone `tracedao-server` repository, with IronClaw retaining CLI/client integration wrappers.</li></ul> |
 | `update` | ✅ | ❌ | P3 | Self-update; `OPENCLAW_NO_AUTO_UPDATE=1` kill-switch |
 | `completion` | ✅ | ✅ | - | Shell completion |

--- a/crates/ironclaw_reborn_cli/src/commands/channels.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/channels.rs
@@ -1,11 +1,6 @@
 use clap::{Args, Subcommand};
 
-const STATUS_NOT_WIRED: &str = "not-wired";
-const V1_STATE_NOT_USED: &str = "not-used";
-const DETAILS: [&str; 2] = [
-    "Reborn channel registry is not wired yet",
-    "v1 channel configuration is intentionally not read",
-];
+use super::not_yet_implemented;
 
 #[derive(Debug, Args)]
 pub(crate) struct ChannelsCommand {
@@ -40,33 +35,19 @@ impl ChannelsCommand {
 
 impl ChannelsListCommand {
     fn execute(self) -> anyhow::Result<()> {
-        let details = self.verbose.then_some(DETAILS.as_slice());
+        Err(not_yet_implemented("channels list"))
+    }
+}
 
-        if self.json {
-            let mut output = serde_json::json!({
-                "configured": 0,
-                "channels": [],
-                "status": STATUS_NOT_WIRED,
-                "v1_state": V1_STATE_NOT_USED,
-            });
-            if let Some(details) = details {
-                output["details"] = serde_json::json!(details);
-            }
-            println!("{}", output);
-            return Ok(());
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn list_reports_not_yet_implemented_regardless_of_flags() {
+        for (verbose, json) in [(false, false), (true, false), (false, true), (true, true)] {
+            let err = ChannelsListCommand { verbose, json }.execute().unwrap_err();
+            assert_eq!(err.to_string(), "`channels list` is not implemented yet");
         }
-
-        println!("IronClaw Reborn channels");
-        println!("configured: 0");
-        println!("status: {STATUS_NOT_WIRED}");
-        println!("v1_state: {V1_STATE_NOT_USED}");
-
-        if let Some(details) = details {
-            for detail in details {
-                println!("detail: {detail}");
-            }
-        }
-
-        Ok(())
     }
 }

--- a/crates/ironclaw_reborn_cli/src/commands/hooks.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/hooks.rs
@@ -1,11 +1,6 @@
 use clap::{Args, Subcommand};
 
-const STATUS_NOT_WIRED: &str = "not-wired";
-const V1_STATE_NOT_USED: &str = "not-used";
-const DETAILS: [&str; 2] = [
-    "Reborn hook registry is not wired yet",
-    "v1 hook configuration is intentionally not read",
-];
+use super::not_yet_implemented;
 
 #[derive(Debug, Args)]
 pub(crate) struct HooksCommand {
@@ -40,33 +35,19 @@ impl HooksCommand {
 
 impl HooksListCommand {
     fn execute(self) -> anyhow::Result<()> {
-        let details = self.verbose.then_some(DETAILS.as_slice());
+        Err(not_yet_implemented("hooks list"))
+    }
+}
 
-        if self.json {
-            let mut output = serde_json::json!({
-                "configured": 0,
-                "hooks": [],
-                "status": STATUS_NOT_WIRED,
-                "v1_state": V1_STATE_NOT_USED,
-            });
-            if let Some(details) = details {
-                output["details"] = serde_json::json!(details);
-            }
-            println!("{}", output);
-            return Ok(());
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn list_reports_not_yet_implemented_regardless_of_flags() {
+        for (verbose, json) in [(false, false), (true, false), (false, true), (true, true)] {
+            let err = HooksListCommand { verbose, json }.execute().unwrap_err();
+            assert_eq!(err.to_string(), "`hooks list` is not implemented yet");
         }
-
-        println!("IronClaw Reborn hooks");
-        println!("configured: 0");
-        println!("status: {STATUS_NOT_WIRED}");
-        println!("v1_state: {V1_STATE_NOT_USED}");
-
-        if let Some(details) = details {
-            for detail in details {
-                println!("detail: {detail}");
-            }
-        }
-
-        Ok(())
     }
 }

--- a/crates/ironclaw_reborn_cli/src/commands/logs.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/logs.rs
@@ -1,11 +1,6 @@
 use clap::Args;
 
-const STATUS_NOT_WIRED: &str = "not-wired";
-const V1_STATE_NOT_USED: &str = "not-used";
-const DETAILS: [&str; 2] = [
-    "Reborn log source is not wired yet",
-    "v1 gateway logs are intentionally not read",
-];
+use super::not_yet_implemented;
 
 #[derive(Debug, Args)]
 pub(crate) struct LogsCommand {
@@ -20,33 +15,19 @@ pub(crate) struct LogsCommand {
 
 impl LogsCommand {
     pub(crate) fn execute(self) -> anyhow::Result<()> {
-        let details = self.verbose.then_some(DETAILS.as_slice());
+        Err(not_yet_implemented("logs"))
+    }
+}
 
-        if self.json {
-            let mut output = serde_json::json!({
-                "entries": 0,
-                "logs": [],
-                "status": STATUS_NOT_WIRED,
-                "v1_state": V1_STATE_NOT_USED,
-            });
-            if let Some(details) = details {
-                output["details"] = serde_json::json!(details);
-            }
-            println!("{}", output);
-            return Ok(());
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reports_not_yet_implemented_regardless_of_flags() {
+        for (verbose, json) in [(false, false), (true, false), (false, true), (true, true)] {
+            let err = LogsCommand { verbose, json }.execute().unwrap_err();
+            assert_eq!(err.to_string(), "`logs` is not implemented yet");
         }
-
-        println!("IronClaw Reborn logs");
-        println!("entries: 0");
-        println!("status: {STATUS_NOT_WIRED}");
-        println!("v1_state: {V1_STATE_NOT_USED}");
-
-        if let Some(details) = details {
-            for detail in details {
-                println!("detail: {detail}");
-            }
-        }
-
-        Ok(())
     }
 }

--- a/crates/ironclaw_reborn_cli/src/commands/mod.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/mod.rs
@@ -136,3 +136,10 @@ pub(crate) fn parse_channel_enabled_bool(field: &str, value: &str) -> anyhow::Re
         _ => anyhow::bail!("{field} must be a boolean value"),
     }
 }
+
+/// Shared error for CLI surfaces that are intentionally kept visible in
+/// `--help`/shell completions but do not yet have a working implementation
+/// (`channels`, `hooks`, `logs`).
+pub(crate) fn not_yet_implemented(command: &str) -> anyhow::Error {
+    anyhow::anyhow!("`{command}` is not implemented yet")
+}

--- a/crates/ironclaw_reborn_cli/src/commands/models.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/models.rs
@@ -92,13 +92,11 @@ impl ModelsListCommand {
 #[cfg(not(feature = "root-llm-provider"))]
 impl ModelsListCommand {
     fn execute(self) -> anyhow::Result<()> {
-        Err(feature_not_available(&format!(
-            "list{}",
-            self.provider
-                .as_deref()
-                .map(|provider| format!(" {provider}"))
-                .unwrap_or_default()
-        )))
+        let command = match self.provider.as_deref() {
+            Some(provider) => format!("list {provider}"),
+            None => "list".to_string(),
+        };
+        Err(feature_not_available(&command))
     }
 }
 

--- a/crates/ironclaw_reborn_cli/src/commands/models.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/models.rs
@@ -92,31 +92,13 @@ impl ModelsListCommand {
 #[cfg(not(feature = "root-llm-provider"))]
 impl ModelsListCommand {
     fn execute(self) -> anyhow::Result<()> {
-        let slots = ironclaw_reborn_composition::reborn_model_slot_names();
-
-        if self.json {
-            let slots = slots
-                .iter()
-                .map(|slot| serde_json::json!({ "slot": slot }))
-                .collect::<Vec<_>>();
-            println!(
-                "{}",
-                serde_json::json!({
-                    "slots": slots,
-                    "routes": "not-configured",
-                    "v1_state": "not-used",
-                })
-            );
-            return Ok(());
-        }
-
-        println!("IronClaw Reborn model slots");
-        for slot in slots {
-            println!("- {}", slot);
-        }
-        println!("routes: not-configured");
-        println!("v1_state: not-used");
-        Ok(())
+        Err(feature_not_available(&format!(
+            "list{}",
+            self.provider
+                .as_deref()
+                .map(|provider| format!(" {provider}"))
+                .unwrap_or_default()
+        )))
     }
 }
 
@@ -186,36 +168,7 @@ fn feature_not_available(command: &str) -> anyhow::Error {
 #[cfg(not(feature = "root-llm-provider"))]
 impl ModelsStatusCommand {
     fn execute(self) -> anyhow::Result<()> {
-        let slots = ironclaw_reborn_composition::reborn_model_slot_names();
-
-        if self.json {
-            let slot_status: serde_json::Map<String, serde_json::Value> = slots
-                .iter()
-                .map(|slot| {
-                    (
-                        (*slot).to_string(),
-                        serde_json::Value::from("not-configured"),
-                    )
-                })
-                .collect();
-            println!(
-                "{}",
-                serde_json::json!({
-                    "routes": "not-configured",
-                    "slots": slot_status,
-                    "v1_state": "not-used",
-                })
-            );
-            return Ok(());
-        }
-
-        println!("IronClaw Reborn model status");
-        println!("routes: not-configured");
-        for slot in slots {
-            println!("{}: not-configured", slot);
-        }
-        println!("v1_state: not-used");
-        Ok(())
+        Err(feature_not_available("status"))
     }
 }
 

--- a/crates/ironclaw_reborn_cli/tests/smoke.rs
+++ b/crates/ironclaw_reborn_cli/tests/smoke.rs
@@ -872,58 +872,27 @@ fn profile_list_json_is_stable_and_does_not_resolve_reborn_home() {
 }
 
 #[test]
-fn channels_list_reports_unwired_empty_surface_without_reborn_home() {
-    assert_empty_not_wired_surface(
+fn channels_list_reports_not_implemented() {
+    assert_not_implemented(
         &["channels", "list"],
-        "IronClaw Reborn channels",
-        "channels",
-        "configured",
+        "`channels list` is not implemented yet",
     );
-}
-
-#[test]
-fn channels_list_verbose_explains_missing_reborn_registry() {
-    assert_verbose_detail(
+    assert_not_implemented(
         &["channels", "list", "--verbose"],
-        "Reborn channel registry is not wired yet",
+        "`channels list` is not implemented yet",
+    );
+    assert_not_implemented(
+        &["channels", "list", "--json"],
+        "`channels list` is not implemented yet",
     );
 }
 
 #[test]
-fn channels_list_json_verbose_includes_status_details() {
-    assert_json_verbose_detail(
-        &["channels", "list", "--json", "--verbose"],
-        "channels",
-        "configured",
-        "Reborn channel registry is not wired yet",
-    );
-}
-
-#[test]
-fn hooks_list_reports_unwired_empty_surface_without_reborn_home() {
-    assert_empty_not_wired_surface(
-        &["hooks", "list"],
-        "IronClaw Reborn hooks",
-        "hooks",
-        "configured",
-    );
-}
-
-#[test]
-fn hooks_list_verbose_explains_missing_reborn_registry() {
-    assert_verbose_detail(
+fn hooks_list_reports_not_implemented() {
+    assert_not_implemented(&["hooks", "list"], "`hooks list` is not implemented yet");
+    assert_not_implemented(
         &["hooks", "list", "--verbose"],
-        "Reborn hook registry is not wired yet",
-    );
-}
-
-#[test]
-fn hooks_list_json_verbose_includes_status_details() {
-    assert_json_verbose_detail(
-        &["hooks", "list", "--json", "--verbose"],
-        "hooks",
-        "configured",
-        "Reborn hook registry is not wired yet",
+        "`hooks list` is not implemented yet",
     );
 }
 
@@ -1090,23 +1059,9 @@ fn skills_list_rejects_unsupported_profiles() {
 }
 
 #[test]
-fn logs_reports_unwired_surface_without_reborn_home() {
-    assert_empty_not_wired_surface(&["logs"], "IronClaw Reborn logs", "logs", "entries");
-}
-
-#[test]
-fn logs_verbose_explains_missing_reborn_log_source() {
-    assert_verbose_detail(&["logs", "--verbose"], "Reborn log source is not wired yet");
-}
-
-#[test]
-fn logs_json_verbose_includes_status_details() {
-    assert_json_verbose_detail(
-        &["logs", "--json", "--verbose"],
-        "logs",
-        "entries",
-        "Reborn log source is not wired yet",
-    );
+fn logs_reports_not_implemented() {
+    assert_not_implemented(&["logs"], "`logs` is not implemented yet");
+    assert_not_implemented(&["logs", "--verbose"], "`logs` is not implemented yet");
 }
 
 #[cfg(feature = "root-llm-provider")]
@@ -1366,7 +1321,7 @@ fn models_write_commands_report_root_llm_provider_required_without_default_featu
         let output = reborn_command()
             .args(args)
             .output()
-            .expect("ironclaw-reborn models write command should run");
+            .expect("ironclaw-reborn models command should run");
 
         assert!(!output.status.success(), "command should fail: {args:?}");
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -1382,54 +1337,20 @@ fn models_write_commands_report_root_llm_provider_required_without_default_featu
     }
 }
 
-fn assert_empty_not_wired_surface(
-    args: &[&str],
-    title: &str,
-    collection_key: &str,
-    count_key: &str,
-) {
+fn assert_not_implemented(args: &[&str], expected_message: &str) {
     let output = reborn_command()
         .args(args)
         .output()
         .expect("ironclaw-reborn command should run");
 
     assert!(
-        output.status.success(),
-        "stderr: {}",
-        String::from_utf8_lossy(&output.stderr)
+        !output.status.success(),
+        "`{}` should fail while disabled",
+        args.join(" ")
     );
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains(title), "stdout: {stdout}");
-    assert!(
-        stdout.contains(&format!("{count_key}: 0")),
-        "stdout: {stdout}"
-    );
-    assert!(stdout.contains("status: not-wired"), "stdout: {stdout}");
-    assert!(stdout.contains("v1_state: not-used"), "stdout: {stdout}");
-
-    let mut json_args = args.to_vec();
-    json_args.push("--json");
-    let output = reborn_command()
-        .args(json_args)
-        .output()
-        .expect("ironclaw-reborn JSON command should run");
-    assert!(
-        output.status.success(),
-        "stderr: {}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let json: serde_json::Value = serde_json::from_str(stdout.trim()).expect("valid JSON");
-    assert_eq!(json[count_key], 0);
-    assert_eq!(
-        json[collection_key]
-            .as_array()
-            .expect("collection array")
-            .len(),
-        0
-    );
-    assert_eq!(json["status"], "not-wired");
-    assert_eq!(json["v1_state"], "not-used");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains(expected_message), "stderr: {stderr}");
+    assert!(!stderr.contains("panicked"), "stderr: {stderr}");
 }
 
 fn write_reborn_skill(reborn_home: &std::path::Path, name: &str, description: &str) {

--- a/crates/ironclaw_reborn_cli/tests/smoke.rs
+++ b/crates/ironclaw_reborn_cli/tests/smoke.rs
@@ -1390,54 +1390,6 @@ fn reborn_cli_skill_root(reborn_home: &std::path::Path) -> std::path::PathBuf {
     reborn_home.join("local-dev/tenants/default/users/reborn-cli/skills")
 }
 
-fn assert_verbose_detail(args: &[&str], expected_detail: &str) {
-    let output = reborn_command()
-        .args(args)
-        .output()
-        .expect("ironclaw-reborn verbose command should run");
-
-    assert!(
-        output.status.success(),
-        "stderr: {}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains(expected_detail), "stdout: {stdout}");
-}
-
-fn assert_json_verbose_detail(
-    args: &[&str],
-    collection_key: &str,
-    count_key: &str,
-    expected_detail: &str,
-) {
-    let output = reborn_command()
-        .args(args)
-        .output()
-        .expect("ironclaw-reborn JSON verbose command should run");
-
-    assert!(
-        output.status.success(),
-        "stderr: {}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let json: serde_json::Value = serde_json::from_str(stdout.trim()).expect("valid JSON");
-    assert_eq!(json[count_key], 0);
-    assert_eq!(
-        json[collection_key]
-            .as_array()
-            .expect("collection array")
-            .len(),
-        0
-    );
-    let details = json["details"].as_array().expect("details array");
-    assert!(
-        details.iter().any(|detail| detail == expected_detail),
-        "json: {json}"
-    );
-}
-
 #[test]
 fn config_path_reports_reborn_home_without_touching_v1_state() {
     let temp = tempfile::tempdir().expect("tempdir");

--- a/docs/reborn-binary.md
+++ b/docs/reborn-binary.md
@@ -629,7 +629,7 @@ cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- --help
 # channels/hooks/logs are disabled — these are expected to exit non-zero
 # with "is not implemented yet", not to succeed.
 cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- channels list; echo "exit: $?"
-cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- completion --shell zsh >/tmp/ironclaw-reborn.zsh
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- completion --shell zsh >"$(mktemp -d)/ironclaw-reborn.zsh"
 IRONCLAW_REBORN_HOME="$(mktemp -d)/reborn-home" \
   cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- config path
 cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- hooks list; echo "exit: $?"

--- a/docs/reborn-binary.md
+++ b/docs/reborn-binary.md
@@ -56,7 +56,7 @@ The `traces` command tree is a contributor-only trace client; see
 
 **`channels`, `hooks`, and `logs` are disabled.** They stay in `--help` and
 shell completions so the eventual real implementation has a stable command
-name, but every invocation returns an explicit
+name, but invoking `channels list`, `hooks list`, or `logs` returns an explicit
 `` `<command>` is not implemented yet `` error (non-zero exit) instead of the
 fake-success placeholder output ( `configured: 0` / `status: not-wired`) they
 used to print. Do not treat that old placeholder shape as the current
@@ -240,8 +240,8 @@ from a browser on the same host against `127.0.0.1`.
 ### `channels list` — disabled
 
 The Reborn channel registry is not wired yet. The command stays visible in
-`--help`/completions for a stable future name, but every invocation returns an
-error and a non-zero exit instead of resolving Reborn home, reading v1 channel
+`--help`/completions for a stable future name, but invoking `channels list`
+returns an error and a non-zero exit instead of resolving Reborn home, reading v1 channel
 config, or printing channel data:
 
 ```bash
@@ -331,7 +331,7 @@ Expected fields include:
 ### `hooks list` — disabled
 
 Same treatment as `channels list` above: the Reborn hook registry is not
-wired yet, so the command stays visible but every invocation errors instead
+wired yet, so the command stays visible but invoking `hooks list` errors instead
 of reporting hook data:
 
 ```bash
@@ -347,7 +347,7 @@ Error: `hooks list` is not implemented yet
 ### `logs` — disabled
 
 Same treatment: the Reborn log source is not wired yet, so `logs` stays
-visible but every invocation errors instead of reporting log data:
+visible but invoking it errors instead of reporting log data:
 
 ```bash
 cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- logs

--- a/docs/reborn-binary.md
+++ b/docs/reborn-binary.md
@@ -12,9 +12,9 @@ It currently supports:
 
 ```bash
 ironclaw-reborn --help
-ironclaw-reborn channels list
-ironclaw-reborn channels list --json
-ironclaw-reborn channels list --verbose
+ironclaw-reborn channels list              # disabled — errors, see below
+ironclaw-reborn channels list --json       # disabled — errors, see below
+ironclaw-reborn channels list --verbose    # disabled — errors, see below
 ironclaw-reborn completion --shell bash
 ironclaw-reborn completion --shell zsh
 ironclaw-reborn config path
@@ -24,12 +24,12 @@ ironclaw-reborn extension search github --json
 ironclaw-reborn extension install github-mcp
 ironclaw-reborn extension activate github-mcp
 ironclaw-reborn extension remove github-mcp
-ironclaw-reborn hooks list
-ironclaw-reborn hooks list --json
-ironclaw-reborn hooks list --verbose
-ironclaw-reborn logs
-ironclaw-reborn logs --json
-ironclaw-reborn logs --verbose
+ironclaw-reborn hooks list                 # disabled — errors, see below
+ironclaw-reborn hooks list --json          # disabled — errors, see below
+ironclaw-reborn hooks list --verbose       # disabled — errors, see below
+ironclaw-reborn logs                       # disabled — errors, see below
+ironclaw-reborn logs --json                # disabled — errors, see below
+ironclaw-reborn logs --verbose             # disabled — errors, see below
 ironclaw-reborn models list
 ironclaw-reborn models list --json
 ironclaw-reborn models status
@@ -54,8 +54,20 @@ ironclaw-reborn skills list --verbose
 The `traces` command tree is a contributor-only trace client; see
 `crates/ironclaw_reborn_cli/src/commands/traces/` for its subcommands.
 
+**`channels`, `hooks`, and `logs` are disabled.** They stay in `--help` and
+shell completions so the eventual real implementation has a stable command
+name, but every invocation returns an explicit
+`` `<command>` is not implemented yet `` error (non-zero exit) instead of the
+fake-success placeholder output ( `configured: 0` / `status: not-wired`) they
+used to print. Do not treat that old placeholder shape as the current
+contract — see the per-command sections below. `skills` is the one CLI
+surface that looks similar (it also used to read a not-yet-real registry) but
+is a genuine working implementation reading real `SKILL.md` files; it is not
+part of this disable.
+
 It intentionally does not yet support:
 
+- real `channels`/`hooks`/`logs` backends (see above);
 - replacing `ironclaw` behavior;
 - daemon/service installation;
 - v1 config, DB, settings, or secrets migration;
@@ -225,11 +237,12 @@ from a browser on the same host against `127.0.0.1`.
 
 ## Commands
 
-### `channels list`
+### `channels list` — disabled
 
-Reports configured Reborn channels without resolving Reborn home, reading v1 channel config, or creating directories.
-
-The Reborn channel registry is not wired yet, so the command currently reports an explicit empty surface:
+The Reborn channel registry is not wired yet. The command stays visible in
+`--help`/completions for a stable future name, but every invocation returns an
+error and a non-zero exit instead of resolving Reborn home, reading v1 channel
+config, or printing channel data:
 
 ```bash
 cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- channels list
@@ -237,11 +250,16 @@ cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- channels list --jso
 cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- channels list --verbose
 ```
 
-Expected fields include:
+All three forms (default/`--json`/`--verbose`) print the same message to
+stderr and exit non-zero:
 
-- `configured: 0`
-- `status: not-wired`
-- `v1_state: not-used`
+```
+Error: `channels list` is not implemented yet
+```
+
+Older revisions of this doc described a fake-success placeholder shape
+(`configured: 0`, `status: not-wired`, `v1_state: not-used`) — that output no
+longer exists; do not implement against it.
 
 ### `extension`
 
@@ -310,11 +328,11 @@ Expected fields include:
 - `v1_state: not-used`
 - `driver_registry: initialized`
 
-### `hooks list`
+### `hooks list` — disabled
 
-Reports configured Reborn hooks without resolving Reborn home, reading v1 hook config, or creating directories.
-
-The Reborn hook registry is not wired yet, so the command currently reports an explicit empty surface:
+Same treatment as `channels list` above: the Reborn hook registry is not
+wired yet, so the command stays visible but every invocation errors instead
+of reporting hook data:
 
 ```bash
 cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- hooks list
@@ -322,17 +340,14 @@ cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- hooks list --json
 cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- hooks list --verbose
 ```
 
-Expected fields include:
+```
+Error: `hooks list` is not implemented yet
+```
 
-- `configured: 0`
-- `status: not-wired`
-- `v1_state: not-used`
+### `logs` — disabled
 
-### `logs`
-
-Reports Reborn log availability without resolving Reborn home, reading v1 gateway logs, or creating directories.
-
-The Reborn log source is not wired yet, so the command currently reports an explicit empty surface:
+Same treatment: the Reborn log source is not wired yet, so `logs` stays
+visible but every invocation errors instead of reporting log data:
 
 ```bash
 cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- logs
@@ -340,11 +355,9 @@ cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- logs --json
 cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- logs --verbose
 ```
 
-Expected fields include:
-
-- `entries: 0`
-- `status: not-wired`
-- `v1_state: not-used`
+```
+Error: `logs` is not implemented yet
+```
 
 ### `onboard`
 
@@ -415,6 +428,27 @@ The secret value still lives in the environment under the catalog's
 records the variable *name*, never the value. Once `[llm.default]` exists it
 selects the provider; `LLM_BACKEND` is only an env fallback when no default slot
 is configured.
+
+All of the above requires the `root-llm-provider` Cargo feature, which is
+**on by default** (`default = ["root-llm-provider", "libsql"]` in
+`crates/ironclaw_reborn_cli/Cargo.toml`). A binary built with
+`--no-default-features` (or any feature set that drops `root-llm-provider`)
+does not have `RebornProviderAdmin` linked in, so all four `models`
+subcommands error instead:
+
+```bash
+cargo run -q -p ironclaw_reborn_cli --no-default-features --features libsql --bin ironclaw-reborn -- models list
+```
+
+```
+Error: `models list` requires the root-llm-provider feature; v1_state: not-used
+```
+
+`set`/`set-provider` report the same `requires the root-llm-provider feature`
+error in that build; `list`/`status` used to instead print placeholder text
+(`routes: not-configured`, `v1_state: not-used`) as if the command had
+succeeded — that placeholder path was removed so all four subcommands fail
+the same way when the feature is off.
 
 ### `profile list`
 
@@ -592,12 +626,14 @@ cargo test -p ironclaw_runner model_slots_are_exposed_in_cli_display_order
 cargo test -p ironclaw_architecture reborn
 cargo clippy -p ironclaw_reborn_cli --all-targets -- -D warnings
 cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- --help
-cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- channels list
+# channels/hooks/logs are disabled — these are expected to exit non-zero
+# with "is not implemented yet", not to succeed.
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- channels list; echo "exit: $?"
 cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- completion --shell zsh >/tmp/ironclaw-reborn.zsh
 IRONCLAW_REBORN_HOME="$(mktemp -d)/reborn-home" \
   cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- config path
-cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- hooks list
-cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- logs
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- hooks list; echo "exit: $?"
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- logs; echo "exit: $?"
 cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- models status
 cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- profile list
 IRONCLAW_REBORN_HOME="$(mktemp -d)/reborn-home" \


### PR DESCRIPTION
## Summary
- `channels list`, `hooks list`, and `logs` were hardcoded stubs that printed fake-success output (`configured: 0`, `status: not-wired`) regardless of real state. They now return an explicit `` `<command>` is not implemented yet `` error, while staying visible in `--help` and shell completions.
- `models list` / `models status` had the same problem in their `root-llm-provider`-disabled fallback (only reachable when that Cargo feature is off): they printed placeholder text instead of erroring. `models set` / `set-provider` already errored via `feature_not_available` in that build; `list`/`status` now match.
- `skills` is intentionally untouched — it's a real, working implementation that reads actual `SKILL.md` files.

## Test plan
- [x] `cargo fmt -p ironclaw_reborn_cli`
- [x] `cargo clippy -p ironclaw_reborn_cli --all-targets --all-features -- -D warnings`
- [x] `cargo clippy -p ironclaw_reborn_cli --all-targets --no-default-features --features libsql -- -D warnings`
- [x] `cargo test -p ironclaw_reborn_cli --bins` (163 passed)
- [x] `cargo test -p ironclaw_reborn_cli --test smoke` (96 passed, default features)
- [x] `cargo test -p ironclaw_reborn_cli --test smoke --no-default-features --features libsql` (86 passed, exercises the models disabled-feature path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)